### PR TITLE
Get cardano-node docker tag from README.md in e2e flow

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -32,13 +32,13 @@ jobs:
 
     - name: Get supported node tag
       run: |
-        export TAG=`cat ../../nix/.stack.nix/cardano-node.nix | grep -o 'version = ".*"' | awk '{ print $3 }' | sed 's/"//g'`
+        export TAG=`cat ../../README.md | grep -o '`master` branch | \[.*\]' | awk '{ print $4 }' | sed -n -e 's/^.*tag\///p' | sed 's/)//g'`
         if [ -z "${{github.event.inputs.nodeTag}}" ]; then
           echo "::set-output name=NODE_TAG::$TAG"
-          echo "Using tag from cardano-node.nix = $TAG"
+          echo "Using cardano-node tag from README.md = $TAG"
         else
           echo "::set-output name=NODE_TAG::${{github.event.inputs.nodeTag}}"
-          echo "Using tag from workflow trigger parameter = ${{github.event.inputs.nodeTag}}"
+          echo "Using cardano-node tag from workflow trigger parameter = ${{github.event.inputs.nodeTag}}"
         fi
       id: cardano-node-tag
 
@@ -74,7 +74,7 @@ jobs:
       run: |
         echo "Wallet: $WALLET"
         echo "Node: ${{steps.cardano-node-tag.outputs.NODE_TAG}}"
-        
+
         NODE=${{steps.cardano-node-tag.outputs.NODE_TAG}} \
         NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK \
         DATA=`pwd`/state/node_db/$NETWORK \


### PR DESCRIPTION

- [x] Get cardano-node docker tag from README.md in e2e flow

### Comments

Docker tag was taken from `/nix/.stack.nix/cardano-node.nix` but the file is no longer there. Getting it from the README instead.
This should fix failing docker [e2e flow](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-docker.yml).

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
