### PR TITLE
Update README.md with correct links

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ See **Installation Instructions** for each available [release](https://github.co
 
 ## How to build from sources
 
-See [Building](https://input-output-hk.github.io/cardano-wallet/dev/Building)
+See [Building](https://input-output-hk.github.io/cardano-wallet/developers/Building)
 
 ## How to test
 
-See [Testing](https://input-output-hk.github.io/cardano-wallet/dev/Testing)
+See [Testing](https://input-output-hk.github.io/cardano-wallet/contributing/Testing)
 
 ## Documentation
 


### PR DESCRIPTION
Update README.md with correct links for Building & Testing

Current README.md in root directory of repo contains broken links for Testing & Building. This changes will fix it.