### PR TITLE
Bump dependencies to cardano-node 1.35.2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -157,8 +157,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: f680ac6979e069fcc013e4389ee607ff5fa6672f
-  --sha256: 180jq8hd0jlg48ya7b5yw3bnd2d5czy0b1agy9ng3mgnzpyq747i
+  tag: a3fba9f4e776c38bc54cb9a1c1cae82d2338b718
+  --sha256: 1vy4fwrq5jbghwkfgnrd5c22zjv8ym9y2j8g38pq50da4nfyv3dh
   subdir:
     plutus-core
     plutus-ledger-api
@@ -183,8 +183,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-ledger
-    tag: 3be8a19083fc13d9261b1640e27dd389b51bb08e
-    --sha256: 0dvm9l43mp1i34bcywmznd0660hhcfxwgawypk9q1hjkml1i41z3
+    tag: ebcf1a8936dd84de0182d54004473f4ce66c7923
+    --sha256: 1nx07kcjhj39alarr0bxw9viw3m6flfr8d14g2a3crymf6hxwg36
     subdir:
       eras/alonzo/impl
       eras/alonzo/test-suite
@@ -213,8 +213,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-node
-    tag: c75451f0ffd7a60b5ad6c4263891e6c8acac105a
-    --sha256: 1z0zv1i58ikmbqg878f9z573jkwp4lzhmmswshm6c96rq6lprzh8
+    tag: 7612a245a6e2c51d0f1c3e0d65d7fe9363850043
+    --sha256: 01a5qdrmsag18s2mlf8axfbrag59j2fp6xyc89pwmzgs7x77ldsr
     subdir:
       cardano-api
       cardano-git-rev
@@ -265,8 +265,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/ouroboros-network
-    tag: a65c29b6a85e90d430c7f58d362b7eb097fd4949
-    --sha256: 1fmab5hmi1y8lss97xh6hhikmyhsx9x31yhvg6zpr2kcq7kc6qkf
+    tag: cb9eba406ceb2df338d8384b35c8addfe2067201
+    --sha256: 066llskxzjgcs13lwlvklb28azb9kd9b77j61x8fvrj1rlf5njfw
     subdir:
       monoidal-synchronisation
       network-mux


### PR DESCRIPTION
- Bumped cardano-node to 1.35.2
- Bumped plutus, cardano-ledger, and ouroboros-network to use the same version that
  cardano-node 1.35.2 uses.

### Comments

[Node CHANGELOG](https://github.com/input-output-hk/cardano-node/blob/7612a245a6e2c51d0f1c3e0d65d7fe9363850043/cardano-node/ChangeLog.md)

#### Plutus changes:

https://github.com/input-output-hk/plutus/compare/f680ac6979e069fcc013e4389ee607ff5fa6672f..a3fba9f4e776c38bc54cb9a1c1cae82d2338b718

#### Node changes:

https://github.com/input-output-hk/cardano-node/compare/c75451f0ffd7a60b5ad6c4263891e6c8acac105a..7612a245a6e2c51d0f1c3e0d65d7fe9363850043

#### Network changes

https://github.com/input-output-hk/ouroboros-network/compare/a65c29b6a85e90d430c7f58d362b7eb097fd4949..cb9eba406ceb2df338d8384b35c8addfe2067201

#### Ledger changes

https://github.com/input-output-hk/cardano-ledger/compare/3be8a19083fc13d9261b1640e27dd389b51bb08e..ebcf1a8936dd84de0182d54004473f4ce66c7923


### Issue Number

[ADP-2066](https://input-output.atlassian.net/browse/ADP-2066)