### PR TITLE
Fix bug in `lightSync` where `from` is off by one

### DIFF
--- a/lib/core/src/Cardano/Wallet/Network/Light.hs
+++ b/lib/core/src/Cardano/Wallet/Network/Light.hs
@@ -166,7 +166,7 @@ proceedToNextPoint light pt = do
     maybeRollback mhere $ \here ->
         if isUnstable (stabilityWindow light) here tip
         then do
-            mblocks <- getNextBlocks light $ chainPointFromBlockHeader here
+            mblocks <- getNextBlocks light pt
             maybeRollback mblocks $ \case
                 [] -> pure $ Unstable [] here tip
                 (b:bs) -> do

--- a/lib/core/src/Cardano/Wallet/Network/Light.hs
+++ b/lib/core/src/Cardano/Wallet/Network/Light.hs
@@ -73,8 +73,8 @@ data LightSyncSource m block addr txs = LightSyncSource
         -- ^ Get the full 'BlockHeader' belonging to a given 'ChainPoint'.
         -- Return 'Nothing' if the point is not consensus anymore.
     , getNextBlocks :: ChainPoint -> m (Maybe [block])
-        -- ^ The the next blocks starting at the given 'Chainpoint'.
-        -- Return 'Nothing' if hte point is not consensus anymore.
+        -- ^ Get several blocks immediately following the given 'Chainpoint'.
+        -- Return 'Nothing' if the point is not consensus anymore.
     , getAddressTxs :: BlockHeader -> BlockHeader -> addr -> m txs
         -- ^ Transactions for a given address and point range.
     }
@@ -134,7 +134,7 @@ lightSync tr light follower = do
             Stable old new tip -> do
                 let summary = mkBlockSummary light old new
                 traceWith tr $
-                    MsgLightRollForward (chainPointFromBlockHeader old) new tip
+                    MsgLightRollForward pt new tip
                 rollForward follower (Right summary) tip
                 pure $ chainPointFromBlockHeader new
             Unstable blocks new tip -> do
@@ -162,13 +162,13 @@ proceedToNextPoint
     -> m (NextPointMove block)
 proceedToNextPoint light pt = do
     tip <- getTip light
-    mold <- getBlockHeaderAt light pt
-    maybeRollback mold $ \old ->
-        if isUnstable (stabilityWindow light) old tip
+    mhere <- getBlockHeaderAt light pt
+    maybeRollback mhere $ \here ->
+        if isUnstable (stabilityWindow light) here tip
         then do
-            mblocks <- getNextBlocks light $ chainPointFromBlockHeader old
+            mblocks <- getNextBlocks light $ chainPointFromBlockHeader here
             maybeRollback mblocks $ \case
-                [] -> pure $ Unstable [] old tip
+                [] -> pure $ Unstable [] here tip
                 (b:bs) -> do
                     let new = getHeader light $ NE.last (b :| bs)
                     continue <- isConsensus light $ chainPointFromBlockHeader new
@@ -176,9 +176,13 @@ proceedToNextPoint light pt = do
                         then Unstable (b:bs) new tip
                         else Rollback
         else do
+            mold <- getBlockHeaderAtHeight light $
+                blockHeightToInteger (blockHeight here) + 1
             mnew <- getBlockHeaderAtHeight light $
                 blockHeightToInteger (blockHeight tip) - stabilityWindow light
-            maybeRollback mnew $ \new -> pure $ Stable old new tip
+            maybeRollback mold $ \old ->
+                maybeRollback mnew $ \new ->
+                    pure $ Stable old new tip
   where
     maybeRollback m f = maybe (pure Rollback) f m
 


### PR DESCRIPTION
### Issue Number

ADP-1422, ADP-1427

### Overview

[Light-mode][] (Epic ADP-1422) aims to make synchronisation to the blockchain faster by trusting an off-chain source of aggregated blockchain data. 

  [light-mode]: https://input-output-hk.github.io/cardano-wallet/design/specs/light-mode

In this pull request, I fix an issue with the implementation of `lightSync`: The `from` field of a `BlockSummary` must point to the `BlockHeader` that immediately *follows* the `BlockHeader` to which we are currently synced. This matches the convention for retrieving a list of blocks, where only new blocks are retrieved, never the current one.

Attempt at visuals:
```
BlockSummary:

  B--------B-----B-----B----B
here      from             to

List:
  B       [B,    B,    B,   B]
here      from             to

```

This pull request also adds a check on `from` to the unit test for `lightSync`.