### PR TITLE
Use correct index for collateral outputs.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -582,8 +582,19 @@ utxoFromTxOutputs Tx {txId, outputs} =
 -- This function ignores the transaction's script validity.
 --
 utxoFromTxCollateralOutputs :: Tx -> UTxO
-utxoFromTxCollateralOutputs Tx {txId, collateralOutput} =
-    UTxO $ Map.fromList $ F.toList $ (TxIn txId 0,) <$> collateralOutput
+utxoFromTxCollateralOutputs Tx {txId, outputs, collateralOutput} =
+    UTxO $ Map.fromList $ F.toList $ (TxIn txId index,) <$> collateralOutput
+  where
+    -- To reference a collateral output within transaction t, we specify an
+    -- output index that is equal to the number of ordinary outputs within t.
+    --
+    -- See definition of function "collOuts" within "Formal Specification of
+    -- the Cardano Ledger for the Babbage era".
+    --
+    -- https://hydra.iohk.io/build/14336206/download/1/babbage-changes.pdf
+    --
+    index :: Word32
+    index = fromIntegral (length outputs)
 
 {-------------------------------------------------------------------------------
                         Address ownership and discovery

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -558,12 +558,14 @@ spendTxD tx !u =
 --
 -- prop> balance (utxoFromTx tx) == foldMap tokens (outputs tx)
 -- prop> size    (utxoFromTx tx) == length         (outputs tx)
+-- prop> toList  (utxoFromTx tx) == toList         (outputs tx)
 --
 -- However, if the transaction is marked as having an invalid script, then the
 -- following properties should hold:
 --
 -- prop> balance (utxoFromTx tx) == foldMap tokens (collateralOutput tx)
 -- prop> size    (utxoFromTx tx) == length         (collateralOutput tx)
+-- prop> toList  (utxoFromTx tx) == toList         (collateralOutput tx)
 --
 utxoFromTx :: Tx -> UTxO
 utxoFromTx tx =

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -554,14 +554,16 @@ spendTxD tx !u =
 -- transaction inputs in subsequent blocks.
 --
 -- Assuming the transaction is not marked as having an invalid script, the
--- following property should hold:
+-- following properties should hold:
 --
--- prop> balance (utxoFromTx tx) = foldMap tokens (outputs tx)
+-- prop> balance (utxoFromTx tx) == foldMap tokens (outputs tx)
+-- prop> size    (utxoFromTx tx) == length         (outputs tx)
 --
 -- However, if the transaction is marked as having an invalid script, then the
--- following property should hold:
+-- following properties should hold:
 --
--- prop> balance (utxoFromTx tx) = foldMap tokens (collateralOutput tx)
+-- prop> balance (utxoFromTx tx) == foldMap tokens (collateralOutput tx)
+-- prop> size    (utxoFromTx tx) == length         (collateralOutput tx)
 --
 utxoFromTx :: Tx -> UTxO
 utxoFromTx tx =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -249,6 +249,8 @@ spec = do
                 (property prop_utxoFromTx_balance)
             it "has expected size"
                 (property prop_utxoFromTx_size)
+            it "has expected values"
+                (property prop_utxoFromTx_values)
             it "prop_utxoFromTx_disjoint"
                 (property prop_utxoFromTx_disjoint)
             it "prop_utxoFromTx_union"
@@ -2099,6 +2101,23 @@ prop_utxoFromTx_size tx =
         if txScriptInvalid tx
         then F.length (collateralOutput tx)
         else F.length (outputs tx)
+
+prop_utxoFromTx_values :: Tx -> Property
+prop_utxoFromTx_values tx =
+    checkCoverage $
+    cover 10
+        (txHasOutputsAndCollateralOutputs tx)
+        "txHasOutputsAndCollateralOutputs tx" $
+    cover 10
+        (txScriptInvalid tx)
+        "txScriptInvalid tx)" $
+    cover 10
+        (not $ txScriptInvalid tx)
+        "not $ txScriptInvalid tx)" $
+    F.toList (unUTxO (utxoFromTx tx)) ===
+        if txScriptInvalid tx
+        then F.toList (collateralOutput tx)
+        else F.toList (outputs tx)
 
 prop_utxoFromTx_disjoint :: Tx -> Property
 prop_utxoFromTx_disjoint tx =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -247,6 +247,8 @@ spec = do
         describe "utxoFromTx" $ do
             it "has expected balance"
                 (property prop_utxoFromTx_balance)
+            it "prop_utxoFromTx_disjoint"
+                (property prop_utxoFromTx_disjoint)
 
         describe "spendTx" $ do
             it "is subset of UTxO"
@@ -2076,6 +2078,16 @@ prop_utxoFromTx_balance tx =
         if txScriptInvalid tx
         then foldMap tokens (collateralOutput tx)
         else foldMap tokens (outputs tx)
+
+prop_utxoFromTx_disjoint :: Tx -> Property
+prop_utxoFromTx_disjoint tx =
+    checkCoverage $
+    cover 10
+        (txHasOutputsAndCollateralOutputs tx)
+        "txHasOutputsAndCollateralOutputs tx" $
+    UTxO.disjoint
+        (utxoFromTxOutputs tx)
+        (utxoFromTxCollateralOutputs tx)
 
 txHasOutputs :: Tx -> Bool
 txHasOutputs = not . null . outputs

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -249,6 +249,8 @@ spec = do
                 (property prop_utxoFromTx_balance)
             it "prop_utxoFromTx_disjoint"
                 (property prop_utxoFromTx_disjoint)
+            it "prop_utxoFromTx_union"
+                (property prop_utxoFromTx_union)
 
         describe "spendTx" $ do
             it "is subset of UTxO"
@@ -2089,6 +2091,18 @@ prop_utxoFromTx_disjoint tx =
         (utxoFromTxOutputs tx)
         (utxoFromTxCollateralOutputs tx)
 
+prop_utxoFromTx_union :: Tx -> Property
+prop_utxoFromTx_union tx =
+    checkCoverage $
+    cover 10
+        (txHasOutputsAndCollateralOutputs tx)
+        "txHasOutputsAndCollateralOutputs tx" $
+    mappend
+        (utxoFromTxOutputs tx)
+        (utxoFromTxCollateralOutputs tx)
+        ===
+        (utxoFromTxOutputsAndCollateralOutputs tx)
+
 txHasOutputs :: Tx -> Bool
 txHasOutputs = not . null . outputs
 
@@ -2098,6 +2112,12 @@ txHasCollateralOutputs = not . null . collateralOutput
 txHasOutputsAndCollateralOutputs :: Tx -> Bool
 txHasOutputsAndCollateralOutputs tx =
     txHasOutputs tx && txHasCollateralOutputs tx
+
+utxoFromTxOutputsAndCollateralOutputs :: Tx -> UTxO
+utxoFromTxOutputsAndCollateralOutputs Tx {txId, outputs, collateralOutput} =
+    UTxO $ Map.fromList $ zip
+        (TxIn txId <$> [0..])
+        (outputs <> F.toList collateralOutput)
 
 --------------------------------------------------------------------------------
 -- spendTx

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -247,8 +247,6 @@ spec = do
         describe "utxoFromTx" $ do
             it "has expected balance"
                 (property prop_utxoFromTx_balance)
-            it "is unspent"
-                (property prop_utxoFromTx_is_unspent)
 
         describe "spendTx" $ do
             it "is subset of UTxO"
@@ -2004,18 +2002,6 @@ prop_filterByAddress_balance_applyTxToUTxO f tx =
             if f (address output)
             then tokens output
             else mempty
-
-prop_utxoFromTx_is_unspent :: Tx -> Property
-prop_utxoFromTx_is_unspent tx =
-    checkCoverage $
-    cover 10
-        (utxoFromTx tx /= mempty)
-        "utxoFromTx tx /= mempty" $
-    cover 10
-        (Set.fromList (inputs tx) /= mempty)
-        "Set.fromList (inputs tx) /= mempty" $
-    utxoFromTx tx `excluding` Set.fromList (inputs tx)
-    === utxoFromTx tx
 
 unit_applyTxToUTxO_spends_input :: Tx -> TxIn -> TxOut -> Coin -> Property
 unit_applyTxToUTxO_spends_input tx txin txout coin =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -247,6 +247,8 @@ spec = do
         describe "utxoFromTx" $ do
             it "has expected balance"
                 (property prop_utxoFromTx_balance)
+            it "has expected size"
+                (property prop_utxoFromTx_size)
             it "prop_utxoFromTx_disjoint"
                 (property prop_utxoFromTx_disjoint)
             it "prop_utxoFromTx_union"
@@ -2080,6 +2082,23 @@ prop_utxoFromTx_balance tx =
         if txScriptInvalid tx
         then foldMap tokens (collateralOutput tx)
         else foldMap tokens (outputs tx)
+
+prop_utxoFromTx_size :: Tx -> Property
+prop_utxoFromTx_size tx =
+    checkCoverage $
+    cover 10
+        (txHasOutputsAndCollateralOutputs tx)
+        "txHasOutputsAndCollateralOutputs tx" $
+    cover 10
+        (txScriptInvalid tx)
+        "txScriptInvalid tx)" $
+    cover 10
+        (not $ txScriptInvalid tx)
+        "not $ txScriptInvalid tx)" $
+    UTxO.size (utxoFromTx tx) ===
+        if txScriptInvalid tx
+        then F.length (collateralOutput tx)
+        else F.length (outputs tx)
 
 prop_utxoFromTx_disjoint :: Tx -> Property
 prop_utxoFromTx_disjoint tx =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -2056,12 +2056,16 @@ unit_applyTxToUTxO_scriptValidity_Unknown tx' (sIn, sOut) (cIn, cOut) coin =
         ===
         (utxo `excluding` Set.singleton sIn) <> utxoFromTxOutputs tx
 
+--------------------------------------------------------------------------------
+-- utxoFromTx
+--------------------------------------------------------------------------------
+
 prop_utxoFromTx_balance :: Tx -> Property
 prop_utxoFromTx_balance tx =
     checkCoverage $
     cover 10
-        (outputs tx /= mempty)
-        "outputs tx /= mempty" $
+        (txHasOutputsAndCollateralOutputs tx)
+        "txHasOutputsAndCollateralOutputs tx" $
     cover 10
         (txScriptInvalid tx)
         "txScriptInvalid tx)" $
@@ -2072,6 +2076,20 @@ prop_utxoFromTx_balance tx =
         if txScriptInvalid tx
         then foldMap tokens (collateralOutput tx)
         else foldMap tokens (outputs tx)
+
+txHasOutputs :: Tx -> Bool
+txHasOutputs = not . null . outputs
+
+txHasCollateralOutputs :: Tx -> Bool
+txHasCollateralOutputs = not . null . collateralOutput
+
+txHasOutputsAndCollateralOutputs :: Tx -> Bool
+txHasOutputsAndCollateralOutputs tx =
+    txHasOutputs tx && txHasCollateralOutputs tx
+
+--------------------------------------------------------------------------------
+-- spendTx
+--------------------------------------------------------------------------------
 
 -- spendTx tx u `isSubsetOf` u
 prop_spendTx_isSubset :: Tx -> UTxO -> Property


### PR DESCRIPTION
## Issue Number

ADP-1718

## Summary

To reference a _collateral_ output within transaction **_t_**, we must specify an output index **_i_** that is equal to the number of _ordinary_ outputs within **_t_**. 

See definition of function `collOuts` within "[Formal Specification of the Cardano Ledger for the Babbage era](https://hydra.iohk.io/build/14336206/download/1/babbage-changes.pdf)".