### PR TITLE
Add new address `Pool addr ix` data type. Simplify `SharedState n k`.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Addresses.hs
@@ -120,10 +120,14 @@ spec = describe "SHARED_ADDRESSES" $ do
   where
      getAccountWallet name = do
           (_, accXPubTxt):_ <- liftIO $ genXPubs 1
+          -- NOTE: A previous test had used "account_index": "30H",
+          -- presumably to spice things up,
+          -- but the `isValidDerivationPath` function expects that the
+          -- account index is equal to "0H".
           let payload = Json [json| {
                   "name": #{name},
                   "account_public_key": #{accXPubTxt},
-                  "account_index": "30H",
+                  "account_index": "0H",
                   "payment_script_template":
                       { "cosigners":
                           { "cosigner#0": #{accXPubTxt} },

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -169,6 +169,7 @@ library
       Cardano.Pool.DB.Sqlite.TH
       Cardano.Pool.Metadata
       Cardano.Wallet
+      Cardano.Wallet.Address.Pool
       Cardano.Wallet.Api
       Cardano.Wallet.Api.Client
       Cardano.Wallet.Api.Link
@@ -408,6 +409,7 @@ test-suite unit
       Cardano.Pool.DB.MVarSpec
       Cardano.Pool.DB.Properties
       Cardano.Pool.DB.SqliteSpec
+      Cardano.Wallet.Address.PoolSpec
       Cardano.Wallet.Api.Malformed
       Cardano.Wallet.Api.Server.TlsSpec
       Cardano.Wallet.Api.ServerSpec

--- a/lib/core/src/Cardano/Wallet/Address/Pool.hs
+++ b/lib/core/src/Cardano/Wallet/Address/Pool.hs
@@ -1,0 +1,216 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+-- Copyright: © 2021 IOHK
+-- License: Apache-2.0
+--
+-- An address pool caches a collection of addresses.
+-- The purpose of this data structure is to aid in BIP-44 style
+-- address discovery with an address gap.
+module Cardano.Wallet.Address.Pool
+    ( Pool
+    , generator
+    , addresses
+    , gap
+    , lookup
+    , size
+    , next
+    , new
+    , load
+    , update
+    , clear
+
+    -- * Internal
+    , loadUnsafe
+    , prop_sequence
+    , prop_gap
+    , prop_fresh
+    , prop_generator
+    , prop_consistent
+    )
+  where
+
+import Prelude hiding
+    ( last, lookup )
+
+import Cardano.Wallet.Primitive.Types.Address
+    ( AddressState (..) )
+import Control.DeepSeq
+    ( NFData )
+import Data.Map.Strict
+    ( Map )
+import Data.Ord
+    ( Down (..) )
+import Fmt
+    ( Buildable (..) )
+import GHC.Generics
+    ( Generic )
+
+{- HLINT ignore "Avoid restricted qualification" -}
+import qualified Data.List as List
+import qualified Data.Map.Strict as Map
+
+{-------------------------------------------------------------------------------
+    Address Pool, abstract data type
+-------------------------------------------------------------------------------}
+-- | An address pool caches a collection of addresses (type @addr@)
+-- which are derived from a numeric index (type @ix@).
+data Pool addr ix = Pool
+    { generator :: ix -> addr
+    -- ^ Each address is obtained from a numeric index.
+    -- The purpose of the 'Pool' data structure is to (partially)
+    -- cache this mapping,
+    -- because it is expensive to compute (hashing)
+    -- and its inverse is practically impossible to compute.
+    , gap :: Int
+    -- ^ The pool gap determines how 'Used' and 'Unused'
+    -- have to be distributed.
+    -- See 'prop_gap' and 'prop_fresh'.
+    , addresses :: Map addr (ix, AddressState)
+    -- ^ Partial, cached inverse of the 'generator'.
+    -- This map contains all cached addresses @addr@,
+    -- their corresponding indices @ix@,
+    -- and whether they are 'Used' or 'Unused'.
+    -- See 'prop_sequence'.
+    } deriving (Generic)
+
+instance (NFData addr, NFData ix) => NFData (Pool addr ix)
+
+-- | Internal invariant:
+-- The indices of the addresses in a pool form a finite
+-- sequence beginning with 'fromEnum'@ 0@.
+prop_sequence :: (Ord ix, Enum ix) => Pool addr ix -> Bool
+prop_sequence Pool{addresses} =
+    indices `List.isPrefixOf` [toEnum 0..]
+  where
+    indices = List.sort $ map fst $ Map.elems addresses
+
+-- | Internal invariant:
+-- If we order the 'addresses' by their indices,
+-- then there are always /less than/ 'gap' many 'Unused'
+-- addresses between two consecutive 'Used' addresses.
+prop_gap :: Ord ix => Pool addr ix -> Bool
+prop_gap Pool{gap,addresses}
+    = all ((< gap) . length)
+    . filter isUnused
+    . dropFresh
+    $ List.group statuses
+  where
+    isUnused (Unused:_) = True
+    isUnused _ = False
+    dropFresh = drop 1 -- drop items that are checked by 'prop_fresh'.
+    statuses = map snd $ List.sortOn (Down . fst) $ Map.elems addresses
+
+-- | Internal invariant:
+-- If we order the 'addresses' by their indices,
+-- there are exactly 'gap' many 'Unused' addresses after the last
+-- 'Used' address.
+prop_fresh :: Ord ix => Pool addr ix -> Bool
+prop_fresh Pool{gap,addresses} =
+    takeWhile (== Unused) end == replicate gap Unused
+  where
+    end = map snd $ List.sortOn (Down . fst) $ Map.elems addresses
+
+-- | Internal invariant:
+-- All 'addresses' in the pool have been generated from their index
+-- via the pool 'generator'.
+prop_generator :: Eq addr => Pool addr ix -> Bool
+prop_generator Pool{generator,addresses} =
+    and $ Map.mapWithKey isGenerated addresses
+  where
+    isGenerated addr (ix,_) = generator ix == addr
+
+-- | Internal invariant: The pool satisfies all invariants above.
+prop_consistent :: (Ord ix, Enum ix, Eq addr) => Pool addr ix -> Bool
+prop_consistent p =
+    all ($ p) [prop_sequence, prop_gap, prop_fresh, prop_generator]
+
+{-------------------------------------------------------------------------------
+    Pretty printing
+-------------------------------------------------------------------------------}
+instance Buildable (Pool addr ix) where
+    build pool = "AddressPool "
+        <> "{ " <> build (size pool) <> " addresses"
+        <> ", gap = " <> build (gap pool)
+        <> "}"
+
+instance (Show addr, Show ix) => Show (Pool addr ix) where
+    show pool = "AddressPool"
+        <> "{ generator = <<function>>"
+        <> ", gap = " <> show (gap pool)
+        <> ", addresses = " <> show (addresses pool)
+        <> "}"
+
+{-------------------------------------------------------------------------------
+    Address Pool, operations
+-------------------------------------------------------------------------------}
+-- | Create a new address pool.
+new :: (Ord addr, Enum ix) => (ix -> addr) -> Int -> Pool addr ix
+new generator gap
+    = ensureFresh (toEnum 0) $ Pool{ generator, gap, addresses = Map.empty }
+
+-- | Replace the collection of addresses in a pool,
+-- but only if this collection satisfies the necessary invariants
+-- such as 'prop_sequence' etc.
+load
+    :: (Ord addr,  Ord ix, Enum ix)
+    => Pool addr ix -> Map addr (ix,AddressState) -> Maybe (Pool addr ix)
+load addrs pool0 = if prop_consistent pool then Just pool else Nothing
+  where pool = loadUnsafe addrs pool0
+
+-- | Replace the collection of addresses in a pool,
+-- but skips checking the invariants.
+loadUnsafe :: Pool addr ix -> Map addr (ix,AddressState) -> Pool addr ix
+loadUnsafe pool addrs = pool{ addresses = addrs }
+
+-- | Remove all previously discovered addresses,
+-- i.e. create a new pool with the same 'generator' and 'gap' as the old pool.
+clear :: (Ord addr, Enum ix) => Pool addr ix -> Pool addr ix
+clear Pool{generator,gap} = new generator gap
+
+-- | Look up an address in the pool.
+lookup :: Ord addr => addr -> Pool addr ix -> Maybe ix
+lookup addr Pool{addresses} = fst <$> Map.lookup addr addresses
+
+-- | Number of addresses cached in the pool.
+size :: Pool addr ix -> Int
+size = Map.size . addresses
+
+-- | Given an index, retrieve the next index that is still in the pool.
+next :: Enum ix => Pool addr ix -> ix -> Maybe ix
+next Pool{addresses} ix = let jx = succ ix in
+    if fromEnum jx >= Map.size addresses then Nothing else Just jx
+
+-- | Update an address to the 'Used' status
+-- and create new 'Unused' addresses in order to satisfy 'prop_fresh'.
+--
+-- Does nothing if the address was not in the pool.
+update :: (Ord addr, Enum ix) => addr -> Pool addr ix -> Pool addr ix
+update addr pool@Pool{addresses} =
+    case Map.lookup addr addresses of
+        Nothing     -> pool
+        Just (ix,_) -> ensureFresh (succ ix) $ pool
+            { addresses = Map.adjust (\(i,_) -> (i, Used)) addr addresses }
+
+-- | Create additional 'Unused' addresses from larger indices
+-- in order to satisfy 'prop_fresh' again.
+--
+-- Precondition: Either @ix = fromEnum 0@,
+-- or the index @jx@ which satisfies to @ix = succ jx@
+-- is associated with a 'Used' address.
+ensureFresh :: (Ord addr, Enum ix) => ix -> Pool addr ix -> Pool addr ix
+ensureFresh ix pool@Pool{generator,gap,addresses}
+    = pool { addresses = Map.union addresses nexts }
+  where
+    fresh = toEnum $ Map.size addresses -- first index that is not in the pool
+    nexts = Map.fromList
+        [ (generator i, (i, Unused)) | i <- [fresh .. to] ]
+      where
+        to = toEnum $ fromEnum ix + fromIntegral gap - 1
+        -- example:
+        --  ix = 0 && fresh = 0 && gap = 20 `implies` [fresh .. to] = [0..19]

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -350,10 +350,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState, mkRndState )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( DerivationPrefix (..)
-    , ParentContext (..)
     , SeqState (..)
     , defaultAddressPoolGap
-    , gap
     , mkSeqStateFromAccountXPub
     , mkSeqStateFromRootXPrv
     , purposeCIP1852
@@ -363,8 +361,6 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     , ErrAddCosigner (..)
     , ErrScriptTemplate (..)
     , SharedState (..)
-    , SharedStateFields (..)
-    , SharedStatePending (..)
     , mkSharedStateFromAccountXPub
     , mkSharedStateFromRootXPrv
     , validateScriptTemplates
@@ -602,6 +598,7 @@ import qualified Cardano.Wallet.DB as W
 import qualified Cardano.Wallet.Network as NW
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Byron as Byron
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Icarus as Icarus
+import qualified Cardano.Wallet.Primitive.AddressDiscovery.Shared as Shared
 import qualified Cardano.Wallet.Primitive.CoinSelection.Balance as Balance
 import qualified Cardano.Wallet.Primitive.CoinSelection.Collateral as Collateral
 import qualified Cardano.Wallet.Primitive.Types as W
@@ -818,7 +815,6 @@ postAccountWallet
         , WalletKey k
         , HasWorkerRegistry s k ctx
         , IsOurs s RewardAccount
-        , Typeable n
         , (k == SharedKey) ~ 'False
         )
     => ctx
@@ -1048,23 +1044,19 @@ mkSharedWallet
         ( ctx ~ ApiLayer s k
         , s ~ SharedState n k
         , HasWorkerRegistry s k ctx
-        , SoftDerivation k
-        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
-        , MkKeyFingerprint k Address
-        , Typeable n
+        , Shared.SupportsDiscovery n k
         )
     => MkApiWallet ctx s ApiSharedWallet
-mkSharedWallet ctx wid cp meta pending progress = case getState cp of
-    SharedState (DerivationPrefix (_,_,accIx)) (PendingFields (SharedStatePending _ pTemplate dTemplateM g)) ->
-        pure $ ApiSharedWallet $ Left $ ApiPendingSharedWallet
+mkSharedWallet ctx wid cp meta pending progress = case Shared.ready st of
+    Shared.Pending -> pure $ ApiSharedWallet $ Left $ ApiPendingSharedWallet
         { id = ApiT wid
         , name = ApiT $ meta ^. #name
         , accountIndex = ApiT $ DerivationIndex $ getIndex accIx
-        , addressPoolGap = ApiT g
-        , paymentScriptTemplate = pTemplate
-        , delegationScriptTemplate = dTemplateM
+        , addressPoolGap = ApiT $ Shared.poolGap st
+        , paymentScriptTemplate = Shared.paymentTemplate st
+        , delegationScriptTemplate = Shared.delegationTemplate st
         }
-    SharedState (DerivationPrefix (_,_,accIx)) (ReadyFields pool) -> do
+    Shared.Active _ -> do
         reward <- withWorkerCtx @_ @s @k ctx wid liftE liftE $ \wrk ->
             -- never fails - returns zero if balance not found
             liftIO $ W.fetchRewardBalance @_ @s @k wrk wid
@@ -1078,16 +1070,15 @@ mkSharedWallet ctx wid cp meta pending progress = case getState cp of
             cp
         let available = availableBalance pending cp
         let total = totalBalance pending reward cp
-        let (ParentContextShared _ pTemplate dTemplateM) = pool ^. #context
         pure $ ApiSharedWallet $ Right $ ApiActiveSharedWallet
             { id = ApiT wid
             , name = ApiT $ meta ^. #name
             , accountIndex = ApiT $ DerivationIndex $ getIndex accIx
-            , addressPoolGap = ApiT $ gap pool
+            , addressPoolGap = ApiT $ Shared.poolGap st
             , passphrase = ApiWalletPassphraseInfo
                 <$> fmap (view #lastUpdatedAt) (meta ^. #passphraseInfo)
-            , paymentScriptTemplate = pTemplate
-            , delegationScriptTemplate = dTemplateM
+            , paymentScriptTemplate = Shared.paymentTemplate st
+            , delegationScriptTemplate = Shared.delegationTemplate st
             , delegation = apiDelegation
             , balance = ApiWalletBalance
                 { available = coinToQuantity (available ^. #coin)
@@ -1101,6 +1092,9 @@ mkSharedWallet ctx wid cp meta pending progress = case getState cp of
             , state = ApiT progress
             , tip = tip'
             }
+  where
+    st = getState cp
+    DerivationPrefix (_,_,accIx) = Shared.derivationPrefix st
 
 patchSharedWallet
     :: forall ctx s k n.
@@ -1275,7 +1269,6 @@ postIcarusWallet
         , k ~ IcarusKey
         , HasWorkerRegistry s k ctx
         , PaymentAddress n IcarusKey
-        , Typeable n
         )
     => ctx
     -> ByronWalletPostData '[12,15,18,21,24]
@@ -1296,7 +1289,6 @@ postTrezorWallet
         , k ~ IcarusKey
         , HasWorkerRegistry s k ctx
         , PaymentAddress n IcarusKey
-        , Typeable n
         )
     => ctx
     -> ByronWalletPostData '[12,15,18,21,24]
@@ -1317,7 +1309,6 @@ postLedgerWallet
         , k ~ IcarusKey
         , HasWorkerRegistry s k ctx
         , PaymentAddress n IcarusKey
-        , Typeable n
         )
     => ctx
     -> ByronWalletPostData '[12,15,18,21,24]

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -24,11 +25,13 @@
 
 module Cardano.Wallet.Primitive.AddressDiscovery.Shared
     (
+      SupportsDiscovery
+
     -- ** State
-      SharedState (..)
-    , SharedStateFields (..)
-    , SharedStatePending (..)
-    , SupportsSharedState
+    , SharedState (..)
+    , Readiness (..)
+    , newSharedAddressPool
+
     , ErrAddCosigner (..)
     , ErrScriptTemplate (..)
     , mkSharedStateFromAccountXPub
@@ -72,13 +75,13 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , MkKeyFingerprint (..)
     , NetworkDiscriminant (..)
     , Passphrase
-    , Role (..)
     , SoftDerivation
     , WalletKey (..)
     , utxoExternal
     )
 import Cardano.Wallet.Primitive.AddressDerivation.SharedKey
     ( SharedKey (..)
+    , constructAddressFromIx
     , purposeCIP1854
     , replaceCosignersWithVerKeys
     , toNetworkTag
@@ -86,22 +89,14 @@ import Cardano.Wallet.Primitive.AddressDerivation.SharedKey
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( CompareDiscovery (..)
     , GetAccount (..)
-    , GetPurpose
     , IsOurs (..)
     , KnownAddresses (..)
     , coinTypeAda
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
-    ( AddressPool
-    , AddressPoolGap
-    , ParentContext (..)
-    , addresses
-    , context
-    , lookupAddress
-    , mkAddressPool
-    )
+    ( AddressPoolGap (..), unsafePaymentKeyFingerprint )
 import Cardano.Wallet.Primitive.Types.Address
-    ( Address (..), AddressState (..) )
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount )
 import Control.Arrow
@@ -110,8 +105,6 @@ import Control.DeepSeq
     ( NFData )
 import Control.Monad
     ( unless )
-import Data.Coerce
-    ( coerce )
 import Data.Either
     ( isRight )
 import Data.Either.Combinators
@@ -131,13 +124,48 @@ import Type.Reflection
 
 import qualified Cardano.Address as CA
 import qualified Cardano.Address.Style.Shelley as CA
+import qualified Cardano.Wallet.Address.Pool as AddressPool
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 
+-- | Convenient alias for commonly used class contexts on keys.
+type SupportsDiscovery (n :: NetworkDiscriminant) k =
+    ( MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
+    , MkKeyFingerprint k Address
+    , SoftDerivation k
+    , Typeable n
+    )
+
 {-------------------------------------------------------------------------------
-                                Shared State
+    Address Pool
+-------------------------------------------------------------------------------}
+-- | An address pool which keeps track of shared addresses.
+-- To create a new pool, see 'newSharedAddressPool'.
+type SharedAddressPool (key :: Depth -> Type -> Type) =
+        AddressPool.Pool
+            (KeyFingerprint "payment" key)
+            (Index 'Soft 'ScriptK)
+
+-- | Create a new shared address pool from complete script templates.
+newSharedAddressPool
+    :: forall (n :: NetworkDiscriminant) key.
+        ( key ~ SharedKey, SupportsDiscovery n key )
+    => AddressPoolGap
+    -> ScriptTemplate
+    -> Maybe ScriptTemplate
+    -> SharedAddressPool key
+newSharedAddressPool g payment delegation =
+    AddressPool.new generator gap
+  where
+    gap = fromIntegral $ getAddressPoolGap g
+    generator
+        = unsafePaymentKeyFingerprint @key
+        . constructAddressFromIx @n payment delegation
+
+{-------------------------------------------------------------------------------
+    Shared State
 -------------------------------------------------------------------------------}
 
 -- | Shared wallet is a new kind of wallet owned by one or more co-signers.
@@ -188,62 +216,50 @@ import qualified Data.Text as T
 data SharedState (n :: NetworkDiscriminant) k = SharedState
     { derivationPrefix :: !DerivationPrefix
         -- ^ Derivation path prefix from a root key up to the account key
-    , fields :: !(SharedStateFields (SharedStatePending k) (AddressPool 'UtxoExternal k))
-        -- ^ Address pool tracking the shared addresses. Co-owning is based on
-        -- payment credential only. Moreover, the parent context information is
-        -- stored ie., validated script template for payment credential,
-        -- optional validated script template for delegation credential and
-        -- account public key with which the shared wallet was initiated
-    } deriving (Generic)
-
-deriving instance
-    ( Show (k 'AccountK XPub)
-    ) => Show (SharedState n k)
-
-deriving instance
-    ( Eq (k 'AccountK XPub)
-    ) => Eq (SharedState n k)
-
-instance
-    ( NFData (k 'AccountK XPub)
-    ) => NFData (SharedState n k)
-
-data SharedStateFields pending ready
-    = PendingFields !pending
-    | ReadyFields !ready
-    deriving (Generic, Show, Eq)
-
-instance (NFData pending, NFData ready) => NFData (SharedStateFields pending ready)
-
-data SharedStatePending k = SharedStatePending
-    { pendingSharedStateAccountKey :: !(k 'AccountK XPub)
+    , accountXPub :: !(k 'AccountK XPub)
         -- ^ The account public key of an initiator of the shared wallet
-    , pendingSharedStatePaymentTemplate :: !ScriptTemplate
+    , paymentTemplate :: !ScriptTemplate
         -- ^ Script template together with a map of account keys and cosigners
-        -- for payment credential
-    , pendingSharedStateDelegationTemplate :: !(Maybe ScriptTemplate)
+        -- for payment credential.
+    , delegationTemplate :: !(Maybe ScriptTemplate)
         -- ^ Script template together with a map of account keys and cosigners
         -- for staking credential. If not specified then the same template as for
-        -- payment is used
-    , pendingSharedStateAddressPoolGap :: !AddressPoolGap
+        -- payment is used.
+    , poolGap :: !AddressPoolGap
         -- ^ Address pool gap to be used in the address pool of shared state
+    , ready :: !(Readiness (SharedAddressPool k))
+        -- ^ Readiness status of the shared state.
+        -- The state is ready if all cosigner public keys have been obtained.
+        -- In this case, an address pool is allocated
     } deriving (Generic)
 
-deriving instance
-    ( Show (k 'AccountK XPub)
-    ) => Show (SharedStatePending k)
+instance ( NFData (k 'AccountK XPub) ) => NFData (SharedState n k)
 
-deriving instance
-    ( Eq (k 'AccountK XPub)
-    ) => Eq (SharedStatePending k)
+deriving instance ( Show (k 'AccountK XPub) ) => Show (SharedState n k)
 
-instance
-    ( NFData (k 'AccountK XPub)
-    ) => NFData (SharedStatePending k)
+-- We have to write the equality instance by hands,
+-- because there is no general equality for address pools
+-- (we cannot test the generators for equality).
+instance Eq (k 'AccountK XPub) => Eq (SharedState n k) where
+    SharedState a1 a2 a3 a4 a5 ap == SharedState b1 b2 b3 b4 b5 bp
+        = and [a1 == b1, a2 == b2, a3 == b3, a4 == b4, a5 == b5, ap `match` bp]
+      where
+        match Pending Pending = True
+        match (Active a) (Active b)
+            = AddressPool.addresses a == AddressPool.addresses b
+        match _ _ = False
+
+-- | Readiness status of the shared state.
+data Readiness a
+    = Pending
+    | Active !a
+    deriving (Generic, Show, Eq)
+
+instance (NFData a) => NFData (Readiness a)
 
 -- | Create a new SharedState from public account key.
 mkSharedStateFromAccountXPub
-    :: (SupportsSharedState n k, WalletKey k, k ~ SharedKey)
+    :: (SupportsDiscovery n k, WalletKey k, k ~ SharedKey)
     => k 'AccountK XPub
     -> Index 'Hardened 'AccountK
     -> AddressPoolGap
@@ -251,64 +267,131 @@ mkSharedStateFromAccountXPub
     -> Maybe ScriptTemplate
     -> SharedState n k
 mkSharedStateFromAccountXPub accXPub accIx gap pTemplate dTemplateM =
-    mkSharedState accIx $
-    SharedStatePending accXPub pTemplate dTemplateM gap
-
-mkSharedState
-    :: (SupportsSharedState n k, WalletKey k, k ~ SharedKey)
-    => Index 'Hardened 'AccountK
-    -> SharedStatePending k
-    -> SharedState n k
-mkSharedState accIx pending = updateSharedState state id
-  where
-    state = SharedState
+    activate $ SharedState
         { derivationPrefix = DerivationPrefix (purposeCIP1854, coinTypeAda, accIx)
-        , fields = PendingFields pending
+        , accountXPub = accXPub
+        , paymentTemplate = pTemplate
+        , delegationTemplate = dTemplateM
+        , poolGap = gap
+        , ready = Pending
         }
-
-type SupportsSharedState (n :: NetworkDiscriminant) k =
-    ( MkKeyFingerprint k Address
-    , SoftDerivation k
-    , Typeable n
-    , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
-    )
 
 -- | Create a new SharedState from root private key and password.
 mkSharedStateFromRootXPrv
-    :: (SupportsSharedState n k, WalletKey k, k ~ SharedKey)
+    :: (SupportsDiscovery n k, WalletKey k, k ~ SharedKey)
     => (k 'RootK XPrv, Passphrase "encryption")
     -> Index 'Hardened 'AccountK
     -> AddressPoolGap
     -> ScriptTemplate
     -> Maybe ScriptTemplate
     -> SharedState n k
-mkSharedStateFromRootXPrv (rootXPrv, pwd) accIx gap pTemplate dTemplateM =
-    mkSharedState accIx $
-    SharedStatePending accXPub pTemplate dTemplateM gap
+mkSharedStateFromRootXPrv (rootXPrv, pwd) accIx =
+    mkSharedStateFromAccountXPub accXPub accIx
   where
     accXPub = publicKey $ deriveAccountPrivateKey pwd rootXPrv accIx
 
--- | Turn a "pending" into an "active" state or identity if already "active".
-updateSharedState
-    :: forall n k. (SupportsSharedState n k, WalletKey k, k ~ SharedKey)
-    => SharedState n k
-    -> (SharedStatePending k -> SharedStatePending k)
+-- | Turn a 'Pending' into an 'Active' state if all templates are complete.
+activate
+    :: forall n k. (SupportsDiscovery n k, WalletKey k, k ~ SharedKey)
+    => SharedState n k -> SharedState n k
+activate
+    st@(SharedState{accountXPub,paymentTemplate=pT,delegationTemplate=dT,poolGap,ready})
+  = st { ready = new ready }
+  where
+    new Pending
+        | templatesComplete accountXPub pT dT
+            = Active $ newSharedAddressPool @n poolGap pT dT
+    new r   = r
+
+-- | Possible errors from adding a co-signer key to the shared wallet state.
+data ErrAddCosigner
+    = NoDelegationTemplate
+        -- ^ Adding key for a cosigner for a non-existant delegation template is
+        -- not allowed.
+    | NoSuchCosigner CredentialType Cosigner
+        -- ^ Adding key for a cosigners for a given script is possible for the
+        -- cosigner present in the script template.
+    | KeyAlreadyPresent CredentialType
+        -- ^ Adding the same key for different cosigners for a given script is
+        -- not allowed.
+    | WalletAlreadyActive
+        -- ^ Adding is possible only to pending shared wallet.
+    | CannotUpdateSharedWalletKey
+        -- ^ Updating key is possible only for other cosigners, not cosigner
+        -- belonging to the shared wallet.
+    deriving (Eq, Show)
+
+-- | The cosigner with his account public key is updated per template.
+--
+-- For each template the script is checked for presence of the cosigner:
+--   * If present, then the key is inserted into the state.
+--   * Otherwise, fail with 'NoSuchCosigner'.
+-- If the key is already present it is going to be updated.
+-- For a given template all keys must be unique. If already present key is tried to be added,
+-- `KeyAlreadyPresent` error is produced. The updating works only with pending shared state,
+--
+-- When an active shared state is used `WalletAlreadyActive` error is triggered.
+--
+-- Updating the key for delegation script can be successful only if delegation script is
+-- present. Otherwise, `NoDelegationTemplate` error is triggered.
+addCosignerAccXPub
+    :: (SupportsDiscovery n k, WalletKey k, k ~ SharedKey)
+    => (Cosigner, k 'AccountK XPub)
+    -> CredentialType
     -> SharedState n k
-updateSharedState st f = case fields st of
-    ReadyFields _ -> st
-    PendingFields pending -> case sharedStateFromPending @n (f pending) of
-        Just ready -> st { fields = ReadyFields ready }
-        Nothing -> st { fields = PendingFields (f pending) }
+    -> Either ErrAddCosigner (SharedState n k)
+addCosignerAccXPub (cosigner, cosignerXPub) cred st = case ready st of
+    Active{} ->
+        Left WalletAlreadyActive
+    Pending ->
+        case (cred, paymentTemplate st, delegationTemplate st) of
+            (Payment, pt, _)
+                | tryingUpdateWalletCosigner pt -> Left CannotUpdateSharedWalletKey
+                | isCosignerMissing pt -> Left $ NoSuchCosigner cred cosigner
+                | isKeyAlreadyPresent pt -> Left $ KeyAlreadyPresent cred
+            (Delegation, _, Just dt)
+                | tryingUpdateWalletCosigner dt -> Left CannotUpdateSharedWalletKey
+                | isCosignerMissing dt -> Left $ NoSuchCosigner cred cosigner
+                | isKeyAlreadyPresent dt -> Left $ KeyAlreadyPresent cred
+            (Delegation, _, Nothing) -> Left NoDelegationTemplate
+            _ -> Right $
+                activate $ addCosignerPending (cosigner, cosignerXPub) cred st
+  where
+    walletKey = accountXPub st
+    isKeyAlreadyPresent (ScriptTemplate cosignerKeys _) =
+        getRawKey cosignerXPub `F.elem` cosignerKeys
+    isCosignerMissing (ScriptTemplate _ script') =
+        cosigner `notElem` retrieveAllCosigners script'
+    tryingUpdateWalletCosigner (ScriptTemplate cosignerKeys _) =
+        case Map.lookup cosigner cosignerKeys of
+            Nothing -> False
+            Just key' -> key' == getRawKey walletKey
 
-sharedStateFromPending
-    :: forall n k. (SupportsSharedState n k, WalletKey k, k ~ SharedKey)
-    => SharedStatePending k
-    -> Maybe (AddressPool 'UtxoExternal k)
-sharedStateFromPending (SharedStatePending accXPub pT dT g)
-    | templatesComplete accXPub pT dT = Just $
-        mkAddressPool @n (ParentContextShared accXPub pT dT) g []
-    | otherwise = Nothing
+addCosignerPending
+    :: WalletKey k
+    => (Cosigner, k 'AccountK XPub)
+    -> CredentialType
+    -> SharedState n k
+    -> SharedState n k
+addCosignerPending (cosigner, cosignerXPub) cred st = case cred of
+    Payment ->
+        st { paymentTemplate = updateScriptTemplate (paymentTemplate st) }
+    Delegation ->
+        st { delegationTemplate = updateScriptTemplate <$> (delegationTemplate st) }
+  where
+    updateScriptTemplate sc@(ScriptTemplate cosignerMap script')
+        | cosigner `elem` retrieveAllCosigners script' =
+            ScriptTemplate (Map.insert cosigner (getRawKey cosignerXPub) cosignerMap) script'
+        | otherwise = sc
 
+retrieveAllCosigners :: Script Cosigner -> [Cosigner]
+retrieveAllCosigners = foldScript (:) []
+
+{-------------------------------------------------------------------------------
+    Template validation
+-------------------------------------------------------------------------------}
+
+-- | Is the given account public key among the cosigners?
 accountXPubCondition
     :: WalletKey k
     => k 'AccountK XPub
@@ -357,6 +440,7 @@ validateScriptTemplates accXPub level pTemplate dTemplateM = do
           accountXPubCondition accXPub template'
       accXPubErr = "The wallet's account key must be always present for the script template."
 
+-- | Do we have all public keys in the templates?
 templatesComplete
     :: WalletKey k
     => k 'AccountK XPub
@@ -370,175 +454,82 @@ templatesComplete accXPub pTemplate dTemplate =
         isRight (validateScriptTemplate RequiredValidation template')
         && (accountXPubCondition accXPub template')
 
--- | Possible errors from adding a co-signer key to the shared wallet state.
-data ErrAddCosigner
-    = NoDelegationTemplate
-        -- ^ Adding key for a cosigner for a non-existant delegation template is
-        -- not allowed.
-    | NoSuchCosigner CredentialType Cosigner
-        -- ^ Adding key for a cosigners for a given script is possible for the
-        -- cosigner present in the script template.
-    | KeyAlreadyPresent CredentialType
-        -- ^ Adding the same key for different cosigners for a given script is
-        -- not allowed.
-    | WalletAlreadyActive
-        -- ^ Adding is possible only to pending shared wallet.
-    | CannotUpdateSharedWalletKey
-        -- ^ Updating key is possible only for other cosigners, not cosigner
-        -- belonging to the shared wallet.
-    deriving (Eq, Show)
-
--- | The cosigner with his account public key is updated per template.
---
--- For each template the script is checked for presence of the cosigner:
---   * If present, then the key is inserted into the staate.
---   * Otherwise, fail with 'NoSuchCosigner'.
--- If the key is already present it is going to be updated.
--- For a given template all keys must be unique. If already present key is tried to be added,
--- `KeyAlreadyPresent` error is produced. The updating works only with pending shared state,
---
--- When an active shared state is used `WalletAlreadyActive` error is triggered.
---
--- Updating the key for delegation script can be successful only if delegation script is
--- present. Otherwise, `NoDelegationTemplate` error is triggered.
-addCosignerAccXPub
-    :: (SupportsSharedState n k, WalletKey k, k ~ SharedKey)
-    => k 'AccountK XPub
-    -> Cosigner
-    -> CredentialType
-    -> SharedState n k
-    -> Either ErrAddCosigner (SharedState n k)
-addCosignerAccXPub accXPub cosigner cred st = case fields st of
-    ReadyFields _ ->
-        Left WalletAlreadyActive
-    PendingFields (SharedStatePending walletKey paymentTmpl delegTmpl _) ->
-        case (cred, paymentTmpl, delegTmpl) of
-            (Payment, pt, _)
-                | tryingUpdateWalletCosigner walletKey pt -> Left CannotUpdateSharedWalletKey
-                | isCosignerMissing pt -> Left $ NoSuchCosigner cred cosigner
-                | isKeyAlreadyPresent pt -> Left $ KeyAlreadyPresent cred
-            (Delegation, _, Just dt)
-                | tryingUpdateWalletCosigner walletKey dt -> Left CannotUpdateSharedWalletKey
-                | isCosignerMissing dt -> Left $ NoSuchCosigner cred cosigner
-                | isKeyAlreadyPresent dt -> Left $ KeyAlreadyPresent cred
-            (Delegation, _, Nothing) -> Left NoDelegationTemplate
-            _ -> Right $
-                 updateSharedState st $
-                 addCosignerAccXPubPending accXPub cosigner cred
-  where
-    isKeyAlreadyPresent (ScriptTemplate cosignerKeys _) =
-        getRawKey accXPub `F.elem` cosignerKeys
-    isCosignerMissing (ScriptTemplate _ script') =
-        cosigner `notElem` retrieveAllCosigners script'
-    tryingUpdateWalletCosigner walletKey (ScriptTemplate cosignerKeys _) =
-        case Map.lookup cosigner cosignerKeys of
-            Nothing -> False
-            Just key' -> key' == getRawKey walletKey
-
-addCosignerAccXPubPending
-    :: WalletKey k
-    => k 'AccountK XPub
-    -> Cosigner
-    -> CredentialType
-    -> SharedStatePending k
-    -> SharedStatePending k
-addCosignerAccXPubPending accXPub cosigner cred (SharedStatePending accXPub' pT dTM g) = SharedStatePending
-    { pendingSharedStateAccountKey = accXPub'
-    , pendingSharedStatePaymentTemplate = case cred of
-        Payment -> updateScriptTemplate pT
-        Delegation -> pT
-    , pendingSharedStateDelegationTemplate = case cred of
-        Payment -> dTM
-        Delegation -> updateScriptTemplate <$> dTM
-    , pendingSharedStateAddressPoolGap = g
-    }
-  where
-    updateScriptTemplate sc@(ScriptTemplate cosignerMap script')
-        | cosigner `elem` retrieveAllCosigners script' =
-            ScriptTemplate (Map.insert cosigner (getRawKey accXPub) cosignerMap) script'
-        | otherwise = sc
-
-retrieveAllCosigners :: Script Cosigner -> [Cosigner]
-retrieveAllCosigners = foldScript (:) []
+{-------------------------------------------------------------------------------
+    Address discovery
+-------------------------------------------------------------------------------}
 
 isShared
-    :: forall (n :: NetworkDiscriminant) k.
-       ( SoftDerivation k
-       , Typeable n
-       , MkKeyFingerprint k Address
-       , MkKeyFingerprint k (Proxy n, k 'AddressK XPub) )
+    :: SupportsDiscovery n k
     => Address
     -> SharedState n k
     -> (Maybe (Index 'Soft 'ScriptK), SharedState n k)
-isShared addr st = case fields st of
-    ReadyFields pool ->
-        let (ixM, pool') = lookupAddress @n (const Used) addr pool
-        in case ixM of
-            Just ix ->
-                ( Just $ coerce ix
-                , st { fields = ReadyFields pool' })
-            Nothing ->
-                (Nothing, st)
-    PendingFields _ ->
-        (Nothing, st)
-
-instance
-    ( SoftDerivation k
-    , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
-    , MkKeyFingerprint k Address
-    , Typeable n
-    ) => IsOurs (SharedState n k) Address
+isShared addrRaw st = case ready st of
+    Pending -> nop
+    Active pool -> case paymentKeyFingerprint addrRaw of
+        Left _ -> nop
+        Right addr -> case AddressPool.lookup addr pool of
+            Nothing -> nop
+            Just ix -> let pool' = AddressPool.update addr pool in
+                ( Just ix , st { ready = Active pool' } )
   where
-    isOurs addr state@(SharedState prefix _) =
-        let DerivationPrefix (purpose, coinType, accIx) = prefix
-            decorateIx addrIx = NE.fromList
-                [ DerivationIndex $ getIndex purpose
-                , DerivationIndex $ getIndex coinType
-                , DerivationIndex $ getIndex accIx
-                , DerivationIndex $ getIndex utxoExternal
-                , DerivationIndex $ getIndex addrIx
-                ]
-            in first (fmap decorateIx) (isShared addr state)
+    nop = (Nothing, st)
+    -- FIXME: Check that the network discrimant of the type
+    -- is compatible with the discriminant of the Address!
+
+instance SupportsDiscovery n k => IsOurs (SharedState n k) Address
+  where
+    isOurs addr st = first (fmap (decoratePath st)) (isShared addr st)
+
+-- | Decorate an index with the derivation prefix corresponding to the state.
+decoratePath
+    :: SharedState n key
+    -> Index 'Soft 'ScriptK
+    -> NE.NonEmpty DerivationIndex
+decoratePath st ix = NE.fromList
+    [ DerivationIndex $ getIndex purpose
+    , DerivationIndex $ getIndex coinType
+    , DerivationIndex $ getIndex accIx
+    , DerivationIndex $ getIndex utxoExternal
+    , DerivationIndex $ getIndex ix
+    ] 
+  where
+    DerivationPrefix (purpose, coinType, accIx) = derivationPrefix st
 
 instance IsOurs (SharedState n k) RewardAccount where
-    isOurs _account state = (Nothing, state)
+    isOurs _account st = (Nothing, st)
 
 instance GetAccount (SharedState n k) k where
-    getAccount (SharedState _ (PendingFields pending)) =
-        pendingSharedStateAccountKey pending
-    getAccount (SharedState _ (ReadyFields pool)) =
-        let (ParentContextShared accXPub _ _) = context pool
-        in accXPub
+    getAccount = accountXPub
 
-instance
-    ( MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
-    , MkKeyFingerprint k Address
-    , SoftDerivation k
-    , Typeable n
-    ) => CompareDiscovery (SharedState n k) where
-    compareDiscovery (SharedState _ state) a1 a2 = case state of
-        PendingFields _ -> error "comparing addresses in pending shared state does not make sense"
-        ReadyFields pool ->
+instance SupportsDiscovery n k => CompareDiscovery (SharedState n k) where
+    compareDiscovery st a1 a2 = case ready st of
+        Pending ->
+            error "comparing addresses in pending shared state does not make sense"
+        Active pool ->
             case (ix a1 pool, ix a2 pool) of
                 (Nothing, Nothing) -> EQ
                 (Nothing, Just _)  -> GT
                 (Just _, Nothing)  -> LT
                 (Just i1, Just i2) -> compare i1 i2
       where
-        ix :: Address -> AddressPool 'UtxoExternal k -> Maybe (Index 'Soft 'AddressK)
-        ix a = fst . lookupAddress @n id a
+        ix :: Address -> SharedAddressPool k -> Maybe (Index 'Soft 'ScriptK)
+        ix a pool = case paymentKeyFingerprint a of
+            Left _ -> Nothing
+            Right addr -> AddressPool.lookup addr pool
 
-instance
-    ( Typeable n
-    , GetPurpose k
-    ) => KnownAddresses (SharedState n k) where
-    knownAddresses (SharedState _ s) = nonChangeAddresses
+instance Typeable n => KnownAddresses (SharedState n k) where
+    knownAddresses st = nonChangeAddresses
       where
-          -- TODO - After enabling txs for shared wallets we will need to expand this
-          nonChangeAddresses = case s of
-              PendingFields _ -> []
-              ReadyFields externalPool ->
-                  addresses (liftPaymentAddress @n @k) externalPool
+        -- TODO - After enabling txs for shared wallets we will need to expand this
+        nonChangeAddresses = case ready st of
+            Pending -> []
+            Active pool -> map swivel $ Map.toList $ AddressPool.addresses pool
+        swivel (k,(ix,s)) = (liftPaymentAddress @n k, s, decoratePath st ix)
+
+{-------------------------------------------------------------------------------
+    Address utilities
+    Payment and Delegation parts
+-------------------------------------------------------------------------------}
 
 data CredentialType = Payment | Delegation
     deriving (Eq, Show, Generic)

--- a/lib/core/test/unit/Cardano/Wallet/Address/PoolSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Address/PoolSpec.hs
@@ -1,0 +1,74 @@
+module Cardano.Wallet.Address.PoolSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Address.Pool
+    ( Pool, addresses, generator, prop_consistent, prop_fresh, prop_gap )
+import Cardano.Wallet.Primitive.Types.Address
+    ( AddressState (..) )
+import Test.Hspec
+    ( Spec, describe, it, parallel )
+import Test.QuickCheck
+    ( Gen, Property, choose, forAll, listOf, oneof, (===) )
+
+import qualified Cardano.Wallet.Address.Pool as AddressPool
+import qualified Data.Map.Strict as Map
+
+spec :: Spec
+spec = do
+    parallel $ describe "Cardano.Wallet.Address.Pool" $ do
+        it "prop_consistent . new" $
+            prop_consistent testPool
+
+        it "generator satisfies prop_gap and prop_fresh" $
+            forAll genUsageWithGap $ \usage ->
+                let pool = fromUsage usage
+                in  all ($ pool) [prop_gap, prop_fresh]
+
+        it "sequence of updates preserves invariants"
+            prop_updates
+
+        it "update does nothing on addresses outside the gap" $
+            let p1 = testPool
+                p2 = AddressPool.update (AddressPool.gap p1 + 1) p1
+            in  addresses p1 === addresses p2
+
+prop_updates :: Property
+prop_updates = forAll genUsageWithGap $ \usage ->
+    let addr ix = AddressPool.generator testPool ix
+        g       = AddressPool.gap testPool
+        addrs1  = [ addr ix | (ix,Used) <- zip [0..] usage ]
+        addrs2  = map addr [0..2*g]
+        pool    = foldl (flip AddressPool.update) testPool (addrs1 <> addrs2)
+    in  prop_consistent pool
+
+{-------------------------------------------------------------------------------
+    Generators
+-------------------------------------------------------------------------------}
+type TestPool = Pool Int Int
+
+-- | Test pool with small parameters suitable for testing.
+testPool :: TestPool
+testPool = AddressPool.new id 5
+
+{- HLINT ignore "Use zipWith" -}
+-- | Make a testing pool from a given list of address statuses
+fromUsage :: [AddressState] -> TestPool
+fromUsage = AddressPool.loadUnsafe testPool
+    . Map.fromList . map decorate . zip [0..]
+  where
+    decorate (ix,status) = (generator testPool ix, (ix, status))
+
+-- | Generate address statuses that respect the address gap.
+genUsageWithGap :: Gen [AddressState]
+genUsageWithGap = do
+    xs <- listOf uu
+    y  <- used
+    pure $ concat xs <> y <> replicate gap Unused
+  where
+    gap    = AddressPool.gap testPool
+    used   = flip replicate Used <$> oneof [choose (1,3), choose (gap+1,2*gap)]
+    unused = flip replicate Unused <$> choose (0,gap-1)
+    uu     = (<>) <$> used <*> unused

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -565,7 +565,7 @@ server byron icarus shelley multisig spl ntp =
         :: ApiLayer (SharedState n SharedKey) SharedKey
         -> Server (SharedAddresses n)
     sharedAddresses apilayer =
-             listAddresses apilayer (normalizeSharedAddress @_ @SharedKey @n)
+             listAddresses apilayer normalizeSharedAddress
 
 postAnyAddress
     :: NetworkId


### PR DESCRIPTION
### Issue number

ADP-1308

### Overview

Previous work in epic ADP-1043 introduced delta encodings, DBVars, and an embedding of the wallet state and its delta encodings into a database table. It's time to integrate these tools with the wallet code. To facilitate code review, the integration proceeds in a sequence of refactorings that do not change functionality and pass all unit tests.

In this step, we continue refactoring the address discovery state.

* First, we implement a new abstract data type, `Pool addr ix`, which aids with BIP-44 style address discovery. Its main benefit is that it is polymorphic in the address type and thus focuses on the essence of address discovery with an address gap while avoiding the plethora of type classes related to specific address formats.
* Then, we use this data type to simplify the implementation of the address discovery state for mult-signature wallets, `SharedState n k`.

### Details

* `Pool` is an abstract data type, its constructor is not to be exported. Its internal invariants are collected in `prop_consistent`. To bypass the invariants, use `loadUnsafe`; the database layer is allowed to do that.
* Some of the unit tests pertaining to the address discovery aspects `SharedState` are partially superseded by the more general unit tests in `Cardano.Wallet.Address.PoolSpec`.
 
### Comments

* The `SeqState n k` states will be refactored in terms of the new `Pool addr ix` data type next.
*  Merge PR #3056 before this one, because this pull request is based on the branch of the former.