### PR TITLE
Add `checkpointPolicy` field to `ChainFollower`

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -971,7 +971,7 @@ restoreWallet
     -> ExceptT ErrNoSuchWallet IO ()
 restoreWallet ctx wid = db & \DBLayer{..} ->
     let checkpointPolicy = CP.defaultPolicy
-        readChainPoints = liftIO $ atomically $ listCheckpoints wid
+        readChainPoints = atomically $ listCheckpoints wid
         rollBackward =
             throwInIO . rollbackBlocks @_ @s @k ctx wid . toSlot
         rollForward' = \blockdata tip -> throwInIO $

--- a/lib/core/src/Cardano/Wallet/Checkpoints/Policy.hs
+++ b/lib/core/src/Cardano/Wallet/Checkpoints/Policy.hs
@@ -16,6 +16,7 @@ module Cardano.Wallet.Checkpoints.Policy
     , atTip
     , trailingArithmetic
     , sparseArithmetic
+    , defaultPolicy
     , gapSize
 
     -- * Internal invariants
@@ -180,6 +181,10 @@ sparseArithmetic epochStability =
   where
     largeGap = gapSize epochStability
     n = epochStability `div` largeGap
+
+-- | A sensible default checkpoint policy; currently 'sparseArithmetic'.
+defaultPolicy :: BlockHeight -> CheckpointPolicy
+defaultPolicy = sparseArithmetic
 
 {- | A reasonable gap size used internally in 'sparseArithmeticPolicy'.
 

--- a/lib/shelley/bench/restore-bench.hs
+++ b/lib/shelley/bench/restore-bench.hs
@@ -84,7 +84,7 @@ import Cardano.Wallet.Logging
     ( trMessageText )
 import Cardano.Wallet.Network
     ( ChainFollowLog (..)
-    , ChainFollower (ChainFollower, readChainPoints, rollBackward, rollForward)
+    , ChainFollower (..)
     , ChainSyncLog (..)
     , NetworkLayer (..)
     )
@@ -247,6 +247,7 @@ import UnliftIO.Temporary
     ( withSystemTempFile )
 
 import qualified Cardano.Wallet as W
+import qualified Cardano.Wallet.Checkpoints.Policy as CP
 import qualified Cardano.Wallet.DB.Layer as Sqlite
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Byron as Byron
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Shelley
@@ -708,7 +709,8 @@ bench_baseline_restoration
         synchronizer <- async
             $ chainSync nw nullTracer
             $ ChainFollower
-            { readChainPoints  = readTVarIO chainPointT
+            { checkpointPolicy = const CP.atTip
+            , readChainPoints  = readTVarIO chainPointT
             , rollForward = \blocks ntip -> do
                 atomically $ writeTVar chainPointT
                     [chainPointFromBlockHeader ntip]

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Node.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Node.hs
@@ -56,7 +56,7 @@ import Cardano.Wallet.Logging
     ( BracketLog, bracketTracer, produceTimings )
 import Cardano.Wallet.Network
     ( ChainFollowLog (..)
-    , ChainFollower (..)
+    , ChainFollower
     , ChainSyncLog (..)
     , ErrPostTx (..)
     , NetworkLayer (..)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -231,6 +231,7 @@ import qualified Blockfrost.Client as BF
 import qualified Cardano.Pool.DB as PoolDb
 import qualified Cardano.Pool.DB.Sqlite as Pool
 import qualified Cardano.Wallet.Api.Types as Api
+import qualified Cardano.Wallet.Checkpoints.Policy as CP
 import qualified Cardano.Wallet.Shelley.Network.Blockfrost.Monad as BFM
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
@@ -728,7 +729,8 @@ monitorStakePools tr (NetworkParameters gp sp _pp) nl DBLayer{..} =
             toChainPoint (BlockHeader sl _ h _) = ChainPoint sl h
 
         chainSync nl (contramap MsgChainMonitoring tr) $ ChainFollower
-            { readChainPoints = map toChainPoint <$> initCursor
+            { checkpointPolicy = CP.defaultPolicy
+            , readChainPoints = map toChainPoint <$> initCursor
             , rollForward  = rollForward
             , rollBackward = rollback
             }


### PR DESCRIPTION
### Issue number

ADP-1497

### Overview

In this pull request, we add a `checkpointPolicy` field to the `ChainFollower` type.

This policy enables any chain synchronizer which does *not* retrieve full blocks — such as `lightSync` — to target those block heights at which the follower makes checkpoints.

ℹ️  This pull request only changes the `ChainFollower` type — incorporating this new information into the `lightSync` algorithm is left for a future pull request.

### Details

* We also add a `defaultPolicy` to `Cardano.Wallet.Checkpoints` in order to reduce cognitive burden in the places where a `ChainFollower` is constructed.

### Comments

* It would be better to adjust the `lightSync` algorithm before merging #3369 — otherwise, no good checkpoints will be created in light-mode. That said, light-mode may be so fast that it can work without checkpoints.