### PR TITLE
Use Integer instead of Word128 for ghcjs

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -139,7 +139,6 @@ library
     , wai
     , warp
     , warp-tls
-    , wide-word
     , x509
     , x509-store
     , x509-validation

--- a/lib/core/src/Control/Monad/Random/Extra.hs
+++ b/lib/core/src/Control/Monad/Random/Extra.hs
@@ -38,8 +38,6 @@ import Data.Bits
     ( (.|.) )
 import Data.Coerce
     ( coerce )
-import Data.WideWord.Word128
-    ( Word128 (..) )
 import Data.Word
     ( Word64 )
 import Data.Word.Odd
@@ -77,7 +75,7 @@ newtype StdGenSeed = StdGenSeed
     deriving (Eq, Bounded, Generic, Ord)
     deriving Show via (Quiet StdGenSeed)
 
-type Word127 = OddWord Word128 (Lit 127)
+type Word127 = OddWord Integer (Lit 127)
 
 instance ToJSON StdGenSeed where
     toJSON = toJSON . Number . fromIntegral . unStdGenSeed

--- a/nix/materialized/stack-nix/cardano-wallet-core.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-core.nix
@@ -142,7 +142,6 @@
           (hsPkgs."wai" or (errorHandler.buildDepError "wai"))
           (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
           (hsPkgs."warp-tls" or (errorHandler.buildDepError "warp-tls"))
-          (hsPkgs."wide-word" or (errorHandler.buildDepError "wide-word"))
           (hsPkgs."x509" or (errorHandler.buildDepError "x509"))
           (hsPkgs."x509-store" or (errorHandler.buildDepError "x509-store"))
           (hsPkgs."x509-validation" or (errorHandler.buildDepError "x509-validation"))


### PR DESCRIPTION
The `wide-word` package does not support 32bit platforms like ghcjs.

@rvl:
> We really didn't need wide-word in this situation.
> Execution speed or memory usage is not relevant.
> Integer would work just as well.
