### PR TITLE
Light NetworkLayer: watchNodeTip/currentNodeTip

### DIFF
--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -58,7 +58,7 @@ withNetworkLayer
     -> Cardano.NetworkId
     -> NetworkParameters
     -> SyncTolerance
-    -> ContT r IO (NetworkLayer IO (CardanoBlock StandardCrypto) )
+    -> ContT r IO (NetworkLayer IO (CardanoBlock StandardCrypto))
 withNetworkLayer tr blockchainSrc net netParams tol =
     ContT $ case blockchainSrc of
         NodeSource nodeConn ver ->


### PR DESCRIPTION
This PR adds 2 functions to the new `light-mode` implementation of the `NetworkLayer`: 

- `currentNodeTip`: calls to the Blockfrost API `getLatestBlock`, translates Blockfrost types to ours;
- `watchNodeTip`: same as `currentNodeTip` but looping forever in a separate thread invoking a callback function;

- [x] I have tested it manually in REPL

### Comments


### Issue Number

ADP-1424
