### PR TITLE
[CAD-4708] UTxO-HD: Limit LMDB max_mapsize in Windows

### DIFF
--- a/lib/launcher/src/Cardano/Launcher/Node.hs
+++ b/lib/launcher/src/Cardano/Launcher/Node.hs
@@ -133,6 +133,9 @@ cardanoNodeProcess cfg socketPath = do
         , "--topology", nodeTopologyFile cfg
         , "--database-path", nodeDatabaseDir cfg
         , "--socket-path", socketPath
+        -- UTxO-HD configurations
+        , "--lmdb-ledger-db-backend"
+        , "--lmdb-mapsize", "2Gi"
         ]
         ++ opt "--port" (show . unNodePort <$> nodePort cfg)
         ++ opt "--signing-key" (nodeSignKeyFile cfg)


### PR DESCRIPTION
Due to the 0.9.29 version of LMDB preallocating the whole mapsize at
once on Windows, the local-cluster executable fails to start with a null
pointer dereference. Limiting the mapsize to a lower value solves this
for now.

### Issue Number

CAD-4708
