### PR TITLE
Remove `scrypt` flag from libraries where it's unneeded.

### DIFF
--- a/lib/coin-selection/cardano-wallet-coin-selection.cabal
+++ b/lib/coin-selection/cardano-wallet-coin-selection.cabal
@@ -34,17 +34,9 @@ flag release
   default:     False
   manual:      True
 
-flag scrypt
-  description: Enable compatibility support for legacy wallet passwords.
-  default:     True
-
 library
   import:          language, opts-lib
   hs-source-dirs:  lib
-
-  if flag(scrypt)
-    cpp-options:   -DHAVE_SCRYPT
-    build-depends: scrypt
 
   build-depends:
     , base
@@ -102,10 +94,6 @@ test-suite test
     , safe
     , text
     , transformers
-
-  if flag(scrypt)
-    cpp-options:   -DHAVE_SCRYPT
-    build-depends: scrypt
 
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -34,17 +34,9 @@ flag release
   default:     False
   manual:      True
 
-flag scrypt
-  description: Enable compatibility support for legacy wallet passwords.
-  default:     True
-
 library
   import:          language, opts-lib
   hs-source-dirs:  lib
-
-  if flag(scrypt)
-    cpp-options:   -DHAVE_SCRYPT
-    build-depends: scrypt
 
   build-depends:
     , aeson
@@ -157,10 +149,6 @@ test-suite test
     , string-qq
     , text
     , text-class
-
-  if flag(scrypt)
-    cpp-options:   -DHAVE_SCRYPT
-    build-depends: scrypt
 
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:


### PR DESCRIPTION
## Issue Number

ADP-2386 (follow-on from #3591)

## Summary

This PR removes the `scrypt` flag from the following libraries:
- `cardano-wallet-primitive`
- `cardano-wallet-coin-selection`