### PR TITLE
Run docker compose smoke test on mainnet

### DIFF
--- a/.github/workflows/docker_linux.yml
+++ b/.github/workflows/docker_linux.yml
@@ -7,7 +7,7 @@ on:
       network:
         description: 'NETWORK'
         required: true
-        default: 'testnet'
+        default: 'mainnet'
 
 jobs:
   build:
@@ -27,4 +27,4 @@ jobs:
           docker-compose up -d
           ./scripts/connect_wallet.rb
         env:
-          NETWORK: ${{ github.event.inputs.network || 'testnet' }}
+          NETWORK: ${{ github.event.inputs.network || 'mainnet' }}

--- a/.github/workflows/docker_macos.yml
+++ b/.github/workflows/docker_macos.yml
@@ -7,7 +7,7 @@ on:
       network:
         description: 'NETWORK'
         required: true
-        default: 'testnet'
+        default: 'mainnet'
 
 jobs:
   build:
@@ -28,4 +28,4 @@ jobs:
           docker-compose up -d
           ./scripts/connect_wallet.rb
         env:
-          NETWORK: ${{ github.event.inputs.network || 'testnet' }}
+          NETWORK: ${{ github.event.inputs.network || 'mainnet' }}

--- a/.github/workflows/docker_macos.yml
+++ b/.github/workflows/docker_macos.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: docker-practice/actions-setup-docker@1.0.10
+      - uses: docker-practice/actions-setup-docker@1.0.11
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.1


### PR DESCRIPTION
- [x] Run docker compose smoke test on mainnet instead of testnet

### Comments

Docker-compose linux: https://github.com/input-output-hk/cardano-wallet/actions/runs/2918139471 :heavy_check_mark: 
Docker-compose macOs: https://github.com/input-output-hk/cardano-wallet/actions/runs/2918266564 :heavy_check_mark: 

### Issue Number

ADP-2153
