### PR TITLE
Light mode: Tx includes non-native assets

### DIFF
--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -755,7 +755,9 @@ assembleTransaction
                                | BF.AssetAmount sd <- _utxoOutputAmount
                                ]
                 tokens <- for bfAssets \(textValue, a) -> do
-                    let (policy, name) = T.splitAt 56 textValue
+                    -- textValue is hex-encoded,
+                    -- the first 28 bytes are the policy script hash
+                    let (policy, name) = T.splitAt (2*28) textValue
                     policyId <-
                         first (InvalidTokenPolicyId policy) (fromText policy)
                     assetName <-

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost/Error.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost/Error.hs
@@ -47,6 +47,8 @@ data BlockfrostError
     | InvalidAddress Text TextDecodingError
     | InvalidStakeAddress Text TextDecodingError
     | InvalidPoolId Text TextDecodingError
+    | InvalidTokenPolicyId Text TextDecodingError
+    | InvalidTokenName Text TextDecodingError
     | PoolStakePercentageError Coin Coin
     | InvalidDecentralizationLevelPercentage Double
     | InvalidPercentage Double MkPercentageError


### PR DESCRIPTION
Originally, light-mode implementation supported only ADA coins, ignoring all non-ADA assets. 

This PR adds a support for the non-ADA assets.

### Issue Number

ADP-1777
