### PR TITLE
Bump to 1.35.3-testnetonly cardano-node tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See **Installation Instructions** for each available [release](https://github.co
 >
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
-> | `master` branch | [1.35.2](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.2) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
+> | `master` branch | [1.35.3-testnetonly](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3-testnetonly) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-07-01](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-07-01) | [1.35.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.0) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-05-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-05-27) | [1.34.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.34.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-04-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-04-27) | [1.34.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.34.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)

--- a/cabal.project
+++ b/cabal.project
@@ -157,8 +157,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: a3fba9f4e776c38bc54cb9a1c1cae82d2338b718
-  --sha256: 1vy4fwrq5jbghwkfgnrd5c22zjv8ym9y2j8g38pq50da4nfyv3dh
+  tag: a56c96598b4b25c9e28215214d25189331087244
+  --sha256: 12d6bndmj0dxl6xlaqmf78326yp5hw093bmybmqfpdkvk4mgz03j
   subdir:
     plutus-core
     plutus-ledger-api
@@ -183,8 +183,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-ledger
-    tag: ebcf1a8936dd84de0182d54004473f4ce66c7923
-    --sha256: 1nx07kcjhj39alarr0bxw9viw3m6flfr8d14g2a3crymf6hxwg36
+    tag: c7c63dabdb215ebdaed8b63274965966f2bf408f
+    --sha256: 1cn1z3dh5dy5yy42bwfd8rg25mg8qp3m55gyfsl563wgw4q1nd6d
     subdir:
       eras/alonzo/impl
       eras/alonzo/test-suite
@@ -213,8 +213,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-node
-    tag: 7612a245a6e2c51d0f1c3e0d65d7fe9363850043
-    --sha256: 01a5qdrmsag18s2mlf8axfbrag59j2fp6xyc89pwmzgs7x77ldsr
+    tag: b443f540133888442e5475c05890dc2eee13d43e
+    --sha256: 0vg5775z683wf421asxjm7g2b6yxmgprpylhs9ryb035id83slp2
     subdir:
       cardano-api
       cardano-git-rev


### PR DESCRIPTION
- Bump cardano-node to 1.35.3-testnetonly tag.
- Bump dependencies to use same version as cardano-node 1.35.3-testnetonly tag.
  - Bump plutus, cardano-ledger.
- Update compatibility matrix.

### Comments

No code changes to cardano-wallet, or cardano-node, were required. This is simply a bump of the Plutus and cardano-ledger dependencies.

See diff of cardano-node bump here:

https://github.com/input-output-hk/cardano-node/compare/1.35.2...1.35.3-testnetonly

### Issue Number

ADP-2085
