### PR TITLE
Bump version from 2022.8.16 to 2022.10.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ See **Installation Instructions** for each available [release](https://github.co
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
 > | `master` branch | [1.35.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
+> | [v2022-10-06](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-10-06) | [1.35.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-08-16](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-08-16) | [1.35.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-07-01](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-07-01) | [1.35.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.0) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
-> | [v2022-05-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-05-27) | [1.34.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.34.1) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 
 ## How to build from sources
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         max-size: "50m"
 
   cardano-wallet:
-    image: inputoutput/cardano-wallet:2022.8.16
+    image: inputoutput/cardano-wallet:2022.10.6
     volumes:
       - wallet-${NETWORK}-db:/wallet-db
       - node-ipc:/ipc

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-launcher
-version:             2022.8.16
+version:             2022.10.6
 synopsis:            Utilities for a building commands launcher
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-test-utils
-version:             2022.8.16
+version:             2022.10.6
 synopsis:            Shared utilities for writing unit and property tests.
 description:         Shared utilities for writing unit and property tests.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -1,5 +1,5 @@
 name:                text-class
-version:             2022.8.16
+version:             2022.10.6
 synopsis:            Extra helpers to convert data-types to and from Text
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               cardano-wallet
-version:            2022.8.16
+version:            2022.10.6
 synopsis:           The Wallet Backend for a Cardano node.
 description:        Please see README.md
 homepage:           https://github.com/input-output-hk/cardano-wallet

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -21,8 +21,8 @@ SCRIPT=$(realpath "$0")
 ################################################################################
 # Release-specific parameters. Can be changed interactively by running the script.
 # Release tags must follow format vYYYY-MM-DD.
-GIT_TAG="v2022-08-16"
-OLD_GIT_TAG="v2022-07-01"
+GIT_TAG="v2022-10-06"
+OLD_GIT_TAG="v2022-08-16"
 CARDANO_NODE_TAG="1.35.3"
 
 ################################################################################

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Cardano Wallet Backend API
-  version: v2022-08-16
+  version: v2022-10-06
   license:
     name: Apache-2.0
     url: https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/LICENSE


### PR DESCRIPTION
- [x] Bump version from 2022.8.16 to 2022.10.6 (4e34968032f52d09dc1178792ca2522f723ca9f4) 

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2245
