### PR TITLE
Add signing endpoint for multisig

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -1058,7 +1058,7 @@ cmdAddressList mkClient =
 -- | Arguments for 'address create' command
 data AddressCreateArgs = AddressCreateArgs
     { _port :: Port "Wallet"
-    , _addressIndex :: Maybe (Index 'Hardened 'AddressK)
+    , _addressIndex :: Maybe (Index 'Hardened 'CredFromKeyK)
     , _id :: WalletId
     }
 

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -1812,7 +1812,7 @@ fixtureRandomWallet = fmap fst . fixtureRandomWalletMws
 
 fixtureRandomWalletAddrs
     :: forall (n :: NetworkDiscriminant) m.
-        ( PaymentAddress n ByronKey 'AddressK
+        ( PaymentAddress n ByronKey 'CredFromKeyK
         , MonadIO m
         , MonadUnliftIO m
         )
@@ -1834,7 +1834,7 @@ fixtureRandomWalletWith
         ( EncodeAddress n
         , DecodeAddress n
         , DecodeStakeAddress n
-        , PaymentAddress n ByronKey 'AddressK
+        , PaymentAddress n ByronKey 'CredFromKeyK
         , MonadIO m
         , MonadUnliftIO m
         )
@@ -1872,7 +1872,7 @@ fixtureIcarusWallet = fmap fst . fixtureIcarusWalletMws
 
 fixtureIcarusWalletAddrs
     :: forall (n :: NetworkDiscriminant) m.
-        ( PaymentAddress n IcarusKey 'AddressK
+        ( PaymentAddress n IcarusKey 'CredFromKeyK
         , MonadIO m
         , MonadUnliftIO m
         )
@@ -1894,7 +1894,7 @@ fixtureIcarusWalletWith
         ( EncodeAddress n
         , DecodeAddress n
         , DecodeStakeAddress n
-        , PaymentAddress n IcarusKey 'AddressK
+        , PaymentAddress n IcarusKey 'CredFromKeyK
         , MonadIO m
         , MonadUnliftIO m
         )
@@ -2259,7 +2259,7 @@ delegationFee ctx w = do
 -- >>> take 1 (randomAddresses @n)
 -- [addr]
 randomAddresses
-    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ByronKey 'AddressK)
+    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ByronKey 'CredFromKeyK)
     => Mnemonic 12
     -> [Address]
 randomAddresses mw =
@@ -2284,7 +2284,7 @@ randomAddresses mw =
 -- >>> take 1 (icarusAddresses @n)
 -- [addr]
 icarusAddresses
-    :: forall (n :: NetworkDiscriminant). (PaymentAddress n IcarusKey 'AddressK)
+    :: forall (n :: NetworkDiscriminant). (PaymentAddress n IcarusKey 'CredFromKeyK)
     => Mnemonic 15
     -> [Address]
 icarusAddresses mw =
@@ -2309,7 +2309,7 @@ icarusAddresses mw =
 -- >>> take 1 (shelleyAddresses @n)
 -- [addr]
 shelleyAddresses
-    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ShelleyKey 'AddressK)
+    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ShelleyKey 'CredFromKeyK)
     => Mnemonic 15
     -> [Address]
 shelleyAddresses mw =

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -1812,7 +1812,7 @@ fixtureRandomWallet = fmap fst . fixtureRandomWalletMws
 
 fixtureRandomWalletAddrs
     :: forall (n :: NetworkDiscriminant) m.
-        ( PaymentAddress n ByronKey
+        ( PaymentAddress n ByronKey 'AddressK
         , MonadIO m
         , MonadUnliftIO m
         )
@@ -1834,7 +1834,7 @@ fixtureRandomWalletWith
         ( EncodeAddress n
         , DecodeAddress n
         , DecodeStakeAddress n
-        , PaymentAddress n ByronKey
+        , PaymentAddress n ByronKey 'AddressK
         , MonadIO m
         , MonadUnliftIO m
         )
@@ -1872,7 +1872,7 @@ fixtureIcarusWallet = fmap fst . fixtureIcarusWalletMws
 
 fixtureIcarusWalletAddrs
     :: forall (n :: NetworkDiscriminant) m.
-        ( PaymentAddress n IcarusKey
+        ( PaymentAddress n IcarusKey 'AddressK
         , MonadIO m
         , MonadUnliftIO m
         )
@@ -1894,7 +1894,7 @@ fixtureIcarusWalletWith
         ( EncodeAddress n
         , DecodeAddress n
         , DecodeStakeAddress n
-        , PaymentAddress n IcarusKey
+        , PaymentAddress n IcarusKey 'AddressK
         , MonadIO m
         , MonadUnliftIO m
         )
@@ -2259,7 +2259,7 @@ delegationFee ctx w = do
 -- >>> take 1 (randomAddresses @n)
 -- [addr]
 randomAddresses
-    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ByronKey)
+    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ByronKey 'AddressK)
     => Mnemonic 12
     -> [Address]
 randomAddresses mw =
@@ -2284,7 +2284,7 @@ randomAddresses mw =
 -- >>> take 1 (icarusAddresses @n)
 -- [addr]
 icarusAddresses
-    :: forall (n :: NetworkDiscriminant). (PaymentAddress n IcarusKey)
+    :: forall (n :: NetworkDiscriminant). (PaymentAddress n IcarusKey 'AddressK)
     => Mnemonic 15
     -> [Address]
 icarusAddresses mw =
@@ -2309,7 +2309,7 @@ icarusAddresses mw =
 -- >>> take 1 (shelleyAddresses @n)
 -- [addr]
 shelleyAddresses
-    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ShelleyKey)
+    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ShelleyKey 'AddressK)
     => Mnemonic 15
     -> [Address]
 shelleyAddresses mw =

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -177,6 +177,7 @@ module Test.Integration.Framework.DSL
     , hexText
     , fromHexText
     , accPubKeyFromMnemonics
+    , submitSharedTxWithWid
 
     -- * Delegation helpers
     , notDelegating
@@ -2399,6 +2400,17 @@ submitTxWithWid
     -> m (HTTP.Status, Either RequestException ApiTxId)
 submitTxWithWid ctx w tx = do
     let submitEndpoint = Link.submitTransaction @'Shelley w
+    let payload = Json $ Aeson.toJSON tx
+    request @ApiTxId ctx submitEndpoint Default payload
+
+submitSharedTxWithWid
+    :: MonadUnliftIO m
+    => Context
+    -> ApiActiveSharedWallet
+    -> ApiSerialisedTransaction
+    -> m (HTTP.Status, Either RequestException ApiTxId)
+submitSharedTxWithWid ctx w tx = do
+    let submitEndpoint = Link.submitTransaction @'Shared w
     let payload = Json $ Aeson.toJSON tx
     request @ApiTxId ctx submitEndpoint Default payload
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
@@ -28,7 +28,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( NetworkDiscriminant, PaymentAddress )
+    ( Depth (..), NetworkDiscriminant, PaymentAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -92,8 +92,8 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ByronKey
-    , PaymentAddress n IcarusKey
+    , PaymentAddress n ByronKey 'AddressK
+    , PaymentAddress n IcarusKey 'AddressK
     ) => SpecWith Context
 spec = do
     describe "BYRON_ADDRESSES" $ do
@@ -310,7 +310,7 @@ scenario_ADDRESS_IMPORT_01
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
+        , PaymentAddress n ByronKey 'AddressK
         )
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context
@@ -339,7 +339,7 @@ scenario_ADDRESS_IMPORT_02
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n IcarusKey
+        , PaymentAddress n IcarusKey 'AddressK
         )
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 15))
     -> SpecWith Context
@@ -361,7 +361,7 @@ scenario_ADDRESS_IMPORT_03
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
+        , PaymentAddress n ByronKey 'AddressK
         )
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context
@@ -385,7 +385,7 @@ scenario_ADDRESS_IMPORT_04
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
+        , PaymentAddress n ByronKey 'AddressK
         )
     => (Context -> ResourceT IO ApiByronWallet)
     -> SpecWith Context
@@ -414,7 +414,7 @@ scenario_ADDRESS_IMPORT_05
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
+        , PaymentAddress n ByronKey 'AddressK
         )
     => Int
     -> (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
@@ -448,7 +448,7 @@ scenario_ADDRESS_IMPORT_06
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
+        , PaymentAddress n ByronKey 'AddressK
         )
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
@@ -92,8 +92,8 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ByronKey 'AddressK
-    , PaymentAddress n IcarusKey 'AddressK
+    , PaymentAddress n ByronKey 'CredFromKeyK
+    , PaymentAddress n IcarusKey 'CredFromKeyK
     ) => SpecWith Context
 spec = do
     describe "BYRON_ADDRESSES" $ do
@@ -310,7 +310,7 @@ scenario_ADDRESS_IMPORT_01
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey 'AddressK
+        , PaymentAddress n ByronKey 'CredFromKeyK
         )
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context
@@ -339,7 +339,7 @@ scenario_ADDRESS_IMPORT_02
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n IcarusKey 'AddressK
+        , PaymentAddress n IcarusKey 'CredFromKeyK
         )
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 15))
     -> SpecWith Context
@@ -361,7 +361,7 @@ scenario_ADDRESS_IMPORT_03
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey 'AddressK
+        , PaymentAddress n ByronKey 'CredFromKeyK
         )
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context
@@ -385,7 +385,7 @@ scenario_ADDRESS_IMPORT_04
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey 'AddressK
+        , PaymentAddress n ByronKey 'CredFromKeyK
         )
     => (Context -> ResourceT IO ApiByronWallet)
     -> SpecWith Context
@@ -414,7 +414,7 @@ scenario_ADDRESS_IMPORT_05
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey 'AddressK
+        , PaymentAddress n ByronKey 'CredFromKeyK
         )
     => Int
     -> (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
@@ -448,7 +448,7 @@ scenario_ADDRESS_IMPORT_06
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey 'AddressK
+        , PaymentAddress n ByronKey 'CredFromKeyK
         )
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/CoinSelections.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/CoinSelections.hs
@@ -23,7 +23,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PaymentAddress )
+    ( Depth (..), PaymentAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -74,8 +74,8 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n IcarusKey
-    , PaymentAddress n ByronKey
+    , PaymentAddress n IcarusKey 'AddressK
+    , PaymentAddress n ByronKey 'AddressK
     ) => SpecWith Context
 spec = describe "BYRON_COIN_SELECTION" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/CoinSelections.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/CoinSelections.hs
@@ -74,8 +74,8 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n IcarusKey 'AddressK
-    , PaymentAddress n ByronKey 'AddressK
+    , PaymentAddress n IcarusKey 'CredFromKeyK
+    , PaymentAddress n ByronKey 'CredFromKeyK
     ) => SpecWith Context
 spec = describe "BYRON_COIN_SELECTION" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
@@ -105,7 +105,7 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n IcarusKey 'AddressK
+    , PaymentAddress n IcarusKey 'CredFromKeyK
     ) => SpecWith Context
 spec = describe "BYRON_HW_WALLETS" $ do
     it "HW_WALLETS_01 - Restoration from account public key preserves funds" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
@@ -36,7 +36,8 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( HardDerivation (..)
+    ( Depth (..)
+    , HardDerivation (..)
     , PaymentAddress
     , PersistPublicKey (..)
     , WalletKey (..)
@@ -104,7 +105,7 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n IcarusKey
+    , PaymentAddress n IcarusKey 'AddressK
     ) => SpecWith Context
 spec = describe "BYRON_HW_WALLETS" $ do
     it "HW_WALLETS_01 - Restoration from account public key preserves funds" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -33,7 +33,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PaymentAddress )
+    ( Depth (..), PaymentAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -114,9 +114,9 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey
-    , PaymentAddress n IcarusKey
-    , PaymentAddress n ByronKey
+    , PaymentAddress n ShelleyKey 'AddressK
+    , PaymentAddress n IcarusKey 'AddressK
+    , PaymentAddress n ByronKey 'AddressK
     ) => SpecWith Context
 spec = describe "BYRON_MIGRATIONS" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -114,9 +114,9 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey 'AddressK
-    , PaymentAddress n IcarusKey 'AddressK
-    , PaymentAddress n ByronKey 'AddressK
+    , PaymentAddress n ShelleyKey 'CredFromKeyK
+    , PaymentAddress n IcarusKey 'CredFromKeyK
+    , PaymentAddress n ByronKey 'CredFromKeyK
     ) => SpecWith Context
 spec = describe "BYRON_MIGRATIONS" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -129,8 +129,8 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ByronKey 'AddressK
-    , PaymentAddress n IcarusKey 'AddressK
+    , PaymentAddress n ByronKey 'CredFromKeyK
+    , PaymentAddress n IcarusKey 'CredFromKeyK
     ) => SpecWith Context
 spec = describe "BYRON_TRANSACTIONS" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -29,7 +29,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PaymentAddress )
+    ( Depth (..), PaymentAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -129,8 +129,8 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ByronKey
-    , PaymentAddress n IcarusKey
+    , PaymentAddress n ByronKey 'AddressK
+    , PaymentAddress n IcarusKey 'AddressK
     ) => SpecWith Context
 spec = describe "BYRON_TRANSACTIONS" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/TransactionsNew.hs
@@ -91,8 +91,8 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ByronKey 'AddressK
-    , PaymentAddress n IcarusKey 'AddressK
+    , PaymentAddress n ByronKey 'CredFromKeyK
+    , PaymentAddress n IcarusKey 'CredFromKeyK
     ) => SpecWith Context
 spec = describe "NEW_BYRON_TRANSACTIONS" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/TransactionsNew.hs
@@ -1,0 +1,452 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Integration.Scenario.API.Byron.TransactionsNew
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Api.Types
+    ( ApiByronWallet
+    , ApiConstructTransaction
+    , ApiT (..)
+    , ApiWallet
+    , DecodeAddress
+    , DecodeStakeAddress
+    , EncodeAddress (..)
+    , WalletStyle (..)
+    )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Depth (..), PaymentAddress )
+import Cardano.Wallet.Primitive.AddressDerivation.Byron
+    ( ByronKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Icarus
+    ( IcarusKey )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+import Control.Monad
+    ( forM_ )
+import Control.Monad.IO.Unlift
+    ( MonadUnliftIO (..), liftIO )
+import Control.Monad.Trans.Resource
+    ( runResourceT )
+import Data.Generics.Internal.VL.Lens
+    ( (^.) )
+import Data.Proxy
+    ( Proxy )
+import Data.Text
+    ( Text )
+import Numeric.Natural
+    ( Natural )
+import Test.Hspec
+    ( SpecWith, describe, pendingWith )
+import Test.Hspec.Expectations.Lifted
+    ( shouldNotBe, shouldSatisfy )
+import Test.Hspec.Extra
+    ( it )
+import Test.Integration.Framework.DSL
+    ( Context (..)
+    , Headers (..)
+    , Payload (..)
+    , emptyIcarusWallet
+    , emptyRandomWallet
+    , emptyWallet
+    , expectErrorMessage
+    , expectField
+    , expectResponseCode
+    , expectSuccess
+    , fixtureIcarusWallet
+    , fixtureIcarusWalletWith
+    , fixtureMultiAssetIcarusWallet
+    , fixtureMultiAssetRandomWallet
+    , fixtureRandomWallet
+    , fixtureRandomWalletWith
+    , json
+    , listAddresses
+    , minUTxOValue
+    , pickAnAsset
+    , request
+    , verify
+    )
+import Test.Integration.Framework.TestData
+    ( errMsg403Fee
+    , errMsg403InvalidConstructTx
+    , errMsg403MinUTxOValue
+    , errMsg403NotEnoughMoney
+    )
+
+import qualified Cardano.Wallet.Api.Link as Link
+import qualified Network.HTTP.Types.Status as HTTP
+
+spec :: forall n.
+    ( DecodeAddress n
+    , DecodeStakeAddress n
+    , EncodeAddress n
+    , PaymentAddress n ByronKey 'AddressK
+    , PaymentAddress n IcarusKey 'AddressK
+    ) => SpecWith Context
+spec = describe "NEW_BYRON_TRANSACTIONS" $ do
+
+    describe "BYRON_TRANS_NEW_CREATE_01a - Empty payload is not allowed" $
+        forM_ [ (fixtureRandomWallet, "Byron fixture wallet")
+              , (fixtureIcarusWallet, "Icarus fixture wallet")] $
+              \(srcFixture, name) -> it name $ \ctx -> runResourceT $ do
+
+                liftIO $ pendingWith "Byron fixture wallet returns 500"
+
+                wa <- srcFixture ctx
+                let emptyPayload = Json [json|{}|]
+
+                rTx <- request @(ApiConstructTransaction n) ctx
+                    (Link.createUnsignedTransaction @'Byron wa)
+                    Default emptyPayload
+                verify rTx
+                    [ expectResponseCode HTTP.status403
+                    , expectErrorMessage errMsg403InvalidConstructTx
+                    ]
+
+    describe "BYRON_TRANS_NEW_CREATE_01c - No payload is bad request" $
+        forM_ [ (fixtureRandomWallet, "Byron fixture wallet")
+              , (fixtureIcarusWallet, "Icarus fixture wallet")] $
+              \(srcFixture, name) -> it name $ \ctx -> runResourceT $ do
+
+                wa <- srcFixture ctx
+
+                rTx <- request @(ApiConstructTransaction n) ctx
+                    (Link.createUnsignedTransaction @'Byron wa) Default Empty
+                verify rTx
+                    [ expectResponseCode HTTP.status400
+                    ]
+
+    describe "BYRON_TRANS_NEW_CREATE_04 - Single Output Transaction" $
+        forM_ [(fixtureRandomWallet, "Byron wallet"),
+              (fixtureIcarusWallet, "Icarus wallet")] $
+              \(srcFixture,name) -> it name $ \ctx -> runResourceT $ do
+
+            liftIO $ pendingWith "Byron wallet returns 500, Icarus wallet returns 403 (invalid_wallet_type)"
+
+
+            (wByron, wShelley) <- (,) <$> srcFixture ctx <*> emptyWallet ctx
+            addrs <- listAddresses @n ctx wShelley
+
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
+            let destination = (addrs !! 1) ^. #id
+            let payload = Json [json|{
+                    "payments": [{
+                        "address": #{destination},
+                        "amount": {
+                            "quantity": #{amt},
+                            "unit": "lovelace"
+                        }
+                    }]
+                }|]
+
+            rTx <- request @(ApiConstructTransaction n) ctx
+                (Link.createUnsignedTransaction @'Byron wByron) Default payload
+            verify rTx
+                [ expectSuccess
+                , expectResponseCode HTTP.status202
+                , expectField (#coinSelection . #inputs) (`shouldSatisfy` (not . null))
+                , expectField (#coinSelection . #outputs) (`shouldSatisfy` (not . null))
+                , expectField (#coinSelection . #change) (`shouldSatisfy` (not . null))
+                ]
+
+    describe "BYRON_TRANS_NEW_CREATE_04c - Can't cover fee" $
+        forM_ [(fixtureRandomWalletWith @n, "Byron wallet"),
+               (fixtureIcarusWalletWith @n, "Icarus wallet")] $
+               \(srcFixture,name) -> it name $ \ctx -> runResourceT $ do
+
+            liftIO $ pendingWith "Byron wallet returns 500, Icarus wallet as expected"
+
+            wa <- srcFixture ctx [minUTxOValue (_mainEra ctx) + 1]
+            wb <- emptyWallet ctx
+
+            payload <- liftIO $ mkTxPayload ctx wb (minUTxOValue (_mainEra ctx))
+
+            rTx <- request @(ApiConstructTransaction n) ctx
+                (Link.createUnsignedTransaction @'Byron wa) Default payload
+            verify rTx
+                [ expectResponseCode HTTP.status403
+                , expectErrorMessage errMsg403Fee
+                ]
+
+    describe "BYRON_TRANS_NEW_CREATE_04d - Not enough money" $
+        forM_ [(fixtureRandomWalletWith @n, "Byron wallet"),
+               (fixtureIcarusWalletWith @n, "Icarus wallet")] $
+               \(srcFixture,name) -> it name $ \ctx -> runResourceT $ do
+
+            liftIO $ pendingWith "Byron wallet returns 500, Icarus wallet as expected"
+
+            let minUTxOValue' = minUTxOValue (_mainEra ctx)
+            let (srcAmt, reqAmt) = (minUTxOValue', 2 * minUTxOValue')
+            wa <- srcFixture ctx [srcAmt]
+            wb <- emptyWallet ctx
+
+            payload <- liftIO $ mkTxPayload ctx wb reqAmt
+
+            rTx <- request @(ApiConstructTransaction n) ctx
+                (Link.createUnsignedTransaction @'Byron wa) Default payload
+            verify rTx
+                [ expectResponseCode HTTP.status403
+                , expectErrorMessage errMsg403NotEnoughMoney
+                ]
+
+    describe "BYRON_TRANS_NEW_CREATE_04d - Not enough money emptyWallet" $
+        forM_ [(emptyRandomWallet, "Empty Byron wallet"),
+               (emptyIcarusWallet, "Empty Icarus wallet")] $
+              \(emptySrcWallet,name) -> it name $ \ctx -> runResourceT $ do
+
+            liftIO $ pendingWith "Byron wallet returns 500, Icarus wallet as expected"
+
+            wa <- emptySrcWallet ctx
+            wb <- emptyWallet ctx
+
+            payload <- liftIO $ mkTxPayload ctx wb (minUTxOValue (_mainEra ctx))
+
+            rTx <- request @(ApiConstructTransaction n) ctx
+                (Link.createUnsignedTransaction @'Byron wa) Default payload
+            verify rTx
+                [ expectResponseCode HTTP.status403
+                , expectErrorMessage errMsg403NotEnoughMoney
+                ]
+
+    describe "BYRON_TRANS_NEW_CREATE_04e - Multiple Output Tx to single wallet" $
+        forM_ [(fixtureRandomWallet, "Byron wallet"),
+              (fixtureIcarusWallet, "Icarus wallet")] $
+              \(srcFixture,name) -> it name $ \ctx -> runResourceT $ do
+
+            liftIO $ pendingWith "Byron wallet returns 500, Icarus wallet returns 403 (invalid_wallet_type)"
+
+            wa <- srcFixture ctx
+            wb <- emptyWallet ctx
+            addrs <- listAddresses @n ctx wb
+
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
+            let destination1 = (addrs !! 1) ^. #id
+            let destination2 = (addrs !! 2) ^. #id
+            let payload = Json [json|{
+                    "payments": [{
+                        "address": #{destination1},
+                        "amount": {
+                            "quantity": #{amt},
+                            "unit": "lovelace"
+                        }
+                    },
+                    {
+                        "address": #{destination2},
+                        "amount": {
+                            "quantity": #{amt},
+                            "unit": "lovelace"
+                        }
+                    }]
+                }|]
+
+            rTx <- request @(ApiConstructTransaction n) ctx
+                (Link.createUnsignedTransaction @'Byron wa) Default payload
+            verify rTx
+                [ expectSuccess
+                , expectResponseCode HTTP.status202
+                , expectField (#coinSelection . #inputs) (`shouldSatisfy` (not . null))
+                , expectField (#coinSelection . #outputs) (`shouldSatisfy` (not . null))
+                , expectField (#coinSelection . #change) (`shouldSatisfy` (not . null))
+                ]
+            -- TODO: now we should sign it and send it in two steps,
+            --       make sure it is delivered
+            --       make sure balance is updated accordingly on src and dst wallets
+
+    describe "BYRON_TRANS_NEW_ASSETS_CREATE_01a - Multi-asset tx with Ada" $
+        forM_ [(fixtureMultiAssetRandomWallet @n, "Byron wallet"),
+              (fixtureMultiAssetIcarusWallet @n, "Icarus wallet")] $
+              \(srcFixture,name) -> it name $ \ctx -> runResourceT $ do
+
+        liftIO $ pendingWith "Byron wallet returns 500, Icarus wallet returns 403 (invalid_wallet_type)"
+
+        wa <- srcFixture ctx
+        wb <- emptyWallet ctx
+        ra <- request @ApiByronWallet ctx (Link.getWallet @'Byron wa) Default Empty
+        let (_, Right wal) = ra
+
+        -- pick out an asset to send
+        let assetsSrc = wal ^. #assets . #total . #getApiT
+        assetsSrc `shouldNotBe` mempty
+        let val = minUTxOValue (_mainEra ctx) <$ pickAnAsset assetsSrc
+
+        -- create payload
+        addrs <- listAddresses @n ctx wb
+        let destination = (addrs !! 1) ^. #id
+        let amt = 2 * minUTxOValue (_mainEra ctx)
+        payload <- mkTxPayloadMA @n destination amt [val]
+
+        --construct transaction
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Byron wa) Default payload
+        verify rTx
+            [ expectSuccess
+            , expectResponseCode HTTP.status202
+            , expectField (#coinSelection . #inputs) (`shouldSatisfy` (not . null))
+            , expectField (#coinSelection . #outputs) (`shouldSatisfy` (not . null))
+            , expectField (#coinSelection . #change) (`shouldSatisfy` (not . null))
+            ]
+        -- TODO: now we should sign it and send it in two steps
+        --       make sure it is delivered
+        --       make sure balance is updated accordingly on src and dst wallets
+
+    describe "BYRON_TRANS_NEW_ASSETS_CREATE_01b - Multi-asset tx with not enough Ada" $
+        forM_ [(fixtureMultiAssetRandomWallet @n, "Byron wallet"),
+              (fixtureMultiAssetIcarusWallet @n, "Icarus wallet")] $
+              \(srcFixture,name) -> it name $ \ctx -> runResourceT $ do
+
+            liftIO $ pendingWith "Byron wallet returns 500, Icarus wallet as expected"
+
+            wa <- srcFixture ctx
+            wb <- emptyWallet ctx
+            ra <- request @ApiByronWallet ctx (Link.getWallet @'Byron wa) Default Empty
+            let (_, Right wal) = ra
+
+            -- pick out an asset to send
+            let assetsSrc = wal ^. #assets . #total . #getApiT
+            assetsSrc `shouldNotBe` mempty
+            let val = minUTxOValue (_mainEra ctx) <$ pickAnAsset assetsSrc
+
+            -- create payload
+            addrs <- listAddresses @n ctx wb
+            let destination = (addrs !! 1) ^. #id
+            let amt = minUTxOValue (_mainEra ctx)
+            payload <- mkTxPayloadMA @n destination amt [val]
+
+            --construct transaction
+            rTx <- request @(ApiConstructTransaction n) ctx
+                (Link.createUnsignedTransaction @'Byron wa) Default payload
+            verify rTx
+                [ expectResponseCode HTTP.status403
+                , expectErrorMessage errMsg403MinUTxOValue
+                ]
+
+    describe "BYRON_TRANS_NEW_ASSETS_CREATE_01c - Multi-asset tx without Ada" $
+        forM_ [(fixtureMultiAssetRandomWallet @n, "Byron wallet"),
+              (fixtureMultiAssetIcarusWallet @n, "Icarus wallet")] $
+              \(srcFixture,name) -> it name $ \ctx -> runResourceT $ do
+
+            liftIO $ pendingWith "Byron wallet returns 500, Icarus wallet returns 403 (invalid_wallet_type)"
+
+            wa <- srcFixture ctx
+            wb <- emptyWallet ctx
+            ra <- request @ApiByronWallet ctx (Link.getWallet @'Byron wa) Default Empty
+            let (_, Right wal) = ra
+
+            -- pick out an asset to send
+            let assetsSrc = wal ^. #assets . #total . #getApiT
+            assetsSrc `shouldNotBe` mempty
+            let val = minUTxOValue (_mainEra ctx) <$ pickAnAsset assetsSrc
+
+            -- create payload
+            addrs <- listAddresses @n ctx wb
+            let destination = (addrs !! 1) ^. #id
+            let amt = 0
+            payload <- mkTxPayloadMA @n destination amt [val]
+
+            --construct transaction
+            rTx <- request @(ApiConstructTransaction n) ctx
+                (Link.createUnsignedTransaction @'Byron wa) Default payload
+            verify rTx
+                [ expectSuccess
+                , expectResponseCode HTTP.status202
+                , expectField (#coinSelection . #inputs) (`shouldSatisfy` (not . null))
+                , expectField (#coinSelection . #outputs) (`shouldSatisfy` (not . null))
+                , expectField (#coinSelection . #change) (`shouldSatisfy` (not . null))
+                ]
+            -- TODO: now we should sign it and send it in two steps
+            --       make sure it is delivered
+            --       make sure balance is updated accordingly on src and dst wallets
+
+    describe "BYRON_TRANS_NEW_ASSETS_CREATE_01d - Multi-asset tx with not enough assets" $
+        forM_ [(fixtureMultiAssetRandomWallet @n, "Byron wallet"),
+              (fixtureMultiAssetIcarusWallet @n, "Icarus wallet")] $
+              \(srcFixture,name) -> it name $ \ctx -> runResourceT $ do
+
+            liftIO $ pendingWith "Byron wallet returns 500, Icarus wallet as expected"
+
+            wa <- srcFixture ctx
+            wb <- emptyWallet ctx
+            ra <- request @ApiByronWallet ctx (Link.getWallet @'Byron wa) Default Empty
+            let (_, Right wal) = ra
+
+            -- pick out an asset to send
+            let assetsSrc = wal ^. #assets . #total . #getApiT
+            assetsSrc `shouldNotBe` mempty
+            let minUTxOValue' = minUTxOValue (_mainEra ctx)
+            let val = (minUTxOValue' * minUTxOValue') <$ pickAnAsset assetsSrc
+
+            -- create payload
+            addrs <- listAddresses @n ctx wb
+            let destination = (addrs !! 1) ^. #id
+            let amt = 0
+            payload <- mkTxPayloadMA @n destination amt [val]
+
+            --construct transaction
+            rTx <- request @(ApiConstructTransaction n) ctx
+                (Link.createUnsignedTransaction @'Byron wa) Default payload
+            verify rTx
+                [ expectResponseCode HTTP.status403
+                , expectErrorMessage errMsg403NotEnoughMoney
+                ]
+
+  where
+   -- Construct a JSON payment request for the given quantity of lovelace.
+   mkTxPayload
+       :: MonadUnliftIO m
+       => Context
+       -> ApiWallet
+       -> Natural
+       -> m Payload
+   mkTxPayload ctx wDest amt = do
+       addrs <- listAddresses @n ctx wDest
+       let destination = (addrs !! 1) ^. #id
+       return $ Json [json|{
+               "payments": [{
+                   "address": #{destination},
+                   "amount": {
+                       "quantity": #{amt},
+                       "unit": "lovelace"
+                   }
+               }]
+           }|]
+
+   -- Like mkTxPayload, except that assets are included in the payment.
+   -- Asset amounts are specified by ((PolicyId Hex, AssetName Hex), amount).
+   mkTxPayloadMA
+       :: forall l m.
+           ( DecodeAddress l
+           , DecodeStakeAddress l
+           , EncodeAddress l
+           , MonadUnliftIO m
+           )
+       => (ApiT Address, Proxy l)
+       -> Natural
+       -> [((Text, Text), Natural)]
+       -> m Payload
+   mkTxPayloadMA destination coin val = do
+       let assetJson ((pid, name), q) = [json|{
+                   "policy_id": #{pid},
+                   "asset_name": #{name},
+                   "quantity": #{q}
+               }|]
+       return $ Json [json|{
+               "payments": [{
+                   "address": #{destination},
+                   "amount": {
+                       "quantity": #{coin},
+                       "unit": "lovelace"
+                   },
+                   "assets": #{map assetJson val}
+               }]
+           }|]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
@@ -26,7 +26,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PaymentAddress )
+    ( Depth (..), PaymentAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -110,8 +110,8 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n IcarusKey
-    , PaymentAddress n ByronKey
+    , PaymentAddress n IcarusKey 'AddressK
+    , PaymentAddress n ByronKey 'AddressK
     ) => SpecWith Context
 spec = describe "BYRON_WALLETS" $ do
     it "BYRON_GET_04, DELETE_01 - Deleted wallet is not available" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
@@ -110,8 +110,8 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n IcarusKey 'AddressK
-    , PaymentAddress n ByronKey 'AddressK
+    , PaymentAddress n IcarusKey 'CredFromKeyK
+    , PaymentAddress n ByronKey 'CredFromKeyK
     ) => SpecWith Context
 spec = describe "BYRON_WALLETS" $ do
     it "BYRON_GET_04, DELETE_01 - Deleted wallet is not available" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
@@ -112,6 +112,8 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text.Encoding as T
 import qualified Network.HTTP.Types as HTTP
 
+import qualified Debug.Trace as TR
+
 
 spec :: forall n.
     ( DecodeAddress n
@@ -227,7 +229,7 @@ spec = describe "SHARED_TRANSACTIONS" $ do
         verify rDecodedTx1 decodedExpectations
 
         let apiTx = getFromResponse #transaction rTx2
-        signedTx <-
+        signedTx <- TR.trace ("---------------SIGN-----------------\n") $
             signSharedTx ctx wal apiTx [ expectResponseCode HTTP.status202 ]
         let txCbor2 =
                 getFromResponse #transaction (HTTP.status202, Right signedTx)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
@@ -112,8 +112,6 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text.Encoding as T
 import qualified Network.HTTP.Types as HTTP
 
-import qualified Debug.Trace as TR
-
 
 spec :: forall n.
     ( DecodeAddress n
@@ -229,7 +227,7 @@ spec = describe "SHARED_TRANSACTIONS" $ do
         verify rDecodedTx1 decodedExpectations
 
         let apiTx = getFromResponse #transaction rTx2
-        signedTx <- TR.trace ("---------------SIGN-----------------\n") $
+        signedTx <-
             signSharedTx ctx wal apiTx [ expectResponseCode HTTP.status202 ]
         let txCbor2 =
                 getFromResponse #transaction (HTTP.status202, Right signedTx)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
@@ -31,7 +31,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PaymentAddress )
+    ( Depth (..), PaymentAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -110,9 +110,9 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey
-    , PaymentAddress n IcarusKey
-    , PaymentAddress n ByronKey
+    , PaymentAddress n ShelleyKey 'AddressK
+    , PaymentAddress n IcarusKey 'AddressK
+    , PaymentAddress n ByronKey 'AddressK
     ) => SpecWith Context
 spec = describe "SHELLEY_COIN_SELECTION" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
@@ -110,9 +110,9 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey 'AddressK
-    , PaymentAddress n IcarusKey 'AddressK
-    , PaymentAddress n ByronKey 'AddressK
+    , PaymentAddress n ShelleyKey 'CredFromKeyK
+    , PaymentAddress n IcarusKey 'CredFromKeyK
+    , PaymentAddress n ByronKey 'CredFromKeyK
     ) => SpecWith Context
 spec = describe "SHELLEY_COIN_SELECTION" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -31,7 +31,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PaymentAddress )
+    ( Depth (..), PaymentAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -122,9 +122,9 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey
-    , PaymentAddress n IcarusKey
-    , PaymentAddress n ByronKey
+    , PaymentAddress n ShelleyKey 'AddressK
+    , PaymentAddress n IcarusKey 'AddressK
+    , PaymentAddress n ByronKey 'AddressK
     ) => SpecWith Context
 spec = describe "SHELLEY_MIGRATIONS" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -122,9 +122,9 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey 'AddressK
-    , PaymentAddress n IcarusKey 'AddressK
-    , PaymentAddress n ByronKey 'AddressK
+    , PaymentAddress n ShelleyKey 'CredFromKeyK
+    , PaymentAddress n IcarusKey 'CredFromKeyK
+    , PaymentAddress n ByronKey 'CredFromKeyK
     ) => SpecWith Context
 spec = describe "SHELLEY_MIGRATIONS" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Settings.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Settings.hs
@@ -66,9 +66,9 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey 'AddressK
-    , PaymentAddress n IcarusKey 'AddressK
-    , PaymentAddress n ByronKey 'AddressK
+    , PaymentAddress n ShelleyKey 'CredFromKeyK
+    , PaymentAddress n IcarusKey 'CredFromKeyK
+    , PaymentAddress n ByronKey 'CredFromKeyK
     ) => SpecWith Context
 spec = describe "SHELLEY_SETTINGS" $ do
     it "SETTINGS_01 - Can put and read settings" $ \ctx -> do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Settings.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Settings.hs
@@ -21,7 +21,7 @@ import Cardano.Wallet.Api.Types
     , EncodeAddress (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PaymentAddress )
+    ( Depth (..), PaymentAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -66,9 +66,9 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey
-    , PaymentAddress n IcarusKey
-    , PaymentAddress n ByronKey
+    , PaymentAddress n ShelleyKey 'AddressK
+    , PaymentAddress n IcarusKey 'AddressK
+    , PaymentAddress n ByronKey 'AddressK
     ) => SpecWith Context
 spec = describe "SHELLEY_SETTINGS" $ do
     it "SETTINGS_01 - Can put and read settings" $ \ctx -> do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -163,7 +163,7 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey 'AddressK
+    , PaymentAddress n ShelleyKey 'CredFromKeyK
     ) => SpecWith Context
 spec = describe "SHELLEY_STAKE_POOLS" $ do
     let listPools ctx stake = request @[ApiStakePool] ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -37,7 +37,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PaymentAddress )
+    ( Depth (..), PaymentAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Primitive.Types
@@ -163,7 +163,7 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey
+    , PaymentAddress n ShelleyKey 'AddressK
     ) => SpecWith Context
 spec = describe "SHELLEY_STAKE_POOLS" $ do
     let listPools ctx stake = request @[ApiStakePool] ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -44,7 +44,7 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Api.Types.SchemaMetadata
     ( detailedMetadata )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PaymentAddress )
+    ( Depth (..), PaymentAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
 import Cardano.Wallet.Primitive.Types
@@ -194,7 +194,7 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n IcarusKey
+    , PaymentAddress n IcarusKey 'AddressK
     ) => SpecWith Context
 spec = describe "SHELLEY_TRANSACTIONS" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -194,7 +194,7 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n IcarusKey 'AddressK
+    , PaymentAddress n IcarusKey 'CredFromKeyK
     ) => SpecWith Context
 spec = describe "SHELLEY_TRANSACTIONS" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -1204,7 +1204,8 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         let validityInterval =
                 ValidityIntervalExplicit (Quantity 0) (Quantity $ toSlot + 10)
 
-        let apiTx'@(ApiSerialisedTransaction apiTx _)= getFromResponse #transaction rTx
+        let apiTx'@(ApiSerialisedTransaction apiTx _)=
+                getFromResponse #transaction rTx
         let decodePayload1 = Json (toJSON apiTx')
         rDecodedTx1 <- request @(ApiDecodedTransaction n) ctx
             (Link.decodeTransaction @'Shelley wa) Default decodePayload1

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -74,7 +74,8 @@ import Cardano.Wallet.Api.Types
     , fromApiEra
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( DerivationIndex (..)
+    ( Depth (..)
+    , DerivationIndex (..)
     , HardDerivation (..)
     , PaymentAddress (..)
     , Role (..)
@@ -243,7 +244,7 @@ spec :: forall n.
     , DecodeStakeAddress n
     , EncodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n IcarusKey
+    , PaymentAddress n IcarusKey 'AddressK
     ) => SpecWith Context
 spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
     it "TRANS_NEW_CREATE_01a - Empty payload is not allowed" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -244,7 +244,7 @@ spec :: forall n.
     , DecodeStakeAddress n
     , EncodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n IcarusKey 'AddressK
+    , PaymentAddress n IcarusKey 'CredFromKeyK
     ) => SpecWith Context
 spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
     it "TRANS_NEW_CREATE_01a - Empty payload is not allowed" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -33,7 +33,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( DerivationIndex (..), PaymentAddress, Role (..) )
+    ( Depth (..), DerivationIndex (..), PaymentAddress, Role (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -157,9 +157,9 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey
-    , PaymentAddress n IcarusKey
-    , PaymentAddress n ByronKey
+    , PaymentAddress n ShelleyKey 'AddressK
+    , PaymentAddress n IcarusKey 'AddressK
+    , PaymentAddress n ByronKey 'AddressK
     ) => SpecWith Context
 spec = describe "SHELLEY_WALLETS" $ do
     it "WALLETS_CREATE_01 - Create a wallet" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -157,9 +157,9 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey 'AddressK
-    , PaymentAddress n IcarusKey 'AddressK
-    , PaymentAddress n ByronKey 'AddressK
+    , PaymentAddress n ShelleyKey 'CredFromKeyK
+    , PaymentAddress n IcarusKey 'CredFromKeyK
+    , PaymentAddress n ByronKey 'CredFromKeyK
     ) => SpecWith Context
 spec = describe "SHELLEY_WALLETS" $ do
     it "WALLETS_CREATE_01 - Create a wallet" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Addresses.hs
@@ -21,7 +21,7 @@ import Cardano.Wallet.Api.Types
     , EncodeAddress (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( NetworkDiscriminant, PaymentAddress )
+    ( Depth (..), NetworkDiscriminant, PaymentAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -73,8 +73,8 @@ import qualified Data.Text as T
 spec :: forall n.
     ( DecodeAddress n
     , EncodeAddress n
-    , PaymentAddress n ByronKey
-    , PaymentAddress n IcarusKey
+    , PaymentAddress n ByronKey 'AddressK
+    , PaymentAddress n IcarusKey 'AddressK
     ) => SpecWith Context
 spec = do
     describe "BYRON_CLI_ADDRESSES" $ do
@@ -327,7 +327,7 @@ scenario_ADDRESS_IMPORT_01
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
+        , PaymentAddress n ByronKey 'AddressK
         )
     => SpecWith Context
 scenario_ADDRESS_IMPORT_01 = it title $ \ctx -> runResourceT @IO $ do
@@ -344,7 +344,7 @@ scenario_ADDRESS_IMPORT_02
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n IcarusKey
+        , PaymentAddress n IcarusKey 'AddressK
         )
     => SpecWith Context
 scenario_ADDRESS_IMPORT_02 = it title $ \ctx -> runResourceT @IO $ do
@@ -361,7 +361,7 @@ scenario_ADDRESS_IMPORT_03
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
+        , PaymentAddress n ByronKey 'AddressK
         )
     => SpecWith Context
 scenario_ADDRESS_IMPORT_03 = it title $ \ctx -> runResourceT @IO $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Addresses.hs
@@ -73,8 +73,8 @@ import qualified Data.Text as T
 spec :: forall n.
     ( DecodeAddress n
     , EncodeAddress n
-    , PaymentAddress n ByronKey 'AddressK
-    , PaymentAddress n IcarusKey 'AddressK
+    , PaymentAddress n ByronKey 'CredFromKeyK
+    , PaymentAddress n IcarusKey 'CredFromKeyK
     ) => SpecWith Context
 spec = do
     describe "BYRON_CLI_ADDRESSES" $ do
@@ -327,7 +327,7 @@ scenario_ADDRESS_IMPORT_01
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey 'AddressK
+        , PaymentAddress n ByronKey 'CredFromKeyK
         )
     => SpecWith Context
 scenario_ADDRESS_IMPORT_01 = it title $ \ctx -> runResourceT @IO $ do
@@ -344,7 +344,7 @@ scenario_ADDRESS_IMPORT_02
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n IcarusKey 'AddressK
+        , PaymentAddress n IcarusKey 'CredFromKeyK
         )
     => SpecWith Context
 scenario_ADDRESS_IMPORT_02 = it title $ \ctx -> runResourceT @IO $ do
@@ -361,7 +361,7 @@ scenario_ADDRESS_IMPORT_03
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey 'AddressK
+        , PaymentAddress n ByronKey 'CredFromKeyK
         )
     => SpecWith Context
 scenario_ADDRESS_IMPORT_03 = it title $ \ctx -> runResourceT @IO $ do

--- a/lib/core/bench/db-bench.hs
+++ b/lib/core/bench/db-bench.hs
@@ -924,7 +924,7 @@ mkAddress i j =
 
 mkByronAddress :: Int -> Int -> Address
 mkByronAddress i j =
-    paymentAddress @'Mainnet ByronKey 'CredFromKeyK
+    paymentAddress @'Mainnet @ByronKey @'CredFromKeyK
         (ByronKey
             (unsafeXPub (B8.pack $ take 64 $ randoms g))
             (Index acctIx, Index addrIx)

--- a/lib/core/bench/db-bench.hs
+++ b/lib/core/bench/db-bench.hs
@@ -890,7 +890,7 @@ ourAccount = publicKey $ unsafeGenerateKeyFromSeed (seed, Nothing) mempty
   where
     seed = someDummyMnemonic (Proxy @15)
 
-rewardAccount :: ShelleyKey 'AddressK XPub
+rewardAccount :: ShelleyKey 'CredFromKeyK XPub
 rewardAccount = publicKey $ unsafeGenerateKeyFromSeed (seed, Nothing) mempty
   where
     seed = someDummyMnemonic (Proxy @15)

--- a/lib/core/bench/db-bench.hs
+++ b/lib/core/bench/db-bench.hs
@@ -924,7 +924,7 @@ mkAddress i j =
 
 mkByronAddress :: Int -> Int -> Address
 mkByronAddress i j =
-    paymentAddress @'Mainnet
+    paymentAddress @'Mainnet ByronKey 'CredFromKeyK
         (ByronKey
             (unsafeXPub (B8.pack $ take 64 $ randoms g))
             (Index acctIx, Index addrIx)

--- a/lib/core/src/Cardano/Byron/Codec/Cbor.hs
+++ b/lib/core/src/Cardano/Byron/Codec/Cbor.hs
@@ -162,7 +162,7 @@ decodeAddressDerivationPath
     :: Passphrase "addr-derivation-payload"
     -> CBOR.Decoder s (Maybe
         ( Index 'WholeDomain 'AccountK
-        , Index 'WholeDomain 'AddressK
+        , Index 'WholeDomain 'CredFromKeyK
         ))
 decodeAddressDerivationPath pwd = do
     _ <- CBOR.decodeListLenCanonicalOf 3
@@ -196,7 +196,7 @@ decodeDerivationPathAttr
     -> [(Word8, ByteString)]
     -> CBOR.Decoder s (Maybe
         ( Index 'WholeDomain 'AccountK
-        , Index 'WholeDomain 'AddressK
+        , Index 'WholeDomain 'CredFromKeyK
         ))
 decodeDerivationPathAttr pwd attrs = do
     case lookup derPathTag attrs of
@@ -210,7 +210,7 @@ decodeDerivationPathAttr pwd attrs = do
     derPathTag = 1
     decoder :: CBOR.Decoder s (Maybe
         ( Index 'WholeDomain 'AccountK
-        , Index 'WholeDomain 'AddressK
+        , Index 'WholeDomain 'CredFromKeyK
         ))
     decoder = do
         bytes <- CBOR.decodeBytes
@@ -224,7 +224,7 @@ decodeDerivationPathAttr pwd attrs = do
 decodeDerivationPath
     :: CBOR.Decoder s
         ( Index 'WholeDomain 'AccountK
-        , Index 'WholeDomain 'AddressK
+        , Index 'WholeDomain 'CredFromKeyK
         )
 decodeDerivationPath = do
     ixs <- decodeListIndef CBOR.decodeWord32
@@ -348,7 +348,7 @@ encodeProtocolMagicAttr pm = mempty
 encodeDerivationPathAttr
     :: Passphrase "addr-derivation-payload"
     -> Index 'WholeDomain 'AccountK
-    -> Index 'WholeDomain 'AddressK
+    -> Index 'WholeDomain 'CredFromKeyK
     -> CBOR.Encoding
 encodeDerivationPathAttr pwd acctIx addrIx = mempty
     <> CBOR.encodeWord8 1 -- Tag for 'DerivationPath' attribute
@@ -358,7 +358,7 @@ encodeDerivationPathAttr pwd acctIx addrIx = mempty
 
 encodeDerivationPath
     :: Index 'WholeDomain 'AccountK
-    -> Index 'WholeDomain 'AddressK
+    -> Index 'WholeDomain 'CredFromKeyK
     -> CBOR.Encoding
 encodeDerivationPath (Index acctIx) (Index addrIx) = mempty
     <> CBOR.encodeListLenIndef
@@ -441,7 +441,7 @@ encryptDerivationPath passphrase payload = unsafeSerialize $ do
     -- if the key was created with 'generateKeyFromSeed'.
     useInvariant = \case
         CryptoPassed res -> res
-        CryptoFailed err -> error $ "encodeAddressKey: " ++ show err
+        CryptoFailed err -> error $ "encodeCredFromKeyKey: " ++ show err
 
 -- | ChaCha20/Poly1305 decrypting and authenticating the HD payload of
 -- addresses.

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -794,7 +794,7 @@ createIcarusWallet
     :: forall ctx s k n.
         ( HasGenesisData ctx
         , HasDBLayer IO s k ctx
-        , PaymentAddress n k
+        , PaymentAddress n k 'AddressK
         , k ~ IcarusKey
         , s ~ SeqState n k
         , Typeable n
@@ -1467,7 +1467,7 @@ listAddresses ctx wid normalize = db & \DBLayer{..} -> do
 createRandomAddress
     :: forall ctx s k n.
         ( HasDBLayer IO s k ctx
-        , PaymentAddress n k
+        , PaymentAddress n k 'AddressK
         , RndStateLike s
         , k ~ ByronKey
         , AddressBookIso s
@@ -1537,7 +1537,7 @@ importRandomAddresses ctx wid addrs = db & \DBLayer{..} ->
 -- to make sure that we compare them correctly.
 normalizeDelegationAddress
     :: forall s k n.
-        ( DelegationAddress n k
+        ( DelegationAddress n k 'AddressK
         , s ~ SeqState n k
         )
     => s
@@ -3518,13 +3518,10 @@ guardHardIndex ix =
 updateCosigner
     :: forall ctx s k n.
         ( s ~ SharedState n k
---        , MkKeyFingerprint k (Proxy n, k 'AddressK CC.XPub)
-        , MkKeyFingerprint k Address
-        , SoftDerivation k
-        , Typeable n
+        , k ~ SharedKey
+        , Shared.SupportsDiscovery n k
         , WalletKey k
         , HasDBLayer IO s k ctx
-        , k ~ SharedKey
         )
     => ctx
     -> WalletId

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -3558,7 +3558,7 @@ normalizeSharedAddress st addr = case Shared.ready st of
         fingerprint <- eitherToMaybe (paymentKeyFingerprint @k addr)
         let (ixM, _) = Shared.isShared addr st
         case (dTM, ixM) of
-            (Just dT, Just ix) ->
+            (Just dT, Just (ix,_)) ->
                 pure $ Shared.liftDelegationAddress @n ix dT fingerprint
             _ ->
                 pure $ Shared.liftPaymentAddress @n fingerprint

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2426,7 +2426,7 @@ signTransaction
   :: forall k ktype
    . ( WalletKey k
      , HardDerivation k
-     , Bounded (Index (AddressIndexDerivationType k) 'CredFromKeyK)
+     , Bounded (Index (AddressIndexDerivationType k) (AddressCredential k))
      )
   => TransactionLayer k ktype SealedTx
   -- ^ The way to interact with the wallet backend
@@ -3397,7 +3397,7 @@ derivePublicKey
     -> WalletId
     -> Role
     -> DerivationIndex
-    -> ExceptT ErrDerivePublicKey IO (k 'CredFromKeyK XPub)
+    -> ExceptT ErrDerivePublicKey IO (k (AddressCredential k) XPub)
 derivePublicKey ctx wid role_ ix = db & \DBLayer{..} -> do
     addrIx <- withExceptT ErrDerivePublicKeyInvalidIndex $ guardSoftIndex ix
 

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2479,11 +2479,11 @@ signTransaction tl preferredLatestEra keyLookup (rootKey, rootPwd) utxo =
 -- do so, use 'submitTx'.
 --
 buildAndSignTransaction
-    :: forall ctx s k ktype.
-        ( HasTransactionLayer k ktype ctx
+    :: forall ctx s k.
+        ( HasTransactionLayer k 'AddressK ctx
         , HasDBLayer IO s k ctx
         , HasNetworkLayer IO ctx
-        , IsOwned s k
+        , IsOwned s k 'AddressK
         )
     => ctx
     -> WalletId
@@ -2513,7 +2513,7 @@ buildAndSignTransaction ctx wid era mkRwdAcct pwd txCtx sel = db & \DBLayer{..} 
             return (tx, meta, time, sealedTx)
   where
     db = ctx ^. dbLayer @IO @s @k
-    tl = ctx ^. transactionLayer @k @ktype
+    tl = ctx ^. transactionLayer @k @'AddressK
     nl = ctx ^. networkLayer
     ti = timeInterpreter nl
 

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2549,7 +2549,7 @@ constructTransaction ctx wid era txCtx sel = db & \DBLayer{..} -> do
 -- for a shared wallet.
 constructSharedTransaction
     :: forall ctx s k (n :: NetworkDiscriminant).
-        ( HasTransactionLayer k 'ScriptK ctx
+        ( HasTransactionLayer k 'CredFromScriptK ctx
         , HasDBLayer IO s k ctx
         , HasNetworkLayer IO ctx
         , k ~ SharedKey
@@ -2576,7 +2576,7 @@ constructSharedTransaction ctx wid era txCtx sel = db & \DBLayer{..} -> do
             mkUnsignedTransaction tl era xpub pp txCtx sel
   where
     db = ctx ^. dbLayer @IO @s @k
-    tl = ctx ^. transactionLayer @k @'ScriptK
+    tl = ctx ^. transactionLayer @k @'CredFromScriptK
     nl = ctx ^. networkLayer
 
 -- | Calculate the transaction expiry slot, given a 'TimeInterpreter', and an

--- a/lib/core/src/Cardano/Wallet/Address/Book.hs
+++ b/lib/core/src/Cardano/Wallet/Address/Book.hs
@@ -133,7 +133,7 @@ newtype SeqAddressMap (c :: Role) (key :: Depth -> Type -> Type) =
     SeqAddressMap
         ( Map
             (KeyFingerprint "payment" key)
-            (Index 'Soft 'AddressK, AddressState)
+            (Index 'Soft 'CredFromKeyK, AddressState)
         )
     deriving Eq
 

--- a/lib/core/src/Cardano/Wallet/Address/Book.hs
+++ b/lib/core/src/Cardano/Wallet/Address/Book.hs
@@ -166,7 +166,7 @@ newtype SharedAddressMap (c :: Role) (key :: Depth -> Type -> Type) =
     SharedAddressMap
         ( Map
             (KeyFingerprint "payment" key)
-            (Index 'Soft 'ScriptK, AddressState)
+            (Index 'Soft 'CredFromScriptK, AddressState)
         )
     deriving Eq
 

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -149,6 +149,8 @@ module Cardano.Wallet.Api
         , ConstructSharedTransaction
         , SignSharedTransaction
         , DecodeSharedTransaction
+        , SubmitSharedTransaction
+
     , GetBlocksLatestHeader
     , Proxy_
         , PostExternalTransaction
@@ -1110,6 +1112,7 @@ type SharedTransactions n =
          ConstructSharedTransaction n
     :<|> SignSharedTransaction n
     :<|> DecodeSharedTransaction n
+    :<|> SubmitSharedTransaction
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/constructSharedTransaction
 type ConstructSharedTransaction n = "shared-wallets"
@@ -1131,6 +1134,13 @@ type DecodeSharedTransaction n = "shared-wallets"
     :> "transactions-decode"
     :> ReqBody '[JSON] ApiSerialisedTransaction
     :> PostAccepted '[JSON] (ApiDecodedTransactionT n)
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/submitSharedTransaction
+type SubmitSharedTransaction = "shared-wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "transactions-submit"
+    :> ReqBody '[JSON] ApiSerialisedTransaction
+    :> PostAccepted '[JSON] ApiTxId
 
 {-------------------------------------------------------------------------------
                                    Proxy_

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -147,6 +147,7 @@ module Cardano.Wallet.Api
 
     , SharedTransactions
         , ConstructSharedTransaction
+        , SignSharedTransaction
         , DecodeSharedTransaction
     , GetBlocksLatestHeader
     , Proxy_
@@ -1107,6 +1108,7 @@ type ListSharedAddresses n = "shared-wallets"
 
 type SharedTransactions n =
          ConstructSharedTransaction n
+    :<|> SignSharedTransaction n
     :<|> DecodeSharedTransaction n
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/constructSharedTransaction
@@ -1115,6 +1117,13 @@ type ConstructSharedTransaction n = "shared-wallets"
     :> "transactions-construct"
     :> ReqBody '[JSON] (ApiConstructTransactionDataT n)
     :> PostAccepted '[JSON] (ApiConstructTransactionT n)
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/signSharedTransaction
+type SignSharedTransaction n = "shared-wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "transactions-sign"
+    :> ReqBody '[JSON] ApiSignTransactionPostData
+    :> PostAccepted '[JSON] ApiSerialisedTransaction
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/decodeSharedTransaction
 type DecodeSharedTransaction n = "shared-wallets"

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -1151,13 +1151,13 @@ type PostExternalTransaction = "proxy"
                                Api Layer
 -------------------------------------------------------------------------------}
 
-data ApiLayer s (k :: Depth -> Type -> Type)
+data ApiLayer s (k :: Depth -> Type -> Type) ktype
     = ApiLayer
         (Tracer IO TxSubmitLog)
         (Tracer IO (WorkerLog WalletId WalletWorkerLog))
         (Block, NetworkParameters)
         (NetworkLayer IO Block)
-        (TransactionLayer k SealedTx)
+        (TransactionLayer k ktype SealedTx)
         (DBFactory IO s k)
         (WorkerRegistry WalletId (DBLayer IO s k))
         (Concierge IO WalletLock)
@@ -1170,10 +1170,10 @@ data ApiLayer s (k :: Depth -> Type -> Type)
 data WalletLock = PostTransactionOld WalletId
     deriving (Eq, Ord, Show)
 
-instance HasWorkerCtx (DBLayer IO s k) (ApiLayer s k) where
-    type WorkerCtx (ApiLayer s k) = WalletLayer IO s k
-    type WorkerMsg (ApiLayer s k) = WalletWorkerLog
-    type WorkerKey (ApiLayer s k) = WalletId
+instance HasWorkerCtx (DBLayer IO s k) (ApiLayer s k ktype) where
+    type WorkerCtx (ApiLayer s k ktype) = WalletLayer IO s k ktype
+    type WorkerMsg (ApiLayer s k ktype) = WalletWorkerLog
+    type WorkerKey (ApiLayer s k ktype) = WalletId
     hoistResource db transform (ApiLayer _ tr gp nw tl _ _ _ _) =
         WalletLayer (contramap transform tr) gp nw tl db
 

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -716,8 +716,7 @@ createUnsignedTransaction w = discriminate @style
 
 signTransaction
     :: forall style w.
-        ( HasCallStack
-        , HasType (ApiT WalletId) w
+        ( HasType (ApiT WalletId) w
         , Discriminate style
         )
     => w
@@ -725,7 +724,7 @@ signTransaction
 signTransaction w = discriminate @style
     (endpoint @(Api.SignTransaction Net) (wid &))
     (notSupported "Byron")
-    (notSupported "Shared") -- TODO: [ADP-909] should be supported in the final version of Transaction Workflow.
+    (endpoint @(Api.SignSharedTransaction Net) (wid &))
   where
     wid = w ^. typed @(ApiT WalletId)
 

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -769,7 +769,7 @@ submitTransaction
 submitTransaction w = discriminate @style
     (endpoint @Api.SubmitTransaction (wid &))
     (notSupported "Byron")
-    (notSupported "Shared")
+    (endpoint @Api.SubmitSharedTransaction (wid &))
   where
     wid = w ^. typed @(ApiT WalletId)
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -818,9 +818,9 @@ type MkApiWallet ctx s w
 postWallet
     :: forall ctx s k n.
         ( s ~ SeqState n k
-        , ctx ~ ApiLayer s k 'AddressK
+        , ctx ~ ApiLayer s k 'CredFromKeyK
         , SoftDerivation k
-        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
+        , MkKeyFingerprint k (Proxy n, k 'CredFromKeyK XPub)
         , MkKeyFingerprint k Address
         , WalletKey k
         , HasDBFactory s k ctx
@@ -847,9 +847,9 @@ postWallet ctx generateKey liftKey (WalletOrAccountPostData body) = case body of
 postShelleyWallet
     :: forall ctx s k n.
         ( s ~ SeqState n k
-        , ctx ~ ApiLayer s k 'AddressK
+        , ctx ~ ApiLayer s k 'CredFromKeyK
         , SoftDerivation k
-        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
+        , MkKeyFingerprint k (Proxy n, k 'CredFromKeyK XPub)
         , MkKeyFingerprint k Address
         , WalletKey k
         , HasDBFactory s k ctx
@@ -886,9 +886,9 @@ postShelleyWallet ctx generateKey body = do
 postAccountWallet
     :: forall ctx s k n w.
         ( s ~ SeqState n k
-        , ctx ~ ApiLayer s k 'AddressK
+        , ctx ~ ApiLayer s k 'CredFromKeyK
         , SoftDerivation k
-        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
+        , MkKeyFingerprint k (Proxy n, k 'CredFromKeyK XPub)
         , MkKeyFingerprint k Address
         , WalletKey k
         , HasWorkerRegistry s k ctx
@@ -921,7 +921,7 @@ postAccountWallet ctx mkWallet liftKey coworker body = do
 
 mkShelleyWallet
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , s ~ SeqState n k
         , IsOurs s Address
         , IsOurs s RewardAccount
@@ -1198,7 +1198,7 @@ patchSharedWallet ctx liftKey cred (ApiT wid) body = do
 
 postLegacyWallet
     :: forall ctx s k.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , KnownDiscovery s
         , IsOurs s RewardAccount
         , IsOurs s Address
@@ -1293,7 +1293,7 @@ mkLegacyWallet ctx wid cp meta pending progress = do
 
 postRandomWallet
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , s ~ RndState n
         , k ~ ByronKey
         )
@@ -1313,7 +1313,7 @@ postRandomWallet ctx body = do
 
 postRandomWalletFromXPrv
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , s ~ RndState n
         , k ~ ByronKey
         , HasNetworkLayer IO ctx
@@ -1338,11 +1338,11 @@ postRandomWalletFromXPrv ctx body = do
 
 postIcarusWallet
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , s ~ SeqState n k
         , k ~ IcarusKey
         , HasWorkerRegistry s k ctx
-        , PaymentAddress n IcarusKey 'AddressK
+        , PaymentAddress n IcarusKey 'CredFromKeyK
         , Typeable n
         )
     => ctx
@@ -1361,11 +1361,11 @@ postIcarusWallet ctx body = do
 
 postTrezorWallet
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , s ~ SeqState n k
         , k ~ IcarusKey
         , HasWorkerRegistry s k ctx
-        , PaymentAddress n IcarusKey 'AddressK
+        , PaymentAddress n IcarusKey 'CredFromKeyK
         , Typeable n
         )
     => ctx
@@ -1384,11 +1384,11 @@ postTrezorWallet ctx body = do
 
 postLedgerWallet
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , s ~ SeqState n k
         , k ~ IcarusKey
         , HasWorkerRegistry s k ctx
-        , PaymentAddress n IcarusKey 'AddressK
+        , PaymentAddress n IcarusKey 'CredFromKeyK
         , Typeable n
         )
     => ctx
@@ -1414,8 +1414,8 @@ postLedgerWallet ctx body = do
 -- Since they have identical ids, we actually lookup both contexts in sequence.
 withLegacyLayer
     :: forall byron icarus n a.
-        ( byron ~ ApiLayer (RndState n) ByronKey 'AddressK
-        , icarus ~ ApiLayer (SeqState n IcarusKey) IcarusKey 'AddressK
+        ( byron ~ ApiLayer (RndState n) ByronKey 'CredFromKeyK
+        , icarus ~ ApiLayer (SeqState n IcarusKey) IcarusKey 'CredFromKeyK
         )
     => ApiT WalletId
     -> (byron, Handler a)
@@ -1430,8 +1430,8 @@ withLegacyLayer (ApiT wid) (byron, withByron) (icarus, withIcarus) =
 -- workers.
 withLegacyLayer'
     :: forall byron icarus n a.
-        ( byron ~ ApiLayer (RndState n) ByronKey 'AddressK
-        , icarus ~ ApiLayer (SeqState n IcarusKey) IcarusKey 'AddressK
+        ( byron ~ ApiLayer (RndState n) ByronKey 'CredFromKeyK
+        , icarus ~ ApiLayer (SeqState n IcarusKey) IcarusKey 'CredFromKeyK
         )
     => ApiT WalletId
     -> (byron, Handler a, ErrWalletNotResponding -> Handler a)
@@ -1606,7 +1606,7 @@ putWalletPassphrase ctx createKey getKey (ApiT wid)
 putByronWalletPassphrase
     :: forall ctx s k.
         ( WalletKey k
-        , ctx ~ ApiLayer s k 'AddressK
+        , ctx ~ ApiLayer s k 'CredFromKeyK
         )
     => ctx
     -> ApiT WalletId
@@ -1659,11 +1659,11 @@ getWalletUtxoSnapshot ctx (ApiT wid) = do
 
 selectCoins
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , SoftDerivation k
         , IsOurs s Address
         , GenChange s
-        , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
+        , Bounded (Index (AddressIndexDerivationType k) 'CredFromKeyK)
         , Typeable n
         , Typeable s
         , WalletKey k
@@ -1707,15 +1707,15 @@ selectCoins ctx genChange (ApiT wid) body = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         utx <- liftHandler $
-            W.selectAssets @_ @_ @s @k @'AddressK wrk era pp selectAssetsParams transform
+            W.selectAssets @_ @_ @s @k @'CredFromKeyK wrk era pp selectAssetsParams transform
         pure $ mkApiCoinSelection [] [] Nothing md utx
 
 selectCoinsForJoin
     :: forall ctx s n k.
         ( s ~ SeqState n k
-        , ctx ~ ApiLayer s k 'AddressK
-        , DelegationAddress n k 'AddressK
-        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
+        , ctx ~ ApiLayer s k 'CredFromKeyK
+        , DelegationAddress n k 'CredFromKeyK
+        , MkKeyFingerprint k (Proxy n, k 'CredFromKeyK XPub)
         , SoftDerivation k
         , Typeable n
         , Typeable s
@@ -1761,7 +1761,7 @@ selectCoinsForJoin ctx knownPools getPoolStatus pid wid = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         utx <- liftHandler
-            $ W.selectAssets @_ @_ @s @k @'AddressK wrk era pp selectAssetsParams transform
+            $ W.selectAssets @_ @_ @s @k @'CredFromKeyK wrk era pp selectAssetsParams transform
         (_, _, path) <- liftHandler
             $ W.readRewardAccount @_ @s @k @n wrk wid
 
@@ -1772,10 +1772,10 @@ selectCoinsForJoin ctx knownPools getPoolStatus pid wid = do
 selectCoinsForQuit
     :: forall ctx s n k.
         ( s ~ SeqState n k
-        , ctx ~ ApiLayer s k 'AddressK
-        , DelegationAddress n k 'AddressK
-        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
-        , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
+        , ctx ~ ApiLayer s k 'CredFromKeyK
+        , DelegationAddress n k 'CredFromKeyK
+        , MkKeyFingerprint k (Proxy n, k 'CredFromKeyK XPub)
+        , Bounded (Index (AddressIndexDerivationType k) 'CredFromKeyK)
         , SoftDerivation k
         , Typeable n
         , Typeable s
@@ -1818,7 +1818,7 @@ selectCoinsForQuit ctx (ApiT wid) = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         utx <- liftHandler
-            $ W.selectAssets @_ @_ @s @k @'AddressK wrk era pp selectAssetsParams transform
+            $ W.selectAssets @_ @_ @s @k @'CredFromKeyK wrk era pp selectAssetsParams transform
         (_, _, path) <- liftHandler $ W.readRewardAccount @_ @s @k @n wrk wid
 
         pure $ mkApiCoinSelection [] [refund] (Just (action, path)) Nothing utx
@@ -1839,7 +1839,7 @@ newtype ErrListAssets = ErrListAssetsNoSuchWallet ErrNoSuchWallet
 -- available). This list may include assets which have already been spent.
 listAssets
     :: forall ctx s k.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , IsOurs s Address
         , HasTokenMetadataClient ctx
         )
@@ -1905,8 +1905,8 @@ postRandomAddress
     :: forall ctx s k n.
         ( s ~ RndState n
         , k ~ ByronKey
-        , ctx ~ ApiLayer s k 'AddressK
-        , PaymentAddress n ByronKey 'AddressK
+        , ctx ~ ApiLayer s k 'CredFromKeyK
+        , PaymentAddress n ByronKey 'CredFromKeyK
         )
     => ctx
     -> ApiT WalletId
@@ -1926,7 +1926,7 @@ putRandomAddress
     :: forall ctx s k n.
         ( s ~ RndState n
         , k ~ ByronKey
-        , ctx ~ ApiLayer s k 'AddressK
+        , ctx ~ ApiLayer s k 'CredFromKeyK
         )
     => ctx
     -> ApiT WalletId
@@ -1941,7 +1941,7 @@ putRandomAddresses
     :: forall ctx s k n.
         ( s ~ RndState n
         , k ~ ByronKey
-        , ctx ~ ApiLayer s k 'AddressK
+        , ctx ~ ApiLayer s k 'CredFromKeyK
         )
     => ctx
     -> ApiT WalletId
@@ -1984,7 +1984,7 @@ listAddresses ctx normalize (ApiT wid) stateFilter = do
 signTransaction
     :: forall ctx s k ktype.
         ( ctx ~ ApiLayer s k ktype
-        , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
+        , Bounded (Index (AddressIndexDerivationType k) 'CredFromKeyK)
         , WalletKey k
         , IsOwned s k ktype
         , HardDerivation k
@@ -2032,12 +2032,12 @@ signTransaction ctx (ApiT wid) body = do
 
 postTransactionOld
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k 'AddressK
-        , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
+        , Bounded (Index (AddressIndexDerivationType k) 'CredFromKeyK)
         , GenChange s
         , HardDerivation k
         , HasNetworkLayer IO ctx
-        , IsOwned s k 'AddressK
+        , IsOwned s k 'CredFromKeyK
         , Typeable n
         , Typeable s
         , WalletKey k
@@ -2087,7 +2087,7 @@ postTransactionOld ctx genChange (ApiT wid) body = do
                     , selectionStrategy = SelectionStrategyOptimal
                     }
             sel <- liftHandler
-                $ W.selectAssets @_ @_ @s @k @'AddressK
+                $ W.selectAssets @_ @_ @s @k @'CredFromKeyK
                     wrk era pp selectAssetsParams
                 $ const Prelude.id
             sel' <- liftHandler
@@ -2123,7 +2123,7 @@ postTransactionOld ctx genChange (ApiT wid) body = do
     ti = timeInterpreter (ctx ^. networkLayer)
 
 deleteTransaction
-    :: forall ctx s k. ctx ~ ApiLayer s k 'AddressK
+    :: forall ctx s k. ctx ~ ApiLayer s k 'CredFromKeyK
     => ctx
     -> ApiT WalletId
     -> ApiTxId
@@ -2134,7 +2134,7 @@ deleteTransaction ctx (ApiT wid) (ApiTxId (ApiT (tid))) = do
     return NoContent
 
 listTransactions
-    :: forall ctx s k n. (ctx ~ ApiLayer s k 'AddressK)
+    :: forall ctx s k n. (ctx ~ ApiLayer s k 'CredFromKeyK)
     => ctx
     -> ApiT WalletId
     -> Maybe MinWithdrawal
@@ -2166,7 +2166,7 @@ listTransactions
     defaultSortOrder = Descending
 
 getTransaction
-    :: forall ctx s k n. (ctx ~ ApiLayer s k 'AddressK)
+    :: forall ctx s k n. (ctx ~ ApiLayer s k 'CredFromKeyK)
     => ctx
     -> ApiT WalletId
     -> ApiTxId
@@ -2225,8 +2225,8 @@ mkApiTransactionFromInfo ti deposit info metadataSchema = do
 
 postTransactionFeeOld
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k 'AddressK
-        , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
+        , Bounded (Index (AddressIndexDerivationType k) 'CredFromKeyK)
         , HardDerivation k
         , Typeable n
         , Typeable s
@@ -2268,15 +2268,15 @@ postTransactionFeeOld ctx (ApiT wid) body = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         let runSelection =
-                W.selectAssets @_ @_ @s @k @'AddressK
+                W.selectAssets @_ @_ @s @k @'CredFromKeyK
                   wrk era pp selectAssetsParams getFee
-        minCoins <- liftIO (W.calcMinimumCoinValues @_ @k @'AddressK wrk era (F.toList outs))
+        minCoins <- liftIO (W.calcMinimumCoinValues @_ @k @'CredFromKeyK wrk era (F.toList outs))
         liftHandler $ mkApiFee Nothing minCoins <$> W.estimateFee runSelection
 
 constructTransaction
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k 'AddressK
-        , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
+        , Bounded (Index (AddressIndexDerivationType k) 'CredFromKeyK)
         , GenChange s
         , HardDerivation k
         , HasNetworkLayer IO ctx
@@ -2478,7 +2478,7 @@ constructTransaction ctx genChange knownPools getPoolStatus (ApiT wid) body = do
                 pure (txCtx, Nothing)
 
         let runSelection outs =
-                W.selectAssets @_ @_ @s @k @'AddressK
+                W.selectAssets @_ @_ @s @k @'CredFromKeyK
                   wrk era pp selectAssetsParams transform
               where
                 selectAssetsParams = W.SelectAssetsParams
@@ -2788,7 +2788,7 @@ decodeSharedTransaction ctx (ApiT wid) (ApiSerialisedTransaction (ApiT sealed) _
 
 balanceTransaction
     :: forall ctx s k (n :: NetworkDiscriminant).
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , HasNetworkLayer IO ctx
         , GenChange s
         , BoundedAddressLength k
@@ -2824,7 +2824,7 @@ balanceTransaction ctx genChange (ApiT wid) body = do
                 => W.PartialTx era
                 -> Handler (Cardano.Tx era)
             balanceTx partialTx =
-                liftHandler $ W.balanceTransaction @_ @IO @s @k @'AddressK
+                liftHandler $ W.balanceTransaction @_ @IO @s @k @'CredFromKeyK
                     wrk
                     genChange
                     (pp, nodePParams)
@@ -2855,7 +2855,7 @@ balanceTransaction ctx genChange (ApiT wid) body = do
 
 decodeTransaction
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , IsOurs s Address
         , Typeable s
         , Typeable n
@@ -2927,7 +2927,7 @@ decodeTransaction ctx (ApiT wid) (ApiSerialisedTransaction (ApiT sealed) _) = do
         , validityInterval = interval
         }
   where
-    tl = ctx ^. W.transactionLayer @k @'AddressK
+    tl = ctx ^. W.transactionLayer @k @'CredFromKeyK
     nl = ctx ^. W.networkLayer @IO
 
     policyIx = ApiT $ DerivationIndex $
@@ -3058,9 +3058,9 @@ toOut ((TxOut addr (TokenBundle (Coin c) tmap)), (Just path)) =
 
 submitTransaction
     :: forall ctx s k (n :: NetworkDiscriminant).
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , HasNetworkLayer IO ctx
-        , IsOwned s k 'AddressK
+        , IsOwned s k 'CredFromKeyK
         , Typeable s
         , Typeable n
         )
@@ -3123,7 +3123,7 @@ submitTransaction ctx apiw@(ApiT wid) apitx = do
             $ W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
     return $ ApiTxId (apiDecoded ^. #id)
   where
-    tl = ctx ^. W.transactionLayer @k @'AddressK
+    tl = ctx ^. W.transactionLayer @k @'CredFromKeyK
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
     nl = ctx ^. networkLayer
     ti = timeInterpreter nl
@@ -3180,12 +3180,12 @@ submitTransaction ctx apiw@(ApiT wid) apitx = do
 
 joinStakePool
     :: forall ctx s n k.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , s ~ SeqState n k
         , AddressIndexDerivationType k ~ 'Soft
-        , DelegationAddress n k 'AddressK
+        , DelegationAddress n k 'CredFromKeyK
         , GenChange s
-        , IsOwned s k 'AddressK
+        , IsOwned s k 'CredFromKeyK
         , SoftDerivation k
         , Typeable n
         , Typeable s
@@ -3244,7 +3244,7 @@ joinStakePool ctx knownPools getPoolStatus apiPoolId (ApiT wid) body = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         sel <- liftHandler
-            $ W.selectAssets @_ @_ @s @k @'AddressK wrk era pp selectAssetsParams
+            $ W.selectAssets @_ @_ @s @k @'CredFromKeyK wrk era pp selectAssetsParams
             $ const Prelude.id
         sel' <- liftHandler
             $ W.assignChangeAddressesAndUpdateDb wrk wid genChange sel
@@ -3284,7 +3284,7 @@ joinStakePool ctx knownPools getPoolStatus apiPoolId (ApiT wid) body = do
 delegationFee
     :: forall ctx s n k.
         ( s ~ SeqState n k
-        , ctx ~ ApiLayer s k 'AddressK
+        , ctx ~ ApiLayer s k 'CredFromKeyK
         , BoundedAddressLength k
         )
     => ctx
@@ -3304,7 +3304,7 @@ delegationFee ctx (ApiT wid) = do
     txCtx = defaultTransactionCtx
 
     runSelection wrk era pp _deposit (utxoAvailable, wallet, pendingTxs) =
-        W.selectAssets @_ @_ @s @k @'AddressK wrk era pp selectAssetsParams calcFee
+        W.selectAssets @_ @_ @s @k @'CredFromKeyK wrk era pp selectAssetsParams calcFee
       where
         calcFee _ = selectionDelta TokenBundle.getCoin
         selectAssetsParams = W.SelectAssetsParams
@@ -3320,13 +3320,13 @@ delegationFee ctx (ApiT wid) = do
 
 quitStakePool
     :: forall ctx s n k.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , s ~ SeqState n k
         , AddressIndexDerivationType k ~ 'Soft
-        , DelegationAddress n k 'AddressK
+        , DelegationAddress n k 'CredFromKeyK
         , GenChange s
         , HasNetworkLayer IO ctx
-        , IsOwned s k 'AddressK
+        , IsOwned s k 'CredFromKeyK
         , SoftDerivation k
         , Typeable n
         , Typeable s
@@ -3370,7 +3370,7 @@ quitStakePool ctx (ApiT wid) body = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         sel <- liftHandler
-            $ W.selectAssets @_ @_ @s @k @'AddressK wrk era pp selectAssetsParams
+            $ W.selectAssets @_ @_ @s @k @'CredFromKeyK wrk era pp selectAssetsParams
             $ const Prelude.id
         sel' <- liftHandler
             $ W.assignChangeAddressesAndUpdateDb wrk wid genChange sel
@@ -3473,7 +3473,7 @@ listStakeKeys' utxo lookupStakeRef fetchRewards ourKeysWithInfo = do
 
 listStakeKeys
     :: forall ctx s n k.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , s ~ SeqState n k
         , HasNetworkLayer IO ctx
         , Typeable n
@@ -3511,10 +3511,10 @@ listStakeKeys lookupStakeRef ctx (ApiT wid) = do
 
 createMigrationPlan
     :: forall ctx n s k.
-        ( ctx ~ ApiLayer s k 'AddressK
-        , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
+        , Bounded (Index (AddressIndexDerivationType k) 'CredFromKeyK)
         , HardDerivation k
-        , IsOwned s k 'AddressK
+        , IsOwned s k 'CredFromKeyK
         , Typeable n
         , Typeable s
         , WalletKey k
@@ -3606,11 +3606,11 @@ mkApiWalletMigrationPlan s addresses rewardWithdrawal plan =
 
 migrateWallet
     :: forall ctx s k n p.
-        ( ctx ~ ApiLayer s k 'AddressK
-        , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
+        , Bounded (Index (AddressIndexDerivationType k) 'CredFromKeyK)
         , HardDerivation k
         , HasNetworkLayer IO ctx
-        , IsOwned s k 'AddressK
+        , IsOwned s k 'CredFromKeyK
         , Typeable n
         , Typeable s
         , WalletKey k
@@ -3794,7 +3794,7 @@ postExternalTransaction ctx (ApiT sealed) = do
 
 signMetadata
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , s ~ SeqState n k
         , HardDerivation k
         , AddressIndexDerivationType k ~ 'Soft
@@ -3891,7 +3891,7 @@ getAccountPublicKey ctx mkAccount (ApiT wid) extended = do
 
 getPolicyKey
     :: forall ctx s k (n :: NetworkDiscriminant).
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , Typeable s
         , Typeable n
         )
@@ -3906,7 +3906,7 @@ getPolicyKey ctx (ApiT wid) hashed = do
 
 postPolicyKey
     :: forall ctx s (n :: NetworkDiscriminant).
-        ( ctx ~ ApiLayer s ShelleyKey 'AddressK
+        ( ctx ~ ApiLayer s ShelleyKey 'CredFromKeyK
         , s ~ SeqState n ShelleyKey
         )
     => ctx
@@ -3923,7 +3923,7 @@ postPolicyKey ctx (ApiT wid) hashed apiPassphrase =
 
 postPolicyId
     :: forall ctx s k (n :: NetworkDiscriminant).
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , WalletKey k
         , Typeable s
         , Typeable n
@@ -3956,7 +3956,7 @@ postPolicyId ctx (ApiT wid) payload = do
 -- XPrv), necessary to derive new change addresses.
 rndStateChange
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , s ~ RndState n
         , k ~ ByronKey
         )
@@ -3975,10 +3975,10 @@ type RewardAccountBuilder k
 
 mkRewardAccountBuilder
     :: forall ctx s k (n :: NetworkDiscriminant) shelley.
-        ( ctx ~ ApiLayer s k 'AddressK
+        ( ctx ~ ApiLayer s k 'CredFromKeyK
         , shelley ~ SeqState n ShelleyKey
         , HardDerivation k
-        , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
+        , Bounded (Index (AddressIndexDerivationType k) 'CredFromKeyK)
         , WalletKey k
         , Typeable s
         , Typeable n
@@ -4004,12 +4004,12 @@ mkRewardAccountBuilder ctx wid withdrawal = do
                 (acct, _, path) <- liftHandler $ W.readRewardAccount @_ @s @k @n wrk wid
                 wdrl <- liftHandler $ W.queryRewardBalance @_ wrk acct
                 (, selfRewardCredentials) . WithdrawalSelf acct path
-                    <$> liftIO (W.readNextWithdrawal @_ @k @'AddressK wrk era wdrl)
+                    <$> liftIO (W.readNextWithdrawal @_ @k @'CredFromKeyK wrk era wdrl)
 
             (Just Refl, Just (ExternalWithdrawal (ApiMnemonicT mw))) -> do
                 let (xprv, acct, path) = W.someRewardAccount @ShelleyKey mw
                 wdrl <- liftHandler (W.queryRewardBalance @_ wrk acct)
-                    >>= liftIO . W.readNextWithdrawal @_ @k @'AddressK wrk era
+                    >>= liftIO . W.readNextWithdrawal @_ @k @'CredFromKeyK wrk era
                 when (wdrl == Coin 0) $ do
                     liftHandler $ throwE ErrWithdrawalNotWorth
                 pure (WithdrawalExternal acct path wdrl, const (xprv, mempty))

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -819,7 +819,7 @@ type MkApiWallet ctx s w
 postWallet
     :: forall ctx s k n.
         ( s ~ SeqState n k
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k 'AddressK
         , SoftDerivation k
         , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
         , MkKeyFingerprint k Address
@@ -848,7 +848,7 @@ postWallet ctx generateKey liftKey (WalletOrAccountPostData body) = case body of
 postShelleyWallet
     :: forall ctx s k n.
         ( s ~ SeqState n k
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k 'AddressK
         , SoftDerivation k
         , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
         , MkKeyFingerprint k Address
@@ -887,7 +887,7 @@ postShelleyWallet ctx generateKey body = do
 postAccountWallet
     :: forall ctx s k n w.
         ( s ~ SeqState n k
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k 'AddressK
         , SoftDerivation k
         , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
         , MkKeyFingerprint k Address
@@ -922,7 +922,7 @@ postAccountWallet ctx mkWallet liftKey coworker body = do
 
 mkShelleyWallet
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , s ~ SeqState n k
         , IsOurs s Address
         , IsOurs s RewardAccount
@@ -1007,9 +1007,9 @@ toApiWalletDelegation W.WalletDelegation{active,next} ti = do
 postSharedWallet
     :: forall ctx s k n.
         ( s ~ SharedState n k
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k 'ScriptK
         , SoftDerivation k
-        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
+        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub) --TODO ADP-1850
         , MkKeyFingerprint k Address
         , WalletKey k
         , HasDBFactory s k ctx
@@ -1032,9 +1032,9 @@ postSharedWallet ctx generateKey liftKey postData =
 postSharedWalletFromRootXPrv
     :: forall ctx s k n.
         ( s ~ SharedState n k
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k 'ScriptK
         , SoftDerivation k
-        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
+        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub) --TODO ADP-1850
         , MkKeyFingerprint k Address
         , WalletKey k
         , HasDBFactory s k ctx
@@ -1078,9 +1078,9 @@ postSharedWalletFromRootXPrv ctx generateKey body = do
 postSharedWalletFromAccountXPub
     :: forall ctx s k n.
         ( s ~ SharedState n k
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k 'ScriptK
         , SoftDerivation k
-        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
+        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub) --TODO 1850
         , MkKeyFingerprint k Address
         , WalletKey k
         , HasDBFactory s k ctx
@@ -1125,7 +1125,7 @@ scriptTemplateFromSelf xpub (ApiScriptTemplateEntry cosigners' template') =
 
 mkSharedWallet
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'ScriptK
         , s ~ SharedState n k
         , HasWorkerRegistry s k ctx
         , Shared.SupportsDiscovery n k
@@ -1183,9 +1183,9 @@ mkSharedWallet ctx wid cp meta pending progress = case Shared.ready st of
 patchSharedWallet
     :: forall ctx s k n.
         ( s ~ SharedState n k
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k 'ScriptK
         , SoftDerivation k
-        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
+        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub) --TODO 1850
         , MkKeyFingerprint k Address
         , WalletKey k
         , HasDBFactory s k ctx
@@ -1211,7 +1211,7 @@ patchSharedWallet ctx liftKey cred (ApiT wid) body = do
 
 postLegacyWallet
     :: forall ctx s k.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , KnownDiscovery s
         , IsOurs s RewardAccount
         , IsOurs s Address
@@ -1306,7 +1306,7 @@ mkLegacyWallet ctx wid cp meta pending progress = do
 
 postRandomWallet
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , s ~ RndState n
         , k ~ ByronKey
         )
@@ -1326,7 +1326,7 @@ postRandomWallet ctx body = do
 
 postRandomWalletFromXPrv
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , s ~ RndState n
         , k ~ ByronKey
         , HasNetworkLayer IO ctx
@@ -1351,7 +1351,7 @@ postRandomWalletFromXPrv ctx body = do
 
 postIcarusWallet
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , s ~ SeqState n k
         , k ~ IcarusKey
         , HasWorkerRegistry s k ctx
@@ -1374,7 +1374,7 @@ postIcarusWallet ctx body = do
 
 postTrezorWallet
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , s ~ SeqState n k
         , k ~ IcarusKey
         , HasWorkerRegistry s k ctx
@@ -1397,7 +1397,7 @@ postTrezorWallet ctx body = do
 
 postLedgerWallet
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , s ~ SeqState n k
         , k ~ IcarusKey
         , HasWorkerRegistry s k ctx
@@ -1427,8 +1427,8 @@ postLedgerWallet ctx body = do
 -- Since they have identical ids, we actually lookup both contexts in sequence.
 withLegacyLayer
     :: forall byron icarus n a.
-        ( byron ~ ApiLayer (RndState n) ByronKey
-        , icarus ~ ApiLayer (SeqState n IcarusKey) IcarusKey
+        ( byron ~ ApiLayer (RndState n) ByronKey 'AddressK
+        , icarus ~ ApiLayer (SeqState n IcarusKey) IcarusKey 'AddressK
         )
     => ApiT WalletId
     -> (byron, Handler a)
@@ -1443,8 +1443,8 @@ withLegacyLayer (ApiT wid) (byron, withByron) (icarus, withIcarus) =
 -- workers.
 withLegacyLayer'
     :: forall byron icarus n a.
-        ( byron ~ ApiLayer (RndState n) ByronKey
-        , icarus ~ ApiLayer (SeqState n IcarusKey) IcarusKey
+        ( byron ~ ApiLayer (RndState n) ByronKey 'AddressK
+        , icarus ~ ApiLayer (SeqState n IcarusKey) IcarusKey 'AddressK
         )
     => ApiT WalletId
     -> (byron, Handler a, ErrWalletNotResponding -> Handler a)
@@ -1478,8 +1478,8 @@ withLegacyLayer' (ApiT wid)
 -------------------------------------------------------------------------------}
 
 deleteWallet
-    :: forall ctx s k.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype.
+        ( ctx ~ ApiLayer s k ktype
         )
     => ctx
     -> ApiT WalletId
@@ -1498,8 +1498,8 @@ deleteWallet ctx (ApiT wid) = do
     df = ctx ^. dbFactory @s @k
 
 getWallet
-    :: forall ctx s k apiWallet.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype apiWallet.
+        ( ctx ~ ApiLayer s k ktype
         , HasWorkerRegistry s k ctx
         , HasDBFactory s k ctx
         )
@@ -1523,8 +1523,8 @@ getWallet ctx mkApiWallet (ApiT wid) = do
         (, meta ^. #creationTime) <$> mkApiWallet ctx wid cp meta pending NotResponding
 
 listWallets
-    :: forall ctx s k apiWallet.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype apiWallet.
+        ( ctx ~ ApiLayer s k ktype
         , NFData apiWallet
         )
     => ctx
@@ -1550,8 +1550,8 @@ listWallets ctx mkApiWallet = do
         . getWallet ctx mkApiWallet
 
 putWallet
-    :: forall ctx s k apiWallet.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype apiWallet.
+        ( ctx ~ ApiLayer s k ktype
         )
     => ctx
     -> MkApiWallet ctx s apiWallet
@@ -1570,9 +1570,9 @@ putWallet ctx mkApiWallet (ApiT wid) body = do
     modify wName meta = meta { name = wName }
 
 putWalletPassphrase
-    :: forall ctx s k.
+    :: forall ctx s k ktype.
         ( WalletKey k
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k ktype
         , GetAccount s k
         , HardDerivation k)
     => ctx
@@ -1613,13 +1613,13 @@ putWalletPassphrase ctx createKey getKey (ApiT wid)
                     $ ErrUpdatePassphraseWithRootKey
                     $ ErrWithRootKeyWrongMnemonic wid
     where
-        withWrk :: (WorkerCtx (ApiLayer s k) -> Handler a) -> Handler a
+        withWrk :: (WorkerCtx (ApiLayer s k ktype) -> Handler a) -> Handler a
         withWrk = withWorkerCtx ctx wid liftE liftE
 
 putByronWalletPassphrase
     :: forall ctx s k.
         ( WalletKey k
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k 'AddressK
         )
     => ctx
     -> ApiT WalletId
@@ -1633,8 +1633,8 @@ putByronWalletPassphrase ctx (ApiT wid) body = do
     return NoContent
 
 getUTxOsStatistics
-    :: forall ctx s k.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype.
+        ( ctx ~ ApiLayer s k ktype
         )
     => ctx
     -> ApiT WalletId
@@ -1645,13 +1645,13 @@ getUTxOsStatistics ctx (ApiT wid) = do
     return $ toApiUtxoStatistics stats
 
 getWalletUtxoSnapshot
-    :: forall ctx s k. (ctx ~ ApiLayer s k)
+    :: forall ctx s k ktype. (ctx ~ ApiLayer s k ktype)
     => ctx
     -> ApiT WalletId
     -> Handler ApiWalletUtxoSnapshot
 getWalletUtxoSnapshot ctx (ApiT wid) = do
     entries <- withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $
-        W.getWalletUtxoSnapshot wrk wid
+        W.getWalletUtxoSnapshot @_ @_ @_ @ktype wrk wid
     return $ mkApiWalletUtxoSnapshot entries
   where
     mkApiWalletUtxoSnapshot :: [(TokenBundle, Coin)] -> ApiWalletUtxoSnapshot
@@ -1672,7 +1672,7 @@ getWalletUtxoSnapshot ctx (ApiT wid) = do
 
 selectCoins
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , SoftDerivation k
         , IsOurs s Address
         , GenChange s
@@ -1720,13 +1720,13 @@ selectCoins ctx genChange (ApiT wid) body = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         utx <- liftHandler $
-            W.selectAssets @_ @_ @s @k wrk era pp selectAssetsParams transform
+            W.selectAssets @_ @_ @s @k @'AddressK wrk era pp selectAssetsParams transform
         pure $ mkApiCoinSelection [] [] Nothing md utx
 
 selectCoinsForJoin
     :: forall ctx s n k.
         ( s ~ SeqState n k
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k 'AddressK
         , DelegationAddress n k
         , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
         , SoftDerivation k
@@ -1774,7 +1774,7 @@ selectCoinsForJoin ctx knownPools getPoolStatus pid wid = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         utx <- liftHandler
-            $ W.selectAssets @_ @_ @s @k wrk era pp selectAssetsParams transform
+            $ W.selectAssets @_ @_ @s @k @'AddressK wrk era pp selectAssetsParams transform
         (_, _, path) <- liftHandler
             $ W.readRewardAccount @_ @s @k @n wrk wid
 
@@ -1785,7 +1785,7 @@ selectCoinsForJoin ctx knownPools getPoolStatus pid wid = do
 selectCoinsForQuit
     :: forall ctx s n k.
         ( s ~ SeqState n k
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k 'AddressK
         , DelegationAddress n k
         , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
         , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
@@ -1831,7 +1831,7 @@ selectCoinsForQuit ctx (ApiT wid) = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         utx <- liftHandler
-            $ W.selectAssets @_ @_ @s @k wrk era pp selectAssetsParams transform
+            $ W.selectAssets @_ @_ @s @k @'AddressK wrk era pp selectAssetsParams transform
         (_, _, path) <- liftHandler $ W.readRewardAccount @_ @s @k @n wrk wid
 
         pure $ mkApiCoinSelection [] [refund] (Just (action, path)) Nothing utx
@@ -1852,7 +1852,7 @@ newtype ErrListAssets = ErrListAssetsNoSuchWallet ErrNoSuchWallet
 -- available). This list may include assets which have already been spent.
 listAssets
     :: forall ctx s k.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , IsOurs s Address
         , HasTokenMetadataClient ctx
         )
@@ -1868,8 +1868,8 @@ listAssets ctx wid = do
 -- | Return a list of all AssetIds involved in the transaction history of this
 -- wallet.
 listAssetsBase
-    :: forall s k. IsOurs s Address =>
-    ApiLayer s k -> ApiT WalletId -> Handler (Set AssetId)
+    :: forall s k ktype. IsOurs s Address =>
+    ApiLayer s k ktype -> ApiT WalletId -> Handler (Set AssetId)
 listAssetsBase ctx (ApiT wallet) =
     withWorkerCtx ctx wallet liftE liftE $ \wctx ->
         liftHandler $ W.listAssets wctx wallet
@@ -1879,8 +1879,8 @@ listAssetsBase ctx (ApiT wallet) =
 -- NOTE: This is slightly inefficient because it greps through the transaction
 -- history to check if the asset is associated with this wallet.
 getAsset
-    :: forall ctx s k.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype.
+        ( ctx ~ ApiLayer s k ktype
         , IsOurs s Address
         , HasTokenMetadataClient ctx
         )
@@ -1899,8 +1899,8 @@ getAsset ctx wid (ApiT policyId) (ApiT assetName) = do
 
 -- | The handler for 'getAsset' when 'TokenName' is empty.
 getAssetDefault
-    :: forall ctx s k.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype.
+        ( ctx ~ ApiLayer s k ktype
         , IsOurs s Address
         , HasTokenMetadataClient ctx
         )
@@ -1918,7 +1918,7 @@ postRandomAddress
     :: forall ctx s k n.
         ( s ~ RndState n
         , k ~ ByronKey
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k 'AddressK
         , PaymentAddress n ByronKey
         )
     => ctx
@@ -1939,7 +1939,7 @@ putRandomAddress
     :: forall ctx s k n.
         ( s ~ RndState n
         , k ~ ByronKey
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k 'AddressK
         )
     => ctx
     -> ApiT WalletId
@@ -1954,7 +1954,7 @@ putRandomAddresses
     :: forall ctx s k n.
         ( s ~ RndState n
         , k ~ ByronKey
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k 'AddressK
         )
     => ctx
     -> ApiT WalletId
@@ -1968,8 +1968,8 @@ putRandomAddresses ctx (ApiT wid) (ApiPutAddressesData addrs)  = do
     addrs' = map (getApiT . fst) addrs
 
 listAddresses
-    :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype n.
+        ( ctx ~ ApiLayer s k ktype
         , CompareDiscovery s
         , KnownAddresses s
         )
@@ -1996,7 +1996,7 @@ listAddresses ctx normalize (ApiT wid) stateFilter = do
 
 signTransaction
     :: forall ctx s k.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
         , WalletKey k
         , IsOwned s k
@@ -2012,7 +2012,7 @@ signTransaction ctx (ApiT wid) body = do
     sealedTx' <- withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $ do
         let
             db = wrk ^. W.dbLayer @IO @s @k
-            tl = wrk ^. W.transactionLayer @k
+            tl = wrk ^. W.transactionLayer @k @'AddressK
             nl = wrk ^. W.networkLayer
         db & \W.DBLayer{atomically, readCheckpoint} -> do
             W.withRootKey @_ @s wrk wid pwd ErrWitnessTxWithRootKey $ \rootK scheme -> do
@@ -2045,7 +2045,7 @@ signTransaction ctx (ApiT wid) body = do
 
 postTransactionOld
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
         , GenChange s
         , HardDerivation k
@@ -2100,13 +2100,14 @@ postTransactionOld ctx genChange (ApiT wid) body = do
                     , selectionStrategy = SelectionStrategyOptimal
                     }
             sel <- liftHandler
-                $ W.selectAssets @_ @_ @s @k wrk era pp selectAssetsParams
+                $ W.selectAssets @_ @_ @s @k @'AddressK
+                    wrk era pp selectAssetsParams
                 $ const Prelude.id
             sel' <- liftHandler
                 $ W.assignChangeAddressesAndUpdateDb wrk wid genChange sel
             (tx, txMeta, txTime, sealedTx) <- liftHandler
-                $ W.buildAndSignTransaction
-                    @_ @s @k wrk wid era mkRwdAcct pwd txCtx sel'
+                $ W.buildAndSignTransaction @_ @s @k @'AddressK
+                    wrk wid era mkRwdAcct pwd txCtx sel'
             liftHandler
                 $ W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
             pure (sel, tx, txMeta, txTime, pp)
@@ -2135,7 +2136,7 @@ postTransactionOld ctx genChange (ApiT wid) body = do
     ti = timeInterpreter (ctx ^. networkLayer)
 
 deleteTransaction
-    :: forall ctx s k. ctx ~ ApiLayer s k
+    :: forall ctx s k. ctx ~ ApiLayer s k 'AddressK
     => ctx
     -> ApiT WalletId
     -> ApiTxId
@@ -2146,7 +2147,7 @@ deleteTransaction ctx (ApiT wid) (ApiTxId (ApiT (tid))) = do
     return NoContent
 
 listTransactions
-    :: forall ctx s k n. (ctx ~ ApiLayer s k)
+    :: forall ctx s k n. (ctx ~ ApiLayer s k 'AddressK)
     => ctx
     -> ApiT WalletId
     -> Maybe MinWithdrawal
@@ -2178,7 +2179,7 @@ listTransactions
     defaultSortOrder = Descending
 
 getTransaction
-    :: forall ctx s k n. (ctx ~ ApiLayer s k)
+    :: forall ctx s k n. (ctx ~ ApiLayer s k 'AddressK)
     => ctx
     -> ApiT WalletId
     -> ApiTxId
@@ -2237,7 +2238,7 @@ mkApiTransactionFromInfo ti deposit info metadataSchema = do
 
 postTransactionFeeOld
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
         , HardDerivation k
         , Typeable n
@@ -2280,13 +2281,14 @@ postTransactionFeeOld ctx (ApiT wid) body = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         let runSelection =
-                W.selectAssets @_ @_ @s @k wrk era pp selectAssetsParams getFee
-        minCoins <- liftIO (W.calcMinimumCoinValues @_ @k wrk era (F.toList outs))
+                W.selectAssets @_ @_ @s @k @'AddressK
+                  wrk era pp selectAssetsParams getFee
+        minCoins <- liftIO (W.calcMinimumCoinValues @_ @k @'AddressK wrk era (F.toList outs))
         liftHandler $ mkApiFee Nothing minCoins <$> W.estimateFee runSelection
 
 constructTransaction
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
         , GenChange s
         , HardDerivation k
@@ -2489,7 +2491,8 @@ constructTransaction ctx genChange knownPools getPoolStatus (ApiT wid) body = do
                 pure (txCtx, Nothing)
 
         let runSelection outs =
-                W.selectAssets @_ @_ @s @k wrk era pp selectAssetsParams transform
+                W.selectAssets @_ @_ @s @k @'AddressK
+                  wrk era pp selectAssetsParams transform
               where
                 selectAssetsParams = W.SelectAssetsParams
                     { outputs = outs
@@ -2628,7 +2631,7 @@ constructSharedTransaction
     :: forall ctx s k n.
         ( k ~ SharedKey
         , s ~ SharedState n k
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k 'ScriptK
         , GenChange s
         , HasNetworkLayer IO ctx
         , IsOurs s Address
@@ -2687,7 +2690,7 @@ constructSharedTransaction
                 (utxoAvailable, wallet, pendingTxs) <-
                     liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk wid
 
-                let runSelection outs = W.selectAssets @_ @_ @s @k
+                let runSelection outs = W.selectAssets @_ @_ @s @k @'ScriptK
                         wrk era pp selectAssetsParams transform
                       where
                         selectAssetsParams = W.SelectAssetsParams
@@ -2731,7 +2734,7 @@ constructSharedTransaction
 
 signSharedTransaction
     :: forall ctx s k.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'ScriptK
         , WalletKey k
         )
     => ctx
@@ -2745,7 +2748,7 @@ signSharedTransaction _ctx (ApiT _wid) _body = do
     sealedTx' <- withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $ do
         let
             db = wrk ^. W.dbLayer @IO @s @k
-            tl = wrk ^. W.transactionLayer @k
+            tl = wrk ^. W.transactionLayer @k 'ScriptK
             nl = wrk ^. W.networkLayer
         db & \W.DBLayer{atomically, readCheckpoint} -> do
             W.withRootKey @_ @s wrk wid pwd ErrWitnessTxWithRootKey $ \rootK scheme -> do
@@ -2778,7 +2781,7 @@ signSharedTransaction _ctx (ApiT _wid) _body = do
 --}
 decodeSharedTransaction
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'ScriptK
         , IsOurs s Address
         , HasNetworkLayer IO ctx
         )
@@ -2834,7 +2837,7 @@ decodeSharedTransaction ctx (ApiT wid) (ApiSerialisedTransaction (ApiT sealed) _
         , validityInterval = interval
         }
   where
-    tl = ctx ^. W.transactionLayer @k
+    tl = ctx ^. W.transactionLayer @k @'ScriptK
     nl = ctx ^. W.networkLayer @IO
 
     emptyApiAssetMntBurn = ApiAssetMintBurn
@@ -2845,7 +2848,7 @@ decodeSharedTransaction ctx (ApiT wid) (ApiSerialisedTransaction (ApiT sealed) _
 
 balanceTransaction
     :: forall ctx s k (n :: NetworkDiscriminant).
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , HasNetworkLayer IO ctx
         , GenChange s
         , BoundedAddressLength k
@@ -2881,7 +2884,7 @@ balanceTransaction ctx genChange (ApiT wid) body = do
                 => W.PartialTx era
                 -> Handler (Cardano.Tx era)
             balanceTx partialTx =
-                liftHandler $ W.balanceTransaction @_ @IO @s @k
+                liftHandler $ W.balanceTransaction @_ @IO @s @k @'AddressK
                     wrk
                     genChange
                     (pp, nodePParams)
@@ -2912,7 +2915,7 @@ balanceTransaction ctx genChange (ApiT wid) body = do
 
 decodeTransaction
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , IsOurs s Address
         , Typeable s
         , Typeable n
@@ -2984,7 +2987,7 @@ decodeTransaction ctx (ApiT wid) (ApiSerialisedTransaction (ApiT sealed) _) = do
         , validityInterval = interval
         }
   where
-    tl = ctx ^. W.transactionLayer @k
+    tl = ctx ^. W.transactionLayer @k @'AddressK
     nl = ctx ^. W.networkLayer @IO
 
     policyIx = ApiT $ DerivationIndex $
@@ -3115,7 +3118,7 @@ toOut ((TxOut addr (TokenBundle (Coin c) tmap)), (Just path)) =
 
 submitTransaction
     :: forall ctx s k (n :: NetworkDiscriminant).
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , HasNetworkLayer IO ctx
         , IsOwned s k
         , Typeable s
@@ -3180,7 +3183,7 @@ submitTransaction ctx apiw@(ApiT wid) apitx = do
             $ W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
     return $ ApiTxId (apiDecoded ^. #id)
   where
-    tl = ctx ^. W.transactionLayer @k
+    tl = ctx ^. W.transactionLayer @k @'AddressK
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
     nl = ctx ^. networkLayer
     ti = timeInterpreter nl
@@ -3237,7 +3240,7 @@ submitTransaction ctx apiw@(ApiT wid) apitx = do
 
 joinStakePool
     :: forall ctx s n k.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , s ~ SeqState n k
         , AddressIndexDerivationType k ~ 'Soft
         , DelegationAddress n k
@@ -3301,12 +3304,12 @@ joinStakePool ctx knownPools getPoolStatus apiPoolId (ApiT wid) body = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         sel <- liftHandler
-            $ W.selectAssets @_ @_ @s @k wrk era pp selectAssetsParams
+            $ W.selectAssets @_ @_ @s @k @'AddressK wrk era pp selectAssetsParams
             $ const Prelude.id
         sel' <- liftHandler
             $ W.assignChangeAddressesAndUpdateDb wrk wid genChange sel
         (tx, txMeta, txTime, sealedTx) <- liftHandler
-            $ W.buildAndSignTransaction @_ @s @k
+            $ W.buildAndSignTransaction @_ @s @k @'AddressK
                 wrk wid era mkRwdAcct pwd txCtx sel'
         liftHandler
             $ W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
@@ -3341,7 +3344,7 @@ joinStakePool ctx knownPools getPoolStatus apiPoolId (ApiT wid) body = do
 delegationFee
     :: forall ctx s n k.
         ( s ~ SeqState n k
-        , ctx ~ ApiLayer s k
+        , ctx ~ ApiLayer s k 'AddressK
         , BoundedAddressLength k
         )
     => ctx
@@ -3361,7 +3364,7 @@ delegationFee ctx (ApiT wid) = do
     txCtx = defaultTransactionCtx
 
     runSelection wrk era pp _deposit (utxoAvailable, wallet, pendingTxs) =
-        W.selectAssets @_ @_ @s @k wrk era pp selectAssetsParams calcFee
+        W.selectAssets @_ @_ @s @k @'AddressK wrk era pp selectAssetsParams calcFee
       where
         calcFee _ = selectionDelta TokenBundle.getCoin
         selectAssetsParams = W.SelectAssetsParams
@@ -3377,7 +3380,7 @@ delegationFee ctx (ApiT wid) = do
 
 quitStakePool
     :: forall ctx s n k.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , s ~ SeqState n k
         , AddressIndexDerivationType k ~ 'Soft
         , DelegationAddress n k
@@ -3427,12 +3430,12 @@ quitStakePool ctx (ApiT wid) body = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         sel <- liftHandler
-            $ W.selectAssets @_ @_ @s @k wrk era pp selectAssetsParams
+            $ W.selectAssets @_ @_ @s @k @'AddressK wrk era pp selectAssetsParams
             $ const Prelude.id
         sel' <- liftHandler
             $ W.assignChangeAddressesAndUpdateDb wrk wid genChange sel
         (tx, txMeta, txTime, sealedTx) <- liftHandler
-            $ W.buildAndSignTransaction @_ @s @k
+            $ W.buildAndSignTransaction @_ @s @k @'AddressK
                 wrk wid era mkRwdAcct pwd txCtx sel'
         liftHandler
             $ W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
@@ -3530,7 +3533,7 @@ listStakeKeys' utxo lookupStakeRef fetchRewards ourKeysWithInfo = do
 
 listStakeKeys
     :: forall ctx s n k.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , s ~ SeqState n k
         , HasNetworkLayer IO ctx
         , Typeable n
@@ -3568,7 +3571,7 @@ listStakeKeys lookupStakeRef ctx (ApiT wid) = do
 
 createMigrationPlan
     :: forall ctx n s k.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
         , HardDerivation k
         , IsOwned s k
@@ -3663,7 +3666,7 @@ mkApiWalletMigrationPlan s addresses rewardWithdrawal plan =
 
 migrateWallet
     :: forall ctx s k n p.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
         , HardDerivation k
         , HasNetworkLayer IO ctx
@@ -3700,7 +3703,7 @@ migrateWallet ctx withdrawalType (ApiT wid) postData = do
                     , txDelegationAction = Nothing
                     }
             (tx, txMeta, txTime, sealedTx) <- liftHandler $
-                W.buildAndSignTransaction @_ @s @k
+                W.buildAndSignTransaction @_ @s @k @'AddressK
                     wrk
                     wid
                     era
@@ -3744,7 +3747,7 @@ data ErrCurrentEpoch
     | ErrCurrentEpochPastHorizonException PastHorizonException
 
 getCurrentEpoch
-    :: forall ctx s k . (ctx ~ ApiLayer s k)
+    :: forall ctx s k ktype. (ctx ~ ApiLayer s k ktype)
     => ctx
     -> Handler W.EpochNo
 getCurrentEpoch ctx = liftIO (runExceptT (currentEpoch ti)) >>= \case
@@ -3811,7 +3814,7 @@ getNetworkInformation nid
 getNetworkParameters
     :: (Block, NetworkParameters)
     -> NetworkLayer IO Block
-    -> TransactionLayer k W.SealedTx
+    -> TransactionLayer k ktype W.SealedTx
     -> Handler ApiNetworkParameters
 getNetworkParameters (_block0, genesisNp) nl tl = do
     pp <- liftIO $ NW.currentProtocolParameters nl
@@ -3839,19 +3842,19 @@ getBlocksLatestHeader nl = liftIO $ mkApiBlockHeader <$> NW.currentNodeTip nl
 -------------------------------------------------------------------------------}
 
 postExternalTransaction
-    :: forall ctx s k.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype.
+        ( ctx ~ ApiLayer s k ktype
         )
     => ctx
     -> ApiT W.SealedTx
     -> Handler ApiTxId
 postExternalTransaction ctx (ApiT sealed) = do
-    tx <- liftHandler $ W.submitExternalTx @ctx @k ctx sealed
+    tx <- liftHandler $ W.submitExternalTx @ctx @k @ktype ctx sealed
     return $ ApiTxId (ApiT (tx ^. #txId))
 
 signMetadata
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , s ~ SeqState n k
         , HardDerivation k
         , AddressIndexDerivationType k ~ 'Soft
@@ -3872,8 +3875,8 @@ signMetadata ctx (ApiT wid) (ApiT role_) (ApiT ix) body = do
             wrk wid (coerce pwd) (role_, ix) meta
 
 derivePublicKey
-    :: forall ctx s k ver.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype ver.
+        ( ctx ~ ApiLayer s k ktype
         , SoftDerivation k
         , WalletKey k
         , GetAccount s k
@@ -3901,8 +3904,8 @@ computeKeyPayload hashed k = case hashing of
         Just v -> if v then WithHashing else WithoutHashing
 
 postAccountPublicKey
-    :: forall ctx s k account.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype account.
+        ( ctx ~ ApiLayer s k ktype
         , WalletKey k
         , GetPurpose k
         )
@@ -3926,8 +3929,8 @@ publicKeyToBytes' = \case
     NonExtended -> xpubPublicKey
 
 getAccountPublicKey
-    :: forall ctx s k account.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype account.
+        ( ctx ~ ApiLayer s k ktype
         , GetAccount s k
         , WalletKey k
         , GetPurpose k
@@ -3948,7 +3951,7 @@ getAccountPublicKey ctx mkAccount (ApiT wid) extended = do
 
 getPolicyKey
     :: forall ctx s k (n :: NetworkDiscriminant).
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , Typeable s
         , Typeable n
         )
@@ -3963,7 +3966,7 @@ getPolicyKey ctx (ApiT wid) hashed = do
 
 postPolicyKey
     :: forall ctx s (n :: NetworkDiscriminant).
-        ( ctx ~ ApiLayer s ShelleyKey
+        ( ctx ~ ApiLayer s ShelleyKey 'AddressK
         , s ~ SeqState n ShelleyKey
         )
     => ctx
@@ -3980,7 +3983,7 @@ postPolicyKey ctx (ApiT wid) hashed apiPassphrase =
 
 postPolicyId
     :: forall ctx s k (n :: NetworkDiscriminant).
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , WalletKey k
         , Typeable s
         , Typeable n
@@ -4013,7 +4016,7 @@ postPolicyId ctx (ApiT wid) payload = do
 -- XPrv), necessary to derive new change addresses.
 rndStateChange
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , s ~ RndState n
         , k ~ ByronKey
         )
@@ -4032,7 +4035,7 @@ type RewardAccountBuilder k
 
 mkRewardAccountBuilder
     :: forall ctx s k (n :: NetworkDiscriminant) shelley.
-        ( ctx ~ ApiLayer s k
+        ( ctx ~ ApiLayer s k 'AddressK
         , shelley ~ SeqState n ShelleyKey
         , HardDerivation k
         , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
@@ -4061,12 +4064,12 @@ mkRewardAccountBuilder ctx wid withdrawal = do
                 (acct, _, path) <- liftHandler $ W.readRewardAccount @_ @s @k @n wrk wid
                 wdrl <- liftHandler $ W.queryRewardBalance @_ wrk acct
                 (, selfRewardCredentials) . WithdrawalSelf acct path
-                    <$> liftIO (W.readNextWithdrawal @_ @k wrk era wdrl)
+                    <$> liftIO (W.readNextWithdrawal @_ @k @'AddressK wrk era wdrl)
 
             (Just Refl, Just (ExternalWithdrawal (ApiMnemonicT mw))) -> do
                 let (xprv, acct, path) = W.someRewardAccount @ShelleyKey mw
                 wdrl <- liftHandler (W.queryRewardBalance @_ wrk acct)
-                    >>= liftIO . W.readNextWithdrawal @_ @k wrk era
+                    >>= liftIO . W.readNextWithdrawal @_ @k @'AddressK wrk era
                 when (wdrl == Coin 0) $ do
                     liftHandler $ throwE ErrWithdrawalNotWorth
                 pure (WithdrawalExternal acct path wdrl, const (xprv, mempty))
@@ -4414,8 +4417,8 @@ fromApiRedeemer = \case
 
 -- | Create a new instance of the wallet layer.
 newApiLayer
-    :: forall ctx s k.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype.
+        ( ctx ~ ApiLayer s k ktype
         , IsOurs s RewardAccount
         , IsOurs s Address
         , AddressBookIso s
@@ -4424,7 +4427,7 @@ newApiLayer
     => Tracer IO WalletEngineLog
     -> (Block, NetworkParameters)
     -> NetworkLayer IO Block
-    -> TransactionLayer k W.SealedTx
+    -> TransactionLayer k ktype W.SealedTx
     -> DBFactory IO s k
     -> TokenMetadataClient IO
     -> (WorkerCtx ctx -> WalletId -> IO ())
@@ -4441,8 +4444,8 @@ newApiLayer tr g0 nw tl df tokenMeta coworker = do
 
 -- | Register a wallet restoration thread with the worker registry.
 startWalletWorker
-    :: forall ctx s k.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype.
+        ( ctx ~ ApiLayer s k ktype
         , IsOurs s RewardAccount
         , IsOurs s Address
         , AddressBookIso s
@@ -4463,8 +4466,8 @@ startWalletWorker ctx coworker = void . registerWorker ctx before coworker
 -- | Register a wallet create and restore thread with the worker registry.
 -- See 'Cardano.Wallet#createWallet'
 createWalletWorker
-    :: forall ctx s k.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype.
+        ( ctx ~ ApiLayer s k ktype
         , IsOurs s RewardAccount
         , IsOurs s Address
         , AddressBookIso s
@@ -4494,8 +4497,8 @@ createWalletWorker ctx wid createWallet coworker =
 -- | Create a worker for an existing wallet, register it, then start the worker
 -- thread. This is used by 'startWalletWorker' and 'createWalletWorker'.
 registerWorker
-    :: forall ctx s k.
-        ( ctx ~ ApiLayer s k
+    :: forall ctx s k ktype.
+        ( ctx ~ ApiLayer s k ktype
         , IsOurs s RewardAccount
         , IsOurs s Address
         , AddressBookIso s

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1007,7 +1007,7 @@ postSharedWallet
     :: forall ctx s k n.
         ( s ~ SharedState n k
         , k ~ SharedKey
-        , ctx ~ ApiLayer s k 'ScriptK
+        , ctx ~ ApiLayer s k 'CredFromScriptK
         , Shared.SupportsDiscovery n k
         , WalletKey k
         , HasDBFactory s k ctx
@@ -1029,7 +1029,7 @@ postSharedWalletFromRootXPrv
     :: forall ctx s k n.
         ( s ~ SharedState n k
         , k ~ SharedKey
-        , ctx ~ ApiLayer s k 'ScriptK
+        , ctx ~ ApiLayer s k 'CredFromScriptK
         , Shared.SupportsDiscovery n k
         , WalletKey k
         , HasDBFactory s k ctx
@@ -1072,7 +1072,7 @@ postSharedWalletFromAccountXPub
     :: forall ctx s k n.
         ( s ~ SharedState n k
         , k ~ SharedKey
-        , ctx ~ ApiLayer s k 'ScriptK
+        , ctx ~ ApiLayer s k 'CredFromScriptK
         , Shared.SupportsDiscovery n k
         , WalletKey k
         , HasDBFactory s k ctx
@@ -1115,7 +1115,7 @@ scriptTemplateFromSelf xpub (ApiScriptTemplateEntry cosigners' template') =
 
 mkSharedWallet
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k 'ScriptK
+        ( ctx ~ ApiLayer s k 'CredFromScriptK
         , s ~ SharedState n k
         , HasWorkerRegistry s k ctx
         , Shared.SupportsDiscovery n k
@@ -1174,7 +1174,7 @@ patchSharedWallet
     :: forall ctx s k n.
         ( s ~ SharedState n k
         , k ~ SharedKey
-        , ctx ~ ApiLayer s k 'ScriptK
+        , ctx ~ ApiLayer s k 'CredFromScriptK
         , Shared.SupportsDiscovery n k
         , WalletKey k
         , HasDBFactory s k ctx
@@ -2618,7 +2618,7 @@ constructSharedTransaction
     :: forall ctx s k n.
         ( k ~ SharedKey
         , s ~ SharedState n k
-        , ctx ~ ApiLayer s k 'ScriptK
+        , ctx ~ ApiLayer s k 'CredFromScriptK
         , GenChange s
         , HasNetworkLayer IO ctx
         , IsOurs s Address
@@ -2677,7 +2677,7 @@ constructSharedTransaction
                 (utxoAvailable, wallet, pendingTxs) <-
                     liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk wid
 
-                let runSelection outs = W.selectAssets @_ @_ @s @k @'ScriptK
+                let runSelection outs = W.selectAssets @_ @_ @s @k @'CredFromScriptK
                         wrk era pp selectAssetsParams transform
                       where
                         selectAssetsParams = W.SelectAssetsParams
@@ -2721,7 +2721,7 @@ constructSharedTransaction
 
 decodeSharedTransaction
     :: forall ctx s k n.
-        ( ctx ~ ApiLayer s k 'ScriptK
+        ( ctx ~ ApiLayer s k 'CredFromScriptK
         , IsOurs s Address
         , HasNetworkLayer IO ctx
         )
@@ -2777,7 +2777,7 @@ decodeSharedTransaction ctx (ApiT wid) (ApiSerialisedTransaction (ApiT sealed) _
         , validityInterval = interval
         }
   where
-    tl = ctx ^. W.transactionLayer @k @'ScriptK
+    tl = ctx ^. W.transactionLayer @k @'CredFromScriptK
     nl = ctx ^. W.networkLayer @IO
 
     emptyApiAssetMntBurn = ApiAssetMintBurn

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2611,6 +2611,7 @@ constructSharedTransaction
         , HasNetworkLayer IO ctx
         , IsOurs s Address
         , BoundedAddressLength k
+        , Typeable n
         )
     => ctx
     -> ArgGenChange s

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2806,7 +2806,7 @@ balanceTransaction ctx genChange (ApiT wid) body = do
                     (fromApiRedeemer <$> body ^. #redeemers)
               where
                 convertToCardano xs =
-                    toCardanoUTxO (wrk ^. W.transactionLayer @k) mempty xs
+                    toCardanoUTxO (wrk ^. W.transactionLayer @k @'CredFromKeyK) mempty xs
 
         let balanceTx
                 :: forall era. Cardano.IsShelleyBasedEra era
@@ -3177,7 +3177,7 @@ isForeign apiDecodedTx =
         all isWdrlForeign generalWdrls
 
 submitSharedTransaction
-    :: forall ctx s k (n :: NetworkDiscriminant).
+    :: forall ctx s k.
         ( ctx ~ ApiLayer s k 'CredFromScriptK
         , HasNetworkLayer IO ctx
         , IsOwned s k 'CredFromScriptK
@@ -3190,10 +3190,10 @@ submitSharedTransaction ctx apiw@(ApiT wid) apitx = do
     ttl <- liftIO $ W.getTxExpiry ti Nothing
     era <- liftIO $ NW.currentNodeEra nl
 
-    let sealedTx = getApiT . (view #transaction) $ apitx
+    let sealedTx = getApiT . (view #serialisedTxSealed) $ apitx
     let (tx,_,_,_,_) = decodeTx tl era sealedTx
 
-    apiDecoded <- decodeSharedTransaction @_ @s @k @n ctx apiw apitx
+    apiDecoded <- decodeSharedTransaction @_ @s @k ctx apiw apitx
     when (isForeign apiDecoded) $
         liftHandler $ throwE ErrSubmitTransactionForeignWallet
     let ourOuts = getOurOuts apiDecoded

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1006,15 +1006,12 @@ toApiWalletDelegation W.WalletDelegation{active,next} ti = do
 postSharedWallet
     :: forall ctx s k n.
         ( s ~ SharedState n k
+        , k ~ SharedKey
         , ctx ~ ApiLayer s k 'ScriptK
-        , SoftDerivation k
-        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub) --TODO ADP-1850
-        , MkKeyFingerprint k Address
+        , Shared.SupportsDiscovery n k
         , WalletKey k
         , HasDBFactory s k ctx
         , HasWorkerRegistry s k ctx
-        , Typeable n
-        , k ~ SharedKey
         )
     => ctx
     -> ((SomeMnemonic, Maybe SomeMnemonic) -> Passphrase "encryption" -> k 'RootK XPrv)
@@ -1031,15 +1028,12 @@ postSharedWallet ctx generateKey liftKey postData =
 postSharedWalletFromRootXPrv
     :: forall ctx s k n.
         ( s ~ SharedState n k
+        , k ~ SharedKey
         , ctx ~ ApiLayer s k 'ScriptK
-        , SoftDerivation k
-        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub) --TODO ADP-1850
-        , MkKeyFingerprint k Address
+        , Shared.SupportsDiscovery n k
         , WalletKey k
         , HasDBFactory s k ctx
         , HasWorkerRegistry s k ctx
-        , Typeable n
-        , k ~ SharedKey
         )
     => ctx
     -> ((SomeMnemonic, Maybe SomeMnemonic) -> Passphrase "encryption" -> k 'RootK XPrv)
@@ -1077,15 +1071,12 @@ postSharedWalletFromRootXPrv ctx generateKey body = do
 postSharedWalletFromAccountXPub
     :: forall ctx s k n.
         ( s ~ SharedState n k
+        , k ~ SharedKey
         , ctx ~ ApiLayer s k 'ScriptK
-        , SoftDerivation k
-        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub) --TODO 1850
-        , MkKeyFingerprint k Address
+        , Shared.SupportsDiscovery n k
         , WalletKey k
         , HasDBFactory s k ctx
         , HasWorkerRegistry s k ctx
-        , Typeable n
-        , k ~ SharedKey
         )
     => ctx
     -> (XPub -> k 'AccountK XPub)
@@ -1182,14 +1173,11 @@ mkSharedWallet ctx wid cp meta pending progress = case Shared.ready st of
 patchSharedWallet
     :: forall ctx s k n.
         ( s ~ SharedState n k
+        , k ~ SharedKey
         , ctx ~ ApiLayer s k 'ScriptK
-        , SoftDerivation k
-        , MkKeyFingerprint k (Proxy n, k 'AddressK XPub) --TODO 1850
-        , MkKeyFingerprint k Address
+        , Shared.SupportsDiscovery n k
         , WalletKey k
         , HasDBFactory s k ctx
-        , Typeable n
-        , k ~ SharedKey
         )
     => ctx
     -> (XPub -> k 'AccountK XPub)
@@ -1354,7 +1342,7 @@ postIcarusWallet
         , s ~ SeqState n k
         , k ~ IcarusKey
         , HasWorkerRegistry s k ctx
-        , PaymentAddress n IcarusKey
+        , PaymentAddress n IcarusKey 'AddressK
         , Typeable n
         )
     => ctx
@@ -1377,7 +1365,7 @@ postTrezorWallet
         , s ~ SeqState n k
         , k ~ IcarusKey
         , HasWorkerRegistry s k ctx
-        , PaymentAddress n IcarusKey
+        , PaymentAddress n IcarusKey 'AddressK
         , Typeable n
         )
     => ctx
@@ -1400,7 +1388,7 @@ postLedgerWallet
         , s ~ SeqState n k
         , k ~ IcarusKey
         , HasWorkerRegistry s k ctx
-        , PaymentAddress n IcarusKey
+        , PaymentAddress n IcarusKey 'AddressK
         , Typeable n
         )
     => ctx
@@ -1726,7 +1714,7 @@ selectCoinsForJoin
     :: forall ctx s n k.
         ( s ~ SeqState n k
         , ctx ~ ApiLayer s k 'AddressK
-        , DelegationAddress n k
+        , DelegationAddress n k 'AddressK
         , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
         , SoftDerivation k
         , Typeable n
@@ -1785,7 +1773,7 @@ selectCoinsForQuit
     :: forall ctx s n k.
         ( s ~ SeqState n k
         , ctx ~ ApiLayer s k 'AddressK
-        , DelegationAddress n k
+        , DelegationAddress n k 'AddressK
         , MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
         , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
         , SoftDerivation k
@@ -1918,7 +1906,7 @@ postRandomAddress
         ( s ~ RndState n
         , k ~ ByronKey
         , ctx ~ ApiLayer s k 'AddressK
-        , PaymentAddress n ByronKey
+        , PaymentAddress n ByronKey 'AddressK
         )
     => ctx
     -> ApiT WalletId
@@ -3195,7 +3183,7 @@ joinStakePool
         ( ctx ~ ApiLayer s k 'AddressK
         , s ~ SeqState n k
         , AddressIndexDerivationType k ~ 'Soft
-        , DelegationAddress n k
+        , DelegationAddress n k 'AddressK
         , GenChange s
         , IsOwned s k 'AddressK
         , SoftDerivation k
@@ -3335,7 +3323,7 @@ quitStakePool
         ( ctx ~ ApiLayer s k 'AddressK
         , s ~ SeqState n k
         , AddressIndexDerivationType k ~ 'Soft
-        , DelegationAddress n k
+        , DelegationAddress n k 'AddressK
         , GenChange s
         , HasNetworkLayer IO ctx
         , IsOwned s k 'AddressK

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1567,7 +1567,7 @@ newtype ApiNetworkClock = ApiNetworkClock
 
 data ApiPostRandomAddressData = ApiPostRandomAddressData
     { passphrase :: !(ApiT (Passphrase "lenient"))
-    , addressIndex :: !(Maybe (ApiT (Index 'AD.Hardened 'AddressK)))
+    , addressIndex :: !(Maybe (ApiT (Index 'AD.Hardened 'CredFromKeyK)))
     } deriving (Eq, Generic, Show)
       deriving anyclass NFData
 

--- a/lib/core/src/Cardano/Wallet/DB/Store/Checkpoints.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Store/Checkpoints.hs
@@ -91,6 +91,7 @@ import Cardano.Wallet.DB.WalletState
     )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
+    , HardDerivation (..)
     , MkKeyFingerprint (..)
     , PaymentAddress (..)
     , PersistPublicKey (..)
@@ -445,6 +446,7 @@ instance
     , PersistPublicKey (key 'PolicyK)
     , MkKeyFingerprint key (Proxy n, key 'CredFromKeyK XPub)
     , PaymentAddress n key 'CredFromKeyK
+    , AddressCredential key ~ 'CredFromKeyK
     , SoftDerivation key
     , Typeable n
     , (key == SharedKey) ~ 'False

--- a/lib/core/src/Cardano/Wallet/DB/Store/Checkpoints.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Store/Checkpoints.hs
@@ -575,7 +575,7 @@ instance
                 | ((Cosigner c), xpub) <- Map.assocs cs
                 ]
 
-        mkSharedStatePendingIxs :: PendingIxs 'ScriptK -> [SharedStatePendingIx]
+        mkSharedStatePendingIxs :: PendingIxs 'CredFromScriptK -> [SharedStatePendingIx]
         mkSharedStatePendingIxs =
             fmap (SharedStatePendingIx wid . W.getIndex) . pendingIxsToList
 
@@ -614,7 +614,7 @@ instance
                 pendingIxs
         pure $ SharedPrologue prologue
       where
-        selectSharedStatePendingIxs :: SqlPersistT IO (PendingIxs 'ScriptK)
+        selectSharedStatePendingIxs :: SqlPersistT IO (PendingIxs 'CredFromScriptK)
         selectSharedStatePendingIxs =
             pendingIxsFromList . fromRes <$> selectList
                 [SharedStatePendingWalletId ==. wid]

--- a/lib/core/src/Cardano/Wallet/DB/Store/Checkpoints.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Store/Checkpoints.hs
@@ -441,10 +441,10 @@ instance
 
 instance
     ( PersistPublicKey (key 'AccountK)
-    , PersistPublicKey (key 'AddressK)
+    , PersistPublicKey (key 'CredFromKeyK)
     , PersistPublicKey (key 'PolicyK)
-    , MkKeyFingerprint key (Proxy n, key 'AddressK XPub)
-    , PaymentAddress n key 'AddressK
+    , MkKeyFingerprint key (Proxy n, key 'CredFromKeyK XPub)
+    , PaymentAddress n key 'CredFromKeyK
     , SoftDerivation key
     , Typeable n
     , (key == SharedKey) ~ 'False
@@ -494,11 +494,11 @@ instance
             <$> selectSeqAddressMap wid sl
             <*> selectSeqAddressMap wid sl
 
-mkSeqStatePendingIxs :: W.WalletId -> PendingIxs 'AddressK -> [SeqStatePendingIx]
+mkSeqStatePendingIxs :: W.WalletId -> PendingIxs 'CredFromKeyK -> [SeqStatePendingIx]
 mkSeqStatePendingIxs wid =
     fmap (SeqStatePendingIx wid . W.getIndex) . pendingIxsToList
 
-selectSeqStatePendingIxs :: W.WalletId -> SqlPersistT IO (PendingIxs 'AddressK)
+selectSeqStatePendingIxs :: W.WalletId -> SqlPersistT IO (PendingIxs 'CredFromKeyK)
 selectSeqStatePendingIxs wid =
     pendingIxsFromList . fromRes <$> selectList
         [SeqStatePendingWalletId ==. wid]
@@ -507,16 +507,16 @@ selectSeqStatePendingIxs wid =
     fromRes = fmap (W.Index . seqStatePendingIxIndex . entityVal)
 
 insertSeqAddressMap
-    :: forall n c key. (PaymentAddress n key 'AddressK, Typeable c)
+    :: forall n c key. (PaymentAddress n key 'CredFromKeyK, Typeable c)
     =>  W.WalletId -> W.SlotNo -> SeqAddressMap c key -> SqlPersistT IO ()
 insertSeqAddressMap wid sl (SeqAddressMap pool) = void $
     dbChunked insertMany_
-        [ SeqStateAddress wid sl (liftPaymentAddress @n @key @'AddressK addr)
+        [ SeqStateAddress wid sl (liftPaymentAddress @n @key @'CredFromKeyK addr)
             (W.getIndex ix) (roleVal @c) status
         | (addr, (ix, status)) <- Map.toList pool
         ]
 
--- MkKeyFingerprint key (Proxy n, key 'AddressK XPub)
+-- MkKeyFingerprint key (Proxy n, key 'CredFromKeyK XPub)
 selectSeqAddressMap :: forall (c :: Role) key.
     ( MkKeyFingerprint key W.Address
     , Typeable c

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -172,7 +172,7 @@ data Depth
     | AccountK
     | RoleK
     | CredFromKeyK
-    | ScriptK
+    | CredFromScriptK
     | PolicyK
 
 -- | Marker for addresses type engaged. We want to handle four cases here.

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -171,7 +171,7 @@ data Depth
     | CoinTypeK
     | AccountK
     | RoleK
-    | AddressK
+    | CredFromKeyK
     | ScriptK
     | PolicyK
 
@@ -254,7 +254,7 @@ utxoInternal = toEnum $ fromEnum UtxoInternal
 mutableAccount :: Index 'Soft 'RoleK
 mutableAccount = toEnum $ fromEnum MutableAccount
 
-zeroAccount :: Index 'Soft 'AddressK
+zeroAccount :: Index 'Soft 'CredFromKeyK
 zeroAccount = minBound
 
 -- | Full path to the stake key. There's only one.
@@ -339,7 +339,7 @@ instance FromText DerivationIndex where
 --
 -- @
 -- let accountIx = Index 'Hardened 'AccountK
--- let addressIx = Index 'Soft 'AddressK
+-- let addressIx = Index 'Soft 'CredFromKeyK
 -- @
 newtype Index (derivationType :: DerivationType) (level :: Depth) = Index
     { getIndex :: Word32 }
@@ -515,8 +515,8 @@ class HardDerivation (key :: Depth -> Type -> Type) where
         :: Passphrase "encryption"
         -> key 'AccountK XPrv
         -> Role
-        -> Index (AddressIndexDerivationType key) 'AddressK
-        -> key 'AddressK XPrv
+        -> Index (AddressIndexDerivationType key) 'CredFromKeyK
+        -> key 'CredFromKeyK XPrv
 
 -- | An interface for doing soft derivations from an account public key
 class HardDerivation key => SoftDerivation (key :: Depth -> Type -> Type) where
@@ -528,13 +528,13 @@ class HardDerivation key => SoftDerivation (key :: Depth -> Type -> Type) where
     deriveAddressPublicKey
         :: key 'AccountK XPub
         -> Role
-        -> Index 'Soft 'AddressK
-        -> key 'AddressK XPub
+        -> Index 'Soft 'CredFromKeyK
+        -> key 'CredFromKeyK XPub
 
 -- | Derivation of a reward account, as a type-class because different between
 -- key types (in particular, Jörmungandr vs Shelley).
 class ToRewardAccount k where
-    toRewardAccount :: k 'AddressK XPub -> RewardAccount
+    toRewardAccount :: k 'CredFromKeyK XPub -> RewardAccount
     someRewardAccount :: SomeMnemonic -> (XPrv, RewardAccount, NonEmpty DerivationIndex)
 
 -- | Derive a reward account from a root private key. It is agreed by standard
@@ -542,11 +542,11 @@ class ToRewardAccount k where
 -- located into a special derivation path and uses the first index of that path.
 deriveRewardAccount
     :: ( HardDerivation k
-       , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
+       , Bounded (Index (AddressIndexDerivationType k) 'CredFromKeyK)
        )
     => Passphrase "encryption"
     -> k 'RootK XPrv
-    -> k 'AddressK XPrv
+    -> k 'CredFromKeyK XPrv
 deriveRewardAccount pwd rootPrv =
     let accPrv = deriveAccountPrivateKey pwd rootPrv minBound
     in deriveAddressPrivateKey pwd accPrv MutableAccount minBound

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
@@ -157,7 +157,7 @@ instance WalletKey ByronKey where
     liftRawKey = error "not supported"
     keyTypeDescriptor _ = "rnd"
 
-instance KnownNat pm => PaymentAddress ('Testnet pm) ByronKey where
+instance KnownNat pm => PaymentAddress ('Testnet pm) ByronKey 'AddressK where
     paymentAddress k = Address
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k)
@@ -170,7 +170,7 @@ instance KnownNat pm => PaymentAddress ('Testnet pm) ByronKey where
     liftPaymentAddress (KeyFingerprint bytes) =
         Address bytes
 
-instance PaymentAddress 'Mainnet ByronKey where
+instance PaymentAddress 'Mainnet ByronKey 'AddressK where
     paymentAddress k = Address
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k)

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
@@ -144,8 +144,8 @@ type family DerivationPathFrom (depth :: Depth) :: Type where
     DerivationPathFrom 'AccountK =
         Index 'WholeDomain 'AccountK
     -- The address key is generated from the account key and address index.
-    DerivationPathFrom 'AddressK =
-        (Index 'WholeDomain 'AccountK, Index 'WholeDomain 'AddressK)
+    DerivationPathFrom 'CredFromKeyK =
+        (Index 'WholeDomain 'AccountK, Index 'WholeDomain 'CredFromKeyK)
 
 instance WalletKey ByronKey where
     changePassphrase = changePassphraseRnd
@@ -157,7 +157,7 @@ instance WalletKey ByronKey where
     liftRawKey = error "not supported"
     keyTypeDescriptor _ = "rnd"
 
-instance KnownNat pm => PaymentAddress ('Testnet pm) ByronKey 'AddressK where
+instance KnownNat pm => PaymentAddress ('Testnet pm) ByronKey 'CredFromKeyK where
     paymentAddress k = Address
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k)
@@ -170,7 +170,7 @@ instance KnownNat pm => PaymentAddress ('Testnet pm) ByronKey 'AddressK where
     liftPaymentAddress (KeyFingerprint bytes) =
         Address bytes
 
-instance PaymentAddress 'Mainnet ByronKey 'AddressK where
+instance PaymentAddress 'Mainnet ByronKey 'CredFromKeyK where
     paymentAddress k = Address
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k)
@@ -362,8 +362,8 @@ deriveAccountPrivateKey (Passphrase pwd) masterKey idx@(Index accIx) = ByronKey
 deriveAddressPrivateKey
     :: Passphrase "encryption"
     -> ByronKey 'AccountK XPrv
-    -> Index 'WholeDomain 'AddressK
-    -> ByronKey 'AddressK XPrv
+    -> Index 'WholeDomain 'CredFromKeyK
+    -> ByronKey 'CredFromKeyK XPrv
 deriveAddressPrivateKey (Passphrase pwd) accountKey idx@(Index addrIx) = ByronKey
     { getKey = deriveXPrv DerivationScheme1 pwd (getKey accountKey) addrIx
     , derivationPath = (derivationPath accountKey, idx)

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
@@ -327,6 +327,7 @@ changePassphraseRnd old new key = ByronKey
 -- we're doing something wrong.
 instance W.HardDerivation ByronKey where
     type AddressIndexDerivationType ByronKey = 'WholeDomain
+    type AddressCredential ByronKey = 'CredFromKeyK
 
     deriveAccountPrivateKey _ _ _ = error
         "unsound evaluation of 'deriveAccountPrivateKey' in the context of Byron key"

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
@@ -296,6 +296,7 @@ unsafeGenerateKeyFromSeed (SomeMnemonic mw) (Passphrase pwd) =
 
 instance HardDerivation IcarusKey where
     type AddressIndexDerivationType IcarusKey = 'Soft
+    type AddressCredential IcarusKey = 'CredFromKeyK
 
     deriveAccountPrivateKey
             (Passphrase pwd) (IcarusKey rootXPrv) (Index accIx) =

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
@@ -366,14 +366,14 @@ instance WalletKey IcarusKey where
 instance GetPurpose IcarusKey where
     getPurpose = purposeBIP44
 
-instance PaymentAddress 'Mainnet IcarusKey where
+instance PaymentAddress 'Mainnet IcarusKey 'AddressK where
     paymentAddress k = Address
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k) []
     liftPaymentAddress (KeyFingerprint bytes) =
         Address bytes
 
-instance KnownNat pm => PaymentAddress ('Testnet pm) IcarusKey where
+instance KnownNat pm => PaymentAddress ('Testnet pm) IcarusKey 'AddressK where
     paymentAddress k = Address
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k)
@@ -388,7 +388,7 @@ instance MkKeyFingerprint IcarusKey Address where
             Just _  -> Right $ KeyFingerprint bytes
             Nothing -> Left $ ErrInvalidAddress addr (Proxy @IcarusKey)
 
-instance PaymentAddress n IcarusKey
+instance PaymentAddress n IcarusKey 'AddressK
     => MkKeyFingerprint IcarusKey (Proxy (n :: NetworkDiscriminant), IcarusKey 'AddressK XPub)
   where
     paymentKeyFingerprint (proxy, k) =
@@ -402,7 +402,9 @@ instance PaymentAddress n IcarusKey
 instance IsOurs (SeqState n IcarusKey) RewardAccount where
     isOurs _account state = (Nothing, state)
 
-instance PaymentAddress n IcarusKey => MaybeLight (SeqState n IcarusKey) where
+instance PaymentAddress n IcarusKey 'AddressK =>
+    MaybeLight (SeqState n IcarusKey)
+  where
     maybeDiscover = Just $ DiscoverTxs discoverSeq
 
 instance BoundedAddressLength IcarusKey where

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
@@ -126,7 +126,7 @@ import qualified Data.Text.Encoding as T
 -- @
 -- let rootPrivateKey = IcarusKey 'RootK XPrv
 -- let accountPubKey = IcarusKey 'AccountK XPub
--- let addressPubKey = IcarusKey 'AddressK XPub
+-- let addressPubKey = IcarusKey 'CredFromKeyK XPub
 -- @
 newtype IcarusKey (depth :: Depth) key =
     IcarusKey { getKey :: key }
@@ -366,14 +366,14 @@ instance WalletKey IcarusKey where
 instance GetPurpose IcarusKey where
     getPurpose = purposeBIP44
 
-instance PaymentAddress 'Mainnet IcarusKey 'AddressK where
+instance PaymentAddress 'Mainnet IcarusKey 'CredFromKeyK where
     paymentAddress k = Address
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k) []
     liftPaymentAddress (KeyFingerprint bytes) =
         Address bytes
 
-instance KnownNat pm => PaymentAddress ('Testnet pm) IcarusKey 'AddressK where
+instance KnownNat pm => PaymentAddress ('Testnet pm) IcarusKey 'CredFromKeyK where
     paymentAddress k = Address
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k)
@@ -388,8 +388,8 @@ instance MkKeyFingerprint IcarusKey Address where
             Just _  -> Right $ KeyFingerprint bytes
             Nothing -> Left $ ErrInvalidAddress addr (Proxy @IcarusKey)
 
-instance PaymentAddress n IcarusKey 'AddressK
-    => MkKeyFingerprint IcarusKey (Proxy (n :: NetworkDiscriminant), IcarusKey 'AddressK XPub)
+instance PaymentAddress n IcarusKey 'CredFromKeyK
+    => MkKeyFingerprint IcarusKey (Proxy (n :: NetworkDiscriminant), IcarusKey 'CredFromKeyK XPub)
   where
     paymentKeyFingerprint (proxy, k) =
         bimap (const err) coerce
@@ -402,7 +402,7 @@ instance PaymentAddress n IcarusKey 'AddressK
 instance IsOurs (SeqState n IcarusKey) RewardAccount where
     isOurs _account state = (Nothing, state)
 
-instance PaymentAddress n IcarusKey 'AddressK =>
+instance PaymentAddress n IcarusKey 'CredFromKeyK =>
     MaybeLight (SeqState n IcarusKey)
   where
     maybeDiscover = Just $ DiscoverTxs discoverSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shared.hs
@@ -181,7 +181,7 @@ instance MkKeyFingerprint SharedKey Address where
     paymentKeyFingerprint (Address bytes) =
         Right $ KeyFingerprint $ BS.take hashSize $ BS.drop 1 bytes
 
-instance MkKeyFingerprint SharedKey (Proxy (n :: NetworkDiscriminant), SharedKey 'AddressK XPub) where
+instance MkKeyFingerprint SharedKey (Proxy (n :: NetworkDiscriminant), SharedKey 'ScriptK XPub) where
     paymentKeyFingerprint (_, paymentK) =
         Right $ KeyFingerprint $ blake2b224 $ xpubPublicKey $ getKey paymentK
 

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shared.hs
@@ -110,6 +110,7 @@ unsafeGenerateKeyFromSeed mnemonics pwd =
 
 instance HardDerivation SharedKey where
     type AddressIndexDerivationType SharedKey = 'Soft
+    type AddressCredential SharedKey = 'CredFromScriptK
 
     deriveAccountPrivateKey pwd (SharedKey rootXPrv) ix =
         SharedKey $ deriveAccountPrivateKeyShelley purposeCIP1854 pwd rootXPrv ix

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shared.hs
@@ -181,7 +181,7 @@ instance MkKeyFingerprint SharedKey Address where
     paymentKeyFingerprint (Address bytes) =
         Right $ KeyFingerprint $ BS.take hashSize $ BS.drop 1 bytes
 
-instance MkKeyFingerprint SharedKey (Proxy (n :: NetworkDiscriminant), SharedKey 'ScriptK XPub) where
+instance MkKeyFingerprint SharedKey (Proxy (n :: NetworkDiscriminant), SharedKey 'CredFromScriptK XPub) where
     paymentKeyFingerprint (_, paymentK) =
         Right $ KeyFingerprint $ blake2b224 $ xpubPublicKey $ getKey paymentK
 

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/SharedKey.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/SharedKey.hs
@@ -81,7 +81,7 @@ purposeCIP1854 = toEnum 0x8000073E
 -- @
 -- let rootPrivateKey = SharedKey 'RootK XPrv
 -- let accountPubKey = SharedKey 'AccountK XPub
--- let addressPubKey = SharedKey 'ScriptK XPub
+-- let addressPubKey = SharedKey 'CredFromScriptK XPub
 -- @
 newtype SharedKey (depth :: Depth) key =
     SharedKey { getKey :: key }
@@ -94,7 +94,7 @@ constructAddressFromIx
     => Role
     -> ScriptTemplate
     -> Maybe ScriptTemplate
-    -> Index 'Soft 'ScriptK
+    -> Index 'Soft 'CredFromScriptK
     -> Address
 constructAddressFromIx role pTemplate dTemplate ix =
     let delegationCredential = DelegationFromScriptHash . toScriptHash
@@ -126,7 +126,7 @@ constructAddressFromIx role pTemplate dTemplate ix =
 replaceCosignersWithVerKeys
     :: CA.Role
     -> ScriptTemplate
-    -> Index 'Soft 'ScriptK
+    -> Index 'Soft 'CredFromScriptK
     -> Script KeyHash
 replaceCosignersWithVerKeys role' (ScriptTemplate xpubs scriptTemplate) ix =
     replaceCosigner scriptTemplate
@@ -139,7 +139,7 @@ replaceCosignersWithVerKeys role' (ScriptTemplate xpubs scriptTemplate) ix =
         RequireSomeOf m xs   -> RequireSomeOf m (map replaceCosigner xs)
         ActiveFromSlot s     -> ActiveFromSlot s
         ActiveUntilSlot s    -> ActiveUntilSlot s
-    convertIndex :: Index 'Soft 'ScriptK -> CA.Index 'CA.Soft 'CA.PaymentK
+    convertIndex :: Index 'Soft 'CredFromScriptK -> CA.Index 'CA.Soft 'CA.PaymentK
     convertIndex = fromJust . CA.indexFromWord32 . fromIntegral . fromEnum
     toKeyHash :: Cosigner -> KeyHash
     toKeyHash c =

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/SharedKey.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/SharedKey.hs
@@ -81,7 +81,7 @@ purposeCIP1854 = toEnum 0x8000073E
 -- @
 -- let rootPrivateKey = SharedKey 'RootK XPrv
 -- let accountPubKey = SharedKey 'AccountK XPub
--- let addressPubKey = SharedKey 'AddressK XPub
+-- let addressPubKey = SharedKey 'ScriptK XPub
 -- @
 newtype SharedKey (depth :: Depth) key =
     SharedKey { getKey :: key }

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -275,7 +275,7 @@ instance WalletKey ShelleyKey where
 instance GetPurpose ShelleyKey where
     getPurpose = purposeCIP1852
 
-instance PaymentAddress 'Mainnet ShelleyKey where
+instance PaymentAddress 'Mainnet ShelleyKey 'AddressK where
     paymentAddress paymentK = do
         Address $ BL.toStrict $ runPut $ do
             putWord8 (enterprise + networkId)
@@ -292,7 +292,7 @@ instance PaymentAddress 'Mainnet ShelleyKey where
         enterprise = 96
         networkId = 1
 
-instance PaymentAddress ('Testnet pm) ShelleyKey where
+instance PaymentAddress ('Testnet pm) ShelleyKey 'AddressK where
     paymentAddress paymentK =
         Address $ BL.toStrict $ runPut $ do
             putWord8 (enterprise + networkId)
@@ -309,7 +309,7 @@ instance PaymentAddress ('Testnet pm) ShelleyKey where
         enterprise = 96
         networkId = 0
 
-instance DelegationAddress 'Mainnet ShelleyKey where
+instance DelegationAddress 'Mainnet ShelleyKey 'AddressK where
     delegationAddress paymentK stakingK =
         Address $ BL.toStrict $ runPut $ do
             putWord8 (base + networkId)
@@ -328,7 +328,7 @@ instance DelegationAddress 'Mainnet ShelleyKey where
         base = 0
         networkId = 1
 
-instance DelegationAddress ('Testnet pm) ShelleyKey where
+instance DelegationAddress ('Testnet pm) ShelleyKey 'AddressK where
     delegationAddress paymentK stakingK =
         Address $ BL.toStrict $ runPut $ do
             putWord8 (base + networkId)
@@ -402,7 +402,7 @@ instance ToRewardAccount ShelleyKey where
 toRewardAccountRaw :: XPub -> RewardAccount
 toRewardAccountRaw = RewardAccount . blake2b224 . xpubPublicKey
 
-instance DelegationAddress n ShelleyKey
+instance DelegationAddress n ShelleyKey 'AddressK
     => MaybeLight (SeqState n ShelleyKey)
   where
     maybeDiscover = Just $ DiscoverTxs discoverSeqWithRewards

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -132,7 +132,7 @@ import qualified Data.List.NonEmpty as NE
 -- @
 -- let rootPrivateKey = ShelleyKey 'RootK XPrv
 -- let accountPubKey = ShelleyKey 'AccountK XPub
--- let addressPubKey = ShelleyKey 'AddressK XPub
+-- let addressPubKey = ShelleyKey 'CredFromKeyK XPub
 -- @
 newtype ShelleyKey (depth :: Depth) key =
     ShelleyKey { getKey :: key }
@@ -275,7 +275,7 @@ instance WalletKey ShelleyKey where
 instance GetPurpose ShelleyKey where
     getPurpose = purposeCIP1852
 
-instance PaymentAddress 'Mainnet ShelleyKey 'AddressK where
+instance PaymentAddress 'Mainnet ShelleyKey 'CredFromKeyK where
     paymentAddress paymentK = do
         Address $ BL.toStrict $ runPut $ do
             putWord8 (enterprise + networkId)
@@ -292,7 +292,7 @@ instance PaymentAddress 'Mainnet ShelleyKey 'AddressK where
         enterprise = 96
         networkId = 1
 
-instance PaymentAddress ('Testnet pm) ShelleyKey 'AddressK where
+instance PaymentAddress ('Testnet pm) ShelleyKey 'CredFromKeyK where
     paymentAddress paymentK =
         Address $ BL.toStrict $ runPut $ do
             putWord8 (enterprise + networkId)
@@ -309,7 +309,7 @@ instance PaymentAddress ('Testnet pm) ShelleyKey 'AddressK where
         enterprise = 96
         networkId = 0
 
-instance DelegationAddress 'Mainnet ShelleyKey 'AddressK where
+instance DelegationAddress 'Mainnet ShelleyKey 'CredFromKeyK where
     delegationAddress paymentK stakingK =
         Address $ BL.toStrict $ runPut $ do
             putWord8 (base + networkId)
@@ -328,7 +328,7 @@ instance DelegationAddress 'Mainnet ShelleyKey 'AddressK where
         base = 0
         networkId = 1
 
-instance DelegationAddress ('Testnet pm) ShelleyKey 'AddressK where
+instance DelegationAddress ('Testnet pm) ShelleyKey 'CredFromKeyK where
     delegationAddress paymentK stakingK =
         Address $ BL.toStrict $ runPut $ do
             putWord8 (base + networkId)
@@ -351,7 +351,7 @@ instance MkKeyFingerprint ShelleyKey Address where
     paymentKeyFingerprint (Address bytes) =
         Right $ KeyFingerprint $ BS.take hashSize $ BS.drop 1 bytes
 
-instance MkKeyFingerprint ShelleyKey (Proxy (n :: NetworkDiscriminant), ShelleyKey 'AddressK XPub) where
+instance MkKeyFingerprint ShelleyKey (Proxy (n :: NetworkDiscriminant), ShelleyKey 'CredFromKeyK XPub) where
     paymentKeyFingerprint (_, paymentK) =
         Right $ KeyFingerprint $ blake2b224 $ xpubPublicKey $ getKey paymentK
 
@@ -402,7 +402,7 @@ instance ToRewardAccount ShelleyKey where
 toRewardAccountRaw :: XPub -> RewardAccount
 toRewardAccountRaw = RewardAccount . blake2b224 . xpubPublicKey
 
-instance DelegationAddress n ShelleyKey 'AddressK
+instance DelegationAddress n ShelleyKey 'CredFromKeyK
     => MaybeLight (SeqState n ShelleyKey)
   where
     maybeDiscover = Just $ DiscoverTxs discoverSeqWithRewards

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -234,6 +234,7 @@ deriveAddressPublicKeyShelley accXPub role (Index addrIx) =
 
 instance HardDerivation ShelleyKey where
     type AddressIndexDerivationType ShelleyKey = 'Soft
+    type AddressCredential ShelleyKey = 'CredFromKeyK
 
     deriveAccountPrivateKey pwd (ShelleyKey rootXPrv) ix =
         ShelleyKey $ deriveAccountPrivateKeyShelley purposeCIP1852 pwd rootXPrv ix

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -104,12 +104,12 @@ class IsOurs s entity where
 -- the root private key of a particular wallet. This isn't true for externally
 -- owned wallet which would delegate its key management to a third party (like
 -- a hardware Ledger or Trezor).
-class IsOurs s Address => IsOwned s key where
+class IsOurs s Address => IsOwned s key ktype where
     isOwned
         :: s
         -> (key 'RootK XPrv, Passphrase "encryption")
         -> Address
-        -> Maybe (key 'AddressK XPrv, Passphrase "encryption")
+        -> Maybe (key ktype XPrv, Passphrase "encryption")
         -- ^ Derive the private key corresponding to an address. Careful, this
         -- operation can be costly. Note that the state is discarded from this
         -- function as we do not intend to discover any addresses from this

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -267,7 +267,7 @@ newtype ErrImportAddress
     = ErrAddrDoesNotBelong Address
     deriving (Generic, Eq, Show)
 
-instance PaymentAddress n ByronKey => GenChange (RndState n) where
+instance PaymentAddress n ByronKey 'AddressK => GenChange (RndState n) where
     type ArgGenChange (RndState n) = (ByronKey 'RootK XPrv, Passphrase "encryption")
     genChange (rootXPrv, pwd) st = (address, st')
       where
@@ -319,7 +319,7 @@ deriveAddressKeyFromPath rootXPrv passphrase (accIx, addrIx) = addrXPrv
 
 -- | Use the key material in 'RndState' to derive a change address.
 deriveRndStateAddress
-    :: forall n. (PaymentAddress n ByronKey)
+    :: forall n. (PaymentAddress n ByronKey 'AddressK)
     => ByronKey 'RootK XPrv
     -> Passphrase "encryption"
     -> DerivationPath
@@ -443,7 +443,7 @@ instance IsOurs (RndAnyState n p) RewardAccount where
 instance KnownNat p => IsOwned (RndAnyState n p) ByronKey 'AddressK where
     isOwned _ _ _ = Nothing
 
-instance PaymentAddress n ByronKey => GenChange (RndAnyState n p) where
+instance PaymentAddress n ByronKey 'AddressK => GenChange (RndAnyState n p) where
     type ArgGenChange (RndAnyState n p) = ArgGenChange (RndState n)
     genChange a (RndAnyState s) = RndAnyState <$> genChange a s
 

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -218,7 +218,7 @@ instance IsOurs (RndState n) Address where
 instance IsOurs (RndState n) RewardAccount where
     isOurs _account state = (Nothing, state)
 
-instance IsOwned (RndState n) ByronKey where
+instance IsOwned (RndState n) ByronKey 'AddressK where
     isOwned st (key, pwd) addr =
         (, pwd) . deriveAddressKeyFromPath key pwd
             <$> addressToPath addr (hdPassphrase st)
@@ -440,7 +440,7 @@ instance KnownNat p => IsOurs (RndAnyState n p) Address where
 instance IsOurs (RndAnyState n p) RewardAccount where
     isOurs _account state = (Nothing, state)
 
-instance KnownNat p => IsOwned (RndAnyState n p) ByronKey where
+instance KnownNat p => IsOwned (RndAnyState n p) ByronKey 'AddressK where
     isOwned _ _ _ = Nothing
 
 instance PaymentAddress n ByronKey => GenChange (RndAnyState n p) where

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -560,7 +560,7 @@ instance
     , SupportsDiscovery n k
     , AddressIndexDerivationType k ~ 'Soft
     )
-    => IsOwned (SeqState n k) k where
+    => IsOwned (SeqState n k) k 'AddressK where
     isOwned st (rootPrv, pwd) addrRaw =
         case paymentKeyFingerprint addrRaw of
             Left _ -> Nothing
@@ -778,7 +778,7 @@ instance IsOurs (SeqAnyState n k p) RewardAccount where
 instance
     ( AddressIndexDerivationType k ~ 'Soft
     , KnownNat p
-    ) => IsOwned (SeqAnyState n k p) k
+    ) => IsOwned (SeqAnyState n k p) k 'AddressK
   where
     isOwned _ _ _ = Nothing
 

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
@@ -84,6 +84,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , SoftDerivation
     , WalletKey (..)
     , roleVal
+    , unsafePaymentKeyFingerprint
     , utxoExternal
     , utxoInternal
     )
@@ -109,7 +110,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , pendingIxsToList
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
-    ( AddressPoolGap (..), unsafePaymentKeyFingerprint )
+    ( AddressPoolGap (..) )
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase )
 import Cardano.Wallet.Primitive.Types.Address
@@ -158,7 +159,7 @@ import qualified Data.Text.Encoding as T
 
 -- | Convenient alias for commonly used class contexts on keys.
 type SupportsDiscovery (n :: NetworkDiscriminant) k =
-    ( MkKeyFingerprint k (Proxy n, k 'AddressK XPub)
+    ( MkKeyFingerprint k (Proxy n, k 'ScriptK XPub)
     , MkKeyFingerprint k Address
     , SoftDerivation k
     , Typeable n

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
@@ -99,6 +99,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , GenChange (..)
     , GetAccount (..)
     , IsOurs (..)
+    , IsOwned (..)
     , KnownAddresses (..)
     , MaybeLight (..)
     , PendingIxs
@@ -729,3 +730,8 @@ toSharedWalletId accXPub pTemplate dTemplateM =
   where
     serializeScriptTemplate (ScriptTemplate _ script) =
         T.encodeUtf8 $ scriptToText script
+
+instance ( key ~ SharedKey
+         , SupportsDiscovery n key ) =>
+         IsOwned (SharedState n key) key 'ScriptK where
+    isOwned _st (_rootPrv, _pwd) _addrRaw = undefined

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
@@ -156,8 +156,6 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 
-import qualified Debug.Trace as TR
-
 -- | Convenient alias for commonly used class contexts on keys.
 type SupportsDiscovery (n :: NetworkDiscriminant) k =
     ( MkKeyFingerprint k (Proxy n, k 'CredFromScriptK XPub)
@@ -547,12 +545,12 @@ isShared
     -> (Maybe (Index 'Soft 'CredFromScriptK, Role), SharedState n k)
 isShared addrRaw st = case ready st of
     Pending -> nop
-    Active (SharedAddressPools extPool intPool pending) -> TR.trace ("extPool:"<>show extPool) $
+    Active (SharedAddressPools extPool intPool pending) ->
         case paymentKeyFingerprint addrRaw of
             Left _ -> nop
             Right addr -> case ( AddressPool.lookup addr (getPool extPool)
                                , AddressPool.lookup addr (getPool intPool)) of
-                (Just ix, Nothing) -> TR.trace ("ix:"<>show ix) $
+                (Just ix, Nothing) ->
                     let pool' = AddressPool.update addr (getPool extPool) in
                     ( Just (ix, UtxoExternal)
                     , st { ready = Active
@@ -743,6 +741,6 @@ instance ( key ~ SharedKey
         (Just (ix, role'), _) ->
             let DerivationPrefix (_,_,accIx) = derivationPrefix st
                 accXPrv = deriveAccountPrivateKey pwd rootPrv accIx
-            in TR.trace ("accIx:"<>show accIx) $ Just ( deriveAddressPrivateKey pwd accXPrv role' ix
+            in Just ( deriveAddressPrivateKey pwd accXPrv role' ix
                     , pwd )
         (Nothing, _) -> Nothing

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
@@ -156,6 +156,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 
+import qualified Debug.Trace as TR
 
 -- | Convenient alias for commonly used class contexts on keys.
 type SupportsDiscovery (n :: NetworkDiscriminant) k =
@@ -546,12 +547,12 @@ isShared
     -> (Maybe (Index 'Soft 'CredFromScriptK, Role), SharedState n k)
 isShared addrRaw st = case ready st of
     Pending -> nop
-    Active (SharedAddressPools extPool intPool pending) ->
+    Active (SharedAddressPools extPool intPool pending) -> TR.trace ("extPool:"<>show extPool) $
         case paymentKeyFingerprint addrRaw of
             Left _ -> nop
             Right addr -> case ( AddressPool.lookup addr (getPool extPool)
                                , AddressPool.lookup addr (getPool intPool)) of
-                (Just ix, Nothing) ->
+                (Just ix, Nothing) -> TR.trace ("ix:"<>show ix) $
                     let pool' = AddressPool.update addr (getPool extPool) in
                     ( Just (ix, UtxoExternal)
                     , st { ready = Active
@@ -742,6 +743,6 @@ instance ( key ~ SharedKey
         (Just (ix, role'), _) ->
             let DerivationPrefix (_,_,accIx) = derivationPrefix st
                 accXPrv = deriveAccountPrivateKey pwd rootPrv accIx
-            in Just ( deriveAddressPrivateKey pwd accXPrv role' ix
+            in TR.trace ("accIx:"<>show accIx) $ Just ( deriveAddressPrivateKey pwd accXPrv role' ix
                     , pwd )
         (Nothing, _) -> Nothing

--- a/lib/core/src/Cardano/Wallet/Primitive/Delegation/State.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Delegation/State.hs
@@ -166,7 +166,7 @@ data State
     -- | There is more than one active stake keys. Can only be reached using
     -- wallets with support for multiple stake keys.
     | More
-        !(Index 'Soft 'AddressK)
+        !(Index 'Soft 'CredFromKeyK)
           -- nextKeyIx - the ix of the next unused key
         PointerUTxO
           -- ^ pointer utxo that need to be spent when changing state.
@@ -192,29 +192,29 @@ data Key0Status = ValidKey0 | MissingKey0
 
 instance NFData Key0Status
 
-instance (NFData (k 'AccountK XPub), NFData (k 'AddressK XPub))
+instance (NFData (k 'AccountK XPub), NFData (k 'CredFromKeyK XPub))
     => NFData (DelegationState k)
 
 deriving instance
     ( Show (k 'AccountK XPub)
-    , Show (k 'AddressK XPub)
+    , Show (k 'CredFromKeyK XPub)
     ) => Show (DelegationState k)
 
 deriving instance
     ( Eq (k 'AccountK XPub)
-    , Eq (k 'AddressK XPub)
+    , Eq (k 'CredFromKeyK XPub)
     ) => Eq (DelegationState k)
 
 keyAtIx
     :: (SoftDerivation k)
     => DelegationState k
-    -> Index 'Soft 'AddressK
-    -> k 'AddressK XPub
+    -> Index 'Soft 'CredFromKeyK
+    -> k 'CredFromKeyK XPub
 keyAtIx s = deriveAddressPublicKey (rewardAccountKey s) MutableAccount
 
 nextKeyIx
     :: DelegationState k
-    -> Index 'Soft 'AddressK
+    -> Index 'Soft 'CredFromKeyK
 nextKeyIx s = case state s of
     Zero -> minBound
     One -> succ minBound
@@ -222,7 +222,7 @@ nextKeyIx s = case state s of
 
 lastActiveIx
     :: DelegationState k
-    -> Maybe (Index 'Soft 'AddressK)
+    -> Maybe (Index 'Soft 'CredFromKeyK)
 lastActiveIx s
     | nextKeyIx s == minBound = Nothing
     | otherwise               = Just $ pred $ nextKeyIx s
@@ -238,7 +238,7 @@ data PointerUTxO = PointerUTxO { pTxIn :: TxIn, pCoin :: Coin }
 -- the @[0] -> [0,1] transition@, i.e. @nextKeyIx 1 -> nextKeyIx 2@.
 pointerIx
     :: Int
-    -> Maybe (Index 'Soft 'AddressK)
+    -> Maybe (Index 'Soft 'CredFromKeyK)
 pointerIx 0 = Nothing
 pointerIx 1 = Nothing
 pointerIx n = Just $ toEnum n
@@ -295,7 +295,7 @@ setPortfolioOf
     => DelegationState k
     -> Coin
         -- ^ minUTxOVal
-    -> (k 'AddressK XPub -> Address)
+    -> (k 'CredFromKeyK XPub -> Address)
         -- ^ A way to construct an Address
     -> (RewardAccount -> Bool)
         -- ^ Whether or not the key is registered.
@@ -347,7 +347,7 @@ setPortfolioOf ds minUTxOVal mkAddress isReg n =
             -- Note: If c > minUTxOVal we need to rely on the wallet to return the
             -- difference to the user as change.
 
-    deleg :: [Index 'Soft 'AddressK] -> [Cert]
+    deleg :: [Index 'Soft 'CredFromKeyK] -> [Cert]
     deleg = (>>= \ix ->
         if isReg (acct ix)
         then [Delegate (acct ix)]
@@ -355,7 +355,7 @@ setPortfolioOf ds minUTxOVal mkAddress isReg n =
         )
 
 
-    dereg :: [Index 'Soft 'AddressK] -> [Cert]
+    dereg :: [Index 'Soft 'CredFromKeyK] -> [Cert]
     dereg ixs =
         [ DeRegisterKey (acct ix)
         | ix <- ixs
@@ -373,7 +373,7 @@ applyTx
     :: forall k. ( SoftDerivation k
         , ToRewardAccount k
         , MkKeyFingerprint k Address
-        , MkKeyFingerprint k (k 'AddressK XPub))
+        , MkKeyFingerprint k (k 'CredFromKeyK XPub))
     => Tx
     -> Hash "Tx"
     -> DelegationState k
@@ -463,7 +463,7 @@ applyTx (Tx cs _ins outs) h ds0 = foldl applyCert ds0 cs
 -- [0, 1]
 -- >>> presentableKeys s2
 -- [0, 1, 2]
-presentableKeys :: SoftDerivation k => DelegationState k -> [k 'AddressK XPub]
+presentableKeys :: SoftDerivation k => DelegationState k -> [k 'CredFromKeyK XPub]
 presentableKeys s = case lastActiveIx s of
     Just i -> map (keyAtIx s) [minBound .. (succ i)]
     Nothing -> [keyAtIx s minBound]
@@ -484,13 +484,13 @@ presentableKeys s = case lastActiveIx s of
 -- Also note that old wallet software may unregister the first stake key 0
 -- despite stake key 1 being active. This doesn't affect `usableKeys`
 -- (it still includes key 0), as we view the state as incorrect and temporary.
-usableKeys :: SoftDerivation k => DelegationState k -> [k 'AddressK XPub]
+usableKeys :: SoftDerivation k => DelegationState k -> [k 'CredFromKeyK XPub]
 usableKeys s = case lastActiveIx s of
     Just i -> map (keyAtIx s) [minBound .. i]
     Nothing -> [keyAtIx s minBound]
 
 -- | For testing. Returns all registered and delegating stake keys.
-activeKeys :: SoftDerivation k => DelegationState k -> [k 'AddressK XPub]
+activeKeys :: SoftDerivation k => DelegationState k -> [k 'CredFromKeyK XPub]
 activeKeys ds = map (keyAtIx ds) $ case state ds of
     Zero                      -> []
     One                       -> [minBound]

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -412,6 +412,8 @@ data TransactionCtx = TransactionCtx
     -- ^ The assets to mint.
     , txAssetsToBurn :: (TokenMap, Map AssetId (Script KeyHash))
     -- ^ The assets to burn.
+    , txScriptInputs :: Map TxIn (Script KeyHash)
+    -- ^ A map of script hashes related to inputs. Only for multisig wallets
     , txCollateralRequirement :: SelectionCollateralRequirement
     -- ^ The collateral requirement.
     , txFeePadding :: !Coin
@@ -443,6 +445,7 @@ defaultTransactionCtx = TransactionCtx
     , txPlutusScriptExecutionCost = Coin 0
     , txAssetsToMint = (TokenMap.empty, Map.empty)
     , txAssetsToBurn = (TokenMap.empty, Map.empty)
+    , txScriptInputs = Map.empty
     , txCollateralRequirement = SelectionCollateralNotRequired
     , txFeePadding = Coin 0
     }

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -143,7 +143,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.Map.Strict as Map
 
-data TransactionLayer k tx = TransactionLayer
+data TransactionLayer k ktype tx = TransactionLayer
     { mkTransaction
         :: AnyCardanoEra
             -- Era for which the transaction should be created.
@@ -174,7 +174,7 @@ data TransactionLayer k tx = TransactionLayer
             -- Reward account
         -> (KeyHash, XPrv, Passphrase "encryption")
             -- policy public and private key
-        -> (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
+        -> (Address -> Maybe (k ktype XPrv, Passphrase "encryption"))
             -- Key store / address resolution
         -> (TxIn -> Maybe Address)
             -- Input resolution

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -412,7 +412,7 @@ data TransactionCtx = TransactionCtx
     -- ^ The assets to mint.
     , txAssetsToBurn :: (TokenMap, Map AssetId (Script KeyHash))
     -- ^ The assets to burn.
-    , txScriptInputs :: Map TxIn (Script KeyHash)
+    , txNativeScriptInputs :: Map TxIn (Script KeyHash)
     -- ^ A map of script hashes related to inputs. Only for multisig wallets
     , txCollateralRequirement :: SelectionCollateralRequirement
     -- ^ The collateral requirement.
@@ -445,7 +445,7 @@ defaultTransactionCtx = TransactionCtx
     , txPlutusScriptExecutionCost = Coin 0
     , txAssetsToMint = (TokenMap.empty, Map.empty)
     , txAssetsToBurn = (TokenMap.empty, Map.empty)
-    , txScriptInputs = Map.empty
+    , txNativeScriptInputs = Map.empty
     , txCollateralRequirement = SelectionCollateralNotRequired
     , txFeePadding = Coin 0
     }

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -149,7 +149,7 @@ data TransactionLayer k ktype tx = TransactionLayer
             -- Era for which the transaction should be created.
         -> (XPrv, Passphrase "encryption")
             -- Reward account
-        -> (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
+        -> (Address -> Maybe (k 'CredFromKeyK XPrv, Passphrase "encryption"))
             -- Key store
         -> ProtocolParameters
             -- Current protocol parameters

--- a/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
+++ b/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
@@ -184,7 +184,7 @@ prop_derivationPathRoundTrip
     :: Passphrase "addr-derivation-payload"
     -> Passphrase "addr-derivation-payload"
     -> Index 'WholeDomain 'AccountK
-    -> Index 'WholeDomain 'AddressK
+    -> Index 'WholeDomain 'CredFromKeyK
     -> Property
 prop_derivationPathRoundTrip pwd pwd' acctIx addrIx =
     let
@@ -208,7 +208,7 @@ instance {-# OVERLAPS #-} Arbitrary (Passphrase "addr-derivation-payload") where
         bytes <- BS.pack <$> vector 32
         return $ Passphrase $ BA.convert bytes
 
-instance Arbitrary (Index 'WholeDomain 'AddressK) where
+instance Arbitrary (Index 'WholeDomain 'CredFromKeyK) where
     shrink _ = []
     arbitrary = arbitraryBoundedEnum
 

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -558,7 +558,7 @@ instance Arbitrary (ShelleyKey 'RootK XPrv) where
 --        map pendingIxsFromList . shrink . pendingIxsToList
 --    arbitrary =
 --        pendingIxsFromList . Set.toList <$> arbitrary
-instance Arbitrary (PendingIxs 'AddressK) where
+instance Arbitrary (PendingIxs 'CredFromKeyK) where
     arbitrary = pure emptyPendingIxs
 
 instance ( Typeable ( c :: Role ) )
@@ -593,7 +593,7 @@ arbitrarySeqAccount =
     mw = someDummyMnemonic (Proxy @15)
 
 arbitraryRewardAccount
-    :: ShelleyKey 'AddressK XPub
+    :: ShelleyKey 'CredFromKeyK XPub
 arbitraryRewardAccount =
     publicKey $ Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
   where

--- a/lib/core/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -298,10 +298,10 @@ spec = parallel $ do
     manualMigrationsSpec
 
 stateMachineSpec
-    :: forall k s.
+    :: forall k s ktype.
         ( WalletKey k
         , PersistPrivateKey (k 'RootK)
-        , PaymentAddress 'Mainnet k
+        , PaymentAddress 'Mainnet k ktype
         , PersistAddressBook s
         , TestConstraints s k
         , Typeable s
@@ -314,11 +314,11 @@ stateMachineSpec = describe ("State machine test (" ++ showState @s ++ ")") $ do
     xit "Parallel" $ prop_parallel newDB
 
 stateMachineSpecSeq, stateMachineSpecRnd, stateMachineSpecShared :: Spec
-stateMachineSpecSeq = stateMachineSpec @ShelleyKey @(SeqState 'Mainnet ShelleyKey)
-stateMachineSpecRnd = stateMachineSpec @ByronKey @(RndState 'Mainnet)
-stateMachineSpecShared = stateMachineSpec @SharedKey @(SharedState 'Mainnet SharedKey)
+stateMachineSpecSeq = stateMachineSpec @ShelleyKey @(SeqState 'Mainnet ShelleyKey) @'AddressK
+stateMachineSpecRnd = stateMachineSpec @ByronKey @(RndState 'Mainnet) @'AddressK
+stateMachineSpecShared = stateMachineSpec @SharedKey @(SharedState 'Mainnet SharedKey) @'ScriptK
 
-instance PaymentAddress 'Mainnet SharedKey where
+instance PaymentAddress 'Mainnet SharedKey 'ScriptK where
     paymentAddress _ = error "does not make sense for SharedKey but want to use stateMachineSpec"
     liftPaymentAddress _ = error "does not make sense for SharedKey but want to use stateMachineSpec"
 
@@ -1105,7 +1105,7 @@ testMigrationTxMetaFee
         , WalletKey k
         , PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
-        , PaymentAddress 'Mainnet k
+        , PaymentAddress 'Mainnet k 'AddressK
         )
     => String
     -> Int
@@ -1162,7 +1162,7 @@ testMigrationCleanupCheckpoints
         , WalletKey k
         , PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
-        , PaymentAddress 'Mainnet k
+        , PaymentAddress 'Mainnet k 'AddressK
         )
     => String
     -> GenesisParameters
@@ -1200,7 +1200,7 @@ testMigrationRole
         , WalletKey k
         , PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
-        , PaymentAddress 'Mainnet k
+        , PaymentAddress 'Mainnet k 'AddressK
         , GetPurpose k
         , Show s
         )

--- a/lib/core/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -316,9 +316,9 @@ stateMachineSpec = describe ("State machine test (" ++ showState @s ++ ")") $ do
 stateMachineSpecSeq, stateMachineSpecRnd, stateMachineSpecShared :: Spec
 stateMachineSpecSeq = stateMachineSpec @ShelleyKey @(SeqState 'Mainnet ShelleyKey) @'CredFromKeyK
 stateMachineSpecRnd = stateMachineSpec @ByronKey @(RndState 'Mainnet) @'CredFromKeyK
-stateMachineSpecShared = stateMachineSpec @SharedKey @(SharedState 'Mainnet SharedKey) @'ScriptK
+stateMachineSpecShared = stateMachineSpec @SharedKey @(SharedState 'Mainnet SharedKey) @'CredFromScriptK
 
-instance PaymentAddress 'Mainnet SharedKey 'ScriptK where
+instance PaymentAddress 'Mainnet SharedKey 'CredFromScriptK where
     paymentAddress _ = error "does not make sense for SharedKey but want to use stateMachineSpec"
     liftPaymentAddress _ = error "does not make sense for SharedKey but want to use stateMachineSpec"
 

--- a/lib/core/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -314,8 +314,8 @@ stateMachineSpec = describe ("State machine test (" ++ showState @s ++ ")") $ do
     xit "Parallel" $ prop_parallel newDB
 
 stateMachineSpecSeq, stateMachineSpecRnd, stateMachineSpecShared :: Spec
-stateMachineSpecSeq = stateMachineSpec @ShelleyKey @(SeqState 'Mainnet ShelleyKey) @'AddressK
-stateMachineSpecRnd = stateMachineSpec @ByronKey @(RndState 'Mainnet) @'AddressK
+stateMachineSpecSeq = stateMachineSpec @ShelleyKey @(SeqState 'Mainnet ShelleyKey) @'CredFromKeyK
+stateMachineSpecRnd = stateMachineSpec @ByronKey @(RndState 'Mainnet) @'CredFromKeyK
 stateMachineSpecShared = stateMachineSpec @SharedKey @(SharedState 'Mainnet SharedKey) @'ScriptK
 
 instance PaymentAddress 'Mainnet SharedKey 'ScriptK where
@@ -1105,7 +1105,7 @@ testMigrationTxMetaFee
         , WalletKey k
         , PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
-        , PaymentAddress 'Mainnet k 'AddressK
+        , PaymentAddress 'Mainnet k 'CredFromKeyK
         )
     => String
     -> Int
@@ -1162,7 +1162,7 @@ testMigrationCleanupCheckpoints
         , WalletKey k
         , PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
-        , PaymentAddress 'Mainnet k 'AddressK
+        , PaymentAddress 'Mainnet k 'CredFromKeyK
         )
     => String
     -> GenesisParameters
@@ -1200,7 +1200,7 @@ testMigrationRole
         , WalletKey k
         , PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
-        , PaymentAddress 'Mainnet k 'AddressK
+        , PaymentAddress 'Mainnet k 'CredFromKeyK
         , GetPurpose k
         , Show s
         )

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -1000,7 +1000,7 @@ instance ToExpr (SharedKey 'AccountK CC.XPub) where
 instance ToExpr (KeyFingerprint "payment" SharedKey) where
     toExpr = defaultExprViaShow
 
-instance ToExpr (PendingIxs 'ScriptK) where
+instance ToExpr (PendingIxs 'CredFromScriptK) where
     toExpr = genericToExpr
 
 instance ToExpr (SharedAddressPool 'UtxoExternal SharedKey) where

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/ByronSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/ByronSpec.hs
@@ -68,23 +68,23 @@ prop_keyDerivationFromSeed
     :: SomeMnemonic
     -> Passphrase "encryption"
     -> Index 'WholeDomain 'AccountK
-    -> Index 'WholeDomain 'AddressK
+    -> Index 'WholeDomain 'CredFromKeyK
     -> Property
 prop_keyDerivationFromSeed seed encPwd accIx addrIx =
     rndKey `seq` property () -- NOTE Making sure this doesn't throw
   where
-    rndKey :: ByronKey 'AddressK XPrv
+    rndKey :: ByronKey 'CredFromKeyK XPrv
     rndKey = unsafeGenerateKeyFromSeed (accIx, addrIx) seed encPwd
 
 prop_keyDerivationFromXPrv
     :: XPrv
     -> Index 'WholeDomain 'AccountK
-    -> Index 'WholeDomain 'AddressK
+    -> Index 'WholeDomain 'CredFromKeyK
     -> Property
 prop_keyDerivationFromXPrv masterkey accIx addrIx =
     rndKey `seq` property () -- NOTE Making sure this doesn't throw
   where
-    rndKey :: ByronKey 'AddressK XPrv
+    rndKey :: ByronKey 'CredFromKeyK XPrv
     rndKey = unsafeMkByronKeyFromMasterKey (accIx, addrIx) masterkey
 
 {-------------------------------------------------------------------------------

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
@@ -96,7 +96,7 @@ prop_publicChildKeyDerivation
     :: SomeMnemonic
     -> Passphrase "encryption"
     -> Role
-    -> Index 'Soft 'AddressK
+    -> Index 'Soft 'CredFromKeyK
     -> Property
 prop_publicChildKeyDerivation seed encPwd cc ix =
     addrXPub1 === addrXPub2
@@ -124,7 +124,7 @@ prop_roundtripFingerprintLift
 prop_roundtripFingerprintLift addr =
     let
         fingerprint = paymentKeyFingerprint @IcarusKey addr
-        eAddr = liftPaymentAddress @'Mainnet @IcarusKey @'AddressK <$> fingerprint
+        eAddr = liftPaymentAddress @'Mainnet @IcarusKey @'CredFromKeyK <$> fingerprint
     in
         eAddr === Right addr
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
@@ -124,7 +124,7 @@ prop_roundtripFingerprintLift
 prop_roundtripFingerprintLift addr =
     let
         fingerprint = paymentKeyFingerprint @IcarusKey addr
-        eAddr = liftPaymentAddress @'Mainnet <$> fingerprint
+        eAddr = liftPaymentAddress @'Mainnet @IcarusKey @'AddressK <$> fingerprint
     in
         eAddr === Right addr
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/MintBurnSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/MintBurnSpec.hs
@@ -336,9 +336,9 @@ prop_keyHashMatchesXPrv pwd masterkey policyIx =
 
     getPublicKey
         :: ShelleyKey 'PolicyK XPrv
-        -> ShelleyKey 'ScriptK XPub
+        -> ShelleyKey 'CredFromScriptK XPub
     getPublicKey =
-        publicKey . (liftRawKey :: XPrv -> ShelleyKey 'ScriptK XPrv) . getRawKey
+        publicKey . (liftRawKey :: XPrv -> ShelleyKey 'CredFromScriptK XPrv) . getRawKey
 
 prop_keyDerivationSameIndexSameKey
     :: Passphrase "encryption"

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
@@ -219,7 +219,7 @@ prop_roundtripEnumIndexHard :: Index 'WholeDomain 'AccountK -> Property
 prop_roundtripEnumIndexHard ix =
     (toEnum . fromEnum) ix === ix .&&. (toEnum . fromEnum . getIndex) ix === ix
 
-prop_roundtripEnumIndexSoft :: Index 'Soft 'AddressK -> Property
+prop_roundtripEnumIndexSoft :: Index 'Soft 'CredFromKeyK -> Property
 prop_roundtripEnumIndexSoft ix =
     (toEnum . fromEnum) ix === ix .&&. (toEnum . fromEnum . getIndex) ix === ix
 
@@ -246,7 +246,7 @@ prop_roundtripXPub key = do
                              Arbitrary Instances
 -------------------------------------------------------------------------------}
 
-instance Arbitrary (Index 'Soft 'AddressK) where
+instance Arbitrary (Index 'Soft 'CredFromKeyK) where
     shrink _ = []
     arbitrary = arbitraryBoundedEnum
 
@@ -254,11 +254,11 @@ instance Arbitrary (Index 'Hardened 'AccountK) where
     shrink _ = []
     arbitrary = arbitraryBoundedEnum
 
-instance Arbitrary (Index 'Hardened 'AddressK) where
+instance Arbitrary (Index 'Hardened 'CredFromKeyK) where
     shrink _ = []
     arbitrary = arbitraryBoundedEnum
 
-instance Arbitrary (Index 'WholeDomain 'AddressK) where
+instance Arbitrary (Index 'WholeDomain 'CredFromKeyK) where
     shrink _ = []
     arbitrary = arbitraryBoundedEnum
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
@@ -159,7 +159,7 @@ prop_IndexesAlwaysHardened g accIx =
     in
         accIx' >= liftIndex (minBound :: Index 'Hardened 'AccountK)
       .&&.
-        addrIx >= liftIndex (minBound :: Index 'Hardened 'AddressK)
+        addrIx >= liftIndex (minBound :: Index 'Hardened 'CredFromKeyK)
 
 goldenSpecTestnet :: Spec
 goldenSpecTestnet =
@@ -281,7 +281,7 @@ data Rnd = Rnd
 prop_derivedKeysAreOurs
     :: Rnd
     -> Rnd
-    -> Index 'WholeDomain 'AddressK
+    -> Index 'WholeDomain 'CredFromKeyK
     -> Property
 prop_derivedKeysAreOurs rnd@(Rnd st _ _) (Rnd st' _ _) addrIx =
     isJust (fst $ isOurs addr st) .&&. isNothing (fst $ isOurs addr st')
@@ -291,12 +291,12 @@ prop_derivedKeysAreOurs rnd@(Rnd st _ _) (Rnd st' _ _) addrIx =
 prop_derivedKeysAreOwned
     :: Rnd
     -> Rnd
-    -> Index 'WholeDomain 'AddressK
+    -> Index 'WholeDomain 'CredFromKeyK
     -> Property
 prop_derivedKeysAreOwned (Rnd st rk pwd) (Rnd st' rk' pwd') addrIx =
-    isOwned @_ @_ @'AddressK st (rk, pwd) addr === Just (addrKey, pwd)
+    isOwned @_ @_ @'CredFromKeyK st (rk, pwd) addr === Just (addrKey, pwd)
     .&&.
-    isOwned @_ @_ @'AddressK st' (rk', pwd') addr === Nothing
+    isOwned @_ @_ @'CredFromKeyK st' (rk', pwd') addr === Nothing
   where
     addr = paymentAddress @'Mainnet (publicKey addrKey)
     addrKey = deriveAddressPrivateKey pwd acctKey addrIx
@@ -313,7 +313,7 @@ prop_changeAddressesBelongToUs (Rnd st rk pwd) (Rnd st' _ _) =
 
 prop_forbiddenAddresses
     :: Rnd
-    -> Index 'WholeDomain 'AddressK
+    -> Index 'WholeDomain 'CredFromKeyK
     -> Property
 prop_forbiddenAddresses rnd@(Rnd st rk pwd) addrIx = conjoin
     [ (Set.notMember addr (forbidden st))
@@ -332,7 +332,7 @@ prop_forbiddenAddresses rnd@(Rnd st rk pwd) addrIx = conjoin
 
 prop_oursAreUsed
     :: Rnd
-    -> Index 'WholeDomain 'AddressK
+    -> Index 'WholeDomain 'CredFromKeyK
     -> Property
 prop_oursAreUsed rnd@(Rnd st _ _) addrIx = do
     case find (\(a,_,_) -> (a == addr)) $ knownAddresses $ snd $ isOurs addr st of
@@ -363,7 +363,7 @@ instance Arbitrary Rnd where
 
 mkAddress
     :: Rnd
-    -> Index 'WholeDomain 'AddressK
+    -> Index 'WholeDomain 'CredFromKeyK
     -> Address
 mkAddress (Rnd (RndState _ accIx _ _ _) rk pwd) addrIx =
     let

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
@@ -294,9 +294,9 @@ prop_derivedKeysAreOwned
     -> Index 'WholeDomain 'AddressK
     -> Property
 prop_derivedKeysAreOwned (Rnd st rk pwd) (Rnd st' rk' pwd') addrIx =
-    isOwned st (rk, pwd) addr === Just (addrKey, pwd)
+    isOwned @_ @_ @'AddressK st (rk, pwd) addr === Just (addrKey, pwd)
     .&&.
-    isOwned st' (rk', pwd') addr === Nothing
+    isOwned @_ @_ @'AddressK st' (rk', pwd') addr === Nothing
   where
     addr = paymentAddress @'Mainnet (publicKey addrKey)
     addrKey = deriveAddressPrivateKey pwd acctKey addrIx

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -297,7 +297,7 @@ prop_lookupDiscovered (s0, addr) =
     mw = someDummyMnemonic (Proxy @12)
     key = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
     prop s = monadicIO $ liftIO $ do
-        unless (isJust $ isOwned @_ @_ @'AddressK s (key, mempty) addr) $ do
+        unless (isJust $ isOwned @_ @_ @'CredFromKeyK s (key, mempty) addr) $ do
             expectationFailure "couldn't find private key corresponding to addr"
 
 
@@ -437,7 +437,8 @@ instance AddressPoolTest ShelleyKey where
       where
         mkAddress k = delegationAddress @'Mainnet k rewardAccount
 
-rewardAccount :: ShelleyKey 'AddressK XPub
+rewardAccount
+    :: ShelleyKey 'CredFromKeyK XPub
 rewardAccount = publicKey $
     Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
   where
@@ -503,7 +504,7 @@ instance Arbitrary Address where
 
 instance
     ( Typeable c
-    , MkKeyFingerprint k (Proxy 'Mainnet, k 'AddressK XPub)
+    , MkKeyFingerprint k (Proxy 'Mainnet, k 'CredFromKeyK XPub)
     , MkKeyFingerprint k Address
     , SoftDerivation k
     , AddressPoolTest k
@@ -536,7 +537,7 @@ data Key = forall (k :: Depth -> * -> *).
     ( Typeable k
     , Eq (k 'AccountK XPub)
     , Show (k 'AccountK XPub)
-    , MkKeyFingerprint k (Proxy 'Mainnet, k 'AddressK XPub)
+    , MkKeyFingerprint k (Proxy 'Mainnet, k 'CredFromKeyK XPub)
     , MkKeyFingerprint k Address
     , SoftDerivation k
     , AddressPoolTest k

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -61,6 +61,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , MkAddressPoolGapError (..)
     , SeqAddressPool (..)
     , SeqState (..)
+    , SupportsDiscovery
     , coinTypeAda
     , defaultAddressPoolGap
     , mkAddressPoolGap
@@ -504,9 +505,7 @@ instance Arbitrary Address where
 
 instance
     ( Typeable c
-    , MkKeyFingerprint k (Proxy 'Mainnet, k 'CredFromKeyK XPub)
-    , MkKeyFingerprint k Address
-    , SoftDerivation k
+    , SupportsDiscovery 'Mainnet k
     , AddressPoolTest k
     , GetPurpose k
     , (k == SharedKey) ~ 'False

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -297,7 +297,7 @@ prop_lookupDiscovered (s0, addr) =
     mw = someDummyMnemonic (Proxy @12)
     key = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
     prop s = monadicIO $ liftIO $ do
-        unless (isJust $ isOwned s (key, mempty) addr) $ do
+        unless (isJust $ isOwned @_ @_ @'AddressK s (key, mempty) addr) $ do
             expectationFailure "couldn't find private key corresponding to addr"
 
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SharedSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SharedSpec.hs
@@ -108,7 +108,7 @@ spec = do
 prop_addressWithScriptFromOurVerKeyIxIn
     :: forall (n :: NetworkDiscriminant). Typeable n
     => CatalystSharedState
-    -> Index 'Soft 'ScriptK
+    -> Index 'Soft 'CredFromScriptK
     -> Property
 prop_addressWithScriptFromOurVerKeyIxIn (CatalystSharedState accXPub' accIx' pTemplate' dTemplate' g) keyIx =
     preconditions keyIx g dTemplate' ==>
@@ -121,7 +121,7 @@ prop_addressWithScriptFromOurVerKeyIxIn (CatalystSharedState accXPub' accIx' pTe
 prop_addressWithScriptFromOurVerKeyIxBeyond
     :: forall (n :: NetworkDiscriminant). Typeable n
     => CatalystSharedState
-    -> Index 'Soft 'ScriptK
+    -> Index 'Soft 'CredFromScriptK
     -> Property
 prop_addressWithScriptFromOurVerKeyIxBeyond (CatalystSharedState accXPub' accIx' pTemplate' dTemplate' g) keyIx =
     fromIntegral (fromEnum keyIx) >= threshold g ==>
@@ -133,7 +133,7 @@ prop_addressWithScriptFromOurVerKeyIxBeyond (CatalystSharedState accXPub' accIx'
 
 getAddrPool
     :: SharedState n k
-    -> AddressPool.Pool (KeyFingerprint "payment" k) (Index 'Soft 'ScriptK)
+    -> AddressPool.Pool (KeyFingerprint "payment" k) (Index 'Soft 'CredFromScriptK)
 getAddrPool st = case ready st of
     Active (SharedAddressPools (SharedAddressPool pool) _ _) -> pool
     Pending -> error "expected active state"
@@ -141,7 +141,7 @@ getAddrPool st = case ready st of
 prop_addressDiscoveryMakesAddressUsed
     :: forall (n :: NetworkDiscriminant). Typeable n
     => CatalystSharedState
-    -> Index 'Soft 'ScriptK
+    -> Index 'Soft 'CredFromScriptK
     -> Property
 prop_addressDiscoveryMakesAddressUsed (CatalystSharedState accXPub' accIx' pTemplate' dTemplate' g) keyIx =
     preconditions keyIx g dTemplate' ==>
@@ -156,7 +156,7 @@ prop_addressDiscoveryMakesAddressUsed (CatalystSharedState accXPub' accIx' pTemp
 prop_addressDoubleDiscovery
     :: forall (n :: NetworkDiscriminant). Typeable n
     => CatalystSharedState
-    -> Index 'Soft 'ScriptK
+    -> Index 'Soft 'CredFromScriptK
     -> Property
 prop_addressDoubleDiscovery (CatalystSharedState accXPub' accIx' pTemplate' dTemplate' g) keyIx =
     preconditions keyIx g dTemplate' ==>
@@ -171,7 +171,7 @@ prop_addressDoubleDiscovery (CatalystSharedState accXPub' accIx' pTemplate' dTem
 prop_addressDiscoveryImpossibleFromOtherAccXPub
     :: forall (n :: NetworkDiscriminant). Typeable n
     => CatalystSharedState
-    -> Index 'Soft 'ScriptK
+    -> Index 'Soft 'CredFromScriptK
     -> SharedKey 'AccountK XPub
     -> Property
 prop_addressDiscoveryImpossibleFromOtherAccXPub (CatalystSharedState _ accIx' pTemplate' dTemplate' g) keyIx accXPub' =
@@ -187,7 +187,7 @@ prop_addressDiscoveryImpossibleFromOtherAccXPub (CatalystSharedState _ accIx' pT
 prop_addressDiscoveryImpossibleFromOtherAccountOfTheSameRootXPrv
     :: forall (n :: NetworkDiscriminant). Typeable n
     => CatalystSharedState
-    -> Index 'Soft 'ScriptK
+    -> Index 'Soft 'CredFromScriptK
     -> (SharedKey 'RootK XPrv, Index 'Hardened 'AccountK, Index 'Hardened 'AccountK)
     -> Property
 prop_addressDiscoveryImpossibleFromOtherAccountOfTheSameRootXPrv (CatalystSharedState _ _ pTemplate' dTemplate' g) keyIx (rootXPrv, accIx', accIx'') =
@@ -206,7 +206,7 @@ prop_addressDiscoveryImpossibleFromOtherAccountOfTheSameRootXPrv (CatalystShared
 prop_addressDiscoveryImpossibleWithinAccountButDifferentScript
     :: forall (n :: NetworkDiscriminant). Typeable n
     => CatalystSharedState
-    -> Index 'Soft 'ScriptK
+    -> Index 'Soft 'CredFromScriptK
     -> OneCosignerScript
     -> Property
 prop_addressDiscoveryImpossibleWithinAccountButDifferentScript (CatalystSharedState accXPub' accIx' pTemplate' dTemplate' g) keyIx (OneCosignerScript script') =
@@ -222,7 +222,7 @@ prop_addressDiscoveryImpossibleWithinAccountButDifferentScript (CatalystSharedSt
 prop_addressDiscoveryDoesNotChangeGapInvariance
     :: forall (n :: NetworkDiscriminant). Typeable n
     => CatalystSharedState
-    -> Index 'Soft 'ScriptK
+    -> Index 'Soft 'CredFromScriptK
     -> Property
 prop_addressDiscoveryDoesNotChangeGapInvariance (CatalystSharedState accXPub' accIx' pTemplate' dTemplate' g) keyIx =
     preconditions keyIx g dTemplate' ==>
@@ -240,7 +240,7 @@ prop_addressDiscoveryDoesNotChangeGapInvariance (CatalystSharedState accXPub' ac
         $ getAddrPool sharedState'
 
 preconditions
-    :: Index 'Soft 'ScriptK
+    :: Index 'Soft 'CredFromScriptK
     -> AddressPoolGap
     -> Maybe ScriptTemplate
     -> Bool
@@ -253,7 +253,7 @@ preconditions keyIx g dTemplate' =
 
 threshold :: AddressPoolGap -> Word32
 threshold g =
-    fromIntegral (fromEnum (minBound @(Index 'Soft 'ScriptK))) +
+    fromIntegral (fromEnum (minBound @(Index 'Soft 'CredFromScriptK))) +
     getAddressPoolGap g
 
 data CatalystSharedState = CatalystSharedState

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SharedSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SharedSpec.hs
@@ -116,7 +116,7 @@ prop_addressWithScriptFromOurVerKeyIxIn (CatalystSharedState accXPub' accIx' pTe
   where
     addr = constructAddressFromIx @n UtxoExternal pTemplate' dTemplate' keyIx
     sharedState = mkSharedStateFromAccountXPub @n accXPub' accIx' g pTemplate' dTemplate'
-    (Just keyIx', _) = isShared @n addr sharedState
+    (Just (keyIx', _), _) = isShared @n addr sharedState
 
 prop_addressWithScriptFromOurVerKeyIxBeyond
     :: forall (n :: NetworkDiscriminant). Typeable n
@@ -150,7 +150,7 @@ prop_addressDiscoveryMakesAddressUsed (CatalystSharedState accXPub' accIx' pTemp
   where
     sharedState = mkSharedStateFromAccountXPub @n accXPub' accIx' g pTemplate' dTemplate'
     addr = AddressPool.addressFromIx (getAddrPool sharedState) keyIx
-    (Just ix, sharedState') = isShared @n (liftPaymentAddress @n addr) sharedState
+    (Just (ix, _), sharedState') = isShared @n (liftPaymentAddress @n addr) sharedState
     ourAddrs = AddressPool.addresses (getAddrPool sharedState')
 
 prop_addressDoubleDiscovery

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
@@ -20,7 +20,7 @@ import Cardano.Mnemonic
 import Cardano.Wallet.Gen
     ( genMnemonic )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (AccountK, AddressK, RootK)
+    ( Depth (AccountK, CredFromKeyK, RootK)
     , DerivationType (..)
     , Index
     , NetworkDiscriminant (..)
@@ -81,11 +81,11 @@ spec = do
 -------------------------------------------------------------------------------}
 
 prop_derivedKeysAreOurs
-    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ByronKey 'AddressK)
+    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ByronKey 'CredFromKeyK)
     => SomeMnemonic
     -> Passphrase "encryption"
     -> Index 'WholeDomain 'AccountK
-    -> Index 'WholeDomain 'AddressK
+    -> Index 'WholeDomain 'CredFromKeyK
     -> ByronKey 'RootK XPrv
     -> Property
 prop_derivedKeysAreOurs seed encPwd accIx addrIx rk' =
@@ -95,7 +95,7 @@ prop_derivedKeysAreOurs seed encPwd accIx addrIx rk' =
     fst' (a,_,_) = a
     (resPos, stPos') = isOurs addr (mkRndState @n rootXPrv 0)
     (resNeg, stNeg') = isOurs addr (mkRndState @n rk' 0)
-    key = publicKey $ unsafeGenerateKeyFromSeed @'AddressK (accIx, addrIx) seed encPwd
+    key = publicKey $ unsafeGenerateKeyFromSeed @'CredFromKeyK (accIx, addrIx) seed encPwd
     rootXPrv = generateKeyFromSeed seed encPwd
     addr = paymentAddress @n key
 
@@ -107,7 +107,7 @@ instance Arbitrary (Index 'WholeDomain 'AccountK) where
     shrink _ = []
     arbitrary = arbitraryBoundedEnum
 
-instance Arbitrary (Index 'WholeDomain 'AddressK) where
+instance Arbitrary (Index 'WholeDomain 'CredFromKeyK) where
     shrink _ = []
     arbitrary = arbitraryBoundedEnum
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
@@ -81,7 +81,7 @@ spec = do
 -------------------------------------------------------------------------------}
 
 prop_derivedKeysAreOurs
-    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ByronKey)
+    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ByronKey 'AddressK)
     => SomeMnemonic
     -> Passphrase "encryption"
     -> Index 'WholeDomain 'AccountK
@@ -95,7 +95,7 @@ prop_derivedKeysAreOurs seed encPwd accIx addrIx rk' =
     fst' (a,_,_) = a
     (resPos, stPos') = isOurs addr (mkRndState @n rootXPrv 0)
     (resNeg, stNeg') = isOurs addr (mkRndState @n rk' 0)
-    key = publicKey $ unsafeGenerateKeyFromSeed (accIx, addrIx) seed encPwd
+    key = publicKey $ unsafeGenerateKeyFromSeed @'AddressK (accIx, addrIx) seed encPwd
     rootXPrv = generateKeyFromSeed seed encPwd
     addr = paymentAddress @n key
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Delegation/StateSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Delegation/StateSpec.hs
@@ -296,6 +296,8 @@ instance ToRewardAccount StakeKey' where
 
 instance HardDerivation StakeKey' where
     type AddressIndexDerivationType StakeKey' = 'Soft
+    type AddressCredential StakeKey' = 'CredFromKeyK
+
     deriveAccountPrivateKey _ _ _ =
         error "deriveAccountPrivateKey: not implemented"
     deriveAddressPrivateKey _ _ _ _ =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Delegation/StateSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Delegation/StateSpec.hs
@@ -288,7 +288,7 @@ isConsecutiveRange (a:b:t)
 newtype StakeKey' (depth :: Depth) key = StakeKey' Word
     deriving newtype (Eq, Enum, Ord, Show, Bounded)
 
-type StakeKey = StakeKey' 'AddressK XPub
+type StakeKey = StakeKey' 'CredFromKeyK XPub
 
 instance ToRewardAccount StakeKey' where
     toRewardAccount (StakeKey' i) = RewardAccount . B8.pack $ show i
@@ -307,11 +307,11 @@ instance SoftDerivation StakeKey' where
 instance MkKeyFingerprint StakeKey' Address where
     paymentKeyFingerprint (Address addr) = Right $ KeyFingerprint $ B8.drop 4 addr
 
-instance PaymentAddress 'Mainnet StakeKey' 'AddressK where
+instance PaymentAddress 'Mainnet StakeKey' 'CredFromKeyK where
     liftPaymentAddress (KeyFingerprint fp) = Address fp
     paymentAddress k = Address $ "addr" <> unRewardAccount (toRewardAccount k)
 
-instance MkKeyFingerprint StakeKey' (StakeKey' 'AddressK XPub) where
+instance MkKeyFingerprint StakeKey' (StakeKey' 'CredFromKeyK XPub) where
     paymentKeyFingerprint k =
         Right $ KeyFingerprint $ unRewardAccount (toRewardAccount k)
 
@@ -465,7 +465,7 @@ stepCmd CmdOldWalletToggleFirstKey env =
             in tryApplyTx tx env
 stepCmd (CmdMimicPointerOutput (RewardAccount acc)) env =
             let
-                addr = liftPaymentAddress @'Mainnet @StakeKey' @'AddressK $
+                addr = liftPaymentAddress @'Mainnet @StakeKey' @'CredFromKeyK $
                     KeyFingerprint acc
                 c = Coin 1
                 out = TxOut addr (TB.fromCoin c)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Delegation/StateSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Delegation/StateSpec.hs
@@ -307,7 +307,7 @@ instance SoftDerivation StakeKey' where
 instance MkKeyFingerprint StakeKey' Address where
     paymentKeyFingerprint (Address addr) = Right $ KeyFingerprint $ B8.drop 4 addr
 
-instance PaymentAddress 'Mainnet StakeKey' where
+instance PaymentAddress 'Mainnet StakeKey' 'AddressK where
     liftPaymentAddress (KeyFingerprint fp) = Address fp
     paymentAddress k = Address $ "addr" <> unRewardAccount (toRewardAccount k)
 
@@ -465,7 +465,8 @@ stepCmd CmdOldWalletToggleFirstKey env =
             in tryApplyTx tx env
 stepCmd (CmdMimicPointerOutput (RewardAccount acc)) env =
             let
-                addr = liftPaymentAddress @'Mainnet @StakeKey' $ KeyFingerprint acc
+                addr = liftPaymentAddress @'Mainnet @StakeKey' @'AddressK $
+                    KeyFingerprint acc
                 c = Coin 1
                 out = TxOut addr (TB.fromCoin c)
                 tx = Tx [] [] [out]

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -1486,7 +1486,7 @@ instance IsOurs DummyState Address where
 instance IsOurs DummyState RewardAccount where
     isOurs _ s = (Nothing, s)
 
-instance IsOwned DummyState ShelleyKey where
+instance IsOwned DummyState ShelleyKey 'AddressK where
     isOwned (DummyState m) (rootK, pwd) addr = do
         ix <- Map.lookup addr m
         let accXPrv = deriveAccountPrivateKey pwd rootK minBound

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -1308,7 +1308,7 @@ instance Arbitrary UTxO where
 
 data WalletLayerFixture s m = WalletLayerFixture
     { _fixtureDBLayer :: DBLayer m s ShelleyKey
-    , _fixtureWalletLayer :: WalletLayer m s ShelleyKey
+    , _fixtureWalletLayer :: WalletLayer m s ShelleyKey 'AddressK
     , _fixtureWallet :: [WalletId]
     , _fixtureSlotNoTime :: SlotNo -> UTCTime
     }
@@ -1340,7 +1340,7 @@ setupFixture (wid, wname, wstate) = do
 
 -- | A dummy transaction layer to see the effect of a root private key. It
 -- implements a fake signer that still produces sort of witnesses
-dummyTransactionLayer :: TransactionLayer ShelleyKey SealedTx
+dummyTransactionLayer :: TransactionLayer ShelleyKey 'AddressK SealedTx
 dummyTransactionLayer = TransactionLayer
     { mkTransaction = \_era _stakeCredentials keystore _pp _ctx cs -> do
         let inps' = NE.toList $ second txOutCoin <$> view #inputs cs

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -1308,7 +1308,7 @@ instance Arbitrary UTxO where
 
 data WalletLayerFixture s m = WalletLayerFixture
     { _fixtureDBLayer :: DBLayer m s ShelleyKey
-    , _fixtureWalletLayer :: WalletLayer m s ShelleyKey 'AddressK
+    , _fixtureWalletLayer :: WalletLayer m s ShelleyKey 'CredFromKeyK
     , _fixtureWallet :: [WalletId]
     , _fixtureSlotNoTime :: SlotNo -> UTCTime
     }
@@ -1340,7 +1340,7 @@ setupFixture (wid, wname, wstate) = do
 
 -- | A dummy transaction layer to see the effect of a root private key. It
 -- implements a fake signer that still produces sort of witnesses
-dummyTransactionLayer :: TransactionLayer ShelleyKey 'AddressK SealedTx
+dummyTransactionLayer :: TransactionLayer ShelleyKey 'CredFromKeyK SealedTx
 dummyTransactionLayer = TransactionLayer
     { mkTransaction = \_era _stakeCredentials keystore _pp _ctx cs -> do
         let inps' = NE.toList $ second txOutCoin <$> view #inputs cs
@@ -1453,7 +1453,7 @@ mockNetworkLayer = dummyNetworkLayer
     dummyHash = Hash "dummy hash"
 
 newtype DummyState
-    = DummyState (Map Address (Index 'Soft 'AddressK))
+    = DummyState (Map Address (Index 'Soft 'CredFromKeyK))
     deriving (Generic, Show, Eq)
 
 instance Sqlite.AddressBookIso DummyState where
@@ -1486,7 +1486,7 @@ instance IsOurs DummyState Address where
 instance IsOurs DummyState RewardAccount where
     isOurs _ s = (Nothing, s)
 
-instance IsOwned DummyState ShelleyKey 'AddressK where
+instance IsOwned DummyState ShelleyKey 'CredFromKeyK where
     isOwned (DummyState m) (rootK, pwd) addr = do
         ix <- Map.lookup addr m
         let accXPrv = deriveAccountPrivateKey pwd rootK minBound

--- a/lib/shelley/bench/restore-bench.hs
+++ b/lib/shelley/bench/restore-bench.hs
@@ -485,12 +485,12 @@ benchmarksRnd
     :: forall (n :: NetworkDiscriminant) s k p.
         ( s ~ RndAnyState n p
         , k ~ ByronKey
-        , PaymentAddress n k
+        , PaymentAddress n k 'CredFromKeyK
         , NetworkDiscriminantVal n
         , KnownNat p
         )
     => Proxy n
-    -> WalletLayer IO s k
+    -> WalletLayer IO s k 'CredFromKeyK
     -> WalletId
     -> WalletName
     -> Text
@@ -533,7 +533,7 @@ benchmarksRnd _ w wid wname benchname restoreTime = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         let runSelection =
-                W.selectAssets @_ @_ @s @k w era pp selectAssetsParams getFee
+                W.selectAssets @_ @_ @s @k @'CredFromKeyK w era pp selectAssetsParams getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection
 
     oneAddress <- genAddresses 1 cp
@@ -590,12 +590,12 @@ benchmarksSeq
         ( s ~ SeqAnyState n k p
         , k ~ ShelleyKey
         , Typeable n
-        , PaymentAddress n k
+        , PaymentAddress n k 'CredFromKeyK
         , NetworkDiscriminantVal n
         , KnownNat p
         )
     => Proxy n
-    -> WalletLayer IO s k
+    -> WalletLayer IO s k 'CredFromKeyK
     -> WalletId
     -> WalletName
     -> Text -- ^ Bench name
@@ -637,7 +637,7 @@ benchmarksSeq _ w wid _wname benchname restoreTime = do
                 , selectionStrategy = SelectionStrategyOptimal
                 }
         let runSelection =
-                W.selectAssets @_ @_ @s @k w era pp selectAssetsParams getFee
+                W.selectAssets @_ @_ @s @k @'CredFromKeyK w era pp selectAssetsParams getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection
 
     let walletOverview = WalletOverview{utxo,addresses,transactions}
@@ -742,7 +742,7 @@ bench_restoration
         ( IsOurs s Address
         , IsOurs s RewardAccount
         , MaybeLight s
-        , IsOwned s k
+        , IsOwned s k 'CredFromKeyK
         , WalletKey k
         , NFData s
         , Show s
@@ -768,7 +768,7 @@ bench_restoration
     -> Bool -- ^ If @True@, will trace detailed progress to a .timelog file.
     -> Percentage -- ^ Target sync progress
     -> (Proxy n
-        -> WalletLayer IO s k
+        -> WalletLayer IO s k 'CredFromKeyK
         -> WalletId
         -> WalletName
         -> Text
@@ -894,7 +894,7 @@ traceBlockHeadersProgressForPlotting t0  tr = Tracer $ \bs -> do
 
 withBenchDBLayer
     :: forall s k a.
-        ( IsOwned s k
+        ( IsOwned s k 'CredFromKeyK
         , NFData s
         , Show s
         , PersistAddressBook s
@@ -947,7 +947,7 @@ waitForWalletsSyncTo
     => Percentage
     -> Tracer IO (BenchmarkLog n)
     -> Proxy n
-    -> WalletLayer IO s k
+    -> WalletLayer IO s k 'CredFromKeyK
     -> [WalletId]
     -> GenesisParameters
     -> NodeToClientVersionData

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -308,10 +308,10 @@ serveWallet
             )
         => Proxy n
         -> Socket
-        -> ApiLayer (RndState n) ByronKey
-        -> ApiLayer (SeqState n IcarusKey) IcarusKey
-        -> ApiLayer (SeqState n ShelleyKey) ShelleyKey
-        -> ApiLayer (SharedState n SharedKey) SharedKey
+        -> ApiLayer (RndState n) ByronKey 'AddressK
+        -> ApiLayer (SeqState n IcarusKey) IcarusKey 'AddressK
+        -> ApiLayer (SeqState n ShelleyKey) ShelleyKey 'AddressK
+        -> ApiLayer (SharedState n SharedKey) SharedKey 'ScriptK
         -> StakePoolLayer
         -> NtpClient
         -> IO ()
@@ -324,7 +324,7 @@ serveWallet
         Server.start serverSettings apiServerTracer tlsConfig socket application
 
     apiLayer
-        :: forall s k.
+        :: forall s k ktype.
             ( IsOurs s Address
             , IsOurs s RewardAccount
             , MaybeLight s
@@ -332,10 +332,10 @@ serveWallet
             , PersistPrivateKey (k 'RootK)
             , WalletKey k
             )
-        => TransactionLayer k SealedTx
+        => TransactionLayer k ktype SealedTx
         -> NetworkLayer IO (CardanoBlock StandardCrypto)
-        -> (WorkerCtx (ApiLayer s k) -> WalletId -> IO ())
-        -> IO (ApiLayer s k)
+        -> (WorkerCtx (ApiLayer s k ktype) -> WalletId -> IO ())
+        -> IO (ApiLayer s k ktype)
     apiLayer txLayer netLayer coworker = do
         tokenMetaClient <- newMetadataClient tokenMetadataTracer tokenMetaUri
         dbFactory <- Sqlite.newDBFactory

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -296,9 +296,9 @@ serveWallet
 
     startServer
         :: forall n.
-            ( PaymentAddress n IcarusKey
-            , PaymentAddress n ByronKey
-            , DelegationAddress n ShelleyKey
+            ( PaymentAddress n IcarusKey 'AddressK
+            , PaymentAddress n ByronKey 'AddressK
+            , DelegationAddress n ShelleyKey 'AddressK
             , DecodeAddress n
             , EncodeAddress n
             , EncodeStakeAddress n

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -296,9 +296,9 @@ serveWallet
 
     startServer
         :: forall n.
-            ( PaymentAddress n IcarusKey 'AddressK
-            , PaymentAddress n ByronKey 'AddressK
-            , DelegationAddress n ShelleyKey 'AddressK
+            ( PaymentAddress n IcarusKey 'CredFromKeyK
+            , PaymentAddress n ByronKey 'CredFromKeyK
+            , DelegationAddress n ShelleyKey 'CredFromKeyK
             , DecodeAddress n
             , EncodeAddress n
             , EncodeStakeAddress n
@@ -308,9 +308,9 @@ serveWallet
             )
         => Proxy n
         -> Socket
-        -> ApiLayer (RndState n) ByronKey 'AddressK
-        -> ApiLayer (SeqState n IcarusKey) IcarusKey 'AddressK
-        -> ApiLayer (SeqState n ShelleyKey) ShelleyKey 'AddressK
+        -> ApiLayer (RndState n) ByronKey 'CredFromKeyK
+        -> ApiLayer (SeqState n IcarusKey) IcarusKey 'CredFromKeyK
+        -> ApiLayer (SeqState n ShelleyKey) ShelleyKey 'CredFromKeyK
         -> ApiLayer (SharedState n SharedKey) SharedKey 'ScriptK
         -> StakePoolLayer
         -> NtpClient

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -311,7 +311,7 @@ serveWallet
         -> ApiLayer (RndState n) ByronKey 'CredFromKeyK
         -> ApiLayer (SeqState n IcarusKey) IcarusKey 'CredFromKeyK
         -> ApiLayer (SeqState n ShelleyKey) ShelleyKey 'CredFromKeyK
-        -> ApiLayer (SharedState n SharedKey) SharedKey 'ScriptK
+        -> ApiLayer (SharedState n SharedKey) SharedKey 'CredFromScriptK
         -> StakePoolLayer
         -> NtpClient
         -> IO ()

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -605,7 +605,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
             (knownPools spl) (getPoolLifeCycleStatus spl)
         :<|> signTransaction @_ @_ @_ @'CredFromScriptK apilayer
         :<|> decodeSharedTransaction apilayer
-        :<|> submitSharedTransaction @_ @_ @_ @n apilayer
+        :<|> submitSharedTransaction @_ @_ @_ apilayer
 
     blocks :: Handler ApiBlockHeader
     blocks = getBlocksLatestHeader (shelley ^. networkLayer)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -124,6 +124,7 @@ import Cardano.Wallet.Api.Server
     , selectCoinsForJoin
     , selectCoinsForQuit
     , signMetadata
+    , signSharedTransaction
     , signTransaction
     , submitTransaction
     , withLegacyLayer
@@ -602,6 +603,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     sharedTransactions apilayer =
         constructSharedTransaction apilayer (constructAddressFromIx @n UtxoInternal)
             (knownPools spl) (getPoolLifeCycleStatus spl)
+        :<|> signSharedTransaction apilayer
         :<|> decodeSharedTransaction apilayer
 
     blocks :: Handler ApiBlockHeader

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -240,7 +240,7 @@ server
     => ApiLayer (RndState n) ByronKey 'CredFromKeyK
     -> ApiLayer (SeqState n IcarusKey) IcarusKey 'CredFromKeyK
     -> ApiLayer (SeqState n ShelleyKey) ShelleyKey 'CredFromKeyK
-    -> ApiLayer (SharedState n SharedKey) SharedKey 'ScriptK
+    -> ApiLayer (SharedState n SharedKey) SharedKey 'CredFromScriptK
     -> StakePoolLayer
     -> NtpClient
     -> BlockchainSource
@@ -569,7 +569,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
                 _ -> pure (ApiHealthCheck NoSmashConfigured)
 
     sharedWallets
-        :: ApiLayer (SharedState n SharedKey) SharedKey 'ScriptK
+        :: ApiLayer (SharedState n SharedKey) SharedKey 'CredFromScriptK
         -> Server SharedWallets
     sharedWallets apilayer =
              postSharedWallet @_ @_ @SharedKey apilayer Shared.generateKeyFromSeed SharedKey
@@ -580,7 +580,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
         :<|> deleteWallet apilayer
 
     sharedWalletKeys
-        :: ApiLayer (SharedState n SharedKey) SharedKey 'ScriptK
+        :: ApiLayer (SharedState n SharedKey) SharedKey 'CredFromScriptK
         -> Server SharedWalletKeys
     sharedWalletKeys apilayer = derivePublicKey apilayer ApiVerificationKeyShared
         :<|> (\wid ix p -> postAccountPublicKey apilayer ApiAccountKeyShared wid ix (toKeyDataPurpose p) )
@@ -591,18 +591,18 @@ server byron icarus shelley multisig spl ntp blockchainSource =
               ApiPostAccountKeyDataWithPurpose p f Nothing
 
     sharedAddresses
-        :: ApiLayer (SharedState n SharedKey) SharedKey 'ScriptK
+        :: ApiLayer (SharedState n SharedKey) SharedKey 'CredFromScriptK
         -> Server (SharedAddresses n)
     sharedAddresses apilayer =
         listAddresses apilayer normalizeSharedAddress
 
     sharedTransactions
-        :: ApiLayer (SharedState n SharedKey) SharedKey 'ScriptK
+        :: ApiLayer (SharedState n SharedKey) SharedKey 'CredFromScriptK
         -> Server (SharedTransactions n)
     sharedTransactions apilayer =
         constructSharedTransaction apilayer (constructAddressFromIx @n UtxoInternal)
             (knownPools spl) (getPoolLifeCycleStatus spl)
-        :<|> signTransaction @_ @_ @_ @'ScriptK apilayer
+        :<|> signTransaction @_ @_ @_ @'CredFromScriptK apilayer
         :<|> decodeSharedTransaction apilayer
 
     blocks :: Handler ApiBlockHeader

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -124,7 +124,6 @@ import Cardano.Wallet.Api.Server
     , selectCoinsForJoin
     , selectCoinsForQuit
     , signMetadata
-    , signSharedTransaction
     , signTransaction
     , submitTransaction
     , withLegacyLayer
@@ -332,7 +331,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     shelleyTransactions :: Server (ShelleyTransactions n)
     shelleyTransactions =
              constructTransaction shelley (delegationAddress @n) (knownPools spl) (getPoolLifeCycleStatus spl)
-        :<|> signTransaction shelley
+        :<|> signTransaction @_ @_ @_ @'AddressK shelley
         :<|>
             (\wid mMinWithdrawal mStart mEnd mOrder simpleMetadataFlag ->
                 listTransactions shelley wid mMinWithdrawal mStart mEnd mOrder
@@ -603,7 +602,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     sharedTransactions apilayer =
         constructSharedTransaction apilayer (constructAddressFromIx @n UtxoInternal)
             (knownPools spl) (getPoolLifeCycleStatus spl)
-        :<|> signSharedTransaction apilayer
+        :<|> signTransaction @_ @_ @_ @'ScriptK apilayer
         :<|> decodeSharedTransaction apilayer
 
     blocks :: Handler ApiBlockHeader

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -125,6 +125,7 @@ import Cardano.Wallet.Api.Server
     , selectCoinsForQuit
     , signMetadata
     , signTransaction
+    , submitSharedTransaction
     , submitTransaction
     , withLegacyLayer
     , withLegacyLayer'
@@ -604,6 +605,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
             (knownPools spl) (getPoolLifeCycleStatus spl)
         :<|> signTransaction @_ @_ @_ @'CredFromScriptK apilayer
         :<|> decodeSharedTransaction apilayer
+        :<|> submitSharedTransaction @_ @_ @_ @n apilayer
 
     blocks :: Handler ApiBlockHeader
     blocks = getBlocksLatestHeader (shelley ^. networkLayer)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -231,9 +231,9 @@ import qualified Data.Text as T
 
 server
     :: forall n.
-        ( PaymentAddress n IcarusKey
-        , PaymentAddress n ByronKey
-        , DelegationAddress n ShelleyKey
+        ( PaymentAddress n IcarusKey 'AddressK
+        , PaymentAddress n ByronKey 'AddressK
+        , DelegationAddress n ShelleyKey 'AddressK
         , Typeable n
         , HasNetworkId n
         )

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -231,15 +231,15 @@ import qualified Data.Text as T
 
 server
     :: forall n.
-        ( PaymentAddress n IcarusKey 'AddressK
-        , PaymentAddress n ByronKey 'AddressK
-        , DelegationAddress n ShelleyKey 'AddressK
+        ( PaymentAddress n IcarusKey 'CredFromKeyK
+        , PaymentAddress n ByronKey 'CredFromKeyK
+        , DelegationAddress n ShelleyKey 'CredFromKeyK
         , Typeable n
         , HasNetworkId n
         )
-    => ApiLayer (RndState n) ByronKey 'AddressK
-    -> ApiLayer (SeqState n IcarusKey) IcarusKey 'AddressK
-    -> ApiLayer (SeqState n ShelleyKey) ShelleyKey 'AddressK
+    => ApiLayer (RndState n) ByronKey 'CredFromKeyK
+    -> ApiLayer (SeqState n IcarusKey) IcarusKey 'CredFromKeyK
+    -> ApiLayer (SeqState n ShelleyKey) ShelleyKey 'CredFromKeyK
     -> ApiLayer (SharedState n SharedKey) SharedKey 'ScriptK
     -> StakePoolLayer
     -> NtpClient
@@ -331,7 +331,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     shelleyTransactions :: Server (ShelleyTransactions n)
     shelleyTransactions =
              constructTransaction shelley (delegationAddress @n) (knownPools spl) (getPoolLifeCycleStatus spl)
-        :<|> signTransaction @_ @_ @_ @'AddressK shelley
+        :<|> signTransaction @_ @_ @_ @'CredFromKeyK shelley
         :<|>
             (\wid mMinWithdrawal mStart mEnd mOrder simpleMetadataFlag ->
                 listTransactions shelley wid mMinWithdrawal mStart mEnd mOrder
@@ -534,7 +534,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
         :<|> getNetworkClock ntp
       where
         nl = icarus ^. networkLayer
-        tl = icarus ^. transactionLayer @IcarusKey @'AddressK
+        tl = icarus ^. transactionLayer @IcarusKey @'CredFromKeyK
         genesis@(_,_) = icarus ^. genesisData
         mode = case blockchainSource of
           NodeSource {} -> Node

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Discriminant.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Discriminant.hs
@@ -40,10 +40,10 @@ data SomeNetworkDiscriminant where
     SomeNetworkDiscriminant
         :: forall (n :: NetworkDiscriminant).
             ( NetworkDiscriminantVal n
-            , PaymentAddress n IcarusKey 'AddressK
-            , PaymentAddress n ByronKey 'AddressK
-            , PaymentAddress n ShelleyKey 'AddressK
-            , DelegationAddress n ShelleyKey 'AddressK
+            , PaymentAddress n IcarusKey 'CredFromKeyK
+            , PaymentAddress n ByronKey 'CredFromKeyK
+            , PaymentAddress n ShelleyKey 'CredFromKeyK
+            , DelegationAddress n ShelleyKey 'CredFromKeyK
             , HasNetworkId n
             , DecodeAddress n
             , EncodeAddress n

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Discriminant.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Discriminant.hs
@@ -16,6 +16,7 @@ import Cardano.Wallet.Api.Types
     ( DecodeAddress, DecodeStakeAddress, EncodeAddress, EncodeStakeAddress )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DelegationAddress
+    , Depth (..)
     , NetworkDiscriminant
     , NetworkDiscriminantVal
     , PaymentAddress
@@ -39,10 +40,10 @@ data SomeNetworkDiscriminant where
     SomeNetworkDiscriminant
         :: forall (n :: NetworkDiscriminant).
             ( NetworkDiscriminantVal n
-            , PaymentAddress n IcarusKey
-            , PaymentAddress n ByronKey
-            , PaymentAddress n ShelleyKey
-            , DelegationAddress n ShelleyKey
+            , PaymentAddress n IcarusKey 'AddressK
+            , PaymentAddress n ByronKey 'AddressK
+            , PaymentAddress n ShelleyKey 'AddressK
+            , DelegationAddress n ShelleyKey 'AddressK
             , HasNetworkId n
             , DecodeAddress n
             , EncodeAddress n

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -387,7 +387,7 @@ mkTx
     -- ^ Slot at which the transaction will start and expire.
     -> (XPrv, Passphrase "encryption")
     -- ^ Reward account
-    -> (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
+    -> (Address -> Maybe (k 'CredFromKeyK XPrv, Passphrase "encryption"))
     -- ^ Key store
     -> Coin
     -- ^ An optional withdrawal amount, can be zero

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -435,7 +435,7 @@ mkTx networkId payload ttl (rewardAcnt, pwdAcnt) addrResolver wdrl cs fees era =
 --
 -- If a key for a given input isn't found, the input is skipped.
 signTransaction
-    :: forall k era.
+    :: forall k ktype era.
         ( EraConstraints era
         , TxWitnessTagFor k
         , WalletKey k
@@ -446,7 +446,7 @@ signTransaction
     -- ^ Stake key store / reward account resolution
     -> (KeyHash -> Maybe (XPrv, Passphrase "encryption"))
     -- ^ Policy key resolution
-    -> (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
+    -> (Address -> Maybe (k ktype XPrv, Passphrase "encryption"))
     -- ^ Payment key store
     -> (TxIn -> Maybe Address)
     -- ^ Input resolver
@@ -550,12 +550,12 @@ signTransaction
         pure $ mkShelleyWitness body (getRawKey k, pwd)
 
 newTransactionLayer
-    :: forall k.
+    :: forall k ktype.
         ( TxWitnessTagFor k
         , WalletKey k
         )
     => NetworkId
-    -> TransactionLayer k SealedTx
+    -> TransactionLayer k ktype SealedTx
 newTransactionLayer networkId = TransactionLayer
     { mkTransaction = \era stakeCreds keystore _pp ctx selection -> do
         let ttl   = txValidityInterval ctx

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -622,7 +622,7 @@ newTransactionLayer networkId = TransactionLayer
         let rewardAcct = toRewardAccountRaw stakeXPub
         let assetsToBeMinted = view #txAssetsToMint ctx
         let assetsToBeBurned = view #txAssetsToBurn ctx
-        let inpsScripts = view #txScriptInputs ctx
+        let inpsScripts = view #txNativeScriptInputs ctx
 
         case view #txDelegationAction ctx of
             Nothing -> do
@@ -2544,4 +2544,3 @@ toLedgerUTxO =
     . unCardanoUTxO
   where
     unCardanoUTxO (Cardano.UTxO m) = m
-

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -198,28 +198,28 @@ spec = do
 
     describe "Shelley Addresses" $ do
         prop "(Mainnet) can be deserialised by shelley ledger spec" $ \k -> do
-            let Address addr = paymentAddress @'Mainnet @ShelleyKey @'AddressK k
+            let Address addr = paymentAddress @'Mainnet @ShelleyKey @'CredFromKeyK k
             case SL.deserialiseAddr @StandardCrypto addr of
                 Just _ -> property True
                 Nothing -> property False
 
         prop "Shelley addresses from bech32" $ \k ->
-            let addr@(Address bytes) = paymentAddress @'Mainnet @ShelleyKey @'AddressK k
+            let addr@(Address bytes) = paymentAddress @'Mainnet @ShelleyKey @'CredFromKeyK k
             in  decodeAddress @'Mainnet (bech32 bytes) === Right addr
                     & counterexample (show $ bech32 bytes)
 
         prop "Shelley addresses with delegation from bech32" $ \k1 k2 ->
-            let addr@(Address bytes) = delegationAddress @'Mainnet @ShelleyKey @'AddressK k1 k2
+            let addr@(Address bytes) = delegationAddress @'Mainnet @ShelleyKey @'CredFromKeyK k1 k2
             in  decodeAddress @'Mainnet (bech32 bytes) === Right addr
                     & counterexample (show $ bech32 bytes)
 
         prop "Shelley addresses from bech32 - testnet" $ \k ->
-            let addr@(Address raw) = paymentAddress @('Testnet 0) @ShelleyKey @'AddressK k
+            let addr@(Address raw) = paymentAddress @('Testnet 0) @ShelleyKey @'CredFromKeyK k
             in  decodeAddress @('Testnet 0) (bech32testnet raw) === Right addr
                    & counterexample (show $ bech32testnet raw)
 
         prop "Byron addresses from base58" $ \k ->
-            let addr@(Address bytes) = paymentAddress @'Mainnet @ByronKey @'AddressK k
+            let addr@(Address bytes) = paymentAddress @'Mainnet @ByronKey @'CredFromKeyK k
             in  decodeAddress @'Mainnet (base58 bytes) === Right addr
                     & counterexample (show $ base58 bytes)
 
@@ -734,13 +734,13 @@ instance Arbitrary SlotId where
         <$> (W.EpochNo . fromIntegral <$> choose (0, 10 :: Word32))
         <*> (W.SlotInEpoch <$> choose (0, 10))
 
-instance Arbitrary (ShelleyKey 'AddressK XPrv) where
+instance Arbitrary (ShelleyKey 'CredFromKeyK XPrv) where
     shrink _ = []
     arbitrary = do
         mnemonic <- arbitrary
         return $ Shelley.unsafeGenerateKeyFromSeed mnemonic mempty
 
-instance Arbitrary (ByronKey 'AddressK XPrv) where
+instance Arbitrary (ByronKey 'CredFromKeyK XPrv) where
     shrink _ = []
     arbitrary = do
         mnemonic <- arbitrary
@@ -758,8 +758,8 @@ instance
         maxIndex = fromIntegral . getIndex $
             maxBound @(AddressDerivation.Index derivationType depth)
 
-instance (WalletKey k, Arbitrary (k 'AddressK XPrv)) =>
-    Arbitrary (k 'AddressK XPub)
+instance (WalletKey k, Arbitrary (k 'CredFromKeyK XPrv)) =>
+    Arbitrary (k 'CredFromKeyK XPub)
   where
     shrink _ = []
     arbitrary = publicKey <$> arbitrary

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -198,28 +198,28 @@ spec = do
 
     describe "Shelley Addresses" $ do
         prop "(Mainnet) can be deserialised by shelley ledger spec" $ \k -> do
-            let Address addr = paymentAddress @'Mainnet @ShelleyKey k
+            let Address addr = paymentAddress @'Mainnet @ShelleyKey @'AddressK k
             case SL.deserialiseAddr @StandardCrypto addr of
                 Just _ -> property True
                 Nothing -> property False
 
         prop "Shelley addresses from bech32" $ \k ->
-            let addr@(Address bytes) = paymentAddress @'Mainnet @ShelleyKey k
+            let addr@(Address bytes) = paymentAddress @'Mainnet @ShelleyKey @'AddressK k
             in  decodeAddress @'Mainnet (bech32 bytes) === Right addr
                     & counterexample (show $ bech32 bytes)
 
         prop "Shelley addresses with delegation from bech32" $ \k1 k2 ->
-            let addr@(Address bytes) = delegationAddress @'Mainnet @ShelleyKey k1 k2
+            let addr@(Address bytes) = delegationAddress @'Mainnet @ShelleyKey @'AddressK k1 k2
             in  decodeAddress @'Mainnet (bech32 bytes) === Right addr
                     & counterexample (show $ bech32 bytes)
 
         prop "Shelley addresses from bech32 - testnet" $ \k ->
-            let addr@(Address raw) = paymentAddress @('Testnet 0) @ShelleyKey k
+            let addr@(Address raw) = paymentAddress @('Testnet 0) @ShelleyKey @'AddressK k
             in  decodeAddress @('Testnet 0) (bech32testnet raw) === Right addr
                    & counterexample (show $ bech32testnet raw)
 
         prop "Byron addresses from base58" $ \k ->
-            let addr@(Address bytes) = paymentAddress @'Mainnet @ByronKey k
+            let addr@(Address bytes) = paymentAddress @'Mainnet @ByronKey @'AddressK k
             in  decodeAddress @'Mainnet (base58 bytes) === Right addr
                     & counterexample (show $ base58 bytes)
 

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -707,7 +707,7 @@ instance Arbitrary a => Arbitrary (NonEmpty a) where
 keyToAddress :: (XPrv, Passphrase "encryption") -> Address
 keyToAddress (xprv, _pwd) =
     -- TODO, decrypt?
-    paymentAddress @'Mainnet @ShelleyKey @'AddressK .
+    paymentAddress @'Mainnet @ShelleyKey @'CredFromKeyK .
     publicKey .
     liftRawKey @ShelleyKey $ xprv
 
@@ -734,11 +734,11 @@ utxoFromKeys keys utxoProp =
 
 lookupFnFromKeys
     :: [(XPrv, Passphrase "encryption")]
-    -> (Address -> Maybe (ShelleyKey 'AddressK XPrv, Passphrase "encryption"))
+    -> (Address -> Maybe (ShelleyKey 'CredFromKeyK XPrv, Passphrase "encryption"))
 lookupFnFromKeys keys addr =
     let
         addrMap
-            :: Map Address (ShelleyKey 'AddressK XPrv, Passphrase "encryption")
+            :: Map Address (ShelleyKey 'CredFromKeyK XPrv, Passphrase "encryption")
         addrMap = Map.fromList
             $ zip (keyToAddress <$> keys) (first liftRawKey <$> keys)
     in
@@ -1995,7 +1995,7 @@ prop_biggerMaxSizeMeansMoreInputs era size outs
         <=
         _estimateMaxNumberOfInputs @k era ((*2) <$> size ) defaultTransactionCtx outs
 
-testTxLayer :: TransactionLayer ShelleyKey 'AddressK SealedTx
+testTxLayer :: TransactionLayer ShelleyKey 'CredFromKeyK SealedTx
 testTxLayer = newTransactionLayer @ShelleyKey Cardano.Mainnet
 
 newtype ForByron a = ForByron { getForByron :: a } deriving (Show, Eq)
@@ -2424,7 +2424,7 @@ instance Arbitrary KeyHash where
         cred <- oneof [pure Payment, pure Delegation]
         KeyHash cred . BS.pack <$> vectorOf 28 arbitrary
 
-data Ctx m = Ctx (Tracer m WalletWorkerLog) (TransactionLayer ShelleyKey 'AddressK SealedTx)
+data Ctx m = Ctx (Tracer m WalletWorkerLog) (TransactionLayer ShelleyKey 'CredFromKeyK SealedTx)
     deriving Generic
 
 instance Arbitrary StdGenSeed  where

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1993,7 +1993,7 @@ prop_biggerMaxSizeMeansMoreInputs era size outs
         <=
         _estimateMaxNumberOfInputs @k era ((*2) <$> size ) defaultTransactionCtx outs
 
-testTxLayer :: TransactionLayer ShelleyKey SealedTx
+testTxLayer :: TransactionLayer ShelleyKey 'AddressK SealedTx
 testTxLayer = newTransactionLayer @ShelleyKey Cardano.Mainnet
 
 newtype ForByron a = ForByron { getForByron :: a } deriving (Show, Eq)
@@ -2422,7 +2422,7 @@ instance Arbitrary KeyHash where
         cred <- oneof [pure Payment, pure Delegation]
         KeyHash cred . BS.pack <$> vectorOf 28 arbitrary
 
-data Ctx m = Ctx (Tracer m WalletWorkerLog) (TransactionLayer ShelleyKey SealedTx)
+data Ctx m = Ctx (Tracer m WalletWorkerLog) (TransactionLayer ShelleyKey 'AddressK SealedTx)
     deriving Generic
 
 instance Arbitrary StdGenSeed  where

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -707,7 +707,9 @@ instance Arbitrary a => Arbitrary (NonEmpty a) where
 keyToAddress :: (XPrv, Passphrase "encryption") -> Address
 keyToAddress (xprv, _pwd) =
     -- TODO, decrypt?
-    paymentAddress @'Mainnet . publicKey . liftRawKey @ShelleyKey $ xprv
+    paymentAddress @'Mainnet @ShelleyKey @'AddressK .
+    publicKey .
+    liftRawKey @ShelleyKey $ xprv
 
 utxoFromKeys
     :: [(XPrv, Passphrase "encryption")]

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1808,7 +1808,7 @@ binaryCalculationsSpec' era = describe ("calculateBinary - "+||era||+"") $ do
           fee = toCardanoLovelace $ selectionDelta txOutCoin cs
           Right unsigned =
               mkUnsignedTx era (Nothing, slotNo) cs md mempty [] fee
-              TokenMap.empty TokenMap.empty Map.empty
+              TokenMap.empty TokenMap.empty Map.empty Map.empty
           cs = Selection
             { inputs = NE.fromList inps
             , collateral = []
@@ -1897,7 +1897,7 @@ makeShelleyTx era testCase = Cardano.makeSignedTransaction addrWits unsigned
     fee = toCardanoLovelace $ selectionDelta txOutCoin cs
     Right unsigned =
         mkUnsignedTx era (Nothing, slotNo) cs md mempty [] fee
-        TokenMap.empty TokenMap.empty Map.empty
+        TokenMap.empty TokenMap.empty Map.empty Map.empty
     addrWits = map (mkShelleyWitness unsigned) pairs
     cs = Selection
         { inputs = NE.fromList inps
@@ -1940,7 +1940,7 @@ makeByronTx era testCase = Cardano.makeSignedTransaction byronWits unsigned
     fee = toCardanoLovelace $ selectionDelta txOutCoin cs
     Right unsigned =
         mkUnsignedTx era (Nothing, slotNo) cs Nothing mempty [] fee
-        TokenMap.empty TokenMap.empty Map.empty
+        TokenMap.empty TokenMap.empty Map.empty Map.empty
     -- byronWits = map (mkByronWitness unsigned ntwrk Nothing) pairs
     byronWits = map (error "makeByronTx: broken") pairs  -- TODO: [ADP-919]
     cs = Selection

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -7573,6 +7573,25 @@ paths:
             schema: *ApiSignTransactionPostData
       responses: *responsesSignTransaction
 
+  /shared-wallets/{walletId}/transactions-submit:
+    post:
+      operationId: submitSharedTransaction
+      tags: ["Shared Transactions"]
+      summary: Submit
+      description: |
+        <p align="right">status: <strong>stable</strong></p>
+        Submit a transaction that was already created and fully signed.
+        Fails for foreign transactions that is transactions which lack
+        the wallet's inputs and withdrawals.
+      parameters:
+        - *parametersWalletId
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: *ApiSignedTransactionEncoded
+      responses: *responsesPostExternalTransaction
+
   /shared-wallets/{walletId}/keys/{index}:
     post:
       operationId: postAccountKeyShared

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -7552,7 +7552,7 @@ paths:
 
   /shared-wallets/{walletId}/transactions-sign:
     post:
-      operationId: signTransaction
+      operationId: signSharedTransaction
       tags: ["Shared Transactions"]
       summary: Sign
       description: |

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -7537,7 +7537,7 @@ paths:
       tags: ["Shared Transactions"]
       summary: Decode
       description: |
-        <p align="right">status: <strong>stable</strong></p>
+        <p align="right">status: <strong>under development</strong></p>
 
         Decode a serialized transaction, either freshly constructed,
         partially signed or fully-signed.
@@ -7549,6 +7549,29 @@ paths:
           application/json:
             schema: *ApiSerialisedTransactionEncoded
       responses: *responsesDecodedTransaction
+
+  /shared-wallets/{walletId}/transactions-sign:
+    post:
+      operationId: signTransaction
+      tags: ["Shared Transactions"]
+      summary: Sign
+      description: |
+        <p align="right">status: <strong>under development</strong></p>
+
+        Signs a serialised transaction, returning the modified
+        transaction.
+
+        This endpoint will add new witnesses using the keys available
+        to this wallet. Any existing witnesses will remain in the
+        witness set.
+      parameters:
+        - *parametersWalletId
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: *ApiSignTransactionPostData
+      responses: *responsesSignTransaction
 
   /shared-wallets/{walletId}/keys/{index}:
     post:


### PR DESCRIPTION
<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->

- [x] I have added sign endpoint scaffolding for shared wallets
- [x] I reused the implementation for signTransaction between shelley and multisig
       To be successful here the following refactoring was needed:
       1. A number of types needed to be parametrized over credential origin (for shelley it comes from key hash, for multisig it comes from script hash). `ApiLayer`, `TransactionLayer`, `MkFingerprint`, `PaymentAddress`, `DelegationAddress` and `IsOwned` were parametrized in this direction.
       2. The current `AddressK` and `ScriptK` are kinda misleading (especially first one). So I changed them
            `AddressK -> CredFromKeyK`
            `ScriptK -> CredFromScriptK`
       3. `HardDerivation` interface is extended and addresses with both `CredFrom{Key,Script}K` can be derived
- [x] IsOwned implementation for multisig
- [x] treat shelley and multisig inputs separately as they transform to cardano-node. shelley inputs goes with announcement that "KeyWitness" are expected, multisig with "ScriptWitness". The latter also need `Script KeyHash` included which needed a way to sneak this information. `TransactionCtx` was used to make it happen. 
- [x] add integration tests
- [x] add submitTransaction 

The `decodeTransaction` will be boosted in next PR, as multi-party witness signing. This PR covers one-party signing. 

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number
adp-1850

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
