### PR TITLE
Break up `DBLayer` type into smaller components

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -332,6 +332,17 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -- ^ Execute operations of the database in isolation and atomically.
     }
 
+{-----------------------------------------------------------------------------
+    Helper functions
+------------------------------------------------------------------------------}
+-- | Clean a database by removing all wallets.
+cleanDB :: DBLayer m s k -> m ()
+cleanDB DBLayer{..} = atomically $
+    listWallets >>= mapM_ (runExceptT . removeWallet)
+
+{-----------------------------------------------------------------------------
+    Errors
+------------------------------------------------------------------------------}
 -- | Can't read the database file because it's in a bad format
 -- (corrupted, too old, …)
 data ErrBadFormat
@@ -364,8 +375,3 @@ data ErrNoSuchTransaction
 newtype ErrWalletAlreadyExists
     = ErrWalletAlreadyExists WalletId -- Wallet already exists in db
     deriving (Eq, Show)
-
--- | Clean a database by removing all wallets.
-cleanDB :: DBLayer m s k -> m ()
-cleanDB DBLayer{..} = atomically $
-    listWallets >>= mapM_ (runExceptT . removeWallet)


### PR DESCRIPTION
### Overview

This pull request aims to break up the `DBLayer` type in order to support future modularization of the wallet logic (e.g. transaction history, pending transactions, wallet state, …).

However, instead of removing the legacy `DBLayer` type outright, we introduce a function `mkDBLayerFromParts` which produces a value of the legacy type from the newly introduced parts. The main reason for doing so is I want the state machine tests to continue operating on the legacy type, as I believe it takes less developer effort to delete these tests wholesale in the future rather than to maintain and update them.

This pull request is part of the transitional architecture for the introduction of `DBVar`.

### Comments

* One reason for breaking down the `DBLayer` record first instead of moving everything to `DBVar` is that we may have to revisit the use of `DBVar` for the `TxHistory`.

### Issue Number

ADP-2292
