### PR TITLE
Split off modules `TxIn.Gen` and `TxOut.Gen`.

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -308,6 +308,7 @@ library
     Cardano.Wallet.Primitive.Types.Tx.TransactionInfo
     Cardano.Wallet.Primitive.Types.Tx.Tx
     Cardano.Wallet.Primitive.Types.Tx.TxIn
+    Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     Cardano.Wallet.Primitive.Types.Tx.TxMeta
     Cardano.Wallet.Primitive.Types.Tx.TxOut
     Cardano.Wallet.Primitive.Types.Tx.TxSeq

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -311,6 +311,7 @@ library
     Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     Cardano.Wallet.Primitive.Types.Tx.TxMeta
     Cardano.Wallet.Primitive.Types.Tx.TxOut
+    Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     Cardano.Wallet.Primitive.Types.Tx.TxSeq
     Cardano.Wallet.Primitive.Types.Tx.TxSeq.Gen
     Cardano.Wallet.Primitive.Types.UTxO

--- a/lib/wallet/src/Cardano/Wallet/CoinSelection.hs
+++ b/lib/wallet/src/Cardano/Wallet/CoinSelection.hs
@@ -107,10 +107,12 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( Flat (..), TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId, TokenMap )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn, TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TokenBundleSizeAssessment, txOutMaxCoin, txOutMaxTokenQuantity )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Primitive.Types.UTxOSelection

--- a/lib/wallet/src/Cardano/Wallet/CoinSelection/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/CoinSelection/Gen.hs
@@ -13,7 +13,7 @@ import Cardano.Wallet.CoinSelection
     ( WalletUTxO (..) )
 import Cardano.Wallet.Primitive.Types.Address.Gen
     ( genAddress, shrinkAddress )
-import Cardano.Wallet.Primitive.Types.Tx.Gen
+import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxIn, genTxInLargeRange, shrinkTxIn )
 import Generics.SOP
     ( NP (..) )

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -7,13 +7,8 @@
 
 module Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTx
-    , genTxOut
-    , genTxOutCoin
-    , genTxOutTokenBundle
     , genTxScriptValidity
     , shrinkTx
-    , shrinkTxOut
-    , shrinkTxOutCoin
     , shrinkTxScriptValidity
     , TxWithoutId (..)
     , txWithoutIdToTx
@@ -24,8 +19,6 @@ import Prelude
 
 import Cardano.Wallet.Gen
     ( genNestedTxMetadata, shrinkTxMetadata )
-import Cardano.Wallet.Primitive.Types.Address.Gen
-    ( genAddress, shrinkAddress )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
@@ -36,27 +29,12 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount.Gen
     ( genRewardAccount, shrinkRewardAccount )
-import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( TokenBundle )
-import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
-    ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
-import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetIdLargeRange )
-import Cardano.Wallet.Primitive.Types.TokenQuantity
-    ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..), TxIn (..), TxMetadata (..), TxOut (..), TxScriptValidity (..) )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( coinIsValidForTxOut
-    , txOutMaxCoin
-    , txOutMaxTokenQuantity
-    , txOutMinCoin
-    , txOutMinTokenQuantity
-    )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxIn, shrinkTxIn )
-import Control.Monad
-    ( replicateM )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
+    ( genTxOut, shrinkTxOut )
 import Data.Map.Strict
     ( Map )
 import Generics.SOP
@@ -65,35 +43,19 @@ import GHC.Generics
     ( Generic )
 import Test.QuickCheck
     ( Gen
-    , choose
-    , frequency
     , liftArbitrary
     , liftArbitrary2
     , liftShrink
     , liftShrink2
     , listOf
     , listOf1
-    , oneof
     , shrinkList
     , shrinkMapBy
-    , suchThat
     )
 import Test.QuickCheck.Arbitrary.Generic
     ( genericArbitrary, genericShrink )
 import Test.QuickCheck.Extra
-    ( chooseNatural
-    , genMapWith
-    , genericRoundRobinShrink
-    , shrinkInterleaved
-    , shrinkMapWith
-    , shrinkNatural
-    , (<:>)
-    , (<@>)
-    )
-
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
-import qualified Data.List as L
+    ( genMapWith, genericRoundRobinShrink, shrinkMapWith, (<:>), (<@>) )
 
 --------------------------------------------------------------------------------
 -- Transactions generated according to the size parameter
@@ -152,81 +114,3 @@ genTxScriptValidity = genericArbitrary
 
 shrinkTxScriptValidity :: TxScriptValidity -> [TxScriptValidity]
 shrinkTxScriptValidity = genericShrink
-
---------------------------------------------------------------------------------
--- Transaction outputs generated according to the size parameter
---------------------------------------------------------------------------------
-
-genTxOut :: Gen TxOut
-genTxOut = TxOut
-    <$> genAddress
-    <*> genTokenBundleSmallRange `suchThat` tokenBundleHasNonZeroCoin
-
-shrinkTxOut :: TxOut -> [TxOut]
-shrinkTxOut (TxOut a b) = uncurry TxOut <$> shrinkInterleaved
-    (a, shrinkAddress)
-    (b, filter tokenBundleHasNonZeroCoin . shrinkTokenBundleSmallRange)
-
-tokenBundleHasNonZeroCoin :: TokenBundle -> Bool
-tokenBundleHasNonZeroCoin b = TokenBundle.getCoin b /= Coin 0
-
---------------------------------------------------------------------------------
--- Coins chosen from the full range allowed in a transaction output
---------------------------------------------------------------------------------
-
--- | Generates coins across the full range allowed in a transaction output.
---
--- This generator has a slight bias towards the limits of the range, but
--- otherwise generates values uniformly across the whole range.
---
--- This can be useful when testing roundtrip conversions between different
--- types.
---
-genTxOutCoin :: Gen Coin
-genTxOutCoin = frequency
-    [ (1, pure txOutMinCoin)
-    , (1, pure txOutMaxCoin)
-    , (8, Coin.fromNatural <$> chooseNatural
-        ( Coin.toNatural txOutMinCoin + 1
-        , Coin.toNatural txOutMaxCoin - 1
-        )
-      )
-    ]
-
-shrinkTxOutCoin :: Coin -> [Coin]
-shrinkTxOutCoin
-    = L.filter coinIsValidForTxOut
-    . shrinkMapBy Coin.fromNatural Coin.toNatural shrinkNatural
-
---------------------------------------------------------------------------------
--- Token bundles with fixed numbers of assets.
---
--- Values are chosen from across the full range of values permitted within
--- transaction outputs.
---
--- Policy identifiers, asset names, token quantities are all allowed to vary.
---------------------------------------------------------------------------------
-
-genTxOutTokenBundle :: Int -> Gen TokenBundle
-genTxOutTokenBundle fixedAssetCount
-    = TokenBundle.fromFlatList
-        <$> genTxOutCoin
-        <*> replicateM fixedAssetCount genAssetQuantity
-  where
-    genAssetQuantity = (,)
-        <$> genAssetIdLargeRange
-        <*> genTokenQuantity
-    genTokenQuantity = integerToTokenQuantity <$> oneof
-        [ pure $ tokenQuantityToInteger txOutMinTokenQuantity
-        , pure $ tokenQuantityToInteger txOutMaxTokenQuantity
-        , choose
-            ( tokenQuantityToInteger txOutMinTokenQuantity + 1
-            , tokenQuantityToInteger txOutMaxTokenQuantity - 1
-            )
-        ]
-      where
-        tokenQuantityToInteger :: TokenQuantity -> Integer
-        tokenQuantityToInteger = fromIntegral . unTokenQuantity
-
-        integerToTokenQuantity :: Integer -> TokenQuantity
-        integerToTokenQuantity = TokenQuantity . fromIntegral

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxIn/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxIn/Gen.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
+
+module Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
+    ( coarbitraryTxIn
+    , genTxHash
+    , genTxIndex
+    , genTxIn
+    , genTxInFunction
+    , genTxInLargeRange
+    , shrinkTxHash
+    , shrinkTxIndex
+    , shrinkTxIn
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Control.Monad
+    ( replicateM )
+import Data.Either
+    ( fromRight )
+import Data.Text.Class
+    ( FromText (..) )
+import Data.Word
+    ( Word16, Word32 )
+import Test.QuickCheck
+    ( Gen, arbitrary, coarbitrary, elements, sized )
+import Test.QuickCheck.Extra
+    ( genFunction, genSized2With, shrinkInterleaved )
+
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text as T
+
+--------------------------------------------------------------------------------
+-- Transaction hashes generated according to the size parameter
+--------------------------------------------------------------------------------
+
+genTxHash :: Gen (Hash "Tx")
+genTxHash = sized $ \size -> elements $ take (max 1 size) txHashes
+
+shrinkTxHash :: Hash "Tx" -> [Hash "Tx"]
+shrinkTxHash x
+    | x == simplest = []
+    | otherwise = [simplest]
+  where
+    simplest = head txHashes
+
+txHashes :: [Hash "Tx"]
+txHashes = mkTxHash <$> ['0' .. '9'] <> ['A' .. 'F']
+
+--------------------------------------------------------------------------------
+-- Transaction hashes chosen from a large range (to minimize collisions)
+--------------------------------------------------------------------------------
+
+genTxHashLargeRange :: Gen (Hash "Tx")
+genTxHashLargeRange = Hash . B8.pack <$> replicateM 32 arbitrary
+
+--------------------------------------------------------------------------------
+-- Transaction indices generated according to the size parameter
+--------------------------------------------------------------------------------
+
+genTxIndex :: Gen Word32
+genTxIndex = sized $ \size -> elements $ take (max 1 size) txIndices
+
+shrinkTxIndex :: Word32 -> [Word32]
+shrinkTxIndex 0 = []
+shrinkTxIndex _ = [0]
+
+txIndices :: [Word32]
+txIndices =
+    let w16range = [0 ..] :: [Word16]
+    in fromIntegral <$> w16range
+
+--------------------------------------------------------------------------------
+-- Transaction inputs generated according to the size parameter
+--------------------------------------------------------------------------------
+
+genTxIn :: Gen TxIn
+genTxIn = genSized2With TxIn genTxHash genTxIndex
+
+shrinkTxIn :: TxIn -> [TxIn]
+shrinkTxIn (TxIn h i) = uncurry TxIn <$> shrinkInterleaved
+    (h, shrinkTxHash)
+    (i, shrinkTxIndex)
+
+--------------------------------------------------------------------------------
+-- Transaction input functions
+--------------------------------------------------------------------------------
+
+coarbitraryTxIn :: TxIn -> Gen a -> Gen a
+coarbitraryTxIn = coarbitrary . show
+
+genTxInFunction :: Gen a -> Gen (TxIn -> a)
+genTxInFunction = genFunction coarbitraryTxIn
+
+--------------------------------------------------------------------------------
+-- Transaction inputs chosen from a large range (to minimize collisions)
+--------------------------------------------------------------------------------
+
+genTxInLargeRange :: Gen TxIn
+genTxInLargeRange = TxIn
+    <$> genTxHashLargeRange
+    -- Note that we don't need to choose indices from a large range, as hashes
+    -- are already chosen from a large range:
+    <*> genTxIndex
+
+--------------------------------------------------------------------------------
+-- Internal utilities
+--------------------------------------------------------------------------------
+
+-- The input must be a character in the range [0-9] or [A-F].
+--
+mkTxHash :: Char -> Hash "Tx"
+mkTxHash c
+    = fromRight reportError
+    $ fromText
+    $ T.pack
+    $ replicate txHashHexStringLength c
+  where
+    reportError = error $
+        "Unable to generate transaction hash from character: " <> show c
+
+txHashHexStringLength :: Int
+txHashHexStringLength = 64

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxOut/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxOut/Gen.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
+
+module Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
+    ( genTxOut
+    , genTxOutCoin
+    , genTxOutTokenBundle
+    , shrinkTxOut
+    , shrinkTxOutCoin
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Address.Gen
+    ( genAddress, shrinkAddress )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle )
+import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
+    ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
+import Cardano.Wallet.Primitive.Types.TokenMap.Gen
+    ( genAssetIdLargeRange )
+import Cardano.Wallet.Primitive.Types.TokenQuantity
+    ( TokenQuantity (..) )
+import Cardano.Wallet.Primitive.Types.Tx.Constraints
+    ( coinIsValidForTxOut
+    , txOutMaxCoin
+    , txOutMaxTokenQuantity
+    , txOutMinCoin
+    , txOutMinTokenQuantity
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
+import Control.Monad
+    ( replicateM )
+import Test.QuickCheck
+    ( Gen, choose, frequency, oneof, shrinkMapBy, suchThat )
+import Test.QuickCheck.Extra
+    ( chooseNatural, shrinkInterleaved, shrinkNatural )
+
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Data.List as L
+
+--------------------------------------------------------------------------------
+-- Transaction outputs generated according to the size parameter
+--------------------------------------------------------------------------------
+
+genTxOut :: Gen TxOut
+genTxOut = TxOut
+    <$> genAddress
+    <*> genTokenBundleSmallRange `suchThat` tokenBundleHasNonZeroCoin
+
+shrinkTxOut :: TxOut -> [TxOut]
+shrinkTxOut (TxOut a b) = uncurry TxOut <$> shrinkInterleaved
+    (a, shrinkAddress)
+    (b, filter tokenBundleHasNonZeroCoin . shrinkTokenBundleSmallRange)
+
+tokenBundleHasNonZeroCoin :: TokenBundle -> Bool
+tokenBundleHasNonZeroCoin b = TokenBundle.getCoin b /= Coin 0
+
+--------------------------------------------------------------------------------
+-- Coins chosen from the full range allowed in a transaction output
+--------------------------------------------------------------------------------
+
+-- | Generates coins across the full range allowed in a transaction output.
+--
+-- This generator has a slight bias towards the limits of the range, but
+-- otherwise generates values uniformly across the whole range.
+--
+-- This can be useful when testing roundtrip conversions between different
+-- types.
+--
+genTxOutCoin :: Gen Coin
+genTxOutCoin = frequency
+    [ (1, pure txOutMinCoin)
+    , (1, pure txOutMaxCoin)
+    , (8, Coin.fromNatural <$> chooseNatural
+        ( Coin.toNatural txOutMinCoin + 1
+        , Coin.toNatural txOutMaxCoin - 1
+        )
+      )
+    ]
+
+shrinkTxOutCoin :: Coin -> [Coin]
+shrinkTxOutCoin
+    = L.filter coinIsValidForTxOut
+    . shrinkMapBy Coin.fromNatural Coin.toNatural shrinkNatural
+
+--------------------------------------------------------------------------------
+-- Token bundles with fixed numbers of assets.
+--
+-- Values are chosen from across the full range of values permitted within
+-- transaction outputs.
+--
+-- Policy identifiers, asset names, token quantities are all allowed to vary.
+--------------------------------------------------------------------------------
+
+genTxOutTokenBundle :: Int -> Gen TokenBundle
+genTxOutTokenBundle fixedAssetCount
+    = TokenBundle.fromFlatList
+        <$> genTxOutCoin
+        <*> replicateM fixedAssetCount genAssetQuantity
+  where
+    genAssetQuantity = (,)
+        <$> genAssetIdLargeRange
+        <*> genTokenQuantity
+    genTokenQuantity = integerToTokenQuantity <$> oneof
+        [ pure $ tokenQuantityToInteger txOutMinTokenQuantity
+        , pure $ tokenQuantityToInteger txOutMaxTokenQuantity
+        , choose
+            ( tokenQuantityToInteger txOutMinTokenQuantity + 1
+            , tokenQuantityToInteger txOutMaxTokenQuantity - 1
+            )
+        ]
+      where
+        tokenQuantityToInteger :: TokenQuantity -> Integer
+        tokenQuantityToInteger = fromIntegral . unTokenQuantity
+
+        integerToTokenQuantity :: Integer -> TokenQuantity
+        integerToTokenQuantity = TokenQuantity . fromIntegral

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -77,8 +77,10 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn, TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Control.DeepSeq
     ( NFData (..) )
 import Data.Bifunctor

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxO/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxO/Gen.hs
@@ -11,7 +11,9 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxIn, TxOut )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxIn, genTxInLargeRange, genTxOut, shrinkTxIn, shrinkTxOut )
+    ( genTxOut, shrinkTxOut )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
+    ( genTxIn, genTxInLargeRange, shrinkTxIn )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Control.Monad

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxO/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/UTxO/Gen.hs
@@ -8,12 +8,14 @@ module Cardano.Wallet.Primitive.Types.UTxO.Gen
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn, TxOut )
-import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxOut, shrinkTxOut )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxIn, genTxInLargeRange, shrinkTxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
+    ( genTxOut, shrinkTxOut )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Control.Monad

--- a/lib/wallet/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/wallet/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -49,7 +49,7 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
-import Cardano.Wallet.Primitive.Types.Tx.Gen
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     ( genTxOutCoin, shrinkTxOutCoin )
 import Control.Arrow
     ( second )

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -334,7 +334,9 @@ import Cardano.Wallet.Primitive.Types.Tx
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxOutCoin, genTxScriptValidity, shrinkTxScriptValidity )
+    ( genTxScriptValidity, shrinkTxScriptValidity )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
+    ( genTxOutCoin )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( HistogramBar (..)
     , UTxO (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/CoinSelectionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/CoinSelectionSpec.hs
@@ -27,7 +27,9 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxIn, TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxIn, genTxOut, shrinkTxIn, shrinkTxOut )
+    ( genTxOut, shrinkTxOut )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
+    ( genTxIn, shrinkTxIn )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO )
 import Cardano.Wallet.Primitive.Types.UTxO.Gen

--- a/lib/wallet/test/unit/Cardano/Wallet/CoinSelectionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/CoinSelectionSpec.hs
@@ -24,12 +24,14 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundle, shrinkTokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genTokenMap, shrinkTokenMap )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn, TxOut (..) )
-import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxOut, shrinkTxOut )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxIn, shrinkTxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
+    ( genTxOut, shrinkTxOut )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO )
 import Cardano.Wallet.Primitive.Types.UTxO.Gen

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -129,11 +129,13 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genTokenMap, shrinkTokenMap )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxOutCoin, genTxScriptValidity, shrinkTxScriptValidity )
+    ( genTxScriptValidity, shrinkTxScriptValidity )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
     ( Tx (..), TxIn (..), TxMetadata, TxOut (..), TxScriptValidity (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxMeta
     ( Direction (..), TxMeta (..), TxStatus (..), isPending )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
+    ( genTxOutCoin )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Read.Eras.EraValue

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/MigrationSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/MigrationSpec.hs
@@ -21,7 +21,7 @@ import Cardano.Wallet.Primitive.Types.Address.Gen
     ( genAddress )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxIn, TxOut (..) )
-import Cardano.Wallet.Primitive.Types.Tx.Gen
+import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxInLargeRange )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -100,9 +100,11 @@ import Cardano.Wallet.Primitive.Types.Tx
     , txScriptInvalid
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTx, genTxOut, genTxScriptValidity, shrinkTx, shrinkTxOut )
+    ( genTx, genTxScriptValidity, shrinkTx )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxIn, shrinkTxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
+    ( genTxOut, shrinkTxOut )
 import Cardano.Wallet.Primitive.Types.Tx.TxSeq
     ( TxSeq )
 import Cardano.Wallet.Primitive.Types.Tx.TxSeq.Gen

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -100,14 +100,9 @@ import Cardano.Wallet.Primitive.Types.Tx
     , txScriptInvalid
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTx
-    , genTxIn
-    , genTxOut
-    , genTxScriptValidity
-    , shrinkTx
-    , shrinkTxIn
-    , shrinkTxOut
-    )
+    ( genTx, genTxOut, genTxScriptValidity, shrinkTx, shrinkTxOut )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
+    ( genTxIn, shrinkTxIn )
 import Cardano.Wallet.Primitive.Types.Tx.TxSeq
     ( TxSeq )
 import Cardano.Wallet.Primitive.Types.Tx.TxSeq.Gen

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/TxSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/TxSpec.hs
@@ -37,7 +37,9 @@ import Cardano.Wallet.Primitive.Types.Tx
     , txRemoveAssetId
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTx, genTxOut, shrinkTx, shrinkTxOut )
+    ( genTx, shrinkTx )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
+    ( genTxOut, shrinkTxOut )
 import Data.ByteString
     ( ByteString, pack )
 import Data.Either

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -27,10 +27,12 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genAssetId, shrinkAssetId )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (..), TokenPolicyId (..) )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn (..), TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( coarbitraryTxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..)
     , dom

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -29,7 +29,7 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (..), TokenPolicyId (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxIn (..), TxOut (..) )
-import Cardano.Wallet.Primitive.Types.Tx.Gen
+import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( coarbitraryTxIn )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
@@ -25,10 +25,10 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantityFullRange, shrinkTokenQuantityFullRange )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxIn (..) )
-import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxOutCoin, shrinkTxOutCoin )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxIn, shrinkTxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
+    ( genTxOutCoin, shrinkTxOutCoin )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( Convert (..) )
 import Data.Proxy

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
@@ -26,7 +26,9 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxIn, genTxOutCoin, shrinkTxIn, shrinkTxOutCoin )
+    ( genTxOutCoin, shrinkTxOutCoin )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
+    ( genTxIn, shrinkTxIn )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( Convert (..) )
 import Data.Proxy

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -76,7 +76,7 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
     , txOutMaxCoin
     , txOutMinCoin
     )
-import Cardano.Wallet.Primitive.Types.Tx.Gen
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     ( genTxOutTokenBundle )
 import Cardano.Wallet.Shelley.Compatibility
     ( CardanoBlock

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -61,7 +61,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin, txOutMaxTokenQuantity, txOutMinTokenQuantity )
-import Cardano.Wallet.Primitive.Types.Tx.Gen
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     ( genTxOutTokenBundle )
 import Cardano.Wallet.Shelley.MinimumUTxO
     ( computeMinimumCoinForUTxO, isBelowMinimumCoinForUTxO )

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -206,7 +206,9 @@ import Cardano.Wallet.Primitive.Types.Tx
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxConstraints (..), TxSize (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxIn, genTxOutTokenBundle )
+    ( genTxOutTokenBundle )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
+    ( genTxIn )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Primitive.Types.UTxOIndex

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -205,10 +205,10 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxConstraints (..), TxSize (..) )
-import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxOutTokenBundle )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
+    ( genTxOutTokenBundle )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
@@ -433,8 +433,8 @@ import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Shelley
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Primitive.Types.Tx.Gen as TxGen
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as TxOutGen
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
@@ -2869,14 +2869,14 @@ instance Arbitrary (TxFeeAndChange [TxOut]) where
         fee <- genCoin
         change <- frequency
             [ (1, pure [])
-            , (1, (: []) <$> TxGen.genTxOut)
-            , (6, listOf TxGen.genTxOut)
+            , (1, (: []) <$> TxOutGen.genTxOut)
+            , (6, listOf TxOutGen.genTxOut)
             ]
         pure $ TxFeeAndChange fee change
     shrink (TxFeeAndChange fee change) =
         uncurry TxFeeAndChange <$> liftShrink2
             (shrinkCoin)
-            (shrinkList TxGen.shrinkTxOut)
+            (shrinkList TxOutGen.shrinkTxOut)
             (fee, change)
 
 -- A helper function to generate properties for 'distributeSurplus' on

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -143,7 +143,9 @@ import Cardano.Wallet.Primitive.Types.Tx
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTx, genTxInLargeRange, shrinkTx )
+    ( genTx, shrinkTx )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
+    ( genTxInLargeRange )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Transaction


### PR DESCRIPTION
## Issue Number

ADP-2386 (following on from PR #3580)

## Summary

This PR creates the `TxIn.Gen` and `TxOut.Gen` modules, which contain generators and shrinkers for types in `TxIn` and `TxOut` respectively. We now have:

- `Primitive.Types.Tx.TxIn`
- `Primitive.Types.Tx.TxIn.Gen`
- `Primitive.Types.Tx.TxOut`
- `Primitive.Types.Tx.TxOut.Gen`

## Motivation

Coin selection (and therefore `balanceTransaction`) currently depends on these generators, but currently it can only consume them by importing from the `Primitive.Types.Tx.Gen` module, which has a very large transitive dependency footprint.

By moving these generators to separate modules, we make it possible for coin selection to depend on just those generators (and not everything in `Primitive.Types.Tx.Gen`). Consequently, we can minimise the dependency footprint of the `CoinSelection` module hierarchy and by extension `balanceTransation`, thus easing the burden of moving it to a separate library.

We eventually plan to **_completely remove_** coin selection's dependency on the `TxIn` and `TxOut` types. This PR is just an evolutionary step, to make the initial extraction of the `CoinSelection` module hierarchy easier.