### PR TITLE
Rework the "Local Tx Submission" node client.

### DIFF
--- a/lib/core/src/Ouroboros/Network/Client/Wallet.hs
+++ b/lib/core/src/Ouroboros/Network/Client/Wallet.hs
@@ -690,11 +690,10 @@ localTxSubmission
         -- outside of the network client to the client itself.
         -- Requests are pushed to the queue which are then transformed into
         -- messages to keep the state-machine moving.
-    -> LocalTxSubmissionClient tx err m ()
+    -> LocalTxSubmissionClient tx err m Void
 localTxSubmission queue = LocalTxSubmissionClient clientStIdle
   where
-    clientStIdle
-        :: m (LocalTxClientStIdle tx err m ())
+    clientStIdle :: m (LocalTxClientStIdle tx err m Void)
     clientStIdle = atomically (peekTQueue queue) <&> \case
         CmdSubmitTx tx respond ->
             SendMsgSubmitTx tx $ \res -> do
@@ -717,11 +716,7 @@ localTxSubmission queue = LocalTxSubmissionClient clientStIdle
 -- the type @a@, so that the 'TQueue' has elements with a monomorphic type.
 -- However, the type signature of `send` allows us to retrieve this particular
 -- type @a@ for later use again.
-send
-    :: MonadSTM m
-    => TQueue m (cmd m)
-    -> ((a -> m ()) -> cmd m)
-    -> m a
+send :: MonadSTM m => TQueue m (cmd m) -> ((a -> m ()) -> cmd m) -> m a
 send queue cmd = do
     tvar <- newEmptyTMVarIO
     atomically $ writeTQueue queue (cmd (atomically . putTMVar tvar))

--- a/lib/shelley/bench/restore-bench.hs
+++ b/lib/shelley/bench/restore-bench.hs
@@ -694,10 +694,8 @@ bench_baseline_restoration
     withRestoreEnvironment action =
         withWalletLayerTracer benchName pipeliningStrat traceToDisk $
             \progressTrace -> withNetworkLayer
-                networkTrace
-                pipeliningStrat
-                networkId np socket vData sTol $
-                    \nw -> action progressTrace nw
+                networkTrace pipeliningStrat np socket vData sTol $ \nw ->
+                    action progressTrace nw
       where
         networkId = networkIdVal proxy
         networkTrace = trMessageText wlTr
@@ -783,7 +781,7 @@ bench_restoration
     let tl = newTransactionLayer @k networkId
     let gp = genesisParameters np
     withNetworkLayer (trMessageText wlTr) pipeliningStrat
-        networkId np socket vData sTol $ \nw' -> do
+        np socket vData sTol $ \nw' -> do
             let convert = fromCardanoBlock gp
             let nw = convert <$> nw'
             let ti = neverFails "bench db shouldn't forecast into future"
@@ -933,7 +931,7 @@ prepareNode tr proxy socketPath np vData = do
     let networkId = networkIdVal proxy
     sl <- withNetworkLayer nullTracer
             tunedForMainnetPipeliningStrategy
-            networkId np socketPath vData sTol $ \nw' -> do
+            np socketPath vData sTol $ \nw' -> do
         let gp = genesisParameters np
         let convert = fromCardanoBlock gp
         let nw = convert <$> nw'

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -28,7 +28,7 @@ import Cardano.Wallet.Shelley.BlockchainSource
 import Cardano.Wallet.Shelley.Compatibility
     ( CardanoBlock, StandardCrypto )
 import Cardano.Wallet.Shelley.Network.Discriminant
-    ( SomeNetworkDiscriminant, networkDiscriminantToId )
+    ( SomeNetworkDiscriminant )
 import Control.Monad.Trans.Cont
     ( ContT (ContT) )
 import Data.Functor.Contravariant
@@ -68,9 +68,8 @@ withNetworkLayer tr pipeliningStrategy blockchainSrc net netParams =
     ContT $ case blockchainSrc of
         NodeSource nodeConn ver tol ->
             let tr' = NodeNetworkLog >$< tr
-                netId = networkDiscriminantToId net
             in Node.withNetworkLayer
-                tr' pipeliningStrategy netId netParams nodeConn ver tol
+                tr' pipeliningStrategy netParams nodeConn ver tol
         BlockfrostSource project ->
             let tr' = BlockfrostNetworkLog >$< tr
             in Blockfrost.withNetworkLayer tr' net netParams project

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Tracers.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Tracers.hs
@@ -45,13 +45,14 @@ import Control.Applicative
     ( Const (..) )
 import Data.Text
     ( Text )
-import qualified Data.Text as T
 import Data.Text.Class
     ( ToText )
 import Network.NTP.Client
     ( NtpTrace )
 import Network.Wai.Middleware.Logging
     ( ApiLog )
+
+import qualified Data.Text as T
 
 -- | The types of trace events produced by the Shelley API server.
 data Tracers' f = Tracers

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -18,8 +18,6 @@ import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
     ( NetworkParameters (..) )
-import Cardano.Wallet.Shelley.Compatibility
-    ( NetworkId (..) )
 import Cardano.Wallet.Shelley.Launch
     ( CardanoNodeConn, withSystemTempDir )
 import Cardano.Wallet.Shelley.Launch.Cluster
@@ -82,7 +80,7 @@ concurrentConnectionSpec = describe "NetworkLayer regression test #1708" $ do
             tasks <- replicateM 10 $ async $
                 withNetworkLayer tr
                     tunedForMainnetPipeliningStrategy
-                    Mainnet np sock vData sTol $ \nl -> do
+                    np sock vData sTol $ \nl -> do
                         -- Wait for the first tip result from the node
                         waiter <- newEmptyMVar
                         race_


### PR DESCRIPTION
After adding more details to the connectivity logging it became visible that error messages like:

```
[cardano-wallet.network:Warning:16] [2022-08-18 12:06:28.77 UTC] Couldn't connect to node (x5). Retrying in a bit...
[cardano-wallet.network:Warning:16] [2022-08-18 12:06:31.77 UTC] Connection lost with the node.
```
are coming from the Local Tx Submission Client.

Further investigation has revealed that "Local Tx Submission"  mini-protocol isn't running inside a multiplexed connection alongside with the "Chain Sync" and the "Local State Query" protocols.  Instead, "Local Tx Submission Client" had its own dedicated connection. Its not clear why [such a change](https://github.com/input-output-hk/cardano-wallet/pull/2896/commits/42df3813e731998e14bd5a2e0447c2a39948c987#diff-e75eb5ae7960b67604a2c1efe943a35f97c1a6ebf28c9d2a06f4d53bf27ca331) was introduced long time ago, as it isn't explained in the corresponding PR. I suspect that such standalone "Local Tx Submission" node client gets disconnected by node as there is no traffic most of the time (The actual error was "Node connection lost because of the mux error (MuxBearerClosed): <socket: 14> closed when reading data, waiting on next header True"). Its peculiar that Ogmios doesn't split the "Local Tx Submission" protocol but [muxes it with other protocols](https://github.com/CardanoSolutions/ogmios/blob/master/server/modules/cardano-client/src/Cardano/Network/Protocol/NodeToClient.hs#L243-L267).

On top of that, wallet's code uses two different ways to connect to protocol clients to the node:
1. using the "low level" node interface. (for all mini-protocols except the "Local Tx Submission" one)
1. using the "higher level" `Cardano.Api` interface.  (for the "Local Tx Submission" mini-protocol only)

This PR:
- [x] Replaces the `Cardano.Api`-based "Local Tx Submission" client with the Node-based API.
- [x] Removes the dedicated "Local Tx Submission" mini-protocol connection, moving it to the same connection that LSQ, CS protocols already use.

This also fixes the problem with periodical disconnects and re-connections. I've tested local tx submission and it works just fine.

### Issue Number

ADP-2150

Closes #3376 