### PR TITLE
Bump bech32 to v1.1.2 tag

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -74,6 +74,13 @@ source-repository-package
 
 source-repository-package
     type: git
+    location: https://github.com/input-output-hk/bech32
+    tag: ab61914443e5f53624d3b2995767761b3f68e576
+    subdir: bech32
+            bech32-th
+
+source-repository-package
+    type: git
     location: https://github.com/input-output-hk/cardano-base
     tag: e8a48cf0500b03c744c7fc6f2fedb86e8bdbe055
     subdir:

--- a/nix/.stack.nix/bech32-th.nix
+++ b/nix/.stack.nix/bech32-th.nix
@@ -1,0 +1,63 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { release = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "bech32-th"; version = "1.1.1"; };
+      license = "Apache-2.0";
+      copyright = "2020 IOHK";
+      maintainer = "operations@iohk.io, erikd@mega-nerd.com, jonathan.knowles@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "https://github.com/input-output-hk/bech32";
+      url = "";
+      synopsis = "Template Haskell extensions to the Bech32 library.";
+      description = "Template Haskell extensions to the Bech32 library, including\nquasi-quoters for compile-time checking of Bech32 string\nliterals.";
+      buildType = "Simple";
+      isLocal = true;
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+          (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          ];
+        buildable = true;
+        };
+      tests = {
+        "bech32-th-test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+            (hsPkgs."bech32-th" or (errorHandler.buildDepError "bech32-th"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))
+            ];
+          buildable = true;
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/bech32";
+      rev = "ab61914443e5f53624d3b2995767761b3f68e576";
+      sha256 = "0isqh5s6rdhmqa3jhvc32zb3kvzy149hmzddx1ld9f9jhls4f3wg";
+      }) // {
+      url = "https://github.com/input-output-hk/bech32";
+      rev = "ab61914443e5f53624d3b2995767761b3f68e576";
+      sha256 = "0isqh5s6rdhmqa3jhvc32zb3kvzy149hmzddx1ld9f9jhls4f3wg";
+      };
+    postUnpack = "sourceRoot+=/bech32-th; echo source root reset to \$sourceRoot";
+    }

--- a/nix/.stack.nix/bech32.nix
+++ b/nix/.stack.nix/bech32.nix
@@ -1,0 +1,89 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { release = false; static = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "bech32"; version = "1.1.2"; };
+      license = "Apache-2.0";
+      copyright = "2017 Marko Bencun, 2019-2020 IOHK";
+      maintainer = "operations@iohk.io, erikd@mega-nerd.com, jonathan.knowles@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "https://github.com/input-output-hk/bech32";
+      url = "";
+      synopsis = "Implementation of the Bech32 cryptocurrency address format (BIP 0173).";
+      description = "Implementation of the Bech32 cryptocurrency address format documented in the\nBIP (Bitcoin Improvement Proposal) 0173.";
+      buildType = "Simple";
+      isLocal = true;
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."array" or (errorHandler.buildDepError "array"))
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          ];
+        buildable = true;
+        };
+      exes = {
+        "bech32" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."base58-bytestring" or (errorHandler.buildDepError "base58-bytestring"))
+            (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+            (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            ];
+          buildable = true;
+          };
+        };
+      tests = {
+        "bech32-test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."base58-bytestring" or (errorHandler.buildDepError "base58-bytestring"))
+            (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+            (hsPkgs."process" or (errorHandler.buildDepError "process"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))
+            (hsPkgs.buildPackages.bech32.components.exes.bech32 or (pkgs.buildPackages.bech32 or (errorHandler.buildToolDepError "bech32:bech32")))
+            ];
+          buildable = true;
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/bech32";
+      rev = "ab61914443e5f53624d3b2995767761b3f68e576";
+      sha256 = "0isqh5s6rdhmqa3jhvc32zb3kvzy149hmzddx1ld9f9jhls4f3wg";
+      }) // {
+      url = "https://github.com/input-output-hk/bech32";
+      rev = "ab61914443e5f53624d3b2995767761b3f68e576";
+      sha256 = "0isqh5s6rdhmqa3jhvc32zb3kvzy149hmzddx1ld9f9jhls4f3wg";
+      };
+    postUnpack = "sourceRoot+=/bech32; echo source root reset to \$sourceRoot";
+    }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -62,6 +62,8 @@
         cardano-addresses-cli = ./cardano-addresses-cli.nix;
         cardano-addresses = ./cardano-addresses.nix;
         optparse-applicative-fork = ./optparse-applicative-fork.nix;
+        bech32 = ./bech32.nix;
+        bech32-th = ./bech32-th.nix;
         base-deriving-via = ./base-deriving-via.nix;
         cardano-binary = ./cardano-binary.nix;
         cardano-binary-test = ./cardano-binary-test.nix;

--- a/stack.yaml
+++ b/stack.yaml
@@ -131,6 +131,13 @@ extra-deps:
 - git: https://github.com/input-output-hk/optparse-applicative
   commit: 7497a29cb998721a9068d5725d49461f2bba0e7a
 
+  # bech32-1.1.2
+- git: https://github.com/input-output-hk/bech32
+  commit: ab61914443e5f53624d3b2995767761b3f68e576
+  subdirs:
+  - bech32
+  - bech32-th
+
 - git: https://github.com/input-output-hk/cardano-base
   commit: e8a48cf0500b03c744c7fc6f2fedb86e8bdbe055
   subdirs:


### PR DESCRIPTION
Updates to bech32 v1.1.2.

### Comments

Next time we update the Cabal index-state or Stackage LTS, we can replace this git repo definitions. 

### Issue

None