### PR TITLE
Add `estimateSignedTxSize` based off ledger's `evaluateTransactionFee`

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -412,8 +412,10 @@ import Test.Hspec
     ( Expectation, HasCallStack )
 import Test.Hspec.Expectations.Lifted
     ( expectationFailure, shouldBe, shouldContain, shouldNotBe, shouldSatisfy )
+import Test.Hspec.Extra
+    ( appendFailureReason, counterexample )
 import Test.HUnit.Lang
-    ( FailureReason (..), HUnitFailure (..) )
+    ( HUnitFailure (..) )
 import Test.Integration.Faucet
     ( NextWallet, nextTxBuilder, nextWallet, seqMnemonics )
 import Test.Integration.Framework.Context
@@ -2473,28 +2475,6 @@ verifyMsg :: (Show a, MonadUnliftIO m) => String -> a -> [a -> m ()] -> m ()
 verifyMsg desc a = counterexample msg . mapM_ (a &)
   where
     msg = "Verifying "+|desc|+" for value:\n"+|indentF 2 (pShowBuilder a)|+""
-
--- | Can be used to add context to a @HUnitFailure@.
---
--- >>> counterexample (show response) (0 `shouldBe` 3)
--- >>>  (Status {statusCode = 200, statusMessage = "OK"},Right [])
--- >>>        expected: 3
--- >>>         but got: 0
-counterexample :: (MonadIO m, MonadUnliftIO m, HasCallStack) => String -> m a -> m a
-counterexample msg = (`catch` (throwIO . appendFailureReason msg))
-
-appendFailureReason :: String -> HUnitFailure -> HUnitFailure
-appendFailureReason message = wrap
-  where
-    wrap :: HUnitFailure -> HUnitFailure
-    wrap (HUnitFailure mloc reason) = HUnitFailure mloc (addMessageTo reason)
-
-    addMessageTo :: FailureReason -> FailureReason
-    addMessageTo (Reason reason) = Reason $ addMessage reason
-    addMessageTo (ExpectedButGot preface expected actual) =
-      ExpectedButGot (Just $ maybe message addMessage preface)  expected actual
-
-    addMessage = (++ "\n" ++ message)
 
 --
 -- Manipulating endpoints

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -191,7 +191,7 @@ data TransactionLayer k tx = TransactionLayer
         --
         -- Returns `Nothing` for ByronEra transactions.
 
-    , estimateSignedTransactionSize
+    , estimateSignedTxSize
         :: Node.ProtocolParameters
         -> tx
         -> Maybe TxSize

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -81,6 +81,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxIn
     , TxMetadata
     , TxOut
+    , TxSize
     )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO )
@@ -187,6 +188,14 @@ data TransactionLayer k tx = TransactionLayer
         --
         -- Will estimate how many witnesses there /should be/, so it works even
         -- for unsigned transactions.
+        --
+        -- Returns `Nothing` for ByronEra transactions.
+
+    , estimateSignedTransactionSize
+        :: Node.ProtocolParameters
+        -> tx
+        -> Maybe TxSize
+        -- ^ Estimate the size of the transaction when fully signed.
         --
         -- Returns `Nothing` for ByronEra transactions.
 

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -1357,9 +1357,9 @@ dummyTransactionLayer = TransactionLayer
         error "dummyTransactionLayer: assignScriptRedeemers not implemented"
     , evaluateMinimumFee =
         error "dummyTransactionLayer: evaluateMinimumFee not implemented"
-    , estimateSignedTransactionSize =
+    , estimateSignedTxSize =
         error "dummyTransactionLayer: \
-              \estimateSignedTransactionSize not implemented"
+              \estimateSignedTxSize not implemented"
     , evaluateTransactionBalance =
         error "dummyTransactionLayer: dummyTransactionLayer not implemented"
     , computeSelectionLimit =

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -1357,6 +1357,9 @@ dummyTransactionLayer = TransactionLayer
         error "dummyTransactionLayer: assignScriptRedeemers not implemented"
     , evaluateMinimumFee =
         error "dummyTransactionLayer: evaluateMinimumFee not implemented"
+    , estimateSignedTransactionSize =
+        error "dummyTransactionLayer: \
+              \estimateSignedTransactionSize not implemented"
     , evaluateTransactionBalance =
         error "dummyTransactionLayer: dummyTransactionLayer not implemented"
     , computeSelectionLimit =

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -919,11 +919,15 @@ _estimateSignedTxSize
     -> TxSize
 _estimateSignedTxSize pparams body =
     let
+        nWits :: Word
         nWits = estimateNumberOfWitnesses body
 
         -- Hack which allows us to rely on the ledger to calculate the size of
         -- witnesses:
+        feeOfWits :: Word -> Coin
         feeOfWits = minfee nWits - minfee 0
+
+        sizeOfWits :: TxSize
         sizeOfWits =
             case feeOfWits `quotRem` perByte of
                 (n, 0) -> TxSize n
@@ -940,6 +944,7 @@ _estimateSignedTxSize pparams body =
                     , show perByte
                     , "lovelace/byte"
                     ]
+        sizeOfTx :: TxSize
         sizeOfTx = TxSize
             . fromIntegral
             . BS.length

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -935,7 +935,7 @@ _estimateSignedTransactionSize pparams body =
                     , "(the fee contribution"
                     , "of"
                     , show nWits
-                    , "witesses),"
+                    , "witnesses),"
                     , "with"
                     , show perByte
                     , "lovelace/byte"
@@ -949,14 +949,10 @@ _estimateSignedTransactionSize pparams body =
         sizeOfTx <> sizeOfWits
   where
     minfee nWits = Coin.toNatural $ fromCardanoLovelace $
-            Cardano.evaluateTransactionFee
-                pparams
-                body
-                nWits
-                0
+        Cardano.evaluateTransactionFee pparams body nWits 0
     perByte = view #protocolParamTxFeePerByte pparams
 
--- | Estimate number of shelley era witnesses
+-- | Estimates the required number of Shelley-era witnesses.
 --
 -- NOTE: Assuming one witness per certificate is wrong. KeyReg certs don't
 -- require witnesses, and several certs may share the same key.
@@ -974,7 +970,7 @@ estimateNumberOfWitnesses (Cardano.TxBody txbodycontent) =
         txIns'' = case txInsCollateral of
             Cardano.TxInsCollateral _ collaterals -> collaterals
             _ -> []
-        txInsUnique =  L.nub $ txIns' ++ txIns''
+        txInsUnique = L.nub $ txIns' ++ txIns''
         txExtraKeyWits = Cardano.txExtraKeyWits txbodycontent
         txExtraKeyWits' = case txExtraKeyWits of
             Cardano.TxExtraKeyWitnesses _ khs -> khs

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -541,10 +541,10 @@ newTransactionLayer networkId = TransactionLayer
                     constructUnsignedTx networkId payload ttl rewardAcct wdrl
                         selection delta
 
-    , estimateSignedTransactionSize = \pp tx -> do
+    , estimateSignedTxSize = \pp tx -> do
         anyShelleyTx <- inAnyShelleyBasedEra (cardanoTx tx)
         pure $ withShelleyBasedBody anyShelleyTx $ \_era body ->
-            _estimateSignedTransactionSize pp body
+            _estimateSignedTxSize pp body
 
     , calcMinimumCost = \pp ctx skeleton ->
         estimateTxCost pp (mkTxSkeleton (txWitnessTagFor @k) ctx skeleton)
@@ -912,12 +912,12 @@ _evaluateMinimumFee pp tx = do
                 0
 
 -- | Estimate the size of the transaction (body) when fully signed.
-_estimateSignedTransactionSize
+_estimateSignedTxSize
     :: Cardano.IsShelleyBasedEra era
     => Cardano.ProtocolParameters
     -> Cardano.TxBody era
     -> TxSize
-_estimateSignedTransactionSize pparams body =
+_estimateSignedTxSize pparams body =
     let
         nWits = estimateNumberOfWitnesses body
 

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2951,7 +2951,7 @@ estimateSignedTxSizeSpec =
                 let pparams = (snd mockProtocolParametersForBalancing)
                         { Cardano.protocolParamMinUTxOValue = Just 1_000_000
                         }
-                estimateSignedTransactionSize testTxLayer pparams tx
+                estimateSignedTxSize testTxLayer pparams tx
                     `shouldBe`
                     Just (TxSize $ fromIntegral $ BS.length bs)
   where

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2949,8 +2949,8 @@ estimateSignedTxSizeSpec =
                 -- 'mockProtocolParametersForBalancing' is not valid for
                 -- 'ShelleyEra'.
                 let pparams = (snd mockProtocolParametersForBalancing)
-                            { Cardano.protocolParamMinUTxOValue = Just 1_000_000
-                            }
+                        { Cardano.protocolParamMinUTxOValue = Just 1_000_000
+                        }
                 estimateSignedTransactionSize testTxLayer pparams tx
                     `shouldBe`
                     Just (TxSize $ fromIntegral $ BS.length bs)
@@ -3044,8 +3044,6 @@ signedTxGoldens =
 
     , txWithInputsOutputsAndWits
     ]
-
-
 readTestTransactions :: SpecM a [(FilePath, SealedTx)]
 readTestTransactions = runIO $ do
     let dir = $(getTestData) </> "plutus"

--- a/lib/test-utils/src/Test/Hspec/Extra.hs
+++ b/lib/test-utils/src/Test/Hspec/Extra.hs
@@ -194,7 +194,11 @@ parallel
 -- >>>  (Status {statusCode = 200, statusMessage = "OK"},Right [])
 -- >>>        expected: 3
 -- >>>         but got: 0
-counterexample :: (MonadIO m, MonadUnliftIO m, HasCallStack) => String -> m a -> m a
+counterexample
+    :: (MonadIO m, MonadUnliftIO m, HasCallStack)
+    => String
+    -> m a
+    -> m a
 counterexample msg = (`catch` (throwIO . appendFailureReason msg))
 
 appendFailureReason :: String -> HUnitFailure -> HUnitFailure

--- a/lib/test-utils/src/Test/Hspec/Extra.hs
+++ b/lib/test-utils/src/Test/Hspec/Extra.hs
@@ -206,7 +206,7 @@ appendFailureReason message = wrap
     addMessageTo :: FailureReason -> FailureReason
     addMessageTo (Reason reason) = Reason $ addMessage reason
     addMessageTo (ExpectedButGot preface expected actual) =
-      ExpectedButGot (Just $ maybe message addMessage preface)  expected actual
+        ExpectedButGot (Just $ maybe message addMessage preface) expected actual
 
     addMessage = (++ "\n" ++ message)
 

--- a/lib/test-utils/src/Test/Hspec/Extra.hs
+++ b/lib/test-utils/src/Test/Hspec/Extra.hs
@@ -15,6 +15,8 @@ module Test.Hspec.Extra
     , itWithCustomTimeout
     , flakyBecauseOf
     , parallel
+    , counterexample
+    , appendFailureReason
 
     -- * Custom test suite runner
     , HspecWrapper
@@ -30,6 +32,10 @@ import Prelude
 
 import Control.Monad
     ( void, (<=<) )
+import Control.Monad.IO.Class
+    ( MonadIO )
+import Control.Monad.IO.Unlift
+    ( MonadUnliftIO )
 import Data.List
     ( elemIndex )
 import Options.Applicative
@@ -68,7 +74,11 @@ import Test.Hspec
 import Test.Hspec.Core.Runner
     ( Config (..), Summary, defaultConfig, evaluateSummary, hspecWithResult )
 import Test.HUnit.Lang
-    ( HUnitFailure (..), assertFailure, formatFailureReason )
+    ( FailureReason (..)
+    , HUnitFailure (..)
+    , assertFailure
+    , formatFailureReason
+    )
 import Test.Utils.Env
     ( withAddedEnv )
 import Test.Utils.Platform
@@ -177,6 +187,28 @@ parallel :: SpecWith a -> SpecWith a
 parallel
     | isWindows = id
     | otherwise = Hspec.parallel
+
+-- | Can be used to add context to a @HUnitFailure@.
+--
+-- >>> counterexample (show response) (0 `shouldBe` 3)
+-- >>>  (Status {statusCode = 200, statusMessage = "OK"},Right [])
+-- >>>        expected: 3
+-- >>>         but got: 0
+counterexample :: (MonadIO m, MonadUnliftIO m, HasCallStack) => String -> m a -> m a
+counterexample msg = (`catch` (throwIO . appendFailureReason msg))
+
+appendFailureReason :: String -> HUnitFailure -> HUnitFailure
+appendFailureReason message = wrap
+  where
+    wrap :: HUnitFailure -> HUnitFailure
+    wrap (HUnitFailure mloc reason) = HUnitFailure mloc (addMessageTo reason)
+
+    addMessageTo :: FailureReason -> FailureReason
+    addMessageTo (Reason reason) = Reason $ addMessage reason
+    addMessageTo (ExpectedButGot preface expected actual) =
+      ExpectedButGot (Just $ maybe message addMessage preface)  expected actual
+
+    addMessage = (++ "\n" ++ message)
 
 {-------------------------------------------------------------------------------
                              Test suite runner main


### PR DESCRIPTION
- [x] Implement `estimateSignedTxSize` based off the ledger's [`evaluateTransactionFee`](https://github.com/input-output-hk/cardano-ledger/blob/ba20b1f7546b029750b52d091a1234ea4922bf90/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs#L506-L535)
    - This avoids having to deal with dummy signatures or CBOR encoding details ourselves
- [x] Test that for a couple of signed tx goldens, the estimated size and the actual size match

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-1372

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
