### PR TITLE
Add `Cardano.Wallet.Read.Block` module

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -346,6 +346,7 @@ library
     Cardano.Wallet.Primitive.Types.UTxOSelection
     Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
     Cardano.Wallet.Read
+    Cardano.Wallet.Read.Block
     Cardano.Wallet.Read.Eras
     Cardano.Wallet.Read.Eras.EraFun
     Cardano.Wallet.Read.Eras.EraValue

--- a/lib/wallet/src/Cardano/Wallet/Read.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read.hs
@@ -13,7 +13,9 @@ import qualified Cardano.Wallet.Read as Read
 @
 -}
 module Cardano.Wallet.Read
-    ( module Cardano.Wallet.Read.Tx
+    ( module Cardano.Wallet.Read.Block
+    , module Cardano.Wallet.Read.Tx
     ) where
 
+import Cardano.Wallet.Read.Block
 import Cardano.Wallet.Read.Tx

--- a/lib/wallet/src/Cardano/Wallet/Read/Block.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Block.hs
@@ -1,0 +1,21 @@
+{- |
+Copyright: © 2022 IOHK
+License: Apache-2.0
+
+The 'Block' type represents blocks as they are read from the mainnet ledger.
+It is compatible with the era-specific types from @cardano-ledger@.
+-}
+module Cardano.Wallet.Read.Block
+    ( Block
+    ) where
+
+import Prelude
+
+import qualified Ouroboros.Consensus.Cardano.Block as O
+
+{-------------------------------------------------------------------------------
+    Block type
+-------------------------------------------------------------------------------}
+-- | Type synonym for 'CardanoBlock' with cryptography as used on mainnet.
+type Block = O.CardanoBlock O.StandardCrypto
+

--- a/lib/wallet/src/Cardano/Wallet/Read/Block.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Block.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
 {- |
 Copyright: © 2022 IOHK
 License: Apache-2.0
@@ -7,11 +10,34 @@ It is compatible with the era-specific types from @cardano-ledger@.
 -}
 module Cardano.Wallet.Read.Block
     ( Block
+    , getTxsFromBlock
+    , getTxsListFromBlock
     ) where
 
 import Prelude
 
+import Cardano.Api
+    ( CardanoEra (..) )
+import Data.Foldable
+    ( toList )
+import Data.Sequence.Strict
+    ( StrictSeq )
+
 import qualified Ouroboros.Consensus.Cardano.Block as O
+import qualified Ouroboros.Consensus.Shelley.Ledger.Block as O
+
+import qualified Cardano.Chain.Block as Byron
+import qualified Cardano.Chain.UTxO as Byron
+import qualified Ouroboros.Consensus.Byron.Ledger.Block as Byron
+
+import qualified Cardano.Ledger.Era as Shelley
+import qualified Cardano.Ledger.Shelley.API as Shelley
+
+import qualified Cardano.Ledger.Alonzo.TxSeq as Alonzo
+
+import qualified Cardano.Wallet.Read.Tx as Read
+
+import qualified Data.Sequence.Strict as Seq
 
 {-------------------------------------------------------------------------------
     Block type
@@ -19,3 +45,45 @@ import qualified Ouroboros.Consensus.Cardano.Block as O
 -- | Type synonym for 'CardanoBlock' with cryptography as used on mainnet.
 type Block = O.CardanoBlock O.StandardCrypto
 
+{-------------------------------------------------------------------------------
+    Block transactions
+-------------------------------------------------------------------------------}
+-- | Retrieve the sequence of 'Tx' contained in a block, as a list.
+getTxsListFromBlock :: Block -> [Read.Tx]
+getTxsListFromBlock = toList . getTxsFromBlock
+
+-- | Retrieve the sequence of 'Tx' contained in a block, as a 'StrictSeq'.
+getTxsFromBlock :: Block -> StrictSeq Read.Tx
+getTxsFromBlock = \case
+    -- See Note [SeeminglyRedundantPatternMatches]
+
+    O.BlockByron block -> getTxsFromBlockByron block
+
+    O.BlockShelley block -> case block of
+        O.ShelleyBlock (Shelley.Block _ txs) _ ->
+            fmap (Read.Tx ShelleyEra) (Shelley.fromTxSeq txs)
+
+    O.BlockAllegra block -> case block of
+        O.ShelleyBlock (Shelley.Block _ txs) _ ->
+            fmap (Read.Tx AllegraEra) (Shelley.fromTxSeq txs)
+
+    O.BlockMary block -> case block of
+        O.ShelleyBlock (Shelley.Block _ txs) _ ->
+            fmap (Read.Tx MaryEra) (Shelley.fromTxSeq txs)
+
+    O.BlockAlonzo block -> case block of
+        O.ShelleyBlock (Shelley.Block _ (Alonzo.TxSeq txs)) _ ->
+            fmap (Read.Tx AlonzoEra) txs
+
+    O.BlockBabbage block -> case block of
+        O.ShelleyBlock (Shelley.Block _ (Alonzo.TxSeq txs)) _ ->
+            fmap (Read.Tx BabbageEra) txs
+
+getTxsFromBlockByron :: Byron.ByronBlock -> StrictSeq Read.Tx
+getTxsFromBlockByron block = Seq.fromList $
+    case Byron.byronBlockRaw block of
+        Byron.ABOBBlock b ->
+            map mkTx . Byron.unTxPayload . Byron.blockTxPayload $ b
+        Byron.ABOBBoundary _ -> []
+  where
+    mkTx = Read.Tx ByronEra . (() <$)

--- a/lib/wallet/src/Cardano/Wallet/Read/Block.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Block.hs
@@ -15,6 +15,7 @@ module Cardano.Wallet.Read.Block
 
     , getTxsFromBlock
     , getTxsListFromBlock
+    , numberOfTransactionsInBlock
     ) where
 
 import Prelude
@@ -125,6 +126,10 @@ getSlotNo = \case
 -- | Retrieve the sequence of 'Tx' contained in a block, as a list.
 getTxsListFromBlock :: Block -> [Read.Tx]
 getTxsListFromBlock = toList . getTxsFromBlock
+
+-- | Count the number of transactions in a 'Block'.
+numberOfTransactionsInBlock :: Block -> Int
+numberOfTransactionsInBlock = Seq.length . getTxsFromBlock
 
 -- | Retrieve the sequence of 'Tx' contained in a block, as a 'StrictSeq'.
 getTxsFromBlock :: Block -> StrictSeq Read.Tx

--- a/lib/wallet/src/Cardano/Wallet/Read/Block.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Block.hs
@@ -11,6 +11,8 @@ It is compatible with the era-specific types from @cardano-ledger@.
 module Cardano.Wallet.Read.Block
     ( Block
     , getBlockHeight
+    , getSlotNo
+
     , getTxsFromBlock
     , getTxsListFromBlock
     ) where
@@ -90,6 +92,32 @@ getBlockHeight = fromBlockNo . \case
 -- FIXME unsafe conversion (Word64 -> Word32)
 fromBlockNo :: O.BlockNo -> Quantity "block" Word32
 fromBlockNo (O.BlockNo h) = Quantity (fromIntegral h)
+
+getSlotNo :: Block -> O.SlotNo
+getSlotNo = \case
+    -- See Note [SeeminglyRedundantPatternMatches]
+    O.BlockByron block ->
+        O.blockSlot block
+
+    O.BlockShelley block -> case block of
+        O.ShelleyBlock (Shelley.Block (Shelley.BHeader header _) _) _ ->
+            Shelley.bheaderSlotNo header
+
+    O.BlockAllegra block -> case block of
+        O.ShelleyBlock (Shelley.Block (Shelley.BHeader header _) _) _ ->
+            Shelley.bheaderSlotNo header
+
+    O.BlockMary block -> case block of
+        O.ShelleyBlock (Shelley.Block (Shelley.BHeader header _) _) _ ->
+            Shelley.bheaderSlotNo header
+
+    O.BlockAlonzo block -> case block of
+        O.ShelleyBlock (Shelley.Block (Shelley.BHeader header _) _) _ ->
+            Shelley.bheaderSlotNo header
+
+    O.BlockBabbage block -> case block of
+        O.ShelleyBlock (Shelley.Block (O.Header header _) _) _ ->
+            O.hbSlotNo header
 
 {-------------------------------------------------------------------------------
     Block transactions


### PR DESCRIPTION
### Issue Number

ADP-2176

### Context

This pull request addresses our mixture of transaction types.

Transactions are used for two _distinct_ purposes:
* Reading from the mainnet ledger — needs to cover all eras
* Writing, ie. submitting transactions to the network — needs to cover the latest eras only

The plan is to use two module hierarchies `Cardano.Wallet.Read` and `Cardano.Wallet.Write`. Any choices of data types, e.g. cardano-ledger vs cardano-api types is to be _confined_ to these module boundaries.

### Summary

This pull requests introduces the module

* `Cardano.Wallet.Read.Block`

and implements the `numberOfTransactionsInBlock` function used in the baseline benchmark.
