### PR TITLE
Fork the `Selection` type.

### DIFF
--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
 -- Copyright: © 2022 IOHK

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -1,3 +1,9 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 -- |
 -- Copyright: © 2022 IOHK
 -- License: Apache-2.0
@@ -61,10 +67,6 @@ import Cardano.Wallet.CoinSelection.Internal
     , SelectionOutputSizeExceedsLimitError (..)
     , SelectionOutputTokenQuantityExceedsLimitError (..)
     , SelectionParams (..)
-    , SelectionReportDetailed
-    , SelectionReportSummarized
-    , makeSelectionReportDetailed
-    , makeSelectionReportSummarized
     , performSelection
     , selectionDelta
     )
@@ -80,3 +82,137 @@ import Cardano.Wallet.CoinSelection.Internal.Balance
     )
 import Cardano.Wallet.CoinSelection.Internal.Collateral
     ( SelectionCollateralError )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn, TxOut (..) )
+import Data.Generics.Internal.VL.Lens
+    ( over, view )
+import Fmt
+    ( Buildable (..), genericF )
+import GHC.Generics
+    ( Generic )
+
+import Prelude
+
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Data.Foldable as F
+import qualified Data.Set as Set
+
+--------------------------------------------------------------------------------
+-- Reporting
+--------------------------------------------------------------------------------
+
+-- | Includes both summarized and detailed information about a selection.
+--
+data SelectionReport = SelectionReport
+    { summary :: SelectionReportSummarized
+    , detail :: SelectionReportDetailed
+    }
+    deriving (Eq, Generic, Show)
+
+-- | Includes summarized information about a selection.
+--
+-- Each data point can be serialized as a single line of text.
+--
+data SelectionReportSummarized = SelectionReportSummarized
+    { computedFee :: Coin
+    , adaBalanceOfSelectedInputs :: Coin
+    , adaBalanceOfExtraCoinSource :: Coin
+    , adaBalanceOfExtraCoinSink :: Coin
+    , adaBalanceOfRequestedOutputs :: Coin
+    , adaBalanceOfGeneratedChangeOutputs :: Coin
+    , numberOfSelectedInputs :: Int
+    , numberOfSelectedCollateralInputs :: Int
+    , numberOfRequestedOutputs :: Int
+    , numberOfGeneratedChangeOutputs :: Int
+    , numberOfUniqueNonAdaAssetsInSelectedInputs :: Int
+    , numberOfUniqueNonAdaAssetsInRequestedOutputs :: Int
+    , numberOfUniqueNonAdaAssetsInGeneratedChangeOutputs :: Int
+    }
+    deriving (Eq, Generic, Show)
+
+-- | Includes detailed information about a selection.
+--
+data SelectionReportDetailed = SelectionReportDetailed
+    { selectedInputs :: [(TxIn, TxOut)]
+    , selectedCollateral :: [(TxIn, TxOut)]
+    , requestedOutputs :: [TxOut]
+    , generatedChangeOutputs :: [TokenBundle.Flat TokenBundle]
+    }
+    deriving (Eq, Generic, Show)
+
+instance Buildable SelectionReport where
+    build = genericF
+instance Buildable SelectionReportSummarized where
+    build = genericF
+instance Buildable SelectionReportDetailed where
+    build = genericF
+
+makeSelectionReport :: Selection -> SelectionReport
+makeSelectionReport s = SelectionReport
+    { summary = makeSelectionReportSummarized s
+    , detail = makeSelectionReportDetailed s
+    }
+
+makeSelectionReportSummarized :: Selection -> SelectionReportSummarized
+makeSelectionReportSummarized s = SelectionReportSummarized {..}
+  where
+    computedFee
+        = selectionDelta TokenBundle.getCoin s
+    adaBalanceOfSelectedInputs
+        = F.foldMap (view (#tokens . #coin) . snd) $ view #inputs s
+    adaBalanceOfExtraCoinSource
+        = view #extraCoinSource s
+    adaBalanceOfExtraCoinSink
+        = view #extraCoinSink s
+    adaBalanceOfGeneratedChangeOutputs
+        = F.foldMap (view #coin) $ view #change s
+    adaBalanceOfRequestedOutputs
+        = F.foldMap (view (#tokens . #coin)) $ view #outputs s
+    numberOfSelectedInputs
+        = length $ view #inputs s
+    numberOfSelectedCollateralInputs
+        = length $ view #collateral s
+    numberOfRequestedOutputs
+        = length $ view #outputs s
+    numberOfGeneratedChangeOutputs
+        = length $ view #change s
+    numberOfUniqueNonAdaAssetsInSelectedInputs
+        = Set.size
+        $ F.foldMap (TokenBundle.getAssets . view #tokens . snd)
+        $ view #inputs s
+    numberOfUniqueNonAdaAssetsInRequestedOutputs
+        = Set.size
+        $ F.foldMap (TokenBundle.getAssets . view #tokens)
+        $ view #outputs s
+    numberOfUniqueNonAdaAssetsInGeneratedChangeOutputs
+        = Set.size
+        $ F.foldMap TokenBundle.getAssets
+        $ view #change s
+
+makeSelectionReportDetailed :: Selection -> SelectionReportDetailed
+makeSelectionReportDetailed s = SelectionReportDetailed
+    { selectedInputs
+        = F.toList $ view #inputs s
+    , selectedCollateral
+        = F.toList $ view #collateral s
+    , requestedOutputs
+        = view #outputs s
+    , generatedChangeOutputs
+        = TokenBundle.Flat <$> view #change s
+    }
+
+-- A convenience instance for 'Buildable' contexts that include a nested
+-- 'SelectionOf TokenBundle' value.
+instance Buildable (SelectionOf TokenBundle) where
+    build = build . makeSelectionReport
+
+-- A convenience instance for 'Buildable' contexts that include a nested
+-- 'SelectionOf TxOut' value.
+instance Buildable (SelectionOf TxOut) where
+    build = build
+        . makeSelectionReport
+        . over #change (fmap $ view #tokens)

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -20,10 +20,9 @@ module Cardano.Wallet.CoinSelection.Internal
     (
     -- * Performing selections
       performSelection
-    , Selection
+    , Selection (..)
     , SelectionConstraints (..)
     , SelectionError (..)
-    , SelectionOf (..)
     , SelectionParams (..)
 
     -- * Output preparation
@@ -41,11 +40,11 @@ module Cardano.Wallet.CoinSelection.Internal
 
     -- * Selection deltas
     , SelectionDelta (..)
-    , selectionDelta
     , selectionDeltaAllAssets
     , selectionDeltaCoin
     , selectionHasValidSurplus
     , selectionMinimumCost
+    , selectionSurplusCoin
 
     -- * Selection collateral
     , SelectionCollateralRequirement (..)
@@ -244,7 +243,7 @@ data SelectionError
 
 -- | Represents a balanced selection.
 --
-data SelectionOf change = Selection
+data Selection = Selection
     { inputs
         :: !(NonEmpty (TxIn, TxOut))
         -- ^ Selected inputs.
@@ -255,7 +254,7 @@ data SelectionOf change = Selection
         :: ![TxOut]
         -- ^ User-specified outputs
     , change
-        :: ![change]
+        :: ![TokenBundle]
         -- ^ Generated change outputs.
     , assetsToMint
         :: !TokenMap
@@ -271,12 +270,6 @@ data SelectionOf change = Selection
         -- ^ An extra sink for ada.
     }
     deriving (Generic, Eq, Show)
-
--- | The default type of selection.
---
--- In this type of selection, change values do not have addresses assigned.
---
-type Selection = SelectionOf TokenBundle
 
 -- | Provides a context for functions related to 'performSelection'.
 
@@ -1186,20 +1179,6 @@ verifySelectionOutputTokenQuantityExceedsLimitError _cs _ps e =
 --------------------------------------------------------------------------------
 -- Selection deltas
 --------------------------------------------------------------------------------
-
--- | Computes the ada surplus of a selection, assuming there is a surplus.
---
--- This function is a convenient synonym for 'selectionSurplusCoin' that is
--- polymorphic over the type of change.
---
-selectionDelta
-    :: (change -> Coin)
-    -- ^ A function to extract the coin value from a change value.
-    -> SelectionOf change
-    -> Coin
-selectionDelta getChangeCoin selection
-    = selectionSurplusCoin
-    $ selection & over #change (fmap $ TokenBundle.fromCoin . getChangeCoin)
 
 -- | Calculates the selection delta for all assets.
 --

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
@@ -54,14 +53,6 @@ module Cardano.Wallet.CoinSelection.Internal
     , selectionCollateralRequired
     , selectionHasSufficientCollateral
     , selectionMinimumCollateral
-
-    -- * Selection reports
-    , SelectionReport (..)
-    , SelectionReportSummarized (..)
-    , SelectionReportDetailed (..)
-    , makeSelectionReport
-    , makeSelectionReportSummarized
-    , makeSelectionReportDetailed
 
     -- * Internal types and functions
     , ComputeMinimumCollateralParams (..)
@@ -124,8 +115,6 @@ import Data.Ratio
     ( (%) )
 import Data.Semigroup
     ( All (..), mtimesDefault )
-import Fmt
-    ( Buildable (..), genericF )
 import GHC.Generics
     ( Generic )
 import GHC.Stack
@@ -142,7 +131,6 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
 
 --------------------------------------------------------------------------------
 -- Types
@@ -1498,119 +1486,3 @@ verifyOutputTokenQuantities out =
     , (asset, quantity) <- TokenMap.toFlatList $ out ^. #tokens . #tokens
     , quantity > txOutMaxTokenQuantity
     ]
-
---------------------------------------------------------------------------------
--- Reporting
---------------------------------------------------------------------------------
-
--- | Includes both summarized and detailed information about a selection.
---
-data SelectionReport = SelectionReport
-    { summary :: SelectionReportSummarized
-    , detail :: SelectionReportDetailed
-    }
-    deriving (Eq, Generic, Show)
-
--- | Includes summarized information about a selection.
---
--- Each data point can be serialized as a single line of text.
---
-data SelectionReportSummarized = SelectionReportSummarized
-    { computedFee :: Coin
-    , adaBalanceOfSelectedInputs :: Coin
-    , adaBalanceOfExtraCoinSource :: Coin
-    , adaBalanceOfExtraCoinSink :: Coin
-    , adaBalanceOfRequestedOutputs :: Coin
-    , adaBalanceOfGeneratedChangeOutputs :: Coin
-    , numberOfSelectedInputs :: Int
-    , numberOfSelectedCollateralInputs :: Int
-    , numberOfRequestedOutputs :: Int
-    , numberOfGeneratedChangeOutputs :: Int
-    , numberOfUniqueNonAdaAssetsInSelectedInputs :: Int
-    , numberOfUniqueNonAdaAssetsInRequestedOutputs :: Int
-    , numberOfUniqueNonAdaAssetsInGeneratedChangeOutputs :: Int
-    }
-    deriving (Eq, Generic, Show)
-
--- | Includes detailed information about a selection.
---
-data SelectionReportDetailed = SelectionReportDetailed
-    { selectedInputs :: [(TxIn, TxOut)]
-    , selectedCollateral :: [(TxIn, TxOut)]
-    , requestedOutputs :: [TxOut]
-    , generatedChangeOutputs :: [TokenBundle.Flat TokenBundle]
-    }
-    deriving (Eq, Generic, Show)
-
-instance Buildable SelectionReport where
-    build = genericF
-instance Buildable SelectionReportSummarized where
-    build = genericF
-instance Buildable SelectionReportDetailed where
-    build = genericF
-
-makeSelectionReport :: Selection -> SelectionReport
-makeSelectionReport s = SelectionReport
-    { summary = makeSelectionReportSummarized s
-    , detail = makeSelectionReportDetailed s
-    }
-
-makeSelectionReportSummarized :: Selection -> SelectionReportSummarized
-makeSelectionReportSummarized s = SelectionReportSummarized {..}
-  where
-    computedFee
-        = selectionDelta TokenBundle.getCoin s
-    adaBalanceOfSelectedInputs
-        = F.foldMap (view (#tokens . #coin) . snd) $ view #inputs s
-    adaBalanceOfExtraCoinSource
-        = view #extraCoinSource s
-    adaBalanceOfExtraCoinSink
-        = view #extraCoinSink s
-    adaBalanceOfGeneratedChangeOutputs
-        = F.foldMap (view #coin) $ view #change s
-    adaBalanceOfRequestedOutputs
-        = F.foldMap (view (#tokens . #coin)) $ view #outputs s
-    numberOfSelectedInputs
-        = length $ view #inputs s
-    numberOfSelectedCollateralInputs
-        = length $ view #collateral s
-    numberOfRequestedOutputs
-        = length $ view #outputs s
-    numberOfGeneratedChangeOutputs
-        = length $ view #change s
-    numberOfUniqueNonAdaAssetsInSelectedInputs
-        = Set.size
-        $ F.foldMap (TokenBundle.getAssets . view #tokens . snd)
-        $ view #inputs s
-    numberOfUniqueNonAdaAssetsInRequestedOutputs
-        = Set.size
-        $ F.foldMap (TokenBundle.getAssets . view #tokens)
-        $ view #outputs s
-    numberOfUniqueNonAdaAssetsInGeneratedChangeOutputs
-        = Set.size
-        $ F.foldMap TokenBundle.getAssets
-        $ view #change s
-
-makeSelectionReportDetailed :: Selection -> SelectionReportDetailed
-makeSelectionReportDetailed s = SelectionReportDetailed
-    { selectedInputs
-        = F.toList $ view #inputs s
-    , selectedCollateral
-        = F.toList $ view #collateral s
-    , requestedOutputs
-        = view #outputs s
-    , generatedChangeOutputs
-        = TokenBundle.Flat <$> view #change s
-    }
-
--- A convenience instance for 'Buildable' contexts that include a nested
--- 'SelectionOf TokenBundle' value.
-instance Buildable (SelectionOf TokenBundle) where
-    build = build . makeSelectionReport
-
--- A convenience instance for 'Buildable' contexts that include a nested
--- 'SelectionOf TxOut' value.
-instance Buildable (SelectionOf TxOut) where
-    build = build
-        . makeSelectionReport
-        . over #change (fmap $ view #tokens)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -325,9 +325,9 @@ import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxSeq as Alonzo
+import qualified Cardano.Ledger.BaseTypes as BT
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Ledger.BaseTypes as SL
-import qualified Cardano.Ledger.BaseTypes as BT
 import qualified Cardano.Ledger.Coin as Ledger
 import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Core as SL.Core


### PR DESCRIPTION
## Issue Number

ADP-1410

## Background

The original `Selection` type was **_polymorphic_** in the type of **_change outputs_**. The intention behind this was to allow the wallet to reuse the `Selection` type in different contexts, _both_ **before** _and_ **after** assigning addresses to change outputs.

However, the internal coin selection library is **not** concerned with assigning addresses to change outputs. Assigning change addresses is a function of the **wallet**, rather than the coin selection library, and the coin selection library shouldn't have to be concerned with this detail.

Moreover, requiring the internal coin selection library's `Selection` type to be polymorphic in the type of change outputs makes the internal library functions and types more complicated than necessary.

## Primary Changes

This PR:

- [x] Forks the `Selection` type into two separate types:
    1. A wallet-specific type,
        located in and exported from `Cardano.Wallet.CoinSelection`
        where the type of `change` is kept polymorphic (as is currently the case).
    2. An internal type,
        located in and exported from `Cardano.Wallet.CoinSelection.Internal`
        where the type of `change` is just `[TokenBundle]`.
- [x] Provides a pair of functions `to{External,Internal}Selection` within `Cardano.Wallet.CoinSelection` to handle conversion between these two types.

## Additional Changes

This PR also:
- [x] Moves the `SelectionReport` type (and related functions) to the wallet-specific `Cardano.Wallet.CoinSelection` module, as this is only required by the wallet, and not required by the internal coin selection library.

## Motivation

- Forking the `Selection` type will make it easier to make further simplifications to the internal type, as we can restrict any breakage to the `to{External,Internal}Selection` functions.
- Retaining the original wallet-specific type means that we don’t have to make any changes to wallet code (which relies on `change` being polymorphic) as part of the library extraction process. If we eventually want to change the wallet-specific type to something else, we can change it later on.
