### PR TITLE
Increase timeout of DB benchmark

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -38,7 +38,7 @@ steps:
 
   - label: 'Database benchmark'
     command: "./.buildkite/bench-db.sh"
-    timeout_in_minutes: 120
+    timeout_in_minutes: 210
     agents:
       system: x86_64-linux
       queue: benchmark


### PR DESCRIPTION
- [x] Increase nightly DB bench timeout from 2h to 3.5h.

Seems to pass in 2h47m: https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1226#673fc413-b752-4729-a456-db01d0d59011
where the old timeout was 2h.