### PR TITLE
Add more conditions to `CoinSelection.verifySelection` function.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -537,19 +537,7 @@ verifySelectionOutputSizes cs _ps selection
         Nothing
   where
     errors :: [SelectionOutputSizeExceedsLimitError]
-    errors = mapMaybe (verifyOutputSize cs) allOutputs
-
-    -- We verify both ordinary outputs and generated change outputs. Since
-    -- generated change outputs do not have addresses at this stage, we
-    -- simply assign them all a dummy address.
-    --
-    allOutputs :: [TxOut]
-    allOutputs = (<>)
-        (selection ^. #outputs)
-        (selection ^. #change <&> TxOut dummyChangeAddress)
-      where
-        dummyChangeAddress :: Address
-        dummyChangeAddress = Address "<change>"
+    errors = mapMaybe (verifyOutputSize cs) (selectionAllOutputs selection)
 
 --------------------------------------------------------------------------------
 -- Selection correctness: output token quantities
@@ -571,19 +559,7 @@ verifySelectionOutputTokenQuantities _cs _ps selection
         Nothing
   where
     errors :: [SelectionOutputTokenQuantityExceedsLimitError]
-    errors = verifyOutputTokenQuantities =<< allOutputs
-
-    -- We verify both ordinary outputs and generated change outputs. Since
-    -- generated change outputs do not have addresses at this stage, we
-    -- simply assign them all a dummy address.
-    --
-    allOutputs :: [TxOut]
-    allOutputs = (<>)
-        (selection ^. #outputs)
-        (selection ^. #change <&> TxOut dummyChangeAddress)
-      where
-        dummyChangeAddress :: Address
-        dummyChangeAddress = Address "<change>"
+    errors = verifyOutputTokenQuantities =<< selectionAllOutputs selection
 
 --------------------------------------------------------------------------------
 -- Selection deltas
@@ -879,6 +855,19 @@ data SelectionOf change = Selection
 -- In this type of selection, change values do not have addresses assigned.
 --
 type Selection = SelectionOf TokenBundle
+
+-- | Returns a selection's ordinary outputs and change outputs in a single list.
+--
+-- Since change outputs do not have addresses at the point of generation,
+-- this function assigns all change outputs with a dummy change address.
+--
+selectionAllOutputs :: Selection -> [TxOut]
+selectionAllOutputs selection = (<>)
+    (selection ^. #outputs)
+    (selection ^. #change <&> TxOut dummyChangeAddress)
+  where
+    dummyChangeAddress :: Address
+    dummyChangeAddress = Address "<change>"
 
 --------------------------------------------------------------------------------
 -- Preparing outputs

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -486,6 +486,8 @@ data VerifySelectionDeltaInvalidError = VerifySelectionDeltaInvalidError
         :: SelectionDelta TokenBundle
     , minimumCost
         :: Coin
+    , maximumCost
+        :: Coin
     }
     deriving (Eq, Show)
 
@@ -499,6 +501,7 @@ verifySelectionDelta cs ps selection
   where
     delta = selectionDeltaAllAssets selection
     minimumCost = selectionMinimumCost cs ps selection
+    maximumCost = selectionMaximumCost cs ps selection
 
 --------------------------------------------------------------------------------
 -- Selection verification: selection limit
@@ -667,6 +670,18 @@ selectionMinimumCost
     -> Coin
 selectionMinimumCost constraints params selection =
     Balance.selectionMinimumCost
+        (fst $ toBalanceConstraintsParams (constraints, params))
+        (toBalanceResult selection)
+
+-- | Computes the maximum acceptable cost of a selection.
+--
+selectionMaximumCost
+    :: SelectionConstraints
+    -> SelectionParams
+    -> Selection
+    -> Coin
+selectionMaximumCost constraints params selection =
+    Balance.selectionMaximumCost
         (fst $ toBalanceConstraintsParams (constraints, params))
         (toBalanceResult selection)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -346,7 +346,7 @@ toBalanceResult selection = Balance.SelectionResult
     }
 
 --------------------------------------------------------------------------------
--- Selection correctness
+-- Selection verification
 --------------------------------------------------------------------------------
 
 -- | The result of verifying a selection with 'verifySelection'.
@@ -418,7 +418,7 @@ verifySelection cs ps selection =
     onError `failWith` thisError = maybe (Right ()) (Left . thisError) onError
 
 --------------------------------------------------------------------------------
--- Selection correctness: collateral sufficiency
+-- Selection verification: collateral sufficiency
 --------------------------------------------------------------------------------
 
 data VerifySelectionCollateralInsufficientError =
@@ -441,7 +441,7 @@ verifySelectionCollateralSufficiency cs ps selection
     collateralRequired = selectionMinimumCollateral cs ps selection
 
 --------------------------------------------------------------------------------
--- Selection correctness: collateral suitability
+-- Selection verification: collateral suitability
 --------------------------------------------------------------------------------
 
 data VerifySelectionCollateralUnsuitableError =
@@ -471,7 +471,7 @@ verifySelectionCollateralSuitability cs _ps selection
     utxoUnsuitableForCollateral = isNothing . (cs ^. #utxoSuitableForCollateral)
 
 --------------------------------------------------------------------------------
--- Selection correctness: delta validity
+-- Selection verification: delta validity
 --------------------------------------------------------------------------------
 
 data VerifySelectionDeltaInvalidError = VerifySelectionDeltaInvalidError
@@ -494,7 +494,7 @@ verifySelectionDelta cs ps selection
     minimumCost = selectionMinimumCost cs ps selection
 
 --------------------------------------------------------------------------------
--- Selection correctness: selection limit
+-- Selection verification: selection limit
 --------------------------------------------------------------------------------
 
 data VerifySelectionLimitExceededError = VerifySelectionLimitExceededError
@@ -523,7 +523,7 @@ verifySelectionLimit cs _ps selection
     selectionLimit = (cs ^. #computeSelectionLimit) (selection ^. #outputs)
 
 --------------------------------------------------------------------------------
--- Selection correctness: minimum ada quantities
+-- Selection verification: minimum ada quantities
 --------------------------------------------------------------------------------
 
 data VerifySelectionOutputCoinBelowMinimumError =
@@ -559,7 +559,7 @@ verifySelectionOutputCoins cs _ps selection
             (output ^. (#tokens . #tokens))
 
 --------------------------------------------------------------------------------
--- Selection correctness: output sizes
+-- Selection verification: output sizes
 --------------------------------------------------------------------------------
 
 newtype VerifySelectionOutputSizeExceedsLimitError =
@@ -580,7 +580,7 @@ verifySelectionOutputSizes cs _ps selection
     errors = mapMaybe (verifyOutputSize cs) (selectionAllOutputs selection)
 
 --------------------------------------------------------------------------------
--- Selection correctness: output token quantities
+-- Selection verification: output token quantities
 --------------------------------------------------------------------------------
 
 newtype VerifySelectionOutputTokenQuantityExceedsLimitError =

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -56,6 +56,7 @@ module Cardano.Wallet.Primitive.CoinSelection.Balance
     , selectionHasValidSurplus
     , selectionSurplusCoin
     , selectionMinimumCost
+    , selectionMaximumCost
     , selectionSkeleton
 
     -- * Querying parameters

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -221,6 +221,7 @@ prop_performSelection_onSuccess =
         either (const $ property True) (onSuccess constraints params)
   where
     onSuccess constraints params selection =
+        report selection "selection" $
         Pretty (verifySelection constraints params selection) ===
         Pretty VerifySelectionSuccess
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -17,9 +17,9 @@ import Cardano.Wallet.Primitive.CoinSelection
     , Selection
     , SelectionCollateralRequirement (..)
     , SelectionConstraints (..)
-    , SelectionCorrectness (..)
     , SelectionError (..)
     , SelectionParams (..)
+    , VerifySelectionResult (..)
     , computeMinimumCollateral
     , performSelection
     , prepareOutputsWith
@@ -222,7 +222,7 @@ prop_performSelection_onSuccess =
   where
     onSuccess constraints params selection =
         Pretty (verifySelection constraints params selection) ===
-        Pretty SelectionCorrect
+        Pretty VerifySelectionSuccess
 
 --------------------------------------------------------------------------------
 -- Construction of balance constraints and parameters


### PR DESCRIPTION
## Issue Number

ADP-1037

## Summary

This PR adds further conditions to the pre-existing `CoinSelection.verifySelection` function.

We now verify that every selection output (regardless of whether it is an ordinary output or a generated change output):

- does not have an ada quantity below the minimum set by the protocol.
- does not have a serialized size that exceeds the limit set by the protocol.
- does not have any token quantities that exceed the limit set by the protocol.

This PR also adjusts `verifySelection` to report **_all_** errors it encounters, rather than just the first error.

## Example Failure

The following example shows multiple verification failures:

![multiple-verification-failures](https://user-images.githubusercontent.com/206319/137082445-9a81a86e-d924-4fcc-96c4-7c67137be01a.png)


