### PR TITLE
Bump to cardano node 1.35.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See **Installation Instructions** for each available [release](https://github.co
 >
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
-> | `master` branch | [1.35.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.0) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
+> | `master` branch | [1.35.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-07-01](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-07-01) | [1.35.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.0) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-05-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-05-27) | [1.34.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.34.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-04-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-04-27) | [1.34.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.34.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)

--- a/cabal.project
+++ b/cabal.project
@@ -213,8 +213,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-node
-    tag: 9f1d7dc163ee66410d912e48509d6a2300cfa68a
-    --sha256: 06arx9hv7dn3qxfy83f0b6018rxbsvh841nvfyg5w6qclm1hddj7
+    tag: c75451f0ffd7a60b5ad6c4263891e6c8acac105a
+    --sha256: 1z0zv1i58ikmbqg878f9z573jkwp4lzhmmswshm6c96rq6lprzh8
     subdir:
       cardano-api
       cardano-git-rev

--- a/cabal.project
+++ b/cabal.project
@@ -183,8 +183,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-ledger
-    tag: ce3057e0863304ccb3f79d78c77136219dc786c6
-    --sha256: 19ijcy1sl1iqa7diy5nsydnjsn3281kp75i2i42qv0fpn58238s9
+    tag: 3be8a19083fc13d9261b1640e27dd389b51bb08e
+    --sha256: 0dvm9l43mp1i34bcywmznd0660hhcfxwgawypk9q1hjkml1i41z3
     subdir:
       eras/alonzo/impl
       eras/alonzo/test-suite


### PR DESCRIPTION

- [x] I have bumped the version of `cardano-node` used by `cardano-wallet` to `1.35.1`.

### Comments

- No changes to our codebase were required.

### Issue Number

ADP-2007
