### PR TITLE
Generalize UTxO identifiers and addresses in coin selection `Gen` modules.

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -421,6 +421,7 @@ test-suite unit
       Cardano.Wallet.Api.ServerSpec
       Cardano.Wallet.Api.TypesSpec
       Cardano.Wallet.ApiSpec
+      Cardano.Wallet.CoinSelectionSpec
       Cardano.Wallet.CoinSelection.InternalSpec
       Cardano.Wallet.CoinSelection.Internal.BalanceSpec
       Cardano.Wallet.CoinSelection.Internal.CollateralSpec

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -263,6 +263,7 @@ library
         -- The following modules define QC generators and shrinkers that can
         -- be used by both `cardano-wallet-core` and `cardano-wallet`:
         --
+      Cardano.Wallet.CoinSelection.Gen
       Cardano.Wallet.CoinSelection.Internal.Balance.Gen
       Cardano.Wallet.Primitive.Types.Address.Gen
       Cardano.Wallet.Primitive.Types.Coin.Gen

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -399,9 +399,8 @@ data SelectionOf change = Selection
 --
 type Selection = SelectionOf TokenBundle
 
-toExternalSelection
-    :: SelectionParams -> Internal.Selection WalletSelectionContext -> Selection
-toExternalSelection _ps Internal.Selection {..} =
+toExternalSelection :: Internal.Selection WalletSelectionContext -> Selection
+toExternalSelection Internal.Selection {..} =
     Selection
         { collateral = toExternalUTxO' TokenBundle.fromCoin
             <$> collateral
@@ -450,7 +449,7 @@ performSelection
     -> SelectionParams
     -> ExceptT (SelectionError WalletSelectionContext) m Selection
 performSelection cs ps =
-    toExternalSelection ps <$>
+    toExternalSelection <$>
     Internal.performSelection @m @WalletSelectionContext
         (toInternalSelectionConstraints cs)
         (toInternalSelectionParams ps)

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -34,6 +34,10 @@ module Cardano.Wallet.CoinSelection
     , toInternalUTxO
     , toInternalUTxOMap
 
+    -- * Mapping between external (wallet) selections and internal selections.
+    , toExternalSelection
+    , toInternalSelection
+
     -- * Performing selections
     , performSelection
     , Selection

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Gen.hs
@@ -1,0 +1,49 @@
+module Cardano.Wallet.CoinSelection.Gen
+    ( coarbitraryWalletUTxO
+    , genWalletUTxO
+    , genWalletUTxOFunction
+    , genWalletUTxOLargeRange
+    , shrinkWalletUTxO
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.CoinSelection
+    ( WalletUTxO (..) )
+import Cardano.Wallet.Primitive.Types.Address.Gen
+    ( genAddress, shrinkAddress )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genTxIn, genTxInLargeRange, shrinkTxIn )
+import Generics.SOP
+    ( NP (..) )
+import Test.QuickCheck
+    ( Gen, coarbitrary )
+import Test.QuickCheck.Extra
+    ( genFunction, genSized2, genericRoundRobinShrink, (<:>), (<@>) )
+
+--------------------------------------------------------------------------------
+-- Wallet UTxO identifiers chosen according to the size parameter
+--------------------------------------------------------------------------------
+
+coarbitraryWalletUTxO :: WalletUTxO -> Gen a -> Gen a
+coarbitraryWalletUTxO = coarbitrary . show
+
+genWalletUTxO :: Gen WalletUTxO
+genWalletUTxO = uncurry WalletUTxO <$> genSized2 genTxIn genAddress
+
+shrinkWalletUTxO :: WalletUTxO -> [WalletUTxO]
+shrinkWalletUTxO = genericRoundRobinShrink
+    <@> shrinkTxIn
+    <:> shrinkAddress
+    <:> Nil
+
+genWalletUTxOFunction :: Gen a -> Gen (WalletUTxO -> a)
+genWalletUTxOFunction = genFunction coarbitraryWalletUTxO
+
+--------------------------------------------------------------------------------
+-- Wallet UTxO identifiers chosen from a large range
+--------------------------------------------------------------------------------
+
+genWalletUTxOLargeRange :: Gen WalletUTxO
+genWalletUTxOLargeRange = WalletUTxO <$> genTxInLargeRange <*> genAddress

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance/Gen.hs
@@ -13,16 +13,14 @@ module Cardano.Wallet.CoinSelection.Internal.Balance.Gen
 
 import Prelude
 
-import Cardano.Wallet.CoinSelection
-    ( WalletSelectionContext )
 import Cardano.Wallet.CoinSelection.Internal.Balance
     ( SelectionLimit
     , SelectionLimitOf (..)
     , SelectionSkeleton (..)
     , SelectionStrategy (..)
     )
-import Cardano.Wallet.Primitive.Types.Address.Gen
-    ( genAddress, shrinkAddress )
+import Cardano.Wallet.CoinSelection.Internal.Context
+    ( SelectionContext (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -72,8 +70,8 @@ shrinkSelectionLimit = \case
 -- Selection skeletons
 --------------------------------------------------------------------------------
 
-genSelectionSkeleton :: Gen (SelectionSkeleton WalletSelectionContext)
-genSelectionSkeleton = SelectionSkeleton
+genSelectionSkeleton :: Gen (Address ctx) -> Gen (SelectionSkeleton ctx)
+genSelectionSkeleton genAddress = SelectionSkeleton
     <$> genSkeletonInputCount
     <*> genSkeletonOutputs
     <*> genSkeletonChange
@@ -89,9 +87,9 @@ genSelectionSkeleton = SelectionSkeleton
         listOf (Set.fromList <$> listOf genAssetId)
 
 shrinkSelectionSkeleton
-    :: SelectionSkeleton WalletSelectionContext
-    -> [SelectionSkeleton WalletSelectionContext]
-shrinkSelectionSkeleton = genericRoundRobinShrink
+    :: (Address ctx -> [Address ctx])
+    -> (SelectionSkeleton ctx -> [SelectionSkeleton ctx])
+shrinkSelectionSkeleton shrinkAddress = genericRoundRobinShrink
     <@> shrinkSkeletonInputCount
     <:> shrinkSkeletonOutputs
     <:> shrinkSkeletonChange

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
@@ -2,6 +2,7 @@ module Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange
     , genTokenBundleSmallRangePositive
     , genTokenBundle
+    , shrinkTokenBundle
     , shrinkTokenBundleSmallRange
     , shrinkTokenBundleSmallRangePositive
     ) where
@@ -31,6 +32,12 @@ genTokenBundle = TokenBundle
     <$> genCoin
     <*> genTokenMap
 
+shrinkTokenBundle :: TokenBundle -> [TokenBundle]
+shrinkTokenBundle (TokenBundle c m)=
+    uncurry TokenBundle <$> shrinkInterleaved
+        (c, shrinkCoin)
+        (m, shrinkTokenMap)
+
 --------------------------------------------------------------------------------
 -- Token bundles with coins, assets, and quantities chosen from small ranges
 --------------------------------------------------------------------------------
@@ -41,10 +48,7 @@ genTokenBundleSmallRange = TokenBundle
     <*> genTokenMapSmallRange
 
 shrinkTokenBundleSmallRange :: TokenBundle -> [TokenBundle]
-shrinkTokenBundleSmallRange (TokenBundle c m) =
-    uncurry TokenBundle <$> shrinkInterleaved
-        (c, shrinkCoin)
-        (m, shrinkTokenMap)
+shrinkTokenBundleSmallRange = shrinkTokenBundle
 
 genTokenBundleSmallRangePositive :: Gen TokenBundle
 genTokenBundleSmallRangePositive = TokenBundle

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
@@ -57,13 +57,14 @@ shrinkUTxOIndex shrinkUTxO =
 --------------------------------------------------------------------------------
 
 genUTxOIndexLarge :: Gen (UTxOIndex WalletUTxO)
-genUTxOIndexLarge = genUTxOIndexLargeN =<< choose (1024, 4096)
-
-genUTxOIndexLargeN :: Int -> Gen (UTxOIndex WalletUTxO)
-genUTxOIndexLargeN n = UTxOIndex.fromSequence <$> replicateM n genEntry
+genUTxOIndexLarge =
+    genUTxOIndexLargeN genWalletUTxOLargeRange =<< choose (1024, 4096)
   where
-    genEntry :: Gen (WalletUTxO, TokenBundle)
-    genEntry = (,) <$> genWalletUTxO <*> genTokenBundleSmallRangePositive
+    genWalletUTxOLargeRange :: Gen WalletUTxO
+    genWalletUTxOLargeRange = WalletUTxO <$> genTxInLargeRange <*> genAddress
 
-    genWalletUTxO :: Gen WalletUTxO
-    genWalletUTxO = WalletUTxO <$> genTxInLargeRange <*> genAddress
+genUTxOIndexLargeN :: forall u. Ord u => Gen u -> Int -> Gen (UTxOIndex u)
+genUTxOIndexLargeN genUTxO n = UTxOIndex.fromSequence <$> replicateM n genEntry
+  where
+    genEntry :: Gen (u, TokenBundle)
+    genEntry = (,) <$> genUTxO <*> genTokenBundleSmallRangePositive

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
@@ -9,16 +9,10 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
 
 import Prelude
 
-import Cardano.Wallet.CoinSelection
-    ( WalletUTxO (..) )
-import Cardano.Wallet.Primitive.Types.Address.Gen
-    ( genAddress )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRangePositive, shrinkTokenBundleSmallRangePositive )
-import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxInLargeRange )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( UTxOIndex )
 import Control.Monad
@@ -56,12 +50,9 @@ shrinkUTxOIndex shrinkUTxO =
 -- Large indices
 --------------------------------------------------------------------------------
 
-genUTxOIndexLarge :: Gen (UTxOIndex WalletUTxO)
-genUTxOIndexLarge =
-    genUTxOIndexLargeN genWalletUTxOLargeRange =<< choose (1024, 4096)
-  where
-    genWalletUTxOLargeRange :: Gen WalletUTxO
-    genWalletUTxOLargeRange = WalletUTxO <$> genTxInLargeRange <*> genAddress
+genUTxOIndexLarge :: Ord u => Gen u -> Gen (UTxOIndex u)
+genUTxOIndexLarge genUTxO =
+    genUTxOIndexLargeN genUTxO =<< choose (1024, 4096)
 
 genUTxOIndexLargeN :: forall u. Ord u => Gen u -> Int -> Gen (UTxOIndex u)
 genUTxOIndexLargeN genUTxO n = UTxOIndex.fromSequence <$> replicateM n genEntry

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection/Gen.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
@@ -35,35 +36,27 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 -- Selections that may be empty
 --------------------------------------------------------------------------------
 
-coarbitraryWalletUTxO :: WalletUTxO -> Gen a -> Gen a
-coarbitraryWalletUTxO = coarbitrary . show
+coarbitraryUTxO :: Show u => u -> Gen a -> Gen a
+coarbitraryUTxO = coarbitrary . show
 
-genWalletUTxOFunction :: Gen a -> Gen (WalletUTxO -> a)
-genWalletUTxOFunction = genFunction coarbitraryWalletUTxO
+genUTxOFunction :: Show u => Gen a -> Gen (u -> a)
+genUTxOFunction = genFunction coarbitraryUTxO
 
-genUTxOSelection :: Gen (UTxOSelection WalletUTxO)
-genUTxOSelection = UTxOSelection.fromIndexFiltered
-    <$> genFilter
-    <*> genUTxOIndex genWalletUTxO
+genUTxOSelection :: forall u. (Ord u, Show u) => Gen u -> Gen (UTxOSelection u)
+genUTxOSelection genUTxO = UTxOSelection.fromIndexFiltered
+    <$> genUTxOFilter
+    <*> genUTxOIndex genUTxO
   where
-    genFilter :: Gen (WalletUTxO -> Bool)
-    genFilter = genWalletUTxOFunction (arbitrary @Bool)
+    genUTxOFilter :: Gen (u -> Bool)
+    genUTxOFilter = genUTxOFunction (arbitrary @Bool)
 
-    genWalletUTxO :: Gen WalletUTxO
-    genWalletUTxO = uncurry WalletUTxO <$> genSized2 genTxIn genAddress
-
-shrinkUTxOSelection :: UTxOSelection WalletUTxO -> [UTxOSelection WalletUTxO]
-shrinkUTxOSelection =
+shrinkUTxOSelection
+    :: Ord u => (u -> [u]) -> (UTxOSelection u -> [UTxOSelection u])
+shrinkUTxOSelection shrinkUTxO =
     shrinkMapBy UTxOSelection.fromIndexPair UTxOSelection.toIndexPair $
         liftShrink2
-            (shrinkUTxOIndex shrinkWalletUTxO)
-            (shrinkUTxOIndex shrinkWalletUTxO)
-  where
-    shrinkWalletUTxO :: WalletUTxO -> [WalletUTxO]
-    shrinkWalletUTxO = genericRoundRobinShrink
-        <@> shrinkTxIn
-        <:> shrinkAddress
-        <:> Nil
+            (shrinkUTxOIndex shrinkUTxO)
+            (shrinkUTxOIndex shrinkUTxO)
 
 --------------------------------------------------------------------------------
 -- Selections that are non-empty
@@ -71,12 +64,21 @@ shrinkUTxOSelection =
 
 genUTxOSelectionNonEmpty :: Gen (UTxOSelectionNonEmpty WalletUTxO)
 genUTxOSelectionNonEmpty =
-    genUTxOSelection `suchThatMap` UTxOSelection.toNonEmpty
+    genUTxOSelection genWalletUTxO `suchThatMap` UTxOSelection.toNonEmpty
+  where
+    genWalletUTxO :: Gen WalletUTxO
+    genWalletUTxO = uncurry WalletUTxO <$> genSized2 genTxIn genAddress
 
 shrinkUTxOSelectionNonEmpty
     :: UTxOSelectionNonEmpty WalletUTxO
     -> [UTxOSelectionNonEmpty WalletUTxO]
 shrinkUTxOSelectionNonEmpty
     = mapMaybe UTxOSelection.toNonEmpty
-    . shrinkUTxOSelection
+    . shrinkUTxOSelection shrinkWalletUTxO
     . UTxOSelection.fromNonEmpty
+  where
+    shrinkWalletUTxO :: WalletUTxO -> [WalletUTxO]
+    shrinkWalletUTxO = genericRoundRobinShrink
+        <@> shrinkTxIn
+        <:> shrinkAddress
+        <:> Nil

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -42,6 +42,12 @@ import Cardano.Numeric.Util
     ( inAscendingPartialOrder )
 import Cardano.Wallet.CoinSelection
     ( WalletSelectionContext, WalletUTxO (..) )
+import Cardano.Wallet.CoinSelection.Gen
+    ( genWalletUTxO
+    , genWalletUTxOFunction
+    , genWalletUTxOLargeRange
+    , shrinkWalletUTxO
+    )
 import Cardano.Wallet.CoinSelection.Internal.Balance
     ( AssetCount (..)
     , BalanceInsufficientError (..)
@@ -108,7 +114,7 @@ import Cardano.Wallet.CoinSelection.Internal.Balance.Gen
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Address.Gen
-    ( genAddress, shrinkAddress )
+    ( shrinkAddress )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
@@ -147,7 +153,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , txOutMaxTokenQuantity
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxIn, genTxInLargeRange, genTxOut, shrinkTxIn, shrinkTxOut )
+    ( genTxOut, shrinkTxOut )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( SelectionFilter (..), UTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
@@ -214,7 +220,6 @@ import Test.QuickCheck
     , arbitraryBoundedEnum
     , checkCoverage
     , choose
-    , coarbitrary
     , conjoin
     , counterexample
     , cover
@@ -240,14 +245,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Classes
     ( eqLaws, ordLaws )
 import Test.QuickCheck.Extra
-    ( genFunction
-    , genSized2
-    , genericRoundRobinShrink
-    , report
-    , verify
-    , (<:>)
-    , (<@>)
-    )
+    ( genericRoundRobinShrink, report, verify, (<:>), (<@>) )
 import Test.QuickCheck.Monadic
     ( PropertyM (..), assert, monadicIO, monitor, run )
 import Test.Utils.Laws
@@ -4377,28 +4375,6 @@ unitTests :: String -> [Expectation] -> SpecWith ()
 unitTests lbl cases =
     forM_ (zip [1..] cases) $ \(i, test) ->
         it (lbl <> " example #" <> show @Int i) test
-
---------------------------------------------------------------------------------
--- Wallet UTxO identifiers
---------------------------------------------------------------------------------
-
-coarbitraryWalletUTxO :: WalletUTxO -> Gen a -> Gen a
-coarbitraryWalletUTxO = coarbitrary . show
-
-genWalletUTxO :: Gen WalletUTxO
-genWalletUTxO = uncurry WalletUTxO <$> genSized2 genTxIn genAddress
-
-genWalletUTxOLargeRange :: Gen WalletUTxO
-genWalletUTxOLargeRange = WalletUTxO <$> genTxInLargeRange <*> genAddress
-
-shrinkWalletUTxO :: WalletUTxO -> [WalletUTxO]
-shrinkWalletUTxO = genericRoundRobinShrink
-    <@> shrinkTxIn
-    <:> shrinkAddress
-    <:> Nil
-
-genWalletUTxOFunction :: Gen a -> Gen (WalletUTxO -> a)
-genWalletUTxOFunction = genFunction coarbitraryWalletUTxO
 
 --------------------------------------------------------------------------------
 -- Arbitrary instances

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -147,7 +147,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , txOutMaxTokenQuantity
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxIn, genTxOut, shrinkTxIn, shrinkTxOut )
+    ( genTxIn, genTxInLargeRange, genTxOut, shrinkTxIn, shrinkTxOut )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( SelectionFilter (..), UTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
@@ -875,7 +875,7 @@ prop_performSelection_huge = ioProperty $
     -- the cost of re-generating it on every pass. This will still generate
     -- interesting cases, since selection within that large index is random.
     property . prop_performSelection_huge_inner
-        <$> generate (genUTxOIndexLargeN 50000)
+        <$> generate (genUTxOIndexLargeN genWalletUTxOLargeRange 50000)
 
 prop_performSelection_huge_inner
     :: UTxOIndex WalletUTxO
@@ -4387,6 +4387,9 @@ coarbitraryWalletUTxO = coarbitrary . show
 
 genWalletUTxO :: Gen WalletUTxO
 genWalletUTxO = uncurry WalletUTxO <$> genSized2 genTxIn genAddress
+
+genWalletUTxOLargeRange :: Gen WalletUTxO
+genWalletUTxOLargeRange = WalletUTxO <$> genTxInLargeRange <*> genAddress
 
 shrinkWalletUTxO :: WalletUTxO -> [WalletUTxO]
 shrinkWalletUTxO = genericRoundRobinShrink

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -661,7 +661,7 @@ shrinkSelectionParams
     -> [SelectionParams WalletSelectionContext]
 shrinkSelectionParams = genericRoundRobinShrink
     <@> shrinkList shrinkOutput
-    <:> shrinkUTxOSelection
+    <:> shrinkUTxOSelection shrinkWalletUTxO
     <:> shrinkCoin
     <:> shrinkCoin
     <:> shrinkTokenMap
@@ -4463,8 +4463,8 @@ instance Arbitrary TxOut where
     shrink = shrinkTxOut
 
 instance Arbitrary (UTxOSelection WalletUTxO) where
-    arbitrary = genUTxOSelection
-    shrink = shrinkUTxOSelection
+    arbitrary = genUTxOSelection genWalletUTxO
+    shrink = shrinkUTxOSelection shrinkWalletUTxO
 
 newtype Large a = Large
     { getLarge :: a }

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -4477,7 +4477,7 @@ newtype Small a = Small
 instance Arbitrary (Large (SelectionParams WalletSelectionContext)) where
     arbitrary = Large <$> genSelectionParams
         (genWalletUTxOFunction (arbitrary @Bool))
-        (genUTxOIndexLarge)
+        (genUTxOIndexLarge genWalletUTxOLargeRange)
     shrink = shrinkMapBy Large getLarge shrinkSelectionParams
 
 instance Arbitrary (Small (SelectionParams WalletSelectionContext)) where
@@ -4487,7 +4487,7 @@ instance Arbitrary (Small (SelectionParams WalletSelectionContext)) where
     shrink = shrinkMapBy Small getSmall shrinkSelectionParams
 
 instance Arbitrary (Large (UTxOIndex WalletUTxO)) where
-    arbitrary = Large <$> genUTxOIndexLarge
+    arbitrary = Large <$> genUTxOIndexLarge genWalletUTxOLargeRange
     shrink = shrinkMapBy Large getLarge (shrinkUTxOIndex shrinkWalletUTxO)
 
 instance Arbitrary (Small (UTxOIndex WalletUTxO)) where

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -18,6 +18,8 @@ import Prelude
 
 import Cardano.Wallet.CoinSelection
     ( WalletSelectionContext, WalletUTxO (..) )
+import Cardano.Wallet.CoinSelection.Gen
+    ( genWalletUTxO, shrinkWalletUTxO )
 import Cardano.Wallet.CoinSelection.Internal
     ( ComputeMinimumCollateralParams (..)
     , Selection
@@ -82,8 +84,6 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( txOutMaxTokenQuantity )
-import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxIn, shrinkTxIn )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
 import Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
@@ -138,7 +138,6 @@ import Test.QuickCheck.Extra
     ( Pretty (..)
     , chooseNatural
     , genMapWith
-    , genSized2
     , genericRoundRobinShrink
     , report
     , shrinkMapWith
@@ -797,9 +796,6 @@ shrinkCollateralRequirement = genericShrink
 -- UTxO available for inputs and collateral
 --------------------------------------------------------------------------------
 
-genWalletUTxO :: Gen WalletUTxO
-genWalletUTxO = uncurry WalletUTxO <$> genSized2 genTxIn genAddress
-
 genUTxOAvailableForCollateral :: Gen (Map WalletUTxO Coin)
 genUTxOAvailableForCollateral = genMapWith genWalletUTxO genCoinPositive
 
@@ -808,12 +804,6 @@ genUTxOAvailableForInputs = frequency
     [ (49, genUTxOSelection genWalletUTxO)
     , (01, pure UTxOSelection.empty)
     ]
-
-shrinkWalletUTxO :: WalletUTxO -> [WalletUTxO]
-shrinkWalletUTxO = genericRoundRobinShrink
-    <@> shrinkTxIn
-    <:> shrinkAddress
-    <:> Nil
 
 shrinkUTxOAvailableForCollateral
     :: Map WalletUTxO Coin -> [Map WalletUTxO Coin]

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -870,5 +870,5 @@ instance Arbitrary (SelectionParams WalletSelectionContext) where
     shrink = shrinkSelectionParams
 
 instance Arbitrary (SelectionSkeleton WalletSelectionContext) where
-    arbitrary = genSelectionSkeleton
-    shrink = shrinkSelectionSkeleton
+    arbitrary = genSelectionSkeleton genAddress
+    shrink = shrinkSelectionSkeleton shrinkAddress

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelectionSpec.hs
@@ -1,0 +1,68 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.CoinSelectionSpec
+    where
+
+import Prelude
+
+import Cardano.Wallet.CoinSelection
+    ( toExternalUTxO, toExternalUTxOMap, toInternalUTxO, toInternalUTxOMap )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn, TxOut )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genTxIn, genTxOut, shrinkTxIn, shrinkTxOut )
+import Cardano.Wallet.Primitive.Types.UTxO
+    ( UTxO )
+import Cardano.Wallet.Primitive.Types.UTxO.Gen
+    ( genUTxO, genUTxOLarge, shrinkUTxO )
+import Data.Function
+    ( (&) )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.Hspec.Extra
+    ( parallel )
+import Test.QuickCheck
+    ( Arbitrary (..), Property, oneof, property, (===) )
+
+spec :: Spec
+spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
+
+    parallel $ describe
+        "Conversion between external (wallet) and internal UTxOs" $ do
+
+        it "prop_toInternalUTxO_toExternalUTxO" $
+            prop_toInternalUTxO_toExternalUTxO & property
+
+        it "prop_toInternalUTxOMap_toExternalUTxOMap" $
+            prop_toInternalUTxOMap_toExternalUTxOMap & property
+
+--------------------------------------------------------------------------------
+-- Conversion between external (wallet) and internal UTxOs
+--------------------------------------------------------------------------------
+
+prop_toInternalUTxO_toExternalUTxO :: TxIn -> TxOut -> Property
+prop_toInternalUTxO_toExternalUTxO i o =
+    (toExternalUTxO . toInternalUTxO) (i, o) === (i, o)
+
+prop_toInternalUTxOMap_toExternalUTxOMap :: UTxO -> Property
+prop_toInternalUTxOMap_toExternalUTxOMap u =
+    (toExternalUTxOMap . toInternalUTxOMap) u === u
+
+--------------------------------------------------------------------------------
+-- Arbitrary instances
+--------------------------------------------------------------------------------
+
+instance Arbitrary TxIn where
+    arbitrary = genTxIn
+    shrink = shrinkTxIn
+
+instance Arbitrary TxOut where
+    arbitrary = genTxOut
+    shrink = shrinkTxOut
+
+instance Arbitrary UTxO where
+    arbitrary = oneof
+        [ genUTxO
+        , genUTxOLarge
+        ]
+    shrink = shrinkUTxO

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -14,10 +14,12 @@ import Prelude
 
 import Cardano.Wallet.CoinSelection
     ( WalletUTxO (..) )
+import Cardano.Wallet.CoinSelection.Gen
+    ( coarbitraryWalletUTxO, genWalletUTxO, shrinkWalletUTxO )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address )
 import Cardano.Wallet.Primitive.Types.Address.Gen
-    ( coarbitraryAddress, genAddress, shrinkAddress )
+    ( coarbitraryAddress )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
@@ -29,7 +31,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxIn, TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( coarbitraryTxIn, genTxIn, genTxOut, shrinkTxIn, shrinkTxOut )
+    ( coarbitraryTxIn, genTxOut, shrinkTxOut )
 import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
     ( genUTxOIndex, shrinkUTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
@@ -44,8 +46,6 @@ import Data.Ratio
     ( (%) )
 import Data.Word
     ( Word8 )
-import Generics.SOP
-    ( NP (..) )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.Hspec.Extra
@@ -59,7 +59,6 @@ import Test.QuickCheck
     , Testable
     , checkCoverage
     , checkCoverageWith
-    , coarbitraryShow
     , conjoin
     , counterexample
     , cover
@@ -73,8 +72,6 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Classes
     ( eqLaws )
-import Test.QuickCheck.Extra
-    ( genSized2, genericRoundRobinShrink, (<:>), (<@>) )
 import Test.QuickCheck.Monadic
     ( assert, monadicIO, monitor, run )
 import Test.Utils.Laws
@@ -784,18 +781,10 @@ tokenBundleIsAdaOnly = TokenBundle.isCoin
 
 instance Arbitrary WalletUTxO where
     arbitrary = genWalletUTxO
-
-genWalletUTxO :: Gen WalletUTxO
-genWalletUTxO = uncurry WalletUTxO <$> genSized2 genTxIn genAddress
-
-shrinkWalletUTxO :: WalletUTxO -> [WalletUTxO]
-shrinkWalletUTxO = genericRoundRobinShrink
-    <@> shrinkTxIn
-    <:> shrinkAddress
-    <:> Nil
+    shrink = shrinkWalletUTxO
 
 instance CoArbitrary WalletUTxO where
-    coarbitrary = coarbitraryShow
+    coarbitrary = coarbitraryWalletUTxO
 
 instance CoArbitrary Address where
     coarbitrary = coarbitraryAddress

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
@@ -151,7 +151,7 @@ prop_genUTxOSelection =
 
 prop_genUTxOSelectionNonEmpty :: Property
 prop_genUTxOSelectionNonEmpty =
-    forAll genUTxOSelectionNonEmpty $ \s ->
+    forAll (genUTxOSelectionNonEmpty genWalletUTxO) $ \s ->
     checkCoverage_UTxOSelectionNonEmpty s $
     isValidSelectionNonEmpty s === True
 
@@ -162,8 +162,9 @@ prop_shrinkUTxOSelection =
 
 prop_shrinkUTxOSelectionNonEmpty :: Property
 prop_shrinkUTxOSelectionNonEmpty =
-    forAll genUTxOSelectionNonEmpty $ \s ->
-    conjoin (isValidSelectionNonEmpty <$> shrinkUTxOSelectionNonEmpty s)
+    forAll (genUTxOSelectionNonEmpty genWalletUTxO) $ \s ->
+    conjoin $ isValidSelectionNonEmpty
+        <$> shrinkUTxOSelectionNonEmpty shrinkWalletUTxO s
 
 checkCoverage_UTxOSelection
     :: Testable p
@@ -456,8 +457,8 @@ instance Arbitrary (UTxOSelection WalletUTxO) where
     shrink = shrinkUTxOSelection shrinkWalletUTxO
 
 instance Arbitrary (UTxOSelectionNonEmpty WalletUTxO) where
-    arbitrary = genUTxOSelectionNonEmpty
-    shrink = shrinkUTxOSelectionNonEmpty
+    arbitrary = genUTxOSelectionNonEmpty genWalletUTxO
+    shrink = shrinkUTxOSelectionNonEmpty shrinkWalletUTxO
 
 --------------------------------------------------------------------------------
 -- CoArbitrary instances

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
@@ -41,6 +41,7 @@ import Test.Hspec.Extra
 import Test.QuickCheck
     ( Arbitrary (..)
     , CoArbitrary (..)
+    , Gen
     , Property
     , Testable
     , checkCoverage
@@ -437,9 +438,18 @@ instance Arbitrary WalletUTxO where
         <:> shrinkAddress
         <:> Nil
 
+genWalletUTxO :: Gen WalletUTxO
+genWalletUTxO = uncurry WalletUTxO <$> genSized2 genTxIn genAddress
+
+shrinkWalletUTxO :: WalletUTxO -> [WalletUTxO]
+shrinkWalletUTxO = genericRoundRobinShrink
+    <@> shrinkTxIn
+    <:> shrinkAddress
+    <:> Nil
+
 instance Arbitrary (UTxOIndex WalletUTxO) where
-    arbitrary = genUTxOIndex
-    shrink = shrinkUTxOIndex
+    arbitrary = genUTxOIndex genWalletUTxO
+    shrink = shrinkUTxOIndex shrinkWalletUTxO
 
 instance Arbitrary (UTxOSelection WalletUTxO) where
     arbitrary = genUTxOSelection

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
@@ -12,14 +12,16 @@ import Prelude
 
 import Cardano.Wallet.CoinSelection
     ( WalletUTxO (..) )
+import Cardano.Wallet.CoinSelection.Gen
+    ( coarbitraryWalletUTxO, genWalletUTxO, shrinkWalletUTxO )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address )
 import Cardano.Wallet.Primitive.Types.Address.Gen
-    ( coarbitraryAddress, genAddress, shrinkAddress )
+    ( coarbitraryAddress )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxIn )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( coarbitraryTxIn, genTxIn, shrinkTxIn )
+    ( coarbitraryTxIn )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( UTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
@@ -32,8 +34,6 @@ import Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
     , shrinkUTxOSelection
     , shrinkUTxOSelectionNonEmpty
     )
-import Generics.SOP
-    ( NP (..) )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.Hspec.Extra
@@ -41,19 +41,15 @@ import Test.Hspec.Extra
 import Test.QuickCheck
     ( Arbitrary (..)
     , CoArbitrary (..)
-    , Gen
     , Property
     , Testable
     , checkCoverage
-    , coarbitraryShow
     , conjoin
     , cover
     , forAll
     , property
     , (===)
     )
-import Test.QuickCheck.Extra
-    ( genSized2, genericRoundRobinShrink, (<:>), (<@>) )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
@@ -433,20 +429,8 @@ isValidSelectionNonEmpty s =
 -- of input identifier has been made into a type parameter.
 --
 instance Arbitrary WalletUTxO where
-    arbitrary = uncurry WalletUTxO <$> genSized2 genTxIn genAddress
-    shrink = genericRoundRobinShrink
-        <@> shrinkTxIn
-        <:> shrinkAddress
-        <:> Nil
-
-genWalletUTxO :: Gen WalletUTxO
-genWalletUTxO = uncurry WalletUTxO <$> genSized2 genTxIn genAddress
-
-shrinkWalletUTxO :: WalletUTxO -> [WalletUTxO]
-shrinkWalletUTxO = genericRoundRobinShrink
-    <@> shrinkTxIn
-    <:> shrinkAddress
-    <:> Nil
+    arbitrary = genWalletUTxO
+    shrink = shrinkWalletUTxO
 
 instance Arbitrary (UTxOIndex WalletUTxO) where
     arbitrary = genUTxOIndex genWalletUTxO
@@ -471,7 +455,7 @@ instance CoArbitrary TxIn where
     coarbitrary = coarbitraryTxIn
 
 instance CoArbitrary WalletUTxO where
-    coarbitrary = coarbitraryShow
+    coarbitrary = coarbitraryWalletUTxO
 
 --------------------------------------------------------------------------------
 -- Show instances

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
@@ -145,7 +145,7 @@ spec =
 
 prop_genUTxOSelection :: Property
 prop_genUTxOSelection =
-    forAll genUTxOSelection $ \s ->
+    forAll (genUTxOSelection genWalletUTxO) $ \s ->
     checkCoverage_UTxOSelection s $
     isValidSelection s === True
 
@@ -157,8 +157,8 @@ prop_genUTxOSelectionNonEmpty =
 
 prop_shrinkUTxOSelection :: Property
 prop_shrinkUTxOSelection =
-    forAll genUTxOSelection $ \s ->
-    conjoin (isValidSelection <$> shrinkUTxOSelection s)
+    forAll (genUTxOSelection genWalletUTxO) $ \s ->
+    conjoin (isValidSelection <$> shrinkUTxOSelection shrinkWalletUTxO s)
 
 prop_shrinkUTxOSelectionNonEmpty :: Property
 prop_shrinkUTxOSelectionNonEmpty =
@@ -452,8 +452,8 @@ instance Arbitrary (UTxOIndex WalletUTxO) where
     shrink = shrinkUTxOIndex shrinkWalletUTxO
 
 instance Arbitrary (UTxOSelection WalletUTxO) where
-    arbitrary = genUTxOSelection
-    shrink = shrinkUTxOSelection
+    arbitrary = genUTxOSelection genWalletUTxO
+    shrink = shrinkUTxOSelection shrinkWalletUTxO
 
 instance Arbitrary (UTxOSelectionNonEmpty WalletUTxO) where
     arbitrary = genUTxOSelectionNonEmpty

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -35,6 +35,10 @@ module Test.QuickCheck.Extra
     , chooseNatural
     , shrinkNatural
 
+      -- * Generating and shrinking non-empty lists
+    , genNonEmpty
+    , shrinkNonEmpty
+
       -- * Counterexamples
     , report
     , verify
@@ -54,6 +58,8 @@ import Prelude
 
 import Data.IntCast
     ( intCast, intCastMaybe )
+import Data.List.NonEmpty
+    ( NonEmpty (..) )
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
@@ -90,6 +96,7 @@ import Text.Pretty.Simple
     ( pShow )
 
 import qualified Data.List as L
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Text.Lazy as TL
 import qualified Generics.SOP.GGP as GGP
@@ -196,6 +203,16 @@ shrinkNatural n
     = mapMaybe (intCastMaybe @Integer @Natural)
     $ shrinkIntegral
     $ intCast n
+
+--------------------------------------------------------------------------------
+-- Generating and shrinking non-empty lists
+--------------------------------------------------------------------------------
+
+genNonEmpty :: Gen a -> Gen (NonEmpty a)
+genNonEmpty genA = (:|) <$> genA <*> listOf genA
+
+shrinkNonEmpty :: (a -> [a]) -> (NonEmpty a -> [NonEmpty a])
+shrinkNonEmpty shrinkA = mapMaybe NE.nonEmpty . shrinkList shrinkA . NE.toList
 
 --------------------------------------------------------------------------------
 -- Generating functions

--- a/nix/materialized/stack-nix/cardano-wallet-core.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-core.nix
@@ -389,6 +389,7 @@
             "Cardano/Wallet/Api/ServerSpec"
             "Cardano/Wallet/Api/TypesSpec"
             "Cardano/Wallet/ApiSpec"
+            "Cardano/Wallet/CoinSelectionSpec"
             "Cardano/Wallet/CoinSelection/InternalSpec"
             "Cardano/Wallet/CoinSelection/Internal/BalanceSpec"
             "Cardano/Wallet/CoinSelection/Internal/CollateralSpec"

--- a/nix/materialized/stack-nix/cardano-wallet-core.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-core.nix
@@ -250,6 +250,7 @@
           "Network/Wai/Middleware/Logging"
           "Ouroboros/Network/Client/Wallet"
           "UnliftIO/Compat"
+          "Cardano/Wallet/CoinSelection/Gen"
           "Cardano/Wallet/CoinSelection/Internal/Balance/Gen"
           "Cardano/Wallet/Primitive/Types/Address/Gen"
           "Cardano/Wallet/Primitive/Types/Coin/Gen"


### PR DESCRIPTION
## Issue Number

ADP-1523

## Summary

This PR removes the dependency on `Address` and `WalletUTxO` from the following modules:
- `Cardano.Wallet.CoinSelection.Internal.Balance.Gen`
- `Cardano.Wallet.Primitive.Types.UTxOIndex.Gen`
- `Cardano.Wallet.Primitive.Types.UTxOSelection.Gen`

It moves all generators and shrinkers for `WalletUTxO` to a new module:
- `Cardano.Wallet.CoinSelection.Gen`

## Future Work

In the long run we should be able to remove module `Cardano.Wallet.CoinSelection.Gen`, as the coin selection test suite will eventually use its own test types for addresses and UTxO identifiers.

But for now, we use this module as a way to minimize duplication.