### PR TITLE
Filter out "Rejected by code reviews" from bors failures

### DIFF
--- a/scripts/bors-stats.rb
+++ b/scripts/bors-stats.rb
@@ -345,7 +345,8 @@ def include_worthy_comment(c)
     (c.bodyText.include? 'Already running a review'),
     (c.bodyText.include? 'This PR was included in a batch that was canceled, it will be automatically retried'),
     (c.bodyText.include? 'This PR was included in a batch that successfully built, but then failed to merge into master'),
-    (c.bodyText.include?  '🔒 Permission denied')
+    (c.bodyText.include? '🔒 Permission denied'),
+    (c.bodyText.include? '👎 Rejected by code reviews')
   ].any?
 end
 


### PR DESCRIPTION
- [x] Add `Rejected by code reviews` to bors failures which are automatically excluded from the flaky test failure statistics

### Comments

#### Before (` ./scripts/bors-stats.rb --after "16 Aug" --force-refetch`)

<img width="1054" alt="Skärmavbild 2022-08-26 kl  12 09 40" src="https://user-images.githubusercontent.com/304423/186881593-87aa84e3-3a43-4dd3-81eb-571f42e915f0.png">

#### Now

<img width="1117" alt="Skärmavbild 2022-08-26 kl  12 09 53" src="https://user-images.githubusercontent.com/304423/186881560-8c3563f6-9298-4dc8-873d-19880633196a.png">

### Issue Number

None.

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
