### PR TITLE
Use `modifyDBVar` instead of `putCheckpoint` in `Cardano.Wallet`

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -324,6 +324,7 @@ test-suite unit
     , contra-tracer
     , cryptonite
     , data-default
+    , dbvar
     , directory
     , deepseq
     , extra >= 1.6.17

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -322,6 +322,8 @@ import Cardano.Wallet.Compat
     ( (^?) )
 import Cardano.Wallet.DB
     ( DBFactory (..) )
+import Cardano.Wallet.DB.Sqlite.AddressBook
+    ( AddressBookIso )
 import Cardano.Wallet.Network
     ( NetworkLayer, fetchRewardAccountBalances, timeInterpreter )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -762,6 +764,7 @@ postWallet
         , Typeable s
         , Typeable n
         , (k == SharedKey) ~ 'False
+        , AddressBookIso s
         )
     => ctx
     -> ((SomeMnemonic, Maybe SomeMnemonic) -> Passphrase "encryption" -> k 'RootK XPrv)
@@ -789,6 +792,7 @@ postShelleyWallet
         , Typeable s
         , Typeable n
         , (k == SharedKey) ~ 'False
+        , AddressBookIso s
         )
     => ctx
     -> ((SomeMnemonic, Maybe SomeMnemonic) -> Passphrase "encryption" -> k 'RootK XPrv)
@@ -823,6 +827,7 @@ postAccountWallet
         , IsOurs s RewardAccount
         , (k == SharedKey) ~ 'False
         , Typeable n
+        , AddressBookIso s
         )
     => ctx
     -> MkApiWallet ctx s w
@@ -1140,6 +1145,7 @@ postLegacyWallet
         , IsOurs s Address
         , HasNetworkLayer IO ctx
         , WalletKey k
+        , AddressBookIso s
         )
     => ctx
         -- ^ Surrounding Context
@@ -1931,6 +1937,7 @@ postTransactionOld
         , Typeable n
         , Typeable s
         , WalletKey k
+        , AddressBookIso s
         )
     => ctx
     -> ArgGenChange s
@@ -2535,6 +2542,7 @@ joinStakePool
         , Typeable n
         , Typeable s
         , WalletKey k
+        , AddressBookIso s
         )
     => ctx
     -> IO (Set PoolId)
@@ -2663,6 +2671,7 @@ quitStakePool
         , Typeable n
         , Typeable s
         , WalletKey k
+        , AddressBookIso s
         )
     => ctx
     -> ApiT WalletId
@@ -3602,6 +3611,7 @@ newApiLayer
         ( ctx ~ ApiLayer s k
         , IsOurs s RewardAccount
         , IsOurs s Address
+        , AddressBookIso s
         )
     => Tracer IO WalletEngineLog
     -> (Block, NetworkParameters, SyncTolerance)
@@ -3627,6 +3637,7 @@ startWalletWorker
         ( ctx ~ ApiLayer s k
         , IsOurs s RewardAccount
         , IsOurs s Address
+        , AddressBookIso s
         )
     => ctx
     -> (WorkerCtx ctx -> WalletId -> IO ())
@@ -3647,6 +3658,7 @@ createWalletWorker
         ( ctx ~ ApiLayer s k
         , IsOurs s RewardAccount
         , IsOurs s Address
+        , AddressBookIso s
         )
     => ctx
         -- ^ Surrounding API context
@@ -3676,6 +3688,7 @@ registerWorker
         ( ctx ~ ApiLayer s k
         , IsOurs s RewardAccount
         , IsOurs s Address
+        , AddressBookIso s
         )
     => ctx
     -> (WorkerCtx ctx -> WalletId -> IO ())

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -38,6 +38,8 @@ import Prelude
 
 import Cardano.Address.Derivation
     ( XPrv )
+import Cardano.Wallet.DB.WalletState
+    ( DeltaMap, DeltaWalletState )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..) )
 import Cardano.Wallet.Primitive.Model
@@ -69,6 +71,8 @@ import Control.Monad.IO.Class
     ( MonadIO )
 import Control.Monad.Trans.Except
     ( ExceptT, runExceptT )
+import Data.DBVar
+    ( DBVar )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Word
@@ -145,6 +149,15 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , listWallets
         :: stm [WalletId]
         -- ^ Get the list of all known wallets in the DB, possibly empty.
+
+    , walletsDB
+        :: DBVar stm (DeltaMap WalletId (DeltaWalletState s))
+        -- ^ 'DBVar' containing the 'WalletState' of each wallet in the database.
+        -- Currently contains all 'Checkpoints' of the 'UTxO' and the
+        -- 'Discoveries', as well as the 'Prologue' of the address discovery state.
+        -- 
+        -- Intended to replace 'putCheckpoint' and 'readCheckpoint' in the short-term,
+        -- and all other functions in the long-term.
 
     , putCheckpoint
         :: WalletId

--- a/lib/core/src/Cardano/Wallet/DB/Checkpoints.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Checkpoints.hs
@@ -32,6 +32,8 @@ import Data.Map.Strict
     ( Map )
 import Data.Maybe
     ( fromMaybe )
+import Fmt
+    ( Buildable (..), listF )
 import GHC.Generics
     ( Generic )
 
@@ -74,9 +76,8 @@ is clear that the data cannot exist at the genesis point
 {-------------------------------------------------------------------------------
     Checkpoints
 -------------------------------------------------------------------------------}
-{- HLINT ignore Checkpoints "Use newtype instead of data" -}
 -- | Collection of checkpoints indexed by 'Slot'.
-data Checkpoints a = Checkpoints
+newtype Checkpoints a = Checkpoints
     { checkpoints :: Map W.Slot a
     -- ^ Map of checkpoints. Always contains the genesis checkpoint.
     } deriving (Eq,Show,Generic)
@@ -126,3 +127,8 @@ instance Delta (DeltaCheckpoints a) where
         Map.filterWithKey (\k _ -> k <= pt)
     apply (RestrictTo pts) = over #checkpoints $ \m ->
         Map.restrictKeys m $ Set.fromList (W.Origin:pts)
+
+instance Buildable (DeltaCheckpoints a) where
+    build (PutCheckpoint slot _) = "PutCheckpoint " <> build slot
+    build (RollbackTo slot) = "RollbackTo " <> build slot
+    build (RestrictTo slots) = "RestrictTo " <> listF slots

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -107,6 +107,7 @@ newDBLayer timeInterpreter = do
         {-----------------------------------------------------------------------
                                     Checkpoints
         -----------------------------------------------------------------------}
+        , walletsDB = error "MVar.walletsDB: not implemented"
 
         , putCheckpoint = \pk cp -> ExceptT $
             alterDB errNoSuchWallet db $

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -160,7 +160,7 @@ import Data.List.Split
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
-    ( catMaybes, isJust )
+    ( catMaybes )
 import Data.Ord
     ( Down (..) )
 import Data.Proxy
@@ -507,7 +507,7 @@ newDBLayerWith
     -> SqliteContext
        -- ^ A (thread-)safe wrapper for query execution.
     -> IO (DBLayer IO s k)
-newDBLayerWith _cacheBehavior tr ti SqliteContext{runQuery} = do
+newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
     -- FIXME LATER during ADP-1043:
     --   Remove the 'NoCache' behavior, we cannot get it back.
     --   This will affect read benchmarks, they will need to benchmark

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/AddressBook.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/AddressBook.hs
@@ -18,6 +18,8 @@ module Cardano.Wallet.DB.Sqlite.AddressBook
     ( AddressBookIso (..)
     , Prologue (..)
     , Discoveries (..)
+    , getPrologue
+    , getDiscoveries
     , SeqAddressMap (..)
     )
   where
@@ -69,6 +71,12 @@ class AddressBookIso s where
     -- | Isomorphism between the address book type 's'
     -- and its two components.
     addressIso :: Iso' s (Prologue s, Discoveries s)
+
+getPrologue :: AddressBookIso s => s -> Prologue s
+getPrologue = withIso addressIso $ \from _ -> fst . from
+
+getDiscoveries :: AddressBookIso s => s -> Discoveries s
+getDiscoveries = withIso addressIso $ \from _ -> snd . from
 
 {-------------------------------------------------------------------------------
     Sequential address book

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/CheckpointsOld.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/CheckpointsOld.hs
@@ -267,7 +267,8 @@ mkStoreCheckpoints wid =
             [ CheckpointWalletId ==. wid
             , CheckpointParentHash !=. BlockId hashOfNoParent
             ]
-    update (RestrictTo points) = do
+    update (RestrictTo pts) = do
+        let points = W.Origin : pts
         let pseudoSlot W.Origin    = W.SlotNo 0
             pseudoSlot (W.At slot) = slot
         let slots = map pseudoSlot points

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/CheckpointsOld.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/CheckpointsOld.hs
@@ -33,6 +33,9 @@ module Cardano.Wallet.DB.Sqlite.CheckpointsOld
     ( mkStoreWallets
     , PersistAddressBook (..)
     , blockHeaderFromEntity
+    
+    -- * Testing
+    , mkStoreWallet
     )
     where
 

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/CheckpointsOld.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/CheckpointsOld.hs
@@ -428,7 +428,11 @@ class AddressBookIso s => PersistAddressBook s where
     Sequential address book storage
 -------------------------------------------------------------------------------}
 -- piggy-back on SeqState existing instance, to simulate the same behavior.
-instance PersistAddressBook (Seq.SeqState n k)
+instance
+    ( Eq (Seq.SeqState n k)
+    , (k == SharedKey) ~ 'False
+    , PersistAddressBook (Seq.SeqState n k)
+    )
     => PersistAddressBook (Seq.SeqAnyState n k p)
   where
     insertPrologue wid (PS s) = insertPrologue wid s
@@ -444,6 +448,7 @@ instance
     , SoftDerivation key
     , Typeable n
     , (key == SharedKey) ~ 'False
+    , Eq (Seq.SeqState n key)
     ) => PersistAddressBook (Seq.SeqState n key) where
 
     insertPrologue wid (SeqPrologue st) = do

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Stores.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Stores.hs
@@ -19,6 +19,8 @@ module Cardano.Wallet.DB.Sqlite.Stores
     ( mkStoreWallets
     , PersistAddressBook (..)
     , blockHeaderFromEntity
+    -- * Testing
+    , mkStoreWallet
     )
     where
 

--- a/lib/core/src/Cardano/Wallet/DB/WalletState.hs
+++ b/lib/core/src/Cardano/Wallet/DB/WalletState.hs
@@ -54,6 +54,8 @@ import Data.Map.Strict
     ( Map )
 import Data.Word
     ( Word32 )
+import Fmt
+    ( Buildable (..), pretty )
 import GHC.Generics
     ( Generic )
 
@@ -147,6 +149,13 @@ instance Delta (DeltaWalletState1 s) where
     type Base (DeltaWalletState1 s) = WalletState s
     apply (ReplacePrologue p) = over #prologue $ const p
     apply (UpdateCheckpoints d) = over #checkpoints $ apply d
+
+instance Buildable (DeltaWalletState1 s) where
+    build (ReplacePrologue _) = "ReplacePrologue …"
+    build (UpdateCheckpoints d) = "UpdateCheckpoints (" <> build d <> ")"
+
+instance Show (DeltaWalletState1 s) where
+    show = pretty
 
 {-------------------------------------------------------------------------------
     A Delta type for Maps,

--- a/lib/core/src/Cardano/Wallet/DB/WalletState.hs
+++ b/lib/core/src/Cardano/Wallet/DB/WalletState.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- |
@@ -70,8 +71,9 @@ data WalletCheckpoint s = WalletCheckpoint
     { currentTip :: !BlockHeader
     , utxo :: !UTxO
     , discoveries :: !(Discoveries s)
-    }
-    deriving (Generic)
+    } deriving (Generic)
+
+deriving instance AddressBookIso s => Eq (WalletCheckpoint s)
 
 -- | Helper function: Get the block height of a wallet checkpoint.
 getBlockHeight :: WalletCheckpoint s -> Word32
@@ -105,9 +107,11 @@ fromWallet w = (pro, WalletCheckpoint (W.currentTip w) (W.utxo w) dis)
 -- FIXME during ADP-1043: Include also TxHistory, pending transactions, …,
 -- everything.
 data WalletState s = WalletState
-    { prologue    :: Prologue s
-    , checkpoints :: Checkpoints (WalletCheckpoint s)
+    { prologue    :: !(Prologue s)
+    , checkpoints :: !(Checkpoints (WalletCheckpoint s))
     } deriving (Generic)
+
+deriving instance AddressBookIso s => Eq (WalletState s)
 
 -- | Create a wallet from the genesis block.
 fromGenesis :: AddressBookIso s => W.Wallet s -> Maybe (WalletState s)

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -39,6 +39,8 @@ import Cardano.Mnemonic
     ( SomeMnemonic (..) )
 import Cardano.Wallet.DB.Model
     ( TxHistory, filterTxHistory )
+import Cardano.Wallet.DB.Sqlite.AddressBook
+    ( AddressBookIso (..) )
 import Cardano.Wallet.DummyTarget.Primitive.Types as DummyTarget
     ( block0, mkTx )
 import Cardano.Wallet.Gen
@@ -219,9 +221,12 @@ import qualified Data.Map.Strict as Map
                                  Modifiers
 -------------------------------------------------------------------------------}
 
+-- | Convenient constraint alias for generating address discovery states
 type GenState s =
-    ( Arbitrary s
+    ( AddressBookIso s
+    , Arbitrary s
     , Buildable s
+    , Eq s
     , IsOurs s Address
     , IsOurs s RewardAccount
     , NFData s

--- a/lib/core/test/unit/Cardano/Wallet/DB/Sqlite/StoresSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Sqlite/StoresSpec.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 module Cardano.Wallet.DB.Sqlite.StoresSpec
@@ -11,15 +13,25 @@ import Prelude
 import Cardano.DB.Sqlite
     ( SqliteContext (runQuery), newInMemorySqliteContext )
 import Cardano.Wallet.DB.Arbitrary
-    ()
+    ( GenState, InitialCheckpoint (..) )
+import Cardano.Wallet.DB.Checkpoints
+    ( DeltaCheckpoints (..) )
 import Cardano.Wallet.DB.Sqlite.AddressBook
-    ( AddressBookIso (..), Prologue )
+    ( AddressBookIso (..), Prologue, getPrologue )
 import Cardano.Wallet.DB.Sqlite.Stores
-    ( PersistAddressBook (..) )
+    ( PersistAddressBook (..), mkStoreWallet )
 import Cardano.Wallet.DB.Sqlite.TH
     ( Wallet (..), migrateAll )
 import Cardano.Wallet.DB.Sqlite.Types
     ( BlockId (..) )
+import Cardano.Wallet.DB.WalletState
+    ( DeltaWalletState
+    , DeltaWalletState1 (..)
+    , fromGenesis
+    , fromWallet
+    , getLatest
+    , getSlot
+    )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (Mainnet) )
 import Cardano.Wallet.Primitive.AddressDerivation.Shared
@@ -33,39 +45,58 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( Readiness (Pending), SharedState (..) )
 import Cardano.Wallet.Primitive.Types
-    ( WalletId (..) )
+    ( SlotNo (..), WalletId (..), WithOrigin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
+import Control.Monad
+    ( forM_ )
 import Control.Tracer
     ( nullTracer )
-import Data.Generics.Internal.VL
-    ( withIso )
+import Data.Bifunctor
+    ( second )
+import Data.DBVar
+    ( Store (..) )
+import Data.Delta
+    ( Base, Delta (..) )
+import Data.Generics.Internal.VL.Lens
+    ( over, (^.) )
 import Data.Time.Clock
     ( UTCTime )
 import Data.Time.Clock.POSIX
     ( posixSecondsToUTCTime )
 import Database.Persist.Sql
-    ( Filter, deleteWhere, insert_ )
+    ( deleteWhere, insert_ )
 import Database.Persist.Sqlite
-    ( SqlPersistT )
+    ( SqlPersistT, (==.) )
 import Fmt
-    ( Buildable, pretty )
+    ( Buildable (..), listF, pretty )
 import Test.Hspec
     ( Spec, around, describe, it )
 import Test.QuickCheck
-    ( Property, counterexample, property )
+    ( Arbitrary (..)
+    , Blind (..)
+    , Gen
+    , Property
+    , choose
+    , counterexample
+    , frequency
+    , property
+    , sized
+    , vectorOf
+    )
 import Test.QuickCheck.Monadic
-    ( PropertyM, assert, monadicIO, monitor, run )
+    ( PropertyM, assert, monadicIO, monitor, pick, run )
 import UnliftIO.Exception
-    ( bracket )
+    ( bracket, impureThrow )
 
 import qualified Cardano.Wallet.DB.Sqlite.TH as TH
+import qualified Data.Map.Strict as Map
 
 spec :: Spec
 spec = around withDBInMemory $ do
-    describe "Writing and loading from store" $ do
+    describe "Writing and loading" $ do
         it "loadPrologue . insertPrologue = id  for SeqState" $
             property . prop_prologue_load_write @(SeqState 'Mainnet ShelleyKey) id
 
@@ -75,6 +106,10 @@ spec = around withDBInMemory $ do
         it "loadPrologue . insertPrologue = id  for SharedState" $
             property . prop_prologue_load_write @(SharedState 'Mainnet SharedKey)
                 (\s -> s { ready = Pending })
+
+    describe "Update" $ do
+        it "mkStoreWallet" $
+            property . prop_StoreWallet @(SeqState 'Mainnet ShelleyKey)
 
 {-------------------------------------------------------------------------------
     Properties
@@ -88,56 +123,142 @@ prop_prologue_load_write
     )
     => (s -> s) -> SqliteContext -> (WalletId, s) -> Property
 prop_prologue_load_write preprocess db (wid, s) =
-    prop_loadAfterWrite insertPrologue loadPrologue db (wid, pro)
+    monadicIO $ run (toIO setup) >> prop
   where
-    (pro, _) = withIso addressIso $ \from _to -> from (preprocess s)
+    toIO = runQuery db
+    setup = initializeWallet wid
+    prop = prop_loadAfterWrite toIO (insertPrologue wid) (loadPrologue wid) pro
+    pro = getPrologue $ preprocess s
     -- FIXME during ADP-1043: See note at 'multisigPoolAbsent'
 
 -- | Checks that loading a value after writing it to a database table
 -- is successful.
 prop_loadAfterWrite
-    :: ( Buildable (f a) , Eq (f a), Applicative f )
-    => (  WalletId
-       -> a
-       -> SqlPersistT IO ()
-       ) -- ^ Write Operation
-    -> (  WalletId
-       -> SqlPersistT IO (f a)
-       ) -- ^ Load Operation
-    -> SqliteContext
-    -> (WalletId, a)
-        -- ^ Property arguments
+    :: ( Monad m, Buildable (f a) , Eq (f a), Applicative f )
+    => (forall b. m b -> IO b)
+    -- ^ Function to embed the monad in 'IO'
+    -> (a -> m ())
+    -- ^ Write operation
+    -> (m (f a))
+    -- ^ Load operation
+    -> a
+    -- ^ Property arguments
+    -> PropertyM IO ()
+prop_loadAfterWrite toIO writeOp loadOp a = do
+    res <- run . toIO $ writeOp a >> loadOp
+    let fa = pure a
+    monitor $ counterexample $ "\nInserted\n" <> pretty fa
+    monitor $ counterexample $ "\nRead\n" <> pretty res
+    assertWith "Inserted == Read" (res == fa)
+
+{-------------------------------------------------------------------------------
+    Update
+-------------------------------------------------------------------------------}
+prop_StoreWallet
+    :: forall s.
+    ( PersistAddressBook s
+    , GenState s
+    )
+    => SqliteContext
+    -> (WalletId, InitialCheckpoint s)
     -> Property
-prop_loadAfterWrite writeOp loadOp db (wid, a) =
+prop_StoreWallet db (wid, InitialCheckpoint cp0) =
     monadicIO (setup >> prop)
   where
-    setup = do
-        run $ runQuery db $ do
-            cleanDB
-            -- Add a wallet to ensure that FOREIGN PRIMARY constraints are satisfied
-            insert_ $ Wallet
-                { walId = wid
-                , walName = "Stores"
-                , walCreationTime = dummyUTCTime
-                , walPassphraseLastUpdatedAt = Nothing
-                , walPassphraseScheme = Nothing
-                , walGenesisHash = BlockId dummyHash
-                , walGenesisStart = dummyUTCTime
-                }
+    toIO = runQuery db
+    setup = run . toIO $ initializeWallet wid
     prop = do
-        run $ runQuery db $ writeOp wid a
-        res <- run $ runQuery db $ loadOp wid
-        let fa = pure a
-        monitor $ counterexample $ "\nInserted\n" <> pretty fa
-        monitor $ counterexample $ "\nRead\n" <> pretty res
-        assertWith "Inserted == Read" (res == fa)
+        let Just w0 = fromGenesis cp0
+        prop_StoreUpdates toIO (mkStoreWallet wid) (pure w0) genDeltaWalletState
 
--- | Like 'assert', but allow giving a label / title before running a assertion
-assertWith :: String -> Bool -> PropertyM IO ()
-assertWith lbl condition = do
-    let flag = if condition then "✓" else "✗"
-    monitor (counterexample $ lbl <> " " <> flag)
-    assert condition
+genDeltaWalletState
+    :: (GenState s, AddressBookIso s)
+    => GenDelta (DeltaWalletState s)
+genDeltaWalletState wallet = frequency . map (second updateCheckpoints) $
+    [ (8, genPutCheckpoint)
+    , (1, pure $ RollbackTo Origin)
+    , (1, RollbackTo . At . SlotNo <$> choose (0, slotLatest))
+    , (1, RollbackTo . At . SlotNo <$> choose (slotLatest+1, slotLatest+10))
+    , (2, RestrictTo <$> genFilteredSlots)
+    , (1, pure $ RestrictTo [])
+    ]
+  where
+    updateCheckpoints gen = (\x -> [UpdateCheckpoints x]) <$> gen
+
+    slotLatest = case getSlot . snd . fromWallet $ getLatest wallet of
+        Origin -> 0
+        At (SlotNo s) -> s
+    genSlotNo = SlotNo . (slotLatest +) <$> choose (1,10)
+
+    genPutCheckpoint = do
+        slot <- genSlotNo
+        cp   <- over (#currentTip . #slotNo) (const slot) <$> arbitrary
+        pure $ PutCheckpoint (At slot) (snd $ fromWallet cp)
+    
+    genFilteredSlots = do
+        let slots = Map.keys $ wallet ^. (#checkpoints . #checkpoints)
+        keeps <- vectorOf (length slots) arbitrary
+        pure . map fst . filter snd $ zip slots keeps
+
+-- | Given a value, generate a random delta starting from this value.
+type GenDelta da = Base da -> Gen da
+
+-- | A sequence of updates and values after updating.
+-- The update that is applied *last* appears in the list *first*.
+newtype Updates da = Updates [(Base da, da)]
+
+instance Show da => Show (Updates da) where
+    show (Updates xs) = show . map snd $ xs
+
+-- | Randomly generate a sequence of updates
+genUpdates :: Delta da => Gen (Base da) -> GenDelta da -> Gen (Updates da)
+genUpdates gen0 more = sized $ \n -> go n [] =<< gen0
+  where
+    go 0 das _  = pure $ Updates das
+    go n das a0 = do
+        da <- more a0
+        let a1 = apply da a0
+        go (n-1) ((a1,da):das) a1
+
+-- | Test whether 'updateS' and 'loadS' behave as expected.
+--
+-- TODO: Shrinking of the update sequence.
+prop_StoreUpdates
+    :: ( Monad m, Delta da, Eq (Base da), Buildable da )
+    => (forall b. m b -> IO b)
+    -- ^ Function to embed the monad in 'IO'
+    -> Store m da
+    -- ^ Store that is to be tested.
+    -> Gen (Base da)
+    -- ^ Generator for the initial value.
+    -> GenDelta da
+    -- ^ Generator for deltas.
+    -> PropertyM IO ()
+prop_StoreUpdates toIO store gen0 more = do
+    let runs = run . toIO
+
+    -- randomly generate a sequence of updates
+    Blind a0 <- pick $ Blind <$> gen0
+    Blind (Updates adas) <- pick $ Blind <$> genUpdates (pure a0) more
+    let as  = map fst adas ++ [a0]
+        das = map snd adas
+
+    monitor $ counterexample $
+        "\nUpdates applied:\n" <> pretty (listF das)
+
+    -- apply those updates
+    ea <- runs $ do
+        writeS store a0
+        -- first update is applied last!
+        let updates = reverse $ zip das (drop 1 as)
+        forM_ updates $ \(da,a) -> updateS store a da
+        loadS store
+
+    -- check whether the last value is correct
+    case ea of
+        Left err -> impureThrow err
+        Right a  -> do
+            assert $ a == head as
 
 {-------------------------------------------------------------------------------
     DB setup
@@ -148,33 +269,22 @@ withDBInMemory action = bracket newDBInMemory fst (action . snd)
 newDBInMemory :: IO (IO (), SqliteContext)
 newDBInMemory = newInMemorySqliteContext nullTracer [] migrateAll
 
--- | Remove all tables in the datase.
-cleanDB :: SqlPersistT IO ()
-cleanDB = do
-    deleteWhere ([] :: [Filter TH.Wallet])
-    deleteWhere ([] :: [Filter TH.PrivateKey])
-    deleteWhere ([] :: [Filter TH.TxMeta])
-    deleteWhere ([] :: [Filter TH.TxIn])
-    deleteWhere ([] :: [Filter TH.TxCollateral])
-    deleteWhere ([] :: [Filter TH.TxOut])
-    deleteWhere ([] :: [Filter TH.TxOutToken])
-    deleteWhere ([] :: [Filter TH.TxWithdrawal])
-    deleteWhere ([] :: [Filter TH.LocalTxSubmission])
-    deleteWhere ([] :: [Filter TH.Checkpoint])
-    deleteWhere ([] :: [Filter TH.ProtocolParameters])
-    deleteWhere ([] :: [Filter TH.StakeKeyCertificate])
-    deleteWhere ([] :: [Filter TH.DelegationCertificate])
-    deleteWhere ([] :: [Filter TH.DelegationReward])
-    deleteWhere ([] :: [Filter TH.UTxO])
-    deleteWhere ([] :: [Filter TH.UTxOToken])
-    deleteWhere ([] :: [Filter TH.SeqState])
-    deleteWhere ([] :: [Filter TH.SeqStateAddress])
-    deleteWhere ([] :: [Filter TH.SeqStatePendingIx])
-    deleteWhere ([] :: [Filter TH.RndState])
-    deleteWhere ([] :: [Filter TH.RndStateAddress])
-    deleteWhere ([] :: [Filter TH.RndStatePendingAddress])
-    deleteWhere ([] :: [Filter TH.SharedState])
-    deleteWhere ([] :: [Filter TH.CosignerKey])
+initializeWallet :: WalletId -> SqlPersistT IO ()
+initializeWallet wid = do
+    deleteWhere [TH.WalId ==. wid] -- triggers delete cascade
+    insertWalletTable wid
+
+-- | Insert a wallet table in order to satisfy  FOREIGN PRIMARY constraints
+insertWalletTable :: WalletId -> SqlPersistT IO ()
+insertWalletTable wid = insert_ $ Wallet
+    { walId = wid
+    , walName = "Stores"
+    , walCreationTime = dummyUTCTime
+    , walPassphraseLastUpdatedAt = Nothing
+    , walPassphraseScheme = Nothing
+    , walGenesisHash = BlockId dummyHash
+    , walGenesisStart = dummyUTCTime
+    }
 
 {-------------------------------------------------------------------------------
     Arbitrary
@@ -185,3 +295,13 @@ dummyUTCTime = posixSecondsToUTCTime 1506203091
 dummyHash :: Hash "BlockHeader"
 dummyHash = Hash $ unsafeFromHex
     "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
+
+{-------------------------------------------------------------------------------
+    QuickCheck utilities
+-------------------------------------------------------------------------------}
+-- | Like 'assert', but allow giving a label / title before running a assertion
+assertWith :: String -> Bool -> PropertyM IO ()
+assertWith lbl condition = do
+    let flag = if condition then "✓" else "✗"
+    monitor (counterexample $ lbl <> " " <> flag)
+    assert condition

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -369,7 +369,6 @@ withLoggingDB = around f . beforeWith clean
 
 getMsgDB :: WalletDBLog -> Maybe DBLog
 getMsgDB (MsgDB msg) = Just msg
-getMsgDB _ = Nothing
 
 shouldHaveMsgQuery :: [DBLog] -> Text -> Expectation
 shouldHaveMsgQuery msgs str = unless (any match msgs) $

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -1348,6 +1348,10 @@ instance Sqlite.AddressBookIso DummyState where
         from x = (DummyPrologue, DummyDiscoveries x)
         to (_,DummyDiscoveries x) = x
 
+instance Eq (Sqlite.Prologue DummyState) where _ == _ = True
+instance Eq (Sqlite.Discoveries DummyState) where
+    DummyDiscoveries a == DummyDiscoveries b = a == b
+ 
 instance Sqlite.PersistAddressBook DummyState where
     insertPrologue _ _ = error "DummyState.insertPrologue: not implemented"
     insertDiscoveries _ _ _ = error "DummyState.insertDiscoveries: not implemented"

--- a/nix/materialized/stack-nix/cardano-wallet-core.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-core.nix
@@ -297,6 +297,7 @@
             (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
             (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
             (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."dbvar" or (errorHandler.buildDepError "dbvar"))
             (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
             (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
             (hsPkgs."extra" or (errorHandler.buildDepError "extra"))


### PR DESCRIPTION
### Issue number

ADP-1406

### Overview

Previous work in epic ADP-1043 introduced delta encodings, DBVars, and an embedding of the wallet state and its delta encodings into a database table. It's time to integrate these tools with the wallet code. To facilitate code review, the integration proceeds in a sequence of refactorings that do not change functionality and pass all unit tests.

In this step, we finally remove `putCheckpoint` in favor of `modifyDBVar`. In the `Cardano.Wallet` module, deep within every monadic action, there is a pure function that wants to be freed — and `modifyDBVar` (or rather its friend `modifyDBMaybe`) finally allows us to free those pure functions! For example, we can now implement `updateCosigner` as

```
updateCosigner … = ExceptT $ atomically $ modifyDBMaybe walletsDB $
        adjustNoSuchWallet wid ErrAddCosignerKeyNoSuchWallet
            updateCosigner'
```

where

```
updateCosigner'
    :: WalletState s
    → Either ErrAddCosignerKey (DeltaWalletState s, ())
```

is a pure function that describes how the wallet state is changed.

### Details

* The `DBLayer` now exports the `walletsDB :: DBVar (WalletState s)`. 🥳
* Previously, the `DBLayer` was tested using a `StateMachine` approach. As more and more data is cached by the `DBVar`, we need to start testing `Store` explicitly. This pull request finally adds property tests for the `mkStoreWallet`. These tests are very similar to the state machine tests, in that random sequences of `DeltaWalletState` are generated, but they are simpler as they do not need to worry about results of applying a delta.

### Comments

* Removing the use of `readCheckpoint` will the subject of a later pull request.
* The functions in `Cardano.Wallet` still use `atomically` to ensure the consistency of the database operations. Once the entire wallet state has been migrated into the in-memory `WalletState s` type, we can drop `atomically` and instead rely on the atomicity of `DBVar`. This will increase parallelism, as functions that only want to read the variable, but do not want to write to it, do not need to obtain a write-lock.
* One of the next steps will be to replace the constructor `PutCheckpoint` for the delta type of wallet states with an actual, smaller delta encoding. This will reduce the memory footprint of the in-memory representation.