### PR TITLE
Add `WalletState`, a pure model for the entire wallet

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -191,6 +191,7 @@ library
       Cardano.Wallet.DB.Sqlite.Migration
       Cardano.Wallet.DB.Sqlite.TH
       Cardano.Wallet.DB.Sqlite.Types
+      Cardano.Wallet.DB.WalletState
       Cardano.Wallet.Logging
       Cardano.Wallet.Network
       Cardano.Wallet.Network.Ports

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -189,6 +189,7 @@ library
       Cardano.Wallet.DB.Sqlite.AddressBook
       Cardano.Wallet.DB.Sqlite.CheckpointsOld
       Cardano.Wallet.DB.Sqlite.Migration
+      Cardano.Wallet.DB.Sqlite.Stores
       Cardano.Wallet.DB.Sqlite.TH
       Cardano.Wallet.DB.Sqlite.Types
       Cardano.Wallet.DB.WalletState
@@ -355,6 +356,7 @@ test-suite unit
     , network-uri
     , nothunks
     , persistent
+    , persistent-sqlite >=2.13 && <2.14
     , plutus-ledger-api
     , pretty-simple
     , regex-pcre-builtin
@@ -423,6 +425,7 @@ test-suite unit
       Cardano.Wallet.DB.MVarSpec
       Cardano.Wallet.DB.Properties
       Cardano.Wallet.DB.SqliteSpec
+      Cardano.Wallet.DB.Sqlite.StoresSpec
       Cardano.Wallet.DB.Sqlite.TypesSpec
       Cardano.Wallet.DB.StateMachine
       Cardano.Wallet.DummyTarget.Primitive.Types

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -332,7 +332,8 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
 -- | Can't read the database file because it's in a bad format
 -- (corrupted, too old, …)
 data ErrBadFormat
-    = ErrBadFormatAddressState
+    = ErrBadFormatAddressPrologue
+    | ErrBadFormatCheckpoints
     deriving (Eq,Show)
 
 instance Exception ErrBadFormat

--- a/lib/core/src/Cardano/Wallet/DB/Checkpoints.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Checkpoints.hs
@@ -10,10 +10,8 @@
 -- Each checkpoints is associated with a 'Slot'.
 
 module Cardano.Wallet.DB.Checkpoints
-    ( getPoint
-
-    -- * Checkpoints  
-    , Checkpoints
+    ( -- * Checkpoints  
+      Checkpoints
     , checkpoints
     , loadCheckpoints
     , fromGenesis
@@ -22,7 +20,6 @@ module Cardano.Wallet.DB.Checkpoints
     
     -- * Delta types
     , DeltaCheckpoints (..)
-    , DeltaMap (..)
     ) where
 
 import Prelude
@@ -38,7 +35,6 @@ import Data.Maybe
 import GHC.Generics
     ( Generic )
 
-import qualified Cardano.Wallet.Primitive.Model as W
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -74,11 +70,6 @@ is clear that the data cannot exist at the genesis point
 (e.g. for TxHistory).
 
 -}
-
--- | Helper function: Get the 'Point' of a wallet state.
-getPoint :: W.Wallet s -> W.Slot
-getPoint =
-    W.toSlot . W.chainPointFromBlockHeader . view #currentTip
 
 {-------------------------------------------------------------------------------
     Checkpoints
@@ -135,18 +126,3 @@ instance Delta (DeltaCheckpoints a) where
         Map.filterWithKey (\k _ -> k <= pt)
     apply (RestrictTo pts) = over #checkpoints $ \m ->
         Map.restrictKeys m $ Set.fromList (W.Origin:pts)
-
-{-------------------------------------------------------------------------------
-    A Delta type for Maps
--------------------------------------------------------------------------------}
--- | Delta type for 'Map'.
-data DeltaMap key da
-    = Insert key (Base da)
-    | Delete key
-    | Adjust key da
-
-instance (Ord key, Delta da) => Delta (DeltaMap key da) where
-    type Base (DeltaMap key da) = Map key (Base da)
-    apply (Insert key a) = Map.insert key a
-    apply (Delete key) = Map.delete key
-    apply (Adjust key da) = Map.adjust (apply da) key

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/CheckpointsOld.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/CheckpointsOld.hs
@@ -21,10 +21,13 @@
 -- Copyright: © 2021 IOHK
 -- License: Apache-2.0
 --
--- Old-style storage for 'Checkpoints' in the database.
+-- 'Store' implementations that can store various wallet types
+-- in an SQLite database using `persistent`.
 --
 -- FIXME LATER during ADP-1043:
--- Swap this module out by "Cardano.Wallet.DB.Sqlite.Checkpoints"
+--
+-- * Inline the contents of this module into its new name
+--   "Cardano.Wallet.DB.Sqlite.Stores"
 
 module Cardano.Wallet.DB.Sqlite.CheckpointsOld
     ( mkStoreWallets
@@ -606,6 +609,14 @@ selectCosigners wid cred = do
        (Cosigner c, unsafeDeserializeXPub key)
 
 -- | Check whether we have ever stored checkpoints for a multi-signature pool
+--
+-- FIXME during APD-1043:
+-- Whether the 'SharedState' is 'Pending' or 'Active' should be apparent
+-- from the data in the table corresponding to the 'Prologue'.
+-- Testing whether the table corresponding to 'Discoveries' is present
+-- or absent is a nice idea, but it ultimately complicates the separation
+-- between Prologue and Discoveries.
+-- Solution: Add a 'Ready' column in the next version of the database format.
 multisigPoolAbsent :: W.WalletId -> SqlPersistT IO Bool
 multisigPoolAbsent wid =
     isNothing <$> selectFirst

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Stores.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Stores.hs
@@ -1,0 +1,25 @@
+-- |
+-- Copyright: © 2022 IOHK
+-- License: Apache-2.0
+--
+-- 'Store' implementations that can store various wallet types
+-- in an SQLite database using `persistent`.
+--
+-- FIXME LATER during ADP-1043:
+--
+-- * Inline the contents of "Cardano.Wallet.DB.Sqlite.CheckpointsOld"
+--   into this module
+-- * Use 'Table' and 'Embedding' to construct the relevant 'Store'
+--   rather than implementing 'loadS', 'writeS', 'updateS' in
+--   a monadic fashion.
+--   Hide the new implementation behind a feature flag,
+--   i.e. "Cardano.Wallet.DB.Sqlite.StoresNew".
+
+module Cardano.Wallet.DB.Sqlite.Stores
+    ( mkStoreWallets
+    , PersistAddressBook (..)
+    , blockHeaderFromEntity
+    )
+    where
+
+import Cardano.Wallet.DB.Sqlite.CheckpointsOld

--- a/lib/core/src/Cardano/Wallet/DB/WalletState.hs
+++ b/lib/core/src/Cardano/Wallet/DB/WalletState.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+-- Copyright: © 2022 IOHK
+-- License: Apache-2.0
+--
+-- Pure data type which represents the entire wallet state,
+-- including all checkpoints.
+--
+-- FIXME during ADP-1043: Actually include everything,
+-- e.g. TxHistory, Pending transactions, …
+
+module Cardano.Wallet.DB.WalletState
+    ( -- * Wallet state
+      WalletState (..)
+    , fromGenesis
+    , getLatest
+    , findNearestPoint
+
+    -- * WalletCheckpoint (internal use mostly)
+    , WalletCheckpoint (..)
+    , toWallet
+    , fromWallet
+    , getBlockHeight
+    , getSlot
+
+    -- * Delta types
+    , DeltaWalletState1 (..)
+    , DeltaWalletState
+    , DeltaMap (..)
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.DB.Checkpoints
+    ( Checkpoints )
+import Cardano.Wallet.DB.Sqlite.AddressBook
+    ( AddressBookIso (..), Discoveries, Prologue )
+import Cardano.Wallet.Primitive.Types
+    ( BlockHeader )
+import Cardano.Wallet.Primitive.Types.UTxO
+    ( UTxO )
+import Data.Delta
+    ( Delta (..) )
+import Data.Generics.Internal.VL
+    ( withIso )
+import Data.Generics.Internal.VL.Lens
+    ( over, view, (^.) )
+import Data.Map.Strict
+    ( Map )
+import Data.Word
+    ( Word32 )
+import GHC.Generics
+    ( Generic )
+
+import qualified Cardano.Wallet.DB.Checkpoints as CPS
+import qualified Cardano.Wallet.Primitive.Model as W
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Data.Map.Strict as Map
+
+{-------------------------------------------------------------------------------
+    Wallet Checkpoint
+-------------------------------------------------------------------------------}
+-- | Data stored in a single checkpoint.
+-- Only includes the 'UTxO' and the 'Discoveries', but not the 'Prologue'.
+data WalletCheckpoint s = WalletCheckpoint
+    { currentTip :: !BlockHeader
+    , utxo :: !UTxO
+    , discoveries :: !(Discoveries s)
+    }
+    deriving (Generic)
+
+-- | Helper function: Get the block height of a wallet checkpoint.
+getBlockHeight :: WalletCheckpoint s -> Word32
+getBlockHeight (WalletCheckpoint currentTip _ _) =
+    currentTip ^. (#blockHeight . #getQuantity)
+
+-- | Helper function: Get the 'Slot' of a wallet checkpoint.
+getSlot :: WalletCheckpoint s -> W.Slot
+getSlot (WalletCheckpoint currentTip _ _) =
+    W.toSlot . W.chainPointFromBlockHeader $ currentTip
+
+-- | Convert a stored 'WalletCheckpoint' to the legacy 'W.Wallet' state.
+toWallet :: AddressBookIso s => Prologue s -> WalletCheckpoint s -> W.Wallet s
+toWallet pro (WalletCheckpoint pt utxo dis) =
+    W.unsafeInitWallet utxo pt $ withIso addressIso $ \_ from -> from (pro,dis)
+
+-- | Convert a legacy 'W.Wallet' state to a 'Prologue' and a 'WalletCheckpoint'
+fromWallet :: AddressBookIso s => W.Wallet s -> (Prologue s, WalletCheckpoint s)
+fromWallet w = (pro, WalletCheckpoint (W.currentTip w) (W.utxo w) dis)
+  where
+    (pro, dis) = withIso addressIso $ \to _ -> to (w ^. #getState)
+
+{-------------------------------------------------------------------------------
+    Wallet State
+-------------------------------------------------------------------------------}
+-- | Wallet state. Currently includes:
+--
+-- * Prologue of the address discovery state
+-- * Checkpoints of UTxO and of discoveries of the address discovery state.
+--
+-- FIXME during ADP-1043: Include also TxHistory, pending transactions, …,
+-- everything.
+data WalletState s = WalletState
+    { prologue    :: Prologue s
+    , checkpoints :: Checkpoints (WalletCheckpoint s)
+    } deriving (Generic)
+
+-- | Create a wallet from the genesis block.
+fromGenesis :: AddressBookIso s => W.Wallet s -> Maybe (WalletState s)
+fromGenesis cp
+    | W.isGenesisBlockHeader header = Just $
+        WalletState{ prologue, checkpoints = CPS.fromGenesis checkpoint }
+    | otherwise = Nothing
+  where
+    header = cp ^. #currentTip
+    (prologue, checkpoint) = fromWallet cp
+
+-- | Get the wallet checkpoint with the largest slot number
+getLatest :: AddressBookIso s => WalletState s -> W.Wallet s
+getLatest w =
+    toWallet (w ^. #prologue) . snd $ CPS.getLatest (w ^. #checkpoints)
+
+-- | Find the nearest 'Checkpoint' that is either at the given point or before.
+findNearestPoint :: WalletState s -> W.Slot -> Maybe W.Slot
+findNearestPoint = CPS.findNearestPoint . view #checkpoints
+
+{-------------------------------------------------------------------------------
+    Delta type for the wallet state
+-------------------------------------------------------------------------------}
+type DeltaWalletState s = [DeltaWalletState1 s]
+
+data DeltaWalletState1 s
+    = ReplacePrologue (Prologue s)
+    -- ^ Replace the prologue of the address discovery state
+    | UpdateCheckpoints (CPS.DeltaCheckpoints (WalletCheckpoint s))
+    -- ^ Update the wallet checkpoints.
+
+instance Delta (DeltaWalletState1 s) where
+    type Base (DeltaWalletState1 s) = WalletState s
+    apply (ReplacePrologue p) = over #prologue $ const p
+    apply (UpdateCheckpoints d) = over #checkpoints $ apply d
+
+{-------------------------------------------------------------------------------
+    A Delta type for Maps,
+    useful for handling multiple wallets.
+-------------------------------------------------------------------------------}
+-- | Delta type for 'Map'.
+data DeltaMap key da
+    = Insert key (Base da)
+    | Delete key
+    | Adjust key da
+
+instance (Ord key, Delta da) => Delta (DeltaMap key da) where
+    type Base (DeltaMap key da) = Map key (Base da)
+    apply (Insert key a) = Map.insert key a
+    apply (Delete key) = Map.delete key
+    apply (Adjust key da) = Map.adjust (apply da) key

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -155,7 +155,7 @@ data RndState (network :: NetworkDiscriminant) = RndState
     -- discovered they are removed from this set and added to 'addresses'.
     , gen :: StdGen
     -- ^ The state of the RNG.
-    } deriving (Generic)
+    } deriving (Generic, Eq)
 
 instance NFData (RndState network) where
     rnf (RndState !_ !_ !_ !_ g) = seq (show g) ()

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -778,13 +778,3 @@ instance Buildable (ShelleyKey depth XPrv, Hash "encryption") where
 
 instance Buildable MockChain where
     build (MockChain chain) = blockListF' mempty build chain
-
-instance Buildable (SharedState 'Mainnet SharedKey) where
-    build st = case ready st of
-        Shared.Pending -> "not supported here"
-        Shared.Active pool ->
-            build (printStateActive <> printIndex prefix) <> build pool
-      where
-        printStateActive = "shared wallet state: active"
-        prefix = Shared.derivationPrefix st
-        printIndex (DerivationPrefix (_,_,ix)) = " hardened index: "<> toText (getIndex ix) <> " "

--- a/lib/core/test/unit/Cardano/Wallet/DB/Sqlite/StoresSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Sqlite/StoresSpec.hs
@@ -1,0 +1,187 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module Cardano.Wallet.DB.Sqlite.StoresSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.DB.Sqlite
+    ( SqliteContext (runQuery), newInMemorySqliteContext )
+import Cardano.Wallet.DB.Arbitrary
+    ()
+import Cardano.Wallet.DB.Sqlite.AddressBook
+    ( AddressBookIso (..), Prologue )
+import Cardano.Wallet.DB.Sqlite.Stores
+    ( PersistAddressBook (..) )
+import Cardano.Wallet.DB.Sqlite.TH
+    ( Wallet (..), migrateAll )
+import Cardano.Wallet.DB.Sqlite.Types
+    ( BlockId (..) )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( NetworkDiscriminant (Mainnet) )
+import Cardano.Wallet.Primitive.AddressDerivation.Shared
+    ( SharedKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Shelley
+    ( ShelleyKey )
+import Cardano.Wallet.Primitive.AddressDiscovery.Random
+    ( RndState )
+import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
+    ( SeqState )
+import Cardano.Wallet.Primitive.AddressDiscovery.Shared
+    ( Readiness (Pending), SharedState (..) )
+import Cardano.Wallet.Primitive.Types
+    ( WalletId (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
+import Cardano.Wallet.Unsafe
+    ( unsafeFromHex )
+import Control.Tracer
+    ( nullTracer )
+import Data.Generics.Internal.VL
+    ( withIso )
+import Data.Time.Clock
+    ( UTCTime )
+import Data.Time.Clock.POSIX
+    ( posixSecondsToUTCTime )
+import Database.Persist.Sql
+    ( Filter, deleteWhere, insert_ )
+import Database.Persist.Sqlite
+    ( SqlPersistT )
+import Fmt
+    ( Buildable, pretty )
+import Test.Hspec
+    ( Spec, around, describe, it )
+import Test.QuickCheck
+    ( Property, counterexample, property )
+import Test.QuickCheck.Monadic
+    ( PropertyM, assert, monadicIO, monitor, run )
+import UnliftIO.Exception
+    ( bracket )
+
+import qualified Cardano.Wallet.DB.Sqlite.TH as TH
+
+spec :: Spec
+spec = around withDBInMemory $ do
+    describe "Writing and loading from store" $ do
+        it "loadPrologue . insertPrologue = id  for SeqState" $
+            property . prop_prologue_load_write @(SeqState 'Mainnet ShelleyKey) id
+
+        it "loadPrologue . insertPrologue = id  for RndState" $
+            property . prop_prologue_load_write @(RndState 'Mainnet) id
+        
+        it "loadPrologue . insertPrologue = id  for SharedState" $
+            property . prop_prologue_load_write @(SharedState 'Mainnet SharedKey)
+                (\s -> s { ready = Pending })
+
+{-------------------------------------------------------------------------------
+    Properties
+-------------------------------------------------------------------------------}
+-- | Check that writing and loading the 'Prologue' works.
+prop_prologue_load_write
+    :: forall s.
+    ( PersistAddressBook s
+    , Buildable (Prologue s)
+    , Eq (Prologue s)
+    )
+    => (s -> s) -> SqliteContext -> (WalletId, s) -> Property
+prop_prologue_load_write preprocess db (wid, s) =
+    prop_loadAfterWrite insertPrologue loadPrologue db (wid, pro)
+  where
+    (pro, _) = withIso addressIso $ \from _to -> from (preprocess s)
+    -- FIXME during ADP-1043: See note at 'multisigPoolAbsent'
+
+-- | Checks that loading a value after writing it to a database table
+-- is successful.
+prop_loadAfterWrite
+    :: ( Buildable (f a) , Eq (f a), Applicative f )
+    => (  WalletId
+       -> a
+       -> SqlPersistT IO ()
+       ) -- ^ Write Operation
+    -> (  WalletId
+       -> SqlPersistT IO (f a)
+       ) -- ^ Load Operation
+    -> SqliteContext
+    -> (WalletId, a)
+        -- ^ Property arguments
+    -> Property
+prop_loadAfterWrite writeOp loadOp db (wid, a) =
+    monadicIO (setup >> prop)
+  where
+    setup = do
+        run $ runQuery db $ do
+            cleanDB
+            -- Add a wallet to ensure that FOREIGN PRIMARY constraints are satisfied
+            insert_ $ Wallet
+                { walId = wid
+                , walName = "Stores"
+                , walCreationTime = dummyUTCTime
+                , walPassphraseLastUpdatedAt = Nothing
+                , walPassphraseScheme = Nothing
+                , walGenesisHash = BlockId dummyHash
+                , walGenesisStart = dummyUTCTime
+                }
+    prop = do
+        run $ runQuery db $ writeOp wid a
+        res <- run $ runQuery db $ loadOp wid
+        let fa = pure a
+        monitor $ counterexample $ "\nInserted\n" <> pretty fa
+        monitor $ counterexample $ "\nRead\n" <> pretty res
+        assertWith "Inserted == Read" (res == fa)
+
+-- | Like 'assert', but allow giving a label / title before running a assertion
+assertWith :: String -> Bool -> PropertyM IO ()
+assertWith lbl condition = do
+    let flag = if condition then "✓" else "✗"
+    monitor (counterexample $ lbl <> " " <> flag)
+    assert condition
+
+{-------------------------------------------------------------------------------
+    DB setup
+-------------------------------------------------------------------------------}
+withDBInMemory :: (SqliteContext -> IO a) -> IO a
+withDBInMemory action = bracket newDBInMemory fst (action . snd)
+
+newDBInMemory :: IO (IO (), SqliteContext)
+newDBInMemory = newInMemorySqliteContext nullTracer [] migrateAll
+
+-- | Remove all tables in the datase.
+cleanDB :: SqlPersistT IO ()
+cleanDB = do
+    deleteWhere ([] :: [Filter TH.Wallet])
+    deleteWhere ([] :: [Filter TH.PrivateKey])
+    deleteWhere ([] :: [Filter TH.TxMeta])
+    deleteWhere ([] :: [Filter TH.TxIn])
+    deleteWhere ([] :: [Filter TH.TxCollateral])
+    deleteWhere ([] :: [Filter TH.TxOut])
+    deleteWhere ([] :: [Filter TH.TxOutToken])
+    deleteWhere ([] :: [Filter TH.TxWithdrawal])
+    deleteWhere ([] :: [Filter TH.LocalTxSubmission])
+    deleteWhere ([] :: [Filter TH.Checkpoint])
+    deleteWhere ([] :: [Filter TH.ProtocolParameters])
+    deleteWhere ([] :: [Filter TH.StakeKeyCertificate])
+    deleteWhere ([] :: [Filter TH.DelegationCertificate])
+    deleteWhere ([] :: [Filter TH.DelegationReward])
+    deleteWhere ([] :: [Filter TH.UTxO])
+    deleteWhere ([] :: [Filter TH.UTxOToken])
+    deleteWhere ([] :: [Filter TH.SeqState])
+    deleteWhere ([] :: [Filter TH.SeqStateAddress])
+    deleteWhere ([] :: [Filter TH.SeqStatePendingIx])
+    deleteWhere ([] :: [Filter TH.RndState])
+    deleteWhere ([] :: [Filter TH.RndStateAddress])
+    deleteWhere ([] :: [Filter TH.RndStatePendingAddress])
+    deleteWhere ([] :: [Filter TH.SharedState])
+    deleteWhere ([] :: [Filter TH.CosignerKey])
+
+{-------------------------------------------------------------------------------
+    Arbitrary
+-------------------------------------------------------------------------------}
+dummyUTCTime :: UTCTime
+dummyUTCTime = posixSecondsToUTCTime 1506203091
+
+dummyHash :: Hash "BlockHeader"
+dummyHash = Hash $ unsafeFromHex
+    "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -1329,16 +1329,3 @@ initDummyStateSeq = mkSeqStateFromRootXPrv (xprv, mempty) purposeCIP1852 default
   where
       mw = SomeMnemonic $ unsafePerformIO (generate $ genMnemonic @15)
       xprv = Seq.generateKeyFromSeed (mw, Nothing) mempty
-
-{-------------------------------------------------------------------------------
-                      Test data and instances - Random AD
--------------------------------------------------------------------------------}
-
-instance Eq (RndState t) where
-    (==)
-        (RndState _ idx1 addrs1 pending1 gen1)
-        (RndState _ idx2 addrs2 pending2 gen2) =
-           idx1 == idx2
-        && addrs1 == addrs2
-        && pending1 == pending2
-        && show gen1 == show gen2

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
@@ -346,10 +346,6 @@ prop_oursAreUsed rnd@(Rnd st _ _) addrIx = do
                     Instances
 -------------------------------------------------------------------------------}
 
-instance Eq (RndState t) where
-    (RndState k1 accIx1 _ _ _) == (RndState k2 accIx2 _ _ _)
-        = k1 == k2 && accIx1 == accIx2
-
 instance Arbitrary Rnd where
     shrink _ = []  -- no shrinking
     arbitrary = do

--- a/nix/materialized/stack-nix/cardano-wallet-core.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-core.nix
@@ -184,8 +184,10 @@
           "Cardano/Wallet/DB/Sqlite/AddressBook"
           "Cardano/Wallet/DB/Sqlite/CheckpointsOld"
           "Cardano/Wallet/DB/Sqlite/Migration"
+          "Cardano/Wallet/DB/Sqlite/Stores"
           "Cardano/Wallet/DB/Sqlite/TH"
           "Cardano/Wallet/DB/Sqlite/Types"
+          "Cardano/Wallet/DB/WalletState"
           "Cardano/Wallet/Logging"
           "Cardano/Wallet/Network"
           "Cardano/Wallet/Network/Ports"
@@ -327,6 +329,7 @@
             (hsPkgs."network-uri" or (errorHandler.buildDepError "network-uri"))
             (hsPkgs."nothunks" or (errorHandler.buildDepError "nothunks"))
             (hsPkgs."persistent" or (errorHandler.buildDepError "persistent"))
+            (hsPkgs."persistent-sqlite" or (errorHandler.buildDepError "persistent-sqlite"))
             (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
             (hsPkgs."pretty-simple" or (errorHandler.buildDepError "pretty-simple"))
             (hsPkgs."regex-pcre-builtin" or (errorHandler.buildDepError "regex-pcre-builtin"))
@@ -390,6 +393,7 @@
             "Cardano/Wallet/DB/MVarSpec"
             "Cardano/Wallet/DB/Properties"
             "Cardano/Wallet/DB/SqliteSpec"
+            "Cardano/Wallet/DB/Sqlite/StoresSpec"
             "Cardano/Wallet/DB/Sqlite/TypesSpec"
             "Cardano/Wallet/DB/StateMachine"
             "Cardano/Wallet/DummyTarget/Primitive/Types"


### PR DESCRIPTION
### Issue number

ADP-1375

### Overview

Previous work in epic ADP-1043 introduced delta encodings, DBVars, and an embedding of the wallet state and its delta encodings into a database table. It's time to integrate these tools with the wallet code. To facilitate code review, the integration proceeds in a sequence of refactorings that do not change functionality and pass all unit tests.

In this step, we introduce a data type `WalletState` which represents the entire wallet state — not just the most recent checkpoint, but _all_ checkpoints.
```
data WalletState s = WalletState
    { prologue    :: Prologue s
    , checkpoints :: Checkpoints (BlockHeader, UTxO, Discoveries s)
    } 
```
The states for the different wallets currently stored in the `walletsVar` DBVar. Eventually, the data type will become the purely functional in-memory representation of all the data associated with a wallet (though perhaps with a different name). The `DBLayer` type will eventually be replaced by a `Store` for values of this type.

The introduction of this type has become possible thanks to the previous separation of the address discovery state `s` into `Prologue s` and `Discoveries s` (PRs #3056, #3068, #3073).

### Details

* As the queries in the `DBLayer` will more and more become queries on the in-memory cache `walletsVar` instead of queries on the database table, I have begun to add unit tests for the database tables. Here, I have added a property test for `loadPrologue` and `insertPrologue`. Eventually, these separate tests will become a single generic test for a `Store` of `Table`.

### Comments

* One of the next steps will be to replace `UTxO` in the above type by its delta encoding `DeltaUTxO`. This will reduce the memory footprint of the in-memory representation.
* The `Cardano.Wallet.DB.Model` module actually implements a pure model for the entire wallet state, including TxHistory etc. When extending the type, we can scavenge from there.