### PR TITLE
Speed up `TransactionSpec.signTransaction`.

### DIFF
--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -494,7 +494,7 @@ whenSupportedInEra test era f =
     case test era of
         Nothing ->
             True
-            & label ("feature not supported in " <> show era <> ".")
+            & label ("feature not supported in " <> show era)
         Just supported ->
             f supported
 

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -412,7 +412,7 @@ spec = do
             "signTransaction adds reward account witness when necessary"
             prop_signTransaction_addsRewardAccountKey
         spec_forAllEras
-            "signTransaction adds extra key witness when necessary"
+            "signTransaction adds extra key witnesses when necessary"
             prop_signTransaction_addsExtraKeyWitnesses
         spec_forAllEras
             "signTransaction adds tx in witnesses when necessary"

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -323,6 +323,7 @@ import Test.QuickCheck
     , InfiniteList (..)
     , NonEmptyList (..)
     , Property
+    , Testable
     , arbitraryPrintableChar
     , checkCoverage
     , choose
@@ -407,20 +408,36 @@ spec = do
     balanceTransactionSpec
     estimateSignedTxSizeSpec
     describe "Sign transaction" $ do
-        forAllEras (\era -> it ("signTransaction adds reward account witness when necessary (" <> show era <> ")") $
-            property (prop_signTransaction_addsRewardAccountKey era))
-        forAllEras (\era -> it ("signTransaction adds extra key witness when necessary (" <> show era <> ")") $
-            property (prop_signTransaction_addsExtraKeyWitnesses era))
-        forAllEras (\era -> it ("signTransaction adds tx in witnesses when necessary (" <> show era <> ")") $
-            property (prop_signTransaction_addsTxInWitnesses era))
-        forAllEras (\era -> it ("signTransaction adds collateral witnesses when necessary (" <> show era <> ")") $
-            property (prop_signTransaction_addsTxInCollateralWitnesses era))
-        forAllEras (\era -> it ("signTransaction never removes witnesses (" <> show era <> ")") $
-            property (prop_signTransaction_neverRemovesWitnesses era))
-        forAllEras (\era -> it ("signTransaction never changes tx body (" <> show era <> ")") $
-            property (prop_signTransaction_neverChangesTxBody era))
-        forAllEras (\era -> it ("signTransaction preserves script integrity (" <> show era <> ")") $
-            property (prop_signTransaction_preservesScriptIntegrity era))
+        spec_forAllEras
+            "signTransaction adds reward account witness when necessary"
+            prop_signTransaction_addsRewardAccountKey
+        spec_forAllEras
+            "signTransaction adds extra key witness when necessary"
+            prop_signTransaction_addsExtraKeyWitnesses
+        spec_forAllEras
+            "signTransaction adds tx in witnesses when necessary"
+            prop_signTransaction_addsTxInWitnesses
+        spec_forAllEras
+            "signTransaction adds collateral witnesses when necessary"
+            prop_signTransaction_addsTxInCollateralWitnesses
+        spec_forAllEras
+            "signTransaction never removes witnesses"
+            prop_signTransaction_neverRemovesWitnesses
+        spec_forAllEras
+            "signTransaction never changes tx body"
+            prop_signTransaction_neverChangesTxBody
+        spec_forAllEras
+            "signTransaction preserves script integrity"
+            prop_signTransaction_preservesScriptIntegrity
+
+spec_forAllEras
+    :: Testable prop => String -> (AnyCardanoEra -> prop) -> Spec
+spec_forAllEras description p =
+    describe description $
+    forAllEras
+        $ \(AnyCardanoEra era) -> it (show era)
+        $ property
+        $ p (AnyCardanoEra era)
 
 instance Arbitrary SealedTx where
     arbitrary = sealedTxFromCardano <$> genTx

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -512,6 +512,7 @@ prop_signTransaction_addsRewardAccountKey
     -> Property
 prop_signTransaction_addsRewardAccountKey
     (AnyCardanoEra era) rootXPrv utxo wdrlAmt =
+    withMaxSuccess 10 $
     whenSupportedInEra Cardano.withdrawalsSupportedInEra era $
     \(supported :: Cardano.WithdrawalsSupportedInEra era) -> do
         let
@@ -562,8 +563,7 @@ prop_signTransaction_addsRewardAccountKey
                         ShelleyBasedEra _ ->
                             [mkShelleyWitness txBody rawRewardK]
 
-            checkCoverage $
-                expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
+            expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
 
 instance Arbitrary (ShelleyKey 'RootK XPrv) where
     shrink _ = []
@@ -595,6 +595,7 @@ prop_signTransaction_addsExtraKeyWitnesses
     -> Property
 prop_signTransaction_addsExtraKeyWitnesses
     (AnyCardanoEra era) rootK utxo extraKeys =
+    withMaxSuccess 10 $
     whenSupportedInEra Cardano.extraKeyWitnessesSupportedInEra era $
     \(supported :: Cardano.TxExtraKeyWitnessesSupportedInEra era) -> do
     let
@@ -640,8 +641,7 @@ prop_signTransaction_addsExtraKeyWitnesses
                     ShelleyBasedEra _ ->
                         mkShelleyWitness txBody <$> extraKeys
 
-        checkCoverage $
-            expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
+        expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
 
 instance Arbitrary a => Arbitrary (NonEmpty a) where
     arbitrary = genericArbitrary
@@ -730,7 +730,8 @@ prop_signTransaction_addsTxInWitnesses
     -- ^ Keys
     -> Property
 prop_signTransaction_addsTxInWitnesses
-    (AnyCardanoEra era) rootK extraKeysNE = do
+    (AnyCardanoEra era) rootK extraKeysNE =
+    withMaxSuccess 10 $ do
 
     let extraKeys = NE.toList extraKeysNE
 
@@ -772,8 +773,7 @@ prop_signTransaction_addsTxInWitnesses
                         ShelleyBasedEra _ ->
                             mkShelleyWitness txBody <$> extraKeys
 
-            checkCoverage $
-                expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
+            expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
 
 prop_signTransaction_addsTxInCollateralWitnesses
     :: AnyCardanoEra
@@ -785,6 +785,7 @@ prop_signTransaction_addsTxInCollateralWitnesses
     -> Property
 prop_signTransaction_addsTxInCollateralWitnesses
     (AnyCardanoEra era) rootK extraKeysNE =
+    withMaxSuccess 10 $
     whenSupportedInEra Cardano.collateralSupportedInEra era $
     \(supported :: Cardano.CollateralSupportedInEra era) -> do
 
@@ -825,9 +826,7 @@ prop_signTransaction_addsTxInCollateralWitnesses
                             ShelleyBasedEra _ ->
                                 mkShelleyWitness txBody <$> extraKeys
 
-                checkCoverage $
-                    expectedWits
-                        `checkSubsetOf` (getSealedTxWitnesses sealedTx')
+                expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
 
 prop_signTransaction_neverRemovesWitnesses
     :: AnyCardanoEra
@@ -841,6 +840,7 @@ prop_signTransaction_neverRemovesWitnesses
     -> Property
 prop_signTransaction_neverRemovesWitnesses
     (AnyCardanoEra era) rootK utxo extraKeys =
+    withMaxSuccess 10 $
     forAll (genTxInEra era) $ \tx -> do
         let
             tl = testTxLayer
@@ -857,7 +857,7 @@ prop_signTransaction_neverRemovesWitnesses
             witnessesAfter = getSealedTxWitnesses sealedTx'
 
         checkCoverage
-            $ cover 30 (not $ null witnessesBefore) "witnesses non-empty before"
+            $ cover 10 (not $ null witnessesBefore) "witnesses non-empty before"
             $ witnessesBefore `checkSubsetOf` witnessesAfter
 
 prop_signTransaction_neverChangesTxBody
@@ -872,6 +872,7 @@ prop_signTransaction_neverChangesTxBody
     -> Property
 prop_signTransaction_neverChangesTxBody
     (AnyCardanoEra era) rootK utxo extraKeys =
+    withMaxSuccess 10 $
     forAll (genTxInEra era) $ \tx -> do
         let
             tl = testTxLayer
@@ -907,6 +908,7 @@ prop_signTransaction_preservesScriptIntegrity
     -- ^ UTxO of wallet
     -> Property
 prop_signTransaction_preservesScriptIntegrity (AnyCardanoEra era) rootK utxo =
+    withMaxSuccess 10 $
     whenSupportedInEra Cardano.scriptDataSupportedInEra era $ \_supported ->
     forAll (genTxInEra era) $ \tx -> do
         let


### PR DESCRIPTION
## Issue Number

ADP-1485

## Summary

This PR:

- adjusts `checkSubsetOf` to use set-based lookups instead of repeated list traversals.
- adjusts `signTransaction` properties to only test 10 examples per property, rather than 100.

This results in a substantial reduction in total time required to run the `signTransaction` tests:

```
Before:  530 ± 10 seconds (over 4 runs)
After:    48 ±  2 seconds (over 4 runs)
```

## Additional Improvements

This PR also:

- introduces function `spec_forAllEras` to eliminate some repetition in the `signTransaction` spec .
- makes the output of `signTransaction` property tests more readable, so that the name of each property is written once as a section header, rather than being repeated for every single era. (The individual eras are still as subsections.)

```hs
Cardano.Wallet.Shelley.Transaction                                                         
  Sign transaction                                                                                                                                                                        signTransaction adds reward account witness when necessary    
      ByronEra                                                                             
        +++ OK, passed 10 tests (100% feature not supported in ByronEra).
      ShelleyEra (2144ms)
        +++ OK, passed 10 tests.
      AllegraEra (2143ms)
        +++ OK, passed 10 tests.
      MaryEra (2142ms)
        +++ OK, passed 10 tests.
      AlonzoEra (2142ms)
        +++ OK, passed 10 tests.
    signTransaction adds extra key witnesses when necessary
      ByronEra
        +++ OK, passed 10 tests (100% feature not supported in ByronEra).
      ShelleyEra
        +++ OK, passed 10 tests (100% feature not supported in ShelleyEra).
      AllegraEra
        +++ OK, passed 10 tests (100% feature not supported in AllegraEra).
      MaryEra
        +++ OK, passed 10 tests (100% feature not supported in MaryEra).
      AlonzoEra (686ms)
        +++ OK, passed 10 tests.
```