### PR TITLE
increase metadata ticker length

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
@@ -263,7 +263,7 @@ validateMetadataName :: Text -> Either String Text
 validateMetadataName = validateMinLength 1 >=> validateMaxLength 50
 
 validateMetadataTicker :: Text -> Either String Text
-validateMetadataTicker = validateMinLength 2 >=> validateMaxLength 5
+validateMetadataTicker = validateMinLength 2 >=> validateMaxLength 6
 
 validateMetadataDescription :: Text -> Either String Text
 validateMetadataDescription = validateMaxLength 500

--- a/lib/core/test/data/Cardano/Wallet/TokenMetadata/golden4.json
+++ b/lib/core/test/data/Cardano/Wallet/TokenMetadata/golden4.json
@@ -1,12 +1,12 @@
 {
   "subjects": [
     {
-      "subject": "malformed acryonym - too long",
+      "subject": "malformed ticker - too long",
       "name": {
         "value": "Token7"
       },
       "ticker": {
-        "value": "Token7"
+        "value": "Token77777"
       },
       "description": {
         "value": "description7"
@@ -45,7 +45,7 @@
         "value": "description13"
       },
       "ticker": {
-        "value": "ticker13"
+        "value": "ticker13longlonglong"
       }
     },
     {


### PR DESCRIPTION
- [x] Iincrease metadata ticker length to ~6~ 9 digits

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-1362

https://github.com/input-output-hk/offchain-metadata-tools/pull/45
