### PR TITLE
add unchecked exceptions support module

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -206,7 +206,6 @@ library
       Cardano.Wallet.DB.Sqlite.Stores
       Cardano.Wallet.DB.Sqlite.Types
       Cardano.Wallet.DB.WalletState
-      Cardano.Wallet.DB.WalletState
       Cardano.Wallet.Logging
       Cardano.Wallet.Network
       Cardano.Wallet.Network.Light

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -206,6 +206,7 @@ library
       Cardano.Wallet.DB.Sqlite.Stores
       Cardano.Wallet.DB.Sqlite.Types
       Cardano.Wallet.DB.WalletState
+      Cardano.Wallet.DB.WalletState
       Cardano.Wallet.Logging
       Cardano.Wallet.Network
       Cardano.Wallet.Network.Light
@@ -261,6 +262,7 @@ library
       Cardano.Wallet.Version
       Cardano.Wallet.Version.TH
       Control.Concurrent.Concierge
+      Control.Monad.Exception.Unchecked
       Control.Monad.Random.Extra
       Crypto.Hash.Utils
       Data.Aeson.Extra

--- a/lib/core/src/Control/Monad/Exception/Unchecked.hs
+++ b/lib/core/src/Control/Monad/Exception/Unchecked.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE LambdaCase #-}
 
--- | work with Unchecked exceptions and SomeException
+-- |
+-- Copyright: © 2022 IOHK
+-- License: Apache-2.0
+--
+-- 'Unchecked' helps convert a checked exception ('ExceptT')
+-- into an unchecked exception (instance of the 'Exception' class).
 module Control.Monad.Exception.Unchecked
     ( throwUnchecked
     , catchUnchecked
@@ -18,7 +23,8 @@ import Control.Monad.Except
 import Data.Typeable
     ( Typeable )
 
--- | An Unchecked exception is just any Typeable type
+-- | The type @Unchecked e@ any 'Typeable' type @e@ into
+-- an instance of the 'Exception' class.
 newtype Unchecked e = Unchecked e
     deriving (Eq, Show)
 

--- a/lib/core/src/Control/Monad/Exception/Unchecked.hs
+++ b/lib/core/src/Control/Monad/Exception/Unchecked.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE LambdaCase #-}
+
+-- | work with Unchecked exceptions and SomeException
+module Control.Monad.Exception.Unchecked
+    ( throwUnchecked
+    , catchUnchecked
+    , throwSomeException
+    ) where
+
+import Prelude
+
+import Control.Exception
+    ( throw )
+import Control.Monad.Catch
+    ( Exception, MonadCatch (catch), SomeException (SomeException) )
+import Control.Monad.Except
+    ( ExceptT (..), runExceptT )
+import Data.Typeable
+    ( Typeable )
+
+-- | An Unchecked exception is just any Typeable type
+newtype Unchecked e = Unchecked e
+    deriving (Eq, Show)
+
+instance (Typeable e, Show e) => Exception (Unchecked e)
+
+throwUnchecked :: (Monad m, Typeable e, Show e) => ExceptT e m b -> m b
+throwUnchecked x =
+    runExceptT x >>= \case
+        Right a -> pure a
+        Left e -> throw $ Unchecked e
+
+catchUnchecked :: (MonadCatch m, Typeable e, Show e) => m a -> ExceptT e m a
+catchUnchecked m =
+    ExceptT $
+        (Right <$> m) `catch` (\(Unchecked e) -> pure $ Left e)
+
+throwSomeException :: Either SomeException t -> (t -> p) -> p
+throwSomeException (Left (SomeException e)) _ = throw e
+throwSomeException (Right x) f = f x

--- a/nix/materialized/stack-nix/cardano-wallet-core.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-core.nix
@@ -249,6 +249,7 @@
           "Cardano/Wallet/Version"
           "Cardano/Wallet/Version/TH"
           "Control/Concurrent/Concierge"
+          "Control/Monad/Exception/Unchecked"
           "Control/Monad/Random/Extra"
           "Crypto/Hash/Utils"
           "Data/Aeson/Extra"

--- a/nix/materialized/stack-nix/cardano-wallet-core.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-core.nix
@@ -194,7 +194,6 @@
           "Cardano/Wallet/DB/Sqlite/Stores"
           "Cardano/Wallet/DB/Sqlite/Types"
           "Cardano/Wallet/DB/WalletState"
-          "Cardano/Wallet/DB/WalletState"
           "Cardano/Wallet/Logging"
           "Cardano/Wallet/Network"
           "Cardano/Wallet/Network/Light"

--- a/nix/materialized/stack-nix/cardano-wallet-core.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-core.nix
@@ -194,6 +194,7 @@
           "Cardano/Wallet/DB/Sqlite/Stores"
           "Cardano/Wallet/DB/Sqlite/Types"
           "Cardano/Wallet/DB/WalletState"
+          "Cardano/Wallet/DB/WalletState"
           "Cardano/Wallet/Logging"
           "Cardano/Wallet/Network"
           "Cardano/Wallet/Network/Light"


### PR DESCRIPTION


- [x] I have added an Unchecked type to represent exceptions of only typeable types

### Comments

This is used in the stores code to wrap synchronous Exceptions like in

```haskell
overWallet
    :: MonadIO m
    => W.WalletId
    -> (Wallet -> SqlPersistT m b)
    -> SqlPersistT m b
overWallet wid f = selectWallet wid >>= \case
        Nothing -> throwUnchecked $ ErrNoSuchWallet wid
        Just x -> f x
```

This avoids create a ErrNoSuchWallet instance of Exception

### Issue Number

ADP-1784
