### PR TITLE
Turn on heap profile in restoration benchmarks

### DIFF
--- a/.buildkite/bench-restore.sh
+++ b/.buildkite/bench-restore.sh
@@ -39,9 +39,7 @@ echo "+++ Results - $network"
 cat $results
 
 mv restore.hp $artifact_name.hp
-
-# FIXME [ADP-1074]
-# hp2pretty $artifact_name.hp
+hp2pretty $artifact_name.hp
 
 GNUPLOT_PROGRAM=$(cat <<EOP
 set timefmt "%s";
@@ -88,8 +86,7 @@ if [ -n "${BUILDKITE:-}" ]; then
   buildkite-agent artifact upload plot.svg
 
   echo "+++ Heap profile"
-  echo "Heap profile visualization has temporarily been disabled because it runs out of memory (ADP-1074)"
-  # printf '\033]1338;url='"artifact://$artifact_name.svg"';alt='"Heap profile"'\a\n'
+  printf '\033]1338;url='"artifact://$artifact_name.svg"';alt='"Heap profile"'\a\n'
   echo "+++ Restore plot"
   printf '\033]1338;url='"artifact://plot.svg"';alt='"Restore plot"'\a\n'
 fi


### PR DESCRIPTION
- [x] I have turned on heap profile plot in restoration benchmark

### Comments

Hopefully it will work now with slimmer benchmarks. 

Testing: https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1188 :green_circle:  :point_left:  it works!

### Issue Number

Follow up to #3051 / ADP-1307.
