### PR TITLE
Get stake pool data using GetRewardInfoPools query

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -76,6 +76,7 @@ module Cardano.Wallet.Api.Types
     , ApiBase64
     , ApiMintBurnData (..)
     , ApiStakePool (..)
+    , invariantApiStakePool
     , ApiStakePoolMetrics (..)
     , ApiStakePoolFlag (..)
     , ApiWallet (..)
@@ -811,14 +812,23 @@ data ApiStakePool = ApiStakePool
     , flags :: ![ApiStakePoolFlag]
     } deriving (Eq, Generic, Show)
 
+-- | The 'ApiStakePool' response contains redundant information
+-- and needs to satisfy this invariant.
+invariantApiStakePool :: ApiStakePool -> Bool
+invariantApiStakePool r = 
+    (OwnerStakeLowerThanPledge `elem` flags r)
+    == (pledge r < ownerStake (metrics r))
+
 data ApiStakePoolFlag
     = Delisted
+    | OwnerStakeLowerThanPledge
     deriving stock (Eq, Generic, Show)
     deriving anyclass NFData
 
 data ApiStakePoolMetrics = ApiStakePoolMetrics
     { nonMyopicMemberRewards :: !(Quantity "lovelace" Natural)
     , relativeStake :: !(Quantity "percent" Percentage)
+    , ownerStake :: !(Quantity "lovelace" Natural)
     , saturation :: !Double
     , producedBlocks :: !(Quantity "block" Natural)
     } deriving (Eq, Generic, Show)

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -43,6 +43,8 @@ import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
+import Cardano.Pool.Rank
+    ( StakePoolsSummary )
 import Cardano.Wallet.Primitive.BlockSummary
     ( LightSummary )
 import Cardano.Wallet.Primitive.Slotting
@@ -55,7 +57,6 @@ import Cardano.Wallet.Primitive.Types
     , ProtocolParameters
     , SlotNo (..)
     , SlottingParameters (..)
-    , StakePoolsSummary
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin )
@@ -160,8 +161,7 @@ data NetworkLayer m block = NetworkLayer
         -- ^ Broadcast a transaction to the chain producer
 
     , stakeDistribution
-        :: Coin -- Stake to consider for rewards
-        -> m StakePoolsSummary
+        :: m (Maybe StakePoolsSummary)
 
     , getCachedRewardAccountBalance
         :: RewardAccount

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -107,7 +107,6 @@ module Cardano.Wallet.Primitive.Types
     , IsDelegatingTo (..)
 
     -- * Stake Pools
-    , StakePoolsSummary (..)
     , PoolId(..)
     , PoolOwner(..)
     , poolIdBytesLength
@@ -215,8 +214,6 @@ import Data.Kind
     ( Type )
 import Data.List
     ( intercalate )
-import Data.Map.Strict
-    ( Map )
 import Data.Maybe
     ( isJust, isNothing )
 import Data.Proxy
@@ -253,7 +250,6 @@ import Fmt
     , blockListF'
     , indentF
     , listF'
-    , mapF
     , prefixF
     , pretty
     , suffixF
@@ -276,7 +272,6 @@ import Test.QuickCheck
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32
 import qualified Data.ByteString as BS
-import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 
@@ -758,19 +753,6 @@ instance FromJSON PoolOwner where
 
 instance ToJSON PoolOwner where
     toJSON = toJSON . toText
-
-data StakePoolsSummary = StakePoolsSummary
-    { nOpt :: Int
-    , rewards :: Map PoolId Coin
-    , stake :: Map PoolId Percentage
-    } deriving (Show, Eq)
-
-instance Buildable StakePoolsSummary where
-    build StakePoolsSummary{nOpt,rewards,stake} = listF' id
-        [ "Stake: " <> mapF (Map.toList stake)
-        , "Non-myopic member rewards: " <> mapF (Map.toList rewards)
-        , "Optimum number of pools: " <> pretty nOpt
-        ]
 
 {-------------------------------------------------------------------------------
                                     Block

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiStakePool.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiStakePool.json
@@ -1,235 +1,275 @@
 {
-    "seed": -4132539117587378523,
+    "seed": -6353861284100187802,
     "samples": [
         {
             "metrics": {
                 "non_myopic_member_rewards": {
-                    "quantity": 230922967059,
+                    "quantity": 12724615746,
                     "unit": "lovelace"
                 },
-                "saturation": 2.7911710375945367,
+                "saturation": 1.6783419495852225,
                 "produced_blocks": {
-                    "quantity": 5618560,
+                    "quantity": 1361059,
                     "unit": "block"
                 },
                 "relative_stake": {
-                    "quantity": 73.47,
+                    "quantity": 4.62,
                     "unit": "percent"
+                },
+                "owner_stake": {
+                    "quantity": 167,
+                    "unit": "lovelace"
                 }
             },
             "cost": {
-                "quantity": 183,
+                "quantity": 187,
                 "unit": "lovelace"
             },
             "pledge": {
-                "quantity": 89,
+                "quantity": 86,
                 "unit": "lovelace"
             },
-            "id": "pool1f2nq95f7fjzl67fmxp6ku2a44gxp94t6yqu3590wuag5uhqfqyv",
+            "id": "pool1x5n885yz59kpstz6dlvxd2jmgxcq9fr3tncxngdrryysu5skk3x",
             "flags": [
                 "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
+                "owner_stake_lower_than_pledge",
                 "delisted"
             ],
             "retirement": {
-                "epoch_start_time": "1872-09-11T14:34:24Z",
-                "epoch_number": 12515
+                "epoch_start_time": "1864-01-30T10:00:00Z",
+                "epoch_number": 27557
             },
             "margin": {
-                "quantity": 9.69,
+                "quantity": 28.75,
                 "unit": "percent"
             },
             "metadata": {
-                "name": "_'F#6,煍\\5)3v?\u00087𑚂􇅘{\u0016W𧛯\u0010\u000f㭢pC\u0005󽵆",
-                "homepage": "󵤁rq183H󸊑z􃣇\u0013󽥓c\u001cTᔨv\u001a\u0015c%H\u0016v󷱠CzUAVu鸛𤮶𫪆Oam樋G\u0011\u001a􆎛!\u0010\u001e\u0015|🯇e􄎾^!S􁱈\r𐑏'$wjTK\r\u0005𫷘y𨑋𗯊\u0007\u0000\u0019 #TpOu쳿𫈲\u001d;U\u001d,ck",
-                "ticker": "𮟜󱏍𫪂a\u0000",
-                "description": "\u001b􃋊\u0011\u001dꑈ[bMd􏦳9y󼵾㈎^3+c𨭏!@I䒑s+`􎹞􀯒\u0004ᓏ9󸆱<𡱞L_>*Rw􇱐\u001eb\nnT0;]E$PW𦚱G6$\n:a\u0018􈯨p\u000ecPck𠤯H\u001exzB󵣊Drz}􋞆}mh堞𦟸𐃮~<i\u000f;+󿨀􎖤>)\u001a.𣍑:wa+\u000cZ&^^q|0\u000c(sJ𖣹>왳\u001e􁀐\u0017\u0008󿽂*󾮍t'~~X!\u001dw9l\u001e󹠏󻃂A\u0018\t3\u0004𝌜u􁟐hd3􎍉"
+                "name": "r\u001etD\u000f􋹥\u0001􄠞 6𣛉󶿈櫰\u0015?􇸫\u0007~\u0000\u0001no呃|]v\u0012F)9!,\u000b\u0001",
+                "homepage": "𠫻\u001b.\u0002(S􁎎\u0012󷌋\u001d'\u001d{\u0010]𖨓\"e𥥬p7\u001f\u0006𦕡𧼲5u\u0001m+,^O𭂯Q𧁅\u0010\u0004\u0011\u0014",
+                "ticker": "s)-v",
+                "description": "i𭼦󲃩\u0006󸲾W\u001a')_󹟪𘉟\n\u001ch_D0^d~􋯦v\u000f𦇷\u0018|𣂨𧥙涾浾\u000bʏ\u0015Kj%)㉀􄊵g遳_+y'Τ9S𡚎\\A\u001dq\u0015bTnᡟ+#􏭸􈈧H\u00004󿐘\u0015SuZd󻓳E\u000c\u0001󺭣𠞒yR|8q􊜶\r\\q}𨧖\u001dq"
             }
         },
         {
             "metrics": {
                 "non_myopic_member_rewards": {
-                    "quantity": 931236682344,
+                    "quantity": 893582426605,
                     "unit": "lovelace"
                 },
-                "saturation": 2.6889115149428333,
+                "saturation": 2.5911365781459947,
                 "produced_blocks": {
-                    "quantity": 21545645,
+                    "quantity": 1343567,
                     "unit": "block"
                 },
                 "relative_stake": {
-                    "quantity": 20.02,
+                    "quantity": 84.71,
                     "unit": "percent"
+                },
+                "owner_stake": {
+                    "quantity": 34,
+                    "unit": "lovelace"
                 }
             },
             "cost": {
-                "quantity": 99,
+                "quantity": 200,
                 "unit": "lovelace"
             },
             "pledge": {
-                "quantity": 185,
+                "quantity": 1,
                 "unit": "lovelace"
             },
-            "id": "pool1t2s33umzqz8qgrrrpzyn2m4d8rdd7cnvs2k9skgh2gsmchj0jja",
+            "id": "pool1feqq7g7g50lltm6kg2mw22vsgylts8wgandvnwzw9pjs6tlzw7p",
             "flags": [
                 "delisted",
+                "owner_stake_lower_than_pledge",
                 "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted"
+                "owner_stake_lower_than_pledge"
             ],
             "retirement": {
-                "epoch_start_time": "1865-07-28T14:13:32.41165225467Z",
-                "epoch_number": 17939
+                "epoch_start_time": "1875-10-09T07:40:16Z",
+                "epoch_number": 26859
             },
             "margin": {
-                "quantity": 96.93,
+                "quantity": 18.27,
                 "unit": "percent"
             },
             "metadata": {
-                "name": "\u000e^#e\u0011􆰭𔕏.j\u0010y\u001a\u00194\u0012􀭅N󹕰\r<􅴈󷀩eY𮈠Uum/菺",
-                "homepage": "䭄𢱝<?𬇩]𗍻)\u0013I\u0018f嬀PnZx󺗄Y8𗐷p\u00037\\8󻝾𖩤~m\"\u001d\t4>^􍫿\u0008麡􎋦ur\u001d𣾊MD\u0017\\VY𬏽눚'Xu`T\u0018\u001ej>B􎔚`\u0012\u0007F!,r&󸂚}𤋶\u000f𥀇ꥁ󷻧\u0016M󰓳\u000c#n\\\u000ce嘄󸋼?󲒢 􅘽>^",
-                "ticker": "}mh𪄄",
-                "description": "0\u0012\u001b\u0011=7\u0012\u000f\u0016(\t4O!🠱j𝂤KU𤨅O\u00146O󿾹\u0016W𣄼🥆\u0006\u0014w,󸈮猙I\u001b𭵗CEq|􂌼/#绑𪹚𢡁h𧃄𑀁􃘓>69O􄾒􍕕􍵝微{PN󾨊􇍲O𢔐󾑄9n\u000c𡜎m󼞠r𮍩􂀲􏉩"
+                "name": "n􎨻8zGE6#𗌤\nc𮫎 1\u0016ro~\u0015䐀\u0008tx\u001c\"O-;Qi\u0005",
+                "homepage": "b\u00021D\u0015􌍭\u000c\nK~@O󱠺2𣡋薢s}􂙱w𦝌􃃺_\u0001\u001f^DE\u0001󿤽`\u0004yJ\u0005ퟎ6𘥍C\u000c􃐌KFU",
+                "ticker": "{~WRq",
+                "description": "c\u0011\u0008\u0018􇅜K𞴸K\u001c7_9硼<VRg02𰧗Q\n\u0008rD𥨹􎴊Qj⢅^M$󴽞#A𰧔b\"󷜘󰙹I\u001e^J𗅻\u001ce *W(𧄩kv倷X𘚨\u0006𗿧󹯮3󶡎he5􎖫B󾘯H䋘B9\u001e\u0018"
             }
         },
         {
             "metrics": {
                 "non_myopic_member_rewards": {
-                    "quantity": 715016730500,
+                    "quantity": 378487821909,
                     "unit": "lovelace"
                 },
-                "saturation": 3.805882497584304,
+                "saturation": 0.8297983794404334,
                 "produced_blocks": {
-                    "quantity": 2474883,
+                    "quantity": 7881972,
                     "unit": "block"
                 },
                 "relative_stake": {
-                    "quantity": 39.95,
+                    "quantity": 11.32,
                     "unit": "percent"
+                },
+                "owner_stake": {
+                    "quantity": 67,
+                    "unit": "lovelace"
                 }
             },
             "cost": {
-                "quantity": 123,
+                "quantity": 70,
                 "unit": "lovelace"
             },
             "pledge": {
-                "quantity": 99,
+                "quantity": 56,
                 "unit": "lovelace"
             },
-            "id": "pool1mwgp60faxdzf0s7cqkwv4vtgasvfamml58u28wx224h22eescvt",
+            "id": "pool1s6pv7q9fwcg6qgu4yxunqhp5xgcaymeyzdcde7wqvxqkw0e72we",
             "flags": [
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
                 "delisted",
                 "delisted",
                 "delisted",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
                 "delisted",
                 "delisted",
                 "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted"
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge"
             ],
             "retirement": {
-                "epoch_start_time": "1894-06-21T21:01:58Z",
-                "epoch_number": 23192
+                "epoch_start_time": "1908-02-02T14:00:00Z",
+                "epoch_number": 29593
             },
             "margin": {
-                "quantity": 52.89,
+                "quantity": 9.24,
                 "unit": "percent"
             },
             "metadata": {
-                "name": "𝈐迖󱙁𫥔􁍢,􋊼^\\\u000ej\u0010\u001d)F",
-                "homepage": "\u0001K􍥂p|+𫻱󻑭Uᦔm`*𫭐B𝧾F\u000c`Q𬂢쥏\u0007w􃅫<\u0006\u001e󾫽𥦂󸧡6)\u001db\t䲲=A􅾥𠮃\ty+纾駠Q󿎡󴌀PL󻞒􇼩\t)/m\u0017𭾦I)i~糒􏎛(Zh: ㅞiR",
-                "ticker": "0-𪏻􇤃\u0001",
-                "description": "hY⺕3;𥻺^n㫩P𖧹e𖩎𢲃􃲨Z'\u0018^iW7𐎸􅼝𣿃@>I󿦣\u0001􉋄cX\u001ddGv\u0014\u0005M\u000b\u0008i󾿧󽪽\u0004唐𠍽y乽1󳉵骝m獿\u0008D\u000fF𢀥0I|%\u0012E\u0006\u001fg\u0001,\u001bj\u00055C\u0015\"\u001e0G\u0005\u0010+)\u0011vCh_W6󴼌\u000eIF\u00001\u000e􀾐Q"
+                "name": "qJn\u0004",
+                "homepage": "\u0005\u000ft*􉾹A\u001cઓ{􅓌8\u0003a\\K\u001f~𪨵\u0013󿣊\u0001tx[\u0015v\u0005\u001f@\u001b#g𗻌N_28#󻫉\u0005/󾋩惜E_-𨊓􃄎",
+                "ticker": "󸩟F➀",
+                "description": "󼙙\u000cU𰛱􏌆2SO.𨡼e9𝜦󷘞R}󳮓CGEn\u000bM\u0019o\u0003󴕣DF790d􉲣󠅛S󻪷􉥾f70v󾐘\u0013Z#󻨃𢟃􉃧󴓗Z\u0002\u0011#􃪍\u0015*\u000bx3􉱯k睔\u001f\u0018m\u0013?0F\u00186F<q%Z𗹰\\\u0018'\u0004\u001dVub?9x􂋜>l􆆼do𢁯𗪡𨦭􅂃i`#\u0013L49\u001e:3􊡀d󶆵\u0010qFo鄨󱍖8􉣨<\u0006󱮶󰊚󳤤ol+z\u0010U󿇝󺭭;✪\u0007$$󺾉J\u0013\u00179𫼼Nz㥑\u0019\u000b`wu􆦳𐕈븈􇟖􅮩𝟫瀇􄂸\u0000dN+b𡛈n\u0016\u0017s𫅬􉤤,IK)SG䑥􅎒\"ᄨN\u0019㺘靻dj\t󻙐RD5YBt=腆*QB𭣹\u0018\u0002rw\u0012_𗆾./𠫛ꡱ\u0006\u0017<𦾼Ko"
             }
         },
         {
             "metrics": {
                 "non_myopic_member_rewards": {
-                    "quantity": 611582347470,
+                    "quantity": 485641102965,
                     "unit": "lovelace"
                 },
-                "saturation": 3.162736306465508,
+                "saturation": 0.14595785855299026,
                 "produced_blocks": {
-                    "quantity": 1670155,
+                    "quantity": 7332022,
                     "unit": "block"
                 },
                 "relative_stake": {
-                    "quantity": 57.99,
+                    "quantity": 11.38,
                     "unit": "percent"
+                },
+                "owner_stake": {
+                    "quantity": 118,
+                    "unit": "lovelace"
                 }
             },
             "cost": {
-                "quantity": 103,
+                "quantity": 237,
+                "unit": "lovelace"
+            },
+            "pledge": {
+                "quantity": 32,
+                "unit": "lovelace"
+            },
+            "id": "pool1k7dhkepjt54geqyksdv59pcmldrlhhwknckar664pplxufc3jwt",
+            "flags": [
+                "delisted",
+                "delisted",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "delisted",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "delisted"
+            ],
+            "retirement": {
+                "epoch_start_time": "1906-11-27T01:23:08Z",
+                "epoch_number": 6496
+            },
+            "margin": {
+                "quantity": 18.3,
+                "unit": "percent"
+            },
+            "metadata": {
+                "name": "钲I%\r.r\u00059",
+                "homepage": "IR\t_\u0013𥾧J󱔛s𣐙왉\u001d\u00198\u000e]𖹴P#U肙\u0015Z󸞥^LA󺥔d\nd.􋃣<𤡮\u0001\u001b\u001bhv\u001d\u0016=B\u0001𰷽\u0007ꏱ~󻛊,,B|+\u0012G\tn󽻧BC5𢄥,\u00143\u000e",
+                "ticker": "]d𮁢a󻝁",
+                "description": "􂵴n􀃯\u0003l\u0016\u0010󺅽[\u0001\r/Yu96퇔68샧GS\u0019N-\u001c\u0010Mᦠǖo|\"Zw$囶\u000fk4i\u0005󺫹𮅦𫔛H𮃆\u001bQ\u000c1\u0014,Y𧬴󻸤0o\u0013h\u001f󲒹􁺚􃚅𥑨5ੇ𧭌𦇂Y0𭉲f\u0011Yz𤵂uTKjTx𦏷󱩅H󸦴\n󿭮󼒟w󴥡󸼕𧏥3|VZ\u0019𥊋a\u0002|i([t7𤣃hzoZ z􋒶>󲷨X􎯹/f\u001bOo􇕠"
+            }
+        },
+        {
+            "metrics": {
+                "non_myopic_member_rewards": {
+                    "quantity": 642185688820,
+                    "unit": "lovelace"
+                },
+                "saturation": 3.6483160136008275e-2,
+                "produced_blocks": {
+                    "quantity": 9216263,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 20.59,
+                    "unit": "percent"
+                },
+                "owner_stake": {
+                    "quantity": 171,
+                    "unit": "lovelace"
+                }
+            },
+            "cost": {
+                "quantity": 21,
                 "unit": "lovelace"
             },
             "pledge": {
                 "quantity": 55,
                 "unit": "lovelace"
             },
-            "id": "pool1j04psh7nas8xue8r4wanag2pmaqudwzzcetactpd79qzuwr4mtc",
+            "id": "pool1rm8qvrwgxxrdl3hdmagj9e969r09r68ztjxvzafgqx4jjjexl2r",
             "flags": [
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "delisted",
+                "owner_stake_lower_than_pledge",
                 "delisted",
                 "delisted",
                 "delisted",
-                "delisted",
-                "delisted",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
                 "delisted",
                 "delisted",
                 "delisted",
@@ -237,332 +277,284 @@
                 "delisted"
             ],
             "retirement": {
-                "epoch_start_time": "1884-04-03T05:00:00Z",
-                "epoch_number": 3091
+                "epoch_start_time": "1870-11-12T08:34:08.545202718431Z",
+                "epoch_number": 23507
             },
             "margin": {
-                "quantity": 48.13,
-                "unit": "percent"
-            }
-        },
-        {
-            "metrics": {
-                "non_myopic_member_rewards": {
-                    "quantity": 925070211673,
-                    "unit": "lovelace"
-                },
-                "saturation": 2.1381965523512143,
-                "produced_blocks": {
-                    "quantity": 13773946,
-                    "unit": "block"
-                },
-                "relative_stake": {
-                    "quantity": 26.62,
-                    "unit": "percent"
-                }
-            },
-            "cost": {
-                "quantity": 248,
-                "unit": "lovelace"
-            },
-            "pledge": {
-                "quantity": 110,
-                "unit": "lovelace"
-            },
-            "id": "pool19mh6s8kqdv7ckykck4t7784musjml9l8kd6ww7p4svapgwgdpzc",
-            "flags": [
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted"
-            ],
-            "margin": {
-                "quantity": 60.33,
+                "quantity": 22.8,
                 "unit": "percent"
             },
             "metadata": {
-                "name": "=U\u0006Y𫠔ad@J)􌣻\r󰱊rJ?X+\u0011􉅴l󴻨𘮌G.\u0007?\u00165𮭰󶐐\u001c󷹜i[\u0011k_􀁴",
-                "homepage": "ry9\u0002x𪳣鈜Q\u001e󱅙􏔇,P\u0015𭽱󸥰𧟞I^k𢋴/२􇗉􂚔JL􎋸􀜊G𠨒/\u0015\u0011f|\u0015\u0014\u001b2Jp=􊛯;T𩠺𮋑?\u0019+\u001aꅕ猐Umr􌁪􋥌Rz\t\u0001𧜭Qld7ｅ$\u0008FCW]Y7o\u0011\u0018[𫳳n(f\rb\u0019𖽦a\\q",
-                "ticker": "&w󼐐G",
-                "description": "􂆢cCV𤁖!F[V\n􋛮󾦜􎣒\u000b𫵆z;ᴹ%\u000c6l;PeA\u0007𩌚!䊥ct𪇄􋠽Ioz 𢑤W󽂜椕V𗬨\u001a&󼲅􂾉\r^\u0017,&h\r%!adNA&棟9@0\nT.C諫\u000fhOB󷜶~f平B𭽩􌚺􊢨S:B4?赐qZ\u00140-󴳽#𘂋*d2%A{Yp\u001b..凮󳙟T\nddIdG5.@|a<\u001cb,lv𫊆k󿫞𤹂2\u0015󸕖I􊜜M`\u000fW\u001d\u0018c\u0007p^⽅󲸪B@<\u00068\u0013(n(蝓:掾\u001a𪪽KyDT"
+                "name": "\t\u0011󱇸𧁋VA^󼎦8\u0012=%𮭋3􈻉\u000c\u001ff-󰴸\u001a0+8\\2𦘖𩍕\u000c󺺠+\r>㴕􌜆璇T\u0013rTb\u0001S^𮚞\u0013\u001dXf",
+                "homepage": "􆽵痵Kj􆅻4{\t􉉺𧃔0a\u001aZhLI󰧩\u0002\u001e󳳙lu􍳟O觳U1",
+                "ticker": "\u000cRu",
+                "description": "\u0015B\u000fiW􎑅\u0019:🪒\u001f\tU𦥲R[P\u0005^\u0008\\}𢈂𭩭錄bp\u001d៊9\u0016Fy𰤏'7@+󹚛󹆨^􎔍\u0007\u00017P󷗳_bD𰟒󾅸<\u000bW㹪G\u0015󷀡13􂚥\u0018\u000e0S􇒟𧢯􈵔y瑼\u0006\rtyj\u000f黲^*M:zhI\u001a𢌀\u001d24Fc\u001d(VfS\u0013\u001d`"
             }
         },
         {
             "metrics": {
                 "non_myopic_member_rewards": {
-                    "quantity": 978927966319,
+                    "quantity": 82875635879,
                     "unit": "lovelace"
                 },
-                "saturation": 4.336767169708285,
+                "saturation": 2.5651485083158243,
                 "produced_blocks": {
-                    "quantity": 5991984,
+                    "quantity": 2118541,
                     "unit": "block"
                 },
                 "relative_stake": {
-                    "quantity": 25.18,
+                    "quantity": 29.48,
                     "unit": "percent"
+                },
+                "owner_stake": {
+                    "quantity": 250,
+                    "unit": "lovelace"
                 }
             },
             "cost": {
-                "quantity": 56,
+                "quantity": 252,
                 "unit": "lovelace"
             },
             "pledge": {
+                "quantity": 88,
+                "unit": "lovelace"
+            },
+            "id": "pool1hyaejn2pg6cmfv3h3x6megy82utzd5pdz2mpf9qpj27t2qdclft",
+            "flags": [
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge"
+            ],
+            "retirement": {
+                "epoch_start_time": "1869-05-29T07:00:00Z",
+                "epoch_number": 3292
+            },
+            "margin": {
+                "quantity": 31.52,
+                "unit": "percent"
+            }
+        },
+        {
+            "metrics": {
+                "non_myopic_member_rewards": {
+                    "quantity": 99355414138,
+                    "unit": "lovelace"
+                },
+                "saturation": 0.36579115531499173,
+                "produced_blocks": {
+                    "quantity": 11885067,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 22.85,
+                    "unit": "percent"
+                },
+                "owner_stake": {
+                    "quantity": 60,
+                    "unit": "lovelace"
+                }
+            },
+            "cost": {
+                "quantity": 83,
+                "unit": "lovelace"
+            },
+            "pledge": {
+                "quantity": 9,
+                "unit": "lovelace"
+            },
+            "id": "pool1hltxe3yy9qgtmlxmnzcx2ny2tf7446kgrgxqngwk8jeqstuf4ee",
+            "flags": [
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "delisted",
+                "delisted",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "delisted",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "delisted"
+            ],
+            "margin": {
+                "quantity": 33.13,
+                "unit": "percent"
+            },
+            "metadata": {
+                "name": "\u0010M㮵\u0007𘘠AwY\u0017ht󻿮\u0012趟7􁩥ꠍ&\nIH\u0002H/%\u0002\u001d𘙢Y􌙲=D;\u0019[)\u001fc9n",
+                "homepage": "\u001c:\u0014.Md\u0004\u001b\u0002E􌈉\"󶣼i>󰱵HWN󾯓\\齐v\t\u000eu0jM􏭈f[xi󿿆|𤵃'6\np*6\t$f󷌌\nFA\u0005𬶙\u000f8\u000b󶁝_i9!B\u0017캙\u0016𦷵4:\u0000\u0005\u0013l8\u000cG툳4𣸱XV\u0008|\u0008l\u0004􁸮𧥏鉿\u0011Jc\u0015\u001f􌰺~C\u0012yLיּ",
+                "ticker": "Ea󶷛\u0010S",
+                "description": "󺙻\u0003b\u0013󴢋\u0019\u001f!\u0016󽧣𡵕\u0007u'𣝶\u0019\u001e󱆋\u000f윭ꄙx𬴿7>b-􂏺\u001eD𫠤]\u001d\u0003_]J\u0001n-pv𢑰󱴁\u001d59P\u0019𘒮\\O.=󻔒眦\u001f􏘈󺌳;\u0005󳃛G^O􃚢􁓫ﺕ\u0002􉂟汅\u0000𢬭􀛵\u0010j6[8鵑\n\u001a.R}D𰖮\u000b6D}ND]ৄmL3󺂍󷐜\u0004\u0000,B+\u0005,𬜠PM"
+            }
+        },
+        {
+            "metrics": {
+                "non_myopic_member_rewards": {
+                    "quantity": 875168845995,
+                    "unit": "lovelace"
+                },
+                "saturation": 1.0376451137365694,
+                "produced_blocks": {
+                    "quantity": 14690720,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 54.48,
+                    "unit": "percent"
+                },
+                "owner_stake": {
+                    "quantity": 219,
+                    "unit": "lovelace"
+                }
+            },
+            "cost": {
                 "quantity": 182,
                 "unit": "lovelace"
             },
-            "id": "pool1syul6a42reuzc5tyt55rzzkfa3deurzn83l7gmkpeg0dvej3hmy",
-            "flags": [
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted"
-            ],
-            "retirement": {
-                "epoch_start_time": "1888-09-24T05:47:59.1534733093Z",
-                "epoch_number": 24956
-            },
-            "margin": {
-                "quantity": 59.35,
-                "unit": "percent"
-            },
-            "metadata": {
-                "name": "𬜎h12kr\u0001􃗱[:",
-                "homepage": "yB#'􇫎",
-                "ticker": "2󺂒\u001a\u0015",
-                "description": "@𦥨F\u0007hdk\u0010<鯝L\u0007$싣s`_K🥦ᙫ𬪭h\u001ff}\u0007􋥠\u0013qgm9\r}\u0005Z&.\u0018<ghya\u001bZ\u001b"
-            }
-        },
-        {
-            "metrics": {
-                "non_myopic_member_rewards": {
-                    "quantity": 417362547390,
-                    "unit": "lovelace"
-                },
-                "saturation": 0.8721692313349294,
-                "produced_blocks": {
-                    "quantity": 647637,
-                    "unit": "block"
-                },
-                "relative_stake": {
-                    "quantity": 49.07,
-                    "unit": "percent"
-                }
-            },
-            "cost": {
-                "quantity": 17,
-                "unit": "lovelace"
-            },
             "pledge": {
-                "quantity": 67,
-                "unit": "lovelace"
-            },
-            "id": "pool1nz9nyrz0d5ucswd99u7y54er877fep0sxlz5pd3xrmq8kedvhsy",
-            "flags": [
-                "delisted"
-            ],
-            "retirement": {
-                "epoch_start_time": "1879-10-17T04:00:00Z",
-                "epoch_number": 28508
-            },
-            "margin": {
-                "quantity": 1.54,
-                "unit": "percent"
-            }
-        },
-        {
-            "metrics": {
-                "non_myopic_member_rewards": {
-                    "quantity": 230409042096,
-                    "unit": "lovelace"
-                },
-                "saturation": 2.9482697018035404,
-                "produced_blocks": {
-                    "quantity": 19989004,
-                    "unit": "block"
-                },
-                "relative_stake": {
-                    "quantity": 5.48,
-                    "unit": "percent"
-                }
-            },
-            "cost": {
-                "quantity": 39,
-                "unit": "lovelace"
-            },
-            "pledge": {
-                "quantity": 187,
-                "unit": "lovelace"
-            },
-            "id": "pool1wl2p7zxgzvm8npcsas0kxgxnyfn77x8dg4za8x0jhp7w5eh7ul2",
-            "flags": [
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted"
-            ],
-            "retirement": {
-                "epoch_start_time": "1866-11-24T22:03:43Z",
-                "epoch_number": 10469
-            },
-            "margin": {
-                "quantity": 15.05,
-                "unit": "percent"
-            },
-            "metadata": {
-                "name": "󼊰(I$n",
-                "homepage": "\u001bL\u0002\u000c\u0012𛊊#*;Iyb\u000c\rTlX6𩽽`\n🅅\r􂦭&륳\u0012􅀖\u0001\u0010m뇩^𖤓P􀕃\tr𧫓U^𭶑V\u000f􌂩N\u0006+$QJH󱷔跳\u0000\u0018H9\r󰹓᳭l\tV㸮󻝷𧃣'@%\u0015 𫕛9\n\u0007v󹄓\u0004&\u00128RU",
-                "ticker": "𗆫ow1",
-                "description": "W\u0017扒R*.𨑥𢣛$n%􎥿\u0004扷p􊙆0B\u001e1N3?nM𣺵a􎳜󾂓Id5𤪂𫭧"
-            }
-        },
-        {
-            "metrics": {
-                "non_myopic_member_rewards": {
-                    "quantity": 224213084495,
-                    "unit": "lovelace"
-                },
-                "saturation": 0.9131127498962321,
-                "produced_blocks": {
-                    "quantity": 14350444,
-                    "unit": "block"
-                },
-                "relative_stake": {
-                    "quantity": 16.69,
-                    "unit": "percent"
-                }
-            },
-            "cost": {
                 "quantity": 69,
                 "unit": "lovelace"
             },
-            "pledge": {
-                "quantity": 28,
-                "unit": "lovelace"
-            },
-            "id": "pool1avg6yhrg8cwsmu6ftuw4jdfrg5lpdxpvnjchx3lpue8zqy3g2mk",
-            "flags": [],
+            "id": "pool1vrtt99vt9kfnzkl7a3pml733wdtg3ggxjtwcketpdw9q5g9rjfq",
+            "flags": [
+                "delisted",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge"
+            ],
             "retirement": {
-                "epoch_start_time": "1882-12-17T00:00:00Z",
-                "epoch_number": 5943
+                "epoch_start_time": "1906-10-01T00:00:00Z",
+                "epoch_number": 17173
             },
             "margin": {
-                "quantity": 40.47,
+                "quantity": 54.77,
                 "unit": "percent"
             },
             "metadata": {
-                "name": "$Tf􄆦5󾧚6\u0008-&+gi𮫛v#\\`R0<EwuI􆺭뀲z(a\u001eD&\u0013",
-                "homepage": "\u001a'D)\t?\u001b㇍O",
-                "ticker": "I%􎗱",
-                "description": "_4K󺺹ɿv𨱞f􆞱\u0012䕫_qi乾$􉞹\u0004RwjXDU\u001a𪕧5𤘻𗘎\u0004x'𩏖󰝽g\u001eP􎭹Qu@𭌈\r\n􊉡ta'RR\u0006~*E\u000e\\7𨣻N\u0002S\u0003 *\u0003t󼔼\u001d?YomӦ\u0013fN捄\u0015\u0005󳅀𧌝[\"𮗱~F&H1\u00105󰋮>bR1􇧠𨦫#M\u0018Jԏ/𐲁uy\u0017UOd.O9|L\u0013\u0002麗_Sv\u0010_𭷞\u001bg\u0008*⎥{EJ2Gn?\u0004|n5f_󳴕tivpK8􃋁\u0007VxU蝑\u0008X󹭅5􆁌J\u0005:\u0011쨾(\u0017󳒱𧂍~<󳲪}v.􄦍􏲛\u0003󴶧?V\u0002iqNCy\u001d𢉎𛉔􌣖𬽸SE6P(~]𥾱k𦼿&\u0006+拔EJ<T􉤁D\u001aM88%\u0007V\u000c\u0002"
+                "name": "L􏌨󹶞\t]33?C\u0019\u000eaLXpzj{\u0017XP󳬩Ut\u000cD􃳠M0󷑰|",
+                "homepage": "e𧂫L./􂇭f<\\Ne\u0003𮒐\t\u0008WhT𦉒𦸅<JJ)ii4\\(𬺊sK}\u0013𑃕\u0001E%蕯x􄕮pp",
+                "ticker": "𪏳E\u001a",
+                "description": "x덝\u00107􎕝kz\u001bj\u000cK;𭦸:58󻳶榷;@1\u0003\u000e\u001c0𩏧y\u0006hr􊡰\u00133\u000cox\u0007\u00085j\u0013|庈ma827h\u001fHx<j2:􇕤\u0017怤5B?\u0019󽤸\u0015P\u0013e粬#3𨵂C聳􈨾-𭏇􉊽O瑹􉁲\u0019𬵆# kzf󷏠𣬜M\t\t􈉛f\"\u0007i\u0010~\u0018𦨆,,lz󲞙<\u0011D􊴶eMa\u0008炡󱇡X뎘|;\u0014狼O􄐵b\u0005\u0003􏓒e1􇣊m𛃈sge\"P\u0010𡬓𤨼[?l\u001e\u0002\u000eᱭᎾ󸱺p󸫒\u0019󺱋𫪂v􇤧!(peF󱬭昞]; ,􃩲=\u000b&ⰷ%w󶶵󳧥K]󾀐􇋹7$6`􋘆k􊮾k5ᛚ󲟥𭷢􄽻nie\u000b󶮔x\t􈂓]p4y𬪝􁺿𩜖wmvL\u001f$\u0011(l{𮘬[\u0016\nHwgG~7𢹯\u0008𰛳<󳍞9􍢪"
             }
         },
         {
             "metrics": {
                 "non_myopic_member_rewards": {
-                    "quantity": 63174787162,
+                    "quantity": 166894133505,
                     "unit": "lovelace"
                 },
-                "saturation": 4.874945199273821,
+                "saturation": 3.4337103550648065,
                 "produced_blocks": {
-                    "quantity": 1596007,
+                    "quantity": 21996126,
                     "unit": "block"
                 },
                 "relative_stake": {
-                    "quantity": 45.43,
+                    "quantity": 68.82,
                     "unit": "percent"
+                },
+                "owner_stake": {
+                    "quantity": 235,
+                    "unit": "lovelace"
                 }
             },
             "cost": {
-                "quantity": 210,
-                "unit": "lovelace"
-            },
-            "pledge": {
                 "quantity": 14,
                 "unit": "lovelace"
             },
-            "id": "pool1xtxazdk5904jjfzcmyelu7cxs5tvggqfwcg9lnzgegnq7976sz6",
+            "pledge": {
+                "quantity": 12,
+                "unit": "lovelace"
+            },
+            "id": "pool1y85rred3nde8s0d5yrum6hzajas0f5mltnfuqtgrp5keqv074g8",
+            "flags": [
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge"
+            ],
+            "margin": {
+                "quantity": 98.53,
+                "unit": "percent"
+            }
+        },
+        {
+            "metrics": {
+                "non_myopic_member_rewards": {
+                    "quantity": 738865057532,
+                    "unit": "lovelace"
+                },
+                "saturation": 1.2562075062400269,
+                "produced_blocks": {
+                    "quantity": 22534380,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 62.22,
+                    "unit": "percent"
+                },
+                "owner_stake": {
+                    "quantity": 251,
+                    "unit": "lovelace"
+                }
+            },
+            "cost": {
+                "quantity": 190,
+                "unit": "lovelace"
+            },
+            "pledge": {
+                "quantity": 210,
+                "unit": "lovelace"
+            },
+            "id": "pool1ef8wd6ch8twqm3hnqcu4dylksvq57gcxktxsuntw3j89umu95gx",
             "flags": [
                 "delisted",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "delisted",
+                "owner_stake_lower_than_pledge",
+                "owner_stake_lower_than_pledge",
+                "delisted",
+                "delisted",
+                "owner_stake_lower_than_pledge",
                 "delisted",
                 "delisted",
                 "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted",
-                "delisted"
+                "owner_stake_lower_than_pledge"
             ],
             "retirement": {
-                "epoch_start_time": "1906-12-26T11:49:17.071427727894Z",
-                "epoch_number": 22927
+                "epoch_start_time": "1880-06-22T10:00:00Z",
+                "epoch_number": 28274
             },
             "margin": {
-                "quantity": 83.94,
+                "quantity": 66.11,
                 "unit": "percent"
             }
         }

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiStakePoolMetrics.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiStakePoolMetrics.json
@@ -1,154 +1,194 @@
 {
-    "seed": 4290201172570848777,
+    "seed": -2379838076033950160,
     "samples": [
         {
             "non_myopic_member_rewards": {
-                "quantity": 583032046136,
+                "quantity": 451187417046,
                 "unit": "lovelace"
             },
-            "saturation": 3.520731350435267,
+            "saturation": 2.752598002317251,
             "produced_blocks": {
-                "quantity": 12254332,
+                "quantity": 15863348,
                 "unit": "block"
             },
             "relative_stake": {
-                "quantity": 26.82,
+                "quantity": 54.56,
                 "unit": "percent"
+            },
+            "owner_stake": {
+                "quantity": 187,
+                "unit": "lovelace"
             }
         },
         {
             "non_myopic_member_rewards": {
-                "quantity": 71304250895,
+                "quantity": 754492381771,
                 "unit": "lovelace"
             },
-            "saturation": 1.8150866593019082,
+            "saturation": 3.271178361345629,
             "produced_blocks": {
-                "quantity": 2452199,
+                "quantity": 605983,
                 "unit": "block"
             },
             "relative_stake": {
-                "quantity": 77.32,
+                "quantity": 75.64,
                 "unit": "percent"
+            },
+            "owner_stake": {
+                "quantity": 173,
+                "unit": "lovelace"
             }
         },
         {
             "non_myopic_member_rewards": {
-                "quantity": 769915288227,
+                "quantity": 326943481898,
                 "unit": "lovelace"
             },
-            "saturation": 2.563554233212745,
+            "saturation": 4.906096862029531,
             "produced_blocks": {
-                "quantity": 14950793,
+                "quantity": 15408002,
                 "unit": "block"
             },
             "relative_stake": {
-                "quantity": 72.8,
+                "quantity": 38.13,
                 "unit": "percent"
+            },
+            "owner_stake": {
+                "quantity": 133,
+                "unit": "lovelace"
             }
         },
         {
             "non_myopic_member_rewards": {
-                "quantity": 289909801070,
+                "quantity": 768532664978,
                 "unit": "lovelace"
             },
-            "saturation": 4.98840786074242,
+            "saturation": 6.798281198287459e-2,
             "produced_blocks": {
-                "quantity": 2788831,
+                "quantity": 13658592,
                 "unit": "block"
             },
             "relative_stake": {
-                "quantity": 22.68,
+                "quantity": 23.68,
                 "unit": "percent"
+            },
+            "owner_stake": {
+                "quantity": 119,
+                "unit": "lovelace"
             }
         },
         {
             "non_myopic_member_rewards": {
-                "quantity": 171969344529,
+                "quantity": 123511090415,
                 "unit": "lovelace"
             },
-            "saturation": 2.526282220346401,
+            "saturation": 0.726934877206562,
             "produced_blocks": {
-                "quantity": 15956433,
+                "quantity": 6885178,
                 "unit": "block"
             },
             "relative_stake": {
-                "quantity": 94.13,
+                "quantity": 69.93,
                 "unit": "percent"
+            },
+            "owner_stake": {
+                "quantity": 220,
+                "unit": "lovelace"
             }
         },
         {
             "non_myopic_member_rewards": {
-                "quantity": 469798378038,
+                "quantity": 630554756054,
                 "unit": "lovelace"
             },
-            "saturation": 4.066364280183616,
+            "saturation": 4.000560547745844,
             "produced_blocks": {
-                "quantity": 3986197,
+                "quantity": 4347007,
                 "unit": "block"
             },
             "relative_stake": {
-                "quantity": 35.37,
+                "quantity": 97.97,
                 "unit": "percent"
+            },
+            "owner_stake": {
+                "quantity": 208,
+                "unit": "lovelace"
             }
         },
         {
             "non_myopic_member_rewards": {
-                "quantity": 22526869434,
+                "quantity": 609784508714,
                 "unit": "lovelace"
             },
-            "saturation": 3.854578222871367,
+            "saturation": 8.667286362816107e-2,
             "produced_blocks": {
-                "quantity": 14318865,
+                "quantity": 22312576,
                 "unit": "block"
             },
             "relative_stake": {
-                "quantity": 35.98,
+                "quantity": 69.22,
                 "unit": "percent"
+            },
+            "owner_stake": {
+                "quantity": 209,
+                "unit": "lovelace"
             }
         },
         {
             "non_myopic_member_rewards": {
-                "quantity": 609495969587,
+                "quantity": 851691716394,
                 "unit": "lovelace"
             },
-            "saturation": 2.0303290394701357,
+            "saturation": 1.5190737602589466,
             "produced_blocks": {
-                "quantity": 17024220,
+                "quantity": 14182236,
                 "unit": "block"
             },
             "relative_stake": {
-                "quantity": 88.89,
+                "quantity": 68.09,
                 "unit": "percent"
+            },
+            "owner_stake": {
+                "quantity": 90,
+                "unit": "lovelace"
             }
         },
         {
             "non_myopic_member_rewards": {
-                "quantity": 694489297361,
+                "quantity": 305578728386,
                 "unit": "lovelace"
             },
-            "saturation": 4.766472743915088,
+            "saturation": 4.268880872088841,
             "produced_blocks": {
-                "quantity": 2952688,
+                "quantity": 8954810,
                 "unit": "block"
             },
             "relative_stake": {
-                "quantity": 62.89,
+                "quantity": 51.96,
                 "unit": "percent"
+            },
+            "owner_stake": {
+                "quantity": 148,
+                "unit": "lovelace"
             }
         },
         {
             "non_myopic_member_rewards": {
-                "quantity": 712155780148,
+                "quantity": 554917587805,
                 "unit": "lovelace"
             },
-            "saturation": 3.321632079239584,
+            "saturation": 2.2043378404870224,
             "produced_blocks": {
-                "quantity": 21890294,
+                "quantity": 17732410,
                 "unit": "block"
             },
             "relative_stake": {
-                "quantity": 58.47,
+                "quantity": 86.94,
                 "unit": "percent"
+            },
+            "owner_stake": {
+                "quantity": 45,
+                "unit": "lovelace"
             }
         }
     ]

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -194,6 +194,7 @@ import Cardano.Wallet.Api.Types
     , WalletPostData (..)
     , WalletPutData (..)
     , WalletPutPassphraseData (..)
+    , invariantApiStakePool
     , toApiAsset
     )
 import Cardano.Wallet.Gen
@@ -418,6 +419,7 @@ import Test.QuickCheck
     , scale
     , shrinkIntegral
     , sized
+    , suchThat
     , vector
     , vectorOf
     , (.&&.)
@@ -1749,7 +1751,7 @@ instance Arbitrary PoolId where
         return $ PoolId $ BS.pack $ take 28 bytes
 
 instance Arbitrary ApiStakePool where
-    arbitrary = ApiStakePool
+    arbitrary = (ApiStakePool
         <$> arbitrary
         <*> arbitrary
         <*> arbitrary
@@ -1757,11 +1759,12 @@ instance Arbitrary ApiStakePool where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
-        <*> arbitrary
+        <*> arbitrary) `suchThat` invariantApiStakePool
 
 instance Arbitrary ApiStakePoolMetrics where
     arbitrary = ApiStakePoolMetrics
         <$> (Quantity . fromIntegral <$> choose (1::Integer, 1_000_000_000_000))
+        <*> arbitrary
         <*> arbitrary
         <*> (choose (0.0, 5.0))
         <*> (Quantity . fromIntegral <$> choose (1::Integer, 22_600_000))

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1767,12 +1767,13 @@ x-stakePoolSaturation: &stakePoolSaturation
   type: number
   minimum: 0
   description: |
-    Saturation-level of the pool based on the desired number of pools aimed by the network.
-    A value above `1` indicates that the pool is saturated.
+    The saturation of a pool is the ratio of the current `relative_stake`
+    to the equilibrium relative stake of `1/k`.
+    This equilibrium stake appears in the long term,
+    where it is expected that `k` pools attract an equal share of the stake.
+    A value above `1` indicates that the pool is oversaturated.
 
-    The `non_myopic_member_rewards` take oversaturation into account, as specified by the [specs](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec).
-
-    The saturation is based on the live `relative_stake`. The saturation at the end of epoch e,
+    The saturation at the end of epoch e,
     will affect the rewards paid out at the end of epoch e+3.
 
   example: 0.74
@@ -1780,8 +1781,16 @@ x-stakePoolSaturation: &stakePoolSaturation
 x-non-myopic-member-rewards: &nonMyopicMemberRewards
   <<: *amount
   description: |
-    The rewards the wallet can expect to receive at the end of an epoch, in the long term, if delegating to
-    this pool.
+    The rewards that the wallet can expect to receive at the end of each epoch, in the long term,
+    if it delegates to this pool.
+
+    In the long term, it is expected that only the first `k` pools
+    with the highest desirability scores will attract an equal share of the stake,
+    while the other pools loose all their delegators.
+    The parameter `k` is fixed by the protocol (e.g. `k = 500` as of 2021-07-30).
+    This expectation is taken into account by `non_myopic_member_rewards`:
+    When delegating to a pool that is oversaturated or has too low desirability,
+    the stake of this wallet will be the main influence on the rewarads.
 
     For more details, see the
     [Design Specification for Delegation and Incentives in Cardano](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec)
@@ -1794,6 +1803,7 @@ x-stakePoolMetrics: &stakePoolMetrics
     - non_myopic_member_rewards
     - produced_blocks
     - saturation
+    - owner_stake
   properties:
     non_myopic_member_rewards: *nonMyopicMemberRewards
     relative_stake:
@@ -1803,6 +1813,10 @@ x-stakePoolMetrics: &stakePoolMetrics
 
         For more details, see the section "Relative Stake: Active vs Total" in
         [Design Specification for Delegation and Incentives in Cardano](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec).
+    owner_stake:
+      <<: *amount
+      description: |
+        Total Ada delegated to the stake pool by the pool owners in order to meet their pledge.
     saturation: *stakePoolSaturation
     produced_blocks:
       <<: *numberOfBlocks
@@ -1812,15 +1826,17 @@ x-stakePoolFlag: &stakePoolFlag
   type: string
   enum:
   - delisted
+  - owner_stake_lower_than_pledge
 
 x-stakePoolFlags: &stakePoolFlags
   type: array
   description: |
     Various flags applicable to stake pools. Possible flags:
 
-    | flag     | description                                                                                                      |
-    | ---      | ---                                                                                                              |
-    | delisted | The pool is marked as delisted on a configured SMASH server; metadata for this pool have therefore been dropped. |
+    | flag                          | description                                                                                                      |
+    | ---                           | ---                                                                                                              |
+    | delisted                      | The pool is marked as delisted on a configured SMASH server; metadata for this pool have therefore been dropped. |
+    | owner_stake_lower_than_pledge | The pool owners fail to meet their pledge; this is bad.
   items: *stakePoolFlag
 
 x-networkInformationSyncProgress: &networkInformationSyncProgress


### PR DESCRIPTION
### Issue number

ADP-1361, ADP-1543

### Overview

In this pull request, we use the new `GetRewardInfoPools` query to retrieve stake pool data that informs a delegation choice. This data includes:

* current pool stake distribution
* current pool owner stake, for testing whether the pool owner meets their pledge
* pool performance estimates

### Details

* This pull request does not yet implement caching.

### Comments

* This pull request essentially cherry-picks commits from #2781 .