### PR TITLE
Remove all remaining usages of `TxOut` from coin selection implementation.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -4328,9 +4328,9 @@ instance IsServerError SelectionOutputSizeExceedsLimitError where
         [ "One of the outputs you've specified contains too many assets. "
         , "Try splitting these assets across two or more outputs. "
         , "Destination address: "
-        , pretty (output ^. #address)
+        , pretty (fst output)
         , ". Asset count: "
-        , pretty (TokenMap.size $ output ^. (#tokens . #tokens))
+        , pretty (TokenMap.size $ snd output ^. #tokens)
         , "."
         ]
       where

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -86,7 +86,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TokenBundleSizeAssessment (..), TxOut (..), txOutMaxTokenQuantity )
+    ( TokenBundleSizeAssessment (..), txOutMaxTokenQuantity )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
 import Control.Monad
@@ -1135,7 +1135,7 @@ verifySelectionOutputError cs ps = \case
 
 newtype FailureToVerifySelectionOutputSizeExceedsLimitError =
     FailureToVerifySelectionOutputSizeExceedsLimitError
-        { outputReportedAsExceedingLimit :: TxOut }
+        { outputReportedAsExceedingLimit :: (Address, TokenBundle) }
     deriving (Eq, Show)
 
 verifySelectionOutputSizeExceedsLimitError
@@ -1149,10 +1149,9 @@ verifySelectionOutputSizeExceedsLimitError cs _ps e =
         TokenBundleSizeWithinLimit -> True
         TokenBundleSizeExceedsLimit -> False
       where
-        bundle = outputReportedAsExceedingLimit ^. #tokens
+        bundle = snd outputReportedAsExceedingLimit
 
-    outputReportedAsExceedingLimit = uncurry TxOut
-        (e ^. #outputThatExceedsLimit)
+    outputReportedAsExceedingLimit = e ^. #outputThatExceedsLimit
 
 --------------------------------------------------------------------------------
 -- Selection error verification: output token quantity errors

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -895,7 +895,7 @@ verifyEmptyUTxOError _cs SelectionParams {utxoAvailableForInputs} _e =
 
 data FailureToVerifyInsufficientMinCoinValueError =
     FailureToVerifyInsufficientMinCoinValueError
-    { reportedOutput :: TxOut
+    { reportedOutput :: (Address, TokenBundle)
     , reportedMinCoinValue :: Coin
     , verifiedMinCoinValue :: Coin
     }
@@ -906,7 +906,7 @@ verifyInsufficientMinCoinValueError
 verifyInsufficientMinCoinValueError cs _ps e =
     verifyAll
         [ reportedMinCoinValue == verifiedMinCoinValue
-        , reportedMinCoinValue > reportedOutput ^. (#tokens . #coin)
+        , reportedMinCoinValue > snd reportedOutput ^. #coin
         ]
         FailureToVerifyInsufficientMinCoinValueError {..}
   where
@@ -914,7 +914,7 @@ verifyInsufficientMinCoinValueError cs _ps e =
     reportedMinCoinValue = e ^. #expectedMinCoinValue
     verifiedMinCoinValue =
         (cs ^. #computeMinimumAdaQuantity)
-        (reportedOutput ^. (#tokens . #tokens))
+        (snd reportedOutput ^. #tokens)
 
 --------------------------------------------------------------------------------
 -- Selection error verification: selection limit errors

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -1151,7 +1151,8 @@ verifySelectionOutputSizeExceedsLimitError cs _ps e =
       where
         bundle = outputReportedAsExceedingLimit ^. #tokens
 
-    outputReportedAsExceedingLimit = e ^. #outputThatExceedsLimit
+    outputReportedAsExceedingLimit = uncurry TxOut
+        (e ^. #outputThatExceedsLimit)
 
 --------------------------------------------------------------------------------
 -- Selection error verification: output token quantity errors
@@ -1404,7 +1405,7 @@ data SelectionOutputError
 
 newtype SelectionOutputSizeExceedsLimitError =
     SelectionOutputSizeExceedsLimitError
-    { outputThatExceedsLimit :: TxOut
+    { outputThatExceedsLimit :: (Address, TokenBundle)
     }
     deriving (Eq, Generic, Show)
 
@@ -1421,7 +1422,7 @@ verifyOutputSize cs out
     | withinLimit =
         Nothing
     | otherwise =
-        Just $ SelectionOutputSizeExceedsLimitError (uncurry TxOut out)
+        Just $ SelectionOutputSizeExceedsLimitError out
   where
     withinLimit :: Bool
     withinLimit =

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -133,13 +133,12 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId, TokenMap )
+    ( AssetId, Flat (..), TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TokenBundleSizeAssessment (..)
     , TokenBundleSizeAssessor (..)
-    , TxOut (..)
     , txOutMaxCoin
     , txOutMaxTokenQuantity
     )
@@ -706,7 +705,7 @@ balanceMissing (BalanceInsufficientError available required) =
 --
 data InsufficientMinCoinValueError = InsufficientMinCoinValueError
     { outputWithInsufficientAda
-        :: !TxOut
+        :: !(Address, TokenBundle)
         -- ^ The particular output that does not have the minimum coin quantity
         -- expected by the protocol.
     , expectedMinCoinValue
@@ -715,9 +714,10 @@ data InsufficientMinCoinValueError = InsufficientMinCoinValueError
     } deriving (Generic, Eq, Show)
 
 instance Buildable InsufficientMinCoinValueError where
-    build (InsufficientMinCoinValueError o c) = unlinesF
+    build (InsufficientMinCoinValueError (a, b) c) = unlinesF
         [ nameF "Expected min coin value" (build c)
-        , nameF "TxOut" (build o)
+        , nameF "Address" (build a)
+        , nameF "Token bundle" (build (Flat b))
         ]
 
 data UnableToConstructChangeError = UnableToConstructChangeError
@@ -903,7 +903,7 @@ performSelectionNonEmpty constraints params
             | otherwise =
                 Just $ InsufficientMinCoinValueError
                     { expectedMinCoinValue
-                    , outputWithInsufficientAda = uncurry TxOut o
+                    , outputWithInsufficientAda = o
                     }
           where
             expectedMinCoinValue = computeMinimumAdaQuantity

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -136,7 +136,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TokenBundleSizeAssessor (..)
     , TxIn (..)
     , TxOut (..)
-    , txOutCoin
     , txOutMaxTokenQuantity
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
@@ -1049,7 +1048,7 @@ prop_performSelection mockConstraints params coverage =
         property True
       where
         actualMinCoinValue
-            = txOutCoin . outputWithInsufficientAda
+            = view #coin . snd . outputWithInsufficientAda
 
     onUnableToConstructChange :: UnableToConstructChangeError -> Property
     onUnableToConstructChange e =


### PR DESCRIPTION
## Issue Number

ADP-1482

## Summary

This PR removes all remaining usages of `TxOut` from the following modules:
- `CoinSelection.Internal`
- `CoinSelection.Internal.Balance`

## Background

This work is part of ADP-1448, the goal of which is to generalize the types used by coin selection, so that coin selection modules do not depend on the `Address`, `TxIn`, `TxOut`, or `UTxO` types.