### PR TITLE
Move `ErrNoSuchWallet` out of `DBTxHistory`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -719,13 +719,8 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
         -----------------------------------------------------------------------}
     let
       dbTxHistory = DBTxHistory
-        { putTxHistory_ = \wid txs -> ExceptT $ do
-            selectWallet wid >>= \case
-                Nothing -> pure $ Left $ ErrNoSuchWallet wid
-                Just _ -> modifyDBMaybe transactionsDBVar $ \_ ->
-                    let
-                        delta = Just $ ExpandTxWalletsHistory wid txs
-                    in  (delta, Right ())
+        { putTxHistory_ = \wid ->
+            updateDBVar transactionsDBVar . ExpandTxWalletsHistory wid
 
         , readTxHistory_ = \wid minWithdrawal order range status tip -> do
             txHistory <- readDBVar transactionsDBVar

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -741,16 +741,13 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
                         ti wid minWithdrawal
                         order filtering txHistory
 
-        , getTx_ = \wid tid -> ExceptT $ do
-            readCheckpoint wid >>= \case
-                Nothing -> pure $ Left $ ErrNoSuchWallet wid
-                Just cp -> do
-                    txHistory <- readDBVar transactionsDBVar
-                    metas <- lift $ selectTxHistory (view #currentTip cp)
-                        ti wid Nothing W.Descending
-                            (\meta -> txMetaTxId meta == TxId tid )
-                            txHistory
-                    pure $ Right $ listToMaybe metas
+        , getTx_ = \wid txid tip -> do
+            txHistory <- readDBVar transactionsDBVar
+            metas <- lift $ selectTxHistory tip
+                ti wid Nothing W.Descending
+                    (\meta -> txMetaTxId meta == TxId txid )
+                    txHistory
+            pure $ listToMaybe metas
         }
 
         {-----------------------------------------------------------------------


### PR DESCRIPTION
This pull request aims to simplify `DBLayerCollection` components in order to support the future modularization of the wallet logic (e.g. transaction history, pending transactions, wallet state, …).

Here, we accomplish two things:

* Change `DBTxHistory` to only depend on the latest tip rather than the latest checkpoint.
* Move `ErrNoSuchWallet` out of the `DBTxHistory `type.

This pull request is part of the transitional architecture for the introduction of `DBVar`.

### Issue Number

ADP-2294