### PR TITLE
Try out `servant-ts` to generate TypeScript client code

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -320,6 +320,19 @@ source-repository-package
   tag: 967d79533c21e33387d0227a5f6cc185203fe658
   --sha256: 0rbqb7a64aya1qizlr3im06hdydg9zr6sl3i8bvqqlf7kpa647sd
 
+source-repository-package
+    type: git
+    location: https://github.com/smaccoun/servant-ts
+    tag: da86b8434c67f228f2f7b3098f4d6ed44e842e61
+    --sha256: 18wmc7kfl6zfv18ikja00si5qabm0i58xc7kf98prmzrwp446r0f
+    subdir: lib
+
+source-repository-package
+    type: git
+    location: https://github.com/smaccoun/aeson-generic-ts
+    tag: 1fb758d7d9ec08c609d59afbad446015c5416e3d
+    --sha256: 00j3h0avi2d3v1vmlq83c6xjdd0c811m8pd1yvbq8pw6mjw62fpr
+
 -- -------------------------------------------------------------------------
 -- Constraints tweaking
 

--- a/flake.nix
+++ b/flake.nix
@@ -178,7 +178,8 @@
                   # Local test cluster and mock metadata server
                   inherit (project.hsPkgs.cardano-wallet.components.exes)
                     local-cluster
-                    mock-token-metadata-server;
+                    mock-token-metadata-server
+                    typescript-gen;
 
                   # Adrestia tool belt
                   inherit (project.hsPkgs.bech32.components.exes) bech32;

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -325,7 +325,7 @@ type Api n apiPool =
     :<|> ByronTransactions n
     :<|> ByronMigrations n
     :<|> Network
-    :<|> Proxy_
+    -- :<|> Proxy_
     :<|> Settings
     :<|> SMASH
     :<|> SharedWallets
@@ -401,7 +401,7 @@ type GetUTxOsStatistics = "wallets"
 
 type WalletKeys =
     GetWalletKey
-    :<|> SignMetadata
+    -- :<|> SignMetadata
     :<|> PostAccountKey
     :<|> GetAccountKey
     :<|> GetPolicyKey
@@ -1129,6 +1129,7 @@ type ConstructSharedTransaction n = "shared-wallets"
   See also: https://input-output-hk.github.io/cardano-wallet/api/edge/#tag/Proxy
 -------------------------------------------------------------------------------}
 
+-- commenting out `Proxy` (above) for typescript-gen.hs
 type Proxy_ =
     PostExternalTransaction
 

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -203,6 +203,39 @@ executable local-cluster
   main-is:
       local-cluster.hs
 
+executable typescript-gen
+  default-language:
+      Haskell2010
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+  ghc-options:
+      -threaded -rtsopts
+      -Wall
+  if (flag(release))
+    ghc-options: -O2 -Werror
+  build-depends:
+      base
+    , cardano-wallet-cli
+    , cardano-wallet-core
+    , cardano-wallet-core-integration
+    , cardano-wallet-launcher
+    , cardano-wallet
+    , contra-tracer
+    , iohk-monitoring
+    , directory
+    , aeson
+    , filepath
+    , lobemo-backend-ekg
+    , text
+    , text-class
+    , servant-ts
+    , aeson-generic-ts
+  hs-source-dirs:
+      exe
+  main-is:
+      typescript-gen.hs
+
 executable mock-token-metadata-server
   default-language:
       Haskell2010

--- a/lib/shelley/exe/typescript-gen.hs
+++ b/lib/shelley/exe/typescript-gen.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveAnyClass #-}
+
+import Prelude
+
+import Data.Proxy
+import qualified Data.Aeson.Types as A
+import Cardano.Wallet.Api
+import Cardano.Wallet.Api.Types (ApiStakePool)
+import qualified Cardano.Wallet.Api.Types
+import qualified Cardano.Wallet.Primitive.Types.Address
+import Cardano.Wallet.Primitive.AddressDerivation (NetworkDiscriminant(..))
+
+import ServantTS.Convert
+import ServantTS.Output.RequestFlavors.Fetch (Fetch)
+import ServantTS.Output.TSFunctions
+import ServantTS.Output.Docs
+import Typescript
+
+type MainnetApi = Cardano.Wallet.Api.ApiV2 'Mainnet ApiStakePool
+
+--deriving instance TypescriptType MainnetApi
+
+deriving instance TypescriptType (Cardano.Wallet.Api.Types.ApiT Cardano.Wallet.Primitive.Types.Address.Address, Proxy 'Mainnet)
+
+-- now:
+--
+-- >     • No instance for (TypescriptType
+-- >                          (Cardano.Wallet.Api.Types.ApiWalletMigrationPostData
+-- >                             'Mainnet "lenient"))
+--
+-- so we should specify those by hand, or use
+-- `Data.Aeson.TypeScript.Recursive.recursivelyDeriveMissingTypeScriptInstancesFor`
+-- which doesn’t seem to want to work with the 'Mainnet parameter
+
+main :: IO ()
+main = apiToTSDocs asTS reqToTSFunction outputFileLocs
+  where
+    outputFileLocs = OutputFileNames "tmp/types.tsx" "tmp/api.tsx"
+    asTS = servantToReqTS (Proxy :: Proxy FpTs) (Proxy :: Proxy MainnetApi)
+    reqToTSFunction = defaultReqToTSFunction (Proxy @Fetch)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -47,7 +47,7 @@ import Cardano.Wallet.Api
     , ByronWallets
     , CoinSelections
     , Network
-    , Proxy_
+    --, Proxy_
     , SMASH
     , Settings
     , SharedAddresses
@@ -98,7 +98,7 @@ import Cardano.Wallet.Api.Server
     , patchSharedWallet
     , postAccountPublicKey
     , postAccountWallet
-    , postExternalTransaction
+    --, postExternalTransaction
     , postIcarusWallet
     , postLedgerWallet
     , postPolicyId
@@ -121,7 +121,7 @@ import Cardano.Wallet.Api.Server
     , selectCoins
     , selectCoinsForJoin
     , selectCoinsForQuit
-    , signMetadata
+    --, signMetadata
     , signTransaction
     , submitTransaction
     , withLegacyLayer
@@ -253,7 +253,7 @@ server byron icarus shelley multisig spl ntp =
     :<|> byronTransactions
     :<|> byronMigrations
     :<|> network' (networkIdVal (Proxy @n))
-    :<|> proxy
+    -- :<|> proxy
     :<|> settingS
     :<|> smash
     :<|> sharedWallets multisig
@@ -274,7 +274,7 @@ server byron icarus shelley multisig spl ntp =
 
     walletKeys :: Server WalletKeys
     walletKeys = derivePublicKey shelley ApiVerificationKeyShelley
-        :<|> signMetadata shelley
+        -- :<|> signMetadata shelley
         :<|> postAccountPublicKey shelley ApiAccountKey
         :<|> getAccountPublicKey shelley ApiAccountKey
         :<|> getPolicyKey @_ @_ @_ @n shelley
@@ -545,8 +545,9 @@ server byron icarus shelley multisig spl ntp =
         tl = icarus ^. transactionLayer @IcarusKey
         genesis@(_,_,syncTolerance) = icarus ^. genesisData
 
-    proxy :: Server Proxy_
-    proxy = postExternalTransaction icarus
+    -- commenting out `proxy` (above) for typescript-gen.hs
+    -- proxy :: Server Proxy_
+    -- proxy = postExternalTransaction icarus
 
     settingS :: Server Settings
     settingS = putSettings' :<|> getSettings'


### PR DESCRIPTION
We (with @przemyslaw-wlodek) are trying to use a library to try to generate TypeScript definitions based on `Cardano.Wallet.Api`.

---

### Related PRs (with different libraries):

* #3413
* #3414 – `servant-ts` seems unmaintained, please look at **PR 3413** first :pray: :bow: 

---

### JIRA issue number

https://input-output.atlassian.net/browse/LW-2669

---

### Issue 1 – requiring to specify all TypescriptType instances by hand?

```
    • No instance for (TypescriptType
                         (Cardano.Wallet.Api.Types.ApiWalletMigrationPostData
                            'Mainnet "lenient"))
```

We could (maybe) use `recursivelyDeriveMissingInstancesFor` from [Data.Aeson.TypeScript.Recursive](https://hackage.haskell.org/package/aeson-typescript-0.4.0.0/docs/Data-Aeson-TypeScript-Recursive.html) but that doesn’t seem to want to work with the `'Mainnet` parameter, cf. issue 2 in #3413

Type help needed :pray: 