### PR TITLE
Add the `SelectionStrategy` type.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -230,6 +230,7 @@ import Cardano.Wallet.CoinSelection
     , SelectionReportDetailed
     , SelectionReportSummarized
     , SelectionSkeleton (..)
+    , SelectionStrategy (..)
     , UnableToConstructChangeError (..)
     , emptySkeleton
     , makeSelectionReportDetailed
@@ -1986,6 +1987,8 @@ selectAssets ctx pp params transform = do
                 intCast @Word16 @Int $ view #maximumCollateralInputCount pp
             , minimumCollateralPercentage =
                 view #minimumCollateralPercentage pp
+            , selectionStrategy =
+                SelectionStrategyOptimal
             }
     let selectionParams = SelectionParams
             { assetsToMint =

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1541,6 +1541,7 @@ balanceTransaction
                 , utxoAvailableForInputs
                 , utxoAvailableForCollateral
                 , wallet
+                , selectionStrategy = SelectionStrategyOptimal
                 }
                 transform
 
@@ -1930,6 +1931,8 @@ data SelectAssetsParams s result = SelectAssetsParams
     , utxoAvailableForCollateral :: Map InputId TokenBundle
     , utxoAvailableForInputs :: UTxOSelection InputId
     , wallet :: Wallet s
+    , selectionStrategy :: SelectionStrategy
+        -- ^ Specifies which selection strategy to use. See 'SelectionStrategy'.
     }
     deriving Generic
 
@@ -1988,7 +1991,7 @@ selectAssets ctx pp params transform = do
             , minimumCollateralPercentage =
                 view #minimumCollateralPercentage pp
             , selectionStrategy =
-                SelectionStrategyOptimal
+                view #selectionStrategy params
             }
     let selectionParams = SelectionParams
             { assetsToMint =

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -314,6 +314,7 @@ import Cardano.Wallet.CoinSelection
     , SelectionOutputError (..)
     , SelectionOutputSizeExceedsLimitError (..)
     , SelectionOutputTokenQuantityExceedsLimitError (..)
+    , SelectionStrategy (..)
     , balanceMissing
     , selectionDelta
     , shortfall
@@ -1599,6 +1600,7 @@ selectCoins ctx genChange (ApiT wid) body = do
                 , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral = UTxOIndex.toMap utxoAvailable
                 , wallet
+                , selectionStrategy = SelectionStrategyOptimal
                 }
         utx <- liftHandler $
             W.selectAssets @_ @_ @s @k wrk pp selectAssetsParams transform
@@ -1650,6 +1652,7 @@ selectCoinsForJoin ctx knownPools getPoolStatus pid wid = do
                 , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral = UTxOIndex.toMap utxoAvailable
                 , wallet
+                , selectionStrategy = SelectionStrategyOptimal
                 }
         utx <- liftHandler
             $ W.selectAssets @_ @_ @s @k wrk pp selectAssetsParams transform
@@ -1701,6 +1704,7 @@ selectCoinsForQuit ctx (ApiT wid) = do
                 , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral = UTxOIndex.toMap utxoAvailable
                 , wallet
+                , selectionStrategy = SelectionStrategyOptimal
                 }
         utx <- liftHandler
             $ W.selectAssets @_ @_ @s @k wrk pp selectAssetsParams transform
@@ -1969,6 +1973,7 @@ postTransactionOld ctx genChange (ApiT wid) body = do
                     , utxoAvailableForCollateral =
                         UTxOIndex.toMap utxoAvailable
                     , wallet
+                    , selectionStrategy = SelectionStrategyOptimal
                     }
             sel <- liftHandler
                 $ W.selectAssets @_ @_ @s @k wrk pp selectAssetsParams
@@ -2119,6 +2124,7 @@ postTransactionFeeOld ctx (ApiT wid) body = do
                 , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral = UTxOIndex.toMap utxoAvailable
                 , wallet
+                , selectionStrategy = SelectionStrategyOptimal
                 }
         let runSelection =
                 W.selectAssets @_ @_ @s @k wrk pp selectAssetsParams getFee
@@ -2230,6 +2236,7 @@ constructTransaction ctx genChange knownPools getPoolStatus (ApiT wid) body = do
                     , utxoAvailableForCollateral =
                         UTxOIndex.toMap utxoAvailable
                     , wallet
+                    , selectionStrategy = SelectionStrategyOptimal
                     }
 
         (sel, sel', fee) <- do
@@ -2588,6 +2595,7 @@ joinStakePool ctx knownPools getPoolStatus apiPoolId (ApiT wid) body = do
                 , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral = UTxOIndex.toMap utxoAvailable
                 , wallet
+                , selectionStrategy = SelectionStrategyOptimal
                 }
         sel <- liftHandler
             $ W.selectAssets @_ @_ @s @k wrk pp selectAssetsParams
@@ -2656,6 +2664,7 @@ delegationFee ctx (ApiT wid) = do
             , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
             , utxoAvailableForCollateral = UTxOIndex.toMap utxoAvailable
             , wallet
+            , selectionStrategy = SelectionStrategyOptimal
             }
 
 quitStakePool
@@ -2702,6 +2711,7 @@ quitStakePool ctx (ApiT wid) body = do
                 , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral = UTxOIndex.toMap utxoAvailable
                 , wallet
+                , selectionStrategy = SelectionStrategyOptimal
                 }
         sel <- liftHandler
             $ W.selectAssets @_ @_ @s @k wrk pp selectAssetsParams

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -31,6 +31,7 @@ module Cardano.Wallet.CoinSelection
     , SelectionLimitOf (..)
     , SelectionOf (..)
     , SelectionParams (..)
+    , SelectionStrategy (..)
 
     -- * Selection skeletons
     , SelectionSkeleton (..)
@@ -164,6 +165,9 @@ data SelectionConstraints = SelectionConstraints
         :: Natural
         -- ^ Specifies the minimum required amount of collateral as a
         -- percentage of the total transaction fee.
+    , selectionStrategy
+        :: SelectionStrategy
+        -- ^ Specifies which selection strategy to use. See 'SelectionStrategy'.
     }
     deriving Generic
 
@@ -175,8 +179,6 @@ toInternalSelectionConstraints SelectionConstraints {..} =
             computeMinimumCost . toExternalSelectionSkeleton
         , computeSelectionLimit =
             computeSelectionLimit . fmap (uncurry TxOut)
-        , selectionStrategy =
-            SelectionStrategyOptimal
         , ..
         }
 

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -69,6 +69,7 @@ import Cardano.Wallet.CoinSelection.Internal.Balance
     , SelectionBalanceError (..)
     , SelectionLimit
     , SelectionLimitOf (..)
+    , SelectionStrategy (..)
     , UnableToConstructChangeError (..)
     , balanceMissing
     )
@@ -174,6 +175,8 @@ toInternalSelectionConstraints SelectionConstraints {..} =
             computeMinimumCost . toExternalSelectionSkeleton
         , computeSelectionLimit =
             computeSelectionLimit . fmap (uncurry TxOut)
+        , selectionStrategy =
+            SelectionStrategyOptimal
         , ..
         }
 

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -72,6 +72,7 @@ import Cardano.Wallet.CoinSelection.Internal.Balance
     , SelectionDelta (..)
     , SelectionLimit
     , SelectionSkeleton
+    , SelectionStrategy (..)
     )
 import Cardano.Wallet.CoinSelection.Internal.Collateral
     ( SelectionCollateralError )
@@ -371,6 +372,8 @@ toBalanceConstraintsParams (constraints, params) =
                 & adjustComputeSelectionLimit
         , assessTokenBundleSize =
             view #assessTokenBundleSize constraints
+        , selectionStrategy =
+            SelectionStrategyOptimal
         }
       where
         adjustComputeMinimumCost

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -176,6 +176,9 @@ data SelectionConstraints = SelectionConstraints
         :: Natural
         -- ^ Specifies the minimum required amount of collateral as a
         -- percentage of the total transaction fee.
+    , selectionStrategy
+        :: SelectionStrategy
+        -- ^ Specifies which selection strategy to use. See 'SelectionStrategy'.
     }
     deriving Generic
 
@@ -373,7 +376,7 @@ toBalanceConstraintsParams (constraints, params) =
         , assessTokenBundleSize =
             view #assessTokenBundleSize constraints
         , selectionStrategy =
-            SelectionStrategyOptimal
+            view #selectionStrategy constraints
         }
       where
         adjustComputeMinimumCost

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -230,6 +230,9 @@ data SelectionConstraints = SelectionConstraints
         :: [(Address, TokenBundle)] -> SelectionLimit
         -- ^ Computes an upper bound for the number of ordinary inputs to
         -- select, given a current set of outputs.
+    , selectionStrategy
+        :: SelectionStrategy
+        -- ^ Specifies which selection strategy to use. See 'SelectionStrategy'.
     }
     deriving Generic
 
@@ -855,7 +858,7 @@ performSelectionNonEmpty constraints params
             { selectionLimit
             , utxoAvailable
             , minimumBalance = utxoBalanceRequired
-            , selectionStrategy = SelectionStrategyOptimal
+            , selectionStrategy
             }
         case maybeSelection of
             Nothing | utxoAvailable == UTxOSelection.empty ->
@@ -877,6 +880,7 @@ performSelectionNonEmpty constraints params
         , computeMinimumAdaQuantity
         , computeMinimumCost
         , computeSelectionLimit
+        , selectionStrategy
         } = constraints
     SelectionParams
         { outputsToCover

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -1295,6 +1295,7 @@ runSelectionStep lens s
         , updatedQuantity
         , minimumQuantity
         , selectQuantity
+        , selectionStrategy
         } = lens
 
     requireImprovement :: state' -> Maybe state'
@@ -1308,8 +1309,12 @@ runSelectionStep lens s
     updatedDistanceFromTarget :: state' -> Natural
     updatedDistanceFromTarget = distance targetQuantity . updatedQuantity
 
+    targetMultiplier :: Natural
+    targetMultiplier = case selectionStrategy of
+        SelectionStrategyOptimal -> 2
+
     targetQuantity :: Natural
-    targetQuantity = minimumQuantity * 2
+    targetQuantity = minimumQuantity * targetMultiplier
 
 --------------------------------------------------------------------------------
 -- Making change

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -1064,6 +1064,7 @@ prop_performSelection mockConstraints params coverage =
                 , computeMinimumAdaQuantity = computeMinimumAdaQuantityZero
                 , computeMinimumCost = computeMinimumCostZero
                 , computeSelectionLimit = const NoLimit
+                , selectionStrategy = SelectionStrategyOptimal
                 }
             performSelection' = performSelection constraints' params
         in
@@ -1700,6 +1701,7 @@ mkBoundaryTestExpectation (BoundaryTestData params expectedResult) = do
         , assessTokenBundleSize = unMockAssessTokenBundleSize $
             boundaryTestBundleSizeAssessor params
         , computeSelectionLimit = const NoLimit
+        , selectionStrategy = SelectionStrategyOptimal
         }
 
 encodeBoundaryTestCriteria :: BoundaryTestCriteria -> SelectionParams InputId
@@ -2116,6 +2118,8 @@ unMockSelectionConstraints m = SelectionConstraints
         unMockComputeMinimumCost $ view #computeMinimumCost m
     , computeSelectionLimit =
         unMockComputeSelectionLimit $ view #computeSelectionLimit m
+    , selectionStrategy =
+        SelectionStrategyOptimal
     }
 
 --------------------------------------------------------------------------------

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -57,6 +57,7 @@ import Cardano.Wallet.CoinSelection.Internal.Balance
     , SelectionResult
     , SelectionResultOf (..)
     , SelectionSkeleton (..)
+    , SelectionStrategy (..)
     , UnableToConstructChangeError (..)
     , addMintValueToChangeMaps
     , addMintValuesToChangeMaps
@@ -1494,6 +1495,7 @@ runMockSelectionStep d =
         , updatedQuantity = id
         , minimumQuantity = mockMinimum d
         , selectQuantity = \s -> pure $ (+ s) <$> mockNext d
+        , selectionStrategy = SelectionStrategyOptimal
         }
 
 prop_runSelectionStep_supplyExhausted

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -1613,7 +1613,8 @@ prop_assetSelectionLens_givesPriorityToSingletonAssets (Blind (Small u)) =
     asset = Set.findMin $ UTxOIndex.assets u
     assetCount = Set.size $ UTxOIndex.assets u
     initialState = UTxOSelection.fromIndex u
-    lens = assetSelectionLens NoLimit (asset, minimumAssetQuantity)
+    lens = assetSelectionLens
+        NoLimit SelectionStrategyOptimal (asset, minimumAssetQuantity)
     minimumAssetQuantity = TokenQuantity 1
 
 prop_coinSelectionLens_givesPriorityToCoins
@@ -1643,7 +1644,8 @@ prop_coinSelectionLens_givesPriorityToCoins (Blind (Small u)) =
   where
     entryCount = UTxOIndex.size u
     initialState = UTxOSelection.fromIndex u
-    lens = coinSelectionLens NoLimit minimumCoinQuantity
+    lens = coinSelectionLens
+        NoLimit SelectionStrategyOptimal minimumCoinQuantity
     minimumCoinQuantity = Coin 1
 
 --------------------------------------------------------------------------------

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -1253,6 +1253,7 @@ prop_runSelection_UTxO_empty balanceRequested = monadicIO $ do
             { selectionLimit = NoLimit
             , utxoAvailable
             , minimumBalance = balanceRequested
+            , selectionStrategy = SelectionStrategyOptimal
             }
     let balanceSelected = UTxOSelection.selectedBalance result
     let balanceLeftover = UTxOSelection.leftoverBalance result
@@ -1275,6 +1276,7 @@ prop_runSelection_UTxO_notEnough utxoAvailable = monadicIO $ do
             { selectionLimit = NoLimit
             , utxoAvailable
             , minimumBalance = balanceRequested
+            , selectionStrategy = SelectionStrategyOptimal
             }
     let balanceSelected = UTxOSelection.selectedBalance result
     let balanceLeftover = UTxOSelection.leftoverBalance result
@@ -1298,6 +1300,7 @@ prop_runSelection_UTxO_exactlyEnough utxoAvailable = monadicIO $ do
             { selectionLimit = NoLimit
             , utxoAvailable
             , minimumBalance = balanceRequested
+            , selectionStrategy = SelectionStrategyOptimal
             }
     let balanceSelected = UTxOSelection.selectedBalance result
     let balanceLeftover = UTxOSelection.leftoverBalance result
@@ -1325,6 +1328,7 @@ prop_runSelection_UTxO_moreThanEnough utxoAvailable = monadicIO $ do
             { selectionLimit = NoLimit
             , utxoAvailable
             , minimumBalance = balanceRequested
+            , selectionStrategy = SelectionStrategyOptimal
             }
     let balanceSelected = UTxOSelection.selectedBalance result
     let balanceLeftover = UTxOSelection.leftoverBalance result
@@ -1372,6 +1376,7 @@ prop_runSelection_UTxO_muchMoreThanEnough (Blind (Large index)) =
                 { selectionLimit = NoLimit
                 , utxoAvailable
                 , minimumBalance = balanceRequested
+                , selectionStrategy = SelectionStrategyOptimal
                 }
         let balanceSelected = UTxOSelection.selectedBalance result
         let balanceLeftover = UTxOSelection.leftoverBalance result

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -34,7 +34,7 @@ import Cardano.Wallet.CoinSelection.Internal
     , verifySelectionError
     )
 import Cardano.Wallet.CoinSelection.Internal.Balance
-    ( SelectionLimit, SelectionSkeleton )
+    ( SelectionLimit, SelectionSkeleton, SelectionStrategy (..) )
 import Cardano.Wallet.CoinSelection.Internal.Balance.Gen
     ( genSelectionSkeleton, shrinkSelectionSkeleton )
 import Cardano.Wallet.CoinSelection.Internal.BalanceSpec
@@ -577,6 +577,8 @@ unMockSelectionConstraints m = SelectionConstraints
         view #maximumCollateralInputCount m
     , minimumCollateralPercentage =
         view #minimumCollateralPercentage m
+    , selectionStrategy =
+        SelectionStrategyOptimal
     }
 
 --------------------------------------------------------------------------------

--- a/lib/shelley/bench/restore-bench.hs
+++ b/lib/shelley/bench/restore-bench.hs
@@ -458,17 +458,17 @@ benchmarksRnd _ w wid wname benchname restoreTime = do
         (utxoAvailable, wallet, pendingTxs) <-
             unsafeRunExceptT $ W.readWalletUTxOIndex @_ @s @k w wid
         pp <- liftIO $ currentProtocolParameters (w ^. networkLayer)
-        let runSelection = W.selectAssets @_ @_ @s @k w pp W.SelectAssetsParams
+        let selectAssetsParams = W.SelectAssetsParams
                 { outputs = [out]
                 , pendingTxs
                 , randomSeed = Nothing
                 , txContext = txCtx
-                , utxoAvailableForInputs =
-                    UTxOSelection.fromIndex utxoAvailable
-                , utxoAvailableForCollateral =
-                    UTxOIndex.toMap utxoAvailable
+                , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
+                , utxoAvailableForCollateral = UTxOIndex.toMap utxoAvailable
                 , wallet
-                } getFee
+                }
+        let runSelection =
+                W.selectAssets @_ @_ @s @k w pp selectAssetsParams getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection
 
     oneAddress <- genAddresses 1 cp
@@ -561,17 +561,17 @@ benchmarksSeq _ w wid _wname benchname restoreTime = do
         (utxoAvailable, wallet, pendingTxs) <-
             unsafeRunExceptT $ W.readWalletUTxOIndex w wid
         pp <- liftIO $ currentProtocolParameters (w ^. networkLayer)
-        let runSelection = W.selectAssets @_ @_ @s @k w pp W.SelectAssetsParams
+        let selectAssetsParams = W.SelectAssetsParams
                 { outputs = [out]
                 , pendingTxs
                 , randomSeed = Nothing
                 , txContext = txCtx
-                , utxoAvailableForInputs =
-                    UTxOSelection.fromIndex utxoAvailable
-                , utxoAvailableForCollateral =
-                    UTxOIndex.toMap utxoAvailable
+                , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
+                , utxoAvailableForCollateral = UTxOIndex.toMap utxoAvailable
                 , wallet
-                } getFee
+                }
+        let runSelection =
+                W.selectAssets @_ @_ @s @k w pp selectAssetsParams getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection
 
     let walletOverview = WalletOverview{utxo,addresses,transactions}

--- a/lib/shelley/bench/restore-bench.hs
+++ b/lib/shelley/bench/restore-bench.hs
@@ -69,7 +69,7 @@ import Cardano.Wallet.BenchShared
     , runBenchmarks
     )
 import Cardano.Wallet.CoinSelection
-    ( selectionDelta )
+    ( SelectionStrategy (..), selectionDelta )
 import Cardano.Wallet.DB
     ( DBLayer )
 import Cardano.Wallet.DB.Sqlite
@@ -466,6 +466,7 @@ benchmarksRnd _ w wid wname benchname restoreTime = do
                 , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral = UTxOIndex.toMap utxoAvailable
                 , wallet
+                , selectionStrategy = SelectionStrategyOptimal
                 }
         let runSelection =
                 W.selectAssets @_ @_ @s @k w pp selectAssetsParams getFee
@@ -569,6 +570,7 @@ benchmarksSeq _ w wid _wname benchname restoreTime = do
                 , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
                 , utxoAvailableForCollateral = UTxOIndex.toMap utxoAvailable
                 , wallet
+                , selectionStrategy = SelectionStrategyOptimal
                 }
         let runSelection =
                 W.selectAssets @_ @_ @s @k w pp selectAssetsParams getFee


### PR DESCRIPTION
## Issue Number

ADP-1499

## Summary

This PR is intended to be a **pure refactoring**, with no changes to behaviour. It adds the `SelectionStrategy` type to the coin selection library, which will eventually be defined as:

```hs
data SelectionStrategy
    = SelectionStrategyMinimal
    | SelectionStrategyOptimal
```

This PR adds only the `SelectionStrategyOptimal` constructor: this strategy corresponds to the **existing** behaviour of coin selection.

A future PR will add the `SelectionStrategyMinimal` constructor, along with appropriate test coverage.

## Explanation

These two strategies are intended to correspond to the following behaviours:

- Specifying the **optimal** strategy (currently the default) should cause the coin selection algorithm to attempt to select _around twice_ the minimum possible amount of each asset from the available UTxO set, making it possible to generate change outputs that are _roughly_ the same sizes and shapes as the user-specified outputs.

- Specifying the **minimal** strategy should cause the coin selection algorithm to select _just enough_ of each asset from the available UTxO set to meet the minimum amount. When the minimum amount of each asset is satisfied, coin selection should terminate. This strategy, if used frequently, may sacrifice the long-term health of the wallet’s UTxO distribution, as it’s likely to produce a greater concentration of dust values. Therefore, it should only be used as a fallback: i.e., if using the optimal strategy produces a selection that is too large.