### PR TITLE
Make it possible to shrink and show values of `IsOursIf2`.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Address/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Address/Gen.hs
@@ -3,7 +3,6 @@ module Cardano.Wallet.Primitive.Types.Address.Gen
       -- * Generators and shrinkers
       genAddress
     , shrinkAddress
-    , coarbitraryAddress
 
       -- * Indicator functions on addresses
     , addressParity
@@ -16,7 +15,7 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Test.QuickCheck
-    ( Gen, coarbitrary, elements, sized )
+    ( Gen, elements, sized )
 
 import qualified Data.Bits as Bits
 import qualified Data.ByteString as BS
@@ -35,9 +34,6 @@ shrinkAddress a
     | otherwise = [simplest]
   where
     simplest = head addresses
-
-coarbitraryAddress :: Address -> Gen a -> Gen a
-coarbitraryAddress = coarbitrary . BS.unpack . unAddress
 
 addresses :: [Address]
 addresses = mkAddress <$> ['0' ..]

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/RewardAccount/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/RewardAccount/Gen.hs
@@ -1,6 +1,5 @@
 module Cardano.Wallet.Primitive.Types.RewardAccount.Gen
-    ( coarbitraryRewardAccount
-    , genRewardAccount
+    ( genRewardAccount
     , shrinkRewardAccount
     )
     where
@@ -10,17 +9,13 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Test.QuickCheck
-    ( Gen, coarbitrary, elements, sized )
+    ( Gen, elements, sized )
 
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 
 --------------------------------------------------------------------------------
 -- Reward accounts generated according to the size parameter
 --------------------------------------------------------------------------------
-
-coarbitraryRewardAccount :: RewardAccount -> Gen a -> Gen a
-coarbitraryRewardAccount = coarbitrary . BS.unpack . unRewardAccount
 
 genRewardAccount :: Gen (RewardAccount)
 genRewardAccount = sized $ \size -> elements $ take (max 1 size) addresses

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -1,16 +1,20 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE TupleSections #-}
 
 module Cardano.Wallet.Primitive.ModelSpec
     ( spec
@@ -70,7 +74,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Address.Gen
-    ( Parity (..), addressParity, coarbitraryAddress )
+    ( Parity (..), addressParity )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
@@ -79,8 +83,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
-import Cardano.Wallet.Primitive.Types.RewardAccount.Gen
-    ( coarbitraryRewardAccount )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -156,10 +158,13 @@ import Test.Hspec.Extra
 import Test.QuickCheck
     ( Arbitrary (..)
     , CoArbitrary (..)
+    , Fun (..)
+    , Function (..)
     , Gen
     , Positive (..)
     , Property
     , Testable
+    , applyFun
     , arbitrarySizedBoundedIntegral
     , checkCoverage
     , choose
@@ -188,6 +193,8 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Extra
     ( chooseNatural, report, verify )
+import Test.QuickCheck.Instances.ByteString
+    ()
 
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
@@ -660,23 +667,20 @@ instance IsOurs (IsOursIf a) a where
 -- entity.
 --
 data IsOursIf2 a b = IsOursIf2
-    { conditionA :: a -> Bool
-    , conditionB :: b -> Bool
+    { conditionA :: Fun a Bool
+    , conditionB :: Fun b Bool
     }
 
-instance Eq (IsOursIf2 a b) where
-    _ == _ = False
-
-instance Show (IsOursIf2 a b) where
-    show _ = "IsOursIf2"
+deriving instance (Eq (Fun a Bool), Eq (Fun b Bool)) => Eq (IsOursIf2 a b)
+deriving instance (Show (Fun a Bool), Show (Fun b Bool)) => Show (IsOursIf2 a b)
 
 instance IsOurs (IsOursIf2 a b) a where
     isOurs entity s@(IsOursIf2 {conditionA}) =
-        isOursIf conditionA entity s
+        isOursIf (applyFun conditionA) entity s
 
 instance IsOurs (IsOursIf2 a b) b where
     isOurs entity s@(IsOursIf2 {conditionB}) =
-        isOursIf conditionB entity s
+        isOursIf (applyFun conditionB) entity s
 
 isOursIf :: (a -> Bool) -> a -> s -> (Maybe (NonEmpty DerivationIndex), s)
 isOursIf condition a s
@@ -1072,7 +1076,9 @@ instance MaybeLight WalletState where
                     then go as s
                     else go as (updateOurs s a)
 
-instance (CoArbitrary a, CoArbitrary b) => Arbitrary (IsOursIf2 a b) where
+instance (CoArbitrary a, CoArbitrary b, Function a, Function b) =>
+    Arbitrary (IsOursIf2 a b)
+  where
     arbitrary = IsOursIf2
         <$> arbitrary
         <*> arbitrary
@@ -2256,11 +2262,10 @@ prop_spendTx_filterByAddress f tx u =
         "spendTx tx u /= mempty && filterByAddress f u /= mempty" $
     filterByAddress f (spendTx tx u) === spendTx tx (filterByAddress f u)
 
-instance CoArbitrary Address where
-    coarbitrary = coarbitraryAddress
-
-instance CoArbitrary RewardAccount where
-    coarbitrary = coarbitraryRewardAccount
+deriving anyclass instance CoArbitrary Address
+deriving anyclass instance CoArbitrary RewardAccount
+deriving anyclass instance Function Address
+deriving anyclass instance Function RewardAccount
 
 instance Show (Address -> Bool) where
     show = const "(Address -> Bool)"

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -1082,6 +1082,7 @@ instance (CoArbitrary a, CoArbitrary b, Function a, Function b) =>
     arbitrary = IsOursIf2
         <$> arbitrary
         <*> arbitrary
+    shrink (IsOursIf2 a b) = uncurry IsOursIf2 <$> shrink (a, b)
 
 instance Arbitrary Coin where
     shrink = shrinkCoin

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -18,7 +18,7 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Address.Gen
-    ( Parity (..), addressParity, coarbitraryAddress )
+    ( Parity (..), addressParity )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..), mockHash )
 import Cardano.Wallet.Primitive.Types.TokenMap
@@ -354,8 +354,8 @@ prop_removeAssetId_assetIds u =
 -- Arbitrary instances
 --------------------------------------------------------------------------------
 
-instance CoArbitrary Address where
-    coarbitrary = coarbitraryAddress
+deriving anyclass instance CoArbitrary Address
+deriving anyclass instance Function Address
 
 instance Arbitrary AssetId where
     arbitrary = genAssetId


### PR DESCRIPTION
## Issue Number

ADP-1538

## Summary

When testing arbitrary transaction sequences, we sometimes need to test transactions that _may_ or _may not_ be relevant to a wallet. We use `IsOursIf2` to simulate wallet states where only a subset of addresses and reward accounts belong to the wallet. The ability to shrink and show values of `IsOurIf2` is extremely useful for producing minimal counterexamples and understanding them.

This PR replaces the use of [`CoArbitrary`](https://hackage.haskell.org/package/QuickCheck-2.14.2/docs/Test-QuickCheck.html#t:CoArbitrary) with [`Function`](https://hackage.haskell.org/package/QuickCheck-2.14.2/docs/Test-QuickCheck.html#t:Function) and [`Fun`](https://hackage.haskell.org/package/QuickCheck-2.14.2/docs/Test-QuickCheck.html#t:Fun), which make it trivial to generate arbitrary functions that can be shrunk and shown.