### PR TITLE
Improve cluster setup reliability

### DIFF
--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Cluster.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Cluster.hs
@@ -1100,8 +1100,9 @@ withCluster tr dir LocalClusterConfig{..} faucetFunds onClusterStart = bracketTr
         -- Submit retirement certs for all pools using the connection to
         -- the only running first pool to avoid the certs being rolled
         -- back.
-        forM_ configuredPools $ \pool -> do
-            finalizeShelleyGenesisSetup pool runningNode
+        when postAlonzo $
+            forM_ configuredPools $ \pool -> do
+                finalizeShelleyGenesisSetup pool runningNode
 
         -- Should ideally not be hard-coded in 'withCluster'
         (rawTx, faucetPrv) <- prepareKeyRegistration tr dir

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -255,6 +255,7 @@ withTestNode tr action = do
             defaultPoolConfigs
             BabbageHardFork
             (LogFileConfig Info Nothing Info)
+    let setup _ = return ()
     withSystemTempDir (contramap MsgTempDir tr) "network-spec" $ \dir ->
-        withCluster tr dir cfg [] $ \(RunningNode sock _ (np, vData) _) ->
+        withCluster tr dir cfg [] setup $ \(RunningNode sock _ (np, vData) _) ->
             action np sock vData

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -255,7 +255,6 @@ withTestNode tr action = do
             defaultPoolConfigs
             BabbageHardFork
             (LogFileConfig Info Nothing Info)
-    let setup _ = return ()
     withSystemTempDir (contramap MsgTempDir tr) "network-spec" $ \dir ->
-        withCluster tr dir cfg [] setup $ \(RunningNode sock _ (np, vData) _) ->
+        withCluster tr dir cfg mempty $ \(RunningNode sock _ (np, vData) _) ->
             action np sock vData


### PR DESCRIPTION
- [x] Ensure only a single pool has started when we submit txs containing important cluster setup
    - Avoids setup being rolled back, later causing integration test failures
- [x] See that it works 

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->

ADP-2140
