### PR TITLE
Upload wallet-db on e2e failure

### DIFF
--- a/.github/workflows/e2e-linux-lite.yml
+++ b/.github/workflows/e2e-linux-lite.yml
@@ -15,7 +15,7 @@ on:
       tags:
         description: 'Test tags (all, light, offchain...)'
         default: 'light'
-        
+
 defaults:
   run:
     working-directory: ./test/e2e
@@ -64,6 +64,13 @@ jobs:
         name: ${{ runner.os }}-logs
         path: test/e2e/state/logs
 
+    - name: 📎 Upload wallet-db
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: ${{ runner.os }}-wallet-db
+        path: test/e2e/state/wallet_db
+        
     env:
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}
       NETWORK: ${{ github.event.inputs.network || 'testnet' }}

--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -98,6 +98,13 @@ jobs:
         name: ${{ runner.os }}-logs
         path: test/e2e/state/logs
 
+    - name: 📎 Upload wallet-db
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: ${{ runner.os }}-wallet-db
+        path: test/e2e/state/wallet_db
+        
     env:
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}
       NETWORK: ${{ github.event.inputs.network || 'testnet' }}

--- a/.github/workflows/e2e-macos-lite.yml
+++ b/.github/workflows/e2e-macos-lite.yml
@@ -67,6 +67,13 @@ jobs:
         name: ${{ runner.os }}-logs
         path: test/e2e/state/logs
 
+    - name: 📎 Upload wallet-db
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: ${{ runner.os }}-wallet-db
+        path: test/e2e/state/wallet_db
+        
     env:
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}
       NETWORK: ${{ github.event.inputs.network || 'testnet' }}

--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -102,6 +102,13 @@ jobs:
         name: ${{ runner.os }}-logs
         path: test/e2e/state/logs
 
+    - name: 📎 Upload wallet-db
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: ${{ runner.os }}-wallet-db
+        path: test/e2e/state/wallet_db
+
     env:
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}
       NETWORK: ${{ github.event.inputs.network || 'testnet' }}

--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -73,9 +73,9 @@ jobs:
       uses: actions/cache@v2.1.7
       with:
         path: test/e2e/state/wallet_db/${{ env.NETWORK }}
-        key: wallet-db-${{ runner.os }}-${{ env.NETWORK }}-${{ steps.date-time.outputs.value }}
+        key: wallet-db2-${{ runner.os }}-${{ env.NETWORK }}-${{ steps.date-time.outputs.value }}
         restore-keys: |
-          wallet-db-${{ runner.os }}-${{ env.NETWORK }}-
+          wallet-db2-${{ runner.os }}-${{ env.NETWORK }}-
 
     - name: ⚙️ Setup (get latest bins and configs and decode fixtures)
       run: rake setup[$NETWORK,$PR]

--- a/.github/workflows/e2e-windows-lite.yml
+++ b/.github/workflows/e2e-windows-lite.yml
@@ -15,7 +15,7 @@ on:
       tags:
         description: 'Test tags (all, light, offchain...)'
         default: 'light'
-        
+
 defaults:
   run:
     working-directory: ./test/e2e
@@ -70,6 +70,13 @@ jobs:
         name: ${{ runner.os }}-logs
         path: test/e2e/state/logs
 
+    - name: 📎 Upload wallet-db
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: ${{ runner.os }}-wallet-db
+        path: test/e2e/state/wallet_db
+        
     env:
       NETWORK: ${{ github.event.inputs.network || 'testnet' }}
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -124,6 +124,13 @@ jobs:
         name: ${{ runner.os }}-logs
         path: C:/cardano-wallet/test/e2e/state/logs
 
+    - name: 📎 Upload wallet-db
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: ${{ runner.os }}-wallet-db
+        path: C:/cardano-wallet/test/e2e/state/wallet_db
+
     env:
       NETWORK: ${{ github.event.inputs.network || 'testnet' }}
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}


### PR DESCRIPTION

- [x] I have added step to upload wallet-db for potential investigation when e2e workflow fails
- [x] reseted wallet-db cache for MacOS due to ADP-2069

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2069
