### PR TITLE
Implement `getStakePoolsSummary'` for Blockfrost

### DIFF
--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -550,17 +550,12 @@ getRewardParams = do
         rationalToCoinViaFloor :: Rational -> Coin
         rationalToCoinViaFloor = Coin . floor
         rPot = fromLovelaces _epochInfoFees <> deltaR1
-        rp = RewardParams
-            { nOpt =
-                fromIntegral _protocolParamsNOpt
-            , a0 =
-                realToFrac _protocolParamsA0
-            , r =
-                rPot
-            , totalStake =
-                fromLovelaces _supplyTotal
-            }
-    pure rp
+    pure RewardParams
+        { nOpt = fromIntegral _protocolParamsNOpt
+        , a0 = realToFrac _protocolParamsA0
+        , r = rPot
+        , totalStake = fromLovelaces _supplyTotal
+        }
 
 fromPoolInfo :: RewardParams -> BF.PoolInfo -> RewardInfoPool
 fromPoolInfo rp BF.PoolInfo{..} = RewardInfoPool


### PR DESCRIPTION
### Issue number

ADP-1422, ADP-1509

### Overview

[Light-mode][] (Epic ADP-1422) aims to make synchronisation to the blockchain faster by trusting an off-chain source of aggregated blockchain data. 

  [light-mode]: https://input-output-hk.github.io/cardano-wallet/design/specs/light-mode

In this pull request, we implement a function `getStakePoolsSummary'` that returns a list of stake pools and, for each pool, information about rewards that inform a delegation choice.

### Details

* Querying the data required for `performanceEstimate` is expensive. In the new reward computation, it will not be needed for all pools, hence we set the value to `1.0` here.
 
### Comments

* Performance: There are about 3k pools on mainnet. Making 3k HTTP requests to Blockforst takes ~20minutes on the free plan. We may have to incrementalize the stake pool listing(s) in the future.