### PR TITLE
Strengthen `distributeSurplus` property regarding `ErrMoreSurplusNeeded`

### DIFF
--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -289,6 +289,12 @@ data TransactionLayer k tx = TransactionLayer
         --    - Any increase in cost is covered:
         --        If the total cost has increased by 𝛿c, then the fee value
         --        will have increased by at least 𝛿c.
+        --
+        -- If the cost of distributing the provided surplus is greater than the
+        -- surplus itself, the function will return 'ErrMoreSurplusNeeded'. If
+        -- the provided surplus is greater or equal to
+        -- @maximumCostOfIncreasingCoin feePolicy@, the function will always
+        -- return 'Right'.
 
     , computeSelectionLimit
         :: ProtocolParameters

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2416,7 +2416,7 @@ prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
     counterexample (show mres) $ case mres of
         Left (ErrMoreSurplusNeeded shortfall) ->
             conjoin
-                [ property $ surplus < (maxCoinCost <> maxCoinCost)
+                [ property $ surplus < maxCoinCostIncrease
                 , property $ shortfall > Coin 0
                 , costOfIncreasingCoin feePolicy fee0 surplus
                     === surplus <> shortfall
@@ -2441,7 +2441,7 @@ prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
   where
     mres = distributeSurplusDelta
         feePolicy surplus (TxFeeAndChange fee0 change0)
-    maxCoinCost = maximumCostOfIncreasingCoin feePolicy
+    maxCoinCostIncrease = maximumCostOfIncreasingCoin feePolicy
 
 --------------------------------------------------------------------------------
 -- Properties for 'distributeSurplus'


### PR DESCRIPTION
1. We can strengthen the condition that we only see ErrNotEnoughSurplus failures when `surplus < 2 * maxCoinCostIncrease`. It can simply be `surplus < maxCoinCostIncrease`. This is important for `balanceTransaction` where we add a padding of maxCoinCostIncrease (8 bytes * feePerByte) to eliminate the possibility of `ErrNotEnoughSurplus` errors. I forgot to update the property when lowering the padding from 16 to 8 bytes.

2. Mention this in the documentation for `distributeSurplus`.

### Comments

```
$ cabal test cardano-wallet:unit --test-options='--match "distributeSurplusDelta" --qc-max-success=10000000'
Cardano.Wallet.Shelley.Transaction
  distributeSurplusDelta
    when increasing change increases fee
      will increase fee (99 lovelace for change, 1 for fee)
    when increasing fee increases fee
      will increase fee (98 lovelace for change, 2 for fee)
    when increasing the change costs more in fees than the increase itself
      will try burning the surplus as fees
      will fail if neither the fee can be increased
    when no change output is present
      will burn surplus as excess fees (29779ms)
        +++ OK, passed 10000000 tests.
    prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus (62ms)
      +++ OK, passed 1600 tests:
      95.56% Success
       4.44% Failure

Finished in 29.8454 seconds, used 29.8278 seconds of CPU time
6 examples, 0 failures
```

### Issue Number

ADP-1514

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
