### PR TITLE
Don't use "testnet" in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ start with Daedalus.
 
 ```
 wget https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/docker-compose.yml
-NETWORK=testnet docker-compose up
+NETWORK=mainnet docker-compose up
 ```
 
 Fantastic! The server is up-and-running, waiting for HTTP requests on `localhost:8090/v2` e.g.:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,10 +41,6 @@ services:
 
 volumes:
   node-mainnet-db:
-  node-testnet-db:
-  node-alonzo-purple-db:
   wallet-mainnet-db:
-  wallet-testnet-db:
-  wallet-alonzo-purple-db:
   node-ipc:
   node-config:


### PR DESCRIPTION
- [x] I have removed ability to start our docker-compose in "testnet" as it no longer is compatible with cardano-node 1.35.3

### Comments
For the moment one will be able to start our docker-compose only for mainnet.
Cardano-node docker image currently does not support neither "preview" nor "preprod" as it used to support "testnet".
I have created issue for that -> https://github.com/input-output-hk/cardano-node/issues/4370.

As soon as it is addressed we can turn new environments on in our docker-compose.

### Issue Number

ADP-2135
