### PR TITLE
Consolidate conversions between `Coin` and `Quantity`.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -4276,7 +4276,7 @@ addressAmountToTxOut
     :: forall (n :: NetworkDiscriminant). AddressAmount (ApiT Address, Proxy n)
     -> TxOut
 addressAmountToTxOut (AddressAmount (ApiT addr, _) c (ApiT assets)) =
-    TxOut addr (TokenBundle.TokenBundle (coinFromQuantity c) assets)
+    TxOut addr (TokenBundle.TokenBundle (Coin.fromQuantity c) assets)
 
 natural :: Quantity q Word32 -> Quantity q Natural
 natural = Quantity . fromIntegral . getQuantity

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -330,8 +330,6 @@ import Cardano.Wallet.Api.Types
     , WalletPutData (..)
     , WalletPutPassphraseData (..)
     , XPubOrSelf (..)
-    , coinFromQuantity
-    , coinToQuantity
     , getApiMnemonicT
     , toApiAsset
     , toApiEpochInfo

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -957,9 +957,9 @@ mkShelleyWallet ctx wid cp meta pending progress = do
     pure ApiWallet
         { addressPoolGap = ApiT $ getGap $ getState cp ^. #externalPool
         , balance = ApiWalletBalance
-            { available = coinToQuantity (available ^. #coin)
-            , total = coinToQuantity (total ^. #coin)
-            , reward = coinToQuantity reward
+            { available = Coin.toQuantity (available ^. #coin)
+            , total = Coin.toQuantity (total ^. #coin)
+            , reward = Coin.toQuantity reward
             }
         , assets = ApiWalletAssetsBalance
             { available = ApiT (available ^. #tokens)
@@ -1164,9 +1164,9 @@ mkSharedWallet ctx wid cp meta pending progress = case Shared.ready st of
             , delegationScriptTemplate = Shared.delegationTemplate st
             , delegation = apiDelegation
             , balance = ApiWalletBalance
-                { available = coinToQuantity (available ^. #coin)
-                , total = coinToQuantity (total ^. #coin)
-                , reward = coinToQuantity reward
+                { available = Coin.toQuantity (available ^. #coin)
+                , total = Coin.toQuantity (total ^. #coin)
+                , reward = Coin.toQuantity reward
                 }
             , assets = ApiWalletAssetsBalance
                 { available = ApiT (available ^. #tokens)
@@ -1279,8 +1279,8 @@ mkLegacyWallet ctx wid cp meta pending progress = do
     let total = totalBalance pending (Coin 0) cp
     pure ApiByronWallet
         { balance = ApiByronWalletBalance
-            { available = coinToQuantity $ TokenBundle.getCoin available
-            , total = coinToQuantity $ TokenBundle.getCoin total
+            { available = Coin.toQuantity $ TokenBundle.getCoin available
+            , total = Coin.toQuantity $ TokenBundle.getCoin total
             }
         , assets = ApiWalletAssetsBalance
             { available = ApiT (available ^. #tokens)
@@ -1660,8 +1660,8 @@ getWalletUtxoSnapshot ctx (ApiT wid) = do
     mkApiWalletUtxoSnapshotEntry
         :: (TokenBundle, Coin) -> ApiWalletUtxoSnapshotEntry
     mkApiWalletUtxoSnapshotEntry (bundle, minCoin) = ApiWalletUtxoSnapshotEntry
-        { ada = coinToQuantity $ view #coin bundle
-        , adaMinimum = coinToQuantity minCoin
+        { ada = Coin.toQuantity $ view #coin bundle
+        , adaMinimum = Coin.toQuantity minCoin
         , assets = ApiT $ view #tokens bundle
         }
 
@@ -3444,25 +3444,25 @@ listStakeKeys' utxo lookupStakeRef fetchRewards ourKeysWithInfo = do
         let mkOurs (acc, ix, deleg) = ApiOurStakeKey
                 { _index = ix
                 , _key = (ApiT acc, Proxy)
-                , _rewardBalance = coinToQuantity $
+                , _rewardBalance = Coin.toQuantity $
                     rewards acc
                 , _delegation = deleg
-                , _stake = coinToQuantity $
+                , _stake = Coin.toQuantity $
                     stake (Just acc) <> rewards acc
                 }
 
         let mkForeign acc = ApiForeignStakeKey
                 { _key = (ApiT acc, Proxy)
-                , _rewardBalance = coinToQuantity $
+                , _rewardBalance = Coin.toQuantity $
                     rewards acc
-                , _stake = coinToQuantity $
+                , _stake = Coin.toQuantity $
                     stake (Just acc) <> rewards acc
                 }
 
         let foreignKeys = stakeKeysInUTxO \\ ourKeys
 
         let nullKey = ApiNullStakeKey
-                { _stake = coinToQuantity $ stake Nothing
+                { _stake = Coin.toQuantity $ stake Nothing
                 }
 
         return $ ApiStakeKeys
@@ -3577,7 +3577,7 @@ mkApiWalletMigrationPlan s addresses rewardWithdrawal plan =
             withdrawal (selection {change = []}) s
 
     totalFee :: Quantity "lovelace" Natural
-    totalFee = coinToQuantity $ view #totalFee plan
+    totalFee = Coin.toQuantity $ view #totalFee plan
 
     balanceLeftover :: ApiWalletMigrationBalance
     balanceLeftover = plan
@@ -3600,7 +3600,7 @@ mkApiWalletMigrationPlan s addresses rewardWithdrawal plan =
 
     mkApiWalletMigrationBalance :: TokenBundle -> ApiWalletMigrationBalance
     mkApiWalletMigrationBalance b = ApiWalletMigrationBalance
-        { ada = coinToQuantity $ view #coin b
+        { ada = Coin.toQuantity $ view #coin b
         , assets = ApiT $ view #tokens b
         }
 
@@ -4078,7 +4078,7 @@ mkApiCoinSelection deps refunds mcerts metadata unsignedTx =
             { id = ApiT txid
             , index = index
             , address = (ApiT addr, Proxy @n)
-            , amount = coinToQuantity amount
+            , amount = Coin.toQuantity amount
             , assets = ApiT assets
             , derivationPath = ApiT <$> path
             }
@@ -4086,7 +4086,7 @@ mkApiCoinSelection deps refunds mcerts metadata unsignedTx =
     mkApiCoinSelectionOutput :: output -> ApiCoinSelectionOutput n
     mkApiCoinSelectionOutput (TxOut addr (TokenBundle amount assets)) =
         ApiCoinSelectionOutput (ApiT addr, Proxy @n)
-        (coinToQuantity amount)
+        (Coin.toQuantity amount)
         (ApiT assets)
 
     mkApiCoinSelectionChange :: change -> ApiCoinSelectionChange n
@@ -4095,7 +4095,7 @@ mkApiCoinSelection deps refunds mcerts metadata unsignedTx =
             { address =
                 (ApiT $ view #address txChange, Proxy @n)
             , amount =
-                coinToQuantity $ view #amount txChange
+                Coin.toQuantity $ view #amount txChange
             , assets =
                 ApiT $ view #assets txChange
             , derivationPath =
@@ -4109,7 +4109,7 @@ mkApiCoinSelection deps refunds mcerts metadata unsignedTx =
             { id = ApiT txid
             , index = index
             , address = (ApiT addr, Proxy @n)
-            , amount = coinToQuantity amount
+            , amount = Coin.toQuantity amount
             , derivationPath = ApiT <$> path
             }
 
@@ -4119,7 +4119,7 @@ mkApiCoinSelection deps refunds mcerts metadata unsignedTx =
             { stakeAddress =
                 (ApiT rewardAcct, Proxy @n)
             , amount =
-                coinToQuantity wdrl
+                Coin.toQuantity wdrl
             , derivationPath =
                 ApiT <$> path
             }

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -237,10 +237,6 @@ module Cardano.Wallet.Api.Types
     , ApiBalanceTransactionPostDataT
     , ApiDecodedTransactionT
 
-    -- * API Type Conversions
-    , coinToQuantity
-    , coinFromQuantity
-
     -- * Others
     , defaultRecordTypeOptions
     , strictRecordTypeOptions
@@ -1407,12 +1403,6 @@ data AddressAmountNoAssets addr = AddressAmountNoAssets
     }
     deriving (Eq, Generic, Show)
     deriving anyclass NFData
-
-coinToQuantity :: Integral n => Coin -> Quantity "lovelace" n
-coinToQuantity = Quantity . fromIntegral . unCoin
-
-coinFromQuantity :: Integral n => Quantity "lovelace" n -> Coin
-coinFromQuantity = Coin . fromIntegral . getQuantity
 
 newtype ApiAddressInspect = ApiAddressInspect
     { unApiAddressInspect :: Aeson.Value }

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -3268,7 +3268,7 @@ instance FromJSON a => FromJSON (AddressAmount a) where
             <*> v .:? "assets" .!= mempty
       where
         validateCoin q
-            | coinIsValidForTxOut (coinFromQuantity q) = pure q
+            | coinIsValidForTxOut (Coin.fromQuantity q) = pure q
             | otherwise = fail $
                 "invalid coin value: value has to be lower than or equal to "
                 <> show (unCoin txOutMaxCoin) <> " lovelace."
@@ -3289,7 +3289,7 @@ instance FromJSON (ApiT W.TokenBundle) where
             <*> fmap getApiT (v .: "assets" .!= mempty)
       where
         validateCoin :: Quantity "lovelace" Word64 -> Aeson.Parser Coin
-        validateCoin (coinFromQuantity -> c)
+        validateCoin (Coin.fromQuantity -> c)
             | coinIsValidForTxOut c = pure c
             | otherwise = fail $
                 "invalid coin value: value has to be lower than or equal to "

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -487,6 +487,7 @@ import Web.HttpApiData
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet.Primitive.AddressDerivation as AD
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
@@ -3275,7 +3276,7 @@ instance FromJSON a => FromJSON (AddressAmount a) where
 instance ToJSON (ApiT W.TokenBundle) where
     -- TODO: consider other structures
     toJSON (ApiT (W.TokenBundle c ts)) = object
-        [ "amount" .= coinToQuantity @Word c
+        [ "amount" .= Coin.unsafeToQuantity @Word @"lovelace" c
         , "assets" .= toJSON (ApiT ts)
         ]
 

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -3266,7 +3266,7 @@ instance FromJSON a => FromJSON (AddressAmount a) where
 instance ToJSON (ApiT W.TokenBundle) where
     -- TODO: consider other structures
     toJSON (ApiT (W.TokenBundle c ts)) = object
-        [ "amount" .= Coin.unsafeToQuantity @Word @"lovelace" c
+        [ "amount" .= Coin.unsafeToQuantity @Word c
         , "assets" .= toJSON (ApiT ts)
         ]
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -21,7 +21,7 @@ module Cardano.Wallet.Primitive.Types.Coin
     , toInteger
     , toNatural
     , toQuantityMaybe
-    , toWord64
+    , toWord64Maybe
 
       -- * Conversions (Unsafe)
     , unsafeFromIntegral
@@ -157,8 +157,8 @@ toQuantityMaybe (Coin c) = Quantity <$> intCastMaybe c
 -- Returns 'Nothing' if the given value does not fit within the bounds of a
 -- 64-bit word.
 --
-toWord64 :: Coin -> Maybe Word64
-toWord64 (Coin c) = intCastMaybe c
+toWord64Maybe :: Coin -> Maybe Word64
+toWord64Maybe (Coin c) = intCastMaybe c
 
 --------------------------------------------------------------------------------
 -- Conversions (Unsafe)
@@ -212,7 +212,7 @@ unsafeToQuantity c = fromMaybe onError (toQuantityMaybe c)
 -- Produces a run-time error if the given value is out of bounds.
 --
 unsafeToWord64 :: HasCallStack => Coin -> Word64
-unsafeToWord64 c = fromMaybe onError (toWord64 c)
+unsafeToWord64 c = fromMaybe onError (toWord64Maybe c)
   where
     onError = error $ unwords
         [ "Coin.unsafeToWord64:"

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -20,6 +20,7 @@ module Cardano.Wallet.Primitive.Types.Coin
       -- * Conversions (Safe)
     , fromIntegralMaybe
     , fromNatural
+    , fromQuantity
     , fromWord64
     , toInteger
     , toNatural
@@ -132,6 +133,14 @@ fromIntegralMaybe i = Coin <$> intCastMaybe i
 --
 fromNatural :: Natural -> Coin
 fromNatural = Coin
+
+-- | Constructs a 'Coin' from a 'Quantity'.
+--
+fromQuantity
+    :: (Integral i, IsIntSubType i Natural ~ 'True)
+    => Quantity n i
+    -> Coin
+fromQuantity (Quantity c) = Coin (intCast c)
 
 -- | Constructs a 'Coin' from a 'Word64' value.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK
@@ -20,6 +23,7 @@ module Cardano.Wallet.Primitive.Types.Coin
     , fromWord64
     , toInteger
     , toNatural
+    , toQuantity
     , toQuantityMaybe
     , toWord64Maybe
 
@@ -54,7 +58,7 @@ import Data.Bits
 import Data.Hashable
     ( Hashable )
 import Data.IntCast
-    ( intCast, intCastMaybe )
+    ( IsIntSubType, intCast, intCastMaybe )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
@@ -143,6 +147,14 @@ toInteger = intCast . unCoin
 --
 toNatural :: Coin -> Natural
 toNatural = unCoin
+
+-- | Converts a 'Coin' to a 'Quantity'.
+--
+toQuantity
+    :: (Integral i, IsIntSubType Natural i ~ 'True)
+    => Coin
+    -> Quantity n i
+toQuantity (Coin c) = Quantity (intCast c)
 
 -- | Converts a 'Coin' to a 'Quantity'.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -138,7 +138,7 @@ fromNatural = Coin
 --
 fromQuantity
     :: (Integral i, IsIntSubType i Natural ~ 'True)
-    => Quantity n i
+    => Quantity "lovelace" i
     -> Coin
 fromQuantity (Quantity c) = Coin (intCast c)
 
@@ -162,7 +162,7 @@ toNatural = unCoin
 toQuantity
     :: (Integral i, IsIntSubType Natural i ~ 'True)
     => Coin
-    -> Quantity n i
+    -> Quantity "lovelace" i
 toQuantity (Coin c) = Quantity (intCast c)
 
 -- | Converts a 'Coin' to a 'Quantity'.
@@ -170,7 +170,10 @@ toQuantity (Coin c) = Quantity (intCast c)
 -- Returns 'Nothing' if the given value does not fit within the bounds of
 -- the target type.
 --
-toQuantityMaybe :: (Bits i, Integral i) => Coin -> Maybe (Quantity n i)
+toQuantityMaybe
+    :: (Bits i, Integral i)
+    => Coin
+    -> Maybe (Quantity "lovelace" i)
 toQuantityMaybe (Coin c) = Quantity <$> intCastMaybe c
 
 -- | Converts a 'Coin' to a 'Word64' value.
@@ -216,7 +219,7 @@ unsafeToQuantity
     :: HasCallStack
     => (Bits i, Integral i)
     => Coin
-    -> Quantity n i
+    -> Quantity "lovelace" i
 unsafeToQuantity c = fromMaybe onError (toQuantityMaybe c)
   where
     onError = error $ unwords

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -20,7 +20,7 @@ module Cardano.Wallet.Primitive.Types.Coin
     , fromWord64
     , toInteger
     , toNatural
-    , toQuantity
+    , toQuantityMaybe
     , toWord64
 
       -- * Conversions (Unsafe)
@@ -149,8 +149,8 @@ toNatural = unCoin
 -- Returns 'Nothing' if the given value does not fit within the bounds of
 -- the target type.
 --
-toQuantity :: (Bits i, Integral i) => Coin -> Maybe (Quantity n i)
-toQuantity (Coin c) = Quantity <$> intCastMaybe c
+toQuantityMaybe :: (Bits i, Integral i) => Coin -> Maybe (Quantity n i)
+toQuantityMaybe (Coin c) = Quantity <$> intCastMaybe c
 
 -- | Converts a 'Coin' to a 'Word64' value.
 --
@@ -196,7 +196,7 @@ unsafeToQuantity
     => (Bits i, Integral i)
     => Coin
     -> Quantity n i
-unsafeToQuantity c = fromMaybe onError (toQuantity c)
+unsafeToQuantity c = fromMaybe onError (toQuantityMaybe c)
   where
     onError = error $ unwords
         [ "Coin.unsafeToQuantity:"

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -15,7 +15,7 @@ module Cardano.Wallet.Primitive.Types.Coin
       Coin (..)
 
       -- * Conversions (Safe)
-    , fromIntegral
+    , fromIntegralMaybe
     , fromNatural
     , fromWord64
     , toInteger
@@ -121,8 +121,8 @@ instance Buildable Coin where
 --
 -- Returns 'Nothing' if the given value is negative.
 --
-fromIntegral :: (Bits i, Integral i) => i -> Maybe Coin
-fromIntegral i = Coin <$> intCastMaybe i
+fromIntegralMaybe :: (Bits i, Integral i) => i -> Maybe Coin
+fromIntegralMaybe i = Coin <$> intCastMaybe i
 
 -- | Constructs a 'Coin' from a 'Natural' value.
 --
@@ -176,7 +176,7 @@ unsafeFromIntegral
     => (Bits i, Integral i, Show i)
     => i
     -> Coin
-unsafeFromIntegral i = fromMaybe onError (fromIntegral i)
+unsafeFromIntegral i = fromMaybe onError (fromIntegralMaybe i)
   where
     onError =  error $ unwords
         [ "Coin.unsafeFromIntegral:"

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -473,6 +473,7 @@ import Web.HttpApiData
     ( FromHttpApiData (..) )
 
 import qualified Cardano.Wallet.Api.Types as Api
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
 import qualified Data.Aeson.KeyMap as Aeson
@@ -2682,8 +2683,8 @@ instance Arbitrary ApiWalletUtxoSnapshot where
             adaValue2 <- genCoinPositive
             -- The actual ada quantity of an output's token bundle must be
             -- greater than or equal to the minimum permissible ada quantity:
-            let ada = Api.coinToQuantity $ max adaValue1 adaValue2
-            let adaMinimum = Api.coinToQuantity $ min adaValue1 adaValue2
+            let ada = Coin.toQuantity $ max adaValue1 adaValue2
+            let adaMinimum = Coin.toQuantity $ min adaValue1 adaValue2
             assets <- ApiT <$> genTokenMapSmallRange
             pure ApiWalletUtxoSnapshotEntry
                 { ada

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -232,6 +232,7 @@ import qualified Cardano.Pool.DB as PoolDb
 import qualified Cardano.Pool.DB.Sqlite as Pool
 import qualified Cardano.Wallet.Api.Types as Api
 import qualified Cardano.Wallet.Checkpoints.Policy as CP
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Shelley.Network.Blockfrost.Monad as BFM
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
@@ -584,7 +585,7 @@ combineDbAndLsqData ti nOpt lsqData =
         pure $ Api.ApiStakePool
             { Api.id = ApiT pid
             , Api.metrics = Api.ApiStakePoolMetrics
-                { Api.nonMyopicMemberRewards = Api.coinToQuantity prew
+                { Api.nonMyopicMemberRewards = Coin.toQuantity prew
                 , Api.relativeStake = Quantity pstk
                 , Api.saturation = psat
                 , Api.producedBlocks =
@@ -593,9 +594,9 @@ combineDbAndLsqData ti nOpt lsqData =
             , Api.metadata =
                 ApiT <$> metadata dbData
             , Api.cost =
-                Api.coinToQuantity $ poolCost $ registrationCert dbData
+                Coin.toQuantity $ poolCost $ registrationCert dbData
             , Api.pledge =
-                Api.coinToQuantity $ poolPledge $ registrationCert dbData
+                Coin.toQuantity $ poolPledge $ registrationCert dbData
             , Api.margin =
                 Quantity $ poolMargin $ registrationCert dbData
             , Api.retirement =

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2615,7 +2615,7 @@ balanceTransactionSpec = describe "balanceTransaction" $ do
 distributeSurplusSpec :: Spec
 distributeSurplusSpec = do
     describe "sizeOfCoin" $ do
-        let coinToWord64Clamped = fromMaybe maxBound . Coin.toWord64
+        let coinToWord64Clamped = fromMaybe maxBound . Coin.toWord64Maybe
         let cborSizeOfCoin =
                 TxSize
                 . fromIntegral


### PR DESCRIPTION
## Issue Number

None, though related to #3491.

## Summary

The wallet has a variety of similar functions that convert between `Coin` and `Quantity` values. Some of these conversions are safe, and others are unsafe.

This PR consolidates these conversion functions (removing duplicated functionality) into a single set of functions within the `Coin` module, and uses a consistent naming scheme:

- `{to,from}Type`
  a **_safe_** conversion that's statically guaranteed to succeed;
- `{to,from}TypeMaybe`
  a **_safe_** conversion that may not succeed (requiring a pattern match);
- `unsafe{to,from}Type`
  an **_unsafe_** conversion that may fail with a run-time error.
  
This PR does not make any attempt to remove any usages of unsafe conversions at call sites. However, it does highlight their lack of safety through use of the `unsafe` prefix. Future PRs should replace any unsafe conversions with safe variants, if possible.