### PR TITLE
Add GitHub action to auto-approve docs PRs

### DIFF
--- a/.github/workflows/approve-docs.yml
+++ b/.github/workflows/approve-docs.yml
@@ -1,0 +1,21 @@
+name: Auto-Approve Docs
+on: pull_request_target
+
+jobs:
+  review:
+    if: '${{ github.ref_protected }}'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: 'Check scope of PR'
+        run: './scripts/gh/check-scope.sh scope'
+        id: check
+
+      # Note that GitHub actions do not run from forked repos, so this
+      # will only approve PRs from branches in the main repo.
+      - name: 'Approve Docs'
+        if: "${{ steps.check.outputs.scope == 'docs' }}"
+        uses: hmarr/auto-approve-action@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/scripts/gh/check-scope.sh
+++ b/scripts/gh/check-scope.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.." || exit 8
+
+base="$GITHUB_BASE_REF"
+branch="$GITHUB_HEAD_REF"
+output="${1:-result}"
+
+printf "Fetching branches\n"
+git fetch origin "$base" "$branch"
+
+printf '\nComparing %s..%s\n' "$base" "$branch"
+dirs=$(scripts/what-changed.sh "remotes/origin/$base" "remotes/origin/$branch")
+printf 'The following top-level paths were changed:\n%s\n' "$dirs"
+
+printf '\nSet output variable "%s"\n' "$output"
+echo "::set-output name=$output::$(xargs <<< "$dirs")"

--- a/scripts/what-changed.sh
+++ b/scripts/what-changed.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# This will print the top-level files/directories modified in a
+# branch, compared to its base branch.
+
+set -euo pipefail
+
+if [ -z "${2:-}" ]; then
+  echo "usage: $0 BASE_REF BRANCH_REF"
+  exit 1
+fi
+
+base="$1"
+branch="$2"
+
+git log --name-only --pretty=format: "${base}..${branch}" | grep -v '^$' | sed 's=^\([^/]*\).*$=\1=' | sort -u


### PR DESCRIPTION
Adds a CI step which looks at what changed in a PR. If it's "only" docs which changed, then the PR gets an automatic review approval.

### Comments

Reviews aren't automatically dismissed if non-docs changes are added to the PR. That would require some modifications to the https://github.com/hmarr/auto-approve-action code.

### Issue Number

ADP-1254
