### PR TITLE
Adjust `Primitive.TypesSpec` so it doesn't depend on `HashSpec`.

### DIFF
--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -94,8 +94,6 @@ import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoin )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
-import Cardano.Wallet.Primitive.Types.HashSpec
-    ()
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
@@ -116,7 +114,7 @@ import Cardano.Wallet.Primitive.Types.UTxO
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
     ( HistogramBar (..), UTxOStatistics (..) )
 import Cardano.Wallet.Unsafe
-    ( someDummyMnemonic )
+    ( someDummyMnemonic, unsafeFromHex )
 import Cardano.Wallet.Util
     ( ShowFmt (..) )
 import Control.Monad
@@ -1311,6 +1309,17 @@ instance Arbitrary PoolId where
 
 instance Arbitrary PoolOwner where
     arbitrary = PoolOwner . BS.pack <$> vector 32
+
+instance Arbitrary (Hash "Tx") where
+    -- No Shrinking
+    arbitrary = elements
+        [ Hash $ unsafeFromHex
+            "0000000000000000000000000000000000000000000000000000000000000001"
+        , Hash $ unsafeFromHex
+            "0000000000000000000000000000000000000000000000000000000000000002"
+        , Hash $ unsafeFromHex
+            "0000000000000000000000000000000000000000000000000000000000000003"
+        ]
 
 {-------------------------------------------------------------------------------
                                   Test data


### PR DESCRIPTION
## Issue Number

ADP-2386

## Summary

This PR adjust `Primitive.TypesSpec` so it doesn't depend on `HashSpec`.

## Motivation

- Silent sharing of orphan `Arbitrary` instances from one `Spec` module to another is hard to track. It's much easier to understand what's going on if each `Spec` module defines its own orphan `Arbitrary` instances and does **not** export them. In cases where we want to share a common method of generating arbitrary values, our standard idiom is to define a shared generator function in a `Gen` module, and import that from all the `Spec` modules that require it.
- We eventually wish to move a small set of core primitive types (and their tests) to a separate internal library. Removing the dependency from `TypesSpec` to `HashSpec` means we are free to move `HashSpec` without also having to move `TypesSpec`.
