### PR TITLE
Fix for the `listAssets` API which shows assets unrelated to a wallet

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -158,6 +158,7 @@ module Cardano.Wallet
     -- ** Transaction
     , forgetTx
     , listTransactions
+    , extractWalletAssetsFromTxs
     , getTransaction
     , submitExternalTx
     , submitTx
@@ -2489,6 +2490,14 @@ listTransactions ctx wid mMinWithdrawal mStart mEnd order = db & \DBLayer{..} ->
                 $ slotRangeFromTimeRange
                 $ Range mStart mEnd
 
+-- | Extract assets associated with a given wallet from its transaction history.
+extractWalletAssetsFromTxs
+    :: WalletId -> [TransactionInfo] -> [TokenMap.AssetId]
+extractWalletAssetsFromTxs _walletId = Set.toList . Set.unions . map txAssets
+  where
+    txAssets = Set.unions
+        . map (TokenBundle.getAssets . view #tokens)
+        . txInfoOutputs
 
 -- | Get transaction and metadata from history for a given wallet.
 getTransaction

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2507,7 +2507,7 @@ listAssets ctx wid = db & \DBLayer{..} -> do
             . map (TokenBundle.getAssets . view #tokens)
             . filter ourOut
             . txInfoOutputs
-        ourOut TxOut {address} = ourAddress address
+        ourOut TxOut{address} = ourAddress address
         ourAddress addr = isJust . fst . isOurs addr $ getState cp
     pure $ Set.unions $ map txAssets txs
   where

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -509,7 +509,7 @@ import Data.List.NonEmpty
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
-    ( fromMaybe, mapMaybe, isJust )
+    ( fromMaybe, isJust, mapMaybe )
 import Data.Proxy
     ( Proxy )
 import Data.Quantity

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1739,7 +1739,7 @@ listAssets
     -> Handler [ApiAsset]
 listAssets ctx wid = do
     assets <- listAssetsBase ctx wid
-    liftIO $ fillMetadata client assets toApiAsset
+    liftIO $ fillMetadata client (Set.toList assets) toApiAsset
   where
     client = ctx ^. tokenMetadataClient
 
@@ -1747,12 +1747,10 @@ listAssets ctx wid = do
 -- wallet.
 listAssetsBase
     :: forall s k. IsOurs s Address =>
-    ApiLayer s k -> ApiT WalletId -> Handler [AssetId]
+    ApiLayer s k -> ApiT WalletId -> Handler (Set AssetId)
 listAssetsBase ctx (ApiT wallet) =
-    withWorkerCtx ctx wallet liftE liftE $ \wctx -> do
-        txs <- liftHandler $
-            W.listTransactions wctx wallet Nothing Nothing Nothing Descending
-        liftHandler $ W.extractWalletAssetsFromTxs wctx wallet txs
+    withWorkerCtx ctx wallet liftE liftE $ \wctx ->
+        liftHandler $ W.listAssets wctx wallet
 
 -- | Look up a single asset and its metadata.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -271,11 +271,11 @@ applyBlock !block (Wallet !u0 _ s0) =
 --
 applyBlocks
     :: (IsOurs s Address, IsOurs s RewardAccount)
-    => NonEmpty (Block)
+    => NonEmpty Block
     -> Wallet s
     -> NonEmpty (FilteredBlock, Wallet s)
-applyBlocks (block0 :| blocks) cp =
-    NE.scanl (flip applyBlock . snd) (applyBlock block0 cp) blocks
+applyBlocks (block0 :| blocks) walletState =
+    NE.scanl (flip applyBlock . snd) (applyBlock block0 walletState) blocks
 
 {-------------------------------------------------------------------------------
                                    Accessors
@@ -379,7 +379,7 @@ changeUTxO pending = evalState $
                                 UTxO operations
 -------------------------------------------------------------------------------}
 
--- | Applies a transaction to a UTxO, moving it from one state from another.
+-- | Applies a transaction to a UTxO, moving it from one state to another.
 --
 -- When applying a transaction to a UTxO:
 --   1. We need to remove any unspents that have been spent in the transaction.
@@ -426,7 +426,7 @@ spendTx tx !u =
 -- | Construct a 'UTxO' corresponding to a given transaction.
 --
 -- It is important for the transaction outputs to be ordered correctly,
--- as their index within this ordering determines how 
+-- as their index within this ordering determines how
 -- they are referenced as transaction inputs in subsequent blocks.
 --
 -- > balance (utxoFromTx tx) = foldMap tokens (outputs tx)
@@ -463,7 +463,7 @@ discoverAddresses block s0 = s2
     -- NOTE: Only outputs and withdrawals can potentially
     -- result in the extension of the address pool and
     -- the learning of new addresses.
-    -- 
+    --
     -- Inputs and collateral are forced to use existing addresses.
     discoverTx s tx = discoverWithdrawals (discoverOutputs s tx) tx
     discoverOutputs s tx =

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -80,7 +80,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , Tx (..)
     , TxIn (..)
     , TxMeta (..)
-    , TxOut (address)
     , TxStatus (..)
     , collateralInputs
     , failedScriptValidation
@@ -557,10 +556,7 @@ applyOurTxToUTxO
 applyOurTxToUTxO !slotNo !blockHeight !s !tx !prevUTxO =
     if ourWithdrawalSum /= mempty || prevUTxO /= ourNextUTxO
         then
-            let updatedTx = tx
-                    { fee = actualFee dir
-                    , outputs = filter (ours s . address) (outputs tx)
-                    }
+            let updatedTx = tx { fee = actualFee dir }
             in Just ((updatedTx, txmeta), ourNextUTxO)
         else Nothing
   where

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE TupleSections #-}
 
 module Cardano.Wallet.Primitive.ModelSpec
     ( spec
@@ -732,34 +733,20 @@ prop_applyOurTxToUTxO_allOurs
     -> Property
 prop_applyOurTxToUTxO_allOurs slotNo blockHeight tx utxo =
     checkCoverage $
-    cover 50  (    haveResult)        "have result" $
+    cover 50 haveResult "have result" $
     cover 0.1 (not haveResult) "do not have result" $
-    report
-        (utxo)
-        "utxo" $
-    report
-        (utxoFromTx tx)
-        "utxoFromTx tx" $
-    report
-        (haveResult)
-        "haveResult" $
-    report
-        (shouldHaveResult)
-        "shouldHaveResult" $
+    report utxo "utxo" $
+    report (utxoFromTx tx) "utxoFromTx tx" $
+    report haveResult "haveResult" $
+    report shouldHaveResult "shouldHaveResult" $
     case maybeResult of
         Nothing ->
-            verify
-                (not shouldHaveResult)
-                "not shouldHaveResult" $
+            verify (not shouldHaveResult) "not shouldHaveResult" $
             property True
         Just utxo' ->
-            cover 10 (utxo /= utxo')
-                "utxo /= utxo'" $
-            verify
-                (shouldHaveResult)
-                "shouldHaveResult" $
-            verify
-                (utxo' == applyTxToUTxO tx utxo)
+            cover 10 (utxo /= utxo') "utxo /= utxo'" $
+            verify shouldHaveResult "shouldHaveResult" $
+            verify (utxo' == applyTxToUTxO tx utxo)
                 "utxo' == applyTxToUTxO tx utxo" $
             property True
   where
@@ -785,32 +772,17 @@ prop_applyOurTxToUTxO_someOurs
     -> Property
 prop_applyOurTxToUTxO_someOurs ourState slotNo blockHeight tx utxo =
     checkCoverage $
-    cover 50  (    haveResult)        "have result" $
+    cover 50 haveResult "have result" $
     cover 0.1 (not haveResult) "do not have result" $
-    report
-        (utxo)
-        "utxo" $
-    report
-        (utxoFromTx tx)
-        "utxoFromTx tx" $
-    report
-        (haveResult)
-        "haveResult" $
-    report
-        (shouldHaveResult)
-        "shouldHaveResult" $
+    report utxo "utxo" $
+    report (utxoFromTx tx) "utxoFromTx tx" $
+    report haveResult "haveResult" $
+    report shouldHaveResult "shouldHaveResult" $
     case maybeResult of
-        Nothing ->
-            verify
-                (not shouldHaveResult)
-                "not shouldHaveResult" $
+        Nothing -> verify (not shouldHaveResult) "not shouldHaveResult" $
             property True
-        Just utxo' ->
-            cover 10 (utxo /= utxo')
-                "utxo /= utxo'" $
-            verify
-                (shouldHaveResult)
-                "shouldHaveResult" $
+        Just utxo' -> cover 10 (utxo /= utxo') "utxo /= utxo'" $
+            verify shouldHaveResult "shouldHaveResult" $
             property True
   where
     haveResult :: Bool

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -331,8 +331,6 @@ spec = parallel $ describe "Cardano.WalletSpec" $ do
             (withMaxSuccess 10 $ property walletKeyIsReencrypted)
         it "Wallet can list transactions"
             (property walletListTransactionsSorted)
-        it "Wallet can list assets"
-            (property walletListAssets)
         it "Wallet won't list unrelated assets used in related transactions"
             (property walletListsOnlyRelatedAssets)
 
@@ -1418,7 +1416,7 @@ instance Sqlite.AddressBookIso DummyState where
 instance Eq (Sqlite.Prologue DummyState) where _ == _ = True
 instance Eq (Sqlite.Discoveries DummyState) where
     DummyDiscoveries a == DummyDiscoveries b = a == b
- 
+
 instance Sqlite.PersistAddressBook DummyState where
     insertPrologue _ _ = error "DummyState.insertPrologue: not implemented"
     insertDiscoveries _ _ _ = error "DummyState.insertDiscoveries: not implemented"

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -5633,8 +5633,8 @@ paths:
         List all assets associated with the wallet, and their metadata
         if known.
 
-        An asset is _associated_ with a wallet if it is involved in a
-        transaction of the wallet.
+        An asset is _associated_ with a wallet if, at one point in history,
+        it was spendable by the wallet.
       parameters:
         - *parametersWalletId
       responses: *responsesListAssets

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
     wait_for_all_shared_wallets(@nightly_shared_wallets)
     wait_for_all_byron_wallets(@nighly_byron_wallets)
 
-    # @wid_sha = "d20b7f812fb571e7a3b14fb8a13c595d32cad5e6"
+    # @wid_sha = "f7b49bb7d58f7986e2394fefdc459a0ce67f42fa"
     # @wid_rnd = "12cbebfdc4521766e63a7e07c4825b24deb4176c"
     # @wid_ic = "f5da82c1eb3e391a535dd5ba2867fe9bdaf2f313"
     # @wid = "a042bafdaf98844cfa8f6d4b1dc47519b21a4d95"
-    # @target_id = "daf9043925bfe12cd891c6c4495c108cdb120632"
+    # @target_id = "d11ceb4d63f69fa0e8a02927d3f866f5fb5f6112"
     # 1f82e83772b7579fc0854bd13db6a9cce21ccd95
     # 2269611a3c10b219b0d38d74b004c298b76d16a9
     # a042bafdaf98844cfa8f6d4b1dc47519b21a4d95
@@ -409,6 +409,17 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       verify_asset_balance(src_after, src_before,
                            target_after, target_before,
                            amt)
+
+      # Target wallet only lists my associated assets
+      assets = SHELLEY.assets.get(@target_id)
+      expect(assets).to be_correct_and_respond 200
+      expect(assets.size).to eq 2
+      expect(assets.to_s).to include ASSETS[0]["policy_id"]
+      expect(assets.to_s).to include ASSETS[0]["asset_name"]
+      expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
+      expect(assets.to_s).to include ASSETS[1]["policy_id"]
+      expect(assets.to_s).to include ASSETS[1]["asset_name"]
+      expect(assets.to_s).to include ASSETS[1]["metadata"]["name"]
     end
 
     it "Only withdrawal" do
@@ -633,10 +644,6 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
   describe "E2E Shelley" do
     describe "Native Assets" do
       it "I can list native assets" do
-        skip %(Underlying query is too large for token-metadata-server
-              which causes this test to fail as token-metadata-server returns 502.
-              ADP-710 should improve things a bit.)
-
         assets = SHELLEY.assets.get @wid
         expect(assets).to be_correct_and_respond 200
         expect(assets.to_s).to include ASSETS[0]["policy_id"]
@@ -1124,6 +1131,17 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       verify_asset_balance(src_after, src_before,
                            target_after, target_before,
                            amt)
+
+      # Target wallet only lists my associated assets
+      assets = SHELLEY.assets.get(target_id)
+      expect(assets).to be_correct_and_respond 200
+      expect(assets.size).to eq 2
+      expect(assets.to_s).to include ASSETS[0]["policy_id"]
+      expect(assets.to_s).to include ASSETS[0]["asset_name"]
+      expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
+      expect(assets.to_s).to include ASSETS[1]["policy_id"]
+      expect(assets.to_s).to include ASSETS[1]["asset_name"]
+      expect(assets.to_s).to include ASSETS[1]["metadata"]["name"]
     end
 
     describe "Byron Transactions" do


### PR DESCRIPTION
<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->
### Issue Number

ADP-710

#### Problematic current state:

list of wallet assets `WAs`  derived like this:

> for each transaction `T` in blockchain:  
>   if `T` has at least one output associated with the current wallet:  
>     add `T` to the list of Wallet transactions `WTs`;  

> for each transaction `T` in `WTs`:
>   for each output `O` of `T`: 
>     for each asset `A` in token bundle of `O`:
>       add `A` to the list of wallet assets `WAs`;

<details><summary><strong><s>Solution №1</s></strong> (unfoldable, superseded by the Solution №2, see below)</summary><p>

When restoring wallet state from blocks of transactions all transaction outputs that are not related to wallet address are omitted;

> for each transaction `T` in blockchain:   
> if `T` has at least one output associated with the current wallet:
> let `T'` be `T` with all unrelated* outputs removed;
> add `T'` to the list of wallet transactions `WTs`;

> for each transaction `T` in `WTs`:
> for each output `O` of `T`:
> for each asset `A` in token bundle of `O`:
> add `A` to the list of wallet assets `WAs`;

* output is considered to be unrelated if its address if not the one belonging to the wallet;

#### Consequences

* Wallet states collected before the fix contain transactions with all outputs (including unrelated) In order for the unrelated assets (those found in unrelated outputs) to disappear wallet state needs to be restored from scratch.

* Modified transactions `T'` are no longer valid as some of their outputs were omitted;
</p></details>

<details><summary><strong><s>Solution №2</s></strong> (unfoldable, superseded by the Solution №3, see below)</summary><p>

#### Solution №2

> for each transaction `T` in blockchain:   
> if `T` has at least one output associated with the current wallet:
> let `T'` be `T` with all outputs tagged with their belonging (ours/theirs) - `b(O)`;
> add `T'` to the list of wallet transactions `WTs`;

> for each transaction `T` in `WTs`:
> for each output `O` of `T`:
> if `b(O)` is not `Ours` then skip this `O`; 
> for each asset `A` in token bundle of `O`:
> add `A` to the list of wallet assets `WAs`;
</p></details>

#### Solution №3

> for each transaction `T` in `WTs`:
> for each output `O` of `T`:
> if `O` is not `Ours` then skip this `O`; 
> for each asset `A` in token bundle of `O`:
> add `A` to the list of wallet assets `WAs`;

### Ad-hoc improvements

- [x] Move asset extraction logic to the `Cardano.Wallet` module
- [x] Add an extra property test to cover transaction application. 