### PR TITLE
Ensure 1.34.1 node bump is reflected in cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -102,11 +102,9 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: 1efbb276ef1a10ca6961d0fd32e6141e9798bd11
+  tag: fc5fe94d3d9525d032bcbc79ff0e1ebcfd8ef143
   subdir:
-    freer-extras
     plutus-core
-    plutus-ledger
     plutus-ledger-api
     plutus-tx
     plutus-tx-plugin
@@ -117,7 +115,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ekg-forward
-  tag: 2adc8b698443bb10154304b24f6c1d6913bb65b9
+  tag: 297cd9db5074339a2fb2e5ae7d0780debb670c63
 
 source-repository-package
   type: git

--- a/cabal.project
+++ b/cabal.project
@@ -154,9 +154,10 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-node
-    tag: 814df2c146f5d56f8c35a681fe75e85b905aed5d
+    tag: 73f9a746362695dc2cb63ba757fbcabb81733d23
     subdir:
       cardano-api
+      cardano-git-rev
       cardano-cli
       cardano-node
       cardano-node-chairman


### PR DESCRIPTION
- [x] Update cabal.project revisions which should have been updated in #3160 
    - This affects `cabal build` **outside** of `nix`. 
    - [x] Check that CI check passes 

### Comments

- Prompted by and includes #3225
- Note: cabal build outside of nix is now tested in normal Buildkite since https://github.com/input-output-hk/cardano-wallet/pull/3200

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

None.

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
