### PR TITLE
Preparation for transaction sequence testing. (Part 3)

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -387,6 +387,7 @@ test-suite unit
     , ouroboros-consensus
     , QuickCheck
     , quickcheck-classes
+    , quickcheck-instances
     , quickcheck-state-machine >= 0.6.0
     , quickcheck-quid
     , quiet

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -46,6 +46,7 @@ module Cardano.Wallet.Primitive.Types.TokenBundle
     -- * Quantities
     , getQuantity
     , hasQuantity
+    , setQuantity
 
     -- * Partitioning
     , equipartitionAssets
@@ -332,6 +333,14 @@ getQuantity = TokenMap.getQuantity . tokens
 --
 hasQuantity :: TokenBundle -> AssetId -> Bool
 hasQuantity = TokenMap.hasQuantity . tokens
+
+-- | Sets the quantity associated with a given asset.
+--
+-- If the given quantity is zero, the resultant bundle will not have an entry
+-- for the given asset.
+--
+setQuantity :: TokenBundle -> AssetId -> TokenQuantity -> TokenBundle
+setQuantity (TokenBundle c m) a q = TokenBundle c (TokenMap.setQuantity m a q)
 
 --------------------------------------------------------------------------------
 -- Partitioning

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -61,6 +61,9 @@ module Cardano.Wallet.Primitive.Types.TokenBundle
     -- * Queries
     , getAssets
 
+    -- * Transformations
+    , mapAssetIds
+
     -- * Unsafe operations
     , unsafeSubtract
 
@@ -384,6 +387,13 @@ equipartitionQuantitiesWithUpperBound (TokenBundle c m) maxQuantity =
 
 getAssets :: TokenBundle -> Set AssetId
 getAssets = TokenMap.getAssets . tokens
+
+--------------------------------------------------------------------------------
+-- Transformations
+--------------------------------------------------------------------------------
+
+mapAssetIds :: (AssetId -> AssetId) -> TokenBundle -> TokenBundle
+mapAssetIds f (TokenBundle c m) = TokenBundle c (TokenMap.mapAssetIds f m)
 
 --------------------------------------------------------------------------------
 -- Unsafe operations

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -90,6 +90,9 @@ module Cardano.Wallet.Primitive.Types.TokenMap
     -- * Queries
     , getAssets
 
+    -- * Transformations
+    , mapAssetIds
+
     -- * Unsafe operations
     , unsafeSubtract
 
@@ -804,6 +807,13 @@ equipartitionQuantitiesWithUpperBound m (TokenQuantity maxQuantity)
 
 getAssets :: TokenMap -> Set AssetId
 getAssets = Set.fromList . fmap fst . toFlatList
+
+--------------------------------------------------------------------------------
+-- Transformations
+--------------------------------------------------------------------------------
+
+mapAssetIds :: (AssetId -> AssetId) -> TokenMap -> TokenMap
+mapAssetIds f m = fromFlatList $ first f <$> toFlatList m
 
 --------------------------------------------------------------------------------
 -- Unsafe operations

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -92,6 +92,7 @@ module Cardano.Wallet.Primitive.Types.Tx
     , txOutAssetIds
 
     -- * Transformations
+    , txMapAssetIds
     , txRemoveAssetId
     , txOutMapAssetIds
     , txOutRemoveAssetId
@@ -994,6 +995,13 @@ txOutAssetIds (TxOut _ bundle) = TokenBundle.getAssets bundle
 --------------------------------------------------------------------------------
 -- Transformations
 --------------------------------------------------------------------------------
+
+txMapAssetIds :: (AssetId -> AssetId) -> Tx -> Tx
+txMapAssetIds f tx = tx
+    & over #outputs
+        (fmap (txOutMapAssetIds f))
+    & over #collateralOutput
+        (fmap (txOutMapAssetIds f))
 
 txRemoveAssetId :: Tx -> AssetId -> Tx
 txRemoveAssetId tx asset = tx

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -87,6 +87,9 @@ module Cardano.Wallet.Primitive.Types.Tx
     , TxSize (..)
     , txSizeDistance
 
+    -- * Queries
+    , txOutAssetIds
+
     -- * Transformations
     , txOutRemoveAssetId
 
@@ -970,6 +973,13 @@ txSizeDistance :: TxSize -> TxSize -> TxSize
 txSizeDistance (TxSize a) (TxSize b)
     | a >= b    = TxSize (a - b)
     | otherwise = TxSize (b - a)
+
+--------------------------------------------------------------------------------
+-- Queries
+--------------------------------------------------------------------------------
+
+txOutAssetIds :: TxOut -> Set AssetId
+txOutAssetIds (TxOut _ bundle) = TokenBundle.getAssets bundle
 
 --------------------------------------------------------------------------------
 -- Transformations

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -91,6 +91,7 @@ module Cardano.Wallet.Primitive.Types.Tx
     , txOutAssetIds
 
     -- * Transformations
+    , txOutMapAssetIds
     , txOutRemoveAssetId
 
     -- * Checks
@@ -984,6 +985,10 @@ txOutAssetIds (TxOut _ bundle) = TokenBundle.getAssets bundle
 --------------------------------------------------------------------------------
 -- Transformations
 --------------------------------------------------------------------------------
+
+txOutMapAssetIds :: (AssetId -> AssetId) -> TxOut -> TxOut
+txOutMapAssetIds f (TxOut address bundle) =
+    TxOut address (TokenBundle.mapAssetIds f bundle)
 
 txOutRemoveAssetId :: TxOut -> AssetId -> TxOut
 txOutRemoveAssetId (TxOut address bundle) asset =

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -88,6 +88,7 @@ module Cardano.Wallet.Primitive.Types.Tx
     , txSizeDistance
 
     -- * Queries
+    , txAssetIds
     , txOutAssetIds
 
     -- * Transformations
@@ -207,6 +208,7 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.ByteString.Char8 as B8
+import qualified Data.Foldable as F
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
@@ -979,6 +981,12 @@ txSizeDistance (TxSize a) (TxSize b)
 --------------------------------------------------------------------------------
 -- Queries
 --------------------------------------------------------------------------------
+
+txAssetIds :: Tx -> Set AssetId
+txAssetIds tx = F.fold
+    [ F.foldMap txOutAssetIds (view #outputs tx)
+    , F.foldMap txOutAssetIds (view #collateralOutput tx)
+    ]
 
 txOutAssetIds :: TxOut -> Set AssetId
 txOutAssetIds (TxOut _ bundle) = TokenBundle.getAssets bundle

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -91,6 +91,7 @@ module Cardano.Wallet.Primitive.Types.Tx
     , txOutAssetIds
 
     -- * Transformations
+    , txRemoveAssetId
     , txOutMapAssetIds
     , txOutRemoveAssetId
 
@@ -148,7 +149,7 @@ import Data.ByteString
 import Data.Either
     ( partitionEithers )
 import Data.Function
-    ( on )
+    ( on, (&) )
 import Data.Generics.Internal.VL.Lens
     ( over, view )
 import Data.Generics.Labels
@@ -985,6 +986,13 @@ txOutAssetIds (TxOut _ bundle) = TokenBundle.getAssets bundle
 --------------------------------------------------------------------------------
 -- Transformations
 --------------------------------------------------------------------------------
+
+txRemoveAssetId :: Tx -> AssetId -> Tx
+txRemoveAssetId tx asset = tx
+    & over #outputs
+        (fmap (`txOutRemoveAssetId` asset))
+    & over #collateralOutput
+        (fmap (`txOutRemoveAssetId` asset))
 
 txOutMapAssetIds :: (AssetId -> AssetId) -> TxOut -> TxOut
 txOutMapAssetIds f (TxOut address bundle) =

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -93,6 +93,7 @@ module Cardano.Wallet.Primitive.Types.Tx
 
     -- * Transformations
     , txMapAssetIds
+    , txMapTxIds
     , txRemoveAssetId
     , txOutMapAssetIds
     , txOutRemoveAssetId
@@ -1002,6 +1003,15 @@ txMapAssetIds f tx = tx
         (fmap (txOutMapAssetIds f))
     & over #collateralOutput
         (fmap (txOutMapAssetIds f))
+
+txMapTxIds :: (Hash "Tx" -> Hash "Tx") -> Tx -> Tx
+txMapTxIds f tx = tx
+    & over #txId
+        f
+    & over #resolvedInputs
+        (fmap (first (over #inputId f)))
+    & over #resolvedCollateralInputs
+        (fmap (first (over #inputId f)))
 
 txRemoveAssetId :: Tx -> AssetId -> Tx
 txRemoveAssetId tx asset = tx

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -87,6 +87,9 @@ module Cardano.Wallet.Primitive.Types.Tx
     , TxSize (..)
     , txSizeDistance
 
+    -- * Transformations
+    , txOutRemoveAssetId
+
     -- * Checks
     , coinIsValidForTxOut
 
@@ -125,7 +128,7 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( Lexicographic (..), TokenMap )
+    ( AssetId, Lexicographic (..), TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Util
@@ -967,6 +970,14 @@ txSizeDistance :: TxSize -> TxSize -> TxSize
 txSizeDistance (TxSize a) (TxSize b)
     | a >= b    = TxSize (a - b)
     | otherwise = TxSize (b - a)
+
+--------------------------------------------------------------------------------
+-- Transformations
+--------------------------------------------------------------------------------
+
+txOutRemoveAssetId :: TxOut -> AssetId -> TxOut
+txOutRemoveAssetId (TxOut address bundle) asset =
+    TxOut address (TokenBundle.setQuantity bundle asset mempty)
 
 {-------------------------------------------------------------------------------
                       Internal functions for unit testing

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -49,6 +49,7 @@ module Cardano.Wallet.Primitive.Types.UTxO
     , assetIds
 
     -- * Transformations
+    , mapAssetIds
     , mapTxIds
     , removeAssetId
 
@@ -74,7 +75,13 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn, TxOut (..), txOutAssetIds, txOutCoin, txOutRemoveAssetId )
+    ( TxIn
+    , TxOut (..)
+    , txOutAssetIds
+    , txOutCoin
+    , txOutMapAssetIds
+    , txOutRemoveAssetId
+    )
 import Control.DeepSeq
     ( NFData (..) )
 import Data.Bifunctor
@@ -279,6 +286,9 @@ assetIds (UTxO u) = foldMap txOutAssetIds u
 --------------------------------------------------------------------------------
 -- Transformations
 --------------------------------------------------------------------------------
+
+mapAssetIds :: (AssetId -> AssetId) -> UTxO -> UTxO
+mapAssetIds f (UTxO u) = UTxO $ Map.map (txOutMapAssetIds f) u
 
 mapTxIds :: (Hash "Tx" -> Hash "Tx") -> UTxO -> UTxO
 mapTxIds f (UTxO u) = UTxO $ Map.mapKeys (over #inputId f) u

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -47,6 +47,7 @@ module Cardano.Wallet.Primitive.Types.UTxO
 
     -- * Queries
     , assetIds
+    , txIds
 
     -- * Transformations
     , mapAssetIds
@@ -282,6 +283,9 @@ receiveD a b = (da, a <> b)
 
 assetIds :: UTxO -> Set AssetId
 assetIds (UTxO u) = foldMap txOutAssetIds u
+
+txIds :: UTxO -> Set (Hash "Tx")
+txIds (UTxO u) = Set.map (view #inputId) (Map.keysSet u)
 
 --------------------------------------------------------------------------------
 -- Transformations

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -44,6 +44,9 @@ module Cardano.Wallet.Primitive.Types.UTxO
     , excludingD
     , receiveD
 
+    -- * Queries
+    , assetIds
+
     -- * Transformations
     , removeAssetId
 
@@ -67,7 +70,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn, TxOut (..), txOutCoin, txOutRemoveAssetId )
+    ( TxIn, TxOut (..), txOutAssetIds, txOutCoin, txOutRemoveAssetId )
 import Control.DeepSeq
     ( NFData (..) )
 import Data.Bifunctor
@@ -261,6 +264,13 @@ excludingD u ins = (du, u `excluding` spent)
 receiveD :: UTxO -> UTxO -> (DeltaUTxO, UTxO)
 receiveD a b = (da, a <> b)
   where da = DeltaUTxO { excluded = mempty, received = b }
+
+--------------------------------------------------------------------------------
+-- Queries
+--------------------------------------------------------------------------------
+
+assetIds :: UTxO -> Set AssetId
+assetIds (UTxO u) = foldMap txOutAssetIds u
 
 --------------------------------------------------------------------------------
 -- Transformations

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -48,6 +49,7 @@ module Cardano.Wallet.Primitive.Types.UTxO
     , assetIds
 
     -- * Transformations
+    , mapTxIds
     , removeAssetId
 
     -- * UTxO Statistics
@@ -65,6 +67,8 @@ import Prelude hiding
 
 import Cardano.Wallet.Primitive.Types.Address
     ( Address )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenMap
@@ -80,7 +84,7 @@ import Data.Delta
 import Data.Functor.Identity
     ( runIdentity )
 import Data.Generics.Internal.VL.Lens
-    ( view )
+    ( over, view )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Map.Strict
@@ -275,6 +279,9 @@ assetIds (UTxO u) = foldMap txOutAssetIds u
 --------------------------------------------------------------------------------
 -- Transformations
 --------------------------------------------------------------------------------
+
+mapTxIds :: (Hash "Tx" -> Hash "Tx") -> UTxO -> UTxO
+mapTxIds f (UTxO u) = UTxO $ Map.mapKeys (over #inputId f) u
 
 removeAssetId :: UTxO -> AssetId -> UTxO
 removeAssetId (UTxO u) a = UTxO $ Map.map (`txOutRemoveAssetId` a) u

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -294,8 +294,14 @@ txIds (UTxO u) = Set.map (view #inputId) (Map.keysSet u)
 mapAssetIds :: (AssetId -> AssetId) -> UTxO -> UTxO
 mapAssetIds f (UTxO u) = UTxO $ Map.map (txOutMapAssetIds f) u
 
+-- | Applies a mapping on transaction identifiers to a 'UTxO' set.
+--
+-- If the provided mapping gives rise to a collision within the 'TxIn' key set,
+-- then only the smallest 'TxOut' is retained, according to the 'Ord' instance
+-- for 'TxOut'.
+--
 mapTxIds :: (Hash "Tx" -> Hash "Tx") -> UTxO -> UTxO
-mapTxIds f (UTxO u) = UTxO $ Map.mapKeys (over #inputId f) u
+mapTxIds f (UTxO u) = UTxO $ Map.mapKeysWith min (over #inputId f) u
 
 removeAssetId :: UTxO -> AssetId -> UTxO
 removeAssetId (UTxO u) a = UTxO $ Map.map (`txOutRemoveAssetId` a) u

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -44,6 +44,9 @@ module Cardano.Wallet.Primitive.Types.UTxO
     , excludingD
     , receiveD
 
+    -- * Transformations
+    , removeAssetId
+
     -- * UTxO Statistics
     , UTxOStatistics (..)
     , BoundType
@@ -61,8 +64,10 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( AssetId )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn, TxOut (..), txOutCoin )
+    ( TxIn, TxOut (..), txOutCoin, txOutRemoveAssetId )
 import Control.DeepSeq
     ( NFData (..) )
 import Data.Bifunctor
@@ -235,7 +240,7 @@ instance Semigroup DeltaUTxO where
         excluded'db = excluded db `excludingS` received da
 
 -- | Exclude the inputs of a 'UTxO' from a 'Set' of inputs.
-excludingS :: Set TxIn -> UTxO -> Set TxIn 
+excludingS :: Set TxIn -> UTxO -> Set TxIn
 excludingS a (UTxO b) = Set.filter (not . (`Map.member` b)) a
 
 -- | Restrict a 'Set' of inputs by the inputs of a 'UTxO'.
@@ -256,6 +261,13 @@ excludingD u ins = (du, u `excluding` spent)
 receiveD :: UTxO -> UTxO -> (DeltaUTxO, UTxO)
 receiveD a b = (da, a <> b)
   where da = DeltaUTxO { excluded = mempty, received = b }
+
+--------------------------------------------------------------------------------
+-- Transformations
+--------------------------------------------------------------------------------
+
+removeAssetId :: UTxO -> AssetId -> UTxO
+removeAssetId (UTxO u) a = UTxO $ Map.map (`txOutRemoveAssetId` a) u
 
 --------------------------------------------------------------------------------
 -- UTxO Statistics

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TxSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TxSpec.hs
@@ -11,19 +11,34 @@ module Cardano.Wallet.Primitive.Types.TxSpec
 import Prelude
 
 import Cardano.Wallet.Primitive.Types.Tx
-    ( SealedTx (..), mockSealedTx, sealedTxFromBytes )
+    ( SealedTx (..)
+    , TxOut (..)
+    , mockSealedTx
+    , sealedTxFromBytes
+    , txOutAssetIds
+    , txOutRemoveAssetId
+    )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genTxOut, shrinkTxOut )
 import Data.ByteString
     ( ByteString, pack )
 import Data.Either
     ( isLeft )
+import Data.Function
+    ( (&) )
+import Data.Maybe
+    ( listToMaybe )
 import Test.Hspec
-    ( Spec, describe )
+    ( Spec, describe, it )
 import Test.Hspec.Extra
     ( parallel )
 import Test.Hspec.QuickCheck
     ( prop )
 import Test.QuickCheck
-    ( Arbitrary (..), Property, (.&&.), (===) )
+    ( Arbitrary (..), Property, property, (.&&.), (===) )
+
+import qualified Data.Foldable as F
+import qualified Data.Set as Set
 
 spec :: Spec
 spec = do
@@ -33,6 +48,10 @@ spec = do
             prop_sealedTxGibberish
         prop "mockSealedTx - passes through mock values"
             prop_mockSealedTx
+
+    parallel $ describe "Transformations" $ do
+        it "prop_txOutRemoveAssetId_txOutAssetIds" $
+            prop_txOutRemoveAssetId_txOutAssetIds & property
 
 {-------------------------------------------------------------------------------
                          Evaluation of SealedTx fields
@@ -51,3 +70,28 @@ newtype Gibberish = Gibberish ByteString deriving (Show, Read, Eq)
 
 instance Arbitrary Gibberish where
     arbitrary = Gibberish . pack <$> arbitrary
+
+--------------------------------------------------------------------------------
+-- Transformations
+--------------------------------------------------------------------------------
+
+prop_txOutRemoveAssetId_txOutAssetIds :: TxOut -> Property
+prop_txOutRemoveAssetId_txOutAssetIds txOut =
+    case assetIdM of
+        Nothing ->
+            assetIds === mempty
+        Just assetId ->
+            Set.notMember assetId
+                (txOutAssetIds (txOut `txOutRemoveAssetId` assetId))
+            === True
+  where
+    assetIdM = listToMaybe $ F.toList assetIds
+    assetIds = txOutAssetIds txOut
+
+--------------------------------------------------------------------------------
+-- Arbitrary instances
+--------------------------------------------------------------------------------
+
+instance Arbitrary TxOut where
+    arbitrary = genTxOut
+    shrink = shrinkTxOut

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TxSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TxSpec.hs
@@ -31,6 +31,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , mockSealedTx
     , sealedTxFromBytes
     , txAssetIds
+    , txMapAssetIds
     , txOutAssetIds
     , txOutMapAssetIds
     , txOutRemoveAssetId
@@ -80,6 +81,12 @@ spec = do
 
     parallel $ describe "Transformations" $ do
 
+        describe "txMapAssetIds" $ do
+            it "prop_txMapAssetIds_identity" $
+                prop_txMapAssetIds_identity & property
+            it "prop_txMapAssetIds_composition" $
+                prop_txMapAssetIds_composition & property
+
         describe "txRemoveAssetId" $ do
             it "prop_txRemoveAssetId_txAssetIds" $
                 prop_txRemoveAssetId_txAssetIds & property
@@ -115,6 +122,16 @@ instance Arbitrary Gibberish where
 --------------------------------------------------------------------------------
 -- Transformations
 --------------------------------------------------------------------------------
+
+prop_txMapAssetIds_identity :: Tx -> Property
+prop_txMapAssetIds_identity m =
+    txMapAssetIds id m === m
+
+prop_txMapAssetIds_composition
+    :: Tx -> Fun AssetId AssetId -> Fun AssetId AssetId -> Property
+prop_txMapAssetIds_composition m (applyFun -> f) (applyFun -> g) =
+    txMapAssetIds f (txMapAssetIds g m) ===
+    txMapAssetIds (f . g) m
 
 prop_txRemoveAssetId_txAssetIds :: Tx -> Property
 prop_txRemoveAssetId_txAssetIds tx =

--- a/nix/materialized/stack-nix/cardano-wallet-core.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-core.nix
@@ -353,6 +353,7 @@
             (hsPkgs."ouroboros-consensus" or (errorHandler.buildDepError "ouroboros-consensus"))
             (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
             (hsPkgs."quickcheck-classes" or (errorHandler.buildDepError "quickcheck-classes"))
+            (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError "quickcheck-instances"))
             (hsPkgs."quickcheck-state-machine" or (errorHandler.buildDepError "quickcheck-state-machine"))
             (hsPkgs."quickcheck-quid" or (errorHandler.buildDepError "quickcheck-quid"))
             (hsPkgs."quiet" or (errorHandler.buildDepError "quiet"))


### PR DESCRIPTION
## Issue Number

[ADP-1538](https://input-output.atlassian.net/browse/ADP-1538)

## Summary

This PR adds the following transformation functions:
```hs
Tx  .mapAssetIds :: (AssetId   -> AssetId  ) -> Tx   -> Tx
UTxO.mapAssetIds :: (AssetId   -> AssetId  ) -> UTxO -> UTxO
Tx  .mapTxIds    :: (Hash "Tx" -> Hash "Tx") -> Tx   -> Tx
UTxO.mapTxIds    :: (Hash "Tx" -> Hash "Tx") -> UTxO -> UTxO

Tx  .removeAssetId :: Tx   -> AssetId -> Tx
UTxO.removeAssetId :: UTxO -> AssetId -> UTxO
```

## Motivation

Suppose we have a sequence of transactions that apply to an initial UTxO set:

```
utxo_0 -> tx_0_1 -> utxo_1
       -> tx_1_2 -> utxo_2
       -> tx_2_3 -> utxo_3
       
       -> ...    -> ...
       
       -> tx_i_j -> utxo_j
```

When generating such a transaction sequence, we generate values of `TxId` and `AssetId` at random, both with fairly large ranges of values, in order to achieve a certain balance between the _uniqueness_ of generated values and the _collision rate_ with existing values. This space scales with the QC size parameter.

However, suppose we discover a transaction sequence that is a **_counterexample_** to some property. We'd ideally like to shrink that counterexample as much as possible. Counterexamples with very long `TxId` and `AssetId` values can be very hard to read, especially if they have unprintable characters requiring escape sequences.

When shrinking, we'd like the ability to simplify the sets of `TxId`s and `AssetId`s that are in use, to be concise values like this:

```hs
[AssetId "A", AssetId "B", AssetId "C", ...]
[TxId    "1", TxId    "2", TxId    "3", ...]
```

In order to ensure referential integrity within a given transaction sequence, we need to apply any transformations to `TxId` and `AssetId` values consistently across the entire sequence.

The functions provided in this PR provide building blocks for this ability.