### PR TITLE
Update docker-compose.yml - cardano-node version till latest 1.35.4. and etc

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,12 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:1.35.4
+    image: inputoutput/cardano-node:1.35.3-configs
     environment:
       NETWORK:
-      CARDANO_NODE_SOCKET_PATH: ${CARDANO_NODE_SOCKET_PATH:-/ipc/node.socket}
+      CARDANO_NODE_SOCKET_PATH: /ipc/node.socket
     volumes:
-      - ./node-${NETWORK}-db:/data
+      - node-${NETWORK}-db:/data
       - node-ipc:/ipc
     restart: on-failure
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: inputoutput/cardano-node:1.35.4
     environment:
       NETWORK:
+      CARDANO_NODE_SOCKET_PATH: ${CARDANO_NODE_SOCKET_PATH:-/ipc/node.socket}
     volumes:
       - ./node-${NETWORK}-db:/data
       - node-ipc:/ipc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,12 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:1.35.3-configs
+    image: inputoutput/cardano-node:1.35.4
     environment:
-      NETWORK:
+      - NETWORK=${NETWORK:-mainnet}
+      - CARDANO_NODE_SOCKET_PATH=${CARDANO_NODE_SOCKET_PATH:-/ipc/node.socket}
     volumes:
-      - node-${NETWORK}-db:/data
+      - ./node-${NETWORK}-db:/data
       - node-ipc:/ipc
     restart: on-failure
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,7 @@ services:
   cardano-node:
     image: inputoutput/cardano-node:1.35.4
     environment:
-      - NETWORK=${NETWORK:-mainnet}
-      - CARDANO_NODE_SOCKET_PATH=${CARDANO_NODE_SOCKET_PATH:-/ipc/node.socket}
+      NETWORK:
     volumes:
       - ./node-${NETWORK}-db:/data
       - node-ipc:/ipc


### PR DESCRIPTION
- [x] Updated cardano-node version till latest 1.35.4.

Additionally updated mounting /data/db as folder on host, so we can copy existing DB to that folder and no need to wait to sync via internet, might be quite useful.


### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
