### PR TITLE
Light Mode: Time Interpreter

### DIFF
--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -66,5 +66,5 @@ withNetworkLayer tr blockchainSrc net netParams tol =
             in Node.withNetworkLayer tr' net netParams nodeConn ver tol
         BlockfrostSource project ->
             let tr' = BlockfrostNetworkLog >$< tr
-            in Blockfrost.withNetworkLayer tr' net project netParams
+            in Blockfrost.withNetworkLayer tr' net netParams project
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -66,5 +66,5 @@ withNetworkLayer tr blockchainSrc net netParams tol =
             in Node.withNetworkLayer tr' net netParams nodeConn ver tol
         BlockfrostSource project ->
             let tr' = BlockfrostNetworkLog >$< tr
-            in Blockfrost.withNetworkLayer tr' net project
+            in Blockfrost.withNetworkLayer tr' net project netParams
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -185,11 +185,11 @@ instance HasSeverityAnnotation Log where
 withNetworkLayer
     :: Tracer IO Log
     -> NetworkId
-    -> BF.Project
     -> NetworkParameters
+    -> BF.Project
     -> (NetworkLayer IO (CardanoBlock StandardCrypto) -> IO a)
     -> IO a
-withNetworkLayer tr net project np k = k NetworkLayer
+withNetworkLayer tr net np project k = k NetworkLayer
     { chainSync = \_tr _chainFollower -> pure ()
     , lightSync = Nothing
     , currentNodeTip

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -201,7 +201,7 @@ withNetworkLayer tr net np project k = k NetworkLayer
     , stakeDistribution = undefined
     , getCachedRewardAccountBalance = undefined
     , fetchRewardAccountBalances = undefined
-    , timeInterpreter = timeInterpreter getGenesisBlockDate
+    , timeInterpreter = timeInterpreterFromStartTime getGenesisBlockDate
     , syncProgress = undefined
     }
   where
@@ -230,9 +230,9 @@ withNetworkLayer tr net np project k = k NetworkLayer
         epoch <- fromBlockfrostM _epochInfoEpoch
         liftEither $ eraByEpoch net epoch
 
-    timeInterpreter ::
+    timeInterpreterFromStartTime ::
         StartTime -> TimeInterpreter (ExceptT PastHorizonException IO)
-    timeInterpreter startTime =
+    timeInterpreterFromStartTime startTime =
         mkTimeInterpreter (MsgTimeInterpreterLog >$< tr) startTime $
             pure $ HF.mkInterpreter $ networkSummary net
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -36,9 +36,7 @@ import Prelude
 import qualified Blockfrost.Client as BF
 import qualified Cardano.Api.Shelley as Node
 import qualified Data.Sequence as Seq
-import qualified Ouroboros.Consensus.HardFork.History.EraParams as HF
 import qualified Ouroboros.Consensus.HardFork.History.Qry as HF
-import qualified Ouroboros.Consensus.HardFork.History.Summary as HF
 
 import Cardano.Api
     ( AnyCardanoEra (..)
@@ -423,7 +421,7 @@ instance FromBlockfrost BF.Epoch EpochNo where
 
 {- Epoch-to-Era translation is not available in the Blockfrost API.
 
-The following histories are hardcoded in order to work around this limiation:
+The following histories are hardcoded in order to work around this limitation:
 
 For the Mainnet:      For the Testnet:
 ┌───────┬─────────┐   ┌───────┬─────────┐

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -526,10 +526,94 @@ networkSummary = \case
                     }
                 }
             }
-    Testnet _ -> error
-        "In light-mode time interpreter is only available for the \
-        \mainnet (interpreter uses a hard-coded history of hard forks). \
-        \It doesn't seem viable to hardcode it for other networks yet."
+    Testnet (NetworkMagic 1097911063) -> -- Magic of the current public testnet
+        Summary
+            { getSummary
+                = NonEmptyCons EraSummary
+                    { eraStart = Bound
+                        { boundTime = RelativeTime 0
+                        , boundSlot = SlotNo 0
+                        , boundEpoch = Node.EpochNo 0
+                        }
+                    , eraEnd = EraEnd Bound
+                        { boundTime = RelativeTime 31968000
+                        , boundSlot = SlotNo 1598400
+                        , boundEpoch = Node.EpochNo 74
+                        }
+                    , eraParams = EraParams
+                        { eraEpochSize = EpochSize 21600
+                        , eraSlotLength = mkSlotLength 20
+                        , eraSafeZone = StandardSafeZone 4320
+                        }
+                    }
+                $ NonEmptyCons EraSummary
+                    { eraStart = Bound
+                        { boundTime = RelativeTime 31968000
+                        , boundSlot = SlotNo 1598400
+                        , boundEpoch = Node.EpochNo 74
+                        }
+                    , eraEnd = EraEnd Bound
+                        { boundTime = RelativeTime 44064000
+                        , boundSlot = SlotNo 13694400
+                        , boundEpoch = Node.EpochNo 102
+                        }
+                    , eraParams = EraParams
+                        { eraEpochSize = EpochSize 432000
+                        , eraSlotLength = mkSlotLength 1
+                        , eraSafeZone = StandardSafeZone 129600
+                        }
+                    }
+                $ NonEmptyCons EraSummary
+                    { eraStart = Bound
+                        { boundTime = RelativeTime 44064000
+                        , boundSlot = SlotNo 13694400
+                        , boundEpoch = Node.EpochNo 102
+                        }
+                    , eraEnd = EraEnd Bound
+                        { boundTime = RelativeTime 48384000
+                        , boundSlot = SlotNo 18014400
+                        , boundEpoch = Node.EpochNo 112
+                        }
+                    , eraParams = EraParams
+                        { eraEpochSize = EpochSize 432000
+                        , eraSlotLength = mkSlotLength 1
+                        , eraSafeZone = StandardSafeZone 129600
+                        }
+                    }
+                $ NonEmptyCons EraSummary
+                    { eraStart = Bound
+                        { boundTime = RelativeTime 48384000
+                        , boundSlot = SlotNo 18014400
+                        , boundEpoch = Node.EpochNo 112
+                        }
+                    , eraEnd = EraEnd Bound
+                        { boundTime = RelativeTime 66528000
+                        , boundSlot = SlotNo 36158400
+                        , boundEpoch = Node.EpochNo 154
+                        }
+                    , eraParams = EraParams
+                        { eraEpochSize = EpochSize 432000
+                        , eraSlotLength = mkSlotLength 1
+                        , eraSafeZone = StandardSafeZone 129600
+                        }
+                    }
+                $ NonEmptyOne EraSummary
+                    { eraStart = Bound
+                        { boundTime = RelativeTime 66528000
+                        , boundSlot = SlotNo 36158400
+                        , boundEpoch = Node.EpochNo 154
+                        }
+                    , eraEnd = EraUnbounded
+                    , eraParams = EraParams
+                        { eraEpochSize = EpochSize 432000
+                        , eraSlotLength = mkSlotLength 1
+                        , eraSafeZone = StandardSafeZone 129600
+                        }
+                    }
+            }
+    Testnet magic ->
+        error $ "Epoch/Era conversion isn't provided for the Testnet "
+            <> show magic
 
 {- Epoch-to-Era translation is not available in the Blockfrost API.
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Node.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Node.hs
@@ -521,8 +521,7 @@ withNodeNetworkLayerBase tr net np conn versionData tol action = do
         let readInterpreter = liftIO $ atomically $ readTMVar var
         mkTimeInterpreter tr' getGenesisBlockDate readInterpreter
 
-    _syncProgress
-        :: TMVar IO (CardanoInterpreter sc)
+    _syncProgress :: TMVar IO (CardanoInterpreter sc)
         -> SlotNo
         -> IO SyncProgress
     _syncProgress var slot = do


### PR DESCRIPTION
### Issue Number

ADP-1422, ADP-1505

### Overview

[Light-mode][] (Epic ADP-1422) aims to make synchronisation to the blockchain faster by trusting an off-chain source of aggregated blockchain data. 

  [light-mode]: https://input-output-hk.github.io/cardano-wallet/design/specs/light-mode

In this pull request, we implement a function `timeInterpreter` that allows wallet to convert between relative blockchain time (epochs, slots) and absolute wall-clock time. To make such conversions correct `TimeInterpreter` needs to take into account historical values for various protocol parameters as well as past hard forks.

Unfortunately Blockfrost API doesn't expose required functionality. We therefore hardcode summary information about past hard forks that happened on the Mainnet.
