### PR TITLE
Make `UTxOIndex` agnostic to the distinction between ada and non-ada assets.

### DIFF
--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -142,7 +142,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.Tx
     ( TokenBundleSizeAssessment (..), TokenBundleSizeAssessor (..) )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
-    ( Asset (..), SelectionFilterNew (..), UTxOIndex (..) )
+    ( Asset (..), SelectionFilter (..), UTxOIndex (..) )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( IsUTxOSelection, UTxOSelection, UTxOSelectionNonEmpty )
 import Control.Monad.Extra
@@ -1273,7 +1273,7 @@ selectCoinQuantity =
 selectMatchingQuantity
     :: forall m utxoSelection u. (MonadRandom m, Ord u)
     => IsUTxOSelection utxoSelection u
-    => NonEmpty (SelectionFilterNew Asset)
+    => NonEmpty (SelectionFilter Asset)
         -- ^ A list of selection filters to be traversed from left-to-right,
         -- in descending order of priority.
     -> SelectionLimit
@@ -1287,7 +1287,7 @@ selectMatchingQuantity filters limit s
     | limitReached =
         pure Nothing
     | otherwise =
-        (updateState =<<) <$> UTxOIndex.selectRandomWithPriorityNew
+        (updateState =<<) <$> UTxOIndex.selectRandomWithPriority
             (UTxOSelection.leftoverIndex s) filters
   where
     limitReached = case limit of

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
@@ -57,9 +57,13 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex
     , disjoint
 
     -- * Selection
+    , Asset (..)
     , SelectionFilter (..)
+    , SelectionFilterNew (..)
     , selectRandom
+    , selectRandomNew
     , selectRandomWithPriority
+    , selectRandomWithPriorityNew
 
     ) where
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
@@ -45,6 +45,7 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex
 
     -- * Queries
     , assets
+    , assetsNew
     , balance
     , lookup
     , member

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
@@ -44,7 +44,7 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex
     , partition
 
     -- * Queries
-    , assetsNew
+    , assets
     , balance
     , lookup
     , member
@@ -57,9 +57,9 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex
 
     -- * Selection
     , Asset (..)
-    , SelectionFilterNew (..)
-    , selectRandomNew
-    , selectRandomWithPriorityNew
+    , SelectionFilter (..)
+    , selectRandom
+    , selectRandomWithPriority
 
     ) where
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
@@ -44,7 +44,6 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex
     , partition
 
     -- * Queries
-    , assets
     , assetsNew
     , balance
     , lookup
@@ -58,11 +57,8 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex
 
     -- * Selection
     , Asset (..)
-    , SelectionFilter (..)
     , SelectionFilterNew (..)
-    , selectRandom
     , selectRandomNew
-    , selectRandomWithPriority
     , selectRandomWithPriorityNew
 
     ) where

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -78,8 +78,11 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
 
     -- * Selection
     , SelectionFilter (..)
+    , SelectionFilterNew (..)
     , selectRandom
+    , selectRandomNew
     , selectRandomWithPriority
+    , selectRandomWithPriorityNew
 
     ----------------------------------------------------------------------------
     -- Internal Interface

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -168,7 +168,18 @@ import qualified Data.Set.Strict.NonEmptySet as NonEmptySet
 -- the 'checkInvariant' function.
 --
 data UTxOIndex u = UTxOIndex
-    { assetsAll
+    { indexAll
+        :: !(Map Asset (NonEmptySet u))
+        -- An index of all entries that contain the given asset.
+    , indexSingletons
+        :: !(Map Asset (NonEmptySet u))
+        -- An index of all entries that contain the given asset and no other
+        -- assets.
+    , indexPairs
+        :: !(Map Asset (NonEmptySet u))
+        -- An index of all entries that contain the given asset and exactly
+        -- one other asset.
+    , assetsAll
         :: !(Map AssetId (NonEmptySet u))
         -- An index of all entries that contain at least one non-ada asset.
     , assetsSingleton
@@ -196,7 +207,10 @@ instance NFData u => NFData (UTxOIndex u)
 --
 empty :: UTxOIndex u
 empty = UTxOIndex
-    { assetsAll = Map.empty
+    { indexAll = Map.empty
+    , indexSingletons = Map.empty
+    , indexPairs = Map.empty
+    , assetsAll = Map.empty
     , assetsSingleton = Map.empty
     , coins = Set.empty
     , balance = TokenBundle.empty

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -520,6 +520,21 @@ selectRandomWithPriority
 selectRandomWithPriority i =
     firstJustM (selectRandom i) . NE.toList
 
+-- TODO:
+--
+-- Rename this to 'selectRandomWithPriority' once the old function has been
+-- removed.
+--
+selectRandomWithPriorityNew
+    :: (MonadRandom m, Ord u)
+    => UTxOIndex u
+    -> NonEmpty (SelectionFilterNew Asset)
+    -- ^ A list of selection filters to be traversed in descending order of
+    -- priority, from left to right.
+    -> m (Maybe ((u, TokenBundle), UTxOIndex u))
+selectRandomWithPriorityNew i =
+    firstJustM (selectRandomNew i) . NE.toList
+
 --------------------------------------------------------------------------------
 -- Internal Interface
 --------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -63,6 +63,7 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
 
     -- * Queries
     , assets
+    , assetsNew
     , balance
     , lookup
     , member
@@ -353,6 +354,13 @@ partition f = bimap fromSequence fromSequence . L.partition (f . fst) . toList
 --
 assets :: UTxOIndex u -> Set AssetId
 assets = Map.keysSet . assetsAll
+
+-- TODO:
+--
+-- Rename this function to 'assets' once the old function has been removed.
+--
+assetsNew :: UTxOIndex u -> Set Asset
+assetsNew = Map.keysSet . indexAll
 
 -- | Returns the value corresponding to the given UTxO identifier.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -871,10 +871,39 @@ indexIsMinimal i = F.and
         & F.all (\(a, u) -> F.all (entryHasSingletonAsset a) u)
     , coins i
         & F.all entryIsCoin
+    , indexAll i
+        & Map.toList
+        & F.all (\(a, u) -> F.all (entryHasAssetNew a) u)
+    , indexSingletons i
+        & Map.toList
+        & F.all (\(a, u) -> F.all (entryHasOneAsset a) u)
+    , indexPairs i
+        & Map.toList
+        & F.all (\(a, u) -> F.all (entryHasTwoAssetsWith a) u)
     ]
   where
     entryHasAsset :: AssetId -> u -> Bool
     entryHasAsset a = entryMatches (`TokenBundle.hasQuantity` a)
+
+    -- TODO:
+    --
+    -- Rename this to 'entryHasAsset', once the old 'entryHasAsset' has been
+    -- removed.
+    --
+    entryHasAssetNew :: Asset -> u -> Bool
+    entryHasAssetNew a = entryMatches (`tokenBundleHasAsset` a)
+
+    entryHasOneAsset :: Asset -> u -> Bool
+    entryHasOneAsset a = entryMatches $ \b -> and
+        [ b `tokenBundleHasAsset` a
+        , tokenBundleAssetCount b == 1
+        ]
+
+    entryHasTwoAssetsWith :: Asset -> u -> Bool
+    entryHasTwoAssetsWith a = entryMatches $ \b -> and
+        [ b `tokenBundleHasAsset` a
+        , tokenBundleAssetCount b == 2
+        ]
 
     entryHasSingletonAsset :: AssetId -> u -> Bool
     entryHasSingletonAsset a = entryMatches $

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -534,6 +534,20 @@ data BundleCategory
     | IsCoinWithMultipleAssets (Set AssetId)
     deriving (Eq, Show)
 
+-- | Represents different categories of token bundles.
+--
+-- TODO:
+--
+-- Rename this to 'BundleCategory', once the old 'BundleCategory' has been
+-- removed.
+--
+data BundleCategoryNew asset
+    = BundleWithNoAssets
+    | BundleWithOneAsset asset
+    | BundleWithTwoAssets (asset, asset)
+    | BundleWithMultipleAssets (Set asset)
+    deriving (Eq, Show)
+
 -- | Categorizes a token bundle by what kind of assets it contains.
 --
 categorizeTokenBundle :: TokenBundle -> BundleCategory
@@ -543,6 +557,22 @@ categorizeTokenBundle b = case F.toList bundleAssets of
     _   -> IsCoinWithMultipleAssets bundleAssets
   where
     bundleAssets = TokenBundle.getAssets b
+
+-- | Categorizes a token bundle by how many assets it contains.
+--
+-- TODO:
+--
+-- Rename this to 'categorizeTokenBundle', once the old 'categorizeTokenBundle'
+-- has been removed.
+--
+categorizeTokenBundleNew :: TokenBundle -> BundleCategoryNew Asset
+categorizeTokenBundleNew b = case F.toList bundleAssets of
+    [      ] -> BundleWithNoAssets
+    [a     ] -> BundleWithOneAsset a
+    [a1, a2] -> BundleWithTwoAssets (a1, a2)
+    _        -> BundleWithMultipleAssets bundleAssets
+  where
+    bundleAssets = tokenBundleAssets b
 
 -- | Returns the set of keys for entries that have no assets other than ada.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -394,9 +394,15 @@ disjoint i1 i2 = universe i1 `Map.disjoint` universe i2
 --
 data SelectionFilter asset
     = SelectSingleton asset
+      -- ^ Matches UTxOs that contain only the given asset and no other assets.
     | SelectPairWith asset
+      -- ^ Matches UTxOs that contain the given asset and exactly one other
+      -- asset.
     | SelectAnyWith asset
+      -- ^ Matches UTxOs that contain the given asset and any number of other
+      -- assets.
     | SelectAny
+      -- ^ Matches all UTxOs regardless of what assets they contain.
     deriving (Eq, Foldable, Functor, Show, Traversable)
 
 -- | Selects an entry at random from the index according to the given filter.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -319,11 +319,24 @@ delete u i =
                 . over #assetsAll (`deleteEntry` a)
             IsCoinWithMultipleAssets as ->
                 over #assetsAll (flip (F.foldl' deleteEntry) as)
+        & case categorizeTokenBundleNew b of
+            BundleWithNoAssets -> id
+            BundleWithOneAsset a -> id
+                . over #indexAll (`deleteEntry` a)
+                . over #indexSingletons (`deleteEntry` a)
+            BundleWithTwoAssets (a1, a2) -> id
+                . over #indexAll (`deleteEntry` a1)
+                . over #indexAll (`deleteEntry` a2)
+                . over #indexPairs (`deleteEntry` a1)
+                . over #indexPairs (`deleteEntry` a2)
+            BundleWithMultipleAssets as -> id
+                . over #indexAll (flip (F.foldl' deleteEntry) as)
 
     deleteEntry
-        :: Map AssetId (NonEmptySet u)
-        -> AssetId
-        -> Map AssetId (NonEmptySet u)
+        :: Ord asset
+        => Map asset (NonEmptySet u)
+        -> asset
+        -> Map asset (NonEmptySet u)
     deleteEntry m a = Map.update (NonEmptySet.delete u) a m
 
 -- | Deletes multiple entries from an index.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -920,12 +920,26 @@ indexIsMinimal i = F.and
 --
 -- In particular, the set of assets in the cached 'balance' must be:
 --
---    - equal to the set of assets in 'assetsAll'
---    - a superset of the set of assets in 'assetsSingleton'.
+--    - equal to the set of assets in 'indexAll'
+--    - a superset of the set of assets in 'indexSingletons'.
+--    - a superset of the set of assets in 'indexPairs'.
 --
 assetsConsistent :: UTxOIndex u -> Bool
-assetsConsistent i = (&&)
-    (Map.keysSet (assetsAll i) == balanceAssets)
-    (Map.keysSet (assetsSingleton i) `Set.isSubsetOf` balanceAssets)
+assetsConsistent i = and
+    [ Map.keysSet (assetsAll i) == balanceAssets
+    , Map.keysSet (assetsSingleton i) `Set.isSubsetOf` balanceAssets
+    , Map.keysSet (indexAll i)
+        == balanceAssetsNew
+    , Map.keysSet (indexSingletons i)
+        `Set.isSubsetOf` balanceAssetsNew
+    , Map.keysSet (indexPairs i)
+        `Set.isSubsetOf` balanceAssetsNew
+    ]
   where
     balanceAssets = TokenBundle.getAssets (balance i)
+
+    -- TODO:
+    --
+    -- Rename to 'balanceAssets', once the old 'balanceAssets' has been removed.
+    --
+    balanceAssetsNew = tokenBundleAssets (balance i)

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -545,7 +545,7 @@ prop_Large_UTxOIndex_coverage (Large index) =
             "UTxO set size >= 3072 entries"
         True
   where
-    assetCount = Set.size $ UTxOIndex.assets index
+    assetCount = Set.size $ UTxOIndex.assetsNew index
     entryCount = UTxOIndex.size index
 
 --------------------------------------------------------------------------------

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -140,7 +140,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
 import Cardano.Wallet.Primitive.Types.Tx
     ( TokenBundleSizeAssessment (..), TokenBundleSizeAssessor (..) )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
-    ( Asset (..), SelectionFilter (..), SelectionFilterNew (..), UTxOIndex )
+    ( Asset (..), SelectionFilterNew (..), UTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
     ( genUTxOIndex, genUTxOIndexLarge, genUTxOIndexLargeN, shrinkUTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
@@ -344,7 +344,7 @@ spec = describe "Cardano.Wallet.CoinSelection.Internal.BalanceSpec" $
 
         it "prop_assetSelectionLens_givesPriorityToSingletonAssets" $
             property prop_assetSelectionLens_givesPriorityToSingletonAssets
-        it "prop_coinSelectonLens_givesPriorityToCoins" $
+        it "prop_coinSelectionLens_givesPriorityToCoins" $
             property prop_coinSelectionLens_givesPriorityToCoins
 
     parallel $ describe "Boundary tests" $ do
@@ -1765,7 +1765,8 @@ prop_coinSelectionLens_givesPriorityToCoins
     -> Property
 prop_coinSelectionLens_givesPriorityToCoins (Blind (Small u)) =
     entryCount > 0 ==> monadicIO $ do
-        hasCoin <- isJust <$> run (UTxOIndex.selectRandom u WithAdaOnly)
+        hasCoin <- isJust <$>
+            run (UTxOIndex.selectRandomNew u (SelectSingleton AssetLovelace))
         monitor $ cover 20 hasCoin
             "There is at least one coin"
         monitor $ cover 1 (not hasCoin)

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -526,7 +526,7 @@ prop_Small_UTxOIndex_coverage (Small index) =
             "UTxO set size > 32 entries"
         True
   where
-    assetCount = Set.size $ UTxOIndex.assets index
+    assetCount = Set.size $ UTxOIndex.assetsNew index
     entryCount = UTxOIndex.size index
 
 prop_Large_UTxOIndex_coverage :: Large (UTxOIndex TestUTxO) -> Property

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -140,7 +140,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
 import Cardano.Wallet.Primitive.Types.Tx
     ( TokenBundleSizeAssessment (..), TokenBundleSizeAssessor (..) )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
-    ( Asset (..), SelectionFilterNew (..), UTxOIndex )
+    ( Asset (..), SelectionFilter (..), UTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
     ( genUTxOIndex, genUTxOIndexLarge, genUTxOIndexLargeN, shrinkUTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
@@ -526,7 +526,7 @@ prop_Small_UTxOIndex_coverage (Small index) =
             "UTxO set size > 32 entries"
         True
   where
-    assetCount = Set.size $ UTxOIndex.assetsNew index
+    assetCount = Set.size $ UTxOIndex.assets index
     entryCount = UTxOIndex.size index
 
 prop_Large_UTxOIndex_coverage :: Large (UTxOIndex TestUTxO) -> Property
@@ -545,7 +545,7 @@ prop_Large_UTxOIndex_coverage (Large index) =
             "UTxO set size >= 3072 entries"
         True
   where
-    assetCount = Set.size $ UTxOIndex.assetsNew index
+    assetCount = Set.size $ UTxOIndex.assets index
     entryCount = UTxOIndex.size index
 
 --------------------------------------------------------------------------------
@@ -1728,7 +1728,7 @@ prop_assetSelectionLens_givesPriorityToSingletonAssets
 prop_assetSelectionLens_givesPriorityToSingletonAssets (Blind (Small u)) =
     nonAdaAssetCount >= 2 ==> monadicIO $ do
         hasSingletonAsset <- isJust <$>
-            run (UTxOIndex.selectRandomNew u $
+            run (UTxOIndex.selectRandom u $
             SelectPairWith (Asset nonAdaAsset))
         monitor $ cover 20 hasSingletonAsset
             "There is at least one singleton entry that matches"
@@ -1766,7 +1766,7 @@ prop_coinSelectionLens_givesPriorityToCoins
 prop_coinSelectionLens_givesPriorityToCoins (Blind (Small u)) =
     entryCount > 0 ==> monadicIO $ do
         hasCoin <- isJust <$>
-            run (UTxOIndex.selectRandomNew u (SelectSingleton AssetLovelace))
+            run (UTxOIndex.selectRandom u (SelectSingleton AssetLovelace))
         monitor $ cover 20 hasCoin
             "There is at least one coin"
         monitor $ cover 1 (not hasCoin)
@@ -4412,7 +4412,7 @@ utxoIndexNonAdaAssets
     = Set.fromList
     . Maybe.mapMaybe toNonAdaAsset
     . Set.toList
-    . UTxOIndex.assetsNew
+    . UTxOIndex.assets
 
 toNonAdaAsset :: Asset -> Maybe AssetId
 toNonAdaAsset = \case

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -1727,6 +1727,24 @@ prop_assetSelectionLens_givesPriorityToSingletonAssets
     -> Property
 prop_assetSelectionLens_givesPriorityToSingletonAssets (Blind (Small u)) =
     nonAdaAssetCount >= 2 ==> monadicIO $ do
+
+        -- TODO: ADP-1449
+        -- Use 'SelectSingleton' rather than 'SelectPairWith'.
+        --
+        -- Ideally, this function would test using 'SelectSingleton', rather
+        -- than 'SelectPairWith'.
+        --
+        -- However, our 'TokenBundle' generators currently have a distribution
+        -- that is skewed toward token bundles with *non-zero* ada quantities.
+        --
+        -- This means that only a *very small* proportion of generated token
+        -- bundles will have a single non-ada asset and no ada, and only very
+        -- few token bundles will be matched by 'SelectSingleton'.
+        --
+        -- Therefore, to ensure that we get sufficient coverage, we use the
+        -- 'SelectPairWith' filter condition, which will not match bundles with
+        -- more than two assets.
+        --
         hasSingletonAsset <- isJust <$>
             run (UTxOIndex.selectRandom u $
             SelectPairWith (Asset nonAdaAsset))

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -657,12 +657,12 @@ prop_selectRandom_all_withAsset i a = checkCoverage $ monadicIO $ do
 -- | Attempt to select all entries with only the given asset from the index.
 --
 prop_selectRandom_all_withAssetOnly
-    :: UTxOIndex TestUTxO -> AssetId -> Property
+    :: UTxOIndex TestUTxO -> Asset -> Property
 prop_selectRandom_all_withAssetOnly i a = checkCoverage $ monadicIO $ do
-    (selectedEntries, i') <- run $ selectAll (WithAssetOnly a) i
-    monitor $ cover 50 (a `Set.member` UTxOIndex.assets i)
+    (selectedEntries, i') <- run $ selectAllNew (SelectSingleton a) i
+    monitor $ cover 50 (a `Set.member` UTxOIndex.assetsNew i)
         "index has the specified asset"
-    monitor $ cover 50 (Set.size (UTxOIndex.assets i) > 1)
+    monitor $ cover 50 (Set.size (UTxOIndex.assetsNew i) > 1)
         "index has more than one asset"
     monitor $ cover 10 (not (null selectedEntries))
         "selected at least one entry"
@@ -826,9 +826,9 @@ tokenBundleHasAsset = TokenBundle.hasQuantity
 -- | Returns 'True' if (and only if) the given token bundle has a non-zero
 --   quantity of the given asset and no other non-ada assets.
 --
-tokenBundleHasAssetOnly :: TokenBundle -> AssetId -> Bool
+tokenBundleHasAssetOnly :: TokenBundle -> Asset -> Bool
 tokenBundleHasAssetOnly b a = (== [a])
-    $ Set.toList $ TokenBundle.getAssets b
+    $ Set.toList $ UTxOIndex.tokenBundleAssets b
 
 -- | Returns 'True' if (and only if) the given token bundle contains no
 --   assets other than ada.

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -465,9 +465,9 @@ prop_SelectionFilterNew_coverage selectionFilter = checkCoverage $ property
 --
 -- This should always return 'Nothing'.
 --
-prop_selectRandom_empty :: SelectionFilter -> Property
+prop_selectRandom_empty :: SelectionFilterNew Asset -> Property
 prop_selectRandom_empty f = monadicIO $ do
-    result <- run $ UTxOIndex.selectRandom (UTxOIndex.empty @TestUTxO) f
+    result <- run $ UTxOIndex.selectRandomNew (UTxOIndex.empty @TestUTxO) f
     assert $ isNothing result
 
 -- | Attempt to select a random entry from a singleton index with entry 'e'.

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -581,12 +581,12 @@ prop_selectRandom_one_withAsset i a = checkCoverage $ monadicIO $ do
 -- quantity of the asset and no other assets.
 --
 prop_selectRandom_one_withAssetOnly
-    :: UTxOIndex TestUTxO -> AssetId -> Property
+    :: UTxOIndex TestUTxO -> Asset -> Property
 prop_selectRandom_one_withAssetOnly i a = checkCoverage $ monadicIO $ do
-    result <- run $ UTxOIndex.selectRandom i (WithAssetOnly a)
-    monitor $ cover 50 (a `Set.member` UTxOIndex.assets i)
+    result <- run $ UTxOIndex.selectRandomNew i (SelectSingleton a)
+    monitor $ cover 50 (a `Set.member` UTxOIndex.assetsNew i)
         "index has the specified asset"
-    monitor $ cover 50 (Set.size (UTxOIndex.assets i) > 1)
+    monitor $ cover 50 (Set.size (UTxOIndex.assetsNew i) > 1)
         "index has more than one asset"
     monitor $ cover 10 (isJust result)
         "selected an entry"
@@ -598,7 +598,8 @@ prop_selectRandom_one_withAssetOnly i a = checkCoverage $ monadicIO $ do
             assert $ UTxOIndex.insert u b i' == i
             assert $ UTxOIndex.member u i
             assert $ not $ UTxOIndex.member u i'
-            assert $ tokenBundleHasAssetOnly b a
+            assert $ UTxOIndex.tokenBundleHasAsset b a
+            assert $ UTxOIndex.tokenBundleAssetCount b == 1
             assert $ i /= i'
 
 -- | Attempt to select all entries from the index.

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -554,24 +554,24 @@ prop_selectRandom_one_withAdaOnly i = checkCoverage $ monadicIO $ do
 -- This should only succeed if there is at least one element with a non-zero
 -- quantity of the asset.
 --
-prop_selectRandom_one_withAsset :: UTxOIndex TestUTxO -> AssetId -> Property
+prop_selectRandom_one_withAsset :: UTxOIndex TestUTxO -> Asset -> Property
 prop_selectRandom_one_withAsset i a = checkCoverage $ monadicIO $ do
-    result <- run $ UTxOIndex.selectRandom i (WithAsset a)
-    monitor $ cover 50 (a `Set.member` UTxOIndex.assets i)
+    result <- run $ UTxOIndex.selectRandomNew i (SelectAnyWith a)
+    monitor $ cover 50 (a `Set.member` UTxOIndex.assetsNew i)
         "index has the specified asset"
-    monitor $ cover 50 (Set.size (UTxOIndex.assets i) > 1)
+    monitor $ cover 50 (Set.size (UTxOIndex.assetsNew i) > 1)
         "index has more than one asset"
     monitor $ cover 50 (isJust result)
         "selected an entry"
     case result of
         Nothing ->
-            assert $ a `Set.notMember` UTxOIndex.assets i
+            assert $ a `Set.notMember` UTxOIndex.assetsNew i
         Just ((u, b), i') -> do
             assert $ UTxOIndex.delete u i == i'
             assert $ UTxOIndex.insert u b i' == i
             assert $ UTxOIndex.member u i
             assert $ not $ UTxOIndex.member u i'
-            assert $ tokenBundleHasAsset b a
+            assert $ UTxOIndex.tokenBundleHasAsset b a
             assert $ i /= i'
 
 -- | Attempt to select a random element with a specific asset and no other

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -303,10 +303,10 @@ prop_insert_assets
     :: u ~ Size 4 TestUTxO => u -> TokenBundle -> UTxOIndex u -> Property
 prop_insert_assets u b i =
     checkCoverage_modify u i $
-    UTxOIndex.assets (UTxOIndex.insert u b i)
+    UTxOIndex.assetsNew (UTxOIndex.insert u b i)
         `Set.intersection` insertedAssets === insertedAssets
   where
-    insertedAssets = TokenBundle.getAssets b
+    insertedAssets = UTxOIndex.tokenBundleAssets b
 
 prop_insert_balance
     :: u ~ Size 4 TestUTxO => u -> TokenBundle -> UTxOIndex u -> Property

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -533,7 +533,7 @@ prop_selectRandom_one_any i = checkCoverage $ monadicIO $ do
 --
 prop_selectRandom_one_withAdaOnly :: UTxOIndex TestUTxO -> Property
 prop_selectRandom_one_withAdaOnly i = checkCoverage $ monadicIO $ do
-    result <- run $ UTxOIndex.selectRandom i WithAdaOnly
+    result <- run $ UTxOIndex.selectRandomNew i (SelectSingleton AssetLovelace)
     monitor $ cover 50 (isJust result)
         "selected an entry"
     case result of

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -637,22 +637,22 @@ prop_selectRandom_all_withAdaOnly i = checkCoverage $ monadicIO $ do
 
 -- | Attempt to select all entries with the given asset from the index.
 --
-prop_selectRandom_all_withAsset :: UTxOIndex TestUTxO -> AssetId -> Property
+prop_selectRandom_all_withAsset :: UTxOIndex TestUTxO -> Asset -> Property
 prop_selectRandom_all_withAsset i a = checkCoverage $ monadicIO $ do
-    (selectedEntries, i') <- run $ selectAll (WithAsset a) i
-    monitor $ cover 50 (a `Set.member` UTxOIndex.assets i)
+    (selectedEntries, i') <- run $ selectAllNew (SelectAnyWith a) i
+    monitor $ cover 50 (a `Set.member` UTxOIndex.assetsNew i)
         "index has the specified asset"
-    monitor $ cover 50 (Set.size (UTxOIndex.assets i) > 1)
+    monitor $ cover 50 (Set.size (UTxOIndex.assetsNew i) > 1)
         "index has more than one asset"
     monitor $ cover 50 (not (null selectedEntries))
         "selected at least one entry"
     assert $ L.all (\(_, b) ->
-        not (tokenBundleHasAsset b a)) (UTxOIndex.toList i')
+        not (UTxOIndex.tokenBundleHasAsset b a)) (UTxOIndex.toList i')
     assert $ L.all (\(_, b) ->
-        tokenBundleHasAsset b a) selectedEntries
+        UTxOIndex.tokenBundleHasAsset b a) selectedEntries
     assert $ UTxOIndex.deleteMany (fst <$> selectedEntries) i == i'
     assert $ UTxOIndex.insertMany selectedEntries i' == i
-    assert $ a `Set.notMember` UTxOIndex.assets i'
+    assert $ a `Set.notMember` UTxOIndex.assetsNew i'
 
 -- | Attempt to select all entries with only the given asset from the index.
 --

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -148,6 +148,8 @@ spec =
 
         it "prop_SelectionFilter_coverage" $
             property prop_SelectionFilter_coverage
+        it "prop_SelectionFilterNew_coverage" $
+            property prop_SelectionFilterNew_coverage
         it "prop_selectRandom_empty" $
             property prop_selectRandom_empty
         it "prop_selectRandom_singleton" $
@@ -420,6 +422,25 @@ prop_SelectionFilter_coverage selectionFilter = checkCoverage $ property
     True
   where
     category = categorizeSelectionFilter selectionFilter
+
+-- TODO:
+--
+-- Rename this to 'prop_SelectionFilterNew_coverage' once the old property
+-- has been deleted.
+--
+prop_SelectionFilterNew_coverage :: SelectionFilterNew Asset -> Property
+prop_SelectionFilterNew_coverage selectionFilter = checkCoverage $ property
+    $ cover 20 (category == SelectSingleton ())
+        "SelectSingleton"
+    $ cover 20 (category == SelectPairWith ())
+        "SelectPairWith"
+    $ cover 20 (category == SelectAnyWith ())
+        "SelectAnyWith"
+    $ cover 20 (category == SelectAny)
+        "SelectAny"
+    True
+  where
+    category = () <$ selectionFilter
 
 -- | Attempt to select a random entry from an empty index.
 --

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -516,7 +516,7 @@ prop_selectRandom_singleton selectionFilter u b = monadicIO $ do
 --
 prop_selectRandom_one_any :: UTxOIndex TestUTxO -> Property
 prop_selectRandom_one_any i = checkCoverage $ monadicIO $ do
-    result <- run $ UTxOIndex.selectRandom i Any
+    result <- run $ UTxOIndex.selectRandomNew i SelectAny
     monitor $ cover 90 (isJust result)
         "selected an entry"
     case result of

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -624,7 +624,8 @@ prop_selectRandom_all_any i = checkCoverage $ monadicIO $ do
 --
 prop_selectRandom_all_withAdaOnly :: UTxOIndex TestUTxO -> Property
 prop_selectRandom_all_withAdaOnly i = checkCoverage $ monadicIO $ do
-    (selectedEntries, i') <- run $ selectAll WithAdaOnly i
+    (selectedEntries, i') <- run $
+        selectAllNew (SelectSingleton AssetLovelace) i
     monitor $ cover 70 (not (null selectedEntries))
         "selected at least one entry"
     assert $ L.all (\(_, b) ->

--- a/lib/shelley/test/data/balanceTx/pingPong_2/golden
+++ b/lib/shelley/test/data/balanceTx/pingPong_2/golden
@@ -1,4 +1,4 @@
- 0.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 2033497}))))
+ 0.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2027293, shortfall = Coin 2027293}))))
  0.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1983497}))))
  0.100000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1933497}))))
  0.150000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 2033497, shortfall = Coin 1883497}))))


### PR DESCRIPTION
## Issue Number

ADP-1419

## Summary

This PR makes the `UTxOIndex` type **_agnostic_** to the distinction between **_ada_** and **_non-ada_** assets.

## Motivation

We want to evolve the coin selection algorithm so that:
- the concept of "value" (provided by inputs and consumed by outputs) is **_generalized_**.
- all asset types are treated equally, with no special treatment for **_ada_** versus **_non-ada_** assets.

Currently, there are a few obstacles that prevent such a generalization:
1. The `UTxOIndex` type indexes ada quantities differently from other assets.
2. The `computeMinimumCost` function is ada-specific.
3. The `computeMinimumAdaQuantity` function is ada-specific.

This PR tackles the **_first_** of these obstacles.

## Details

We make the following change to `SelectionFilter`:

```patch
- data SelectionFilter
-     = WithAdaOnly
-     | WithAssetOnly AssetId
-     | WithAsset AssetId
-     | Any
+ data SelectionFilter asset
+     = SelectSingleton asset
+     | SelectPairWith asset
+     | SelectAnyWith asset
+     | SelectAny
```

We also (temporarily) introduce a type called `Asset`, which can represent both ada and non-ada assets:
```hs
data Asset
    = AssetLovelace
    | Asset AssetId
```

This allows us to generalize the way we perform random selection for ada and non-ada assets in the `Balance` module:
```patch
 selectAdaQuantity =
-    selectMatchingQuantity (WithAdaOnly :| [Any])
+    selectMatchingQuantity
+        [ SelectSingleton AssetLovelace
+        , SelectPairWith AssetLovelace
+        , SelectAnyWith AssetLovelace
+        ]

 selectNonAdaAssetQuantity asset =
-    selectMatchingQuantity [WithAssetOnly asset, WithAsset asset]
+    selectMatchingQuantity
+        [ SelectSingleton (Asset asset)
+        , SelectPairWith (Asset asset)
+        , SelectAnyWith (Asset asset)
+        ]
```
In the above functions, selection filters are processed in the following order of priority:
1. `SelectSingleton`
    matches UTxOs that contain **_just_** the given asset and **_no other_** assets
2. `SelectPairWith`
    matches UTxOs that contain the given asset and **_one other_** asset.
2. `SelectAnyWith`
    matches UTxOs that contain the given asset and **_any number_** of other assets.

Because both selection functions now share **_exactly the same priority order_**, we can simplify these definitions even further by extracting out the shared priority order and parameterizing over the type of asset.