### PR TITLE
Simplify validation of minimum UTxO values for user-specified outputs.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -672,24 +672,28 @@ walletId =
 -- Constants
 --
 
--- | Min UTxO parameter for the test cluster.
+-- | Minimum UTxO parameter for the test cluster.
+--
+-- The value returned by this function is only appropriate for a very minimal
+-- output, where:
+--
+-- - the output has no assets other than ada.
+-- - the output uses a Shelley-era address of the length typically used in
+--   the integration test suite.
+-- - the output has no datum hash.
+--
+-- This value will almost certainly not be correct for outputs with non-ada
+-- assets, for outputs with longer addresses, or outputs with a datum hash.
+--
+-- In those cases, a larger value will be required. The precise value can be
+-- determined by calling one of the endpoints that returns an 'ApiFee' object,
+-- and inspecting the 'minimumCoins' field.
+--
 minUTxOValue :: ApiEra -> Natural
 minUTxOValue e
-    | e >= ApiBabbage = 995_610
-        -- This value is a slight overestimation for outputs with Shelley
-        -- addresses and no tokens.
-        --
-        -- However, it would be incorrect for outputs with Byron addresses,
-        -- where the lower bound would be greater by the following amount:
-        --
-        -- 4310 lovelace/byte * (86 - 57) byte ≈ 0.125 ada
-        --
-        -- However, this value appears to be fine for the purposes of
-        -- integration tests.
-        --
-    | e >= ApiAlonzo = 999_978
-        -- From 34482 lovelace/word.
-    | otherwise   = 1_000_000
+    | e >= ApiBabbage =   978_370
+    | e >= ApiAlonzo  =   999_978
+    | otherwise       = 1_000_000
 
 minUTxOValueForMinLengthAddress :: ApiEra -> Natural
 minUTxOValueForMinLengthAddress = \case

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -3437,7 +3437,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         let minUtxoWithAsset = minutxo +
                 -- The extra amount is dependent on the era:
                 if _mainEra ctx >= ApiBabbage
-                then 176_710
+                then 193_950
                 else 344_820 -- = 34_482 lovelace per word * 10 words
 
         eventually

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1973,7 +1973,11 @@ balanceTransactionWithSelectionStrategy
                 , certificateDepositAmount =
                     view #stakeKeyDeposit pp
                 , computeMinimumAdaQuantity =
-                    view #txOutputMinimumAdaQuantity $ constraints tl era pp
+                    view #txOutputMinimumAdaQuantity
+                        (constraints tl era pp)
+                , isBelowMinimumAdaQuantity =
+                    view #txOutputBelowMinimumAdaQuantity
+                        (constraints tl era pp)
                 , computeMinimumCost = \skeleton -> mconcat
                     [ feePadding
                     , fromCardanoLovelace fee0
@@ -2243,7 +2247,11 @@ selectAssets ctx era pp params transform = do
             , certificateDepositAmount =
                 view #stakeKeyDeposit pp
             , computeMinimumAdaQuantity =
-                view #txOutputMinimumAdaQuantity $ constraints tl era pp
+                view #txOutputMinimumAdaQuantity
+                    (constraints tl era pp)
+            , isBelowMinimumAdaQuantity =
+                view #txOutputBelowMinimumAdaQuantity
+                    (constraints tl era pp)
             , computeMinimumCost =
                 calcMinimumCost tl era pp $ params ^. #txContext
             , computeSelectionLimit =

--- a/lib/core/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection.hs
@@ -226,6 +226,10 @@ data SelectionConstraints = SelectionConstraints
     , computeMinimumAdaQuantity
         :: Address -> TokenMap -> Coin
         -- ^ Computes the minimum ada quantity required for a given output.
+    , isBelowMinimumAdaQuantity
+        :: Address -> TokenBundle -> Bool
+      -- ^ Returns 'True' if the given 'TokenBundle' has a 'Coin' value that is
+      -- below the minimum required.
     , computeMinimumCost
         :: SelectionSkeleton -> Coin
         -- ^ Computes the minimum cost of a given selection skeleton.

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -1453,18 +1453,10 @@ prepareOutputsInternal constraints outputsUnprepared
     outputsToCover =
         prepareOutputsWith computeMinimumAdaQuantity outputsUnprepared
 
--- | Transforms a set of outputs (provided by users) into valid Cardano outputs.
+-- | Assigns minimal ada quantities to outputs without ada quantities.
 --
--- Every output in Cardano needs to have a minimum quantity of ada, in order to
--- prevent attacks that flood the network with worthless UTxOs.
---
--- However, we do not require users to specify the minimum ada quantity
--- themselves. Most users would prefer to send '10 Apple' rather than
--- '10 Apple & 1.2 Ada'.
---
--- Therefore, unless a coin quantity is explicitly specified, we assign a coin
--- quantity manually for each non-ada output. That quantity is the minimum
--- quantity required to make a particular output valid.
+-- This function only modifies outputs that have an ada quantity of zero.
+-- Outputs that have non-zero ada quantities will not be modified.
 --
 prepareOutputsWith
     :: forall f address. Functor f

--- a/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/CoinSelection/Internal.hs
@@ -161,6 +161,10 @@ data SelectionConstraints ctx = SelectionConstraints
     , computeMinimumAdaQuantity
         :: Address ctx -> TokenMap -> Coin
         -- ^ Computes the minimum ada quantity required for a given output.
+    , isBelowMinimumAdaQuantity
+        :: Address ctx -> TokenBundle -> Bool
+      -- ^ Returns 'True' if the given 'TokenBundle' has a 'Coin' value that is
+      -- below the minimum required.
     , computeMinimumCost
         :: SelectionSkeleton ctx -> Coin
         -- ^ Computes the minimum cost of a given selection skeleton.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -972,6 +972,9 @@ data TxConstraints = TxConstraints
       -- ^ The maximum token quantity that can appear in a transaction output.
     , txOutputMinimumAdaQuantity :: Address -> TokenMap -> Coin
       -- ^ The variable minimum ada quantity of a transaction output.
+    , txOutputBelowMinimumAdaQuantity :: Address -> TokenBundle -> Bool
+      -- ^ Returns 'True' if the given 'TokenBundle' has a 'Coin' value that is
+      -- below the minimum required.
     , txRewardWithdrawalCost :: Coin -> Coin
       -- ^ The variable cost of a reward withdrawal.
     , txRewardWithdrawalSize :: Coin -> TxSize

--- a/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/CoinSelection/InternalSpec.hs
@@ -586,6 +586,8 @@ unMockSelectionConstraints m = SelectionConstraints
         view #certificateDepositAmount m
     , computeMinimumAdaQuantity =
         unMockComputeMinimumAdaQuantity $ view #computeMinimumAdaQuantity m
+    , isBelowMinimumAdaQuantity =
+        unMockIsBelowMinimumAdaQuantity $ view #computeMinimumAdaQuantity m
     , computeMinimumCost =
         unMockComputeMinimumCost $ view #computeMinimumCost m
     , computeSelectionLimit =
@@ -613,6 +615,15 @@ genCertificateDepositAmount = genCoinPositive
 
 shrinkCertificateDepositAmount :: Coin -> [Coin]
 shrinkCertificateDepositAmount = shrinkCoinPositive
+
+--------------------------------------------------------------------------------
+-- Minimum ada quantities
+--------------------------------------------------------------------------------
+
+unMockIsBelowMinimumAdaQuantity
+    :: MockComputeMinimumAdaQuantity -> TestAddress -> TokenBundle -> Bool
+unMockIsBelowMinimumAdaQuantity mock addr b =
+    view #coin b < unMockComputeMinimumAdaQuantity mock addr (view #tokens b)
 
 --------------------------------------------------------------------------------
 -- Maximum collateral input counts

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
@@ -750,6 +750,8 @@ unMockTxConstraints MockTxConstraints {..} = TxConstraints
         unMockTxOutputMaximumTokenQuantity mockTxOutputMaximumTokenQuantity
     , txOutputMinimumAdaQuantity =
         unMockTxOutputMinimumAdaQuantity mockTxOutputMinimumAdaQuantity
+    , txOutputBelowMinimumAdaQuantity =
+        unMockTxOutputBelowMinimumAdaQuantity mockTxOutputMinimumAdaQuantity
     , txRewardWithdrawalCost =
         mockSizeToCost . mockRewardWithdrawalSize
     , txRewardWithdrawalSize =
@@ -861,6 +863,12 @@ unMockTxOutputMinimumAdaQuantity mock _addr m =
     let assetCount = TokenMap.size m in
     perOutput mock
         <> mtimesDefault assetCount (perOutputAsset mock)
+
+unMockTxOutputBelowMinimumAdaQuantity
+    :: MockTxOutputMinimumAdaQuantity
+    -> (Address -> TokenBundle -> Bool)
+unMockTxOutputBelowMinimumAdaQuantity mock addr b =
+    view #coin b < unMockTxOutputMinimumAdaQuantity mock addr (view #tokens b)
 
 genMockTxOutputMinimumAdaQuantity :: Gen MockTxOutputMinimumAdaQuantity
 genMockTxOutputMinimumAdaQuantity = MockTxOutputMinimumAdaQuantity

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -58,7 +58,7 @@ computeMinimumCoinForUTxO = \case
     MinimumUTxOConstant c ->
         \_addr _tokenMap -> c
     MinimumUTxOForShelleyBasedEraOf minUTxO ->
-        computeMinimumCoinForShelleyBasedEra minUTxO
+        computeMinimumCoinForUTxOShelleyBasedEra minUTxO
 
 -- | Computes a minimum 'Coin' value for a 'TokenMap' that is destined for
 --   inclusion in a transaction output.
@@ -67,13 +67,13 @@ computeMinimumCoinForUTxO = \case
 -- Importantly, a value that is valid in one era will not necessarily be valid
 -- in another era.
 --
-computeMinimumCoinForShelleyBasedEra
+computeMinimumCoinForUTxOShelleyBasedEra
     :: HasCallStack
     => MinimumUTxOForShelleyBasedEra
     -> Address
     -> TokenMap
     -> Coin
-computeMinimumCoinForShelleyBasedEra
+computeMinimumCoinForUTxOShelleyBasedEra
     (MinimumUTxOForShelleyBasedEra era pp) addr tokenMap =
         unsafeCoinFromCardanoApiCalculateMinimumUTxOResult $
         Cardano.calculateMinimumUTxO era

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -75,38 +75,10 @@ computeMinimumCoinForShelleyBasedEra
     -> Coin
 computeMinimumCoinForShelleyBasedEra
     (MinimumUTxOForShelleyBasedEra era pp) addr tokenMap =
-        extractResult $
+        unsafeCoinFromCardanoApiCalculateMinimumUTxOResult $
         Cardano.calculateMinimumUTxO era
             (embedTokenMapWithinPaddedTxOut era addr tokenMap)
             (Cardano.fromLedgerPParams era pp)
-  where
-    extractResult :: Either Cardano.MinimumUTxOError Cardano.Value -> Coin
-    extractResult = \case
-        Right value ->
-            -- We assume that the returned value is a non-negative ada quantity
-            -- with no other assets. If this assumption is violated, we have no
-            -- way to continue, and must raise an error:
-            value
-                & unsafeValueToLovelace
-                & unsafeLovelaceToWalletCoin
-        Left e ->
-            -- The 'Cardano.calculateMinimumUTxO' function should only return
-            -- an error if a required protocol parameter is missing.
-            --
-            -- However, given that values of 'MinimumUTxOForShelleyBasedEra'
-            -- can only be constructed by supplying an era-specific protocol
-            -- parameters record, it should be impossible to trigger this
-            -- condition.
-            --
-            -- Any violation of this assumption indicates a programming error.
-            -- If this condition is triggered, we have no way to continue, and
-            -- must raise an error:
-            --
-            error $ unwords
-                [ "computeMinimumCoinForUTxO:"
-                , "unexpected error:"
-                , show e
-                ]
 
 -- | Embeds a 'TokenMap' within a padded 'Cardano.TxOut' value.
 --
@@ -147,6 +119,40 @@ embedTokenMapWithinPaddedTxOut era addr m =
 --
 maxLengthCoin :: Coin
 maxLengthCoin = Coin $ intCast @Word64 @Natural $ maxBound
+
+-- | Extracts a 'Coin' value from the result of calling the Cardano API
+--   function 'calculateMinimumUTxO'.
+--
+unsafeCoinFromCardanoApiCalculateMinimumUTxOResult
+    :: HasCallStack
+    => Either Cardano.MinimumUTxOError Cardano.Value
+    -> Coin
+unsafeCoinFromCardanoApiCalculateMinimumUTxOResult = \case
+    Right value ->
+        -- We assume that the returned value is a non-negative ada quantity
+        -- with no other assets. If this assumption is violated, we have no
+        -- way to continue, and must raise an error:
+        value
+            & unsafeValueToLovelace
+            & unsafeLovelaceToWalletCoin
+    Left e ->
+        -- The 'Cardano.calculateMinimumUTxO' function should only return
+        -- an error if a required protocol parameter is missing.
+        --
+        -- However, given that values of 'MinimumUTxOForShelleyBasedEra'
+        -- can only be constructed by supplying an era-specific protocol
+        -- parameters record, it should be impossible to trigger this
+        -- condition.
+        --
+        -- Any violation of this assumption indicates a programming error.
+        -- If this condition is triggered, we have no way to continue, and
+        -- must raise an error:
+        --
+        error $ unwords
+            [ "unsafeCoinFromCardanoApiCalculateMinimumUTxOResult:"
+            , "unexpected error:"
+            , show e
+            ]
 
 -- | Extracts a 'Coin' value from a 'Cardano.Lovelace' value.
 --

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -11,8 +11,6 @@ module Cardano.Wallet.Shelley.MinimumUTxO
     ( computeMinimumCoinForUTxO
     , isBelowMinimumCoinForUTxO
     , maxLengthCoin
-    , unsafeLovelaceToWalletCoin
-    , unsafeValueToLovelace
     ) where
 
 import Prelude
@@ -30,11 +28,11 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxOut (..) )
 import Cardano.Wallet.Shelley.Compatibility
-    ( toCardanoTxOut )
+    ( toCardanoTxOut, unsafeLovelaceToWalletCoin, unsafeValueToLovelace )
 import Data.Function
     ( (&) )
 import Data.IntCast
-    ( intCast, intCastMaybe )
+    ( intCast )
 import Data.Word
     ( Word64 )
 import GHC.Stack
@@ -193,33 +191,3 @@ unsafeCoinFromCardanoApiCalculateMinimumUTxOResult = \case
             , "unexpected error:"
             , show e
             ]
-
--- | Extracts a 'Coin' value from a 'Cardano.Lovelace' value.
---
--- Fails with a run-time error if the value is negative.
---
-unsafeLovelaceToWalletCoin :: HasCallStack => Cardano.Lovelace -> Coin
-unsafeLovelaceToWalletCoin (Cardano.Lovelace v) =
-  case intCastMaybe @Integer @Natural v of
-      Nothing -> error $ unwords
-          [ "unsafeLovelaceToWalletCoin:"
-          , "encountered negative value:"
-          , show v
-          ]
-      Just lovelaceNonNegative ->
-          Coin lovelaceNonNegative
-
--- | Extracts a 'Cardano.Lovelace' value from a 'Cardano.Value'.
---
--- Fails with a run-time error if the 'Cardano.Value' contains any non-ada
--- assets.
---
-unsafeValueToLovelace :: HasCallStack => Cardano.Value -> Cardano.Lovelace
-unsafeValueToLovelace v =
-    case Cardano.valueToLovelace v of
-        Nothing -> error $ unwords
-            [ "unsafeValueToLovelace:"
-            , "encountered value with non-ada assets:"
-            , show v
-            ]
-        Just lovelace -> lovelace

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Copyright: © 2022 IOHK
@@ -10,7 +9,6 @@
 module Cardano.Wallet.Shelley.MinimumUTxO
     ( computeMinimumCoinForUTxO
     , isBelowMinimumCoinForUTxO
-    , maxLengthCoin
     ) where
 
 import Prelude
@@ -26,19 +24,13 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxOut (..) )
+    ( TxOut (..), txOutMaxCoin )
 import Cardano.Wallet.Shelley.Compatibility
     ( toCardanoTxOut, unsafeLovelaceToWalletCoin, unsafeValueToLovelace )
 import Data.Function
     ( (&) )
-import Data.IntCast
-    ( intCast )
-import Data.Word
-    ( Word64 )
 import GHC.Stack
     ( HasCallStack )
-import Numeric.Natural
-    ( Natural )
 
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
@@ -147,16 +139,7 @@ embedTokenMapWithinPaddedTxOut
     -> TokenMap
     -> Cardano.TxOut Cardano.CtxTx era
 embedTokenMapWithinPaddedTxOut era addr m =
-    toCardanoTxOut era $ TxOut addr $ TokenBundle maxLengthCoin m
-
--- | A 'Coin' value that is maximal in length when serialized to bytes.
---
--- When serialized to bytes, this 'Coin' value has a length that is greater
--- than or equal to the serialized length of any 'Coin' value that is valid
--- for inclusion in a transaction output.
---
-maxLengthCoin :: Coin
-maxLengthCoin = Coin $ intCast @Word64 @Natural $ maxBound
+    toCardanoTxOut era $ TxOut addr $ TokenBundle txOutMaxCoin m
 
 -- | Extracts a 'Coin' value from the result of calling the Cardano API
 --   function 'calculateMinimumUTxO'.

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -183,7 +183,7 @@ import Cardano.Wallet.Shelley.Compatibility
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( toAlonzoTxOut, toBabbageTxOut )
 import Cardano.Wallet.Shelley.MinimumUTxO
-    ( computeMinimumCoinForUTxO )
+    ( computeMinimumCoinForUTxO, isBelowMinimumCoinForUTxO )
 import Cardano.Wallet.Transaction
     ( AnyScript (..)
     , DelegationAction (..)
@@ -1474,6 +1474,7 @@ txConstraints era protocolParams witnessTag = TxConstraints
     , txOutputMaximumSize
     , txOutputMaximumTokenQuantity
     , txOutputMinimumAdaQuantity
+    , txOutputBelowMinimumAdaQuantity
     , txRewardWithdrawalCost
     , txRewardWithdrawalSize
     , txMaximumSize
@@ -1508,6 +1509,9 @@ txConstraints era protocolParams witnessTag = TxConstraints
 
     txOutputMinimumAdaQuantity =
         computeMinimumCoinForUTxO (minimumUTxO protocolParams)
+
+    txOutputBelowMinimumAdaQuantity =
+        isBelowMinimumCoinForUTxO (minimumUTxO protocolParams)
 
     txRewardWithdrawalCost c =
         marginalCostOf empty {txRewardWithdrawal = c}

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1462,7 +1462,8 @@ _assignScriptRedeemers pparams ti resolveInput redeemers tx =
                 }
             }
 
-txConstraints :: AnyCardanoEra -> ProtocolParameters -> TxWitnessTag -> TxConstraints
+txConstraints
+    :: AnyCardanoEra -> ProtocolParameters -> TxWitnessTag -> TxConstraints
 txConstraints era protocolParams witnessTag = TxConstraints
     { txBaseCost
     , txBaseSize

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -62,14 +62,9 @@ import Cardano.Wallet.Primitive.Types.Tx
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTxOutTokenBundle )
 import Cardano.Wallet.Shelley.Compatibility
-    ( toCardanoTxOut )
+    ( toCardanoTxOut, unsafeLovelaceToWalletCoin, unsafeValueToLovelace )
 import Cardano.Wallet.Shelley.MinimumUTxO
-    ( computeMinimumCoinForUTxO
-    , isBelowMinimumCoinForUTxO
-    , maxLengthCoin
-    , unsafeLovelaceToWalletCoin
-    , unsafeValueToLovelace
-    )
+    ( computeMinimumCoinForUTxO, isBelowMinimumCoinForUTxO, maxLengthCoin )
 import Control.Monad
     ( forM_ )
 import Data.Data

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -58,13 +58,13 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     ( mkTokenPolicyId )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxOut (..), txOutMaxTokenQuantity, txOutMinTokenQuantity )
+    ( TxOut (..), txOutMaxCoin, txOutMaxTokenQuantity, txOutMinTokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTxOutTokenBundle )
 import Cardano.Wallet.Shelley.Compatibility
     ( toCardanoTxOut, unsafeLovelaceToWalletCoin, unsafeValueToLovelace )
 import Cardano.Wallet.Shelley.MinimumUTxO
-    ( computeMinimumCoinForUTxO, isBelowMinimumCoinForUTxO, maxLengthCoin )
+    ( computeMinimumCoinForUTxO, isBelowMinimumCoinForUTxO )
 import Control.Monad
     ( forM_ )
 import Data.Data
@@ -217,7 +217,7 @@ prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
                 (tokenBundle)
             apiResultMaxBound = apiComputeMinCoin
                 (maxLengthAddress)
-                (TokenBundle.setCoin tokenBundle maxLengthCoin)
+                (TokenBundle.setCoin tokenBundle txOutMaxCoin)
         in
         property True
             & verify


### PR DESCRIPTION
## Issue Number

#1978

## Summary

This PR adjusts the **_validation_** of **_user-specified_** outputs so that:
- for a given user-specified output `out` with ada quantity `a0`
- if Cardano API function [`calculateMinimumUTxO`](https://github.com/input-output-hk/cardano-node/blob/866c4211a1110ac67f3d866ca6632a6bc51f6041/cardano-api/src/Cardano/Api/Fees.hs#L1219) applied to `out` returns ada quantity `a1` such that `a1 <= a0`
- then wallet API functions will not reject output `out` for having an ada quantity that is too low.

In other words: if a user has previously used the Cardano API to validate the ada quantity of a given output, the wallet API should not reject that ada quantity.

This PR does **_not_** change the way we assign minimum ada quantities to **_auto-generated_** outputs. For auto-generated outputs, we continue to use our previous approach of computing a minimum that can **_always be safely increased_**. This gives the coin selection and migration algorithms the flexibility to freely reassign spare ada without the risk of creating an ada quantity that is invalid.

## Details

This PR introduces the following function:
```hs
isBelowMinimumCoinForUTxO
    :: MinimumUTxO
    -> Address
    -> TokenBundle
    -> Bool
```
This function simply wraps the Cardano API function [`calculateMinimumUTxO`](https://github.com/input-output-hk/cardano-node/blob/866c4211a1110ac67f3d866ca6632a6bc51f6041/cardano-api/src/Cardano/Api/Fees.hs#L1219), returning `True` if (and only) if the resultant ada quantity is **_greater_** than the ada quantity of the original `TokenBundle`, which indicates that the original value was **_insufficient_**.

If applying `isBelowMinimumCoinForUTxO` to a given `TokenBundle` returns `True`, then callers should use `computeMinimumCoinForUTxO` to get a `Coin` value that does satisfy the required minimum.

In particular, the following composition should always evaluate to `False` (arguments left out for brevity):

```hs
isBelowMinimumCoinForUTxO . computeMinimumCoinForUTxO == False
```

This PR makes the `isBelowMinimumCoinForUTxO` function available to the coin selection function `prepareOutputsInternal`, which uses it to validate the ada quantities of user-specified outputs.