### PR TITLE
Ensure nightly test advances to the correct commit

### DIFF
--- a/.buildkite/push-branch.sh
+++ b/.buildkite/push-branch.sh
@@ -55,7 +55,7 @@ git fetch origin "$other_branch" || true
 if [ -n "${GITHUB_SHA:-}" ]; then
   head="$GITHUB_SHA"
 else
-  head=$(git show-ref -s HEAD)
+  head=$(git rev-parse --verify HEAD)
 fi
 
 advance_branch "$this_branch" "$head"


### PR DESCRIPTION
### Comments

- The `push-branch.sh` script needs to advance the linux-tests-pass branch from it's current revision, to the revision the nightly tests were just run on (HEAD).
- `git show-ref -s HEAD` doesn't return HEAD, but `refs/remotes/origin/HEAD`, i.e. the current revision of the default branch (master). Sometimes this lines up with the revision the nightly tests were just run on (HEAD), but sometimes it does not.
- Use instead `git rev-parse --verify HEAD`, which always returns HEAD, not refs/remotes/origin/HEAD.

### Issue Number

ADP-1584
