### PR TITLE
Fix coin_selection e2e test giving utxo_too_small rather than expected not_enough_money

### DIFF
--- a/test/e2e/spec/byron_spec.rb
+++ b/test/e2e/spec/byron_spec.rb
@@ -246,8 +246,8 @@ RSpec.describe CardanoWallet::Byron, :all, :byron do
       wid = create_byron_wallet "icarus"
       addresses = BYRON.addresses.list(wid)
       addr_amount = [
-         { addresses[0]['id'] => MIN_UTXO_VALUE },
-         { addresses[1]['id'] => MIN_UTXO_VALUE }
+         { addresses[0]['id'] => MIN_UTXO_VALUE_PURE_ADA },
+         { addresses[1]['id'] => MIN_UTXO_VALUE_PURE_ADA }
         ]
 
       rnd = BYRON.coin_selections.random wid, addr_amount

--- a/test/e2e/spec/byron_spec.rb
+++ b/test/e2e/spec/byron_spec.rb
@@ -246,8 +246,8 @@ RSpec.describe CardanoWallet::Byron, :all, :byron do
       wid = create_byron_wallet "icarus"
       addresses = BYRON.addresses.list(wid)
       addr_amount = [
-         { addresses[0]['id'] => 123 },
-         { addresses[1]['id'] => 456 }
+         { addresses[0]['id'] => MIN_UTXO_VALUE },
+         { addresses[1]['id'] => MIN_UTXO_VALUE }
         ]
 
       rnd = BYRON.coin_selections.random wid, addr_amount

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -400,7 +400,7 @@ RSpec.describe "Cardano Wallet E2E tests", :all, :e2e do
 
   describe "E2E Construct -> Sign -> Submit" do
     it "Single output transaction" do
-      amt = MIN_UTXO_VALUE
+      amt = MIN_UTXO_VALUE_PURE_ADA
       address = SHELLEY.addresses.list(@target_id)[0]['id']
       target_before = get_shelley_balances(@target_id)
       src_before = get_shelley_balances(@wid)
@@ -439,7 +439,7 @@ RSpec.describe "Cardano Wallet E2E tests", :all, :e2e do
     end
 
     it "Multi output transaction" do
-      amt = MIN_UTXO_VALUE
+      amt = MIN_UTXO_VALUE_PURE_ADA
       address = SHELLEY.addresses.list(@target_id)[0]['id']
       target_before = get_shelley_balances(@target_id)
       src_before = get_shelley_balances(@wid)
@@ -1573,7 +1573,7 @@ RSpec.describe "Cardano Wallet E2E tests", :all, :e2e do
   describe "E2E Shared" do
     describe "E2E Construct -> Sign -> Submit", :shared do
       it "Single output transaction" do
-        amt = MIN_UTXO_VALUE
+        amt = MIN_UTXO_VALUE_PURE_ADA
         address = SHELLEY.addresses.list(@target_id)[1]['id']
         target_before = get_shelley_balances(@target_id)
         src_before = get_shared_balances(@wid_sha)
@@ -1587,7 +1587,7 @@ RSpec.describe "Cardano Wallet E2E tests", :all, :e2e do
       end
 
       it "Multi output transaction" do
-        amt = MIN_UTXO_VALUE
+        amt = MIN_UTXO_VALUE_PURE_ADA
         address = SHELLEY.addresses.list(@target_id)[1]['id']
         target_before = get_shelley_balances(@target_id)
         src_before = get_shared_balances(@wid_sha)
@@ -1641,7 +1641,7 @@ RSpec.describe "Cardano Wallet E2E tests", :all, :e2e do
       end
 
       it "Validity intervals" do
-        amt = MIN_UTXO_VALUE
+        amt = MIN_UTXO_VALUE_PURE_ADA
         address = SHELLEY.addresses.list(@target_id)[1]['id']
         target_before = get_shelley_balances(@target_id)
         src_before = get_shared_balances(@wid_sha)
@@ -1817,7 +1817,7 @@ RSpec.describe "Cardano Wallet E2E tests", :all, :e2e do
 
     describe "Shelley Transactions" do
       it "I can send transaction and funds are received" do
-        amt = MIN_UTXO_VALUE
+        amt = MIN_UTXO_VALUE_PURE_ADA
 
         address = SHELLEY.addresses.list(@target_id)[0]['id']
         available_before = SHELLEY.wallets.get(@target_id)['balance']['available']['quantity']
@@ -1836,7 +1836,7 @@ RSpec.describe "Cardano Wallet E2E tests", :all, :e2e do
       end
 
       it "I can send transaction with ttl and funds are received" do
-        amt = MIN_UTXO_VALUE
+        amt = MIN_UTXO_VALUE_PURE_ADA
         ttl_in_s = 1200
 
         address = SHELLEY.addresses.list(@target_id)[0]['id']
@@ -1861,7 +1861,7 @@ RSpec.describe "Cardano Wallet E2E tests", :all, :e2e do
 
       it "Transaction with ttl = 0 would expire and I can forget it" do
         skip "Test is flaky due to ADP-608"
-        amt = MIN_UTXO_VALUE
+        amt = MIN_UTXO_VALUE_PURE_ADA
         ttl_in_s = 0
 
         address = SHELLEY.addresses.list(@target_id)[0]['id']
@@ -1887,7 +1887,7 @@ RSpec.describe "Cardano Wallet E2E tests", :all, :e2e do
       end
 
       it "I can send transaction using 'withdrawal' flag and funds are received" do
-        amt = MIN_UTXO_VALUE
+        amt = MIN_UTXO_VALUE_PURE_ADA
         address = SHELLEY.addresses.list(@target_id)[0]['id']
         target_before = get_shelley_balances(@target_id)
         src_before = get_shelley_balances(@wid)
@@ -1908,7 +1908,7 @@ RSpec.describe "Cardano Wallet E2E tests", :all, :e2e do
       end
 
       it "I can send transaction with metadata" do
-        amt = MIN_UTXO_VALUE
+        amt = MIN_UTXO_VALUE_PURE_ADA
         metadata = METADATA
 
         address = SHELLEY.addresses.list(@target_id)[0]['id']
@@ -1942,7 +1942,7 @@ RSpec.describe "Cardano Wallet E2E tests", :all, :e2e do
         metadata = METADATA
 
         address = SHELLEY.addresses.list(@target_id)[0]['id']
-        amt = [{ address => MIN_UTXO_VALUE }]
+        amt = [{ address => MIN_UTXO_VALUE_PURE_ADA }]
 
         txs = SHELLEY.transactions
         fees = txs.payment_fees(@wid, amt)
@@ -2165,7 +2165,7 @@ RSpec.describe "Cardano Wallet E2E tests", :all, :e2e do
   describe "E2E Byron" do
 
     def test_byron_tx(source_wid, target_wid)
-      amt = MIN_UTXO_VALUE
+      amt = MIN_UTXO_VALUE_PURE_ADA
       address = SHELLEY.addresses.list(target_wid)[0]['id']
       target_before = get_shelley_balances(target_wid)
       src_before = get_byron_balances(source_wid)
@@ -2327,7 +2327,7 @@ RSpec.describe "Cardano Wallet E2E tests", :all, :e2e do
 
   describe "E2E External transaction" do
     it "Single output transaction" do
-      amt = MIN_UTXO_VALUE
+      amt = MIN_UTXO_VALUE_PURE_ADA
       address = SHELLEY.addresses.list(@target_id)[0]['id']
       target_before = get_shelley_balances(@target_id)
       src_before = get_shelley_balances(@wid)

--- a/test/e2e/spec/shelley_spec.rb
+++ b/test/e2e/spec/shelley_spec.rb
@@ -303,8 +303,8 @@ RSpec.describe CardanoWallet::Shelley, :all, :shelley do
       wid = create_shelley_wallet
       addresses = SHELLEY.addresses.list(wid)
       addr_amount = [
-         { addresses[0]['id'] => 123 },
-         { addresses[1]['id'] => 456 }
+         { addresses[0]['id'] => MIN_UTXO_VALUE },
+         { addresses[1]['id'] => MIN_UTXO_VALUE }
         ]
 
       rnd = SHELLEY.coin_selections.random wid, addr_amount

--- a/test/e2e/spec/shelley_spec.rb
+++ b/test/e2e/spec/shelley_spec.rb
@@ -303,8 +303,8 @@ RSpec.describe CardanoWallet::Shelley, :all, :shelley do
       wid = create_shelley_wallet
       addresses = SHELLEY.addresses.list(wid)
       addr_amount = [
-         { addresses[0]['id'] => MIN_UTXO_VALUE },
-         { addresses[1]['id'] => MIN_UTXO_VALUE }
+         { addresses[0]['id'] => MIN_UTXO_VALUE_PURE_ADA },
+         { addresses[1]['id'] => MIN_UTXO_VALUE_PURE_ADA }
         ]
 
       rnd = SHELLEY.coin_selections.random wid, addr_amount

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -92,7 +92,10 @@ ASSETS = [ { "policy_id" => "ee1ce9d7560f48a4ba3867037dbec2d8fed776d94dd6b00a353
             },
          ]
 
-MIN_UTXO_VALUE = 1107670
+##
+# Since alonzo min_utxo_value is calculated based on the particular output size
+# 1 ADA, however should be enough for sending pure Ada output to shelley address
+MIN_UTXO_VALUE_PURE_ADA = 1000000
 
 def create_incomplete_shared_wallet(m, acc_ix, acc_xpub)
   script_template = { 'cosigners' =>


### PR DESCRIPTION

- [x] Fix coin_selection e2e test giving utxo_too_small rather than expected not_enough_money

### Comments

The failure was:
```
     Failure/Error: expect(rnd.to_s).to include "not_enough_money"
       expected "{\"code\":\"utxo_too_small\",\"message\":\"One of the outputs you've specified has an ada quantity t...: 00af2f6b...7f05be11 Required minimum ada quantity: 0.995610 Specified ada quantity: 0.000123  \"}" to include "not_enough_money"
```
Before the error was "not_enough_money" when triggering coin selection on emtpy wallet with ada amt < min_utxo_value, which seems to have changed.

### Issue Number

ADP-1978
