### PR TITLE
initial floskell config

### DIFF
--- a/floskell.json
+++ b/floskell.json
@@ -135,9 +135,9 @@
         "penalty": {
             "indent": 10,
             "max-line-length": 80,
-            "overfull": 100,
+            "overfull": 70,
             "overfull-once": 200,
-            "linebreak": 50
+            "linebreak": 100
         },
         "options": {
             "sort-pragmas": true,

--- a/floskell.json
+++ b/floskell.json
@@ -24,7 +24,7 @@
             },
             "[": {
                 "force-linebreak": false,
-                "spaces": "both",
+                "spaces": "after",
                 "linebreaks": "after"
             },
             "[ in type": {
@@ -37,7 +37,7 @@
             "deriving": 4,
             "import-spec-list": "indent-by 4",
             "where": 2,
-            "typesig": "indent-by 4",
+            "typesig": "align",
             "do": "indent-by 4",
             "app": "indent-by 4",
             "where-binds": "indent-by 2",
@@ -54,10 +54,7 @@
         "align": {
             "where": false,
             "matches": false,
-            "limits": [
-                10,
-                25
-            ],
+            "limits": [80,80],
             "import-spec": false,
             "class": false,
             "let-binds": false,
@@ -78,8 +75,8 @@
             },
             ". in type": {
                 "force-linebreak": false,
-                "spaces": "after",
-                "linebreaks": "after"
+                "spaces": "both",
+                "linebreaks": "before"
             },
             ", in other": {
                 "force-linebreak": false,
@@ -112,17 +109,12 @@
                 "linebreaks": "before"
             },
             "-> in type": {
-                "force-linebreak": true,
-                "spaces": "both",
-                "linebreaks": "none"
-            },
-            "::": {
                 "force-linebreak": false,
                 "spaces": "both",
                 "linebreaks": "before"
             },
-            "=>": {
-                "force-linebreak": true,
+            "::": {
+                "force-linebreak": false,
                 "spaces": "both",
                 "linebreaks": "before"
             }
@@ -132,7 +124,7 @@
             "import-spec-list": "vertical",
             "declaration": "try-oneline",
             "app": "try-oneline",
-            "type": "vertical",
+            "type": "try-oneline",
             "list-comp": "flex",
             "if": "vertical",
             "con-decls": "vertical",
@@ -141,11 +133,11 @@
             "export-spec-list": "try-oneline"
         },
         "penalty": {
-            "indent": 1,
+            "indent": 10,
             "max-line-length": 80,
-            "overfull": 10,
+            "overfull": 100,
             "overfull-once": 200,
-            "linebreak": 100
+            "linebreak": 50
         },
         "options": {
             "sort-pragmas": true,
@@ -154,7 +146,11 @@
             "preserve-vertical-space": true,
             "preserve-horizontal-space": true,
             "align-let-binds-and-in-expr": false,
-            "decl-no-blank-lines": [],
+            "decl-no-blank-lines": [
+                "where",
+                "instance",
+                "class"
+            ],
             "split-language-pragmas": false,
             "sort-import-lists": true,
             "sort-imports": false

--- a/floskell.json
+++ b/floskell.json
@@ -58,7 +58,7 @@
             "import-spec": false,
             "class": false,
             "let-binds": false,
-            "case": true,
+            "case": false,
             "import-module": false,
             "record-fields": false
         },
@@ -137,7 +137,7 @@
             "max-line-length": 80,
             "overfull": 70,
             "overfull-once": 200,
-            "linebreak": 100
+            "linebreak": 50
         },
         "options": {
             "sort-pragmas": true,

--- a/floskell.json
+++ b/floskell.json
@@ -37,14 +37,14 @@
             "deriving": 4,
             "import-spec-list": "indent-by 4",
             "where": 2,
-            "typesig": "align",
+            "typesig": "indent-by 4",
             "do": "indent-by 4",
             "app": "indent-by 4",
             "where-binds": "indent-by 2",
-            "multi-if": "indent-by 2",
+            "multi-if": "indent-by 4",
             "class": "indent-by 4",
             "if": "indent-by 4",
-            "let-binds": "align",
+            "let-binds": "indent-by 4",
             "onside": 4,
             "case": "indent-by 4",
             "let-in": "align",
@@ -60,7 +60,7 @@
             "let-binds": false,
             "case": true,
             "import-module": false,
-            "record-fields": true
+            "record-fields": false
         },
         "op": {
             ",": {

--- a/floskell.json
+++ b/floskell.json
@@ -1,0 +1,166 @@
+{
+    "fixities": [],
+    "formatting": {
+        "group": {
+            "{ in pattern": {
+                "force-linebreak": false,
+                "spaces": "none",
+                "linebreaks": "none"
+            },
+            "{": {
+                "force-linebreak": false,
+                "spaces": "both",
+                "linebreaks": "after"
+            },
+            "default": {
+                "force-linebreak": false,
+                "spaces": "none",
+                "linebreaks": "none"
+            },
+            "( in other": {
+                "force-linebreak": false,
+                "spaces": "both",
+                "linebreaks": "none"
+            },
+            "[": {
+                "force-linebreak": false,
+                "spaces": "both",
+                "linebreaks": "after"
+            },
+            "[ in type": {
+                "force-linebreak": false,
+                "linebreaks": "none",
+                "spaces": "none"
+            }
+        },
+        "indent": {
+            "deriving": 4,
+            "import-spec-list": "indent-by 4",
+            "where": 2,
+            "typesig": "indent-by 4",
+            "do": "indent-by 4",
+            "app": "indent-by 4",
+            "where-binds": "indent-by 2",
+            "multi-if": "indent-by 2",
+            "class": "indent-by 4",
+            "if": "indent-by 4",
+            "let-binds": "align",
+            "onside": 4,
+            "case": "indent-by 4",
+            "let-in": "align",
+            "let": "align",
+            "export-spec-list": "indent-by 4"
+        },
+        "align": {
+            "where": false,
+            "matches": false,
+            "limits": [
+                10,
+                25
+            ],
+            "import-spec": false,
+            "class": false,
+            "let-binds": false,
+            "case": true,
+            "import-module": false,
+            "record-fields": true
+        },
+        "op": {
+            ",": {
+                "force-linebreak": false,
+                "spaces": "after",
+                "linebreaks": "before"
+            },
+            "=": {
+                "force-linebreak": false,
+                "spaces": "both",
+                "linebreaks": "after"
+            },
+            ". in type": {
+                "force-linebreak": false,
+                "spaces": "after",
+                "linebreaks": "after"
+            },
+            ", in other": {
+                "force-linebreak": false,
+                "spaces": "after",
+                "linebreaks": "before"
+            },
+            ", in pattern": {
+                "force-linebreak": false,
+                "spaces": "none",
+                "linebreaks": "before"
+            },
+            "default": {
+                "force-linebreak": false,
+                "spaces": "both",
+                "linebreaks": "before"
+            },
+            "record in pattern": {
+                "force-linebreak": false,
+                "spaces": "after",
+                "linebreaks": "after"
+            },
+            "record": {
+                "force-linebreak": true,
+                "spaces": "after",
+                "linebreaks": "after"
+            },
+            ": in pattern": {
+                "force-linebreak": false,
+                "spaces": "both",
+                "linebreaks": "before"
+            },
+            "-> in type": {
+                "force-linebreak": true,
+                "spaces": "both",
+                "linebreaks": "none"
+            },
+            "::": {
+                "force-linebreak": false,
+                "spaces": "both",
+                "linebreaks": "before"
+            },
+            "=>": {
+                "force-linebreak": true,
+                "spaces": "both",
+                "linebreaks": "before"
+            }
+        },
+        "layout": {
+            "infix-app": "try-oneline",
+            "import-spec-list": "vertical",
+            "declaration": "try-oneline",
+            "app": "try-oneline",
+            "type": "vertical",
+            "list-comp": "flex",
+            "if": "vertical",
+            "con-decls": "vertical",
+            "record": "vertical",
+            "let": "vertical",
+            "export-spec-list": "try-oneline"
+        },
+        "penalty": {
+            "indent": 1,
+            "max-line-length": 80,
+            "overfull": 10,
+            "overfull-once": 200,
+            "linebreak": 100
+        },
+        "options": {
+            "sort-pragmas": true,
+            "flexible-oneline": true,
+            "align-sum-type-decl": true,
+            "preserve-vertical-space": true,
+            "preserve-horizontal-space": true,
+            "align-let-binds-and-in-expr": false,
+            "decl-no-blank-lines": [],
+            "split-language-pragmas": false,
+            "sort-import-lists": true,
+            "sort-imports": false
+        }
+    },
+    "language": "Haskell2010",
+    "style": "johan-tibell",
+    "extensions": []
+}


### PR DESCRIPTION
- [x] I have created a floskell configuration which decently respects our formatting standards

### Comments

I tried to tweak this config for some time ...

To be noted that the import reshuffling is almost the same as for stylish-haskell, it will respect the stanzas, but it's not so smart with ending ')'  so stylish-haskell needs to be invoked as of now to pass CI.

But if we decide this floskell thing is enough for our thirsty for beauty we could try to patch the lib for these small differences.  

### Issue Number

ADP-1119
