### PR TITLE
Refactor and simplify `SeqState n k`

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -737,6 +737,7 @@ createIcarusWallet
         , PaymentAddress n k
         , k ~ IcarusKey
         , s ~ SeqState n k
+        , Typeable n
         )
     => ctx
     -> WalletId

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -352,6 +352,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( DerivationPrefix (..)
     , SeqState (..)
     , defaultAddressPoolGap
+    , getGap
     , mkSeqStateFromAccountXPub
     , mkSeqStateFromRootXPrv
     , purposeCIP1852
@@ -748,7 +749,6 @@ postWallet
         , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
         , MkKeyFingerprint k Address
         , WalletKey k
-        , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
         , HasDBFactory s k ctx
         , HasWorkerRegistry s k ctx
         , IsOurs s RewardAccount
@@ -776,7 +776,6 @@ postShelleyWallet
         , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
         , MkKeyFingerprint k Address
         , WalletKey k
-        , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
         , HasDBFactory s k ctx
         , HasWorkerRegistry s k ctx
         , IsOurs s RewardAccount
@@ -816,6 +815,7 @@ postAccountWallet
         , HasWorkerRegistry s k ctx
         , IsOurs s RewardAccount
         , (k == SharedKey) ~ 'False
+        , Typeable n
         )
     => ctx
     -> MkApiWallet ctx s w
@@ -873,7 +873,7 @@ mkShelleyWallet ctx wid cp meta pending progress = do
     let available = availableBalance pending cp
     let total = totalBalance pending reward cp
     pure ApiWallet
-        { addressPoolGap = ApiT $ getState cp ^. #externalPool . #gap
+        { addressPoolGap = ApiT $ getGap $ getState cp ^. #externalPool
         , balance = ApiWalletBalance
             { available = coinToQuantity (available ^. #coin)
             , total = coinToQuantity (total ^. #coin)
@@ -1269,6 +1269,7 @@ postIcarusWallet
         , k ~ IcarusKey
         , HasWorkerRegistry s k ctx
         , PaymentAddress n IcarusKey
+        , Typeable n
         )
     => ctx
     -> ByronWalletPostData '[12,15,18,21,24]
@@ -1289,6 +1290,7 @@ postTrezorWallet
         , k ~ IcarusKey
         , HasWorkerRegistry s k ctx
         , PaymentAddress n IcarusKey
+        , Typeable n
         )
     => ctx
     -> ByronWalletPostData '[12,15,18,21,24]
@@ -1309,6 +1311,7 @@ postLedgerWallet
         , k ~ IcarusKey
         , HasWorkerRegistry s k ctx
         , PaymentAddress n IcarusKey
+        , Typeable n
         )
     => ctx
     -> ByronWalletPostData '[12,15,18,21,24]

--- a/lib/core/test/unit/Cardano/Wallet/Address/PoolSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Address/PoolSpec.hs
@@ -1,5 +1,7 @@
 module Cardano.Wallet.Address.PoolSpec
     ( spec
+    , genPool
+    , shrinkPool
     ) where
 
 import Prelude
@@ -8,14 +10,19 @@ import Cardano.Wallet.Address.Pool
     ( Pool, addresses, generator, prop_consistent, prop_fresh, prop_gap )
 import Cardano.Wallet.Primitive.Types.Address
     ( AddressState (..) )
+import Data.List
+    ( sortOn )
 import Test.Hspec
     ( Spec, describe, it, parallel )
 import Test.QuickCheck
-    ( Gen, Property, choose, forAll, listOf, oneof, (===) )
+    ( Gen, Property, choose, forAll, listOf, oneof, sized, (===) )
 
 import qualified Cardano.Wallet.Address.Pool as AddressPool
 import qualified Data.Map.Strict as Map
 
+{-------------------------------------------------------------------------------
+    Properties
+-------------------------------------------------------------------------------}
 spec :: Spec
 spec = do
     parallel $ describe "Cardano.Wallet.Address.Pool" $ do
@@ -23,26 +30,54 @@ spec = do
             prop_consistent testPool
 
         it "generator satisfies prop_gap and prop_fresh" $
-            forAll genUsageWithGap $ \usage ->
-                let pool = fromUsage usage
+            forAll (genUsageForGap $ AddressPool.gap testPool) $ \usage ->
+                let pool = fromUsage testPool usage
                 in  all ($ pool) [prop_gap, prop_fresh]
 
-        it "sequence of updates preserves invariants"
-            prop_updates
+        it "sequence of updates preserves invariants" $
+            prop_updates testPool
+
+        it "order of updates (within range) is irrelevant for pool content" $
+            prop_updates_order $ AddressPool.new (id :: Int -> Int) 3
 
         it "update does nothing on addresses outside the gap" $
             let p1 = testPool
                 p2 = AddressPool.update (AddressPool.gap p1 + 1) p1
             in  addresses p1 === addresses p2
 
-prop_updates :: Property
-prop_updates = forAll genUsageWithGap $ \usage ->
-    let addr ix = AddressPool.generator testPool ix
-        g       = AddressPool.gap testPool
-        addrs1  = [ addr ix | (ix,Used) <- zip [0..] usage ]
-        addrs2  = map addr [0..2*g]
-        pool    = foldl (flip AddressPool.update) testPool (addrs1 <> addrs2)
-    in  prop_consistent pool
+prop_updates :: (Ord addr, Ord ix, Enum ix) => Pool addr ix -> Property
+prop_updates pool = forAll (genUsageForGap $ AddressPool.gap pool) $ \usage ->
+    let addr ix = AddressPool.generator pool ix
+        g       = AddressPool.gap pool
+        addrs1  = [ addr ix | (ix,Used) <- zip [toEnum 0..] usage ]
+        addrs2  = map (addr . toEnum) [0..2*g]
+        pool1   = foldl (flip AddressPool.update) pool (addrs1 <> addrs2)
+    in  prop_consistent pool1
+
+prop_updates_order
+    :: (Ord addr, Ord ix, Enum ix, Show addr, Show ix)
+    => Pool addr ix -> Property
+prop_updates_order pool0 = forAll genUpdates $ \pool ->
+      AddressPool.addresses pool
+    ===
+      AddressPool.addresses (applyUsageInOrder pool0 $ toUsage pool)
+  where
+    addr ix = AddressPool.generator pool0 ix
+    g       = AddressPool.gap pool0
+
+    -- generate and apply a random sequence of updates
+    genUpdates = sized $ randomUpdates pool0
+    randomUpdates pool 0 = pure pool
+    randomUpdates pool n = do
+        let end = AddressPool.size pool - 1
+        ix <- toEnum <$>
+            oneof [choose (0,end), choose (end-(g-1),end)]
+        randomUpdates (AddressPool.update (addr ix) pool) (n-1)
+
+    applyUsageInOrder pool usage =
+        foldl (flip AddressPool.update) pool
+            [ addr ix | (ix,Used) <- zip [toEnum 0..] usage ]
+    toUsage = map snd . sortOn fst . Map.elems . AddressPool.addresses
 
 {-------------------------------------------------------------------------------
     Generators
@@ -53,22 +88,66 @@ type TestPool = Pool Int Int
 testPool :: TestPool
 testPool = AddressPool.new id 5
 
-{- HLINT ignore "Use zipWith" -}
--- | Make a testing pool from a given list of address statuses
-fromUsage :: [AddressState] -> TestPool
-fromUsage = AddressPool.loadUnsafe testPool
-    . Map.fromList . map decorate . zip [0..]
+-- | Fill a given pool from a list of address statuses
+fromUsage :: (Ord addr, Enum ix) => Pool addr ix -> [AddressState] -> Pool addr ix
+fromUsage pool = AddressPool.loadUnsafe pool
+    . Map.fromList . zipWith decorate [(toEnum 0)..]
   where
-    decorate (ix,status) = (generator testPool ix, (ix, status))
+    decorate ix status = (generator pool ix, (ix, status))
 
 -- | Generate address statuses that respect the address gap.
-genUsageWithGap :: Gen [AddressState]
-genUsageWithGap = do
+genUsageForGap :: Int -> Gen [AddressState]
+genUsageForGap gap = do
     xs <- listOf uu
     y  <- used
     pure $ concat xs <> y <> replicate gap Unused
   where
-    gap    = AddressPool.gap testPool
     used   = flip replicate Used <$> oneof [choose (1,3), choose (gap+1,2*gap)]
     unused = flip replicate Unused <$> choose (0,gap-1)
     uu     = (<>) <$> used <*> unused
+
+-- | Generate a random address Pool that satisfies 'prop_consistent'
+-- from existing pool (parameters).
+genPool :: (Ord addr, Enum ix) => Pool addr ix -> Gen (Pool addr ix)
+genPool pool = fromUsage pool <$> genUsageForGap (AddressPool.gap pool) 
+
+{-------------------------------------------------------------------------------
+    Shrinkers
+-------------------------------------------------------------------------------}
+-- | Shrink an address pool. The gap will be shrunk as well.
+shrinkPool
+    :: (Ord addr, Enum ix)
+    => Int -- ^ minimum gap to shrink to
+    -> Pool addr ix -> [Pool addr ix]
+shrinkPool minGap pool
+    | k == gap && gap == minGap = []
+    | k == gap && gap >  minGap = [ minimalPool ]
+    | otherwise =
+        [ minimalPool
+        , AddressPool.clear pool
+        , AddressPool.loadUnsafe pool $ removeN n gap $ AddressPool.addresses pool
+        ]
+  where
+    k = AddressPool.size pool
+    n = gap `div` 5
+    gap = AddressPool.gap pool
+    minimalPool = AddressPool.new (AddressPool.generator pool) minGap
+
+-- | Remove the top @n@ indices and restore the upper @gap@ indices to 'Unused'.
+--
+-- Note: This function is only used for shrinking and not unit tested.
+-- This is ok, because a bug in the shrinker only affects
+-- our ability to find the cause of a bug,
+-- but does not affect the visibility of said bug.
+removeN
+    :: Enum ix
+    => Int -> Int
+    -> Map.Map addr (ix, AddressState)
+    -> Map.Map addr (ix, AddressState)
+removeN n gap addrs = Map.map unuse $ Map.filter (not . isTop) addrs
+  where
+    top = Map.size addrs - 1 -- topmost index
+    isTop (ix,_) = top <= fromEnum ix + (n-1)
+    unuse a@(ix,_)
+        | top <= fromEnum ix + (n-1) + gap = (ix, Unused)
+        | otherwise = a

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -108,7 +108,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , KeyFingerprint
     , NetworkDiscriminant (..)
     , PersistPrivateKey (..)
-    , Role (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
@@ -121,7 +120,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
-    ( AddressPool (..), AddressPoolGap, SeqState (..) )
+    ( AddressPoolGap, SeqState (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( Readiness, SharedState (..) )
 import Cardano.Wallet.Primitive.Model
@@ -968,13 +967,6 @@ instance ToExpr (SeqState 'Mainnet ShelleyKey) where
     toExpr = defaultExprViaShow
 
 instance ToExpr (RndState 'Mainnet) where
-    toExpr = defaultExprViaShow
-
-instance (Show (key 'AccountK CC.XPub)) =>
-    ToExpr (AddressPool
-        (chain :: Role)
-        (key :: Depth -> * -> *)
-    ) where
     toExpr = defaultExprViaShow
 
 instance ToExpr a => ToExpr (Readiness a) where


### PR DESCRIPTION
### Issue number

ADP-1308

### Overview

Previous work in epic ADP-1043 introduced delta encodings, DBVars, and an embedding of the wallet state and its delta encodings into a database table. It's time to integrate these tools with the wallet code. To facilitate code review, the integration proceeds in a sequence of refactorings that do not change functionality and pass all unit tests.

In this step, we continue refactoring the address discovery state. Here, we refactor and simplify the `SeqState n k` type to use the new abstract data type `Pool addr ix`, which aids with BIP-44 style address discovery.

### Details

* The testing module `PoolSpec` now also provides a shrinker `shrinkPool` for use in the old testing module `Cardano.Wallet.Primitive.AddressDiscovery.SequentialSpec`.
* The property tests pertaining to the address discovery aspects of `SeqState` are superseded by the more general unit tests in `Cardano.Wallet.Address.PoolSpec`.
 
### Comments

* Merge PR ##3068 before this one, because this pull request is based on the branch of the former.
