### PR TITLE
substitute dblayer transactions history implementation

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Layer.hs
@@ -116,7 +116,7 @@ import Cardano.Wallet.DB.Sqlite.Types
 import Cardano.Wallet.DB.Store.Checkpoints
     ( PersistAddressBook (..), blockHeaderFromEntity, mkStoreWallets )
 import Cardano.Wallet.DB.Store.Meta.Model
-    ( ManipulateTxMetaHistory (AgeTxMetaHistory, PruneTxMetaHistory), TxMetaHistory (..) )
+    ( ManipulateTxMetaHistory (..), TxMetaHistory (..) )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( TxHistoryF (..) )
 import Cardano.Wallet.DB.Store.Wallets.Store
@@ -145,12 +145,16 @@ import Cardano.Wallet.Primitive.Slotting
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..) )
+import Control.Exception
+    ( throw )
 import Control.Monad
     ( forM, unless, void, when, (<=<) )
 import Control.Monad.Extra
     ( concatMapM )
 import Control.Monad.IO.Class
     ( MonadIO (..) )
+import Control.Monad.Trans
+    ( lift )
 import Control.Monad.Trans.Except
     ( ExceptT (..) )
 import Control.Tracer
@@ -636,45 +640,40 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
                 [ CheckpointWalletId ==. wid ]
                 [ Asc CheckpointSlot ]
 
-        , rollbackTo = \wid requestedPoint -> ExceptT $ do
-            iomNearestCheckpoint <- modifyDBMaybe walletsDB_ $ \ws ->
-                case Map.lookup wid ws of
-                    Nothing  -> (Nothing, pure Nothing)
-                    Just wal -> case findNearestPoint wal requestedPoint of
-                        Nothing ->
-                            ( Nothing
-                            , throwIO $ ErrNoOlderCheckpoint wid requestedPoint
-                            )
-                        Just nearestPoint ->
-                            ( Just $ Adjust wid
-                                [ UpdateCheckpoints [ RollbackTo nearestPoint ] ]
-                            , pure $ Map.lookup nearestPoint $
-                                wal ^. #checkpoints ^. #checkpoints
-                            )
-            mNearestCheckpoint <- liftIO iomNearestCheckpoint
+        , rollbackTo = \wid requestedPoint -> do
+            mNearestCheckpoint <-  ExceptT $ do
+                modifyDBMaybe walletsDB_ $ \ws ->
+                    case Map.lookup wid ws of
+                        Nothing  -> (Nothing, pure Nothing)
+                        Just wal -> case findNearestPoint wal requestedPoint of
+                            Nothing ->
+                                ( Nothing
+                                , throw $ ErrNoOlderCheckpoint wid requestedPoint
+                                )
+                            Just nearestPoint ->
+                                ( Just $ Adjust wid
+                                    [ UpdateCheckpoints [ RollbackTo nearestPoint ] ]
+                                , pure $ Map.lookup nearestPoint $
+                                    wal ^. #checkpoints ^. #checkpoints
+                                )
 
             case mNearestCheckpoint of
-                Nothing  -> pure $ Left $ ErrNoSuchWallet wid
+                Nothing  -> ExceptT $ pure $ Left $ ErrNoSuchWallet wid
                 Just wcp -> do
                     let nearestPoint = wcp ^. #currentTip ^. #slotNo
-                    deleteDelegationCertificates wid
+                    lift $ deleteDelegationCertificates wid
                         [ CertSlot >. nearestPoint
                         ]
-                    updateTxMetas wid
-                        [ TxMetaDirection ==. W.Outgoing
-                        , TxMetaSlot >. nearestPoint
-                        ]
-                        [ TxMetaStatus =. W.Pending
-                        , TxMetaSlot =. nearestPoint
-                        ]
-                    deleteTxMetas wid
-                        [ TxMetaDirection ==. W.Incoming
-                        , TxMetaSlot >. nearestPoint
-                        ]
-                    deleteStakeKeyCerts wid
+                    lift $ deleteStakeKeyCerts wid
                         [ StakeKeyCertSlot >. nearestPoint
                         ]
-                    pure $ Right
+                    ExceptT $ modifyDBMaybe transactionsDBVar $ \_ ->
+                        let
+                            delta = Just
+                                $ ChangeTxMetaWalletsHistory wid
+                                $ RollBackTxMetaHistory nearestPoint
+                        in  (delta, Right ())
+                    pure
                         $ W.chainPointFromBlockHeader
                         $ view #currentTip wcp
 
@@ -1135,14 +1134,6 @@ selectWallet :: MonadIO m => W.WalletId -> SqlPersistT m (Maybe Wallet)
 selectWallet wid =
     fmap entityVal <$> selectFirst [WalId ==. wid] []
 
--- | Delete TxMeta values for a wallet.
-deleteTxMetas
-    :: W.WalletId
-    -> [Filter TxMeta]
-    -> SqlPersistT IO ()
-deleteTxMetas wid filters =
-    deleteWhere ((TxMetaWalletId ==. wid) : filters)
-
 -- | Delete stake key certificates for a wallet.
 deleteStakeKeyCerts
     :: W.WalletId
@@ -1151,14 +1142,6 @@ deleteStakeKeyCerts
 deleteStakeKeyCerts wid filters =
     deleteWhere ((StakeKeyCertWalletId ==. wid) : filters)
 
-updateTxMetas
-    :: W.WalletId
-    -> [Filter TxMeta]
-    -> [Update TxMeta]
-    -> SqlPersistT IO ()
-updateTxMetas wid filters =
-    updateWhere ((TxMetaWalletId ==. wid) : filters)
-
 -- | Delete all delegation certificates matching the given filter
 deleteDelegationCertificates
     :: W.WalletId
@@ -1166,7 +1149,6 @@ deleteDelegationCertificates
     -> SqlPersistT IO ()
 deleteDelegationCertificates wid filters = do
     deleteWhere ((CertWalletId ==. wid) : filters)
-
 
 -- This relies on available information from the database to reconstruct coin
 -- selection information for __outgoing__ payments. We can't however guarantee

--- a/lib/core/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Layer.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
@@ -15,6 +14,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE RecordWildCards #-}
 
 {- HLINT ignore "Redundant flip" -}
 {- HLINT ignore "Redundant ^." -}
@@ -64,8 +64,6 @@ import Cardano.DB.Sqlite
     , ForeignKeysSetting (ForeignKeysEnabled)
     , SqliteContext (..)
     , chunkSize
-    , dbChunked'
-    , dbChunkedFor
     , handleConstraint
     , newInMemorySqliteContext
     , newSqliteContext
@@ -117,6 +115,12 @@ import Cardano.Wallet.DB.Sqlite.Types
     ( BlockId (..), TxId (..) )
 import Cardano.Wallet.DB.Store.Checkpoints
     ( PersistAddressBook (..), blockHeaderFromEntity, mkStoreWallets )
+import Cardano.Wallet.DB.Store.Meta.Model
+    ( ManipulateTxMetaHistory (AgeTxMetaHistory, PruneTxMetaHistory), TxMetaHistory (..) )
+import Cardano.Wallet.DB.Store.Transactions.Model
+    ( TxHistoryF (..) )
+import Cardano.Wallet.DB.Store.Wallets.Store
+    ( DeltaTxWalletsHistory (..), mkStoreTxWalletsHistory )
 import Cardano.Wallet.DB.WalletState
     ( DeltaMap (..)
     , DeltaWalletState1 (..)
@@ -145,8 +149,6 @@ import Control.Monad
     ( forM, unless, void, when, (<=<) )
 import Control.Monad.Extra
     ( concatMapM )
-import Control.Monad.Identity
-    ( Identity (..) )
 import Control.Monad.IO.Class
     ( MonadIO (..) )
 import Control.Monad.Trans.Except
@@ -170,7 +172,7 @@ import Data.List.Split
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
-    ( catMaybes, listToMaybe, maybeToList )
+    ( catMaybes, listToMaybe )
 import Data.Ord
     ( Down (..) )
 import Data.Proxy
@@ -192,12 +194,10 @@ import Database.Persist.Sql
     , Single (..)
     , Update (..)
     , deleteWhere
-    , deleteWhereCount
     , insert_
     , rawExecute
     , rawSql
     , repsert
-    , repsertMany
     , selectFirst
     , selectKeysList
     , selectList
@@ -528,6 +528,7 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
     -- FIXME LATER during ADP-1043:
     --   Handle the case where loading the database fails.
     walletsDB_ <- runQuery $ loadDBVar mkStoreWallets
+    transactionsDBVar <- runQuery $ loadDBVar mkStoreTxWalletsHistory
 
     -- NOTE
     -- The cache will not work properly unless 'atomically' is protected by a
@@ -579,40 +580,34 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
                                       Wallets
         -----------------------------------------------------------------------}
 
-        { initializeWallet = \wid cp meta txs gp -> ExceptT $ do
-            res <- handleConstraint (ErrWalletAlreadyExists wid) $
-                insert_ (mkWalletEntity wid meta gp)
-            when (isRight res) $ do
-                insertCheckpointGenesis wid cp
-                let Identity
-                        ( txMetas
-                        , txIns
-                        , txCollateralIns
-                        , txOuts
-                        , txOutTokens
-                        , txCollateralOuts
-                        , txCollateralOutTokens
-                        , txWithdrawals
-                        ) = Identity $ mkTxHistory wid txs
-                putTxs
-                    txMetas
-                    txIns
-                    txCollateralIns
-                    txOuts
-                    txOutTokens
-                    txCollateralOuts
-                    txCollateralOutTokens
-                    txWithdrawals
-            pure res
-
-        , removeWallet = \wid -> ExceptT $ do
-            selectWallet wid >>= \case
-                Nothing -> pure $ Left $ ErrNoSuchWallet wid
-                Just _  -> Right <$> do
-                    deleteWhere [WalId ==. wid]
-                    deleteLooseTransactions
-                    deleteCheckpoints wid
-
+        { initializeWallet = \wid cp meta txs gp -> do
+            ExceptT $ do
+                res <- handleConstraint (ErrWalletAlreadyExists wid) $
+                    insert_ (mkWalletEntity wid meta gp)
+                when (isRight res) $ do
+                    insertCheckpointGenesis wid cp
+                    void $ modifyDBMaybe transactionsDBVar $ \(_txsOld, _ws) ->
+                        let delta = Just $ ExpandTxWalletsHistory wid txs
+                        in  (delta, Right ())
+                pure res
+        , removeWallet = \wid -> do
+            ExceptT $ do
+                selectWallet wid >>= \case
+                    Nothing -> pure $ Left $ ErrNoSuchWallet wid
+                    Just _  -> Right <$> do
+                        deleteWhere [WalId ==. wid]
+                        deleteCheckpoints wid
+            ExceptT $ modifyDBMaybe transactionsDBVar $ \(_txsOld, ws) ->
+                case Map.lookup wid ws of
+                    Nothing -> (Nothing, Left $ ErrNoSuchWallet wid)
+                    Just _  ->
+                        let
+                            delta = Just $ RemoveWallet wid
+                        in  (delta, Right ())
+            ExceptT $ modifyDBMaybe transactionsDBVar $ \_ ->
+                        let
+                            delta = Just GarbageCollectTxWalletsHistory
+                        in  (delta, Right ())
         , listWallets = map unWalletKey <$> selectKeysList [] [Asc WalId]
 
         {-----------------------------------------------------------------------
@@ -683,14 +678,22 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
                         $ W.chainPointFromBlockHeader
                         $ view #currentTip wcp
 
-        , prune = \wid epochStability -> ExceptT $ do
-            readCheckpoint_ wid >>= \case
-                Nothing -> pure $ Left $ ErrNoSuchWallet wid
-                Just cp -> Right <$> do
-                    let tip = cp ^. #currentTip
-                    pruneCheckpoints wid epochStability tip
-                    pruneLocalTxSubmission wid epochStability tip
-                    deleteLooseTransactions
+        , prune = \wid epochStability -> do
+            ExceptT $ do
+                readCheckpoint_ wid >>= \case
+                    Nothing -> pure $ Left $ ErrNoSuchWallet wid
+                    Just cp -> Right <$> do
+                        let tip = cp ^. #currentTip
+                        pruneCheckpoints wid epochStability tip
+                        pruneLocalTxSubmission wid epochStability tip
+            ExceptT $ modifyDBMaybe transactionsDBVar $ \(_txsOld, ws) ->
+                case Map.lookup wid ws of
+                    Nothing -> (Nothing, Left $ ErrNoSuchWallet wid)
+                    Just _  ->
+                        let
+                            delta = Just GarbageCollectTxWalletsHistory
+                        in  (delta, Right ())
+            -- deleteLooseTransactions
 
         {-----------------------------------------------------------------------
                                    Wallet Metadata
@@ -748,31 +751,14 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
         {-----------------------------------------------------------------------
                                      Tx History
         -----------------------------------------------------------------------}
-
         , putTxHistory = \wid txs -> ExceptT $ do
-            selectWallet wid >>= \case
-                Nothing -> pure $ Left $ ErrNoSuchWallet wid
-                Just _ -> do
-                    let Identity
-                            ( txMetas
-                            , txIns
-                            , txCollateralIns
-                            , txOuts
-                            , txOutTokens
-                            , txCollateralOuts
-                            , txCollateralOutTokens
-                            , txWithdrawals
-                            ) = Identity $ mkTxHistory wid txs
-                    putTxs
-                        txMetas
-                        txIns
-                        txCollateralIns
-                        txOuts
-                        txOutTokens
-                        txCollateralOuts
-                        txCollateralOutTokens
-                        txWithdrawals
-                    pure $ Right ()
+            modifyDBMaybe transactionsDBVar $ \(_txsOld, ws) ->
+                case Map.lookup wid ws of
+                    Nothing -> (Nothing, Left $ ErrNoSuchWallet wid)
+                    Just _  ->
+                        let
+                            delta = Just $ ExpandTxWalletsHistory wid txs
+                        in  (delta, Right ())
 
         , readTxHistory = \wid minWithdrawal order range status -> do
             readCheckpoint_ wid >>= \case
@@ -801,11 +787,16 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
             . listPendingLocalTxSubmissionQuery
 
         , updatePendingTxForExpiry = \wid tip -> ExceptT $ do
-            selectWallet wid >>= \case
-                Nothing -> pure $ Left $ ErrNoSuchWallet wid
-                Just _ -> Right <$> updatePendingTxForExpiryQuery wid tip
-
-        , removePendingOrExpiredTx = \wid tid -> ExceptT $ do
+            modifyDBMaybe transactionsDBVar $ \(_txsOld, ws) ->
+                case Map.lookup wid ws of
+                    Nothing -> (Nothing, Left $ ErrNoSuchWallet wid)
+                    Just _  ->
+                        let
+                            delta = Just
+                                $ ChangeTxMetaWalletsHistory wid
+                                $ AgeTxMetaHistory tip
+                        in  (delta, Right ())
+{-         , removePendingOrExpiredTx = \wid tid -> ExceptT $ do
             let errNoSuchWallet =
                     Left $ ErrRemoveTxNoSuchWallet $ ErrNoSuchWallet wid
             let errNoMorePending =
@@ -821,7 +812,33 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
                         count <- deletePendingOrExpiredTx wid tid
                         pure $ if count == 0
                             then errNoMorePending
-                            else Right ()
+                            else Right () -}
+        , removePendingOrExpiredTx = \wid txId -> ExceptT $ do
+            modifyDBMaybe transactionsDBVar $ \(TxHistoryF _txsOld, ws) ->
+                case Map.lookup wid ws of
+                    Nothing ->
+                        ( Nothing
+                        , Left
+                            $ ErrRemoveTxNoSuchWallet
+                            $ ErrNoSuchWallet wid
+                        )
+                    Just (TxMetaHistory metas)  ->
+                        case Map.lookup (TxId txId) metas of
+                            Just TxMeta{..} ->
+                                if txMetaStatus == W.InLedger then
+                                    (Nothing,
+                                        Left $ ErrRemoveTxAlreadyInLedger txId
+                                    )
+                                else
+                                    let delta = Just
+                                            $ ChangeTxMetaWalletsHistory wid
+                                            $ PruneTxMetaHistory $ TxId txId
+                                    in  (delta, Right ())
+                            Nothing ->
+                                (Nothing, Left
+                                    $ ErrRemoveTxNoSuchTransaction
+                                    $ ErrNoSuchTransaction wid txId
+                                    )
 
         , getTx = \wid tid -> ExceptT $ do
             readCheckpoint_ wid >>= \case
@@ -987,165 +1004,6 @@ privateKeyFromEntity
 privateKeyFromEntity (PrivateKey _ k h) =
     unsafeDeserializeXPrv (k, h)
 
-mkTxHistory
-    :: W.WalletId
-    -> [(W.Tx, W.TxMeta)]
-    ->  ( [TxMeta]
-        , [TxIn]
-        , [TxCollateral]
-        , [TxOut]
-        , [TxOutToken]
-        , [TxCollateralOut]
-        , [TxCollateralOutToken]
-        , [TxWithdrawal]
-        )
-mkTxHistory wid txs = flatTxHistory
-    [ ( mkTxMetaEntity
-          wid txid (W.fee tx) (W.metadata tx) derived (W.scriptValidity tx)
-      , mkTxInputsOutputs (txid, tx)
-      , mkTxWithdrawals (txid, tx)
-      )
-    | (tx, derived) <- txs
-    , let txid = view #txId tx
-    ]
-  where
-    -- | Make flat lists of entities from the result of 'mkTxHistory'.
-    flatTxHistory ::
-        [ ( TxMeta
-          , ( [TxIn]
-            , [TxCollateral]
-            , [(TxOut, [TxOutToken])]
-            , [(TxCollateralOut, [TxCollateralOutToken])]
-            )
-          , [TxWithdrawal]
-          )
-        ] ->
-        ( [TxMeta]
-        , [TxIn]
-        , [TxCollateral]
-        , [TxOut]
-        , [TxOutToken]
-        , [TxCollateralOut]
-        , [TxCollateralOutToken]
-        , [TxWithdrawal]
-        )
-    flatTxHistory es =
-        (               map (                       (\(a, _, _) -> a)) es
-        ,         concatMap ((\(a, _, _, _) -> a) . (\(_, b, _) -> b)) es
-        ,         concatMap ((\(_, b, _, _) -> b) . (\(_, b, _) -> b)) es
-        , fst <$> concatMap ((\(_, _, c, _) -> c) . (\(_, b, _) -> b)) es
-        , snd =<< concatMap ((\(_, _, c, _) -> c) . (\(_, b, _) -> b)) es
-        , fst <$> concatMap ((\(_, _, _, d) -> d) . (\(_, b, _) -> b)) es
-        , snd =<< concatMap ((\(_, _, _, d) -> d) . (\(_, b, _) -> b)) es
-        ,         concatMap (                       (\(_, _, c) -> c)) es
-        )
-
-mkTxInputsOutputs ::
-    (W.Hash "Tx", W.Tx) ->
-    ( [TxIn]
-    , [TxCollateral]
-    , [(TxOut, [TxOutToken])]
-    , [(TxCollateralOut, [TxCollateralOutToken])]
-    )
-mkTxInputsOutputs tx =
-    ( (dist mkTxIn . ordered W.resolvedInputs) tx
-    , (dist mkTxCollateral . ordered W.resolvedCollateralInputs) tx
-    , (dist mkTxOut . ordered W.outputs) tx
-    , (dist mkTxCollateralOut . fmap (maybeToList . W.collateralOutput)) tx
-    )
-  where
-    mkTxIn tid (ix, (txIn, amt)) = TxIn
-        { txInputTxId = TxId tid
-        , txInputOrder = ix
-        , txInputSourceTxId = TxId (W.inputId txIn)
-        , txInputSourceIndex = W.inputIx txIn
-        , txInputSourceAmount = amt
-        }
-    mkTxCollateral tid (ix, (txCollateral, amt)) = TxCollateral
-        { txCollateralTxId = TxId tid
-        , txCollateralOrder = ix
-        , txCollateralSourceTxId = TxId (W.inputId txCollateral)
-        , txCollateralSourceIndex = W.inputIx txCollateral
-        , txCollateralSourceAmount = amt
-        }
-    mkTxOut tid (ix, txOut) = (out, tokens)
-      where
-        out = TxOut
-            { txOutputTxId = TxId tid
-            , txOutputIndex = ix
-            , txOutputAddress = view #address txOut
-            , txOutputAmount = W.txOutCoin txOut
-            }
-        tokens = mkTxOutToken tid ix <$>
-            snd (TokenBundle.toFlatList $ view #tokens txOut)
-    mkTxOutToken tid ix (AssetId policy token, quantity) = TxOutToken
-        { txOutTokenTxId = TxId tid
-        , txOutTokenTxIndex = ix
-        , txOutTokenPolicyId = policy
-        , txOutTokenName = token
-        , txOutTokenQuantity = quantity
-        }
-    mkTxCollateralOut tid txCollateralOut = (out, tokens)
-      where
-        out = TxCollateralOut
-            { txCollateralOutTxId = TxId tid
-            , txCollateralOutAddress = view #address txCollateralOut
-            , txCollateralOutAmount = W.txOutCoin txCollateralOut
-            }
-        tokens = mkTxCollateralOutToken tid <$>
-            snd (TokenBundle.toFlatList $ view #tokens txCollateralOut)
-    mkTxCollateralOutToken tid (AssetId policy token, quantity) =
-        TxCollateralOutToken
-        { txCollateralOutTokenTxId = TxId tid
-        , txCollateralOutTokenPolicyId = policy
-        , txCollateralOutTokenName = token
-        , txCollateralOutTokenQuantity = quantity
-        }
-    ordered f = fmap (zip [0..] . f)
-    -- | Distribute `a` across many `b`s using the given function.
-    -- >>> dist TxOut (addr, [Coin 1, Coin 42, Coin 14])
-    -- [TxOut addr (Coin 1), TxOut addr (Coin 42), TxOut addr (Coin 14)]
-    dist :: (a -> b -> c) -> (a, [b]) -> [c]
-    dist f (a, bs) = [f a b | b <- bs]
-
-mkTxWithdrawals
-    :: (W.Hash "Tx", W.Tx)
-    -> [TxWithdrawal]
-mkTxWithdrawals (txid, tx) =
-    mkTxWithdrawal <$> Map.toList (tx ^. #withdrawals)
-  where
-    txWithdrawalTxId = TxId txid
-    mkTxWithdrawal (txWithdrawalAccount, txWithdrawalAmount) =
-        TxWithdrawal
-            { txWithdrawalTxId
-            , txWithdrawalAccount
-            , txWithdrawalAmount
-            }
-
-mkTxMetaEntity
-    :: W.WalletId
-    -> W.Hash "Tx"
-    -> Maybe W.Coin
-    -> Maybe W.TxMetadata
-    -> W.TxMeta
-    -> Maybe W.TxScriptValidity
-    -> TxMeta
-mkTxMetaEntity wid txid mfee meta derived scriptValidity = TxMeta
-    { txMetaTxId = TxId txid
-    , txMetaWalletId = wid
-    , txMetaStatus = derived ^. #status
-    , txMetaDirection = derived ^. #direction
-    , txMetaSlot = derived ^. #slotNo
-    , txMetaBlockHeight = getQuantity (derived ^. #blockHeight)
-    , txMetaAmount = derived ^. #amount
-    , txMetaFee = fromIntegral . W.unCoin <$> mfee
-    , txMetaSlotExpires = derived ^. #expiry
-    , txMetadata = meta
-    , txMetaScriptValidity = scriptValidity <&> \case
-          W.TxScriptValid -> True
-          W.TxScriptInvalid -> False
-    }
-
 -- note: TxIn records must already be sorted by order
 -- and TxOut records must already be sorted by index
 txHistoryFromEntity
@@ -1300,84 +1158,6 @@ updateTxMetas
     -> SqlPersistT IO ()
 updateTxMetas wid filters =
     updateWhere ((TxMetaWalletId ==. wid) : filters)
-
--- | Insert multiple transactions, removing old instances first.
-putTxs
-    :: [TxMeta]
-    -> [TxIn]
-    -> [TxCollateral]
-    -> [TxOut]
-    -> [TxOutToken]
-    -> [TxCollateralOut]
-    -> [TxCollateralOutToken]
-    -> [TxWithdrawal]
-    -> SqlPersistT IO ()
-putTxs
-    txMetas
-    txIns
-    txCollateralIns
-    txOuts
-    txOutTokens
-    txCollateralOuts
-    txCollateralOutTokens
-    txWithdrawals = do
-        dbChunked' repsertMany
-            [ (TxMetaKey txMetaTxId txMetaWalletId, m)
-            | m@TxMeta{..} <- txMetas]
-        dbChunked' repsertMany
-            [ (TxInKey txInputTxId txInputSourceTxId txInputSourceIndex, i)
-            | i@TxIn{..} <- txIns ]
-        dbChunked' repsertMany
-            [ ( TxCollateralKey
-                txCollateralTxId
-                txCollateralSourceTxId
-                txCollateralSourceIndex
-              , i
-              )
-            | i@TxCollateral{..} <- txCollateralIns ]
-        dbChunked' repsertMany
-            [ (TxOutKey txOutputTxId txOutputIndex, o)
-            | o@TxOut{..} <- txOuts ]
-        dbChunked' repsertMany
-            [ ( TxOutTokenKey
-                txOutTokenTxId
-                txOutTokenTxIndex
-                txOutTokenPolicyId
-                txOutTokenName
-              , o
-              )
-            | o@TxOutToken{..} <- txOutTokens ]
-        dbChunked' repsertMany
-            [ (TxCollateralOutKey txCollateralOutTxId, o)
-            | o@TxCollateralOut{..} <- txCollateralOuts ]
-        dbChunked' repsertMany
-            [ ( TxCollateralOutTokenKey
-                txCollateralOutTokenTxId
-                txCollateralOutTokenPolicyId
-                txCollateralOutTokenName
-              , o
-              )
-            | o@TxCollateralOutToken{..} <- txCollateralOutTokens ]
-        dbChunked' repsertMany
-            [ (TxWithdrawalKey txWithdrawalTxId txWithdrawalAccount, w)
-            | w@TxWithdrawal{..} <- txWithdrawals ]
-
--- | Delete transactions that aren't referred to by TxMeta of any wallet.
-deleteLooseTransactions :: SqlPersistT IO ()
-deleteLooseTransactions = do
-    deleteLoose "tx_in"
-    deleteLoose "tx_out"
-    deleteLoose "tx_withdrawal"
-  where
-    -- Deletes all TxIn/TxOuts/TxWithdrawal returned by the sub-select.
-    -- The sub-select outer joins TxMeta with TxIn/TxOut/TxWithdrawal.
-    -- All rows of the join table TxMeta as NULL are loose (unreferenced)
-    -- transactions.
-    deleteLoose t = flip rawExecute [] $
-        "DELETE FROM "<> t <>" WHERE tx_id IN (" <>
-            "SELECT "<> t <>".tx_id FROM "<> t <>" " <>
-            "LEFT OUTER JOIN tx_meta ON tx_meta.tx_id = "<> t <>".tx_id " <>
-            "WHERE (tx_meta.tx_id IS NULL))"
 
 -- | Delete all delegation certificates matching the given filter
 deleteDelegationCertificates
@@ -1564,28 +1344,6 @@ selectTxHistory cp ti wid minWithdrawal order conditions = do
         W.Ascending -> [Asc TxMetaSlot, Desc TxMetaTxId]
         W.Descending -> [Desc TxMetaSlot, Asc TxMetaTxId]
 
-selectTxMeta
-    :: W.WalletId
-    -> W.Hash "Tx"
-    -> SqlPersistT IO (Maybe TxMeta)
-selectTxMeta wid tid =
-    fmap entityVal <$> selectFirst
-        [ TxMetaWalletId ==. wid, TxMetaTxId ==. (TxId tid)]
-        [ Desc TxMetaSlot ]
-
--- | Delete the transaction, but only if it's not in ledger.
--- Returns non-zero if this was a success.
-deletePendingOrExpiredTx
-    :: W.WalletId
-    -> W.Hash "Tx"
-    -> SqlPersistT IO Int
-deletePendingOrExpiredTx wid tid = do
-    let filt = [ TxMetaWalletId ==. wid, TxMetaTxId ==. (TxId tid) ]
-    selectFirst ((TxMetaStatus ==. W.InLedger):filt) [] >>= \case
-        Just _ -> pure 0  -- marked in ledger - refuse to delete
-        Nothing -> fromIntegral <$> deleteWhereCount
-            ((TxMetaStatus <-. [W.Pending, W.Expired]):filt)
-
 -- | Returns the initial submission slot and submission record for all pending
 -- transactions in the wallet.
 listPendingLocalTxSubmissionQuery
@@ -1626,29 +1384,6 @@ pruneLocalTxSubmission wid (Quantity epochStability) tip =
         "( SELECT tx_id FROM tx_meta WHERE tx_meta.block_height < ? )"
     params = [toPersistValue wid, toPersistValue stableHeight]
     stableHeight = getQuantity (tip ^. #blockHeight) - epochStability
-
--- | Mutates all pending transaction entries which have exceeded their TTL so
--- that their status becomes expired. Then it removes these transactions from
--- the local tx submission pool.
---
--- Transaction expiry is not something which can be rolled back.
-updatePendingTxForExpiryQuery
-    :: W.WalletId
-    -> W.SlotNo
-    -> SqlPersistT IO ()
-updatePendingTxForExpiryQuery wid tip = do
-    txIds <- fmap (txMetaTxId . entityVal) <$> selectList isExpired []
-    updateWhere isExpired [TxMetaStatus =. W.Expired]
-    -- Remove these transactions from the wallet's local submission pool.
-    dbChunkedFor @LocalTxSubmission (\batch -> deleteWhere
-        [ LocalTxSubmissionWalletId ==. wid
-        , LocalTxSubmissionTxId <-. batch
-        ]) txIds
-  where
-    isExpired =
-        [ TxMetaWalletId ==. wid
-        , TxMetaStatus ==. W.Pending
-        , TxMetaSlotExpires <=. Just tip ]
 
 selectPrivateKey
     :: (MonadIO m, PersistPrivateKey (k 'RootK))

--- a/lib/core/src/Cardano/Wallet/DB/Store/Meta/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Store/Meta/Model.hs
@@ -79,7 +79,7 @@ instance Buildable DeltaTxMetaHistory where
 
 instance Delta DeltaTxMetaHistory where
     type Base DeltaTxMetaHistory = TxMetaHistory
-    apply (Expand txs) h = h <> txs
+    apply (Expand txs) h = txs <> h
     apply (Manipulate d) h = apply d h
 
 instance Delta ManipulateTxMetaHistory where

--- a/lib/core/src/Cardano/Wallet/DB/Store/Meta/Store.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Store/Meta/Store.hs
@@ -33,6 +33,8 @@ import Data.DBVar
     ( Store (Store, loadS, updateS, writeS) )
 import Data.Foldable
     ( Foldable (toList) )
+import Data.List.Split
+    ( chunksOf )
 import Data.Maybe
     ( fromJust )
 import Database.Persist.Sql
@@ -111,4 +113,7 @@ load wid =
 -- Only one meta-transaction can be stored per transaction for a given wallet.
 putMetas :: TxMetaHistory -> SqlPersistT IO ()
 putMetas (TxMetaHistory metas) =
-    repsertMany [(fromJust keyFromRecordM x, x) | x <- toList metas]
+    chunked repsertMany [(fromJust keyFromRecordM x, x) | x <- toList metas]
+    where
+        -- needed to submit large numberot transactions
+        chunked f xs = mapM_ f (chunksOf 1000 xs)

--- a/lib/core/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -164,7 +164,9 @@ instance Buildable DeltaTxHistory where
 
 instance Delta DeltaTxHistory where
     type Base DeltaTxHistory = TxHistory
-    apply (Append txs) h = h <> txs
+    -- transactions are immutable so here there should happen no rewriting
+    -- but we mimic the repsert in the store
+    apply (Append txs) h = txs <> h 
     apply (DeleteTx tid) (TxHistoryF txs) =
         TxHistoryF $ Map.delete tid txs
 

--- a/lib/core/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
@@ -49,6 +49,8 @@ import Data.Foldable
     ( fold, forM_, toList )
 import Data.List
     ( sortOn )
+import Data.List.Split
+    ( chunksOf )
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
@@ -100,6 +102,7 @@ write txs = do
     deleteWhere @_ @_ @TxWithdrawal mempty
     putTxHistory txs
 
+
 -- | Insert multiple transactions
 putTxHistory :: TxHistory -> SqlPersistT IO ()
 putTxHistory (TxHistoryF tx_map) = forM_ tx_map $ \TxRelationF {..} -> do
@@ -114,7 +117,9 @@ putTxHistory (TxHistoryF tx_map) = forM_ tx_map $ \TxRelationF {..} -> do
     where
         repsertMany' xs = let
             Just f = keyFromRecordM
-            in repsertMany [(f x, x) | x <- xs]
+            in chunked repsertMany [(f x, x) | x <- xs]
+        -- needed to submit large numberot transactions
+        chunked f xs = mapM_ f (chunksOf 1000 xs)
 
 -- | Select transactions history from the database
 selectTxHistory :: SqlPersistT IO TxHistory

--- a/lib/core/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -10,12 +13,27 @@ Pure model for the transactions ('Tx') and metadata about them ('TxMeta')
 in a collection of wallets.
 
 -}
-module Cardano.Wallet.DB.Store.Wallets.Model where
+module Cardano.Wallet.DB.Store.Wallets.Model
+    ( DeltaTxWalletsHistory (..)
+    , TxWalletsHistory
+    , walletsLinkedTransactions
+    , mkTransactionInfo
+    ) where
 
 import Prelude
 
+import Cardano.Wallet.DB.Sqlite.Schema
+    ( TxCollateral (..)
+    , TxCollateralOut (..)
+    , TxCollateralOutToken (..)
+    , TxIn (..)
+    , TxMeta (..)
+    , TxOut (..)
+    , TxOutToken (..)
+    , TxWithdrawal (..)
+    )
 import Cardano.Wallet.DB.Sqlite.Types
-    ( TxId )
+    ( TxId (getTxId) )
 import Cardano.Wallet.DB.Store.Meta.Model
     ( DeltaTxMetaHistory (..)
     , ManipulateTxMetaHistory
@@ -23,31 +41,53 @@ import Cardano.Wallet.DB.Store.Meta.Model
     , mkTxMetaHistory
     )
 import Cardano.Wallet.DB.Store.Transactions.Model
-    ( TxHistory, TxHistoryF (..), mkTxHistory )
+    ( Decoration (With)
+    , TxHistory
+    , TxHistory
+    , TxHistoryF (..)
+    , TxRelationF (..)
+    , WithTxOut (..)
+    , mkTxHistory
+    )
+import Cardano.Wallet.Primitive.Slotting
+    ( TimeInterpreter, interpretQuery, slotToUTCTime )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( AssetId (AssetId) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxMeta (..), TxOut (..) )
 import Data.Delta
     ( Delta (..) )
 import Data.DeltaMap
     ( DeltaMap (Adjust, Insert) )
+import Data.Foldable
+    ( toList )
 import Data.Function
     ( (&) )
+import Data.Functor
+    ( (<&>) )
+import Data.Generics.Internal.VL
+    ( (^.) )
 import Data.Map.Strict
     ( Map )
+import Data.Quantity
+    ( Quantity (..) )
 import Data.Set
     ( Set )
 import Fmt
     ( Buildable, build )
 
+import qualified Cardano.Wallet.DB.Sqlite.Schema as DB
 import qualified Cardano.Wallet.DB.Store.Meta.Model as TxMetaStore
 import qualified Cardano.Wallet.DB.Store.Transactions.Model as TxStore
 import qualified Cardano.Wallet.Primitive.Types as W
-import qualified Cardano.Wallet.Primitive.Types.Tx as W
-import Data.Foldable
-    ( toList )
+import qualified Cardano.Wallet.Primitive.Types.Coin as WC
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.Tx as WT
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
 data DeltaTxWalletsHistory
-    = ExpandTxWalletsHistory W.WalletId [(W.Tx, W.TxMeta)]
+    = ExpandTxWalletsHistory W.WalletId [(WT.Tx, WT.TxMeta)]
     | ChangeTxMetaWalletsHistory W.WalletId ManipulateTxMetaHistory
     | GarbageCollectTxWalletsHistory
     | RemoveWallet W.WalletId
@@ -90,3 +130,79 @@ linkedTransactions (TxMetaHistory m) = Map.keysSet m
 
 walletsLinkedTransactions :: Map W.WalletId TxMetaHistory -> Set TxId
 walletsLinkedTransactions = Set.unions . toList .  fmap linkedTransactions
+
+mkTransactionInfo :: Monad m
+    => TimeInterpreter m
+    -> W.BlockHeader
+    -> TxRelationF 'With
+    -> DB.TxMeta
+    -> m WT.TransactionInfo
+mkTransactionInfo ti tip TxRelationF{..} DB.TxMeta{..} = do
+    txTime <- interpretQuery ti . slotToUTCTime $ txMetaSlot
+    return
+        $ WT.TransactionInfo
+        { WT.txInfoId = getTxId txMetaTxId
+        , WT.txInfoFee = WC.Coin . fromIntegral <$> txMetaFee
+        , WT.txInfoInputs = mkTxIn <$> ins
+        , WT.txInfoCollateralInputs = mkTxCollateral <$> collateralIns
+        , WT.txInfoOutputs = mkTxOut <$> outs
+        , WT.txInfoCollateralOutput = mkTxCollateralOut <$> collateralOuts
+        , WT.txInfoWithdrawals = Map.fromList $ map mkTxWithdrawal withdrawals
+        , WT.txInfoMeta = WT.TxMeta
+              { WT.status = txMetaStatus
+              , WT.direction = txMetaDirection
+              , WT.slotNo = txMetaSlot
+              , WT.blockHeight = Quantity (txMetaBlockHeight)
+              , amount = txMetaAmount
+              , WT.expiry = txMetaSlotExpires
+              }
+        , WT.txInfoMetadata = txMetadata
+        , WT.txInfoDepth = Quantity
+              $ fromIntegral
+              $ if tipH > txMetaBlockHeight
+                  then tipH - txMetaBlockHeight
+                  else 0
+        , WT.txInfoTime = txTime
+        , WT.txInfoScriptValidity = txMetaScriptValidity <&> \case
+              False -> WT.TxScriptInvalid
+              True -> WT.TxScriptValid
+        }
+  where
+    tipH = getQuantity $ tip ^. #blockHeight
+    mkTxIn (WithTxOut tx out) =
+        ( WT.TxIn
+          { WT.inputId = getTxId (txInputSourceTxId tx)
+          , WT.inputIx = txInputSourceIndex tx
+          }
+        , txInputSourceAmount tx
+        , mkTxOut <$> out)
+    mkTxCollateral (WithTxOut tx out) =
+        ( WT.TxIn
+          { WT.inputId = getTxId (txCollateralSourceTxId tx)
+          , WT.inputIx = txCollateralSourceIndex tx
+          }
+        , txCollateralSourceAmount tx
+        , mkTxOut <$> out)
+    mkTxOut (out,tokens) =
+        WT.TxOut
+        { address = txOutputAddress out
+        , WT.tokens = TokenBundle.fromFlatList
+              (txOutputAmount out)
+              (mkTxOutToken <$> tokens)
+        }
+    mkTxOutToken token =
+        ( AssetId (txOutTokenPolicyId token) (txOutTokenName token)
+        , txOutTokenQuantity token)
+    mkTxCollateralOut (out,tokens) =
+        WT.TxOut
+        { address = txCollateralOutAddress out
+        , WT.tokens = TokenBundle.fromFlatList
+              (txCollateralOutAmount out)
+              (mkTxCollateralOutToken <$> tokens)
+        }
+    mkTxCollateralOutToken token =
+        ( AssetId
+              (txCollateralOutTokenPolicyId token)
+              (txCollateralOutTokenName token)
+        , txCollateralOutTokenQuantity token)
+    mkTxWithdrawal w = (txWithdrawalAccount w, txWithdrawalAmount w)


### PR DESCRIPTION
After creating a store for the wallets-transactions, the goal is to substitute all DB operations regarding transactions with verbs of the store. 


- [x] add a dbvar around a TxWalletsHistory 
- [x] switch all operations regarding transactions in the dblayer to use the new dbvar
- [x] make all DB units tests pass 
- [x] make state machine tests pass
- [x] move `mkTransactionInfo` from the dblayer to the model 




### Issue Number

ADP-1955
