### PR TITLE
Adjust type of `TokenQuantity.pred` so that it is a total function.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
@@ -15,6 +15,7 @@ module Cardano.Wallet.Primitive.Types.TokenQuantity
     , add
     , subtract
     , pred
+    , predZero
     , succ
     , difference
 
@@ -131,6 +132,17 @@ subtract x y = guard (x >= y) $> unsafeSubtract x y
 --
 pred :: TokenQuantity -> Maybe TokenQuantity
 pred = (`subtract` TokenQuantity 1)
+
+-- | Finds the predecessor of a given token quantity.
+--
+-- Returns 'zero' if the given quantity is 'zero'.
+--
+-- Satisfies the following property:
+--
+-- >>> predZero x == x `difference` 1
+--
+predZero :: TokenQuantity -> TokenQuantity
+predZero = fromMaybe zero . pred
 
 -- | Finds the successor of a given token quantity.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
@@ -61,8 +61,6 @@ import Numeric.Natural
 import Quiet
     ( Quiet (..) )
 
-import qualified Prelude
-
 --------------------------------------------------------------------------------
 -- Type
 --------------------------------------------------------------------------------
@@ -127,11 +125,17 @@ add (TokenQuantity x) (TokenQuantity y) = TokenQuantity $ x + y
 subtract :: TokenQuantity -> TokenQuantity -> Maybe TokenQuantity
 subtract x y = guard (x >= y) $> unsafeSubtract x y
 
-pred :: TokenQuantity -> TokenQuantity
-pred (TokenQuantity q) = TokenQuantity $ Prelude.pred q
+-- | Finds the predecessor of a given token quantity.
+--
+-- Returns 'Nothing' if the given quantity is zero.
+--
+pred :: TokenQuantity -> Maybe TokenQuantity
+pred = (`subtract` TokenQuantity 1)
 
+-- | Finds the successor of a given token quantity.
+--
 succ :: TokenQuantity -> TokenQuantity
-succ (TokenQuantity q) = TokenQuantity $ Prelude.succ q
+succ = (`add` TokenQuantity 1)
 
 -- | Subtracts the second token quantity from the first.
 --

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -1712,7 +1712,10 @@ boundaryTest_largeTokenQuantities_1 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    (q1, q2) = (TokenQuantity 1, TokenQuantity.pred txOutMaxTokenQuantity)
+    (q1, q2) =
+        ( TokenQuantity 1
+        , TokenQuantity.difference txOutMaxTokenQuantity (TokenQuantity 1)
+        )
     boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -1712,10 +1712,7 @@ boundaryTest_largeTokenQuantities_1 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    (q1, q2) =
-        ( TokenQuantity 1
-        , TokenQuantity.difference txOutMaxTokenQuantity (TokenQuantity 1)
-        )
+    (q1, q2) = (TokenQuantity 1, TokenQuantity.predZero txOutMaxTokenQuantity)
     boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -57,7 +57,7 @@ import Data.Function
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
-    ( mapMaybe )
+    ( fromMaybe, mapMaybe )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Ratio
@@ -362,9 +362,7 @@ prop_adjustQuantity_invariant :: TokenMap -> AssetId -> Property
 prop_adjustQuantity_invariant b asset = property $
     invariantHolds $ TokenMap.adjustQuantity b asset adjust
   where
-    adjust quantity
-        | quantity > TokenQuantity.zero = TokenQuantity.pred quantity
-        | otherwise = quantity
+    adjust = fromMaybe TokenQuantity.zero . TokenQuantity.pred
 
 --------------------------------------------------------------------------------
 -- Construction and deconstruction properties
@@ -650,9 +648,7 @@ prop_adjustQuantity_getQuantity b asset =
         === adjust quantityOriginal
   where
     quantityOriginal = TokenMap.getQuantity b asset
-    adjust quantity
-        | quantity > TokenQuantity.zero = TokenQuantity.pred quantity
-        | otherwise = quantity
+    adjust = fromMaybe TokenQuantity.zero . TokenQuantity.pred
 
 prop_adjustQuantity_hasQuantity
     :: TokenMap -> AssetId -> Property
@@ -661,9 +657,7 @@ prop_adjustQuantity_hasQuantity b asset =
         === TokenQuantity.isNonZero (adjust quantityOriginal)
   where
     quantityOriginal = TokenMap.getQuantity b asset
-    adjust quantity
-        | quantity > TokenQuantity.zero = TokenQuantity.pred quantity
-        | otherwise = quantity
+    adjust = fromMaybe TokenQuantity.zero . TokenQuantity.pred
 
 prop_maximumQuantity_all
     :: TokenMap -> Property

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -57,7 +57,7 @@ import Data.Function
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
-    ( fromMaybe, mapMaybe )
+    ( mapMaybe )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Ratio
@@ -360,9 +360,7 @@ prop_setQuantity_invariant b asset quantity = property $
 
 prop_adjustQuantity_invariant :: TokenMap -> AssetId -> Property
 prop_adjustQuantity_invariant b asset = property $
-    invariantHolds $ TokenMap.adjustQuantity b asset adjust
-  where
-    adjust = fromMaybe TokenQuantity.zero . TokenQuantity.pred
+    invariantHolds $ TokenMap.adjustQuantity b asset TokenQuantity.predZero
 
 --------------------------------------------------------------------------------
 -- Construction and deconstruction properties
@@ -648,7 +646,7 @@ prop_adjustQuantity_getQuantity b asset =
         === adjust quantityOriginal
   where
     quantityOriginal = TokenMap.getQuantity b asset
-    adjust = fromMaybe TokenQuantity.zero . TokenQuantity.pred
+    adjust = TokenQuantity.predZero
 
 prop_adjustQuantity_hasQuantity
     :: TokenMap -> AssetId -> Property
@@ -657,7 +655,7 @@ prop_adjustQuantity_hasQuantity b asset =
         === TokenQuantity.isNonZero (adjust quantityOriginal)
   where
     quantityOriginal = TokenMap.getQuantity b asset
-    adjust = fromMaybe TokenQuantity.zero . TokenQuantity.pred
+    adjust = TokenQuantity.predZero
 
 prop_maximumQuantity_all
     :: TokenMap -> Property

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenQuantitySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenQuantitySpec.hs
@@ -114,11 +114,11 @@ spec =
 
 prop_pred_succ :: TokenQuantity -> Property
 prop_pred_succ q = q > TokenQuantity.zero ==>
-    TokenQuantity.succ (TokenQuantity.pred q) === q
+    (TokenQuantity.succ <$> TokenQuantity.pred q) === Just q
 
 prop_succ_pred :: TokenQuantity -> Property
 prop_succ_pred q =
-    TokenQuantity.pred (TokenQuantity.succ q) === q
+    TokenQuantity.pred (TokenQuantity.succ q) === Just q
 
 prop_difference_zero :: TokenQuantity -> Property
 prop_difference_zero x =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenQuantitySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenQuantitySpec.hs
@@ -35,8 +35,10 @@ import Test.Hspec.Extra
 import Test.QuickCheck
     ( Arbitrary (..)
     , Property
+    , checkCoverage
     , conjoin
     , counterexample
+    , cover
     , property
     , (===)
     , (==>)
@@ -83,6 +85,12 @@ spec =
             property prop_pred_succ
         it "prop_succ_pred" $
             property prop_succ_pred
+        it "prop_succ_predZero" $
+            property prop_succ_predZero
+        it "prop_predZero_difference" $
+            property prop_predZero_difference
+        it "prop_predZero_pred" $
+            property prop_predZero_pred
         it "prop_difference_zero (x - 0 = x)" $
             property prop_difference_zero
         it "prop_difference_zero2 (0 - x = 0)" $
@@ -119,6 +127,26 @@ prop_pred_succ q = q > TokenQuantity.zero ==>
 prop_succ_pred :: TokenQuantity -> Property
 prop_succ_pred q =
     TokenQuantity.pred (TokenQuantity.succ q) === Just q
+
+prop_succ_predZero :: TokenQuantity -> Property
+prop_succ_predZero q =
+    TokenQuantity.predZero (TokenQuantity.succ q) === q
+
+prop_predZero_difference :: TokenQuantity -> Property
+prop_predZero_difference q =
+    checkCoverage $
+    cover  1 (q == TokenQuantity 0) "q == 0" $
+    cover 10 (q >= TokenQuantity 1) "q >= 1" $
+    TokenQuantity.predZero q === q `TokenQuantity.difference` TokenQuantity 1
+
+prop_predZero_pred :: TokenQuantity -> Property
+prop_predZero_pred q =
+    checkCoverage $
+    cover  1 (q == TokenQuantity 0) "q == 0" $
+    cover 10 (q >= TokenQuantity 1) "q >= 1" $
+    if q == TokenQuantity.zero
+    then TokenQuantity.predZero q === TokenQuantity.zero
+    else Just (TokenQuantity.predZero q) === TokenQuantity.pred q
 
 prop_difference_zero :: TokenQuantity -> Property
 prop_difference_zero x =


### PR DESCRIPTION
## Issue number

None. (Developed while working on other unrelated things.)

## Summary

This PR:

- [x] fixes `TokenQuantity.pred` so that it is a total function, returning `Nothing` when applied to `TokenQuantity 0`.
- [x] adds the function `predZero`, which returns:
    - `0` when `pred` returns `Nothing`;
    - `x` when `pred` returns `Just x`.
- [x] uses `predZero` to simplify various tests.

