### PR TITLE
Fix mint-burn assets decode assertion

### DIFF
--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -128,7 +128,8 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       burn_script = "mintBurn_2.json"
       assets = [{"asset_name" => "6d696e742d6275726e",
                  "quantity" => 1,
-                 "policy_id" => "c22560ac64be051102d6d1cfe5b9b82eb6af4f00dd3806e5cd82e837"}]
+                 "policy_id" => policy_id}]
+                 
       payload_mint = get_templated_plutus_tx(mint_script,{vkHash: vkHash,
                                                           policyId: policy_id,
                                                           policy: policy})


### PR DESCRIPTION

- [x] I have fixed mint-burn assets decode assertion introduced in https://github.com/input-output-hk/cardano-wallet/pull/3029. 

### Comments
Policy id of minted/burned asset in this test depends on fixture wallet's pub key so it is different for each fixture wallet.

### Issue Number

ADP-1245
