### PR TITLE
Add more collateral output test coverage.

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -1123,11 +1123,11 @@ instance Arbitrary (WithPending WalletState) where
         subChain <- flip take blockchain <$> choose (1, length blockchain)
         let wallet = foldl (\cp b -> snd . snd $ applyBlock b cp) cp0 subChain
         rewards <- Coin <$> oneof [pure 0, chooseNatural (1, 10000)]
-        pending <- genPendingTx (totalUTxO Set.empty wallet) rewards
+        pending <- genPendingTxs (totalUTxO Set.empty wallet) rewards
         pure $ WithPending wallet pending rewards
       where
-        genPendingTx :: UTxO -> Coin -> Gen (Set Tx)
-        genPendingTx (UTxO u) rewards
+        genPendingTxs :: UTxO -> Coin -> Gen (Set Tx)
+        genPendingTxs (UTxO u) rewards
             | Map.null u = pure Set.empty
             | otherwise  = do
                 (inp, out) <-

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -338,7 +338,6 @@ prop_3_2 (ApplyBlock s utxo block) =
         return $ utxo' `excluding` txIns txs
     updateUTxO' b u = evalState (updateUTxO b u) s
 
-
 prop_applyBlockBasic
     :: WalletState
     -> Property
@@ -1212,7 +1211,6 @@ instance Arbitrary ApplyBlock where
     arbitrary = headBlock <$> arbitrary
       where
         headBlock (ApplyBlocks s u (b :| _)) = ApplyBlock s u b
-
 
 addresses :: [Address]
 addresses = map address

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -97,7 +97,14 @@ import Cardano.Wallet.Primitive.Types.Tx
     , txScriptInvalid
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTx, genTxIn, genTxOut, shrinkTx, shrinkTxIn, shrinkTxOut )
+    ( genTx
+    , genTxIn
+    , genTxOut
+    , genTxScriptValidity
+    , shrinkTx
+    , shrinkTxIn
+    , shrinkTxOut
+    )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..), balance, dom, excluding, filterByAddress, restrictedTo )
 import Cardano.Wallet.Primitive.Types.UTxO.Gen
@@ -165,6 +172,7 @@ import Test.QuickCheck
     , frequency
     , genericShrink
     , label
+    , liftArbitrary
     , listOf
     , oneof
     , property
@@ -1161,6 +1169,7 @@ instance Arbitrary (WithPending WalletState) where
                 --   change output and an explicit withdrawal in the
                 --   transaction.
                 let tokens = TokenBundle.fromCoin $ simulateFee $ txOutCoin out
+                scriptValidity <- liftArbitrary genTxScriptValidity
                 let pending = withWithdrawal $ Tx
                         { txId = arbitraryHash
                         , fee = Nothing
@@ -1172,7 +1181,7 @@ instance Arbitrary (WithPending WalletState) where
                         , outputs = [out {tokens}]
                         , withdrawals = mempty
                         , metadata = Nothing
-                        , scriptValidity = Nothing
+                        , scriptValidity
                         }
 
                 elements [Set.singleton pending, Set.empty]


### PR DESCRIPTION
## Issue Number

ADP-1718

## Summary

This PR tidies up some loose ends, and:

- Updates one of the "golden rollback scenarios" to exercise collateral outputs. This is basically a unit test to demonstrate that we can spend a collateral output created in a previous transaction (using the correct index), and that the resultant UTxO set is correct.
- Adjusts `genPendingTxs` within `ModelSpec` to allow generation of transactions marked as having invalid scripts.