### PR TITLE
Use `PatternSynonyms` to replace usages of `ViewPatterns`.

### DIFF
--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -5,9 +5,11 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK
@@ -72,6 +74,11 @@ module Test.QuickCheck.Extra
     , ScaleDiv (..)
     , ScaleMod (..)
 
+      -- * Pattern synonyms
+    , pattern ViewFun
+    , pattern ViewFun2
+    , pattern ViewFun3
+
       -- * Utilities
     , interleaveRoundRobin
 
@@ -100,9 +107,13 @@ import Numeric.Natural
     ( Natural )
 import Test.QuickCheck
     ( Arbitrary (..)
+    , Fun (..)
     , Gen
     , Property
     , Testable
+    , applyFun
+    , applyFun2
+    , applyFun3
     , chooseInt
     , chooseInteger
     , counterexample
@@ -930,3 +941,19 @@ infixl 6 <@>
 (<:>) :: (x -> [x]) -> NP (I -.-> []) xs -> NP (I -.-> []) (x : xs)
 a <:> b = liftShrinker a :* b
 infixr 7 <:>
+
+--------------------------------------------------------------------------------
+-- Pattern synonyms
+--------------------------------------------------------------------------------
+
+{-# COMPLETE ViewFun #-}
+pattern ViewFun :: (a -> b) -> Fun a b
+pattern ViewFun f <- (applyFun -> f)
+
+{-# COMPLETE ViewFun2 #-}
+pattern ViewFun2 :: (a -> b -> c) -> Fun (a, b) c
+pattern ViewFun2 f <- (applyFun2 -> f)
+
+{-# COMPLETE ViewFun3 #-}
+pattern ViewFun3 :: (a -> b -> c -> d) -> Fun (a, b, c) d
+pattern ViewFun3 f <- (applyFun3 -> f)

--- a/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -53,7 +54,6 @@ import Test.QuickCheck
     , Property
     , Small (..)
     , Testable
-    , applyFun
     , checkCoverage
     , chooseInteger
     , conjoin
@@ -71,6 +71,7 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Extra
     ( Pretty (..)
+    , pattern ViewFun
     , genShrinkSequence
     , genericRoundRobinShrink
     , interleaveRoundRobin
@@ -744,7 +745,7 @@ prop_shrinkSpace_singleton a =
 --------------------------------------------------------------------------------
 
 prop_shrinkWhile_coverage :: Arbitrary a => Fun a Bool -> a -> Property
-prop_shrinkWhile_coverage (applyFun -> condition) a
+prop_shrinkWhile_coverage (ViewFun condition) a
     = checkCoverage
     $ cover 10
         (isJust shrinkWhileResult)
@@ -757,17 +758,17 @@ prop_shrinkWhile_coverage (applyFun -> condition) a
     shrinkWhileResult = shrinkWhile condition shrink a
 
 prop_shrinkWhile_isNothing :: Arbitrary a => Fun a Bool -> a -> Property
-prop_shrinkWhile_isNothing (applyFun -> condition) a =
+prop_shrinkWhile_isNothing (ViewFun condition) a =
     isNothing (shrinkWhile condition shrink a)
     === (not (condition a) || null (L.find condition (shrink a)))
 
 prop_shrinkWhile_satisfy :: Arbitrary a => Fun a Bool -> a -> Property
-prop_shrinkWhile_satisfy (applyFun -> condition) a =
+prop_shrinkWhile_satisfy (ViewFun condition) a =
     all condition (shrinkWhile condition shrink a)
     === True
 
 prop_shrinkWhileSteps_coverage :: Arbitrary a => Fun a Bool -> a -> Property
-prop_shrinkWhileSteps_coverage (applyFun -> condition) a
+prop_shrinkWhileSteps_coverage (ViewFun condition) a
     = checkCoverage
     $ cover 10
         (null shrinkWhileStepsResult)
@@ -783,7 +784,7 @@ prop_shrinkWhileSteps_coverage (applyFun -> condition) a
     shrinkWhileStepsResult = shrinkWhileSteps condition shrink a
 
 prop_shrinkWhileSteps_satisfy :: Arbitrary a => Fun a Bool -> a -> Property
-prop_shrinkWhileSteps_satisfy (applyFun -> condition) a =
+prop_shrinkWhileSteps_satisfy (ViewFun condition) a =
     all condition (shrinkWhileSteps condition shrink a)
     === True
 

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq/Gen.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- Copyright: © 2022 IOHK
@@ -19,6 +21,7 @@ module Cardano.Wallet.Primitive.Types.Tx.TxSeq.Gen
     (
     -- * Public interface
       ShrinkableTxSeq
+    , pattern ViewTxSeq
     , genTxSeq
     , getTxSeq
     , shrinkTxSeq
@@ -116,6 +119,10 @@ genTxSeq genUTxO genAddr = fmap toShrinkable $ sized $ \size ->
 --
 getTxSeq :: ShrinkableTxSeq -> TxSeq
 getTxSeq = txSeq
+
+{-# COMPLETE ViewTxSeq #-}
+pattern ViewTxSeq :: TxSeq -> ShrinkableTxSeq
+pattern ViewTxSeq s <- (txSeq -> s)
 
 -- | Shrinks a transaction sequence.
 --

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/StateDeltaSeqSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/StateDeltaSeqSpec.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -34,7 +35,6 @@ import Test.QuickCheck
     , Function
     , Gen
     , Property
-    , applyFun
     , arbitraryBoundedEnum
     , checkCoverage
     , choose
@@ -53,6 +53,8 @@ import Test.QuickCheck.Classes
     , functorLaws
     , showLaws
     )
+import Test.QuickCheck.Extra
+    ( pattern ViewFun )
 import Test.Utils.Laws
     ( testLawsMany )
 
@@ -343,7 +345,7 @@ prop_applyDeltas_length (TestStateDeltaSeq seq) deltas =
 prop_countEmptyTransitionsWhere_coverage
     :: TestStateDeltaSeq -> Fun TestDelta Bool -> Property
 prop_countEmptyTransitionsWhere_coverage
-    (TestStateDeltaSeq seq) (applyFun -> f) =
+    (TestStateDeltaSeq seq) (ViewFun f) =
         checkCoverage $
         cover 10
             (strictlyIncreasing [0, matchCount, emptyCount, length seq])
@@ -370,7 +372,7 @@ prop_dropEmptyTransitions_toStateList (TestStateDeltaSeq seq) =
 prop_dropEmptyTransitionWhere_countEmptyTransitionsWhere
     :: TestStateDeltaSeq -> Fun TestDelta Bool -> Property
 prop_dropEmptyTransitionWhere_countEmptyTransitionsWhere
-    (TestStateDeltaSeq seq) (applyFun -> f) =
+    (TestStateDeltaSeq seq) (ViewFun f) =
         all ((== pred emptyTransitionCount) . Seq.countEmptyTransitionsWhere f)
             (Seq.dropEmptyTransitionWhere f seq)
         === True
@@ -380,14 +382,14 @@ prop_dropEmptyTransitionWhere_countEmptyTransitionsWhere
 prop_dropEmptyTransitionWhere_isValid
     :: TestStateDeltaSeq -> Fun TestDelta Bool -> Property
 prop_dropEmptyTransitionWhere_isValid
-    (TestStateDeltaSeq seq) (applyFun -> f) =
+    (TestStateDeltaSeq seq) (ViewFun f) =
         all (Seq.isValid applyTestDelta) (Seq.dropEmptyTransitionWhere f seq)
         === True
 
 prop_dropEmptyTransitionWhere_headState
     :: TestStateDeltaSeq -> Fun TestDelta Bool -> Property
 prop_dropEmptyTransitionWhere_headState
-    (TestStateDeltaSeq seq) (applyFun -> f) =
+    (TestStateDeltaSeq seq) (ViewFun f) =
         all ((== Seq.headState seq) . Seq.headState)
             (Seq.dropEmptyTransitionWhere f seq)
         === True
@@ -395,7 +397,7 @@ prop_dropEmptyTransitionWhere_headState
 prop_dropEmptyTransitionWhere_lastState
     :: TestStateDeltaSeq -> Fun TestDelta Bool -> Property
 prop_dropEmptyTransitionWhere_lastState
-    (TestStateDeltaSeq seq) (applyFun -> f) =
+    (TestStateDeltaSeq seq) (ViewFun f) =
         all ((== Seq.lastState seq) . Seq.lastState)
             (Seq.dropEmptyTransitionWhere f seq)
         === True
@@ -403,7 +405,7 @@ prop_dropEmptyTransitionWhere_lastState
 prop_dropEmptyTransitionWhere_length
     :: TestStateDeltaSeq -> Fun TestDelta Bool -> Property
 prop_dropEmptyTransitionWhere_length
-    (TestStateDeltaSeq seq) (applyFun -> f) =
+    (TestStateDeltaSeq seq) (ViewFun f) =
         length (Seq.dropEmptyTransitionWhere f seq)
         === Seq.countEmptyTransitionsWhere f seq
 
@@ -414,35 +416,35 @@ prop_dropEmptyTransitionWhere_length
 prop_dropEmptyTransitionsWhere_countEmptyTransitionsWhere
     :: TestStateDeltaSeq -> Fun TestDelta Bool -> Property
 prop_dropEmptyTransitionsWhere_countEmptyTransitionsWhere
-    (TestStateDeltaSeq seq) (applyFun -> f) =
+    (TestStateDeltaSeq seq) (ViewFun f) =
         Seq.countEmptyTransitionsWhere f (Seq.dropEmptyTransitionsWhere f seq)
         === 0
 
 prop_dropEmptyTransitionsWhere_isValid
     :: TestStateDeltaSeq -> Fun TestDelta Bool -> Property
 prop_dropEmptyTransitionsWhere_isValid
-    (TestStateDeltaSeq seq) (applyFun -> f) =
+    (TestStateDeltaSeq seq) (ViewFun f) =
         Seq.isValid applyTestDelta (Seq.dropEmptyTransitionsWhere f seq)
         === True
 
 prop_dropEmptyTransitionsWhere_headState
     :: TestStateDeltaSeq -> Fun TestDelta Bool -> Property
 prop_dropEmptyTransitionsWhere_headState
-    (TestStateDeltaSeq seq) (applyFun -> f) =
+    (TestStateDeltaSeq seq) (ViewFun f) =
         Seq.headState (Seq.dropEmptyTransitionsWhere f seq)
         === Seq.headState seq
 
 prop_dropEmptyTransitionsWhere_lastState
     :: TestStateDeltaSeq -> Fun TestDelta Bool -> Property
 prop_dropEmptyTransitionsWhere_lastState
-    (TestStateDeltaSeq seq) (applyFun -> f) =
+    (TestStateDeltaSeq seq) (ViewFun f) =
         Seq.lastState (Seq.dropEmptyTransitionsWhere f seq)
         === Seq.lastState seq
 
 prop_dropEmptyTransitionsWhere_length
     :: TestStateDeltaSeq -> Fun TestDelta Bool -> Property
 prop_dropEmptyTransitionsWhere_length
-    (TestStateDeltaSeq seq) (applyFun -> f) =
+    (TestStateDeltaSeq seq) (ViewFun f) =
         length (Seq.dropEmptyTransitionsWhere f seq)
             + Seq.countEmptyTransitionsWhere f seq
         === length seq

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -4,11 +4,11 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {- HLINT ignore "Use camelCase" -}
 {- HLINT ignore "Functor law" -}
@@ -122,6 +122,8 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Classes
     ( eqLaws, monoidLaws, ordLaws, semigroupLaws, semigroupMonoidLaws )
+import Test.QuickCheck.Extra
+    ( pattern ViewFun )
 import Test.QuickCheck.Instances.ByteString
     ()
 import Test.Utils.Laws
@@ -739,7 +741,7 @@ prop_mapAssetIds_identity m =
 
 prop_mapAssetIds_composition
     :: TokenMap -> Fun AssetId AssetId -> Fun AssetId AssetId -> Property
-prop_mapAssetIds_composition m (applyFun -> f) (applyFun -> g) =
+prop_mapAssetIds_composition m (ViewFun f) (ViewFun g) =
     TokenMap.mapAssetIds f (TokenMap.mapAssetIds g m) ===
     TokenMap.mapAssetIds (f . g) m
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -43,7 +44,6 @@ import Test.QuickCheck
     , Function (..)
     , Property
     , Testable (..)
-    , applyFun
     , checkCoverage
     , chooseInt
     , cover
@@ -54,7 +54,12 @@ import Test.QuickCheck
     , (==>)
     )
 import Test.QuickCheck.Extra
-    ( ScaleDiv (..), genShrinkSequence, labelInterval, shrinkWhile )
+    ( ScaleDiv (..)
+    , pattern ViewFun
+    , genShrinkSequence
+    , labelInterval
+    , shrinkWhile
+    )
 import Test.QuickCheck.Instances.ByteString
     ()
 
@@ -415,7 +420,7 @@ prop_shrinkTxSeq_genShrinkSequence_length =
 --------------------------------------------------------------------------------
 
 prop_mapAssetIds_assetIds :: ShrinkableTxSeq -> Fun AssetId AssetId -> Property
-prop_mapAssetIds_assetIds (getTxSeq -> txSeq) (applyFun -> f) =
+prop_mapAssetIds_assetIds (getTxSeq -> txSeq) (ViewFun f) =
     TxSeq.assetIds (TxSeq.mapAssetIds f txSeq)
     ===
     Set.map f (TxSeq.assetIds txSeq)
@@ -426,7 +431,7 @@ prop_mapAssetIds_composition
     -> Fun AssetId AssetId
     -> Property
 prop_mapAssetIds_composition
-    (getTxSeq -> txSeq) (applyFun -> f) (applyFun -> g) =
+    (getTxSeq -> txSeq) (ViewFun f) (ViewFun g) =
         TxSeq.mapAssetIds f (TxSeq.mapAssetIds g txSeq) ===
         TxSeq.mapAssetIds (f . g) txSeq
 
@@ -438,7 +443,7 @@ prop_mapAssetIds_isValid
     :: ScaleDiv 2 ShrinkableTxSeq
     -> Fun AssetId AssetId
     -> Property
-prop_mapAssetIds_isValid (getTxSeq . unScaleDiv -> txSeq) (applyFun -> f) =
+prop_mapAssetIds_isValid (getTxSeq . unScaleDiv -> txSeq) (ViewFun f) =
     -- Validity is maintained regardless of whether the specified mapping
     -- function is injective w.r.t. the set of asset identifiers in the
     -- given sequence.
@@ -455,7 +460,7 @@ prop_mapAssetIds_isValid (getTxSeq . unScaleDiv -> txSeq) (applyFun -> f) =
 
 prop_mapTxIds_txIds
     :: ShrinkableTxSeq -> Fun (Hash "Tx") (Hash "Tx") -> Property
-prop_mapTxIds_txIds (getTxSeq -> txSeq) (applyFun -> f) =
+prop_mapTxIds_txIds (getTxSeq -> txSeq) (ViewFun f) =
     TxSeq.txIds (TxSeq.mapTxIds f txSeq) === Set.map f (TxSeq.txIds txSeq)
 
 prop_mapTxIds_composition
@@ -463,7 +468,7 @@ prop_mapTxIds_composition
     -> Fun (Hash "Tx") (Hash "Tx")
     -> Fun (Hash "Tx") (Hash "Tx")
     -> Property
-prop_mapTxIds_composition (getTxSeq -> txSeq) (applyFun -> f) (applyFun -> g) =
+prop_mapTxIds_composition (getTxSeq -> txSeq) (ViewFun f) (ViewFun g) =
     TxSeq.mapTxIds f (TxSeq.mapTxIds g txSeq) ===
     TxSeq.mapTxIds (f . g) txSeq
 
@@ -473,7 +478,7 @@ prop_mapTxIds_identity (getTxSeq -> txSeq) =
 
 prop_mapTxIds_isValid
     :: ShrinkableTxSeq -> Fun (Hash "Tx") (Hash "Tx") -> Property
-prop_mapTxIds_isValid (getTxSeq -> txSeq) (applyFun -> f) =
+prop_mapTxIds_isValid (getTxSeq -> txSeq) (ViewFun f) =
     -- Validity is only guaranteed if the specified mapping function is
     -- injective w.r.t. the set of transaction identifiers in the given
     -- sequence.

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {- HLINT ignore "Hoist not" -}
 
@@ -449,7 +448,7 @@ prop_mapAssetIds_isValid
     :: ScaleDiv 2 ShrinkableTxSeq
     -> Fun AssetId AssetId
     -> Property
-prop_mapAssetIds_isValid (unScaleDiv -> (ViewTxSeq txSeq)) (ViewFun f) =
+prop_mapAssetIds_isValid (ScaleDiv (ViewTxSeq txSeq)) (ViewFun f) =
     -- Validity is maintained regardless of whether the specified mapping
     -- function is injective w.r.t. the set of asset identifiers in the
     -- given sequence.

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/TxSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/TxSpec.hs
@@ -3,8 +3,8 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
@@ -61,10 +61,11 @@ import Test.QuickCheck
     , Fun (..)
     , Function (..)
     , Property
-    , applyFun
     , property
     , (===)
     )
+import Test.QuickCheck.Extra
+    ( pattern ViewFun )
 import Test.QuickCheck.Instances.ByteString
     ()
 
@@ -135,7 +136,7 @@ prop_txMapAssetIds_identity m =
 
 prop_txMapAssetIds_composition
     :: Tx -> Fun AssetId AssetId -> Fun AssetId AssetId -> Property
-prop_txMapAssetIds_composition m (applyFun -> f) (applyFun -> g) =
+prop_txMapAssetIds_composition m (ViewFun f) (ViewFun g) =
     txMapAssetIds f (txMapAssetIds g m) ===
     txMapAssetIds (f . g) m
 
@@ -148,7 +149,7 @@ prop_txMapTxIds_composition
     -> Fun (Hash "Tx") (Hash "Tx")
     -> Fun (Hash "Tx") (Hash "Tx")
     -> Property
-prop_txMapTxIds_composition m (applyFun -> f) (applyFun -> g) =
+prop_txMapTxIds_composition m (ViewFun f) (ViewFun g) =
     txMapTxIds f (txMapTxIds g m) ===
     txMapTxIds (f . g) m
 
@@ -171,7 +172,7 @@ prop_txOutMapAssetIds_identity m =
 
 prop_txOutMapAssetIds_composition
     :: TxOut -> Fun AssetId AssetId -> Fun AssetId AssetId -> Property
-prop_txOutMapAssetIds_composition m (applyFun -> f) (applyFun -> g) =
+prop_txOutMapAssetIds_composition m (ViewFun f) (ViewFun g) =
     txOutMapAssetIds f (txOutMapAssetIds g m) ===
     txOutMapAssetIds (f . g) m
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -4,8 +4,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {- HLINT ignore "Use camelCase" -}
 
@@ -63,13 +63,14 @@ import Test.QuickCheck
     , Function (..)
     , Property
     , Testable
-    , applyFun
     , checkCoverage
     , conjoin
     , cover
     , property
     , (===)
     )
+import Test.QuickCheck.Extra
+    ( pattern ViewFun )
 import Test.QuickCheck.Instances.ByteString
     ()
 
@@ -320,7 +321,7 @@ prop_mapAssetIds_composition
     -> Fun AssetId AssetId
     -> Fun AssetId AssetId
     -> Property
-prop_mapAssetIds_composition m (applyFun -> f) (applyFun -> g) =
+prop_mapAssetIds_composition m (ViewFun f) (ViewFun g) =
     UTxO.mapAssetIds f (UTxO.mapAssetIds g m) ===
     UTxO.mapAssetIds (f . g) m
 
@@ -333,7 +334,7 @@ prop_mapTxIds_composition
     -> Fun (Hash "Tx") (Hash "Tx")
     -> Fun (Hash "Tx") (Hash "Tx")
     -> Property
-prop_mapTxIds_composition m (applyFun -> f) (applyFun -> g) =
+prop_mapTxIds_composition m (ViewFun f) (ViewFun g) =
     UTxO.mapTxIds f (UTxO.mapTxIds g m) ===
     UTxO.mapTxIds (f . g) m
 

--- a/lib/wallet/test/unit/Control/Monad/UtilSpec.hs
+++ b/lib/wallet/test/unit/Control/Monad/UtilSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -29,12 +30,13 @@ import Test.QuickCheck
     ( Fun (..)
     , NonNegative (..)
     , Property
-    , applyFun
     , conjoin
     , property
     , withMaxSuccess
     , (===)
     )
+import Test.QuickCheck.Extra
+    ( pattern ViewFun )
 
 spec :: Spec
 spec = describe "Control.Monad.UtilSpec" $ do
@@ -70,7 +72,7 @@ spec = describe "Control.Monad.UtilSpec" $ do
 
 prop_applyNM_applyN
     :: (Eq a, Show a) => Int -> Fun a a -> a -> Property
-prop_applyNM_applyN n (applyFun -> f) a =
+prop_applyNM_applyN n (ViewFun f) a =
     applyNM n (Identity <$> f) a === Identity (applyN n f a)
 
 prop_applyNM_iterate
@@ -79,14 +81,14 @@ prop_applyNM_iterate
     -> Fun a (m a)
     -> a
     -> Property
-prop_applyNM_iterate (getNonNegative -> n) (applyFun -> f) a =
+prop_applyNM_iterate (getNonNegative -> n) (ViewFun f) a =
     applyNM n f a === applyNM_iterate n f a
   where
     applyNM_iterate n' f' = (!! n') . iterate (f' =<<) . pure
 
 prop_applyNM_unit
     :: (Monad m, Eq (m a), Show (m a)) => Fun a (m a) -> a -> Property
-prop_applyNM_unit (applyFun -> f) a = conjoin
+prop_applyNM_unit (ViewFun f) a = conjoin
     [ applyNM 0 f a === pure a
     , applyNM 1 f a === f a
     , applyNM 2 f a === (f <=< f) a


### PR DESCRIPTION
## Issue Number

Follow-up PR from #3483 (ADP-2230)

## Description

This PR introduces various pattern synonyms and uses them to replace usages of `ViewPatterns`.

Not all usages of `ViewPatterns` are tackled in this PR. If we decide to use this approach, then subsequent PRs can make further progress.