### PR TITLE
Operators for generic n-ary product shrinking

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance/Gen.hs
@@ -30,7 +30,7 @@ import Test.QuickCheck
     , shrinkMapBy
     )
 import Test.QuickCheck.Extra
-    ( genericRoundRobinShrink, liftShrinker )
+    ( genericRoundRobinShrink, (<:>), (<@>) )
 
 import qualified Data.Set as Set
 
@@ -69,13 +69,11 @@ genSelectionSkeleton = SelectionSkeleton
         listOf (Set.fromList <$> listOf genAssetId)
 
 shrinkSelectionSkeleton :: SelectionSkeleton -> [SelectionSkeleton]
-shrinkSelectionSkeleton =
-    genericRoundRobinShrink
-        (  liftShrinker shrinkSkeletonInputCount
-        :* liftShrinker shrinkSkeletonOutputs
-        :* liftShrinker shrinkSkeletonChange
-        :* Nil
-        )
+shrinkSelectionSkeleton = genericRoundRobinShrink
+    <@> shrinkSkeletonInputCount
+    <:> shrinkSkeletonOutputs
+    <:> shrinkSkeletonChange
+    <:> Nil
   where
     shrinkSkeletonInputCount =
         shrink @Int

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance/Gen.hs
@@ -76,11 +76,11 @@ shrinkSelectionSkeleton =
         :* liftShrinker shrinkSkeletonChange
         :* Nil
         )
-    where
-        shrinkSkeletonInputCount =
-            shrink @Int
-        shrinkSkeletonOutputs =
-            shrinkList shrinkTxOut
-        shrinkSkeletonChange =
-            shrinkList $
-            shrinkMapBy Set.fromList Set.toList (shrinkList shrinkAssetId)
+  where
+    shrinkSkeletonInputCount =
+        shrink @Int
+    shrinkSkeletonOutputs =
+        shrinkList shrinkTxOut
+    shrinkSkeletonChange =
+        shrinkList $
+        shrinkMapBy Set.fromList Set.toList (shrinkList shrinkAssetId)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -83,9 +83,10 @@ import Test.QuickCheck.Extra
     , genMapWith
     , genSized2With
     , genericRoundRobinShrink
-    , liftShrinker
     , shrinkInterleaved
     , shrinkMapWith
+    , (<:>)
+    , (<@>)
     )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
@@ -124,17 +125,15 @@ genTxWithoutId = TxWithoutId
     <*> liftArbitrary genTxScriptValidity
 
 shrinkTxWithoutId :: TxWithoutId -> [TxWithoutId]
-shrinkTxWithoutId =
-    genericRoundRobinShrink
-        ( liftShrinker (liftShrink shrinkCoinPositive)
-        :* liftShrinker (shrinkList (liftShrink2 shrinkTxIn shrinkCoinPositive))
-        :* liftShrinker (shrinkList (liftShrink2 shrinkTxIn shrinkCoinPositive))
-        :* liftShrinker (shrinkList shrinkTxOut)
-        :* liftShrinker (liftShrink shrinkTxMetadata)
-        :* liftShrinker (shrinkMapWith shrinkRewardAccount shrinkCoinPositive)
-        :* liftShrinker (liftShrink shrinkTxScriptValidity)
-        :* Nil
-        )
+shrinkTxWithoutId = genericRoundRobinShrink
+    <@> liftShrink shrinkCoinPositive
+    <:> shrinkList (liftShrink2 shrinkTxIn shrinkCoinPositive)
+    <:> shrinkList (liftShrink2 shrinkTxIn shrinkCoinPositive)
+    <:> shrinkList shrinkTxOut
+    <:> liftShrink shrinkTxMetadata
+    <:> shrinkMapWith shrinkRewardAccount shrinkCoinPositive
+    <:> liftShrink shrinkTxScriptValidity
+    <:> Nil
 
 txWithoutIdToTx :: TxWithoutId -> Tx
 txWithoutIdToTx tx@TxWithoutId {..} = Tx {txId = mockHash tx, ..}

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -227,7 +227,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Classes
     ( eqLaws, ordLaws )
 import Test.QuickCheck.Extra
-    ( genericRoundRobinShrink, liftShrinker, report, verify )
+    ( genericRoundRobinShrink, report, verify, (<:>), (<@>) )
 import Test.QuickCheck.Monadic
     ( PropertyM (..), assert, monadicIO, monitor, run )
 import Test.Utils.Laws
@@ -615,16 +615,14 @@ genSelectionParams genPreselectedInputs genUTxOIndex' = do
     genPreselectedInputsNone = pure $ const False
 
 shrinkSelectionParams :: SelectionParams -> [SelectionParams]
-shrinkSelectionParams =
-    genericRoundRobinShrink
-        ( liftShrinker (shrinkList shrinkTxOut)
-        :* liftShrinker (shrinkUTxOSelection)
-        :* liftShrinker (shrinkCoin)
-        :* liftShrinker (shrinkCoin)
-        :* liftShrinker (shrinkTokenMap)
-        :* liftShrinker (shrinkTokenMap)
-        :* Nil
-        )
+shrinkSelectionParams = genericRoundRobinShrink
+    <@> shrinkList shrinkTxOut
+    <:> shrinkUTxOSelection
+    <:> shrinkCoin
+    <:> shrinkCoin
+    <:> shrinkTokenMap
+    <:> shrinkTokenMap
+    <:> Nil
 
 prop_performSelection_small
     :: MockSelectionConstraints
@@ -2044,14 +2042,12 @@ genMockSelectionConstraints = MockSelectionConstraints
 
 shrinkMockSelectionConstraints
     :: MockSelectionConstraints -> [MockSelectionConstraints]
-shrinkMockSelectionConstraints =
-    genericRoundRobinShrink
-        ( liftShrinker shrinkMockAssessTokenBundleSize
-        :* liftShrinker shrinkMockComputeMinimumAdaQuantity
-        :* liftShrinker shrinkMockComputeMinimumCost
-        :* liftShrinker shrinkMockComputeSelectionLimit
-        :* Nil
-        )
+shrinkMockSelectionConstraints = genericRoundRobinShrink
+    <@> shrinkMockAssessTokenBundleSize
+    <:> shrinkMockComputeMinimumAdaQuantity
+    <:> shrinkMockComputeMinimumCost
+    <:> shrinkMockComputeSelectionLimit
+    <:> Nil
 
 unMockSelectionConstraints :: MockSelectionConstraints -> SelectionConstraints
 unMockSelectionConstraints m = SelectionConstraints

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -127,9 +127,10 @@ import Test.QuickCheck.Extra
     ( Pretty (..)
     , chooseNatural
     , genericRoundRobinShrink
-    , liftShrinker
     , report
     , shrinkNatural
+    , (<:>)
+    , (<@>)
     )
 import Test.QuickCheck.Monadic
     ( monadicIO, run )
@@ -536,18 +537,16 @@ genMockSelectionConstraints = MockSelectionConstraints
 
 shrinkMockSelectionConstraints
     :: MockSelectionConstraints -> [MockSelectionConstraints]
-shrinkMockSelectionConstraints =
-    genericRoundRobinShrink
-        (  liftShrinker (shrinkMockAssessTokenBundleSize)
-        :* liftShrinker (shrinkCertificateDepositAmount)
-        :* liftShrinker (shrinkMockComputeMinimumAdaQuantity)
-        :* liftShrinker (shrinkMockComputeMinimumCost)
-        :* liftShrinker (shrinkMockComputeSelectionLimit)
-        :* liftShrinker (shrinkMaximumCollateralInputCount)
-        :* liftShrinker (shrinkMinimumCollateralPercentage)
-        :* liftShrinker (shrinkMockUTxOSuitableForCollateral)
-        :* Nil
-        )
+shrinkMockSelectionConstraints = genericRoundRobinShrink
+    <@> shrinkMockAssessTokenBundleSize
+    <:> shrinkCertificateDepositAmount
+    <:> shrinkMockComputeMinimumAdaQuantity
+    <:> shrinkMockComputeMinimumCost
+    <:> shrinkMockComputeSelectionLimit
+    <:> shrinkMaximumCollateralInputCount
+    <:> shrinkMinimumCollateralPercentage
+    <:> shrinkMockUTxOSuitableForCollateral
+    <:> Nil
 
 unMockSelectionConstraints :: MockSelectionConstraints -> SelectionConstraints
 unMockSelectionConstraints m = SelectionConstraints
@@ -642,19 +641,17 @@ genSelectionParams = SelectionParams
     <*> genUTxOAvailableForInputs
 
 shrinkSelectionParams :: SelectionParams -> [SelectionParams]
-shrinkSelectionParams =
-    genericRoundRobinShrink
-        (  liftShrinker shrinkAssetsToBurn
-        :* liftShrinker shrinkAssetsToMint
-        :* liftShrinker shrinkOutputsToCover
-        :* liftShrinker shrinkRewardWithdrawal
-        :* liftShrinker shrinkCerticateDepositsTaken
-        :* liftShrinker shrinkCerticateDepositsReturned
-        :* liftShrinker shrinkCollateralRequirement
-        :* liftShrinker shrinkUTxOAvailableForCollateral
-        :* liftShrinker shrinkUTxOAvailableForInputs
-        :* Nil
-        )
+shrinkSelectionParams = genericRoundRobinShrink
+    <@> shrinkAssetsToBurn
+    <:> shrinkAssetsToMint
+    <:> shrinkOutputsToCover
+    <:> shrinkRewardWithdrawal
+    <:> shrinkCerticateDepositsTaken
+    <:> shrinkCerticateDepositsReturned
+    <:> shrinkCollateralRequirement
+    <:> shrinkUTxOAvailableForCollateral
+    <:> shrinkUTxOAvailableForInputs
+    <:> Nil
 
 --------------------------------------------------------------------------------
 -- Assets to mint and burn

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -344,26 +344,26 @@ liftShrinker shrinker = fn (shrinker . unI)
 -- @
 groundRobinShrinkP :: NP (I -.-> []) xs -> NP I xs -> [NP I xs]
 groundRobinShrinkP fns = interleaveRoundRobin . groundRobinShrinkP' fns
-    where
-        groundRobinShrinkP' :: NP (I -.-> []) xs -> NP I xs -> [[NP I xs]]
-        groundRobinShrinkP' Nil Nil =
-            -- In the case of no argument constructors, there is no need to
-            -- shrink
-            []
-        groundRobinShrinkP' (s :* ss) (x1 :* xs) =
-            -- Best explained with example:
-            --   BoolChar b c
-            --     1. shrink b = [b1, b2, b3]
-            --     -- shrink the first argument
-            --     2. [ BoolChar b1 c, BoolChar b2 c, BoolChar b3 c ]
-            --     -- create a list of values with only first value shrunk
-            --     3. shrink c = [c1, c2, c3]
-            --     -- shrink the second argument
-            --     4. [ BoolChar b c1, BoolChar b c2, BoolChar b c3 ]
-            --     -- create a list of values with only second value shrunk
-            --     -- append and return the lists in 2. and 4.
-            [ [ ( I x1' :* xs ) | x1' <- apFn s x1 ] ]
-            <> (fmap (x1 :*) <$> groundRobinShrinkP' ss xs)
+  where
+    groundRobinShrinkP' :: NP (I -.-> []) xs -> NP I xs -> [[NP I xs]]
+    groundRobinShrinkP' Nil Nil =
+        -- In the case of no argument constructors, there is no need to
+        -- shrink
+        []
+    groundRobinShrinkP' (s :* ss) (x1 :* xs) =
+        -- Best explained with example:
+        --   BoolChar b c
+        --     1. shrink b = [b1, b2, b3]
+        --     -- shrink the first argument
+        --     2. [ BoolChar b1 c, BoolChar b2 c, BoolChar b3 c ]
+        --     -- create a list of values with only first value shrunk
+        --     3. shrink c = [c1, c2, c3]
+        --     -- shrink the second argument
+        --     4. [ BoolChar b c1, BoolChar b c2, BoolChar b c3 ]
+        --     -- create a list of values with only second value shrunk
+        --     -- append and return the lists in 2. and 4.
+        [ [ ( I x1' :* xs ) | x1' <- apFn s x1 ] ]
+        <> (fmap (x1 :*) <$> groundRobinShrinkP' ss xs)
 
 -- | Using a round-robin algorithm, apply a list of shrinkers to their
 -- corresponding types in a Generics.SOP type. Only defined for types with a
@@ -460,7 +460,7 @@ genericRoundRobinShrink
     -> a
     -> [a]
 genericRoundRobinShrink f x =
-  GGP.gto <$> groundRobinShrinkS f (GGP.gfrom x)
+    GGP.gto <$> groundRobinShrinkS f (GGP.gfrom x)
 
 -- | Same as @genericRoundRobinShrink@ but uses available Arbitrary instance for
 -- shrinking.
@@ -474,6 +474,6 @@ genericRoundRobinShrink'
     => a
     -> [a]
 genericRoundRobinShrink' x =
-  fmap GGP.gto
-  $ groundRobinShrinkS (hcpure (Proxy @Arbitrary) (liftShrinker shrink))
-  $ GGP.gfrom x
+    fmap GGP.gto
+    $ groundRobinShrinkS (hcpure (Proxy @Arbitrary) (liftShrinker shrink))
+    $ GGP.gfrom x


### PR DESCRIPTION
## Issue Number

#2999

## Summary

This PR provides operators to make it easier to use generic n-ary product shrinking.
   
These operators allow us to compose shrinkers with a syntax that is very
similar to the applicative syntax for composing generators. This makes it easier to compare the definitions of generators and shrinkers that are related to one another.

For example:

```haskell

data MyRecord = MyRecord
    { foo :: Foo
    , bar :: Bar
    , baz :: Baz
    }
    deriving (Eq, Generic, Show)

genMyRecord :: Gen MyRecord
genMyRecord = MyRecord
    <$> genFoo
    <*> genBar
    <*> genBaz

shrinkMyRecord :: MyRecord -> [MyRecord]
shrinkMyRecord = genericRoundRobinShrink
    <@> shrinkFoo
    <:> shrinkBar
    <:> shrinkBaz
    <:> Nil

```