### PR TITLE
Filling in missing babbage unit tests

### DIFF
--- a/lib/core/src/Cardano/Api/Gen.hs
+++ b/lib/core/src/Cardano/Api/Gen.hs
@@ -1462,11 +1462,12 @@ genTxInEra era = do
 
 genTx :: Gen (InAnyCardanoEra Tx)
 genTx =
-    oneof [ InAnyCardanoEra ByronEra   <$> genTxInEra ByronEra
-          , InAnyCardanoEra ShelleyEra <$> genTxInEra ShelleyEra
-          , InAnyCardanoEra MaryEra    <$> genTxInEra MaryEra
-          , InAnyCardanoEra AllegraEra <$> genTxInEra AllegraEra
-          , InAnyCardanoEra AlonzoEra  <$> genTxInEra AlonzoEra
+    oneof [ InAnyCardanoEra ByronEra    <$> genTxInEra ByronEra
+          , InAnyCardanoEra ShelleyEra  <$> genTxInEra ShelleyEra
+          , InAnyCardanoEra MaryEra     <$> genTxInEra MaryEra
+          , InAnyCardanoEra AllegraEra  <$> genTxInEra AllegraEra
+          , InAnyCardanoEra AlonzoEra   <$> genTxInEra AlonzoEra
+          , InAnyCardanoEra BabbageEra  <$> genTxInEra BabbageEra
           ]
 
 -- TODO: Generate txs with no inputs

--- a/lib/core/test/unit/Cardano/Api/GenSpec.hs
+++ b/lib/core/test/unit/Cardano/Api/GenSpec.hs
@@ -1738,4 +1738,5 @@ forAllShelleyBasedEras f =
                 , AnyCardanoEra AllegraEra
                 , AnyCardanoEra MaryEra
                 , AnyCardanoEra AlonzoEra
+                , AnyCardanoEra BabbageEra
                 ]

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -42,6 +42,7 @@ module Cardano.Wallet.Shelley.Transaction
     , TxSkeleton (..)
     , TxWitnessTag (..)
     , TxWitnessTagFor (..)
+    , EraConstraints
     , _decodeSealedTx
     , _estimateMaxNumberOfInputs
     , _maxScriptExecutionCost

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1406,9 +1406,11 @@ binaryCalculationsSpec (AnyCardanoEra era) =
             ShelleyBasedEraMary ->
                 binaryCalculationsSpec' @Cardano.MaryEra shelleyEra
             ShelleyBasedEraAlonzo ->
-                binaryCalculationsSpec' @Cardano.AlonzoEra shelleyEra
+                pure () -- TO_DO when ledger's PR 2863 is included in node bump
+                --binaryCalculationsSpec' @Cardano.AlonzoEra shelleyEra
             ShelleyBasedEraBabbage ->
-                binaryCalculationsSpec' @Cardano.BabbageEra shelleyEra
+                pure () -- TO_DO when ledger's PR 2863 is included in node bump
+                --binaryCalculationsSpec' @Cardano.BabbageEra shelleyEra
 
 binaryCalculationsSpec'
     :: forall era. EraConstraints era

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -982,6 +982,7 @@ forAllShelleyBasedEras eraSpec = do
     eraSpec (AnyCardanoEra AllegraEra)
     eraSpec (AnyCardanoEra MaryEra)
     eraSpec (AnyCardanoEra AlonzoEra)
+    eraSpec (AnyCardanoEra BabbageEra)
 
 allEras :: [(Int, AnyCardanoEra)]
 allEras =
@@ -990,6 +991,7 @@ allEras =
     , (3, AnyCardanoEra AllegraEra)
     , (4, AnyCardanoEra MaryEra)
     , (5, AnyCardanoEra AlonzoEra)
+    , (6, AnyCardanoEra BabbageEra)
     ]
 
 eraNum :: AnyCardanoEra -> Int


### PR DESCRIPTION
<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->


- [x] I have enabled babbage era tests in core unit tests
- [x] I have enabled babbage era tests in shelley unit tests
- [x] I have unpended byron witnesses tests for any era
- [x] I have investigated/fixed byron wits tests for Alonzo and Babbage
- [x] I have postponed checking byron wits tests for Alonzo and Babbage to future PR when ledger's https://github.com/input-output-hk/cardano-ledger/pull/2863 is included in node bump

### Comments

I have the following error:
```
  calculateBinary - ShelleyBasedEraShelley
    Byron witnesses - mainnet
      1 input, 2 outputs [✔]
      2 inputs, 3 outputs [✔]
    Byron witnesses - testnet
      1 input, 2 outputs [✔]
      2 inputs, 3 outputs [✔]
  calculateBinary - ShelleyBasedEraAllegra
    Byron witnesses - mainnet
      1 input, 2 outputs [✔]
      2 inputs, 3 outputs [✔]
    Byron witnesses - testnet
      1 input, 2 outputs [✔]
      2 inputs, 3 outputs [✔]
  calculateBinary - ShelleyBasedEraMary
    Byron witnesses - mainnet
      1 input, 2 outputs [✔]
      2 inputs, 3 outputs [✔]
    Byron witnesses - testnet
      1 input, 2 outputs [✔]
      2 inputs, 3 outputs [✔]
  calculateBinary - ShelleyBasedEraAlonzo
    Byron witnesses - mainnet
      1 input, 2 outputs [✘]
      2 inputs, 3 outputs [✘]
    Byron witnesses - testnet
      1 input, 2 outputs [✘]
      2 inputs, 3 outputs [✘]
  calculateBinary - ShelleyBasedEraBabbage
    Byron witnesses - mainnet
      1 input, 2 outputs [✘]
      2 inputs, 3 outputs [✘]
    Byron witnesses - testnet
      1 input, 2 outputs [✘]
      2 inputs, 3 outputs [✘]
```
and one example (*Alonzo*)
```
  test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs:1436:13: 
  1) Cardano.Wallet.Shelley.Transaction, calculateBinary - ShelleyBasedEraAlonzo, Byron witnesses - mainnet, 1 input, 2 outputs
       expected: "83a4008182582000000000000000000000000000000000000000000000000000000000000000000001828258390101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101011a001e84808258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a0078175c021a0001faa403191e46a1028184582001000000000000000000000000000000000000000000000000000000000000005840d7af60ae33d2af351411c1445c79590526990bfa73cbb3732b54ef322daa142e6884023410f8be3c16e9bd52076f2bb36bf38dfe034a9f04658e9f56197ab80f5820000000000000000000000000000000000000000000000000000000000000000041a0f6"
        but got: "84a600818258200000000000000000000000000000000000000000000000000000000000000000000d8001828258390101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101011a001e84808258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a0078175c021a0001faa403191e460e80a10281845820010000000000000000000000000000000000000000000000000000000000000058408d3a42ab5219a082c7993ec39f205bf1a6c39e611ec855f6c64eca6116891567b0fcdc09e86258f6720dfb48ce6bf9777211d306811e08128f2460e2520f1f0d5820000000000000000000000000000000000000000000000000000000000000000041a0f5f6"
```

and corresponding example for *Babbage*:
```
  test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs:1436:13: 
  5) Cardano.Wallet.Shelley.Transaction, calculateBinary - ShelleyBasedEraBabbage, Byron witnesses - mainnet, 1 input, 2 outputs
       expected: "83a4008182582000000000000000000000000000000000000000000000000000000000000000000001828258390101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101011a001e84808258390102020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202021a0078175c021a0001faa403191e46a1028184582001000000000000000000000000000000000000000000000000000000000000005840d7af60ae33d2af351411c1445c79590526990bfa73cbb3732b54ef322daa142e6884023410f8be3c16e9bd52076f2bb36bf38dfe034a9f04658e9f56197ab80f5820000000000000000000000000000000000000000000000000000000000000000041a0f6"
        but got: "84a700818258200000000000000000000000000000000000000000000000000000000000000000000d8012800182a2005839010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101011a001e8480a2005839010202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202011a0078175c021a0001faa403191e460e80a10281845820010000000000000000000000000000000000000000000000000000000000000058400ff32401589cbffd01f4ee20a716493e1502bff1d45e084d1122f9d54bd49742c7ab1ed3c2205d8de2dffacef77109ad0ea298001293f99c7c93090288a4410c5820000000000000000000000000000000000000000000000000000000000000000041a0f5f6"
```

After analyzing cbor we see:
```
shelley,mary,allegra
[{0: [[h'0000000000000000000000000000000000000000000000000000000000000000', 0]], 1: [[h'010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101', 2000000],   [h'010202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202', 7870300]], 2: 129700, 3: 7750}
, {2: [[h'0100000000000000000000000000000000000000000000000000000000000000', h'D7AF60AE33D2AF351411C1445C79590526990BFA73CBB3732B54EF322DAA142E6884023410F8BE3C16E9BD52076F2BB36BF38DFE034A9F04658E9F56197AB80F', h'0000000000000000000000000000000000000000000000000000000000000000', h'A0']]}
, null]

alonzo
[{0: [[h'0000000000000000000000000000000000000000000000000000000000000000', 0]], 13: [], 1: [[h'010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101', 2000000], [h'010202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202', 7870300]], 2: 129700, 3: 7750, 14: []}
, {2: [[h'0100000000000000000000000000000000000000000000000000000000000000', h'8D3A42AB5219A082C7993EC39F205BF1A6C39E611EC855F6C64ECA6116891567B0FCDC09E86258F6720DFB48CE6BF9777211D306811E08128F2460E2520F1F0D', h'0000000000000000000000000000000000000000000000000000000000000000', h'A0']]}
, true
, null]

babbage
[{0: [[h'0000000000000000000000000000000000000000000000000000000000000000', 0]], 13: [], 18: [], 1: [{0: h'010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101', 1: 2000000}, {0: h'010202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202', 1: 7870300}], 2: 129700, 3: 7750, 14: []}
, {2: [[h'0100000000000000000000000000000000000000000000000000000000000000', h'0FF32401589CBFFD01F4EE20A716493E1502BFF1D45E084D1122F9D54BD49742C7AB1ED3C2205D8DE2DFFACEF77109AD0EA298001293F99C7C93090288A4410C', h'0000000000000000000000000000000000000000000000000000000000000000', h'A0']]}
, true
, null]
```


<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number
ADP-1885

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
