### PR TITLE
Fix broken build from cardano-ledger-specs repo renaming

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -116,7 +116,7 @@ source-repository-package
 
 source-repository-package
     type: git
-    location: https://github.com/input-output-hk/cardano-ledger-specs
+    location: https://github.com/input-output-hk/cardano-ledger
     tag: f827a4321e42f528e25f6079f7af3eb18f10d391
     subdir: alonzo/impl
             byron/chain/executable-spec

--- a/docs/developers/Resources.md
+++ b/docs/developers/Resources.md
@@ -14,12 +14,12 @@
 - Low-Level Specifications
   - [[Byron] On-Chain Binary Formats](https://github.com/input-output-hk/cardano-sl/blob/master/docs/on-the-wire/current-spec.cddl)
   - [[Shelley] Network Binary Formats - Draft](https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-network/test/messages.cddl)
-  - [[Shelley] On chain Binary formats - Draft](https://github.com/input-output-hk/cardano-ledger-specs/blob/master/shelley/chain-and-ledger/cddl-spec/shelley.cddl#L32)
+  - [[Shelley] On chain Binary formats - Draft](https://github.com/input-output-hk/cardano-ledger/blob/master/shelley/chain-and-ledger/cddl-spec/shelley.cddl#L32)
 
 ## Plutus
 
 - [Plutus Book](https://plutus-book.surge.sh)
-- [Multi-assets Ledger Specs extension](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/specs.shelley-mc/latest/download/1/multi-asset.pdf)
+- [Multi-assets Ledger Specs extension](https://hydra.iohk.io/job/Cardano/cardano-ledger/specs.shelley-mc/latest/download/1/multi-asset.pdf)
 
 ## Emurgo
 

--- a/docs/developers/Resources.md
+++ b/docs/developers/Resources.md
@@ -19,7 +19,7 @@
 ## Plutus
 
 - [Plutus Book](https://plutus-book.surge.sh)
-- [Multi-assets Ledger Specs extension](https://hydra.iohk.io/job/Cardano/cardano-ledger/specs.shelley-mc/latest/download/1/multi-asset.pdf)
+- [Multi-assets Ledger Specs extension](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/specs.shelley-mc/latest/download/1/multi-asset.pdf)
 
 ## Emurgo
 

--- a/lib/core/src/Cardano/Api/Gen.hs
+++ b/lib/core/src/Cardano/Api/Gen.hs
@@ -749,7 +749,7 @@ genRational =
     ratioToRational = toRational
 
 -- TODO: consolidate this back to just genRational once this is merged:
--- https://github.com/input-output-hk/cardano-ledger-specs/pull/2330
+-- https://github.com/input-output-hk/cardano-ledger/pull/2330
 genRationalInt64 :: Gen Rational
 genRationalInt64 =
     (\d -> ratioToRational (1 % d)) <$> genDenominator

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1195,8 +1195,8 @@ estimateTxCost pp skeleton =
 -- This function uses the upper bounds of CBOR serialized objects as the basis
 -- for many of its calculations. The following document is used as a reference:
 --
--- https://github.com/input-output-hk/cardano-ledger-specs/blob/master/shelley/chain-and-ledger/shelley-spec-ledger-test/cddl-files/shelley.cddl
--- https://github.com/input-output-hk/cardano-ledger-specs/blob/master/shelley-ma/shelley-ma-test/cddl-files/shelley-ma.cddl
+-- https://github.com/input-output-hk/cardano-ledger/blob/master/shelley/chain-and-ledger/shelley-spec-ledger-test/cddl-files/shelley.cddl
+-- https://github.com/input-output-hk/cardano-ledger/blob/master/shelley-ma/shelley-ma-test/cddl-files/shelley-ma.cddl
 --
 estimateTxSize :: TxSkeleton -> TxSize
 estimateTxSize skeleton =

--- a/nix/.stack.nix/byron-spec-chain.nix
+++ b/nix/.stack.nix/byron-spec-chain.nix
@@ -63,11 +63,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/nix/.stack.nix/byron-spec-ledger.nix
+++ b/nix/.stack.nix/byron-spec-ledger.nix
@@ -67,11 +67,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -43,11 +43,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -70,11 +70,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/nix/.stack.nix/cardano-ledger-alonzo-test.nix
+++ b/nix/.stack.nix/cardano-ledger-alonzo-test.nix
@@ -84,11 +84,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/nix/.stack.nix/cardano-ledger-alonzo.nix
+++ b/nix/.stack.nix/cardano-ledger-alonzo.nix
@@ -61,11 +61,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/nix/.stack.nix/cardano-ledger-byron-test.nix
+++ b/nix/.stack.nix/cardano-ledger-byron-test.nix
@@ -62,11 +62,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/nix/.stack.nix/cardano-ledger-byron.nix
+++ b/nix/.stack.nix/cardano-ledger-byron.nix
@@ -121,11 +121,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/nix/.stack.nix/cardano-ledger-core.nix
+++ b/nix/.stack.nix/cardano-ledger-core.nix
@@ -61,11 +61,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/nix/.stack.nix/cardano-ledger-shelley-ma-test.nix
+++ b/nix/.stack.nix/cardano-ledger-shelley-ma-test.nix
@@ -88,11 +88,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/nix/.stack.nix/cardano-ledger-shelley-ma.nix
+++ b/nix/.stack.nix/cardano-ledger-shelley-ma.nix
@@ -54,11 +54,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -62,7 +62,7 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "097890495cbb0e8b62106bcd090a5721c3f4b36f";
       sha256 = "0i3y9n0rsyarvhfqzzzjccqnjgwb9fbmbs6b7vj40afjhimf5hcj";
       });

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -121,7 +121,7 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "097890495cbb0e8b62106bcd090a5721c3f4b36f";
       sha256 = "0i3y9n0rsyarvhfqzzzjccqnjgwb9fbmbs6b7vj40afjhimf5hcj";
       });

--- a/nix/.stack.nix/cardano-protocol-tpraos.nix
+++ b/nix/.stack.nix/cardano-protocol-tpraos.nix
@@ -47,11 +47,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "ec51e4fb1b17461ab612cf427b79f1742942e8cb";
       sha256 = "05bwy7x1asyfshqsfsyv2c70qwrxp4680xlvhwdm1hz9bi0lpq41";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "ec51e4fb1b17461ab612cf427b79f1742942e8cb";
       sha256 = "05bwy7x1asyfshqsfsyv2c70qwrxp4680xlvhwdm1hz9bi0lpq41";
       };

--- a/nix/.stack.nix/shelley-spec-ledger-test.nix
+++ b/nix/.stack.nix/shelley-spec-ledger-test.nix
@@ -144,11 +144,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/nix/.stack.nix/shelley-spec-ledger.nix
+++ b/nix/.stack.nix/shelley-spec-ledger.nix
@@ -63,11 +63,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/nix/.stack.nix/shelley-spec-non-integral.nix
+++ b/nix/.stack.nix/shelley-spec-non-integral.nix
@@ -41,11 +41,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/nix/.stack.nix/small-steps-test.nix
+++ b/nix/.stack.nix/small-steps-test.nix
@@ -66,11 +66,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/nix/.stack.nix/small-steps.nix
+++ b/nix/.stack.nix/small-steps.nix
@@ -51,11 +51,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       }) // {
-      url = "https://github.com/input-output-hk/cardano-ledger-specs";
+      url = "https://github.com/input-output-hk/cardano-ledger";
       rev = "f827a4321e42f528e25f6079f7af3eb18f10d391";
       sha256 = "0dmgxg7cpgz4lnscqrrk4gakw9w90dx8ljv5wr923rfp9nyzc5qf";
       };

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1767,7 +1767,7 @@ x-stakePoolSaturation: &stakePoolSaturation
     Saturation-level of the pool based on the desired number of pools aimed by the network.
     A value above `1` indicates that the pool is saturated.
 
-    The `non_myopic_member_rewards` take oversaturation into account, as specified by the [specs](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec).
+    The `non_myopic_member_rewards` take oversaturation into account, as specified by the [specs](https://hydra.iohk.io/job/Cardano/cardano-ledger/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec).
 
     The saturation is based on the live `relative_stake`. The saturation at the end of epoch e,
     will affect the rewards paid out at the end of epoch e+3.
@@ -1781,7 +1781,7 @@ x-non-myopic-member-rewards: &nonMyopicMemberRewards
     this pool.
 
     For more details, see the
-    [Design Specification for Delegation and Incentives in Cardano](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec)
+    [Design Specification for Delegation and Incentives in Cardano](https://hydra.iohk.io/job/Cardano/cardano-ledger/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec)
     document.
 
 x-stakePoolMetrics: &stakePoolMetrics
@@ -1799,7 +1799,7 @@ x-stakePoolMetrics: &stakePoolMetrics
         The live pool stake relative to the *total* stake.
 
         For more details, see the section "Relative Stake: Active vs Total" in
-        [Design Specification for Delegation and Incentives in Cardano](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec).
+        [Design Specification for Delegation and Incentives in Cardano](https://hydra.iohk.io/job/Cardano/cardano-ledger/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec).
     saturation: *stakePoolSaturation
     produced_blocks:
       <<: *numberOfBlocks
@@ -3305,7 +3305,7 @@ components:
 
     ScriptTemplateValue: *ScriptTemplateValue
 
-    # https://github.com/input-output-hk/cardano-ledger-specs/blob/8d836e61bb88bda4a6a5c00694735928390067a1/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MetaData.hs#L48-L65
+    # https://github.com/input-output-hk/cardano-ledger/blob/8d836e61bb88bda4a6a5c00694735928390067a1/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MetaData.hs#L48-L65
     TransactionMetadataValue: &TransactionMetadataValue
       oneOf:
         - title: String

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1767,7 +1767,7 @@ x-stakePoolSaturation: &stakePoolSaturation
     Saturation-level of the pool based on the desired number of pools aimed by the network.
     A value above `1` indicates that the pool is saturated.
 
-    The `non_myopic_member_rewards` take oversaturation into account, as specified by the [specs](https://hydra.iohk.io/job/Cardano/cardano-ledger/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec).
+    The `non_myopic_member_rewards` take oversaturation into account, as specified by the [specs](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec).
 
     The saturation is based on the live `relative_stake`. The saturation at the end of epoch e,
     will affect the rewards paid out at the end of epoch e+3.
@@ -1781,7 +1781,7 @@ x-non-myopic-member-rewards: &nonMyopicMemberRewards
     this pool.
 
     For more details, see the
-    [Design Specification for Delegation and Incentives in Cardano](https://hydra.iohk.io/job/Cardano/cardano-ledger/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec)
+    [Design Specification for Delegation and Incentives in Cardano](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec)
     document.
 
 x-stakePoolMetrics: &stakePoolMetrics
@@ -1799,7 +1799,7 @@ x-stakePoolMetrics: &stakePoolMetrics
         The live pool stake relative to the *total* stake.
 
         For more details, see the section "Relative Stake: Active vs Total" in
-        [Design Specification for Delegation and Incentives in Cardano](https://hydra.iohk.io/job/Cardano/cardano-ledger/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec).
+        [Design Specification for Delegation and Incentives in Cardano](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec).
     saturation: *stakePoolSaturation
     produced_blocks:
       <<: *numberOfBlocks

--- a/stack.yaml
+++ b/stack.yaml
@@ -155,7 +155,7 @@ extra-deps:
 - git: https://github.com/input-output-hk/cardano-crypto
   commit: 07397f0e50da97eaa0575d93bee7ac4b2b2576ec
 
-- git: https://github.com/input-output-hk/cardano-ledger-specs
+- git: https://github.com/input-output-hk/cardano-ledger
   commit: f827a4321e42f528e25f6079f7af3eb18f10d391
   subdirs:
   - alonzo/impl


### PR DESCRIPTION
- [x] `git grep -l 'hk/cardano-ledger-specs' | xargs sed -i 's/cardano-ledger-specs/cardano-ledger/g'`
- [x] Ensure f827a4321e42f528e25f6079f7af3eb18f10d391 still exists in the repo 
- [x] `./nix/regenerate.sh`
- [x] Revert a few links to spec documents in hydra, where cardano-ledger-specs is still used

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

#3054

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
