### PR TITLE
Increase timeout for node connection in e2e tests

### DIFF
--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -86,8 +86,8 @@ task :wait_until_node_synced do
   puts "\n  >> Waiting for node to be synced"
 
   network = CardanoWallet.new.misc.network
-  # it seems that occasionally cardano-node needs more time to spin up 
-  timeout = 1800
+  # it seems that occasionally cardano-node needs more time to spin up
+  timeout = 7200
   current_time = Time.now
   timeout_treshold = current_time + timeout
   puts "Timeout: #{timeout}s"


### PR DESCRIPTION
- [x] Increase timeout for node connection as replaying blocks on the node may take ~even 1h~ more than 1h on node version bumps

### Comments
https://github.com/input-output-hk/cardano-wallet/runs/4788838771?check_suite_focus=true

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
