### PR TITLE
flake.nix: Add aarch64-darwin to hydraJobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         id: hydra
         with:
           hydra: 'https://hydra.iohk.io'
-          jobs: 'linux.musl.cardano-wallet-linux64 macos.cardano-wallet-macos64 linux.windows.cardano-wallet-win64'
+          jobs: 'linux.musl.cardano-wallet-linux64 macos.cardano-wallet-macos-intel linux.windows.cardano-wallet-win64'
 
       - name: '🍒 Fetch release files'
         run: |

--- a/docs/developers/Building.md
+++ b/docs/developers/Building.md
@@ -157,7 +157,7 @@ The Hydra [Jobset page](https://hydra.iohk.io/jobset/Cardano/cardano-wallet#tabs
 shows all jobs defined in the `hydraJobs` attribute of `flake.nix`. Some of the release jobs have a download link.
 
 - [Windows](https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-win64/latest)
-- [macOS](https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-macos64/latest)
+- [macOS](https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-macos-intel/latest)
 
 See [[Hydra]] for more information.
 

--- a/flake.nix
+++ b/flake.nix
@@ -308,12 +308,13 @@
                     };
                 };
               } // (lib.optionalAttrs buildPlatform.isMacOS {
-              macos = let packages = mkPackages hydraProject; in
-                packages // {
-                  cardano-wallet-macos64 = import ./nix/release-package.nix {
+                macos.intel = let
+                  packages = mkPackages hydraProject;
+                in packages // {
+                  cardano-wallet-macos-intel = import ./nix/release-package.nix {
                     inherit pkgs;
                     exes = releaseContents packages;
-                    platform = "macos64";
+                    platform = "macos-intel";
                     format = "tar.gz";
                   };
                   shells = (mkDevShells hydraProject) // {
@@ -325,6 +326,25 @@
                     iohk-nix-utils = pkgs.iohk-nix-utils.roots;
                   };
                 };
+
+                macos.silicon = lib.dontRecurseIntoAttrs (let
+                  packages = mkPackages hydraProject;
+                in packages // {
+                    cardano-wallet-macos-silicon = import ./nix/release-package.nix {
+                      inherit pkgs;
+                      exes = releaseContents packages;
+                      platform = "macos-silicon";
+                      format = "tar.gz";
+                    };
+                    shells = (mkDevShells hydraProject) // {
+                      default = hydraProject.shell;
+                    };
+                    scripts = mkScripts hydraProject;
+                    internal.roots = {
+                      project = hydraProject.roots;
+                      iohk-nix-utils = pkgs.iohk-nix-utils.roots;
+                    };
+                  });
             });
           in
           rec {

--- a/nix/release-package.nix
+++ b/nix/release-package.nix
@@ -23,7 +23,7 @@ let
   makeZip = format == "zip";
 
   isLinux = platform == "linux64";
-  isMacOS = platform == "macos64";
+  isMacOS = platform == "macos-intel" || platform == "macos-silicon";
   isWindows = platform == "win64";
 
 in

--- a/nix/supported-systems.nix
+++ b/nix/supported-systems.nix
@@ -1,4 +1,5 @@
 [
   "x86_64-linux"
   "x86_64-darwin"
+  "aarch64-darwin"
 ]


### PR DESCRIPTION
Adds `aarch64-darwin` to release.nix.  Something like this will be handy when hydra has `aarch64-darwin` builders.  We could test it on `ci.zw3rk.com`.