### PR TITLE
Replace stack invocations in documentation with cabal

### DIFF
--- a/docs/contributing/Testing.md
+++ b/docs/contributing/Testing.md
@@ -5,14 +5,14 @@
 ## Unit Tests
 
 ```
-$ stack test cardano-wallet-core:unit
-$ stack test cardano-wallet:unit
+$ cabal test cardano-wallet-core:unit
+$ cabal test cardano-wallet:unit
 ```
 
 Alternatively, one can run tests of a particular module by running:
 
 ```
-$ stack test cardano-wallet:unit --test-arguments "--match MyModule"
+$ cabal test cardano-wallet:unit --test-options "--match MyModule"
 ```
 
 ## Integration Tests
@@ -21,12 +21,12 @@ $ stack test cardano-wallet:unit --test-arguments "--match MyModule"
 
 Install [`cardano-node`](https://docs.cardano.org/projects/cardano-node/en/latest/getting-started/install.html) and [`cardano-cli`](https://docs.cardano.org/projects/cardano-node/en/latest/getting-started/install.html); make sure to use one of the [compatible versions](https://github.com/input-output-hk/cardano-wallet/blob/master/README.md#latest-releases).
 
-Alternatively, use `stack test --nix --ta "-j8"`.
+Alternatively, use `cabal test all -j8`.
 
 #### Test
 
 ```
-$ stack test cardano-wallet:integration
+$ cabal test cardano-wallet:integration
 ```
 
 Many tests require a cardano network with stake pools. To support
@@ -186,7 +186,7 @@ instructions.
 ### Database
 
 ```
-$ stack bench cardano-wallet-core:db
+$ cabal bench cardano-wallet-core:db
 ```
 
 ### Restoration
@@ -198,7 +198,7 @@ $ stack bench cardano-wallet-core:db
 2. (Optional) Install [hp2pretty](https://www.stackage.org/nightly-2019-03-25/package/hp2pretty-0.9)
 
     ```
-    $ stack install hp2pretty
+    $ cabal install hp2pretty
     ```
 
 #### Test
@@ -210,19 +210,19 @@ $ stack bench cardano-wallet-core:db
 > sure your system isn't too far behind the tip before running.
 
 ```
-$ stack bench cardano-wallet:restore
+$ cabal bench cardano-wallet:restore
 ```
 
 Alternatively, one can specify a target network (by default, benchmarks run on `testnet`):
 
 ```
-$ stack bench cardano-wallet:restore --benchmark-arguments "mainnet"
+$ cabal bench cardano-wallet:restore --benchmark-options "mainnet"
 ```
 
 Also, it's interesting to look at heap consumption during the running of the benchmark:
 
 ```
-$ stack bench cardano-wallet:restore --benchmark-arguments "mainnet +RTS -h -RTS"
+$ cabal bench cardano-wallet:restore --benchmark-options "mainnet +RTS -h -RTS"
 $ hp2pretty restore.hp
 $ eog restore.svg
 ```
@@ -235,10 +235,10 @@ $ eog restore.svg
 
 #### Test
 
-Running combined code coverage on all components is pretty easy. This generates code coverage reports in an HTML format as well as a short summary in the console. Note that, because code has to be compiled in a particular way to be "instrumentable" by the code coverage engine, it is recommended to run this command using another working directory (`--work-dir` option) so that one can easily switch between coverage testing and standard testing (faster to run):
+Running combined code coverage on all components is pretty easy. This generates code coverage reports in an HTML format as well as a short summary in the console. Note that, because code has to be compiled in a particular way to be "instrumentable" by the code coverage engine, it is recommended to run this command using another working directory (`--builddir` option) so that one can easily switch between coverage testing and standard testing (faster to run):
 
 ```
-$ stack test --coverage --fast --work-dir .stack-work-coverage
+$ cabal test all --enable-coverage --builddir .dist-coverage
 ```
 
 Note that, integration tests are excluded from the basic coverage report because the cardano-wallet server runs in a separate process. It it still possible to combine coverage from various sources (see [this article](https://medium.com/@_KtorZ_/continuous-integration-in-haskell-9ad2a73e8e46) for some examples / details).

--- a/docs/contributing/Updating-Dependencies.md
+++ b/docs/contributing/Updating-Dependencies.md
@@ -15,11 +15,9 @@ The default `nix develop` contains build tools, utilities and GHC
 configured with a global package-db which matches `stack.yaml`. This
 is defined in the `devShell` attribute of `flake.nix`.
 
-## Stack
+## Buildkite
 
-On Buildkite, the project will be built with `stack build --nix`. This
-means that all stack commands will run inside the `nix-shell` defined
-by [`nix/stack-shell.nix`](https://github.com/input-output-hk/cardano-wallet/blob/master/nix/stack-shell.nix). If there is a program that is needed by the
+On Buildkite, the project will be built with `cabal build` in a particular Nix shell. The Nix shell provisioned is defined by [`nix/cabal-shell.nix`](https://github.com/input-output-hk/cardano-wallet/blob/master/nix/cabal-shell.nix). If there is a program that is needed by the
 build or tests, make sure that it is present there.
 
 ## nix flake lock

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -27,7 +27,7 @@ In the second case, please refer to the [[hierarchical-deterministic-wallets]] s
 
 ## Is there a reason why I would have to build from src?
 
-If you intend to contribute to Cardano by making code changes to one of the core components, then yes. We recommend using [stack](https://docs.haskellstack.org/en/stable/README/) for a better developer experience.
+If you intend to contribute to Cardano by making code changes to one of the core components, then yes. We recommend using [cabal](https://www.haskell.org/cabal/) for a better developer experience.
 
 If you only intend to use the services as-is then, using either the pre-compiled release artifacts for your appropriate platform or a pre-packaged docker image is preferable.
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -38,7 +38,7 @@ See [[Building]].
 
 If you feel brave enough and want to compile everything from sources, please refer to [[Building]], or the equivalent documentation in each source repository (instructions often appear in `README.md`).
 
-As a pre-requisite, you may want to install and configure [Nix](https://nixos.org/), [stack](https://docs.haskellstack.org/en/stable/README/) or [cabal](https://www.haskell.org/cabal/) depending on your weapon of choice.
+As a pre-requisite, you may want to install and configure [Nix](https://nixos.org/) or [cabal](https://www.haskell.org/cabal/), depending on your weapon of choice.
 
 ## Summary
 

--- a/test/manual/FlakyTests.md
+++ b/test/manual/FlakyTests.md
@@ -2,14 +2,10 @@
 
 Some tests might have been disabled in CI with the `flakyBecauseOf` helper.
 
-Run them locally using 
+Run them locally using:
 
 ```bash
-RUN_FLAKY_TESTS=1 stack test cardano-wallet:integration
+RUN_FLAKY_TESTS=1 cabal test cardano-wallet:integration
 ```
 
-or on Windows:
-```bash
-set RUN_FLAKY_TESTS=1
-cardano-wallet-test-integration.exe
-```
+Running integration tests under Wine is not possible because ouroboros-network doesn't fully work under Wine.


### PR DESCRIPTION
ADP-1540

- Stack is no longer supported, so update our documentation accordingly.

