### PR TITLE
Light mode: hardcode epoch/era conversion for the Testnet

### DIFF
--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/Network/BlockfrostSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/Network/BlockfrostSpec.hs
@@ -34,8 +34,8 @@ spec = describe "Blockfrost Network" $ do
         , (236, AnyCardanoEra AllegraEra)
         , (235, AnyCardanoEra ShelleyEra)
         , (220, AnyCardanoEra ShelleyEra)
-        , (202, AnyCardanoEra ShelleyEra)
-        , (201, AnyCardanoEra ByronEra)
+        , (208, AnyCardanoEra ShelleyEra)
+        , (207, AnyCardanoEra ByronEra)
         , (001, AnyCardanoEra ByronEra)
         , (000, AnyCardanoEra ByronEra)
         ]


### PR DESCRIPTION
### Issue Number

ADP-1422, ADP-1504

### Overview

[Light-mode][] (Epic ADP-1422) aims to make synchronisation to the blockchain faster by trusting an off-chain source of aggregated blockchain data. 

  [light-mode]: https://input-output-hk.github.io/cardano-wallet/design/specs/light-mode

In this pull request, we implement a function `currentNodeEra` that that determines current Era by the current epoch retrieved from the Testnet Blockfrost API.
