### PR TITLE
Re-enable Babbage-era minimum UTxO calculation for the Babbage era

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -674,7 +674,8 @@ walletId =
 -- | Min UTxO parameter for the test cluster.
 minUTxOValue :: ApiEra -> Natural
 minUTxOValue e
-    | e >= ApiBabbage = 999_920
+    | e >= ApiBabbage = 1_107_670 -- needs to be overestimated for the sake of
+    -- long byron addresses
     | e >= ApiAlonzo = 999_978 -- From 34482 lovelace per word
     | otherwise   = 1_000_000
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -506,7 +506,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             -- small enough to make the migration algorithm categorize the
             -- entry as a freerider.
             --
-            let perEntryAdaQuantity = Coin 1_562_500
+            let perEntryAdaQuantity = Coin 1_462_500
             let perEntryAssetCount = 1
             let batchSize = 20
             sourceAddresses <- take 20 . map (getApiT . fst . view #id)
@@ -520,7 +520,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
 
             -- Check that minting was successful, and that the balance and UTxO
             -- distribution have both changed accordingly:
-            let expectedBalanceAda = 287_500_000
+            let expectedBalanceAda = 275_500_000
             let expectedAssetCount = 20
             request @ApiWallet ctx
                 (Link.getWallet @'Shelley sourceWallet) Default Empty
@@ -566,9 +566,9 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 , expectField id
                     ((`shouldBe` 1) . apiPlanTotalOutputCount)
                 , expectField (#balanceSelected . #ada . #getQuantity)
-                    (`shouldBe` 257_812_500)
+                    (`shouldBe` 247_712_500)
                 , expectField (#balanceLeftover . #ada . #getQuantity)
-                    (`shouldBe`  29_687_500)
+                    (`shouldBe` 27_787_500)
                 , expectField (#balanceSelected . #assets . #getApiT)
                     ((.> 0) . TokenMap.size)
                 , expectField (#balanceLeftover . #assets . #getApiT)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -225,8 +225,9 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             -- entry as a freerider.
 
             let perEntryAdaQuantity = Coin $ case _mainEra ctx of
-                    e | e >= ApiAlonzo -> 3_100_000
-                      | otherwise      -> 3_300_000
+                    e | e == ApiAlonzo  -> 3_100_000
+                      | e == ApiBabbage -> 2_500_000
+                      | otherwise       -> 3_300_000
 
             let perEntryAssetCount = 10
             let batchSize = 20

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -952,8 +952,12 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 { testName =
                     "transaction with metadata from ADP-1005 (2 outputs)"
                 , txOutputAdaQuantities = \_minUTxOVal ->
-                    -- The exact ada quantities recorded in ADP-1005:
-                    [1_000_000, 498_283_127]
+                    -- An ada quantity that is greater than or equal to the
+                    -- minimum ada quantity for all known eras:
+                    [ 1_107_670
+                    -- The exact ada quantity recorded in ADP-1005:
+                    , 498_283_127
+                    ]
                 , txMetadata =
                       Just txMetadata_ADP_1005
                 , expectedFee =

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -2697,7 +2697,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
     it "TRANS_NEW_JOIN_02 - Can join stakepool in case I have many UTxOs on 1 address"
         $ \ctx -> runResourceT $ do
-        let amt = 1_000_000
+        let amt = minUTxOValue (_mainEra ctx)
         src <- emptyWallet ctx
         wa <- fixtureWallet ctx
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -3434,13 +3434,11 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         -- UTxO plus additional adjusting of assets in output. Here, we are
         -- having 80-byte (10-word) asset's additional burden
         --
-        let lovelacePerUtxoWord =
+        let minUtxoWithAsset = minutxo +
+                -- The extra amount is dependent on the era:
                 if _mainEra ctx >= ApiBabbage
-                then 34480
-                -- Not sure why this differs... perhaps because of the new
-                -- minUTxO calculation. Should be fine nonethenless though.
-                else 34482
-        let minUtxoWithAsset = minutxo + 10*lovelacePerUtxoWord
+                then 176_710
+                else 344_820 -- = 34_482 lovelace per word * 10 words
 
         eventually
             "Wallet balance is decreased by fee and adjusted minimum UTxO and \

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -277,8 +277,6 @@ import Data.ByteString.Short
     ( fromShort, toShort )
 import Data.Coerce
     ( coerce )
-import Data.Default
-    ( Default (..) )
 import Data.Foldable
     ( toList )
 import Data.Function
@@ -915,19 +913,7 @@ fromBabbagePParams eraInfo currentNodeProtocolParameters pp =
         , desiredNumberOfStakePools =
             desiredNumberOfStakePoolsFromPParams pp
         , minimumUTxO =
-            -- FIXME [ADP-1978] need to fix for final Babbage support ⚠️
-            --
-            -- We unexpectedly needed to increase @maxLengthAddress@ causing
-            -- tests to break in Babbage. Using the Alonzo calculation even in
-            -- Babbage is correct enough to make the integration tests to pass
-            -- in Babbage, and for us to be able to merge the Babbage
-            -- integration cluster support to master. This is not waterproof
-            -- though, and we should definitely use the babbage-specific
-            -- calculation.
-            minimumUTxOForShelleyBasedEra ShelleyBasedEraAlonzo $
-                def { Alonzo._coinsPerUTxOWord =
-                        multiplyCoinBy 8 $ Babbage._coinsPerUTxOByte pp
-                    }
+            minimumUTxOForShelleyBasedEra ShelleyBasedEraBabbage pp
         , stakeKeyDeposit = stakeKeyDepositFromPParams pp
         , eras = fromBoundToEpochNo <$> eraInfo
         , maximumCollateralInputCount = unsafeIntToWord $
@@ -938,8 +924,6 @@ fromBabbagePParams eraInfo currentNodeProtocolParameters pp =
             Just $ executionUnitPricesFromPParams pp
         , currentNodeProtocolParameters
         }
-  where
-    multiplyCoinBy a (SL.Coin c) = SL.Coin (a * c)
 
 -- | Extract the current network decentralization level from the given set of
 -- protocol parameters.

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -24,9 +24,6 @@
 -- Jörmungandr dual support.
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
--- We have to use it until 'BabbageEra' appears in 'Cardano.Api'.
-{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
-
 -- |
 -- Copyright: © 2020 IOHK
 -- License: Apache-2.0

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -134,11 +134,9 @@ spec = do
             goldenTests_computeMinimumCoinForUTxO "Alonzo"
                 goldenMinimumUTxO_Alonzo
                 goldenMinimumCoins_Alonzo
-
-            -- FIXME [ADP-1978] Re-enable
-            --goldenTests_computeMinimumCoinForUTxO "Babbage"
-            --    goldenMinimumUTxO_Babbage
-            --    goldenMinimumCoins_Babbage
+            goldenTests_computeMinimumCoinForUTxO "Babbage"
+                goldenMinimumUTxO_Babbage
+                goldenMinimumCoins_Babbage
 
 -- Check that it's possible to evaluate 'computeMinimumCoinForUTxO' without
 -- any run-time error.
@@ -346,9 +344,8 @@ goldenMinimumUTxO_Alonzo =
     minimumUTxOForShelleyBasedEra ShelleyBasedEraAlonzo
         def {Alonzo._coinsPerUTxOWord = testParameter_coinsPerUTxOWord_Alonzo}
 
--- FIXME [ADP-1978] Re-enable
-_goldenMinimumUTxO_Babbage :: MinimumUTxO
-_goldenMinimumUTxO_Babbage =
+goldenMinimumUTxO_Babbage :: MinimumUTxO
+goldenMinimumUTxO_Babbage =
     minimumUTxOForShelleyBasedEra ShelleyBasedEraBabbage
         def {Babbage._coinsPerUTxOByte = testParameter_coinsPerUTxOByte_Babbage}
 
@@ -392,9 +389,8 @@ goldenMinimumCoins_Alonzo =
     , (goldenTokenMap_4, Coin 1_862_028)
     ]
 
--- FIXME [ADP-1978] Re-enable
-_goldenMinimumCoins_Babbage :: [(TokenMap, Coin)]
-_goldenMinimumCoins_Babbage =
+goldenMinimumCoins_Babbage :: [(TokenMap, Coin)]
+goldenMinimumCoins_Babbage =
     [ (goldenTokenMap_0, Coin   995_610)
     , (goldenTokenMap_1, Coin 1_150_770)
     , (goldenTokenMap_2, Coin 1_323_170)

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -391,11 +391,11 @@ goldenMinimumCoins_Alonzo =
 
 goldenMinimumCoins_Babbage :: [(TokenMap, Coin)]
 goldenMinimumCoins_Babbage =
-    [ (goldenTokenMap_0, Coin   995_610)
-    , (goldenTokenMap_1, Coin 1_150_770)
-    , (goldenTokenMap_2, Coin 1_323_170)
-    , (goldenTokenMap_3, Coin 1_323_170)
-    , (goldenTokenMap_4, Coin 2_012_770)
+    [ (goldenTokenMap_0, Coin 1_107_670)
+    , (goldenTokenMap_1, Coin 1_262_830)
+    , (goldenTokenMap_2, Coin 1_435_230)
+    , (goldenTokenMap_3, Coin 1_435_230)
+    , (goldenTokenMap_4, Coin 2_124_830)
     ]
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
## Issue Number

ADP-2026

## Summary

This PR reverts a subset of the changes made in #3318.

In particular, we:
- re-enable the Babbage-era minimum UTxO calculation for the Babbage era;
- re-enable the golden tests for Babbage-era UTxO values.

In addition, we:
- fix integration tests for Alonzo and Babbage eras by adjusting several hard-coded constants that relate to minimum UTxO values.