### PR TITLE
Make wallet responsible for determining collateral suitability

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -316,7 +316,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     , addCosignerAccXPub
     )
 import Cardano.Wallet.Primitive.Collateral
-    ( asCollateral )
+    ( addressSuitableForCollateral )
 import Cardano.Wallet.Primitive.Migration
     ( MigrationPlan (..) )
 import Cardano.Wallet.Primitive.Model
@@ -1909,8 +1909,6 @@ selectAssets ctx pp params transform = do
                 intCast @Word16 @Int $ view #maximumCollateralInputCount pp
             , minimumCollateralPercentage =
                 view #minimumCollateralPercentage pp
-            , utxoSuitableForCollateral =
-                asCollateral . snd
             }
     let selectionParams = SelectionParams
             { assetsToMint =
@@ -1933,7 +1931,9 @@ selectAssets ctx pp params transform = do
             , collateralRequirement =
                 params ^. (#txContext . #txCollateralRequirement)
             , utxoAvailableForCollateral =
-                params ^. #utxoAvailableForCollateral
+                UTxO.filterByAddress
+                    addressSuitableForCollateral
+                    (params ^. #utxoAvailableForCollateral)
             , utxoAvailableForInputs =
                 params ^. #utxoAvailableForInputs
             }

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -315,8 +315,6 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     , SharedState (..)
     , addCosignerAccXPub
     )
-import Cardano.Wallet.Primitive.Collateral
-    ( addressSuitableForCollateral )
 import Cardano.Wallet.Primitive.Migration
     ( MigrationPlan (..) )
 import Cardano.Wallet.Primitive.Model
@@ -1931,9 +1929,7 @@ selectAssets ctx pp params transform = do
             , collateralRequirement =
                 params ^. (#txContext . #txCollateralRequirement)
             , utxoAvailableForCollateral =
-                UTxO.filterByAddress
-                    addressSuitableForCollateral
-                    (params ^. #utxoAvailableForCollateral)
+                params ^. #utxoAvailableForCollateral
             , utxoAvailableForInputs =
                 params ^. #utxoAvailableForInputs
             }

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -168,7 +168,14 @@ data SelectionParams = SelectionParams
 
 toInternalSelectionParams :: SelectionParams -> Internal.SelectionParams
 toInternalSelectionParams SelectionParams {..} =
-    Internal.SelectionParams {..}
+    Internal.SelectionParams
+        { utxoAvailableForCollateral =
+            -- Note: only pure-ada UTxOs are suitable for use as collateral.
+            -- Therefore, we must filter out any UTxOs with non-ada assets.
+            Map.mapMaybe (TokenBundle.toCoin . view #tokens) $
+            unUTxO utxoAvailableForCollateral
+        , ..
+        }
 
 -- | Represents a balanced selection.
 --

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -76,6 +76,8 @@ import Cardano.Wallet.CoinSelection.Internal.Balance
     )
 import Cardano.Wallet.CoinSelection.Internal.Collateral
     ( SelectionCollateralError )
+import Cardano.Wallet.Primitive.Collateral
+    ( asCollateral )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -221,10 +223,7 @@ toInternalSelectionParams :: SelectionParams -> Internal.SelectionParams
 toInternalSelectionParams SelectionParams {..} =
     Internal.SelectionParams
         { utxoAvailableForCollateral =
-            -- Note: only pure-ada UTxOs are suitable for use as collateral.
-            -- Therefore, we must filter out any UTxOs with non-ada assets.
-            Map.mapMaybe (TokenBundle.toCoin . view #tokens) $
-            unUTxO utxoAvailableForCollateral
+            Map.mapMaybe asCollateral $ unUTxO utxoAvailableForCollateral
         , ..
         }
 

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -84,8 +84,6 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TokenBundleSizeAssessment (..), TxIn, TxOut (..), txOutMaxTokenQuantity )
-import Cardano.Wallet.Primitive.Types.UTxO
-    ( UTxO (..) )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
 import Control.Monad
@@ -125,7 +123,6 @@ import qualified Cardano.Wallet.CoinSelection.Internal.Balance as Balance
 import qualified Cardano.Wallet.CoinSelection.Internal.Collateral as Collateral
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
@@ -209,7 +206,7 @@ data SelectionParams = SelectionParams
         :: !SelectionCollateralRequirement
         -- ^ Specifies the collateral requirement for this selection.
     , utxoAvailableForCollateral
-        :: !UTxO
+        :: !(Map TxIn Coin)
         -- ^ Specifies a set of UTxOs that are available for selection as
         -- collateral inputs.
         --
@@ -457,9 +454,7 @@ toCollateralConstraintsParams balanceResult (constraints, params) =
         }
     collateralParams = Collateral.SelectionParams
         { coinsAvailable =
-            Map.mapMaybe
-                (TokenBundle.toCoin . view #tokens)
-                (unUTxO $ view #utxoAvailableForCollateral params)
+            view #utxoAvailableForCollateral params
         , minimumSelectionAmount =
             computeMinimumCollateral ComputeMinimumCollateralParams
                 { minimumCollateralPercentage =
@@ -476,12 +471,9 @@ mkSelection
     -> Balance.SelectionResult
     -> Collateral.SelectionResult
     -> Selection
-mkSelection params balanceResult collateralResult = Selection
+mkSelection _params balanceResult collateralResult = Selection
     { inputs = view #inputsSelected balanceResult
-    , collateral = Map.toList $ Map.map (view (#tokens . #coin)) $ unUTxO $
-        view #utxoAvailableForCollateral params
-        `UTxO.restrictedBy`
-        Map.keysSet (view #coinsSelected collateralResult)
+    , collateral = Map.toList $ view #coinsSelected collateralResult
     , outputs = view #outputsCovered balanceResult
     , change = view #changeGenerated balanceResult
     , assetsToMint = view #assetsToMint balanceResult
@@ -683,7 +675,7 @@ verifySelectionCollateralSuitable _cs ps selection =
     utxoSuitableForCollateral (i, c) =
         Map.singleton i c
         `Map.isSubmapOf`
-        (view (#tokens . #coin) <$> unUTxO (ps ^. #utxoAvailableForCollateral))
+        view #utxoAvailableForCollateral ps
 
 --------------------------------------------------------------------------------
 -- Selection verification: delta validity
@@ -1104,21 +1096,7 @@ verifySelectionCollateralError cs ps e =
     largestCombinationUnsuitableSubset :: Map TxIn Coin
     largestCombinationUnsuitableSubset = Map.withoutKeys
         (largestCombination)
-        (Map.keysSet largestCombinationSuitableSubset)
-      where
-        -- The largest reported combination of UTxOs, but with outputs fully
-        -- resolved according to the set of UTxOs originally made available
-        -- to the selection algorithm.
-        largestCombinationResolved :: Map TxIn TxOut
-        largestCombinationResolved = Map.restrictKeys
-            (unUTxO (ps ^. #utxoAvailableForCollateral))
-            (Map.keysSet largestCombination)
-
-        -- The subset of the largest reported combination that is suitable for
-        -- use as collateral. This set should be exactly the same size as the
-        -- reported largest combination.
-        largestCombinationSuitableSubset = Map.mapMaybe
-            (TokenBundle.toCoin . view #tokens) largestCombinationResolved
+        (Map.keysSet $ ps ^. #utxoAvailableForCollateral)
 
     maximumSelectionSize :: Int
     maximumSelectionSize = cs ^. #maximumCollateralInputCount

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -248,7 +248,7 @@ import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
 
 spec :: Spec
-spec = describe "Cardano.Wallet.Primitive.CoinSelection.BalanceSpec" $
+spec = describe "Cardano.Wallet.CoinSelection.Internal.BalanceSpec" $
 
     modifyMaxSuccess (const 1000) $ do
 

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -144,7 +144,7 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Data.Foldable as F
 
 spec :: Spec
-spec = describe "Cardano.Wallet.Primitive.CoinSelectionSpec" $ do
+spec = describe "Cardano.Wallet.CoinSelection.InternalSpec" $ do
 
     parallel $ describe "Performing selections" $ do
 

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -71,13 +71,9 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxOut (..), txOutCoin, txOutMaxTokenQuantity )
+    ( TxIn, TxOut (..), txOutCoin, txOutMaxTokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxOut, shrinkTxOut )
-import Cardano.Wallet.Primitive.Types.UTxO
-    ( UTxO )
-import Cardano.Wallet.Primitive.Types.UTxO.Gen
-    ( genUTxO, shrinkUTxO )
+    ( genTxIn, genTxOut, shrinkTxIn, shrinkTxOut )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
 import Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
@@ -94,6 +90,8 @@ import Data.Functor
     ( (<&>) )
 import Data.Generics.Internal.VL.Lens
     ( over, view, (^.) )
+import Data.Map.Strict
+    ( Map )
 import Generics.SOP
     ( NP (..) )
 import GHC.Generics
@@ -128,8 +126,10 @@ import Test.QuickCheck
 import Test.QuickCheck.Extra
     ( Pretty (..)
     , chooseNatural
+    , genMapWith
     , genericRoundRobinShrink
     , report
+    , shrinkMapWith
     , shrinkNatural
     , (<:>)
     , (<@>)
@@ -755,8 +755,8 @@ shrinkCollateralRequirement = genericShrink
 -- UTxO available for inputs and collateral
 --------------------------------------------------------------------------------
 
-genUTxOAvailableForCollateral :: Gen UTxO
-genUTxOAvailableForCollateral = genUTxO
+genUTxOAvailableForCollateral :: Gen (Map TxIn Coin)
+genUTxOAvailableForCollateral = genMapWith genTxIn genCoinPositive
 
 genUTxOAvailableForInputs :: Gen UTxOSelection
 genUTxOAvailableForInputs = frequency
@@ -764,8 +764,8 @@ genUTxOAvailableForInputs = frequency
     , (01, pure UTxOSelection.empty)
     ]
 
-shrinkUTxOAvailableForCollateral :: UTxO -> [UTxO]
-shrinkUTxOAvailableForCollateral = shrinkUTxO
+shrinkUTxOAvailableForCollateral :: Map TxIn Coin -> [Map TxIn Coin]
+shrinkUTxOAvailableForCollateral = shrinkMapWith shrinkTxIn shrinkCoinPositive
 
 shrinkUTxOAvailableForInputs :: UTxOSelection -> [UTxOSelection]
 shrinkUTxOAvailableForInputs = shrinkUTxOSelection


### PR DESCRIPTION
## Issue Number

ADP-1411

## Background

The coin selection library is currently responsible for filtering the available UTxO set for entries that are suitable for use as collateral. However, this responsibility is actually delegated back to the wallet, as the **_wallet_** must provide a definition of the following function:
```hs
utxoSuitableForCollateral
    :: (TxIn, TxOut) -> Maybe Coin
    -- ^ Indicates whether an individual UTxO entry is suitable for use as
    -- a collateral input. This function should return a 'Coin' value if
    -- (and only if) the given UTxO is suitable for use as collateral.
```
The coin selection library merely **_applies_** this function as a **_filter_** on the set of available UTxO entries.

## Why this is a problem

The requirement to provide the `utxoSuitableForCollateral` function means that the coin selection library must depend on the `TxOut` type (as collateral suitability is a function of `Address`). Our goal is to evolve the coin selection library so that it does not depend on wallet-specific types like `TxOut`, `Address`, and `UTxO`.

## Changes made by this PR

This PR:

- [x] Removes the `utxoSuitableForCollateral` function from `SelectionConstraints`.
- [x] Makes the wallet fully responsible for identifying which UTxO entries are suitable for collateral, by requiring it to pre-filter the `utxoAvailableForCollateral` set.
- [x] Changes the type of `SelectionParams.utxoAvailableForCollateral` from `UTxO` to Map `TxIn Coin`, as collateral entries can never have non-ada assets.
- [x] Changes the type of `Selection.collateral` from `[(TxIn, TxOut)]` to `[(TxIn, Coin)]`.

## Notes

We will eventually replace all usages of `TxIn` in the coin selection library with a type parameter and `Ord` constraints (where appropriate). This PR is a step towards this goal.