### PR TITLE
[ADP-2377] Add `DB` abstraction

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -232,6 +232,7 @@ library
     Cardano.Wallet.DB.Sqlite.Stores
     Cardano.Wallet.DB.Sqlite.Types
     Cardano.Wallet.DB.Store.Checkpoints
+    Cardano.Wallet.DB.Store.QueryStore
     Cardano.Wallet.DB.Store.Meta.Model
     Cardano.Wallet.DB.Store.Meta.Store
     Cardano.Wallet.DB.Store.Submissions.Model

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/QueryStore.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/QueryStore.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Wallet.DB.Store.QueryStore
+    (QueryStore (..), queryStoreProperty, untry)
+    where
+
+import Prelude
+
+import Control.Exception
+    ( SomeException (..), throwIO )
+import Control.Monad.IO.Class
+    ( MonadIO (liftIO) )
+import Data.DBVar
+    ( Store (loadS) )
+import Data.Delta
+    ( Delta (Base) )
+{-----------------------------------------------------------------------------
+    General QueryStore abstraction
+------------------------------------------------------------------------------}
+{- |
+A 'QueryStore' is a storage facility for a Haskell value of type @a ~@'Base'@ da@.
+Typical use cases are a file or a database on the hard disk.
+
+In addition, 'QueryStore' also allows reading /parts/ of the data through 'queryS'
+— often, it is more efficient to read part of the data from disk
+rather than first load the entire data through 'loadDB' into memory,
+and then filtering the parts of interest.
+
+The parts of the data are expressed through a type constructor @read@
+— typically implemented as a GADT representing different read operations.
+We expect that there is a function @query :: read b -> World a -> b@ which
+applies the operation to a plain value.
+Then, 'queryS' must satisfy
+
+> ∀ qs read.  query read <$> (loadS . store) qs  =  queryS qs read
+
+In other words, loading the value into memory and reading a part
+is equivalent to reading it directly.
+For notational simplicity, we make no attempt at codifying this expectation
+in Haskell.
+
+We stress that all these operations — especially 'updateS' and 'queryS' —
+only exist in order to express control over the storage location
+and in order to enable an efficient implementation.
+Conceptually, a 'QueryStore' is very plain — it stores a single value of type
+@a ~@'Base'@ da@, nothing more, nothing less.
+(If you want to store multiple values, consider storing a 'Set' or 'Map'.)
+-}
+data QueryStore m qa da = QueryStore
+    { store :: Store m da
+    , queryS :: forall b. qa b -> m b
+    }
+
+class Query qa where
+    type family World qa
+    query :: qa b -> World qa -> b
+
+queryStoreProperty
+    :: (Monad m, Eq b, Query qa, MonadFail m, Base da ~ World qa)
+    => qa b
+    -> QueryStore m qa da
+    -> m Bool
+queryStoreProperty r QueryStore{store, queryS} = do
+    Right z <- loadS store
+    (query r z ==) <$> queryS r
+
+-- | Helper function to retry the exception reported by 'loadS'.
+untry :: MonadIO m => m (Either SomeException a) -> m a
+untry action = action >>= liftIO . \case
+    Left (SomeException e) -> throwIO e
+    Right a -> pure a

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Layer.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{- |
+Copyright: © 2022 IOHK
+License: Apache-2.0
+
+Implementation of a 'DB' for 'TxSet'.
+
+-}
+module Cardano.Wallet.DB.Store.Transactions.Layer
+    ( ReadTxSet (..)
+    , mkDBTxSet
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.DB.Sqlite.Types
+    ( TxId )
+import Cardano.Wallet.DB.Store.Transactions.Model
+    ( DeltaTxSet, TxRelation )
+import Database.Persist.Sql
+    ( SqlPersistT )
+
+import Cardano.Wallet.DB.Store.QueryStore
+    ( QueryStore (..) )
+import qualified Cardano.Wallet.DB.Store.Transactions.Store as TxSet
+
+{-----------------------------------------------------------------------------
+    DB for 'TxSet'
+------------------------------------------------------------------------------}
+data ReadTxSet b where
+    GetByTxId :: TxId -> ReadTxSet (Maybe TxRelation)
+
+-- | Implementation of a 'DB' for 'TxSet'.
+mkDBTxSet :: QueryStore (SqlPersistT IO) ReadTxSet DeltaTxSet
+mkDBTxSet = QueryStore
+    { queryS = \case
+        GetByTxId txid -> TxSet.selectTx txid
+    , store = TxSet.mkStoreTransactions
+    }

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
@@ -18,8 +18,8 @@ module Cardano.Wallet.DB.Store.Transactions.Store
     , putTxSet
     , updateTxSet
     , mkStoreTransactions
-    , mkDBTxSet
-    , DBTxSet (..)
+
+    , selectTx
     ) where
 
 import Prelude
@@ -235,18 +235,3 @@ selectTx k = select
                 , withdrawals = sortOn txWithdrawalAccount withds
                 , cbor = listToMaybe mcbor
                 }
-
--- | A database layer that stores transactions.
-data DBTxSet stm = DBTxSet
-    { getTxById
-        :: TxId -> stm (Maybe TxRelation)
-    , updateTxSet
-        :: DeltaTxSet -> stm ()
-    }
-
--- | Create a 'DBTxSet' specialized for sqlite backend
-mkDBTxSet :: DBTxSet (SqlPersistT IO)
-mkDBTxSet = DBTxSet
-    {   getTxById = selectTx
-    ,   updateTxSet = update
-    }

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
@@ -16,6 +16,7 @@ Implementation of a 'Store' for 'TxSet'.
 module Cardano.Wallet.DB.Store.Transactions.Store
     ( selectTxSet
     , putTxSet
+    , updateTxSet
     , mkStoreTransactions
     , mkDBTxSet
     , DBTxSet (..)
@@ -87,11 +88,11 @@ mkStoreTransactions =
     Store
     { loadS = Right <$> selectTxSet
     , writeS = write
-    , updateS = const update
+    , updateS = const updateTxSet
     }
 
-update :: DeltaTxSet -> SqlPersistT IO ()
-update change = case change of
+updateTxSet :: DeltaTxSet -> SqlPersistT IO ()
+updateTxSet change = case change of
     Append txs -> putTxSet txs
     DeleteTx tid -> do
         deleteWhere [TxInputTxId ==. tid ]


### PR DESCRIPTION
This pull request adds an abstraction `DB` which represents a storage facility for a Haskell value. It generalizes `Store` with a `readDB` function for reading parts of the data (as opposed to the entirety of the data). The operations for reading a part are specified through a type constructor, which is typically implemented as GADT.

This pull request introduces the abstraction and implements a `DB` for the `TxSet` type. An implementation of a `DB` for the `TxWalletsHistory` is planned for a future pull request — this will move the transaction storage partially back to disk.

This pull request is part of the new architecture for the database layer.

### Issue number

ADP-2377