### PR TITLE
Increase timeouts for fetching node in benchmarks and e2e tests

### DIFF
--- a/lib/shelley/bench/restore-bench.hs
+++ b/lib/shelley/bench/restore-bench.hs
@@ -778,7 +778,7 @@ waitForNodeSync
     => Tracer IO (BenchmarkLog n)
     -> NetworkLayer IO Block
     -> IO SlotNo
-waitForNodeSync tr nw = loop 480 -- allow 120 minutes for first tip
+waitForNodeSync tr nw = loop 960 -- allow 240 minutes for first tip
   where
     loop :: Int -> IO SlotNo
     loop retries = do

--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -86,8 +86,8 @@ task :wait_until_node_synced do
   puts "\n  >> Waiting for node to be synced"
 
   network = CardanoWallet.new.misc.network
-  # it seems that occasionally cardano-node needs more time to spin up
-  timeout = 7200
+  # allow 180 mins for connecting to the node in case it needs to replay ledger 
+  timeout = 10800
   current_time = Time.now
   timeout_treshold = current_time + timeout
   puts "Timeout: #{timeout}s"


### PR DESCRIPTION
- [x] I have increased timeouts in restoration benchmarks and e2e tests

### Comments

Follow up to https://github.com/input-output-hk/cardano-wallet/pull/3079.
 - e2e tests 120 mins was not enough for [MacOS](https://github.com/input-output-hk/cardano-wallet/actions/runs/1689464914). 
   - :test_tube: [Testing](https://github.com/input-output-hk/cardano-wallet/actions/runs/1691714591). 180mins :heavy_check_mark: 
 - hopefully the same issue in [benchmarks](https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1216#68ecaf3e-2649-4d9e-804e-bef3bad97fc). 
   - :test_tube: [Testing](https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1218)  180mins :x: 
   - :test_tube: [Testing](https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1219) 240mins :heavy_check_mark: (build failed due to cancellation signal :thinking: , but passed through connecting to the node)

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
