### PR TITLE
Enable more tests for construct ep

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -235,7 +235,6 @@ import Cardano.Wallet.Api.Types
     , ApiBlockReference (..)
     , ApiByronWallet
     , ApiCoinSelection
-    , ApiConstructTransaction (transaction)
     , ApiEpochInfo
     , ApiEra (..)
     , ApiFee
@@ -2258,11 +2257,10 @@ signTx
     :: MonadUnliftIO m
     => Context
     -> ApiWallet
-    -> ApiConstructTransaction n
+    -> ApiT SealedTx
     -> [(HTTP.Status, Either RequestException ApiSerialisedTransaction) -> m ()]
     -> m (ApiT SealedTx)
-signTx ctx w apiTx expectations = do
-    let sealedTx = transaction apiTx
+signTx ctx w sealedTx expectations = do
     let toSign = Json [aesonQQ|
                            { "transaction": #{sealedTx}
                            , "passphrase": #{fixturePassphrase}

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -218,7 +218,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             , expectField (#fee . #getQuantity) (`shouldBe` expectedFee)
             ]
 
-        apiTx <- unsafeGetTx rTx
+        let apiTx = getFromResponse #transaction rTx
 
         signedTx <- signTx ctx wa apiTx [ expectResponseCode HTTP.status202 ]
 
@@ -268,7 +268,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             ]
         let expectedFee = getFromResponse (#fee . #getQuantity) rTx
 
-        apiTx <- unsafeGetTx rTx
+        let apiTx = getFromResponse #transaction rTx
 
         signedTx <- signTx ctx wa apiTx [ expectResponseCode HTTP.status202 ]
 
@@ -305,7 +305,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             , expectField (#coinSelection . #withdrawals) (`shouldSatisfy` (not . null))
             ]
 
-        apiTx <- unsafeGetTx rTx
+        let apiTx = getFromResponse #transaction rTx
 
         signedTx <- signTx ctx wa apiTx [ expectResponseCode HTTP.status202 ]
 
@@ -353,7 +353,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             , expectField (#coinSelection . #withdrawals) (`shouldSatisfy` (not . null))
             ]
 
-        apiTx <- unsafeGetTx rTx
+        let apiTx = getFromResponse #transaction rTx
 
         signedTx <- signTx ctx wa apiTx [ expectResponseCode HTTP.status202 ]
 
@@ -407,7 +407,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 getFromResponse (#coinSelection . #inputs) rTx
         length coinSelInputs `shouldBe` 1
 
-        apiTx <- unsafeGetTx rTx
+        let apiTx = getFromResponse #transaction rTx
 
         signedTx <- signTx ctx wa apiTx [ expectResponseCode HTTP.status202 ]
 
@@ -527,7 +527,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             ]
 
         let expectedFee = getFromResponse (#fee . #getQuantity) rTx
-        apiTx <- unsafeGetTx rTx
+        let apiTx = getFromResponse #transaction rTx
 
         signedTx <- signTx ctx wa apiTx [ expectResponseCode HTTP.status202 ]
 
@@ -583,7 +583,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             ]
 
         let expectedFee = getFromResponse (#fee . #getQuantity) rTx
-        apiTx <- unsafeGetTx rTx
+        let apiTx = getFromResponse #transaction rTx
 
         signedTx <- signTx ctx wa apiTx [ expectResponseCode HTTP.status202 ]
 
@@ -666,7 +666,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             ]
 
         let expectedFee = getFromResponse (#fee . #getQuantity) rTx
-        apiTx <- unsafeGetTx rTx
+        let apiTx = getFromResponse #transaction rTx
 
         signedTx <- signTx ctx wa apiTx [ expectResponseCode HTTP.status202 ]
 
@@ -850,7 +850,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             [ expectResponseCode HTTP.status202
             ]
 
-        apiTx <- unsafeGetTx rTx
+        let apiTx = getFromResponse #transaction rTx
 
         signedTx <- signTx ctx wa apiTx [ expectResponseCode HTTP.status202 ]
 
@@ -879,7 +879,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             [ expectResponseCode HTTP.status202
             ]
 
-        apiTx <- unsafeGetTx rTx
+        let apiTx = getFromResponse #transaction rTx
 
         signedTx <- signTx ctx wa apiTx [ expectResponseCode HTTP.status202 ]
 
@@ -1177,6 +1177,12 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             , expectResponseCode HTTP.status202
             ]
 
+        -- let apiTx = getFromResponse #transaction rTx
+        --
+        -- signedTx <- signTx ctx wa apiTx [ expectResponseCode HTTP.status202 ]
+        --
+        -- void $ submitTx ctx signedTx [ expectResponseCode HTTP.status202 ]
+
     it "TRANS_NEW_BALANCE_01e - plutus with missing covering inputs wallet enough funds" $ \ctx -> runResourceT $ do
 
         -- constructing source wallet
@@ -1302,9 +1308,6 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             , expectErrorMessage "FeeTooSmallUTxO"
             ]
 
-    -- it "TRANS_NEW_BALANCE" $ do
-
-
     describe "Plutus scenarios" $ do
         let scenarios =
                 [ ( "ping-pong"
@@ -1397,12 +1400,6 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
             foldM_ runStep txid steps
   where
-    unsafeGetTx
-        :: MonadIO m
-        => (HTTP.Status, Either RequestException (ApiConstructTransaction n))
-        -> m (ApiConstructTransaction n)
-    unsafeGetTx (_, Left e)   = throwIO e
-    unsafeGetTx (_, Right tx) = pure tx
 
     -- | Just one million Ada, in Lovelace.
     oneMillionAda :: Integer

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1247,7 +1247,10 @@ x-multiDelegationAction: &multiDelegationAction
             stake_key_index: *derivationSegment
 
 x-transactionDelegations: &transactionDelegations
-  description: A list of staking actions (joining, rejoining or leaving from stake pools).
+  description: |
+    <p>status: <strong>⚠ under development</strong></p>
+
+    A list of staking actions (joining, rejoining or leaving from stake pools).
   type: array
   minItems: 0
   items:
@@ -2971,6 +2974,8 @@ components:
         address_index: *addressIndex
 
     ApiValidityInterval: &ApiValidityInterval
+      description: |
+        <p>status: <strong>⚠ under development</strong></p>
       type: object
       required:
         - invalid_before
@@ -5144,7 +5149,6 @@ x-tagGroups:
     - Byron Addresses
     - Byron Coin Selections
     - Byron Transactions
-    - Byron Transactions New
     - Byron Migrations
 
   - name: Miscellaneous
@@ -5487,7 +5491,7 @@ paths:
       tags: ["Transactions New"]
       summary: Construct
       description: |
-        <p align="right">status: <strong>unstable</strong></p>
+        <p align="right">status: <strong>under development</strong></p>
 
         Create a transaction to be signed from the wallet.
       parameters:


### PR DESCRIPTION
- bcf78bf4592f291fe8bf91debf90ae837d15becc
  Enable remaining construct ep integration tests (where applicable)
  
- df75842f6da952ac2a4dfea6840b0106c27f5f9c
  Make signTx DSL useful also in balance -> sign -> submit workflow
  
- 4e26f5d2c1423a4c2530ab953396d9fc0f00bcad
  Update swagger to reflect current state of affairs, in particular removing Byron Transactions New altogether from displaying on rendered api doc
  
- d80d6b675465d3a0b3fc2b8ffacd6a505592a368
  Use expectedFee returned by construct ep rather than explicit value

### Comments

Wanted to add more tests for balance ep, but noticed first that few tests for construct can be enabled. 
Also updated swagger so it reflects current state more accurately.

### Issue Number

sort of ADP-1223
