### PR TITLE
Update to cardano-node 1.35-rc3

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See **Installation Instructions** for each available [release](https://github.co
 >
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
-> | `master` branch | [1.35.0-rc2](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.0-rc2) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
+> | `master` branch | [1.35.0-rc3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.0-rc3) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-05-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-05-27) | [1.34.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.34.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-04-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-04-27) | [1.34.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.34.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-01-18](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-01-18) | [1.33.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.33.0) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)

--- a/cabal.project
+++ b/cabal.project
@@ -105,8 +105,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-base
-    tag: 631cb6cf1fa01ab346233b610a38b3b4cba6e6ab
-    --sha256: 0944wg2nqazmhlmsynwgdwxxj6ay0hb9qig9l128isb2cjia0hlp
+    tag: 0f3a867493059e650cda69e20a5cbf1ace289a57
+    --sha256: 0p0az3sbkhb7njji8xxdrfb0yx2gc8fmrh872ffm8sfip1w29gg1
     subdir:
             base-deriving-via
             binary
@@ -154,8 +154,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-ledger
-    tag: e290bf8d0ea272a51e9acd10adc96b4e12e00d37
-    --sha256: 1pmdg80a8irrqgdhbp46a9jx628mjbrj0k89xv5nb5dy37z5ig5f
+    tag: 52da70e5a0472cd4433876289f1aebaa0c6e5c85
+    --sha256: 0aiislbwx5yqdidwd66zqqpskvay84iwkgsgi5l96rbfcsf0n8lq
     subdir:
       eras/alonzo/impl
       eras/alonzo/test-suite
@@ -239,8 +239,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/ouroboros-network
-    tag: 04245dbd69387da98d3a37de9f400965e922bb0e
-    --sha256: 0bgfclc7h441dwq9z69697nqfir6shj4358zxmwjiaifp93zkc2p
+    tag: a65c29b6a85e90d430c7f58d362b7eb097fd4949
+    --sha256: 1fmab5hmi1y8lss97xh6hhikmyhsx9x31yhvg6zpr2kcq7kc6qkf
     subdir:
       monoidal-synchronisation
       network-mux

--- a/cabal.project
+++ b/cabal.project
@@ -184,8 +184,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-node
-    tag: 95c3692cfbd4cdb82071495d771b23e51840fb0e
-    --sha256: 1s4jjksz185dg4lp36ldha7vccxh0rk8zlvqms00zhg8kla21kr5
+    tag: 6471c31f8b61798df57a9f3345548703295cac9e
+    --sha256: 1xq2m40wgl6aw9zygzkvzcxxakcwd3p62q9j671r99i4c4x36z8g
     subdir:
       cardano-api
       cardano-git-rev

--- a/lib/core/src/Cardano/Api/Gen.hs
+++ b/lib/core/src/Cardano/Api/Gen.hs
@@ -116,6 +116,7 @@ import Cardano.Api.Shelley
     , PoolId
     , ProtocolParameters (..)
     , ReferenceScript (..)
+    , SimpleScriptOrReferenceInput (..)
     , StakeCredential (..)
     , StakePoolMetadata (..)
     , StakePoolMetadataReference (..)
@@ -453,6 +454,17 @@ genSimpleScript lang =
         (Positive m) <- arbitrary
         genTerm (n `div` (m + 3))
 
+genReferenceInput :: Gen TxIn
+genReferenceInput = genTxIn
+
+genSimpleScriptOrReferenceInput
+    :: SimpleScriptVersion lang
+    -> Gen (SimpleScriptOrReferenceInput lang)
+genSimpleScriptOrReferenceInput lang =
+    oneof [ SScript <$> genSimpleScript lang
+          , SReferenceScript <$> genReferenceInput
+          ]
+
 genScript :: ScriptLanguage lang -> Gen (Script lang)
 genScript (SimpleScriptLanguage lang) =
     SimpleScript lang <$> genSimpleScript lang
@@ -690,7 +702,7 @@ genScriptWitnessMint
 genScriptWitnessMint langEra =
     case languageOfScriptLanguageInEra langEra of
         (SimpleScriptLanguage ver) ->
-            SimpleScriptWitness langEra ver <$> genSimpleScript ver
+            SimpleScriptWitness langEra ver <$> genSimpleScriptOrReferenceInput ver
         (PlutusScriptLanguage ver) ->
             PlutusScriptWitness langEra ver
             <$> genPlutusScriptOrReferenceInput ver
@@ -704,7 +716,7 @@ genScriptWitnessStake
 genScriptWitnessStake langEra =
     case languageOfScriptLanguageInEra langEra of
         (SimpleScriptLanguage ver) ->
-            SimpleScriptWitness langEra ver <$> genSimpleScript ver
+            SimpleScriptWitness langEra ver <$> genSimpleScriptOrReferenceInput ver
         (PlutusScriptLanguage ver) ->
             PlutusScriptWitness langEra ver
             <$> genPlutusScriptOrReferenceInput ver
@@ -718,7 +730,7 @@ genScriptWitnessSpend
 genScriptWitnessSpend langEra =
     case languageOfScriptLanguageInEra langEra of
         (SimpleScriptLanguage ver) ->
-            SimpleScriptWitness langEra ver <$> genSimpleScript ver
+            SimpleScriptWitness langEra ver <$> genSimpleScriptOrReferenceInput ver
         (PlutusScriptLanguage ver) ->
             PlutusScriptWitness langEra ver
             <$> genPlutusScriptOrReferenceInput ver

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -5043,17 +5043,6 @@ instance IsServerError ErrAssignRedeemers where
                 , "for one of your redeemers since I am unable to decode it"
                 , "into a valid Plutus data:", pretty r <> "."
                 ]
-        ErrAssignRedeemersUnresolvedTxIns ins ->
-            -- Note that although this error is thrown from
-            -- '_assignScriptRedeemers', it's more related to balanceTransaction
-            -- in general than to assigning redeemers. Hence we don't mention
-            -- redeemers in the message.
-            apiError err400 UnresolvedInputs $ T.unwords
-                [ "The transaction I was given contains inputs I don't know"
-                , "about. Please ensure all foreign inputs are specified as "
-                , "part of the API request. The unknown inputs are:\n\n"
-                , pretty ins
-                ]
         ErrAssignRedeemersTranslationError TimeTranslationPastHorizon ->
             -- We differentiate this from @TranslationError@ for partial API
             -- backwards compatibility.

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -5043,12 +5043,12 @@ instance IsServerError ErrAssignRedeemers where
                 , "for one of your redeemers since I am unable to decode it"
                 , "into a valid Plutus data:", pretty r <> "."
                 ]
-        ErrAssignRedeemersTranslationError TimeTranslationPastHorizon ->
+        ErrAssignRedeemersTranslationError (TimeTranslationPastHorizon t) ->
             -- We differentiate this from @TranslationError@ for partial API
             -- backwards compatibility.
             apiError err400 PastHorizon $ T.unwords
                 [ "The transaction's validity interval is past the horizon"
-                , "of safe slot-to-time conversions."
+                , "of safe slot-to-time conversions: " <> t <> "."
                 , "This may happen when I know about a future era"
                 , "which has not yet been confirmed on-chain. Try setting the"
                 , "bounds of the validity interval to be earlier."

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -5048,10 +5048,11 @@ instance IsServerError ErrAssignRedeemers where
             -- backwards compatibility.
             apiError err400 PastHorizon $ T.unwords
                 [ "The transaction's validity interval is past the horizon"
-                , "of safe slot-to-time conversions: " <> t <> "."
+                , "of safe slot-to-time conversions."
                 , "This may happen when I know about a future era"
                 , "which has not yet been confirmed on-chain. Try setting the"
-                , "bounds of the validity interval to be earlier."
+                , "bounds of the validity interval to be earlier.\n\n"
+                , "Here are the full details: " <> t
                 ]
         ErrAssignRedeemersTranslationError e ->
             apiError err400 TranslationError $ T.unwords

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -59,6 +59,8 @@ import Cardano.Api
     ( AnyCardanoEra )
 import Cardano.Ledger.Alonzo.TxInfo
     ( TranslationError )
+import Cardano.Ledger.Crypto
+    ( StandardCrypto )
 import Cardano.Wallet.CoinSelection
     ( SelectionCollateralRequirement (..)
     , SelectionLimit
@@ -508,9 +510,7 @@ data ErrAssignRedeemers
     -- ^ The given redeemer target couldn't be located in the transaction.
     | ErrAssignRedeemersInvalidData Redeemer String
     -- ^ Redeemer's data isn't a valid Plutus' data.
-    | ErrAssignRedeemersUnresolvedTxIns [TxIn]
-    -- ^ The transaction contains inputs which couldn't be resolved.
-    | ErrAssignRedeemersTranslationError TranslationError
+    | ErrAssignRedeemersTranslationError (TranslationError StandardCrypto)
     -- ^ Mistranslating of hashes, credentials, certificates etc.
     deriving (Generic, Eq, Show)
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -83,9 +83,7 @@ import Cardano.Binary
 import Cardano.Crypto.Wallet
     ( XPub )
 import Cardano.Ledger.Alonzo.Tools
-    ( BasicFailure (BadTranslation, UnknownTxIns)
-    , evaluateTransactionExecutionUnits
-    )
+    ( evaluateTransactionExecutionUnits )
 import Cardano.Ledger.Crypto
     ( DSIGN )
 import Cardano.Ledger.Era
@@ -1311,10 +1309,7 @@ _assignScriptRedeemers pparams ti resolveInput redeemers tx =
                 systemStart
                 costs
         case res of
-            Left (UnknownTxIns ins) ->
-                Left $ ErrAssignRedeemersUnresolvedTxIns $
-                    map fromShelleyTxIn (F.toList ins)
-            Left (BadTranslation translationError) ->
+            Left translationError ->
                 Left $ ErrAssignRedeemersTranslationError translationError
             Right report ->
                 Right $ hoistScriptFailure indexedRedeemers report
@@ -1339,10 +1334,7 @@ _assignScriptRedeemers pparams ti resolveInput redeemers tx =
                 systemStart
                 costs
         case res of
-            Left (UnknownTxIns ins) ->
-                Left $ ErrAssignRedeemersUnresolvedTxIns $
-                    map fromShelleyTxIn (F.toList ins)
-            Left (BadTranslation translationError) -> do
+            Left translationError ->
                 Left $ ErrAssignRedeemersTranslationError translationError
             Right report ->
                 Right $ hoistScriptFailure indexedRedeemers report
@@ -2339,8 +2331,10 @@ mkUnsignedTx era ttl cs md wdrls certs fees mintData burnData allScripts =
                         Cardano.negateValue $
                         toCardanoValue (TokenBundle (Coin 0) burnData)
                     toScriptWitness script =
-                        Cardano.SimpleScriptWitness scriptWitsSupported
-                        Cardano.SimpleScriptV2 (toCardanoSimpleScript script)
+                        Cardano.SimpleScriptWitness
+                          scriptWitsSupported
+                          Cardano.SimpleScriptV2
+                          (Cardano.SScript $ toCardanoSimpleScript script)
                     witMap =
                         Map.map toScriptWitness $
                         Map.mapKeys (toCardanoPolicyId . TokenMap.tokenPolicyId)

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -62,6 +62,8 @@ import Cardano.BM.Data.Tracer
     ( nullTracer )
 import Cardano.BM.Tracer
     ( Tracer )
+import Cardano.Ledger.Alonzo.TxInfo
+    ( TranslationError (TranslationLogicMissingInput) )
 import Cardano.Ledger.Shelley.API
     ( StrictMaybe (SJust, SNothing), Wdrl (..) )
 import Cardano.Ledger.ShelleyMA.Timelocks
@@ -237,6 +239,7 @@ import Cardano.Wallet.Shelley.Transaction
     )
 import Cardano.Wallet.Transaction
     ( DelegationAction (RegisterKeyAndJoin)
+    , ErrAssignRedeemers (..)
     , ErrMoreSurplusNeeded (..)
     , TransactionCtx (..)
     , TransactionLayer (..)
@@ -2978,7 +2981,7 @@ balanceTransaction' (Wallet' utxo wal pending) seed tx  =
             (utxo, wal, pending)
             tx
 
--- | Tests that 'ErrAssignRedeemersUnresolvedTxIns' can in fact be returned by
+-- | Tests that 'TranslationLogicMissingInput' can in fact be returned by
 -- 'balanceTransaction'.
 prop_balanceTransactionUnresolvedInputs
     :: Wallet'
@@ -2989,19 +2992,31 @@ prop_balanceTransactionUnresolvedInputs wallet (ShowBuildable partialTx') seed =
     checkCoverage
         $ forAll (dropResolvedInputs partialTx') $ \(partialTx, dropped) -> do
             let res = balanceTransaction' wallet seed partialTx
-            case res of
-                Right _
-                    | null dropped
-                        -> label "nothing dropped"
-                            $ property True
-                    | otherwise
-                        -> label "succeeded despite unresolved input"
-                            $ property True
-                        -- Balancing can succeed if the dropped inputs
-                        -- happen to be a part of the wallet UTxO.
-                Left _
-                    -> label "other error" $ property True
+            cover 0.1 (isUnresolvedTxInsErr res) "unknown txins" $
+                case res of
+                    Right _
+                        | null dropped
+                            -> label "nothing dropped"
+                                $ property True
+                        | otherwise
+                            -> label "succeeded despite unresolved input"
+                                $ property True
+                            -- Balancing can succeed if the dropped inputs
+                            -- happen to be a part of the wallet UTxO.
+                    Left (ErrBalanceTxAssignRedeemers
+                        (ErrAssignRedeemersTranslationError
+                            (TranslationLogicMissingInput _)))
+                        -> property True
+                    Left _
+                        -> label "other error" $ property True
   where
+    isUnresolvedTxInsErr
+        (Left
+            (ErrBalanceTxAssignRedeemers
+                (ErrAssignRedeemersTranslationError
+                    (TranslationLogicMissingInput _)))) = True
+    isUnresolvedTxInsErr _ = False
+
     dropResolvedInputs (PartialTx tx inputs redeemers) = do
         shouldKeep <- vectorOf (length inputs) $ frequency
             [ (8, pure False)


### PR DESCRIPTION
I have:

- Bumped the following dependencies to the `1.35.0-rc3` tag:
  - cardano-node
  - cardano-base
  - cardano-ledger
  - ouroboros-network
- Updated cardano-wallet code to build with `1.35.0-rc3` tag:
  - `evaluateTransactionExecutionUnits` has a new error type, updated
  `ErrAssignRedeemers` accordingly.
  - `SimpleScriptWitness` now takes a `SimpleScriptOrReferenceInput` instead of a
  `SimpleScript`, updated generators accordingly.
 
TODO:
- [x] Consider whether the `prop_balanceTransactionUnresolvedInputs` test makes sense anymore.
- [ ] Test the API output of `ErrAssignRedeemersTranslationError`.
- [x] Update readme compatibility matrix

### Issue Number

ADP-1907