### PR TITLE
Factor out pure balanceTransaction logic

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1404,7 +1404,7 @@ balanceTransaction
     let candidateMinFee = fromMaybe (Coin 0) $
             evaluateMinimumFee tl nodePParams candidateTx
 
-    let surplus = delta `Coin.distance` candidateMinFee
+    let surplus = delta `Coin.difference` candidateMinFee
     assembleTransaction $ TxUpdate
         { extraInputs
         , extraCollateral

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1424,9 +1424,11 @@ balanceTransaction
       where
         resolveInput :: TxIn -> Maybe (TxOut, Maybe (Hash "Datum"))
         resolveInput i =
-            (\(_,o,d) -> (o,d)) <$> L.find (\(i',_,_) -> i == i') externalInputs
+            (\(_,o,d) -> (o,d))
+                <$> L.find (\(i',_,_) -> i == i') externalInputs
             <|>
-            (\(_,o) -> (o, Nothing)) <$> L.find (\(i',_) -> i == i') (extraInputs update)
+            (\(_,o) -> (o, Nothing))
+                <$> L.find (\(i',_) -> i == i') (extraInputs update)
 
     extractFromTx tx =
         let (Tx _id _fee _coll _inps outs wdrlMap meta _vldt, toMint, toBurn)

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -624,7 +624,7 @@ type HasDBLayer m s k = HasType (DBLayer m s k)
 
 type HasGenesisData = HasType (Block, NetworkParameters, SyncTolerance)
 
-type HasLogger msg = HasType (Tracer IO msg)
+type HasLogger m msg = HasType (Tracer m msg)
 
 -- | This module is only interested in one block-, and tx-type. This constraint
 -- hides that choice, for some ease of use.
@@ -645,10 +645,10 @@ genesisData =
     typed @(Block, NetworkParameters, SyncTolerance)
 
 logger
-    :: forall msg ctx. HasLogger msg ctx
-    => Lens' ctx (Tracer IO msg)
+    :: forall m msg ctx. HasLogger m msg ctx
+    => Lens' ctx (Tracer m msg)
 logger =
-    typed @(Tracer IO msg)
+    typed @(Tracer m msg)
 
 networkLayer
     :: forall m ctx. (HasNetworkLayer m ctx)
@@ -868,7 +868,7 @@ restoreWallet
     :: forall ctx s k.
         ( HasNetworkLayer IO ctx
         , HasDBLayer IO s k ctx
-        , HasLogger WalletWorkerLog ctx
+        , HasLogger IO WalletWorkerLog ctx
         , IsOurs s Address
         , IsOurs s RewardAccount
         )
@@ -884,7 +884,7 @@ restoreWallet ctx wid = db & \DBLayer{..} -> do
   where
     db = ctx ^. dbLayer @IO @s @k
     nw = ctx ^. networkLayer
-    tr = contramap MsgFollow (ctx ^. logger @WalletWorkerLog)
+    tr = contramap MsgFollow (ctx ^. logger @_ @WalletWorkerLog)
 
     run :: ExceptT ErrNoSuchWallet IO () -> IO (FollowAction ErrNoSuchWallet)
     run = fmap (either ExitWith (const Continue)) . runExceptT
@@ -1106,7 +1106,7 @@ queryRewardBalance ctx acct = do
 
 manageRewardBalance
     :: forall ctx s k (n :: NetworkDiscriminant).
-        ( HasLogger WalletWorkerLog ctx
+        ( HasLogger IO WalletWorkerLog ctx
         , HasNetworkLayer IO ctx
         , HasDBLayer IO s k ctx
         , Typeable s
@@ -1143,7 +1143,7 @@ manageRewardBalance _ ctx wid = db & \DBLayer{..} -> do
   where
     db = ctx ^. dbLayer @IO @s @k
     NetworkLayer{watchNodeTip} = ctx ^. networkLayer
-    tr = contramap MsgWallet $ ctx ^. logger @WalletWorkerLog
+    tr = contramap MsgWallet $ ctx ^. logger @_ @WalletWorkerLog
 
 {-------------------------------------------------------------------------------
                                     Address
@@ -1433,8 +1433,8 @@ data SelectAssetsParams s result = SelectAssetsParams
 selectAssets
     :: forall ctx s k result.
         ( HasTransactionLayer k ctx
-        , HasLogger WalletWorkerLog ctx
         , HasNetworkLayer IO ctx
+        , HasLogger IO WalletWorkerLog ctx
         )
     => ctx
     -> SelectAssetsParams s result
@@ -1718,7 +1718,7 @@ submitTx
     :: forall ctx s k.
         ( HasNetworkLayer IO ctx
         , HasDBLayer IO s k ctx
-        , HasLogger WalletWorkerLog ctx
+        , HasLogger IO WalletWorkerLog ctx
         )
     => ctx
     -> WalletId
@@ -1751,7 +1751,7 @@ submitExternalTx
     :: forall ctx k.
         ( HasNetworkLayer IO ctx
         , HasTransactionLayer k ctx
-        , HasLogger TxSubmitLog ctx
+        , HasLogger IO TxSubmitLog ctx
         )
     => ctx
     -> SealedTx
@@ -1824,7 +1824,7 @@ runLocalTxSubmissionPool
     :: forall ctx s k m.
         ( MonadUnliftIO m
         , MonadMonotonicTime m
-        , HasLogger WalletWorkerLog ctx
+        , HasLogger IO WalletWorkerLog ctx
         , HasNetworkLayer m ctx
         , HasDBLayer m s k ctx
         )
@@ -1857,7 +1857,7 @@ runLocalTxSubmissionPool cfg ctx wid = db & \DBLayer{..} -> do
     rateLimited = throttle (rateLimit cfg) . const
 
     tr = unliftIOTracer $ contramap (MsgWallet . MsgTxSubmit) $
-        ctx ^. logger @WalletWorkerLog
+        ctx ^. logger @_ @WalletWorkerLog
     trBracket = contramap MsgProcessPendingPool tr
     trRetry i = contramap (MsgRetryPostTx i) tr
 
@@ -2043,7 +2043,7 @@ joinStakePool
     :: forall ctx s k n.
         ( HasDBLayer IO s k ctx
         , HasNetworkLayer IO ctx
-        , HasLogger WalletWorkerLog ctx
+        , HasLogger IO WalletWorkerLog ctx
         , s ~ SeqState n k
         )
     => ctx

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2350,7 +2350,8 @@ delegationFee ctx (ApiT wid) = do
             W.readWalletUTxOIndex @_ @s @k wrk wid
         pp <- liftIO $ NW.currentProtocolParameters (wrk ^. networkLayer)
         deposit <- W.calcMinimumDeposit @_ @s @k wrk wid
-        mkApiFee (Just deposit) [] <$> W.estimateFee (runSelection wrk pp deposit w)
+        mkApiFee (Just deposit) [] <$>
+            W.estimateFee (runSelection wrk pp deposit w)
   where
     txCtx :: TransactionCtx
     txCtx = defaultTransactionCtx

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -356,8 +356,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     , validateScriptTemplates
     )
 import Cardano.Wallet.Primitive.CoinSelection
-    ( SelectionCollateralRequirement (..)
-    , SelectionError (..)
+    ( SelectionError (..)
     , SelectionOf (..)
     , SelectionOutputInvalidError (..)
     , SelectionOutputSizeExceedsLimitError (..)
@@ -365,10 +364,7 @@ import Cardano.Wallet.Primitive.CoinSelection
     , selectionDelta
     )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionSkeleton (..)
-    , UnableToConstructChangeError (..)
-    , balanceMissing
-    )
+    ( UnableToConstructChangeError (..), balanceMissing )
 import Cardano.Wallet.Primitive.Delegation.UTxO
     ( stakeKeyCoinDistr )
 import Cardano.Wallet.Primitive.Migration
@@ -403,7 +399,6 @@ import Cardano.Wallet.Primitive.SyncProgress
 import Cardano.Wallet.Primitive.Types
     ( Block
     , BlockHeader (..)
-    , FeePolicy (..)
     , NetworkParameters (..)
     , PassphraseScheme (..)
     , PoolId
@@ -418,11 +413,11 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), coinQuantity, subtractCoin, sumCoins )
+    ( Coin (..), coinQuantity )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Redeemer
-    ( Redeemer (..), redeemerData )
+    ( Redeemer (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( Flat (..), TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
@@ -430,15 +425,13 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (..), TokenPolicyId (..), nullTokenName )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( SealedTx
-    , TransactionInfo
+    ( TransactionInfo
     , Tx (..)
     , TxChange (..)
     , TxIn (..)
     , TxOut (..)
     , TxStatus (..)
     , UnsignedTx (..)
-    , txOutAddCoin
     , txOutCoin
     )
 import Cardano.Wallet.Registry
@@ -456,16 +449,11 @@ import Cardano.Wallet.Transaction
     , ErrSignTx (..)
     , TransactionCtx (..)
     , TransactionLayer (..)
-    , TxUpdate (..)
     , Withdrawal (..)
     , defaultTransactionCtx
     )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
-import Cardano.Wallet.Util
-    ( mapFirst )
-import Control.Applicative
-    ( (<|>) )
 import Control.Arrow
     ( second )
 import Control.DeepSeq
@@ -593,7 +581,6 @@ import UnliftIO.Concurrent
 import UnliftIO.Exception
     ( IOException, bracket, throwIO, tryAnyDeep, tryJust )
 
-import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.Api.Types as Api
 import qualified Cardano.Wallet.Network as NW
@@ -602,7 +589,6 @@ import qualified Cardano.Wallet.Primitive.AddressDerivation.Icarus as Icarus
 import qualified Cardano.Wallet.Primitive.CoinSelection.Balance as Balance
 import qualified Cardano.Wallet.Primitive.CoinSelection.Collateral as Collateral
 import qualified Cardano.Wallet.Primitive.Types as W
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
@@ -615,7 +601,6 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Foldable as F
-import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -2243,188 +2228,23 @@ balanceTransaction ctx genChange (ApiT wid) body = do
     pp <- liftIO $ NW.currentProtocolParameters nl
     -- TODO: This throws when still in the Byron era.
     nodePParams <- fromJust <$> liftIO (NW.currentNodeProtocolParameters nl)
-
-    ti <- liftIO $ snapshot $ timeInterpreter (ctx ^. networkLayer)
-
-    let (outputs, txWithdrawal, txMetadata, txAssetsToMint, txAssetsToBurn) = extractFromTx partialTx
-
-    (delta, extraInputs, extraCollateral, extraOutputs) <-
-      withWorkerCtx ctx wid liftE liftE $ \wrk -> do
-        (internalUtxoAvailable, wallet, pendingTxs) <-
-            liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk wid
-
-        let externalSelectedUtxo = UTxOIndex.fromSequence
-                ((\(a,b,_)-> (a,b)) <$> externalInputs)
-
-        let utxoAvailableForInputs = UTxOSelection.fromIndexPair
-                (internalUtxoAvailable, externalSelectedUtxo)
-
-        let utxoAvailableForCollateral =
-                UTxOIndex.toUTxO internalUtxoAvailable
-
-        -- NOTE: It is not possible to know the script execution cost in
-        -- advance because it actually depends on the final transaction. Inputs
-        -- selected as part of the fee balancing might have an influence on the
-        -- execution cost.
-        -- However, they are bounded so it is possible to balance the
-        -- transaction considering only the maximum cost, and only after, try to
-        -- adjust the change and ExUnits of each redeemer to something more
-        -- sensible than the max execution cost.
-        let txPlutusScriptExecutionCost = maxScriptExecutionCost tl pp redeemers
-        let txContext = defaultTransactionCtx
-                { txPlutusScriptExecutionCost
-                , txMetadata
-                , txWithdrawal
-                , txAssetsToMint
-                , txAssetsToBurn
-                , txCollateralRequirement =
-                    if txPlutusScriptExecutionCost > Coin 0 then
-                        SelectionCollateralRequired
-                    else
-                        SelectionCollateralNotRequired
-                } & padFeeEstimation partialTx pp nodePParams
-
-        -- FIXME: The coin selection and reported fees will likely be wrong in
-        -- the presence of certificates (and deposits / refunds). An immediate
-        -- "fix" is to return a proper error from the handler when any key or
-        -- pool registration (resp. deregistration) certificate is found in the
-        -- transaction. A long-term fix is to handle this case properly during
-        -- balancing.
-        let transform s sel =
-                let (sel', _) = W.assignChangeAddresses genChange sel s
-                    inputs = F.toList (sel' ^. #inputs)
-                 in ( selectionDelta txOutCoin sel'
-                    , inputs
-                    , fst <$> (sel' ^. #collateral)
-                    , sel' ^. #change
-                    )
-        liftHandler $ W.selectAssets @_ @_ @s @k wrk pp W.SelectAssetsParams
-            { outputs
-            , pendingTxs
-            , txContext
-            , utxoAvailableForInputs
-            , utxoAvailableForCollateral
-            , wallet
-            }
-            transform
-
-    -- NOTE:
-    -- Once the coin-selection is done, we need to
-    --
-    -- (a) Add selected inputs, collateral and change outputs to the transaction
-    -- (b) Assign correct execution units to every redeemers
-    -- (c) Correctly reference redeemed entities with redeemer pointers
-    -- (d) Adjust fees and change output(s) to the new fees.
-    --
-    -- There's a strong assumption that modifying the fee value AND increasing
-    -- the coin value of change outputs does not modify transaction fees; or
-    -- more exactly, does not modify the execution units of scripts. This is in
-    -- principle a fair assumption because scripts validators ought to be
-    -- unaware of change outputs. If their execution cost increases when change
-    -- output increases, then it becomes impossible to guarantee that the fee
-    -- balancing will ever converge towards a fixed point. A script validator
-    -- doing such thing is considered bonkers and this is not a behavior we
-    -- ought to support.
-
-    candidateTx <- assembleTransaction nodePParams ti $ TxUpdate
-        { extraInputs
-        , extraCollateral
-        , extraOutputs
-        , newFee = const delta
-        }
-    let candidateMinFee = fromMaybe (Coin 0) $
-            evaluateMinimumFee tl nodePParams candidateTx
-
-    let surplus = delta `Coin.distance` candidateMinFee
-    finalTx <- assembleTransaction nodePParams ti $ TxUpdate
-        { extraInputs
-        , extraCollateral
-        , extraOutputs = mapFirst (txOutAddCoin surplus) extraOutputs
-        , newFee = const candidateMinFee
-        }
-
-    pure $ ApiSerialisedTransaction
-        { transaction = ApiT finalTx
-        }
+    let partialTx = W.PartialTx
+            (getApiT $ body ^. #transaction)
+            (fromExternalInput <$> body ^. #inputs)
+            (fromApiRedeemer <$> body ^. #redeemers)
+    withWorkerCtx ctx wid liftE liftE $ \wrk -> do
+        wallet <- liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk wid
+        ti <- liftIO $ snapshot $ timeInterpreter $ ctx ^. networkLayer
+        transaction <- liftHandler $ ApiT <$> W.balanceTransaction @IO @s @k
+            wrk
+            genChange
+            (pp, nodePParams)
+            ti
+            wallet
+            partialTx
+        return $ ApiSerialisedTransaction { transaction }
   where
     nl = ctx ^. networkLayer
-    tl = ctx ^. W.transactionLayer @k
-
-    partialTx :: SealedTx
-    partialTx = body ^. #transaction . #getApiT
-
-    redeemers :: [Redeemer]
-    redeemers = fromApiRedeemer <$> body ^. #redeemers
-
-    externalInputs :: [(TxIn, TxOut, Maybe (Hash "Datum"))]
-    externalInputs = fromExternalInput <$> body ^. #inputs
-
-    assembleTransaction
-        :: Cardano.ProtocolParameters
-        -> TimeInterpreter (Either PastHorizonException)
-        -> TxUpdate
-        -> Handler SealedTx
-    assembleTransaction nodePParams ti update = do
-        tx' <- asHandler $ updateTx tl partialTx update
-        liftHandler $ ExceptT $ pure $ assignScriptRedeemers
-            tl nodePParams ti resolveInput redeemers tx'
-      where
-        resolveInput :: TxIn -> Maybe (TxOut, Maybe (Hash "Datum"))
-        resolveInput i =
-            (\(_,o,d) -> (o,d)) <$> L.find (\(i',_,_) -> i == i') externalInputs
-            <|>
-            (\(_,o) -> (o, Nothing)) <$> L.find (\(i',_) -> i == i') (extraInputs update)
-
-    extractFromTx tx =
-        let (Tx _id _fee _coll _inps outs wdrlMap meta _vldt, toMint, toBurn) = decodeTx tl tx
-            -- TODO: Find a better abstraction that can cover this case.
-            wdrl = WithdrawalSelf
-                (error $ "WithdrawalSelf: reward-account should never been use "
-                      <> "when balancing transactions but it was!"
-                )
-                (error $ "WithdrawalSelf: derivation path should never been use "
-                      <> "when balancing transactions but it was!"
-                )
-                (sumCoins wdrlMap)
-         in (outs, wdrl, meta, toMint, toBurn)
-
-    -- | Wallet coin selection is unaware of many kinds of transaction content
-    -- (e.g. datums, redeemers), which could be included in the input to
-    -- `balanceTransaction`. As a workaround we add some padding using
-    -- `evaluateMinimumFee`.
-    --
-    -- TODO: This logic needs to be consistent with how we call `selectAssets`,
-    -- so it would be good to join them into some single helper.
-    padFeeEstimation
-        :: W.SealedTx
-        -> W.ProtocolParameters
-        -> Cardano.ProtocolParameters
-        -> TransactionCtx
-        -> TransactionCtx
-    padFeeEstimation sealedTx pp pp' txCtx =
-        let
-            (walletTx, _, _) = decodeTx tl sealedTx
-            worseEstimate = calcMinimumCost tl pp txCtx skeleton
-            skeleton = SelectionSkeleton
-                { skeletonInputCount = length (view #resolvedInputs walletTx)
-                , skeletonOutputs = view #outputs walletTx
-                , skeletonChange = mempty
-                }
-            LinearFee _ (Quantity b) = pp ^. #txParameters . #getFeePolicy
-            -- NOTE: Coping with the later additions of script integrity hash and
-            -- redeemers ex units increased from 0 to their actual values.
-            extraMargin = Coin $ ceiling $ (*) b $ fromIntegral
-                $ sizeOfScriptIntegrityHash
-                + sum ((+sizeOfRedeemerCommon) . BS.length . redeemerData <$> redeemers)
-              where
-                sizeOfScriptIntegrityHash = 35
-                sizeOfRedeemerCommon = 17
-
-            txFeePadding = (<> extraMargin) $ fromMaybe (Coin 0) $ do
-                betterEstimate <- evaluateMinimumFee tl pp' sealedTx
-                betterEstimate `subtractCoin` worseEstimate
-        in
-            txCtx { txFeePadding }
 
 joinStakePool
     :: forall ctx s n k.
@@ -3665,11 +3485,6 @@ liftHandler action = Handler (withExceptT toServerError action)
 liftE :: IsServerError e => e -> Handler a
 liftE = liftHandler . throwE
 
-asHandler :: IsServerError e => Either e a -> Handler a
-asHandler = \case
-    Left e  -> liftE e
-    Right a -> return a
-
 apiError :: ServerError -> ApiErrorCode -> Text -> ServerError
 apiError err code message = err
     { errBody = Aeson.encode $ Aeson.object
@@ -3880,6 +3695,8 @@ instance IsServerError ErrBalanceTx where
                 , "the transaction body is modified. "
                 , "Please sign the transaction after it is balanced instead."
                 ]
+        ErrBalanceTxSelectAssets err -> toServerError err
+        ErrBalanceTxAssignRedeemers err -> toServerError err
         ErrBalanceTxNotImplemented ->
             apiError err501 NotImplemented
                 "This feature is not yet implemented."

--- a/lib/core/src/Cardano/Wallet/Registry.hs
+++ b/lib/core/src/Cardano/Wallet/Registry.hs
@@ -201,7 +201,7 @@ register
         ( Ord key
         , key ~ WorkerKey ctx
         , msg ~ WorkerMsg ctx
-        , HasLogger (WorkerLog key msg) ctx
+        , HasLogger IO (WorkerLog key msg) ctx
         , HasWorkerCtx resource ctx
         )
     => WorkerRegistry key resource
@@ -219,7 +219,7 @@ register registry ctx k (MkWorker before main after acquire) = do
     threadId <- work `forkFinally` cleanup resourceVar
     takeMVar resourceVar >>= traverse (create threadId)
   where
-    tr = ctx ^. logger @(WorkerLog key msg)
+    tr = ctx ^. logger @IO @(WorkerLog key msg)
     create threadId resource = do
         let worker = Worker
                 { workerId = k

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -77,8 +77,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxMetadata
     , TxOut
     )
-import Control.Monad.Trans.Except
-    ( ExceptT )
 import Data.List.NonEmpty
     ( NonEmpty )
 import Data.Text
@@ -213,7 +211,7 @@ data TransactionLayer k tx = TransactionLayer
     , assignScriptRedeemers
         :: Node.ProtocolParameters
             -- Current protocol parameters
-        -> TimeInterpreter (ExceptT PastHorizonException IO)
+        -> TimeInterpreter (Either PastHorizonException)
             -- Time interpreter in the Monad m
         -> (TxIn -> Maybe (TxOut, Maybe (Hash "Datum")))
             -- A input resolver for transactions' inputs containing scripts.
@@ -221,7 +219,7 @@ data TransactionLayer k tx = TransactionLayer
             -- A list of redeemers to set on the transaction.
         -> tx
             -- Transaction containing scripts
-        -> IO (Either ErrAssignRedeemers tx)
+        -> (Either ErrAssignRedeemers tx)
     }
     deriving Generic
 

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -321,6 +321,7 @@ benchmark restore
     , deepseq
     , filepath
     , fmt
+    , generic-lens
     , iohk-monitoring
     , say
     , text

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -229,6 +229,7 @@ test-suite unit
     , hspec
     , hspec-core
     , memory
+    , MonadRandom
     , optparse-applicative
     , ouroboros-consensus-shelley
     , ouroboros-network

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -931,8 +931,10 @@ _assignScriptRedeemers (toAlonzoPParams -> pparams) ti resolveInput redeemers tx
     evaluateExecutionUnits
         :: Map Alonzo.RdmrPtr Redeemer
         -> AlonzoTx
-        -> Either ErrAssignRedeemers (Map Alonzo.RdmrPtr (Either ErrAssignRedeemers Alonzo.ExUnits))
-    evaluateExecutionUnits indexedRedeemers alonzoTx = left ErrAssignRedeemersPastHorizon $ do
+        -> Either ErrAssignRedeemers
+            (Map Alonzo.RdmrPtr (Either ErrAssignRedeemers Alonzo.ExUnits))
+    evaluateExecutionUnits indexedRedeemers alonzoTx =
+        left ErrAssignRedeemersPastHorizon $ do
         let utxo = utxoFromAlonzoTx alonzoTx
         let costs = toCostModelsAsArray (Alonzo._costmdls pparams)
         let systemStart = getSystemStart ti

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -172,7 +172,7 @@ import Control.Monad
 import Control.Monad.Trans.Class
     ( lift )
 import Control.Monad.Trans.Except
-    ( ExceptT, except, mapExceptT, runExceptT, throwE, withExceptT )
+    ( runExceptT )
 import Control.Monad.Trans.State.Strict
     ( StateT (..), execStateT, get, modify' )
 import Data.Function
@@ -853,15 +853,14 @@ type AlonzoTx =
     Ledger.Tx (Cardano.ShelleyLedgerEra Cardano.AlonzoEra)
 
 _assignScriptRedeemers
-    :: forall m.  ( Monad m )
-    => Cardano.ProtocolParameters
-    -> TimeInterpreter (ExceptT PastHorizonException m)
+    :: Cardano.ProtocolParameters
+    -> TimeInterpreter (Either PastHorizonException)
     -> (TxIn -> Maybe (TxOut, Maybe (Hash "Datum")))
     -> [Redeemer]
     -> SealedTx
-    -> m (Either ErrAssignRedeemers SealedTx)
+    -> Either ErrAssignRedeemers SealedTx
 _assignScriptRedeemers (toAlonzoPParams -> pparams) ti resolveInput redeemers tx =
-    runExceptT $ case cardanoTx tx of
+    case cardanoTx tx of
         InAnyCardanoEra ByronEra _ ->
             pure tx
         InAnyCardanoEra ShelleyEra _ ->
@@ -884,18 +883,18 @@ _assignScriptRedeemers (toAlonzoPParams -> pparams) ti resolveInput redeemers tx
     -- 'Redeemer' type which is mapped to an 'Alonzo.ScriptPurpose'.
     assignNullRedeemers
         :: AlonzoTx
-        -> ExceptT ErrAssignRedeemers m (Map Alonzo.RdmrPtr Redeemer, AlonzoTx)
+        -> Either ErrAssignRedeemers (Map Alonzo.RdmrPtr Redeemer, AlonzoTx)
     assignNullRedeemers alonzoTx = do
         (indexedRedeemers, nullRedeemers) <- fmap unzip $ forM redeemers $ \rd -> do
             ptr <- case Alonzo.rdptr (Alonzo.body alonzoTx) (toScriptPurpose rd) of
                 SNothing ->
-                    throwE $ ErrAssignRedeemersTargetNotFound rd
+                    Left $ ErrAssignRedeemersTargetNotFound rd
                 SJust ptr ->
                     pure ptr
 
             rData <- case deserialiseOrFail (BL.fromStrict $ redeemerData rd) of
                 Left e ->
-                    throwE $ ErrAssignRedeemersInvalidData rd (show e)
+                    Left $ ErrAssignRedeemersInvalidData rd (show e)
                 Right d ->
                     pure (Alonzo.Data d)
 
@@ -932,15 +931,14 @@ _assignScriptRedeemers (toAlonzoPParams -> pparams) ti resolveInput redeemers tx
     evaluateExecutionUnits
         :: Map Alonzo.RdmrPtr Redeemer
         -> AlonzoTx
-        -> ExceptT ErrAssignRedeemers m (Map Alonzo.RdmrPtr (Either ErrAssignRedeemers Alonzo.ExUnits))
-    evaluateExecutionUnits indexedRedeemers alonzoTx = withExceptT ErrAssignRedeemersPastHorizon $ do
+        -> Either ErrAssignRedeemers (Map Alonzo.RdmrPtr (Either ErrAssignRedeemers Alonzo.ExUnits))
+    evaluateExecutionUnits indexedRedeemers alonzoTx = left ErrAssignRedeemersPastHorizon $ do
         let utxo = utxoFromAlonzoTx alonzoTx
         let costs = toCostModelsAsArray (Alonzo._costmdls pparams)
         let systemStart = getSystemStart ti
-
         epochInfo <- toEpochInfo ti
 
-        mapExceptT (pure . hoistScriptFailure . runIdentity) $ do
+        hoistScriptFailure $ runIdentity $ runExceptT $ do
             evaluateTransactionExecutionUnits
                 pparams
                 alonzoTx
@@ -964,11 +962,11 @@ _assignScriptRedeemers (toAlonzoPParams -> pparams) ti resolveInput redeemers tx
     assignExecutionUnits
         :: Map Alonzo.RdmrPtr (Either ErrAssignRedeemers Alonzo.ExUnits)
         -> AlonzoTx
-        -> ExceptT ErrAssignRedeemers m AlonzoTx
+        -> Either ErrAssignRedeemers AlonzoTx
     assignExecutionUnits exUnits alonzoTx = do
         let wits = Alonzo.wits alonzoTx
         let Alonzo.Redeemers rdmrs = Alonzo.txrdmrs wits
-        rdmrs' <- except $ Map.mergeA
+        rdmrs' <- Map.mergeA
             Map.preserveMissing
             Map.dropMissing
             (Map.zipWithAMatched (const assignUnits))

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -172,6 +172,7 @@
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
             (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
             (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+            (hsPkgs."MonadRandom" or (errorHandler.buildDepError "MonadRandom"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."ouroboros-consensus-shelley" or (errorHandler.buildDepError "ouroboros-consensus-shelley"))
             (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -230,6 +230,7 @@
             (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
             (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
             (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
+            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
             (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
             (hsPkgs."say" or (errorHandler.buildDepError "say"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))


### PR DESCRIPTION
### Motivation

Make property testing of the `balanceTransaction`  logic possible.

### Overview

- [x] Add `m` to `HasLogger` constraint rather than to assume IO
- [x] Make selectAssets run in `MonadRandom m` rather than IO
- [x] Let selectAssets take PParams directly, rather than fetching from NetworkLayer
- [x] Remove IO from assignScriptRedeemers
- [x] Factor out W.balanceTransaction running in `MonadRandom m`

### Issue Number

ADP-1182

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
