### PR TITLE
E2e testing: Minting/burning

### DIFF
--- a/test/e2e/Gemfile
+++ b/test/e2e/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'cardano_wallet', '~> 0.3.18'
+gem 'cardano_wallet', '~> 0.3.19'
 # gem 'cardano_wallet', path: "~/wb/cardano_wallet"
 gem 'bip_mnemonic', '0.0.4'
 gem 'rake', '12.3.3'

--- a/test/e2e/Gemfile.lock
+++ b/test/e2e/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     bip_mnemonic (0.0.4)
     blake2b (0.10.0)
-    cardano_wallet (0.3.18)
+    cardano_wallet (0.3.19)
       httparty (~> 0.18.0)
     cbor (0.5.9.6)
     diff-lcs (1.4.4)
@@ -36,7 +36,7 @@ PLATFORMS
 DEPENDENCIES
   bip_mnemonic (= 0.0.4)
   blake2b (= 0.10.0)
-  cardano_wallet (~> 0.3.18)
+  cardano_wallet (~> 0.3.19)
   cbor (= 0.5.9.6)
   mustache (= 1.1.1)
   rake (= 12.3.3)

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -605,7 +605,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
     describe "Minting and Burning" do
       def mint(asset_name, quantity, policy_script, address)
-        {
+        mint = {
             'operation' => {
               'mint' =>
                 {
@@ -615,22 +615,24 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
                                }
                 }
             },
-            'policy_script_template' => policy_script,
-            'asset_name' => asset_name
-        }
+            'policy_script_template' => policy_script
+         }
+         mint['asset_name'] = asset_name unless asset_name == nil
+         mint
       end
 
       def burn(asset_name, quantity, policy_script)
-        {
+        burn = {
             'operation' => {
               'burn' => { 'quantity' => quantity,
                           'unit' => 'assets'
                          }
 
              },
-            'policy_script_template' => policy_script,
-            'asset_name' => asset_name
+            'policy_script_template' => policy_script
         }
+        burn['asset_name'] = asset_name unless asset_name == nil
+        burn
       end
 
       ##
@@ -661,7 +663,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         # Minting:
         mint = [mint(asset_name('Token1'), 1000, policy_script1, address),
                 mint(asset_name('Token2'), 1000, policy_script2, address),
-                mint(asset_name('Token3'), 1000, policy_script3, address)
+                mint('', 1000, policy_script3, address)
                ]
         create_policy_key_if_not_exists(@wid)
         tx_constructed, tx_signed, tx_submitted = construct_sign_submit(@wid,
@@ -692,7 +694,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         # Burn half:
         burn = [burn(asset_name('Token1'), 500, policy_script1),
                 burn(asset_name('Token2'), 500, policy_script2),
-                burn(asset_name('Token3'), 500, policy_script3)
+                burn('', 500, policy_script3)
                ]
         tx_constructed, tx_signed, tx_submitted = construct_sign_submit(@wid,
                                                                         payments = nil,
@@ -722,7 +724,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         # Burn all the rest:
         burn = [burn(asset_name('Token1'), 500, policy_script1),
                 burn(asset_name('Token2'), 500, policy_script2),
-                burn(asset_name('Token3'), 500, policy_script3)
+                burn('', 500, policy_script3)
                ]
         tx_constructed, tx_signed, tx_submitted = construct_sign_submit(@wid,
                                                                         payments = nil,

--- a/test/e2e/spec/shelley_spec.rb
+++ b/test/e2e/spec/shelley_spec.rb
@@ -458,6 +458,28 @@ RSpec.describe CardanoWallet::Shelley do
       expect(res).to be_correct_and_respond 200
       expect(res.to_s).to include "acct_xvk"
     end
+
+    it "I can create and get policy key and it's hash" do
+      wid = create_shelley_wallet
+      created = SHELLEY.keys.create_policy_key(wid, PASS, { hash: true })
+      expect(created).to be_correct_and_respond 202
+      expect(created.to_s).to include "policy_vkh"
+
+      get = SHELLEY.keys.get_policy_key(wid, { hash: true })
+      expect(get).to be_correct_and_respond 200
+
+      expect(get.to_s).to eq created.to_s
+
+      created = SHELLEY.keys.create_policy_key(wid, PASS)
+      expect(created).to be_correct_and_respond 202
+      expect(created.to_s).to include "policy_vk"
+      expect(created.to_s).not_to include "policy_vkh"
+
+      get = SHELLEY.keys.get_policy_key(wid)
+      expect(get).to be_correct_and_respond 200
+
+      expect(get.to_s).to eq created.to_s
+    end
   end
 
 end

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -531,8 +531,10 @@ def create_policy_key_if_not_exists(wid)
   if gpkey.code == 403 && gpkey['code'] == "missing_policy_public_key"
     pkey = SHELLEY.keys.create_policy_key(wid, PASS)
     expect(pkey).to be_correct_and_respond 202
+    pkey
+  else
+    gpkey
   end
-  pkey || gpkey
 end
 
 ##

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -526,6 +526,17 @@ def construct_sign_submit(wid,
   [tx_constructed, tx_signed, tx_submitted]
 end
 
+def create_policy_key_if_not_exists(wid)
+  gpkey = SHELLEY.keys.get_policy_key(wid)
+  if gpkey.code == 403 && gpkey['code'] == "missing_policy_public_key"
+    pkey = SHELLEY.keys.create_policy_key(wid, PASS)
+    expect(pkey).to be_correct_and_respond 202
+  end
+  pkey || gpkey
+end
+
+##
+# Plutus helpers
 def get_plutus_tx(file)
   JSON.parse(File.read(File.join(PLUTUS_DIR, file)))
 end


### PR DESCRIPTION
- [x] e2e tests fpr policy keys endpoints
- [x] e2e tests for minting/burning

### Comments
Can be merged after: https://github.com/input-output-hk/cardano-wallet/pull/3199

Some tests are currently `pending` due to issues with mint/burn.
```
    Minting and Burning
      Can mint and then burn
      Can mint and burn with metadata
      Can mint and burn in the same tx (PENDING: TODO MINT: Mint and burn fails in single tx)
      Cannot mint and burn the same asset in single tx (PENDING: TODO MINT: Mint and burn fails in single tx)
      Cannot burn if I don't have it
      Cannot burn with wrong policy_script or more than I have
      Mint to foreign wallet / Cannot burn if I don't have keys (PENDING: TODO MINT: It doesn't mint to foreign wallet!)
      Cannot mint if I make too big transaction
      Mint/Burn quantities
        Cannot mint -9223372036854775808 assets (PENDING: TODO MINT: Mint burn quantities edge cases)
        Cannot burn -9223372036854775808 assets (PENDING: TODO MINT: Mint burn quantities edge cases)
        Cannot mint -1 assets (PENDING: TODO MINT: Mint burn quantities edge cases)
        Cannot burn -1 assets (PENDING: TODO MINT: Mint burn quantities edge cases)
        Cannot mint 0 assets (PENDING: TODO MINT: Mint burn quantities edge cases)
        Cannot burn 0 assets (PENDING: TODO MINT: Mint burn quantities edge cases)
        Cannot mint 9223372036854775808 assets (PENDING: TODO MINT: Mint burn quantities edge cases)
        Cannot burn 9223372036854775808 assets (PENDING: TODO MINT: Mint burn quantities edge cases)
      Mint/Burn asset_name
        Cannot mint if my asset name is too long (PENDING: TODO MINT: asset name too long throws 'Something went wrong' on construct)
        Cannot mint if my asset name is invalid hex (PENDING: TODO MINT: asset name too long throws 'Something went wrong' on construct)
      Mint/Burn invalid policy script
        Cannot mint if my policy script is invalid: cosigner#1
        Cannot mint if my policy script is invalid: {"all"=>["cosigner#0", "cosigner#1"]}
        Cannot mint if my policy script is invalid: {"any"=>["cosigner#0", "cosigner#0"]}
        Cannot mint if my policy script is invalid: {"some"=>{"at_least"=>2, "from"=>["cosigner#0"]}}
        Cannot mint if my policy script is invalid: {"some"=>["cosigner#0"]}

```

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-1574
