### PR TITLE
Improve asset assertion in e2e tests

### DIFF
--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
     # @wid_sha = "d20b7f812fb571e7a3b14fb8a13c595d32cad5e6"
     # @wid_rnd = "12cbebfdc4521766e63a7e07c4825b24deb4176c"
     # @wid_ic = "f5da82c1eb3e391a535dd5ba2867fe9bdaf2f313"
-    # @wid = "1f82e83772b7579fc0854bd13db6a9cce21ccd95"
-    # @target_id = "e47d780efac3ee9e3565f5996f8f357472f7b8bc"
+    # @wid = "2269611a3c10b219b0d38d74b004c298b76d16a9"
+    # @target_id = "8d0fc5d4450d7430a822f2102a84ac2ca1bc1bf1"
     # 1f82e83772b7579fc0854bd13db6a9cce21ccd95
     # 2269611a3c10b219b0d38d74b004c298b76d16a9
     # a042bafdaf98844cfa8f6d4b1dc47519b21a4d95
@@ -622,16 +622,21 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
 
         target_after = get_shelley_balances(@target_id)
-
+        
         # verify balances are correct on target wallet
+        assets_to_check = ["#{ASSETS[0]["policy_id"]}#{ASSETS[0]["asset_name"]}",
+                           "#{ASSETS[1]["policy_id"]}#{ASSETS[1]["asset_name"]}"]
+        target_total_after = assets_balance(target_after['assets_total'], {assets_to_check: assets_to_check})
+        target_avail_after = assets_balance(target_after['assets_available'], {assets_to_check: assets_to_check})
+        target_total_expected = assets_balance(target_before['assets_total'], {assets_to_check: assets_to_check, delta: (+amt)})
+        target_avail_expected = assets_balance(target_before['assets_available'], {assets_to_check: assets_to_check, delta: (+amt)})
         if target_before['assets_total'] == []
-          target_balance = [{ "#{ASSETS[0]["policy_id"]}#{ASSETS[0]["asset_name"]}" => amt },
-                            { "#{ASSETS[1]["policy_id"]}#{ASSETS[1]["asset_name"]}" => amt }].to_set
-          expect(assets_balance(target_after['assets_total'])).to eq target_balance
-          expect(assets_balance(target_after['assets_available'])).to eq target_balance
+          target_balance_expected = assets_to_check.map {|a| {a => amt}}.to_set
+          expect(target_total_after).to eq target_balance_expected
+          expect(target_avail_after).to eq target_balance_expected
         else
-          expect(assets_balance(target_after['assets_total'])).to eq assets_balance(target_before['assets_total'], (+amt))
-          expect(assets_balance(target_after['assets_available'])).to eq assets_balance(target_before['assets_available'], (+amt))
+          expect(target_total_after).to eq target_total_expected
+          expect(target_avail_after).to eq target_avail_expected
         end
       end
 

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -293,8 +293,21 @@ end
 
 ##
 # return asset total or available balance for comparison
-def assets_balance(assets, received = 0)
-  assets.map { |x| { "#{x['policy_id']}#{x['asset_name']}" => x['quantity'] + received } }.to_set
+# @param [Hash] assets - asset balance Hash from the wallet (output of get_wallet_balances['assets_*'])
+# @param [Hash] options - 
+#                    options[:delta] [Int] - received/sent assets that we are expecting (default: 0)
+#                    options[:assets_to_check] [Array] - limit looking up balance to only assets in the array ["#{policy_id}#{asset_name}",...] (default: nil)
+# @return [Set] Set of Hashes {"#{policy_id}#{asset_name}" => balance}
+def assets_balance(assets, options = {})
+  options[:delta] ||= 0
+  assets_to_check = options[:assets_to_check]
+
+  asset_set = assets.map { |x| { "#{x['policy_id']}#{x['asset_name']}" => x['quantity'] + options[:delta] } }.to_set
+  if assets_to_check
+    asset_set.select! {|a| assets_to_check.include? a.keys.first}
+  else
+    asset_set
+  end
 end
 
 ##
@@ -347,19 +360,35 @@ def verify_ada_balance(src_after, src_before, target_after, target_before, amt, 
   expect(src_after['total']).to eq (src_before['total'] - amt - fee)
 end
 
-def verify_asset_balance(src_after, src_before, target_after, target_before, amt)
+##
+# Verify assets balance on target and src wallets after transaction
+# @params src_after, src_before, target_after, target_before - src and target wallet balances before and after tx
+# @param [Int] amt - amt of assets sent in tx
+# @param [Array] assets_to_check - array of assets sent in the tx in the form of ["#{policy_id}#{asset_name}",...]
+def verify_asset_balance(src_after, src_before, target_after, target_before, amt, 
+                         assets_to_check = ["#{ASSETS[0]['policy_id']}#{ASSETS[0]['asset_name']}",
+                                            "#{ASSETS[1]['policy_id']}#{ASSETS[1]['asset_name']}"])
+  
+  target_total_after = assets_balance(target_after['assets_total'], {assets_to_check: assets_to_check})
+  target_avail_after = assets_balance(target_after['assets_available'], {assets_to_check: assets_to_check})
+  target_total_expected = assets_balance(target_before['assets_total'], {assets_to_check: assets_to_check, delta: (+amt)})
+  target_avail_expected = assets_balance(target_before['assets_available'], {assets_to_check: assets_to_check, delta: (+amt)})
+  src_total_after = assets_balance(src_after['assets_total'], {assets_to_check: assets_to_check})
+  src_avail_after = assets_balance(src_after['assets_available'], {assets_to_check: assets_to_check})
+  src_total_expected = assets_balance(src_before['assets_total'], {assets_to_check: assets_to_check, delta: (-amt)})
+  src_avail_expected = assets_balance(src_before['assets_available'], {assets_to_check: assets_to_check, delta: (-amt)})
+
   if target_before['assets_total'] == []
-    target_balance = [{ "#{ASSETS[0]["policy_id"]}#{ASSETS[0]["asset_name"]}" => amt },
-                      { "#{ASSETS[1]["policy_id"]}#{ASSETS[1]["asset_name"]}" => amt }].to_set
-    expect(assets_balance(target_after['assets_total'])).to eq target_balance
-    expect(assets_balance(target_after['assets_available'])).to eq target_balance
+    target_balance_expected = assets_to_check.map {|a| {a => amt}}.to_set
+    expect(target_total_after).to eq target_balance_expected
+    expect(target_avail_after).to eq target_balance_expected
   else
-    expect(assets_balance(target_after['assets_total'])).to eq assets_balance(target_before['assets_total'], (+amt))
-    expect(assets_balance(target_after['assets_available'])).to eq assets_balance(target_before['assets_available'], (+amt))
+    expect(target_total_after).to eq target_total_expected
+    expect(target_avail_after).to eq target_avail_expected
   end
 
-  expect(assets_balance(src_after['assets_total'])).to eq assets_balance(src_before['assets_total'], (-amt))
-  expect(assets_balance(src_after['assets_available'])).to eq assets_balance(src_before['assets_available'], (-amt))
+  expect(src_total_after).to eq src_total_expected
+  expect(src_avail_after).to eq src_avail_expected
 end
 
 def wait_for_tx_in_ledger(wid, tx_id)

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -304,7 +304,7 @@ def assets_balance(assets, options = {})
 
   asset_set = assets.map { |x| { "#{x['policy_id']}#{x['asset_name']}" => x['quantity'] + options[:delta] } }.to_set
   if assets_to_check
-    asset_set.select! {|a| assets_to_check.include? a.keys.first}
+    asset_set.select {|a| assets_to_check.include? a.keys.first}.to_set
   else
     asset_set
   end


### PR DESCRIPTION

- [ ] I have improved assertion checking asset balance after tx so it is possible to assert specific asset balance

### Comments

This is to get rid of potential false positives when there are some more assets on fixture wallets.

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
