### PR TITLE
Extract `DelegationRequest` data type and use in in the `constructTransaction`

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -367,13 +367,13 @@ instance IsServerError ErrConstructTx where
         ErrConstructTxMultidelegationNotSupported ->
             apiError err403 CreatedMultidelegationTransaction $ mconcat
             [ "It looks like I've created a transaction "
-            , "with multiple delegations, which is not supported at this moment."
+            , "with multiple delegations, which is not supported at this moment. "
             , "Please use at most one delegation action: join, quit or none."
             ]
         ErrConstructTxMultiaccountNotSupported ->
             apiError err403 CreatedMultiaccountTransaction $ mconcat
             [ "It looks like I've created a transaction "
-            , "with a delegation, which uses a stake key for the unsupported account."
+            , "with a delegation, which uses a stake key for the unsupported account. "
             , "Please use delegation action engaging '0H' account."
             ]
         ErrConstructTxWrongMintingBurningTemplate ->

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2420,12 +2420,12 @@ constructTransaction
         (_, _, rewardPath) <- liftHandler $ W.readRewardAccount @n db walletId
 
         let deposits = case txDelegationAction transactionCtx2 of
-              Just (JoinRegisteringKey _poolId) -> [W.stakeKeyDeposit pp]
-              _ -> []
+                Just (JoinRegisteringKey _poolId) -> [W.stakeKeyDeposit pp]
+                _ -> []
 
         let refunds = case txDelegationAction transactionCtx2 of
-              Just Quit -> [W.stakeKeyDeposit pp]
-              _ -> []
+                Just Quit -> [W.stakeKeyDeposit pp]
+                _ -> []
 
         pure ApiConstructTransaction
             { transaction = balancedTx

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1743,7 +1743,7 @@ selectCoinsForJoin ctx knownPools getPoolStatus pid wid = do
             $ W.readRewardAccount db wid
 
         let deposits = case action of
-                JoinRegsteringKey _poolId -> [W.stakeKeyDeposit pp]
+                JoinRegisteringKey _poolId -> [W.stakeKeyDeposit pp]
                 Join _poolId -> []
                 Quit -> []
 
@@ -2420,7 +2420,7 @@ constructTransaction
         (_, _, rewardPath) <- liftHandler $ W.readRewardAccount @n db walletId
 
         let deposits = case txDelegationAction transactionCtx2 of
-              Just (JoinRegsteringKey _poolId) -> [W.stakeKeyDeposit pp]
+              Just (JoinRegisteringKey _poolId) -> [W.stakeKeyDeposit pp]
               _ -> []
 
         let refunds = case txDelegationAction transactionCtx2 of
@@ -4123,7 +4123,7 @@ mkApiCoinSelection deps refunds mcerts metadata unsignedTx =
         case action of
             Join pid -> pure $ Api.JoinPool apiStakePath (ApiT pid)
             Quit -> pure $ Api.QuitPool apiStakePath
-            JoinRegsteringKey pid -> NE.fromList
+            JoinRegisteringKey pid -> NE.fromList
                 [ Api.RegisterRewardAccount apiStakePath
                 , Api.JoinPool apiStakePath (ApiT pid)
                 ]

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2518,9 +2518,9 @@ constructTransaction
         case otherActions of
             [] -> case action of
                Joining (ApiT pool) stakeKeyIdx | isValidKeyIdx stakeKeyIdx ->
-                    Right $ WD.StartDelegatingRegisteringKey pool
+                    Right $ WD.Join pool
                Leaving stakeKeyIdx | isValidKeyIdx stakeKeyIdx ->
-                    Right WD.StopDelegating
+                    Right WD.Quit
                _ -> Left ErrConstructTxMultiaccountNotSupported
             -- Current limitation:
             -- at this moment we are handling just one delegation action:

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1755,7 +1755,7 @@ selectCoinsForJoin ctx knownPools getPoolStatus pid wid = do
         let deposits = case action of
                 JoinRegsteringKey _poolId deposit -> [deposit]
                 Join _poolId -> []
-                Quit _redund -> []
+                Quit _refund -> []
 
         pure $ mkApiCoinSelection deposits [] (Just (action, path)) Nothing utx
 

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -241,6 +241,7 @@ library
     Cardano.Wallet.DB.Store.Wallets.Model
     Cardano.Wallet.DB.Store.Wallets.Store
     Cardano.Wallet.DB.WalletState
+    Cardano.Wallet.Delegation
     Cardano.Wallet.Gen
     Cardano.Wallet.Logging
     Cardano.Wallet.Network
@@ -310,6 +311,7 @@ library
     Cardano.Wallet.Read.Primitive.Tx.Mary
     Cardano.Wallet.Read.Primitive.Tx.Shelley
     Cardano.Wallet.Read.Tx
+    Cardano.Wallet.Read.Tx.Cardano
     Cardano.Wallet.Read.Tx.CBOR
     Cardano.Wallet.Read.Tx.Certificates
     Cardano.Wallet.Read.Tx.Eras
@@ -319,7 +321,6 @@ library
     Cardano.Wallet.Read.Tx.Mint
     Cardano.Wallet.Read.Tx.Validity
     Cardano.Wallet.Read.Tx.Witnesses
-    Cardano.Wallet.Read.Tx.Cardano
     Cardano.Wallet.Registry
     Cardano.Wallet.Shelley.BlockchainSource
     Cardano.Wallet.Shelley.Compatibility
@@ -722,6 +723,7 @@ test-suite unit
     , generic-lens
     , generics-sop
     , hedgehog
+    , hedgehog-corpus
     , hedgehog-quickcheck
     , hspec                        >=2.8.2
     , hspec-core                   >=2.8.2
@@ -830,6 +832,7 @@ test-suite unit
     Cardano.Wallet.DB.Store.Submissions.StoreSpec
     Cardano.Wallet.DB.Store.Transactions.StoreSpec
     Cardano.Wallet.DB.Store.Wallets.StoreSpec
+    Cardano.Wallet.DelegationSpec
     Cardano.Wallet.DummyTarget.Primitive.Types
     Cardano.Wallet.Network.LightSpec
     Cardano.Wallet.Network.PortsSpec
@@ -858,6 +861,7 @@ test-suite unit
     Cardano.Wallet.Primitive.Types.TxSpec
     Cardano.Wallet.Primitive.TypesSpec
     Cardano.Wallet.Read.Tx.CBORSpec
+    Cardano.Wallet.Read.Tx.CBORSpec
     Cardano.Wallet.RegistrySpec
     Cardano.Wallet.Shelley.Compatibility.LedgerSpec
     Cardano.Wallet.Shelley.CompatibilitySpec
@@ -868,7 +872,6 @@ test-suite unit
     Cardano.Wallet.Shelley.NetworkSpec
     Cardano.Wallet.Shelley.TransactionSpec
     Cardano.Wallet.TokenMetadataSpec
-    Cardano.Wallet.Read.Tx.CBORSpec
     Cardano.Wallet.Write.TxSpec
     Cardano.WalletSpec
     Control.Concurrent.ConciergeSpec

--- a/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
@@ -686,14 +686,14 @@ errMsg403MissingWitsInTransaction expected got = mconcat
 errMsg403MultidelegationTransaction :: String
 errMsg403MultidelegationTransaction = mconcat
     [ "It looks like I've created a transaction "
-    , "with multiple delegations, which is not supported at this moment."
+    , "with multiple delegations, which is not supported at this moment. "
     , "Please use at most one delegation action: join, quit or none."
     ]
 
 errMsg403MultiaccountTransaction :: String
 errMsg403MultiaccountTransaction = mconcat
     [ "It looks like I've created a transaction "
-    , "with a delegation, which uses a stake key for the unsupported account."
+    , "with a delegation, which uses a stake key for the unsupported account. "
     , "Please use delegation action engaging '0H' account."
     ]
 

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -2537,9 +2537,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             ]
 
     it "TRANS_NEW_JOIN_01b - Invalid pool id" $ \ctx -> runResourceT $ do
-
         wa <- fixtureWallet ctx
-
         let invalidPoolId = T.replicate 32 "1"
         let delegation = Json [json|{
                 "delegations": [{
@@ -2557,7 +2555,6 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             ]
 
     it "TRANS_NEW_JOIN_01b - Absent pool id" $ \ctx -> runResourceT $ do
-
         wa <- fixtureWallet ctx
         let absentPoolIdBech32 = "pool1mgjlw24rg8sp4vrzctqxtf2nn29rjhtkq2kdzvf4tcjd5pl547k"
         (Right absentPoolId) <- pure $ decodePoolIdBech32 absentPoolIdBech32
@@ -2577,7 +2574,6 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             ]
 
     it "TRANS_NEW_JOIN_01c - Multidelegation not supported" $ \ctx -> runResourceT $ do
-
         wa <- fixtureWallet ctx
         let pool' = "pool1mgjlw24rg8sp4vrzctqxtf2nn29rjhtkq2kdzvf4tcjd5pl547k" :: Text
         let delegations = Json [json|{
@@ -2600,16 +2596,10 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             ]
 
     it "TRANS_NEW_JOIN_01d - Multiaccount not supported" $ \ctx -> runResourceT $ do
-
         wa <- fixtureWallet ctx
         let pool' = "pool1mgjlw24rg8sp4vrzctqxtf2nn29rjhtkq2kdzvf4tcjd5pl547k" :: Text
         let delegations = Json [json|{
                 "delegations": [{
-                    "join": {
-                        "pool": #{pool'},
-                        "stake_key_index": "0H"
-                    }
-                },{
                     "join": {
                         "pool": #{pool'},
                         "stake_key_index": "1H"

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2409,7 +2409,7 @@ selectAssets ctx era pp params transform = do
                     _ -> 0
             , certificateDepositsTaken =
                 case params ^. #txContext . #txDelegationAction of
-                    Just (JoinRegsteringKey _) -> 1
+                    Just (JoinRegisteringKey _) -> 1
                     _ -> 0
             , collateralRequirement =
                 params ^. #txContext . #txCollateralRequirement

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2405,11 +2405,11 @@ selectAssets ctx era pp params transform = do
                 withdrawalToCoin $ params ^. #txContext . #txWithdrawal
             , certificateDepositsReturned =
                 case params ^. #txContext . #txDelegationAction of
-                    Just (Quit _refund) -> 1
+                    Just Quit -> 1
                     _ -> 0
             , certificateDepositsTaken =
                 case params ^. #txContext . #txDelegationAction of
-                    Just (JoinRegsteringKey _ _) -> 1
+                    Just (JoinRegsteringKey _) -> 1
                     _ -> 0
             , collateralRequirement =
                 params ^. #txContext . #txCollateralRequirement

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2379,8 +2379,7 @@ selectAssets
 selectAssets ctx era pp params transform = do
     guardPendingWithdrawal
     lift $ traceWith tr $ MsgSelectionStart
-        (UTxOSelection.availableSize
-            $ params ^. #utxoAvailableForInputs)
+        (UTxOSelection.availableSize $ params ^. #utxoAvailableForInputs)
         (params ^. #outputs)
     let selectionConstraints = SelectionConstraints
             { assessTokenBundleSize =
@@ -2390,11 +2389,9 @@ selectAssets ctx era pp params transform = do
             , certificateDepositAmount =
                 view #stakeKeyDeposit pp
             , computeMinimumAdaQuantity =
-                view #txOutputMinimumAdaQuantity
-                    (constraints tl era pp)
+                view #txOutputMinimumAdaQuantity (constraints tl era pp)
             , isBelowMinimumAdaQuantity =
-                view #txOutputBelowMinimumAdaQuantity
-                    (constraints tl era pp)
+                view #txOutputBelowMinimumAdaQuantity (constraints tl era pp)
             , computeMinimumCost =
                 calcMinimumCost tl era pp $ params ^. #txContext
             , computeSelectionLimit =
@@ -2409,24 +2406,24 @@ selectAssets ctx era pp params transform = do
             }
     let selectionParams = SelectionParams
             { assetsToMint =
-                fst $ params ^. (#txContext . #txAssetsToMint)
+                fst $ params ^. #txContext . #txAssetsToMint
             , assetsToBurn =
-                fst $ params ^. (#txContext . #txAssetsToBurn)
+                fst $ params ^. #txContext . #txAssetsToBurn
             , extraCoinIn = Coin 0
             , extraCoinOut = Coin 0
             , outputsToCover = params ^. #outputs
             , rewardWithdrawal =
-                withdrawalToCoin $ params ^. (#txContext . #txWithdrawal)
+                withdrawalToCoin $ params ^. #txContext . #txWithdrawal
             , certificateDepositsReturned =
-                case params ^. (#txContext . #txDelegationAction) of
+                case params ^. #txContext . #txDelegationAction of
                     Just Quit -> 1
                     _ -> 0
             , certificateDepositsTaken =
-                case params ^. (#txContext . #txDelegationAction) of
-                    Just (RegisterKeyAndJoin _) -> 1
+                case params ^. #txContext . #txDelegationAction of
+                    Just (JoinRegsteringKey _ _) -> 1
                     _ -> 0
             , collateralRequirement =
-                params ^. (#txContext . #txCollateralRequirement)
+                params ^. #txContext . #txCollateralRequirement
             , utxoAvailableForCollateral =
                 params ^. #utxoAvailableForCollateral
             , utxoAvailableForInputs =

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -152,11 +152,6 @@ module Cardano.Wallet
 
     -- ** Delegation
     , PoolRetirementEpochInfo (..)
-    , joinStakePool
-    , quitStakePool
-    , validatedQuitStakePoolAction
-    , guardJoin
-    , guardQuit
     , ErrStakePoolDelegation (..)
 
     -- ** Fee Estimation
@@ -232,8 +227,6 @@ import Cardano.Crypto.Wallet
     ( toXPub )
 import Cardano.Mnemonic
     ( SomeMnemonic )
-import Cardano.Pool.Types
-    ( PoolId )
 import Cardano.Slotting.Slot
     ( SlotNo (..) )
 import Cardano.Tx.Balance.Internal.CoinSelection
@@ -397,10 +390,8 @@ import Cardano.Wallet.Primitive.Types
     , DelegationCertificate (..)
     , FeePolicy (LinearFee)
     , GenesisParameters (..)
-    , IsDelegatingTo (..)
     , LinearFunction (LinearFunction)
     , NetworkParameters (..)
-    , PoolLifeCycleStatus
     , ProtocolParameters (..)
     , Range (..)
     , Signature (..)
@@ -590,8 +581,6 @@ import GHC.Generics
     ( Generic )
 import Numeric.Natural
     ( Natural )
-import Safe
-    ( lastMay )
 import Statistics.Quantile
     ( medianUnbiased, quantiles )
 import System.Random.StdGenSeed
@@ -2420,7 +2409,7 @@ selectAssets ctx era pp params transform = do
                     _ -> 0
             , certificateDepositsTaken =
                 case params ^. #txContext . #txDelegationAction of
-                    Just (JoinRegsteringKey _ _) -> 1
+                    Just (RegisterKeyAndJoin _) -> 1
                     _ -> 0
             , collateralRequirement =
                 params ^. #txContext . #txCollateralRequirement
@@ -3108,94 +3097,6 @@ migrationPlanToSelectionWithdrawals plan rewardWithdrawal outputAddressesToCycle
         outputAddressesRemaining :: [Address]
         outputAddressesRemaining =
             drop (length outputs) outputAddresses
-
-{-------------------------------------------------------------------------------
-                                  Delegation
--------------------------------------------------------------------------------}
-
-joinStakePool
-    :: forall ctx s k.
-        ( HasDBLayer IO s k ctx
-        , HasNetworkLayer IO ctx
-        , HasLogger IO WalletWorkerLog ctx
-        )
-    => ctx
-    -> W.EpochNo
-    -> Set PoolId
-    -> PoolId
-    -> PoolLifeCycleStatus
-    -> WalletId
-    -> ExceptT ErrStakePoolDelegation IO (DelegationAction, Maybe Coin)
-    -- ^ snd is the deposit
-joinStakePool ctx currentEpoch knownPools pid poolStatus wid =
-    db & \DBLayer{..} -> do
-        ((_ , walDelegation), isKeyReg) <- mapExceptT atomically $ do
-            walMeta <- withExceptT ErrStakePoolDelegationNoSuchWallet
-                $ withNoSuchWallet wid
-                $ readWalletMeta wid
-            isKeyReg <- withExceptT ErrStakePoolDelegationNoSuchWallet
-                $ isStakeKeyRegistered wid
-            pure (walMeta, isKeyReg)
-
-        let mRetirementEpoch = view #retirementEpoch <$>
-                W.getPoolRetirementCertificate poolStatus
-        let retirementInfo =
-                PoolRetirementEpochInfo currentEpoch <$> mRetirementEpoch
-
-        withExceptT ErrStakePoolJoin $ except $
-            guardJoin knownPools walDelegation pid retirementInfo
-
-        liftIO $ traceWith tr $ MsgIsStakeKeyRegistered isKeyReg
-
-        dep <- liftIO $ stakeKeyDeposit <$> currentProtocolParameters nl
-
-        return $ if isKeyReg
-            then (Join pid, Nothing)
-            else (RegisterKeyAndJoin pid, Just dep)
-  where
-    db = ctx ^. dbLayer @IO @s @k
-    tr = contramap MsgWallet $ ctx ^. logger
-    nl = ctx ^. networkLayer
-
--- | Helper function to factor necessary logic for quitting a stake pool.
-validatedQuitStakePoolAction
-    :: forall s k
-     . DBLayer IO s k
-    -> WalletId
-    -> Withdrawal
-    -> IO DelegationAction
-validatedQuitStakePoolAction db@DBLayer{..} walletId withdrawal = do
-    (_, delegation) <- atomically (readWalletMeta walletId)
-        >>= maybe
-            (throwIO (ExceptionStakePoolDelegation
-                (ErrStakePoolDelegationNoSuchWallet
-                    (ErrNoSuchWallet walletId))))
-            pure
-    rewards <- liftIO $ fetchRewardBalance @s @k db walletId
-    either (throwIO . ExceptionStakePoolDelegation . ErrStakePoolQuit) pure
-        (guardQuit delegation withdrawal rewards)
-    pure Quit
-
-quitStakePool
-    :: forall (n :: NetworkDiscriminant)
-     . NetworkLayer IO Block
-    -> DBLayer IO (SeqState n ShelleyKey) ShelleyKey
-    -> TimeInterpreter (ExceptT PastHorizonException IO)
-    -> WalletId
-    -> IO TransactionCtx
-quitStakePool netLayer db timeInterpreter walletId = do
-    (rewardAccount, _, derivationPath) <-
-        runExceptT (readRewardAccount db walletId)
-            >>= either (throwIO . ExceptionReadRewardAccount) pure
-    withdrawal <- WithdrawalSelf rewardAccount derivationPath
-        <$> getCachedRewardAccountBalance netLayer rewardAccount
-    action <- validatedQuitStakePoolAction db walletId withdrawal
-    ttl <- transactionExpirySlot timeInterpreter  Nothing
-    pure defaultTransactionCtx
-        { txWithdrawal = withdrawal
-        , txValidityInterval = (Nothing, ttl)
-        , txDelegationAction = Just action
-        }
 
 {-------------------------------------------------------------------------------
                                  Fee Estimation
@@ -3961,43 +3862,6 @@ data PoolRetirementEpochInfo = PoolRetirementEpochInfo
         -- ^ The retirement epoch of a pool.
     }
     deriving (Eq, Generic, Show)
-
-guardJoin
-    :: Set PoolId
-    -> WalletDelegation
-    -> PoolId
-    -> Maybe PoolRetirementEpochInfo
-    -> Either ErrCannotJoin ()
-guardJoin knownPools delegation pid mRetirementEpochInfo = do
-    when (pid `Set.notMember` knownPools) $
-        Left (ErrNoSuchPool pid)
-
-    forM_ mRetirementEpochInfo $ \info ->
-        when (currentEpoch info >= retirementEpoch info) $
-            Left (ErrNoSuchPool pid)
-
-    when ((null next) && isDelegatingTo (== pid) active) $
-        Left (ErrAlreadyDelegating pid)
-
-    when (not (null next) && isDelegatingTo (== pid) (last next)) $
-        Left (ErrAlreadyDelegating pid)
-  where
-    WalletDelegation {active, next} = delegation
-
-guardQuit :: WalletDelegation -> Withdrawal -> Coin -> Either ErrCannotQuit ()
-guardQuit WalletDelegation{active,next} wdrl rewards = do
-    let last_ = maybe active (view #status) $ lastMay next
-
-    unless (isDelegatingTo anyone last_) $
-        Left ErrNotDelegatingOrAboutTo
-
-    case wdrl of
-        WithdrawalSelf {} -> return ()
-        _
-            | rewards == Coin 0  -> return ()
-            | otherwise          -> Left $ ErrNonNullRewards rewards
-  where
-    anyone = const True
 
 {-------------------------------------------------------------------------------
                                     Logging

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2409,7 +2409,7 @@ selectAssets ctx era pp params transform = do
                     _ -> 0
             , certificateDepositsTaken =
                 case params ^. #txContext . #txDelegationAction of
-                    Just (RegisterKeyAndJoin _) -> 1
+                    Just (JoinRegsteringKey _ _) -> 1
                     _ -> 0
             , collateralRequirement =
                 params ^. #txContext . #txCollateralRequirement

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2405,7 +2405,7 @@ selectAssets ctx era pp params transform = do
                 withdrawalToCoin $ params ^. #txContext . #txWithdrawal
             , certificateDepositsReturned =
                 case params ^. #txContext . #txDelegationAction of
-                    Just Quit -> 1
+                    Just (Quit _refund) -> 1
                     _ -> 0
             , certificateDepositsTaken =
                 case params ^. #txContext . #txDelegationAction of

--- a/lib/wallet/src/Cardano/Wallet/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation.hs
@@ -150,7 +150,7 @@ joinStakePoolDelegationAction
     pure $
         if stakeKeyIsRegistered
         then Join poolId
-        else JoinRegsteringKey poolId
+        else JoinRegisteringKey poolId
 
 guardJoin
     :: Set PoolId

--- a/lib/wallet/src/Cardano/Wallet/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation.hs
@@ -1,0 +1,198 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Wallet.Delegation
+    ( joinStakePool
+    , guardJoin
+    , quitStakePool
+    , guardQuit
+    , validatedQuitStakePoolAction
+    ) where
+
+import Prelude
+
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Data.Set as Set
+
+import Cardano.Pool.Types
+    ( PoolId (..) )
+import Cardano.Wallet
+    ( ErrCannotQuit (..)
+    , ErrNoSuchWallet (..)
+    , ErrStakePoolDelegation (..)
+    , PoolRetirementEpochInfo (..)
+    , WalletException (..)
+    , WalletLog (..)
+    , fetchRewardBalance
+    , readRewardAccount
+    , transactionExpirySlot
+    , withNoSuchWallet
+    )
+import Cardano.Wallet.DB
+    ( DBLayer (..) )
+import Cardano.Wallet.Network
+    ( NetworkLayer (..) )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( NetworkDiscriminant )
+import Cardano.Wallet.Primitive.AddressDerivation.Shelley
+    ( ShelleyKey (..) )
+import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
+    ( SeqState (..) )
+import Cardano.Wallet.Primitive.Slotting
+    ( PastHorizonException, TimeInterpreter )
+import Cardano.Wallet.Primitive.Types
+    ( Block (..)
+    , IsDelegatingTo (..)
+    , PoolLifeCycleStatus
+    , ProtocolParameters (..)
+    , WalletDelegation (..)
+    , WalletId (..)
+    )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Transaction
+    ( DelegationAction (..)
+    , ErrCannotJoin (..)
+    , TransactionCtx
+    , Withdrawal (..)
+    , defaultTransactionCtx
+    , txDelegationAction
+    , txValidityInterval
+    , txWithdrawal
+    )
+import Control.Error
+    ( lastMay )
+import Control.Exception
+    ( throwIO )
+import Control.Monad
+    ( forM_, unless, when )
+import Control.Monad.Except
+    ( ExceptT, mapExceptT, runExceptT, withExceptT )
+import Control.Monad.IO.Class
+    ( MonadIO (..) )
+import Control.Monad.Trans.Except
+    ( except )
+import Control.Tracer
+    ( Tracer, traceWith )
+import Data.Generics.Internal.VL.Lens
+    ( view )
+import Data.Set
+    ( Set )
+
+
+joinStakePool
+    :: forall s k
+     . Tracer IO WalletLog
+    -> DBLayer IO s k
+    -> NetworkLayer IO Block
+    -> W.EpochNo
+    -> Set PoolId
+    -> PoolId
+    -> PoolLifeCycleStatus
+    -> WalletId
+    -> ExceptT ErrStakePoolDelegation IO (DelegationAction, Maybe Coin)
+    -- ^ snd is the deposit
+joinStakePool tr DBLayer{..} nl currentEpoch knownPools pid poolStatus wid = do
+    ((_ , walDelegation), isKeyReg) <- mapExceptT atomically $ do
+        walMeta <- withExceptT ErrStakePoolDelegationNoSuchWallet
+            $ withNoSuchWallet wid
+            $ readWalletMeta wid
+        isKeyReg <- withExceptT ErrStakePoolDelegationNoSuchWallet
+            $ isStakeKeyRegistered wid
+        pure (walMeta, isKeyReg)
+
+    let mRetirementEpoch = view #retirementEpoch <$>
+            W.getPoolRetirementCertificate poolStatus
+    let retirementInfo =
+            PoolRetirementEpochInfo currentEpoch <$> mRetirementEpoch
+
+    withExceptT ErrStakePoolJoin $ except $
+        guardJoin knownPools walDelegation pid retirementInfo
+
+    liftIO $ traceWith tr $ MsgIsStakeKeyRegistered isKeyReg
+
+    dep <- liftIO $ stakeKeyDeposit <$> currentProtocolParameters nl
+
+    pure $ if isKeyReg
+        then (Join pid, Nothing)
+        else (RegisterKeyAndJoin pid, Just dep)
+
+guardJoin
+    :: Set PoolId
+    -> WalletDelegation
+    -> PoolId
+    -> Maybe PoolRetirementEpochInfo
+    -> Either ErrCannotJoin ()
+guardJoin knownPools delegation pid mRetirementEpochInfo = do
+    when (pid `Set.notMember` knownPools) $
+        Left (ErrNoSuchPool pid)
+
+    forM_ mRetirementEpochInfo $ \info ->
+        when (currentEpoch info >= retirementEpoch info) $
+            Left (ErrNoSuchPool pid)
+
+    when ((null next) && isDelegatingTo (== pid) active) $
+        Left (ErrAlreadyDelegating pid)
+
+    when (not (null next) && isDelegatingTo (== pid) (last next)) $
+        Left (ErrAlreadyDelegating pid)
+  where
+    WalletDelegation {active, next} = delegation
+
+-- | Helper function to factor necessary logic for quitting a stake pool.
+validatedQuitStakePoolAction
+    :: forall s k
+     . DBLayer IO s k
+    -> WalletId
+    -> Withdrawal
+    -> IO DelegationAction
+validatedQuitStakePoolAction db@DBLayer{..} walletId withdrawal = do
+    (_, delegation) <- atomically (readWalletMeta walletId)
+        >>= maybe
+            (throwIO (ExceptionStakePoolDelegation
+                (ErrStakePoolDelegationNoSuchWallet
+                    (ErrNoSuchWallet walletId))))
+            pure
+    rewards <- liftIO $ fetchRewardBalance @s @k db walletId
+    either (throwIO . ExceptionStakePoolDelegation . ErrStakePoolQuit) pure
+        (guardQuit delegation withdrawal rewards)
+    pure Quit
+
+quitStakePool
+    :: forall (n :: NetworkDiscriminant)
+     . NetworkLayer IO Block
+    -> DBLayer IO (SeqState n ShelleyKey) ShelleyKey
+    -> TimeInterpreter (ExceptT PastHorizonException IO)
+    -> WalletId
+    -> IO TransactionCtx
+quitStakePool netLayer db timeInterpreter walletId = do
+    (rewardAccount, _, derivationPath) <-
+        runExceptT (readRewardAccount db walletId)
+            >>= either (throwIO . ExceptionReadRewardAccount) pure
+    withdrawal <- WithdrawalSelf rewardAccount derivationPath
+        <$> getCachedRewardAccountBalance netLayer rewardAccount
+    action <- validatedQuitStakePoolAction db walletId withdrawal
+    ttl <- transactionExpirySlot timeInterpreter  Nothing
+    pure defaultTransactionCtx
+        { txWithdrawal = withdrawal
+        , txValidityInterval = (Nothing, ttl)
+        , txDelegationAction = Just action
+        }
+
+guardQuit :: WalletDelegation -> Withdrawal -> Coin -> Either ErrCannotQuit ()
+guardQuit WalletDelegation{active,next} wdrl rewards = do
+    let last_ = maybe active (view #status) $ lastMay next
+    let anyone _ = True
+    unless (isDelegatingTo anyone last_) $ Left ErrNotDelegatingOrAboutTo
+
+    case wdrl of
+        WithdrawalSelf {} -> Right ()
+        _
+            | rewards == Coin 0  -> Right ()
+            | otherwise          -> Left $ ErrNonNullRewards rewards

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -726,7 +726,7 @@ mkDelegationCertificates da accXPub =
     case da of
        Join poolId ->
                [ toStakePoolDlgCert accXPub poolId ]
-       JoinRegsteringKey poolId ->
+       JoinRegisteringKey poolId ->
             [ toStakeKeyRegCert accXPub
             , toStakePoolDlgCert accXPub poolId
             ]
@@ -1859,7 +1859,7 @@ estimateTxSize era skeleton =
             = case txDelegationAction of
                 Nothing ->
                     0
-                Just JoinRegsteringKey{} ->
+                Just JoinRegisteringKey{} ->
                     sizeOf_SmallUInt
                     + sizeOf_SmallArray
                     + sizeOf_StakeRegistration

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -726,11 +726,11 @@ mkDelegationCertificates da accXPub =
     case da of
        Join poolId ->
                [ toStakePoolDlgCert accXPub poolId ]
-       JoinRegsteringKey poolId _depositAmount ->
+       JoinRegsteringKey poolId ->
             [ toStakeKeyRegCert accXPub
             , toStakePoolDlgCert accXPub poolId
             ]
-       Quit _refundAmount -> [toStakeKeyDeregCert accXPub]
+       Quit -> [toStakeKeyDeregCert accXPub]
 
 
 -- | For testing that

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -726,7 +726,7 @@ mkDelegationCertificates da accXPub =
     case da of
        Join poolId ->
                [ toStakePoolDlgCert accXPub poolId ]
-       RegisterKeyAndJoin poolId ->
+       JoinRegsteringKey poolId _depositAmount ->
                [ toStakeKeyRegCert  accXPub
                , toStakePoolDlgCert accXPub poolId
                ]
@@ -1859,7 +1859,7 @@ estimateTxSize era skeleton =
             = case txDelegationAction of
                 Nothing ->
                     0
-                Just RegisterKeyAndJoin{} ->
+                Just JoinRegsteringKey{} ->
                     sizeOf_SmallUInt
                     + sizeOf_SmallArray
                     + sizeOf_StakeRegistration

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -727,10 +727,10 @@ mkDelegationCertificates da accXPub =
        Join poolId ->
                [ toStakePoolDlgCert accXPub poolId ]
        JoinRegsteringKey poolId _depositAmount ->
-               [ toStakeKeyRegCert  accXPub
-               , toStakePoolDlgCert accXPub poolId
-               ]
-       Quit -> [toStakeKeyDeregCert accXPub]
+            [ toStakeKeyRegCert accXPub
+            , toStakePoolDlgCert accXPub poolId
+            ]
+       Quit _refundAmount -> [toStakeKeyDeregCert accXPub]
 
 
 -- | For testing that

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -24,8 +24,6 @@ module Cardano.Wallet.Transaction
     -- * Interface
       TransactionLayer (..)
     , DelegationAction (..)
-    , delegationActionDeposit
-    , delegationActionRefund
     , TransactionCtx (..)
     , PreSelection (..)
     , defaultTransactionCtx
@@ -397,18 +395,7 @@ data TransactionCtx = TransactionCtx
     } deriving (Show, Generic, Eq)
 
 -- | Represents a preliminary selection of tx outputs typically made by user.
-data PreSelection = PreSelection
-    { outputs :: ![TxOut]
-      -- ^ User-specified outputs
-    , assetsToMint :: !TokenMap
-      -- ^ Assets to mint.
-    , assetsToBurn :: !TokenMap
-      -- ^ Assets to burn.
-    , extraCoinSource :: !Coin
-      -- ^ An extra source of ada.
-    , extraCoinSink :: !Coin
-      -- ^ An extra sink for ada.
-    }
+newtype PreSelection = PreSelection { outputs :: [TxOut] }
     deriving (Generic, Eq, Show)
 
 data Withdrawal
@@ -443,25 +430,13 @@ defaultTransactionCtx = TransactionCtx
 -- | User-requested action related to a delegation
 -- that is taken into account when constructing a transaction.
 data DelegationAction
-    = JoinRegsteringKey PoolId Coin
-    -- ^ Join stake pool, registering stake key with deposit amount in `Coin`s
+    = JoinRegsteringKey PoolId
+    -- ^ Join stake pool, registering stake key.
     | Join PoolId
     -- ^ Join stake pool, assuming that stake key has been registered before.
-    | Quit Coin
-    -- ^ Quit all stake pools, receiving deposit amount in `Coin`s back.
+    | Quit
+    -- ^ Quit all stake pools
     deriving (Show, Eq, Generic)
-
-delegationActionDeposit :: DelegationAction -> Maybe Coin
-delegationActionDeposit = \case
-  JoinRegsteringKey _poolId deposit -> Just deposit
-  Join _poolId -> Nothing
-  Quit _refund -> Nothing
-
-delegationActionRefund :: DelegationAction -> Maybe Coin
-delegationActionRefund = \case
-  JoinRegsteringKey _poolId _deposit -> Nothing
-  Join _poolId -> Nothing
-  Quit refund -> Just refund
 
 instance Buildable DelegationAction where
     build = genericF

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -24,6 +24,7 @@ module Cardano.Wallet.Transaction
     -- * Interface
       TransactionLayer (..)
     , DelegationAction (..)
+    , delegationActionDeposit
     , TransactionCtx (..)
     , PreSelection (..)
     , defaultTransactionCtx
@@ -438,9 +439,22 @@ defaultTransactionCtx = TransactionCtx
     , txFeePadding = Coin 0
     }
 
--- | Whether the user is attempting any particular delegation action.
-data DelegationAction = RegisterKeyAndJoin PoolId | Join PoolId | Quit
+-- | User-requested action related to a delegation
+-- that is taken into account when constructing a transaction.
+data DelegationAction
+    = JoinRegsteringKey PoolId Coin
+    -- ^ Join stake pool, registering stake key with deposit amount in `Coin`s
+    | Join PoolId
+    -- ^ Join stake pool, assuming that stake key has been registered before.
+    | Quit
+    -- ^ Quit all stake pools
     deriving (Show, Eq, Generic)
+
+delegationActionDeposit :: DelegationAction -> Maybe Coin
+delegationActionDeposit = \case
+  JoinRegsteringKey _poolId deposit -> Just deposit
+  Join _poolId -> Nothing
+  Quit -> Nothing
 
 instance Buildable DelegationAction where
     build = genericF

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -25,6 +25,7 @@ module Cardano.Wallet.Transaction
       TransactionLayer (..)
     , DelegationAction (..)
     , delegationActionDeposit
+    , delegationActionRefund
     , TransactionCtx (..)
     , PreSelection (..)
     , defaultTransactionCtx
@@ -446,15 +447,21 @@ data DelegationAction
     -- ^ Join stake pool, registering stake key with deposit amount in `Coin`s
     | Join PoolId
     -- ^ Join stake pool, assuming that stake key has been registered before.
-    | Quit
-    -- ^ Quit all stake pools
+    | Quit Coin
+    -- ^ Quit all stake pools, receiving deposit amount in `Coin`s back.
     deriving (Show, Eq, Generic)
 
 delegationActionDeposit :: DelegationAction -> Maybe Coin
 delegationActionDeposit = \case
   JoinRegsteringKey _poolId deposit -> Just deposit
   Join _poolId -> Nothing
-  Quit -> Nothing
+  Quit _refund -> Nothing
+
+delegationActionRefund :: DelegationAction -> Maybe Coin
+delegationActionRefund = \case
+  JoinRegsteringKey _poolId _deposit -> Nothing
+  Join _poolId -> Nothing
+  Quit refund -> Just refund
 
 instance Buildable DelegationAction where
     build = genericF

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -430,7 +430,7 @@ defaultTransactionCtx = TransactionCtx
 -- | User-requested action related to a delegation
 -- that is taken into account when constructing a transaction.
 data DelegationAction
-    = JoinRegsteringKey PoolId
+    = JoinRegisteringKey PoolId
     -- ^ Join stake pool, registering stake key.
     | Join PoolId
     -- ^ Join stake pool, assuming that stake key has been registered before.

--- a/lib/wallet/test/unit/Cardano/Wallet/DelegationSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DelegationSpec.hs
@@ -1,0 +1,252 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Wallet.DelegationSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Pool.Types
+    ( PoolId (..) )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( DerivationIndex (..) )
+import Cardano.Wallet.Primitive.Types
+    ( EpochNo (..)
+    , WalletDelegation (..)
+    , WalletDelegationNext (WalletDelegationNext)
+    , WalletDelegationStatus (..)
+    )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Coin.Gen
+    ( genCoinPositive )
+import Cardano.Wallet.Primitive.Types.RewardAccount
+    ( RewardAccount (..) )
+import Cardano.Wallet.Transaction
+    ( Withdrawal (..) )
+import Data.List.NonEmpty
+    ( NonEmpty (..) )
+import Data.Maybe
+    ( isNothing )
+import Data.Word
+    ( Word64 )
+import Data.Word.Odd
+    ( Word31 )
+import Hedgehog.Corpus
+    ( metasyntactic )
+import Test.Hspec
+    ( Spec, describe, it, shouldBe )
+import Test.Hspec.Extra
+    ( parallel )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , NonEmptyList (..)
+    , Property
+    , arbitrarySizedBoundedIntegral
+    , checkCoverage
+    , cover
+    , elements
+    , label
+    , oneof
+    , property
+    , shrinkIntegral
+    , vector
+    , (.&&.)
+    , (===)
+    )
+import Test.QuickCheck.Arbitrary.Generic
+    ( genericArbitrary, genericShrink )
+
+import qualified Cardano.Wallet as W
+import qualified Cardano.Wallet.Delegation as WD
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+import qualified Data.ByteString as BS
+import qualified Data.Set as Set
+
+spec :: Spec
+spec = parallel $ describe "Cardano.Wallet.DelegationSpec" $ do
+
+    describe "Join/Quit Stake pool properties" $ do
+        it "You can quit if you cannot join" $ do
+            property prop_guardJoinQuit
+        it "You can join if you cannot quit" $ do
+            property prop_guardQuitJoin
+
+    describe "Join/Quit Stake pool unit mockEventSource" $ do
+        it "Cannot join A, when active = A" $ do
+            let dlg = WalletDelegation {active = Delegating pidA, next = []}
+            WD.guardJoin knownPools dlg pidA noRetirementPlanned
+                `shouldBe` Left (W.ErrAlreadyDelegating pidA)
+        it "Cannot join A, when next = [A]" $ do
+            let next1 = WalletDelegationNext (EpochNo 1) (Delegating pidA)
+            let dlg = WalletDelegation {active = NotDelegating, next = [next1]}
+            WD.guardJoin knownPools dlg pidA noRetirementPlanned
+                `shouldBe` Left (W.ErrAlreadyDelegating pidA)
+        it "Can join A, when active = A, next = [B]" $ do
+            let next1 = WalletDelegationNext (EpochNo 1) (Delegating pidB)
+            let dlg = WalletDelegation
+                    {active = Delegating pidA, next = [next1]}
+            WD.guardJoin knownPools dlg pidA noRetirementPlanned
+                `shouldBe` Right ()
+        it "Cannot join A, when active = A, next = [B, A]" $ do
+            let next1 = WalletDelegationNext (EpochNo 1) (Delegating pidB)
+            let next2 = WalletDelegationNext (EpochNo 2) (Delegating pidA)
+            let dlg = WalletDelegation
+                    {active = Delegating pidA, next = [next1, next2]}
+            WD.guardJoin knownPools dlg pidA noRetirementPlanned
+                `shouldBe` Left (W.ErrAlreadyDelegating pidA)
+        it "Cannot join when pool is unknown" $ do
+            let dlg = WalletDelegation {active = NotDelegating, next = []}
+            WD.guardJoin knownPools dlg pidUnknown noRetirementPlanned
+                `shouldBe` Left (W.ErrNoSuchPool pidUnknown)
+        it "Cannot quit when active: not_delegating, next = []" $ do
+            let dlg = WalletDelegation {active = NotDelegating, next = []}
+            WD.guardQuit dlg NoWithdrawal (Coin 0)
+                `shouldBe` Left (W.ErrNotDelegatingOrAboutTo)
+        it "Cannot quit when active: A, next = [not_delegating]" $ do
+            let next1 = WalletDelegationNext (EpochNo 1) NotDelegating
+            let dlg = WalletDelegation
+                    {active = Delegating pidA, next = [next1]}
+            WD.guardQuit dlg NoWithdrawal (Coin 0)
+                `shouldBe` Left (W.ErrNotDelegatingOrAboutTo)
+        it "Cannot quit when active: A, next = [B, not_delegating]" $ do
+            let next1 = WalletDelegationNext (EpochNo 1) (Delegating pidB)
+            let next2 = WalletDelegationNext (EpochNo 2) NotDelegating
+            let dlg = WalletDelegation
+                    {active = Delegating pidA, next = [next1, next2]}
+            WD.guardQuit dlg NoWithdrawal (Coin 0)
+                `shouldBe` Left (W.ErrNotDelegatingOrAboutTo)
+        it "Can quit when active: not_delegating, next = [A]" $ do
+            let next1 = WalletDelegationNext (EpochNo 1) (Delegating pidA)
+            let dlg = WalletDelegation
+                    {active = NotDelegating, next = [next1]}
+            WD.guardQuit dlg NoWithdrawal (Coin 0) `shouldBe` Right ()
+  where
+    pidA = PoolId "A"
+    pidB = PoolId "B"
+    pidUnknown = PoolId "unknown"
+    knownPools = Set.fromList [pidA, pidB]
+    noRetirementPlanned = Nothing
+
+{-------------------------------------------------------------------------------
+                                    Properties
+-------------------------------------------------------------------------------}
+
+prop_guardJoinQuit
+    :: [PoolId]
+    -> WalletDelegation
+    -> PoolId
+    -> Withdrawal
+    -> Maybe W.PoolRetirementEpochInfo
+    -> Property
+prop_guardJoinQuit knownPoolsList dlg pid wdrl mRetirementInfo = checkCoverage
+    $ cover 10 retirementNotPlanned
+        "retirementNotPlanned"
+    $ cover 10 retirementPlanned
+        "retirementPlanned"
+    $ cover 10 alreadyRetired
+        "alreadyRetired"
+    $ case WD.guardJoin knownPools dlg pid mRetirementInfo of
+        Right () ->
+            label "I can join" $ property $
+                alreadyRetired `shouldBe` False
+        Left W.ErrNoSuchPool{} ->
+            label "ErrNoSuchPool" $ property True
+        Left W.ErrAlreadyDelegating{} ->
+            label "ErrAlreadyDelegating"
+                (WD.guardQuit dlg wdrl (Coin 0) === Right ())
+  where
+    knownPools = Set.fromList knownPoolsList
+    retirementNotPlanned =
+        isNothing mRetirementInfo
+    retirementPlanned =
+        (Just True ==) $ do
+            info <- mRetirementInfo
+            pure $ W.currentEpoch info < W.retirementEpoch info
+    alreadyRetired =
+        (Just True ==) $ do
+            info <- mRetirementInfo
+            pure $ W.currentEpoch info >= W.retirementEpoch info
+
+prop_guardQuitJoin
+    :: NonEmptyList PoolId
+    -> WalletDelegation
+    -> Word64
+    -> Withdrawal
+    -> Property
+prop_guardQuitJoin (NonEmpty knownPoolsList) dlg rewards wdrl =
+    let knownPools = Set.fromList knownPoolsList in
+    let noRetirementPlanned = Nothing in
+    case WD.guardQuit dlg wdrl (Coin.fromWord64 rewards) of
+        Right () ->
+            label "I can quit" $ property True
+        Left W.ErrNotDelegatingOrAboutTo ->
+            label "ErrNotDelegatingOrAboutTo" $
+                WD.guardJoin
+                    knownPools dlg (last knownPoolsList) noRetirementPlanned
+                    === Right ()
+        Left W.ErrNonNullRewards{} ->
+            label "ErrNonNullRewards" $
+                property (rewards /= 0)
+                    .&&. not (isSelfWdrl wdrl)
+  where
+    isSelfWdrl WithdrawalSelf{} = True
+    isSelfWdrl _                = False
+
+{-------------------------------------------------------------------------------
+                    Arbitrary instances
+-------------------------------------------------------------------------------}
+
+instance Arbitrary PoolId where
+    arbitrary = PoolId <$> elements metasyntactic
+
+instance Arbitrary WalletDelegation where
+    shrink = genericShrink
+    arbitrary = WalletDelegation
+        <$> arbitrary
+        <*> oneof [ pure [], vector 1, vector 2 ]
+
+instance Arbitrary WalletDelegationStatus where
+    shrink = genericShrink
+    arbitrary = genericArbitrary
+
+instance Arbitrary EpochNo => Arbitrary WalletDelegationNext where
+    shrink = genericShrink
+    arbitrary = genericArbitrary
+
+instance Arbitrary Withdrawal where
+    arbitrary = oneof
+        [ WithdrawalSelf <$> arbitrary <*> arbitrary <*> arbitrary
+        , WithdrawalExternal <$> arbitrary <*> arbitrary <*> arbitrary
+        , pure NoWithdrawal
+        ]
+
+instance Arbitrary RewardAccount where
+    arbitrary = RewardAccount . BS.pack <$> vector 28
+
+instance Arbitrary W.PoolRetirementEpochInfo where
+    arbitrary = W.PoolRetirementEpochInfo <$> arbitrary <*> arbitrary
+    shrink = genericShrink
+
+instance Arbitrary EpochNo where
+    shrink (EpochNo x) = EpochNo <$> shrink x
+    arbitrary = EpochNo <$> arbitrary
+
+instance Arbitrary DerivationIndex where
+    arbitrary = DerivationIndex <$> arbitrary
+
+instance Arbitrary Coin where
+    shrink _ = []
+    arbitrary = genCoinPositive
+
+instance Arbitrary Word31 where
+    arbitrary = arbitrarySizedBoundedIntegral
+    shrink = shrinkIntegral
+
+instance Arbitrary a => Arbitrary (NonEmpty a) where
+    arbitrary = (:|) <$> arbitrary <*> arbitrary
+    shrink = genericShrink

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -256,7 +256,7 @@ import Cardano.Wallet.Shelley.Transaction
     , _maxScriptExecutionCost
     )
 import Cardano.Wallet.Transaction
-    ( DelegationAction (RegisterKeyAndJoin)
+    ( DelegationAction (..)
     , ErrAssignRedeemers (..)
     , ErrMoreSurplusNeeded (..)
     , TransactionCtx (..)
@@ -3503,7 +3503,7 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
             Nothing
             Cardano.TxScriptValidityNone
 
-        certs = mkDelegationCertificates (RegisterKeyAndJoin poolId) xpub
+        certs = mkDelegationCertificates delegationAction xpub
           where
             poolId = PoolId "\236(\243=\203\230\214@\n\RS^3\155\208d|\
                             \\ts\202l\f\249\194\187\230\131\141\198"
@@ -3511,6 +3511,7 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
             mw = SomeMnemonic $ either (error . show) id
                 (entropyToMnemonic @12 <$> mkEntropy "0000000000000001")
             rootK = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
+            delegationAction = JoinRegsteringKey poolId (Coin 0)
         ledgerBody = Babbage.TxBody
           { Babbage.inputs = mempty
           , Babbage.collateral = mempty

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3511,7 +3511,7 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
             mw = SomeMnemonic $ either (error . show) id
                 (entropyToMnemonic @12 <$> mkEntropy "0000000000000001")
             rootK = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
-            delegationAction = JoinRegsteringKey poolId (Coin 0)
+            delegationAction = JoinRegsteringKey poolId
         ledgerBody = Babbage.TxBody
           { Babbage.inputs = mempty
           , Babbage.collateral = mempty

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3511,7 +3511,7 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
             mw = SomeMnemonic $ either (error . show) id
                 (entropyToMnemonic @12 <$> mkEntropy "0000000000000001")
             rootK = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
-            delegationAction = JoinRegsteringKey poolId
+            delegationAction = JoinRegisteringKey poolId
         ledgerBody = Babbage.TxBody
           { Babbage.inputs = mempty
           , Babbage.collateral = mempty


### PR DESCRIPTION
Currently there is a data type in the Wallet’s API layer that represents a delegation action: `ApiMultiDelegationAction`
This datatype is used for:

1. capturing HTTP API client’s payload.
2. HTTP request payload validation.

The problem is that the [business logic that handles the request and is located in the API layer.](https://github.com/input-output-hk/cardano-wallet/blob/956fa1f62221a789cecb0b6d314411637472875a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs#L2295-L2327)

The solution is to move this logic to the library layer in order to make it re-usable across the endpoints.

However, the `ApiMultiDelegationAction` data type can’t be moved to the library layer as its API specific and there has to be its analog.

I have created a `DelegationRequest` data type that represents a valid delegation request;
This type is then converted to a specific `DelegationAction`, depending on the state of users account.

### Issue Number

ADP-2431
