### PR TITLE
Drop `cabal build` check in Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,11 +23,6 @@ steps:
   - wait: ~
     if: 'build.branch == "bors/staging"'
 
-  - label: 'Check Cabal Configure'
-    command: 'nix develop .#cabal --command scripts/buildkite/cabal-ci.sh configure'
-    agents:
-      system: x86_64-linux
-
   - label: 'Check auto-generated Nix'
     key: nix
     commands:
@@ -52,14 +47,6 @@ steps:
     command: 'nix develop --command bash -c "echo +++ HLint ; hlint lib"'
     agents:
       system: x86_64-linux
-
-  - label: 'Full cabal build'
-    command:
-      - "mkdir -p config && echo '{  outputs = _: { withCabalCache = true; }; }'  > config/flake.nix"
-      - "nix develop --override-input customConfig path:./config .#cabal --command scripts/buildkite/cabal-ci.sh build"
-    agents:
-      system: x86_64-linux
-    if: 'build.env("step") == null || build.env("step") =~ /cabal/'
 
   - label: 'Validate OpenAPI Specification'
     depends_on: nix
@@ -89,36 +76,5 @@ steps:
     commands:
       - 'echo +++ Shellcheck'
       - './scripts/shellcheck.sh'
-    agents:
-      system: x86_64-linux
-
-  - block: "Clear cabal cache"
-    prompt: "This command cannot guarantee the caches to be cleared on every buildkite agent, but will try to make this likely by scheduling many duplicated cache-clearing steps."
-    key: 'should_clear_cache'
-    allow_dependency_failure: true
-    depends_on: [] # allows triggering this step even if previous steps failed
-
-  - label: 'Clearing cabal cache'
-    command: 'rm -vrf $CABAL_DIR'
-    agents:
-      system: x86_64-linux
-
-  - label: 'Clearing cabal cache 2'
-    command: 'rm -vrf $CABAL_DIR'
-    agents:
-      system: x86_64-linux
-
-  - label: 'Clearing cabal cache 3'
-    command: 'rm -vrf $CABAL_DIR'
-    agents:
-      system: x86_64-linux
-
-  - label: 'Clearing cabal cache 4'
-    command: 'rm -vrf $CABAL_DIR'
-    agents:
-      system: x86_64-linux
-
-  - label: 'Clearing cabal cache 5'
-    command: 'rm -vrf $CABAL_DIR'
     agents:
       system: x86_64-linux


### PR DESCRIPTION
- [x] Drop `cabal build` buildkite checks (and related `cabal configure` one)

### Comments

- This check is broken in the node bump (#3593 ) and I don't know how to make it green.  Regardless, it has historically been fragile (often requiring caches to be cleared) and will also stop working in a few days when the packet.net agents become unavailible.
- The ability to build the project through haskell.nix is checked by hydra/cicero.
- The `cabal build` checks were added during a time when `stack` was the main tool for development in cardano-wallet. Now we only use `cabal`. If the "cabal in nix-shell" build were to break separately from the nix build, we'd notice fast enough.

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2382

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
