### PR TITLE
Add utility functions for testing shrinkers

### DIFF
--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -105,6 +105,7 @@ test-suite unit
     , generic-lens
     , generics-sop
     , lattices
+    , safe
     , silently
     , QuickCheck
     , unliftio

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -308,6 +308,15 @@ shrinkSpace shrinkFn = loop mempty . Set.fromList . shrinkFn
 
 -- | Repeatedly applies a shrinking function to a value while a condition holds.
 --
+-- This function can be used to predict the final value that QuickCheck will
+-- produce when searching for a minimal counterexample.
+--
+-- Example:
+--
+-- >>> isCounterexample a = (a > 0) && (a `mod` 8 == 0)
+-- >>> shrinkWhile isCounterexample shrinkIntegral 1024
+-- Just 8
+--
 -- Provided that the given starting value satisfies the condition, and provided
 -- that at least one shrunken value satisfies the condition, this function will
 -- terminate with the smallest shrunken value that cannot be shrunk further
@@ -326,6 +335,15 @@ shrinkWhile condition shrinkFn =
 
 -- | Repeatedly applies a shrinking function to a value while a condition holds,
 --   returning all the intermediate shrinking steps.
+--
+-- This function can be used to predict the sequence of intermediate values
+-- that QuickCheck will produce when searching for a minimal counterexample.
+--
+-- Example:
+--
+-- >>> isCounterexample = (>= 100)
+-- >>> shrinkWhileSteps isCounterexample shrinkIntegral 1024
+-- [512,256,128,112,105,102,101,100]
 --
 -- Provided that the given starting value satisfies the condition, and provided
 -- that at least one shrunken value satisfies the condition, this function will

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -251,24 +251,33 @@ genShrinkSequence shrinkFn = loop
         [] -> pure []
         as -> liftM2 fmap (:) loop =<< elements as
 
--- | Computes the entire shrink space of a given value and shrinking function.
+-- | Computes the shrink space of a given shrinking function for a given
+--   starting value.
 --
--- This function returns the set of all possible values to which the given
--- starting value can be shrunk. By default, the given starting value is not
--- included in the result.
+-- This function returns the set of all values that are transitively reachable
+-- through repeated applications of the given shrinking function to the given
+-- starting value.
 --
--- Example:
+-- By default, the given starting value is not included in the result.
 --
--- >>> shrinkSpace shrinkIntegral (8 :: Int)
--- fromList [0,1,2,3,4,5,6,7]
+-- Examples:
+--
+-- >>> shrinkSpace shrink "abc"
+-- ["","a","aa","aaa","aab","aac","ab","aba","abb","ac","b","ba","bb","bc","c"]
+--
+-- >>> shrinkSpace shrink (8 :: Int)
+-- [0,1,2,3,4,5,6,7]
+--
+-- >>> shrinkSpace shrink (2 :: Int, 2 :: Int)
+-- [(0,0),(0,1),(0,2),(1,0),(1,1),(1,2),(2,0),(2,1)]
 --
 -- Caution:
 --
 -- Depending on the particular choice of shrinking function and starting value,
 -- the shrink space can grow very quickly. Therefore, this function should be
--- used with extreme caution to avoid non-termination within test cases. If in
--- doubt, use the 'within' modifier provided by QuickCheck to ensure that your
--- test case terminates within a fixed time limit.
+-- used with caution to avoid non-termination within test cases. If in doubt,
+-- use the 'within' modifier provided by QuickCheck to ensure that your test
+-- case terminates within a fixed time limit.
 --
 -- This function can be used to test that a given shrinking function always
 -- generates values that satisfy a given condition. For example:

--- a/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
@@ -196,6 +196,9 @@ spec = describe "Test.QuickCheck.ExtraSpec" $ do
                 it "prop_shrinkSpace_complete" $
                     prop_shrinkSpace_complete
                         @Int & property
+                it "prop_shrinkSpace_empty" $
+                    prop_shrinkSpace_empty
+                        @Int & property
 
         describe "Repeatedly shrinking while a condition holds" $ do
 
@@ -724,6 +727,10 @@ prop_shrinkSpace_complete a =
   where
     ss = shrinkSpace shrink a
     twoSeconds = 2_000_000
+
+prop_shrinkSpace_empty :: (Arbitrary a, Ord a, Show a) => a -> Property
+prop_shrinkSpace_empty a =
+    shrinkSpace (const []) a === mempty
 
 --------------------------------------------------------------------------------
 -- Repeatedly shrinking while a condition holds

--- a/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
@@ -199,6 +199,9 @@ spec = describe "Test.QuickCheck.ExtraSpec" $ do
                 it "prop_shrinkSpace_empty" $
                     prop_shrinkSpace_empty
                         @Int & property
+                it "prop_shrinkSpace_singleton" $
+                    prop_shrinkSpace_singleton
+                        @Int & property
 
         describe "Repeatedly shrinking while a condition holds" $ do
 
@@ -731,6 +734,10 @@ prop_shrinkSpace_complete a =
 prop_shrinkSpace_empty :: (Arbitrary a, Ord a, Show a) => a -> Property
 prop_shrinkSpace_empty a =
     shrinkSpace (const []) a === mempty
+
+prop_shrinkSpace_singleton :: (Arbitrary a, Ord a, Show a) => a -> Property
+prop_shrinkSpace_singleton a =
+    shrinkSpace (const [a]) a === Set.singleton a
 
 --------------------------------------------------------------------------------
 -- Repeatedly shrinking while a condition holds

--- a/nix/materialized/stack-nix/cardano-wallet-test-utils.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-test-utils.nix
@@ -105,6 +105,7 @@
             (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
             (hsPkgs."generics-sop" or (errorHandler.buildDepError "generics-sop"))
             (hsPkgs."lattices" or (errorHandler.buildDepError "lattices"))
+            (hsPkgs."safe" or (errorHandler.buildDepError "safe"))
             (hsPkgs."silently" or (errorHandler.buildDepError "silently"))
             (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
             (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))


### PR DESCRIPTION
## Issue Number

ADP-1538

## Summary

This PR adds a set of utility functions for testing shrinkers:

- `genShrinkSequence :: (a -> [a]) -> a -> Gen [a]`
    Generates a random sequence of progressively shrunken values from a given starting value and shrinking function. Terminates with a value that cannot be shrunk further with the given shrinking function.
- `shrinkWhile :: (a -> Bool) -> (a -> [a]) -> a -> Maybe a`
    Repeatedly applies a shrinking function to a value while a condition holds. Terminates with the smallest shrunken value that cannot be shrunk further with the given shrinking function.
- `shrinkWhileSteps :: (a -> Bool) -> (a -> [a]) -> a -> [a]`
    Repeatedly applies a shrinking function to a value while a condition holds, returning all the intermediate steps (lazily).
- `shrinkSpace :: Ord a => (a -> [a]) -> a -> Set a`
    Returns the set of all values to which a given value can be shrunk, for a given shrinking function.