### PR TITLE
Add more property tests for `distributeSurplus`. 

### DIFF
--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -274,11 +274,21 @@ data TransactionLayer k tx = TransactionLayer
         -- When comparing the original fee and change outputs to the adjusted
         -- fee and change outputs, this function guarantees that:
         --
-        --  - The number of the change outputs remains constant;
-        --  - The fee quantity either remains the same or increases.
-        --  - For each change output:
-        --      - the ada quantity either remains constant or increases.
-        --      - non-ada quantities remain the same.
+        --    - The number of the change outputs remains constant;
+        --
+        --    - The fee quantity either remains the same or increases.
+        --
+        --    - For each change output:
+        --        - the ada quantity either remains constant or increases.
+        --        - non-ada quantities remain the same.
+        --
+        --    - The surplus is conserved:
+        --        The total increase in the fee and change ada quantities is
+        --        exactly equal to the surplus.
+        --
+        --    - Any increase in cost is covered:
+        --        If the total cost has increased by 𝛿c, then the fee value
+        --        will have increased by at least 𝛿c.
 
     , computeSelectionLimit
         :: ProtocolParameters

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1609,13 +1609,14 @@ burnSurplusAsFees
     -> Coin -- Surplus
     -> TxFeeAndChange ()
     -> Either ErrMoreSurplusNeeded (TxFeeAndChange ())
-burnSurplusAsFees feePolicy surplus (TxFeeAndChange fee0 ()) =
-    case costOfBurningSurplus `Coin.subtract` surplus of
-        Just shortfall -> Left $ ErrMoreSurplusNeeded shortfall
-        Nothing ->
-            Right $ TxFeeAndChange surplus ()
+burnSurplusAsFees feePolicy surplus (TxFeeAndChange fee0 ())
+    | shortfall > Coin 0 =
+        Left $ ErrMoreSurplusNeeded shortfall
+    | otherwise =
+        Right $ TxFeeAndChange surplus ()
   where
     costOfBurningSurplus = costOfIncreasingCoin feePolicy fee0 surplus
+    shortfall = costOfBurningSurplus `Coin.difference` surplus
 
 -- | Estimates the final size of a transaction based on its skeleton.
 --

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2519,9 +2519,21 @@ prop_distributeSurplus_onSuccess propertyToTest policy txSurplus fc =
     cover 2
         (feeOriginal == Coin 0)
         "feeOriginal == Coin 0" $
+    cover 2
+        (feeOriginal == Coin 1)
+        "feeOriginal == Coin 1" $
     cover 50
-        (feeOriginal >= Coin 1)
-        "feeOriginal >= Coin 1" $
+        (feeOriginal >= Coin 2)
+        "feeOriginal >= Coin 2" $
+    cover 1
+        (surplus == Coin 0)
+        "surplus == Coin 0" $
+    cover 1
+        (surplus == Coin 1)
+        "surplus == Coin 1" $
+    cover 50
+        (surplus >= Coin 2)
+        "surplus >= Coin 2" $
     either
         (const $ property True)
         (property . propertyToTest policy surplus fc)


### PR DESCRIPTION
## Issue

[ADP-1514](https://input-output.atlassian.net/browse/ADP-1514)

(Also fixes https://github.com/input-output-hk/cardano-wallet/issues/3242)

## Summary

This PR adds a pair of property tests for `distributeSurplus`:
- `prop_distributeSurplus_onSuccess_conservesSurplus`
- `prop_distributeSurplus_onSuccess_coversCostIncrease`

This PR also adds descriptions of these properties to the comment for `TransactionLayer.distributeSurplus`.

Finally, this PR also improves test coverage of the surplus value, by defining and using a `TxBalanceSurplus Coin` generator that:
- includes zero `Coin` values (previously, this value was excluded).
- includes difference ranges of coins.
