### PR TITLE
Bump version numbers for release of v2022-08-16

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ See **Installation Instructions** for each available [release](https://github.co
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
 > | `master` branch | [1.35.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
+> | [v2022-08-16](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-08-16) | [1.35.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-07-01](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-07-01) | [1.35.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.0) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-05-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-05-27) | [1.34.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.34.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
-> | [v2022-04-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-04-27) | [1.34.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.34.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 
 ## How to build from sources
 

--- a/cabal.project
+++ b/cabal.project
@@ -81,12 +81,11 @@ source-repository-package
 -- work with aeson-2, library dependencies will need to be updated to no longer use
 -- this compatibility shim and have bounds to indicate they work with aeson-2 only.
 -- After this, the dependency to hw-aeson can be dropped.
--- Using a fork until our patches can be merged upstream: https://github.com/haskell-works/hw-aeson/pull/64
 source-repository-package
     type: git
-    location: https://github.com/sevanspowell/hw-aeson
-    tag: b5ef03a7d7443fcd6217ed88c335f0c411a05408
-    --sha256: 1dwx90wqavdl4d0npbzbxyh2pzi9zs1qz7nvsrb3n1cm2xbv4i5z
+    location: https://github.com/haskell-works/hw-aeson
+    tag: ba7c1e41c6e54d6bf9fd1cd013489ac713fc3153
+    --sha256: 1czyn0whgv7czzgwn5y1zgwlkb9p9sn9z9sc9gixrjprcyc0p15p
 
 -- Using a fork until our patches can be merged upstream
 
@@ -119,8 +118,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-addresses
-    tag: b7273a5d3c21f1a003595ebf1e1f79c28cd72513
-    --sha256: 129r5kyiw10n2021bkdvnr270aiiwyq58h472d151ph0r7wpslgp
+    tag: 2d1904ad93c6b6fbc5bd20f3e7d074ace3ecfd35
+    --sha256: 1y4qzgcni8ifm2fz19bpykiah1m99xy6sj0w469nnwq0dc37zfkj
     subdir: command-line
             core
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:1.35.0
+    image: inputoutput/cardano-node:1.35.3
     environment:
       NETWORK:
     volumes:
@@ -17,7 +17,7 @@ services:
         max-size: "50m"
 
   cardano-wallet:
-    image: inputoutput/cardano-wallet:2022.7.1
+    image: inputoutput/cardano-wallet:2022.8.16
     volumes:
       - wallet-${NETWORK}-db:/wallet-db
       - node-ipc:/ipc

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-cli
-version:             2022.7.1
+version:             2022.8.16
 synopsis:            Utilities for a building Command-Line Interfaces
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-core-integration
-version:             2022.7.1
+version:             2022.8.16
 synopsis:            Core integration test library.
 description:         Shared core functionality for our integration test suites.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-core
-version:             2022.7.1
+version:             2022.8.16
 synopsis:            The Wallet Backend for a Cardano node.
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-launcher
-version:             2022.7.1
+version:             2022.8.16
 synopsis:            Utilities for a building commands launcher
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet
-version:             2022.7.1
+version:             2022.8.16
 synopsis:            Wallet backend protocol-specific bits implemented using Shelley nodes
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-test-utils
-version:             2022.7.1
+version:             2022.8.16
 synopsis:            Shared utilities for writing unit and property tests.
 description:         Shared utilities for writing unit and property tests.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -1,5 +1,5 @@
 name:                text-class
-version:             2022.7.1
+version:             2022.8.16
 synopsis:            Extra helpers to convert data-types to and from Text
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/nix/materialized/stack-nix/cardano-wallet-cli.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-cli.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-cli"; version = "2022.7.1"; };
+      identifier = { name = "cardano-wallet-cli"; version = "2022.8.16"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/materialized/stack-nix/cardano-wallet-core-integration.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-core-integration.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-core-integration";
-        version = "2022.7.1";
+        version = "2022.8.16";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/materialized/stack-nix/cardano-wallet-core.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-core.nix
@@ -11,7 +11,7 @@
     flags = { release = false; scrypt = true; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-core"; version = "2022.7.1"; };
+      identifier = { name = "cardano-wallet-core"; version = "2022.8.16"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/materialized/stack-nix/cardano-wallet-launcher.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-launcher.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-launcher"; version = "2022.7.1"; };
+      identifier = { name = "cardano-wallet-launcher"; version = "2022.8.16"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/materialized/stack-nix/cardano-wallet-test-utils.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-test-utils.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-test-utils";
-        version = "2022.7.1";
+        version = "2022.8.16";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/materialized/stack-nix/cardano-wallet.nix
+++ b/nix/materialized/stack-nix/cardano-wallet.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet"; version = "2022.7.1"; };
+      identifier = { name = "cardano-wallet"; version = "2022.8.16"; };
       license = "Apache-2.0";
       copyright = "2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/materialized/stack-nix/text-class.nix
+++ b/nix/materialized/stack-nix/text-class.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "text-class"; version = "2022.7.1"; };
+      identifier = { name = "text-class"; version = "2022.8.16"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -21,9 +21,9 @@ SCRIPT=$(realpath "$0")
 ################################################################################
 # Release-specific parameters. Can be changed interactively by running the script.
 # Release tags must follow format vYYYY-MM-DD.
-GIT_TAG="v2022-07-01"
-OLD_GIT_TAG="v2022-05-27"
-CARDANO_NODE_TAG="1.35.0"
+GIT_TAG="v2022-08-16"
+OLD_GIT_TAG="v2022-07-01"
+CARDANO_NODE_TAG="1.35.3"
 
 ################################################################################
 # Tag munging functions

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Cardano Wallet Backend API
-  version: v2022-07-01
+  version: v2022-08-16
   license:
     name: Apache-2.0
     url: https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/LICENSE


### PR DESCRIPTION
- [x] Bump dependencies to match `cardano-node` 1.35.3
- [x] Bump dependency on `cardano-addresses`.
- [x] Bump `cardano-wallet` version number to `2022.8.16`.

### Comments

In preparation for a release, this pull request bumps dependencies and the package  version number.

### Issue Number

ADP-1999