### PR TITLE
Generalize UTxO identifier type within `UTxOIndex`.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1493,7 +1493,7 @@ balanceTransaction
                 (internalUtxoAvailable, externalSelectedUtxo)
 
         let utxoAvailableForCollateral =
-                UTxOIndex.toUTxO internalUtxoAvailable
+                UTxOIndex.toMap internalUtxoAvailable
 
         -- NOTE: It is not possible to know the script execution cost in
         -- advance because it actually depends on the final transaction. Inputs
@@ -1868,7 +1868,7 @@ readWalletUTxOIndex
     -> ExceptT ErrNoSuchWallet IO (UTxOIndex InputId, Wallet s, Set Tx)
 readWalletUTxOIndex ctx wid = do
     (cp, _, pending) <- readWallet @ctx @s @k ctx wid
-    let utxo = UTxOIndex.fromUTxO $ utxoToInputMap $ availableUTxO @s pending cp
+    let utxo = UTxOIndex.fromMap $ utxoToInputMap $ availableUTxO @s pending cp
     return (utxo, cp, pending)
 
 -- | Calculate the minimum coin values required for a bunch of specified

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1466,7 +1466,7 @@ balanceTransaction
     -> ArgGenChange s
     -> (W.ProtocolParameters, Cardano.ProtocolParameters)
     -> TimeInterpreter (Either PastHorizonException)
-    -> (UTxOIndex, Wallet s, Set Tx)
+    -> (UTxOIndex InputId, Wallet s, Set Tx)
     -> PartialTx
     -> ExceptT ErrBalanceTx m SealedTx
 balanceTransaction
@@ -1865,7 +1865,7 @@ readWalletUTxOIndex
     :: forall ctx s k. HasDBLayer IO s k ctx
     => ctx
     -> WalletId
-    -> ExceptT ErrNoSuchWallet IO (UTxOIndex, Wallet s, Set Tx)
+    -> ExceptT ErrNoSuchWallet IO (UTxOIndex InputId, Wallet s, Set Tx)
 readWalletUTxOIndex ctx wid = do
     (cp, _, pending) <- readWallet @ctx @s @k ctx wid
     let utxo = UTxOIndex.fromUTxO $ utxoToInputMap $ availableUTxO @s pending cp

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1600,7 +1600,7 @@ selectCoins ctx genChange (ApiT wid) body = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 }
                 transform
@@ -1653,7 +1653,7 @@ selectCoinsForJoin ctx knownPools getPoolStatus pid wid = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 }
                 transform
@@ -1706,7 +1706,7 @@ selectCoinsForQuit ctx (ApiT wid) = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 }
                 transform
@@ -1974,7 +1974,7 @@ postTransactionOld ctx genChange (ApiT wid) body = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 }
                 (const Prelude.id)
@@ -2122,7 +2122,7 @@ postTransactionFeeOld ctx (ApiT wid) body = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 } getFee
               where getFee = const (selectionDelta TokenBundle.getCoin)
@@ -2227,7 +2227,7 @@ constructTransaction ctx genChange knownPools getPoolStatus (ApiT wid) body = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 } transform
 
@@ -2587,7 +2587,7 @@ joinStakePool ctx knownPools getPoolStatus apiPoolId (ApiT wid) body = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 }
                 (const Prelude.id)
@@ -2652,7 +2652,7 @@ delegationFee ctx (ApiT wid) = do
             , utxoAvailableForInputs =
                 UTxOSelection.fromIndex utxoAvailable
             , utxoAvailableForCollateral =
-                UTxOIndex.toUTxO utxoAvailable
+                UTxOIndex.toMap utxoAvailable
             , wallet
             } calcFee
       where
@@ -2702,7 +2702,7 @@ quitStakePool ctx (ApiT wid) body = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 }
                 (const Prelude.id)

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -1231,7 +1231,7 @@ selectMatchingQuantity filters limit s
         NoLimit -> False
 
     updateState
-        :: ((InputId, TokenBundle), UTxOIndex)
+        :: ((InputId, TokenBundle), UTxOIndex InputId)
         -> Maybe UTxOSelectionNonEmpty
     updateState ((i, _b), _remaining) = UTxOSelection.select i s
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
@@ -2,11 +2,12 @@
 -- Copyright: © 2018-2021 IOHK
 -- License: Apache-2.0
 --
--- Provides the 'UTxOIndex' type, which indexes a UTxO set by asset ID.
+-- Provides the 'UTxOIndex' type, which indexes a UTxO set by asset identifier.
 --
--- The index makes it possible to efficiently compute the subset of a UTxO
--- set containing a particular asset, or to select a UTxO entry containing
--- that asset, without having to search through the entire UTxO set.
+-- The index makes it possible to efficiently compute the subset of a UTxO set
+-- containing a particular asset, or to select just a single UTxO containing a
+-- particular asset, without having to search linearly through the entire UTxO
+-- set.
 --
 -- See the documentation for 'UTxOIndex' for more details.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
@@ -23,12 +23,12 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex
     -- * Construction
     , empty
     , singleton
+    , fromMap
     , fromSequence
-    , fromUTxO
 
     -- * Deconstruction
     , toList
-    , toUTxO
+    , toMap
 
     -- * Folding
     , fold

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
@@ -42,7 +42,7 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 --
 type InputId = (TxIn, Address)
 
-genUTxOIndex :: Gen UTxOIndex
+genUTxOIndex :: Gen (UTxOIndex InputId)
 genUTxOIndex = UTxOIndex.fromSequence <$> listOf genEntry
   where
     genEntry :: Gen (InputId, TokenBundle)
@@ -51,7 +51,7 @@ genUTxOIndex = UTxOIndex.fromSequence <$> listOf genEntry
     genInputId :: Gen InputId
     genInputId = genSized2 genTxIn genAddress
 
-shrinkUTxOIndex :: UTxOIndex -> [UTxOIndex]
+shrinkUTxOIndex :: UTxOIndex InputId -> [UTxOIndex InputId]
 shrinkUTxOIndex =
     shrinkMapBy UTxOIndex.fromSequence UTxOIndex.toList (shrinkList shrinkEntry)
   where
@@ -71,10 +71,10 @@ shrinkUTxOIndex =
 -- Large indices
 --------------------------------------------------------------------------------
 
-genUTxOIndexLarge :: Gen UTxOIndex
+genUTxOIndexLarge :: Gen (UTxOIndex InputId)
 genUTxOIndexLarge = genUTxOIndexLargeN =<< choose (1024, 4096)
 
-genUTxOIndexLargeN :: Int -> Gen UTxOIndex
+genUTxOIndexLargeN :: Int -> Gen (UTxOIndex InputId)
 genUTxOIndexLargeN n = UTxOIndex.fromSequence <$> replicateM n genEntry
   where
     genEntry :: Gen (InputId, TokenBundle)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -39,11 +39,11 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
     , empty
     , singleton
     , fromSequence
-    , fromUTxO
+    , fromMap
 
     -- * Deconstruction
     , toList
-    , toUTxO
+    , toMap
 
     -- * Folding
     , fold
@@ -215,8 +215,8 @@ fromSequence = flip insertMany empty
 -- Note that this operation is potentially expensive as it must construct an
 -- index from scratch, and therefore should only be used sparingly.
 --
-fromUTxO :: Ord u => Map u TokenBundle -> UTxOIndex u
-fromUTxO = fromSequence . Map.toList
+fromMap :: Ord u => Map u TokenBundle -> UTxOIndex u
+fromMap = fromSequence . Map.toList
 
 --------------------------------------------------------------------------------
 -- Deconstruction
@@ -233,8 +233,8 @@ toList = fold (\ubs u b -> (u, b) : ubs) []
 --
 -- Consider using 'fold' if your goal is to consume all entries in the output.
 --
-toUTxO :: UTxOIndex u -> Map u TokenBundle
-toUTxO = universe
+toMap :: UTxOIndex u -> Map u TokenBundle
+toMap = universe
 
 --------------------------------------------------------------------------------
 -- Folding

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
@@ -355,7 +355,7 @@ leftoverIndex = leftover . state
 -- | Retrieves the leftover UTxO set.
 --
 leftoverUTxO :: IsUTxOSelection u => u -> Map InputId TokenBundle
-leftoverUTxO = UTxOIndex.toUTxO . leftoverIndex
+leftoverUTxO = UTxOIndex.toMap . leftoverIndex
 
 -- | Retrieves a list of the leftover UTxOs.
 --
@@ -380,7 +380,7 @@ selectedIndex = selected . state
 -- | Retrieves the selected UTxO set.
 --
 selectedUTxO :: IsUTxOSelection u => u -> Map InputId TokenBundle
-selectedUTxO = UTxOIndex.toUTxO . selectedIndex
+selectedUTxO = UTxOIndex.toMap . selectedIndex
 
 --------------------------------------------------------------------------------
 -- Modification

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
@@ -149,9 +149,9 @@ type InputId = (TxIn, Address)
 -- | The internal state of a selection.
 --
 data State = State
-    { leftover :: !UTxOIndex
+    { leftover :: !(UTxOIndex InputId)
       -- ^ UTxOs that have not yet been selected.
-    , selected :: !UTxOIndex
+    , selected :: !(UTxOIndex InputId)
       -- ^ UTxOs that have already been selected.
     }
     deriving (Eq, Generic, Show)
@@ -195,7 +195,7 @@ empty = fromIndex UTxOIndex.empty
 --
 -- All UTxOs in the index will be added to the leftover set.
 --
-fromIndex :: UTxOIndex -> UTxOSelection
+fromIndex :: UTxOIndex InputId -> UTxOSelection
 fromIndex i = UTxOSelection State
     { leftover = i
     , selected = UTxOIndex.empty
@@ -206,7 +206,7 @@ fromIndex i = UTxOSelection State
 -- All UTxOs that match the given filter will be added to the selected set,
 -- whereas all UTxOs that do not match will be added to the leftover set.
 --
-fromIndexFiltered :: (InputId -> Bool) -> UTxOIndex -> UTxOSelection
+fromIndexFiltered :: (InputId -> Bool) -> UTxOIndex InputId -> UTxOSelection
 fromIndexFiltered f =
     UTxOSelection . uncurry State . swap . UTxOIndex.partition f
 
@@ -217,7 +217,7 @@ fromIndexFiltered f =
 --
 -- Any items that are in both sets are removed from the leftover set.
 --
-fromIndexPair :: (UTxOIndex, UTxOIndex) -> UTxOSelection
+fromIndexPair :: (UTxOIndex InputId, UTxOIndex InputId) -> UTxOSelection
 fromIndexPair (leftover, selected) =
     UTxOSelection State
         { leftover = leftover `UTxOIndex.difference` selected
@@ -229,7 +229,7 @@ fromIndexPair (leftover, selected) =
 -- The 1st index in the pair represents the leftover set.
 -- The 2nd index in the pair represents the selected set.
 --
-toIndexPair :: IsUTxOSelection u => u -> (UTxOIndex, UTxOIndex)
+toIndexPair :: IsUTxOSelection u => u -> (UTxOIndex InputId, UTxOIndex InputId)
 toIndexPair s = (leftoverIndex s, selectedIndex s)
 
 --------------------------------------------------------------------------------
@@ -349,7 +349,7 @@ leftoverSize = UTxOIndex.size . leftoverIndex
 
 -- | Retrieves an index of the leftover UTxOs.
 --
-leftoverIndex :: IsUTxOSelection u => u -> UTxOIndex
+leftoverIndex :: IsUTxOSelection u => u -> UTxOIndex InputId
 leftoverIndex = leftover . state
 
 -- | Retrieves the leftover UTxO set.
@@ -374,7 +374,7 @@ selectedSize = UTxOIndex.size . selectedIndex
 
 -- | Retrieves an index of the selected UTxOs.
 --
-selectedIndex :: IsUTxOSelection u => u -> UTxOIndex
+selectedIndex :: IsUTxOSelection u => u -> UTxOIndex InputId
 selectedIndex = selected . state
 
 -- | Retrieves the selected UTxO set.

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -518,7 +518,7 @@ spec = describe "Cardano.Wallet.CoinSelection.Internal.BalanceSpec" $
 -- Coverage
 --------------------------------------------------------------------------------
 
-prop_Small_UTxOIndex_coverage :: Small UTxOIndex -> Property
+prop_Small_UTxOIndex_coverage :: Small (UTxOIndex InputId) -> Property
 prop_Small_UTxOIndex_coverage (Small index) =
     checkCoverage $ property
         -- Asset counts:
@@ -540,7 +540,7 @@ prop_Small_UTxOIndex_coverage (Small index) =
     assetCount = Set.size $ UTxOIndex.assets index
     entryCount = UTxOIndex.size index
 
-prop_Large_UTxOIndex_coverage :: Large UTxOIndex -> Property
+prop_Large_UTxOIndex_coverage :: Large (UTxOIndex InputId) -> Property
 prop_Large_UTxOIndex_coverage (Large index) =
     -- Generation of large UTxO sets takes longer, so limit the number of runs:
     withMaxSuccess 100 $ checkCoverage $ property
@@ -610,7 +610,7 @@ type PerformSelectionResult = Either SelectionBalanceError SelectionResult
 
 genSelectionParams
     :: Gen (InputId -> Bool)
-    -> Gen UTxOIndex
+    -> Gen (UTxOIndex InputId)
     -> Gen SelectionParams
 genSelectionParams genPreselectedInputs genUTxOIndex' = do
     utxoAvailable <- genUTxOIndex'
@@ -637,7 +637,7 @@ genSelectionParams genPreselectedInputs genUTxOIndex' = do
         , assetsToBurn
         }
   where
-    genAssetsToMintAndBurn :: UTxOIndex -> Gen (TokenMap, TokenMap)
+    genAssetsToMintAndBurn :: UTxOIndex InputId -> Gen (TokenMap, TokenMap)
     genAssetsToMintAndBurn utxoAvailable = do
         assetsToMint <- genTokenMapSmallRange
         let assetsToBurn = adjustAllTokenMapQuantities
@@ -864,7 +864,7 @@ prop_performSelection_huge = ioProperty $
         <$> generate (genUTxOIndexLargeN 50000)
 
 prop_performSelection_huge_inner
-    :: UTxOIndex
+    :: UTxOIndex InputId
     -> MockSelectionConstraints
     -> Large SelectionParams
     -> Property
@@ -1359,7 +1359,7 @@ prop_runSelection_UTxO_moreThanEnough utxoAvailable = monadicIO $ do
         cutAssetSetSizeInHalf balanceAvailable
 
 prop_runSelection_UTxO_muchMoreThanEnough
-    :: Blind (Large UTxOIndex)
+    :: Blind (Large (UTxOIndex InputId))
     -> Property
 prop_runSelection_UTxO_muchMoreThanEnough (Blind (Large index)) =
     -- Generation of large UTxO sets takes longer, so limit the number of runs:
@@ -1577,7 +1577,7 @@ prop_runSelectionStep_exceedsTargetAndGetsFurtherAway
 --------------------------------------------------------------------------------
 
 prop_assetSelectionLens_givesPriorityToSingletonAssets
-    :: Blind (Small UTxOIndex)
+    :: Blind (Small (UTxOIndex InputId))
     -> Property
 prop_assetSelectionLens_givesPriorityToSingletonAssets (Blind (Small u)) =
     assetCount >= 2 ==> monadicIO $ do
@@ -1613,7 +1613,7 @@ prop_assetSelectionLens_givesPriorityToSingletonAssets (Blind (Small u)) =
     minimumAssetQuantity = TokenQuantity 1
 
 prop_coinSelectionLens_givesPriorityToCoins
-    :: Blind (Small UTxOIndex)
+    :: Blind (Small (UTxOIndex InputId))
     -> Property
 prop_coinSelectionLens_givesPriorityToCoins (Blind (Small u)) =
     entryCount > 0 ==> monadicIO $ do
@@ -4090,11 +4090,11 @@ instance Arbitrary (Small SelectionParams) where
         (genUTxOIndex)
     shrink = shrinkMapBy Small getSmall shrinkSelectionParams
 
-instance Arbitrary (Large UTxOIndex) where
+instance Arbitrary (Large (UTxOIndex InputId)) where
     arbitrary = Large <$> genUTxOIndexLarge
     shrink = shrinkMapBy Large getLarge shrinkUTxOIndex
 
-instance Arbitrary (Small UTxOIndex) where
+instance Arbitrary (Small (UTxOIndex InputId)) where
     arbitrary = Small <$> genUTxOIndex
     shrink = shrinkMapBy Small getSmall shrinkUTxOIndex
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -576,8 +576,10 @@ prop_selectRandom_all_withAdaOnly u = checkCoverage $ monadicIO $ do
     (selectedEntries, u') <- run $ selectAll WithAdaOnly u
     monitor $ cover 70 (not (null selectedEntries))
         "selected at least one entry"
-    assert $ L.all (\(_, o) -> not (tokenBundleIsAdaOnly o)) (UTxOIndex.toList u')
-    assert $ L.all (\(_, o) -> tokenBundleIsAdaOnly o) selectedEntries
+    assert $ L.all (\(_, o) ->
+        not (tokenBundleIsAdaOnly o)) (UTxOIndex.toList u')
+    assert $ L.all (\(_, o) ->
+        tokenBundleIsAdaOnly o) selectedEntries
     assert $ UTxOIndex.deleteMany (fst <$> selectedEntries) u == u'
     assert $ UTxOIndex.insertMany selectedEntries u' == u
 
@@ -592,8 +594,10 @@ prop_selectRandom_all_withAsset u a = checkCoverage $ monadicIO $ do
         "index has more than one asset"
     monitor $ cover 50 (not (null selectedEntries))
         "selected at least one entry"
-    assert $ L.all (\(_, o) -> not (tokenBundleHasAsset o a)) (UTxOIndex.toList u')
-    assert $ L.all (\(_, o) -> tokenBundleHasAsset o a) selectedEntries
+    assert $ L.all (\(_, o) ->
+        not (tokenBundleHasAsset o a)) (UTxOIndex.toList u')
+    assert $ L.all (\(_, o) ->
+        tokenBundleHasAsset o a) selectedEntries
     assert $ UTxOIndex.deleteMany (fst <$> selectedEntries) u == u'
     assert $ UTxOIndex.insertMany selectedEntries u' == u
     assert $ a `Set.notMember` UTxOIndex.assets u'
@@ -609,8 +613,10 @@ prop_selectRandom_all_withAssetOnly u a = checkCoverage $ monadicIO $ do
         "index has more than one asset"
     monitor $ cover 10 (not (null selectedEntries))
         "selected at least one entry"
-    assert $ all (\(_, o) -> not (tokenBundleHasAssetOnly o a)) (UTxOIndex.toList u')
-    assert $ all (\(_, o) -> tokenBundleHasAssetOnly o a) selectedEntries
+    assert $ all (\(_, o) ->
+        not (tokenBundleHasAssetOnly o a)) (UTxOIndex.toList u')
+    assert $ all (\(_, o) ->
+        tokenBundleHasAssetOnly o a) selectedEntries
     assert $ UTxOIndex.deleteMany (fst <$> selectedEntries) u == u'
     assert $ UTxOIndex.insertMany selectedEntries u' == u
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -384,7 +384,7 @@ checkCoverage_filter_partition f u
   where
     u1 `isNonEmptyProperSubsetOf` u2 =
         not (UTxOIndex.null u1)
-        && UTxOIndex.toUTxO u1 `Map.isSubmapOf` UTxOIndex.toUTxO u2
+        && UTxOIndex.toMap u1 `Map.isSubmapOf` UTxOIndex.toMap u2
         && u1 /= u2
 
     filterSize g = UTxOIndex.size . UTxOIndex.filter g

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
@@ -193,27 +193,31 @@ checkCoverage_UTxOSelectionNonEmpty s
 -- Construction and deconstruction
 --------------------------------------------------------------------------------
 
-prop_fromIndex_isValid :: UTxOIndex -> Property
+prop_fromIndex_isValid :: UTxOIndex InputId -> Property
 prop_fromIndex_isValid u =
     isValidSelection (UTxOSelection.fromIndex u)
     === True
 
-prop_fromIndexFiltered_isValid :: (InputId -> Bool) -> UTxOIndex -> Property
+prop_fromIndexFiltered_isValid
+    :: (InputId -> Bool) -> UTxOIndex InputId -> Property
 prop_fromIndexFiltered_isValid f u =
     isValidSelection (UTxOSelection.fromIndexFiltered f u)
     === True
 
-prop_fromIndexPair_isValid :: (UTxOIndex, UTxOIndex) -> Property
+prop_fromIndexPair_isValid :: (UTxOIndex InputId, UTxOIndex InputId) -> Property
 prop_fromIndexPair_isValid (u1, u2) =
     isValidSelection (UTxOSelection.fromIndexPair (u1, u2))
     === True
 
-prop_fromIndex_toIndexPair :: UTxOIndex -> Property
+prop_fromIndex_toIndexPair :: UTxOIndex InputId-> Property
 prop_fromIndex_toIndexPair u =
     UTxOSelection.toIndexPair (UTxOSelection.fromIndex u)
     === (u, UTxOIndex.empty)
 
-prop_fromIndexFiltered_toIndexPair :: (InputId -> Bool) -> UTxOIndex -> Property
+prop_fromIndexFiltered_toIndexPair
+    :: (InputId -> Bool)
+    -> UTxOIndex InputId
+    -> Property
 prop_fromIndexFiltered_toIndexPair f u =
     UTxOSelection.toIndexPair (UTxOSelection.fromIndexFiltered f u)
     === (UTxOIndex.filter (not . f) u, UTxOIndex.filter f u)
@@ -423,7 +427,7 @@ instance {-# OVERLAPPING #-} Arbitrary InputId where
         <:> shrinkAddress
         <:> Nil
 
-instance Arbitrary UTxOIndex where
+instance Arbitrary (UTxOIndex InputId) where
     arbitrary = genUTxOIndex
     shrink = shrinkUTxOIndex
 

--- a/lib/shelley/bench/restore-bench.hs
+++ b/lib/shelley/bench/restore-bench.hs
@@ -466,7 +466,7 @@ benchmarksRnd _ w wid wname benchname restoreTime = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 } getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection
@@ -569,7 +569,7 @@ benchmarksSeq _ w wid _wname benchname restoreTime = do
                 , utxoAvailableForInputs =
                     UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral =
-                    UTxOIndex.toUTxO utxoAvailable
+                    UTxOIndex.toMap utxoAvailable
                 , wallet
                 } getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2006,7 +2006,16 @@ instance MonadRandom Gen where
     getRandomR range = mkGen (fst . randomR range)
     getRandomRs range = mkGen (randomRs range)
 
-data Wallet' = Wallet' UTxOIndex (Wallet (SeqState 'Mainnet ShelleyKey)) (Set Tx)
+-- TODO: ADP-1448:
+--
+-- Replace this type synonym with a type parameter on types that use it.
+--
+type InputId = (TxIn, Address)
+
+data Wallet' = Wallet'
+    (UTxOIndex InputId)
+    (Wallet (SeqState 'Mainnet ShelleyKey))
+    (Set Tx)
 
 instance Show Wallet' where
     show (Wallet' u w pending) = fmt $ mconcat


### PR DESCRIPTION
## Issue Number 

ADP-1418

## Summary

This PR adds the type parameter `u` to the `UTxOIndex` type, to represent unique UTxO identifiers. The parameter `u` can be instantiated to any type for which there is an `Ord` instance.
```patch
- data UTxOIndex   = UTxOIndex
+ data UTxOIndex u = UTxOIndex
      { assetsAll
-         :: !(Map AssetId (NonEmptySet InputId ))
+         :: !(Map AssetId (NonEmptySet u       ))
          -- An index of all entries that contain at least one non-ada asset.
      , assetsSingleton
-         :: !(Map AssetId (NonEmptySet InputId))
+         :: !(Map AssetId (NonEmptySet u      ))
          -- An index of all entries that contain exactly one non-ada asset.
      , coins
-         :: !(Set InputId)
+         :: !(Set u      )
          -- An index of all entries that contain no non-ada assets.
      , balance
          :: !TokenBundle
          -- The total balance of all entries.
-     , utxo
+     , universe
-         :: !(Map InputId TokenBundle)
+         :: !(Map u       TokenBundle)
          -- The complete set of all entries.
      }
```

## Additional Work

This PR also:

- [x] Revises comments within `UTxOIndex` module to reflect the `UTxOIndex` type's generality.
- [x] Revises names for identifiers within `UTxOIndex` according to the following scheme:
      - `u` represents a unique identifier for an individual UTxO (unspent transaction output).
      - `b` represents a `TokenBundle` value.
      - `i` represents an index of type `UTxOIndex`.
- [x] Renames functions `UTxOIndex.{to,from}UTxO` to `UTxOIndex.{to,from}Map`, since these functions really do produce and consume values of type `Map`.
- [x] Renames internal field `utxo` of type `UTxOIndex` to `universe`, to avoid overloading the term `UTxO`, which refers to a _**single**_ unspent transaction output in this module.