### PR TITLE
Introduce `Prologue` and `Discoveries` of an address book

### DIFF
--- a/lib/core/bench/db-bench.hs
+++ b/lib/core/bench/db-bench.hs
@@ -68,7 +68,11 @@ import Cardano.Startup
 import Cardano.Wallet.DB
     ( DBLayer (..), cleanDB )
 import Cardano.Wallet.DB.Sqlite
-    ( CacheBehavior (..), PersistState, WalletDBLog (..), newDBLayerWith )
+    ( CacheBehavior (..)
+    , PersistAddressBook
+    , WalletDBLog (..)
+    , newDBLayerWith
+    )
 import Cardano.Wallet.DB.Sqlite.TH
     ( migrateAll )
 import Cardano.Wallet.DummyTarget.Primitive.Types
@@ -666,7 +670,7 @@ txHistoryFixture db@DBLayer{..} bSize nAssets range = do
 -- database in a temporary location.
 withDB
     :: forall s k.
-        ( PersistState s
+        ( PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
         , WalletKey k
         )
@@ -690,7 +694,7 @@ withTempSqliteFile action = withSystemTempFile "bench.db" $ \fp _ -> action fp
 
 setupDB
     :: forall s k.
-        ( PersistState s
+        ( PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
         , WalletKey k
         )

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -181,6 +181,7 @@ library
       Cardano.Wallet.DB.MVar
       Cardano.Wallet.DB.Model
       Cardano.Wallet.DB.Sqlite
+      Cardano.Wallet.DB.Sqlite.AddressBook
       Cardano.Wallet.DB.Sqlite.CheckpointsOld
       Cardano.Wallet.DB.Sqlite.Migration
       Cardano.Wallet.DB.Sqlite.TH

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -26,6 +26,7 @@ module Cardano.Wallet.DB
     , gapSize
 
       -- * Errors
+    , ErrBadFormat(..)
     , ErrNoSuchWallet(..)
     , ErrWalletAlreadyExists(..)
     , ErrNoSuchTransaction (..)
@@ -72,6 +73,8 @@ import Data.Quantity
     ( Quantity (..) )
 import Data.Word
     ( Word32, Word8 )
+import UnliftIO.Exception
+    ( Exception )
 
 import qualified Data.List as L
 
@@ -325,6 +328,14 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         :: forall a. stm a -> m a
         -- ^ Execute operations of the database in isolation and atomically.
     }
+
+-- | Can't read the database file because it's in a bad format
+-- (corrupted, too old, …)
+data ErrBadFormat
+    = ErrBadFormatAddressState
+    deriving (Eq,Show)
+
+instance Exception ErrBadFormat
 
 -- | Can't perform given operation because there's no wallet
 newtype ErrNoSuchWallet

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -42,7 +42,7 @@ module Cardano.Wallet.DB.Sqlite
     , newDBLayerInMemory
 
     -- * Interfaces
-    , PersistState (..)
+    , PersistAddressBook (..)
 
     -- * Migration Support
     , DefaultFieldValues (..)
@@ -95,7 +95,10 @@ import Cardano.Wallet.DB.Checkpoints
     , getPoint
     )
 import Cardano.Wallet.DB.Sqlite.CheckpointsOld
-    ( PersistState (..), blockHeaderFromEntity, mkStoreWalletsCheckpoints )
+    ( PersistAddressBook (..)
+    , blockHeaderFromEntity
+    , mkStoreWalletsCheckpoints
+    )
 import Cardano.Wallet.DB.Sqlite.Migration
     ( DefaultFieldValues (..), migrateManually )
 import Cardano.Wallet.DB.Sqlite.TH
@@ -231,7 +234,7 @@ import qualified Data.Text as T
 -- | Instantiate a 'DBFactory' from a given directory, or in-memory for testing.
 newDBFactory
     :: forall s k.
-        ( PersistState s
+        ( PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
         , WalletKey k
         )
@@ -385,7 +388,7 @@ instance ToText DBFactoryLog where
 -- library.
 withDBLayer
     :: forall s k a.
-        ( PersistState s
+        ( PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
         , WalletKey k
         )
@@ -442,7 +445,7 @@ instance ToText CheckpointCacheLog where
 -- database.
 withDBLayerInMemory
     :: forall s k a.
-        ( PersistState s
+        ( PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
         )
     => Tracer IO WalletDBLog
@@ -459,7 +462,7 @@ withDBLayerInMemory tr ti action = bracket (newDBLayerInMemory tr ti) fst (actio
 -- finished with the 'DBLayer'.
 newDBLayerInMemory
     :: forall s k.
-        ( PersistState s
+        ( PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
         )
     => Tracer IO WalletDBLog
@@ -492,7 +495,7 @@ data CacheBehavior
 -- is better initialized with 'withDBLayer'.
 newDBLayer
     :: forall s k.
-        ( PersistState s
+        ( PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
         )
     => Tracer IO WalletDBLog
@@ -508,7 +511,7 @@ newDBLayer = newDBLayerWith @s @k CacheLatestCheckpoint
 -- | Like 'newDBLayer', but allows to explicitly specify the caching behavior.
 newDBLayerWith
     :: forall s k.
-        ( PersistState s
+        ( PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
         )
     => CacheBehavior

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/AddressBook.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/AddressBook.hs
@@ -1,0 +1,228 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# LANGUAGE TypeFamilies #-}
+-- |
+-- Copyright: © 2021 IOHK
+-- License: Apache-2.0
+--
+-- Address books consist of a 'Prologue'
+-- and discovered addresses ('Discoveries').
+module Cardano.Wallet.DB.Sqlite.AddressBook
+    ( AddressBookIso (..)
+    , Prologue (..)
+    , Discoveries (..)
+    , SeqAddressList (..)
+    )
+  where
+
+import Prelude
+
+import Cardano.Address.Derivation
+    ( XPub )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Depth (..)
+    , MkKeyFingerprint (..)
+    , NetworkDiscriminant (..)
+    , PaymentAddress (..)
+    , Role (..)
+    , SoftDerivation (..)
+    )
+import Cardano.Wallet.Primitive.AddressDerivation.SharedKey
+    ( SharedKey (..) )
+import Cardano.Wallet.Primitive.AddressDiscovery
+    ( GetPurpose )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..), AddressState (..) )
+import Data.Generics.Internal.VL
+    ( Iso', iso, withIso )
+import Data.Kind
+    ( Type )
+import Data.Map.Strict
+    ( Map )
+import Data.Proxy
+    ( Proxy (..) )
+import Data.Type.Equality
+    ( type (==) )
+import Data.Typeable
+    ( Typeable )
+
+import qualified Cardano.Wallet.Primitive.AddressDiscovery.Random as Rnd
+import qualified Cardano.Wallet.Primitive.AddressDiscovery.Sequential as Seq
+import qualified Cardano.Wallet.Primitive.AddressDiscovery.Shared as Shared
+import qualified Cardano.Wallet.Primitive.Types.Address as W
+import qualified Data.Map.Strict as Map
+
+{-------------------------------------------------------------------------------
+    AddressBook isomorphism
+-------------------------------------------------------------------------------}
+-- | FIXME LATER during ADP-1043:
+-- Move 'Prologue' and 'Discoveries' closer into address types.
+class AddressBookIso s where
+    -- | Address information contained in the prologue of the address book,
+    -- such as public keys or the address gap.
+    data Prologue s :: Type
+    -- | Addresses that were collected during discovery on the blockchain.
+    data Discoveries s :: Type
+
+    -- | Isomorphism between the address book type 's'
+    -- and its two components.
+    addressIso :: Iso' s (Prologue s, Discoveries s)
+
+{-------------------------------------------------------------------------------
+    Sequential address book
+-------------------------------------------------------------------------------}
+-- | Sequential list of addresses
+newtype SeqAddressList (c :: Role) = SeqAddressList [(W.Address, W.AddressState)]
+
+-- piggy-back on SeqState existing instance, to simulate the same behavior.
+instance AddressBookIso (Seq.SeqState n k)
+    => AddressBookIso (Seq.SeqAnyState n k p)
+  where
+    data Prologue (Seq.SeqAnyState n k p) = PS (Prologue (Seq.SeqState n k))
+    data Discoveries (Seq.SeqAnyState n k p) = DS (Discoveries (Seq.SeqState n k))
+
+    addressIso = withIso addressIso $ \from to ->
+        let from2 st = let (a,b) = from $ Seq.innerState st in (PS a, DS b)
+            to2 (PS a, DS b) = Seq.SeqAnyState $ to (a,b)
+        in  iso from2 to2
+
+-- | Isomorphism for sequential address book.
+instance 
+    ( MkKeyFingerprint key (Proxy n, key 'AddressK XPub)
+    , GetPurpose key
+    , SoftDerivation key
+    , PaymentAddress n key
+    , Typeable n
+    , (key == SharedKey) ~ 'False
+    ) => AddressBookIso (Seq.SeqState n key)
+  where
+    data Prologue (Seq.SeqState n key)
+        = SeqPrologue (Seq.SeqState n key)
+        -- Trick: We keep the type, but we empty the discovered addresses
+    data Discoveries (Seq.SeqState n key)
+        = SeqDiscoveries
+            (SeqAddressList 'UtxoInternal)
+            (SeqAddressList 'UtxoExternal)
+
+    addressIso = iso from to
+      where
+        from (Seq.SeqState int ext a b c) =
+            ( SeqPrologue $ Seq.SeqState (emptyPool int) (emptyPool ext) a b c
+            , SeqDiscoveries (toDiscoveries @n int) (toDiscoveries @n ext)
+            )
+        to (SeqPrologue (Seq.SeqState int ext a b c), SeqDiscoveries ints exts)
+          = Seq.SeqState (fromDiscoveries @n int ints) (fromDiscoveries @n ext exts) a b c
+
+-- | Extract the discovered addresses from an address pool.
+toDiscoveries
+    :: forall (n :: NetworkDiscriminant) (c :: Role) key.
+    ( GetPurpose key
+    , PaymentAddress n key
+    , Typeable c
+    ) => Seq.AddressPool c key -> SeqAddressList c
+toDiscoveries pool = SeqAddressList
+    [ (a,st) | (a,st,_) <- Seq.addresses (liftPaymentAddress @n) pool ]
+
+-- | Variant of 'toDiscoveries' that can be used with 'SharedKey'
+toDiscoveriesShared
+    :: forall (n :: NetworkDiscriminant) (c :: Role) key.
+    ( GetPurpose key
+    , Typeable c
+    , Typeable n
+    , key ~ SharedKey
+    ) => Seq.AddressPool c key -> SeqAddressList c
+toDiscoveriesShared pool = SeqAddressList
+    [ (a,st) | (a,st,_) <- Seq.addresses (Shared.liftPaymentAddress @n) pool ]
+
+-- | Fill an empty address pool with addresses.
+fromDiscoveries
+    :: forall (n :: NetworkDiscriminant) (c :: Role) key.
+    ( MkKeyFingerprint key (Proxy n, key 'AddressK XPub)
+    , MkKeyFingerprint key Address
+    , SoftDerivation key
+    , Typeable n
+    , Typeable c
+    ) => Seq.AddressPool c key -> SeqAddressList c -> Seq.AddressPool c key
+fromDiscoveries ctx (SeqAddressList addrs) =
+    Seq.mkAddressPool @n (Seq.context ctx) (Seq.gap ctx) addrs
+
+-- | Remove all discovered addresses from an address pool,
+-- but keep context.
+emptyPool :: Seq.AddressPool c key -> Seq.AddressPool c key
+emptyPool pool = pool{ Seq.indexedKeys = Map.empty }
+
+{-------------------------------------------------------------------------------
+    Shared key address book
+-------------------------------------------------------------------------------}
+-- | Isomorphism for multi-sig address book.
+instance
+    ( MkKeyFingerprint key (Proxy n, key 'AddressK XPub)
+    , MkKeyFingerprint key Address
+    , GetPurpose key
+    , SoftDerivation key
+    , Typeable n
+    , key ~ SharedKey
+    ) => AddressBookIso (Shared.SharedState n key)
+  where
+    data Prologue (Shared.SharedState n key)
+        = SharedPrologue (Shared.SharedState n key)
+        -- Trick: We keep the type, but we empty the discovered addresses
+    data Discoveries (Shared.SharedState n key)
+        = SharedDiscoveries (SeqAddressList 'UtxoExternal)
+
+    addressIso = iso from to
+      where
+        from st@(Shared.SharedState a b) = case b of
+            Shared.PendingFields{} ->
+                ( SharedPrologue st
+                , SharedDiscoveries (SeqAddressList [])
+                )
+            Shared.ReadyFields pool ->
+                let b0 = Shared.ReadyFields $ emptyPool pool
+                in  ( SharedPrologue (Shared.SharedState a b0)
+                    , SharedDiscoveries (toDiscoveriesShared @n pool)
+                    )
+        to  ( SharedPrologue st@(Shared.SharedState a b0)
+            , SharedDiscoveries addrs
+            )
+          = case b0 of
+            Shared.PendingFields{} -> st
+            Shared.ReadyFields pool0
+                -> Shared.SharedState a $ Shared.ReadyFields
+                $ fromDiscoveries @n pool0 addrs
+
+{-------------------------------------------------------------------------------
+    HD Random address book
+-------------------------------------------------------------------------------}
+-- piggy-back on SeqState existing instance, to simulate the same behavior.
+instance AddressBookIso (Rnd.RndAnyState n p)
+  where
+    data Prologue (Rnd.RndAnyState n p) = PR (Prologue (Rnd.RndState n))
+    data Discoveries (Rnd.RndAnyState n p) = DR (Discoveries (Rnd.RndState n))
+
+    addressIso = withIso addressIso $ \from to ->
+        let from2 st = let (a,b) = from $ Rnd.innerState st in (PR a, DR b)
+            to2 (PR a, DR b) = Rnd.RndAnyState $ to (a,b)
+        in  iso from2 to2
+
+-- | Isomorphism for HD random address book.
+instance AddressBookIso (Rnd.RndState n) where
+    data Prologue (Rnd.RndState n)
+        = RndPrologue (Rnd.RndState n)
+        -- Trick: We keep the type, but we empty the discovered addresses
+    data Discoveries (Rnd.RndState n)
+        = RndDiscoveries (Map Rnd.DerivationPath (Address, AddressState))
+
+    addressIso = iso from to
+      where
+        from (Rnd.RndState a b addrs c d)
+            = (RndPrologue (Rnd.RndState a b Map.empty c d), RndDiscoveries addrs)
+        to (RndPrologue (Rnd.RndState a b _ c d), RndDiscoveries addrs)
+            = Rnd.RndState a b addrs c d

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -42,7 +42,7 @@ module Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , mkUnboundedAddressPoolGap
 
     -- ** Address Pool
-    , AddressPool
+    , AddressPool (indexedKeys)
     , ParentContext (..)
     , gap
     , addresses

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -59,7 +59,7 @@ import Cardano.Wallet.DB.Properties
     ( properties )
 import Cardano.Wallet.DB.Sqlite
     ( DefaultFieldValues (..)
-    , PersistState
+    , PersistAddressBook
     , WalletDBLog (..)
     , newDBFactory
     , newDBLayerInMemory
@@ -289,7 +289,7 @@ stateMachineSpec
         ( WalletKey k
         , PersistPrivateKey (k 'RootK)
         , PaymentAddress 'Mainnet k
-        , PersistState s
+        , PersistAddressBook s
         , TestConstraints s k
         , Typeable s
         )
@@ -344,7 +344,7 @@ loggingSpec = withLoggingDB @(SeqState 'Mainnet ShelleyKey) $ do
             length msgs `shouldBe` count * 2
 
 withLoggingDB
-    :: (Show s, PersistState s)
+    :: (Show s, PersistAddressBook s)
     => SpecWith (IO [DBLog], DBLayer IO s ShelleyKey)
     -> Spec
 withLoggingDB = around f . beforeWith clean
@@ -691,7 +691,7 @@ fileModeSpec =  do
 -- SQLite session has the same effect as executing the same operations over
 -- multiple sessions.
 prop_randomOpChunks
-    :: (Eq s, PersistState s, Show s)
+    :: (Eq s, PersistAddressBook s, Show s)
     => KeyValPairs WalletId (Wallet s, WalletMetadata)
     -> Property
 prop_randomOpChunks (KeyValPairs pairs) =
@@ -794,11 +794,11 @@ defaultFieldValues = DefaultFieldValues
 
 -- Note: Having helper with concrete key types reduces the need
 -- for type-application everywhere.
-withShelleyDBLayer :: PersistState s => (DBLayer IO s ShelleyKey -> IO a) -> IO a
+withShelleyDBLayer :: PersistAddressBook s => (DBLayer IO s ShelleyKey -> IO a) -> IO a
 withShelleyDBLayer = withDBLayerInMemory nullTracer dummyTimeInterpreter
 
 withShelleyFileDBLayer
-    :: PersistState s
+    :: PersistAddressBook s
     => FilePath
     -> (DBLayer IO s ShelleyKey -> IO a)
     -> IO a
@@ -1026,7 +1026,7 @@ testMigrationTxMetaFee
         ( s ~ SeqState 'Mainnet k
         , k ~ ShelleyKey
         , WalletKey k
-        , PersistState s
+        , PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
         , PaymentAddress 'Mainnet k
         )
@@ -1083,7 +1083,7 @@ testMigrationCleanupCheckpoints
         ( s ~ SeqState 'Mainnet k
         , k ~ ShelleyKey
         , WalletKey k
-        , PersistState s
+        , PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
         , PaymentAddress 'Mainnet k
         )
@@ -1121,7 +1121,7 @@ testMigrationRole
     :: forall k s.
         ( s ~ SeqState 'Mainnet k
         , WalletKey k
-        , PersistState s
+        , PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
         , PaymentAddress 'Mainnet k
         , GetPurpose k
@@ -1154,7 +1154,7 @@ testMigrationSeqStateDerivationPrefix
     :: forall k s.
         ( s ~ SeqState 'Mainnet k
         , WalletKey k
-        , PersistState s
+        , PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
         , Show s
         )

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -177,8 +177,8 @@ import Data.Either
     ( isLeft, isRight )
 import Data.Function
     ( on )
-import Data.Generics.Internal.VL.Lens
-    ( set, view, (^.) )
+import Data.Generics.Internal.VL
+    ( iso, set, view, (^.) )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Map.Strict
@@ -265,6 +265,7 @@ import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.DB.MVar as MVar
 import qualified Cardano.Wallet.DB.Sqlite as Sqlite
+import qualified Cardano.Wallet.DB.Sqlite.AddressBook as Sqlite
 import qualified Cardano.Wallet.Primitive.CoinSelection.Balance as Balance
 import qualified Cardano.Wallet.Primitive.Migration as Migration
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
@@ -1330,9 +1331,19 @@ newtype DummyState
     = DummyState (Map Address (Index 'Soft 'AddressK))
     deriving (Generic, Show, Eq)
 
-instance Sqlite.PersistState DummyState where
-    insertState _ _ = error "DummyState.insertState: not implemented"
-    selectState _ = error "DummyState.selectState: not implemented"
+instance Sqlite.AddressBookIso DummyState where
+    data Prologue DummyState = DummyPrologue
+    data Discoveries DummyState = DummyDiscoveries DummyState
+    addressIso = iso from to
+      where
+        from x = (DummyPrologue, DummyDiscoveries x)
+        to (_,DummyDiscoveries x) = x
+
+instance Sqlite.PersistAddressBook DummyState where
+    insertPrologue _ _ = error "DummyState.insertPrologue: not implemented"
+    insertDiscoveries _ _ _ = error "DummyState.insertDiscoveries: not implemented"
+    loadPrologue _ = error "DummyState.loadPrologue: not implemented"
+    loadDiscoveries _ _ = error "DummyState.loadDiscoveries: not implemented"
 
 instance NFData DummyState
 

--- a/lib/shelley/bench/restore-bench.hs
+++ b/lib/shelley/bench/restore-bench.hs
@@ -71,7 +71,7 @@ import Cardano.Wallet.BenchShared
 import Cardano.Wallet.DB
     ( DBLayer )
 import Cardano.Wallet.DB.Sqlite
-    ( PersistState, withDBLayer )
+    ( PersistAddressBook, withDBLayer )
 import Cardano.Wallet.Logging
     ( trMessageText )
 import Cardano.Wallet.Network
@@ -595,7 +595,7 @@ bench_restoration
         , WalletKey k
         , NFData s
         , Show s
-        , PersistState s
+        , PersistAddressBook s
         , CompareDiscovery s
         , KnownAddresses s
         , PersistPrivateKey (k 'RootK)
@@ -703,7 +703,7 @@ withBenchDBLayer
         ( IsOwned s k
         , NFData s
         , Show s
-        , PersistState s
+        , PersistAddressBook s
         , IsOurs s RewardAccount
         , IsOurs s Address
         , PersistPrivateKey (k 'RootK)

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -73,7 +73,7 @@ import Cardano.Wallet.Api.Types
     , EncodeStakeAddress
     )
 import Cardano.Wallet.DB.Sqlite
-    ( DBFactoryLog, DefaultFieldValues (..), PersistState )
+    ( DBFactoryLog, DefaultFieldValues (..), PersistAddressBook )
 import Cardano.Wallet.Logging
     ( trMessageText )
 import Cardano.Wallet.Network
@@ -378,7 +378,7 @@ serveWallet
         :: forall s k.
             ( IsOurs s Address
             , IsOurs s RewardAccount
-            , PersistState s
+            , PersistAddressBook s
             , PersistPrivateKey (k 'RootK)
             , WalletKey k
             )


### PR DESCRIPTION
### Issue number

ADP-1043

### Overview

Previous work in epic ADP-1043 introduced delta encodings, DBVars, and an embedding of the wallet state and its delta encodings into a database table. It's time to integrate these tools with the wallet code. To facilitate code review, the integration proceeds in a sequence of refactorings that do not change functionality and pass all unit tests.

In this step, we begin refactoring the address discovery state (the `s` in `Wallet s`). First, I would like to update our nomenclature and call this state an *address book*. Second, we introduce two new data families `Prologue s` and `Discoveries s`, with the intention that any address book is isomorphic to a pair of these two types, that is `s ~ (Prologue s, Discoveries s)`. The idea is that the Prologue of the address book contains "static" information such as public keys or the address gap (default 20), while the Discoveries of the address book contains information that was gathered during on-chain address discovery.

### Details

* We introduce a type class `AddressBookIso` which provides the isomorphism `s ~ (Prologue s, Discoveries s)`.
* For this pull request, we avoid making any changes to the `AddressDiscovery.*` hierarchy. Instead, the isomorphisms are implemented using newly defined data families whose representation is close to the types in the database.
* The implementation for the sequential states uses `liftPaymentAddress` to convert the payment part to and from the `Address` type. This is ok when convering to/from the database layer, but does not make sense for in-memory data structures. Therefore, further work in this epic will introduce changes in the `AddressDiscovery.*` hierarchy.

### Comments

* The overall goal is that, in a future PR, we can represent the wallet state along the lines of `WalletState s ~ (Prologue s, Checkpoints (BlockHeader, UTxO, Discoveries s) `.
* Merge PR #3048 before this one, because this pull request is based on the branch of the former.