### PR TITLE
Move `ErrNoSuchWallet` out of `DBPrivateKey` and `DBDelegation`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -452,6 +452,12 @@ data DBWallets stm s = DBWallets
     , listWallets_
         :: stm [WalletId]
         -- ^ Get the list of all known wallets in the DB, possibly empty.
+
+    , hasWallet_
+        :: WalletId
+        -> stm Bool
+        -- ^ Check whether the wallet with 'WalletId' is present
+        -- in the database.
     }
 
 -- | A database layer for storing wallet states.

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -168,7 +168,7 @@ import Data.Generics.Internal.VL.Lens
 import Data.List
     ( sortOn )
 import Data.Maybe
-    ( catMaybes, fromMaybe, listToMaybe, maybeToList )
+    ( catMaybes, fromMaybe, isJust, listToMaybe, maybeToList )
 import Data.Ord
     ( Down (..) )
 import Data.Proxy
@@ -603,6 +603,8 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
                         in  (delta, Right ())
 
         , listWallets_ = map unWalletKey <$> selectKeysList [] [Asc WalId]
+
+        , hasWallet_ = fmap isJust . selectWallet
         }
 
         {-----------------------------------------------------------------------


### PR DESCRIPTION
This pull request aims to simplify `DBLayerCollection` components in order to support the future modularization of the wallet logic (e.g. transaction history, pending transactions, wallet state, …).

Here, we move the error `ErrNoSuchWallet` out of the `DBDelegation` and `DBPrivateKey` types. In other words, the responsibility for checking that a given WalletId exists has been shifted from these types to `mkDBLayerFromParts`.

This pull request is part of the transitional architecture for the introduction of DBVar.

### Issue Number

ADP-2293