### PR TITLE
Add integration tests for error messages from balance endpoint

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -42,6 +42,7 @@ module Test.Integration.Framework.TestData
     , errMsg400WalletIdEncoding
     , errMsg400StartTimeLaterThanEndTime
     , errMsg403Fee
+    , errMsg403Collateral
     , errMsg403NotAByronWallet
     , errMsg403NotAnIcarusWallet
     , errMsg403NotEnoughMoney
@@ -307,6 +308,12 @@ errMsg403Fee =
     "I am unable to finalize the transaction, as there is not enough ada \
     \available to pay for the fee and also pay for the minimum ada quantities \
     \of all change outputs."
+
+errMsg403Collateral :: String
+errMsg403Collateral =
+    "I'm unable to create this transaction because the balance of pure ada \
+    \UTxOs in your wallet is insufficient to cover the minimum amount of \
+    \collateral required."
 
 errMsg403NotAByronWallet :: String
 errMsg403NotAByronWallet =

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -1414,6 +1414,16 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         verify rTx'
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403Collateral
+            , expectErrorMessage $ unwords
+                -- TODO: [ADP-1227] Adjust this amount:
+                [ "I need an ada amount of at least:"
+                , "865.807382"
+                ]
+            , expectErrorMessage $ unwords
+                -- TODO: [ADP-1227] Adjust these amounts:
+                [ "The largest combination of pure ada UTxOs I could find is:"
+                , "[297.866700, 300.000000]"
+                ]
             ]
 
     it "TRANS_NEW_BALANCE_03 - I can balance base-64 encoded tx" $

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -146,8 +146,8 @@ import Test.Integration.Framework.DSL
     , waitForTxImmutability
     )
 import Test.Integration.Framework.TestData
-    ( errMsg403Fee
-    , errMsg403Collateral
+    ( errMsg403Collateral
+    , errMsg403Fee
     , errMsg403InvalidConstructTx
     , errMsg403MinUTxOValue
     , errMsg403NotDelegating
@@ -1363,7 +1363,8 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             , expectResponseCode HTTP.status202
             ]
 
-    it "TRANS_NEW_BALANCE_02a - Cannot balance on empty wallet" $ \ctx -> runResourceT $ do
+    it "TRANS_NEW_BALANCE_02a - Cannot balance on empty wallet" $
+        \ctx -> runResourceT $ do
         wa <- emptyWallet ctx
         let balancePayload = Json PlutusScenario.pingPong_1
         rTx <- request @ApiSerialisedTransaction ctx
@@ -1373,7 +1374,8 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             , expectErrorMessage errMsg403NotEnoughMoney
             ]
 
-    it "TRANS_NEW_BALANCE_02b - Cannot balance on when I cannot afford fee" $ \ctx -> runResourceT $ do
+    it "TRANS_NEW_BALANCE_02b - Cannot balance on when I cannot afford fee" $
+        \ctx -> runResourceT $ do
         wa <- fixtureWalletWith @n ctx [2 * 1_000_000]
         let balancePayload = Json PlutusScenario.pingPong_1
         rTx <- request @ApiSerialisedTransaction ctx
@@ -1383,7 +1385,9 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             , expectErrorMessage errMsg403Fee
             ]
 
-    it "TRANS_NEW_BALANCE_02c - Cannot balance on when I cannot afford collateral" $ \ctx -> runResourceT $ do
+    it "TRANS_NEW_BALANCE_02c - \
+        \Cannot balance on when I cannot afford collateral" $
+        \ctx -> runResourceT $ do
         -- TODO: adjust when ADP-1227 is fixed
         wa <- fixtureWalletWith @n ctx [600 * 1_000_000]
         let toBalance = Json PlutusScenario.pingPong_1
@@ -1398,7 +1402,8 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         txId <- submitTx ctx signedTx [ expectResponseCode HTTP.status202 ]
 
         waitForTxImmutability ctx
-        partialTx' <- PlutusScenario.pingPong_2 $ Aeson.object [ "transactionId" .= view #id txId ]
+        partialTx' <- PlutusScenario.pingPong_2 $ Aeson.object
+            [ "transactionId" .= view #id txId ]
         let toBalance' = Json (toJSON partialTx')
 
         rTx' <- request @ApiSerialisedTransaction ctx
@@ -1408,7 +1413,8 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             , expectErrorMessage errMsg403Collateral
             ]
 
-    it "TRANS_NEW_BALANCE_03 - I can balance base-64 encoded tx" $ \ctx -> runResourceT $ do
+    it "TRANS_NEW_BALANCE_03 - I can balance base-64 encoded tx" $
+        \ctx -> runResourceT $ do
         wa <- fixtureWallet ctx
         let pingPong1Base64 = Json [json|{
             "transaction": "hKUAgA2AAYGDWB1xTXLPVpozmhin2TAjE5g/VuDZbNRb3LHWUS3KahoAHoSAWCCSORjkA79Dw0tO9rSOsu4Eur7RcyDY0bn/mtCG6G9E7AIADoChBIHYeYD19g==",
@@ -1428,7 +1434,9 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
         void $ submitTx ctx signedTx [ expectResponseCode HTTP.status202 ]
 
-    it "TRANS_NEW_BALANCE_04a - I get proper error message when payload is not hex or base64 encoded" $ \ctx -> runResourceT $ do
+    it "TRANS_NEW_BALANCE_04a - \
+        \I get proper error message when payload is not hex or base64 encoded" $
+        \ctx -> runResourceT $ do
         wa <- fixtureWallet ctx
         -- transaction is invalid hex / base64
         let payload = Json [json|{
@@ -1444,7 +1452,9 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             -- returns: Parse error. Expecting Base64-encoded format.
             ]
 
-    it "TRANS_NEW_BALANCE_04b - I get proper error message when payload cannot be decoded" $ \ctx -> runResourceT $ do
+    it "TRANS_NEW_BALANCE_04b - \
+        \I get proper error message when payload cannot be decoded" $
+        \ctx -> runResourceT $ do
         wa <- fixtureWallet ctx
         -- transaction is a VALID hex, but invalid transaction format
         let payload = Json [json|{
@@ -1460,7 +1470,9 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             -- returns: Parse error. Expecting Base64-encoded format.
             ]
 
-    it "TRANS_NEW_BALANCE_04c - I get proper error message when payload cannot be decoded" $ \ctx -> runResourceT $ do
+    it "TRANS_NEW_BALANCE_04c - \
+        \I get proper error message when payload cannot be decoded" $
+        \ctx -> runResourceT $ do
         wa <- fixtureWallet ctx
         -- transaction is a VALID hex, but invalid transaction format
         let payload = Json [json|{
@@ -1476,7 +1488,9 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             -- returns: Parse error. Expecting Base64-encoded format.
             ]
 
-    it "TRANS_NEW_BALANCE_04d - I get proper error message when payload cannot be decoded" $ \ctx -> runResourceT $ do
+    it "TRANS_NEW_BALANCE_04d - \
+        \I get proper error message when payload cannot be decoded" $
+        \ctx -> runResourceT $ do
         wa <- fixtureWallet ctx
         -- transaction is a VALID base64, but invalid transaction format
         let payload = Json [json|{

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -1389,7 +1389,10 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         \Cannot balance when I cannot afford collateral" $
         \ctx -> runResourceT $ do
         -- TODO: adjust when ADP-1227 is fixed
-        wa <- fixtureWalletWith @n ctx [600 * 1_000_000]
+        wa <- fixtureWalletWith @n ctx
+            [ 300 * 1_000_000
+            , 300 * 1_000_000
+            ]
         let toBalance = Json PlutusScenario.pingPong_1
         rTx <- request @ApiSerialisedTransaction ctx
             (Link.balanceTransaction @'Shelley wa) Default toBalance

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -1447,6 +1447,8 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
     it "TRANS_NEW_BALANCE_04a - \
         \I get proper error message when payload is not hex or base64 encoded" $
         \ctx -> runResourceT $ do
+        liftIO $ pendingWith
+            "ADP-1225: revise error messages to reflect supported formats"
         wa <- fixtureWallet ctx
         -- transaction is invalid hex / base64
         let payload = Json [json|{
@@ -1465,6 +1467,8 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
     it "TRANS_NEW_BALANCE_04b - \
         \I get proper error message when payload cannot be decoded" $
         \ctx -> runResourceT $ do
+        liftIO $ pendingWith
+            "ADP-1225: revise error messages to reflect supported formats"
         wa <- fixtureWallet ctx
         -- transaction is a VALID hex, but invalid transaction format
         let payload = Json [json|{
@@ -1483,6 +1487,8 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
     it "TRANS_NEW_BALANCE_04c - \
         \I get proper error message when payload cannot be decoded" $
         \ctx -> runResourceT $ do
+        liftIO $ pendingWith
+            "ADP-1225: revise error messages to reflect supported formats"
         wa <- fixtureWallet ctx
         -- transaction is a VALID hex, but invalid transaction format
         let payload = Json [json|{
@@ -1501,6 +1507,8 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
     it "TRANS_NEW_BALANCE_04d - \
         \I get proper error message when payload cannot be decoded" $
         \ctx -> runResourceT $ do
+        liftIO $ pendingWith
+            "ADP-1225: revise error messages to reflect supported formats"
         wa <- fixtureWallet ctx
         -- transaction is a VALID base64, but invalid transaction format
         let payload = Json [json|{

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -1374,7 +1374,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             , expectErrorMessage errMsg403NotEnoughMoney
             ]
 
-    it "TRANS_NEW_BALANCE_02b - Cannot balance on when I cannot afford fee" $
+    it "TRANS_NEW_BALANCE_02b - Cannot balance when I cannot afford fee" $
         \ctx -> runResourceT $ do
         wa <- fixtureWalletWith @n ctx [2 * 1_000_000]
         let balancePayload = Json PlutusScenario.pingPong_1
@@ -1386,7 +1386,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             ]
 
     it "TRANS_NEW_BALANCE_02c - \
-        \Cannot balance on when I cannot afford collateral" $
+        \Cannot balance when I cannot afford collateral" $
         \ctx -> runResourceT $ do
         -- TODO: adjust when ADP-1227 is fixed
         wa <- fixtureWalletWith @n ctx [600 * 1_000_000]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -1362,6 +1362,70 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             , expectResponseCode HTTP.status202
             ]
 
+    it "TRANS_NEW_BALANCE_04a - I get proper error message when payload is not hex or base64 encoded" $ \ctx -> runResourceT $ do
+        wa <- fixtureWallet ctx
+        -- transaction is invalid hex / base64
+        let payload = Json [json|{
+            "transaction": "!!!!#",
+            "redeemers": [],
+            "inputs": []
+        }|]
+        rTx <- request @ApiSerialisedTransaction ctx
+            (Link.balanceTransaction @'Shelley wa) Default payload
+        verify rTx
+            [ expectResponseCode HTTP.status400
+            , expectErrorMessage "Parse error. Expecting CBOR-encoded transaction represented in either hex or base64 encoding."
+            -- returns: Parse error. Expecting Base64-encoded format.
+            ]
+
+    it "TRANS_NEW_BALANCE_04b - I get proper error message when payload cannot be decoded" $ \ctx -> runResourceT $ do
+        wa <- fixtureWallet ctx
+        -- transaction is a VALID hex, but invalid transaction format
+        let payload = Json [json|{
+            "transaction": "11",
+            "redeemers": [],
+            "inputs": []
+        }|]
+        rTx <- request @ApiSerialisedTransaction ctx
+            (Link.balanceTransaction @'Shelley wa) Default payload
+        verify rTx
+            [ expectResponseCode HTTP.status400
+            , expectErrorMessage "Parse error. Cannot deserialize transaction. Make sure it is valid CBOR-encoded transaction represented in either hex or base64 encoding."
+            -- returns: Parse error. Expecting Base64-encoded format.
+            ]
+
+    it "TRANS_NEW_BALANCE_04c - I get proper error message when payload cannot be decoded" $ \ctx -> runResourceT $ do
+        wa <- fixtureWallet ctx
+        -- transaction is a VALID hex, but invalid transaction format
+        let payload = Json [json|{
+            "transaction": "11111",
+            "redeemers": [],
+            "inputs": []
+        }|]
+        rTx <- request @ApiSerialisedTransaction ctx
+            (Link.balanceTransaction @'Shelley wa) Default payload
+        verify rTx
+            [ expectResponseCode HTTP.status400
+            , expectErrorMessage "Parse error. Cannot deserialize transaction. Make sure it is valid CBOR-encoded transaction represented in either hex or base64 encoding."
+            -- returns: Parse error. Expecting Base64-encoded format.
+            ]
+
+    it "TRANS_NEW_BALANCE_04d - I get proper error message when payload cannot be decoded" $ \ctx -> runResourceT $ do
+        wa <- fixtureWallet ctx
+        -- transaction is a VALID base64, but invalid transaction format
+        let payload = Json [json|{
+            "transaction": "EQ==",
+            "redeemers": [],
+            "inputs": []
+        }|]
+        rTx <- request @ApiSerialisedTransaction ctx
+            (Link.balanceTransaction @'Shelley wa) Default payload
+        verify rTx
+            [ expectResponseCode HTTP.status400
+            , expectErrorMessage "Parse error. Cannot deserialize transaction. Make sure it is valid CBOR-encoded transaction represented in either hex or base64 encoding."
+            -- returns: Deserialisation failure while decoding Shelley Tx. CBOR failed with error: DeserialiseFailure 0 'expected list len or indef'
+            ]
+
     it "TRANS_NEW_SIGN_01 - Sign single-output transaction" $ \ctx -> runResourceT $ do
         w <- fixtureWallet ctx
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -1388,10 +1388,9 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
     it "TRANS_NEW_BALANCE_02c - \
         \Cannot balance when I cannot afford collateral" $
         \ctx -> runResourceT $ do
-        -- TODO: adjust when ADP-1227 is fixed
         wa <- fixtureWalletWith @n ctx
-            [ 300 * 1_000_000
-            , 300 * 1_000_000
+            [ 2_000_000
+            , 2_000_000
             ]
         let toBalance = Json PlutusScenario.pingPong_1
         rTx <- request @ApiSerialisedTransaction ctx
@@ -1415,14 +1414,12 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403Collateral
             , expectErrorMessage $ unwords
-                -- TODO: [ADP-1227] Adjust this amount:
                 [ "I need an ada amount of at least:"
-                , "865.807382"
+                , "2.779500"
                 ]
             , expectErrorMessage $ unwords
-                -- TODO: [ADP-1227] Adjust these amounts:
                 [ "The largest combination of pure ada UTxOs I could find is:"
-                , "[297.866700, 300.000000]"
+                , "[1.853000]"
                 ]
             ]
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -532,7 +532,7 @@ import Data.Type.Equality
 import Data.Word
     ( Word32 )
 import Fmt
-    ( blockListF, indentF, pretty )
+    ( blockListF, indentF, listF, pretty )
 import GHC.Generics
     ( Generic )
 import GHC.Stack
@@ -609,6 +609,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Foldable as F
+import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -4152,7 +4153,8 @@ instance IsServerError (Collateral.SelectionError) where
             , "I need an ada amount of at least:"
             , pretty (view #minimumSelectionAmount e)
             , "The largest combination of pure ada UTxOs I could find is:"
-            , pretty (F.toList $ view #largestCombinationAvailable e)
+            , pretty $ listF $ L.sort $ F.toList $
+                view #largestCombinationAvailable e
             , "To fix this, you'll need to add one or more pure ada UTxOs"
             , "to your wallet that can cover the minimum amount required."
             ]


### PR DESCRIPTION
### Issue Number

ADP-1241
ADP-1225

### Comments

This PR adds:
- integration test coverage for the numeric/variable parts of a collateral selection error.
- integration test coverage for error messages from the balance point. (These are currently marked as pending, as we expect to improve these errors.)

