### PR TITLE
Fix cardano-wallet nightly build

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -63,17 +63,6 @@ steps:
   #     system: x86_64-linux
   #   if: 'build.env("step") == null || build.env("step") =~ /migration-tests/'
 
-  - label: 'Full cabal build'
-    command:
-      - "mkdir -p config && echo '{  outputs = _: { withCabalCache = true; }; }'  > config/flake.nix"
-      - "nix develop --override-input customConfig path:./config .#cabal --command scripts/buildkite/cabal-ci.sh build"
-    env:
-      CABAL_CACHE_ARCHIVE: "/cache/cardano-wallet"
-      CABAL_STORE_DIR: "/build/cardano-wallet.store"
-    agents:
-      system: x86_64-linux
-    if: 'build.env("step") == null || build.env("step") =~ /cabal/'
-
   - wait
 
   - label: "Advance linux-tests-pass and all-tests-pass branches"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,6 +54,17 @@ steps:
     agents:
       system: x86_64-linux
 
+  - label: 'Full cabal build'
+    command:
+      - "mkdir -p config && echo '{  outputs = _: { withCabalCache = true; }; }'  > config/flake.nix"
+      - "nix develop --override-input customConfig path:./config .#cabal --command scripts/buildkite/cabal-ci.sh build"
+    env:
+      CABAL_CACHE_ARCHIVE: "/cache/cardano-wallet"
+      CABAL_STORE_DIR: "/build/cardano-wallet.store"
+    agents:
+      system: x86_64-linux
+    if: 'build.env("step") == null || build.env("step") =~ /cabal/'
+
   - label: 'Validate OpenAPI Specification'
     depends_on: nix
     command: 'nix develop --command bash -c "echo +++ openapi-spec-validator ; openapi-spec-validator --schema 3.0.0 specifications/api/swagger.yaml"'

--- a/cabal.project
+++ b/cabal.project
@@ -67,7 +67,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-addresses
-    tag: 71006f9eb956b0004022e80aadd4ad50d837b621
+    tag: 8bf98905b903455196495e231b23613ad2264cb0
     subdir: command-line
             core
 
@@ -196,7 +196,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/ouroboros-network
-    tag: d2d219a86cda42787325bb8c20539a75c2667132
+    tag: 4fac197b6f0d2ff60dc3486c593b68dc00969fbf
     subdir:
       io-sim
       io-classes


### PR DESCRIPTION
- Update the versions of cardano-addresses and ouroboros-network in the
cabal.project file to match the stack.yaml file.
- A full cabal build typically takes around 20 minutes on the Buildkite agents.
This is similar in length to the Stack build. Considering we have removed the
Stack build from the Buildkite pipeline, I think it's valuable to replace it
with the Cabal build. Cabal build failures are a common reason for the nightly
build to fail.