### PR TITLE
Reduce overestimation of minimum UTXO values for Shelley-era addresses.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -674,9 +674,20 @@ walletId =
 -- | Min UTxO parameter for the test cluster.
 minUTxOValue :: ApiEra -> Natural
 minUTxOValue e
-    | e >= ApiBabbage = 1_107_670 -- needs to be overestimated for the sake of
-    -- long byron addresses
-    | e >= ApiAlonzo = 999_978 -- From 34482 lovelace per word
+    | e >= ApiBabbage = 995_610
+        -- This value is a slight overestimation for outputs with Shelley
+        -- addresses and no tokens.
+        --
+        -- However, it would be incorrect for outputs with Byron addresses,
+        -- where the lower bound would be greater by the following amount:
+        --
+        -- 4310 lovelace/byte * (86 - 57) byte ≈ 0.125 ada
+        --
+        -- However, this value appears to be fine for the purposes of
+        -- integration tests.
+        --
+    | e >= ApiAlonzo = 999_978
+        -- From 34482 lovelace/word.
     | otherwise   = 1_000_000
 
 -- | Parameter in test cluster shelley genesis.

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -21,7 +21,7 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.ProtocolMagic
     ( getProtocolMagic, mainnetMagic )
 import Control.Monad
     ( when )

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -1433,8 +1433,8 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
     costOfJoining :: Context -> Natural
     costOfJoining ctx =
         if _mainEra ctx >= ApiBabbage
-        then costOf (\coeff cst -> 458 * coeff + cst) ctx
-        else costOf (\coeff cst -> 454 * coeff + cst) ctx
+        then costOf (\coeff cst -> 487 * coeff + cst) ctx
+        else costOf (\coeff cst -> 483 * coeff + cst) ctx
 
     costOfQuitting :: Context -> Natural
     costOfQuitting ctx =

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -252,6 +252,7 @@ library
       Cardano.Wallet.Primitive.Passphrase.Types
       Cardano.Wallet.Primitive.Types
       Cardano.Wallet.Primitive.Types.Address
+      Cardano.Wallet.Primitive.Types.Address.Constants
       Cardano.Wallet.Primitive.Types.Coin
       Cardano.Wallet.Primitive.Types.Hash
       Cardano.Wallet.Primitive.Types.MinimumUTxO

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -256,6 +256,7 @@ library
       Cardano.Wallet.Primitive.Types.Hash
       Cardano.Wallet.Primitive.Types.MinimumUTxO
       Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
+      Cardano.Wallet.Primitive.Types.ProtocolMagic
       Cardano.Wallet.Primitive.Types.Redeemer
       Cardano.Wallet.Primitive.Types.RewardAccount
       Cardano.Wallet.Primitive.Types.TokenBundle

--- a/lib/core/src/Cardano/Byron/Codec/Cbor.hs
+++ b/lib/core/src/Cardano/Byron/Codec/Cbor.hs
@@ -49,12 +49,12 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), DerivationType (..), Index (..) )
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase (..) )
-import Cardano.Wallet.Primitive.Types
-    ( ProtocolMagic (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.ProtocolMagic
+    ( ProtocolMagic (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxIn (..), TxOut (..), unsafeCoinToTxOutCoinValue )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -422,8 +422,6 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (UnsafeTokenName), TokenPolicyId (UnsafeTokenPolicyId) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
@@ -474,7 +472,7 @@ import Cardano.Wallet.Transaction
 import Control.Applicative
     ( (<|>) )
 import Control.Arrow
-    ( left )
+    ( first, left )
 import Control.DeepSeq
     ( NFData )
 import Control.Monad
@@ -547,7 +545,7 @@ import Data.Map.Strict
 import Data.Maybe
     ( fromMaybe, isJust, mapMaybe )
 import Data.Proxy
-    ( Proxy )
+    ( Proxy (..) )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Set
@@ -923,26 +921,28 @@ getWalletUtxoSnapshot ctx wid = do
     (wallet, _, pending) <- withExceptT id (readWallet @ctx @s @k ctx wid)
     pp <- liftIO $ currentProtocolParameters nl
     era <- liftIO $ currentNodeEra nl
-    let bundles = availableUTxO @s pending wallet
+    let txOuts = availableUTxO @s pending wallet
             & unUTxO
             & F.toList
-            & fmap (view #tokens)
-    pure $ pairBundleWithMinAdaQuantity era pp <$> bundles
+    pure $ first (view #tokens) . pairTxOutWithMinAdaQuantity era pp <$> txOuts
   where
     nl = ctx ^. networkLayer
     tl = ctx ^. transactionLayer @k
 
-    pairBundleWithMinAdaQuantity
+    pairTxOutWithMinAdaQuantity
         :: Cardano.AnyCardanoEra
         -> ProtocolParameters
-        -> TokenBundle
-        -> (TokenBundle, Coin)
-    pairBundleWithMinAdaQuantity era pp bundle =
-        (bundle, computeMinAdaQuantity $ view #tokens bundle)
+        -> TxOut
+        -> (TxOut, Coin)
+    pairTxOutWithMinAdaQuantity era pp out =
+        (out, computeMinAdaQuantity out)
       where
-        computeMinAdaQuantity :: TokenMap -> Coin
-        computeMinAdaQuantity =
-            view #txOutputMinimumAdaQuantity (constraints tl era pp)
+        computeMinAdaQuantity :: TxOut -> Coin
+        computeMinAdaQuantity (TxOut addr bundle) =
+            view #txOutputMinimumAdaQuantity
+                (constraints tl era pp)
+                (addr)
+                (view #tokens bundle)
 
 -- | List the wallet's UTxO statistics.
 listUtxoStatistics
@@ -1988,6 +1988,8 @@ balanceTransactionWithSelectionStrategy
                     intCast @Word16 @Int $ view #maximumCollateralInputCount pp
                 , minimumCollateralPercentage =
                     view #minimumCollateralPercentage pp
+                , maximumLengthChangeAddress =
+                    maxLengthAddressFor $ Proxy @k
                 }
 
             selectionParams = SelectionParams
@@ -2174,8 +2176,8 @@ calcMinimumCoinValues
 calcMinimumCoinValues ctx era outs = do
     pp <- currentProtocolParameters nl
     pure
-        $ view #txOutputMinimumAdaQuantity (constraints tl era pp)
-        . view (#tokens . #tokens) <$> outs
+        $ uncurry (view #txOutputMinimumAdaQuantity (constraints tl era pp))
+        . (\o -> (view #address o, view (#tokens . #tokens) o)) <$> outs
   where
     nl = ctx ^. networkLayer
     tl = ctx ^. transactionLayer @k
@@ -2251,6 +2253,8 @@ selectAssets ctx era pp params transform = do
                 intCast @Word16 @Int $ view #maximumCollateralInputCount pp
             , minimumCollateralPercentage =
                 view #minimumCollateralPercentage pp
+            , maximumLengthChangeAddress =
+                maxLengthAddressFor $ Proxy @k
             }
     let selectionParams = SelectionParams
             { assetsToMint =

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -290,7 +290,8 @@ import Cardano.Wallet.Network
     , NetworkLayer (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( DelegationAddress (..)
+    ( BoundedAddressLength (..)
+    , DelegationAddress (..)
     , Depth (..)
     , DerivationIndex (..)
     , DerivationPrefix (..)
@@ -1568,6 +1569,7 @@ balanceTransaction
         , MonadRandom m
         , HasLogger m WalletWorkerLog ctx
         , Cardano.IsShelleyBasedEra era
+        , BoundedAddressLength k
         )
     => ctx
     -> ArgGenChange s
@@ -1591,6 +1593,7 @@ balanceTransactionWithSelectionStrategy
     :: forall era m s k ctx.
         ( HasTransactionLayer k ctx
         , GenChange s
+        , BoundedAddressLength k
         , MonadRandom m
         , HasLogger m WalletWorkerLog ctx
         , Cardano.IsShelleyBasedEra era
@@ -2213,7 +2216,8 @@ data SelectAssetsParams s result = SelectAssetsParams
 --
 selectAssets
     :: forall ctx m s k result.
-        ( HasTransactionLayer k ctx
+        ( BoundedAddressLength k
+        , HasTransactionLayer k ctx
         , HasLogger m WalletWorkerLog ctx
         , MonadRandom m
         )

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2623,7 +2623,8 @@ constructSharedTransaction
     -> ApiT WalletId
     -> ApiConstructTransactionData n
     -> Handler (ApiConstructTransaction n)
-constructSharedTransaction ctx genChange _knownPools _getPoolStatus (ApiT wid) body = do
+constructSharedTransaction
+    ctx genChange _knownPools _getPoolStatus (ApiT wid) body = do
     let isNoPayload =
             isNothing (body ^. #payments) &&
             isNothing (body ^. #withdrawal) &&
@@ -2668,8 +2669,8 @@ constructSharedTransaction ctx genChange _knownPools _getPoolStatus (ApiT wid) b
                 (utxoAvailable, wallet, pendingTxs) <-
                     liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk wid
 
-                let runSelection outs =
-                        W.selectAssets @_ @_ @s @k wrk era pp selectAssetsParams transform
+                let runSelection outs = W.selectAssets @_ @_ @s @k
+                        wrk era pp selectAssetsParams transform
                       where
                         selectAssetsParams = W.SelectAssetsParams
                             { outputs = outs

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -359,7 +359,8 @@ import Cardano.Wallet.DB
 import Cardano.Wallet.Network
     ( NetworkLayer (..), fetchRewardAccountBalances, timeInterpreter )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( DelegationAddress (..)
+    ( BoundedAddressLength (..)
+    , DelegationAddress (..)
     , Depth (..)
     , DerivationIndex (..)
     , DerivationType (..)
@@ -1671,6 +1672,7 @@ selectCoins
         , Typeable n
         , Typeable s
         , WalletKey k
+        , BoundedAddressLength k
         )
     => ctx
     -> ArgGenChange s
@@ -1722,6 +1724,7 @@ selectCoinsForJoin
         , SoftDerivation k
         , Typeable n
         , Typeable s
+        , BoundedAddressLength k
         )
     => ctx
     -> IO (Set PoolId)
@@ -1782,6 +1785,7 @@ selectCoinsForQuit
         , Typeable n
         , Typeable s
         , WalletKey k
+        , BoundedAddressLength k
         )
     => ctx
     -> ApiT WalletId
@@ -2043,6 +2047,7 @@ postTransactionOld
         , Typeable s
         , WalletKey k
         , AddressBookIso s
+        , BoundedAddressLength k
         )
     => ctx
     -> ArgGenChange s
@@ -2230,6 +2235,7 @@ postTransactionFeeOld
         , Typeable n
         , Typeable s
         , WalletKey k
+        , BoundedAddressLength k
         )
     => ctx
     -> ApiT WalletId
@@ -2281,6 +2287,7 @@ constructTransaction
         , Typeable n
         , Typeable s
         , WalletKey k
+        , BoundedAddressLength k
         )
     => ctx
     -> ArgGenChange s
@@ -2615,6 +2622,7 @@ constructSharedTransaction
         , GenChange s
         , HasNetworkLayer IO ctx
         , IsOurs s Address
+        , BoundedAddressLength k
         )
     => ctx
     -> ArgGenChange s
@@ -2717,6 +2725,7 @@ balanceTransaction
         ( ctx ~ ApiLayer s k
         , HasNetworkLayer IO ctx
         , GenChange s
+        , BoundedAddressLength k
         )
     => ctx
     -> ArgGenChange s
@@ -3101,6 +3110,7 @@ joinStakePool
         , Typeable s
         , WalletKey k
         , AddressBookIso s
+        , BoundedAddressLength k
         )
     => ctx
     -> IO (Set PoolId)
@@ -3194,6 +3204,7 @@ delegationFee
     :: forall ctx s n k.
         ( s ~ SeqState n k
         , ctx ~ ApiLayer s k
+        , BoundedAddressLength k
         )
     => ctx
     -> ApiT WalletId
@@ -3240,6 +3251,7 @@ quitStakePool
         , Typeable s
         , WalletKey k
         , AddressBookIso s
+        , BoundedAddressLength k
         )
     => ctx
     -> ApiT WalletId

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -157,8 +157,6 @@ instance SC.SelectionContext WalletSelectionContext where
     type Address WalletSelectionContext = Address
     type UTxO WalletSelectionContext = WalletUTxO
 
-    dummyAddress = Address ""
-
 --------------------------------------------------------------------------------
 -- Mapping between external (wallet) and internal UTxO identifiers
 --------------------------------------------------------------------------------
@@ -253,6 +251,8 @@ toInternalSelectionConstraints SelectionConstraints {..} =
             computeMinimumCost . toExternalSelectionSkeleton
         , computeSelectionLimit =
             computeSelectionLimit . fmap (uncurry TxOut)
+        , dummyAddress =
+            Address ""
         , maximumOutputAdaQuantity =
             txOutMaxCoin
         , maximumOutputTokenQuantity =

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -96,6 +96,8 @@ import Cardano.Wallet.Primitive.Collateral
     ( asCollateral )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Address.Constants
+    ( minLengthAddress )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -257,6 +259,8 @@ toInternalSelectionConstraints SelectionConstraints {..} =
             txOutMaxCoin
         , maximumOutputTokenQuantity =
             txOutMaxTokenQuantity
+        , minimumLengthChangeAddress =
+            minLengthAddress
         , ..
         }
 

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -251,12 +251,14 @@ toInternalSelectionConstraints SelectionConstraints {..} =
             computeMinimumCost . toExternalSelectionSkeleton
         , computeSelectionLimit =
             computeSelectionLimit . fmap (uncurry TxOut)
-        , dummyAddress =
-            Address ""
         , maximumOutputAdaQuantity =
             txOutMaxCoin
         , maximumOutputTokenQuantity =
             txOutMaxTokenQuantity
+        , maximumLengthChangeAddress =
+            -- TODO:
+            -- Specify a real address of the maximum length here.
+            Address ""
         , ..
         }
 

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -222,7 +222,7 @@ data SelectionConstraints = SelectionConstraints
         -- ^ Amount that should be taken from/returned back to the wallet for
         -- each stake key registration/de-registration in the transaction.
     , computeMinimumAdaQuantity
-        :: TokenMap -> Coin
+        :: Address -> TokenMap -> Coin
         -- ^ Computes the minimum ada quantity required for a given output.
     , computeMinimumCost
         :: SelectionSkeleton -> Coin
@@ -239,6 +239,8 @@ data SelectionConstraints = SelectionConstraints
         :: Natural
         -- ^ Specifies the minimum required amount of collateral as a
         -- percentage of the total transaction fee.
+    , maximumLengthChangeAddress
+        :: Address
     }
     deriving Generic
 
@@ -255,10 +257,6 @@ toInternalSelectionConstraints SelectionConstraints {..} =
             txOutMaxCoin
         , maximumOutputTokenQuantity =
             txOutMaxTokenQuantity
-        , maximumLengthChangeAddress =
-            -- TODO:
-            -- Specify a real address of the maximum length here.
-            Address ""
         , ..
         }
 

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -185,6 +185,8 @@ data SelectionConstraints ctx = SelectionConstraints
         -- token bundle of an output.
     , maximumLengthChangeAddress
         :: Address ctx
+    , minimumLengthChangeAddress
+        :: Address ctx
     }
     deriving Generic
 
@@ -418,6 +420,8 @@ toBalanceConstraintsParams (constraints, params) =
             view #maximumOutputTokenQuantity constraints
         , maximumLengthChangeAddress =
             view #maximumLengthChangeAddress constraints
+        , minimumLengthChangeAddress =
+            view #minimumLengthChangeAddress constraints
         }
       where
         adjustComputeMinimumCost

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Copyright: © 2021 IOHK
@@ -159,7 +158,7 @@ data SelectionConstraints ctx = SelectionConstraints
         -- ^ Amount that should be taken from/returned back to the wallet for
         -- each stake key registration/de-registration in the transaction.
     , computeMinimumAdaQuantity
-        :: TokenMap -> Coin
+        :: Address ctx -> TokenMap -> Coin
         -- ^ Computes the minimum ada quantity required for a given output.
     , computeMinimumCost
         :: SelectionSkeleton ctx -> Coin
@@ -382,7 +381,8 @@ performSelectionCollateral balanceResult cs ps
 -- | Returns a selection's ordinary outputs and change outputs in a single list.
 --
 -- Since change outputs do not have addresses at the point of generation,
--- this function assigns all change outputs with a dummy change address.
+-- this function assigns all change outputs with a dummy change address
+-- of the maximum possible length.
 --
 selectionAllOutputs
     :: SelectionConstraints ctx
@@ -827,6 +827,7 @@ verifySelectionOutputCoinsSufficient cs _ps selection =
         minimumExpectedCoin :: Coin
         minimumExpectedCoin =
             (cs ^. #computeMinimumAdaQuantity)
+            (fst output)
             (snd output ^. #tokens)
 
 --------------------------------------------------------------------------------
@@ -971,6 +972,7 @@ verifyInsufficientMinCoinValueError cs _ps e =
     reportedMinCoinValue = e ^. #expectedMinCoinValue
     verifiedMinCoinValue =
         (cs ^. #computeMinimumAdaQuantity)
+        (fst reportedOutput)
         (snd reportedOutput ^. #tokens)
 
 --------------------------------------------------------------------------------
@@ -1111,7 +1113,7 @@ verifyUnableToConstructChangeError cs ps errorOriginal =
         -- A modified set of constraints that should always allow the
         -- successful creation of a selection:
         cs' = cs
-            { computeMinimumAdaQuantity = const $ Coin 0
+            { computeMinimumAdaQuantity = const $ const $ Coin 0
             , computeMinimumCost = const $ Coin 0
             , computeSelectionLimit = const Balance.NoLimit
             }
@@ -1434,19 +1436,18 @@ prepareOutputsInternal constraints outputsUnprepared
 -- quantity required to make a particular output valid.
 --
 prepareOutputsWith
-    :: Functor f
-    => (TokenMap -> Coin)
+    :: forall f address. Functor f
+    => (address -> TokenMap -> Coin)
     -> f (address, TokenBundle)
     -> f (address, TokenBundle)
 prepareOutputsWith minCoinValueFor =
-    fmap $ fmap augmentBundle
+    fmap augmentBundle
   where
-    augmentBundle :: TokenBundle -> TokenBundle
-    augmentBundle bundle
-        | TokenBundle.getCoin bundle == Coin 0 =
-            bundle & set #coin (minCoinValueFor (view #tokens bundle))
-        | otherwise =
-            bundle
+    augmentBundle :: (address, TokenBundle) -> (address, TokenBundle)
+    augmentBundle (addr, bundle) = (addr,) $
+        if TokenBundle.getCoin bundle == Coin 0
+        then bundle & set #coin (minCoinValueFor addr (view #tokens bundle))
+        else bundle
 
 -- | Indicates a problem when preparing outputs for a coin selection.
 --

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -168,8 +168,6 @@ data SelectionConstraints ctx = SelectionConstraints
         :: [(Address ctx, TokenBundle)] -> SelectionLimit
         -- ^ Computes an upper bound for the number of ordinary inputs to
         -- select, given a current set of outputs.
-    , dummyAddress
-        :: Address ctx
     , maximumCollateralInputCount
         :: Int
         -- ^ Specifies an inclusive upper bound on the number of unique inputs
@@ -186,6 +184,8 @@ data SelectionConstraints ctx = SelectionConstraints
         :: TokenQuantity
         -- ^ Specifies the largest non-ada quantity that can appear in the
         -- token bundle of an output.
+    , maximumLengthChangeAddress
+        :: Address ctx
     }
     deriving Generic
 
@@ -390,7 +390,7 @@ selectionAllOutputs
     -> [(Address ctx, TokenBundle)]
 selectionAllOutputs constraints selection = (<>)
     (selection ^. #outputs)
-    (selection ^. #change <&> (dummyAddress constraints, ))
+    (selection ^. #change <&> (maximumLengthChangeAddress constraints, ))
 
 -- | Creates constraints and parameters for 'Balance.performSelection'.
 --
@@ -410,14 +410,14 @@ toBalanceConstraintsParams (constraints, params) =
         , computeSelectionLimit =
             view #computeSelectionLimit constraints
                 & adjustComputeSelectionLimit
-        , dummyAddress =
-            view #dummyAddress constraints
         , assessTokenBundleSize =
             view #assessTokenBundleSize constraints
         , maximumOutputAdaQuantity =
             view #maximumOutputAdaQuantity constraints
         , maximumOutputTokenQuantity =
             view #maximumOutputTokenQuantity constraints
+        , maximumLengthChangeAddress =
+            view #maximumLengthChangeAddress constraints
         }
       where
         adjustComputeMinimumCost

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -228,6 +228,8 @@ data SelectionConstraints ctx = SelectionConstraints
         :: [(Address ctx, TokenBundle)] -> SelectionLimit
         -- ^ Computes an upper bound for the number of ordinary inputs to
         -- select, given a current set of outputs.
+    , dummyAddress
+        :: Address ctx
     , maximumOutputAdaQuantity
         :: Coin
         -- ^ Specifies the largest ada quantity that can appear in the token
@@ -819,7 +821,7 @@ performSelection = performSelectionEmpty performSelectionNonEmpty
 --          selectionHasValidSurplus constraints (transformResult result)
 --
 performSelectionEmpty
-    :: forall m ctx. (Functor m, SelectionContext ctx)
+    :: forall m ctx. (Functor m)
     => PerformSelection m NonEmpty ctx
     -> PerformSelection m []       ctx
 performSelectionEmpty performSelectionFn constraints params =
@@ -850,7 +852,7 @@ performSelectionEmpty performSelectionFn constraints params =
     transform x y = maybe x y $ NE.nonEmpty $ view #outputsToCover params
 
     dummyOutput :: (Address ctx, TokenBundle)
-    dummyOutput = (dummyAddress @ctx, TokenBundle.fromCoin minCoin)
+    dummyOutput = (dummyAddress constraints, TokenBundle.fromCoin minCoin)
 
     -- The 'performSelectionNonEmpty' function imposes a precondition that all
     -- outputs must have at least the minimum ada quantity. Therefore, the

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -228,7 +228,7 @@ data SelectionConstraints ctx = SelectionConstraints
         :: [(Address ctx, TokenBundle)] -> SelectionLimit
         -- ^ Computes an upper bound for the number of ordinary inputs to
         -- select, given a current set of outputs.
-    , dummyAddress
+    , maximumLengthChangeAddress
         :: Address ctx
     , maximumOutputAdaQuantity
         :: Coin
@@ -852,7 +852,10 @@ performSelectionEmpty performSelectionFn constraints params =
     transform x y = maybe x y $ NE.nonEmpty $ view #outputsToCover params
 
     dummyOutput :: (Address ctx, TokenBundle)
-    dummyOutput = (dummyAddress constraints, TokenBundle.fromCoin minCoin)
+    dummyOutput =
+        ( maximumLengthChangeAddress constraints
+        , TokenBundle.fromCoin minCoin
+        )
 
     -- The 'performSelectionNonEmpty' function imposes a precondition that all
     -- outputs must have at least the minimum ada quantity. Therefore, the

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Balance.hs
@@ -230,6 +230,8 @@ data SelectionConstraints ctx = SelectionConstraints
         -- select, given a current set of outputs.
     , maximumLengthChangeAddress
         :: Address ctx
+    , minimumLengthChangeAddress
+        :: Address ctx
     , maximumOutputAdaQuantity
         :: Coin
         -- ^ Specifies the largest ada quantity that can appear in the token
@@ -852,7 +854,7 @@ performSelectionEmpty performSelectionFn constraints params =
     transform x y = maybe x y $ NE.nonEmpty $ view #outputsToCover params
 
     dummyAddress :: Address ctx
-    dummyAddress = maximumLengthChangeAddress constraints
+    dummyAddress = minimumLengthChangeAddress constraints
 
     dummyOutput :: (Address ctx, TokenBundle)
     dummyOutput = (dummyAddress, TokenBundle.fromCoin minCoin)

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Context.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal/Context.hs
@@ -39,6 +39,3 @@ class
 
     -- | A unique identifier for an individual UTxO.
     type UTxO c
-
-    -- | Generates a dummy address value.
-    dummyAddress :: Address c

--- a/lib/core/src/Cardano/Wallet/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Gen.hs
@@ -53,7 +53,6 @@ import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , BlockHeader (..)
     , ChainPoint (..)
-    , ProtocolMagic (..)
     , Slot
     , SlotNo (..)
     , WithOrigin (..)
@@ -62,6 +61,8 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.ProtocolMagic
+    ( ProtocolMagic (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeMkEntropy, unsafeMkPercentage )
 import Data.Aeson

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -65,6 +65,7 @@ module Cardano.Wallet.Primitive.AddressDerivation
     -- * Backends Interoperability
     , PaymentAddress(..)
     , DelegationAddress(..)
+    , BoundedAddressLength (..)
     , WalletKey(..)
     , PersistPrivateKey(..)
     , PersistPublicKey(..)
@@ -608,6 +609,25 @@ class WalletKey (key :: Depth -> Type -> Type) where
     liftRawKey
         :: raw
         -> key depth raw
+
+-- | The class of keys for which addresses are bounded in length.
+--
+class BoundedAddressLength key where
+    -- | Returns the longest address that the wallet can generate for a given
+    --   key.
+    --
+    -- This is useful in situations where we want to compute some function of
+    -- an output under construction (such as a minimum UTxO value), but don't
+    -- yet have convenient access to a real address.
+    --
+    -- Please note that this address should:
+    --
+    --  - never be used for anything besides its length and validity properties.
+    --  - never be used as a payment target within a real transaction.
+    --
+    maxLengthAddressFor
+        :: Proxy key
+        -> Address
 
 -- | Encoding of addresses for certain key types and backend targets.
 class MkKeyFingerprint key Address

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
@@ -78,10 +78,10 @@ import Cardano.Wallet.Primitive.Passphrase
     , PassphraseScheme (..)
     , changePassphraseXPrv
     )
-import Cardano.Wallet.Primitive.Types
-    ( testnetMagic )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Primitive.Types.ProtocolMagic
+    ( testnetMagic )
 import Cardano.Wallet.Util
     ( invariant )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
@@ -59,7 +59,8 @@ import Cardano.Crypto.Wallet
 import Cardano.Mnemonic
     ( SomeMnemonic (..), entropyToBytes, mnemonicToEntropy )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
+    ( BoundedAddressLength (..)
+    , Depth (..)
     , DerivationType (..)
     , ErrMkKeyFingerprint (..)
     , Index (..)
@@ -81,7 +82,7 @@ import Cardano.Wallet.Primitive.Passphrase
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.ProtocolMagic
-    ( testnetMagic )
+    ( ProtocolMagic (..), testnetMagic )
 import Cardano.Wallet.Util
     ( invariant )
 import Control.DeepSeq
@@ -105,13 +106,14 @@ import GHC.Generics
 import GHC.TypeLits
     ( KnownNat )
 
-
 import qualified Cardano.Byron.Codec.Cbor as CBOR
+import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet.Primitive.AddressDerivation as W
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
 import qualified Crypto.KDF.PBKDF2 as PBKDF2
 import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 
 {-------------------------------------------------------------------------------
@@ -184,6 +186,24 @@ instance MkKeyFingerprint ByronKey Address where
         case CBOR.deserialiseCbor CBOR.decodeAddressPayload bytes of
             Just _  -> Right $ KeyFingerprint bytes
             Nothing -> Left $ ErrInvalidAddress addr (Proxy @ByronKey)
+
+instance BoundedAddressLength ByronKey where
+    -- Matching 'paymentAddress' above.
+    maxLengthAddressFor _ = Address
+        $ CBOR.toStrictByteString
+        $ CBOR.encodeAddress xpub
+            [ CBOR.encodeDerivationPathAttr passphrase maxBound maxBound
+            , CBOR.encodeProtocolMagicAttr (ProtocolMagic maxBound)
+            ]
+      where
+        -- Must apparently always be 32 bytes:
+        passphrase :: Passphrase "addr-derivation-payload"
+        passphrase = Passphrase $ BA.convert $ BS.replicate 32 0
+
+        xpub :: CC.XPub
+        xpub = CC.toXPub $ CC.generate (BS.replicate 32 0) xprvPass
+          where
+            xprvPass = mempty :: BS.ByteString
 
 {-------------------------------------------------------------------------------
                                  Key generation

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
@@ -71,10 +71,10 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState, coinTypeAda, discoverSeq, purposeBIP44 )
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase (..), PassphraseHash (..), changePassphraseXPrv )
-import Cardano.Wallet.Primitive.Types
-    ( testnetMagic )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Primitive.Types.ProtocolMagic
+    ( testnetMagic )
 import Cardano.Wallet.Util
     ( invariant )
 import Control.Arrow

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
@@ -43,12 +43,12 @@ import Cardano.Crypto.Wallet
     , unXPub
     , xPrvChangePass
     , xprv
-    , xpub
     )
 import Cardano.Mnemonic
     ( SomeMnemonic (..), entropyToBytes, mnemonicToEntropy, mnemonicToText )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
+    ( BoundedAddressLength (..)
+    , Depth (..)
     , DerivationType (..)
     , ErrMkKeyFingerprint (..)
     , HardDerivation (..)
@@ -74,7 +74,7 @@ import Cardano.Wallet.Primitive.Passphrase
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.ProtocolMagic
-    ( testnetMagic )
+    ( ProtocolMagic (..), testnetMagic )
 import Cardano.Wallet.Util
     ( invariant )
 import Control.Arrow
@@ -111,6 +111,7 @@ import GHC.TypeLits
     ( KnownNat )
 
 import qualified Cardano.Byron.Codec.Cbor as CBOR
+import qualified Cardano.Crypto.Wallet as CC
 import qualified Codec.CBOR.Write as CBOR
 import qualified Crypto.ECC.Edwards25519 as Ed25519
 import qualified Crypto.KDF.PBKDF2 as PBKDF2
@@ -404,6 +405,19 @@ instance IsOurs (SeqState n IcarusKey) RewardAccount where
 instance PaymentAddress n IcarusKey => MaybeLight (SeqState n IcarusKey) where
     maybeDiscover = Just $ DiscoverTxs discoverSeq
 
+instance BoundedAddressLength IcarusKey where
+    -- Matching 'paymentAddress' above.
+    maxLengthAddressFor _ = Address
+        $ CBOR.toStrictByteString
+        $ CBOR.encodeAddress xpub
+            [ CBOR.encodeProtocolMagicAttr (ProtocolMagic maxBound)
+            ]
+      where
+        xpub :: CC.XPub
+        xpub = CC.toXPub $ CC.generate (BS.replicate 32 0) xprvPass
+          where
+            xprvPass = mempty :: BS.ByteString
+
 {-------------------------------------------------------------------------------
                           Storing and retrieving keys
 -------------------------------------------------------------------------------}
@@ -428,5 +442,5 @@ instance PersistPublicKey (IcarusKey depth) where
     unsafeDeserializeXPub =
         either err IcarusKey . xpubFromText
       where
-        xpubFromText = xpub <=< fromHex @ByteString
+        xpubFromText = CC.xpub <=< fromHex @ByteString
         err _ = error "unsafeDeserializeXPub: unable to deserialize IcarusKey"

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shared.hs
@@ -38,7 +38,8 @@ import Cardano.Crypto.Wallet
 import Cardano.Mnemonic
     ( SomeMnemonic )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
+    ( BoundedAddressLength (..)
+    , Depth (..)
     , DerivationType (..)
     , HardDerivation (..)
     , KeyFingerprint (..)
@@ -183,6 +184,9 @@ instance MkKeyFingerprint SharedKey Address where
 instance MkKeyFingerprint SharedKey (Proxy (n :: NetworkDiscriminant), SharedKey 'AddressK XPub) where
     paymentKeyFingerprint (_, paymentK) =
         Right $ KeyFingerprint $ blake2b224 $ xpubPublicKey $ getKey paymentK
+
+instance BoundedAddressLength SharedKey where
+    maxLengthAddressFor _ = Address $ BS.replicate 57 0
 
 {-------------------------------------------------------------------------------
                                  Internals

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -55,7 +55,8 @@ import Cardano.Crypto.Wallet
 import Cardano.Mnemonic
     ( SomeMnemonic (..), entropyToBytes, mnemonicToEntropy )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( DelegationAddress (..)
+    ( BoundedAddressLength (..)
+    , DelegationAddress (..)
     , Depth (..)
     , DerivationIndex (..)
     , DerivationType (..)
@@ -353,6 +354,9 @@ instance MkKeyFingerprint ShelleyKey Address where
 instance MkKeyFingerprint ShelleyKey (Proxy (n :: NetworkDiscriminant), ShelleyKey 'AddressK XPub) where
     paymentKeyFingerprint (_, paymentK) =
         Right $ KeyFingerprint $ blake2b224 $ xpubPublicKey $ getKey paymentK
+
+instance BoundedAddressLength ShelleyKey where
+    maxLengthAddressFor _ = Address $ BS.replicate 57 0
 
 {-------------------------------------------------------------------------------
                           Dealing with Rewards

--- a/lib/core/src/Cardano/Wallet/Primitive/Migration/Selection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Migration/Selection.hs
@@ -56,6 +56,8 @@ module Cardano.Wallet.Primitive.Migration.Selection
 
 import Prelude
 
+import Cardano.Wallet.Primitive.Types.Address.Constants
+    ( maxLengthAddress )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -274,7 +276,15 @@ assignMinimumAdaQuantity :: TxConstraints -> TokenMap -> TokenBundle
 assignMinimumAdaQuantity constraints m =
     TokenBundle c m
   where
-    c = txOutputMinimumAdaQuantity constraints m
+    -- Using @maxLengthAddressFor $ Proxy @k@ via @constraints@ would not help
+    -- here, as outputs created by the migration algorithm are assigned with
+    -- user-defined addresses.
+    --
+    -- Something we /could/ do would be to pass in the actual user-defined
+    -- addresses here, since they are available in the 'createMigrationPlan'
+    -- server handler.
+    --
+    c = txOutputMinimumAdaQuantity constraints maxLengthAddress m
 
 --------------------------------------------------------------------------------
 -- Adding value to outputs
@@ -835,8 +845,9 @@ checkOutputMinimumAdaQuantities constraints selection =
                 , expectedMinimumAdaQuantity
                 }
       where
-        expectedMinimumAdaQuantity =
-            txOutputMinimumAdaQuantity constraints (view #tokens outputBundle)
+        expectedMinimumAdaQuantity = txOutputMinimumAdaQuantity constraints
+            maxLengthAddress
+            (view #tokens outputBundle)
 
 --------------------------------------------------------------------------------
 -- Selection correctness: output sizes

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -144,11 +144,6 @@ module Cardano.Wallet.Primitive.Types
     , rangeLowerBound
     , rangeUpperBound
 
-    -- * ProtocolMagic
-    , ProtocolMagic (..)
-    , mainnetMagic
-    , testnetMagic
-
     -- * Polymorphic
     , Signature (..)
 
@@ -216,8 +211,6 @@ import Data.Generics.Internal.VL.Lens
     ( set, view, (^.) )
 import Data.Generics.Labels
     ()
-import Data.Int
-    ( Int32 )
 import Data.Kind
     ( Type )
 import Data.List
@@ -226,8 +219,6 @@ import Data.Map.Strict
     ( Map )
 import Data.Maybe
     ( isJust, isNothing )
-import Data.Proxy
-    ( Proxy (..) )
 import Data.Quantity
     ( Percentage (..), Quantity (..), complementPercentage )
 import Data.Scientific
@@ -269,8 +260,6 @@ import GHC.Generics
     ( Generic )
 import GHC.Stack
     ( HasCallStack )
-import GHC.TypeLits
-    ( KnownNat, natVal )
 import Network.URI
     ( URI (..), uriToString )
 import NoThunks.Class
@@ -1380,28 +1369,6 @@ newtype StartTime = StartTime UTCTime
     deriving (Show, Eq, Ord, Generic)
 
 instance NFData StartTime
-
-{-------------------------------------------------------------------------------
-                                Protocol Magic
--------------------------------------------------------------------------------}
-
--- | Magic constant associated to a given network
-newtype ProtocolMagic = ProtocolMagic { getProtocolMagic :: Int32 }
-    deriving (Generic, Show, Eq, NFData, FromJSON, ToJSON)
-
-instance ToText ProtocolMagic where
-    toText (ProtocolMagic pm) = T.pack (show pm)
-
-instance FromText ProtocolMagic where
-    fromText = fmap (ProtocolMagic . fromIntegral @Natural) . fromText
-
--- | Hard-coded protocol magic for the Byron MainNet
-mainnetMagic :: ProtocolMagic
-mainnetMagic =  ProtocolMagic 764824073
-
--- | Derive testnet magic from a type-level Nat
-testnetMagic :: forall pm. KnownNat pm => ProtocolMagic
-testnetMagic = ProtocolMagic $ fromIntegral $ natVal $ Proxy @pm
 
 {-------------------------------------------------------------------------------
               Stake Pool Delegation and Registration Certificates

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Address/Constants.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Address/Constants.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2022 IOHK
+-- License: Apache-2.0
+--
+-- Provides various 'Address' constants used by the wallet or its tests.
+--
+module Cardano.Wallet.Primitive.Types.Address.Constants
+    ( maxLengthAddress
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( BoundedAddressLength (..) )
+import Cardano.Wallet.Primitive.AddressDerivation.Byron
+    ( ByronKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Icarus
+    ( IcarusKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Shared
+    ( SharedKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Shelley
+    ( ShelleyKey )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+import Data.Proxy
+    ( Proxy (..) )
+
+import Data.Function
+    ( on )
+
+import qualified Data.ByteString as BS
+import qualified Data.List as L
+
+-- | A dummy 'Address' of the greatest length that the wallet can generate.
+--
+-- Please note that this address should:
+--
+--  - never be used for anything besides its length and validity properties.
+--  - never be used as a payment target within a real transaction.
+--
+maxLengthAddress :: Address
+maxLengthAddress = L.maximumBy (compare `on` (BS.length . unAddress))
+    [ maxLengthAddressFor $ Proxy @ByronKey
+    , maxLengthAddressFor $ Proxy @IcarusKey
+    , maxLengthAddressFor $ Proxy @ShelleyKey
+    , maxLengthAddressFor $ Proxy @SharedKey
+    ]

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Address/Constants.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Address/Constants.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BinaryLiterals #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -9,6 +10,7 @@
 --
 module Cardano.Wallet.Primitive.Types.Address.Constants
     ( maxLengthAddress
+    , minLengthAddress
     ) where
 
 import Prelude
@@ -48,3 +50,19 @@ maxLengthAddress = L.maximumBy (compare `on` (BS.length . unAddress))
     , maxLengthAddressFor $ Proxy @ShelleyKey
     , maxLengthAddressFor $ Proxy @SharedKey
     ]
+
+-- | A dummy 'Address' of the shortest length that the wallet can generate.
+--
+-- Please note that this address should:
+--
+--  - never be used for anything besides its length and validity properties.
+--  - never be used as a payment target within a real transaction.
+--
+minLengthAddress :: Address
+minLengthAddress = minLengthAddressShelley
+  where
+    minLengthAddressShelley =
+        Address $ BS.singleton enterpriseAddressHeaderByte <> payload
+      where
+        enterpriseAddressHeaderByte = 0b01100000
+        payload = BS.replicate 28 0

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/ProtocolMagic.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/ProtocolMagic.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK
+-- License: Apache-2.0
+--
+-- Provides the 'ProtocolMagic' type and related constants.
+--
+module Cardano.Wallet.Primitive.Types.ProtocolMagic
+    ( ProtocolMagic (..)
+    , mainnetMagic
+    , testnetMagic
+    ) where
+
+import Prelude
+
+import Control.DeepSeq
+    ( NFData (..) )
+import Data.Aeson
+    ( FromJSON (..), ToJSON (..) )
+import Data.Int
+    ( Int32 )
+import Data.Proxy
+    ( Proxy (..) )
+import Data.Text.Class
+    ( FromText (..), ToText (..) )
+import GHC.Generics
+    ( Generic )
+import GHC.TypeLits
+    ( KnownNat, natVal )
+import Numeric.Natural
+    ( Natural )
+
+import qualified Data.Text as T
+
+-- | Magic constant associated with a given network.
+--
+newtype ProtocolMagic = ProtocolMagic { getProtocolMagic :: Int32 }
+    deriving (Generic, Show, Eq, NFData, FromJSON, ToJSON)
+
+instance ToText ProtocolMagic where
+    toText (ProtocolMagic pm) = T.pack (show pm)
+
+instance FromText ProtocolMagic where
+    fromText = fmap (ProtocolMagic . fromIntegral @Natural) . fromText
+
+-- | Hard-coded protocol magic for the Byron MainNet
+mainnetMagic :: ProtocolMagic
+mainnetMagic =  ProtocolMagic 764824073
+
+-- | Derive testnet magic from a type-level Nat
+testnetMagic :: forall pm. KnownNat pm => ProtocolMagic
+testnetMagic = ProtocolMagic $ fromIntegral $ natVal $ Proxy @pm

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -83,7 +83,6 @@ module Cardano.Wallet.Primitive.Types.Tx
     , TxConstraints (..)
     , txOutputCoinCost
     , txOutputCoinSize
-    , txOutputCoinMinimum
     , txOutputHasValidSize
     , txOutputHasValidTokenQuantities
     , TxSize (..)
@@ -971,7 +970,7 @@ data TxConstraints = TxConstraints
       -- ^ The maximum size of a transaction output.
     , txOutputMaximumTokenQuantity :: TokenQuantity
       -- ^ The maximum token quantity that can appear in a transaction output.
-    , txOutputMinimumAdaQuantity :: TokenMap -> Coin
+    , txOutputMinimumAdaQuantity :: Address -> TokenMap -> Coin
       -- ^ The variable minimum ada quantity of a transaction output.
     , txRewardWithdrawalCost :: Coin -> Coin
       -- ^ The variable cost of a reward withdrawal.
@@ -987,9 +986,6 @@ txOutputCoinCost constraints = txOutputCost constraints . TokenBundle.fromCoin
 
 txOutputCoinSize :: TxConstraints -> Coin -> TxSize
 txOutputCoinSize constraints = txOutputSize constraints . TokenBundle.fromCoin
-
-txOutputCoinMinimum :: TxConstraints -> Coin
-txOutputCoinMinimum constraints = txOutputMinimumAdaQuantity constraints mempty
 
 txOutputHasValidSize :: TxConstraints -> TokenBundle -> Bool
 txOutputHasValidSize constraints b =

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -21,7 +21,7 @@ module Cardano.Wallet.CoinSelection.Internal.BalanceSpec
     , MockComputeMinimumAdaQuantity
     , MockComputeMinimumCost
     , MockComputeSelectionLimit
-    , TestAddress
+    , TestAddress (..)
     , TestSelectionContext
     , TestUTxO
     , genMockAssessTokenBundleSize
@@ -1859,6 +1859,7 @@ mkBoundaryTestExpectation (BoundaryTestData params expectedResult) = do
         , assessTokenBundleSize = unMockAssessTokenBundleSize $
             boundaryTestBundleSizeAssessor params
         , computeSelectionLimit = const NoLimit
+        , dummyAddress = TestAddress 0x0
         , maximumOutputAdaQuantity = testMaximumOutputAdaQuantity
         , maximumOutputTokenQuantity = testMaximumOutputTokenQuantity
         }
@@ -2489,6 +2490,8 @@ unMockSelectionConstraints m = SelectionConstraints
         unMockComputeMinimumCost $ view #computeMinimumCost m
     , computeSelectionLimit =
         unMockComputeSelectionLimit $ view #computeSelectionLimit m
+    , dummyAddress =
+        TestAddress 0x0
     , maximumOutputAdaQuantity =
         testMaximumOutputAdaQuantity
     , maximumOutputTokenQuantity =
@@ -4448,8 +4451,6 @@ data TestSelectionContext
 instance SC.SelectionContext TestSelectionContext where
     type Address TestSelectionContext = TestAddress
     type UTxO TestSelectionContext = TestUTxO
-
-    dummyAddress = TestAddress 0x0
 
 newtype TestAddress = TestAddress (Hexadecimal Quid)
     deriving Arbitrary via Quid

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -1859,9 +1859,9 @@ mkBoundaryTestExpectation (BoundaryTestData params expectedResult) = do
         , assessTokenBundleSize = unMockAssessTokenBundleSize $
             boundaryTestBundleSizeAssessor params
         , computeSelectionLimit = const NoLimit
-        , dummyAddress = TestAddress 0x0
         , maximumOutputAdaQuantity = testMaximumOutputAdaQuantity
         , maximumOutputTokenQuantity = testMaximumOutputTokenQuantity
+        , maximumLengthChangeAddress = TestAddress 0x0
         }
 
 encodeBoundaryTestCriteria
@@ -2490,12 +2490,12 @@ unMockSelectionConstraints m = SelectionConstraints
         unMockComputeMinimumCost $ view #computeMinimumCost m
     , computeSelectionLimit =
         unMockComputeSelectionLimit $ view #computeSelectionLimit m
-    , dummyAddress =
-        TestAddress 0x0
     , maximumOutputAdaQuantity =
         testMaximumOutputAdaQuantity
     , maximumOutputTokenQuantity =
         testMaximumOutputTokenQuantity
+    , maximumLengthChangeAddress =
+        TestAddress 0x0
     }
 
 -- | Specifies the largest ada quantity that can appear in the token bundle

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/Internal/BalanceSpec.hs
@@ -1863,6 +1863,7 @@ mkBoundaryTestExpectation (BoundaryTestData params expectedResult) = do
         , maximumOutputAdaQuantity = testMaximumOutputAdaQuantity
         , maximumOutputTokenQuantity = testMaximumOutputTokenQuantity
         , maximumLengthChangeAddress = TestAddress 0x0
+        , minimumLengthChangeAddress = TestAddress 0x0
         }
 
 encodeBoundaryTestCriteria
@@ -2496,6 +2497,8 @@ unMockSelectionConstraints m = SelectionConstraints
     , maximumOutputTokenQuantity =
         testMaximumOutputTokenQuantity
     , maximumLengthChangeAddress =
+        TestAddress 0x0
+    , minimumLengthChangeAddress =
         TestAddress 0x0
     }
 

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -544,9 +544,9 @@ data MockSelectionConstraints = MockSelectionConstraints
     , minimumCollateralPercentage
         :: Natural
     , maximumOutputAdaQuantity
-         :: Coin
+        :: Coin
     , maximumOutputTokenQuantity
-         :: TokenQuantity
+        :: TokenQuantity
     }
     deriving (Eq, Generic, Show)
 

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -49,7 +49,7 @@ import Cardano.Wallet.CoinSelection.Internal.BalanceSpec
     , MockComputeMinimumAdaQuantity
     , MockComputeMinimumCost
     , MockComputeSelectionLimit
-    , TestAddress
+    , TestAddress (..)
     , TestSelectionContext
     , TestUTxO
     , genMockAssessTokenBundleSize
@@ -589,6 +589,8 @@ unMockSelectionConstraints m = SelectionConstraints
         unMockComputeMinimumCost $ view #computeMinimumCost m
     , computeSelectionLimit =
         unMockComputeSelectionLimit $ view #computeSelectionLimit m
+    , dummyAddress =
+        TestAddress 0x0
     , maximumCollateralInputCount =
         view #maximumCollateralInputCount m
     , minimumCollateralPercentage =

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -480,7 +480,8 @@ prop_prepareOutputsWith_preparedOrExistedBefore minCoinValueDef outs =
         | outputCoin before /= Coin 0 =
             outputCoin after == outputCoin before
         | otherwise =
-            outputCoin after == minCoinValueFor (view #tokens $ snd before)
+            outputCoin after ==
+                uncurry minCoinValueFor (view #tokens <$> before)
       where
         outputCoin = view #coin . snd
 

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -600,6 +600,8 @@ unMockSelectionConstraints m = SelectionConstraints
         view #maximumOutputTokenQuantity m
     , maximumLengthChangeAddress =
         TestAddress 0x0
+    , minimumLengthChangeAddress =
+        TestAddress 0x0
     }
 
 --------------------------------------------------------------------------------

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -589,8 +589,6 @@ unMockSelectionConstraints m = SelectionConstraints
         unMockComputeMinimumCost $ view #computeMinimumCost m
     , computeSelectionLimit =
         unMockComputeSelectionLimit $ view #computeSelectionLimit m
-    , dummyAddress =
-        TestAddress 0x0
     , maximumCollateralInputCount =
         view #maximumCollateralInputCount m
     , minimumCollateralPercentage =
@@ -599,6 +597,8 @@ unMockSelectionConstraints m = SelectionConstraints
         view #maximumOutputAdaQuantity m
     , maximumOutputTokenQuantity =
         view #maximumOutputTokenQuantity m
+    , maximumLengthChangeAddress =
+        TestAddress 0x0
     }
 
 --------------------------------------------------------------------------------

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
@@ -30,6 +30,8 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Coin.Gen
+    ( chooseCoin )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -102,7 +104,7 @@ import Test.QuickCheck
     , withMaxSuccess
     )
 import Test.QuickCheck.Extra
-    ( chooseNatural, report, verify )
+    ( report, verify )
 
 import qualified Cardano.Wallet.Primitive.Migration.Selection as Selection
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
@@ -395,7 +397,7 @@ prop_minimizeFee (Blind mockConstraints) =
     prop_minimizeFee_inner mockConstraints feeExcessToMinimize outputs
   where
     genFeeExcess :: Gen Coin
-    genFeeExcess = genCoinRange (Coin 0) (Coin 10_000)
+    genFeeExcess = chooseCoin (Coin 0, Coin 10_000)
 
     genOutputs :: Gen (NonEmpty TokenBundle)
     genOutputs = do
@@ -487,7 +489,7 @@ prop_minimizeFeeStep (Blind mockConstraints) =
     prop_minimizeFeeStep_inner mockConstraints feeExcessToMinimize output
   where
     genFeeExcess :: Gen Coin
-    genFeeExcess = genCoinRange (Coin 0) (Coin 10_000)
+    genFeeExcess = chooseCoin (Coin 0, Coin 10_000)
 
     genOutput :: Gen TokenBundle
     genOutput = genTokenBundleMixed mockConstraints
@@ -787,8 +789,8 @@ data MockTxCostFunction = MockTxCostFunction
 
 genMockTxCostFunction :: Gen MockTxCostFunction
 genMockTxCostFunction = MockTxCostFunction
-    <$> genCoinRange (Coin 0) (Coin 1000)
-    <*> genCoinRange (Coin 1) (Coin 4)
+    <$> chooseCoin (Coin 0, Coin 1000)
+    <*> chooseCoin (Coin 1, Coin 4)
 
 --------------------------------------------------------------------------------
 -- Mock base transaction sizes
@@ -862,8 +864,8 @@ unMockTxOutputMinimumAdaQuantity mock _addr m =
 
 genMockTxOutputMinimumAdaQuantity :: Gen MockTxOutputMinimumAdaQuantity
 genMockTxOutputMinimumAdaQuantity = MockTxOutputMinimumAdaQuantity
-    <$> genCoinRange (Coin 4) (Coin 8)
-    <*> genCoinRange (Coin 1) (Coin 2)
+    <$> chooseCoin (Coin 4, Coin 8)
+    <*> chooseCoin (Coin 1, Coin 2)
 
 -- Addresses are currently never used within the mock minimum ada quantity
 -- calculation. However, 'unMockTxOutputMinimumAdaQuantity' still requires an
@@ -934,7 +936,7 @@ genMockInputId = MockInputId . BS.pack <$>
 
 genCoinAboveMinimumAdaQuantity :: MockTxConstraints -> Gen Coin
 genCoinAboveMinimumAdaQuantity mockConstraints =
-    genCoinRange lo hi
+    chooseCoin (lo, hi)
   where
     constraints = unMockTxConstraints mockConstraints
     lo = txOutputMinimumAdaQuantity constraints dummyAddress TokenMap.empty
@@ -942,17 +944,13 @@ genCoinAboveMinimumAdaQuantity mockConstraints =
 
 genCoinBelowMinimumAdaQuantity :: MockTxConstraints -> Gen Coin
 genCoinBelowMinimumAdaQuantity mockConstraints =
-    genCoinRange lo hi
+    chooseCoin (lo, hi)
   where
     constraints = unMockTxConstraints mockConstraints
     lo = Coin 1
     hi = Coin.difference
         (txOutputMinimumAdaQuantity constraints dummyAddress TokenMap.empty)
         (Coin 1)
-
-genCoinRange :: Coin -> Coin -> Gen Coin
-genCoinRange (Coin minCoin) (Coin maxCoin) =
-    Coin <$> chooseNatural (minCoin, maxCoin)
 
 genTokenBundleMixed :: MockTxConstraints -> Gen TokenBundle
 genTokenBundleMixed mockConstraints =
@@ -983,7 +981,7 @@ genTokenBundleAboveMinimumAdaQuantity :: MockTxConstraints -> Gen TokenBundle
 genTokenBundleAboveMinimumAdaQuantity mockConstraints = do
     m <- genTokenMap mockConstraints
     let minAda = txOutputMinimumAdaQuantity constraints dummyAddress m
-    c <- genCoinRange (minAda <> Coin 1) (minAda `scaleCoin` 1000)
+    c <- chooseCoin (minAda <> Coin 1, minAda `scaleCoin` 1000)
     pure $ TokenBundle c m
   where
     constraints = unMockTxConstraints mockConstraints
@@ -1032,7 +1030,7 @@ mockAssetIds =
 genRewardWithdrawal :: Gen RewardWithdrawal
 genRewardWithdrawal = RewardWithdrawal <$> oneof
     [ pure (Coin 0)
-    , genCoinRange (Coin 1) (Coin 1_000_000)
+    , chooseCoin (Coin 1, Coin 1_000_000)
     ]
 
 --------------------------------------------------------------------------------

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -102,6 +102,7 @@ import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
+import qualified Cardano.Wallet.Primitive.Types.ProtocolMagic as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Data.List.NonEmpty as NE

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -57,8 +57,12 @@ import Cardano.Wallet.Logging
     ( BracketLog, BracketLog' (..), bracketTracer )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), NetworkParameters (..), ProtocolMagic (..) )
+    ( Block (..), NetworkParameters (..) )
+import Cardano.Wallet.Primitive.Types.ProtocolMagic
+    ( ProtocolMagic (..) )
 import Cardano.Wallet.Shelley
     ( SomeNetworkDiscriminant (..) )
 import Control.Monad.IO.Unlift
@@ -96,9 +100,7 @@ import UnliftIO.Temporary
     ( withTempDirectory )
 
 import qualified Cardano.Wallet.Byron.Compatibility as Byron
-import Cardano.Wallet.Primitive.SyncProgress
-    ( SyncTolerance )
-import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.ProtocolMagic as W
 import qualified Cardano.Wallet.Shelley.Launch.Blockfrost as Blockfrost
 import qualified Data.ByteString.Lazy.Char8 as BL8
 import qualified Data.Text as T

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -20,14 +20,14 @@ import Prelude
 
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase (..) )
-import Cardano.Wallet.Primitive.Types
-    ( ProtocolMagic (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO
     ( MinimumUTxO (..), MinimumUTxOForShelleyBasedEra (..) )
+import Cardano.Wallet.Primitive.Types.ProtocolMagic
+    ( ProtocolMagic (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap

--- a/lib/shelley/test/data/balanceTx/delegate/golden
+++ b/lib/shelley/test/data/balanceTx/delegate/golden
@@ -38,10 +38,10 @@
  1.850000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1850000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
  1.900000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1900000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
  1.950000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (BalanceInsufficient (BalanceInsufficientError {utxoBalanceAvailable = TokenBundle {coin = Coin 1950000, tokens = TokenMap (fromList [])}, utxoBalanceRequired = TokenBundle {coin = Coin 2000000, tokens = TokenMap (fromList [])}}))))
- 2.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 180901, shortfall = Coin 180901}))))
- 2.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 180901, shortfall = Coin 130901}))))
- 2.100000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 180901, shortfall = Coin 80901}))))
- 2.150000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 180901, shortfall = Coin 30901}))))
+ 2.000000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 182177, shortfall = Coin 182177}))))
+ 2.050000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 182177, shortfall = Coin 132177}))))
+ 2.100000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 182177, shortfall = Coin 82177}))))
+ 2.150000,ErrBalanceTxSelectAssets (ErrSelectAssetsSelectionError (SelectionBalanceErrorOf (UnableToConstructChange (UnableToConstructChangeError {requiredCost = Coin 182177, shortfall = Coin 32177}))))
  2.200000,0.200000,0.175401
  2.250000,0.250000,0.175401
  2.300000,0.300000,0.175401

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -17,8 +17,16 @@ import Cardano.Api
     ( ShelleyBasedEra (..) )
 import Cardano.Api.Gen
     ( genAddressAny )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( BoundedAddressLength (..) )
+import Cardano.Wallet.Primitive.AddressDerivation.Byron
+    ( ByronKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Shelley
+    ( ShelleyKey )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Address.Constants
+    ( maxLengthAddress )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO
@@ -57,13 +65,14 @@ import Cardano.Wallet.Shelley.Compatibility
     ( toCardanoTxOut )
 import Cardano.Wallet.Shelley.MinimumUTxO
     ( computeMinimumCoinForUTxO
-    , maxLengthAddress
     , maxLengthCoin
     , unsafeLovelaceToWalletCoin
     , unsafeValueToLovelace
     )
 import Control.Monad
     ( forM_ )
+import Data.Data
+    ( Proxy (..) )
 import Data.Default
     ( Default (..) )
 import Data.Function
@@ -122,30 +131,60 @@ spec = do
 
         describe "Golden Tests" $ do
 
-            goldenTests_computeMinimumCoinForUTxO "Shelley"
-                goldenMinimumUTxO_Shelley
-                goldenMinimumCoins_Shelley
-            goldenTests_computeMinimumCoinForUTxO "Allegra"
-                goldenMinimumUTxO_Allegra
-                goldenMinimumCoins_Allegra
-            goldenTests_computeMinimumCoinForUTxO "Mary"
-                goldenMinimumUTxO_Mary
-                goldenMinimumCoins_Mary
-            goldenTests_computeMinimumCoinForUTxO "Alonzo"
-                goldenMinimumUTxO_Alonzo
-                goldenMinimumCoins_Alonzo
-            goldenTests_computeMinimumCoinForUTxO "Babbage"
-                goldenMinimumUTxO_Babbage
-                goldenMinimumCoins_Babbage
+            describe "Byron-style addresses" $ do
+
+                goldenTests_computeMinimumCoinForUTxO
+                    "Shelley"
+                    goldenMinimumUTxO_ShelleyEra
+                    goldenMinimumCoins_ByronAddress_ShelleyEra
+                goldenTests_computeMinimumCoinForUTxO
+                    "Allegra"
+                    goldenMinimumUTxO_AllegraEra
+                    goldenMinimumCoins_ByronAddress_AllegraEra
+                goldenTests_computeMinimumCoinForUTxO
+                    "Mary"
+                    goldenMinimumUTxO_MaryEra
+                    goldenMinimumCoins_ByronAddress_MaryEra
+                goldenTests_computeMinimumCoinForUTxO
+                    "Alonzo"
+                    goldenMinimumUTxO_AlonzoEra
+                    goldenMinimumCoins_ByronAddress_AlonzoEra
+                goldenTests_computeMinimumCoinForUTxO
+                    "Babbage"
+                    goldenMinimumUTxO_BabbageEra
+                    goldenMinimumCoins_ByronAddress_BabbageEra
+
+            describe "Shelley-style addresses" $ do
+
+                goldenTests_computeMinimumCoinForUTxO
+                    "Shelley"
+                    goldenMinimumUTxO_ShelleyEra
+                    goldenMinimumCoins_ShelleyAddress_ShelleyEra
+                goldenTests_computeMinimumCoinForUTxO
+                    "Allegra"
+                    goldenMinimumUTxO_AllegraEra
+                    goldenMinimumCoins_ShelleyAddress_AllegraEra
+                goldenTests_computeMinimumCoinForUTxO
+                    "Mary"
+                    goldenMinimumUTxO_MaryEra
+                    goldenMinimumCoins_ShelleyAddress_MaryEra
+                goldenTests_computeMinimumCoinForUTxO
+                    "Alonzo"
+                    goldenMinimumUTxO_AlonzoEra
+                    goldenMinimumCoins_ShelleyAddress_AlonzoEra
+                goldenTests_computeMinimumCoinForUTxO
+                    "Babbage"
+                    goldenMinimumUTxO_BabbageEra
+                    goldenMinimumCoins_ShelleyAddress_BabbageEra
 
 -- Check that it's possible to evaluate 'computeMinimumCoinForUTxO' without
 -- any run-time error.
 --
 prop_computeMinimumCoinForUTxO_evaluation
-    :: MinimumUTxO -> TokenMap -> Property
-prop_computeMinimumCoinForUTxO_evaluation minimumUTxO m = property $
+    :: MinimumUTxO -> Address -> TokenMap -> Property
+prop_computeMinimumCoinForUTxO_evaluation minimumUTxO addr m = property $
     -- Use an arbitrary test to force evaluation of the result:
-    computeMinimumCoinForUTxO minimumUTxO m >= Coin 0
+    computeMinimumCoinForUTxO minimumUTxO addr m >= Coin 0
 
 -- Check that 'computeMinimumCoinForUTxO' produces a result that is within
 -- bounds, as determined by the Cardano API function 'calculateMinimumUTxO'.
@@ -158,12 +197,13 @@ prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
 prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
     tokenBundle addr (MinimumUTxOForShelleyBasedEra era pp) =
         let ourResult = ourComputeMinCoin
+                (fromCardanoAddressAny addr)
                 (TokenBundle.tokens tokenBundle)
             apiResultMinBound = apiComputeMinCoin
                 (fromCardanoAddressAny addr)
                 (tokenBundle)
             apiResultMaxBound = apiComputeMinCoin
-                (maxLengthAddress)
+                (maxLengthAddressFor $ Proxy @ByronKey)
                 (TokenBundle.setCoin tokenBundle maxLengthCoin)
         in
         property True
@@ -190,7 +230,7 @@ prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
                 "BS.length (unAddress (fromCardanoAddressAny addr))"
             & report
                 (BS.length (unAddress maxLengthAddress))
-                "BS.length (unAddress maxLengthAddress))"
+                "BS.length (unAddress maxLengthAddress)))"
   where
     -- Uses the Cardano API function 'calculateMinimumUTxO' to compute a
     -- minimum 'Coin' value.
@@ -210,9 +250,9 @@ prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
     -- Uses the wallet function 'computeMinimumCoinForUTxO' to compute a
     -- minimum 'Coin' value.
     --
-    ourComputeMinCoin :: TokenMap -> Coin
-    ourComputeMinCoin =
-        computeMinimumCoinForUTxO (minimumUTxOForShelleyBasedEra era pp)
+    ourComputeMinCoin :: Address -> TokenMap -> Coin
+    ourComputeMinCoin = computeMinimumCoinForUTxO
+        (minimumUTxOForShelleyBasedEra era pp)
 
 -- Compares the stability of:
 --
@@ -290,8 +330,8 @@ prop_computeMinimumCoinForUTxO_shelleyBasedEra_stability
     -- minimum 'Coin' value.
     --
     ourComputeMinCoin :: TokenMap -> Coin
-    ourComputeMinCoin =
-        computeMinimumCoinForUTxO (minimumUTxOForShelleyBasedEra era pp)
+    ourComputeMinCoin = computeMinimumCoinForUTxO
+        (minimumUTxOForShelleyBasedEra era pp) (fromCardanoAddressAny addr)
 
 --------------------------------------------------------------------------------
 -- Golden tests
@@ -302,100 +342,157 @@ goldenTests_computeMinimumCoinForUTxO
     -- ^ The era name.
     -> MinimumUTxO
     -- ^ The minimum UTxO function.
-    -> [(TokenMap, Coin)]
+    -> [(Address, TokenMap, Coin)]
     -- ^ Mappings from 'TokenMap' values to expected minimum 'Coin' values.
     -> Spec
 goldenTests_computeMinimumCoinForUTxO
-    eraName minimumUTxO expectedMinimumCoins =
+    testName minimumUTxO expectedMinimumCoins =
         goldenTests title
-            (uncurry computeMinimumCoinForUTxO)
+            (\(minUTxO, addrSpec, m) ->
+                computeMinimumCoinForUTxO minUTxO addrSpec m)
             (mkTest <$> expectedMinimumCoins)
   where
     mkTest
-        :: (TokenMap, Coin) -> GoldenTestData (MinimumUTxO, TokenMap) Coin
-    mkTest (tokenMap, coinExpected) = GoldenTestData
-        { params = (minimumUTxO, tokenMap)
+        :: (Address, TokenMap, Coin)
+        -> GoldenTestData (MinimumUTxO, Address, TokenMap) Coin
+    mkTest (addr, tokenMap, coinExpected) = GoldenTestData
+        { params = (minimumUTxO, addr, tokenMap)
         , resultExpected = coinExpected
         }
     title = unwords
-        ["goldenTests_computeMinimumCoinForUTxO", eraName]
+        ["goldenTests_computeMinimumCoinForUTxO:", testName]
 
 --------------------------------------------------------------------------------
 -- Golden 'MinimumUTxO' values
 --------------------------------------------------------------------------------
 
-goldenMinimumUTxO_Shelley :: MinimumUTxO
-goldenMinimumUTxO_Shelley =
+goldenMinimumUTxO_ShelleyEra :: MinimumUTxO
+goldenMinimumUTxO_ShelleyEra =
     minimumUTxOForShelleyBasedEra ShelleyBasedEraShelley
         def {Shelley._minUTxOValue = testParameter_minUTxOValue_Shelley}
 
-goldenMinimumUTxO_Allegra :: MinimumUTxO
-goldenMinimumUTxO_Allegra =
+goldenMinimumUTxO_AllegraEra :: MinimumUTxO
+goldenMinimumUTxO_AllegraEra =
     minimumUTxOForShelleyBasedEra ShelleyBasedEraAllegra
         def {Shelley._minUTxOValue = testParameter_minUTxOValue_Allegra}
 
-goldenMinimumUTxO_Mary :: MinimumUTxO
-goldenMinimumUTxO_Mary =
+goldenMinimumUTxO_MaryEra :: MinimumUTxO
+goldenMinimumUTxO_MaryEra =
     minimumUTxOForShelleyBasedEra ShelleyBasedEraMary
         def {Shelley._minUTxOValue = testParameter_minUTxOValue_Mary}
 
-goldenMinimumUTxO_Alonzo :: MinimumUTxO
-goldenMinimumUTxO_Alonzo =
+goldenMinimumUTxO_AlonzoEra :: MinimumUTxO
+goldenMinimumUTxO_AlonzoEra =
     minimumUTxOForShelleyBasedEra ShelleyBasedEraAlonzo
         def {Alonzo._coinsPerUTxOWord = testParameter_coinsPerUTxOWord_Alonzo}
 
-goldenMinimumUTxO_Babbage :: MinimumUTxO
-goldenMinimumUTxO_Babbage =
+goldenMinimumUTxO_BabbageEra :: MinimumUTxO
+goldenMinimumUTxO_BabbageEra =
     minimumUTxOForShelleyBasedEra ShelleyBasedEraBabbage
         def {Babbage._coinsPerUTxOByte = testParameter_coinsPerUTxOByte_Babbage}
 
 --------------------------------------------------------------------------------
--- Golden minimum 'Coin' values
+-- Golden minimum 'Coin' values: Byron-style addresses
 --------------------------------------------------------------------------------
 
-goldenMinimumCoins_Shelley :: [(TokenMap, Coin)]
-goldenMinimumCoins_Shelley =
-    [ (goldenTokenMap_0, Coin 1_000_000)
-    , (goldenTokenMap_1, Coin 1_000_000)
-    , (goldenTokenMap_2, Coin 1_000_000)
-    , (goldenTokenMap_3, Coin 1_000_000)
-    , (goldenTokenMap_4, Coin 1_000_000)
+maxLengthAddressBryon :: Address
+maxLengthAddressBryon = maxLengthAddressFor $ Proxy @ByronKey
+
+goldenMinimumCoins_ByronAddress_ShelleyEra :: [(Address, TokenMap, Coin)]
+goldenMinimumCoins_ByronAddress_ShelleyEra =
+    [ (maxLengthAddressBryon, goldenTokenMap_0, Coin 1_000_000)
+    , (maxLengthAddressBryon, goldenTokenMap_1, Coin 1_000_000)
+    , (maxLengthAddressBryon, goldenTokenMap_2, Coin 1_000_000)
+    , (maxLengthAddressBryon, goldenTokenMap_3, Coin 1_000_000)
+    , (maxLengthAddressBryon, goldenTokenMap_4, Coin 1_000_000)
     ]
 
-goldenMinimumCoins_Allegra :: [(TokenMap, Coin)]
-goldenMinimumCoins_Allegra =
-    [ (goldenTokenMap_0, Coin 1_000_000)
-    , (goldenTokenMap_1, Coin 1_000_000)
-    , (goldenTokenMap_2, Coin 1_000_000)
-    , (goldenTokenMap_3, Coin 1_000_000)
-    , (goldenTokenMap_4, Coin 1_000_000)
+goldenMinimumCoins_ByronAddress_AllegraEra :: [(Address, TokenMap, Coin)]
+goldenMinimumCoins_ByronAddress_AllegraEra =
+    [ (maxLengthAddressBryon, goldenTokenMap_0, Coin 1_000_000)
+    , (maxLengthAddressBryon, goldenTokenMap_1, Coin 1_000_000)
+    , (maxLengthAddressBryon, goldenTokenMap_2, Coin 1_000_000)
+    , (maxLengthAddressBryon, goldenTokenMap_3, Coin 1_000_000)
+    , (maxLengthAddressBryon, goldenTokenMap_4, Coin 1_000_000)
     ]
 
-goldenMinimumCoins_Mary :: [(TokenMap, Coin)]
-goldenMinimumCoins_Mary =
-    [ (goldenTokenMap_0, Coin 1_000_000)
-    , (goldenTokenMap_1, Coin 1_444_443)
-    , (goldenTokenMap_2, Coin 1_555_554)
-    , (goldenTokenMap_3, Coin 1_740_739)
-    , (goldenTokenMap_4, Coin 1_999_998)
+goldenMinimumCoins_ByronAddress_MaryEra :: [(Address, TokenMap, Coin)]
+goldenMinimumCoins_ByronAddress_MaryEra =
+    [ (maxLengthAddressBryon, goldenTokenMap_0, Coin 1_000_000)
+    , (maxLengthAddressBryon, goldenTokenMap_1, Coin 1_444_443)
+    , (maxLengthAddressBryon, goldenTokenMap_2, Coin 1_555_554)
+    , (maxLengthAddressBryon, goldenTokenMap_3, Coin 1_740_739)
+    , (maxLengthAddressBryon, goldenTokenMap_4, Coin 1_999_998)
     ]
 
-goldenMinimumCoins_Alonzo :: [(TokenMap, Coin)]
-goldenMinimumCoins_Alonzo =
-    [ (goldenTokenMap_0, Coin   999_978)
-    , (goldenTokenMap_1, Coin 1_344_798)
-    , (goldenTokenMap_2, Coin 1_448_244)
-    , (goldenTokenMap_3, Coin 1_620_654)
-    , (goldenTokenMap_4, Coin 1_862_028)
+goldenMinimumCoins_ByronAddress_AlonzoEra :: [(Address, TokenMap, Coin)]
+goldenMinimumCoins_ByronAddress_AlonzoEra =
+    [ (maxLengthAddressBryon, goldenTokenMap_0, Coin   999_978)
+    , (maxLengthAddressBryon, goldenTokenMap_1, Coin 1_344_798)
+    , (maxLengthAddressBryon, goldenTokenMap_2, Coin 1_448_244)
+    , (maxLengthAddressBryon, goldenTokenMap_3, Coin 1_620_654)
+    , (maxLengthAddressBryon, goldenTokenMap_4, Coin 1_862_028)
     ]
 
-goldenMinimumCoins_Babbage :: [(TokenMap, Coin)]
-goldenMinimumCoins_Babbage =
-    [ (goldenTokenMap_0, Coin 1_107_670)
-    , (goldenTokenMap_1, Coin 1_262_830)
-    , (goldenTokenMap_2, Coin 1_435_230)
-    , (goldenTokenMap_3, Coin 1_435_230)
-    , (goldenTokenMap_4, Coin 2_124_830)
+goldenMinimumCoins_ByronAddress_BabbageEra :: [(Address, TokenMap, Coin)]
+goldenMinimumCoins_ByronAddress_BabbageEra =
+    [ (maxLengthAddressBryon, goldenTokenMap_0, Coin 1_107_670)
+    , (maxLengthAddressBryon, goldenTokenMap_1, Coin 1_262_830)
+    , (maxLengthAddressBryon, goldenTokenMap_2, Coin 1_435_230)
+    , (maxLengthAddressBryon, goldenTokenMap_3, Coin 1_435_230)
+    , (maxLengthAddressBryon, goldenTokenMap_4, Coin 2_124_830)
+    ]
+
+--------------------------------------------------------------------------------
+-- Golden minimum 'Coin' values: Shelley-style addresses
+--------------------------------------------------------------------------------
+
+maxLengthAddressShelley :: Address
+maxLengthAddressShelley = maxLengthAddressFor $ Proxy @ShelleyKey
+
+goldenMinimumCoins_ShelleyAddress_ShelleyEra :: [(Address, TokenMap, Coin)]
+goldenMinimumCoins_ShelleyAddress_ShelleyEra =
+    [ (maxLengthAddressShelley, goldenTokenMap_0, Coin 1_000_000)
+    , (maxLengthAddressShelley, goldenTokenMap_1, Coin 1_000_000)
+    , (maxLengthAddressShelley, goldenTokenMap_2, Coin 1_000_000)
+    , (maxLengthAddressShelley, goldenTokenMap_3, Coin 1_000_000)
+    , (maxLengthAddressShelley, goldenTokenMap_4, Coin 1_000_000)
+    ]
+
+goldenMinimumCoins_ShelleyAddress_AllegraEra :: [(Address, TokenMap, Coin)]
+goldenMinimumCoins_ShelleyAddress_AllegraEra =
+    [ (maxLengthAddressShelley, goldenTokenMap_0, Coin 1_000_000)
+    , (maxLengthAddressShelley, goldenTokenMap_1, Coin 1_000_000)
+    , (maxLengthAddressShelley, goldenTokenMap_2, Coin 1_000_000)
+    , (maxLengthAddressShelley, goldenTokenMap_3, Coin 1_000_000)
+    , (maxLengthAddressShelley, goldenTokenMap_4, Coin 1_000_000)
+    ]
+
+goldenMinimumCoins_ShelleyAddress_MaryEra :: [(Address, TokenMap, Coin)]
+goldenMinimumCoins_ShelleyAddress_MaryEra =
+    [ (maxLengthAddressShelley, goldenTokenMap_0, Coin 1_000_000)
+    , (maxLengthAddressShelley, goldenTokenMap_1, Coin 1_444_443)
+    , (maxLengthAddressShelley, goldenTokenMap_2, Coin 1_555_554)
+    , (maxLengthAddressShelley, goldenTokenMap_3, Coin 1_740_739)
+    , (maxLengthAddressShelley, goldenTokenMap_4, Coin 1_999_998)
+    ]
+
+goldenMinimumCoins_ShelleyAddress_AlonzoEra :: [(Address, TokenMap, Coin)]
+goldenMinimumCoins_ShelleyAddress_AlonzoEra =
+    [ (maxLengthAddressShelley, goldenTokenMap_0, Coin   999_978)
+    , (maxLengthAddressShelley, goldenTokenMap_1, Coin 1_344_798)
+    , (maxLengthAddressShelley, goldenTokenMap_2, Coin 1_448_244)
+    , (maxLengthAddressShelley, goldenTokenMap_3, Coin 1_620_654)
+    , (maxLengthAddressShelley, goldenTokenMap_4, Coin 1_862_028)
+    ]
+
+goldenMinimumCoins_ShelleyAddress_BabbageEra :: [(Address, TokenMap, Coin)]
+goldenMinimumCoins_ShelleyAddress_BabbageEra =
+    [ (maxLengthAddressShelley, goldenTokenMap_0, Coin   995_610)
+    , (maxLengthAddressShelley, goldenTokenMap_1, Coin 1_150_770)
+    , (maxLengthAddressShelley, goldenTokenMap_2, Coin 1_323_170)
+    , (maxLengthAddressShelley, goldenTokenMap_3, Coin 1_323_170)
+    , (maxLengthAddressShelley, goldenTokenMap_4, Coin 2_012_770)
     ]
 
 --------------------------------------------------------------------------------
@@ -519,6 +616,9 @@ fromCardanoAddressAny =  Address . Cardano.serialiseToRawBytes
 
 instance Arbitrary Cardano.AddressAny where
     arbitrary = genAddressAny
+
+instance Arbitrary Address where
+    arbitrary = fromCardanoAddressAny <$> arbitrary
 
 instance Arbitrary TokenBundle where
     arbitrary = sized genTxOutTokenBundle

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2207,8 +2207,15 @@ components:
             It is only applicable for pure-ada outputs. If outputs contain other assets
             or a datum hash, the true minimum will be higher than this value.
 
-            With Alonzo, `minimum_utxo_value` is not a real protocol parameter, but rather
+            In Alonzo, `minimum_utxo_value` is not a real protocol parameter, but rather
             derived from from the Alonzo genesis `adaPerUTxOWord`.
+
+            In Babbage, `minimum_utxo_value` is derived from `adaPerUTxOByte`, and dependent on the
+            actual serialised size of an output. In particular, address length and size of the encoded
+            ada-quantity now matters. This value assumes the largest possible ada-quantity encoding, and
+            the largest possible Shelley address. The `minimum_utxo_value` for outputs with Byron addresses
+            will be larger.
+
         eras: *ApiEraInfo
         maximum_collateral_input_count:
           <<: *collateralInputCount

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2202,19 +2202,54 @@ components:
         minimum_utxo_value:
           <<: *amount
           description: |
-            The minimum ada / Lovelace quantity required for new transaction outputs.
+            The absolute minimum quantity of ada required for a new transaction
+            output created with the wallet.
 
-            It is only applicable for pure-ada outputs. If outputs contain other assets
-            or a datum hash, the true minimum will be higher than this value.
+            In general, the ledger rules require that every transaction output
+            has a minimum quantity of ada. This minimum quantity is determined
+            by an era-specific function whose value increases as the number of
+            different assets increases, as the quantity of any individual asset
+            increases, as the length of the target address increases, and if a
+            datum hash is added.
 
-            In Alonzo, `minimum_utxo_value` is not a real protocol parameter, but rather
-            derived from from the Alonzo genesis `adaPerUTxOWord`.
+            Therefore, the value reported by this field should only be viewed
+            as an absolute minimum, and only applies to outputs that send ada
+            (and no other assets) to Shelley-era addresses. If an output
+            contains other assets, specifies a datum hash, or sends funds to a
+            Byron-era address, then the minimum value required by the ledger
+            (and the wallet) will be higher than the value reported by this
+            field.
 
-            In Babbage, `minimum_utxo_value` is derived from `adaPerUTxOByte`, and dependent on the
-            actual serialised size of an output. In particular, address length and size of the encoded
-            ada-quantity now matters. This value assumes the largest possible ada-quantity encoding, and
-            the largest possible Shelley address. The `minimum_utxo_value` for outputs with Byron addresses
-            will be larger.
+            When using the wallet to construct or balance a transaction, if the
+            caller specifies an output with a non-zero ada quantity, then the
+            wallet will verify that the specified quantity is not less than the
+            minimum quantity required by the ledger, and if this verification
+            step fails, return an error that reports the required minimum. If
+            the caller specifies an output without an ada quantity, then the
+            wallet will automatically assign a minimal ada quantity to that
+            output.
+
+            In the Shelley, Allegra, and Mary eras, the `minimum_utxo_value`
+            field was equivalent to the ledger `minUTxOValue` protocol
+            parameter.
+
+            In the Alonzo era, the `minUTxOValue` protocol parameter was
+            replaced by the `coinsPerUTxOWord` protocol parameter. In this era,
+            the minimum ada quantity for an output was determined by
+            multiplying the `coinsPerUTxOWord` parameter by the length (in
+            8-byte words) of the in-memory representation of that output, which
+            was not dependent on the length of the address. Therefore, in this
+            era, specifying a longer address would not require an increase in
+            the minimum ada quantity.
+
+            In the Babbage era, the `coinsPerUTxOWord` protocol parameter was
+            replaced by the `coinsPerUTxOByte` protocol parameter. In this era,
+            the minimum ada quantity for an output is determined by multiplying
+            the `coinsPerUTxOByte` parameter by the length (in bytes) of the
+            serialised representation of the output, which is dependent on the
+            length of the address (among other factors).  Therefore, in this
+            era, specifying a longer address will require an increase in the
+            minimum ada quantity.
 
         eras: *ApiEraInfo
         maximum_collateral_input_count:


### PR DESCRIPTION
### Issue Number

ADP-2039

### Summary

This PR uses information about the boundaries of address lengths to reduce our overestimation of minimum UTxO values for Shelley-era addresses.

- [x] Use `BoundedAddressLength key` class to have address length overestimations for Shelley, Byron, Icarus, Shared **individually** for change generation. This reduces the overestimation of minUTxOValue for Shelley change outputs by 29 bytes (86-57).
- [x] When validating user-specified outputs, or replacing `Coin 0` values with the minimum allowed, we now use the **specific address** for the `minimumUTxOValue` calculation, instead of using `maxLengthAddress`. 

### Comments

- We are still using `maxLengthAddress` when calculating the minUTxOValue for outputs in migration. It would be better to use the longest address from the list we are given by the user.

### Outstanding Tasks

- [x] Verify the `BoundedAddressLength` implementation for `SharedKey`. (Recently added.)
- [x] Consider adding `minLengthAddressFor` to `BoundedAddressLength`, and redefining the global `minLengthAddress` constant in a similar way to how `maxLengthAddress` is defined (by taking the minimum of all values across all known key types).
- [ ] Add golden tests for the lengths (in bytes) of addresses returned by `maxLengthAddressFor` and `minLengthAddressFor`. These will fail fast if anything in our underlying implementation changes.
- [ ] Consider adding individual `maxLengthAddressFor` key addresses to the `Address` generators for `MinimumUTxOSpec`.