### PR TITLE
make decodeTx not so strict when policy key is missing

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,6 +148,7 @@
         "flake-utils": "flake-utils_5",
         "heist": "heist",
         "nixpkgs": [
+          "emanote",
           "ema",
           "nixpkgs"
         ],

--- a/flake.lock
+++ b/flake.lock
@@ -148,7 +148,6 @@
         "flake-utils": "flake-utils_5",
         "heist": "heist",
         "nixpkgs": [
-          "emanote",
           "ema",
           "nixpkgs"
         ],

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -1335,12 +1335,12 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         let activeAssetsInfo = ApiAssetMintBurn
                 { tokenMap = ApiT tokens
                 , policyScripts = [mintScript]
-                , walletPolicyKeyHash = policyKeyHashPayload
+                , walletPolicyKeyHash = Just policyKeyHashPayload
                 }
         let inactiveAssetsInfo = ApiAssetMintBurn
                 { tokenMap = ApiT TokenMap.empty
                 , policyScripts = []
-                , walletPolicyKeyHash = policyKeyHashPayload
+                , walletPolicyKeyHash = Just policyKeyHashPayload
                 }
         rTx <- request @(ApiDecodedTransaction n) ctx
             (Link.decodeTransaction @'Shelley wa) Default decodeMintPayload
@@ -3236,12 +3236,12 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         let activeAssetsInfo = ApiAssetMintBurn
                 { tokenMap = ApiT tokens
                 , policyScripts = [mintScript]
-                , walletPolicyKeyHash = policyKeyHashPayload
+                , walletPolicyKeyHash = Just policyKeyHashPayload
                 }
         let inactiveAssetsInfo = ApiAssetMintBurn
                 { tokenMap = ApiT TokenMap.empty
                 , policyScripts = []
-                , walletPolicyKeyHash = policyKeyHashPayload
+                , walletPolicyKeyHash = Just policyKeyHashPayload
                 }
 
         let mintInfoExpected = Just $ NE.fromList
@@ -3316,12 +3316,12 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         let activeAssetsInfo = ApiAssetMintBurn
                 { tokenMap = ApiT TokenMap.empty
                 , policyScripts = []
-                , walletPolicyKeyHash = policyKeyHashPayload
+                , walletPolicyKeyHash = Just policyKeyHashPayload
                 }
         let inactiveAssetsInfo = ApiAssetMintBurn
                 { tokenMap = ApiT tokens
                 , policyScripts = [burnScript]
-                , walletPolicyKeyHash = policyKeyHashPayload
+                , walletPolicyKeyHash = Just policyKeyHashPayload
                 }
 
         let burnInfoExpected = Just $ NE.fromList

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1233,7 +1233,7 @@ data ApiPolicyScript = ApiPolicyScript
 data ApiAssetMintBurn = ApiAssetMintBurn
     { tokenMap :: !(ApiT W.TokenMap)
     , policyScripts :: ![ApiPolicyScript]
-    , walletPolicyKeyHash :: !ApiPolicyKey
+    , walletPolicyKeyHash :: !(Maybe ApiPolicyKey)
     }
     deriving (Eq, Generic, Show)
     deriving anyclass NFData

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2518,7 +2518,6 @@ components:
       required:
         - token_map
         - policy_scripts
-        - wallet_policy_key_hash
       properties:
         token_map:
           type: array


### PR DESCRIPTION
adp-1549

<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->


- [x] I have make sure checking for policy key is only taking place when minting/burning is on. 

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
