### PR TITLE
docker-compose tag update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         max-size: "50m"
 
   cardano-wallet:
-    image: inputoutput/cardano-wallet:2022.8.16-configs
+    image: inputoutput/cardano-wallet:2022.8.16
     volumes:
       - wallet-${NETWORK}-db:/wallet-db
       - node-ipc:/ipc


### PR DESCRIPTION
- [x] back to `2022-08-16`

### Comments

Buildkite updated previous tag on docker-hub upon me creating a tag `v2022-08-16-config`, so changing it back in docker-compose. 

Good thing is that it works!
```
NETWORK=preview docker-compose up
NETWORK=preprod docker-compose up
NETWORK=mainnet docker-compose up
```

### Issue Number
https://input-output.atlassian.net/browse/ADP-2153
