### PR TITLE
Fix haskell-language-server build

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -52,6 +52,16 @@ steps:
       queue: benchmark
     if: 'build.env("step") == null || build.env("step") =~ /bench-latency/'
 
+  - label: 'Full cabal build'
+    command:
+      - "mkdir -p config && echo '{  outputs = _: { withCabalCache = true; }; }'  > config/flake.nix"
+      - "nix develop --override-input customConfig path:./config .#cabal --command scripts/buildkite/cabal-ci.sh build"
+    env:
+      IS_NIGHTLY: "true"
+    agents:
+      system: x86_64-linux
+    if: 'build.env("step") == null || build.env("step") =~ /cabal/'
+
   # TODO: ADP-549 Port migrations test to shelley
   # - label: 'Database Migrations Test'
   #   commands:

--- a/scripts/buildkite/cabal-ci.sh
+++ b/scripts/buildkite/cabal-ci.sh
@@ -70,8 +70,6 @@ if [ "$job" = build ]; then
 
   echo "+++ haskell-language-server"
   ln -sf hie-direnv.yaml hie.yaml
-  # hie-bios occasionally segfaults. Re-running is usually enough to overcome the
-  # segfault.
 
   nix develop --command "$(dirname "$0")/hls-ci.sh"
 fi

--- a/scripts/buildkite/cabal-ci.sh
+++ b/scripts/buildkite/cabal-ci.sh
@@ -67,4 +67,11 @@ if [ "$job" = build ]; then
 
   echo "+++ Building cardano-wallet"
   cabal "${cabal_args[@]}" build all
+
+  echo "+++ haskell-language-server"
+  ln -sf hie-direnv.yaml hie.yaml
+  # hie-bios occasionally segfaults. Re-running is usually enough to overcome the
+  # segfault.
+
+  nix develop --command "$(dirname "$0")/hls-ci.sh"
 fi

--- a/scripts/buildkite/hls-ci.sh
+++ b/scripts/buildkite/hls-ci.sh
@@ -4,8 +4,10 @@ set -euo pipefail
 
 . "$(dirname "$0")/../cabal-lib.sh"
 
+# hie-bios occasionally segfaults. Re-running is usually enough to overcome the
+# segfault.
 hie-bios check lib/core/src/Cardano/Wallet.hs || true
 
 hie-bios check lib/core/src/Cardano/Wallet.hs
 
-printf '%s\0' $(list_sources) | xargs -0 haskell-language-server
+haskell-language-server lib/core/src/Cardano/Wallet.hs

--- a/scripts/buildkite/hls-ci.sh
+++ b/scripts/buildkite/hls-ci.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+. "$(dirname "$0")/../cabal-lib.sh"
+
+hie-bios check lib/core/src/Cardano/Wallet.hs || true
+
+hie-bios check lib/core/src/Cardano/Wallet.hs
+
+printf '%s\0' $(list_sources) | xargs -0 haskell-language-server

--- a/scripts/buildkite/hls-ci.sh
+++ b/scripts/buildkite/hls-ci.sh
@@ -10,4 +10,11 @@ hie-bios check lib/core/src/Cardano/Wallet.hs || true
 
 hie-bios check lib/core/src/Cardano/Wallet.hs
 
-haskell-language-server lib/core/src/Cardano/Wallet.hs
+if [ -z  ${IS_NIGHTLY+x} ]; then
+  # If not nightly, just check one file.
+  haskell-language-server lib/core/src/Cardano/Wallet.hs
+else
+  # If nightly, execute haskell-language-server on every file in the project.
+  mapfile -t srcs < <(list_sources)
+  haskell-language-server "${srcs[@]}"
+fi

--- a/scripts/cabal-lib.sh
+++ b/scripts/cabal-lib.sh
@@ -23,8 +23,11 @@ get_cabal_version() {
 }
 
 list_sources() {
+  # Exclude lib/core-integration/extra. Those files are Plutus scripts intended
+  # to be serialised for use in the tests. They are not intended to be built
+  # with the project.
   # Exclude prototypes dir because it's a different project.
-  git ls-files 'lib/**/*.hs' | grep -v Main.hs | grep -v prototypes/
+  git ls-files 'lib/**/*.hs' | grep -v Main.hs | grep -v prototypes/ | grep -v lib/core-integration/extra
 }
 
 # usage: query_plan_json PACKAGE COMP:NAME KEY

--- a/scripts/cabal-lib.sh
+++ b/scripts/cabal-lib.sh
@@ -72,6 +72,7 @@ ghci_flags() {
 -fwarn-unused-binds
 -fwarn-unused-imports
 -fwarn-orphans
+-fprint-potential-instances
 -Wno-missing-home-modules
 EOF
 

--- a/scripts/cabal-lib.sh
+++ b/scripts/cabal-lib.sh
@@ -10,7 +10,8 @@ cabal_opts=("--builddir=$builddir")
 plan_json=$builddir/cache/plan.json
 
 list_cabal_files() {
-  git ls-files '*.cabal'
+  # Exclude prototypes dir because it's a different project.
+  git ls-files '*.cabal' | grep -v prototypes/
 }
 
 list_packages() {
@@ -22,7 +23,8 @@ get_cabal_version() {
 }
 
 list_sources() {
-  git ls-files 'lib/**/*.hs' | grep -v Main.hs
+  # Exclude prototypes dir because it's a different project.
+  git ls-files 'lib/**/*.hs' | grep -v Main.hs | grep -v prototypes/
 }
 
 # usage: query_plan_json PACKAGE COMP:NAME KEY


### PR DESCRIPTION
### Issue Number

ADP-1612

### Summary

I've fixed the **haskell-language-server** build so that I could include it in my nix developer documentation (ADP-1536).

- Alters the **hie-bios** invocation to skip files:
  - In the prototype/ directory, because this directory has a separate cabal.project file and so will need a separate hie-bios invocation.
  - In the lib/core-integration/extra/ directory, because these are Plutus scripts intended to be serialised and placed in the tests, they are not intended to be built with the project.
- Includes a **hie-bios** invocation in the Buildkite build so that the **haskell-language-server** and **hie-bios** can be tested on each commit (preventing future breakages).
- Adds documentation on how to configure, use, and troubleshoot **haskell-language-server**.
- Setup **haskell-language-server** to check every file in the project on a nightly basis (takes >30 mins on Buildkite, so don't want to do it per-commit). I've also signed myself up to be notified of nightly build failures.



