### PR TITLE
Introduce types `DeltaUTxO` and `DeltaWallet`

### DIFF
--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -51,21 +51,15 @@ Wallet Backend specifications, the notation is inspired from the [Z notation](ht
 <details>
   <summary>What is <code>dom</code> from <strong>Lemma 2.1</strong></summary>
 
-  There are multiple occurrences in the spec of expressions like: `(dom u ∩ ins) ◃ u`. The meaning of `dom u` isn't quite clearly defined anywhere but refers to the set of keys from the mapping defined by `u: txin ↦ txout`. Hence,
-`dom u` refers to all `txin` available in `u`.
+  There are multiple occurrences in the spec of expressions like: `(dom u ∩ ins) ◃ u`. The meaning of `dom u` isn't quite clearly defined anywhere but refers to the set of keys from the mapping defined by `u: txin ↦ txout`. Hence, `dom u` refers to all `txin` available in `u`.
 
   In Haskell, this translates to:
 
   ```hs
-  class Dom a where
-    type DomElem a :: *
-    dom :: a -> Set (DomElem a)
-
   newtype UTxO = UTxO (Map TxIn TxOut)
 
-  instance Dom UTxO where
-    type DomElem UTxO = TxIn
-    dom (UTxO utxo)   = Set.fromList $ Map.keys utxo
+  dom :: UTxO -> Set TxIn
+  dom (UTxO utxo) = Set.fromList $ Map.keys utxo
   ```
 </details>
 

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1021,7 +1021,8 @@ restoreBlocks ctx tr wid blocks nodeTip = db & \DBLayer{..} -> mapExceptT atomic
         , pretty (header (NE.head blocks))
         ]
 
-    let (filteredBlocks, cps) = NE.unzip $ applyBlocks @s blocks cp0
+    let (filteredBlocks, cps') = NE.unzip $ applyBlocks @s blocks cp0
+        cps = NE.map snd cps'
     let slotPoolDelegations =
             [ (slotNo, cert)
             | let slots = view #slotNo . view #header <$> blocks

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -188,7 +188,7 @@ data DeltaWallet s = DeltaWallet
     { deltaUTxO :: DeltaUTxO
     , deltaCurrentTip :: Delta.Replace BlockHeader
     , deltaAddressBook :: DeltaAddressBook s
-    }
+    } deriving (Show)
 
 type DeltaAddressBook s = Delta.Replace s
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -593,6 +593,12 @@ applyOurTxToUTxO !slotNo !blockHeight !s !tx !u0 =
     -- transaction outputs we've spent)
     (du, u) = (du21 <> du10, u2)
 
+    -- Note [Naming of Deltas]
+    -- The identifiers for delta encodings carry two indices
+    -- which indicate the "to" and "from" value of the delta.
+    -- For example, the delta du10 maps the value u0 to the value u1,
+    -- and the delta du21 maps the value u1 to the value u2.
+    -- In general, the naming convention is  ui = duij `apply` uj
     (du10, u1)   = spendTxD tx u0
     receivedUTxO = UTxO.filterByAddress (ours s) (utxoFromTx tx)
     (du21, u2)   = receiveD u1 receivedUTxO

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -18,8 +18,8 @@ module Cardano.Wallet.Primitive.Types.UTxO
     (
     -- * UTxO
       UTxO (..)
-    , Dom (..)
 
+    , dom
     , null
     , size
     , balance
@@ -73,8 +73,6 @@ import Data.Functor.Identity
     ( runIdentity )
 import Data.Generics.Internal.VL.Lens
     ( view )
-import Data.Kind
-    ( Type )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Map.Strict
@@ -106,17 +104,6 @@ newtype UTxO = UTxO { unUTxO :: Map TxIn TxOut }
 
 instance NFData UTxO
 
--- | Allows us to define the "domain" of any type — @UTxO@ in particular — and
--- use 'dom' to refer to the /inputs/ of an /utxo/.
---
-class Dom a where
-    type DomElem a :: Type
-    dom :: a -> Set (DomElem a)
-
-instance Dom UTxO where
-    type DomElem UTxO = TxIn
-    dom (UTxO utxo) = Map.keysSet utxo
-
 instance Buildable UTxO where
     build (UTxO utxo) =
         blockListF' "-" utxoF (Map.toList utxo)
@@ -128,6 +115,10 @@ instance Buildable UTxO where
               , build out)
             ]
         buildMap = blockMapF . fmap (first $ id @String)
+
+-- | Domain of a 'UTxO' = the set of /inputs/ of the /utxo/.
+dom :: UTxO -> Set TxIn
+dom (UTxO utxo) = Map.keysSet utxo
 
 -- | Compute the balance of a UTxO
 balance :: UTxO -> TokenBundle

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -797,7 +797,7 @@ prop_rollbackCheckpoint db@DBLayer{..} (InitialCheckpoint cp0) (MockChain chain)
     cps :: [Wallet s]
     cps = flip unfoldr (chain, cp0) $ \case
         ([], _) -> Nothing
-        (b:q, cp) -> let cp' = snd $ applyBlock b cp in Just (cp', (q, cp'))
+        (b:q, cp) -> let cp' = snd . snd $ applyBlock b cp in Just (cp', (q, cp'))
 
     setup wid meta = run $ do
         cleanDB db

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -553,7 +553,7 @@ fileModeSpec =  do
                             })
                             mockTxs
                             mempty
-                    let (FilteredBlock{transactions=txs}, cpB) = applyBlock fakeBlock cpA
+                    let (FilteredBlock{transactions=txs}, (_,cpB)) = applyBlock fakeBlock cpA
                     print $ utxo cpB
                     atomically $ do
                         unsafeRunExceptT $ putCheckpoint testWid cpB

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -89,7 +89,7 @@ import Cardano.Wallet.Primitive.Types.Tx
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTx, genTxIn, genTxOut, shrinkTx, shrinkTxIn, shrinkTxOut )
 import Cardano.Wallet.Primitive.Types.UTxO
-    ( Dom (..), UTxO (..), balance, excluding, filterByAddress, restrictedTo )
+    ( UTxO (..), balance, dom, excluding, filterByAddress, restrictedTo )
 import Cardano.Wallet.Primitive.Types.UTxO.Gen
     ( genUTxO, shrinkUTxO )
 import Cardano.Wallet.Util

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -99,8 +99,45 @@ prop_deltaUTxO_semigroup_apply =
     ===
         (delta2 <> delta1) `apply` utxo0
   where
-    -- As the functions in 'DeltaUTxO' are implemented in terms of set
-    -- operations, we only have to test a Venn diagram using few elements.
+    {- Note [Property Testing of Boolean Algebras]
+
+    It turns out that the validity of simple properties of finite sets
+    (or, more generally, boolean algebras) can be decided
+    by considering a single, universal example.
+    Essentially, this example corresponds to a truth table.
+    These examples are typically visualized as Venn diagrams.
+
+    For example, in order to show that the equality
+    
+        (A ∩ B) ∪ C = (A ∪ C) ∩ (B ∪ C)
+
+    holds for all finite sets A,B,C, it is sufficient to show that it
+    holds for the specific case
+
+        A = { "100", "110", "101", "111"}
+        B = { "010", "110", "011", "111"}
+        C = { "001", "101", "011", "111"}
+
+    Even though the elements like "010" seem very specific, they stand
+    for an entire subset of elements; here, "010" stands for all elements
+    that are contained in B, but not in A or C.
+    -}
+    {- Note [Property Testing of DeltaUTxO]
+
+    In order to test properties of `DeltaUTxO`, we can apply 
+    Note [Property Testing of Boolean Algebras] above, as most operations
+    on this data type are essentially set-theoretic operations.
+
+    In particular, the associativity of `(<>)` on `DeltaUTxO` corresponds
+    to a simple statement about finite sets, and it is sufficient to
+    test a single, universal case — the test case below.
+
+    The outputs named "a0" etc correspond to entire subsets of outputs.
+    For example, "a2" represents the subset of outputs contained in utxo0,
+    not spent by delta1, but spent by delta2.
+    Due to the "no double-spending" constraint, not all
+    subsets are relevant; the relevant ones are included in this test case.
+    -}
     utxo0  = mkUTxOs ["a0","a1","a2"]
     delta1 = mkDelta ["a1"] ["b1","b2"]
     delta2 = mkDelta ["a2","b2"] ["c2"]

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -111,12 +111,12 @@ import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTx, shrinkTx )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( BoundType
-    , Dom (..)
     , HistogramBar (..)
     , UTxO (..)
     , UTxOStatistics (..)
     , balance
     , computeUtxoStatistics
+    , dom
     , excluding
     , isSubsetOf
     , log10

--- a/lib/dbvar/src/Data/Delta.hs
+++ b/lib/dbvar/src/Data/Delta.hs
@@ -40,6 +40,8 @@ import Data.Either
     ( fromRight )
 import Data.Kind
     ( Type )
+import Data.List.NonEmpty
+    ( NonEmpty )
 import Data.Semigroupoid
     ( Semigroupoid (..) )
 import Data.Set
@@ -98,6 +100,12 @@ instance Delta delta => Delta (Maybe delta) where
 -- > apply (d1 <> d2) = apply d1 . apply d2
 instance Delta delta => Delta [delta] where
     type Base [delta] = Base delta
+    apply ds a = foldr apply a ds
+
+-- | For convenience, a nonempty list of deltas
+-- can be applied like a list of deltas.
+instance Delta delta => Delta (NonEmpty delta) where
+    type Base (NonEmpty delta) = Base delta
     apply ds a = foldr apply a ds
 
 -- | A pair of deltas represents a delta for a pair.


### PR DESCRIPTION
### Issue number

ADP-1434

### Overview

Previous work in epic ADP-1043 introduced delta encodings, DBVars, and an embedding of the wallet state and its delta encodings into a database table. It's time to integrate these tools with the wallet code. To facilitate code review, the integration proceeds in a sequence of refactorings that do not change functionality and pass all unit tests.

In this step, we finally introduce the type `DeltaUTxO` which represents a delta encoding of the `UTxO` set, i.e. a package of changes that can be applied to one `UTxO` set in order to obtain another one. The type `DeltaUTxO` is abstract, but internally, it is implemented as
```hs
data DeltaUTxO = DeltaUTxO
    { excluded :: !(Set TxIn) -- ^ First exclude these inputs
    , received :: !UTxO       -- ^ Then receive these additional outputs.
    }
```
i.e. it stores a set of `TxIn` that was spent, and a `UTxO` that was received.

Building on this, we also introduce a delta encoding `DeltaWallet` for the wallet state `Wallet s`. The main change is that the `applyBlock` function now also computes and returns this delta encoding when computing the new `Wallet s` state.

```hs
applyBlock
    :: (…)
    => Block -> Wallet s -> (FilteredBlock, (DeltaWallet s, Wallet s))
```

However, this pull request does not yet integrate this type into the `WalletState` checkpoints; this will be the subject of an upcoming pull request.

### Details

* `DeltaWallet s` currently uses the trivial delta encoding `Data.Delta.Replace` for the address discovery state.
* As indicated, the delta encodings `DeltaWallet s` are not yet used with the `Checkpoint` mechanism. Instead, they are currently discarded.
* Even though it is currently discarded, the `DeltaUTxO` type has suggested an optimization where a transaction that does not change the `UTxO` set can be discarded more quickly. This may already improve the wallet restoration benchmarks slightly.
* I have smuggled in a small cleanup commit that removes the `Dom` type class, as it is no longer used.

### Comments

* @piotr-iohk I'd be interested in the wallet restoration benchmark for this branch — I expect slight improvements for the `0.01-percent-seq` and `0.01-percent-rnd` benchmarks.
