### PR TITLE
Construct tx for multisig wallet

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -118,8 +118,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-addresses
-    tag: b6f2f3cef01a399376064194fd96711a5bdba4a7
-    --sha256: 10yj47gay72kx6v564qlfiigggcpqfdzrg61ii8p25m5n8ijz045
+    tag: ee4f4fc14f2aad6b518a4094c0ef6b878b8ed000
+    --sha256: 053cxq7ld9bav3z7dxyqnc7yagxyf9af73knsc4ccqfk4wy6ac0s
     subdir: command-line
             core
 

--- a/cabal.project
+++ b/cabal.project
@@ -118,8 +118,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-addresses
-    tag: ee4f4fc14f2aad6b518a4094c0ef6b878b8ed000
-    --sha256: 053cxq7ld9bav3z7dxyqnc7yagxyf9af73knsc4ccqfk4wy6ac0s
+    tag: 4a369086471d0849d40ba384ca39a4ab94f23d82
+    --sha256: 1rxbaycknxaadyrwn1knlz0mp1mwavm2kcw7dmp1pyb6ifrq62iq
     subdir: command-line
             core
 

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -119,6 +119,7 @@ library
       Test.Integration.Scenario.API.Shelley.Wallets
       Test.Integration.Scenario.API.Shared.Wallets
       Test.Integration.Scenario.API.Shared.Addresses
+      Test.Integration.Scenario.API.Shared.Transactions
       Test.Integration.Scenario.API.Network
       Test.Integration.Scenario.CLI.Byron.Wallets
       Test.Integration.Scenario.CLI.Byron.Addresses

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -114,6 +114,7 @@ module Test.Integration.Framework.TestData
     , errMsg403MintOrBurnAssetQuantityOutOfBounds
     , errMsg403InvalidValidityBounds
     , errMsg403ValidityIntervalNotInsideScriptTimelock
+    , errMsg403SharedWalletPending
     ) where
 
 import Prelude
@@ -734,6 +735,13 @@ errMsg403ValidityIntervalNotInsideScriptTimelock = unwords
     [ "Attempted to create a transaction with a validity interval"
     , "that is not a subinterval of an associated script's timelock"
     , "interval."
+    ]
+
+errMsg403SharedWalletPending :: String
+errMsg403SharedWalletPending = unwords
+    [ "Transaction for a shared wallet should not be tried for "
+    , "a pending shared wallet. Make the wallet active before sending "
+    , "transaction."
     ]
 
 --------------------------------------------------------------------------------

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -739,8 +739,8 @@ errMsg403ValidityIntervalNotInsideScriptTimelock = unwords
 
 errMsg403SharedWalletPending :: String
 errMsg403SharedWalletPending = unwords
-    [ "Transaction for a shared wallet should not be tried for "
-    , "a pending shared wallet. Make the wallet active before sending "
+    [ "Transaction for a shared wallet should not be tried for"
+    , "a pending shared wallet. Make the wallet active before sending"
     , "transaction."
     ]
 

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -739,9 +739,11 @@ errMsg403ValidityIntervalNotInsideScriptTimelock = unwords
 
 errMsg403SharedWalletPending :: String
 errMsg403SharedWalletPending = unwords
-    [ "Transaction for a shared wallet should not be tried for"
-    , "a pending shared wallet. Make the wallet active before sending"
-    , "transaction."
+    [ "I cannot construct transaction for a shared wallet that is in 'incomplete'"
+    , "state. Please update your wallet accordingly with"
+    , "'PATCH /shared-wallets/{walletId}/payment-script-template' or"
+    , "'PATCH /shared-wallets/{walletId}/delegation-script-template' to make"
+    , "it applicable for constructing transaction."
     ]
 
 --------------------------------------------------------------------------------

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Addresses.hs
@@ -83,7 +83,7 @@ spec = describe "SHARED_ADDRESSES" $ do
             (Link.listAddresses @'Shared wal) Default Empty
         expectResponseCode HTTP.status200 r
         let g = fromIntegral $ getAddressPoolGap defaultAddressPoolGap
-        expectListSize g r
+        expectListSize (2*g) r
         forM_ [0..(g-1)] $ \addrNum -> do
             expectListField addrNum (#state . #getApiT) (`shouldBe` Unused) r
             expectListField addrNum #derivationPath

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.Integration.Scenario.API.Shared.Transactions
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Mnemonic
+    ( MkSomeMnemonic (..) )
+import Cardano.Wallet.Api.Types
+    ( ApiConstructTransaction (..)
+    , ApiSharedWallet (..)
+    , DecodeAddress
+    , DecodeStakeAddress
+    , EncodeAddress (..)
+    , WalletStyle (..)
+    )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..) )
+import Control.Monad.IO.Class
+    ( liftIO )
+import Control.Monad.Trans.Resource
+    ( runResourceT )
+import Data.Either.Combinators
+    ( swapEither )
+import Data.Generics.Internal.VL.Lens
+    ( view )
+import Test.Hspec
+    ( SpecWith, describe )
+import Test.Hspec.Extra
+    ( it )
+import Test.Integration.Framework.DSL
+    ( Context (..)
+    , Headers (..)
+    , MnemonicLength (..)
+    , Payload (..)
+    , accPubKeyFromMnemonics
+    , expectErrorMessage
+    , expectResponseCode
+    , fixturePassphrase
+    , genMnemonics
+    , getFromResponse
+    , json
+    , postSharedWallet
+    , request
+    , verify
+    )
+import Test.Integration.Framework.TestData
+    ( errMsg403SharedWalletPending )
+
+import qualified Cardano.Wallet.Api.Link as Link
+import qualified Data.ByteArray as BA
+import qualified Data.Text.Encoding as T
+import qualified Network.HTTP.Types as HTTP
+
+
+spec :: forall n.
+    ( DecodeAddress n
+    , DecodeStakeAddress n
+    , EncodeAddress n
+    ) => SpecWith Context
+spec = describe "SHARED_TRANSACTIONS" $ do
+
+    it "SHARED_TRANSACTIONS_CREATE_01 - Cannot create tx for a pending shared wallet" $ \ctx -> runResourceT $ do
+        m15txt <- liftIO $ genMnemonics M15
+        m12txt <- liftIO $ genMnemonics M12
+        let (Right m15) = mkSomeMnemonic @'[ 15 ] m15txt
+        let (Right m12) = mkSomeMnemonic @'[ 12 ] m12txt
+        let passphrase = Passphrase $ BA.convert $ T.encodeUtf8 fixturePassphrase
+        let index = 30
+        let accXPubDerived = accPubKeyFromMnemonics m15 (Just m12) index passphrase
+        let payload = Json [json| {
+                "name": "Shared Wallet",
+                "mnemonic_sentence": #{m15txt},
+                "mnemonic_second_factor": #{m12txt},
+                "passphrase": #{fixturePassphrase},
+                "account_index": "30H",
+                "payment_script_template":
+                    { "cosigners":
+                        { "cosigner#0": #{accXPubDerived} },
+                      "template":
+                          { "all":
+                             [ "cosigner#0",
+                               "cosigner#1",
+                               { "active_from": 120 }
+                             ]
+                          }
+                    }
+                } |]
+        rPost <- postSharedWallet ctx Default payload
+        verify (fmap (swapEither . view #wallet) <$> rPost)
+            [ expectResponseCode HTTP.status201
+            ]
+
+        let (ApiSharedWallet (Left wal)) = getFromResponse id rPost
+
+        let metadata = Json [json|{ "metadata": { "1": { "string": "hello" } } }|]
+
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shared wal) Default metadata
+        verify rTx
+            [ expectResponseCode HTTP.status403
+            , expectErrorMessage errMsg403SharedWalletPending
+            ]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
@@ -164,15 +164,21 @@ spec = describe "SHARED_TRANSACTIONS" $ do
 
         let metadata = Json [json|{ "metadata": { "1": { "string": "hello" } } }|]
 
-        rTx <- request @(ApiConstructTransaction n) ctx
+        rTx1 <- request @(ApiConstructTransaction n) ctx
             (Link.createUnsignedTransaction @'Shared wal) Default metadata
-        verify rTx
+        verify rTx1
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403EmptyUTxO
             ]
 
         let amt = 10 * minUTxOValue (_mainEra ctx)
         fundSharedWallet ctx amt walShared
+
+        rTx2 <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shared wal) Default metadata
+        verify rTx2
+            [ expectResponseCode HTTP.status202
+            ]
   where
      fundSharedWallet ctx amt walShared = do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
@@ -43,12 +43,14 @@ import Data.Either.Combinators
     ( swapEither )
 import Data.Generics.Internal.VL.Lens
     ( view, (^.) )
+import Data.Maybe
+    ( isJust )
 import Data.Quantity
     ( Quantity (..) )
 import Test.Hspec
     ( SpecWith, describe )
 import Test.Hspec.Expectations.Lifted
-    ( shouldBe )
+    ( shouldBe, shouldSatisfy )
 import Test.Hspec.Extra
     ( it )
 import Test.Integration.Framework.DSL
@@ -178,12 +180,14 @@ spec = describe "SHARED_TRANSACTIONS" $ do
             (Link.createUnsignedTransaction @'Shared wal) Default metadata
         verify rTx2
             [ expectResponseCode HTTP.status202
+            , expectField (#coinSelection . #metadata) (`shouldSatisfy` isJust)
+            , expectField (#fee . #getQuantity) (`shouldSatisfy` (>0))
             ]
   where
      fundSharedWallet ctx amt walShared = do
 
         let wal = case walShared of
-                ApiSharedWallet (Right wal) -> wal
+                ApiSharedWallet (Right wal') -> wal'
                 _ -> error "funding of shared wallet make sense only for active one"
 
         rAddr <- request @[ApiAddress n] ctx

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -101,6 +101,7 @@ module Cardano.Wallet
     , ErrAddCosignerKey (..)
     , ErrConstructSharedWallet (..)
     , normalizeSharedAddress
+    , constructSharedTransaction
 
     -- ** Address
     , createRandomAddress
@@ -215,6 +216,8 @@ import Cardano.Address.Derivation
     ( XPrv, XPub )
 import Cardano.Address.Script
     ( Cosigner (..), KeyHash )
+import Cardano.Address.Style.Shared
+    ( deriveDelegationPublicKey )
 import Cardano.Api
     ( serialiseToCBOR )
 import Cardano.BM.Data.Severity
@@ -593,6 +596,7 @@ import UnliftIO.MVar
     ( modifyMVar_, newMVar )
 
 import qualified Cardano.Address.Script as CA
+import qualified Cardano.Address.Style.Shared as CA
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Crypto.Wallet as CC
@@ -2432,6 +2436,45 @@ constructTransaction ctx wid era txCtx sel = db & \DBLayer{..} -> do
     tl = ctx ^. transactionLayer @k
     nl = ctx ^. networkLayer
 
+-- | Construct an unsigned transaction from a given selection
+-- for a shared wallet.
+constructSharedTransaction
+    :: forall ctx s k (n :: NetworkDiscriminant) shared.
+        ( HasTransactionLayer k ctx
+        , HasDBLayer IO s k ctx
+        , HasNetworkLayer IO ctx
+        , shared ~ SharedState n SharedKey
+        , Typeable s
+        , Typeable n
+        )
+    => ctx
+    -> WalletId
+    -> Cardano.AnyCardanoEra
+    -> TransactionCtx
+    -> SelectionOf TxOut
+    -> ExceptT ErrConstructTx IO SealedTx
+constructSharedTransaction ctx wid era txCtx sel = db & \DBLayer{..} -> do
+    cp <- withExceptT ErrConstructTxNoSuchWallet
+        $ mapExceptT atomically
+        $ withNoSuchWallet wid
+        $ readCheckpoint wid
+    xpub <- case testEquality (typeRep @s) (typeRep @shared) of
+        Nothing ->
+            throwE ErrConstructTxNotASharedWallet
+        Just Refl -> do
+            let s = getState cp
+            let accXPub = getRawKey $ Shared.accountXPub s
+            pure $ CA.getKey $
+                deriveDelegationPublicKey (CA.liftXPub accXPub) minBound
+    mapExceptT atomically $ do
+        pp <- liftIO $ currentProtocolParameters nl
+        withExceptT ErrConstructTxBody $ ExceptT $ pure $
+            mkUnsignedTransaction tl era xpub pp txCtx sel
+  where
+    db = ctx ^. dbLayer @IO @s @k
+    tl = ctx ^. transactionLayer @k
+    nl = ctx ^. networkLayer
+
 -- | Calculate the transaction expiry slot, given a 'TimeInterpreter', and an
 -- optional TTL in seconds.
 --
@@ -3524,6 +3567,7 @@ data ErrConstructTx
     | ErrConstructTxWrongValidityBounds
     | ErrConstructTxValidityIntervalNotWithinScriptTimelock
     | ErrConstructTxSharedWalletPending
+    | ErrConstructTxNotASharedWallet
     | ErrConstructTxNotImplemented String
     -- ^ Temporary error constructor.
     deriving (Show, Eq)

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -3523,6 +3523,7 @@ data ErrConstructTx
     | ErrConstructTxMintOrBurnAssetQuantityOutOfBounds
     | ErrConstructTxWrongValidityBounds
     | ErrConstructTxValidityIntervalNotWithinScriptTimelock
+    | ErrConstructTxSharedWalletPending
     | ErrConstructTxNotImplemented String
     -- ^ Temporary error constructor.
     deriving (Show, Eq)

--- a/lib/core/src/Cardano/Wallet/Address/Book.hs
+++ b/lib/core/src/Cardano/Wallet/Address/Book.hs
@@ -191,7 +191,7 @@ instance ( key ~ SharedKey ) => AddressBookIso (Shared.SharedState n key)
             Shared.Active (Shared.SharedAddressPools extPool intPool _pending) ->
                 let extPool0 = clearShared extPool
                     intPool0 = clearShared intPool
-                    pending0 = Seq.emptyPendingIxs
+                    pending0 = Shared.emptyPendingIxs
                     pools0 = Shared.SharedAddressPools extPool0 intPool0 pending0
                 in  ( SharedPrologue st{ Shared.ready = Shared.Active pools0 }
                     , SharedDiscoveries

--- a/lib/core/src/Cardano/Wallet/Address/Book.hs
+++ b/lib/core/src/Cardano/Wallet/Address/Book.hs
@@ -188,11 +188,10 @@ instance ( key ~ SharedKey ) => AddressBookIso (Shared.SharedState n key)
             Shared.Pending ->
                 ( SharedPrologue st
                 , SharedDiscoveries (SharedAddressMap Map.empty) (SharedAddressMap Map.empty))
-            Shared.Active (Shared.SharedAddressPools extPool intPool _pending) ->
+            Shared.Active (Shared.SharedAddressPools extPool intPool pending) ->
                 let extPool0 = clearShared extPool
                     intPool0 = clearShared intPool
-                    pending0 = Shared.emptyPendingIxs
-                    pools0 = Shared.SharedAddressPools extPool0 intPool0 pending0
+                    pools0 = Shared.SharedAddressPools extPool0 intPool0 pending
                 in  ( SharedPrologue st{ Shared.ready = Shared.Active pools0 }
                     , SharedDiscoveries
                         (addressesShared extPool)
@@ -204,7 +203,6 @@ instance ( key ~ SharedKey ) => AddressBookIso (Shared.SharedState n key)
             Shared.Active (Shared.SharedAddressPools extPool0 intPool0 pending0) ->
                 let extPool = loadUnsafeShared extPool0 exts
                     intPool = loadUnsafeShared intPool0 ints
-                    -- TODO - think about pending here and in from
                     pools = Shared.SharedAddressPools extPool intPool pending0
                 in  st{ Shared.ready = Shared.Active pools }
 

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -147,6 +147,9 @@ module Cardano.Wallet.Api
     , SharedAddresses
         , ListSharedAddresses
 
+    , SharedTransactions
+        , ConstructSharedTransaction
+
     , Proxy_
         , PostExternalTransaction
 
@@ -328,6 +331,7 @@ type Api n apiPool =
     :<|> SharedWallets
     :<|> SharedWalletKeys
     :<|> SharedAddresses n
+    :<|> SharedTransactions n
 
 {-------------------------------------------------------------------------------
                                   Wallets
@@ -1101,6 +1105,23 @@ type ListSharedAddresses n = "shared-wallets"
     :> "addresses"
     :> QueryParam "state" (ApiT AddressState)
     :> Get '[JSON] [ApiAddressT n]
+
+{-------------------------------------------------------------------------------
+                                  Shared Transactions
+
+  See also: https://input-output-hk.github.io/cardano-wallet/api/#tag/Shared-Transactions
+-------------------------------------------------------------------------------}
+
+type SharedTransactions n =
+         ConstructSharedTransaction n
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/constructSharedTransaction
+type ConstructSharedTransaction n = "shared-wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "transactions-construct"
+    :> ReqBody '[JSON] (ApiConstructTransactionDataT n)
+    :> PostAccepted '[JSON] (ApiConstructTransactionT n)
+
 
 {-------------------------------------------------------------------------------
                                    Proxy_

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -702,8 +702,7 @@ getTransaction w t = discriminate @style
 
 createUnsignedTransaction
     :: forall style w.
-        ( HasCallStack
-        , HasType (ApiT WalletId) w
+        ( HasType (ApiT WalletId) w
         , Discriminate style
         )
     => w
@@ -711,7 +710,7 @@ createUnsignedTransaction
 createUnsignedTransaction w = discriminate @style
     (endpoint @(Api.ConstructTransaction Net) (wid &))
     (endpoint @(Api.ConstructByronTransaction Net) (wid &))
-    (notSupported "Shared") -- TODO: [ADP-909] should be supported in the final version of Transaction Workflow.
+    (endpoint @(Api.ConstructSharedTransaction Net) (wid &))
   where
     wid = w ^. typed @(ApiT WalletId)
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2603,7 +2603,7 @@ handleValidityInterval ti validityInterval = do
                     fromValidityBound (Right val)
             pure (before'', hereafter'')
 
-    pure $ (before, hereafter, isThereNegativeTime)
+    pure (before, hereafter, isThereNegativeTime)
 
 -- TO-DO delegations/withdrawals
 -- TO-DO minting/burning

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2605,11 +2605,12 @@ handleValidityInterval ti validityInterval = do
 
     pure $ (before, hereafter, isThereNegativeTime)
 
--- TO-DO delegations
--- TO-DO minting
+-- TO-DO delegations/withdrawals
+-- TO-DO minting/burning
 constructSharedTransaction
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( s ~ SharedState n k
+        , ctx ~ ApiLayer s k
         , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
         , GenChange s
         , HardDerivation k
@@ -2662,50 +2663,56 @@ constructSharedTransaction ctx genChange _knownPools _getPoolStatus (ApiT wid) b
             )
 
     withWorkerCtx ctx wid liftE liftE $ \wrk -> do
-        pp <- liftIO $ NW.currentProtocolParameters (wrk ^. networkLayer)
-        era <- liftIO $ NW.currentNodeEra (wrk ^. networkLayer)
+        (cp, _, _) <- liftHandler $ withExceptT ErrConstructTxNoSuchWallet $
+            W.readWallet @_ @s @k wrk wid
+        case Shared.ready (getState cp) of
+            Shared.Pending ->
+                liftHandler $ throwE ErrConstructTxSharedWalletPending
+            Shared.Active _ -> do
+                pp <- liftIO $ NW.currentProtocolParameters (wrk ^. networkLayer)
+                era <- liftIO $ NW.currentNodeEra (wrk ^. networkLayer)
 
-        (utxoAvailable, wallet, pendingTxs) <-
-            liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk wid
+                (utxoAvailable, wallet, pendingTxs) <-
+                    liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk wid
 
-        let runSelection outs =
-                W.selectAssets @_ @_ @s @k wrk era pp selectAssetsParams transform
-              where
-                selectAssetsParams = W.SelectAssetsParams
-                    { outputs = outs
-                    , pendingTxs
-                    , randomSeed = Nothing
-                    , txContext = txCtx
-                    , utxoAvailableForInputs =
-                        UTxOSelection.fromIndex utxoAvailable
-                    , utxoAvailableForCollateral =
-                        UTxOIndex.toMap utxoAvailable
-                    , wallet
-                    , selectionStrategy = SelectionStrategyOptimal
+                let runSelection outs =
+                        W.selectAssets @_ @_ @s @k wrk era pp selectAssetsParams transform
+                      where
+                        selectAssetsParams = W.SelectAssetsParams
+                            { outputs = outs
+                            , pendingTxs
+                            , randomSeed = Nothing
+                            , txContext = txCtx
+                            , utxoAvailableForInputs =
+                                UTxOSelection.fromIndex utxoAvailable
+                            , utxoAvailableForCollateral =
+                                UTxOIndex.toMap utxoAvailable
+                            , wallet
+                            , selectionStrategy = SelectionStrategyOptimal
+                            }
+                (sel, sel', fee) <- do
+                    outs <- case (body ^. #payments) of
+                        Nothing -> pure []
+                        Just (ApiPaymentAddresses content) ->
+                            pure $ F.toList (addressAmountToTxOut <$> content)
+                        Just (ApiPaymentAll _) -> do
+                            liftHandler $
+                                throwE $ ErrConstructTxNotImplemented "ADP-1189"
+
+                    (sel', utx, fee') <- liftHandler $ runSelection outs
+                    sel <- liftHandler $
+                        W.assignChangeAddressesWithoutDbUpdate wrk wid genChange utx
+                    (FeeEstimation estMin _) <- liftHandler $ W.estimateFee (pure fee')
+                    pure (sel, sel', estMin)
+
+                tx <- liftHandler
+                    $ W.constructTransaction @_ @s @k @n wrk wid era txCtx sel
+
+                pure $ ApiConstructTransaction
+                    { transaction = ApiT tx
+                    , coinSelection = mkApiCoinSelection [] [] Nothing md sel'
+                    , fee = Quantity $ fromIntegral fee
                     }
-        (sel, sel', fee) <- do
-            outs <- case (body ^. #payments) of
-                Nothing -> pure []
-                Just (ApiPaymentAddresses content) ->
-                    pure $ F.toList (addressAmountToTxOut <$> content)
-                Just (ApiPaymentAll _) -> do
-                    liftHandler $
-                        throwE $ ErrConstructTxNotImplemented "ADP-1189"
-
-            (sel', utx, fee') <- liftHandler $ runSelection outs
-            sel <- liftHandler $
-                W.assignChangeAddressesWithoutDbUpdate wrk wid genChange utx
-            (FeeEstimation estMin _) <- liftHandler $ W.estimateFee (pure fee')
-            pure (sel, sel', estMin)
-
-        tx <- liftHandler
-            $ W.constructTransaction @_ @s @k @n wrk wid era txCtx sel
-
-        pure $ ApiConstructTransaction
-            { transaction = ApiT tx
-            , coinSelection = mkApiCoinSelection [] [] Nothing md sel'
-            , fee = Quantity $ fromIntegral fee
-            }
   where
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
     ti = timeInterpreter (ctx ^. networkLayer)
@@ -4677,6 +4684,12 @@ instance IsServerError ErrConstructTx where
             [ "Attempted to create a transaction with a validity interval"
             , "that is not a subinterval of an associated script's timelock"
             , "interval."
+            ]
+        ErrConstructTxSharedWalletPending ->
+            apiError err403 SharedWalletPending $ mconcat
+            [ "Transaction for a shared wallet should not be tried for "
+            , "a pending shared wallet. Make the wallet active before sending "
+            , "transaction."
             ]
         ErrConstructTxNotImplemented _ ->
             apiError err501 NotImplemented

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -96,6 +96,7 @@ module Cardano.Wallet.Api.Server
     , getPolicyKey
     , postPolicyKey
     , postPolicyId
+    , constructSharedTransaction
 
     -- * Server error responses
     , IsServerError(..)
@@ -2593,6 +2594,26 @@ constructTransaction ctx genChange knownPools getPoolStatus (ApiT wid) body = do
         map toTxOut
             . Map.toList
             . foldr (uncurry (Map.insertWith (<>))) Map.empty
+
+constructSharedTransaction
+    :: forall ctx s k n.
+        ( ctx ~ ApiLayer s k
+        , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
+        , HardDerivation k
+        , HasNetworkLayer IO ctx
+        , IsOurs s Address
+        , Typeable n
+        , Typeable s
+        , WalletKey k
+        )
+    => ctx
+    -> IO (Set PoolId)
+    -> (PoolId -> IO PoolLifeCycleStatus)
+    -> ApiT WalletId
+    -> ApiConstructTransactionData n
+    -> Handler (ApiConstructTransaction n)
+constructSharedTransaction _ctx _knownPools _getPoolStatus (ApiT _wid) _body = undefined
+
 
 -- TODO: Most of the body of this function should really belong to
 -- Cardano.Wallet to keep the Api.Server module free of business logic!

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2350,53 +2350,8 @@ constructTransaction ctx genChange knownPools getPoolStatus (ApiT wid) body = do
 
     let md = body ^? #metadata . traverse . #txMetadataWithSchema_metadata
 
-    let isValidityBoundTimeNegative
-            (ApiValidityBoundAsTimeFromNow (Quantity sec)) = sec < 0
-        isValidityBoundTimeNegative _ = False
-
-    let isThereNegativeTime = case body ^. #validityInterval of
-            Just (ApiValidityInterval (Just before') Nothing) ->
-                isValidityBoundTimeNegative before'
-            Just (ApiValidityInterval Nothing (Just hereafter')) ->
-                isValidityBoundTimeNegative hereafter'
-            Just (ApiValidityInterval (Just before') (Just hereafter')) ->
-                isValidityBoundTimeNegative before' ||
-                isValidityBoundTimeNegative hereafter'
-            _ -> False
-
-    let fromValidityBound = liftIO . \case
-            Left ApiValidityBoundUnspecified ->
-                pure $ SlotNo 0
-            Right ApiValidityBoundUnspecified ->
-                W.getTxExpiry ti Nothing
-            Right (ApiValidityBoundAsTimeFromNow (Quantity sec)) ->
-                W.getTxExpiry ti (Just sec)
-            Left (ApiValidityBoundAsTimeFromNow (Quantity sec)) ->
-                W.getTxExpiry ti (Just sec)
-            Right (ApiValidityBoundAsSlot (Quantity slot)) ->
-                pure $ SlotNo slot
-            Left (ApiValidityBoundAsSlot (Quantity slot)) ->
-                pure $ SlotNo slot
-
-    (before, hereafter) <- case body ^. #validityInterval of
-        Nothing -> do
-            before' <-
-                fromValidityBound (Left ApiValidityBoundUnspecified)
-            hereafter' <-
-                fromValidityBound (Right ApiValidityBoundUnspecified)
-            pure (before', hereafter')
-        Just (ApiValidityInterval before' hereafter') -> do
-            before'' <- case before' of
-                Nothing ->
-                    fromValidityBound (Left ApiValidityBoundUnspecified)
-                Just val ->
-                    fromValidityBound (Left val)
-            hereafter'' <- case hereafter' of
-                Nothing ->
-                    fromValidityBound (Right ApiValidityBoundUnspecified)
-                Just val ->
-                    fromValidityBound (Right val)
-            pure (before'', hereafter'')
+    (before, hereafter, isThereNegativeTime) <-
+        handleValidityInterval ti (body ^. #validityInterval)
 
     when (hereafter < before || isThereNegativeTime) $
         liftHandler $ throwE ErrConstructTxWrongValidityBounds
@@ -2595,6 +2550,61 @@ constructTransaction ctx genChange knownPools getPoolStatus (ApiT wid) body = do
             . Map.toList
             . foldr (uncurry (Map.insertWith (<>))) Map.empty
 
+handleValidityInterval
+    :: TimeInterpreter (ExceptT PastHorizonException IO)
+    -> Maybe ApiValidityInterval
+    -> Handler (SlotNo, SlotNo, Bool)
+handleValidityInterval ti validityInterval = do
+    let isValidityBoundTimeNegative
+            (ApiValidityBoundAsTimeFromNow (Quantity sec)) = sec < 0
+        isValidityBoundTimeNegative _ = False
+
+    let isThereNegativeTime = case validityInterval of
+            Just (ApiValidityInterval (Just before') Nothing) ->
+                isValidityBoundTimeNegative before'
+            Just (ApiValidityInterval Nothing (Just hereafter')) ->
+                isValidityBoundTimeNegative hereafter'
+            Just (ApiValidityInterval (Just before') (Just hereafter')) ->
+                isValidityBoundTimeNegative before' ||
+                isValidityBoundTimeNegative hereafter'
+            _ -> False
+
+    let fromValidityBound = liftIO . \case
+            Left ApiValidityBoundUnspecified ->
+                pure $ SlotNo 0
+            Right ApiValidityBoundUnspecified ->
+                W.getTxExpiry ti Nothing
+            Right (ApiValidityBoundAsTimeFromNow (Quantity sec)) ->
+                W.getTxExpiry ti (Just sec)
+            Left (ApiValidityBoundAsTimeFromNow (Quantity sec)) ->
+                W.getTxExpiry ti (Just sec)
+            Right (ApiValidityBoundAsSlot (Quantity slot)) ->
+                pure $ SlotNo slot
+            Left (ApiValidityBoundAsSlot (Quantity slot)) ->
+                pure $ SlotNo slot
+
+    (before, hereafter) <- case validityInterval of
+        Nothing -> do
+            before' <-
+                fromValidityBound (Left ApiValidityBoundUnspecified)
+            hereafter' <-
+                fromValidityBound (Right ApiValidityBoundUnspecified)
+            pure (before', hereafter')
+        Just (ApiValidityInterval before' hereafter') -> do
+            before'' <- case before' of
+                Nothing ->
+                    fromValidityBound (Left ApiValidityBoundUnspecified)
+                Just val ->
+                    fromValidityBound (Left val)
+            hereafter'' <- case hereafter' of
+                Nothing ->
+                    fromValidityBound (Right ApiValidityBoundUnspecified)
+                Just val ->
+                    fromValidityBound (Right val)
+            pure (before'', hereafter'')
+
+    pure $ (before, hereafter, isThereNegativeTime)
+
 constructSharedTransaction
     :: forall ctx s k n.
         ( ctx ~ ApiLayer s k
@@ -2612,7 +2622,20 @@ constructSharedTransaction
     -> ApiT WalletId
     -> ApiConstructTransactionData n
     -> Handler (ApiConstructTransaction n)
-constructSharedTransaction _ctx _knownPools _getPoolStatus (ApiT _wid) _body = undefined
+constructSharedTransaction ctx _knownPools _getPoolStatus (ApiT wid) body = do
+    (before, hereafter, isThereNegativeTime) <-
+        handleValidityInterval ti (body ^. #validityInterval)
+
+    when (hereafter < before || isThereNegativeTime) $
+        liftHandler $ throwE ErrConstructTxWrongValidityBounds
+
+    withWorkerCtx ctx wid liftE liftE $ \wrk -> do
+        (utxoAvailable, wallet, pendingTxs) <-
+            liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk wid
+        undefined
+  where
+    ti :: TimeInterpreter (ExceptT PastHorizonException IO)
+    ti = timeInterpreter (ctx ^. networkLayer)
 
 
 -- TODO: Most of the body of this function should really belong to

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2605,10 +2605,13 @@ handleValidityInterval ti validityInterval = do
 
     pure $ (before, hereafter, isThereNegativeTime)
 
+-- TO-DO delegations
+-- TO-DO minting
 constructSharedTransaction
     :: forall ctx s k n.
         ( ctx ~ ApiLayer s k
         , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
+        , GenChange s
         , HardDerivation k
         , HasNetworkLayer IO ctx
         , IsOurs s Address
@@ -2617,22 +2620,91 @@ constructSharedTransaction
         , WalletKey k
         )
     => ctx
+    -> ArgGenChange s
     -> IO (Set PoolId)
     -> (PoolId -> IO PoolLifeCycleStatus)
     -> ApiT WalletId
     -> ApiConstructTransactionData n
     -> Handler (ApiConstructTransaction n)
-constructSharedTransaction ctx _knownPools _getPoolStatus (ApiT wid) body = do
+constructSharedTransaction ctx genChange _knownPools _getPoolStatus (ApiT wid) body = do
+    let isNoPayload =
+            isNothing (body ^. #payments) &&
+            isNothing (body ^. #withdrawal) &&
+            isNothing (body ^. #metadata) &&
+            isNothing (body ^. #mintBurn) &&
+            isNothing (body ^. #delegations)
+    when isNoPayload $
+        liftHandler $ throwE ErrConstructTxWrongPayload
+
+    let md = body ^? #metadata . traverse . #txMetadataWithSchema_metadata
+
+    (wdrl, _) <-
+        mkRewardAccountBuilder @_ @s @_ @n ctx wid (body ^. #withdrawal)
+
     (before, hereafter, isThereNegativeTime) <-
         handleValidityInterval ti (body ^. #validityInterval)
 
     when (hereafter < before || isThereNegativeTime) $
         liftHandler $ throwE ErrConstructTxWrongValidityBounds
 
+    let txCtx = defaultTransactionCtx
+            { txWithdrawal = wdrl
+            , txMetadata = md
+            , txValidityInterval = (Just before, hereafter)
+            , txDelegationAction = Nothing
+            }
+
+    let transform s sel =
+            ( W.assignChangeAddresses genChange sel s
+                & uncurry (W.selectionToUnsignedTx (txWithdrawal txCtx))
+            , sel
+            , selectionDelta TokenBundle.getCoin sel
+            )
+
     withWorkerCtx ctx wid liftE liftE $ \wrk -> do
+        pp <- liftIO $ NW.currentProtocolParameters (wrk ^. networkLayer)
+
         (utxoAvailable, wallet, pendingTxs) <-
             liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk wid
-        undefined
+
+        let runSelection outs =
+                W.selectAssets @_ @_ @s @k wrk pp selectAssetsParams transform
+              where
+                selectAssetsParams = W.SelectAssetsParams
+                    { outputs = outs
+                    , pendingTxs
+                    , randomSeed = Nothing
+                    , txContext = txCtx
+                    , utxoAvailableForInputs =
+                        UTxOSelection.fromIndex utxoAvailable
+                    , utxoAvailableForCollateral =
+                        UTxOIndex.toMap utxoAvailable
+                    , wallet
+                    , selectionStrategy = SelectionStrategyOptimal
+                    }
+        (sel, sel', fee) <- do
+            outs <- case (body ^. #payments) of
+                Nothing -> pure []
+                Just (ApiPaymentAddresses content) ->
+                    pure $ F.toList (addressAmountToTxOut <$> content)
+                Just (ApiPaymentAll _) -> do
+                    liftHandler $
+                        throwE $ ErrConstructTxNotImplemented "ADP-1189"
+
+            (sel', utx, fee') <- liftHandler $ runSelection outs
+            sel <- liftHandler $
+                W.assignChangeAddressesWithoutDbUpdate wrk wid genChange utx
+            (FeeEstimation estMin _) <- liftHandler $ W.estimateFee (pure fee')
+            pure (sel, sel', estMin)
+
+        tx <- liftHandler
+            $ W.constructTransaction @_ @s @k @n wrk wid txCtx sel
+
+        pure $ ApiConstructTransaction
+            { transaction = ApiT tx
+            , coinSelection = mkApiCoinSelection [] [] Nothing md sel'
+            , fee = Quantity $ fromIntegral fee
+            }
   where
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
     ti = timeInterpreter (ctx ^. networkLayer)

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -4679,9 +4679,11 @@ instance IsServerError ErrConstructTx where
             ]
         ErrConstructTxSharedWalletPending ->
             apiError err403 SharedWalletPending $ mconcat
-            [ "Transaction for a shared wallet should not be tried for "
-            , "a pending shared wallet. Make the wallet active before sending "
-            , "transaction."
+            [ "I cannot construct transaction for a shared wallet that is in 'incomplete' "
+            , "state. Please update your wallet accordingly with "
+            , "'PATCH /shared-wallets/{walletId}/payment-script-template' or "
+            , "'PATCH /shared-wallets/{walletId}/delegation-script-template' to make "
+            , "it applicable for constructing transaction."
             ]
         ErrConstructTxNotASharedWallet ->
             apiError err403 InvalidWalletType $ mconcat

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2663,12 +2663,13 @@ constructSharedTransaction ctx genChange _knownPools _getPoolStatus (ApiT wid) b
 
     withWorkerCtx ctx wid liftE liftE $ \wrk -> do
         pp <- liftIO $ NW.currentProtocolParameters (wrk ^. networkLayer)
+        era <- liftIO $ NW.currentNodeEra (wrk ^. networkLayer)
 
         (utxoAvailable, wallet, pendingTxs) <-
             liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk wid
 
         let runSelection outs =
-                W.selectAssets @_ @_ @s @k wrk pp selectAssetsParams transform
+                W.selectAssets @_ @_ @s @k wrk era pp selectAssetsParams transform
               where
                 selectAssetsParams = W.SelectAssetsParams
                     { outputs = outs
@@ -2698,7 +2699,7 @@ constructSharedTransaction ctx genChange _knownPools _getPoolStatus (ApiT wid) b
             pure (sel, sel', estMin)
 
         tx <- liftHandler
-            $ W.constructTransaction @_ @s @k @n wrk wid txCtx sel
+            $ W.constructTransaction @_ @s @k @n wrk wid era txCtx sel
 
         pure $ ApiConstructTransaction
             { transaction = ApiT tx

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2611,14 +2611,11 @@ constructSharedTransaction
     :: forall ctx s k n.
         ( s ~ SharedState n k
         , ctx ~ ApiLayer s k
-        , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
         , GenChange s
-        , HardDerivation k
         , HasNetworkLayer IO ctx
         , IsOurs s Address
         , Typeable n
         , Typeable s
-        , WalletKey k
         )
     => ctx
     -> ArgGenChange s
@@ -2639,9 +2636,6 @@ constructSharedTransaction ctx genChange _knownPools _getPoolStatus (ApiT wid) b
 
     let md = body ^? #metadata . traverse . #txMetadataWithSchema_metadata
 
-    (wdrl, _) <-
-        mkRewardAccountBuilder @_ @s @_ @n ctx wid (body ^. #withdrawal)
-
     (before, hereafter, isThereNegativeTime) <-
         handleValidityInterval ti (body ^. #validityInterval)
 
@@ -2649,7 +2643,7 @@ constructSharedTransaction ctx genChange _knownPools _getPoolStatus (ApiT wid) b
         liftHandler $ throwE ErrConstructTxWrongValidityBounds
 
     let txCtx = defaultTransactionCtx
-            { txWithdrawal = wdrl
+            { txWithdrawal = NoWithdrawal
             , txMetadata = md
             , txValidityInterval = (Just before, hereafter)
             , txDelegationAction = Nothing
@@ -2692,12 +2686,10 @@ constructSharedTransaction ctx genChange _knownPools _getPoolStatus (ApiT wid) b
                             }
                 (sel, sel', fee) <- do
                     outs <- case (body ^. #payments) of
-                        Nothing -> pure []
                         Just (ApiPaymentAddresses content) ->
                             pure $ F.toList (addressAmountToTxOut <$> content)
-                        Just (ApiPaymentAll _) -> do
-                            liftHandler $
-                                throwE $ ErrConstructTxNotImplemented "ADP-1189"
+                        _ ->
+                            pure []
 
                     (sel', utx, fee') <- liftHandler $ runSelection outs
                     sel <- liftHandler $
@@ -2706,7 +2698,7 @@ constructSharedTransaction ctx genChange _knownPools _getPoolStatus (ApiT wid) b
                     pure (sel, sel', estMin)
 
                 tx <- liftHandler
-                    $ W.constructTransaction @_ @s @k @n wrk wid era txCtx sel
+                    $ W.constructSharedTransaction @_ @s @k @n wrk wid era txCtx sel
 
                 pure $ ApiConstructTransaction
                     { transaction = ApiT tx
@@ -4691,6 +4683,12 @@ instance IsServerError ErrConstructTx where
             , "a pending shared wallet. Make the wallet active before sending "
             , "transaction."
             ]
+        ErrConstructTxNotASharedWallet ->
+            apiError err403 InvalidWalletType $ mconcat
+                [ "It is regrettable but you've just attempted an operation "
+                , "that is invalid for this type of wallet. Only new 'Shared' "
+                , "wallets can do something with both script and keyhash delegation ."
+                ]
         ErrConstructTxNotImplemented _ ->
             apiError err501 NotImplemented
                 "This feature is not yet implemented."

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1761,6 +1761,7 @@ data ApiErrorCode
     | SharedWalletNoDelegationTemplate
     | SharedWalletNoSuchCosigner
     | SharedWalletNotPending
+    | SharedWalletPending
     | SharedWalletScriptTemplateInvalid
     | SoftDerivationRequired
     | StartTimeLaterThanEndTime

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Schema.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Schema.hs
@@ -459,6 +459,15 @@ SharedState
     Foreign Wallet OnDeleteCascade shared_state sharedStateWalletId
     deriving Show Generic
 
+-- Shared Wallet -- pending change indexes
+SharedStatePendingIx                            sql=shared_state_pending
+    sharedStatePendingWalletId     W.WalletId   sql=wallet_id
+    sharedStatePendingIxIndex      Word32       sql=pending_ix
+
+    Primary sharedStatePendingWalletId sharedStatePendingIxIndex
+    Foreign Wallet OnDeleteCascade shared_state_address_pending sharedStatePendingWalletId
+    deriving Show Generic
+
 CosignerKey
     cosignerKeyWalletId                  W.WalletId                sql=wallet_id
     cosignerKeyCredential                CredentialType            sql=credential

--- a/lib/core/src/Cardano/Wallet/DB/Store/Checkpoints.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Store/Checkpoints.hs
@@ -597,7 +597,7 @@ instance
             False -> mkSharedState $ Shared.Active $ Shared.SharedAddressPools
                 (Shared.newSharedAddressPool @n @'UtxoExternal gap pTemplate dTemplateM)
                 (Shared.newSharedAddressPool @n @'UtxoInternal gap pTemplate dTemplateM)
-                Seq.emptyPendingIxs
+                Shared.emptyPendingIxs
         pure $ SharedPrologue prologue
 
     loadDiscoveries wid sl = do

--- a/lib/core/src/Cardano/Wallet/DB/Store/Checkpoints.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Store/Checkpoints.hs
@@ -552,7 +552,7 @@ instance
             let (Shared.Active (Shared.SharedAddressPools _ _ pendingIxs)) =
                     readiness
             deleteWhere [SharedStatePendingWalletId ==. wid]
-            dbChunked insertMany_ (mkSharedStatePendingIxs wid pendingIxs)
+            dbChunked insertMany_ (mkSharedStatePendingIxs pendingIxs)
       where
          insertSharedState prefix accXPub gap pTemplate dTemplateM = do
              deleteWhere [SharedStateWalletId ==. wid]
@@ -572,8 +572,8 @@ instance
                  | ((Cosigner c), xpub) <- Map.assocs cs
                  ]
 
-         mkSharedStatePendingIxs :: W.WalletId -> Shared.PendingIxs -> [SharedStatePendingIx]
-         mkSharedStatePendingIxs wid =
+         mkSharedStatePendingIxs :: Shared.PendingIxs -> [SharedStatePendingIx]
+         mkSharedStatePendingIxs =
              fmap (SharedStatePendingIx wid . W.getIndex) . Shared.pendingIxsToList
 
     insertDiscoveries wid sl sharedDiscoveries = do

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/SharedKey.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/SharedKey.hs
@@ -151,12 +151,12 @@ replaceCosignersWithVerKeys role' (ScriptTemplate xpubs scriptTemplate) ix =
         in hashKey walletRole verKey
     walletRole = case role' of
         CA.UTxOExternal -> CA.Payment
+        CA.UTxOInternal -> CA.Payment
         CA.Stake -> CA.Delegation
-        _ ->  error "replaceCosignersWithVerKeys is supported only for role=0 and role=2"
     deriveMultisigPublicKey = case role' of
         CA.UTxOExternal -> deriveAddressPublicKey
+        CA.UTxOInternal -> deriveAddressPublicKey
         CA.Stake -> deriveDelegationPublicKey
-        _ ->  error "replaceCosignersWithVerKeys is supported only for role=0 and role=2"
 
 -- | Convert 'NetworkDiscriminant type parameter to
 -- 'Cardano.Address.NetworkTag'.

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/SharedKey.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/SharedKey.hs
@@ -153,10 +153,10 @@ replaceCosignersWithVerKeys role' (ScriptTemplate xpubs scriptTemplate) ix =
         CA.UTxOExternal -> CA.Payment
         CA.UTxOInternal -> CA.Payment
         CA.Stake -> CA.Delegation
-    deriveMultisigPublicKey = case role' of
-        CA.UTxOExternal -> deriveAddressPublicKey
-        CA.UTxOInternal -> deriveAddressPublicKey
-        CA.Stake -> deriveDelegationPublicKey
+    deriveMultisigPublicKey accXPub = case role' of
+        CA.UTxOExternal -> deriveAddressPublicKey accXPub role'
+        CA.UTxOInternal -> deriveAddressPublicKey accXPub role'
+        CA.Stake -> deriveDelegationPublicKey accXPub
 
 -- | Convert 'NetworkDiscriminant type parameter to
 -- 'Cardano.Address.NetworkTag'.

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/SharedKey.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/SharedKey.hs
@@ -116,7 +116,7 @@ constructAddressFromIx role pTemplate dTemplate ix =
         pScript =
             replaceCosignersWithVerKeys role' pTemplate ix
         dScript s =
-            replaceCosignersWithVerKeys CA.Stake s ix
+            replaceCosignersWithVerKeys CA.Stake s minBound
     in Address $ case dTemplate of
         Just dTemplate' ->
             createBaseAddress pScript (dScript dTemplate')

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
@@ -558,7 +558,7 @@ instance MaybeLight (SharedState n k) where
 
 instance GenChange (SharedState n k) where
     type ArgGenChange (SharedState n k) =
-        (k 'AddressK XPub -> k 'AddressK XPub -> Address)
+        (ScriptTemplate -> Maybe ScriptTemplate -> Index 'Soft 'ScriptK -> Address)
 
     genChange mkAddress st = undefined
 

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
@@ -30,6 +30,8 @@ module Cardano.Wallet.Primitive.AddressDiscovery.Shared
     -- ** State
     , SharedState (..)
     , Readiness (..)
+    , SharedAddressPools (..)
+    , SharedAddressPool (..)
     , newSharedAddressPool
 
     , ErrAddCosigner (..)

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
@@ -91,6 +91,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.SharedKey
     )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( CompareDiscovery (..)
+    , GenChange (..)
     , GetAccount (..)
     , IsOurs (..)
     , KnownAddresses (..)
@@ -554,6 +555,12 @@ instance Typeable n => KnownAddresses (SharedState n k) where
 
 instance MaybeLight (SharedState n k) where
     maybeDiscover = Nothing
+
+instance GenChange (SharedState n k) where
+    type ArgGenChange (SharedState n k) =
+        (k 'AddressK XPub -> k 'AddressK XPub -> Address)
+
+    genChange mkAddress st = undefined
 
 {-------------------------------------------------------------------------------
     Address utilities

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
@@ -37,6 +37,7 @@ module Cardano.Wallet.Primitive.AddressDiscovery.Shared
     , PendingIxs
     , emptyPendingIxs
     , pendingIxsToList
+    , pendingIxsFromList
 
     , ErrAddCosigner (..)
     , ErrScriptTemplate (..)
@@ -149,6 +150,7 @@ import qualified Cardano.Address as CA
 import qualified Cardano.Address.Style.Shelley as CA
 import qualified Cardano.Wallet.Address.Pool as AddressPool
 import qualified Data.Foldable as F
+import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
@@ -180,6 +182,11 @@ instance NFData PendingIxs
 -- of combining two pending sets.
 emptyPendingIxs :: PendingIxs
 emptyPendingIxs = PendingIxs mempty
+
+-- | Construct a 'PendingIxs' from a list, ensuring that it is a set of indexes
+-- in descending order.
+pendingIxsFromList :: [Index 'Soft 'ScriptK] -> PendingIxs
+pendingIxsFromList = PendingIxs . reverse . map head . L.group . L.sort
 
 {-------------------------------------------------------------------------------
     Address Pool

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -75,7 +75,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , purposeCIP1852
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
-    ( SharedState (..) )
+    ( SharedAddressPools (..), SharedState (..) )
 import Cardano.Wallet.Primitive.Model
     ( Wallet, currentTip, getState, unsafeInitWallet, utxo )
 import Cardano.Wallet.Primitive.Passphrase.Types

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -71,7 +71,6 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , SeqState (..)
     , coinTypeAda
     , defaultAddressPoolGap
-    , emptyPendingIxs
     , purposeCIP1852
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -71,6 +71,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , SeqState (..)
     , coinTypeAda
     , defaultAddressPoolGap
+    , emptyPendingIxs
     , purposeCIP1852
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
@@ -648,8 +649,11 @@ instance Arbitrary (SharedState 'Mainnet SharedKey) where
             pt
             Nothing
             defaultAddressPoolGap
-            (Shared.Active
-                $ Shared.newSharedAddressPool @'Mainnet defaultAddressPoolGap pt Nothing)
+            (Shared.Active $ SharedAddressPools
+                (Shared.newSharedAddressPool @'Mainnet defaultAddressPoolGap pt Nothing)
+                (Shared.newSharedAddressPool @'Mainnet defaultAddressPoolGap pt Nothing)
+                emptyPendingIxs
+            )
 
 defaultSharedStatePrefix :: DerivationPrefix
 defaultSharedStatePrefix = DerivationPrefix

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -652,7 +652,7 @@ instance Arbitrary (SharedState 'Mainnet SharedKey) where
             (Shared.Active $ SharedAddressPools
                 (Shared.newSharedAddressPool @'Mainnet defaultAddressPoolGap pt Nothing)
                 (Shared.newSharedAddressPool @'Mainnet defaultAddressPoolGap pt Nothing)
-                emptyPendingIxs
+                Shared.emptyPendingIxs
             )
 
 defaultSharedStatePrefix :: DerivationPrefix

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -122,9 +122,10 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
-    ( AddressPoolGap, PendingIxs (..), SeqState (..) )
+    ( AddressPoolGap, SeqState (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
-    ( Readiness
+    ( PendingIxs
+    , Readiness
     , SharedAddressPool (..)
     , SharedAddressPools (..)
     , SharedState (..)

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -109,6 +109,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , KeyFingerprint
     , NetworkDiscriminant (..)
     , PersistPrivateKey (..)
+    , Role (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
@@ -121,9 +122,13 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
-    ( AddressPoolGap, SeqState (..) )
+    ( AddressPoolGap, PendingIxs (..), SeqState (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
-    ( Readiness, SharedState (..) )
+    ( Readiness
+    , SharedAddressPool (..)
+    , SharedAddressPools (..)
+    , SharedState (..)
+    )
 import Cardano.Wallet.Primitive.Model
     ( Wallet )
 import Cardano.Wallet.Primitive.Passphrase.Types
@@ -987,6 +992,18 @@ instance ToExpr (SharedKey 'AccountK CC.XPub) where
 
 instance ToExpr (KeyFingerprint "payment" SharedKey) where
     toExpr = defaultExprViaShow
+
+instance ToExpr PendingIxs where
+    toExpr = genericToExpr
+
+instance ToExpr (SharedAddressPool 'UtxoExternal SharedKey) where
+    toExpr = genericToExpr
+
+instance ToExpr (SharedAddressPool 'UtxoInternal SharedKey) where
+    toExpr = genericToExpr
+
+instance ToExpr (SharedAddressPools SharedKey) where
+    toExpr = genericToExpr
 
 instance ToExpr (SharedState 'Mainnet SharedKey) where
     toExpr = genericToExpr

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -298,8 +298,7 @@ serveWallet
             (Server.manageRewardBalance proxyNetwork)
 
     withMultisigApi netLayer =
-        let txLayerUdefined = error "TO-DO in ADP-686"
-        in lift $ apiLayer txLayerUdefined netLayer Server.idleWorker
+        lift $ apiLayer (newTransactionLayer netId) netLayer Server.idleWorker
 
     startServer
         :: forall n.

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -166,6 +166,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Shared
     ( SharedKey (..) )
+import Cardano.Wallet.Primitive.AddressDerivation.SharedKey
+    ( constructAddressFromIx )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
@@ -225,7 +227,6 @@ server
         ( PaymentAddress n IcarusKey
         , PaymentAddress n ByronKey
         , DelegationAddress n ShelleyKey
-        , DelegationAddress n SharedKey
         , Typeable n
         , HasNetworkId n
         )
@@ -604,7 +605,7 @@ server byron icarus shelley multisig spl ntp =
         :: ApiLayer (SharedState n SharedKey) SharedKey
         -> Server (SharedTransactions n)
     sharedTransactions apilayer =
-        constructSharedTransaction apilayer (delegationAddress @n) (knownPools spl) (getPoolLifeCycleStatus spl)
+        constructSharedTransaction apilayer (constructAddressFromIx @n) (knownPools spl) (getPoolLifeCycleStatus spl)
 
 postAnyAddress
     :: NetworkId

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -51,6 +51,7 @@ import Cardano.Wallet.Api
     , SMASH
     , Settings
     , SharedAddresses
+    , SharedTransactions
     , SharedWalletKeys
     , SharedWallets
     , ShelleyMigrations
@@ -62,6 +63,7 @@ import Cardano.Wallet.Api
 import Cardano.Wallet.Api.Server
     ( apiError
     , balanceTransaction
+    , constructSharedTransaction
     , constructTransaction
     , createMigrationPlan
     , decodeTransaction
@@ -255,6 +257,7 @@ server byron icarus shelley multisig spl ntp =
     :<|> sharedWallets multisig
     :<|> sharedWalletKeys multisig
     :<|> sharedAddresses multisig
+    :<|> sharedTransactions multisig
   where
     wallets :: Server Wallets
     wallets = deleteWallet shelley
@@ -595,6 +598,12 @@ server byron icarus shelley multisig spl ntp =
         -> Server (SharedAddresses n)
     sharedAddresses apilayer =
              listAddresses apilayer normalizeSharedAddress
+
+    sharedTransactions
+        :: ApiLayer (SharedState n SharedKey) SharedKey
+        -> Server (SharedTransactions n)
+    sharedTransactions apilayer =
+             constructSharedTransaction apilayer (knownPools spl) (getPoolLifeCycleStatus spl)
 
 postAnyAddress
     :: NetworkId

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -225,6 +225,7 @@ server
         ( PaymentAddress n IcarusKey
         , PaymentAddress n ByronKey
         , DelegationAddress n ShelleyKey
+        , DelegationAddress n SharedKey
         , Typeable n
         , HasNetworkId n
         )
@@ -265,7 +266,7 @@ server byron icarus shelley multisig spl ntp =
         :<|> (fmap fst <$> listWallets shelley mkShelleyWallet)
         :<|> postWallet shelley Shelley.generateKeyFromSeed ShelleyKey
         :<|> putWallet shelley mkShelleyWallet
-        :<|> putWalletPassphrase 
+        :<|> putWalletPassphrase
                 shelley Shelley.generateKeyFromSeed Shelley.getKey
         :<|> getWalletUtxoSnapshot shelley
         :<|> getUTxOsStatistics shelley
@@ -597,13 +598,13 @@ server byron icarus shelley multisig spl ntp =
         :: ApiLayer (SharedState n SharedKey) SharedKey
         -> Server (SharedAddresses n)
     sharedAddresses apilayer =
-             listAddresses apilayer normalizeSharedAddress
+        listAddresses apilayer normalizeSharedAddress
 
     sharedTransactions
         :: ApiLayer (SharedState n SharedKey) SharedKey
         -> Server (SharedTransactions n)
     sharedTransactions apilayer =
-             constructSharedTransaction apilayer (knownPools spl) (getPoolLifeCycleStatus spl)
+        constructSharedTransaction apilayer (delegationAddress @n) (knownPools spl) (getPoolLifeCycleStatus spl)
 
 postAnyAddress
     :: NetworkId

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -159,7 +159,7 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Api.Types.SchemaMetadata
     ( TxMetadataSchema (..), parseSimpleMetadataFlag )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( DelegationAddress (..), PaymentAddress (..) )
+    ( DelegationAddress (..), PaymentAddress (..), Role (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -605,7 +605,8 @@ server byron icarus shelley multisig spl ntp =
         :: ApiLayer (SharedState n SharedKey) SharedKey
         -> Server (SharedTransactions n)
     sharedTransactions apilayer =
-        constructSharedTransaction apilayer (constructAddressFromIx @n) (knownPools spl) (getPoolLifeCycleStatus spl)
+        constructSharedTransaction apilayer (constructAddressFromIx @n UtxoInternal)
+        (knownPools spl) (getPoolLifeCycleStatus spl)
 
 postAnyAddress
     :: NetworkId

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -606,7 +606,7 @@ server byron icarus shelley multisig spl ntp =
         -> Server (SharedTransactions n)
     sharedTransactions apilayer =
         constructSharedTransaction apilayer (constructAddressFromIx @n UtxoInternal)
-        (knownPools spl) (getPoolLifeCycleStatus spl)
+            (knownPools spl) (getPoolLifeCycleStatus spl)
 
 postAnyAddress
     :: NetworkId

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -107,6 +107,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Shared
+    ( SharedKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey, toRewardAccountRaw )
 import Cardano.Wallet.Primitive.Passphrase
@@ -335,6 +337,9 @@ class TxWitnessTagFor (k :: Depth -> Type -> Type) where
     txWitnessTagFor :: TxWitnessTag
 
 instance TxWitnessTagFor ShelleyKey where
+    txWitnessTagFor = TxWitnessShelleyUTxO
+
+instance TxWitnessTagFor SharedKey where
     txWitnessTagFor = TxWitnessShelleyUTxO
 
 instance TxWitnessTagFor IcarusKey where

--- a/lib/shelley/test/integration/shelley-integration-test.hs
+++ b/lib/shelley/test/integration/shelley-integration-test.hs
@@ -157,6 +157,7 @@ import qualified Test.Integration.Scenario.API.Byron.TransactionsNew as ByronTra
 import qualified Test.Integration.Scenario.API.Byron.Wallets as ByronWallets
 import qualified Test.Integration.Scenario.API.Network as Network
 import qualified Test.Integration.Scenario.API.Shared.Addresses as SharedAddresses
+import qualified Test.Integration.Scenario.API.Shared.Transactions as SharedTransactions
 import qualified Test.Integration.Scenario.API.Shared.Wallets as SharedWallets
 import qualified Test.Integration.Scenario.API.Shelley.Addresses as Addresses
 import qualified Test.Integration.Scenario.API.Shelley.CoinSelections as CoinSelections
@@ -193,6 +194,7 @@ main = withTestsSetup $ \testDir tracers -> do
                     Wallets.spec @n
                     SharedWallets.spec @n
                     SharedAddresses.spec @n
+                    SharedTransactions.spec @n
                     ByronWallets.spec @n
                     HWWallets.spec @n
                     Migrations.spec @n

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -7400,12 +7400,16 @@ paths:
   /shared-wallets/{walletId}/transactions-construct:
     post:
       operationId: constructSharedTransaction
-      tags: ["Transactions New"]
+      tags: ["Shared Wallets"]
       summary: Construct
       description: |
         <p align="right">status: <strong>under development</strong></p>
 
         Create a transaction to be signed from the shared wallet.
+        Works for the following fields:
+              - payments
+              - metadata
+              - validity_interval
       parameters:
         - *parametersWalletId
       requestBody:

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -7397,6 +7397,24 @@ paths:
             schema: *ApiSharedWalletPatchData
       responses: *responsesPatchSharedWallet
 
+  /shared-wallets/{walletId}/transactions-construct:
+    post:
+      operationId: constructSharedTransaction
+      tags: ["Transactions New"]
+      summary: Construct
+      description: |
+        <p align="right">status: <strong>under development</strong></p>
+
+        Create a transaction to be signed from the shared wallet.
+      parameters:
+        - *parametersWalletId
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: *ApiConstructTransactionData
+      responses: *responsesConstructTransaction
+
   /shared-wallets/{walletId}/keys/{index}:
     post:
       operationId: postAccountKeyShared

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -5922,6 +5922,7 @@ x-tagGroups:
     - Shared Wallets
     - Shared Keys
     - Shared Addresses
+    - Shared Transactions
 
   - name: Byron (Random)
     tags:
@@ -7413,16 +7414,17 @@ paths:
   /shared-wallets/{walletId}/transactions-construct:
     post:
       operationId: constructSharedTransaction
-      tags: ["Shared Wallets"]
+      tags: ["Shared Transactions"]
       summary: Construct
       description: |
         <p align="right">status: <strong>under development</strong></p>
 
         Create a transaction to be signed from the shared wallet.
+
         Works for the following fields:
-              - payments
-              - metadata
-              - validity_interval
+          - payments
+          - metadata
+          - validity_interval
       parameters:
         - *parametersWalletId
       requestBody:

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -4229,6 +4229,18 @@ x-errValidityIntervalNotInsideScriptTimelock: &errValidityIntervalNotInsideScrip
       type: string
       enum: ['validity_interval_not_inside_script_timelock']
 
+x-errSharedWalletPending: &errSharedWalletPending
+  <<: *responsesErr
+  title: shared_wallet_pending
+  properties:
+    message:
+      type: string
+      description:
+        Occurs when attempting to create a transaction for a pending shared wallet.
+    code:
+      type: string
+      enum: ['shared_wallet_pending']
+
 x-errInputsDepleted: &errInputsDepleted
   <<: *responsesErr
   title: inputs_depleted
@@ -5421,6 +5433,7 @@ x-responsesConstructTransaction: &responsesConstructTransaction
             - <<: *errMintOrBurnAssetQuantityOutOfBounds
             - <<: *errInvalidValidityBounds
             - <<: *errValidityIntervalNotInsideScriptTimelock
+            - <<: *errSharedWalletPending
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
   <<: *responsesErr415UnsupportedMediaType


### PR DESCRIPTION
<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->

The work was realized in three areas:
1. On api level, the constructSharedTx was added in core's api level. Also swagger was updated accordingly.
    On api's server level the simplest (without delegation or minting support) impl was chosen. The error outlawing calling this endpoint was introduced when shared wallet is in pending state. Also transaction integration test suite was added 

2. The shared wallet state was extended. When the wallet is in active state now both external and internal pools are available. Also `PendingIxs` was added there. Those three things are now encapsulated in `SharedAddressPools` abstraction. So the accounting logic is like with shelley's wallet. In order to achieve that `SharedAddressPool` abstraction was generalized to account for chain type parameter. As previously active state has only external shared address pool, the change to have two more things had significant ripple effects down to DB layer. It also affected core unit testing. As `deriveAddressPublicKey` from cardano-addresses was assuming external chain only, the prerequisite for this PR is https://github.com/input-output-hk/cardano-addresses/pull/191 that enabled also derivation for internal chain.

Moreover, `GenChange` interface impl was added, also impl of `constructAddressFromIx` was changed, the same for `isShared` impl.   

3. `constructSharedTransaction` was added in `Cardano.Wallet`. `constructTransaction` wallet therein could not be used as it sets reward account in a way that is not enough for shared wallets, also it outlawsnon-shelly style wallets. For shared wallets delegation credential could be both keyhash (like for shelley) or script hash - at this moment key hash solution based on accXPub of wallet and ix=0 was added. In next PRs we will return to this subject. 
 
### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

adp-1623

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
