### PR TITLE
Light Mode: Node tip and Protocol Parameters

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -40,6 +41,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Primitive.Types
     ( FeePolicy (..)
+    , LinearFunction (..)
     , PoolId (..)
     , PoolMetadataGCStatus (..)
     , PoolMetadataSource (..)
@@ -152,6 +154,8 @@ import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.ByteString as BS
 import qualified Data.Set as Set
 import qualified Data.Text as T
+import Data.Tuple.Extra
+    ( both )
 import qualified Network.HTTP.Types.Status as HTTP
 
 spec :: forall n.
@@ -1435,8 +1439,8 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
         withCoefficients coeff cst
       where
         pp = ctx ^. #_networkParameters . #protocolParameters
-        (cst, coeff) = (round $ getQuantity a, round $ getQuantity b)
-        LinearFee a b = pp ^. #txParameters . #getFeePolicy
+        (cst, coeff) = both round (intercept, slope)
+        LinearFee LinearFunction {..} = pp ^. #txParameters . #getFeePolicy
 
 -- The complete set of pool identifiers in the static test pool cluster.
 --

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -372,6 +372,7 @@ import Cardano.Wallet.Primitive.Types
     , FeePolicy (LinearFee)
     , GenesisParameters (..)
     , IsDelegatingTo (..)
+    , LinearFunction (LinearFunction)
     , NetworkParameters (..)
     , PassphraseScheme (..)
     , PoolId (..)
@@ -1935,8 +1936,7 @@ balanceTransactionWithSelectionStrategy
             -- with a coin value just about the 9 byte limit (4294967296). I.e.
             -- seems like a problem of coin selection.
             feePadding =
-                let
-                    LinearFee _ (Quantity perByte) =
+                let LinearFee LinearFunction {slope = perByte} =
                         view (#txParameters . #getFeePolicy) pp
                     scriptIntegrityHashBytes = 32 + 2
                     extraBytes = 4

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2393,7 +2393,7 @@ balanceTransaction
 balanceTransaction ctx genChange (ApiT wid) body = do
     pp <- liftIO $ NW.currentProtocolParameters nl
     -- TODO: This throws when still in the Byron era.
-    nodePParams <- fromJust <$> liftIO (NW.currentNodeProtocolParameters nl)
+    let nodePParams = fromJust $ W.currentNodeProtocolParameters pp
     let partialTx = W.PartialTx
             (getApiT $ body ^. #transaction)
             (fromExternalInput <$> body ^. #inputs)

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -100,7 +100,6 @@ import UnliftIO.Async
 import UnliftIO.Concurrent
     ( threadDelay )
 
-import qualified Cardano.Api.Shelley as Node
 import qualified Data.List.NonEmpty as NE
 
 {-------------------------------------------------------------------------------
@@ -136,11 +135,6 @@ data NetworkLayer m block = NetworkLayer
     , currentProtocolParameters
         :: m ProtocolParameters
         -- ^ Get the last known protocol parameters. In principle, these can
-        -- only change once per epoch.
-
-    , currentNodeProtocolParameters
-        :: m (Maybe Node.ProtocolParameters)
-        -- ^ Get the last known node's protocol parameters. In principle, these can
         -- only change once per epoch.
 
     , currentSlottingParameters

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -87,6 +87,8 @@ import Prelude
 
 import Cardano.Address.Derivation
     ( XPrv, XPub, xpubPublicKey )
+import Cardano.Address.Script
+    ( KeyHash (KeyHash), KeyRole )
 import Cardano.Mnemonic
     ( SomeMnemonic )
 import Cardano.Wallet.Primitive.Types
@@ -152,8 +154,6 @@ import Quiet
 import Safe
     ( readMay, toEnumMay )
 
-import Cardano.Address.Script
-    ( KeyHash (KeyHash), KeyRole )
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
 import qualified Crypto.Scrypt as Scrypt

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -84,6 +84,7 @@ module Cardano.Wallet.Primitive.Types
     , unsafeEpochNo
     , isValidEpochNo
     , FeePolicy (..)
+    , LinearFunction (..)
     , SlotId (..)
     , SlotNo (..)
     , SlotLength (..)
@@ -890,33 +891,32 @@ instance Buildable Slot where
     build Origin    = "[genesis]"
     build (At slot) = "[at slot " <> pretty slot <> "]"
 
+data LinearFunction a = LinearFunction { intercept :: a, slope :: a }
+    deriving (Eq, Show, Generic)
+
+instance NFData a => NFData (LinearFunction a)
+
 -- | A linear equation of a free variable `x`. Represents the @\x -> a + b*x@
--- function where @x@ can be the transaction size in bytes or, a number of
--- inputs + outputs.
---
--- @a@ and @b@ are constant coefficients.
---
--- FIXME 'Double' is an old artifact from the Byron era on cardano-sl. It must
--- go.
-data FeePolicy = LinearFee
-    (Quantity "lovelace" Double)
-    (Quantity "lovelace/byte" Double)
+-- function where @x@ can be either a transaction size in bytes or
+-- a number of inputs + outputs.
+newtype FeePolicy = LinearFee (LinearFunction Double)
     deriving (Eq, Show, Generic)
 
 instance NFData FeePolicy
 
 instance ToText FeePolicy where
-    toText (LinearFee (Quantity a) (Quantity b)) =
-        toText a <> " + " <> toText b <> "x"
+    toText (LinearFee LinearFunction {..}) =
+        toText intercept <> " + " <>
+        toText slope <> "x"
 
 instance FromText FeePolicy where
     fromText txt = case T.splitOn " + " txt of
         [a, b] | T.takeEnd 1 b == "x" ->
-            left (const err) $ LinearFee
-                <$> fmap Quantity (fromText a)
-                <*> fmap Quantity (fromText (T.dropEnd 1 b))
-        _ ->
-            Left err
+            left (const err) $
+                (LinearFee .) . LinearFunction
+                    <$> fromText a
+                    <*> fromText (T.dropEnd 1 b)
+        _ -> Left err
       where
         err = TextDecodingError
             "Unable to decode FeePolicy: \

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -15,6 +15,7 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -273,6 +274,7 @@ import Numeric.Natural
 import Test.QuickCheck
     ( Arbitrary (..), oneof )
 
+import qualified Cardano.Api.Shelley as Node
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32
 import qualified Data.ByteString as BS
@@ -1138,9 +1140,25 @@ data ProtocolParameters = ProtocolParameters
         -- used to determine the fee for the use of a script within a
         -- transaction, based on the 'ExecutionUnits' needed by the use of
         -- the script.
+    , currentNodeProtocolParameters
+        :: Maybe Node.ProtocolParameters
+        -- ^ Get the last known node's protocol parameters.
+        -- In principle, these can only change once per epoch.
     } deriving (Eq, Generic, Show)
 
-instance NFData ProtocolParameters
+instance NFData ProtocolParameters where
+    rnf ProtocolParameters {..} = mconcat
+        [ rnf decentralizationLevel
+        , rnf txParameters
+        , rnf desiredNumberOfStakePools
+        , rnf minimumUTxOvalue
+        , rnf stakeKeyDeposit
+        , rnf eras
+        , rnf maximumCollateralInputCount
+        , rnf minimumCollateralPercentage
+        , rnf executionUnitPrices
+        -- currentNodeProtocolParameters is omitted
+        ]
 
 instance Buildable ProtocolParameters where
     build pp = blockListF' "" id

--- a/lib/core/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -128,6 +128,7 @@ dummyProtocolParameters = ProtocolParameters
     , maximumCollateralInputCount = 3
     , minimumCollateralPercentage = 100
     , executionUnitPrices = Nothing
+    , currentNodeProtocolParameters = Nothing
     }
 
 -- | Construct a @Tx@, computing its hash using the dummy @mkTxId@.
@@ -168,7 +169,6 @@ dummyNetworkLayer = NetworkLayer
     , currentNodeTip = error "currentNodeTip: not implemented"
     , watchNodeTip = error "watchNodeTip: not implemented"
     , currentProtocolParameters = error "currentProtocolParameters: not implemented"
-    , currentNodeProtocolParameters = error "currentNodeProtocolParameters: not implemented"
     , currentSlottingParameters = error "currentSlottingParameters: not implemented"
     , postTx = error "postTx: not implemented"
     , stakeDistribution = error "stakeDistribution: not implemented"

--- a/lib/core/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -31,6 +31,7 @@ import Cardano.Wallet.Primitive.Types
     , ExecutionUnits (..)
     , FeePolicy (..)
     , GenesisParameters (..)
+    , LinearFunction (..)
     , MinimumUTxOValue (..)
     , NetworkParameters (..)
     , ProtocolParameters (..)
@@ -104,7 +105,7 @@ dummyTimeInterpreter = hoistTimeInterpreter (pure . runIdentity)
 
 dummyTxParameters :: TxParameters
 dummyTxParameters = TxParameters
-    { getFeePolicy = LinearFee (Quantity 14) (Quantity 42)
+    { getFeePolicy = LinearFee $ LinearFunction { intercept = 14, slope = 42 }
     , getTxMaxSize = Quantity 8192
     , getTokenBundleMaxSize = TokenBundleMaxSize (TxSize 4000)
     , getMaxExecutionUnits = ExecutionUnits 0 0

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -18,7 +19,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Cardano.Wallet.DB.Arbitrary
     ( GenTxHistory (..)
@@ -89,6 +89,7 @@ import Cardano.Wallet.Primitive.Types
     , ExecutionUnitPrices (..)
     , ExecutionUnits (..)
     , FeePolicy (..)
+    , LinearFunction (LinearFunction)
     , MinimumUTxOValue (..)
     , PassphraseScheme (..)
     , PoolId (..)
@@ -724,9 +725,9 @@ instance Arbitrary ExecutionUnits where
         <*> arbitrary
 
 instance Arbitrary FeePolicy where
-    arbitrary = LinearFee
-        <$> fmap Quantity (choose (0, 1000))
-        <*> fmap Quantity (choose (0, 100))
+    arbitrary = (LinearFee . ) . LinearFunction
+        <$> choose (0, 1000)
+        <*> choose (0, 100)
 
 instance (Integral a, Arbitrary a) => Arbitrary (Quantity n a) where
     shrink (Quantity a) = Quantity <$> shrinkIntegral a

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -18,6 +18,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Cardano.Wallet.DB.Arbitrary
     ( GenTxHistory (..)
@@ -663,7 +664,17 @@ arbitrarySharedAccount =
 -------------------------------------------------------------------------------}
 
 instance Arbitrary ProtocolParameters where
-    shrink = genericShrink
+    shrink ProtocolParameters {..} = ProtocolParameters
+        <$> shrink decentralizationLevel
+        <*> shrink txParameters
+        <*> shrink desiredNumberOfStakePools
+        <*> shrink minimumUTxOvalue
+        <*> shrink stakeKeyDeposit
+        <*> shrink eras
+        <*> shrink maximumCollateralInputCount
+        <*> shrink minimumCollateralPercentage
+        <*> shrink executionUnitPrices
+        <*> pure Nothing
     arbitrary = ProtocolParameters
         <$> arbitrary
         <*> arbitrary
@@ -674,6 +685,7 @@ instance Arbitrary ProtocolParameters where
         <*> genMaximumCollateralInputCount
         <*> genMinimumCollateralPercentage
         <*> arbitrary
+        <*> pure Nothing
       where
         genMaximumCollateralInputCount :: Gen Word16
         genMaximumCollateralInputCount = arbitrarySizedNatural

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -134,6 +134,7 @@ import Cardano.Wallet.Primitive.Types
     , ExecutionUnits (..)
     , FeePolicy
     , GenesisParameters (..)
+    , LinearFunction
     , PoolId (..)
     , Range (..)
     , Slot
@@ -1054,6 +1055,9 @@ instance ToExpr TxParameters where
     toExpr = genericToExpr
 
 instance ToExpr ExecutionUnits where
+    toExpr = genericToExpr
+
+instance ToExpr a => ToExpr (LinearFunction a) where
     toExpr = genericToExpr
 
 instance ToExpr FeePolicy where

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -4,9 +4,11 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Wallet.Primitive.TypesSpec
@@ -54,6 +56,7 @@ import Cardano.Wallet.Primitive.Types
     , EpochLength (..)
     , EpochNo (..)
     , FeePolicy (..)
+    , LinearFunction (..)
     , PoolId (..)
     , PoolOwner (..)
     , Range (..)
@@ -1091,13 +1094,11 @@ instance Arbitrary Direction where
 
 instance Arbitrary FeePolicy where
     arbitrary = do
-        NonNegative a <- arbitrary
-        NonNegative b <- arbitrary
-        return $ LinearFee (Quantity a) (Quantity b)
-    shrink (LinearFee (Quantity a) (Quantity b)) =
-        f <$> shrink (a, b)
-      where
-        f (x, y) = LinearFee (Quantity x) (Quantity y)
+        NonNegative intercept <- arbitrary
+        NonNegative slope <- arbitrary
+        pure $ LinearFee LinearFunction {..}
+    shrink (LinearFee LinearFunction {..}) =
+        LinearFee . uncurry LinearFunction <$> shrink (intercept, slope)
 
 -- Same for addresses
 instance Arbitrary Address where

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -133,7 +133,8 @@ mainnetNetworkParameters = W.NetworkParameters
             minBound
         , txParameters = W.TxParameters
             { getFeePolicy =
-                W.LinearFee (Quantity 155381) (Quantity 43.946)
+                W.LinearFee $
+                    W.LinearFunction { intercept = 155381, slope = 43.946 }
             , getTxMaxSize =
                 Quantity 4096
             , getTokenBundleMaxSize = maryTokenBundleMaxSize
@@ -317,9 +318,10 @@ fromBlockNo (BlockNo h) =
 
 fromTxFeePolicy :: TxFeePolicy -> W.FeePolicy
 fromTxFeePolicy (TxFeePolicyTxSizeLinear (TxSizeLinear a b)) =
-    W.LinearFee
-        (Quantity (lovelaceToDouble a))
-        (Quantity (rationalToDouble b))
+    W.LinearFee $ W.LinearFunction
+        { intercept = lovelaceToDouble a
+        , slope = rationalToDouble b
+        }
   where
     lovelaceToDouble :: Lovelace -> Double
     lovelaceToDouble = fromIntegral . unsafeGetLovelace

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -782,9 +782,10 @@ txParametersFromPParams
     -> pparams
     -> W.TxParameters
 txParametersFromPParams maxBundleSize getMaxExecutionUnits pp = W.TxParameters
-    { getFeePolicy = W.LinearFee
-        (Quantity (naturalToDouble (getField @"_minfeeB" pp)))
-        (Quantity (naturalToDouble (getField @"_minfeeA" pp)))
+    { getFeePolicy = W.LinearFee $ W.LinearFunction
+        { intercept = naturalToDouble (getField @"_minfeeB" pp)
+        , slope = naturalToDouble (getField @"_minfeeA" pp)
+        }
     , getTxMaxSize = fromMaxSize $ getField @"_maxTxSize" pp
     , getTokenBundleMaxSize = maxBundleSize
     , getMaxExecutionUnits

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -2,12 +2,15 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Copyright: © 2020 IOHK
@@ -24,12 +27,18 @@ module Cardano.Wallet.Shelley.Network.Blockfrost
 
     -- * Internal
     , getPoolPerformanceEstimate
+    -- * Blockfrost -> Cardano translation
+    , fromBlockfrost
     ) where
 
 import Prelude
 
 import qualified Blockfrost.Client as BF
+import qualified Cardano.Api.Shelley as Node
+import qualified Data.Sequence as Seq
 
+import Cardano.Api
+    ( AnyCardanoEra )
 import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Tracer
@@ -47,27 +56,51 @@ import Cardano.Wallet.Network
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
     , DecentralizationLevel (..)
+    , ExecutionUnitPrices (..)
+    , ExecutionUnits (..)
+    , FeePolicy (LinearFee)
+    , MinimumUTxOValue (..)
+    , ProtocolParameters (..)
     , SlotNo (SlotNo)
+    , SlotNo (..)
     , SlottingParameters (..)
+    , TokenBundleMaxSize (..)
+    , TxParameters (..)
+    , emptyEraInfo
+    , executionMemory
+    , executionSteps
     )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..) )
+    ( Coin (Coin, unCoin) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxSize (..) )
+import Control.Arrow
+    ( (<<<) )
 import Control.Concurrent
     ( threadDelay )
 import Control.Monad
-    ( forever )
+    ( forever, (<=<) )
 import Control.Monad.Error.Class
-    ( MonadError, throwError )
+    ( MonadError, liftEither, throwError )
 import Control.Monad.Trans.Except
-    ( ExceptT (ExceptT), runExceptT )
+    ( ExceptT (..), runExceptT )
 import Data.Bifunctor
     ( first )
+import Data.Bits
+    ( Bits )
+import Data.Function
+    ( (&) )
 import Data.Functor.Contravariant
     ( (>$<) )
+import Data.IntCast
+    ( intCast, intCastMaybe )
 import Data.Quantity
-    ( Quantity (..) )
+    ( MkPercentageError (PercentageOutOfBoundsError)
+    , Quantity (..)
+    , mkPercentage
+    )
 import Data.Text.Class
     ( FromText (fromText), TextDecodingError (..), ToText (..) )
 import Data.Traversable
@@ -83,7 +116,6 @@ import UnliftIO.Async
 import UnliftIO.Exception
     ( Exception )
 
-import qualified Data.Sequence as Seq
 
 {-------------------------------------------------------------------------------
     NetworkLayer
@@ -91,8 +123,10 @@ import qualified Data.Sequence as Seq
 data BlockfrostError
     = ClientError BF.BlockfrostError
     | NoSlotError BF.Block
+    | IntegralCastError String
     | NoBlockHeight BF.Block
     | InvalidBlockHash BF.BlockHash TextDecodingError
+    | InvalidDecentralizationLevelPercentage Double
     deriving (Show)
 
 newtype BlockfrostException = BlockfrostException BlockfrostError
@@ -120,8 +154,8 @@ withNetworkLayer tr project k = k NetworkLayer
     { chainSync = \_tr _chainFollower -> pure ()
     , lightSync = Nothing
     , currentNodeTip
-    , currentNodeEra = undefined
-    , currentProtocolParameters = undefined
+    , currentNodeEra
+    , currentProtocolParameters
     , currentSlottingParameters = undefined
     , watchNodeTip
     , postTx = undefined
@@ -133,7 +167,7 @@ withNetworkLayer tr project k = k NetworkLayer
     }
   where
     currentNodeTip :: IO BlockHeader
-    currentNodeTip = runExceptT fetchLatestBlockHeader >>= \case
+    currentNodeTip = runBlockfrost BF.getLatestBlock & runExceptT >>= \case
         -- TODO: use cached value while retrying
         Left err -> throwIO (BlockfrostException err)
         Right header -> pure header
@@ -143,19 +177,32 @@ withNetworkLayer tr project k = k NetworkLayer
       where
         pollNodeTip :: (BlockHeader -> IO ()) -> IO ()
         pollNodeTip cb = forever $ do
-            runExceptT fetchLatestBlockHeader >>= \case
+            runBlockfrost BF.getLatestBlock & runExceptT >>= \case
                 Left err -> throwIO (BlockfrostException err)
                 Right header ->
                     bracketTracer (MsgWatcherUpdate header >$< tr) $ cb header
             threadDelay 2_000_000
 
-    fetchLatestBlockHeader :: ExceptT BlockfrostError IO BlockHeader
-    fetchLatestBlockHeader =
-        runBlockfrost BF.getLatestBlock >>= blockToBlockHeader
+    currentProtocolParameters :: IO ProtocolParameters
+    currentProtocolParameters =
+        runBlockfrost BF.getLatestEpochProtocolParams & runExceptT >>= \case
+            -- TODO: use cached value while retrying
+            Left err -> throwIO (BlockfrostException err)
+            Right params -> pure params
 
-    runBlockfrost :: BF.BlockfrostClientT IO a -> ExceptT BlockfrostError IO a
+    currentNodeEra :: IO AnyCardanoEra
+    currentNodeEra = undefined
+
+    runBlockfrost ::
+        FromBlockfrost b w =>
+        BF.BlockfrostClientT IO b ->
+        ExceptT BlockfrostError IO w
     runBlockfrost =
-        ExceptT . (first ClientError <$>) . BF.runBlockfrostClientT project
+        fromBlockfrostM
+            <=< ExceptT
+            <<< (first ClientError <$>)
+            <<< BF.runBlockfrostClientT project
+
 
 blockToBlockHeader ::
     forall m. MonadError BlockfrostError m => BF.Block -> m BlockHeader
@@ -177,16 +224,21 @@ blockToBlockHeader block@BF.Block{..} = do
             Left tde -> throwError $ InvalidBlockHash blockHash tde
 
 class FromBlockfrost b w where
-    fromBlockfrost :: forall m. MonadError BlockfrostError m => b -> m w
+    fromBlockfrost :: b -> Either BlockfrostError w
+
+fromBlockfrostM
+    :: FromBlockfrost b w
+    => MonadError BlockfrostError m
+    => b
+    -> m w
+fromBlockfrostM = liftEither . fromBlockfrost
 
 instance FromBlockfrost BF.Block BlockHeader where
     fromBlockfrost block@BF.Block{..} = do
-        slotNo <- case _blockSlot of
-            Just s -> pure $ SlotNo $ fromIntegral $ BF.unSlot s
-            Nothing -> throwError $ NoSlotError block
-        blockHeight <- case _blockHeight of
-            Just height -> pure $ Quantity $ fromIntegral height
-            Nothing -> throwError $ NoBlockHeight block
+        slotNo <- _blockSlot <?> NoSlotError block >>= fromBlockfrostM
+        blockHeight <-
+            _blockHeight <?> NoBlockHeight block >>=
+                (Quantity <$>) . (<?#> "BlockHeight")
         headerHash <- parseBlockHeader _blockHash
         parentHeaderHash <- for _blockPreviousBlock parseBlockHeader
         pure BlockHeader { slotNo, blockHeight, headerHash, parentHeaderHash }
@@ -206,40 +258,155 @@ instance FromBlockfrost BF.ProtocolParams ProtocolParameters where
                     throwError $ InvalidDecentralizationLevelPercentage
                         _protocolParamsDecentralisationParam
                 Right level -> pure $ DecentralizationLevel level
-        let intToQuantity :: (Num q, Integral i) => i -> Quantity s q
-            intToQuantity = Quantity . fromIntegral
-            txParameters = TxParameters
-                { getFeePolicy =  LinearFee
-                    (intToQuantity _protocolParamsMinFeeA)
-                    (intToQuantity _protocolParamsMinFeeB)
+        minFeeA <-
+            _protocolParamsMinFeeA <?#> "MinFeeA"
+        minFeeB <-
+            _protocolParamsMinFeeB <?#> "MinFeeB"
+        maxTxSize <-
+            _protocolParamsMaxTxSize <?#> "MaxTxSize"
+        maxValSize <-
+            BF.unQuantity _protocolParamsMaxValSize <?#> "MaxValSize"
+        maxTxExSteps <-
+            BF.unQuantity _protocolParamsMaxTxExSteps <?#> "MaxTxExSteps"
+        maxBlockExSteps <-
+            BF.unQuantity _protocolParamsMaxBlockExSteps <?#> "MaxBlockExSteps"
+        maxBlockExMem <-
+            BF.unQuantity _protocolParamsMaxBlockExMem <?#> "MaxBlockExMem"
+        maxTxExMem <-
+            BF.unQuantity _protocolParamsMaxTxExMem <?#> "MaxTxExMem"
+        desiredNumberOfStakePools <-
+            _protocolParamsNOpt <?#> "NOpt"
+        minimumUTxOvalue <-
+            MinimumUTxOValueCostPerWord . Coin <$>
+                intCast @_ @Integer _protocolParamsCoinsPerUtxoWord
+                    <?#> "CoinsPerUtxoWord"
+        stakeKeyDeposit <-
+            Coin <$>
+                intCast @_ @Integer _protocolParamsKeyDeposit <?#> "KeyDeposit"
+        maxCollateralInputs <-
+            _protocolParamsMaxCollateralInputs <?#> "MaxCollateralInputs"
+        collateralPercent <-
+            _protocolParamsCollateralPercent <?#> "CollateralPercent"
+        protoMajorVer <-
+            _protocolParamsProtocolMajorVer <?#> "ProtocolMajorVer"
+        protoMinorVer <-
+            _protocolParamsProtocolMinorVer <?#> "ProtocolMinorVer"
+        maxBlockHeaderSize <-
+            _protocolParamsMaxBlockHeaderSize <?#> "MaxBlockHeaderSize"
+        maxBlockBodySize <-
+            _protocolParamsMaxBlockSize <?#> "MaxBlockBodySize"
+        eMax <-
+            _protocolParamsEMax <?#> "EMax"
+        nOpt <-
+            _protocolParamsNOpt <?#> "NOpt"
+
+        pure ProtocolParameters
+            { eras = emptyEraInfo
+            , txParameters = TxParameters
+                { getFeePolicy =
+                    LinearFee
+                        (Quantity $ fromIntegral minFeeA)
+                        (Quantity $ fromIntegral minFeeB)
                 , getTxMaxSize =
-                    intToQuantity _protocolParamsMaxTxSize
+                    Quantity maxTxSize
                 , getTokenBundleMaxSize =
-                    TokenBundleMaxSize $ TxSize $ fromIntegral $
-                        BF.unQuantity _protocolParamsMaxValSize
+                    TokenBundleMaxSize $ TxSize maxValSize
                 , getMaxExecutionUnits =
                     ExecutionUnits
-                        { executionSteps = fromIntegral $
-                            BF.unQuantity _protocolParamsMaxTxExSteps
-                        , executionMemory = fromIntegral $
-                            BF.unQuantity _protocolParamsMaxTxExMem
+                        { executionSteps = maxTxExSteps
+                        , executionMemory = maxTxExMem
                         }
                 }
-            desiredNumberOfStakePools = fromIntegral _protocolParamsNOpt
-            minimumUTxOvalue = MinimumUTxOValueCostPerWord $ Coin $
-                fromIntegral _protocolParamsCoinsPerUtxoWord
-            stakeKeyDeposit = Coin $ fromIntegral _protocolParamsKeyDeposit
-            eras = emptyEraInfo
-            maximumCollateralInputCount =
-                fromIntegral _protocolParamsMaxCollateralInputs
-            minimumCollateralPercentage =
-                fromIntegral _protocolParamsCollateralPercent
-            executionUnitPrices = Just $ ExecutionUnitPrices
+            , executionUnitPrices = Just $ ExecutionUnitPrices
                 { pricePerStep = toRational _protocolParamsPriceStep
                 , pricePerMemoryUnit = toRational _protocolParamsPriceMem
                 }
-        currentNodeProtocolParameters <- undefined
-        pure ProtocolParameters {..}
+
+            , maximumCollateralInputCount = maxCollateralInputs
+            , minimumCollateralPercentage = collateralPercent
+            , currentNodeProtocolParameters = Just Node.ProtocolParameters
+                { protocolParamProtocolVersion =
+                    (protoMajorVer, protoMinorVer)
+                , protocolParamDecentralization =
+                    toRational _protocolParamsDecentralisationParam
+                , protocolParamExtraPraosEntropy = Nothing
+                , protocolParamMaxBlockHeaderSize = maxBlockHeaderSize
+                , protocolParamMaxBlockBodySize = maxBlockBodySize
+                , protocolParamMaxTxSize = intCast maxTxSize
+                , protocolParamTxFeeFixed = minFeeB
+                , protocolParamTxFeePerByte = minFeeA
+                , protocolParamMinUTxOValue =
+                    Just $ Node.Lovelace $ intCast _protocolParamsMinUtxo
+                , protocolParamStakeAddressDeposit =
+                    Node.Lovelace $
+                        intCast @_ @Integer _protocolParamsKeyDeposit
+                , protocolParamStakePoolDeposit =
+                    Node.Lovelace $
+                        intCast @_ @Integer _protocolParamsPoolDeposit
+                , protocolParamMinPoolCost =
+                    Node.Lovelace $
+                        intCast @_ @Integer _protocolParamsMinPoolCost
+                , protocolParamPoolRetireMaxEpoch = Node.EpochNo eMax
+                , protocolParamStakePoolTargetNum = nOpt
+                , protocolParamPoolPledgeInfluence =
+                    toRational _protocolParamsA0
+                , protocolParamMonetaryExpansion = toRational _protocolParamsRho
+                , protocolParamTreasuryCut = toRational _protocolParamsTau
+                , protocolParamUTxOCostPerWord =
+                    Just $ Node.Lovelace $
+                        intCast _protocolParamsCoinsPerUtxoWord
+                , protocolParamCostModels =
+                    mempty
+                    -- Cost models aren't available via BF
+                    -- TODO: Hardcode or retrieve from elswhere.
+                    -- https://input-output.atlassian.net/browse/ADP-1572
+                , protocolParamPrices =
+                    Just $ Node.ExecutionUnitPrices
+                        { priceExecutionSteps =
+                            toRational _protocolParamsPriceStep
+                        , priceExecutionMemory =
+                            toRational _protocolParamsPriceMem
+                        }
+                , protocolParamMaxTxExUnits =
+                    Just $ Node.ExecutionUnits
+                        { executionSteps = maxTxExSteps
+                        , executionMemory = maxTxExMem
+                        }
+                , protocolParamMaxBlockExUnits =
+                    Just $ Node.ExecutionUnits
+                        { executionSteps = maxBlockExSteps
+                        , executionMemory = maxBlockExMem
+                        }
+                , protocolParamMaxValueSize = Just maxValSize
+                , protocolParamCollateralPercent = Just collateralPercent
+                , protocolParamMaxCollateralInputs =
+                    Just $ intCast maxCollateralInputs
+                }
+            , ..
+            }
+
+instance FromBlockfrost BF.Slot SlotNo where
+    fromBlockfrost = fmap SlotNo . (<?#> "SlotNo") . BF.unSlot
+
+-- | Raises an error in case of an absent value
+(<?>) :: MonadError e' m => Maybe a -> e' -> m a
+(<?>) Nothing e = throwError e
+(<?>) (Just a) _ = pure a
+
+infixl 8 <?>
+{-# INLINE (<?>) #-}
+
+-- | Casts integral values safely or raises an `IntegralCastError`
+(<?#>) ::
+    ( MonadError BlockfrostError m
+    , Integral a, Integral b
+    , Bits a, Bits b
+    ) =>
+    a -> String -> m b
+(<?#>) a e = intCastMaybe a <?> IntegralCastError e
+
+infixl 8 <?#>
+{-# INLINE (<?#>) #-}
 
 
 {-------------------------------------------------------------------------------

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -305,8 +305,8 @@ instance FromBlockfrost BF.ProtocolParams ProtocolParameters where
             , txParameters = TxParameters
                 { getFeePolicy =
                     LinearFee
-                        (Quantity $ fromIntegral minFeeA)
                         (Quantity $ fromIntegral minFeeB)
+                        (Quantity $ fromIntegral minFeeA)
                 , getTxMaxSize =
                     Quantity maxTxSize
                 , getTokenBundleMaxSize =
@@ -321,7 +321,6 @@ instance FromBlockfrost BF.ProtocolParams ProtocolParameters where
                 { pricePerStep = toRational _protocolParamsPriceStep
                 , pricePerMemoryUnit = toRational _protocolParamsPriceMem
                 }
-
             , maximumCollateralInputCount = maxCollateralInputs
             , minimumCollateralPercentage = collateralPercent
             , currentNodeProtocolParameters = Just Node.ProtocolParameters

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -59,9 +59,9 @@ import Cardano.Wallet.Primitive.Types
     , ExecutionUnitPrices (..)
     , ExecutionUnits (..)
     , FeePolicy (LinearFee)
+    , LinearFunction (..)
     , MinimumUTxOValue (..)
     , ProtocolParameters (..)
-    , SlotNo (SlotNo)
     , SlotNo (..)
     , SlottingParameters (..)
     , TokenBundleMaxSize (..)
@@ -304,9 +304,10 @@ instance FromBlockfrost BF.ProtocolParams ProtocolParameters where
             { eras = emptyEraInfo
             , txParameters = TxParameters
                 { getFeePolicy =
-                    LinearFee
-                        (Quantity $ fromIntegral minFeeB)
-                        (Quantity $ fromIntegral minFeeA)
+                    LinearFee $ LinearFunction
+                        { intercept = fromIntegral minFeeB
+                        , slope = fromIntegral minFeeA
+                        }
                 , getTxMaxSize =
                     Quantity maxTxSize
                 , getTokenBundleMaxSize =

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -130,6 +130,7 @@ import Cardano.Wallet.Primitive.Types
     , ExecutionUnits (..)
     , FeePolicy (..)
     , GenesisParameters (..)
+    , LinearFunction (..)
     , MinimumUTxOValue (..)
     , PoolId (PoolId)
     , ProtocolParameters (..)
@@ -1214,11 +1215,11 @@ feeCalculationSpec = describe "fee calculations" $ do
   where
     pp :: ProtocolParameters
     pp = dummyProtocolParameters
-        { txParameters = dummyTxParameters
-            { getFeePolicy = fp
+            { txParameters = dummyTxParameters
+                { getFeePolicy =
+                    LinearFee LinearFunction {intercept = 100_000, slope = 100}
+                }
             }
-        }
-    fp = LinearFee (Quantity 100_000) (Quantity 100)
 
     minFee :: TransactionCtx -> Integer
     minFee ctx = Coin.toInteger $ calcMinimumCost testTxLayer pp ctx sel
@@ -1792,7 +1793,10 @@ emptyTxSkeleton = mkTxSkeleton
     emptySkeleton
 
 mockFeePolicy :: FeePolicy
-mockFeePolicy = LinearFee (Quantity 155381) (Quantity 44)
+mockFeePolicy = LinearFee $ LinearFunction
+    { intercept = 155381
+    , slope = 44
+    }
 
 mockProtocolParameters :: ProtocolParameters
 mockProtocolParameters = dummyProtocolParameters

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1772,6 +1772,8 @@ dummyProtocolParameters = ProtocolParameters
         error "dummyProtocolParameters: minimumCollateralPercentage"
     , executionUnitPrices =
         error "dummyProtocolParameters: executionUnitPrices"
+    , currentNodeProtocolParameters =
+        error "dummyProtocolParameters: currentNodeProtocolParameters"
     }
 
 -- | Like generate, but the random generate is fixed to a particular seed so


### PR DESCRIPTION
- [x] Move `currentNodeProtocolParameters` inside the `ProtocolParameters` data type (record).
- [x] Popolate `ProtocolParameters` with the data retrieved from Blockfrost API (except cost models).

### Issue Number

ADP-1423
