### PR TITLE
Fix for the `nextChangeIndex` invariant violation in the light mode

### DIFF
--- a/lib/core/src/Cardano/Wallet/Address/Pool.hs
+++ b/lib/core/src/Cardano/Wallet/Address/Pool.hs
@@ -37,7 +37,6 @@ module Cardano.Wallet.Address.Pool
     , prop_fresh
     , prop_fromIx
     , prop_consistent
-    , prop_next_is_unused
     )
   where
 
@@ -138,12 +137,6 @@ prop_fromIx Pool{addressFromIx,addresses} =
   where
     isGenerated addr (ix,_) = addressFromIx ix == addr
 
-prop_next_is_unused :: (Eq ix, Enum ix) => Pool addr ix -> Bool
-prop_next_is_unused p =
-    let i = nextIndex p
-        indexState = filter ((== i) . fst) (Map.elems (addresses p))
-    in  indexState == [(i, Unused)]
-
 -- | Internal invariant: The pool satisfies all invariants above.
 prop_consistent :: (Ord ix, Enum ix, Eq addr) => Pool addr ix -> Bool
 prop_consistent p = all ($ p)
@@ -151,7 +144,6 @@ prop_consistent p = all ($ p)
     , prop_gap
     , prop_fresh
     , prop_fromIx
-    , prop_next_is_unused
     ]
 
 {-------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Address/Pool.hs
+++ b/lib/core/src/Cardano/Wallet/Address/Pool.hs
@@ -206,6 +206,7 @@ usedAddresses :: Pool addr ix -> [addr]
 usedAddresses pool =
     [ addr | (addr,(_,Used)) <- Map.toList $ addresses pool ]
 
+-- | The first index that is 'Unused' and that comes after any 'Used' index.
 nextIndex :: Enum ix => Pool addr ix -> ix
 nextIndex Pool{addresses,gap} = toEnum (Map.size addresses - gap)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -350,7 +350,7 @@ instance Bounded (Index 'Hardened level) where
 
 instance Bounded (Index 'Soft level) where
     minBound = Index minBound
-    maxBound = let (Index ix) = minBound @(Index 'Hardened _) in Index (ix - 1)
+    maxBound = let Index ix = minBound @(Index 'Hardened _) in Index (ix - 1)
 
 instance Bounded (Index 'WholeDomain level) where
     minBound = Index minBound

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -359,26 +359,53 @@ instance Bounded (Index 'WholeDomain level) where
 instance Enum (Index 'Hardened level) where
     fromEnum (Index ix) = fromIntegral ix
     toEnum ix
-        | Index (fromIntegral ix) < minBound @(Index 'Hardened _) =
-            error "Index@Hardened.toEnum: bad argument"
+        | ix >= minIndex && ix <= maxIndex = Index (fromIntegral ix)
         | otherwise =
-            Index (fromIntegral ix)
+            error $ concat
+                [ "Index@Hardened.toEnum: value "
+                , show ix
+                , " is not within bounds: "
+                , show minIndex
+                , " <= value <= "
+                , show maxIndex
+                ]
+      where
+        minIndex = fromIntegral (getIndex (minBound @(Index 'Hardened _)))
+        maxIndex = fromIntegral (getIndex (maxBound @(Index 'Hardened _)))
 
 instance Enum (Index 'Soft level) where
     fromEnum (Index ix) = fromIntegral ix
     toEnum ix
-        | Index (fromIntegral ix) > maxBound @(Index 'Soft _) =
-            error "Index@Soft.toEnum: bad argument"
+        | ix >= minIndex && ix <= maxIndex = Index (fromIntegral ix)
         | otherwise =
-            Index (fromIntegral ix)
+            error $ concat
+                [ "Index@Soft.toEnum: value "
+                , show ix
+                , " is not within bounds: "
+                , show minIndex
+                , " <= value <= "
+                , show maxIndex
+                ]
+      where
+        minIndex = fromIntegral (getIndex (minBound @(Index 'Soft _)))
+        maxIndex = fromIntegral (getIndex (maxBound @(Index 'Soft _)))
 
 instance Enum (Index 'WholeDomain level) where
     fromEnum (Index ix) = fromIntegral ix
     toEnum ix
-        | Index (fromIntegral ix) > maxBound @(Index 'WholeDomain _) =
-            error "Index@WholeDomain.toEnum: bad argument"
+        | ix >= minIndex && ix <= maxIndex = Index (fromIntegral ix)
         | otherwise =
-            Index (fromIntegral ix)
+            error $ concat
+                [ "Index@WholeDomain.toEnum: value "
+                , show ix
+                , " is not within bounds: "
+                , show minIndex
+                , " <= value <= "
+                , show maxIndex
+                ]
+      where
+        minIndex = fromIntegral (getIndex (minBound @(Index 'WholeDomain _)))
+        maxIndex = fromIntegral (getIndex (maxBound @(Index 'WholeDomain _)))
 
 instance Buildable (Index derivationType level) where
     build (Index ix) = fromString (show ix)

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -36,7 +36,7 @@ module Cardano.Wallet.Primitive.AddressDiscovery
     , pendingIxsToList
     , pendingIxsFromList
     , nextChangeIndex
-    , updatePendingIxs
+    , dropLowerPendingIxs
     ) where
 
 import Prelude
@@ -63,8 +63,6 @@ import Control.DeepSeq
     ( NFData )
 import Data.Kind
     ( Type )
-import Data.List
-    ( intercalate )
 import Data.List.NonEmpty
     ( NonEmpty )
 import GHC.Generics
@@ -204,13 +202,13 @@ newtype DiscoverTxs addr txs s = DiscoverTxs
     }
 
 {-------------------------------------------------------------------------------
-                            Pending Change Indexes
+                        Pending Tx Change Indexes
 -------------------------------------------------------------------------------}
 
--- | An ordered set of pending indexes. This keep track of indexes used
+-- | An ordered set of indexes used by pending transactions.
 newtype PendingIxs k = PendingIxs
-    { pendingIxsToList :: [Index 'Soft k] }
-    deriving stock (Generic, Show, Eq)
+    { pendingIxsToList :: [Index 'Soft k]
+    } deriving stock (Generic, Show, Eq)
 
 instance NFData (PendingIxs k)
 
@@ -233,34 +231,38 @@ nextChangeIndex
        AddressPool.Pool (KeyFingerprint "payment" key) (Index 'Soft k)
     -> PendingIxs k
     -> (Index 'Soft k, PendingIxs k)
-nextChangeIndex pool (PendingIxs ixs) =
-    let
-        poolLen = AddressPool.size  pool
-        (firstUnused, lastUnused) =
-            ( toEnum $ poolLen - AddressPool.gap pool
-            , toEnum $ poolLen - 1
-            )
-        (ix, ixs') = case ixs of
-            [] ->
-                (firstUnused, PendingIxs [firstUnused])
-            h:_ | length ixs < AddressPool.gap pool ->
-                (succ h, PendingIxs (succ h:ixs))
-            h:q ->
-                (h, PendingIxs (q++[h]))
+nextChangeIndex pool (PendingIxs pendingIndexes) =
+    let poolLen = AddressPool.size pool
+        gap = AddressPool.gap pool
+        firstUnused = toEnum $ poolLen - gap
+        lastUnused = toEnum $ poolLen - 1
+        (nextIndex, pendingIndexes') =
+            case pendingIndexes of
+                [] -> (firstUnused, PendingIxs [firstUnused])
+                firstIndex : restIndexes ->
+                    if length pendingIndexes < AddressPool.gap pool
+                        then let next = succ firstIndex
+                             in (next, PendingIxs (next : pendingIndexes))
+                        else ( firstIndex
+                             , PendingIxs (restIndexes <> [firstIndex])
+                             )
+        errorMessage = concat
+            [ "Next change index ("
+            , show (getIndex nextIndex)
+            , ") is NOT between the first unused ("
+            , show (getIndex firstUnused)
+            , ") and the last unused ("
+            , show (getIndex lastUnused)
+            , ") indexes. Pool length is "
+            , show poolLen
+            , ", gap is "
+            , show gap
+            , ". The pending indexes are: "
+            , L.intercalate ", " $ fmap (show . getIndex) pendingIndexes
+            ]
     in
-        invariant "index is within first unused and last unused" (ix, ixs')
-            (\(i,_) -> i >= firstUnused && i <= lastUnused)
+        invariant errorMessage (nextIndex, pendingIndexes') $ \(index, _) ->
+            index >= firstUnused && index <= lastUnused
 
--- | Update the set of pending indexes by discarding every indexes _below_ the
--- given index.
---
--- Why is that?
---
--- Because we really do care about the higher index that was last used in order
--- to know from where we can generate new indexes.
-updatePendingIxs
-    :: Index 'Soft k
-    -> PendingIxs k
-    -> PendingIxs k
-updatePendingIxs ix (PendingIxs ixs) =
-    PendingIxs $ L.filter (> ix) ixs
+dropLowerPendingIxs :: Index 'Soft k -> PendingIxs k -> PendingIxs k
+dropLowerPendingIxs ix (PendingIxs ixs) = PendingIxs $ L.filter (> ix) ixs

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -20,9 +20,7 @@
 --  * "Cardano.Wallet.Primitive.AddressDiscovery.Random"
 
 module Cardano.Wallet.Primitive.AddressDiscovery
-    (
-    -- * Abstractions
-      IsOurs(..)
+    ( IsOurs(..)
     , IsOwned(..)
     , GenChange(..)
     , CompareDiscovery(..)
@@ -55,7 +53,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     )
 import Cardano.Wallet.Primitive.BlockSummary
     ( ChainEvents )
-import Cardano.Wallet.Primitive.Passphrase
+import Cardano.Wallet.Primitive.Passphrase.Types
     ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
@@ -65,6 +63,8 @@ import Control.DeepSeq
     ( NFData )
 import Data.Kind
     ( Type )
+import Data.List
+    ( intercalate )
 import Data.List.NonEmpty
     ( NonEmpty )
 import GHC.Generics

--- a/lib/core/test/unit/Cardano/Wallet/Address/PoolSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Address/PoolSpec.hs
@@ -66,6 +66,10 @@ spec = do
                 p2 = AddressPool.update (AddressPool.gap p1 + 1) p1
             in  addresses p1 === addresses p2
 
+        it "nextIndex always points to an unused address"
+            prop_next_is_unused
+
+
     parallel $ describe "Address discovery" $ do
         it "discover by query = discover in sequence" $
             prop_discover (AddressPool.new (*2) (6::Int))
@@ -131,6 +135,12 @@ prop_discover pool0 = forAll (genAddresses pool0) prop
         discoverQuery =
             second AddressPool.addresses
             . runIdentity $ AddressPool.discover query pool0
+
+prop_next_is_unused :: Property
+prop_next_is_unused = forAll (genPool testPool) $ \p ->
+    let i = AddressPool.nextIndex p
+        indexState = filter ((== i) . fst) (Map.elems (addresses p))
+    in  indexState == [(i, Unused)]
 
 {-------------------------------------------------------------------------------
     Generators

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -246,33 +246,25 @@ prop_roundtripEnumGap g =
 
 -- | We can always generate at exactly `gap` change addresses (on the internal
 -- chain) using mkSeqStateFromRootXPrv
-prop_genChangeGapFromRootXPrv
-    :: AddressPoolGap
-    -> Property
-prop_genChangeGapFromRootXPrv g =
-    property prop
+prop_genChangeGapFromRootXPrv :: AddressPoolGap -> Property
+prop_genChangeGapFromRootXPrv g = property $
+    length (fst $ changeAddresses [] s0) === fromEnum g
   where
     mw = someDummyMnemonic (Proxy @12)
     key = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
     s0 = mkSeqStateFromRootXPrv (key, mempty) purposeCIP1852 g
-    prop =
-        length (fst $ changeAddresses [] s0) === fromEnum g
 
 -- | We can always generate at exactly `gap` change addresses (on the internal
 -- chain) using mkSeqStateFromAccountXPub
-prop_genChangeGapFromAccountXPub
-    :: AddressPoolGap
-    -> Property
-prop_genChangeGapFromAccountXPub g =
-    property prop
+prop_genChangeGapFromAccountXPub :: AddressPoolGap -> Property
+prop_genChangeGapFromAccountXPub g = property $
+    length (fst $ changeAddresses [] s0) === fromEnum g
   where
     mw = someDummyMnemonic (Proxy @12)
     rootXPrv = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
     accIx = toEnum 0x80000000
     accXPub = publicKey $ deriveAccountPrivateKey mempty rootXPrv accIx
     s0 = mkSeqStateFromAccountXPub accXPub Nothing purposeCIP1852 g
-    prop =
-        length (fst $ changeAddresses [] s0) === fromEnum g
 
 prop_changeAddressRotation
     :: SeqState 'Mainnet ShelleyKey
@@ -445,8 +437,7 @@ instance AddressPoolTest ShelleyKey where
       where
         mkAddress k = delegationAddress @'Mainnet k rewardAccount
 
-rewardAccount
-    :: ShelleyKey 'AddressK XPub
+rewardAccount :: ShelleyKey 'AddressK XPub
 rewardAccount = publicKey $
     Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
   where
@@ -461,16 +452,12 @@ changeAddresses as s =
     in if a `elem` as then (as, s) else changeAddresses (a:as) s'
 
 unsafeMkAddressPoolGap :: (Integral a, Show a) => a -> AddressPoolGap
-unsafeMkAddressPoolGap g = case (mkAddressPoolGap $ fromIntegral g) of
+unsafeMkAddressPoolGap g = case mkAddressPoolGap (fromIntegral g) of
     Right a -> a
     Left _ -> error $ "unsafeMkAddressPoolGap: bad argument: " <> show g
 
 defaultPrefix :: DerivationPrefix
-defaultPrefix = DerivationPrefix
-    ( purposeCIP1852
-    , coinTypeAda
-    , minBound
-    )
+defaultPrefix = DerivationPrefix (purposeCIP1852, coinTypeAda, minBound)
 
 {-------------------------------------------------------------------------------
                                 Arbitrary Instances


### PR DESCRIPTION
It turns out that address discovery in the light-mode did not update the list of pending indexes. We came to the conclusion that instead of adding fixing this in the light-mode, we change the behavior in node-mode too — specifically, we change the semantics of `nextChangeIndex` to automatically drop pending indexes that are too old. The idea is that `PendingIxs` now behaves more like a random seed rather than a specific list of addresses; by making this type abstract, we can switch out its implementation later (if desired).

- [x] I have re-formatted code to add readability and code-style compliance in a separate commit;
- [x] changed the code such that pending indexes are not updated when a new address discovered, but are updated right before the next change index is about to be generated. This way its easier to maintain pending indexes invariant as the update logic isn't scattered across modules.

### Issue Number

ADP-2154