### PR TITLE
Move `adjustNoSuchWallet` and `ErrNoSuchWallet`

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -27,7 +27,6 @@ module Cardano.Wallet.DB
 
       -- * Errors
     , ErrBadFormat(..)
-    , ErrNoSuchWallet(..)
     , ErrWalletAlreadyExists(..)
     , ErrNoSuchTransaction (..)
     , ErrRemoveTx (..)
@@ -39,7 +38,7 @@ import Prelude
 import Cardano.Address.Derivation
     ( XPrv )
 import Cardano.Wallet.DB.WalletState
-    ( DeltaMap, DeltaWalletState )
+    ( DeltaMap, DeltaWalletState, ErrNoSuchWallet (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..) )
 import Cardano.Wallet.Primitive.Model
@@ -352,11 +351,6 @@ data ErrBadFormat
     deriving (Eq,Show)
 
 instance Exception ErrBadFormat
-
--- | Can't perform given operation because there's no wallet
-newtype ErrNoSuchWallet
-    = ErrNoSuchWallet WalletId -- Wallet is gone or doesn't exist yet
-    deriving (Eq, Show)
 
 -- | Can't add a transaction to the local tx submission pool.
 data ErrPutLocalTxSubmission

--- a/lib/core/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Layer.hs
@@ -83,7 +83,6 @@ import Cardano.Wallet.DB
     ( DBFactory (..)
     , DBLayer (..)
     , ErrNoSuchTransaction (..)
-    , ErrNoSuchWallet (..)
     , ErrPutLocalTxSubmission (..)
     , ErrRemoveTx (..)
     , ErrWalletAlreadyExists (..)
@@ -119,6 +118,7 @@ import Cardano.Wallet.DB.Store.Checkpoints
 import Cardano.Wallet.DB.WalletState
     ( DeltaMap (..)
     , DeltaWalletState1 (..)
+    , ErrNoSuchWallet (..)
     , findNearestPoint
     , fromGenesis
     , fromWallet

--- a/lib/core/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -24,7 +24,6 @@ import Cardano.Address.Derivation
 import Cardano.Wallet.DB
     ( DBLayer (..)
     , ErrNoSuchTransaction (..)
-    , ErrNoSuchWallet (..)
     , ErrPutLocalTxSubmission (..)
     , ErrRemoveTx (..)
     , ErrWalletAlreadyExists (..)
@@ -58,6 +57,8 @@ import Cardano.Wallet.DB.Pure.Implementation
     , mRollbackTo
     , mUpdatePendingTxForExpiry
     )
+import Cardano.Wallet.DB.WalletState
+    ( ErrNoSuchWallet (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..) )
 import Cardano.Wallet.Primitive.Passphrase

--- a/lib/core/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -52,7 +52,7 @@ import Cardano.DB.Sqlite
 import Cardano.Mnemonic
     ( SomeMnemonic (..) )
 import Cardano.Wallet.DB
-    ( DBFactory (..), DBLayer (..), ErrNoSuchWallet (..), cleanDB )
+    ( DBFactory (..), DBLayer (..), cleanDB )
 import Cardano.Wallet.DB.Arbitrary
     ( GenState, KeyValPairs (..) )
 import Cardano.Wallet.DB.Layer
@@ -73,6 +73,8 @@ import Cardano.Wallet.DB.Sqlite.Migration
     )
 import Cardano.Wallet.DB.StateMachine
     ( TestConstraints, prop_parallel, prop_sequential, validateGenerators )
+import Cardano.Wallet.DB.WalletState
+    ( ErrNoSuchWallet (..) )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( block0, dummyGenesisParameters, dummyTimeInterpreter )
 import Cardano.Wallet.Gen

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -24,7 +24,6 @@ import Prelude
 
 import Cardano.Wallet.DB
     ( DBLayer (..)
-    , ErrNoSuchWallet (..)
     , ErrWalletAlreadyExists (..)
     , SparseCheckpointsConfig (..)
     , cleanDB
@@ -41,6 +40,8 @@ import Cardano.Wallet.DB.Arbitrary
     )
 import Cardano.Wallet.DB.Pure.Implementation
     ( filterTxHistory )
+import Cardano.Wallet.DB.WalletState
+    ( ErrNoSuchWallet (..) )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( dummyGenesisParameters )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -61,7 +61,6 @@ import Cardano.Address.Script
 import Cardano.Wallet.DB
     ( DBLayer (..)
     , ErrNoSuchTransaction (..)
-    , ErrNoSuchWallet (..)
     , ErrPutLocalTxSubmission (..)
     , ErrRemoveTx (..)
     , ErrWalletAlreadyExists (..)
@@ -99,6 +98,8 @@ import Cardano.Wallet.DB.Pure.Implementation
     , mRollbackTo
     , mUpdatePendingTxForExpiry
     )
+import Cardano.Wallet.DB.WalletState
+    ( ErrNoSuchWallet (..) )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( dummyGenesisParameters, dummyTimeInterpreter )
 import Cardano.Wallet.Primitive.AddressDerivation

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -46,7 +46,9 @@ import Cardano.Wallet.CoinSelection
     , SelectionError (..)
     )
 import Cardano.Wallet.DB
-    ( DBLayer (..), ErrNoSuchWallet (..), putTxHistory )
+    ( DBLayer (..), putTxHistory )
+import Cardano.Wallet.DB.WalletState
+    ( ErrNoSuchWallet (..) )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( block0
     , dummyNetworkLayer


### PR DESCRIPTION
### Issue number

ADP-1043

### Overview

This pull request is a pure refactoring.

We move `adjustNoSuchWallet` and `ErrNoSuchWallet` to the `Cardano.Wallet.DB.WalletState` module.
