### PR TITLE
Redefine `Coin` in terms of `Natural` and remove the `Bounded` instance.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -314,7 +314,13 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( SealedTx (..), TxIn (..), TxOut (..), TxStatus (..) )
+    ( SealedTx (..)
+    , TxIn (..)
+    , TxOut (..)
+    , TxStatus (..)
+    , txOutMaxCoin
+    , txOutMinCoin
+    )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( HistogramBar (..)
     , UTxO (..)
@@ -443,6 +449,7 @@ import qualified Cardano.Wallet.Primitive.AddressDerivation.Icarus as Icarus
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shared as Shared
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Shelley
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
@@ -739,8 +746,8 @@ computeApiCoinSelectionFee selection
         - balanceOfDeposits
     feeIsValid :: Bool
     feeIsValid = (&&)
-        (fee >= fromIntegral (unCoin (minBound :: Coin)))
-        (fee <= fromIntegral (unCoin (maxBound :: Coin)))
+        (fee >= Coin.toInteger txOutMinCoin)
+        (fee <= Coin.toInteger txOutMaxCoin)
     balanceOfInputs
         = selection
         & view #inputs

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -383,7 +383,7 @@ import Data.Time
 import Data.Time.Text
     ( iso8601ExtendedUtc, utcTimeToText )
 import Data.Word
-    ( Word16, Word32, Word64 )
+    ( Word16, Word32 )
 import Fmt
     ( indentF, (+|), (|+) )
 import Language.Haskell.TH.Quote
@@ -563,7 +563,7 @@ expectListSizeSatisfy cond (_, res) = liftIO $ case res of
 -- pre-calculated statistics.
 expectWalletUTxO
     :: (HasCallStack, MonadIO m)
-    => [Word64]
+    => [Natural]
     -> Either RequestException ApiUtxoStatistics
     -> m ()
 expectWalletUTxO coins = \case

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -74,7 +74,9 @@ import Data.Quantity
 import Data.Text
     ( Text )
 import Data.Word
-    ( Word32, Word64 )
+    ( Word32 )
+import Numeric.Natural
+    ( Natural )
 import Test.Hspec
     ( SpecWith, describe )
 import Test.Hspec.Expectations.Lifted
@@ -964,7 +966,9 @@ spec = describe "SHELLEY_WALLETS" $ do
         --send funds
         addrs <- listAddresses @n ctx wDest
         let destination = (addrs !! 1) ^. #id
-        let coins = [13_000_000::Word64, 43_000_000, 66_000_000, 101_000_000, 1339_000_000]
+        let coins :: [Natural]
+            coins =
+                [13_000_000, 43_000_000, 66_000_000, 101_000_000, 1339_000_000]
         let payments = flip map coins $ \c -> [json|{
                 "address": #{destination},
                 "amount": {

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -53,7 +53,9 @@ import Data.Quantity
 import Data.Text
     ( Text )
 import Data.Word
-    ( Word32, Word64 )
+    ( Word32 )
+import Numeric.Natural
+    ( Natural )
 import System.Command
     ( Exit (..), Stderr (..), Stdout (..) )
 import System.Exit
@@ -735,7 +737,9 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
         wDest <- emptyWallet ctx
 
         --send transactions to the wallet
-        let coins = [13_000_000, 43_000_000, 66_000_000, 101_000_000, 1339_000_000] :: [Word64]
+        let coins :: [Natural]
+            coins =
+                [13_000_000, 43_000_000, 66_000_000, 101_000_000, 1339_000_000]
         addrs:_ <- listAddresses @n ctx wDest
         let addr = encodeAddress @n (getApiT $ fst $ addrs ^. #id)
 

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -332,6 +332,7 @@ test-suite unit
     , http-client-tls
     , http-media
     , http-types
+    , int-cast
     , iohk-monitoring
     , io-classes
     , io-sim

--- a/lib/core/src/Cardano/Byron/Codec/Cbor.hs
+++ b/lib/core/src/Cardano/Byron/Codec/Cbor.hs
@@ -51,12 +51,10 @@ import Cardano.Wallet.Primitive.Types
     ( ProtocolMagic (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
-import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn (..), TxOut (..) )
+    ( TxIn (..), TxOut (..), unsafeCoinToTxOutCoinValue )
 import Control.Monad
     ( replicateM, when )
 import Crypto.Error
@@ -74,6 +72,7 @@ import Data.Either.Extra
 import Data.Word
     ( Word8 )
 
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Encoding as CBOR
@@ -270,7 +269,7 @@ decodeTxOut :: CBOR.Decoder s TxOut
 decodeTxOut = do
     _ <- CBOR.decodeListLenCanonicalOf 2
     addr <- decodeAddress
-    TxOut addr . TokenBundle.fromCoin . Coin <$> CBOR.decodeWord64
+    TxOut addr . TokenBundle.fromCoin . Coin.fromWord64 <$> CBOR.decodeWord64
 
 -- * Encoding
 
@@ -399,7 +398,7 @@ encodeTxOut :: TxOut -> CBOR.Encoding
 encodeTxOut (TxOut (Address addr) tb) = mempty
     <> CBOR.encodeListLen 2
     <> encodeAddressPayload payload
-    <> CBOR.encodeWord64 (unCoin $ TokenBundle.getCoin tb)
+    <> CBOR.encodeWord64 (unsafeCoinToTxOutCoinValue $ TokenBundle.getCoin tb)
   where
     invariant =
         error $ "encodeTxOut: unable to decode address payload: " <> show addr

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -142,7 +142,7 @@ import UnliftIO.Exception
 
 import qualified Cardano.Pool.DB.Sqlite.TH as TH
 import qualified Cardano.Wallet.Primitive.Types as W
-import qualified Cardano.Wallet.Primitive.Types.Coin as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Database.Sqlite as Sqlite
@@ -304,8 +304,8 @@ newDBLayer tr ti SqliteContext{runQuery} =
                         $ getPercentage $ poolMargin cert)
                     (fromIntegral $ denominator
                         $ getPercentage $ poolMargin cert)
-                    (W.unCoin $ poolCost cert)
-                    (W.unCoin $ poolPledge cert)
+                    (Coin.unsafeToWord64 $ poolCost cert)
+                    (Coin.unsafeToWord64 $ poolPledge cert)
                     (fst <$> poolMetadata cert)
                     (snd <$> poolMetadata cert)
             _ <- repsert poolRegistrationKey poolRegistrationRow
@@ -455,8 +455,8 @@ newDBLayer tr ti SqliteContext{runQuery} =
                     <$> fromPersistValue fieldPoolId
                     <*> fromPersistValue fieldOwners
                     <*> parseMargin
-                    <*> (W.Coin <$> fromPersistValue fieldCost)
-                    <*> (W.Coin <$> fromPersistValue fieldPledge)
+                    <*> (Coin.fromWord64 <$> fromPersistValue fieldCost)
+                    <*> (Coin.fromWord64 <$> fromPersistValue fieldPledge)
                     <*> parseMetadata
 
                 parseRetirementCertificate = do
@@ -597,8 +597,8 @@ newDBLayer tr ti SqliteContext{runQuery} =
                         poolMetadataHash = entityVal meta
                 let poolMargin = unsafeMkPercentage $
                         toRational $ marginNum % marginDen
-                let poolCost = W.Coin poolCost_
-                let poolPledge = W.Coin poolPledge_
+                let poolCost = Coin.fromWord64 poolCost_
+                let poolPledge = Coin.fromWord64 poolPledge_
                 let poolMetadata = (,) <$> poolMetadataUrl <*> poolMetadataHash
                 poolOwners <- fmap (poolOwnerOwner . entityVal) <$>
                     selectList

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -373,7 +373,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), addCoin, coinToInteger, sumCoins )
+    ( Coin (..), addCoin, sumCoins )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Redeemer
@@ -1160,7 +1160,7 @@ readNextWithdrawal ctx (Coin withdrawal) = do
             calcMinimumCost tl pp (mkTxCtx $ Coin 0) emptySkeleton
 
     let costOfWithdrawal =
-            coinToInteger costWith - coinToInteger costWithout
+            Coin.toInteger costWith - Coin.toInteger costWithout
 
     if toInteger withdrawal < 2 * costOfWithdrawal
     then pure (Coin 0)

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -373,7 +373,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), addCoin )
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Redeemer
@@ -2069,7 +2069,7 @@ mkTxMeta ti' blockHeader wState txCtx sel =
             -- transaction is considered 'Incoming' since it brings extra money
             -- to the wallet from elsewhere).
             & case txWithdrawal txCtx of
-                w@WithdrawalSelf{} -> addCoin (withdrawalToCoin w)
+                w@WithdrawalSelf{} -> Coin.add (withdrawalToCoin w)
                 WithdrawalExternal{} -> Prelude.id
                 NoWithdrawal -> Prelude.id
     in do

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -373,7 +373,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), addCoin, sumCoins )
+    ( Coin (..), addCoin )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Redeemer
@@ -1588,7 +1588,7 @@ balanceTransaction
                     , "when balancing a transaction, but it was!"
                     ]
                 )
-                (sumCoins wdrlMap)
+                (F.fold wdrlMap)
          in (outs, wdrl, meta, toMint, toBurn)
 
     -- | Wallet coin selection is unaware of many kinds of transaction content
@@ -2055,13 +2055,13 @@ mkTxMeta
     -> IO (UTCTime, TxMeta)
 mkTxMeta ti' blockHeader wState txCtx sel =
     let
-        amtOuts = sumCoins $
+        amtOuts = F.fold $
             (txOutCoin <$> view #change sel)
             ++
             mapMaybe ourCoin (view #outputs sel)
 
         amtInps
-            = sumCoins (txOutCoin . snd <$> view #inputs sel)
+            = F.fold (txOutCoin . snd <$> view #inputs sel)
             -- NOTE: In case where rewards were pulled from an external
             -- source, they aren't added to the calculation because the
             -- money is considered to come from outside of the wallet; which

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1625,7 +1625,7 @@ balanceTransaction
 
             txFeePadding = (<> extraMargin) $ fromMaybe (Coin 0) $ do
                 betterEstimate <- evaluateMinimumFee tl nodePParams sealedTx
-                betterEstimate `Coin.subtractCoin` worseEstimate
+                betterEstimate `Coin.subtract` worseEstimate
         in
             txCtx { txFeePadding }
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -420,7 +420,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), coinQuantity )
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Redeemer
@@ -596,6 +596,7 @@ import qualified Cardano.Wallet.Primitive.AddressDerivation.Icarus as Icarus
 import qualified Cardano.Wallet.Primitive.CoinSelection.Balance as Balance
 import qualified Cardano.Wallet.Primitive.CoinSelection.Collateral as Collateral
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
@@ -3241,8 +3242,8 @@ mkApiFee :: Maybe Coin -> [Coin] -> FeeEstimation -> ApiFee
 mkApiFee mDeposit minCoins (FeeEstimation estMin estMax) = ApiFee
     { estimatedMin = qty estMin
     , estimatedMax = qty estMax
-    , minimumCoins = coinQuantity <$> minCoins
-    , deposit = coinQuantity $ fromMaybe (Coin 0) mDeposit
+    , minimumCoins = Coin.unsafeToQuantity <$> minCoins
+    , deposit = Coin.unsafeToQuantity $ fromMaybe (Coin 0) mDeposit
     }
   where
     qty = Quantity . fromIntegral

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -3831,7 +3831,7 @@ instance IsServerError ErrCannotQuit where
                 , "although you're not even delegating, nor won't be in an "
                 , "immediate future."
                 ]
-        ErrNonNullRewards (Coin rewards) ->
+        ErrNonNullRewards rewards ->
             apiError err403 NonNullRewards $ mconcat
                 [ "It seems that you're trying to retire from delegation "
                 , "although you've unspoiled rewards in your rewards "

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -3242,8 +3242,8 @@ mkApiFee :: Maybe Coin -> [Coin] -> FeeEstimation -> ApiFee
 mkApiFee mDeposit minCoins (FeeEstimation estMin estMax) = ApiFee
     { estimatedMin = qty estMin
     , estimatedMax = qty estMax
-    , minimumCoins = Coin.unsafeToQuantity <$> minCoins
-    , deposit = Coin.unsafeToQuantity $ fromMaybe (Coin 0) mDeposit
+    , minimumCoins = Quantity . Coin.toNatural <$> minCoins
+    , deposit = Quantity . Coin.toNatural $ fromMaybe (Coin 0) mDeposit
     }
   where
     qty = Quantity . fromIntegral

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -313,7 +313,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), isValidCoin )
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -325,6 +325,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxMetadata
     , TxScriptValidity (..)
     , TxStatus (..)
+    , coinIsValidForTxOut
     , sealedTxFromBytes
     , txMetadataIsNull
     )
@@ -2939,7 +2940,7 @@ instance FromJSON a => FromJSON (AddressAmount a) where
             <*> v .:? "assets" .!= mempty
       where
         validateCoin q
-            | isValidCoin (coinFromQuantity q) = pure q
+            | coinIsValidForTxOut (coinFromQuantity q) = pure q
             | otherwise = fail $
                 "invalid coin value: value has to be lower than or equal to "
                 <> show (unCoin maxBound) <> " lovelace."
@@ -2961,7 +2962,7 @@ instance FromJSON (ApiT W.TokenBundle) where
       where
         validateCoin :: Quantity "lovelace" Word64 -> Aeson.Parser Coin
         validateCoin (coinFromQuantity -> c)
-            | isValidCoin c = pure c
+            | coinIsValidForTxOut c = pure c
             | otherwise = fail $
                 "invalid coin value: value has to be lower than or equal to "
                 <> show (unCoin maxBound) <> " lovelace."

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -328,6 +328,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , coinIsValidForTxOut
     , sealedTxFromBytes
     , txMetadataIsNull
+    , txOutMaxCoin
     )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( BoundType, HistogramBar (..), UTxOStatistics (..) )
@@ -2943,7 +2944,7 @@ instance FromJSON a => FromJSON (AddressAmount a) where
             | coinIsValidForTxOut (coinFromQuantity q) = pure q
             | otherwise = fail $
                 "invalid coin value: value has to be lower than or equal to "
-                <> show (unCoin maxBound) <> " lovelace."
+                <> show (unCoin txOutMaxCoin) <> " lovelace."
 
 instance ToJSON (ApiT W.TokenBundle) where
     -- TODO: consider other structures
@@ -2965,7 +2966,7 @@ instance FromJSON (ApiT W.TokenBundle) where
             | coinIsValidForTxOut c = pure c
             | otherwise = fail $
                 "invalid coin value: value has to be lower than or equal to "
-                <> show (unCoin maxBound) <> " lovelace."
+                <> show (unCoin txOutMaxCoin) <> " lovelace."
 
 instance ToJSON a => ToJSON (AddressAmount a) where
     toJSON = genericToJSON defaultRecordTypeOptions

--- a/lib/core/src/Cardano/Wallet/DB/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Model.hs
@@ -225,7 +225,7 @@ mInitializeWallet wid cp meta txs0 gp db@Database{wallets,txs}
                 , txHistory = history
                 , xprv = Nothing
                 , genesisParameters = gp
-                , rewardAccountBalance = minBound
+                , rewardAccountBalance = Coin 0
                 , submittedTxs = mempty
                 }
             txs' = Map.fromList $ (\(tx, _) -> (view #txId tx, tx)) <$> txs0
@@ -517,7 +517,7 @@ mPutDelegationRewardBalance wid amt = alterModel wid $ \wal ->
 mReadDelegationRewardBalance
     :: Ord wid => wid -> ModelOp wid s xprv Coin
 mReadDelegationRewardBalance wid db@(Database wallets _) =
-    (Right (maybe minBound rewardAccountBalance $ Map.lookup wid wallets), db)
+    (Right (maybe (Coin 0) rewardAccountBalance $ Map.lookup wid wallets), db)
 
 mPutLocalTxSubmission :: Ord wid => wid -> Hash "Tx" -> SealedTx -> SlotNo -> ModelOp wid s xprv ()
 mPutLocalTxSubmission wid tid tx sl = alterModelErr wid $ \wal ->

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -263,6 +263,7 @@ import qualified Cardano.Wallet.Primitive.AddressDiscovery.Shared as Shared
 import qualified Cardano.Wallet.Primitive.Model as W
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
@@ -1607,16 +1608,16 @@ newDBLayerWith cacheBehavior tr ti SqliteContext{runQuery} = do
         -----------------------------------------------------------------------}
 
         , putDelegationRewardBalance =
-            \wid (W.Coin amt) -> ExceptT $ do
+            \wid amt -> ExceptT $ do
             selectWallet wid >>= \case
                 Nothing -> pure $ Left $ ErrNoSuchWallet wid
                 Just _  -> Right <$> repsert
                     (DelegationRewardKey wid)
-                    (DelegationReward wid amt)
+                    (DelegationReward wid (Coin.unsafeToWord64 amt))
 
         , readDelegationRewardBalance =
             \wid ->
-                W.Coin . maybe 0 (rewardAccountBalance . entityVal) <$>
+                Coin.fromWord64 . maybe 0 (rewardAccountBalance . entityVal) <$>
                 selectFirst [RewardWalletId ==. wid] []
 
         {-----------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -62,7 +62,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), isValidCoin )
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
@@ -138,6 +138,7 @@ import Web.HttpApiData
 import Web.PathPieces
     ( PathPiece (..) )
 
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
@@ -462,15 +463,9 @@ instance PersistFieldSql SealedTx where
 ----------------------------------------------------------------------------
 -- Coin
 
-mkCoin :: Word64 -> Either Text Coin
-mkCoin n
-    | isValidCoin c = Right c
-    | otherwise = Left . T.pack $ "not a valid coin: " <> show n
-    where c = Coin n
-
 instance PersistField Coin where
-    toPersistValue = toPersistValue . unCoin
-    fromPersistValue = fromPersistValue >=> mkCoin
+    toPersistValue = toPersistValue . Coin.unsafeToWord64
+    fromPersistValue = fmap Coin.fromWord64 . fromPersistValue
 
 instance PersistFieldSql Coin where
     sqlType _ = sqlType (Proxy @Word64)

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -140,6 +140,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TokenBundleSizeAssessor (..)
     , TxIn
     , TxOut (..)
+    , txOutMaxCoin
     , txOutMaxTokenQuantity
     )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
@@ -1454,7 +1455,7 @@ makeChange criteria
             assessBundleSizeWithMaxCoin :: TokenBundleSizeAssessor
             assessBundleSizeWithMaxCoin = TokenBundleSizeAssessor
                 $ view #assessTokenBundleSize bundleSizeAssessor
-                . flip TokenBundle.setCoin (maxBound @Coin)
+                . flip TokenBundle.setCoin txOutMaxCoin
 
     -- Change for user-specified assets: assets that were present in the
     -- original set of user-specified outputs ('outputsToCover').

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -785,7 +785,7 @@ performSelectionEmpty performSelectionFn constraints params =
         -> SelectionParamsOf (NonEmpty TxOut)
     transformParams
         = over #extraCoinSource
-            (transform (`Coin.addCoin` minCoin) (const id))
+            (transform (`Coin.add` minCoin) (const id))
         . over #outputsToCover
             (transform (const (dummyOutput :| [])) (const . id))
 

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -1367,7 +1367,7 @@ makeChange criteria
         first mkUnableToConstructChangeError $ do
             adaAvailable <- maybeToEither
                 (requiredCost `Coin.difference` excessCoin)
-                (excessCoin `Coin.subtractCoin` requiredCost)
+                (excessCoin `Coin.subtract` requiredCost)
             assignCoinsToChangeMaps
                 adaAvailable minCoinFor changeMapOutputCoinPairs
   where

--- a/lib/core/src/Cardano/Wallet/Primitive/Migration/Selection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Migration/Selection.hs
@@ -65,6 +65,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxConstraints (..)
     , TxSize
+    , txOutMaxCoin
     , txOutputCoinCost
     , txOutputHasValidSize
     , txOutputHasValidTokenQuantities
@@ -417,7 +418,7 @@ splitOutputIfTokenQuantityExceedsLimit
 --
 txOutputHasValidSizeIfAdaMaximized :: TxConstraints -> TokenMap -> Bool
 txOutputHasValidSizeIfAdaMaximized constraints output =
-    txOutputHasValidSize constraints (TokenBundle maxBound output)
+    txOutputHasValidSize constraints (TokenBundle txOutMaxCoin output)
 
 --------------------------------------------------------------------------------
 -- Minimizing fees

--- a/lib/core/src/Cardano/Wallet/Primitive/Migration/Selection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Migration/Selection.hs
@@ -248,7 +248,7 @@ balance constraints unbalancedSelection = do
     let minimumFeeForUnbalancedSelection =
             computeMinimumFee constraints unbalancedSelection
     unbalancedFeeExcess <- maybeToEither SelectionAdaInsufficient $
-            Coin.subtractCoin unbalancedFee minimumFeeForUnbalancedSelection
+        Coin.subtract unbalancedFee minimumFeeForUnbalancedSelection
     let (minimizedFeeExcess, maximizedOutputs) = minimizeFee constraints
             (unbalancedFeeExcess, minimizedOutputs)
     let costIncrease = Coin.distance

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -67,7 +67,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), distance, sumCoins )
+    ( Coin (..), distance )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -531,7 +531,7 @@ prefilterBlock b u0 = runState $ do
 
                 (Nothing, Outgoing) -> -- Byron
                     let
-                        totalOut = sumCoins (txOutCoin <$> outputs tx)
+                        totalOut = F.fold (txOutCoin <$> outputs tx)
 
                         totalIn = TB.getCoin spent
                     in

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -82,12 +82,17 @@ import qualified Prelude
 --
 -- Reminder: 1 ada = 1,000,000 lovelace.
 --
+-- The 'Coin' type has 'Semigroup' and 'Monoid' instances that correspond
+-- to ordinary addition and summation.
+--
 newtype Coin = Coin
     { unCoin :: Natural
     }
     deriving stock (Ord, Eq, Generic)
     deriving (Read, Show) via (Quiet Coin)
 
+-- | The 'Semigroup' instance for 'Coin' corresponds to ordinary addition.
+--
 instance Semigroup Coin where
     -- Natural doesn't have a default Semigroup instance.
     (<>) = add

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -98,7 +98,7 @@ newtype Coin = Coin
     deriving (Read, Show) via (Quiet Coin)
 
 instance Semigroup Coin where
-    -- Word64 doesn't have a default Semigroup instance.
+    -- Natural doesn't have a default Semigroup instance.
     Coin a <> Coin b = Coin (a + b)
 
 instance Monoid Coin where

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE ExplicitForAll #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- |
@@ -104,10 +103,6 @@ instance FromText Coin where
 
 instance NFData Coin
 instance Hashable Coin
-
-instance Bounded Coin where
-    minBound = Coin 0
-    maxBound = Coin 45_000_000_000_000_000
 
 instance Buildable Coin where
     build (Coin c) = fixedF @Double 6 (Prelude.fromIntegral c / 1e6)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -30,7 +30,7 @@ module Cardano.Wallet.Primitive.Types.Coin
 
       -- * Arithmetic operations
     , add
-    , subtractCoin
+    , subtract
     , difference
     , distance
 
@@ -42,7 +42,7 @@ module Cardano.Wallet.Primitive.Types.Coin
     ) where
 
 import Prelude hiding
-    ( fromIntegral, toInteger )
+    ( fromIntegral, subtract, toInteger )
 
 import Cardano.Numeric.Util
     ( equipartitionNatural, partitionNatural )
@@ -214,16 +214,16 @@ unsafeToWord64 c = fromMaybe onError (toWord64 c)
         , "does not fit within the bounds of a 64-bit word."
         ]
 
-{-------------------------------------------------------------------------------
-                                   Operations
--------------------------------------------------------------------------------}
+--------------------------------------------------------------------------------
+-- Arithmetic operations
+--------------------------------------------------------------------------------
 
 -- | Subtracts the second coin from the first.
 --
 -- Returns 'Nothing' if the second coin is strictly greater than the first.
 --
-subtractCoin :: Coin -> Coin -> Maybe Coin
-subtractCoin (Coin a) (Coin b)
+subtract :: Coin -> Coin -> Maybe Coin
+subtract (Coin a) (Coin b)
     | a >= b    = Just $ Coin (a - b)
     | otherwise = Nothing
 
@@ -237,7 +237,7 @@ add (Coin a) (Coin b) = Coin (a + b)
 -- Returns 'Coin 0' if the second coin is strictly greater than the first.
 --
 difference :: Coin -> Coin -> Coin
-difference a b = fromMaybe (Coin 0) (subtractCoin a b)
+difference a b = fromMaybe (Coin 0) (subtract a b)
 
 -- | Absolute difference between two coin amounts. The result is never negative.
 distance :: Coin -> Coin -> Coin

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -19,6 +19,7 @@ module Cardano.Wallet.Primitive.Types.Coin
     , fromIntegral
     , fromWord64
     , toInteger
+    , toNatural
     , toQuantity
     , toWord64
 
@@ -28,7 +29,6 @@ module Cardano.Wallet.Primitive.Types.Coin
     , unsafeToWord64
 
       -- * Compatibility
-    , coinToNatural
     , unsafeNaturalToCoin
 
       -- * Checks
@@ -149,6 +149,11 @@ fromWord64 = Coin . intCast
 toInteger :: Coin -> Integer
 toInteger = intCast . unCoin
 
+-- | Converts a 'Coin' to a 'Natural' value.
+--
+toNatural :: Coin -> Natural
+toNatural = unCoin
+
 -- | Converts a 'Coin' to a 'Quantity'.
 --
 -- Returns 'Nothing' if the given value does not fit within the bounds of
@@ -229,9 +234,6 @@ unsafeToWord64 c = fromMaybe onError (toWord64 c)
                                Compatibility
 -------------------------------------------------------------------------------}
 
-coinToNatural :: Coin -> Natural
-coinToNatural = unCoin
-
 unsafeNaturalToCoin :: Natural -> Coin
 unsafeNaturalToCoin = Coin
 
@@ -302,7 +304,7 @@ equipartition
 equipartition c =
     -- Note: the natural-to-coin conversion is safe, as partitioning guarantees
     -- to produce values that are less than or equal to the original value.
-    fmap unsafeNaturalToCoin . equipartitionNatural (coinToNatural c)
+    fmap unsafeNaturalToCoin . equipartitionNatural (toNatural c)
 
 -- | Partitions a coin into a number of parts, where the size of each part is
 --   proportional to the size of its corresponding element in the given list
@@ -321,8 +323,8 @@ partition c
     -- Note: the natural-to-coin conversion is safe, as partitioning guarantees
     -- to produce values that are less than or equal to the original value.
     = fmap (fmap unsafeNaturalToCoin)
-    . partitionNatural (coinToNatural c)
-    . fmap coinToNatural
+    . partitionNatural (toNatural c)
+    . fmap toNatural
 
 -- | Partitions a coin into a number of parts, where the size of each part is
 --   proportional to the size of its corresponding element in the given list

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -18,6 +18,7 @@ module Cardano.Wallet.Primitive.Types.Coin
       -- * Conversions (Safe)
     , fromIntegral
     , fromWord64
+    , toInteger
     , toQuantity
     , toWord64
 
@@ -27,7 +28,6 @@ module Cardano.Wallet.Primitive.Types.Coin
     , unsafeToWord64
 
       -- * Compatibility
-    , coinToInteger
     , coinToNatural
     , unsafeNaturalToCoin
 
@@ -49,7 +49,7 @@ module Cardano.Wallet.Primitive.Types.Coin
     ) where
 
 import Prelude hiding
-    ( fromIntegral )
+    ( fromIntegral, toInteger )
 
 import Cardano.Numeric.Util
     ( equipartitionNatural, partitionNatural )
@@ -144,6 +144,11 @@ fromIntegral i = Coin <$> intCastMaybe i
 fromWord64 :: Word64 -> Coin
 fromWord64 = Coin . intCast
 
+-- | Converts a 'Coin' to an 'Integer' value.
+--
+toInteger :: Coin -> Integer
+toInteger = intCast . unCoin
+
 -- | Converts a 'Coin' to a 'Quantity'.
 --
 -- Returns 'Nothing' if the given value does not fit within the bounds of
@@ -223,9 +228,6 @@ unsafeToWord64 c = fromMaybe onError (toWord64 c)
 {-------------------------------------------------------------------------------
                                Compatibility
 -------------------------------------------------------------------------------}
-
-coinToInteger :: Coin -> Integer
-coinToInteger = Prelude.fromIntegral . unCoin
 
 coinToNatural :: Coin -> Natural
 coinToNatural = unCoin

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -29,7 +29,7 @@ module Cardano.Wallet.Primitive.Types.Coin
     , unsafeToWord64
 
       -- * Arithmetic operations
-    , addCoin
+    , add
     , subtractCoin
     , difference
     , distance
@@ -90,7 +90,7 @@ newtype Coin = Coin
 
 instance Semigroup Coin where
     -- Natural doesn't have a default Semigroup instance.
-    Coin a <> Coin b = Coin (a + b)
+    (<>) = add
 
 instance Monoid Coin where
     mempty = Coin 0
@@ -227,15 +227,10 @@ subtractCoin (Coin a) (Coin b)
     | a >= b    = Just $ Coin (a - b)
     | otherwise = Nothing
 
--- | Calculate the combined value of two coins.
+-- | Calculates the combined value of two coins.
 --
--- NOTE: It is generally safe to add coins and stay in the same domain because
--- the max supply is known (45B), which easily fits within a 'Word64'. So for
--- the vast majority of usages of this function within cardano-wallet, it is a
--- safe operation.
---
-addCoin :: Coin -> Coin -> Coin
-addCoin (Coin a) (Coin b) = Coin (a + b)
+add :: Coin -> Coin -> Coin
+add (Coin a) (Coin b) = Coin (a + b)
 
 -- | Subtracts the second coin from the first.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -53,8 +53,6 @@ import Cardano.Numeric.Util
     ( equipartitionNatural, partitionNatural )
 import Control.DeepSeq
     ( NFData (..) )
-import Control.Monad
-    ( (<=<) )
 import Data.Bits
     ( Bits )
 import Data.Foldable
@@ -70,7 +68,7 @@ import Data.Maybe
 import Data.Quantity
     ( Quantity (..) )
 import Data.Text.Class
-    ( FromText (..), TextDecodingError (..), ToText (..) )
+    ( FromText (..), ToText (..) )
 import Data.Word
     ( Word64 )
 import Fmt
@@ -108,13 +106,7 @@ instance ToText Coin where
     toText (Coin c) = T.pack $ show c
 
 instance FromText Coin where
-    fromText = validate <=< (fmap Coin . fromText @Natural)
-      where
-        validate x
-            | isValidCoin x =
-                return x
-            | otherwise =
-                Left $ TextDecodingError "Coin value is out of bounds"
+    fromText = fmap Coin . fromText @Natural
 
 instance NFData Coin
 instance Hashable Coin

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -29,9 +29,6 @@ module Cardano.Wallet.Primitive.Types.Coin
     , unsafeToQuantity
     , unsafeToWord64
 
-      -- * Checks
-    , isValidCoin
-
       -- * Arithmetic operations
     , addCoin
     , subtractCoin
@@ -224,14 +221,6 @@ unsafeToWord64 c = fromMaybe onError (toWord64 c)
         , show c
         , "does not fit within the bounds of a 64-bit word."
         ]
-
-{-------------------------------------------------------------------------------
-                                     Checks
--------------------------------------------------------------------------------}
-
--- | Whether the coin amount is less than the total amount of Ada.
-isValidCoin :: Coin -> Bool
-isValidCoin c = c >= minBound && c <= maxBound
 
 {-------------------------------------------------------------------------------
                                    Operations

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -32,7 +32,6 @@ module Cardano.Wallet.Primitive.Types.Coin
       -- * Arithmetic operations
     , addCoin
     , subtractCoin
-    , sumCoins
     , difference
     , distance
 
@@ -52,8 +51,6 @@ import Control.DeepSeq
     ( NFData (..) )
 import Data.Bits
     ( Bits )
-import Data.Foldable
-    ( foldl' )
 import Data.Hashable
     ( Hashable )
 import Data.IntCast
@@ -244,10 +241,6 @@ subtractCoin (Coin a) (Coin b)
 --
 addCoin :: Coin -> Coin -> Coin
 addCoin (Coin a) (Coin b) = Coin (a + b)
-
--- | Add a list of coins together.
-sumCoins :: Foldable t => t Coin -> Coin
-sumCoins = foldl' addCoin (Coin 0)
 
 -- | Subtracts the second coin from the first.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -17,6 +17,7 @@ module Cardano.Wallet.Primitive.Types.Coin
 
       -- * Conversions (Safe)
     , fromIntegral
+    , fromNatural
     , fromWord64
     , toInteger
     , toNatural
@@ -27,9 +28,6 @@ module Cardano.Wallet.Primitive.Types.Coin
     , unsafeFromIntegral
     , unsafeToQuantity
     , unsafeToWord64
-
-      -- * Compatibility
-    , unsafeNaturalToCoin
 
       -- * Checks
     , isValidCoin
@@ -139,6 +137,11 @@ instance Buildable Coin where
 fromIntegral :: (Bits i, Integral i) => i -> Maybe Coin
 fromIntegral i = Coin <$> intCastMaybe i
 
+-- | Constructs a 'Coin' from a 'Natural' value.
+--
+fromNatural :: Natural -> Coin
+fromNatural = Coin
+
 -- | Constructs a 'Coin' from a 'Word64' value.
 --
 fromWord64 :: Word64 -> Coin
@@ -231,13 +234,6 @@ unsafeToWord64 c = fromMaybe onError (toWord64 c)
         ]
 
 {-------------------------------------------------------------------------------
-                               Compatibility
--------------------------------------------------------------------------------}
-
-unsafeNaturalToCoin :: Natural -> Coin
-unsafeNaturalToCoin = Coin
-
-{-------------------------------------------------------------------------------
                                      Checks
 -------------------------------------------------------------------------------}
 
@@ -302,9 +298,7 @@ equipartition
     -> NonEmpty Coin
     -- ^ The partitioned coins.
 equipartition c =
-    -- Note: the natural-to-coin conversion is safe, as partitioning guarantees
-    -- to produce values that are less than or equal to the original value.
-    fmap unsafeNaturalToCoin . equipartitionNatural (toNatural c)
+    fmap fromNatural . equipartitionNatural (toNatural c)
 
 -- | Partitions a coin into a number of parts, where the size of each part is
 --   proportional to the size of its corresponding element in the given list
@@ -320,9 +314,7 @@ partition
     -> Maybe (NonEmpty Coin)
     -- ^ The partitioned coins.
 partition c
-    -- Note: the natural-to-coin conversion is safe, as partitioning guarantees
-    -- to produce values that are less than or equal to the original value.
-    = fmap (fmap unsafeNaturalToCoin)
+    = fmap (fmap fromNatural)
     . partitionNatural (toNatural c)
     . fmap toNatural
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin/Gen.hs
@@ -1,10 +1,8 @@
 module Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoin
     , genCoinPositive
-    , genCoinFullRange
     , shrinkCoin
     , shrinkCoinPositive
-    , shrinkCoinFullRange
     ) where
 
 import Prelude
@@ -12,9 +10,9 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Test.QuickCheck
-    ( Gen, choose, frequency, sized )
+    ( Gen, choose, sized )
 import Test.QuickCheck.Extra
-    ( chooseNatural, shrinkNatural )
+    ( shrinkNatural )
 
 --------------------------------------------------------------------------------
 -- Coins chosen according to the size parameter.
@@ -35,28 +33,3 @@ genCoinPositive = sized $ \n -> Coin . fromIntegral <$> choose (1, max 1 n)
 
 shrinkCoinPositive :: Coin -> [Coin]
 shrinkCoinPositive (Coin c) = Coin <$> filter (> 0) (shrinkNatural c)
-
---------------------------------------------------------------------------------
--- Coins chosen from the full range available.
---------------------------------------------------------------------------------
-
--- | Generates coins across the full range available.
---
--- This generator has a slight bias towards the limits of the range, but
--- otherwise generates values uniformly across the whole range.
---
--- This can be useful when testing roundtrip conversions between different
--- types.
---
-genCoinFullRange :: Gen Coin
-genCoinFullRange = frequency
-    [ (1, pure (Coin 0))
-    , (1, pure (maxBound :: Coin))
-    , (8, Coin <$> chooseNatural (1, unCoin (maxBound :: Coin) - 1))
-    ]
-
-shrinkCoinFullRange :: Coin -> [Coin]
-shrinkCoinFullRange =
-    -- Given that we may have a large value, we limit the number of results
-    -- returned in order to avoid processing long lists of shrunken values.
-    take 8 . shrinkCoin

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin/Gen.hs
@@ -12,7 +12,9 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Test.QuickCheck
-    ( Gen, choose, frequency, shrink, sized )
+    ( Gen, choose, frequency, sized )
+import Test.QuickCheck.Extra
+    ( chooseNatural, shrinkNatural )
 
 --------------------------------------------------------------------------------
 -- Coins chosen according to the size parameter.
@@ -22,7 +24,7 @@ genCoin :: Gen Coin
 genCoin = sized $ \n -> Coin . fromIntegral <$> choose (0, n)
 
 shrinkCoin :: Coin -> [Coin]
-shrinkCoin (Coin c) = Coin <$> shrink c
+shrinkCoin (Coin c) = Coin <$> shrinkNatural c
 
 --------------------------------------------------------------------------------
 -- Coins chosen according to the size parameter, but strictly positive.
@@ -32,7 +34,7 @@ genCoinPositive :: Gen Coin
 genCoinPositive = sized $ \n -> Coin . fromIntegral <$> choose (1, max 1 n)
 
 shrinkCoinPositive :: Coin -> [Coin]
-shrinkCoinPositive (Coin c) = Coin <$> filter (> 0) (shrink c)
+shrinkCoinPositive (Coin c) = Coin <$> filter (> 0) (shrinkNatural c)
 
 --------------------------------------------------------------------------------
 -- Coins chosen from the full range available.
@@ -50,7 +52,7 @@ genCoinFullRange :: Gen Coin
 genCoinFullRange = frequency
     [ (1, pure (Coin 0))
     , (1, pure (maxBound :: Coin))
-    , (8, Coin <$> choose (1, unCoin (maxBound :: Coin) - 1))
+    , (8, Coin <$> chooseNatural (1, unCoin (maxBound :: Coin) - 1))
     ]
 
 shrinkCoinFullRange :: Coin -> [Coin]

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
@@ -1,6 +1,5 @@
 module Cardano.Wallet.Primitive.Types.TokenBundle.Gen
-    ( genFixedSizeTokenBundle
-    , genTokenBundleSmallRange
+    ( genTokenBundleSmallRange
     , genTokenBundleSmallRangePositive
     , genTokenBundle
     , shrinkTokenBundleSmallRange
@@ -10,58 +9,15 @@ module Cardano.Wallet.Primitive.Types.TokenBundle.Gen
 import Prelude
 
 import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoin
-    , genCoinFullRange
-    , genCoinPositive
-    , shrinkCoin
-    , shrinkCoinPositive
-    )
+    ( genCoin, genCoinPositive, shrinkCoin, shrinkCoinPositive )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetIdLargeRange, genTokenMapSmallRange, shrinkTokenMap )
-import Cardano.Wallet.Primitive.Types.TokenQuantity
-    ( TokenQuantity (..) )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( txOutMaxTokenQuantity, txOutMinTokenQuantity )
-import Control.Monad
-    ( replicateM )
+    ( genTokenMap, genTokenMapSmallRange, shrinkTokenMap )
 import Test.QuickCheck
-    ( Gen, choose, oneof, sized )
+    ( Gen )
 import Test.QuickCheck.Extra
     ( shrinkInterleaved )
-
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
-
---------------------------------------------------------------------------------
--- Token bundles with fixed numbers of assets.
---
--- Policy identifiers, asset names, token quantities are all allowed to vary.
---------------------------------------------------------------------------------
-
-genFixedSizeTokenBundle :: Int -> Gen TokenBundle
-genFixedSizeTokenBundle fixedAssetCount
-    = TokenBundle.fromFlatList
-        <$> genCoinFullRange
-        <*> replicateM fixedAssetCount genAssetQuantity
-  where
-    genAssetQuantity = (,)
-        <$> genAssetIdLargeRange
-        <*> genTokenQuantity
-    genTokenQuantity = integerToTokenQuantity <$> oneof
-        [ pure $ tokenQuantityToInteger txOutMinTokenQuantity
-        , pure $ tokenQuantityToInteger txOutMaxTokenQuantity
-        , choose
-            ( tokenQuantityToInteger txOutMinTokenQuantity + 1
-            , tokenQuantityToInteger txOutMaxTokenQuantity - 1
-            )
-        ]
-      where
-        tokenQuantityToInteger :: TokenQuantity -> Integer
-        tokenQuantityToInteger = fromIntegral . unTokenQuantity
-
-        integerToTokenQuantity :: Integer -> TokenQuantity
-        integerToTokenQuantity = TokenQuantity . fromIntegral
 
 --------------------------------------------------------------------------------
 -- Token bundles with variable numbers of assets, the upper bound being
@@ -71,8 +27,9 @@ genFixedSizeTokenBundle fixedAssetCount
 --------------------------------------------------------------------------------
 
 genTokenBundle :: Gen TokenBundle
-genTokenBundle = sized $ \maxAssetCount ->
-    choose (0, maxAssetCount) >>= genFixedSizeTokenBundle
+genTokenBundle = TokenBundle
+    <$> genCoin
+    <*> genTokenMap
 
 --------------------------------------------------------------------------------
 -- Token bundles with coins, assets, and quantities chosen from small ranges

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -828,7 +828,7 @@ data TokenBundleSizeAssessment
 --   token bundle.
 --
 txOutMinCoin :: Coin
-txOutMinCoin = Coin 1
+txOutMinCoin = Coin 0
 
 -- | The greatest quantity of lovelace that can appear in a transaction output's
 --   token bundle.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -85,6 +85,9 @@ module Cardano.Wallet.Primitive.Types.Tx
     , TxSize (..)
     , txSizeDistance
 
+    -- * Checks
+    , coinIsValidForTxOut
+
     -- * Conversions (Unsafe)
     , unsafeCoinToTxOutCoinValue
 
@@ -952,6 +955,15 @@ unsafeSealedTxFromBytes = either (internalError . errMsg) id . sealedTxFromBytes
 mockSealedTx :: HasCallStack => ByteString -> SealedTx
 mockSealedTx = SealedTx False
     (internalError "mockSealedTx: attempted to decode gibberish")
+
+{-------------------------------------------------------------------------------
+                          Checks
+-------------------------------------------------------------------------------}
+
+coinIsValidForTxOut :: Coin -> Bool
+coinIsValidForTxOut c = (&&)
+    (c >= txOutMinCoin)
+    (c <= txOutMaxCoin)
 
 {-------------------------------------------------------------------------------
                           Conversions (Unsafe)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -69,6 +70,8 @@ module Cardano.Wallet.Primitive.Types.Tx
     , failedScriptValidation
 
     -- * Constants
+    , txOutMinCoin
+    , txOutMaxCoin
     , txOutMinTokenQuantity
     , txOutMaxTokenQuantity
 
@@ -813,6 +816,18 @@ data TokenBundleSizeAssessment
 --------------------------------------------------------------------------------
 -- Constants
 --------------------------------------------------------------------------------
+
+-- | The smallest quantity of lovelace that can appear in a transaction output's
+--   token bundle.
+--
+txOutMinCoin :: Coin
+txOutMinCoin = Coin 1
+
+-- | The greatest quantity of lovelace that can appear in a transaction output's
+--   token bundle.
+--
+txOutMaxCoin :: Coin
+txOutMaxCoin = Coin 45_000_000_000_000_000
 
 -- | The smallest token quantity that can appear in a transaction output's
 --   token bundle.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -14,12 +14,15 @@ module Cardano.Wallet.Primitive.Types.Tx.Gen
     , genTxInFunction
     , genTxInLargeRange
     , genTxOut
+    , genTxOutCoin
+    , genTxOutTokenBundle
     , genTxScriptValidity
     , shrinkTx
     , shrinkTxHash
     , shrinkTxIndex
     , shrinkTxIn
     , shrinkTxOut
+    , shrinkTxOutCoin
     , shrinkTxScriptValidity
     )
     where
@@ -44,8 +47,22 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
+import Cardano.Wallet.Primitive.Types.TokenMap.Gen
+    ( genAssetIdLargeRange )
+import Cardano.Wallet.Primitive.Types.TokenQuantity
+    ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( Tx (..), TxIn (..), TxMetadata (..), TxOut (..), TxScriptValidity (..) )
+    ( Tx (..)
+    , TxIn (..)
+    , TxMetadata (..)
+    , TxOut (..)
+    , TxScriptValidity (..)
+    , coinIsValidForTxOut
+    , txOutMaxCoin
+    , txOutMaxTokenQuantity
+    , txOutMinCoin
+    , txOutMinTokenQuantity
+    )
 import Control.Monad
     ( replicateM )
 import Data.Either
@@ -63,14 +80,17 @@ import GHC.Generics
 import Test.QuickCheck
     ( Gen
     , arbitrary
+    , choose
     , coarbitrary
     , elements
+    , frequency
     , liftArbitrary
     , liftArbitrary2
     , liftShrink
     , liftShrink2
     , listOf
     , listOf1
+    , oneof
     , shrinkList
     , shrinkMapBy
     , sized
@@ -79,18 +99,22 @@ import Test.QuickCheck
 import Test.QuickCheck.Arbitrary.Generic
     ( genericArbitrary, genericShrink )
 import Test.QuickCheck.Extra
-    ( genFunction
+    ( chooseNatural
+    , genFunction
     , genMapWith
     , genSized2With
     , genericRoundRobinShrink
     , shrinkInterleaved
     , shrinkMapWith
+    , shrinkNatural
     , (<:>)
     , (<@>)
     )
 
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Data.ByteString.Char8 as B8
+import qualified Data.List as L
 import qualified Data.Text as T
 
 --------------------------------------------------------------------------------
@@ -234,6 +258,67 @@ shrinkTxOut (TxOut a b) = uncurry TxOut <$> shrinkInterleaved
 
 tokenBundleHasNonZeroCoin :: TokenBundle -> Bool
 tokenBundleHasNonZeroCoin b = TokenBundle.getCoin b /= Coin 0
+
+--------------------------------------------------------------------------------
+-- Coins chosen from the full range allowed in a transaction output
+--------------------------------------------------------------------------------
+
+-- | Generates coins across the full range allowed in a transaction output.
+--
+-- This generator has a slight bias towards the limits of the range, but
+-- otherwise generates values uniformly across the whole range.
+--
+-- This can be useful when testing roundtrip conversions between different
+-- types.
+--
+genTxOutCoin :: Gen Coin
+genTxOutCoin = frequency
+    [ (1, pure txOutMinCoin)
+    , (1, pure txOutMaxCoin)
+    , (8, Coin.fromNatural <$> chooseNatural
+        ( Coin.toNatural txOutMinCoin + 1
+        , Coin.toNatural txOutMaxCoin - 1
+        )
+      )
+    ]
+
+shrinkTxOutCoin :: Coin -> [Coin]
+shrinkTxOutCoin
+    = L.filter coinIsValidForTxOut
+    . shrinkMapBy Coin.fromNatural Coin.toNatural shrinkNatural
+
+--------------------------------------------------------------------------------
+-- Token bundles with fixed numbers of assets.
+--
+-- Values are chosen from across the full range of values permitted within
+-- transaction outputs.
+--
+-- Policy identifiers, asset names, token quantities are all allowed to vary.
+--------------------------------------------------------------------------------
+
+genTxOutTokenBundle :: Int -> Gen TokenBundle
+genTxOutTokenBundle fixedAssetCount
+    = TokenBundle.fromFlatList
+        <$> genTxOutCoin
+        <*> replicateM fixedAssetCount genAssetQuantity
+  where
+    genAssetQuantity = (,)
+        <$> genAssetIdLargeRange
+        <*> genTokenQuantity
+    genTokenQuantity = integerToTokenQuantity <$> oneof
+        [ pure $ tokenQuantityToInteger txOutMinTokenQuantity
+        , pure $ tokenQuantityToInteger txOutMaxTokenQuantity
+        , choose
+            ( tokenQuantityToInteger txOutMinTokenQuantity + 1
+            , tokenQuantityToInteger txOutMaxTokenQuantity - 1
+            )
+        ]
+      where
+        tokenQuantityToInteger :: TokenQuantity -> Integer
+        tokenQuantityToInteger = fromIntegral . unTokenQuantity
+
+        integerToTokenQuantity :: Integer -> TokenQuantity
+        integerToTokenQuantity = TokenQuantity . fromIntegral
 
 --------------------------------------------------------------------------------
 -- Internal utilities

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -52,8 +52,6 @@ import Prelude hiding
 
 import Cardano.Wallet.Primitive.Types.Address
     ( Address )
-import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -81,6 +79,7 @@ import Fmt
 import GHC.Generics
     ( Generic )
 
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TB
 import qualified Control.Foldl as F
 import qualified Data.List as L
@@ -298,7 +297,7 @@ log10 = Log10
 -- | Compute UtxoStatistics from UTxOs
 computeUtxoStatistics :: BoundType -> UTxO -> UTxOStatistics
 computeUtxoStatistics btype
-    = computeStatistics (pure . fromIntegral . unCoin . txOutCoin) btype
+    = computeStatistics (pure . Coin.unsafeToWord64 . txOutCoin) btype
     . Map.elems
     . unUTxO
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -297,8 +297,10 @@ log10 = Log10
 
 -- | Compute UtxoStatistics from UTxOs
 computeUtxoStatistics :: BoundType -> UTxO -> UTxOStatistics
-computeUtxoStatistics btype =
-    computeStatistics (pure . unCoin . txOutCoin) btype . Map.elems . unUTxO
+computeUtxoStatistics btype
+    = computeStatistics (pure . fromIntegral . unCoin . txOutCoin) btype
+    . Map.elems
+    . unUTxO
 
 -- | A more generic function for computing UTxO statistics on some other type of
 -- data that maps to UTxO's values.

--- a/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
+++ b/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
@@ -32,8 +32,6 @@ import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey (..), generateKeyFromSeed )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
-import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -63,6 +61,7 @@ import Test.QuickCheck
     , (==>)
     )
 
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteArray as BA
@@ -220,7 +219,7 @@ instance Arbitrary (Index 'WholeDomain 'AccountK) where
 -------------------------------------------------------------------------------}
 
 coinToBundle :: Word64 -> TokenBundle
-coinToBundle = TokenBundle.fromCoin . Coin
+coinToBundle = TokenBundle.fromCoin . Coin.fromWord64
 
 -- A mainnet block with a transaction
 txs1 :: [([TxIn], [TxOut])]

--- a/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -46,10 +46,10 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
-import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinFullRange, shrinkCoinFullRange )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genTxOutCoin, shrinkTxOutCoin )
 import Control.Arrow
     ( second )
 import Control.Monad
@@ -141,8 +141,8 @@ instance Arbitrary (Quantity "lovelace" Word64) where
     arbitrary = Quantity <$> arbitrary
 
 instance Arbitrary Coin where
-    shrink = shrinkCoinFullRange
-    arbitrary = genCoinFullRange
+    shrink = shrinkTxOutCoin
+    arbitrary = genTxOutCoin
 
 arbitraryEpochLength :: Word32
 arbitraryEpochLength = 100

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -288,6 +288,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxOut (..)
     , TxScriptValidity (..)
     , TxStatus (..)
+    , txOutMaxCoin
     , unsafeSealedTxFromBytes
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
@@ -754,13 +755,13 @@ spec = parallel $ do
         it "AddressAmount (too big)" $ do
             let msg = "Error in $: parsing AddressAmount failed, \
                     \invalid coin value: value has to be lower \
-                    \than or equal to " <> show (unCoin maxBound)
+                    \than or equal to " <> show (unCoin txOutMaxCoin)
                     <> " lovelace."
             Aeson.parseEither parseJSON [aesonQQ|
                 { "address": "<addr>"
                 , "amount":
                     { "unit":"lovelace"
-                    ,"quantity":#{unCoin maxBound + 1}
+                    ,"quantity":#{unCoin txOutMaxCoin + 1}
                     }
                 }
             |] `shouldBe` (Left @String @(AddressAmount (ApiT Address, Proxy ('Testnet 0))) msg)

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -253,7 +253,7 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinFullRange, genCoinPositive )
+    ( genCoinPositive )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
@@ -291,7 +291,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , unsafeSealedTxFromBytes
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxScriptValidity, shrinkTxScriptValidity )
+    ( genTxOutCoin, genTxScriptValidity, shrinkTxScriptValidity )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( HistogramBar (..)
     , UTxO (..)
@@ -2363,7 +2363,7 @@ instance Arbitrary RewardAccount where
 
 instance Arbitrary Coin where
     -- No Shrinking
-    arbitrary = genCoinFullRange
+    arbitrary = genTxOutCoin
 
 instance Arbitrary UTxO where
     shrink (UTxO utxo) = UTxO <$> shrink utxo

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -112,8 +112,6 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
-import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinFullRange )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..), mockHash )
 import Cardano.Wallet.Primitive.Types.RewardAccount
@@ -132,7 +130,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , isPending
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxScriptValidity, shrinkTxScriptValidity )
+    ( genTxOutCoin, genTxScriptValidity, shrinkTxScriptValidity )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Unsafe
@@ -429,7 +427,7 @@ instance Arbitrary TxMetadata where
     shrink = shrinkTxMetadata
 
 instance Arbitrary Coin where
-    arbitrary = genCoinFullRange
+    arbitrary = genTxOutCoin
 
 instance Arbitrary UTxO where
     shrink (UTxO u) =

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -263,6 +263,7 @@ import UnliftIO.Temporary
 
 import qualified Cardano.Wallet.DB.Sqlite.TH as DB
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Seq
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
@@ -1242,7 +1243,7 @@ testMigrationPassphraseScheme = do
 -------------------------------------------------------------------------------}
 
 coinToBundle :: Word64 -> TokenBundle
-coinToBundle = TokenBundle.fromCoin . Coin
+coinToBundle = TokenBundle.fromCoin . Coin.fromWord64
 
 testCp :: Wallet (SeqState 'Mainnet ShelleyKey)
 testCp = snd $ initWallet block0 initDummyState

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -233,6 +233,7 @@ import Test.QuickCheck.Monadic
 import Test.Utils.Laws
     ( testLawsMany )
 
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
@@ -2701,7 +2702,9 @@ unit_makeChange =
         ]
 
     b :: Word64 -> [(AssetId, Natural)] -> TokenBundle
-    b c = TokenBundle (Coin c) . TokenMap.fromFlatList . fmap (second TokenQuantity)
+    b c = TokenBundle (Coin.fromWord64 c)
+        . TokenMap.fromFlatList
+        . fmap (second TokenQuantity)
 
     assetA :: AssetId
     assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
@@ -2988,10 +2991,14 @@ unit_assignCoinsToChangeMaps =
         ]
 
     m :: Word64 -> [(AssetId, Natural)] -> (TokenMap, Coin)
-    m c = (,Coin c) . TokenMap.fromFlatList . fmap (second TokenQuantity)
+    m c = (, Coin.fromWord64 c)
+        . TokenMap.fromFlatList
+        . fmap (second TokenQuantity)
 
     b :: Word64 -> [(AssetId, Natural)] -> TokenBundle
-    b c = TokenBundle (Coin c) . TokenMap.fromFlatList . fmap (second TokenQuantity)
+    b c = TokenBundle (Coin.fromWord64 c)
+        . TokenMap.fromFlatList
+        . fmap (second TokenQuantity)
 
     assetA :: AssetId
     assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -100,7 +100,7 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance.Gen
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), addCoin )
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoin, genCoinPositive, shrinkCoin, shrinkCoinPositive )
 import Cardano.Wallet.Primitive.Types.Hash
@@ -2609,8 +2609,10 @@ prop_makeChange_fail_minValueTooBig p =
         -- coins available to generate all change outputs.
         Right change ->
             conjoin
-                [ deltaCoin < totalMinCoinDeposit `addCoin` view #requiredCost p
-                , deltaCoin >= view #requiredCost p
+                [ deltaCoin <
+                    totalMinCoinDeposit `Coin.add` view #requiredCost p
+                , deltaCoin >=
+                    view #requiredCost p
                 ]
                 & counterexample counterexampleText
           where
@@ -2627,7 +2629,7 @@ prop_makeChange_fail_minValueTooBig p =
                 totalOutputValue
             minCoinValueFor =
                 unMockComputeMinimumAdaQuantity (minCoinFor p)
-            totalMinCoinDeposit = F.foldr addCoin (Coin 0)
+            totalMinCoinDeposit = F.foldr Coin.add (Coin 0)
                 (minCoinValueFor . view #tokens <$> change)
   where
     totalInputValue =
@@ -2955,7 +2957,7 @@ unit_assignCoinsToChangeMaps =
 
         -- Single Ada-only output, but not enough left to create a change
         , ( Coin 1
-          , (`addCoin` Coin 1) . computeMinimumAdaQuantityLinear
+          , (`Coin.add` Coin 1) . computeMinimumAdaQuantityLinear
           , m 42 [] :| []
           , Right []
           )
@@ -3009,7 +3011,7 @@ unit_assignCoinsToChangeMaps =
 
 prop_makeChangeForCoin_sum :: NonEmpty Coin -> Coin -> Property
 prop_makeChangeForCoin_sum weights surplus =
-    surplus === F.foldr addCoin (Coin 0) changes
+    surplus === F.foldr Coin.add (Coin 0) changes
   where
     changes = makeChangeForCoin weights surplus
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/CollateralSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/CollateralSpec.hs
@@ -55,6 +55,8 @@ import Data.Generics.Internal.VL.Lens
     ( view )
 import Data.Generics.Labels
     ()
+import Data.IntCast
+    ( intCast )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Map.Strict
@@ -65,6 +67,8 @@ import Data.Word
     ( Word64 )
 import GHC.Generics
     ( Generic )
+import Numeric.Natural
+    ( Natural )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.Hspec.Extra
@@ -704,7 +708,7 @@ instance Arbitrary SingleBitCoinMap where
     shrink = shrinkSingleBitCoinMap
 
 allSingleBitCoins :: [Coin]
-allSingleBitCoins = Coin . ((2 :: Word64) ^) <$> [0 :: Word64 .. ]
+allSingleBitCoins = Coin . ((2 :: Natural) ^) <$> [0 :: Natural .. ]
 
 genSingleBitCoinMap :: Gen SingleBitCoinMap
 genSingleBitCoinMap = sized $ \size -> do
@@ -1244,7 +1248,7 @@ genLongInputId =
 --------------------------------------------------------------------------------
 
 scaleCoin :: Coin -> Word64 -> Coin
-scaleCoin (Coin c) w = Coin (c * w)
+scaleCoin (Coin c) w = Coin (c * intCast w)
 
 instance Arbitrary Coin where
     arbitrary = genCoinPositive

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
@@ -100,7 +100,7 @@ import Test.QuickCheck
     , withMaxSuccess
     )
 import Test.QuickCheck.Extra
-    ( report, verify )
+    ( chooseNatural, report, verify )
 
 import qualified Cardano.Wallet.Primitive.Migration.Selection as Selection
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
@@ -938,7 +938,7 @@ genCoinBelowMinimumAdaQuantity mockConstraints =
 
 genCoinRange :: Coin -> Coin -> Gen Coin
 genCoinRange (Coin minCoin) (Coin maxCoin) =
-    Coin . fromIntegral <$> choose (minCoin, maxCoin)
+    Coin <$> chooseNatural (minCoin, maxCoin)
 
 genTokenBundleMixed :: MockTxConstraints -> Gen TokenBundle
 genTokenBundleMixed mockConstraints =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
@@ -41,6 +41,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxConstraints (..)
     , TxSize (..)
+    , txOutMaxCoin
     , txOutputCoinCost
     , txOutputCoinMinimum
     , txOutputCoinSize
@@ -380,7 +381,7 @@ prop_addValueToOutputs_inner mockConstraints outputs =
 
 txOutputHasValidSizeWithMaxAda :: TxConstraints -> TokenMap -> Bool
 txOutputHasValidSizeWithMaxAda constraints b =
-    txOutputHasValidSize constraints $ TokenBundle maxBound b
+    txOutputHasValidSize constraints $ TokenBundle txOutMaxCoin b
 
 --------------------------------------------------------------------------------
 -- Minimizing fees
@@ -628,7 +629,7 @@ prop_txOutputCost_inner mockConstraints output =
         $ multiplyCoinByTen
         $ TokenBundle.getCoin output
     outputWithMaxCoin =
-        TokenBundle.setCoin output maxBound
+        TokenBundle.setCoin output txOutMaxCoin
     multiplyCoinByTen (Coin n) = Coin $ 10 * n
 
 --------------------------------------------------------------------------------
@@ -684,7 +685,7 @@ prop_txOutputSize_inner mockConstraints output =
         $ multiplyCoinByTen
         $ TokenBundle.getCoin output
     outputWithMaxCoin =
-        TokenBundle.setCoin output maxBound
+        TokenBundle.setCoin output txOutMaxCoin
     multiplyCoinByTen (Coin n) = Coin $ 10 * n
 
 --------------------------------------------------------------------------------
@@ -977,8 +978,10 @@ genTokenBundleAboveMinimumAdaQuantity mockConstraints = do
 genTokenMap :: MockTxConstraints -> Gen TokenMap
 genTokenMap mockConstraints =
     genInner
-        `suchThat` (txOutputHasValidSize constraints . (TokenBundle maxBound))
-        `suchThat` (txOutputHasValidTokenQuantities constraints)
+        `suchThat`
+            (txOutputHasValidSize constraints . (TokenBundle txOutMaxCoin))
+        `suchThat`
+            (txOutputHasValidTokenQuantities constraints)
   where
     constraints = unMockTxConstraints mockConstraints
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -153,8 +153,9 @@ import Test.QuickCheck
     , (===)
     )
 import Test.QuickCheck.Extra
-    ( report )
+    ( chooseNatural, report )
 
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Data.ByteString as BS
@@ -803,7 +804,7 @@ instance Arbitrary (WithPending WalletState) where
         (_, cp0) <- initWallet @_ block0 <$> arbitrary
         subChain <- flip take blockchain <$> choose (1, length blockchain)
         let wallet = foldl (\cp b -> snd $ applyBlock b cp) cp0 subChain
-        rewards <- Coin <$> oneof [pure 0, choose (1, 10000)]
+        rewards <- Coin <$> oneof [pure 0, chooseNatural (1, 10000)]
         pending <- genPendingTx (totalUTxO Set.empty wallet) rewards
         pure $ WithPending wallet pending rewards
       where
@@ -886,7 +887,7 @@ addresses = map address
     blockchain
 
 coinToBundle :: Word64 -> TokenBundle
-coinToBundle = TokenBundle.fromCoin . Coin
+coinToBundle = TokenBundle.fromCoin . Coin.fromWord64
 
 -- A excerpt of mainnet, epoch #14, first 20 blocks; plus a few previous blocks
 -- which contains transactions referred to in the former. This is useful to test

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/CoinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/CoinSpec.hs
@@ -68,15 +68,15 @@ prop_add_subtract :: Coin -> Coin -> Property
 prop_add_subtract a b =
     checkCoverageCoin a b $
     conjoin
-    [ (a `Coin.addCoin` b) `Coin.subtractCoin` b === Just a
-    , (b `Coin.addCoin` a) `Coin.subtractCoin` a === Just b
+    [ (a `Coin.add` b) `Coin.subtractCoin` b === Just a
+    , (b `Coin.add` a) `Coin.subtractCoin` a === Just b
     ]
 
 prop_add_toNatural :: Coin -> Coin -> Property
 prop_add_toNatural a b =
     checkCoverageCoin a b $
     (===)
-        (Coin.toNatural (a `Coin.addCoin` b))
+        (Coin.toNatural (a `Coin.add` b))
         (Coin.toNatural a + Coin.toNatural b)
 
 prop_difference_distance :: Coin -> Coin -> Property

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/CoinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/CoinSpec.hs
@@ -7,7 +7,7 @@ module Cardano.Wallet.Primitive.Types.CoinSpec
 import Prelude
 
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), isValidCoin )
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoin, genCoinPositive, shrinkCoin, shrinkCoinPositive )
 import Test.Hspec
@@ -49,8 +49,6 @@ spec = describe "Cardano.Wallet.Primitive.Types.CoinSpec" $ do
     parallel $ describe "Generators and shrinkers" $ do
 
         describe "Coins that can be zero" $ do
-            it "genCoin" $
-                property prop_genCoin
             it "genCoin_coverage" $
                 property prop_genCoin_coverage
             it "shrinkCoin" $
@@ -117,9 +115,6 @@ prop_subtract_toNatural a b =
 -- Coins that can be zero
 --------------------------------------------------------------------------------
 
-prop_genCoin :: Property
-prop_genCoin = forAll genCoin isValidCoin
-
 prop_genCoin_coverage :: Coin -> Coin -> Property
 prop_genCoin_coverage a b =
     checkCoverageCoin a b True
@@ -138,10 +133,7 @@ checkCoverageCoin a b
 prop_shrinkCoin :: Property
 prop_shrinkCoin = forAll genCoin $ \c ->
     let shrunken = shrinkCoin c in
-    conjoin $ ($ shrunken) <$>
-        [ all (< c)
-        , all isValidCoin
-        ]
+    all (< c) shrunken
 
 --------------------------------------------------------------------------------
 -- Coins that are strictly positive

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/CoinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/CoinSpec.hs
@@ -78,8 +78,8 @@ prop_add_toNatural :: Coin -> Coin -> Property
 prop_add_toNatural a b =
     checkCoverageCoin a b $
     (===)
-        (Coin.coinToNatural (a `Coin.addCoin` b))
-        (Coin.coinToNatural a + Coin.coinToNatural b)
+        (Coin.toNatural (a `Coin.addCoin` b))
+        (Coin.toNatural a + Coin.toNatural b)
 
 prop_difference_distance :: Coin -> Coin -> Property
 prop_difference_distance a b =
@@ -105,13 +105,13 @@ prop_subtract_toNatural a b =
     checkCoverageCoin a b $
     if (a >= b)
     then
-        (Coin.coinToNatural <$> (a `Coin.subtractCoin` b))
+        (Coin.toNatural <$> (a `Coin.subtractCoin` b))
         ===
-        (Just (Coin.coinToNatural a - Coin.coinToNatural b))
+        (Just (Coin.toNatural a - Coin.toNatural b))
     else
-        (Coin.coinToNatural <$> (b `Coin.subtractCoin` a))
+        (Coin.toNatural <$> (b `Coin.subtractCoin` a))
         ===
-        (Just (Coin.coinToNatural b - Coin.coinToNatural a))
+        (Just (Coin.toNatural b - Coin.toNatural a))
 
 --------------------------------------------------------------------------------
 -- Coins that can be zero

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/CoinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/CoinSpec.hs
@@ -68,8 +68,8 @@ prop_add_subtract :: Coin -> Coin -> Property
 prop_add_subtract a b =
     checkCoverageCoin a b $
     conjoin
-    [ (a `Coin.add` b) `Coin.subtractCoin` b === Just a
-    , (b `Coin.add` a) `Coin.subtractCoin` a === Just b
+    [ (a `Coin.add` b) `Coin.subtract` b === Just a
+    , (b `Coin.add` a) `Coin.subtract` a === Just b
     ]
 
 prop_add_toNatural :: Coin -> Coin -> Property
@@ -90,8 +90,8 @@ prop_difference_subtract :: Coin -> Coin -> Property
 prop_difference_subtract a b =
     checkCoverageCoin a b $
     if (a >= b)
-    then a `Coin.subtractCoin` b === Just (a `Coin.difference` b)
-    else a `Coin.subtractCoin` b === Nothing
+    then a `Coin.subtract` b === Just (a `Coin.difference` b)
+    else a `Coin.subtract` b === Nothing
 
 prop_distance_commutative :: Coin -> Coin -> Property
 prop_distance_commutative a b =
@@ -103,11 +103,11 @@ prop_subtract_toNatural a b =
     checkCoverageCoin a b $
     if (a >= b)
     then
-        (Coin.toNatural <$> (a `Coin.subtractCoin` b))
+        (Coin.toNatural <$> (a `Coin.subtract` b))
         ===
         (Just (Coin.toNatural a - Coin.toNatural b))
     else
-        (Coin.toNatural <$> (b `Coin.subtractCoin` a))
+        (Coin.toNatural <$> (b `Coin.subtract` a))
         ===
         (Just (Coin.toNatural b - Coin.toNatural a))
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/CoinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/CoinSpec.hs
@@ -151,7 +151,7 @@ prop_shrinkCoinPositive = forAll genCoinPositive $ \c ->
         ]
 
 isValidCoinPositive :: Coin -> Bool
-isValidCoinPositive c = c > Coin 0 && c <= maxBound
+isValidCoinPositive c = c > Coin 0
 
 --------------------------------------------------------------------------------
 -- Arbitrary instances

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -137,6 +137,8 @@ import Data.Function
     ( (&) )
 import Data.Function.Utils
     ( applyN )
+import Data.IntCast
+    ( intCast )
 import Data.Maybe
     ( catMaybes, fromMaybe, isJust, isNothing )
 import Data.Proxy
@@ -214,6 +216,7 @@ import Test.Utils.Time
 import UnliftIO.Exception
     ( evaluate )
 
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Data.ByteString as BS
 import qualified Data.Map
@@ -1006,7 +1009,7 @@ propUtxoTotalIsBalance
     -> ShowFmt UTxO
     -> Property
 propUtxoTotalIsBalance bType (ShowFmt utxo) =
-    Coin totalStake == TokenBundle.getCoin (balance utxo)
+    Coin.fromWord64 totalStake == TokenBundle.getCoin (balance utxo)
     & cover 75 (utxo /= mempty) "UTxO /= empty"
   where
     UTxOStatistics _ totalStake _ = computeUtxoStatistics bType utxo
@@ -1019,7 +1022,8 @@ propUtxoSumDistribution
     -> ShowFmt UTxO
     -> Property
 propUtxoSumDistribution bType (ShowFmt utxo) =
-    sum (upperVal <$> bars) >= unCoin (TokenBundle.getCoin (balance utxo))
+    intCast (sum (upperVal <$> bars)) >=
+        unCoin (TokenBundle.getCoin (balance utxo))
     & cover 75 (utxo /= mempty) "UTxO /= empty"
     & counterexample ("Histogram: " <> pretty bars)
   where

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -88,7 +88,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), isValidCoin )
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoin )
 import Cardano.Wallet.Primitive.Types.Hash
@@ -226,9 +226,6 @@ import qualified Data.Text as T
 
 spec :: Spec
 spec = describe "Cardano.Wallet.Primitive.Types" $ do
-
-    parallel $ describe "Generators are valid" $ do
-        it "Arbitrary Coin" $ property isValidCoin
 
     describe "Class instances obey laws" $ do
         testLawsMany @TxOut

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -61,6 +61,7 @@ library
     , filepath
     , fmt
     , generic-lens
+    , int-cast
     , io-classes
     , iohk-monitoring
     , memory

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -96,6 +96,7 @@ import qualified Cardano.Chain.Update.Validation.Interface as Update
 import qualified Cardano.Crypto.Hashing as CC
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
@@ -296,7 +297,7 @@ fromTxIn (TxInUtxo id_ ix) = W.TxIn
 fromTxOut :: TxOut -> W.TxOut
 fromTxOut (TxOut addr coin) = W.TxOut
     { address = W.Address (serialize' addr)
-    , tokens = TokenBundle.fromCoin $ W.Coin $ unsafeGetLovelace coin
+    , tokens = TokenBundle.fromCoin $ Coin.fromWord64 $ unsafeGetLovelace coin
     }
 
 fromByronHash :: ByronHash -> W.Hash "BlockHeader"

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs
@@ -73,15 +73,16 @@ import Data.Generics.Internal.VL.Lens
     ( view )
 import Data.Generics.Labels
     ()
-import Data.Word
-    ( Word64 )
+import Data.IntCast
+    ( intCast )
 import Fmt
     ( pretty )
 import GHC.Stack
     ( HasCallStack )
+import Numeric.Natural
+    ( Natural )
 import Ouroboros.Consensus.Shelley.Eras
     ( StandardCrypto )
-
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Ledger.Address as Ledger
@@ -90,6 +91,7 @@ import qualified Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo
 import qualified Cardano.Ledger.Mary.Value as Ledger
 import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as Ledger
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.ByteString as BS
@@ -152,23 +154,10 @@ instance Convert Coin Ledger.Coin where
     toWallet = toWalletCoin
 
 toLedgerCoin :: Coin -> Ledger.Coin
-toLedgerCoin (Coin c) =
-      Ledger.Coin $ fromIntegral @Word64 @Integer c
+toLedgerCoin (Coin c) = Ledger.Coin $ intCast @Natural @Integer c
 
 toWalletCoin :: Ledger.Coin -> Coin
-toWalletCoin (Ledger.Coin c)
-    | isValidCoin =
-        Coin $ fromIntegral @Integer @Word64 c
-    | otherwise =
-        error $ unwords
-            [ "Ledger.toWalletCoin:"
-            , "Unexpected invalid coin value:"
-            , pretty c
-            ]
-  where
-    isValidCoin = (&&)
-        (c >= fromIntegral @Word64 @Integer (unCoin minBound))
-        (c <= fromIntegral @Word64 @Integer (unCoin maxBound))
+toWalletCoin (Ledger.Coin c) = Coin.unsafeFromIntegral c
 
 --------------------------------------------------------------------------------
 -- Conversions for 'TokenBundle'

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -813,7 +813,7 @@ fetchRewardAccounts tr queryRewardQ accounts = do
         return res
   where
     byronValue :: Map W.RewardAccount W.Coin
-    byronValue = Map.fromList . map (, minBound) $ Set.toList accounts
+    byronValue = Map.fromList . map (, W.Coin 0) $ Set.toList accounts
 
     shelleyQry
         :: (Crypto.HashAlgorithm (SL.ADDRHASH (EraCrypto shelleyEra)))

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -185,6 +185,8 @@ import Data.Generics.Internal.VL.Lens
     ( view, (^.) )
 import Data.Generics.Labels
     ()
+import Data.IntCast
+    ( intCast )
 import Data.Kind
     ( Type )
 import Data.Map.Strict
@@ -699,10 +701,12 @@ updateSealedTx (cardanoTx -> InAnyCardanoEra _era tx) extraContent = do
             extraOutputs' = toCardanoTxOut era <$> extraOutputs
             modifyFee' old = toLedgerCoin $ modifyFee $ fromLedgerCoin old
               where
+                toLedgerCoin :: Coin -> Ledger.Coin
                 toLedgerCoin (Coin c) =
-                    Ledger.word64ToCoin c
+                    Ledger.Coin (intCast c)
+                fromLedgerCoin :: Ledger.Coin -> Coin
                 fromLedgerCoin (Ledger.Coin c) =
-                    Coin.unsafeNaturalToCoin $ fromIntegral c
+                    Coin.unsafeFromIntegral c
                     -- fromIntegral will throw "Exception: arithmetic underflow"
                     -- if (c :: Integral) for some reason were to be negative.
 
@@ -1467,7 +1471,7 @@ estimateTxSize skeleton =
         . BS.length
         . CBOR.toStrictByteString
         . CBOR.encodeWord64
-        . unCoin
+        . Coin.unsafeToWord64
 
     -- withdrawals =
     --   { * reward_account => coin }

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1176,7 +1176,7 @@ mkTxSkeleton witness context skeleton = TxSkeleton
 --
 estimateTxCost :: ProtocolParameters -> TxSkeleton -> Coin
 estimateTxCost pp skeleton =
-    Coin.sumCoins
+    F.fold
         [ computeFee (estimateTxSize skeleton)
         , scriptExecutionCosts
         ]

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -847,7 +847,7 @@ _maxScriptExecutionCost pp redeemers
     maxExecutionUnits = view (#txParameters . #getMaxExecutionUnits) pp
 
     executionCost :: ExecutionUnitPrices -> ExecutionUnits -> Coin
-    executionCost ps us = Coin.unsafeNaturalToCoin . ceiling
+    executionCost ps us = Coin.fromNatural . ceiling
         $ (ps ^. #pricePerStep)       * toRational (us ^. #executionSteps)
         + (ps ^. #pricePerMemoryUnit) * toRational (us ^. #executionMemory)
 

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
@@ -27,7 +27,11 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantityFullRange, shrinkTokenQuantityFullRange )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( txOutMaxTokenQuantity, txOutMinTokenQuantity )
+    ( txOutMaxCoin
+    , txOutMaxTokenQuantity
+    , txOutMinCoin
+    , txOutMinTokenQuantity
+    )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTxOutCoin, genTxOutTokenBundle, shrinkTxOutCoin )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
@@ -130,8 +134,8 @@ prop_computeMinimumAdaQuantity_agnosticToAdaQuantity
             , bundleWithCoinMinimized =/= bundleWithCoinMaximized
             ]
   where
-    bundleWithCoinMinimized = TokenBundle.setCoin bundle minBound
-    bundleWithCoinMaximized = TokenBundle.setCoin bundle maxBound
+    bundleWithCoinMinimized = TokenBundle.setCoin bundle txOutMinCoin
+    bundleWithCoinMaximized = TokenBundle.setCoin bundle txOutMaxCoin
     compute = computeMinimumAdaQuantityInternal minParam
     counterexampleText = unlines
         [ "bundle:"

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
@@ -66,6 +66,7 @@ import Test.QuickCheck
     , (===)
     )
 
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Data.Set as Set
 
@@ -275,8 +276,8 @@ instance Arbitrary Coin where
 
 instance Arbitrary MinimumUTxOValue where
     arbitrary = oneof
-        [ MinimumUTxOValue . Coin . (* 1_000_000) <$> genSmallWord
-        , MinimumUTxOValueCostPerWord . Coin <$> genSmallWord
+        [ MinimumUTxOValue . Coin.fromWord64 . (* 1_000_000) <$> genSmallWord
+        , MinimumUTxOValueCostPerWord . Coin.fromWord64 <$> genSmallWord
         ]
       where
       genSmallWord = fromIntegral @Int @Word64 . getPositive <$> arbitrary

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
@@ -14,15 +14,10 @@ import Cardano.Wallet.Primitive.Types
     ( MinimumUTxOValue (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
-import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinFullRange, shrinkCoinFullRange )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( Flat (..), TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
-    ( genFixedSizeTokenBundle
-    , genTokenBundleSmallRange
-    , shrinkTokenBundleSmallRange
-    )
+    ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName, TokenPolicyId )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
@@ -33,6 +28,8 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantityFullRange, shrinkTokenQuantityFullRange )
 import Cardano.Wallet.Primitive.Types.Tx
     ( txOutMaxTokenQuantity, txOutMinTokenQuantity )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genTxOutCoin, genTxOutTokenBundle, shrinkTxOutCoin )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( Convert (..), computeMinimumAdaQuantityInternal )
 import Data.Bifunctor
@@ -271,8 +268,8 @@ newtype FixedSize256 a = FixedSize256 { unFixedSize256 :: a }
 instance Arbitrary Coin where
     -- This instance is used to test roundtrip conversions, so it's important
     -- that we generate coins across the full range available.
-    arbitrary = genCoinFullRange
-    shrink = shrinkCoinFullRange
+    arbitrary = genTxOutCoin
+    shrink = shrinkTxOutCoin
 
 instance Arbitrary MinimumUTxOValue where
     arbitrary = oneof
@@ -288,15 +285,15 @@ instance Arbitrary TokenBundle where
     shrink = shrinkTokenBundleSmallRange
 
 instance Arbitrary (FixedSize8 TokenBundle) where
-    arbitrary = FixedSize8 <$> genFixedSizeTokenBundle 8
+    arbitrary = FixedSize8 <$> genTxOutTokenBundle 8
     -- No shrinking
 
 instance Arbitrary (FixedSize64 TokenBundle) where
-    arbitrary = FixedSize64 <$> genFixedSizeTokenBundle 64
+    arbitrary = FixedSize64 <$> genTxOutTokenBundle 64
     -- No shrinking
 
 instance Arbitrary (FixedSize256 TokenBundle) where
-    arbitrary = FixedSize256 <$> genFixedSizeTokenBundle 256
+    arbitrary = FixedSize256 <$> genTxOutTokenBundle 256
     -- No shrinking
 
 instance Arbitrary TokenName where

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -404,7 +404,7 @@ instance (Arbitrary n, Integral n, Num w) => Arbitrary (TrickyInt n w) where
 -- bundle that is still over the size limit.
 --
 prop_assessTokenBundleSize_enlarge
-    :: Blind (VariableSize128 TokenBundle)
+    :: Blind (VariableSize1024 TokenBundle)
     -> Blind (VariableSize16 TokenBundle)
     -> Property
 prop_assessTokenBundleSize_enlarge b1' b2' =
@@ -417,14 +417,14 @@ prop_assessTokenBundleSize_enlarge b1' b2' =
   where
     assess = assessTokenBundleSize
         $ tokenBundleSizeAssessor maryTokenBundleMaxSize
-    b1 = unVariableSize128 $ getBlind b1'
+    b1 = unVariableSize1024 $ getBlind b1'
     b2 = unVariableSize16 $ getBlind b2'
 
 -- Shrinking a token bundle that is within the size limit should yield a token
 -- bundle that is still within the size limit.
 --
 prop_assessTokenBundleSize_shrink
-    :: Blind (VariableSize128 TokenBundle)
+    :: Blind (VariableSize1024 TokenBundle)
     -> Blind (VariableSize16 TokenBundle)
     -> TokenBundleMaxSize
     -> Property
@@ -437,7 +437,7 @@ prop_assessTokenBundleSize_shrink b1' b2' maxSize =
         ]
   where
     assess = assessTokenBundleSize (tokenBundleSizeAssessor maxSize)
-    b1 = unVariableSize128 $ getBlind b1'
+    b1 = unVariableSize1024 $ getBlind b1'
     b2 = unVariableSize16 $ getBlind b2'
 
 -- | Creates a test to assess the size of a token bundle with a fixed number of
@@ -788,7 +788,7 @@ newtype FixedSize128 a = FixedSize128 { unFixedSize128 :: a }
 newtype VariableSize16 a = VariableSize16 { unVariableSize16 :: a}
     deriving (Eq, Show)
 
-newtype VariableSize128 a = VariableSize128 { unVariableSize128 :: a}
+newtype VariableSize1024 a = VariableSize1024 { unVariableSize1024 :: a}
     deriving (Eq, Show)
 
 instance Arbitrary (FixedSize32 TokenBundle) where
@@ -811,8 +811,8 @@ instance Arbitrary (VariableSize16 TokenBundle) where
     arbitrary = VariableSize16 <$> resize 16 genTokenBundle
     -- No shrinking
 
-instance Arbitrary (VariableSize128 TokenBundle) where
-    arbitrary = VariableSize128 <$> resize 128 genTokenBundle
+instance Arbitrary (VariableSize1024 TokenBundle) where
+    arbitrary = VariableSize1024 <$> resize 1024 genTokenBundle
     -- No shrinking
 
 --

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -72,6 +72,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( TokenBundleSizeAssessment (..)
     , TokenBundleSizeAssessor (..)
     , TxSize (..)
+    , txOutMaxCoin
+    , txOutMinCoin
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTxOutTokenBundle )
@@ -409,7 +411,7 @@ prop_assessTokenBundleSize_enlarge b1' b2' =
     assess b1 == TokenBundleSizeExceedsLimit ==> conjoin
         [ assess (b1 `TokenBundle.add` b2)
             === TokenBundleSizeExceedsLimit
-        , assess (b1 `TokenBundle.setCoin` maxBound)
+        , assess (b1 `TokenBundle.setCoin` txOutMaxCoin)
             === TokenBundleSizeExceedsLimit
         ]
   where
@@ -430,7 +432,7 @@ prop_assessTokenBundleSize_shrink b1' b2' maxSize =
     assess b1 == TokenBundleSizeWithinLimit ==> conjoin
         [ assess (b1 `TokenBundle.difference` b2)
             === TokenBundleSizeWithinLimit
-        , assess (b1 `TokenBundle.setCoin` minBound)
+        , assess (b1 `TokenBundle.setCoin` txOutMinCoin)
             === TokenBundleSizeWithinLimit
         ]
   where

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -67,16 +67,14 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
-    ( genFixedSizeTokenBundle
-    , genTokenBundle
-    , genTokenBundleSmallRange
-    , shrinkTokenBundleSmallRange
-    )
+    ( genTokenBundle, genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TokenBundleSizeAssessment (..)
     , TokenBundleSizeAssessor (..)
     , TxSize (..)
     )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genTxOutTokenBundle )
 import Cardano.Wallet.Shelley.Compatibility
     ( CardanoBlock
     , StandardCrypto
@@ -792,19 +790,19 @@ newtype VariableSize128 a = VariableSize128 { unVariableSize128 :: a}
     deriving (Eq, Show)
 
 instance Arbitrary (FixedSize32 TokenBundle) where
-    arbitrary = FixedSize32 <$> genFixedSizeTokenBundle 32
+    arbitrary = FixedSize32 <$> genTxOutTokenBundle 32
     -- No shrinking
 
 instance Arbitrary (FixedSize48 TokenBundle) where
-    arbitrary = FixedSize48 <$> genFixedSizeTokenBundle 48
+    arbitrary = FixedSize48 <$> genTxOutTokenBundle 48
     -- No shrinking
 
 instance Arbitrary (FixedSize64 TokenBundle) where
-    arbitrary = FixedSize64 <$> genFixedSizeTokenBundle 64
+    arbitrary = FixedSize64 <$> genTxOutTokenBundle 64
     -- No shrinking
 
 instance Arbitrary (FixedSize128 TokenBundle) where
-    arbitrary = FixedSize128 <$> genFixedSizeTokenBundle 128
+    arbitrary = FixedSize128 <$> genTxOutTokenBundle 128
     -- No shrinking
 
 instance Arbitrary (VariableSize16 TokenBundle) where

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -84,7 +84,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), coinToInteger )
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoinPositive, shrinkCoinPositive )
 import Cardano.Wallet.Primitive.Types.Hash
@@ -661,11 +661,11 @@ feeCalculationSpec = describe "fee calculations" $ do
     fp = LinearFee (Quantity 100_000) (Quantity 100)
 
     minFee :: TransactionCtx -> Integer
-    minFee ctx = coinToInteger $ calcMinimumCost testTxLayer pp ctx sel
+    minFee ctx = Coin.toInteger $ calcMinimumCost testTxLayer pp ctx sel
       where sel = emptySkeleton
 
     minFeeSkeleton :: TxSkeleton -> Integer
-    minFeeSkeleton = coinToInteger . estimateTxCost pp
+    minFeeSkeleton = Coin.toInteger . estimateTxCost pp
 
     estimateTxSize' :: TxSkeleton -> Integer
     estimateTxSize' = fromIntegral . unTxSize . estimateTxSize

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -94,10 +94,7 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( AssetId, TokenBundle, tokenName )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
-    ( genFixedSizeTokenBundle
-    , genTokenBundleSmallRange
-    , shrinkTokenBundleSmallRange
-    )
+    ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (UnsafeTokenName), TokenPolicyId, unTokenName )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
@@ -118,6 +115,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     , txMetadataIsNull
     , txOutCoin
     )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genTxOutTokenBundle )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Shelley.Compatibility
@@ -1355,7 +1354,7 @@ newtype Large a = Large { unLarge :: a }
     deriving (Eq, Show)
 
 instance Arbitrary (Large TokenBundle) where
-    arbitrary = fmap Large . genFixedSizeTokenBundle =<< choose (1, 128)
+    arbitrary = fmap Large . genTxOutTokenBundle =<< choose (1, 128)
 
 -- Tests that if a bundle is oversized (when serialized), then a comparison
 -- between 'txOutputSize' and 'txOutputMaximumSize' should also indicate that

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -192,6 +192,7 @@
             (hsPkgs."http-client-tls" or (errorHandler.buildDepError "http-client-tls"))
             (hsPkgs."http-media" or (errorHandler.buildDepError "http-media"))
             (hsPkgs."http-types" or (errorHandler.buildDepError "http-types"))
+            (hsPkgs."int-cast" or (errorHandler.buildDepError "int-cast"))
             (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
             (hsPkgs."io-classes" or (errorHandler.buildDepError "io-classes"))
             (hsPkgs."io-sim" or (errorHandler.buildDepError "io-sim"))

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -58,6 +58,7 @@
           (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
           (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
+          (hsPkgs."int-cast" or (errorHandler.buildDepError "int-cast"))
           (hsPkgs."io-classes" or (errorHandler.buildDepError "io-classes"))
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
           (hsPkgs."memory" or (errorHandler.buildDepError "memory"))


### PR DESCRIPTION
## Issue Number

ADP-1283

## Summary

This PR:
- Redefines `Coin` in terms of `Natural` (rather than `Word64`).
- Removes the `Bounded` instance for `Coin`.
- Adds `txOut{Min,Max}Coin` constants to `Primitive.Types.Tx`, in the same style as the existing `txOut{Min,Max}TokenQuantity` constants.
- Pushes validation checks for coins that must be within a certain range to the places where those checks are actually required.

## Implementation Notes

Where possible, this PR uses `intCast` and `intCastMaybe` (instead of `fromIntegral`) to perform statically-checked integral conversations.

## Motivation

The wallet uses the `Coin` type to represent an amount of _lovelace_.

It's currently defined in terms of `Word64`, and has a `Bounded` instance that limits the range to `[0, 45_000_000_000_000_000]`.

However, this approach is problematic, for several reasons:

- Boundary checks for `Coin` values make sense in contexts where there are boundaries.  However, for pure `Coin` values in the absence of any particular context, there isn't one particular upper bound that makes sense.
- The current choice of `Bounded` specifically defines the limits of what can be included in a _transaction output_. However, encoding values that appear in transaction outputs is not the only use of the `Coin` type.
- For example, it's quite reasonable to use `Coin` for other purposes, like finding the total volume of ada transacted over some period of time. For such usages, there is no obvious choice of upper limit that we could consider “ideal”.
- Right now, we often use awkward workarounds such as casting `Coin` values to `Natural` values before computing summations, thus losing the descriptive value of using the `Coin` type to mark that “this is a quantity of lovelace”.
- Given that the default data constructor for `Coin` is exported, it’s possible to directly construct “invalid” Coin values from outside the `Coin` module.
- Using the existing `Semigroup` instance, we can combine valid `Coin` values into values that are **_invalid_**, which can lead to unexpected run-time errors when those “invalid” values are passed to functions that we believe to be safe.  💣 

For an example of the last problem, consider this:

```haskell
> :set -XNumericUnderscores
> :set -XOverloadedLists
> import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
> coinA = Coin 45_000_000_000_000_000
> coinB = coinA <> coinA
> coinB
Coin 90000000000000000
> Coin.equipartition coinB [()]
*** Exception: unsafeNaturalToCoin: overflow
CallStack (from HasCallStack):
  error, called at /home/jsk/projects/input-output-hk/cardano-wallet-master/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs:131:37 in main:Cardano.Wallet.Primitive.Types.Coin
```