### PR TITLE
Add integration tests for postRandomWalletFromXPrv

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -62,7 +62,7 @@ import Data.Text.Class
 import Numeric.Natural
     ( Natural )
 import Test.Hspec
-    ( ActionWith, SpecWith, describe, pendingWith )
+    ( ActionWith, SpecWith, describe )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldNotBe )
 import Test.Hspec.Extra
@@ -123,7 +123,6 @@ import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as TokenPolicy
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 import qualified Network.HTTP.Types.Status as HTTP
 
 data TestCase a = TestCase

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -106,7 +106,7 @@ import Control.Monad
 import Crypto.Hash
     ( Digest, HashAlgorithm )
 import Crypto.Hash.Utils
-    ( blake2b224, blake2b256 )
+    ( blake2b224 )
 import Crypto.KDF.PBKDF2
     ( Parameters (..), fastPBKDF2_SHA512 )
 import Crypto.Random.Types
@@ -585,17 +585,17 @@ encryptPassphrase  (Passphrase bytes) = do
         <> BA.convert @ByteString (fastPBKDF2_SHA512 params bytes salt)
 
 -- | Manipulation done on legacy passphrases before getting encrypted.
+--
+-- NOTE March 2022:
+-- It seems like the idea that some manipulation should be done was incorrect.
+-- We could remove this fucntion then.
 preparePassphrase
     :: PassphraseScheme
     -> Passphrase "raw"
     -> Passphrase "encryption"
 preparePassphrase = \case
     EncryptWithPBKDF2 -> coerce
-    EncryptWithScrypt -> Passphrase . hashMaybe
-  where
-    hashMaybe pw@(Passphrase bytes)
-        | pw == mempty = BA.convert bytes
-        | otherwise = BA.convert $ blake2b256 bytes
+    EncryptWithScrypt -> coerce
 
 -- | Check whether a 'Passphrase' matches with a stored 'Hash'
 checkPassphrase


### PR DESCRIPTION
- [x] Add integration tests showing that a wallet created with `postRandomWalletFromXPrv` can spend funds (using goldens Piotr pointed to: https://github.com/input-output-hk/cardano-sl/pull/4278#issuecomment-600553878)
- [x] Drop `hashMaybe` from `preparePassphrase` (required to make the test with a non-empty passphrase pass) 

### Comments

Integration tests are:
```
    BYRON_SCRYPT_TRANS_CREATE_01 - wallet with password
    BYRON_SCRYPT_TRANS_CREATE_02 - wallet without password
```

#### Some tested scenarios

- `master` (without cde1767ed23394d4261da40c8d725840029a815e) -> first test fails
- #2767  -> first test fails
- #2767 with e3edfa0823c525de5fdced931a3e7c88ce9cbbee reverted -> both tests fail
- #2767 dropping `hashMaybe` -> both tests pass
    
- I hope the passing tests shows the need for e3edfa0823c525de5fdced931a3e7c88ce9cbbee in that PR, but haven't tested it. 

- Mainly wanted to bring this to your attention, but I guess it might as well be merged as well.

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

Partly related to ADP-842 and _potentially_ (that's what we'd like to find out) to https://input-output.atlassian.net/browse/ADP-1335

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
