### PR TITLE
`database_schema_version` table stores current database schema version.

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -355,7 +355,7 @@ test-suite unit
     , network
     , network-uri
     , nothunks
-    , persistent
+    , persistent >=2.13 && <2.14
     , persistent-sqlite >=2.13 && <2.14
     , plutus-ledger-api
     , pretty-simple

--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -49,7 +49,6 @@ module Cardano.DB.Sqlite
 
     -- * Logging
     , DBLog (..)
-    , DatabaseMetadataLog (..)
     ) where
 
 import Prelude
@@ -58,8 +57,6 @@ import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
-import Cardano.Wallet.DB.Sqlite.Types
-    ( DatabaseFileFormatVersion, naturalDatabaseFileFormat )
 import Cardano.Wallet.Logging
     ( BracketLog, bracketTracer )
 import Control.Monad
@@ -529,7 +526,6 @@ data DBLog
     | MsgManualMigrationNotNeeded DBField
     | MsgUpdatingForeignKeysSetting ForeignKeysSetting
     | MsgRetryOnBusy Int RetryLog
-    | MsgMetadata DatabaseMetadataLog
     deriving (Generic, Show, Eq, ToJSON)
 
 data RetryLog = MsgRetry | MsgRetryGaveUp | MsgRetryDone
@@ -557,7 +553,6 @@ instance HasSeverityAnnotation DBLog where
             | n <= 1 -> Debug
             | n <= 3 -> Notice
             | otherwise -> Warning
-        MsgMetadata dml -> getSeverityAnnotation dml
 
 instance ToText DBLog where
     toText = \case
@@ -616,30 +611,6 @@ instance ToText DBLog where
             MsgRetryDone
                 | n > 3 -> "DB query succeeded after " +| n |+ " attempts."
                 | otherwise -> ""
-        MsgMetadata msg -> toText msg
-
-data DatabaseMetadataLog
-    = DatabaseMetadataCreated
-    | DatabaseVersionSet DatabaseFileFormatVersion
-    | DatabaseVersionMatched DatabaseFileFormatVersion
-    deriving (Generic, Show, Eq, ToJSON)
-
-instance HasSeverityAnnotation DatabaseMetadataLog where
-    getSeverityAnnotation = \case
-        DatabaseMetadataCreated -> Notice
-        DatabaseVersionSet _version -> Notice
-        DatabaseVersionMatched _version -> Notice
-
-instance ToText DatabaseMetadataLog where
-    toText = \case
-        DatabaseMetadataCreated ->
-            "Database metadata table created"
-        DatabaseVersionSet ver ->
-            "Database file format version set to " <> showVersion ver
-        DatabaseVersionMatched ver ->
-            "Database file format version matches expected: " <> showVersion ver
-      where
-        showVersion = T.pack . show . naturalDatabaseFileFormat
 
 -- | Produce a persistent 'LogFunc' backed by 'Tracer IO DBLog'
 queryLogFunc :: Tracer IO DBLog -> LogFunc

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Migration.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Migration.hs
@@ -144,14 +144,10 @@ migrateManually tr proxy defaultFieldValues =
         return ()
 
     dropTable :: Text -> Text
-    dropTable table = mconcat
-        [ "DROP TABLE IF EXISTS " <> table <> ";"
-        ]
+    dropTable table = "DROP TABLE IF EXISTS " <> table <> ";"
 
     getTableInfo :: Text -> Text
-    getTableInfo table = mconcat
-        [ "PRAGMA table_info(", table, ");"
-        ]
+    getTableInfo table = "PRAGMA table_info(" <> table <> ");"
 
     filterColumn :: [Text] -> [PersistValue] -> Maybe [PersistValue]
     filterColumn excluding = \case

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -128,10 +127,6 @@ import GHC.Generics
     ( Generic )
 import Network.URI
     ( parseAbsoluteURI )
-import Numeric.Natural
-    ( Natural )
-import Quiet
-    ( Quiet (..) )
 import System.Random.Internal
     ( StdGen (..) )
 import System.Random.SplitMix
@@ -863,10 +858,3 @@ newtype EitherText a = EitherText { getEitherText :: Either Text a }
 
 instance MonadFail EitherText where
     fail = EitherText . Left . T.pack
-
-newtype DatabaseFileFormatVersion = DatabaseFileFormatVersion
-    { naturalDatabaseFileFormat :: Natural }
-    deriving stock Generic
-    deriving newtype (Eq, Ord, Enum, Num, Real, Integral, ToJSON)
-    deriving Show via (Quiet DatabaseFileFormatVersion)
-

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -48,7 +48,13 @@ import Cardano.BM.Trace
 import Cardano.Crypto.Wallet
     ( XPrv )
 import Cardano.DB.Sqlite
-    ( DBField, DBLog (..), SqliteContext, fieldName, newInMemorySqliteContext )
+    ( DBField
+    , DBLog (..)
+    , DatabaseMetadataLog (..)
+    , SqliteContext
+    , fieldName
+    , newInMemorySqliteContext
+    )
 import Cardano.Mnemonic
     ( SomeMnemonic (..) )
 import Cardano.Wallet.DB
@@ -66,6 +72,10 @@ import Cardano.Wallet.DB.Sqlite
     , withDBLayer
     , withDBLayerInMemory
     )
+import Cardano.Wallet.DB.Sqlite.Migration
+    ( InvalidDatabaseSchemaVersion (..) )
+import Cardano.Wallet.DB.Sqlite.Types
+    ( DatabaseFileFormatVersion (..) )
 import Cardano.Wallet.DB.StateMachine
     ( TestConstraints, prop_parallel, prop_sequential, validateGenerators )
 import Cardano.Wallet.DummyTarget.Primitive.Types
@@ -272,6 +282,8 @@ import qualified Data.List as L
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import qualified Database.Persist.Sql as Sql
+import qualified Database.Persist.Sqlite as Sqlite
 import qualified UnliftIO.STM as STM
 
 spec :: Spec
@@ -1021,6 +1033,12 @@ manualMigrationsSpec = describe "Manual migrations" $ do
               )
             ]
 
+    it "'migrate' db to create metadata table when it doesn't exist"
+        testCreateMetadataTable
+
+    it "'migrate' db never modifies database with newer version"
+        testNewerDatabaseIsNeverModified
+
 testMigrationTxMetaFee
     :: forall k s.
         ( s ~ SeqState 'Mainnet k
@@ -1243,6 +1261,37 @@ testMigrationPassphraseScheme = do
     Right walNewScheme     = fromText "5e481f55084afda69fc9cd3863ced80fa83734aa"
     Right walOldScheme     = fromText "4a6279cd71d5993a288b2c5879daa7c42cebb73d"
     Right walNoPassphrase  = fromText "ba74a7d2c1157ea7f32a93f255dac30e9ebca62b"
+
+testCreateMetadataTable ::
+    forall s k. (k ~ ShelleyKey, s ~ SeqState 'Mainnet k) => IO ()
+testCreateMetadataTable = do
+    (logs, _) <- captureLogging $ \tr ->
+        withDBLayer @s @k tr defaultFieldValues ":memory:" dummyTimeInterpreter
+            (const $ pure ())
+    [ l | MsgDB (MsgMetadata l) <- logs ] `shouldBe`
+        [ DatabaseMetadataCreated
+        , DatabaseVersionSet (DatabaseFileFormatVersion 1)
+        ]
+
+testNewerDatabaseIsNeverModified ::
+    forall s k. (k ~ ShelleyKey, s ~ SeqState 'Mainnet k) => IO ()
+testNewerDatabaseIsNeverModified = withSystemTempFile "db.sql" $ \path _ -> do
+    let newerVersion = DatabaseFileFormatVersion 100
+        currentVersion = DatabaseFileFormatVersion 1
+    _ <- Sqlite.runSqlite (T.pack path) $ do
+        Sqlite.rawExecute "CREATE TABLE database_metadata (name, version)" []
+        Sqlite.rawExecute (
+            let v = T.pack . show $ naturalDatabaseFileFormat newerVersion
+            in "INSERT INTO database_metadata VALUES ('metadata', " <> v <> ")"
+            ) []
+    let noop _ = pure ()
+        tr = nullTracer
+    withDBLayer @s @k tr defaultFieldValues path dummyTimeInterpreter noop
+        `shouldThrow` \case
+            InvalidDatabaseSchemaVersion {..}
+                | expectedVersion == currentVersion
+                && actualVersion == newerVersion -> True
+            _ -> False
 
 {-------------------------------------------------------------------------------
                                    Test data


### PR DESCRIPTION
### Issue Number

[ADP-1135](https://input-output.atlassian.net/browse/ADP-1135)

This PR adds a database table `database_metadata` with 1 row and 1 column in it: `version` (from here DV).
The idea is that wallet library knows (hardcodes) version of the database file format that it expects to work with (EV), and then:
- if `DV > EV` then its a "database from the future" and no changes should be made to it. Following migrations are aborted.
- if `DV < EV` then its a database from the past, and it needs to be migrated (the new mechanism to apply migrations isn't implemented yet)
- if `DV = EV` then its all good.
