### PR TITLE
Split address discovery and UTxO updates in wallet model

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -363,6 +363,7 @@ totalUTxO pending (Wallet u _ s) =
 --   and typically does not agree with the order in which we have submitted
 --   them onto the chain. Hence, the address discovery phase is not really
 --   very effective.
+--   TODO: Add slot to 'Tx' and sort the pending set by slot.
 changeUTxO
     :: IsOurs s Address
     => Set Tx

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -622,9 +622,9 @@ ourWithdrawalSumFromTx s tx
     -- Therefore, any reward withdrawals included in such a transaction should
     -- also have no effect.
     --
-    | failedScriptValidation tx =
-        Coin 0
-    | otherwise =
-        F.foldMap snd
-        . filter (ours s . fst)
-        $ Map.toList (tx ^. #withdrawals)
+    | failedScriptValidation tx = Coin 0
+    | otherwise = Map.foldlWithKey' add (Coin 0) (tx ^. #withdrawals)
+  where
+    add total account coin
+        | ours s account = total <> coin
+        | otherwise      = total

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -11,10 +11,10 @@
 -- License: Apache-2.0
 --
 -- This module implements the "business logic" to manage a Cardano wallet.
--- It is a direct implementation of the model from the
+-- It is a direct implementation of the model, with extensions, from the
 -- [Formal Specification for a Cardano Wallet](https://github.com/input-output-hk/cardano-wallet/blob/master/specifications/wallet/formal-specification-for-a-cardano-wallet.pdf).
 --
--- in other words, this module is about how the wallet keeps
+-- In other words, this module is about how the wallet keeps
 -- track of its internal state, specifically the 'UTxO' set and
 -- the address discovery state.
 -- This module is intentionally agnostic to specific address formats,
@@ -131,7 +131,7 @@ import qualified Data.Set as Set
 --
 -- A 'Wallet' keeps track of transaction outputs and associated addresses
 -- that belong to /us/ -- we are able to spend these outputs because
--- we know the secret keys belonging to the addresses.
+-- we know the corresponding signing key belonging to the output. Hence, we are able to produce witness engaging those outputs as they become inputs in forthcoming transactions according to UTxO model. 
 -- This information is associated to a particular point on the blockchain.
 --
 -- Internally, a 'Wallet' keeps track of

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -470,12 +470,9 @@ discoverAddresses block s0 = s2
     discoverWithdrawals s tx =
         L.foldl' updateOurs s $ Map.keys (tx ^. #withdrawals)
 
--- | Helper based on 'isOurs'.
-updateOurs :: IsOurs s entity => s -> entity -> s
-updateOurs s x = snd $ isOurs x s
-
--- | Helper based on 'isOurs'.
-ours :: IsOurs s entity => s -> entity -> Bool
+-- | Indicates whether an address is known to be ours, without updating the
+-- address discovery state.
+ours :: IsOurs s addr => s -> addr -> Bool
 ours s x = isJust . fst $ isOurs x s
 
 -- | Performs address discovery and indicates whether a given transaction is
@@ -516,7 +513,13 @@ isOurTx tx u
     txHasRelevantWithdrawal =
         F.or <$> sequence (isOursState . fst <$> Map.toList (tx ^. #withdrawals))
 
-isOursState :: IsOurs s entity => entity -> State s Bool
+-- | Add an address to the address discovery state, iff it belongs to us.
+updateOurs :: IsOurs s addr => s -> addr -> s
+updateOurs s x = snd $ isOurs x s
+
+-- | Perform stateful address discovery, and return whether the given address
+-- belongs to us.
+isOursState :: IsOurs s addr => addr -> State s Bool
 isOursState x = isJust <$> state (isOurs x)
 
 {-------------------------------------------------------------------------------

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -547,7 +547,7 @@ fileModeSpec =  do
                             })
                             mockTxs
                             mempty
-                    let (FilteredBlock _ txs, cpB) = applyBlock fakeBlock cpA
+                    let (FilteredBlock{transactions=txs}, cpB) = applyBlock fakeBlock cpA
                     print $ utxo cpB
                     atomically $ do
                         unsafeRunExceptT $ putCheckpoint testWid cpB

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -272,7 +272,7 @@ spec = do
             property prop_applyOurTxToUTxO_allOurs
         it "prop_applyOurTxToUTxO_someOurs" $
             property prop_applyOurTxToUTxO_someOurs
-    
+
     parallel $ describe "Address discovery" $ do
         it "discoverAddresses ~ isOurTx" $
             property prop_discoverAddresses
@@ -822,14 +822,15 @@ prop_applyOurTxToUTxO_someOurs ourState slotNo blockHeight tx utxo =
     shouldHaveResult = evalState (isOurTx tx utxo) ourState
 
 {-------------------------------------------------------------------------------
-    Address discovery
+                               Address discovery
 -------------------------------------------------------------------------------}
+
 {- HLINT ignore prop_discoverAddresses "Avoid lambda using `infix`" -}
 prop_discoverAddresses :: ApplyBlock -> Property
 prop_discoverAddresses (ApplyBlock s utxo block) =
-        discoverAddresses block s
+    discoverAddresses block s
     ===
-        execState (mapM (\tx -> isOurTx tx utxo) txs) s
+    execState (mapM (\tx -> isOurTx tx utxo) txs) s
   where
     txs = view #transactions block
 


### PR DESCRIPTION
### Issue number

ADP-1323

### Overview

Previous work in epic ADP-1043 introduced delta encodings, DBVars, and an embedding of the wallet state and its delta encodings into a database table. It's time to integrate these tools with the wallet code. To facilitate code review, the integration proceeds in a sequence of refactorings that do not change functionality and pass all unit tests.

In this step, we prepare the introduction of delta encodings in the "business logic" of the wallet, i.e. the `applyBlock` function. To facilitate keeping track of state changes, we split this function into two parts:

* `discoverAddresses` changes only the address discovery state `s` by looking at all transactions in the block.
* `applyBlockToUTxO` changes only the `UTxO` set, using the addresses discovered in the previous step.

By disentangling the changes to the wallet state, it also becomes more clear in which order the addresses within the block are discovered. Due to the nature of address discovery with an address gap, this order does matter!

### Details

* I have taken the liberty to rewrite and update the module commentary.
    * For example, the commentary to `applyOurTxToUTxO` was slightly misleading in that the function did *not* expect a precondition that the transaction `tx` is guaranteed to be relevant to the wallet. The main reason for this lack of precondition is that a `TxIn` only references an output, but does not record the address associated with that output -- thus, we cannot know whether a `TxIn` belongs to us unless we retrieve its address. In this case, we retrieve the address via the `UTxO` set that we have to carry around anyway.

### Comments

* The property tests for the wallet business logic are currently based on a small initial fragment of Mainnet. Since this is a core component of the wallet relating to asset balances, we may want to look into more elaborate generation of valid chains. Then again, combining `UTxO` sets is not rocket science, and in addition to careful code reading, the existing tests should be sufficient.
    * One idea for generating new chain fragments would be to randomize addresses within a given chain fragment.
