### PR TITLE
Light Mode: correctly fetch next block

### DIFF
--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost/Conversion.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost/Conversion.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -8,32 +11,46 @@ import Prelude
 
 import Cardano.Wallet.Api.Types
     ( decodeAddress, decodeStakeAddress )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( RewardAccount )
 import Cardano.Wallet.Primitive.Types
-    ( StakePoolMetadataHash )
+    ( BlockHeader (..)
+    , EpochNo
+    , PoolId
+    , SlotNo (SlotNo)
+    , StakePoolMetadataHash
+    , decodePoolIdBech32
+    )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (Coin) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash )
+import Cardano.Wallet.Primitive.Types.RewardAccount
+    ( RewardAccount )
 import Cardano.Wallet.Shelley.Network.Blockfrost.Error
     ( BlockfrostError (..), (<?#>) )
 import Cardano.Wallet.Shelley.Network.Discriminant
     ( SomeNetworkDiscriminant (..) )
 import Control.Monad.Error.Class
     ( MonadError (throwError) )
+import Data.Bifunctor
+    ( first )
 import Data.IntCast
     ( intCast )
+import Data.Maybe
+    ( fromMaybe )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
-    ( Percentage, mkPercentage )
+    ( Percentage, Quantity (Quantity), mkPercentage )
 import Data.Text
     ( Text )
 import Data.Text.Class
     ( fromText )
+import Data.Traversable
+    ( for )
 
 import qualified Blockfrost.Client as BF
-import Cardano.Wallet.Primitive.Types.Address
-    ( Address )
 
 fromBfLovelaces :: MonadError BlockfrostError m => BF.Lovelaces -> m Coin
 fromBfLovelaces lovs = Coin <$> (intCast @_ @Integer lovs <?#> "Lovelaces")
@@ -70,3 +87,30 @@ stakePoolMetadataHashFromText text =
     case fromText text of
         Left e -> throwError (InvalidStakePoolMetadataHash text e)
         Right a -> pure a
+
+bfBlockHeader :: BF.Block -> Either BlockfrostError BlockHeader
+bfBlockHeader BF.Block{..} = do
+    slotNo <- fromMaybe 0 <$> for _blockSlot fromBfSlot
+    blockHeight <- Quantity <$> fromMaybe 0 _blockHeight <?#> "BlockHeight"
+    headerHash <- parseBlockHeader _blockHash
+    parentHeaderHash <- for _blockPreviousBlock parseBlockHeader
+    pure BlockHeader{slotNo, blockHeight, headerHash, parentHeaderHash}
+  where
+    parseBlockHeader blockHash =
+        case fromText (BF.unBlockHash blockHash) of
+            Right hash -> pure hash
+            Left tde -> throwError $ InvalidBlockHash blockHash tde
+
+fromBfTxHash :: BF.TxHash -> Either BlockfrostError (Hash "Tx")
+fromBfTxHash txHash = first (InvalidTxHash hash) $ fromText hash
+  where hash = BF.unTxHash txHash
+
+fromBfSlot :: BF.Slot -> Either BlockfrostError SlotNo
+fromBfSlot = fmap SlotNo . (<?#> "SlotNo") . BF.unSlot
+
+fromBfPoolId :: BF.PoolId -> Either BlockfrostError PoolId
+fromBfPoolId poolId = first (InvalidPoolId addr) (decodePoolIdBech32 addr)
+  where addr = BF.unPoolId poolId
+
+fromBfEpoch :: BF.Epoch -> EpochNo
+fromBfEpoch = fromIntegral


### PR DESCRIPTION
I have implemented a function to fetch next block in the light mode, such that it doesn't rely on the block height as not all blocks have it (EBB doesn't)

Additionally I have replaced the `FromBlockfrost` typeclass with individual conversion functions.
 
### Issue Number

ADP-1903