### PR TITLE
Use `(TxIn, Address)` as a unique input identifier within coin selection modules.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1493,7 +1493,7 @@ balanceTransaction
                 (internalUtxoAvailable, externalSelectedUtxo)
 
         let utxoAvailableForCollateral =
-                UTxOIndex.toUTxO internalUtxoAvailable
+                UTxOIndex.toMap internalUtxoAvailable
 
         -- NOTE: It is not possible to know the script execution cost in
         -- advance because it actually depends on the final transaction. Inputs
@@ -1868,7 +1868,7 @@ readWalletUTxOIndex
     -> ExceptT ErrNoSuchWallet IO (UTxOIndex InputId, Wallet s, Set Tx)
 readWalletUTxOIndex ctx wid = do
     (cp, _, pending) <- readWallet @ctx @s @k ctx wid
-    let utxo = UTxOIndex.fromUTxO $ utxoToInputMap $ availableUTxO @s pending cp
+    let utxo = UTxOIndex.fromMap $ utxoToInputMap $ availableUTxO @s pending cp
     return (utxo, cp, pending)
 
 -- | Calculate the minimum coin values required for a bunch of specified

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1466,7 +1466,7 @@ balanceTransaction
     -> ArgGenChange s
     -> (W.ProtocolParameters, Cardano.ProtocolParameters)
     -> TimeInterpreter (Either PastHorizonException)
-    -> (UTxOIndex, Wallet s, Set Tx)
+    -> (UTxOIndex InputId, Wallet s, Set Tx)
     -> PartialTx
     -> ExceptT ErrBalanceTx m SealedTx
 balanceTransaction
@@ -1865,7 +1865,7 @@ readWalletUTxOIndex
     :: forall ctx s k. HasDBLayer IO s k ctx
     => ctx
     -> WalletId
-    -> ExceptT ErrNoSuchWallet IO (UTxOIndex, Wallet s, Set Tx)
+    -> ExceptT ErrNoSuchWallet IO (UTxOIndex InputId, Wallet s, Set Tx)
 readWalletUTxOIndex ctx wid = do
     (cp, _, pending) <- readWallet @ctx @s @k ctx wid
     let utxo = UTxOIndex.fromUTxO $ utxoToInputMap $ availableUTxO @s pending cp

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1600,7 +1600,7 @@ selectCoins ctx genChange (ApiT wid) body = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 }
                 transform
@@ -1653,7 +1653,7 @@ selectCoinsForJoin ctx knownPools getPoolStatus pid wid = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 }
                 transform
@@ -1706,7 +1706,7 @@ selectCoinsForQuit ctx (ApiT wid) = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 }
                 transform
@@ -1974,7 +1974,7 @@ postTransactionOld ctx genChange (ApiT wid) body = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 }
                 (const Prelude.id)
@@ -2122,7 +2122,7 @@ postTransactionFeeOld ctx (ApiT wid) body = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 } getFee
               where getFee = const (selectionDelta TokenBundle.getCoin)
@@ -2227,7 +2227,7 @@ constructTransaction ctx genChange knownPools getPoolStatus (ApiT wid) body = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 } transform
 
@@ -2587,7 +2587,7 @@ joinStakePool ctx knownPools getPoolStatus apiPoolId (ApiT wid) body = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 }
                 (const Prelude.id)
@@ -2652,7 +2652,7 @@ delegationFee ctx (ApiT wid) = do
             , utxoAvailableForInputs =
                 UTxOSelection.fromIndex utxoAvailable
             , utxoAvailableForCollateral =
-                UTxOIndex.toUTxO utxoAvailable
+                UTxOIndex.toMap utxoAvailable
             , wallet
             } calcFee
       where
@@ -2702,7 +2702,7 @@ quitStakePool ctx (ApiT wid) body = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 }
                 (const Prelude.id)

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -1231,7 +1231,7 @@ selectMatchingQuantity filters limit s
         NoLimit -> False
 
     updateState
-        :: ((InputId, TokenBundle), UTxOIndex)
+        :: ((InputId, TokenBundle), UTxOIndex InputId)
         -> Maybe UTxOSelectionNonEmpty
     updateState ((i, _b), _remaining) = UTxOSelection.select i s
 

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Collateral.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Collateral.hs
@@ -61,6 +61,8 @@ module Cardano.Wallet.CoinSelection.Internal.Collateral
     )
     where
 
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -145,7 +147,7 @@ data SelectionParamsOf inputId = SelectionParams
 
 -- | The default type for 'SelectionParamsOf'.
 --
-type SelectionParams = SelectionParamsOf TxIn
+type SelectionParams = SelectionParamsOf InputId
 
 -- | Specifies an upper bound on the search space size.
 --
@@ -177,7 +179,7 @@ newtype SelectionResultOf inputId = SelectionResult
 
 -- | The default type for 'SelectionResultOf'.
 --
-type SelectionResult = SelectionResultOf TxIn
+type SelectionResult = SelectionResultOf InputId
 
 -- | A completely empty result, with no inputs selected.
 --
@@ -196,9 +198,15 @@ data SelectionCollateralErrorOf inputId = SelectionCollateralError
     }
     deriving (Eq, Generic, Show)
 
+-- TODO: ADP-1448:
+--
+-- Replace this type synonym with a type parameter on types that use it.
+--
+type InputId = (TxIn, Address)
+
 -- | The default type for `SelectionCollateralErrorOf`.
 --
-type SelectionCollateralError = SelectionCollateralErrorOf TxIn
+type SelectionCollateralError = SelectionCollateralErrorOf InputId
 
 -- | Selects coins for collateral.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
@@ -2,11 +2,12 @@
 -- Copyright: © 2018-2021 IOHK
 -- License: Apache-2.0
 --
--- Provides the 'UTxOIndex' type, which indexes a UTxO set by asset ID.
+-- Provides the 'UTxOIndex' type, which indexes a UTxO set by asset identifier.
 --
--- The index makes it possible to efficiently compute the subset of a UTxO
--- set containing a particular asset, or to select a UTxO entry containing
--- that asset, without having to search through the entire UTxO set.
+-- The index makes it possible to efficiently compute the subset of a UTxO set
+-- containing a particular asset, or to select just a single UTxO containing a
+-- particular asset, without having to search linearly through the entire UTxO
+-- set.
 --
 -- See the documentation for 'UTxOIndex' for more details.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
@@ -23,12 +23,12 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex
     -- * Construction
     , empty
     , singleton
+    , fromMap
     , fromSequence
-    , fromUTxO
 
     -- * Deconstruction
     , toList
-    , toUTxO
+    , toMap
 
     -- * Folding
     , fold

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
@@ -7,12 +7,28 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.UTxO.Gen
-    ( genUTxO, genUTxOLarge, genUTxOLargeN, shrinkUTxO )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address )
+import Cardano.Wallet.Primitive.Types.Address.Gen
+    ( genAddress, shrinkAddress )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle )
+import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
+    ( genTokenBundleSmallRangePositive, shrinkTokenBundleSmallRangePositive )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genTxIn, genTxInLargeRange, shrinkTxIn )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( UTxOIndex )
+import Control.Monad
+    ( replicateM )
+import Generics.SOP
+    ( NP (..) )
 import Test.QuickCheck
-    ( Gen )
+    ( Gen, choose, listOf, shrinkList, shrinkMapBy )
+import Test.QuickCheck.Extra
+    ( genSized2, genericRoundRobinShrink, (<:>), (<@>) )
 
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 
@@ -20,18 +36,49 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 -- Indices generated according to the size parameter
 --------------------------------------------------------------------------------
 
+-- TODO: ADP-1448:
+--
+-- Replace this type synonym with a type parameter on types that use it.
+--
+type InputId = (TxIn, Address)
+
 genUTxOIndex :: Gen UTxOIndex
-genUTxOIndex = UTxOIndex.fromUTxO <$> genUTxO
+genUTxOIndex = UTxOIndex.fromSequence <$> listOf genEntry
+  where
+    genEntry :: Gen (InputId, TokenBundle)
+    genEntry = (,) <$> genInputId <*> genTokenBundleSmallRangePositive
+
+    genInputId :: Gen InputId
+    genInputId = genSized2 genTxIn genAddress
 
 shrinkUTxOIndex :: UTxOIndex -> [UTxOIndex]
-shrinkUTxOIndex = fmap UTxOIndex.fromUTxO . shrinkUTxO . UTxOIndex.toUTxO
+shrinkUTxOIndex =
+    shrinkMapBy UTxOIndex.fromSequence UTxOIndex.toList (shrinkList shrinkEntry)
+  where
+    shrinkEntry :: (InputId, TokenBundle) -> [(InputId, TokenBundle)]
+    shrinkEntry = genericRoundRobinShrink
+        <@> shrinkInputId
+        <:> shrinkTokenBundleSmallRangePositive
+        <:> Nil
+
+    shrinkInputId :: InputId -> [InputId]
+    shrinkInputId = genericRoundRobinShrink
+        <@> shrinkTxIn
+        <:> shrinkAddress
+        <:> Nil
 
 --------------------------------------------------------------------------------
 -- Large indices
 --------------------------------------------------------------------------------
 
 genUTxOIndexLarge :: Gen UTxOIndex
-genUTxOIndexLarge = UTxOIndex.fromUTxO <$> genUTxOLarge
+genUTxOIndexLarge = genUTxOIndexLargeN =<< choose (1024, 4096)
 
 genUTxOIndexLargeN :: Int -> Gen UTxOIndex
-genUTxOIndexLargeN n = UTxOIndex.fromUTxO <$> genUTxOLargeN n
+genUTxOIndexLargeN n = UTxOIndex.fromSequence <$> replicateM n genEntry
+  where
+    genEntry :: Gen (InputId, TokenBundle)
+    genEntry = (,) <$> genInputId <*> genTokenBundleSmallRangePositive
+
+    genInputId :: Gen InputId
+    genInputId = (,) <$> genTxInLargeRange <*> genAddress

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
@@ -42,7 +42,7 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 --
 type InputId = (TxIn, Address)
 
-genUTxOIndex :: Gen UTxOIndex
+genUTxOIndex :: Gen (UTxOIndex InputId)
 genUTxOIndex = UTxOIndex.fromSequence <$> listOf genEntry
   where
     genEntry :: Gen (InputId, TokenBundle)
@@ -51,7 +51,7 @@ genUTxOIndex = UTxOIndex.fromSequence <$> listOf genEntry
     genInputId :: Gen InputId
     genInputId = genSized2 genTxIn genAddress
 
-shrinkUTxOIndex :: UTxOIndex -> [UTxOIndex]
+shrinkUTxOIndex :: UTxOIndex InputId -> [UTxOIndex InputId]
 shrinkUTxOIndex =
     shrinkMapBy UTxOIndex.fromSequence UTxOIndex.toList (shrinkList shrinkEntry)
   where
@@ -71,10 +71,10 @@ shrinkUTxOIndex =
 -- Large indices
 --------------------------------------------------------------------------------
 
-genUTxOIndexLarge :: Gen UTxOIndex
+genUTxOIndexLarge :: Gen (UTxOIndex InputId)
 genUTxOIndexLarge = genUTxOIndexLargeN =<< choose (1024, 4096)
 
-genUTxOIndexLargeN :: Int -> Gen UTxOIndex
+genUTxOIndexLargeN :: Int -> Gen (UTxOIndex InputId)
 genUTxOIndexLargeN n = UTxOIndex.fromSequence <$> replicateM n genEntry
   where
     genEntry :: Gen (InputId, TokenBundle)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -39,11 +39,11 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
     , empty
     , singleton
     , fromSequence
-    , fromUTxO
+    , fromMap
 
     -- * Deconstruction
     , toList
-    , toUTxO
+    , toMap
 
     -- * Folding
     , fold
@@ -215,8 +215,8 @@ fromSequence = flip insertMany empty
 -- Note that this operation is potentially expensive as it must construct an
 -- index from scratch, and therefore should only be used sparingly.
 --
-fromUTxO :: Ord u => Map u TokenBundle -> UTxOIndex u
-fromUTxO = fromSequence . Map.toList
+fromMap :: Ord u => Map u TokenBundle -> UTxOIndex u
+fromMap = fromSequence . Map.toList
 
 --------------------------------------------------------------------------------
 -- Deconstruction
@@ -233,8 +233,8 @@ toList = fold (\ubs u b -> (u, b) : ubs) []
 --
 -- Consider using 'fold' if your goal is to consume all entries in the output.
 --
-toUTxO :: UTxOIndex u -> Map u TokenBundle
-toUTxO = universe
+toMap :: UTxOIndex u -> Map u TokenBundle
+toMap = universe
 
 --------------------------------------------------------------------------------
 -- Folding

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
@@ -355,7 +355,7 @@ leftoverIndex = leftover . state
 -- | Retrieves the leftover UTxO set.
 --
 leftoverUTxO :: IsUTxOSelection u => u -> Map InputId TokenBundle
-leftoverUTxO = UTxOIndex.toUTxO . leftoverIndex
+leftoverUTxO = UTxOIndex.toMap . leftoverIndex
 
 -- | Retrieves a list of the leftover UTxOs.
 --
@@ -380,7 +380,7 @@ selectedIndex = selected . state
 -- | Retrieves the selected UTxO set.
 --
 selectedUTxO :: IsUTxOSelection u => u -> Map InputId TokenBundle
-selectedUTxO = UTxOIndex.toUTxO . selectedIndex
+selectedUTxO = UTxOIndex.toMap . selectedIndex
 
 --------------------------------------------------------------------------------
 -- Modification

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
@@ -149,9 +149,9 @@ type InputId = (TxIn, Address)
 -- | The internal state of a selection.
 --
 data State = State
-    { leftover :: !UTxOIndex
+    { leftover :: !(UTxOIndex InputId)
       -- ^ UTxOs that have not yet been selected.
-    , selected :: !UTxOIndex
+    , selected :: !(UTxOIndex InputId)
       -- ^ UTxOs that have already been selected.
     }
     deriving (Eq, Generic, Show)
@@ -195,7 +195,7 @@ empty = fromIndex UTxOIndex.empty
 --
 -- All UTxOs in the index will be added to the leftover set.
 --
-fromIndex :: UTxOIndex -> UTxOSelection
+fromIndex :: UTxOIndex InputId -> UTxOSelection
 fromIndex i = UTxOSelection State
     { leftover = i
     , selected = UTxOIndex.empty
@@ -206,7 +206,7 @@ fromIndex i = UTxOSelection State
 -- All UTxOs that match the given filter will be added to the selected set,
 -- whereas all UTxOs that do not match will be added to the leftover set.
 --
-fromIndexFiltered :: (InputId -> Bool) -> UTxOIndex -> UTxOSelection
+fromIndexFiltered :: (InputId -> Bool) -> UTxOIndex InputId -> UTxOSelection
 fromIndexFiltered f =
     UTxOSelection . uncurry State . swap . UTxOIndex.partition f
 
@@ -217,7 +217,7 @@ fromIndexFiltered f =
 --
 -- Any items that are in both sets are removed from the leftover set.
 --
-fromIndexPair :: (UTxOIndex, UTxOIndex) -> UTxOSelection
+fromIndexPair :: (UTxOIndex InputId, UTxOIndex InputId) -> UTxOSelection
 fromIndexPair (leftover, selected) =
     UTxOSelection State
         { leftover = leftover `UTxOIndex.difference` selected
@@ -229,7 +229,7 @@ fromIndexPair (leftover, selected) =
 -- The 1st index in the pair represents the leftover set.
 -- The 2nd index in the pair represents the selected set.
 --
-toIndexPair :: IsUTxOSelection u => u -> (UTxOIndex, UTxOIndex)
+toIndexPair :: IsUTxOSelection u => u -> (UTxOIndex InputId, UTxOIndex InputId)
 toIndexPair s = (leftoverIndex s, selectedIndex s)
 
 --------------------------------------------------------------------------------
@@ -349,7 +349,7 @@ leftoverSize = UTxOIndex.size . leftoverIndex
 
 -- | Retrieves an index of the leftover UTxOs.
 --
-leftoverIndex :: IsUTxOSelection u => u -> UTxOIndex
+leftoverIndex :: IsUTxOSelection u => u -> UTxOIndex InputId
 leftoverIndex = leftover . state
 
 -- | Retrieves the leftover UTxO set.
@@ -374,7 +374,7 @@ selectedSize = UTxOIndex.size . selectedIndex
 
 -- | Retrieves an index of the selected UTxOs.
 --
-selectedIndex :: IsUTxOSelection u => u -> UTxOIndex
+selectedIndex :: IsUTxOSelection u => u -> UTxOIndex InputId
 selectedIndex = selected . state
 
 -- | Retrieves the selected UTxO set.

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -518,7 +518,7 @@ spec = describe "Cardano.Wallet.CoinSelection.Internal.BalanceSpec" $
 -- Coverage
 --------------------------------------------------------------------------------
 
-prop_Small_UTxOIndex_coverage :: Small UTxOIndex -> Property
+prop_Small_UTxOIndex_coverage :: Small (UTxOIndex InputId) -> Property
 prop_Small_UTxOIndex_coverage (Small index) =
     checkCoverage $ property
         -- Asset counts:
@@ -540,7 +540,7 @@ prop_Small_UTxOIndex_coverage (Small index) =
     assetCount = Set.size $ UTxOIndex.assets index
     entryCount = UTxOIndex.size index
 
-prop_Large_UTxOIndex_coverage :: Large UTxOIndex -> Property
+prop_Large_UTxOIndex_coverage :: Large (UTxOIndex InputId) -> Property
 prop_Large_UTxOIndex_coverage (Large index) =
     -- Generation of large UTxO sets takes longer, so limit the number of runs:
     withMaxSuccess 100 $ checkCoverage $ property
@@ -610,7 +610,7 @@ type PerformSelectionResult = Either SelectionBalanceError SelectionResult
 
 genSelectionParams
     :: Gen (InputId -> Bool)
-    -> Gen UTxOIndex
+    -> Gen (UTxOIndex InputId)
     -> Gen SelectionParams
 genSelectionParams genPreselectedInputs genUTxOIndex' = do
     utxoAvailable <- genUTxOIndex'
@@ -637,7 +637,7 @@ genSelectionParams genPreselectedInputs genUTxOIndex' = do
         , assetsToBurn
         }
   where
-    genAssetsToMintAndBurn :: UTxOIndex -> Gen (TokenMap, TokenMap)
+    genAssetsToMintAndBurn :: UTxOIndex InputId -> Gen (TokenMap, TokenMap)
     genAssetsToMintAndBurn utxoAvailable = do
         assetsToMint <- genTokenMapSmallRange
         let assetsToBurn = adjustAllTokenMapQuantities
@@ -864,7 +864,7 @@ prop_performSelection_huge = ioProperty $
         <$> generate (genUTxOIndexLargeN 50000)
 
 prop_performSelection_huge_inner
-    :: UTxOIndex
+    :: UTxOIndex InputId
     -> MockSelectionConstraints
     -> Large SelectionParams
     -> Property
@@ -1359,7 +1359,7 @@ prop_runSelection_UTxO_moreThanEnough utxoAvailable = monadicIO $ do
         cutAssetSetSizeInHalf balanceAvailable
 
 prop_runSelection_UTxO_muchMoreThanEnough
-    :: Blind (Large UTxOIndex)
+    :: Blind (Large (UTxOIndex InputId))
     -> Property
 prop_runSelection_UTxO_muchMoreThanEnough (Blind (Large index)) =
     -- Generation of large UTxO sets takes longer, so limit the number of runs:
@@ -1577,7 +1577,7 @@ prop_runSelectionStep_exceedsTargetAndGetsFurtherAway
 --------------------------------------------------------------------------------
 
 prop_assetSelectionLens_givesPriorityToSingletonAssets
-    :: Blind (Small UTxOIndex)
+    :: Blind (Small (UTxOIndex InputId))
     -> Property
 prop_assetSelectionLens_givesPriorityToSingletonAssets (Blind (Small u)) =
     assetCount >= 2 ==> monadicIO $ do
@@ -1613,7 +1613,7 @@ prop_assetSelectionLens_givesPriorityToSingletonAssets (Blind (Small u)) =
     minimumAssetQuantity = TokenQuantity 1
 
 prop_coinSelectionLens_givesPriorityToCoins
-    :: Blind (Small UTxOIndex)
+    :: Blind (Small (UTxOIndex InputId))
     -> Property
 prop_coinSelectionLens_givesPriorityToCoins (Blind (Small u)) =
     entryCount > 0 ==> monadicIO $ do
@@ -4090,11 +4090,11 @@ instance Arbitrary (Small SelectionParams) where
         (genUTxOIndex)
     shrink = shrinkMapBy Small getSmall shrinkSelectionParams
 
-instance Arbitrary (Large UTxOIndex) where
+instance Arbitrary (Large (UTxOIndex InputId)) where
     arbitrary = Large <$> genUTxOIndexLarge
     shrink = shrinkMapBy Large getLarge shrinkUTxOIndex
 
-instance Arbitrary (Small UTxOIndex) where
+instance Arbitrary (Small (UTxOIndex InputId)) where
     arbitrary = Small <$> genUTxOIndex
     shrink = shrinkMapBy Small getSmall shrinkUTxOIndex
 

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -140,9 +140,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , txOutMaxTokenQuantity
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxInFunction, genTxOut, shrinkTxOut )
-import Cardano.Wallet.Primitive.Types.UTxO
-    ( UTxO (..) )
+    ( genTxOut, shrinkTxOut )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( SelectionFilter (..), UTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
@@ -174,7 +172,7 @@ import Data.List.NonEmpty
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
-    ( fromMaybe, isJust, isNothing )
+    ( fromMaybe, isJust, isNothing, listToMaybe )
 import Data.Set
     ( Set )
 import Data.Tuple
@@ -182,7 +180,7 @@ import Data.Tuple
 import Data.Word
     ( Word64, Word8 )
 import Fmt
-    ( blockListF, pretty )
+    ( Buildable (..), blockListF, pretty )
 import Generics.SOP
     ( NP (..) )
 import GHC.Generics
@@ -209,6 +207,7 @@ import Test.QuickCheck
     , arbitraryBoundedEnum
     , checkCoverage
     , choose
+    , coarbitrary
     , conjoin
     , counterexample
     , cover
@@ -234,7 +233,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Classes
     ( eqLaws, ordLaws )
 import Test.QuickCheck.Extra
-    ( genericRoundRobinShrink, report, verify, (<:>), (<@>) )
+    ( genFunction, genericRoundRobinShrink, report, verify, (<:>), (<@>) )
 import Test.QuickCheck.Monadic
     ( PropertyM (..), assert, monadicIO, monitor, run )
 import Test.Utils.Laws
@@ -253,6 +252,33 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
+
+-- TODO: ADP-1448:
+--
+-- Replace this type synonym with a type parameter on types that use it.
+--
+type InputId = (TxIn, Address)
+
+-- TODO: ADP-1448:
+--
+-- Remove this instance once 'InputId' has been replaced with a type parameter.
+--
+instance Buildable (InputId, TokenBundle) where
+    build ((i, a), b) = build i <> ":" <> build a <> ":" <> build (Flat b)
+
+-- TODO: ADP-1448:
+--
+-- Remove this function once 'InputId' has been replaced with a type parameter.
+--
+coarbitraryInputId :: InputId -> Gen a -> Gen a
+coarbitraryInputId = coarbitrary . show
+
+-- TODO: ADP-1448:
+--
+-- Remove this function once 'InputId' has been replaced with a type parameter.
+--
+genInputIdFunction :: Gen a -> Gen (InputId -> a)
+genInputIdFunction = genFunction coarbitraryInputId
 
 spec :: Spec
 spec = describe "Cardano.Wallet.CoinSelection.Internal.BalanceSpec" $
@@ -582,7 +608,10 @@ prop_AssetCount_TokenMap_placesEmptyMapsFirst maps =
 --
 type PerformSelectionResult = Either SelectionBalanceError SelectionResult
 
-genSelectionParams :: Gen (TxIn -> Bool) -> Gen UTxOIndex -> Gen SelectionParams
+genSelectionParams
+    :: Gen (InputId -> Bool)
+    -> Gen UTxOIndex
+    -> Gen SelectionParams
 genSelectionParams genPreselectedInputs genUTxOIndex' = do
     utxoAvailable <- genUTxOIndex'
     isInputPreselected <- oneof
@@ -619,7 +648,7 @@ genSelectionParams genPreselectedInputs genUTxOIndex' = do
         utxoAvailableAssets :: TokenMap
         utxoAvailableAssets = view (#balance . #tokens) utxoAvailable
 
-    genPreselectedInputsNone :: Gen (TxIn -> Bool)
+    genPreselectedInputsNone :: Gen (InputId -> Bool)
     genPreselectedInputsNone = pure $ const False
 
 shrinkSelectionParams :: SelectionParams -> [SelectionParams]
@@ -1203,8 +1232,8 @@ mockPerformSelectionNonEmpty constraints params = Identity $ Right result
         , outputsCovered = view #outputsToCover params
         }
 
-    makeInputsOfValue :: TokenBundle -> NonEmpty (TxIn, TokenBundle)
-    makeInputsOfValue v = (TxIn (Hash "") 0, v) :| []
+    makeInputsOfValue :: TokenBundle -> NonEmpty (InputId, TokenBundle)
+    makeInputsOfValue v = ((TxIn (Hash "") 0, Address ""), v) :| []
 
     makeChangeOfValue :: TokenBundle -> [TokenBundle]
     makeChangeOfValue v = [v]
@@ -1432,11 +1461,12 @@ mockSelectSingleEntry :: UTxOSelection -> Maybe UTxOSelectionNonEmpty
 mockSelectSingleEntry state =
     selectEntry =<< firstLeftoverEntry state
   where
-    firstLeftoverEntry :: UTxOSelection -> Maybe (TxIn, TxOut)
-    firstLeftoverEntry = Map.lookupMin . unUTxO . UTxOSelection.leftoverUTxO
+    firstLeftoverEntry :: UTxOSelection -> Maybe (InputId, TokenBundle)
+    firstLeftoverEntry =
+        listToMaybe . UTxOIndex.toList . UTxOSelection.leftoverIndex
 
-    selectEntry :: (TxIn, TxOut) -> Maybe UTxOSelectionNonEmpty
-    selectEntry (i, _o) = UTxOSelection.select i state
+    selectEntry :: (InputId, TokenBundle) -> Maybe UTxOSelectionNonEmpty
+    selectEntry (i, _b) = UTxOSelection.select i state
 
 --------------------------------------------------------------------------------
 -- Running a selection step
@@ -1567,8 +1597,7 @@ prop_assetSelectionLens_givesPriorityToSingletonAssets (Blind (Small u)) =
                 monitor $ counterexample "Error: unable to select any entry"
                 assert False
             Just result -> do
-                let output = NE.head $ snd <$> UTxOSelection.selectedList result
-                let bundle = view #tokens output
+                let bundle = NE.head $ snd <$> UTxOSelection.selectedList result
                 case F.toList $ TokenBundle.getAssets bundle of
                     [a] -> assertWith
                         "a == asset"
@@ -1603,8 +1632,7 @@ prop_coinSelectionLens_givesPriorityToCoins (Blind (Small u)) =
                 monitor $ counterexample "Error: unable to select any entry"
                 assert False
             Just result -> do
-                let output = NE.head $ snd <$> UTxOSelection.selectedList result
-                let bundle = view #tokens output
+                let bundle = NE.head $ snd <$> UTxOSelection.selectedList result
                 case F.toList $ TokenBundle.getAssets bundle of
                     [] -> assertWith     "hasCoin" (    hasCoin)
                     _  -> assertWith "not hasCoin" (not hasCoin)
@@ -1672,10 +1700,8 @@ encodeBoundaryTestCriteria c = SelectionParams
     , utxoAvailable =
         UTxOSelection.fromIndex
         $ UTxOIndex.fromSequence
-        $ zip dummyTxIns
-        $ zipWith TxOut
-            (dummyAddresses)
-            (uncurry TokenBundle.fromFlatList <$> boundaryTestUTxO c)
+        $ zip dummyInputIds
+        $ uncurry TokenBundle.fromFlatList <$> boundaryTestUTxO c
     , extraCoinSource =
         Coin 0
     , extraCoinSink =
@@ -1686,6 +1712,9 @@ encodeBoundaryTestCriteria c = SelectionParams
         TokenMap.empty
     }
   where
+    dummyInputIds :: [InputId]
+    dummyInputIds = zip dummyTxIns dummyAddresses
+
     dummyAddresses :: [Address]
     dummyAddresses = [Address (B8.pack $ show x) | x :: Word64 <- [0 ..]]
 
@@ -4051,13 +4080,13 @@ newtype Small a = Small
 
 instance Arbitrary (Large SelectionParams) where
     arbitrary = Large <$> genSelectionParams
-        (genTxInFunction (arbitrary @Bool))
+        (genInputIdFunction (arbitrary @Bool))
         (genUTxOIndexLarge)
     shrink = shrinkMapBy Large getLarge shrinkSelectionParams
 
 instance Arbitrary (Small SelectionParams) where
     arbitrary = Small <$> genSelectionParams
-        (genTxInFunction (arbitrary @Bool))
+        (genInputIdFunction (arbitrary @Bool))
         (genUTxOIndex)
     shrink = shrinkMapBy Small getSmall shrinkSelectionParams
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -576,8 +576,10 @@ prop_selectRandom_all_withAdaOnly u = checkCoverage $ monadicIO $ do
     (selectedEntries, u') <- run $ selectAll WithAdaOnly u
     monitor $ cover 70 (not (null selectedEntries))
         "selected at least one entry"
-    assert $ L.all (\(_, o) -> not (tokenBundleIsAdaOnly o)) (UTxOIndex.toList u')
-    assert $ L.all (\(_, o) -> tokenBundleIsAdaOnly o) selectedEntries
+    assert $ L.all (\(_, o) ->
+        not (tokenBundleIsAdaOnly o)) (UTxOIndex.toList u')
+    assert $ L.all (\(_, o) ->
+        tokenBundleIsAdaOnly o) selectedEntries
     assert $ UTxOIndex.deleteMany (fst <$> selectedEntries) u == u'
     assert $ UTxOIndex.insertMany selectedEntries u' == u
 
@@ -592,8 +594,10 @@ prop_selectRandom_all_withAsset u a = checkCoverage $ monadicIO $ do
         "index has more than one asset"
     monitor $ cover 50 (not (null selectedEntries))
         "selected at least one entry"
-    assert $ L.all (\(_, o) -> not (tokenBundleHasAsset o a)) (UTxOIndex.toList u')
-    assert $ L.all (\(_, o) -> tokenBundleHasAsset o a) selectedEntries
+    assert $ L.all (\(_, o) ->
+        not (tokenBundleHasAsset o a)) (UTxOIndex.toList u')
+    assert $ L.all (\(_, o) ->
+        tokenBundleHasAsset o a) selectedEntries
     assert $ UTxOIndex.deleteMany (fst <$> selectedEntries) u == u'
     assert $ UTxOIndex.insertMany selectedEntries u' == u
     assert $ a `Set.notMember` UTxOIndex.assets u'
@@ -609,8 +613,10 @@ prop_selectRandom_all_withAssetOnly u a = checkCoverage $ monadicIO $ do
         "index has more than one asset"
     monitor $ cover 10 (not (null selectedEntries))
         "selected at least one entry"
-    assert $ all (\(_, o) -> not (tokenBundleHasAssetOnly o a)) (UTxOIndex.toList u')
-    assert $ all (\(_, o) -> tokenBundleHasAssetOnly o a) selectedEntries
+    assert $ all (\(_, o) ->
+        not (tokenBundleHasAssetOnly o a)) (UTxOIndex.toList u')
+    assert $ all (\(_, o) ->
+        tokenBundleHasAssetOnly o a) selectedEntries
     assert $ UTxOIndex.deleteMany (fst <$> selectedEntries) u == u'
     assert $ UTxOIndex.insertMany selectedEntries u' == u
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -384,7 +384,7 @@ checkCoverage_filter_partition f u
   where
     u1 `isNonEmptyProperSubsetOf` u2 =
         not (UTxOIndex.null u1)
-        && UTxOIndex.toUTxO u1 `Map.isSubmapOf` UTxOIndex.toUTxO u2
+        && UTxOIndex.toMap u1 `Map.isSubmapOf` UTxOIndex.toMap u2
         && u1 /= u2
 
     filterSize g = UTxOIndex.size . UTxOIndex.filter g

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
@@ -193,27 +193,31 @@ checkCoverage_UTxOSelectionNonEmpty s
 -- Construction and deconstruction
 --------------------------------------------------------------------------------
 
-prop_fromIndex_isValid :: UTxOIndex -> Property
+prop_fromIndex_isValid :: UTxOIndex InputId -> Property
 prop_fromIndex_isValid u =
     isValidSelection (UTxOSelection.fromIndex u)
     === True
 
-prop_fromIndexFiltered_isValid :: (InputId -> Bool) -> UTxOIndex -> Property
+prop_fromIndexFiltered_isValid
+    :: (InputId -> Bool) -> UTxOIndex InputId -> Property
 prop_fromIndexFiltered_isValid f u =
     isValidSelection (UTxOSelection.fromIndexFiltered f u)
     === True
 
-prop_fromIndexPair_isValid :: (UTxOIndex, UTxOIndex) -> Property
+prop_fromIndexPair_isValid :: (UTxOIndex InputId, UTxOIndex InputId) -> Property
 prop_fromIndexPair_isValid (u1, u2) =
     isValidSelection (UTxOSelection.fromIndexPair (u1, u2))
     === True
 
-prop_fromIndex_toIndexPair :: UTxOIndex -> Property
+prop_fromIndex_toIndexPair :: UTxOIndex InputId-> Property
 prop_fromIndex_toIndexPair u =
     UTxOSelection.toIndexPair (UTxOSelection.fromIndex u)
     === (u, UTxOIndex.empty)
 
-prop_fromIndexFiltered_toIndexPair :: (InputId -> Bool) -> UTxOIndex -> Property
+prop_fromIndexFiltered_toIndexPair
+    :: (InputId -> Bool)
+    -> UTxOIndex InputId
+    -> Property
 prop_fromIndexFiltered_toIndexPair f u =
     UTxOSelection.toIndexPair (UTxOSelection.fromIndexFiltered f u)
     === (UTxOIndex.filter (not . f) u, UTxOIndex.filter f u)
@@ -423,7 +427,7 @@ instance {-# OVERLAPPING #-} Arbitrary InputId where
         <:> shrinkAddress
         <:> Nil
 
-instance Arbitrary UTxOIndex where
+instance Arbitrary (UTxOIndex InputId) where
     arbitrary = genUTxOIndex
     shrink = shrinkUTxOIndex
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
@@ -9,6 +9,10 @@ module Cardano.Wallet.Primitive.Types.UTxOSelectionSpec
 
 import Prelude
 
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address )
+import Cardano.Wallet.Primitive.Types.Address.Gen
+    ( coarbitraryAddress, genAddress, shrinkAddress )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxIn )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
@@ -25,6 +29,8 @@ import Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
     , shrinkUTxOSelection
     , shrinkUTxOSelectionNonEmpty
     )
+import Generics.SOP
+    ( NP (..) )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.Hspec.Extra
@@ -41,11 +47,19 @@ import Test.QuickCheck
     , property
     , (===)
     )
+import Test.QuickCheck.Extra
+    ( genSized2, genericRoundRobinShrink, (<:>), (<@>) )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
-import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
+import qualified Data.Foldable as F
+
+-- TODO: ADP-1448:
+--
+-- Replace this type synonym with a type parameter on types that use it.
+--
+type InputId = (TxIn, Address)
 
 spec :: Spec
 spec =
@@ -184,7 +198,7 @@ prop_fromIndex_isValid u =
     isValidSelection (UTxOSelection.fromIndex u)
     === True
 
-prop_fromIndexFiltered_isValid :: (TxIn -> Bool) -> UTxOIndex -> Property
+prop_fromIndexFiltered_isValid :: (InputId -> Bool) -> UTxOIndex -> Property
 prop_fromIndexFiltered_isValid f u =
     isValidSelection (UTxOSelection.fromIndexFiltered f u)
     === True
@@ -199,7 +213,7 @@ prop_fromIndex_toIndexPair u =
     UTxOSelection.toIndexPair (UTxOSelection.fromIndex u)
     === (u, UTxOIndex.empty)
 
-prop_fromIndexFiltered_toIndexPair :: (TxIn -> Bool) -> UTxOIndex -> Property
+prop_fromIndexFiltered_toIndexPair :: (InputId -> Bool) -> UTxOIndex -> Property
 prop_fromIndexFiltered_toIndexPair f u =
     UTxOSelection.toIndexPair (UTxOSelection.fromIndexFiltered f u)
     === (UTxOIndex.filter (not . f) u, UTxOIndex.filter f u)
@@ -234,7 +248,7 @@ prop_availableBalance_availableUTxO :: UTxOSelection -> Property
 prop_availableBalance_availableUTxO s =
     checkCoverage_UTxOSelection s $
     UTxOSelection.availableBalance s
-    === UTxO.balance (UTxOSelection.availableUTxO s)
+    === F.fold (UTxOSelection.availableUTxO s)
 
 prop_isNonEmpty_selectedSize :: UTxOSelection -> Property
 prop_isNonEmpty_selectedSize s =
@@ -276,37 +290,37 @@ prop_leftoverSize_selectedSize s =
 -- Modification
 --------------------------------------------------------------------------------
 
-prop_select_empty :: TxIn -> Property
+prop_select_empty :: InputId -> Property
 prop_select_empty i =
     UTxOSelection.select i UTxOSelection.empty === Nothing
 
-prop_select_isValid :: TxIn -> UTxOSelection -> Property
+prop_select_isValid :: InputId -> UTxOSelection -> Property
 prop_select_isValid i s = property $
     checkCoverage_select i s $
     maybe True isValidSelectionNonEmpty (UTxOSelection.select i s)
 
-prop_select_isLeftover :: TxIn -> UTxOSelection -> Property
+prop_select_isLeftover :: InputId -> UTxOSelection -> Property
 prop_select_isLeftover i s =
     checkCoverage_select i s $
     (UTxOSelection.isLeftover i <$> UTxOSelection.select i s)
     ===
     if UTxOSelection.isLeftover i s then Just False else Nothing
 
-prop_select_isSelected :: TxIn -> UTxOSelection -> Property
+prop_select_isSelected :: InputId -> UTxOSelection -> Property
 prop_select_isSelected i s =
     checkCoverage_select i s $
     (UTxOSelection.isSelected i <$> UTxOSelection.select i s)
     ===
     if UTxOSelection.isLeftover i s then Just True else Nothing
 
-prop_select_isProperSubSelectionOf :: TxIn -> UTxOSelection -> Property
+prop_select_isProperSubSelectionOf :: InputId -> UTxOSelection -> Property
 prop_select_isProperSubSelectionOf i s =
     checkCoverage_select i s $
     (UTxOSelection.isProperSubSelectionOf s <$> UTxOSelection.select i s)
     ===
     if UTxOSelection.isLeftover i s then Just True else Nothing
 
-prop_select_availableBalance :: TxIn -> UTxOSelection -> Property
+prop_select_availableBalance :: InputId -> UTxOSelection -> Property
 prop_select_availableBalance i s =
     checkCoverage_select i s $
     (UTxOSelection.availableBalance <$> UTxOSelection.select i s)
@@ -315,7 +329,7 @@ prop_select_availableBalance i s =
     then Just (UTxOSelection.availableBalance s)
     else Nothing
 
-prop_select_availableUTxO :: TxIn -> UTxOSelection -> Property
+prop_select_availableUTxO :: InputId -> UTxOSelection -> Property
 prop_select_availableUTxO i s =
     checkCoverage_select i s $
     (UTxOSelection.availableUTxO <$> UTxOSelection.select i s)
@@ -324,7 +338,7 @@ prop_select_availableUTxO i s =
     then Just (UTxOSelection.availableUTxO s)
     else Nothing
 
-prop_select_leftoverSize :: TxIn -> UTxOSelection -> Property
+prop_select_leftoverSize :: InputId -> UTxOSelection -> Property
 prop_select_leftoverSize i s =
     checkCoverage_select i s $
     (UTxOSelection.leftoverSize <$> UTxOSelection.select i s)
@@ -333,7 +347,7 @@ prop_select_leftoverSize i s =
     then Just (UTxOSelection.leftoverSize s - 1)
     else Nothing
 
-prop_select_selectedSize :: TxIn -> UTxOSelection -> Property
+prop_select_selectedSize :: InputId -> UTxOSelection -> Property
 prop_select_selectedSize i s =
     checkCoverage_select i s $
     (UTxOSelection.selectedSize <$> UTxOSelection.select i s)
@@ -342,7 +356,8 @@ prop_select_selectedSize i s =
     then Just (UTxOSelection.selectedSize s + 1)
     else Nothing
 
-prop_selectMany_isSubSelectionOf :: (TxIn -> Bool) -> UTxOSelection -> Property
+prop_selectMany_isSubSelectionOf
+    :: (InputId -> Bool) -> UTxOSelection -> Property
 prop_selectMany_isSubSelectionOf f s =
     checkCoverage_UTxOSelection s $
     UTxOSelection.isSubSelectionOf s (UTxOSelection.selectMany toSelect s)
@@ -365,7 +380,7 @@ prop_selectMany_selectedSize_all s =
     === (UTxOSelection.leftoverSize s + UTxOSelection.selectedSize s)
 
 checkCoverage_select
-    :: Testable prop => TxIn -> UTxOSelection -> (prop -> Property)
+    :: Testable prop => InputId -> UTxOSelection -> (prop -> Property)
 checkCoverage_select i s
     = checkCoverage
     . cover 10 (UTxOSelection.isLeftover i s)
@@ -396,9 +411,17 @@ isValidSelectionNonEmpty s =
 -- Arbitrary instances
 --------------------------------------------------------------------------------
 
-instance Arbitrary TxIn where
-    arbitrary = genTxIn
-    shrink = shrinkTxIn
+-- TODO: ADP-1448:
+--
+-- Replace this instance with one for a mock input identifier, after the type
+-- of input identifier has been made into a type parameter.
+--
+instance {-# OVERLAPPING #-} Arbitrary InputId where
+    arbitrary = genSized2 genTxIn genAddress
+    shrink = genericRoundRobinShrink
+        <@> shrinkTxIn
+        <:> shrinkAddress
+        <:> Nil
 
 instance Arbitrary UTxOIndex where
     arbitrary = genUTxOIndex
@@ -416,6 +439,9 @@ instance Arbitrary UTxOSelectionNonEmpty where
 -- CoArbitrary instances
 --------------------------------------------------------------------------------
 
+instance CoArbitrary Address where
+    coarbitrary = coarbitraryAddress
+
 instance CoArbitrary TxIn where
     coarbitrary = coarbitraryTxIn
 
@@ -423,5 +449,5 @@ instance CoArbitrary TxIn where
 -- Show instances
 --------------------------------------------------------------------------------
 
-instance Show (TxIn -> Bool) where
-    show = const "(TxIn -> Bool)"
+instance Show (InputId -> Bool) where
+    show = const "(InputId -> Bool)"

--- a/lib/shelley/bench/restore-bench.hs
+++ b/lib/shelley/bench/restore-bench.hs
@@ -466,7 +466,7 @@ benchmarksRnd _ w wid wname benchname restoreTime = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 } getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection
@@ -569,7 +569,7 @@ benchmarksSeq _ w wid _wname benchname restoreTime = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 } getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2022,7 +2022,10 @@ instance Arbitrary Wallet' where
         let s = mkSeqStateFromRootXPrv (rootK mw) purposeCIP1852 defaultAddressPoolGap
 
         return $ Wallet'
-            (UTxOIndex.fromUTxO utxo)
+            (UTxOIndex.fromSequence
+                $ fmap (\(i, TxOut a b) -> ((i, a), b))
+                $ Map.toList
+                $ unUTxO utxo)
             (unsafeInitWallet utxo (header block0) s)
             mempty
       where
@@ -2048,11 +2051,16 @@ instance Arbitrary Wallet' where
         setUTxO :: UTxO -> Wallet' -> Wallet'
         setUTxO u (Wallet' _ wal pending) =
             Wallet'
-                (UTxOIndex.fromUTxO u)
+                (UTxOIndex.fromSequence
+                    $ fmap (\(i, TxOut a b) -> ((i, a), b))
+                    $ Map.toList
+                    $ unUTxO u)
                 (wal { utxo = u})
                 pending
 
-        getUTxO (Wallet' u _ _) = UTxOIndex.toUTxO u
+        getUTxO (Wallet' u _ _) = UTxO
+            $ Map.fromList
+            $ (\((i, a), b) -> (i, TxOut a b)) <$> UTxOIndex.toList u
 
         shrinkUTxO' u
             | UTxO.size u > 1 && simplifyUTxO u /= u

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2006,7 +2006,16 @@ instance MonadRandom Gen where
     getRandomR range = mkGen (fst . randomR range)
     getRandomRs range = mkGen (randomRs range)
 
-data Wallet' = Wallet' UTxOIndex (Wallet (SeqState 'Mainnet ShelleyKey)) (Set Tx)
+-- TODO: ADP-1448:
+--
+-- Replace this type synonym with a type parameter on types that use it.
+--
+type InputId = (TxIn, Address)
+
+data Wallet' = Wallet'
+    (UTxOIndex InputId)
+    (Wallet (SeqState 'Mainnet ShelleyKey))
+    (Set Tx)
 
 instance Show Wallet' where
     show (Wallet' u w pending) = fmt $ mconcat


### PR DESCRIPTION
## Issue Number

ADP-1417

## Background

We eventually want to change the internal coin selection library so that it:
- does not depend on the following wallet-specific types:
    - `TxIn`
    - `TxOut`
    - `Address`
    - `UTxO`
- produces selections of the form:
    ```haskell
    data Selection input = Selection
        { inputs     = [(input, TokenBundle)]
        , collateral = [(input, Coin       )]
        , ...
        }
    ```
    (where `input` is a **_type parameter_** that **_uniquely_** identifies a selected input)

However, the **_wallet_** currently expects to manipulate selections of the following form:
```haskell
data Selection = Selection
    { inputs =     [(TxIn, TxOut)]
    , collateral = [(TxIn, TxOut)]
    , ...
    }
```

Since (for the time being) we wish to avoid making major changes to the wallet codebase, we need a way to translate a `Selection` produced by the internal algorithm to a wallet-friendly `Selection`.

One way to achieve this is to instantiate type `input` as `(TxIn, Address)`, so that our internal selection type is instantiated to:
```haskell
data Selection = Selection
    { inputs     = [((TxIn, Address), TokenBundle)]
    , collateral = [((TxIn, Address), Coin       )]
    , ...
    }
```

With this substitution, it's trivial to convert from internal `Selection` values to wallet-friendly `Selection` values, because the choice of concrete type for `input` has all the context necessary to reconstruct a `(TxIn, TxOut)` pair.

## This PR

This PR **_doesn't_** introduce any new type parameters, but instead makes an evolutionary step **_towards_** the goal outlined above.

This PR:
  - [x] Introduces a (temporary) type synonym `InputId = (TxIn, Address)`.
  - [x] Amends core coin selection modules to use `InputId` as the unique identifier for inputs.
  - [x] Amends core coin selection modules so that they no longer depend on the `TxOut` and `UTxO` types.
  - [x] Amends the `readWalletUTxOIndex` function to perform the translation from `UTxO` (equivalent to `Map TxIn TxOut`) to `Map InputId TokenBundle`.
  - [x] Amends the wallet-facing `Cardano.Wallet.CoinSelection` module to perform the reverse translation from `(InputId, TokenBundle)` pairs to `(TxIn, TxOut)` pairs.

## Future Work

A **future PR** will replace the `InputId` type synonym with a type parameter on the following types:
  - `Selection`
  - `SelectionParams`
  - `UTxOIndex`
  - `UTxOSelection`

## Performance Considerations

It's important that the translations stated above do not add any performance overhead. 
- The translation from `(TxIn, TxOut)` to `(InputId, TokenBundle)` within `readWalletUTxOIndex` does need to traverse the UTxO, but it only does so a single time. It was already necessary to traverse the UTxO in order to construct the `UTxOIndex`. When estimating a fee, the function `readWalletUTxOIndex` is only evaluated a single time.
- The translation from `(InputId, TokenBundle)` to `(TxIn, TxOut)` is only applied to the inputs that are eventually selected.