### PR TITLE
[ADP-2392] implement store db for new submissions store

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -826,6 +826,7 @@ test-suite unit
     Cardano.Wallet.DB.Store.Meta.ModelSpec
     Cardano.Wallet.DB.Store.Meta.StoreSpec
     Cardano.Wallet.DB.Store.Submissions.ModelSpec
+    Cardano.Wallet.DB.Store.Submissions.New.StoreSpec
     Cardano.Wallet.DB.Store.Submissions.StoreSpec
     Cardano.Wallet.DB.Store.Transactions.StoreSpec
     Cardano.Wallet.DB.Store.Wallets.StoreSpec

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -234,6 +234,7 @@ library
     Cardano.Wallet.DB.Store.Meta.Model
     Cardano.Wallet.DB.Store.Meta.Store
     Cardano.Wallet.DB.Store.Submissions.Model
+    Cardano.Wallet.DB.Store.Submissions.New.Operations
     Cardano.Wallet.DB.Store.Submissions.Store
     Cardano.Wallet.DB.Store.Transactions.Layer
     Cardano.Wallet.DB.Store.Transactions.Model

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
@@ -34,7 +34,7 @@ import Cardano.Pool.Types
 import Cardano.Slotting.Slot
     ( SlotNo )
 import Cardano.Wallet.DB.Sqlite.Types
-    ( BlockId, HDPassphrase, TxId, sqlSettings' )
+    ( BlockId, HDPassphrase, TxId, TxSubmissionStatusEnum (..), sqlSettings' )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( CredentialType )
 import Data.Quantity
@@ -491,4 +491,22 @@ CBOR
     Primary cborTxId
     deriving Show Generic Eq
 
+Submissions
+    submissionTxId TxId  sql=tx_id
+    submissionTx W.SealedTx sql=tx
+    submissionExpiration SlotNo sql=expiration
+    submissionAcceptance (Maybe SlotNo) sql=acceptance
+    submissionWallet W.WalletId sql=wallet_id
+    submissionStatus TxSubmissionStatusEnum sql=status
+
+    Primary submissionTxId
+    deriving Show Generic Eq
+
+SubmissionsSlots
+    submissionsSlotsFinality SlotNo sql=finality
+    submissionsSlotsTip SlotNo sql=tip
+    submissionsSlotsWallet W.WalletId sql=wallet_id
+
+    Primary submissionsSlotsWallet
+    deriving Show Generic Eq
 |]

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -727,3 +727,13 @@ newtype EitherText a = EitherText { getEitherText :: Either Text a }
 
 instance MonadFail EitherText where
     fail = EitherText . Left . T.pack
+
+data TxSubmissionStatusEnum = InSubmissionE | InLedgerE | ExpiredE
+    deriving (Eq, Show, Enum, Generic)
+
+instance PersistField TxSubmissionStatusEnum where
+    toPersistValue = toPersistValue . fromEnum
+    fromPersistValue = fmap toEnum . fromPersistValue
+
+instance PersistFieldSql TxSubmissionStatusEnum where
+    sqlType _ = sqlType (Proxy @Int)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Operations.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+{- |
+Copyright: 2022 IOHK
+License: Apache-2.0
+
+Implementation of a 'Store' for 'TxSubmissions' based on 'DeltaTxSubmissions' delta.
+
+-}
+module Cardano.Wallet.DB.Store.Submissions.New.Operations
+    ( TxSubmissions
+    , mkTransactions
+    , syncSubmissions
+    , mkStoreSubmissions
+    , DeltaTxSubmissions
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.DB.Sqlite.Schema
+    ( EntityField (SubmissionWallet, SubmissionsSlotsWallet)
+    , Key (SubmissionsKey, SubmissionsSlotsKey)
+    , Submissions (Submissions)
+    , SubmissionsSlots (SubmissionsSlots)
+    )
+import Cardano.Wallet.DB.Sqlite.Types
+    ( TxId, TxSubmissionStatusEnum (..) )
+import Cardano.Wallet.Primitive.Types
+    ( SlotNo (..), WalletId )
+import Cardano.Wallet.Submissions.Operations
+    ( applyOperations )
+import Cardano.Wallet.Submissions.Submissions
+    ( finality, tip, transactions )
+import Control.Exception
+    ( Exception, SomeException (..) )
+import Control.Monad
+    ( forM_ )
+import Data.DBVar
+    ( Store (..) )
+import Data.Delta
+    ( Delta (..) )
+import Data.Map.Strict
+    ( Map )
+import Database.Persist
+    ( Entity (Entity), PersistStoreWrite (delete, repsert), selectList, (==.) )
+import Database.Persist.Sql
+    ( SqlPersistT )
+
+import qualified Cardano.Wallet.Primitive.Types.Tx as W
+import qualified Cardano.Wallet.Submissions.Operations as Sbm
+import qualified Cardano.Wallet.Submissions.Submissions as Sbm
+import qualified Cardano.Wallet.Submissions.TxStatus as Sbm
+import qualified Data.Map.Strict as Map
+
+type TxSubmissions = Sbm.Submissions SlotNo (TxId, W.SealedTx)
+type TxSubmissionsStatus = Sbm.TxStatus SlotNo (TxId, W.SealedTx)
+type DeltaTxSubmissions = Sbm.Operation SlotNo (TxId, W.SealedTx)
+
+
+syncSubmissions :: WalletId -> TxSubmissions -> TxSubmissions -> SqlPersistT IO ()
+syncSubmissions wid old new = do
+
+    let deletes = transactions old `Map.difference` transactions new
+    forM_ (Map.keys deletes) $ \k -> delete (SubmissionsKey k)
+
+    let repserts = transactions new
+    forM_ (Map.assocs repserts) $ \(iden, status) -> do
+        let result = case status of
+                Sbm.Expired expiring (_, sealed)
+                    -> Just (sealed, expiring, Nothing, ExpiredE)
+                Sbm.InSubmission expiring (_, sealed)
+                    -> Just (sealed, expiring, Nothing, InSubmissionE)
+                Sbm.InLedger expiring acceptance (_, sealed)
+                    -> Just (sealed, expiring, Just acceptance, InLedgerE)
+                Sbm.Unknown -> Nothing
+        case result of
+            Just (sealed, expiring, acceptance, statusNumber) -> repsert
+                (SubmissionsKey iden)
+                (Submissions iden sealed expiring acceptance wid statusNumber)
+            Nothing -> pure ()
+    repsert
+        (SubmissionsSlotsKey wid)
+        $ SubmissionsSlots (finality new) (tip new) wid
+
+instance Sbm.HasTxId (TxId, W.SealedTx) where
+    type TxId (TxId, W.SealedTx) = TxId
+    txId (iden,_) = iden
+
+data ErrSubmissions
+    = ErrSubmissionsSlotsMissingForWallet WalletId
+    | ErrMoreThanOneSubmissionsSlotsDefinedForWallet WalletId
+    deriving (Show, Eq, Exception)
+
+mkStoreAnySubmissions
+    :: (Base d ~ TxSubmissions, Delta d)
+    => WalletId
+    -> Store (SqlPersistT IO) d
+mkStoreAnySubmissions wid =
+    Store
+    { loadS = do
+        slots <- selectList [SubmissionsSlotsWallet ==. wid] []
+        txs <- selectList [SubmissionWallet ==. wid ] []
+        pure $ case slots of
+            [] -> Left $ SomeException $ ErrSubmissionsSlotsMissingForWallet wid
+            [Entity _ (SubmissionsSlots finality' tip' _)] -> Right
+                $ Sbm.Submissions (mkTransactions txs) finality' tip'
+                -- Note: We don't try very hard to detect whether the database
+                -- contains messed-up data.
+            _ -> Left $ SomeException
+                    $ ErrMoreThanOneSubmissionsSlotsDefinedForWallet wid
+    , writeS = syncSubmissions wid (Sbm.Submissions mempty 0 0)
+    , updateS = \base delta -> syncSubmissions wid base $ apply delta base
+    }
+
+mkTransactions :: [Entity Submissions] -> Map TxId TxSubmissionsStatus
+mkTransactions xs = Map.fromList $ do
+    Entity _  (Submissions iden sealed expiration acceptance _ status) <- xs
+    pure (iden, mkStatus iden sealed expiration acceptance status)
+
+mkStatus
+    :: TxId -> W.SealedTx -> SlotNo -> Maybe SlotNo
+    -> TxSubmissionStatusEnum -> TxSubmissionsStatus
+mkStatus iden sealed expiring (Just acceptance) InLedgerE
+    = Sbm.InLedger expiring acceptance (iden, sealed)
+mkStatus iden sealed expiring Nothing InSubmissionE
+    = Sbm.InSubmission expiring (iden, sealed)
+mkStatus iden sealed expiring Nothing ExpiredE
+    = Sbm.Expired expiring (iden, sealed)
+mkStatus _ _ _ _ _
+    = Sbm.Unknown
+
+instance Delta DeltaTxSubmissions where
+  type Base DeltaTxSubmissions = TxSubmissions
+  apply = applyOperations
+
+mkStoreSubmissions :: WalletId -> Store (SqlPersistT IO) DeltaTxSubmissions
+mkStoreSubmissions = mkStoreAnySubmissions

--- a/lib/wallet/src/Cardano/Wallet/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Gen.hs
@@ -28,6 +28,7 @@ module Cardano.Wallet.Gen
     , genScriptTemplate
     , genMockXPub
     , genNatural
+    , genWalletId
     ) where
 
 import Prelude
@@ -52,6 +53,7 @@ import Cardano.Wallet.Primitive.Types
     , ChainPoint (..)
     , Slot
     , SlotNo (..)
+    , WalletId (..)
     , WithOrigin (..)
     )
 import Cardano.Wallet.Primitive.Types.Address
@@ -62,6 +64,10 @@ import Cardano.Wallet.Primitive.Types.ProtocolMagic
     ( ProtocolMagic (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeMkEntropy, unsafeMkPercentage )
+import Control.Monad
+    ( replicateM )
+import Crypto.Hash
+    ( hash )
 import Data.Aeson
     ( ToJSON (..) )
 import Data.ByteArray.Encoding
@@ -349,3 +355,7 @@ genMockXPub = fromMaybe impossible . xpubFromBytes . BS.pack <$> genBytes
     genBytes = vectorOf 64 arbitrary
     impossible = error "incorrect length in genMockXPub"
 
+genWalletId :: Gen WalletId
+genWalletId = do
+    bytes <- BS.pack <$> replicateM 16 arbitrary
+    pure $ WalletId (hash bytes)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/New/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/New/StoreSpec.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Wallet.DB.Store.Submissions.New.StoreSpec ( spec ) where
+
+import Prelude
+
+import Cardano.DB.Sqlite
+    ( ForeignKeysSetting (ForeignKeysDisabled) )
+import Cardano.Wallet.DB.Arbitrary
+    ()
+import Cardano.Wallet.DB.Fixtures
+    ( WalletProperty, logScale, withDBInMemory, withInitializedWalletProp )
+import Cardano.Wallet.DB.Sqlite.Types
+    ( TxId (..) )
+import Cardano.Wallet.DB.Store.Submissions.New.Operations
+    ( DeltaTxSubmissions, mkStoreSubmissions )
+import Cardano.Wallet.Primitive.Types
+    ( SlotNo (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( SealedTx (..), mockSealedTx )
+import Cardano.Wallet.Submissions.OperationsSpec
+    ( genOperationsDelta )
+import Cardano.Wallet.Submissions.Submissions
+    ( Submissions (..) )
+import Control.Monad
+    ( replicateM, void )
+import Fmt
+    ( Buildable (..) )
+import System.Random
+    ( Random )
+import Test.DBVar
+    ( prop_StoreUpdates )
+import Test.Hspec
+    ( Spec, around, describe, it )
+import Test.QuickCheck
+    ( Arbitrary (..), property )
+
+import qualified Data.ByteString as BS
+
+spec :: Spec
+spec = do
+    around (withDBInMemory ForeignKeysDisabled) $ do
+        describe "submissions via API for a single wallet store" $ do
+            it "respects store laws"
+                $ property . prop_SingleWalletStoreLawsOperations
+
+instance Buildable DeltaTxSubmissions where
+    build = build . show
+
+deriving instance Random SlotNo
+
+prop_SingleWalletStoreLawsOperations :: WalletProperty
+prop_SingleWalletStoreLawsOperations = withInitializedWalletProp
+    $ \wid runQ -> do
+        void $ prop_StoreUpdates
+            runQ
+            (mkStoreSubmissions wid)
+            (pure $ Submissions mempty 0 0)
+            (logScale . genOperationsDelta)
+
+{-------------------------------------------------------------------------------
+    Arbitrary instances
+-------------------------------------------------------------------------------}
+instance Arbitrary TxId where
+    arbitrary = TxId <$> arbitrary
+
+instance Arbitrary SealedTx where
+    arbitrary = mockSealedTx . BS.pack <$> replicateM 16 arbitrary


### PR DESCRIPTION

- [x] ~~implement store db for new submissions store primitives~~
- [x] ~~implement store laws properties for new submissions store primitives~~
- [x] implement store db for new submissions store API operations
- [x] implement store laws properties for new submissions store API operations

### Comments

The delta language of the API, called Operation, is implemented as a composition of primitive deltas. Primitive deltas are not required to respect all API-level invariants. In reality, only the roll-forward operation is a proper composition of 2 primitives.

The DB implementation uses the in-memory state change to compute the database difference, which means we are not pattern-matching the delta language as we do in the in-memory implementation. This removes even the instantiation of a store at the primitive level, so we end up with a very small implementation that relies on the correctness of the model that is executed in parallel to the DB one. This missing code could be necessary if we want to switch to an in-disk-only store.

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2392
<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
