### PR TITLE
Blockfrost Metadata unmarshalling uses CBOR not JSON

### DIFF
--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost/Error.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost/Error.hs
@@ -30,6 +30,7 @@ import Data.Text.Class
     ( TextDecodingError )
 
 import qualified Blockfrost.Client as BF
+import qualified Cardano.Binary as Binary
 import qualified Servant.Client as Servant
 
 data BlockfrostError
@@ -37,8 +38,8 @@ data BlockfrostError
     | NoSlotError BF.Block
     | IntegralCastError String
     | InvalidBlockHash BF.BlockHash TextDecodingError
-    | InvalidTxMetadataLabel String
-    | InvalidTxMetadataValue String
+    | MetadataBase16Error String
+    | MetadataCborError Binary.DecoderError
     | InvalidStakePoolMetadataHash Text TextDecodingError
     | PoolRegistrationIsMissing PoolId
     | PoolRetirementCertificateNotFound PoolId BF.PoolUpdate

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost/Layer.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network/Blockfrost/Layer.hs
@@ -34,7 +34,7 @@ import Blockfrost.Client
     , SortOrder (Ascending)
     , Transaction
     , TransactionDelegation
-    , TransactionMetaJSON
+    , TransactionMetaCBOR
     , TransactionStake
     , TransactionUtxos
     , TransactionWithdrawal
@@ -56,7 +56,7 @@ import Blockfrost.Client
     , getPoolHistory'
     , getTx
     , getTxDelegations
-    , getTxMetadataJSON
+    , getTxMetadataCBOR
     , getTxStakes
     , getTxUtxos
     , getTxWithdrawals
@@ -129,8 +129,8 @@ data BlockfrostLayer m = BlockfrostLayer
         TxHash -> m [TransactionWithdrawal]
     , bfGetTxDelegations ::
         TxHash -> m [TransactionDelegation]
-    , bfGetTxMetadataJSON ::
-        TxHash -> m [TransactionMetaJSON]
+    , bfGetTxMetadataCBOR ::
+        TxHash -> m [TransactionMetaCBOR]
     , bfGetAddressTransactions ::
         Address
         -> Maybe BlockIndex
@@ -171,7 +171,7 @@ blockfrostLayer = BlockfrostLayer
     , bfGetTxUtxos = getTxUtxos
     , bfGetTxWithdrawals = getTxWithdrawals
     , bfGetTxDelegations = getTxDelegations
-    , bfGetTxMetadataJSON = getTxMetadataJSON
+    , bfGetTxMetadataCBOR = getTxMetadataCBOR
     , bfGetAddressTransactions = \a f t ->
         empty404 $ allPages' \p -> getAddressTransactions' a p Ascending f t
     , bfGetAccountRegistrations = \a ->
@@ -205,7 +205,7 @@ hoistBlockfrostLayer BlockfrostLayer{..} nt =
     , bfGetTxUtxos = nt . bfGetTxUtxos
     , bfGetTxWithdrawals = nt . bfGetTxWithdrawals
     , bfGetTxDelegations = nt . bfGetTxDelegations
-    , bfGetTxMetadataJSON = nt . bfGetTxMetadataJSON
+    , bfGetTxMetadataCBOR = nt . bfGetTxMetadataCBOR
     , bfGetAddressTransactions = ((nt .) .) . bfGetAddressTransactions
     , bfGetAccountRegistrations = nt . bfGetAccountRegistrations
     , bfGetAccountDelegations = nt . bfGetAccountDelegations

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/Network/BlockfrostSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/Network/BlockfrostSpec.hs
@@ -2,40 +2,81 @@ module Cardano.Wallet.Shelley.Network.BlockfrostSpec (spec) where
 
 import Prelude
 
+import Blockfrost.Client
+    ( TransactionMetaCBOR (..) )
 import Cardano.Api
-    ( AnyCardanoEra (..), CardanoEra (..), NetworkId (Mainnet) )
+    ( AnyCardanoEra (..)
+    , CardanoEra (..)
+    , NetworkId (Mainnet)
+    , TxMetadata (..)
+    , TxMetadataValue (..)
+    )
 import Cardano.Wallet.Primitive.Types
     ( EpochNo )
 import Cardano.Wallet.Shelley.Network.Blockfrost
-    ( eraByEpoch )
+    ( eraByEpoch, unmarshalMetadata )
 import Data.Foldable
     ( for_ )
 import Test.Hspec
     ( Spec, describe, it, shouldBe )
 
+import qualified Data.Map as Map
+
 spec :: Spec
 spec = describe "Blockfrost Network" $ do
     it "determines era by epoch" $ do
+        let epochEras :: [(EpochNo, AnyCardanoEra)]
+            epochEras =
+                [ (329, AnyCardanoEra AlonzoEra)
+                , (298, AnyCardanoEra AlonzoEra)
+                , (297, AnyCardanoEra AlonzoEra)
+                , (295, AnyCardanoEra AlonzoEra)
+                , (290, AnyCardanoEra AlonzoEra)
+                , (289, AnyCardanoEra MaryEra)
+                , (260, AnyCardanoEra MaryEra)
+                , (251, AnyCardanoEra MaryEra)
+                , (250, AnyCardanoEra AllegraEra)
+                , (240, AnyCardanoEra AllegraEra)
+                , (236, AnyCardanoEra AllegraEra)
+                , (235, AnyCardanoEra ShelleyEra)
+                , (220, AnyCardanoEra ShelleyEra)
+                , (208, AnyCardanoEra ShelleyEra)
+                , (207, AnyCardanoEra ByronEra)
+                , (001, AnyCardanoEra ByronEra)
+                , (000, AnyCardanoEra ByronEra)
+                ]
         for_ epochEras $ \(epoch, era) ->
             eraByEpoch Mainnet epoch `shouldBe` Right era
-  where
-    epochEras :: [(EpochNo, AnyCardanoEra)]
-    epochEras =
-        [ (329, AnyCardanoEra AlonzoEra)
-        , (298, AnyCardanoEra AlonzoEra)
-        , (297, AnyCardanoEra AlonzoEra)
-        , (295, AnyCardanoEra AlonzoEra)
-        , (290, AnyCardanoEra AlonzoEra)
-        , (289, AnyCardanoEra MaryEra)
-        , (260, AnyCardanoEra MaryEra)
-        , (251, AnyCardanoEra MaryEra)
-        , (250, AnyCardanoEra AllegraEra)
-        , (240, AnyCardanoEra AllegraEra)
-        , (236, AnyCardanoEra AllegraEra)
-        , (235, AnyCardanoEra ShelleyEra)
-        , (220, AnyCardanoEra ShelleyEra)
-        , (208, AnyCardanoEra ShelleyEra)
-        , (207, AnyCardanoEra ByronEra)
-        , (001, AnyCardanoEra ByronEra)
-        , (000, AnyCardanoEra ByronEra)
-        ]
+
+    it "unmarshals metadata value" $ do
+        let actualResult = unmarshalMetadata
+                [ TransactionMetaCBOR "0" $
+                    Just "A1006763617264616E6F"
+                , TransactionMetaCBOR "1" $
+                    Just "A1010E"
+                , TransactionMetaCBOR "2" $
+                    Just "A10244CAFEBABE"
+                , TransactionMetaCBOR "3" $
+                    Just "A103830E182A6431333337"
+                , TransactionMetaCBOR "4" $
+                    Just "A104A2636B65796576616C75650E182A"
+                ]
+        let expectedResult = Right $ TxMetadata $ Map.fromList
+                [ (0, TxMetaText "cardano")
+                , (1, TxMetaNumber 14)
+                , (2, TxMetaBytes "\xca\xfe\xba\xbe")
+                , (3, TxMetaList
+                        [ TxMetaNumber 14
+                        , TxMetaNumber 42
+                        , TxMetaText "1337"
+                        ]
+                  )
+                , (4, TxMetaMap
+                        [ (TxMetaText "key", TxMetaText "value")
+                        , (TxMetaNumber 14, TxMetaNumber 42)
+                        ]
+                  )
+                ]
+
+        actualResult `shouldBe` expectedResult
+


### PR DESCRIPTION
In the light mode Blockfrost provides metatdata in two flavors:
1. JSON
2. CBOR

Unfortunatly, the JSON representation loses some type information (when transforming keys to strings). 

This PR reworks metadata retrieval functionality to use CBOR to avoid losing type info.

### Issue Number

ADP-2155
