### PR TITLE
Alleviate hspec-discover/cabal cache errors

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,9 +58,6 @@ steps:
     command:
       - "mkdir -p config && echo '{  outputs = _: { withCabalCache = true; }; }'  > config/flake.nix"
       - "nix develop --override-input customConfig path:./config .#cabal --command scripts/buildkite/cabal-ci.sh build"
-    env:
-      CABAL_CACHE_ARCHIVE: "/cache/cardano-wallet"
-      CABAL_STORE_DIR: "/build/cardano-wallet.store"
     agents:
       system: x86_64-linux
     if: 'build.env("step") == null || build.env("step") =~ /cabal/'


### PR DESCRIPTION

- Attempt to alleviate issues seen in CI (see associated ticket) by not caching cabal build artifacts between builds.

- There's no guarantee that doing this will fix the issue, but not using the cache did not noticeably increase the time it took for the cabal build to run, so we don't lose anything for trying.

- We'll need to "wait and see" to determine if the issue is fixed. 

### Issue Number

ADP-1724
