### PR TITLE
updated blockfrost dependencies to 0.6 (Vasil HF Version)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -58,6 +58,19 @@ packages:
 package cryptonite
   flags: -support_rdrand
 
+-- TODO : This is patch to work with the new version of blockfrost (0.6.0.0)
+-- Removing this dependency require an upgrade of Haskell.nix and all the 
+-- consequent update modification to be done.
+source-repository-package
+  type: git
+  location: https://github.com/blockfrost/blockfrost-haskell
+  tag: 5ced57686d95e7b14569e96f4244b701f1e321e4
+  --sha256: sha256-jGTq+S7byvo/4eQFFzw71I65EefiFlkOcDYiMnuPtok=
+  subdir:
+    blockfrost-api
+    blockfrost-client
+    blockfrost-client-core
+
 -- TODO This was patched to work with aeson 1 & 2 with the help of hw-aeson.
 -- Once downstream projects are all upgraded to work with aeson-2, they can
 -- be changed to work strictly with aeson 2 only.
@@ -319,6 +332,8 @@ source-repository-package
   location: https://github.com/input-output-hk/hedgehog-extras
   tag: 714ee03a5a786a05fc57ac5d2f1c2edce4660d85
   --sha256: 1qa4mm36xynaf17990ijmzww0ij8hjrc0vw5nas6d0zx6q9hb978
+
+
 
 -- -------------------------------------------------------------------------
 -- Constraints tweaking

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -37,9 +37,9 @@ library
     , bech32
     , bech32-th
     , binary
-    , blockfrost-api >= 0.4 && < 0.5
-    , blockfrost-client >= 0.4 && < 0.5
-    , blockfrost-client-core >= 0.4 && < 0.5
+    , blockfrost-api >= 0.6 && < 0.7
+    , blockfrost-client >= 0.6 && < 0.7
+    , blockfrost-client-core >= 0.6 && < 0.7
     , bytestring
     , cardano-addresses
     , cardano-api

--- a/nix/materialized/stack-nix/default.nix
+++ b/nix/materialized/stack-nix/default.nix
@@ -7,9 +7,9 @@
         "hspec" = (((hackage.hspec)."2.8.2").revisions).default;
         "hspec-core" = (((hackage.hspec-core)."2.8.2").revisions).default;
         "hspec-discover" = (((hackage.hspec-discover)."2.8.2").revisions).default;
-        "blockfrost-api" = (((hackage.blockfrost-api)."0.4.0.0").revisions).default;
-        "blockfrost-client" = (((hackage.blockfrost-client)."0.4.0.0").revisions).default;
-        "blockfrost-client-core" = (((hackage.blockfrost-client-core)."0.4.0.0").revisions).default;
+        "blockfrost-api" = (((hackage.blockfrost-api)."0.6.0.0").revisions).default;
+        "blockfrost-client" = (((hackage.blockfrost-client)."0.6.0.0").revisions).default;
+        "blockfrost-client-core" = (((hackage.blockfrost-client-core)."0.6.0.0").revisions).default;
         "quickcheck-quid" = (((hackage.quickcheck-quid)."0.0.1").revisions).default;
         "servant-multipart-client" = (((hackage.servant-multipart-client)."0.12.1").revisions).default;
         "cryptonite" = (((hackage.cryptonite)."0.27").revisions).default;


### PR DESCRIPTION
**Intent** : This is a dependency update with the new blockfrost version supporting Vasil HF  and the new Preview and Preprod Networks (v0.6.0.0) : https://github.com/blockfrost/blockfrost-haskell/releases/tag/v0.6.0.0

**N.B** : I didn't update the Haskell.nix... I've tried but I don't have enough knowledge in this project to do the necessary modifications... Therefore, I've added a dependency in the cabal.project directly...


