### PR TITLE
Remove `{mint,burn}` fields from API, primitive transaction types, and DB schema.

### DIFF
--- a/lib/core/bench/db-bench.hs
+++ b/lib/core/bench/db-bench.hs
@@ -141,10 +141,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , TransactionInfo
     , Tx (..)
-    , TxBurn (..)
     , TxIn (..)
     , TxMeta (..)
-    , TxMint (..)
     , TxOut (..)
     , TxStatus (..)
     )
@@ -584,10 +582,6 @@ mkTxHistory numTx numInputs numOutputs numAssets range =
             , collateralOutput =
                 -- TODO: [ADP-1670]
                 Nothing
-            -- TODO: [ADP-1654]
-            , mint = TxMint mempty
-            -- TODO: [ADP-1654]
-            , burn = TxBurn mempty
             , withdrawals = mempty
             , metadata = Nothing
             , scriptValidity = Nothing

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -3843,7 +3843,6 @@ mkApiTransaction timeInterpreter setTimeReference tx = do
         , collateralOutputs = ApiAsArray $
             toAddressAmount @n <$> tx ^. #txCollateralOutput
         , withdrawals = mkApiWithdrawal @n <$> Map.toList (tx ^. #txWithdrawals)
-        , mint = mempty  -- TODO: ADP-xxx
         , status = ApiT (tx ^. (#txMeta . #status))
         , metadata = ApiTxMetadata $ ApiT <$> (tx ^. #txMetadata)
         , scriptValidity = ApiT <$> tx ^. #txScriptValidity

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1153,7 +1153,6 @@ data ApiTransaction (n :: NetworkDiscriminant) = ApiTransaction
     , collateralOutputs ::
         !(ApiAsArray "collateral_outputs" (Maybe (ApiTxOutput n)))
     , withdrawals :: ![ApiWithdrawal n]
-    , mint :: !(ApiT W.TokenMap)
     , status :: !(ApiT TxStatus)
     , metadata :: !ApiTxMetadata
     , scriptValidity :: !(Maybe (ApiT TxScriptValidity))

--- a/lib/core/src/Cardano/Wallet/DB/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Model.hs
@@ -486,10 +486,6 @@ mReadTxHistory ti wid minWithdrawal order range mstatus db@(Database wallets txs
             outputs tx
         , txInfoCollateralOutput =
             collateralOutput tx
-        , txInfoMint =
-            mint tx
-        , txInfoBurn =
-            burn tx
         , txInfoWithdrawals =
             withdrawals tx
         , txInfoMeta =

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -212,24 +212,6 @@ TxCollateralOutToken
     Foreign TxCollateralOut OnDeleteCascade txCollateralOut txCollateralOutTokenTxId
     deriving Show Generic
 
-TxMint
-    txMintTxId           TxId              sql=tx_id
-    txMintTokenPolicyId  W.TokenPolicyId   sql=token_policy_id
-    txMintTokenName      W.TokenName       sql=token_name
-    txMintTokenQuantity  W.TokenQuantity   sql=token_quantity
-
-    Primary txMintTxId txMintTokenPolicyId txMintTokenName
-    deriving Show Generic
-
-TxBurn
-    txBurnTxId           TxId              sql=tx_id
-    txBurnTokenPolicyId  W.TokenPolicyId   sql=token_policy_id
-    txBurnTokenName      W.TokenName       sql=token_name
-    txBurnTokenQuantity  W.TokenQuantity   sql=token_quantity
-
-    Primary txBurnTxId txBurnTokenPolicyId txBurnTokenName
-    deriving Show Generic
-
 -- | A transaction withdrawal associated with TxMeta.
 --
 -- There is no wallet ID because these values depend only on the transaction,

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
@@ -29,8 +28,6 @@ module Cardano.Wallet.Primitive.Types.Tx
     , TxMeta (..)
     , TxMetadata (..)
     , TxMetadataValue (..)
-    , TxMint (..)
-    , TxBurn (..)
     , TxStatus (..)
     , UnsignedTx (..)
     , TransactionInfo (..)
@@ -247,14 +244,6 @@ data Tx = Tx
 
     , collateralOutput :: !(Maybe TxOut)
         -- ^ An output that is only created if a transaction script fails.
-
-    , mint
-        :: !TxMint
-        -- ^ Tokens that are minted by this transaction.
-
-    , burn
-        :: !TxBurn
-        -- ^ Tokens that are burned by this transaction.
 
     , withdrawals
         :: !(Map RewardAccount Coin)
@@ -737,10 +726,6 @@ data TransactionInfo = TransactionInfo
     -- ^ Payment destination.
     , txInfoCollateralOutput :: !(Maybe TxOut)
     -- ^ An output that is only created if a transaction script fails.
-    , txInfoMint :: !TxMint
-    -- ^ Tokens that are minted by this transaction.
-    , txInfoBurn :: !TxBurn
-    -- ^ Tokens that are burned by this transaction.
     , txInfoWithdrawals :: !(Map RewardAccount Coin)
     -- ^ Withdrawals on this transaction.
     , txInfoMeta :: !TxMeta
@@ -787,8 +772,6 @@ fromTransactionInfo info = Tx
     , resolvedCollateralInputs = drop3rd <$> txInfoCollateralInputs info
     , outputs = txInfoOutputs info
     , collateralOutput = txInfoCollateralOutput info
-    , mint = txInfoMint info
-    , burn = txInfoBurn info
     , withdrawals = txInfoWithdrawals info
     , metadata = txInfoMetadata info
     , scriptValidity = txInfoScriptValidity info
@@ -1036,17 +1019,3 @@ unsafeCoinToTxOutCoinValue c
             ]
     | otherwise =
         Coin.unsafeToWord64 c
-
---------------------------------------------------------------------------------
--- Minting and burning
---------------------------------------------------------------------------------
-
-newtype TxMint = TxMint {unTxMint :: TokenMap}
-    deriving stock (Eq, Generic, Show)
-    deriving Ord via (Lexicographic TokenMap)
-    deriving anyclass NFData
-
-newtype TxBurn = TxBurn {unTxBurn :: TokenMap}
-    deriving stock (Eq, Generic, Show)
-    deriving Ord via (Lexicographic TokenMap)
-    deriving anyclass NFData

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -16,8 +16,6 @@ module Cardano.Wallet.Primitive.Types.Tx.Gen
     , genTxOut
     , genTxOutCoin
     , genTxOutTokenBundle
-    , genTxMint
-    , genTxBurn
     , genTxScriptValidity
     , shrinkTx
     , shrinkTxHash
@@ -25,8 +23,6 @@ module Cardano.Wallet.Primitive.Types.Tx.Gen
     , shrinkTxIn
     , shrinkTxOut
     , shrinkTxOutCoin
-    , shrinkTxMint
-    , shrinkTxBurn
     , shrinkTxScriptValidity
     )
     where
@@ -52,15 +48,13 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetIdLargeRange, genTokenMap, shrinkTokenMap )
+    ( genAssetIdLargeRange )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..)
-    , TxBurn (..)
     , TxIn (..)
     , TxMetadata (..)
-    , TxMint (..)
     , TxOut (..)
     , TxScriptValidity (..)
     , coinIsValidForTxOut
@@ -139,8 +133,6 @@ data TxWithoutId = TxWithoutId
     , resolvedCollateralInputs :: ![(TxIn, Coin)]
     , outputs :: ![TxOut]
     , collateralOutput :: !(Maybe TxOut)
-    , mint :: !TxMint
-    , burn :: !TxBurn
     , metadata :: !(Maybe TxMetadata)
     , withdrawals :: !(Map RewardAccount Coin)
     , scriptValidity :: !(Maybe TxScriptValidity)
@@ -154,8 +146,6 @@ genTxWithoutId = TxWithoutId
     <*> listOf1 (liftArbitrary2 genTxIn genCoinPositive)
     <*> listOf genTxOut
     <*> liftArbitrary genTxOut
-    <*> genTxMint
-    <*> genTxBurn
     <*> liftArbitrary genNestedTxMetadata
     <*> genMapWith genRewardAccount genCoinPositive
     <*> liftArbitrary genTxScriptValidity
@@ -167,8 +157,6 @@ shrinkTxWithoutId = genericRoundRobinShrink
     <:> shrinkList (liftShrink2 shrinkTxIn shrinkCoinPositive)
     <:> shrinkList shrinkTxOut
     <:> liftShrink shrinkTxOut
-    <:> shrinkTxMint
-    <:> shrinkTxBurn
     <:> liftShrink shrinkTxMetadata
     <:> shrinkMapWith shrinkRewardAccount shrinkCoinPositive
     <:> liftShrink shrinkTxScriptValidity
@@ -334,22 +322,6 @@ genTxOutTokenBundle fixedAssetCount
 
         integerToTokenQuantity :: Integer -> TokenQuantity
         integerToTokenQuantity = TokenQuantity . fromIntegral
-
---------------------------------------------------------------------------------
--- Minting and burning
---------------------------------------------------------------------------------
-
-genTxMint :: Gen TxMint
-genTxMint = TxMint <$> genTokenMap
-
-genTxBurn :: Gen TxBurn
-genTxBurn = TxBurn <$> genTokenMap
-
-shrinkTxMint :: TxMint -> [TxMint]
-shrinkTxMint = shrinkMapBy TxMint unTxMint shrinkTokenMap
-
-shrinkTxBurn :: TxBurn -> [TxBurn]
-shrinkTxBurn = shrinkMapBy TxBurn unTxBurn shrinkTokenMap
 
 --------------------------------------------------------------------------------
 -- Internal utilities

--- a/lib/core/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 
 module Cardano.Wallet.DummyTarget.Primitive.Types
     ( -- * Dummy values
@@ -52,10 +51,8 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..)
-    , TxBurn (..)
     , TxIn (..)
     , TxMetadata (..)
-    , TxMint (..)
     , TxOut (..)
     , TxScriptValidity (..)
     , TxSize (..)
@@ -142,13 +139,11 @@ mkTx
     -> [(TxIn, Coin)]
     -> [TxOut]
     -> Maybe TxOut
-    -> TxMint
-    -> TxBurn
     -> Map RewardAccount Coin
     -> Maybe TxMetadata
     -> Maybe TxScriptValidity
     -> Tx
-mkTx fees ins cins outs cout mint burn wdrls md validity =
+mkTx fees ins cins outs cout wdrls md validity =
     Tx
       { txId = (mkTxId ins outs wdrls md)
       , fee = fees
@@ -156,8 +151,6 @@ mkTx fees ins cins outs cout mint burn wdrls md validity =
       , resolvedCollateralInputs = cins
       , outputs = outs
       , collateralOutput = cout
-      , mint
-      , burn
       , withdrawals = wdrls
       , metadata = md
       , scriptValidity = validity

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiTransactionTestnet0.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiTransactionTestnet0.json
@@ -1,11 +1,114 @@
 {
-    "seed": -3815467787361906923,
+    "seed": -4866043259366810391,
     "samples": [
         {
-            "status": "pending",
+            "status": "expired",
             "withdrawals": [],
             "deposit_taken": {
-                "quantity": 5,
+                "quantity": 97,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "incoming",
+            "collateral_outputs": [
+                {
+                    "address": "<addr>",
+                    "amount": {
+                        "quantity": 1,
+                        "unit": "lovelace"
+                    },
+                    "assets": []
+                }
+            ],
+            "outputs": [],
+            "expires_at": {
+                "epoch_number": 12051,
+                "time": "1865-05-09T02:00:00Z",
+                "absolute_slot_number": 2739720,
+                "slot_number": 29170
+            },
+            "script_validity": "valid",
+            "pending_since": {
+                "height": {
+                    "quantity": 29707,
+                    "unit": "block"
+                },
+                "epoch_number": 2014,
+                "time": "1863-07-06T18:00:00Z",
+                "absolute_slot_number": 16263,
+                "slot_number": 23641
+            },
+            "id": "333e513456230a65786634c133550055946018190f7f623d8a172dcf05661523",
+            "depth": {
+                "quantity": 20102,
+                "unit": "block"
+            },
+            "amount": {
+                "quantity": 99,
+                "unit": "lovelace"
+            },
+            "fee": {
+                "quantity": 211,
+                "unit": "lovelace"
+            },
+            "deposit_returned": {
+                "quantity": 205,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "3": {
+                    "bytes": "1e4872067a15091eba67512357"
+                }
+            },
+            "collateral": []
+        },
+        {
+            "status": "in_ledger",
+            "withdrawals": [],
+            "deposit_taken": {
+                "quantity": 35,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "incoming",
+            "collateral_outputs": [],
+            "outputs": [],
+            "script_validity": "valid",
+            "id": "3c4d1877492b0c4b4d33591b73014e10293e0a0f0d791a142ee5379d707d4655",
+            "depth": {
+                "quantity": 19453,
+                "unit": "block"
+            },
+            "amount": {
+                "quantity": 179,
+                "unit": "lovelace"
+            },
+            "inserted_at": {
+                "height": {
+                    "quantity": 22669,
+                    "unit": "block"
+                },
+                "epoch_number": 25931,
+                "time": "1893-12-16T12:27:11.705258843013Z",
+                "absolute_slot_number": 13453142,
+                "slot_number": 30689
+            },
+            "fee": {
+                "quantity": 42,
+                "unit": "lovelace"
+            },
+            "deposit_returned": {
+                "quantity": 123,
+                "unit": "lovelace"
+            },
+            "metadata": null,
+            "collateral": []
+        },
+        {
+            "status": "in_ledger",
+            "withdrawals": [],
+            "deposit_taken": {
+                "quantity": 138,
                 "unit": "lovelace"
             },
             "inputs": [],
@@ -14,59 +117,83 @@
                 {
                     "address": "<addr>",
                     "amount": {
-                        "quantity": 0,
+                        "quantity": 1,
                         "unit": "lovelace"
                     },
                     "assets": []
                 }
             ],
             "outputs": [],
-            "expires_at": {
-                "epoch_number": 28790,
-                "time": "1907-08-09T02:00:00Z",
-                "absolute_slot_number": 6822296,
-                "slot_number": 22067
+            "id": "3c3c09e4a25d10603c1d4d23155e2d01221212102b730c1b855d263f33096c25",
+            "depth": {
+                "quantity": 13180,
+                "unit": "block"
             },
-            "script_validity": "valid",
-            "pending_since": {
-                "height": {
-                    "quantity": 3994,
-                    "unit": "block"
-                },
-                "epoch_number": 32255,
-                "time": "1872-06-30T04:00:52.046884296075Z",
-                "absolute_slot_number": 2181304,
-                "slot_number": 20179
-            },
-            "id": "6e461f231b411f5c06097e4c55196f03712f79556501762c773e2c545939207a",
             "amount": {
-                "quantity": 216,
+                "quantity": 117,
                 "unit": "lovelace"
             },
+            "inserted_at": {
+                "height": {
+                    "quantity": 7240,
+                    "unit": "block"
+                },
+                "epoch_number": 6107,
+                "time": "1901-05-01T08:00:00Z",
+                "absolute_slot_number": 13879225,
+                "slot_number": 6756
+            },
             "fee": {
-                "quantity": 212,
+                "quantity": 104,
                 "unit": "lovelace"
             },
             "deposit_returned": {
-                "quantity": 80,
+                "quantity": 100,
                 "unit": "lovelace"
             },
             "metadata": {
-                "21": {
-                    "map": []
+                "16": {
+                    "map": [
+                        {
+                            "k": {
+                                "string": "놱"
+                            },
+                            "v": {
+                                "map": [
+                                    {
+                                        "k": {
+                                            "string": "𒂄􋱔"
+                                        },
+                                        "v": {
+                                            "int": -2
+                                        }
+                                    },
+                                    {
+                                        "k": {
+                                            "string": "􅨲"
+                                        },
+                                        "v": {
+                                            "bytes": "9a3eda7418653035195403693e7d06cc7fd846372ef0831538584848584c509f3707ca"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "k": {
+                                "string": "􋩁"
+                            },
+                            "v": {
+                                "list": []
+                            }
+                        }
+                    ]
                 }
             },
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e41",
-                    "quantity": 9,
-                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
-                }
-            ]
+            "collateral": []
         },
         {
-            "status": "expired",
+            "status": "in_ledger",
             "withdrawals": [],
             "deposit_taken": {
                 "quantity": 98,
@@ -74,50 +201,170 @@
             },
             "inputs": [],
             "direction": "outgoing",
-            "collateral_outputs": [],
+            "collateral_outputs": [
+                {
+                    "address": "<addr>",
+                    "amount": {
+                        "quantity": 1,
+                        "unit": "lovelace"
+                    },
+                    "assets": []
+                }
+            ],
             "outputs": [],
-            "expires_at": {
-                "epoch_number": 29701,
-                "time": "1875-08-18T00:37:27Z",
-                "absolute_slot_number": 2917283,
-                "slot_number": 11867
-            },
-            "pending_since": {
-                "height": {
-                    "quantity": 3230,
-                    "unit": "block"
-                },
-                "epoch_number": 26902,
-                "time": "1878-12-31T12:00:00Z",
-                "absolute_slot_number": 6997214,
-                "slot_number": 19854
-            },
-            "id": "3641503014516a794c0308e04f6f6f053445fa0f1d0e4a98703537554e052436",
+            "id": "4e710a6706041733342dfe1031303d2a544b351d42a4032a7e26ed7d7601505f",
             "depth": {
-                "quantity": 6488,
+                "quantity": 6092,
                 "unit": "block"
             },
             "amount": {
+                "quantity": 48,
+                "unit": "lovelace"
+            },
+            "inserted_at": {
+                "height": {
+                    "quantity": 25614,
+                    "unit": "block"
+                },
+                "epoch_number": 149,
+                "time": "1881-03-29T04:00:00Z",
+                "absolute_slot_number": 15333495,
+                "slot_number": 27299
+            },
+            "fee": {
+                "quantity": 160,
+                "unit": "lovelace"
+            },
+            "deposit_returned": {
+                "quantity": 196,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "0": {
+                    "bytes": "20338500314ef79005257e1323530414eb324163"
+                }
+            },
+            "collateral": []
+        },
+        {
+            "status": "expired",
+            "withdrawals": [],
+            "deposit_taken": {
+                "quantity": 226,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "incoming",
+            "collateral_outputs": [
+                {
+                    "address": "<addr>",
+                    "amount": {
+                        "quantity": 1,
+                        "unit": "lovelace"
+                    },
+                    "assets": []
+                }
+            ],
+            "outputs": [],
+            "expires_at": {
+                "epoch_number": 22745,
+                "time": "1873-08-02T13:50:18.347642065807Z",
+                "absolute_slot_number": 7809228,
+                "slot_number": 18661
+            },
+            "script_validity": "invalid",
+            "pending_since": {
+                "height": {
+                    "quantity": 9960,
+                    "unit": "block"
+                },
+                "epoch_number": 25945,
+                "time": "1865-11-10T02:20:52Z",
+                "absolute_slot_number": 12904136,
+                "slot_number": 31431
+            },
+            "id": "544f391b4f3734425971f9728b273c2c7f10792608b735ffa90848b04c667f5b",
+            "amount": {
+                "quantity": 29,
+                "unit": "lovelace"
+            },
+            "fee": {
+                "quantity": 162,
+                "unit": "lovelace"
+            },
+            "deposit_returned": {
+                "quantity": 239,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "30": {
+                    "int": 0
+                }
+            },
+            "collateral": []
+        },
+        {
+            "status": "pending",
+            "withdrawals": [],
+            "deposit_taken": {
+                "quantity": 179,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "collateral_outputs": [
+                {
+                    "address": "<addr>",
+                    "amount": {
+                        "quantity": 1,
+                        "unit": "lovelace"
+                    },
+                    "assets": []
+                }
+            ],
+            "outputs": [],
+            "expires_at": {
+                "epoch_number": 6016,
+                "time": "1905-07-18T01:30:18.320653333638Z",
+                "absolute_slot_number": 11387964,
+                "slot_number": 31694
+            },
+            "script_validity": "invalid",
+            "pending_since": {
+                "height": {
+                    "quantity": 665,
+                    "unit": "block"
+                },
+                "epoch_number": 24248,
+                "time": "1868-10-24T05:00:00Z",
+                "absolute_slot_number": 7833053,
+                "slot_number": 22284
+            },
+            "id": "05cf64731802676543021a032a4db857453f790a36505405193d71904b2e227c",
+            "depth": {
+                "quantity": 15790,
+                "unit": "block"
+            },
+            "amount": {
+                "quantity": 73,
+                "unit": "lovelace"
+            },
+            "fee": {
                 "quantity": 20,
                 "unit": "lovelace"
             },
-            "fee": {
-                "quantity": 108,
-                "unit": "lovelace"
-            },
             "deposit_returned": {
-                "quantity": 242,
+                "quantity": 192,
                 "unit": "lovelace"
             },
             "metadata": null,
-            "collateral": [],
-            "mint": []
+            "collateral": []
         },
         {
             "status": "pending",
             "withdrawals": [],
             "deposit_taken": {
-                "quantity": 15,
+                "quantity": 25,
                 "unit": "lovelace"
             },
             "inputs": [],
@@ -134,68 +381,90 @@
             ],
             "outputs": [],
             "expires_at": {
-                "epoch_number": 856,
-                "time": "1903-07-06T03:52:21Z",
-                "absolute_slot_number": 15122955,
-                "slot_number": 29753
+                "epoch_number": 26760,
+                "time": "1884-12-28T14:37:01Z",
+                "absolute_slot_number": 14693967,
+                "slot_number": 13746
             },
-            "script_validity": "valid",
-            "pending_since": {
-                "height": {
-                    "quantity": 20467,
-                    "unit": "block"
-                },
-                "epoch_number": 10256,
-                "time": "1908-07-17T03:32:37.86921690816Z",
-                "absolute_slot_number": 9534834,
-                "slot_number": 11065
-            },
-            "id": "4b731d0b28698e6f506b16732d495348193d2f1f0245f0470f540b7831337d00",
+            "script_validity": "invalid",
+            "id": "42525c622b249f5d6f6b79277b3245698c358c222779734a7178702a2d10bb01",
             "depth": {
-                "quantity": 28478,
+                "quantity": 31946,
                 "unit": "block"
             },
             "amount": {
-                "quantity": 158,
+                "quantity": 31,
                 "unit": "lovelace"
             },
             "fee": {
-                "quantity": 99,
+                "quantity": 177,
                 "unit": "lovelace"
             },
             "deposit_returned": {
-                "quantity": 182,
+                "quantity": 23,
                 "unit": "lovelace"
             },
             "metadata": {
-                "25": {
-                    "string": "⯔"
+                "15": {
+                    "list": [
+                        {
+                            "list": [
+                                {
+                                    "map": [
+                                        {
+                                            "k": {
+                                                "string": "󾔬"
+                                            },
+                                            "v": {
+                                                "int": -1
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "map": [
+                                        {
+                                            "k": {
+                                                "string": "󲬧"
+                                            },
+                                            "v": {
+                                                "string": "􉆧ᠣ"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "map": [
+                                {
+                                    "k": {
+                                        "string": "𣼢"
+                                    },
+                                    "v": {
+                                        "bytes": "3a3d6e1869665e3c48084b6b285fe070c85d692c64245110399b10187630c6b555c504f519171f6b"
+                                    }
+                                },
+                                {
+                                    "k": {
+                                        "string": "􍔭􇎳"
+                                    },
+                                    "v": {
+                                        "list": []
+                                    }
+                                }
+                            ]
+                        }
+                    ]
                 }
             },
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 35,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                },
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 21,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
-                },
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 21,
-                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
-                }
-            ]
+            "collateral": []
         },
         {
             "status": "expired",
             "withdrawals": [],
             "deposit_taken": {
-                "quantity": 14,
+                "quantity": 56,
                 "unit": "lovelace"
             },
             "inputs": [],
@@ -212,436 +481,158 @@
             ],
             "outputs": [],
             "expires_at": {
-                "epoch_number": 21855,
-                "time": "1869-01-16T19:00:00Z",
-                "absolute_slot_number": 16598464,
-                "slot_number": 29244
-            },
-            "pending_since": {
-                "height": {
-                    "quantity": 12214,
-                    "unit": "block"
-                },
-                "epoch_number": 4268,
-                "time": "1894-07-10T09:36:19.450165945698Z",
-                "absolute_slot_number": 12029517,
-                "slot_number": 16945
-            },
-            "id": "6579a76674582b5bfa15d629471e429d72402c7a2f3039006a2c61775a380f4e",
-            "depth": {
-                "quantity": 14403,
-                "unit": "block"
-            },
-            "amount": {
-                "quantity": 227,
-                "unit": "lovelace"
-            },
-            "fee": {
-                "quantity": 155,
-                "unit": "lovelace"
-            },
-            "deposit_returned": {
-                "quantity": 163,
-                "unit": "lovelace"
-            },
-            "metadata": {
-                "6": {
-                    "int": 0
-                }
-            },
-            "collateral": [],
-            "mint": []
-        },
-        {
-            "status": "expired",
-            "withdrawals": [],
-            "deposit_taken": {
-                "quantity": 210,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "incoming",
-            "collateral_outputs": [
-                {
-                    "address": "<addr>",
-                    "amount": {
-                        "quantity": 1,
-                        "unit": "lovelace"
-                    },
-                    "assets": []
-                }
-            ],
-            "outputs": [],
-            "expires_at": {
-                "epoch_number": 12721,
-                "time": "1898-10-05T23:44:54.375049975696Z",
-                "absolute_slot_number": 4144861,
-                "slot_number": 7281
+                "epoch_number": 29568,
+                "time": "1877-03-10T20:26:10.065320592865Z",
+                "absolute_slot_number": 13492235,
+                "slot_number": 15038
             },
             "script_validity": "invalid",
             "pending_since": {
                 "height": {
-                    "quantity": 729,
+                    "quantity": 30456,
                     "unit": "block"
                 },
-                "epoch_number": 12714,
-                "time": "1882-06-23T02:11:40Z",
-                "absolute_slot_number": 10786432,
-                "slot_number": 14068
+                "epoch_number": 17540,
+                "time": "1888-06-30T12:14:54Z",
+                "absolute_slot_number": 6500318,
+                "slot_number": 10773
             },
-            "id": "082c06487a48ae57e909121a53878a445b6f6e54600f3c113103b3bc296c0941",
+            "id": "525f013fb1145e2a1c375b044e1f39474d3b200b4c1e35ea415934701b452db4",
             "depth": {
-                "quantity": 1068,
+                "quantity": 16438,
                 "unit": "block"
             },
             "amount": {
-                "quantity": 253,
+                "quantity": 116,
                 "unit": "lovelace"
             },
             "fee": {
-                "quantity": 71,
-                "unit": "lovelace"
-            },
-            "deposit_returned": {
-                "quantity": 122,
-                "unit": "lovelace"
-            },
-            "metadata": {
-                "14": {
-                    "string": "𘠤딡"
-                }
-            },
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e42",
-                    "quantity": 16,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                },
-                {
-                    "asset_name": "546f6b656e41",
-                    "quantity": 23,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
-                },
-                {
-                    "asset_name": "546f6b656e45",
-                    "quantity": 2,
-                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
-                },
-                {
-                    "asset_name": "546f6b656e41",
-                    "quantity": 16,
-                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
-                }
-            ]
-        },
-        {
-            "status": "expired",
-            "withdrawals": [],
-            "deposit_taken": {
-                "quantity": 59,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "outgoing",
-            "collateral_outputs": [
-                {
-                    "address": "<addr>",
-                    "amount": {
-                        "quantity": 0,
-                        "unit": "lovelace"
-                    },
-                    "assets": []
-                }
-            ],
-            "outputs": [],
-            "expires_at": {
-                "epoch_number": 25929,
-                "time": "1869-04-23T11:00:00Z",
-                "absolute_slot_number": 8859446,
-                "slot_number": 32724
-            },
-            "script_validity": "valid",
-            "pending_since": {
-                "height": {
-                    "quantity": 29180,
-                    "unit": "block"
-                },
-                "epoch_number": 12996,
-                "time": "1865-04-29T08:03:27.153067097292Z",
-                "absolute_slot_number": 10516626,
-                "slot_number": 5997
-            },
-            "id": "4094417024723600505a7cc217414e5934285afa161701096176116553344278",
-            "amount": {
-                "quantity": 44,
-                "unit": "lovelace"
-            },
-            "fee": {
-                "quantity": 86,
-                "unit": "lovelace"
-            },
-            "deposit_returned": {
-                "quantity": 155,
-                "unit": "lovelace"
-            },
-            "metadata": {
-                "25": {
-                    "string": "암"
-                }
-            },
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e44",
-                    "quantity": 25,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
-                }
-            ]
-        },
-        {
-            "status": "pending",
-            "withdrawals": [],
-            "deposit_taken": {
-                "quantity": 210,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "incoming",
-            "collateral_outputs": [
-                {
-                    "address": "<addr>",
-                    "amount": {
-                        "quantity": 1,
-                        "unit": "lovelace"
-                    },
-                    "assets": []
-                }
-            ],
-            "outputs": [],
-            "expires_at": {
-                "epoch_number": 11570,
-                "time": "1894-04-20T19:00:00Z",
-                "absolute_slot_number": 2153245,
-                "slot_number": 8201
-            },
-            "id": "787f427344690422250023502e6d17f83d500219847c5471823a0c3d337a0547",
-            "depth": {
-                "quantity": 998,
-                "unit": "block"
-            },
-            "amount": {
-                "quantity": 135,
-                "unit": "lovelace"
-            },
-            "fee": {
-                "quantity": 102,
-                "unit": "lovelace"
-            },
-            "deposit_returned": {
-                "quantity": 36,
-                "unit": "lovelace"
-            },
-            "metadata": {
-                "11": {
-                    "int": 0
-                }
-            },
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e42",
-                    "quantity": 13,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                }
-            ]
-        },
-        {
-            "status": "expired",
-            "withdrawals": [],
-            "deposit_taken": {
                 "quantity": 208,
                 "unit": "lovelace"
             },
-            "inputs": [],
-            "direction": "outgoing",
-            "collateral_outputs": [],
-            "outputs": [],
-            "expires_at": {
-                "epoch_number": 18238,
-                "time": "1878-03-25T10:00:00Z",
-                "absolute_slot_number": 13569160,
-                "slot_number": 16996
-            },
-            "script_validity": "invalid",
-            "pending_since": {
-                "height": {
-                    "quantity": 19622,
-                    "unit": "block"
-                },
-                "epoch_number": 6313,
-                "time": "1889-10-18T21:56:21.058122255785Z",
-                "absolute_slot_number": 1444498,
-                "slot_number": 29887
-            },
-            "id": "592077047756b07e31ed48a43951d77b696002272a1d4e077c194f58350d4b39",
-            "depth": {
-                "quantity": 31724,
-                "unit": "block"
-            },
-            "amount": {
-                "quantity": 19,
-                "unit": "lovelace"
-            },
-            "fee": {
-                "quantity": 142,
-                "unit": "lovelace"
-            },
             "deposit_returned": {
-                "quantity": 119,
+                "quantity": 166,
                 "unit": "lovelace"
             },
-            "metadata": null,
-            "collateral": [],
-            "mint": []
+            "metadata": {
+                "17": {
+                    "list": [
+                        {
+                            "bytes": "59406d292666c4042128056e3fe775e53d453f440f6d1b32043d16"
+                        },
+                        {
+                            "list": [
+                                {
+                                    "list": []
+                                }
+                            ]
+                        },
+                        {
+                            "list": [
+                                {
+                                    "map": [
+                                        {
+                                            "k": {
+                                                "string": "ⲙ"
+                                            },
+                                            "v": {
+                                                "int": 1
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "list": []
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "collateral": []
         },
         {
-            "status": "expired",
+            "status": "in_ledger",
             "withdrawals": [],
             "deposit_taken": {
-                "quantity": 137,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "incoming",
-            "collateral_outputs": [
-                {
-                    "address": "<addr>",
-                    "amount": {
-                        "quantity": 1,
-                        "unit": "lovelace"
-                    },
-                    "assets": []
-                }
-            ],
-            "outputs": [],
-            "expires_at": {
-                "epoch_number": 8098,
-                "time": "1902-12-22T12:52:31.48455326189Z",
-                "absolute_slot_number": 7212224,
-                "slot_number": 5401
-            },
-            "script_validity": "invalid",
-            "id": "7e6e01554a3789973a1f7dd765b825160924fa004e0a1199531d27ec76006055",
-            "depth": {
-                "quantity": 29025,
-                "unit": "block"
-            },
-            "amount": {
-                "quantity": 65,
-                "unit": "lovelace"
-            },
-            "fee": {
-                "quantity": 233,
-                "unit": "lovelace"
-            },
-            "deposit_returned": {
-                "quantity": 66,
-                "unit": "lovelace"
-            },
-            "metadata": null,
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e41",
-                    "quantity": 22,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                },
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 28,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                },
-                {
-                    "asset_name": "546f6b656e44",
-                    "quantity": 15,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
-                },
-                {
-                    "asset_name": "546f6b656e44",
-                    "quantity": 22,
-                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
-                },
-                {
-                    "asset_name": "546f6b656e45",
-                    "quantity": 24,
-                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
-                },
-                {
-                    "asset_name": "546f6b656e42",
-                    "quantity": 5,
-                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
-                },
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 6,
-                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
-                },
-                {
-                    "asset_name": "546f6b656e44",
-                    "quantity": 1,
-                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
-                }
-            ]
-        },
-        {
-            "status": "expired",
-            "withdrawals": [],
-            "deposit_taken": {
-                "quantity": 15,
+                "quantity": 91,
                 "unit": "lovelace"
             },
             "inputs": [],
             "direction": "incoming",
             "collateral_outputs": [],
             "outputs": [],
-            "expires_at": {
-                "epoch_number": 22973,
-                "time": "1868-01-03T13:41:07Z",
-                "absolute_slot_number": 5060782,
-                "slot_number": 22317
-            },
-            "script_validity": "invalid",
-            "pending_since": {
-                "height": {
-                    "quantity": 29478,
-                    "unit": "block"
-                },
-                "epoch_number": 8434,
-                "time": "1892-12-11T10:40:46Z",
-                "absolute_slot_number": 1898385,
-                "slot_number": 32617
-            },
-            "id": "02fe02315217072c269e76b412482577284a165f4f33d92f7a4b320025d001c0",
-            "depth": {
-                "quantity": 18280,
-                "unit": "block"
-            },
+            "id": "30756306481722033039be407e9252975636748f6d7375274b387a502e04385c",
             "amount": {
-                "quantity": 217,
+                "quantity": 149,
                 "unit": "lovelace"
             },
+            "inserted_at": {
+                "height": {
+                    "quantity": 30713,
+                    "unit": "block"
+                },
+                "epoch_number": 3487,
+                "time": "1884-10-04T02:51:13.770809250957Z",
+                "absolute_slot_number": 12100795,
+                "slot_number": 31394
+            },
             "fee": {
-                "quantity": 47,
+                "quantity": 118,
                 "unit": "lovelace"
             },
             "deposit_returned": {
-                "quantity": 4,
+                "quantity": 86,
                 "unit": "lovelace"
             },
             "metadata": null,
-            "collateral": [],
-            "mint": []
+            "collateral": []
+        },
+        {
+            "status": "pending",
+            "withdrawals": [],
+            "deposit_taken": {
+                "quantity": 143,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "incoming",
+            "collateral_outputs": [],
+            "outputs": [],
+            "script_validity": "invalid",
+            "pending_since": {
+                "height": {
+                    "quantity": 27204,
+                    "unit": "block"
+                },
+                "epoch_number": 7607,
+                "time": "1883-06-01T22:56:55Z",
+                "absolute_slot_number": 2343272,
+                "slot_number": 18457
+            },
+            "id": "d1443c7e29399e375d54d7242a1442a53539607d8f6951f929a5b3414037aa61",
+            "depth": {
+                "quantity": 28258,
+                "unit": "block"
+            },
+            "amount": {
+                "quantity": 172,
+                "unit": "lovelace"
+            },
+            "fee": {
+                "quantity": 199,
+                "unit": "lovelace"
+            },
+            "deposit_returned": {
+                "quantity": 226,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "1": {
+                    "string": "𫘚"
+                }
+            },
+            "collateral": []
         }
     ]
 }

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1182,8 +1182,6 @@ spec = parallel $ do
                         (x :: ApiTransaction ('Testnet 0))
                     , withdrawals = withdrawals
                         (x :: ApiTransaction ('Testnet 0))
-                    , mint = mint
-                        (x :: ApiTransaction ('Testnet 0))
                     , metadata = metadata
                         (x :: ApiTransaction ('Testnet 0))
                     , scriptValidity = scriptValidity
@@ -2550,7 +2548,6 @@ instance Arbitrary (ApiTransaction n) where
             <*> genCollateral
             <*> genCollateralOutputs
             <*> genWithdrawals
-            <*> arbitrary
             <*> pure txStatus
             <*> arbitrary
             <*> liftArbitrary (ApiT <$> genTxScriptValidity)

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -130,23 +130,16 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , Tx (..)
-    , TxBurn (..)
     , TxIn (..)
     , TxMeta (..)
     , TxMetadata
-    , TxMint (..)
     , TxOut (..)
     , TxScriptValidity (..)
     , TxStatus (..)
     , isPending
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxBurn
-    , genTxMint
-    , genTxOutCoin
-    , genTxScriptValidity
-    , shrinkTxScriptValidity
-    )
+    ( genTxOutCoin, genTxScriptValidity, shrinkTxScriptValidity )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Unsafe
@@ -417,11 +410,11 @@ arbitraryChainLength = 10
 -------------------------------------------------------------------------------}
 
 instance Arbitrary Tx where
-    shrink (Tx _tid fees ins cins outs cout tmint tburn wdrls md validity) =
-        [ mkTx fees ins' cins' outs' cout' tmint' tburn' wdrls' md' validity'
-        | (ins', cins', outs', cout', tmint', tburn', wdrls', md', validity')
+    shrink (Tx _tid fees ins cins outs cout wdrls md validity) =
+        [ mkTx fees ins' cins' outs' cout' wdrls' md' validity'
+        | (ins', cins', outs', cout', wdrls', md', validity')
             <- shrink
-                (ins, cins, outs, cout, tmint, tburn, wdrls, md, validity)
+                (ins, cins, outs, cout, wdrls, md, validity)
         ]
 
     arbitrary = do
@@ -429,19 +422,14 @@ instance Arbitrary Tx where
         cins <- fmap (L.nub . L.take 5 . getNonEmpty) arbitrary
         outs <- fmap (L.take 5 . getNonEmpty) arbitrary
         cout <- arbitrary
-        tmint <- scale (`div` 4) genTxMint
-        tburn <- scale (`div` 4) genTxBurn
         wdrls <- fmap (Map.fromList . L.take 5) arbitrary
         fees <- arbitrary
-        mkTx fees ins cins outs cout tmint tburn wdrls
+        mkTx fees ins cins outs cout wdrls
             <$> arbitrary <*> liftArbitrary genTxScriptValidity
 
 instance Arbitrary TokenMap where
     arbitrary = genTokenMap
     shrink = shrinkTokenMap
-
-deriving instance (Arbitrary TxMint)
-deriving instance (Arbitrary TxBurn)
 
 instance Arbitrary TxIn where
     arbitrary = TxIn

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -160,10 +160,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , TransactionInfo (..)
     , Tx (..)
-    , TxBurn (..)
     , TxIn (..)
     , TxMeta (..)
-    , TxMint (..)
     , TxOut (..)
     , TxScriptValidity (..)
     , TxStatus (..)
@@ -595,8 +593,6 @@ fileModeSpec =  do
                                             (coinToBundle 8)
                                     ]
                                 , collateralOutput = Nothing
-                                , mint = TxMint mempty
-                                , burn = TxBurn mempty
                                 , withdrawals = mempty
                                 , metadata = Nothing
                                 , scriptValidity = Just TxScriptValid
@@ -623,8 +619,6 @@ fileModeSpec =  do
                                     (fst $ ourAddrs !! 1) (coinToBundle 2)
                                 ]
                             , collateralOutput = Nothing
-                            , mint = TxMint mempty
-                            , burn = TxBurn mempty
                             , withdrawals = mempty
                             , metadata = Nothing
                             , scriptValidity = Just TxScriptInvalid
@@ -663,8 +657,6 @@ fileModeSpec =  do
                             , outputs =
                                 [TxOut (fst $ head ourAddrs) (coinToBundle 4)]
                             , collateralOutput = Nothing
-                            , mint = TxMint mempty
-                            , burn = TxBurn mempty
                             , withdrawals = mempty
                             , metadata = Nothing
                             , scriptValidity = Nothing
@@ -688,8 +680,6 @@ fileModeSpec =  do
                             , TxOut (fst $ ourAddrs !! 1) (coinToBundle 2)
                             ]
                         , collateralOutput = Nothing
-                        , mint = TxMint mempty
-                        , burn = TxBurn mempty
                         , withdrawals = mempty
                         , metadata = Nothing
                         , scriptValidity = Nothing
@@ -1348,8 +1338,6 @@ testTxs = [(tx, txMeta)]
             []
         , outputs = [TxOut (Address "addr") (coinToBundle 1)]
         , collateralOutput = Nothing
-        , mint = TxMint mempty
-        , burn = TxBurn mempty
         , withdrawals = mempty
         , metadata = Nothing
         , scriptValidity = Nothing

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -170,11 +170,9 @@ import Cardano.Wallet.Primitive.Types.Tx
     , SealedTx (..)
     , TransactionInfo (..)
     , Tx (..)
-    , TxBurn (..)
     , TxIn (..)
     , TxMeta
     , TxMetadata
-    , TxMint (..)
     , TxOut (..)
     , TxScriptValidity
     , TxSize (..)
@@ -1002,12 +1000,6 @@ instance ToExpr WalletMetadata where
     toExpr = defaultExprViaShow
 
 instance ToExpr Tx where
-    toExpr = genericToExpr
-
-instance ToExpr TxMint where
-    toExpr = genericToExpr
-
-instance ToExpr TxBurn where
     toExpr = genericToExpr
 
 instance ToExpr TxScriptValidity where

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -84,10 +84,8 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , Tx (..)
-    , TxBurn (..)
     , TxIn (..)
     , TxMeta (direction)
-    , TxMint (..)
     , TxOut (..)
     , TxScriptValidity (..)
     , collateralInputs
@@ -1128,10 +1126,6 @@ instance Arbitrary (WithPending WalletState) where
                         , resolvedCollateralInputs = []
                         -- TODO: [ADP-1670]
                         , collateralOutput = Nothing
-                        -- TODO: [ADP-1654]
-                        , mint = TxMint mempty
-                        -- TODO: [ADP-1654]
-                        , burn = TxBurn mempty
                         , outputs = [out {tokens}]
                         , withdrawals = mempty
                         , metadata = Nothing
@@ -1223,8 +1217,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1261,8 +1253,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1288,8 +1278,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1326,8 +1314,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1353,8 +1339,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1391,8 +1375,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1439,8 +1421,6 @@ blockchain =
                       }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1476,8 +1456,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1514,8 +1492,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1566,8 +1542,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1644,8 +1618,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1671,8 +1643,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1709,8 +1679,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1736,8 +1704,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1834,8 +1800,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1861,8 +1825,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1899,8 +1861,6 @@ blockchain =
                         }
                     ]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TxSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TxSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
@@ -12,9 +11,7 @@ module Cardano.Wallet.Primitive.Types.TxSpec
 import Prelude
 
 import Cardano.Wallet.Primitive.Types.Tx
-    ( SealedTx (..), TxBurn, TxMint, mockSealedTx, sealedTxFromBytes )
-import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxBurn, genTxMint, shrinkTxBurn, shrinkTxMint )
+    ( SealedTx (..), mockSealedTx, sealedTxFromBytes )
 import Data.ByteString
     ( ByteString, pack )
 import Data.Either
@@ -27,10 +24,6 @@ import Test.Hspec.QuickCheck
     ( prop )
 import Test.QuickCheck
     ( Arbitrary (..), Property, (.&&.), (===) )
-import Test.QuickCheck.Classes
-    ( ordLaws )
-import Test.Utils.Laws
-    ( testLaws )
 
 spec :: Spec
 spec = do
@@ -40,10 +33,6 @@ spec = do
             prop_sealedTxGibberish
         prop "mockSealedTx - passes through mock values"
             prop_mockSealedTx
-
-    parallel $ describe "Minting and burning" $ do
-        testLaws @TxMint ordLaws
-        testLaws @TxBurn ordLaws
 
 {-------------------------------------------------------------------------------
                          Evaluation of SealedTx fields
@@ -62,15 +51,3 @@ newtype Gibberish = Gibberish ByteString deriving (Show, Read, Eq)
 
 instance Arbitrary Gibberish where
     arbitrary = Gibberish . pack <$> arbitrary
-
---------------------------------------------------------------------------------
--- Minting and burning
---------------------------------------------------------------------------------
-
-instance Arbitrary TxMint where
-    arbitrary = genTxMint
-    shrink = shrinkTxMint
-
-instance Arbitrary TxBurn where
-    arbitrary = genTxBurn
-    shrink = shrinkTxBurn

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -131,11 +131,9 @@ import Cardano.Wallet.Primitive.Types.Tx
     , SealedTx (..)
     , TransactionInfo (..)
     , Tx (..)
-    , TxBurn (..)
     , TxIn (..)
     , TxMeta (..)
     , TxMetadata
-    , TxMint (..)
     , TxOut (..)
     , TxStatus (..)
     , isPending
@@ -683,8 +681,6 @@ walletListsOnlyRelatedAssets txId txMeta =
                 , resolvedCollateralInputs = mempty
                 , outputs = [out1, out2]
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , metadata = mempty
                 , withdrawals = mempty
                 , scriptValidity = Nothing
@@ -804,8 +800,6 @@ instance Arbitrary GenTxHistory where
             , resolvedCollateralInputs = []
             , outputs = []
             , collateralOutput = Nothing
-            , mint = TxMint mempty
-            , burn = TxBurn mempty
             , withdrawals = mempty
             , metadata = Nothing
             , scriptValidity = Nothing
@@ -1352,8 +1346,6 @@ dummyTransactionLayer = TransactionLayer
                 , resolvedCollateralInputs = cinps'
                 , outputs = view #outputs cs
                 , collateralOutput = Nothing
-                , mint = TxMint mempty
-                , burn = TxBurn mempty
                 , withdrawals = mempty
                 , metadata = Nothing
                 , scriptValidity = Nothing
@@ -1401,8 +1393,6 @@ dummyTransactionLayer = TransactionLayer
             , resolvedCollateralInputs = mempty
             , outputs = mempty
             , collateralOutput = Nothing
-            , mint = TxMint mempty
-            , burn = TxBurn mempty
             , withdrawals = mempty
             , metadata = mempty
             , scriptValidity = Nothing

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -218,10 +218,6 @@ genesisBlockFromTxOuts gp outs = W.Block
         , resolvedCollateralInputs = []
         , outputs = [out]
         , collateralOutput = Nothing
-        -- Minting was not supported at the time of genesis:
-        , mint = W.TxMint mempty
-        -- Burning was not supported at the time of genesis:
-        , burn = W.TxBurn mempty
         , withdrawals = mempty
         , metadata = Nothing
         , scriptValidity = Nothing
@@ -287,11 +283,6 @@ fromTxAux txAux = case taTx txAux of
 
         , collateralOutput =
             Nothing
-
-        -- Minting was not supported in the Byron era:
-        , mint = W.TxMint mempty
-        -- Burning was not supported in the Byron era:
-        , burn = W.TxBurn mempty
 
         , withdrawals =
             mempty

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -1216,10 +1216,6 @@ fromGenesisData g initialFunds =
                 ]
             -- Collateral outputs were not supported at the time of genesis:
             , collateralOutput = Nothing
-            -- Minting was not supported at the time of genesis:
-            , mint = W.TxMint mempty
-            -- Burning was not supported at the time of genesis:
-            , burn = W.TxBurn mempty
             , withdrawals = mempty
             , metadata = Nothing
             , scriptValidity = Nothing
@@ -1399,10 +1395,6 @@ fromShelleyTx tx =
         , collateralOutput =
             -- Collateral outputs are not supported in Shelley.
             Nothing
-        -- TODO: [ADP-1654]
-        , mint = W.TxMint mempty
-        -- TODO: [ADP-1654]
-        , burn = W.TxBurn mempty
         , withdrawals =
             fromShelleyWdrl wdrls
         , metadata =
@@ -1442,10 +1434,6 @@ fromAllegraTx tx =
         , collateralOutput =
             -- Collateral outputs are not supported in Allegra.
             Nothing
-        -- Minting was not supporetd in Allegra.
-        , mint = W.TxMint mempty
-        -- Burning was not supported in Allegra.
-        , burn = W.TxBurn mempty
         , withdrawals =
             fromShelleyWdrl wdrls
         , metadata =
@@ -1503,10 +1491,6 @@ fromMaryTx tx =
         , collateralOutput =
             -- Collateral outputs are not supported in Mary.
             Nothing
-        -- TODO: [ADP-1654]
-        , mint = W.TxMint mempty
-        -- TODO: [ADP-1654]
-        , burn = W.TxBurn mempty
         , withdrawals =
             fromShelleyWdrl wdrls
         , metadata =
@@ -1603,10 +1587,6 @@ fromAlonzoTxBodyAndAux bod mad wits =
         , collateralOutput =
             -- Collateral outputs are not supported in Alonzo.
             Nothing
-        -- TODO: [ADP-1654]
-        , mint = W.TxMint mempty
-        -- TODO: [ADP-1654]
-        , burn = W.TxBurn mempty
         , withdrawals =
             fromShelleyWdrl wdrls
         , metadata =

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -954,22 +954,6 @@ x-walletAssets: &walletAssets
   type: array
   items: *walletAsset
 
-x-assetMint: &assetMint
-  type: object
-  required:
-    - policy_id
-    - asset_name
-    - quantity
-  properties:
-    policy_id: *assetPolicyId
-    asset_name: *assetName
-    fingerprint: *assetFingerprint
-    quantity:
-      type: integer
-      description: |
-        Positive values mean creation and negative values mean
-        destruction.
-
 x-walletAssetsBalance: &walletAssetsBalance
   description: |
     Current non-Ada asset holdings of the wallet.
@@ -1352,22 +1336,6 @@ x-transactionDelegations: &transactionDelegations
   minItems: 0
   items:
     <<: *multiDelegationAction
-
-x-transactionMint: &transactionMint
-  description: |
-    <p>status: <strong>⚠ under development</strong></p>
-
-    _This field is not implemented yet, and will always be empty._
-
-    Assets minted (created) or unminted (destroyed)
-
-    This amount contributes to the total transaction value.
-
-    Positive values denote creation of assets and negative values
-    denote the reverse.
-  type: array
-  minItems: 0
-  items: *assetMint
 
 x-transactionChange: &transactionChange
   description: A list of transaction change outputs.
@@ -2522,7 +2490,6 @@ components:
         - inputs
         - outputs
         - withdrawals
-        - mint
         - status
       properties:
         id: *transactionId
@@ -2550,7 +2517,6 @@ components:
         collateral: *transactionCollateral
         collateral_outputs: *transactionCollateralOutputs
         withdrawals: *transactionWithdrawals
-        mint: *transactionMint
         status: *transactionStatus
         metadata: *transactionMetadata
         script_validity: *txScriptValidity


### PR DESCRIPTION
## Issue Number

ADP-1654

## Summary

In this PR, we:

1. Remove (currently unused) field `mint` from `Api.Types.ApiTransaction`.
2. Remove fields `{mint,burn}` from `Primitive.Types.Tx`.
3. Remove fields `txInfo{Mint,Burn}` from `Primitive.Types.TransactionInfo`.
4. Remove types `Primitive.Types.Tx{Mint,Burn}`.
5. Remove database relations `Tx{Mint,Burn}`.