### PR TITLE
Parameterize UTxO identifier type in internal coin selection modules.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -3227,7 +3227,7 @@ data ErrSelectAssets
     = ErrSelectAssetsPrepareOutputsError SelectionOutputError
     | ErrSelectAssetsNoSuchWallet ErrNoSuchWallet
     | ErrSelectAssetsAlreadyWithdrawing Tx
-    | ErrSelectAssetsSelectionError SelectionError
+    | ErrSelectAssetsSelectionError (SelectionError InputId)
     deriving (Generic, Eq, Show)
 
 data ErrStakePoolDelegation
@@ -3377,7 +3377,7 @@ data WalletFollowLog
 -- | Log messages from API server actions running in a wallet worker context.
 data WalletLog
     = MsgSelectionStart UTxO [TxOut]
-    | MsgSelectionError SelectionError
+    | MsgSelectionError (SelectionError InputId)
     | MsgSelectionReportSummarized SelectionReportSummarized
     | MsgSelectionReportDetailed SelectionReportDetailed
     | MsgMigrationUTxOBefore UTxOStatistics

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1952,7 +1952,7 @@ selectAssets ctx pp params transform = do
     guardPendingWithdrawal
     lift $ traceWith tr $ MsgSelectionStart
         (inputMapToUTxO
-            $ UTxOSelection.availableUTxO
+            $ UTxOSelection.availableMap
             $ params ^. #utxoAvailableForInputs)
         (params ^. #outputs)
     let selectionConstraints = SelectionConstraints

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -4382,7 +4382,7 @@ instance IsServerError ErrSelectAssets where
         ErrSelectAssetsSelectionError (SelectionOutputErrorOf e) ->
             toServerError e
 
-instance IsServerError (SelectionBalanceError) where
+instance IsServerError (SelectionBalanceError (TxIn, Address)) where
     toServerError = \case
         BalanceInsufficient e ->
             apiError err403 NotEnoughMoney $ mconcat

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -4425,7 +4425,7 @@ instance IsServerError (SelectionBalanceError (TxIn, Address)) where
                 , "required in order to create a transaction."
                 ]
 
-instance IsServerError SelectionCollateralError where
+instance IsServerError (SelectionCollateralError (TxIn, Address)) where
     toServerError e =
         apiError err403 InsufficientCollateral $ T.unwords
             [ "I'm unable to create this transaction because the balance"

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -234,7 +234,7 @@ data SelectionParams = SelectionParams
     }
     deriving (Eq, Generic, Show)
 
-toInternalSelectionParams :: SelectionParams -> Internal.SelectionParams
+toInternalSelectionParams :: SelectionParams -> Internal.SelectionParams InputId
 toInternalSelectionParams SelectionParams {..} =
     Internal.SelectionParams
         { utxoAvailableForCollateral =
@@ -328,7 +328,8 @@ data SelectionOf change = Selection
 --
 type Selection = SelectionOf TokenBundle
 
-toExternalSelection :: SelectionParams -> Internal.Selection -> Selection
+toExternalSelection
+    :: SelectionParams -> Internal.Selection InputId -> Selection
 toExternalSelection _ps Internal.Selection {..} =
     Selection
         { collateral =
@@ -345,7 +346,7 @@ toExternalSelection _ps Internal.Selection {..} =
 toInternalSelection
     :: (change -> TokenBundle)
     -> SelectionOf change
-    -> Internal.Selection
+    -> Internal.Selection InputId
 toInternalSelection getChangeBundle Selection {..} =
     Internal.Selection
         { change = getChangeBundle
@@ -378,7 +379,7 @@ performSelection
     :: (HasCallStack, MonadRandom m)
     => SelectionConstraints
     -> SelectionParams
-    -> ExceptT SelectionError m Selection
+    -> ExceptT (SelectionError InputId) m Selection
 performSelection cs ps =
     toExternalSelection ps <$>
     Internal.performSelection

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -325,14 +325,14 @@ prepareOutputs cs ps =
 
 performSelectionBalance
     :: (HasCallStack, MonadRandom m)
-    => PerformSelection m Balance.SelectionResult
+    => PerformSelection m (Balance.SelectionResult InputId)
 performSelectionBalance cs ps =
     withExceptT SelectionBalanceErrorOf $ ExceptT $
     uncurry Balance.performSelection $ toBalanceConstraintsParams (cs, ps)
 
 performSelectionCollateral
     :: Applicative m
-    => Balance.SelectionResult
+    => Balance.SelectionResult InputId
     -> PerformSelection m Collateral.SelectionResult
 performSelectionCollateral balanceResult cs ps
     | selectionCollateralRequired ps =
@@ -443,7 +443,7 @@ toBalanceConstraintsParams (constraints, params) =
 -- | Creates constraints and parameters for 'Collateral.performSelection'.
 --
 toCollateralConstraintsParams
-    :: Balance.SelectionResult
+    :: Balance.SelectionResult InputId
     -> (           SelectionConstraints,            SelectionParams)
     -> (Collateral.SelectionConstraints, Collateral.SelectionParams)
 toCollateralConstraintsParams balanceResult (constraints, params) =
@@ -476,7 +476,7 @@ toCollateralConstraintsParams balanceResult (constraints, params) =
 --
 mkSelection
     :: SelectionParams
-    -> Balance.SelectionResult
+    -> Balance.SelectionResult InputId
     -> Collateral.SelectionResult
     -> Selection
 mkSelection _params balanceResult collateralResult = Selection
@@ -492,7 +492,7 @@ mkSelection _params balanceResult collateralResult = Selection
 
 -- | Converts a 'Selection' to a balance result.
 --
-toBalanceResult :: Selection -> Balance.SelectionResult
+toBalanceResult :: Selection -> Balance.SelectionResult InputId
 toBalanceResult selection = Balance.SelectionResult
     { inputsSelected = view #inputs selection
     , outputsCovered = view #outputs selection

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -228,7 +228,7 @@ data SelectionParams = SelectionParams
 --
 data SelectionError
     = SelectionBalanceErrorOf
-      SelectionBalanceError
+      (SelectionBalanceError InputId)
     | SelectionCollateralErrorOf
       SelectionCollateralError
     | SelectionOutputErrorOf
@@ -837,7 +837,8 @@ verifySelectionError cs ps = \case
 -- Selection error verification: balance errors
 --------------------------------------------------------------------------------
 
-verifySelectionBalanceError :: VerifySelectionError SelectionBalanceError
+verifySelectionBalanceError
+    :: VerifySelectionError (SelectionBalanceError InputId)
 verifySelectionBalanceError cs ps = \case
     Balance.BalanceInsufficient e ->
         verifyBalanceInsufficientError cs ps e
@@ -922,7 +923,7 @@ verifyInsufficientMinCoinValueError cs _ps e =
 data FailureToVerifySelectionLimitReachedError =
     FailureToVerifySelectionLimitReachedError
         { selectedInputs
-            :: [(TxIn, TxOut)]
+            :: [(InputId, TokenBundle)]
             -- ^ The inputs that were actually selected.
         , selectedInputCount
             :: Int
@@ -942,13 +943,13 @@ data FailureToVerifySelectionLimitReachedError =
 -- given the amount of space we expect to be reserved for collateral inputs.
 --
 verifySelectionLimitReachedError
-    :: VerifySelectionError Balance.SelectionLimitReachedError
+    :: VerifySelectionError (Balance.SelectionLimitReachedError InputId)
 verifySelectionLimitReachedError cs ps e =
     verify
         (Balance.MaximumInputLimit selectedInputCount >= selectionLimitAdjusted)
         (FailureToVerifySelectionLimitReachedError {..})
   where
-    selectedInputs :: [(TxIn, TxOut)]
+    selectedInputs :: [(InputId, TokenBundle)]
     selectedInputs = e ^. #inputsSelected
 
     selectedInputCount :: Int

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -359,7 +359,7 @@ selectionAllOutputs selection = (<>)
 --
 toBalanceConstraintsParams
     :: (        SelectionConstraints,         SelectionParams)
-    -> (Balance.SelectionConstraints, Balance.SelectionParams)
+    -> (Balance.SelectionConstraints, Balance.SelectionParams InputId)
 toBalanceConstraintsParams (constraints, params) =
     (balanceConstraints, balanceParams)
   where

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -230,7 +230,7 @@ data SelectionError
     = SelectionBalanceErrorOf
       (SelectionBalanceError InputId)
     | SelectionCollateralErrorOf
-      SelectionCollateralError
+      (SelectionCollateralError InputId)
     | SelectionOutputErrorOf
       SelectionOutputError
     deriving (Eq, Show)
@@ -333,7 +333,7 @@ performSelectionBalance cs ps =
 performSelectionCollateral
     :: Applicative m
     => Balance.SelectionResult InputId
-    -> PerformSelection m Collateral.SelectionResult
+    -> PerformSelection m (Collateral.SelectionResult InputId)
 performSelectionCollateral balanceResult cs ps
     | selectionCollateralRequired ps =
         withExceptT SelectionCollateralErrorOf $ ExceptT $ pure $
@@ -444,8 +444,8 @@ toBalanceConstraintsParams (constraints, params) =
 --
 toCollateralConstraintsParams
     :: Balance.SelectionResult InputId
-    -> (           SelectionConstraints,            SelectionParams)
-    -> (Collateral.SelectionConstraints, Collateral.SelectionParams)
+    -> (           SelectionConstraints,            SelectionParams        )
+    -> (Collateral.SelectionConstraints, Collateral.SelectionParams InputId)
 toCollateralConstraintsParams balanceResult (constraints, params) =
     (collateralConstraints, collateralParams)
   where
@@ -477,7 +477,7 @@ toCollateralConstraintsParams balanceResult (constraints, params) =
 mkSelection
     :: SelectionParams
     -> Balance.SelectionResult InputId
-    -> Collateral.SelectionResult
+    -> Collateral.SelectionResult InputId
     -> Selection
 mkSelection _params balanceResult collateralResult = Selection
     { inputs = view #inputsSelected balanceResult
@@ -1088,7 +1088,8 @@ data FailureToVerifySelectionCollateralError =
         }
         deriving (Eq, Show)
 
-verifySelectionCollateralError :: VerifySelectionError SelectionCollateralError
+verifySelectionCollateralError
+    :: VerifySelectionError (SelectionCollateralError InputId)
 verifySelectionCollateralError cs ps e =
     verifyAll
         [ Map.null largestCombinationUnsuitableSubset

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -271,13 +271,12 @@ data SelectionParamsOf outputs u = SelectionParams
     deriving Generic
 
 deriving instance
-    Eq (outputs (Address, TokenBundle)) =>
-    Eq u =>
-    Eq (SelectionParamsOf outputs u)
+    (Eq (outputs (Address, TokenBundle)), Eq u) =>
+        Eq (SelectionParamsOf outputs u)
+
 deriving instance
-    Show (outputs (Address, TokenBundle)) =>
-    Show u =>
-    Show (SelectionParamsOf outputs u)
+    (Show (outputs (Address, TokenBundle)), Show u) =>
+        Show (SelectionParamsOf outputs u)
 
 -- | Indicates whether the balance of available UTxO entries is sufficient.
 --
@@ -484,13 +483,11 @@ data SelectionResultOf outputs u = SelectionResult
     deriving Generic
 
 deriving instance
-    Eq (outputs (Address, TokenBundle)) =>
-    Eq u =>
-    Eq (SelectionResultOf outputs u)
+    (Eq (outputs (Address, TokenBundle)), Eq u) =>
+        Eq (SelectionResultOf outputs u)
 deriving instance
-    Show (outputs (Address, TokenBundle)) =>
-    Show u =>
-    Show (SelectionResultOf outputs u)
+    (Show (outputs (Address, TokenBundle)), Show u) =>
+        Show (SelectionResultOf outputs u)
 
 -- | Indicates the difference between total input value and total output value
 --   of a 'SelectionResult'.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
@@ -65,7 +65,7 @@ module Cardano.Wallet.Primitive.Types.UTxOSelection
 
       -- * Accessor functions
     , availableBalance
-    , availableUTxO
+    , availableMap
     , leftoverBalance
     , leftoverSize
     , leftoverIndex
@@ -325,7 +325,7 @@ isProperSubSelectionOf s1 s2 = state s1 /= state s2 && s1 `isSubSelectionOf` s2
 availableBalance :: IsUTxOSelection s u => s u -> TokenBundle
 availableBalance s = leftoverBalance s <> selectedBalance s
 
--- | Computes the available UTxO set.
+-- | Computes the complete map of all available UTxOs.
 --
 -- The available UTxO set is the union of the selected and leftover UTxO sets.
 --
@@ -334,10 +334,10 @@ availableBalance s = leftoverBalance s <> selectedBalance s
 -- This result of this function remains constant over applications of 'select'
 -- and 'selectMany':
 --
--- >>> availableUTxO s == availableUTxO (selectMany is s)
+-- >>> availableMap s == availableMap (selectMany is s)
 --
-availableUTxO :: IsUTxOSelection s u => Ord u => s u -> Map u TokenBundle
-availableUTxO s = leftoverMap s <> selectedMap s
+availableMap :: IsUTxOSelection s u => Ord u => s u -> Map u TokenBundle
+availableMap s = leftoverMap s <> selectedMap s
 
 -- | Retrieves the balance of leftover UTxOs.
 --

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -907,7 +907,7 @@ prop_performSelection mockConstraints params coverage =
         , assetsToBurn
         } = params
 
-    onSuccess :: SelectionResultOf [(Address, TokenBundle)] -> Property
+    onSuccess :: SelectionResultOf [] -> Property
     onSuccess result =
         counterexample "onSuccess" $
         report
@@ -1160,13 +1160,13 @@ prop_performSelectionEmpty mockConstraints (Small params) =
     constraints :: SelectionConstraints
     constraints = unMockSelectionConstraints mockConstraints
 
-    paramsTransformed :: SelectionParamsOf (NonEmpty (Address, TokenBundle))
+    paramsTransformed :: SelectionParamsOf NonEmpty
     paramsTransformed = view #paramsTransformed transformationReport
 
-    result :: SelectionResultOf (NonEmpty (Address, TokenBundle))
+    result :: SelectionResultOf NonEmpty
     result = expectRight $ view #result transformationReport
 
-    resultTransformed :: SelectionResultOf [(Address, TokenBundle)]
+    resultTransformed :: SelectionResultOf []
     resultTransformed =
         expectRight $ view #resultTransformed transformationReport
 
@@ -1211,17 +1211,17 @@ withTransformationReport p r = TransformationReport p r r
 --    - a single change output to cover the output deficit.
 --
 mockPerformSelectionNonEmpty
-    :: PerformSelection Identity (NonEmpty (Address, TokenBundle))
+    :: PerformSelection Identity NonEmpty
 mockPerformSelectionNonEmpty constraints params = Identity $ Right result
   where
-    result :: SelectionResultOf (NonEmpty (Address, TokenBundle))
+    result :: SelectionResultOf NonEmpty
     result = resultWithoutDelta & set #inputsSelected
         (makeInputsOfValue $ deficitIn <> TokenBundle.fromCoin minimumCost)
       where
         minimumCost :: Coin
         minimumCost = selectionMinimumCost constraints resultWithoutDelta
 
-    resultWithoutDelta :: SelectionResultOf (NonEmpty (Address, TokenBundle))
+    resultWithoutDelta :: SelectionResultOf NonEmpty
     resultWithoutDelta = SelectionResult
         { inputsSelected = makeInputsOfValue deficitIn
         , changeGenerated = makeChangeOfValue deficitOut

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -607,7 +607,7 @@ prop_AssetCount_TokenMap_placesEmptyMapsFirst maps =
 -- We define this type alias to shorten type signatures.
 --
 type PerformSelectionResult =
-    Either SelectionBalanceError (SelectionResult InputId)
+    Either (SelectionBalanceError InputId) (SelectionResult InputId)
 
 genSelectionParams
     :: Gen (InputId -> Bool)
@@ -973,7 +973,7 @@ prop_performSelection mockConstraints params coverage =
                 (view #inputsSelected result <&> fst)
                 (view #utxoAvailable params)
 
-    onFailure :: SelectionBalanceError -> Property
+    onFailure :: SelectionBalanceError InputId -> Property
     onFailure = \case
         BalanceInsufficient e ->
             onBalanceInsufficient e
@@ -1011,7 +1011,7 @@ prop_performSelection mockConstraints params coverage =
       where
         BalanceInsufficientError errorBalanceAvailable errorBalanceRequired = e
 
-    onSelectionLimitReached :: SelectionLimitReachedError -> Property
+    onSelectionLimitReached :: SelectionLimitReachedError InputId -> Property
     onSelectionLimitReached e =
         counterexample "onSelectionLimitReached" $
         report errorBalanceRequired
@@ -1212,7 +1212,7 @@ withTransformationReport p r = TransformationReport p r r
 --    - a single change output to cover the output deficit.
 --
 mockPerformSelectionNonEmpty
-    :: PerformSelection Identity NonEmpty
+    :: PerformSelection Identity NonEmpty InputId
 mockPerformSelectionNonEmpty constraints params = Identity $ Right result
   where
     result :: SelectionResultOf NonEmpty InputId
@@ -1248,7 +1248,7 @@ mockPerformSelectionNonEmpty constraints params = Identity $ Right result
 
 prop_runSelection_UTxO_empty :: TokenBundle -> Property
 prop_runSelection_UTxO_empty balanceRequested = monadicIO $ do
-    result <- run $ runSelection
+    result <- run $ runSelection @_ @InputId
         RunSelectionParams
             { selectionLimit = NoLimit
             , utxoAvailable

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/CollateralSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/CollateralSpec.hs
@@ -25,13 +25,13 @@ import Prelude hiding
     ( sequence )
 
 import Cardano.Wallet.CoinSelection.Internal.Collateral
-    ( PerformSelectionOf
+    ( PerformSelection
     , SearchSpaceLimit (..)
     , SearchSpaceRequirement (..)
-    , SelectionCollateralErrorOf (..)
+    , SelectionCollateralError (..)
     , SelectionConstraints (..)
-    , SelectionParamsOf (..)
-    , SelectionResultOf (..)
+    , SelectionParams (..)
+    , SelectionResult (..)
     , firstRight
     , guardSearchSpaceSize
     , numberOfSubsequencesOfSize
@@ -202,7 +202,7 @@ spec = do
 --  - maximum selection sizes
 --
 prop_performSelection_general_withFunction
-    :: PerformSelectionOf LongInputId -> Property
+    :: PerformSelection LongInputId -> Property
 prop_performSelection_general_withFunction performSelectionFn =
     checkCoverage $
     forAll (arbitrary @(Map LongInputId Coin))
@@ -225,8 +225,8 @@ prop_performSelection_general_withFunction performSelectionFn =
 prop_performSelection_general_withResult
     :: (Ord inputId, Show inputId)
     => SelectionConstraints
-    -> SelectionParamsOf inputId
-    -> Either (SelectionCollateralErrorOf inputId) (SelectionResultOf inputId)
+    -> SelectionParams inputId
+    -> Either (SelectionCollateralError inputId) (SelectionResult inputId)
     -> Property
 prop_performSelection_general_withResult constraints params eitherErrorResult =
     cover 20.0 (isLeft  eitherErrorResult) "Failure" $
@@ -240,8 +240,8 @@ prop_performSelection_general_withResult constraints params eitherErrorResult =
 prop_performSelection_onFailure
     :: (Ord inputId, Show inputId)
     => SelectionConstraints
-    -> SelectionParamsOf inputId
-    -> SelectionCollateralErrorOf inputId
+    -> SelectionParams inputId
+    -> SelectionCollateralError inputId
     -> Property
 prop_performSelection_onFailure constraints params err =
     counterexample ("Error: " <> show (Pretty err)) $
@@ -257,8 +257,8 @@ prop_performSelection_onFailure constraints params err =
 prop_performSelection_onSuccess
     :: (Ord inputId, Show inputId)
     => SelectionConstraints
-    -> SelectionParamsOf inputId
-    -> SelectionResultOf inputId
+    -> SelectionParams inputId
+    -> SelectionResult inputId
     -> Property
 prop_performSelection_onSuccess constraints params result =
     counterexample ("Result: " <> show (Pretty result)) $

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -191,7 +192,7 @@ spec = describe "Cardano.Wallet.CoinSelection.InternalSpec" $ do
 
 prop_performSelection
     :: Pretty MockSelectionConstraints
-    -> Pretty SelectionParams
+    -> Pretty (SelectionParams InputId)
     -> Property
 prop_performSelection (Pretty mockConstraints) (Pretty params) =
     monadicIO $
@@ -202,8 +203,8 @@ prop_performSelection (Pretty mockConstraints) (Pretty params) =
 
 prop_performSelection_inner
     :: SelectionConstraints
-    -> SelectionParams
-    -> Either SelectionError Selection
+    -> SelectionParams InputId
+    -> Either (SelectionError InputId) (Selection InputId)
     -> Property
 prop_performSelection_inner constraints params result =
     checkCoverage $
@@ -220,8 +221,8 @@ prop_performSelection_inner constraints params result =
 
 prop_performSelection_coverage
     :: Testable property
-    => SelectionParams
-    -> Either SelectionError Selection
+    => SelectionParams InputId
+    -> Either (SelectionError InputId) (Selection InputId)
     -> property
     -> Property
 prop_performSelection_coverage params r innerProperty =
@@ -316,7 +317,7 @@ prop_performSelection_coverage params r innerProperty =
 --
 prop_toBalanceConstraintsParams_computeMinimumCost
     :: MockSelectionConstraints
-    -> SelectionParams
+    -> SelectionParams InputId
     -> SelectionSkeleton
     -> Property
 prop_toBalanceConstraintsParams_computeMinimumCost
@@ -373,7 +374,7 @@ prop_toBalanceConstraintsParams_computeMinimumCost
 --
 prop_toBalanceConstraintsParams_computeSelectionLimit
     :: MockSelectionConstraints
-    -> SelectionParams
+    -> SelectionParams InputId
     -> Property
 prop_toBalanceConstraintsParams_computeSelectionLimit mockConstraints params =
     checkCoverage $
@@ -612,7 +613,7 @@ shrinkMinimumCollateralPercentage = shrinkNatural
 -- Selection parameters
 --------------------------------------------------------------------------------
 
-genSelectionParams :: Gen SelectionParams
+genSelectionParams :: Gen (SelectionParams InputId)
 genSelectionParams = SelectionParams
     <$> genAssetsToBurn
     <*> genAssetsToMint
@@ -626,7 +627,7 @@ genSelectionParams = SelectionParams
     <*> genUTxOAvailableForCollateral
     <*> genUTxOAvailableForInputs
 
-shrinkSelectionParams :: SelectionParams -> [SelectionParams]
+shrinkSelectionParams :: SelectionParams InputId -> [SelectionParams InputId]
 shrinkSelectionParams = genericRoundRobinShrink
     <@> shrinkAssetsToBurn
     <:> shrinkAssetsToMint
@@ -848,7 +849,7 @@ instance Arbitrary MockSelectionConstraints where
     arbitrary = genMockSelectionConstraints
     shrink = shrinkMockSelectionConstraints
 
-instance Arbitrary SelectionParams where
+instance Arbitrary (SelectionParams InputId) where
     arbitrary = genSelectionParams
     shrink = shrinkSelectionParams
 

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -55,7 +55,7 @@ import Cardano.Wallet.CoinSelection.Internal.BalanceSpec
     , unMockComputeSelectionLimit
     )
 import Cardano.Wallet.CoinSelection.Internal.Collateral
-    ( SelectionCollateralErrorOf (..) )
+    ( SelectionCollateralError (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address )
 import Cardano.Wallet.Primitive.Types.Address.Gen

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
@@ -101,8 +101,8 @@ spec =
 
     parallel $ describe "Indicator and accessor functions" $ do
 
-        it "prop_availableBalance_availableUTxO" $
-            property prop_availableBalance_availableUTxO
+        it "prop_availableBalance_availableMap" $
+            property prop_availableBalance_availableMap
         it "prop_isNonEmpty_selectedSize" $
             property prop_isNonEmpty_selectedSize
         it "prop_isNonEmpty_selectedIndex" $
@@ -128,8 +128,8 @@ spec =
             property prop_select_isProperSubSelectionOf
         it "prop_select_availableBalance" $
             property prop_select_availableBalance
-        it "prop_select_availableUTxO" $
-            property prop_select_availableUTxO
+        it "prop_select_availableMap" $
+            property prop_select_availableMap
         it "prop_select_leftoverSize" $
             property prop_select_leftoverSize
         it "prop_select_selectedSize" $
@@ -249,11 +249,11 @@ prop_toNonEmpty_fromNonEmpty s =
 -- Indicator and accessor functions
 --------------------------------------------------------------------------------
 
-prop_availableBalance_availableUTxO :: UTxOSelection InputId -> Property
-prop_availableBalance_availableUTxO s =
+prop_availableBalance_availableMap :: UTxOSelection InputId -> Property
+prop_availableBalance_availableMap s =
     checkCoverage_UTxOSelection s $
     UTxOSelection.availableBalance s
-    === F.fold (UTxOSelection.availableUTxO s)
+    === F.fold (UTxOSelection.availableMap s)
 
 prop_isNonEmpty_selectedSize :: UTxOSelection InputId -> Property
 prop_isNonEmpty_selectedSize s =
@@ -335,13 +335,13 @@ prop_select_availableBalance i s =
     then Just (UTxOSelection.availableBalance s)
     else Nothing
 
-prop_select_availableUTxO :: InputId -> UTxOSelection InputId -> Property
-prop_select_availableUTxO i s =
+prop_select_availableMap :: InputId -> UTxOSelection InputId -> Property
+prop_select_availableMap i s =
     checkCoverage_select i s $
-    (UTxOSelection.availableUTxO <$> UTxOSelection.select i s)
+    (UTxOSelection.availableMap <$> UTxOSelection.select i s)
     ===
     if UTxOSelection.isLeftover i s
-    then Just (UTxOSelection.availableUTxO s)
+    then Just (UTxOSelection.availableMap s)
     else Nothing
 
 prop_select_leftoverSize :: InputId -> UTxOSelection InputId -> Property


### PR DESCRIPTION
## Issue Number

ADP-1478

## Summary

This PR parameterizes the UTxO identifier type in all modules within the `CoinSelection.Internal` hierarchy.

As before, we use the type parameter `u` to represent the type of unique identifiers for individual UTxOs (unspent transaction outputs).

In general, callers of coin selection can instantiate `u` to any type for which there is an `Ord` instance.

## Not tackled by this PR

A future PR will update the test suite to use a more general type of UTxO identifier. For now, we continue to generate arbitrary values of `(TxIn, Address)` to act as UTxO identifiers.