### PR TITLE
Bump haskell language server to 1.7.0.0

### DIFF
--- a/nix/overlays/build-tools.nix
+++ b/nix/overlays/build-tools.nix
@@ -33,7 +33,7 @@ pkgs: super: let
     cabal-install.exe               = "cabal";
     cabal-install.version           = "3.4.0.0";
     haskell-language-server = {
-      version = "1.5.0.0";
+      version = "1.7.0.0";
       modules = [{ reinstallableLibGhc = false; }];
     };
     hie-bios = {


### PR DESCRIPTION

- [x] Bump haskell language server from 1.5.0.0 to 1.7.0.0
    - Hopefully more stable
    - Requires haskell.nix bump


### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
