### PR TITLE
Update compatibility matrix to point to official 1.35.3 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See **Installation Instructions** for each available [release](https://github.co
 >
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
-> | `master` branch | [1.35.3-rc1](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3-rc1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
+> | `master` branch | [1.35.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-07-01](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-07-01) | [1.35.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.0) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-05-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-05-27) | [1.34.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.34.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-04-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-04-27) | [1.34.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.34.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)


### PR DESCRIPTION
- 1.35.3-rc1 was successful, hence there is no difference between 1.35.3-rc1 and
1.35.3.
- So we simply need to update the compatibility matrix.


### Issue Number

ADP-2123
