### PR TITLE
Light mode: reduce concurrency when retrieving data.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Network/Light.hs
+++ b/lib/core/src/Cardano/Wallet/Network/Light.hs
@@ -130,7 +130,7 @@ lightSync tr light follower = readChainPoints follower >>= syncFrom . latest
                 prev <- secondLatest <$> readChainPoints follower
                 -- NOTE: Rolling back to a result of 'readChainPoints'
                 -- should always be possible,
-                -- but the code current does not need this assumption.
+                -- but the code currently does not need this assumption.
                 traceWith tr $ MsgLightRollBackward chainPoint prev
                 rollBackward follower prev
             Stable old new tip -> do
@@ -156,6 +156,10 @@ data NextPointMove block
     -- ^ We are entering the unstable region.
     -- @Unstable blocks new tip@.
 
+-- | 'Consensual' represents the result of query on the blockchain.
+-- Either the result is a value that is part of the consensus chain,
+-- or the result is an indication that the consensus had changed
+-- before the entire value could be retrieved.
 data Consensual a
     = NotConsensual
     | Consensual a

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -64,7 +64,7 @@ import Cardano.Wallet.Logging
 import Cardano.Wallet.Network
     ( ChainFollower, NetworkLayer (..) )
 import Cardano.Wallet.Network.Light
-    ( Consensual (Consensual, NotConsensual), LightSyncSource (..) )
+    ( Consensual (..), LightSyncSource (..) )
 import Cardano.Wallet.Primitive.BlockSummary
     ( BlockEvents (..)
     , ChainEvents

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -705,10 +705,10 @@ fetchNextBlocks
     -> Hash "BlockHeader"
     -> m [Block]
 fetchNextBlocks tr nd hash = do
-    let blockHash = BF.BlockHash $ toText hash
-    BF.getNextBlocks (Right blockHash) >>= traverse \block@BF.Block{..} -> do
+    let prevBlockHash = BF.BlockHash $ toText hash
+    BF.getNextBlocks (Right prevBlockHash) >>= traverse \block@BF.Block{..} -> do
         header <- liftEither $ bfBlockHeader block
-        txhs <- fetchTxHashes blockHash _blockTxCount
+        txhs <- fetchTxHashes _blockHash _blockTxCount
         transactions <- fmap snd <$> traverse (fetchTransaction tr nd) txhs
         delegations <- join <$> traverse (fetchDelegation tr nd) txhs
         pure Block{header, transactions, delegations}

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost/Monad.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost/Monad.hs
@@ -10,6 +10,8 @@ module Cardano.Wallet.Shelley.Network.Blockfrost.Monad where
 
 import Prelude
 
+import Cardano.Wallet.Network.Light
+    ( Consensual (..) )
 import Cardano.Wallet.Shelley.Network.Blockfrost.Error
     ( BlockfrostError (ClientError)
     , BlockfrostException (BlockfrostException)
@@ -70,3 +72,6 @@ maybe404 bfm = (Just <$> bfm) `catchError` \case
 
 empty404 :: Monoid a => BFM a -> BFM a
 empty404 = (fromMaybe mempty <$>) . maybe404
+
+consensual404 :: BFM a -> BFM (Consensual a)
+consensual404 = (maybe NotConsensual Consensual <$>) . maybe404


### PR DESCRIPTION
- [x] Replace concurrent traversals with sequential ones in order to minimize likelihood of hitting `Too Many Requests` error.
- [x] Fix bug with fetching Tx hashes for the same block multiple times.

### Comments

Unfortunately the "Too Many Requests" error shows up anyway:
[wallet.log](https://github.com/input-output-hk/cardano-wallet/files/8918830/wallet.log)

### Issue Number

ADP-1651
