### PR TITLE
Quick fix: Constrain hedgehog < 1.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -245,6 +245,11 @@ allow-newer:
 
 constraints:
     hedgehog >= 1.0.2
+  -- QUICK FIX: hedgehog >= 1.1 defines Rec constructor, PlutusIR also defines
+  -- Rec constructor, and imports Hedgehog unqualified, leading to ambiguous
+  -- reference to Rec.
+  -- FIXME: https://input-output.atlassian.net/browse/ADP-1545
+  , hedgehog < 1.1
   , hashable < 1.4
   , bimap >= 0.4.0
   , libsystemd-journal >= 1.4.4


### PR DESCRIPTION
- Constrain the version of hedgehog to < 1.1. Versions >= 1.1 define the Rec
  constructor in Hedgehog, which conflicts with the Rec constructor defined in
  plutus-ir/src/PlutusIR/Generators/AST.hs.
- This is the quickest way to fix the cardano-wallet nightly build. A more long-term fix would be to upgrade the version of Plutus we are using. To do so, we'd need to do this ticket first: ADP-1545.
