### PR TITLE
Implement `DiscoverTxs` for `SeqState`

### DIFF
--- a/lib/core/bench/db-bench.hs
+++ b/lib/core/bench/db-bench.hs
@@ -379,7 +379,7 @@ mkSeqState numAddrs _ = s
     fillPool (SeqAddressPool pool0) = SeqAddressPool $
         foldl' (\p ix -> AddressPool.update (gen ix) p) pool0 [0 .. numAddrs-1]
       where
-        gen ix = AddressPool.generator pool0 $ toEnum ix
+        gen ix = AddressPool.addressFromIx pool0 $ toEnum ix
 
 ----------------------------------------------------------------------------
 -- Wallet State (Random Scheme) Benchmarks

--- a/lib/core/src/Cardano/Wallet/Address/Pool.hs
+++ b/lib/core/src/Cardano/Wallet/Address/Pool.hs
@@ -263,8 +263,9 @@ discover query pool0 =
         -- TODO: Maybe cache the `generator` in the Pool using lazy evaluation.
         let addr = generator pool0 old
         newtxs <- query addr
-        let pool2 = if mempty == newtxs then pool1 else update addr pool1
-            txs2  = if mempty == newtxs then txs1 else txs1 <> newtxs
+        let (pool2, txs2) = if mempty == newtxs
+                then (pool1, txs1)
+                else (update addr pool1, txs1 <> newtxs)
         case successor pool2 old of
             Nothing    -> pure (txs2, pool2)
             Just next  -> go txs2 pool2 next

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -815,6 +815,7 @@ postWallet
         , Typeable n
         , (k == SharedKey) ~ 'False
         , AddressBookIso s
+        , MaybeLight s
         )
     => ctx
     -> ((SomeMnemonic, Maybe SomeMnemonic) -> Passphrase "encryption" -> k 'RootK XPrv)
@@ -839,6 +840,7 @@ postShelleyWallet
         , HasDBFactory s k ctx
         , HasWorkerRegistry s k ctx
         , IsOurs s RewardAccount
+        , MaybeLight s
         , Typeable s
         , Typeable n
         , (k == SharedKey) ~ 'False
@@ -876,6 +878,7 @@ postAccountWallet
         , WalletKey k
         , HasWorkerRegistry s k ctx
         , IsOurs s RewardAccount
+        , MaybeLight s
         , (k == SharedKey) ~ 'False
         , Typeable n
         , AddressBookIso s

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
@@ -66,9 +66,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , hex
     )
 import Cardano.Wallet.Primitive.AddressDiscovery
-    ( GetPurpose (..), IsOurs (..) )
+    ( DiscoverTxs (..), GetPurpose (..), IsOurs (..), MaybeLight (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
-    ( SeqState, coinTypeAda, purposeBIP44 )
+    ( SeqState, coinTypeAda, discoverSeq, purposeBIP44 )
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase (..), PassphraseHash (..), changePassphraseXPrv )
 import Cardano.Wallet.Primitive.Types
@@ -400,6 +400,9 @@ instance PaymentAddress n IcarusKey
 
 instance IsOurs (SeqState n IcarusKey) RewardAccount where
     isOurs _account state = (Nothing, state)
+
+instance PaymentAddress n IcarusKey => MaybeLight (SeqState n IcarusKey) where
+    maybeDiscover = Just $ DiscoverTxs discoverSeq
 
 {-------------------------------------------------------------------------------
                           Storing and retrieving keys

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -77,11 +77,12 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , mutableAccount
     )
 import Cardano.Wallet.Primitive.AddressDiscovery
-    ( GetPurpose (..), IsOurs (..) )
+    ( DiscoverTxs (..), GetPurpose (..), IsOurs (..), MaybeLight (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( DerivationPrefix (..)
     , SeqState (..)
     , coinTypeAda
+    , discoverSeqWithRewards
     , purposeBIP44
     , purposeCIP1852
     , rewardAccountKey
@@ -396,6 +397,11 @@ instance ToRewardAccount ShelleyKey where
 
 toRewardAccountRaw :: XPub -> RewardAccount
 toRewardAccountRaw = RewardAccount . blake2b224 . xpubPublicKey
+
+instance DelegationAddress n ShelleyKey
+    => MaybeLight (SeqState n ShelleyKey)
+  where
+    maybeDiscover = Just $ DiscoverTxs discoverSeqWithRewards
 
 {-------------------------------------------------------------------------------
                           Storing and retrieving keys

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -67,6 +67,8 @@ module Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , coinTypeAda
     , mkSeqStateFromRootXPrv
     , mkSeqStateFromAccountXPub
+    , discoverSeq
+    , discoverSeqWithRewards
 
     -- ** Benchmarking
     , SeqAnyState (..)
@@ -82,7 +84,8 @@ import Cardano.Address.Script
 import Cardano.Crypto.Wallet
     ( XPrv, XPub )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
+    ( DelegationAddress (..)
+    , Depth (..)
     , DerivationIndex (..)
     , DerivationPrefix (..)
     , DerivationType (..)
@@ -95,6 +98,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , PersistPublicKey (..)
     , Role (..)
     , SoftDerivation (..)
+    , ToRewardAccount (..)
     , WalletKey (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation.MintBurn
@@ -111,6 +115,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , MaybeLight (..)
     , coinTypeAda
     )
+import Cardano.Wallet.Primitive.BlockSummary
+    ( ChainEvents )
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase )
 import Cardano.Wallet.Primitive.Types.Address
@@ -128,7 +134,7 @@ import Control.DeepSeq
 import Control.Monad
     ( unless )
 import Data.Bifunctor
-    ( first )
+    ( first, second )
 import Data.Digest.CRC32
     ( crc32 )
 import Data.Kind
@@ -718,8 +724,54 @@ instance
 instance GetAccount (SeqState n k) k where
     getAccount = accountXPub
 
-instance MaybeLight (SeqState n k) where
-    maybeDiscover = Nothing
+-- | Discover addresses and transactions using an
+-- efficient query @addr -> m txs@.
+-- Does /not/ take 'RewardAccount' into account.
+discoverSeq
+    :: forall n k m. (PaymentAddress n k, Monad m)
+    => (Either Address RewardAccount -> m ChainEvents)
+    -> SeqState n k -> m (ChainEvents, SeqState n k)
+discoverSeq query s@SeqState{internalPool,externalPool} = do
+    (blocks1,int) <- discover internalPool
+    (blocks2,ext) <- discover externalPool
+    pure
+        ( blocks1 <> blocks2
+        , s{internalPool=int,externalPool=ext}
+        )
+  where
+    -- Only enterprise address (for legacy Icarus keys)
+    fromPayment hash = liftPaymentAddress @n hash
+    discover :: SeqAddressPool r k -> m (ChainEvents, SeqAddressPool r k)
+    discover = fmap (second SeqAddressPool)
+        . AddressPool.discover (query . Left . fromPayment) . getPool
+
+-- | Discover addresses and transactions using an
+-- efficient query @addr -> m txs@.
+-- Does take 'RewardAccount' into account.
+discoverSeqWithRewards
+    :: forall n k m. (DelegationAddress n k, ToRewardAccount k, Monad m)
+    => (Either Address RewardAccount -> m ChainEvents)
+    -> SeqState n k -> m (ChainEvents, SeqState n k)
+discoverSeqWithRewards query s@SeqState{internalPool,externalPool,rewardAccountKey} = do
+    blocks0 <- query . Right $ toRewardAccount rewardAccountKey
+    (blocks1,int) <- discover internalPool
+    (blocks2,ext) <- discover externalPool
+    pure
+        ( blocks0 <> blocks1 <> blocks2
+        , s{internalPool=int,externalPool=ext}
+        )
+  where
+    -- Every 'Address' is composed of a payment part and a staking part.
+    -- Ideally, we would want 'query' to give us all transactions
+    -- belonging to a given payment part, regardless of the staking parts
+    -- that are paired with that payment part. 
+    -- Unfortunately, this is not possible at the moment.
+    -- However, fortunately, the staking part is always the same,
+    -- so we supply it here in order to obtain an 'Address' that we can query.
+    fromPayment hash = liftDelegationAddress @n hash rewardAccountKey
+    discover :: SeqAddressPool r k -> m (ChainEvents, SeqAddressPool r k)
+    discover = fmap (second SeqAddressPool)
+        . AddressPool.discover (query . Left . fromPayment) . getPool
 
 {-------------------------------------------------------------------------------
     SeqAnyState

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -278,10 +278,11 @@ newSeqAddressPool
     => key 'AccountK XPub
     -> AddressPoolGap
     -> SeqAddressPool c key
-newSeqAddressPool account g = SeqAddressPool $ AddressPool.new generator gap
+newSeqAddressPool account g =
+    SeqAddressPool $ AddressPool.new addressFromIx gap
   where
     gap = fromIntegral $ getAddressPoolGap g
-    generator ix =
+    addressFromIx ix =
         unsafePaymentKeyFingerprint @key
             ( Proxy @n
             , deriveAddressPublicKey @key account (role @c) ix
@@ -832,7 +833,7 @@ instance KnownNat p => IsOurs (SeqAnyState n k p) Address where
             let
                 pool = getPool $ externalPool inner
                 ix = toEnum $ AddressPool.size pool - AddressPool.gap pool
-                addr = AddressPool.generator pool ix
+                addr = AddressPool.addressFromIx pool ix
                 pool' = AddressPool.update addr pool
                 path = DerivationIndex (getIndex ix) :| []
             in

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
@@ -162,10 +162,10 @@ newSharedAddressPool
     -> Maybe ScriptTemplate
     -> SharedAddressPool key
 newSharedAddressPool g payment delegation =
-    AddressPool.new generator gap
+    AddressPool.new addressFromIx gap
   where
     gap = fromIntegral $ getAddressPoolGap g
-    generator
+    addressFromIx
         = unsafePaymentKeyFingerprint @key
         . constructAddressFromIx @n payment delegation
 

--- a/lib/core/test/unit/Cardano/Wallet/Address/PoolSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Address/PoolSpec.hs
@@ -174,10 +174,12 @@ genAddresses pool = sized $ go 0
     gap = AddressPool.gap pool
     go _    0 = pure []
     go maxi n = do
-        i <- frequency 
-            [ (2, choose (0,maxi))
-            , (2, choose (maxi,maxi+gap-1))
-            , (1, pure (maxi+gap-1)) ]
+        i <- frequency
+            [ (1, choose (0,min maxi 3)) -- generate duplicates
+            , (3, choose (0,maxi))
+            , (3, choose (maxi,maxi+gap-1))
+            , (2, pure (maxi+gap-1))     -- generate at edge of the pool
+            ]
         let addr = AddressPool.generator pool $ toEnum i
         (addr:) <$> go (max i maxi) (n-1)
 

--- a/lib/core/test/unit/Cardano/Wallet/Address/PoolSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Address/PoolSpec.hs
@@ -7,7 +7,7 @@ module Cardano.Wallet.Address.PoolSpec
 import Prelude
 
 import Cardano.Wallet.Address.Pool
-    ( Pool, addresses, generator, prop_consistent, prop_fresh, prop_gap )
+    ( Pool, addressFromIx, addresses, prop_consistent, prop_fresh, prop_gap )
 import Cardano.Wallet.Primitive.Types.Address
     ( AddressState (..) )
 import Data.Bifunctor
@@ -50,7 +50,7 @@ spec = do
         it "prop_consistent . new" $
             prop_consistent testPool
 
-        it "generator satisfies prop_gap and prop_fresh" $
+        it "generated pool always satisfies prop_gap and prop_fresh" $
             forAll (genUsageForGap $ AddressPool.gap testPool) $ \usage ->
                 let pool = fromUsage testPool usage
                 in  all ($ pool) [prop_gap, prop_fresh]
@@ -76,7 +76,7 @@ spec = do
 
 prop_updates :: (Ord addr, Ord ix, Enum ix) => Pool addr ix -> Property
 prop_updates pool = forAll (genUsageForGap $ AddressPool.gap pool) $ \usage ->
-    let addr ix = AddressPool.generator pool ix
+    let addr ix = AddressPool.addressFromIx pool ix
         g       = AddressPool.gap pool
         addrs1  = [ addr ix | (ix,Used) <- zip [toEnum 0..] usage ]
         addrs2  = map (addr . toEnum) [0..2*g]
@@ -91,7 +91,7 @@ prop_updates_order pool0 = forAll genUpdates $ \pool ->
     ===
       AddressPool.addresses (applyUsageInOrder pool0 $ toUsage pool)
   where
-    addr ix = AddressPool.generator pool0 ix
+    addr ix = AddressPool.addressFromIx pool0 ix
     g       = AddressPool.gap pool0
 
     -- generate and apply a random sequence of updates
@@ -147,7 +147,7 @@ fromUsage :: (Ord addr, Enum ix) => Pool addr ix -> [AddressState] -> Pool addr 
 fromUsage pool = AddressPool.loadUnsafe pool
     . Map.fromList . zipWith decorate [(toEnum 0)..]
   where
-    decorate ix status = (generator pool ix, (ix, status))
+    decorate ix status = (addressFromIx pool ix, (ix, status))
 
 -- | Generate address statuses that respect the address gap.
 genUsageForGap :: Int -> Gen [AddressState]
@@ -180,7 +180,7 @@ genAddresses pool = sized $ go 0
             , (3, choose (maxi,maxi+gap-1))
             , (2, pure (maxi+gap-1))     -- generate at edge of the pool
             ]
-        let addr = AddressPool.generator pool $ toEnum i
+        let addr = AddressPool.addressFromIx pool $ toEnum i
         (addr:) <$> go (max i maxi) (n-1)
 
 {-------------------------------------------------------------------------------
@@ -203,7 +203,7 @@ shrinkPool minGap pool
     k = AddressPool.size pool
     n = gap `div` 5
     gap = AddressPool.gap pool
-    minimalPool = AddressPool.new (AddressPool.generator pool) minGap
+    minimalPool = AddressPool.new (AddressPool.addressFromIx pool) minGap
 
 -- | Remove the top @n@ indices and restore the upper @gap@ indices to 'Unused'.
 --

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SharedSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SharedSpec.hs
@@ -138,7 +138,7 @@ prop_addressDiscoveryMakesAddressUsed (CatalystSharedState accXPub' accIx' pTemp
     fromIntegral (Map.size ourAddrs) === (fromIntegral (fromEnum ix + 1) + getAddressPoolGap g)
   where
     sharedState = mkSharedStateFromAccountXPub @n accXPub' accIx' g pTemplate' dTemplate'
-    addr = AddressPool.generator (getPool sharedState) keyIx
+    addr = AddressPool.addressFromIx (getPool sharedState) keyIx
     (Just ix, sharedState') = isShared @n (liftPaymentAddress @n addr) sharedState
     getPool st = case ready st of
         Active pool -> pool
@@ -221,7 +221,7 @@ prop_addressDiscoveryDoesNotChangeGapInvariance (CatalystSharedState accXPub' ac
     fromIntegral (L.length mapOfConsecutiveUnused) === getAddressPoolGap g
   where
     sharedState = mkSharedStateFromAccountXPub @n accXPub' accIx' g pTemplate' dTemplate'
-    addr = AddressPool.generator (getPool sharedState) keyIx
+    addr = AddressPool.addressFromIx (getPool sharedState) keyIx
     (_, sharedState') = isShared @n (liftPaymentAddress @n addr) sharedState
     getPool st = case ready st of
         Active pool -> pool


### PR DESCRIPTION
### Issue number

ADP-1422, ADP-1577

### Overview

[Light-mode][] (Epic ADP-1422) aims to make synchronisation to the blockchain faster by trusting an off-chain source of aggregated blockchain data. 

  [light-mode]: https://input-output-hk.github.io/cardano-wallet/design/specs/light-mode

In this pull request, we implement `discoverSeq`, the "gemstone" 💎 of light-mode. This function uses the query in a `BlockSummary` to discover addresses and corresponding `ChainEvents` using sequential address discovery.

### Details

* `Cardano.Address.Pool.discover` performs address and transaction discovery on the level of address `Pool`.
* `discoverSeq` uses this to provide discovery for key schemes without reward accounts, like `IcarusKey`.
* `discoverSeqWithRewards` uses this provide discovery for key schemes with reward accounts, like `ShelleyKey`.

### Comments

* While `Address.Pool.discover` is tested with property tests, it seems to me that the most sensible way to ensure correctness of `discoverSeq*` is to rely on the type system and careful inspection, as I can't think of any properties that are sufficiently independent (and *not* already covered by ensuring that `discover` is correct) of the original code to add value.