### PR TITLE
Use Cardano API function `calculateMinimumUTxO` for minimum UTxO calculations.

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -52,11 +52,14 @@ library
     , cardano-crypto-class
     , cardano-crypto-test
     , cardano-numeric
-    , cardano-ledger-core
-    , cardano-ledger-byron-test
-    , cardano-ledger-shelley-test
-    , cardano-ledger-shelley
     , cardano-ledger-alonzo
+    , cardano-ledger-alonzo-test
+    , cardano-ledger-babbage
+    , cardano-ledger-byron-test
+    , cardano-ledger-core
+    , cardano-ledger-shelley
+    , cardano-ledger-shelley-ma
+    , cardano-ledger-shelley-test
     , cardano-slotting
     , cborg
     , containers
@@ -251,6 +254,8 @@ library
       Cardano.Wallet.Primitive.Types.Address
       Cardano.Wallet.Primitive.Types.Coin
       Cardano.Wallet.Primitive.Types.Hash
+      Cardano.Wallet.Primitive.Types.MinimumUTxO
+      Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
       Cardano.Wallet.Primitive.Types.Redeemer
       Cardano.Wallet.Primitive.Types.RewardAccount
       Cardano.Wallet.Primitive.Types.TokenBundle

--- a/lib/core/src/Cardano/Api/Gen.hs
+++ b/lib/core/src/Cardano/Api/Gen.hs
@@ -9,7 +9,8 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Api.Gen
-    ( genAddressByron
+    ( genAddressAny
+    , genAddressByron
     , genAddressInEra
     , genAddressShelley
     , genAlphaNum
@@ -859,6 +860,14 @@ genPaymentCredential =
 
         byScript :: Gen PaymentCredential
         byScript = PaymentCredentialByScript <$> genScriptHash
+
+genAddressAny :: Gen AddressAny
+genAddressAny = oneof
+    [ AddressByron
+        <$> genAddressByron
+    , AddressShelley
+        <$> genAddressShelley
+    ]
 
 genAddressByron :: Gen (Address ByronAddr)
 genAddressByron = makeByronAddress <$> genNetworkId

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -308,7 +308,6 @@ import Cardano.Wallet.Primitive.Types
     , EpochNo (..)
     , ExecutionUnitPrices (..)
     , GenesisParameters (..)
-    , MinimumUTxOValue (..)
     , NetworkParameters (..)
     , NonWalletCertificate (..)
     , PoolId (..)
@@ -1129,11 +1128,8 @@ toApiNetworkParameters (NetworkParameters gp sp pp) txConstraints toEpochInfo = 
             $ getDecentralizationLevel
             $ view #decentralizationLevel pp
         , desiredPoolNumber = view #desiredNumberOfStakePools pp
-        , minimumUtxoValue = toApiCoin $ case (view #minimumUTxOvalue pp) of
-            MinimumUTxOValue c ->
-                c
-            MinimumUTxOValueCostPerWord _perWord ->
-                txOutputMinimumAdaQuantity txConstraints TokenMap.empty
+        , minimumUtxoValue = toApiCoin $
+            txOutputMinimumAdaQuantity txConstraints TokenMap.empty
         , eras = apiEras
         , maximumCollateralInputCount =
             view #maximumCollateralInputCount pp

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1162,13 +1162,18 @@ instance NFData ProtocolParameters where
 
 instance Buildable ProtocolParameters where
     build pp = blockListF' "" id
-        [ "Decentralization level: " <> build (pp ^. #decentralizationLevel)
-        , "Transaction parameters: " <> build (pp ^. #txParameters)
-        , "Desired number of pools: " <> build (pp ^. #desiredNumberOfStakePools)
-        , "Minimum UTxO value: " <> build (pp ^. #minimumUTxOvalue)
-        , "Eras:\n" <> indentF 2 (build (pp ^. #eras))
-        , "Execution unit prices: " <>
-            maybe "not specified" build (pp ^. #executionUnitPrices)
+        [ "Decentralization level: "
+            <> build (pp ^. #decentralizationLevel)
+        , "Transaction parameters: "
+            <> build (pp ^. #txParameters)
+        , "Desired number of pools: "
+            <> build (pp ^. #desiredNumberOfStakePools)
+        , "Minimum UTxO value: "
+            <> build (pp ^. #minimumUTxOvalue)
+        , "Eras:\n"
+            <> indentF 2 (build (pp ^. #eras))
+        , "Execution unit prices: "
+            <> maybe "not specified" build (pp ^. #executionUnitPrices)
         ]
 
 data ExecutionUnits = ExecutionUnits

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -181,6 +181,8 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..), hashFromText )
+import Cardano.Wallet.Primitive.Types.MinimumUTxO
+    ( MinimumUTxO )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -1111,6 +1113,9 @@ data ProtocolParameters = ProtocolParameters
         :: Word16
         -- ^ The current desired number of stakepools in the network.
         -- Also known as k parameter.
+    , minimumUTxO
+        :: MinimumUTxO
+        -- ^ Represents a way of calculating minimum UTxO values.
     , minimumUTxOvalue
         :: MinimumUTxOValue
         -- ^ The minimum UTxO value.
@@ -1151,6 +1156,7 @@ instance NFData ProtocolParameters where
         [ rnf decentralizationLevel
         , rnf txParameters
         , rnf desiredNumberOfStakePools
+        , rnf minimumUTxO
         , rnf minimumUTxOvalue
         , rnf stakeKeyDeposit
         , rnf eras
@@ -1168,6 +1174,8 @@ instance Buildable ProtocolParameters where
             <> build (pp ^. #txParameters)
         , "Desired number of pools: "
             <> build (pp ^. #desiredNumberOfStakePools)
+        , "Minimum UTxO: "
+            <> build (pp ^. #minimumUTxO)
         , "Minimum UTxO value: "
             <> build (pp ^. #minimumUTxOvalue)
         , "Eras:\n"

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -72,7 +72,6 @@ module Cardano.Wallet.Primitive.Types
     , GenesisParameters (..)
     , SlottingParameters (..)
     , ProtocolParameters (..)
-    , MinimumUTxOValue (..)
     , TxParameters (..)
     , TokenBundleMaxSize (..)
     , EraInfo (..)
@@ -1082,23 +1081,6 @@ instance Buildable (EraInfo EpochNo) where
       where
         boundF (Just e) = " from " <> build e
         boundF Nothing = " <not started>"
-
-data MinimumUTxOValue
-    -- | In Shelley, tx outputs could only be created if they were larger than
-    -- this `MinimumUTxOValue`.
-    = MinimumUTxOValue Coin
-
-    -- | With Alonzo, `MinimumUTxOValue` is replaced by an ada-cost per word of
-    -- the output. Note that the alonzo ledger assumes fixed sizes for address
-    -- and coin, so the size is not the serialized size exactly.
-    | MinimumUTxOValueCostPerWord Coin
-    deriving (Eq, Generic, Show)
-
-instance NFData MinimumUTxOValue
-
-instance Buildable MinimumUTxOValue where
-    build (MinimumUTxOValue c) = "constant " <> build c
-    build (MinimumUTxOValueCostPerWord c) = build c <> " per word"
 
 -- | Protocol parameters that can be changed through the update system.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1116,9 +1116,6 @@ data ProtocolParameters = ProtocolParameters
     , minimumUTxO
         :: MinimumUTxO
         -- ^ Represents a way of calculating minimum UTxO values.
-    , minimumUTxOvalue
-        :: MinimumUTxOValue
-        -- ^ The minimum UTxO value.
     , stakeKeyDeposit
         :: Coin
         -- ^ Registering a stake key requires storage on the node and as such
@@ -1157,7 +1154,6 @@ instance NFData ProtocolParameters where
         , rnf txParameters
         , rnf desiredNumberOfStakePools
         , rnf minimumUTxO
-        , rnf minimumUTxOvalue
         , rnf stakeKeyDeposit
         , rnf eras
         , rnf maximumCollateralInputCount
@@ -1176,8 +1172,6 @@ instance Buildable ProtocolParameters where
             <> build (pp ^. #desiredNumberOfStakePools)
         , "Minimum UTxO: "
             <> build (pp ^. #minimumUTxO)
-        , "Minimum UTxO value: "
-            <> build (pp ^. #minimumUTxOvalue)
         , "Eras:\n"
             <> indentF 2 (build (pp ^. #eras))
         , "Execution unit prices: "

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/MinimumUTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/MinimumUTxO.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
+-- |
+-- Copyright: © 2022 IOHK
+-- License: Apache-2.0
+--
+-- Defines the 'MinimumUTxO' type and related functions.
+--
+module Cardano.Wallet.Primitive.Types.MinimumUTxO
+    ( MinimumUTxO (..)
+    , minimumUTxONone
+    , minimumUTxOConstant
+    , minimumUTxOForShelleyBasedEra
+    , ProtocolParametersForShelleyBasedEra (..)
+    )
+    where
+
+import Prelude
+
+import Cardano.Api.Shelley
+    ( ShelleyBasedEra, ShelleyLedgerEra, fromLedgerPParams )
+import Cardano.Ledger.Core
+    ( PParams )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin )
+import Control.DeepSeq
+    ( NFData (..) )
+import Data.Function
+    ( on )
+import Fmt
+    ( Buildable (..), blockListF )
+
+--------------------------------------------------------------------------------
+-- The 'MinimumUTxO' type
+--------------------------------------------------------------------------------
+
+data MinimumUTxO where
+    MinimumUTxONone
+        :: MinimumUTxO
+    MinimumUTxOConstant
+        :: Coin
+        -> MinimumUTxO
+    MinimumUTxOForShelleyBasedEra
+        :: ProtocolParametersForShelleyBasedEra
+        -> MinimumUTxO
+
+instance Buildable MinimumUTxO where
+    build = \case
+        MinimumUTxONone ->
+            "MinimumUTxONone"
+        MinimumUTxOConstant c -> blockListF
+            [ "MinimumUTxOConstant"
+            , build c
+            ]
+        MinimumUTxOForShelleyBasedEra pp -> blockListF
+            [ "MinimumUTxOForShelleyBasedEra"
+            , build pp
+            ]
+
+instance Eq MinimumUTxO where
+    (==) = (==) `on` show
+
+instance NFData MinimumUTxO where
+    rnf = \case
+        MinimumUTxONone ->
+            rnf ()
+        MinimumUTxOConstant c ->
+            rnf c
+        MinimumUTxOForShelleyBasedEra pp ->
+            rnf pp
+
+instance Show MinimumUTxO where
+    show = \case
+        MinimumUTxONone ->
+            "MinimumUTxONone"
+        MinimumUTxOConstant c -> unwords
+            [ "MinimumUTxOConstant"
+            , show c
+            ]
+        MinimumUTxOForShelleyBasedEra pp -> unwords
+            [ "MinimumUTxOForShelleyBasedEra"
+            , show pp
+            ]
+
+minimumUTxONone :: MinimumUTxO
+minimumUTxONone = MinimumUTxONone
+
+minimumUTxOConstant :: Coin -> MinimumUTxO
+minimumUTxOConstant = MinimumUTxOConstant
+
+minimumUTxOForShelleyBasedEra
+    :: ShelleyBasedEra era
+    -> PParams (ShelleyLedgerEra era)
+    -> MinimumUTxO
+minimumUTxOForShelleyBasedEra era pp =
+    MinimumUTxOForShelleyBasedEra $
+    ProtocolParametersForShelleyBasedEra era pp
+
+--------------------------------------------------------------------------------
+-- The 'ProtocolParametersForShelleyBasedEra' type
+--------------------------------------------------------------------------------
+
+data ProtocolParametersForShelleyBasedEra where
+    ProtocolParametersForShelleyBasedEra
+        :: ShelleyBasedEra era
+        -> PParams (ShelleyLedgerEra era)
+        -> ProtocolParametersForShelleyBasedEra
+
+instance Buildable ProtocolParametersForShelleyBasedEra where
+    build (ProtocolParametersForShelleyBasedEra era _) = blockListF
+        [ "ProtocolParametersForShelleyBasedEra"
+        , show era
+        ]
+
+instance Eq ProtocolParametersForShelleyBasedEra where
+    (==) = (==) `on` show
+
+instance NFData ProtocolParametersForShelleyBasedEra where
+    rnf (ProtocolParametersForShelleyBasedEra !_ !_) = rnf ()
+
+instance Show ProtocolParametersForShelleyBasedEra where
+    show (ProtocolParametersForShelleyBasedEra era pp) = unwords
+        [ show era
+        , show (fromLedgerPParams era pp)
+        ]

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/MinimumUTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/MinimumUTxO.hs
@@ -13,7 +13,7 @@ module Cardano.Wallet.Primitive.Types.MinimumUTxO
     , minimumUTxONone
     , minimumUTxOConstant
     , minimumUTxOForShelleyBasedEra
-    , ProtocolParametersForShelleyBasedEra (..)
+    , MinimumUTxOForShelleyBasedEra (..)
     )
     where
 
@@ -42,8 +42,8 @@ data MinimumUTxO where
     MinimumUTxOConstant
         :: Coin
         -> MinimumUTxO
-    MinimumUTxOForShelleyBasedEra
-        :: ProtocolParametersForShelleyBasedEra
+    MinimumUTxOForShelleyBasedEraOf
+        :: MinimumUTxOForShelleyBasedEra
         -> MinimumUTxO
 
 instance Buildable MinimumUTxO where
@@ -54,9 +54,9 @@ instance Buildable MinimumUTxO where
             [ "MinimumUTxOConstant"
             , build c
             ]
-        MinimumUTxOForShelleyBasedEra pp -> blockListF
+        MinimumUTxOForShelleyBasedEraOf m -> blockListF
             [ "MinimumUTxOForShelleyBasedEra"
-            , build pp
+            , build m
             ]
 
 instance Eq MinimumUTxO where
@@ -68,7 +68,7 @@ instance NFData MinimumUTxO where
             rnf ()
         MinimumUTxOConstant c ->
             rnf c
-        MinimumUTxOForShelleyBasedEra pp ->
+        MinimumUTxOForShelleyBasedEraOf pp ->
             rnf pp
 
 instance Show MinimumUTxO where
@@ -79,7 +79,7 @@ instance Show MinimumUTxO where
             [ "MinimumUTxOConstant"
             , show c
             ]
-        MinimumUTxOForShelleyBasedEra pp -> unwords
+        MinimumUTxOForShelleyBasedEraOf pp -> unwords
             [ "MinimumUTxOForShelleyBasedEra"
             , show pp
             ]
@@ -95,33 +95,33 @@ minimumUTxOForShelleyBasedEra
     -> PParams (ShelleyLedgerEra era)
     -> MinimumUTxO
 minimumUTxOForShelleyBasedEra era pp =
-    MinimumUTxOForShelleyBasedEra $
-    ProtocolParametersForShelleyBasedEra era pp
+    MinimumUTxOForShelleyBasedEraOf $
+    MinimumUTxOForShelleyBasedEra era pp
 
 --------------------------------------------------------------------------------
--- The 'ProtocolParametersForShelleyBasedEra' type
+-- The 'MinimumUTxOForShelleyBasedEra' type
 --------------------------------------------------------------------------------
 
-data ProtocolParametersForShelleyBasedEra where
-    ProtocolParametersForShelleyBasedEra
+data MinimumUTxOForShelleyBasedEra where
+    MinimumUTxOForShelleyBasedEra
         :: ShelleyBasedEra era
         -> PParams (ShelleyLedgerEra era)
-        -> ProtocolParametersForShelleyBasedEra
+        -> MinimumUTxOForShelleyBasedEra
 
-instance Buildable ProtocolParametersForShelleyBasedEra where
-    build (ProtocolParametersForShelleyBasedEra era _) = blockListF
-        [ "ProtocolParametersForShelleyBasedEra"
+instance Buildable MinimumUTxOForShelleyBasedEra where
+    build (MinimumUTxOForShelleyBasedEra era _) = blockListF
+        [ "MinimumUTxOForShelleyBasedEra"
         , show era
         ]
 
-instance Eq ProtocolParametersForShelleyBasedEra where
+instance Eq MinimumUTxOForShelleyBasedEra where
     (==) = (==) `on` show
 
-instance NFData ProtocolParametersForShelleyBasedEra where
-    rnf (ProtocolParametersForShelleyBasedEra !_ !_) = rnf ()
+instance NFData MinimumUTxOForShelleyBasedEra where
+    rnf (MinimumUTxOForShelleyBasedEra !_ !_) = rnf ()
 
-instance Show ProtocolParametersForShelleyBasedEra where
-    show (ProtocolParametersForShelleyBasedEra era pp) = unwords
+instance Show MinimumUTxOForShelleyBasedEra where
+    show (MinimumUTxOForShelleyBasedEra era pp) = unwords
         [ show era
         , show (fromLedgerPParams era pp)
         ]

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/MinimumUTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/MinimumUTxO.hs
@@ -9,11 +9,15 @@
 -- Defines the 'MinimumUTxO' type and related functions.
 --
 module Cardano.Wallet.Primitive.Types.MinimumUTxO
-    ( MinimumUTxO (..)
+    (
+    -- * Types
+      MinimumUTxO (..)
+    , MinimumUTxOForShelleyBasedEra (..)
+
+    -- * Constructor functions
     , minimumUTxONone
     , minimumUTxOConstant
     , minimumUTxOForShelleyBasedEra
-    , MinimumUTxOForShelleyBasedEra (..)
     )
     where
 
@@ -36,15 +40,20 @@ import Fmt
 -- The 'MinimumUTxO' type
 --------------------------------------------------------------------------------
 
+-- | Represents a function for computing minimum UTxO values.
+--
 data MinimumUTxO where
     MinimumUTxONone
         :: MinimumUTxO
+        -- ^ Indicates that there is no minimum UTxO value.
     MinimumUTxOConstant
         :: Coin
         -> MinimumUTxO
+        -- ^ Indicates a constant minimum UTxO value.
     MinimumUTxOForShelleyBasedEraOf
         :: MinimumUTxOForShelleyBasedEra
         -> MinimumUTxO
+        -- ^ Indicates a Shelley-based era-specific minimum UTxO function.
 
 instance Buildable MinimumUTxO where
     build = \case
@@ -84,24 +93,12 @@ instance Show MinimumUTxO where
             , show pp
             ]
 
-minimumUTxONone :: MinimumUTxO
-minimumUTxONone = MinimumUTxONone
-
-minimumUTxOConstant :: Coin -> MinimumUTxO
-minimumUTxOConstant = MinimumUTxOConstant
-
-minimumUTxOForShelleyBasedEra
-    :: ShelleyBasedEra era
-    -> PParams (ShelleyLedgerEra era)
-    -> MinimumUTxO
-minimumUTxOForShelleyBasedEra era pp =
-    MinimumUTxOForShelleyBasedEraOf $
-    MinimumUTxOForShelleyBasedEra era pp
-
 --------------------------------------------------------------------------------
 -- The 'MinimumUTxOForShelleyBasedEra' type
 --------------------------------------------------------------------------------
 
+-- | Represents a minimum UTxO function that is specific to a Shelley-based era.
+--
 data MinimumUTxOForShelleyBasedEra where
     MinimumUTxOForShelleyBasedEra
         :: ShelleyBasedEra era
@@ -125,3 +122,21 @@ instance Show MinimumUTxOForShelleyBasedEra where
         [ show era
         , show (fromLedgerPParams era pp)
         ]
+
+--------------------------------------------------------------------------------
+-- Constructor functions
+--------------------------------------------------------------------------------
+
+minimumUTxONone :: MinimumUTxO
+minimumUTxONone = MinimumUTxONone
+
+minimumUTxOConstant :: Coin -> MinimumUTxO
+minimumUTxOConstant = MinimumUTxOConstant
+
+minimumUTxOForShelleyBasedEra
+    :: ShelleyBasedEra era
+    -> PParams (ShelleyLedgerEra era)
+    -> MinimumUTxO
+minimumUTxOForShelleyBasedEra era pp =
+    MinimumUTxOForShelleyBasedEraOf $
+    MinimumUTxOForShelleyBasedEra era pp

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/MinimumUTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/MinimumUTxO.hs
@@ -49,7 +49,9 @@ data MinimumUTxO where
     MinimumUTxOConstant
         :: Coin
         -> MinimumUTxO
-        -- ^ Indicates a constant minimum UTxO value.
+        -- ^ Indicates a constant minimum UTxO value. This constructor is
+        -- useful for writing tests, where we often want to have precise
+        -- control over the value that is chosen.
     MinimumUTxOForShelleyBasedEraOf
         :: MinimumUTxOForShelleyBasedEra
         -> MinimumUTxO

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/MinimumUTxO/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/MinimumUTxO/Gen.hs
@@ -9,9 +9,9 @@
 --
 module Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
     ( genMinimumUTxO
-    , genProtocolParametersForShelleyBasedEra
+    , genMinimumUTxOForShelleyBasedEra
     , shrinkMinimumUTxO
-    , shrinkProtocolParametersForShelleyBasedEra
+    , shrinkMinimumUTxOForShelleyBasedEra
     )
     where
 
@@ -22,7 +22,7 @@ import Cardano.Api
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO
-    ( MinimumUTxO (..), ProtocolParametersForShelleyBasedEra (..) )
+    ( MinimumUTxO (..), MinimumUTxOForShelleyBasedEra (..) )
 import Data.Bits
     ( Bits )
 import Data.Default
@@ -49,7 +49,7 @@ genMinimumUTxO :: Gen MinimumUTxO
 genMinimumUTxO = frequency
     [ (1, genMinimumUTxONone)
     , (1, genMinimumUTxOConstant)
-    , (8, genMinimumUTxOForShelleyBasedEra)
+    , (8, MinimumUTxOForShelleyBasedEraOf <$> genMinimumUTxOForShelleyBasedEra)
     ]
   where
     genMinimumUTxONone :: Gen MinimumUTxO
@@ -59,20 +59,16 @@ genMinimumUTxO = frequency
     genMinimumUTxOConstant = MinimumUTxOConstant . Coin
         <$> genInterestingCoinValue
 
-    genMinimumUTxOForShelleyBasedEra :: Gen MinimumUTxO
-    genMinimumUTxOForShelleyBasedEra = MinimumUTxOForShelleyBasedEra
-        <$> genProtocolParametersForShelleyBasedEra
-
 shrinkMinimumUTxO :: MinimumUTxO -> [MinimumUTxO]
 shrinkMinimumUTxO = const []
 
 --------------------------------------------------------------------------------
--- Generating 'ProtocolParametersForShelleyBasedEra' values
+-- Generating 'MinimumUTxOForShelleyBasedEra' values
 --------------------------------------------------------------------------------
 
-genProtocolParametersForShelleyBasedEra
-    :: Gen ProtocolParametersForShelleyBasedEra
-genProtocolParametersForShelleyBasedEra = oneof
+genMinimumUTxOForShelleyBasedEra
+    :: Gen MinimumUTxOForShelleyBasedEra
+genMinimumUTxOForShelleyBasedEra = oneof
     [ genShelley
     , genAllegra
     , genMary
@@ -80,40 +76,39 @@ genProtocolParametersForShelleyBasedEra = oneof
     , genBabbage
     ]
   where
-    genShelley :: Gen ProtocolParametersForShelleyBasedEra
+    genShelley :: Gen MinimumUTxOForShelleyBasedEra
     genShelley = do
         minUTxOValue <- genInterestingLedgerCoin
-        pure $ ProtocolParametersForShelleyBasedEra ShelleyBasedEraShelley
+        pure $ MinimumUTxOForShelleyBasedEra ShelleyBasedEraShelley
             def {Shelley._minUTxOValue = minUTxOValue}
 
-    genAllegra :: Gen ProtocolParametersForShelleyBasedEra
+    genAllegra :: Gen MinimumUTxOForShelleyBasedEra
     genAllegra = do
         minUTxOValue <- genInterestingLedgerCoin
-        pure $ ProtocolParametersForShelleyBasedEra ShelleyBasedEraAllegra
+        pure $ MinimumUTxOForShelleyBasedEra ShelleyBasedEraAllegra
             def {Shelley._minUTxOValue = minUTxOValue}
 
-    genMary :: Gen ProtocolParametersForShelleyBasedEra
+    genMary :: Gen MinimumUTxOForShelleyBasedEra
     genMary = do
         minUTxOValue <- genInterestingLedgerCoin
-        pure $ ProtocolParametersForShelleyBasedEra ShelleyBasedEraMary
+        pure $ MinimumUTxOForShelleyBasedEra ShelleyBasedEraMary
             def {Shelley._minUTxOValue = minUTxOValue}
 
-    genAlonzo :: Gen ProtocolParametersForShelleyBasedEra
+    genAlonzo :: Gen MinimumUTxOForShelleyBasedEra
     genAlonzo = do
         coinsPerUTxOWord <- genInterestingLedgerCoin
-        pure $ ProtocolParametersForShelleyBasedEra ShelleyBasedEraAlonzo
+        pure $ MinimumUTxOForShelleyBasedEra ShelleyBasedEraAlonzo
             def {Alonzo._coinsPerUTxOWord = coinsPerUTxOWord}
 
-    genBabbage :: Gen ProtocolParametersForShelleyBasedEra
+    genBabbage :: Gen MinimumUTxOForShelleyBasedEra
     genBabbage = do
         coinsPerUTxOByte <- genInterestingLedgerCoin
-        pure $ ProtocolParametersForShelleyBasedEra ShelleyBasedEraBabbage
+        pure $ MinimumUTxOForShelleyBasedEra ShelleyBasedEraBabbage
             def {Babbage._coinsPerUTxOByte = coinsPerUTxOByte}
 
-shrinkProtocolParametersForShelleyBasedEra
-    :: ProtocolParametersForShelleyBasedEra
-    -> [ProtocolParametersForShelleyBasedEra]
-shrinkProtocolParametersForShelleyBasedEra = const []
+shrinkMinimumUTxOForShelleyBasedEra
+    :: MinimumUTxOForShelleyBasedEra -> [MinimumUTxOForShelleyBasedEra]
+shrinkMinimumUTxOForShelleyBasedEra = const []
 
 --------------------------------------------------------------------------------
 -- Internal functions

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/MinimumUTxO/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/MinimumUTxO/Gen.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2022 IOHK
+-- License: Apache-2.0
+--
+-- Defines generators and shrinkers for the 'MinimumUTxO' data type.
+--
+module Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
+    ( genMinimumUTxO
+    , genProtocolParametersForShelleyBasedEra
+    , shrinkMinimumUTxO
+    , shrinkProtocolParametersForShelleyBasedEra
+    )
+    where
+
+import Prelude
+
+import Cardano.Api
+    ( ShelleyBasedEra (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.MinimumUTxO
+    ( MinimumUTxO (..), ProtocolParametersForShelleyBasedEra (..) )
+import Data.Bits
+    ( Bits )
+import Data.Default
+    ( Default (..) )
+import Data.IntCast
+    ( intCast, intCastMaybe )
+import Data.Maybe
+    ( fromMaybe )
+import Numeric.Natural
+    ( Natural )
+import Test.QuickCheck
+    ( Gen, choose, frequency, oneof )
+
+import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
+import qualified Cardano.Ledger.Babbage.PParams as Babbage
+import qualified Cardano.Ledger.Coin as Ledger
+import qualified Cardano.Ledger.Shelley.PParams as Shelley
+
+--------------------------------------------------------------------------------
+-- Generating 'MinimumUTxO' values
+--------------------------------------------------------------------------------
+
+genMinimumUTxO :: Gen MinimumUTxO
+genMinimumUTxO = frequency
+    [ (1, genMinimumUTxONone)
+    , (1, genMinimumUTxOConstant)
+    , (8, genMinimumUTxOForShelleyBasedEra)
+    ]
+  where
+    genMinimumUTxONone :: Gen MinimumUTxO
+    genMinimumUTxONone = pure MinimumUTxONone
+
+    genMinimumUTxOConstant :: Gen MinimumUTxO
+    genMinimumUTxOConstant = MinimumUTxOConstant . Coin
+        <$> genInterestingCoinValue
+
+    genMinimumUTxOForShelleyBasedEra :: Gen MinimumUTxO
+    genMinimumUTxOForShelleyBasedEra = MinimumUTxOForShelleyBasedEra
+        <$> genProtocolParametersForShelleyBasedEra
+
+shrinkMinimumUTxO :: MinimumUTxO -> [MinimumUTxO]
+shrinkMinimumUTxO = const []
+
+--------------------------------------------------------------------------------
+-- Generating 'ProtocolParametersForShelleyBasedEra' values
+--------------------------------------------------------------------------------
+
+genProtocolParametersForShelleyBasedEra
+    :: Gen ProtocolParametersForShelleyBasedEra
+genProtocolParametersForShelleyBasedEra = oneof
+    [ genShelley
+    , genAllegra
+    , genMary
+    , genAlonzo
+    , genBabbage
+    ]
+  where
+    genShelley :: Gen ProtocolParametersForShelleyBasedEra
+    genShelley = do
+        minUTxOValue <- genInterestingLedgerCoin
+        pure $ ProtocolParametersForShelleyBasedEra ShelleyBasedEraShelley
+            def {Shelley._minUTxOValue = minUTxOValue}
+
+    genAllegra :: Gen ProtocolParametersForShelleyBasedEra
+    genAllegra = do
+        minUTxOValue <- genInterestingLedgerCoin
+        pure $ ProtocolParametersForShelleyBasedEra ShelleyBasedEraAllegra
+            def {Shelley._minUTxOValue = minUTxOValue}
+
+    genMary :: Gen ProtocolParametersForShelleyBasedEra
+    genMary = do
+        minUTxOValue <- genInterestingLedgerCoin
+        pure $ ProtocolParametersForShelleyBasedEra ShelleyBasedEraMary
+            def {Shelley._minUTxOValue = minUTxOValue}
+
+    genAlonzo :: Gen ProtocolParametersForShelleyBasedEra
+    genAlonzo = do
+        coinsPerUTxOWord <- genInterestingLedgerCoin
+        pure $ ProtocolParametersForShelleyBasedEra ShelleyBasedEraAlonzo
+            def {Alonzo._coinsPerUTxOWord = coinsPerUTxOWord}
+
+    genBabbage :: Gen ProtocolParametersForShelleyBasedEra
+    genBabbage = do
+        coinsPerUTxOByte <- genInterestingLedgerCoin
+        pure $ ProtocolParametersForShelleyBasedEra ShelleyBasedEraBabbage
+            def {Babbage._coinsPerUTxOByte = coinsPerUTxOByte}
+
+shrinkProtocolParametersForShelleyBasedEra
+    :: ProtocolParametersForShelleyBasedEra
+    -> [ProtocolParametersForShelleyBasedEra]
+shrinkProtocolParametersForShelleyBasedEra = const []
+
+--------------------------------------------------------------------------------
+-- Internal functions
+--------------------------------------------------------------------------------
+
+genInterestingCoinValue :: Gen Natural
+genInterestingCoinValue = do
+    base <- (1_000_000 *) <$> choose (0, 8)
+    offset <- choose @Integer (-10, 10)
+    pure $ intCastMaybeZero $ base + offset
+
+genInterestingLedgerCoin :: Gen Ledger.Coin
+genInterestingLedgerCoin = Ledger.Coin . intCast
+    <$> genInterestingCoinValue
+
+intCastMaybeZero :: (Integral a, Integral b, Bits a, Bits b) => a -> b
+intCastMaybeZero = fromMaybe 0 . intCastMaybe

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/MinimumUTxO/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/MinimumUTxO/Gen.hs
@@ -8,12 +8,19 @@
 -- Defines generators and shrinkers for the 'MinimumUTxO' data type.
 --
 module Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
-    ( genMinimumUTxO
+    (
+    -- * Generators and shrinkers
+      genMinimumUTxO
     , genMinimumUTxOForShelleyBasedEra
     , shrinkMinimumUTxO
     , shrinkMinimumUTxOForShelleyBasedEra
-    , genCoinOfSimilarMagnitude
-    , genLedgerCoinOfSimilarMagnitude
+
+    -- * Test protocol parameter values
+    , testParameter_minUTxOValue_Shelley
+    , testParameter_minUTxOValue_Allegra
+    , testParameter_minUTxOValue_Mary
+    , testParameter_coinsPerUTxOWord_Alonzo
+    , testParameter_coinsPerUTxOByte_Babbage
     )
     where
 

--- a/lib/core/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -32,7 +32,6 @@ import Cardano.Wallet.Primitive.Types
     , FeePolicy (..)
     , GenesisParameters (..)
     , LinearFunction (..)
-    , MinimumUTxOValue (..)
     , NetworkParameters (..)
     , ProtocolParameters (..)
     , SlotLength (..)
@@ -126,7 +125,6 @@ dummyProtocolParameters = ProtocolParameters
     , txParameters = dummyTxParameters
     , desiredNumberOfStakePools = 100
     , minimumUTxO = MinimumUTxONone
-    , minimumUTxOvalue = MinimumUTxOValue $ Coin 0
     , stakeKeyDeposit = Coin 0
     , eras = emptyEraInfo
     , maximumCollateralInputCount = 3

--- a/lib/core/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -47,6 +47,8 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..), mockHash )
+import Cardano.Wallet.Primitive.Types.MinimumUTxO
+    ( MinimumUTxO (MinimumUTxONone) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -123,6 +125,7 @@ dummyProtocolParameters = ProtocolParameters
     { decentralizationLevel = minBound
     , txParameters = dummyTxParameters
     , desiredNumberOfStakePools = 100
+    , minimumUTxO = MinimumUTxONone
     , minimumUTxOvalue = MinimumUTxOValue $ Coin 0
     , stakeKeyDeposit = Coin 0
     , eras = emptyEraInfo

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -94,7 +94,6 @@ import Cardano.Wallet.Primitive.Types
     , ExecutionUnits (..)
     , FeePolicy (..)
     , LinearFunction (LinearFunction)
-    , MinimumUTxOValue (..)
     , PoolId (..)
     , ProtocolParameters (..)
     , Range (..)
@@ -717,10 +716,6 @@ instance Arbitrary Natural where
     shrink = shrinkIntegral
 
 instance Arbitrary ExecutionUnitPrices where
-    shrink = genericShrink
-    arbitrary = genericArbitrary
-
-instance Arbitrary MinimumUTxOValue where
     shrink = genericShrink
     arbitrary = genericArbitrary
 

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -692,7 +692,6 @@ instance Arbitrary ProtocolParameters where
         <:> shrink
         <:> shrink
         <:> shrink
-        <:> shrink
         <:> const []
         <:> Nil
     arbitrary = ProtocolParameters
@@ -700,7 +699,6 @@ instance Arbitrary ProtocolParameters where
         <*> arbitrary
         <*> choose (0, 100)
         <*> genMinimumUTxO
-        <*> arbitrary
         <*> arbitrary
         <*> arbitrary
         <*> genMaximumCollateralInputCount

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -120,6 +120,8 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..), mockHash )
+import Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
+    ( genMinimumUTxO, shrinkMinimumUTxO )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
@@ -684,6 +686,7 @@ instance Arbitrary ProtocolParameters where
         <@> shrink
         <:> shrink
         <:> shrink
+        <:> shrinkMinimumUTxO
         <:> shrink
         <:> shrink
         <:> shrink
@@ -696,6 +699,7 @@ instance Arbitrary ProtocolParameters where
         <$> arbitrary
         <*> arbitrary
         <*> choose (0, 100)
+        <*> genMinimumUTxO
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -62,6 +62,7 @@ library
     , cborg
     , containers
     , contra-tracer
+    , data-default
     , directory
     , extra
     , filepath

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -267,6 +267,7 @@ test-suite unit
     , fmt
     , generic-arbitrary
     , generic-lens
+    , generics-sop
     , hspec-core
     , hspec-golden
     , iohk-monitoring

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -125,6 +125,7 @@ library
       Cardano.Wallet.Shelley.Launch.Blockfrost
       Cardano.Wallet.Shelley.Launch.Cluster
       Cardano.Wallet.Shelley.Logging
+      Cardano.Wallet.Shelley.MinimumUTxO
       Cardano.Wallet.Shelley.Network
       Cardano.Wallet.Shelley.Network.Blockfrost
       Cardano.Wallet.Shelley.Network.Blockfrost.Conversion
@@ -282,6 +283,7 @@ test-suite unit
     , ouroboros-network
     , cardano-ledger-shelley
     , plutus-core
+    , quickcheck-classes
     , text
     , text-class
     , transformers
@@ -301,6 +303,7 @@ test-suite unit
       Cardano.Wallet.Shelley.Compatibility.LedgerSpec
       Cardano.Wallet.Shelley.LaunchSpec
       Cardano.Wallet.Shelley.Launch.BlockfrostSpec
+      Cardano.Wallet.Shelley.MinimumUTxOSpec
       Cardano.Wallet.Shelley.NetworkSpec
       Cardano.Wallet.Shelley.Network.BlockfrostSpec
       Cardano.Wallet.Shelley.TransactionSpec

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -264,6 +264,7 @@ test-suite unit
     , strict-containers
     , containers
     , contra-tracer
+    , data-default
     , directory
     , filepath
     , fmt

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -273,6 +273,7 @@ test-suite unit
     , time
     , hspec
     , hspec-core
+    , int-cast
     , memory
     , MonadRandom
     , optparse-applicative

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -66,6 +66,8 @@ import Cardano.Crypto
     ( serializeCborHash )
 import Cardano.Crypto.ProtocolMagic
     ( ProtocolMagicId, unProtocolMagicId )
+import Cardano.Wallet.Primitive.Types.MinimumUTxO
+    ( minimumUTxONone )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Crypto.Hash.Utils
@@ -141,6 +143,7 @@ mainnetNetworkParameters = W.NetworkParameters
             , getMaxExecutionUnits = W.ExecutionUnits 0 0
             }
         , desiredNumberOfStakePools = 0
+        , minimumUTxO = minimumUTxONone
         , minimumUTxOvalue = W.MinimumUTxOValue $ W.Coin 0
         , stakeKeyDeposit = W.Coin 0
         , eras = W.emptyEraInfo
@@ -364,6 +367,7 @@ protocolParametersFromPP eraInfo currentNodeProtocolParameters pp =
             , getMaxExecutionUnits = W.ExecutionUnits 0 0
             }
         , desiredNumberOfStakePools = 0
+        , minimumUTxO = minimumUTxONone
         , minimumUTxOvalue = W.MinimumUTxOValue $ W.Coin 0
         , stakeKeyDeposit = W.Coin 0
         , eras = fromBound <$> eraInfo

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -144,7 +144,6 @@ mainnetNetworkParameters = W.NetworkParameters
             }
         , desiredNumberOfStakePools = 0
         , minimumUTxO = minimumUTxONone
-        , minimumUTxOvalue = W.MinimumUTxOValue $ W.Coin 0
         , stakeKeyDeposit = W.Coin 0
         , eras = W.emptyEraInfo
         -- Collateral inputs were not supported or required in Byron:
@@ -368,7 +367,6 @@ protocolParametersFromPP eraInfo currentNodeProtocolParameters pp =
             }
         , desiredNumberOfStakePools = 0
         , minimumUTxO = minimumUTxONone
-        , minimumUTxOvalue = W.MinimumUTxOValue $ W.Coin 0
         , stakeKeyDeposit = W.Coin 0
         , eras = fromBound <$> eraInfo
         -- Collateral inputs were not supported or required in Byron:

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -229,6 +229,8 @@ import Cardano.Wallet.Primitive.Types
     , ProtocolParameters (txParameters)
     , TxParameters (getTokenBundleMaxSize)
     )
+import Cardano.Wallet.Primitive.Types.MinimumUTxO
+    ( minimumUTxOForShelleyBasedEra )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap, toNestedList )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
@@ -805,6 +807,8 @@ fromShelleyPParams eraInfo currentNodeProtocolParameters pp =
                 maryTokenBundleMaxSize (W.ExecutionUnits 0 0) pp
         , desiredNumberOfStakePools =
             desiredNumberOfStakePoolsFromPParams pp
+        , minimumUTxO =
+            minimumUTxOForShelleyBasedEra ShelleyBasedEraShelley pp
         , minimumUTxOvalue =
             MinimumUTxOValue . toWalletCoin $ SLAPI._minUTxOValue pp
         , stakeKeyDeposit = stakeKeyDepositFromPParams pp
@@ -831,6 +835,8 @@ fromAllegraPParams eraInfo currentNodeProtocolParameters pp =
                 maryTokenBundleMaxSize (W.ExecutionUnits 0 0) pp
         , desiredNumberOfStakePools =
             desiredNumberOfStakePoolsFromPParams pp
+        , minimumUTxO =
+            minimumUTxOForShelleyBasedEra ShelleyBasedEraAllegra pp
         , minimumUTxOvalue =
             MinimumUTxOValue . toWalletCoin $ SLAPI._minUTxOValue pp
         , stakeKeyDeposit = stakeKeyDepositFromPParams pp
@@ -857,6 +863,8 @@ fromMaryPParams eraInfo currentNodeProtocolParameters pp =
                 maryTokenBundleMaxSize (W.ExecutionUnits 0 0) pp
         , desiredNumberOfStakePools =
             desiredNumberOfStakePoolsFromPParams pp
+        , minimumUTxO =
+            minimumUTxOForShelleyBasedEra ShelleyBasedEraMary pp
         , minimumUTxOvalue =
             MinimumUTxOValue . toWalletCoin $ SLAPI._minUTxOValue pp
         , stakeKeyDeposit = stakeKeyDepositFromPParams pp
@@ -888,6 +896,8 @@ fromAlonzoPParams eraInfo currentNodeProtocolParameters pp =
             pp
         , desiredNumberOfStakePools =
             desiredNumberOfStakePoolsFromPParams pp
+        , minimumUTxO =
+            minimumUTxOForShelleyBasedEra ShelleyBasedEraAlonzo pp
         , minimumUTxOvalue = MinimumUTxOValueCostPerWord
             . toWalletCoin $ Alonzo._coinsPerUTxOWord pp
         , stakeKeyDeposit = stakeKeyDepositFromPParams pp
@@ -917,6 +927,8 @@ fromBabbagePParams eraInfo currentNodeProtocolParameters pp =
             pp
         , desiredNumberOfStakePools =
             desiredNumberOfStakePoolsFromPParams pp
+        , minimumUTxO =
+            minimumUTxOForShelleyBasedEra ShelleyBasedEraBabbage pp
         , minimumUTxOvalue = MinimumUTxOValueCostPerWord
             . fromByteToWord . toWalletCoin $ Babbage._coinsPerUTxOByte pp
         , stakeKeyDeposit = stakeKeyDepositFromPParams pp

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -222,7 +222,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Types
     ( Certificate (..)
     , ChainPoint (..)
-    , MinimumUTxOValue (..)
     , PoolCertificate (..)
     , PoolRegistrationCertificate (..)
     , PoolRetirementCertificate (..)
@@ -793,8 +792,7 @@ fromMaxSize :: Natural -> Quantity "byte" Word16
 fromMaxSize = Quantity . fromIntegral
 
 fromShelleyPParams
-    :: HasCallStack
-    => W.EraInfo Bound
+    :: W.EraInfo Bound
     -> Maybe Cardano.ProtocolParameters
     -> Shelley.PParams StandardShelley
     -> W.ProtocolParameters
@@ -809,8 +807,6 @@ fromShelleyPParams eraInfo currentNodeProtocolParameters pp =
             desiredNumberOfStakePoolsFromPParams pp
         , minimumUTxO =
             minimumUTxOForShelleyBasedEra ShelleyBasedEraShelley pp
-        , minimumUTxOvalue =
-            MinimumUTxOValue . toWalletCoin $ SLAPI._minUTxOValue pp
         , stakeKeyDeposit = stakeKeyDepositFromPParams pp
         , eras = fromBoundToEpochNo <$> eraInfo
         -- Collateral inputs were not supported or required in Shelley:
@@ -821,8 +817,7 @@ fromShelleyPParams eraInfo currentNodeProtocolParameters pp =
         }
 
 fromAllegraPParams
-    :: HasCallStack
-    => W.EraInfo Bound
+    :: W.EraInfo Bound
     -> Maybe Cardano.ProtocolParameters
     -> Allegra.PParams StandardAllegra
     -> W.ProtocolParameters
@@ -837,8 +832,6 @@ fromAllegraPParams eraInfo currentNodeProtocolParameters pp =
             desiredNumberOfStakePoolsFromPParams pp
         , minimumUTxO =
             minimumUTxOForShelleyBasedEra ShelleyBasedEraAllegra pp
-        , minimumUTxOvalue =
-            MinimumUTxOValue . toWalletCoin $ SLAPI._minUTxOValue pp
         , stakeKeyDeposit = stakeKeyDepositFromPParams pp
         , eras = fromBoundToEpochNo <$> eraInfo
         -- Collateral inputs were not supported or required in Allegra:
@@ -849,8 +842,7 @@ fromAllegraPParams eraInfo currentNodeProtocolParameters pp =
         }
 
 fromMaryPParams
-    :: HasCallStack
-    => W.EraInfo Bound
+    :: W.EraInfo Bound
     -> Maybe Cardano.ProtocolParameters
     -> Mary.PParams StandardMary
     -> W.ProtocolParameters
@@ -865,8 +857,6 @@ fromMaryPParams eraInfo currentNodeProtocolParameters pp =
             desiredNumberOfStakePoolsFromPParams pp
         , minimumUTxO =
             minimumUTxOForShelleyBasedEra ShelleyBasedEraMary pp
-        , minimumUTxOvalue =
-            MinimumUTxOValue . toWalletCoin $ SLAPI._minUTxOValue pp
         , stakeKeyDeposit = stakeKeyDepositFromPParams pp
         , eras = fromBoundToEpochNo <$> eraInfo
         -- Collateral inputs were not supported or required in Mary:
@@ -898,8 +888,6 @@ fromAlonzoPParams eraInfo currentNodeProtocolParameters pp =
             desiredNumberOfStakePoolsFromPParams pp
         , minimumUTxO =
             minimumUTxOForShelleyBasedEra ShelleyBasedEraAlonzo pp
-        , minimumUTxOvalue = MinimumUTxOValueCostPerWord
-            . toWalletCoin $ Alonzo._coinsPerUTxOWord pp
         , stakeKeyDeposit = stakeKeyDepositFromPParams pp
         , eras = fromBoundToEpochNo <$> eraInfo
         , maximumCollateralInputCount = unsafeIntToWord $
@@ -929,8 +917,6 @@ fromBabbagePParams eraInfo currentNodeProtocolParameters pp =
             desiredNumberOfStakePoolsFromPParams pp
         , minimumUTxO =
             minimumUTxOForShelleyBasedEra ShelleyBasedEraBabbage pp
-        , minimumUTxOvalue = MinimumUTxOValueCostPerWord
-            . fromByteToWord . toWalletCoin $ Babbage._coinsPerUTxOByte pp
         , stakeKeyDeposit = stakeKeyDepositFromPParams pp
         , eras = fromBoundToEpochNo <$> eraInfo
         , maximumCollateralInputCount = unsafeIntToWord $
@@ -941,8 +927,6 @@ fromBabbagePParams eraInfo currentNodeProtocolParameters pp =
             Just $ executionUnitPricesFromPParams pp
         , currentNodeProtocolParameters
         }
-  where
-    fromByteToWord (W.Coin v) = W.Coin $ 8 * v
 
 -- | Extract the current network decentralization level from the given set of
 -- protocol parameters.

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -1907,7 +1906,7 @@ toCardanoTxOut era = case era of
                 <$> deserialiseFromRawBytes AsByronAddress addr
             ]
 
-    toBabbageTxOut :: HasCallStack => W.TxOut -> Cardano.TxOut ctx _
+    toBabbageTxOut :: HasCallStack => W.TxOut -> Cardano.TxOut ctx BabbageEra
     toBabbageTxOut (W.TxOut (W.Address addr) tokens) =
         Cardano.TxOut
             addrInEra

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -87,6 +87,7 @@ module Cardano.Wallet.Shelley.Compatibility
     , fromCardanoLovelace
     , rewardAccountFromAddress
     , fromShelleyPParams
+    , fromAllegraPParams
     , fromAlonzoPParams
     , fromBabbagePParams
     , fromLedgerExUnits
@@ -317,6 +318,7 @@ import Ouroboros.Consensus.Cardano.Block
     ( CardanoBlock
     , CardanoEras
     , HardForkBlock (..)
+    , StandardAllegra
     , StandardAlonzo
     , StandardBabbage
     , StandardShelley
@@ -353,6 +355,7 @@ import qualified Cardano.Byron.Codec.Cbor as CBOR
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Ledger.Address as SL
+import qualified Cardano.Ledger.Allegra as Allegra
 import qualified Cardano.Ledger.Alonzo as Alonzo
 import qualified Cardano.Ledger.Alonzo.Data as Alonzo
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
@@ -803,6 +806,32 @@ fromShelleyPParams eraInfo currentNodeProtocolParameters pp =
         , stakeKeyDeposit = stakeKeyDepositFromPParams pp
         , eras = fromBoundToEpochNo <$> eraInfo
         -- Collateral inputs were not supported or required in Shelley:
+        , maximumCollateralInputCount = 0
+        , minimumCollateralPercentage = 0
+        , executionUnitPrices = Nothing
+        , currentNodeProtocolParameters
+        }
+
+fromAllegraPParams
+    :: HasCallStack
+    => W.EraInfo Bound
+    -> Maybe Cardano.ProtocolParameters
+    -> Allegra.PParams StandardAllegra
+    -> W.ProtocolParameters
+fromAllegraPParams eraInfo currentNodeProtocolParameters pp =
+    W.ProtocolParameters
+        { decentralizationLevel =
+            decentralizationLevelFromPParams pp
+        , txParameters =
+            txParametersFromPParams
+                maryTokenBundleMaxSize (W.ExecutionUnits 0 0) pp
+        , desiredNumberOfStakePools =
+            desiredNumberOfStakePoolsFromPParams pp
+        , minimumUTxOvalue =
+            MinimumUTxOValue . toWalletCoin $ SLAPI._minUTxOValue pp
+        , stakeKeyDeposit = stakeKeyDepositFromPParams pp
+        , eras = fromBoundToEpochNo <$> eraInfo
+        -- Collateral inputs were not supported or required in Allegra:
         , maximumCollateralInputCount = 0
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -381,6 +381,7 @@ import qualified Cardano.Ledger.Mary.Value as SL
 import qualified Cardano.Ledger.SafeHash as SafeHash
 import qualified Cardano.Ledger.Shelley as SL hiding
     ( Value )
+import qualified Cardano.Ledger.Shelley as Shelley
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Ledger.Shelley.API as SLAPI
 import qualified Cardano.Ledger.Shelley.BlockChain as SL
@@ -793,7 +794,7 @@ fromShelleyPParams
     :: HasCallStack
     => W.EraInfo Bound
     -> Maybe Cardano.ProtocolParameters
-    -> SLAPI.PParams era
+    -> Shelley.PParams StandardShelley
     -> W.ProtocolParameters
 fromShelleyPParams eraInfo currentNodeProtocolParameters pp =
     W.ProtocolParameters
@@ -1043,7 +1044,7 @@ localNodeConnectInfo sp net = LocalNodeConnectInfo params net . nodeSocketFile
 
 -- | Convert genesis data into blockchain params and an initial set of UTxO
 fromGenesisData
-    :: forall e crypto. (Era e, e ~ SL.ShelleyEra crypto)
+    :: forall e crypto. (e ~ SL.ShelleyEra crypto, crypto ~ StandardCrypto)
     => ShelleyGenesis e
     -> [(SL.Addr crypto, SL.Coin)]
     -> (W.NetworkParameters, W.Block)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -88,6 +88,7 @@ module Cardano.Wallet.Shelley.Compatibility
     , rewardAccountFromAddress
     , fromShelleyPParams
     , fromAllegraPParams
+    , fromMaryPParams
     , fromAlonzoPParams
     , fromBabbagePParams
     , fromLedgerExUnits
@@ -321,6 +322,7 @@ import Ouroboros.Consensus.Cardano.Block
     , StandardAllegra
     , StandardAlonzo
     , StandardBabbage
+    , StandardMary
     , StandardShelley
     )
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras
@@ -374,6 +376,7 @@ import qualified Cardano.Ledger.Core as SL.Core
 import qualified Cardano.Ledger.Credential as SL
 import qualified Cardano.Ledger.Crypto as SL
 import qualified Cardano.Ledger.Era as Ledger.Era
+import qualified Cardano.Ledger.Mary as Mary
 import qualified Cardano.Ledger.Mary.Value as SL
 import qualified Cardano.Ledger.SafeHash as SafeHash
 import qualified Cardano.Ledger.Shelley as SL hiding
@@ -832,6 +835,32 @@ fromAllegraPParams eraInfo currentNodeProtocolParameters pp =
         , stakeKeyDeposit = stakeKeyDepositFromPParams pp
         , eras = fromBoundToEpochNo <$> eraInfo
         -- Collateral inputs were not supported or required in Allegra:
+        , maximumCollateralInputCount = 0
+        , minimumCollateralPercentage = 0
+        , executionUnitPrices = Nothing
+        , currentNodeProtocolParameters
+        }
+
+fromMaryPParams
+    :: HasCallStack
+    => W.EraInfo Bound
+    -> Maybe Cardano.ProtocolParameters
+    -> Mary.PParams StandardMary
+    -> W.ProtocolParameters
+fromMaryPParams eraInfo currentNodeProtocolParameters pp =
+    W.ProtocolParameters
+        { decentralizationLevel =
+            decentralizationLevelFromPParams pp
+        , txParameters =
+            txParametersFromPParams
+                maryTokenBundleMaxSize (W.ExecutionUnits 0 0) pp
+        , desiredNumberOfStakePools =
+            desiredNumberOfStakePoolsFromPParams pp
+        , minimumUTxOvalue =
+            MinimumUTxOValue . toWalletCoin $ SLAPI._minUTxOValue pp
+        , stakeKeyDeposit = stakeKeyDepositFromPParams pp
+        , eras = fromBoundToEpochNo <$> eraInfo
+        -- Collateral inputs were not supported or required in Mary:
         , maximumCollateralInputCount = 0
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -416,6 +416,7 @@ import qualified Ouroboros.Consensus.Shelley.Ledger as O
 import qualified Ouroboros.Consensus.Shelley.Protocol.Abstract as Consensus
 import qualified Ouroboros.Network.Block as O
 import qualified Ouroboros.Network.Point as Point
+
 --------------------------------------------------------------------------------
 --
 -- Chain Parameters
@@ -871,7 +872,6 @@ fromBabbagePParams eraInfo currentNodeProtocolParameters pp =
         }
   where
     fromByteToWord (W.Coin v) = W.Coin $ 8 * v
-
 
 -- | Extract the current network decentralization level from the given set of
 -- protocol parameters.

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs
@@ -14,11 +14,8 @@
 --
 module Cardano.Wallet.Shelley.Compatibility.Ledger
     (
-      -- * Exported ledger functions
-      computeMinimumAdaQuantity
-
       -- * Conversions from wallet types to ledger specification types
-    , toLedgerCoin
+      toLedgerCoin
     , toLedgerTokenBundle
     , toLedgerTokenPolicyId
     , toLedgerTokenName
@@ -38,9 +35,6 @@ module Cardano.Wallet.Shelley.Compatibility.Ledger
       --   types
     , Convert (..)
 
-      -- * Internal functions
-    , computeMinimumAdaQuantityInternal
-
     ) where
 
 import Prelude
@@ -51,8 +45,6 @@ import Cardano.Crypto.Hash
     ( hashFromBytes, hashToBytes )
 import Cardano.Ledger.SafeHash
     ( unsafeMakeSafeHash )
-import Cardano.Wallet.Primitive.Types
-    ( MinimumUTxOValue (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -61,8 +53,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (..), TokenPolicyId (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
@@ -93,7 +83,6 @@ import Ouroboros.Consensus.Shelley.Eras
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Ledger.Address as Ledger
 import qualified Cardano.Ledger.Alonzo as Alonzo
-import qualified Cardano.Ledger.Alonzo.Rules.Utxo as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo
 import qualified Cardano.Ledger.Babbage as Babbage
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
@@ -101,40 +90,13 @@ import qualified Cardano.Ledger.Crypto as Ledger
 import qualified Cardano.Ledger.Keys as Ledger
 import qualified Cardano.Ledger.Mary.Value as Ledger
 import qualified Cardano.Ledger.Shelley.API as Ledger
-import qualified Cardano.Ledger.ShelleyMA.Rules.Utxo as Ledger
 import qualified Cardano.Ledger.ShelleyMA.Timelocks as MA
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
 import qualified Data.Map.Strict.NonEmptyMap as NonEmptyMap
 import qualified Ouroboros.Network.Block as O
-
---------------------------------------------------------------------------------
--- Public functions
---------------------------------------------------------------------------------
-
--- | Uses the ledger specification to compute the minimum required ada quantity
---   for a token map.
---
-computeMinimumAdaQuantity
-    :: MinimumUTxOValue
-    -- ^ The absolute minimum ada quantity specified by the protocol.
-    -> TokenMap
-    -- ^ The token map to evaluate.
-    -> Coin
-    -- ^ The minimum ada quantity for the given token map.
-computeMinimumAdaQuantity protocolMinimum m =
-    -- Note:
-    --
-    -- We assume here that 'computeMinimumAdaQuantityInternal' has the property
-    -- of being constant w.r.t. to the ada value. Assuming this property holds,
-    -- it is safe to call it with an ada value of 0.
-    --
-    -- See 'prop_computeMinimumAdaQuantity_agnosticToAdaQuantity'.
-    --
-    computeMinimumAdaQuantityInternal protocolMinimum (TokenBundle (Coin 0) m)
 
 --------------------------------------------------------------------------------
 -- Roundtrip conversion between wallet types and ledger specification types
@@ -342,54 +304,3 @@ toWalletScript keyrole = fromLedgerScript
         ActiveUntilSlot $ fromIntegral slot
     fromLedgerScript (MA.RequireTimeStart (O.SlotNo slot)) =
         ActiveFromSlot $ fromIntegral slot
-
---------------------------------------------------------------------------------
--- Internal functions
---------------------------------------------------------------------------------
-
--- | Uses the ledger specification to compute the minimum required ada quantity
---   for a token bundle.
---
--- This function is intended to be constant with respect to:
---
---    - the ada quantity;
---    - the quantities of individual assets.
---
--- See the following properties:
---
---    - 'prop_computeMinimumAdaQuantity_agnosticToAdaQuantity';
---    - 'prop_computeMinimumAdaQuantity_agnosticToAssetQuantities'.
---
--- TODO: [ADP-954] Datum hashes are currently not taken into account.
-computeMinimumAdaQuantityInternal
-    :: MinimumUTxOValue
-    -- ^ The absolute minimum ada quantity specified by the protocol.
-    -> TokenBundle
-    -- ^ The token bundle to evaluate.
-    -> Coin
-    -- ^ The minimum ada quantity for the given token bundle.
-computeMinimumAdaQuantityInternal (MinimumUTxOValue protocolMinimum) bundle =
-    toWalletCoin $
-        Ledger.scaledMinDeposit
-            (toLedgerTokenBundle bundle)
-            (toLedgerCoin protocolMinimum)
-computeMinimumAdaQuantityInternal (MinimumUTxOValueCostPerWord (Coin perWord)) bundle =
-    let
-        outputSize = Alonzo.utxoEntrySize $
-            toAlonzoTxOut (TxOut dummyAddr bundle) Nothing
-    in
-        Coin $ fromIntegral outputSize * perWord
-  where
-    -- We just need an address the ledger can deserialize. It doesn't actually
-    -- use the length of it.
-    --
-    -- This should not change (if Alonzo is already in-use, it would have to be
-    -- changed in a new era).
-    --
-    -- Regardless, the dummy address is a payment / enterprise address -- can't
-    -- get any shorter than that. The integration tests use longer addresses.
-    -- They should break if this were to be wrong.
-    --
-    -- Because the ledger function is pure and not taking a network, passing in
-    -- a mainnet network should be fine regardless of network.
-    dummyAddr = Address $ BS.pack $ 97 : replicate 28 0

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -20,7 +20,7 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO
-    ( MinimumUTxO (..), ProtocolParametersForShelleyBasedEra (..) )
+    ( MinimumUTxO (..), MinimumUTxOForShelleyBasedEra (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
@@ -52,16 +52,16 @@ computeMinimumCoinForUTxO = \case
         const (Coin 0)
     MinimumUTxOConstant c ->
         const c
-    MinimumUTxOForShelleyBasedEra pp ->
+    MinimumUTxOForShelleyBasedEraOf pp ->
         computeMinimumCoinForShelleyBasedEra pp
 
 computeMinimumCoinForShelleyBasedEra
     :: HasCallStack
-    => ProtocolParametersForShelleyBasedEra
+    => MinimumUTxOForShelleyBasedEra
     -> TokenMap
     -> Coin
 computeMinimumCoinForShelleyBasedEra
-    (ProtocolParametersForShelleyBasedEra era pp) tokenMap =
+    (MinimumUTxOForShelleyBasedEra era pp) tokenMap =
         extractResult $
         Cardano.calculateMinimumUTxO era
             (embedTokenMapWithinPaddedTxOut era tokenMap)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -1,0 +1,155 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2022 IOHK
+-- License: Apache-2.0
+--
+-- Computing minimum UTxO values.
+--
+module Cardano.Wallet.Shelley.MinimumUTxO
+    ( computeMinimumCoinForUTxO
+    , unsafeLovelaceToWalletCoin
+    , unsafeValueToLovelace
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.MinimumUTxO
+    ( MinimumUTxO (..), ProtocolParametersForShelleyBasedEra (..) )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle (..) )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( TokenMap )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxOut (..) )
+import Cardano.Wallet.Shelley.Compatibility
+    ( toCardanoTxOut )
+import Data.Function
+    ( (&) )
+import Data.IntCast
+    ( intCast, intCastMaybe )
+import Data.Word
+    ( Word64 )
+import GHC.Stack
+    ( HasCallStack )
+import Numeric.Natural
+    ( Natural )
+
+import qualified Cardano.Api.Shelley as Cardano
+import qualified Data.ByteString as BS
+
+-- | Computes a minimum 'Coin' value for a 'TokenMap' that is destined for
+--   inclusion in a transaction output.
+--
+computeMinimumCoinForUTxO :: HasCallStack => MinimumUTxO -> TokenMap -> Coin
+computeMinimumCoinForUTxO = \case
+    MinimumUTxONone ->
+        const (Coin 0)
+    MinimumUTxOConstant c ->
+        const c
+    MinimumUTxOForShelleyBasedEra pp ->
+        computeMinimumCoinForShelleyBasedEra pp
+
+computeMinimumCoinForShelleyBasedEra
+    :: HasCallStack
+    => ProtocolParametersForShelleyBasedEra
+    -> TokenMap
+    -> Coin
+computeMinimumCoinForShelleyBasedEra
+    (ProtocolParametersForShelleyBasedEra era pp) tokenMap =
+        extractResult $
+        Cardano.calculateMinimumUTxO era
+            (embedTokenMapWithinPaddedTxOut era tokenMap)
+            (Cardano.fromLedgerPParams era pp)
+  where
+    extractResult :: Either Cardano.MinimumUTxOError Cardano.Value -> Coin
+    extractResult = \case
+        Right value ->
+            -- We assume that the returned value is a non-negative ada quantity
+            -- with no other assets. If this assumption is violated, we have no
+            -- way to continue, and must raise an error:
+            value
+                & unsafeValueToLovelace
+                & unsafeLovelaceToWalletCoin
+        Left e ->
+            -- We assume that the provided protocol parameters record has all
+            -- the required parameters for the given era. If this assumption is
+            -- violated, we have no way to continue, and must raise an error:
+            error $ unwords
+                [ "computeMinimumCoinForUTxO:"
+                , "unexpected error:"
+                , show e
+                ]
+
+-- | Embeds a 'TokenMap' within a padded 'Cardano.TxOut' value.
+--
+-- When computing the minimum UTxO quantity for a given 'TokenMap', we do not
+-- have access to an address or to an ada quantity.
+--
+-- However, in order to compute a minimum UTxO quantity through the Cardano
+-- API, we must supply a 'TxOut' value with a valid address and ada quantity.
+--
+-- It's imperative that we do not underestimate minimum UTxO quantities, as
+-- this may result in the creation of transactions that are unacceptable to
+-- the ledger. In the case of change generation, this would be particularly
+-- problematic, as change outputs are generated automatically, and users do
+-- not have direct control over the ada quantities generated.
+--
+-- However, while we cannot underestimate minimum UTxO quantities, we are at
+-- liberty to moderately overestimate them.
+--
+-- Since the minimum UTxO quantity function is monotonically increasing in the
+-- serialized length of its input, if we supply a 'TxOut' with an address and
+-- ada quantity whose serialized lengths are the maximum possible lengths, we
+-- can be confident that the resultant value will not be an underestimate.
+--
+embedTokenMapWithinPaddedTxOut
+    :: Cardano.ShelleyBasedEra era
+    -> TokenMap
+    -> Cardano.TxOut Cardano.CtxTx era
+embedTokenMapWithinPaddedTxOut era m =
+    toCardanoTxOut era $ TxOut dummyAddress $ TokenBundle dummyCoin m
+  where
+    dummyAddress :: Address
+    dummyAddress = Address $ BS.pack $ replicate maximumAddressLength 0
+      where
+        maximumAddressLength :: Int
+        maximumAddressLength = 57
+
+    dummyCoin :: Coin
+    dummyCoin = Coin $ intCast @Word64 @Natural $ maxBound
+
+-- | Extracts a 'Coin' value from a 'Cardano.Lovelace' value.
+--
+-- Fails with a run-time error if the value is negative.
+--
+unsafeLovelaceToWalletCoin :: HasCallStack => Cardano.Lovelace -> Coin
+unsafeLovelaceToWalletCoin (Cardano.Lovelace v) =
+  case intCastMaybe @Integer @Natural v of
+      Nothing -> error $ unwords
+          [ "unsafeLovelaceToWalletCoin:"
+          , "encountered negative value:"
+          , show v
+          ]
+      Just lovelaceNonNegative ->
+          Coin lovelaceNonNegative
+
+-- | Extracts a 'Cardano.Lovelace' value from a 'Cardano.Value'.
+--
+-- Fails with a run-time error if the 'Cardano.Value' contains any non-ada
+-- assets.
+--
+unsafeValueToLovelace :: HasCallStack => Cardano.Value -> Cardano.Lovelace
+unsafeValueToLovelace v =
+    case Cardano.valueToLovelace v of
+        Nothing -> error $ unwords
+            [ "unsafeValueToLovelace:"
+            , "encountered value with non-ada assets:"
+            , show v
+            ]
+        Just lovelace -> lovelace

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -57,6 +57,13 @@ computeMinimumCoinForUTxO = \case
     MinimumUTxOForShelleyBasedEraOf pp ->
         computeMinimumCoinForShelleyBasedEra pp
 
+-- | Computes a minimum 'Coin' value for a 'TokenMap' that is destined for
+--   inclusion in a transaction output.
+--
+-- This function returns a value that is specific to a given Shelley-based era.
+-- Importantly, a value that is valid in one era will not necessarily be valid
+-- in another era.
+--
 computeMinimumCoinForShelleyBasedEra
     :: HasCallStack
     => MinimumUTxOForShelleyBasedEra
@@ -79,9 +86,18 @@ computeMinimumCoinForShelleyBasedEra
                 & unsafeValueToLovelace
                 & unsafeLovelaceToWalletCoin
         Left e ->
-            -- We assume that the provided protocol parameters record has all
-            -- the required parameters for the given era. If this assumption is
-            -- violated, we have no way to continue, and must raise an error:
+            -- The 'Cardano.calculateMinimumUTxO' function should only return
+            -- an error if a required protocol parameter is missing.
+            --
+            -- However, given that values of 'MinimumUTxOForShelleyBasedEra'
+            -- can only be constructed by supplying an era-specific protocol
+            -- parameters record, it should be impossible to trigger this
+            -- condition.
+            --
+            -- Any violation of this assumption indicates a programming error.
+            -- If this condition is triggered, we have no way to continue, and
+            -- must raise an error:
+            --
             error $ unwords
                 [ "computeMinimumCoinForUTxO:"
                 , "unexpected error:"

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -121,10 +121,11 @@ computeMinimumCoinForShelleyBasedEra
 -- However, while we cannot underestimate minimum UTxO quantities, we are at
 -- liberty to moderately overestimate them.
 --
--- Since the minimum UTxO quantity function is monotonically increasing in the
--- serialized length of its input, if we supply a 'TxOut' with an address and
--- ada quantity whose serialized lengths are the maximum possible lengths, we
--- can be confident that the resultant value will not be an underestimate.
+-- Since the minimum UTxO quantity function is monotonically increasing w.r.t.
+-- the size of the address and ada quantity, if we supply a 'TxOut' with an
+-- address and ada quantity whose serialized lengths are the maximum possible
+-- lengths, we can be confident that the resultant value will not be an
+-- underestimate.
 --
 embedTokenMapWithinPaddedTxOut
     :: Cardano.ShelleyBasedEra era

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -120,6 +120,8 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (Coin, unCoin) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash )
+import Cardano.Wallet.Primitive.Types.MinimumUTxO
+    ( minimumUTxONone )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -865,6 +867,8 @@ fromBlockfrostPP network BF.ProtocolParams{..} = do
                     }
         , maximumCollateralInputCount = maxCollateralInputs
         , minimumCollateralPercentage = collateralPercent
+        -- TODO: Determine the appropriate value for this field:
+        , minimumUTxO = minimumUTxONone
         , currentNodeProtocolParameters =
             Just
                 Node.ProtocolParameters

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -94,7 +94,6 @@ import Cardano.Wallet.Primitive.Types
     , FeePolicy (LinearFee)
     , GenesisParameters (..)
     , LinearFunction (..)
-    , MinimumUTxOValue (..)
     , NetworkParameters (..)
     , PoolId
     , ProtocolParameters (..)
@@ -815,10 +814,6 @@ fromBlockfrostPP network BF.ProtocolParams{..} = do
         BF.unQuantity _protocolParamsMaxTxExMem <?#> "MaxTxExMem"
     desiredNumberOfStakePools <-
         _protocolParamsNOpt <?#> "NOpt"
-    minimumUTxOvalue <-
-        MinimumUTxOValueCostPerWord . Coin
-            <$> intCast @_ @Integer _protocolParamsCoinsPerUtxoWord
-            <?#> "CoinsPerUtxoWord"
     stakeKeyDeposit <-
         Coin
             <$> intCast @_ @Integer _protocolParamsKeyDeposit <?#> "KeyDeposit"

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Node.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Node.hs
@@ -78,6 +78,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( StandardCrypto
+    , fromAllegraPParams
     , fromAlonzoPParams
     , fromBabbagePParams
     , fromNonMyopicMemberRewards
@@ -714,7 +715,7 @@ mkTipSyncClient tr np onPParamsUpdate onInterpreterUpdate onEraUpdate = do
                     <$> LSQry Byron.GetUpdateInterfaceState)
                 (fromShelleyPParams eraBounds ppNode
                     <$> LSQry Shelley.GetCurrentPParams)
-                (fromShelleyPParams eraBounds ppNode
+                (fromAllegraPParams eraBounds ppNode
                     <$> LSQry Shelley.GetCurrentPParams)
                 (fromShelleyPParams eraBounds ppNode
                     <$> LSQry Shelley.GetCurrentPParams)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Node.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Node.hs
@@ -81,6 +81,7 @@ import Cardano.Wallet.Shelley.Compatibility
     , fromAllegraPParams
     , fromAlonzoPParams
     , fromBabbagePParams
+    , fromMaryPParams
     , fromNonMyopicMemberRewards
     , fromPoint
     , fromPoolDistr
@@ -717,7 +718,7 @@ mkTipSyncClient tr np onPParamsUpdate onInterpreterUpdate onEraUpdate = do
                     <$> LSQry Shelley.GetCurrentPParams)
                 (fromAllegraPParams eraBounds ppNode
                     <$> LSQry Shelley.GetCurrentPParams)
-                (fromShelleyPParams eraBounds ppNode
+                (fromMaryPParams eraBounds ppNode
                     <$> LSQry Shelley.GetCurrentPParams)
                 (fromAlonzoPParams eraBounds ppNode
                     <$> LSQry Shelley.GetCurrentPParams)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -178,7 +178,9 @@ import Cardano.Wallet.Shelley.Compatibility
     , toStakePoolDlgCert
     )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( computeMinimumAdaQuantity, toAlonzoTxOut, toBabbageTxOut )
+    ( toAlonzoTxOut, toBabbageTxOut )
+import Cardano.Wallet.Shelley.MinimumUTxO
+    ( computeMinimumCoinForUTxO )
 import Cardano.Wallet.Transaction
     ( AnyScript (..)
     , DelegationAction (..)
@@ -1496,7 +1498,7 @@ txConstraints era protocolParams witnessTag = TxConstraints
         TokenQuantity $ fromIntegral $ maxBound @Word64
 
     txOutputMinimumAdaQuantity =
-        computeMinimumAdaQuantity (minimumUTxOvalue protocolParams)
+        computeMinimumCoinForUTxO (minimumUTxO protocolParams)
 
     txRewardWithdrawalCost c =
         marginalCostOf empty {txRewardWithdrawal = c}

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -10,12 +9,10 @@ module Cardano.Wallet.Shelley.Compatibility.LedgerSpec
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types
-    ( MinimumUTxOValue (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( Flat (..), TokenBundle )
+    ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
@@ -26,50 +23,20 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantityFullRange, shrinkTokenQuantityFullRange )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( txOutMaxCoin
-    , txOutMaxTokenQuantity
-    , txOutMinCoin
-    , txOutMinTokenQuantity
-    )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxOutCoin, genTxOutTokenBundle, shrinkTxOutCoin )
+    ( genTxOutCoin, shrinkTxOutCoin )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( Convert (..), computeMinimumAdaQuantityInternal )
-import Data.Bifunctor
-    ( second )
+    ( Convert (..) )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Typeable
     ( Typeable, typeRep )
-import Data.Word
-    ( Word64 )
-import Fmt
-    ( pretty )
 import Test.Hspec
     ( Spec, describe, it, parallel )
 import Test.Hspec.Core.QuickCheck
     ( modifyMaxSuccess )
 import Test.QuickCheck
-    ( Arbitrary (..)
-    , Blind (..)
-    , Positive (..)
-    , Property
-    , checkCoverage
-    , conjoin
-    , counterexample
-    , cover
-    , genericShrink
-    , oneof
-    , property
-    , withMaxSuccess
-    , (=/=)
-    , (===)
-    )
-
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
-import qualified Data.Set as Set
+    ( Arbitrary (..), property, (===) )
 
 spec :: Spec
 spec = describe "Cardano.Wallet.Shelley.Compatibility.LedgerSpec" $
@@ -84,160 +51,9 @@ spec = describe "Cardano.Wallet.Shelley.Compatibility.LedgerSpec" $
         ledgerRoundtrip $ Proxy @TokenPolicyId
         ledgerRoundtrip $ Proxy @TokenQuantity
 
-    parallel $ describe "Properties for computeMinimumAdaQuantity" $ do
-
-        it "prop_computeMinimumAdaQuantity_forCoin" $
-            property prop_computeMinimumAdaQuantity_forCoin
-        it "prop_computeMinimumAdaQuantity_agnosticToAdaQuantity" $
-            property prop_computeMinimumAdaQuantity_agnosticToAdaQuantity
-        it "prop_computeMinimumAdaQuantity_agnosticToAssetQuantities" $
-            property prop_computeMinimumAdaQuantity_agnosticToAssetQuantities
-
-    parallel $ describe "Unit tests for computeMinimumAdaQuantity" $ do
-
-        it "unit_computeMinimumAdaQuantity_emptyBundle" $
-            property unit_computeMinimumAdaQuantity_emptyBundle
-        it "unit_computeMinimumAdaQuantity_fixedSizeBundle_8" $
-            property unit_computeMinimumAdaQuantity_fixedSizeBundle_8
-        it "unit_computeMinimumAdaQuantity_fixedSizeBundle_64" $
-            property unit_computeMinimumAdaQuantity_fixedSizeBundle_64
-        it "unit_computeMinimumAdaQuantity_fixedSizeBundle_256" $
-            property unit_computeMinimumAdaQuantity_fixedSizeBundle_256
-
---------------------------------------------------------------------------------
--- Properties
---------------------------------------------------------------------------------
-
-prop_computeMinimumAdaQuantity_forCoin
-    :: MinimumUTxOValue
-    -> Coin
-    -> Property
-prop_computeMinimumAdaQuantity_forCoin minParam c =
-    computeMinimumAdaQuantityInternal
-        minParam
-        (TokenBundle.fromCoin c)
-        === expectedMinimumAdaQuantity
-  where
-    expectedMinimumAdaQuantity = case minParam of
-        MinimumUTxOValue c' -> c'
-        MinimumUTxOValueCostPerWord (Coin x) -> Coin $ x * 29
-
-prop_computeMinimumAdaQuantity_agnosticToAdaQuantity
-    :: Blind TokenBundle
-    -> MinimumUTxOValue
-    -> Property
-prop_computeMinimumAdaQuantity_agnosticToAdaQuantity
-    (Blind bundle) minParam =
-        counterexample counterexampleText $ conjoin
-            [ compute bundle === compute bundleWithCoinMinimized
-            , compute bundle === compute bundleWithCoinMaximized
-            , bundleWithCoinMinimized =/= bundleWithCoinMaximized
-            ]
-  where
-    bundleWithCoinMinimized = TokenBundle.setCoin bundle txOutMinCoin
-    bundleWithCoinMaximized = TokenBundle.setCoin bundle txOutMaxCoin
-    compute = computeMinimumAdaQuantityInternal minParam
-    counterexampleText = unlines
-        [ "bundle:"
-        , pretty (Flat bundle)
-        , "bundle minimized:"
-        , pretty (Flat bundleWithCoinMinimized)
-        , "bundle maximized:"
-        , pretty (Flat bundleWithCoinMaximized)
-        ]
-
-prop_computeMinimumAdaQuantity_agnosticToAssetQuantities
-    :: Blind TokenBundle
-    -> MinimumUTxOValue
-    -> Property
-prop_computeMinimumAdaQuantity_agnosticToAssetQuantities
-    (Blind bundle) minVal =
-        checkCoverage $
-        cover 40 (assetCount >= 1)
-            "Token bundle has at least 1 non-ada asset" $
-        cover 20 (assetCount >= 2)
-            "Token bundle has at least 2 non-ada assets" $
-        cover 10 (assetCount >= 4)
-            "Token bundle has at least 4 non-ada assets" $
-        counterexample counterexampleText $ conjoin
-            [ compute bundle === compute bundleMinimized
-            , compute bundle === compute bundleMaximized
-            , assetCount === assetCountMinimized
-            , assetCount === assetCountMaximized
-            , if assetCount == 0
-                then bundleMinimized === bundleMaximized
-                else bundleMinimized =/= bundleMaximized
-            ]
-  where
-    assetCount = Set.size $ TokenBundle.getAssets bundle
-    assetCountMinimized = Set.size $ TokenBundle.getAssets bundleMinimized
-    assetCountMaximized = Set.size $ TokenBundle.getAssets bundleMaximized
-    bundleMinimized = bundle `setAllQuantitiesTo` txOutMinTokenQuantity
-    bundleMaximized = bundle `setAllQuantitiesTo` txOutMaxTokenQuantity
-    compute = computeMinimumAdaQuantityInternal minVal
-    setAllQuantitiesTo = flip (adjustAllQuantities . const)
-    counterexampleText = unlines
-        [ "bundle:"
-        , pretty (Flat bundle)
-        , "bundle minimized:"
-        , pretty (Flat bundleMinimized)
-        , "bundle maximized:"
-        , pretty (Flat bundleMaximized)
-        ]
-
---------------------------------------------------------------------------------
--- Unit tests
---------------------------------------------------------------------------------
-
--- | Creates a test to compute the minimum ada quantity for a token bundle with
---   a fixed number of assets, where the expected result is a constant.
---
--- Policy identifiers, asset names, token quantities are all allowed to vary.
---
-unit_computeMinimumAdaQuantity_fixedSizeBundle
-    :: TokenBundle
-    -- ^ Fixed size bundle
-    -> Coin
-    -- ^ Expected minimum ada quantity
-    -> Property
-unit_computeMinimumAdaQuantity_fixedSizeBundle bundle expectation =
-    withMaxSuccess 100 $
-    computeMinimumAdaQuantityInternal (MinimumUTxOValue protocolMinimum) bundle === expectation
-  where
-    protocolMinimum = Coin 1_000_000
-
-unit_computeMinimumAdaQuantity_emptyBundle :: Property
-unit_computeMinimumAdaQuantity_emptyBundle =
-    unit_computeMinimumAdaQuantity_fixedSizeBundle TokenBundle.empty $
-        Coin 1000000
-
-unit_computeMinimumAdaQuantity_fixedSizeBundle_8
-    :: Blind (FixedSize8 TokenBundle) -> Property
-unit_computeMinimumAdaQuantity_fixedSizeBundle_8 (Blind (FixedSize8 b)) =
-    unit_computeMinimumAdaQuantity_fixedSizeBundle b $
-        Coin 3888885
-
-unit_computeMinimumAdaQuantity_fixedSizeBundle_64
-    :: Blind (FixedSize64 TokenBundle) -> Property
-unit_computeMinimumAdaQuantity_fixedSizeBundle_64 (Blind (FixedSize64 b)) =
-    unit_computeMinimumAdaQuantity_fixedSizeBundle b $
-        Coin 22555533
-
-unit_computeMinimumAdaQuantity_fixedSizeBundle_256
-    :: Blind (FixedSize256 TokenBundle) -> Property
-unit_computeMinimumAdaQuantity_fixedSizeBundle_256 (Blind (FixedSize256 b)) =
-    unit_computeMinimumAdaQuantity_fixedSizeBundle b $
-        Coin 86555469
-
 --------------------------------------------------------------------------------
 -- Utilities
 --------------------------------------------------------------------------------
-
-adjustAllQuantities
-    :: (TokenQuantity -> TokenQuantity) -> TokenBundle -> TokenBundle
-adjustAllQuantities adjust b = uncurry TokenBundle.fromFlatList $ second
-    (fmap (fmap adjust))
-    (TokenBundle.toFlatList b)
 
 ledgerRoundtrip
     :: forall w l. (Arbitrary w, Eq w, Show w, Typeable w, Convert w l)
@@ -253,19 +69,6 @@ ledgerRoundtrip proxy = it title $
         ]
 
 --------------------------------------------------------------------------------
--- Adaptors
---------------------------------------------------------------------------------
-
-newtype FixedSize8 a = FixedSize8 { unFixedSize8 :: a }
-    deriving (Eq, Show)
-
-newtype FixedSize64 a = FixedSize64 { unFixedSize64 :: a }
-    deriving (Eq, Show)
-
-newtype FixedSize256 a = FixedSize256 { unFixedSize256 :: a }
-    deriving (Eq, Show)
-
---------------------------------------------------------------------------------
 -- Arbitraries
 --------------------------------------------------------------------------------
 
@@ -275,30 +78,9 @@ instance Arbitrary Coin where
     arbitrary = genTxOutCoin
     shrink = shrinkTxOutCoin
 
-instance Arbitrary MinimumUTxOValue where
-    arbitrary = oneof
-        [ MinimumUTxOValue . Coin.fromWord64 . (* 1_000_000) <$> genSmallWord
-        , MinimumUTxOValueCostPerWord . Coin.fromWord64 <$> genSmallWord
-        ]
-      where
-      genSmallWord = fromIntegral @Int @Word64 . getPositive <$> arbitrary
-    shrink = genericShrink
-
 instance Arbitrary TokenBundle where
     arbitrary = genTokenBundleSmallRange
     shrink = shrinkTokenBundleSmallRange
-
-instance Arbitrary (FixedSize8 TokenBundle) where
-    arbitrary = FixedSize8 <$> genTxOutTokenBundle 8
-    -- No shrinking
-
-instance Arbitrary (FixedSize64 TokenBundle) where
-    arbitrary = FixedSize64 <$> genTxOutTokenBundle 64
-    -- No shrinking
-
-instance Arbitrary (FixedSize256 TokenBundle) where
-    arbitrary = FixedSize256 <$> genTxOutTokenBundle 256
-    -- No shrinking
 
 instance Arbitrary TokenName where
     arbitrary = genTokenNameLargeRange

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -79,17 +79,25 @@ spec = do
             ]
 
     describe "computeMinimumCoinForUTxO" $ do
-        it "prop_computeMinimumCoinForUTxO" $
-            prop_computeMinimumCoinForUTxO
+        it "prop_computeMinimumCoinForUTxO_evaluation" $
+            prop_computeMinimumCoinForUTxO_evaluation
                 & property
         it "prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds" $
             prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
                 & property
 
-prop_computeMinimumCoinForUTxO :: MinimumUTxO -> TokenMap -> Property
-prop_computeMinimumCoinForUTxO minimumUTxO m = property $
+-- Check that it's possible to evaluate 'computeMinimumCoinForUTxO' without
+-- any run-time error.
+--
+prop_computeMinimumCoinForUTxO_evaluation
+    :: MinimumUTxO -> TokenMap -> Property
+prop_computeMinimumCoinForUTxO_evaluation minimumUTxO m = property $
+    -- Use an arbitrary test to force evaluation of the result:
     computeMinimumCoinForUTxO minimumUTxO m >= Coin 0
 
+-- Check that 'computeMinimumCoinForUTxO' produces a result that is within
+-- bounds, as determined by the Cardano API function 'calculateMinimumUTxO'.
+--
 prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
     :: TokenBundle
     -> Cardano.AddressAny

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -10,7 +10,7 @@ module Cardano.Wallet.Shelley.MinimumUTxOSpec
 import Prelude
 
 import Cardano.Api.Gen
-    ( genAddressShelley )
+    ( genAddressAny )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -37,7 +37,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxOut (..) )
 import Cardano.Wallet.Shelley.Compatibility
-    ( fromCardanoAddress, toCardanoTxOut )
+    ( toCardanoTxOut )
 import Cardano.Wallet.Shelley.MinimumUTxO
     ( computeMinimumCoinForUTxO
     , maxLengthAddress
@@ -92,7 +92,7 @@ prop_computeMinimumCoinForUTxO minimumUTxO m = property $
 
 prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
     :: TokenBundle
-    -> Cardano.Address Cardano.ShelleyAddr
+    -> Cardano.AddressAny
     -> MinimumUTxOForShelleyBasedEra
     -> Property
 prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
@@ -125,8 +125,8 @@ prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
             (BS.length (Cardano.serialiseToRawBytes addr))
             "BS.length (Cardano.serialiseToRawBytes addr))"
         & report
-            (BS.length (unAddress (fromCardanoAddress addr)))
-            "BS.length (unAddress (fromCardanoAddress addr))"
+            (BS.length (unAddress (fromCardanoAddressAny addr)))
+            "BS.length (unAddress (fromCardanoAddressAny addr))"
         & report
             (BS.length (unAddress maxLengthAddress))
             "BS.length (unAddress maxLengthAddress))"
@@ -142,7 +142,7 @@ prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
             Cardano.fromLedgerPParams era pp
 
         apiTxOutMinBound =
-            toCardanoTxOut era $ TxOut (fromCardanoAddress addr) tokenBundle
+            toCardanoTxOut era $ TxOut (fromCardanoAddressAny addr) tokenBundle
 
         apiTxOutMaxBound =
             toCardanoTxOut era $ TxOut maxLengthAddress $
@@ -154,11 +154,18 @@ prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
         (TokenBundle.tokens tokenBundle)
 
 --------------------------------------------------------------------------------
+-- Utility functions
+--------------------------------------------------------------------------------
+
+fromCardanoAddressAny :: Cardano.AddressAny -> Address
+fromCardanoAddressAny =  Address . Cardano.serialiseToRawBytes
+
+--------------------------------------------------------------------------------
 -- Arbitrary instances
 --------------------------------------------------------------------------------
 
-instance Arbitrary (Cardano.Address Cardano.ShelleyAddr) where
-    arbitrary = genAddressShelley
+instance Arbitrary Cardano.AddressAny where
+    arbitrary = genAddressAny
 
 instance Arbitrary TokenBundle where
     arbitrary = TokenBundle

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -529,5 +529,8 @@ instance Arbitrary MinimumUTxOForShelleyBasedEra where
     shrink = shrinkMinimumUTxOForShelleyBasedEra
 
 instance Arbitrary TokenMap where
-    arbitrary = genTokenMap
+    arbitrary = frequency
+        [ (4, genTokenMap)
+        , (1, elements goldenTokenMaps)
+        ]
     shrink = shrinkTokenMap

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -15,8 +15,6 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
-import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( chooseCoin, shrinkCoin )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO
     ( MinimumUTxO
     , MinimumUTxOForShelleyBasedEra (..)
@@ -30,12 +28,16 @@ import Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
+import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
+    ( shrinkTokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genTokenMap, shrinkTokenMap )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genTxOutTokenBundle )
 import Cardano.Wallet.Shelley.Compatibility
     ( toCardanoTxOut )
 import Cardano.Wallet.Shelley.MinimumUTxO
@@ -47,22 +49,14 @@ import Cardano.Wallet.Shelley.MinimumUTxO
     )
 import Data.Function
     ( (&) )
-import Data.IntCast
-    ( intCast )
-import Data.Word
-    ( Word64 )
-import Generics.SOP
-    ( NP (..) )
-import Numeric.Natural
-    ( Natural )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
-    ( Arbitrary (..), Property, property )
+    ( Arbitrary (..), Property, property, sized )
 import Test.QuickCheck.Classes
     ( eqLaws, showLaws )
 import Test.QuickCheck.Extra
-    ( genericRoundRobinShrink, report, verify, (<:>), (<@>) )
+    ( report, verify )
 import Test.Utils.Laws
     ( testLawsMany )
 
@@ -176,13 +170,8 @@ instance Arbitrary Cardano.AddressAny where
     arbitrary = genAddressAny
 
 instance Arbitrary TokenBundle where
-    arbitrary = TokenBundle
-        <$> chooseCoin (Coin 0, Coin $ intCast @Word64 @Natural $ maxBound)
-        <*> genTokenMap
-    shrink = genericRoundRobinShrink
-        <@> shrinkCoin
-        <:> shrinkTokenMap
-        <:> Nil
+    arbitrary = sized genTxOutTokenBundle
+    shrink = shrinkTokenBundle
 
 instance Arbitrary MinimumUTxO where
     arbitrary = genMinimumUTxO

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.Shelley.MinimumUTxOSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Api.Gen
+    ( genAddressShelley )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Coin.Gen
+    ( chooseCoin, shrinkCoin )
+import Cardano.Wallet.Primitive.Types.MinimumUTxO
+    ( MinimumUTxO
+    , ProtocolParametersForShelleyBasedEra (..)
+    , minimumUTxOForShelleyBasedEra
+    )
+import Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
+    ( genMinimumUTxO
+    , genProtocolParametersForShelleyBasedEra
+    , shrinkMinimumUTxO
+    , shrinkProtocolParametersForShelleyBasedEra
+    )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle (..) )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( TokenMap )
+import Cardano.Wallet.Primitive.Types.TokenMap.Gen
+    ( genTokenMap, shrinkTokenMap )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxOut (..) )
+import Cardano.Wallet.Shelley.Compatibility
+    ( fromCardanoAddress, toCardanoTxOut )
+import Cardano.Wallet.Shelley.MinimumUTxO
+    ( computeMinimumCoinForUTxO
+    , unsafeLovelaceToWalletCoin
+    , unsafeValueToLovelace
+    )
+import Data.Function
+    ( (&) )
+import Data.IntCast
+    ( intCast )
+import Data.Word
+    ( Word64 )
+import Generics.SOP
+    ( NP (..) )
+import Numeric.Natural
+    ( Natural )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Arbitrary (..), Property, property )
+import Test.QuickCheck.Classes
+    ( eqLaws, showLaws )
+import Test.QuickCheck.Extra
+    ( genericRoundRobinShrink, report, (<:>), (<@>) )
+import Test.Utils.Laws
+    ( testLawsMany )
+
+import qualified Cardano.Api.Shelley as Cardano
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Data.ByteString as BS
+
+spec :: Spec
+spec = do
+    describe "Class instances obey laws" $ do
+        testLawsMany @MinimumUTxO
+            [ eqLaws
+            , showLaws
+            ]
+
+    describe "computeMinimumCoinForUTxO" $ do
+        it "prop_computeMinimumCoinForUTxO" $
+            prop_computeMinimumCoinForUTxO
+                & property
+        it "prop_computeMinimumCoinForUTxO_shelleyBasedEra_lowerBound" $
+            prop_computeMinimumCoinForUTxO_shelleyBasedEra_lowerBound
+                & property
+
+prop_computeMinimumCoinForUTxO :: MinimumUTxO -> TokenMap -> Property
+prop_computeMinimumCoinForUTxO minimumUTxO m = property $
+    computeMinimumCoinForUTxO minimumUTxO m >= Coin 0
+
+prop_computeMinimumCoinForUTxO_shelleyBasedEra_lowerBound
+    :: TokenBundle
+    -> Cardano.Address Cardano.ShelleyAddr
+    -> ProtocolParametersForShelleyBasedEra
+    -> Property
+prop_computeMinimumCoinForUTxO_shelleyBasedEra_lowerBound
+    tokenBundle addr (ProtocolParametersForShelleyBasedEra era pp) =
+        case apiResultMaybe of
+            Left e -> error $ unwords
+                [ "Failed to obtain result from Cardano API:"
+                , show e
+                ]
+            Right value -> prop_inner
+                $ unsafeLovelaceToWalletCoin
+                $ unsafeValueToLovelace value
+  where
+    prop_inner :: Coin -> Property
+    prop_inner apiResult =
+        ourResult >= apiResult
+            & report
+                (apiResult)
+                "apiResult"
+            & report
+                (ourResult)
+                "ourResult"
+            & report
+                (BS.length (Cardano.serialiseToRawBytes addr))
+                "BS.length (Cardano.serialiseToRawBytes addr))"
+            & report
+                (BS.length (unAddress (fromCardanoAddress addr)))
+                "BS.length (unAddress (fromCardanoAddress addr))"
+
+    apiResultMaybe :: Either Cardano.MinimumUTxOError Cardano.Value
+    apiResultMaybe =
+        Cardano.calculateMinimumUTxO era apiTxOut apiProtocolParameters
+      where
+        apiTxOut =
+            toCardanoTxOut era $
+            TxOut (fromCardanoAddress addr) tokenBundle
+
+        apiProtocolParameters :: Cardano.ProtocolParameters
+        apiProtocolParameters =
+            Cardano.fromLedgerPParams era pp
+
+    ourResult :: Coin
+    ourResult = computeMinimumCoinForUTxO
+        (minimumUTxOForShelleyBasedEra era pp)
+        (TokenBundle.tokens tokenBundle)
+
+--------------------------------------------------------------------------------
+-- Arbitrary instances
+--------------------------------------------------------------------------------
+
+instance Arbitrary (Cardano.Address Cardano.ShelleyAddr) where
+    arbitrary = genAddressShelley
+
+instance Arbitrary TokenBundle where
+    arbitrary = TokenBundle
+        <$> chooseCoin (Coin 0, Coin $ intCast @Word64 @Natural $ maxBound)
+        <*> genTokenMap
+    shrink = genericRoundRobinShrink
+        <@> shrinkCoin
+        <:> shrinkTokenMap
+        <:> Nil
+
+instance Arbitrary MinimumUTxO where
+    arbitrary = genMinimumUTxO
+    shrink = shrinkMinimumUTxO
+
+instance Arbitrary ProtocolParametersForShelleyBasedEra where
+    arbitrary = genProtocolParametersForShelleyBasedEra
+    shrink = shrinkProtocolParametersForShelleyBasedEra
+
+instance Arbitrary TokenMap where
+    arbitrary = genTokenMap
+    shrink = shrinkTokenMap

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -1,7 +1,12 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{- HLINT ignore "Use camelCase" -}
 
 module Cardano.Wallet.Shelley.MinimumUTxOSpec
     ( spec
@@ -9,6 +14,8 @@ module Cardano.Wallet.Shelley.MinimumUTxOSpec
 
 import Prelude
 
+import Cardano.Api
+    ( ShelleyBasedEra (..) )
 import Cardano.Api.Gen
     ( genAddressAny )
 import Cardano.Wallet.Primitive.Types.Address
@@ -31,11 +38,15 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( shrinkTokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( TokenMap )
+    ( AssetId (..), TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genTokenMap, shrinkTokenMap )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenName (UnsafeTokenName) )
+import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
+    ( mkTokenPolicyId )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxOut (..) )
+    ( TxOut (..), txOutMaxTokenQuantity, txOutMinTokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTxOutTokenBundle )
 import Cardano.Wallet.Shelley.Compatibility
@@ -47,8 +58,16 @@ import Cardano.Wallet.Shelley.MinimumUTxO
     , unsafeLovelaceToWalletCoin
     , unsafeValueToLovelace
     )
+import Control.Monad
+    ( forM_ )
+import Data.Default
+    ( Default (..) )
 import Data.Function
     ( (&) )
+import Data.Generics.Internal.VL.Lens
+    ( view )
+import GHC.Generics
+    ( Generic )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
@@ -57,6 +76,8 @@ import Test.QuickCheck
     , checkCoverage
     , conjoin
     , cover
+    , elements
+    , frequency
     , property
     , sized
     )
@@ -66,10 +87,19 @@ import Test.QuickCheck.Extra
     ( report, verify )
 import Test.Utils.Laws
     ( testLawsMany )
+import Test.Utils.Pretty
+    ( (====) )
 
 import qualified Cardano.Api.Shelley as Cardano
+import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
+import qualified Cardano.Ledger.Babbage.PParams as Babbage
+import qualified Cardano.Ledger.Coin as Ledger
+import qualified Cardano.Ledger.Shelley.PParams as Shelley
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.ByteString as BS
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 
 spec :: Spec
 spec = do
@@ -80,15 +110,36 @@ spec = do
             ]
 
     describe "computeMinimumCoinForUTxO" $ do
-        it "prop_computeMinimumCoinForUTxO_evaluation" $
-            prop_computeMinimumCoinForUTxO_evaluation
-                & property
-        it "prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds" $
-            prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
-                & property
-        it "prop_computeMinimumCoinForUTxO_shelleyBasedEra_stability" $
-            prop_computeMinimumCoinForUTxO_shelleyBasedEra_stability
-                & property
+
+        describe "Properties" $ do
+
+            it "prop_computeMinimumCoinForUTxO_evaluation" $
+                prop_computeMinimumCoinForUTxO_evaluation
+                    & property
+            it "prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds" $
+                prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
+                    & property
+            it "prop_computeMinimumCoinForUTxO_shelleyBasedEra_stability" $
+                prop_computeMinimumCoinForUTxO_shelleyBasedEra_stability
+                    & property
+
+        describe "Golden Tests" $ do
+
+            goldenTests_computeMinimumCoinForUTxO "Shelley"
+                goldenMinimumUTxO_Shelley
+                goldenMinimumCoins_Shelley
+            goldenTests_computeMinimumCoinForUTxO "Allegra"
+                goldenMinimumUTxO_Allegra
+                goldenMinimumCoins_Allegra
+            goldenTests_computeMinimumCoinForUTxO "Mary"
+                goldenMinimumUTxO_Mary
+                goldenMinimumCoins_Mary
+            goldenTests_computeMinimumCoinForUTxO "Alonzo"
+                goldenMinimumUTxO_Alonzo
+                goldenMinimumCoins_Alonzo
+            goldenTests_computeMinimumCoinForUTxO "Babbage"
+                goldenMinimumUTxO_Babbage
+                goldenMinimumCoins_Babbage
 
 -- Check that it's possible to evaluate 'computeMinimumCoinForUTxO' without
 -- any run-time error.
@@ -236,6 +287,220 @@ prop_computeMinimumCoinForUTxO_shelleyBasedEra_stability
     ourComputeMinCoin :: TokenMap -> Coin
     ourComputeMinCoin =
         computeMinimumCoinForUTxO (minimumUTxOForShelleyBasedEra era pp)
+
+--------------------------------------------------------------------------------
+-- Golden tests
+--------------------------------------------------------------------------------
+
+goldenTests_computeMinimumCoinForUTxO
+    :: String
+    -- ^ The era name.
+    -> MinimumUTxO
+    -- ^ The minimum UTxO function.
+    -> [(TokenMap, Coin)]
+    -- ^ Mappings from 'TokenMap' values to expected minimum 'Coin' values.
+    -> Spec
+goldenTests_computeMinimumCoinForUTxO
+    eraName minimumUTxO expectedMinimumCoins =
+        goldenTests title
+            (uncurry computeMinimumCoinForUTxO)
+            (mkTest <$> expectedMinimumCoins)
+  where
+    mkTest
+        :: (TokenMap, Coin) -> GoldenTestData (MinimumUTxO, TokenMap) Coin
+    mkTest (tokenMap, coinExpected) = GoldenTestData
+        { params = (minimumUTxO, tokenMap)
+        , result = coinExpected
+        }
+    title = unwords
+        ["goldenTests_computeMinimumCoinForUTxO", eraName]
+
+--------------------------------------------------------------------------------
+-- Golden 'MinimumUTxO' values
+--------------------------------------------------------------------------------
+
+goldenMinimumUTxO_Shelley :: MinimumUTxO
+goldenMinimumUTxO_Shelley =
+    minimumUTxOForShelleyBasedEra ShelleyBasedEraShelley
+        -- Value derived from 'mainnet-shelley-genesis.json':
+        def {Shelley._minUTxOValue = Ledger.Coin 1_000_000}
+
+goldenMinimumUTxO_Allegra :: MinimumUTxO
+goldenMinimumUTxO_Allegra =
+    minimumUTxOForShelleyBasedEra ShelleyBasedEraAllegra
+        -- Value derived from 'mainnet-shelley-genesis.json':
+        def {Shelley._minUTxOValue = Ledger.Coin 1_000_000}
+
+goldenMinimumUTxO_Mary :: MinimumUTxO
+goldenMinimumUTxO_Mary =
+    minimumUTxOForShelleyBasedEra ShelleyBasedEraMary
+        -- Value derived from 'mainnet-shelley-genesis.json':
+        def {Shelley._minUTxOValue = Ledger.Coin 1_000_000}
+
+goldenMinimumUTxO_Alonzo :: MinimumUTxO
+goldenMinimumUTxO_Alonzo =
+    minimumUTxOForShelleyBasedEra ShelleyBasedEraAlonzo
+        -- Value derived from 'mainnet-alonzo-genesis.json':
+        def {Alonzo._coinsPerUTxOWord = Ledger.Coin 34_482}
+
+goldenMinimumUTxO_Babbage :: MinimumUTxO
+goldenMinimumUTxO_Babbage =
+    minimumUTxOForShelleyBasedEra ShelleyBasedEraBabbage
+        -- Value derived from 'mainnet-alonzo-genesis.json':
+        def {Babbage._coinsPerUTxOByte = Ledger.Coin 4_310}
+
+--------------------------------------------------------------------------------
+-- Golden minimum 'Coin' values
+--------------------------------------------------------------------------------
+
+goldenMinimumCoins_Shelley :: [(TokenMap, Coin)]
+goldenMinimumCoins_Shelley =
+    [ (goldenTokenMap_0, Coin 1_000_000)
+    , (goldenTokenMap_1, Coin 1_000_000)
+    , (goldenTokenMap_2, Coin 1_000_000)
+    , (goldenTokenMap_3, Coin 1_000_000)
+    , (goldenTokenMap_4, Coin 1_000_000)
+    ]
+
+goldenMinimumCoins_Allegra :: [(TokenMap, Coin)]
+goldenMinimumCoins_Allegra =
+    [ (goldenTokenMap_0, Coin 1_000_000)
+    , (goldenTokenMap_1, Coin 1_000_000)
+    , (goldenTokenMap_2, Coin 1_000_000)
+    , (goldenTokenMap_3, Coin 1_000_000)
+    , (goldenTokenMap_4, Coin 1_000_000)
+    ]
+
+goldenMinimumCoins_Mary :: [(TokenMap, Coin)]
+goldenMinimumCoins_Mary =
+    [ (goldenTokenMap_0, Coin 1_000_000)
+    , (goldenTokenMap_1, Coin 1_444_443)
+    , (goldenTokenMap_2, Coin 1_555_554)
+    , (goldenTokenMap_3, Coin 1_740_739)
+    , (goldenTokenMap_4, Coin 1_999_998)
+    ]
+
+goldenMinimumCoins_Alonzo :: [(TokenMap, Coin)]
+goldenMinimumCoins_Alonzo =
+    [ (goldenTokenMap_0, Coin   999_978)
+    , (goldenTokenMap_1, Coin 1_344_798)
+    , (goldenTokenMap_2, Coin 1_448_244)
+    , (goldenTokenMap_3, Coin 1_620_654)
+    , (goldenTokenMap_4, Coin 1_862_028)
+    ]
+
+goldenMinimumCoins_Babbage :: [(TokenMap, Coin)]
+goldenMinimumCoins_Babbage =
+    [ (goldenTokenMap_0, Coin   995_610)
+    , (goldenTokenMap_1, Coin 1_150_770)
+    , (goldenTokenMap_2, Coin 1_323_170)
+    , (goldenTokenMap_3, Coin 1_323_170)
+    , (goldenTokenMap_4, Coin 2_012_770)
+    ]
+
+--------------------------------------------------------------------------------
+-- Golden 'TokenMap' values
+--------------------------------------------------------------------------------
+
+goldenTokenMaps :: [TokenMap]
+goldenTokenMaps =
+    [ goldenTokenMap_0
+    , goldenTokenMap_1
+    , goldenTokenMap_2
+    , goldenTokenMap_3
+    , goldenTokenMap_4
+    ]
+
+goldenTokenMap_0 :: TokenMap
+goldenTokenMap_0 = TokenMap.empty
+
+goldenTokenMap_1 :: TokenMap
+goldenTokenMap_1 = TokenMap.fromFlatList
+    [ (goldenAssetId_A_1_short, txOutMinTokenQuantity)
+    ]
+
+goldenTokenMap_2 :: TokenMap
+goldenTokenMap_2 = TokenMap.fromFlatList
+    [ (goldenAssetId_A_1_long, txOutMaxTokenQuantity)
+    ]
+
+goldenTokenMap_3 :: TokenMap
+goldenTokenMap_3 = TokenMap.fromFlatList
+    [ (goldenAssetId_A_1_short, txOutMinTokenQuantity)
+    , (goldenAssetId_A_2_short, txOutMinTokenQuantity)
+    , (goldenAssetId_B_1_short, txOutMinTokenQuantity)
+    , (goldenAssetId_B_2_short, txOutMinTokenQuantity)
+    ]
+
+goldenTokenMap_4 :: TokenMap
+goldenTokenMap_4 = TokenMap.fromFlatList
+    [ (goldenAssetId_A_1_long, txOutMaxTokenQuantity)
+    , (goldenAssetId_A_2_long, txOutMaxTokenQuantity)
+    , (goldenAssetId_B_1_long, txOutMaxTokenQuantity)
+    , (goldenAssetId_B_2_long, txOutMaxTokenQuantity)
+    ]
+
+--------------------------------------------------------------------------------
+-- Golden 'AssetId' values
+--------------------------------------------------------------------------------
+
+goldenAssetId_A_1_short :: AssetId
+goldenAssetId_A_1_short = mkAssetId 'A' "1"
+
+goldenAssetId_A_2_short :: AssetId
+goldenAssetId_A_2_short = mkAssetId 'A' "2"
+
+goldenAssetId_B_1_short :: AssetId
+goldenAssetId_B_1_short = mkAssetId 'B' "1"
+
+goldenAssetId_B_2_short :: AssetId
+goldenAssetId_B_2_short = mkAssetId 'B' "2"
+
+goldenAssetId_A_1_long :: AssetId
+goldenAssetId_A_1_long = mkAssetId 'A' (replicate 32 '1')
+
+goldenAssetId_A_2_long :: AssetId
+goldenAssetId_A_2_long = mkAssetId 'A' (replicate 32 '2')
+
+goldenAssetId_B_1_long :: AssetId
+goldenAssetId_B_1_long = mkAssetId 'B' (replicate 32 '1')
+
+goldenAssetId_B_2_long :: AssetId
+goldenAssetId_B_2_long = mkAssetId 'B' (replicate 32 '2')
+
+mkAssetId :: Char -> String -> AssetId
+mkAssetId pid name = AssetId
+    (mkTokenPolicyId pid)
+    (UnsafeTokenName $ T.encodeUtf8 $ T.pack name)
+
+--------------------------------------------------------------------------------
+-- Golden test support
+--------------------------------------------------------------------------------
+
+data GoldenTestData params result = GoldenTestData
+    { params :: params
+    , result :: result
+    }
+    deriving (Eq, Generic, Show)
+
+goldenTests
+    :: (Eq result, Show result)
+    => String
+    -> (params -> result)
+    -> [GoldenTestData params result]
+    -> Spec
+goldenTests title f goldenTestData =
+    describe title $
+    forM_ (zip testNumbers goldenTestData) $
+        \(testNumber :: Int, test) -> do
+            let subtitle = "golden test #" <> show testNumber
+            it subtitle $
+                let resultExpected = view #result test in
+                let resultActual = f (view #params test) in
+                property $ resultExpected ==== resultActual
+  where
+    testNumbers :: [Int]
+    testNumbers = [0 ..]
 
 --------------------------------------------------------------------------------
 -- Utility functions

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -19,14 +19,14 @@ import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( chooseCoin, shrinkCoin )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO
     ( MinimumUTxO
-    , ProtocolParametersForShelleyBasedEra (..)
+    , MinimumUTxOForShelleyBasedEra (..)
     , minimumUTxOForShelleyBasedEra
     )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
     ( genMinimumUTxO
-    , genProtocolParametersForShelleyBasedEra
+    , genMinimumUTxOForShelleyBasedEra
     , shrinkMinimumUTxO
-    , shrinkProtocolParametersForShelleyBasedEra
+    , shrinkMinimumUTxOForShelleyBasedEra
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
@@ -91,10 +91,10 @@ prop_computeMinimumCoinForUTxO minimumUTxO m = property $
 prop_computeMinimumCoinForUTxO_shelleyBasedEra_lowerBound
     :: TokenBundle
     -> Cardano.Address Cardano.ShelleyAddr
-    -> ProtocolParametersForShelleyBasedEra
+    -> MinimumUTxOForShelleyBasedEra
     -> Property
 prop_computeMinimumCoinForUTxO_shelleyBasedEra_lowerBound
-    tokenBundle addr (ProtocolParametersForShelleyBasedEra era pp) =
+    tokenBundle addr (MinimumUTxOForShelleyBasedEra era pp) =
         case apiResultMaybe of
             Left e -> error $ unwords
                 [ "Failed to obtain result from Cardano API:"
@@ -157,9 +157,9 @@ instance Arbitrary MinimumUTxO where
     arbitrary = genMinimumUTxO
     shrink = shrinkMinimumUTxO
 
-instance Arbitrary ProtocolParametersForShelleyBasedEra where
-    arbitrary = genProtocolParametersForShelleyBasedEra
-    shrink = shrinkProtocolParametersForShelleyBasedEra
+instance Arbitrary MinimumUTxOForShelleyBasedEra where
+    arbitrary = genMinimumUTxOForShelleyBasedEra
+    shrink = shrinkMinimumUTxOForShelleyBasedEra
 
 instance Arbitrary TokenMap where
     arbitrary = genTokenMap

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -215,6 +215,14 @@ prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
 -- - the Cardano API function 'calculateMinimumUTxO'
 -- - the wallet function 'computeMinimumCoinForUTxO'
 --
+-- In particular, we:
+--
+-- Demonstrate that applying the Cardano API function to its own result can
+-- lead to an increase in the ada quantity.
+--
+-- Demonstrate that applying the Cardano API function to the result of the
+-- wallet function does not lead to an increase in the ada quantity.
+--
 prop_computeMinimumCoinForUTxO_shelleyBasedEra_stability
     :: TokenMap
     -> Cardano.AddressAny

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -31,6 +31,11 @@ import Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
     , genMinimumUTxOForShelleyBasedEra
     , shrinkMinimumUTxO
     , shrinkMinimumUTxOForShelleyBasedEra
+    , testParameter_coinsPerUTxOByte_Babbage
+    , testParameter_coinsPerUTxOWord_Alonzo
+    , testParameter_minUTxOValue_Allegra
+    , testParameter_minUTxOValue_Mary
+    , testParameter_minUTxOValue_Shelley
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
@@ -86,7 +91,6 @@ import Test.Utils.Laws
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
 import qualified Cardano.Ledger.Babbage.PParams as Babbage
-import qualified Cardano.Ledger.Coin as Ledger
 import qualified Cardano.Ledger.Shelley.PParams as Shelley
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
@@ -323,33 +327,27 @@ goldenTests_computeMinimumCoinForUTxO
 goldenMinimumUTxO_Shelley :: MinimumUTxO
 goldenMinimumUTxO_Shelley =
     minimumUTxOForShelleyBasedEra ShelleyBasedEraShelley
-        -- Value derived from 'mainnet-shelley-genesis.json':
-        def {Shelley._minUTxOValue = Ledger.Coin 1_000_000}
+        def {Shelley._minUTxOValue = testParameter_minUTxOValue_Shelley}
 
 goldenMinimumUTxO_Allegra :: MinimumUTxO
 goldenMinimumUTxO_Allegra =
     minimumUTxOForShelleyBasedEra ShelleyBasedEraAllegra
-        -- Value derived from 'mainnet-shelley-genesis.json':
-        def {Shelley._minUTxOValue = Ledger.Coin 1_000_000}
+        def {Shelley._minUTxOValue = testParameter_minUTxOValue_Allegra}
 
 goldenMinimumUTxO_Mary :: MinimumUTxO
 goldenMinimumUTxO_Mary =
     minimumUTxOForShelleyBasedEra ShelleyBasedEraMary
-        -- Value derived from 'mainnet-shelley-genesis.json':
-        def {Shelley._minUTxOValue = Ledger.Coin 1_000_000}
+        def {Shelley._minUTxOValue = testParameter_minUTxOValue_Mary}
 
 goldenMinimumUTxO_Alonzo :: MinimumUTxO
 goldenMinimumUTxO_Alonzo =
     minimumUTxOForShelleyBasedEra ShelleyBasedEraAlonzo
-        -- Value derived from 'mainnet-alonzo-genesis.json':
-        def {Alonzo._coinsPerUTxOWord = Ledger.Coin 34_482}
+        def {Alonzo._coinsPerUTxOWord = testParameter_coinsPerUTxOWord_Alonzo}
 
 goldenMinimumUTxO_Babbage :: MinimumUTxO
 goldenMinimumUTxO_Babbage =
     minimumUTxOForShelleyBasedEra ShelleyBasedEraBabbage
-        -- Value derived from 'mainnet-alonzo-genesis.json':
-        -- >>> 34_482 `div` 8 == 4_310
-        def {Babbage._coinsPerUTxOByte = Ledger.Coin 4_310}
+        def {Babbage._coinsPerUTxOByte = testParameter_coinsPerUTxOByte_Babbage}
 
 --------------------------------------------------------------------------------
 -- Golden minimum 'Coin' values

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -340,6 +340,7 @@ goldenMinimumUTxO_Babbage :: MinimumUTxO
 goldenMinimumUTxO_Babbage =
     minimumUTxOForShelleyBasedEra ShelleyBasedEraBabbage
         -- Value derived from 'mainnet-alonzo-genesis.json':
+        -- >>> 34_482 `div` 8 == 4_310
         def {Babbage._coinsPerUTxOByte = Ledger.Coin 4_310}
 
 --------------------------------------------------------------------------------

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -161,6 +161,8 @@ import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoin, genCoinPositive, shrinkCoin, shrinkCoinPositive )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..), mockHash )
+import Cardano.Wallet.Primitive.Types.MinimumUTxO
+    ( MinimumUTxO (..) )
 import Cardano.Wallet.Primitive.Types.Redeemer
     ( Redeemer (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
@@ -2133,6 +2135,8 @@ dummyProtocolParameters = ProtocolParameters
         error "dummyProtocolParameters: txParameters"
     , desiredNumberOfStakePools =
         error "dummyProtocolParameters: desiredNumberOfStakePools"
+    , minimumUTxO =
+        error "dummyProtocolParameters: minimumUTxO"
     , minimumUTxOvalue =
         error "dummyProtocolParameters: minimumUTxOvalue"
     , stakeKeyDeposit =
@@ -2181,6 +2185,7 @@ mockProtocolParameters = dummyProtocolParameters
         , getTokenBundleMaxSize = TokenBundleMaxSize $ TxSize 4000
         , getMaxExecutionUnits = ExecutionUnits 10_000_000_000 14_000_000
         }
+    , minimumUTxO = MinimumUTxOConstant $ Coin 1000000
     , minimumUTxOvalue = MinimumUTxOValue $ Coin 1000000
     , maximumCollateralInputCount = 3
     , minimumCollateralPercentage = 150

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -143,7 +143,6 @@ import Cardano.Wallet.Primitive.Types
     , FeePolicy (..)
     , GenesisParameters (..)
     , LinearFunction (..)
-    , MinimumUTxOValue (..)
     , PoolId (PoolId)
     , ProtocolParameters (..)
     , SlotLength (SlotLength)
@@ -2137,8 +2136,6 @@ dummyProtocolParameters = ProtocolParameters
         error "dummyProtocolParameters: desiredNumberOfStakePools"
     , minimumUTxO =
         error "dummyProtocolParameters: minimumUTxO"
-    , minimumUTxOvalue =
-        error "dummyProtocolParameters: minimumUTxOvalue"
     , stakeKeyDeposit =
         error "dummyProtocolParameters: stakeKeyDeposit"
     , eras =
@@ -2186,7 +2183,6 @@ mockProtocolParameters = dummyProtocolParameters
         , getMaxExecutionUnits = ExecutionUnits 10_000_000_000 14_000_000
         }
     , minimumUTxO = MinimumUTxOConstant $ Coin 1000000
-    , minimumUTxOvalue = MinimumUTxOValue $ Coin 1000000
     , maximumCollateralInputCount = 3
     , minimumCollateralPercentage = 150
     }

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -543,7 +543,7 @@ report a name = counterexample $
 --
 -- On failure, reports the name of the condition that failed.
 --
-verify :: Bool -> String -> Property -> Property
+verify :: Testable t => Bool -> String -> t -> Property
 verify condition conditionTitle =
     (.&&.) (counterexample counterexampleText $ property condition)
   where


### PR DESCRIPTION
## Issue Number 

ADP-1978

## Summary

This PR uses the Cardano API function [`calculateMinimumUTxO`](https://github.com/input-output-hk/cardano-node/blob/42809ad3d420f0695eb147d4c66b90573d27cafd/cardano-api/src/Cardano/Api/Fees.hs#L1226) to replace our hand-coded [`computeMinimumAdaQuantity`](https://github.com/input-output-hk/cardano-wallet/blob/4f0b2f3c3cb9af139029418f4a2ebeb166fd0691/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs#L121) function.

## Goals

1. **Ensure that we cannot underestimate minimum UTxO values.** 
    _It's imperative that we do not underestimate minimum UTxO quantities, as this may result in the creation of transactions that are unacceptable to the ledger. In the case of change generation, this would be particularly problematic, as change outputs are generated automatically, and users do not have direct control over the ada quantities generated._
    
2. **Decrease the complexity and fragility of minimum UTxO calculations within the wallet.**
    _The current design makes it trivial to specify a minimum UTxO function that's inappropriate for the era in which a transaction will be submitted. Using the wrong minimum UTxO function makes it possible to create transactions that will ultimately be rejected by the ledger._

## Design

We replace the existing `MinimumUTxOValue` type with the following pair of types:
```hs
data MinimumUTxO where
    MinimumUTxONone
        :: MinimumUTxO
    MinimumUTxOConstant
        :: Coin
        -> MinimumUTxO
    MinimumUTxOForShelleyBasedEraOf
        :: MinimumUTxOForShelleyBasedEra
        -> MinimumUTxO

data MinimumUTxOForShelleyBasedEra where
    MinimumUTxOForShelleyBasedEra
        :: ShelleyBasedEra era
        -> PParams (ShelleyLedgerEra era)
        -> MinimumUTxOForShelleyBasedEra
```
Where:
> - `MinimumUTxONone`
>     _Specifies that there is no minimum UTxO value._
> - `MinimumUTxOConstant`
>     _Specifies a constant minimum UTxO value._
> - `MinimumUTxOForShelleyBasedEra`
>     _Represents a minimum UTxO function for a Shelley-based era. Ensures that values can only be constructed with a set of protocol parameters that are specific to the given era._

Furthermore, we make the following change to `Primitive.Types.ProtocolParameters`:
```patch
-    , minimumUTxOvalue
-        :: MinimumUTxOValue
-        -- ^ The minimum UTxO value.
+    , minimumUTxO
+        :: MinimumUTxO
+        -- ^ Represents a way of calculating minimum UTxO values.
```

Finally, we introduce function [`computeMinimumCoinForUTxO`](https://github.com/input-output-hk/cardano-wallet/blob/a2c414ad3e44d1af900280b9a890bb398783e400/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs#L51):
```hs
computeMinimumCoinForUTxO :: MinimumUTxO -> TokenMap -> Coin
```
This function computes a minimum `Coin`value for a `TokenMap` that is destined for inclusion in a transaction output.

We use the above function to re-implement [`Shelley.Transaction.constraints.txOutputMinimumAdaQuantity`](https://github.com/input-output-hk/cardano-wallet/blob/a2c414ad3e44d1af900280b9a890bb398783e400/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs#L1500), which means that both the coin selection and migration algorithms will take advantage of this updated implementation.

## Completed QA Tasks
- [x] Transfer our existing test coverage of [`computeMinimumAdaQuantity`](https://github.com/input-output-hk/cardano-wallet/blob/4f0b2f3c3cb9af139029418f4a2ebeb166fd0691/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs#L121) (including [golden tests](https://github.com/input-output-hk/cardano-wallet/blob/a2c414ad3e44d1af900280b9a890bb398783e400/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs#L288)) to [`computeMinimumCoinForUTxO`](https://github.com/input-output-hk/cardano-wallet/blob/a2c414ad3e44d1af900280b9a890bb398783e400/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs#L51).
- [x] Verify that our minimum UTxO calculation is stable w.r.t. to the starting ada quantity. In particular, it should obey the following property:
     - if we call [`computeMinimumCoinForUTxO`](https://github.com/input-output-hk/cardano-wallet/blob/a2c414ad3e44d1af900280b9a890bb398783e400/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs#L51) and receive `Coin` value `c1`
     - if we call the Cardano API function [`calculateMinimumUTxO`](https://github.com/input-output-hk/cardano-node/blob/42809ad3d420f0695eb147d4c66b90573d27cafd/cardano-api/src/Cardano/Api/Fees.hs#L1226) with `Coin` value `c1` and receive `Coin` value `c2`
     - then `c2` **_must not_** be greater than `c1`.
   (See [`prop_computeMinimumCoinForUTxO_shelleyBasedEra_stability`](https://github.com/input-output-hk/cardano-wallet/blob/a2c414ad3e44d1af900280b9a890bb398783e400/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs#L213).)
- [x] Determine what level of test coverage is applied to the Cardano API function [`calculateMinimumUTxO`](https://github.com/input-output-hk/cardano-node/blob/42809ad3d420f0695eb147d4c66b90573d27cafd/cardano-api/src/Cardano/Api/Fees.hs#L1226). Ensure that we build appropriate test coverage to cover any deficits.
- [x] Ensure that we have test coverage to cover all valid lengths of addresses.
- [x] Ensure that we have test coverage to characterize the effect of different coin sizes (up to the limit of `txOutMaxCoin`).
- [x] Ensure that we have test coverage to characterize the effect of different token quantities (up to the limit of `txOutMaxTokenQuantity`).

## Completed Implementation Tasks

- [x] Determine the most appropriate way to initialize field `minimumUTxO` within function `fromBlockfrostPP`. See 3c035604572b3a0805864d5493ebc4a409f391cb and ADP-1994.
- [x] Remove type `MinimumUTxOValue` from `Primitive.Types`.
- [x] Remove function [`computeMinimumAdaQuantity`](https://github.com/input-output-hk/cardano-wallet/blob/4f0b2f3c3cb9af139029418f4a2ebeb166fd0691/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs#L121) and associated tests.

## Completed Admin Tasks 

- [x] Create a ticket to review and revise the behaviour of the Blockfrost protocol parameter conversion function so that it does not hard-code the choice of minimum UTxO function to the Alonzo era (which uses a coins-per-word calculation). See ADP-1994.
- [x] Create an issue on `cardano-node` to report the fact that the [`calculateMinimumUTxO`](https://github.com/input-output-hk/cardano-node/blob/42809ad3d420f0695eb147d4c66b90573d27cafd/cardano-api/src/Cardano/Api/Fees.hs#L1226) function does not appear to reach a fixed point before returning its result. (See https://github.com/input-output-hk/cardano-node/issues/4163). The current behaviour appears to be as follows:
    - If we call `calculateMinimumUTxO` with `Coin 0` and get `Coin a` back.
    - If we call `calculateMinimumUTxO` with `Coin a` and get `Coin b` back.
    - It's possible for `b` to be greater than `a`.