### PR TITLE
Provide lexicographic ordering for `TokenMap` and `TokenBundle`.

### DIFF
--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -136,7 +136,7 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId, Flat (..), TokenMap )
+    ( AssetId, Flat (..), Lexicographic (..), TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -2229,13 +2229,9 @@ selectedCoinQuantity
 -- lexicographic ordering as a tie-breaker.
 --
 instance Ord (AssetCount TokenMap) where
-    compare (AssetCount m1) (AssetCount m2) =
-        case compare (assetCount m1) (assetCount m2) of
-            LT -> LT
-            GT -> GT
-            EQ -> comparing TokenMap.toNestedList m1 m2
+    compare = comparing projection
       where
-        assetCount = TokenMap.size
+        projection (AssetCount m) = (TokenMap.size m, Lexicographic m)
 
 newtype AssetCount a = AssetCount
     { unAssetCount :: a }

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -125,9 +125,7 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( TokenMap )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( TokenName, TokenPolicyId )
+    ( Lexicographic (..), TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Util
@@ -143,15 +141,13 @@ import Data.ByteString
 import Data.Either
     ( partitionEithers )
 import Data.Function
-    ( on, (&) )
+    ( on )
 import Data.Generics.Internal.VL.Lens
     ( over, view )
 import Data.Generics.Labels
     ()
 import Data.Int
     ( Int64 )
-import Data.List.NonEmpty
-    ( NonEmpty (..) )
 import Data.Map.Strict
     ( Map )
 import Data.Ord
@@ -363,22 +359,13 @@ txOutSubtractCoin toSubtract =
 -- (as that would lead to arithmetically invalid orderings), this means we can't
 -- automatically derive an 'Ord' instance for the 'TxOut' type.
 --
--- Instead, we define an 'Ord' instance that makes comparisons based on the list
--- representation of a 'TokenBundle'.
+-- Instead, we define an 'Ord' instance that makes comparisons based on
+-- lexicographic ordering of 'TokenBundle' values.
 --
 instance Ord TxOut where
     compare = comparing projection
       where
-        projection :: TxOut ->
-            ( Address
-            , Coin
-            , [(TokenPolicyId, NonEmpty (TokenName, TokenQuantity))]
-            )
-        projection out =
-            ( out & view #address
-            , out & view (#tokens . #coin)
-            , out & view (#tokens . #tokens) & TokenMap.toNestedList
-            )
+        projection (TxOut address bundle) = (address, Lexicographic bundle)
 
 data TxChange derivationPath = TxChange
     { address

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {- HLINT ignore "Use camelCase" -}
@@ -14,7 +17,14 @@ import Algebra.PartialOrd
 import Cardano.Numeric.Util
     ( inAscendingPartialOrder )
 import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( TokenBundle (..), add, difference, isCoin, subtract, unsafeSubtract )
+    ( Lexicographic (..)
+    , TokenBundle (..)
+    , add
+    , difference
+    , isCoin
+    , subtract
+    , unsafeSubtract
+    )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
@@ -38,7 +48,7 @@ import Test.QuickCheck
     , (==>)
     )
 import Test.QuickCheck.Classes
-    ( eqLaws, monoidLaws, semigroupLaws, semigroupMonoidLaws )
+    ( eqLaws, monoidLaws, ordLaws, semigroupLaws, semigroupMonoidLaws )
 import Test.Utils.Laws
     ( testLawsMany )
 import Test.Utils.Laws.PartialOrd
@@ -61,6 +71,10 @@ spec =
             , partialOrdLaws
             , semigroupLaws
             , semigroupMonoidLaws
+            ]
+        testLawsMany @(Lexicographic TokenBundle)
+            [ eqLaws
+            , ordLaws
             ]
 
     describe "Arithmetic" $ do
@@ -206,3 +220,5 @@ instance Arbitrary TokenBundle where
 instance Arbitrary TokenQuantity where
     arbitrary = genTokenQuantityPositive
     shrink = shrinkTokenQuantityPositive
+
+deriving instance Arbitrary (Lexicographic TokenBundle)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -18,7 +20,13 @@ import Algebra.PartialOrd
 import Cardano.Numeric.Util
     ( inAscendingPartialOrder )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..), Flat (..), Nested (..), TokenMap, difference )
+    ( AssetId (..)
+    , Flat (..)
+    , Lexicographic (..)
+    , Nested (..)
+    , TokenMap
+    , difference
+    )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( AssetIdF (..)
     , genAssetId
@@ -103,7 +111,7 @@ import Test.QuickCheck
     , (==>)
     )
 import Test.QuickCheck.Classes
-    ( eqLaws, monoidLaws, semigroupLaws, semigroupMonoidLaws )
+    ( eqLaws, monoidLaws, ordLaws, semigroupLaws, semigroupMonoidLaws )
 import Test.Utils.Laws
     ( testLawsMany )
 import Test.Utils.Laws.PartialOrd
@@ -133,6 +141,10 @@ spec =
             , partialOrdLaws
             , semigroupLaws
             , semigroupMonoidLaws
+            ]
+        testLawsMany @(Lexicographic TokenMap)
+            [ eqLaws
+            , ordLaws
             ]
 
     parallel $ describe
@@ -1018,6 +1030,8 @@ newtype Large a = Large
 newtype Positive a = Positive
     { getPositive :: a }
     deriving (Eq, Show)
+
+deriving instance Arbitrary (Lexicographic TokenMap)
 
 instance Arbitrary a => Arbitrary (Flat a) where
     arbitrary = Flat <$> arbitrary


### PR DESCRIPTION
## Issue Number

Related to ADP-1654.

## Summary

This PR provides the `Lexicographic` newtype wrapper, and `Ord` instances for:
- `Lexicographic TokenMap`
- `Lexicographic TokenBundle`

It uses these instances to simplify the following instances:
- `Ord TxOut`
- `Ord (AssetCount TokenMap)`

## Motivation

The presence of these instances will alleviate the burden of defining `Ord` for `Tx` once we add `mint` and `burn` fields (which internally are of type `TokenMap`).