### PR TITLE
Remove use of `TxOut` from `Selection.{inputs,outputs}`

### DIFF
--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -170,6 +170,8 @@ toInternalSelectionConstraints SelectionConstraints {..} =
     Internal.SelectionConstraints
         { computeMinimumCost =
             computeMinimumCost . toExternalSelectionSkeleton
+        , computeSelectionLimit =
+            computeSelectionLimit . fmap (uncurry TxOut)
         , ..
         }
 

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -267,7 +267,11 @@ emptySkeleton = SelectionSkeleton
 
 toExternalSelectionSkeleton :: Internal.SelectionSkeleton -> SelectionSkeleton
 toExternalSelectionSkeleton Internal.SelectionSkeleton {..} =
-    SelectionSkeleton {..}
+    SelectionSkeleton
+        { skeletonOutputs =
+            uncurry TxOut <$> skeletonOutputs
+        , ..
+        }
 
 --------------------------------------------------------------------------------
 -- Selections

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -88,6 +88,8 @@ import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
+import Control.Arrow
+    ( (&&&) )
 import Control.Monad.Random.Class
     ( MonadRandom (..) )
 import Control.Monad.Trans.Except
@@ -231,6 +233,8 @@ toInternalSelectionParams SelectionParams {..} =
     Internal.SelectionParams
         { utxoAvailableForCollateral =
             Map.mapMaybe asCollateral $ unUTxO utxoAvailableForCollateral
+        , outputsToCover =
+            (view #address &&& view #tokens) <$> outputsToCover
         , ..
         }
 
@@ -322,6 +326,8 @@ toExternalSelection ps Internal.Selection {..} =
             resolveInput utxoAvailableForCollateral . fst <$> collateral
         , inputs =
             resolveInput utxoAvailableForInputs . fst <$> inputs
+        , outputs =
+            uncurry TxOut <$> outputs
         , ..
         }
   where
@@ -361,6 +367,7 @@ toInternalSelection getChangeBundle Selection {..} =
         { change = getChangeBundle <$> change
         , collateral = fmap (view (#tokens . #coin)) <$> collateral
         , inputs = fmap (view #tokens) <$> inputs
+        , outputs = (view #address &&& view #tokens) <$> outputs
         , ..
         }
 

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -237,7 +237,7 @@ data SelectionError
 --
 data Selection = Selection
     { inputs
-        :: !(NonEmpty (TxIn, TxOut))
+        :: !(NonEmpty (TxIn, TokenBundle))
         -- ^ Selected inputs.
     , collateral
         :: ![(TxIn, Coin)]

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
 
 -- |
 -- Copyright: © 2021 IOHK
@@ -87,8 +88,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( TokenBundleSizeAssessment (..), TxIn, TxOut (..), txOutMaxTokenQuantity )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
-import Control.Arrow
-    ( (&&&) )
 import Control.Monad
     ( (<=<) )
 import Control.Monad.Random.Class
@@ -194,7 +193,7 @@ data SelectionParams = SelectionParams
         :: !Coin
         -- ^ Specifies extra 'Coin' out.
     , outputsToCover
-        :: ![TxOut]
+        :: ![(Address, TokenBundle)]
         -- ^ Specifies a set of outputs that must be paid for.
     , rewardWithdrawal
         :: !Coin
@@ -246,7 +245,7 @@ data Selection = Selection
         :: ![(TxIn, Coin)]
         -- ^ Selected collateral inputs.
     , outputs
-        :: ![TxOut]
+        :: ![(Address, TokenBundle)]
         -- ^ User-specified outputs
     , change
         :: ![TokenBundle]
@@ -342,10 +341,10 @@ performSelectionCollateral balanceResult cs ps
 -- Since change outputs do not have addresses at the point of generation,
 -- this function assigns all change outputs with a dummy change address.
 --
-selectionAllOutputs :: Selection -> [TxOut]
+selectionAllOutputs :: Selection -> [(Address, TokenBundle)]
 selectionAllOutputs selection = (<>)
     (selection ^. #outputs)
-    (selection ^. #change <&> TxOut dummyChangeAddress)
+    (selection ^. #change <&> (dummyChangeAddress, ))
   where
     dummyChangeAddress :: Address
     dummyChangeAddress = Address "<change>"
@@ -730,9 +729,7 @@ verifySelectionInputCountWithinLimit cs _ps selection =
     collateralInputCount = length (selection ^. #collateral)
     ordinaryInputCount = length (selection ^. #inputs)
     totalInputCount = collateralInputCount + ordinaryInputCount
-    selectionLimit =
-        (cs ^. #computeSelectionLimit)
-        ((view #address &&& view #tokens) <$> (selection ^. #outputs))
+    selectionLimit = (cs ^. #computeSelectionLimit) (selection ^. #outputs)
 
 --------------------------------------------------------------------------------
 -- Selection verification: minimum ada quantities
@@ -745,7 +742,7 @@ newtype FailureToVerifySelectionOutputCoinsSufficient =
 
 data SelectionOutputCoinInsufficientError = SelectionOutputCoinInsufficientError
     { minimumExpectedCoin :: Coin
-    , output :: TxOut
+    , output :: (Address, TokenBundle)
     }
     deriving (Eq, Show)
 
@@ -756,9 +753,11 @@ verifySelectionOutputCoinsSufficient cs _ps selection =
     errors :: [SelectionOutputCoinInsufficientError]
     errors = mapMaybe maybeError (selectionAllOutputs selection)
 
-    maybeError :: TxOut -> Maybe SelectionOutputCoinInsufficientError
+    maybeError
+        :: (Address, TokenBundle)
+        -> Maybe SelectionOutputCoinInsufficientError
     maybeError output
-        | output ^. (#tokens . #coin) < minimumExpectedCoin =
+        | snd output ^. #coin < minimumExpectedCoin =
             Just SelectionOutputCoinInsufficientError
                 {minimumExpectedCoin, output}
         | otherwise =
@@ -767,7 +766,7 @@ verifySelectionOutputCoinsSufficient cs _ps selection =
         minimumExpectedCoin :: Coin
         minimumExpectedCoin =
             (cs ^. #computeMinimumAdaQuantity)
-            (output ^. (#tokens . #tokens))
+            (snd output ^. #tokens)
 
 --------------------------------------------------------------------------------
 -- Selection verification: output sizes
@@ -953,20 +952,12 @@ verifySelectionLimitReachedError cs ps e =
     selectionLimitAdjusted = toBalanceConstraintsParams (cs, ps)
         & fst
         & view #computeSelectionLimit
-        & (
-            $ fmap (view #address &&& view #tokens)
-            $ F.toList
-            $ e ^. #outputsToCover
-          )
+        & ($ F.toList $ e ^. #outputsToCover)
 
     selectionLimitOriginal :: SelectionLimit
     selectionLimitOriginal = cs
         & view #computeSelectionLimit
-        & (
-            $ fmap (view #address &&& view #tokens)
-            $ F.toList
-            $ e ^. #outputsToCover
-          )
+        & ($ F.toList $ e ^. #outputsToCover)
 
 --------------------------------------------------------------------------------
 -- Selection error verification: change construction errors
@@ -1329,8 +1320,8 @@ computeMinimumCollateral params =
 --
 prepareOutputsInternal
     :: SelectionConstraints
-    -> [TxOut]
-    -> Either SelectionOutputError [TxOut]
+    -> [(Address, TokenBundle)]
+    -> Either SelectionOutputError [(Address, TokenBundle)]
 prepareOutputsInternal constraints outputsUnprepared
     | e : _ <- excessivelyLargeBundles =
         Left $
@@ -1376,9 +1367,13 @@ prepareOutputsInternal constraints outputsUnprepared
 -- quantity manually for each non-ada output. That quantity is the minimum
 -- quantity required to make a particular output valid.
 --
-prepareOutputsWith :: Functor f => (TokenMap -> Coin) -> f TxOut -> f TxOut
+prepareOutputsWith
+    :: Functor f
+    => (TokenMap -> Coin)
+    -> f (Address, TokenBundle)
+    -> f (Address, TokenBundle)
 prepareOutputsWith minCoinValueFor =
-    fmap $ over #tokens augmentBundle
+    fmap $ fmap augmentBundle
   where
     augmentBundle :: TokenBundle -> TokenBundle
     augmentBundle bundle
@@ -1409,17 +1404,17 @@ newtype SelectionOutputSizeExceedsLimitError =
 --
 verifyOutputSize
     :: SelectionConstraints
-    -> TxOut
+    -> (Address, TokenBundle)
     -> Maybe SelectionOutputSizeExceedsLimitError
 verifyOutputSize cs out
     | withinLimit =
         Nothing
     | otherwise =
-        Just $ SelectionOutputSizeExceedsLimitError out
+        Just $ SelectionOutputSizeExceedsLimitError (uncurry TxOut out)
   where
     withinLimit :: Bool
     withinLimit =
-        case (cs ^. #assessTokenBundleSize) (out ^. #tokens) of
+        case (cs ^. #assessTokenBundleSize) (snd out) of
             TokenBundleSizeWithinLimit -> True
             TokenBundleSizeExceedsLimit -> False
 
@@ -1445,11 +1440,11 @@ data SelectionOutputTokenQuantityExceedsLimitError =
 -- protocol.
 --
 verifyOutputTokenQuantities
-    :: TxOut -> [SelectionOutputTokenQuantityExceedsLimitError]
+    :: (Address, TokenBundle) -> [SelectionOutputTokenQuantityExceedsLimitError]
 verifyOutputTokenQuantities out =
     [ SelectionOutputTokenQuantityExceedsLimitError
         {address, asset, quantity, quantityMaxBound = txOutMaxTokenQuantity}
-    | let address = out ^. #address
-    , (asset, quantity) <- TokenMap.toFlatList $ out ^. #tokens . #tokens
+    | let address = fst out
+    , (asset, quantity) <- TokenMap.toFlatList $ (snd out) ^. #tokens
     , quantity > txOutMaxTokenQuantity
     ]

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -24,6 +24,7 @@ module Cardano.Wallet.CoinSelection.Internal
     , SelectionConstraints (..)
     , SelectionError (..)
     , SelectionParams (..)
+    , SelectionSkeleton (..)
 
     -- * Output preparation
     , prepareOutputsWith

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -466,7 +466,7 @@ type SelectionResult = SelectionResultOf [TxOut]
 --
 data SelectionResultOf outputs = SelectionResult
     { inputsSelected
-        :: !(NonEmpty (TxIn, TxOut))
+        :: !(NonEmpty (TxIn, TokenBundle))
         -- ^ A (non-empty) list of inputs selected from 'utxoAvailable'.
     , extraCoinSource
         :: !Coin
@@ -534,7 +534,7 @@ selectionDeltaAllAssets result
         `TokenBundle.add`
         TokenBundle.fromCoin extraCoinSource
         `TokenBundle.add`
-        F.foldMap (view #tokens . snd) inputsSelected
+        F.foldMap snd inputsSelected
     balanceOut =
         TokenBundle.fromTokenMap assetsToBurn
         `TokenBundle.add`
@@ -1029,7 +1029,7 @@ performSelectionNonEmpty constraints params
             , requiredCost
             , extraCoinSource
             , extraCoinSink
-            , inputBundles = view #tokens . snd <$> inputsSelected
+            , inputBundles = snd <$> inputsSelected
             , outputBundles = view #tokens <$> outputsToCover
             , assetsToMint
             , assetsToBurn
@@ -1055,7 +1055,7 @@ performSelectionNonEmpty constraints params
             }
 
         skeletonChange = predictChange s
-        inputsSelected = UTxOSelection.selectedList s
+        inputsSelected = fmap (view #tokens) <$> UTxOSelection.selectedList s
 
     invariantResultWithNoCost inputs_ = error $ unlines
         -- This should be impossible, as the 'makeChange' function should

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -228,7 +228,7 @@ data SelectionConstraints = SelectionConstraints
         :: SelectionSkeleton -> Coin
         -- ^ Computes the minimum cost of a given selection skeleton.
     , computeSelectionLimit
-        :: [TxOut] -> SelectionLimit
+        :: [(Address, TokenBundle)] -> SelectionLimit
         -- ^ Computes an upper bound for the number of ordinary inputs to
         -- select, given a current set of outputs.
     }
@@ -876,7 +876,9 @@ performSelectionNonEmpty constraints params
             }
 
     selectionLimit :: SelectionLimit
-    selectionLimit = computeSelectionLimit (F.toList outputsToCover)
+    selectionLimit = computeSelectionLimit $
+        (view #address &&& view #tokens)
+            <$> (F.toList outputsToCover)
 
     utxoBalanceAvailable :: TokenBundle
     utxoBalanceAvailable = computeUTxOBalanceAvailable params

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -30,7 +30,6 @@ module Cardano.Wallet.CoinSelection.Internal.Balance
       PerformSelection
     , performSelection
     , performSelectionEmpty
-    , emptySkeleton
     , SelectionConstraints (..)
     , SelectionParams
     , SelectionParamsOf (..)
@@ -410,15 +409,6 @@ data SelectionSkeleton = SelectionSkeleton
         :: ![Set AssetId]
     }
     deriving (Eq, Generic, Show)
-
--- | Creates an empty 'SelectionSkeleton'.
---
-emptySkeleton :: SelectionSkeleton
-emptySkeleton = SelectionSkeleton
-    { skeletonInputCount = 0
-    , skeletonOutputs = mempty
-    , skeletonChange = mempty
-    }
 
 -- | Specifies a limit to adhere to when performing a selection.
 --

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -146,8 +146,6 @@ import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( SelectionFilter (..), UTxOIndex (..) )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( IsUTxOSelection, UTxOSelection, UTxOSelectionNonEmpty )
-import Control.Arrow
-    ( (&&&) )
 import Control.Monad.Extra
     ( andM )
 import Control.Monad.Random.Class
@@ -234,7 +232,7 @@ data SelectionConstraints = SelectionConstraints
     }
     deriving Generic
 
-type SelectionParams = SelectionParamsOf [TxOut]
+type SelectionParams = SelectionParamsOf [(Address, TokenBundle)]
 
 -- | Specifies all parameters that are specific to a given selection.
 --
@@ -301,7 +299,7 @@ data UTxOBalanceSufficiencyInfo = UTxOBalanceSufficiencyInfo
 -- | Computes the balance of UTxO entries available for selection.
 --
 computeUTxOBalanceAvailable
-    :: SelectionParamsOf (f TxOut)
+    :: SelectionParamsOf (f (Address, TokenBundle))
     -> TokenBundle
 computeUTxOBalanceAvailable =
     UTxOSelection.availableBalance . view #utxoAvailable
@@ -310,13 +308,13 @@ computeUTxOBalanceAvailable =
 --
 computeUTxOBalanceRequired
     :: Foldable f
-    => SelectionParamsOf (f TxOut)
+    => SelectionParamsOf (f (Address, TokenBundle))
     -> TokenBundle
 computeUTxOBalanceRequired = fst . computeDeficitInOut
 
 computeBalanceInOut
     :: Foldable f
-    => SelectionParamsOf (f TxOut)
+    => SelectionParamsOf (f (Address, TokenBundle))
     -> (TokenBundle, TokenBundle)
 computeBalanceInOut params =
     (balanceIn, balanceOut)
@@ -330,11 +328,11 @@ computeBalanceInOut params =
         `TokenBundle.add`
         TokenBundle.fromCoin (view #extraCoinSink params)
         `TokenBundle.add`
-        F.foldMap (view #tokens) (view #outputsToCover params)
+        F.foldMap snd (view #outputsToCover params)
 
 computeDeficitInOut
     :: Foldable f
-    => SelectionParamsOf (f TxOut)
+    => SelectionParamsOf (f (Address, TokenBundle))
     -> (TokenBundle, TokenBundle)
 computeDeficitInOut params =
     (deficitIn, deficitOut)
@@ -352,7 +350,7 @@ computeDeficitInOut params =
 --
 computeUTxOBalanceSufficiency
     :: Foldable f
-    => SelectionParamsOf (f TxOut)
+    => SelectionParamsOf (f (Address, TokenBundle))
     -> UTxOBalanceSufficiency
 computeUTxOBalanceSufficiency = sufficiency . computeUTxOBalanceSufficiencyInfo
 
@@ -362,7 +360,7 @@ computeUTxOBalanceSufficiency = sufficiency . computeUTxOBalanceSufficiencyInfo
 --
 computeUTxOBalanceSufficiencyInfo
     :: Foldable f
-    => SelectionParamsOf (f TxOut)
+    => SelectionParamsOf (f (Address, TokenBundle))
     -> UTxOBalanceSufficiencyInfo
 computeUTxOBalanceSufficiencyInfo params =
     UTxOBalanceSufficiencyInfo {available, required, difference, sufficiency}
@@ -385,7 +383,7 @@ computeUTxOBalanceSufficiencyInfo params =
 --
 isUTxOBalanceSufficient
     :: Foldable f
-    => SelectionParamsOf (f TxOut)
+    => SelectionParamsOf (f (Address, TokenBundle))
     -> Bool
 isUTxOBalanceSufficient params =
     case computeUTxOBalanceSufficiency params of
@@ -452,7 +450,7 @@ reduceSelectionLimitBy limit reduction
     | otherwise =
         subtract reduction <$> limit
 
-type SelectionResult = SelectionResultOf [TxOut]
+type SelectionResult = SelectionResultOf [(Address, TokenBundle)]
 
 -- | The result of performing a successful selection.
 --
@@ -514,7 +512,9 @@ instance Buildable a => Buildable (SelectionDelta a) where
 -- See 'SelectionDelta'.
 --
 selectionDeltaAllAssets
-    :: Foldable f => SelectionResultOf (f TxOut) -> SelectionDelta TokenBundle
+    :: Foldable f
+    => SelectionResultOf (f (Address, TokenBundle))
+    -> SelectionDelta TokenBundle
 selectionDeltaAllAssets result
     | balanceOut `leq` balanceIn =
         SelectionSurplus $ TokenBundle.difference balanceIn balanceOut
@@ -532,7 +532,7 @@ selectionDeltaAllAssets result
         `TokenBundle.add`
         TokenBundle.fromCoin extraCoinSink
         `TokenBundle.add`
-        F.foldMap (view #tokens) outputsCovered
+        F.foldMap snd outputsCovered
         `TokenBundle.add`
         F.fold changeGenerated
     SelectionResult
@@ -550,7 +550,9 @@ selectionDeltaAllAssets result
 -- See 'SelectionDelta'.
 --
 selectionDeltaCoin
-    :: Foldable f => SelectionResultOf (f TxOut) -> SelectionDelta Coin
+    :: Foldable f
+    => SelectionResultOf (f (Address, TokenBundle))
+    -> SelectionDelta Coin
 selectionDeltaCoin = fmap TokenBundle.getCoin . selectionDeltaAllAssets
 
 -- | Indicates whether or not a selection result has a valid surplus.
@@ -558,7 +560,7 @@ selectionDeltaCoin = fmap TokenBundle.getCoin . selectionDeltaAllAssets
 selectionHasValidSurplus
     :: Foldable f
     => SelectionConstraints
-    -> SelectionResultOf (f TxOut)
+    -> SelectionResultOf (f (Address, TokenBundle))
     -> Bool
 selectionHasValidSurplus constraints selection =
     case selectionDeltaAllAssets selection of
@@ -595,7 +597,9 @@ selectionHasValidSurplus constraints selection =
 -- Use 'selectionDeltaCoin' if you wish to handle the case where there is
 -- a deficit.
 --
-selectionSurplusCoin :: Foldable f => SelectionResultOf (f TxOut) -> Coin
+selectionSurplusCoin
+    :: Foldable f
+    => SelectionResultOf (f (Address, TokenBundle)) -> Coin
 selectionSurplusCoin result =
     case selectionDeltaCoin result of
         SelectionSurplus surplus -> surplus
@@ -604,12 +608,12 @@ selectionSurplusCoin result =
 -- | Converts a selection into a skeleton.
 --
 selectionSkeleton
-    :: Foldable f => SelectionResultOf (f TxOut) -> SelectionSkeleton
+    :: Foldable f
+    => SelectionResultOf (f (Address, TokenBundle))
+    -> SelectionSkeleton
 selectionSkeleton s = SelectionSkeleton
     { skeletonInputCount = F.length (view #inputsSelected s)
-    , skeletonOutputs =
-        (view #address &&& view #tokens)
-            <$> F.toList (view #outputsCovered s)
+    , skeletonOutputs = F.toList (view #outputsCovered s)
     , skeletonChange = TokenBundle.getAssets <$> view #changeGenerated s
     }
 
@@ -618,7 +622,7 @@ selectionSkeleton s = SelectionSkeleton
 selectionMinimumCost
     :: Foldable f
     => SelectionConstraints
-    -> SelectionResultOf (f TxOut)
+    -> SelectionResultOf (f (Address, TokenBundle))
     -> Coin
 selectionMinimumCost c = view #computeMinimumCost c . selectionSkeleton
 
@@ -639,7 +643,7 @@ selectionMinimumCost c = view #computeMinimumCost c . selectionSkeleton
 selectionMaximumCost
     :: Foldable f
     => SelectionConstraints
-    -> SelectionResultOf (f TxOut)
+    -> SelectionResultOf (f (Address, TokenBundle))
     -> Coin
 selectionMaximumCost c = mtimesDefault (2 :: Int) . selectionMinimumCost c
 
@@ -669,7 +673,7 @@ data SelectionLimitReachedError = SelectionLimitReachedError
       -- ^ The inputs that could be selected while satisfying the
       -- 'selectionLimit'.
     , outputsToCover
-        :: !(NonEmpty TxOut)
+        :: !(NonEmpty (Address, TokenBundle))
     } deriving (Generic, Eq, Show)
 
 -- | Indicates that the balance of available UTxO entries is insufficient to
@@ -736,7 +740,7 @@ type PerformSelection m outputs =
 --
 performSelection
     :: forall m. (HasCallStack, MonadRandom m)
-    => PerformSelection m [TxOut]
+    => PerformSelection m [(Address, TokenBundle)]
 performSelection = performSelectionEmpty performSelectionNonEmpty
 
 -- | Transforms a coin selection function that requires a non-empty list of
@@ -768,15 +772,15 @@ performSelection = performSelectionEmpty performSelectionNonEmpty
 --
 performSelectionEmpty
     :: Functor m
-    => PerformSelection m (NonEmpty TxOut)
-    -> PerformSelection m [         TxOut]
+    => PerformSelection m (NonEmpty (Address, TokenBundle))
+    -> PerformSelection m [         (Address, TokenBundle)]
 performSelectionEmpty performSelectionFn constraints params =
     fmap transformResult <$>
     performSelectionFn constraints (transformParams params)
   where
     transformParams
-        :: SelectionParamsOf [         TxOut]
-        -> SelectionParamsOf (NonEmpty TxOut)
+        :: SelectionParamsOf [         (Address, TokenBundle)]
+        -> SelectionParamsOf (NonEmpty (Address, TokenBundle))
     transformParams
         = over #extraCoinSource
             (transform (`Coin.add` minCoin) (const id))
@@ -784,19 +788,19 @@ performSelectionEmpty performSelectionFn constraints params =
             (transform (const (dummyOutput :| [])) (const . id))
 
     transformResult
-        :: SelectionResultOf (NonEmpty TxOut)
-        -> SelectionResultOf [         TxOut]
+        :: SelectionResultOf (NonEmpty (Address, TokenBundle))
+        -> SelectionResultOf [         (Address, TokenBundle)]
     transformResult
         = over #extraCoinSource
             (transform (`Coin.difference` minCoin) (const id))
         . over #outputsCovered
             (transform (const []) (const . F.toList))
 
-    transform :: a -> (NonEmpty TxOut -> a) -> a
+    transform :: a -> (NonEmpty (Address, TokenBundle) -> a) -> a
     transform x y = maybe x y $ NE.nonEmpty $ view #outputsToCover params
 
-    dummyOutput :: TxOut
-    dummyOutput = TxOut (Address "") $ TokenBundle.fromCoin minCoin
+    dummyOutput :: (Address, TokenBundle)
+    dummyOutput = (Address "", TokenBundle.fromCoin minCoin)
 
     -- The 'performSelectionNonEmpty' function imposes a precondition that all
     -- outputs must have at least the minimum ada quantity. Therefore, the
@@ -817,7 +821,7 @@ performSelectionEmpty performSelectionFn constraints params =
 
 performSelectionNonEmpty
     :: forall m. (HasCallStack, MonadRandom m)
-    => PerformSelection m (NonEmpty TxOut)
+    => PerformSelection m (NonEmpty (Address, TokenBundle))
 performSelectionNonEmpty constraints params
     -- Is the total available UTXO balance sufficient?
     | not utxoBalanceSufficient =
@@ -876,9 +880,7 @@ performSelectionNonEmpty constraints params
             }
 
     selectionLimit :: SelectionLimit
-    selectionLimit = computeSelectionLimit $
-        (view #address &&& view #tokens)
-            <$> (F.toList outputsToCover)
+    selectionLimit = computeSelectionLimit $ F.toList outputsToCover
 
     utxoBalanceAvailable :: TokenBundle
     utxoBalanceAvailable = computeUTxOBalanceAvailable params
@@ -894,17 +896,19 @@ performSelectionNonEmpty constraints params
         mapMaybe mkInsufficientMinCoinValueError outputsToCover
       where
         mkInsufficientMinCoinValueError
-            :: TxOut
+            :: (Address, TokenBundle)
             -> Maybe InsufficientMinCoinValueError
         mkInsufficientMinCoinValueError o
-            | view (#tokens . #coin) o >= expectedMinCoinValue =
+            | view #coin (snd o) >= expectedMinCoinValue =
                 Nothing
             | otherwise =
                 Just $ InsufficientMinCoinValueError
-                    { expectedMinCoinValue, outputWithInsufficientAda = o }
+                    { expectedMinCoinValue
+                    , outputWithInsufficientAda = uncurry TxOut o
+                    }
           where
             expectedMinCoinValue = computeMinimumAdaQuantity
-                (view (#tokens . #tokens) o)
+                (view #tokens $ snd o)
 
     -- Given a UTxO index that corresponds to a valid selection covering
     -- 'outputsToCover', 'predictChange' yields a non-empty list of assets
@@ -954,7 +958,7 @@ performSelectionNonEmpty constraints params
         )
       where
         inputBundles = view #tokens . snd <$> UTxOSelection.selectedList s
-        outputBundles = view #tokens <$> outputsToCover
+        outputBundles = snd <$> outputsToCover
 
         noMinimumCoin :: TokenMap -> Coin
         noMinimumCoin = const (Coin 0)
@@ -978,7 +982,11 @@ performSelectionNonEmpty constraints params
     --
     makeChangeRepeatedly
         :: UTxOSelectionNonEmpty
-        -> m (Either SelectionBalanceError (SelectionResultOf (NonEmpty TxOut)))
+        -> m
+            ( Either
+                SelectionBalanceError
+                (SelectionResultOf (NonEmpty (Address, TokenBundle)))
+            )
     makeChangeRepeatedly s = case mChangeGenerated of
 
         Right change | length change >= length outputsToCover ->
@@ -1026,12 +1034,14 @@ performSelectionNonEmpty constraints params
             , extraCoinSource
             , extraCoinSink
             , inputBundles = snd <$> inputsSelected
-            , outputBundles = view #tokens <$> outputsToCover
+            , outputBundles = snd <$> outputsToCover
             , assetsToMint
             , assetsToBurn
             }
 
-        mkSelectionResult :: [TokenBundle] -> SelectionResultOf (NonEmpty TxOut)
+        mkSelectionResult
+            :: [TokenBundle]
+            -> SelectionResultOf (NonEmpty (Address, TokenBundle))
         mkSelectionResult changeGenerated = SelectionResult
             { inputsSelected
             , extraCoinSource
@@ -1046,9 +1056,7 @@ performSelectionNonEmpty constraints params
 
         requiredCost = computeMinimumCost SelectionSkeleton
             { skeletonInputCount = UTxOSelection.selectedSize s
-            , skeletonOutputs =
-                (view #address &&& view #tokens)
-                    <$> NE.toList outputsToCover
+            , skeletonOutputs = NE.toList outputsToCover
             , skeletonChange
             }
 

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -1187,8 +1187,8 @@ mockPerformSelectionNonEmpty constraints params = Identity $ Right result
         , outputsCovered = view #outputsToCover params
         }
 
-    makeInputsOfValue :: TokenBundle -> NonEmpty (TxIn, TxOut)
-    makeInputsOfValue v = (TxIn (Hash "") 0, TxOut (Address "") v) :| []
+    makeInputsOfValue :: TokenBundle -> NonEmpty (TxIn, TokenBundle)
+    makeInputsOfValue v = (TxIn (Hash "") 0, v) :| []
 
     makeChangeOfValue :: TokenBundle -> [TokenBundle]
     makeChangeOfValue v = [v]
@@ -1679,7 +1679,7 @@ encodeBoundaryTestCriteria c = SelectionParams
 decodeBoundaryTestResult :: SelectionResult -> BoundaryTestResult
 decodeBoundaryTestResult r = BoundaryTestResult
     { boundaryTestInputs = L.sort $ NE.toList $
-        TokenBundle.toFlatList . view #tokens . snd <$> view #inputsSelected r
+        TokenBundle.toFlatList . snd <$> view #inputsSelected r
     , boundaryTestChange =
         TokenBundle.toFlatList <$> view #changeGenerated r
     }

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -2142,7 +2142,7 @@ computeMinimumCostLinear s
     = Coin
     $ fromIntegral
     $ skeletonInputCount s
-    + F.length (TokenMap.size . view (#tokens . #tokens) <$> skeletonOutputs s)
+    + F.length (TokenMap.size . view #tokens . snd <$> skeletonOutputs s)
     + F.sum (Set.size <$> skeletonChange s)
 
 --------------------------------------------------------------------------------

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -59,13 +59,15 @@ import Cardano.Wallet.CoinSelection.Internal.Collateral
 import Cardano.Wallet.Primitive.Types.Address
     ( Address )
 import Cardano.Wallet.Primitive.Types.Address.Gen
-    ( genAddress )
+    ( genAddress, shrinkAddress )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoin, genCoinPositive, shrinkCoin, shrinkCoinPositive )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
+import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
+    ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
@@ -73,15 +75,13 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn, TxOut (..), txOutCoin, txOutMaxTokenQuantity )
+    ( TxIn, txOutMaxTokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxIn, genTxOut, shrinkTxIn, shrinkTxOut )
+    ( genTxIn, shrinkTxIn )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
 import Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
     ( genUTxOSelection, shrinkUTxOSelection )
-import Control.Arrow
-    ( (&&&) )
 import Control.Monad
     ( forM_ )
 import Control.Monad.Trans.Except
@@ -124,6 +124,7 @@ import Test.QuickCheck
     , scale
     , shrink
     , shrinkList
+    , suchThat
     , vectorOf
     , (===)
     )
@@ -407,11 +408,11 @@ prop_toBalanceConstraintsParams_computeSelectionLimit mockConstraints params =
 
     selectionLimitOriginal :: SelectionLimit
     selectionLimitOriginal = computeSelectionLimitOriginal $
-        (view #address &&& view #tokens) <$> (params ^. #outputsToCover)
+        params ^. #outputsToCover
 
     selectionLimitAdjusted :: SelectionLimit
     selectionLimitAdjusted = computeSelectionLimitAdjusted $
-        (view #address &&& view #tokens) <$> (params ^. #outputsToCover)
+        params ^. #outputsToCover
 
 --------------------------------------------------------------------------------
 -- Preparing outputs
@@ -419,7 +420,7 @@ prop_toBalanceConstraintsParams_computeSelectionLimit mockConstraints params =
 
 prop_prepareOutputsWith_twice
     :: MockComputeMinimumAdaQuantity
-    -> [TxOut]
+    -> [(Address, TokenBundle)]
     -> Property
 prop_prepareOutputsWith_twice minCoinValueDef outs =
     once === twice
@@ -429,7 +430,7 @@ prop_prepareOutputsWith_twice minCoinValueDef outs =
 
 prop_prepareOutputsWith_length
     :: MockComputeMinimumAdaQuantity
-    -> [TxOut]
+    -> [(Address, TokenBundle)]
     -> Property
 prop_prepareOutputsWith_length minCoinValueDef outs =
     F.length (prepareOutputsWith minCoinValueFor outs) === F.length outs
@@ -438,19 +439,19 @@ prop_prepareOutputsWith_length minCoinValueDef outs =
 
 prop_prepareOutputsWith_assetsUnchanged
     :: MockComputeMinimumAdaQuantity
-    -> [TxOut]
+    -> [(Address, TokenBundle)]
     -> Property
 prop_prepareOutputsWith_assetsUnchanged minCoinValueDef outs =
-    (txOutAssets <$> (prepareOutputsWith minCoinValueFor outs))
+    (outputAssets <$> (prepareOutputsWith minCoinValueFor outs))
     ===
-    (txOutAssets <$> outs)
+    (outputAssets <$> outs)
   where
     minCoinValueFor = unMockComputeMinimumAdaQuantity minCoinValueDef
-    txOutAssets = TokenBundle.getAssets . view #tokens
+    outputAssets = TokenBundle.getAssets . snd
 
 prop_prepareOutputsWith_preparedOrExistedBefore
     :: MockComputeMinimumAdaQuantity
-    -> [TxOut]
+    -> [(Address, TokenBundle)]
     -> Property
 prop_prepareOutputsWith_preparedOrExistedBefore minCoinValueDef outs =
     property $ F.all isPreparedOrExistedBefore (zip outs outs')
@@ -458,12 +459,15 @@ prop_prepareOutputsWith_preparedOrExistedBefore minCoinValueDef outs =
     minCoinValueFor = unMockComputeMinimumAdaQuantity minCoinValueDef
     outs' = prepareOutputsWith minCoinValueFor outs
 
-    isPreparedOrExistedBefore :: (TxOut, TxOut) -> Bool
+    isPreparedOrExistedBefore
+        :: ((Address, TokenBundle), (Address, TokenBundle)) -> Bool
     isPreparedOrExistedBefore (before, after)
-        | txOutCoin before /= Coin 0 =
-            txOutCoin after == txOutCoin before
+        | outputCoin before /= Coin 0 =
+            outputCoin after == outputCoin before
         | otherwise =
-            txOutCoin after == minCoinValueFor (view (#tokens . #tokens) before)
+            outputCoin after == minCoinValueFor (view #tokens $ snd before)
+      where
+        outputCoin = view #coin . snd
 
 --------------------------------------------------------------------------------
 -- Computing minimum collateral amounts
@@ -672,19 +676,23 @@ shrinkExtraCoinOut = shrinkCoin
 -- Outputs to cover
 --------------------------------------------------------------------------------
 
-genOutputsToCover :: Gen [TxOut]
+genOutputsToCover :: Gen [(Address, TokenBundle)]
 genOutputsToCover = do
     count <- choose (1, 4)
     vectorOf count genOutputToCover
   where
-    genOutputToCover :: Gen TxOut
+    genOutputToCover :: Gen (Address, TokenBundle)
     genOutputToCover = frequency
-        [ (49, scale (`mod` 8) genTxOut)
-        , (01, genTxOutWith genTokenQuantityThatMayExceedLimit)
+        [ (49, scale (`mod` 8) genOutput)
+        , (01, genOutputWith genTokenQuantityThatMayExceedLimit)
         ]
+      where
+        genOutput = (,)
+            <$> genAddress
+            <*> genTokenBundleSmallRange `suchThat` tokenBundleHasNonZeroCoin
 
-    genTxOutWith :: Gen TokenQuantity -> Gen TxOut
-    genTxOutWith genTokenQuantityFn = TxOut
+    genOutputWith :: Gen TokenQuantity -> Gen (Address, TokenBundle)
+    genOutputWith genTokenQuantityFn = (,)
         <$> genAddress
         <*> genTokenBundleWith genTokenQuantityFn
 
@@ -715,8 +723,16 @@ genOutputsToCover = do
         limit :: Natural
         limit = unTokenQuantity txOutMaxTokenQuantity
 
-shrinkOutputsToCover :: [TxOut] -> [[TxOut]]
-shrinkOutputsToCover = shrinkList shrinkTxOut
+shrinkOutputsToCover :: [(Address, TokenBundle)] -> [[(Address, TokenBundle)]]
+shrinkOutputsToCover = shrinkList shrinkOutput
+  where
+    shrinkOutput = genericRoundRobinShrink
+        <@> shrinkAddress
+        <:> (filter tokenBundleHasNonZeroCoin . shrinkTokenBundleSmallRange)
+        <:> Nil
+
+tokenBundleHasNonZeroCoin :: TokenBundle -> Bool
+tokenBundleHasNonZeroCoin b = TokenBundle.getCoin b /= Coin 0
 
 --------------------------------------------------------------------------------
 -- Reward withdrawals
@@ -806,6 +822,10 @@ unitTests title f unitTestData =
 --------------------------------------------------------------------------------
 -- Arbitrary instances
 --------------------------------------------------------------------------------
+
+instance Arbitrary Address where
+    arbitrary = genAddress
+    shrink = shrinkAddress
 
 instance Arbitrary MockSelectionConstraints where
     arbitrary = genMockSelectionConstraints

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -56,6 +56,8 @@ import Cardano.Wallet.CoinSelection.Internal.BalanceSpec
     )
 import Cardano.Wallet.CoinSelection.Internal.Collateral
     ( SelectionCollateralErrorOf (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address )
 import Cardano.Wallet.Primitive.Types.Address.Gen
     ( genAddress )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -78,6 +80,8 @@ import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
 import Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
     ( genUTxOSelection, shrinkUTxOSelection )
+import Control.Arrow
+    ( (&&&) )
 import Control.Monad
     ( forM_ )
 import Control.Monad.Trans.Except
@@ -393,21 +397,21 @@ prop_toBalanceConstraintsParams_computeSelectionLimit mockConstraints params =
     maximumCollateralInputCount :: Int
     maximumCollateralInputCount = constraints ^. #maximumCollateralInputCount
 
-    computeSelectionLimitOriginal :: [TxOut] -> SelectionLimit
+    computeSelectionLimitOriginal :: [(Address, TokenBundle)] -> SelectionLimit
     computeSelectionLimitOriginal = constraints ^. #computeSelectionLimit
 
-    computeSelectionLimitAdjusted :: [TxOut] -> SelectionLimit
+    computeSelectionLimitAdjusted :: [(Address, TokenBundle)] -> SelectionLimit
     computeSelectionLimitAdjusted =
         toBalanceConstraintsParams (constraints, params)
             & fst & view #computeSelectionLimit
 
     selectionLimitOriginal :: SelectionLimit
-    selectionLimitOriginal = computeSelectionLimitOriginal
-        (params ^. #outputsToCover)
+    selectionLimitOriginal = computeSelectionLimitOriginal $
+        (view #address &&& view #tokens) <$> (params ^. #outputsToCover)
 
     selectionLimitAdjusted :: SelectionLimit
-    selectionLimitAdjusted = computeSelectionLimitAdjusted
-        (params ^. #outputsToCover)
+    selectionLimitAdjusted = computeSelectionLimitAdjusted $
+        (view #address &&& view #tokens) <$> (params ^. #outputsToCover)
 
 --------------------------------------------------------------------------------
 -- Preparing outputs


### PR DESCRIPTION
## Issue Numbers

ADP-1412
ADP-1415
ADP-1429
ADP-1438

## Motivation

Within the internal coin selection library, we eventually want to:

- replace `TxIn` with an abstract type parameter `input`;
- replace `TxOut` with an abstract type parameter `output`.

This PR is a step towards that goal.

## Summary

This PR makes the following changes to types within `Cardano.Wallet.CoinSelection.Internal`:
```patch
  data Selection = Selection
      { inputs
-         :: !(NonEmpty (TxIn, TxOut      ))
+         :: !(NonEmpty (TxIn, TokenBundle))
      , outputs
-         :: ![TxOut                 ]
+         :: ![(Address, TokenBundle)]
      , ...
      }
```
```patch
  data SelectionParams = SelectionParams
      { outputsToCover
-         :: [TxOut                 ]
+         :: [(Address, TokenBundle)]
      , ...
      }
```

```patch
  data SelectionSkeleton = SelectionSkeleton                                                                                                                                            
      { skeletonOutputs
-         :: ![TxOut                 ]
+         :: ![(Address, TokenBundle)]
      , ...
      }
```