### PR TITLE
Try out `servant-typescript` to generate TypeScript client code

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -178,7 +178,8 @@
                   # Local test cluster and mock metadata server
                   inherit (project.hsPkgs.cardano-wallet.components.exes)
                     local-cluster
-                    mock-token-metadata-server;
+                    mock-token-metadata-server
+                    typescript-gen;
 
                   # Adrestia tool belt
                   inherit (project.hsPkgs.bech32.components.exes) bech32;

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -325,7 +325,7 @@ type Api n apiPool =
     :<|> ByronTransactions n
     :<|> ByronMigrations n
     :<|> Network
-    :<|> Proxy_
+    -- :<|> Proxy_
     :<|> Settings
     :<|> SMASH
     :<|> SharedWallets
@@ -401,7 +401,7 @@ type GetUTxOsStatistics = "wallets"
 
 type WalletKeys =
     GetWalletKey
-    :<|> SignMetadata
+    -- :<|> SignMetadata
     :<|> PostAccountKey
     :<|> GetAccountKey
     :<|> GetPolicyKey
@@ -1129,6 +1129,7 @@ type ConstructSharedTransaction n = "shared-wallets"
   See also: https://input-output-hk.github.io/cardano-wallet/api/edge/#tag/Proxy
 -------------------------------------------------------------------------------}
 
+-- commenting out `Proxy` (above) for typescript-gen.hs
 type Proxy_ =
     PostExternalTransaction
 

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -203,6 +203,39 @@ executable local-cluster
   main-is:
       local-cluster.hs
 
+executable typescript-gen
+  default-language:
+      Haskell2010
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+  ghc-options:
+      -threaded -rtsopts
+      -Wall
+  if (flag(release))
+    ghc-options: -O2 -Werror
+  build-depends:
+      base
+    , cardano-wallet-cli
+    , cardano-wallet-core
+    , cardano-wallet-core-integration
+    , cardano-wallet-launcher
+    , cardano-wallet
+    , contra-tracer
+    , iohk-monitoring
+    , directory
+    , aeson
+    , aeson-typescript
+    , filepath
+    , lobemo-backend-ekg
+    , text
+    , text-class
+    , servant-typescript
+  hs-source-dirs:
+      exe
+  main-is:
+      typescript-gen.hs
+
 executable mock-token-metadata-server
   default-language:
       Haskell2010

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -225,12 +225,13 @@ executable typescript-gen
     , iohk-monitoring
     , directory
     , aeson
-    , aeson-typescript
     , filepath
     , lobemo-backend-ekg
     , text
     , text-class
+    , servant-server
     , servant-typescript
+    , aeson-typescript
   hs-source-dirs:
       exe
   main-is:

--- a/lib/shelley/exe/typescript-gen.hs
+++ b/lib/shelley/exe/typescript-gen.hs
@@ -8,6 +8,9 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 import Prelude
 
@@ -17,40 +20,46 @@ import Cardano.Wallet.Api
 import Servant.TypeScript
 import Cardano.Wallet.Api.Types (ApiStakePool)
 import qualified Cardano.Wallet.Api.Types
+import qualified Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.AddressDerivation (NetworkDiscriminant(..))
 import Data.Aeson.TypeScript.Recursive (recursivelyDeriveMissingTypeScriptInstancesFor)
 import Data.Aeson.TypeScript.TH (deriveJSONAndTypeScript, TypeScript)
+import Servant ((:<|>)(..), (:>)(..))
 
-type MainnetApi = Cardano.Wallet.Api.ApiV2 'Mainnet ApiStakePool
+type SmallerApiV2 = "v2" :> SmallerApi
 
-$(recursivelyDeriveMissingTypeScriptInstancesFor ''MainnetApi (deriveJSONAndTypeScript A.defaultOptions))
+-- FIXME: cardano-wallet API without:
+--   • parts referencing (n :: NetworkDiscriminant)
+--   • and apiPool
+--   • and endpoints returning `OctetStream`
+--       So for now, we commented out `PostExternalTransaction` and `SignMetadata`
+--
+--       We would (maybe) like to propose a JSON representation of OctetStream along the lines of:
+--
+--       > {"data":"base64-encoded-string"}
+type SmallerApi =
+         Wallets
+    :<|> WalletKeys
+    :<|> Assets
+    :<|> ByronWallets
+    :<|> ByronAssets
+    :<|> Network
+    :<|> Settings
+    :<|> SMASH
+    :<|> SharedWallets
+    :<|> SharedWalletKeys
 
--- Hmmm… The 'Mainnet parameter is not handled by `recursivelyDeriveMissingTypeScriptInstancesFor`?
-instance TypeScript (Cardano.Wallet.Api.Types.ApiWalletMigrationPostData 'Mainnet "lenient")
-instance TypeScript (Cardano.Wallet.Api.Types.ApiWalletMigrationPostData 'Mainnet "user")
-instance TypeScript (Cardano.Wallet.Api.Types.ApiAddress 'Mainnet)
--- etc. …
--- No instance for (TypeScript (Cardano.Wallet.Api.Types.ApiSelectCoinsData 'Mainnet))
--- etc. … so we’d have to specify all of them by hand…
+-- TODO: pls, help us get the whole `MainnetApi` instead of `SmallerApi` here :pray:
+--type MainnetApi = Cardano.Wallet.Api.ApiV2 'Mainnet ApiStakePool
 
--- Why is this needed???
-instance TypeScript (Proxy 'Mainnet)
+deriving instance TypeScript Cardano.Wallet.Primitive.Types.WalletId
+
+-- ↑ results in:
+-- • No instance for (TypeScript
+--                      (cryptonite-0.27:Crypto.Hash.Types.Digest
+--                         cryptonite-0.27:Crypto.Hash.Blake2b.Blake2b_160))
+
+$(recursivelyDeriveMissingTypeScriptInstancesFor ''SmallerApi (deriveJSONAndTypeScript A.defaultOptions))
 
 main :: IO ()
-main = writeTypeScriptLibrary (Proxy :: Proxy MainnetApi) "tmp"
-
--- But OctetStream (ByteString) cannot be processed, since it’s not JSON:
---
--- > exe/typescript-gen.hs:28:8: error:
--- >     • servant-0.19:Servant.API.ContentTypes.JSON expected in list '[servant-0.19:Servant.API.ContentTypes.OctetStream]
---
--- And `Data.Aeson.TypeScript.TH` is a “library provides a way to
--- generate TypeScript .d.ts files that match your existing Aeson
--- ToJSON instances.”,
--- cf. <https://hackage.haskell.org/package/aeson-typescript-0.4.0.0/docs/Data-Aeson-TypeScript-TH.html>
---
--- So for now, we commented out `PostExternalTransaction` and `SignMetadata`
---
--- We would (maybe) like to propose a JSON representation of OctetStream along the lines of:
---
--- > {"data":"base64-encoded-string"}
+main = writeTypeScriptLibrary (Proxy :: Proxy SmallerApi) "tmp"

--- a/lib/shelley/exe/typescript-gen.hs
+++ b/lib/shelley/exe/typescript-gen.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 import Prelude
@@ -16,13 +16,25 @@ import qualified Data.Aeson.Types as A
 import Cardano.Wallet.Api
 import Servant.TypeScript
 import Cardano.Wallet.Api.Types (ApiStakePool)
+import qualified Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.AddressDerivation (NetworkDiscriminant(..))
 import Data.Aeson.TypeScript.Recursive (recursivelyDeriveMissingTypeScriptInstancesFor)
-import Data.Aeson.TypeScript.TH (deriveJSONAndTypeScript)
+import Data.Aeson.TypeScript.TH (deriveJSONAndTypeScript, TypeScript)
 
 type MainnetApi = Cardano.Wallet.Api.ApiV2 'Mainnet ApiStakePool
 
 $(recursivelyDeriveMissingTypeScriptInstancesFor ''MainnetApi (deriveJSONAndTypeScript A.defaultOptions))
+
+-- Hmmm… The 'Mainnet parameter is not handled by `recursivelyDeriveMissingTypeScriptInstancesFor`?
+instance TypeScript (Cardano.Wallet.Api.Types.ApiWalletMigrationPostData 'Mainnet "lenient")
+instance TypeScript (Cardano.Wallet.Api.Types.ApiWalletMigrationPostData 'Mainnet "user")
+instance TypeScript (Cardano.Wallet.Api.Types.ApiAddress 'Mainnet)
+-- etc. …
+-- No instance for (TypeScript (Cardano.Wallet.Api.Types.ApiSelectCoinsData 'Mainnet))
+-- etc. … so we’d have to specify all of them by hand…
+
+-- Why is this needed???
+instance TypeScript (Proxy 'Mainnet)
 
 main :: IO ()
 main = writeTypeScriptLibrary (Proxy :: Proxy MainnetApi) "tmp"
@@ -36,3 +48,9 @@ main = writeTypeScriptLibrary (Proxy :: Proxy MainnetApi) "tmp"
 -- generate TypeScript .d.ts files that match your existing Aeson
 -- ToJSON instances.”,
 -- cf. <https://hackage.haskell.org/package/aeson-typescript-0.4.0.0/docs/Data-Aeson-TypeScript-TH.html>
+--
+-- So for now, we commented out `PostExternalTransaction` and `SignMetadata`
+--
+-- We would (maybe) like to propose a JSON representation of OctetStream along the lines of:
+--
+-- > {"data":"base64-encoded-string"}

--- a/lib/shelley/exe/typescript-gen.hs
+++ b/lib/shelley/exe/typescript-gen.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{-# LANGUAGE TemplateHaskell #-}
+
+import Prelude
+
+import Data.Proxy
+import qualified Data.Aeson.Types as A
+import Cardano.Wallet.Api
+import Servant.TypeScript
+import Cardano.Wallet.Api.Types (ApiStakePool)
+import Cardano.Wallet.Primitive.AddressDerivation (NetworkDiscriminant(..))
+import Data.Aeson.TypeScript.Recursive (recursivelyDeriveMissingTypeScriptInstancesFor)
+import Data.Aeson.TypeScript.TH (deriveJSONAndTypeScript)
+
+type MainnetApi = Cardano.Wallet.Api.ApiV2 'Mainnet ApiStakePool
+
+$(recursivelyDeriveMissingTypeScriptInstancesFor ''MainnetApi (deriveJSONAndTypeScript A.defaultOptions))
+
+main :: IO ()
+main = writeTypeScriptLibrary (Proxy :: Proxy MainnetApi) "tmp"
+
+-- But OctetStream (ByteString) cannot be processed, since it’s not JSON:
+--
+-- > exe/typescript-gen.hs:28:8: error:
+-- >     • servant-0.19:Servant.API.ContentTypes.JSON expected in list '[servant-0.19:Servant.API.ContentTypes.OctetStream]
+--
+-- And `Data.Aeson.TypeScript.TH` is a “library provides a way to
+-- generate TypeScript .d.ts files that match your existing Aeson
+-- ToJSON instances.”,
+-- cf. <https://hackage.haskell.org/package/aeson-typescript-0.4.0.0/docs/Data-Aeson-TypeScript-TH.html>

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -47,7 +47,7 @@ import Cardano.Wallet.Api
     , ByronWallets
     , CoinSelections
     , Network
-    , Proxy_
+    --, Proxy_
     , SMASH
     , Settings
     , SharedAddresses
@@ -98,7 +98,7 @@ import Cardano.Wallet.Api.Server
     , patchSharedWallet
     , postAccountPublicKey
     , postAccountWallet
-    , postExternalTransaction
+    --, postExternalTransaction
     , postIcarusWallet
     , postLedgerWallet
     , postPolicyId
@@ -121,7 +121,7 @@ import Cardano.Wallet.Api.Server
     , selectCoins
     , selectCoinsForJoin
     , selectCoinsForQuit
-    , signMetadata
+    --, signMetadata
     , signTransaction
     , submitTransaction
     , withLegacyLayer
@@ -253,7 +253,7 @@ server byron icarus shelley multisig spl ntp =
     :<|> byronTransactions
     :<|> byronMigrations
     :<|> network' (networkIdVal (Proxy @n))
-    :<|> proxy
+    -- :<|> proxy
     :<|> settingS
     :<|> smash
     :<|> sharedWallets multisig
@@ -274,7 +274,7 @@ server byron icarus shelley multisig spl ntp =
 
     walletKeys :: Server WalletKeys
     walletKeys = derivePublicKey shelley ApiVerificationKeyShelley
-        :<|> signMetadata shelley
+        -- :<|> signMetadata shelley
         :<|> postAccountPublicKey shelley ApiAccountKey
         :<|> getAccountPublicKey shelley ApiAccountKey
         :<|> getPolicyKey @_ @_ @_ @n shelley
@@ -545,8 +545,9 @@ server byron icarus shelley multisig spl ntp =
         tl = icarus ^. transactionLayer @IcarusKey
         genesis@(_,_,syncTolerance) = icarus ^. genesisData
 
-    proxy :: Server Proxy_
-    proxy = postExternalTransaction icarus
+    -- commenting out `proxy` (above) for typescript-gen.hs
+    -- proxy :: Server Proxy_
+    -- proxy = postExternalTransaction icarus
 
     settingS :: Server Settings
     settingS = putSettings' :<|> getSettings'


### PR DESCRIPTION
We (with @przemyslaw-wlodek) are trying to use a library to try to generate TypeScript definitions based on `Cardano.Wallet.Api`.

---

### Related PRs (with different libraries):

* #3413
* #3414 – `servant-ts` seems unmaintained, please look at **PR 3413** first :pray: :bow: 

---

### JIRA issue number

https://input-output.atlassian.net/browse/LW-2669

---

### Issue 3 – when not using endpoints that use `n` or `apiPool` – commit 82928993b99c345121a6ec566b612b217ede8d60

I’m not sure yet how to define those:

```
    • No instance for (TypeScript
                         (cryptonite-0.27:Crypto.Hash.Types.Digest
                            cryptonite-0.27:Crypto.Hash.Blake2b.Blake2b_160))
```

---

### Issue 2 – `recursivelyDeriveMissingTypeScriptInstancesFor` not handling `'Mainnet` – commit a8a876385fdc2db6956c510405d18a59bd759e8d

We’re giving this type to the typescript library:

```
type MainnetApi = Cardano.Wallet.Api.ApiV2 'Mainnet ApiStakePool
```

But it doesn’t seem to generate instances with that concrete `'Mainnet` parameter resolved… … And we’re getting such errors for each endpoint using `n :: NetworkDiscriminant`:

```
No instance for (TypeScript (Cardano.Wallet.Api.Types.ApiSelectCoinsData 'Mainnet))
```

Not sure how to proceed, we could list them all by hand, but… … … That doesn’t seem right.

Can we get a little help from someone more versed in Haskell? :pray: 

---

### Issue 1 – no encoding for `OctetStream` – kind-of solved by commenting out `SignMetadata` and `PostExternalTransaction` – commit 9b41e007ac01b2a91b90062a5cd1350ed26fa9fa

Although we need to consult what to do with `OctetStream` / `ByteString` – that doesn’t compile:

```
exe/typescript-gen.hs:28:8: error:
    • servant-0.19:Servant.API.ContentTypes.JSON expected in list '[servant-0.19:Servant.API.ContentTypes.OctetStream]
    • In the expression:
        writeTypeScriptLibrary (Proxy :: Proxy MainnetApi) "tmp"
      In an equation for ‘main’:
          main = writeTypeScriptLibrary (Proxy :: Proxy MainnetApi) "tmp"
```

It may be problematic, since [`Data.Aeson.TypeScript.TH` documentation](https://hackage.haskell.org/package/aeson-typescript-0.4.0.0/docs/Data-Aeson-TypeScript-TH.html) says:

> This library provides a way to generate TypeScript .d.ts files that match your existing Aeson [`ToJSON`](https://hackage.haskell.org/package/aeson-2.0.3.0/docs/Data-Aeson-Types.html#t:ToJSON) instances.

… and `ByteString` encoded as `OctetStream` will not have a `ToJSON` instance?