### PR TITLE
Move `UTxOStatistics` type to separate module.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -380,7 +380,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxStatus (..)
     , sealedTxFromBytes
     )
-import Cardano.Wallet.Primitive.Types.UTxO
+import Cardano.Wallet.Primitive.Types.UTxOStatistics
     ( BoundType, HistogramBar (..), UTxOStatistics (..) )
 import Cardano.Wallet.Shelley.Network.Discriminant
     ( DecodeAddress (..)

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -151,6 +151,8 @@ import Cardano.Wallet.Shelley.Compatibility
     , fromCardanoBlock
     , numberOfTransactionsInBlock
     )
+import Cardano.Wallet.Shelley.Network.Discriminant
+    ( HasNetworkId (networkIdVal) )
 import Cardano.Wallet.Shelley.Network.Node
     ( withNetworkLayer )
 import Cardano.Wallet.Shelley.Transaction
@@ -244,8 +246,6 @@ import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Shelley
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
-import Cardano.Wallet.Shelley.Network.Discriminant
-    ( HasNetworkId (networkIdVal) )
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -495,8 +495,7 @@ benchmarksRnd _ w wid wname benchname restoreTime = do
         pure (cp, pending)
 
     (utxo, _) <- bench "utxo statistics" $
-        pure $ UTxOStatistics.compute UTxOStatistics.log10
-            (totalUTxO pending cp)
+        pure $ UTxOStatistics.compute (totalUTxO pending cp)
 
     (addresses, listAddressesTime) <- bench "list addresses"
         $ fmap (fromIntegral . length)
@@ -600,8 +599,7 @@ benchmarksSeq _ w wid _wname benchname restoreTime = do
         (cp, _, pending) <- unsafeRunExceptT $ W.readWallet w wid
         pure (cp, pending)
     (utxo, _) <- bench "utxo statistics" $
-        pure $ UTxOStatistics.compute UTxOStatistics.log10
-            (totalUTxO pending cp)
+        pure $ UTxOStatistics.compute (totalUTxO pending cp)
 
     (addresses, listAddressesTime) <- bench "list addresses"
         $ fmap (fromIntegral . length)

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -139,7 +139,7 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxOut (..) )
-import Cardano.Wallet.Primitive.Types.UTxO
+import Cardano.Wallet.Primitive.Types.UTxOStatistics
     ( UTxOStatistics (..), computeUtxoStatistics, log10 )
 import Cardano.Wallet.Shelley
     ( SomeNetworkDiscriminant (..) )

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -140,7 +140,7 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
-    ( UTxOStatistics (..), computeUtxoStatistics, log10 )
+    ( UTxOStatistics (..) )
 import Cardano.Wallet.Shelley
     ( SomeNetworkDiscriminant (..) )
 import Cardano.Wallet.Shelley.Compatibility
@@ -246,6 +246,7 @@ import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Shelley
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
+import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -493,8 +494,9 @@ benchmarksRnd _ w wid wname benchname restoreTime = do
         (cp, _, pending) <- unsafeRunExceptT $ W.readWallet w wid
         pure (cp, pending)
 
-    (utxo, _) <- bench "utxo statistics" $ do
-        pure $ computeUtxoStatistics log10 (totalUTxO pending cp)
+    (utxo, _) <- bench "utxo statistics" $
+        pure $ UTxOStatistics.compute UTxOStatistics.log10
+            (totalUTxO pending cp)
 
     (addresses, listAddressesTime) <- bench "list addresses"
         $ fmap (fromIntegral . length)
@@ -597,8 +599,9 @@ benchmarksSeq _ w wid _wname benchname restoreTime = do
     ((cp, pending), readWalletTime) <- bench "read wallet" $ do
         (cp, _, pending) <- unsafeRunExceptT $ W.readWallet w wid
         pure (cp, pending)
-    (utxo, _) <- bench "utxo statistics" $ do
-        pure $ computeUtxoStatistics log10 (totalUTxO pending cp)
+    (utxo, _) <- bench "utxo statistics" $
+        pure $ UTxOStatistics.compute UTxOStatistics.log10
+            (totalUTxO pending cp)
 
     (addresses, listAddressesTime) <- bench "list addresses"
         $ fmap (fromIntegral . length)

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -319,6 +319,7 @@ library
     Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
     Cardano.Wallet.Primitive.Types.UTxOSelection
     Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
+    Cardano.Wallet.Primitive.Types.UTxOStatistics
     Cardano.Wallet.Read
     Cardano.Wallet.Read.Eras
     Cardano.Wallet.Read.Eras.EraFun

--- a/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
@@ -340,7 +340,7 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
-    ( HistogramBar (..), UTxOStatistics (..), computeUtxoStatistics, log10 )
+    ( HistogramBar (..), UTxOStatistics (..) )
 import Control.Arrow
     ( second )
 import Control.Monad
@@ -467,6 +467,7 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
+import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
@@ -610,7 +611,7 @@ expectWalletUTxO coins = \case
                 )
         let utxo = UTxO $ Map.fromList $ zipWith constructUtxoEntry [0..] coins
         let (UTxOStatistics hist stakes bType) =
-                computeUtxoStatistics log10 utxo
+                UTxOStatistics.compute UTxOStatistics.log10 utxo
         let distr = Map.fromList $ map (\(HistogramBar k v)-> (k,v)) hist
         (ApiUtxoStatistics (Quantity (fromIntegral stakes)) (ApiT bType) distr)
             `shouldBe` stats

--- a/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
@@ -338,12 +338,9 @@ import Cardano.Wallet.Primitive.Types.Tx
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin, txOutMinCoin )
 import Cardano.Wallet.Primitive.Types.UTxO
-    ( HistogramBar (..)
-    , UTxO (..)
-    , UTxOStatistics (..)
-    , computeUtxoStatistics
-    , log10
-    )
+    ( UTxO (..) )
+import Cardano.Wallet.Primitive.Types.UTxOStatistics
+    ( HistogramBar (..), UTxOStatistics (..), computeUtxoStatistics, log10 )
 import Control.Arrow
     ( second )
 import Control.Monad

--- a/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
@@ -610,8 +610,7 @@ expectWalletUTxO coins = \case
                 , TxOut addr (TokenBundle.fromCoin $ Coin c)
                 )
         let utxo = UTxO $ Map.fromList $ zipWith constructUtxoEntry [0..] coins
-        let (UTxOStatistics hist stakes bType) =
-                UTxOStatistics.compute UTxOStatistics.log10 utxo
+        let (UTxOStatistics hist stakes bType) = UTxOStatistics.compute utxo
         let distr = Map.fromList $ map (\(HistogramBar k v)-> (k,v)) hist
         (ApiUtxoStatistics (Quantity (fromIntegral stakes)) (ApiT bType) distr)
             `shouldBe` stats

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -458,7 +458,7 @@ import Cardano.Wallet.Primitive.Types.UTxOIndex
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
-    ( UTxOStatistics, computeUtxoStatistics, log10 )
+    ( UTxOStatistics )
 import Cardano.Wallet.Read.Tx.CBOR
     ( TxCBOR )
 import Cardano.Wallet.Shelley.Compatibility
@@ -625,6 +625,7 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
+import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Data.ByteArray as BA
 import qualified Data.Foldable as F
 import qualified Data.List as L
@@ -946,7 +947,7 @@ listUtxoStatistics ctx wid = do
     (wal, _, pending) <- withExceptT
         ErrListUTxOStatisticsNoSuchWallet (readWallet @ctx @s @k ctx wid)
     let utxo = availableUTxO @s pending wal
-    pure $ computeUtxoStatistics log10 utxo
+    pure $ UTxOStatistics.compute UTxOStatistics.log10 utxo
 
 -- | Restore a wallet from its current tip.
 --

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -947,7 +947,7 @@ listUtxoStatistics ctx wid = do
     (wal, _, pending) <- withExceptT
         ErrListUTxOStatisticsNoSuchWallet (readWallet @ctx @s @k ctx wid)
     let utxo = availableUTxO @s pending wal
-    pure $ UTxOStatistics.compute UTxOStatistics.log10 utxo
+    pure $ UTxOStatistics.compute utxo
 
 -- | Restore a wallet from its current tip.
 --

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -452,11 +452,13 @@ import Cardano.Wallet.Primitive.Types.Tx
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxSize (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
-    ( UTxO (..), UTxOStatistics, computeUtxoStatistics, log10 )
+    ( UTxO (..) )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( UTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
+import Cardano.Wallet.Primitive.Types.UTxOStatistics
+    ( UTxOStatistics, computeUtxoStatistics, log10 )
 import Cardano.Wallet.Read.Tx.CBOR
     ( TxCBOR )
 import Cardano.Wallet.Shelley.Compatibility

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -56,14 +55,6 @@ module Cardano.Wallet.Primitive.Types.UTxO
     , mapTxIds
     , removeAssetId
 
-    -- * UTxO Statistics
-    , UTxOStatistics (..)
-    , BoundType
-    , HistogramBar (..)
-
-    , computeStatistics
-    , computeUtxoStatistics
-    , log10
     ) where
 
 import Prelude hiding
@@ -89,25 +80,17 @@ import Data.Functor.Identity
     ( runIdentity )
 import Data.Generics.Internal.VL.Lens
     ( over, view )
-import Data.List.NonEmpty
-    ( NonEmpty (..) )
 import Data.Map.Strict
     ( Map )
 import Data.Set
     ( Set )
-import Data.Word
-    ( Word64 )
 import Fmt
-    ( Buildable (..), blockListF', blockMapF, padRightF, tupleF )
+    ( Buildable (..), blockListF', blockMapF )
 import GHC.Generics
     ( Generic )
 
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TB
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
-import qualified Control.Foldl as F
-import qualified Data.List as L
-import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
@@ -308,126 +291,3 @@ mapTxIds f (UTxO u) = UTxO $ Map.mapKeysWith min (over #inputId f) u
 
 removeAssetId :: UTxO -> AssetId -> UTxO
 removeAssetId (UTxO u) a = UTxO $ Map.map (`TxOut.removeAssetId` a) u
-
---------------------------------------------------------------------------------
--- UTxO Statistics
---------------------------------------------------------------------------------
-
-data UTxOStatistics = UTxOStatistics
-    { histogram :: ![HistogramBar]
-    , allStakes :: !Word64
-    , boundType :: BoundType
-    } deriving (Show, Generic, Ord)
-
-instance NFData UTxOStatistics
-
--- Example output:
---
--- @
---    = Total value of 14061000005 lovelace across 7 UTxOs
---     ... 10                2
---     ... 100               0
---     ... 1000              0
---     ... 10000             0
---     ... 100000            0
---     ... 1000000           0
---     ... 10000000          0
---     ... 100000000         2
---     ... 1000000000        0
---     ... 10000000000       3
---     ... 100000000000      0
---     ... 1000000000000     0
---     ... 10000000000000    0
---     ... 100000000000000   0
---     ... 1000000000000000  0
---     ... 10000000000000000 0
---     ... 45000000000000000 0
---  @
-instance Buildable UTxOStatistics where
-    build (UTxOStatistics hist val _) = mconcat
-        [ "= Total value of "
-        , build val
-        , " lovelace across "
-        , wordF $ sum $ map bucketCount hist
-        , " UTxOs"
-        , "\n"
-        , blockListF' "" buildBar hist
-        ]
-      where
-        buildBar (HistogramBar b c) =
-            -- NOTE: Picked to fit well with the max value of Lovelace.
-            "... " <> (padRightF 17 ' ' b) <> " " <> wordF c
-
-        -- This is a workaround for the fact that:
-        -- > fmt (build (0::Word)) == "-0"
-        wordF = build . toInteger
-
-instance Eq UTxOStatistics where
-    (UTxOStatistics h s _) == (UTxOStatistics h' s' _) =
-        s == s' && sorted h == sorted h'
-      where
-        sorted :: [HistogramBar] -> [HistogramBar]
-        sorted = L.sortOn (\(HistogramBar key _) -> key)
-
--- An 'HistogramBar' captures the value of a particular bucket. It specifies
--- the bucket upper bound, and its corresponding distribution (on the y-axis).
-data HistogramBar = HistogramBar
-    { bucketUpperBound :: !Word64
-    , bucketCount      :: !Word64
-    } deriving (Show, Eq, Ord, Generic)
-
-instance NFData HistogramBar
-
-instance Buildable HistogramBar where
-    build (HistogramBar k v) = tupleF (k, v)
-
---  Buckets boundaries can be constructed in different ways
-data BoundType = Log10 deriving (Eq, Show, Ord, Generic)
-
-instance NFData BoundType
-
--- | Smart-constructor to create bounds using a log-10 scale
-log10 :: BoundType
-log10 = Log10
-{-# INLINE log10 #-}
-
--- | Compute UtxoStatistics from UTxOs
-computeUtxoStatistics :: BoundType -> UTxO -> UTxOStatistics
-computeUtxoStatistics btype
-    = computeStatistics (pure . Coin.unsafeToWord64 . TxOut.coin) btype
-    . Map.elems
-    . unUTxO
-
--- | A more generic function for computing UTxO statistics on some other type of
--- data that maps to UTxO's values.
-computeStatistics :: (a -> [Word64]) -> BoundType -> [a] -> UTxOStatistics
-computeStatistics getCoins btype utxos =
-    (F.fold foldStatistics (mconcat $ getCoins <$> utxos)) btype
-  where
-    foldStatistics :: F.Fold Word64 (BoundType -> UTxOStatistics)
-    foldStatistics = UTxOStatistics
-        <$> foldBuckets (generateBounds btype)
-        <*> F.sum
-
-    foldBuckets :: NonEmpty Word64 -> F.Fold Word64 [HistogramBar]
-    foldBuckets bounds =
-        let
-            step :: Map Word64 Word64 -> Word64 -> Map Word64 Word64
-            step x a = case Map.lookupGE a x of
-                Just (k, v) -> Map.insert k (v+1) x
-                Nothing -> Map.adjust (+1) (NE.head bounds) x
-            initial :: Map Word64 Word64
-            initial =
-                Map.fromList $ zip (NE.toList bounds) (repeat 0)
-            extract :: Map Word64 Word64 -> [HistogramBar]
-            extract =
-                map (uncurry HistogramBar) . Map.toList
-        in
-            F.Fold step initial extract
-
-    generateBounds :: BoundType -> NonEmpty Word64
-    generateBounds = \case
-        Log10 -> NE.fromList $ map (10 ^!) [1..16] ++ [45 * (10 ^! 15)]
-
-    (^!) :: Word64 -> Word64 -> Word64
-    (^!) = (^)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxOStatistics.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxOStatistics.hs
@@ -12,7 +12,6 @@ module Cardano.Wallet.Primitive.Types.UTxOStatistics
     , BoundType
     , HistogramBar (..)
     , compute
-    , computeWith
     ) where
 
 import Prelude

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxOStatistics.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxOStatistics.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK
+-- License: Apache-2.0
+--
+-- This module provides the 'UTxOStatistics' type.
+--
+module Cardano.Wallet.Primitive.Types.UTxOStatistics
+    ( UTxOStatistics (..)
+    , BoundType
+    , HistogramBar (..)
+    , computeStatistics
+    , computeUtxoStatistics
+    , log10
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.UTxO
+    ( UTxO (..) )
+import Control.DeepSeq
+    ( NFData (..) )
+import Data.List.NonEmpty
+    ( NonEmpty (..) )
+import Data.Map.Strict
+    ( Map )
+import Data.Word
+    ( Word64 )
+import Fmt
+    ( Buildable (..), blockListF', padRightF, tupleF )
+import GHC.Generics
+    ( Generic )
+
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
+import qualified Control.Foldl as F
+import qualified Data.List as L
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
+
+data UTxOStatistics = UTxOStatistics
+    { histogram :: ![HistogramBar]
+    , allStakes :: !Word64
+    , boundType :: BoundType
+    } deriving (Show, Generic, Ord)
+
+instance NFData UTxOStatistics
+
+-- Example output:
+--
+-- @
+--    = Total value of 14061000005 lovelace across 7 UTxOs
+--     ... 10                2
+--     ... 100               0
+--     ... 1000              0
+--     ... 10000             0
+--     ... 100000            0
+--     ... 1000000           0
+--     ... 10000000          0
+--     ... 100000000         2
+--     ... 1000000000        0
+--     ... 10000000000       3
+--     ... 100000000000      0
+--     ... 1000000000000     0
+--     ... 10000000000000    0
+--     ... 100000000000000   0
+--     ... 1000000000000000  0
+--     ... 10000000000000000 0
+--     ... 45000000000000000 0
+--  @
+instance Buildable UTxOStatistics where
+    build (UTxOStatistics hist val _) = mconcat
+        [ "= Total value of "
+        , build val
+        , " lovelace across "
+        , wordF $ sum $ map bucketCount hist
+        , " UTxOs"
+        , "\n"
+        , blockListF' "" buildBar hist
+        ]
+      where
+        buildBar (HistogramBar b c) =
+            -- NOTE: Picked to fit well with the max value of Lovelace.
+            "... " <> (padRightF 17 ' ' b) <> " " <> wordF c
+
+        -- This is a workaround for the fact that:
+        -- > fmt (build (0::Word)) == "-0"
+        wordF = build . toInteger
+
+instance Eq UTxOStatistics where
+    (UTxOStatistics h s _) == (UTxOStatistics h' s' _) =
+        s == s' && sorted h == sorted h'
+      where
+        sorted :: [HistogramBar] -> [HistogramBar]
+        sorted = L.sortOn (\(HistogramBar key _) -> key)
+
+-- An 'HistogramBar' captures the value of a particular bucket. It specifies
+-- the bucket upper bound, and its corresponding distribution (on the y-axis).
+data HistogramBar = HistogramBar
+    { bucketUpperBound :: !Word64
+    , bucketCount      :: !Word64
+    } deriving (Show, Eq, Ord, Generic)
+
+instance NFData HistogramBar
+
+instance Buildable HistogramBar where
+    build (HistogramBar k v) = tupleF (k, v)
+
+--  Buckets boundaries can be constructed in different ways
+data BoundType = Log10 deriving (Eq, Show, Ord, Generic)
+
+instance NFData BoundType
+
+-- | Smart-constructor to create bounds using a log-10 scale
+log10 :: BoundType
+log10 = Log10
+{-# INLINE log10 #-}
+
+-- | Compute UtxoStatistics from UTxOs
+computeUtxoStatistics :: BoundType -> UTxO -> UTxOStatistics
+computeUtxoStatistics btype
+    = computeStatistics (pure . Coin.unsafeToWord64 . TxOut.coin) btype
+    . Map.elems
+    . unUTxO
+
+-- | A more generic function for computing UTxO statistics on some other type of
+-- data that maps to UTxO's values.
+computeStatistics :: (a -> [Word64]) -> BoundType -> [a] -> UTxOStatistics
+computeStatistics getCoins btype utxos =
+    (F.fold foldStatistics (mconcat $ getCoins <$> utxos)) btype
+  where
+    foldStatistics :: F.Fold Word64 (BoundType -> UTxOStatistics)
+    foldStatistics = UTxOStatistics
+        <$> foldBuckets (generateBounds btype)
+        <*> F.sum
+
+    foldBuckets :: NonEmpty Word64 -> F.Fold Word64 [HistogramBar]
+    foldBuckets bounds =
+        let
+            step :: Map Word64 Word64 -> Word64 -> Map Word64 Word64
+            step x a = case Map.lookupGE a x of
+                Just (k, v) -> Map.insert k (v+1) x
+                Nothing -> Map.adjust (+1) (NE.head bounds) x
+            initial :: Map Word64 Word64
+            initial =
+                Map.fromList $ zip (NE.toList bounds) (repeat 0)
+            extract :: Map Word64 Word64 -> [HistogramBar]
+            extract =
+                map (uncurry HistogramBar) . Map.toList
+        in
+            F.Fold step initial extract
+
+    generateBounds :: BoundType -> NonEmpty Word64
+    generateBounds = \case
+        Log10 -> NE.fromList $ map (10 ^!) [1..16] ++ [45 * (10 ^! 15)]
+
+    (^!) :: Word64 -> Word64 -> Word64
+    (^!) = (^)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxOStatistics.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxOStatistics.hs
@@ -119,9 +119,9 @@ log10 = Log10
 {-# INLINE log10 #-}
 
 -- | Computes a 'UTxOStatistics' object from a 'UTxO' set.
-compute :: BoundType -> UTxO -> UTxOStatistics
-compute btype
-    = computeWith (pure . Coin.unsafeToWord64 . TxOut.coin) btype
+compute :: UTxO -> UTxOStatistics
+compute
+    = computeWith (pure . Coin.unsafeToWord64 . TxOut.coin) log10
     . Map.elems
     . unUTxO
 

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxOStatistics.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxOStatistics.hs
@@ -96,7 +96,7 @@ instance Eq UTxOStatistics where
         sorted :: [HistogramBar] -> [HistogramBar]
         sorted = L.sortOn (\(HistogramBar key _) -> key)
 
--- An 'HistogramBar' captures the value of a particular bucket. It specifies
+-- | A 'HistogramBar' captures the value of a particular bucket. It specifies
 -- the bucket upper bound, and its corresponding distribution (on the y-axis).
 data HistogramBar = HistogramBar
     { bucketUpperBound :: !Word64
@@ -108,25 +108,24 @@ instance NFData HistogramBar
 instance Buildable HistogramBar where
     build (HistogramBar k v) = tupleF (k, v)
 
---  Buckets boundaries can be constructed in different ways
+-- | A method of distributing values into buckets.
 data BoundType = Log10 deriving (Eq, Show, Ord, Generic)
 
 instance NFData BoundType
 
--- | Smart-constructor to create bounds using a log-10 scale
+-- | Smart constructor to create bounds using a log-10 scale.
 log10 :: BoundType
 log10 = Log10
 {-# INLINE log10 #-}
 
--- | Compute UtxoStatistics from UTxOs
+-- | Computes a 'UTxOStatistics' object from a 'UTxO' set.
 computeUtxoStatistics :: BoundType -> UTxO -> UTxOStatistics
 computeUtxoStatistics btype
     = computeStatistics (pure . Coin.unsafeToWord64 . TxOut.coin) btype
     . Map.elems
     . unUTxO
 
--- | A more generic function for computing UTxO statistics on some other type of
--- data that maps to UTxO's values.
+-- | Computes a 'UTxOStatistics' object from an abstract source of values.
 computeStatistics :: (a -> [Word64]) -> BoundType -> [a] -> UTxOStatistics
 computeStatistics getCoins btype utxos =
     (F.fold foldStatistics (mconcat $ getCoins <$> utxos)) btype

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxOStatistics.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxOStatistics.hs
@@ -13,7 +13,6 @@ module Cardano.Wallet.Primitive.Types.UTxOStatistics
     , HistogramBar (..)
     , compute
     , computeWith
-    , log10
     ) where
 
 import Prelude
@@ -113,15 +112,10 @@ data BoundType = Log10 deriving (Eq, Show, Ord, Generic)
 
 instance NFData BoundType
 
--- | Smart constructor to create bounds using a log-10 scale.
-log10 :: BoundType
-log10 = Log10
-{-# INLINE log10 #-}
-
 -- | Computes a 'UTxOStatistics' object from a 'UTxO' set.
 compute :: UTxO -> UTxOStatistics
 compute
-    = computeWith (pure . Coin.unsafeToWord64 . TxOut.coin) log10
+    = computeWith (pure . Coin.unsafeToWord64 . TxOut.coin) Log10
     . Map.elems
     . unUTxO
 

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxOStatistics.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxOStatistics.hs
@@ -11,8 +11,8 @@ module Cardano.Wallet.Primitive.Types.UTxOStatistics
     ( UTxOStatistics (..)
     , BoundType
     , HistogramBar (..)
-    , computeStatistics
-    , computeUtxoStatistics
+    , compute
+    , computeWith
     , log10
     ) where
 
@@ -119,15 +119,15 @@ log10 = Log10
 {-# INLINE log10 #-}
 
 -- | Computes a 'UTxOStatistics' object from a 'UTxO' set.
-computeUtxoStatistics :: BoundType -> UTxO -> UTxOStatistics
-computeUtxoStatistics btype
-    = computeStatistics (pure . Coin.unsafeToWord64 . TxOut.coin) btype
+compute :: BoundType -> UTxO -> UTxOStatistics
+compute btype
+    = computeWith (pure . Coin.unsafeToWord64 . TxOut.coin) btype
     . Map.elems
     . unUTxO
 
 -- | Computes a 'UTxOStatistics' object from an abstract source of values.
-computeStatistics :: (a -> [Word64]) -> BoundType -> [a] -> UTxOStatistics
-computeStatistics getCoins btype utxos =
+computeWith :: (a -> [Word64]) -> BoundType -> [a] -> UTxOStatistics
+computeWith getCoins btype utxos =
     (F.fold foldStatistics (mconcat $ getCoins <$> utxos)) btype
   where
     foldStatistics :: F.Fold Word64 (BoundType -> UTxOStatistics)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxOStatistics.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxOStatistics.hs
@@ -136,20 +136,16 @@ computeStatistics getCoins btype utxos =
         <*> F.sum
 
     foldBuckets :: NonEmpty Word64 -> F.Fold Word64 [HistogramBar]
-    foldBuckets bounds =
-        let
-            step :: Map Word64 Word64 -> Word64 -> Map Word64 Word64
-            step x a = case Map.lookupGE a x of
-                Just (k, v) -> Map.insert k (v+1) x
-                Nothing -> Map.adjust (+1) (NE.head bounds) x
-            initial :: Map Word64 Word64
-            initial =
-                Map.fromList $ zip (NE.toList bounds) (repeat 0)
-            extract :: Map Word64 Word64 -> [HistogramBar]
-            extract =
-                map (uncurry HistogramBar) . Map.toList
-        in
-            F.Fold step initial extract
+    foldBuckets bounds = F.Fold step initial extract
+      where
+        step :: Map Word64 Word64 -> Word64 -> Map Word64 Word64
+        step x a = case Map.lookupGE a x of
+            Just (k, v) -> Map.insert k (v+1) x
+            Nothing -> Map.adjust (+1) (NE.head bounds) x
+        initial :: Map Word64 Word64
+        initial = Map.fromList $ zip (NE.toList bounds) (repeat 0)
+        extract :: Map Word64 Word64 -> [HistogramBar]
+        extract = map (uncurry HistogramBar) . Map.toList
 
     generateBounds :: BoundType -> NonEmpty Word64
     generateBounds = \case

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -2300,7 +2300,7 @@ instance Arbitrary ApiUtxoStatistics where
     arbitrary = do
         utxos <- arbitrary
         let (UTxOStatistics histoBars stakes bType) =
-                UTxOStatistics.compute UTxOStatistics.log10 utxos
+                UTxOStatistics.compute utxos
         let boundCountMap =
                 Map.fromList $ map (\(HistogramBar k v)-> (k,v)) histoBars
         return $ ApiUtxoStatistics

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -336,12 +336,9 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTxOutCoin, genTxScriptValidity, shrinkTxScriptValidity )
 import Cardano.Wallet.Primitive.Types.UTxO
-    ( HistogramBar (..)
-    , UTxO (..)
-    , UTxOStatistics (..)
-    , computeUtxoStatistics
-    , log10
-    )
+    ( UTxO (..) )
+import Cardano.Wallet.Primitive.Types.UTxOStatistics
+    ( HistogramBar (..), UTxOStatistics (..), computeUtxoStatistics, log10 )
 import Cardano.Wallet.Shelley.Network.Discriminant
     ( DecodeAddress (..)
     , DecodeStakeAddress (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -338,7 +338,7 @@ import Cardano.Wallet.Primitive.Types.Tx.Gen
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
-    ( HistogramBar (..), UTxOStatistics (..), computeUtxoStatistics, log10 )
+    ( HistogramBar (..), UTxOStatistics (..) )
 import Cardano.Wallet.Shelley.Network.Discriminant
     ( DecodeAddress (..)
     , DecodeStakeAddress (..)
@@ -502,6 +502,7 @@ import Web.HttpApiData
 
 import qualified Cardano.Wallet.Api.Types as Api
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
 import qualified Data.Aeson.KeyMap as Aeson
@@ -2299,7 +2300,7 @@ instance Arbitrary ApiUtxoStatistics where
     arbitrary = do
         utxos <- arbitrary
         let (UTxOStatistics histoBars stakes bType) =
-                computeUtxoStatistics log10 utxos
+                UTxOStatistics.compute UTxOStatistics.log10 utxos
         let boundCountMap =
                 Map.fromList $ map (\(HistogramBar k v)-> (k,v)) histoBars
         return $ ApiUtxoStatistics

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -114,7 +114,7 @@ import Cardano.Wallet.Primitive.Types.UTxO
     , restrictedTo
     )
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
-    ( BoundType, HistogramBar (..), UTxOStatistics (..) )
+    ( HistogramBar (..), UTxOStatistics (..) )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic )
 import Cardano.Wallet.Util
@@ -1220,10 +1220,6 @@ instance Arbitrary WalletName where
     shrink (WalletName t)
         | T.length t <= walletNameMinLength = []
         | otherwise = [WalletName $ T.take walletNameMinLength t]
-
-instance Arbitrary BoundType where
-    shrink = genericShrink
-    arbitrary = genericArbitrary
 
 instance Arbitrary SlotLength where
     shrink (SlotLength t) =

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -105,18 +105,20 @@ import Cardano.Wallet.Primitive.Types.Tx.Tx
 import Cardano.Wallet.Primitive.Types.Tx.TxMeta
     ( Direction (..), TxMeta (..), TxStatus (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
-    ( BoundType
-    , HistogramBar (..)
-    , UTxO (..)
-    , UTxOStatistics (..)
+    ( UTxO (..)
     , balance
-    , computeUtxoStatistics
     , dom
     , excluding
     , isSubsetOf
-    , log10
     , restrictedBy
     , restrictedTo
+    )
+import Cardano.Wallet.Primitive.Types.UTxOStatistics
+    ( BoundType
+    , HistogramBar (..)
+    , UTxOStatistics (..)
+    , computeUtxoStatistics
+    , log10
     )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic )


### PR DESCRIPTION
## Issue Number

ADP-2386

## Description

This PR:
- moves the `UTxOStatistics` type (and related functions) to a dedicated module of its own.
- simplifies the interface of the `UTxOStatistics` module.

## Motivation

1. Establish a clearer abstraction boundary for the `UTxO` type: all functions within the `UTxO` module now just relate to the `UTxO` type, rather than being an ad-hoc mixture of functions relating to two different types.
2. Make it possible for the `UTxO` type to be moved to a different internal library without bringing extra baggage along with it.

## Context

We wish to move all coin selection modules to a separate internal `coin-selection` library. However, coin selection (currently) also depends on other types that are not exclusively related to coin selection. We plan (over time) to minimise this dependency footprint, and eventually eliminate it. Coin selection (and by extension `balanceTransaction`) currently depends on the `UTxO` type, but it does not depend on the `UTxOStatistics` type.