### PR TITLE
Remove `minimum_utxo_value` field from REST API.

### DIFF
--- a/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
@@ -55,7 +55,6 @@ module Test.Integration.Framework.DSL
 
     -- * Constants
     , minUTxOValue
-    , minUTxOValueForMinLengthAddress
     , slotLengthValue
     , securityParameterValue
     , epochLengthValue
@@ -680,15 +679,6 @@ minUTxOValue e
     | e >= ApiBabbage =   978_370
     | e >= ApiAlonzo  =   999_978
     | otherwise       = 1_000_000
-
-minUTxOValueForMinLengthAddress :: ApiEra -> Natural
-minUTxOValueForMinLengthAddress = \case
-    ApiByron   ->         0
-    ApiShelley -> 1_000_000
-    ApiAllegra -> 1_000_000
-    ApiMary    -> 1_000_000
-    ApiAlonzo  ->   999_978
-    ApiBabbage ->   874_930
 
 -- | Parameter in test cluster shelley genesis.
 --

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -34,7 +34,6 @@ import Test.Integration.Framework.DSL
     , expectField
     , expectResponseCode
     , maximumCollateralInputCountByEra
-    , minUTxOValueForMinLengthAddress
     , minimumCollateralPercentageByEra
     , request
     , securityParameterValue
@@ -93,9 +92,6 @@ spec = describe "SHELLEY_NETWORK" $ do
                 (`shouldBe` d)
             , expectField #desiredPoolNumber
                 (`shouldBe` nOpt)
-            , expectField #minimumUtxoValue
-                (`shouldBe` Quantity
-                    (minUTxOValueForMinLengthAddress (_mainEra ctx)))
             , expectField #slotLength
                 (`shouldBe` Quantity slotLengthValue)
             , expectField #epochLength

--- a/lib/wallet/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/wallet/src/Cardano/Wallet/Api/Server.hs
@@ -3796,9 +3796,8 @@ getNetworkInformation nid
 getNetworkParameters
     :: (Block, NetworkParameters)
     -> NetworkLayer IO Block
-    -> TransactionLayer k ktype W.SealedTx
     -> Handler ApiNetworkParameters
-getNetworkParameters (_block0, genesisNp) nl _tl = do
+getNetworkParameters (_block0, genesisNp) nl = do
     pp <- liftIO $ NW.currentProtocolParameters nl
     sp <- liftIO $ NW.currentSlottingParameters nl
     let np = genesisNp { protocolParameters = pp, slottingParameters = sp }

--- a/lib/wallet/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/wallet/src/Cardano/Wallet/Api/Server.hs
@@ -3798,13 +3798,11 @@ getNetworkParameters
     -> NetworkLayer IO Block
     -> TransactionLayer k ktype W.SealedTx
     -> Handler ApiNetworkParameters
-getNetworkParameters (_block0, genesisNp) nl tl = do
+getNetworkParameters (_block0, genesisNp) nl _tl = do
     pp <- liftIO $ NW.currentProtocolParameters nl
     sp <- liftIO $ NW.currentSlottingParameters nl
-    era <- liftIO $ NW.currentNodeEra nl
     let np = genesisNp { protocolParameters = pp, slottingParameters = sp }
-    let txConstraints = constraints tl era pp
-    liftIO $ toApiNetworkParameters np txConstraints (interpretQuery ti . toApiEpochInfo)
+    liftIO $ toApiNetworkParameters np (interpretQuery ti . toApiEpochInfo)
   where
     ti :: TimeInterpreter IO
     ti = neverFails

--- a/lib/wallet/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/Api/Types.hs
@@ -389,8 +389,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxStatus (..)
     , sealedTxFromBytes
     )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TxConstraints (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( BoundType, HistogramBar (..), UTxOStatistics (..) )
 import Cardano.Wallet.TokenMetadata
@@ -1148,10 +1146,9 @@ data ApiEraInfo = ApiEraInfo
 toApiNetworkParameters
     :: Monad m
     => NetworkParameters
-    -> TxConstraints
     -> (EpochNo -> m ApiEpochInfo)
     -> m ApiNetworkParameters
-toApiNetworkParameters (NetworkParameters gp sp pp) _txConstraints toEpochInfo = do
+toApiNetworkParameters (NetworkParameters gp sp pp) toEpochInfo = do
     byron <- traverse toEpochInfo (pp ^. #eras . #byron)
     shelley <- traverse toEpochInfo (pp ^. #eras . #shelley)
     allegra <- traverse toEpochInfo (pp ^. #eras . #allegra)

--- a/lib/wallet/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/Api/Types.hs
@@ -377,10 +377,6 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
-import Cardano.Wallet.Primitive.Types.Address.Constants
-    ( minLengthAddress )
-import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -510,7 +506,6 @@ import qualified Cardano.Wallet.Primitive.AddressDerivation as AD
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
-import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
 import qualified Codec.Binary.Bech32 as Bech32
@@ -1134,7 +1129,6 @@ data ApiNetworkParameters = ApiNetworkParameters
     , activeSlotCoefficient :: !(Quantity "percent" Double)
     , decentralizationLevel :: !(Quantity "percent" Percentage)
     , desiredPoolNumber :: !Word16
-    , minimumUtxoValue :: !(Quantity "lovelace" Natural)
     , maximumTokenBundleSize :: !(Quantity "byte" Natural)
     , eras :: !ApiEraInfo
     , maximumCollateralInputCount :: !Word16
@@ -1157,7 +1151,7 @@ toApiNetworkParameters
     -> TxConstraints
     -> (EpochNo -> m ApiEpochInfo)
     -> m ApiNetworkParameters
-toApiNetworkParameters (NetworkParameters gp sp pp) txConstraints toEpochInfo = do
+toApiNetworkParameters (NetworkParameters gp sp pp) _txConstraints toEpochInfo = do
     byron <- traverse toEpochInfo (pp ^. #eras . #byron)
     shelley <- traverse toEpochInfo (pp ^. #eras . #shelley)
     allegra <- traverse toEpochInfo (pp ^. #eras . #allegra)
@@ -1181,31 +1175,6 @@ toApiNetworkParameters (NetworkParameters gp sp pp) txConstraints toEpochInfo = 
             $ getDecentralizationLevel
             $ view #decentralizationLevel pp
         , desiredPoolNumber = view #desiredNumberOfStakePools pp
-        , minimumUtxoValue = toApiCoin $
-            -- NOTE:
-            --
-            -- In eras prior to Babbage, the ledger minimum UTxO function was
-            -- independent of the length of an address.
-            --
-            -- However, from the Babbage era onwards, the ledger minimum UTxO
-            -- function is *dependent* on the length of an address: longer
-            -- addresses give rise to greater minimum UTxO values.
-            --
-            -- Since address lengths are variable, there is no single ideal
-            -- constant that we can return here.
-            --
-            -- Therefore, we return the absolute minimum UTxO quantity for an
-            -- output that sends ada (and no other assets) to an address of the
-            -- minimum possible length.
-            --
-            -- We should consider deprecating this parameter, and replacing it
-            -- with era-specific protocol parameters such as:
-            --
-            -- - lovelacePerUTxOWord (Alonzo)
-            -- - lovelacePerUTxOByte (Babbage)
-            --
-            txOutputMinimumAdaQuantity
-                txConstraints minLengthAddress TokenMap.empty
         , eras = apiEras
         , maximumCollateralInputCount =
             view #maximumCollateralInputCount pp
@@ -1216,8 +1185,6 @@ toApiNetworkParameters (NetworkParameters gp sp pp) txConstraints toEpochInfo = 
             #unTxSize)
         , executionUnitPrices = view #executionUnitPrices pp
         }
-  where
-    toApiCoin = Quantity . fromIntegral . unCoin
 
 newtype ApiTxId = ApiTxId
     { id :: ApiT (Hash "Tx")

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Address/Constants.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Address/Constants.hs
@@ -10,7 +10,6 @@
 --
 module Cardano.Wallet.Primitive.Types.Address.Constants
     ( maxLengthAddress
-    , minLengthAddress
     ) where
 
 import Prelude
@@ -49,19 +48,3 @@ maxLengthAddress = L.maximumBy (compare `on` (BS.length . unAddress))
     , maxLengthAddressFor $ Proxy @ShelleyKey
     , maxLengthAddressFor $ Proxy @SharedKey
     ]
-
--- | A dummy 'Address' of the shortest length that the wallet can generate.
---
--- Please note that this address should:
---
---  - never be used for anything besides its length and validity properties.
---  - never be used as a payment target within a real transaction.
---
-minLengthAddress :: Address
-minLengthAddress = minLengthAddressShelley
-  where
-    minLengthAddressShelley =
-        Address $ BS.singleton enterpriseAddressHeaderByte <> payload
-      where
-        enterpriseAddressHeaderByte = 0b01100000
-        payload = BS.replicate 28 0

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Address/Constants.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Address/Constants.hs
@@ -27,11 +27,10 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
-import Data.Proxy
-    ( Proxy (..) )
-
 import Data.Function
     ( on )
+import Data.Proxy
+    ( Proxy (..) )
 
 import qualified Data.ByteString as BS
 import qualified Data.List as L

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -32,7 +32,6 @@ import Cardano.Wallet
     , networkLayer
     , normalizeDelegationAddress
     , normalizeSharedAddress
-    , transactionLayer
     )
 import Cardano.Wallet.Api
     ( Addresses
@@ -531,11 +530,10 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     network' :: NetworkId -> Server Network
     network' nid =
         getNetworkInformation nid nl mode
-        :<|> getNetworkParameters genesis nl tl
+        :<|> getNetworkParameters genesis nl
         :<|> getNetworkClock ntp
       where
         nl = icarus ^. networkLayer
-        tl = icarus ^. transactionLayer @IcarusKey @'CredFromKeyK
         genesis@(_,_) = icarus ^. genesisData
         mode = case blockchainSource of
           NodeSource {} -> Node

--- a/lib/wallet/test/data/Cardano/Wallet/Api/ApiNetworkParameters.json
+++ b/lib/wallet/test/data/Cardano/Wallet/Api/ApiNetworkParameters.json
@@ -2,660 +2,629 @@
     "samples": [
         {
             "active_slot_coefficient": {
-                "quantity": 80.75976959599012,
+                "quantity": 60.83614082548352,
                 "unit": "percent"
             },
-            "blockchain_start_time": "1889-11-04T10:55:24Z",
+            "blockchain_start_time": "1878-01-27T16:00:00Z",
             "decentralization_level": {
-                "quantity": 34.3,
+                "quantity": 87.47,
                 "unit": "percent"
             },
-            "desired_pool_number": 5436,
+            "desired_pool_number": 16376,
             "epoch_length": {
-                "quantity": 55,
+                "quantity": 5618,
                 "unit": "slot"
             },
             "eras": {
                 "allegra": {
-                    "epoch_number": 8365,
-                    "epoch_start_time": "1870-07-16T20:49:43Z"
+                    "epoch_number": 3234,
+                    "epoch_start_time": "1875-11-03T22:06:33.158337937384Z"
                 },
-                "alonzo": null,
+                "alonzo": {
+                    "epoch_number": 10866,
+                    "epoch_start_time": "1868-03-07T23:00:00Z"
+                },
                 "babbage": null,
-                "byron": {
-                    "epoch_number": 6025,
-                    "epoch_start_time": "1868-04-30T19:36:43Z"
-                },
-                "mary": {
-                    "epoch_number": 2477,
-                    "epoch_start_time": "1878-05-08T08:00:00Z"
-                },
-                "shelley": null
-            },
-            "genesis_block_hash": "1516145658104c086cacfacf0b395c7ae726631d4b5d584261ea526d116da750",
-            "maximum_collateral_input_count": 4083,
-            "maximum_token_bundle_size": {
-                "quantity": 6030056,
-                "unit": "byte"
-            },
-            "minimum_collateral_percentage": 16,
-            "minimum_utxo_value": {
-                "quantity": 85,
-                "unit": "lovelace"
-            },
-            "security_parameter": {
-                "quantity": 10194,
-                "unit": "block"
-            },
-            "slot_length": {
-                "quantity": 8629,
-                "unit": "second"
-            }
-        },
-        {
-            "active_slot_coefficient": {
-                "quantity": 2.436524790435035,
-                "unit": "percent"
-            },
-            "blockchain_start_time": "1874-06-27T07:00:00Z",
-            "decentralization_level": {
-                "quantity": 11.51,
-                "unit": "percent"
-            },
-            "desired_pool_number": 8901,
-            "epoch_length": {
-                "quantity": 1030,
-                "unit": "slot"
-            },
-            "eras": {
-                "allegra": {
-                    "epoch_number": 12428,
-                    "epoch_start_time": "1899-03-05T18:03:42.426624779629Z"
-                },
-                "alonzo": {
-                    "epoch_number": 2926,
-                    "epoch_start_time": "1903-06-12T03:02:01Z"
-                },
-                "babbage": {
-                    "epoch_number": 13873,
-                    "epoch_start_time": "1885-06-04T08:00:10Z"
-                },
-                "byron": {
-                    "epoch_number": 14961,
-                    "epoch_start_time": "1878-01-07T14:37:29Z"
-                },
-                "mary": {
-                    "epoch_number": 14311,
-                    "epoch_start_time": "1881-10-16T10:21:54.239559240587Z"
-                },
-                "shelley": {
-                    "epoch_number": 8657,
-                    "epoch_start_time": "1900-05-01T20:00:00Z"
-                }
-            },
-            "execution_unit_prices": {
-                "memory_unit_price": {
-                    "denominator": 522896597553,
-                    "numerator": 9859718929862
-                },
-                "step_price": {
-                    "denominator": 2979748850296,
-                    "numerator": 18254254571051
-                }
-            },
-            "genesis_block_hash": "6c308756e76672370f4c425c2b85567cf51a155b074259663b884506715c1e64",
-            "maximum_collateral_input_count": 14101,
-            "maximum_token_bundle_size": {
-                "quantity": 4599490,
-                "unit": "byte"
-            },
-            "minimum_collateral_percentage": 20,
-            "minimum_utxo_value": {
-                "quantity": 250,
-                "unit": "lovelace"
-            },
-            "security_parameter": {
-                "quantity": 13953,
-                "unit": "block"
-            },
-            "slot_length": {
-                "quantity": 4268,
-                "unit": "second"
-            }
-        },
-        {
-            "active_slot_coefficient": {
-                "quantity": 10.096269254929647,
-                "unit": "percent"
-            },
-            "blockchain_start_time": "1865-06-26T10:00:00Z",
-            "decentralization_level": {
-                "quantity": 83.42,
-                "unit": "percent"
-            },
-            "desired_pool_number": 6129,
-            "epoch_length": {
-                "quantity": 11681,
-                "unit": "slot"
-            },
-            "eras": {
-                "allegra": {
-                    "epoch_number": 15903,
-                    "epoch_start_time": "1872-12-14T06:56:34Z"
-                },
-                "alonzo": {
-                    "epoch_number": 10964,
-                    "epoch_start_time": "1885-02-06T06:00:00Z"
-                },
-                "babbage": {
-                    "epoch_number": 8501,
-                    "epoch_start_time": "1875-07-12T21:18:31Z"
-                },
                 "byron": null,
                 "mary": {
-                    "epoch_number": 10101,
-                    "epoch_start_time": "1859-01-14T00:27:20Z"
+                    "epoch_number": 13191,
+                    "epoch_start_time": "1875-04-25T00:55:38Z"
                 },
                 "shelley": {
-                    "epoch_number": 16037,
-                    "epoch_start_time": "1874-05-03T14:00:00Z"
-                }
-            },
-            "genesis_block_hash": "04424419215db71c0a590d5c07440130704f5c0b3330617a7d6266102f4aa94a",
-            "maximum_collateral_input_count": 12334,
-            "maximum_token_bundle_size": {
-                "quantity": 2639037,
-                "unit": "byte"
-            },
-            "minimum_collateral_percentage": 7,
-            "minimum_utxo_value": {
-                "quantity": 165,
-                "unit": "lovelace"
-            },
-            "security_parameter": {
-                "quantity": 12372,
-                "unit": "block"
-            },
-            "slot_length": {
-                "quantity": 9615,
-                "unit": "second"
-            }
-        },
-        {
-            "active_slot_coefficient": {
-                "quantity": 94.13578562587841,
-                "unit": "percent"
-            },
-            "blockchain_start_time": "1864-10-09T11:00:00Z",
-            "decentralization_level": {
-                "quantity": 4.53,
-                "unit": "percent"
-            },
-            "desired_pool_number": 12526,
-            "epoch_length": {
-                "quantity": 5726,
-                "unit": "slot"
-            },
-            "eras": {
-                "allegra": {
-                    "epoch_number": 6064,
-                    "epoch_start_time": "1871-02-13T22:00:00Z"
-                },
-                "alonzo": {
-                    "epoch_number": 7764,
-                    "epoch_start_time": "1907-06-20T20:09:07Z"
-                },
-                "babbage": {
-                    "epoch_number": 10311,
-                    "epoch_start_time": "1907-03-05T18:12:07Z"
-                },
-                "byron": {
-                    "epoch_number": 4580,
-                    "epoch_start_time": "1879-04-25T00:32:47.853977480272Z"
-                },
-                "mary": {
-                    "epoch_number": 14603,
-                    "epoch_start_time": "1879-11-14T19:00:00Z"
-                },
-                "shelley": {
-                    "epoch_number": 5716,
-                    "epoch_start_time": "1900-11-01T12:01:32.960028255536Z"
+                    "epoch_number": 1938,
+                    "epoch_start_time": "1872-10-13T00:49:09Z"
                 }
             },
             "execution_unit_prices": {
                 "memory_unit_price": {
-                    "denominator": 8556071788959,
-                    "numerator": 117317872946881
+                    "denominator": 1920674077214,
+                    "numerator": 22853504092795
                 },
                 "step_price": {
-                    "denominator": 3992901900872,
-                    "numerator": 103998821949873
+                    "denominator": 6731989820801,
+                    "numerator": 31908322808545
                 }
             },
-            "genesis_block_hash": "293a2e093467a72c4af17f7795636322a818764d146321453a30ee1e28243a09",
-            "maximum_collateral_input_count": 8028,
+            "genesis_block_hash": "7e42afb87134065b86550b00325864191141180d011e753526b36d4b7b1a1563",
+            "maximum_collateral_input_count": 1839,
             "maximum_token_bundle_size": {
-                "quantity": 3213955,
+                "quantity": 7374424,
                 "unit": "byte"
             },
-            "minimum_collateral_percentage": 26,
-            "minimum_utxo_value": {
-                "quantity": 192,
-                "unit": "lovelace"
-            },
+            "minimum_collateral_percentage": 14,
             "security_parameter": {
-                "quantity": 7571,
+                "quantity": 252,
                 "unit": "block"
             },
             "slot_length": {
-                "quantity": 9716,
+                "quantity": 9965,
                 "unit": "second"
             }
         },
         {
             "active_slot_coefficient": {
-                "quantity": 28.472934380343307,
+                "quantity": 50.75165915714318,
                 "unit": "percent"
             },
-            "blockchain_start_time": "1866-05-30T07:00:00Z",
+            "blockchain_start_time": "1863-02-27T18:14:11.931764390942Z",
             "decentralization_level": {
-                "quantity": 76.77,
+                "quantity": 62.37,
                 "unit": "percent"
             },
-            "desired_pool_number": 13002,
+            "desired_pool_number": 4621,
             "epoch_length": {
-                "quantity": 9173,
+                "quantity": 15900,
                 "unit": "slot"
             },
             "eras": {
                 "allegra": {
-                    "epoch_number": 7992,
-                    "epoch_start_time": "1884-11-26T13:00:00Z"
+                    "epoch_number": 6579,
+                    "epoch_start_time": "1868-06-09T23:11:11Z"
                 },
                 "alonzo": {
-                    "epoch_number": 5784,
-                    "epoch_start_time": "1898-08-04T17:22:32Z"
+                    "epoch_number": 6812,
+                    "epoch_start_time": "1884-12-31T13:33:46Z"
                 },
                 "babbage": {
-                    "epoch_number": 2118,
-                    "epoch_start_time": "1860-04-11T09:08:11Z"
+                    "epoch_number": 8334,
+                    "epoch_start_time": "1864-02-14T22:37:09Z"
                 },
                 "byron": {
-                    "epoch_number": 10503,
-                    "epoch_start_time": "1893-07-14T22:36:01.448022511034Z"
+                    "epoch_number": 370,
+                    "epoch_start_time": "1880-10-10T12:19:20.815896240174Z"
                 },
                 "mary": {
-                    "epoch_number": 8440,
-                    "epoch_start_time": "1869-10-23T19:37:19.567233198916Z"
+                    "epoch_number": 11871,
+                    "epoch_start_time": "1870-06-11T00:00:00Z"
                 },
                 "shelley": {
-                    "epoch_number": 13676,
-                    "epoch_start_time": "1891-02-06T09:52:38.73466752662Z"
+                    "epoch_number": 2210,
+                    "epoch_start_time": "1907-07-04T06:53:02Z"
                 }
             },
             "execution_unit_prices": {
                 "memory_unit_price": {
-                    "denominator": 705850593099,
-                    "numerator": 10715930020645
+                    "denominator": 3709550718685,
+                    "numerator": 61950137214254
                 },
                 "step_price": {
-                    "denominator": 2444753395080,
-                    "numerator": 67560991324721
+                    "denominator": 4269000267967,
+                    "numerator": 52605068366077
                 }
             },
-            "genesis_block_hash": "5cef132c722d363308165561393018143d7f7c7a291f014d303f001b1d7b4f30",
-            "maximum_collateral_input_count": 9959,
+            "genesis_block_hash": "2a23792f693c7d4f551c33794e7bd6402d196137022b637b016ba575785f6d45",
+            "maximum_collateral_input_count": 1147,
             "maximum_token_bundle_size": {
-                "quantity": 3660773,
+                "quantity": 2476141,
                 "unit": "byte"
             },
-            "minimum_collateral_percentage": 9,
-            "minimum_utxo_value": {
-                "quantity": 134,
-                "unit": "lovelace"
-            },
+            "minimum_collateral_percentage": 29,
             "security_parameter": {
-                "quantity": 2385,
+                "quantity": 6547,
                 "unit": "block"
             },
             "slot_length": {
-                "quantity": 9944,
+                "quantity": 3812,
                 "unit": "second"
             }
         },
         {
             "active_slot_coefficient": {
-                "quantity": 49.813581610567105,
+                "quantity": 19.715215155150823,
                 "unit": "percent"
             },
-            "blockchain_start_time": "1867-09-15T03:45:14Z",
+            "blockchain_start_time": "1870-04-14T12:50:37.788586970534Z",
             "decentralization_level": {
-                "quantity": 41.56,
+                "quantity": 44.35,
                 "unit": "percent"
             },
-            "desired_pool_number": 15483,
+            "desired_pool_number": 15297,
             "epoch_length": {
-                "quantity": 9230,
-                "unit": "slot"
-            },
-            "eras": {
-                "allegra": {
-                    "epoch_number": 16296,
-                    "epoch_start_time": "1884-06-09T00:00:00Z"
-                },
-                "alonzo": {
-                    "epoch_number": 8518,
-                    "epoch_start_time": "1902-11-12T07:41:20.860058557969Z"
-                },
-                "babbage": {
-                    "epoch_number": 13277,
-                    "epoch_start_time": "1862-12-15T23:00:00Z"
-                },
-                "byron": {
-                    "epoch_number": 7805,
-                    "epoch_start_time": "1861-07-20T01:15:33Z"
-                },
-                "mary": {
-                    "epoch_number": 2187,
-                    "epoch_start_time": "1882-12-05T05:28:04Z"
-                },
-                "shelley": {
-                    "epoch_number": 15255,
-                    "epoch_start_time": "1896-08-09T08:00:00Z"
-                }
-            },
-            "genesis_block_hash": "377a5f3f16d36a4d5a190a56d66d173e5b074f0b461e62133f48090fa0625127",
-            "maximum_collateral_input_count": 15018,
-            "maximum_token_bundle_size": {
-                "quantity": 282943,
-                "unit": "byte"
-            },
-            "minimum_collateral_percentage": 10,
-            "minimum_utxo_value": {
-                "quantity": 142,
-                "unit": "lovelace"
-            },
-            "security_parameter": {
-                "quantity": 8264,
-                "unit": "block"
-            },
-            "slot_length": {
-                "quantity": 1063,
-                "unit": "second"
-            }
-        },
-        {
-            "active_slot_coefficient": {
-                "quantity": 81.99293316840372,
-                "unit": "percent"
-            },
-            "blockchain_start_time": "1903-04-15T21:45:18Z",
-            "decentralization_level": {
-                "quantity": 17.2,
-                "unit": "percent"
-            },
-            "desired_pool_number": 4548,
-            "epoch_length": {
-                "quantity": 14904,
-                "unit": "slot"
-            },
-            "eras": {
-                "allegra": {
-                    "epoch_number": 2776,
-                    "epoch_start_time": "1865-09-13T20:00:00Z"
-                },
-                "alonzo": {
-                    "epoch_number": 9187,
-                    "epoch_start_time": "1862-12-28T17:30:31Z"
-                },
-                "babbage": {
-                    "epoch_number": 720,
-                    "epoch_start_time": "1890-09-10T06:26:46.709293612594Z"
-                },
-                "byron": {
-                    "epoch_number": 3766,
-                    "epoch_start_time": "1859-05-13T22:24:23.178616987199Z"
-                },
-                "mary": {
-                    "epoch_number": 8487,
-                    "epoch_start_time": "1884-11-06T06:30:35Z"
-                },
-                "shelley": null
-            },
-            "execution_unit_prices": {
-                "memory_unit_price": {
-                    "denominator": 4024576385852,
-                    "numerator": 25443375225089
-                },
-                "step_price": {
-                    "denominator": 1829528527489,
-                    "numerator": 42404805154176
-                }
-            },
-            "genesis_block_hash": "392f604409441b5744f844255e4c79352d0261663a647e47241f0c4769500278",
-            "maximum_collateral_input_count": 12514,
-            "maximum_token_bundle_size": {
-                "quantity": 1956060,
-                "unit": "byte"
-            },
-            "minimum_collateral_percentage": 11,
-            "minimum_utxo_value": {
-                "quantity": 189,
-                "unit": "lovelace"
-            },
-            "security_parameter": {
-                "quantity": 2770,
-                "unit": "block"
-            },
-            "slot_length": {
-                "quantity": 6954,
-                "unit": "second"
-            }
-        },
-        {
-            "active_slot_coefficient": {
-                "quantity": 55.53775143202688,
-                "unit": "percent"
-            },
-            "blockchain_start_time": "1886-12-04T02:00:00Z",
-            "decentralization_level": {
-                "quantity": 33.74,
-                "unit": "percent"
-            },
-            "desired_pool_number": 14355,
-            "epoch_length": {
-                "quantity": 9958,
+                "quantity": 7257,
                 "unit": "slot"
             },
             "eras": {
                 "allegra": null,
                 "alonzo": {
-                    "epoch_number": 11217,
-                    "epoch_start_time": "1866-01-22T23:41:58.43621999873Z"
+                    "epoch_number": 15240,
+                    "epoch_start_time": "1861-03-23T11:00:00Z"
                 },
-                "babbage": {
-                    "epoch_number": 11884,
-                    "epoch_start_time": "1892-04-05T17:19:24Z"
-                },
+                "babbage": null,
                 "byron": {
-                    "epoch_number": 7586,
-                    "epoch_start_time": "1890-05-22T20:21:09Z"
+                    "epoch_number": 16140,
+                    "epoch_start_time": "1902-04-15T06:56:28Z"
                 },
                 "mary": null,
                 "shelley": {
-                    "epoch_number": 13669,
-                    "epoch_start_time": "1897-02-06T18:19:24Z"
+                    "epoch_number": 6535,
+                    "epoch_start_time": "1875-04-04T14:36:32Z"
                 }
             },
             "execution_unit_prices": {
                 "memory_unit_price": {
-                    "denominator": 6933200459219,
-                    "numerator": 6021430368420
+                    "denominator": 473807508218,
+                    "numerator": 1281700145885
                 },
                 "step_price": {
-                    "denominator": 3181215959556,
-                    "numerator": 54293317127405
+                    "denominator": 1654133137142,
+                    "numerator": 24119840367403
                 }
             },
-            "genesis_block_hash": "14fe63746c234f5a6457305565155d623c2279116d024d3c6d404832407d0e14",
-            "maximum_collateral_input_count": 1638,
+            "genesis_block_hash": "03331a2a7203734d70084f1c1e761b5d82ba4b2d302b2f6a4b650f4d381103fc",
+            "maximum_collateral_input_count": 12660,
             "maximum_token_bundle_size": {
-                "quantity": 4816386,
+                "quantity": 7514462,
                 "unit": "byte"
             },
-            "minimum_collateral_percentage": 25,
-            "minimum_utxo_value": {
-                "quantity": 205,
-                "unit": "lovelace"
-            },
+            "minimum_collateral_percentage": 5,
             "security_parameter": {
-                "quantity": 7242,
+                "quantity": 14778,
                 "unit": "block"
             },
             "slot_length": {
-                "quantity": 5663,
+                "quantity": 6209,
                 "unit": "second"
             }
         },
         {
             "active_slot_coefficient": {
-                "quantity": 89.09325898759997,
+                "quantity": 32.33536882267233,
                 "unit": "percent"
             },
-            "blockchain_start_time": "1896-06-03T01:49:15.422904943581Z",
+            "blockchain_start_time": "1881-01-07T21:00:00Z",
             "decentralization_level": {
-                "quantity": 23.92,
+                "quantity": 43.61,
                 "unit": "percent"
             },
-            "desired_pool_number": 4651,
+            "desired_pool_number": 4708,
             "epoch_length": {
-                "quantity": 15809,
+                "quantity": 5639,
                 "unit": "slot"
             },
             "eras": {
                 "allegra": {
-                    "epoch_number": 11367,
-                    "epoch_start_time": "1893-05-15T19:00:00Z"
+                    "epoch_number": 5573,
+                    "epoch_start_time": "1874-07-04T00:48:46.894683941011Z"
                 },
-                "alonzo": {
-                    "epoch_number": 12793,
-                    "epoch_start_time": "1893-05-16T09:39:05Z"
-                },
+                "alonzo": null,
                 "babbage": {
-                    "epoch_number": 6817,
-                    "epoch_start_time": "1901-04-15T20:24:32Z"
+                    "epoch_number": 2135,
+                    "epoch_start_time": "1906-08-08T21:21:22Z"
                 },
-                "byron": {
-                    "epoch_number": 11868,
-                    "epoch_start_time": "1900-09-03T06:09:22.639716599206Z"
-                },
-                "mary": {
-                    "epoch_number": 9022,
-                    "epoch_start_time": "1896-03-16T02:28:09Z"
-                },
+                "byron": null,
+                "mary": null,
                 "shelley": {
-                    "epoch_number": 5571,
-                    "epoch_start_time": "1898-08-11T09:02:33.535974157376Z"
+                    "epoch_number": 11823,
+                    "epoch_start_time": "1882-12-16T22:29:49.580410903032Z"
                 }
             },
             "execution_unit_prices": {
                 "memory_unit_price": {
-                    "denominator": 2023622938347,
-                    "numerator": 28974299462650
+                    "denominator": 1074896394981,
+                    "numerator": 29603591010428
                 },
                 "step_price": {
-                    "denominator": 4055295379309,
-                    "numerator": 44341497840214
+                    "denominator": 1543389454178,
+                    "numerator": 40816363625105
                 }
             },
-            "genesis_block_hash": "5b7c235146605f6c136a111712f8649b6f2f79411e1b4bdf7c7e076f481fe615",
-            "maximum_collateral_input_count": 8014,
+            "genesis_block_hash": "170c406e431cf1aee8276c332c645743bd09fe6a1e481e0e2d457c6025385d6a",
+            "maximum_collateral_input_count": 12944,
             "maximum_token_bundle_size": {
-                "quantity": 6606992,
+                "quantity": 7563203,
                 "unit": "byte"
             },
-            "minimum_collateral_percentage": 9,
-            "minimum_utxo_value": {
-                "quantity": 52,
-                "unit": "lovelace"
-            },
+            "minimum_collateral_percentage": 5,
             "security_parameter": {
-                "quantity": 9602,
+                "quantity": 3308,
                 "unit": "block"
             },
             "slot_length": {
-                "quantity": 3956,
+                "quantity": 5196,
                 "unit": "second"
             }
         },
         {
             "active_slot_coefficient": {
-                "quantity": 24.222542134689174,
+                "quantity": 90.06545517911273,
                 "unit": "percent"
             },
-            "blockchain_start_time": "1889-05-13T23:52:57.257637816352Z",
+            "blockchain_start_time": "1868-11-05T00:32:23Z",
             "decentralization_level": {
-                "quantity": 65.65,
+                "quantity": 58.14,
                 "unit": "percent"
             },
-            "desired_pool_number": 9701,
+            "desired_pool_number": 11644,
             "epoch_length": {
-                "quantity": 1417,
+                "quantity": 14439,
+                "unit": "slot"
+            },
+            "eras": {
+                "allegra": {
+                    "epoch_number": 3804,
+                    "epoch_start_time": "1871-07-05T22:53:01Z"
+                },
+                "alonzo": {
+                    "epoch_number": 7741,
+                    "epoch_start_time": "1890-06-21T23:00:00Z"
+                },
+                "babbage": {
+                    "epoch_number": 579,
+                    "epoch_start_time": "1895-04-15T12:59:13.392871345842Z"
+                },
+                "byron": {
+                    "epoch_number": 5603,
+                    "epoch_start_time": "1889-07-14T00:11:01.617018543683Z"
+                },
+                "mary": null,
+                "shelley": {
+                    "epoch_number": 7421,
+                    "epoch_start_time": "1880-11-02T07:50:42Z"
+                }
+            },
+            "execution_unit_prices": {
+                "memory_unit_price": {
+                    "denominator": 34107650457,
+                    "numerator": 157461686095
+                },
+                "step_price": {
+                    "denominator": 255960125587,
+                    "numerator": 6723604123193
+                }
+            },
+            "genesis_block_hash": "3a4a91350f094c5d0083cd0d4f0dff2e7d2a307310085f48171c7e09ca023093",
+            "maximum_collateral_input_count": 11820,
+            "maximum_token_bundle_size": {
+                "quantity": 1298137,
+                "unit": "byte"
+            },
+            "minimum_collateral_percentage": 4,
+            "security_parameter": {
+                "quantity": 2308,
+                "unit": "block"
+            },
+            "slot_length": {
+                "quantity": 9949,
+                "unit": "second"
+            }
+        },
+        {
+            "active_slot_coefficient": {
+                "quantity": 91.98595571227001,
+                "unit": "percent"
+            },
+            "blockchain_start_time": "1891-03-03T01:19:06Z",
+            "decentralization_level": {
+                "quantity": 69.45,
+                "unit": "percent"
+            },
+            "desired_pool_number": 8021,
+            "epoch_length": {
+                "quantity": 11952,
+                "unit": "slot"
+            },
+            "eras": {
+                "allegra": {
+                    "epoch_number": 10231,
+                    "epoch_start_time": "1886-01-06T14:00:00Z"
+                },
+                "alonzo": null,
+                "babbage": {
+                    "epoch_number": 6308,
+                    "epoch_start_time": "1867-09-17T02:00:00Z"
+                },
+                "byron": {
+                    "epoch_number": 735,
+                    "epoch_start_time": "1898-07-16T20:00:00Z"
+                },
+                "mary": {
+                    "epoch_number": 16146,
+                    "epoch_start_time": "1864-11-08T03:03:54Z"
+                },
+                "shelley": {
+                    "epoch_number": 4319,
+                    "epoch_start_time": "1870-07-25T15:00:00Z"
+                }
+            },
+            "execution_unit_prices": {
+                "memory_unit_price": {
+                    "denominator": 3302388287743,
+                    "numerator": 86546593176727
+                },
+                "step_price": {
+                    "denominator": 2923682743561,
+                    "numerator": 84710263089050
+                }
+            },
+            "genesis_block_hash": "4241560b62285e5e54061a9d617436a8cab72ec331770b736aab565227204b6a",
+            "maximum_collateral_input_count": 2288,
+            "maximum_token_bundle_size": {
+                "quantity": 4266359,
+                "unit": "byte"
+            },
+            "minimum_collateral_percentage": 4,
+            "security_parameter": {
+                "quantity": 15808,
+                "unit": "block"
+            },
+            "slot_length": {
+                "quantity": 8432,
+                "unit": "second"
+            }
+        },
+        {
+            "active_slot_coefficient": {
+                "quantity": 95.41380710254634,
+                "unit": "percent"
+            },
+            "blockchain_start_time": "1884-11-08T20:45:59Z",
+            "decentralization_level": {
+                "quantity": 77.88,
+                "unit": "percent"
+            },
+            "desired_pool_number": 11440,
+            "epoch_length": {
+                "quantity": 8380,
+                "unit": "slot"
+            },
+            "eras": {
+                "allegra": {
+                    "epoch_number": 12880,
+                    "epoch_start_time": "1907-05-29T00:00:00Z"
+                },
+                "alonzo": {
+                    "epoch_number": 7651,
+                    "epoch_start_time": "1901-12-26T18:09:09.101987636117Z"
+                },
+                "babbage": {
+                    "epoch_number": 4576,
+                    "epoch_start_time": "1868-09-12T01:10:46Z"
+                },
+                "byron": null,
+                "mary": null,
+                "shelley": {
+                    "epoch_number": 15151,
+                    "epoch_start_time": "1863-07-28T14:00:00Z"
+                }
+            },
+            "execution_unit_prices": {
+                "memory_unit_price": {
+                    "denominator": 8200841643201,
+                    "numerator": 166381469362670
+                },
+                "step_price": {
+                    "denominator": 4132559468609,
+                    "numerator": 90061312976345
+                }
+            },
+            "genesis_block_hash": "434a20667e21f8396043063b661e67266ebd4d4c4e3b1f2768151da81a366712",
+            "maximum_collateral_input_count": 1097,
+            "maximum_token_bundle_size": {
+                "quantity": 180497,
+                "unit": "byte"
+            },
+            "minimum_collateral_percentage": 28,
+            "security_parameter": {
+                "quantity": 14425,
+                "unit": "block"
+            },
+            "slot_length": {
+                "quantity": 1570,
+                "unit": "second"
+            }
+        },
+        {
+            "active_slot_coefficient": {
+                "quantity": 92.13890963471583,
+                "unit": "percent"
+            },
+            "blockchain_start_time": "1896-06-19T00:00:00Z",
+            "decentralization_level": {
+                "quantity": 25.73,
+                "unit": "percent"
+            },
+            "desired_pool_number": 15258,
+            "epoch_length": {
+                "quantity": 2276,
                 "unit": "slot"
             },
             "eras": {
                 "allegra": null,
                 "alonzo": {
-                    "epoch_number": 14500,
-                    "epoch_start_time": "1903-07-10T07:15:00Z"
+                    "epoch_number": 12905,
+                    "epoch_start_time": "1864-08-30T04:00:00Z"
                 },
                 "babbage": {
-                    "epoch_number": 10059,
-                    "epoch_start_time": "1883-02-27T07:45:24Z"
+                    "epoch_number": 14943,
+                    "epoch_start_time": "1879-08-08T16:00:00Z"
                 },
-                "byron": {
-                    "epoch_number": 8798,
-                    "epoch_start_time": "1887-08-08T12:44:03Z"
-                },
+                "byron": null,
                 "mary": {
-                    "epoch_number": 14408,
-                    "epoch_start_time": "1864-09-13T06:53:56Z"
+                    "epoch_number": 2825,
+                    "epoch_start_time": "1868-01-04T13:00:00Z"
                 },
                 "shelley": {
-                    "epoch_number": 15598,
-                    "epoch_start_time": "1869-03-28T18:48:09.354162119828Z"
+                    "epoch_number": 12298,
+                    "epoch_start_time": "1901-01-09T08:31:07.139328251948Z"
                 }
             },
             "execution_unit_prices": {
                 "memory_unit_price": {
-                    "denominator": 1163861553247,
-                    "numerator": 6555654203110
+                    "denominator": 777196911289,
+                    "numerator": 13505927203598
                 },
                 "step_price": {
-                    "denominator": 409004409016,
-                    "numerator": 7018095256649
+                    "denominator": 2373309012955,
+                    "numerator": 3437949358294
                 }
             },
-            "genesis_block_hash": "59614f2f1b032b741e48590d49bb199936846e523c7a3d1beb77552f664b2e66",
-            "maximum_collateral_input_count": 2840,
+            "genesis_block_hash": "1adf5636323f522c674c045336fc0f3c27ad38106d79786beb1316f0463c6068",
+            "maximum_collateral_input_count": 7751,
             "maximum_token_bundle_size": {
-                "quantity": 8089582,
+                "quantity": 3792792,
                 "unit": "byte"
             },
-            "minimum_collateral_percentage": 17,
-            "minimum_utxo_value": {
-                "quantity": 220,
-                "unit": "lovelace"
-            },
+            "minimum_collateral_percentage": 23,
             "security_parameter": {
-                "quantity": 15870,
+                "quantity": 168,
                 "unit": "block"
             },
             "slot_length": {
-                "quantity": 8165,
+                "quantity": 4668,
+                "unit": "second"
+            }
+        },
+        {
+            "active_slot_coefficient": {
+                "quantity": 55.18954434001877,
+                "unit": "percent"
+            },
+            "blockchain_start_time": "1868-10-23T08:00:00Z",
+            "decentralization_level": {
+                "quantity": 2.99,
+                "unit": "percent"
+            },
+            "desired_pool_number": 3108,
+            "epoch_length": {
+                "quantity": 14973,
+                "unit": "slot"
+            },
+            "eras": {
+                "allegra": {
+                    "epoch_number": 5389,
+                    "epoch_start_time": "1896-02-12T11:00:00Z"
+                },
+                "alonzo": {
+                    "epoch_number": 8576,
+                    "epoch_start_time": "1873-08-12T18:49:40.209979787815Z"
+                },
+                "babbage": {
+                    "epoch_number": 1445,
+                    "epoch_start_time": "1893-02-10T15:24:31Z"
+                },
+                "byron": {
+                    "epoch_number": 2215,
+                    "epoch_start_time": "1880-03-30T08:35:52Z"
+                },
+                "mary": {
+                    "epoch_number": 7898,
+                    "epoch_start_time": "1896-04-02T06:13:11.368998622272Z"
+                },
+                "shelley": {
+                    "epoch_number": 16310,
+                    "epoch_start_time": "1885-04-29T05:56:21.048052353564Z"
+                }
+            },
+            "execution_unit_prices": {
+                "memory_unit_price": {
+                    "denominator": 8728377515000,
+                    "numerator": 69293331722987
+                },
+                "step_price": {
+                    "denominator": 4088047406935,
+                    "numerator": 89442723671402
+                }
+            },
+            "genesis_block_hash": "6d5a7f513e395ed9755b240a19263c340e086d173707d2066533d427a4492e0d",
+            "maximum_collateral_input_count": 182,
+            "maximum_token_bundle_size": {
+                "quantity": 1118605,
+                "unit": "byte"
+            },
+            "minimum_collateral_percentage": 29,
+            "security_parameter": {
+                "quantity": 1416,
+                "unit": "block"
+            },
+            "slot_length": {
+                "quantity": 3513,
+                "unit": "second"
+            }
+        },
+        {
+            "active_slot_coefficient": {
+                "quantity": 37.072761720187955,
+                "unit": "percent"
+            },
+            "blockchain_start_time": "1891-09-10T13:22:41.215436783953Z",
+            "decentralization_level": {
+                "quantity": 61.15,
+                "unit": "percent"
+            },
+            "desired_pool_number": 10837,
+            "epoch_length": {
+                "quantity": 3092,
+                "unit": "slot"
+            },
+            "eras": {
+                "allegra": {
+                    "epoch_number": 7821,
+                    "epoch_start_time": "1904-01-11T01:44:22Z"
+                },
+                "alonzo": {
+                    "epoch_number": 15125,
+                    "epoch_start_time": "1906-05-16T16:40:47.534743529887Z"
+                },
+                "babbage": {
+                    "epoch_number": 12342,
+                    "epoch_start_time": "1866-03-20T03:31:11.074164507224Z"
+                },
+                "byron": {
+                    "epoch_number": 12730,
+                    "epoch_start_time": "1871-04-21T13:05:14.801767512019Z"
+                },
+                "mary": {
+                    "epoch_number": 2311,
+                    "epoch_start_time": "1895-01-27T10:02:39Z"
+                },
+                "shelley": null
+            },
+            "execution_unit_prices": {
+                "memory_unit_price": {
+                    "denominator": 8174664420063,
+                    "numerator": 205749067641205
+                },
+                "step_price": {
+                    "denominator": 7662412973159,
+                    "numerator": 56909539934752
+                }
+            },
+            "genesis_block_hash": "15c8040f3d1e8c8b2067550c7c0671105327702ede6d823d074f58367a6d0674",
+            "maximum_collateral_input_count": 4017,
+            "maximum_token_bundle_size": {
+                "quantity": 8005708,
+                "unit": "byte"
+            },
+            "minimum_collateral_percentage": 12,
+            "security_parameter": {
+                "quantity": 14593,
+                "unit": "block"
+            },
+            "slot_length": {
+                "quantity": 2138,
                 "unit": "second"
             }
         }
     ],
-    "seed": -1419407547
+    "seed": -748884308
 }

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1373,8 +1373,6 @@ spec = parallel $ do
                         (x :: ApiNetworkParameters)
                     , desiredPoolNumber = desiredPoolNumber
                         (x :: ApiNetworkParameters)
-                    , minimumUtxoValue = minimumUtxoValue
-                        (x :: ApiNetworkParameters)
                     , maximumTokenBundleSize = maximumTokenBundleSize
                         (x :: ApiNetworkParameters)
                     , eras = eras

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1357,34 +1357,34 @@ spec = parallel $ do
                 x' === x .&&. show x' === show x
         it "ApiNetworkParameters" $ property $ \x ->
             let x' = ApiNetworkParameters
-                    { genesisBlockHash =
-                        genesisBlockHash (x :: ApiNetworkParameters)
-                    , blockchainStartTime =
-                        blockchainStartTime (x :: ApiNetworkParameters)
-                    , slotLength =
-                        slotLength (x :: ApiNetworkParameters)
-                    , epochLength =
-                        epochLength (x :: ApiNetworkParameters)
-                    , securityParameter =
-                        securityParameter (x :: ApiNetworkParameters)
-                    , activeSlotCoefficient =
-                        activeSlotCoefficient (x :: ApiNetworkParameters)
-                    , decentralizationLevel =
-                        decentralizationLevel (x :: ApiNetworkParameters)
-                    , desiredPoolNumber =
-                        desiredPoolNumber (x :: ApiNetworkParameters)
-                    , minimumUtxoValue =
-                        minimumUtxoValue (x :: ApiNetworkParameters)
-                    , maximumTokenBundleSize =
-                        maximumTokenBundleSize (x :: ApiNetworkParameters)
-                    , eras =
-                        eras (x :: ApiNetworkParameters)
-                    , maximumCollateralInputCount =
-                        maximumCollateralInputCount (x :: ApiNetworkParameters)
-                    , minimumCollateralPercentage =
-                        minimumCollateralPercentage (x :: ApiNetworkParameters)
-                    , executionUnitPrices =
-                        executionUnitPrices (x :: ApiNetworkParameters)
+                    { genesisBlockHash = genesisBlockHash
+                        (x :: ApiNetworkParameters)
+                    , blockchainStartTime = blockchainStartTime
+                        (x :: ApiNetworkParameters)
+                    , slotLength = slotLength
+                        (x :: ApiNetworkParameters)
+                    , epochLength = epochLength
+                        (x :: ApiNetworkParameters)
+                    , securityParameter = securityParameter
+                        (x :: ApiNetworkParameters)
+                    , activeSlotCoefficient = activeSlotCoefficient
+                        (x :: ApiNetworkParameters)
+                    , decentralizationLevel = decentralizationLevel
+                        (x :: ApiNetworkParameters)
+                    , desiredPoolNumber = desiredPoolNumber
+                        (x :: ApiNetworkParameters)
+                    , minimumUtxoValue = minimumUtxoValue
+                        (x :: ApiNetworkParameters)
+                    , maximumTokenBundleSize = maximumTokenBundleSize
+                        (x :: ApiNetworkParameters)
+                    , eras = eras
+                        (x :: ApiNetworkParameters)
+                    , maximumCollateralInputCount = maximumCollateralInputCount
+                        (x :: ApiNetworkParameters)
+                    , minimumCollateralPercentage = minimumCollateralPercentage
+                        (x :: ApiNetworkParameters)
+                    , executionUnitPrices = executionUnitPrices
+                        (x :: ApiNetworkParameters)
                     }
             in
             x' === x .&&. show x' === show x

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2215,7 +2215,6 @@ components:
         - active_slot_coefficient
         - decentralization_level
         - desired_pool_number
-        - minimum_utxo_value
         - eras
         - maximum_collateral_input_count
         - maximum_token_bundle_size
@@ -2228,69 +2227,6 @@ components:
         active_slot_coefficient: *percentage
         decentralization_level: *percentage
         desired_pool_number: *stakePoolsNumber
-        minimum_utxo_value:
-          <<: *amount
-          description: |
-            The absolute minimum quantity of ada required for a new transaction
-            output created with the wallet.
-
-            Warning: This field may be deprecated or removed in future versions
-            of the wallet.
-
-            In general, the ledger rules require that every transaction output
-            has a minimum quantity of ada. This minimum quantity is determined
-            by an era-specific function whose value increases:
-
-              - as the number of different assets increases;
-              - as the quantity of any individual asset increases;
-              - as the length of the target address increases; and
-              - if a datum hash is added.
-
-            Therefore, the value reported by this field should only be viewed
-            as an absolute minimum, and only applies to outputs that send ada
-            (and no other assets) to addresses of the minimum possible length.
-            (At the time of writing, this corresponds to a 29-byte long
-            Shelley-era address.)
-
-            In practice, if an output contains other assets, specifies a datum
-            hash, or sends funds to an address that is longer than the absolute
-            minimum length, then the minimum value required by the ledger (and
-            the wallet) will be higher than the value reported by this field.
-
-            When using the wallet to construct or balance a transaction:
-
-              - if the caller specifies an output without an ada quantity, then
-                the wallet will automatically assign a minimal ada quantity to
-                the output that is guaranteed to be accepted by the ledger;
-
-              - if the caller specifes an output with a non-zero ada quantity,
-                then the wallet will verify that the specified quantity is not
-                less than the minimum quantity required by the ledger, and if
-                this verification step fails, return an error that reports the
-                required minimum.
-
-            In the Shelley, Allegra, and Mary eras, the `minimum_utxo_value`
-            field was equivalent to the ledger `minUTxOValue` protocol
-            parameter.
-
-            In the Alonzo era, the `minUTxOValue` protocol parameter was
-            replaced by the `coinsPerUTxOWord` protocol parameter. In this era,
-            the minimum ada quantity for an output was determined by
-            multiplying the `coinsPerUTxOWord` parameter by the length (in
-            8-byte words) of the in-memory representation of that output, which
-            was not dependent on the length of the address. Therefore, in this
-            era, specifying a longer address would not require an increase in
-            the minimum ada quantity.
-
-            In the Babbage era, the `coinsPerUTxOWord` protocol parameter was
-            replaced by the `coinsPerUTxOByte` protocol parameter. In this era,
-            the minimum ada quantity for an output is determined by multiplying
-            the `coinsPerUTxOByte` parameter by the length (in bytes) of the
-            serialised representation of the output, which is dependent on the
-            length of the address (among other factors).  Therefore, in this
-            era, specifying a longer address will require an increase in the
-            minimum ada quantity.
-
         eras: *ApiEraInfo
         maximum_collateral_input_count:
           <<: *collateralInputCount


### PR DESCRIPTION
## Issue Number

ADP-2250

## Summary

This PR removes the `minimum_utxo_value` field from the REST API.

Future PRs will improve our API documentation relating to the treatment of minimum UTxO values by other endpoints.