### PR TITLE
Retry connection to node on MuxSDU*Timeout error

### DIFF
--- a/lib/core/src/UnliftIO/Compat.hs
+++ b/lib/core/src/UnliftIO/Compat.hs
@@ -33,15 +33,15 @@ import qualified Control.Monad.Catch as Exceptions
 import qualified UnliftIO.Exception as UnliftIO
 
 -- | Convert the generalized handler from 'UnliftIO.Exception' type to 'Control.Monad.Catch' type
-coerceHandler :: UnliftIO.Handler IO Bool -> Exceptions.Handler IO Bool
+coerceHandler :: UnliftIO.Handler IO b -> Exceptions.Handler IO b
 coerceHandler (UnliftIO.Handler h) = Exceptions.Handler h
 
 -- | Convert a list of handler factories from the 'UnliftIO.Exception' type to
 -- 'Control.Monad.Catch' type. Such handlers are used in
 -- 'Control.Retry.Recovering' for example.
 coerceHandlers
-    :: [a -> UnliftIO.Handler IO Bool]
-    -> [a -> Exceptions.Handler IO Bool]
+    :: [a -> UnliftIO.Handler IO b]
+    -> [a -> Exceptions.Handler IO b]
 coerceHandlers = map (coerceHandler .)
 
 -- | Shortcut for creating a single 'Control.Retry' handler, which doesn't use


### PR DESCRIPTION
### Issue number

ADP-1301

### Overview

This pull request fixes an issue where a wallet would lose the connection to its local node due to a `MuxSDUReadTimeout`.

### Details

A `MuxSDUReadTimeout` or `MuxSDUWriteTimeout` is thrown when the bandwidth of the node-to-client inter-process communication (IPC) has deteriorated unexpectedly. Specifially, the ouroboros-network code will close the IPC socket if it did not yield data after a 30 second timeout ([sduTimeout](https://github.com/input-output-hk/ouroboros-network/blob/b947cb89561066958af859c733a26ecddd139c68/ouroboros-network-framework/src/Ouroboros/Network/ConnectionHandler.hs#L62-L77)).

Chances are that the system is just overloaded and wasn't able to handle the data going through the socket connection in a timely manner. It make sense for the wallet to reconnect its local node after a delay. To give the system a chance to catch up, it also seems reasonable to choose this delay to be of the same order of magnitude as the original timeout; here we specifically choose 30 seconds.

### Comments

As the issue likely involves system overload, I do not know how to test this in an automated fashion.
