### PR TITLE
Improve test coverage of `applyOurTxToUTxO`.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types/RewardAccount/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/RewardAccount/Gen.hs
@@ -1,5 +1,6 @@
 module Cardano.Wallet.Primitive.Types.RewardAccount.Gen
-    ( genRewardAccount
+    ( coarbitraryRewardAccount
+    , genRewardAccount
     , shrinkRewardAccount
     )
     where
@@ -9,13 +10,17 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Test.QuickCheck
-    ( Gen, elements, sized )
+    ( Gen, coarbitrary, elements, sized )
 
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 
 --------------------------------------------------------------------------------
 -- Reward accounts generated according to the size parameter
 --------------------------------------------------------------------------------
+
+coarbitraryRewardAccount :: RewardAccount -> Gen a -> Gen a
+coarbitraryRewardAccount = coarbitrary . BS.unpack . unRewardAccount
 
 genRewardAccount :: Gen (RewardAccount)
 genRewardAccount = sized $ \size -> elements $ take (max 1 size) addresses

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -554,6 +554,15 @@ prop_changeUTxO_inner pendingTxs =
 -- Matching entities with 'IsOurs'
 --------------------------------------------------------------------------------
 
+-- | A simplified wallet state that marks all entities as "ours".
+--
+data AllOurs = AllOurs
+
+instance IsOurs AllOurs a where
+    isOurs _ s = (Just shouldNotEvaluate, s)
+      where
+        shouldNotEvaluate = error "AllOurs: unexpected evaluation"
+
 -- | Encapsulates a filter condition for matching entities with 'IsOurs'.
 --
 newtype IsOursIf a = IsOursIf {condition :: a -> Bool}
@@ -707,15 +716,6 @@ prop_totalUTxO makeProperty =
 --------------------------------------------------------------------------------
 -- Applying transactions to UTxO sets
 --------------------------------------------------------------------------------
-
--- | A simplified wallet state that marks all entities as "ours".
---
-data AllOurs = AllOurs
-
-instance IsOurs AllOurs a where
-    isOurs _ s = (Just shouldNotEvaluate, s)
-      where
-        shouldNotEvaluate = error "AllOurs: unexpected evaluation"
 
 -- Verifies that 'applyOurTxToUTxO' updates the UTxO set in an identical
 -- way to 'applyTxToUTxO' in the case that all entities are marked as ours.


### PR DESCRIPTION
## Issue Number

ADP-1039

## Summary

This PR improves  test coverage of the `applyOurTxToUTxO` function.

## Background

The **_existing property_** `prop_applyOurTxToUTxO_allOurs` tests `applyOurTxToUTxO` in a context where **_all_** addresses and reward accounts are identified as "ours". In this context, we can assert that `applyOurTxToUTxO` returns a an updated `UTxO` set that is **_identical_** to `applyTxToUTxO`.

## Details

This PR adds a **_new property_** `prop_applyOurTxToUTxO_someOurs` that is similar to the above property, except that **_only some_** `Address` and `RewardAccount` values are marked as "ours". In this context we can **_no longer_** assert any equivalence between `applyOurTxToUTxO` and `applyTxToUTxO`, but we **_can_** assert that `applyOurTxToUTxO` only returns a result when `isOurTx` returns `True`.