### PR TITLE
[ADP-1963] Break up API types into submodules

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -178,8 +178,8 @@ library
       Cardano.Ledger.Credential.Safe
       Cardano.Pool.DB
       Cardano.Pool.DB.Log
-      Cardano.Pool.DB.MVar
       Cardano.Pool.DB.Model
+      Cardano.Pool.DB.MVar
       Cardano.Pool.DB.Sqlite
       Cardano.Pool.DB.Sqlite.TH
       Cardano.Pool.Metadata
@@ -189,18 +189,27 @@ library
       Cardano.Wallet.Address.Book
       Cardano.Wallet.Address.Pool
       Cardano.Wallet.Api
+      Cardano.Wallet.Api.Aeson
       Cardano.Wallet.Api.Aeson.Variant
       Cardano.Wallet.Api.Client
-      Cardano.Wallet.Api.Aeson
       Cardano.Wallet.Api.Hex
+      Cardano.Wallet.Api.Lib.ApiAsArray
+      Cardano.Wallet.Api.Lib.ApiT
+      Cardano.Wallet.Api.Lib.ExtendedObject
+      Cardano.Wallet.Api.Lib.Options
       Cardano.Wallet.Api.Link
       Cardano.Wallet.Api.Server
       Cardano.Wallet.Api.Server.Tls
       Cardano.Wallet.Api.Types
+      Cardano.Wallet.Api.Types.Address
       Cardano.Wallet.Api.Types.BlockHeader
+      Cardano.Wallet.Api.Types.Certificate
+      Cardano.Wallet.Api.Types.Key
+      Cardano.Wallet.Api.Types.Primitive
       Cardano.Wallet.Api.Types.SchemaMetadata
-      Cardano.Wallet.Checkpoints.Policy
+      Cardano.Wallet.Api.Types.Transaction
       Cardano.Wallet.Checkpoints
+      Cardano.Wallet.Checkpoints.Policy
       Cardano.Wallet.CoinSelection
       Cardano.Wallet.CoinSelection.Internal
       Cardano.Wallet.CoinSelection.Internal.Balance
@@ -208,9 +217,9 @@ library
       Cardano.Wallet.CoinSelection.Internal.Context
       Cardano.Wallet.Compat
       Cardano.Wallet.DB
+      Cardano.Wallet.DB.Layer
       Cardano.Wallet.DB.Pure.Implementation
       Cardano.Wallet.DB.Pure.Layer
-      Cardano.Wallet.DB.Layer
       Cardano.Wallet.DB.Sqlite.Migration
       Cardano.Wallet.DB.Sqlite.Schema
       Cardano.Wallet.DB.Sqlite.Stores
@@ -230,7 +239,6 @@ library
       Cardano.Wallet.Network.Light
       Cardano.Wallet.Network.Ports
       Cardano.Wallet.Orphans
-      Cardano.Wallet.TokenMetadata
       Cardano.Wallet.Primitive.AddressDerivation
       Cardano.Wallet.Primitive.AddressDerivation.Byron
       Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -250,13 +258,13 @@ library
       Cardano.Wallet.Primitive.Migration.Planning
       Cardano.Wallet.Primitive.Migration.Selection
       Cardano.Wallet.Primitive.Model
-      Cardano.Wallet.Primitive.Slotting
-      Cardano.Wallet.Primitive.SyncProgress
       Cardano.Wallet.Primitive.Passphrase
       Cardano.Wallet.Primitive.Passphrase.Current
       Cardano.Wallet.Primitive.Passphrase.Gen
       Cardano.Wallet.Primitive.Passphrase.Legacy
       Cardano.Wallet.Primitive.Passphrase.Types
+      Cardano.Wallet.Primitive.Slotting
+      Cardano.Wallet.Primitive.SyncProgress
       Cardano.Wallet.Primitive.Types
       Cardano.Wallet.Primitive.Types.Address
       Cardano.Wallet.Primitive.Types.Address.Constants
@@ -282,6 +290,7 @@ library
       Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
       Cardano.Wallet.Primitive.Types.UTxOSelection
       Cardano.Wallet.Registry
+      Cardano.Wallet.TokenMetadata
       Cardano.Wallet.TokenMetadata.MockServer
       Cardano.Wallet.Transaction
       Cardano.Wallet.Types.Read
@@ -299,13 +308,13 @@ library
       Crypto.Hash.Utils
       Data.Aeson.Extra
       Data.Function.Utils
+      Data.Quantity
       Data.Time.Text
       Data.Time.Utils
-      Data.Quantity
       Data.Vector.Shuffle
       Network.Ntp
-      Network.Wai.Middleware.ServerError
       Network.Wai.Middleware.Logging
+      Network.Wai.Middleware.ServerError
       Ouroboros.Network.Client.Wallet
       UnliftIO.Compat
         -- TODO:

--- a/lib/core/src/Cardano/Wallet/Api/Lib/ApiAsArray.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Lib/ApiAsArray.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK
+-- License: Apache-2.0
+
+module Cardano.Wallet.Api.Lib.ApiAsArray (ApiAsArray (..)) where
+
+import Prelude
+
+import Control.DeepSeq
+    ( NFData )
+import Data.Aeson
+    ( FromJSON (..), ToJSON (..) )
+import Data.Maybe
+    ( maybeToList )
+import Data.Typeable
+    ( Proxy (..), Typeable )
+import GHC.Base
+    ( Symbol )
+import GHC.Generics
+    ( Generic )
+import GHC.TypeLits
+    ( KnownSymbol, symbolVal )
+
+-- | A wrapper that allows any type to be serialized as a JSON array.
+--
+-- The number of items permitted in the array is dependent on the wrapped type.
+--
+newtype ApiAsArray (s :: Symbol) a = ApiAsArray a
+    deriving (Eq, Generic, Show, Typeable)
+    deriving newtype (Monoid, Semigroup)
+    deriving anyclass NFData
+
+instance (KnownSymbol s, FromJSON a) => FromJSON (ApiAsArray s (Maybe a)) where
+    parseJSON json = parseJSON @[a] json >>= \case
+        [a] ->
+            pure $ ApiAsArray $ Just a
+        [] ->
+            pure $ ApiAsArray Nothing
+        _  ->
+            fail $ mconcat
+                [ "Expected at most one item for "
+                , show $ symbolVal $ Proxy @s
+                , "."
+                ]
+
+instance ToJSON a => ToJSON (ApiAsArray s (Maybe a)) where
+    toJSON (ApiAsArray m) = toJSON (maybeToList m)

--- a/lib/core/src/Cardano/Wallet/Api/Lib/ApiT.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Lib/ApiT.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK
+-- License: Apache-2.0
+
+module Cardano.Wallet.Api.Lib.ApiT
+    ( ApiT (..)
+    , fromTextApiT
+    , toTextApiT
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Api.Aeson
+    ( fromTextJSON, toTextJSON )
+import Control.DeepSeq
+    ( NFData )
+import Data.Aeson
+    ( Value )
+import Data.Aeson.Types
+    ( Parser )
+import Data.Hashable
+    ( Hashable )
+import Data.Text.Class
+    ( FromText, ToText )
+import GHC.Generics
+    ( Generic )
+import Quiet
+    ( Quiet (Quiet) )
+
+-- | Polymorphic wrapper type to put around primitive types and, 3rd party lib
+-- types to avoid defining orphan instances and/or, undesirable instances on
+-- primitive types. It helps to keep a nice separation of concerns between the
+-- API layer and other modules.
+newtype ApiT a =
+    ApiT { getApiT :: a }
+    deriving (Generic, Eq, Functor)
+    deriving newtype (Semigroup, Monoid, Hashable)
+    deriving anyclass NFData
+    deriving Show via (Quiet (ApiT a))
+deriving instance Ord a => Ord (ApiT a)
+
+fromTextApiT :: FromText a => String -> Value -> Parser (ApiT a)
+fromTextApiT t = fmap ApiT . fromTextJSON t
+
+toTextApiT :: ToText a => ApiT a -> Value
+toTextApiT = toTextJSON . getApiT

--- a/lib/core/src/Cardano/Wallet/Api/Lib/ExtendedObject.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Lib/ExtendedObject.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK
+-- License: Apache-2.0
+
+module Cardano.Wallet.Api.Lib.ExtendedObject
+    ( parseExtendedAesonObject
+    , extendAesonObject
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Api.Lib.Options
+    ( defaultRecordTypeOptions )
+import Data.Aeson.Types
+    ( Parser, Value (..), genericParseJSON, genericToJSON, object, withObject )
+import Data.Text
+    ( Text )
+import GHC.Generics
+    ( Generic (..) )
+
+import qualified Data.Aeson.Key as Aeson
+import qualified Data.Aeson.KeyMap as Aeson
+import qualified Data.Aeson.Types as Aeson
+
+parseExtendedAesonObject
+    :: ( Generic a
+       , Aeson.GFromJSON Aeson.Zero (Rep a) )
+    => String
+    -> Text
+    -> Value
+    -> Parser a
+parseExtendedAesonObject txt fieldtoremove = withObject txt $ \o -> do
+    let removeCertType numKey _ = Aeson.toText numKey /= fieldtoremove
+    let o' = Aeson.filterWithKey removeCertType o
+    genericParseJSON defaultRecordTypeOptions (Object o')
+
+extendAesonObject
+    :: ( Generic a
+       , Aeson.GToJSON' Value Aeson.Zero (Rep a))
+    => [Aeson.Pair]
+    -> a
+    -> Value
+extendAesonObject tobeadded apipool =
+    let Object obj = genericToJSON defaultRecordTypeOptions apipool
+        Object obj' = object tobeadded
+    in Object $ obj <> obj'

--- a/lib/core/src/Cardano/Wallet/Api/Lib/Options.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Lib/Options.hs
@@ -1,0 +1,52 @@
+-- |
+-- Copyright: © 2018-2022 IOHK
+-- License: Apache-2.0
+
+module Cardano.Wallet.Api.Lib.Options
+    ( TaggedObjectOptions (..)
+    , defaultRecordTypeOptions
+    , defaultSumTypeOptions
+    , explicitNothingRecordTypeOptions
+    , strictRecordTypeOptions
+    , taggedSumTypeOptions
+    )
+    where
+
+import Prelude
+
+import Data.Aeson
+    ( Options (..), SumEncoding (..), camelTo2 )
+
+import qualified Data.Aeson as Aeson
+
+data TaggedObjectOptions = TaggedObjectOptions
+    { _tagFieldName :: String
+    , _contentsFieldName :: String
+    }
+
+defaultSumTypeOptions :: Aeson.Options
+defaultSumTypeOptions = Aeson.defaultOptions
+    { constructorTagModifier = camelTo2 '_'
+    , tagSingleConstructors = True
+    }
+
+defaultRecordTypeOptions :: Aeson.Options
+defaultRecordTypeOptions = Aeson.defaultOptions
+    { fieldLabelModifier = camelTo2 '_' . dropWhile (== '_')
+    , omitNothingFields = True
+    }
+
+strictRecordTypeOptions :: Aeson.Options
+strictRecordTypeOptions = defaultRecordTypeOptions
+    { rejectUnknownFields = True
+    }
+
+taggedSumTypeOptions :: Aeson.Options -> TaggedObjectOptions -> Aeson.Options
+taggedSumTypeOptions base opts = base
+    { sumEncoding = TaggedObject (_tagFieldName opts) (_contentsFieldName opts)
+    }
+
+explicitNothingRecordTypeOptions :: Aeson.Options
+explicitNothingRecordTypeOptions = defaultRecordTypeOptions
+    { omitNothingFields = False
+    }

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2358,7 +2358,6 @@ constructTransaction ctx genChange knownPools getPoolStatus (ApiT wid) body = do
         $ liftHandler
         $ throwE ErrConstructTxValidityIntervalNotWithinScriptTimelock
 
-
     -- FIXME [ADP-1489] mkRewardAccountBuilder does itself read
     -- @currentNodeEra@ which is not guaranteed with the era read here. This
     -- could cause problems under exceptional circumstances.

--- a/lib/core/src/Cardano/Wallet/Api/Types/Address.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types/Address.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK
+-- License: Apache-2.0
+
+module Cardano.Wallet.Api.Types.Address
+    ( DecodeAddress (..)
+    , DecodeStakeAddress (..)
+    , EncodeAddress (..)
+    , EncodeStakeAddress (..)
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( NetworkDiscriminant (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+import Data.Text
+    ( Text )
+import Data.Text.Class
+    ( TextDecodingError (..) )
+
+import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
+
+-- | An abstract class to allow encoding of addresses depending on the target
+-- backend used.
+class EncodeAddress (n :: NetworkDiscriminant) where
+    encodeAddress :: Address -> Text
+
+instance EncodeAddress 'Mainnet => EncodeAddress ('Staging pm) where
+    encodeAddress = encodeAddress @'Mainnet
+
+-- | An abstract class to allow decoding of addresses depending on the target
+-- backend used.
+class DecodeAddress (n :: NetworkDiscriminant) where
+    decodeAddress :: Text -> Either TextDecodingError Address
+
+instance DecodeAddress 'Mainnet => DecodeAddress ('Staging pm) where
+    decodeAddress = decodeAddress @'Mainnet
+
+class EncodeStakeAddress (n :: NetworkDiscriminant) where
+    encodeStakeAddress :: W.RewardAccount -> Text
+
+instance EncodeStakeAddress 'Mainnet => EncodeStakeAddress ('Staging pm) where
+    encodeStakeAddress = encodeStakeAddress @'Mainnet
+
+class DecodeStakeAddress (n :: NetworkDiscriminant) where
+    decodeStakeAddress :: Text -> Either TextDecodingError W.RewardAccount
+
+instance DecodeStakeAddress 'Mainnet => DecodeStakeAddress ('Staging pm) where
+    decodeStakeAddress = decodeStakeAddress @'Mainnet

--- a/lib/core/src/Cardano/Wallet/Api/Types/BlockHeader.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types/BlockHeader.hs
@@ -3,6 +3,10 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE RecordWildCards #-}
 
+-- |
+-- Copyright: © 2018-2022 IOHK
+-- License: Apache-2.0
+
 module Cardano.Wallet.Api.Types.BlockHeader
     ( ApiBlockHeader (..)
     , mkApiBlockHeader

--- a/lib/core/src/Cardano/Wallet/Api/Types/Certificate.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types/Certificate.hs
@@ -1,0 +1,178 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK
+-- License: Apache-2.0
+
+module Cardano.Wallet.Api.Types.Certificate
+    ( ApiAnyCertificate (..)
+    , ApiCertificate (..)
+    , ApiDeregisterPool (..)
+    , ApiExternalCertificate (..)
+    , ApiRegisterPool (..)
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Api.Lib.ApiT
+    ( ApiT )
+import Cardano.Wallet.Api.Lib.ExtendedObject
+    ( extendAesonObject, parseExtendedAesonObject )
+import Cardano.Wallet.Api.Types.Address
+    ( DecodeStakeAddress, EncodeStakeAddress )
+import Cardano.Wallet.Api.Types.Primitive
+    ()
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( DerivationIndex (..), NetworkDiscriminant )
+import Cardano.Wallet.Primitive.Types
+    ( NonWalletCertificate, PoolId (..) )
+import Control.DeepSeq
+    ( NFData )
+import Data.Aeson.Types
+    ( FromJSON (parseJSON)
+    , KeyValue ((.=))
+    , Options (..)
+    , SumEncoding (TaggedObject, contentsFieldName, tagFieldName)
+    , ToJSON (toJSON)
+    , Value (Object, String)
+    , camelTo2
+    , defaultOptions
+    , genericParseJSON
+    , genericToJSON
+    , withObject
+    , (.:)
+    )
+import Data.List.NonEmpty
+    ( NonEmpty )
+import Data.Quantity
+    ( Percentage, Quantity (..) )
+import Data.Typeable
+    ( Proxy )
+import GHC.Generics
+    ( Generic )
+import Numeric.Natural
+    ( Natural )
+
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
+import qualified Data.Aeson.Types as Aeson
+
+data ApiExternalCertificate (n :: NetworkDiscriminant)
+    = RegisterRewardAccountExternal
+        { rewardAccount :: (ApiT W.RewardAccount, Proxy n)
+        }
+    | JoinPoolExternal
+        { rewardAccount :: (ApiT W.RewardAccount, Proxy n)
+        , pool :: ApiT PoolId
+        }
+    | QuitPoolExternal
+        { rewardAccount :: (ApiT W.RewardAccount, Proxy n)
+        }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
+instance DecodeStakeAddress n => FromJSON (ApiExternalCertificate n) where
+    parseJSON = genericParseJSON apiCertificateOptions
+instance EncodeStakeAddress n => ToJSON (ApiExternalCertificate n) where
+    toJSON = genericToJSON apiCertificateOptions
+
+data ApiRegisterPool = ApiRegisterPool
+    { poolId :: ApiT PoolId
+    , poolOwners :: [ApiT W.PoolOwner]
+    , poolMargin :: Quantity "percent" Percentage
+    , poolCost :: Quantity "lovelace" Natural
+    , poolPledge :: Quantity "lovelace" Natural
+    , poolMetadata :: Maybe (ApiT W.StakePoolMetadataUrl, ApiT W.StakePoolMetadataHash)
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
+
+data ApiDeregisterPool = ApiDeregisterPool
+    { poolId :: ApiT PoolId
+    , retirementEpoch :: ApiT W.EpochNo
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
+
+data ApiCertificate
+    = RegisterRewardAccount
+        { rewardAccountPath :: NonEmpty (ApiT DerivationIndex)
+        }
+    | JoinPool
+        { rewardAccountPath :: NonEmpty (ApiT DerivationIndex)
+        , pool :: ApiT PoolId
+        }
+    | QuitPool
+        { rewardAccountPath :: NonEmpty (ApiT DerivationIndex)
+        }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
+
+data ApiAnyCertificate n =
+      WalletDelegationCertificate ApiCertificate
+    | DelegationCertificate (ApiExternalCertificate n)
+    | StakePoolRegister ApiRegisterPool
+    | StakePoolDeregister ApiDeregisterPool
+    | OtherCertificate (ApiT NonWalletCertificate)
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
+
+instance FromJSON ApiRegisterPool where
+    parseJSON = parseExtendedAesonObject "ApiRegisterPool" "certificate_type"
+instance ToJSON ApiRegisterPool where
+    toJSON = extendAesonObject ["certificate_type" .= String "register_pool"]
+
+instance FromJSON ApiDeregisterPool where
+    parseJSON = parseExtendedAesonObject "ApiDeregisterPool" "certificate_type"
+instance ToJSON ApiDeregisterPool where
+    toJSON = extendAesonObject ["certificate_type" .= String "deregister_pool"]
+
+instance DecodeStakeAddress n => FromJSON (ApiAnyCertificate n) where
+    parseJSON = withObject "ApiAnyCertificate" $ \o -> do
+        (certType :: String) <- o .: "certificate_type"
+        case certType of
+            "register_pool" -> StakePoolRegister <$> parseJSON (Object o)
+            "deregister_pool" -> StakePoolDeregister <$> parseJSON (Object o)
+            "join_pool" -> WalletDelegationCertificate <$> parseJSON (Object o)
+            "quit_pool" -> WalletDelegationCertificate <$> parseJSON (Object o)
+            "register_reward_account" -> WalletDelegationCertificate <$> parseJSON (Object o)
+            "join_pool_external" -> DelegationCertificate <$> parseJSON (Object o)
+            "quit_pool_external" -> DelegationCertificate <$> parseJSON (Object o)
+            "register_reward_account_external" -> DelegationCertificate <$> parseJSON (Object o)
+            "mir" -> OtherCertificate <$> parseJSON (Object o)
+            "genesis" -> OtherCertificate <$> parseJSON (Object o)
+            _ -> fail $ "unknown certificate_type: " <> show certType
+
+instance EncodeStakeAddress n => ToJSON (ApiAnyCertificate n) where
+    toJSON (WalletDelegationCertificate cert) = toJSON cert
+    toJSON (DelegationCertificate cert) = toJSON cert
+    toJSON (StakePoolRegister reg) = toJSON reg
+    toJSON (StakePoolDeregister dereg) = toJSON dereg
+    toJSON (OtherCertificate cert) = toJSON cert
+
+apiCertificateOptions :: Aeson.Options
+apiCertificateOptions = defaultOptions
+      { constructorTagModifier = camelTo2 '_'
+      , tagSingleConstructors = True
+      , fieldLabelModifier = camelTo2 '_' . dropWhile (== '_')
+      , omitNothingFields = True
+      , sumEncoding = TaggedObject
+          {
+            tagFieldName = "certificate_type"
+          , contentsFieldName = "details" -- this isn't actually used
+          }
+      }
+
+instance FromJSON ApiCertificate where
+    parseJSON = genericParseJSON apiCertificateOptions
+
+instance ToJSON ApiCertificate where
+    toJSON = genericToJSON apiCertificateOptions

--- a/lib/core/src/Cardano/Wallet/Api/Types/Key.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types/Key.hs
@@ -1,0 +1,333 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StrictData #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK
+-- License: Apache-2.0
+
+module Cardano.Wallet.Api.Types.Key
+    ( ApiAccountKey (..)
+    , ApiAccountKeyShared (..)
+    , ApiPolicyKey (..)
+    , ApiVerificationKeyShared (..)
+    , ApiVerificationKeyShelley (..)
+    , KeyFormat (..)
+    , VerificationKeyHashing (..)
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Depth (..), DerivationType (..), Index (..), Role (..) )
+import Cardano.Wallet.Primitive.AddressDerivation.SharedKey
+    ( purposeCIP1854 )
+import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
+    ( purposeCIP1852 )
+import Codec.Binary.Bech32
+    ( dataPartFromBytes, dataPartToBytes )
+import Codec.Binary.Bech32.TH
+    ( humanReadablePart )
+import Control.DeepSeq
+    ( NFData )
+import Data.Aeson.Types
+    ( FromJSON (..), ToJSON (..) )
+import Data.ByteString
+    ( ByteString )
+import Data.String
+    ( IsString )
+import Data.Text
+    ( Text )
+import Data.Text.Class
+    ( FromText (..), TextDecodingError (TextDecodingError), ToText (..) )
+import GHC.Generics
+    ( Generic )
+import Servant.API
+    ( ToHttpApiData )
+import Web.Internal.HttpApiData
+    ( ToHttpApiData (..) )
+
+import qualified Codec.Binary.Bech32 as Bech32
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.Text as T
+
+parseBech32
+    :: Text
+    -> Text
+    -> Aeson.Parser (Bech32.HumanReadablePart, ByteString)
+parseBech32 err =
+    either (const $ fail errBech32) parseDataPart . Bech32.decodeLenient
+  where
+      errBech32 =
+          T.unpack err <>". Expected a bech32-encoded key."
+
+parseDataPart
+    :: (Bech32.HumanReadablePart, Bech32.DataPart)
+    -> Aeson.Parser (Bech32.HumanReadablePart, ByteString)
+parseDataPart =
+    maybe (fail errDataPart) pure . traverse dataPartToBytes
+  where
+      errDataPart =
+          "Couldn't decode data-part to valid UTF-8 bytes."
+
+parsePubVer :: MonadFail f => ByteString -> f ByteString
+parsePubVer bytes
+    | BS.length bytes == 32 =
+          pure bytes
+    | otherwise =
+          fail "Not a valid Ed25519 public key. Must be 32 bytes, without chain code"
+
+parsePubVerHash :: MonadFail f => ByteString -> f ByteString
+parsePubVerHash bytes
+    | BS.length bytes == 28 =
+          pure bytes
+    | otherwise =
+          fail "Not a valid hash of Ed25519 public key. Must be 28 bytes."
+
+parsePubErr :: IsString p => KeyFormat -> p
+parsePubErr = \case
+    Extended ->
+        "Not a valid Ed25519 extended public key. Must be 64 bytes, with chain code"
+    NonExtended ->
+        "Not a valid Ed25519 normal public key. Must be 32 bytes, without chain code"
+
+parsePub :: MonadFail f => ByteString -> KeyFormat -> f ByteString
+parsePub bytes extd
+    | BS.length bytes == bytesExpectedLength =
+          pure bytes
+    | otherwise =
+          fail $ parsePubErr extd
+  where
+    bytesExpectedLength = case extd of
+        Extended -> 64
+        NonExtended -> 32
+
+-- ApiPolicyKey
+
+data VerificationKeyHashing = WithHashing | WithoutHashing
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
+
+data ApiPolicyKey = ApiPolicyKey
+    { getApiPolicyKey :: ByteString
+    , hashed :: VerificationKeyHashing
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
+
+instance ToJSON ApiPolicyKey where
+    toJSON (ApiPolicyKey pub hashed') =
+        toJSON $ Bech32.encodeLenient hrp $ dataPartFromBytes pub
+      where
+        hrp = case hashed' of
+            WithHashing -> [humanReadablePart|policy_vkh|]
+            WithoutHashing -> [humanReadablePart|policy_vk|]
+
+instance FromJSON ApiPolicyKey where
+    parseJSON value = do
+        (hrp, bytes) <- parseJSON value >>= (parseBech32 "Malformed policy key")
+        hashing <- parseHashing hrp
+        payload <- case hashing of
+            WithoutHashing -> parsePubVer bytes
+            WithHashing -> parsePubVerHash bytes
+        pure $ ApiPolicyKey payload hashing
+      where
+        parseHashing = \case
+            hrp | hrp == [humanReadablePart|policy_vk|] -> pure WithoutHashing
+            hrp | hrp == [humanReadablePart|policy_vkh|] -> pure WithHashing
+            _ -> fail errRole
+          where
+            errRole =
+                "Unrecognized human-readable part. Expected either\
+                \ \"policy_vkh\" or \"policy_vk\"."
+
+-- ApiVerificationKeyShared
+
+data ApiVerificationKeyShared = ApiVerificationKeyShared
+    { getApiVerificationKey :: (ByteString, Role)
+    , hashed :: VerificationKeyHashing
+    } deriving (Eq, Generic, Show)
+      deriving anyclass NFData
+
+instance ToJSON ApiVerificationKeyShared where
+    toJSON (ApiVerificationKeyShared (pub, role_) hashed') =
+        toJSON $ Bech32.encodeLenient hrp $ dataPartFromBytes pub
+      where
+        hrp = case role_ of
+            UtxoExternal -> case hashed' of
+                WithHashing -> [humanReadablePart|addr_shared_vkh|]
+                WithoutHashing -> [humanReadablePart|addr_shared_vk|]
+            UtxoInternal -> case hashed' of
+                WithHashing -> [humanReadablePart|addr_shared_vkh|]
+                WithoutHashing -> [humanReadablePart|addr_shared_vk|]
+            MutableAccount -> case hashed' of
+                WithHashing -> [humanReadablePart|stake_shared_vkh|]
+                WithoutHashing -> [humanReadablePart|stake_shared_vk|]
+
+instance FromJSON ApiVerificationKeyShared where
+    parseJSON value = do
+        (hrp, bytes) <- parseJSON value >>= (parseBech32 "Malformed verification key")
+        (role, hashing) <- parseRoleHashing hrp
+        payload <- case hashing of
+            WithoutHashing -> parsePubVer bytes
+            WithHashing -> parsePubVerHash bytes
+        pure $ ApiVerificationKeyShared (payload,role) hashing
+      where
+        parseRoleHashing = \case
+            hrp | hrp == [humanReadablePart|addr_shared_vk|] -> pure (UtxoExternal, WithoutHashing)
+            hrp | hrp == [humanReadablePart|stake_shared_vk|] -> pure (MutableAccount, WithoutHashing)
+            hrp | hrp == [humanReadablePart|addr_shared_vkh|] -> pure (UtxoExternal, WithHashing)
+            hrp | hrp == [humanReadablePart|stake_shared_vkh|] -> pure (MutableAccount, WithHashing)
+            _ -> fail errRole
+          where
+            errRole =
+                "Unrecognized human-readable part. Expected one of:\
+                \ \"addr_shared_vkh\", \"stake_shared_vkh\",\"addr_shared_vk\" or \"stake_shared_vk\"."
+
+-- ApiAccountKey
+
+data ApiAccountKey = ApiAccountKey
+    { getApiAccountKey :: ByteString
+    , format :: KeyFormat
+    , purpose :: Index 'Hardened 'PurposeK
+    } deriving (Eq, Generic, Show)
+      deriving anyclass NFData
+
+instance ToJSON ApiAccountKey where
+    toJSON (ApiAccountKey pub extd purpose') =
+        toJSON $ Bech32.encodeLenient (hrp purpose') $ dataPartFromBytes pub
+      where
+        hrp p
+            | p == purposeCIP1854 = case extd of
+                  Extended -> [humanReadablePart|acct_shared_xvk|]
+                  NonExtended -> [humanReadablePart|acct_shared_vk|]
+            | otherwise = case extd of
+                  Extended -> [humanReadablePart|acct_xvk|]
+                  NonExtended -> [humanReadablePart|acct_vk|]
+
+instance FromJSON ApiAccountKey where
+    parseJSON value = do
+        (hrp, bytes) <- parseJSON value >>= (parseBech32 "Malformed extended/normal account public key")
+        (extended', purpose') <- parseHrp hrp
+        pub <- parsePub bytes extended'
+        pure $ ApiAccountKey pub extended' purpose'
+      where
+        parseHrp = \case
+            hrp | hrp == [humanReadablePart|acct_xvk|] -> pure (Extended, purposeCIP1852)
+            hrp | hrp == [humanReadablePart|acct_vk|] -> pure (NonExtended, purposeCIP1852)
+            hrp | hrp == [humanReadablePart|acct_shared_xvk|] -> pure (Extended, purposeCIP1854)
+            hrp | hrp == [humanReadablePart|acct_shared_vk|] -> pure (NonExtended, purposeCIP1854)
+            _ -> fail errHrp
+          where
+              errHrp =
+                  "Unrecognized human-readable part. Expected one of:\
+                  \ \"acct_xvk\", \"acct_vk\", \"acct_shared_xvk\" or \"acct_shared_vk\"."
+
+-- KeyFormat
+
+data KeyFormat = Extended | NonExtended
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
+
+instance ToText KeyFormat where
+    toText Extended = "extended"
+    toText NonExtended = "non_extended"
+
+instance ToHttpApiData KeyFormat where
+    toUrlPiece = toText
+
+instance FromText KeyFormat where
+    fromText txt = case txt of
+        "extended" -> Right Extended
+        "non_extended" -> Right NonExtended
+        _ -> Left $ TextDecodingError $ unwords
+            [ "I couldn't parse the given key format."
+            , "I am expecting one of the words 'extended' or"
+            , "'non_extended'."]
+
+-- ApiAccountKeyShared
+
+data ApiAccountKeyShared = ApiAccountKeyShared
+    { getApiAccountKey :: ByteString
+    , format :: KeyFormat
+    , purpose :: Index 'Hardened 'PurposeK
+    } deriving (Eq, Generic, Show)
+      deriving anyclass NFData
+
+instance ToJSON ApiAccountKeyShared where
+    toJSON (ApiAccountKeyShared pub extd _) =
+        toJSON $ Bech32.encodeLenient hrp $ dataPartFromBytes pub
+      where
+        hrp = case extd of
+            Extended -> [humanReadablePart|acct_shared_xvk|]
+            NonExtended -> [humanReadablePart|acct_shared_vk|]
+
+instance FromJSON ApiAccountKeyShared where
+    parseJSON value = do
+        (hrp, bytes) <- parseJSON value >>= (parseBech32 "Malformed extended/normal account public key")
+        extended' <- parseHrp hrp
+        pub <- parsePub bytes extended'
+        pure $ ApiAccountKeyShared pub extended' purposeCIP1854
+      where
+        parseHrp = \case
+            hrp | hrp == [humanReadablePart|acct_shared_xvk|] -> pure Extended
+            hrp | hrp == [humanReadablePart|acct_shared_vk|] -> pure NonExtended
+            _ -> fail errHrp
+          where
+              errHrp =
+                  "Unrecognized human-readable part. Expected one of:\
+                  \ \"acct_shared_xvk\" or \"acct_shared_vk\"."
+
+-- ApiVerificationKetShelley
+
+data ApiVerificationKeyShelley = ApiVerificationKeyShelley
+    { getApiVerificationKey :: (ByteString, Role)
+    , hashed :: VerificationKeyHashing
+    } deriving (Eq, Generic, Show)
+      deriving anyclass NFData
+
+instance ToJSON ApiVerificationKeyShelley where
+    toJSON (ApiVerificationKeyShelley (pub, role_) hashed') =
+        toJSON $ Bech32.encodeLenient hrp $ dataPartFromBytes pub
+      where
+        hrp = case role_ of
+            UtxoExternal -> case hashed' of
+                WithHashing -> [humanReadablePart|addr_vkh|]
+                WithoutHashing -> [humanReadablePart|addr_vk|]
+            UtxoInternal -> case hashed' of
+                WithHashing -> [humanReadablePart|addr_vkh|]
+                WithoutHashing -> [humanReadablePart|addr_vk|]
+            MutableAccount -> case hashed' of
+                WithHashing -> [humanReadablePart|stake_vkh|]
+                WithoutHashing -> [humanReadablePart|stake_vk|]
+
+instance FromJSON ApiVerificationKeyShelley where
+    parseJSON value = do
+        (hrp, bytes) <- parseJSON value >>= (parseBech32 "Malformed verification key")
+        (role, hashing) <- parseRoleHashing hrp
+        payload <- case hashing of
+            WithoutHashing -> parsePubVer bytes
+            WithHashing -> parsePubVerHash bytes
+        pure $ ApiVerificationKeyShelley (payload,role) hashing
+      where
+        parseRoleHashing = \case
+            hrp | hrp == [humanReadablePart|addr_vk|] -> pure (UtxoExternal, WithoutHashing)
+            hrp | hrp == [humanReadablePart|stake_vk|] -> pure (MutableAccount, WithoutHashing)
+            hrp | hrp == [humanReadablePart|addr_vkh|] -> pure (UtxoExternal, WithHashing)
+            hrp | hrp == [humanReadablePart|stake_vkh|] -> pure (MutableAccount, WithHashing)
+            _ -> fail errRole
+          where
+            errRole =
+                "Unrecognized human-readable part. Expected one of:\
+                \ \"addr_vkh\", \"stake_vkh\",\"addr_vk\" or \"stake_vk\"."

--- a/lib/core/src/Cardano/Wallet/Api/Types/Primitive.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types/Primitive.hs
@@ -1,0 +1,269 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK
+-- License: Apache-2.0
+
+module Cardano.Wallet.Api.Types.Primitive () where
+
+import Prelude
+
+import Cardano.Api
+    ( TxMetadataJsonSchema (..)
+    , displayError
+    , metadataFromJson
+    , metadataToJson
+    )
+import Cardano.Wallet.Api.Aeson
+    ( eitherToParser )
+import Cardano.Wallet.Api.Hex
+    ( fromHexText, hexText )
+import Cardano.Wallet.Api.Lib.ApiT
+    ( ApiT (..), fromTextApiT, toTextApiT )
+import Cardano.Wallet.Api.Types.Address
+    ( DecodeAddress (..)
+    , DecodeStakeAddress (..)
+    , EncodeAddress (..)
+    , EncodeStakeAddress (..)
+    )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( DerivationIndex, RewardAccount )
+import Cardano.Wallet.Primitive.Types
+    ( EpochNo (..)
+    , NonWalletCertificate (..)
+    , PoolId (..)
+    , SlotInEpoch (..)
+    , SlotNo (..)
+    , decodePoolIdBech32
+    , encodePoolIdBech32
+    , unsafeEpochNo
+    )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..), coinFromQuantity, coinToQuantity )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx.Constraints
+    ( coinIsValidForTxOut, txOutMaxCoin )
+import Cardano.Wallet.Primitive.Types.Tx.Tx
+    ( TxIn (..), TxMetadata (..), TxScriptValidity )
+import Cardano.Wallet.Transaction
+    ( AnyScript (..) )
+import Cardano.Wallet.Util
+    ( ShowFmt (..) )
+import Control.Monad
+    ( (>=>) )
+import Data.Aeson
+    ( FromJSON (parseJSON)
+    , KeyValue (..)
+    , Options (..)
+    , ToJSON (toJSON)
+    , Value (..)
+    , camelTo2
+    , genericParseJSON
+    , genericToJSON
+    , object
+    , withObject
+    , withText
+    , (.!=)
+    , (.:)
+    , (.:?)
+    )
+import Data.Aeson.Types
+    ( prependFailure )
+import qualified Data.Aeson.Types as Aeson
+import Data.Bifunctor
+    ( Bifunctor (..) )
+import Data.Proxy
+    ( Proxy (..) )
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Text.Class
+    ( ToText (..) )
+import Data.Word
+    ( Word32, Word64 )
+import Data.Word.Odd
+    ( Word31 )
+
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
+import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
+
+instance ToJSON (ApiT DerivationIndex) where
+    toJSON = toTextApiT
+instance FromJSON (ApiT DerivationIndex) where
+    parseJSON = fromTextApiT "DerivationIndex"
+
+instance FromJSON (ApiT W.TokenPolicyId) where
+    parseJSON = fromTextApiT "PolicyId"
+instance ToJSON (ApiT W.TokenPolicyId) where
+    toJSON = toTextApiT
+
+instance FromJSON (ApiT AnyScript) where
+    parseJSON = withObject "ApiT AnyScript" $ \obj -> do
+        scriptType <- obj .:? "script_type"
+        case (scriptType :: Maybe String) of
+            Just t | t == "plutus"  ->
+                ApiT . PlutusScript <$> obj .: "language_version"
+            Just t | t == "native" ->
+                ApiT . NativeScript <$> obj .: "script"
+            _ -> fail "AnyScript needs either 'native' or 'plutus' in 'script_type'"
+
+instance ToJSON (ApiT AnyScript) where
+    toJSON (ApiT (NativeScript s)) =
+        object [ "script_type" .= String "native"
+               , "script" .= toJSON s]
+    toJSON (ApiT (PlutusScript v)) =
+        object [ "script_type" .= String "plutus"
+               , "language_version" .= toJSON v]
+
+instance FromJSON (ApiT W.TokenName) where
+    parseJSON = withText "AssetName"
+        (fmap (ApiT . W.UnsafeTokenName) . eitherToParser . fromHexText)
+instance ToJSON (ApiT W.TokenName) where
+    toJSON = toJSON . hexText . W.unTokenName . getApiT
+
+instance FromJSON (ApiT W.TokenFingerprint) where
+    parseJSON = fromTextApiT "TokenFingerprint"
+instance ToJSON (ApiT W.TokenFingerprint) where
+    toJSON = toTextApiT
+
+instance FromJSON (ApiT EpochNo) where
+    parseJSON = fmap (ApiT . unsafeEpochNo) . parseJSON
+instance ToJSON (ApiT EpochNo) where
+    toJSON (ApiT (EpochNo en)) = toJSON $ fromIntegral @Word31 @Word32 en
+
+instance FromJSON (ApiT SlotInEpoch) where
+    parseJSON = fmap (ApiT . SlotInEpoch) . parseJSON
+instance ToJSON (ApiT SlotInEpoch) where
+    toJSON (ApiT (SlotInEpoch sn)) = toJSON sn
+
+instance FromJSON (ApiT SlotNo) where
+    parseJSON = fmap (ApiT . SlotNo) . parseJSON
+instance ToJSON (ApiT SlotNo) where
+    toJSON (ApiT (SlotNo sn)) = toJSON sn
+
+instance FromJSON (ApiT W.TokenMap) where
+    parseJSON = fmap (ApiT . W.getFlat) . parseJSON
+instance ToJSON (ApiT W.TokenMap) where
+    toJSON = toJSON . W.Flat . getApiT
+instance ToJSON (ApiT W.TokenBundle) where
+    -- TODO: consider other structures
+    toJSON (ApiT (W.TokenBundle c ts)) = object
+        [ "amount" .= coinToQuantity @Word c
+        , "assets" .= toJSON (ApiT ts)
+        ]
+
+instance FromJSON (ApiT W.TokenBundle) where
+    -- TODO: reject unknown fields
+    parseJSON = withObject "Value " $ \v ->
+        prependFailure "parsing Value failed, " $
+        fmap ApiT $ W.TokenBundle
+            <$> (v .: "amount" >>= validateCoin)
+            <*> fmap getApiT (v .: "assets" .!= mempty)
+      where
+        validateCoin :: Quantity "lovelace" Word64 -> Aeson.Parser Coin
+        validateCoin (coinFromQuantity -> c)
+            | coinIsValidForTxOut c = pure c
+            | otherwise = fail $
+                "invalid coin value: value has to be lower than or equal to "
+                <> show (unCoin txOutMaxCoin) <> " lovelace."
+
+instance FromJSON (ApiT TxIn) where
+    parseJSON = withObject "TxIn" $ \v -> ApiT <$>
+        (TxIn <$> fmap getApiT (v .: "id") <*> v .: "index")
+
+instance ToJSON (ApiT TxIn) where
+    toJSON (ApiT (TxIn txid ix)) = object
+        [ "id" .= toJSON (ApiT txid)
+        , "index" .= toJSON ix ]
+
+instance FromJSON (ApiT (Hash "Tx")) where
+    parseJSON = fromTextApiT "Tx Hash"
+instance ToJSON (ApiT (Hash "Tx")) where
+    toJSON = toTextApiT
+
+instance FromJSON (ApiT TxScriptValidity) where
+    parseJSON = fmap ApiT . genericParseJSON Aeson.defaultOptions
+        { constructorTagModifier = camelTo2 '_' . drop 8 }
+
+instance ToJSON (ApiT TxScriptValidity) where
+    toJSON = genericToJSON Aeson.defaultOptions
+        { constructorTagModifier = camelTo2 '_' . drop 8 } . getApiT
+
+instance {-# OVERLAPS #-} DecodeAddress n => FromJSON (ApiT Address, Proxy n)
+  where
+    parseJSON x = do
+        let proxy = Proxy @n
+        addr <- parseJSON x >>= eitherToParser
+            . bimap ShowFmt ApiT
+            . decodeAddress @n
+        return (addr, proxy)
+instance {-# OVERLAPS #-} EncodeAddress n => ToJSON (ApiT Address, Proxy n)
+  where
+    toJSON (addr, _) = toJSON . encodeAddress @n . getApiT $ addr
+
+instance {-# OVERLAPS #-} (DecodeStakeAddress n)
+    => FromJSON (ApiT RewardAccount, Proxy n)
+  where
+    parseJSON x = do
+        let proxy = Proxy @n
+        acct <- parseJSON x >>= eitherToParser
+            . bimap ShowFmt ApiT
+            . decodeStakeAddress @n
+        return (acct, proxy)
+
+instance {-# OVERLAPS #-} EncodeStakeAddress n
+    => ToJSON (ApiT RewardAccount, Proxy n)
+  where
+    toJSON (acct, _) = toJSON . encodeStakeAddress @n . getApiT $ acct
+
+instance FromJSON (ApiT PoolId) where
+    parseJSON = parseJSON >=> eitherToParser
+           . bimap ShowFmt ApiT
+           . decodePoolIdBech32
+instance ToJSON (ApiT PoolId) where
+    toJSON = toJSON . encodePoolIdBech32 . getApiT
+
+instance FromJSON (ApiT W.StakePoolMetadataHash) where
+    parseJSON = fromTextApiT "ApiT StakePoolMetadataHash"
+instance ToJSON (ApiT W.StakePoolMetadataHash) where
+    toJSON = toTextApiT
+
+instance FromJSON (ApiT W.PoolOwner) where
+    parseJSON = fromTextApiT "ApiT PoolOwner"
+instance ToJSON (ApiT W.PoolOwner) where
+    toJSON = toTextApiT
+
+instance FromJSON (ApiT W.StakePoolMetadataUrl) where
+    parseJSON = fromTextApiT "ApiT StakePoolMetadataUrl"
+instance ToJSON (ApiT W.StakePoolMetadataUrl) where
+    toJSON = toTextApiT
+
+instance FromJSON (ApiT W.NonWalletCertificate) where
+  parseJSON val
+    | val == object ["certificate_type" .= String "mir"]
+    = pure $ ApiT MIRCertificate
+    | val == object ["certificate_type" .= String "genesis"]
+    = pure $ ApiT GenesisCertificate
+    | otherwise
+    = fail
+        "expected object with key 'certificate_type' and value either 'mir' or 'genesis'"
+instance ToJSON (ApiT W.NonWalletCertificate) where
+    toJSON (ApiT cert) = object ["certificate_type" .= String (toText cert)]
+
+instance FromJSON (ApiT TxMetadata) where
+    parseJSON = fmap ApiT
+        . either (fail . displayError) pure
+        . metadataFromJson TxMetadataJsonDetailedSchema
+
+instance ToJSON (ApiT TxMetadata) where
+    toJSON = metadataToJson TxMetadataJsonDetailedSchema . getApiT

--- a/lib/core/src/Cardano/Wallet/Api/Types/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types/Transaction.hs
@@ -1,0 +1,357 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK
+-- License: Apache-2.0
+
+module Cardano.Wallet.Api.Types.Transaction
+    ( AddressAmount (..)
+    , ApiAssetMintBurn (..)
+    , ApiDecodedTransaction (..)
+    , ApiPostPolicyKeyData (..)
+    , ApiTokenAmountFingerprint (..)
+    , ApiTokens (..)
+    , ApiTxInputGeneral (..)
+    , ApiTxMetadata (..)
+    , ApiTxOutput
+    , ApiTxOutputGeneral (..)
+    , ApiWalletInput (..)
+    , ApiWalletOutput (..)
+    , ApiWithdrawal (..)
+    , ApiWithdrawalGeneral (..)
+    , ResourceContext (..)
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Api.Lib.ApiAsArray
+    ( ApiAsArray )
+import Cardano.Wallet.Api.Lib.ApiT
+    ( ApiT (ApiT) )
+import Cardano.Wallet.Api.Lib.Options
+    ( defaultRecordTypeOptions )
+import Cardano.Wallet.Api.Types.Address
+    ( DecodeAddress, DecodeStakeAddress, EncodeAddress, EncodeStakeAddress )
+import Cardano.Wallet.Api.Types.Certificate
+    ( ApiAnyCertificate )
+import Cardano.Wallet.Api.Types.Key
+    ( ApiPolicyKey )
+import Cardano.Wallet.Api.Types.Primitive
+    ()
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( DerivationIndex (..), NetworkDiscriminant )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (unCoin), coinFromQuantity )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx.Constraints
+    ( coinIsValidForTxOut, txOutMaxCoin )
+import Cardano.Wallet.Primitive.Types.Tx.Tx
+    ( TxIn (..), TxMetadata (..), TxScriptValidity, txMetadataIsNull )
+import Cardano.Wallet.Transaction
+    ( AnyScript, ValidityIntervalExplicit (..) )
+import Control.DeepSeq
+    ( NFData )
+import Data.Aeson.Types
+    ( FromJSON (..)
+    , KeyValue (..)
+    , ToJSON (..)
+    , Value (..)
+    , genericParseJSON
+    , genericToJSON
+    , object
+    , prependFailure
+    , withObject
+    , (.!=)
+    , (.:)
+    , (.:?)
+    )
+import Data.List.NonEmpty
+    ( NonEmpty )
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Text
+    ( Text )
+import Data.Typeable
+    ( Proxy, Typeable )
+import Data.Word
+    ( Word32 )
+import GHC.Generics
+    ( Generic )
+import Numeric.Natural
+    ( Natural )
+import Quiet
+    ( Quiet (Quiet) )
+
+import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
+import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
+import qualified Data.Aeson.Types as Aeson
+
+newtype ApiTxMetadata = ApiTxMetadata
+    { getApiTxMetadata :: Maybe (ApiT TxMetadata)
+    }
+    deriving (Eq, Generic)
+    deriving anyclass NFData
+    deriving Show via (Quiet ApiTxMetadata)
+
+instance FromJSON ApiTxMetadata where
+    parseJSON Aeson.Null = pure $ ApiTxMetadata Nothing
+    parseJSON v = ApiTxMetadata . Just <$> parseJSON v
+instance ToJSON ApiTxMetadata where
+    toJSON (ApiTxMetadata x) = case x of
+        Nothing -> Aeson.Null
+        Just (ApiT md) | txMetadataIsNull md -> Aeson.Null
+        Just md -> toJSON md
+
+data ApiDecodedTransaction (n :: NetworkDiscriminant) = ApiDecodedTransaction
+    { id :: ApiT (Hash "Tx")
+    , fee :: Quantity "lovelace" Natural
+    , inputs :: [ApiTxInputGeneral n]
+    , outputs :: [ApiTxOutputGeneral n]
+    , collateral :: [ApiTxInputGeneral n]
+    , collateralOutputs ::
+        ApiAsArray "collateral_outputs" (Maybe (ApiTxOutputGeneral n))
+    , withdrawals :: [ApiWithdrawalGeneral n]
+    , mint :: ApiAssetMintBurn
+    , burn :: ApiAssetMintBurn
+    , certificates :: [ApiAnyCertificate n]
+    , depositsTaken :: [Quantity "lovelace" Natural]
+    , depositsReturned :: [Quantity "lovelace" Natural]
+    , metadata :: ApiTxMetadata
+    , scriptValidity :: Maybe (ApiT TxScriptValidity)
+    , validityInterval :: Maybe ValidityIntervalExplicit
+    }
+    deriving (Eq, Generic, Show, Typeable)
+    deriving anyclass NFData
+
+instance
+    ( DecodeAddress n
+    , DecodeStakeAddress n
+    ) => FromJSON (ApiDecodedTransaction n)
+  where
+    parseJSON = genericParseJSON defaultRecordTypeOptions
+instance
+    ( EncodeAddress n
+    , EncodeStakeAddress n
+    ) => ToJSON (ApiDecodedTransaction n)
+  where
+    toJSON = genericToJSON defaultRecordTypeOptions
+
+data ApiWalletInput (n :: NetworkDiscriminant) = ApiWalletInput
+    { id :: ApiT (Hash "Tx")
+    , index :: Word32
+    , address :: (ApiT Address, Proxy n)
+    , derivationPath :: NonEmpty (ApiT DerivationIndex)
+    , amount :: Quantity "lovelace" Natural
+    , assets :: ApiT W.TokenMap
+    } deriving (Eq, Generic, Show, Typeable)
+      deriving anyclass NFData
+
+instance DecodeAddress n => FromJSON (ApiWalletInput n) where
+    parseJSON = genericParseJSON defaultRecordTypeOptions
+instance EncodeAddress n => ToJSON (ApiWalletInput n) where
+    toJSON = genericToJSON defaultRecordTypeOptions
+
+data ApiTxInputGeneral (n :: NetworkDiscriminant) =
+      ExternalInput (ApiT TxIn)
+    | WalletInput (ApiWalletInput n)
+      deriving (Eq, Generic, Show, Typeable)
+      deriving anyclass NFData
+
+instance
+    ( DecodeAddress n
+    , DecodeStakeAddress n
+    ) => FromJSON (ApiTxInputGeneral n)
+  where
+    parseJSON obj = do
+        derPathM <-
+            (withObject "ApiTxInputGeneral" $
+             \o -> o .:? "derivation_path"
+                :: Aeson.Parser (Maybe (NonEmpty (ApiT DerivationIndex)))) obj
+        case derPathM of
+            Nothing -> do
+                xs <- parseJSON obj :: Aeson.Parser (ApiT TxIn)
+                pure $ ExternalInput xs
+            Just _ -> do
+                xs <- parseJSON obj :: Aeson.Parser (ApiWalletInput n)
+                pure $ WalletInput xs
+instance
+    ( EncodeAddress n
+    , EncodeStakeAddress n
+    ) => ToJSON (ApiTxInputGeneral n)
+  where
+    toJSON (ExternalInput content) = toJSON content
+    toJSON (WalletInput content) = toJSON content
+
+data ResourceContext = External | Our
+      deriving (Eq, Generic, Show, Typeable)
+      deriving anyclass NFData
+
+data ApiWithdrawalGeneral (n :: NetworkDiscriminant) = ApiWithdrawalGeneral
+    { stakeAddress :: (ApiT W.RewardAccount, Proxy n)
+    , amount :: Quantity "lovelace" Natural
+    , context :: ResourceContext
+    } deriving (Eq, Generic, Show)
+      deriving anyclass NFData
+
+data ApiWalletOutput (n :: NetworkDiscriminant) = ApiWalletOutput
+    { address :: (ApiT Address, Proxy n)
+    , amount :: Quantity "lovelace" Natural
+    , assets :: ApiT W.TokenMap
+    , derivationPath :: NonEmpty (ApiT DerivationIndex)
+    } deriving (Eq, Generic, Show, Typeable)
+      deriving anyclass NFData
+instance DecodeAddress n => FromJSON (ApiWalletOutput n) where
+    parseJSON = genericParseJSON defaultRecordTypeOptions
+instance EncodeAddress n => ToJSON (ApiWalletOutput n) where
+    toJSON = genericToJSON defaultRecordTypeOptions
+
+data AddressAmount addr = AddressAmount
+    { address :: addr
+    , amount :: Quantity "lovelace" Natural
+    , assets :: ApiT W.TokenMap
+    } deriving (Eq, Generic, Show)
+      deriving anyclass NFData
+
+instance FromJSON a => FromJSON (AddressAmount a) where
+    parseJSON = withObject "AddressAmount " $ \v ->
+        prependFailure "parsing AddressAmount failed, " $
+        AddressAmount
+            <$> v .: "address"
+            <*> (v .: "amount" >>= validateCoin)
+            <*> v .:? "assets" .!= mempty
+      where
+        validateCoin q
+            | coinIsValidForTxOut (coinFromQuantity q) = pure q
+            | otherwise = fail $
+                "invalid coin value: value has to be lower than or equal to "
+                <> show (unCoin txOutMaxCoin) <> " lovelace."
+
+instance ToJSON a => ToJSON (AddressAmount a) where
+    toJSON = genericToJSON defaultRecordTypeOptions
+-- | A helper type to reduce the amount of repetition.
+--
+type ApiTxOutput n = AddressAmount (ApiT Address, Proxy n)
+
+data ApiTxOutputGeneral (n :: NetworkDiscriminant) =
+      ExternalOutput (ApiTxOutput n)
+    | WalletOutput (ApiWalletOutput n)
+      deriving (Eq, Generic, Show, Typeable)
+      deriving anyclass NFData
+
+instance
+    ( DecodeAddress n
+    , DecodeStakeAddress n
+    ) => FromJSON (ApiTxOutputGeneral n)
+  where
+    parseJSON obj = do
+        derPathM <-
+            (withObject "ApiTxOutputGeneral" $
+             \o -> o .:? "derivation_path"
+                :: Aeson.Parser (Maybe (NonEmpty (ApiT DerivationIndex)))) obj
+        case derPathM of
+            Nothing -> do
+                xs <- parseJSON obj
+                    :: Aeson.Parser (ApiTxOutput n)
+                pure $ ExternalOutput xs
+            Just _ -> do
+                xs <- parseJSON obj
+                    :: Aeson.Parser (ApiWalletOutput n)
+                pure $ WalletOutput xs
+instance
+    ( EncodeAddress n
+    , EncodeStakeAddress n
+    ) => ToJSON (ApiTxOutputGeneral n)
+  where
+    toJSON (ExternalOutput content) = toJSON content
+    toJSON (WalletOutput content) = toJSON content
+
+newtype ApiPostPolicyKeyData = ApiPostPolicyKeyData
+    { passphrase :: ApiT (Passphrase "user")
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
+
+data ApiTokenAmountFingerprint = ApiTokenAmountFingerprint
+    { assetName :: ApiT W.TokenName
+    , quantity :: Natural
+    , fingerprint :: ApiT W.TokenFingerprint
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
+
+instance FromJSON ApiTokenAmountFingerprint where
+    parseJSON = genericParseJSON defaultRecordTypeOptions
+instance ToJSON ApiTokenAmountFingerprint where
+    toJSON = genericToJSON defaultRecordTypeOptions
+
+data ApiTokens = ApiTokens
+    { policyId :: ApiT W.TokenPolicyId
+    , policyScript :: ApiT AnyScript
+    , assets :: NonEmpty ApiTokenAmountFingerprint
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
+
+instance FromJSON ApiTokens where
+    parseJSON = genericParseJSON defaultRecordTypeOptions
+instance ToJSON ApiTokens where
+    toJSON = genericToJSON defaultRecordTypeOptions
+
+data ApiAssetMintBurn = ApiAssetMintBurn
+    { tokens :: [ApiTokens]
+    , walletPolicyKeyHash :: Maybe ApiPolicyKey
+    , walletPolicyKeyIndex :: Maybe (ApiT DerivationIndex)
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
+
+instance FromJSON ApiAssetMintBurn where
+    parseJSON = genericParseJSON defaultRecordTypeOptions
+instance ToJSON ApiAssetMintBurn where
+    toJSON = genericToJSON defaultRecordTypeOptions
+
+data ApiWithdrawal n = ApiWithdrawal
+    { stakeAddress :: !(ApiT W.RewardAccount, Proxy n)
+    , amount :: !(Quantity "lovelace" Natural)
+    } deriving (Eq, Generic, Show)
+      deriving anyclass NFData
+
+instance DecodeStakeAddress n => FromJSON (ApiWithdrawal n) where
+    parseJSON = genericParseJSON defaultRecordTypeOptions
+instance EncodeStakeAddress n => ToJSON (ApiWithdrawal n) where
+    toJSON = genericToJSON defaultRecordTypeOptions
+
+instance DecodeStakeAddress n => FromJSON (ApiWithdrawalGeneral n) where
+    parseJSON obj = do
+        myResource <-
+            (withObject "ApiWithdrawalGeneral" $
+             \o -> o .:? "context" :: Aeson.Parser (Maybe Text)) obj
+        case myResource of
+            Nothing -> do
+                (ApiWithdrawal addr amt)  <- parseJSON obj :: Aeson.Parser (ApiWithdrawal n)
+                pure $ ApiWithdrawalGeneral addr amt External
+            _ -> do
+                (ApiWithdrawal addr amt)  <- parseJSON obj :: Aeson.Parser (ApiWithdrawal n)
+                pure $ ApiWithdrawalGeneral addr amt Our
+
+instance EncodeStakeAddress n => ToJSON (ApiWithdrawalGeneral n) where
+    toJSON (ApiWithdrawalGeneral addr amt ctx) = do
+        let obj = [ "stake_address" .= toJSON addr
+                  , "amount" .= toJSON amt]
+        case ctx of
+            External -> object obj
+            Our -> object $ obj ++ ["context" .= String "ours"]

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -44,7 +44,8 @@ module Cardano.Wallet.Primitive.Types.Coin
     , partition
     , partitionDefault
     , unsafePartition
-
+    , coinToQuantity
+    , coinFromQuantity
     ) where
 
 import Prelude hiding
@@ -184,6 +185,11 @@ toQuantityMaybe (Coin c) = Quantity <$> intCastMaybe c
 toWord64Maybe :: Coin -> Maybe Word64
 toWord64Maybe (Coin c) = intCastMaybe c
 
+coinToQuantity :: Integral n => Coin -> Quantity "lovelace" n
+coinToQuantity = Quantity . Prelude.fromIntegral . unCoin
+
+coinFromQuantity :: Integral n => Quantity "lovelace" n -> Coin
+coinFromQuantity = Coin . Prelude.fromIntegral . getQuantity
 --------------------------------------------------------------------------------
 -- Conversions (Unsafe)
 -------------------------------------------------------------------------------

--- a/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -296,7 +296,7 @@ instance Malformed (BodyParam ApiPostPolicyKeyData) where
         , ( Aeson.encode [aesonQQ|
             {
             }|]
-          , "Error in $: parsing Cardano.Wallet.Api.Types.ApiPostPolicyKeyData(ApiPostPolicyKeyData) failed, key 'passphrase' not found"
+          , "Error in $: parsing Cardano.Wallet.Api.Types.Transaction.ApiPostPolicyKeyData(ApiPostPolicyKeyData) failed, key 'passphrase' not found"
           )
         ]
 
@@ -1260,16 +1260,16 @@ instance Malformed (BodyParam ApiPostAccountKeyData) where
               , "Error in $: parsing Cardano.Wallet.Api.Types.ApiPostAccountKeyData(ApiPostAccountKeyData) failed, key 'format' not found"
               )
             , ( [aesonQQ| { "passphrase": "The proper passphrase", "format": 123 }|]
-              , "Error in $.format: parsing Cardano.Wallet.Api.Types.KeyFormat failed, expected String, but encountered Number"
+              , "Error in $.format: parsing Cardano.Wallet.Api.Types.Key.KeyFormat failed, expected String, but encountered Number"
               )
             , ( [aesonQQ| { "passphrase": "The proper passphrase", "format": [] }|]
-              , "Error in $.format: parsing Cardano.Wallet.Api.Types.KeyFormat failed, expected String, but encountered Array"
+              , "Error in $.format: parsing Cardano.Wallet.Api.Types.Key.KeyFormat failed, expected String, but encountered Array"
               )
             , ( [aesonQQ| { "passphrase": "The proper passphrase", "format": 1.5 }|]
-              , "Error in $.format: parsing Cardano.Wallet.Api.Types.KeyFormat failed, expected String, but encountered Number"
+              , "Error in $.format: parsing Cardano.Wallet.Api.Types.Key.KeyFormat failed, expected String, but encountered Number"
               )
             , ( [aesonQQ| { "passphrase": "The proper passphrase", "format": "ok" }|]
-              , "Error in $.format: parsing Cardano.Wallet.Api.Types.KeyFormat failed, expected one of the tags ['extended','non_extended'], but found tag 'ok'"
+              , "Error in $.format: parsing Cardano.Wallet.Api.Types.Key.KeyFormat failed, expected one of the tags ['extended','non_extended'], but found tag 'ok'"
               )
             ]
 
@@ -1302,16 +1302,16 @@ instance Malformed (BodyParam ApiPostAccountKeyDataWithPurpose) where
               , "Error in $: parsing Cardano.Wallet.Api.Types.ApiPostAccountKeyDataWithPurpose(ApiPostAccountKeyDataWithPurpose) failed, key 'format' not found"
               )
             , ( [aesonQQ| { "passphrase": "The proper passphrase", "format": 123 }|]
-              , "Error in $.format: parsing Cardano.Wallet.Api.Types.KeyFormat failed, expected String, but encountered Number"
+              , "Error in $.format: parsing Cardano.Wallet.Api.Types.Key.KeyFormat failed, expected String, but encountered Number"
               )
             , ( [aesonQQ| { "passphrase": "The proper passphrase", "format": [] }|]
-              , "Error in $.format: parsing Cardano.Wallet.Api.Types.KeyFormat failed, expected String, but encountered Array"
+              , "Error in $.format: parsing Cardano.Wallet.Api.Types.Key.KeyFormat failed, expected String, but encountered Array"
               )
             , ( [aesonQQ| { "passphrase": "The proper passphrase", "format": 1.5 }|]
-              , "Error in $.format: parsing Cardano.Wallet.Api.Types.KeyFormat failed, expected String, but encountered Number"
+              , "Error in $.format: parsing Cardano.Wallet.Api.Types.Key.KeyFormat failed, expected String, but encountered Number"
               )
             , ( [aesonQQ| { "passphrase": "The proper passphrase", "format": "ok" }|]
-              , "Error in $.format: parsing Cardano.Wallet.Api.Types.KeyFormat failed, expected one of the tags ['extended','non_extended'], but found tag 'ok'"
+              , "Error in $.format: parsing Cardano.Wallet.Api.Types.Key.KeyFormat failed, expected one of the tags ['extended','non_extended'], but found tag 'ok'"
               )
             ]
 

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -21,7 +21,12 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK
+-- License: Apache-2.0
 
 module Cardano.Wallet.Api.TypesSpec (spec) where
 
@@ -277,7 +282,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..) )
+    ( Coin (..), coinToQuantity )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoinPositive )
 import Cardano.Wallet.Primitive.Types.Hash
@@ -744,7 +749,6 @@ spec = parallel $ do
             Aeson.parseEither parseJSON [aesonQQ|
                 ["toilet", "toilet", "toilet"]
             |] `shouldBe` (Left @String @(ApiMnemonicT '[12]) msg)
-
 
         it "ApiT DerivationIndex (too small)" $ do
             let message = unwords
@@ -1440,7 +1444,6 @@ instance EncodeStakeAddress ('Testnet 0) where
 instance DecodeStakeAddress ('Testnet 0) where
     decodeStakeAddress "<stake-addr>" = Right $ RewardAccount "<stake-addr>"
     decodeStakeAddress _ = Left $ TextDecodingError "invalid stake address"
-
 
 {-------------------------------------------------------------------------------
                               Arbitrary Instances

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -282,7 +282,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), coinToQuantity )
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoinPositive )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -241,7 +241,6 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified UnliftIO.STM as STM
 
-
 data StakePoolLayer = StakePoolLayer
     { getPoolLifeCycleStatus :: PoolId -> IO PoolLifeCycleStatus
 
@@ -731,7 +730,6 @@ monitorStakePools tr (NetworkParameters gp sp _pp) genesisPools nl DBLayer{..} =
             toChainPoint (BlockHeader  0 _ _ _) = ChainPointAtGenesis
             toChainPoint (BlockHeader sl _ h _) = ChainPoint sl h
 
-
         -- Write genesis pools to DB. These are specific to the integration test
         -- cluster, and is always set to [] in the cardano-wallet executable.
         --
@@ -901,7 +899,6 @@ monitorStakePools tr (NetworkParameters gp sp _pp) genesisPools nl DBLayer{..} =
             (publicationTime, Retirement cert) -> do
                 liftIO $ traceWith tr $ MsgStakePoolRetirement cert
                 putPoolRetirement publicationTime cert
-
 
 -- | Worker thread that monitors pool metadata and syncs it to the database.
 monitorMetadata


### PR DESCRIPTION
<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->

I have
- [x] factor out `ApiDecodedTransaction` from the Api.Types module
- [x] created ApiT, ApiAsArray, ExtendedObject, Options as API  libraries
- [x] factor out `Certificate` and `Key` API types with relatives closures
- [x] factor out `Primitive` for all ApiT instances that just wrap types in the `Primitive` hierarchy
- [x] moved out a couple of coin functions to the `Coin` primitive

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->
This work is preliminary to ApiDecodedTransaction reuse in the ADP work, but independent from CBOR PRs

### Issue Number

ADP-1963