### PR TITLE
Add `Cardano.Wallet.Types.Read.Tx` module

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -281,6 +281,7 @@ library
       Cardano.Wallet.Registry
       Cardano.Wallet.TokenMetadata.MockServer
       Cardano.Wallet.Transaction
+      Cardano.Wallet.Types.Read.Tx
       Cardano.Wallet.Unsafe
       Cardano.Wallet.Util
       Cardano.Wallet.Version

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -281,6 +281,7 @@ library
       Cardano.Wallet.Registry
       Cardano.Wallet.TokenMetadata.MockServer
       Cardano.Wallet.Transaction
+      Cardano.Wallet.Types.Read
       Cardano.Wallet.Types.Read.Tx
       Cardano.Wallet.Unsafe
       Cardano.Wallet.Util

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/CBOR/Hash.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/CBOR/Hash.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -17,14 +16,11 @@ module Cardano.Wallet.Primitive.Types.Tx.CBOR.Hash
     , alonzoTxHash
     , shelleyTxHash
     , fromShelleyTxId
-    , parseTxHash
     )
     where
 
 import Prelude
 
-import Cardano.Api
-    ( CardanoEra (..) )
 import Cardano.Binary
     ( ToCBOR (..) )
 import Cardano.Chain.UTxO
@@ -37,11 +33,6 @@ import Cardano.Ledger.Era
     ( Era (..) )
 import Cardano.Ledger.Shelley.TxBody
     ( EraIndependentTxBody )
-import Cardano.Wallet.Primitive.Types.Tx.CBOR
-import Codec.CBOR.Read
-    ( DeserialiseFailure )
-import Data.Functor
-    ( (<&>) )
 
 import qualified Cardano.Crypto as CryptoC
 import qualified Cardano.Crypto.Hash as Crypto
@@ -82,12 +73,3 @@ shelleyTxHash
 fromShelleyTxId :: SL.TxId crypto -> W.Hash "Tx"
 fromShelleyTxId (SL.TxId h) =
     W.Hash $ Crypto.hashToBytes $ SafeHash.extractHash h
-
-parseTxHash :: TxCBOR -> Either DeserialiseFailure (W.Hash "Tx")
-parseTxHash cbor = parseCBOR cbor <&> \case
-    EraTx ByronEra x -> byronTxHash x
-    EraTx ShelleyEra x -> shelleyTxHash x
-    EraTx MaryEra x -> shelleyTxHash x
-    EraTx AllegraEra x -> shelleyTxHash x
-    EraTx AlonzoEra x -> shelleyTxHash x
-    EraTx BabbageEra x -> shelleyTxHash x

--- a/lib/core/src/Cardano/Wallet/Types/Read.hs
+++ b/lib/core/src/Cardano/Wallet/Types/Read.hs
@@ -1,0 +1,19 @@
+{- |
+Copyright: © 2022 IOHK
+License: Apache-2.0
+
+Data that is read from the mainnet ledger, represented in a way
+that is compatible with the era-specific types from @cardano-ledger@.
+
+This module re-exports the children of this module hierarchy
+and is meant to be imported qualified, e.g.
+
+@
+import qualified Cardano.Wallet.Types.Read as Read
+@
+-}
+module Cardano.Wallet.Types.Read
+    ( module Cardano.Wallet.Types.Read.Tx
+    ) where
+
+import Cardano.Wallet.Types.Read.Tx

--- a/lib/core/src/Cardano/Wallet/Types/Read/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Types/Read/Tx.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{- |
+Copyright: © 2022 IOHK
+License: Apache-2.0
+
+The 'Tx' type represents transactions as they are read from the mainnet ledger.
+It is compatible with the era-specific types from @cardano-ledger@.
+-}
+module Cardano.Wallet.Types.Read.Tx
+    ( -- * Transactions
+      TxEra
+    , Tx (..)
+    , TxId
+    , computeTxId
+    ) where
+
+import Prelude
+
+import Cardano.Api
+    ( AllegraEra
+    , AlonzoEra
+    , BabbageEra
+    , ByronEra
+    , CardanoEra (..)
+    , MaryEra
+    , ShelleyEra
+    )
+
+import qualified Cardano.Api as Api
+import qualified Cardano.Api.Shelley as Api
+
+import qualified Cardano.Chain.UTxO as Byron
+
+import qualified Cardano.Ledger.Shelley.API as Shelley
+import qualified Cardano.Ledger.TxIn as Shelley
+
+import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
+
+import qualified Cardano.Wallet.Primitive.Types.Hash as W
+
+import qualified Cardano.Crypto as CryptoC
+import qualified Cardano.Crypto.Hash as Crypto
+import qualified Cardano.Ledger.SafeHash as SafeHash
+
+{-------------------------------------------------------------------------------
+    Transaction type
+-------------------------------------------------------------------------------}
+-- | Closed type family returning the ledger 'Tx' type for each known @era@.
+type family TxEra era where
+    TxEra ByronEra = Byron.ATxAux ()
+    TxEra ShelleyEra = Shelley.Tx (Api.ShelleyLedgerEra ShelleyEra)
+    TxEra AllegraEra = Shelley.Tx (Api.ShelleyLedgerEra AllegraEra)
+    TxEra MaryEra = Shelley.Tx (Api.ShelleyLedgerEra MaryEra)
+    TxEra AlonzoEra = Alonzo.ValidatedTx (Api.ShelleyLedgerEra AlonzoEra)
+    TxEra BabbageEra = Alonzo.ValidatedTx (Api.ShelleyLedgerEra BabbageEra)
+
+{- Note [CardanoEra]
+
+The `CardanoEra` from `Cardano.Api` enumerates the known Cardano eras.
+It's very convenient, because it's a GADT and
+brings a type level `era` in scope.
+
+This `era` is not immediately suitable for use with the ledger types,
+but the type family `Api.ShelleyLedgerEra` performs the conversion.
+-}
+
+-- | A transaction as it can be read from the Cardano mainnet.
+--
+-- This transaction can come from any era, old (Byron) and new (Babbage).
+data Tx where
+    Tx
+        :: forall era. Api.IsCardanoEra era
+        => Api.CardanoEra era
+        -> TxEra era
+        -> Tx
+
+{- Note [SeeminglyRedundantPatternMatches]
+
+When writing code that handles multiple eras, it is highly recommended
+that you pattern match on each era invidiually and handle the specialized
+types that arise.
+
+When doing these pattern matches, you may find that some cases
+may seem highly redundant.
+However, the types of the patterns are wildly different due to
+type-level programming, so the cases are not actually redundant.
+
+In other words, it is best to keep each case separate,
+even if this seemingly duplicates code,
+and *not* attempt to refactor them into common function,
+as the type signatures for those functions are more complicated
+than any simplification that would result from avoided repetition.
+
+Look, you have been warned!
+-}
+
+{-------------------------------------------------------------------------------
+    TxId
+-------------------------------------------------------------------------------}
+type TxId = W.Hash "Tx"
+
+-- | Compute the 'txId' of a transaction by hashing the transaction body.
+computeTxId :: Tx -> TxId
+computeTxId (Tx era tx) = case era of
+    -- See Note [SeeminglyRedundantPatternMatches]
+
+    ByronEra -> txHashByron tx
+
+    ShelleyEra -> case tx of
+        Shelley.Tx bod _ _ -> fromShelleyTxId $ Shelley.txid bod
+    MaryEra -> case tx of
+        Shelley.Tx bod _ _ -> fromShelleyTxId $ Shelley.txid bod
+    AllegraEra -> case tx of
+        Shelley.Tx bod _ _ -> fromShelleyTxId $ Shelley.txid bod
+
+    AlonzoEra -> case tx of
+        Alonzo.ValidatedTx bod _ _ _ -> fromShelleyTxId $ Shelley.txid bod
+    BabbageEra -> case tx of
+        Alonzo.ValidatedTx bod _ _ _ -> fromShelleyTxId $ Shelley.txid bod
+
+txHashByron :: Byron.ATxAux a -> W.Hash tag
+txHashByron =
+    W.Hash . CryptoC.hashToBytes . CryptoC.serializeCborHash . Byron.taTx
+
+fromShelleyTxId :: Shelley.TxId crypto -> W.Hash "Tx"
+fromShelleyTxId (Shelley.TxId h) =
+    W.Hash $ Crypto.hashToBytes $ SafeHash.extractHash h


### PR DESCRIPTION
### Issue Number

ADP-2176

### Context

This pull request addresses our mixture of transaction types.

Transactions are used for two _distinct_ purposes:
* Reading from the mainnet ledger — needs to cover all eras
* Writing, ie. submitting transactions to the network — needs to cover the latest eras only

The plan is to use two module hierarchies `Cardano.Wallet.Types.Read` and `Cardano.Wallet.Types.Write`. Any choices of data types, e.g. cardano-ledger vs cardano-api types is to be _confined_ to these module boundaries.

### Summary

This pull requests introduces the modules

* `Cardano.Wallet.Types.Read`
* `Cardano.Wallet.Types.Read.Tx`

and implements the computation of the transaction id by hashing the transaction body.

### Comments

* A next logical step is to merge the `Cardano.Wallet.Primitive.Types.Tx.CBOR` module into the `Cardano.Wallet.Types.Read.Tx` hierarchy.
