### PR TITLE
Workaround for bech32 on Windows e2e tests

### DIFF
--- a/test/e2e/helpers/utils.rb
+++ b/test/e2e/helpers/utils.rb
@@ -1,6 +1,7 @@
 require 'bip_mnemonic'
 require 'httparty'
 require 'fileutils'
+require 'tmpdir'
 
 module Helpers
   module Utils
@@ -40,7 +41,17 @@ module Helpers
     end
 
     def bech32_to_base16(key)
-      cmd(%(echo #{key} | bech32)).gsub("\n", '')
+      if is_win?
+        # workaround for Windows "echo" probably adding eol
+        # which bech32 doesn't like
+        t_path = File.join(Dir.tmpdir, 'vk.tmp')
+        File.open(t_path, "w") do |f|
+          f.write(key)
+        end
+        cmd(%(type "#{t_path}"| bech32)).gsub("\n", '')
+      else
+        cmd(%(echo #{key} | bech32)).gsub("\n", '')
+      end
     end
 
     def hex_to_bytes(s)

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
     end
 
     it "mint-burn" do
-      vk = SHELLEY.keys.get_public_key(@wid, 'utxo_external', 0, {hash: true})
+      vk = SHELLEY.keys.get_public_key(@wid, 'utxo_external', 0, {hash: true}).gsub("\"",'')
       vkHash = bech32_to_base16(vk)
       policy = read_mustached_file("mintBurn_policy", {vkHash: vkHash})
       policy_id = get_policy_id(policy)


### PR DESCRIPTION
- 21f613e617a64e086990e820d9631ed83498e4d5
  Workaround for bech32 on Windows

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

n/a
