### PR TITLE
Bump cardano-node to 1.35.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See **Installation Instructions** for each available [release](https://github.co
 >
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
-> | `master` branch | [1.35.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
+> | `master` branch | [1.35.4](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.4) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-10-06](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-10-06) | [1.35.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-08-16](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-08-16) | [1.35.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-07-01](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-07-01) | [1.35.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.0) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)

--- a/cabal.project
+++ b/cabal.project
@@ -38,7 +38,23 @@
 --
 --------------------------------------------------------------------------------
 
-index-state: 2022-05-18T00:00:00Z
+-- Custom repository for cardano haskell packages, see
+-- https://github.com/input-output-hk/cardano-haskell-packages
+-- for more information.
+repository cardano-haskell-packages
+  url: https://input-output-hk.github.io/cardano-haskell-packages
+  secure: True
+  root-keys:
+    3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
+    443abb7fb497a134c343faf52f0b659bd7999bc06b7f63fa76dc99d631f9bea1
+    a86a1f6ce86c449c46666bda44268677abf29b5b2d2eb5ec7af903ec2f117a82
+    bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
+    c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
+    d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
+
+index-state: 2022-09-27T00:00:00Z
+index-state: cardano-haskell-packages 2022-10-25T20:00:00Z
+
 with-compiler: ghc-8.10.7
 
 packages:
@@ -59,35 +75,6 @@ packages:
 package cryptonite
   flags: -support_rdrand
 
--- TODO This was patched to work with aeson 1 & 2 with the help of hw-aeson.
--- Once downstream projects are all upgraded to work with aeson-2, they can
--- be changed to work strictly with aeson 2 only.
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/hjsonpointer
-    tag: bb99294424e0c5b3c2942c743b545e4b01c12ce8
-    --sha256: 11z5s4xmm6cxy6sdcf9ly4lr0qh3c811hpm0bmlp4c3yq8v3m9rk
-
--- TODO This was patched to work with aeson 1 & 2 with the help of hw-aeson.
--- Once downstream projects are all upgraded to work with aeson-2, they can
--- be changed to work strictly with aeson 2 only.
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/hjsonschema
-    tag: 1546af7fc267d5eea805ef223dd2b59ac120b784
-    --sha256: 0sdikhsq6nnhmmvcpwzzrwfn9cn7rg75629qnrx01i5vm5ci4314
-
--- TODO This is a compatibility shim to make it easier for our library dependencies to
--- be compatible with both aeson 1 & 2.  Once downstream projects are all upgraded to
--- work with aeson-2, library dependencies will need to be updated to no longer use
--- this compatibility shim and have bounds to indicate they work with aeson-2 only.
--- After this, the dependency to hw-aeson can be dropped.
-source-repository-package
-    type: git
-    location: https://github.com/haskell-works/hw-aeson
-    tag: ba7c1e41c6e54d6bf9fd1cd013489ac713fc3153
-    --sha256: 1czyn0whgv7czzgwn5y1zgwlkb9p9sn9z9sc9gixrjprcyc0p15p
-
 -- Using a fork until our patches can be merged upstream
 
 -- TODO: ADP-1713
@@ -103,18 +90,6 @@ source-repository-package
   location: https://github.com/paolino/openapi3
   tag: c30d0de6875d75edd64d1aac2272886528bc492d
   --sha256: 0b0fzj5vrnfrc8qikabxhsnp4p8lrjpssblbh2rb7aji5hzzfli9
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/optparse-applicative
-  tag: 7497a29cb998721a9068d5725d49461f2bba0e7a
-  --sha256: 1gvsrg925vynwgqwplgjmp53vj953qyh3wbdf34pw21c8r47w35r
-
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/Win32-network
-    tag: 3825d3abf75f83f406c1f7161883c438dac7277d
-    --sha256: 19wahfv726fa3mqajpqdqhnl9ica3xmf68i254q45iyjcpj1psqx
 
 source-repository-package
     type: git
@@ -134,40 +109,9 @@ source-repository-package
 
 source-repository-package
     type: git
-    location: https://github.com/input-output-hk/cardano-base
-    tag: 0f3a867493059e650cda69e20a5cbf1ace289a57
-    --sha256: 0p0az3sbkhb7njji8xxdrfb0yx2gc8fmrh872ffm8sfip1w29gg1
-    subdir:
-            base-deriving-via
-            binary
-            binary/test
-            cardano-crypto-class
-            cardano-crypto-praos
-            cardano-crypto-tests
-            orphans-deriving-via
-            measures
-            strict-containers
-            slotting
-
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/cardano-crypto
-    tag: f73079303f663e028288f9f4a9e08bcca39a923e
-    --sha256: 1n87i15x54s0cjkh3nsxs4r1x016cdw1fypwmr68936n3xxsjn6q
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/plutus
-  tag: a56c96598b4b25c9e28215214d25189331087244
-  --sha256: 12d6bndmj0dxl6xlaqmf78326yp5hw093bmybmqfpdkvk4mgz03j
-  subdir:
-    plutus-core
-    plutus-ledger-api
-    plutus-tx
-    plutus-tx-plugin
-    prettyprinter-configurable
-    stubs/plutus-ghc-stub
-    word-array
+    location: https://github.com/input-output-hk/cardano-sl-x509
+    tag: a91add165152fa36f08e95fafe7da24f1dba4690
+    --sha256: 1ia8vlqghis92cla8qmqa6kh8f3jn29b01fshyk5hmgy5373s684
 
 source-repository-package
   type: git
@@ -176,110 +120,10 @@ source-repository-package
   --sha256: 1zcwry3y5rmd9lgxy89wsb3k4kpffqji35dc7ghzbz603y1gy24g
 
 source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-config
-  tag: 1646e9167fab36c0bff82317743b96efa2d3adaa
-  --sha256: 11kf65x38laqhwspsl28j2x5a4rky8mfr6356w0li5g53sfykmjc
-
-source-repository-package
     type: git
-    location: https://github.com/input-output-hk/cardano-ledger
-    tag: c7c63dabdb215ebdaed8b63274965966f2bf408f
-    --sha256: 1cn1z3dh5dy5yy42bwfd8rg25mg8qp3m55gyfsl563wgw4q1nd6d
-    subdir:
-      eras/alonzo/impl
-      eras/alonzo/test-suite
-      eras/babbage/impl
-      eras/babbage/test-suite
-      eras/byron/chain/executable-spec
-      eras/byron/crypto
-      eras/byron/crypto/test
-      eras/byron/ledger/executable-spec
-      eras/byron/ledger/impl
-      eras/byron/ledger/impl/test
-      eras/shelley/impl
-      eras/shelley/test-suite
-      eras/shelley-ma/impl
-      eras/shelley-ma/test-suite
-      libs/cardano-ledger-core
-      libs/cardano-ledger-pretty
-      libs/cardano-protocol-tpraos
-      libs/cardano-data
-      libs/vector-map
-      libs/set-algebra
-      libs/small-steps
-      libs/small-steps-test
-      libs/non-integral
-
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/cardano-node
-    tag: 950c4e222086fed5ca53564e642434ce9307b0b9
-    --sha256: 020fwimsm24yblr1fmnwx240wj8r3x715p89cpjgnnd8axwf32p0
-    subdir:
-      cardano-api
-      cardano-git-rev
-      cardano-cli
-      cardano-node
-      cardano-node-chairman
-      trace-dispatcher
-      trace-resources
-      trace-forward
-
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/cardano-prelude
-    tag: bb4ed71ba8e587f672d06edf9d2e376f4b055555
-    --sha256: 00h10l5mmiza9819p9v5q5749nb9pzgi20vpzpy1d34zmh6gf1cj
-    subdir: cardano-prelude
-            cardano-prelude-test
-
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/cardano-sl-x509
-    tag: a91add165152fa36f08e95fafe7da24f1dba4690
-    --sha256: 1ia8vlqghis92cla8qmqa6kh8f3jn29b01fshyk5hmgy5373s684
-
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/goblins
-    tag: cde90a2b27f79187ca8310b6549331e59595e7ba
-    --sha256: 17c88rbva3iw82yg9srlxjv2ia5wjb9cyqw44hik565f5v9svnyg
-
--- In particular we rely on the code from this PR:
---  * <https://github.com/input-output-hk/iohk-monitoring-framework/pull/622>
--- being merged.
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/iohk-monitoring-framework
-    tag: 066f7002aac5a0efc20e49643fea45454f226caa
-    --sha256: 0s6x4in11k5ba7nl7la896g28sznf9185xlqg9c604jqz58vj9nj
-    subdir: contra-tracer
-            iohk-monitoring
-            plugins/backend-aggregation
-            plugins/backend-ekg
-            plugins/backend-monitoring
-            plugins/backend-trace-forwarder
-            plugins/scribe-systemd
-            tracer-transformers
-
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/ouroboros-network
-    tag: cb9eba406ceb2df338d8384b35c8addfe2067201
-    --sha256: 066llskxzjgcs13lwlvklb28azb9kd9b77j61x8fvrj1rlf5njfw
-    subdir:
-      monoidal-synchronisation
-      network-mux
-      ouroboros-consensus
-      ouroboros-consensus-byron
-      ouroboros-consensus-cardano
-      ouroboros-consensus-protocol
-      ouroboros-consensus-shelley
-      ouroboros-network
-      ouroboros-network-framework
-      ouroboros-network-testing
-      ntp-client
+    location: https://github.com/input-output-hk/cardano-crypto
+    tag: f73079303f663e028288f9f4a9e08bcca39a923e
+    --sha256: 1n87i15x54s0cjkh3nsxs4r1x016cdw1fypwmr68936n3xxsjn6q
 
 source-repository-package
   type: git
@@ -291,44 +135,44 @@ source-repository-package
     io-sim
     strict-stm
 
+-- Temporary patch for version 0.1.0.0 (181601bc3d9e9d21a671ce01e0b481348b3ca104)
+-- in order to change io-sim from 606de33fa2f467d108fb1efb86daeb3348bf34e3
+-- to 57e888b1894829056cb00b7b5785fdf6a74c3271 to include the ReaderT fix.
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/typed-protocols
-  tag: 181601bc3d9e9d21a671ce01e0b481348b3ca104
-  --sha256: 1lr97b2z7l0rpsmmz92rsv27qzd5vavz10cf7n25svya4kkiysp5
+  location: https://github.com/Anviking/typed-protocols.git
+  tag: 93b180f0a8cba67d54a23faf0a4c5ffe4629ed41
+  --sha256: 1hkdc75mwpgkgbdz92lsq7ybrrmyb8dkqnqxmp27xl3jd6vdd258
   subdir:
     typed-protocols
     typed-protocols-cborg
     typed-protocols-examples
 
--- Drops an instance breaking cardano-node.
+-- It seems that if we remove this source-repository-package to rely on CHaP,
+-- for some reason, we're unable to retrieve the cardano-node executables in
+-- our nix/haskell.nix file.
+
+-- Without this source-repository-package:
+-- config.hsPkgs.cardano-node.components.exes
+-- => []
+--
+-- With:
+-- config.hsPkgs.cardano-node.components.exes
+-- => [ "cardano-node" ]
 source-repository-package
     type: git
-    location: https://github.com/input-output-hk/flat
-    tag: ee59880f47ab835dbd73bea0847dab7869fc20d8
-    --sha256: 1lrzknw765pz2j97nvv9ip3l1mcpf2zr4n56hwlz0rk7wq7ls4cm
-
--- Until https://github.com/tibbe/ekg-json/pull/12 gets merged with aeson2 support
-source-repository-package
-  type: git
-  location: https://github.com/vshabanov/ekg-json
-  tag: 00ebe7211c981686e65730b7144fbf5350462608
-  --sha256: 1zvjm3pb38w0ijig5wk5mdkzcszpmlp5d4zxvks2jk1rkypi8gsm
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/hedgehog-extras
-  tag: 714ee03a5a786a05fc57ac5d2f1c2edce4660d85
-  --sha256: 1qa4mm36xynaf17990ijmzww0ij8hjrc0vw5nas6d0zx6q9hb978
-
--- Workaround for duplicate modules warning
--- Related fix: https://github.com/astanin/moo/pull/11
--- Related slack thread: https://input-output-rnd.slack.com/archives/CG386Q1NE/p1664547089510409?thread_ts=1664541672.103389&cid=CG386Q1NE
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/moo
-  tag: 8c487714fbfdea66188fcb85053e7e292e0cc348
-  --sha256: 1mdj218hgh7s5a6b9k14vg9i06zxah0wa42ycdgh245izs8nfv0x
+    location: https://github.com/input-output-hk/cardano-node
+    tag: ebc7be471b30e5931b35f9bbc236d21c375b91bb
+    --sha256: 1j01m2cp2vdcl26zx9xmipr551v3b2rz9kfn9ik8byfwj1z7652r
+    subdir:
+      cardano-api
+      cardano-git-rev
+      cardano-cli
+      cardano-node
+      cardano-node-chairman
+      trace-dispatcher
+      trace-resources
+      trace-forward
 
 -- -------------------------------------------------------------------------
 -- Constraints tweaking
@@ -354,8 +198,7 @@ allow-newer:
   async-timer:unliftio-core
 
 constraints:
-    hashable < 1.4
-  , bimap >= 0.4.0
+    bimap >= 0.4.0
   , openapi3 >= 3.2.0
   , libsystemd-journal >= 1.4.4
   , systemd >= 2.3.0
@@ -367,12 +210,48 @@ constraints:
   , Cabal >= 3.4.0.0
   , async-timer >= 0.2.0.0
   , unliftio-core >= 0.2.0.1
+  , cardano-api == 1.35.4
+  , cardano-node == 1.35.4
+  , generic-arbitrary == 0.2.2
+  , iohk-monitoring >= 0.1.11
 
-  -- This pin is just here to make cabalProejct == stackProject.
-  -- Remove it if you are happy for a newer version to be picked when possible.
-  , semigroups == 0.19.2
-  , persistent < 2.13.3.4
+  -- Could probably be bumped with minor work in the wallet
+  , resource-pool == 0.2.3.2
 
+  -- TH Name shadowing warnings need to be addressed when bumping to 2.13.3.5
+  , persistent == 2.13.3.3
+
+  -- Copied from cardano-node's cabal.project:
+  , bimap >= 0.4.0
+  , libsystemd-journal >= 1.4.4
+  , systemd >= 2.3.0
+    -- systemd-2.3.0 requires at least network 3.1.1.0 but it doesn't declare
+    -- that dependency
+  , network >= 3.1.1.0
+  , HSOpenSSL >= 0.11.7.2
+  , algebraic-graphs < 0.7
+  , protolude < 0.3.1
+    -- TODO: these should be set in cabal files, but avoiding setting them in lower dependencies for initial CHaP release
+  , cardano-prelude == 0.1.0.0
+--  , cardano-prelude <0.1.0.1
+  , base-deriving-via == 0.1.0.0
+  , cardano-binary  == 1.5.0
+  , cardano-binary-test == 1.3.0
+  , cardano-crypto-class  == 2.0.0.0.1
+  , cardano-crypto-praos  == 2.0.0.0.1
+  , cardano-crypto-tests  == 2.0.0.0.1
+  , cardano-slotting  == 0.1.0.0
+  , measures == 0.1.0.0
+  , orphans-deriving-via == 0.1.0.0
+  , strict-containers == 0.1.0.0
+  , plutus-core == 1.0.0.1
+  , plutus-ledger-api == 1.0.0.1
+  , plutus-tx == 1.0.0.0
+  , plutus-tx-plugin == 1.0.0.0
+  , prettyprinter-configurable == 0.1.0.0
+  , plutus-ghc-stub == 8.6.5
+  , word-array == 0.1.0.0
+  , word-array == 0.1.0.0
 -- ----------------------------------------------------------------
 -- Flags for dependencies
 

--- a/cabal.project
+++ b/cabal.project
@@ -231,9 +231,7 @@ constraints:
   , HSOpenSSL >= 0.11.7.2
   , algebraic-graphs < 0.7
   , protolude < 0.3.1
-    -- TODO: these should be set in cabal files, but avoiding setting them in lower dependencies for initial CHaP release
   , cardano-prelude == 0.1.0.0
---  , cardano-prelude <0.1.0.1
   , base-deriving-via == 0.1.0.0
   , cardano-binary  == 1.5.0
   , cardano-binary-test == 1.3.0
@@ -252,6 +250,7 @@ constraints:
   , plutus-ghc-stub == 8.6.5
   , word-array == 0.1.0.0
   , word-array == 0.1.0.0
+
 -- ----------------------------------------------------------------
 -- Flags for dependencies
 

--- a/cabal.project
+++ b/cabal.project
@@ -138,6 +138,8 @@ source-repository-package
 -- Temporary patch for version 0.1.0.0 (181601bc3d9e9d21a671ce01e0b481348b3ca104)
 -- in order to change io-sim from 606de33fa2f467d108fb1efb86daeb3348bf34e3
 -- to 57e888b1894829056cb00b7b5785fdf6a74c3271 to include the ReaderT fix.
+--
+-- TODO [ADP-2447] This source-repository-package should be removable with next node bump.
 source-repository-package
   type: git
   location: https://github.com/Anviking/typed-protocols.git
@@ -159,6 +161,8 @@ source-repository-package
 -- With:
 -- config.hsPkgs.cardano-node.components.exes
 -- => [ "cardano-node" ]
+--
+-- TODO [ADP-2447] See if the situation has improved and try to remove this source-repository-package.
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-node

--- a/cabal.project
+++ b/cabal.project
@@ -125,6 +125,8 @@ source-repository-package
     tag: f73079303f663e028288f9f4a9e08bcca39a923e
     --sha256: 1n87i15x54s0cjkh3nsxs4r1x016cdw1fypwmr68936n3xxsjn6q
 
+-- Different version than from CHaP to include the ReaderT fix.
+-- TODO [ADP-2447] This source-repository-package should be removable with next node bump.
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/io-sim
@@ -134,21 +136,6 @@ source-repository-package
     io-classes
     io-sim
     strict-stm
-
--- Temporary patch for version 0.1.0.0 (181601bc3d9e9d21a671ce01e0b481348b3ca104)
--- in order to change io-sim from 606de33fa2f467d108fb1efb86daeb3348bf34e3
--- to 57e888b1894829056cb00b7b5785fdf6a74c3271 to include the ReaderT fix.
---
--- TODO [ADP-2447] This source-repository-package should be removable with next node bump.
-source-repository-package
-  type: git
-  location: https://github.com/Anviking/typed-protocols.git
-  tag: 93b180f0a8cba67d54a23faf0a4c5ffe4629ed41
-  --sha256: 1hkdc75mwpgkgbdz92lsq7ybrrmyb8dkqnqxmp27xl3jd6vdd258
-  subdir:
-    typed-protocols
-    typed-protocols-cborg
-    typed-protocols-examples
 
 -- It seems that if we remove this source-repository-package to rely on CHaP,
 -- for some reason, we're unable to retrieve the cardano-node executables in

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "CHaP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668433977,
+        "narHash": "sha256-JcfyzvIJeeXFu4nCJdR/uI9G5pmjcIZ79YxONKVy8GU=",
+        "owner": "input-output-hk",
+        "repo": "cardano-haskell-packages",
+        "rev": "7ba66a729344ced7636a419c99ddaba35d3f0b8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
     "HTTP": {
       "flake": false,
       "locked": {
@@ -415,6 +432,21 @@
     },
     "flake-utils_10": {
       "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_11": {
+      "locked": {
         "lastModified": 1653893745,
         "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
@@ -428,7 +460,7 @@
         "type": "github"
       }
     },
-    "flake-utils_11": {
+    "flake-utils_12": {
       "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
@@ -443,7 +475,7 @@
         "type": "github"
       }
     },
-    "flake-utils_12": {
+    "flake-utils_13": {
       "locked": {
         "lastModified": 1653893745,
         "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
@@ -750,11 +782,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663072120,
-        "narHash": "sha256-npRp5ULHI8/dvDAkBvudLybz0/vVBHg0p7ps7myxKgk=",
+        "lastModified": 1667394105,
+        "narHash": "sha256-YhS7zGd6jK/QM/+wWyj0zUBZmE3HOXAL/kpJptGYIWg=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "e936cc0972fceb544dd7847e39fbcace1c9c00de",
+        "rev": "7fc7625a9ab2ba137bc70ddbc89a13d3fdb78c8b",
         "type": "github"
       },
       "original": {
@@ -837,7 +869,7 @@
     },
     "n2c_2": {
       "inputs": {
-        "flake-utils": "flake-utils_12",
+        "flake-utils": "flake-utils_13",
         "nixpkgs": [
           "tullia",
           "std",
@@ -904,20 +936,10 @@
     "nix-nomad_2": {
       "inputs": {
         "flake-compat": "flake-compat_5",
-        "flake-utils": [
-          "tullia",
-          "nix2container",
-          "flake-utils"
-        ],
+        "flake-utils": "flake-utils_10",
         "gomod2nix": "gomod2nix_2",
-        "nixpkgs": [
-          "tullia",
-          "nixpkgs"
-        ],
-        "nixpkgs-lib": [
-          "tullia",
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_13",
+        "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
         "lastModified": 1658277770,
@@ -954,8 +976,8 @@
     },
     "nix2container_2": {
       "inputs": {
-        "flake-utils": "flake-utils_10",
-        "nixpkgs": "nixpkgs_13"
+        "flake-utils": "flake-utils_11",
+        "nixpkgs": "nixpkgs_14"
       },
       "locked": {
         "lastModified": 1658567952,
@@ -1133,6 +1155,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1668905993,
+        "narHash": "sha256-vv8a+x9X9YevHbly2R1gBFFObYnr2P3zfCm2A82/jBs=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "5f4e4e69b8fb6fa9e3cc83542b722e6657943379",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -1214,6 +1251,22 @@
     },
     "nixpkgs_13": {
       "locked": {
+        "lastModified": 1669316115,
+        "narHash": "sha256-olvHZVUaBp5uwm5XfrqPY0K4Itt48yMTDNu/G2i5R2s=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d4556b01cd32e95567656e7d9e11f39f011b5390",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_14": {
+      "locked": {
         "lastModified": 1654807842,
         "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
         "owner": "NixOS",
@@ -1227,7 +1280,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_14": {
+    "nixpkgs_15": {
       "locked": {
         "lastModified": 1665087388,
         "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
@@ -1401,6 +1454,7 @@
     },
     "root": {
       "inputs": {
+        "CHaP": "CHaP",
         "customConfig": "customConfig",
         "ema": "ema",
         "emanote": "emanote",
@@ -1477,7 +1531,7 @@
         "blank": "blank_2",
         "devshell": "devshell_2",
         "dmerge": "dmerge_2",
-        "flake-utils": "flake-utils_11",
+        "flake-utils": "flake-utils_12",
         "makes": [
           "tullia",
           "std",
@@ -1491,7 +1545,7 @@
         ],
         "n2c": "n2c_2",
         "nixago": "nixago_2",
-        "nixpkgs": "nixpkgs_14",
+        "nixpkgs": "nixpkgs_15",
         "yants": "yants_2"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,10 @@
   inputs = {
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     hostNixpkgs.follows = "nixpkgs";
+    CHaP = {
+      url = "github:input-output-hk/cardano-haskell-packages?ref=repo";
+      flake = false;
+    };
     haskellNix = {
       url = "github:input-output-hk/haskell.nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -61,7 +65,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, hostNixpkgs, flake-utils, haskellNix, iohkNix, customConfig, emanote, tullia, ... }:
+  outputs = { self, nixpkgs, hostNixpkgs, flake-utils, haskellNix, iohkNix, CHaP, customConfig, emanote, tullia, ... }:
     let
       inherit (nixpkgs) lib;
       config = import ./nix/config.nix lib customConfig;
@@ -150,7 +154,7 @@
               collectChecks
               check;
 
-            project = (import ./nix/haskell.nix pkgs.haskell-nix).appendModule [{
+            project = (import ./nix/haskell.nix CHaP pkgs.haskell-nix).appendModule [{
               gitrev =
                 if config.gitrev != null
                 then config.gitrev

--- a/lib/wallet/api/http/Cardano/Wallet/Launch/Cluster.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Launch/Cluster.hs
@@ -915,7 +915,7 @@ generateGenesis dir systemStart initialFunds addPoolsToGenesis = do
             -- There are a few smaller features/fixes which are enabled based on
             -- the protocol version rather than just the era, so we need to
             -- set it to a realisitic value.
-            , _protocolVersion = Ledger.ProtVer 7 0
+            , _protocolVersion = Ledger.ProtVer 8 0
 
             -- Sensible pool & reward parameters:
             , _nOpt = 3

--- a/lib/wallet/test/data/cardano-node-shelley/node.config
+++ b/lib/wallet/test/data/cardano-node-shelley/node.config
@@ -30,7 +30,7 @@ MaxConcurrencyDeadline: 2
 
 ApplicationName: cardano-sl
 ApplicationVersion: 1
-LastKnownBlockVersion-Major: 6
+LastKnownBlockVersion-Major: 8
 LastKnownBlockVersion-Minor: 0
 LastKnownBlockVersion-Alt: 0
 

--- a/lib/wallet/test/integration/shelley-integration-test.hs
+++ b/lib/wallet/test/integration/shelley-integration-test.hs
@@ -270,7 +270,7 @@ specWithServer testDir (tr, tracers) = aroundAll withContext
                     }
                 faucet <- initFaucet
 
-                era <- clusterToApiEra <$> clusterEraFromEnv
+                era <- clusterEraFromEnv
 
                 mintSeaHorseAssetsLock <- newMVar ()
 
@@ -282,15 +282,15 @@ specWithServer testDir (tr, tracers) = aroundAll withContext
                     , _feeEstimator = error "feeEstimator: unused in shelley specs"
                     , _networkParameters = np
                     , _poolGarbageCollectionEvents = poolGarbageCollectionEvents
-                    , _mainEra = era
+                    , _mainEra = clusterToApiEra era
                     , _smashUrl = smashUrl
                     , _mintSeaHorseAssets = \nPerAddr batchSize c addrs ->
                         withMVar mintSeaHorseAssetsLock $ \() ->
-                            sendFaucetAssetsTo tr' conn testDir batchSize
+                            sendFaucetAssetsTo tr' conn testDir era batchSize
                                 $ encodeAddresses
                                 $ seaHorseTestAssets nPerAddr c addrs
                     , _moveRewardsToScript = \(script, coin) ->
-                            moveInstantaneousRewardsTo tr' conn testDir
+                            moveInstantaneousRewardsTo tr' conn testDir era
                             [(ScriptCredential script, coin)]
                     }
         let action' = bracketTracer' tr "spec" . action

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -1,7 +1,7 @@
 ############################################################################
 # Builds Haskell packages with Haskell.nix
 ############################################################################
-haskell-nix: haskell-nix.cabalProject' [
+CHaP: haskell-nix: haskell-nix.cabalProject' [
   ({ lib, pkgs, buildProject, ... }: {
     options = {
       gitrev = lib.mkOption {
@@ -148,6 +148,8 @@ haskell-nix: haskell-nix.cabalProject' [
           (drv: lib.isDerivation drv && drv.name != "regenerate-materialized-nix")
           (lib.attrValues haskell-build-tools));
       };
+
+      inputMap = { "https://input-output-hk.github.io/cardano-haskell-packages" = CHaP; };
 
       modules =
         let inherit (config) src coverage profiling doIntegrationCheck buildBenchmarks;

--- a/nix/overlays/common-lib.nix
+++ b/nix/overlays/common-lib.nix
@@ -40,7 +40,7 @@ in {
 
     # Get the index-state and ghc version out of a cabal.project file.
     #
-    # TODO: It would be better to re-use functions from haskell.nix like:
+    # TODO [ADP-2445] It would be better to re-use functions from haskell.nix like:
     # https://github.com/input-output-hk/haskell.nix/blob/a30665693a1991341d067df55bbf2bec1124bddd/lib/cabal-project-parser.nix
     cabalProjectIndexState = cabalProject: let
       awkProgram = builtins.replaceStrings ["\n"] [" "] ''

--- a/nix/overlays/common-lib.nix
+++ b/nix/overlays/common-lib.nix
@@ -39,13 +39,24 @@ in {
       go;
 
     # Get the index-state and ghc version out of a cabal.project file.
+    #
+    # TODO: It would be better to re-use functions from haskell.nix like:
+    # https://github.com/input-output-hk/haskell.nix/blob/a30665693a1991341d067df55bbf2bec1124bddd/lib/cabal-project-parser.nix
     cabalProjectIndexState = cabalProject: let
+      awkProgram = builtins.replaceStrings ["\n"] [" "] ''
+            BEGIN { print "{"; }
+            END { print "}"; }
+            { if (($1=="index-state:" || $1=="with-compiler:") && $2!="cardano-haskell-packages")
+              { gsub(/:/, "", $1); print"  " $1 " = \"" $2 "\";"; }
+            }
+            '';
+
       parsed = import (self.runCommandNoCC "cabal-project-index-state.nix" {
         preferLocalBuild = true;
         allowSubstitutes = false;
-      } ''
-        awk 'BEGIN { print "{"; } END { print "}"; } /^(index-state|with-compiler)/ { gsub(/:/, "", $1); print"  " $1 " = \"" $2 "\";"; }' < ${cabalProject} > $out
-      '');
+      } (''
+          awk '${awkProgram}' < ${cabalProject} > $out
+        '' ));
     in {
       index-state = parsed.index-state or null;
       compiler-nix-name = if parsed ? with-compiler


### PR DESCRIPTION
- [x] Somehow use [CHaP](https://github.com/input-output-hk/cardano-haskell-packages) to get the right revisions
- [x] Keep `nix-shell` working 
- [x] Are we actually using the correct ledger revisions?
    - Seems right https://github.com/input-output-hk/plutus/blame/d5f6f4a5505094490f61c8d164515adf7c8f46cc/plutus-ledger-api/src/Plutus/ApiCommon.hs#L147
- [x] Get `cabal build` working
    - [x] Fix warnings of the type `src/Cardano/Pool/DB/Sqlite/TH.hs:56:1: warning: [-Wname-shadowing]`
- [x] De-duplicate source of truth for compiler version and index state
- [x] Use non-broken version of `io-classes` to fix integration tests
    - Can't use 0.2.0.0 / f4183f274d88d0ad15817c7052df3a6a8b40e6dc
- [x] Misc cleanup
- [x] Update readme matrix


### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2382
