### PR TITLE
Fix node db cache and e2e workflow improvements

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -68,7 +68,8 @@ jobs:
         key: node-db-docker-${{ env.NETWORK }}-${{ steps.date-time.outputs.value }}
         restore-keys: |
           node-db-docker-${{ env.NETWORK }}-
-
+          node-db-Linux-${{ env.NETWORK }}-
+            
     - name: 🚀 Start node and wallet
       run: |
         echo "Wallet: $WALLET"

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -51,8 +51,8 @@ jobs:
     - name: Install dependencies
       run: bundle install
 
-    - name: ⚙️ Setup (get configs and decode fixtures)
-      run: TESTS_E2E_BINDIR='' rake setup[$NETWORK]
+    - name: ⚙️ Setup (get latest bins and configs and decode fixtures)
+      run: rake setup[$NETWORK]
 
     - name: 🕒 Get Date/Time
       id: date-time
@@ -64,18 +64,21 @@ jobs:
       id: cache
       uses: actions/cache@v2.1.4
       with:
-        path: ~/node-db-nightly-docker
+        path: test/e2e/state/node_db/${{ env.NETWORK }}
         key: node-db-docker-${{ env.NETWORK }}-${{ steps.date-time.outputs.value }}
         restore-keys: |
           node-db-docker-${{ env.NETWORK }}-
           node-db-Linux-${{ env.NETWORK }}-
-            
+
     - name: 🚀 Start node and wallet
       run: |
         echo "Wallet: $WALLET"
         echo "Node: ${{steps.cardano-node-tag.outputs.NODE_TAG}}"
-        NODE=${{steps.cardano-node-tag.outputs.NODE_TAG}} NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK docker-compose -f docker-compose-test.yml up --detach
-        ls ~/node-db-nightly-docker
+        
+        NODE=${{steps.cardano-node-tag.outputs.NODE_TAG}} \
+        NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK \
+        DATA=`pwd`/state/node_db/$NETWORK \
+        docker-compose -f docker-compose-test.yml up --detach
 
     - name: 🔍 Display versions
       run: |

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -57,12 +57,20 @@ jobs:
         rake get_latest_configs[$NETWORK]
         rake get_latest_bins
 
+    - name: Get Date/Time
+      id: date-time
+      shell: bash
+      run: |
+        echo "::set-output name=value::$(rake datetime)"
+
     - name: Cache node db
       id: cache
       uses: actions/cache@v2.1.4
       with:
         path: ~/node-db-nightly-docker
-        key: ${{ runner.os }}-docker-node-cache-v2-${{ env.NETWORK }}
+        key: node-db-docker-${{ env.NETWORK }}-${{ steps.date-time.outputs.value }}
+        restore-keys: |
+          node-db-docker-${{ env.NETWORK }}-
 
     - name: Set up cardano-wallet and cardano-node
       run: |

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -8,7 +8,7 @@ on:
       nodeTag:
         description: 'Node tag (docker)'
         required: true
-        default: '1.30.0'
+        default: '1.30.1'
       walletTag:
         description: 'Wallet tag (docker)'
         required: true
@@ -51,19 +51,16 @@ jobs:
     - name: Install dependencies
       run: bundle install
 
-    - name: Get recent configs and decode fixture_wallets.json.gpg
-      run: |
-        rake fixture_wallets_decode
-        rake get_latest_configs[$NETWORK]
-        rake get_latest_bins
+    - name: ⚙️ Setup (get configs and decode fixtures)
+      run: TESTS_E2E_BINDIR='' rake setup[$NETWORK]
 
-    - name: Get Date/Time
+    - name: 🕒 Get Date/Time
       id: date-time
       shell: bash
       run: |
         echo "::set-output name=value::$(rake datetime)"
 
-    - name: Cache node db
+    - name: 💾 Cache node db
       id: cache
       uses: actions/cache@v2.1.4
       with:
@@ -72,25 +69,25 @@ jobs:
         restore-keys: |
           node-db-docker-${{ env.NETWORK }}-
 
-    - name: Set up cardano-wallet and cardano-node
+    - name: 🚀 Start node and wallet
       run: |
         echo "Wallet: $WALLET"
         echo "Node: ${{steps.cardano-node-tag.outputs.NODE_TAG}}"
         NODE=${{steps.cardano-node-tag.outputs.NODE_TAG}} NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK docker-compose -f docker-compose-test.yml up --detach
         ls ~/node-db-nightly-docker
 
-    - name: Display versions
+    - name: 🔍 Display versions
       run: |
         docker run --rm inputoutput/cardano-wallet:$WALLET version
         docker run --rm inputoutput/cardano-node:${{steps.cardano-node-tag.outputs.NODE_TAG}} cli version
 
-    - name: Wait until node is synced
+    - name: ⏳ Wait until node is synced
       run: rake wait_until_node_synced
 
-    - name: Run all tests
+    - name: 🧪 Run all tests
       run: rake spec
 
-    - name: Get docker logs
+    - name: 📖 Get docker logs
       if: always()
       run: rake get_docker_logs
 

--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -30,12 +30,20 @@ jobs:
     - name: Install dependencies
       run: bundle install
 
+    - name: Get Date/Time
+      id: date-time
+      shell: bash
+      run: |
+        echo "::set-output name=value::$(rake datetime)"
+
     - name: Cache node db
       id: cache
       uses: actions/cache@v2.1.4
       with:
         path: test/e2e/state/node_db/${{ env.NETWORK }}
-        key: ${{ runner.os }}-node-cache-v2-${{ env.NETWORK }}
+        key: node-db-${{ runner.os }}-${{ env.NETWORK }}-${{ steps.date-time.outputs.value }}
+        restore-keys: |
+          node-db-${{ runner.os }}-${{ env.NETWORK }}-
 
     - name: Run all tests
       run: rake run_on[$NETWORK]

--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -30,13 +30,13 @@ jobs:
     - name: Install dependencies
       run: bundle install
 
-    - name: Get Date/Time
+    - name: 🕒 Get Date/Time
       id: date-time
       shell: bash
       run: |
         echo "::set-output name=value::$(rake datetime)"
 
-    - name: Cache node db
+    - name: 💾 Cache node db
       id: cache
       uses: actions/cache@v2.1.4
       with:
@@ -45,8 +45,23 @@ jobs:
         restore-keys: |
           node-db-${{ runner.os }}-${{ env.NETWORK }}-
 
-    - name: Run all tests
-      run: rake run_on[$NETWORK]
+    - name: ⚙️ Setup (get latest bins and configs and decode fixtures)
+      run: rake setup[$NETWORK]
+
+    - name: 🔍 Display versions
+      run: rake display_versions
+
+    - name: 🚀 Start node and wallet
+      run: rake start_node_and_wallet[$NETWORK]
+
+    - name: ⏳ Wait until node is synced
+      run: rake wait_until_node_synced
+
+    - name: 🧪 Run all tests
+      run: rake spec
+
+    - name: 🏁 Stop node and wallet
+      run: rake stop_node_and_wallet[$NETWORK]
 
     - name: 📎 Upload logs
       uses: actions/upload-artifact@v2

--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -33,13 +33,13 @@ jobs:
     - name: Prepare MacOS
       run: brew install screen
 
-    - name: Get Date/Time
+    - name: 🕒 Get Date/Time
       id: date-time
       shell: bash
       run: |
         echo "::set-output name=value::$(rake datetime)"
 
-    - name: Cache node db
+    - name: 💾 Cache node db
       id: cache
       uses: actions/cache@v2.1.4
       with:
@@ -48,8 +48,23 @@ jobs:
         restore-keys: |
           node-db-${{ runner.os }}-${{ env.NETWORK }}-
 
-    - name: Run all tests
-      run: rake run_on[$NETWORK]
+    - name: ⚙️ Setup (get latest bins and configs and decode fixtures)
+      run: rake setup[$NETWORK]
+
+    - name: 🔍 Display versions
+      run: rake display_versions
+
+    - name: 🚀 Start node and wallet
+      run: rake start_node_and_wallet[$NETWORK]
+
+    - name: ⏳ Wait until node is synced
+      run: rake wait_until_node_synced
+
+    - name: 🧪 Run all tests
+      run: rake spec
+
+    - name: 🏁 Stop node and wallet
+      run: rake stop_node_and_wallet[$NETWORK]
 
     - name: 📎 Upload logs
       uses: actions/upload-artifact@v2

--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -47,6 +47,7 @@ jobs:
         key: node-db-${{ runner.os }}-${{ env.NETWORK }}-${{ steps.date-time.outputs.value }}
         restore-keys: |
           node-db-${{ runner.os }}-${{ env.NETWORK }}-
+          node-db-Linux-${{ env.NETWORK }}-
 
     - name: ⚙️ Setup (get latest bins and configs and decode fixtures)
       run: rake setup[$NETWORK]

--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -33,12 +33,20 @@ jobs:
     - name: Prepare MacOS
       run: brew install screen
 
+    - name: Get Date/Time
+      id: date-time
+      shell: bash
+      run: |
+        echo "::set-output name=value::$(rake datetime)"
+
     - name: Cache node db
       id: cache
       uses: actions/cache@v2.1.4
       with:
         path: test/e2e/state/node_db/${{ env.NETWORK }}
-        key: ${{ runner.os }}-node-cache-v2-${{ env.NETWORK }}
+        key: node-db-${{ runner.os }}-${{ env.NETWORK }}-${{ steps.date-time.outputs.value }}
+        restore-keys: |
+          node-db-${{ runner.os }}-${{ env.NETWORK }}-
 
     - name: Run all tests
       run: rake run_on[$NETWORK]

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -21,13 +21,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Cache node db
-      id: cache
-      uses: actions/cache@v2.1.4
-      with:
-        path: test/e2e/state/node_db/${{ env.NETWORK }}
-        key: ${{ runner.os }}-node-cache-v2-${{ env.NETWORK }}
-
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -43,6 +36,21 @@ jobs:
         choco install unzip
         choco install nssm
 
+    - name: Get Date/Time
+      id: date-time
+      shell: bash
+      run: |
+        echo "::set-output name=value::$(rake datetime)"
+
+    - name: Cache node db
+      id: cache
+      uses: actions/cache@v2.1.4
+      with:
+        path: test/e2e/state/node_db/${{ env.NETWORK }}
+        key: node-db-${{ runner.os }}-${{ env.NETWORK }}-${{ steps.date-time.outputs.value }}
+        restore-keys: |
+          node-db-${{ runner.os }}-${{ env.NETWORK }}-
+            
     - name: Run all tests
       run: rake run_on[%NETWORK%]
 

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -36,13 +36,13 @@ jobs:
         choco install unzip
         choco install nssm
 
-    - name: Get Date/Time
+    - name: 🕒 Get Date/Time
       id: date-time
       shell: bash
       run: |
         echo "::set-output name=value::$(rake datetime)"
 
-    - name: Cache node db
+    - name: 💾 Cache node db
       id: cache
       uses: actions/cache@v2.1.4
       with:
@@ -50,9 +50,24 @@ jobs:
         key: node-db-${{ runner.os }}-${{ env.NETWORK }}-${{ steps.date-time.outputs.value }}
         restore-keys: |
           node-db-${{ runner.os }}-${{ env.NETWORK }}-
-            
-    - name: Run all tests
-      run: rake run_on[%NETWORK%]
+
+    - name: ⚙️ Setup (get latest bins and configs and decode fixtures)
+      run: rake setup[%NETWORK%]
+
+    - name: 🔍 Display versions
+      run: rake display_versions
+      
+    - name: 🚀 Start node and wallet
+      run: rake start_node_and_wallet[%NETWORK%]
+
+    - name: ⏳ Wait until node is synced
+      run: rake wait_until_node_synced
+
+    - name: 🧪 Run all tests
+      run: rake spec
+
+    - name: 🏁 Stop node and wallet
+      run: rake stop_node_and_wallet[%NETWORK%]
 
     - name: 📎 Upload logs
       uses: actions/upload-artifact@v2

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -50,13 +50,14 @@ jobs:
         key: node-db-${{ runner.os }}-${{ env.NETWORK }}-${{ steps.date-time.outputs.value }}
         restore-keys: |
           node-db-${{ runner.os }}-${{ env.NETWORK }}-
-
+          node-db-Linux-${{ env.NETWORK }}-
+            
     - name: ⚙️ Setup (get latest bins and configs and decode fixtures)
       run: rake setup[%NETWORK%]
 
     - name: 🔍 Display versions
       run: rake display_versions
-      
+
     - name: 🚀 Start node and wallet
       run: rake start_node_and_wallet[%NETWORK%]
 

--- a/test/e2e/.rake_tasks~
+++ b/test/e2e/.rake_tasks~
@@ -1,14 +1,16 @@
 clean_bins
 clean_logs
+datetime
+display_versions
 fixture_wallets_decode
 fixture_wallets_encode
 fixture_wallets_template
 get_docker_logs
 get_latest_bins
 get_latest_configs
-launch_on
 run_on
 spec
+setup
 start_node_and_wallet
 stop_node_and_wallet
 wait_until_node_synced

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -3,6 +3,7 @@
 
 
 
+
 # E2E testing
 [![E2E Docker](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-docker.yml/badge.svg)](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-docker.yml) [![E2E Linux](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-linux.yml/badge.svg)](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-linux.yml) [![E2E MacOS](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-macos.yml/badge.svg)](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-macos.yml) [![E2E Windows](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-windows.yml/badge.svg)](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-windows.yml)
 
@@ -61,8 +62,9 @@ One can also start tests against cardano-wallet docker. There is docker-compose-
 >NETWORK=testnet \
 >TESTS_E2E_TOKEN_METADATA=https://metadata.cardano-testnet.iohkdev.io/ \
 >WALLET=dev-master \
->NODE=1.26.2 \
+>NODE=1.30.1 \
 >NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK \
+>DATA=`pwd`/state/node_db/$NETWORK
 >docker-compose -f docker-compose-test.yml up
 >```
 > Then running tests against docker is just:

--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -292,5 +292,5 @@ end
 # $ rake datetime
 # 20211122-94332
 task :datetime do
-  puts Time.now.strftime('%Y%m%d-%-k%M%S')
+  puts Time.now.strftime('%Y%m%d-%H%M%S')
 end

--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -78,7 +78,7 @@ task :clean_logs, [:env] do |task, args|
 end
 
 task :clean_bins do
-  puts "\n  >> Removing bins"
+  puts "\n  >> Removing old bins"
   rm_files(BINS)
 end
 
@@ -94,7 +94,7 @@ task :wait_until_node_synced do
   begin
     current_time = Time.now
     while network.information["sync_progress"]["status"] == "syncing" do
-      puts "Syncing... #{network.information["sync_progress"]["progress"]["quantity"]}%"
+      puts "Syncing node... #{network.information["sync_progress"]["progress"]["quantity"]}%"
       sleep 15
     end
   rescue
@@ -155,23 +155,21 @@ task :start_node_and_wallet, [:env] do |task, args|
 
     cmd "screen -dmS NODE_#{args[:env]} -L -Logfile #{log_dir}/node.log #{start_node}"
     cmd "screen -dmS WALLET_#{args[:env]} -L -Logfile #{log_dir}/wallet.log #{start_wallet}"
-    cmd "screen -ls"
+    cmd "screen -ls", true
   end
 end
 
-##
-# Utility task for getting binaries, configs and starting wallet and node
-task :launch_on, [:env] do |task, args|
-  env = args[:env]
+task :display_versions do
+  puts "\n  >> cardano-node and cardano-wallet versions:"
 
-  if BINS == ''
-    puts "\n  >> Skipping getting latest binaries. Will launch wallet and node from $PATH."
+  bin_dir = BINS == '' ? BINS : "#{BINS}/"
+  if is_win?
+    cmd "#{bin_dir}cardano-wallet.exe version", true
+    cmd "#{bin_dir}cardano-node.exe version", true
   else
-    Rake::Task[:get_latest_bins].invoke
+    cmd "#{bin_dir}cardano-wallet version", true
+    cmd "#{bin_dir}cardano-node version", true
   end
-
-  Rake::Task[:get_latest_configs].invoke(env)
-  Rake::Task[:start_node_and_wallet].invoke(env)
 end
 
 task :stop_node_and_wallet, [:env] do |task, args|
@@ -252,20 +250,31 @@ task :get_docker_logs do
   cmd "sudo chmod a+rw #{LOGS}/wallet.log"
 end
 
-task :run_on, [:env, :sync_strategy, :skip_configs] do |task, args|
-  puts "\n>> Setting up env and running tests..."
-  puts "TESTS_E2E_STATEDIR=#{STATE}"
+##
+# Setup utility task getting node and wallet binaries, configs and decoding fixtures
+# so it is ready to start
+task :setup, [:env, :skip_configs] do |task, args|
+  puts "\n  >> Getting latest binaries and configs and decoding fixtures..."
   env = args[:env]
-  sync_strategy = args[:sync_strategy] || :sync
-
+  skip_configs = args[:skip_configs]
   if BINS == ''
     puts "\n  >> Skipping getting latest binaries. Will test wallet and node from $PATH."
   else
     Rake::Task[:get_latest_bins].invoke
   end
-
+  Rake::Task[:get_latest_configs].invoke(env) unless skip_configs
   Rake::Task[:fixture_wallets_decode].invoke
-  Rake::Task[:get_latest_configs].invoke(env) unless args[:skip_configs]
+end
+
+task :run_on, [:env, :sync_strategy, :skip_configs] do |task, args|
+  puts "\n>> Setting up env and running tests..."
+  puts "TESTS_E2E_STATEDIR=#{STATE}"
+  env = args[:env]
+  skip_configs = args[:skip_configs]
+  sync_strategy = args[:sync_strategy] || :sync
+
+  Rake::Task[:setup].invoke(env, skip_configs)
+  Rake::Task[:display_versions].invoke
   Rake::Task[:start_node_and_wallet].invoke(env)
 
   if sync_strategy == "no-sync"

--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -277,3 +277,11 @@ task :run_on, [:env, :sync_strategy, :skip_configs] do |task, args|
   Rake::Task[:spec].invoke
   Rake::Task[:stop_node_and_wallet].invoke(env)
 end
+
+##
+# print datetime in format that's consistent across different OS
+# $ rake datetime
+# 20211122-94332
+task :datetime do
+  puts Time.now.strftime('%Y%m%d-%-k%M%S')
+end

--- a/test/e2e/docker-compose-test.yml
+++ b/test/e2e/docker-compose-test.yml
@@ -5,7 +5,7 @@ services:
     container_name: cardano-node
     image: inputoutput/cardano-node:${NODE}
     volumes:
-      - ~/node-db-nightly-docker:/data
+      - ${DATA}:/data
       - node-ipc:/ipc
       - ${NODE_CONFIG_PATH}:/config
     command: run --socket-path /ipc/node.socket --config /config/configuration.json --topology /config/topology.json --database-path /data

--- a/test/e2e/docker_compose
+++ b/test/e2e/docker_compose
@@ -3,4 +3,5 @@ TESTS_E2E_TOKEN_METADATA=https://metadata.cardano-testnet.iohkdev.io/ \
 WALLET=dev-master \
 NODE=1.28.0 \
 NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK \
+DATA=`pwd`/state/node_db/$NETWORK
 docker-compose -f docker-compose-test.yml $1

--- a/test/e2e/helpers/utils.rb
+++ b/test/e2e/helpers/utils.rb
@@ -4,9 +4,10 @@ require 'fileutils'
 
 module Helpers
   module Utils
-    def cmd(cmd)
+    def cmd(cmd, display_result = false)
       cmd.gsub(/\s+/, ' ')
       res = `#{cmd}`
+      puts res if display_result
       res
     end
 


### PR DESCRIPTION
- 5cccf82387fbac4e3cdae831d51a667dd086471f
  Attempt to fix node db caching
  
- 53566437298ceb0126464ede4b8b27f4276e1617
  More granular steps in e2e workflows
  
- 087f7a504da50887f88370745a112b5a18e73cf5
  Use Linux workflow cache if other not available
  
- 0d752a0938cf3136b6d0c9d1eed2d2a4e53a2a13
  Docker workflow adjustments
  
- e2b2ef59a14496381336851825a81ac11aa7e944
  update README

### Comments

Improvements made here and in #3027 bring significant improvements in speed and reliability of e2e tests. Tests on MacOS and Linux used to take 2-3h overall and on Windows even up to 6h (which often led to exceeding GH actions timeout). This was mainly due to incorrect use of node db caching which caused a lot of time spend of syncing node db against testnet. Improved execution times are as follows:

|  Linux|MacOS|Windows|Docker|
|--|--|--|--|
|[1h](https://github.com/input-output-hk/cardano-wallet/actions/runs/1490250065)|[1h 6m](https://github.com/input-output-hk/cardano-wallet/actions/runs/1490370180)|[1h 31m](https://github.com/input-output-hk/cardano-wallet/actions/runs/1490442118)|[1h](https://github.com/input-output-hk/cardano-wallet/actions/runs/1493877513)|

Due to node db caching, which is happening properly now on every run, node db syncing time is cut from few hours to few minutes :tada:. Majority of the remaining test suite time is still spend on syncing fixture wallets, but it is good test on it's own so there seems to be no need for further improvements. Execution times seem to be satisfactory for nightly e2e tests and also in the need for an ad-hoc e2e run. 

### Issue Number

ADP-1196
