### PR TITLE
Generalize UTxO identifier type within `UTxOSelection`.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1913,7 +1913,7 @@ data SelectAssetsParams s result = SelectAssetsParams
     , randomSeed :: Maybe StdGenSeed
     , txContext :: TransactionCtx
     , utxoAvailableForCollateral :: Map InputId TokenBundle
-    , utxoAvailableForInputs :: UTxOSelection
+    , utxoAvailableForInputs :: UTxOSelection InputId
     , wallet :: Wallet s
     }
     deriving Generic

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -225,7 +225,7 @@ data SelectionParams = SelectionParams
         -- This set is allowed to intersect with 'utxoAvailableForInputs',
         -- since the ledger does not require that these sets are disjoint.
     , utxoAvailableForInputs
-        :: !UTxOSelection
+        :: !(UTxOSelection InputId)
         -- ^ Specifies a set of UTxOs that are available for selection as
         -- ordinary inputs and optionally, a subset that has already been
         -- selected.

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -215,7 +215,7 @@ data SelectionParams = SelectionParams
         -- This set is allowed to intersect with 'utxoAvailableForInputs',
         -- since the ledger does not require that these sets are disjoint.
     , utxoAvailableForInputs
-        :: !UTxOSelection
+        :: !(UTxOSelection InputId)
         -- ^ Specifies a set of UTxOs that are available for selection as
         -- ordinary inputs and optionally, a subset that has already been
         -- selected.
@@ -879,7 +879,7 @@ verifyBalanceInsufficientError cs ps e =
 --------------------------------------------------------------------------------
 
 newtype FailureToVerifyEmptyUTxOError = FailureToVerifyEmptyUTxOError
-    { utxoAvailableForInputs :: UTxOSelection }
+    { utxoAvailableForInputs :: UTxOSelection InputId }
     deriving (Eq, Show)
 
 verifyEmptyUTxOError :: VerifySelectionError ()

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
@@ -70,12 +70,12 @@ module Cardano.Wallet.Primitive.Types.UTxOSelection
     , leftoverSize
     , leftoverIndex
     , leftoverList
-    , leftoverUTxO
+    , leftoverMap
     , selectedBalance
     , selectedSize
     , selectedIndex
     , selectedList
-    , selectedUTxO
+    , selectedMap
 
       -- * Modification
     , select
@@ -288,7 +288,7 @@ isSubSelectionOf
 isSubSelectionOf s1 s2 = state (selectMany toSelect s1) == state s2
   where
     toSelect = fst <$> Map.toList
-        (selectedUTxO s2 `Map.difference` selectedUTxO s1)
+        (selectedMap s2 `Map.difference` selectedMap s1)
 
 -- | Returns 'True' iff. the first selection is a proper sub-selection of the
 --   second.
@@ -329,7 +329,7 @@ availableBalance s = leftoverBalance s <> selectedBalance s
 --
 -- The available UTxO set is the union of the selected and leftover UTxO sets.
 --
--- It predicts what 'selectedUTxO' would be if every single UTxO were selected.
+-- It predicts what 'selectedMap' would be if every single UTxO were selected.
 --
 -- This result of this function remains constant over applications of 'select'
 -- and 'selectMany':
@@ -337,7 +337,7 @@ availableBalance s = leftoverBalance s <> selectedBalance s
 -- >>> availableUTxO s == availableUTxO (selectMany is s)
 --
 availableUTxO :: IsUTxOSelection s u => Ord u => s u -> Map u TokenBundle
-availableUTxO s = leftoverUTxO s <> selectedUTxO s
+availableUTxO s = leftoverMap s <> selectedMap s
 
 -- | Retrieves the balance of leftover UTxOs.
 --
@@ -354,10 +354,10 @@ leftoverSize = UTxOIndex.size . leftoverIndex
 leftoverIndex :: IsUTxOSelection s u => s u -> UTxOIndex u
 leftoverIndex = leftover . state
 
--- | Retrieves the leftover UTxO set.
+-- | Retrieves a map of the leftover UTxOs.
 --
-leftoverUTxO :: IsUTxOSelection s u => s u -> Map u TokenBundle
-leftoverUTxO = UTxOIndex.toMap . leftoverIndex
+leftoverMap :: IsUTxOSelection s u => s u -> Map u TokenBundle
+leftoverMap = UTxOIndex.toMap . leftoverIndex
 
 -- | Retrieves a list of the leftover UTxOs.
 --
@@ -379,10 +379,10 @@ selectedSize = UTxOIndex.size . selectedIndex
 selectedIndex :: IsUTxOSelection s u => s u -> UTxOIndex u
 selectedIndex = selected . state
 
--- | Retrieves the selected UTxO set.
+-- | Retrieves a map of the selected UTxOs.
 --
-selectedUTxO :: IsUTxOSelection s u => s u -> Map u TokenBundle
-selectedUTxO = UTxOIndex.toMap . selectedIndex
+selectedMap :: IsUTxOSelection s u => s u -> Map u TokenBundle
+selectedMap = UTxOIndex.toMap . selectedIndex
 
 --------------------------------------------------------------------------------
 -- Modification

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
@@ -260,17 +260,17 @@ isNonEmpty = not . isEmpty
 -- Otherwise, returns 'False'.
 --
 isMember :: IsUTxOSelection s u => Ord u => u -> s u -> Bool
-isMember i s = isLeftover i s || isSelected i s
+isMember u s = isLeftover u s || isSelected u s
 
 -- | Returns 'True' iff. the given 'InputId' is a member of the leftover set.
 --
 isLeftover :: IsUTxOSelection s u => Ord u => u -> s u -> Bool
-isLeftover i = UTxOIndex.member i . leftoverIndex
+isLeftover u = UTxOIndex.member u . leftoverIndex
 
 -- | Returns 'True' iff. the given 'InputId' is a member of the selected set.
 --
 isSelected :: IsUTxOSelection s u => Ord u => u -> s u -> Bool
-isSelected i = UTxOIndex.member i . selectedIndex
+isSelected u = UTxOIndex.member u . selectedIndex
 
 -- | Returns 'True' iff. the first selection is a sub-selection of the second.
 --
@@ -418,12 +418,12 @@ selectMany = ap fromMaybe . withState . flip (F.foldrM selectState)
 -- | Moves a single entry from the leftover set to the selected set.
 --
 selectState :: Ord u => u -> State u -> Maybe (State u)
-selectState i s =
-    updateFields <$> UTxOIndex.lookup i (leftover s)
+selectState u s =
+    updateFields <$> UTxOIndex.lookup u (leftover s)
   where
-    updateFields o = s
-        & over #leftover (UTxOIndex.delete i)
-        & over #selected (UTxOIndex.insert i o)
+    updateFields b = s
+        & over #leftover (UTxOIndex.delete u)
+        & over #selected (UTxOIndex.insert u b)
 
 -- | Applies the given function to the internal state.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection/Gen.hs
@@ -51,7 +51,7 @@ coarbitraryInputId = coarbitrary . show
 genInputIdFunction :: Gen a -> Gen (InputId -> a)
 genInputIdFunction = genFunction coarbitraryInputId
 
-genUTxOSelection :: Gen UTxOSelection
+genUTxOSelection :: Gen (UTxOSelection InputId)
 genUTxOSelection = UTxOSelection.fromIndexFiltered
     <$> genFilter
     <*> genUTxOIndex
@@ -59,7 +59,7 @@ genUTxOSelection = UTxOSelection.fromIndexFiltered
     genFilter :: Gen (InputId -> Bool)
     genFilter = genInputIdFunction (arbitrary @Bool)
 
-shrinkUTxOSelection :: UTxOSelection -> [UTxOSelection]
+shrinkUTxOSelection :: UTxOSelection InputId -> [UTxOSelection InputId]
 shrinkUTxOSelection =
     shrinkMapBy UTxOSelection.fromIndexPair UTxOSelection.toIndexPair $
         liftShrink2
@@ -70,11 +70,13 @@ shrinkUTxOSelection =
 -- Selections that are non-empty
 --------------------------------------------------------------------------------
 
-genUTxOSelectionNonEmpty :: Gen UTxOSelectionNonEmpty
+genUTxOSelectionNonEmpty :: Gen (UTxOSelectionNonEmpty InputId)
 genUTxOSelectionNonEmpty =
     genUTxOSelection `suchThatMap` UTxOSelection.toNonEmpty
 
-shrinkUTxOSelectionNonEmpty :: UTxOSelectionNonEmpty -> [UTxOSelectionNonEmpty]
+shrinkUTxOSelectionNonEmpty
+    :: UTxOSelectionNonEmpty InputId
+    -> [UTxOSelectionNonEmpty InputId]
 shrinkUTxOSelectionNonEmpty
     = mapMaybe UTxOSelection.toNonEmpty
     . shrinkUTxOSelection

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -1267,7 +1267,7 @@ prop_runSelection_UTxO_empty balanceRequested = monadicIO $ do
   where
     utxoAvailable = UTxOSelection.fromIndex UTxOIndex.empty
 
-prop_runSelection_UTxO_notEnough :: UTxOSelection -> Property
+prop_runSelection_UTxO_notEnough :: UTxOSelection InputId -> Property
 prop_runSelection_UTxO_notEnough utxoAvailable = monadicIO $ do
     result <- run $ runSelection
         RunSelectionParams
@@ -1290,7 +1290,7 @@ prop_runSelection_UTxO_notEnough utxoAvailable = monadicIO $ do
     balanceAvailable = UTxOSelection.availableBalance utxoAvailable
     balanceRequested = adjustAllTokenBundleQuantities (* 2) balanceAvailable
 
-prop_runSelection_UTxO_exactlyEnough :: UTxOSelection -> Property
+prop_runSelection_UTxO_exactlyEnough :: UTxOSelection InputId -> Property
 prop_runSelection_UTxO_exactlyEnough utxoAvailable = monadicIO $ do
     result <- run $ runSelection
         RunSelectionParams
@@ -1317,7 +1317,7 @@ prop_runSelection_UTxO_exactlyEnough utxoAvailable = monadicIO $ do
   where
     balanceRequested = UTxOSelection.availableBalance utxoAvailable
 
-prop_runSelection_UTxO_moreThanEnough :: UTxOSelection -> Property
+prop_runSelection_UTxO_moreThanEnough :: UTxOSelection InputId -> Property
 prop_runSelection_UTxO_moreThanEnough utxoAvailable = monadicIO $ do
     result <- run $ runSelection
         RunSelectionParams
@@ -1410,7 +1410,7 @@ prop_runSelection_UTxO_muchMoreThanEnough (Blind (Large index)) =
 -- Running a selection (non-empty)
 --------------------------------------------------------------------------------
 
-prop_runSelectionNonEmpty :: UTxOSelection -> Property
+prop_runSelectionNonEmpty :: UTxOSelection InputId -> Property
 prop_runSelectionNonEmpty result =
     case (haveLeftover, haveSelected) of
         (False, False) ->
@@ -1452,20 +1452,22 @@ prop_runSelectionNonEmpty result =
                     (UTxOSelection.leftoverIndex resultNonEmpty)
                 === UTxOSelection.leftoverIndex result
 
-    maybeResultNonEmpty :: Maybe UTxOSelectionNonEmpty
+    maybeResultNonEmpty :: Maybe (UTxOSelectionNonEmpty InputId)
     maybeResultNonEmpty = runIdentity $ runSelectionNonEmptyWith
         (Identity <$> mockSelectSingleEntry)
         (result)
 
-mockSelectSingleEntry :: UTxOSelection -> Maybe UTxOSelectionNonEmpty
+mockSelectSingleEntry
+    :: UTxOSelection InputId -> Maybe (UTxOSelectionNonEmpty InputId)
 mockSelectSingleEntry state =
     selectEntry =<< firstLeftoverEntry state
   where
-    firstLeftoverEntry :: UTxOSelection -> Maybe (InputId, TokenBundle)
+    firstLeftoverEntry :: UTxOSelection InputId -> Maybe (InputId, TokenBundle)
     firstLeftoverEntry =
         listToMaybe . UTxOIndex.toList . UTxOSelection.leftoverIndex
 
-    selectEntry :: (InputId, TokenBundle) -> Maybe UTxOSelectionNonEmpty
+    selectEntry
+        :: (InputId, TokenBundle) -> Maybe (UTxOSelectionNonEmpty InputId)
     selectEntry (i, _b) = UTxOSelection.select i state
 
 --------------------------------------------------------------------------------
@@ -4066,7 +4068,7 @@ instance Arbitrary TxOut where
     arbitrary = genTxOut
     shrink = shrinkTxOut
 
-instance Arbitrary UTxOSelection where
+instance Arbitrary (UTxOSelection InputId) where
     arbitrary = genUTxOSelection
     shrink = shrinkUTxOSelection
 

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -788,7 +788,7 @@ genUTxOAvailableForCollateral = genMapWith genInputId genCoinPositive
     genInputId :: Gen InputId
     genInputId = genSized2 genTxIn genAddress
 
-genUTxOAvailableForInputs :: Gen UTxOSelection
+genUTxOAvailableForInputs :: Gen (UTxOSelection InputId)
 genUTxOAvailableForInputs = frequency
     [ (49, genUTxOSelection)
     , (01, pure UTxOSelection.empty)
@@ -804,7 +804,7 @@ shrinkUTxOAvailableForCollateral =
         <:> shrinkAddress
         <:> Nil
 
-shrinkUTxOAvailableForInputs :: UTxOSelection -> [UTxOSelection]
+shrinkUTxOAvailableForInputs :: UTxOSelection InputId -> [UTxOSelection InputId]
 shrinkUTxOAvailableForInputs = shrinkUTxOSelection
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
## Issue Number

ADP-1450

## Background

Within coin selection modules, we are steadily replacing all uses of `TxIn`, `Address`, `TxOut` with type parameters, so that the coin selection library does not depend on these concrete wallet types.

## Summary

This PR replaces all uses of `InputId` (a temporary type synonym introduced in #3149) with a type parameter within module `UTxOSelection`.

We use the following convention for type parameters and identifier names:
- `u` represents a unique identifier for an individual UTxO (unspent transaction output).
- `s` represents a selection of type `UTxOSelection`.
- `b` represents a `TokenBundle` value.
- `i` represents an index of type `UTxOIndex`.
