### PR TITLE
Use `cardano-ledger` for all minimum UTxO calculations

### DIFF
--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -129,6 +129,7 @@ library
       Cardano.Wallet.Shelley.Launch.Cluster
       Cardano.Wallet.Shelley.Logging
       Cardano.Wallet.Shelley.MinimumUTxO
+      Cardano.Wallet.Shelley.MinimumUTxO.Internal
       Cardano.Wallet.Shelley.Network
       Cardano.Wallet.Shelley.Network.Blockfrost
       Cardano.Wallet.Shelley.Network.Blockfrost.Conversion

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs
@@ -20,8 +20,6 @@ module Cardano.Wallet.Shelley.Compatibility.Ledger
     , toLedgerTokenPolicyId
     , toLedgerTokenName
     , toLedgerTokenQuantity
-    , toAlonzoTxOut
-    , toBabbageTxOut
 
       -- * Conversions from ledger specification types to wallet types
     , toWalletCoin
@@ -34,6 +32,13 @@ module Cardano.Wallet.Shelley.Compatibility.Ledger
       -- * Roundtrip conversion between wallet types and ledger specification
       --   types
     , Convert (..)
+
+      -- * Conversions for transaction outputs
+    , toShelleyTxOut
+    , toAllegraTxOut
+    , toMaryTxOut
+    , toAlonzoTxOut
+    , toBabbageTxOut
 
     ) where
 
@@ -78,7 +83,7 @@ import GHC.Stack
 import Numeric.Natural
     ( Natural )
 import Ouroboros.Consensus.Shelley.Eras
-    ( StandardCrypto )
+    ( StandardAllegra, StandardCrypto, StandardMary, StandardShelley )
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Ledger.Address as Ledger
@@ -90,6 +95,7 @@ import qualified Cardano.Ledger.Crypto as Ledger
 import qualified Cardano.Ledger.Keys as Ledger
 import qualified Cardano.Ledger.Mary.Value as Ledger
 import qualified Cardano.Ledger.Shelley.API as Ledger
+import qualified Cardano.Ledger.Shelley.TxBody as Shelley
 import qualified Cardano.Ledger.ShelleyMA.Timelocks as MA
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
@@ -247,6 +253,28 @@ instance Convert Address (Ledger.Addr StandardCrypto) where
             , pretty (Address bytes)
             ]
     toWallet = Address . Ledger.serialiseAddr
+
+--------------------------------------------------------------------------------
+-- Conversions for 'TxOut'
+--------------------------------------------------------------------------------
+
+toShelleyTxOut
+    :: TxOut
+    -> Shelley.TxOut StandardShelley
+toShelleyTxOut (TxOut addr bundle) =
+    Shelley.TxOut (toLedger addr) (toLedger (TokenBundle.coin bundle))
+
+toAllegraTxOut
+    :: TxOut
+    -> Shelley.TxOut StandardAllegra
+toAllegraTxOut (TxOut addr bundle) =
+    Shelley.TxOut (toLedger addr) (toLedger (TokenBundle.coin bundle))
+
+toMaryTxOut
+    :: TxOut
+    -> Shelley.TxOut StandardMary
+toMaryTxOut (TxOut addr bundle) =
+    Shelley.TxOut (toLedger addr) (toLedger bundle)
 
 toAlonzoTxOut
     :: TxOut

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs
@@ -262,7 +262,10 @@ toAlonzoTxOut (TxOut addr bundle) = \case
         Alonzo.TxOut
             (toLedger addr)
             (toLedger bundle)
-            (Ledger.SJust $ unsafeMakeSafeHash $ Crypto.UnsafeHash $ toShort bytes)
+            (Ledger.SJust
+                $ unsafeMakeSafeHash
+                $ Crypto.UnsafeHash
+                $ toShort bytes)
 
 toBabbageTxOut
     :: TxOut

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs
@@ -83,7 +83,13 @@ import GHC.Stack
 import Numeric.Natural
     ( Natural )
 import Ouroboros.Consensus.Shelley.Eras
-    ( StandardAllegra, StandardCrypto, StandardMary, StandardShelley )
+    ( StandardAllegra
+    , StandardAlonzo
+    , StandardBabbage
+    , StandardCrypto
+    , StandardMary
+    , StandardShelley
+    )
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Ledger.Address as Ledger
@@ -279,7 +285,7 @@ toMaryTxOut (TxOut addr bundle) =
 toAlonzoTxOut
     :: TxOut
     -> Maybe (Hash "Datum")
-    -> Alonzo.TxOut (Alonzo.AlonzoEra StandardCrypto)
+    -> Alonzo.TxOut StandardAlonzo
 toAlonzoTxOut (TxOut addr bundle) = \case
     Nothing ->
         Alonzo.TxOut
@@ -298,7 +304,7 @@ toAlonzoTxOut (TxOut addr bundle) = \case
 toBabbageTxOut
     :: TxOut
     -> Maybe (Hash "Datum")
-    -> Babbage.TxOut (Babbage.BabbageEra StandardCrypto)
+    -> Babbage.TxOut StandardBabbage
 toBabbageTxOut (TxOut addr bundle) = \case
     Nothing ->
         Babbage.TxOut

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -50,29 +50,15 @@ computeMinimumCoinForUTxO
     -> Address
     -> TokenMap
     -> Coin
-computeMinimumCoinForUTxO = \case
-    MinimumUTxONone ->
-        \_addr _tokenMap -> Coin 0
-    MinimumUTxOConstant c ->
-        \_addr _tokenMap -> c
-    MinimumUTxOForShelleyBasedEraOf minUTxO ->
-        computeMinimumCoinForUTxOShelleyBasedEra minUTxO
-
--- | Computes a minimum 'Coin' value for a 'TokenMap' that is destined for
---   inclusion in a transaction output.
---
--- This function returns a value that is specific to a given Shelley-based era.
--- Importantly, a value that is valid in one era will not necessarily be valid
--- in another era.
---
-computeMinimumCoinForUTxOShelleyBasedEra
-    :: MinimumUTxOForShelleyBasedEra
-    -> Address
-    -> TokenMap
-    -> Coin
-computeMinimumCoinForUTxOShelleyBasedEra minimumUTxO addr tokenMap =
-    Internal.computeMinimumCoinForUTxOCardanoLedger minimumUTxO
-        (TxOut addr $ TokenBundle txOutMaxCoin tokenMap)
+computeMinimumCoinForUTxO minimumUTxO addr tokenMap =
+    case minimumUTxO of
+        MinimumUTxONone ->
+            Coin 0
+        MinimumUTxOConstant c ->
+            c
+        MinimumUTxOForShelleyBasedEraOf minimumUTxOShelley ->
+            Internal.computeMinimumCoinForUTxOCardanoLedger minimumUTxOShelley
+                (TxOut addr $ TokenBundle txOutMaxCoin tokenMap)
 
 -- | Returns 'True' if and only if the given 'TokenBundle' has a 'Coin' value
 --   that is below the minimum acceptable 'Coin' value.

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -34,8 +34,6 @@ import Cardano.Wallet.Shelley.Compatibility
     ( toCardanoTxOut )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( toBabbageTxOut, toWalletCoin )
-import GHC.Stack
-    ( HasCallStack )
 import Ouroboros.Consensus.Cardano.Block
     ( StandardBabbage )
 
@@ -48,8 +46,7 @@ import qualified Cardano.Wallet.Shelley.MinimumUTxO.Internal as Internal
 --   inclusion in a transaction output.
 --
 computeMinimumCoinForUTxO
-    :: HasCallStack
-    => MinimumUTxO
+    :: MinimumUTxO
     -> Address
     -> TokenMap
     -> Coin
@@ -69,8 +66,7 @@ computeMinimumCoinForUTxO = \case
 -- in another era.
 --
 computeMinimumCoinForUTxOShelleyBasedEra
-    :: HasCallStack
-    => MinimumUTxOForShelleyBasedEra
+    :: MinimumUTxOForShelleyBasedEra
     -> Address
     -> TokenMap
     -> Coin
@@ -84,7 +80,7 @@ computeMinimumCoinForUTxOShelleyBasedEra
                 computeLedgerMinimumCoinForBabbage pp addr
                     (TokenBundle txOutMaxCoin tokenMap)
             _ ->
-                Internal.computeMinimumCoinForUTxOCardanoApi minimumUTxO
+                Internal.computeMinimumCoinForUTxOCardanoLedger minimumUTxO
                     (TxOut addr $ TokenBundle txOutMaxCoin tokenMap)
 
 -- | Returns 'True' if and only if the given 'TokenBundle' has a 'Coin' value
@@ -124,7 +120,7 @@ isBelowMinimumCoinForUTxOShelleyBasedEra
                 Cardano.ShelleyBasedEraBabbage ->
                     computeLedgerMinimumCoinForBabbage pp addr tokenBundle
                 _ ->
-                    Internal.computeMinimumCoinForUTxOCardanoApi minimumUTxO
+                    Internal.computeMinimumCoinForUTxOCardanoLedger minimumUTxO
                         (TxOut addr tokenBundle)
 
 -- | Embeds a 'TokenMap' within a padded 'Cardano.TxOut' value.

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 
 -- |
 -- Copyright: © 2022 IOHK
@@ -23,7 +22,7 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO
-    ( MinimumUTxO (..), MinimumUTxOForShelleyBasedEra (..) )
+    ( MinimumUTxO (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
@@ -68,29 +67,16 @@ isBelowMinimumCoinForUTxO
     -> Address
     -> TokenBundle
     -> Bool
-isBelowMinimumCoinForUTxO = \case
-    MinimumUTxONone ->
-        \_addr _tokenBundle ->
+isBelowMinimumCoinForUTxO minimumUTxO addr tokenBundle =
+    case minimumUTxO of
+        MinimumUTxONone ->
             False
-    MinimumUTxOConstant c ->
-        \_addr tokenBundle ->
+        MinimumUTxOConstant c ->
             TokenBundle.getCoin tokenBundle < c
-    MinimumUTxOForShelleyBasedEraOf minUTxO ->
-        isBelowMinimumCoinForUTxOShelleyBasedEra minUTxO
-
--- | Returns 'True' if and only if the given 'TokenBundle' has a 'Coin' value
---   that is below the minimum acceptable 'Coin' value for a Shelley-based
---   era.
---
-isBelowMinimumCoinForUTxOShelleyBasedEra
-    :: MinimumUTxOForShelleyBasedEra
-    -> Address
-    -> TokenBundle
-    -> Bool
-isBelowMinimumCoinForUTxOShelleyBasedEra minimumUTxO addr tokenBundle =
-    TokenBundle.getCoin tokenBundle <
-        Internal.computeMinimumCoinForUTxOCardanoLedger minimumUTxO
-            (TxOut addr tokenBundle)
+        MinimumUTxOForShelleyBasedEraOf minimumUTxOShelley ->
+            TokenBundle.getCoin tokenBundle <
+                Internal.computeMinimumCoinForUTxOCardanoLedger
+                    minimumUTxOShelley (TxOut addr tokenBundle)
 
 -- | Embeds a 'TokenMap' within a padded 'Cardano.TxOut' value.
 --

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -44,7 +44,8 @@ computeMinimumCoinForUTxO minimumUTxO addr tokenMap =
         MinimumUTxOConstant c ->
             c
         MinimumUTxOForShelleyBasedEraOf minimumUTxOShelley ->
-            Internal.computeMinimumCoinForUTxOCardanoLedger minimumUTxOShelley
+            Internal.computeMinimumCoinForUTxO_CardanoLedger
+                minimumUTxOShelley
                 (TxOut addr $ TokenBundle txOutMaxCoin tokenMap)
 
 -- | Returns 'True' if and only if the given 'TokenBundle' has a 'Coin' value
@@ -63,5 +64,6 @@ isBelowMinimumCoinForUTxO minimumUTxO addr tokenBundle =
             TokenBundle.getCoin tokenBundle < c
         MinimumUTxOForShelleyBasedEraOf minimumUTxOShelley ->
             TokenBundle.getCoin tokenBundle <
-                Internal.computeMinimumCoinForUTxOCardanoLedger
-                    minimumUTxOShelley (TxOut addr tokenBundle)
+                Internal.computeMinimumCoinForUTxO_CardanoLedger
+                    minimumUTxOShelley
+                    (TxOut addr tokenBundle)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -13,10 +13,6 @@ module Cardano.Wallet.Shelley.MinimumUTxO
 
 import Prelude
 
-import Cardano.Ledger.Babbage.Rules.Utxo
-    ( babbageMinUTxOValue )
-import Cardano.Ledger.Serialization
-    ( mkSized )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -29,15 +25,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxOut (..), txOutMaxCoin )
-import Cardano.Wallet.Shelley.Compatibility
-    ( toCardanoTxOut )
-import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( toBabbageTxOut, toWalletCoin )
-import Ouroboros.Consensus.Cardano.Block
-    ( StandardBabbage )
 
-import qualified Cardano.Api.Shelley as Cardano
-import qualified Cardano.Ledger.Babbage.PParams as Babbage
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Shelley.MinimumUTxO.Internal as Internal
 
@@ -77,47 +65,3 @@ isBelowMinimumCoinForUTxO minimumUTxO addr tokenBundle =
             TokenBundle.getCoin tokenBundle <
                 Internal.computeMinimumCoinForUTxOCardanoLedger
                     minimumUTxOShelley (TxOut addr tokenBundle)
-
--- | Embeds a 'TokenMap' within a padded 'Cardano.TxOut' value.
---
--- When computing the minimum UTxO quantity for a given 'TokenMap', we do not
--- have access to an address or to an ada quantity.
---
--- However, in order to compute a minimum UTxO quantity through the Cardano
--- API, we must supply a 'TxOut' value with a valid address and ada quantity.
---
--- It's imperative that we do not underestimate minimum UTxO quantities, as
--- this may result in the creation of transactions that are unacceptable to
--- the ledger. In the case of change generation, this would be particularly
--- problematic, as change outputs are generated automatically, and users do
--- not have direct control over the ada quantities generated.
---
--- However, while we cannot underestimate minimum UTxO quantities, we are at
--- liberty to moderately overestimate them.
---
--- Since the minimum UTxO quantity function is monotonically increasing w.r.t.
--- the size of the address and ada quantity, if we supply a 'TxOut' with an
--- address and ada quantity whose serialized lengths are the maximum possible
--- lengths, we can be confident that the resultant value will not be an
--- underestimate.
---
-_embedTokenMapWithinPaddedTxOut
-    :: Cardano.ShelleyBasedEra era
-    -> Address
-    -> TokenMap
-    -> Cardano.TxOut Cardano.CtxTx era
-_embedTokenMapWithinPaddedTxOut era addr m =
-    toCardanoTxOut era $ TxOut addr $ TokenBundle txOutMaxCoin m
-
--- | Uses the ledger to compute a minimum ada quantity for the Babbage era.
---
-_computeLedgerMinimumCoinForBabbage
-    :: Babbage.PParams StandardBabbage
-    -> Address
-    -> TokenBundle
-    -> Coin
-_computeLedgerMinimumCoinForBabbage pp addr tokenBundle =
-    toWalletCoin
-        $ babbageMinUTxOValue pp
-        $ mkSized
-        $ toBabbageTxOut (TxOut addr tokenBundle) Nothing

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -32,6 +32,11 @@ import qualified Cardano.Wallet.Shelley.MinimumUTxO.Internal as Internal
 -- | Computes a minimum 'Coin' value for a 'TokenMap' that is destined for
 --   inclusion in a transaction output.
 --
+-- The value returned is a /safe/ minimum, in the sense that any value above
+-- the minimum should also satisfy the minimum UTxO rule. Consequently, when
+-- assigning ada quantities to outputs, it should be safe to assign any value
+-- that is greater than or equal to the value returned by this function.
+--
 computeMinimumCoinForUTxO
     :: MinimumUTxO
     -> Address
@@ -44,12 +49,45 @@ computeMinimumCoinForUTxO minimumUTxO addr tokenMap =
         MinimumUTxOConstant c ->
             c
         MinimumUTxOForShelleyBasedEraOf minimumUTxOShelley ->
+            -- It's very important that we do not underestimate minimum UTxO
+            -- quantities, as this may result in the creation of transactions
+            -- that are unacceptable to the ledger.
+            --
+            -- In the cases of change generation and wallet balance migration,
+            -- any underestimation would be particularly problematic, as
+            -- outputs are generated automatically, and users do not have
+            -- direct control over the ada quantities generated.
+            --
+            -- However, while we cannot underestimate minimum UTxO quantities,
+            -- we are at liberty to moderately overestimate them.
+            --
+            -- Since the minimum UTxO function is monotonically increasing
+            -- w.r.t. the size of the ada quantity, if we supply a 'TxOut' with
+            -- an ada quantity whose serialized length is the maximum possible
+            -- length, we can be confident that the resultant value can always
+            -- safely be increased.
+            --
             Internal.computeMinimumCoinForUTxO_CardanoLedger
                 minimumUTxOShelley
                 (TxOut addr $ TokenBundle txOutMaxCoin tokenMap)
 
 -- | Returns 'True' if and only if the given 'TokenBundle' has a 'Coin' value
 --   that is below the minimum acceptable 'Coin' value.
+--
+-- This function should /only/ be used to validate existing 'Coin' values that
+-- do not need to be modified in any way.
+--
+-- Increasing the 'Coin' value of an output can lead to an increase in the
+-- serialized length of that output, which can in turn lead to an increase in
+-- the minimum required 'Coin' value, since the minimum required 'Coin' value
+-- is dependent on an output's serialized length.
+--
+-- Therefore, even if this function indicates that a given value 'Coin' value
+-- 'c' satisfies the minimum UTxO rule, it should not be taken to imply that
+-- all values greater than 'c' will also satisfy the minimum UTxO rule.
+--
+-- If you need to generate a value that can always safely be increased, use
+-- the 'computeMinimumCoinForUTxO' function instead.
 --
 isBelowMinimumCoinForUTxO
     :: MinimumUTxO

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -70,18 +70,9 @@ computeMinimumCoinForUTxOShelleyBasedEra
     -> Address
     -> TokenMap
     -> Coin
-computeMinimumCoinForUTxOShelleyBasedEra
-    minimumUTxO@(MinimumUTxOForShelleyBasedEra era pp) addr tokenMap =
-        case era of
-            -- Here we treat the Babbage era specially and use the ledger
-            -- to compute the minimum ada quantity, bypassing the Cardano
-            -- API. This appears to be significantly faster.
-            Cardano.ShelleyBasedEraBabbage ->
-                computeLedgerMinimumCoinForBabbage pp addr
-                    (TokenBundle txOutMaxCoin tokenMap)
-            _ ->
-                Internal.computeMinimumCoinForUTxOCardanoLedger minimumUTxO
-                    (TxOut addr $ TokenBundle txOutMaxCoin tokenMap)
+computeMinimumCoinForUTxOShelleyBasedEra minimumUTxO addr tokenMap =
+    Internal.computeMinimumCoinForUTxOCardanoLedger minimumUTxO
+        (TxOut addr $ TokenBundle txOutMaxCoin tokenMap)
 
 -- | Returns 'True' if and only if the given 'TokenBundle' has a 'Coin' value
 --   that is below the minimum acceptable 'Coin' value.
@@ -110,18 +101,10 @@ isBelowMinimumCoinForUTxOShelleyBasedEra
     -> Address
     -> TokenBundle
     -> Bool
-isBelowMinimumCoinForUTxOShelleyBasedEra
-    minimumUTxO@(MinimumUTxOForShelleyBasedEra era pp) addr tokenBundle =
-        TokenBundle.getCoin tokenBundle <
-            -- Here we treat the Babbage era specially and use the ledger
-            -- to compute the minimum ada quantity, bypassing the Cardano
-            -- API. This appears to be significantly faster.
-            case era of
-                Cardano.ShelleyBasedEraBabbage ->
-                    computeLedgerMinimumCoinForBabbage pp addr tokenBundle
-                _ ->
-                    Internal.computeMinimumCoinForUTxOCardanoLedger minimumUTxO
-                        (TxOut addr tokenBundle)
+isBelowMinimumCoinForUTxOShelleyBasedEra minimumUTxO addr tokenBundle =
+    TokenBundle.getCoin tokenBundle <
+        Internal.computeMinimumCoinForUTxOCardanoLedger minimumUTxO
+            (TxOut addr tokenBundle)
 
 -- | Embeds a 'TokenMap' within a padded 'Cardano.TxOut' value.
 --
@@ -156,12 +139,12 @@ _embedTokenMapWithinPaddedTxOut era addr m =
 
 -- | Uses the ledger to compute a minimum ada quantity for the Babbage era.
 --
-computeLedgerMinimumCoinForBabbage
+_computeLedgerMinimumCoinForBabbage
     :: Babbage.PParams StandardBabbage
     -> Address
     -> TokenBundle
     -> Coin
-computeLedgerMinimumCoinForBabbage pp addr tokenBundle =
+_computeLedgerMinimumCoinForBabbage pp addr tokenBundle =
     toWalletCoin
         $ babbageMinUTxOValue pp
         $ mkSized

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO/Internal.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO/Internal.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE LambdaCase #-}
+
+-- |
+-- Copyright: © 2022 IOHK
+-- License: Apache-2.0
+--
+-- Computing minimum UTxO values: internal interface.
+--
+module Cardano.Wallet.Shelley.MinimumUTxO.Internal
+    ( unsafeCoinFromCardanoApiCalculateMinimumUTxOResult
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin )
+import Cardano.Wallet.Shelley.Compatibility
+    ( unsafeLovelaceToWalletCoin, unsafeValueToLovelace )
+import Data.Function
+    ( (&) )
+import GHC.Stack
+    ( HasCallStack )
+
+import qualified Cardano.Api.Shelley as Cardano
+
+-- | Extracts a 'Coin' value from the result of calling the Cardano API
+--   function 'calculateMinimumUTxO'.
+--
+unsafeCoinFromCardanoApiCalculateMinimumUTxOResult
+    :: HasCallStack
+    => Either Cardano.MinimumUTxOError Cardano.Value
+    -> Coin
+unsafeCoinFromCardanoApiCalculateMinimumUTxOResult = \case
+    Right value ->
+        -- We assume that the returned value is a non-negative ada quantity
+        -- with no other assets. If this assumption is violated, we have no
+        -- way to continue, and must raise an error:
+        value
+            & unsafeValueToLovelace
+            & unsafeLovelaceToWalletCoin
+    Left e ->
+        -- The 'Cardano.calculateMinimumUTxO' function should only return
+        -- an error if a required protocol parameter is missing.
+        --
+        -- However, given that values of 'MinimumUTxOForShelleyBasedEra'
+        -- can only be constructed by supplying an era-specific protocol
+        -- parameters record, it should be impossible to trigger this
+        -- condition.
+        --
+        -- Any violation of this assumption indicates a programming error.
+        -- If this condition is triggered, we have no way to continue, and
+        -- must raise an error:
+        --
+        error $ unwords
+            [ "unsafeCoinFromCardanoApiCalculateMinimumUTxOResult:"
+            , "unexpected error:"
+            , show e
+            ]

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO/Internal.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO/Internal.hs
@@ -8,7 +8,6 @@
 --
 module Cardano.Wallet.Shelley.MinimumUTxO.Internal
     ( computeMinimumCoinForUTxOCardanoApi
-    , unsafeCoinFromCardanoApiCalculateMinimumUTxOResult
     ) where
 
 import Prelude
@@ -37,41 +36,37 @@ computeMinimumCoinForUTxOCardanoApi
     -> Coin
 computeMinimumCoinForUTxOCardanoApi
     (MinimumUTxOForShelleyBasedEra era pp) txOut =
-        unsafeCoinFromCardanoApiCalculateMinimumUTxOResult $
+        unsafeCoinFromResult $
             Cardano.calculateMinimumUTxO era
                 (toCardanoTxOut era txOut)
                 (Cardano.fromLedgerPParams era pp)
-
--- | Extracts a 'Coin' value from the result of calling the Cardano API
---   function 'calculateMinimumUTxO'.
---
-unsafeCoinFromCardanoApiCalculateMinimumUTxOResult
-    :: HasCallStack
-    => Either Cardano.MinimumUTxOError Cardano.Value
-    -> Coin
-unsafeCoinFromCardanoApiCalculateMinimumUTxOResult = \case
-    Right value ->
-        -- We assume that the returned value is a non-negative ada quantity
-        -- with no other assets. If this assumption is violated, we have no
-        -- way to continue, and must raise an error:
-        value
-            & unsafeValueToLovelace
-            & unsafeLovelaceToWalletCoin
-    Left e ->
-        -- The 'Cardano.calculateMinimumUTxO' function should only return
-        -- an error if a required protocol parameter is missing.
-        --
-        -- However, given that values of 'MinimumUTxOForShelleyBasedEra'
-        -- can only be constructed by supplying an era-specific protocol
-        -- parameters record, it should be impossible to trigger this
-        -- condition.
-        --
-        -- Any violation of this assumption indicates a programming error.
-        -- If this condition is triggered, we have no way to continue, and
-        -- must raise an error:
-        --
-        error $ unwords
-            [ "unsafeCoinFromCardanoApiCalculateMinimumUTxOResult:"
-            , "unexpected error:"
-            , show e
-            ]
+  where
+    unsafeCoinFromResult
+        :: Either Cardano.MinimumUTxOError Cardano.Value
+        -> Coin
+    unsafeCoinFromResult = \case
+        Right value ->
+            -- We assume that the returned value is a non-negative ada quantity
+            -- with no other assets. If this assumption is violated, we have no
+            -- way to continue, and must raise an error:
+            value
+                & unsafeValueToLovelace
+                & unsafeLovelaceToWalletCoin
+        Left e ->
+            -- The 'Cardano.calculateMinimumUTxO' function should only return
+            -- an error if a required protocol parameter is missing.
+            --
+            -- However, given that values of 'MinimumUTxOForShelleyBasedEra'
+            -- can only be constructed by supplying an era-specific protocol
+            -- parameters record, it should be impossible to trigger this
+            -- condition.
+            --
+            -- Any violation of this assumption indicates a programming error.
+            -- If this condition is triggered, we have no way to continue, and
+            -- must raise an error:
+            --
+            error $ unwords
+                [ "computeMinimumCoinForUTxOCardanoApi:"
+                , "unexpected error:"
+                , show e
+                ]

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO/Internal.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 
 -- |
@@ -8,10 +9,13 @@
 --
 module Cardano.Wallet.Shelley.MinimumUTxO.Internal
     ( computeMinimumCoinForUTxOCardanoApi
+    , computeMinimumCoinForUTxOCardanoLedger
     ) where
 
 import Prelude
 
+import Cardano.Ledger.Shelley.API.Wallet
+    ( evaluateMinLovelaceOutput )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO
@@ -20,6 +24,14 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( TxOut )
 import Cardano.Wallet.Shelley.Compatibility
     ( toCardanoTxOut, unsafeLovelaceToWalletCoin, unsafeValueToLovelace )
+import Cardano.Wallet.Shelley.Compatibility.Ledger
+    ( toAllegraTxOut
+    , toAlonzoTxOut
+    , toBabbageTxOut
+    , toMaryTxOut
+    , toShelleyTxOut
+    , toWalletCoin
+    )
 import Data.Function
     ( (&) )
 import GHC.Stack
@@ -70,3 +82,28 @@ computeMinimumCoinForUTxOCardanoApi
                 , "unexpected error:"
                 , show e
                 ]
+
+-- | Computes a minimum UTxO value with Cardano Ledger.
+--
+computeMinimumCoinForUTxOCardanoLedger
+    :: MinimumUTxOForShelleyBasedEra
+    -> TxOut
+    -> Coin
+computeMinimumCoinForUTxOCardanoLedger
+    (MinimumUTxOForShelleyBasedEra era pp) txOut =
+        toWalletCoin $ case era of
+            Cardano.ShelleyBasedEraShelley ->
+                evaluateMinLovelaceOutput pp
+                    $ toShelleyTxOut txOut
+            Cardano.ShelleyBasedEraAllegra ->
+                evaluateMinLovelaceOutput pp
+                    $ toAllegraTxOut txOut
+            Cardano.ShelleyBasedEraMary ->
+                evaluateMinLovelaceOutput pp
+                    $ toMaryTxOut txOut
+            Cardano.ShelleyBasedEraAlonzo ->
+                evaluateMinLovelaceOutput pp
+                    $ toAlonzoTxOut txOut Nothing
+            Cardano.ShelleyBasedEraBabbage ->
+                evaluateMinLovelaceOutput pp
+                    $ toBabbageTxOut txOut Nothing

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO/Internal.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO/Internal.hs
@@ -42,6 +42,11 @@ import qualified Cardano.Api.Shelley as Cardano
 
 -- | Computes a minimum UTxO value with the Cardano API.
 --
+-- Caution:
+--
+-- This function does /not/ attempt to reach a fixed point before returning its
+-- result.
+--
 computeMinimumCoinForUTxO_CardanoApi
     :: HasCallStack
     => MinimumUTxOForShelleyBasedEra
@@ -85,6 +90,11 @@ computeMinimumCoinForUTxO_CardanoApi
                 ]
 
 -- | Computes a minimum UTxO value with Cardano Ledger.
+--
+-- Caution:
+--
+-- This function does /not/ attempt to reach a fixed point before returning its
+-- result.
 --
 computeMinimumCoinForUTxO_CardanoLedger
     :: MinimumUTxOForShelleyBasedEra

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO/Internal.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO/Internal.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{- HLINT ignore "Use camelCase" -}
 
 -- |
 -- Copyright: © 2022 IOHK
@@ -8,8 +9,8 @@
 -- Computing minimum UTxO values: internal interface.
 --
 module Cardano.Wallet.Shelley.MinimumUTxO.Internal
-    ( computeMinimumCoinForUTxOCardanoApi
-    , computeMinimumCoinForUTxOCardanoLedger
+    ( computeMinimumCoinForUTxO_CardanoApi
+    , computeMinimumCoinForUTxO_CardanoLedger
     ) where
 
 import Prelude
@@ -41,12 +42,12 @@ import qualified Cardano.Api.Shelley as Cardano
 
 -- | Computes a minimum UTxO value with the Cardano API.
 --
-computeMinimumCoinForUTxOCardanoApi
+computeMinimumCoinForUTxO_CardanoApi
     :: HasCallStack
     => MinimumUTxOForShelleyBasedEra
     -> TxOut
     -> Coin
-computeMinimumCoinForUTxOCardanoApi
+computeMinimumCoinForUTxO_CardanoApi
     (MinimumUTxOForShelleyBasedEra era pp) txOut =
         unsafeCoinFromResult $
             Cardano.calculateMinimumUTxO era
@@ -78,18 +79,18 @@ computeMinimumCoinForUTxOCardanoApi
             -- must raise an error:
             --
             error $ unwords
-                [ "computeMinimumCoinForUTxOCardanoApi:"
+                [ "computeMinimumCoinForUTxO_CardanoApi:"
                 , "unexpected error:"
                 , show e
                 ]
 
 -- | Computes a minimum UTxO value with Cardano Ledger.
 --
-computeMinimumCoinForUTxOCardanoLedger
+computeMinimumCoinForUTxO_CardanoLedger
     :: MinimumUTxOForShelleyBasedEra
     -> TxOut
     -> Coin
-computeMinimumCoinForUTxOCardanoLedger
+computeMinimumCoinForUTxO_CardanoLedger
     (MinimumUTxOForShelleyBasedEra era pp) txOut =
         toWalletCoin $ case era of
             Cardano.ShelleyBasedEraShelley ->

--- a/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO/Internal.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/MinimumUTxO/Internal.hs
@@ -7,21 +7,40 @@
 -- Computing minimum UTxO values: internal interface.
 --
 module Cardano.Wallet.Shelley.MinimumUTxO.Internal
-    ( unsafeCoinFromCardanoApiCalculateMinimumUTxOResult
+    ( computeMinimumCoinForUTxOCardanoApi
+    , unsafeCoinFromCardanoApiCalculateMinimumUTxOResult
     ) where
 
 import Prelude
 
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin )
+import Cardano.Wallet.Primitive.Types.MinimumUTxO
+    ( MinimumUTxOForShelleyBasedEra (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxOut )
 import Cardano.Wallet.Shelley.Compatibility
-    ( unsafeLovelaceToWalletCoin, unsafeValueToLovelace )
+    ( toCardanoTxOut, unsafeLovelaceToWalletCoin, unsafeValueToLovelace )
 import Data.Function
     ( (&) )
 import GHC.Stack
     ( HasCallStack )
 
 import qualified Cardano.Api.Shelley as Cardano
+
+-- | Computes a minimum UTxO value with the Cardano API.
+--
+computeMinimumCoinForUTxOCardanoApi
+    :: HasCallStack
+    => MinimumUTxOForShelleyBasedEra
+    -> TxOut
+    -> Coin
+computeMinimumCoinForUTxOCardanoApi
+    (MinimumUTxOForShelleyBasedEra era pp) txOut =
+        unsafeCoinFromCardanoApiCalculateMinimumUTxOResult $
+            Cardano.calculateMinimumUTxO era
+                (toCardanoTxOut era txOut)
+                (Cardano.fromLedgerPParams era pp)
 
 -- | Extracts a 'Coin' value from the result of calling the Cardano API
 --   function 'calculateMinimumUTxO'.

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -193,10 +193,10 @@ prop_computeMinimumCoinForUTxO_CardanoApi_CardanoLedger
     -> Property
 prop_computeMinimumCoinForUTxO_CardanoApi_CardanoLedger
     minimumUTxO address coin tokenMap =
-        Internal.computeMinimumCoinForUTxOCardanoApi
+        Internal.computeMinimumCoinForUTxO_CardanoApi
             minimumUTxO txOut
         ===
-        Internal.computeMinimumCoinForUTxOCardanoLedger
+        Internal.computeMinimumCoinForUTxO_CardanoLedger
             minimumUTxO txOut
   where
     txOut = TxOut address (TokenBundle coin tokenMap)

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -29,8 +29,6 @@ import Cardano.Wallet.Primitive.Types.Address.Constants
     ( maxLengthAddress )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
-import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( chooseCoin )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO
     ( MinimumUTxO (..)
     , MinimumUTxOForShelleyBasedEra (..)
@@ -60,12 +58,7 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     ( mkTokenPolicyId )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxOut (..)
-    , txOutMaxCoin
-    , txOutMaxTokenQuantity
-    , txOutMinCoin
-    , txOutMinTokenQuantity
-    )
+    ( TxOut (..), txOutMaxCoin, txOutMaxTokenQuantity, txOutMinTokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTxOutTokenBundle )
 import Cardano.Wallet.Shelley.MinimumUTxO
@@ -186,18 +179,15 @@ spec = do
 prop_computeMinimumCoinForUTxO_CardanoApi_CardanoLedger
     :: MinimumUTxOForShelleyBasedEra
     -> Address
-    -> Coin
-    -> TokenMap
+    -> TokenBundle
     -> Property
 prop_computeMinimumCoinForUTxO_CardanoApi_CardanoLedger
-    minimumUTxO address coin tokenMap =
+    minimumUTxO address tokenBundle =
         Internal.computeMinimumCoinForUTxO_CardanoApi
-            minimumUTxO txOut
+            minimumUTxO (TxOut address tokenBundle)
         ===
         Internal.computeMinimumCoinForUTxO_CardanoLedger
-            minimumUTxO txOut
-  where
-    txOut = TxOut address (TokenBundle coin tokenMap)
+            minimumUTxO (TxOut address tokenBundle)
 
 -- Tests the following composition:
 --
@@ -629,13 +619,6 @@ instance Arbitrary Cardano.AddressAny where
 
 instance Arbitrary Address where
     arbitrary = fromCardanoAddressAny <$> arbitrary
-
-instance Arbitrary Coin where
-    arbitrary = frequency
-        [ (1, pure txOutMinCoin)
-        , (1, pure txOutMaxCoin)
-        , (8, chooseCoin (txOutMinCoin, txOutMaxCoin))
-        ]
 
 instance Arbitrary TokenBundle where
     arbitrary = sized genTxOutTokenBundle

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -128,11 +128,11 @@ spec = do
             it "prop_computeMinimumCoinForUTxO_isBelowMinimumCoinForUTxO" $
                 prop_computeMinimumCoinForUTxO_isBelowMinimumCoinForUTxO
                     & property
-            it "prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds" $
-                prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
+            it "prop_computeMinimumCoinForUTxO_bounds" $
+                prop_computeMinimumCoinForUTxO_bounds
                     & property
-            it "prop_computeMinimumCoinForUTxO_shelleyBasedEra_stability" $
-                prop_computeMinimumCoinForUTxO_shelleyBasedEra_stability
+            it "prop_computeMinimumCoinForUTxO_stability" $
+                prop_computeMinimumCoinForUTxO_stability
                     & property
 
         describe "Golden Tests" $ do
@@ -215,12 +215,12 @@ prop_computeMinimumCoinForUTxO_isBelowMinimumCoinForUTxO minimumUTxO addr m =
 -- Check that 'computeMinimumCoinForUTxO' produces a result that is within
 -- bounds, as determined by the Cardano API function 'calculateMinimumUTxO'.
 --
-prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
+prop_computeMinimumCoinForUTxO_bounds
     :: TokenBundle
     -> Cardano.AddressAny
     -> MinimumUTxOForShelleyBasedEra
     -> Property
-prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
+prop_computeMinimumCoinForUTxO_bounds
     tokenBundle addr minimumUTxO =
         let ourResult = ourComputeMinCoin
                 (fromCardanoAddressAny addr)
@@ -285,12 +285,12 @@ prop_computeMinimumCoinForUTxO_shelleyBasedEra_bounds
 -- Demonstrate that applying the Cardano API function to the result of the
 -- wallet function does not lead to an increase in the ada quantity.
 --
-prop_computeMinimumCoinForUTxO_shelleyBasedEra_stability
+prop_computeMinimumCoinForUTxO_stability
     :: TokenMap
     -> Cardano.AddressAny
     -> MinimumUTxOForShelleyBasedEra
     -> Property
-prop_computeMinimumCoinForUTxO_shelleyBasedEra_stability
+prop_computeMinimumCoinForUTxO_stability
     tokenMap addr minimumUTxO =
         conjoin
             [ prop_apiFunctionStability

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -127,9 +127,6 @@ spec = do
             it "prop_computeMinimumCoinForUTxO_CardanoApi_CardanoLedger" $
                 prop_computeMinimumCoinForUTxO_CardanoApi_CardanoLedger
                     & property
-            it "prop_computeMinimumCoinForUTxO_evaluation" $
-                prop_computeMinimumCoinForUTxO_evaluation
-                    & property
             it "prop_computeMinimumCoinForUTxO_isBelowMinimumCoinForUTxO" $
                 prop_computeMinimumCoinForUTxO_isBelowMinimumCoinForUTxO
                     & property
@@ -203,15 +200,6 @@ prop_computeMinimumCoinForUTxO_CardanoApi_CardanoLedger
             minimumUTxO txOut
   where
     txOut = TxOut address (TokenBundle coin tokenMap)
-
--- Check that it's possible to evaluate 'computeMinimumCoinForUTxO' without
--- any run-time error.
---
-prop_computeMinimumCoinForUTxO_evaluation
-    :: MinimumUTxO -> Address -> TokenMap -> Property
-prop_computeMinimumCoinForUTxO_evaluation minimumUTxO addr m = property $
-    -- Use an arbitrary test to force evaluation of the result:
-    computeMinimumCoinForUTxO minimumUTxO addr m >= Coin 0
 
 -- Tests the following composition:
 --


### PR DESCRIPTION
## Issue Number

ADP-2144

## Summary

This PR:

-  uses the ledger function [`evaluateMinLovelaceOutput`](https://github.com/input-output-hk/cardano-ledger/blob/68a535603c80b7cf53425fd34558e23f9983dfe8/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs#L506) to replace the use of Cardano API function [`calculateMinimumUTxO`](https://github.com/input-output-hk/cardano-node/blob/42809ad3d420f0695eb147d4c66b90573d27cafd/cardano-api/src/Cardano/Api/Fees.hs#L1226) in all implementation code, for all eras.
- repurposes the Cardano API function [`calculateMinimumUTxO`](https://github.com/input-output-hk/cardano-node/blob/42809ad3d420f0695eb147d4c66b90573d27cafd/cardano-api/src/Cardano/Api/Fees.hs#L1226) for use as an oracle, to compare against when testing.
- removes all special-casing for the Babbage era, and replaces it with a simpler implementation that works in all eras.
- revises documentation for the `{compute,isBelow}minimumCoinForUTxO` functions to explain their intended purpose more clearly.

## Context

- The ledger function [`evaluateMinLovelaceOutput`](https://github.com/input-output-hk/cardano-ledger/blob/68a535603c80b7cf53425fd34558e23f9983dfe8/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs#L506) accepts an _era-specific_ protocol parameters object and, unlike like the Cardano API, does _not_ require that we convert to an era-agnostic protocol parameters object. Since values of the `MinimumUTxO` type already contain era-specific protocol parameters, this means we can avoid the extra complication of record conversion whenever we call:
    - `isBelowMinimumCoinForUTxO`
    - `computeMinimumCoinForUTxO`
    
## Performance

Mainnet (Alonzo):

```sh
$ time curl -X POST http://localhost:8091/v2/wallets/042094088ed439a7b14e811e0781a00185b921c2/payment-fees -d '{"payments":[{"address":"addr1qylgm2dh3vpv07cjfcyuu6vhaqhf8998qcx6s8ucpkly6f8l0dw5r75vk42mv3ykq8vyjeaanvpytg79xqzymqy5acmqgyxuyr","amount":{"quantity":100000000,"unit":"lovelace"}}]}' -H "Content-Type: application/json"
{"deposit":{"quantity":0,"unit":"lovelace"},"estimated_max":{"quantity":187633,"unit":"lovelace"},"estimated_min":{"quantity":169021,"unit":"lovelace"},"minimum_coins":[{"quantity":999978,"unit":"lovelace"}]}
real	0m0,029s
user	0m0,006s
sys	0m0,000s
```

Preprod (Alonzo):
```sh
$ time curl -X POST http://localhost:8090/v2/wallets/1f82e83772b7579fc0854bd13db6a9cce21ccd95/payment-fees \
> -d '{"payments":[{"address":"addr_test1qrtez7vn0d8xp495ggypmu2kyt7tt6qyva2spm0f5a3ewn0v474mcs4q8e9g55yknx3729kyg5dl69x5596ee9tvnynq7ffety","amount":{"quantity":1000000,"unit":"lovelace"}}]}' \
> -H "Content-Type: application/json"
{"deposit":{"quantity":0,"unit":"lovelace"},"estimated_max":{"quantity":169021,"unit":"lovelace"},"estimated_min":{"quantity":169021,"unit":"lovelace"},"minimum_coins":[{"quantity":999978,"unit":"lovelace"}]}
real	0m0,029s
user	0m0,006s
sys	0m0,000s
```

Preview (Babbage):
```sh
$ time curl -X POST http://localhost:8090/v2/wallets/1f82e83772b7579fc0854bd13db6a9cce21ccd95/payment-fees -d '{"payments":[{"address":"addr_test1qrtez7vn0d8xp495ggypmu2kyt7tt6qyva2spm0f5a3ewn0v474mcs4q8e9g55yknx3729kyg5dl69x5596ee9tvnynq7ffety","amount":{"quantity":100000000,"unit":"lovelace"}}]}' -H "Content-Type: application/json"
{"deposit":{"quantity":0,"unit":"lovelace"},"estimated_max":{"quantity":187809,"unit":"lovelace"},"estimated_min":{"quantity":169197,"unit":"lovelace"},"minimum_coins":[{"quantity":995610,"unit":"lovelace"}]}
real	0m0,036s
user	0m0,003s
sys	0m0,003s
```