### PR TITLE
[ADP-2322] Rename `TxHistory` model to `TxSet`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Store/CBOR/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/CBOR/Model.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Cardano.Wallet.DB.Store.CBOR.Model
-    ( TxCBORHistory (..)
+    ( TxCBORSet (..)
     , DeltaTxCBOR (..)
     )
     where
@@ -24,12 +24,12 @@ import Fmt
 import GHC.Generics
     ( Generic )
 
-newtype TxCBORHistory =
-    TxCBORHistory {relations :: Map TxId TxCBOR}
+newtype TxCBORSet =
+    TxCBORSet {relations :: Map TxId TxCBOR}
     deriving ( Eq, Show, Generic, Monoid, Semigroup )
 
 data DeltaTxCBOR
-    = Append TxCBORHistory
+    = Append TxCBORSet
     -- ^ Add or overwrite (by id) transactions cbor.
     | DeleteTx TxId
     -- ^ Remove cbor by transaction id.
@@ -39,7 +39,7 @@ instance Buildable DeltaTxCBOR where
     build = build . show
 
 instance Delta DeltaTxCBOR where
-    type Base DeltaTxCBOR = TxCBORHistory
+    type Base DeltaTxCBOR = TxCBORSet
     apply (Append addendum) x = addendum <> x
-    apply (DeleteTx tid) (TxCBORHistory m) = TxCBORHistory
+    apply (DeleteTx tid) (TxCBORSet m) = TxCBORSet
         $ Map.delete tid m

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/CBOR/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/CBOR/Store.hs
@@ -11,7 +11,7 @@
 Copyright: 2022 IOHK
 License: Apache-2.0
 
-Implementation of a 'Store' for 'TxCBORHistory'.
+Implementation of a 'Store' for 'TxCBORSet'.
 
 -}
 
@@ -24,7 +24,7 @@ import Cardano.Wallet.DB.Sqlite.Schema
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.CBOR.Model
-    ( DeltaTxCBOR (..), TxCBORHistory (..) )
+    ( DeltaTxCBOR (..), TxCBORSet (..) )
 import Cardano.Wallet.Read.Eras
 import Cardano.Wallet.Read.Tx.CBOR
     ( TxCBOR )
@@ -76,8 +76,8 @@ fromTxCBOR :: CBOR -> Either (CBOR, TxCBORRaw ) (TxId, TxCBOR)
 fromTxCBOR s@(CBOR {..}) = bimap (s ,) (cborTxId ,) $
     match eraValueSerialize $ (cborTxCBOR, cborTxEra) ^. fromIso i
 
-repsertCBORs :: TxCBORHistory -> SqlPersistT IO ()
-repsertCBORs (TxCBORHistory txs) =
+repsertCBORs :: TxCBORSet -> SqlPersistT IO ()
+repsertCBORs (TxCBORSet txs) =
     repsertMany
         [(fromJust keyFromRecordM x, x)
         | x <- fst . toTxCBOR <$> Map.assocs txs
@@ -94,7 +94,7 @@ mkStoreCBOR = Store
         cbors <- selectList [] []
         pure $ first (SomeException . CBOROutOfEra . snd) $ do
             ps <- mapM (fromTxCBOR . entityVal) cbors
-            pure . TxCBORHistory . Map.fromList $ ps
+            pure . TxCBORSet . Map.fromList $ ps
     , writeS = \txs -> do
           repsertCBORs txs
     , updateS = \_ -> \case

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/TransactionsWithCBOR/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/TransactionsWithCBOR/Store.hs
@@ -22,7 +22,7 @@ import Cardano.Wallet.DB.Store.CBOR.Store
 import Cardano.Wallet.DB.Store.Transactions.Store
     ( mkStoreTransactions )
 import Cardano.Wallet.DB.Store.TransactionsWithCBOR.Model
-    ( DeltaTx (Append, DeleteTx), TxHistoryWithCBOR (TxHistoryWithCBOR) )
+    ( DeltaTx (Append, DeleteTx), TxSetWithCBOR (..) )
 import Control.Monad.Except
     ( ExceptT (..), runExceptT )
 import Data.DBVar
@@ -38,14 +38,14 @@ mkStoreTransactionsWithCBOR
     :: Store (SqlPersistT IO) WithCBOR.DeltaTx
 mkStoreTransactionsWithCBOR =
     Store
-    { loadS = runExceptT $ TxHistoryWithCBOR
+    { loadS = runExceptT $ TxSetWithCBOR
                 <$> ExceptT (loadS mkStoreTransactions)
                 <*> ExceptT (loadS mkStoreCBOR)
-    , writeS = \(TxHistoryWithCBOR txs cbors) -> do
+    , writeS = \(TxSetWithCBOR txs cbors) -> do
                 writeS mkStoreTransactions txs
                 writeS mkStoreCBOR cbors
-    , updateS = \(TxHistoryWithCBOR oldtxs oldcbors) -> \case
-        Append (TxHistoryWithCBOR newtxs newcbors) -> do
+    , updateS = \(TxSetWithCBOR oldtxs oldcbors) -> \case
+        Append (TxSetWithCBOR newtxs newcbors) -> do
             updateS mkStoreTransactions oldtxs (Txs.Append newtxs)
             updateS mkStoreCBOR oldcbors (CBOR.Append newcbors)
         DeleteTx tid  -> do

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -34,15 +34,15 @@ import Cardano.Wallet.DB.Store.Submissions.Model
 import Cardano.Wallet.DB.Store.Submissions.Store
     ( mkStoreSubmissions )
 import Cardano.Wallet.DB.Store.Transactions.Model
-    ( TxHistory (..) )
+    ( TxSet (..) )
 import Cardano.Wallet.DB.Store.TransactionsWithCBOR.Model
-    ( DeltaTx (..), TxHistoryWithCBOR (TxHistoryWithCBOR) )
+    ( DeltaTx (..), TxSetWithCBOR (..) )
 import Cardano.Wallet.DB.Store.TransactionsWithCBOR.Store
     ( mkStoreTransactionsWithCBOR )
 import Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaTxWalletsHistory (..)
     , DeltaWalletsMetaWithSubmissions (..)
-    , mkTxHistoryWithCBORs
+    , mkTxSetWithCBOR
     , walletsLinkedTransactions
     )
 import Control.Applicative
@@ -152,10 +152,10 @@ mkStoreTxWalletsHistory =
           liftA2 (,)
             <$> loadS mkStoreTransactionsWithCBOR
             <*> loadS mkStoreWalletsMetaWithSubmissions
-    , writeS = \(txHistory,txMetaHistory) -> do
-          writeS mkStoreTransactionsWithCBOR txHistory
+    , writeS = \(txSet,txMetaHistory) -> do
+          writeS mkStoreTransactionsWithCBOR txSet
           writeS mkStoreWalletsMetaWithSubmissions txMetaHistory
-    , updateS = \(txh@(TxHistoryWithCBOR (TxHistory mtxh) _) ,mtxmh) -> \case
+    , updateS = \(txh@(TxSetWithCBOR (TxSet mtxh) _) ,mtxmh) -> \case
             ChangeTxMetaWalletsHistory wid change
                 -> updateS mkStoreWalletsMetaWithSubmissions mtxmh
                 $ Adjust wid change
@@ -169,7 +169,7 @@ mkStoreTxWalletsHistory =
             ExpandTxWalletsHistory wid cs -> do
                 updateS mkStoreTransactionsWithCBOR txh
                     $ Append
-                    $ mkTxHistoryWithCBORs
+                    $ mkTxSetWithCBOR
                     $ fst <$> cs
                 updateS mkStoreWalletsMetaWithSubmissions mtxmh
                     $ case Map.lookup wid mtxmh of

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/CBOR/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/CBOR/ModelSpec.hs
@@ -8,7 +8,7 @@ import Cardano.Wallet.DB.Arbitrary
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.CBOR.Model
-    ( DeltaTxCBOR (..), TxCBORHistory (..) )
+    ( DeltaTxCBOR (..), TxCBORSet (..) )
 import Control.Monad
     ( forM )
 import Test.Hspec
@@ -22,24 +22,24 @@ spec :: Spec
 spec = pure ()
 
 genDeltas
-    :: TxCBORHistory
+    :: TxCBORSet
     -- ^ submitted ones
     -> Gen (DeltaTxCBOR)
 genDeltas  old = genDeltasConstrained old Nothing
 
 genDeltasConstrained
-    ::  TxCBORHistory
+    ::  TxCBORSet
     -- ^ submitted ones
     -> Maybe [TxId]
     -- ^ possible pool of txids
     -> Gen (DeltaTxCBOR)
-genDeltasConstrained (TxCBORHistory old) txids = frequency $
+genDeltasConstrained (TxCBORSet old) txids = frequency $
     [(1, sized $ \n -> do
         tids <- genTxIds n txids
         locals <- forM tids $ \txId' -> do
                 txcbor  <- arbitrary
                 pure (txId', txcbor)
-        pure $ Append . TxCBORHistory $ Map.fromList locals)
+        pure $ Append . TxCBORSet $ Map.fromList locals)
     ] <>
     [(3, DeleteTx <$> elements (Map.keys old) ) | not (null old)]
 

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -20,14 +20,14 @@ import Cardano.Wallet.DB.Fixtures
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (TxId) )
 import Cardano.Wallet.DB.Store.Transactions.Model
-    ( DeltaTxHistory (..)
-    , TxHistory (..)
+    ( DeltaTxSet (..)
+    , TxSet (..)
     , collateralIns
     , decorateTxIns
     , ins
     , lookupTxOutForTxCollateral
     , lookupTxOutForTxIn
-    , mkTxHistory
+    , mkTxSet
     )
 import Cardano.Wallet.DB.Store.Transactions.Store
     ( mkStoreTransactions )
@@ -85,11 +85,11 @@ prop_DecorateLinksTxInToTxOuts = do
                     , let txin = (W.TxIn txId txOutPos, W.Coin 0)
                     ]
             let guinea' = set #resolvedInputs txins guinea
-            pure (guineaId, mkTxHistory (guinea' : transactions), txouts)
+            pure (guineaId, mkTxSet (guinea' : transactions), txouts)
 
-    forAll transactionsGen $ \(txid, TxHistory history, txouts) ->
-        let guinea = history Map.! txid
-            deco   = decorateTxIns (TxHistory history) guinea
+    forAll transactionsGen $ \(txid, TxSet pile, txouts) ->
+        let guinea = pile Map.! txid
+            deco   = decorateTxIns (TxSet pile) guinea
         in  [ lookupTxOutForTxIn txin deco | txin <- ins guinea]
             === map Just txouts
 
@@ -112,11 +112,11 @@ prop_DecorateLinksTxCollateralsToTxOuts = do
                     , let txin = (W.TxIn txId txOutPos, W.Coin 0)
                     ]
             let guinea' = set #resolvedCollateralInputs txins guinea
-            pure (guineaId, mkTxHistory (guinea' : transactions), txouts)
+            pure (guineaId, mkTxSet (guinea' : transactions), txouts)
 
-    forAll transactionsGen $ \(txid, TxHistory history, txouts) ->
-        let guinea = history Map.! txid
-            deco   = decorateTxIns (TxHistory history) guinea
+    forAll transactionsGen $ \(txid, TxSet pile, txouts) ->
+        let guinea = pile Map.! txid
+            deco   = decorateTxIns (TxSet pile) guinea
         in  [ lookupTxOutForTxCollateral txcol deco
             | txcol <- collateralIns guinea
             ]
@@ -130,17 +130,17 @@ prop_StoreLaws = withStoreProp $ \runQ ->
         (pure mempty)
         (logScale . genDeltas)
 
--- | Generate interesting changes to 'TxHistory'.
-genDeltas :: GenDelta DeltaTxHistory
-genDeltas (TxHistory history) =
+-- | Generate interesting changes to 'TxSet'.
+genDeltas :: GenDelta DeltaTxSet
+genDeltas (TxSet pile) =
     frequency
-        [ (8, Append . mkTxHistory <$> arbitrary)
+        [ (8, Append . mkTxSet <$> arbitrary)
         , (1, DeleteTx . TxId <$> arbitrary)
         ,
             ( 2
             , DeleteTx
-                <$> if null history
+                <$> if null pile
                     then TxId <$> arbitrary
-                    else elements (Map.keys history)
+                    else elements (Map.keys pile)
             )
         ]


### PR DESCRIPTION
This pull request renames the data type `TxHistory` from `Cardano.Wallet.DB.Store.Transactions.Model` to `TxPile`, as this better reflects the purpose of the data type — it's a pile of transactions.

### Issue Number

ADP-2322