### PR TITLE
Light Mode: currentCardanoEra

### DIFF
--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -277,6 +277,7 @@ test-suite unit
       Cardano.Wallet.Shelley.LaunchSpec
       Cardano.Wallet.Shelley.Launch.BlockfrostSpec
       Cardano.Wallet.Shelley.NetworkSpec
+      Cardano.Wallet.Shelley.Network.BlockfrostSpec
       Cardano.Wallet.Shelley.TransactionSpec
       Spec
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -66,5 +66,5 @@ withNetworkLayer tr blockchainSrc net netParams tol =
             in Node.withNetworkLayer tr' net netParams nodeConn ver tol
         BlockfrostSource project ->
             let tr' = BlockfrostNetworkLog >$< tr
-            in Blockfrost.withNetworkLayer tr' project
+            in Blockfrost.withNetworkLayer tr' net project
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -28,6 +28,7 @@ module Cardano.Wallet.Shelley.Network.Blockfrost
 
     -- * Internal
     , getPoolPerformanceEstimate
+    , eraByEpoch
     ) where
 
 import Prelude
@@ -124,7 +125,7 @@ data BlockfrostError
     | InvalidBlockHash BF.BlockHash TextDecodingError
     | InvalidDecentralizationLevelPercentage Double
     | UnknownEraForEpoch EpochNo
-    deriving (Show)
+    deriving (Show, Eq)
 
 newtype BlockfrostException = BlockfrostException BlockfrostError
     deriving stock (Show)

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/Network/BlockfrostSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/Network/BlockfrostSpec.hs
@@ -1,0 +1,41 @@
+module Cardano.Wallet.Shelley.Network.BlockfrostSpec (spec) where
+
+import Prelude
+
+import Cardano.Api
+    ( AnyCardanoEra (..), CardanoEra (..) )
+import Cardano.Wallet.Primitive.Types
+    ( EpochNo )
+import Cardano.Wallet.Shelley.Network.Blockfrost
+    ( eraByEpoch )
+import Data.Foldable
+    ( for_ )
+import Test.Hspec
+    ( Spec, describe, it, shouldBe )
+
+spec :: Spec
+spec = describe "Blockfrost Network" $ do
+    it "determines era by epoch" $ do
+        for_ epochEras $ \(epoch, era) ->
+            eraByEpoch epoch `shouldBe` Right era
+  where
+    epochEras :: [(EpochNo, AnyCardanoEra)]
+    epochEras =
+        [ (329, AnyCardanoEra AlonzoEra)
+        , (298, AnyCardanoEra AlonzoEra)
+        , (297, AnyCardanoEra AlonzoEra)
+        , (295, AnyCardanoEra AlonzoEra)
+        , (290, AnyCardanoEra AlonzoEra)
+        , (289, AnyCardanoEra MaryEra)
+        , (260, AnyCardanoEra MaryEra)
+        , (251, AnyCardanoEra MaryEra)
+        , (250, AnyCardanoEra AllegraEra)
+        , (240, AnyCardanoEra AllegraEra)
+        , (236, AnyCardanoEra AllegraEra)
+        , (235, AnyCardanoEra ShelleyEra)
+        , (220, AnyCardanoEra ShelleyEra)
+        , (202, AnyCardanoEra ShelleyEra)
+        , (201, AnyCardanoEra ByronEra)
+        , (001, AnyCardanoEra ByronEra)
+        , (000, AnyCardanoEra ByronEra)
+        ]

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/Network/BlockfrostSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/Network/BlockfrostSpec.hs
@@ -3,7 +3,7 @@ module Cardano.Wallet.Shelley.Network.BlockfrostSpec (spec) where
 import Prelude
 
 import Cardano.Api
-    ( AnyCardanoEra (..), CardanoEra (..) )
+    ( AnyCardanoEra (..), CardanoEra (..), NetworkId (Mainnet) )
 import Cardano.Wallet.Primitive.Types
     ( EpochNo )
 import Cardano.Wallet.Shelley.Network.Blockfrost
@@ -17,7 +17,7 @@ spec :: Spec
 spec = describe "Blockfrost Network" $ do
     it "determines era by epoch" $ do
         for_ epochEras $ \(epoch, era) ->
-            eraByEpoch epoch `shouldBe` Right era
+            eraByEpoch Mainnet epoch `shouldBe` Right era
   where
     epochEras :: [(EpochNo, AnyCardanoEra)]
     epochEras =

--- a/nix/materialized/stack-nix/cardano-wallet.nix
+++ b/nix/materialized/stack-nix/cardano-wallet.nix
@@ -248,6 +248,7 @@
             "Cardano/Wallet/Shelley/LaunchSpec"
             "Cardano/Wallet/Shelley/Launch/BlockfrostSpec"
             "Cardano/Wallet/Shelley/NetworkSpec"
+            "Cardano/Wallet/Shelley/Network/BlockfrostSpec"
             "Cardano/Wallet/Shelley/TransactionSpec"
             "Spec"
             ];


### PR DESCRIPTION
- [x] I have tested Epoch/Era translation in REPL manually.
- [x] wrote unit test for the Epoch/Era translation.

### Comments

Blockfrost API doesn't expose current Era so its implemented as a translation from current epoch number using a hardcoded table.

```
┌───────┬───────┬─────────┐
│ Epoch │ Major │   Era   │
├───────┼───────┼─────────┤
│  ...  │   6   │ Alonzo  │
│  298  │   6   │ Alonzo  │
├───────┼───────┼─────────┤
│  297  │   5   │ Alonzo  │
│  ...  │   5   │ Alonzo  │
│  290  │   5   │ Alonzo  │
├───────┼───────┼─────────┤
│  289  │   4   │  Mary   │
│  ...  │   4   │  Mary   │
│  251  │   4   │  Mary   │
├───────┼───────┼─────────┤
│  250  │   3   │ Allegra │
│  ...  │   3   │ Allegra │
│  236  │   3   │ Allegra │
├───────┼───────┼─────────┤
│  235  │   2   │ Shelley │
│  ...  │   2   │ Shelley │
│  202  │   2   │ Shelley │
├───────┼───────┼─────────┤
│  201  │   1   │  Byron  │
│  ...  │   1   │  Byron  │
└───────┴───────┴─────────┘
```

When new era type is added its expected that compiler emits a warning about non-exhaustive pattern match, thus forcing developer to update translation table with the corresponding epoch number;

### Issue Number

ADP-1504
