### PR TITLE
[ADP-1812] new API endpoint to retrieve the full block header of the node tip 

### DIFF
--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -99,6 +99,7 @@ library
       Test.Integration.Framework.Request
       Test.Integration.Framework.TestData
       Test.Integration.Plutus
+      Test.Integration.Scenario.API.Blocks
       Test.Integration.Scenario.API.Byron.Wallets
       Test.Integration.Scenario.API.Byron.HWWallets
       Test.Integration.Scenario.API.Byron.Addresses

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Blocks.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Blocks.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Integration.Scenario.API.Blocks
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Api.Types.BlockHeader
+    ( ApiBlockHeader )
+import Test.Hspec
+    ( SpecWith, describe )
+import Test.Hspec.Extra
+    ( it )
+import Test.Integration.Framework.DSL
+    ( Context (..)
+    , Headers (..)
+    , Payload (..)
+    , expectResponseCode
+    , expectSuccess
+    , request
+    )
+
+import qualified Cardano.Wallet.Api.Link as Link
+import qualified Network.HTTP.Types.Status as HTTP
+
+spec :: SpecWith Context
+spec = describe "BLOCKS" $ do
+    it "LATEST_BLOCK Current tip is reported" $ \ctx -> do
+        r <- request
+            @ApiBlockHeader ctx Link.getBlocksLatestHeader Default Empty
+        expectSuccess r
+        expectResponseCode @IO HTTP.status200 r

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -189,6 +189,8 @@ library
       Cardano.Wallet.Api
       Cardano.Wallet.Api.Aeson.Variant
       Cardano.Wallet.Api.Client
+      Cardano.Wallet.Api.Aeson
+      Cardano.Wallet.Api.Hex
       Cardano.Wallet.Api.Link
       Cardano.Wallet.Api.Server
       Cardano.Wallet.Api.Server.Tls

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -195,6 +195,7 @@ library
       Cardano.Wallet.Api.Server
       Cardano.Wallet.Api.Server.Tls
       Cardano.Wallet.Api.Types
+      Cardano.Wallet.Api.Types.BlockHeader
       Cardano.Wallet.Api.Types.SchemaMetadata
       Cardano.Wallet.Checkpoints.Policy
       Cardano.Wallet.Checkpoints

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -150,7 +150,7 @@ module Cardano.Wallet.Api
     , SharedTransactions
         , ConstructSharedTransaction
         , DecodeSharedTransaction
-
+    , GetBlocksLatestHeader
     , Proxy_
         , PostExternalTransaction
 
@@ -234,6 +234,8 @@ import Cardano.Wallet.Api.Types
     , WalletPutData
     , WalletPutPassphraseData
     )
+import Cardano.Wallet.Api.Types.BlockHeader
+    ( ApiBlockHeader )
 import Cardano.Wallet.DB
     ( DBFactory, DBLayer )
 import Cardano.Wallet.Network
@@ -331,6 +333,7 @@ type Api n apiPool =
     :<|> SharedWalletKeys
     :<|> SharedAddresses n
     :<|> SharedTransactions n
+    :<|> GetBlocksLatestHeader
 
 {-------------------------------------------------------------------------------
                                   Wallets
@@ -996,6 +999,15 @@ type GetNetworkClock = "network"
     :> QueryFlag "forceNtpCheck"
     :> Get '[JSON] ApiNetworkClock
 
+{-------------------------------------------------------------------------------
+                                  Blocks
+
+-------------------------------------------------------------------------------}
+
+type GetBlocksLatestHeader = "blocks"
+    :> "latest"
+    :> "header"
+    :> Get '[JSON] ApiBlockHeader
 {-------------------------------------------------------------------------------
                                   SMASH
 

--- a/lib/core/src/Cardano/Wallet/Api/Aeson.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Aeson.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DerivingVia #-}
+
+module Cardano.Wallet.Api.Aeson
+    ( eitherToParser
+    , toTextJSON
+    , fromTextJSON
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Util
+    ( ShowFmt (..) )
+import Data.Aeson
+    ( ToJSON (..), Value, withText )
+import Data.Bifunctor
+    ( Bifunctor (..) )
+import Data.Text.Class
+    ( FromText (..), ToText (toText) )
+
+import qualified Data.Aeson.Types as Aeson
+
+eitherToParser :: Show s => Either s a -> Aeson.Parser a
+eitherToParser = either (fail . show) pure
+
+toTextJSON :: ToText a => a -> Value
+toTextJSON = toJSON . toText
+
+fromTextJSON :: FromText a => String -> Value -> Aeson.Parser a
+fromTextJSON n = withText n (eitherToParser . first ShowFmt  . fromText)

--- a/lib/core/src/Cardano/Wallet/Api/Hex.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Hex.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE DerivingVia #-}
+
+module Cardano.Wallet.Api.Hex
+    ( hexText
+    , fromHexText
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( fromHex, hex )
+import Data.ByteString
+    ( ByteString )
+import Data.Text
+    ( Text )
+
+import qualified Data.Text.Encoding as T
+
+hexText :: ByteString -> Text
+hexText = T.decodeLatin1 . hex
+
+fromHexText :: Text -> Either String ByteString
+fromHexText = fromHex . T.encodeUtf8

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -102,7 +102,7 @@ module Cardano.Wallet.Api.Link
     , getNetworkParams
     , getNetworkClock
     , getNetworkClock'
-
+    , getBlocksLatestHeader
       -- * Proxy
     , postExternalTransaction
 
@@ -918,6 +918,14 @@ patchSharedWallet w cred =
             endpoint @Api.PatchSharedWalletInDelegation (wid &)
   where
     wid = w ^. typed @(ApiT WalletId)
+
+--
+-- Node
+--
+
+getBlocksLatestHeader :: (Method, Text)
+getBlocksLatestHeader = endpoint @Api.GetBlocksLatestHeader id
+
 
 --
 -- Internals

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -98,6 +98,7 @@ module Cardano.Wallet.Api.Server
     , postPolicyId
     , constructSharedTransaction
     , decodeSharedTransaction
+    , getBlocksLatestHeader
 
     -- * Server error responses
     , IsServerError(..)
@@ -119,7 +120,8 @@ module Cardano.Wallet.Api.Server
 
     -- * Logging
     , WalletEngineLog (..)
-    ) where
+    )
+    where
 
 import Prelude
 
@@ -338,6 +340,8 @@ import Cardano.Wallet.Api.Types
     , toApiNetworkParameters
     , toApiUtxoStatistics
     )
+import Cardano.Wallet.Api.Types.BlockHeader
+    ( ApiBlockHeader, mkApiBlockHeader )
 import Cardano.Wallet.Api.Types.SchemaMetadata
     ( TxMetadataSchema (..), TxMetadataWithSchema (TxMetadataWithSchema) )
 import Cardano.Wallet.CoinSelection
@@ -3768,6 +3772,9 @@ getNetworkParameters (_block0, genesisNp) nl tl = do
 
 getNetworkClock :: NtpClient -> Bool -> Handler ApiNetworkClock
 getNetworkClock client = liftIO . getNtpStatus client
+
+getBlocksLatestHeader :: NetworkLayer IO Block -> Handler ApiBlockHeader
+getBlocksLatestHeader nl = liftIO $ mkApiBlockHeader <$> NW.currentNodeTip nl
 
 {-------------------------------------------------------------------------------
                                Miscellaneous

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -26,8 +26,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
-{-# OPTIONS_GHC -Wno-orphans #-}
-
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -26,6 +26,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
@@ -283,8 +285,12 @@ import Cardano.Mnemonic
     , mnemonicToText
     , natVals
     )
+import Cardano.Wallet.Api.Aeson
+    ( eitherToParser, fromTextJSON, toTextJSON )
 import Cardano.Wallet.Api.Aeson.Variant
     ( variant, variants )
+import Cardano.Wallet.Api.Hex
+    ( fromHexText, hexText )
 import Cardano.Wallet.Api.Types.SchemaMetadata
     ( TxMetadataWithSchema )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -294,8 +300,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , Index (..)
     , NetworkDiscriminant (..)
     , Role (..)
-    , fromHex
-    , hex
     )
 import Cardano.Wallet.Primitive.AddressDerivation.SharedKey
     ( purposeCIP1854 )
@@ -1856,9 +1860,9 @@ instance FromText Iso8601Time where
             <> ", e.g. 2012-09-25T10:15:00Z."
 
 instance FromJSON (ApiT Iso8601Time) where
-    parseJSON = fromTextJSON "ISO-8601 Time"
+    parseJSON = fromTextApiT "ISO-8601 Time"
 instance ToJSON (ApiT Iso8601Time) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 instance FromHttpApiData Iso8601Time where
     parseUrlPiece = first (T.pack . getTextDecodingError) . fromText
@@ -2141,9 +2145,9 @@ instance ToJSON ApiPolicyId where
     toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON (ApiT W.TokenPolicyId) where
-    parseJSON = fromTextJSON "PolicyId"
+    parseJSON = fromTextApiT "PolicyId"
 instance ToJSON (ApiT W.TokenPolicyId) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 instance FromJSON (ApiT W.TokenName) where
     parseJSON = withText "AssetName"
@@ -2152,9 +2156,9 @@ instance ToJSON (ApiT W.TokenName) where
     toJSON = toJSON . hexText . W.unTokenName . getApiT
 
 instance FromJSON (ApiT W.TokenFingerprint) where
-    parseJSON = fromTextJSON "TokenFingerprint"
+    parseJSON = fromTextApiT "TokenFingerprint"
 instance ToJSON (ApiT W.TokenFingerprint) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 instance FromJSON ApiAssetMetadata where
     parseJSON = genericParseJSON defaultRecordTypeOptions
@@ -2179,9 +2183,9 @@ instance ToJSON (ApiT W.AssetDecimals) where
     toJSON = toJSON . W.unAssetDecimals . getApiT
 
 instance ToJSON (ApiT DerivationIndex) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 instance FromJSON (ApiT DerivationIndex) where
-    parseJSON = fromTextJSON "DerivationIndex"
+    parseJSON = fromTextApiT "DerivationIndex"
 
 instance ToJSON ApiVerificationKeyShelley where
     toJSON (ApiVerificationKeyShelley (pub, role_) hashed) =
@@ -2695,7 +2699,7 @@ instance ToJSON (ByronWalletPostData mw) where
 instance FromJSON (ApiT PassphraseHash) where
     parseJSON = parseJSON >=> eitherToParser . first ShowFmt . fromText
 instance ToJSON (ApiT PassphraseHash) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 instance FromJSON (ApiT XPrv) where
     parseJSON = parseJSON >=> eitherToParser . first ShowFmt . fromText
@@ -2703,14 +2707,14 @@ instance ToJSON (ApiT XPrv) where
     toJSON = toJSON . toText
 
 instance FromJSON (ApiT (Hash "VerificationKey")) where
-    parseJSON = fromTextJSON "VerificationKey Hash"
+    parseJSON = fromTextApiT "VerificationKey Hash"
 instance ToJSON (ApiT (Hash "VerificationKey")) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 instance FromJSON (ApiT (Hash "TokenPolicy")) where
-    parseJSON = fromTextJSON "TokenPolicy Hash"
+    parseJSON = fromTextApiT "TokenPolicy Hash"
 instance ToJSON (ApiT (Hash "TokenPolicy")) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 instance FromJSON ByronWalletFromXPrvPostData where
     parseJSON = genericParseJSON defaultRecordTypeOptions
@@ -2817,9 +2821,9 @@ instance ToJSON ApiFee where
 
 instance (PassphraseMaxLength purpose, PassphraseMinLength purpose)
     => FromJSON (ApiT (Passphrase purpose)) where
-    parseJSON = fromTextJSON "Passphrase"
+    parseJSON = fromTextApiT "Passphrase"
 instance ToJSON (ApiT (Passphrase purpose)) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 instance FromJSON ApiCredential where
     parseJSON v =
@@ -2947,9 +2951,9 @@ instance ToJSON (ApiMnemonicT sizes) where
     toJSON (ApiMnemonicT (SomeMnemonic mw)) = toJSON (mnemonicToText mw)
 
 instance FromJSON (ApiT WalletId) where
-    parseJSON = fromTextJSON "WalletId"
+    parseJSON = fromTextApiT "WalletId"
 instance ToJSON (ApiT WalletId) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 instance FromJSON (ApiT AddressPoolGap) where
     parseJSON = parseJSON >=>
@@ -3021,9 +3025,9 @@ instance ToJSON ApiStakePoolFlag where
     toJSON = genericToJSON defaultSumTypeOptions
 
 instance FromJSON (ApiT WalletName) where
-    parseJSON = fromTextJSON "WalletName"
+    parseJSON = fromTextApiT "WalletName"
 instance ToJSON (ApiT WalletName) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 instance FromJSON (ApiT W.Settings) where
     parseJSON = fmap ApiT . genericParseJSON defaultRecordTypeOptions
@@ -3323,19 +3327,19 @@ instance EncodeStakeAddress n => ToJSON (ApiExternalCertificate n) where
     toJSON = genericToJSON apiCertificateOptions
 
 instance FromJSON (ApiT W.PoolOwner) where
-    parseJSON = fromTextJSON "ApiT PoolOwner"
+    parseJSON = fromTextApiT "ApiT PoolOwner"
 instance ToJSON (ApiT W.PoolOwner) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 instance FromJSON (ApiT W.StakePoolMetadataUrl) where
-    parseJSON = fromTextJSON "ApiT StakePoolMetadataUrl"
+    parseJSON = fromTextApiT "ApiT StakePoolMetadataUrl"
 instance ToJSON (ApiT W.StakePoolMetadataUrl) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 instance FromJSON (ApiT W.StakePoolMetadataHash) where
-    parseJSON = fromTextJSON "ApiT StakePoolMetadataHash"
+    parseJSON = fromTextApiT "ApiT StakePoolMetadataHash"
 instance ToJSON (ApiT W.StakePoolMetadataHash) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 instance FromJSON (ApiT W.NonWalletCertificate) where
   parseJSON val
@@ -3536,14 +3540,14 @@ instance ToJSON (ApiT TxIn) where
         , "index" .= toJSON ix ]
 
 instance FromJSON (ApiT (Hash "Tx")) where
-    parseJSON = fromTextJSON "Tx Hash"
+    parseJSON = fromTextApiT "Tx Hash"
 instance ToJSON (ApiT (Hash "Tx")) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 instance FromJSON (ApiT (Hash "Datum")) where
-    parseJSON = fromTextJSON "Datum Hash"
+    parseJSON = fromTextApiT "Datum Hash"
 instance ToJSON (ApiT (Hash "Datum")) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 instance FromJSON (ApiT Direction) where
     parseJSON = fmap ApiT . genericParseJSON defaultSumTypeOptions
@@ -3602,9 +3606,9 @@ instance ToJSON (ApiT ActiveSlotCoefficient) where
     toJSON (ApiT (ActiveSlotCoefficient sn)) = toJSON sn
 
 instance FromJSON (ApiT (Hash "Genesis")) where
-    parseJSON = fromTextJSON "Genesis Hash"
+    parseJSON = fromTextApiT "Genesis Hash"
 instance ToJSON (ApiT (Hash "Genesis")) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 instance FromJSON ApiEraInfo where
     parseJSON = genericParseJSON explicitNothingRecordTypeOptions
@@ -4029,25 +4033,6 @@ explicitNothingRecordTypeOptions = defaultRecordTypeOptions
     }
 
 {-------------------------------------------------------------------------------
-                                   Helpers
--------------------------------------------------------------------------------}
-
-eitherToParser :: Show s => Either s a -> Aeson.Parser a
-eitherToParser = either (fail . show) pure
-
-hexText :: ByteString -> Text
-hexText = T.decodeLatin1 . hex
-
-fromHexText :: Text -> Either String ByteString
-fromHexText = fromHex . T.encodeUtf8
-
-toTextJSON :: ToText a => ApiT a -> Value
-toTextJSON = toJSON . toText . getApiT
-
-fromTextJSON :: FromText a => String -> Value -> Aeson.Parser (ApiT a)
-fromTextJSON n = withText n (eitherToParser . bimap ShowFmt ApiT . fromText)
-
-{-------------------------------------------------------------------------------
                           User-Facing Address Encoding
 -------------------------------------------------------------------------------}
 
@@ -4188,9 +4173,9 @@ instance ToJSON ApiHealthCheck where
     toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON (ApiT SmashServer) where
-    parseJSON = fromTextJSON "SmashServer"
+    parseJSON = fromTextApiT "SmashServer"
 instance ToJSON (ApiT SmashServer) where
-    toJSON = toTextJSON
+    toJSON = toTextApiT
 
 {-------------------------------------------------------------------------------
                          Token minting types
@@ -4337,3 +4322,9 @@ instance (KnownSymbol s, FromJSON a) => FromJSON (ApiAsArray s (Maybe a)) where
 
 instance ToJSON a => ToJSON (ApiAsArray s (Maybe a)) where
     toJSON (ApiAsArray m) = toJSON (maybeToList m)
+
+fromTextApiT :: FromText a => String -> Value -> Parser (ApiT a)
+fromTextApiT t = fmap ApiT . fromTextJSON t
+
+toTextApiT :: ToText a => ApiT a -> Value
+toTextApiT = toTextJSON . getApiT

--- a/lib/core/src/Cardano/Wallet/Api/Types/BlockHeader.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types/BlockHeader.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Cardano.Wallet.Api.Types.BlockHeader
+    ( ApiBlockHeader (..)
+    , mkApiBlockHeader
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Api.Aeson
+    ( fromTextJSON, toTextJSON )
+import Cardano.Wallet.Primitive.Types
+    ( BlockHeader (..), SlotNo (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash )
+import Data.Aeson
+    ( FromJSON (parseJSON), ToJSON (toJSON), (.:), (.=) )
+import Data.Binary
+    ( Word32, Word64 )
+import Data.Quantity
+    ( Quantity (Quantity) )
+import GHC.Generics
+    ( Generic )
+
+import qualified Data.Aeson as Aeson
+
+data ApiBlockHeader = ApiBlockHeader
+  { headerHash :: Hash "BlockHeader"
+  , slotNo :: Quantity "slot" Word64
+  , blockHeight :: Quantity "block" Word32
+  }
+  deriving (Eq, Show, Generic)
+
+mkApiBlockHeader :: BlockHeader -> ApiBlockHeader
+mkApiBlockHeader BlockHeader{..} = ApiBlockHeader
+    {slotNo = Quantity $ unSlotNo slotNo, ..}
+
+instance ToJSON ApiBlockHeader where
+    toJSON ApiBlockHeader{..} =
+        Aeson.object
+            [ "slot_no" .= slotNo
+            , "block_height" .= blockHeight
+            , "header_hash" .= toTextJSON headerHash
+            ]
+
+instance FromJSON ApiBlockHeader where
+    parseJSON = Aeson.withObject "ApiBlockHeader" $ \o -> do
+        slotNo <- o .: "slot_no"
+        blockHeight <- o .: "block_height"
+        headerHash <- o .: "header_hash" >>= fromTextJSON "header_hash"
+        pure ApiBlockHeader{..}

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -203,6 +203,8 @@ import Cardano.Wallet.Api.Types
     , WalletPutPassphraseOldPassphraseData (..)
     , toApiAsset
     )
+import Cardano.Wallet.Api.Types.BlockHeader
+    ( ApiBlockHeader )
 import Cardano.Wallet.Api.Types.SchemaMetadata
     ( TxMetadataSchema (..), TxMetadataWithSchema (..) )
 import Cardano.Wallet.Gen
@@ -2725,7 +2727,10 @@ instance Arbitrary TxStatus where
     shrink = genericShrink
 
 instance Arbitrary (Quantity "block" Natural) where
-    arbitrary = fmap (Quantity . fromIntegral) (arbitrary @Word32)
+    arbitrary = Quantity . fromIntegral <$> arbitrary @Word32
+
+instance Arbitrary (Quantity "slot" Word64) where
+    arbitrary = Quantity <$> arbitrary @Word64
 
 instance Arbitrary ApiPostRandomAddressData where
     arbitrary = genericArbitrary
@@ -2802,6 +2807,12 @@ instance Arbitrary ApiNullStakeKey where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
+instance Arbitrary (Hash "BlockHeader") where
+    arbitrary = Hash . B8.pack <$> replicateM 32 arbitrary
+
+instance Arbitrary ApiBlockHeader where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
 {-------------------------------------------------------------------------------
                    Specification / Servant-Swagger Machinery
 
@@ -3180,6 +3191,9 @@ instance Typeable n => ToSchema (ApiDecodedTransaction n) where
         addDefinition =<< declareSchemaForDefinition "TransactionMetadataValueNoSchema"
         addDefinition =<< declareSchemaForDefinition "ScriptValue"
         declareSchemaForDefinition "ApiDecodedTransaction"
+
+instance ToSchema ApiBlockHeader where
+    declareNamedSchema _ = declareSchemaForDefinition "ApiBlockHeader"
 
 -- | Utility function to provide an ad-hoc 'ToSchema' instance for a definition:
 -- we simply look it up within the Swagger specification.

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -75,6 +75,7 @@ import Cardano.Wallet.Api.Server
     , getAccountPublicKey
     , getAsset
     , getAssetDefault
+    , getBlocksLatestHeader
     , getCurrentEpoch
     , getNetworkClock
     , getNetworkInformation
@@ -158,6 +159,8 @@ import Cardano.Wallet.Api.Types
     , SettingsPutData (..)
     , SomeByronWalletPostData (..)
     )
+import Cardano.Wallet.Api.Types.BlockHeader
+    ( ApiBlockHeader )
 import Cardano.Wallet.Api.Types.SchemaMetadata
     ( TxMetadataSchema (..), parseSimpleMetadataFlag )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -266,7 +269,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     :<|> sharedWalletKeys multisig
     :<|> sharedAddresses multisig
     :<|> sharedTransactions multisig
-    :<|> error "not implemented"
+    :<|> blocks
   where
     wallets :: Server Wallets
     wallets = deleteWallet shelley
@@ -618,6 +621,9 @@ server byron icarus shelley multisig spl ntp blockchainSource =
         constructSharedTransaction apilayer (constructAddressFromIx @n UtxoInternal)
             (knownPools spl) (getPoolLifeCycleStatus spl)
         :<|> decodeSharedTransaction apilayer
+
+    blocks :: Handler ApiBlockHeader
+    blocks = getBlocksLatestHeader (shelley ^. networkLayer)
 
 postAnyAddress
     :: NetworkId

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -266,6 +266,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     :<|> sharedWalletKeys multisig
     :<|> sharedAddresses multisig
     :<|> sharedTransactions multisig
+    :<|> error "not implemented"
   where
     wallets :: Server Wallets
     wallets = deleteWallet shelley

--- a/lib/shelley/test/integration/shelley-integration-test.hs
+++ b/lib/shelley/test/integration/shelley-integration-test.hs
@@ -149,6 +149,7 @@ import qualified Cardano.BM.Backend.EKGView as EKG
 import qualified Cardano.Pool.DB as Pool
 import qualified Cardano.Pool.DB.Sqlite as Pool
 import qualified Data.Text as T
+import qualified Test.Integration.Scenario.API.Blocks as Blocks
 import qualified Test.Integration.Scenario.API.Byron.Addresses as ByronAddresses
 import qualified Test.Integration.Scenario.API.Byron.CoinSelections as ByronCoinSelections
 import qualified Test.Integration.Scenario.API.Byron.HWWallets as ByronHWWallets
@@ -190,6 +191,7 @@ main = withTestsSetup $ \testDir tracers -> do
                 parallel $ do
                     Addresses.spec @n
                     CoinSelections.spec @n
+                    Blocks.spec
                     ByronAddresses.spec @n
                     ByronCoinSelections.spec @n
                     Wallets.spec @n

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -66,7 +66,7 @@ x-epochInfo: &epochInfo
     epoch_start_time: *date
 
 x-blockId: &blockId
-  description: The hash of genesis block
+  description: The hash of a block
   type: string
   format: hex
   maxLength: 64
@@ -3833,6 +3833,18 @@ components:
             type: array
             items: *ApiRedeemer
 
+    ApiBlockHeader: &ApiBlockHeader
+        description: |
+          A Block Header.
+        required:
+          - header_hash
+          - slot_no
+          - block_height
+        properties:
+          header_hash: *blockId
+          slot_no: *numberOfSlots
+          block_height: *numberOfBlocks
+
 
 #############################################################################
 #                                                                           #
@@ -6040,6 +6052,7 @@ x-tagGroups:
     - Proxy
     - Settings
     - Experimental
+    - Node
 
 paths:
   /wallets/{walletId}/signatures/{role}/{index}:
@@ -7624,3 +7637,18 @@ paths:
         - *parametersWalletId
         - *parametersAddressState
       responses: *responsesListAddresses
+
+  /blocks/latest/header:
+    get:
+      tags: ["Node"]
+      summary: Block Header
+      description: |
+        <p align="right">status: <strong>stable</strong></p>
+
+        Return the latest block-header available at the chain source
+      responses: 
+        200:
+          description: OK
+          content:
+            application/json:
+              schema: *ApiBlockHeader


### PR DESCRIPTION
- [x] added OpenAPI specifications
- [x] added an `ApiBlockHeader` to support the json specification
- [x] added a path in servant API type
- [x] added a response action in the server definition
- [x] add a simple integration test
- [x] add TypeSpec support
- [x] renounce to publish `parentHeader` as it's not available in the `currentTip`

### Comments

In progress

### Issue Number

ADP-1812
