### PR TITLE
Nightly benchmarks

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -60,6 +60,7 @@ steps:
       IS_NIGHTLY: "true"
     agents:
       system: x86_64-linux
+      queue: benchmark
     if: 'build.env("step") == null || build.env("step") =~ /cabal/'
 
   # TODO: ADP-549 Port migrations test to shelley
@@ -79,4 +80,5 @@ steps:
     command: "./.buildkite/push-branch.sh linux-tests-pass windows-tests-pass all-tests-pass"
     agents:
       system: x86_64-linux
+      queue: benchmark
     if: 'build.env("step") == null'


### PR DESCRIPTION
### Comments
*6 Dec 2022:*
 - nightly picked up queue: benchmark but mainnet restoration failed https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1598
 - running again https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1599 :crossed_fingers:

*5 Dec 2022:*
 - new agents arrived (queue: benchmark), running against them https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1597 (so far mainnet restoration failed, raised [question](https://input-output-rnd.slack.com/archives/C819S481Y/p1670249917742479?thread_ts=1670208448.122399&cid=C819S481Y) about the failure)

*2 Dec 2022:*
 - running on mac-minis (default) does not work https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1577 :x:
 - running on `queue = benchmark_large` does not work https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1589 :x:
 - runnin on `queue = project42` does not work https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1590 :x:

### Issue Number

ADP-2439
