### PR TITLE
Preparation for transaction sequence testing. (Part 2)

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -270,8 +270,9 @@ equipartition c =
     fmap fromNatural . equipartitionNatural (toNatural c)
 
 -- | Partitions a coin into a number of parts, where the size of each part is
---   proportional to the size of its corresponding element in the given list
---   of weights, and the number of parts is equal to the number of weights.
+--   proportional (modulo rounding) to the size of its corresponding element in
+--   the given list of weights, and the number of parts is equal to the number
+--   of weights.
 --
 -- Returns 'Nothing' if the sum of weights is equal to zero.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -37,6 +37,7 @@ module Cardano.Wallet.Primitive.Types.Coin
       -- * Partitioning
     , equipartition
     , partition
+    , partitionDefault
     , unsafePartition
 
     ) where
@@ -287,6 +288,30 @@ partition c
     = fmap (fmap fromNatural)
     . partitionNatural (toNatural c)
     . fmap toNatural
+
+-- | Partitions a coin into a number of parts, where the size of each part is
+--   proportional (modulo rounding) to the size of its corresponding element in
+--   the given list of weights, and the number of parts is equal to the number
+--   of weights.
+--
+-- This function always satisfies the following properties:
+--
+-- prop> fold   (partitionDefault c ws) == c
+-- prop> length (partitionDefault c ws) == length ws
+--
+-- If the sum of weights is equal to zero, then this function returns an
+-- 'equipartition' satisfying the following property:
+--
+-- prop> partitionDefault c ws == equipartition c ws
+--
+partitionDefault
+    :: Coin
+    -- ^ The token quantity to be partitioned.
+    -> NonEmpty Coin
+    -- ^ The list of weights.
+    -> NonEmpty Coin
+    -- ^ The partitioned token quantities.
+partitionDefault c ws = fromMaybe (equipartition c ws) (partition c ws)
 
 -- | Partitions a coin into a number of parts, where the size of each part is
 --   proportional (modulo rounding) to the size of its corresponding element in

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -289,8 +289,9 @@ partition c
     . fmap toNatural
 
 -- | Partitions a coin into a number of parts, where the size of each part is
---   proportional to the size of its corresponding element in the given list
---   of weights, and the number of parts is equal to the number of weights.
+--   proportional (modulo rounding) to the size of its corresponding element in
+--   the given list of weights, and the number of parts is equal to the number
+--   of weights.
 --
 -- Throws a run-time error if the sum of weights is equal to zero.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin/Gen.hs
@@ -4,18 +4,26 @@ module Cardano.Wallet.Primitive.Types.Coin.Gen
     , genCoinPositive
     , shrinkCoin
     , shrinkCoinPositive
+    , genCoinPartition
     ) where
 
 import Prelude
 
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Control.Monad
+    ( replicateM )
 import Data.Coerce
     ( coerce )
+import Data.List.NonEmpty
+    ( NonEmpty )
 import Test.QuickCheck
     ( Gen, choose, sized )
 import Test.QuickCheck.Extra
     ( chooseNatural, shrinkNatural )
+
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+import qualified Data.List.NonEmpty as NE
 
 --------------------------------------------------------------------------------
 -- Choosing coins from a range.
@@ -43,3 +51,22 @@ genCoinPositive = sized $ \n -> Coin . fromIntegral <$> choose (1, max 1 n)
 
 shrinkCoinPositive :: Coin -> [Coin]
 shrinkCoinPositive (Coin c) = Coin <$> filter (> 0) (shrinkNatural c)
+
+--------------------------------------------------------------------------------
+-- Partitioning coins
+--------------------------------------------------------------------------------
+
+-- | Partitions a coin randomly into a given number of parts.
+--
+-- Satisfies the following properties:
+--
+-- prop> forAll (genCoinPartition c i) $ (==       c) . fold
+-- prop> forAll (genCoinPartition c i) $ (== max 1 i) . length
+--
+genCoinPartition :: Coin -> Int -> Gen (NonEmpty Coin)
+genCoinPartition c i =
+    Coin.partitionDefault c <$> genWeights
+  where
+    genWeights :: Gen (NonEmpty Coin)
+    genWeights = NE.fromList <$> replicateM (max 1 i)
+        (chooseCoin (Coin 1, max (Coin 1) c))

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin/Gen.hs
@@ -1,5 +1,6 @@
 module Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoin
+    ( chooseCoin
+    , genCoin
     , genCoinPositive
     , shrinkCoin
     , shrinkCoinPositive
@@ -9,10 +10,19 @@ import Prelude
 
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Data.Coerce
+    ( coerce )
 import Test.QuickCheck
     ( Gen, choose, sized )
 import Test.QuickCheck.Extra
-    ( shrinkNatural )
+    ( chooseNatural, shrinkNatural )
+
+--------------------------------------------------------------------------------
+-- Choosing coins from a range.
+--------------------------------------------------------------------------------
+
+chooseCoin :: (Coin, Coin) -> Gen Coin
+chooseCoin = coerce chooseNatural
 
 --------------------------------------------------------------------------------
 -- Coins chosen according to the size parameter.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
@@ -9,6 +9,8 @@ module Cardano.Wallet.Primitive.Types.TokenMap.Gen
     , shrinkAssetId
     , shrinkTokenMap
     , AssetIdF (..)
+    , genTokenMapPartition
+    , genTokenMapPartitionNonNull
     ) where
 
 import Prelude
@@ -25,16 +27,22 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     , testTokenNames
     , testTokenPolicyIds
     )
+import Cardano.Wallet.Primitive.Types.TokenQuantity
+    ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
-    ( genTokenQuantity, shrinkTokenQuantity )
+    ( genTokenQuantity, genTokenQuantityPartition, shrinkTokenQuantity )
 import Control.Monad
     ( replicateM )
 import Data.List
-    ( elemIndex )
+    ( elemIndex, transpose )
+import Data.List.NonEmpty
+    ( NonEmpty )
 import Data.Maybe
     ( fromMaybe )
 import GHC.Generics
     ( Generic )
+import Safe
+    ( fromJustNote )
 import Test.QuickCheck
     ( CoArbitrary (..)
     , Function (..)
@@ -50,6 +58,8 @@ import Test.QuickCheck.Extra
     ( genSized2With, shrinkInterleaved )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Data.Foldable as F
+import qualified Data.List.NonEmpty as NE
 
 --------------------------------------------------------------------------------
 -- Asset identifiers chosen from a range that depends on the size parameter
@@ -128,3 +138,36 @@ instance CoArbitrary AssetIdF where
         let n = fromMaybe 0 (elemIndex tokenName testTokenNames)
         let m = fromMaybe 0 (elemIndex tokenPolicyId testTokenPolicyIds)
         variant (n+m) genB
+
+--------------------------------------------------------------------------------
+-- Partitioning token maps
+--------------------------------------------------------------------------------
+
+-- | Partitions a token map randomly into a given number of parts.
+--
+-- Satisfies the following properties:
+--
+-- prop> forAll (genTokenMapPartition m i) $ (== m      ) . fold
+-- prop> forAll (genTokenMapPartition m i) $ (== max 1 i) . length
+--
+genTokenMapPartition :: TokenMap -> Int -> Gen (NonEmpty TokenMap)
+genTokenMapPartition m i
+    | TokenMap.isEmpty m =
+        pure $ NE.fromList $ replicate (max 1 i) mempty
+    | otherwise =
+        fmap TokenMap.fromFlatList . transposeNE <$>
+        traverse partitionAQ (TokenMap.toFlatList m)
+  where
+    partitionAQ :: (a, TokenQuantity) -> Gen (NonEmpty (a, TokenQuantity))
+    partitionAQ = fmap sequenceA . traverse (`genTokenQuantityPartition` i)
+
+    transposeNE :: [NonEmpty a] -> NonEmpty [a]
+    transposeNE = fromJustNote note . NE.nonEmpty . transpose . fmap NE.toList
+      where
+        note = "genTokenMapPartition.transposeNE: unexpected empty list"
+
+-- | Like 'genTokenMapPartition', but with empty values removed from the result.
+--
+genTokenMapPartitionNonNull :: TokenMap -> Int -> Gen [TokenMap]
+genTokenMapPartitionNonNull m i =
+    filter (/= mempty) . F.toList <$> genTokenMapPartition m i

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
@@ -178,8 +178,9 @@ equipartition q =
     fmap TokenQuantity . equipartitionNatural (unTokenQuantity q)
 
 -- | Partitions a token quantity into a number of parts, where the size of each
---   part is proportional to the size of its corresponding element in the given
---   list of weights, and the number of parts is equal to the number of weights.
+--   part is proportional (modulo rounding) to the size of its corresponding
+--   element in the given list of weights, and the number of parts is equal to
+--   the number of weights.
 --
 -- Returns 'Nothing' if the sum of weights is equal to zero.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
@@ -22,6 +22,7 @@ module Cardano.Wallet.Primitive.Types.TokenQuantity
       -- * Partitioning
     , equipartition
     , partition
+    , partitionDefault
 
       -- * Tests
     , isNonZero
@@ -195,6 +196,30 @@ partition c
     = fmap (fmap TokenQuantity)
     . partitionNatural (unTokenQuantity c)
     . fmap unTokenQuantity
+
+-- | Partitions a token quantity into a number of parts, where the size of each
+--   part is proportional (modulo rounding) to the size of its corresponding
+--   element in the given list of weights, and the number of parts is equal to
+--   the number of weights.
+--
+-- This function always satisfies the following properties:
+--
+-- prop> fold   (partitionDefault q ws) == c
+-- prop> length (partitionDefault q ws) == length ws
+--
+-- If the sum of weights is equal to zero, then this function returns an
+-- 'equipartition' satisfying the following property:
+--
+-- prop> partitionDefault q ws == equipartition q ws
+--
+partitionDefault
+    :: TokenQuantity
+    -- ^ The token quantity to be partitioned.
+    -> NonEmpty TokenQuantity
+    -- ^ The list of weights.
+    -> NonEmpty TokenQuantity
+    -- ^ The partitioned token quantities.
+partitionDefault q ws = fromMaybe (equipartition q ws) (partition q ws)
 
 --------------------------------------------------------------------------------
 -- Tests

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity/Gen.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
-    ( genTokenQuantity
+    ( chooseTokenQuantity
+    , genTokenQuantity
     , genTokenQuantityPositive
     , genTokenQuantityFullRange
     , shrinkTokenQuantity
@@ -13,10 +14,21 @@ import Prelude
 
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
+import Data.Coerce
+    ( coerce )
 import Data.Word
     ( Word64 )
 import Test.QuickCheck
     ( Gen, choose, frequency, shrink, sized )
+import Test.QuickCheck.Extra
+    ( chooseNatural )
+
+--------------------------------------------------------------------------------
+-- Choosing token quantities from a range.
+--------------------------------------------------------------------------------
+
+chooseTokenQuantity :: (TokenQuantity, TokenQuantity) -> Gen TokenQuantity
+chooseTokenQuantity = coerce chooseNatural
 
 --------------------------------------------------------------------------------
 -- Token quantities chosen according to the size parameter.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity/Gen.hs
@@ -8,20 +8,28 @@ module Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     , shrinkTokenQuantity
     , shrinkTokenQuantityPositive
     , shrinkTokenQuantityFullRange
+    , genTokenQuantityPartition
     ) where
 
 import Prelude
 
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
+import Control.Monad
+    ( replicateM )
 import Data.Coerce
     ( coerce )
+import Data.List.NonEmpty
+    ( NonEmpty )
 import Data.Word
     ( Word64 )
 import Test.QuickCheck
     ( Gen, choose, frequency, shrink, sized )
 import Test.QuickCheck.Extra
     ( chooseNatural )
+
+import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
+import qualified Data.List.NonEmpty as NE
 
 --------------------------------------------------------------------------------
 -- Choosing token quantities from a range.
@@ -88,6 +96,26 @@ shrinkTokenQuantityFullRange =
     -- Given that we may have a large value, we limit the number of results
     -- returned in order to avoid processing long lists of shrunken values.
     take 8 . shrinkTokenQuantity
+
+--------------------------------------------------------------------------------
+-- Partitioning token quantities
+--------------------------------------------------------------------------------
+
+-- | Partitions a token quantity randomly into a given number of parts.
+--
+-- Satisfies the following properties:
+--
+-- prop> forAll (genTokenQuantityPartition q i) $ (==       q) . fold
+-- prop> forAll (genTokenQuantityPartition q i) $ (== max 1 i) . length
+--
+genTokenQuantityPartition
+    :: TokenQuantity -> Int -> Gen (NonEmpty TokenQuantity)
+genTokenQuantityPartition c i =
+    TokenQuantity.partitionDefault c <$> genWeights
+  where
+    genWeights :: Gen (NonEmpty TokenQuantity)
+    genWeights = NE.fromList <$> replicateM (max 1 i)
+        (chooseTokenQuantity (TokenQuantity 1, max (TokenQuantity 1) c))
 
 --------------------------------------------------------------------------------
 -- Internal functions

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO/Gen.hs
@@ -16,8 +16,6 @@ import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Control.Monad
     ( replicateM )
-import Data.Coerce
-    ( coerce )
 import Test.QuickCheck
     ( Gen, choose, shrinkList, sized )
 import Test.QuickCheck.Extra
@@ -80,4 +78,4 @@ genEntryLargeRange = (,)
 -- removed.
 --
 selectUTxOEntries :: UTxO -> Int -> Gen ([(TxIn, TxOut)], UTxO)
-selectUTxOEntries = (coerce .) . selectMapEntries . unUTxO
+selectUTxOEntries = (fmap (fmap UTxO) .) . selectMapEntries . unUTxO

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO/Gen.hs
@@ -2,6 +2,7 @@ module Cardano.Wallet.Primitive.Types.UTxO.Gen
     ( genUTxO
     , genUTxOLarge
     , genUTxOLargeN
+    , selectUTxOEntries
     , shrinkUTxO
     ) where
 
@@ -15,10 +16,12 @@ import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Control.Monad
     ( replicateM )
+import Data.Coerce
+    ( coerce )
 import Test.QuickCheck
     ( Gen, choose, shrinkList, sized )
 import Test.QuickCheck.Extra
-    ( shrinkInterleaved )
+    ( selectMapEntries, shrinkInterleaved )
 
 import qualified Data.Map.Strict as Map
 
@@ -66,3 +69,15 @@ genEntryLargeRange = (,)
     -- Note that we don't need to choose outputs from a large range, as inputs
     -- are already chosen from a large range:
     <*> genTxOut
+
+--------------------------------------------------------------------------------
+-- Selecting random UTxO entries
+--------------------------------------------------------------------------------
+
+-- | Selects up to a given number of entries at random from the given UTxO set.
+--
+-- Returns the selected entries and the remaining UTxO set with the entries
+-- removed.
+--
+selectUTxOEntries :: UTxO -> Int -> Gen ([(TxIn, TxOut)], UTxO)
+selectUTxOEntries = (coerce .) . selectMapEntries . unUTxO

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -283,8 +283,8 @@ selectMapEntry m
 -- Returns the selected entries and the remaining map with the entries removed.
 --
 selectMapEntries
-    :: forall k v. Ord k => Int -> Map k v -> Gen ([(k, v)], Map k v)
-selectMapEntries i m0 =
+    :: forall k v. Ord k => Map k v -> Int -> Gen ([(k, v)], Map k v)
+selectMapEntries m0 i =
     foldM (const . selectOne) ([], m0) (replicate i ())
   where
     selectOne :: ([(k, v)], Map k v) -> Gen ([(k, v)], Map k v)

--- a/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
@@ -140,6 +140,9 @@ spec = describe "Test.QuickCheck.ExtraSpec" $ do
             it "prop_selectMapEntries_fromList" $
                 prop_selectMapEntries_fromList
                     @Int @Int & property
+            it "prop_selectMapEntries_length" $
+                prop_selectMapEntries_length
+                    @Int @Int & property
             it "prop_selectMapEntries_nonPositive" $
                 prop_selectMapEntries_nonPositive
                     @Int @Int & property
@@ -530,6 +533,22 @@ prop_selectMapEntries_fromList m =
         "number of available entries = 0" $
     forAll (selectMapEntries m (length m)) $
         (=== (m, mempty)) . first Map.fromList
+
+prop_selectMapEntries_length
+    :: forall k v. (Ord k, Show k, Eq v, Show v)
+    => Map k v
+    -> Positive (Small Int)
+    -> Property
+prop_selectMapEntries_length m (Positive (Small i)) =
+    forAll (selectMapEntries m i) $ \(kvs, _) ->
+        checkCoverage $
+        cover 10 (i < Map.size m)
+            "number of requested entries < size of map" $
+        cover 10 (i > Map.size m)
+            "number of requested entries > size of map" $
+        cover 1 (i == Map.size m)
+            "number of requested entries = size of map" $
+        length kvs === min i (Map.size m)
 
 prop_selectMapEntries_nonPositive
     :: (Ord k, Show k, Eq v, Show v)

--- a/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
@@ -518,7 +518,7 @@ prop_selectMapEntry_lookup_Nothing m0 =
 prop_selectMapEntries_empty
     :: forall k v. (Ord k, Show k, Eq v, Show v) => Int -> Property
 prop_selectMapEntries_empty i =
-    forAll (selectMapEntries i (Map.empty @k @v)) (=== ([], Map.empty))
+    forAll (selectMapEntries (Map.empty @k @v) i) (=== ([], Map.empty))
 
 prop_selectMapEntries_fromList
     :: (Ord k, Show k, Eq v, Show v) => Map k v -> Property
@@ -528,24 +528,24 @@ prop_selectMapEntries_fromList m =
         "number of available entries > 0" $
     cover 1 (Map.size m == 0)
         "number of available entries = 0" $
-    forAll (selectMapEntries (length m) m) $
+    forAll (selectMapEntries m (length m)) $
         (=== (m, mempty)) . first Map.fromList
 
 prop_selectMapEntries_nonPositive
     :: (Ord k, Show k, Eq v, Show v)
-    => NonPositive (Small Int)
-    -> Map k v
+    => Map k v
+    -> NonPositive (Small Int)
     -> Property
-prop_selectMapEntries_nonPositive (NonPositive (Small i)) m =
-    forAll (selectMapEntries i m) (== ([], m))
+prop_selectMapEntries_nonPositive m (NonPositive (Small i)) =
+    forAll (selectMapEntries m i) (== ([], m))
 
 prop_selectMapEntries_disjoint
     :: (Ord k, Show k, Eq v, Show v)
-    => Positive (Small Int)
-    -> Map k v
+    => Map k v
+    -> Positive (Small Int)
     -> Property
-prop_selectMapEntries_disjoint (Positive (Small i)) m0 =
-    forAll (selectMapEntries i m0) $ \(kvs, m1) ->
+prop_selectMapEntries_disjoint m0 (Positive (Small i)) =
+    forAll (selectMapEntries m0 i) $ \(kvs, m1) ->
         checkCoverage $
         cover 10 (length kvs == i && i >= 1)
             "number of selected entries = requested number" $
@@ -557,11 +557,11 @@ prop_selectMapEntries_disjoint (Positive (Small i)) m0 =
 
 prop_selectMapEntries_union
     :: (Ord k, Show k, Eq v, Show v)
-    => Positive (Small Int)
-    -> Map k v
+    => Map k v
+    -> Positive (Small Int)
     -> Property
-prop_selectMapEntries_union (Positive (Small i)) m0 =
-    forAll (selectMapEntries i m0) $ \(kvs, m1) ->
+prop_selectMapEntries_union m0 (Positive (Small i)) =
+    forAll (selectMapEntries m0 i) $ \(kvs, m1) ->
         checkCoverage $
         cover 10 (length kvs == i && i >= 1)
             "number of selected entries = requested number" $


### PR DESCRIPTION
## Issue Number

ADP-1538

## Summary

This PR adds some more elementary building blocks for generating sequences of transactions, including:
- `selectUTxOEntries :: UTxO -> Int -> Gen ([(TxIn, TxOut)], UTxO)`
    - **Behaviour**:
        Selects up to a given number of entries at random from the given UTxO set.
    - **Intended use**:
        When generating a transaction, selecting UTxO entries to act as inputs.

- `genTokenBundlePartition :: TokenBundle -> Int -> Gen (NonEmpty TokenBundle)`
    - **Behaviour**:
        Partitions a token bundle randomly into a given number of parts.
    - **Intended use**:
        When generating a transaction, redistributing the value of selected inputs (UTxO entries) to one or more outputs.

