### PR TITLE
Make it easier to clear cabal caches on more buildkite agents

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -101,3 +101,23 @@ steps:
     command: 'rm -vrf $CABAL_DIR'
     agents:
       system: x86_64-linux
+
+  - label: 'Clearing cabal cache 2'
+    command: 'rm -vrf $CABAL_DIR'
+    agents:
+      system: x86_64-linux
+
+  - label: 'Clearing cabal cache 3'
+    command: 'rm -vrf $CABAL_DIR'
+    agents:
+      system: x86_64-linux
+
+  - label: 'Clearing cabal cache 4'
+    command: 'rm -vrf $CABAL_DIR'
+    agents:
+      system: x86_64-linux
+
+  - label: 'Clearing cabal cache 5'
+    command: 'rm -vrf $CABAL_DIR'
+    agents:
+      system: x86_64-linux

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -93,6 +93,7 @@ steps:
       system: x86_64-linux
 
   - block: "Clear cabal cache"
+    prompt: "This command cannot guarantee the caches to be cleared on every buildkite agent, but will try to make this likely by scheduling many duplicated cache-clearing steps."
     key: 'should_clear_cache'
     allow_dependency_failure: true
     depends_on: [] # allows triggering this step even if previous steps failed


### PR DESCRIPTION
- [x] Add "hack" for clearing buildkite cabal caches on more than just 1 buildkite agent

<img width="1181" alt="Skärmavbild 2022-10-17 kl  12 42 54" src="https://user-images.githubusercontent.com/304423/196157839-dc74bfcd-ab5c-445e-b350-24ab4e614236.png">

### Comments

- I went with 5 steps because the buildkite agents seem to be split over 5 machines
    - not sure whether there are e.g. several containers with separate caches on each machine
    - If needed we can increase the number of steps in the future.

### Motivation

Need was discovered when attempting to merge #3522, whose cabal caches where somehow incompatible with those of master. Buildkite steps would not succeed on the PR without clearing the caches, and if a step completed after doing so (but not merge to master), it would break CI in other PRs.

Having the opportunity to clear the caches on "hopefully all" agents  should make dealing with cache-breaking PRs easier in the future.