### PR TITLE
Successfully depend on Plutus

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -102,17 +102,18 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: 1efbb276ef1a10ca6961d0fd32e6141e9798bd11
+  tag: 4710dff2e30ce131191a6a1ccbe43595b2e3af24
   subdir:
-    freer-extras
+    plutus-benchmark
     plutus-core
-    plutus-ledger
+    plutus-errors
     plutus-ledger-api
+    plutus-metatheory
     plutus-tx
     plutus-tx-plugin
     prettyprinter-configurable
-    stubs/plutus-ghc-stub
     word-array
+    stubs/plutus-ghc-stub
 
 source-repository-package
   type: git

--- a/cabal.project
+++ b/cabal.project
@@ -102,7 +102,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: 4710dff2e30ce131191a6a1ccbe43595b2e3af24
+  tag: 103fe104e8138dcf2a8d52d5e45177bac4e396b1
   subdir:
     plutus-benchmark
     plutus-core

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -77,6 +77,8 @@ library
     , microstache
     , network-uri
     , optparse-applicative
+    , plutus-ledger-api
+    , plutus-tx-plugin
     , process
     , resourcet
     , retry

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -74,6 +74,8 @@
           (hsPkgs."microstache" or (errorHandler.buildDepError "microstache"))
           (hsPkgs."network-uri" or (errorHandler.buildDepError "network-uri"))
           (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+          (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+          (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
           (hsPkgs."process" or (errorHandler.buildDepError "process"))
           (hsPkgs."resourcet" or (errorHandler.buildDepError "resourcet"))
           (hsPkgs."retry" or (errorHandler.buildDepError "retry"))

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -141,28 +141,23 @@
         cardano-client = ./cardano-client.nix;
         ntp-client = ./ntp-client.nix;
         ouroboros-consensus-mock = ./ouroboros-consensus-mock.nix;
-        freer-extras = ./freer-extras.nix;
-        playground-common = ./playground-common.nix;
-        plutus-chain-index = ./plutus-chain-index.nix;
-        plutus-contract = ./plutus-contract.nix;
+        plutus-benchmark = ./plutus-benchmark.nix;
         plutus-core = ./plutus-core.nix;
-        plutus-ledger = ./plutus-ledger.nix;
+        plutus-errors = ./plutus-errors.nix;
         plutus-ledger-api = ./plutus-ledger-api.nix;
-        plutus-pab = ./plutus-pab.nix;
+        plutus-metatheory = ./plutus-metatheory.nix;
         plutus-tx = ./plutus-tx.nix;
         plutus-tx-plugin = ./plutus-tx-plugin.nix;
-        plutus-use-cases = ./plutus-use-cases.nix;
-        plutus-ghc-stub = ./plutus-ghc-stub.nix;
         prettyprinter-configurable = ./prettyprinter-configurable.nix;
-        quickcheck-dynamic = ./quickcheck-dynamic.nix;
         word-array = ./word-array.nix;
+        plutus-ghc-stub = ./plutus-ghc-stub.nix;
         ekg-forward = ./ekg-forward.nix;
         cardano-config = ./cardano-config.nix;
         servant-purescript = ./servant-purescript.nix;
         Win32-network = ./Win32-network.nix;
         };
-      compiler.version = "8.10.7";
-      compiler.nix-name = "ghc8107";
+      compiler.version = "8.10.420210212";
+      compiler.nix-name = "ghc810420210212";
       };
   resolver = "lts-18.21";
   modules = [
@@ -182,5 +177,5 @@
     ({ lib, ... }:
       { planned = lib.mkOverride 900 true; })
     ];
-  compiler = "ghc-8.10.7";
+  compiler = "ghc-8.10.4-2021-02-12";
   }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -156,8 +156,8 @@
         servant-purescript = ./servant-purescript.nix;
         Win32-network = ./Win32-network.nix;
         };
-      compiler.version = "8.10.420210212";
-      compiler.nix-name = "ghc810420210212";
+      compiler.version = "8.10.7";
+      compiler.nix-name = "ghc8107";
       };
   resolver = "lts-18.21";
   modules = [
@@ -177,5 +177,5 @@
     ({ lib, ... }:
       { planned = lib.mkOverride 900 true; })
     ];
-  compiler = "ghc-8.10.4-2021-02-12";
+  compiler = "ghc-8.10.7";
   }

--- a/nix/.stack.nix/plutus-benchmark.nix
+++ b/nix/.stack.nix/plutus-benchmark.nix
@@ -1,0 +1,180 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.2";
+      identifier = { name = "plutus-benchmark"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "radu.ometita@iohk.io";
+      author = "Radu Ometita";
+      homepage = "https://github.com/iohk/plutus#readme";
+      url = "";
+      synopsis = "";
+      description = "Please see the README on GitHub at <https://github.com/input-output-hk/plutus#readme>";
+      buildType = "Simple";
+      isLocal = true;
+      };
+    components = {
+      sublibs = {
+        "plutus-benchmark-common" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            ];
+          buildable = true;
+          };
+        "nofib-internal" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark".components.sublibs.plutus-benchmark-common or (errorHandler.buildDepError "plutus-benchmark:plutus-benchmark-common"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
+            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            ];
+          buildable = true;
+          };
+        "lists-internal" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark".components.sublibs.plutus-benchmark-common or (errorHandler.buildDepError "plutus-benchmark:plutus-benchmark-common"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
+            ];
+          buildable = true;
+          };
+        };
+      exes = {
+        "nofib-exe" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark".components.sublibs.plutus-benchmark-common or (errorHandler.buildDepError "plutus-benchmark:plutus-benchmark-common"))
+            (hsPkgs."plutus-benchmark".components.sublibs.nofib-internal or (errorHandler.buildDepError "plutus-benchmark:nofib-internal"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."ansi-wl-pprint" or (errorHandler.buildDepError "ansi-wl-pprint"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            ];
+          buildable = true;
+          };
+        "list-sort-exe" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark".components.sublibs.plutus-benchmark-common or (errorHandler.buildDepError "plutus-benchmark:plutus-benchmark-common"))
+            (hsPkgs."plutus-benchmark".components.sublibs.lists-internal or (errorHandler.buildDepError "plutus-benchmark:lists-internal"))
+            (hsPkgs."monoidal-containers" or (errorHandler.buildDepError "monoidal-containers"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            ];
+          buildable = true;
+          };
+        };
+      tests = {
+        "plutus-benchmark-nofib-tests" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark".components.sublibs.plutus-benchmark-common or (errorHandler.buildDepError "plutus-benchmark:plutus-benchmark-common"))
+            (hsPkgs."plutus-benchmark".components.sublibs.nofib-internal or (errorHandler.buildDepError "plutus-benchmark:nofib-internal"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            ];
+          buildable = true;
+          };
+        "plutus-benchmark-lists-tests" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark".components.sublibs.plutus-benchmark-common or (errorHandler.buildDepError "plutus-benchmark:plutus-benchmark-common"))
+            (hsPkgs."plutus-benchmark".components.sublibs.lists-internal or (errorHandler.buildDepError "plutus-benchmark:lists-internal"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            ];
+          buildable = true;
+          };
+        };
+      benchmarks = {
+        "nofib" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark".components.sublibs.plutus-benchmark-common or (errorHandler.buildDepError "plutus-benchmark:plutus-benchmark-common"))
+            (hsPkgs."plutus-benchmark".components.sublibs.nofib-internal or (errorHandler.buildDepError "plutus-benchmark:nofib-internal"))
+            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+            ];
+          buildable = true;
+          };
+        "nofib-hs" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark".components.sublibs.plutus-benchmark-common or (errorHandler.buildDepError "plutus-benchmark:plutus-benchmark-common"))
+            (hsPkgs."plutus-benchmark".components.sublibs.nofib-internal or (errorHandler.buildDepError "plutus-benchmark:nofib-internal"))
+            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+            ];
+          buildable = true;
+          };
+        "lists" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark".components.sublibs.plutus-benchmark-common or (errorHandler.buildDepError "plutus-benchmark:plutus-benchmark-common"))
+            (hsPkgs."plutus-benchmark".components.sublibs.lists-internal or (errorHandler.buildDepError "plutus-benchmark:lists-internal"))
+            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+            ];
+          buildable = true;
+          };
+        "validation" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark".components.sublibs.plutus-benchmark-common or (errorHandler.buildDepError "plutus-benchmark:plutus-benchmark-common"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            ];
+          buildable = true;
+          };
+        "cek-calibration" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
+            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+            ];
+          buildable = true;
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/plutus";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      }) // {
+      url = "https://github.com/input-output-hk/plutus";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      };
+    postUnpack = "sourceRoot+=/plutus-benchmark; echo source root reset to \$sourceRoot";
+    }

--- a/nix/.stack.nix/plutus-benchmark.nix
+++ b/nix/.stack.nix/plutus-benchmark.nix
@@ -169,12 +169,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       };
     postUnpack = "sourceRoot+=/plutus-benchmark; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/plutus-core.nix
+++ b/nix/.stack.nix/plutus-core.nix
@@ -340,12 +340,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       };
     postUnpack = "sourceRoot+=/plutus-core; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/plutus-core.nix
+++ b/nix/.stack.nix/plutus-core.nix
@@ -110,6 +110,7 @@
         "plc" = {
           depends = [
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
@@ -144,12 +145,32 @@
         "pir" = {
           depends = [
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
             (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."monoidal-containers" or (errorHandler.buildDepError "monoidal-containers"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+            (hsPkgs."cassava" or (errorHandler.buildDepError "cassava"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            ];
+          buildable = true;
+          };
+        "traceToStacks" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cassava" or (errorHandler.buildDepError "cassava"))
+            (hsPkgs."integer-gmp" or (errorHandler.buildDepError "integer-gmp"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
             ];
           buildable = true;
           };
@@ -185,6 +206,10 @@
             (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+            (hsPkgs."th-lift-instances" or (errorHandler.buildDepError "th-lift-instances"))
+            (hsPkgs."th-utilities" or (errorHandler.buildDepError "th-utilities"))
             ];
           buildable = true;
           };
@@ -223,6 +248,18 @@
             ];
           buildable = true;
           };
+        "traceToStacks-test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cassava" or (errorHandler.buildDepError "cassava"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
+            ];
+          buildable = true;
+          };
         "index-envs-test" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
@@ -247,7 +284,10 @@
             (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
             (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError "quickcheck-instances"))
             (hsPkgs."random" or (errorHandler.buildDepError "random"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
             ];
           buildable = true;
           };
@@ -279,6 +319,7 @@
             (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
             (hsPkgs."inline-r" or (errorHandler.buildDepError "inline-r"))
             (hsPkgs."mmorph" or (errorHandler.buildDepError "mmorph"))
+            (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
             ];
@@ -299,12 +340,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "1efbb276ef1a10ca6961d0fd32e6141e9798bd11";
-      sha256 = "1jicyk4hr8p0xksj4048gdxndrb42jz4wsnkhc3ymxbm5v6snalf";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "1efbb276ef1a10ca6961d0fd32e6141e9798bd11";
-      sha256 = "1jicyk4hr8p0xksj4048gdxndrb42jz4wsnkhc3ymxbm5v6snalf";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
       };
     postUnpack = "sourceRoot+=/plutus-core; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/plutus-errors.nix
+++ b/nix/.stack.nix/plutus-errors.nix
@@ -63,12 +63,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       };
     postUnpack = "sourceRoot+=/plutus-errors; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/plutus-errors.nix
+++ b/nix/.stack.nix/plutus-errors.nix
@@ -1,0 +1,74 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.2";
+      identifier = { name = "plutus-errors"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "nikolaos.bezirgiannis@iohk.io";
+      author = "Nikolaos Bezirgiannis";
+      homepage = "";
+      url = "";
+      synopsis = "The error codes of the Plutus compiler & runtime";
+      description = "Contains the documentation and helper code of all the errors and their error-codes\nwhich can be thrown by the Plutus framework: compiler, interpreter, and client code";
+      buildType = "Simple";
+      isLocal = true;
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."th-abstraction" or (errorHandler.buildDepError "th-abstraction"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+          (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+          (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+          (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
+          ];
+        buildable = true;
+        };
+      exes = {
+        "plutus-errors-next" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."plutus-errors" or (errorHandler.buildDepError "plutus-errors"))
+            (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+            ];
+          buildable = true;
+          };
+        "plutus-errors-bootstrap" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+            (hsPkgs."th-abstraction" or (errorHandler.buildDepError "th-abstraction"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."plutus-errors" or (errorHandler.buildDepError "plutus-errors"))
+            ];
+          buildable = true;
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/plutus";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      }) // {
+      url = "https://github.com/input-output-hk/plutus";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      };
+    postUnpack = "sourceRoot+=/plutus-errors; echo source root reset to \$sourceRoot";
+    }

--- a/nix/.stack.nix/plutus-ghc-stub.nix
+++ b/nix/.stack.nix/plutus-ghc-stub.nix
@@ -37,12 +37,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "1efbb276ef1a10ca6961d0fd32e6141e9798bd11";
-      sha256 = "1jicyk4hr8p0xksj4048gdxndrb42jz4wsnkhc3ymxbm5v6snalf";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "1efbb276ef1a10ca6961d0fd32e6141e9798bd11";
-      sha256 = "1jicyk4hr8p0xksj4048gdxndrb42jz4wsnkhc3ymxbm5v6snalf";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
       };
     postUnpack = "sourceRoot+=/stubs/plutus-ghc-stub; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/plutus-ghc-stub.nix
+++ b/nix/.stack.nix/plutus-ghc-stub.nix
@@ -37,12 +37,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       };
     postUnpack = "sourceRoot+=/stubs/plutus-ghc-stub; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/plutus-ledger-api.nix
+++ b/nix/.stack.nix/plutus-ledger-api.nix
@@ -74,12 +74,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       };
     postUnpack = "sourceRoot+=/plutus-ledger-api; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/plutus-ledger-api.nix
+++ b/nix/.stack.nix/plutus-ledger-api.nix
@@ -55,12 +55,17 @@
         "plutus-ledger-api-test" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
             (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
             (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
             (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             ];
           buildable = true;
           };
@@ -69,12 +74,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "1efbb276ef1a10ca6961d0fd32e6141e9798bd11";
-      sha256 = "1jicyk4hr8p0xksj4048gdxndrb42jz4wsnkhc3ymxbm5v6snalf";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "1efbb276ef1a10ca6961d0fd32e6141e9798bd11";
-      sha256 = "1jicyk4hr8p0xksj4048gdxndrb42jz4wsnkhc3ymxbm5v6snalf";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
       };
     postUnpack = "sourceRoot+=/plutus-ledger-api; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/plutus-metatheory.nix
+++ b/nix/.stack.nix/plutus-metatheory.nix
@@ -103,12 +103,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       };
     postUnpack = "sourceRoot+=/plutus-metatheory; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/plutus-metatheory.nix
+++ b/nix/.stack.nix/plutus-metatheory.nix
@@ -1,0 +1,114 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.4";
+      identifier = { name = "plutus-metatheory"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "james.chapman@iohk.io";
+      author = "James Chapman";
+      homepage = "https://github.com/input-output-hk/plutus";
+      url = "";
+      synopsis = "Command line tool for running plutus core programs";
+      description = "";
+      buildType = "Custom";
+      isLocal = true;
+      setup-depends = [
+        (hsPkgs.buildPackages.base or (pkgs.buildPackages.base or (errorHandler.setupDepError "base")))
+        (hsPkgs.buildPackages.Cabal or (pkgs.buildPackages.Cabal or (errorHandler.setupDepError "Cabal")))
+        (hsPkgs.buildPackages.process or (pkgs.buildPackages.process or (errorHandler.setupDepError "process")))
+        (hsPkgs.buildPackages.turtle or (pkgs.buildPackages.turtle or (errorHandler.setupDepError "turtle")))
+        ];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
+          (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."ieee754" or (errorHandler.buildDepError "ieee754"))
+          (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+          (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+          (hsPkgs."process" or (errorHandler.buildDepError "process"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+          ];
+        buildable = true;
+        };
+      exes = {
+        "plc-agda" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-metatheory" or (errorHandler.buildDepError "plutus-metatheory"))
+            ];
+          buildable = true;
+          };
+        };
+      tests = {
+        "test1" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-metatheory" or (errorHandler.buildDepError "plutus-metatheory"))
+            (hsPkgs."process" or (errorHandler.buildDepError "process"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.plutus-core.components.exes.plc or (pkgs.buildPackages.plc or (errorHandler.buildToolDepError "plutus-core:plc")))
+            (hsPkgs.buildPackages.plutus-core.components.exes.uplc or (pkgs.buildPackages.uplc or (errorHandler.buildToolDepError "plutus-core:uplc")))
+            ];
+          buildable = true;
+          };
+        "test2" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."Cabal" or (errorHandler.buildDepError "Cabal"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."plutus-metatheory" or (errorHandler.buildDepError "plutus-metatheory"))
+            (hsPkgs."process" or (errorHandler.buildDepError "process"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.plutus-core.components.exes.plc or (pkgs.buildPackages.plc or (errorHandler.buildToolDepError "plutus-core:plc")))
+            (hsPkgs.buildPackages.plutus-core.components.exes.uplc or (pkgs.buildPackages.uplc or (errorHandler.buildToolDepError "plutus-core:uplc")))
+            ];
+          buildable = true;
+          };
+        "test3" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."lazy-search" or (errorHandler.buildDepError "lazy-search"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+            (hsPkgs."plutus-metatheory" or (errorHandler.buildDepError "plutus-metatheory"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."size-based" or (errorHandler.buildDepError "size-based"))
+            (hsPkgs."Stream" or (errorHandler.buildDepError "Stream"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            ];
+          buildable = true;
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/plutus";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      }) // {
+      url = "https://github.com/input-output-hk/plutus";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      };
+    postUnpack = "sourceRoot+=/plutus-metatheory; echo source root reset to \$sourceRoot";
+    }

--- a/nix/.stack.nix/plutus-tx-plugin.nix
+++ b/nix/.stack.nix/plutus-tx-plugin.nix
@@ -40,6 +40,7 @@
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
           (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+          (hsPkgs."array" or (errorHandler.buildDepError "array"))
           ] ++ (if flags.use-ghc-stub
           then [
             (hsPkgs."plutus-ghc-stub" or (errorHandler.buildDepError "plutus-ghc-stub"))
@@ -47,49 +48,28 @@
           else [ (hsPkgs."ghc" or (errorHandler.buildDepError "ghc")) ]);
         buildable = true;
         };
-      exes = {
-        "profile" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-            (hsPkgs."integer-gmp" or (errorHandler.buildDepError "integer-gmp"))
-            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
-            (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
-            (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
-            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
-            (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            ];
-          buildable = true;
-          };
-        };
       tests = {
         "plutus-tx-tests" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
             (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
             (hsPkgs."integer-gmp" or (errorHandler.buildDepError "integer-gmp"))
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
             (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
             (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
             (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
             (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
-            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
             (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
             (hsPkgs."ghc-prim" or (errorHandler.buildDepError "ghc-prim"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             ];
           buildable = if flags.use-ghc-stub then false else true;
           };
@@ -98,12 +78,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "1efbb276ef1a10ca6961d0fd32e6141e9798bd11";
-      sha256 = "1jicyk4hr8p0xksj4048gdxndrb42jz4wsnkhc3ymxbm5v6snalf";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "1efbb276ef1a10ca6961d0fd32e6141e9798bd11";
-      sha256 = "1jicyk4hr8p0xksj4048gdxndrb42jz4wsnkhc3ymxbm5v6snalf";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
       };
     postUnpack = "sourceRoot+=/plutus-tx-plugin; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/plutus-tx-plugin.nix
+++ b/nix/.stack.nix/plutus-tx-plugin.nix
@@ -78,12 +78,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       };
     postUnpack = "sourceRoot+=/plutus-tx-plugin; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/plutus-tx.nix
+++ b/nix/.stack.nix/plutus-tx.nix
@@ -72,12 +72,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       };
     postUnpack = "sourceRoot+=/plutus-tx; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/plutus-tx.nix
+++ b/nix/.stack.nix/plutus-tx.nix
@@ -72,12 +72,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "1efbb276ef1a10ca6961d0fd32e6141e9798bd11";
-      sha256 = "1jicyk4hr8p0xksj4048gdxndrb42jz4wsnkhc3ymxbm5v6snalf";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "1efbb276ef1a10ca6961d0fd32e6141e9798bd11";
-      sha256 = "1jicyk4hr8p0xksj4048gdxndrb42jz4wsnkhc3ymxbm5v6snalf";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
       };
     postUnpack = "sourceRoot+=/plutus-tx; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/prettyprinter-configurable.nix
+++ b/nix/.stack.nix/prettyprinter-configurable.nix
@@ -10,7 +10,7 @@
   {
     flags = {};
     package = {
-      specVersion = "1.10";
+      specVersion = "2.4";
       identifier = {
         name = "prettyprinter-configurable";
         version = "0.1.0.0";
@@ -61,7 +61,6 @@
           };
         "prettyprinter-configurable-doctest" = {
           depends = [
-            (hsPkgs."prettyprinter-configurable" or (errorHandler.buildDepError "prettyprinter-configurable"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."doctest" or (errorHandler.buildDepError "doctest"))
             ];
@@ -72,12 +71,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "1efbb276ef1a10ca6961d0fd32e6141e9798bd11";
-      sha256 = "1jicyk4hr8p0xksj4048gdxndrb42jz4wsnkhc3ymxbm5v6snalf";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "1efbb276ef1a10ca6961d0fd32e6141e9798bd11";
-      sha256 = "1jicyk4hr8p0xksj4048gdxndrb42jz4wsnkhc3ymxbm5v6snalf";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
       };
     postUnpack = "sourceRoot+=/prettyprinter-configurable; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/prettyprinter-configurable.nix
+++ b/nix/.stack.nix/prettyprinter-configurable.nix
@@ -71,12 +71,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       };
     postUnpack = "sourceRoot+=/prettyprinter-configurable; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/word-array.nix
+++ b/nix/.stack.nix/word-array.nix
@@ -51,11 +51,9 @@
         "bench" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-bench" or (errorHandler.buildDepError "tasty-bench"))
             (hsPkgs."word-array" or (errorHandler.buildDepError "word-array"))
             (hsPkgs."primitive" or (errorHandler.buildDepError "primitive"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
             ];
           buildable = true;
           };
@@ -64,12 +62,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "1efbb276ef1a10ca6961d0fd32e6141e9798bd11";
-      sha256 = "1jicyk4hr8p0xksj4048gdxndrb42jz4wsnkhc3ymxbm5v6snalf";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "1efbb276ef1a10ca6961d0fd32e6141e9798bd11";
-      sha256 = "1jicyk4hr8p0xksj4048gdxndrb42jz4wsnkhc3ymxbm5v6snalf";
+      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
+      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
       };
     postUnpack = "sourceRoot+=/word-array; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/word-array.nix
+++ b/nix/.stack.nix/word-array.nix
@@ -62,12 +62,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       }) // {
       url = "https://github.com/input-output-hk/plutus";
-      rev = "4710dff2e30ce131191a6a1ccbe43595b2e3af24";
-      sha256 = "0z61mxdk6r092vblfzn81m2d9ss9iqwa1k2nsmmfyhn0q7h66yvg";
+      rev = "103fe104e8138dcf2a8d52d5e45177bac4e396b1";
+      sha256 = "169p3si18mgzb7s91ghrq0crsqq2xbqjk1q0hpfild2dbgcdpcsd";
       };
     postUnpack = "sourceRoot+=/word-array; echo source root reset to \$sourceRoot";
     }

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -289,21 +289,21 @@ let
       # Allow installation of a newer version of Win32 than what is
       # included with GHC. The packages in this list are all those
       # installed with GHC, except for Win32.
-      { nonReinstallablePkgs =
-        [ "rts" "ghc-heap" "ghc-prim" "integer-gmp" "integer-simple" "base"
-          "deepseq" "array" "ghc-boot-th" "pretty" "template-haskell"
-          # ghcjs custom packages
-          "ghcjs-prim" "ghcjs-th"
-          "ghc-boot"
-          "ghc" "array" "binary" "bytestring" "containers"
-          "filepath" "ghc-boot" "ghc-compact" "ghc-prim"
-          # "ghci" "haskeline"
-          "hpc"
-          "mtl" "parsec" "text" "transformers"
-          "xhtml"
-          # "stm" "terminfo"
-        ];
-      }
+      # { nonReinstallablePkgs =
+      #   [ "rts" "ghc-heap" "ghc-prim" "integer-gmp" "integer-simple" "base"
+      #     "deepseq" "array" "ghc-boot-th" "pretty" "template-haskell"
+      #     # ghcjs custom packages
+      #     "ghcjs-prim" "ghcjs-th"
+      #     "ghc-boot"
+      #     "ghc" "array" "binary" "bytestring" "containers"
+      #     "filepath" "ghc-boot" "ghc-compact" "ghc-prim"
+      #     # "ghci" "haskeline"
+      #     "hpc"
+      #     "mtl" "parsec" "text" "transformers"
+      #     "xhtml"
+      #     # "stm" "terminfo"
+      #   ];
+      # }
       {
         packages.cardano-wallet-core.components.library.build-tools = [ pkgs.buildPackages.buildPackages.gitMinimal ];
         packages.cardano-config.components.library.build-tools = [ pkgs.buildPackages.buildPackages.gitMinimal ];

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -85,6 +85,8 @@ let
           unit.testFlags = lib.optionals pkgs.stdenv.hostPlatform.isDarwin ["-j" "1"];
         };
 
+	packages.plutus-tx-plugin.ghcOptions = [ "-DUBXT_PATCH" ];
+
         packages.cardano-wallet.components.tests = {
           # Only run integration tests on non-PR jobsets. Note that
           # the master branch jobset will just re-use the cached Bors

--- a/stack.yaml
+++ b/stack.yaml
@@ -254,23 +254,18 @@ extra-deps:
   - ouroboros-consensus-mock
 
 - git: https://github.com/input-output-hk/plutus
-  commit: 1efbb276ef1a10ca6961d0fd32e6141e9798bd11
+  commit: 4710dff2e30ce131191a6a1ccbe43595b2e3af24
   subdirs:
-    - freer-extras
-    - playground-common
-    - plutus-chain-index
-    - plutus-contract
+    - plutus-benchmark
     - plutus-core
-    - plutus-ledger
+    - plutus-errors
     - plutus-ledger-api
-    - plutus-pab
+    - plutus-metatheory
     - plutus-tx
     - plutus-tx-plugin
-    - plutus-use-cases
-    - stubs/plutus-ghc-stub
     - prettyprinter-configurable
-    - quickcheck-dynamic
     - word-array
+    - stubs/plutus-ghc-stub
 
 - git: https://github.com/input-output-hk/ekg-forward
   commit: 2adc8b698443bb10154304b24f6c1d6913bb65b9

--- a/stack.yaml
+++ b/stack.yaml
@@ -254,7 +254,7 @@ extra-deps:
   - ouroboros-consensus-mock
 
 - git: https://github.com/input-output-hk/plutus
-  commit: 4710dff2e30ce131191a6a1ccbe43595b2e3af24
+  commit: 103fe104e8138dcf2a8d52d5e45177bac4e396b1
   subdirs:
     - plutus-benchmark
     - plutus-core


### PR DESCRIPTION
We might include Plutus in our stack.yaml, but we don't actually use Plutus atm, so it hasn't been added to our build plan. If we try to add it, it fails. This PR attempts to fix that.
