### PR TITLE
Tighten criteria for accepting Shelley or Byron addresses in REST API

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -24,6 +24,9 @@ module Test.Integration.Framework.TestData
     , russianWalletName
     , wildcardsWalletName
 
+    -- * Addresses
+    , invalidByronBase58
+
     -- * Assets
     , steveToken
 
@@ -209,6 +212,12 @@ wildcardsWalletName :: Text
 wildcardsWalletName = "`~`!@#$%^&*()_+-=<>,./?;':\"\"'{}[]\\|❤️ 💔 💌 💕 💞 \
 \💓 💗 💖 💘 💝 💟 💜 💛 💚 💙0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸"
 
+---
+--- Addresses
+---
+
+invalidByronBase58 :: Text
+invalidByronBase58 = "DdzFFPUkBXGf2an4Lgygm8tYUKXePj9KT4d3opFmG9nnygXRrDjQ6FQe"
 
 ---
 --- Assets

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
@@ -105,6 +105,7 @@ import Test.Integration.Framework.TestData
     , errMsg404CannotFindTx
     , errMsg404NoWallet
     , falseWalletIds
+    , invalidByronBase58
     , kanjiWalletName
     , polishWalletName
     , wildcardsWalletName
@@ -935,24 +936,19 @@ spec = describe "SHELLEY_CLI_TRANSACTIONS" $ do
           ]
 
       encodeErr = "Unrecognized address encoding"
-      encodeErr2 = "Unable to decode address"
       parseErr = "Parse error. Expecting format \"<amount>@<address>\""
       matrixInvalidAddrs =
--- TODO: For the haskell node, hex is valid. For jormungandr it is not.
---  longAddr = replicate 10000 '1'
---  We should optimally find a way to test this.
---          [ ( "long hex", longAddr, encodeErr )
---          , ( "short hex", "1", encodeErr )
           [ ( "-1000", "-1000", encodeErr )
-          , ( "q", "q", encodeErr2 )
-          , ( "empty", "", encodeErr2 )
+          , ( "q", "q", encodeErr )
+          , ( "empty", "", encodeErr )
           , ( "wildcards", T.unpack wildcardsWalletName, parseErr )
           , ( "arabic", T.unpack arabicWalletName, encodeErr )
           , ( "kanji", T.unpack kanjiWalletName, encodeErr )
           , ( "polish", T.unpack polishWalletName, encodeErr )
           , ( "[]", "[]", encodeErr )
-          , ( "no address", "", encodeErr2 )
+          , ( "no address", "", encodeErr )
           , ( "address is space", " ", encodeErr )
+          , ( "invalid Byron", T.unpack invalidByronBase58, encodeErr)
           ]
       errNum = "Expecting natural number"
       matrixInvalidAmt =

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -2043,10 +2043,10 @@ decodeBytes t =
         Just bytes ->
             Right bytes
         _ ->
-            Left $ TextDecodingError $ mconcat
+            Left $ TextDecodingError $ unwords
                 [ "Unrecognized address encoding: must be either bech32 or base58."
-                , " Perhaps your address is not entirely right?"
-                , " Every character has to be correct!"
+                , "Perhaps your address is not entirely correct?"
+                , "Please double-check each character within the address and try again."
                 ]
 
 -- | Attempt to decode a Shelley 'Address' using a Bech32 encoding.

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -232,12 +232,10 @@ import Data.Binary.Put
     ( putByteString, putWord8, runPut )
 import Data.Bits
     ( (.&.), (.|.) )
-import Data.ByteArray.Encoding
-    ( Base (Base16), convertFromBase )
 import Data.ByteString
     ( ByteString )
 import Data.ByteString.Base58
-    ( bitcoinAlphabet, decodeBase58, encodeBase58 )
+    ( bitcoinAlphabet, encodeBase58 )
 import Data.ByteString.Short
     ( fromShort, toShort )
 import Data.Coerce
@@ -302,6 +300,7 @@ import Ouroboros.Network.NodeToClient
 import Ouroboros.Network.Point
     ( WithOrigin (..) )
 
+import qualified Cardano.Address as CA
 import qualified Cardano.Address.Style.Shelley as CA
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Byron as Cardano
@@ -2040,28 +2039,36 @@ instance DecodeAddress ('Testnet pm) where
 
 decodeBytes :: Text -> Either TextDecodingError ByteString
 decodeBytes t =
-    case tryBase16 t <|> tryBech32 t <|> tryBase58 t of
+    case tryBech32 t <|> tryBase58 t of
         Just bytes ->
             Right bytes
         _ ->
-            Left $ TextDecodingError
-                "Unrecognized address encoding: must be either bech32, base58 or base16"
+            Left $ TextDecodingError $ mconcat
+                [ "Unrecognized address encoding: must be either bech32 or base58."
+                , " Perhaps your address is not entirely right?"
+                , " Every character has to be correct!"
+                ]
 
--- | Attempt decoding an 'Address' using a Bech32 encoding.
+-- | Attempt to decode a Shelley 'Address' using a Bech32 encoding.
 tryBech32 :: Text -> Maybe ByteString
-tryBech32 text = do
-    (_, dp) <- either (const Nothing) Just (Bech32.decodeLenient text)
-    dataPartToBytes dp
+tryBech32 = fmap CA.unAddress . CA.fromBech32
 
--- | Attempt decoding a legacy 'Address' using a Base58 encoding.
+-- | Attempt to decode a legacy Byron 'Address' using a Base58 encoding.
+--
+-- NOTE: As of Oct 2021, the Shelley ledger does *not* check whether
+-- a Byron address is in valid Byron binary format. This implies that
+-- an invalid Base58 Byron address can be interpreted as a valid Shelly
+-- address, which results in unexpected loss of user funds.
+--
+-- Here, the 'tryBase58' function uses 'Cardano.Address',
+-- which performs the additional check of deserializing the
+-- address from Byron CBOR format.
+-- 
+-- Even so, we strongly recommend the Bech32 format, 
+-- as it includes error detection
+-- and is more robust against typos and misspellings.
 tryBase58 :: Text -> Maybe ByteString
-tryBase58 text =
-    decodeBase58 bitcoinAlphabet (T.encodeUtf8 text)
-
--- | Attempt decoding an 'Address' using Base16 encoding
-tryBase16 :: Text -> Maybe ByteString
-tryBase16 text =
-    either (const Nothing) Just $ convertFromBase Base16 (T.encodeUtf8 text)
+tryBase58 = fmap CA.unAddress . CA.fromBase58
 
 errMalformedAddress :: TextDecodingError
 errMalformedAddress = TextDecodingError

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -102,8 +102,6 @@ import Codec.Binary.Encoding
     ( fromBase16 )
 import Control.Monad
     ( forM_ )
-import Data.ByteArray.Encoding
-    ( Base (..), convertToBase )
 import Data.ByteString
     ( ByteString )
 import Data.ByteString.Base58
@@ -201,15 +199,11 @@ spec = do
                 Just _ -> property True
                 Nothing -> property False
 
-        prop "Shelley addresses from base16, bech32 and base58" $ \k -> do
+        prop "Shelley addresses from bech32" $ \k -> do
             let addr@(Address bytes) = paymentAddress @'Mainnet @ShelleyKey k
             conjoin
-                [ decodeAddress @'Mainnet (base16 bytes) === Right addr
-                    & counterexample (show $ base16 bytes)
-                , decodeAddress @'Mainnet (bech32 bytes) === Right addr
+                [ decodeAddress @'Mainnet (bech32 bytes) === Right addr
                     & counterexample (show $ bech32 bytes)
-                , decodeAddress @'Mainnet (base58 bytes) === Right addr
-                    & counterexample (show $ base58 bytes)
                 ]
 
         prop "Shelley addresses from bech32 - testnet" $ \k ->
@@ -217,14 +211,10 @@ spec = do
             in decodeAddress @('Testnet 0) (bech32testnet raw) === Right addr
                    & counterexample (show $ bech32testnet raw)
 
-        prop "Byron addresses from base16, bech32 and base58" $ \k -> do
+        prop "Byron addresses from base58" $ \k -> do
             let addr@(Address bytes) = paymentAddress @'Mainnet @ByronKey k
             conjoin
-                [ decodeAddress @'Mainnet (base16 bytes) === Right addr
-                    & counterexample (show $ base16 bytes)
-                , decodeAddress @'Mainnet (bech32 bytes) === Right addr
-                    & counterexample (show $ bech32 bytes)
-                , decodeAddress @'Mainnet (base58 bytes) === Right addr
+                [ decodeAddress @'Mainnet (base58 bytes) === Right addr
                     & counterexample (show $ base58 bytes)
                 ]
 
@@ -827,9 +817,6 @@ instance Arbitrary (VariableSize128 TokenBundle) where
 -- Helpers
 --
 --
-
-base16 :: ByteString -> Text
-base16 = T.decodeUtf8 . convertToBase Base16
 
 bech32 :: ByteString -> Text
 bech32 = Bech32.encodeLenient hrp . Bech32.dataPartFromBytes

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -47,6 +47,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , NetworkDiscriminant (..)
     , PaymentAddress (..)
     , WalletKey
+    , delegationAddress
     , publicKey
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
@@ -199,24 +200,25 @@ spec = do
                 Just _ -> property True
                 Nothing -> property False
 
-        prop "Shelley addresses from bech32" $ \k -> do
+        prop "Shelley addresses from bech32" $ \k ->
             let addr@(Address bytes) = paymentAddress @'Mainnet @ShelleyKey k
-            conjoin
-                [ decodeAddress @'Mainnet (bech32 bytes) === Right addr
+            in  decodeAddress @'Mainnet (bech32 bytes) === Right addr
                     & counterexample (show $ bech32 bytes)
-                ]
+
+        prop "Shelley addresses with delegation from bech32" $ \k1 k2 ->
+            let addr@(Address bytes) = delegationAddress @'Mainnet @ShelleyKey k1 k2
+            in  decodeAddress @'Mainnet (bech32 bytes) === Right addr
+                    & counterexample (show $ bech32 bytes)
 
         prop "Shelley addresses from bech32 - testnet" $ \k ->
             let addr@(Address raw) = paymentAddress @('Testnet 0) @ShelleyKey k
-            in decodeAddress @('Testnet 0) (bech32testnet raw) === Right addr
+            in  decodeAddress @('Testnet 0) (bech32testnet raw) === Right addr
                    & counterexample (show $ bech32testnet raw)
 
-        prop "Byron addresses from base58" $ \k -> do
+        prop "Byron addresses from base58" $ \k ->
             let addr@(Address bytes) = paymentAddress @'Mainnet @ByronKey k
-            conjoin
-                [ decodeAddress @'Mainnet (base58 bytes) === Right addr
+            in  decodeAddress @'Mainnet (base58 bytes) === Right addr
                     & counterexample (show $ base58 bytes)
-                ]
 
     describe "decentralizationLevelFromPParams" $ do
 

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -260,6 +260,15 @@ x-addressId: &addressId
   type: string
   format: base58|bech32
   example: addr1sjck9mdmfyhzvjhydcjllgj9vjvl522w0573ncustrrr2rg7h9azg4cyqd36yyd48t5ut72hgld0fg2xfvz82xgwh7wal6g2xt8n996s3xvu5g
+  description: |
+    A sequence of characters that encodes (in Base58 or Bech32) a sequence of bytes
+    which represents an address on the Cardano blockchain.
+    Sequences in Base58 encoding are expected to be legacy Byron addresses,
+    whereas sequences in Bech32 encoding correspond to current Shelley addresses.
+
+    For more details, see
+    [CIP-0019 — Cardano addresses](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0019)
+    .
 
 x-addressState: &addressState
   type: string


### PR DESCRIPTION
### Summary

It has become established usage that Byron addresses are associated with the Base58 encoding while Shelley addresses are associated with the Bech32 encoding.

To catch more user errors, we now enforce this usage more strictly.

Specifically,

* Base58 encoded addresses are assumed to be Byron addresses and are additionally deserialized to CBOR to check whether they comply with the  Byron address binary format.
* We no longer accept Base16 encoded addresses. The swagger documentation has already highlighted that only Base58 and Bech32 are accepted.

To avoid loss of funds, we strongly recommend to use Shelley addresses and the Bech32 encoding, as this encoding includes error detection and is more robust against misspellings and truncations.

Relevant standards: [CIP 19 — Cardano addresses](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0019).

### Comments

(EDIT: correction)

* Ideally, lay users would only see a single canonical version of every address. Unfortunately, we are not quite there yet, and this PR is only a partial improvement. For example,
    * Bech32-encoded addresses can represent Byron addresses instead of Shelley addresses. These would be shown in Base58 encoding in the blockchain explorer.
    * A sequence of bytes which is too long to be a valid Shelley address, but has a header-byte that indicates a Shelley address, may be truncated to the proper size. Put differently, seemingly invalid addresses are mapped to valid ones. Fortunately, the error correction inherent to Bech32 and reserving the Base58 encoding for Byron addresses (implemented in this PR) make this less likely to occur through user mistake.
* A general clean up of our address data types would be nice, but is out of scope for this pull request.

### Issue Number

ADP-1033, ADP-1280