### PR TITLE
Correct ada-lovelace conversion in name of unit test

### DIFF
--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2316,7 +2316,7 @@ balanceTransactionSpec = do
                 sizeOfCoin (Coin $ 2 `power` 32    ) `shouldBe` TxSize 9
 
     describe "costOfIncreasingCoin" $ do
-        it "costs 176 lovelace to increase 4.294967295 ada (2^32 - 1 lovelace) \
+        it "costs 176 lovelace to increase 4294.967295 ada (2^32 - 1 lovelace) \
            \by 1 lovelace on mainnet" $ do
             let feePolicy = LinearFee $ LinearFunction
                     { intercept = 150_000, slope = 44 }


### PR DESCRIPTION
- [x] Update incorrect conversion of `2^32-1` lovelace to ada from `≈4.295 ada` to `≈4295 ada` in the name of a unit test

### Comments

- 2^32/1e6 = 4 294,967296
- I had been thinking about it wrong the whole time 😱 
- This means fee coin values on mainnet would basically always be encoded as 5 bytes (`distributeSurplus` should still be useful, even on mainnet, because of change-output values though)

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

None.

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
