### PR TITLE
Adjust `stylish-haskell` configuration to strip trailing whitespace.

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -15,6 +15,7 @@ steps:
       pad_module_names: false
       separate_lists: true
       space_surround: true
+  - trailing_whitespace: {}
 
   - language_pragmas:
       align: false

--- a/lib/core-integration/extra/Plutus/FlatInteger.hs
+++ b/lib/core-integration/extra/Plutus/FlatInteger.hs
@@ -48,7 +48,7 @@ word7s x
 ------------------------------------------------------------------------------}
 -- | Convert a bytes into a sequence of bits.
 -- The least significant bit comes last, e.g.
--- 
+--
 -- > toBits 0x03 = [False,False,False,False,False,False,True,True]
 toBits :: Word8 -> [Bool]
 toBits x = map (Bits.testBit x) [7,6,5,4,3,2,1,0]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -72,7 +72,7 @@ spec = describe "COMMON_NETWORK" $ do
                 , expectField (#nodeEra) (`shouldBe` _mainEra ctx)
                 , expectField (#nodeTip . #absoluteSlotNumber . #getApiT) (`shouldNotBe` 0)
                 , \x -> (epochStartTime <$> nextEpoch (unsafeResponse x)) .> Just now
-                , expectField (#networkInfo . #protocolMagic) 
+                , expectField (#networkInfo . #protocolMagic)
                     (`shouldBe` fromIntegral (getProtocolMagic mainnetMagic))
                 ]
             counterexample (show r) $ do

--- a/lib/core/src/Cardano/Pool/Rank/Likelihood.hs
+++ b/lib/core/src/Cardano/Pool/Rank/Likelihood.hs
@@ -88,7 +88,7 @@ estimatePoolPerformance
         -- Recent performance weighs more than past performance:
         --
         -- * Block production from > 25 epochs ago has less than 10% influence
-        -- on the likelihoods. 
+        -- on the likelihoods.
         -- * Block production from > 50 epochs ago has less than 1% influence
         -- on the likelihoods and can be ignored.
     -> PerformanceEstimate

--- a/lib/core/src/Cardano/Wallet/Address/Pool.hs
+++ b/lib/core/src/Cardano/Wallet/Address/Pool.hs
@@ -229,7 +229,7 @@ update addr pool@Pool{addresses} =
 -- in order to satisfy 'prop_fresh' again.
 --
 -- Preconditions:
--- 
+--
 -- * The index @ix@ satisfies:
 --
 --     either @ix = fromEnum 0@

--- a/lib/core/src/Cardano/Wallet/Api/Aeson/Variant.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Aeson/Variant.hs
@@ -48,7 +48,7 @@ variant = Variant
 -- representing the 'Left'/'Right' cases.
 -- Instead, the predicates of the variants can be used to disambiguate a
 -- 'Value' by checking the presence of absence of certain JSON object keys.
-variants 
+variants
     :: String -- ^ Error message suffix in case of parse failure.
     -> [Variant a] -- ^ Possible variants.
     -> Value -- ^ Value to parse.

--- a/lib/core/src/Cardano/Wallet/Api/Client.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Client.hs
@@ -126,7 +126,7 @@ import qualified Data.Aeson as Aeson
 {-------------------------------------------------------------------------------
                               Server Interaction
 -------------------------------------------------------------------------------}
-type family  WalletPutPassphraseFormat wallet where 
+type family  WalletPutPassphraseFormat wallet where
     WalletPutPassphraseFormat ApiWallet = WalletPutPassphraseData
     WalletPutPassphraseFormat ApiByronWallet = ByronWalletPutPassphraseData
 

--- a/lib/core/src/Cardano/Wallet/Checkpoints.hs
+++ b/lib/core/src/Cardano/Wallet/Checkpoints.hs
@@ -12,18 +12,18 @@
 -- Each checkpoints is associated with a 'Slot'.
 
 module Cardano.Wallet.Checkpoints
-    ( -- * Checkpoints  
+    ( -- * Checkpoints
       Checkpoints
     , checkpoints
     , loadCheckpoints
     , fromGenesis
     , getLatest
     , findNearestPoint
-    
+
     -- * Delta types
     , DeltaCheckpoints (..)
     , DeltasCheckpoints
-    
+
     -- * Checkpoint hygiene
     , SparseCheckpointsConfig (..)
     , defaultSparseCheckpointsConfig
@@ -114,7 +114,7 @@ fromGenesis a = Checkpoints $ Map.singleton W.Origin a
 
 -- | Get the checkpoint with the largest 'SlotNo'.
 getLatest :: Checkpoints a -> (W.Slot, a)
-getLatest = from . Map.lookupMax . view #checkpoints 
+getLatest = from . Map.lookupMax . view #checkpoints
   where
     from = fromMaybe (error "getLatest: there should always be at least a genesis checkpoint")
 

--- a/lib/core/src/Cardano/Wallet/Checkpoints/Policy.hs
+++ b/lib/core/src/Cardano/Wallet/Checkpoints/Policy.hs
@@ -160,7 +160,7 @@ Hence, we should strive to
 - Keep only one checkpoint every `largeGap` ~100 blocks
 - But still keep ~10 most recent checkpoints to cope with small rollbacks.
 
-Roughly, the 'sparseArithmetic' 
+Roughly, the 'sparseArithmetic'
 
 0 ..... N*largeGap .... (N+1)*largeGap .. .. M*smallGap (M+1)*smallGap tip
         |_______________________________________________________________|

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -145,7 +145,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -- ^ 'DBVar' containing the 'WalletState' of each wallet in the database.
         -- Currently contains all 'Checkpoints' of the 'UTxO' and the
         -- 'Discoveries', as well as the 'Prologue' of the address discovery state.
-        -- 
+        --
         -- Intended to replace 'putCheckpoint' and 'readCheckpoint' in the short-term,
         -- and all other functions in the long-term.
 

--- a/lib/core/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -83,7 +83,7 @@ import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Data.Map.Strict as Map
 
 -- | A context that carries a TxOut together with its tokens
--- (this will be needed in the future for the DB Layer 
+-- (this will be needed in the future for the DB Layer
 -- to reconstruct 'TransactionInfo').
 data WithTxOut txin = WithTxOut
     { txIn :: txin, context :: Maybe (TxOut, [TxOutToken]) }
@@ -169,7 +169,7 @@ instance Delta DeltaTxHistory where
     type Base DeltaTxHistory = TxHistory
     -- transactions are immutable so here there should happen no rewriting
     -- but we mimic the repsert in the store
-    apply (Append txs) h = txs <> h 
+    apply (Append txs) h = txs <> h
     apply (DeleteTx tid) (TxHistoryF txs) =
         TxHistoryF $ Map.delete tid txs
 
@@ -184,7 +184,7 @@ mkTxIn tid (ix,(txIn,amt)) =
     }
 
 mkTxCollateral :: TxId
-    -> (Int, (W.TxIn, W.Coin)) 
+    -> (Int, (W.TxIn, W.Coin))
     -> TxCollateral
 mkTxCollateral tid (ix,(txCollateral,amt)) =
     TxCollateral

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -203,7 +203,7 @@ data ChainFollower m point tip blocks = ChainFollower
         -- is used by the 'ChainFollower'.
         -- The argument of this field is the @epochStability@.
         --
-        -- Exposing this policy here enables any chain synchronizer 
+        -- Exposing this policy here enables any chain synchronizer
         -- which does not retrieve full blocks, such as 'lightSync',
         -- to specifically target those block heights at which
         -- the 'ChainFollower' intends to create checkpoints.

--- a/lib/core/test/unit/Cardano/Pool/RankSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/RankSpec.hs
@@ -102,7 +102,7 @@ proportionTo (Coin x) (Coin y) = fromIntegral x / fromIntegral y
 
 genStakePoolsSummary :: RewardParams -> Gen StakePoolsSummary
 genStakePoolsSummary rp =
-    StakePoolsSummary rp <$> liftArbitrary (genRewardInfoPool rp) 
+    StakePoolsSummary rp <$> liftArbitrary (genRewardInfoPool rp)
 
 instance Arbitrary PoolId where
     arbitrary =

--- a/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -1067,7 +1067,7 @@ instance Malformed (BodyParam WalletPutPassphraseData) where
                 }|]
               , "Error in $['mnemonic_second_factor']: Invalid entropy checksum: please double-check the last word of your mnemonic sentence., mnemonic variant"
               )
-            
+
             ]
 
 instance Malformed (BodyParam ByronWalletPutPassphraseData) where

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1999,7 +1999,7 @@ instance Arbitrary ApiSlotId where
     shrink = genericShrink
 
 instance Arbitrary ApiNetworkInfo where
-    arbitrary = oneof 
+    arbitrary = oneof
         [ pure $ ApiNetworkInfo "mainnet" 764824073
         , ApiNetworkInfo "testnet" <$> arbitrary
         ]

--- a/lib/core/test/unit/Cardano/Wallet/Checkpoints/PolicySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Checkpoints/PolicySpec.hs
@@ -56,10 +56,10 @@ spec = do
 
         it "trailingArithmetic n _  has at most n checkpoints" $
             property prop_trailingLength
-        
+
         it "trailingArithmetic checkpoints are located at grid points" $
             property prop_trailingGrid
-    
+
         it "sparseArithmetic checkpoints after genesis are close to tip" $
             property $ \(GenHeightContext epochStability tip) ->
                 maybe False (>= tip - 2*epochStability - 20) $

--- a/lib/dbvar/src/Data/Chain.hs
+++ b/lib/dbvar/src/Data/Chain.hs
@@ -193,13 +193,13 @@ collapseNode now chain@Chain{next,prev} =
                 $ Map.delete now next
             , prev
                 = Map.insert nto (Just nfrom)
-                $ Map.delete now prev 
+                $ Map.delete now prev
             }
         _ -> chain
 
 -- | Remove the tip and more nodes from the chain until
 -- the given node is the tip.
--- 
+--
 -- Do nothing if the node is not in the chain.
 rollbackTo :: Ord node => node -> Chain node edge -> Chain node edge
 rollbackTo new chain@Chain{next,prev,tip}
@@ -306,6 +306,6 @@ data Edge node edge = Edge
 instance Functor (Edge node) where
     fmap f e@Edge{via} = e{ via = f via }
 
--- | Flatten a list of edges 
+-- | Flatten a list of edges
 flattenEdge :: Edge node [edge] -> [Edge node edge]
 flattenEdge Edge{to,from,via} = [ Edge{to,from,via=v} | v <- via ]

--- a/lib/dbvar/src/Data/Delta.hs
+++ b/lib/dbvar/src/Data/Delta.hs
@@ -12,14 +12,14 @@ module Data.Delta (
     -- is a delta encoding of the corresponding base type 'Base'@ delta@.
     --
     -- Delta encodings can be transformed into each other using an 'Embedding'.
-    
+
     -- * Delta encodings
     Delta (..)
     , NoChange (..), Replace (..)
     , DeltaList (..)
     , DeltaSet1 (..)
     , DeltaSet, mkDeltaSet, deltaSetToList, deltaSetFromList
-    
+
     -- * Embedding of types and delta encodings
     -- $Embedding
     , Embedding
@@ -57,7 +57,7 @@ class Delta delta where
     -- | Base type for which @delta@ represents a delta encoding.
     -- This is implemented as a type family, so that we can have
     -- multiple delta encodings for the same base type.
-    -- 
+    --
     -- FIXME: Better name for 'Base'? It's sooo generic.
     -- Pier, dock, ground, anchor, site, …
     type Base delta :: Type
@@ -286,7 +286,7 @@ mkEmbedding Embedding'{load,write,update} = Embedding
 -- from an efficient 'Embedding'.
 fromEmbedding :: (Delta da, Delta db) => Embedding da db -> Embedding' da db
 fromEmbedding Embedding{inject,project} = Embedding'
-    { load = fmap fst . project 
+    { load = fmap fst . project
     , write = state_ . inject
     , update = \a b da ->
         let (_ ,mab) = from (project b)
@@ -351,7 +351,7 @@ replaceFromApply = Embedding'
 {-
 -- | Use the 'update' function of an 'Embedding' to convert
 -- one delta encoding to another.
--- 
+--
 -- This function assumes that the 'Embedding' argument satisfies
 -- @load = Just@ and @write = id@.
 applyWithEmbedding

--- a/lib/dbvar/src/Data/Table.hs
+++ b/lib/dbvar/src/Data/Table.hs
@@ -200,7 +200,7 @@ fromSet = Pile . Set.toList
 -- Every function @f :: Pile A -> B@ should satisfy
 --
 -- > forall g.  f . permute g = f
--- 
+--
 -- permute :: RandomGen g => g -> Pile a -> Pile a
 -- permute = undefined
 --      let (index, g2) = randomR (1,n) g1
@@ -214,7 +214,7 @@ deltaSetToPile = Pile . Delta.deltaSetToList
 --
 -- > deltaSetFromPile . deltaSetToPile = id
 deltaSetFromPile :: Ord a => Pile (DeltaSet1 a) -> DeltaSet a
-deltaSetFromPile = Delta.deltaSetFromList . getPile 
+deltaSetFromPile = Delta.deltaSetFromList . getPile
 
 -- | Map a 'DeltaList' to a 'Pile' of indexed single element concatenations.
 -- Higher indices are prepended later.

--- a/lib/dbvar/src/Database/Persist/Delta.hs
+++ b/lib/dbvar/src/Database/Persist/Delta.hs
@@ -106,7 +106,7 @@ sqlDB = Database
     Database operations
 -------------------------------------------------------------------------------}
 -- | Construct a 'Store' from an SQL table.
--- 
+--
 -- The unique IDs will be stored in a column "id" at the end of
 -- each row in the database table.
 newSqlStore

--- a/lib/dbvar/src/Database/Schema.hs
+++ b/lib/dbvar/src/Database/Schema.hs
@@ -22,7 +22,7 @@ module Database.Schema (
     -- * SQL Queries
     , Query, callSql, runSql
     , createTable, selectAll, insertOne, repsertOne, updateOne, deleteAll, deleteOne
-    
+
     -- * Testing
     , testPerson
     ) where

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -72,7 +72,7 @@ withNetworkLayer tr pipeliningStrategy blockchainSrc net netParams tol =
         NodeSource nodeConn ver ->
             let tr' = NodeNetworkLog >$< tr
                 netId = networkDiscriminantToId net
-            in Node.withNetworkLayer 
+            in Node.withNetworkLayer
                 tr' pipeliningStrategy netId netParams nodeConn ver tol
         BlockfrostSource project ->
             let tr' = BlockfrostNetworkLog >$< tr

--- a/prototypes/light-mode-test/src/Light/Types.hs
+++ b/prototypes/light-mode-test/src/Light/Types.hs
@@ -43,6 +43,6 @@ latest = maximumBy (comparing height)
 -- | Get the 'ChainPoint' that the block is associated to.
 fromBlock :: Block -> ChainPoint
 fromBlock b = case _blockHeight b of
-    Nothing -> Origin 
+    Nothing -> Origin
     Just height -> At height (_blockHash b)
 


### PR DESCRIPTION
## Issue Number

None

## Summary

This PR adjusts our `stylish-haskell` configuration to strip trailing whitespace from the end of lines in Haskell files.

It also strips trailing whitespace from existing files in our repository.