### PR TITLE
add wallets transaction store

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -476,6 +476,7 @@ test-suite unit
       Cardano.Wallet.DB.Store.Meta.ModelSpec
       Cardano.Wallet.DB.Store.Meta.StoreSpec
       Cardano.Wallet.DB.Store.Transactions.StoreSpec
+      Cardano.Wallet.DB.Store.Wallets.StoreSpec
       Cardano.Wallet.DummyTarget.Primitive.Types
       Cardano.Wallet.Network.LightSpec
       Cardano.Wallet.Network.PortsSpec

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -213,6 +213,7 @@ library
       Cardano.Wallet.DB.Store.Transactions.Model
       Cardano.Wallet.DB.Store.Transactions.Store
       Cardano.Wallet.DB.Store.Wallets.Model
+      Cardano.Wallet.DB.Store.Wallets.Store
       Cardano.Wallet.DB.WalletState
       Cardano.Wallet.Logging
       Cardano.Wallet.Network

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -212,6 +212,7 @@ library
       Cardano.Wallet.DB.Store.Meta.Store
       Cardano.Wallet.DB.Store.Transactions.Model
       Cardano.Wallet.DB.Store.Transactions.Store
+      Cardano.Wallet.DB.Store.Wallets.Model
       Cardano.Wallet.DB.WalletState
       Cardano.Wallet.Logging
       Cardano.Wallet.Network

--- a/lib/core/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{- |
+ Copyright: © 2018-2022 IOHK
+ License: Apache-2.0
+
+Pure model for the transactions ('Tx') and metadata about them ('TxMeta')
+in a collection of wallets.
+
+-}
+module Cardano.Wallet.DB.Store.Wallets.Model where
+
+import Prelude
+
+import Cardano.Wallet.DB.Sqlite.Types
+    ( TxId )
+import Cardano.Wallet.DB.Store.Meta.Model
+    ( DeltaTxMetaHistory (..)
+    , ManipulateTxMetaHistory
+    , TxMetaHistory (..)
+    , mkTxMetaHistory
+    )
+import Cardano.Wallet.DB.Store.Transactions.Model
+    ( TxHistory, TxHistoryF (..), mkTxHistory )
+import Data.Delta
+    ( Delta (..) )
+import Data.DeltaMap
+    ( DeltaMap (Adjust, Insert) )
+import Data.Function
+    ( (&) )
+import Data.Map.Strict
+    ( Map )
+import Data.Set
+    ( Set )
+import Fmt
+    ( Buildable, build )
+
+import qualified Cardano.Wallet.DB.Store.Meta.Model as TxMetaStore
+import qualified Cardano.Wallet.DB.Store.Transactions.Model as TxStore
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Tx as W
+import Data.Foldable
+    ( toList )
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+
+data DeltaTxWalletsHistory
+    = ExpandTxWalletsHistory W.WalletId [(W.Tx, W.TxMeta)]
+    | ChangeTxMetaWalletsHistory W.WalletId ManipulateTxMetaHistory
+    | GarbageCollectTxWalletsHistory
+    | RemoveWallet W.WalletId
+    deriving ( Show, Eq )
+
+instance Buildable DeltaTxWalletsHistory where
+    build = build . show
+
+type TxWalletsHistory = (TxHistory, Map W.WalletId TxMetaHistory)
+
+instance Delta DeltaTxWalletsHistory where
+    type Base DeltaTxWalletsHistory = TxWalletsHistory
+    apply (ExpandTxWalletsHistory wid cs) (txh,mtxmh) =
+        ( apply (TxStore.Append $ mkTxHistory $ fst <$> cs) txh
+        , mtxmh & case Map.lookup wid mtxmh of
+              Nothing -> apply @(DeltaMap _ DeltaTxMetaHistory)
+                  $ Insert wid
+                  $ mkTxMetaHistory wid cs
+              Just _ -> apply @(DeltaMap _ DeltaTxMetaHistory)
+                  $ Adjust wid
+                  $ TxMetaStore.Expand
+                  $ mkTxMetaHistory wid cs)
+    apply (ChangeTxMetaWalletsHistory wid change) (txh, mtxmh) =
+        (txh, garbageCollectEmptyWallets
+            $ mtxmh & apply (Adjust wid $ Manipulate change))
+    apply GarbageCollectTxWalletsHistory (TxHistoryF txh, mtxmh) =
+        ( TxHistoryF $ Map.restrictKeys txh $ walletsLinkedTransactions mtxmh
+        , mtxmh)
+    apply (RemoveWallet wid) (TxHistoryF txh, mtxmh) =
+        ( TxHistoryF txh, Map.delete wid mtxmh )
+
+-- necessary because database will not distinuish between
+-- a missing wallet in the map
+-- and a wallet that has no meta-transactions
+garbageCollectEmptyWallets :: Map k TxMetaHistory -> Map k TxMetaHistory
+garbageCollectEmptyWallets = Map.filter (not . null . relations)
+
+linkedTransactions :: TxMetaHistory -> Set TxId
+linkedTransactions (TxMetaHistory m) = Map.keysSet m
+
+walletsLinkedTransactions :: Map W.WalletId TxMetaHistory -> Set TxId
+walletsLinkedTransactions = Set.unions . toList .  fmap linkedTransactions

--- a/lib/core/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -1,0 +1,124 @@
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{- |
+Copyright: © 2022 IOHK
+License: Apache-2.0
+
+Implementation of a store for 'TxWalletsHistory'
+
+-}
+module Cardano.Wallet.DB.Store.Wallets.Store
+    ( mkStoreTxWalletsHistory
+    , DeltaTxWalletsHistory(..)
+    , mkStoreWalletsMeta ) where
+
+import Prelude
+
+import Cardano.Wallet.DB.Sqlite.Schema
+    ( EntityField (TxMetaWalletId), TxMeta )
+import Cardano.Wallet.DB.Store.Meta.Model
+    ( DeltaTxMetaHistory (Manipulate), TxMetaHistory, mkTxMetaHistory )
+import Cardano.Wallet.DB.Store.Meta.Store
+    ( mkStoreMetaTransactions )
+import Cardano.Wallet.DB.Store.Transactions.Model
+    ( DeltaTxHistory (..), TxHistoryF (..), mkTxHistory )
+import Cardano.Wallet.DB.Store.Transactions.Store
+    ( mkStoreTransactions )
+import Cardano.Wallet.DB.Store.Wallets.Model
+    ( DeltaTxWalletsHistory (..), walletsLinkedTransactions )
+import Control.Applicative
+    ( liftA2 )
+import Control.Exception
+    ( SomeException )
+import Control.Monad
+    ( forM, forM_ )
+import Control.Monad.Except
+    ( ExceptT (ExceptT), runExceptT )
+import Data.DBVar
+    ( Store (..) )
+import Data.DeltaMap
+    ( DeltaMap (..) )
+import Data.Generics.Internal.VL
+    ( view )
+import Data.List
+    ( nub )
+import Database.Persist.Sql
+    ( SqlPersistT, deleteWhere, entityVal, selectList, (==.) )
+
+import qualified Cardano.Wallet.DB.Store.Meta.Model as TxMetaStore
+import qualified Cardano.Wallet.DB.Store.Transactions.Model as TxStore
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Data.Map.Strict as Map
+
+-- | Store for 'WalletsMeta' of multiple different wallets.
+mkStoreWalletsMeta :: Store
+        (SqlPersistT IO)
+        (DeltaMap W.WalletId DeltaTxMetaHistory)
+mkStoreWalletsMeta =
+    Store
+    { loadS = load
+    , writeS = write
+    , updateS = update
+    }
+  where
+    write reset = forM_ (Map.assocs reset) $ \(wid,metas)
+        -> writeS (mkStoreMetaTransactions wid) metas
+    update _ (Insert wid metas) =
+        writeS (mkStoreMetaTransactions wid) metas
+    update _ (Delete wid) = do
+        deleteWhere [TxMetaWalletId ==. wid ]
+    update _ (Adjust wid da) =
+        updateS (mkStoreMetaTransactions wid) undefined da
+    load :: SqlPersistT
+            IO
+            (Either SomeException (Map.Map W.WalletId TxMetaHistory))
+    load = do
+        wids <- nub . fmap (view #txMetaWalletId . entityVal)
+            <$> selectList @TxMeta [] []
+        runExceptT $ do
+            xs <- forM wids $ ExceptT . loadS . mkStoreMetaTransactions
+            pure $ Map.fromList $ zip wids xs
+
+mkStoreTxWalletsHistory
+    :: Store (SqlPersistT IO) DeltaTxWalletsHistory
+mkStoreTxWalletsHistory =
+    Store
+    { loadS =
+            liftA2 (,) <$> loadS mkStoreTransactions <*> loadS mkStoreWalletsMeta
+    , writeS = \(txHistory,txMetaHistory) -> do
+            writeS mkStoreTransactions txHistory
+            writeS mkStoreWalletsMeta txMetaHistory
+    , updateS = \(txh@(TxHistoryF mtxh),mtxmh) -> \case
+            ExpandTxWalletsHistory wid cs -> do
+                updateS mkStoreTransactions txh
+                    $ TxStore.Append
+                    $ mkTxHistory
+                    $ fst <$> cs
+                -- see also Store.Wallets.Model.garbageCollectEmptyWallets
+                updateS mkStoreWalletsMeta mtxmh
+                    $ case Map.lookup wid mtxmh of
+                        Nothing ->
+                            Insert wid $ mkTxMetaHistory wid cs
+                        Just _ ->
+                            Adjust wid
+                            $ TxMetaStore.Expand
+                            $ mkTxMetaHistory wid cs
+            ChangeTxMetaWalletsHistory wid change
+                -> updateS mkStoreWalletsMeta mtxmh
+                $ Adjust wid
+                $ Manipulate change
+            GarbageCollectTxWalletsHistory -> mapM_
+                (updateS mkStoreTransactions txh . DeleteTx)
+                $ Map.keys
+                $ Map.withoutKeys mtxh
+                $ walletsLinkedTransactions mtxmh
+            RemoveWallet wid -> updateS mkStoreWalletsMeta mtxmh $ Delete wid
+    }
+

--- a/lib/core/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Wallet.DB.Store.Wallets.StoreSpec ( spec ) where
+
+import Prelude
+
+import Cardano.Wallet.DB.Arbitrary
+    ()
+import Cardano.Wallet.DB.Fixtures
+    ( WalletProperty, logScale, withDBInMemory, withInitializedWalletProp )
+import Cardano.Wallet.DB.Store.Meta.ModelSpec
+    ( genDeltasForManipulate )
+import Cardano.Wallet.DB.Store.Wallets.Store
+    ( DeltaTxWalletsHistory (..), mkStoreTxWalletsHistory )
+import Test.DBVar
+    ( GenDelta, prop_StoreUpdates )
+import Test.Hspec
+    ( Spec, around, describe, it )
+import Test.QuickCheck
+    ( NonEmptyList (getNonEmpty), arbitrary, frequency, property )
+
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Data.Map.Strict as Map
+
+spec :: Spec
+spec = around withDBInMemory $ do
+    describe "wallets-transactions store" $ do
+        it "respects store laws" $ property . prop_StoreWalletsLaws
+
+prop_StoreWalletsLaws :: WalletProperty
+prop_StoreWalletsLaws =
+    withInitializedWalletProp $ \wid runQ -> prop_StoreUpdates
+        runQ
+        mkStoreTxWalletsHistory
+        (pure mempty)
+        (logScale . genDeltaTxWallets wid)
+
+genDeltaTxWallets :: W.WalletId -> GenDelta DeltaTxWalletsHistory
+genDeltaTxWallets wid (_,wmeta) = do
+    let metaGens = case Map.lookup wid wmeta of
+            Nothing -> []
+            Just history
+                -> [( 10
+                    , ChangeTxMetaWalletsHistory wid
+                      <$> frequency (genDeltasForManipulate history))
+                  , (5, pure GarbageCollectTxWalletsHistory)
+                  , (1, pure $ RemoveWallet wid)
+                   ]
+    frequency
+        $ (10, ExpandTxWalletsHistory wid . getNonEmpty <$> arbitrary)
+        : metaGens
+

--- a/lib/dbvar/src/Data/DeltaMap.hs
+++ b/lib/dbvar/src/Data/DeltaMap.hs
@@ -1,18 +1,24 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Data.DeltaMap
-    ( DeltaMap (..)
+    ( DeltaMap(..)
     ) where
 
 import Prelude
-    ( Ord )
 
 import Data.Delta
     ( Delta (..) )
 import Data.Map.Strict
     ( Map )
-    
+import Fmt
+    ( Buildable (..) )
+
+
 import qualified Data.Map.Strict as Map
+
 {-------------------------------------------------------------------------------
     A Delta type for Maps,
     useful for handling multiple wallets.
@@ -23,8 +29,14 @@ data DeltaMap key da
     | Delete key
     | Adjust key da
 
-instance (Ord key, Delta da) => Delta (DeltaMap key da) where
+deriving instance (Show key, Show da, Show (Base da)) => Show (DeltaMap key da)
+instance (Ord key, Delta da)
+    => Delta (DeltaMap key da) where
     type Base (DeltaMap key da) = Map key (Base da)
     apply (Insert key a) = Map.insert key a
     apply (Delete key) = Map.delete key
     apply (Adjust key da) = Map.adjust (apply da) key
+
+instance (Show key, Show da, Show (Base da))
+    => Buildable (DeltaMap key da) where
+    build = build . show

--- a/lib/dbvar/src/Test/DBVar.hs
+++ b/lib/dbvar/src/Test/DBVar.hs
@@ -49,7 +49,7 @@ genUpdates gen0 more = sized $ \n -> go n [] =<< gen0
 --
 -- TODO: Shrinking of the update sequence.
 prop_StoreUpdates
-    :: ( Monad m, Delta da, Eq (Base da), Buildable da )
+    :: ( Monad m, Delta da, Eq (Base da), Buildable da, Show (Base da))
     => (forall b. m b -> PropertyM IO b)
     -- ^ Function to embed the monad in 'IO'
     -> Store m da
@@ -81,5 +81,7 @@ prop_StoreUpdates toPropertyM store gen0 more = do
     -- check whether the last value is correct
     case ea of
         Left err -> impureThrow err
-        Right a  -> assert $ a == head as
-
+        Right a  -> do
+            monitor $ counterexample $ "\nExpected:\n" <> show (head as)
+            monitor $ counterexample $ "\nGot:\n" <> show a
+            assert $ a == head as


### PR DESCRIPTION

- [x] I have added a store that encapsulates the transaction stores and the indexed-by-wallet meta transactions store 
- [ ]  I have checked that consistency is not harmed (review phase task)

### Comments 

This layer will take care of operations that involve both stores and are potentially harming the inter-consistency if not executed in concert. This is a grey area where database acid properties are lost. We have to take care that they are not necessary, and anyway have operations to recover consistency in case atomicity was lost.   

### Todo

Spike research on exposing the SQL transactionality on the store level API. 

### Issue Number

ADP-1784
