### PR TITLE
Rework CLI error reporting for the --blockfrost-token-file

### DIFF
--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -36,8 +36,9 @@ library
     , bech32
     , bech32-th
     , binary
-    , blockfrost-client >=0.3.1.0 && <0.4
-    , blockfrost-client-core >=0.2.0.0 && <0.3
+    , blockfrost-api
+    , blockfrost-client
+    , blockfrost-client-core
     , bytestring
     , cardano-addresses
     , cardano-api

--- a/lib/shelley/exe/cardano-wallet.hs
+++ b/lib/shelley/exe/cardano-wallet.hs
@@ -236,12 +236,17 @@ cmdServe = command "serve" $ info (helper <*> helper' <*> cmd) $
                 setupDirectory (logInfo tr . MsgSetupDatabases)
 
             blockchainSource <- case mode of
-                Normal conn ->
-                    pure $ NodeSource conn vData
-                Light token ->
-                    BlockfrostSource <$> Blockfrost.readToken token
-                        `catch` \(Blockfrost.TokenFileException fp) -> do
-                            logError tr (MsgBlockfrostTokenError fp)
+                Normal conn -> pure $ NodeSource conn vData
+                Light token -> BlockfrostSource <$> Blockfrost.readToken token
+                    `catch` \case
+                        Blockfrost.BadTokenFile f -> do
+                            logError tr $ MsgBlockfrostTokenFileError f
+                            exitWith $ ExitFailure 1
+                        Blockfrost.EmptyToken f -> do
+                            logError tr $ MsgBlockfrostTokenError f
+                            exitWith $ ExitFailure 1
+                        Blockfrost.InvalidToken f -> do
+                            logError tr $ MsgBlockfrostTokenError f
                             exitWith $ ExitFailure 1
 
             exitWith =<< serveWallet
@@ -284,6 +289,7 @@ data MainLog
     | MsgSigInt
     | MsgShutdownHandler ShutdownHandlerLog
     | MsgFailedToParseGenesis Text
+    | MsgBlockfrostTokenFileError FilePath
     | MsgBlockfrostTokenError FilePath
     deriving (Show)
 
@@ -316,9 +322,14 @@ instance ToText MainLog where
             , "parameters."
             , "Here's (perhaps) some helpful hint:", hint
             ]
+        MsgBlockfrostTokenFileError tokenFile -> T.unwords
+            [ "File"
+            , "'" <> T.pack tokenFile <> "'"
+            , "specified in the --blockfrost-token-file can't be read."
+            ]
         MsgBlockfrostTokenError tokenFile -> T.unwords
             [ "File"
-            , T.pack tokenFile
+            , "'" <> T.pack tokenFile <> "'"
             , "specified in the --blockfrost-token-file\
             \ argument doesn't contain a valid Blockfrost API token."
             ]

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Blockfrost.hs
@@ -23,8 +23,8 @@ import Data.Text
 import Options.Applicative
     ( Parser, help, long, metavar, option, str )
 
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
+import qualified Data.Text.IO as T
+import qualified Data.Text as T
 
 newtype TokenFile = TokenFile FilePath
     deriving newtype (Eq, Show)
@@ -45,14 +45,14 @@ tokenFileOption = option (TokenFile <$> str) $ mconcat
     ]
 
 readToken :: TokenFile -> IO Project
-readToken (TokenFile fp) = Text.readFile fp >>=
+readToken (TokenFile fp) = T.readFile fp >>=
     either (throw (TokenFileException fp) . const) pure . mkProject
   where
     -- Can't use `Blockfrost.Client.Core.projectFromFile` as it uses `error`
     -- and it leads to an unnecessary output that pollutes stdout.
     mkProject :: Text -> Either Text Project
     mkProject t =
-      let st = Text.strip t
-          tEnv = Text.dropEnd 32 st
-          token = Text.drop (Text.length tEnv) st
+      let st = T.strip t
+          tEnv = T.dropEnd 32 st
+          token = T.drop (T.length tEnv) st
       in Project <$> parseEnv tEnv <*> pure token

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Blockfrost.hs
@@ -7,6 +7,7 @@ module Cardano.Wallet.Shelley.Launch.Blockfrost
     ( TokenFile (..)
     , readToken
     , tokenFileOption
+    , TokenException(..)
     , TokenFileException(..)
     ) where
 
@@ -17,17 +18,21 @@ import Blockfrost.Client.Types
 import Blockfrost.Env
     ( parseEnv )
 import Control.Exception
-    ( Exception, throw )
-import Data.Text
-    ( Text )
+    ( Exception, IOException, catch, throw )
+import Control.Monad
+    ( when )
 import Options.Applicative
     ( Parser, help, long, metavar, option, str )
 
-import qualified Data.Text.IO as T
 import qualified Data.Text as T
+import qualified Data.Text.IO as T
 
 newtype TokenFile = TokenFile FilePath
     deriving newtype (Eq, Show)
+
+data TokenException = EmptyToken FilePath | InvalidToken FilePath
+    deriving stock (Eq, Show)
+    deriving anyclass (Exception)
 
 newtype TokenFileException = TokenFileException FilePath
     deriving stock (Eq, Show)
@@ -45,14 +50,15 @@ tokenFileOption = option (TokenFile <$> str) $ mconcat
     ]
 
 readToken :: TokenFile -> IO Project
-readToken (TokenFile fp) = T.readFile fp >>=
-    either (throw (TokenFileException fp) . const) pure . mkProject
-  where
+readToken (TokenFile fp) = do
     -- Can't use `Blockfrost.Client.Core.projectFromFile` as it uses `error`
     -- and it leads to an unnecessary output that pollutes stdout.
-    mkProject :: Text -> Either Text Project
-    mkProject t =
-      let st = T.strip t
-          tEnv = T.dropEnd 32 st
-          token = T.drop (T.length tEnv) st
-      in Project <$> parseEnv tEnv <*> pure token
+    line <- T.readFile fp `catch` \(_ :: IOException) ->
+        throw $ TokenFileException fp
+    let tokenSrc = T.strip line
+    when (T.null tokenSrc) $ throw $ EmptyToken fp
+    let tEnv = T.dropEnd 32 tokenSrc
+        token = T.drop (T.length tEnv) tokenSrc
+    case Project <$> parseEnv tEnv <*> pure token of
+      Left _ -> throw $ InvalidToken fp
+      Right project -> pure project

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Blockfrost.hs
@@ -1,23 +1,37 @@
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Wallet.Shelley.Launch.Blockfrost
-    ( TokenFile
+    ( TokenFile (..)
     , readToken
     , tokenFileOption
+    , TokenFileException(..)
     ) where
 
 import Prelude
 
-import Blockfrost.Client.Core
-    ( projectFromFile )
 import Blockfrost.Client.Types
     ( Project (..) )
+import Blockfrost.Env
+    ( parseEnv )
+import Control.Exception
+    ( Exception, throw )
+import Data.Text
+    ( Text )
 import Options.Applicative
     ( Parser, help, long, metavar, option, str )
 
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+
 newtype TokenFile = TokenFile FilePath
     deriving newtype (Eq, Show)
+
+newtype TokenFileException = TokenFileException FilePath
+    deriving stock (Eq, Show)
+    deriving anyclass (Exception)
 
 -- | --blockfrost-token-file FILE
 tokenFileOption :: Parser TokenFile
@@ -31,4 +45,14 @@ tokenFileOption = option (TokenFile <$> str) $ mconcat
     ]
 
 readToken :: TokenFile -> IO Project
-readToken (TokenFile fp) = projectFromFile fp
+readToken (TokenFile fp) = Text.readFile fp >>=
+    either (throw (TokenFileException fp) . const) pure . mkProject
+  where
+    -- Can't use `Blockfrost.Client.Core.projectFromFile` as it uses `error`
+    -- and it leads to an unnecessary output that pollutes stdout.
+    mkProject :: Text -> Either Text Project
+    mkProject t =
+      let st = Text.strip t
+          tEnv = Text.dropEnd 32 st
+          token = Text.drop (Text.length tEnv) st
+      in Project <$> parseEnv tEnv <*> pure token

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/Launch/BlockfrostSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/Launch/BlockfrostSpec.hs
@@ -12,11 +12,7 @@ import Blockfrost.Env
 import Cardano.Wallet.Shelley.Launch
     ( Mode (Light, Normal), modeOption )
 import Cardano.Wallet.Shelley.Launch.Blockfrost
-    ( TokenException (..)
-    , TokenFile (TokenFile)
-    , TokenFileException (TokenFileException)
-    , readToken
-    )
+    ( TokenException (..), TokenFile (TokenFile), readToken )
 import Options.Applicative
     ( ParserFailure (execFailure)
     , ParserResult (CompletionInvoked, Failure, Success)
@@ -76,7 +72,7 @@ spec = describe "Blockfrost CLI options" $ do
 
     it "readToken throws in case of a non-existing token file" $ do
         readToken (TokenFile "non-existing-file")
-            `shouldThrow` \(TokenFileException _) -> True
+            `shouldThrow` \(BadTokenFile _) -> True
 
     it "readToken throws in case of an empty token file" $
         withSystemTempFile "blockfrost.token" $ \f h -> do

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/Launch/BlockfrostSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/Launch/BlockfrostSpec.hs
@@ -22,7 +22,7 @@ import Options.Applicative
     , info
     )
 import Test.Hspec
-    ( Spec, describe, expectationFailure, it, shouldBe, shouldReturn )
+    ( Spec, describe, expectationFailure, it, shouldReturn, shouldStartWith )
 import Test.Utils.Platform
     ( isWindows )
 import UnliftIO
@@ -60,14 +60,8 @@ spec = describe "Blockfrost CLI options" $ do
             args = ["--blockfrost-token-file", mockSocketOrPipe]
         case execParserPure defaultPrefs parserInfo args of
             Failure pf | (help, _code, _int) <- execFailure pf "" ->
-                show help `shouldBe`
-                    "Missing: --light\n\n\
-                    \Usage:  (--node-socket " <> nodeSocketMetavar <> " | \
-                    \--light --blockfrost-token-file FILE)"
+                show help `shouldStartWith` "Missing: --light"
             result -> expectationFailure $ show result
-
-nodeSocketMetavar :: String
-nodeSocketMetavar = if isWindows then "PIPENAME" else "FILE"
 
 mockSocketOrPipe :: String
 mockSocketOrPipe = if isWindows then "\\\\.\\pipe\\test" else "/tmp/pipe"

--- a/nix/materialized/stack-nix/cardano-wallet.nix
+++ b/nix/materialized/stack-nix/cardano-wallet.nix
@@ -40,6 +40,7 @@
           (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
           (hsPkgs."bech32-th" or (errorHandler.buildDepError "bech32-th"))
           (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+          (hsPkgs."blockfrost-api" or (errorHandler.buildDepError "blockfrost-api"))
           (hsPkgs."blockfrost-client" or (errorHandler.buildDepError "blockfrost-client"))
           (hsPkgs."blockfrost-client-core" or (errorHandler.buildDepError "blockfrost-client-core"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))


### PR DESCRIPTION
- [x] I have changed the way token parsing errors are reported.

### Comments

Example:
```
[cardano-wallet.main:Error:4] [2022-03-18 17:44:51.47 UTC] File /nix/store/7mxbly45mn9x8lijmigk3k25wlzvcn3a-cardano-node-deployments/testnet/genesis-byron.json specified in the --blockfrost-token-file argument doesn't contain a valid Blockfrost API token.
[cardano-wallet.main:Debug:4] [2022-03-18 17:44:51.47 UTC] Logging shutdown.
```

### Issue Number

ADP-1426
