### PR TITLE
Limit re-exports of `TxIn` and `TxOut` types.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -481,8 +481,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , Tx (..)
     , TxCBOR
     , TxChange (..)
-    , TxIn (..)
-    , TxOut (..)
     , TxStatus (..)
     , UnsignedTx (..)
     , cardanoTxIdeallyNoLaterThan
@@ -490,6 +488,10 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txMintBurnMaxTokenQuantity )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Registry
     ( HasWorkerCtx (..)
     , MkWorker (..)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -374,12 +374,13 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , SealedTx (..)
     , SerialisedTx (..)
-    , TxIn (..)
     , TxMetadata
     , TxScriptValidity (..)
     , TxStatus (..)
     , sealedTxFromBytes
     )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
     ( BoundType, HistogramBar (..), UTxOStatistics (..) )
 import Cardano.Wallet.Shelley.Network.Discriminant

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
@@ -53,7 +53,9 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( coinIsValidForTxOut, txOutMaxCoin )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
-    ( TxIn (..), TxMetadata (..), TxScriptValidity )
+    ( TxMetadata (..), TxScriptValidity )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
 import Cardano.Wallet.Shelley.Network.Discriminant
     ( DecodeAddress (..)
     , DecodeStakeAddress (..)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Transaction.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Transaction.hs
@@ -59,7 +59,9 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( coinIsValidForTxOut, txOutMaxCoin )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
-    ( TxIn (..), TxMetadata (..), TxScriptValidity, txMetadataIsNull )
+    ( TxMetadata (..), TxScriptValidity, txMetadataIsNull )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
 import Cardano.Wallet.Shelley.Network.Discriminant
     ( DecodeAddress, DecodeStakeAddress, EncodeAddress, EncodeStakeAddress )
 import Cardano.Wallet.Transaction

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -136,14 +136,11 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( Direction (..)
-    , TransactionInfo
-    , Tx (..)
-    , TxIn (..)
-    , TxMeta (..)
-    , TxOut (..)
-    , TxStatus (..)
-    )
+    ( Direction (..), TransactionInfo, Tx (..), TxMeta (..), TxStatus (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Unsafe

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -137,7 +137,7 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount )
-import Cardano.Wallet.Primitive.Types.Tx
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
     ( UTxOStatistics (..) )

--- a/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
@@ -334,9 +334,13 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( SealedTx (..), TxIn (..), TxOut (..), TxStatus (..) )
+    ( SealedTx (..), TxStatus (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin, txOutMinCoin )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Primitive.Types.UTxOStatistics

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -101,7 +101,6 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , SealedTx (..)
-    , TxIn (..)
     , TxMetadata (..)
     , TxMetadataValue (..)
     , TxScriptValidity (..)
@@ -110,6 +109,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     , getSealedTxBody
     , sealedTxFromCardanoBody
     )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
 import Cardano.Wallet.Transaction
     ( AnyScript (..), ValidityIntervalExplicit (..) )
 import Cardano.Wallet.Unsafe

--- a/lib/wallet/src/Cardano/Byron/Codec/Cbor.hs
+++ b/lib/wallet/src/Cardano/Byron/Codec/Cbor.hs
@@ -56,7 +56,11 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.ProtocolMagic
     ( ProtocolMagic (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn (..), TxOut (..), unsafeCoinToTxOutCoinValue )
+    ( unsafeCoinToTxOutCoinValue )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Control.Monad
     ( replicateM, when )
 import Crypto.Error

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -439,10 +439,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TransactionInfo (..)
     , Tx (..)
     , TxChange (..)
-    , TxIn (..)
     , TxMeta (..)
     , TxMetadata (..)
-    , TxOut (..)
     , TxStatus (..)
     , UnsignedTx (..)
     , fromTransactionInfo
@@ -451,6 +449,10 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxSize (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Primitive.Types.UTxOIndex

--- a/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -101,6 +101,8 @@ import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.ProtocolMagic as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+    ( TxOut (TxOut) )
 import qualified Data.Map.Strict as Map
 import qualified Ouroboros.Consensus.Block as O
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Checkpoints.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Checkpoints.hs
@@ -168,7 +168,11 @@ import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
-import qualified Cardano.Wallet.Primitive.Types.Tx as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
+    ( TxIn (TxIn) )
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+    ( TxOut (TxOut) )
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
 import qualified Data.Map.Merge.Strict as Map
 import qualified Data.Map.Strict as Map

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -101,7 +101,14 @@ import GHC.Generics
 
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W.Tx
 import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W
+    ( Tx )
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
+    ( TxIn )
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W.TxIn
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+    ( TxOut (TxOut) )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Generics.Internal.VL as L
@@ -169,8 +176,8 @@ mkTxIn tid (ix,(txIn,amt)) =
     TxIn
     { txInputTxId = tid
     , txInputOrder = ix
-    , txInputSourceTxId = TxId (W.inputId txIn)
-    , txInputSourceIndex = W.inputIx txIn
+    , txInputSourceTxId = TxId (W.TxIn.inputId txIn)
+    , txInputSourceIndex = W.TxIn.inputIx txIn
     , txInputSourceAmount = amt
     }
 
@@ -181,8 +188,8 @@ mkTxCollateral tid (ix,(txCollateral,amt)) =
     TxCollateral
     { txCollateralTxId = tid
     , txCollateralOrder = ix
-    , txCollateralSourceTxId = TxId $ W.inputId txCollateral
-    , txCollateralSourceIndex = W.inputIx txCollateral
+    , txCollateralSourceTxId = TxId $ W.TxIn.inputId txCollateral
+    , txCollateralSourceIndex = W.TxIn.inputIx txCollateral
     , txCollateralSourceAmount = amt
     }
 
@@ -260,13 +267,13 @@ mkTxWithdrawal tid (txWithdrawalAccount,txWithdrawalAmount) =
 mkTxRelation :: W.Tx -> TxRelation
 mkTxRelation tx =
     TxRelation
-    { ins = fmap (mkTxIn tid) $ indexed . W.resolvedInputs $ tx
+    { ins = fmap (mkTxIn tid) $ indexed . W.Tx.resolvedInputs $ tx
     , collateralIns =
-          fmap (mkTxCollateral tid) $ indexed $ W.resolvedCollateralInputs tx
-    , outs = fmap (mkTxOut tid) $ indexed $ W.outputs tx
-    , collateralOuts = mkTxCollateralOut tid <$> W.collateralOutput tx
+          fmap (mkTxCollateral tid) $ indexed $ W.Tx.resolvedCollateralInputs tx
+    , outs = fmap (mkTxOut tid) $ indexed $ W.Tx.outputs tx
+    , collateralOuts = mkTxCollateralOut tid <$> W.Tx.collateralOutput tx
     , withdrawals =
-          fmap (mkTxWithdrawal tid) $ Map.toList $ W.withdrawals tx
+          fmap (mkTxWithdrawal tid) $ Map.toList $ W.Tx.withdrawals tx
     , cbor = fst . L.build txCBORPrism . (tid,) <$> txCBOR tx
     }
   where
@@ -288,8 +295,8 @@ mkTxSet txs = TxSet $ fold $ do
 fromTxOut :: (TxOut, [TxOutToken]) -> W.TxOut
 fromTxOut (out,tokens) =
     W.TxOut
-    { W.address = txOutputAddress out
-    , W.tokens = TokenBundle.fromFlatList
+    { W.TxOut.address = txOutputAddress out
+    , W.TxOut.tokens = TokenBundle.fromFlatList
             (txOutputAmount out)
             (fromTxOutToken <$> tokens)
     }
@@ -302,8 +309,8 @@ fromTxOut (out,tokens) =
 fromTxCollateralOut :: (TxCollateralOut, [TxCollateralOutToken]) -> W.TxOut
 fromTxCollateralOut (out,tokens) =
     W.TxOut
-    { W.address = txCollateralOutAddress out
-    , W.tokens = TokenBundle.fromFlatList
+    { W.TxOut.address = txCollateralOutAddress out
+    , W.TxOut.tokens = TokenBundle.fromFlatList
             (txCollateralOutAmount out)
             (fromTxCollateralOutToken <$> tokens)
     }

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -74,6 +74,9 @@ import qualified Cardano.Wallet.DB.Store.Transactions.Model as TxStore
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as WC
 import qualified Cardano.Wallet.Primitive.Types.Tx as WT
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as WT
+    ( TxIn (TxIn) )
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as WT.TxIn
 import qualified Data.Generics.Internal.VL as L
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -195,16 +198,16 @@ mkTransactionInfo ti tip TxRelation{..} decor DB.TxMeta{..} = do
     tipH = getQuantity $ tip ^. #blockHeight
     mkTxIn tx =
         ( WT.TxIn
-          { WT.inputId = getTxId (txInputSourceTxId tx)
-          , WT.inputIx = txInputSourceIndex tx
+          { inputId = getTxId (txInputSourceTxId tx)
+          , inputIx = txInputSourceIndex tx
           }
         , txInputSourceAmount tx
         , lookupTxOutForTxIn tx decor
         )
     mkTxCollateral tx =
         ( WT.TxIn
-          { WT.inputId = getTxId (txCollateralSourceTxId tx)
-          , WT.inputIx = txCollateralSourceIndex tx
+          { inputId = getTxId (txCollateralSourceTxId tx)
+          , inputIx = txCollateralSourceIndex tx
           }
         , txCollateralSourceAmount tx
         , lookupTxOutForTxCollateral tx decor

--- a/lib/wallet/src/Cardano/Wallet/Primitive/BlockSummary.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/BlockSummary.hs
@@ -53,7 +53,9 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( Tx (..), TxOut (..) )
+    ( Tx (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Data.Foldable
     ( Foldable (toList) )
 import Data.Functor.Identity

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Collateral.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Collateral.hs
@@ -39,7 +39,7 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin )
-import Cardano.Wallet.Primitive.Types.Tx
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..) )
 import Data.Word
     ( Word8 )

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Delegation/State.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Delegation/State.hs
@@ -58,8 +58,10 @@ import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn (..), TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Control.DeepSeq
     ( NFData )
 import Data.Maybe

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Delegation/UTxO.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Delegation/UTxO.hs
@@ -10,7 +10,7 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
-import Cardano.Wallet.Primitive.Types.Tx
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Migration.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Migration.hs
@@ -26,10 +26,12 @@ import Cardano.Wallet.Primitive.Migration.Selection
     ( RewardWithdrawal (..), Selection (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn, TxOut )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxConstraints (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO )
 import Data.Generics.Internal.VL.Lens

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Migration/Planning.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Migration/Planning.hs
@@ -45,10 +45,12 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn, TxOut )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxConstraints (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Data.Either

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Model.hs
@@ -103,13 +103,14 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , Tx (..)
-    , TxIn (..)
     , TxMeta (..)
     , TxStatus (..)
     , collateralInputs
     , inputs
     , txScriptInvalid
     )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( DeltaUTxO, UTxO (..), balance, excluding, excludingD, receiveD )
 import Control.DeepSeq

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Redeemer.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Redeemer.hs
@@ -19,7 +19,7 @@ import Cardano.Api
     ( StakeAddress, serialiseToBech32 )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenPolicyId )
-import Cardano.Wallet.Primitive.Types.Tx
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn )
 import Data.ByteString
     ( ByteString )

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -18,8 +18,6 @@ module Cardano.Wallet.Primitive.Types.Tx
     (
     -- * Types
       Tx (..)
-    , TxIn (..)
-    , TxOut (..)
     , TxChange (..)
     , TxMeta (..)
     , TxMetadata (..)
@@ -115,10 +113,8 @@ import Cardano.Wallet.Primitive.Types.Tx.TransactionInfo
 import Cardano.Wallet.Primitive.Types.Tx.Tx
     ( ScriptWitnessIndex (..)
     , Tx (..)
-    , TxIn (..)
     , TxMetadata (..)
     , TxMetadataValue (..)
-    , TxOut (..)
     , TxScriptValidity (..)
     , collateralInputs
     , inputs

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -30,9 +30,13 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
 import Cardano.Wallet.Primitive.Types.RewardAccount.Gen
     ( genRewardAccount, shrinkRewardAccount )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( Tx (..), TxIn (..), TxMetadata (..), TxOut (..), TxScriptValidity (..) )
+    ( Tx (..), TxMetadata (..), TxScriptValidity (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxIn, shrinkTxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     ( genTxOut, shrinkTxOut )
 import Data.Map.Strict

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TransactionInfo.hs
@@ -29,9 +29,13 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
-    ( Tx (..), TxIn, TxMetadata, TxOut, TxScriptValidity )
+    ( Tx (..), TxMetadata, TxScriptValidity )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn )
 import Cardano.Wallet.Primitive.Types.Tx.TxMeta
     ( TxMeta )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut )
 import Cardano.Wallet.Read.Tx.CBOR
     ( TxCBOR )
 import Control.DeepSeq

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
@@ -18,8 +18,6 @@ module Cardano.Wallet.Primitive.Types.Tx.Tx
     (
     -- * Types
       Tx (..)
-    , TxIn (..)
-    , TxOut (..)
     , TxMetadata (..)
     , TxMetadataValue (..)
     , TxScriptValidity(..)
@@ -34,7 +32,6 @@ module Cardano.Wallet.Primitive.Types.Tx.Tx
 
     -- * Queries
     , txAssetIds
-    , TxOut.assetIds
 
     -- * Transformations
     , txMapAssetIds

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
@@ -121,7 +121,9 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (..), TokenPolicyId (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( Tx (..), TxIn, txAssetIds, txMapAssetIds, txMapTxIds, txRemoveAssetId )
+    ( Tx (..), txAssetIds, txMapAssetIds, txMapTxIds, txRemoveAssetId )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO )
 import Data.Bifoldable

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq/Gen.hs
@@ -47,9 +47,11 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( Tx (..), TxOut (..), TxScriptValidity (..) )
+    ( Tx (..), TxScriptValidity (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( TxWithoutId (..), txWithoutIdToTx )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxSeq
     ( TxSeq )
 import Cardano.Wallet.Primitive.Types.UTxO

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Alonzo.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Alonzo.hs
@@ -80,6 +80,8 @@ import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+    ( TxOut (TxOut) )
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Babbage.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Babbage.hs
@@ -83,6 +83,8 @@ import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+    ( TxOut (TxOut) )
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Byron.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Byron.hs
@@ -37,6 +37,12 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
+    ( TxIn (TxIn) )
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W.TxIn
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+    ( TxOut (TxOut) )
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Data.List.NonEmpty as NE
 
 fromTxAux :: ATxAux a -> W.Tx

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Mary.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Mary.hs
@@ -81,6 +81,8 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+    ( TxOut (TxOut) )
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Shelley.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Shelley.hs
@@ -60,7 +60,6 @@ import Data.Map.Strict
 import Data.Word
     ( Word16, Word32, Word64 )
 
-
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Ledger.Address as SL
@@ -78,6 +77,10 @@ import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
+    ( TxIn (TxIn) )
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+    ( TxOut (TxOut) )
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -394,7 +394,11 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.SealedTx as W
     ( SealedTx, cardanoTxIdeallyNoLaterThan )
 import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W
-    ( Tx (..), TxIn (TxIn), TxOut (TxOut) )
+    ( Tx (..) )
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
+    ( TxIn (TxIn) )
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+    ( TxOut (TxOut) )
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs
@@ -63,8 +63,10 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (..), TokenPolicyId (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn (..), TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Data.ByteString.Short
     ( fromShort, toShort )
 import Data.Foldable

--- a/lib/wallet/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/MinimumUTxO.hs
@@ -23,10 +23,10 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Shelley.MinimumUTxO.Internal as Internal

--- a/lib/wallet/src/Cardano/Wallet/Shelley/MinimumUTxO/Internal.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/MinimumUTxO/Internal.hs
@@ -21,7 +21,7 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO
     ( MinimumUTxOForShelleyBasedEra (..) )
-import Cardano.Wallet.Primitive.Types.Tx
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut )
 import Cardano.Wallet.Shelley.Compatibility
     ( toCardanoTxOut, unsafeLovelaceToWalletCoin, unsafeValueToLovelace )

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Network/Blockfrost.hs
@@ -132,15 +132,13 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( SealedTx
-    , Tx (..)
-    , TxIn (..)
-    , TxOut (..)
-    , TxScriptValidity (..)
-    , serialisedTx
-    )
+    ( SealedTx, Tx (..), TxScriptValidity (..), serialisedTx )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxSize (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( shelleyDecodeStakeAddress
     , shelleyEncodeAddress

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -143,9 +143,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)
     , Tx (..)
-    , TxIn
     , TxMetadata (..)
-    , TxOut (..)
     , cardanoTxIdeallyNoLaterThan
     , sealedTxFromCardano'
     , sealedTxFromCardanoBody
@@ -153,6 +151,10 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxConstraints (..), TxSize (..), txSizeDistance )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Read.Primitive.Tx
     ( fromCardanoTx )
 import Cardano.Wallet.Shelley.Compatibility

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -102,7 +102,11 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TokenBundleSizeAssessor, TxConstraints, TxSize )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
-    ( Tx (..), TxIn, TxMetadata, TxOut )
+    ( Tx (..), TxMetadata )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Control.DeepSeq
     ( NFData (..) )
 import Data.List.NonEmpty

--- a/lib/wallet/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/wallet/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -51,15 +51,13 @@ import Cardano.Wallet.Primitive.Types.MinimumUTxO
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( Tx (..)
-    , TxCBOR
-    , TxIn (..)
-    , TxMetadata (..)
-    , TxOut (..)
-    , TxScriptValidity (..)
-    )
+    ( Tx (..), TxCBOR, TxMetadata (..), TxScriptValidity (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxSize (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Data.Functor.Identity
     ( Identity (..) )
 import Data.Map.Strict

--- a/lib/wallet/test/unit/Cardano/Byron/Codec/CborSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Byron/Codec/CborSpec.hs
@@ -38,8 +38,10 @@ import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn (..), TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeDeserialiseCbor, unsafeFromHex )
 import Data.ByteString

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -324,9 +324,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , SealedTx (..)
     , SerialisedTx (..)
     , SerialisedTxParts (..)
-    , TxIn (..)
     , TxMetadata (..)
-    , TxOut (..)
     , TxScriptValidity (..)
     , TxStatus (..)
     , unsafeSealedTxFromBytes
@@ -335,6 +333,10 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTxScriptValidity, shrinkTxScriptValidity )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     ( genTxOutCoin )
 import Cardano.Wallet.Primitive.Types.UTxO

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -131,9 +131,13 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTxScriptValidity, shrinkTxScriptValidity )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
-    ( Tx (..), TxIn (..), TxMetadata, TxOut (..), TxScriptValidity (..) )
+    ( Tx (..), TxMetadata, TxScriptValidity (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxMeta
     ( Direction (..), TxMeta (..), TxStatus (..), isPending )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     ( genTxOutCoin )
 import Cardano.Wallet.Primitive.Types.UTxO

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -162,13 +162,15 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , TransactionInfo (..)
     , Tx (..)
-    , TxIn (..)
     , TxMeta (..)
-    , TxOut (..)
     , TxScriptValidity (..)
     , TxStatus (..)
     , toTxHistory
     )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeRunExceptT )
 import Control.Monad

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -177,10 +177,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TransactionInfo (..)
     , Tx (..)
     , TxCBOR
-    , TxIn (..)
     , TxMeta
     , TxMetadata
-    , TxOut (..)
     , TxScriptValidity
     , TxStatus
     , inputs
@@ -188,6 +186,10 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxSize (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Read.Eras.EraValue

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -53,6 +53,8 @@ import Test.QuickCheck.Monadic
 
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
+    ( TxIn (TxIn) )
 import qualified Data.Map.Strict as Map
 
 spec :: Spec

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/CollateralSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/CollateralSpec.hs
@@ -24,7 +24,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRangePositive, shrinkTokenBundleSmallRangePositive )
-import Cardano.Wallet.Primitive.Types.Tx
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeBech32Decode )

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Delegation/StateSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Delegation/StateSpec.hs
@@ -49,8 +49,10 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn (..), TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Control.Arrow
     ( first )
 import Crypto.Hash.Utils

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/MigrationSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/MigrationSpec.hs
@@ -19,10 +19,12 @@ import Cardano.Wallet.Primitive.Migration.SelectionSpec
     )
 import Cardano.Wallet.Primitive.Types.Address.Gen
     ( genAddress )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn, TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxInLargeRange )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Control.Monad

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -90,9 +90,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , Tx (..)
-    , TxIn (..)
     , TxMeta (direction)
-    , TxOut (..)
     , TxScriptValidity (..)
     , collateralInputs
     , inputs
@@ -101,8 +99,12 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTx, genTxScriptValidity, shrinkTx )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxIn, shrinkTxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     ( genTxOut, shrinkTxOut )
 import Cardano.Wallet.Primitive.Types.Tx.TxSeq

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/TxSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/TxSpec.hs
@@ -28,7 +28,6 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)
     , Tx (..)
-    , TxOut (..)
     , mockSealedTx
     , sealedTxFromBytes
     , txAssetIds
@@ -38,6 +37,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTx, shrinkTx )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     ( genTxOut, shrinkTxOut )
 import Data.ByteString

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -101,9 +101,13 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTx, shrinkTx )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
-    ( Tx (..), TxIn (..), TxMetadata (..), TxMetadataValue (..), TxOut (..) )
+    ( Tx (..), TxMetadata (..), TxMetadataValue (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxMeta
     ( Direction (..), TxMeta (..), TxStatus (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..)
     , balance

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
@@ -23,7 +23,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantityFullRange, shrinkTokenQuantityFullRange )
-import Cardano.Wallet.Primitive.Types.Tx
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxIn, shrinkTxIn )

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/MinimumUTxOSpec.hs
@@ -57,10 +57,10 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (UnsafeTokenName) )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     ( mkTokenPolicyId )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin, txOutMaxTokenQuantity, txOutMinTokenQuantity )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     ( genTxOutTokenBundle )
 import Cardano.Wallet.Shelley.MinimumUTxO

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -190,10 +190,8 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)
     , Tx
-    , TxIn (..)
     , TxMetadata (..)
     , TxMetadataValue (..)
-    , TxOut (..)
     , cardanoTxIdeallyNoLaterThan
     , getSealedTxWitnesses
     , sealedTxFromBytes
@@ -206,8 +204,12 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxConstraints (..), TxSize (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     ( genTxOutTokenBundle )
 import Cardano.Wallet.Primitive.Types.UTxO

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -132,10 +132,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     , SealedTx (..)
     , TransactionInfo (..)
     , Tx (..)
-    , TxIn (..)
     , TxMeta (..)
     , TxMetadata
-    , TxOut (..)
     , TxStatus (..)
     , isPending
     , mockSealedTx
@@ -144,8 +142,12 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTx, shrinkTx )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxInLargeRange )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Transaction


### PR DESCRIPTION
## Issue Number

ADP-2386 (following on from PR #3580)

## Summary

This PR limits the re-exports of the `TxIn` and `TxOut` types, and adjusts modules that consume these types to import directly from the `TxIn` and `TxOut` modules.

## Motivation

We wish to extract coin selection modules out into a separate internal library. Coin selection depends on the `TxIn` and `TxOut` types, but not on the `Tx` type, or any other type defined within `Types.Tx` or `Types.Tx.Tx`.

Some transitive dependencies of coin selection import `TxIn` and `TxOut` via the `Types.Tx` or `Types.Tx.Tx` modules. This increases the transitive dependency footprint of coin selection (and by extension, `balanceTransaction`).

By limiting the re-exports of these types, we can ensure that coin selection modules do not transitively depend on the `Types.Tx` or `Types.Tx.Tx` modules, which have large dependency footprints, and consequently minimise the work we need to do when extracting coin selection out to a separate internal library.