### PR TITLE
Bump cardano-addresses to 3.7.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -68,7 +68,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-addresses
-    tag: 4003fc09780da61bc09d85337bdd4c7664aa49ba
+    tag: 71006f9eb956b0004022e80aadd4ad50d837b621
     subdir: command-line
             core
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
@@ -350,25 +350,57 @@ spec = describe "SHELLEY_ADDRESSES" $ do
         listAddresses @n ctx wB
             >>= verifyAddrs (initialTotalB + 1) (initialUsedB + 1)
 
-    it "ADDRESS_INSPECT_01 - Address inspect OK" $ \ctx -> do
+    it "ADDRESS_INSPECT_01 - Address inspect OK Icarus" $ \ctx -> do
         let str = "Ae2tdPwUPEYz6ExfbWubiXPB6daUuhJxikMEb4eXRp5oKZBKZwrbJ2k7EZe"
         r <- request @Aeson.Value ctx (Link.inspectAddress str) Default Empty
-        expectResponseCode HTTP.status200 r
+        verify r
+            [ expectResponseCode HTTP.status200
+            , expectField (Aeson.key "address_style" . Aeson._String)
+                (`shouldBe` "Icarus")
+            , expectField (Aeson.key "address_type" . Aeson._Number)
+                (`shouldBe` 8)
+            ]
 
-    it "ADDRESS_INSPECT_02 - Address inspect KO" $ \ctx -> runResourceT $ do
+    it "ADDRESS_INSPECT_02 - Address inspect OK Byron" $ \ctx -> do
+        let str = "37btjrVyb4KE2ByiPiJUQfAUBGaMyKScg4mnYjzVAsN2PUxj1WxTg98ien3oAo8vKBhP2KTuC9wi76vZ9kDNFkjbmzywdLTJgaz8n3RD3Rueim3Pd3"
+        r <- request @Aeson.Value ctx (Link.inspectAddress str) Default Empty
+        verify r
+            [ expectResponseCode HTTP.status200
+            , expectField (Aeson.key "address_style" . Aeson._String)
+                (`shouldBe` "Byron")
+            , expectField (Aeson.key "address_type" . Aeson._Number)
+                (`shouldBe` 8)
+            ]
+
+    it "ADDRESS_INSPECT_03 - Address inspect OK reward" $ \ctx -> do
+        let str = "stake1u8pn5jr7cfa0x8ndtdufyg5lty3avg3zd2tq35c06hpsh8gptdza4"
+        r <- request @Aeson.Value ctx (Link.inspectAddress str) Default Empty
+        verify r
+            [ expectResponseCode HTTP.status200
+            , expectField (Aeson.key "address_style" . Aeson._String)
+                (`shouldBe` "Shelley")
+            , expectField (Aeson.key "address_type" . Aeson._Number)
+                (`shouldBe` 14)
+            ]
+
+    it "ADDRESS_INSPECT_04 - Address inspect KO" $ \ctx -> runResourceT $ do
         let str = "patate"
         r <- request @Aeson.Value ctx (Link.inspectAddress str) Default Empty
         expectResponseCode HTTP.status400 r
 
-    it "ADDRESS_INSPECT_03 - Address inspect bech32" $ \ctx -> do
+    it "ADDRESS_INSPECT_05 - Address inspect OK bech32" $ \ctx -> do
         let str = "addr_test1qzamu40sglnsrylzv9jylekjmzgaqsg5v5z9u6yk3jpnnxjwck77fqu8deuumsvnazjnjhwasc2eetfqpa2pvygts78ssd5388"
         r <- request @Aeson.Value ctx (Link.inspectAddress str) Default Empty
         verify r
             [ expectResponseCode HTTP.status200
+            , expectField (Aeson.key "address_style" . Aeson._String)
+                (`shouldBe` "Shelley")
             , expectField (Aeson.key "spending_key_hash_bech32" . Aeson._String)
                 (`shouldBe` "addr_vkh1hwl9tuz8uuqe8cnpv387d5kcj8gyz9r9q30x395vsvue5e44fh7")
             , expectField (Aeson.key "stake_key_hash_bech32" . Aeson._String)
                 (`shouldBe` "stake_vkh1fmzmmeyrsah8nnwpj0522w2amkrpt89dyq84g9s3pwrc7dqjnfu")
+            , expectField (Aeson.key "address_type" . Aeson._Number)
+                (`shouldBe` 0)
             ]
 
     -- Generating golden test data for enterprise addresses - script credential:

--- a/nix/.stack.nix/cardano-addresses-cli.nix
+++ b/nix/.stack.nix/cardano-addresses-cli.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.12";
-      identifier = { name = "cardano-addresses-cli"; version = "3.6.0"; };
+      identifier = { name = "cardano-addresses-cli"; version = "3.7.0"; };
       license = "Apache-2.0";
       copyright = "2021 IOHK";
       maintainer = "operations@iohk.io";
@@ -85,12 +85,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-addresses";
-      rev = "4003fc09780da61bc09d85337bdd4c7664aa49ba";
-      sha256 = "0ffavab3h56p1b1narn1w8aq4wr2affdl5xyz8cxv5ighi1sw98g";
+      rev = "71006f9eb956b0004022e80aadd4ad50d837b621";
+      sha256 = "11dl3fmq7ry5wdmz8kw07ji8yvrxnrsf7pgilw5q9mi4aqyvnaqk";
       }) // {
       url = "https://github.com/input-output-hk/cardano-addresses";
-      rev = "4003fc09780da61bc09d85337bdd4c7664aa49ba";
-      sha256 = "0ffavab3h56p1b1narn1w8aq4wr2affdl5xyz8cxv5ighi1sw98g";
+      rev = "71006f9eb956b0004022e80aadd4ad50d837b621";
+      sha256 = "11dl3fmq7ry5wdmz8kw07ji8yvrxnrsf7pgilw5q9mi4aqyvnaqk";
       };
     postUnpack = "sourceRoot+=/command-line; echo source root reset to \$sourceRoot";
     }) // { cabal-generator = "hpack"; }

--- a/nix/.stack.nix/cardano-addresses.nix
+++ b/nix/.stack.nix/cardano-addresses.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.12";
-      identifier = { name = "cardano-addresses"; version = "3.6.0"; };
+      identifier = { name = "cardano-addresses"; version = "3.7.0"; };
       license = "Apache-2.0";
       copyright = "2021 IOHK";
       maintainer = "operations@iohk.io";
@@ -80,12 +80,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-addresses";
-      rev = "4003fc09780da61bc09d85337bdd4c7664aa49ba";
-      sha256 = "0ffavab3h56p1b1narn1w8aq4wr2affdl5xyz8cxv5ighi1sw98g";
+      rev = "71006f9eb956b0004022e80aadd4ad50d837b621";
+      sha256 = "11dl3fmq7ry5wdmz8kw07ji8yvrxnrsf7pgilw5q9mi4aqyvnaqk";
       }) // {
       url = "https://github.com/input-output-hk/cardano-addresses";
-      rev = "4003fc09780da61bc09d85337bdd4c7664aa49ba";
-      sha256 = "0ffavab3h56p1b1narn1w8aq4wr2affdl5xyz8cxv5ighi1sw98g";
+      rev = "71006f9eb956b0004022e80aadd4ad50d837b621";
+      sha256 = "11dl3fmq7ry5wdmz8kw07ji8yvrxnrsf7pgilw5q9mi4aqyvnaqk";
       };
     postUnpack = "sourceRoot+=/core; echo source root reset to \$sourceRoot";
     }) // { cabal-generator = "hpack"; }

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2085,6 +2085,11 @@ components:
             description: Only for 'Byron' style.
             type: string
             format: base16
+          address_type:
+            description: The raw type field of the address.
+            type: integer
+            minimum: 0
+            maximum: 15
 
     ApiNetworkTip: &ApiNetworkTip
       <<: *slotReference

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2086,7 +2086,24 @@ components:
             type: string
             format: base16
           address_type:
-            description: The raw type field of the address.
+            description: |
+              The raw type field of the address.
+
+              Details about possible address types are following (refer also to [cddl](https://github.com/input-output-hk/cardano-ledger/blob/master/eras/alonzo/test-suite/cddl-files/alonzo.cddl)).
+
+              | address_type | binary prefix  |   Meaning                                                |
+              | ------------ |:--------------:|:--------------------------------------------------------:|
+              |      0       |  0000          |   base address: keyhash28,keyhash28                      |
+              |      1       |  0001          |   base address: scripthash28,keyhash28                   |
+              |      2       |  0010          |   base address: keyhash28,scripthash28                   |
+              |      3       |  0011          |   base address: scripthash28,scripthash28                |
+              |      4       |  0100          |   pointer address: keyhash28, 3 variable length uint     |
+              |      5       |  0101          |   pointer address: scripthash28, 3 variable length uint  |
+              |      6       |  0110          |   enterprise address: keyhash28                          |
+              |      7       |  0111          |   enterprise address: scripthash28                       |
+              |      8       |  1000          |   byron/icarus                                           |
+              |      14      |  1110          |   reward account: keyhash28                              |
+              |      15      |  1111          |   reward account: scripthash28                           |
             type: integer
             minimum: 0
             maximum: 15

--- a/stack.yaml
+++ b/stack.yaml
@@ -70,9 +70,9 @@ extra-deps:
 - hspec-core-2.8.2
 - hspec-discover-2.8.2
 
-# cardano-addresses-3.6.0
+# cardano-addresses-3.7.0
 - git: https://github.com/input-output-hk/cardano-addresses
-  commit: 4003fc09780da61bc09d85337bdd4c7664aa49ba
+  commit: 71006f9eb956b0004022e80aadd4ad50d837b621
   subdirs:
     - command-line
     - core


### PR DESCRIPTION
Updates cardano-addresses to [3.7.0](), which adds an `address_type` field to the inspectAddress output.

### Issue Number

[DDW-742](https://input-output.atlassian.net/browse/DDW-742)
