### PR TITLE
Fix link to hydra in e2e tests

### DIFF
--- a/test/e2e/helpers/utils.rb
+++ b/test/e2e/helpers/utils.rb
@@ -132,16 +132,16 @@ module Helpers
 
     def get_latest_binary_url
       if is_linux?
-        os = "linux"
+        os = "linux.musl.cardano-wallet-linux64"
       end
       if is_mac?
-        os = "macos"
+        os = "macos.intel.cardano-wallet-macos-intel"
       end
       if is_win?
-        os = "win"
+        os = "linux.windows.cardano-wallet-win64"
       end
 
-      "https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-#{os}64/latest/download-by-type/file/binary-dist"
+      "https://hydra.iohk.io/job/Cardano/cardano-wallet/#{os}/latest/download-by-type/file/binary-dist"
     end
 
     def get_latest_configs_base_url


### PR DESCRIPTION

- [x] I have updated the links to hydra in order to get latest binaries for testing

### Comments

Testing:
 - [Linux](https://github.com/input-output-hk/cardano-wallet/runs/5180336604?check_suite_focus=true) `v2022-01-18 (git revision: 6361a5a24522411c7325c03e333002375edaec26)` :heavy_check_mark: 
 - [Windows](https://github.com/input-output-hk/cardano-wallet/runs/5180340432?check_suite_focus=true) `v2022-01-18 (git revision: 6361a5a24522411c7325c03e333002375edaec26)` :heavy_check_mark: 
 - [MacOS](https://github.com/input-output-hk/cardano-wallet/runs/5180732270?check_suite_focus=true) `v2022-01-18 (git revision: 6361a5a24522411c7325c03e333002375edaec26)` :heavy_check_mark: 

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
