### PR TITLE
Bump cardano-node to final 1.35.0 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See **Installation Instructions** for each available [release](https://github.co
 >
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
-> | `master` branch | [1.35.0-rc4](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.0-rc4) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
+> | `master` branch | [1.35.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.0) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-05-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-05-27) | [1.34.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.34.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-04-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-04-27) | [1.34.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.34.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-01-18](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-01-18) | [1.33.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.33.0) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)

--- a/cabal.project
+++ b/cabal.project
@@ -213,8 +213,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-node
-    tag: 43393ac88faa99986ecaa0be409e8b6353f5e9fe
-    --sha256: 0g2m1gj0jqsk8gwx19n1h6kh3xjywwvxzw5caqj4jwz5m2z1cmml
+    tag: 9f1d7dc163ee66410d912e48509d6a2300cfa68a
+    --sha256: 06arx9hv7dn3qxfy83f0b6018rxbsvh841nvfyg5w6qclm1hddj7
     subdir:
       cardano-api
       cardano-git-rev


### PR DESCRIPTION
- [x] Bump cardano-node from rc4 to 1.35.0

### Comments

`git diff 1.35.0 1.35.0-rc4 -- cabal.project` - no changes, only the cardano-node rev changed.

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->

ADP-1962
