### PR TITLE
Attempt to fix Windows e2e tests

### DIFF
--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -82,9 +82,9 @@ jobs:
       uses: actions/cache@v2.1.7
       with:
         path: C:/cardano-wallet/test/e2e/state/wallet_db/${{ env.NETWORK }}
-        key: wallet-db-${{ runner.os }}-${{ env.NETWORK }}-${{ steps.date-time.outputs.value }}
+        key: wallet-db2-${{ runner.os }}-${{ env.NETWORK }}-${{ steps.date-time.outputs.value }}
         restore-keys: |
-          wallet-db-${{ runner.os }}-${{ env.NETWORK }}-
+          wallet-db2-${{ runner.os }}-${{ env.NETWORK }}-
 
     - name: ⚙️ Setup (get latest bins and configs and decode fixtures)
       working-directory: C:/cardano-wallet/test/e2e

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -31,6 +31,13 @@ jobs:
     - name: Check space
       run: Get-PSDrive
 
+    - name: configure Pagefile
+      uses: al-cheb/configure-pagefile-action@v1.2
+      with:
+        minimum-size: 16GB
+        maximum-size: 24GB
+        disk-root: "C:"
+
     - name: Checkout
       shell: bash
       run: |


### PR DESCRIPTION
- [x] Attempt to fix Windows e2e tests by making pageFile bigger

### Comments

So, usually wallets DB that is used in e2e tests is taken from the [GH cache](https://github.com/input-output-hk/cardano-wallet/blob/master/.github/workflows/e2e-windows.yml#L80-L87). Few days ago I believe the cache didn't work for some reason which lead to wallet synchronizing 4-5 wallets from scratch before the test. This didn't go well on Windows, the wallet during the restoration phase was stopping and then re-starting with:
```
cardano-wallet.exe: getMBlocks: VirtualAlloc MEM_COMMIT failed: The paging file is too small for this operation to complete.
```
(which was causing the whole suite to fail)

As a fix/workaround for that I made pageFile bigger (min 16GB)... and with that it seems to work fine:

https://github.com/input-output-hk/cardano-wallet/runs/7427696173?check_suite_focus=true

Not entirely sure if the issue `VirtualAlloc MEM_COMMIT failed` is something to worry about, clearly it is now not enough mem for the GH action windows. I haven't encountered this on my local Windows VM though.

### Issue Number

n/a
