### PR TITLE
Fix two byte underestimation in integration tests

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,7 +141,7 @@
         "ema": "ema_2",
         "flake-parts": "flake-parts",
         "haskell-flake": "haskell-flake",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "tailwind-haskell": "tailwind-haskell"
       },
       "locked": {
@@ -192,10 +192,7 @@
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs": [
-          "emanote",
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1655570068,
@@ -450,7 +447,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_6",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -595,6 +592,22 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1656461576,
+        "narHash": "sha256-rlmmw6lIlkMQIiB+NsnO8wQYWTfle8TA41UREPLP5VY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cf3ab54b4afe2b7477faa1dd0b65bf74c055d70c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1655567057,
         "narHash": "sha256-Cc5hQSMsTzOHmZnYm8OSJ5RNUp22bd5NADWLHorULWQ=",
         "owner": "NixOS",
@@ -607,7 +620,21 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1656401090,
+        "narHash": "sha256-bUS2nfQsvTQW2z8SK7oEFSElbmoBahOPtbXPm0AL3I4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "16de63fcc54e88b9a106a603038dd5dd2feb21eb",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
@@ -695,10 +722,7 @@
     "tailwind-haskell": {
       "inputs": {
         "flake-utils": "flake-utils_3",
-        "nixpkgs": [
-          "emanote",
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1654211622,

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2354,6 +2354,7 @@ buildAndSignTransaction
         )
     => ctx
     -> WalletId
+    -> Cardano.AnyCardanoEra
     -> ( (k 'RootK XPrv, Passphrase "encryption") ->
          (         XPrv, Passphrase "encryption")
        )
@@ -2362,8 +2363,7 @@ buildAndSignTransaction
     -> TransactionCtx
     -> SelectionOf TxOut
     -> ExceptT ErrSignPayment IO (Tx, TxMeta, UTCTime, SealedTx)
-buildAndSignTransaction ctx wid mkRwdAcct pwd txCtx sel = db & \DBLayer{..} -> do
-    era <- liftIO $ currentNodeEra nl
+buildAndSignTransaction ctx wid era mkRwdAcct pwd txCtx sel = db & \DBLayer{..} -> do
     withRootKey @_ @s ctx wid pwd ErrSignPaymentWithRootKey $ \xprv scheme -> do
         let pwdP = preparePassphrase scheme pwd
         mapExceptT atomically $ do
@@ -2396,11 +2396,11 @@ constructTransaction
         )
     => ctx
     -> WalletId
+    -> Cardano.AnyCardanoEra
     -> TransactionCtx
     -> SelectionOf TxOut
     -> ExceptT ErrConstructTx IO SealedTx
-constructTransaction ctx wid txCtx sel = db & \DBLayer{..} -> do
-    era <- liftIO $ currentNodeEra nl
+constructTransaction ctx wid era txCtx sel = db & \DBLayer{..} -> do
     (_, xpub, _) <- withExceptT ErrConstructTxReadRewardAccount $
         readRewardAccount @ctx @s @k @n ctx wid
     mapExceptT atomically $ do

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -919,23 +919,27 @@ getWalletUtxoSnapshot
 getWalletUtxoSnapshot ctx wid = do
     (wallet, _, pending) <- withExceptT id (readWallet @ctx @s @k ctx wid)
     pp <- liftIO $ currentProtocolParameters nl
+    era <- liftIO $ currentNodeEra nl
     let bundles = availableUTxO @s pending wallet
             & unUTxO
             & F.toList
             & fmap (view #tokens)
-    pure $ pairBundleWithMinAdaQuantity pp <$> bundles
+    pure $ pairBundleWithMinAdaQuantity era pp <$> bundles
   where
     nl = ctx ^. networkLayer
     tl = ctx ^. transactionLayer @k
 
     pairBundleWithMinAdaQuantity
-        :: ProtocolParameters -> TokenBundle -> (TokenBundle, Coin)
-    pairBundleWithMinAdaQuantity pp bundle =
+        :: Cardano.AnyCardanoEra
+        -> ProtocolParameters
+        -> TokenBundle
+        -> (TokenBundle, Coin)
+    pairBundleWithMinAdaQuantity era pp bundle =
         (bundle, computeMinAdaQuantity $ view #tokens bundle)
       where
         computeMinAdaQuantity :: TokenMap -> Coin
         computeMinAdaQuantity =
-            view #txOutputMinimumAdaQuantity (constraints tl pp)
+            view #txOutputMinimumAdaQuantity (constraints tl era pp)
 
 -- | List the wallet's UTxO statistics.
 listUtxoStatistics
@@ -1208,16 +1212,17 @@ readNextWithdrawal
         , HasNetworkLayer IO ctx
         )
     => ctx
+    -> Cardano.AnyCardanoEra
     -> Coin
     -> IO Coin
-readNextWithdrawal ctx (Coin withdrawal) = do
+readNextWithdrawal ctx era (Coin withdrawal) = do
     pp <- currentProtocolParameters nl
 
     let costWith =
-            calcMinimumCost tl pp (mkTxCtx $ Coin withdrawal) emptySkeleton
+            calcMinimumCost tl era pp (mkTxCtx $ Coin withdrawal) emptySkeleton
 
     let costWithout =
-            calcMinimumCost tl pp (mkTxCtx $ Coin 0) emptySkeleton
+            calcMinimumCost tl era pp (mkTxCtx $ Coin 0) emptySkeleton
 
     let costOfWithdrawal =
             Coin.toInteger costWith - Coin.toInteger costWithout
@@ -1598,6 +1603,8 @@ balanceTransactionWithSelectionStrategy
     guardZeroAdaOutputs (extractOutputsFromTx $ toSealed partialTx)
     guardConflictingWithdrawalNetworks partialTx
 
+    let era = Cardano.anyCardanoEra $ Cardano.cardanoEra @era
+
     (balance0, minfee0) <- balanceAfterSettingMinFee partialTx
 
     (extraInputs, extraCollateral, extraOutputs) <- do
@@ -1652,6 +1659,7 @@ balanceTransactionWithSelectionStrategy
             (BuildableInAnyEra Cardano.cardanoEra ptx)
 
         let mSel = selectAssets'
+                era
                 (extractOutputsFromTx $ toSealed partialTx)
                 (UTxOSelection.fromIndexPair
                     (internalUtxoAvailable, externalSelectedUtxo))
@@ -1872,7 +1880,8 @@ balanceTransactionWithSelectionStrategy
     -- transaction. For this, and other reasons, the selection may include too
     -- much ada.
     selectAssets'
-        :: [TxOut]
+        :: Cardano.AnyCardanoEra
+        -> [TxOut]
         -> UTxOSelection WalletUTxO
         -- ^ Describes which utxos are pre-selected, and which can be used as
         -- inputs or collateral.
@@ -1880,7 +1889,7 @@ balanceTransactionWithSelectionStrategy
         -> Cardano.Lovelace -- Current minfee (before selecting assets)
         -> StdGenSeed
         -> Either (SelectionError WalletSelectionContext) Selection
-    selectAssets' outs utxoSelection balance fee0 seed =
+    selectAssets' era outs utxoSelection balance fee0 seed =
         let
             txPlutusScriptExecutionCost = maxScriptExecutionCost tl pp redeemers
             colReq =
@@ -1910,6 +1919,7 @@ balanceTransactionWithSelectionStrategy
                         }
                 in calcMinimumCost
                         tl
+                        era
                         pp
                         defaultTransactionCtx
                         boringSkeleton
@@ -1942,11 +1952,11 @@ balanceTransactionWithSelectionStrategy
                 , certificateDepositAmount =
                     view #stakeKeyDeposit pp
                 , computeMinimumAdaQuantity =
-                    view #txOutputMinimumAdaQuantity $ constraints tl pp
+                    view #txOutputMinimumAdaQuantity $ constraints tl era pp
                 , computeMinimumCost = \skeleton -> mconcat
                     [ feePadding
                     , fromCardanoLovelace fee0
-                    , calcMinimumCost tl pp
+                    , calcMinimumCost tl era pp
                         (defaultTransactionCtx
                             { txPlutusScriptExecutionCost =
                                 txPlutusScriptExecutionCost })
@@ -2137,12 +2147,13 @@ calcMinimumCoinValues
         , Applicative f
         )
     => ctx
+    -> Cardano.AnyCardanoEra
     -> f TxOut
     -> IO (f Coin)
-calcMinimumCoinValues ctx outs = do
+calcMinimumCoinValues ctx era outs = do
     pp <- currentProtocolParameters nl
     pure
-        $ view #txOutputMinimumAdaQuantity (constraints tl pp)
+        $ view #txOutputMinimumAdaQuantity (constraints tl era pp)
         . view (#tokens . #tokens) <$> outs
   where
     nl = ctx ^. networkLayer
@@ -2189,11 +2200,12 @@ selectAssets
         , MonadRandom m
         )
     => ctx
+    -> Cardano.AnyCardanoEra
     -> ProtocolParameters
     -> SelectAssetsParams s result
     -> (s -> Selection -> result)
     -> ExceptT ErrSelectAssets m result
-selectAssets ctx pp params transform = do
+selectAssets ctx era pp params transform = do
     guardPendingWithdrawal
     lift $ traceWith tr $ MsgSelectionStart
         (UTxOSelection.availableSize
@@ -2207,12 +2219,12 @@ selectAssets ctx pp params transform = do
             , certificateDepositAmount =
                 view #stakeKeyDeposit pp
             , computeMinimumAdaQuantity =
-                view #txOutputMinimumAdaQuantity $ constraints tl pp
+                view #txOutputMinimumAdaQuantity $ constraints tl era pp
             , computeMinimumCost =
-                calcMinimumCost tl pp $ params ^. #txContext
+                calcMinimumCost tl era pp $ params ^. #txContext
             , computeSelectionLimit =
                 Cardano.Wallet.Transaction.computeSelectionLimit
-                    tl pp $ params ^. #txContext
+                    tl era pp $ params ^. #txContext
             , maximumCollateralInputCount =
                 intCast @Word16 @Int $ view #maximumCollateralInputCount pp
             , minimumCollateralPercentage =
@@ -2785,14 +2797,15 @@ createMigrationPlan
         , HasTransactionLayer k ctx
         )
     => ctx
+    -> Cardano.AnyCardanoEra
     -> WalletId
     -> Withdrawal
     -> ExceptT ErrCreateMigrationPlan IO MigrationPlan
-createMigrationPlan ctx wid rewardWithdrawal = do
+createMigrationPlan ctx era wid rewardWithdrawal = do
     (wallet, _, pending) <- withExceptT ErrCreateMigrationPlanNoSuchWallet $
         readWallet @ctx @s @k ctx wid
     pp <- liftIO $ currentProtocolParameters nl
-    let txConstraints = constraints tl pp
+    let txConstraints = constraints tl era pp
     let utxo = availableUTxO @s pending wallet
     pure
         $ Migration.createPlan txConstraints utxo

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2081,7 +2081,7 @@ postTransactionOld ctx genChange (ApiT wid) body = do
                 $ W.assignChangeAddressesAndUpdateDb wrk wid genChange sel
             (tx, txMeta, txTime, sealedTx) <- liftHandler
                 $ W.buildAndSignTransaction
-                    @_ @s @k wrk wid mkRwdAcct pwd txCtx sel'
+                    @_ @s @k wrk wid era mkRwdAcct pwd txCtx sel'
             liftHandler
                 $ W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
             pure (sel, tx, txMeta, txTime, pp)
@@ -2540,7 +2540,7 @@ constructTransaction ctx genChange knownPools getPoolStatus (ApiT wid) body = do
             pure (sel, sel', estMin)
 
         tx <- liftHandler
-            $ W.constructTransaction @_ @s @k @n wrk wid txCtx' sel
+            $ W.constructTransaction @_ @s @k @n wrk wid era txCtx' sel
 
         pure $ ApiConstructTransaction
             { transaction = ApiT tx
@@ -3007,7 +3007,8 @@ joinStakePool ctx knownPools getPoolStatus apiPoolId (ApiT wid) body = do
         sel' <- liftHandler
             $ W.assignChangeAddressesAndUpdateDb wrk wid genChange sel
         (tx, txMeta, txTime, sealedTx) <- liftHandler
-            $ W.buildAndSignTransaction @_ @s @k wrk wid mkRwdAcct pwd txCtx sel'
+            $ W.buildAndSignTransaction @_ @s @k
+                wrk wid era mkRwdAcct pwd txCtx sel'
         liftHandler
             $ W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
 
@@ -3127,7 +3128,8 @@ quitStakePool ctx (ApiT wid) body = do
         sel' <- liftHandler
             $ W.assignChangeAddressesAndUpdateDb wrk wid genChange sel
         (tx, txMeta, txTime, sealedTx) <- liftHandler
-            $ W.buildAndSignTransaction @_ @s @k wrk wid mkRwdAcct pwd txCtx sel'
+            $ W.buildAndSignTransaction @_ @s @k
+                wrk wid era mkRwdAcct pwd txCtx sel'
         liftHandler
             $ W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
 
@@ -3388,7 +3390,12 @@ migrateWallet ctx withdrawalType (ApiT wid) postData = do
                     , txDelegationAction = Nothing
                     }
             (tx, txMeta, txTime, sealedTx) <- liftHandler $
-                W.buildAndSignTransaction @_ @s @k wrk wid mkRewardAccount pwd
+                W.buildAndSignTransaction @_ @s @k
+                    wrk
+                    wid
+                    era
+                    mkRewardAccount
+                    pwd
                     txContext (selection {change = []})
             liftHandler $
                 W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -56,6 +56,7 @@ module Cardano.Wallet.Primitive.Types.Tx
 
     -- ** Unit testing helpers
     , mockSealedTx
+    , withinEra
 
     -- * Functions
     , fromTransactionInfo

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -210,7 +210,9 @@ data TransactionLayer k tx = TransactionLayer
         -- The function returns CBOR-ed transaction body to be signed in another step.
 
     , calcMinimumCost
-        :: ProtocolParameters
+        :: AnyCardanoEra
+            -- Era for which the transaction should be created.
+        -> ProtocolParameters
             -- Current protocol parameters
         -> TransactionCtx
             -- Additional information about the transaction
@@ -309,7 +311,8 @@ data TransactionLayer k tx = TransactionLayer
         -- return 'Right'.
 
     , computeSelectionLimit
-        :: ProtocolParameters
+        :: AnyCardanoEra
+        -> ProtocolParameters
         -> TransactionCtx
         -> [TxOut]
         -> SelectionLimit
@@ -319,7 +322,9 @@ data TransactionLayer k tx = TransactionLayer
         -- ^ A function to assess the size of a token bundle.
 
     , constraints
-        :: ProtocolParameters
+        :: AnyCardanoEra
+        -- Era for which the transaction should be created.
+        -> ProtocolParameters
         -- Current protocol parameters.
         -> TxConstraints
         -- The set of constraints that apply to all transactions.

--- a/lib/shelley/bench/restore-bench.hs
+++ b/lib/shelley/bench/restore-bench.hs
@@ -520,6 +520,7 @@ benchmarksRnd _ w wid wname benchname restoreTime = do
         (utxoAvailable, wallet, pendingTxs) <-
             unsafeRunExceptT $ W.readWalletUTxOIndex @_ @s @k w wid
         pp <- liftIO $ currentProtocolParameters (w ^. networkLayer)
+        era <- liftIO $ currentNodeEra (w ^. networkLayer)
         let selectAssetsParams = W.SelectAssetsParams
                 { outputs = [out]
                 , pendingTxs
@@ -531,7 +532,7 @@ benchmarksRnd _ w wid wname benchname restoreTime = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         let runSelection =
-                W.selectAssets @_ @_ @s @k w pp selectAssetsParams getFee
+                W.selectAssets @_ @_ @s @k w era pp selectAssetsParams getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection
 
     oneAddress <- genAddresses 1 cp
@@ -623,6 +624,7 @@ benchmarksSeq _ w wid _wname benchname restoreTime = do
         (utxoAvailable, wallet, pendingTxs) <-
             unsafeRunExceptT $ W.readWalletUTxOIndex w wid
         pp <- liftIO $ currentProtocolParameters (w ^. networkLayer)
+        era <- liftIO $ currentNodeEra (w ^. networkLayer)
         let selectAssetsParams = W.SelectAssetsParams
                 { outputs = [out]
                 , pendingTxs
@@ -634,7 +636,7 @@ benchmarksSeq _ w wid _wname benchname restoreTime = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         let runSelection =
-                W.selectAssets @_ @_ @s @k w pp selectAssetsParams getFee
+                W.selectAssets @_ @_ @s @k w era pp selectAssetsParams getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection
 
     let walletOverview = WalletOverview{utxo,addresses,transactions}

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -151,6 +151,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , txOutAddCoin
     , txOutCoin
     , txSizeDistance
+    , withinEra
     )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
@@ -2005,23 +2006,15 @@ estimateTxSize era skeleton =
         + sumVia sizeOf_NativeAsset (TokenBundle.getAssets tokens)
 
     sizeOf_Output
-        = case era of
-          (AnyCardanoEra ByronEra)   -> sizeOf_LegacyTransactionOutput
-          (AnyCardanoEra ShelleyEra) -> sizeOf_LegacyTransactionOutput
-          (AnyCardanoEra AllegraEra) -> sizeOf_LegacyTransactionOutput
-          (AnyCardanoEra MaryEra)    -> sizeOf_LegacyTransactionOutput
-          (AnyCardanoEra AlonzoEra)  -> sizeOf_LegacyTransactionOutput
-          (AnyCardanoEra BabbageEra) -> sizeOf_PostAlonzoTransactionOutput
+        = if withinEra (AnyCardanoEra AlonzoEra) era
+          then sizeOf_LegacyTransactionOutput
+          else sizeOf_PostAlonzoTransactionOutput
 
     sizeOf_ChangeOutput :: Set AssetId -> Integer
     sizeOf_ChangeOutput
-        = case era of
-          (AnyCardanoEra ByronEra)   -> sizeOf_LegacyChangeOutput
-          (AnyCardanoEra ShelleyEra) -> sizeOf_LegacyChangeOutput
-          (AnyCardanoEra AllegraEra) -> sizeOf_LegacyChangeOutput
-          (AnyCardanoEra MaryEra)    -> sizeOf_LegacyChangeOutput
-          (AnyCardanoEra AlonzoEra)  -> sizeOf_LegacyChangeOutput
-          (AnyCardanoEra BabbageEra) -> sizeOf_PostAlonzoChangeOutput
+        = if withinEra (AnyCardanoEra AlonzoEra) era
+          then sizeOf_LegacyChangeOutput
+          else sizeOf_PostAlonzoChangeOutput
 
     -- transaction_output =
     --   [address, amount : value]

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1797,12 +1797,9 @@ binaryCalculationsSpec' era = describe ("calculateBinary - "+||era||+"") $ do
 
 transactionConstraintsSpec :: Spec
 transactionConstraintsSpec = describe "Transaction constraints" $ do
-    spec_forAllEras "cost of empty transaction" $
-        prop_txConstraints_txBaseCost
-    spec_forAllEras "size of empty transaction" $
-        prop_txConstraints_txBaseSize
-    spec_forAllEras "cost of non-empty transaction" $
-        prop_txConstraints_txCost
+    spec_forAllEras "cost of empty transaction" prop_txConstraints_txBaseCost
+    spec_forAllEras "size of empty transaction" prop_txConstraints_txBaseSize
+    spec_forAllEras "cost of non-empty transaction" prop_txConstraints_txCost
     it "size of non-empty transaction" $
         property prop_txConstraints_txSize
     it "maximum size of output" $

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -192,6 +192,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , txMetadataIsNull
     , txOutCoin
     , txOutSubtractCoin
+    , withinEra
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTxIn, genTxOutTokenBundle )
@@ -433,8 +434,8 @@ import qualified Test.Hspec.Extra as Hspec
 spec :: Spec
 spec = do
     decodeSealedTxSpec
-    estimateMaxInputsSpec
-    feeCalculationSpec
+    forAllEras estimateMaxInputsSpec
+    forAllEras feeCalculationSpec
     feeEstimationRegressionSpec
     forAllEras binaryCalculationsSpec
     transactionConstraintsSpec
@@ -1046,17 +1047,30 @@ decodeSealedTxSpec = describe "SealedTx serialisation/deserialisation" $ do
 -- If these tests fail unexpectedly, it's a good idea to check whether or
 -- not the distribution of generated token bundles has changed.
 --
-estimateMaxInputsSpec :: Spec
-estimateMaxInputsSpec = do
-    estimateMaxInputsTests @ShelleyKey
-        [(1,115),(5,109),(10,104),(20,93),(50,54)]
-    estimateMaxInputsTests @ByronKey
-        [(1,73),(5,69),(10,65),(20,57),(50,29)]
-    estimateMaxInputsTests @IcarusKey
-        [(1,73),(5,69),(10,65),(20,57),(50,29)]
+estimateMaxInputsSpec :: AnyCardanoEra -> Spec
+estimateMaxInputsSpec era@(AnyCardanoEra cEra) =
+    if withinEra (AnyCardanoEra AlonzoEra) era
+    then do
+        describe ("Alonzo and earlier - " <> show cEra) $ do
+            estimateMaxInputsTests @ShelleyKey era
+                [(1,115),(5,109),(10,104),(20,93),(50,54)]
+            estimateMaxInputsTests @ByronKey era
+                [(1,73),(5,69),(10,65),(20,57),(50,29)]
+            estimateMaxInputsTests @IcarusKey era
+                [(1,73),(5,69),(10,65),(20,57),(50,29)]
+    -- Babbage era and later has slightly larger transactions, meaning slightly
+    -- smaller expected outputs.
+    else do
+        describe ("Babbage and later - " <> show cEra) $ do
+            estimateMaxInputsTests @ShelleyKey era
+                [(1,115),(5,109),(10,104),(20,92),(50,53)]
+            estimateMaxInputsTests @ByronKey era
+                [(1,73),(5,69),(10,65),(20,56),(50,28)]
+            estimateMaxInputsTests @IcarusKey era
+                [(1,73),(5,69),(10,65),(20,56),(50,28)]
 
-feeCalculationSpec :: Spec
-feeCalculationSpec = describe "fee calculations" $ do
+feeCalculationSpec :: AnyCardanoEra -> Spec
+feeCalculationSpec era = describe "fee calculations" $ do
     it "withdrawals incur fees" $ property $ \wdrl ->
         let
             costWith =
@@ -1374,14 +1388,14 @@ feeCalculationSpec = describe "fee calculations" $ do
             }
 
     minFee :: TransactionCtx -> Integer
-    minFee ctx = Coin.toInteger $ calcMinimumCost testTxLayer pp ctx sel
+    minFee ctx = Coin.toInteger $ calcMinimumCost testTxLayer era pp ctx sel
       where sel = emptySkeleton
 
     minFeeSkeleton :: TxSkeleton -> Integer
-    minFeeSkeleton = Coin.toInteger . estimateTxCost pp
+    minFeeSkeleton = Coin.toInteger . estimateTxCost era pp
 
     estimateTxSize' :: TxSkeleton -> Integer
-    estimateTxSize' = fromIntegral . unTxSize . estimateTxSize
+    estimateTxSize' = fromIntegral . unTxSize . estimateTxSize era
 
     (dummyAcct, dummyPath) =
         (RewardAccount mempty, DerivationIndex 0 :| [])
@@ -1783,12 +1797,12 @@ binaryCalculationsSpec' era = describe ("calculateBinary - "+||era||+"") $ do
 
 transactionConstraintsSpec :: Spec
 transactionConstraintsSpec = describe "Transaction constraints" $ do
-    it "cost of empty transaction" $
-        property prop_txConstraints_txBaseCost
-    it "size of empty transaction" $
-        property prop_txConstraints_txBaseSize
-    it "cost of non-empty transaction" $
-        property prop_txConstraints_txCost
+    spec_forAllEras "cost of empty transaction" $
+        prop_txConstraints_txBaseCost
+    spec_forAllEras "size of empty transaction" $
+        prop_txConstraints_txBaseSize
+    spec_forAllEras "cost of non-empty transaction" $
+        prop_txConstraints_txCost
     it "size of non-empty transaction" $
         property prop_txConstraints_txSize
     it "maximum size of output" $
@@ -1801,9 +1815,10 @@ newtype ExpectedNumInputs = ExpectedNumInputs Int deriving Num
 -- layer.
 estimateMaxInputsTests
     :: forall k. (TxWitnessTagFor k, Typeable k)
-    => [(GivenNumOutputs, ExpectedNumInputs)]
+    => AnyCardanoEra
+    -> [(GivenNumOutputs, ExpectedNumInputs)]
     -> SpecWith ()
-estimateMaxInputsTests cases = do
+estimateMaxInputsTests era cases = do
     let k = show $ typeRep (Proxy @k)
     describe ("estimateMaxNumberOfInputs for "<>k) $ do
         forM_ cases $ \(GivenNumOutputs nOuts, ExpectedNumInputs nInps) -> do
@@ -1816,11 +1831,11 @@ estimateMaxInputsTests cases = do
                 -- They also broke when bumping to lts-18.4.
                 let outs = [ generatePure r arbitrary | r <- [ 1 .. nOuts ] ]
                 length outs `shouldBe` nOuts
-                _estimateMaxNumberOfInputs @k (Quantity 16384) defaultTransactionCtx outs
+                _estimateMaxNumberOfInputs @k era (Quantity 16384) defaultTransactionCtx outs
                     `shouldBe` nInps
 
         prop "more outputs ==> less inputs"
-            (prop_moreOutputsMeansLessInputs @k)
+            (prop_moreOutputsMeansLessInputs @k era)
         prop "bigger size  ==> more inputs"
             (prop_biggerMaxSizeMeansMoreInputs @k)
 
@@ -1931,29 +1946,31 @@ compareOnCBOR b sealed = case cardanoTx sealed of
 -- | Increasing the number of outputs reduces the number of inputs.
 prop_moreOutputsMeansLessInputs
     :: forall k. TxWitnessTagFor k
-    => Quantity "byte" Word16
+    => AnyCardanoEra
+    -> Quantity "byte" Word16
     -> NonEmptyList TxOut
     -> Property
-prop_moreOutputsMeansLessInputs size (NonEmpty xs)
+prop_moreOutputsMeansLessInputs era size (NonEmpty xs)
     = withMaxSuccess 1000
     $ within 300000
-    $ _estimateMaxNumberOfInputs @k size defaultTransactionCtx (tail xs)
+    $ _estimateMaxNumberOfInputs @k era size defaultTransactionCtx (tail xs)
       >=
-      _estimateMaxNumberOfInputs @k size defaultTransactionCtx xs
+      _estimateMaxNumberOfInputs @k era size defaultTransactionCtx xs
 
 -- | Increasing the max size automatically increased the number of inputs
 prop_biggerMaxSizeMeansMoreInputs
     :: forall k. TxWitnessTagFor k
-    => Quantity "byte" Word16
+    => AnyCardanoEra
+    -> Quantity "byte" Word16
     -> [TxOut]
     -> Property
-prop_biggerMaxSizeMeansMoreInputs size outs
+prop_biggerMaxSizeMeansMoreInputs era size outs
     = withMaxSuccess 1000
     $ within 300000
     $ getQuantity size < maxBound `div` 2 ==>
-        _estimateMaxNumberOfInputs @k size defaultTransactionCtx outs
+        _estimateMaxNumberOfInputs @k era size defaultTransactionCtx outs
         <=
-        _estimateMaxNumberOfInputs @k ((*2) <$> size ) defaultTransactionCtx outs
+        _estimateMaxNumberOfInputs @k era ((*2) <$> size ) defaultTransactionCtx outs
 
 testTxLayer :: TransactionLayer ShelleyKey SealedTx
 testTxLayer = newTransactionLayer @ShelleyKey Cardano.Mainnet
@@ -2172,8 +2189,9 @@ mockProtocolParameters = dummyProtocolParameters
     , minimumCollateralPercentage = 150
     }
 
-mockTxConstraints :: TxConstraints
-mockTxConstraints = txConstraints mockProtocolParameters TxWitnessShelleyUTxO
+mockTxConstraints :: AnyCardanoEra -> TxConstraints
+mockTxConstraints era =
+    txConstraints era mockProtocolParameters TxWitnessShelleyUTxO
 
 data MockSelection = MockSelection
     { txInputCount :: Int
@@ -2222,26 +2240,26 @@ instance Arbitrary MockSelection where
 -- produces a result that is consistent with the result of using
 -- 'estimateTxCost'.
 --
-prop_txConstraints_txBaseCost :: Property
-prop_txConstraints_txBaseCost =
-    txBaseCost mockTxConstraints
-        === estimateTxCost mockProtocolParameters emptyTxSkeleton
+prop_txConstraints_txBaseCost :: AnyCardanoEra -> Property
+prop_txConstraints_txBaseCost era =
+    txBaseCost (mockTxConstraints era)
+        === estimateTxCost era mockProtocolParameters emptyTxSkeleton
 
 -- Tests that using 'txBaseSize' to estimate the size of an empty selection
 -- produces a result that is consistent with the result of using
 -- 'estimateTxSize'.
 --
-prop_txConstraints_txBaseSize :: Property
-prop_txConstraints_txBaseSize =
-    txBaseSize mockTxConstraints
-        === estimateTxSize emptyTxSkeleton
+prop_txConstraints_txBaseSize :: AnyCardanoEra -> Property
+prop_txConstraints_txBaseSize era =
+    txBaseSize (mockTxConstraints era)
+        === estimateTxSize era emptyTxSkeleton
 
 -- Tests that using 'txConstraints' to estimate the cost of a non-empty
 -- selection produces a result that is consistent with the result of using
 -- 'estimateTxCost'.
 --
-prop_txConstraints_txCost :: MockSelection -> Property
-prop_txConstraints_txCost mock =
+prop_txConstraints_txCost :: AnyCardanoEra -> MockSelection -> Property
+prop_txConstraints_txCost era mock =
     counterexample ("result: " <> show result) $
     counterexample ("lower bound: " <> show lowerBound) $
     counterexample ("upper bound: " <> show upperBound) $
@@ -2253,12 +2271,12 @@ prop_txConstraints_txCost mock =
     MockSelection {txInputCount, txOutputs, txRewardWithdrawal} = mock
     result :: Coin
     result = mconcat
-        [ txBaseCost mockTxConstraints
-        , txInputCount `mtimesDefault` txInputCost mockTxConstraints
-        , F.foldMap (txOutputCost mockTxConstraints . tokens) txOutputs
-        , txRewardWithdrawalCost mockTxConstraints txRewardWithdrawal
+        [ txBaseCost (mockTxConstraints era)
+        , txInputCount `mtimesDefault` txInputCost (mockTxConstraints era)
+        , F.foldMap (txOutputCost (mockTxConstraints era) . tokens) txOutputs
+        , txRewardWithdrawalCost (mockTxConstraints era) txRewardWithdrawal
         ]
-    lowerBound = estimateTxCost mockProtocolParameters emptyTxSkeleton
+    lowerBound = estimateTxCost era mockProtocolParameters emptyTxSkeleton
         {txInputCount, txOutputs, txRewardWithdrawal}
     -- We allow a small amount of overestimation due to the slight variation in
     -- the marginal cost of an input:
@@ -2268,8 +2286,8 @@ prop_txConstraints_txCost mock =
 -- selection produces a result that is consistent with the result of using
 -- 'estimateTxSize'.
 --
-prop_txConstraints_txSize :: MockSelection -> Property
-prop_txConstraints_txSize mock =
+prop_txConstraints_txSize :: AnyCardanoEra -> MockSelection -> Property
+prop_txConstraints_txSize era mock =
     counterexample ("result: " <> show result) $
     counterexample ("lower bound: " <> show lowerBound) $
     counterexample ("upper bound: " <> show upperBound) $
@@ -2281,12 +2299,12 @@ prop_txConstraints_txSize mock =
     MockSelection {txInputCount, txOutputs, txRewardWithdrawal} = mock
     result :: TxSize
     result = mconcat
-        [ txBaseSize mockTxConstraints
-        , txInputCount `mtimesDefault` txInputSize mockTxConstraints
-        , F.foldMap (txOutputSize mockTxConstraints . tokens) txOutputs
-        , txRewardWithdrawalSize mockTxConstraints txRewardWithdrawal
+        [ txBaseSize (mockTxConstraints era)
+        , txInputCount `mtimesDefault` txInputSize (mockTxConstraints era)
+        , F.foldMap (txOutputSize (mockTxConstraints era) . tokens) txOutputs
+        , txRewardWithdrawalSize (mockTxConstraints era) txRewardWithdrawal
         ]
-    lowerBound = estimateTxSize emptyTxSkeleton
+    lowerBound = estimateTxSize era emptyTxSkeleton
         {txInputCount, txOutputs, txRewardWithdrawal}
     -- We allow a small amount of overestimation due to the slight variation in
     -- the marginal size of an input:
@@ -2302,8 +2320,11 @@ instance Arbitrary (Large TokenBundle) where
 -- between 'txOutputSize' and 'txOutputMaximumSize' should also indicate that
 -- the bundle is oversized.
 --
-prop_txConstraints_txOutputMaximumSize :: Blind (Large TokenBundle) -> Property
-prop_txConstraints_txOutputMaximumSize (Blind (Large bundle)) =
+prop_txConstraints_txOutputMaximumSize
+    :: AnyCardanoEra
+    -> Blind (Large TokenBundle)
+    -> Property
+prop_txConstraints_txOutputMaximumSize era (Blind (Large bundle)) =
     checkCoverage $
     cover 10 (authenticComparison == LT)
         "authentic bundle size is smaller than maximum" $
@@ -2349,9 +2370,9 @@ prop_txConstraints_txOutputMaximumSize (Blind (Large bundle)) =
     authenticSizeMax = unTokenBundleMaxSize maryTokenBundleMaxSize
 
     simulatedSize :: TxSize
-    simulatedSize = txOutputSize mockTxConstraints bundle
+    simulatedSize = txOutputSize (mockTxConstraints era) bundle
     simulatedSizeMax :: TxSize
-    simulatedSizeMax = txOutputMaximumSize mockTxConstraints
+    simulatedSizeMax = txOutputMaximumSize (mockTxConstraints era)
 
 instance Arbitrary AssetId where
     arbitrary =


### PR DESCRIPTION
- [x] Fed era to `estimateTxSize`.
- [x] Attempted to fix underestimation.
    - Manually tested on #3318 

### Comments



### Issue Number

ADP-1964
