### PR TITLE
Remove MacOS build from list of required builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,11 @@
 
       mkRequiredJob = hydraJobs:
         let
-          nonRequiredPaths = map lib.hasPrefix [ ];
+          nonRequiredPaths = map lib.hasPrefix [
+            # Temporarily disable macos builds until regular timeouts are fixed
+            # (ADP-1737).
+            "macos"
+          ];
         in
         self.legacyPackages.${lib.head supportedSystems}.pkgs.releaseTools.aggregate {
           name = "github-required";


### PR DESCRIPTION

- MacOS builds are consistently timing out, remove them from the required set until we can fix this.

### Issue Number

ADP-1737
