### PR TITLE
cabal.project: Add upper bound on hashable package version

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -245,6 +245,10 @@ allow-newer:
 
 constraints:
     hedgehog >= 1.0.2
+  , hashable < 1.4
+  , bimap >= 0.4.0
+  , libsystemd-journal >= 1.4.4
+  , systemd >= 2.3.0
   -- dependency of systemd-2.3.0
   , network >= 3.1.1.1
   -- choose versions that work with base >= 4.12


### PR DESCRIPTION
This fixes a cabal build error due to an API change on the Hashable
class.

It also adds some more constraints found in `cardano-node/cabal.project`.

### Issue Number

ADP-1263
