### PR TITLE
Fix CI issues on master

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -434,17 +434,17 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1647307075,
-        "narHash": "sha256-+6Ezxy07ii+Ppk5JTezlG+oNxxXvKqhke+hqmL/wwJY=",
+        "lastModified": 1647315229,
+        "narHash": "sha256-GRS3fA7jnPY6c+p7xssXthsGG1nG7M+u22DMz9jDZQ4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "308c937bfc68071d8ab0206b44e0f3dde35a401e",
+        "rev": "eb49a3b7213470e36570f4aa1ed7a64e6d6cf160",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "308c937bfc68071d8ab0206b44e0f3dde35a401e",
+        "rev": "eb49a3b7213470e36570f4aa1ed7a64e6d6cf160",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -145,15 +145,18 @@
       "inputs": {
         "ema": "ema_2",
         "flake-compat": [
+          "emanote",
           "ema",
           "flake-compat"
         ],
         "flake-utils": [
+          "emanote",
           "ema",
           "flake-utils"
         ],
         "heist": "heist",
         "nixpkgs": [
+          "emanote",
           "ema",
           "nixpkgs"
         ],
@@ -431,16 +434,17 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1646278384,
-        "narHash": "sha256-Gv1Ws3vAojjvjATcsvwAOTuOhzpxwt6tBci7EBaXxU4=",
+        "lastModified": 1647307075,
+        "narHash": "sha256-+6Ezxy07ii+Ppk5JTezlG+oNxxXvKqhke+hqmL/wwJY=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "7e06e14ae1b894445254fe41288bfa7dd4ccbc6f",
+        "rev": "308c937bfc68071d8ab0206b44e0f3dde35a401e",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "rev": "308c937bfc68071d8ab0206b44e0f3dde35a401e",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
     nixpkgs.follows = "haskellNix/nixpkgs-2111";
     hostNixpkgs.follows = "nixpkgs";
     haskellNix = {
-      url = "github:input-output-hk/haskell.nix/308c937bfc68071d8ab0206b44e0f3dde35a401e";
+      url = "github:input-output-hk/haskell.nix/eb49a3b7213470e36570f4aa1ed7a64e6d6cf160";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-utils.url = "github:numtide/flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
     nixpkgs.follows = "haskellNix/nixpkgs-2111";
     hostNixpkgs.follows = "nixpkgs";
     haskellNix = {
-      url = "github:input-output-hk/haskell.nix";
+      url = "github:input-output-hk/haskell.nix/308c937bfc68071d8ab0206b44e0f3dde35a401e";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-utils.url = "github:numtide/flake-utils";


### PR DESCRIPTION
- Works with haskell.nix#308c937bfc68071d8ab0206b44e0f3dde35a401e.
- Fails with haskell.nix#eb49a3b7213470e36570f4aa1ed7a64e6d6cf160.

Error is with build of secp256k1, likely related to https://github.com/input-output-hk/haskell.nix/pull/1400:

```
error: builder for '/nix/store/mv7pmxjhympa220i2mqybzfcdbgp4y1a-secp256k1-x86_64-w64-mingw32-unstable-2021-06-06.drv' failed with exit code 1;
       last 10 log lines:
       > checking for x86_64 assembly availability... yes
       > checking for openssl/crypto.h... no
       > checking how to run the C preprocessor... x86_64-w64-mingw32-gcc -E
       > checking for gcc... no
       > checking for cc... no
       > checking for cl.exe... no
       > checking for clang... no
       > configure: error: in `/build/source':
       > configure: error: no acceptable C compiler found in $PATH
       > See `config.log' for more details
       For full logs, run 'nix log /nix/store/mv7pmxjhympa220i2mqybzfcdbgp4y1a-secp256k1-x86_64-w64-mingw32-unstable-2021-06-06.drv'.
error: 1 dependencies of derivation '/nix/store/3nqrq5hi2w85zq03kvjpw94qw4ir6ww3-remote-iserv-exe-remote-iserv-x86_64-w64-mingw32-8.10.7.drv' failed to build
error: 1 dependencies of derivation '/nix/store/ilnlrbf2g7h0br1yffvcd2l30shn28j4-remote-iserv-exe-remote-iserv-x86_64-w64-mingw32-8.10.7.drv' failed to build
error: 1 dependencies of derivation '/nix/store/8l5lli94bkirzc0plrlfhinxj94wwf6w-iserv-wrapper-prof.drv' failed to build
error: 1 dependencies of derivation '/nix/store/n8w35qszczz72dizd4zc446asbc1494a-iserv-wrapper.drv' failed to build
error: 1 dependencies of derivation '/nix/store/cpz9p4wcpzxx7h9vz0kin8fgrybvcwnc-bech32-exe-bech32-x86_64-w64-mingw32-1.1.2.drv' failed to build

```

Run `nix build .#hydraJobs.linux.windows.bech32` to reproduce.