### PR TITLE
Remove assertions for pending tx after doing submit tx (it's flaky)

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -843,7 +843,6 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         verify rGetTx
             [ expectResponseCode HTTP.status200
             , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-            , expectField (#status . #getApiT) (`shouldBe` Pending)
             ]
 
         eventually "Source wallet balance is decreased by amt + fee" $ do

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -271,7 +271,6 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       tx_signed = SHELLEY.transactions.sign(@wid, PASS, tx_constructed['transaction'])
       tx_submitted = SHELLEY.transactions.submit(@wid, tx_signed['transaction'])
       tx_id = tx_submitted['id']
-      expect(SHELLEY.transactions.get(@wid, tx_id)['status']).to eq 'pending'
 
       wait_for_tx_in_ledger(@wid, tx_id)
 
@@ -306,7 +305,6 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       tx_submitted = SHELLEY.transactions.submit(@wid, tx_signed['transaction'])
       expect(tx_submitted).to be_correct_and_respond 202
       tx_id = tx_submitted['id']
-      expect(SHELLEY.transactions.get(@wid, tx_id)['status']).to eq 'pending'
 
       wait_for_tx_in_ledger(@wid, tx_id)
 
@@ -348,7 +346,6 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       tx_submitted = SHELLEY.transactions.submit(@wid, tx_signed['transaction'])
       expect(tx_submitted).to be_correct_and_respond 202
       tx_id = tx_submitted['id']
-      expect(SHELLEY.transactions.get(@wid, tx_id)['status']).to eq 'pending'
 
       wait_for_tx_in_ledger(@wid, tx_id)
 
@@ -396,7 +393,6 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       tx_submitted = SHELLEY.transactions.submit(@wid, tx_signed['transaction'])
       expect(tx_submitted).to be_correct_and_respond 202
       tx_id = tx_submitted['id']
-      expect(SHELLEY.transactions.get(@wid, tx_id)['status']).to eq 'pending'
 
       wait_for_tx_in_ledger(@wid, tx_id)
 
@@ -434,7 +430,6 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       tx_submitted = SHELLEY.transactions.submit(@wid, tx_signed['transaction'])
       expect(tx_submitted).to be_correct_and_respond 202
       tx_id = tx_submitted['id']
-      expect(SHELLEY.transactions.get(@wid, tx_id)['status']).to eq 'pending'
 
       wait_for_tx_in_ledger(@wid, tx_id)
 
@@ -467,7 +462,6 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       tx_submitted = SHELLEY.transactions.submit(@wid, tx_signed['transaction'])
       expect(tx_submitted).to be_correct_and_respond 202
       tx_id = tx_submitted['id']
-      expect(SHELLEY.transactions.get(@wid, tx_id)['status']).to eq 'pending'
 
       wait_for_tx_in_ledger(@wid, tx_id)
 
@@ -1245,7 +1239,6 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       tx_submitted = SHELLEY.transactions.submit(@wid, tx_signed['transaction'])
       expect(tx_submitted).to be_correct_and_respond 202
       tx_id = tx_submitted['id']
-      expect(SHELLEY.transactions.get(@wid, tx_id)['status']).to eq 'pending'
 
       wait_for_tx_in_ledger(@wid, tx_id)
 

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -444,7 +444,6 @@ def balance_sign_submit(wid, payload)
 
   tx_submitted = SHELLEY.transactions.submit(wid, tx_signed['transaction'])
   expect(tx_submitted).to be_correct_and_respond 202
-  expect(SHELLEY.transactions.get(wid, tx_submitted['id'])['status']).to eq 'pending'
 
   [tx_balanced, tx_signed, tx_submitted]
 end
@@ -473,7 +472,6 @@ def construct_sign_submit(wid,
 
   tx_submitted = SHELLEY.transactions.submit(wid, tx_signed['transaction'])
   expect(tx_submitted).to be_correct_and_respond 202
-  expect(SHELLEY.transactions.get(wid, tx_submitted['id'])['status']).to eq 'pending'
 
   [tx_constructed, tx_signed, tx_submitted]
 end


### PR DESCRIPTION
- 6ffe085b35d838b89a166268ce94d4d5dd7aeeef
  remove Pending tx assertion as it causes flakiness
  
- 0d9870fd879957f536113ae2ca89389448b08eaf
  remove Pending tx assertion from e2e tests too as they cause false-positives sometimes as well


### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
