### PR TITLE
Undelegate with existing rewards

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -2026,7 +2026,8 @@ faucetUtxoAmt = ada 100_000
     ada = (*) (1_000_000)
 
 getFromResponse
-    :: Lens' s a
+    :: HasCallStack
+    => Lens' s a
     -> (HTTP.Status, Either RequestException s)
     -> a
 getFromResponse getter (_, res) = case res of

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -402,6 +402,8 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             [ expectResponseCode HTTP.status202
             , expectField (#status . #getApiT) (`shouldBe` Pending)
             , expectField (#direction . #getApiT) (`shouldBe` Incoming)
+            , expectField #depositTaken (`shouldBe` Quantity 0)
+            , expectField #depositReturned (`shouldBe` Quantity 1000000)
             ]
         let txid = getFromResponse Prelude.id rq
         let quitFeeAmt = getFromResponse #amount rq
@@ -542,9 +544,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             [ expectResponseCode HTTP.status202
             , expectField #depositTaken (`shouldBe` (Quantity 0))
             , expectField #depositReturned
-                (`shouldBe` (Quantity 0))
-                    -- FIXME: We would expect 1000000 here;
-                    -- seems like a bug!
+                (`shouldBe` (Quantity 1000000))
             ]
 
     it "STAKE_POOLS_JOIN_01 - Can rejoin another stakepool" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -27,6 +27,7 @@ import Cardano.Wallet.Api.Types
     , ApiTxInput (..)
     , ApiWallet
     , ApiWalletDelegationStatus (..)
+    , ApiWithdrawal (..)
     , DecodeAddress
     , DecodeStakeAddress
     , EncodeAddress
@@ -140,7 +141,6 @@ import Test.Integration.Framework.DSL
 import Test.Integration.Framework.TestData
     ( errMsg403EmptyUTxO
     , errMsg403Fee
-    , errMsg403NonNullReward
     , errMsg403NotDelegating
     , errMsg403PoolAlreadyJoined
     , errMsg403WrongPass
@@ -649,10 +649,12 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                         (.> (Quantity 0))
                     ]
 
-        -- Can't quite if unspoiled rewards.
+        -- Can quit with rewards
         quitStakePool @n ctx (w, fixturePassphrase) >>= flip verify
-            [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403NonNullReward
+            [ expectResponseCode HTTP.status202
+            , expectField #depositReturned (`shouldBe` Quantity 1000000)
+            , expectField (#withdrawals)
+                (\[ApiWithdrawal _ c] -> c .> Quantity 0)
             ]
 
     it "STAKE_POOLS_JOIN_05 - \

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -534,10 +534,17 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                 ctx (Link.listStakePools arbitraryStake) Empty
         joinStakePool @n ctx pool (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
+            , expectField #depositTaken (`shouldBe` (Quantity 0))
+            , expectField #depositReturned (`shouldBe` (Quantity 0))
             ]
         waitForTxImmutability ctx
         quitStakePool @n ctx (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
+            , expectField #depositTaken (`shouldBe` (Quantity 0))
+            , expectField #depositReturned
+                (`shouldBe` (Quantity 0))
+                    -- FIXME: We would expect 1000000 here;
+                    -- seems like a bug!
             ]
 
     it "STAKE_POOLS_JOIN_01 - Can rejoin another stakepool" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -2776,9 +2776,15 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                     }
                 }]
             }|]
-        unsignedTx1 <- getFromResponse #transaction
-            <$> request @(ApiConstructTransaction n) ctx
+        rUnsignedTx1 <- request @(ApiConstructTransaction n) ctx
             (Link.createUnsignedTransaction @'Shelley w) Default payload
+        let unsignedTx1 = getFromResponse #transaction rUnsignedTx1
+        verify rUnsignedTx1
+            [ expectField (#coinSelection . #depositsReturned)
+                (`shouldBe` [])
+            , expectField (#coinSelection . #depositsTaken)
+                (`shouldBe` []) -- key already registered
+            ]
         signedTx1 <- signTx ctx w unsignedTx1 [ expectResponseCode HTTP.status202 ]
         submitTxWithWid ctx w signedTx1 >>= flip verify
             [ expectSuccess
@@ -2795,9 +2801,15 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 }],
                 "withdrawal": "self"
             }|]
-        unsignedTx2 <- getFromResponse (#transaction)
-            <$> request @(ApiConstructTransaction n) ctx
+        rUnsignedTx2 <- request @(ApiConstructTransaction n) ctx
             (Link.createUnsignedTransaction @'Shelley w) Default payload2
+        let unsignedTx2 = getFromResponse #transaction rUnsignedTx2
+        verify rUnsignedTx2
+            [ expectField (#coinSelection . #depositsReturned)
+                (`shouldBe` [Quantity 1000000])
+            , expectField (#coinSelection . #depositsTaken)
+                (`shouldBe` [])
+            ]
         signedTx2 <- signTx ctx w unsignedTx2 [ expectResponseCode HTTP.status202 ]
         submitTxWithWid ctx w signedTx2 >>= flip verify
             [ expectSuccess

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -189,6 +189,7 @@ import Test.Integration.Framework.TestData
     , errMsg403MissingWitsInTransaction
     , errMsg403MultiaccountTransaction
     , errMsg403MultidelegationTransaction
+    , errMsg403NonNullReward
     , errMsg403NotDelegating
     , errMsg403NotEnoughMoney
     , errMsg404NoSuchPool
@@ -2716,6 +2717,91 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         verify rTx
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403NotDelegating
+            ]
+
+    it "TRANS_NEW_QUIT_02a - Cannot quit with rewards without explicit withdrawal"
+        $ \ctx -> runResourceT $ do
+        (w, _) <- rewardWallet ctx
+
+        pool1:_:_ <- map (view #id) . snd
+            <$> unsafeRequest @[ApiStakePool]
+                ctx (Link.listStakePools arbitraryStake) Empty
+
+        let payload = Json [json|{
+                "delegations": [{
+                    "join": {
+                        "pool": #{pool1},
+                        "stake_key_index": "0H"
+                    }
+                }]
+            }|]
+        unsignedTx1 <- view #transaction . snd
+            <$> unsafeRequest @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley w) payload
+        signedTx1 <- signTx ctx w unsignedTx1 [ expectResponseCode HTTP.status202 ]
+        submitTxWithWid ctx w signedTx1 >>= flip verify
+            [ expectSuccess
+            , expectResponseCode HTTP.status202
+            ]
+
+        waitForTxImmutability ctx
+
+        let payload2 = Json [json|{
+                "delegations": [{
+                    "quit": {
+                        "stake_key_index": "0H"
+                    }
+                }]
+            }|]
+        request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley w) Default payload2
+            >>= flip verify
+            [ expectResponseCode HTTP.status403
+            , expectErrorMessage errMsg403NonNullReward
+            ]
+
+    it "TRANS_NEW_QUIT_02b - Can quit with rewards with explicit withdrawal"
+        $ \ctx -> runResourceT $ do
+        (w, _) <- rewardWallet ctx
+
+        pool1:_:_ <- map (view #id) . snd
+            <$> unsafeRequest @[ApiStakePool]
+                ctx (Link.listStakePools arbitraryStake) Empty
+
+        let payload = Json [json|{
+                "delegations": [{
+                    "join": {
+                        "pool": #{pool1},
+                        "stake_key_index": "0H"
+                    }
+                }]
+            }|]
+        unsignedTx1 <- getFromResponse #transaction
+            <$> request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley w) Default payload
+        signedTx1 <- signTx ctx w unsignedTx1 [ expectResponseCode HTTP.status202 ]
+        submitTxWithWid ctx w signedTx1 >>= flip verify
+            [ expectSuccess
+            , expectResponseCode HTTP.status202
+            ]
+
+        waitForTxImmutability ctx
+
+        let payload2 = Json [json|{
+                "delegations": [{
+                    "quit": {
+                        "stake_key_index": "0H"
+                    }
+                }],
+                "withdrawal": "self"
+            }|]
+        unsignedTx2 <- getFromResponse (#transaction)
+            <$> request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley w) Default payload2
+        signedTx2 <- signTx ctx w unsignedTx2 [ expectResponseCode HTTP.status202 ]
+        submitTxWithWid ctx w signedTx2 >>= flip verify
+            [ expectSuccess
+            , expectResponseCode HTTP.status202
             ]
 
     it "TRANS_NEW_CREATE_MULTI_TX - Tx including payments, delegation, metadata, withdrawals, validity_interval" $ \ctx -> runResourceT $ do

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -3458,16 +3458,12 @@ mkApiTransaction timeInterpreter setTimeReference tx = do
     reclaimIfAny :: Natural
     reclaimIfAny
         | tx ^. (#txMeta . #direction) == W.Incoming =
-              if ( totalInWithoutFee > 0 && totalOut > 0 && totalOut > totalInWithoutFee)
-                 && (totalOut - totalInWithoutFee <= depositValue) then
+              if ( totalIn > 0 && totalOut > 0 && totalOut > totalIn)
+                 && (totalOut - totalIn <= depositValue) then
                   depositValue
               else
                   0
         | otherwise = 0
-
-    totalInWithoutFee :: Natural
-    totalInWithoutFee
-        = sum (txOutValue <$> mapMaybe snd (tx ^. #txInputs))
 
     totalIn :: Natural
     totalIn

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -6133,6 +6133,8 @@ paths:
 
         Stop delegating completely. The wallet's stake will become inactive.
 
+        Any current rewards will automatically withdrawn.
+
         > ⚠️  Disclaimer ⚠️
         >
         > This endpoint historically use to take a stake pool id as a path parameter.


### PR DESCRIPTION
Old workflow:
- [x] Automatically withdraw rewards when quitting (both for HW and normal wallets)

New workflow (constructTransaction):
- [x] Don't fail with `ErrNonNullRewards` if `"withdrawal": "self"` is set when quitting

### Comments

`cabal v2-test cardano-wallet:integration --test-option=-j --test-option="10" --test-option="--match" --test-option "quit with rewards"`

<details>
<summary>Before fix</summary>

```shell
    TRANS_NEW_QUIT_02a - Cannot quit with rewards without explicit withdrawal (51966ms)
    TRANS_NEW_QUIT_02b - Can quit with rewards with explicit withdrawal FAILED [1] (51967ms)
  SHELLEY_STAKE_POOLS
    STAKE_POOLS_QUIT_03 - Can quit with rewards FAILED [2] (51966ms)

Failures:

  src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs:2597:24:
  1) API Specifications, NEW_SHELLEY_TRANSACTIONS, TRANS_NEW_QUIT_02b - Can quit with rewards with explicit withdrawal
       uncaught exception: ErrorCall
       getFromResponse failed to get item
       CallStack (from HasCallStack):
         error, called at src/Test/Integration/Framework/DSL.hs:2034:16 in cardano-wallet-core-integration-2022.1.18-inplace:Test.Integration.Framework.DSL
         getFromResponse, called at src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs:2597:24 in cardano-wallet-core-integration-2022.1.18-inplace:Test.Integration.Scenario.API.Shelley.TransactionsNew

  To rerun use: --match "/API Specifications/NEW_SHELLEY_TRANSACTIONS/TRANS_NEW_QUIT_02b - Can quit with rewards with explicit withdrawal/"

  src/Test/Integration/Scenario/API/Shelley/StakePools.hs:537:15:
  2) API Specifications, SHELLEY_STAKE_POOLS, STAKE_POOLS_QUIT_03 - Can quit with rewards
       From the following response: Left
           ( ClientError
               ( Object
                   ( fromList
                       [
                           ( "code"
                           , String "non_null_rewards"
                           )
                       ,
                           ( "message"
                           , String "It seems that you're trying to retire from delegation although you've unspoiled rewards in your rewards account! Make sure to withdraw your 1000000.000000 lovelace first."
                           )
                       ]
                   )
               )
           )
       While verifying value:
         ( Status
             { statusCode = 403
             , statusMessage = "Forbidden"
             }
         , Left
             ( ClientError
                 ( Object
                     ( fromList
                         [
                             ( "code"
                             , String "non_null_rewards"
                             )
                         ,
                             ( "message"
                             , String "It seems that you're trying to retire from delegation although you've unspoiled rewards in your rewards account! Make sure to withdraw your 1000000.000000 lovelace first."
                             )
                         ]
                     )
                 )
             )
         )
       expected: Status {statusCode = 202, statusMessage = "Accepted"}
        but got: Status {statusCode = 403, statusMessage = "Forbidden"}

  To rerun use: --match "/API Specifications/SHELLEY_STAKE_POOLS/STAKE_POOLS_QUIT_03 - Can quit with rewards/"

Randomized with seed 1670117879

Finished in 52.0220 seconds, used 10.2823 seconds of CPU time
3 examples, 2 failures
```

</details>

After fixes:

```
    TRANS_NEW_QUIT_02a - Cannot quit with rewards without explicit withdrawal (51666ms)
    TRANS_NEW_QUIT_02b - Can quit with rewards with explicit withdrawal (51975ms)
  SHELLEY_STAKE_POOLS
    STAKE_POOLS_QUIT_03 - Can quit with rewards (51975ms)
```

### Issue Number

ADP-1067
