### PR TITLE
Update Building.md on how to build without scrypt

### DIFF
--- a/docs/developers/Building.md
+++ b/docs/developers/Building.md
@@ -77,6 +77,13 @@ See [`nix/overlays/build-tools.nix`](https://github.com/input-output-hk/cardano-
    $ cabal install --install-method=copy --installdir=/usr/local/bin
    ```
 
+7. Build without `scrypt` (for compatibility with Apple M1 chip)
+
+   ```console
+   $ cabal configure --disable-tests --disable-benchmarks -f-scrypt -O2
+   $ cabal build cardano-wallet:exe:cardano-wallet --ghc-options -O2
+   ```
+
 #### Syncing `stack` and `cabal` dependencies
 
 1. Install [stack2cabal](https://hackage.haskell.org/package/stack2cabal)

--- a/docs/developers/Building.md
+++ b/docs/developers/Building.md
@@ -81,7 +81,7 @@ See [`nix/overlays/build-tools.nix`](https://github.com/input-output-hk/cardano-
 
    ```console
    $ cabal configure --disable-tests --disable-benchmarks -f-scrypt -O2
-   $ cabal build cardano-wallet:exe:cardano-wallet --ghc-options -O2
+   $ cabal build cardano-wallet:exe:cardano-wallet
    ```
 
 #### Syncing `stack` and `cabal` dependencies


### PR DESCRIPTION
- [x] Update Building.md on how to build without scrypt.

### Comments

 - works for me locally on Linux
 - apparently works on M1 as well based on https://github.com/input-output-hk/cardano-wallet/issues/2578#issuecomment-1106474925

### Issue Number

ADP-1383
