### PR TITLE
Skip alwaysfails.plutus test (PlutusV2 cost model removed on testnet)

### DIFF
--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe "Cardano Wallet E2E tests", :all, :e2e do
       when 'vasil-dev'
         script_utxo = 'ce149a5dea4b09d1717ffbe79f8e46ddd9bf0401e95a69502b71f792982b5013#1'
       when 'testnet'
+        skip "Skipping temporarily as PlutusV2 cost model was removed from testnet"
         script_utxo = '54b4e4e34a022424e441b00d8a73e9aaef71b3c63084e76246d326074c5d3756#1'
       else
         skip %(


### PR DESCRIPTION

- [x] Skip alwaysfails.plutus test (PlutusV2 cost model removed on testnet)

### Comments

Temporarily skip this test. It is failing because PlutusV2 cost model was removed from testnet for now.

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
