### PR TITLE
Fix: connection status log severity

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Shelley/Network/Node.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Network/Node.hs
@@ -1295,7 +1295,7 @@ instance ToText Log where
 instance HasPrivacyAnnotation Log
 instance HasSeverityAnnotation Log where
     getSeverityAnnotation = \case
-        MsgConnectionStatus{} -> Info
+        MsgConnectionStatus _client msg -> getSeverityAnnotation msg
         MsgTxSubmission{} -> Info
         MsgPostTx{} -> Debug
         MsgLocalStateQuery{} -> Debug


### PR DESCRIPTION
This small PR fixes severity for the connection status log messages: it used to be always `Info` (wrong) 