### PR TITLE
Add function `applyNM` to `Control.Monad.Util`.

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -290,6 +290,7 @@ library
       Control.Concurrent.Concierge
       Control.Monad.Exception.Unchecked
       Control.Monad.Random.Extra
+      Control.Monad.Util
       Crypto.Hash.Utils
       Data.Aeson.Extra
       Data.Function.Utils
@@ -541,6 +542,7 @@ test-suite unit
       Cardano.WalletSpec
       Control.Concurrent.ConciergeSpec
       Control.Monad.Random.ExtraSpec
+      Control.Monad.UtilSpec
       Data.Function.UtilsSpec
       Data.QuantitySpec
       Data.Time.TextSpec

--- a/lib/core/src/Control/Monad/Util.hs
+++ b/lib/core/src/Control/Monad/Util.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Copyright: © 2022 IOHK
+-- License: Apache-2.0
+--
+-- Monadic utility functions.
+--
+module Control.Monad.Util
+    ( applyNM
+    ) where
+
+import Prelude
+
+-- | Applies a monadic function @n@ times to an initial value.
+--
+-- Returns the final result, equivalent to the nth element of the following
+-- sequence:
+--
+-- @
+-- [ pure a
+-- , f a
+-- , (f <=< f) a
+-- , (f <=< f <=< f) a
+-- , (f <=< f <=< f <=< f) a
+-- , ...
+-- ]
+-- @
+--
+applyNM :: forall m a. Monad m => Int -> (a -> m a) -> a -> m a
+applyNM n next = loop n
+  where
+    loop :: Int -> a -> m a
+    loop !i !a
+        | i <= 0 = pure a
+        | otherwise = loop (i - 1) =<< next a

--- a/lib/core/test/unit/Control/Monad/UtilSpec.hs
+++ b/lib/core/test/unit/Control/Monad/UtilSpec.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- |
+-- Copyright: © 2022 IOHK
+-- License: Apache-2.0
+--
+module Control.Monad.UtilSpec
+    ( spec
+    )
+    where
+
+import Prelude
+
+import Control.Monad
+    ( (<=<) )
+import Control.Monad.Identity
+    ( Identity (..) )
+import Control.Monad.Util
+    ( applyNM )
+import Data.Function
+    ( (&) )
+import Data.Function.Utils
+    ( applyN )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Fun (..), Property, applyFun, conjoin, property, (===) )
+
+spec :: Spec
+spec = describe "Control.Monad.UtilSpec" $ do
+
+    describe "applyNM" $ do
+        it "prop_applyNM_applyN @Int" $
+            prop_applyNM_applyN @Int
+                & property
+        it "prop_applyNM_unit @Identity @Int" $
+            prop_applyNM_unit @Identity @Int
+                & property
+        it "prop_applyNM_unit @Maybe @Int" $
+            prop_applyNM_unit @Maybe @Int
+                & property
+        it "prop_applyNM_unit @[] @Int" $
+            prop_applyNM_unit @[] @Int
+                & property
+
+--------------------------------------------------------------------------------
+-- applyNM
+--------------------------------------------------------------------------------
+
+prop_applyNM_applyN
+    :: (Eq a, Show a) => Int -> Fun a a -> a -> Property
+prop_applyNM_applyN n (applyFun -> f) a =
+    applyNM n (Identity <$> f) a === Identity (applyN n f a)
+
+prop_applyNM_unit
+    :: (Monad m, Eq (m a), Show (m a)) => Fun a (m a) -> a -> Property
+prop_applyNM_unit (applyFun -> f) a = conjoin
+    [ applyNM 0 f a === pure a
+    , applyNM 1 f a === f a
+    , applyNM 2 f a === (f <=< f) a
+    , applyNM 3 f a === (f <=< f <=< f) a
+    , applyNM 4 f a === (f <=< f <=< f <=< f) a
+    ]

--- a/lib/core/test/unit/Control/Monad/UtilSpec.hs
+++ b/lib/core/test/unit/Control/Monad/UtilSpec.hs
@@ -32,6 +32,7 @@ import Test.QuickCheck
     , applyFun
     , conjoin
     , property
+    , withMaxSuccess
     , (===)
     )
 
@@ -50,6 +51,7 @@ spec = describe "Control.Monad.UtilSpec" $ do
                 & property
         it "prop_applyNM_iterate @[] @Int" $
             prop_applyNM_iterate @[] @Int
+                & withMaxSuccess 10
                 & property
         it "prop_applyNM_unit @Identity @Int" $
             prop_applyNM_unit @Identity @Int
@@ -59,6 +61,7 @@ spec = describe "Control.Monad.UtilSpec" $ do
                 & property
         it "prop_applyNM_unit @[] @Int" $
             prop_applyNM_unit @[] @Int
+                & withMaxSuccess 10
                 & property
 
 --------------------------------------------------------------------------------

--- a/lib/core/test/unit/Control/Monad/UtilSpec.hs
+++ b/lib/core/test/unit/Control/Monad/UtilSpec.hs
@@ -26,7 +26,14 @@ import Data.Function.Utils
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
-    ( Fun (..), Property, applyFun, conjoin, property, (===) )
+    ( Fun (..)
+    , NonNegative (..)
+    , Property
+    , applyFun
+    , conjoin
+    , property
+    , (===)
+    )
 
 spec :: Spec
 spec = describe "Control.Monad.UtilSpec" $ do
@@ -34,6 +41,15 @@ spec = describe "Control.Monad.UtilSpec" $ do
     describe "applyNM" $ do
         it "prop_applyNM_applyN @Int" $
             prop_applyNM_applyN @Int
+                & property
+        it "prop_applyNM_iterate @Identity @Int" $
+            prop_applyNM_iterate @Identity @Int
+                & property
+        it "prop_applyNM_iterate @Maybe @Int" $
+            prop_applyNM_iterate @Maybe @Int
+                & property
+        it "prop_applyNM_iterate @[] @Int" $
+            prop_applyNM_iterate @[] @Int
                 & property
         it "prop_applyNM_unit @Identity @Int" $
             prop_applyNM_unit @Identity @Int
@@ -53,6 +69,17 @@ prop_applyNM_applyN
     :: (Eq a, Show a) => Int -> Fun a a -> a -> Property
 prop_applyNM_applyN n (applyFun -> f) a =
     applyNM n (Identity <$> f) a === Identity (applyN n f a)
+
+prop_applyNM_iterate
+    :: (Monad m, Eq (m a), Show (m a))
+    => NonNegative Int
+    -> Fun a (m a)
+    -> a
+    -> Property
+prop_applyNM_iterate (getNonNegative -> n) (applyFun -> f) a =
+    applyNM n f a === applyNM_iterate n f a
+  where
+    applyNM_iterate n' f' = (!! n') . iterate (f' =<<) . pure
 
 prop_applyNM_unit
     :: (Monad m, Eq (m a), Show (m a)) => Fun a (m a) -> a -> Property


### PR DESCRIPTION
## Issue Number

ADP-1783

## Summary

This PR adds the `applyNM` function and property tests.

The `applyNM` function applies a monadic function **_n_** times to an initial value, returning the final result.

Its behaviour is similar to `applyN`, but applies a monadic function instead of a pure function, hence the addition of the `M` suffix:

```hs
applyN  :: forall   a.            Int -> (a ->   a) -> a ->   a
applyNM :: forall m a. Monad m => Int -> (a -> m a) -> a -> m a
```