### PR TITLE
Make manual testing easier

### DIFF
--- a/test/manual/README.md
+++ b/test/manual/README.md
@@ -1,0 +1,36 @@
+# Manual Tests
+
+The `./make-env.sh` script in this directory will make the environment necessary to run the tests listed here.
+
+Call it with the appropriate `WALLET_VERSION` and `NODE_VERSION` environment variables set:
+
+```
+WALLET_VERSION=2022-04-27 NODE_VERSION=1.34.1 ./make-env.sh
+```
+
+Binaries:
+
+  - cardano-node: `./cardano-node/bin/cardano-node`
+  - cardano-wallet: `./cardano-wallet/bin/cardano-wallet`
+
+Directories:
+
+  - Use `db-testnet` as the database directory for `cardano-node`.
+  - Use `wallet-db-testnet` as the database directory for `cardano-wallet`.
+
+E.g.:
+
+```
+cardano-node/bin/cardano-node run \
+    --config ./testnet-config.json \
+    --topology ./testnet-topology.json \
+    --database-path ./db-testnet \
+    --socket-path ./node.socket
+
+cardano-wallet/bin/cardano-wallet serve --port 8090 \
+    --node-socket ./node.socket \
+    --testnet ./testnet-byron-genesis.json  \
+    --database ./wallet-db-testnet
+```
+
+Type `exit` to leave the test environment.

--- a/test/manual/make-env.sh
+++ b/test/manual/make-env.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# The following script creates the environment needed to run the manual tests.
+
+if [[ -z "${WALLET_VERSION}" ]]; then
+    echo "WALLET_VERSION is not set!"
+    exit 1
+fi
+
+if [[ -z "${NODE_VERSION}" ]]; then
+    echo "NODE_VERSION is not set!"
+    exit 1
+fi
+
+set -euxo pipefail
+
+pushd $(mktemp -d)
+
+# Download source repositories
+curl -L -o cardano-wallet.tar.gz "https://github.com/input-output-hk/cardano-wallet/archive/refs/tags/v${WALLET_VERSION}.tar.gz"
+tar -xzf cardano-wallet.tar.gz
+
+curl -L -o cardano-node.tar.gz "https://github.com/input-output-hk/cardano-node/archive/refs/tags/${NODE_VERSION}.tar.gz"
+tar -xzf cardano-node.tar.gz
+
+WALLET_DIR=cardano-wallet-${WALLET_VERSION}
+NODE_DIR=cardano-node-${NODE_VERSION}
+
+# Build binaries
+nix-build $NODE_DIR -A cardano-node -o cardano-node
+nix-build $WALLET_DIR -A cardano-wallet -o cardano-wallet
+
+# Get latest configs
+curl -L -o testnet-config.json https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest/download/1/testnet-config.json
+curl -L -o testnet-topology.json https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest/download/1/testnet-topology.json
+curl -L -o testnet-byron-genesis.json https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest/download/1/testnet-byron-genesis.json
+curl -L -o testnet-shelley-genesis.json https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest/download/1/testnet-shelley-genesis.json
+curl -L -o testnet-alonzo-genesis.json https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest/download/1/testnet-alonzo-genesis.json
+
+# Restore node database
+curl -L -o db-testnet.tar.gz https://updates-cardano-testnet.s3.amazonaws.com/cardano-node-state/db-testnet.tar.gz
+tar -xzf db-testnet.tar.gz
+
+mkdir wallet-db-testnet
+
+exec bash


### PR DESCRIPTION

- Provide a script that enters a testing environment with:
  - The cardano-wallet source and binary
  - The cardano-node source and binary
  - A testnet database restored from IOHK snapshot.
  - The latest config/topology/genesis files.
- Hopefully this will make the process of manual testing a little quicker for
  those who don't already have a synced testnet database.

### Comments

In future, some of the manual tests could be automated* using this script as a basis, though perhaps more nixified (we're just fetching sources).

*: as in, still run manually on release, but the steps are executed and checked automatically.