### PR TITLE
Bump cardano-node to 1.35.3-rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See **Installation Instructions** for each available [release](https://github.co
 >
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
-> | `master` branch | [1.35.3-testnetonly](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3-testnetonly) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
+> | `master` branch | [1.35.3-rc1](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3-rc1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-07-01](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-07-01) | [1.35.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.0) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-05-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-05-27) | [1.34.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.34.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-04-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-04-27) | [1.34.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.34.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)

--- a/cabal.project
+++ b/cabal.project
@@ -84,8 +84,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/haskell-works/hw-aeson
-    tag: 5b4613379830ce06b167301c5ecb3c49c7d7eb4b
-    --sha256: 0i0f7rnbr49rk59fzap9433b00hklgiq26aq9vqgmw9dmafv43i3
+    tag: b5ef03a7d7443fcd6217ed88c335f0c411a05408
+    --sha256: 1dwx90wqavdl4d0npbzbxyh2pzi9zs1qz7nvsrb3n1cm2xbv4i5z
 
 -- Using a fork until our patches can be merged upstream
 
@@ -118,8 +118,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-addresses
-    tag: a5d50375f936ab13111c9f7d257d4bda0fa3eb85
-    --sha256: 12w7q9faix691djs45lcr547jm29y7jakqm112f3ipdsxwr3dsyx
+    tag: b7273a5d3c21f1a003595ebf1e1f79c28cd72513
+    --sha256: 129r5kyiw10n2021bkdvnr270aiiwyq58h472d151ph0r7wpslgp
     subdir: command-line
             core
 

--- a/cabal.project
+++ b/cabal.project
@@ -84,8 +84,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/haskell-works/hw-aeson
-    tag: 6dc309ff4260c71d9a18c220cbae8aa1dfe2a02e
-    --sha256: 08zxzkk1fy8xrvl46lhzmpyisizl0nzl1n00g417vc0l170wsr9j
+    tag: 5b4613379830ce06b167301c5ecb3c49c7d7eb4b
+    --sha256: 0i0f7rnbr49rk59fzap9433b00hklgiq26aq9vqgmw9dmafv43i3
 
 -- Using a fork until our patches can be merged upstream
 
@@ -118,8 +118,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-addresses
-    tag: 8f57479422264f33bfbf58198623c035cc973f30
-    --sha256: 032knh0kli2shpqh9b4w2ci9rp01q6p8albj56brg6gn5l9sknzy
+    tag: a5d50375f936ab13111c9f7d257d4bda0fa3eb85
+    --sha256: 12w7q9faix691djs45lcr547jm29y7jakqm112f3ipdsxwr3dsyx
     subdir: command-line
             core
 

--- a/cabal.project
+++ b/cabal.project
@@ -81,9 +81,10 @@ source-repository-package
 -- work with aeson-2, library dependencies will need to be updated to no longer use
 -- this compatibility shim and have bounds to indicate they work with aeson-2 only.
 -- After this, the dependency to hw-aeson can be dropped.
+-- Using a fork until our patches can be merged upstream: https://github.com/haskell-works/hw-aeson/pull/64
 source-repository-package
     type: git
-    location: https://github.com/haskell-works/hw-aeson
+    location: https://github.com/sevanspowell/hw-aeson
     tag: b5ef03a7d7443fcd6217ed88c335f0c411a05408
     --sha256: 1dwx90wqavdl4d0npbzbxyh2pzi9zs1qz7nvsrb3n1cm2xbv4i5z
 

--- a/cabal.project
+++ b/cabal.project
@@ -84,8 +84,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/haskell-works/hw-aeson
-    tag: d99d2f3e39a287607418ae605b132a3deb2b753f
-    --sha256: 1vxqcwjg9q37wbwi27y9ba5163lzfz51f1swbi0rp681yg63zvn4
+    tag: 6dc309ff4260c71d9a18c220cbae8aa1dfe2a02e
+    --sha256: 08zxzkk1fy8xrvl46lhzmpyisizl0nzl1n00g417vc0l170wsr9j
 
 -- Using a fork until our patches can be merged upstream
 
@@ -213,8 +213,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-node
-    tag: b443f540133888442e5475c05890dc2eee13d43e
-    --sha256: 0vg5775z683wf421asxjm7g2b6yxmgprpylhs9ryb035id83slp2
+    tag: 950c4e222086fed5ca53564e642434ce9307b0b9
+    --sha256: 020fwimsm24yblr1fmnwx240wj8r3x715p89cpjgnnd8axwf32p0
     subdir:
       cardano-api
       cardano-git-rev
@@ -317,8 +317,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/hedgehog-extras
-  tag: 967d79533c21e33387d0227a5f6cc185203fe658
-  --sha256: 0rbqb7a64aya1qizlr3im06hdydg9zr6sl3i8bvqqlf7kpa647sd
+  tag: 714ee03a5a786a05fc57ac5d2f1c2edce4660d85
+  --sha256: 1qa4mm36xynaf17990ijmzww0ij8hjrc0vw5nas6d0zx6q9hb978
 
 -- -------------------------------------------------------------------------
 -- Constraints tweaking

--- a/lib/core/src/Cardano/Api/Gen.hs
+++ b/lib/core/src/Cardano/Api/Gen.hs
@@ -1022,6 +1022,7 @@ genProtocolParameters =
     <*> liftArbitrary genNat
     <*> liftArbitrary genNat
     <*> liftArbitrary genNat
+    <*> liftArbitrary genLovelace
 
 genProtocolParametersWithAlonzoScripts :: Gen ProtocolParameters
 genProtocolParametersWithAlonzoScripts =
@@ -1051,6 +1052,7 @@ genProtocolParametersWithAlonzoScripts =
     <*> (Just <$> genNat)
     <*> (Just <$> genNat)
     <*> (Just <$> genNat)
+    <*> (Just <$> genLovelace)
 
 genWitnessNetworkIdOrByronAddress :: Gen WitnessNetworkIdOrByronAddress
 genWitnessNetworkIdOrByronAddress =
@@ -1296,6 +1298,8 @@ genProtocolParametersUpdate = do
         liftArbitrary genNat
     protocolUpdateMaxCollateralInputs <-
         liftArbitrary genNat
+    protocolUpdateUTxOCostPerByte <-
+        liftArbitrary genLovelace
 
     pure $ ProtocolParametersUpdate
         { Api.protocolUpdateProtocolVersion
@@ -1323,6 +1327,7 @@ genProtocolParametersUpdate = do
         , Api.protocolUpdateMaxValueSize
         , Api.protocolUpdateCollateralPercent
         , Api.protocolUpdateMaxCollateralInputs
+        , Api.protocolUpdateUTxOCostPerByte
         }
 
 genUpdateProposal :: CardanoEra era -> Gen (TxUpdateProposal era)

--- a/lib/core/src/Cardano/Api/Gen.hs
+++ b/lib/core/src/Cardano/Api/Gen.hs
@@ -1284,6 +1284,8 @@ genProtocolParametersUpdate = do
         liftArbitrary genRational
     protocolUpdateUTxOCostPerWord <-
         liftArbitrary genLovelace
+    protocolUpdateUTxOCostPerByte <-
+        liftArbitrary genLovelace
     protocolUpdateCostModels <-
         genCostModels
     protocolUpdatePrices <-
@@ -1298,8 +1300,6 @@ genProtocolParametersUpdate = do
         liftArbitrary genNat
     protocolUpdateMaxCollateralInputs <-
         liftArbitrary genNat
-    protocolUpdateUTxOCostPerByte <-
-        liftArbitrary genLovelace
 
     pure $ ProtocolParametersUpdate
         { Api.protocolUpdateProtocolVersion
@@ -1320,6 +1320,7 @@ genProtocolParametersUpdate = do
         , Api.protocolUpdateMonetaryExpansion
         , Api.protocolUpdateTreasuryCut
         , Api.protocolUpdateUTxOCostPerWord
+        , Api.protocolUpdateUTxOCostPerByte
         , Api.protocolUpdateCostModels
         , Api.protocolUpdatePrices
         , Api.protocolUpdateMaxTxExUnits
@@ -1327,7 +1328,6 @@ genProtocolParametersUpdate = do
         , Api.protocolUpdateMaxValueSize
         , Api.protocolUpdateCollateralPercent
         , Api.protocolUpdateMaxCollateralInputs
-        , Api.protocolUpdateUTxOCostPerByte
         }
 
 genUpdateProposal :: CardanoEra era -> Gen (TxUpdateProposal era)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -965,6 +965,7 @@ fromBlockfrostPP network pp@BF.ProtocolParams{..} = do
                     , protocolParamCollateralPercent = Just collateralPercent
                     , protocolParamMaxCollateralInputs =
                         Just $ intCast maxCollateralInputs
+                    , protocolParamUTxOCostPerByte = Just 4310
                     }
         , .. }
   where

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -937,6 +937,9 @@ fromBlockfrostPP network pp@BF.ProtocolParams{..} = do
                         Just $
                             Node.Lovelace $
                                 intCast _protocolParamsCoinsPerUtxoWord
+                    -- TODO Blockfrost has not yet updated their API to include
+                    -- the "UTxO Cost Per Byte" protocol parameter.
+                    , protocolParamUTxOCostPerByte = Nothing
                     , protocolParamCostModels =
                         Map.singleton
                             (AnyPlutusScriptVersion PlutusScriptV1)
@@ -965,7 +968,6 @@ fromBlockfrostPP network pp@BF.ProtocolParams{..} = do
                     , protocolParamCollateralPercent = Just collateralPercent
                     , protocolParamMaxCollateralInputs =
                         Just $ intCast maxCollateralInputs
-                    , protocolParamUTxOCostPerByte = Just 4310
                     }
         , .. }
   where

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -163,6 +163,10 @@ import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..), mockHash )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO
     ( MinimumUTxO (..) )
+import Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
+    ( testParameter_coinsPerUTxOByte_Babbage
+    , testParameter_coinsPerUTxOWord_Alonzo
+    )
 import Cardano.Wallet.Primitive.Types.Redeemer
     ( Redeemer (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
@@ -3842,7 +3846,10 @@ mockProtocolParametersForBalancing = (mockProtocolParameters, nodePParams)
         , Cardano.protocolParamPoolPledgeInfluence = 0
         , Cardano.protocolParamMonetaryExpansion = 0
         , Cardano.protocolParamTreasuryCut  = 0
-        , Cardano.protocolParamUTxOCostPerWord = Just 34482
+        , Cardano.protocolParamUTxOCostPerWord =
+            Just $ fromIntegral $ SL.unCoin testParameter_coinsPerUTxOWord_Alonzo
+        , Cardano.protocolParamUTxOCostPerByte =
+            Just $ fromIntegral $ SL.unCoin testParameter_coinsPerUTxOByte_Babbage
         , Cardano.protocolParamCostModels =
             Map.singleton
                 (Cardano.AnyPlutusScriptVersion Cardano.PlutusScriptV1)
@@ -3855,7 +3862,6 @@ mockProtocolParametersForBalancing = (mockProtocolParameters, nodePParams)
             Just $ Cardano.ExecutionUnits 10000000000 14000000
         , Cardano.protocolParamCollateralPercent = Just 1
         , Cardano.protocolParamMaxCollateralInputs = Just 3
-        , Cardano.protocolParamUTxOCostPerByte = Just 4310
         }
     costModel = Cardano.CostModel
         . fromMaybe (error "Plutus.defaultCostModelParams")

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3855,6 +3855,7 @@ mockProtocolParametersForBalancing = (mockProtocolParameters, nodePParams)
             Just $ Cardano.ExecutionUnits 10000000000 14000000
         , Cardano.protocolParamCollateralPercent = Just 1
         , Cardano.protocolParamMaxCollateralInputs = Just 3
+        , Cardano.protocolParamUTxOCostPerByte = Just 4310
         }
     costModel = Cardano.CostModel
         . fromMaybe (error "Plutus.defaultCostModelParams")


### PR DESCRIPTION
- Bump dependencies:
  - cardano-node to 1.35.3-rc1
  - hw-aeson to match cardano-node
  - hedgehog-extras to match cardano-node
- Update compatibility matrix.

### Comments

Changelogs:

- [API](https://github.com/input-output-hk/cardano-node/blob/release/1.35/cardano-api/ChangeLog.md)
- [CLI](https://github.com/input-output-hk/cardano-node/blob/release/1.35/cardano-cli/ChangeLog.md)
- [Node](https://github.com/input-output-hk/cardano-node/blob/release/1.35/cardano-node/ChangeLog.md)

- [Compare v1.35.3-testnetonly and v1.35.3-rc1](https://github.com/input-output-hk/cardano-node/compare/1.35.3-testnetonly...1.35.3-rc1)

### Issue Number

ADP-2123
