### PR TITLE
Increase timeout for node to spin up in e2e tests

### DIFF
--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -86,7 +86,7 @@ task :wait_until_node_synced do
   puts "\n  >> Waiting for node to be synced"
 
   network = CardanoWallet.new.misc.network
-  timeout = 180
+  timeout = 600
   current_time = Time.now
   timeout_treshold = current_time + timeout
   puts "Timeout: #{timeout}s"


### PR DESCRIPTION

- [x] I have increased timeout to 600s

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
