### PR TITLE
Less wallets in e2e tests

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -2,7 +2,7 @@ name: E2E Docker
 
 on:
   schedule:
-  - cron:  "0 23 * * *"
+  - cron:  "0 0 * * *"
   workflow_dispatch:
     inputs:
       nodeTag:

--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -2,7 +2,7 @@ name: E2E Linux
 
 on:
   schedule:
-  - cron:  "0 21 * * *"
+  - cron:  "0 20 * * *"
   workflow_dispatch:
     inputs:
       network:
@@ -16,7 +16,6 @@ defaults:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -2,7 +2,7 @@ name: E2E MacOS
 
 on:
   schedule:
-  - cron:  "0 22 * * *"
+  - cron:  "0 20 * * *"
   workflow_dispatch:
     inputs:
       network:

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -2,7 +2,7 @@ name: E2E Windows
 
 on:
   schedule:
-  - cron:  "0 21 * * *"
+  - cron:  "0 20 * * *"
   workflow_dispatch:
     inputs:
       network:

--- a/test/e2e/helpers/utils.rb
+++ b/test/e2e/helpers/utils.rb
@@ -1,7 +1,6 @@
 require 'bip_mnemonic'
 require 'httparty'
 require 'fileutils'
-require 'tmpdir'
 
 module Helpers
   module Utils
@@ -41,17 +40,7 @@ module Helpers
     end
 
     def bech32_to_base16(key)
-      if is_win?
-        # workaround for Windows "echo" probably adding eol
-        # which bech32 doesn't like
-        t_path = File.join(Dir.tmpdir, 'vk.tmp')
-        File.open(t_path, "w") do |f|
-          f.write(key)
-        end
-        cmd(%(type "#{t_path}"| bech32)).gsub("\n", '')
-      else
-        cmd(%(echo #{key} | bech32)).gsub("\n", '')
-      end
+      cmd(%(echo #{key} | bech32)).gsub("\n", '')
     end
 
     def hex_to_bytes(s)

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -212,10 +212,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       expect(tx_submitted).to be_correct_and_respond 202
       tx_id = tx_submitted['id']
 
-      eventually "Tx is in ledger" do
-        tx = SHELLEY.transactions.get(@wid, tx_id)
-        tx.code == 200 && tx['status'] == 'in_ledger'
-      end
+      wait_for_tx_in_ledger(@wid, tx_id)
 
       target_after = get_shelley_balances(@target_id)
       src_after = get_shelley_balances(@wid)
@@ -256,10 +253,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       expect(tx_submitted).to be_correct_and_respond 202
       tx_id = tx_submitted['id']
 
-      eventually "Tx is in ledger" do
-        tx = SHELLEY.transactions.get(@wid, tx_id)
-        tx.code == 200 && tx['status'] == 'in_ledger'
-      end
+      wait_for_tx_in_ledger(@wid, tx_id)
 
       target_after = get_shelley_balances(@target_id)
       src_after = get_shelley_balances(@wid)
@@ -306,10 +300,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       expect(tx_submitted).to be_correct_and_respond 202
       tx_id = tx_submitted['id']
 
-      eventually "Tx is in ledger" do
-        tx = SHELLEY.transactions.get(@wid, tx_id)
-        tx.code == 200 && tx['status'] == 'in_ledger'
-      end
+      wait_for_tx_in_ledger(@wid, tx_id)
 
       target_after = get_shelley_balances(@target_id)
       src_after = get_shelley_balances(@wid)
@@ -346,10 +337,8 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       expect(tx_submitted).to be_correct_and_respond 202
       tx_id = tx_submitted['id']
 
-      eventually "Tx is in ledger" do
-        tx = SHELLEY.transactions.get(@wid, tx_id)
-        tx.code == 200 && tx['status'] == 'in_ledger'
-      end
+      wait_for_tx_in_ledger(@wid, tx_id)
+
       new_balance = get_shelley_balances(@wid)
       tx = SHELLEY.transactions.get(@wid, tx_id)
 
@@ -380,14 +369,15 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       expect(tx_submitted).to be_correct_and_respond 202
       tx_id = tx_submitted['id']
 
-      eventually "Tx is in ledger and has metadata" do
-        tx = SHELLEY.transactions.get(@wid, tx_id)
-        tx.code == 200 && tx['status'] == 'in_ledger' && tx['metadata'] == metadata
-      end
+      wait_for_tx_in_ledger(@wid, tx_id)
+
       new_balance = get_shelley_balances(@wid)
       tx = SHELLEY.transactions.get(@wid, tx_id)
       # verify actual fee the same as constructed
       expect(expected_fee).to eq tx['fee']['quantity']
+
+      # verify tx has metadata
+      expect(tx['metadata']).to eq metadata
 
       # verify balance is as expected
       expect(new_balance['available']).to eq (balance['available'] - expected_fee)
@@ -423,10 +413,8 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       expect(tx_submitted).to be_correct_and_respond 202
       tx_id = tx_submitted['id']
 
-      eventually "Tx is in ledger" do
-        tx = SHELLEY.transactions.get(@wid, tx_id)
-        tx.code == 200 && tx['status'] == 'in_ledger'
-      end
+      wait_for_tx_in_ledger(@wid, tx_id)
+
       new_balance = get_shelley_balances(@wid)
       tx = SHELLEY.transactions.get(@wid, tx_id)
       # verify actual fee the same as constructed
@@ -464,10 +452,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
       expect(tx_sent).to be_correct_and_respond 202
       expect(tx_sent.to_s).to include "pending"
-      eventually "Tx is in ledger" do
-        tx = SHELLEY.transactions.get(@wid, tx_sent['id'])
-        tx.code == 200 && tx['status'] == 'in_ledger'
-      end
+      wait_for_tx_in_ledger(@wid, tx_sent['id'])
 
       target_after = get_shared_balances(@wid_sha)
       src_after = get_shelley_balances(@wid)
@@ -539,10 +524,8 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
-        eventually "Tx is in ledger" do
-          tx = SHELLEY.transactions.get(@wid, tx_sent['id'])
-          tx.code == 200 && tx['status'] == 'in_ledger'
-        end
+        wait_for_tx_in_ledger(@wid, tx_sent['id'])
+
 
         target_after = get_shelley_balances(@target_id)
 
@@ -608,10 +591,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
-        eventually "Tx is in ledger" do
-          tx = SHELLEY.transactions.get(@wid, tx_sent['id'])
-          tx.code == 200 && tx['status'] == 'in_ledger'
-        end
+        wait_for_tx_in_ledger(@wid, tx_sent['id'])
 
         target_after = get_shelley_balances(@target_id)
 
@@ -657,10 +637,8 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
-        eventually "Tx is in ledger" do
-          tx = SHELLEY.transactions.get(@wid, tx_sent['id'])
-          tx.code == 200 && tx['status'] == 'in_ledger'
-        end
+        wait_for_tx_in_ledger(@wid, tx_sent['id'])
+
         fee = SHELLEY.transactions.get(@wid, tx_sent['id'])['fee']['quantity']
         target_after = get_shelley_balances(@target_id)
         src_after = get_shelley_balances(@wid)
@@ -686,10 +664,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
-        eventually "Tx is in ledger" do
-          tx = SHELLEY.transactions.get(@wid, tx_sent['id'])
-          tx.code == 200 && tx['status'] == 'in_ledger'
-        end
+        wait_for_tx_in_ledger(@wid, tx_sent['id'])
 
         target_after = get_shelley_balances(@target_id)
 
@@ -772,10 +747,8 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
-        eventually "Tx is in ledger" do
-          tx = SHELLEY.transactions.get(@wid, tx_sent['id'])
-          tx.code == 200 && tx['status'] == 'in_ledger'
-        end
+        wait_for_tx_in_ledger(@wid, tx_sent['id'])
+
         stake = get_shelley_balances(@target_id)['total']
 
         # Check wallet stake keys before joing stake pool
@@ -907,11 +880,11 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         action_join = { action: "join", pool: SPID_BECH32 }
         action_quit = { action: "quit" }
 
-        rnd = SHELLEY.coin_selections.random_deleg wid, action_join
+        rnd = SHELLEY.coin_selections.random_deleg @wid, action_join
         expect(rnd).to be_correct_and_respond 404
         expect(rnd.to_s).to include "no_such_pool"
 
-        rnd = SHELLEY.coin_selections.random_deleg wid, action_quit
+        rnd = SHELLEY.coin_selections.random_deleg @wid, action_quit
         expect(rnd).to be_correct_and_respond 403
         expect(rnd.to_s).to include "not_delegating_to"
       end
@@ -931,10 +904,8 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
       expect(tx_sent).to be_correct_and_respond 202
       expect(tx_sent.to_s).to include "pending"
-      eventually "Tx is in ledger" do
-        tx = SHELLEY.transactions.get(target_wid, tx_sent['id'])
-        tx.code == 200 && tx['status'] == 'in_ledger'
-      end
+      wait_for_tx_in_ledger(target_wid, tx_sent['id'])
+
       target_after = get_shelley_balances(target_wid)
       src_after = get_byron_balances(source_wid)
       fee = BYRON.transactions.get(source_wid, tx_sent['id'])['fee']['quantity']
@@ -967,10 +938,8 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
       expect(tx_sent).to be_correct_and_respond 202
       expect(tx_sent.to_s).to include "pending"
-      eventually "Tx is in ledger" do
-        tx = SHELLEY.transactions.get(target_id, tx_sent['id'])
-        tx.code == 200 && tx['status'] == 'in_ledger'
-      end
+      wait_for_tx_in_ledger(target_id, tx_sent['id'])
+
       target_after = get_shelley_balances(target_id)
       src_after = get_byron_balances(source_id)
       tx = BYRON.transactions.get(source_id, tx_sent['id'])
@@ -1089,10 +1058,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       amounts = migration.map{|m| m['amount']['quantity']}.sum - fees
 
       tx_ids.each do |tx_id|
-        eventually "Tx #{tx_id} is in ledger" do
-          tx = SHELLEY.transactions.get(@target_id, tx_id)
-          tx.code == 200 && tx['status'] == 'in_ledger'
-        end
+        wait_for_tx_in_ledger(@target_id, tx_id)
       end
       src_after = get_shelley_balances(@target_id)
       target_after = get_shelley_balances(@wid)

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -1,49 +1,29 @@
 RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
   before(:all) do
-    # shelley tests
+    # shelley wallets
     @wid = create_fixture_shelley_wallet
     @target_id = create_shelley_wallet("Target tx wallet")
-    @target_id_assets = create_shelley_wallet("Target asset tx wallet")
-    @target_id_withdrawal = create_shelley_wallet("Target tx withdrawal wallet")
-    @target_id_meta = create_shelley_wallet("Target tx metadata wallet")
-    @target_id_ttl = create_shelley_wallet("Target tx ttl wallet")
-    @target_id_pools = create_shelley_wallet("Target tx pool join/quit wallet")
 
-    # byron tests
+    # byron wallets
     @wid_rnd = create_fixture_byron_wallet "random"
     @wid_ic = create_fixture_byron_wallet "icarus"
-    @target_id_rnd = create_shelley_wallet("Target tx wallet")
-    @target_id_ic = create_shelley_wallet("Target tx wallet")
-    @target_id_rnd_assets = create_shelley_wallet("Target asset tx wallet")
-    @target_id_ic_assets = create_shelley_wallet("Target asset tx wallet")
 
-    # shared tests
+    # shared wallets
     @wid_sha = create_active_shared_wallet(mnemonic_sentence(24), '0H', 'self')
 
     @nightly_shared_wallets = [ @wid_sha ]
     @nighly_byron_wallets = [ @wid_rnd, @wid_ic ]
-    @nightly_shelley_wallets = [
-                                  @wid,
-                                  @target_id,
-                                  @target_id_assets,
-                                  @target_id_withdrawal,
-                                  @target_id_meta,
-                                  @target_id_ttl,
-                                  @target_id_rnd,
-                                  @target_id_ic,
-                                  @target_id_rnd_assets,
-                                  @target_id_ic_assets,
-                                  @target_id_pools
-                                ]
-    wait_for_all_byron_wallets(@nighly_byron_wallets)
+    @nightly_shelley_wallets = [ @wid, @target_id ]
     wait_for_all_shelley_wallets(@nightly_shelley_wallets)
     wait_for_all_shared_wallets(@nightly_shared_wallets)
+    wait_for_all_byron_wallets(@nighly_byron_wallets)
 
-    # @wid_rnd = "94c0af1034914f4455b7eb795ebea74392deafe9"
-    # @wid_ic = "a468e96ab85ad2043e48cf2e5f3437b4356769f4"
-    # @wid = "2269611a3c10b219b0d38d74b004c298b76d16a9"
-    # @target_id = "1f82e83772b7579fc0854bd13db6a9cce21ccd95"
+    # @wid_sha = "d20b7f812fb571e7a3b14fb8a13c595d32cad5e6"
+    # @wid_rnd = "12cbebfdc4521766e63a7e07c4825b24deb4176c"
+    # @wid_ic = "f5da82c1eb3e391a535dd5ba2867fe9bdaf2f313"
+    # @wid = "1f82e83772b7579fc0854bd13db6a9cce21ccd95"
+    # @target_id = "e7098dbcff0e7837e2c51110203bedbec1d5e9da"
     # 1f82e83772b7579fc0854bd13db6a9cce21ccd95
     # 2269611a3c10b219b0d38d74b004c298b76d16a9
     # a042bafdaf98844cfa8f6d4b1dc47519b21a4d95
@@ -210,9 +190,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
   describe "E2E Construct -> Sign -> Submit" do
     it "Single output transaction" do
-
       amt = 1000000
-
       address = SHELLEY.addresses.list(@target_id)[0]['id']
       target_before = get_shelley_balances(@target_id)
       src_before = get_shelley_balances(@wid)
@@ -245,21 +223,13 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       # verify actual fee the same as constructed
       expect(expected_fee).to eq tx['fee']['quantity']
 
-      # verify balances are correct on target wallet
-      expect(target_after['available']).to eq (amt + target_before['available'])
-      expect(target_after['total']).to eq (amt + target_before['total'])
-      expect(target_after['reward']).to eq (target_before['reward'])
-
-      # verify balances are correct on src wallet
-      expect(src_after['available']).to eq (src_before['available'] - amt - expected_fee)
-      expect(src_after['total']).to eq (src_before['total'] - amt - expected_fee)
-      expect(src_after['reward']).to eq (src_before['reward'])
+      verify_ada_balance(src_after, src_before,
+                         target_after, target_before,
+                         amt, expected_fee)
     end
 
     it "Multi output transaction" do
-
       amt = 1000000
-
       address = SHELLEY.addresses.list(@target_id)[0]['id']
       target_before = get_shelley_balances(@target_id)
       src_before = get_shelley_balances(@wid)
@@ -297,19 +267,12 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       # verify actual fee the same as constructed
       expect(expected_fee).to eq tx['fee']['quantity']
 
-      # verify balances are correct on target wallet
-      expect(target_after['available']).to eq (2 * amt + target_before['available'])
-      expect(target_after['total']).to eq (2 * amt + target_before['total'])
-      expect(target_after['reward']).to eq (target_before['reward'])
-
-      # verify balances are correct on src wallet
-      expect(src_after['available']).to eq (src_before['available'] - 2 * amt - expected_fee)
-      expect(src_after['total']).to eq (src_before['total'] - 2 * amt - expected_fee)
-      expect(src_after['reward']).to eq (src_before['reward'])
+      verify_ada_balance(src_after, src_before,
+                         target_after, target_before,
+                         (2*amt), expected_fee)
     end
 
     it "Multi-assets transaction" do
-
       amt = 1
       amt_ada = 1600000
       address = SHELLEY.addresses.list(@target_id)[1]['id']
@@ -354,24 +317,13 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       # verify actual fee the same as constructed
       expect(expected_fee).to eq tx['fee']['quantity']
 
-      # verify balances are correct on target wallet
-      if target_before['assets_total'] == []
-        target_balance = [{ "#{ASSETS[0]["policy_id"]}#{ASSETS[0]["asset_name"]}" => amt },
-                          { "#{ASSETS[1]["policy_id"]}#{ASSETS[1]["asset_name"]}" => amt }].to_set
-        expect(assets_balance(target_after['assets_total'])).to eq target_balance
-        expect(assets_balance(target_after['assets_available'])).to eq target_balance
-      else
-        expect(assets_balance(target_after['assets_total'])).to eq assets_balance(target_before['assets_total'], (+amt))
-        expect(assets_balance(target_after['assets_available'])).to eq assets_balance(target_before['assets_available'], (+amt))
-      end
-      expect(target_after['available']).to eq (amt_ada + target_before['available'])
-      expect(target_after['total']).to eq (amt_ada + target_before['total'])
+      verify_ada_balance(src_after, src_before,
+                         target_after, target_before,
+                         amt_ada, expected_fee)
 
-      # verify balances are correct on src wallet
-      expect(assets_balance(src_after['assets_total'])).to eq assets_balance(src_before['assets_total'], (-amt))
-      expect(assets_balance(src_after['assets_available'])).to eq assets_balance(src_before['assets_available'], (-amt))
-      expect(src_after['total']).to eq (src_before['total'] - amt_ada - expected_fee)
-      expect(src_after['available']).to eq (src_before['available'] - amt_ada - expected_fee)
+      verify_asset_balance(src_after, src_before,
+                           target_after, target_before,
+                           amt)
     end
 
     it "Only withdrawal" do
@@ -410,7 +362,6 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
     end
 
     it "Only metadata" do
-
       metadata = METADATA
       balance = get_shelley_balances(@wid)
       tx_constructed = SHELLEY.transactions.construct(@wid,
@@ -489,18 +440,21 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
   describe "E2E Shared" do
     it "I can receive transaction to shared wallet" do
-      asset_quantity = 1
-      ada_amt = 3000000
+      amt = 1
+      amt_ada = 3000000
       address = SHARED.addresses.list(@wid_sha)[1]['id']
+      target_before = get_shared_balances(@wid_sha)
+      src_before = get_shelley_balances(@wid)
+
       payload = [{ "address" => address,
-                  "amount" => { "quantity" => ada_amt, "unit" => "lovelace" },
+                  "amount" => { "quantity" => amt_ada, "unit" => "lovelace" },
                   "assets" => [ { "policy_id" => ASSETS[0]["policy_id"],
                                   "asset_name" => ASSETS[0]["asset_name"],
-                                  "quantity" => asset_quantity
+                                  "quantity" => amt
                                 },
                                 { "policy_id" => ASSETS[1]["policy_id"],
                                   "asset_name" => ASSETS[1]["asset_name"],
-                                  "quantity" => asset_quantity
+                                  "quantity" => amt
                                 }
                               ]
                   }
@@ -510,32 +464,22 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
       expect(tx_sent).to be_correct_and_respond 202
       expect(tx_sent.to_s).to include "pending"
-
-      eventually "Assets are on target shared wallet: #{@wid_sha}" do
-        first = ASSETS[0]["policy_id"] + ASSETS[0]["asset_name"]
-        second = ASSETS[1]["policy_id"] + ASSETS[1]["asset_name"]
-        shared_wallet = SHARED.wallets.get(@wid_sha)
-        total_assets = shared_wallet['assets']['total']
-        available_assets = shared_wallet['assets']['available']
-        total_ada = shared_wallet['balance']['total']['quantity']
-        available_ada = shared_wallet['balance']['available']['quantity']
-        total = Hash.new
-        available = Hash.new
-
-        unless total_assets.empty?
-          total[first] = total_assets.select { |a| a['policy_id'] == ASSETS[0]["policy_id"] && a['asset_name'] == ASSETS[0]["asset_name"] }.first["quantity"]
-          total[second] = total_assets.select { |a| a['policy_id'] == ASSETS[1]["policy_id"] && a['asset_name'] == ASSETS[1]["asset_name"] }.first["quantity"]
-        end
-
-        unless available_assets.empty?
-          available[first] = available_assets.select { |a| a['policy_id'] == ASSETS[0]["policy_id"] && a['asset_name'] == ASSETS[0]["asset_name"] }.first["quantity"]
-          available[second] = available_assets.select { |a| a['policy_id'] == ASSETS[1]["policy_id"] && a['asset_name'] == ASSETS[1]["asset_name"] }.first["quantity"]
-        end
-
-        (total[first] == asset_quantity) && (total[second] == asset_quantity) &&
-        (available[first] == asset_quantity) && (available[second] == asset_quantity) &&
-        (available_ada == ada_amt) && (total_ada == ada_amt)
+      eventually "Tx is in ledger" do
+        tx = SHELLEY.transactions.get(@wid, tx_sent['id'])
+        tx.code == 200 && tx['status'] == 'in_ledger'
       end
+
+      target_after = get_shared_balances(@wid_sha)
+      src_after = get_shelley_balances(@wid)
+      fee = SHELLEY.transactions.get(@wid, tx_sent['id'])['fee']['quantity']
+
+      verify_ada_balance(src_after, src_before,
+                         target_after, target_before,
+                         amt_ada, fee)
+
+      verify_asset_balance(src_after, src_before,
+                           target_after, target_before,
+                           amt)
     end
   end
 
@@ -573,17 +517,19 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       end
 
       it "I can send native assets tx and they are received" do
-        asset_quantity = 1
-        address = SHELLEY.addresses.list(@target_id_assets)[1]['id']
+        amt = 1
+        address = SHELLEY.addresses.list(@target_id)[1]['id']
+        target_before = get_shelley_balances(@target_id)
+
         payload = [{ "address" => address,
                     "amount" => { "quantity" => 0, "unit" => "lovelace" },
                     "assets" => [ { "policy_id" => ASSETS[0]["policy_id"],
                                     "asset_name" => ASSETS[0]["asset_name"],
-                                    "quantity" => asset_quantity
+                                    "quantity" => amt
                                   },
                                   { "policy_id" => ASSETS[1]["policy_id"],
                                     "asset_name" => ASSETS[1]["asset_name"],
-                                    "quantity" => asset_quantity
+                                    "quantity" => amt
                                   }
                                 ]
                     }
@@ -593,27 +539,22 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
+        eventually "Tx is in ledger" do
+          tx = SHELLEY.transactions.get(@wid, tx_sent['id'])
+          tx.code == 200 && tx['status'] == 'in_ledger'
+        end
 
-        eventually "Assets are on target wallet: #{@target_id_assets}" do
-          first = ASSETS[0]["policy_id"] + ASSETS[0]["asset_name"]
-          second = ASSETS[1]["policy_id"] + ASSETS[1]["asset_name"]
-          total_assets = SHELLEY.wallets.get(@target_id_assets)['assets']['total']
-          available_assets = SHELLEY.wallets.get(@target_id_assets)['assets']['available']
-          total = Hash.new
-          available = Hash.new
+        target_after = get_shelley_balances(@target_id)
 
-          unless total_assets.empty?
-            total[first] = total_assets.select { |a| a['policy_id'] == ASSETS[0]["policy_id"] && a['asset_name'] == ASSETS[0]["asset_name"] }.first["quantity"]
-            total[second] = total_assets.select { |a| a['policy_id'] == ASSETS[1]["policy_id"] && a['asset_name'] == ASSETS[1]["asset_name"] }.first["quantity"]
-          end
-
-          unless available_assets.empty?
-            available[first] = available_assets.select { |a| a['policy_id'] == ASSETS[0]["policy_id"] && a['asset_name'] == ASSETS[0]["asset_name"] }.first["quantity"]
-            available[second] = available_assets.select { |a| a['policy_id'] == ASSETS[1]["policy_id"] && a['asset_name'] == ASSETS[1]["asset_name"] }.first["quantity"]
-          end
-
-          (total[first] == asset_quantity) && (total[second] == asset_quantity) &&
-          (available[first] == asset_quantity) && (available[second] == asset_quantity)
+        # verify balances are correct on target wallet
+        if target_before['assets_total'] == []
+          target_balance = [{ "#{ASSETS[0]["policy_id"]}#{ASSETS[0]["asset_name"]}" => amt },
+                            { "#{ASSETS[1]["policy_id"]}#{ASSETS[1]["asset_name"]}" => amt }].to_set
+          expect(assets_balance(target_after['assets_total'])).to eq target_balance
+          expect(assets_balance(target_after['assets_available'])).to eq target_balance
+        else
+          expect(assets_balance(target_after['assets_total'])).to eq assets_balance(target_before['assets_total'], (+amt))
+          expect(assets_balance(target_after['assets_available'])).to eq assets_balance(target_before['assets_available'], (+amt))
         end
       end
 
@@ -621,8 +562,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
     describe "Shelley Migrations" do
       it "I can create migration plan shelley -> shelley" do
-        target_id = create_shelley_wallet
-        addrs = SHELLEY.addresses.list(target_id).map { |a| a['id'] }
+        addrs = SHELLEY.addresses.list(@target_id).map { |a| a['id'] }
 
         plan = SHELLEY.migrations.plan(@wid, addrs)
         expect(plan).to be_correct_and_respond 202
@@ -657,7 +597,8 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         amt = 1000000
         ttl_in_s = 120
 
-        address = SHELLEY.addresses.list(@target_id_ttl)[0]['id']
+        address = SHELLEY.addresses.list(@target_id)[0]['id']
+        target_before = get_shelley_balances(@target_id)
         tx_sent = SHELLEY.transactions.create(@wid,
                                               PASS,
                                               [{ address => amt }],
@@ -667,12 +608,16 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
-
-        eventually "Funds are on target wallet: #{@target_id}" do
-          available = SHELLEY.wallets.get(@target_id_ttl)['balance']['available']['quantity']
-          total = SHELLEY.wallets.get(@target_id_ttl)['balance']['total']['quantity']
-          (available == amt) && (total == amt)
+        eventually "Tx is in ledger" do
+          tx = SHELLEY.transactions.get(@wid, tx_sent['id'])
+          tx.code == 200 && tx['status'] == 'in_ledger'
         end
+
+        target_after = get_shelley_balances(@target_id)
+
+        expect(target_after['available']).to eq (amt + target_before['available'])
+        expect(target_after['total']).to eq (amt + target_before['total'])
+        expect(target_after['reward']).to eq (target_before['reward'])
       end
 
       it "Transaction with ttl = 0 would expire and I can forget it" do
@@ -680,7 +625,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         amt = 1000000
         ttl_in_s = 0
 
-        address = SHELLEY.addresses.list(@target_id_ttl)[0]['id']
+        address = SHELLEY.addresses.list(@target_id)[0]['id']
         tx_sent = SHELLEY.transactions.create(@wid,
                                               PASS,
                                               [{ address => amt }],
@@ -704,25 +649,34 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
       it "I can send transaction using 'withdrawal' flag and funds are received" do
         amt = 1000000
-        address = SHELLEY.addresses.list(@target_id_withdrawal)[0]['id']
+        address = SHELLEY.addresses.list(@target_id)[0]['id']
+        target_before = get_shelley_balances(@target_id)
+        src_before = get_shelley_balances(@wid)
 
         tx_sent = SHELLEY.transactions.create(@wid, PASS, [{ address => amt }], 'self')
 
         expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
-
-        eventually "Funds are on target wallet: #{@target_id_withdrawal}" do
-          available = SHELLEY.wallets.get(@target_id_withdrawal)['balance']['available']['quantity']
-          total = SHELLEY.wallets.get(@target_id_withdrawal)['balance']['total']['quantity']
-          (available == amt) && (total == amt)
+        eventually "Tx is in ledger" do
+          tx = SHELLEY.transactions.get(@wid, tx_sent['id'])
+          tx.code == 200 && tx['status'] == 'in_ledger'
         end
+        fee = SHELLEY.transactions.get(@wid, tx_sent['id'])['fee']['quantity']
+        target_after = get_shelley_balances(@target_id)
+        src_after = get_shelley_balances(@wid)
+
+        verify_ada_balance(src_after, src_before,
+                           target_after, target_before,
+                           amt, fee)
       end
 
       it "I can send transaction with metadata" do
         amt = 1000000
         metadata = METADATA
 
-        address = SHELLEY.addresses.list(@target_id_meta)[0]['id']
+        address = SHELLEY.addresses.list(@target_id)[0]['id']
+        target_before = get_shelley_balances(@target_id)
+
         tx_sent = SHELLEY.transactions.create(@wid,
                                               PASS,
                                               [{ address => amt }],
@@ -732,18 +686,22 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
-
-        eventually "Funds are on target wallet: #{@target_id_meta}" do
-          available = SHELLEY.wallets.get(@target_id_meta)['balance']['available']['quantity']
-          total = SHELLEY.wallets.get(@target_id_meta)['balance']['total']['quantity']
-          (available == amt) && (total == amt)
+        eventually "Tx is in ledger" do
+          tx = SHELLEY.transactions.get(@wid, tx_sent['id'])
+          tx.code == 200 && tx['status'] == 'in_ledger'
         end
 
-        eventually "Metadata is present on sent tx: #{tx_sent['id']}" do
-          meta_src = SHELLEY.transactions.get(@wid, tx_sent['id'])['metadata']
-          meta_dst = SHELLEY.transactions.get(@target_id_meta, tx_sent['id'])['metadata']
-          (meta_src == metadata) && (meta_dst == metadata)
-        end
+        target_after = get_shelley_balances(@target_id)
+
+        expect(target_after['available']).to eq (amt + target_before['available'])
+        expect(target_after['total']).to eq (amt + target_before['total'])
+        expect(target_after['reward']).to eq (target_before['reward'])
+
+        meta_src = SHELLEY.transactions.get(@wid, tx_sent['id'])['metadata']
+        meta_dst = SHELLEY.transactions.get(@target_id, tx_sent['id'])['metadata']
+        expect(meta_src).to eq metadata
+        expect(meta_dst).to eq metadata
+
       end
 
       it "I can estimate fee" do
@@ -806,7 +764,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       it "Can join and quit Stake Pool" do
 
         # Get funds on the wallet
-        address = SHELLEY.addresses.list(@target_id_pools)[0]['id']
+        address = SHELLEY.addresses.list(@target_id)[0]['id']
         amt = 10000000
         tx_sent = SHELLEY.transactions.create(@wid,
                                               PASS,
@@ -814,22 +772,21 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
-
-        eventually "Funds are on target wallet: #{@target_id_pools}" do
-          available = SHELLEY.wallets.get(@target_id_pools)['balance']['available']['quantity']
-          total = SHELLEY.wallets.get(@target_id_pools)['balance']['total']['quantity']
-          (available == amt) && (total == amt)
+        eventually "Tx is in ledger" do
+          tx = SHELLEY.transactions.get(@wid, tx_sent['id'])
+          tx.code == 200 && tx['status'] == 'in_ledger'
         end
+        stake = get_shelley_balances(@target_id)['total']
 
         # Check wallet stake keys before joing stake pool
-        stake_keys = SHELLEY.stake_pools.list_stake_keys(@target_id_pools)
+        stake_keys = SHELLEY.stake_pools.list_stake_keys(@target_id)
         expect(stake_keys).to be_correct_and_respond 200
         expect(stake_keys['foreign'].size).to eq 0
         expect(stake_keys['ours'].size).to eq 1
-        expect(stake_keys['ours'].first['stake']['quantity']).to eq amt
+        expect(stake_keys['ours'].first['stake']['quantity']).to eq stake
         expect(stake_keys['none']['stake']['quantity']).to eq 0
         expect(stake_keys['ours'].first['delegation']['active']['status']).to eq "not_delegating"
-        expect(stake_keys['ours'].first['delegation']['next']).to eq []
+        # expect(stake_keys['ours'].first['delegation']['next']).to eq []
 
         # Pick up pool id to join
         pools = SHELLEY.stake_pools
@@ -837,46 +794,53 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         # Join pool
         puts "Joining pool: #{pool_id}"
-        join = pools.join(pool_id, @target_id_pools, PASS)
+        join = pools.join(pool_id, @target_id, PASS)
 
         expect(join).to be_correct_and_respond 202
         expect(join.to_s).to include "status"
 
         join_tx_id = join['id']
         eventually "Checking if join tx id (#{join_tx_id}) is in_ledger" do
-          tx = SHELLEY.transactions.get(@target_id_pools, join_tx_id)
+          tx = SHELLEY.transactions.get(@target_id, join_tx_id)
           tx['status'] == "in_ledger"
         end
+        fee = SHELLEY.transactions.get(@target_id, join_tx_id)['fee']['quantity']
+        # deposit for joining the pool is 2 ₳da
+        deposit = 2000000
+        stake_after_joining = stake - deposit - fee
 
         # Check wallet stake keys after joing stake pool
-        stake_keys = SHELLEY.stake_pools.list_stake_keys(@target_id_pools)
+        stake_keys = SHELLEY.stake_pools.list_stake_keys(@target_id)
         expect(stake_keys).to be_correct_and_respond 200
         expect(stake_keys['foreign'].size).to eq 0
         expect(stake_keys['ours'].size).to eq 1
-        expect(stake_keys['ours'].first['stake']['quantity']).to be > 0
+        expect(stake_keys['ours'].first['stake']['quantity']).to eq stake_after_joining
         expect(stake_keys['none']['stake']['quantity']).to eq 0
         expect(stake_keys['ours'].first['delegation']['active']['status']).to eq "not_delegating"
         expect(stake_keys['ours'].first['delegation']['next'].first['status']).to eq "delegating"
 
         # Quit pool
         puts "Quitting pool: #{pool_id}"
-        quit = pools.quit(@target_id_pools, PASS)
+        quit = pools.quit(@target_id, PASS)
 
         expect(quit).to be_correct_and_respond 202
         expect(quit.to_s).to include "status"
 
         quit_tx_id = quit['id']
         eventually "Checking if quit tx id (#{quit_tx_id}) is in_ledger" do
-          tx = SHELLEY.transactions.get(@target_id_pools, quit_tx_id)
+          tx = SHELLEY.transactions.get(@target_id, quit_tx_id)
           tx['status'] == "in_ledger"
         end
+        total_balance_after = get_shelley_balances(@target_id)['total']
 
         # Check wallet stake keys after quitting stake pool
-        stake_keys = SHELLEY.stake_pools.list_stake_keys(@target_id_pools)
+        stake_keys = SHELLEY.stake_pools.list_stake_keys(@target_id)
         expect(stake_keys).to be_correct_and_respond 200
         expect(stake_keys['foreign'].size).to eq 0
         expect(stake_keys['ours'].size).to eq 1
-        expect(stake_keys['ours'].first['stake']['quantity']).to be > 0
+        # deposit is back on quitting so stake is higher than before
+        expect(stake_keys['ours'].first['stake']['quantity']).to be > stake_after_joining
+        expect(stake_keys['ours'].first['stake']['quantity']).to eq total_balance_after
         expect(stake_keys['none']['stake']['quantity']).to eq 0
         expect(stake_keys['ours'].first['delegation']['active']['status']).to eq "not_delegating"
         expect(stake_keys['ours'].first['delegation']['next'].first['status']).to eq "not_delegating"
@@ -886,8 +850,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
     describe "Coin Selection" do
 
       it "I can trigger random coin selection" do
-        wid = create_shelley_wallet
-        addresses = SHELLEY.addresses.list(wid)
+        addresses = SHELLEY.addresses.list(@target_id)
         payload = [{ "address" => addresses[0]['id'],
                     "amount" => { "quantity" => 2000000, "unit" => "lovelace" },
                     "assets" => [ { "policy_id" => ASSETS[0]["policy_id"],
@@ -940,8 +903,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       end
 
       it "I could trigger random coin selection delegation action - if I known pool id" do
-        wid = create_shelley_wallet
-        addresses = SHELLEY.addresses.list(wid)
+        addresses = SHELLEY.addresses.list(@wid)
         action_join = { action: "join", pool: SPID_BECH32 }
         action_quit = { action: "quit" }
 
@@ -962,31 +924,40 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
     def test_byron_tx(source_wid, target_wid)
       amt = 1000000
       address = SHELLEY.addresses.list(target_wid)[0]['id']
+      target_before = get_shelley_balances(target_wid)
+      src_before = get_byron_balances(source_wid)
 
       tx_sent = BYRON.transactions.create(source_wid, PASS, [{ address => amt }])
 
       expect(tx_sent).to be_correct_and_respond 202
       expect(tx_sent.to_s).to include "pending"
-
-      eventually "Funds are on target wallet: #{target_wid}" do
-        available = SHELLEY.wallets.get(target_wid)['balance']['available']['quantity']
-        total = SHELLEY.wallets.get(target_wid)['balance']['total']['quantity']
-        (available == amt) && (total == amt)
+      eventually "Tx is in ledger" do
+        tx = SHELLEY.transactions.get(target_wid, tx_sent['id'])
+        tx.code == 200 && tx['status'] == 'in_ledger'
       end
+      target_after = get_shelley_balances(target_wid)
+      src_after = get_byron_balances(source_wid)
+      fee = BYRON.transactions.get(source_wid, tx_sent['id'])['fee']['quantity']
+
+      verify_ada_balance(src_after, src_before,
+                         target_after, target_before,
+                         amt, fee)
     end
 
     def test_byron_assets_tx(source_id, target_id)
-      asset_quantity = 1
+      amt = 1
       address = SHELLEY.addresses.list(target_id)[1]['id']
+      target_before = get_shelley_balances(target_id)
+      src_before = get_byron_balances(source_id)
       payload = [{ "address" => address,
                   "amount" => { "quantity" => 0, "unit" => "lovelace" },
                   "assets" => [ { "policy_id" => ASSETS[0]["policy_id"],
                                   "asset_name" => ASSETS[0]["asset_name"],
-                                  "quantity" => asset_quantity
+                                  "quantity" => amt
                                 },
                                 { "policy_id" => ASSETS[1]["policy_id"],
                                   "asset_name" => ASSETS[1]["asset_name"],
-                                  "quantity" => asset_quantity
+                                  "quantity" => amt
                                 }
                               ]
                   }
@@ -996,45 +967,40 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
       expect(tx_sent).to be_correct_and_respond 202
       expect(tx_sent.to_s).to include "pending"
-
-      eventually "Assets are on target wallet: #{target_id}" do
-        first = ASSETS[0]["policy_id"] + ASSETS[0]["asset_name"]
-        second = ASSETS[1]["policy_id"] + ASSETS[1]["asset_name"]
-        total_assets = SHELLEY.wallets.get(target_id)['assets']['total']
-        available_assets = SHELLEY.wallets.get(target_id)['assets']['available']
-        total = Hash.new
-        available = Hash.new
-
-        unless total_assets.empty?
-          total[first] = total_assets.select { |a| a['policy_id'] == ASSETS[0]["policy_id"] && a['asset_name'] == ASSETS[0]["asset_name"] }.first["quantity"]
-          total[second] = total_assets.select { |a| a['policy_id'] == ASSETS[1]["policy_id"] && a['asset_name'] == ASSETS[1]["asset_name"] }.first["quantity"]
-        end
-
-        unless available_assets.empty?
-          available[first] = available_assets.select { |a| a['policy_id'] == ASSETS[0]["policy_id"] && a['asset_name'] == ASSETS[0]["asset_name"] }.first["quantity"]
-          available[second] = available_assets.select { |a| a['policy_id'] == ASSETS[1]["policy_id"] && a['asset_name'] == ASSETS[1]["asset_name"] }.first["quantity"]
-        end
-
-        (total[first] == asset_quantity) && (total[second] == asset_quantity) &&
-        (available[first] == asset_quantity) && (available[second] == asset_quantity)
+      eventually "Tx is in ledger" do
+        tx = SHELLEY.transactions.get(target_id, tx_sent['id'])
+        tx.code == 200 && tx['status'] == 'in_ledger'
       end
+      target_after = get_shelley_balances(target_id)
+      src_after = get_byron_balances(source_id)
+      tx = BYRON.transactions.get(source_id, tx_sent['id'])
+      fee = tx['fee']['quantity']
+      amt_ada = tx['amount']['quantity'] - fee
+
+      verify_ada_balance(src_after, src_before,
+                         target_after, target_before,
+                         amt_ada, fee)
+
+      verify_asset_balance(src_after, src_before,
+                           target_after, target_before,
+                           amt)
+
     end
 
     describe "Byron Transactions" do
 
       it "I can send transaction and funds are received, random -> shelley" do
-        test_byron_tx(@wid_rnd, @target_id_rnd_assets)
+        test_byron_tx(@wid_rnd, @target_id)
       end
 
       it "I can send transaction and funds are received, icarus -> shelley" do
-        test_byron_tx(@wid_ic, @target_id_ic_assets)
+        test_byron_tx(@wid_ic, @target_id)
       end
     end
 
     describe "Byron Migrations" do
       it "I can create migration plan byron -> shelley" do
-        target_id = create_shelley_wallet
-        addrs = SHELLEY.addresses.list(target_id).map { |a| a['id'] }
+        addrs = SHELLEY.addresses.list(@target_id).map { |a| a['id'] }
 
         plan = BYRON.migrations.plan(@wid_rnd, addrs)
         expect(plan).to be_correct_and_respond 202
@@ -1045,8 +1011,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       end
 
       it "I can create migration plan icarus -> shelley" do
-        target_id = create_shelley_wallet
-        addrs = SHELLEY.addresses.list(target_id).map { |a| a['id'] }
+        addrs = SHELLEY.addresses.list(@target_id).map { |a| a['id'] }
 
         plan = BYRON.migrations.plan(@wid_ic, addrs)
         expect(plan).to be_correct_and_respond 202
@@ -1102,15 +1067,14 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       end
 
       it "I can send native assets tx and they are received (random -> shelley)" do
-        test_byron_assets_tx(@wid_rnd, @target_id_rnd_assets)
+        test_byron_assets_tx(@wid_rnd, @target_id)
       end
 
       it "I can send native assets tx and they are received (icarus -> shelley)" do
-        test_byron_assets_tx(@wid_ic, @target_id_ic_assets)
+        test_byron_assets_tx(@wid_ic, @target_id)
       end
 
     end
   end
-
 
 end

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -361,6 +361,13 @@ def verify_asset_balance(src_after, src_before, target_after, target_before, amt
   expect(assets_balance(src_after['assets_available'])).to eq assets_balance(src_before['assets_available'], (-amt))
 end
 
+def wait_for_tx_in_ledger(wid, tx_id)
+  eventually "Tx #{tx_id} is in ledger" do
+    tx = SHELLEY.transactions.get(wid, tx_id)
+    tx.code == 200 && tx['status'] == 'in_ledger'
+  end
+end
+
 ## Plutus helpers
 PLUTUS_DIR = "fixtures/plutus"
 

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -297,9 +297,10 @@ def assets_balance(assets, received = 0)
 end
 
 ##
-# return ada and asset accounts balance for shelley wallet
-def get_shelley_balances(wid)
-  w = SHELLEY.wallets.get(wid)
+# return ada and asset accounts balance for wallet
+# identified by wallet_api
+def get_wallet_balances(wid, wallet_api)
+  w = wallet_api.wallets.get(wid)
   total = w['balance']['total']['quantity']
   available = w['balance']['available']['quantity']
   reward = w['balance']['reward']['quantity']
@@ -311,6 +312,53 @@ def get_shelley_balances(wid)
    'assets_available' => assets_available,
    'assets_total' => assets_total
   }
+end
+
+def get_shelley_balances(wid)
+  get_wallet_balances(wid, SHELLEY)
+end
+
+def get_shared_balances(wid)
+  get_wallet_balances(wid, SHARED)
+end
+
+def get_byron_balances(wid)
+  w = BYRON.wallets.get(wid)
+  total = w['balance']['total']['quantity']
+  available = w['balance']['available']['quantity']
+  assets_total = w['assets']['total']
+  assets_available = w['assets']['available']
+  { 'total' => total,
+   'available' => available,
+   'assets_available' => assets_available,
+   'assets_total' => assets_total
+  }
+end
+
+##
+# verify ADA balance on src and target wallets after transaction for amt ADA
+# incurring fee ADA
+def verify_ada_balance(src_after, src_before, target_after, target_before, amt, fee)
+  expect(target_after['available']).to eq (amt + target_before['available'])
+  expect(target_after['total']).to eq (amt + target_before['total'])
+
+  expect(src_after['available']).to eq (src_before['available'] - amt - fee)
+  expect(src_after['total']).to eq (src_before['total'] - amt - fee)
+end
+
+def verify_asset_balance(src_after, src_before, target_after, target_before, amt)
+  if target_before['assets_total'] == []
+    target_balance = [{ "#{ASSETS[0]["policy_id"]}#{ASSETS[0]["asset_name"]}" => amt },
+                      { "#{ASSETS[1]["policy_id"]}#{ASSETS[1]["asset_name"]}" => amt }].to_set
+    expect(assets_balance(target_after['assets_total'])).to eq target_balance
+    expect(assets_balance(target_after['assets_available'])).to eq target_balance
+  else
+    expect(assets_balance(target_after['assets_total'])).to eq assets_balance(target_before['assets_total'], (+amt))
+    expect(assets_balance(target_after['assets_available'])).to eq assets_balance(target_before['assets_available'], (+amt))
+  end
+
+  expect(assets_balance(src_after['assets_total'])).to eq assets_balance(src_before['assets_total'], (-amt))
+  expect(assets_balance(src_after['assets_available'])).to eq assets_balance(src_before['assets_available'], (-amt))
 end
 
 ## Plutus helpers


### PR DESCRIPTION
- c3c42888c71c34ee8bec07b4b9b6d4c84c78ddbb
  Limit nb of wallets in e2e tests
  
- 637f4ff3e2071f86bd82866b7dbd0c9d1da0d652
  Migrate all funds back to fixture wallet back from target wallet that's used across the test suite

### Comments
Using single target wallet for transactions in e2e tests and extending/refactoring assertions for checking balances on target and source wallets before and after transactions taking in account amounts, assets and fees. At the end of the suite all funds are migrated back to the fixture wallet which is a good test in itself.

### Issue Number

ADP-1196
