### PR TITLE
Add --markdown-output and unclassified failures count to scripts/bors-stats.rb

### DIFF
--- a/scripts/bors-stats.rb
+++ b/scripts/bors-stats.rb
@@ -61,6 +61,7 @@ class BorsStats < Thor
     :long_desc => "`--group #1 #2 #3` will replace #2 and #3 with #1."
 
   desc "list", "list all failures"
+  method_option :markdown_output, :type => :boolean, :required => false, :desc => "Create markdown links to issues"
   def list()
     comments = fetch_comments_with_options options
 
@@ -84,7 +85,14 @@ class BorsStats < Thor
       n = k[:n]
       title = tm.dig t, "title"
       title = title.nil? ? "" : title
-      puts (bold(n.to_s) + " times (" + bold(failure_rate(n, nTot)) + ") " + yellow(t) + " " + bold(title))
+
+      tag_str =
+        if options[:markdown_output] and is_issue? t
+          then "[" + t + "](https://github.com/input-output-hk/cardano-wallet/issues/" + t.delete_prefix("#") + ")"
+          else yellow t
+          end
+
+      puts (bold(n.to_s) + " times (" + bold(failure_rate(n, nTot)) + ") " + tag_str + " " + bold(title))
     end
   end
 
@@ -662,6 +670,16 @@ def rewrite_tags(comments, title_map)
       if t2 then t2 else t end
     end
   end
+end
+
+##
+# >>> is_issue? "#0"
+# true
+#
+## >>> is_issue? "0"
+# false
+def is_issue? t
+  true if t.start_with? "#" and Integer(t.delete_prefix "#") rescue false
 end
 
 ######################################################################


### PR DESCRIPTION
- [x] Count unclassified failures in scripts/bors-stats.rb
- [x] Add --markdown-output option to scripts/bors-stats.rb

### Comments

```shell
$ ./scripts/bors-stats.rb --markdown-output --after "1 Jan" --annotate "Timed out."
[...]
10 Feb 13:21 hydra https://github.com/input-output-hk/cardano-wallet/pull/3110#issuecomment-1034915493
https://hydra.iohk.io/build/12719899
Build failed:

ci/hydra-build:required

succeeded: 15 failed: 51 (77%) total: 66
Excluding 22 #expected or #duplicate failures
Unclassified: 8 (16% of all failures)

Broken down by tags/issues:
25 times (38%) hydra
19 times (29%) buildkite
9 times (14%) [#3120](https://github.com/input-output-hk/cardano-wallet/issues/3120) Flaky test: Various arcane `stack` problems in buildkite (pantry, libffi, ...)
6 times (9%) [#3057](https://github.com/input-output-hk/cardano-wallet/issues/3057) Flaky test: `StakeKeyAlreadyRegisteredDELEG` from `Plutus scenarios, withdrawal`
5 times (8%) [#3124](https://github.com/input-output-hk/cardano-wallet/issues/3124) Flaky test: ValidationFailedV1 NotEnoughSpace from `Plutus scenarios, currency`
5 times (8%) [#3123](https://github.com/input-output-hk/cardano-wallet/issues/3123) Flaky test: Lots of integration tests errors due to cluster or setup
5 times (8%) Timed out.
4 times (6%) [#3121](https://github.com/input-output-hk/cardano-wallet/issues/3121) Flaky test: `gai_strerror not supported: 11002` from `API Server, handles bad host name`
3 times (5%) [#3122](https://github.com/input-output-hk/cardano-wallet/issues/3122) Flaky test: `Plutus scenarios`, `missing_witnesses_in_transaction`
3 times (5%) [#2472](https://github.com/input-output-hk/cardano-wallet/issues/2472) Unit tests sometimes time out.
3 times (5%) [#2855](https://github.com/input-output-hk/cardano-wallet/issues/2855) Flaky test: Various CLI tests failing due to high load
```


### Issue Number

None.
