### PR TITLE
Restrict `Checkpoints` to be constructible from genesis only

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/CheckpointsOld.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/CheckpointsOld.hs
@@ -37,7 +37,12 @@ import Cardano.Address.Script
 import Cardano.DB.Sqlite
     ( dbChunked )
 import Cardano.Wallet.DB.Checkpoints
-    ( Checkpoints (..), DeltaCheckpoints (..), DeltaMap (..), getPoint )
+    ( Checkpoints (..)
+    , DeltaCheckpoints (..)
+    , DeltaMap (..)
+    , getPoint
+    , loadCheckpoints
+    )
 import Cardano.Wallet.DB.Sqlite.TH
     ( Checkpoint (..)
     , CosignerKey (..)
@@ -187,10 +192,9 @@ mkStoreCheckpoints wid =
   where
     load = do
         cps <- selectAllCheckpoints wid
-        pure $ Right $ Checkpoints{ checkpoints = Map.fromList cps }
+        pure $ Right $ loadCheckpoints cps
 
-    write Checkpoints{checkpoints} =
-        forM_ (Map.toList checkpoints) $ \(pt,cp) ->
+    write cps = forM_ (Map.toList $ checkpoints cps) $ \(pt,cp) ->
             update (PutCheckpoint pt cp)
 
     update (PutCheckpoint _ state) =


### PR DESCRIPTION
### Issue number

ADP-1043

### Overview

Previous work in epic ADP-1043 introduced delta encodings, DBVars, and an embedding of the wallet state and its delta encodings into a database table. It's time to integrate these tools with the wallet code. To facilitate code review, the integration proceeds in a sequence of refactorings that do not change functionality and pass all unit tests.

In this step, we implement a suggestion that came up during review where we remove the `singleton` function in favor of `fromGenesis`, making sure that the `Checkpoints` structure always contains a checkpoint for the genesis block.

### Details

* The `initializeWallet` function will now throw an exception if it is incorrectly called with a checkpoint that is not at the genesis block.
* Many unit tests are adapted to use the `InitialCheckpoint` generator in order to comply with the above restriction.

### Comments

Merge PR #3046 before this one, because this pull request is based on the branch of the former.
