### PR TITLE
Re-write balanceTransaction using Node.evaluateTransactionBalance

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -1700,8 +1700,8 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         \Cannot balance when I cannot afford collateral" $
         \ctx -> runResourceT $ do
         wa <- fixtureWalletWith @n ctx
-            [ 2_000_000
-            , 2_000_000
+            [ 2_500_000
+            , 2_500_000
             ]
         let toBalance = Json PlutusScenario.pingPong_1
         rTx <- request @ApiSerialisedTransaction ctx
@@ -1731,11 +1731,11 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             , expectErrorMessage errMsg403Collateral
             , expectErrorMessage $ unwords
                 [ "I need an ada amount of at least:"
-                , "2.779500"
+                , "4.278900"
                 ]
             , expectErrorMessage $ unwords
                 [ "The largest combination of pure ada UTxOs I could find is:"
-                , "[1.853000]"
+                , "[2.852600]"
                 ]
             ]
 
@@ -1847,9 +1847,6 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
     it "TRANS_NEW_BALANCE_05/ADP-1286 - \
         \I can balance correctly in case I need to spend my remaining ADA for fee" $
         \ctx -> runResourceT $ do
-        liftIO $ pendingWith
-            "ADP-1286 - ValueNotConservedUTxO: Transaction seems balanced incorrectly \
-            \in case when less than minUtxOValue is left on the wallet"
         wa <- fixtureWalletWith @n ctx [3_000_000]
         -- PlutusScenario.pingPong_1 is sending out 2₳ therefore tx fee
         -- needs to be 1₳ to comply with minUTxOValue constraint

--- a/lib/core/src/Cardano/Api/Gen.hs
+++ b/lib/core/src/Cardano/Api/Gen.hs
@@ -256,8 +256,14 @@ genLovelace = Lovelace <$> frequency
             , (8, pure 65536)
             , (90, pure 4294967296)
             ]
-        x <- choose (-1_000_000, 1_000_000)
-        pure $ max 0 $ boundary + x
+
+        offset <- frequency
+            [ (1, choose (-10, 10))
+            , (1, choose (-220_000, -150_000))
+            , (1, choose (150_000, 220_000))
+            , (1, choose (-1_000_000, 1_000_000))
+            ]
+        pure $ max 0 $ boundary + offset
 
 
 genTxFee :: CardanoEra era -> Gen (TxFee era)

--- a/lib/core/src/Cardano/Api/Gen.hs
+++ b/lib/core/src/Cardano/Api/Gen.hs
@@ -259,8 +259,13 @@ genLovelace = Lovelace <$> frequency
 
         offset <- frequency
             [ (1, choose (-10, 10))
+
+            -- Offset by values close to common fee values, in both the positive
+            -- and negative direction, with the hope that this helps find
+            -- corner-cases.
             , (1, choose (-220_000, -150_000))
             , (1, choose (150_000, 220_000))
+
             , (1, choose (-1_000_000, 1_000_000))
             ]
         pure $ max 0 $ boundary + offset

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -197,6 +197,7 @@ module Cardano.Wallet
     , throttle
     , guardHardIndex
     , withNoSuchWallet
+    , posAndNegFromCardanoValue
 
     -- * Logging
     , WalletWorkerLog (..)

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1682,6 +1682,11 @@ balanceTransactionWithSelectionStrategy
         , extraCollateral
         , extraOutputs
         , feeUpdate = UseNewTxFee $ unsafeFromLovelace minfee0
+         -- TODO [ADP-1514] Ensure the choice of fee here doesn't cause the fee
+         -- minimization to fail.
+         --
+         -- Assuming fees are between 0.065536 and 4.294967296 ada, it
+         -- shouldn't, but it would be better not to rely on this.
         }
 
     (balance, candidateMinFee) <- balanceAfterSettingMinFee candidateTx

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1545,12 +1545,38 @@ balanceTransaction
     -> (UTxOIndex WalletUTxO, Wallet s, Set Tx)
     -> PartialTx
     -> ExceptT ErrBalanceTx m SealedTx
-balanceTransaction
+balanceTransaction ctx change pp ti wallet ptx = do
+    let balanceWith strategy = balanceTransactionWithSelectionStrategy @m @s @k
+            ctx change pp ti wallet strategy ptx
+    balanceWith SelectionStrategyOptimal
+        `catchE` \case
+            ErrBalanceTxMaxSizeLimitExceeded
+                -> balanceWith SelectionStrategyMinimal
+            otherErr
+                -> throwE otherErr
+
+balanceTransactionWithSelectionStrategy
+    :: forall m s k ctx.
+        ( HasTransactionLayer k ctx
+        , GenChange s
+        , MonadRandom m
+        , HasLogger m WalletWorkerLog ctx
+        )
+    => ctx
+    -> ArgGenChange s
+    -> (W.ProtocolParameters, Cardano.ProtocolParameters)
+    -> TimeInterpreter (Either PastHorizonException)
+    -> (UTxOIndex WalletUTxO, Wallet s, Set Tx)
+    -> SelectionStrategy
+    -> PartialTx
+    -> ExceptT ErrBalanceTx m SealedTx
+balanceTransactionWithSelectionStrategy
     ctx
     generateChange
     (pp, nodePParams)
     ti
     (internalUtxoAvailable, wallet, _pendingTxs)
+    selectionStrategy
     ptx@(PartialTx partialTx@(cardanoTx -> Cardano.InAnyCardanoEra _ (Cardano.Tx (Cardano.TxBody bod) _)) externalInputs redeemers)
     = do
     guardExistingCollateral
@@ -1953,7 +1979,7 @@ balanceTransaction
                 , utxoAvailableForCollateral =
                       UTxOSelection.availableMap utxoSelection
                 , utxoAvailableForInputs = utxoSelection
-                , selectionStrategy = SelectionStrategyOptimal
+                , selectionStrategy = selectionStrategy
 
                 }
             in

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -3392,7 +3392,6 @@ data ErrBalanceTx
     | ErrBalanceTxAssignRedeemers ErrAssignRedeemers
     | ErrBalanceTxNotYetSupported BalanceTxNotSupportedReason
     | ErrBalanceTxFailedBalancing Cardano.Value
-    | ErrBalanceTxMaxSizeLimitExceeded
 
 -- TODO: Remove once problems are fixed.
 data BalanceTxNotSupportedReason

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1848,16 +1848,16 @@ balanceTransactionWithSelectionStrategy
         (Cardano.InAnyCardanoEra _ (Cardano.Tx (Cardano.TxBody body) _))) = do
         -- Use of withdrawals with different networks breaks balancing.
         --
-        -- For instance the partial tx might contain two withdrawals with the same
-        -- key but different networks:
+        -- For instance the partial tx might contain two withdrawals with the
+        -- same key but different networks:
         -- [ (Mainnet, pkh1, coin1)
         -- , (Testnet, pkh1, coin2)
         -- ]
         --
-        -- Even though this is absurd, the node/ledger @evaluateTransactionBalance@
-        -- will count @coin1+coin2@ towards the total balance. Because the wallet
-        -- does not consider the network tag, it will drop one of the two, leading
-        -- to a discrepancy.
+        -- Even though this is absurd, the node/ledger
+        -- @evaluateTransactionBalance@ will count @coin1+coin2@ towards the
+        -- total balance. Because the wallet does not consider the network tag,
+        -- it will drop one of the two, leading to a discrepancy.
         let networkOfWdrl ((Cardano.StakeAddress nw _), _, _) = nw
         let conflictingWdrlNetworks = case Cardano.txWithdrawals body of
                 Cardano.TxWithdrawalsNone -> False
@@ -1869,9 +1869,9 @@ balanceTransactionWithSelectionStrategy
     guardExistingCollateral (cardanoTx ->
         (Cardano.InAnyCardanoEra _ (Cardano.Tx (Cardano.TxBody body) _))) = do
         -- Coin selection does not support pre-defining collateral. In Sep 2021
-        -- consensus was that we /could/ allow for it with just a day's work or so,
-        -- but that the need for it was unclear enough that it was not in any way
-        -- a priority.
+        -- consensus was that we /could/ allow for it with just a day's work or
+        -- so, but that the need for it was unclear enough that it was not in
+        -- any way a priority.
         case Cardano.txInsCollateral body of
             Cardano.TxInsCollateralNone -> return ()
             Cardano.TxInsCollateral _ [] -> return ()

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -403,7 +403,7 @@ import Cardano.Wallet.Primitive.Types.Redeemer
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( TokenBundle )
+    ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
@@ -1577,7 +1577,14 @@ balanceTransactionWithSelectionStrategy
     ti
     (internalUtxoAvailable, wallet, _pendingTxs)
     selectionStrategy
-    ptx@(PartialTx partialTx@(cardanoTx -> Cardano.InAnyCardanoEra _ (Cardano.Tx (Cardano.TxBody bod) _)) externalInputs redeemers)
+    ptx@(
+        PartialTx partialTx@(
+            cardanoTx ->
+                Cardano.InAnyCardanoEra _ (Cardano.Tx (Cardano.TxBody bod) _)
+        )
+        externalInputs
+        redeemers
+    )
     = do
     guardExistingCollateral
     guardZeroAdaOutputs (extractOutputsFromTx partialTx)
@@ -1872,15 +1879,14 @@ balanceTransactionWithSelectionStrategy
         let
             txPlutusScriptExecutionCost = maxScriptExecutionCost tl pp redeemers
             colReq =
-                    if txPlutusScriptExecutionCost > Coin 0 then
-                        SelectionCollateralRequired
-                    else
-                        SelectionCollateralNotRequired
+                if txPlutusScriptExecutionCost > Coin 0 then
+                    SelectionCollateralRequired
+                else
+                    SelectionCollateralNotRequired
 
-
-            (   TokenBundle.TokenBundle positiveAda positiveTokens
-                , TokenBundle.TokenBundle negativeAda negativeTokens
-                ) = posAndNegFromCardanoValue balance
+            (positiveBundle, negativeBundle) = posAndNegFromCardanoValue balance
+            (TokenBundle positiveAda positiveTokens) = positiveBundle
+            (TokenBundle negativeAda negativeTokens) = negativeBundle
 
             outs = extractOutputsFromTx tx
             adaInOutputs = F.foldMap (TokenBundle.getCoin . view #tokens) outs

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -522,7 +522,7 @@ import Data.Generics.Labels
 import Data.Generics.Product.Typed
     ( HasType, typed )
 import Data.IntCast
-    ( intCast )
+    ( intCast, intCastMaybe )
 import Data.Kind
     ( Type )
 import Data.List
@@ -3858,10 +3858,12 @@ posAndNegFromCardanoValue = foldMap go . Cardano.valueToList
         :: Cardano.Quantity
         -> (Natural -> TokenBundle.TokenBundle)
         -> (TokenBundle.TokenBundle, TokenBundle.TokenBundle)
-    partition (Cardano.Quantity q) f
-        | q > 0     = (f $ fromIntegral q, mempty)
-        | q < 0     = (mempty, f $ fromIntegral $ abs q)
+    partition (Cardano.Quantity i) f
+        | Just n <- maybeIntegerToNatural      i  = (f n, mempty)
+        | Just n <- maybeIntegerToNatural (abs i) = (mempty, f n)
         | otherwise = (mempty, mempty)
+
+    maybeIntegerToNatural = intCastMaybe @Integer @Natural
 
     mkPolicyId = UnsafeTokenPolicyId . Hash . Cardano.serialiseToRawBytes
     mkTokenName = UnsafeTokenName . Cardano.serialiseToRawBytes

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1659,7 +1659,7 @@ balanceTransactionWithSelectionStrategy
                 transform (getState wallet) <$> mSel
 
     -- NOTE:
-    -- Once the coin-selection is done, we need to
+    -- Once the coin selection is done, we need to
     --
     -- (a) Add selected inputs, collateral and change outputs to the transaction
     -- (b) Assign correct execution units to every redeemer
@@ -1705,7 +1705,7 @@ balanceTransactionWithSelectionStrategy
     let extraFeeToBurn = case extraOutputs of
             [] | surplus > Coin 20_000_000 ->
                 error $ unwords
-                    [ "final redunant safety check in balanceTransaction:"
+                    [ "final redundant safety check in balanceTransaction:"
                     , "burning more than 20 ada in fees is unreasonable"
                     ]
             [] ->
@@ -1771,7 +1771,7 @@ balanceTransactionWithSelectionStrategy
         -- - 4.294967296 ada and more is encoded as 9 bytes
         --
         -- To avoid fee minimization unknowingly increasing the size by 4 bytes,
-        -- we preemtively add an extra 4 bytes here.
+        -- we preemptively add an extra 4 bytes here.
         --
         -- https://json.nlohmann.me/features/binary_formats/cbor/
         --

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1634,7 +1634,7 @@ balanceTransactionWithSelectionStrategy
                     )
 
         lift $ traceWith tr $ MsgSelectionForBalancingStart
-            (CS.toExternalUTxOMap $ UTxOIndex.toMap internalUtxoAvailable)
+            (UTxOIndex.size internalUtxoAvailable)
             ptx
 
         let mSel = selectAssets'
@@ -2207,8 +2207,7 @@ selectAssets
 selectAssets ctx pp params transform = do
     guardPendingWithdrawal
     lift $ traceWith tr $ MsgSelectionStart
-        (CS.toExternalUTxOMap
-            $ UTxOSelection.availableMap
+        (UTxOSelection.availableSize
             $ params ^. #utxoAvailableForInputs)
         (params ^. #outputs)
     let selectionConstraints = SelectionConstraints
@@ -3665,8 +3664,8 @@ data WalletFollowLog
 
 -- | Log messages from API server actions running in a wallet worker context.
 data WalletLog
-    = MsgSelectionStart UTxO [TxOut]
-    | MsgSelectionForBalancingStart UTxO PartialTx
+    = MsgSelectionStart Int [TxOut]
+    | MsgSelectionForBalancingStart Int PartialTx
     | MsgSelectionError (SelectionError WalletSelectionContext)
     | MsgSelectionReportSummarized SelectionReportSummarized
     | MsgSelectionReportDetailed SelectionReportDetailed
@@ -3707,13 +3706,13 @@ instance ToText WalletFollowLog where
 
 instance ToText WalletLog where
     toText = \case
-        MsgSelectionStart utxo recipients ->
+        MsgSelectionStart utxoSize recipients ->
             "Starting coin selection " <>
-            "|utxo| = "+|UTxO.size utxo|+" " <>
+            "|utxo| = "+|utxoSize|+" " <>
             "#recipients = "+|length recipients|+""
-        MsgSelectionForBalancingStart utxo partialTx ->
+        MsgSelectionForBalancingStart utxoSize partialTx ->
             "Starting coin selection for balancing " <>
-            "|utxo| = "+|UTxO.size utxo|+" " <>
+            "|utxo| = "+|utxoSize|+" " <>
             "partialTx = "+|partialTx|+""
         MsgSelectionError e ->
             "Failed to select assets:\n"+|| e ||+""

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -3392,6 +3392,7 @@ data ErrBalanceTx
     | ErrBalanceTxAssignRedeemers ErrAssignRedeemers
     | ErrBalanceTxNotYetSupported BalanceTxNotSupportedReason
     | ErrBalanceTxFailedBalancing Cardano.Value
+    deriving (Show, Eq)
 
 -- TODO: Remove once problems are fixed.
 data BalanceTxNotSupportedReason

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1971,11 +1971,6 @@ balanceTransactionWithSelectionStrategy
                 -- selections notion of balance by @balance0 - sum inputs + sum
                 -- outputs + fee0@ where @balance0@ is the balance of the
                 -- partial tx.
-                --
-                -- We need to compensate for inputs and outputs affecting both
-                -- 1) the @balance@ itself and coin-selection and 2) the coin
-                -- selections notion of balance. Hence we add @-sum inputs + sum
-                -- outputs@ to cancel the effect of (2).
                 { assetsToMint = positiveTokens <> tokensInOutputs
                 , assetsToBurn = negativeTokens <> tokensInInputs
                 , extraCoinIn =

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -421,6 +421,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxMeta (..)
     , TxMetadata (..)
     , TxOut (..)
+    , TxSize (..)
     , TxStatus (..)
     , UnsignedTx (..)
     , fromTransactionInfo
@@ -1663,7 +1664,7 @@ balanceTransaction
                    | otherwise -> surplus
                 _              -> Coin 0
 
-    guardTxBalanced =<< (assembleTransaction $ TxUpdate
+    guardTxSize =<< guardTxBalanced =<< (assembleTransaction $ TxUpdate
         { extraInputs
         , extraCollateral
         , extraOutputs =
@@ -1677,6 +1678,19 @@ balanceTransaction
   where
     tl = ctx ^. transactionLayer @k
     tr = contramap MsgWallet $ ctx ^. logger @m
+
+    guardTxSize :: SealedTx -> ExceptT ErrBalanceTx m SealedTx
+    guardTxSize tx =
+        case estimateSignedTxSize tl nodePParams tx of
+            Nothing -> throwE $ ErrBalanceTxUpdateError ErrByronTxNotSupported
+            Just size -> do
+                let maxSize = TxSize
+                        . intCast
+                        . getQuantity
+                        $ view (#txParameters . #getTxMaxSize) pp
+                when (size > maxSize) $
+                    throwE ErrBalanceTxMaxSizeLimitExceeded
+                return tx
 
     guardTxBalanced :: SealedTx -> ExceptT ErrBalanceTx m SealedTx
     guardTxBalanced tx = do
@@ -3347,11 +3361,12 @@ data ErrSignPayment
 data ErrBalanceTx
     = ErrBalanceTxUpdateError ErrUpdateSealedTx
     | ErrBalanceTxSelectAssets ErrSelectAssets
+    | ErrBalanceTxMaxSizeLimitExceeded
     | ErrBalanceTxExistingCollateral
     | ErrBalanceTxAssignRedeemers ErrAssignRedeemers
     | ErrBalanceTxNotYetSupported BalanceTxNotSupportedReason
     | ErrBalanceTxFailedBalancing Cardano.Value
-    deriving (Show, Eq)
+    | ErrBalanceTxMaxSizeLimitExceeded
 
 -- TODO: Remove once problems are fixed.
 data BalanceTxNotSupportedReason

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1769,8 +1769,8 @@ balanceTransactionWithSelectionStrategy
         -- 0.065536 ada or more. This is certainly the case on mainnet with a
         -- minUTxOValue of ≈1 ada. Then we only need to care about the following
         -- two sizes of CBOR lovelace values:
-        -- - 0.065536 ada is encoded as 5 bytes
-        -- - 4.294967296 ada is encoded as 9 bytes
+        -- - [0.065536 ada, 4.294967296 ada) is encoded as 5 bytes
+        -- - 4.294967296 ada and more is encoded as 9 bytes
         --
         -- To avoid fee minimization unknowingly increasing the size by 4 bytes,
         -- we preemtively add an extra 4 bytes here.

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -4206,6 +4206,12 @@ instance IsServerError ErrBalanceTx where
                 , " by " <> pretty c
                 , "and cannot finish balancing."
                 ]
+        ErrBalanceTxMaxSizeLimitExceeded ->
+            apiError err403 CreatedInvalidTransaction $ mconcat
+                [ "I was not able to balance the transaction without exceeding"
+                , "the maximum transaction size."
+                ]
+
 
 instance IsServerError ErrMintBurnAssets where
     toServerError = \case

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -4195,10 +4195,6 @@ instance IsServerError ErrBalanceTx where
             apiError err500 CreatedInvalidTransaction $ mconcat
                 [ "The transaction contains one or more zero ada outputs."
                 ]
-        ErrBalanceTxNotYetSupported Deposits ->
-            apiError err500 CreatedInvalidTransaction $ mconcat
-                [ "Deposits/refunds are not yet supported for balancing."
-                ]
         ErrBalanceTxFailedBalancing v ->
             apiError err500 CreatedInvalidTransaction $ mconcat
                 [ "I have somehow failed to balance the transaction. The balance"

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
@@ -66,6 +66,7 @@ module Cardano.Wallet.Primitive.Types.UTxOSelection
       -- * Accessor functions
     , availableBalance
     , availableMap
+    , availableSize
     , leftoverBalance
     , leftoverSize
     , leftoverIndex
@@ -338,6 +339,11 @@ availableBalance s = leftoverBalance s <> selectedBalance s
 --
 availableMap :: IsUTxOSelection s u => Ord u => s u -> Map u TokenBundle
 availableMap s = leftoverMap s <> selectedMap s
+
+-- | Computes the size of the available UTxO set.
+--
+availableSize :: IsUTxOSelection s u => s u -> Int
+availableSize s = leftoverSize s + selectedSize s
 
 -- | Retrieves the balance of leftover UTxOs.
 --

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
@@ -55,6 +55,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Data.Foldable as F
+import qualified Data.Map.Strict as Map
 
 spec :: Spec
 spec =
@@ -97,6 +98,8 @@ spec =
 
         it "prop_availableBalance_availableMap" $
             property prop_availableBalance_availableMap
+        it "prop_availableMap_availableSize" $
+            property prop_availableMap_availableSize
         it "prop_isNonEmpty_selectedSize" $
             property prop_isNonEmpty_selectedSize
         it "prop_isNonEmpty_selectedIndex" $
@@ -256,6 +259,12 @@ prop_availableBalance_availableMap s =
     checkCoverage_UTxOSelection s $
     UTxOSelection.availableBalance s
     === F.fold (UTxOSelection.availableMap s)
+
+prop_availableMap_availableSize :: UTxOSelection WalletUTxO -> Property
+prop_availableMap_availableSize s =
+    checkCoverage_UTxOSelection s $
+    UTxOSelection.availableSize s
+    === Map.size (UTxOSelection.availableMap s)
 
 prop_isNonEmpty_selectedSize :: UTxOSelection WalletUTxO -> Property
 prop_isNonEmpty_selectedSize s =

--- a/lib/shelley/test/data/balanceTx/1ada-payment/golden
+++ b/lib/shelley/test/data/balanceTx/1ada-payment/golden
@@ -18,64 +18,64 @@
  0.850000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 850000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 1000000, tokens = TokenMap (fromList [])}}))))
  0.900000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 900000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 1000000, tokens = TokenMap (fromList [])}}))))
  0.950000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 950000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 1000000, tokens = TokenMap (fromList [])}}))))
- 1.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 169329, shortfall = Coin 169329}))))
- 1.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 169329, shortfall = Coin 119329}))))
- 1.100000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 169329, shortfall = Coin 69329}))))
- 1.150000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 169329, shortfall = Coin 19329}))))
- 1.200000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,36083)])
- 1.250000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,86083)])
- 1.300000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,136083)])
- 1.350000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,186083)])
- 1.400000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,236083)])
- 1.450000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,286083)])
- 1.500000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,336083)])
- 1.550000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,386083)])
- 1.600000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,436083)])
- 1.650000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,486083)])
- 1.700000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,536083)])
- 1.750000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,586083)])
- 1.800000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,636083)])
- 1.850000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,686083)])
- 1.900000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,736083)])
- 1.950000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,786083)])
- 2.000000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,836083)])
- 2.050000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,886083)])
- 2.100000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,936083)])
- 2.150000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,986083)])
- 2.200000,0.166777,0.166777
- 2.250000,0.166777,0.166777
- 2.300000,0.166777,0.166777
- 2.350000,0.166777,0.166777
- 2.400000,0.166777,0.166777
- 2.450000,0.166777,0.166777
- 2.500000,0.166777,0.166777
- 2.550000,0.166777,0.166777
- 2.600000,0.166777,0.166777
- 2.650000,0.166777,0.166777
- 2.700000,0.166777,0.166777
- 2.750000,0.166777,0.166777
- 2.800000,0.166777,0.166777
- 2.850000,0.166777,0.166777
- 2.900000,0.166777,0.166777
- 2.950000,0.166777,0.166777
- 3.000000,0.166777,0.166777
- 3.050000,0.166777,0.166777
- 3.100000,0.166777,0.166777
- 3.150000,0.166777,0.166777
- 3.200000,0.166777,0.166777
- 3.250000,0.166777,0.166777
- 3.300000,0.166777,0.166777
- 3.350000,0.166777,0.166777
- 3.400000,0.166777,0.166777
- 3.450000,0.166777,0.166777
- 3.500000,0.166777,0.166777
- 3.550000,0.166777,0.166777
- 3.600000,0.166777,0.166777
- 3.650000,0.166777,0.166777
- 3.700000,0.166777,0.166777
- 3.750000,0.166777,0.166777
- 3.800000,0.166777,0.166777
- 3.850000,0.166777,0.166777
- 3.900000,0.166777,0.166777
- 3.950000,0.166777,0.166777
- 4.000000,0.166777,0.166777
+ 1.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 168933, shortfall = Coin 168933}))))
+ 1.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 168933, shortfall = Coin 118933}))))
+ 1.100000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 168933, shortfall = Coin 68933}))))
+ 1.150000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 168933, shortfall = Coin 18933}))))
+ 1.200000,0.200000,0.163917
+ 1.250000,0.250000,0.163917
+ 1.300000,0.300000,0.163917
+ 1.350000,0.350000,0.163917
+ 1.400000,0.400000,0.163917
+ 1.450000,0.450000,0.163917
+ 1.500000,0.500000,0.163917
+ 1.550000,0.550000,0.163917
+ 1.600000,0.600000,0.163917
+ 1.650000,0.650000,0.163917
+ 1.700000,0.700000,0.163917
+ 1.750000,0.750000,0.163917
+ 1.800000,0.800000,0.163917
+ 1.850000,0.850000,0.163917
+ 1.900000,0.900000,0.163917
+ 1.950000,0.950000,0.163917
+ 2.000000,1.000000,0.163917
+ 2.050000,1.050000,0.163917
+ 2.100000,1.100000,0.163917
+ 2.150000,1.150000,0.163917
+ 2.200000,0.166953,0.166777
+ 2.250000,0.166953,0.166777
+ 2.300000,0.166953,0.166777
+ 2.350000,0.166953,0.166777
+ 2.400000,0.166953,0.166777
+ 2.450000,0.166953,0.166777
+ 2.500000,0.166953,0.166777
+ 2.550000,0.166953,0.166777
+ 2.600000,0.166953,0.166777
+ 2.650000,0.166953,0.166777
+ 2.700000,0.166953,0.166777
+ 2.750000,0.166953,0.166777
+ 2.800000,0.166953,0.166777
+ 2.850000,0.166953,0.166777
+ 2.900000,0.166953,0.166777
+ 2.950000,0.166953,0.166777
+ 3.000000,0.166953,0.166777
+ 3.050000,0.166953,0.166777
+ 3.100000,0.166953,0.166777
+ 3.150000,0.166953,0.166777
+ 3.200000,0.166953,0.166777
+ 3.250000,0.166953,0.166777
+ 3.300000,0.166953,0.166777
+ 3.350000,0.166953,0.166777
+ 3.400000,0.166953,0.166777
+ 3.450000,0.166953,0.166777
+ 3.500000,0.166953,0.166777
+ 3.550000,0.166953,0.166777
+ 3.600000,0.166953,0.166777
+ 3.650000,0.166953,0.166777
+ 3.700000,0.166953,0.166777
+ 3.750000,0.166953,0.166777
+ 3.800000,0.166953,0.166777
+ 3.850000,0.166953,0.166777
+ 3.900000,0.166953,0.166777
+ 3.950000,0.166953,0.166777
+ 4.000000,0.166953,0.166777

--- a/lib/shelley/test/data/balanceTx/delegate/golden
+++ b/lib/shelley/test/data/balanceTx/delegate/golden
@@ -1,81 +1,81 @@
- 0.000000,ErrBalanceTxNotYetSupported Deposits
- 0.050000,ErrBalanceTxNotYetSupported Deposits
- 0.100000,ErrBalanceTxNotYetSupported Deposits
- 0.150000,ErrBalanceTxNotYetSupported Deposits
- 0.200000,ErrBalanceTxNotYetSupported Deposits
- 0.250000,ErrBalanceTxNotYetSupported Deposits
- 0.300000,ErrBalanceTxNotYetSupported Deposits
- 0.350000,ErrBalanceTxNotYetSupported Deposits
- 0.400000,ErrBalanceTxNotYetSupported Deposits
- 0.450000,ErrBalanceTxNotYetSupported Deposits
- 0.500000,ErrBalanceTxNotYetSupported Deposits
- 0.550000,ErrBalanceTxNotYetSupported Deposits
- 0.600000,ErrBalanceTxNotYetSupported Deposits
- 0.650000,ErrBalanceTxNotYetSupported Deposits
- 0.700000,ErrBalanceTxNotYetSupported Deposits
- 0.750000,ErrBalanceTxNotYetSupported Deposits
- 0.800000,ErrBalanceTxNotYetSupported Deposits
- 0.850000,ErrBalanceTxNotYetSupported Deposits
- 0.900000,ErrBalanceTxNotYetSupported Deposits
- 0.950000,ErrBalanceTxNotYetSupported Deposits
- 1.000000,ErrBalanceTxNotYetSupported Deposits
- 1.050000,ErrBalanceTxNotYetSupported Deposits
- 1.100000,ErrBalanceTxNotYetSupported Deposits
- 1.150000,ErrBalanceTxNotYetSupported Deposits
- 1.200000,ErrBalanceTxNotYetSupported Deposits
- 1.250000,ErrBalanceTxNotYetSupported Deposits
- 1.300000,ErrBalanceTxNotYetSupported Deposits
- 1.350000,ErrBalanceTxNotYetSupported Deposits
- 1.400000,ErrBalanceTxNotYetSupported Deposits
- 1.450000,ErrBalanceTxNotYetSupported Deposits
- 1.500000,ErrBalanceTxNotYetSupported Deposits
- 1.550000,ErrBalanceTxNotYetSupported Deposits
- 1.600000,ErrBalanceTxNotYetSupported Deposits
- 1.650000,ErrBalanceTxNotYetSupported Deposits
- 1.700000,ErrBalanceTxNotYetSupported Deposits
- 1.750000,ErrBalanceTxNotYetSupported Deposits
- 1.800000,ErrBalanceTxNotYetSupported Deposits
- 1.850000,ErrBalanceTxNotYetSupported Deposits
- 1.900000,ErrBalanceTxNotYetSupported Deposits
- 1.950000,ErrBalanceTxNotYetSupported Deposits
- 2.000000,ErrBalanceTxNotYetSupported Deposits
- 2.050000,ErrBalanceTxNotYetSupported Deposits
- 2.100000,ErrBalanceTxNotYetSupported Deposits
- 2.150000,ErrBalanceTxNotYetSupported Deposits
- 2.200000,ErrBalanceTxNotYetSupported Deposits
- 2.250000,ErrBalanceTxNotYetSupported Deposits
- 2.300000,ErrBalanceTxNotYetSupported Deposits
- 2.350000,ErrBalanceTxNotYetSupported Deposits
- 2.400000,ErrBalanceTxNotYetSupported Deposits
- 2.450000,ErrBalanceTxNotYetSupported Deposits
- 2.500000,ErrBalanceTxNotYetSupported Deposits
- 2.550000,ErrBalanceTxNotYetSupported Deposits
- 2.600000,ErrBalanceTxNotYetSupported Deposits
- 2.650000,ErrBalanceTxNotYetSupported Deposits
- 2.700000,ErrBalanceTxNotYetSupported Deposits
- 2.750000,ErrBalanceTxNotYetSupported Deposits
- 2.800000,ErrBalanceTxNotYetSupported Deposits
- 2.850000,ErrBalanceTxNotYetSupported Deposits
- 2.900000,ErrBalanceTxNotYetSupported Deposits
- 2.950000,ErrBalanceTxNotYetSupported Deposits
- 3.000000,ErrBalanceTxNotYetSupported Deposits
- 3.050000,ErrBalanceTxNotYetSupported Deposits
- 3.100000,ErrBalanceTxNotYetSupported Deposits
- 3.150000,ErrBalanceTxNotYetSupported Deposits
- 3.200000,ErrBalanceTxNotYetSupported Deposits
- 3.250000,ErrBalanceTxNotYetSupported Deposits
- 3.300000,ErrBalanceTxNotYetSupported Deposits
- 3.350000,ErrBalanceTxNotYetSupported Deposits
- 3.400000,ErrBalanceTxNotYetSupported Deposits
- 3.450000,ErrBalanceTxNotYetSupported Deposits
- 3.500000,ErrBalanceTxNotYetSupported Deposits
- 3.550000,ErrBalanceTxNotYetSupported Deposits
- 3.600000,ErrBalanceTxNotYetSupported Deposits
- 3.650000,ErrBalanceTxNotYetSupported Deposits
- 3.700000,ErrBalanceTxNotYetSupported Deposits
- 3.750000,ErrBalanceTxNotYetSupported Deposits
- 3.800000,ErrBalanceTxNotYetSupported Deposits
- 3.850000,ErrBalanceTxNotYetSupported Deposits
- 3.900000,ErrBalanceTxNotYetSupported Deposits
- 3.950000,ErrBalanceTxNotYetSupported Deposits
- 4.000000,ErrBalanceTxNotYetSupported Deposits
+ 0.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 0, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 50000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.100000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 100000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.150000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 150000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.200000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 200000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.250000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 250000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.300000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 300000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.350000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 350000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.400000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 400000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.450000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 450000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.500000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 500000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.550000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 550000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.600000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 600000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.650000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 650000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.700000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 700000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.750000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 750000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.800000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 800000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.850000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 850000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.900000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 900000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 0.950000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 950000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1000000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1050000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.100000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1100000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.150000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1150000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.200000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1200000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.250000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1250000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.300000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1300000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.350000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1350000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.400000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1400000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.450000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1450000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.500000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1500000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.550000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1550000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.600000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1600000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.650000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1650000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.700000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1700000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.750000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1750000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.800000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1800000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.850000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1850000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.900000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1900000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 1.950000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1950000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
+ 2.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 181077, shortfall = Coin 181077}))))
+ 2.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 181077, shortfall = Coin 131077}))))
+ 2.100000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 181077, shortfall = Coin 81077}))))
+ 2.150000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 181077, shortfall = Coin 31077}))))
+ 2.200000,0.200000,0.175577
+ 2.250000,0.250000,0.175577
+ 2.300000,0.300000,0.175577
+ 2.350000,0.350000,0.175577
+ 2.400000,0.400000,0.175577
+ 2.450000,0.450000,0.175577
+ 2.500000,0.500000,0.175577
+ 2.550000,0.550000,0.175577
+ 2.600000,0.600000,0.175577
+ 2.650000,0.650000,0.175577
+ 2.700000,0.700000,0.175577
+ 2.750000,0.750000,0.175577
+ 2.800000,0.800000,0.175577
+ 2.850000,0.850000,0.175577
+ 2.900000,0.900000,0.175577
+ 2.950000,0.950000,0.175577
+ 3.000000,1.000000,0.175577
+ 3.050000,1.050000,0.175577
+ 3.100000,1.100000,0.175577
+ 3.150000,1.150000,0.175577
+ 3.200000,0.178613,0.178437
+ 3.250000,0.178613,0.178437
+ 3.300000,0.178613,0.178437
+ 3.350000,0.178613,0.178437
+ 3.400000,0.178613,0.178437
+ 3.450000,0.178613,0.178437
+ 3.500000,0.178613,0.178437
+ 3.550000,0.178613,0.178437
+ 3.600000,0.178613,0.178437
+ 3.650000,0.178613,0.178437
+ 3.700000,0.178613,0.178437
+ 3.750000,0.178613,0.178437
+ 3.800000,0.178613,0.178437
+ 3.850000,0.178613,0.178437
+ 3.900000,0.178613,0.178437
+ 3.950000,0.178613,0.178437
+ 4.000000,0.178613,0.178437

--- a/lib/shelley/test/data/balanceTx/pingPong_1/golden
+++ b/lib/shelley/test/data/balanceTx/pingPong_1/golden
@@ -38,44 +38,44 @@
  1.850000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1850000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
  1.900000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1900000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
  1.950000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1950000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
- 2.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 170341, shortfall = Coin 170341}))))
- 2.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 170341, shortfall = Coin 120341}))))
- 2.100000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 170341, shortfall = Coin 70341}))))
- 2.150000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 170341, shortfall = Coin 20341}))))
- 2.200000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,32827)])
- 2.250000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,82827)])
- 2.300000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,132827)])
- 2.350000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,182827)])
- 2.400000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,232827)])
- 2.450000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,282827)])
- 2.500000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,332827)])
- 2.550000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,382827)])
- 2.600000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,432827)])
- 2.650000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,482827)])
- 2.700000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,532827)])
- 2.750000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,582827)])
- 2.800000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,632827)])
- 2.850000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,682827)])
- 2.900000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,732827)])
- 2.950000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,782827)])
- 3.000000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,832827)])
- 3.050000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,882827)])
- 3.100000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,932827)])
- 3.150000,ErrBalanceTxFailedBalancing (valueFromList [(AdaAssetId,982827)])
- 3.200000,0.170033,0.170033
- 3.250000,0.170033,0.170033
- 3.300000,0.170033,0.170033
- 3.350000,0.170033,0.170033
- 3.400000,0.170033,0.170033
- 3.450000,0.170033,0.170033
- 3.500000,0.170033,0.170033
- 3.550000,0.170033,0.170033
- 3.600000,0.170033,0.170033
- 3.650000,0.170033,0.170033
- 3.700000,0.170033,0.170033
- 3.750000,0.170033,0.170033
- 3.800000,0.170033,0.170033
- 3.850000,0.170033,0.170033
- 3.900000,0.170033,0.170033
- 3.950000,0.170033,0.170033
- 4.000000,0.170033,0.170033
+ 2.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 170649, shortfall = Coin 170649}))))
+ 2.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 170649, shortfall = Coin 120649}))))
+ 2.100000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 170649, shortfall = Coin 70649}))))
+ 2.150000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 170649, shortfall = Coin 20649}))))
+ 2.200000,0.200000,0.167173
+ 2.250000,0.250000,0.167173
+ 2.300000,0.300000,0.167173
+ 2.350000,0.350000,0.167173
+ 2.400000,0.400000,0.167173
+ 2.450000,0.450000,0.167173
+ 2.500000,0.500000,0.167173
+ 2.550000,0.550000,0.167173
+ 2.600000,0.600000,0.167173
+ 2.650000,0.650000,0.167173
+ 2.700000,0.700000,0.167173
+ 2.750000,0.750000,0.167173
+ 2.800000,0.800000,0.167173
+ 2.850000,0.850000,0.167173
+ 2.900000,0.900000,0.167173
+ 2.950000,0.950000,0.167173
+ 3.000000,1.000000,0.167173
+ 3.050000,1.050000,0.167173
+ 3.100000,1.100000,0.167173
+ 3.150000,1.150000,0.167173
+ 3.200000,0.170209,0.170033
+ 3.250000,0.170209,0.170033
+ 3.300000,0.170209,0.170033
+ 3.350000,0.170209,0.170033
+ 3.400000,0.170209,0.170033
+ 3.450000,0.170209,0.170033
+ 3.500000,0.170209,0.170033
+ 3.550000,0.170209,0.170033
+ 3.600000,0.170209,0.170033
+ 3.650000,0.170209,0.170033
+ 3.700000,0.170209,0.170033
+ 3.750000,0.170209,0.170033
+ 3.800000,0.170209,0.170033
+ 3.850000,0.170209,0.170033
+ 3.900000,0.170209,0.170033
+ 3.950000,0.170209,0.170033
+ 4.000000,0.170209,0.170033

--- a/lib/shelley/test/data/balanceTx/pingPong_2/golden
+++ b/lib/shelley/test/data/balanceTx/pingPong_2/golden
@@ -1,44 +1,44 @@
- 0.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 1723825}))))
- 0.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 1673825}))))
- 0.100000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 1623825}))))
- 0.150000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 1573825}))))
- 0.200000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 1523825}))))
- 0.250000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 1473825}))))
- 0.300000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 1423825}))))
- 0.350000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 1373825}))))
- 0.400000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 1323825}))))
- 0.450000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 1273825}))))
- 0.500000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 1223825}))))
- 0.550000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 1173825}))))
- 0.600000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 1123825}))))
- 0.650000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 1073825}))))
- 0.700000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 1023825}))))
- 0.750000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 973825}))))
- 0.800000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 923825}))))
- 0.850000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 873825}))))
- 0.900000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 823825}))))
- 0.950000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 773825}))))
- 1.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 723825}))))
- 1.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 673825}))))
- 1.100000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 623825}))))
- 1.150000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 573825}))))
- 1.200000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 523825}))))
- 1.250000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 473825}))))
- 1.300000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 423825}))))
- 1.350000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 373825}))))
- 1.400000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 323825}))))
- 1.450000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 273825}))))
- 1.500000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 223825}))))
- 1.550000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 173825}))))
- 1.600000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 123825}))))
- 1.650000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 73825}))))
- 1.700000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 1723825, shortfall = Coin 23825}))))
- 1.750000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 1750000)], minimumSelectionAmount = Coin 2625000})))
- 1.800000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 1800000)], minimumSelectionAmount = Coin 2700000})))
- 1.850000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 1850000)], minimumSelectionAmount = Coin 2775000})))
- 1.900000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 1900000)], minimumSelectionAmount = Coin 2850000})))
- 1.950000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 1950000)], minimumSelectionAmount = Coin 2925000})))
- 2.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 2000000)], minimumSelectionAmount = Coin 3000000})))
+ 0.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 2033497}))))
+ 0.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1983497}))))
+ 0.100000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1933497}))))
+ 0.150000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1883497}))))
+ 0.200000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1833497}))))
+ 0.250000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1783497}))))
+ 0.300000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1733497}))))
+ 0.350000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1683497}))))
+ 0.400000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1633497}))))
+ 0.450000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1583497}))))
+ 0.500000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1533497}))))
+ 0.550000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1483497}))))
+ 0.600000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1433497}))))
+ 0.650000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1383497}))))
+ 0.700000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1333497}))))
+ 0.750000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1283497}))))
+ 0.800000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1233497}))))
+ 0.850000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1183497}))))
+ 0.900000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1133497}))))
+ 0.950000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1083497}))))
+ 1.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1033497}))))
+ 1.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 983497}))))
+ 1.100000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 933497}))))
+ 1.150000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 883497}))))
+ 1.200000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 833497}))))
+ 1.250000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 783497}))))
+ 1.300000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 733497}))))
+ 1.350000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 683497}))))
+ 1.400000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 633497}))))
+ 1.450000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 583497}))))
+ 1.500000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 533497}))))
+ 1.550000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 483497}))))
+ 1.600000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 433497}))))
+ 1.650000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 383497}))))
+ 1.700000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 333497}))))
+ 1.750000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 283497}))))
+ 1.800000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 233497}))))
+ 1.850000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 183497}))))
+ 1.900000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 133497}))))
+ 1.950000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 83497}))))
+ 2.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 33497}))))
  2.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 2050000)], minimumSelectionAmount = Coin 3075000})))
  2.100000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 2100000)], minimumSelectionAmount = Coin 3150000})))
  2.150000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 2150000)], minimumSelectionAmount = Coin 3225000})))
@@ -53,29 +53,29 @@
  2.600000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 2600000)], minimumSelectionAmount = Coin 3900000})))
  2.650000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 2650000)], minimumSelectionAmount = Coin 3975000})))
  2.700000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 2700000)], minimumSelectionAmount = Coin 4050000})))
- 2.750000,0.612050,0.612050
- 2.800000,0.612050,0.612050
- 2.850000,0.612050,0.612050
- 2.900000,0.612050,0.612050
- 2.950000,0.612050,0.612050
- 3.000000,0.612050,0.612050
- 3.050000,0.612050,0.612050
- 3.100000,0.612050,0.612050
- 3.150000,0.612050,0.612050
- 3.200000,0.612050,0.612050
- 3.250000,0.612050,0.612050
- 3.300000,0.612050,0.612050
- 3.350000,0.612050,0.612050
- 3.400000,0.612050,0.612050
- 3.450000,0.612050,0.612050
- 3.500000,0.612050,0.612050
- 3.550000,0.612050,0.612050
- 3.600000,0.612050,0.612050
- 3.650000,0.612050,0.612050
- 3.700000,0.612050,0.612050
- 3.750000,0.612050,0.612050
- 3.800000,0.612050,0.612050
- 3.850000,0.612050,0.612050
- 3.900000,0.612050,0.612050
- 3.950000,0.612050,0.612050
- 4.000000,0.612050,0.612050
+ 2.750000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 2750000)], minimumSelectionAmount = Coin 4125000})))
+ 2.800000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 2800000)], minimumSelectionAmount = Coin 4200000})))
+ 2.850000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 2850000)], minimumSelectionAmount = Coin 4275000})))
+ 2.900000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 2900000)], minimumSelectionAmount = Coin 4350000})))
+ 2.950000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 2950000)], minimumSelectionAmount = Coin 4425000})))
+ 3.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 3000000)], minimumSelectionAmount = Coin 4500000})))
+ 3.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionCollateralErrorOf (SelectionCollateralError {largestCombinationAvailable = fromList [(WalletUTxO {txIn = TxIn {inputId = Hash "00000000000000000000000000000000", inputIx = 0}, address = Address "`\177\229\224\251t\200l\128\USdhA\224|\219B\223\139\130\239<\228\229|\181A.w"},Coin 3050000)], minimumSelectionAmount = Coin 3050246})))
+ 3.100000,0.612226,0.612050
+ 3.150000,0.612226,0.612050
+ 3.200000,0.612226,0.612050
+ 3.250000,0.612226,0.612050
+ 3.300000,0.612226,0.612050
+ 3.350000,0.612226,0.612050
+ 3.400000,0.612226,0.612050
+ 3.450000,0.612226,0.612050
+ 3.500000,0.612226,0.612050
+ 3.550000,0.612226,0.612050
+ 3.600000,0.612226,0.612050
+ 3.650000,0.612226,0.612050
+ 3.700000,0.612226,0.612050
+ 3.750000,0.612226,0.612050
+ 3.800000,0.612226,0.612050
+ 3.850000,0.612226,0.612050
+ 3.900000,0.612226,0.612050
+ 3.950000,0.612226,0.612050
+ 4.000000,0.612226,0.612050

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2245,6 +2245,7 @@ shrinkTxBody (Cardano.ShelleyTxBody e bod scripts scriptData aux val) = tail
             { Alonzo.mint = mint' }
             { Alonzo.reqSignerHashes = rsh' }
             { Alonzo.txUpdates = updates' }
+            { Alonzo.txfee = txfee' }
         | updates' <- prependOriginal shrinkUpdates (Alonzo.txUpdates body)
         , wdrls' <- prependOriginal shrinkWdrl (Alonzo.txwdrls body)
         , outs' <- prependOriginal (shrinkSeq (const [])) (Alonzo.outputs body)
@@ -2254,6 +2255,7 @@ shrinkTxBody (Cardano.ShelleyTxBody e bod scripts scriptData aux val) = tail
         , rsh' <- prependOriginal
             (shrinkSet (const []))
             (Alonzo.reqSignerHashes body)
+        , txfee' <- prependOriginal shrinkFee (Alonzo.txfee body)
         ]
 
     shrinkValue v = filter (/= v) [v0]
@@ -2264,6 +2266,10 @@ shrinkTxBody (Cardano.ShelleyTxBody e bod scripts scriptData aux val) = tail
     shrinkSet shrinkElem = map Set.fromList . shrinkList shrinkElem . F.toList
 
     shrinkSeq shrinkElem = map StrictSeq.fromList . shrinkList shrinkElem . F.toList
+
+    shrinkFee :: Ledger.Coin -> [Ledger.Coin]
+    shrinkFee (Ledger.Coin 0) = []
+    shrinkFee _ = [Ledger.Coin 0]
 
     shrinkWdrl :: Wdrl era -> [Wdrl era]
     shrinkWdrl (Wdrl m) = map (Wdrl . Map.fromList) $ shrinkList shrinkWdrl' (Map.toList m)

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2737,8 +2737,9 @@ prop_balanceTransactionBalanced wallet (ShowBuildable partialTx') seed
 
     valueFromCardanoTxOutValue
         :: forall era. Cardano.TxOutValue era -> Cardano.Value
-    valueFromCardanoTxOutValue (TxOutAdaOnly _ coin) = Cardano.lovelaceToValue coin
-    valueFromCardanoTxOutValue (TxOutValue _ val) = val
+    valueFromCardanoTxOutValue = \case
+        TxOutAdaOnly _ coin -> Cardano.lovelaceToValue coin
+        TxOutValue _ val -> val
 
     (_, nodePParams) = mockProtocolParametersForBalancing
 
@@ -3102,21 +3103,21 @@ paymentPartialTx txouts = PartialTx (sealedTxFromCardanoBody body) [] []
         Nothing
         Cardano.TxScriptValidityNone
     alonzoBody = Alonzo.TxBody
-      { Alonzo.inputs = mempty
-      , Alonzo.collateral = mempty
-      , Alonzo.outputs = StrictSeq.fromList $
-             map (`toAlonzoTxOut` Nothing) txouts
-      , Alonzo.txcerts = mempty
-      , Alonzo.txwdrls = Wdrl mempty
-      , Alonzo.txfee = mempty
-      , Alonzo.txvldt = ValidityInterval SNothing SNothing
-      , Alonzo.txUpdates = SNothing
-      , Alonzo.reqSignerHashes = mempty
-      , Alonzo.mint = mempty
-      , Alonzo.scriptIntegrityHash = SNothing
-      , Alonzo.adHash = SNothing
-      , Alonzo.txnetworkid = SNothing
-      }
+        { Alonzo.inputs = mempty
+        , Alonzo.collateral = mempty
+        , Alonzo.outputs = StrictSeq.fromList $
+            map (`toAlonzoTxOut` Nothing) txouts
+        , Alonzo.txcerts = mempty
+        , Alonzo.txwdrls = Wdrl mempty
+        , Alonzo.txfee = mempty
+        , Alonzo.txvldt = ValidityInterval SNothing SNothing
+        , Alonzo.txUpdates = SNothing
+        , Alonzo.reqSignerHashes = mempty
+        , Alonzo.mint = mempty
+        , Alonzo.scriptIntegrityHash = SNothing
+        , Alonzo.adHash = SNothing
+        , Alonzo.txnetworkid = SNothing
+        }
 
 txWithInputsOutputsAndWits :: ByteString
 txWithInputsOutputsAndWits =

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2378,6 +2378,7 @@ data BalanceTxGolden =
         Cardano.Lovelace -- ^ Fee
         Cardano.Lovelace -- ^ Minimum fee
     | BalanceTxGoldenFailure Coin String
+    deriving (Eq, Show)
 
 -- CSV with the columns: wallet_balance,(fee,minfee | error)
 instance Buildable BalanceTxGolden where

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2589,6 +2589,8 @@ prop_balanceTransactionBalanced (Wallet' utxo wal pending) (ShowBuildable partia
                 label "existing collateral" True
             Left (ErrBalanceTxNotYetSupported ZeroAdaOutput) ->
                 label "not yet supported: zero ada output" $ property True
+            Left ErrBalanceTxMaxSizeLimitExceeded ->
+                label "maxTxSize limit exceeded" $ property True
             Left (ErrBalanceTxNotYetSupported ConflictingNetworks) ->
                 label "not yet supported: conflicting networks" $ property True
             Left

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2709,8 +2709,8 @@ prop_balanceTransactionBalanced wallet (ShowBuildable partialTx') seed
 
     walletUTxO :: UTxO
     walletUTxO =
-          let Wallet' _ w _ = wallet
-          in view #utxo w
+        let Wallet' _ w _ = wallet
+        in view #utxo w
 
     hasCollateral :: SealedTx -> Bool
     hasCollateral tx = withAlonzoBody tx $ \(Cardano.TxBody content) ->

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2571,7 +2571,7 @@ prop_balanceTransactionValid
     -> StdGenSeed
     -> Property
 prop_balanceTransactionValid wallet (ShowBuildable partialTx') seed
-    = withMaxSuccess 20000 $ do
+    = withMaxSuccess 1000 $ do
         let combinedUTxO = mconcat
                 [ resolvedInputsUTxO Cardano.ShelleyBasedEraAlonzo partialTx
                 , toCardanoUTxO Cardano.ShelleyBasedEraAlonzo walletUTxO

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2045,12 +2045,11 @@ balanceTransactionSpec = do
             let rootK = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
             let tid = Hash $ B8.replicate 32 '1'
             let wallet = mkTestWallet rootK $ UTxO $ Map.fromList $
-                        [ ( TxIn tid ix
-                          , TxOut addr
-                            (TokenBundle.fromCoin $ Coin 1_000_000)
-                          )
-                        | ix <- [0 .. 500]
-                        ]
+                    [ ( TxIn tid ix
+                      , TxOut addr (TokenBundle.fromCoin $ Coin 1_000_000)
+                      )
+                    | ix <- [0 .. 500]
+                    ]
 
             let balance = balanceTransaction' wallet testStdGenSeed
             let totalOutput tx =

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2066,7 +2066,7 @@ balanceTransactionSpec = do
                         [ TxOut addr
                             (TokenBundle.fromCoin (Coin 100_000_000))
                         ]
-                totalOutput <$> tx `shouldBe` Right (Coin 100_000_000)
+                totalOutput <$> tx `shouldBe` Right (Coin 102_000_000)
 
             it "otherwise fails with ErrBalanceTxMaxSizeLimitExceeded" $ do
                 let tx = balance $ paymentPartialTx


### PR DESCRIPTION
- [x] Rewrite balanceTransaction using `evaluateTransactionBalance`
     - Effects on goldens can be viewed in the diff of this PR
- [x] Enable `prop_balanceTransactionBalanced`
- [x] Polish
- [x] Even more polish
    - [x] Will look through from top to bottom before merging

### Future work
- [x] Pay surplus as excess fee when we cannot afford a change-output. (Would like to do while comparing constructTx with balanceTx)
- [x] Ensure tx size limit is respected (Requires fixing ADP-1484 _and_ [this](https://github.com/input-output-hk/cardano-wallet/blob/ae8a2206b6f659b879d3bf14fd4ffdad7e781992/lib/core/src/Cardano/Wallet.hs#L1788-L1818) )
 
### Comments

First part introducing goldens and the evaluateTransactionBalance function: #3150

### Issue Number


ADP-1372

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
