### PR TITLE
Decorate individual Txs instead of the entire TxHistory

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -105,7 +105,7 @@ import Cardano.Wallet.DB.Store.Meta.Model
 import Cardano.Wallet.DB.Store.Submissions.Model
     ( TxLocalSubmissionHistory (..) )
 import Cardano.Wallet.DB.Store.Transactions.Model
-    ( TxHistoryF (..), decorateTxIns, withdrawals )
+    ( TxHistory (..), decorateTxIns, withdrawals )
 import Cardano.Wallet.DB.Store.TransactionsWithCBOR.Model
     ( TxHistoryWithCBOR (TxHistoryWithCBOR) )
 import Cardano.Wallet.DB.Store.Wallets.Model

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -105,7 +105,7 @@ import Cardano.Wallet.DB.Store.Meta.Model
 import Cardano.Wallet.DB.Store.Submissions.Model
     ( TxLocalSubmissionHistory (..) )
 import Cardano.Wallet.DB.Store.Transactions.Model
-    ( TxHistoryF (..), decorateWithTxOuts, withdrawals )
+    ( TxHistoryF (..), decorateTxIns, withdrawals )
 import Cardano.Wallet.DB.Store.TransactionsWithCBOR.Model
     ( TxHistoryWithCBOR (TxHistoryWithCBOR) )
 import Cardano.Wallet.DB.Store.Wallets.Model
@@ -1047,9 +1047,11 @@ selectTxHistory cp ti wid minWithdrawal order whichMeta
             (\coin -> any (>= coin)
                 $ txWithdrawalAmount <$>  withdrawals transaction)
             minWithdrawal
+        let decoration = decorateTxIns txHistory transaction
         pure $ mkTransactionInfo
             ti (W.currentTip cp)
                 transaction
+                decoration
                 (Map.lookup (txMetaTxId meta) txCBORHistory)
                 meta
     pure $ sortTx tinfos
@@ -1059,7 +1061,7 @@ selectTxHistory cp ti wid minWithdrawal order whichMeta
                 $ (,) <$> slotNo . txInfoMeta <*> Down . txInfoId
             W.Descending -> sortOn
                 $ (,) <$> (Down . slotNo . txInfoMeta) <*> txInfoId
-        TxHistoryF txs = decorateWithTxOuts txHistory
+        TxHistoryF txs = txHistory
 
 
 -- | Returns the initial submission slot and submission record for all pending

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -1061,7 +1061,7 @@ selectTxHistory cp ti wid minWithdrawal order whichMeta
                 $ (,) <$> slotNo . txInfoMeta <*> Down . txInfoId
             W.Descending -> sortOn
                 $ (,) <$> (Down . slotNo . txInfoMeta) <*> txInfoId
-        TxHistoryF txs = txHistory
+        TxHistory txs = txHistory
 
 
 -- | Returns the initial submission slot and submission record for all pending

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -96,7 +96,7 @@ import qualified Data.Map.Strict as Map
  but they are not removed from the data.
 -}
 data TxRelation =
-    TxRelationF
+    TxRelation
     { ins :: [TxIn]
     , collateralIns :: [TxCollateral]
     , outs :: [(TxOut, [TxOutToken])]
@@ -239,7 +239,7 @@ mkTxWithdrawal tid (txWithdrawalAccount,txWithdrawalAmount) =
 
 mkTxRelation :: W.Tx -> TxRelation
 mkTxRelation tx =
-    TxRelationF
+    TxRelation
     { ins = fmap (mkTxIn tid) $ indexed . W.resolvedInputs $ tx
     , collateralIns =
           fmap (mkTxCollateral tid) $ indexed $ W.resolvedCollateralInputs tx
@@ -333,7 +333,7 @@ lookupTxOutForTxCollateral tx =
 -- by searching the 'TxHistory' for corresponding output values.
 decorateTxIns
     :: TxHistory -> TxRelation -> DecoratedTxIns
-decorateTxIns (TxHistory relations) TxRelationF{ins,collateralIns} =
+decorateTxIns (TxHistory relations) TxRelation{ins,collateralIns} =
     DecoratedTxIns . Map.fromList . catMaybes $
         (lookupOutput . toKeyTxIn <$> ins)
         ++ (lookupOutput . toKeyTxCollateral <$> collateralIns)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -107,15 +107,15 @@ data TxRelation =
 
 -- | Transactions history is 'TxRelation's indexed by 'TxId'
 newtype TxHistory =
-    TxHistoryF { relations :: Map TxId TxRelation }
+    TxHistory { relations :: Map TxId TxRelation }
     deriving ( Generic, Eq, Show )
 
 instance Monoid TxHistory where
-    mempty = TxHistoryF mempty
+    mempty = TxHistory mempty
 
 instance Semigroup TxHistory where
-    TxHistoryF h1 <> TxHistoryF h2 =
-        TxHistoryF $ h1 <> h2
+    TxHistory h1 <> TxHistory h2 =
+        TxHistory $ h1 <> h2
 
 instance Buildable TxHistory where
     build txs = "TxHistory " <> build (show $ relations txs)
@@ -137,8 +137,8 @@ instance Delta DeltaTxHistory where
     -- transactions are immutable so here there should happen no rewriting
     -- but we mimic the repsert in the store
     apply (Append txs) h = txs <> h
-    apply (DeleteTx tid) (TxHistoryF txs) =
-        TxHistoryF $ Map.delete tid txs
+    apply (DeleteTx tid) (TxHistory txs) =
+        TxHistory $ Map.delete tid txs
 
 {-------------------------------------------------------------------------------
     Type conversions
@@ -255,7 +255,7 @@ mkTxRelation tx =
 
 -- | Convert high level transactions definition in low level DB history
 mkTxHistory :: [W.Tx] -> TxHistory
-mkTxHistory txs = TxHistoryF $ fold $ do
+mkTxHistory txs = TxHistory $ fold $ do
     tx <- txs
     let relation = mkTxRelation tx
     pure $ Map.singleton (TxId $ tx ^. #txId) relation
@@ -333,7 +333,7 @@ lookupTxOutForTxCollateral tx =
 -- by searching the 'TxHistory' for corresponding output values.
 decorateTxIns
     :: TxHistory -> TxRelation -> DecoratedTxIns
-decorateTxIns (TxHistoryF relations) TxRelationF{ins,collateralIns} =
+decorateTxIns (TxHistory relations) TxRelationF{ins,collateralIns} =
     DecoratedTxIns . Map.fromList . catMaybes $
         (lookupOutput . toKeyTxIn <$> ins)
         ++ (lookupOutput . toKeyTxCollateral <$> collateralIns)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
@@ -33,11 +33,9 @@ import Cardano.Wallet.DB.Sqlite.Schema
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId )
 import Cardano.Wallet.DB.Store.Transactions.Model
-    ( Decoration (Without)
-    , DeltaTxHistory (..)
-    , TxHistory
-    , TxHistoryF (TxHistoryF)
-    , TxRelationF (..)
+    ( DeltaTxHistory (..)
+    , TxHistory (..)
+    , TxRelation (..)
     , tokenCollateralOrd
     , tokenOutOrd
     )
@@ -126,7 +124,7 @@ selectTxHistory :: SqlPersistT IO TxHistory
 selectTxHistory = TxHistoryF <$> select
   where
     selectListAll = selectList [] []
-    select :: SqlPersistT IO (Map TxId (TxRelationF 'Without))
+    select :: SqlPersistT IO (Map TxId TxRelation)
     select = do
         inputs <- mkMap txInputTxId selectListAll
         collaterals <- mkMap txCollateralTxId selectListAll

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
@@ -103,7 +103,7 @@ write txs = do
 
 -- | Insert multiple transactions
 putTxHistory :: TxHistory -> SqlPersistT IO ()
-putTxHistory (TxHistoryF tx_map) = forM_ tx_map $ \TxRelationF {..} -> do
+putTxHistory (TxHistory tx_map) = forM_ tx_map $ \TxRelationF {..} -> do
     repsertMany' ins
     repsertMany' collateralIns
     repsertMany' $ fst <$> outs
@@ -121,7 +121,7 @@ putTxHistory (TxHistoryF tx_map) = forM_ tx_map $ \TxRelationF {..} -> do
 
 -- | Select transactions history from the database
 selectTxHistory :: SqlPersistT IO TxHistory
-selectTxHistory = TxHistoryF <$> select
+selectTxHistory = TxHistory <$> select
   where
     selectListAll = selectList [] []
     select :: SqlPersistT IO (Map TxId TxRelation)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
@@ -103,7 +103,7 @@ write txs = do
 
 -- | Insert multiple transactions
 putTxHistory :: TxHistory -> SqlPersistT IO ()
-putTxHistory (TxHistory tx_map) = forM_ tx_map $ \TxRelationF {..} -> do
+putTxHistory (TxHistory tx_map) = forM_ tx_map $ \TxRelation {..} -> do
     repsertMany' ins
     repsertMany' collateralIns
     repsertMany' $ fst <$> outs
@@ -157,7 +157,7 @@ selectTxHistory = TxHistory <$> select
             k <- toList ids
             pure
                 $ Map.singleton k
-                $ TxRelationF
+                $ TxRelation
                 { ins = sortOn txInputOrder $ Map.findWithDefault [] k inputs
                 , collateralIns = sortOn txCollateralOrder
                       $ Map.findWithDefault [] k collaterals

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -174,7 +174,7 @@ mkTransactionInfo :: Monad m
     -> Maybe TxCBOR
     -> DB.TxMeta
     -> m WT.TransactionInfo
-mkTransactionInfo ti tip TxRelationF{..} decor txCBOR DB.TxMeta{..} = do
+mkTransactionInfo ti tip TxRelation{..} decor txCBOR DB.TxMeta{..} = do
     txTime <- interpretQuery ti . slotToUTCTime $ txMetaSlot
     return
         $ WT.TransactionInfo

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -26,15 +26,7 @@ module Cardano.Wallet.DB.Store.Wallets.Model
 import Prelude
 
 import Cardano.Wallet.DB.Sqlite.Schema
-    ( TxCollateral (..)
-    , TxCollateralOut (..)
-    , TxCollateralOutToken (..)
-    , TxIn (..)
-    , TxMeta (..)
-    , TxOut (..)
-    , TxOutToken (..)
-    , TxWithdrawal (..)
-    )
+    ( TxCollateral (..), TxIn (..), TxMeta (..), TxWithdrawal (..) )
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.CBOR.Model
@@ -44,20 +36,22 @@ import Cardano.Wallet.DB.Store.Meta.Model
 import Cardano.Wallet.DB.Store.Submissions.Model
     ( DeltaTxLocalSubmission (..), TxLocalSubmissionHistory (..) )
 import Cardano.Wallet.DB.Store.Transactions.Model
-    ( Decoration (With)
+    ( DecoratedTxIns
+    , Decoration (Without)
     , TxHistoryF (..)
     , TxRelationF (..)
-    , WithTxOut (..)
+    , fromTxCollateralOut
+    , fromTxOut
+    , lookupTxOutForTxCollateral
+    , lookupTxOutForTxIn
     , mkTxHistory
     )
 import Cardano.Wallet.DB.Store.TransactionsWithCBOR.Model
     ( TxHistoryWithCBOR (..) )
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter, interpretQuery, slotToUTCTime )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (AssetId) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( Tx (..), TxCBOR, TxMeta (..), TxOut (..) )
+    ( Tx (..), TxCBOR, TxMeta (..) )
 import Data.Delta
     ( Delta (..) )
 import Data.DeltaMap
@@ -86,7 +80,6 @@ import qualified Cardano.Wallet.DB.Store.Meta.Model as TxMetaStore
 import qualified Cardano.Wallet.DB.Store.TransactionsWithCBOR.Model as TxStore
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as WC
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx as WT
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -177,11 +170,12 @@ walletsLinkedTransactions = Set.unions . toList . fmap linkedTransactions
 mkTransactionInfo :: Monad m
     => TimeInterpreter m
     -> W.BlockHeader
-    -> TxRelationF 'With
+    -> TxRelationF 'Without
+    -> DecoratedTxIns
     -> Maybe TxCBOR
     -> DB.TxMeta
     -> m WT.TransactionInfo
-mkTransactionInfo ti tip TxRelationF{..} txCBOR DB.TxMeta{..} = do
+mkTransactionInfo ti tip TxRelationF{..} decor txCBOR DB.TxMeta{..} = do
     txTime <- interpretQuery ti . slotToUTCTime $ txMetaSlot
     return
         $ WT.TransactionInfo
@@ -190,8 +184,8 @@ mkTransactionInfo ti tip TxRelationF{..} txCBOR DB.TxMeta{..} = do
         , WT.txInfoFee = WC.Coin . fromIntegral <$> txMetaFee
         , WT.txInfoInputs = mkTxIn <$> ins
         , WT.txInfoCollateralInputs = mkTxCollateral <$> collateralIns
-        , WT.txInfoOutputs = mkTxOut <$> outs
-        , WT.txInfoCollateralOutput = mkTxCollateralOut <$> collateralOuts
+        , WT.txInfoOutputs = fromTxOut <$> outs
+        , WT.txInfoCollateralOutput = fromTxCollateralOut <$> collateralOuts
         , WT.txInfoWithdrawals = Map.fromList $ map mkTxWithdrawal withdrawals
         , WT.txInfoMeta = WT.TxMeta
               { WT.status = txMetaStatus
@@ -214,40 +208,20 @@ mkTransactionInfo ti tip TxRelationF{..} txCBOR DB.TxMeta{..} = do
         }
   where
     tipH = getQuantity $ tip ^. #blockHeight
-    mkTxIn (WithTxOut tx out) =
+    mkTxIn tx =
         ( WT.TxIn
           { WT.inputId = getTxId (txInputSourceTxId tx)
           , WT.inputIx = txInputSourceIndex tx
           }
         , txInputSourceAmount tx
-        , mkTxOut <$> out)
-    mkTxCollateral (WithTxOut tx out) =
+        , lookupTxOutForTxIn tx decor
+        )
+    mkTxCollateral tx =
         ( WT.TxIn
           { WT.inputId = getTxId (txCollateralSourceTxId tx)
           , WT.inputIx = txCollateralSourceIndex tx
           }
         , txCollateralSourceAmount tx
-        , mkTxOut <$> out)
-    mkTxOut (out,tokens) =
-        WT.TxOut
-        { address = txOutputAddress out
-        , WT.tokens = TokenBundle.fromFlatList
-              (txOutputAmount out)
-              (mkTxOutToken <$> tokens)
-        }
-    mkTxOutToken token =
-        ( AssetId (txOutTokenPolicyId token) (txOutTokenName token)
-        , txOutTokenQuantity token)
-    mkTxCollateralOut (out,tokens) =
-        WT.TxOut
-        { address = txCollateralOutAddress out
-        , WT.tokens = TokenBundle.fromFlatList
-              (txCollateralOutAmount out)
-              (mkTxCollateralOutToken <$> tokens)
-        }
-    mkTxCollateralOutToken token =
-        ( AssetId
-              (txCollateralOutTokenPolicyId token)
-              (txCollateralOutTokenName token)
-        , txCollateralOutTokenQuantity token)
+        , lookupTxOutForTxCollateral tx decor
+        )
     mkTxWithdrawal w = (txWithdrawalAccount w, txWithdrawalAmount w)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -37,9 +37,8 @@ import Cardano.Wallet.DB.Store.Submissions.Model
     ( DeltaTxLocalSubmission (..), TxLocalSubmissionHistory (..) )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( DecoratedTxIns
-    , Decoration (Without)
-    , TxHistoryF (..)
-    , TxRelationF (..)
+    , TxHistory (..)
+    , TxRelation (..)
     , fromTxCollateralOut
     , fromTxOut
     , lookupTxOutForTxCollateral
@@ -165,12 +164,12 @@ walletsLinkedTransactions
 walletsLinkedTransactions = Set.unions . toList . fmap linkedTransactions
 
 -- | Compute a high level view of a transaction known as 'TransactionInfo'
--- from a 'TxMeta' and a 'TxRelationF'.
+-- from a 'TxMeta' and a 'TxRelation'.
 -- Assumes that these data refer to the same 'TxId', does /not/ check this.
 mkTransactionInfo :: Monad m
     => TimeInterpreter m
     -> W.BlockHeader
-    -> TxRelationF 'Without
+    -> TxRelation
     -> DecoratedTxIns
     -> Maybe TxCBOR
     -> DB.TxMeta

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -138,12 +138,12 @@ instance Delta DeltaTxWalletsHistory where
             $ mtxmh & apply (Adjust wid change)
             )
     apply GarbageCollectTxWalletsHistory
-        (TxHistoryWithCBOR (TxHistoryF txh) (TxCBORHistory cborh) , mtxmh) =
+        (TxHistoryWithCBOR (TxHistory txh) (TxCBORHistory cborh) , mtxmh) =
             let gc :: Map TxId x -> Map TxId x
                 gc x = Map.restrictKeys x
                     $ walletsLinkedTransactions mtxmh
             in (TxHistoryWithCBOR
-                (TxHistoryF $ gc txh)
+                (TxHistory $ gc txh)
                 (TxCBORHistory $ gc cborh)
                     , mtxmh)
     apply (RemoveWallet wid) (x , mtxmh) = (x, Map.delete wid mtxmh)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -155,7 +155,7 @@ mkStoreTxWalletsHistory =
     , writeS = \(txHistory,txMetaHistory) -> do
           writeS mkStoreTransactionsWithCBOR txHistory
           writeS mkStoreWalletsMetaWithSubmissions txMetaHistory
-    , updateS = \(txh@(TxHistoryWithCBOR (TxHistoryF mtxh) _) ,mtxmh) -> \case
+    , updateS = \(txh@(TxHistoryWithCBOR (TxHistory mtxh) _) ,mtxmh) -> \case
             ChangeTxMetaWalletsHistory wid change
                 -> updateS mkStoreWalletsMetaWithSubmissions mtxmh
                 $ Adjust wid change

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -34,7 +34,7 @@ import Cardano.Wallet.DB.Store.Submissions.Model
 import Cardano.Wallet.DB.Store.Submissions.Store
     ( mkStoreSubmissions )
 import Cardano.Wallet.DB.Store.Transactions.Model
-    ( TxHistoryF (..) )
+    ( TxHistory (..) )
 import Cardano.Wallet.DB.Store.TransactionsWithCBOR.Model
     ( DeltaTx (..), TxHistoryWithCBOR (TxHistoryWithCBOR) )
 import Cardano.Wallet.DB.Store.TransactionsWithCBOR.Store

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -87,9 +87,9 @@ prop_DecorateLinksTxInToTxOuts = do
             let guinea' = set #resolvedInputs txins guinea
             pure (guineaId, mkTxHistory (guinea' : transactions), txouts)
 
-    forAll transactionsGen $ \(txid, TxHistoryF history, txouts) ->
+    forAll transactionsGen $ \(txid, TxHistory history, txouts) ->
         let guinea = history Map.! txid
-            deco   = decorateTxIns (TxHistoryF history) guinea
+            deco   = decorateTxIns (TxHistory history) guinea
         in  [ lookupTxOutForTxIn txin deco | txin <- ins guinea]
             === map Just txouts
 
@@ -114,9 +114,9 @@ prop_DecorateLinksTxCollateralsToTxOuts = do
             let guinea' = set #resolvedCollateralInputs txins guinea
             pure (guineaId, mkTxHistory (guinea' : transactions), txouts)
 
-    forAll transactionsGen $ \(txid, TxHistoryF history, txouts) ->
+    forAll transactionsGen $ \(txid, TxHistory history, txouts) ->
         let guinea = history Map.! txid
-            deco   = decorateTxIns (TxHistoryF history) guinea
+            deco   = decorateTxIns (TxHistory history) guinea
         in  [ lookupTxOutForTxCollateral txcol deco
             | txcol <- collateralIns guinea
             ]
@@ -132,7 +132,7 @@ prop_StoreLaws = withStoreProp $ \runQ ->
 
 -- | Generate interesting changes to 'TxHistory'.
 genDeltas :: GenDelta DeltaTxHistory
-genDeltas (TxHistoryF history) =
+genDeltas (TxHistory history) =
     frequency
         [ (8, Append . mkTxHistory <$> arbitrary)
         , (1, DeleteTx . TxId <$> arbitrary)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -21,7 +21,7 @@ import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (TxId) )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( DeltaTxHistory (..)
-    , TxHistoryF (..)
+    , TxHistory (..)
     , collateralIns
     , decorateTxIns
     , ins

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -23,13 +23,11 @@ import Cardano.Wallet.DB.Store.Transactions.Model
     ( DeltaTxHistory (..)
     , TxHistoryF (..)
     , collateralIns
-    , decorateWithTxOuts
     , decorateTxIns
     , ins
     , lookupTxOutForTxCollateral
     , lookupTxOutForTxIn
     , mkTxHistory
-    , undecorateFromTxOuts
     )
 import Cardano.Wallet.DB.Store.Transactions.Store
     ( mkStoreTransactions )
@@ -56,8 +54,6 @@ spec = do
                 property . prop_StoreLaws
 
     describe "TxOut decoration" $ do
-        it "respects order and content of transactions" $
-            property prop_DecorateIsInvertible
         it
             "reports a transaction where inputs point \
             \to all other transactions output"
@@ -70,11 +66,6 @@ spec = do
 {-----------------------------------------------------------------------------
     Properties
 ------------------------------------------------------------------------------}
-prop_DecorateIsInvertible :: [Tx] -> Bool
-prop_DecorateIsInvertible transactions =
-    let txh = mkTxHistory transactions
-     in undecorateFromTxOuts (decorateWithTxOuts txh) == txh
-
 {- | We check that `decorateTxIns` indeed decorates transaction inputs.
 We do this by generating a set of random transactions, as well as a
 "guinea pig" transaction, whose inputs point to all outputs


### PR DESCRIPTION
This task is about decorated transaction inputs with corresponding outputs, if the outputs are known to wallet, e.g. because they are part of transactions belonging to the transaction history.

Before, the entire transaction history was decorated, albeit lazily.

After, only the transactions shown in endpoint are decorated.

### Issue Number

ADP-2254