### PR TITLE
Use `UTxO era` as single source of truth in balanceTransaction (second take)

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1567,6 +1567,7 @@ normalizeDelegationAddress s addr = do
 data PartialTx era = PartialTx
     { tx :: Cardano.Tx era
     , inputs :: Cardano.UTxO era
+      -- ^ NOTE: Can we rename this to something better? Perhaps 'extraUTxO'?
     , redeemers :: [Redeemer]
     } deriving (Show, Generic, Eq)
 

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1778,10 +1778,22 @@ balanceTransactionWithSelectionStrategy
     toSealed :: Cardano.Tx era -> SealedTx
     toSealed = sealedTxFromCardano . Cardano.InAnyCardanoEra Cardano.cardanoEra
 
-    -- | Extract the resolved inputs contained in the @PartialTx@
+    -- | Extract the inputs from the raw 'tx' of the 'Partialtx', with the
+    -- corresponding 'TxOut' according to @combinedUTxO@.
     --
-    -- Requires @guardWalletUTxOConsistencyWith inputUTxO@ to validate
-    -- for balancing to succeed.
+    -- === Examples using pseudo-code
+    --
+    -- >>> let extraUTxO = {inA -> outA, inB -> outB }
+    -- >>> let tx = addInputs [inA] emptyTx
+    -- >>> let ptx = PartialTx tx extraUTxO []
+    -- >>> extractExternallySelectedUTxO ptx
+    -- Right (UTxOIndex.fromMap {inA -> outA})
+    --
+    -- >>> let extraUTxO = {inB -> outB }
+    -- >>> let tx = addInputs [inA, inC] emptyTx
+    -- >>> let ptx = PartialTx tx extraUTxO []
+    -- >>> extractExternallySelectedUTxO ptx
+    -- Left (ErrBalanceTxUnresolvedInputs [inA, inC])
     extractExternallySelectedUTxO
         :: PartialTx era
         -> ExceptT ErrBalanceTx m (UTxOIndex WalletUTxO)

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1824,6 +1824,7 @@ data ApiErrorCode
     | UnableToDetermineCurrentEpoch
     | UnexpectedError
     | UnresolvedInputs
+    | InputResolutionConflicts
     | UnsupportedMediaType
     | UtxoTooSmall
     | WalletAlreadyExists

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -360,6 +360,23 @@ data TransactionLayer k tx = TransactionLayer
         -> (Cardano.Tx era)
             -- Transaction containing scripts
         -> (Either ErrAssignRedeemers (Cardano.Tx era))
+
+    , toCardanoUTxO
+        :: forall era. Cardano.IsShelleyBasedEra era
+        => UTxO
+        -> [(TxIn, TxOut, Maybe (Hash "Datum"))]
+        -> Cardano.UTxO era
+        -- ^ Temporary hack to allow access to conversion in balanceTransaction
+
+    , fromCardanoTxIn
+        :: Cardano.TxIn -> TxIn
+        -- ^ Temporary hack to allow access to conversion in balanceTransaction
+
+    , fromCardanoTxOut
+        :: forall era ctx. Cardano.IsCardanoEra era
+        => Cardano.TxOut ctx era
+        -> TxOut
+        -- ^ Temporary hack to allow access to conversion in balanceTransaction
     }
 
 -- | Method to use when updating the fee of a transaction.

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -57,8 +57,10 @@ import Cardano.Address.Script
     ( KeyHash, Script )
 import Cardano.Api
     ( AnyCardanoEra )
+import Cardano.Api.Extra
+    ()
 import Cardano.Ledger.Alonzo.TxInfo
-    ( TranslationError )
+    ( TranslationError (..) )
 import Cardano.Ledger.Crypto
     ( StandardCrypto )
 import Cardano.Wallet.CoinSelection
@@ -254,8 +256,7 @@ data TransactionLayer k tx = TransactionLayer
         :: forall era. Cardano.IsShelleyBasedEra era
         => Cardano.Tx era
         -> Cardano.ProtocolParameters
-        -> UTxO
-        -> [(TxIn, TxOut, Maybe (Hash "Datum"))] -- Extra UTxO
+        -> Cardano.UTxO era
         -> Cardano.Value
         -- ^ Evaluate the balance of a transaction using the ledger. The balance
         -- is defined as @(value consumed by transaction) - (value produced by
@@ -352,9 +353,7 @@ data TransactionLayer k tx = TransactionLayer
         => Cardano.ProtocolParameters
             -- Current protocol parameters
         -> TimeInterpreter (Either PastHorizonException)
-            -- Time interpreter in the Monad m
-        -> (TxIn -> Maybe (TxOut, Maybe (Hash "Datum")))
-            -- A input resolver for transactions' inputs containing scripts.
+        -> Cardano.UTxO era
         -> [Redeemer]
             -- A list of redeemers to set on the transaction.
         -> (Cardano.Tx era)
@@ -524,17 +523,11 @@ data ErrMkTransaction
 
 data ErrAssignRedeemers
     = ErrAssignRedeemersScriptFailure Redeemer String
-    -- ^ Failed to assign execution units for a particular redeemer. The
-    -- 'String' indicates the reason of the failure.
-    --
-    -- TODO: Refine this type to avoid the 'String' and provides a better
-    -- sum-type of possible errors.
     | ErrAssignRedeemersTargetNotFound Redeemer
     -- ^ The given redeemer target couldn't be located in the transaction.
     | ErrAssignRedeemersInvalidData Redeemer String
     -- ^ Redeemer's data isn't a valid Plutus' data.
     | ErrAssignRedeemersTranslationError (TranslationError StandardCrypto)
-    -- ^ Mistranslating of hashes, credentials, certificates etc.
     deriving (Generic, Eq, Show)
 
 -- | Possible signing error

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -1393,6 +1393,12 @@ dummyTransactionLayer = TransactionLayer
         error "dummyTransactionLayer: tokenBundleSizeAssessor not implemented"
     , constraints =
         error "dummyTransactionLayer: constraints not implemented"
+    , toCardanoUTxO =
+        error "dummyTransactionLayer: toCardanoUTxO not implemented"
+    , fromCardanoTxIn =
+        error "dummyTransactionLayer: fromCardanoTxIn not implemented"
+    , fromCardanoTxOut =
+        error "dummyTransactionLayer: fromCardanoTxOut not implemented"
     , decodeTx = \_era _sealed ->
         ( Tx
             { txId = Hash ""

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -215,15 +215,12 @@ import Cardano.Wallet.Shelley.Compatibility
     ( AnyShelleyBasedEra (..)
     , computeTokenBundleSerializedLengthBytes
     , fromCardanoLovelace
-    , fromCardanoTxIn
-    , fromCardanoTxOut
     , getScriptIntegrityHash
     , getShelleyBasedEra
     , shelleyToCardanoEra
     , toCardanoLovelace
     , toCardanoTxIn
     , toCardanoTxOut
-    , toCardanoUTxO
     , toCardanoValue
     )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
@@ -434,6 +431,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx.Gen as TxGen
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
+import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteArray as BA
@@ -3120,8 +3118,8 @@ instance Arbitrary Wallet' where
           where
             genEntry = (,) <$> genIn <*> genOut
               where
-                genIn = fromCardanoTxIn <$> Cardano.genTxIn
-                genOut = fromCardanoTxOut <$> genTxOut AlonzoEra
+                genIn = Compatibility.fromCardanoTxIn <$> Cardano.genTxIn
+                genOut = Compatibility.fromCardanoTxOut <$> genTxOut AlonzoEra
 
         rootK :: SomeMnemonic -> ShelleyKey 'RootK XPrv
         rootK mw = generateKeyFromSeed (mw, Nothing) mempty
@@ -3176,8 +3174,8 @@ instance Arbitrary (PartialTx Cardano.AlonzoEra) where
             -- `maxBound :: Word64`, however users could supply these.
             -- We should ideally test what happens, and make it clear what code,
             -- if any, should validate.
-            o <- fromCardanoTxOut <$> genTxOut Cardano.AlonzoEra
-            return (fromCardanoTxIn $ fst i, o, Nothing)
+            o <- Compatibility.fromCardanoTxOut <$> genTxOut Cardano.AlonzoEra
+            return (Compatibility.fromCardanoTxIn $ fst i, o, Nothing)
         let redeemers = []
         return $ PartialTx
             tx
@@ -3210,8 +3208,8 @@ instance Arbitrary (PartialTx Cardano.BabbageEra) where
             -- `maxBound :: Word64`, however users could supply these.
             -- We should ideally test what happens, and make it clear what code,
             -- if any, should validate.
-            o <- fromCardanoTxOut <$> genTxOut Cardano.BabbageEra
-            return (fromCardanoTxIn $ fst i, o, Nothing)
+            o <- Compatibility.fromCardanoTxOut <$> genTxOut Cardano.BabbageEra
+            return (Compatibility.fromCardanoTxIn $ fst i, o, Nothing)
         let redeemers = []
         return $ PartialTx tx resolvedInputs redeemers
     shrink (PartialTx tx inputs redeemers) =
@@ -3265,7 +3263,7 @@ restrictResolution (PartialTx tx inputs redeemers) =
         PartialTx tx inputs' redeemers
   where
     inputsInTx (Cardano.Tx (Cardano.TxBody bod) _) =
-        Set.fromList $ map (fromCardanoTxIn . fst) $ Cardano.txIns bod
+        Set.fromList $ map (Compatibility.fromCardanoTxIn . fst) $ Cardano.txIns bod
 
 shrinkTxBodyAlonzo
     :: Cardano.TxBody Cardano.AlonzoEra
@@ -3594,7 +3592,7 @@ prop_balanceTransactionValid wallet (ShowBuildable partialTx') seed
     = withMaxSuccess 1000 $ do
         let combinedUTxO = mconcat
                 [ resolvedInputsUTxO Cardano.ShelleyBasedEraAlonzo partialTx
-                , toCardanoUTxO Cardano.ShelleyBasedEraAlonzo walletUTxO
+                , Compatibility.toCardanoUTxO Cardano.ShelleyBasedEraAlonzo walletUTxO
                 ]
         let originalBalance = txBalance (view #tx partialTx) combinedUTxO
         let res = balanceTransaction'

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -50,13 +50,16 @@ import Cardano.Api
 import Cardano.Api.Extra
     ( asAnyShelleyBasedEra, withShelleyBasedTx )
 import Cardano.Api.Gen
-    ( genEncodingBoundaryLovelace
+    ( genAddressInEra
+    , genEncodingBoundaryLovelace
     , genSignedValue
     , genTx
     , genTxBodyContent
     , genTxForBalancing
     , genTxInEra
     , genTxOut
+    , genTxOutDatum
+    , genValueForTxOut
     , genWitnesses
     )
 import Cardano.BM.Data.Tracer
@@ -215,12 +218,12 @@ import Cardano.Wallet.Shelley.Compatibility
     ( AnyShelleyBasedEra (..)
     , computeTokenBundleSerializedLengthBytes
     , fromCardanoLovelace
+    , fromCardanoValue
     , getScriptIntegrityHash
     , getShelleyBasedEra
     , shelleyToCardanoEra
     , toCardanoLovelace
     , toCardanoTxIn
-    , toCardanoTxOut
     , toCardanoValue
     )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
@@ -2491,8 +2494,7 @@ balanceTransactionSpec = describe "balanceTransaction" $ do
             tx `shouldBe` Left ErrBalanceTxMaxSizeLimitExceeded
 
     describe "when passed unresolved inputs" $ do
-        it "fails with some error" $ do
-            pendingWith "currently silently ignored"
+        it "fails with ErrBalanceTxUnresolvedTxIn" $ do
             let txin = TxIn (Hash $ B8.replicate 32 '3') 10
 
             let addr = Address $ unsafeFromHex
@@ -2504,23 +2506,20 @@ balanceTransactionSpec = describe "balanceTransaction" $ do
                     paymentPartialTx
                         [ TxOut addr (TokenBundle.fromCoin (Coin 1_000_000))
                         ]
-            case balanceTx partialTx of
-                Left _ -> return ()
-                Right _ -> expectationFailure "expected Left"
+            balanceTx partialTx
+                `shouldBe`
+                Left (ErrBalanceTxUnresolvedInputs (txin :| []))
 
         describe "with redeemers" $
-            it "fails with RedeemerPointsToUnknownScriptHash" $ do
+            it "fails with ErrBalanceTxUnresolvedInputs" $ do
                 let withNoUTxO :: PartialTx era -> PartialTx era
-                    withNoUTxO ptx = ptx { inputs = [] }
+                    withNoUTxO ptx = ptx { inputs = mempty }
 
                 balanceTx (withNoUTxO pingPong_2)
                     `shouldBe` Left
-                        (ErrBalanceTxAssignRedeemers
-                            (ErrAssignRedeemersScriptFailure
-                                (head (redeemers pingPong_2))
-                                "RedeemerPointsToUnknownScriptHash \
-                                \(RdmrPtr Spend 1)"
-                            )
+                        (ErrBalanceTxUnresolvedInputs $ NE.fromList
+                            [ TxIn (Hash "11111111111111111111111111111111") 0
+                            ]
                         )
 
     describe "when validity interval is too far in the future" $ do
@@ -3163,39 +3162,80 @@ instance Buildable a => Show (ShowBuildable a) where
 instance Arbitrary (Hash "Datum") where
     arbitrary = pure $ Hash $ BS.pack $ replicate 28 0
 
+instance IsCardanoEra era => Arbitrary (Cardano.AddressInEra era) where
+      arbitrary = genAddressInEra Cardano.cardanoEra
+
+instance IsCardanoEra era => Arbitrary (Cardano.TxOutDatum ctx era) where
+      arbitrary = genTxOutDatum Cardano.cardanoEra
+
+instance IsCardanoEra era => Arbitrary (Cardano.TxOut ctx era) where
+      arbitrary = genTxOut Cardano.cardanoEra
+      shrink (Cardano.TxOut addr val dat refScript) = tail
+          [ Cardano.TxOut addr' val' dat' refScript'
+          | addr' <- prependOriginal shrink addr
+          , val' <- prependOriginal shrink val
+          , dat' <- prependOriginal shrink dat
+          , refScript' <- prependOriginal (const []) refScript
+          ]
+
+-- NOTE: We should constrain by @IsRecentEra era@ instead, where @RecentEra@ is
+-- the two latest eras.
+instance IsCardanoEra era => Arbitrary (Cardano.TxOutValue era) where
+      arbitrary = case Cardano.cardanoEra @era of
+         Cardano.AlonzoEra ->
+             Cardano.TxOutValue Cardano.MultiAssetInAlonzoEra
+                 <$> genValueForTxOut
+         Cardano.BabbageEra ->
+             Cardano.TxOutValue Cardano.MultiAssetInBabbageEra
+                 <$>  genValueForTxOut
+         e -> error $ mconcat
+             [ "Arbitrary (TxOutValue "
+             , show e
+             , ") not implemented)"
+             ]
+
+      shrink (Cardano.TxOutValue Cardano.MultiAssetInAlonzoEra val) =
+          map
+              (Cardano.TxOutValue Cardano.MultiAssetInAlonzoEra
+                  . toCardanoValue)
+              (shrink $ Compatibility.fromCardanoValue val)
+
+      shrink (Cardano.TxOutValue Cardano.MultiAssetInBabbageEra val) =
+          map
+              (Cardano.TxOutValue Cardano.MultiAssetInBabbageEra
+                  . toCardanoValue)
+              (shrink $ fromCardanoValue val)
+      shrink _ =
+        error "Arbitrary (TxOutValue era) is not implemented for old eras"
+
 instance Arbitrary (PartialTx Cardano.AlonzoEra) where
     arbitrary = do
         let era = AlonzoEra
         tx <- genTxForBalancing era
         let (Cardano.Tx (Cardano.TxBody content) _) = tx
         let inputs = Cardano.txIns content
-        resolvedInputs <- forM inputs $ \i -> do
+        inputUTxO <- fmap (Cardano.UTxO . Map.fromList) . forM inputs $ \i -> do
             -- NOTE: genTxOut does not generate quantities larger than
             -- `maxBound :: Word64`, however users could supply these.
             -- We should ideally test what happens, and make it clear what code,
             -- if any, should validate.
-            o <- Compatibility.fromCardanoTxOut <$> genTxOut Cardano.AlonzoEra
-            return (Compatibility.fromCardanoTxIn $ fst i, o, Nothing)
+            o <- genTxOut Cardano.AlonzoEra
+            return (fst i, o)
         let redeemers = []
         return $ PartialTx
             tx
-            resolvedInputs
+            inputUTxO
             redeemers
-    shrink (PartialTx tx inputs redeemers) =
-        [ PartialTx tx inputs' redeemers
-        | inputs' <- shrinkInputs inputs
+    shrink (PartialTx tx inputUTxO redeemers) =
+        [ PartialTx tx inputUTxO' redeemers
+        | inputUTxO' <- shrinkInputResolution inputUTxO
         ] ++
         [ restrictResolution $ PartialTx
             tx'
-            inputs
+            inputUTxO
             redeemers
         | tx' <- shrinkTxAlonzo tx
         ]
-      where
-        shrinkInputs (i:ins) =
-            map (:ins) (shrink i) ++ map (i:) (shrinkInputs ins)
-        shrinkInputs [] =
-            []
 
 instance Arbitrary (PartialTx Cardano.BabbageEra) where
     arbitrary = do
@@ -3203,35 +3243,45 @@ instance Arbitrary (PartialTx Cardano.BabbageEra) where
         tx <- genTxForBalancing era
         let (Cardano.Tx (Cardano.TxBody content) _) = tx
         let inputs = Cardano.txIns content
-        resolvedInputs <- forM inputs $ \i -> do
+        inputUTxO <- fmap (Cardano.UTxO . Map.fromList) . forM inputs $ \i -> do
             -- NOTE: genTxOut does not generate quantities larger than
             -- `maxBound :: Word64`, however users could supply these.
             -- We should ideally test what happens, and make it clear what code,
             -- if any, should validate.
-            o <- Compatibility.fromCardanoTxOut <$> genTxOut Cardano.BabbageEra
-            return (Compatibility.fromCardanoTxIn $ fst i, o, Nothing)
+            o <- genTxOut Cardano.BabbageEra
+            return (fst i, o)
         let redeemers = []
-        return $ PartialTx tx resolvedInputs redeemers
-    shrink (PartialTx tx inputs redeemers) =
-        [ PartialTx tx inputs' redeemers | inputs' <- shrinkInputs inputs ] <>
-        [ restrictResolution $ PartialTx tx' inputs redeemers
-        | tx' <- shrinkTxBabbage tx ]
-      where
-        shrinkInputs (i:ins) =
-            map (:ins) (shrink i) ++ map (i:) (shrinkInputs ins)
-        shrinkInputs [] = []
+        return $ PartialTx tx inputUTxO redeemers
+    shrink (PartialTx tx inputUTxO redeemers) =
+        [ PartialTx tx inputUTxO' redeemers
+        | inputUTxO' <- shrinkInputResolution inputUTxO
+        ] <>
+        [ restrictResolution $ PartialTx tx' inputUTxO redeemers
+        | tx' <- shrinkTxBabbage tx
+        ]
 
-resolvedInputsUTxO
-    :: ShelleyBasedEra era
-    -> PartialTx era
-    -> Cardano.UTxO era
-resolvedInputsUTxO era (PartialTx _ resolvedInputs _) =
-    Cardano.UTxO $ Map.fromList $ map convertUTxO resolvedInputs
-  where
-    convertUTxO (i, o, Nothing) =
-        (toCardanoTxIn i, toCardanoTxOut era o)
-    convertUTxO (_, _, Just _) =
-        error "resolvedInputsUTxO: todo: handle datum hash"
+
+shrinkInputResolution
+    :: forall era.
+        ( Cardano.IsCardanoEra era
+        , Arbitrary (Cardano.TxOut Cardano.CtxUTxO era)
+        )
+    => Cardano.UTxO era
+    -> [Cardano.UTxO era]
+shrinkInputResolution =
+     map utxoFromList . shrinkUTxOEntries . utxoToList
+   where
+     utxoToList (Cardano.UTxO u) = Map.toList u
+     utxoFromList = Cardano.UTxO . Map.fromList
+
+shrinkUTxOEntries :: Arbitrary o => [(i, o)] -> [[(i, o)]]
+shrinkUTxOEntries ((i,o) : rest) = mconcat
+    -- First shrink the first element
+    [ map (\o' -> (i, o') : rest ) (shrink o)
+    -- Recurse to shrink subsequent elements on their own
+    , map ((i,o):) (shrinkUTxOEntries rest)
+    ]
+shrinkUTxOEntries [] = []
 
 instance Semigroup (Cardano.UTxO era) where
     Cardano.UTxO a <> Cardano.UTxO b = Cardano.UTxO (a <> b)
@@ -3255,15 +3305,14 @@ shrinkTxBabbage (Cardano.Tx bod wits) =
 --
 -- NOTE: Perhaps ideally 'PartialTx' would handle this automatically.
 restrictResolution :: PartialTx era -> PartialTx era
-restrictResolution (PartialTx tx inputs redeemers) =
+restrictResolution (PartialTx tx (Cardano.UTxO u) redeemers) =
     let
-        inputs' = flip filter inputs $  \(i, _, _) ->
-            i `Set.member` inputsInTx tx
+        u' = u `Map.restrictKeys` (inputsInTx tx)
     in
-        PartialTx tx inputs' redeemers
+        PartialTx tx (Cardano.UTxO u') redeemers
   where
     inputsInTx (Cardano.Tx (Cardano.TxBody bod) _) =
-        Set.fromList $ map (Compatibility.fromCardanoTxIn . fst) $ Cardano.txIns bod
+             Set.fromList $ map fst $ Cardano.txIns bod
 
 shrinkTxBodyAlonzo
     :: Cardano.TxBody Cardano.AlonzoEra
@@ -3528,7 +3577,7 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
             "60b1e5e0fb74c86c801f646841e07cdb42df8b82ef3ce4e57cb5412e77"
 
     delegate :: PartialTx Cardano.BabbageEra
-    delegate = PartialTx (Cardano.Tx body []) [] []
+    delegate = PartialTx (Cardano.Tx body []) mempty []
       where
         body = Cardano.ShelleyTxBody
             Cardano.ShelleyBasedEraBabbage
@@ -3588,10 +3637,10 @@ prop_balanceTransactionValid
     -> ShowBuildable (PartialTx Cardano.AlonzoEra)
     -> StdGenSeed
     -> Property
-prop_balanceTransactionValid wallet (ShowBuildable partialTx') seed
+prop_balanceTransactionValid wallet (ShowBuildable partialTx) seed
     = withMaxSuccess 1000 $ do
         let combinedUTxO = mconcat
-                [ resolvedInputsUTxO Cardano.ShelleyBasedEraAlonzo partialTx
+                [ view #inputs partialTx
                 , Compatibility.toCardanoUTxO Cardano.ShelleyBasedEraAlonzo walletUTxO
                 ]
         let originalBalance = txBalance (view #tx partialTx) combinedUTxO
@@ -3680,6 +3729,8 @@ prop_balanceTransactionValid wallet (ShowBuildable partialTx') seed
                 (ErrSelectAssetsSelectionError
                 (SelectionBalanceErrorOf (UnableToConstructChange _)))) ->
                 label "unable to construct change" $ property True
+            Left ErrBalanceTxInputResolutionConflicts{} ->
+                label "input resolution conflicts" $ property True
             Left err -> label "other error" $
                 counterexample ("balanceTransaction failed: " <> show err) False
   where
@@ -3734,21 +3785,6 @@ prop_balanceTransactionValid wallet (ShowBuildable partialTx') seed
                 , show tx
                 ]
         counterexample msg $ property (size <= limit)
-
-    -- NOTE: Here we change the input-resolution of the 'PartialTx' to be
-    -- consistent with the 'UTxO'. We may want to instead either
-    -- 1. Make generators generate consistent data (but requires
-    --  interdependency)
-    -- 2. Make `balanceTransaction` identify and fail when user-specified UTxOs
-    -- conflict with the wallet's UTxO set (but may be bad for
-    -- prop_balanceTransactionBalanced coverage)
-    partialTx = PartialTx s ins' r
-      where
-        PartialTx s ins r = partialTx'
-        ins' = flip map ins $ \(i,o,dh) ->
-            case UTxO.lookup i walletUTxO of
-                Just o' -> (i,o',Nothing)
-                Nothing -> (i,o,dh)
 
     walletUTxO :: UTxO
     walletUTxO =
@@ -4070,7 +4106,7 @@ sealedFee =
     view #fee . fst5 . _decodeSealedTx maxBound . sealedTxFromCardano'
 
 paymentPartialTx :: [TxOut] -> PartialTx Cardano.BabbageEra
-paymentPartialTx txouts = PartialTx (Cardano.Tx body []) [] []
+paymentPartialTx txouts = PartialTx (Cardano.Tx body []) mempty []
   where
     body = Cardano.ShelleyTxBody
         Cardano.ShelleyBasedEraBabbage
@@ -4105,7 +4141,7 @@ paymentPartialTx txouts = PartialTx (Cardano.Tx body []) [] []
         }
 
 pingPong_1 :: PartialTx Cardano.BabbageEra
-pingPong_1 = PartialTx tx [] []
+pingPong_1 = PartialTx tx mempty []
   where
     tx = deserializeBabbageTx $ unsafeFromHex
         "84a500800d80018183581d714d72cf569a339a18a7d9302313983f56e0d96cd4\
@@ -4119,7 +4155,7 @@ pingPong_2 = PartialTx
         , bytes tid
         , unsafeFromHex "000d80018183581d714d72cf569a339a18a7d9302313983f56e0d96cd45bdcb1d6512dca6a1a001e848058208392f0c940435c06888f9bdb8c74a95dc69f156367d6a089cf008ae05caae01e02000e80a20381591b72591b6f01000033233332222333322223322332232323332223233322232333333332222222232333222323333222232323322323332223233322232323322332232323333322222332233223322332233223322223223223232533530333330083333573466e1d40192004204f23333573466e1d401d2002205123333573466e1d40212000205323504b35304c3357389201035054310004d49926499263333573466e1d40112004205323333573466e1d40152002205523333573466e1d40192000205723504b35304c3357389201035054310004d49926499263333573466e1cd55cea8012400046601664646464646464646464646666ae68cdc39aab9d500a480008cccccccccc064cd409c8c8c8cccd5cd19b8735573aa004900011980f981d1aba15002302c357426ae8940088d4164d4c168cd5ce2481035054310005b49926135573ca00226ea8004d5d0a80519a8138141aba150093335502e75ca05a6ae854020ccd540b9d728169aba1500733502704335742a00c66a04e66aa0a8098eb4d5d0a8029919191999ab9a3370e6aae754009200023350213232323333573466e1cd55cea80124000466a05266a084eb4d5d0a80118239aba135744a00446a0ba6a60bc66ae712401035054310005f49926135573ca00226ea8004d5d0a8011919191999ab9a3370e6aae7540092000233502733504275a6ae854008c11cd5d09aba2500223505d35305e3357389201035054310005f49926135573ca00226ea8004d5d09aba2500223505935305a3357389201035054310005b49926135573ca00226ea8004d5d0a80219a813bae35742a00666a04e66aa0a8eb88004d5d0a801181c9aba135744a00446a0aa6a60ac66ae71241035054310005749926135744a00226ae8940044d5d1280089aba25001135744a00226ae8940044d5d1280089aba25001135573ca00226ea8004d5d0a8011919191999ab9a3370ea00290031180f181d9aba135573ca00646666ae68cdc3a801240084603a608a6ae84d55cf280211999ab9a3370ea00690011180e98181aba135573ca00a46666ae68cdc3a80224000460406eb8d5d09aab9e50062350503530513357389201035054310005249926499264984d55cea80089baa001357426ae8940088d4124d4c128cd5ce249035054310004b49926104a1350483530493357389201035054350004a4984d55cf280089baa001135573a6ea80044d55ce9baa0012212330010030022001222222222212333333333300100b00a00900800700600500400300220012212330010030022001122123300100300212001122123300100300212001122123300100300212001212222300400521222230030052122223002005212222300100520011232230023758002640026aa078446666aae7c004940388cd4034c010d5d080118019aba200203323232323333573466e1cd55cea801a4000466600e6464646666ae68cdc39aab9d5002480008cc034c0c4d5d0a80119a8098169aba135744a00446a06c6a606e66ae71241035054310003849926135573ca00226ea8004d5d0a801999aa805bae500a35742a00466a01eeb8d5d09aba25002235032353033335738921035054310003449926135744a00226aae7940044dd50009110919980080200180110009109198008018011000899aa800bae75a224464460046eac004c8004d540d888c8cccd55cf80112804919a80419aa81898031aab9d5002300535573ca00460086ae8800c0b84d5d08008891001091091198008020018900089119191999ab9a3370ea002900011a80418029aba135573ca00646666ae68cdc3a801240044a01046a0526a605466ae712401035054310002b499264984d55cea80089baa001121223002003112200112001232323333573466e1cd55cea8012400046600c600e6ae854008dd69aba135744a00446a0466a604866ae71241035054310002549926135573ca00226ea80048848cc00400c00880048c8cccd5cd19b8735573aa002900011bae357426aae7940088d407cd4c080cd5ce24810350543100021499261375400224464646666ae68cdc3a800a40084a00e46666ae68cdc3a8012400446a014600c6ae84d55cf280211999ab9a3370ea00690001280511a8111a981199ab9c490103505431000244992649926135573aa00226ea8004484888c00c0104488800844888004480048c8cccd5cd19b8750014800880188cccd5cd19b8750024800080188d4068d4c06ccd5ce249035054310001c499264984d55ce9baa0011220021220012001232323232323333573466e1d4005200c200b23333573466e1d4009200a200d23333573466e1d400d200823300b375c6ae854014dd69aba135744a00a46666ae68cdc3a8022400c46601a6eb8d5d0a8039bae357426ae89401c8cccd5cd19b875005480108cc048c050d5d0a8049bae357426ae8940248cccd5cd19b875006480088c050c054d5d09aab9e500b23333573466e1d401d2000230133016357426aae7940308d407cd4c080cd5ce2481035054310002149926499264992649926135573aa00826aae79400c4d55cf280109aab9e500113754002424444444600e01044244444446600c012010424444444600a010244444440082444444400644244444446600401201044244444446600201201040024646464646666ae68cdc3a800a400446660106eb4d5d0a8021bad35742a0066eb4d5d09aba2500323333573466e1d400920002300a300b357426aae7940188d4040d4c044cd5ce2490350543100012499264984d55cea80189aba25001135573ca00226ea80048488c00800c888488ccc00401401000c80048c8c8cccd5cd19b875001480088c018dd71aba135573ca00646666ae68cdc3a80124000460106eb8d5d09aab9e500423500a35300b3357389201035054310000c499264984d55cea80089baa001212230020032122300100320011122232323333573466e1cd55cea80124000466aa016600c6ae854008c014d5d09aba25002235007353008335738921035054310000949926135573ca00226ea8004498480048004448848cc00400c008448004488800c488800848880048004488800c488800848880048004448c8c00400488cc00cc008008004c8c8cc88cc88c8ccc888c8c8c8c8c8ccc888ccc888ccc888c8cccc8888c8cc88c8cccc8888c8cc88c8cc88c8ccc888c8c8cc88c8c8cc88c8c8c8cccc8888c8c8c8c8c8cc88c8cc88cc88ccccccccccccc8888888888888c8c8c8c8c8cccccccc88888888cc88cc88cc88cc88c8ccccc88888c8cc88cc88cc88c8cc88cc88cc88c8cc88c8c8c8cccc8888cccc8888c8888d4d540400108888c8c8c94cd4c24004ccc0140280240205400454cd4c24004cd5ce249025331000910115001109101153353508101003215335309001333573466e1cccc109400cd4c07800488004c0580212002092010910115002153353090013357389201025332000910115002109101150011533535080013300533501b00833303e03f5001323355306012001235355096010012233550990100233553063120012353550990100122335509c0100233704900080080080099a809801180a003003909a9aa84a8080091911a9a80f00091299a984a0098050010a99a984a00999aa9837090009a835283491a9aa84d8080091199aa9838890009a836a83611a9aa84f0080091199ab9a3370e900000084e0084d808008008a8020a99a984a0099ab9c49102533300095011500410950113535501e00522253353097013333355027253335301400113374a90001bb14984cdd2a40046ec52613374a90021bb149800c008c8cd400541d141d4488cc008cd40ac01cccc124128018cd4078034c07c04400403c4264044cd5ce249025335000980113535501a0012225335309301333335502325301d00100300200100b109501133573892010253340009401133573892010253360008f0113530220052235302d002222222222253353508b013303000a00b2135303a0012235303e0012220021350a10135309d0133573892010253300009e01498cccd5403488d4d404c008894ccd4c02400c54ccd4c01400854ccd4c02400c541f04d41f4cd542400554034cd405801c004541f054ccd4c02400c4d41f4cd542400554034cd4058020004541f0541f0541f054ccd4c01400854ccd4c02400c541f04d41f4cd542400554034cd405801c004541f054ccd4c02400c4d41f4cd542400554034cd4058020004541f0541f0541f04d41f4cd542400554034cd4058019419894ccd4c008004421c04421c044220048882280541e0488800c488800848880048004488800c48880084888004800444ccd5401d416541654164494cd4d41b8004848cd4168cd5421404d4c03000888004cd4168cd54214040052002505b505b12505a235355081013530100012235301b00222222222225335350793301e00a00b213530280012235302c00122235303100322335308701002230930116253353508201004213355098010020011309301161308a01162200211222212333300100500400300211200120011122212333001004003002112001122123300100300212001221233001003002200111222225335307533355304f120013504b504a235300b002223301500200300415335307533355304f120013504b504a235300b002223530160022222222222353501500d22533530840133355305e120013505450562353025001223304b00200400c10860113357389201024c30000850100315335307533355304f120013504b504a235300b002223530160022222222222353501300d22533530840133355305e12001350545056235302700122253353507a00121533530890133305108501003006153353507b330623019007009213308501001002108a01108a011089015335350763301b00c00d2135302500122353029001222333553055120012235302e00222235303300822353035005225335309301333308401004003002001133506f0090081008506701113508c01353088013357389201024c6600089014984218044cd5ce2481024c3100085010021077150741507415074122123300100300212001122123300100300212001221233001003002200122533335300300121505f21505f21505f2133355304612001504a235300d001225335306f3303300200413506300315062003212222300400521222230030052122223002005212222300100520013200135506c22233333333333353019001235300500322222222225335307153353506333355304b12001504f253353072333573466e3c0300041d01cc4d41980045419400c841d041c841cc4cd5ce249024c340007222353006004222222222253353506453353506433355304c1200150502353550790012253353075333573466e3c00803c1dc1d84d41a400c541a000884d419cd4d541e40048800454194854cd4c1ccccd5cd19baf00100c0750741075150701506f235300500322222222225335307133355304b120013504150432333573466ebc0300041d01cccd54c108480048d4d541e00048800400841cc4cd5ce249024c320007222225335306a333573466e1cd4c0200188888888888ccc09801c0380300041b01ac41b04cd5ce2481024c390006b22235300700522222222225335307333355304d1200135043504523530160012225335350690012153353078333040074003010153353506a35301601422222222223305b01b0022153353079333573466e3c0040081ec1e84d4c07401488cccc1b0008004c1d005541b841e841e441e441e002441d44cd5ce249024c6200074225335306833303002f0013335530331200150175045353006004222222222233355303d120012235301600222235301b00322335307100225335307a333573466e3c0500041f01ec4cd415801401c401c801d413c02441a84cd5ce2481024c610006925335306733302f02e001353005003222222222233355304b12001501f235301400122200200910691335738921024c36000682533530673335530411200135037503923300500400100110691335738921024c640006825335306733302f02e001353005003222222222233355304b12001501f23530120012235301600122200200a106913357389201024c35000682353005003222222222253353506333355304b12001504f235301200122533530743303800200e1350680031506700a213530120012235301600122253353506900121507610791506f22353006004222222222253353506433355304c120015050235301300122533530753303900200f1350690031506800a2107513357389201024c380007323530050032222222222353503100b22353503500222353503500822353503900222533530793333333222222253335306d33350640070060031533530800100215335308001005133350610070010041081011333506100700100410810113335061007001004333333335064075225335307b333573466e1c0080041f41f041ac54cd4c1ecccd5cd19b8900200107d07c1069106a22333573466e200080041f41f010088ccd5cd19b8900200107c07d22333573466e200080041f01f4894cd4c1ecccd5cd19b8900200107d07c10011002225335307b333573466e240080041f41f04008400401801401c00800400c41ec4cd5ce249024c330007a222222222212333333333300100b00a009008007006005004003002200122123300100300220012221233300100400300220012212330010030022001212222222300700822122222223300600900821222222230050081222222200412222222003221222222233002009008221222222233001009008200113350325001502f13001002222335530241200123535505a00122335505d002335530271200123535505d001223355060002333535502500123300a4800000488cc02c0080048cc02800520000013301c00200122337000040024446464600200a640026aa0b64466a6a05e0029000111a9aa82e00111299a982c199ab9a3371e0040120b40b22600e0022600c006640026aa0b44466a6a05c0029000111a9aa82d80111299a982b999ab9a3371e00400e0b20b020022600c00642444444444444601801a4424444444444446601601c01a42444444444444601401a44442444444444444666601202001e01c01a444244444444444466601001e01c01a4424444444444446600e01c01a42444444444444600c01a42444444444444600a01a42444444444444600801a42444444444444600601a4424444444444446600401c01a42444444444444600201a400224424660020060042400224424660020060042400244a66a607c666ae68cdc79a9801801110011a98018009100102001f8999ab9a3370e6a6006004440026a60060024400208007e207e442466002006004400244666ae68cdc480100081e81e111199aa980a890009a808a80811a9aa82100091199aa980c090009a80a280991a9aa82280091199a9aa8068009198052400000244660160040024660140029000000998020010009119aa98050900091a9aa8200009119aa821801199a9aa804000919aa98070900091a9aa8220009119aa8238011aa80780080091199aaa80401c801000919aa98070900091a9aa8220009119aa8238011aa806800800999aaa80181a001000888911199aa980209000a80a99aa98050900091a9aa8200009119aa8218011aa805800999aa980209000911a9aa82080111299a981e999aa980b890009a806a80791a9aa82200091198050010028030801899a80c802001a80b00099aa98050900091a9aa820000911919aa8220019800802990009aa82291299a9a80c80089aa8058019109a9aa82300111299a982119806001004099aa80800380089803001801190009aa81f1108911299a9a80a800880111099802801199aa980389000802802000889091118018020891091119801002802089091118008020890008919a80891199a9a803001910010010009a9a80200091000990009aa81c110891299a9a8070008a80811099a808980200119aa980309000802000899a80111299a981800108190800817891091980080180109000899a80191299a9816801080088170168919a80591199a9a802001910010010009a9a8010009100089109198008018010900091299a9a80d999aa980189000a80391a9aa81800091299a9816199ab9a3375e00200a05c05a26a0400062a03e002426a03c6a6aa060002440042a038640026aa05e4422444a66a6a00c00226a6a01400644002442666a6a01800a440046008004666aa600e2400200a00800222440042442446600200800624002266a00444a66a6a02c004420062002a02a24424660020060042400224446a6a008004446a6a00c00644a666a6026666a01400e0080042a66a604c00620022050204e2050244246600200600424002244464646464a666a6a01000c42a666a6a01200c42a666a6a0140104260082c260062c2a666a6a01400e4260082c260062c202a20262a666a6a01200e4260082c260062c2a666a6a01200c4260082c260062c20282a666a6a01000a42024202620222a666a6a01000a42a666a6a01200e42600a2c260082c2a666a6a01200c42600a2c260082c202820242a666a6a01000c42600a2c260082c2a666a6a01000a42600a2c260082c20264a666a6a01000a42a666a6a01200e42a666a6a01400e42666a01e014004002260222c260222c260202c20262a666a6a01000c42a666a6a01200c42666a01c012004002260202c260202c2601e2c202420224a666a6a00e00842a666a6a01000c42a666a6a01200c42666a01c012004002260202c260202c2601e2c20242a666a6a00e00a42a666a6a01000a42666a01a0100040022601e2c2601e2c2601c2c202220204a666a6a00c00642a666a6a00e00a42a666a6a01000a42666a01a0100040022601e2c2601e2c2601c2c20222a666a6a00c00842a666a6a00e00842666a01800e0040022601c2c2601c2c2601a2c2020201e4a666a6a00a00442a666a6a00c00842a666a6a00e00842666a01800e0040022601c2c2601c2c2601a2c20202a666a6a00a00642a666a6a00c00642666a01600c0040022601a2c2601a2c260182c201e201c2424446006008224440042244400224002246a6a0040024444444400e244444444246666666600201201000e00c00a008006004240024c244400624440042444002400244446466a601800a466a601a0084a66a602c666ae68cdc780100080c00b8a801880b900b919a9806802100b9299a980b199ab9a3371e00400203002e2a006202e2a66a6a00a00642a66a6a00c0044266a6014004466a6016004466a601e004466a60200044660280040024034466a6020004403446602800400244403444466a601a0084034444a66a6036666ae68cdc380300180e80e0a99a980d999ab9a3370e00a00403a03826602e00800220382038202a2a66a6a00a0024202a202a2424460040062244002240024244600400644424466600200a00800640024244600400642446002006400244666ae68cdc780100080480411199ab9a3370e00400201000e266ae712401024c630000413357389201024c370000313357389201024c64000021220021220012001235006353002335738921024c6700003498480048004448848cc00400c008448004498448c8c00400488cc00cc0080080050482d87a80d87980f5f6"
         ]
-    , inputs =
+    , inputs = toCardanoUTxO testTxLayer mempty
         [ ( TxIn tid 0
           , TxOut
                 (Address $ unsafeFromHex

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2166,7 +2166,7 @@ components:
         next_epoch: *epochInfo
         node_era: *ApiEra
         network_info: *NetworkInfo
-        wallet_mode: 
+        wallet_mode:
           type: string
           enum:
             - light
@@ -4176,7 +4176,7 @@ x-errMalformedTxPayload: &errMalformedTxPayload
 
 x-errMempoolIsFull: &errMempoolIsFull
   <<: *responsesErr
-  title: mempool_is_full 
+  title: mempool_is_full
   properties:
     message:
       type: string
@@ -5034,7 +5034,8 @@ x-errUnresolvedInputs: &errUnresolvedInputs
     message:
       type: string
       description: |
-        The transaction contains foreign inputs which cannot be resolved.
+        There are inputs in the transaction for which the corresponding outputs
+        could not be found.
     code:
       type: string
       enum: ['unknown_inputs']
@@ -5074,6 +5075,20 @@ x-errExistingKeyWitnesses: &errExistingKeyWitnesses
     code:
       type: string
       enum: ['existing_key_witnesses']
+
+x-errInputResolutionConflicts: &errInputResolutionConflicts
+  <<: *responsesErr
+  title: input_resolution_conflicts
+  properties:
+    message:
+      type: string
+      description: |
+        At least one of the provided inputs has an
+        asset quantity or address that is different from that
+        recorded in the wallet's UTxO set.
+    code:
+      type: string
+      enum: ['input_resolution_conflicts']
 
 x-responsesErr400: &responsesErr400
   400:
@@ -5975,8 +5990,9 @@ x-responsesBalanceTransaction: &responsesBalanceTransaction
             - <<: *errRedeemerScriptFailure
             - <<: *errRedeemerTargetNotFound
             - <<: *errRedeemerInvalidData
-            - <<: *errUnresolvedInputs
             - <<: *errTranslationError
+            - <<: *errUnresolvedInputs
+            - <<: *errInputResolutionConflicts
   403:
     description: Forbidden
     content:


### PR DESCRIPTION
- [x] Ensure all of `balanceTx` sees a consistent `UTxO` set / input resolution.
    - [x] Let `assignScriptRedeemers` take `Ledger.UTxO era` easily converted from `Cardano.UTxO era`
    - [x] Create a `combinedUTxO :: Cardano.UTxO era` once in balanceTx as single source of truth for all input lookup
    - **New error**: `unresolved_inputs ` replacing undefined behaviour
    -  **New error**: `input_resolution_conflicts` replacing undefined behaviour

### Comments

- This PR is like #3255 but only with minimal changes to `assignScriptRedeemers` and no changes to `NetworkLayer`.
- Replacing `Cardano.UTxO` with `Ledger.UTxO` in the interface to `balanceTransaction` can be done later.

### Issue Number

ADP-1662
