### PR TITLE
Use function `babbageMinUTxOValue` for faster minimum UTxO calculations.

### DIFF
--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Copyright: © 2022 IOHK
@@ -34,19 +33,16 @@ import Cardano.Wallet.Primitive.Types.Tx
 import Cardano.Wallet.Shelley.Compatibility
     ( toCardanoTxOut, unsafeLovelaceToWalletCoin, unsafeValueToLovelace )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( toBabbageTxOut )
+    ( toBabbageTxOut, toWalletCoin )
 import Data.Function
     ( (&) )
 import GHC.Stack
     ( HasCallStack )
-import Numeric.Natural
-    ( Natural )
 import Ouroboros.Consensus.Cardano.Block
     ( StandardBabbage )
 
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Ledger.Babbage.PParams as Babbage
-import qualified Cardano.Ledger.Coin as Ledger
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 
 -- | Computes a minimum 'Coin' value for a 'TokenMap' that is destined for
@@ -212,8 +208,7 @@ computeLedgerMinimumCoinForBabbage
     -> TokenBundle
     -> Coin
 computeLedgerMinimumCoinForBabbage pp addr tokenBundle =
-    Coin $ fromIntegral @Integer @Natural result
-  where
-    Ledger.Coin result = babbageMinUTxOValue pp
+    toWalletCoin
+        $ babbageMinUTxOValue pp
         $ mkSized
         $ toBabbageTxOut (TxOut addr tokenBundle) Nothing

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Copyright: © 2022 IOHK
@@ -13,6 +15,10 @@ module Cardano.Wallet.Shelley.MinimumUTxO
 
 import Prelude
 
+import Cardano.Ledger.Babbage.Rules.Utxo
+    ( babbageMinUTxOValue )
+import Cardano.Ledger.Serialization
+    ( mkSized )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -27,12 +33,20 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( TxOut (..), txOutMaxCoin )
 import Cardano.Wallet.Shelley.Compatibility
     ( toCardanoTxOut, unsafeLovelaceToWalletCoin, unsafeValueToLovelace )
+import Cardano.Wallet.Shelley.Compatibility.Ledger
+    ( toBabbageTxOut )
 import Data.Function
     ( (&) )
 import GHC.Stack
     ( HasCallStack )
+import Numeric.Natural
+    ( Natural )
+import Ouroboros.Consensus.Cardano.Block
+    ( StandardBabbage )
 
 import qualified Cardano.Api.Shelley as Cardano
+import qualified Cardano.Ledger.Babbage.PParams as Babbage
+import qualified Cardano.Ledger.Coin as Ledger
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 
 -- | Computes a minimum 'Coin' value for a 'TokenMap' that is destined for
@@ -66,11 +80,18 @@ computeMinimumCoinForUTxOShelleyBasedEra
     -> TokenMap
     -> Coin
 computeMinimumCoinForUTxOShelleyBasedEra
-    (MinimumUTxOForShelleyBasedEra era pp) addr tokenMap =
-        unsafeCoinFromCardanoApiCalculateMinimumUTxOResult $
-        Cardano.calculateMinimumUTxO era
-            (embedTokenMapWithinPaddedTxOut era addr tokenMap)
-            (Cardano.fromLedgerPParams era pp)
+    (MinimumUTxOForShelleyBasedEra era pp) addr tokenMap = case era of
+        -- Here we treat the Babbage era specially and use the ledger
+        -- to compute the minimum ada quantity, bypassing the Cardano
+        -- API. This appears to be significantly faster.
+        Cardano.ShelleyBasedEraBabbage ->
+            computeLedgerMinimumCoinForBabbage pp addr
+                (TokenBundle txOutMaxCoin tokenMap)
+        _ ->
+            unsafeCoinFromCardanoApiCalculateMinimumUTxOResult $
+            Cardano.calculateMinimumUTxO era
+                (embedTokenMapWithinPaddedTxOut era addr tokenMap)
+                (Cardano.fromLedgerPParams era pp)
 
 -- | Returns 'True' if and only if the given 'TokenBundle' has a 'Coin' value
 --   that is below the minimum acceptable 'Coin' value.
@@ -101,7 +122,15 @@ isBelowMinimumCoinForUTxOShelleyBasedEra
     -> Bool
 isBelowMinimumCoinForUTxOShelleyBasedEra
     (MinimumUTxOForShelleyBasedEra era pp) addr tokenBundle =
-        TokenBundle.getCoin tokenBundle < cardanoApiMinimumCoin
+        TokenBundle.getCoin tokenBundle <
+            -- Here we treat the Babbage era specially and use the ledger
+            -- to compute the minimum ada quantity, bypassing the Cardano
+            -- API. This appears to be significantly faster.
+            case era of
+                Cardano.ShelleyBasedEraBabbage ->
+                    computeLedgerMinimumCoinForBabbage pp addr tokenBundle
+                _ ->
+                    cardanoApiMinimumCoin
   where
     cardanoApiMinimumCoin :: Coin
     cardanoApiMinimumCoin =
@@ -174,3 +203,17 @@ unsafeCoinFromCardanoApiCalculateMinimumUTxOResult = \case
             , "unexpected error:"
             , show e
             ]
+
+-- | Uses the ledger to compute a minimum ada quantity for the Babbage era.
+--
+computeLedgerMinimumCoinForBabbage
+    :: Babbage.PParams StandardBabbage
+    -> Address
+    -> TokenBundle
+    -> Coin
+computeLedgerMinimumCoinForBabbage pp addr tokenBundle =
+    Coin $ fromIntegral @Integer @Natural result
+  where
+    Ledger.Coin result = babbageMinUTxOValue pp
+        $ mkSized
+        $ toBabbageTxOut (TxOut addr tokenBundle) Nothing


### PR DESCRIPTION
## Issue Number

ADP-2144

## Summary

This PR adjusts the `{compute,isBelow}MinimumCoinForUTxO` functions so that in the Babbage era only, we bypass the Cardano API function `calculateMinimumUTxO`, and instead directly use the ledger function `babbageMinUTxOValue`.

This leads to a significant reduction in latency when computing transaction fees:

**Before:**
```
    Latencies for 2 fixture wallets scenario
        postTransactionFee  - 3177.0 ms
    Latencies for 10 fixture wallets scenario
        postTransactionFee  - 3555.3 ms
```

**After:**
```
    Latencies for 2 fixture wallets scenario
        postTransactionFee  - 13.5 ms
    Latencies for 10 fixture wallets scenario
        postTransactionFee  - 15.6 ms
```