### PR TITLE
Remove the need for `Proxy` when generating a dummy address.

### DIFF
--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -148,7 +148,7 @@ instance SC.SelectionContext WalletSelectionContext where
     type Address WalletSelectionContext = Address
     type UTxO WalletSelectionContext = WalletUTxO
 
-    dummyAddress _ = Address ""
+    dummyAddress = Address ""
 
 --------------------------------------------------------------------------------
 -- Mapping between external (wallet) and internal UTxO identifiers

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -112,8 +112,6 @@ import Data.Map.Strict
     ( Map )
 import Data.Maybe
     ( mapMaybe )
-import Data.Proxy
-    ( Proxy (..) )
 import Data.Ratio
     ( (%) )
 import Data.Semigroup
@@ -382,7 +380,7 @@ selectionAllOutputs
     -> [(Address ctx, TokenBundle)]
 selectionAllOutputs selection = (<>)
     (selection ^. #outputs)
-    (selection ^. #change <&> (dummyAddress (Proxy @ctx), ))
+    (selection ^. #change <&> (dummyAddress @ctx, ))
 
 -- | Creates constraints and parameters for 'Balance.performSelection'.
 --

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -174,8 +174,6 @@ import Data.Maybe
     ( fromMaybe )
 import Data.Ord
     ( comparing )
-import Data.Proxy
-    ( Proxy (..) )
 import Data.Semigroup
     ( mtimesDefault )
 import Data.Set
@@ -847,7 +845,7 @@ performSelectionEmpty performSelectionFn constraints params =
     transform x y = maybe x y $ NE.nonEmpty $ view #outputsToCover params
 
     dummyOutput :: (Address ctx, TokenBundle)
-    dummyOutput = (dummyAddress (Proxy @ctx), TokenBundle.fromCoin minCoin)
+    dummyOutput = (dummyAddress @ctx, TokenBundle.fromCoin minCoin)
 
     -- The 'performSelectionNonEmpty' function imposes a precondition that all
     -- outputs must have at least the minimum ada quantity. Therefore, the

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Context.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Context.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -17,8 +18,6 @@ module Cardano.Wallet.CoinSelection.Internal.Context
 
 import Prelude
 
-import Data.Proxy
-    ( Proxy (..) )
 import Fmt
     ( Buildable )
 
@@ -42,4 +41,4 @@ class
     type UTxO c
 
     -- | Generates a dummy address value.
-    dummyAddress :: Proxy c -> Address c
+    dummyAddress :: Address c


### PR DESCRIPTION
## Issue Number

#3165

## Summary

This PR removes the use of `Proxy` in the type signature for `dummyAddress`:

```patch
     -- | Generates a dummy address value.
-    dummyAddress :: Proxy c -> Address c
+    dummyAddress :: Address c
```