### PR TITLE
docs: Pin versions of tools used for build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,12 +6,14 @@ on:
       - master
     tags:
       - 'v*'
+  pull_request:
 
 jobs:
   docs:
     runs-on: ubuntu-20.04
     env:
-      DOCS_DIR: _build
+      PUBLISH_DIR: _build
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: '📥 Checkout repository'
         uses: actions/checkout@v2
@@ -24,16 +26,8 @@ jobs:
             substituters = https://hydra.iohk.io https://cache.nixos.org/
             trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
-      - name: '❄ Install dependencies'
-        run: 'nix develop .#docs --command emanote --version'
-
-      - name: '🔧 Build emanote site'
-        run: |
-          mkdir -p "$DOCS_DIR"
-          nix develop .#docs -c emanote --layers "docs;docs/.deploy/github" gen "$DOCS_DIR"
-
-      - name: '📸 Build Documentation'
-        id: build
+      - name: '🔧 Set versions'
+        id: versions
         run: |
           if [[ $GITHUB_REF =~ ^refs/tags/v ]]; then
             tag="${GITHUB_REF/refs\/tags\//}"
@@ -43,13 +37,27 @@ jobs:
             commit_message="$default_commit_message"
           fi
           echo "::set-output name=commit_message::$commit_message"
-
-          ./scripts/gh/update-docs.sh "$DOCS_DIR" $tag
+          echo "::set-output name=tag::$tag"
         env:
           default_commit_message: |
             docs: ${{ github.event.head_commit.message }}
 
             Source commit: ${{ github.sha }}
+
+      - name: '❄ Install dependencies'
+        run: 'nix develop .#docs --command emanote --version'
+
+      - name: '📸 Build Documentation'
+        run: |
+          build_dir="$PUBLISH_DIR"
+          if [ -n "$PR_NUMBER" ]; then
+            build_dir="$build_dir/_pr/$PR_NUMBER"
+            nix develop .#docs -c yq --in-place -y '.template.baseUrl|=.+"_pr/\(env.PR_NUMBER)/"' docs/.deploy/github/index.yaml
+          fi
+
+          mkdir -p "$build_dir"
+          nix develop .#docs -c emanote --layers "docs;docs/.deploy/github" gen "$build_dir"
+          ./scripts/gh/update-docs.sh "$build_dir" ${{ steps.versions.outputs.tag }}
 
       - name: '📘 Publish'
         if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
@@ -57,8 +65,8 @@ jobs:
         with:
           github_token: ${{ secrets.WILLIAM_KING_TOKEN }}
           enable_jekyll: false
-          publish_dir: ${{ env.DOCS_DIR }}
+          publish_dir: ${{ env.PUBLISH_DIR }}
           keep_files: true
           user_name: 'William King Noel Bot'
           user_email: 'adrestia@iohk.io'
-          full_commit_message: ${{ steps.build.outputs.commit_message }}
+          full_commit_message: ${{ steps.versions.outputs.commit_message }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,22 +10,29 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-20.04
+    env:
+      DOCS_DIR: _build
     steps:
-      - name: 'Checkout repository 📥'
+      - name: '📥 Checkout repository'
         uses: actions/checkout@v2
 
-      - name: 'Build emanote site 🔧'
-        run: |
-          cd docs
-          mkdir -p output.docker
-          docker run \
-            -e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 \
-            --tmpfs /tmp \
-            -v $PWD:/data sridca/emanote \
-            emanote --layers "/data;/data/.deploy/github" gen /data/output.docker
-          cp -r output.docker ../_build  # Ditch docker created root-owned files
+      - name: '❄ Install Nix'
+        uses: cachix/install-nix-action@v16
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            substituters = https://hydra.iohk.io https://cache.nixos.org/
+            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
-      - name: 'Build Documentation 📸'
+      - name: '❄ Install dependencies'
+        run: 'nix develop .#docs --command emanote --version'
+
+      - name: '🔧 Build emanote site'
+        run: |
+          mkdir -p "$DOCS_DIR"
+          nix develop .#docs -c emanote --layers "docs;docs/.deploy/github" gen "$DOCS_DIR"
+
+      - name: '📸 Build Documentation'
         id: build
         run: |
           if [[ $GITHUB_REF =~ ^refs/tags/v ]]; then
@@ -37,20 +44,20 @@ jobs:
           fi
           echo "::set-output name=commit_message::$commit_message"
 
-          ./scripts/gh/update-docs.sh _build $tag
+          ./scripts/gh/update-docs.sh "$DOCS_DIR" $tag
         env:
           default_commit_message: |
             docs: ${{ github.event.head_commit.message }}
 
             Source commit: ${{ github.sha }}
 
-      - name: 'Publish 📘'
+      - name: '📘 Publish'
         if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.WILLIAM_KING_TOKEN }}
           enable_jekyll: false
-          publish_dir: _build
+          publish_dir: ${{ env.DOCS_DIR }}
           keep_files: true
           user_name: 'William King Noel Bot'
           user_email: 'adrestia@iohk.io'

--- a/flake.nix
+++ b/flake.nix
@@ -221,7 +221,7 @@
               });
               docs = pkgs.mkShell {
                 name = "cardano-wallet-docs";
-                nativeBuildInputs = [ emanote.defaultPackage.${system} ];
+                nativeBuildInputs = [ emanote.defaultPackage.${system} pkgs.yq ];
                 # allow building the shell so that it can be cached in hydra
                 phases = [ "installPhase" ];
                 installPhase = "echo $nativeBuildInputs > $out";


### PR DESCRIPTION
Pins the version of emanote used to build docs.
It uses `nix develop` for this.
This way is better than using the docker image because docker will always pull the latest version, and new versions can unexpectedly break things, as they did for our v2022-01-18 release.
Also the program versions used locally with `nix develop` will match exactly those used in CI.

### Issue Number

ADP-1358