### PR TITLE
fix publish doc workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,11 +43,16 @@ jobs:
             tag=""
             commit_message="$default_commit_message"
           fi
-          echo "commit_message=$commit_message" >> $GITHUB_OUTPUT
+          # commit message can be multiline
+          echo 'commit_message<<EOF' >> $GITHUB_OUTPUT
+          echo $commit_message >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
           echo "tag=$tag" >> $GITHUB_OUTPUT
         env:
           default_commit_message: |
-            docs: ${{ github.event.head_commit.message }} Source commit: ${{ github.sha }}
+            docs: ${{ github.event.head_commit.message }}
+
+            Source commit: ${{ github.sha }}
 
       - name: '❄ Install dependencies'
         run: 'nix develop .#docs --command emanote --version'


### PR DESCRIPTION
- [x] fix publish doc workflow

### Comments

In previous PR I have changed e2e test GH workflows and docs publish workflow to use `$GITHUB_OUTPUT` instead of `set-output` (as the latter will be [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)). It seems that doc publish workflow may produce a multiline `$commit_message` which needs to be handled in `$GITHUB_OUTPUT` differently. Trying to fix.

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
