### PR TITLE
Alleviate "truncated tar archive" issue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,6 +41,7 @@ steps:
     command: 'nix develop --command scripts/buildkite/check-haskell-nix-cabal.sh'
     agents:
       system: x86_64-linux
+    needs: 'Check Cabal Configure'
 
   - label: 'Check Stylish Haskell'
     depends_on: nix
@@ -61,6 +62,7 @@ steps:
     agents:
       system: x86_64-linux
     if: 'build.env("step") == null || build.env("step") =~ /cabal/'
+    needs: 'Check Cabal Configure (Haskell.nix shellFor)'
 
   - label: 'Validate OpenAPI Specification'
     depends_on: nix

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,7 +64,7 @@ steps:
     agents:
       system: x86_64-linux
     if: 'build.env("step") == null || build.env("step") =~ /cabal/'
-    depend_on: "cabal-configure-haskell-nix"
+    depends_on: "cabal-configure-haskell-nix"
 
   - label: 'Validate OpenAPI Specification'
     depends_on: nix

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,6 +27,7 @@ steps:
     command: 'nix develop .#cabal --command scripts/buildkite/cabal-ci.sh configure'
     agents:
       system: x86_64-linux
+    key: "cabal-configure"
 
   - label: 'Check auto-generated Nix'
     key: nix
@@ -41,7 +42,8 @@ steps:
     command: 'nix develop --command scripts/buildkite/check-haskell-nix-cabal.sh'
     agents:
       system: x86_64-linux
-    needs: 'Check Cabal Configure'
+    key: "cabal-configure-haskell-nix"
+    depends_on: "cabal-configure"
 
   - label: 'Check Stylish Haskell'
     depends_on: nix
@@ -62,7 +64,7 @@ steps:
     agents:
       system: x86_64-linux
     if: 'build.env("step") == null || build.env("step") =~ /cabal/'
-    needs: 'Check Cabal Configure (Haskell.nix shellFor)'
+    depend_on: "cabal-configure-haskell-nix"
 
   - label: 'Validate OpenAPI Specification'
     depends_on: nix

--- a/scripts/buildkite/cabal-ci.sh
+++ b/scripts/buildkite/cabal-ci.sh
@@ -50,7 +50,16 @@ save_cache() {
 
 echo "--- Updating Hackage index"
 
-( cd "$HOME" && cabal "${cabal_args[@]}" update )
+# ADP-1796
+# Sometimes cabal fails to download the Hackage archive. In this case we remove
+# the hackage archive and try again.
+{
+    ( cd "$HOME" && cabal "${cabal_args[@]}" update )
+} || {
+    echo "---- Failed to update Hackage index, trying again"
+    rm -r "${HOME}/.cabal/packages/hackage.haskell.org/"
+    ( cd "$HOME" && cabal "${cabal_args[@]}" update )
+}
 
 configure_args=(--enable-tests --enable-benchmarks)
 

--- a/scripts/buildkite/cabal-ci.sh
+++ b/scripts/buildkite/cabal-ci.sh
@@ -50,15 +50,7 @@ save_cache() {
 
 echo "--- Updating Hackage index"
 
-# ADP-1796
-# Sometimes cabal fails to download the Hackage archive. In this case we remove
-# the hackage archive and try again.
-{
-    ( cd "$HOME" && cabal "${cabal_args[@]}" update )
-} || {
-    echo "---- Failed to update Hackage index, trying again"
-    ( cd "$HOME" && cabal "${cabal_args[@]}" update )
-}
+( cd "$HOME" && cabal "${cabal_args[@]}" update )
 
 configure_args=(--enable-tests --enable-benchmarks)
 

--- a/scripts/buildkite/cabal-ci.sh
+++ b/scripts/buildkite/cabal-ci.sh
@@ -50,7 +50,15 @@ save_cache() {
 
 echo "--- Updating Hackage index"
 
-( cd "$HOME" && cabal "${cabal_args[@]}" update )
+# ADP-1796
+# Sometimes cabal fails to download the Hackage archive. In this case we try
+# again.
+{
+    ( cd "$HOME" && cabal "${cabal_args[@]}" update )
+} || {
+    echo "---- Failed to update Hackage index, trying again"
+    ( cd "$HOME" && cabal "${cabal_args[@]}" update )
+}
 
 configure_args=(--enable-tests --enable-benchmarks)
 

--- a/scripts/buildkite/cabal-ci.sh
+++ b/scripts/buildkite/cabal-ci.sh
@@ -57,7 +57,6 @@ echo "--- Updating Hackage index"
     ( cd "$HOME" && cabal "${cabal_args[@]}" update )
 } || {
     echo "---- Failed to update Hackage index, trying again"
-    rm -r "${HOME}/.cabal/packages/hackage.haskell.org/"
     ( cd "$HOME" && cabal "${cabal_args[@]}" update )
 }
 


### PR DESCRIPTION
- Cabal would sometimes fail to download the Hackage package index with an error: "truncated tar archive".
- To alleviate this, on an error, we remove the Hackage package index (presuming it is corrupted) and try again.

### Issue Number

ADP-1796
