### PR TITLE
Move `TxIn` and `TxOut` to separate modules.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -478,7 +478,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , UnsignedTx (..)
     , cardanoTxIdeallyNoLaterThan
     , getSealedTxWitnesses
-    , txOutCoin
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txMintBurnMaxTokenQuantity )
@@ -626,6 +625,7 @@ import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex.Internal as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
@@ -4203,7 +4203,7 @@ mkApiTransaction timeInterpreter wrk wid setTimeReference tx = do
         + maybe 0 (fromIntegral . unCoin) (tx ^. #txFee)
 
     txOutValue :: TxOut -> Natural
-    txOutValue = fromIntegral . unCoin . txOutCoin
+    txOutValue = fromIntegral . unCoin . TxOut.coin
 
     toAddressAmountNoAssets
         :: TxOut

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -308,6 +308,7 @@ library
     Cardano.Wallet.Primitive.Types.Tx.Tx
     Cardano.Wallet.Primitive.Types.Tx.TxIn
     Cardano.Wallet.Primitive.Types.Tx.TxMeta
+    Cardano.Wallet.Primitive.Types.Tx.TxOut
     Cardano.Wallet.Primitive.Types.Tx.TxSeq
     Cardano.Wallet.Primitive.Types.Tx.TxSeq.Gen
     Cardano.Wallet.Primitive.Types.UTxO

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -306,6 +306,7 @@ library
     Cardano.Wallet.Primitive.Types.Tx.SealedTx
     Cardano.Wallet.Primitive.Types.Tx.TransactionInfo
     Cardano.Wallet.Primitive.Types.Tx.Tx
+    Cardano.Wallet.Primitive.Types.Tx.TxIn
     Cardano.Wallet.Primitive.Types.Tx.TxMeta
     Cardano.Wallet.Primitive.Types.Tx.TxSeq
     Cardano.Wallet.Primitive.Types.Tx.TxSeq.Gen

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -442,7 +442,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , UnsignedTx (..)
     , fromTransactionInfo
     , sealedTxFromCardano
-    , txOutCoin
     , withdrawals
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
@@ -617,6 +616,7 @@ import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
@@ -2650,7 +2650,7 @@ mkTxMetaWithoutSel
     -> IO TxMeta
 mkTxMetaWithoutSel blockHeader txCtx inps outs =
     let
-        amtOuts = F.fold $ map txOutCoin outs
+        amtOuts = F.fold $ map TxOut.coin outs
 
         amtInps
             = F.fold (map snd inps)
@@ -2693,12 +2693,12 @@ mkTxMeta
 mkTxMeta ti' blockHeader wState txCtx sel =
     let
         amtOuts = F.fold $
-            (txOutCoin <$> view #change sel)
+            (TxOut.coin <$> view #change sel)
             ++
             mapMaybe (`ourCoin` wState) (view #outputs sel)
 
         amtInps
-            = F.fold (txOutCoin . snd <$> view #inputs sel)
+            = F.fold (TxOut.coin . snd <$> view #inputs sel)
             -- NOTE: In case where rewards were pulled from an external
             -- source, they aren't added to the calculation because the
             -- money is considered to come from outside of the wallet; which

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -102,6 +102,7 @@ import GHC.Generics
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Generics.Internal.VL as L
 import qualified Data.Map.Strict as Map
@@ -204,7 +205,7 @@ mkTxOut tid (ix,txOut) = (out, sortOn tokenOutOrd tokens)
         { txOutputTxId = tid
         , txOutputIndex = ix
         , txOutputAddress = view #address txOut
-        , txOutputAmount = W.txOutCoin txOut
+        , txOutputAmount = W.TxOut.coin txOut
         }
     tokens =
         mkTxOutToken tid ix
@@ -234,7 +235,7 @@ mkTxCollateralOut tid txCollateralOut = (out, sortOn tokenCollateralOrd tokens)
         TxCollateralOut
         { txCollateralOutTxId = tid
         , txCollateralOutAddress = view #address txCollateralOut
-        , txCollateralOutAmount = W.txOutCoin txCollateralOut
+        , txCollateralOutAmount = W.TxOut.coin txCollateralOut
         }
     tokens =
         mkTxCollateralOutToken tid

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Model.hs
@@ -108,7 +108,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxStatus (..)
     , collateralInputs
     , inputs
-    , txOutCoin
     , txScriptInvalid
     )
 import Cardano.Wallet.Primitive.Types.UTxO
@@ -143,6 +142,7 @@ import GHC.Generics
     ( Generic )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TB
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Data.Delta as Delta
 import qualified Data.Foldable as F
@@ -796,7 +796,7 @@ applyOurTxToUTxO !slot !blockHeight !s !tx !u0 =
             Just x
         (Nothing, Outgoing) ->
             -- Byron:
-            let totalOut = F.fold (txOutCoin <$> outputs tx)
+            let totalOut = F.fold (TxOut.coin <$> outputs tx)
                 totalIn = TB.getCoin spent
             in
             Just $ distance totalIn totalOut

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -62,21 +62,15 @@ module Cardano.Wallet.Primitive.Types.Tx
     , toTxHistory
     , txIns
     , txMetadataIsNull
-    , txOutCoin
-    , txOutAddCoin
-    , txOutSubtractCoin
     , txScriptInvalid
 
     -- * Queries
     , txAssetIds
-    , txOutAssetIds
 
     -- * Transformations
     , txMapAssetIds
     , txMapTxIds
     , txRemoveAssetId
-    , txOutMapAssetIds
-    , txOutRemoveAssetId
 
     -- * Conversions (Unsafe)
     , unsafeCoinToTxOutCoinValue
@@ -133,12 +127,6 @@ import Cardano.Wallet.Primitive.Types.Tx.Tx
     , txMapAssetIds
     , txMapTxIds
     , txMetadataIsNull
-    , txOutAddCoin
-    , txOutAssetIds
-    , txOutCoin
-    , txOutMapAssetIds
-    , txOutRemoveAssetId
-    , txOutSubtractCoin
     , txRemoveAssetId
     , txScriptInvalid
     )

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
@@ -31,21 +31,16 @@ module Cardano.Wallet.Primitive.Types.Tx.Tx
     , collateralInputs
     , txIns
     , txMetadataIsNull
-    , txOutCoin
-    , txOutAddCoin
-    , txOutSubtractCoin
     , txScriptInvalid
 
     -- * Queries
     , txAssetIds
-    , txOutAssetIds
+    , TxOut.assetIds
 
     -- * Transformations
     , txMapAssetIds
     , txMapTxIds
     , txRemoveAssetId
-    , txOutMapAssetIds
-    , txOutRemoveAssetId
 
     ) where
 
@@ -66,14 +61,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
-    ( TxOut (..)
-    , txOutAddCoin
-    , txOutAssetIds
-    , txOutCoin
-    , txOutMapAssetIds
-    , txOutRemoveAssetId
-    , txOutSubtractCoin
-    )
+    ( TxOut (..) )
 import Cardano.Wallet.Read.Tx.CBOR
     ( TxCBOR )
 import Control.DeepSeq
@@ -95,6 +83,7 @@ import Fmt
 import GHC.Generics
     ( Generic )
 
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Data.Foldable as F
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -224,8 +213,8 @@ instance NFData TxScriptValidity
 
 txAssetIds :: Tx -> Set AssetId
 txAssetIds tx = F.fold
-    [ F.foldMap txOutAssetIds (view #outputs tx)
-    , F.foldMap txOutAssetIds (view #collateralOutput tx)
+    [ F.foldMap TxOut.assetIds (view #outputs tx)
+    , F.foldMap TxOut.assetIds (view #collateralOutput tx)
     ]
 
 -- | Returns 'True' if (and only if) the given transaction is marked as having
@@ -252,9 +241,9 @@ txMetadataIsNull (TxMetadata md) = Map.null md
 txMapAssetIds :: (AssetId -> AssetId) -> Tx -> Tx
 txMapAssetIds f tx = tx
     & over #outputs
-        (fmap (txOutMapAssetIds f))
+        (fmap (TxOut.mapAssetIds f))
     & over #collateralOutput
-        (fmap (txOutMapAssetIds f))
+        (fmap (TxOut.mapAssetIds f))
 
 txMapTxIds :: (Hash "Tx" -> Hash "Tx") -> Tx -> Tx
 txMapTxIds f tx = tx
@@ -268,6 +257,6 @@ txMapTxIds f tx = tx
 txRemoveAssetId :: Tx -> AssetId -> Tx
 txRemoveAssetId tx asset = tx
     & over #outputs
-        (fmap (`txOutRemoveAssetId` asset))
+        (fmap (`TxOut.removeAssetId` asset))
     & over #collateralOutput
-        (fmap (`txOutRemoveAssetId` asset))
+        (fmap (`TxOut.removeAssetId` asset))

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK
@@ -189,9 +188,6 @@ inputs = map fst . resolvedInputs
 
 collateralInputs :: Tx -> [TxIn]
 collateralInputs = map fst . resolvedCollateralInputs
-
-instance Buildable (TxIn, TxOut) where
-    build (txin, txout) = build txin <> " ==> " <> build txout
 
 -- | Indicates whether or not a transaction is marked as having an invalid
 --   script.

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
@@ -67,6 +67,8 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId, Lexicographic (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
 import Cardano.Wallet.Read.Tx.CBOR
     ( TxCBOR )
 import Control.DeepSeq
@@ -85,18 +87,8 @@ import Data.Ord
     ( comparing )
 import Data.Set
     ( Set )
-import Data.Word
-    ( Word32 )
 import Fmt
-    ( Buildable (..)
-    , blockListF'
-    , blockMapF
-    , nameF
-    , ordinalF
-    , prefixF
-    , suffixF
-    , tupleF
-    )
+    ( Buildable (..), blockListF', blockMapF, nameF, prefixF, suffixF, tupleF )
 import GHC.Generics
     ( Generic )
 
@@ -208,21 +200,6 @@ inputs = map fst . resolvedInputs
 
 collateralInputs :: Tx -> [TxIn]
 collateralInputs = map fst . resolvedCollateralInputs
-
-data TxIn = TxIn
-    { inputId
-        :: !(Hash "Tx")
-    , inputIx
-        :: !Word32
-    } deriving (Read, Show, Generic, Eq, Ord)
-
-instance NFData TxIn
-
-instance Buildable TxIn where
-    build txin = mempty
-        <> ordinalF (inputIx txin + 1)
-        <> " "
-        <> build (inputId txin)
 
 data TxOut = TxOut
     { address

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxIn.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxIn.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK
+-- License: Apache-2.0
+--
+-- This module defines the 'TxIn' type.
+--
+module Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..)
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
+import Control.DeepSeq
+    ( NFData (..) )
+import Data.Word
+    ( Word32 )
+import Fmt
+    ( Buildable (..), ordinalF )
+import GHC.Generics
+    ( Generic )
+
+data TxIn = TxIn
+    { inputId
+        :: !(Hash "Tx")
+    , inputIx
+        :: !Word32
+    }
+    deriving (Read, Show, Generic, Eq, Ord)
+
+instance NFData TxIn
+
+instance Buildable TxIn where
+    build txin = mempty
+        <> ordinalF (inputIx txin + 1)
+        <> " "
+        <> build (inputId txin)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxOut.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxOut.hs
@@ -16,14 +16,14 @@ module Cardano.Wallet.Primitive.Types.Tx.TxOut
       TxOut (..)
 
     -- * Queries
-    , txOutAssetIds
-    , txOutCoin
+    , assetIds
+    , coin
 
     -- * Modifiers
-    , txOutAddCoin
-    , txOutMapAssetIds
-    , txOutRemoveAssetId
-    , txOutSubtractCoin
+    , addCoin
+    , mapAssetIds
+    , removeAssetId
+    , subtractCoin
 
     ) where
 
@@ -93,7 +93,7 @@ instance Buildable TxOut where
         [ ("address"
           , addressShort)
         , ("coin"
-          , build (txOutCoin txOut))
+          , build (coin txOut))
         , ("tokens"
           , build (TokenMap.Nested $ view (#tokens . #tokens) txOut))
         ]
@@ -111,15 +111,15 @@ instance Buildable TxOut where
 
 -- | Gets the current set of asset identifiers from a transaction output.
 --
-txOutAssetIds :: TxOut -> Set AssetId
-txOutAssetIds (TxOut _ bundle) = TokenBundle.getAssets bundle
+assetIds :: TxOut -> Set AssetId
+assetIds (TxOut _ bundle) = TokenBundle.getAssets bundle
 
 -- | Gets the current 'Coin' value from a transaction output.
 --
 -- 'Coin' values correspond to the ada asset.
 --
-txOutCoin :: TxOut -> Coin
-txOutCoin = TokenBundle.getCoin . view #tokens
+coin :: TxOut -> Coin
+coin = TokenBundle.getCoin . view #tokens
 
 --------------------------------------------------------------------------------
 -- Modifiers
@@ -129,33 +129,33 @@ txOutCoin = TokenBundle.getCoin . view #tokens
 --
 -- Satisfies the following property for all values of 'c':
 --
--- >>> txOutSubtractCoin c . txOutAddCoin c == id
+-- >>> subtractCoin c . addCoin c == id
 --
-txOutAddCoin :: Coin -> TxOut -> TxOut
-txOutAddCoin val TxOut {address, tokens} =
+addCoin :: Coin -> TxOut -> TxOut
+addCoin val TxOut {address, tokens} =
     TxOut address (tokens <> TokenBundle.fromCoin val)
 
 -- | Applies the given function to all asset identifiers in a 'TxOut'.
 --
-txOutMapAssetIds :: (AssetId -> AssetId) -> TxOut -> TxOut
-txOutMapAssetIds f (TxOut address bundle) =
+mapAssetIds :: (AssetId -> AssetId) -> TxOut -> TxOut
+mapAssetIds f (TxOut address bundle) =
     TxOut address (TokenBundle.mapAssetIds f bundle)
 
 -- | Removes the asset corresponding to the given 'AssetId' from a 'TxOut'.
 --
-txOutRemoveAssetId :: TxOut -> AssetId -> TxOut
-txOutRemoveAssetId (TxOut address bundle) asset =
+removeAssetId :: TxOut -> AssetId -> TxOut
+removeAssetId (TxOut address bundle) asset =
     TxOut address (TokenBundle.setQuantity bundle asset mempty)
 
 -- | Decrements the 'Coin' value of a 'TxOut'.
 --
 -- Satisfies the following property for all values of 'c':
 --
--- >>> txOutSubtractCoin c . txOutAddCoin c == id
+-- >>> subtractCoin c . addCoin c == id
 --
 -- If the given 'Coin' is greater than the 'Coin' value of the given 'TxOut',
 -- the resulting 'TxOut' will have a 'Coin' value of zero.
 --
-txOutSubtractCoin :: Coin -> TxOut -> TxOut
-txOutSubtractCoin toSubtract =
+subtractCoin :: Coin -> TxOut -> TxOut
+subtractCoin toSubtract =
     over (#tokens . #coin) (`Coin.difference` toSubtract)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxOut.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxOut.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK
+-- License: Apache-2.0
+--
+-- This module defines the 'TxOut' type.
+--
+module Cardano.Wallet.Primitive.Types.Tx.TxOut
+    (
+    -- * Type
+      TxOut (..)
+
+    -- * Queries
+    , txOutAssetIds
+    , txOutCoin
+
+    -- * Modifiers
+    , txOutAddCoin
+    , txOutMapAssetIds
+    , txOutRemoveAssetId
+    , txOutSubtractCoin
+
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( AssetId, Lexicographic (..) )
+import Control.DeepSeq
+    ( NFData (..) )
+import Data.Bifunctor
+    ( first )
+import Data.Generics.Internal.VL.Lens
+    ( over, view )
+import Data.Generics.Labels
+    ()
+import Data.Ord
+    ( comparing )
+import Data.Set
+    ( Set )
+import Fmt
+    ( Buildable (..), blockMapF, prefixF, suffixF )
+import GHC.Generics
+    ( Generic )
+
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+
+--------------------------------------------------------------------------------
+-- Type
+--------------------------------------------------------------------------------
+
+data TxOut = TxOut
+    { address
+        :: !Address
+    , tokens
+        :: !TokenBundle
+    }
+    deriving (Read, Show, Generic, Eq)
+
+--------------------------------------------------------------------------------
+-- Instances
+--------------------------------------------------------------------------------
+
+-- Since the 'TokenBundle' type deliberately does not provide an 'Ord' instance
+-- (as that would lead to arithmetically invalid orderings), this means we can't
+-- automatically derive an 'Ord' instance for the 'TxOut' type.
+--
+-- Instead, we define an 'Ord' instance that makes comparisons based on
+-- lexicographic ordering of 'TokenBundle' values.
+--
+instance Ord TxOut where
+    compare = comparing projection
+      where
+        projection (TxOut address bundle) = (address, Lexicographic bundle)
+
+instance NFData TxOut
+
+instance Buildable TxOut where
+    build txOut = buildMap
+        [ ("address"
+          , addressShort)
+        , ("coin"
+          , build (txOutCoin txOut))
+        , ("tokens"
+          , build (TokenMap.Nested $ view (#tokens . #tokens) txOut))
+        ]
+      where
+        addressShort = mempty
+            <> prefixF 8 addressFull
+            <> "..."
+            <> suffixF 8 addressFull
+        addressFull = build $ view #address txOut
+        buildMap = blockMapF . fmap (first $ id @String)
+
+--------------------------------------------------------------------------------
+-- Queries
+--------------------------------------------------------------------------------
+
+-- | Gets the current set of asset identifiers from a transaction output.
+--
+txOutAssetIds :: TxOut -> Set AssetId
+txOutAssetIds (TxOut _ bundle) = TokenBundle.getAssets bundle
+
+-- | Gets the current 'Coin' value from a transaction output.
+--
+-- 'Coin' values correspond to the ada asset.
+--
+txOutCoin :: TxOut -> Coin
+txOutCoin = TokenBundle.getCoin . view #tokens
+
+--------------------------------------------------------------------------------
+-- Modifiers
+--------------------------------------------------------------------------------
+
+-- | Increments the 'Coin' value of a 'TxOut'.
+--
+-- Satisfies the following property for all values of 'c':
+--
+-- >>> txOutSubtractCoin c . txOutAddCoin c == id
+--
+txOutAddCoin :: Coin -> TxOut -> TxOut
+txOutAddCoin val TxOut {address, tokens} =
+    TxOut address (tokens <> TokenBundle.fromCoin val)
+
+-- | Applies the given function to all asset identifiers in a 'TxOut'.
+--
+txOutMapAssetIds :: (AssetId -> AssetId) -> TxOut -> TxOut
+txOutMapAssetIds f (TxOut address bundle) =
+    TxOut address (TokenBundle.mapAssetIds f bundle)
+
+-- | Removes the asset corresponding to the given 'AssetId' from a 'TxOut'.
+--
+txOutRemoveAssetId :: TxOut -> AssetId -> TxOut
+txOutRemoveAssetId (TxOut address bundle) asset =
+    TxOut address (TokenBundle.setQuantity bundle asset mempty)
+
+-- | Decrements the 'Coin' value of a 'TxOut'.
+--
+-- Satisfies the following property for all values of 'c':
+--
+-- >>> txOutSubtractCoin c . txOutAddCoin c == id
+--
+-- If the given 'Coin' is greater than the 'Coin' value of the given 'TxOut',
+-- the resulting 'TxOut' will have a 'Coin' value of zero.
+--
+txOutSubtractCoin :: Coin -> TxOut -> TxOut
+txOutSubtractCoin toSubtract =
+    over (#tokens . #coin) (`Coin.difference` toSubtract)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
@@ -143,6 +143,7 @@ import Data.Set
 
 import qualified Cardano.Wallet.Primitive.Types.StateDeltaSeq as Seq
 import qualified Cardano.Wallet.Primitive.Types.Tx as Tx
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
@@ -528,7 +529,7 @@ canApplyTxToUTxO tx u =  (&&)
     inputRefIsValid :: (TxIn, Coin) -> Bool
     inputRefIsValid (ti, c) = case UTxO.lookup ti u of
         Nothing -> False
-        Just to -> Tx.txOutCoin to == c
+        Just to -> TxOut.coin to == c
 
 safeAppendTx :: MonadFail m => UTxO -> Tx -> m UTxO
 safeAppendTx = flip safeApplyTxToUTxO

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -78,13 +78,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn
-    , TxOut (..)
-    , txOutAssetIds
-    , txOutCoin
-    , txOutMapAssetIds
-    , txOutRemoveAssetId
-    )
+    ( TxIn, TxOut (..) )
 import Control.DeepSeq
     ( NFData (..) )
 import Data.Bifunctor
@@ -110,6 +104,7 @@ import GHC.Generics
 
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TB
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Control.Foldl as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
@@ -290,7 +285,7 @@ receiveD a b = (da, a <> b)
 --------------------------------------------------------------------------------
 
 assetIds :: UTxO -> Set AssetId
-assetIds (UTxO u) = foldMap txOutAssetIds u
+assetIds (UTxO u) = foldMap TxOut.assetIds u
 
 txIds :: UTxO -> Set (Hash "Tx")
 txIds (UTxO u) = Set.map (view #inputId) (Map.keysSet u)
@@ -300,7 +295,7 @@ txIds (UTxO u) = Set.map (view #inputId) (Map.keysSet u)
 --------------------------------------------------------------------------------
 
 mapAssetIds :: (AssetId -> AssetId) -> UTxO -> UTxO
-mapAssetIds f (UTxO u) = UTxO $ Map.map (txOutMapAssetIds f) u
+mapAssetIds f (UTxO u) = UTxO $ Map.map (TxOut.mapAssetIds f) u
 
 -- | Applies a mapping on transaction identifiers to a 'UTxO' set.
 --
@@ -312,7 +307,7 @@ mapTxIds :: (Hash "Tx" -> Hash "Tx") -> UTxO -> UTxO
 mapTxIds f (UTxO u) = UTxO $ Map.mapKeysWith min (over #inputId f) u
 
 removeAssetId :: UTxO -> AssetId -> UTxO
-removeAssetId (UTxO u) a = UTxO $ Map.map (`txOutRemoveAssetId` a) u
+removeAssetId (UTxO u) a = UTxO $ Map.map (`TxOut.removeAssetId` a) u
 
 --------------------------------------------------------------------------------
 -- UTxO Statistics
@@ -399,7 +394,7 @@ log10 = Log10
 -- | Compute UtxoStatistics from UTxOs
 computeUtxoStatistics :: BoundType -> UTxO -> UTxOStatistics
 computeUtxoStatistics btype
-    = computeStatistics (pure . Coin.unsafeToWord64 . txOutCoin) btype
+    = computeStatistics (pure . Coin.unsafeToWord64 . TxOut.coin) btype
     . Map.elems
     . unUTxO
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -97,7 +97,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , collateralInputs
     , inputs
     , txIns
-    , txOutCoin
     , txScriptInvalid
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
@@ -219,6 +218,7 @@ import Test.Utils.Pretty
 
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxSeq as TxSeq
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Data.ByteString as BS
@@ -495,7 +495,7 @@ prop_countRewardsOnce (WithPending wallet pending rewards)
       else property (totalWithPending == totalWithoutPending)
   where
     pendingBalance =
-        sum $ (unCoin . txOutCoin) <$> concatMap outputs (Set.elems pending)
+        sum $ (unCoin . TxOut.coin) <$> concatMap outputs (Set.elems pending)
     totalWithPending =
         TokenBundle.getCoin $ totalBalance pending rewards wallet
     totalWithoutPending =
@@ -1229,13 +1229,13 @@ instance Arbitrary (WithPending WalletState) where
                 -- - Sometimes, we also add a withdrawal by creating another
                 --   change output and an explicit withdrawal in the
                 --   transaction.
-                let tokens = TokenBundle.fromCoin $ simulateFee $ txOutCoin out
+                let tokens = TokenBundle.fromCoin $ simulateFee $ TxOut.coin out
                 scriptValidity <- liftArbitrary genTxScriptValidity
                 let pending = withWithdrawal $ Tx
                         { txId = arbitraryHash
                         , txCBOR = Nothing
                         , fee = Nothing
-                        , resolvedInputs = [(inp, txOutCoin out)]
+                        , resolvedInputs = [(inp, TxOut.coin out)]
                         -- TODO: (ADP-957)
                         , resolvedCollateralInputs = []
                         -- TODO: [ADP-1670]

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/TxSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/TxSpec.hs
@@ -34,9 +34,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , txAssetIds
     , txMapAssetIds
     , txMapTxIds
-    , txOutAssetIds
-    , txOutMapAssetIds
-    , txOutRemoveAssetId
     , txRemoveAssetId
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
@@ -68,6 +65,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Instances.ByteString
     ()
 
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Data.Foldable as F
 import qualified Data.Set as Set
 
@@ -167,13 +165,13 @@ prop_txRemoveAssetId_txAssetIds tx =
 
 prop_txOutMapAssetIds_identity :: TxOut -> Property
 prop_txOutMapAssetIds_identity m =
-    txOutMapAssetIds id m === m
+    TxOut.mapAssetIds id m === m
 
 prop_txOutMapAssetIds_composition
     :: TxOut -> Fun AssetId AssetId -> Fun AssetId AssetId -> Property
 prop_txOutMapAssetIds_composition m (applyFun -> f) (applyFun -> g) =
-    txOutMapAssetIds f (txOutMapAssetIds g m) ===
-    txOutMapAssetIds (f . g) m
+    TxOut.mapAssetIds f (TxOut.mapAssetIds g m) ===
+    TxOut.mapAssetIds (f . g) m
 
 prop_txOutRemoveAssetId_txOutAssetIds :: TxOut -> Property
 prop_txOutRemoveAssetId_txOutAssetIds txOut =
@@ -182,11 +180,11 @@ prop_txOutRemoveAssetId_txOutAssetIds txOut =
             assetIds === mempty
         Just assetId ->
             Set.notMember assetId
-                (txOutAssetIds (txOut `txOutRemoveAssetId` assetId))
+                (TxOut.assetIds (txOut `TxOut.removeAssetId` assetId))
             === True
   where
     assetIdM = listToMaybe $ F.toList assetIds
-    assetIds = txOutAssetIds txOut
+    assetIds = TxOut.assetIds txOut
 
 --------------------------------------------------------------------------------
 -- Arbitrary instances

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -139,7 +139,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxStatus (..)
     , isPending
     , mockSealedTx
-    , txOutCoin
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin )
@@ -290,6 +289,7 @@ import qualified Cardano.Wallet.Primitive.Migration as Migration
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -1348,7 +1348,7 @@ setupFixture (wid, wname, wstate) = do
 dummyTransactionLayer :: TransactionLayer ShelleyKey 'CredFromKeyK SealedTx
 dummyTransactionLayer = TransactionLayer
     { mkTransaction = \_era _stakeCredentials keystore _pp _ctx cs -> do
-        let inps' = NE.toList $ second txOutCoin <$> view #inputs cs
+        let inps' = NE.toList $ second TxOut.coin <$> view #inputs cs
         -- TODO: (ADP-957)
         let cinps' = []
         let txId = mkTxId inps' (view #outputs cs) mempty Nothing


### PR DESCRIPTION
## Issue Number

ADP-2386

## Summary

This PR moves the `TxIn` and `TxOut` types out of `Primitive.Types.Tx` and into the following modules:
- `Primitive.Types.Tx.TxIn`
- `Primitive.Types.Tx.TxOut`

## Motivation

Coin selection (and therefore `balanceTransaction`) currently depends on these types, but currently it can only consume them by importing from the `Primitive.Types.Tx` module, which has a very large transitive dependency footprint.

By moving these types to separate modules, we make it possible for coin selection to depend on just those types (and not everything in `Primitive.Types.Tx`). Consequently, we can minimise the dependency footprint of the `CoinSelection` module hierarchy and by extension `balanceTransation`, thus easing the burden of moving it to a separate library.

We eventually plan to **_completely remove_** coin selection's dependency on the `TxIn` and `TxOut` types. This PR is just an evolutionary step, to make the initial extraction of the `CoinSelection` module hierarchy easier.