### PR TITLE
Change schema to factual in swagger for decode endpoint

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2305,6 +2305,14 @@ components:
       properties:
         transaction: *serialisedTransactionBase64
 
+    ApiSerialisedTransactionEncoded: &ApiSerialisedTransactionEncoded
+      description: |
+        An encoded transaction.
+      required:
+        - transaction
+      properties:
+        transaction: *serialisedTransactionEncoded
+
     ApiConstructTransaction: &ApiConstructTransaction
       type: object
       required:
@@ -5687,7 +5695,7 @@ paths:
         required: true
         content:
           application/json:
-            schema: *ApiSerialisedTransaction
+            schema: *ApiSerialisedTransactionEncoded
       responses: *responsesDecodedTransaction
 
   /wallets/{walletId}/addresses:


### PR DESCRIPTION



- [x] Change schema to factual in swagger for decode endpoint

### Comments

It seems that decode endpoint is able to consume both base64 and hex encoded serialized tx. Change in swagger to reflect this.

Before:
![Screenshot from 2021-11-05 16-56-53](https://user-images.githubusercontent.com/42900201/140540399-0f2f4d74-be78-4120-a628-75c22a7e2759.png)

After:
![Screenshot from 2021-11-05 16-57-20](https://user-images.githubusercontent.com/42900201/140540462-eb833e34-f252-4515-a222-8737f8a1550e.png)

### Issue Number

ADP-974
