### PR TITLE
Fix macos job name in release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         id: hydra
         with:
           hydra: 'https://hydra.iohk.io'
-          jobs: 'linux.musl.cardano-wallet-linux64 macos.cardano-wallet-macos-intel linux.windows.cardano-wallet-win64'
+          jobs: 'linux.musl.cardano-wallet-linux64 macos.intel.cardano-wallet-macos-intel linux.windows.cardano-wallet-win64'
 
       - name: '🍒 Fetch release files'
         run: |


### PR DESCRIPTION
- macos job name is incorrect (missing 'intel' path), adds the intel path.