### PR TITLE
Make `TRANS_NEW_JOIN_01a` less flaky

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -2443,7 +2443,15 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             Default Empty
         verify rw1 [ expectListSize 0 ]
 
-        -- can use rewards with an explicit withdrawal request to self.
+        -- We can use rewards
+        -- Tested by making an explicit withdrawal request to self.
+
+        -- We wait for the start of a new epoch here
+        -- so that there is a good chance that we spend all rewards
+        -- in the next transaction, and don't receive any new rewards
+        -- before that transaction has concluded.
+        waitForNextEpoch ctx
+
         addrs <- listAddresses @n ctx dest
         let coin = minUTxOValue (_mainEra ctx) :: Natural
         let addr = (addrs !! 1) ^. #id
@@ -2479,6 +2487,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                     [ expectField
                         (#balance . #reward)
                         (`shouldBe` (Quantity 0))
+                        -- this assumes that we have received no new rewards
                     , expectField
                         (#balance . #available)
                         (.> previousBalance)


### PR DESCRIPTION
- [x] Attempt to make the `TRANS_NEW_JOIN_01a ` integration test less flaky by adding `waitForNextEpoch` before withdrawing rewards.

### Comments

This integration test seems to be particularly flaky on macOS.

### Issue Number

ADP-2149