### PR TITLE
E2e tests for upgrading passphrase using mnemonics

### DIFF
--- a/test/e2e/spec/byron_spec.rb
+++ b/test/e2e/spec/byron_spec.rb
@@ -49,20 +49,82 @@ RSpec.describe CardanoWallet::Byron do
       expect(WalletFactory.delete(:byron, wid)).to be_correct_and_respond 204
     end
 
-    it "Can update_metadata" do
-      w = BYRON.wallets
-      id = create_byron_wallet
-      u = w.update_metadata(id, { name: "New wallet name" })
-      expect(u).to be_correct_and_respond 200
+    describe "Update wallet" do
+      matrix = ["random", "icarus"]
+      matrix.each do |wallet_style|
+        it "Can update_metadata of #{wallet_style} wallet" do
+          w = BYRON.wallets
+          id = create_byron_wallet(wallet_style)
+          u = w.update_metadata(id, { name: "New wallet name" })
+          expect(u).to be_correct_and_respond 200
+        end
 
-    end
+        it "Can update_passphrase of #{wallet_style} wallet" do
+          w = BYRON.wallets
+          id = create_byron_wallet(wallet_style)
+          upd = w.update_passphrase(id, { old_passphrase: "Secure Passphrase",
+                                          new_passphrase: "Securer Passphrase" })
+          expect(upd).to be_correct_and_respond 204
+        end
 
-    it "Can update_passphrase" do
-      w = BYRON.wallets
-      id = create_byron_wallet
-      upd = w.update_passphrase(id, { old_passphrase: "Secure Passphrase",
-                                    new_passphrase: "Securer Passphrase" })
-      expect(upd).to be_correct_and_respond 204
+        it "Cannot update_passphrase of #{wallet_style} wallet not knowing old pass" do
+          w = BYRON.wallets
+          id = create_byron_wallet(wallet_style)
+          upd = w.update_passphrase(id, { old_passphrase: "wrong-passphrase",
+                                          new_passphrase: "Securer Passphrase" })
+          expect(upd).to be_correct_and_respond 403
+          expect(upd.to_s).to include 'wrong_encryption_passphrase'
+        end
+
+        it "Can update_passphrase using mnemonics of #{wallet_style} wallet" do
+          w = BYRON.wallets
+          mnemonics = mnemonic_sentence(24)
+          id = create_byron_wallet(wallet_style, "Wallet", mnemonics)
+          upd = w.update_passphrase(id, { mnemonics: mnemonics,
+                                          new_passphrase: "Securer Passphrase" })
+          expect(upd).to be_correct_and_respond 204
+        end
+
+        it "Cannot update_passphrase using wrong mnemonics of #{wallet_style} wallet" do
+          w = BYRON.wallets
+          mnemonics = mnemonic_sentence(24)
+          wrong_mnemonics = mnemonic_sentence(24)
+          id = create_byron_wallet(wallet_style, "Wallet", mnemonics)
+          upd = w.update_passphrase(id, { mnemonics: wrong_mnemonics,
+                                          new_passphrase: "Securer Passphrase" })
+          expect(upd).to be_correct_and_respond 403
+          expect(upd.to_s).to include 'wrong_mnemonic'
+        end
+      end
+
+      it "Can update_passphrase of icarus wallet from pub key using mnemonics from which pub key is derived" do
+        mnemonics = mnemonic_sentence(24)
+        root_xsk = CA.prv_key_from_recovery_phrase(mnemonics, "Icarus")
+        acct_key = CA.key_child(root_xsk, "44H/1815H/0H")
+        pub_key = CA.key_public(acct_key, with_chain_code = true)
+        acc_pub_key_base16 = bech32_to_base16(pub_key)
+
+        payload = { name: "Wallet from pub key",
+                    account_public_key: acc_pub_key_base16,
+                    address_pool_gap: 20
+                  }
+        wallet = WalletFactory.create(:byron, payload)
+        expect(wallet).to be_correct_and_respond 201
+
+        wid = wallet['id']
+
+        # I can update passphrase using mnemonics
+        upd = BYRON.wallets.update_passphrase(wid, { mnemonic_sentence: mnemonics,
+                                                     new_passphrase: "Secure Passphrase" })
+        expect(upd).to be_correct_and_respond 204
+
+        # Once password is set I can perform passphrase-protected operations,
+        # like update passphrase using old passprase
+        upd2 = BYRON.wallets.update_passphrase(wid, { old_passphrase: "Secure Passphrase",
+                                                      new_passphrase: "Securer Passphrase" })
+        expect(upd2).to be_correct_and_respond 204
+      end
+
     end
 
     it "Can see utxo" do
@@ -87,7 +149,7 @@ RSpec.describe CardanoWallet::Byron do
         wallet_style = m[1]
         it "I can get #{wallet_type} #{wallet_style} walletid using cardano-addresses" do
           mnemonics = mnemonic_sentence(24)
-          wid = create_byron_wallet_with(mnemonics, style = wallet_style)
+          wid = create_byron_wallet(style = wallet_style, "Wallet - ID", mnemonics)
 
           # based on root prv key
           root_xsk = CA.prv_key_from_recovery_phrase(mnemonics, wallet_type)
@@ -102,7 +164,7 @@ RSpec.describe CardanoWallet::Byron do
 
         it "#{wallet_type} walletid is not based on acct key" do
           mnemonics = mnemonic_sentence(24)
-          wid = create_byron_wallet_with(mnemonics, style = wallet_style)
+          wid = create_byron_wallet(style = wallet_style, "Wallet - ID", mnemonics)
 
           # based on acct prv key
           root_xsk = CA.prv_key_from_recovery_phrase(mnemonics, wallet_type)
@@ -189,7 +251,8 @@ RSpec.describe CardanoWallet::Byron do
     it "I can import address - random" do
       mnemonics = mnemonic_sentence(15)
       derivation_path = '14H/42H'
-      id = create_byron_wallet_with(mnemonics)
+      id = create_byron_wallet("random", "Wallet - import", mnemonics)
+
       addr = cardano_address_get_byron_addr(mnemonics, derivation_path)
 
       addr_import = BYRON.addresses.import(id, addr)

--- a/test/e2e/spec/byron_spec.rb
+++ b/test/e2e/spec/byron_spec.rb
@@ -75,56 +75,7 @@ RSpec.describe CardanoWallet::Byron do
           expect(upd).to be_correct_and_respond 403
           expect(upd.to_s).to include 'wrong_encryption_passphrase'
         end
-
-        it "Can update_passphrase using mnemonics of #{wallet_style} wallet" do
-          w = BYRON.wallets
-          mnemonics = mnemonic_sentence(24)
-          id = create_byron_wallet(wallet_style, "Wallet", mnemonics)
-          upd = w.update_passphrase(id, { mnemonics: mnemonics,
-                                          new_passphrase: "Securer Passphrase" })
-          expect(upd).to be_correct_and_respond 204
-        end
-
-        it "Cannot update_passphrase using wrong mnemonics of #{wallet_style} wallet" do
-          w = BYRON.wallets
-          mnemonics = mnemonic_sentence(24)
-          wrong_mnemonics = mnemonic_sentence(24)
-          id = create_byron_wallet(wallet_style, "Wallet", mnemonics)
-          upd = w.update_passphrase(id, { mnemonics: wrong_mnemonics,
-                                          new_passphrase: "Securer Passphrase" })
-          expect(upd).to be_correct_and_respond 403
-          expect(upd.to_s).to include 'wrong_mnemonic'
-        end
       end
-
-      it "Can update_passphrase of icarus wallet from pub key using mnemonics from which pub key is derived" do
-        mnemonics = mnemonic_sentence(24)
-        root_xsk = CA.prv_key_from_recovery_phrase(mnemonics, "Icarus")
-        acct_key = CA.key_child(root_xsk, "44H/1815H/0H")
-        pub_key = CA.key_public(acct_key, with_chain_code = true)
-        acc_pub_key_base16 = bech32_to_base16(pub_key)
-
-        payload = { name: "Wallet from pub key",
-                    account_public_key: acc_pub_key_base16,
-                    address_pool_gap: 20
-                  }
-        wallet = WalletFactory.create(:byron, payload)
-        expect(wallet).to be_correct_and_respond 201
-
-        wid = wallet['id']
-
-        # I can update passphrase using mnemonics
-        upd = BYRON.wallets.update_passphrase(wid, { mnemonic_sentence: mnemonics,
-                                                     new_passphrase: "Secure Passphrase" })
-        expect(upd).to be_correct_and_respond 204
-
-        # Once password is set I can perform passphrase-protected operations,
-        # like update passphrase using old passprase
-        upd2 = BYRON.wallets.update_passphrase(wid, { old_passphrase: "Secure Passphrase",
-                                                      new_passphrase: "Securer Passphrase" })
-        expect(upd2).to be_correct_and_respond 204
-      end
-
     end
 
     it "Can see utxo" do

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -1940,6 +1940,17 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e do
       end
 
     end
+
+    describe "Update passphrase" do
+      it "I can update passphrase with mnemonic and the wallet does not have to re-sync" do
+        mnemonics = get_fixture_wallet_mnemonics(:fixture, :shelley)
+        upd = SHELLEY.wallets.update_passphrase(@wid, { mnemonic_sentence: mnemonics,
+                                                        new_passphrase: PASS })
+        expect(upd).to be_correct_and_respond 204
+        wallet = SHELLEY.wallets.get(@wid)
+        expect(wallet['state']['status']).to eq 'ready'
+      end
+    end
   end
 
   describe "E2E Byron" do

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -176,11 +176,14 @@ def wait_for_all_shared_wallets(wids)
   end
 end
 
-def create_shelley_wallet(name = "Wallet from mnemonic_sentence", mnemonic_sentence = mnemonic_sentence(24))
+def create_shelley_wallet(name = "Wallet from mnemonic_sentence",
+                          mnemonic_sentence = mnemonic_sentence(24),
+                          mnemonic_second_factor = nil)
   payload = { name: name,
               passphrase: PASS,
               mnemonic_sentence: mnemonic_sentence
              }
+  payload[:mnemonic_second_factor] = mnemonic_second_factor if mnemonic_second_factor
   WalletFactory.create(:shelley, payload)['id']
 end
 

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -211,21 +211,13 @@ def wait_for_all_shelley_wallets(wids)
   end
 end
 
-def create_byron_wallet_with(mnem, style = "random", name = "Wallet from mnemonic_sentence")
+def create_byron_wallet(style = "random",
+                        name = "Wallet from mnemonic_sentence",
+                        mnemonics = mnemonic_sentence(24))
   payload = { style: style,
               name: name,
               passphrase: PASS,
-              mnemonic_sentence: mnem
-             }
-  WalletFactory.create(:byron, payload)['id']
-end
-
-def create_byron_wallet(style = "random", name = "Wallet from mnemonic_sentence")
-  style == "random" ? mnem = mnemonic_sentence(12) : mnem = mnemonic_sentence(15)
-  payload = { style: style,
-              name: name,
-              passphrase: PASS,
-              mnemonic_sentence: mnem
+              mnemonic_sentence: mnemonics
              }
   WalletFactory.create(:byron, payload)['id']
 end


### PR DESCRIPTION
<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->


- [x] I have added e2e tests for updating passphrase using mnemonics for Shelley ~and Byron~ wallets

### Comments
 - tests for Shelley wallets work fine against https://github.com/input-output-hk/cardano-wallet/pull/3279
 - ~tests for Byron wallets fail for now~ no tests for Byron wallets

### Issue Number

ADP-1658
