### PR TITLE
Add support for minimal coin selections

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1992,8 +1992,6 @@ selectAssets ctx pp params transform = do
                 intCast @Word16 @Int $ view #maximumCollateralInputCount pp
             , minimumCollateralPercentage =
                 view #minimumCollateralPercentage pp
-            , selectionStrategy =
-                view #selectionStrategy params
             }
     let selectionParams = SelectionParams
             { assetsToMint =
@@ -2019,6 +2017,8 @@ selectAssets ctx pp params transform = do
                 params ^. #utxoAvailableForCollateral
             , utxoAvailableForInputs =
                 params ^. #utxoAvailableForInputs
+            , selectionStrategy =
+                view #selectionStrategy params
             }
     randomSeed <- maybe stdGenSeed pure (params ^. #randomSeed)
     let mSel = flip evalRand (stdGenFromSeed randomSeed)

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -165,9 +165,6 @@ data SelectionConstraints = SelectionConstraints
         :: Natural
         -- ^ Specifies the minimum required amount of collateral as a
         -- percentage of the total transaction fee.
-    , selectionStrategy
-        :: SelectionStrategy
-        -- ^ Specifies which selection strategy to use. See 'SelectionStrategy'.
     }
     deriving Generic
 
@@ -236,6 +233,9 @@ data SelectionParams = SelectionParams
         -- selected.
         --
         -- Further entries from this set will be selected to cover any deficit.
+    , selectionStrategy
+        :: SelectionStrategy
+        -- ^ Specifies which selection strategy to use. See 'SelectionStrategy'.
     }
     deriving (Eq, Generic, Show)
 

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -176,9 +176,6 @@ data SelectionConstraints = SelectionConstraints
         :: Natural
         -- ^ Specifies the minimum required amount of collateral as a
         -- percentage of the total transaction fee.
-    , selectionStrategy
-        :: SelectionStrategy
-        -- ^ Specifies which selection strategy to use. See 'SelectionStrategy'.
     }
     deriving Generic
 
@@ -226,6 +223,9 @@ data SelectionParams u = SelectionParams
         -- selected.
         --
         -- Further entries from this set will be selected to cover any deficit.
+    , selectionStrategy
+        :: SelectionStrategy
+        -- ^ Specifies which selection strategy to use. See 'SelectionStrategy'.
     }
     deriving (Eq, Generic, Show)
 
@@ -375,8 +375,6 @@ toBalanceConstraintsParams (constraints, params) =
                 & adjustComputeSelectionLimit
         , assessTokenBundleSize =
             view #assessTokenBundleSize constraints
-        , selectionStrategy =
-            view #selectionStrategy constraints
         }
       where
         adjustComputeMinimumCost
@@ -441,6 +439,8 @@ toBalanceConstraintsParams (constraints, params) =
             view #outputsToCover params
         , utxoAvailable =
             view #utxoAvailableForInputs params
+        , selectionStrategy =
+            view #selectionStrategy params
         }
 
 -- | Creates constraints and parameters for 'Collateral.performSelection'.

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -316,7 +316,7 @@ deriving instance
 data SelectionStrategy
     = SelectionStrategyMinimal
     | SelectionStrategyOptimal
-    deriving (Eq, Show)
+    deriving (Bounded, Enum, Eq, Show)
 
 -- | Indicates whether the balance of available UTxO entries is sufficient.
 --

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -293,8 +293,29 @@ deriving instance
 -- UTxO set, making it possible to generate change outputs that are roughly
 -- the same sizes and shapes as the user-specified outputs.
 --
+-- Specifying 'SelectionStrategyMinimal' will cause the selection algorithm to
+-- only select __just enough__ of each asset from the available UTxO set to
+-- meet the minimum amount. The selection process will terminate as soon as
+-- the minimum amount of each asset is covered.
+--
+-- The "optimal" strategy is recommended for most situations, as using this
+-- strategy will help to ensure that a wallet's UTxO distribution can evolve
+-- over time to resemble the typical distribution of payments made by the
+-- wallet owner.  This increases the likelihood that future selections will
+-- succeed, and lowers the amortized cost of future transactions.
+--
+-- The "minimal" strategy is recommended only for situations where it is not
+-- possible to create a selection with the "optimal" strategy. It is advised to
+-- use this strategy only when necessary, as it increases the likelihood of
+-- generating change outputs that are much smaller than user-specified outputs.
+-- If this strategy is used regularly, the UTxO set can evolve to a state where
+-- the distribution no longer resembles the typical distribution of payments
+-- made by the user. This increases the likelihood that future selections will
+-- not succeed, and increases the amortized cost of future transactions.
+--
 data SelectionStrategy
-    = SelectionStrategyOptimal
+    = SelectionStrategyMinimal
+    | SelectionStrategyOptimal
     deriving (Eq, Show)
 
 -- | Indicates whether the balance of available UTxO entries is sufficient.
@@ -1288,8 +1309,8 @@ data SelectionLens m state state' = SelectionLens
 --    - If the total selected token quantity of the previous selection had
 --      already reached or surpassed 100% of the output token quantity, any
 --      additional selection is considered to be an improvement if and only
---      if it takens the total selected token quantity closer to 200% of the
---      output token quantity, but not further away.
+--      if it takens the total selected token quantity closer to the target
+--      token quantity, but not further away.
 --
 runSelectionStep
     :: forall m state state'. Monad m
@@ -1323,6 +1344,7 @@ runSelectionStep lens s
 
     targetMultiplier :: Natural
     targetMultiplier = case selectionStrategy of
+        SelectionStrategyMinimal -> 1
         SelectionStrategyOptimal -> 2
 
     targetQuantity :: Natural

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -230,9 +230,6 @@ data SelectionConstraints = SelectionConstraints
         :: [(Address, TokenBundle)] -> SelectionLimit
         -- ^ Computes an upper bound for the number of ordinary inputs to
         -- select, given a current set of outputs.
-    , selectionStrategy
-        :: SelectionStrategy
-        -- ^ Specifies which selection strategy to use. See 'SelectionStrategy'.
     }
     deriving Generic
 
@@ -270,6 +267,9 @@ data SelectionParamsOf outputs u = SelectionParams
         -- By burning tokens, we generally increase the burden of the selection
         -- algorithm, requiring it to select more UTxO entries in order to
         -- cover the burn.
+    , selectionStrategy
+        :: SelectionStrategy
+        -- ^ Specifies which selection strategy to use. See 'SelectionStrategy'.
     }
     deriving Generic
 
@@ -901,7 +901,6 @@ performSelectionNonEmpty constraints params
         , computeMinimumAdaQuantity
         , computeMinimumCost
         , computeSelectionLimit
-        , selectionStrategy
         } = constraints
     SelectionParams
         { outputsToCover
@@ -910,6 +909,7 @@ performSelectionNonEmpty constraints params
         , extraCoinSink
         , assetsToMint
         , assetsToBurn
+        , selectionStrategy
         } = params
 
     selectionLimitReachedError

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance/Gen.hs
@@ -4,15 +4,21 @@
 module Cardano.Wallet.CoinSelection.Internal.Balance.Gen
     ( genSelectionLimit
     , genSelectionSkeleton
+    , genSelectionStrategy
     , shrinkSelectionLimit
     , shrinkSelectionSkeleton
+    , shrinkSelectionStrategy
     )
     where
 
 import Prelude
 
 import Cardano.Wallet.CoinSelection.Internal.Balance
-    ( SelectionLimit, SelectionLimitOf (..), SelectionSkeleton (..) )
+    ( SelectionLimit
+    , SelectionLimitOf (..)
+    , SelectionSkeleton (..)
+    , SelectionStrategy (..)
+    )
 import Cardano.Wallet.Primitive.Types.Address.Gen
     ( genAddress, shrinkAddress )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -29,6 +35,7 @@ import Test.QuickCheck
     ( Gen
     , NonNegative (..)
     , arbitrary
+    , arbitraryBoundedEnum
     , listOf
     , oneof
     , shrink
@@ -101,3 +108,18 @@ shrinkSelectionSkeleton = genericRoundRobinShrink
 
 tokenBundleHasNonZeroCoin :: TokenBundle -> Bool
 tokenBundleHasNonZeroCoin b = TokenBundle.getCoin b /= Coin 0
+
+--------------------------------------------------------------------------------
+-- Selection strategies
+--------------------------------------------------------------------------------
+
+genSelectionStrategy :: Gen SelectionStrategy
+genSelectionStrategy = arbitraryBoundedEnum
+
+shrinkSelectionStrategy :: SelectionStrategy -> [SelectionStrategy]
+shrinkSelectionStrategy = \case
+    -- Shrinking from "optimal" to "minimal" should increase the likelihood of
+    -- making a successful selection, as the "minimal" strategy is designed to
+    -- generate smaller selections.
+    SelectionStrategyMinimal -> []
+    SelectionStrategyOptimal -> [SelectionStrategyMinimal]

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -1812,6 +1812,8 @@ data BoundaryTestCriteria = BoundaryTestCriteria
         :: [BoundaryTestEntry]
     , boundaryTestUTxO
         :: [BoundaryTestEntry]
+    , boundaryTestSelectionStrategy
+        :: SelectionStrategy
     }
     deriving (Eq, Show)
 
@@ -1859,7 +1861,7 @@ encodeBoundaryTestCriteria c = SelectionParams
     , assetsToBurn =
         TokenMap.empty
     , selectionStrategy =
-        SelectionStrategyOptimal
+        boundaryTestSelectionStrategy c
     }
   where
     dummyInputIds :: [InputId]
@@ -1909,6 +1911,7 @@ boundaryTest_largeTokenQuantities_1 = BoundaryTestData
   where
     (q1, q2) = (TokenQuantity 1, TokenQuantity.predZero txOutMaxTokenQuantity)
     boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
+    boundaryTestSelectionStrategy = SelectionStrategyOptimal
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
@@ -1938,6 +1941,7 @@ boundaryTest_largeTokenQuantities_2 = BoundaryTestData
   where
     q1 :| [q2] = TokenQuantity.equipartition txOutMaxTokenQuantity (() :| [()])
     boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
+    boundaryTestSelectionStrategy = SelectionStrategyOptimal
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
@@ -1968,6 +1972,7 @@ boundaryTest_largeTokenQuantities_3 = BoundaryTestData
     q1 :| [q2] = TokenQuantity.equipartition
         (TokenQuantity.succ txOutMaxTokenQuantity) (() :| [()])
     boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
+    boundaryTestSelectionStrategy = SelectionStrategyOptimal
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
@@ -1998,6 +2003,7 @@ boundaryTest_largeTokenQuantities_4 = BoundaryTestData
     }
   where
     boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
+    boundaryTestSelectionStrategy = SelectionStrategyOptimal
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
@@ -2026,6 +2032,7 @@ boundaryTest_largeTokenQuantities_5 = BoundaryTestData
     }
   where
     boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
+    boundaryTestSelectionStrategy = SelectionStrategyOptimal
     boundaryTestOutputs =
       [ (Coin 2_000_000, []) ]
     boundaryTestUTxO =
@@ -2064,6 +2071,7 @@ boundaryTest_largeTokenQuantities_6 = BoundaryTestData
     }
   where
     boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
+    boundaryTestSelectionStrategy = SelectionStrategyOptimal
     boundaryTestOutputs =
       [ (Coin 1_000_000, [])
       , (Coin 1_000_000, [])
@@ -2114,6 +2122,7 @@ boundaryTest_largeAssetCounts_1 = BoundaryTestData
     }
   where
     boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUpperLimit 4
+    boundaryTestSelectionStrategy = SelectionStrategyOptimal
     boundaryTestOutputs =
       [ (Coin 1_000_000, []) ]
     boundaryTestUTxO =
@@ -2145,6 +2154,7 @@ boundaryTest_largeAssetCounts_2 = BoundaryTestData
     }
   where
     boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUpperLimit 3
+    boundaryTestSelectionStrategy = SelectionStrategyOptimal
     boundaryTestOutputs =
       [ (Coin 1_000_000, []) ]
     boundaryTestUTxO =
@@ -2171,6 +2181,7 @@ boundaryTest_largeAssetCounts_3 = BoundaryTestData
     }
   where
     boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUpperLimit 2
+    boundaryTestSelectionStrategy = SelectionStrategyOptimal
     boundaryTestOutputs =
       [ (Coin 1_000_000, []) ]
     boundaryTestUTxO =
@@ -2197,6 +2208,7 @@ boundaryTest_largeAssetCounts_4 = BoundaryTestData
     }
   where
     boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUpperLimit 1
+    boundaryTestSelectionStrategy = SelectionStrategyOptimal
     boundaryTestOutputs =
       [ (Coin 1_000_000, []) ]
     boundaryTestUTxO =

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -377,6 +377,8 @@ spec = describe "Cardano.Wallet.CoinSelection.Internal.BalanceSpec" $
             boundaryTestMatrix_largeTokenQuantities
         unit_testBoundaries "Large asset counts"
             boundaryTestMatrix_largeAssetCounts
+        unit_testBoundaries "Comparison of selection strategies"
+            boundaryTestMatrix_selectionStrategies
 
     parallel $ describe "Making change" $ do
 
@@ -2224,6 +2226,200 @@ boundaryTest_largeAssetCounts_4 = BoundaryTestData
       , (Coin 250_000, [mockAssetQuantity "B" 1])
       , (Coin 250_000, [mockAssetQuantity "C" 1])
       , (Coin 250_000, [mockAssetQuantity "D" 1])
+      ]
+
+--------------------------------------------------------------------------------
+-- Boundary tests: comparison of selection strategies
+--------------------------------------------------------------------------------
+
+boundaryTestMatrix_selectionStrategies :: [BoundaryTestData]
+boundaryTestMatrix_selectionStrategies =
+    [ boundaryTest_selectionStrategies_1_minimal
+    , boundaryTest_selectionStrategies_1_optimal
+    , boundaryTest_selectionStrategies_2_minimal
+    , boundaryTest_selectionStrategies_2_optimal
+    , boundaryTest_selectionStrategies_3_minimal
+    , boundaryTest_selectionStrategies_3_optimal
+    , boundaryTest_selectionStrategies_4_minimal
+    , boundaryTest_selectionStrategies_4_optimal
+    ]
+
+boundaryTest_selectionStrategies_1_minimal :: BoundaryTestData
+boundaryTest_selectionStrategies_1_minimal = BoundaryTestData
+    { boundaryTestCriteria = BoundaryTestCriteria {..}
+    , boundaryTestExpectedResult = BoundaryTestResult {..}
+    }
+  where
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
+    boundaryTestSelectionStrategy = SelectionStrategyMinimal
+    boundaryTestOutputs =
+      [ (Coin 1, []) ]
+    boundaryTestUTxO =
+      [ (Coin 1, []), (Coin 1, []) ]
+    boundaryTestInputs =
+      [ (Coin 1, []) ]
+    boundaryTestChange =
+      [ (Coin 0, []) ]
+      -- Note that a single empty change bundle is expected here, as:
+      --    - we attempt to always generate one change output for
+      --      each user-specified output.
+      --    - the minimum ada quantity is zero.
+
+boundaryTest_selectionStrategies_1_optimal :: BoundaryTestData
+boundaryTest_selectionStrategies_1_optimal = BoundaryTestData
+    { boundaryTestCriteria = BoundaryTestCriteria {..}
+    , boundaryTestExpectedResult = BoundaryTestResult {..}
+    }
+  where
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
+    boundaryTestSelectionStrategy = SelectionStrategyOptimal
+    boundaryTestOutputs =
+      [ (Coin 1, []) ]
+    boundaryTestUTxO =
+      [ (Coin 1, []), (Coin 1, []) ]
+    boundaryTestInputs =
+      [ (Coin 1, []), (Coin 1, []) ]
+    boundaryTestChange =
+      [ (Coin 1, []) ]
+
+boundaryTest_selectionStrategies_2_minimal :: BoundaryTestData
+boundaryTest_selectionStrategies_2_minimal = BoundaryTestData
+    { boundaryTestCriteria = BoundaryTestCriteria {..}
+    , boundaryTestExpectedResult = BoundaryTestResult {..}
+    }
+  where
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
+    boundaryTestSelectionStrategy = SelectionStrategyMinimal
+    boundaryTestOutputs =
+      [ (Coin 1, []) ]
+    boundaryTestUTxO =
+      [ (Coin 1, [mockAssetQuantity "A" 1])
+      , (Coin 1, [mockAssetQuantity "A" 1])
+      ]
+    boundaryTestInputs =
+      [ (Coin 1, [mockAssetQuantity "A" 1]) ]
+    boundaryTestChange =
+      [ (Coin 0, [mockAssetQuantity "A" 1]) ]
+
+boundaryTest_selectionStrategies_2_optimal :: BoundaryTestData
+boundaryTest_selectionStrategies_2_optimal = BoundaryTestData
+    { boundaryTestCriteria = BoundaryTestCriteria {..}
+    , boundaryTestExpectedResult = BoundaryTestResult {..}
+    }
+  where
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
+    boundaryTestSelectionStrategy = SelectionStrategyOptimal
+    boundaryTestOutputs =
+      [ (Coin 1, []) ]
+    boundaryTestUTxO =
+      [ (Coin 1, [mockAssetQuantity "A" 1])
+      , (Coin 1, [mockAssetQuantity "A" 1])
+      ]
+    boundaryTestInputs =
+      [ (Coin 1, [mockAssetQuantity "A" 1])
+      , (Coin 1, [mockAssetQuantity "A" 1])
+      ]
+    boundaryTestChange =
+      [ (Coin 1, [mockAssetQuantity "A" 2]) ]
+
+boundaryTest_selectionStrategies_3_minimal :: BoundaryTestData
+boundaryTest_selectionStrategies_3_minimal = BoundaryTestData
+    { boundaryTestCriteria = BoundaryTestCriteria {..}
+    , boundaryTestExpectedResult = BoundaryTestResult {..}
+    }
+  where
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
+    boundaryTestSelectionStrategy = SelectionStrategyMinimal
+    boundaryTestOutputs =
+      [ (Coin 1, [mockAssetQuantity "A" 1]) ]
+    boundaryTestUTxO =
+      [ (Coin 1, [mockAssetQuantity "A" 1])
+      , (Coin 1, [mockAssetQuantity "A" 1])
+      ]
+    boundaryTestInputs =
+      [ (Coin 1, [mockAssetQuantity "A" 1]) ]
+    boundaryTestChange =
+      [ (Coin 0, []) ]
+
+boundaryTest_selectionStrategies_3_optimal :: BoundaryTestData
+boundaryTest_selectionStrategies_3_optimal = BoundaryTestData
+    { boundaryTestCriteria = BoundaryTestCriteria {..}
+    , boundaryTestExpectedResult = BoundaryTestResult {..}
+    }
+  where
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
+    boundaryTestSelectionStrategy = SelectionStrategyOptimal
+    boundaryTestOutputs =
+      [ (Coin 1, [mockAssetQuantity "A" 1]) ]
+    boundaryTestUTxO =
+      [ (Coin 1, [mockAssetQuantity "A" 1])
+      , (Coin 1, [mockAssetQuantity "A" 1])
+      ]
+    boundaryTestInputs =
+      [ (Coin 1, [mockAssetQuantity "A" 1])
+      , (Coin 1, [mockAssetQuantity "A" 1])
+      ]
+    boundaryTestChange =
+      [ (Coin 1, [mockAssetQuantity "A" 1]) ]
+
+boundaryTest_selectionStrategies_4_minimal :: BoundaryTestData
+boundaryTest_selectionStrategies_4_minimal = BoundaryTestData
+    { boundaryTestCriteria = BoundaryTestCriteria {..}
+    , boundaryTestExpectedResult = BoundaryTestResult {..}
+    }
+  where
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
+    boundaryTestSelectionStrategy = SelectionStrategyMinimal
+    boundaryTestOutputs =
+      [ (Coin 2, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      ]
+    boundaryTestUTxO =
+      [ (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      ]
+    boundaryTestInputs =
+      [ (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      ]
+    boundaryTestChange =
+      [ (Coin 0, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      ]
+
+boundaryTest_selectionStrategies_4_optimal :: BoundaryTestData
+boundaryTest_selectionStrategies_4_optimal = BoundaryTestData
+    { boundaryTestCriteria = BoundaryTestCriteria {..}
+    , boundaryTestExpectedResult = BoundaryTestResult {..}
+    }
+  where
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
+    boundaryTestSelectionStrategy = SelectionStrategyOptimal
+    boundaryTestOutputs =
+      [ (Coin 2, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      ]
+    boundaryTestUTxO =
+      [ (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      ]
+    boundaryTestInputs =
+      [ (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      , (Coin 1, [mockAssetQuantity "A" 2, mockAssetQuantity "B" 2000])
+      ]
+    boundaryTestChange =
+      [ (Coin 2, [mockAssetQuantity "A" 6, mockAssetQuantity "B" 6000])
       ]
 
 --------------------------------------------------------------------------------

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -97,7 +97,11 @@ import Cardano.Wallet.CoinSelection.Internal.Balance
     , ungroupByKey
     )
 import Cardano.Wallet.CoinSelection.Internal.Balance.Gen
-    ( genSelectionLimit, shrinkSelectionLimit )
+    ( genSelectionLimit
+    , genSelectionStrategy
+    , shrinkSelectionLimit
+    , shrinkSelectionStrategy
+    )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Address.Gen
@@ -2579,21 +2583,6 @@ unMockComputeSelectionLimit = \case
         const NoLimit
     MockComputeSelectionLimit n ->
         const $ MaximumInputLimit n
-
---------------------------------------------------------------------------------
--- Selection strategies
---------------------------------------------------------------------------------
-
-genSelectionStrategy :: Gen SelectionStrategy
-genSelectionStrategy = arbitraryBoundedEnum
-
-shrinkSelectionStrategy :: SelectionStrategy -> [SelectionStrategy]
-shrinkSelectionStrategy = \case
-    -- Shrinking from "optimal" to "minimal" should increase the likelihood of
-    -- making a successful selection, as the "minimal" strategy is designed to
-    -- generate smaller selections.
-    SelectionStrategyMinimal -> []
-    SelectionStrategyOptimal -> [SelectionStrategyMinimal]
 
 --------------------------------------------------------------------------------
 -- Assessing token bundle sizes

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -2593,7 +2593,9 @@ prop_makeChange_length p =
             }
 
     getLargestAssetSetSize :: [TokenBundle] -> Int
-    getLargestAssetSetSize = F.maximum . fmap (Set.size . TokenBundle.getAssets)
+    getLargestAssetSetSize = \case
+        [] -> 0
+        bs -> F.maximum $ fmap (Set.size . TokenBundle.getAssets) bs
 
     zeroCostMakeChangeScenario = p
         { minCoinFor = computeMinimumAdaQuantityZero

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -34,9 +34,13 @@ import Cardano.Wallet.CoinSelection.Internal
     , verifySelectionError
     )
 import Cardano.Wallet.CoinSelection.Internal.Balance
-    ( SelectionLimit, SelectionSkeleton, SelectionStrategy (..) )
+    ( SelectionLimit, SelectionSkeleton )
 import Cardano.Wallet.CoinSelection.Internal.Balance.Gen
-    ( genSelectionSkeleton, shrinkSelectionSkeleton )
+    ( genSelectionSkeleton
+    , genSelectionStrategy
+    , shrinkSelectionSkeleton
+    , shrinkSelectionStrategy
+    )
 import Cardano.Wallet.CoinSelection.Internal.BalanceSpec
     ( MockAssessTokenBundleSize
     , MockComputeMinimumAdaQuantity
@@ -809,22 +813,6 @@ shrinkUTxOAvailableForCollateral =
 
 shrinkUTxOAvailableForInputs :: UTxOSelection InputId -> [UTxOSelection InputId]
 shrinkUTxOAvailableForInputs = shrinkUTxOSelection
-
---------------------------------------------------------------------------------
--- Selection strategies
---------------------------------------------------------------------------------
-
-genSelectionStrategy :: Gen SelectionStrategy
-genSelectionStrategy =
-    -- TODO: ADP-1500
-    -- Generate the full range of strategies here.
-    pure SelectionStrategyOptimal
-
-shrinkSelectionStrategy :: SelectionStrategy -> [SelectionStrategy]
-shrinkSelectionStrategy =
-    -- TODO: ADP-1500
-    -- Implement a shrinker for the full range of strategies here.
-    const []
 
 --------------------------------------------------------------------------------
 -- Unit test support

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -577,8 +577,6 @@ unMockSelectionConstraints m = SelectionConstraints
         view #maximumCollateralInputCount m
     , minimumCollateralPercentage =
         view #minimumCollateralPercentage m
-    , selectionStrategy =
-        SelectionStrategyOptimal
     }
 
 --------------------------------------------------------------------------------
@@ -628,6 +626,7 @@ genSelectionParams = SelectionParams
     <*> genCollateralRequirement
     <*> genUTxOAvailableForCollateral
     <*> genUTxOAvailableForInputs
+    <*> genSelectionStrategy
 
 shrinkSelectionParams :: SelectionParams InputId -> [SelectionParams InputId]
 shrinkSelectionParams = genericRoundRobinShrink
@@ -642,6 +641,7 @@ shrinkSelectionParams = genericRoundRobinShrink
     <:> shrinkCollateralRequirement
     <:> shrinkUTxOAvailableForCollateral
     <:> shrinkUTxOAvailableForInputs
+    <:> shrinkSelectionStrategy
     <:> Nil
 
 --------------------------------------------------------------------------------
@@ -809,6 +809,22 @@ shrinkUTxOAvailableForCollateral =
 
 shrinkUTxOAvailableForInputs :: UTxOSelection InputId -> [UTxOSelection InputId]
 shrinkUTxOAvailableForInputs = shrinkUTxOSelection
+
+--------------------------------------------------------------------------------
+-- Selection strategies
+--------------------------------------------------------------------------------
+
+genSelectionStrategy :: Gen SelectionStrategy
+genSelectionStrategy =
+    -- TODO: ADP-1500
+    -- Generate the full range of strategies here.
+    pure SelectionStrategyOptimal
+
+shrinkSelectionStrategy :: SelectionStrategy -> [SelectionStrategy]
+shrinkSelectionStrategy =
+    -- TODO: ADP-1500
+    -- Implement a shrinker for the full range of strategies here.
+    const []
 
 --------------------------------------------------------------------------------
 -- Unit test support


### PR DESCRIPTION
## Issue Number

ADP-1500

## Summary

This PR provides a new **_minimal_** strategy for coin selection, in addition to the original **_optimal_** strategy.

When the **_minimal_** strategy is specified, the UTxO selection algorithm will select just enough of each asset from the available UTxO set to meet the minimum amount. When the minimum amounts of all assets are satisfied, the selection process will terminate.

Change outputs are generated as normal, but the sizes of change outputs will generally be much smaller than with the original **_optimal_** strategy (which tries to select around twice the minimum amount of each asset).

## Code Changes

This PR:

- [x] adds a new `SelectionStrategyMinimal` constructor to the existing `SelectionStrategy` type:
    ```patch
      data SelectionStrategy
    -     = SelectionStrategyOptimal
    +     = SelectionStrategyMinimal
    +     | SelectionStrategyOptimal
    ```
- [x] adjusts the `prop_performSelection` family of properties to use an arbitrary choice of selection strategy.
- [x] adjusts the `prop_runSelection` family of properties to use an arbitrary choice of selection strategy.
- [x] adds new properties to the existing `prop_runSelectionStep` family of properties, specifically to cover the different termination conditions associated with the minimal selection strategy.
- [x] adds unit tests to demonstrate the difference between the minimal and optimal strategies.