### PR TITLE
Remove hard-coded dependency on `txOutMax{Coin,TokenQuantity}` within coin selection modules

### DIFF
--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -103,7 +103,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId, TokenMap )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TokenBundleSizeAssessment, TxIn, TxOut (..) )
+    ( TokenBundleSizeAssessment, TxIn, TxOut (..), txOutMaxCoin )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
@@ -248,6 +248,8 @@ toInternalSelectionConstraints SelectionConstraints {..} =
             computeMinimumCost . toExternalSelectionSkeleton
         , computeSelectionLimit =
             computeSelectionLimit . fmap (uncurry TxOut)
+        , maximumOutputAdaQuantity =
+            txOutMaxCoin
         , ..
         }
 

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -103,7 +103,12 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId, TokenMap )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TokenBundleSizeAssessment, TxIn, TxOut (..), txOutMaxCoin )
+    ( TokenBundleSizeAssessment
+    , TxIn
+    , TxOut (..)
+    , txOutMaxCoin
+    , txOutMaxTokenQuantity
+    )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
@@ -250,6 +255,8 @@ toInternalSelectionConstraints SelectionConstraints {..} =
             computeSelectionLimit . fmap (uncurry TxOut)
         , maximumOutputAdaQuantity =
             txOutMaxCoin
+        , maximumOutputTokenQuantity =
+            txOutMaxTokenQuantity
         , ..
         }
 

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -176,6 +176,10 @@ data SelectionConstraints ctx = SelectionConstraints
         :: Natural
         -- ^ Specifies the minimum required amount of collateral as a
         -- percentage of the total transaction fee.
+    , maximumOutputAdaQuantity
+        :: Coin
+        -- ^ Specifies the largest ada quantity that can appear in the token
+        -- bundle of an output.
     }
     deriving Generic
 
@@ -402,6 +406,8 @@ toBalanceConstraintsParams (constraints, params) =
                 & adjustComputeSelectionLimit
         , assessTokenBundleSize =
             view #assessTokenBundleSize constraints
+        , maximumOutputAdaQuantity =
+            view #maximumOutputAdaQuantity constraints
         }
       where
         adjustComputeMinimumCost

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -180,6 +180,10 @@ data SelectionConstraints ctx = SelectionConstraints
         :: Coin
         -- ^ Specifies the largest ada quantity that can appear in the token
         -- bundle of an output.
+    , maximumOutputTokenQuantity
+        :: TokenQuantity
+        -- ^ Specifies the largest non-ada quantity that can appear in the
+        -- token bundle of an output.
     }
     deriving Generic
 
@@ -408,6 +412,8 @@ toBalanceConstraintsParams (constraints, params) =
             view #assessTokenBundleSize constraints
         , maximumOutputAdaQuantity =
             view #maximumOutputAdaQuantity constraints
+        , maximumOutputTokenQuantity =
+            view #maximumOutputTokenQuantity constraints
         }
       where
         adjustComputeMinimumCost

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -909,6 +909,7 @@ performSelectionNonEmpty constraints params
         , computeMinimumAdaQuantity
         , computeMinimumCost
         , computeSelectionLimit
+        , maximumOutputAdaQuantity
         } = constraints
     SelectionParams
         { outputsToCover
@@ -1002,6 +1003,7 @@ performSelectionNonEmpty constraints params
             , outputBundles
             , assetsToMint
             , assetsToBurn
+            , maximumOutputAdaQuantity
             }
         )
       where
@@ -1083,6 +1085,7 @@ performSelectionNonEmpty constraints params
             , outputBundles = snd <$> outputsToCover
             , assetsToMint
             , assetsToBurn
+            , maximumOutputAdaQuantity
             }
 
         mkSelectionResult :: [TokenBundle] -> SelectionResultOf NonEmpty ctx
@@ -1394,6 +1397,10 @@ data MakeChangeCriteria minCoinFor bundleSizeAssessor = MakeChangeCriteria
         -- ^ Assets to mint: these provide input value to a transaction.
     , assetsToBurn :: TokenMap
         -- ^ Assets to burn: these consume output value from a transaction.
+    , maximumOutputAdaQuantity
+        :: Coin
+        -- ^ Specifies the largest ada quantity that can appear in the token
+        -- bundle of an output.
     } deriving (Eq, Generic, Show)
 
 -- | Indicates 'True' if and only if a token bundle exceeds the maximum size

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -231,6 +231,10 @@ data SelectionConstraints ctx = SelectionConstraints
         :: [(Address ctx, TokenBundle)] -> SelectionLimit
         -- ^ Computes an upper bound for the number of ordinary inputs to
         -- select, given a current set of outputs.
+    , maximumOutputAdaQuantity
+        :: Coin
+        -- ^ Specifies the largest ada quantity that can appear in the token
+        -- bundle of an output.
     }
     deriving Generic
 

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -139,10 +139,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TokenBundleSizeAssessment (..)
-    , TokenBundleSizeAssessor (..)
-    , txOutMaxTokenQuantity
-    )
+    ( TokenBundleSizeAssessment (..), TokenBundleSizeAssessor (..) )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( SelectionFilter (..), UTxOIndex (..) )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
@@ -1472,6 +1469,7 @@ makeChange criteria
         , assetsToMint
         , assetsToBurn
         , maximumOutputAdaQuantity
+        , maximumOutputTokenQuantity
         } = criteria
 
     -- The following subtraction is safe, as we have already checked
@@ -1525,7 +1523,7 @@ makeChange criteria
                 & flip splitBundlesWithExcessiveAssetCounts
                     (tokenBundleSizeExceedsLimit assessBundleSizeWithMaxCoin)
                 & flip splitBundlesWithExcessiveTokenQuantities
-                    txOutMaxTokenQuantity
+                    maximumOutputTokenQuantity
 
             -- When assessing the size of a change map to determine if it is
             -- excessively large, we don't yet know how large the associated

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -141,7 +141,6 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.Tx
     ( TokenBundleSizeAssessment (..)
     , TokenBundleSizeAssessor (..)
-    , txOutMaxCoin
     , txOutMaxTokenQuantity
     )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
@@ -1461,6 +1460,7 @@ makeChange criteria
         , outputBundles
         , assetsToMint
         , assetsToBurn
+        , maximumOutputAdaQuantity
         } = criteria
 
     -- The following subtraction is safe, as we have already checked
@@ -1535,7 +1535,7 @@ makeChange criteria
             assessBundleSizeWithMaxCoin :: TokenBundleSizeAssessor
             assessBundleSizeWithMaxCoin = TokenBundleSizeAssessor
                 $ view #assessTokenBundleSize bundleSizeAssessor
-                . flip TokenBundle.setCoin txOutMaxCoin
+                . flip TokenBundle.setCoin maximumOutputAdaQuantity
 
     -- Change for user-specified assets: assets that were present in the
     -- original set of user-specified outputs ('outputsToCover').

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -234,6 +234,10 @@ data SelectionConstraints ctx = SelectionConstraints
         :: Coin
         -- ^ Specifies the largest ada quantity that can appear in the token
         -- bundle of an output.
+    , maximumOutputTokenQuantity
+        :: TokenQuantity
+        -- ^ Specifies the largest non-ada quantity that can appear in the
+        -- token bundle of an output.
     }
     deriving Generic
 

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -913,6 +913,7 @@ performSelectionNonEmpty constraints params
         , computeMinimumCost
         , computeSelectionLimit
         , maximumOutputAdaQuantity
+        , maximumOutputTokenQuantity
         } = constraints
     SelectionParams
         { outputsToCover
@@ -1007,6 +1008,7 @@ performSelectionNonEmpty constraints params
             , assetsToMint
             , assetsToBurn
             , maximumOutputAdaQuantity
+            , maximumOutputTokenQuantity
             }
         )
       where
@@ -1089,6 +1091,7 @@ performSelectionNonEmpty constraints params
             , assetsToMint
             , assetsToBurn
             , maximumOutputAdaQuantity
+            , maximumOutputTokenQuantity
             }
 
         mkSelectionResult :: [TokenBundle] -> SelectionResultOf NonEmpty ctx
@@ -1404,6 +1407,10 @@ data MakeChangeCriteria minCoinFor bundleSizeAssessor = MakeChangeCriteria
         :: Coin
         -- ^ Specifies the largest ada quantity that can appear in the token
         -- bundle of an output.
+    , maximumOutputTokenQuantity
+        :: TokenQuantity
+        -- ^ Specifies the largest non-ada quantity that can appear in the
+        -- token bundle of an output.
     } deriving (Eq, Generic, Show)
 
 -- | Indicates 'True' if and only if a token bundle exceeds the maximum size

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -2701,6 +2701,7 @@ genMakeChangeData = flip suchThat isValidMakeChangeData $ do
         <*> genAssetsToMint
         <*> genAssetsToBurn
         <*> genMaximumOutputAdaQuantity
+        <*> genMaximumOutputTokenQuantity
   where
     genAssetsToMint :: Gen TokenMap
     genAssetsToMint = genTokenMapSmallRange
@@ -2724,6 +2725,9 @@ genMakeChangeData = flip suchThat isValidMakeChangeData $ do
 
     genMaximumOutputAdaQuantity :: Gen Coin
     genMaximumOutputAdaQuantity = pure testMaximumOutputAdaQuantity
+
+    genMaximumOutputTokenQuantity :: Gen TokenQuantity
+    genMaximumOutputTokenQuantity = pure testMaximumOutputTokenQuantity
 
 makeChangeWith
     :: MakeChangeData
@@ -2751,6 +2755,7 @@ prop_makeChange_identity bundles = (===)
         , assetsToMint = TokenMap.empty
         , assetsToBurn = TokenMap.empty
         , maximumOutputAdaQuantity = testMaximumOutputAdaQuantity
+        , maximumOutputTokenQuantity = testMaximumOutputTokenQuantity
         }
 
 -- | Tests that 'makeChange' generates the correct number of change bundles.
@@ -3112,6 +3117,7 @@ unit_makeChange =
               , assetsToMint = TokenMap.empty
               , assetsToBurn = TokenMap.empty
               , maximumOutputAdaQuantity = testMaximumOutputAdaQuantity
+              , maximumOutputTokenQuantity = testMaximumOutputTokenQuantity
               }
     ]
   where

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -2686,6 +2686,7 @@ genMakeChangeData = flip suchThat isValidMakeChangeData $ do
         <*> genTokenBundles outputBundleCount
         <*> genAssetsToMint
         <*> genAssetsToBurn
+        <*> genMaximumOutputAdaQuantity
   where
     genAssetsToMint :: Gen TokenMap
     genAssetsToMint = genTokenMapSmallRange
@@ -2706,6 +2707,9 @@ genMakeChangeData = flip suchThat isValidMakeChangeData $ do
     genTokenBundles count = (:|)
         <$> genTokenBundleSmallRangePositive
         <*> replicateM count genTokenBundleSmallRangePositive
+
+    genMaximumOutputAdaQuantity :: Gen Coin
+    genMaximumOutputAdaQuantity = pure testMaximumOutputAdaQuantity
 
 makeChangeWith
     :: MakeChangeData
@@ -2732,6 +2736,7 @@ prop_makeChange_identity bundles = (===)
         , outputBundles = bundles
         , assetsToMint = TokenMap.empty
         , assetsToBurn = TokenMap.empty
+        , maximumOutputAdaQuantity = testMaximumOutputAdaQuantity
         }
 
 -- | Tests that 'makeChange' generates the correct number of change bundles.
@@ -3092,6 +3097,7 @@ unit_makeChange =
               , outputBundles = o
               , assetsToMint = TokenMap.empty
               , assetsToBurn = TokenMap.empty
+              , maximumOutputAdaQuantity = testMaximumOutputAdaQuantity
               }
     ]
   where

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -1847,6 +1847,7 @@ mkBoundaryTestExpectation (BoundaryTestData params expectedResult) = do
         , assessTokenBundleSize = unMockAssessTokenBundleSize $
             boundaryTestBundleSizeAssessor params
         , computeSelectionLimit = const NoLimit
+        , maximumOutputAdaQuantity = testMaximumOutputAdaQuantity
         }
 
 encodeBoundaryTestCriteria
@@ -2474,7 +2475,18 @@ unMockSelectionConstraints m = SelectionConstraints
         unMockComputeMinimumCost $ view #computeMinimumCost m
     , computeSelectionLimit =
         unMockComputeSelectionLimit $ view #computeSelectionLimit m
+    , maximumOutputAdaQuantity =
+        testMaximumOutputAdaQuantity
     }
+
+-- | Specifies the largest ada quantity that can appear in the token bundle
+--   of an output.
+--
+-- For the moment, we use the same constant that is used in the wallet. In
+-- future, we can improve our test coverage by allowing this value to vary.
+--
+testMaximumOutputAdaQuantity :: Coin
+testMaximumOutputAdaQuantity = Coin 45_000_000_000_000_000
 
 --------------------------------------------------------------------------------
 -- Computing minimum ada quantities

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -180,6 +180,8 @@ import Data.Generics.Internal.VL.Lens
     ( view )
 import Data.Generics.Labels
     ()
+import Data.IntCast
+    ( intCast )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Map.Strict
@@ -1848,6 +1850,7 @@ mkBoundaryTestExpectation (BoundaryTestData params expectedResult) = do
             boundaryTestBundleSizeAssessor params
         , computeSelectionLimit = const NoLimit
         , maximumOutputAdaQuantity = testMaximumOutputAdaQuantity
+        , maximumOutputTokenQuantity = testMaximumOutputTokenQuantity
         }
 
 encodeBoundaryTestCriteria
@@ -2477,6 +2480,8 @@ unMockSelectionConstraints m = SelectionConstraints
         unMockComputeSelectionLimit $ view #computeSelectionLimit m
     , maximumOutputAdaQuantity =
         testMaximumOutputAdaQuantity
+    , maximumOutputTokenQuantity =
+        testMaximumOutputTokenQuantity
     }
 
 -- | Specifies the largest ada quantity that can appear in the token bundle
@@ -2487,6 +2492,15 @@ unMockSelectionConstraints m = SelectionConstraints
 --
 testMaximumOutputAdaQuantity :: Coin
 testMaximumOutputAdaQuantity = Coin 45_000_000_000_000_000
+
+-- | Specifies the largest non-ada quantity that can appear in the token bundle
+--   of an output.
+--
+-- For the moment, we use the same constant that is used in the wallet. In
+-- future, we can improve our test coverage by allowing this value to vary.
+--
+testMaximumOutputTokenQuantity :: TokenQuantity
+testMaximumOutputTokenQuantity = TokenQuantity $ intCast $ maxBound @Word64
 
 --------------------------------------------------------------------------------
 -- Computing minimum ada quantities

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -542,6 +543,8 @@ data MockSelectionConstraints = MockSelectionConstraints
         :: Int
     , minimumCollateralPercentage
         :: Natural
+    , maximumOutputAdaQuantity
+         :: Coin
     }
     deriving (Eq, Generic, Show)
 
@@ -554,6 +557,7 @@ genMockSelectionConstraints = MockSelectionConstraints
     <*> genMockComputeSelectionLimit
     <*> genMaximumCollateralInputCount
     <*> genMinimumCollateralPercentage
+    <*> genMaximumOutputAdaQuantity
 
 shrinkMockSelectionConstraints
     :: MockSelectionConstraints -> [MockSelectionConstraints]
@@ -565,6 +569,7 @@ shrinkMockSelectionConstraints = genericRoundRobinShrink
     <:> shrinkMockComputeSelectionLimit
     <:> shrinkMaximumCollateralInputCount
     <:> shrinkMinimumCollateralPercentage
+    <:> shrinkMaximumOutputAdaQuantity
     <:> Nil
 
 unMockSelectionConstraints
@@ -584,6 +589,8 @@ unMockSelectionConstraints m = SelectionConstraints
         view #maximumCollateralInputCount m
     , minimumCollateralPercentage =
         view #minimumCollateralPercentage m
+    , maximumOutputAdaQuantity =
+        view #maximumOutputAdaQuantity m
     }
 
 --------------------------------------------------------------------------------
@@ -615,6 +622,25 @@ genMinimumCollateralPercentage = chooseNatural (0, 1000)
 
 shrinkMinimumCollateralPercentage :: Natural -> [Natural]
 shrinkMinimumCollateralPercentage = shrinkNatural
+
+--------------------------------------------------------------------------------
+-- Maximum token quantities
+--------------------------------------------------------------------------------
+
+genMaximumOutputAdaQuantity :: Gen Coin
+genMaximumOutputAdaQuantity = pure testMaximumOutputAdaQuantity
+
+shrinkMaximumOutputAdaQuantity :: Coin -> [Coin]
+shrinkMaximumOutputAdaQuantity = const []
+
+-- | Specifies the largest ada quantity that can appear in the token bundle
+--   of an output.
+--
+-- For the moment, we use the same constant that is used in the wallet. In
+-- future, we can improve our test coverage by allowing this value to vary.
+--
+testMaximumOutputAdaQuantity :: Coin
+testMaximumOutputAdaQuantity = Coin 45_000_000_000_000_000
 
 --------------------------------------------------------------------------------
 -- Selection parameters


### PR DESCRIPTION
## Issue Number

ADP-1481

## Summary

This PR adjusts the **_internal_** coin selection modules so that they no longer depend on **_hard-coded_** maximum token quantity constants imported from the wallet.

Instead, these constants are now **_passed in_** to coin selection as part of `SelectionConstraints`.

```patch
  data SelectionConstraints ctx = SelectionConstraints
      { ...
+     , outputMaximumAdaQuantity
+        :: Coin
+     , outputMaximumTokenQuantity
+        :: TokenQuantity
      , ...
      }
 ```
 
There is no impact on the wallet itself, since these dependencies are injected in automatically by the `Cardano.Wallet.CoinSelection` module, which provides a wallet-friendly interface to coin selection.

## Future Work

We intend to eventually adjust coin selection so that it **_does not discriminate_** between **_ada_** and **_non-ada_** quantities. (See https://input-output.atlassian.net/browse/ADP-1449). When that moment comes, we may want to replace these two constants with a function similar to:

```patch
 data SelectionConstraints ctx = SelectionConstraints
     { ...
-    , outputMaximumAdaQuantity
-       :: Coin
-    , outputMaximumTokenQuantity
-       :: TokenQuantity
+    , outputMaximumTokenQuantity
+        :: Asset ctx -> TokenQuantity 
     , ...
     }
 ```

Then, callers of coin selection can provide a function that meets their requirements. If the requirement is still to have different limits for ada and non-ada quantities, then this can be encoded in the function.

Or, if we can get away with a single limit for all asset types (including ada), then we can reduce this to a single constant.