### PR TITLE
Fix the `flake.lock` file.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,7 +148,6 @@
         "flake-utils": "flake-utils_5",
         "heist": "heist",
         "nixpkgs": [
-          "emanote",
           "ema",
           "nixpkgs"
         ],


### PR DESCRIPTION
## Summary

Issuing a `nix develop` command causes the `flake.lock` file to be updated, which results in a dirty git tree.

This PR commits the updated `flake.lock` file.