### PR TITLE
Turn `DecentralizationLevel` into an abstract data type

### DIFF
--- a/lib/core/src/Cardano/Pool/Rank/Likelihood.hs
+++ b/lib/core/src/Cardano/Pool/Rank/Likelihood.hs
@@ -32,9 +32,10 @@ import Prelude
 
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
-    , DecentralizationLevel (..)
+    , DecentralizationLevel
     , EpochLength (..)
     , SlottingParameters (..)
+    , getFederationPercentage
     )
 import Control.DeepSeq
     ( NFData )
@@ -91,7 +92,7 @@ estimatePoolPerformance
         -- * Block production from > 50 epochs ago has less than 1% influence
         -- on the likelihoods and can be ignored.
     -> PerformanceEstimate
-estimatePoolPerformance sp (DecentralizationLevel d) history =
+estimatePoolPerformance sp d history =
     percentile' $ foldl' considerEpoch mempty (Seq.reverse history)
   where
     considerEpoch li perf = applyDecay decayFactor li <> likelihood' perf
@@ -99,7 +100,7 @@ estimatePoolPerformance sp (DecentralizationLevel d) history =
     prob perf = leaderProbability
         (toActiveSlotCoeff $ getActiveSlotCoefficient sp)
         (stakeRelative perf)
-        (getPercentage d)
+        (getPercentage $ getFederationPercentage d)
     likelihood' perf = likelihood
         (blocksProduced perf)
         (prob perf)

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -304,7 +304,6 @@ import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
-    , DecentralizationLevel (..)
     , EpochLength (..)
     , EpochNo (..)
     , ExecutionUnitPrices (..)
@@ -325,6 +324,7 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , decodePoolIdBech32
     , encodePoolIdBech32
+    , getDecentralizationLevel
     , unsafeEpochNo
     )
 import Cardano.Wallet.Primitive.Types.Address
@@ -1123,7 +1123,7 @@ toApiNetworkParameters (NetworkParameters gp sp pp) txConstraints toEpochInfo = 
             $ unActiveSlotCoefficient
             $ getActiveSlotCoefficient sp
         , decentralizationLevel = Quantity
-            $ unDecentralizationLevel
+            $ getDecentralizationLevel
             $ view #decentralizationLevel pp
         , desiredPoolNumber = view #desiredNumberOfStakePools pp
         , minimumUtxoValue = toApiCoin $ case (view #minimumUTxOvalue pp) of

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -78,7 +78,11 @@ module Cardano.Wallet.Primitive.Types
     , EraInfo (..)
     , emptyEraInfo
     , ActiveSlotCoefficient (..)
-    , DecentralizationLevel (..)
+    , DecentralizationLevel
+    , getDecentralizationLevel
+    , getFederationPercentage
+    , fromDecentralizationLevel
+    , fromFederationPercentage
     , EpochLength (..)
     , EpochNo (..)
     , unsafeEpochNo
@@ -224,7 +228,7 @@ import Data.Maybe
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
-    ( Percentage (..), Quantity (..) )
+    ( Percentage (..), Quantity (..), complementPercentage )
 import Data.Scientific
     ( fromRationalRepetendLimited )
 import Data.String
@@ -1219,13 +1223,24 @@ instance FromJSON ExecutionUnitPrices where
 --   * '100 %' indicates that the network is /completely decentralized/.
 --
 newtype DecentralizationLevel = DecentralizationLevel
-    { unDecentralizationLevel :: Percentage }
+    { getDecentralizationLevel :: Percentage }
     deriving (Bounded, Eq, Generic, Show)
+
+fromDecentralizationLevel :: Percentage -> DecentralizationLevel
+fromDecentralizationLevel = DecentralizationLevel
+
+-- | Percentage of federated nodes.
+-- Equal to the "decentralization parameter" /d/ from the ledger specification.
+fromFederationPercentage :: Percentage -> DecentralizationLevel
+fromFederationPercentage = fromDecentralizationLevel . complementPercentage
+
+getFederationPercentage :: DecentralizationLevel -> Percentage
+getFederationPercentage = complementPercentage . getDecentralizationLevel
 
 instance NFData DecentralizationLevel
 
 instance Buildable DecentralizationLevel where
-    build = build . unDecentralizationLevel
+    build = build . getDecentralizationLevel
 
 -- | The maximum size of a serialized `TokenBundle` (`_maxValSize` in the Alonzo
 -- ledger)

--- a/lib/core/src/Data/Quantity.hs
+++ b/lib/core/src/Data/Quantity.hs
@@ -26,6 +26,7 @@ module Data.Quantity
     , mkPercentage
     , getPercentage
     , clipToPercentage
+    , complementPercentage
     , percentageToDouble
     ) where
 
@@ -220,6 +221,12 @@ data MkPercentageError
 -- out of bounds.
 clipToPercentage :: Rational -> Percentage
 clipToPercentage = Percentage . min 1 . max 0
+
+-- | The complement is the amount that is missing to make it 100%.
+--
+-- Example: The 'complementPercentage' of 0.7 is 0.3.
+complementPercentage :: Percentage -> Percentage
+complementPercentage (Percentage p) = Percentage (1-p)
 
 -- | Desired number of digits after the decimal point for presenting the
 -- @Percentage@ type.

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -86,7 +86,7 @@ import Cardano.Wallet.Primitive.Passphrase.Types
 import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
-    , DecentralizationLevel (..)
+    , DecentralizationLevel
     , DelegationCertificate (..)
     , EpochNo (..)
     , EraInfo (..)
@@ -109,6 +109,7 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , WalletName (..)
     , WithOrigin (..)
+    , fromDecentralizationLevel
     , rangeIsValid
     , unsafeEpochNo
     , wholeRange
@@ -768,7 +769,7 @@ instance Arbitrary Percentage where
         upperLimit = 10_000
 
 instance Arbitrary DecentralizationLevel where
-    arbitrary = DecentralizationLevel <$> arbitrary
+    arbitrary = fromDecentralizationLevel <$> arbitrary
 
 instance Arbitrary RewardAccount where
     arbitrary =

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -752,33 +752,12 @@ fromAlonzoPParams eraInfo currentNodeProtocolParameters pp =
 
 -- | Extract the current network decentralization level from the given set of
 -- protocol parameters.
---
--- According to the Design Specification for Delegation and Incentives in
--- Cardano, the decentralization parameter __/d/__ is a value in the range
--- '[0, 1]', where:
---
---   * __/d/__ = '1' indicates that the network is /completely federalized/.
---   * __/d/__ = '0' indicates that the network is /completely decentralized/.
---
--- However, in Cardano Wallet, we represent the decentralization level as a
--- percentage, where:
---
---   * '  0 %' indicates that the network is /completely federalized/.
---   * '100 %' indicates that the network is /completely decentralized/.
---
--- Therefore, we must invert the value provided by cardano-node before we
--- convert it into a percentage.
---
 decentralizationLevelFromPParams
     :: HasField "_d" pparams SL.UnitInterval
     => pparams
     -> W.DecentralizationLevel
 decentralizationLevelFromPParams pp =
-    W.DecentralizationLevel $ fromUnitInterval
-        -- We must invert the value provided: (see function comment)
-        $ invertUnitInterval d
-  where
-    d = getField @"_d" pp
+    W.fromFederationPercentage $ fromUnitInterval $ getField @"_d" pp
 
 executionUnitPricesFromPParams
     :: HasField "_prices" pparams Alonzo.Prices

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -93,7 +93,7 @@ import Cardano.Wallet.Primitive.Types
     , Block (..)
     , BlockHeader (..)
     , ChainPoint (..)
-    , DecentralizationLevel (..)
+    , DecentralizationLevel
     , DelegationCertificate (..)
     , EpochLength (EpochLength)
     , EpochNo (..)
@@ -118,6 +118,7 @@ import Cardano.Wallet.Primitive.Types
     , emptyEraInfo
     , executionMemory
     , executionSteps
+    , fromFederationPercentage
     , genesisParameters
     , getGenesisBlockDate
     , header
@@ -864,7 +865,7 @@ fromBlockfrostPP network BF.ProtocolParams{..} = do
                     throwError $
                         InvalidDecentralizationLevelPercentage
                             _protocolParamsDecentralisationParam
-                Right level -> pure $ DecentralizationLevel level
+                Right level -> pure $ fromFederationPercentage level
     minFeeA <-
         _protocolParamsMinFeeA <?#> "MinFeeA"
     minFeeB <-

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -55,7 +55,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Byron
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey (..) )
 import Cardano.Wallet.Primitive.Types
-    ( DecentralizationLevel (..), SlotId (..), TokenBundleMaxSize (..) )
+    ( SlotId (..), TokenBundleMaxSize (..), getDecentralizationLevel )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -241,7 +241,7 @@ spec = do
                     & unsafeBoundRational
                     & mkDecentralizationParam
                     & decentralizationLevelFromPParams
-                    & unDecentralizationLevel
+                    & getDecentralizationLevel
                     & toText
             it title $ output `shouldBe` expectedOutput
 


### PR DESCRIPTION
### Issue number

ADP-1422

### Overview

This pull request turns the `DecentralizationLevel` type into an abstract data type with no access to the internals.

We use this two fix bugs in

* `estimatePoolPerformance`
* `fromBlockfrostPP`

where the decentralization *parameter* d was interchanged with the quantity (1-d). Making the data type abstract prevents this bug.

### Details

* removes the `DecentralizationLevel` constructor from the export list
* adds accessor functions like `fromDecentralizationLevel` and `fromFederationLevel` instead

