### PR TITLE
Remove pool_metadata_source from light mode tests for now

### DIFF
--- a/test/e2e/spec/misc_spec.rb
+++ b/test/e2e/spec/misc_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe CardanoWallet::Misc do
     end
   end
 
-  describe CardanoWallet::Misc::Settings, :light do
+  describe CardanoWallet::Misc::Settings do
 
     after(:all) do
       SETTINGS.update({ :pool_metadata_source => "none" })


### PR DESCRIPTION

- [x] I have removed pool_metadata_source from light mode tests for now

### Comments

Test will not be run in light-mode e2e suite.

### Issue Number

sort of adp-1895.