### PR TITLE
Use `DerivingVia` to reduce boilerplate in `Api.Types`.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Lib/Options.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Lib/Options.hs
@@ -12,6 +12,8 @@ module Cardano.Wallet.Api.Lib.Options
     , explicitNothingRecordTypeOptions
     , strictRecordTypeOptions
     , taggedSumTypeOptions
+
+    -- * Support for deriving default JSON encodings
     , DefaultRecord (..)
     , DefaultSum (..)
     )
@@ -69,6 +71,19 @@ explicitNothingRecordTypeOptions = defaultRecordTypeOptions
     { omitNothingFields = False
     }
 
+-- | Enables deriving of the default API JSON encoding for record types.
+--
+-- Usage:
+--
+-- @
+-- data ApiMyRecord = ApiMyRecord
+--     { foo :: Foo
+--     , bar :: Bar
+--     , baz :: Baz
+--     }
+--     deriving (FromJSON, ToJSON) via DefaultRecord ApiMyRecord
+-- @
+--
 newtype DefaultRecord a = DefaultRecord {unDefaultRecord :: a}
 
 instance (Generic a, GFromJSON Zero (Rep a)) => FromJSON (DefaultRecord a)
@@ -79,6 +94,18 @@ instance (Generic a, GToJSON' Value Zero (Rep a)) => ToJSON (DefaultRecord a)
   where
     toJSON = genericToJSON defaultRecordTypeOptions . unDefaultRecord
 
+-- | Enables deriving of the default API JSON encoding for sum types.
+--
+-- Usage:
+--
+-- @
+-- data ApiMySum
+--     = Foo
+--     | Bar
+--     | Baz
+--     deriving (FromJSON, ToJSON) via DefaultSum ApiMySum
+-- @
+--
 newtype DefaultSum a = DefaultSum {unDefaultSum :: a}
 
 instance (Generic a, GFromJSON Zero (Rep a)) => FromJSON (DefaultSum a)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Lib/Options.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Lib/Options.hs
@@ -13,6 +13,7 @@ module Cardano.Wallet.Api.Lib.Options
     , strictRecordTypeOptions
     , taggedSumTypeOptions
     , DefaultRecord (..)
+    , DefaultSum (..)
     )
     where
 
@@ -77,3 +78,13 @@ instance (Generic a, GFromJSON Zero (Rep a)) => FromJSON (DefaultRecord a)
 instance (Generic a, GToJSON' Value Zero (Rep a)) => ToJSON (DefaultRecord a)
   where
     toJSON = genericToJSON defaultRecordTypeOptions . unDefaultRecord
+
+newtype DefaultSum a = DefaultSum {unDefaultSum :: a}
+
+instance (Generic a, GFromJSON Zero (Rep a)) => FromJSON (DefaultSum a)
+  where
+    parseJSON = fmap DefaultSum . genericParseJSON defaultSumTypeOptions
+
+instance (Generic a, GToJSON' Value Zero (Rep a)) => ToJSON (DefaultSum a)
+  where
+    toJSON = genericToJSON defaultSumTypeOptions . unDefaultSum

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -2261,12 +2261,6 @@ instance FromJSON ApiFee where
 instance ToJSON ApiFee where
     toJSON = genericToJSON defaultRecordTypeOptions
 
-instance (PassphraseMaxLength purpose, PassphraseMinLength purpose)
-    => FromJSON (ApiT (Passphrase purpose)) where
-    parseJSON = fromTextApiT "Passphrase"
-instance ToJSON (ApiT (Passphrase purpose)) where
-    toJSON = toTextApiT
-
 instance FromJSON ApiCredential where
     parseJSON v =
         (CredentialScriptHash . ScriptHash <$> parseCredential 28 ["script"] v) <|>

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -1012,7 +1012,8 @@ data ApiMultiDelegationAction
     deriving anyclass NFData
 
 -- | Input parameters for transaction construction.
-data ApiConstructTransactionData (n :: NetworkDiscriminant) = ApiConstructTransactionData
+data ApiConstructTransactionData (n :: NetworkDiscriminant) =
+    ApiConstructTransactionData
     { payments :: !(Maybe (ApiPaymentDestination n))
     , withdrawal :: !(Maybe ApiSelfWithdrawalPostData)
     , metadata :: !(Maybe TxMetadataWithSchema)
@@ -1069,7 +1070,8 @@ data PostTransactionOldData (n :: NetworkDiscriminant) = PostTransactionOldData
     deriving (Eq, Generic, Show, Typeable)
 
 -- | Legacy transaction API.
-data PostTransactionFeeOldData (n :: NetworkDiscriminant) = PostTransactionFeeOldData
+data PostTransactionFeeOldData (n :: NetworkDiscriminant) =
+    PostTransactionFeeOldData
     { payments :: !(NonEmpty (ApiTxOutput n))
     , withdrawal :: !(Maybe ApiWithdrawalPostData)
     , metadata :: !(Maybe TxMetadataWithSchema )
@@ -1097,7 +1099,8 @@ data ApiExternalInput (n :: NetworkDiscriminant) = ApiExternalInput
     deriving (Eq, Generic, Show, Typeable)
     deriving anyclass NFData
 
-data ApiBalanceTransactionPostData (n :: NetworkDiscriminant) = ApiBalanceTransactionPostData
+data ApiBalanceTransactionPostData (n :: NetworkDiscriminant) =
+    ApiBalanceTransactionPostData
     { transaction :: !(ApiT SealedTx)
     , inputs :: ![ApiExternalInput n]
     , redeemers :: ![ApiRedeemer n]
@@ -1479,10 +1482,12 @@ data ApiScriptTemplateEntry = ApiScriptTemplateEntry
     deriving (Eq, Generic, Show)
     deriving anyclass NFData
 
-data ApiSharedWalletPostDataFromMnemonics = ApiSharedWalletPostDataFromMnemonics
+data ApiSharedWalletPostDataFromMnemonics =
+    ApiSharedWalletPostDataFromMnemonics
     { name :: !(ApiT WalletName)
     , mnemonicSentence :: !(ApiMnemonicT (AllowedMnemonics 'Shelley))
-    , mnemonicSecondFactor :: !(Maybe (ApiMnemonicT (AllowedMnemonics 'SndFactor)))
+    , mnemonicSecondFactor
+        :: !(Maybe (ApiMnemonicT (AllowedMnemonics 'SndFactor)))
     , passphrase :: !(ApiT (Passphrase "user"))
     , accountIndex :: !(ApiT DerivationIndex)
     , paymentScriptTemplate :: !ApiScriptTemplateEntry
@@ -1491,7 +1496,8 @@ data ApiSharedWalletPostDataFromMnemonics = ApiSharedWalletPostDataFromMnemonics
     }
     deriving (Eq, Generic, Show)
 
-data ApiSharedWalletPostDataFromAccountPubX = ApiSharedWalletPostDataFromAccountPubX
+data ApiSharedWalletPostDataFromAccountPubX =
+    ApiSharedWalletPostDataFromAccountPubX
     { name :: !(ApiT WalletName)
     , accountPublicKey :: !ApiAccountPublicKey
     , accountIndex :: !(ApiT DerivationIndex)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -613,11 +613,13 @@ newtype ApiMaintenanceAction = ApiMaintenanceAction
 
 newtype ApiPolicyId = ApiPolicyId
     { policyId :: ApiT W.TokenPolicyId
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 newtype ApiPostPolicyIdData = ApiPostPolicyIdData
     { policyScriptTemplate :: (ApiT (Script Cosigner))
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 data ApiAsset = ApiAsset
     { policyId :: ApiT W.TokenPolicyId
@@ -625,8 +627,9 @@ data ApiAsset = ApiAsset
     , fingerprint :: ApiT W.TokenFingerprint
     , metadata :: Maybe ApiAssetMetadata
     , metadataError :: Maybe ApiMetadataError
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data ApiMetadataError = Fetch | Parse
     deriving (Eq, Generic, Show)
@@ -639,8 +642,9 @@ data ApiAssetMetadata = ApiAssetMetadata
     , url :: Maybe (ApiT W.AssetURL)
     , logo :: Maybe (ApiT W.AssetLogo)
     , decimals :: Maybe (ApiT W.AssetDecimals)
-    } deriving (Eq, Generic, Ord, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Ord, Show)
+    deriving anyclass NFData
 
 toApiAsset
     :: Either TokenMetadataError (Maybe W.AssetMetadata)
@@ -668,8 +672,9 @@ data ApiAddress (n :: NetworkDiscriminant) = ApiAddress
     { id :: !(ApiT Address, Proxy n)
     , state :: !(ApiT AddressState)
     , derivationPath :: NonEmpty (ApiT DerivationIndex)
-    } deriving (Eq, Generic, Show, Typeable)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show, Typeable)
+    deriving anyclass NFData
 
 data ApiCredential =
       CredentialExtendedPubKey ByteString
@@ -682,7 +687,8 @@ data ApiCredential =
 data ApiAddressData = ApiAddressData
     { address :: !ApiAddressDataPayload
     , validationLevel :: !(Maybe (ApiT ValidationLevel))
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 data ApiAddressDataPayload =
       AddrEnterprise ApiCredential
@@ -699,7 +705,8 @@ data AnyAddress = AnyAddress
     { payload :: ByteString
     , flavour :: AnyAddressType
     , network :: Int
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 data ApiSelectCoinsData (n :: NetworkDiscriminant)
     = ApiSelectForPayment (ApiSelectCoinsPayments n)
@@ -710,7 +717,8 @@ data ApiSelectCoinsPayments (n :: NetworkDiscriminant) = ApiSelectCoinsPayments
     { payments :: NonEmpty (ApiTxOutput n)
     , withdrawal :: !(Maybe ApiWithdrawalPostData)
     , metadata :: !(Maybe (ApiT TxMetadata))
-    } deriving (Eq, Generic, Show, Typeable)
+    }
+    deriving (Eq, Generic, Show, Typeable)
 
 newtype ApiSelectCoinsAction = ApiSelectCoinsAction
     { delegationAction :: ApiDelegationAction
@@ -732,23 +740,26 @@ data ApiCoinSelection (n :: NetworkDiscriminant) = ApiCoinSelection
     , depositsTaken :: ![Quantity "lovelace" Natural]
     , depositsReturned :: ![Quantity "lovelace" Natural]
     , metadata :: !(Maybe ApiBase64)
-    } deriving (Eq, Generic, Show, Typeable)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show, Typeable)
+    deriving anyclass NFData
 
 data ApiCoinSelectionChange (n :: NetworkDiscriminant) = ApiCoinSelectionChange
     { address :: !(ApiT Address, Proxy n)
     , amount :: !(Quantity "lovelace" Natural)
     , assets :: !(ApiT TokenMap)
     , derivationPath :: NonEmpty (ApiT DerivationIndex)
-    } deriving (Eq, Generic, Show, Typeable)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show, Typeable)
+    deriving anyclass NFData
 
 data ApiCoinSelectionOutput (n :: NetworkDiscriminant) = ApiCoinSelectionOutput
     { address :: !(ApiT Address, Proxy n)
     , amount :: !(Quantity "lovelace" Natural)
     , assets :: !(ApiT TokenMap)
-    } deriving (Eq, Ord, Generic, Show, Typeable)
-      deriving anyclass (NFData, Hashable)
+    }
+    deriving (Eq, Ord, Generic, Show, Typeable)
+    deriving anyclass (NFData, Hashable)
 
 data ApiCoinSelectionCollateral (n :: NetworkDiscriminant) =
     ApiCoinSelectionCollateral
@@ -771,21 +782,24 @@ data ApiWallet = ApiWallet
     , passphrase :: !(Maybe ApiWalletPassphraseInfo)
     , state :: !(ApiT SyncProgress)
     , tip :: !ApiBlockReference
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data ApiWalletBalance = ApiWalletBalance
     { available :: !(Quantity "lovelace" Natural)
     , total :: !(Quantity "lovelace" Natural)
     , reward :: !(Quantity "lovelace" Natural)
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data ApiWalletAssetsBalance = ApiWalletAssetsBalance
     { available :: !(ApiT TokenMap)
     , total :: !(ApiT TokenMap)
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 newtype ApiWalletPassphraseInfo = ApiWalletPassphraseInfo
     { lastUpdatedAt :: UTCTime
@@ -797,15 +811,17 @@ newtype ApiWalletPassphraseInfo = ApiWalletPassphraseInfo
 data ApiWalletDelegation = ApiWalletDelegation
     { active :: !ApiWalletDelegationNext
     , next :: ![ApiWalletDelegationNext]
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data ApiWalletDelegationNext = ApiWalletDelegationNext
     { status :: !ApiWalletDelegationStatus
     , target :: !(Maybe (ApiT PoolId))
     , changesAt :: !(Maybe EpochInfo)
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data ApiWalletDelegationStatus
     = NotDelegating
@@ -839,8 +855,9 @@ data ApiUtxoStatistics = ApiUtxoStatistics
     { total :: !(Quantity "lovelace" Natural)
     , scale :: !(ApiT BoundType)
     , distribution :: !(Map Word64 Word64)
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 toApiUtxoStatistics :: UTxOStatistics -> ApiUtxoStatistics
 toApiUtxoStatistics (UTxOStatistics histo totalStakes bType) =
@@ -856,7 +873,8 @@ data WalletPostData = WalletPostData
     , mnemonicSecondFactor :: !(Maybe (ApiMnemonicT (AllowedMnemonics 'SndFactor)))
     , name :: !(ApiT WalletName)
     , passphrase :: !(ApiT (Passphrase "user"))
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 data SomeByronWalletPostData
     = RandomWalletFromMnemonic (ByronWalletPostData (AllowedMnemonics 'Random))
@@ -871,7 +889,8 @@ data ByronWalletPostData mw = ByronWalletPostData
     { mnemonicSentence :: !(ApiMnemonicT mw)
     , name :: !(ApiT WalletName)
     , passphrase :: !(ApiT (Passphrase "user"))
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 data ByronWalletFromXPrvPostData = ByronWalletFromXPrvPostData
     { name :: !(ApiT WalletName)
@@ -884,8 +903,9 @@ data ByronWalletFromXPrvPostData = ByronWalletFromXPrvPostData
     -- - logN = 14
     -- - r = 8
     -- - p = 1
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 newtype ApiAccountPublicKey = ApiAccountPublicKey
     { key :: (ApiT XPub)
@@ -904,7 +924,8 @@ data AccountPostData = AccountPostData
     { name :: !(ApiT WalletName)
     , accountPublicKey :: !ApiAccountPublicKey
     , addressPoolGap :: !(Maybe (ApiT AddressPoolGap))
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 newtype WalletPutData = WalletPutData
     { name :: (Maybe (ApiT WalletName))
@@ -922,12 +943,14 @@ data WalletPutPassphraseMnemonicData = WalletPutPassphraseMnemonicData
     { mnemonicSentence :: !(ApiMnemonicT (AllowedMnemonics 'Shelley))
     , mnemonicSecondFactor :: !(Maybe (ApiMnemonicT (AllowedMnemonics 'SndFactor)))
     , newPassphrase :: !(ApiT (Passphrase "user"))
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 data WalletPutPassphraseOldPassphraseData = WalletPutPassphraseOldPassphraseData
     { oldPassphrase :: !(ApiT (Passphrase "user"))
     , newPassphrase :: !(ApiT (Passphrase "user"))
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 newtype WalletPutPassphraseData = WalletPutPassphraseData
     (  Either
@@ -939,11 +962,12 @@ newtype WalletPutPassphraseData = WalletPutPassphraseData
 data ByronWalletPutPassphraseData = ByronWalletPutPassphraseData
     { oldPassphrase :: !(Maybe (ApiT (Passphrase "lenient")))
     , newPassphrase :: !(ApiT (Passphrase "user"))
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 data ApiSealedTxEncoding = HexEncoded | Base64Encoded
-      deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 instance ToText ApiSealedTxEncoding where
     toText HexEncoded = "base16"
@@ -968,8 +992,9 @@ data ApiConstructTransaction (n :: NetworkDiscriminant) = ApiConstructTransactio
     { transaction :: !ApiSerialisedTransaction
     , coinSelection :: !(ApiCoinSelection n)
     , fee :: !(Quantity "lovelace" Natural)
-    } deriving (Eq, Generic, Show, Typeable)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show, Typeable)
+    deriving anyclass NFData
 
 -- | Index of the stake key.
 newtype ApiStakeKeyIndex = ApiStakeKeyIndex (ApiT DerivationIndex)
@@ -995,7 +1020,8 @@ data ApiConstructTransactionData (n :: NetworkDiscriminant) = ApiConstructTransa
     , delegations :: !(Maybe (NonEmpty ApiMultiDelegationAction))
     , validityInterval :: !(Maybe ApiValidityInterval)
     , encoding :: !(Maybe ApiSealedTxEncoding)
-    } deriving (Eq, Generic, Show, Typeable)
+    }
+    deriving (Eq, Generic, Show, Typeable)
     deriving anyclass NFData
 
 newtype ApiPaymentDestination (n :: NetworkDiscriminant)
@@ -1010,7 +1036,8 @@ data ApiValidityInterval = ApiValidityInterval
     -- ^ Tx is not valid before this time. Defaults to genesis.
     , invalidHereafter :: !(Maybe ApiValidityBound)
     -- ^ Tx is not valid at this time and after. Defaults to now + 2 hours.
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
     deriving anyclass NFData
 
 -- | One side of the validity interval.
@@ -1028,7 +1055,8 @@ data ApiSignTransactionPostData = ApiSignTransactionPostData
     { transaction :: !(ApiT SealedTx)
     , passphrase :: !(ApiT (Passphrase "lenient"))
     , encoding :: !(Maybe ApiSealedTxEncoding)
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 -- | Legacy transaction API.
 data PostTransactionOldData (n :: NetworkDiscriminant) = PostTransactionOldData
@@ -1037,7 +1065,8 @@ data PostTransactionOldData (n :: NetworkDiscriminant) = PostTransactionOldData
     , withdrawal :: !(Maybe ApiWithdrawalPostData)
     , metadata :: !(Maybe TxMetadataWithSchema)
     , timeToLive :: !(Maybe (Quantity "second" NominalDiffTime))
-    } deriving (Eq, Generic, Show, Typeable)
+    }
+    deriving (Eq, Generic, Show, Typeable)
 
 -- | Legacy transaction API.
 data PostTransactionFeeOldData (n :: NetworkDiscriminant) = PostTransactionFeeOldData
@@ -1045,15 +1074,17 @@ data PostTransactionFeeOldData (n :: NetworkDiscriminant) = PostTransactionFeeOl
     , withdrawal :: !(Maybe ApiWithdrawalPostData)
     , metadata :: !(Maybe TxMetadataWithSchema )
     , timeToLive :: !(Maybe (Quantity "second" NominalDiffTime))
-    } deriving (Eq, Generic, Show, Typeable)
+    }
+    deriving (Eq, Generic, Show, Typeable)
 
 type ApiBase64 = ApiBytesT 'Base64 ByteString
 
 data ApiSerialisedTransaction = ApiSerialisedTransaction
     { serialisedTxSealed :: ApiT SealedTx
     , serialisedTxEncoding :: ApiSealedTxEncoding
-    } deriving stock (Eq, Generic, Show)
-      deriving anyclass (NFData)
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving anyclass (NFData)
 
 data ApiExternalInput (n :: NetworkDiscriminant) = ApiExternalInput
     { id :: !(ApiT (Hash "Tx"))
@@ -1062,15 +1093,17 @@ data ApiExternalInput (n :: NetworkDiscriminant) = ApiExternalInput
     , amount :: !(Quantity "lovelace" Natural)
     , assets :: !(ApiT TokenMap)
     , datum :: !(Maybe (ApiT (Hash "Datum")))
-    } deriving (Eq, Generic, Show, Typeable)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show, Typeable)
+    deriving anyclass NFData
 
 data ApiBalanceTransactionPostData (n :: NetworkDiscriminant) = ApiBalanceTransactionPostData
     { transaction :: !(ApiT SealedTx)
     , inputs :: ![ApiExternalInput n]
     , redeemers :: ![ApiRedeemer n]
     , encoding :: !(Maybe ApiSealedTxEncoding)
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 type ApiRedeemerData = ApiBytesT 'Base16 ByteString
 
@@ -1085,7 +1118,8 @@ data ApiFee = ApiFee
     , estimatedMax :: !(Quantity "lovelace" Natural)
     , minimumCoins :: ![Quantity "lovelace" Natural]
     , deposit :: !(Quantity "lovelace" Natural)
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 data ApiNetworkParameters = ApiNetworkParameters
     { genesisBlockHash :: !(ApiT (Hash "Genesis"))
@@ -1101,7 +1135,8 @@ data ApiNetworkParameters = ApiNetworkParameters
     , maximumCollateralInputCount :: !Word16
     , minimumCollateralPercentage :: !Natural
     , executionUnitPrices :: !(Maybe ExecutionUnitPrices)
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 data ApiEraInfo = ApiEraInfo
     { byron :: !(Maybe EpochInfo)
@@ -1110,7 +1145,8 @@ data ApiEraInfo = ApiEraInfo
     , mary :: !(Maybe EpochInfo)
     , alonzo :: !(Maybe EpochInfo)
     , babbage :: !(Maybe EpochInfo)
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 toApiNetworkParameters
     :: Monad m
@@ -1204,8 +1240,9 @@ data ApiCoinSelectionWithdrawal n = ApiCoinSelectionWithdrawal
     { stakeAddress :: !(ApiT W.RewardAccount, Proxy n)
     , derivationPath :: !(NonEmpty (ApiT DerivationIndex))
     , amount :: !(Quantity "lovelace" Natural)
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data ApiSelfWithdrawalPostData = SelfWithdraw
     deriving (Eq, Generic, Show)
@@ -1220,14 +1257,16 @@ data ApiWithdrawalPostData
 data ApiTxInput (n :: NetworkDiscriminant) = ApiTxInput
     { source :: !(Maybe (ApiTxOutput n))
     , input :: !(ApiT TxIn)
-    } deriving (Eq, Generic, Show, Typeable)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show, Typeable)
+    deriving anyclass NFData
 
 data ApiTxCollateral (n :: NetworkDiscriminant) = ApiTxCollateral
     { source :: !(Maybe (AddressAmountNoAssets (ApiT Address, Proxy n)))
     , input :: !(ApiT TxIn)
-    } deriving (Eq, Generic, Show, Typeable)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show, Typeable)
+    deriving anyclass NFData
 
 data AddressAmountNoAssets addr = AddressAmountNoAssets
     { address :: !addr
@@ -1253,22 +1292,25 @@ data ApiSlotReference = ApiSlotReference
     { absoluteSlotNumber :: !(ApiT SlotNo)
     , slotId :: !ApiSlotId
     , time :: !UTCTime
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data ApiSlotId = ApiSlotId
     { epochNumber :: !(ApiT EpochNo)
     , slotNumber :: !(ApiT SlotInEpoch)
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data ApiBlockReference = ApiBlockReference
     { absoluteSlotNumber :: !(ApiT SlotNo)
     , slotId :: !ApiSlotId
     , time :: !UTCTime
     , block :: !ApiBlockInfo
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 newtype ApiBlockInfo = ApiBlockInfo
     { height :: Quantity "block" Natural
@@ -1354,8 +1396,9 @@ newtype ApiNetworkClock = ApiNetworkClock { ntpStatus :: NtpStatusWithOffset }
 data ApiPostRandomAddressData = ApiPostRandomAddressData
     { passphrase :: !(ApiT (Passphrase "lenient"))
     , addressIndex :: !(Maybe (ApiT (Index 'AD.Hardened 'CredFromKeyK)))
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 newtype ApiWalletMigrationPlanPostData (n :: NetworkDiscriminant) =
     ApiWalletMigrationPlanPostData
@@ -1369,8 +1412,9 @@ data ApiWalletMigrationPostData (n :: NetworkDiscriminant) (s :: Symbol) =
     ApiWalletMigrationPostData
     { passphrase :: !(ApiT (Passphrase s))
     , addresses :: !(NonEmpty (ApiT Address, Proxy n))
-    } deriving (Eq, Generic, Show, Typeable)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show, Typeable)
+    deriving anyclass NFData
 
 newtype ApiPutAddressesData (n :: NetworkDiscriminant) = ApiPutAddressesData
     { addresses :: [(ApiT Address, Proxy n)]
@@ -1382,16 +1426,18 @@ newtype ApiPutAddressesData (n :: NetworkDiscriminant) = ApiPutAddressesData
 data ApiWalletMigrationBalance = ApiWalletMigrationBalance
     { ada :: !(Quantity "lovelace" Natural)
     , assets :: !(ApiT TokenMap)
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data ApiWalletMigrationPlan (n :: NetworkDiscriminant) = ApiWalletMigrationPlan
     { selections :: !(NonEmpty (ApiCoinSelection n))
     , totalFee :: Quantity "lovelace" Natural
     , balanceLeftover :: ApiWalletMigrationBalance
     , balanceSelected :: ApiWalletMigrationBalance
-    } deriving (Eq, Generic, Show, Typeable)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show, Typeable)
+    deriving anyclass NFData
 
 newtype ApiWithdrawRewards = ApiWithdrawRewards Bool
     deriving (Eq, Generic, Show)
@@ -1400,8 +1446,9 @@ newtype ApiWithdrawRewards = ApiWithdrawRewards Bool
 data ApiWalletSignData = ApiWalletSignData
     { metadata :: ApiT TxMetadata
     , passphrase :: ApiT (Passphrase "lenient")
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 instance FromHttpApiData KeyFormat where
     parseUrlPiece = first (T.pack . getTextDecodingError) . fromText
@@ -1409,15 +1456,17 @@ instance FromHttpApiData KeyFormat where
 data ApiPostAccountKeyData = ApiPostAccountKeyData
     { passphrase :: ApiT (Passphrase "user")
     , format :: KeyFormat
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data ApiPostAccountKeyDataWithPurpose = ApiPostAccountKeyDataWithPurpose
     { passphrase :: ApiT (Passphrase "user")
     , format :: KeyFormat
     , purpose :: Maybe (ApiT DerivationIndex)
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data XPubOrSelf = SomeAccountKey XPub | Self
     deriving (Eq, Generic, Show)
@@ -1426,8 +1475,9 @@ data XPubOrSelf = SomeAccountKey XPub | Self
 data ApiScriptTemplateEntry = ApiScriptTemplateEntry
     { cosigners :: Map Cosigner XPubOrSelf
     , template :: Script Cosigner
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data ApiSharedWalletPostDataFromMnemonics = ApiSharedWalletPostDataFromMnemonics
     { name :: !(ApiT WalletName)
@@ -1438,7 +1488,8 @@ data ApiSharedWalletPostDataFromMnemonics = ApiSharedWalletPostDataFromMnemonics
     , paymentScriptTemplate :: !ApiScriptTemplateEntry
     , delegationScriptTemplate :: !(Maybe ApiScriptTemplateEntry)
     , scriptValidation :: !(Maybe (ApiT ValidationLevel))
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 data ApiSharedWalletPostDataFromAccountPubX = ApiSharedWalletPostDataFromAccountPubX
     { name :: !(ApiT WalletName)
@@ -1447,7 +1498,8 @@ data ApiSharedWalletPostDataFromAccountPubX = ApiSharedWalletPostDataFromAccount
     , paymentScriptTemplate :: !ApiScriptTemplateEntry
     , delegationScriptTemplate :: !(Maybe ApiScriptTemplateEntry)
     , scriptValidation :: !(Maybe (ApiT ValidationLevel))
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic, Show)
 
 newtype ApiSharedWalletPostData = ApiSharedWalletPostData
     { wallet :: Either
@@ -1470,8 +1522,9 @@ data ApiActiveSharedWallet = ApiActiveSharedWallet
     , assets :: !ApiWalletAssetsBalance
     , state :: !(ApiT SyncProgress)
     , tip :: !ApiBlockReference
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data ApiPendingSharedWallet = ApiPendingSharedWallet
     { id :: !(ApiT WalletId)
@@ -1480,8 +1533,9 @@ data ApiPendingSharedWallet = ApiPendingSharedWallet
     , addressPoolGap :: !(ApiT AddressPoolGap)
     , paymentScriptTemplate :: !ScriptTemplate
     , delegationScriptTemplate :: !(Maybe ScriptTemplate)
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 newtype ApiSharedWallet = ApiSharedWallet
     { wallet :: Either ApiPendingSharedWallet ApiActiveSharedWallet
@@ -1493,8 +1547,9 @@ newtype ApiSharedWallet = ApiSharedWallet
 data ApiSharedWalletPatchData = ApiSharedWalletPatchData
     { cosigner :: !(ApiT Cosigner)
     , accountPublicKey :: !ApiAccountPublicKey
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 -- | Error codes returned by the API, in the form of snake_cased strings
 data ApiErrorCode
@@ -1731,8 +1786,9 @@ data ApiByronWallet = ApiByronWallet
     , passphrase :: !(Maybe ApiWalletPassphraseInfo)
     , state :: !(ApiT SyncProgress)
     , tip :: !ApiBlockReference
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data ApiWalletDiscovery
     = DiscoveryRandom
@@ -1798,7 +1854,8 @@ data ApiOurStakeKey (n :: NetworkDiscriminant) = ApiOurStakeKey
       -- ^ The current reward balance (not lifetime).
     , _delegation :: !ApiWalletDelegation
       -- ^ The delegation of this stake key
-    } deriving (Generic, Eq, Show)
+    }
+    deriving (Generic, Eq, Show)
 
 -- | A stake key found in the wallet UTxO, but which isn't ours.
 --
@@ -1811,7 +1868,8 @@ data ApiForeignStakeKey (n :: NetworkDiscriminant) = ApiForeignStakeKey
       -- also includes the reward balance.
     , _rewardBalance :: !(Quantity "lovelace" Natural)
       -- ^ The current reward balance (not lifetime).
-    } deriving (Generic, Eq, Show)
+    }
+    deriving (Generic, Eq, Show)
 
 -- | For describing how much stake is associated with no stake key.
 newtype ApiNullStakeKey = ApiNullStakeKey
@@ -1827,7 +1885,8 @@ data ApiStakeKeys (n :: NetworkDiscriminant) = ApiStakeKeys
     { _ours :: ![ApiOurStakeKey n]
     , _foreign :: ![ApiForeignStakeKey n]
     , _none :: !ApiNullStakeKey
-    } deriving (Generic, Eq, Show)
+    }
+    deriving (Generic, Eq, Show)
 
 {-------------------------------------------------------------------------------
                                JSON Instances
@@ -2408,8 +2467,9 @@ instance ToJSON ApiWalletBalance where
 data ApiByronWalletBalance = ApiByronWalletBalance
     { available :: !(Quantity "lovelace" Natural)
     , total :: !(Quantity "lovelace" Natural)
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 instance FromJSON ApiByronWalletBalance where
     parseJSON = genericParseJSON defaultRecordTypeOptions

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -286,7 +286,8 @@ import Cardano.Wallet.Api.Lib.ApiAsArray
 import Cardano.Wallet.Api.Lib.ApiT
     ( ApiT (..), fromTextApiT, toTextApiT )
 import Cardano.Wallet.Api.Lib.Options
-    ( TaggedObjectOptions (..)
+    ( DefaultRecord (..)
+    , TaggedObjectOptions (..)
     , defaultRecordTypeOptions
     , defaultSumTypeOptions
     , explicitNothingRecordTypeOptions
@@ -335,11 +336,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Random
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap, SeqState, getAddressPoolGap )
 import Cardano.Wallet.Primitive.Passphrase.Types
-    ( Passphrase (..)
-    , PassphraseHash (..)
-    , PassphraseMaxLength (..)
-    , PassphraseMinLength (..)
-    )
+    ( Passphrase (..), PassphraseHash (..) )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
@@ -603,23 +600,27 @@ newtype ApiMaintenanceActionPostData = ApiMaintenanceActionPostData
     { maintenanceAction :: MaintenanceAction
     }
     deriving (Eq, Generic)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiMaintenanceActionPostData
     deriving Show via (Quiet ApiMaintenanceActionPostData)
 
 newtype ApiMaintenanceAction = ApiMaintenanceAction
     { gcStakePools :: ApiT PoolMetadataGCStatus
     }
     deriving (Eq, Generic)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiMaintenanceAction
     deriving Show via (Quiet ApiMaintenanceAction)
 
 newtype ApiPolicyId = ApiPolicyId
     { policyId :: ApiT W.TokenPolicyId
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiPolicyId
 
 newtype ApiPostPolicyIdData = ApiPostPolicyIdData
     { policyScriptTemplate :: (ApiT (Script Cosigner))
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiPostPolicyIdData
 
 data ApiAsset = ApiAsset
     { policyId :: ApiT W.TokenPolicyId
@@ -629,6 +630,7 @@ data ApiAsset = ApiAsset
     , metadataError :: Maybe ApiMetadataError
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiAsset
     deriving anyclass NFData
 
 data ApiMetadataError = Fetch | Parse
@@ -644,6 +646,7 @@ data ApiAssetMetadata = ApiAssetMetadata
     , decimals :: Maybe (ApiT W.AssetDecimals)
     }
     deriving (Eq, Generic, Ord, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiAssetMetadata
     deriving anyclass NFData
 
 toApiAsset
@@ -674,6 +677,7 @@ data ApiAddress (n :: NetworkDiscriminant) = ApiAddress
     , derivationPath :: NonEmpty (ApiT DerivationIndex)
     }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiAddress n)
     deriving anyclass NFData
 
 data ApiCredential =
@@ -719,11 +723,13 @@ data ApiSelectCoinsPayments (n :: NetworkDiscriminant) = ApiSelectCoinsPayments
     , metadata :: !(Maybe (ApiT TxMetadata))
     }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiSelectCoinsPayments n)
 
 newtype ApiSelectCoinsAction = ApiSelectCoinsAction
     { delegationAction :: ApiDelegationAction
     }
     deriving (Eq, Generic)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiSelectCoinsAction
     deriving Show via (Quiet ApiSelectCoinsAction)
 
 data ApiDelegationAction = Join (ApiT PoolId) | Quit
@@ -742,6 +748,7 @@ data ApiCoinSelection (n :: NetworkDiscriminant) = ApiCoinSelection
     , metadata :: !(Maybe ApiBase64)
     }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiCoinSelection n)
     deriving anyclass NFData
 
 data ApiCoinSelectionChange (n :: NetworkDiscriminant) = ApiCoinSelectionChange
@@ -751,6 +758,7 @@ data ApiCoinSelectionChange (n :: NetworkDiscriminant) = ApiCoinSelectionChange
     , derivationPath :: NonEmpty (ApiT DerivationIndex)
     }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiCoinSelectionChange n)
     deriving anyclass NFData
 
 data ApiCoinSelectionOutput (n :: NetworkDiscriminant) = ApiCoinSelectionOutput
@@ -759,6 +767,7 @@ data ApiCoinSelectionOutput (n :: NetworkDiscriminant) = ApiCoinSelectionOutput
     , assets :: !(ApiT TokenMap)
     }
     deriving (Eq, Ord, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiCoinSelectionOutput n)
     deriving anyclass (NFData, Hashable)
 
 data ApiCoinSelectionCollateral (n :: NetworkDiscriminant) =
@@ -770,6 +779,7 @@ data ApiCoinSelectionCollateral (n :: NetworkDiscriminant) =
         , amount :: !(Quantity "lovelace" Natural)
         }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiCoinSelectionCollateral n)
     deriving anyclass NFData
 
 data ApiWallet = ApiWallet
@@ -784,6 +794,7 @@ data ApiWallet = ApiWallet
     , tip :: !ApiBlockReference
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiWallet
     deriving anyclass NFData
 
 data ApiWalletBalance = ApiWalletBalance
@@ -792,6 +803,7 @@ data ApiWalletBalance = ApiWalletBalance
     , reward :: !(Quantity "lovelace" Natural)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiWalletBalance
     deriving anyclass NFData
 
 data ApiWalletAssetsBalance = ApiWalletAssetsBalance
@@ -799,12 +811,14 @@ data ApiWalletAssetsBalance = ApiWalletAssetsBalance
     , total :: !(ApiT TokenMap)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiWalletAssetsBalance
     deriving anyclass NFData
 
 newtype ApiWalletPassphraseInfo = ApiWalletPassphraseInfo
     { lastUpdatedAt :: UTCTime
     }
     deriving (Eq, Generic)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiWalletPassphraseInfo
     deriving anyclass NFData
     deriving Show via (Quiet ApiWalletPassphraseInfo)
 
@@ -813,6 +827,7 @@ data ApiWalletDelegation = ApiWalletDelegation
     , next :: ![ApiWalletDelegationNext]
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiWalletDelegation
     deriving anyclass NFData
 
 data ApiWalletDelegationNext = ApiWalletDelegationNext
@@ -821,6 +836,7 @@ data ApiWalletDelegationNext = ApiWalletDelegationNext
     , changesAt :: !(Maybe EpochInfo)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiWalletDelegationNext
     deriving anyclass NFData
 
 data ApiWalletDelegationStatus
@@ -833,6 +849,7 @@ newtype ApiWalletPassphrase = ApiWalletPassphrase
     { passphrase :: ApiT (Passphrase "lenient")
     }
     deriving (Eq, Generic)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiWalletPassphrase
     deriving anyclass NFData
     deriving Show via (Quiet ApiWalletPassphrase)
 
@@ -840,6 +857,7 @@ newtype ApiWalletUtxoSnapshot = ApiWalletUtxoSnapshot
     { entries :: [ApiWalletUtxoSnapshotEntry]
     }
     deriving (Eq, Generic)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiWalletUtxoSnapshot
     deriving anyclass NFData
     deriving Show via (Quiet ApiWalletUtxoSnapshot)
 
@@ -849,6 +867,7 @@ data ApiWalletUtxoSnapshotEntry = ApiWalletUtxoSnapshotEntry
     , assets :: !(ApiT TokenMap)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiWalletUtxoSnapshotEntry
     deriving anyclass NFData
 
 data ApiUtxoStatistics = ApiUtxoStatistics
@@ -857,6 +876,7 @@ data ApiUtxoStatistics = ApiUtxoStatistics
     , distribution :: !(Map Word64 Word64)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiUtxoStatistics
     deriving anyclass NFData
 
 toApiUtxoStatistics :: UTxOStatistics -> ApiUtxoStatistics
@@ -874,6 +894,7 @@ data WalletPostData = WalletPostData
     , name :: !(ApiT WalletName)
     , passphrase :: !(ApiT (Passphrase "user"))
     }
+    deriving (FromJSON, ToJSON) via DefaultRecord WalletPostData
     deriving (Eq, Generic, Show)
 
 data SomeByronWalletPostData
@@ -891,6 +912,7 @@ data ByronWalletPostData mw = ByronWalletPostData
     , passphrase :: !(ApiT (Passphrase "user"))
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ByronWalletPostData mw)
 
 data ByronWalletFromXPrvPostData = ByronWalletFromXPrvPostData
     { name :: !(ApiT WalletName)
@@ -905,6 +927,7 @@ data ByronWalletFromXPrvPostData = ByronWalletFromXPrvPostData
     -- - p = 1
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ByronWalletFromXPrvPostData
     deriving anyclass NFData
 
 newtype ApiAccountPublicKey = ApiAccountPublicKey
@@ -925,18 +948,21 @@ data AccountPostData = AccountPostData
     , accountPublicKey :: !ApiAccountPublicKey
     , addressPoolGap :: !(Maybe (ApiT AddressPoolGap))
     }
+    deriving (FromJSON, ToJSON) via DefaultRecord AccountPostData
     deriving (Eq, Generic, Show)
 
 newtype WalletPutData = WalletPutData
     { name :: (Maybe (ApiT WalletName))
     }
     deriving (Eq, Generic)
+    deriving (FromJSON, ToJSON) via DefaultRecord WalletPutData
     deriving Show via (Quiet WalletPutData)
 
 newtype SettingsPutData = SettingsPutData
     { settings :: (ApiT W.Settings)
     }
     deriving (Eq, Generic)
+    deriving (FromJSON, ToJSON) via DefaultRecord SettingsPutData
     deriving Show via (Quiet SettingsPutData)
 
 data WalletPutPassphraseMnemonicData = WalletPutPassphraseMnemonicData
@@ -945,12 +971,16 @@ data WalletPutPassphraseMnemonicData = WalletPutPassphraseMnemonicData
     , newPassphrase :: !(ApiT (Passphrase "user"))
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON)
+        via DefaultRecord WalletPutPassphraseMnemonicData
 
 data WalletPutPassphraseOldPassphraseData = WalletPutPassphraseOldPassphraseData
     { oldPassphrase :: !(ApiT (Passphrase "user"))
     , newPassphrase :: !(ApiT (Passphrase "user"))
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON)
+        via DefaultRecord WalletPutPassphraseOldPassphraseData
 
 newtype WalletPutPassphraseData = WalletPutPassphraseData
     (  Either
@@ -964,6 +994,8 @@ data ByronWalletPutPassphraseData = ByronWalletPutPassphraseData
     , newPassphrase :: !(ApiT (Passphrase "user"))
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON)
+        via DefaultRecord ByronWalletPutPassphraseData
 
 data ApiSealedTxEncoding = HexEncoded | Base64Encoded
     deriving (Eq, Generic, Show)
@@ -1023,6 +1055,8 @@ data ApiConstructTransactionData (n :: NetworkDiscriminant) =
     , encoding :: !(Maybe ApiSealedTxEncoding)
     }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON)
+        via DefaultRecord (ApiConstructTransactionData n)
     deriving anyclass NFData
 
 newtype ApiPaymentDestination (n :: NetworkDiscriminant)
@@ -1039,6 +1073,7 @@ data ApiValidityInterval = ApiValidityInterval
     -- ^ Tx is not valid at this time and after. Defaults to now + 2 hours.
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiValidityInterval
     deriving anyclass NFData
 
 -- | One side of the validity interval.
@@ -1068,6 +1103,7 @@ data PostTransactionOldData (n :: NetworkDiscriminant) = PostTransactionOldData
     , timeToLive :: !(Maybe (Quantity "second" NominalDiffTime))
     }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (PostTransactionOldData n)
 
 -- | Legacy transaction API.
 data PostTransactionFeeOldData (n :: NetworkDiscriminant) =
@@ -1078,6 +1114,7 @@ data PostTransactionFeeOldData (n :: NetworkDiscriminant) =
     , timeToLive :: !(Maybe (Quantity "second" NominalDiffTime))
     }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (PostTransactionFeeOldData n)
 
 type ApiBase64 = ApiBytesT 'Base64 ByteString
 
@@ -1097,6 +1134,7 @@ data ApiExternalInput (n :: NetworkDiscriminant) = ApiExternalInput
     , datum :: !(Maybe (ApiT (Hash "Datum")))
     }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiExternalInput n)
     deriving anyclass NFData
 
 data ApiBalanceTransactionPostData (n :: NetworkDiscriminant) =
@@ -1107,6 +1145,8 @@ data ApiBalanceTransactionPostData (n :: NetworkDiscriminant) =
     , encoding :: !(Maybe ApiSealedTxEncoding)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON)
+        via DefaultRecord (ApiBalanceTransactionPostData n)
 
 type ApiRedeemerData = ApiBytesT 'Base16 ByteString
 
@@ -1123,6 +1163,7 @@ data ApiFee = ApiFee
     , deposit :: !(Quantity "lovelace" Natural)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiFee
 
 data ApiNetworkParameters = ApiNetworkParameters
     { genesisBlockHash :: !(ApiT (Hash "Genesis"))
@@ -1140,6 +1181,7 @@ data ApiNetworkParameters = ApiNetworkParameters
     , executionUnitPrices :: !(Maybe ExecutionUnitPrices)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiNetworkParameters
 
 data ApiEraInfo = ApiEraInfo
     { byron :: !(Maybe EpochInfo)
@@ -1211,6 +1253,7 @@ instance ToHttpApiData ApiPoolSpecifier where
 
 newtype ApiTxId = ApiTxId { id :: ApiT (Hash "Tx") }
     deriving (Eq, Generic)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiTxId
     deriving anyclass NFData
     deriving Show via (Quiet ApiTxId)
 
@@ -1237,14 +1280,17 @@ data ApiTransaction (n :: NetworkDiscriminant) = ApiTransaction
     , certificates :: [ApiAnyCertificate n]
     }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiTransaction n)
     deriving anyclass NFData
 
-data ApiCoinSelectionWithdrawal n = ApiCoinSelectionWithdrawal
+data ApiCoinSelectionWithdrawal (n :: NetworkDiscriminant) =
+    ApiCoinSelectionWithdrawal
     { stakeAddress :: !(ApiT W.RewardAccount, Proxy n)
     , derivationPath :: !(NonEmpty (ApiT DerivationIndex))
     , amount :: !(Quantity "lovelace" Natural)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiCoinSelectionWithdrawal n)
     deriving anyclass NFData
 
 data ApiSelfWithdrawalPostData = SelfWithdraw
@@ -1276,6 +1322,7 @@ data AddressAmountNoAssets addr = AddressAmountNoAssets
     , amount :: !(Quantity "lovelace" Natural)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord (AddressAmountNoAssets addr)
     deriving anyclass NFData
 
 newtype ApiAddressInspect = ApiAddressInspect
@@ -1304,6 +1351,7 @@ data ApiSlotId = ApiSlotId
     , slotNumber :: !(ApiT SlotInEpoch)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiSlotId
     deriving anyclass NFData
 
 data ApiBlockReference = ApiBlockReference
@@ -1319,6 +1367,7 @@ newtype ApiBlockInfo = ApiBlockInfo
     { height :: Quantity "block" Natural
     }
     deriving (Eq, Generic)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiBlockInfo
     deriving anyclass NFData
     deriving Show via (Quiet ApiBlockInfo)
 
@@ -1389,8 +1438,8 @@ data ApiNetworkInformation = ApiNetworkInformation
     , walletMode :: !ApiWalletMode
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiNetworkInformation
     deriving anyclass NFData
-
 
 newtype ApiNetworkClock = ApiNetworkClock { ntpStatus :: NtpStatusWithOffset }
     deriving (Eq, Generic)
@@ -1401,6 +1450,7 @@ data ApiPostRandomAddressData = ApiPostRandomAddressData
     , addressIndex :: !(Maybe (ApiT (Index 'AD.Hardened 'CredFromKeyK)))
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiPostRandomAddressData
     deriving anyclass NFData
 
 newtype ApiWalletMigrationPlanPostData (n :: NetworkDiscriminant) =
@@ -1408,6 +1458,8 @@ newtype ApiWalletMigrationPlanPostData (n :: NetworkDiscriminant) =
     { addresses :: NonEmpty (ApiT Address, Proxy n)
     }
     deriving (Eq, Generic, Typeable)
+    deriving (FromJSON, ToJSON)
+        via DefaultRecord (ApiWalletMigrationPlanPostData n)
     deriving anyclass NFData
     deriving Show via (Quiet (ApiWalletMigrationPlanPostData n))
 
@@ -1417,12 +1469,15 @@ data ApiWalletMigrationPostData (n :: NetworkDiscriminant) (s :: Symbol) =
     , addresses :: !(NonEmpty (ApiT Address, Proxy n))
     }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON)
+        via DefaultRecord (ApiWalletMigrationPostData n s)
     deriving anyclass NFData
 
 newtype ApiPutAddressesData (n :: NetworkDiscriminant) = ApiPutAddressesData
     { addresses :: [(ApiT Address, Proxy n)]
     }
     deriving (Eq, Generic, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiPutAddressesData n)
     deriving anyclass NFData
     deriving Show via (Quiet (ApiPutAddressesData n))
 
@@ -1431,6 +1486,7 @@ data ApiWalletMigrationBalance = ApiWalletMigrationBalance
     , assets :: !(ApiT TokenMap)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiWalletMigrationBalance
     deriving anyclass NFData
 
 data ApiWalletMigrationPlan (n :: NetworkDiscriminant) = ApiWalletMigrationPlan
@@ -1440,6 +1496,7 @@ data ApiWalletMigrationPlan (n :: NetworkDiscriminant) = ApiWalletMigrationPlan
     , balanceSelected :: ApiWalletMigrationBalance
     }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiWalletMigrationPlan n)
     deriving anyclass NFData
 
 newtype ApiWithdrawRewards = ApiWithdrawRewards Bool
@@ -1451,6 +1508,7 @@ data ApiWalletSignData = ApiWalletSignData
     , passphrase :: ApiT (Passphrase "lenient")
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiWalletSignData
     deriving anyclass NFData
 
 instance FromHttpApiData KeyFormat where
@@ -1461,6 +1519,7 @@ data ApiPostAccountKeyData = ApiPostAccountKeyData
     , format :: KeyFormat
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiPostAccountKeyData
     deriving anyclass NFData
 
 data ApiPostAccountKeyDataWithPurpose = ApiPostAccountKeyDataWithPurpose
@@ -1469,6 +1528,8 @@ data ApiPostAccountKeyDataWithPurpose = ApiPostAccountKeyDataWithPurpose
     , purpose :: Maybe (ApiT DerivationIndex)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON)
+        via DefaultRecord ApiPostAccountKeyDataWithPurpose
     deriving anyclass NFData
 
 data XPubOrSelf = SomeAccountKey XPub | Self
@@ -1495,6 +1556,8 @@ data ApiSharedWalletPostDataFromMnemonics =
     , scriptValidation :: !(Maybe (ApiT ValidationLevel))
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON)
+        via DefaultRecord ApiSharedWalletPostDataFromMnemonics
 
 data ApiSharedWalletPostDataFromAccountPubX =
     ApiSharedWalletPostDataFromAccountPubX
@@ -1506,6 +1569,8 @@ data ApiSharedWalletPostDataFromAccountPubX =
     , scriptValidation :: !(Maybe (ApiT ValidationLevel))
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON)
+        via DefaultRecord ApiSharedWalletPostDataFromAccountPubX
 
 newtype ApiSharedWalletPostData = ApiSharedWalletPostData
     { wallet :: Either
@@ -1530,6 +1595,7 @@ data ApiActiveSharedWallet = ApiActiveSharedWallet
     , tip :: !ApiBlockReference
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiActiveSharedWallet
     deriving anyclass NFData
 
 data ApiPendingSharedWallet = ApiPendingSharedWallet
@@ -1794,6 +1860,7 @@ data ApiByronWallet = ApiByronWallet
     , tip :: !ApiBlockReference
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiByronWallet
     deriving anyclass NFData
 
 data ApiWalletDiscovery
@@ -1862,6 +1929,7 @@ data ApiOurStakeKey (n :: NetworkDiscriminant) = ApiOurStakeKey
       -- ^ The delegation of this stake key
     }
     deriving (Generic, Eq, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiOurStakeKey n)
 
 -- | A stake key found in the wallet UTxO, but which isn't ours.
 --
@@ -1876,6 +1944,7 @@ data ApiForeignStakeKey (n :: NetworkDiscriminant) = ApiForeignStakeKey
       -- ^ The current reward balance (not lifetime).
     }
     deriving (Generic, Eq, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiForeignStakeKey n)
 
 -- | For describing how much stake is associated with no stake key.
 newtype ApiNullStakeKey = ApiNullStakeKey
@@ -1884,6 +1953,7 @@ newtype ApiNullStakeKey = ApiNullStakeKey
       -- stake key, because it's part of an enterprise address.
     }
     deriving (Generic, Eq)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiNullStakeKey
     deriving Show via (Quiet ApiNullStakeKey)
 
 -- | Collection of stake keys associated with a wallet.
@@ -1893,60 +1963,16 @@ data ApiStakeKeys (n :: NetworkDiscriminant) = ApiStakeKeys
     , _none :: !ApiNullStakeKey
     }
     deriving (Generic, Eq, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiStakeKeys n)
 
 {-------------------------------------------------------------------------------
                                JSON Instances
 -------------------------------------------------------------------------------}
 
-instance DecodeAddress n => FromJSON (ApiAddress n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiAddress n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
 instance FromJSON ApiMetadataError where
     parseJSON = genericParseJSON defaultSumTypeOptions
 instance ToJSON ApiMetadataError where
     toJSON = genericToJSON defaultSumTypeOptions
-
-instance FromJSON ApiAsset where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiAsset where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance DecodeStakeAddress n => FromJSON (ApiOurStakeKey n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeStakeAddress n => ToJSON (ApiOurStakeKey n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance DecodeStakeAddress n => FromJSON (ApiForeignStakeKey n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeStakeAddress n => ToJSON (ApiForeignStakeKey n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiNullStakeKey where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiNullStakeKey where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance DecodeStakeAddress n => FromJSON (ApiStakeKeys n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeStakeAddress n => ToJSON (ApiStakeKeys n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiPostPolicyIdData where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiPostPolicyIdData where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiPolicyId where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiPolicyId where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiAssetMetadata where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiAssetMetadata where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON (ApiT W.AssetURL) where
     parseJSON value = parseJSON value >>= either fail (pure . ApiT) . W.validateMetadataURL
@@ -1965,35 +1991,10 @@ instance FromJSON (ApiT W.AssetDecimals) where
 instance ToJSON (ApiT W.AssetDecimals) where
     toJSON = toJSON . W.unAssetDecimals . getApiT
 
-instance FromJSON ApiPostPolicyKeyData where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiPostPolicyKeyData where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
 instance FromJSON KeyFormat where
     parseJSON = genericParseJSON defaultSumTypeOptions
 instance ToJSON KeyFormat where
     toJSON = genericToJSON defaultSumTypeOptions
-
-instance FromJSON ApiPostAccountKeyData where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiPostAccountKeyData where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiPostAccountKeyDataWithPurpose where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiPostAccountKeyDataWithPurpose where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiSelectCoinsAction where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiSelectCoinsAction where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance DecodeAddress n => FromJSON (ApiSelectCoinsPayments n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiSelectCoinsPayments n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance DecodeAddress n => FromJSON (ApiSelectCoinsData n) where
     parseJSON = withObject "DelegationAction" $ \o -> do
@@ -2012,15 +2013,6 @@ instance DecodeAddress n => FromJSON (ApiSelectCoinsData n) where
 instance EncodeAddress n => ToJSON (ApiSelectCoinsData n) where
     toJSON (ApiSelectForPayment v) = toJSON v
     toJSON (ApiSelectForDelegation v) = toJSON v
-
-instance (DecodeStakeAddress n, DecodeAddress n) =>
-    FromJSON (ApiCoinSelection n)
-  where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance (EncodeStakeAddress n, EncodeAddress n) =>
-    ToJSON (ApiCoinSelection n)
-  where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 apiDelegationActionOptions :: Aeson.Options
 apiDelegationActionOptions = Aeson.defaultOptions
@@ -2065,55 +2057,10 @@ instance FromJSON ApiMultiDelegationAction where
                 Leaving <$> o .: "stake_key_index"
             _ -> fail "ApiMultiDelegationAction needs either 'join' or 'quit', but not both"
 
-instance DecodeAddress n => FromJSON (ApiCoinSelectionChange n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiCoinSelectionChange n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance DecodeAddress n => FromJSON (ApiCoinSelectionCollateral n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiCoinSelectionCollateral n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance DecodeAddress n => FromJSON (ApiCoinSelectionOutput n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiCoinSelectionOutput n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance DecodeStakeAddress n => FromJSON (ApiCoinSelectionWithdrawal n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeStakeAddress n => ToJSON (ApiCoinSelectionWithdrawal n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
 instance FromJSON (ApiT AddressState) where
     parseJSON = fmap ApiT . genericParseJSON defaultSumTypeOptions
 instance ToJSON (ApiT AddressState) where
     toJSON = genericToJSON defaultSumTypeOptions . getApiT
-
-instance FromJSON ApiWallet where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiWallet where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiWalletPassphrase where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiWalletPassphrase where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiWalletUtxoSnapshot where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiWalletUtxoSnapshot where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiWalletUtxoSnapshotEntry where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiWalletUtxoSnapshotEntry where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON WalletPostData where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON WalletPostData where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON ApiAccountPublicKey where
     parseJSON =
@@ -2141,11 +2088,6 @@ instance FromJSON WalletOrAccountPostData where
 instance ToJSON WalletOrAccountPostData where
     toJSON (WalletOrAccountPostData (Left c))= toJSON c
     toJSON (WalletOrAccountPostData (Right c))= toJSON c
-
-instance FromJSON AccountPostData where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON AccountPostData where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance ToJSON SomeByronWalletPostData where
     toJSON = \case
@@ -2198,11 +2140,6 @@ withExtraField (k,v) = \case
     Aeson.Object m -> Aeson.Object (Aeson.insert (Aeson.fromText k) v m)
     json -> json
 
-instance MkSomeMnemonic mw => FromJSON (ByronWalletPostData mw) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON (ByronWalletPostData mw) where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
 instance FromJSON (ApiT PassphraseHash) where
     parseJSON = parseJSON >=> eitherToParser . first ShowFmt . fromText
 instance ToJSON (ApiT PassphraseHash) where
@@ -2222,31 +2159,6 @@ instance FromJSON (ApiT (Hash "TokenPolicy")) where
     parseJSON = fromTextApiT "TokenPolicy Hash"
 instance ToJSON (ApiT (Hash "TokenPolicy")) where
     toJSON = toTextApiT
-
-instance FromJSON ByronWalletFromXPrvPostData where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ByronWalletFromXPrvPostData where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON WalletPutData where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON  WalletPutData where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON SettingsPutData where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON  SettingsPutData where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON WalletPutPassphraseMnemonicData where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON WalletPutPassphraseMnemonicData where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON WalletPutPassphraseOldPassphraseData where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON  WalletPutPassphraseOldPassphraseData where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON WalletPutPassphraseData where
     parseJSON  =
@@ -2296,35 +2208,10 @@ instance ToJSON (ApiT PoolMetadataGCStatus) where
         object [ "status" .= String "has_run"
             , "last_run" .= ApiT (Iso8601Time (posixSecondsToUTCTime gctime)) ]
 
-instance FromJSON ByronWalletPutPassphraseData where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ByronWalletPutPassphraseData where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiMaintenanceActionPostData where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiMaintenanceActionPostData where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiMaintenanceAction where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiMaintenanceAction where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
 instance FromJSON MaintenanceAction where
     parseJSON = genericParseJSON defaultSumTypeOptions
 instance ToJSON MaintenanceAction where
     toJSON = genericToJSON defaultSumTypeOptions
-
-instance FromJSON ApiTxId where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiTxId where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiFee where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiFee where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON ApiCredential where
     parseJSON v =
@@ -2465,52 +2352,26 @@ instance FromJSON (ApiT AddressPoolGap) where
 instance ToJSON (ApiT AddressPoolGap) where
     toJSON = toJSON . getAddressPoolGap . getApiT
 
-instance FromJSON ApiWalletBalance where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiWalletBalance where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
 data ApiByronWalletBalance = ApiByronWalletBalance
     { available :: !(Quantity "lovelace" Natural)
     , total :: !(Quantity "lovelace" Natural)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiByronWalletBalance
     deriving anyclass NFData
-
-instance FromJSON ApiByronWalletBalance where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiByronWalletBalance where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiWalletAssetsBalance where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiWalletAssetsBalance where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON ApiWalletDelegationStatus where
     parseJSON = genericParseJSON defaultSumTypeOptions
 instance ToJSON ApiWalletDelegationStatus where
     toJSON = genericToJSON defaultSumTypeOptions
 
-instance FromJSON ApiWalletDelegation where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiWalletDelegation where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiWalletDelegationNext where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiWalletDelegationNext where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
 instance FromJSON EpochNo where
     parseJSON = fmap unsafeEpochNo . parseJSON
 instance ToJSON EpochNo where
     toJSON (EpochNo en) = toJSON $ fromIntegral @Word31 @Word32 en
 
-instance FromJSON EpochInfo where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON EpochInfo where
-    toJSON = genericToJSON defaultRecordTypeOptions
+deriving via DefaultRecord EpochInfo instance FromJSON EpochInfo
+deriving via DefaultRecord EpochInfo instance ToJSON EpochInfo
 
 instance FromJSON (ApiT StakePool) where
     parseJSON = fmap (ApiT <$>) . withObject "StakePool" $ \o -> do
@@ -2548,8 +2409,7 @@ instance ToJSON (ApiT StakePoolMetrics) where
 toJsonStakePoolMetrics :: StakePoolMetrics -> Aeson.Value
 toJsonStakePoolMetrics = genericToJSON defaultRecordTypeOptions
 
-instance ToJSON StakePoolMetadata where
-    toJSON = genericToJSON defaultRecordTypeOptions
+deriving via DefaultRecord StakePoolMetadata instance ToJSON StakePoolMetadata
 
 instance FromJSON StakePoolFlag where
     parseJSON = genericParseJSON defaultSumTypeOptions
@@ -2561,25 +2421,13 @@ instance FromJSON (ApiT WalletName) where
 instance ToJSON (ApiT WalletName) where
     toJSON = toTextApiT
 
-instance FromJSON (ApiT W.Settings) where
-    parseJSON = fmap ApiT . genericParseJSON defaultRecordTypeOptions
-instance ToJSON (ApiT W.Settings) where
-    toJSON = genericToJSON defaultRecordTypeOptions . getApiT
-
-instance FromJSON ApiWalletPassphraseInfo where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiWalletPassphraseInfo where
-    toJSON = genericToJSON defaultRecordTypeOptions
+deriving via DefaultRecord W.Settings instance FromJSON (ApiT W.Settings)
+deriving via DefaultRecord W.Settings instance ToJSON (ApiT W.Settings)
 
 instance FromJSON (ApiT SyncProgress) where
     parseJSON = fmap ApiT . genericParseJSON syncProgressOptions
 instance ToJSON (ApiT SyncProgress) where
     toJSON = genericToJSON syncProgressOptions . getApiT
-
-instance FromJSON ApiUtxoStatistics where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiUtxoStatistics where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance ToJSON (ApiT BoundType) where
     toJSON = genericToJSON defaultSumTypeOptions . getApiT
@@ -2631,11 +2479,6 @@ instance FromJSON ApiSignTransactionPostData where
 instance ToJSON ApiSignTransactionPostData where
     toJSON = genericToJSON strictRecordTypeOptions
 
-instance DecodeAddress t => FromJSON (PostTransactionOldData t) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress t => ToJSON (PostTransactionOldData t) where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
 instance DecodeAddress t => FromJSON (ApiPaymentDestination t) where
     parseJSON obj = parseAddrs
       where
@@ -2643,16 +2486,6 @@ instance DecodeAddress t => FromJSON (ApiPaymentDestination t) where
 
 instance EncodeAddress t => ToJSON (ApiPaymentDestination t) where
     toJSON (ApiPaymentAddresses addrs) = toJSON addrs
-
-instance DecodeAddress t => FromJSON (ApiConstructTransactionData t) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress t => ToJSON (ApiConstructTransactionData t) where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance DecodeAddress n => FromJSON (ApiExternalInput n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiExternalInput n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance DecodeStakeAddress n => FromJSON (ApiRedeemer n) where
     parseJSON = withObject "ApiRedeemer" $ \o -> do
@@ -2688,15 +2521,6 @@ instance EncodeStakeAddress n => ToJSON (ApiRedeemer n) where
             , "stake_address" .= serialiseToBech32 addr
             ]
 
-instance (DecodeStakeAddress n, DecodeAddress n)
-    => FromJSON (ApiBalanceTransactionPostData n)
-  where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance (EncodeStakeAddress n, EncodeAddress n)
-    => ToJSON (ApiBalanceTransactionPostData n)
-  where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
 instance ToJSON ApiValidityBound where
     toJSON ApiValidityBoundUnspecified = Aeson.Null
     toJSON (ApiValidityBoundAsTimeFromNow from) = toJSON from
@@ -2717,11 +2541,6 @@ instance FromJSON ApiValidityBound where
                     "slot" -> ApiValidityBoundAsSlot <$> parseJSON obj
                     _ -> fail "ApiValidityBound string must have either 'second' or 'slot' unit."
                 _ -> fail "ApiValidityBound string must have 'unit' field."
-
-instance ToJSON ApiValidityInterval where
-    toJSON = genericToJSON defaultRecordTypeOptions
-instance FromJSON ApiValidityInterval where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
 
 instance (DecodeAddress t, DecodeStakeAddress t) => FromJSON (ApiConstructTransaction t) where
     parseJSON = withObject "ApiConstructTransaction object" $ \o -> do
@@ -2763,11 +2582,6 @@ instance ToJSON ApiWithdrawalPostData where
         SelfWithdrawal -> toJSON ("self" :: String)
         ExternalWithdrawal mw -> toJSON mw
 
-instance DecodeAddress t => FromJSON (PostTransactionFeeOldData t) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress t => ToJSON (PostTransactionFeeOldData t) where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
 -- Note: These custom JSON instances are for compatibility with the existing API
 -- schema. At some point, we can switch to the generic instances.
 instance FromJSON ApiSlotReference where
@@ -2780,10 +2594,6 @@ instance ToJSON ApiSlotReference where
     toJSON (ApiSlotReference sln sli t) =
         let Aeson.Object rest = toJSON sli
         in Aeson.Object ("absolute_slot_number" .= sln <> "time" .= t <> rest)
-instance FromJSON ApiSlotId where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiSlotId where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 -- Note: These custom JSON instances are for compatibility with the existing API
 -- schema. At some point, we can switch to the generic instances.
@@ -2796,49 +2606,6 @@ instance ToJSON ApiBlockReference where
     toJSON (ApiBlockReference sln sli t (ApiBlockInfo bh)) =
         let Aeson.Object rest = toJSON (ApiSlotReference sln sli t)
         in Aeson.Object ("height" .= bh <> rest)
-instance FromJSON ApiBlockInfo where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiBlockInfo where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON a => FromJSON (AddressAmountNoAssets a) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-
-instance ToJSON a => ToJSON (AddressAmountNoAssets a) where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance
-    ( DecodeAddress n
-    , DecodeStakeAddress n
-    ) => FromJSON (ApiTransaction n)
-  where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance
-    ( EncodeAddress n
-    , EncodeStakeAddress n
-    ) => ToJSON (ApiTransaction n)
-  where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance DecodeAddress n => FromJSON (ApiWalletMigrationPlanPostData n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiWalletMigrationPlanPostData n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance (DecodeAddress n, PassphraseMaxLength s, PassphraseMinLength s) =>
-    FromJSON (ApiWalletMigrationPostData n s)
-  where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n =>
-    ToJSON (ApiWalletMigrationPostData n s)
-  where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance (DecodeAddress n) => FromJSON (ApiPutAddressesData n)
-  where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiPutAddressesData n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance DecodeAddress n => FromJSON (ApiTxInput n) where
     parseJSON v = ApiTxInput <$> optional (parseJSON v) <*> parseJSON v
@@ -2875,28 +2642,23 @@ instance FromJSON (ApiT TxStatus) where
 instance ToJSON (ApiT TxStatus) where
     toJSON = genericToJSON defaultSumTypeOptions . getApiT
 
-instance FromJSON ApiNetworkInformation where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiNetworkInformation where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
 instance FromJSON NtpSyncingStatus where
     parseJSON = parseJSON >=> eitherToParser . first ShowFmt . fromText
 instance ToJSON NtpSyncingStatus where
     toJSON = toJSON . toText
 
-instance FromJSON NtpStatusWithOffset where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON NtpStatusWithOffset where
-    toJSON = genericToJSON defaultRecordTypeOptions
+deriving via DefaultRecord NtpStatusWithOffset
+    instance FromJSON NtpStatusWithOffset
+deriving via DefaultRecord NtpStatusWithOffset
+    instance ToJSON NtpStatusWithOffset
 
 deriving newtype instance FromJSON ApiNetworkClock
 deriving newtype instance ToJSON ApiNetworkClock
 
-instance FromJSON (ApiT StakePoolMetadata) where
-    parseJSON = fmap ApiT . genericParseJSON defaultRecordTypeOptions
-instance ToJSON (ApiT StakePoolMetadata) where
-    toJSON = genericToJSON defaultRecordTypeOptions . getApiT
+deriving via DefaultRecord StakePoolMetadata
+    instance FromJSON (ApiT StakePoolMetadata)
+deriving via DefaultRecord StakePoolMetadata
+    instance ToJSON (ApiT StakePoolMetadata)
 
 instance FromJSON (ApiT StartTime) where
     parseJSON = fmap (ApiT . StartTime) . parseJSON
@@ -2927,16 +2689,6 @@ instance FromJSON ApiEraInfo where
     parseJSON = genericParseJSON explicitNothingRecordTypeOptions
 instance ToJSON ApiEraInfo where
     toJSON = genericToJSON explicitNothingRecordTypeOptions
-
-instance FromJSON ApiNetworkParameters where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiNetworkParameters where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiWalletSignData where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiWalletSignData where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance ToJSON XPubOrSelf where
     toJSON (SomeAccountKey xpub) =
@@ -2985,16 +2737,6 @@ instance ToJSON ApiScriptTemplateEntry where
             , toJSON xpubOrSelf
             )
 
-instance FromJSON ApiSharedWalletPostDataFromAccountPubX where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiSharedWalletPostDataFromAccountPubX where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiSharedWalletPostDataFromMnemonics where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiSharedWalletPostDataFromMnemonics where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
 instance FromJSON ApiSharedWalletPostData where
     parseJSON obj = do
         mnemonic <-
@@ -3032,11 +2774,6 @@ instance FromJSON ApiSharedWalletPatchData where
 instance ToJSON ApiSharedWalletPatchData where
     toJSON (ApiSharedWalletPatchData cosigner accXPub) =
         object [ Aeson.fromText (toText cosigner) .= toJSON accXPub ]
-
-instance FromJSON ApiActiveSharedWallet where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiActiveSharedWallet where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON ApiPendingSharedWallet where
     parseJSON val = case val of
@@ -3090,30 +2827,6 @@ syncProgressOptions = taggedSumTypeOptions defaultSumTypeOptions $
 {-------------------------------------------------------------------------------
                              JSON Instances: Byron
 -------------------------------------------------------------------------------}
-
-instance FromJSON ApiByronWallet where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiByronWallet where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiWalletMigrationBalance where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiWalletMigrationBalance where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance (DecodeStakeAddress n, DecodeAddress n) =>
-    FromJSON (ApiWalletMigrationPlan n)
-  where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance (EncodeStakeAddress n, EncodeAddress n) =>
-    ToJSON (ApiWalletMigrationPlan n)
-  where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON ApiPostRandomAddressData where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiPostRandomAddressData where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance
   ( Enum (Index derivation level)
@@ -3337,6 +3050,7 @@ instance ToJSON HealthStatusSMASH where
 
 newtype ApiHealthCheck = ApiHealthCheck { health :: HealthCheckSMASH }
     deriving (Generic, Eq, Ord)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiHealthCheck
     deriving Show via (Quiet ApiHealthCheck)
 
 instance FromJSON HealthCheckSMASH where
@@ -3344,11 +3058,6 @@ instance FromJSON HealthCheckSMASH where
         { sumEncoding = UntaggedValue }
 instance ToJSON HealthCheckSMASH where
     toJSON = genericToJSON defaultSumTypeOptions
-
-instance FromJSON ApiHealthCheck where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiHealthCheck where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON (ApiT SmashServer) where
     parseJSON = fromTextApiT "SmashServer"
@@ -3386,13 +3095,8 @@ data ApiMintBurnData (n :: NetworkDiscriminant) = ApiMintBurnData
         -- ^ The minting or burning operation to perform.
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiMintBurnData n)
     deriving anyclass NFData
-
-instance DecodeAddress n => FromJSON (ApiMintBurnData n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-
-instance EncodeAddress n => ToJSON (ApiMintBurnData n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 -- | A user may choose to either mint tokens or burn tokens with each operation.
 data ApiMintBurnOperation (n :: NetworkDiscriminant)
@@ -3418,13 +3122,8 @@ data ApiMintData (n :: NetworkDiscriminant) = ApiMintData
         -- ^ Amount of assets to mint.
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiMintData n)
     deriving anyclass NFData
-
-instance DecodeAddress n => FromJSON (ApiMintData n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-
-instance EncodeAddress n => ToJSON (ApiMintData n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 -- | The format of a burn request: burn "amount". The user can only specify the
 -- type of tokens to burn (policyId, assetName), and the amount, the exact
@@ -3433,13 +3132,8 @@ newtype ApiBurnData = ApiBurnData
     { quantity :: Natural
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiBurnData
     deriving anyclass NFData
-
-instance FromJSON ApiBurnData where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-
-instance ToJSON ApiBurnData where
-    toJSON (burn) = genericToJSON defaultRecordTypeOptions burn
 
 instance EncodeAddress n => ToJSON (ApiMintBurnOperation n) where
     toJSON = object . pure . \case

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Key.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Key.hs
@@ -170,8 +170,9 @@ instance FromJSON ApiPolicyKey where
 data ApiVerificationKeyShared = ApiVerificationKeyShared
     { getApiVerificationKey :: (ByteString, Role)
     , hashed :: VerificationKeyHashing
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 instance ToJSON ApiVerificationKeyShared where
     toJSON (ApiVerificationKeyShared (pub, role_) hashed') =
@@ -214,8 +215,9 @@ data ApiAccountKey = ApiAccountKey
     { getApiAccountKey :: ByteString
     , format :: KeyFormat
     , purpose :: Index 'Hardened 'PurposeK
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 instance ToJSON ApiAccountKey where
     toJSON (ApiAccountKey pub extd purpose') =
@@ -275,8 +277,9 @@ data ApiAccountKeyShared = ApiAccountKeyShared
     { getApiAccountKey :: ByteString
     , format :: KeyFormat
     , purpose :: Index 'Hardened 'PurposeK
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 instance ToJSON ApiAccountKeyShared where
     toJSON (ApiAccountKeyShared pub extd _) =
@@ -307,8 +310,9 @@ instance FromJSON ApiAccountKeyShared where
 data ApiVerificationKeyShelley = ApiVerificationKeyShelley
     { getApiVerificationKey :: (ByteString, Role)
     , hashed :: VerificationKeyHashing
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 instance ToJSON ApiVerificationKeyShelley where
     toJSON (ApiVerificationKeyShelley (pub, role_) hashed') =

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Key.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Key.hs
@@ -28,6 +28,8 @@ module Cardano.Wallet.Api.Types.Key
 
 import Prelude
 
+import Cardano.Wallet.Api.Lib.Options
+    ( DefaultSum (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), DerivationType (..), Index (..), Role (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.SharedKey
@@ -253,6 +255,7 @@ instance FromJSON ApiAccountKey where
 
 data KeyFormat = Extended | NonExtended
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultSum KeyFormat
     deriving anyclass NFData
 
 instance ToText KeyFormat where

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
@@ -29,10 +29,7 @@ import Cardano.Wallet.Api.Lib.ApiT
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DerivationIndex, RewardAccount )
 import Cardano.Wallet.Primitive.Passphrase.Types
-    ( Passphrase (..)
-    , PassphraseMaxLength (..)
-    , PassphraseMinLength (..)
-    )
+    ( Passphrase (..), PassphraseMaxLength (..), PassphraseMinLength (..) )
 import Cardano.Wallet.Primitive.Types
     ( EpochNo (..)
     , NonWalletCertificate (..)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
@@ -28,6 +28,11 @@ import Cardano.Wallet.Api.Lib.ApiT
     ( ApiT (..), fromTextApiT, toTextApiT )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DerivationIndex, RewardAccount )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..)
+    , PassphraseMaxLength (..)
+    , PassphraseMinLength (..)
+    )
 import Cardano.Wallet.Primitive.Types
     ( EpochNo (..)
     , NonWalletCertificate (..)
@@ -101,6 +106,12 @@ instance ToJSON (ApiT DerivationIndex) where
     toJSON = toTextApiT
 instance FromJSON (ApiT DerivationIndex) where
     parseJSON = fromTextApiT "DerivationIndex"
+
+instance (PassphraseMaxLength purpose, PassphraseMinLength purpose)
+    => FromJSON (ApiT (Passphrase purpose)) where
+    parseJSON = fromTextApiT "Passphrase"
+instance ToJSON (ApiT (Passphrase purpose)) where
+    toJSON = toTextApiT
 
 instance FromJSON (ApiT W.TokenPolicyId) where
     parseJSON = fromTextApiT "PolicyId"

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Transaction.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Transaction.hs
@@ -37,7 +37,7 @@ import Cardano.Wallet.Api.Lib.ApiAsArray
 import Cardano.Wallet.Api.Lib.ApiT
     ( ApiT (ApiT) )
 import Cardano.Wallet.Api.Lib.Options
-    ( defaultRecordTypeOptions )
+    ( DefaultRecord (..) )
 import Cardano.Wallet.Api.Types.Certificate
     ( ApiAnyCertificate )
 import Cardano.Wallet.Api.Types.Key
@@ -69,8 +69,6 @@ import Data.Aeson.Types
     , KeyValue (..)
     , ToJSON (..)
     , Value (..)
-    , genericParseJSON
-    , genericToJSON
     , object
     , prependFailure
     , withObject
@@ -135,20 +133,8 @@ data ApiDecodedTransaction (n :: NetworkDiscriminant) = ApiDecodedTransaction
     , validityInterval :: Maybe ValidityIntervalExplicit
     }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiDecodedTransaction n)
     deriving anyclass NFData
-
-instance
-    ( DecodeAddress n
-    , DecodeStakeAddress n
-    ) => FromJSON (ApiDecodedTransaction n)
-  where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance
-    ( EncodeAddress n
-    , EncodeStakeAddress n
-    ) => ToJSON (ApiDecodedTransaction n)
-  where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 data ApiWalletInput (n :: NetworkDiscriminant) = ApiWalletInput
     { id :: ApiT (Hash "Tx")
@@ -159,12 +145,8 @@ data ApiWalletInput (n :: NetworkDiscriminant) = ApiWalletInput
     , assets :: ApiT W.TokenMap
     }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiWalletInput n)
     deriving anyclass NFData
-
-instance DecodeAddress n => FromJSON (ApiWalletInput n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiWalletInput n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 data ApiTxInputGeneral (n :: NetworkDiscriminant) =
       ExternalInput (ApiT TxIn)
@@ -216,11 +198,8 @@ data ApiWalletOutput (n :: NetworkDiscriminant) = ApiWalletOutput
     , derivationPath :: NonEmpty (ApiT DerivationIndex)
     }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiWalletOutput n)
     deriving anyclass NFData
-instance DecodeAddress n => FromJSON (ApiWalletOutput n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiWalletOutput n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 data AddressAmount addr = AddressAmount
     { address :: addr
@@ -228,6 +207,7 @@ data AddressAmount addr = AddressAmount
     , assets :: ApiT W.TokenMap
     }
     deriving (Eq, Generic, Show)
+    deriving ToJSON via DefaultRecord (AddressAmount addr)
     deriving anyclass NFData
 
 instance FromJSON a => FromJSON (AddressAmount a) where
@@ -244,8 +224,6 @@ instance FromJSON a => FromJSON (AddressAmount a) where
                 "invalid coin value: value has to be lower than or equal to "
                 <> show (unCoin txOutMaxCoin) <> " lovelace."
 
-instance ToJSON a => ToJSON (AddressAmount a) where
-    toJSON = genericToJSON defaultRecordTypeOptions
 -- | A helper type to reduce the amount of repetition.
 --
 type ApiTxOutput n = AddressAmount (ApiT Address, Proxy n)
@@ -287,6 +265,7 @@ newtype ApiPostPolicyKeyData = ApiPostPolicyKeyData
     { passphrase :: ApiT (Passphrase "user")
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiPostPolicyKeyData
     deriving anyclass NFData
 
 data ApiTokenAmountFingerprint = ApiTokenAmountFingerprint
@@ -295,12 +274,8 @@ data ApiTokenAmountFingerprint = ApiTokenAmountFingerprint
     , fingerprint :: ApiT W.TokenFingerprint
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiTokenAmountFingerprint
     deriving anyclass NFData
-
-instance FromJSON ApiTokenAmountFingerprint where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiTokenAmountFingerprint where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 data ApiTokens = ApiTokens
     { policyId :: ApiT W.TokenPolicyId
@@ -308,12 +283,8 @@ data ApiTokens = ApiTokens
     , assets :: NonEmpty ApiTokenAmountFingerprint
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiTokens
     deriving anyclass NFData
-
-instance FromJSON ApiTokens where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiTokens where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 data ApiAssetMintBurn = ApiAssetMintBurn
     { tokens :: [ApiTokens]
@@ -321,24 +292,16 @@ data ApiAssetMintBurn = ApiAssetMintBurn
     , walletPolicyKeyIndex :: Maybe (ApiT DerivationIndex)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiAssetMintBurn
     deriving anyclass NFData
 
-instance FromJSON ApiAssetMintBurn where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance ToJSON ApiAssetMintBurn where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-data ApiWithdrawal n = ApiWithdrawal
+data ApiWithdrawal (n :: NetworkDiscriminant) = ApiWithdrawal
     { stakeAddress :: !(ApiT W.RewardAccount, Proxy n)
     , amount :: !(Quantity "lovelace" Natural)
     }
     deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiWithdrawal n)
     deriving anyclass NFData
-
-instance DecodeStakeAddress n => FromJSON (ApiWithdrawal n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeStakeAddress n => ToJSON (ApiWithdrawal n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance DecodeStakeAddress n => FromJSON (ApiWithdrawalGeneral n) where
     parseJSON obj = do

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Transaction.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Transaction.hs
@@ -157,8 +157,9 @@ data ApiWalletInput (n :: NetworkDiscriminant) = ApiWalletInput
     , derivationPath :: NonEmpty (ApiT DerivationIndex)
     , amount :: Quantity "lovelace" Natural
     , assets :: ApiT W.TokenMap
-    } deriving (Eq, Generic, Show, Typeable)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show, Typeable)
+    deriving anyclass NFData
 
 instance DecodeAddress n => FromJSON (ApiWalletInput n) where
     parseJSON = genericParseJSON defaultRecordTypeOptions
@@ -168,8 +169,8 @@ instance EncodeAddress n => ToJSON (ApiWalletInput n) where
 data ApiTxInputGeneral (n :: NetworkDiscriminant) =
       ExternalInput (ApiT TxIn)
     | WalletInput (ApiWalletInput n)
-      deriving (Eq, Generic, Show, Typeable)
-      deriving anyclass NFData
+    deriving (Eq, Generic, Show, Typeable)
+    deriving anyclass NFData
 
 instance
     ( DecodeAddress n
@@ -197,23 +198,25 @@ instance
     toJSON (WalletInput content) = toJSON content
 
 data ResourceContext = External | Our
-      deriving (Eq, Generic, Show, Typeable)
-      deriving anyclass NFData
+    deriving (Eq, Generic, Show, Typeable)
+    deriving anyclass NFData
 
 data ApiWithdrawalGeneral (n :: NetworkDiscriminant) = ApiWithdrawalGeneral
     { stakeAddress :: (ApiT W.RewardAccount, Proxy n)
     , amount :: Quantity "lovelace" Natural
     , context :: ResourceContext
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data ApiWalletOutput (n :: NetworkDiscriminant) = ApiWalletOutput
     { address :: (ApiT Address, Proxy n)
     , amount :: Quantity "lovelace" Natural
     , assets :: ApiT W.TokenMap
     , derivationPath :: NonEmpty (ApiT DerivationIndex)
-    } deriving (Eq, Generic, Show, Typeable)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show, Typeable)
+    deriving anyclass NFData
 instance DecodeAddress n => FromJSON (ApiWalletOutput n) where
     parseJSON = genericParseJSON defaultRecordTypeOptions
 instance EncodeAddress n => ToJSON (ApiWalletOutput n) where
@@ -223,8 +226,9 @@ data AddressAmount addr = AddressAmount
     { address :: addr
     , amount :: Quantity "lovelace" Natural
     , assets :: ApiT W.TokenMap
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 instance FromJSON a => FromJSON (AddressAmount a) where
     parseJSON = withObject "AddressAmount " $ \v ->
@@ -249,8 +253,8 @@ type ApiTxOutput n = AddressAmount (ApiT Address, Proxy n)
 data ApiTxOutputGeneral (n :: NetworkDiscriminant) =
       ExternalOutput (ApiTxOutput n)
     | WalletOutput (ApiWalletOutput n)
-      deriving (Eq, Generic, Show, Typeable)
-      deriving anyclass NFData
+    deriving (Eq, Generic, Show, Typeable)
+    deriving anyclass NFData
 
 instance
     ( DecodeAddress n
@@ -327,8 +331,9 @@ instance ToJSON ApiAssetMintBurn where
 data ApiWithdrawal n = ApiWithdrawal
     { stakeAddress :: !(ApiT W.RewardAccount, Proxy n)
     , amount :: !(Quantity "lovelace" Natural)
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 instance DecodeStakeAddress n => FromJSON (ApiWithdrawal n) where
     parseJSON = genericParseJSON defaultRecordTypeOptions


### PR DESCRIPTION
## Issue Number

None

## Summary

This PR uses `DerivingVia` to simplify the definitions of standard `{From,To}JSON` instances within the `Api.Types` module hierarchy.

## Details

This PR:

1. Applies the following transformation to all API types with `{From,To}JSON` instances based on `defaultRecordTypeOptions`:

    ```patch
      data ApiRecord = ApiRecord
          { fieldA :: TypeA
          , fieldB :: TypeB
          , fieldC :: TypeC
          }
          deriving (Eq, Generic, Show)
    +     deriving (FromJSON, ToJSON) via DefaultRecord ApiRecord
    -
    - instance FromJSON ApiRecord where
    -     parseJSON = genericParseJSON defaultRecordTypeOptions
    - instance ToJSON ApiRecord where
    -     toJSON = genericToJSON defaultRecordTypeOptions
    ```
2. Applies the following transformation to all API types with `{From,To}JSON` instances based on `defaultSumTypeOptions`:

    ```patch
      data ApiSum
          = ApiSumA
          | ApiSumB
          | ApiSumC
          deriving (Eq, Generic, Show)
    +     deriving (FromJSON, ToJSON) via DefaultSum ApiSum
    -
    - instance FromJSON ApiSum where
    -     parseJSON = genericParseJSON defaultSumTypeOptions
    - instance ToJSON ApiSum where
    -     toJSON = genericToJSON defaultSumTypeOptions
    ```

To achieve this, we define two new helper types with reusable `{From,To}JSON` instances:
```hs
newtype DefaultRecord a = DefaultRecord {unDefaultRecord :: a}
newtype DefaultSum    a = DefaultRecord {unDefaultSum    :: a}

instance (Generic a, ...) => FromJSON (DefaultRecord a) where ...
instance (Generic a, ...) =>   ToJSON (DefaultRecord a) where ...
instance (Generic a, ...) => FromJSON (DefaultSum    a) where ...
instance (Generic a, ...) =>   ToJSON (DefaultSum    a) where ...

```

In some cases, the reduction in boilerplate is substantial, since when using `DerivingVia`, GHC is able to _infer_ class constraints, whereas with hand-written instances, class constraints have to be declared _explicitly_. For example:

```patch

     data ApiDecodedTransaction (n :: NetworkDiscriminant) = ApiDecodedTransaction
     { id :: ...
     }
     deriving (Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord (ApiDecodedTransaction n)

-instance
-    ( DecodeAddress n
-    , DecodeStakeAddress n
-    ) => FromJSON (ApiDecodedTransaction n)
-  where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance
-    ( EncodeAddress n
-    , EncodeStakeAddress n
-    ) => ToJSON (ApiDecodedTransaction n)
-  where
-    toJSON = genericToJSON defaultRecordTypeOptions
```