### PR TITLE
Make restore benchmark slimmer

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -375,8 +375,8 @@ instance NFData (RndAnyState n p)
 -- seed.
 --
 -- The type parameter is expected to be a ratio of addresses we ought to simply
--- recognize as ours. It is expressed in tenths of percent, so "1" means 0.1%,
--- "10" means 1% and 1000 means 100%.
+-- recognize as ours. It is expressed in per-myriad, so "1" means 0.01%,
+-- "100" means 1% and 10000 means 100%.
 mkRndAnyState
     :: forall (p :: Nat) n. ()
     => ByronKey 'RootK XPrv
@@ -427,7 +427,7 @@ instance KnownNat p => IsOurs (RndAnyState n p) Address where
             (Nothing, _) ->
                 (Nothing, st)
       where
-        p = floor (double (maxBound :: Word32) * double (natVal (Proxy @p)) / 1000)
+        p = floor (double (maxBound :: Word32) * double (natVal (Proxy @p)) / 10000)
 
         double :: Integral a => a -> Double
         double = fromIntegral

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -917,8 +917,8 @@ instance
 -- seed.
 --
 -- The type parameter is expected to be a ratio of addresses we ought to simply
--- recognize as ours. It is expressed in tenths of percent, so "1" means 0.1%,
--- "10" means 1% and 1000 means 100%.
+-- recognize as ours. It is expressed in per-myriad, so "1" means 0.01%,
+-- "100" means 1% and 10000 means 100%.
 mkSeqAnyState
     :: forall (p :: Nat) n k.
         ( SoftDerivation k
@@ -957,7 +957,7 @@ instance
         | otherwise =
             (Nothing, st)
       where
-        p = floor (double sup * double (natVal (Proxy @p)) / 1000)
+        p = floor (double sup * double (natVal (Proxy @p)) / 10000)
           where
             sup = maxBound :: Word32
 

--- a/lib/shelley/bench/restore-bench.hs
+++ b/lib/shelley/bench/restore-bench.hs
@@ -195,7 +195,7 @@ import GHC.Generics
 import GHC.TypeLits
     ( KnownNat, Nat, natVal )
 import Numeric
-    ( showFFloat )
+    ( fromRat, showFFloat )
 import Say
     ( sayErr )
 import System.Exit
@@ -838,15 +838,22 @@ instance NetworkDiscriminantVal n => ToText (BenchmarkLog n) where
 --
 -- >>> showPercentFromPermyriad (Proxy @0)
 -- "0"
+--
+-- Unfortunately we have:
+--
+-- >>> showPercentFromPermyriad (Proxy @10)
+-- "0.10"
+--
+-- rather than "0.1", but we'll have to live with it.
 showPercentFromPermyriad :: forall (p :: Nat) . KnownNat p => Proxy p -> Text
 showPercentFromPermyriad =
-    T.pack . display . (/100) . fromRational . toRational . natVal
+    T.pack . display . (/100) . toRational . natVal
   where
-    -- I cannot find a haskell way to format a rational with a /minimum/ number
-    -- of decimals, so this will do.
-    display :: Double -> String
+    -- I cannot find a haskell way to format a rational with as few decimals as
+    -- possible, so this will have to do:
+    display :: Rational -> String
     display 0 = "0"
-    display x = show x
+    display x = showFFloat @Double (Just 2) (fromRat x) ""
 
 sTol :: SyncTolerance
 sTol = mkSyncTolerance 3600

--- a/lib/shelley/bench/restore-bench.hs
+++ b/lib/shelley/bench/restore-bench.hs
@@ -272,7 +272,7 @@ cardanoRestoreBench tr c socketFile = do
                 benchmarksSeq
 
     let benchRestoreRndWithOwnership p = do
-            let benchname = showPercentFromPermille p <> "-percent-rnd"
+            let benchname = showPercentFromPermyriad p <> "-percent-rnd"
             bench_restoration
                 networkProxy
                 (trMessageText tr)
@@ -288,7 +288,7 @@ cardanoRestoreBench tr c socketFile = do
                 benchmarksRnd
 
     let benchRestoreSeqWithOwnership p = do
-            let benchname = showPercentFromPermille p <> "-percent-seq"
+            let benchname = showPercentFromPermyriad p <> "-percent-seq"
             bench_restoration
                 networkProxy
                 (trMessageText tr)
@@ -309,16 +309,11 @@ cardanoRestoreBench tr c socketFile = do
           -- to-100% time.
           benchRestoreMultipleWallets 1 (unsafeMkPercentage 0.1)
         , benchRestoreMultipleWallets 10 (unsafeMkPercentage 0.01)
-        , benchRestoreMultipleWallets 20 (unsafeMkPercentage 0.01)
-        , benchRestoreMultipleWallets 40 (unsafeMkPercentage 0.01)
-        , benchRestoreMultipleWallets 80 (unsafeMkPercentage 0.01)
         , benchRestoreMultipleWallets 100 (unsafeMkPercentage 0.01)
 
         , benchRestoreSeqWithOwnership (Proxy @0)
-        , benchRestoreSeqWithOwnership (Proxy @2)
-
-        , benchRestoreRndWithOwnership (Proxy @0)
-        , benchRestoreRndWithOwnership (Proxy @2)
+        , benchRestoreSeqWithOwnership (Proxy @1)
+        , benchRestoreRndWithOwnership (Proxy @1)
         ]
   where
     walletRnd
@@ -836,16 +831,16 @@ instance NetworkDiscriminantVal n => ToText (BenchmarkLog n) where
             "Fetching tip failed, retrying in " +|| (delay `div` 1000) ||+ "ms"
 
 
--- | Format a type-level per-mille number as percent
+-- | Format a type-level per-myriad number as percent
 --
--- >>> showPercentFromPermille (Proxy @1)
--- "0.1"
+-- >>> showPercentFromPermyriad (Proxy @1)
+-- "0.01"
 --
--- >>> showPercentFromPermille (Proxy @0)
+-- >>> showPercentFromPermyriad (Proxy @0)
 -- "0"
-showPercentFromPermille :: forall (p :: Nat) . KnownNat p => Proxy p -> Text
-showPercentFromPermille =
-    T.pack . display . (/10) . fromRational . toRational . natVal
+showPercentFromPermyriad :: forall (p :: Nat) . KnownNat p => Proxy p -> Text
+showPercentFromPermyriad =
+    T.pack . display . (/100) . fromRational . toRational . natVal
   where
     -- I cannot find a haskell way to format a rational with a /minimum/ number
     -- of decimals, so this will do.


### PR DESCRIPTION
To avoid timeouts, remove as much of the benchmarks we can.

### Comments

Let's see if this works:
- 0.1% https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1177 🔴 
- 0.01% (name in logs wrong; later fixed) https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1179 🟢 
- 0.01% https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1181#98793ee0-8d3d-4f88-a924-f314069ba47b 🟢 
- [x] TODO: Seems the percentages are shown in scientific notation in the file names now. Should fix `showPercentageAsPermyriad`
- https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1186#db0958bc-d2db-4f9f-bfc8-59cd0c15e964 -> not yet finished

cc @piotr-iohk 

### Issue Number

Don't think there is one.

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
