### PR TITLE
Improve documentation styling

### DIFF
--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -5,6 +5,19 @@ page:
   siteTitle: Cardano Wallet
   headHtml: |
     <snippet var="js.fixAnchorLinks" />
+    <style>
+      p code, li code {
+        background-color: rgb(243,244,246) !important;
+        color: black !important;
+      }
+      pre {
+        background-color: rgb(243,244,246) !important;
+      }
+    </style>
+  # NOTE: The template styles <code> tags by adding classes
+  # to the `class` attribute.
+  # I did not find a way to configure this, hence the
+  # CSS styling hack above.
 
 template:
   theme: red

--- a/docs/user-guide/common-use-cases/how-to-create-a-wallet.md
+++ b/docs/user-guide/common-use-cases/how-to-create-a-wallet.md
@@ -3,12 +3,12 @@ order: 1
 title: How to create a wallet
 ---
 
-{{<hint warning>}}
+::: {.highlight-block}
 **Difficulty:** beginner
 
 **Requires:**
 - 📦 cardano-wallet >= `v2020-03-11`
-{{</hint>}}
+:::
 
 The easiest and most common way of managing your funds on the Cardano blockchain is through a [[hierarchical-deterministic-wallets]]. One can create a wallet using the following endpoint of [[http-api]]:
 
@@ -22,9 +22,9 @@ There are several wallet types available:
 
 The basic difference between them is that for a `random` wallet user needs to [[how-to-create-addresses|create new address]] manually, whereas for sequential wallets like `icarus`, `trezor` and `ledger` addresses are [[how-to-create-addresses#listing-addresses-in-sequential-wallets|generated automatically]]) by the wallet.
 
-{{<hint danger>}}
+::: {.highlight-block}
 Please note that `random` wallets are considered **deprecated** and should not be used by new applications.
-{{</hint>}}
+:::
 
 Note also that you can have many wallets being operated by a single `cardano-wallet` server.
 

--- a/docs/user-guide/common-use-cases/how-to-create-addresses.md
+++ b/docs/user-guide/common-use-cases/how-to-create-addresses.md
@@ -3,17 +3,32 @@ order: 3
 title: How to "create" addresses
 ---
 
-{{<tabs>}}
-
-{{<tab "using cardano-wallet">}}
-{{<hint warning>}}
+::: {.highlight-block}
 **Difficulty:** beginner
 
 **Requires:**
 - 📦 cardano-wallet >= `v2020-04-01`
-{{</hint>}}
+:::
 
 Once you have a wallet you can manage your funds. In order to receive a transaction you need to provide an address associated with your wallet to the sender.
+
+## Sequential wallets (Icarus & Shelley)
+
+Since Icarus, wallets use sequential derivation which must satisfy very specific rules: a wallet is not allowed to use addresses beyond a certain limit before previously generated addresses have been used. This means that, at a given point in a time, a wallet has both a minimum and a maximum number of possible unused addresses. By default, the maximum number of consecutive unused addresses is set to `20`.
+
+Therefore, address management is entirely done by the server and users aren't allowed to fiddle with them. The list of available addresses can be fetched from the server at any time via:
+
+[`GET /byron-wallets/{walletId}/addresses`](https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/listByronAddresses)
+
+This list automatically expands when new addresses become available so that there's always `address_pool_gap` consecutive unused addresses available (where `address_pool_gap` can be configured when a wallet is first restored / created).
+
+::: {.highlight-block}
+Alternatively, this endpoint can also be reached from the command-line:
+
+```
+$ cardano-wallet address list WALLET_ID
+```
+:::
 
 ## Random wallets (Legacy Byron)
 
@@ -28,37 +43,11 @@ In order to list existing addresses another endpoint can be used.
 [`GET /byron-wallets/{walletId}/addresses`](https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/listByronAddresses)
 
 
-{{<hint info>}}
+::: {.highlight-block}
 Alternatively, these endpoints can also be reached from the command-line:
 
 ```
 $ cardano-wallet address create WALLET_ID
 $ cardano-wallet address list WALLET_ID
 ```
-{{</hint>}}
-
-## Sequential wallets (Icarus & Shelley)
-
-Since Icarus, wallets use sequential derivation which must satisfy very specific rules: a wallet is not allowed to use addresses beyond a certain limit before previously generated addresses have been used. This means that, at a given point in a time, a wallet has both a minimum and a maximum number of possible unused addresses. By default, the maximum number of consecutive unused addresses is set to `20`.
-
-Therefore, address management is entirely done by the server and users aren't allowed to fiddle with them. The list of available addresses can be fetched from the server at any time via:
-
-[`GET /byron-wallets/{walletId}/addresses`](https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/listByronAddresses)
-
-This list automatically expands when new addresses become available so that there's always `address_pool_gap` consecutive unused addresses available (where `address_pool_gap` can be configured when a wallet is first restored / created).
-{{</tab>}}
-
-{{<hint info>}}
-Alternatively, this endpoint can also be reached from the command-line:
-
-```
-$ cardano-wallet address list WALLET_ID
-```
-{{</hint>}}
-
-
-{{<tab "using cardano-addresses">}}
-Coming soon.
-{{</tab>}}
-
-{{</tabs>}}
+:::

--- a/docs/user-guide/common-use-cases/how-to-make-a-transaction.md
+++ b/docs/user-guide/common-use-cases/how-to-make-a-transaction.md
@@ -2,15 +2,14 @@
 order: 4
 title: How to make a transaction
 ---
-{{<tabs>}}
 
-{{<tab "using cardano-wallet">}}
-{{<hint warning>}}
+## New transaction
+::: {.highlight-block}
 **Difficulty:** beginner
 
 **Requires:**
 - 📦 cardano-wallet >= `v2020-04-01`
-{{</hint>}}
+:::
 
 Assuming you have already created a wallet, you can send a transaction by using the following endpoint:
 
@@ -27,18 +26,15 @@ Which returns a list of all transactions for this particular wallet. Optional ra
 [`DELETE /v2/byron-wallets/{walletId}/transactions/{transactionId}`](https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/deleteByronTransaction)
 
 For more information about transactions lifecycle, have a look at [[About-Transactions-Lifecycle]].
-{{</tab>}}
 
-
-{{<tab "using cardano-transactions">}}
-
-{{<hint warning>}}
+## Signed and serialized transactions 
+::: {.highlight-block}
 **Difficulty:** advanced
 
 **Requires:**
 - 📦 cardano-transactions >= `1.0.0`
 - 📦 cardano-submit-api >= `2.0.0` OR cardano-wallet >= `v2020-04-01`
-{{</hint>}}
+:::
 
 Alternatively, `cardano-wallet` and `cardano-submit-api` allows clients to submit already signed and serialized transactions as a raw bytes blob. This can be done by submitting such serialized data as an `application/octet-stream` to either of:
 
@@ -48,6 +44,4 @@ Alternatively, `cardano-wallet` and `cardano-submit-api` allows clients to submi
 In this scenario, the server engine will verify that the transaction is structurally well-formed and forward it to its associated node. If the transaction belongs to a known wallet, it will eventually show up in the wallet your wallet.
 
 Such transactions can be constructed from raw data using either [cardano-transactions library or command-line interface](https://github.com/input-output-hk/cardano-transactions). Examples and documentation excerpts are available on the corresponding Github repository.
-{{</tab>}}
 
-{{</tabs>}}

--- a/docs/user-guide/common-use-cases/how-to-manage-wallets.md
+++ b/docs/user-guide/common-use-cases/how-to-manage-wallets.md
@@ -3,12 +3,12 @@ order: 2
 title: How to manage wallets
 ---
 
-{{<hint warning>}}
+::: {.highlight-block}
 **Difficulty:** beginner
 
 **Requires:**
 - 📦 cardano-wallet >= `v2020-04-01`
-{{</hint>}}
+:::
 
 Once you created a wallet you can manage it with `cardano-wallet` endpoints. There are several operations available.
 


### PR DESCRIPTION
This pull requests improves the style of the rendered documentation.

### Details

* `<code>` tags now use a dark-on-light color scheme. This is easier on the eyes when the rest of the document also has a light-on-dark color scheme.
* Fixed the `{{tab}}` and `{{hint}}` tags that were leftover in the How-tos.
