### PR TITLE
Preparation for transaction sequence testing.

### DIFF
--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -37,8 +37,8 @@ module Test.QuickCheck.Extra
     , partitionList
 
       -- * Selecting entries from maps
-    , mapEntry
-    , mapEntries
+    , selectMapEntry
+    , selectMapEntries
 
       -- * Generating and shrinking natural numbers
     , chooseNatural
@@ -266,8 +266,9 @@ partitionList (x, y) =
 --
 -- Returns 'Nothing' if (and only if) the given map is empty.
 --
-mapEntry :: forall k v. Ord k => Map k v -> Gen (Maybe ((k, v), Map k v))
-mapEntry m
+selectMapEntry
+    :: forall k v. Ord k => Map k v -> Gen (Maybe ((k, v), Map k v))
+selectMapEntry m
     | Map.null m =
         pure Nothing
     | otherwise =
@@ -281,12 +282,13 @@ mapEntry m
 --
 -- Returns the selected entries and the remaining map with the entries removed.
 --
-mapEntries :: forall k v. Ord k => Int -> Map k v -> Gen ([(k, v)], Map k v)
-mapEntries i m0 =
+selectMapEntries
+    :: forall k v. Ord k => Int -> Map k v -> Gen ([(k, v)], Map k v)
+selectMapEntries i m0 =
     foldM (const . selectOne) ([], m0) (replicate i ())
   where
     selectOne :: ([(k, v)], Map k v) -> Gen ([(k, v)], Map k v)
-    selectOne (es, m) = mapEntry m >>= \case
+    selectOne (es, m) = selectMapEntry m >>= \case
         Nothing -> pure (es, m)
         Just (e, m') -> pure (e : es, m')
 

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -35,6 +35,9 @@ module Test.QuickCheck.Extra
       -- * Partitioning lists
     , partitionList
 
+      -- * Selecting entries from maps
+    , mapEntry
+
       -- * Generating and shrinking natural numbers
     , chooseNatural
     , shrinkNatural
@@ -248,6 +251,27 @@ partitionList (x, y) =
 
     x' = max 0 x
     y' = max 1 (max y x')
+
+--------------------------------------------------------------------------------
+-- Selecting random map entries
+--------------------------------------------------------------------------------
+
+-- | Selects an entry at random from the given map.
+--
+-- Returns the selected entry and the remaining map with the entry removed.
+--
+-- Returns 'Nothing' if (and only if) the given map is empty.
+--
+mapEntry :: forall k v. Ord k => Map k v -> Gen (Maybe ((k, v), Map k v))
+mapEntry m
+    | Map.null m =
+        pure Nothing
+    | otherwise =
+        Just . selectAndRemoveElemAt <$> chooseInt (0, Map.size m - 1)
+  where
+    selectAndRemoveElemAt :: Int -> ((k, v), Map k v)
+    selectAndRemoveElemAt =
+        (\(k, v) -> ((k, v), Map.delete k m)) . flip Map.elemAt m
 
 --------------------------------------------------------------------------------
 -- Generating and shrinking natural numbers


### PR DESCRIPTION
## Issue Number

ADP-1783

## Summary

This PR adds the following generator functions to `Test.QuickCheck.Extra`:

- **`partitionList`**
    partitions a list into a list of sublists of random lengths.
    
- `selectMapEntry`
    selects an entry at random from a `Map`.

- `selectMapEntries`
    selects up to a given number of entries at random from a `Map`.

## Motivation

- **`selectMapEntries`**
    can be used to randomly select one or more UTxO entries to act as inputs when generating transactions.

- **`partitionList`**
    can be used to transform lists of transactions into arbitrary lists of blocks, where each block can contain zero, one, or many transactions.