### PR TITLE
Add property tests for conversion functions in `Wallet.CoinSelection`.

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -421,6 +421,7 @@ test-suite unit
       Cardano.Wallet.Api.ServerSpec
       Cardano.Wallet.Api.TypesSpec
       Cardano.Wallet.ApiSpec
+      Cardano.Wallet.CoinSelectionSpec
       Cardano.Wallet.CoinSelection.InternalSpec
       Cardano.Wallet.CoinSelection.Internal.BalanceSpec
       Cardano.Wallet.CoinSelection.Internal.CollateralSpec

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -399,9 +399,8 @@ data SelectionOf change = Selection
 --
 type Selection = SelectionOf TokenBundle
 
-toExternalSelection
-    :: SelectionParams -> Internal.Selection WalletSelectionContext -> Selection
-toExternalSelection _ps Internal.Selection {..} =
+toExternalSelection :: Internal.Selection WalletSelectionContext -> Selection
+toExternalSelection Internal.Selection {..} =
     Selection
         { collateral = toExternalUTxO' TokenBundle.fromCoin
             <$> collateral
@@ -450,7 +449,7 @@ performSelection
     -> SelectionParams
     -> ExceptT (SelectionError WalletSelectionContext) m Selection
 performSelection cs ps =
-    toExternalSelection ps <$>
+    toExternalSelection <$>
     Internal.performSelection @m @WalletSelectionContext
         (toInternalSelectionConstraints cs)
         (toInternalSelectionParams ps)

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -34,6 +34,10 @@ module Cardano.Wallet.CoinSelection
     , toInternalUTxO
     , toInternalUTxOMap
 
+    -- * Mapping between external (wallet) selections and internal selections.
+    , toExternalSelection
+    , toInternalSelection
+
     -- * Performing selections
     , performSelection
     , Selection

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
@@ -2,6 +2,7 @@ module Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange
     , genTokenBundleSmallRangePositive
     , genTokenBundle
+    , shrinkTokenBundle
     , shrinkTokenBundleSmallRange
     , shrinkTokenBundleSmallRangePositive
     ) where
@@ -31,6 +32,12 @@ genTokenBundle = TokenBundle
     <$> genCoin
     <*> genTokenMap
 
+shrinkTokenBundle :: TokenBundle -> [TokenBundle]
+shrinkTokenBundle (TokenBundle c m)=
+    uncurry TokenBundle <$> shrinkInterleaved
+        (c, shrinkCoin)
+        (m, shrinkTokenMap)
+
 --------------------------------------------------------------------------------
 -- Token bundles with coins, assets, and quantities chosen from small ranges
 --------------------------------------------------------------------------------
@@ -41,10 +48,7 @@ genTokenBundleSmallRange = TokenBundle
     <*> genTokenMapSmallRange
 
 shrinkTokenBundleSmallRange :: TokenBundle -> [TokenBundle]
-shrinkTokenBundleSmallRange (TokenBundle c m) =
-    uncurry TokenBundle <$> shrinkInterleaved
-        (c, shrinkCoin)
-        (m, shrinkTokenMap)
+shrinkTokenBundleSmallRange = shrinkTokenBundle
 
 genTokenBundleSmallRangePositive :: Gen TokenBundle
 genTokenBundleSmallRangePositive = TokenBundle

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelectionSpec.hs
@@ -1,0 +1,68 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.CoinSelectionSpec
+    where
+
+import Prelude
+
+import Cardano.Wallet.CoinSelection
+    ( toExternalUTxO, toExternalUTxOMap, toInternalUTxO, toInternalUTxOMap )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn, TxOut )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genTxIn, genTxOut, shrinkTxIn, shrinkTxOut )
+import Cardano.Wallet.Primitive.Types.UTxO
+    ( UTxO )
+import Cardano.Wallet.Primitive.Types.UTxO.Gen
+    ( genUTxO, genUTxOLarge, shrinkUTxO )
+import Data.Function
+    ( (&) )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.Hspec.Extra
+    ( parallel )
+import Test.QuickCheck
+    ( Arbitrary (..), Property, oneof, property, (===) )
+
+spec :: Spec
+spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
+
+    parallel $ describe
+        "Conversion between external (wallet) and internal UTxOs" $ do
+
+        it "prop_toInternalUTxO_toExternalUTxO" $
+            prop_toInternalUTxO_toExternalUTxO & property
+
+        it "prop_toInternalUTxOMap_toExternalUTxOMap" $
+            prop_toInternalUTxOMap_toExternalUTxOMap & property
+
+--------------------------------------------------------------------------------
+-- Conversion between external (wallet) and internal UTxOs
+--------------------------------------------------------------------------------
+
+prop_toInternalUTxO_toExternalUTxO :: TxIn -> TxOut -> Property
+prop_toInternalUTxO_toExternalUTxO i o =
+    (toExternalUTxO . toInternalUTxO) (i, o) === (i, o)
+
+prop_toInternalUTxOMap_toExternalUTxOMap :: UTxO -> Property
+prop_toInternalUTxOMap_toExternalUTxOMap u =
+    (toExternalUTxOMap . toInternalUTxOMap) u === u
+
+--------------------------------------------------------------------------------
+-- Arbitrary instances
+--------------------------------------------------------------------------------
+
+instance Arbitrary TxIn where
+    arbitrary = genTxIn
+    shrink = shrinkTxIn
+
+instance Arbitrary TxOut where
+    arbitrary = genTxOut
+    shrink = shrinkTxOut
+
+instance Arbitrary UTxO where
+    arbitrary = oneof
+        [ genUTxO
+        , genUTxOLarge
+        ]
+    shrink = shrinkUTxO

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -35,6 +35,10 @@ module Test.QuickCheck.Extra
     , chooseNatural
     , shrinkNatural
 
+      -- * Generating and shrinking non-empty lists
+    , genNonEmpty
+    , shrinkNonEmpty
+
       -- * Counterexamples
     , report
     , verify
@@ -54,6 +58,8 @@ import Prelude
 
 import Data.IntCast
     ( intCast, intCastMaybe )
+import Data.List.NonEmpty
+    ( NonEmpty (..) )
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
@@ -90,6 +96,7 @@ import Text.Pretty.Simple
     ( pShow )
 
 import qualified Data.List as L
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Text.Lazy as TL
 import qualified Generics.SOP.GGP as GGP
@@ -196,6 +203,16 @@ shrinkNatural n
     = mapMaybe (intCastMaybe @Integer @Natural)
     $ shrinkIntegral
     $ intCast n
+
+--------------------------------------------------------------------------------
+-- Generating and shrinking non-empty lists
+--------------------------------------------------------------------------------
+
+genNonEmpty :: Gen a -> Gen (NonEmpty a)
+genNonEmpty genA = (:|) <$> genA <*> listOf genA
+
+shrinkNonEmpty :: (a -> [a]) -> (NonEmpty a -> [NonEmpty a])
+shrinkNonEmpty shrinkA = mapMaybe NE.nonEmpty . shrinkList shrinkA . NE.toList
 
 --------------------------------------------------------------------------------
 -- Generating functions

--- a/nix/materialized/stack-nix/cardano-wallet-core.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-core.nix
@@ -389,6 +389,7 @@
             "Cardano/Wallet/Api/ServerSpec"
             "Cardano/Wallet/Api/TypesSpec"
             "Cardano/Wallet/ApiSpec"
+            "Cardano/Wallet/CoinSelectionSpec"
             "Cardano/Wallet/CoinSelection/InternalSpec"
             "Cardano/Wallet/CoinSelection/Internal/BalanceSpec"
             "Cardano/Wallet/CoinSelection/Internal/CollateralSpec"


### PR DESCRIPTION
## Issue Number

ADP-1448

## Description

This PR adds round-trip property tests for conversions between external (wallet) types and internal types in `Cardano.Wallet.CoinSelection`:

- `to{Internal,External}Selection`
- `to{Internal,External}UTxO`
- `to{Internal,External}UTxOMap`
