### PR TITLE
Light-mode: Fixes for Ada balance and rewards

### DIFF
--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -752,8 +752,9 @@ assembleTransaction
             :: [BF.UtxoInput]
             -> Either BlockfrostError ([(TxIn, Coin)], [(TxIn, Coin)])
         fromInputs utxos =
-            bitraverse f f $ partition BF._utxoInputCollateral utxos
+            bitraverse f f $ partition isRegularTxIn utxos
           where
+            isRegularTxIn = not . BF._utxoInputCollateral
             f :: [BF.UtxoInput] -> Either BlockfrostError [(TxIn, Coin)]
             f = traverse \input@BF.UtxoInput{..} -> do
                 txHash <- parseTxHash $ BF.unTxHash _utxoInputTxHash

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -71,7 +71,6 @@ import Cardano.Wallet.Primitive.BlockSummary
     , Sublist
     , fromBlockEvents
     , unsafeMkSublist
-    , wholeList
     )
 import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException
@@ -489,7 +488,7 @@ withNetworkLayer tr network np project k = do
                                 txBlockEvents
                                     bftx
                                     (unsafeMkSublist [((txIndex, 0), tx)])
-                                    (wholeList [])
+                                    (unsafeMkSublist [])
                         Right account -> do
                             let address = BF.Address $ encodeStakeAddress @nd account
                             regTxHashes <-
@@ -508,7 +507,7 @@ withNetworkLayer tr network np project k = do
                                         _transactionIndex <?#> "_transactionIndex"
                                     txBlockEvents
                                         tx
-                                        (wholeList [])
+                                        ( unsafeMkSublist [] )
                                         ( unsafeMkSublist $
                                             (\(n, dc) -> ((txIndex, n), dc))
                                                 <$> zip [0 ..] dcerts
@@ -527,7 +526,7 @@ withNetworkLayer tr network np project k = do
                                     txBlockEvents
                                         bftx
                                         (unsafeMkSublist [((txIndex, 0), tx)])
-                                        (wholeList [])
+                                        (unsafeMkSublist [])
                             pure $ blockEventsRegDeleg <> blockEventsWithdraw
                   where
                     txBlockEvents ::

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -377,7 +377,7 @@ withNetworkLayer tr network np project k = do
                     bfGetAccount bfLayer addr
                         >>= traverse \BF.AccountInfo{..} -> throwBlockfrostError $
                             (rewardAccount,) . Coin <$>
-                                fromIntegral @_ @Integer _accountInfoRewardsSum
+                                fromIntegral @_ @Integer _accountInfoWithdrawableAmount
                                     <?#> "AccountInfoRewardsSum"
 
     getCachedRewardAccountBalance :: BlockfrostLayer IO -> RewardAccount -> IO Coin

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -600,10 +600,8 @@ blockfrostLightSyncSource
                 pure $ blockEventsRegDeleg <> blockEventsWithdraw
       where
         slotFromBlockHeader = toSlot . chainPointFromBlockHeader
-        (slotFrom, slotTo) =
-            ( slotFromBlockHeader bhFrom
-            , slotFromBlockHeader bhTo
-            )
+        slotFrom = slotFromBlockHeader bhFrom
+        slotTo = slotFromBlockHeader bhTo
 
         txBlockEvents ::
             BF.Transaction ->

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -607,6 +607,9 @@ withNetworkLayer tr network np project k = do
                                 throwIO . BlockfrostException $
                                     PoolStakePercentageError total live
 
+{-------------------------------------------------------------------------------
+    Fetching blocks and transactions
+-------------------------------------------------------------------------------}
 fetchNextBlocks
     :: Tracer IO Log
     -> SomeNetworkDiscriminant
@@ -785,6 +788,9 @@ unmarshalMetadataValue = \case
     Aeson.Null ->
         Left "Expected TxMetadataValue but got null"
 
+{-------------------------------------------------------------------------------
+    Protocol parameters and network information
+-------------------------------------------------------------------------------}
 fromBlockfrostPP
     :: NetworkId
     -> BF.ProtocolParams

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -178,7 +178,7 @@ import Data.Functor.Contravariant
 import Data.IntCast
     ( intCast )
 import Data.List
-    ( partition )
+    ( partition, sortOn )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Map
@@ -210,8 +210,6 @@ import Data.Traversable
     ( for )
 import Fmt
     ( pretty )
-import GHC.OldList
-    ( sortOn )
 import Ouroboros.Consensus.Cardano.Block
     ( CardanoBlock, StandardCrypto )
 import Ouroboros.Consensus.HardFork.History.EraParams
@@ -731,7 +729,9 @@ assembleTransaction
         let fee = Just $ Coin $ fromIntegral _transactionFees
         (resolvedInputs, resolvedCollateralInputs) <-
             fromInputs _transactionUtxosInputs
-        outputs <- for _transactionUtxosOutputs \out@BF.UtxoOutput{..} -> do
+        let sortedTransactionUtxosOutputs =
+                sortOn BF._utxoOutputOutputIndex _transactionUtxosOutputs
+        outputs <- for sortedTransactionUtxosOutputs \out@BF.UtxoOutput{..} -> do
             address <- fromBfAddress network _utxoOutputAddress
             tokens <- do
                 coin <- case [ lovelaces


### PR DESCRIPTION
### Issue number

ADP-2013

### Overview

This pull request fixes a couple of issues with light-mode, specifically those relating to the ADA and reward balances.

### Details
* Fix accidental interchange of regular and collateral inputs in `fromInputs`.
* Fix usage of `wholeList`. This function only makes sense when we fetch an entire block — only then do we know that we have the whole list, not just a sublist.
* Use `_accountInfoWithdrawableAmount` instead of`_accountInfoRewardsSum`. It looks like the latter function shows all rewards that were ever accumulated, while we want the balance of rewards that can still be withdrawn from the account.
* Fix filtering of transactions for RewardAccount — we only want those transactions that fall within the bounds `bhFrom` and `bhTo`.
* Fix sorting of transaction outputs — it turns out that `_transactionUtxosOutputs` does not necessarily yield the transaction outputs in order, which messes up the output indices.
