### PR TITLE
Revise definition of the API field `minimum_utxo_value`.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -55,6 +55,7 @@ module Test.Integration.Framework.DSL
 
     -- * Constants
     , minUTxOValue
+    , minUTxOValueForMinLengthAddress
     , slotLengthValue
     , securityParameterValue
     , epochLengthValue
@@ -689,6 +690,15 @@ minUTxOValue e
     | e >= ApiAlonzo = 999_978
         -- From 34482 lovelace/word.
     | otherwise   = 1_000_000
+
+minUTxOValueForMinLengthAddress :: ApiEra -> Natural
+minUTxOValueForMinLengthAddress = \case
+    ApiByron   ->         0
+    ApiShelley -> 1_000_000
+    ApiAllegra -> 1_000_000
+    ApiMary    -> 1_000_000
+    ApiAlonzo  ->   999_978
+    ApiBabbage ->   874_930
 
 -- | Parameter in test cluster shelley genesis.
 --

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -89,19 +89,28 @@ spec = describe "SHELLEY_NETWORK" $ do
                 else expectField #executionUnitPrices (`shouldBe` Nothing)
 
         verify r $
-            [ expectField #decentralizationLevel (`shouldBe` d)
-            , expectField #desiredPoolNumber (`shouldBe` nOpt)
-            , expectField #minimumUtxoValue (`shouldBe` Quantity (minUTxOValue (_mainEra ctx)))
-            , expectField #slotLength (`shouldBe` Quantity slotLengthValue)
-            , expectField #epochLength (`shouldBe` Quantity epochLengthValue)
-            , expectField #securityParameter (`shouldBe` Quantity securityParameterValue)
-            , expectField #activeSlotCoefficient (`shouldBe` Quantity 50.0)
+            [ expectField #decentralizationLevel
+                (`shouldBe` d)
+            , expectField #desiredPoolNumber
+                (`shouldBe` nOpt)
+            , expectField #minimumUtxoValue
+                (`shouldBe` Quantity (minUTxOValue (_mainEra ctx)))
+            , expectField #slotLength
+                (`shouldBe` Quantity slotLengthValue)
+            , expectField #epochLength
+                (`shouldBe` Quantity epochLengthValue)
+            , expectField #securityParameter
+                (`shouldBe` Quantity securityParameterValue)
+            , expectField #activeSlotCoefficient
+                (`shouldBe` Quantity 50.0)
             , expectField #maximumCollateralInputCount
-                  (`shouldBe` maximumCollateralInputCountByEra (_mainEra ctx))
+                (`shouldBe` maximumCollateralInputCountByEra (_mainEra ctx))
             , expectField #minimumCollateralPercentage
-                  (`shouldBe` minimumCollateralPercentageByEra (_mainEra ctx))
-            , expectField #maximumTokenBundleSize (`shouldBe` Quantity 5000)
-            , checkExecutionUnitPricesPresence (_mainEra ctx)
+                (`shouldBe` minimumCollateralPercentageByEra (_mainEra ctx))
+            , expectField #maximumTokenBundleSize
+                (`shouldBe` Quantity 5000)
+            , checkExecutionUnitPricesPresence
+                (_mainEra ctx)
             ]
             ++ map (expectEraField (`shouldNotBe` Nothing)) knownEras
             ++ map (expectEraField (`shouldBe` Nothing)) unknownEras

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -34,7 +34,7 @@ import Test.Integration.Framework.DSL
     , expectField
     , expectResponseCode
     , maximumCollateralInputCountByEra
-    , minUTxOValue
+    , minUTxOValueForMinLengthAddress
     , minimumCollateralPercentageByEra
     , request
     , securityParameterValue
@@ -94,7 +94,8 @@ spec = describe "SHELLEY_NETWORK" $ do
             , expectField #desiredPoolNumber
                 (`shouldBe` nOpt)
             , expectField #minimumUtxoValue
-                (`shouldBe` Quantity (minUTxOValue (_mainEra ctx)))
+                (`shouldBe` Quantity
+                    (minUTxOValueForMinLengthAddress (_mainEra ctx)))
             , expectField #slotLength
                 (`shouldBe` Quantity slotLengthValue)
             , expectField #epochLength

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -293,8 +293,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     )
 import Cardano.Wallet.Primitive.AddressDerivation.SharedKey
     ( purposeCIP1854 )
-import Cardano.Wallet.Primitive.AddressDerivation.Shelley
-    ( ShelleyKey )
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
@@ -335,6 +333,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
+import Cardano.Wallet.Primitive.Types.Address.Constants
+    ( minLengthAddress )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
@@ -1148,10 +1148,9 @@ toApiNetworkParameters (NetworkParameters gp sp pp) txConstraints toEpochInfo = 
             -- Since address lengths are variable, there is no single ideal
             -- constant that we can return here.
             --
-            -- Therefore, we return a "minimum" UTxO quantity that is likely to
-            -- be more useful than others: the quantity required to send a
-            -- 9-byte ada quantity (and no non-ada tokens) to the longest
-            -- possible Shelley address.
+            -- Therefore, we return the absolute minimum UTxO quantity for an
+            -- output that sends ada (and no other assets) to an address of the
+            -- minimum possible length.
             --
             -- We should consider deprecating this parameter, and replacing it
             -- with era-specific protocol parameters such as:
@@ -1159,9 +1158,8 @@ toApiNetworkParameters (NetworkParameters gp sp pp) txConstraints toEpochInfo = 
             -- - lovelacePerUTxOWord (Alonzo)
             -- - lovelacePerUTxOByte (Babbage)
             --
-            txOutputMinimumAdaQuantity txConstraints
-                (AD.maxLengthAddressFor $ Proxy @ShelleyKey)
-                TokenMap.empty
+            txOutputMinimumAdaQuantity
+                txConstraints minLengthAddress TokenMap.empty
         , eras = apiEras
         , maximumCollateralInputCount =
             view #maximumCollateralInputCount pp

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2205,29 +2205,40 @@ components:
             The absolute minimum quantity of ada required for a new transaction
             output created with the wallet.
 
+            Warning: This field may be deprecated or removed in future versions
+            of the wallet.
+
             In general, the ledger rules require that every transaction output
             has a minimum quantity of ada. This minimum quantity is determined
-            by an era-specific function whose value increases as the number of
-            different assets increases, as the quantity of any individual asset
-            increases, as the length of the target address increases, and if a
-            datum hash is added.
+            by an era-specific function whose value increases:
+
+              - as the number of different assets increases;
+              - as the quantity of any individual asset increases;
+              - as the length of the target address increases; and
+              - if a datum hash is added.
 
             Therefore, the value reported by this field should only be viewed
             as an absolute minimum, and only applies to outputs that send ada
-            (and no other assets) to Shelley-era addresses. If an output
-            contains other assets, specifies a datum hash, or sends funds to a
-            Byron-era address, then the minimum value required by the ledger
-            (and the wallet) will be higher than the value reported by this
-            field.
+            (and no other assets) to addresses of the minimum possible length.
+            (At the time of writing, this corresponds to a 29-byte long
+            Shelley-era address.)
 
-            When using the wallet to construct or balance a transaction, if the
-            caller specifies an output with a non-zero ada quantity, then the
-            wallet will verify that the specified quantity is not less than the
-            minimum quantity required by the ledger, and if this verification
-            step fails, return an error that reports the required minimum. If
-            the caller specifies an output without an ada quantity, then the
-            wallet will automatically assign a minimal ada quantity to that
-            output.
+            In practice, if an output contains other assets, specifies a datum
+            hash, or sends funds to an address that is longer than the absolute
+            minimum length, then the minimum value required by the ledger (and
+            the wallet) will be higher than the value reported by this field.
+
+            When using the wallet to construct or balance a transaction:
+
+              - if the caller specifies an output without an ada quantity, then
+                the wallet will automatically assign a minimal ada quantity to
+                the output that is guaranteed to be accepted by the ledger;
+
+              - if the caller specifes an output with a non-zero ada quantity,
+                then the wallet will verify that the specified quantity is not
+                less than the minimum quantity required by the ledger, and if
+                this verification step fails, return an error that reports the
+                required minimum.
 
             In the Shelley, Allegra, and Mary eras, the `minimum_utxo_value`
             field was equivalent to the ledger `minUTxOValue` protocol


### PR DESCRIPTION
## Issue Number

ADP-2039

## Summary

This PR adjusts the definition of the API field `minimum_utxo_value`:

- We adjust the internal definition so that it generates a value based on an address of the **_minimum length_**. As a result, we can now say that the value returned by the API truly is an absolute minimum w.r.t. to the wallet.
- We also adjust the API description of this field to make it more both more readable and more accurate.