### PR TITLE
refactor: sync tolerance for the node-mode only.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -379,7 +379,7 @@ import Cardano.Wallet.Primitive.Slotting
     , unsafeExtendSafeZone
     )
 import Cardano.Wallet.Primitive.SyncProgress
-    ( SyncProgress, SyncTolerance (..) )
+    ( SyncProgress )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Block (..)
@@ -665,7 +665,7 @@ import qualified Data.Vector as V
 data WalletLayer m s (k :: Depth -> Type -> Type)
     = WalletLayer
         (Tracer m WalletWorkerLog)
-        (Block, NetworkParameters, SyncTolerance)
+        (Block, NetworkParameters)
         (NetworkLayer m Block)
         (TransactionLayer k SealedTx)
         (DBLayer m s k)
@@ -703,7 +703,7 @@ data WalletLayer m s (k :: Depth -> Type -> Type)
 -- and their metadata does not require any networking layer.
 type HasDBLayer m s k = HasType (DBLayer m s k)
 
-type HasGenesisData = HasType (Block, NetworkParameters, SyncTolerance)
+type HasGenesisData = HasType (Block, NetworkParameters)
 
 type HasLogger m msg = HasType (Tracer m msg)
 
@@ -721,9 +721,9 @@ dbLayer =
 
 genesisData
     :: forall ctx. HasGenesisData ctx
-    => Lens' ctx (Block, NetworkParameters, SyncTolerance)
+    => Lens' ctx (Block, NetworkParameters)
 genesisData =
-    typed @(Block, NetworkParameters, SyncTolerance)
+    typed @(Block, NetworkParameters)
 
 logger
     :: forall m msg ctx. HasLogger m msg ctx
@@ -775,7 +775,7 @@ createWallet ctx wid wname s = db & \DBLayer{..} -> do
         initializeWallet wid cp meta hist gp $> wid
   where
     db = ctx ^. dbLayer @m @s @k
-    (block0, NetworkParameters gp _sp _pp, _) = ctx ^. genesisData
+    (block0, NetworkParameters gp _sp _pp) = ctx ^. genesisData
 
 -- | Initialise and store a new legacy Icarus wallet. These wallets are
 -- intrinsically sequential, but, in the incentivized testnet, we only have
@@ -812,7 +812,7 @@ createIcarusWallet ctx wid wname credentials = db & \DBLayer{..} -> do
         initializeWallet wid cp meta hist gp $> wid
   where
     db = ctx ^. dbLayer @IO @s @k
-    (block0, NetworkParameters gp _sp _pp, _) = ctx ^. genesisData
+    (block0, NetworkParameters gp _sp _pp) = ctx ^. genesisData
 
 -- | Check whether a wallet is in good shape when restarting a worker.
 checkWalletIntegrity

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -239,8 +239,6 @@ import Cardano.Wallet.Network
     ( NetworkLayer )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth, DerivationIndex, Role )
-import Cardano.Wallet.Primitive.SyncProgress
-    ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
     ( Block
     , NetworkParameters
@@ -1146,7 +1144,7 @@ data ApiLayer s (k :: Depth -> Type -> Type)
     = ApiLayer
         (Tracer IO TxSubmitLog)
         (Tracer IO (WorkerLog WalletId WalletWorkerLog))
-        (Block, NetworkParameters, SyncTolerance)
+        (Block, NetworkParameters)
         (NetworkLayer IO Block)
         (TransactionLayer k SealedTx)
         (DBFactory IO s k)

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -175,6 +175,7 @@ data NetworkLayer m block = NetworkLayer
 
     , timeInterpreter
         :: TimeInterpreter (ExceptT PastHorizonException m)
+
     , syncProgress
         :: SlotNo -> m (SyncProgress)
         -- ^ Compute the ratio between the provided 'SlotNo' and the slot
@@ -203,7 +204,7 @@ data ChainFollower m point tip blocks = ChainFollower
         -- is used by the 'ChainFollower'.
         -- The argument of this field is the @epochStability@.
         --
-        -- Exposing this policy here enables any chain synchronizer 
+        -- Exposing this policy here enables any chain synchronizer
         -- which does not retrieve full blocks, such as 'lightSync',
         -- to specifically target those block heights at which
         -- the 'ChainFollower' intends to create checkpoints.

--- a/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
@@ -524,11 +524,9 @@ neverFails
     :: String
     -> TimeInterpreter (ExceptT PastHorizonException IO)
     -> TimeInterpreter IO
-neverFails reason = f . hoistTimeInterpreter (runExceptT >=> eitherToIO)
+neverFails reason =
+    f . hoistTimeInterpreter (runExceptT >=> either throwIO pure)
   where
-    eitherToIO (Right x) = pure x
-    eitherToIO (Left e) = throwIO e
-
     f (TimeInterpreter getI ss tr h) = TimeInterpreter
         { interpreter = getI
         , blockchainStartTime = ss

--- a/lib/core/src/Cardano/Wallet/Primitive/SyncProgress.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/SyncProgress.hs
@@ -81,8 +81,7 @@ newtype SyncTolerance = SyncTolerance NominalDiffTime
 
 -- | Construct a 'SyncTolerance' from a number of __seconds__
 mkSyncTolerance :: Int -> SyncTolerance
-mkSyncTolerance =
-    SyncTolerance . toEnum . (* pico)
+mkSyncTolerance = SyncTolerance . toEnum . (* pico)
   where
     pico = 1_000_000_000_000
 

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -90,8 +90,6 @@ import Cardano.Wallet.Primitive.Passphrase
     ( ErrWrongPassphrase (..), Passphrase (..) )
 import Cardano.Wallet.Primitive.Passphrase.Current
     ( preparePassphrase )
-import Cardano.Wallet.Primitive.SyncProgress
-    ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Block
@@ -1326,7 +1324,7 @@ setupFixture (wid, wname, wstate) = do
     let nl = mockNetworkLayer
     let tl = dummyTransactionLayer
     db <- PureLayer.newDBLayer timeInterpreter
-    let wl = WalletLayer nullTracer (block0, np, st) nl tl db
+    let wl = WalletLayer nullTracer (block0, np) nl tl db
     res <- runExceptT $ W.createWallet wl wid wname wstate
     let wal = case res of
             Left _ -> []
@@ -1336,7 +1334,6 @@ setupFixture (wid, wname, wstate) = do
     timeInterpreter = dummyTimeInterpreter
     slotNoTime = posixSecondsToUTCTime . fromIntegral . unSlotNo
     np = dummyNetworkParameters
-    st = SyncTolerance 10
 
 -- | A dummy transaction layer to see the effect of a root private key. It
 -- implements a fake signer that still produces sort of witnesses

--- a/lib/shelley/bench/latency-bench.hs
+++ b/lib/shelley/bench/latency-bench.hs
@@ -481,13 +481,12 @@ withShelleyServer tracers action = do
 
         listen <- walletListenFromEnv
         serveWallet
-            (NodeSource conn vData)
+            (NodeSource conn vData (SyncTolerance 10))
             np
             tunedForMainnetPipeliningStrategy
             (SomeNetworkDiscriminant $ Proxy @'Mainnet)
             []
             tracers
-            (SyncTolerance 10)
             (Just db)
             Nothing
             "127.0.0.1"

--- a/lib/shelley/bench/restore-bench.hs
+++ b/lib/shelley/bench/restore-bench.hs
@@ -795,9 +795,7 @@ bench_restoration
                     let tracer =
                             trMessageText wlTr <>
                             contramap walletWorkerLogToBlockHeight progressTrace
-                    let w = WalletLayer
-                            tracer (emptyGenesis gp, np, sTol) nw tl db
-
+                    let w = WalletLayer tracer (emptyGenesis gp, np) nw tl db
                     forM_ wallets $ \(wid, wname, s) -> do
                         _ <- unsafeRunExceptT $ W.createWallet w wid wname s
                         void

--- a/lib/shelley/exe/local-cluster.hs
+++ b/lib/shelley/exe/local-cluster.hs
@@ -256,13 +256,12 @@ main = withLocalClusterSetup $ \dir clusterLogs walletLogs ->
                 <$> getEKGURL
 
             void $ serveWallet
-                (NodeSource socketPath vData)
+                (NodeSource socketPath vData (SyncTolerance 10))
                 gp
                 tunedForMainnetPipeliningStrategy
                 (SomeNetworkDiscriminant $ Proxy @'Mainnet)
                 []
                 tracers
-                (SyncTolerance 10)
                 (Just db)
                 Nothing
                 "127.0.0.1"

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -537,13 +537,13 @@ server byron icarus shelley multisig spl ntp =
 
     network' :: NetworkId -> Server Network
     network' nid =
-        getNetworkInformation nid syncTolerance nl
+        getNetworkInformation nid nl
         :<|> getNetworkParameters genesis nl tl
         :<|> getNetworkClock ntp
       where
         nl = icarus ^. networkLayer
         tl = icarus ^. transactionLayer @IcarusKey
-        genesis@(_,_,syncTolerance) = icarus ^. genesisData
+        genesis@(_,_) = icarus ^. genesisData
 
     proxy :: Server Proxy_
     proxy = postExternalTransaction icarus

--- a/lib/shelley/src/Cardano/Wallet/Shelley/BlockchainSource.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/BlockchainSource.hs
@@ -10,15 +10,13 @@ module Cardano.Wallet.Shelley.BlockchainSource
 
 import Cardano.Launcher.Node
     ( CardanoNodeConn )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance )
 import Cardano.Wallet.Shelley.Compatibility
     ( NodeToClientVersionData )
 
 import qualified Blockfrost.Client as Blockfrost
 
 data BlockchainSource
-    = NodeSource
-        CardanoNodeConn
-        -- ^ Socket for communicating with the node
-        NodeToClientVersionData
+    = NodeSource CardanoNodeConn NodeToClientVersionData SyncTolerance
     | BlockfrostSource Blockfrost.Project
-    -- ^ Blockfrost token when working in the light mode

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -48,7 +48,7 @@ import Cardano.BM.Data.Tracer
 import Cardano.Chain.Genesis
     ( GenesisData (..), readGenesisData )
 import Cardano.CLI
-    ( optionT )
+    ( optionT, syncToleranceOption )
 import Cardano.Launcher
     ( LauncherLog )
 import Cardano.Launcher.Node
@@ -96,6 +96,8 @@ import UnliftIO.Temporary
     ( withTempDirectory )
 
 import qualified Cardano.Wallet.Byron.Compatibility as Byron
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance )
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Shelley.Launch.Blockfrost as Blockfrost
 import qualified Data.ByteString.Lazy.Char8 as BL8
@@ -387,14 +389,16 @@ instance HasSeverityAnnotation TempDirLog where
                                     Mode
 -------------------------------------------------------------------------------}
 
-data Mode = Normal CardanoNodeConn | Light Blockfrost.TokenFile
+data Mode
+    = Normal CardanoNodeConn SyncTolerance
+    | Light Blockfrost.TokenFile
   deriving (Show)
 
 modeOption :: Parser Mode
 modeOption = normalMode <|> lightMode
   where
     normalMode =
-        Normal <$> nodeSocketOption
+        Normal <$> nodeSocketOption <*> syncToleranceOption
     lightMode =
         flag' () (long "light" <> help "Enable light mode") *>
         fmap Light Blockfrost.tokenFileOption

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -21,8 +21,6 @@ import Cardano.BM.Tracing
     ( HasPrivacyAnnotation, HasSeverityAnnotation (..), Tracer )
 import Cardano.Wallet.Network
     ( NetworkLayer )
-import Cardano.Wallet.Primitive.SyncProgress
-    ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
     ( NetworkParameters )
 import Cardano.Wallet.Shelley.BlockchainSource
@@ -65,14 +63,13 @@ withNetworkLayer
     -> BlockchainSource
     -> SomeNetworkDiscriminant
     -> NetworkParameters
-    -> SyncTolerance
     -> ContT r IO (NetworkLayer IO (CardanoBlock StandardCrypto))
-withNetworkLayer tr pipeliningStrategy blockchainSrc net netParams tol =
+withNetworkLayer tr pipeliningStrategy blockchainSrc net netParams =
     ContT $ case blockchainSrc of
-        NodeSource nodeConn ver ->
+        NodeSource nodeConn ver tol ->
             let tr' = NodeNetworkLog >$< tr
                 netId = networkDiscriminantToId net
-            in Node.withNetworkLayer 
+            in Node.withNetworkLayer
                 tr' pipeliningStrategy netId netParams nodeConn ver tol
         BlockfrostSource project ->
             let tr' = BlockfrostNetworkLog >$< tr

--- a/lib/shelley/test/integration/shelley-integration-test.hs
+++ b/lib/shelley/test/integration/shelley-integration-test.hs
@@ -357,13 +357,12 @@ specWithServer testDir (tr, tracers) = aroundAll withContext
         let testMetadata = $(getTestData) </> "token-metadata.json"
         withMetadataServer (queryServerStatic testMetadata) $ \tokenMetaUrl ->
             serveWallet
-                (NodeSource conn vData)
+                (NodeSource conn vData (SyncTolerance 10))
                 gp
                 tunedForMainnetPipeliningStrategy
                 (SomeNetworkDiscriminant $ Proxy @'Mainnet)
                 genesisPools
                 tracers
-                (SyncTolerance 10)
                 (Just db)
                 (Just dbDecorator)
                 "127.0.0.1"

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/Launch/BlockfrostSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/Launch/BlockfrostSpec.hs
@@ -47,8 +47,8 @@ spec = describe "Blockfrost CLI options" $ do
         case execParserPure defaultPrefs parserInfo args of
             Failure pf -> expectationFailure $ show pf
             CompletionInvoked cr -> expectationFailure $ show cr
-            Success (Light _) -> expectationFailure "Normal mode expected"
-            Success (Normal _conn) -> pure ()
+            Success Light{} -> expectationFailure "Normal mode expected"
+            Success Normal{} -> pure ()
 
     it "modeOption --light" $ withSystemTempFile "blockfrost.token" $ \f h -> do
         let parserInfo = info modeOption fullDesc
@@ -58,7 +58,7 @@ spec = describe "Blockfrost CLI options" $ do
         case execParserPure defaultPrefs parserInfo args of
             Failure pf -> expectationFailure $ show pf
             CompletionInvoked cr -> expectationFailure $ show cr
-            Success (Normal _conn) -> expectationFailure "Light mode expected"
+            Success Normal{} -> expectationFailure "Light mode expected"
             Success (Light tf) -> do
                 hClose h *> writeFile f (net <> projectId)
                 readToken tf `shouldReturn`


### PR DESCRIPTION
`SyncTolerance` parameter is not used in the light-mode so it makes sense to reorganize CLI options such that its only accepted in the node-mode.

I have stumbled upon the fact that [syncProgress](https://github.com/input-output-hk/cardano-wallet/blob/master/lib/core/src/Cardano/Wallet/Primitive/SyncProgress.hs#L123) function depends on the `SyncTolerance` parameter and is used directly in the `Cardano.Wallet.Api.Server.getNetworkInformation` function. For this reason `SyncTolerance` is passed through all the way from CLI to the `getNetworkInformation`. However, there is another mode-specific `syncProgress` function in the `NetworkLayer` and it doesn't require `SyncTolerance` parameter to be carried around. I have re-worked the code to use `syncProgress` from the `NetworkLayer` but I am not 100% certain that this code change doesn't also change the behavior (slightly) with respect to the blocking in the corner case when node client is not connected yet. 

### Comments

Before:
```
Usage: cardano-wallet serve [--listen-address HOST] 
                            (--node-socket FILE | --light
                              --blockfrost-token-file FILE) 
                            [--random-port | --port INT] 
                            [--tls-ca-cert FILE --tls-sv-cert FILE
                              --tls-sv-key FILE] 
                            (--mainnet | --testnet FILE | --staging FILE) 
                            [--database DIR] [--sync-tolerance DURATION] 
                            [--shutdown-handler] 
                            [--pool-metadata-fetching ( none | direct | SMASH-URL )]
                            [--token-metadata-server URL] 
                            [--trace-NAME SEVERITY]
```

After:
```
Usage: cardano-wallet serve [--listen-address HOST] 
                            (--node-socket FILE [--sync-tolerance DURATION] | 
                              --light --blockfrost-token-file FILE) 
                            [--random-port | --port INT] 
                            [--tls-ca-cert FILE --tls-sv-cert FILE
                              --tls-sv-key FILE] 
                            (--mainnet | --testnet FILE | --staging FILE) 
                            [--database DIR] [--shutdown-handler] 
                            [--pool-metadata-fetching ( none | direct | SMASH-URL )]
                            [--token-metadata-server URL] 
                            [--trace-NAME SEVERITY]
```
### Issue Number

ADP-1508
