### PR TITLE
Fix wallet state transition functions to properly account for script validation failures.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -469,15 +469,6 @@ prefilterBlock b u0 = runState $ do
     (transactions, ourU) <- foldM applyOurTx (mempty, u0) (b ^. #transactions)
     return (FilteredBlock {delegations, transactions}, ourU)
   where
-    mkTxMeta :: Coin -> Direction -> TxMeta
-    mkTxMeta amount dir = TxMeta
-        { status = InLedger
-        , direction = dir
-        , slotNo = b ^. #header . #slotNo
-        , blockHeight = b ^. #header . #blockHeight
-        , amount = amount
-        , expiry = Nothing
-        }
     applyOurTx
         :: (IsOurs s Address, IsOurs s RewardAccount)
         => ([(Tx, TxMeta)], UTxO)
@@ -578,6 +569,16 @@ prefilterBlock b u0 = runState $ do
                 )
         else
             Nothing
+      where
+        mkTxMeta :: Coin -> Direction -> TxMeta
+        mkTxMeta amount dir = TxMeta
+            { status = InLedger
+            , direction = dir
+            , slotNo = b ^. #header . #slotNo
+            , blockHeight = b ^. #header . #blockHeight
+            , amount = amount
+            , expiry = Nothing
+            }
 
 -- | Get the change UTxO
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -542,6 +542,16 @@ applyBlockToUTxO b u0 = runState $ do
     slotNo = b ^. #header . #slotNo
     blockHeight = b ^. #header . #blockHeight
 
+-- | Applies the given transaction if it is relevant to the wallet.
+--
+-- This function returns a result if (and only if) the given transaction is
+-- relevant to the wallet.
+--
+-- It satisfies the following property:
+--
+-- >> isJust (flip evalState state (applyOurTxToUTxO slot bh tx u))
+-- >>     == (flip evalState state (   isOurTx               tx u))
+--
 applyOurTxToUTxO
     :: (IsOurs s Address, IsOurs s RewardAccount)
     => SlotNo

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -544,20 +544,17 @@ applyOurTxToUTxO !slotNo !blockHeight !tx !prevUTxO = do
     -- do make the assumption that if one input is ours, then all inputs are
     -- necessarily ours and therefore, known as part of our current UTxO.
     let actualFee direction = case (tx ^. #fee, direction) of
-            (Just x, Outgoing) -> -- Shelley and beyond.
+            (Just x, Outgoing) ->
+                -- Shelley and beyond:
                 Just x
-
-            (Nothing, Outgoing) -> -- Byron
-                let
-                    totalOut = F.fold (txOutCoin <$> outputs tx)
-
+            (Nothing, Outgoing) ->
+                -- Byron:
+                let totalOut = F.fold (txOutCoin <$> outputs tx)
                     totalIn = TB.getCoin spent
                 in
-                    Just $ distance totalIn totalOut
-
+                Just $ distance totalIn totalOut
             (_, Incoming) ->
                 Nothing
-
     return $ if hasKnownOutput && not hasKnownInput then
         let dir = Incoming in
         Just
@@ -567,8 +564,7 @@ applyOurTxToUTxO !slotNo !blockHeight !tx !prevUTxO = do
             , ourNextUTxO
             )
     else if hasKnownInput || hasKnownWithdrawal then
-        let
-            adaSpent = TB.getCoin spent
+        let adaSpent = TB.getCoin spent
             adaReceived = TB.getCoin received
             dir = if adaSpent > adaReceived then Outgoing else Incoming
             amount = distance adaSpent adaReceived

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -408,6 +408,15 @@ isOurAddress
     -> StateT s m Bool
 isOurAddress = fmap isJust . state . isOurs
 
+ourDelegation
+    :: IsOurs s RewardAccount
+    => DelegationCertificate
+    -> State s (Maybe DelegationCertificate)
+ourDelegation cert =
+    state (isOurs $ dlgCertAccount cert) <&> \case
+        Nothing -> Nothing
+        Just{}  -> Just cert
+
 ourWithdrawal
     :: IsOurs s RewardAccount
     => (RewardAccount, Coin)
@@ -453,14 +462,6 @@ prefilterBlock b u0 = runState $ do
     (transactions, ourU) <- foldM applyTx (mempty, u0) (b ^. #transactions)
     return (FilteredBlock {delegations, transactions}, ourU)
   where
-    ourDelegation
-        :: IsOurs s RewardAccount
-        => DelegationCertificate
-        -> State s (Maybe DelegationCertificate)
-    ourDelegation cert =
-        state (isOurs $ dlgCertAccount cert) <&> \case
-            Nothing -> Nothing
-            Just{}  -> Just cert
     mkTxMeta :: Coin -> Direction -> TxMeta
     mkTxMeta amount dir = TxMeta
         { status = InLedger

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -426,6 +426,13 @@ ourWithdrawal (acct, amt) =
         Nothing -> Nothing
         Just{}  -> Just (acct, amt)
 
+ourWithdrawalSumFromTx
+    :: IsOurs s RewardAccount
+    => Tx
+    -> State s Coin
+ourWithdrawalSumFromTx tx = F.foldMap snd <$>
+    mapMaybeM ourWithdrawal (Map.toList $ withdrawals tx)
+
 {-------------------------------------------------------------------------------
                                Internals
 -------------------------------------------------------------------------------}
@@ -483,8 +490,7 @@ prefilterBlock b u0 = runState $ do
             (spendTx tx prevUTxO <>)
             <$> filterByAddressM isOurAddress (utxoFromTx tx)
 
-        ourWithdrawalSum :: Coin <- F.foldMap snd <$>
-            mapMaybeM ourWithdrawal (Map.toList $ withdrawals tx)
+        ourWithdrawalSum <- ourWithdrawalSumFromTx tx
 
         let received = balance (ourNextUTxO `excluding` dom prevUTxO)
         let spent =

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -481,13 +481,13 @@ prefilterBlock b u0 = runState $ do
             (spendTx tx prevUTxO <>)
             <$> filterByAddressM isOurAddress (utxoFromTx tx)
 
-        ourWithdrawals :: Coin <- F.foldMap snd <$>
+        ourWithdrawalSum :: Coin <- F.foldMap snd <$>
             mapMaybeM ourWithdrawal (Map.toList $ withdrawals tx)
 
         let received = balance (ourNextUTxO `excluding` dom prevUTxO)
         let spent =
                 balance (prevUTxO `excluding` dom ourNextUTxO)
-                `TB.add` TB.fromCoin ourWithdrawals
+                `TB.add` TB.fromCoin ourWithdrawalSum
 
         (ownedAndKnownTxIns, ownedAndKnownTxOuts) <- do
             -- A new transaction expands the set of transaction inputs/outputs
@@ -516,7 +516,7 @@ prefilterBlock b u0 = runState $ do
         let hasKnownOutput = not $ Set.disjoint
                 (Set.fromList $ outputs tx)
                 (Set.fromList ownedAndKnownTxOuts)
-        let hasKnownWithdrawal = ourWithdrawals /= mempty
+        let hasKnownWithdrawal = ourWithdrawalSum /= mempty
 
         -- NOTE 1: The only case where fees can be 'Nothing' is when dealing with
         -- a Byron transaction. In which case fees can actually be calculated as

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -408,6 +408,15 @@ isOurAddress
     -> StateT s m Bool
 isOurAddress = fmap isJust . state . isOurs
 
+ourWithdrawal
+    :: IsOurs s RewardAccount
+    => (RewardAccount, Coin)
+    -> State s (Maybe (RewardAccount, Coin))
+ourWithdrawal (acct, amt) =
+    state (isOurs acct) <&> \case
+        Nothing -> Nothing
+        Just{}  -> Just (acct, amt)
+
 {-------------------------------------------------------------------------------
                                Internals
 -------------------------------------------------------------------------------}
@@ -452,14 +461,6 @@ prefilterBlock b u0 = runState $ do
         state (isOurs $ dlgCertAccount cert) <&> \case
             Nothing -> Nothing
             Just{}  -> Just cert
-    ourWithdrawal
-        :: IsOurs s RewardAccount
-        => (RewardAccount, Coin)
-        -> State s (Maybe (RewardAccount, Coin))
-    ourWithdrawal (acct, amt) =
-        state (isOurs acct) <&> \case
-            Nothing -> Nothing
-            Just{}  -> Just (acct, amt)
     mkTxMeta :: Coin -> Direction -> TxMeta
     mkTxMeta amount dir = TxMeta
         { status = InLedger

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -42,6 +42,7 @@ module Cardano.Wallet.Primitive.Model
     , applyBlocks
     , unsafeInitWallet
     , applyTxToUTxO
+    , applyOurTxToUTxO
     , utxoFromTx
     , spendTx
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -481,7 +481,7 @@ prefilterBlock b u0 = runState $ do
             (spendTx tx prevUTxO <>)
             <$> filterByAddressM isOurAddress (utxoFromTx tx)
 
-        ourWithdrawals <- Coin . sum . fmap (unCoin . snd) <$>
+        ourWithdrawals :: Coin <- F.foldMap snd <$>
             mapMaybeM ourWithdrawal (Map.toList $ withdrawals tx)
 
         let received = balance (ourNextUTxO `excluding` dom prevUTxO)

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -93,7 +93,7 @@ import Control.Monad
 import Control.Monad.Extra
     ( mapMaybeM )
 import Control.Monad.Trans.State.Strict
-    ( State, StateT, evalState, runState, state )
+    ( State, evalState, runState, state )
 import Data.Functor
     ( (<&>) )
 import Data.Generics.Internal.VL.Lens
@@ -407,10 +407,9 @@ utxoFromUnvalidatedTx Tx {txId, outputs} =
     UTxO $ Map.fromList $ zip (TxIn txId <$> [0..]) outputs
 
 isOurAddress
-    :: forall s m
-     . (Monad m, IsOurs s Address)
+    :: IsOurs s Address
     => Address
-    -> StateT s m Bool
+    -> State s Bool
 isOurAddress = fmap isJust . state . isOurs
 
 ourDelegation

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -112,7 +112,7 @@ import Data.List
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
-    ( catMaybes, isJust, isNothing )
+    ( catMaybes, isJust )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Set
@@ -695,10 +695,8 @@ prop_applyTxToUTxO_applyOurTxToUTxO_AllOurs
     -> Property
 prop_applyTxToUTxO_applyOurTxToUTxO_AllOurs slotNo blockHeight tx utxo =
     checkCoverage $
-    cover 50 (isJust maybeUpdatedUTxO)
-        "isJust " $
-    cover 0.1 (isNothing maybeUpdatedUTxO)
-        "isNothing" $
+    cover 50  (    haveResult)        "have result" $
+    cover 0.1 (not haveResult) "do not have result" $
     report
         (utxo)
         "utxo" $
@@ -706,36 +704,36 @@ prop_applyTxToUTxO_applyOurTxToUTxO_AllOurs slotNo blockHeight tx utxo =
         (utxoFromTx tx)
         "utxoFromTx tx" $
     report
-        (haveUpdatedUTxO)
-        "haveUpdatedUTxO" $
+        (haveResult)
+        "haveResult" $
     report
-        (shouldHaveUpdatedUTxO)
-        "shouldHaveUpdatedUTxO" $
-    case maybeUpdatedUTxO of
+        (shouldHaveResult)
+        "shouldHaveResult" $
+    case maybeResult of
         Nothing ->
             verify
-                (not shouldHaveUpdatedUTxO)
-                "not shouldHaveUpdatedUTxO" $
+                (not shouldHaveResult)
+                "not shouldHaveResult" $
             property True
         Just utxo' ->
             cover 10 (utxo /= utxo')
                 "utxo /= utxo'" $
             verify
-                (shouldHaveUpdatedUTxO)
-                "shouldHaveUpdatedUTxO" $
+                (shouldHaveResult)
+                "shouldHaveResult" $
             verify
                 (utxo' == applyTxToUTxO tx utxo)
                 "utxo' == applyTxToUTxO tx utxo" $
             property True
   where
-    maybeUpdatedUTxO :: Maybe UTxO
-    maybeUpdatedUTxO = snd <$> evalState
+    haveResult :: Bool
+    haveResult = isJust maybeResult
+    maybeResult :: Maybe UTxO
+    maybeResult = snd <$> evalState
         (applyOurTxToUTxO slotNo blockHeight tx utxo)
         (AllOurs)
-    haveUpdatedUTxO :: Bool
-    haveUpdatedUTxO = isJust maybeUpdatedUTxO
-    shouldHaveUpdatedUTxO :: Bool
-    shouldHaveUpdatedUTxO = evalState (isOurTx tx utxo) AllOurs
+    shouldHaveResult :: Bool
+    shouldHaveResult = evalState (isOurTx tx utxo) AllOurs
 
 {-------------------------------------------------------------------------------
                Basic Model - See Wallet Specification, section 3


### PR DESCRIPTION
## Issue Number

ADP-1039

## Summary

This PR:

- breaks up wallet state transition functions into smaller functions for easier testing.
- adds function `isOurTx`, which returns `True` if and only if a transaction is relevant to the wallet.
- adjusts the withdrawal sum computation within `applyOurTxToUTxO` to correctly account for script validation failure.
- adds a property test for `applyOurTxToUTxO` that relates it to `isOurTx` and `applyTxToUTxO`.
- fixes the termination logic of `applyOurTxToUTxO` so that it returns a result only when appropriate.