### PR TITLE
Unify calculation of wallet id for multisig wallets

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -60,7 +60,7 @@ source-repository-package
   type: git
   location: https://github.com/biocad/servant-openapi3
   tag: 4165b837d3a71debd1059c3735460075840000b5
-  
+
 -- TODO: ADP-1713
 source-repository-package
   type: git
@@ -80,7 +80,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-addresses
-    tag: 8bf98905b903455196495e231b23613ad2264cb0
+    tag: b33e0f365550bd9d329bdbb0a0d2dfe2b23a3dcf
     subdir: command-line
             core
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Wallets.hs
@@ -268,6 +268,30 @@ spec = describe "SHARED_WALLETS" $ do
 
         (walAcctSameActive ^. #id)  `shouldBe` (walActive ^. #id)
 
+        let payloadAcctSameOtherScript = Json [json| {
+                "name": "Shared Wallet",
+                "account_public_key": #{accXPubDerived},
+                "account_index": "30H",
+                "payment_script_template":
+                    { "cosigners":
+                        { "cosigner#0": #{accXPubDerived} },
+                      "template":
+                          { "all":
+                             [ "cosigner#0",
+                               { "active_from": 100 }
+                             ]
+                          }
+                    }
+                } |]
+        rPostAcctSameOtherScript <- postSharedWallet ctx Default payloadAcctSameOtherScript
+        verify (fmap (view #wallet) <$> rPostAcctSameOtherScript)
+            [ expectResponseCode HTTP.status201 ]
+        let walAcctSameOtherScript = getFromResponse id rPostAcctSameOtherScript
+        let (ApiSharedWallet (Right walAcctSameOtherScriptActive)) = walAcctSameOtherScript
+
+        (walAcctSameOtherScriptActive ^. #id)  `shouldNotBe` (walActive ^. #id)
+
+
     it "SHARED_WALLETS_CREATE_02 - Create a pending shared wallet from root xprv" $ \ctx -> runResourceT $ do
         m15txt <- liftIO $ genMnemonics M15
         m12txt <- liftIO $ genMnemonics M12

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -415,8 +415,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     , SharedState (..)
     , mkSharedStateFromAccountXPub
     , mkSharedStateFromRootXPrv
-    , validateScriptTemplates
     , toSharedWalletId
+    , validateScriptTemplates
     )
 import Cardano.Wallet.Primitive.Delegation.UTxO
     ( stakeKeyCoinDistr )

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1054,11 +1054,11 @@ postSharedWalletFromRootXPrv ctx generateKey body = do
     rootXPrv = generateKey (seed, secondFactor) pwdP
     g = defaultAddressPoolGap
     ix = getApiT (body ^. #accountIndex)
-    wid = WalletId $ digest $ publicKey rootXPrv
     pTemplate = scriptTemplateFromSelf (getRawKey accXPub) $ body ^. #paymentScriptTemplate
     dTemplateM = scriptTemplateFromSelf (getRawKey accXPub) <$> body ^. #delegationScriptTemplate
     wName = getApiT (body ^. #name)
     accXPub = publicKey $ deriveAccountPrivateKey pwdP rootXPrv (Index $ getDerivationIndex ix)
+    wid = WalletId $ digest accXPub
     scriptValidation = maybe RecommendedValidation getApiT (body ^. #scriptValidation)
 
 postSharedWalletFromAccountXPub

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -416,6 +416,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     , mkSharedStateFromAccountXPub
     , mkSharedStateFromRootXPrv
     , validateScriptTemplates
+    , toSharedWalletId
     )
 import Cardano.Wallet.Primitive.Delegation.UTxO
     ( stakeKeyCoinDistr )
@@ -1058,7 +1059,7 @@ postSharedWalletFromRootXPrv ctx generateKey body = do
     dTemplateM = scriptTemplateFromSelf (getRawKey accXPub) <$> body ^. #delegationScriptTemplate
     wName = getApiT (body ^. #name)
     accXPub = publicKey $ deriveAccountPrivateKey pwdP rootXPrv (Index $ getDerivationIndex ix)
-    wid = WalletId $ digest accXPub
+    wid = WalletId $ toSharedWalletId accXPub pTemplate dTemplateM
     scriptValidation = maybe RecommendedValidation getApiT (body ^. #scriptValidation)
 
 postSharedWalletFromAccountXPub
@@ -1098,7 +1099,7 @@ postSharedWalletFromAccountXPub ctx liftKey body = do
     wName = getApiT (body ^. #name)
     (ApiAccountPublicKey accXPubApiT) =  body ^. #accountPublicKey
     accXPub = getApiT accXPubApiT
-    wid = WalletId $ digest (liftKey accXPub)
+    wid = WalletId $ toSharedWalletId (liftKey accXPub) pTemplate dTemplateM
     scriptValidation = maybe RecommendedValidation getApiT (body ^. #scriptValidation)
 
 scriptTemplateFromSelf :: XPub -> ApiScriptTemplateEntry -> ScriptTemplate

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
@@ -61,6 +61,8 @@ import Cardano.Address.Script
     , toScriptHash
     , validateScriptTemplate
     )
+import Cardano.Address.Script.Parser
+    ( scriptToText )
 import Cardano.Address.Style.Shelley
     ( Credential (..), delegationAddress, paymentAddress )
 import Cardano.Crypto.Wallet
@@ -611,8 +613,8 @@ toSharedWalletId
 toSharedWalletId accXPub pTemplate dTemplateM =
     hash $
     (unXPub . getRawKey $ accXPub) <>
-    toByteString pTemplate <>
-    maybe mempty toByteString dTemplateM
+    serializeScriptTemplate pTemplate <>
+    maybe mempty serializeScriptTemplate dTemplateM
   where
-    toByteString (ScriptTemplate _ script) =
-        T.encodeUtf8 $ T.pack $ show script
+    serializeScriptTemplate (ScriptTemplate _ script) =
+        T.encodeUtf8 $ scriptToText script

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
@@ -615,4 +615,4 @@ toSharedWalletId accXPub pTemplate dTemplateM =
     maybe mempty toByteString dTemplateM
   where
     toByteString (ScriptTemplate _ script) =
-        T.encodeUtf8 $ T.pack $ show $ script
+        T.encodeUtf8 $ T.pack $ show script

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
@@ -40,6 +40,7 @@ module Cardano.Wallet.Primitive.AddressDiscovery.Shared
     , isShared
     , retrieveAllCosigners
     , validateScriptTemplates
+    , toSharedWalletId
 
     , CredentialType (..)
     , liftPaymentAddress
@@ -63,7 +64,7 @@ import Cardano.Address.Script
 import Cardano.Address.Style.Shelley
     ( Credential (..), delegationAddress, paymentAddress )
 import Cardano.Crypto.Wallet
-    ( XPrv, XPub )
+    ( XPrv, XPub, unXPub )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , DerivationIndex (..)
@@ -108,6 +109,8 @@ import Control.DeepSeq
     ( NFData )
 import Control.Monad
     ( unless )
+import Crypto.Hash
+    ( Blake2b_160, Digest, hash )
 import Data.Either
     ( isRight )
 import Data.Either.Combinators
@@ -134,6 +137,7 @@ import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 
 -- | Convenient alias for commonly used class contexts on keys.
 type SupportsDiscovery (n :: NetworkDiscriminant) k =
@@ -597,3 +601,18 @@ liftDelegationAddress ix dTemplate (KeyFingerprint fingerprint) =
     delegationCredential = DelegationFromScript . toScriptHash
     dScript =
         replaceCosignersWithVerKeys CA.Stake dTemplate ix
+
+toSharedWalletId
+    :: (WalletKey k, k ~ SharedKey)
+    => k 'AccountK XPub
+    -> ScriptTemplate
+    -> Maybe ScriptTemplate
+    -> Digest Blake2b_160
+toSharedWalletId accXPub pTemplate dTemplateM =
+    hash $
+    (unXPub . getRawKey $ accXPub) <>
+    toByteString pTemplate <>
+    maybe mempty toByteString dTemplateM
+  where
+    toByteString (ScriptTemplate _ script) =
+        T.encodeUtf8 $ T.pack $ show $ script

--- a/nix/materialized/stack-nix/.stack-to-nix.cache
+++ b/nix/materialized/stack-nix/.stack-to-nix.cache
@@ -1,5 +1,5 @@
-https://github.com/input-output-hk/cardano-addresses 8bf98905b903455196495e231b23613ad2264cb0 command-line 0jzlm1gnlbvz9kify2z74v9iydy6vf39nk954r73yaddknhxrq2r cardano-addresses-cli .stack-to-nix.cache.0
-https://github.com/input-output-hk/cardano-addresses 8bf98905b903455196495e231b23613ad2264cb0 core 0jzlm1gnlbvz9kify2z74v9iydy6vf39nk954r73yaddknhxrq2r cardano-addresses .stack-to-nix.cache.1
+https://github.com/input-output-hk/cardano-addresses b33e0f365550bd9d329bdbb0a0d2dfe2b23a3dcf command-line 05vj2fc6n8rmn3ch6115pc6l5vw6pqbv2kwbzxf3y41sa40k50vc cardano-addresses-cli .stack-to-nix.cache.0
+https://github.com/input-output-hk/cardano-addresses b33e0f365550bd9d329bdbb0a0d2dfe2b23a3dcf core 05vj2fc6n8rmn3ch6115pc6l5vw6pqbv2kwbzxf3y41sa40k50vc cardano-addresses .stack-to-nix.cache.1
 https://github.com/biocad/servant-openapi3 4165b837d3a71debd1059c3735460075840000b5 . 1dngrr353kjhmwhn0b289jzqz5rf32llwcv79zcyq15ldpqpbib9 servant-openapi3 .stack-to-nix.cache.2
 https://github.com/paolino/openapi3 c30d0de6875d75edd64d1aac2272886528bc492d . 0b0fzj5vrnfrc8qikabxhsnp4p8lrjpssblbh2rb7aji5hzzfli9 openapi3 .stack-to-nix.cache.3
 https://github.com/input-output-hk/optparse-applicative 7497a29cb998721a9068d5725d49461f2bba0e7a . 1gvsrg925vynwgqwplgjmp53vj953qyh3wbdf34pw21c8r47w35r optparse-applicative-fork .stack-to-nix.cache.4

--- a/nix/materialized/stack-nix/.stack-to-nix.cache.0
+++ b/nix/materialized/stack-nix/.stack-to-nix.cache.0
@@ -82,5 +82,5 @@
         };
       };
     } // rec {
-    src = (pkgs.lib).mkDefault /nix/store/ygizp24vac8mm3j4dq59sajld3l4v991-cardano-addresses-8bf9890/command-line;
+    src = (pkgs.lib).mkDefault /nix/store/mppiglijmgwx201yk20kkcfdx3zp7101-cardano-addresses-b33e0f3/command-line;
     }

--- a/nix/materialized/stack-nix/.stack-to-nix.cache.1
+++ b/nix/materialized/stack-nix/.stack-to-nix.cache.1
@@ -77,5 +77,5 @@
         };
       };
     } // rec {
-    src = (pkgs.lib).mkDefault /nix/store/ygizp24vac8mm3j4dq59sajld3l4v991-cardano-addresses-8bf9890/core;
+    src = (pkgs.lib).mkDefault /nix/store/mppiglijmgwx201yk20kkcfdx3zp7101-cardano-addresses-b33e0f3/core;
     }

--- a/nix/sha256map.nix
+++ b/nix/sha256map.nix
@@ -1,5 +1,5 @@
 {
-  "https://github.com/input-output-hk/cardano-addresses"."8bf98905b903455196495e231b23613ad2264cb0" = "0jzlm1gnlbvz9kify2z74v9iydy6vf39nk954r73yaddknhxrq2r";
+  "https://github.com/input-output-hk/cardano-addresses"."b33e0f365550bd9d329bdbb0a0d2dfe2b23a3dcf" = "05vj2fc6n8rmn3ch6115pc6l5vw6pqbv2kwbzxf3y41sa40k50vc";
   "https://github.com/biocad/servant-openapi3"."4165b837d3a71debd1059c3735460075840000b5" = "1dngrr353kjhmwhn0b289jzqz5rf32llwcv79zcyq15ldpqpbib9";
   "https://github.com/paolino/openapi3"."c30d0de6875d75edd64d1aac2272886528bc492d" = "0b0fzj5vrnfrc8qikabxhsnp4p8lrjpssblbh2rb7aji5hzzfli9";
   "https://github.com/input-output-hk/optparse-applicative"."7497a29cb998721a9068d5725d49461f2bba0e7a" = "1gvsrg925vynwgqwplgjmp53vj953qyh3wbdf34pw21c8r47w35r";

--- a/stack.yaml
+++ b/stack.yaml
@@ -77,7 +77,7 @@ extra-deps:
 
 # cardano-addresses-3.9.0
 - git: https://github.com/input-output-hk/cardano-addresses
-  commit: 8bf98905b903455196495e231b23613ad2264cb0
+  commit: b33e0f365550bd9d329bdbb0a0d2dfe2b23a3dcf
   subdirs:
     - command-line
     - core


### PR DESCRIPTION
<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->


- [x] I have unified how wallet id is calculated in multisig wallets. Basically I wanted to achieve the following:
1. for a given wallet created from mnemonic and account pubic key (and having the same payment/staking script) we end up with the same wallet id. This is not the case for shelley wallets where wallet id from mnemonic and account public key are different as the first is calculated on pub key of rootK, and the second is calculated based on account public key. I think this is wrong, and for normal wallet account public key should be the source of wallet id calculation! As multisig are not operational yet, I propose to use the unified calculation of wallet id 
2. As we can have situation that for a given account public key we can have many different multisig wallet, I propose to add script(s) imprint to accXPub and after that hash it. thanks to that we could delete a given shared wallet (using wallet id), rather than many shared wallets sharing accXPub, we have distinct differentiation of them. 
3. Why to take imprint from Script Cosigner rather than Script KeyHash? Because we can have pending shared wallet and not completed Script KeyHash value, but we need wallet id even in pending stage as DB is affected and the shared walet already started lifecycle

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number
adp-1621
<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
