### PR TITLE
Fix `FilteredBlock` transactions being reversed

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -696,10 +696,10 @@ applyBlockEventsToUTxO BlockEvents{slot,blockHeight,transactions,delegations} s 
   where
     fblock = FilteredBlock
       { slot
-      , transactions = txs1
+      , transactions = reverse rtxs1
       , delegations = filter (ours s . dlgCertAccount) $ toList delegations
       }
-    (txs1, du1, u1) = L.foldl' applyOurTx (mempty, mempty, u0)
+    (rtxs1, du1, u1) = L.foldl' applyOurTx (mempty, mempty, u0)
         $ toList transactions
 
     applyOurTx


### PR DESCRIPTION
### Issue number

ADP-1783

### Overview

This pull request fixes a small issue where the order of transactions in a `FilteredBlock` was accidentally reversed.

### Comments

* The order of transactions in a `Block` does matter, and any mistakes there would impact the wallet balance. Fortunately, the `FilteredBlock` is created after processing blocks and the data contained therein is only used to archive the transaction history.
* This issue was introduced when the helper function `applyOurTx` was introduced in the scope of a `foldl'`.
