### PR TITLE
Move JSON encodings for transaction types into HTTP API layer.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -328,6 +328,8 @@ import Cardano.Wallet.Api.Types.MintBurn
     ( noApiAsset )
 import Cardano.Wallet.Api.Types.SchemaMetadata
     ( TxMetadataSchema (..), TxMetadataWithSchema (TxMetadataWithSchema) )
+import Cardano.Wallet.Api.Types.Transaction
+    ( ApiWitnessCount (..) )
 import Cardano.Wallet.CoinSelection
     ( SelectionOf (..), SelectionStrategy (..), selectionDelta )
 import Cardano.Wallet.Compat
@@ -2716,7 +2718,7 @@ decodeSharedTransaction ctx (ApiT wid) (ApiSerialisedTransaction (ApiT sealed) _
         , metadata = ApiTxMetadata $ ApiT <$> metadata
         , scriptValidity = ApiT <$> scriptValidity
         , validityInterval = interval
-        , witnessCount = witsCount
+        , witnessCount = ApiWitnessCount witsCount
         }
   where
     tl = ctx ^. W.transactionLayer @k @'CredFromScriptK
@@ -2891,7 +2893,7 @@ decodeTransaction ctx (ApiT wid) (ApiSerialisedTransaction (ApiT sealed) _) = do
             , metadata = ApiTxMetadata $ ApiT <$> metadata
             , scriptValidity = ApiT <$> scriptValidity
             , validityInterval = interval
-            , witnessCount = witsCount
+            , witnessCount = ApiWitnessCount witsCount
             }
   where
     tl = ctx ^. W.transactionLayer @k @'CredFromKeyK

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -329,7 +329,7 @@ import Cardano.Wallet.Api.Types.MintBurn
 import Cardano.Wallet.Api.Types.SchemaMetadata
     ( TxMetadataSchema (..), TxMetadataWithSchema (TxMetadataWithSchema) )
 import Cardano.Wallet.Api.Types.Transaction
-    ( ApiValidityIntervalExplicit (..), ApiWitnessCount (..) )
+    ( ApiValidityIntervalExplicit (..), mkApiWitnessCount )
 import Cardano.Wallet.CoinSelection
     ( SelectionOf (..), SelectionStrategy (..), selectionDelta )
 import Cardano.Wallet.Compat
@@ -2718,7 +2718,7 @@ decodeSharedTransaction ctx (ApiT wid) (ApiSerialisedTransaction (ApiT sealed) _
         , metadata = ApiTxMetadata $ ApiT <$> metadata
         , scriptValidity = ApiT <$> scriptValidity
         , validityInterval = ApiValidityIntervalExplicit <$> interval
-        , witnessCount = ApiWitnessCount witsCount
+        , witnessCount = mkApiWitnessCount witsCount
         }
   where
     tl = ctx ^. W.transactionLayer @k @'CredFromScriptK
@@ -2893,7 +2893,7 @@ decodeTransaction ctx (ApiT wid) (ApiSerialisedTransaction (ApiT sealed) _) = do
             , metadata = ApiTxMetadata $ ApiT <$> metadata
             , scriptValidity = ApiT <$> scriptValidity
             , validityInterval = ApiValidityIntervalExplicit <$> interval
-            , witnessCount = ApiWitnessCount witsCount
+            , witnessCount = mkApiWitnessCount witsCount
             }
   where
     tl = ctx ^. W.transactionLayer @k @'CredFromKeyK

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -327,6 +327,7 @@ import Cardano.Wallet.Api.Types.Transaction
     , ApiTxMetadata (..)
     , ApiTxOutput
     , ApiTxOutputGeneral (..)
+    , ApiValidityIntervalExplicit (..)
     , ApiWalletInput (..)
     , ApiWalletOutput (..)
     , ApiWithdrawal (..)
@@ -389,8 +390,6 @@ import Cardano.Wallet.Shelley.Pools
     ( EpochInfo, StakePool (..), StakePoolFlag, StakePoolMetrics )
 import Cardano.Wallet.TokenMetadata
     ( TokenMetadataError (..) )
-import Cardano.Wallet.Transaction
-    ( ValidityIntervalExplicit )
 import Cardano.Wallet.Util
     ( ShowFmt (..) )
 import "cardano-addresses" Codec.Binary.Encoding
@@ -1298,7 +1297,7 @@ data ApiTransaction (n :: NetworkDiscriminant) = ApiTransaction
     , certificates :: [ApiAnyCertificate n]
     , mint :: ApiAssetMintBurn
     , burn :: ApiAssetMintBurn
-    , validityInterval :: Maybe ValidityIntervalExplicit
+    , validityInterval :: Maybe ApiValidityIntervalExplicit
     , scriptIntegrity :: Maybe (ApiT (Hash "ScriptIntegrity"))
     , extraSignatures :: [ApiT (Hash "ExtraSignature")]
     }

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Transaction.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Transaction.hs
@@ -20,6 +20,7 @@ module Cardano.Wallet.Api.Types.Transaction
     , ApiTxMetadata (..)
     , ApiTxOutput
     , ApiTxOutputGeneral (..)
+    , ApiValidityIntervalExplicit (..)
     , ApiWalletInput (..)
     , ApiWalletOutput (..)
     , ApiWithdrawal (..)
@@ -128,11 +129,17 @@ data ApiDecodedTransaction (n :: NetworkDiscriminant) = ApiDecodedTransaction
     , depositsReturned :: [Quantity "lovelace" Natural]
     , metadata :: ApiTxMetadata
     , scriptValidity :: Maybe (ApiT TxScriptValidity)
-    , validityInterval :: Maybe ValidityIntervalExplicit
+    , validityInterval :: Maybe ApiValidityIntervalExplicit
     , witnessCount :: ApiWitnessCount
     }
     deriving (Eq, Generic, Show, Typeable)
     deriving (FromJSON, ToJSON) via DefaultRecord (ApiDecodedTransaction n)
+    deriving anyclass NFData
+
+newtype ApiValidityIntervalExplicit =
+    ApiValidityIntervalExplicit ValidityIntervalExplicit
+    deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord ValidityIntervalExplicit
     deriving anyclass NFData
 
 data ApiWalletInput (n :: NetworkDiscriminant) = ApiWalletInput

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Transaction.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Transaction.hs
@@ -24,6 +24,7 @@ module Cardano.Wallet.Api.Types.Transaction
     , ApiWalletOutput (..)
     , ApiWithdrawal (..)
     , ApiWithdrawalGeneral (..)
+    , ApiWitnessCount (..)
     , ResourceContext (..)
     )
     where
@@ -128,7 +129,7 @@ data ApiDecodedTransaction (n :: NetworkDiscriminant) = ApiDecodedTransaction
     , metadata :: ApiTxMetadata
     , scriptValidity :: Maybe (ApiT TxScriptValidity)
     , validityInterval :: Maybe ValidityIntervalExplicit
-    , witnessCount :: WitnessCount
+    , witnessCount :: ApiWitnessCount
     }
     deriving (Eq, Generic, Show, Typeable)
     deriving (FromJSON, ToJSON) via DefaultRecord (ApiDecodedTransaction n)
@@ -144,6 +145,11 @@ data ApiWalletInput (n :: NetworkDiscriminant) = ApiWalletInput
     }
     deriving (Eq, Generic, Show, Typeable)
     deriving (FromJSON, ToJSON) via DefaultRecord (ApiWalletInput n)
+    deriving anyclass NFData
+
+newtype ApiWitnessCount = ApiWitnessCount WitnessCount
+    deriving (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via DefaultRecord WitnessCount
     deriving anyclass NFData
 
 data ApiTxInputGeneral (n :: NetworkDiscriminant) =

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -43,7 +44,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Api.Types.Transaction
-    ( ApiWitnessCount (..) )
+    ( mkApiWitnessCount )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DerivationIndex (..), Index (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.SharedKey
@@ -559,7 +560,7 @@ spec = describe "SHARED_TRANSACTIONS" $ do
                 NativeScript $ changeRole CA.Policy $
                 replaceCosignersWithVerKeys CA.UTxOExternal scriptTemplate (Index 1)
 
-        let noVerKeyWitness = ApiWitnessCount WitnessCount
+        let noVerKeyWitness = mkApiWitnessCount WitnessCount
                 { verificationKey = 0
                 , scripts = [paymentScript]
                 , bootstrap = 0
@@ -590,7 +591,7 @@ spec = describe "SHARED_TRANSACTIONS" $ do
         rDecodedTx2Target <- request @(ApiDecodedTransaction n) ctx
             (Link.decodeTransaction @'Shelley wb) Default decodePayload2
 
-        let oneVerKeyWitness = ApiWitnessCount WitnessCount
+        let oneVerKeyWitness = mkApiWitnessCount WitnessCount
                 { verificationKey = 1
                 , scripts = [paymentScript]
                 , bootstrap = 0
@@ -707,7 +708,7 @@ spec = describe "SHARED_TRANSACTIONS" $ do
                 -- TODO- ADP-2312 We will want CA.Payment here
                 NativeScript $ changeRole CA.Policy $
                 replaceCosignersWithVerKeys CA.UTxOExternal scriptTemplate (Index 1)
-        let noVerKeyWitness = ApiWitnessCount WitnessCount
+        let noVerKeyWitness = mkApiWitnessCount WitnessCount
                 { verificationKey = 0
                 , scripts = [paymentScript]
                 , bootstrap = 0
@@ -734,7 +735,7 @@ spec = describe "SHARED_TRANSACTIONS" $ do
         rDecodedTx2Target <- request @(ApiDecodedTransaction n) ctx
             (Link.decodeTransaction @'Shelley wb) Default decodePayload2
 
-        let oneVerKeyWitness = ApiWitnessCount WitnessCount
+        let oneVerKeyWitness = mkApiWitnessCount WitnessCount
                 { verificationKey = 1
                 , scripts = [paymentScript]
                 , bootstrap = 0

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
@@ -42,6 +42,8 @@ import Cardano.Wallet.Api.Types
     , EncodeAddress (..)
     , WalletStyle (..)
     )
+import Cardano.Wallet.Api.Types.Transaction
+    ( ApiWitnessCount (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DerivationIndex (..), Index (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.SharedKey
@@ -557,7 +559,7 @@ spec = describe "SHARED_TRANSACTIONS" $ do
                 NativeScript $ changeRole CA.Policy $
                 replaceCosignersWithVerKeys CA.UTxOExternal scriptTemplate (Index 1)
 
-        let noVerKeyWitness = WitnessCount
+        let noVerKeyWitness = ApiWitnessCount WitnessCount
                 { verificationKey = 0
                 , scripts = [paymentScript]
                 , bootstrap = 0
@@ -588,7 +590,7 @@ spec = describe "SHARED_TRANSACTIONS" $ do
         rDecodedTx2Target <- request @(ApiDecodedTransaction n) ctx
             (Link.decodeTransaction @'Shelley wb) Default decodePayload2
 
-        let oneVerKeyWitness = WitnessCount
+        let oneVerKeyWitness = ApiWitnessCount WitnessCount
                 { verificationKey = 1
                 , scripts = [paymentScript]
                 , bootstrap = 0
@@ -705,7 +707,7 @@ spec = describe "SHARED_TRANSACTIONS" $ do
                 -- TODO- ADP-2312 We will want CA.Payment here
                 NativeScript $ changeRole CA.Policy $
                 replaceCosignersWithVerKeys CA.UTxOExternal scriptTemplate (Index 1)
-        let noVerKeyWitness = WitnessCount
+        let noVerKeyWitness = ApiWitnessCount WitnessCount
                 { verificationKey = 0
                 , scripts = [paymentScript]
                 , bootstrap = 0
@@ -732,7 +734,7 @@ spec = describe "SHARED_TRANSACTIONS" $ do
         rDecodedTx2Target <- request @(ApiDecodedTransaction n) ctx
             (Link.decodeTransaction @'Shelley wb) Default decodePayload2
 
-        let oneVerKeyWitness = WitnessCount
+        let oneVerKeyWitness = ApiWitnessCount WitnessCount
                 { verificationKey = 1
                 , scripts = [paymentScript]
                 , bootstrap = 0

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -71,6 +71,8 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     , fromApiEra
     )
+import Cardano.Wallet.Api.Types.Transaction
+    ( ApiValidityIntervalExplicit (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DerivationIndex (..)
     , HardDerivation (..)
@@ -1189,7 +1191,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             ]
 
         let (SlotNo toSlot) = sl
-        let validityInterval =
+        let validityInterval = ApiValidityIntervalExplicit $
                 ValidityIntervalExplicit (Quantity 0) (Quantity $ toSlot + 10)
 
         let apiTx'@(ApiSerialisedTransaction apiTx _)=

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -114,9 +114,6 @@ import Data.Aeson.Types
     , Parser
     , ToJSON (..)
     , Value (..)
-    , camelTo2
-    , genericParseJSON
-    , genericToJSON
     , object
     , withObject
     , (.:)
@@ -145,7 +142,6 @@ import GHC.Generics
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Data.Aeson.Types as Aeson
 import qualified Data.Map.Strict as Map
 
 data TransactionLayer k ktype tx = TransactionLayer
@@ -608,14 +604,3 @@ data ValidityIntervalExplicit = ValidityIntervalExplicit
     }
     deriving (Generic, Eq, Show)
     deriving anyclass NFData
-
-instance ToJSON ValidityIntervalExplicit where
-    toJSON = genericToJSON defaultRecordTypeOptions
-instance FromJSON ValidityIntervalExplicit where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-
-defaultRecordTypeOptions :: Aeson.Options
-defaultRecordTypeOptions = Aeson.defaultOptions
-    { Aeson.fieldLabelModifier = camelTo2 '_' . dropWhile (== '_')
-    , Aeson.omitNothingFields = True
-    }

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -522,11 +522,6 @@ data WitnessCount = WitnessCount
     deriving (Eq, Generic, Show)
     deriving anyclass NFData
 
-instance ToJSON WitnessCount where
-    toJSON = genericToJSON defaultRecordTypeOptions
-instance FromJSON WitnessCount where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-
 emptyWitnessCount :: WitnessCount
 emptyWitnessCount = WitnessCount
     { verificationKey = 0

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -110,16 +110,7 @@ import Control.DeepSeq
 import Control.Monad
     ( (>=>) )
 import Data.Aeson.Types
-    ( FromJSON (..)
-    , Parser
-    , ToJSON (..)
-    , Value (..)
-    , object
-    , withObject
-    , (.:)
-    , (.:?)
-    , (.=)
-    )
+    ( FromJSON (..), Parser, ToJSON (..) )
 import Data.Bifunctor
     ( bimap )
 import Data.List.NonEmpty
@@ -474,24 +465,6 @@ instance FromJSON PlutusScriptInfo where
           eitherToParser = either (fail . show) pure
 instance ToJSON PlutusScriptInfo where
     toJSON (PlutusScriptInfo v) = toJSON $ toText v
-
-instance FromJSON AnyScript where
-    parseJSON = withObject "AnyScript" $ \obj -> do
-        scriptType <- obj .:? "script_type"
-        case (scriptType :: Maybe String) of
-            Just t | t == "plutus"  ->
-                PlutusScript <$> obj .: "language_version"
-            Just t | t == "native" ->
-                NativeScript <$> obj .: "script"
-            _ -> fail "AnyScript needs either 'native' or 'plutus' in 'script_type'"
-
-instance ToJSON AnyScript where
-    toJSON (NativeScript s) =
-        object [ "script_type" .= String "native"
-               , "script" .= toJSON s]
-    toJSON (PlutusScript v) =
-        object [ "script_type" .= String "plutus"
-               , "language_version" .= toJSON v]
 
 data AnyScript =
       NativeScript !(Script KeyHash)

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -103,16 +103,8 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TokenBundleSizeAssessor, TxConstraints, TxSize )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
     ( Tx (..), TxIn, TxMetadata, TxOut )
-import Cardano.Wallet.Util
-    ( ShowFmt (..) )
 import Control.DeepSeq
     ( NFData (..) )
-import Control.Monad
-    ( (>=>) )
-import Data.Aeson.Types
-    ( FromJSON (..), Parser, ToJSON (..) )
-import Data.Bifunctor
-    ( bimap )
 import Data.List.NonEmpty
     ( NonEmpty )
 import Data.Map.Strict
@@ -456,15 +448,6 @@ newtype PlutusScriptInfo = PlutusScriptInfo
     }
     deriving (Eq, Generic, Show)
     deriving anyclass NFData
-
-instance FromJSON PlutusScriptInfo where
-    parseJSON = parseJSON >=>
-        eitherToParser . bimap ShowFmt PlutusScriptInfo . fromText
-      where
-          eitherToParser :: Show s => Either s a -> Parser a
-          eitherToParser = either (fail . show) pure
-instance ToJSON PlutusScriptInfo where
-    toJSON (PlutusScriptInfo v) = toJSON $ toText v
 
 data AnyScript =
       NativeScript !(Script KeyHash)

--- a/lib/wallet/test/data/Cardano/Wallet/Api/ApiValidityIntervalExplicit.json
+++ b/lib/wallet/test/data/Cardano/Wallet/Api/ApiValidityIntervalExplicit.json
@@ -1,0 +1,105 @@
+{
+    "samples": [
+        {
+            "invalid_before": {
+                "quantity": 8328533,
+                "unit": "slot"
+            },
+            "invalid_hereafter": {
+                "quantity": 15546827,
+                "unit": "slot"
+            }
+        },
+        {
+            "invalid_before": {
+                "quantity": 8944094,
+                "unit": "slot"
+            },
+            "invalid_hereafter": {
+                "quantity": 12734814,
+                "unit": "slot"
+            }
+        },
+        {
+            "invalid_before": {
+                "quantity": 11535733,
+                "unit": "slot"
+            },
+            "invalid_hereafter": {
+                "quantity": 25179749,
+                "unit": "slot"
+            }
+        },
+        {
+            "invalid_before": {
+                "quantity": 4257968,
+                "unit": "slot"
+            },
+            "invalid_hereafter": {
+                "quantity": 11273778,
+                "unit": "slot"
+            }
+        },
+        {
+            "invalid_before": {
+                "quantity": 11760089,
+                "unit": "slot"
+            },
+            "invalid_hereafter": {
+                "quantity": 12018703,
+                "unit": "slot"
+            }
+        },
+        {
+            "invalid_before": {
+                "quantity": 13792537,
+                "unit": "slot"
+            },
+            "invalid_hereafter": {
+                "quantity": 32662326,
+                "unit": "slot"
+            }
+        },
+        {
+            "invalid_before": {
+                "quantity": 7589595,
+                "unit": "slot"
+            },
+            "invalid_hereafter": {
+                "quantity": 10901636,
+                "unit": "slot"
+            }
+        },
+        {
+            "invalid_before": {
+                "quantity": 8554150,
+                "unit": "slot"
+            },
+            "invalid_hereafter": {
+                "quantity": 9626434,
+                "unit": "slot"
+            }
+        },
+        {
+            "invalid_before": {
+                "quantity": 2286146,
+                "unit": "slot"
+            },
+            "invalid_hereafter": {
+                "quantity": 9549221,
+                "unit": "slot"
+            }
+        },
+        {
+            "invalid_before": {
+                "quantity": 2703648,
+                "unit": "slot"
+            },
+            "invalid_hereafter": {
+                "quantity": 21534705,
+                "unit": "slot"
+            }
+        }
+    ],
+    "seed": -994754440
+}

--- a/lib/wallet/test/data/Cardano/Wallet/Api/ApiWitnessCount.json
+++ b/lib/wallet/test/data/Cardano/Wallet/Api/ApiWitnessCount.json
@@ -1,0 +1,820 @@
+{
+    "samples": [
+        {
+            "bootstrap": 0,
+            "scripts": [
+                {
+                    "script": {
+                        "any": [
+                            {
+                                "any": [
+                                    {
+                                        "active_until": 1
+                                    },
+                                    {
+                                        "active_until": 5
+                                    },
+                                    "stake_shared_vkh1fs5d6q9j0eg83xkuy0ea7dl5u3nzs2p86v7nhfcs8uvczql3zds",
+                                    "addr_shared_vkh1hww8fnwdg0f3zu2d0yt9uqst0u6gw4ajn8nkmfyhtyl4x2nykdp",
+                                    {
+                                        "active_until": 4
+                                    }
+                                ]
+                            },
+                            {
+                                "any": [
+                                    {
+                                        "active_until": 1
+                                    },
+                                    {
+                                        "active_until": 4
+                                    },
+                                    {
+                                        "active_from": 6
+                                    },
+                                    {
+                                        "active_from": 5
+                                    },
+                                    {
+                                        "active_until": 8
+                                    }
+                                ]
+                            },
+                            {
+                                "some": {
+                                    "at_least": 7,
+                                    "from": [
+                                        "addr_shared_vkh1hww8fnwdg0f3zu2d0yt9uqst0u6gw4ajn8nkmfyhtyl4x2nykdp",
+                                        {
+                                            "active_until": 1
+                                        },
+                                        {
+                                            "active_until": 1
+                                        },
+                                        "stake_shared_vkh1j02yf0nrkwh3u69tzveur78643t356r30ctt8azfw3ydqd2uzvp",
+                                        {
+                                            "active_until": 2
+                                        },
+                                        {
+                                            "active_from": 9
+                                        },
+                                        {
+                                            "active_until": 1
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "any": [
+                                    "addr_shared_vkh1ngv0xp6wj7za5alqc4u34krk5c86tuzu5wrz7gpj2zu4zj07kls",
+                                    "stake_shared_vkh1j02yf0nrkwh3u69tzveur78643t356r30ctt8azfw3ydqd2uzvp",
+                                    {
+                                        "active_from": 9
+                                    },
+                                    "addr_shared_vkh1380yp0lep8dwgv2juyn7ndz3ep4mc77vdgss0rqkt094uwe3n6y",
+                                    {
+                                        "active_until": 6
+                                    },
+                                    "addr_shared_vkh1ngv0xp6wj7za5alqc4u34krk5c86tuzu5wrz7gpj2zu4zj07kls",
+                                    {
+                                        "active_from": 10
+                                    },
+                                    {
+                                        "active_until": 1
+                                    },
+                                    "stake_shared_vkh1j02yf0nrkwh3u69tzveur78643t356r30ctt8azfw3ydqd2uzvp"
+                                ]
+                            },
+                            {
+                                "any": [
+                                    {
+                                        "active_until": 9
+                                    },
+                                    "addr_shared_vkh1dlxtek8evmv9u8u7e8mgs45nkp2uy639mpp5xkp5pcr67ryjtlu",
+                                    {
+                                        "active_from": 1
+                                    },
+                                    "addr_shared_vkh1c5gxkep9ke7e9p62razpsa788jua9gw9656s2g342vhhyuvegl6",
+                                    {
+                                        "active_from": 9
+                                    }
+                                ]
+                            },
+                            {
+                                "any": [
+                                    {
+                                        "active_from": 8
+                                    },
+                                    "addr_shared_vkh17ml4g84lcv8fr72krmhs8uqaktz4akat6crvf5kh0thcs04k595",
+                                    {
+                                        "active_until": 5
+                                    },
+                                    {
+                                        "active_until": 7
+                                    },
+                                    "addr_shared_vkh1ngv0xp6wj7za5alqc4u34krk5c86tuzu5wrz7gpj2zu4zj07kls",
+                                    {
+                                        "active_from": 3
+                                    },
+                                    {
+                                        "active_until": 4
+                                    }
+                                ]
+                            },
+                            {
+                                "all": [
+                                    {
+                                        "active_until": 4
+                                    },
+                                    "addr_shared_vkh1dlxtek8evmv9u8u7e8mgs45nkp2uy639mpp5xkp5pcr67ryjtlu",
+                                    "addr_shared_vkh1hww8fnwdg0f3zu2d0yt9uqst0u6gw4ajn8nkmfyhtyl4x2nykdp",
+                                    {
+                                        "active_from": 3
+                                    },
+                                    {
+                                        "active_from": 7
+                                    },
+                                    "addr_shared_vkh17ml4g84lcv8fr72krmhs8uqaktz4akat6crvf5kh0thcs04k595",
+                                    "addr_shared_vkh1kpw003p4vrj8tev7rhh8sdw8r3gsjufj30t6vgyeatv6gm82ypa"
+                                ]
+                            },
+                            {
+                                "any": [
+                                    {
+                                        "active_from": 2
+                                    },
+                                    {
+                                        "active_from": 9
+                                    },
+                                    {
+                                        "active_until": 1
+                                    },
+                                    "addr_shared_vkh1hww8fnwdg0f3zu2d0yt9uqst0u6gw4ajn8nkmfyhtyl4x2nykdp",
+                                    {
+                                        "active_until": 1
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "script_type": "native"
+                }
+            ],
+            "verification_key": 4
+        },
+        {
+            "bootstrap": 2,
+            "scripts": [
+                {
+                    "script": {
+                        "any": [
+                            {
+                                "all": [
+                                    {
+                                        "active_from": 9
+                                    },
+                                    {
+                                        "active_until": 2
+                                    },
+                                    "stake_shared_vkh1krt4mwcf0ptsgs7hxfud8yx9cz9ztwekr2qvk4zq453typtzcr2",
+                                    "addr_shared_vkh1c7ahyvyks5hrkrvaspt3z0gem3lmrdyrp4fygcz6rfr3ctgyzru",
+                                    {
+                                        "active_until": 6
+                                    },
+                                    {
+                                        "active_until": 4
+                                    }
+                                ]
+                            },
+                            {
+                                "some": {
+                                    "at_least": 5,
+                                    "from": [
+                                        {
+                                            "active_from": 4
+                                        },
+                                        {
+                                            "active_until": 3
+                                        },
+                                        {
+                                            "active_from": 3
+                                        },
+                                        {
+                                            "active_until": 3
+                                        },
+                                        {
+                                            "active_until": 5
+                                        },
+                                        "addr_shared_vkh1l53038l866m709xfz3dhd4cc476gg3nj06k78t5vdcg62ut9spc",
+                                        {
+                                            "active_until": 6
+                                        },
+                                        {
+                                            "active_from": 9
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "some": {
+                                    "at_least": 1,
+                                    "from": [
+                                        {
+                                            "active_until": 4
+                                        },
+                                        {
+                                            "active_until": 7
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "any": [
+                                    {
+                                        "active_from": 7
+                                    },
+                                    "stake_shared_vkh1dgygnhhwpe262sw333nzuz8dmk3efjdcg4ugrlhlpjtz5pj7cax",
+                                    {
+                                        "active_from": 2
+                                    },
+                                    {
+                                        "active_from": 4
+                                    },
+                                    {
+                                        "active_until": 1
+                                    },
+                                    {
+                                        "active_until": 5
+                                    },
+                                    "stake_shared_vkh1dgygnhhwpe262sw333nzuz8dmk3efjdcg4ugrlhlpjtz5pj7cax",
+                                    {
+                                        "active_until": 2
+                                    },
+                                    {
+                                        "active_from": 1
+                                    },
+                                    {
+                                        "active_from": 7
+                                    }
+                                ]
+                            },
+                            {
+                                "any": [
+                                    "stake_shared_vkh1s95uefg4s27yq5uq45yluymwh6kr8y4zrqq2f5catsc6svypclj",
+                                    "addr_shared_vkh1c7ahyvyks5hrkrvaspt3z0gem3lmrdyrp4fygcz6rfr3ctgyzru",
+                                    {
+                                        "active_from": 0
+                                    },
+                                    "stake_shared_vkh1wl3e0levtvwz6g7xashlrs4w34df8s8gxr3vdc6qazphzcdml7q",
+                                    {
+                                        "active_until": 3
+                                    },
+                                    "addr_shared_vkh1dmu8ghrccw469s3hyasue28nhsutks0j3rt06rqsfs2ms28ltxw",
+                                    {
+                                        "active_until": 8
+                                    },
+                                    {
+                                        "active_until": 5
+                                    },
+                                    {
+                                        "active_until": 8
+                                    }
+                                ]
+                            },
+                            {
+                                "all": [
+                                    {
+                                        "active_until": 3
+                                    },
+                                    {
+                                        "active_from": 3
+                                    },
+                                    {
+                                        "active_until": 7
+                                    },
+                                    "addr_shared_vkh1dmu8ghrccw469s3hyasue28nhsutks0j3rt06rqsfs2ms28ltxw",
+                                    {
+                                        "active_from": 2
+                                    }
+                                ]
+                            },
+                            {
+                                "some": {
+                                    "at_least": 1,
+                                    "from": [
+                                        {
+                                            "active_until": 5
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "script_type": "native"
+                }
+            ],
+            "verification_key": 1
+        },
+        {
+            "bootstrap": 0,
+            "scripts": [],
+            "verification_key": 0
+        },
+        {
+            "bootstrap": 2,
+            "scripts": [
+                {
+                    "script": {
+                        "some": {
+                            "at_least": 5,
+                            "from": [
+                                {
+                                    "all": [
+                                        {
+                                            "active_until": 4
+                                        },
+                                        {
+                                            "active_until": 6
+                                        }
+                                    ]
+                                },
+                                {
+                                    "all": [
+                                        {
+                                            "active_until": 10
+                                        },
+                                        {
+                                            "active_until": 1
+                                        },
+                                        {
+                                            "active_until": 9
+                                        },
+                                        {
+                                            "active_from": 3
+                                        }
+                                    ]
+                                },
+                                {
+                                    "all": [
+                                        {
+                                            "active_until": 6
+                                        },
+                                        "addr_shared_vkh1nru8kkp8vjlwxlz8rlhff46h4kmze70kmvx05adcmq8lctde5rj",
+                                        "addr_shared_vkh1k0j6xexh8sr49axpemk40yj7t6hmyfmhlt05l9glcznpuesk0s5",
+                                        {
+                                            "active_from": 1
+                                        },
+                                        "stake_shared_vkh1nmzml0wlmm0zrsc75uqe7zyua6nmfzeacn38x6kvsym9qwcmjm3",
+                                        {
+                                            "active_until": 7
+                                        }
+                                    ]
+                                },
+                                {
+                                    "any": [
+                                        {
+                                            "active_from": 7
+                                        }
+                                    ]
+                                },
+                                {
+                                    "all": [
+                                        {
+                                            "active_until": 5
+                                        },
+                                        {
+                                            "active_until": 4
+                                        },
+                                        {
+                                            "active_until": 0
+                                        },
+                                        {
+                                            "active_until": 6
+                                        },
+                                        "addr_shared_vkh1k0j6xexh8sr49axpemk40yj7t6hmyfmhlt05l9glcznpuesk0s5",
+                                        {
+                                            "active_until": 9
+                                        },
+                                        {
+                                            "active_until": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "some": {
+                                        "at_least": 2,
+                                        "from": [
+                                            {
+                                                "active_until": 3
+                                            },
+                                            {
+                                                "active_until": 9
+                                            },
+                                            {
+                                                "active_until": 7
+                                            },
+                                            {
+                                                "active_from": 3
+                                            },
+                                            {
+                                                "active_until": 5
+                                            },
+                                            {
+                                                "active_until": 5
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "all": [
+                                        {
+                                            "active_from": 1
+                                        },
+                                        {
+                                            "active_until": 2
+                                        },
+                                        "stake_shared_vkh1frm220mrf530lgq23ssncmp9szttnsx8pek7d3d9mfmwqef3cfg",
+                                        {
+                                            "active_until": 9
+                                        },
+                                        {
+                                            "active_from": 10
+                                        },
+                                        "addr_shared_vkh1hqdn6sldk9plr2292zwt8eap35j2qrqmj0pejkx0zdpk6h90aeg"
+                                    ]
+                                },
+                                {
+                                    "all": [
+                                        {
+                                            "active_until": 4
+                                        },
+                                        "addr_shared_vkh1a9kda6qnmq6jefzscvykjhv0gqzhpkw02xlzn7404rnq2zkl0tu",
+                                        "addr_shared_vkh1kh3yxwuh6mctn78eglhfaule7l9adajt7yg0yvmxne73qzvzev2"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "script_type": "native"
+                }
+            ],
+            "verification_key": 9
+        },
+        {
+            "bootstrap": 0,
+            "scripts": [
+                {
+                    "script": {
+                        "some": {
+                            "at_least": 3,
+                            "from": [
+                                {
+                                    "all": [
+                                        {
+                                            "active_from": 8
+                                        },
+                                        {
+                                            "active_until": 1
+                                        },
+                                        {
+                                            "active_until": 10
+                                        },
+                                        {
+                                            "active_until": 8
+                                        },
+                                        {
+                                            "active_from": 10
+                                        },
+                                        {
+                                            "active_from": 0
+                                        },
+                                        "stake_shared_vkh19wt885uecjq7m7kazs4uhxawf4a86uzrydz3saeur6vm55naasv",
+                                        {
+                                            "active_until": 1
+                                        },
+                                        {
+                                            "active_until": 7
+                                        },
+                                        "addr_shared_vkh1yk9vple9mn3qps7gssgfuw84qe9s84wtmjm5u82kgn6jqwp3y29"
+                                    ]
+                                },
+                                {
+                                    "all": [
+                                        "stake_shared_vkh1ajl5ufurkm8qmv0mzvasmg87jwr5gqs2xx4h73u9j6tkxnq780n"
+                                    ]
+                                },
+                                {
+                                    "some": {
+                                        "at_least": 6,
+                                        "from": [
+                                            {
+                                                "active_until": 5
+                                            },
+                                            "stake_shared_vkh1u3qgnypjugyhk3q586m6adnl3czc8x6z40htjavh6aaq67ph6uf",
+                                            "stake_shared_vkh1ajl5ufurkm8qmv0mzvasmg87jwr5gqs2xx4h73u9j6tkxnq780n",
+                                            "addr_shared_vkh1cl5r6vk3a60lc0wuqh3mevlxutqmsvfzdqxndsaxh639x6p5r0x",
+                                            {
+                                                "active_until": 0
+                                            },
+                                            {
+                                                "active_from": 0
+                                            },
+                                            "stake_shared_vkh1e2v0zf9ndrgzcx8rq7r7cwdjy00tnpgt9crcdrds430vkvy84dc"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "some": {
+                                        "at_least": 7,
+                                        "from": [
+                                            {
+                                                "active_from": 10
+                                            },
+                                            {
+                                                "active_until": 10
+                                            },
+                                            {
+                                                "active_until": 5
+                                            },
+                                            {
+                                                "active_from": 7
+                                            },
+                                            {
+                                                "active_from": 2
+                                            },
+                                            {
+                                                "active_until": 9
+                                            },
+                                            {
+                                                "active_from": 1
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "any": [
+                                        "stake_shared_vkh19wt885uecjq7m7kazs4uhxawf4a86uzrydz3saeur6vm55naasv",
+                                        {
+                                            "active_until": 6
+                                        }
+                                    ]
+                                },
+                                {
+                                    "some": {
+                                        "at_least": 2,
+                                        "from": [
+                                            "addr_shared_vkh1tu3944d7dvvfauxzxkr2cpm9wdh8tys3tlwnrs4qx0jyytza54w",
+                                            {
+                                                "active_from": 3
+                                            },
+                                            {
+                                                "active_until": 9
+                                            },
+                                            "stake_shared_vkh1e2v0zf9ndrgzcx8rq7r7cwdjy00tnpgt9crcdrds430vkvy84dc"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "any": [
+                                        {
+                                            "active_from": 10
+                                        },
+                                        {
+                                            "active_from": 10
+                                        },
+                                        {
+                                            "active_from": 4
+                                        },
+                                        "addr_shared_vkh1ngd0qm8wcdnqz2l85j6076dqs4xc3ttfgu9ta0jrmv0f2ut9wd0"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "script_type": "native"
+                }
+            ],
+            "verification_key": 4
+        },
+        {
+            "bootstrap": 0,
+            "scripts": [
+                {
+                    "script": {
+                        "all": [
+                            {
+                                "any": [
+                                    {
+                                        "active_until": 0
+                                    },
+                                    {
+                                        "active_until": 9
+                                    },
+                                    {
+                                        "active_until": 10
+                                    },
+                                    {
+                                        "active_from": 1
+                                    },
+                                    "addr_shared_vkh1r06qufml9umtmgc9xj4sut8q2j5m3hu37ugu7kd5620h6jxu4e0",
+                                    "addr_shared_vkh1wde9szssucfudnewh578we6j4yclccj58ywsn06s39f35txexvc",
+                                    "stake_shared_vkh179674u8l3j7whtgcnsnr6s424xu3j4v8awjfcqjz8zk67dx2kmc",
+                                    {
+                                        "active_from": 6
+                                    },
+                                    "stake_shared_vkh179674u8l3j7whtgcnsnr6s424xu3j4v8awjfcqjz8zk67dx2kmc"
+                                ]
+                            },
+                            {
+                                "all": [
+                                    {
+                                        "active_until": 6
+                                    },
+                                    {
+                                        "active_from": 1
+                                    },
+                                    {
+                                        "active_until": 10
+                                    },
+                                    "addr_shared_vkh1wde9szssucfudnewh578we6j4yclccj58ywsn06s39f35txexvc",
+                                    "stake_shared_vkh179674u8l3j7whtgcnsnr6s424xu3j4v8awjfcqjz8zk67dx2kmc",
+                                    {
+                                        "active_from": 5
+                                    },
+                                    "addr_shared_vkh1w2edsvxzvxlp3rygt3jpqxvgusjkdcpct8gujg9vzxm37at6ep0",
+                                    {
+                                        "active_until": 2
+                                    }
+                                ]
+                            },
+                            {
+                                "some": {
+                                    "at_least": 1,
+                                    "from": [
+                                        "addr_shared_vkh1r06qufml9umtmgc9xj4sut8q2j5m3hu37ugu7kd5620h6jxu4e0",
+                                        "stake_shared_vkh1u38c3c5jnxp2guhuss5xjupcnl8kyr3dcpjdlxwau84jz0t2zll",
+                                        "stake_shared_vkh1q47vpku2dw07xx7u0qaxyke7hz6xjeakx6y5ztj7xxds7uhlfyu"
+                                    ]
+                                }
+                            },
+                            {
+                                "some": {
+                                    "at_least": 2,
+                                    "from": [
+                                        "stake_shared_vkh1u38c3c5jnxp2guhuss5xjupcnl8kyr3dcpjdlxwau84jz0t2zll",
+                                        "stake_shared_vkh1a37cc56mzxt0ceh8949syfyulxmfrtf60scfvnq2fhhn6qdp06f",
+                                        "addr_shared_vkh1923zl6y6dsr379n9wf984wu608a0fwpu46lcrfgd38fl6mrwvdy",
+                                        {
+                                            "active_until": 7
+                                        },
+                                        {
+                                            "active_from": 5
+                                        },
+                                        {
+                                            "active_until": 7
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "all": [
+                                    {
+                                        "active_until": 7
+                                    },
+                                    "stake_shared_vkh1eznuwr7aqa6654e99fftjvlmavh2x5jfqjrflkccpv9zx06d8pa"
+                                ]
+                            },
+                            {
+                                "all": [
+                                    {
+                                        "active_from": 6
+                                    },
+                                    {
+                                        "active_from": 5
+                                    }
+                                ]
+                            },
+                            {
+                                "some": {
+                                    "at_least": 1,
+                                    "from": [
+                                        {
+                                            "active_from": 1
+                                        },
+                                        {
+                                            "active_until": 0
+                                        },
+                                        "addr_shared_vkh1923zl6y6dsr379n9wf984wu608a0fwpu46lcrfgd38fl6mrwvdy",
+                                        {
+                                            "active_from": 1
+                                        },
+                                        {
+                                            "active_from": 4
+                                        },
+                                        "addr_shared_vkh1r06qufml9umtmgc9xj4sut8q2j5m3hu37ugu7kd5620h6jxu4e0",
+                                        "addr_shared_vkh1wde9szssucfudnewh578we6j4yclccj58ywsn06s39f35txexvc",
+                                        {
+                                            "active_from": 5
+                                        },
+                                        "stake_shared_vkh1a37cc56mzxt0ceh8949syfyulxmfrtf60scfvnq2fhhn6qdp06f",
+                                        {
+                                            "active_until": 5
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "script_type": "native"
+                }
+            ],
+            "verification_key": 1
+        },
+        {
+            "bootstrap": 2,
+            "scripts": [],
+            "verification_key": 2
+        },
+        {
+            "bootstrap": 2,
+            "scripts": [],
+            "verification_key": 7
+        },
+        {
+            "bootstrap": 0,
+            "scripts": [
+                {
+                    "script": {
+                        "all": [
+                            {
+                                "some": {
+                                    "at_least": 2,
+                                    "from": [
+                                        {
+                                            "some": {
+                                                "at_least": 4,
+                                                "from": [
+                                                    {
+                                                        "active_until": 7
+                                                    },
+                                                    "stake_shared_vkh1j86guumjravnyw98jepkwhc65mtlsjxv5x52pxn588kskuzv4ud",
+                                                    "stake_shared_vkh10lsaslwa6u5wdfzm49zh3fns3ydkyr4gxqfz70f04qfyzg034z5",
+                                                    {
+                                                        "active_from": 7
+                                                    },
+                                                    "addr_shared_vkh1lwkrndwaa0v8735g22w7a9zr4j6dswygjfxdlwjuytje7znec2y"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "all": [
+                                                "stake_shared_vkh1x370ypzpz4j6exfaed3kc5vd72mkemmlqwjq0q34v44a22pkxzx",
+                                                {
+                                                    "active_from": 10
+                                                },
+                                                {
+                                                    "active_from": 5
+                                                },
+                                                {
+                                                    "active_until": 6
+                                                },
+                                                "stake_shared_vkh1j86guumjravnyw98jepkwhc65mtlsjxv5x52pxn588kskuzv4ud",
+                                                "stake_shared_vkh1x370ypzpz4j6exfaed3kc5vd72mkemmlqwjq0q34v44a22pkxzx",
+                                                {
+                                                    "active_until": 1
+                                                },
+                                                {
+                                                    "active_until": 0
+                                                },
+                                                "stake_shared_vkh1j86guumjravnyw98jepkwhc65mtlsjxv5x52pxn588kskuzv4ud"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "all": [
+                                    {
+                                        "active_from": 7
+                                    },
+                                    "stake_shared_vkh1x370ypzpz4j6exfaed3kc5vd72mkemmlqwjq0q34v44a22pkxzx",
+                                    {
+                                        "active_until": 10
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "script_type": "native"
+                }
+            ],
+            "verification_key": 10
+        },
+        {
+            "bootstrap": 1,
+            "scripts": [],
+            "verification_key": 0
+        }
+    ],
+    "seed": 1545059101
+}

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -219,7 +219,10 @@ import Cardano.Wallet.Api.Types.Error
 import Cardano.Wallet.Api.Types.SchemaMetadata
     ( TxMetadataSchema (..), TxMetadataWithSchema (..) )
 import Cardano.Wallet.Api.Types.Transaction
-    ( ApiValidityIntervalExplicit (..), ApiWitnessCount (..) )
+    ( ApiValidityIntervalExplicit (..)
+    , ApiWitnessCount (..)
+    , mkApiWitnessCount
+    )
 import Cardano.Wallet.Gen
     ( genMnemonic
     , genMockXPub
@@ -1898,10 +1901,10 @@ instance Arbitrary ValidityIntervalExplicit where
         slot2 <- arbitrary `suchThat` (> slot1)
         pure $ ValidityIntervalExplicit (Quantity slot1) (Quantity slot2)
 
-instance Arbitrary WitnessCount where
+instance Arbitrary ApiWitnessCount where
     arbitrary = do
         numberOfScripts <- choose (0, 1)
-        WitnessCount
+        fmap mkApiWitnessCount $ WitnessCount
             <$> choose (0, 10)
             <*> vectorOf numberOfScripts (NativeScript <$> arbitrary)
             <*> choose (0, 2)
@@ -2067,8 +2070,6 @@ instance Arbitrary ApiWithdrawalPostData where
     shrink = genericShrink
 
 deriving instance Arbitrary ApiValidityIntervalExplicit
-
-deriving instance Arbitrary ApiWitnessCount
 
 instance Arbitrary (ApiPutAddressesData n) where
     arbitrary = do

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -219,7 +219,7 @@ import Cardano.Wallet.Api.Types.Error
 import Cardano.Wallet.Api.Types.SchemaMetadata
     ( TxMetadataSchema (..), TxMetadataWithSchema (..) )
 import Cardano.Wallet.Api.Types.Transaction
-    ( ApiWitnessCount (..) )
+    ( ApiValidityIntervalExplicit (..), ApiWitnessCount (..) )
 import Cardano.Wallet.Gen
     ( genMnemonic
     , genMockXPub
@@ -2064,6 +2064,8 @@ instance Arbitrary TokenName where
 instance Arbitrary ApiWithdrawalPostData where
     arbitrary = genericArbitrary
     shrink = genericShrink
+
+deriving instance Arbitrary ApiValidityIntervalExplicit
 
 deriving instance Arbitrary ApiWitnessCount
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -635,6 +635,7 @@ spec = parallel $ do
         jsonTest @ApiWalletPassphrase
         jsonTest @ApiWalletPassphraseInfo
         jsonTest @ApiWalletUtxoSnapshot
+        jsonTest @ApiWitnessCount
         jsonTest @ByronWalletFromXPrvPostData
         jsonTest @ByronWalletPutPassphraseData
         jsonTest @SettingsPutData

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -625,6 +625,7 @@ spec = parallel $ do
         jsonTest @ApiTxId
         jsonTest @ApiTxMetadata
         jsonTest @ApiUtxoStatistics
+        jsonTest @ApiValidityIntervalExplicit
         jsonTest @ApiVerificationKeyShared
         jsonTest @ApiVerificationKeyShelley
         jsonTest @ApiWallet

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -218,6 +218,8 @@ import Cardano.Wallet.Api.Types.Error
     )
 import Cardano.Wallet.Api.Types.SchemaMetadata
     ( TxMetadataSchema (..), TxMetadataWithSchema (..) )
+import Cardano.Wallet.Api.Types.Transaction
+    ( ApiWitnessCount (..) )
 import Cardano.Wallet.Gen
     ( genMnemonic
     , genMockXPub
@@ -2061,6 +2063,8 @@ instance Arbitrary TokenName where
 instance Arbitrary ApiWithdrawalPostData where
     arbitrary = genericArbitrary
     shrink = genericShrink
+
+deriving instance Arbitrary ApiWitnessCount
 
 instance Arbitrary (ApiPutAddressesData n) where
     arbitrary = do


### PR DESCRIPTION
## Issue Number

None. Created while reviewing #3529.

## Summary

This PR:

1. Moves the definitions of HTTP-API-specific JSON encodings for types in `Cardano.Wallet.Transaction` into the HTTP API layer.
2. Adds JSON encoding round-trip tests for these types, if they were missing.

## Context

Quite a few of our HTTP-API-specific JSON encodings are defined _outside_ of the HTTP API layer. This breaks our desired abstraction boundary, which is that:
- the HTTP API layer should be responsible for defining its own JSON encodings.
- wallet library modules should not be concerned with the HTTP API.

One major advantage of keeping all of our HTTP API JSON encodings in one place is that we can re-use shared JSON machinery such as `deriving (FromJSON, ToJSON) via DefaultRecord`, rather than re-defining this machinery in many places.

This PR moves the encodings for just the types in `Cardano.Wallet.Transaction`, as an example for other types.