### PR TITLE
Revise error name to `WithdrawalNotBeneficial`.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -70,7 +70,7 @@ import Cardano.Wallet
     , ErrWalletAlreadyExists (..)
     , ErrWalletNotResponding (..)
     , ErrWithRootKey (..)
-    , ErrWithdrawalNotWorth (..)
+    , ErrWithdrawalNotBeneficial (..)
     , ErrWitnessTx (..)
     , ErrWritePolicyPublicKey (..)
     , ErrWrongPassphrase (..)
@@ -223,7 +223,7 @@ instance IsServerError WalletException where
         ExceptionImportRandomAddress e -> toServerError e
         ExceptionNotASequentialWallet e -> toServerError e
         ExceptionReadRewardAccount e -> toServerError e
-        ExceptionWithdrawalNotWorth e -> toServerError e
+        ExceptionWithdrawalNotBeneficial e -> toServerError e
         ExceptionReadPolicyPublicKey e -> toServerError e
         ExceptionWritePolicyPublicKey e -> toServerError e
         ExceptionSoftDerivationIndex e -> toServerError e
@@ -744,10 +744,10 @@ instance IsServerError ErrNotASequentialWallet where
                 , "Make sure to use a sequential wallet style, like Icarus."
                 ]
 
-instance IsServerError ErrWithdrawalNotWorth where
+instance IsServerError ErrWithdrawalNotBeneficial where
     toServerError = \case
-        ErrWithdrawalNotWorth ->
-            apiError err403 WithdrawalNotWorth $ mconcat
+        ErrWithdrawalNotBeneficial ->
+            apiError err403 WithdrawalNotBeneficial $ mconcat
                 [ "I've noticed that you're requesting a withdrawal from an "
                 , "account that is either empty or doesn't have a balance big "
                 , "enough to deserve being withdrawn. I won't proceed with that "

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Error.hs
@@ -156,7 +156,7 @@ data ApiErrorInfo
     | ValidityIntervalNotInsideScriptTimelock
     | WalletAlreadyExists
     | WalletNotResponding
-    | WithdrawalNotWorth
+    | WithdrawalNotBeneficial
     | WrongEncryptionPassphrase
     | WrongMnemonic
     deriving (Eq, Generic, Show, Data, Typeable)

--- a/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
@@ -80,7 +80,7 @@ module Test.Integration.Framework.TestData
     , errMsg400NumberOfWords
     , errMsgNotInDictionary
     , errMsg400MinWithdrawalWrong
-    , errMsg403WithdrawalNotWorth
+    , errMsg403WithdrawalNotBeneficial
     , errMsg403NotAShelleyWallet
     , errMsg403MinUTxOValue
     , errMsg403CouldntIdentifyAddrAsMine
@@ -512,8 +512,8 @@ errMsgNotInDictionary = "Found an unknown word not present in the pre-defined\
 errMsg400NumberOfWords :: String
 errMsg400NumberOfWords = "Invalid number of words:"
 
-errMsg403WithdrawalNotWorth :: String
-errMsg403WithdrawalNotWorth =
+errMsg403WithdrawalNotBeneficial :: String
+errMsg403WithdrawalNotBeneficial =
     "I've noticed that you're requesting a withdrawal from an account that is \
     \either empty or doesn't have a balance big enough to deserve being \
     \withdrawn. I won't proceed with that request."

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -164,7 +164,7 @@ import Test.Integration.Framework.TestData
     , errMsg403NotAShelleyWallet
     , errMsg403NotEnoughMoney
     , errMsg403TxTooBig
-    , errMsg403WithdrawalNotWorth
+    , errMsg403WithdrawalNotBeneficial
     , errMsg403WrongPass
     , errMsg404CannotFindTx
     , errMsg404NoAsset
@@ -2148,7 +2148,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             (Link.createTransactionOld @'Shelley wSelf) Default payload
         verify rTx
             [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403WithdrawalNotWorth
+            , expectErrorMessage errMsg403WithdrawalNotBeneficial
             ]
 
     it "SHELLEY_TX_REDEEM_04 - Can always ask for self redemption" $
@@ -2199,7 +2199,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             (Link.createTransactionOld @'Shelley wSelf) Default payload
         verify rTx
             [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403WithdrawalNotWorth
+            , expectErrorMessage errMsg403WithdrawalNotBeneficial
             ]
 
     it "SHELLEY_TX_REDEEM_06 - Can't redeem rewards using byron wallet" $

--- a/lib/wallet/test/data/Cardano/Wallet/Api/ApiError.json
+++ b/lib/wallet/test/data/Cardano/Wallet/Api/ApiError.json
@@ -791,7 +791,7 @@
             "message": "S􂻿\u001b𐫴b:5IO=\u0007?h\u0019\u001d∶y􈕄ﻵ\u001d!d"
         },
         {
-            "code": "withdrawal_not_worth",
+            "code": "withdrawal_not_beneficial",
             "message": "𩮼}CL\u0018𢩤ef\t|\u0004:z\u0005Q&ẏ􊰑\u0013c\u001bFH"
         },
         {

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1290,14 +1290,17 @@ x-otherCertificate: &otherCertificate
 x-transactionRedemptionRequest: &transactionRedemptionRequest
   <<: *walletMnemonicSentence
   description: |
-    When provided, attempts to withdraw rewards from the default stake address corresponding to the given mnemonic.
+    When provided, attempts to withdraw rewards from the default stake address
+    corresponding to the given mnemonic.
 
-    Should the rewards be null or too small to be worth withdrawing (i.e. the cost of adding them into the transaction
-    is more than their own intrinsic value), the server will reject the request with a `withdrawal_not_worth` error.
+    Should the rewards be null or too small to be worth withdrawing (i.e. the
+    cost of adding them into the transaction is more than their own intrinsic
+    value), the server will reject the request with a
+    `withdrawal_not_beneficial` error.
 
     withdrawal field    | reward balance | result
     ---                 | ---            | ---
-    any recovery phrase | too small      | x Error 403 `withdrawal_not_worth`
+    any recovery phrase | too small      | x Error 403 `withdrawal_not_beneficial`
     any recovery phrase | big enough     | ✓ withdrawal generated
 
 x-transactionWithdrawalRequestSelf: &transactionWithdrawalRequestSelf
@@ -4994,16 +4997,18 @@ x-errAlreadyWithdrawing: &errAlreadyWithdrawing
       enum: ['already_withdrawing']
 
 # TODO: Map this error to the place it belongs.
-x-errWithdrawalNotWorth: &errWithdrawalNotWorth
+x-errWithdrawalNotBeneficial: &errWithdrawalNotBeneficial
   <<: *responsesErr
-  title: withdrawal_not_worth
+  title: withdrawal_not_beneficial
   properties:
     message:
       type: string
-      description: May occur when withdrawing an amount would cost more than the withdrawn value.
+      description: |
+        Occurs when the cost of withdrawing a reward balance would be greater
+        than the reward balance itself.
     code:
       type: string
-      enum: ['withdrawal_not_worth']
+      enum: ['withdrawal_not_beneficial']
 
 # TODO: Map this error to the place it belongs.
 x-errPastHorizon: &errPastHorizon

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2762,7 +2762,7 @@ components:
         mint: *ApiAssetMintBurn
         burn: *ApiAssetMintBurn
         validity_interval: *ApiValidityIntervalExplicit
-        script_integrity: *scriptIntegrityHash 
+        script_integrity: *scriptIntegrityHash
         extra_signatures:
           type: array
           minItems: 0


### PR DESCRIPTION
## Issue Number

None. Noticed while reviewing #3555.

## Description

This PR renames `ErrWithdrawalNotWorth` to `ErrWithdrawalNotBeneficial`.

The wording of the former error name is broken. We _can_ say "a withdrawal is not worth **it**", but saying something is "not worth" (without the "it") just doesn't make sense in English.

## Compatibility

Usages of the JSON error code `withdrawal_not_worth` are very rare: [Usages of `withdrawal_not_worth`](https://github.com/search?q=org%3Ainput-output-hk+%22withdrawal_not_worth%22&type=code).

These rare cases can easily be updated with a tiny PR or two.