### PR TITLE
Reuse balance transaction in construct transaction

### DIFF
--- a/lib/coin-selection/lib/Cardano/Wallet/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/Wallet/CoinSelection.hs
@@ -50,7 +50,6 @@ module Cardano.Wallet.CoinSelection
     , SelectionOf (..)
     , SelectionParams (..)
     , SelectionStrategy (..)
-    , PreSelection (..)
 
     -- * Selection skeletons
     , SelectionSkeleton (..)
@@ -386,27 +385,6 @@ toExternalSelectionSkeleton Internal.SelectionSkeleton {..} =
 --------------------------------------------------------------------------------
 -- Selections
 --------------------------------------------------------------------------------
-
--- | Represents a unbalanced selection.
---
-data PreSelection = PreSelection
-    { outputs
-        :: ![TxOut]
-        -- ^ User-specified outputs
-    , assetsToMint
-        :: !TokenMap
-        -- ^ Assets to mint.
-    , assetsToBurn
-        :: !TokenMap
-        -- ^ Assets to burn.
-    , extraCoinSource
-        :: !Coin
-        -- ^ An extra source of ada.
-    , extraCoinSink
-        :: !Coin
-        -- ^ An extra sink for ada.
-    }
-    deriving (Generic, Eq, Show)
 
 -- | Represents a balanced selection.
 --

--- a/lib/coin-selection/lib/Cardano/Wallet/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/Wallet/CoinSelection.hs
@@ -408,7 +408,6 @@ data PreSelection = PreSelection
     }
     deriving (Generic, Eq, Show)
 
-
 -- | Represents a balanced selection.
 --
 data SelectionOf change = Selection

--- a/lib/coin-selection/lib/Cardano/Wallet/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/Wallet/CoinSelection.hs
@@ -50,6 +50,7 @@ module Cardano.Wallet.CoinSelection
     , SelectionOf (..)
     , SelectionParams (..)
     , SelectionStrategy (..)
+    , PreSelection (..)
 
     -- * Selection skeletons
     , SelectionSkeleton (..)
@@ -385,6 +386,28 @@ toExternalSelectionSkeleton Internal.SelectionSkeleton {..} =
 --------------------------------------------------------------------------------
 -- Selections
 --------------------------------------------------------------------------------
+
+-- | Represents a unbalanced selection.
+--
+data PreSelection = PreSelection
+    { outputs
+        :: ![TxOut]
+        -- ^ User-specified outputs
+    , assetsToMint
+        :: !TokenMap
+        -- ^ Assets to mint.
+    , assetsToBurn
+        :: !TokenMap
+        -- ^ Assets to burn.
+    , extraCoinSource
+        :: !Coin
+        -- ^ An extra source of ada.
+    , extraCoinSink
+        :: !Coin
+        -- ^ An extra sink for ada.
+    }
+    deriving (Generic, Eq, Show)
+
 
 -- | Represents a balanced selection.
 --

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2478,8 +2478,8 @@ constructTransaction ctx genChange knownPools getPoolStatus apiw@(ApiT wid) body
         pure $ ApiConstructTransaction
             { transaction = balancedTx
             , coinSelection = mkApiCoinSelection
-                (maybe [] (\x->[x]) deposit)
-                (maybe [] (\x->[x]) refund)
+                (maybe [] singleton deposit)
+                (maybe [] singleton refund)
                 ((,rewardPath) <$> txCtx' ^. #txDelegationAction)
                 md
                 (unsignedTx rewardPath (outs ++ mintingOuts) apiDecoded)
@@ -2488,6 +2488,8 @@ constructTransaction ctx genChange knownPools getPoolStatus apiw@(ApiT wid) body
   where
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
     ti = timeInterpreter (ctx ^. networkLayer)
+
+    singleton x = [x]
 
     toUnsignedTxChange initialOuts (WalletOutput (ApiWalletOutput (ApiT addr, _) (Quantity c) (ApiT tmap) derPath)) =
         let txchange = TxChange addr (Coin $ fromIntegral c) tmap (NE.map getApiT derPath)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2453,7 +2453,7 @@ constructTransaction
                 }
         unbalancedTx <- liftHandler $
             W.constructTransaction @_ @_ @_ @n @'CredFromKeyK
-                wrk wid era txCtx' (Left preSel)
+                wrk wid era txCtx' preSel
 
         let balancedPostData = ApiBalanceTransactionPostData
                 { transaction = ApiT unbalancedTx

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -337,11 +337,7 @@ import Cardano.Wallet.Api.Types.SchemaMetadata
 import Cardano.Wallet.Api.Types.Transaction
     ( ApiValidityIntervalExplicit (..), mkApiWitnessCount )
 import Cardano.Wallet.CoinSelection
-    ( PreSelection (..)
-    , SelectionOf (..)
-    , SelectionStrategy (..)
-    , selectionDelta
-    )
+    ( SelectionOf (..), SelectionStrategy (..), selectionDelta )
 import Cardano.Wallet.Compat
     ( (^?) )
 import Cardano.Wallet.DB
@@ -509,6 +505,7 @@ import Cardano.Wallet.TokenMetadata
     ( TokenMetadataClient, fillMetadata )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
+    , PreSelection (..)
     , TransactionCtx (..)
     , TransactionLayer (..)
     , Withdrawal (..)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2755,9 +2755,9 @@ decodeSharedTransaction ctx (ApiT wid) (ApiSerialisedTransaction (ApiT sealed) _
         }
 
 balanceTransaction
-    :: forall s k (n :: NetworkDiscriminant)
+    :: forall s k ktype (n :: NetworkDiscriminant)
      . (GenChange s, BoundedAddressLength k)
-    => ApiLayer s k 'CredFromKeyK
+    => ApiLayer s k ktype
     -> ArgGenChange s
     -> ApiT WalletId
     -> ApiBalanceTransactionPostData n
@@ -2823,7 +2823,7 @@ balanceTransaction ctx@ApiLayer{..} genChange (ApiT wid) body = do
                 => W.PartialTx era
                 -> Handler (Cardano.Tx era)
             balanceTx partialTx =
-                liftHandler $ W.balanceTransaction @_ @IO @s @k @'CredFromKeyK
+                liftHandler $ W.balanceTransaction @_ @IO @s @k @ktype
                     wrk
                     genChange
                     (pp, nodePParams)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2449,8 +2449,8 @@ constructTransaction
                 , extraCoinSink = fromMaybe (Coin 0) deposit
                 }
         unbalancedTx <- liftHandler $
-            W.constructTransaction @_ @_ @_ @n @'CredFromKeyK
-                wrk wid era txCtx' preSel
+            W.constructTransaction @n @'CredFromKeyK
+                txLayer netLayer db wid era txCtx' preSel
 
         let balancedPostData = ApiBalanceTransactionPostData
                 { transaction = ApiT unbalancedTx

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -419,7 +419,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         verify rTx
             [ expectResponseCode HTTP.status202
             , expectField (#coinSelection . #metadata) (`shouldBe` Nothing)
-            , expectField (#coinSelection . #withdrawals) (`shouldSatisfy` (not . null))
+            , expectField (#coinSelection . #withdrawals) (`shouldSatisfy` null)
             ]
         let expectedFee = getFromResponse (#fee . #getQuantity) rTx
 

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -244,7 +244,8 @@ import Cardano.Wallet.Checkpoints
     , sparseCheckpoints
     )
 import Cardano.Wallet.CoinSelection
-    ( Selection
+    ( PreSelection
+    , Selection
     , SelectionBalanceError (..)
     , SelectionCollateralRequirement (..)
     , SelectionConstraints (..)
@@ -2533,7 +2534,7 @@ constructTransaction
     -> WalletId
     -> Cardano.AnyCardanoEra
     -> TransactionCtx
-    -> SelectionOf TxOut
+    -> Either PreSelection (SelectionOf TxOut)
     -> ExceptT ErrConstructTx IO SealedTx
 constructTransaction ctx wid era txCtx sel = db & \DBLayer{..} -> do
     (_, xpub, _) <- withExceptT ErrConstructTxReadRewardAccount $
@@ -2541,7 +2542,7 @@ constructTransaction ctx wid era txCtx sel = db & \DBLayer{..} -> do
     mapExceptT atomically $ do
         pp <- liftIO $ currentProtocolParameters nl
         withExceptT ErrConstructTxBody $ ExceptT $ pure $
-            mkUnsignedTransaction tl era xpub pp txCtx (Right sel)
+            mkUnsignedTransaction tl era xpub pp txCtx sel
   where
     db = ctx ^. dbLayer @IO @s @k
     tl = ctx ^. transactionLayer @k @ktype

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2522,31 +2522,21 @@ buildAndSignTransaction ctx wid era mkRwdAcct pwd txCtx sel = db & \DBLayer{..} 
 
 -- | Construct an unsigned transaction from a given selection.
 constructTransaction
-    :: forall ctx s k (n :: NetworkDiscriminant) ktype.
-        ( HasTransactionLayer k ktype ctx
-        , HasDBLayer IO s k ctx
-        , HasNetworkLayer IO ctx
-        , Typeable s
-        , Typeable n
-        , Typeable k
-        )
-    => ctx
+    :: forall (n :: NetworkDiscriminant) ktype
+     . TransactionLayer ShelleyKey ktype SealedTx
+    -> NetworkLayer IO Block
+    -> DBLayer IO (SeqState n ShelleyKey) ShelleyKey
     -> WalletId
     -> Cardano.AnyCardanoEra
     -> TransactionCtx
     -> PreSelection
     -> ExceptT ErrConstructTx IO SealedTx
-constructTransaction ctx wid era txCtx preSel = db & \DBLayer{..} -> do
-    (_, xpub, _) <- withExceptT ErrConstructTxReadRewardAccount $
-        shelleyOnlyReadRewardAccount @s @k @n db wid
-    mapExceptT atomically $ do
-        pp <- liftIO $ currentProtocolParameters nl
-        withExceptT ErrConstructTxBody $ ExceptT $ pure $
-            mkUnsignedTransaction tl era xpub pp txCtx (Left preSel)
-  where
-    db = ctx ^. dbLayer @IO @s @k
-    tl = ctx ^. transactionLayer @k @ktype
-    nl = ctx ^. networkLayer
+constructTransaction txLayer netLayer db wid era txCtx preSel = do
+    (_, xpub, _) <- readRewardAccount db wid
+        & withExceptT ErrConstructTxReadRewardAccount
+    pp <- liftIO $ currentProtocolParameters netLayer
+    mkUnsignedTransaction txLayer era xpub pp txCtx (Left preSel)
+        & withExceptT ErrConstructTxBody . except
 
 -- | Construct an unsigned transaction from a given selection
 -- for a shared wallet.

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2541,7 +2541,7 @@ constructTransaction ctx wid era txCtx sel = db & \DBLayer{..} -> do
     mapExceptT atomically $ do
         pp <- liftIO $ currentProtocolParameters nl
         withExceptT ErrConstructTxBody $ ExceptT $ pure $
-            mkUnsignedTransaction tl era xpub pp txCtx sel
+            mkUnsignedTransaction tl era xpub pp txCtx (Right sel)
   where
     db = ctx ^. dbLayer @IO @s @k
     tl = ctx ^. transactionLayer @k @ktype
@@ -2595,7 +2595,7 @@ constructSharedTransaction ctx wid era txCtx sel = db & \DBLayer{..} -> do
     mapExceptT atomically $ do
         pp <- liftIO $ currentProtocolParameters nl
         withExceptT ErrConstructTxBody $ ExceptT $ pure $
-            mkUnsignedTransaction tl era xpub pp txCtx' sel
+            mkUnsignedTransaction tl era xpub pp txCtx' (Right sel)
   where
     db = ctx ^. dbLayer @IO @s @k
     tl = ctx ^. transactionLayer @k @'CredFromScriptK

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -244,8 +244,7 @@ import Cardano.Wallet.Checkpoints
     , sparseCheckpoints
     )
 import Cardano.Wallet.CoinSelection
-    ( PreSelection
-    , Selection
+    ( Selection
     , SelectionBalanceError (..)
     , SelectionCollateralRequirement (..)
     , SelectionConstraints (..)
@@ -475,6 +474,7 @@ import Cardano.Wallet.Transaction
     , ErrMoreSurplusNeeded (ErrMoreSurplusNeeded)
     , ErrSignTx (..)
     , ErrUpdateSealedTx (..)
+    , PreSelection
     , TransactionCtx (..)
     , TransactionLayer (..)
     , TxFeeAndChange (TxFeeAndChange)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2534,15 +2534,15 @@ constructTransaction
     -> WalletId
     -> Cardano.AnyCardanoEra
     -> TransactionCtx
-    -> Either PreSelection (SelectionOf TxOut)
+    -> PreSelection
     -> ExceptT ErrConstructTx IO SealedTx
-constructTransaction ctx wid era txCtx sel = db & \DBLayer{..} -> do
+constructTransaction ctx wid era txCtx preSel = db & \DBLayer{..} -> do
     (_, xpub, _) <- withExceptT ErrConstructTxReadRewardAccount $
         shelleyOnlyReadRewardAccount @s @k @n db wid
     mapExceptT atomically $ do
         pp <- liftIO $ currentProtocolParameters nl
         withExceptT ErrConstructTxBody $ ExceptT $ pure $
-            mkUnsignedTransaction tl era xpub pp txCtx sel
+            mkUnsignedTransaction tl era xpub pp txCtx (Left preSel)
   where
     db = ctx ^. dbLayer @IO @s @k
     tl = ctx ^. transactionLayer @k @ktype

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -353,9 +353,8 @@ instance TxWitnessTagFor ByronKey where
     txWitnessTagFor = TxWitnessByronUTxO Byron
 
 constructUnsignedTx
-    :: forall era.
-        ( EraConstraints era
-        )
+    :: forall era
+     . EraConstraints era
     => Cardano.NetworkId
     -> (Maybe Cardano.TxMetadata, [Cardano.Certificate])
     -> (Maybe SlotNo, SlotNo)
@@ -2219,9 +2218,11 @@ sumVia :: (Foldable t, Num m) => (a -> m) -> t a -> m
 sumVia f = F.foldl' (\t -> (t +) . f) 0
 
 withShelleyBasedEra
-    :: forall a. ()
-    => AnyCardanoEra
-    -> (forall era. EraConstraints era => ShelleyBasedEra era -> Either ErrMkTransaction a)
+    :: forall a
+     . AnyCardanoEra
+    -> ( forall era. EraConstraints era
+         => ShelleyBasedEra era -> Either ErrMkTransaction a
+       )
     -> Either ErrMkTransaction a
 withShelleyBasedEra era fn = case era of
     AnyCardanoEra ByronEra    -> Left $ ErrMkTransactionInvalidEra era

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -97,7 +97,6 @@ import Cardano.Slotting.EpochInfo.API
     ( hoistEpochInfo )
 import Cardano.Wallet.CoinSelection
     ( PreSelection (..)
-    , PreSelection (..)
     , SelectionLimitOf (..)
     , SelectionOf (..)
     , SelectionSkeleton (..)
@@ -180,6 +179,8 @@ import Cardano.Wallet.Shelley.Compatibility
     , toStakeKeyRegCert
     , toStakePoolDlgCert
     )
+import Cardano.Wallet.Shelley.Compatibility.Ledger
+    ( toLedger )
 import Cardano.Wallet.Shelley.MinimumUTxO
     ( computeMinimumCoinForUTxO, isBelowMinimumCoinForUTxO )
 import Cardano.Wallet.Transaction
@@ -799,7 +800,6 @@ modifyShelleyTxBody txUpdate era ledgerBody = case era of
                 . toCardanoTxOut era <$> extraOutputs
                 )
         , Babbage.inputs =
-               filterOutDummyInp $
                Babbage.inputs ledgerBody
             <> Set.fromList (Cardano.toShelleyTxIn <$> extraInputs')
         , Babbage.collateral = Babbage.collateral ledgerBody
@@ -815,7 +815,6 @@ modifyShelleyTxBody txUpdate era ledgerBody = case era of
                 . toCardanoTxOut era <$> extraOutputs
                 )
         , Alonzo.inputs =
-               filterOutDummyInp $
                Alonzo.inputs ledgerBody
             <> Set.fromList (Cardano.toShelleyTxIn <$> extraInputs')
         , Alonzo.collateral = Alonzo.collateral ledgerBody
@@ -834,7 +833,7 @@ modifyShelleyTxBody txUpdate era ledgerBody = case era of
                 . toCardanoTxOut era
         in
         ShelleyMA.TxBody
-            (filterOutDummyInp $ inputs <> Set.fromList (Cardano.toShelleyTxIn <$> extraInputs'))
+            (inputs <> Set.fromList (Cardano.toShelleyTxIn <$> extraInputs'))
             (outputs <> StrictSeq.fromList (toTxOut <$> extraOutputs))
             certs
             wdrls
@@ -854,7 +853,7 @@ modifyShelleyTxBody txUpdate era ledgerBody = case era of
                 . toCardanoTxOut era
         in
         ShelleyMA.TxBody
-            (filterOutDummyInp $ inputs <> Set.fromList (Cardano.toShelleyTxIn <$> extraInputs'))
+            (inputs <> Set.fromList (Cardano.toShelleyTxIn <$> extraInputs'))
             (outputs <> StrictSeq.fromList (toTxOut <$> extraOutputs))
             certs
             wdrls
@@ -873,7 +872,7 @@ modifyShelleyTxBody txUpdate era ledgerBody = case era of
                 . toCardanoTxOut era
         in
         Shelley.TxBody
-            (filterOutDummyInp $ inputs <> Set.fromList (Cardano.toShelleyTxIn <$> extraInputs'))
+            (inputs <> Set.fromList (Cardano.toShelleyTxIn <$> extraInputs'))
             (outputs <> StrictSeq.fromList (toTxOut <$> extraOutputs))
             certs
             wdrls
@@ -887,9 +886,6 @@ modifyShelleyTxBody txUpdate era ledgerBody = case era of
 
     extraInputs' = toCardanoTxIn . fst <$> extraInputs
     extraCollateral' = toCardanoTxIn <$> extraCollateral
-
-    filterOutDummyInp =
-        Set.delete (Cardano.toShelleyTxIn $ toCardanoTxIn dummyInput)
 
     modifyFee old = case feeUpdate of
         UseNewTxFee new -> toLedgerCoin new
@@ -2242,7 +2238,7 @@ mkUnsignedTx
     -> Map TxIn (Script KeyHash)
     -> Either ErrMkTransaction (Cardano.TxBody era)
 mkUnsignedTx era ttl cs md wdrls certs fees mintData burnData mintingScripts inpsScripts =
-    left toErrMkTx $ Cardano.makeTransactionBody $ Cardano.TxBodyContent
+    left toErrMkTx $ fmap removeDummyInput $ Cardano.makeTransactionBody $ Cardano.TxBodyContent
     { Cardano.txIns = inputWits
 
     , txInsReference = Cardano.TxInsReferenceNone
@@ -2418,10 +2414,27 @@ mkUnsignedTx era ttl cs md wdrls certs fees mintData burnData mintingScripts inp
             [( toCardanoTxIn dummyInput
              , Cardano.BuildTxWith (Cardano.KeyWitness Cardano.KeyWitnessForSpending))]
 
+
+
+
 -- cardano-node does not allow to construct tx without inputs at this moment.
 -- this should change and this hack should be removed
 dummyInput :: TxIn
 dummyInput = TxIn (Hash $ BS.replicate 32 0) 999
+
+removeDummyInput
+    :: Cardano.IsCardanoEra era
+    => Cardano.TxBody era
+    -> Cardano.TxBody era
+removeDummyInput (Cardano.ShelleyTxBody era bod scripts scriptData aux val) =
+    (Cardano.ShelleyTxBody era (removeDummyIn bod) scripts scriptData aux val)
+
+  where
+    removeDummyIn body = case era of
+        ShelleyBasedEraBabbage -> body
+            { Babbage.inputs = Set.delete (toLedger dummyInput) (Babbage.inputs body)
+            }
+        _ -> error "todo"
 
 mkWithdrawals
     :: NetworkId

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1035,7 +1035,7 @@ estimateNumberOfWitnesses
     :: forall era. Cardano.IsShelleyBasedEra era
     => Cardano.TxBody era
     -> Word
-estimateNumberOfWitnesses (Cardano.TxBody txbodycontent) =
+estimateNumberOfWitnesses txbody@(Cardano.TxBody txbodycontent) =
     let txIns = Cardano.txIns txbodycontent
         txIns' = [ txin | (txin, Cardano.ViewTx) <- txIns ]
         txInsCollateral = Cardano.txInsCollateral txbodycontent
@@ -1063,9 +1063,7 @@ estimateNumberOfWitnesses (Cardano.TxBody txbodycontent) =
             Cardano.TxCertificates _ certs _ -> length certs
             -- FIXME [ADP-1515] Not all certificates require witnesses. Will
             -- over-estimate unnecessarily.
-        txMintingScripts = case Cardano.txMintValue txbodycontent of
-            Cardano.TxMintValue _ _ _ -> 1
-            Cardano.TxMintNone -> 0
+        txMintingScripts = length $ filter isScriptNative scripts
     in
     fromIntegral $
         length txInsUnique +
@@ -1075,8 +1073,22 @@ estimateNumberOfWitnesses (Cardano.TxBody txbodycontent) =
         txCerts +
         txMintingScripts
   where
-    -- Silence warning from redundant @IsShelleyBasedEra@ constraint:
-    _ = shelleyBasedEra @era
+    (Cardano.ShelleyTxBody _ _ scripts _ _ _) = txbody
+    isScriptNative script = case Cardano.shelleyBasedEra @era of
+        Cardano.ShelleyBasedEraShelley ->
+            False
+        Cardano.ShelleyBasedEraAllegra ->
+            False
+        Cardano.ShelleyBasedEraMary->
+            True --only native scripts allowed
+        Cardano.ShelleyBasedEraAlonzo ->
+            case script of
+                Alonzo.TimelockScript _ -> True
+                _ -> False
+        Cardano.ShelleyBasedEraBabbage ->
+            case script of
+                Alonzo.TimelockScript _ -> True
+                _ -> False
 
 _maxScriptExecutionCost
     :: ProtocolParameters

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -2421,7 +2421,7 @@ mkUnsignedTx era ttl cs md wdrls certs fees mintData burnData mintingScripts inp
 -- cardano-node does not allow to construct tx without inputs at this moment.
 -- this should change and this hack should be removed
 dummyInput :: TxIn
-dummyInput = TxIn (Hash $ B8.replicate 32 '0') 0
+dummyInput = TxIn (Hash $ BS.replicate 32 0) 999
 
 mkWithdrawals
     :: NetworkId

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -97,8 +97,7 @@ import Cardano.Slotting.EpochInfo
 import Cardano.Slotting.EpochInfo.API
     ( hoistEpochInfo )
 import Cardano.Wallet.CoinSelection
-    ( PreSelection (..)
-    , SelectionLimitOf (..)
+    ( SelectionLimitOf (..)
     , SelectionOf (..)
     , SelectionSkeleton (..)
     , selectionDelta
@@ -191,6 +190,7 @@ import Cardano.Wallet.Transaction
     , ErrMkTransaction (..)
     , ErrMoreSurplusNeeded (ErrMoreSurplusNeeded)
     , ErrUpdateSealedTx (..)
+    , PreSelection (..)
     , TokenMapWithScripts
     , TransactionCtx (..)
     , TransactionLayer (..)

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -286,7 +286,6 @@ import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Foldable as F
 import qualified Data.List as L

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -2444,12 +2444,12 @@ dummyInput = TxIn (Hash $ BS.replicate 32 0) 999
 removeDummyInput :: HasCallStack => Cardano.TxBody era -> Cardano.TxBody era
 removeDummyInput txBody =
     case txBody of
-        Byron.ByronTxBody {} -> txBody
+        Byron.ByronTxBody {} -> bailOut
         Cardano.ShelleyTxBody era body scripts scriptData aux val ->
             case era of
-                ShelleyBasedEraShelley -> txBody
-                ShelleyBasedEraAllegra -> txBody
-                ShelleyBasedEraMary -> txBody
+                ShelleyBasedEraShelley -> bailOut
+                ShelleyBasedEraAllegra -> bailOut
+                ShelleyBasedEraMary -> bailOut
                 ShelleyBasedEraAlonzo ->
                     let body' = body
                             { Alonzo.inputs =
@@ -2478,6 +2478,8 @@ removeDummyInput txBody =
                         scriptData
                         aux
                         val
+  where
+    bailOut = error "removeDummyInput only supported for the Babbage era"
 
 mkWithdrawals
     :: NetworkId

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -2434,6 +2434,7 @@ mkUnsignedTx
             = Cardano.BuildTxWith
             $ Cardano.KeyWitness Cardano.KeyWitnessForSpending
 
+-- TODO: ADP-2257
 -- cardano-node does not allow to construct tx without inputs at this moment.
 -- this should change and this hack should be removed
 dummyInput :: TxIn

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -2442,25 +2442,29 @@ dummyInput :: TxIn
 dummyInput = TxIn (Hash $ BS.replicate 32 0) 999
 
 removeDummyInput :: HasCallStack => Cardano.TxBody era -> Cardano.TxBody era
-removeDummyInput = \case
-    Byron.ByronTxBody {} ->
-        bailOut
-    Cardano.ShelleyTxBody era body scripts scriptData aux val -> case era of
-        ShelleyBasedEraShelley ->
-            bailOut
-        ShelleyBasedEraAllegra ->
-            bailOut
-        ShelleyBasedEraMary ->
-            bailOut
-        ShelleyBasedEraAlonzo ->
-            bailOut
-        ShelleyBasedEraBabbage ->
-            Cardano.ShelleyTxBody
-                era (body `removeInput` dummyInput) scripts scriptData aux val
-  where
-    bailOut = error "removeDummyInput only supported for the Babbage era"
-    removeInput b i = b
-        {Babbage.inputs = Set.delete (toLedger i) (Babbage.inputs b)}
+removeDummyInput txBody =
+    case txBody of
+        Byron.ByronTxBody {} -> txBody
+        Cardano.ShelleyTxBody era body scripts scriptData aux val ->
+            case era of
+                ShelleyBasedEraShelley -> txBody
+                ShelleyBasedEraAllegra -> txBody
+                ShelleyBasedEraMary -> txBody
+                ShelleyBasedEraAlonzo -> txBody
+                ShelleyBasedEraBabbage ->
+                    let body' = body
+                            { Babbage.inputs =
+                                Set.delete
+                                    (toLedger dummyInput)
+                                    (Babbage.inputs body)
+                            }
+                    in Cardano.ShelleyTxBody
+                        era
+                        body'
+                        scripts
+                        scriptData
+                        aux
+                        val
 
 mkWithdrawals
     :: NetworkId

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -2439,10 +2439,7 @@ mkUnsignedTx
 dummyInput :: TxIn
 dummyInput = TxIn (Hash $ BS.replicate 32 0) 999
 
-removeDummyInput
-    :: Cardano.IsCardanoEra era
-    => Cardano.TxBody era
-    -> Cardano.TxBody era
+removeDummyInput :: Cardano.TxBody era -> Cardano.TxBody era
 removeDummyInput (Cardano.ShelleyTxBody era bod scripts scriptData aux val) =
     (Cardano.ShelleyTxBody era (removeDummyIn bod) scripts scriptData aux val)
 

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1063,13 +1063,17 @@ estimateNumberOfWitnesses (Cardano.TxBody txbodycontent) =
             Cardano.TxCertificates _ certs _ -> length certs
             -- FIXME [ADP-1515] Not all certificates require witnesses. Will
             -- over-estimate unnecessarily.
+        txMintingScripts = case Cardano.txMintValue txbodycontent of
+            Cardano.TxMintValue _ _ _ -> 1
+            Cardano.TxMintNone -> 0
     in
     fromIntegral $
         length txInsUnique +
         length txExtraKeyWits' +
         length txWithdrawals' +
         txUpdateProposal' +
-        txCerts
+        txCerts +
+        txMintingScripts
   where
     -- Silence warning from redundant @IsShelleyBasedEra@ constraint:
     _ = shelleyBasedEra @era

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -22,6 +22,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
+{- HLINT ignore "Use <$>" -}
 
 -- |
 -- Copyright: © 2020 IOHK
@@ -406,14 +407,17 @@ mkTx
     -- ^ Explicit fee amount
     -> ShelleyBasedEra era
     -> Either ErrMkTransaction (Tx, SealedTx)
-mkTx networkId payload ttl (rewardAcnt, pwdAcnt) addrResolver wdrl cs fees era = do
+mkTx networkId payload ttl (rewardAcnt, pwdAcnt) addrResolver wdrl cs fees era =
+    do
+
     let TxPayload md certs mkExtraWits = payload
     let wdrls = mkWithdrawals
             networkId
             (toRewardAccountRaw . toXPub $ rewardAcnt)
             wdrl
 
-    unsigned <- mkUnsignedTx era ttl (Right cs) md wdrls certs (toCardanoLovelace fees)
+    unsigned <- mkUnsignedTx era ttl (Right cs) md wdrls certs
+        (toCardanoLovelace fees)
         TokenMap.empty TokenMap.empty Map.empty Map.empty
     let signed = signTransaction networkId acctResolver (const Nothing)
             addrResolver inputResolver (unsigned, mkExtraWits unsigned)
@@ -798,8 +802,7 @@ modifyShelleyTxBody txUpdate era ledgerBody = case era of
                 . Cardano.toCtxUTxOTxOut
                 . toCardanoTxOut era <$> extraOutputs
                 )
-        , Babbage.inputs =
-               Babbage.inputs ledgerBody
+        , Babbage.inputs = Babbage.inputs ledgerBody
             <> Set.fromList (Cardano.toShelleyTxIn <$> extraInputs')
         , Babbage.collateral = Babbage.collateral ledgerBody
             <> Set.fromList (Cardano.toShelleyTxIn <$> extraCollateral')
@@ -813,8 +816,7 @@ modifyShelleyTxBody txUpdate era ledgerBody = case era of
                 . Cardano.toCtxUTxOTxOut
                 . toCardanoTxOut era <$> extraOutputs
                 )
-        , Alonzo.inputs =
-               Alonzo.inputs ledgerBody
+        , Alonzo.inputs = Alonzo.inputs ledgerBody
             <> Set.fromList (Cardano.toShelleyTxIn <$> extraInputs')
         , Alonzo.collateral = Alonzo.collateral ledgerBody
             <> Set.fromList (Cardano.toShelleyTxIn <$> extraCollateral')
@@ -2252,26 +2254,28 @@ mkUnsignedTx
     -> Map AssetId (Script KeyHash)
     -> Map TxIn (Script KeyHash)
     -> Either ErrMkTransaction (Cardano.TxBody era)
-mkUnsignedTx era ttl cs md wdrls certs fees mintData burnData mintingScripts inpsScripts =
-    left toErrMkTx $ fmap removeDummyInput $ Cardano.makeTransactionBody $ Cardano.TxBodyContent
+mkUnsignedTx
+    era ttl cs md wdrls certs fees mintData burnData mintingScripts inpsScripts =
+    left toErrMkTx $ fmap removeDummyInput $ Cardano.makeTransactionBody
+    Cardano.TxBodyContent
     { Cardano.txIns = inputWits
 
     , txInsReference = Cardano.TxInsReferenceNone
 
     , Cardano.txOuts = case cs of
-            Right selOf ->
-                toCardanoTxOut era <$> view #outputs selOf ++ F.toList (view #change selOf)
-            Left preSel ->
-                toCardanoTxOut era <$> view #outputs preSel
+        Right selOf ->
+            toCardanoTxOut era <$>
+                view #outputs selOf ++ F.toList (view #change selOf)
+        Left preSel ->
+            toCardanoTxOut era <$>
+                view #outputs preSel
 
     , Cardano.txWithdrawals =
-        let
-            wit = Cardano.BuildTxWith
+        let wit = Cardano.BuildTxWith
                 $ Cardano.KeyWitness Cardano.KeyWitnessForStakeAddr
         in
-            Cardano.TxWithdrawals wdrlsSupported
-                (map (\(key, coin) -> (key, coin, wit)) wdrls)
-
+        Cardano.TxWithdrawals wdrlsSupported
+            (map (\(key, coin) -> (key, coin, wit)) wdrls)
 
     -- @mkUnsignedTx@ is never used with Plutus scripts, and so we never have to
     -- care about collateral or PParams (for script integrity hash) here.
@@ -2283,10 +2287,7 @@ mkUnsignedTx era ttl cs md wdrls certs fees mintData burnData mintingScripts inp
     , txTotalCollateral = Cardano.TxTotalCollateralNone
     , txReturnCollateral = Cardano.TxReturnCollateralNone
     , txProtocolParams = Cardano.BuildTxWith Nothing
-
-    , txScriptValidity =
-        Cardano.TxScriptValidityNone
-
+    , txScriptValidity = Cardano.TxScriptValidityNone
     , txExtraKeyWits = Cardano.TxExtraKeyWitnessesNone
 
     , Cardano.txCertificates =
@@ -2295,7 +2296,7 @@ mkUnsignedTx era ttl cs md wdrls certs fees mintData burnData mintingScripts inp
             witMap = Map.empty
             ctx = Cardano.BuildTxWith witMap
         in
-            Cardano.TxCertificates certSupported certs ctx
+        Cardano.TxCertificates certSupported certs ctx
 
     , Cardano.txFee = explicitFees era fees
 
@@ -2303,7 +2304,8 @@ mkUnsignedTx era ttl cs md wdrls certs fees mintData burnData mintingScripts inp
         let toLowerBound from = case txValidityLowerBoundSupported of
                 Just lowerBoundSupported ->
                     Cardano.TxValidityLowerBound lowerBoundSupported from
-                Nothing -> Cardano.TxValidityNoLowerBound
+                Nothing ->
+                    Cardano.TxValidityNoLowerBound
         in
         bimap
             (maybe Cardano.TxValidityNoLowerBound toLowerBound)

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -2442,44 +2442,44 @@ dummyInput :: TxIn
 dummyInput = TxIn (Hash $ BS.replicate 32 0) 999
 
 removeDummyInput :: HasCallStack => Cardano.TxBody era -> Cardano.TxBody era
-removeDummyInput txBody =
-    case txBody of
-        Byron.ByronTxBody {} -> bailOut
-        Cardano.ShelleyTxBody era body scripts scriptData aux val ->
-            case era of
-                ShelleyBasedEraShelley -> bailOut
-                ShelleyBasedEraAllegra -> bailOut
-                ShelleyBasedEraMary -> bailOut
-                ShelleyBasedEraAlonzo ->
-                    let body' = body
-                            { Alonzo.inputs =
-                                Set.delete
-                                    (toLedger dummyInput)
-                                    (Alonzo.inputs body)
-                            }
-                    in Cardano.ShelleyTxBody
-                        era
-                        body'
-                        scripts
-                        scriptData
-                        aux
-                        val
-                ShelleyBasedEraBabbage ->
-                    let body' = body
-                            { Babbage.inputs =
-                                Set.delete
-                                    (toLedger dummyInput)
-                                    (Babbage.inputs body)
-                            }
-                    in Cardano.ShelleyTxBody
-                        era
-                        body'
-                        scripts
-                        scriptData
-                        aux
-                        val
+removeDummyInput = \case
+    Byron.ByronTxBody {} -> bailOut
+    Cardano.ShelleyTxBody era body scripts scriptData aux val ->
+        case era of
+            ShelleyBasedEraShelley -> bailOut
+            ShelleyBasedEraAllegra -> bailOut
+            ShelleyBasedEraMary -> bailOut
+            ShelleyBasedEraAlonzo ->
+                let body' = body
+                        { Alonzo.inputs =
+                            Set.delete
+                                (toLedger dummyInput)
+                                (Alonzo.inputs body)
+                        }
+                in Cardano.ShelleyTxBody
+                    era
+                    body'
+                    scripts
+                    scriptData
+                    aux
+                    val
+            ShelleyBasedEraBabbage ->
+                let body' = body
+                        { Babbage.inputs =
+                            Set.delete
+                                (toLedger dummyInput)
+                                (Babbage.inputs body)
+                        }
+                in Cardano.ShelleyTxBody
+                    era
+                    body'
+                    scripts
+                    scriptData
+                    aux
+                    val
   where
-    bailOut = error "removeDummyInput only supported for the Babbage era"
+    bailOut = error "removing dummy inputs is only supported \
+        \for the Alonzo or Babbage era"
 
 mkWithdrawals
     :: NetworkId

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -2422,17 +2422,17 @@ mkUnsignedTx
     inputWits = case cs of
         Right selOf ->
             if inpsScripts == Map.empty then
-                (,Cardano.BuildTxWith (Cardano.KeyWitness Cardano.KeyWitnessForSpending))
-                . toCardanoTxIn
-                . fst <$> F.toList (view #inputs selOf)
+                (, buildTxCommand)
+                    . toCardanoTxIn
+                    . fst <$> F.toList (view #inputs selOf)
             else
                 constructInpScriptWit . fst <$> F.toList (view #inputs selOf)
         Left _preSel ->
-            [( toCardanoTxIn dummyInput
-             , Cardano.BuildTxWith (Cardano.KeyWitness Cardano.KeyWitnessForSpending))]
-
-
-
+            [(toCardanoTxIn dummyInput, buildTxCommand)]
+      where
+        buildTxCommand
+            = Cardano.BuildTxWith
+            $ Cardano.KeyWitness Cardano.KeyWitnessForSpending
 
 -- cardano-node does not allow to construct tx without inputs at this moment.
 -- this should change and this hack should be removed

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -2450,7 +2450,20 @@ removeDummyInput txBody =
                 ShelleyBasedEraShelley -> txBody
                 ShelleyBasedEraAllegra -> txBody
                 ShelleyBasedEraMary -> txBody
-                ShelleyBasedEraAlonzo -> txBody
+                ShelleyBasedEraAlonzo ->
+                    let body' = body
+                            { Alonzo.inputs =
+                                Set.delete
+                                    (toLedger dummyInput)
+                                    (Alonzo.inputs body)
+                            }
+                    in Cardano.ShelleyTxBody
+                        era
+                        body'
+                        scripts
+                        scriptData
+                        aux
+                        val
                 ShelleyBasedEraBabbage ->
                     let body' = body
                             { Babbage.inputs =

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -394,8 +394,7 @@ data TransactionCtx = TransactionCtx
     -- this. For instance: datums.
     } deriving (Show, Generic, Eq)
 
--- | Represents a unbalanced selection.
---
+-- | Represents a preliminary selection of tx outputs typically made by user.
 data PreSelection = PreSelection
     { outputs :: ![TxOut]
       -- ^ User-specified outputs

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -68,7 +68,8 @@ import Cardano.Ledger.Crypto
 import Cardano.Pool.Types
     ( PoolId )
 import Cardano.Wallet.CoinSelection
-    ( SelectionCollateralRequirement (..)
+    ( PreSelection
+    , SelectionCollateralRequirement (..)
     , SelectionLimit
     , SelectionOf (..)
     , SelectionSkeleton
@@ -183,7 +184,7 @@ data TransactionLayer k ktype tx = TransactionLayer
             -- Current protocol parameters
         -> TransactionCtx
             -- An additional context about the transaction
-        -> SelectionOf TxOut
+        -> Either PreSelection (SelectionOf TxOut)
             -- A balanced coin selection where all change addresses have been
             -- assigned.
         -> Either ErrMkTransaction tx

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -397,21 +397,16 @@ data TransactionCtx = TransactionCtx
 -- | Represents a unbalanced selection.
 --
 data PreSelection = PreSelection
-    { outputs
-        :: ![TxOut]
-        -- ^ User-specified outputs
-    , assetsToMint
-        :: !TokenMap
-        -- ^ Assets to mint.
-    , assetsToBurn
-        :: !TokenMap
-        -- ^ Assets to burn.
-    , extraCoinSource
-        :: !Coin
-        -- ^ An extra source of ada.
-    , extraCoinSink
-        :: !Coin
-        -- ^ An extra sink for ada.
+    { outputs :: ![TxOut]
+      -- ^ User-specified outputs
+    , assetsToMint :: !TokenMap
+      -- ^ Assets to mint.
+    , assetsToBurn :: !TokenMap
+      -- ^ Assets to burn.
+    , extraCoinSource :: !Coin
+      -- ^ An extra source of ada.
+    , extraCoinSink :: !Coin
+      -- ^ An extra sink for ada.
     }
     deriving (Generic, Eq, Show)
 

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -25,6 +25,7 @@ module Cardano.Wallet.Transaction
       TransactionLayer (..)
     , DelegationAction (..)
     , TransactionCtx (..)
+    , PreSelection (..)
     , defaultTransactionCtx
     , Withdrawal (..)
     , withdrawalToCoin
@@ -68,8 +69,7 @@ import Cardano.Ledger.Crypto
 import Cardano.Pool.Types
     ( PoolId )
 import Cardano.Wallet.CoinSelection
-    ( PreSelection
-    , SelectionCollateralRequirement (..)
+    ( SelectionCollateralRequirement (..)
     , SelectionLimit
     , SelectionOf (..)
     , SelectionSkeleton
@@ -393,6 +393,27 @@ data TransactionCtx = TransactionCtx
     -- cardano-wallet types, which makes it useful to account for them like
     -- this. For instance: datums.
     } deriving (Show, Generic, Eq)
+
+-- | Represents a unbalanced selection.
+--
+data PreSelection = PreSelection
+    { outputs
+        :: ![TxOut]
+        -- ^ User-specified outputs
+    , assetsToMint
+        :: !TokenMap
+        -- ^ Assets to mint.
+    , assetsToBurn
+        :: !TokenMap
+        -- ^ Assets to burn.
+    , extraCoinSource
+        :: !Coin
+        -- ^ An extra source of ada.
+    , extraCoinSink
+        :: !Coin
+        -- ^ An extra sink for ada.
+    }
+    deriving (Generic, Eq, Show)
 
 data Withdrawal
     = WithdrawalSelf RewardAccount (NonEmpty DerivationIndex) Coin

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- |
@@ -36,6 +37,7 @@ module Cardano.Wallet.Write.Tx
     , shelleyBasedEraFromRecentEra
 
     -- ** Existential wrapper
+    , AnyRecentEra (..)
     , InAnyRecentEra (..)
     , asAnyRecentEra
     , withRecentEra
@@ -212,6 +214,9 @@ data RecentEra era where
     RecentEraBabbage :: RecentEra BabbageEra
     RecentEraAlonzo :: RecentEra AlonzoEra
 
+deriving instance Eq (RecentEra era)
+deriving instance Show (RecentEra era)
+
 class Cardano.IsShelleyBasedEra era => IsRecentEra era where
     recentEra :: RecentEra era
 
@@ -276,6 +281,15 @@ asAnyRecentEra = \case
     Cardano.InAnyCardanoEra Cardano.AlonzoEra a ->
         Just $ InAnyRecentEra RecentEraAlonzo a
     _ -> Nothing
+
+-- | An existential type like 'AnyCardanoEra', but for 'RecentEra'.
+data AnyRecentEra where
+     AnyRecentEra :: IsRecentEra era -- Provide class constraint
+                  => RecentEra era   -- and explicit value.
+                  -> AnyRecentEra    -- and that's it.
+
+instance Show AnyRecentEra where
+    show (AnyRecentEra era) = "AnyRecentEra " <> show era
 
 --------------------------------------------------------------------------------
 -- TxIn

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1823,7 +1823,7 @@ binaryCalculationsSpec' era = describe ("calculateBinary - "+||era||+"") $ do
           addrWits = zipWith (mkByronWitness' unsigned) inps pairs
           fee = toCardanoLovelace $ selectionDelta TxOut.coin cs
           Right unsigned =
-              mkUnsignedTx era (Nothing, slotNo) cs md mempty [] fee
+              mkUnsignedTx era (Nothing, slotNo) (Right cs) md mempty [] fee
               TokenMap.empty TokenMap.empty Map.empty Map.empty
           cs = Selection
             { inputs = NE.fromList inps
@@ -1912,7 +1912,7 @@ makeShelleyTx era testCase = Cardano.makeSignedTransaction addrWits unsigned
     inps = Map.toList $ unUTxO utxo
     fee = toCardanoLovelace $ selectionDelta TxOut.coin cs
     Right unsigned =
-        mkUnsignedTx era (Nothing, slotNo) cs md mempty [] fee
+        mkUnsignedTx era (Nothing, slotNo) (Right cs) md mempty [] fee
         TokenMap.empty TokenMap.empty Map.empty Map.empty
     addrWits = map (mkShelleyWitness unsigned) pairs
     cs = Selection
@@ -1955,7 +1955,7 @@ makeByronTx era testCase = Cardano.makeSignedTransaction byronWits unsigned
     inps = Map.toList $ unUTxO utxo
     fee = toCardanoLovelace $ selectionDelta TxOut.coin cs
     Right unsigned =
-        mkUnsignedTx era (Nothing, slotNo) cs Nothing mempty [] fee
+        mkUnsignedTx era (Nothing, slotNo) (Right cs) Nothing mempty [] fee
         TokenMap.empty TokenMap.empty Map.empty Map.empty
     -- byronWits = map (mkByronWitness unsigned ntwrk Nothing) pairs
     byronWits = map (error "makeByronTx: broken") pairs  -- TODO: [ADP-919]


### PR DESCRIPTION
<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->


- [x] Added PreSelection along side SelectionOf
- [x] Enabled mkUnsignedTx to use either PreSelection or SelectionOf
- [x] constructTransaction produces "no-inputs/no-fee" sealed tx using mkUnsignedTx
- [x] constructTransaction uses balanceTransaction to add inputs and fees
- [x] coin selection and fee are retrieved from decodeTransaction
- [x] checking all integration tests
- [x] adding dummyTxIn as node does not allow producing no-inputs txs at the moment  

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number
adp-2257

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
