### PR TITLE
buildAndSignTransaction replacement that does a coin selection using `balanceTx`

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3003,7 +3003,8 @@ balanceTransaction ctx@ApiLayer{..} genChange (ApiT wid) body = do
                 -> Handler (Cardano.Tx era)
             balanceTx partialTx =
                 liftHandler $ W.balanceTransaction @_ @IO @s @k @ktype
-                    wrk
+                    (MsgWallet >$< wrk ^. W.logger)
+                    (ctx ^. typed)
                     genChange
                     (pp, nodePParams)
                     ti

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2273,8 +2273,8 @@ mkApiTransactionFromInfo ti wrk wid deposit info metadataSchema = do
         MkApiTransactionParams
             { txId = info ^. #txInfoId
             , txFee = info ^. #txInfoFee
-            , txInputs = info ^. #txInfoInputs <&> drop2nd
-            , txCollateralInputs = info ^. #txInfoCollateralInputs <&> drop2nd
+            , txInputs = info ^. #txInfoInputs
+            , txCollateralInputs = info ^. #txInfoCollateralInputs
             , txOutputs = info ^. #txInfoOutputs
             , txCollateralOutput = info ^. #txInfoCollateralOutput
             , txWithdrawals = info ^. #txInfoWithdrawals
@@ -2291,7 +2291,6 @@ mkApiTransactionFromInfo ti wrk wid deposit info metadataSchema = do
         InLedger -> apiTx {depth = Just $ info ^. #txInfoDepth}
         Expired  -> apiTx
   where
-    drop2nd (a,_,c) = (a,c)
     status :: Lens' (ApiTransaction n) (Maybe ApiBlockReference)
     status = case info ^. #txInfoMeta . #status of
         Pending  -> #pendingSince

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -167,7 +167,6 @@ import Cardano.Wallet
     , ErrConstructTx (..)
     , ErrCreateMigrationPlan (..)
     , ErrGetPolicyId (..)
-    , ErrMkTransaction (..)
     , ErrNoSuchWallet (..)
     , ErrReadRewardAccount (..)
     , ErrSelectAssets (..)
@@ -4115,7 +4114,7 @@ withRecentEra
     -> (forall e. WriteTx.IsRecentEra e => WriteTx.RecentEra e -> Handler a)
     -> Handler a
 withRecentEra anyCardanoEra handleRecentEra = do
-    let invalidEra = ErrMkTransactionInvalidEra anyCardanoEra
+    let invalidEra = ErrOldEraNotSupported anyCardanoEra
     case anyCardanoEra of
         Cardano.AnyCardanoEra cardanoEra ->
             case cardanoEra of

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -167,6 +167,7 @@ import Cardano.Wallet
     , ErrConstructTx (..)
     , ErrCreateMigrationPlan (..)
     , ErrGetPolicyId (..)
+    , ErrMkTransaction (..)
     , ErrNoSuchWallet (..)
     , ErrReadRewardAccount (..)
     , ErrSelectAssets (..)
@@ -493,6 +494,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , UnsignedTx (..)
     , cardanoTxIdeallyNoLaterThan
     , getSealedTxWitnesses
+    , sealedTxFromCardanoBody
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txMintBurnMaxTokenQuantity )
@@ -2355,8 +2357,7 @@ constructTransaction
     -> ApiT WalletId
     -> ApiConstructTransactionData n
     -> Handler (ApiConstructTransaction n)
-constructTransaction
-    apiLayer genChange knownPools poolStatus apiWalletId body = do
+constructTransaction api genChange knownPools poolStatus apiWalletId body = do
     body & \(ApiConstructTransactionData _ _ _ _ _ _ _) ->
     -- Above is the way to get a compiler error when number of fields changes,
     -- in order not to forget to update the pattern below:
@@ -2382,147 +2383,148 @@ constructTransaction
     let metadata =
             body ^? #metadata . traverse . #txMetadataWithSchema_metadata
 
-    withWorkerCtx apiLayer walletId liftE liftE $ \wrk -> do
+    withWorkerCtx api walletId liftE liftE $ \wrk -> do
         let db = wrk ^. dbLayer
             netLayer = wrk ^. networkLayer
             txLayer = wrk ^. transactionLayer @ShelleyKey @'CredFromKeyK
             trWorker = MsgWallet >$< wrk ^. logger
         pp <- liftIO $ NW.currentProtocolParameters netLayer
         era <- liftIO $ NW.currentNodeEra netLayer
-        epoch <- getCurrentEpoch apiLayer
-        withdrawal <-
-            case body ^. #withdrawal of
-                Just SelfWithdraw -> liftIO
-                    $ W.shelleyOnlyMkSelfWithdrawal @_ @_ @_ @_ @n
+        epoch <- getCurrentEpoch api
+
+        withRecentEra era $ \(_recjentEra :: WriteTx.RecentEra era) -> do
+            withdrawal <- case body ^. #withdrawal of
+                Just SelfWithdraw -> liftIO $
+                    W.shelleyOnlyMkSelfWithdrawal @_ @_ @_ @_ @n
                         netLayer txLayer era db walletId
                 _ -> pure NoWithdrawal
 
-        let transactionCtx0 = defaultTransactionCtx
-                 { txWithdrawal = withdrawal
-                 , txMetadata = metadata
-                 , txValidityInterval = first Just validityInterval
-                 }
+            let transactionCtx0 = defaultTransactionCtx
+                    { txWithdrawal = withdrawal
+                    , txMetadata = metadata
+                    , txValidityInterval = first Just validityInterval
+                    }
 
-        optionalDelegationAction <- liftHandler $
-            forM delegationRequest $
-                WD.handleDelegationRequest
-                    trWorker db epoch knownPools
-                    poolStatus walletId withdrawal
+            optionalDelegationAction <- liftHandler $
+                forM delegationRequest $
+                    WD.handleDelegationRequest
+                        trWorker db epoch knownPools
+                        poolStatus walletId withdrawal
 
-        let transactionCtx1 =
-                case optionalDelegationAction of
-                    Nothing -> transactionCtx0
-                    Just action ->
-                        transactionCtx0 { txDelegationAction = Just action }
+            let transactionCtx1 =
+                    case optionalDelegationAction of
+                        Nothing -> transactionCtx0
+                        Just action ->
+                            transactionCtx0 { txDelegationAction = Just action }
 
-        (transactionCtx2, policyXPubM) <-
-            if isJust mintBurnData then do
-                (policyXPub, _) <-
-                    liftHandler $ W.readPolicyPublicKey @_ @_ @_ @n wrk walletId
-                let isMinting (ApiMintBurnData _ _ (ApiMint _)) = True
-                    isMinting _ = False
-                let getMinting = \case
-                        ApiMintBurnData
-                            (ApiT scriptT)
-                            (Just (ApiT tName))
-                            (ApiMint (ApiMintData _ amt)) ->
-                            toTokenMapAndScript @ShelleyKey
-                                scriptT
-                                (Map.singleton (Cosigner 0) policyXPub)
-                                tName
-                                amt
-                        _ -> error "getMinting should not be used in this way"
-                let getBurning = \case
-                        ApiMintBurnData
-                            (ApiT scriptT)
-                            (Just (ApiT tName))
-                            (ApiBurn (ApiBurnData amt)) ->
-                            toTokenMapAndScript @ShelleyKey
-                                scriptT
-                                (Map.singleton (Cosigner 0) policyXPub)
-                                tName
-                                amt
-                        _ -> error "getBurning should not be used in this way"
-                let toTokenMap =
-                        fromFlatList .
-                        map (\(a,q,_) -> (a,q))
-                let toScriptTemplateMap =
-                        Map.fromList .
-                        map (\(a,_,s) -> (a,s))
-                let mintingData =
-                        toTokenMap &&& toScriptTemplateMap $
-                        map getMinting $
-                        filter isMinting $
-                        NE.toList $ fromJust mintBurnData
-                let burningData =
-                        toTokenMap &&& toScriptTemplateMap $
-                        map getBurning $
-                        filter (not . isMinting) $
-                        NE.toList $ fromJust mintBurnData
-                pure ( transactionCtx1
-                      { txAssetsToMint = mintingData
-                      , txAssetsToBurn = burningData
-                      }
-                     , Just policyXPub)
-            else
-                pure (transactionCtx1, Nothing)
+            (transactionCtx2, policyXPubM) <-
+                if isJust mintBurnData then do
+                    (policyXPub, _) <-
+                        liftHandler $ W.readPolicyPublicKey @_ @_ @_ @n wrk walletId
+                    let isMinting (ApiMintBurnData _ _ (ApiMint _)) = True
+                        isMinting _ = False
+                    let getMinting = \case
+                            ApiMintBurnData
+                                (ApiT scriptT)
+                                (Just (ApiT tName))
+                                (ApiMint (ApiMintData _ amt)) ->
+                                toTokenMapAndScript @ShelleyKey
+                                    scriptT
+                                    (Map.singleton (Cosigner 0) policyXPub)
+                                    tName
+                                    amt
+                            _ -> error "getMinting should not be used in this way"
+                    let getBurning = \case
+                            ApiMintBurnData
+                                (ApiT scriptT)
+                                (Just (ApiT tName))
+                                (ApiBurn (ApiBurnData amt)) ->
+                                toTokenMapAndScript @ShelleyKey
+                                    scriptT
+                                    (Map.singleton (Cosigner 0) policyXPub)
+                                    tName
+                                    amt
+                            _ -> error "getBurning should not be used in this way"
+                    let toTokenMap =
+                            fromFlatList .
+                            map (\(a,q,_) -> (a,q))
+                    let toScriptTemplateMap =
+                            Map.fromList .
+                            map (\(a,_,s) -> (a,s))
+                    let mintingData =
+                            toTokenMap &&& toScriptTemplateMap $
+                            map getMinting $
+                            filter isMinting $
+                            NE.toList $ fromJust mintBurnData
+                    let burningData =
+                            toTokenMap &&& toScriptTemplateMap $
+                            map getBurning $
+                            filter (not . isMinting) $
+                            NE.toList $ fromJust mintBurnData
+                    pure ( transactionCtx1
+                        { txAssetsToMint = mintingData
+                        , txAssetsToBurn = burningData
+                        }
+                        , Just policyXPub)
+                else
+                    pure (transactionCtx1, Nothing)
 
-        outs <- case body ^. #payments of
-            Nothing -> pure []
-            Just (ApiPaymentAddresses content) ->
-                pure $ F.toList (addressAmountToTxOut <$> content)
+            outs <- case body ^. #payments of
+                Nothing -> pure []
+                Just (ApiPaymentAddresses content) ->
+                    pure $ F.toList (addressAmountToTxOut <$> content)
 
-        let mintWithAddress
-                (ApiMintBurnData _ _ (ApiMint (ApiMintData (Just _) _)))
-                = True
-            mintWithAddress _ = False
-        let mintingOuts = case mintBurnData of
-                Just mintBurns ->
-                    coalesceTokensPerAddr $
-                    map (toMintTxOut (fromJust policyXPubM)) $
-                    filter mintWithAddress $
-                    NE.toList mintBurns
-                Nothing -> []
+            let mintWithAddress
+                    (ApiMintBurnData _ _ (ApiMint (ApiMintData (Just _) _)))
+                    = True
+                mintWithAddress _ = False
+            let mintingOuts = case mintBurnData of
+                    Just mintBurns ->
+                        coalesceTokensPerAddr $
+                        map (toMintTxOut (fromJust policyXPubM)) $
+                        filter mintWithAddress $
+                        NE.toList mintBurns
+                    Nothing -> []
 
-        unbalancedTx <- liftHandler $
-            W.constructTransaction @n @'CredFromKeyK
-                txLayer netLayer db walletId era transactionCtx2
-                    PreSelection { outputs = outs <> mintingOuts }
+            unbalancedTx <- liftHandler $
+                W.constructTransaction @n @'CredFromKeyK @era
+                    txLayer netLayer db walletId transactionCtx2
+                        PreSelection { outputs = outs <> mintingOuts }
 
-        balancedTx <-
-            balanceTransaction apiLayer genChange apiWalletId
-                ApiBalanceTransactionPostData
-                { transaction = ApiT unbalancedTx
-                , inputs = []
-                , redeemers = []
-                , encoding = body ^. #encoding
+            balancedTx <-
+                balanceTransaction api genChange apiWalletId
+                    ApiBalanceTransactionPostData
+                    { transaction = ApiT (sealedTxFromCardanoBody unbalancedTx)
+                    , inputs = []
+                    , redeemers = []
+                    , encoding = body ^. #encoding
+                    }
+
+            apiDecoded <- decodeTransaction @_ @_ @n api apiWalletId balancedTx
+
+            (_, _, rewardPath) <- liftHandler $ W.readRewardAccount @n db walletId
+
+            let deposits = case txDelegationAction transactionCtx2 of
+                    Just (JoinRegisteringKey _poolId) -> [W.stakeKeyDeposit pp]
+                    _ -> []
+
+            let refunds = case txDelegationAction transactionCtx2 of
+                    Just Quit -> [W.stakeKeyDeposit pp]
+                    _ -> []
+
+            pure ApiConstructTransaction
+                { transaction = balancedTx
+                , coinSelection = mkApiCoinSelection
+                    deposits
+                    refunds
+                    ((,rewardPath) <$> transactionCtx2 ^. #txDelegationAction)
+                    metadata
+                    (unsignedTx rewardPath (outs ++ mintingOuts) apiDecoded)
+                , fee = apiDecoded ^. #fee
                 }
-
-        apiDecoded <- decodeTransaction @_ @_ @n apiLayer apiWalletId balancedTx
-
-        (_, _, rewardPath) <- liftHandler $ W.readRewardAccount @n db walletId
-
-        let deposits = case txDelegationAction transactionCtx2 of
-                Just (JoinRegisteringKey _poolId) -> [W.stakeKeyDeposit pp]
-                _ -> []
-
-        let refunds = case txDelegationAction transactionCtx2 of
-                Just Quit -> [W.stakeKeyDeposit pp]
-                _ -> []
-
-        pure ApiConstructTransaction
-            { transaction = balancedTx
-            , coinSelection = mkApiCoinSelection
-                deposits
-                refunds
-                ((,rewardPath) <$> transactionCtx2 ^. #txDelegationAction)
-                metadata
-                (unsignedTx rewardPath (outs ++ mintingOuts) apiDecoded)
-            , fee = apiDecoded ^. #fee
-            }
   where
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
-    ti = timeInterpreter (apiLayer ^. networkLayer)
+    ti = timeInterpreter (api ^. networkLayer)
 
     walletId = getApiT apiWalletId
 
@@ -2794,73 +2796,76 @@ constructSharedTransaction
         parseValidityInterval ti (body ^. #validityInterval)
 
     withWorkerCtx ctx wid liftE liftE $ \wrk -> do
-        (cp, _, _) <- liftHandler $ withExceptT ErrConstructTxNoSuchWallet $
-            W.readWallet @_ @s @k wrk wid
+        era <- liftIO $ NW.currentNodeEra (wrk ^. networkLayer)
+        withRecentEra era $ \(_recentEra :: WriteTx.RecentEra era) -> do
+            (cp, _, _) <- liftHandler $ withExceptT ErrConstructTxNoSuchWallet $
+                W.readWallet @_ @s @k wrk wid
 
-        let txCtx = defaultTransactionCtx
-                { txWithdrawal = NoWithdrawal
-                , txMetadata = md
-                , txValidityInterval = (Just before, hereafter)
-                , txDelegationAction = Nothing
-                , txPaymentCredentialScriptTemplate =
-                        Just (Shared.paymentTemplate $ getState cp)
-                }
-
-        let transform s sel =
-                ( W.assignChangeAddresses genChange sel s
-                    & uncurry (W.selectionToUnsignedTx (txWithdrawal txCtx))
-                , sel
-                , selectionDelta TokenBundle.getCoin sel
-                )
-
-        case Shared.ready (getState cp) of
-            Shared.Pending ->
-                liftHandler $ throwE ErrConstructTxSharedWalletIncomplete
-            Shared.Active _ -> do
-                pp <- liftIO $ NW.currentProtocolParameters (wrk ^. networkLayer)
-                era <- liftIO $ NW.currentNodeEra (wrk ^. networkLayer)
-
-                (utxoAvailable, wallet, pendingTxs) <-
-                    liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk wid
-
-                let runSelection outs = W.selectAssets @_ @_ @s @k @'CredFromScriptK
-                        wrk era pp selectAssetsParams transform
-                      where
-                        selectAssetsParams = W.SelectAssetsParams
-                            { outputs = outs
-                            , pendingTxs
-                            , randomSeed = Nothing
-                            , txContext = txCtx
-                            , utxoAvailableForInputs =
-                                UTxOSelection.fromIndex utxoAvailable
-                            , utxoAvailableForCollateral =
-                                UTxOIndex.toMap utxoAvailable
-                            , wallet
-                            , selectionStrategy = SelectionStrategyOptimal
-                            }
-                (sel, sel', fee) <- do
-                    outs <- case (body ^. #payments) of
-                        Just (ApiPaymentAddresses content) ->
-                            pure $ F.toList (addressAmountToTxOut <$> content)
-                        _ ->
-                            pure []
-
-                    (sel', utx, fee') <- liftHandler $ runSelection outs
-                    sel <- liftHandler $
-                        W.assignChangeAddressesWithoutDbUpdate wrk wid genChange utx
-                    (FeeEstimation estMin _) <- liftHandler $ W.estimateFee (pure fee')
-                    pure (sel, sel', estMin)
-
-                tx <- liftHandler
-                    $ W.constructSharedTransaction @_ @s @k @n wrk wid era txCtx sel
-
-                pure $ ApiConstructTransaction
-                    { transaction = case body ^. #encoding of
-                            Just HexEncoded -> ApiSerialisedTransaction (ApiT tx) HexEncoded
-                            _ -> ApiSerialisedTransaction (ApiT tx) Base64Encoded
-                    , coinSelection = mkApiCoinSelection [] [] Nothing md sel'
-                    , fee = Quantity $ fromIntegral fee
+            let txCtx = defaultTransactionCtx
+                    { txWithdrawal = NoWithdrawal
+                    , txMetadata = md
+                    , txValidityInterval = (Just before, hereafter)
+                    , txDelegationAction = Nothing
+                    , txPaymentCredentialScriptTemplate =
+                            Just (Shared.paymentTemplate $ getState cp)
                     }
+
+            let transform s sel =
+                    ( W.assignChangeAddresses genChange sel s
+                        & uncurry (W.selectionToUnsignedTx (txWithdrawal txCtx))
+                    , sel
+                    , selectionDelta TokenBundle.getCoin sel
+                    )
+
+            case Shared.ready (getState cp) of
+                Shared.Pending ->
+                    liftHandler $ throwE ErrConstructTxSharedWalletIncomplete
+                Shared.Active _ -> do
+                    pp <- liftIO $ NW.currentProtocolParameters (wrk ^. networkLayer)
+
+                    (utxoAvailable, wallet, pendingTxs) <-
+                        liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk wid
+
+                    let runSelection outs = W.selectAssets @_ @_ @s @k @'CredFromScriptK
+                            wrk era pp selectAssetsParams transform
+                          where
+                            selectAssetsParams = W.SelectAssetsParams
+                                { outputs = outs
+                                , pendingTxs
+                                , randomSeed = Nothing
+                                , txContext = txCtx
+                                , utxoAvailableForInputs =
+                                    UTxOSelection.fromIndex utxoAvailable
+                                , utxoAvailableForCollateral =
+                                    UTxOIndex.toMap utxoAvailable
+                                , wallet
+                                , selectionStrategy = SelectionStrategyOptimal
+                                }
+                    (sel, sel', fee) <- do
+                        outs <- case body ^. #payments of
+                            Just (ApiPaymentAddresses content) ->
+                                pure $ F.toList (addressAmountToTxOut <$> content)
+                            _ ->
+                                pure []
+
+                        (sel', utx, fee') <- liftHandler $ runSelection outs
+                        sel <- liftHandler $
+                            W.assignChangeAddressesWithoutDbUpdate wrk wid genChange utx
+                        (FeeEstimation estMin _) <- liftHandler $ W.estimateFee (pure fee')
+                        pure (sel, sel', estMin)
+
+                    tx <- liftHandler
+                        $ sealedTxFromCardanoBody
+                        <$> W.constructSharedTransaction @_ @s @k @n @era
+                            wrk wid txCtx sel
+
+                    pure ApiConstructTransaction
+                        { transaction = case body ^. #encoding of
+                                Just HexEncoded -> ApiSerialisedTransaction (ApiT tx) HexEncoded
+                                _ -> ApiSerialisedTransaction (ApiT tx) Base64Encoded
+                        , coinSelection = mkApiCoinSelection [] [] Nothing md sel'
+                        , fee = Quantity $ fromIntegral fee
+                        }
   where
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
     ti = timeInterpreter (ctx ^. networkLayer)
@@ -3016,7 +3021,7 @@ balanceTransaction ctx@ApiLayer{..} genChange (ApiT wid) body = do
             . cardanoTxIdeallyNoLaterThan era
             . getApiT $ body ^. #transaction
 
-        res <- WriteTx.withRecentEra anyRecentTx
+        res <- WriteTx.withInAnyRecentEra anyRecentTx
             (fmap inAnyCardanoEra . balanceTx <=< mkPartialTx)
 
         case body ^. #encoding of
@@ -4100,6 +4105,22 @@ rndStateChange ctx (ApiT wid) pwd =
 type RewardAccountBuilder k
         =  (k 'RootK XPrv, Passphrase "encryption")
         -> (XPrv, Passphrase "encryption")
+
+withRecentEra
+    :: AnyCardanoEra
+    -> (forall e. WriteTx.IsRecentEra e => WriteTx.RecentEra e -> Handler a)
+    -> Handler a
+withRecentEra anyCardanoEra handleRecentEra = do
+    let invalidEra = ErrMkTransactionInvalidEra anyCardanoEra
+    case anyCardanoEra of
+        Cardano.AnyCardanoEra cardanoEra ->
+            case cardanoEra of
+                Cardano.BabbageEra -> handleRecentEra WriteTx.RecentEraBabbage
+                Cardano.AlonzoEra  -> handleRecentEra WriteTx.RecentEraAlonzo
+                Cardano.MaryEra    -> liftE invalidEra
+                Cardano.AllegraEra -> liftE invalidEra
+                Cardano.ShelleyEra -> liftE invalidEra
+                Cardano.ByronEra   -> liftE invalidEra
 
 mkWithdrawal
     :: forall (n :: NetworkDiscriminant) ktype tx

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -533,7 +533,7 @@ import Control.DeepSeq
 import Control.Error.Util
     ( failWith )
 import Control.Monad
-    ( forM, forever, join, void, when, (<=<), (>=>) )
+    ( forM, forever, join, void, when, (<=<) )
 import Control.Monad.Error.Class
     ( throwError )
 import Control.Monad.IO.Class
@@ -1309,11 +1309,11 @@ mkLegacyWallet ctx wid cp meta _ pending progress = do
             pure Nothing
         Just (WalletPassphraseInfo time EncryptWithPBKDF2) ->
             pure $ Just $ ApiWalletPassphraseInfo time
-        Just (WalletPassphraseInfo time EncryptWithScrypt) -> do
-            withWorkerCtx @_ @s @k ctx wid liftE liftE $
-                matchEmptyPassphrase >=> \case
-                    Right{} -> pure Nothing
-                    Left{} -> pure $ Just $ ApiWalletPassphraseInfo time
+        Just (WalletPassphraseInfo time EncryptWithScrypt) ->
+            withWorkerCtx @_ @s @k ctx wid liftE liftE $ \wrk ->
+                matchEmptyPassphrase (wrk ^. typed) <&> \case
+                    Right{} -> Nothing
+                    Left{} -> Just $ ApiWalletPassphraseInfo time
 
     tip' <- liftIO $ getWalletTip (expectAndThrowFailures ti) cp
     let available = availableBalance pending cp

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2085,9 +2085,10 @@ signTransaction ctx (ApiT wid) body = do
     -- TODO: The body+witnesses seem redundant with the sealedTx already. What's
     -- the use-case for having them provided separately? In the end, the client
     -- should be able to decouple them if they need to.
-    case body ^. #encoding of
-        Just HexEncoded -> pure $ ApiSerialisedTransaction (ApiT sealedTx') HexEncoded
-        _ -> pure $ ApiSerialisedTransaction (ApiT sealedTx') Base64Encoded
+    pure $ ApiSerialisedTransaction (ApiT sealedTx') $
+        case body ^. #encoding of
+            Just HexEncoded -> HexEncoded
+            _otherEncodings -> Base64Encoded
 
 postTransactionOld
     :: forall ctx s k n.

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -586,15 +586,18 @@ mkTxHistory numTx numInputs numOutputs numAssets range =
   where
     sl i = SlotNo $ range !! (i `mod` length range)
 
-mkInputs :: Int -> Int -> [(TxIn, Coin)]
+mkInputs :: Int -> Int -> [(TxIn, Maybe TxOut)]
 mkInputs prefix n =
     [ force
         ( TxIn (Hash (label lbl i)) (fromIntegral i)
-        , Coin $ fromIntegral n
+        , Just $ mkTxOut n
         )
     | !i <- [1..n]]
   where
     lbl = show prefix <> "in"
+    mkTxOut i = TxOut
+        (mkAddress prefix i)
+        (TokenBundle.TokenBundle (Coin $ fromIntegral i) mempty)
 
 -- | Creates transaction outputs with multi-asset token bundles.
 mkOutputs :: Int -> Int -> Int -> [TxOut]

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -211,6 +211,7 @@ import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.BM.Data.BackendKind as CM
 import qualified Cardano.Wallet.Address.Pool as AddressPool
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Byron as Byron
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.ByteArray as BA
@@ -597,7 +598,7 @@ mkInputs prefix n =
     lbl = show prefix <> "in"
     mkTxOut i = TxOut
         (mkAddress prefix i)
-        (TokenBundle.TokenBundle (Coin $ fromIntegral i) mempty)
+        (TokenBundle.TokenBundle (Coin.unsafeFromIntegral i) mempty)
 
 -- | Creates transaction outputs with multi-asset token bundles.
 mkOutputs :: Int -> Int -> Int -> [TxOut]

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1581,15 +1581,14 @@ instance Buildable (PartialTx era) where
         cardanoTxF tx' = pretty $ pShow tx'
 
 balanceTransaction
-    :: forall era m s k ktype ctx.
-        ( HasTransactionLayer k ktype ctx
-        , GenChange s
+    :: forall era m s k ktype.
+        ( GenChange s
         , MonadRandom m
-        , HasLogger m WalletWorkerLog ctx
         , WriteTx.IsRecentEra era
         , BoundedAddressLength k
         )
-    => ctx
+    => Tracer m WalletLog
+    -> TransactionLayer k ktype SealedTx
     -> ArgGenChange s
     -> (W.ProtocolParameters, Cardano.ProtocolParameters)
     -- ^ 'Cardano.ProtocolParameters' can be retrieved via a Local State Query
@@ -1615,7 +1614,7 @@ balanceTransaction
     -- @Wallet s@ for change address generation.
     -> PartialTx era
     -> ExceptT ErrBalanceTx m (Cardano.Tx era)
-balanceTransaction ctx change pp ti wallet unadjustedPtx = do
+balanceTransaction tr txLayer change pp ti wallet unadjustedPtx = do
     -- TODO [ADP-1490] Take 'Ledger.PParams era' directly as argument, and avoid
     -- converting to/from Cardano.ProtocolParameters. This may affect
     -- performance. The addition of this one specific conversion seems to have
@@ -1628,7 +1627,7 @@ balanceTransaction ctx change pp ti wallet unadjustedPtx = do
     let balanceWith strategy =
             balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 @era @m @s @k @ktype
-                ctx change pp ti wallet strategy adjustedPtx
+                tr txLayer change pp ti wallet strategy adjustedPtx
     balanceWith SelectionStrategyOptimal
         `catchE` \e ->
             if minimalStrategyIsWorthTrying e
@@ -1704,15 +1703,14 @@ increaseZeroAdaOutputs era pp = WriteTx.modifyLedgerBody $
 
 -- | Internal helper to 'balanceTransaction'
 balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
-    :: forall era m s k ktype ctx.
-        ( HasTransactionLayer k ktype ctx
-        , GenChange s
+    :: forall era m s k ktype.
+        ( GenChange s
         , BoundedAddressLength k
         , MonadRandom m
-        , HasLogger m WalletWorkerLog ctx
         , WriteTx.IsRecentEra era
         )
-    => ctx
+    => Tracer m WalletLog
+    -> TransactionLayer k ktype SealedTx
     -> ArgGenChange s
     -> (W.ProtocolParameters, Cardano.ProtocolParameters)
     -> TimeInterpreter (Either PastHorizonException)
@@ -1721,7 +1719,8 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     -> PartialTx era
     -> ExceptT ErrBalanceTx m (Cardano.Tx era)
 balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
-    ctx
+    tr
+    txLayer
     generateChange
     (pp, nodePParams)
     ti
@@ -1836,7 +1835,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         (\(ErrMoreSurplusNeeded c) ->
             ErrBalanceTxInternalError
                 $ ErrUnderestimatedFee c (toSealed candidateTx))
-        (ExceptT . pure $ distributeSurplus tl feePolicy surplus feeAndChange)
+        (ExceptT . pure $ distributeSurplus txLayer feePolicy surplus feeAndChange)
 
     guardTxSize =<< guardTxBalanced =<< (assembleTransaction $ TxUpdate
         { extraInputs
@@ -1845,9 +1844,6 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         , feeUpdate = UseNewTxFee updatedFee
         })
   where
-    tl = ctx ^. transactionLayer @k @ktype
-    tr = contramap MsgWallet $ ctx ^. logger @m
-
     toSealed :: Cardano.Tx era -> SealedTx
     toSealed = sealedTxFromCardano . Cardano.InAnyCardanoEra Cardano.cardanoEra
 
@@ -1895,7 +1891,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 
     guardTxSize :: Cardano.Tx era -> ExceptT ErrBalanceTx m (Cardano.Tx era)
     guardTxSize tx = do
-        let size = estimateSignedTxSize tl nodePParams tx
+        let size = estimateSignedTxSize txLayer nodePParams tx
         let maxSize = TxSize
                 . intCast
                 . getQuantity
@@ -1913,7 +1909,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 
     txBalance :: Cardano.Tx era -> Cardano.Value
     txBalance tx =
-        evaluateTransactionBalance tl tx nodePParams combinedUTxO
+        evaluateTransactionBalance txLayer tx nodePParams combinedUTxO
 
     balanceAfterSettingMinFee
         :: Cardano.Tx era
@@ -1921,10 +1917,10 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     balanceAfterSettingMinFee tx = ExceptT . pure $ do
         -- NOTE: evaluateMinimumFee relies on correctly estimating the required
         -- number of witnesses.
-        let minfee = evaluateMinimumFee tl nodePParams tx
+        let minfee = evaluateMinimumFee txLayer nodePParams tx
         let update = TxUpdate [] [] [] (UseNewTxFee minfee)
-        tx' <- left ErrBalanceTxUpdateError $ updateTx tl tx update
-        let balance = evaluateTransactionBalance tl tx' nodePParams combinedUTxO
+        tx' <- left ErrBalanceTxUpdateError $ updateTx txLayer tx update
+        let balance = evaluateTransactionBalance txLayer tx' nodePParams combinedUTxO
         let minfee' = Cardano.Lovelace $ fromIntegral $ unCoin minfee
         return (balance, minfee')
 
@@ -1978,14 +1974,14 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         :: TxUpdate
         -> ExceptT ErrBalanceTx m (Cardano.Tx era)
     assembleTransaction update = ExceptT . pure $ do
-        tx' <- left ErrBalanceTxUpdateError $ updateTx tl partialTx update
+        tx' <- left ErrBalanceTxUpdateError $ updateTx txLayer partialTx update
         left ErrBalanceTxAssignRedeemers $ assignScriptRedeemers
-            tl nodePParams ti combinedUTxO redeemers tx'
+            txLayer nodePParams ti combinedUTxO redeemers tx'
 
     extractOutputsFromTx tx =
         let
             era = Cardano.AnyCardanoEra $ Cardano.cardanoEra @era
-            (Tx {outputs}, _, _, _, _, _) = decodeTx tl era AnyWitnessCountCtx tx
+            (Tx {outputs}, _, _, _, _, _) = decodeTx txLayer era AnyWitnessCountCtx tx
         in outputs
 
     guardConflictingWithdrawalNetworks
@@ -2051,7 +2047,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         -> Either (SelectionError WalletSelectionContext) Selection
     selectAssets' era outs utxoSelection balance fee0 seed =
         let
-            txPlutusScriptExecutionCost = maxScriptExecutionCost tl pp redeemers
+            txPlutusScriptExecutionCost = maxScriptExecutionCost txLayer pp redeemers
             colReq =
                 if txPlutusScriptExecutionCost > Coin 0 then
                     SelectionCollateralRequired
@@ -2078,7 +2074,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                         , skeletonChange = []
                         }
                 in calcMinimumCost
-                        tl
+                        txLayer
                         era
                         pp
                         defaultTransactionCtx
@@ -2107,20 +2103,20 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             selectionConstraints = SelectionConstraints
                 { assessTokenBundleSize =
                     view #assessTokenBundleSize $
-                    tokenBundleSizeAssessor tl $
+                    tokenBundleSizeAssessor txLayer $
                     pp ^. (#txParameters . #getTokenBundleMaxSize)
                 , certificateDepositAmount =
                     view #stakeKeyDeposit pp
                 , computeMinimumAdaQuantity =
                     view #txOutputMinimumAdaQuantity
-                        (constraints tl era pp)
+                        (constraints txLayer era pp)
                 , isBelowMinimumAdaQuantity =
                     view #txOutputBelowMinimumAdaQuantity
-                        (constraints tl era pp)
+                        (constraints txLayer era pp)
                 , computeMinimumCost = \skeleton -> mconcat
                     [ feePadding
                     , fromCardanoLovelace fee0
-                    , calcMinimumCost tl era pp
+                    , calcMinimumCost txLayer era pp
                         (defaultTransactionCtx
                             { txPlutusScriptExecutionCost =
                                 txPlutusScriptExecutionCost })

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2531,10 +2531,7 @@ buildAndSignTransaction
     => ctx
     -> WalletId
     -> Cardano.AnyCardanoEra
-    -> ( (k 'RootK XPrv, Passphrase "encryption") ->
-         (         XPrv, Passphrase "encryption")
-       )
-       -- ^ Reward account derived from the root key (or somewhere else).
+    -> MakeRewardAccountBuilder k
     -> Passphrase "user"
     -> TransactionCtx
     -> SelectionOf TxOut
@@ -2551,19 +2548,40 @@ buildAndSignTransaction ctx wid era mkRwdAcct pwd txCtx sel = db & \DBLayer{..} 
             let rewardAcnt = mkRwdAcct (xprv, pwdP)
             (tx, sealedTx) <- withExceptT ErrSignPaymentMkTx $ ExceptT $ pure $
                 mkTransaction tl era rewardAcnt keyFrom pp txCtx sel
-            (time, meta) <- liftIO $
-                mkTxMeta ti (currentTip cp) (getState cp) txCtx sel
-            return (tx, meta, time, sealedTx)
+            let amountOut :: Coin =
+                    F.fold $
+                        fmap TxOut.coin (sel ^. #change) <>
+                        mapMaybe (`ourCoin` getState cp) (sel ^. #outputs)
+                amountIn :: Coin =
+                    F.fold (NE.toList (TxOut.coin . snd <$> sel ^. #inputs))
+                    -- NOTE: In case where rewards were pulled from an external
+                    -- source, they aren't added to the calculation because the
+                    -- money is considered to come from outside of the wallet; which
+                    -- changes the way we look at transactions (in such case, a
+                    -- transaction is considered 'Incoming' since it brings extra money
+                    -- to the wallet from elsewhere).
+                    & case txWithdrawal txCtx of
+                        w@WithdrawalSelf{} -> Coin.add (withdrawalToCoin w)
+                        WithdrawalExternal{} -> Prelude.id
+                        NoWithdrawal -> Prelude.id
+            time <- liftIO $ tipSlotStartTime $ currentTip cp
+            let meta = mkTxMeta
+                    (currentTip cp) (txValidityInterval txCtx)
+                    amountIn amountOut
+            pure (tx, meta, time, sealedTx)
   where
     db = ctx ^. dbLayer @IO @s @k
     tl = ctx ^. transactionLayer @k @'CredFromKeyK
     nl = ctx ^. networkLayer
     ti = timeInterpreter nl
+    tipSlotStartTime tipHeader = interpretQuery
+        (neverFails "buildAndSignTransaction slot is ahead of the node tip" ti)
+        (slotToUTCTime (tipHeader ^. #slotNo))
 
 -- | Construct an unsigned transaction from a given selection.
 constructTransaction
     :: forall (n :: NetworkDiscriminant) ktype era
-     . Write.Tx.IsRecentEra era
+     . WriteTx.IsRecentEra era
     => TransactionLayer ShelleyKey ktype SealedTx
     -> NetworkLayer IO Block
     -> DBLayer IO (SeqState n ShelleyKey) ShelleyKey
@@ -2588,7 +2606,7 @@ constructSharedTransaction
         , k ~ SharedKey
         , s ~ SharedState n k
         , Typeable n
-        , Write.Tx.IsRecentEra era
+        , WriteTx.IsRecentEra era
         )
     => ctx
     -> WalletId
@@ -2660,95 +2678,39 @@ constructTxMeta
     -> ExceptT ErrSubmitTransaction IO TxMeta
 constructTxMeta DBLayer{..} wid txCtx inps outs =
     mapExceptT atomically $ do
-        cp <- withExceptT ErrSubmitTransactionNoSuchWallet
+        checkpoint <- withExceptT ErrSubmitTransactionNoSuchWallet
               $ withNoSuchWallet wid
               $ readCheckpoint wid
-        liftIO $ mkTxMetaWithoutSel (currentTip cp) txCtx inps outs
+        let latestBlockHeader = currentTip checkpoint
+        let amountOut = F.fold $ map TxOut.coin outs
+            amountIn = F.fold (map snd inps)
+                & case txWithdrawal txCtx of
+                    w@WithdrawalSelf{} -> Coin.add (withdrawalToCoin w)
+                    WithdrawalExternal{} -> Prelude.id
+                    NoWithdrawal -> Prelude.id
+        let validity = txValidityInterval txCtx
+        pure $ mkTxMeta latestBlockHeader validity amountIn amountOut
 
-mkTxMetaWithoutSel
-    :: BlockHeader
-    -> TransactionCtx
-    -> [(TxIn, Coin)]
-    -> [TxOut]
-    -> IO TxMeta
-mkTxMetaWithoutSel blockHeader txCtx inps outs =
-    let
-        amtOuts = F.fold $ map TxOut.coin outs
-
-        amtInps
-            = F.fold (map snd inps)
-            & case txWithdrawal txCtx of
-                w@WithdrawalSelf{} -> Coin.add (withdrawalToCoin w)
-                WithdrawalExternal{} -> Prelude.id
-                NoWithdrawal -> Prelude.id
-    in return TxMeta
-       { status = Pending
-       , direction = if amtInps > amtOuts then Outgoing else Incoming
-       , slotNo = blockHeader ^. #slotNo
-       , blockHeight = blockHeader ^. #blockHeight
-       , amount = Coin.distance amtInps amtOuts
-       , expiry = Just (snd $ txValidityInterval txCtx)
-       }
-
-ourCoin
-    :: IsOurs s Address
-    => TxOut
-    -> s
-    -> Maybe Coin
+ourCoin :: IsOurs s Address => TxOut -> s -> Maybe Coin
 ourCoin (TxOut addr tokens) wState =
-    case fst (isOurs addr wState) of
-        Just{}  -> Just (TokenBundle.getCoin tokens)
-        Nothing -> Nothing
+    fst (isOurs addr wState) $> TokenBundle.getCoin tokens
 
--- | Construct transaction metadata for a pending transaction from the block
--- header of the current tip and a list of input and output.
---
--- FIXME: There's a logic duplication regarding the calculation of the transaction
--- amount between right here, and the Primitive.Model (see prefilterBlocks).
+-- | Construct transaction metadata for a pending transaction
 mkTxMeta
-    :: IsOurs s Address
-    => TimeInterpreter (ExceptT PastHorizonException IO)
-    -> BlockHeader
-    -> s
-    -> TransactionCtx
-    -> SelectionOf TxOut
-    -> IO (UTCTime, TxMeta)
-mkTxMeta ti' blockHeader wState txCtx sel =
-    let
-        amtOuts = F.fold $
-            (TxOut.coin <$> view #change sel)
-            ++
-            mapMaybe (`ourCoin` wState) (view #outputs sel)
-
-        amtInps
-            = F.fold (TxOut.coin . snd <$> view #inputs sel)
-            -- NOTE: In case where rewards were pulled from an external
-            -- source, they aren't added to the calculation because the
-            -- money is considered to come from outside of the wallet; which
-            -- changes the way we look at transactions (in such case, a
-            -- transaction is considered 'Incoming' since it brings extra money
-            -- to the wallet from elsewhere).
-            & case txWithdrawal txCtx of
-                w@WithdrawalSelf{} -> Coin.add (withdrawalToCoin w)
-                WithdrawalExternal{} -> Prelude.id
-                NoWithdrawal -> Prelude.id
-    in do
-        t <- slotStartTime' (blockHeader ^. #slotNo)
-        return
-            ( t
-            , TxMeta
-                { status = Pending
-                , direction = if amtInps > amtOuts then Outgoing else Incoming
-                , slotNo = blockHeader ^. #slotNo
-                , blockHeight = blockHeader ^. #blockHeight
-                , amount = Coin.distance amtInps amtOuts
-                , expiry = Just (snd $ txValidityInterval txCtx)
-                }
-            )
-  where
-    slotStartTime' = interpretQuery ti . slotToUTCTime
-      where
-        ti = neverFails "mkTxMeta slots should never be ahead of the node tip" ti'
+    :: BlockHeader
+    -> TxValidityInterval
+    -> Coin -- Our inputs amount
+    -> Coin -- Outputs amount
+    -> TxMeta
+mkTxMeta latestBlockHeader txValidity amountIn amountOut =
+    TxMeta
+        { status = Pending
+        , direction = if amountIn > amountOut then Outgoing else Incoming
+        , slotNo = latestBlockHeader ^. #slotNo
+        , blockHeight = latestBlockHeader ^. #blockHeight
+        , amount = Coin.distance amountIn amountOut
+        , expiry = Just (snd txValidity)
+        }
 
 -- | Broadcast a (signed) transaction to the network.
 submitTx

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -558,7 +558,7 @@ import Data.List.NonEmpty
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
-    ( fromJust, fromMaybe, isJust, mapMaybe )
+    ( fromMaybe, isJust, mapMaybe )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
@@ -2637,7 +2637,13 @@ buildAndSignTransactionNew
     balanceTx protocolParams utxo unsignedTxBody = do
         let protocolParameters =
                 ( protocolParams
-                , fromJust $ currentNodeProtocolParameters protocolParams
+                , fromMaybe
+                    (error $ unwords
+                        [ "buildAndSignTransactionNew: no nodePParams."
+                        , "should only be possible in Byron, where"
+                        , "withRecentEra should prevent this to be reached."
+                        ])
+                    $ currentNodeProtocolParameters protocolParams
                 )
             partialTx = PartialTx
                 (Cardano.Tx unsignedTxBody [])(Cardano.UTxO mempty) mempty

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1836,16 +1836,17 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     -- padding in @selectAssets'@.
     TxFeeAndChange updatedFee updatedChange <- withExceptT
         (\(ErrMoreSurplusNeeded c) ->
-            ErrBalanceTxInternalError
-                $ ErrUnderestimatedFee c (toSealed candidateTx))
-        (ExceptT . pure $ distributeSurplus txLayer feePolicy surplus feeAndChange)
+            ErrBalanceTxInternalError $
+                ErrUnderestimatedFee c (toSealed candidateTx))
+        (ExceptT . pure $
+            distributeSurplus txLayer feePolicy surplus feeAndChange)
 
-    guardTxSize =<< guardTxBalanced =<< (assembleTransaction $ TxUpdate
+    guardTxSize =<< guardTxBalanced =<< assembleTransaction TxUpdate
         { extraInputs
         , extraCollateral
         , extraOutputs = updatedChange
         , feeUpdate = UseNewTxFee updatedFee
-        })
+        }
   where
     toSealed :: Cardano.Tx era -> SealedTx
     toSealed = sealedTxFromCardano . Cardano.InAnyCardanoEra Cardano.cardanoEra

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -620,6 +620,7 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Cardano.Wallet.Write.Tx as WriteTx
+import qualified Cardano.Wallet.Write.Tx as Write.Tx
 import qualified Data.ByteArray as BA
 import qualified Data.Foldable as F
 import qualified Data.List as L
@@ -2558,40 +2559,40 @@ buildAndSignTransaction ctx wid era mkRwdAcct pwd txCtx sel = db & \DBLayer{..} 
 
 -- | Construct an unsigned transaction from a given selection.
 constructTransaction
-    :: forall (n :: NetworkDiscriminant) ktype
-     . TransactionLayer ShelleyKey ktype SealedTx
+    :: forall (n :: NetworkDiscriminant) ktype era
+     . Write.Tx.IsRecentEra era
+    => TransactionLayer ShelleyKey ktype SealedTx
     -> NetworkLayer IO Block
     -> DBLayer IO (SeqState n ShelleyKey) ShelleyKey
     -> WalletId
-    -> Cardano.AnyCardanoEra
     -> TransactionCtx
     -> PreSelection
-    -> ExceptT ErrConstructTx IO SealedTx
-constructTransaction txLayer netLayer db wid era txCtx preSel = do
+    -> ExceptT ErrConstructTx IO (Cardano.TxBody era)
+constructTransaction txLayer netLayer db wid txCtx preSel = do
     (_, xpub, _) <- readRewardAccount db wid
         & withExceptT ErrConstructTxReadRewardAccount
     pp <- liftIO $ currentProtocolParameters netLayer
-    mkUnsignedTransaction txLayer era xpub pp txCtx (Left preSel)
+    mkUnsignedTransaction txLayer xpub pp txCtx (Left preSel)
         & withExceptT ErrConstructTxBody . except
 
 -- | Construct an unsigned transaction from a given selection
 -- for a shared wallet.
 constructSharedTransaction
-    :: forall ctx s k (n :: NetworkDiscriminant).
+    :: forall ctx s k (n :: NetworkDiscriminant) era.
         ( HasTransactionLayer k 'CredFromScriptK ctx
         , HasDBLayer IO s k ctx
         , HasNetworkLayer IO ctx
         , k ~ SharedKey
         , s ~ SharedState n k
         , Typeable n
+        , Write.Tx.IsRecentEra era
         )
     => ctx
     -> WalletId
-    -> Cardano.AnyCardanoEra
     -> TransactionCtx
     -> SelectionOf TxOut
-    -> ExceptT ErrConstructTx IO SealedTx
-constructSharedTransaction ctx wid era txCtx sel = db & \DBLayer{..} -> do
+    -> ExceptT ErrConstructTx IO (Cardano.TxBody era)
+constructSharedTransaction ctx wid txCtx sel = db & \DBLayer{..} -> do
     cp <- withExceptT ErrConstructTxNoSuchWallet
         $ mapExceptT atomically
         $ withNoSuchWallet wid
@@ -2621,8 +2622,8 @@ constructSharedTransaction ctx wid era txCtx sel = db & \DBLayer{..} -> do
     let txCtx' = txCtx {txNativeScriptInputs = scriptInps}
     mapExceptT atomically $ do
         pp <- liftIO $ currentProtocolParameters nl
-        withExceptT ErrConstructTxBody $ ExceptT $ pure $
-            mkUnsignedTransaction tl era xpub pp txCtx' (Right sel)
+        withExceptT ErrConstructTxBody $ ExceptT $ pure
+            $ mkUnsignedTransaction tl @era xpub pp txCtx' (Right sel)
   where
     db = ctx ^. dbLayer @IO @s @k
     tl = ctx ^. transactionLayer @k @'CredFromScriptK

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -129,6 +129,7 @@ module Cardano.Wallet
     , assignChangeAddressesAndUpdateDb
     , assignChangeAddressesWithoutDbUpdate
     , selectionToUnsignedTx
+    , buildAndSignTransactionNew
     , buildAndSignTransaction
     , signTransaction
     , constructTransaction
@@ -220,6 +221,8 @@ import Cardano.Address.Style.Shared
     ( deriveDelegationPublicKey )
 import Cardano.Api
     ( AnyCardanoEra, serialiseToCBOR )
+import Cardano.Api.Extra
+    ( inAnyCardanoEra )
 import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Data.Tracer
@@ -320,7 +323,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.MintBurn
 import Cardano.Wallet.Primitive.AddressDerivation.SharedKey
     ( SharedKey (..), replaceCosignersWithVerKeys )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
-    ( ShelleyKey, deriveAccountPrivateKeyShelley )
+    ( ShelleyKey (..), deriveAccountPrivateKeyShelley )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( CompareDiscovery (..)
     , GenChange (..)
@@ -334,7 +337,11 @@ import Cardano.Wallet.Primitive.AddressDiscovery
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( ErrImportAddress (..), RndStateLike )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
-    ( SeqState, defaultAddressPoolGap, mkSeqStateFromRootXPrv, purposeBIP44 )
+    ( SeqState (..)
+    , defaultAddressPoolGap
+    , mkSeqStateFromRootXPrv
+    , purposeBIP44
+    )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( CredentialType (..)
     , ErrAddCosigner (..)
@@ -351,6 +358,7 @@ import Cardano.Wallet.Primitive.Model
     ( BlockData (..)
     , Wallet
     , applyBlocks
+    , applyOurTxToUTxO
     , availableUTxO
     , currentTip
     , firstHeader
@@ -375,6 +383,7 @@ import Cardano.Wallet.Primitive.Slotting
     , addRelTime
     , ceilingSlotAt
     , currentRelativeTime
+    , hoistTimeInterpreter
     , interpretQuery
     , neverFails
     , slotRangeFromTimeRange
@@ -467,23 +476,26 @@ import Cardano.Wallet.Transaction
     , ErrMoreSurplusNeeded (ErrMoreSurplusNeeded)
     , ErrSignTx (..)
     , ErrUpdateSealedTx (..)
-    , PreSelection
+    , PreSelection (..)
     , TransactionCtx (..)
     , TransactionLayer (..)
     , TxFeeAndChange (TxFeeAndChange)
     , TxFeeUpdate (..)
     , TxUpdate (..)
+    , TxValidityInterval
     , Withdrawal (..)
     , WitnessCountCtx (..)
     , defaultTransactionCtx
     , withdrawalToCoin
     )
+import Cardano.Wallet.Write.Tx
+    ( AnyRecentEra )
 import Control.Arrow
     ( first, left )
 import Control.DeepSeq
     ( NFData )
 import Control.Monad
-    ( forM, forM_, replicateM, unless, when )
+    ( forM, forM_, replicateM, unless, when, (<=<) )
 import Control.Monad.Class.MonadTime
     ( DiffTime
     , MonadMonotonicTime (..)
@@ -546,7 +558,7 @@ import Data.List.NonEmpty
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
-    ( fromMaybe, isJust, mapMaybe )
+    ( fromJust, fromMaybe, isJust, mapMaybe )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
@@ -603,6 +615,7 @@ import qualified Cardano.Address.Style.Shelley as CAShelley
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Crypto.Wallet as CC
+import qualified Cardano.Slotting.Slot as Slot
 import qualified Cardano.Tx.Balance.Internal.CoinSelection as CS
 import qualified Cardano.Wallet.Checkpoints.Policy as CP
 import qualified Cardano.Wallet.DB.WalletState as WS
@@ -620,7 +633,6 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Cardano.Wallet.Write.Tx as WriteTx
-import qualified Cardano.Wallet.Write.Tx as Write.Tx
 import qualified Data.ByteArray as BA
 import qualified Data.Foldable as F
 import qualified Data.List as L
@@ -2514,6 +2526,159 @@ signTransaction tl preferredLatestEra keyLookup (rootKey, rootPwd) utxo =
             policyKey
             keyLookup
             inputResolver
+
+type MakeRewardAccountBuilder k =
+    (k 'RootK XPrv, Passphrase "encryption") -> (XPrv, Passphrase "encryption")
+
+-- | Produce witnesses and construct a transaction from a given selection.
+--
+-- Requires the encryption passphrase in order to decrypt the root private key.
+-- Note that this doesn't broadcast the transaction to the network. In order to
+-- do so, use 'submitTx'.
+--
+buildAndSignTransactionNew
+    :: forall k ktype s (n :: NetworkDiscriminant)
+     . ( Typeable n
+       , Typeable s
+       , Typeable k
+       , WalletKey k
+       , HardDerivation k
+       , BoundedAddressLength k
+       , Bounded (Index (AddressIndexDerivationType k) (AddressCredential k))
+       , IsOwned s k ktype
+       , IsOurs s RewardAccount
+       , GenChange s
+       )
+    => Tracer IO WalletLog
+    -> TimeInterpreter (Either PastHorizonException)
+    -> DBLayer IO s k
+    -> NetworkLayer IO Block
+    -> TransactionLayer k ktype SealedTx
+    -> WalletId
+    -> ArgGenChange s
+    -> AnyRecentEra
+    -> Passphrase "user"
+    -> PreSelection
+    -> TransactionCtx
+    -> IO (Tx, TxMeta, UTCTime, SealedTx)
+buildAndSignTransactionNew
+    tr ti db netLayer txLayer walletId changeGen era pwd preSelection txCtx =
+    WriteTx.withRecentEra era $ \(_ :: WriteTx.RecentEra recentEra) -> do
+        utxo@(_utxoIndex, wallet, _history) <-
+            errorToException ErrConstructTxNoSuchWallet <=< runExceptT $
+                readWalletUTxOIndex @_ @_ @k db walletId
+
+        protocolParams <- currentProtocolParameters netLayer
+        unsignedTxBody <-
+            errorToException ErrConstructTxBody $
+                mkUnsignedTransaction txLayer @recentEra
+                    (unsafeShelleyOnlyGetRewardXPub wallet)
+                    protocolParams txCtx (Left preSelection)
+
+        unsignedBalancedTx <- balanceTx protocolParams utxo unsignedTxBody
+        signedSealedTx <- signBalancedTx wallet unsignedBalancedTx
+
+        let ( tx
+                , _tokenMapWithScripts1
+                , _tokenMapWithScripts2
+                , _certificates
+                , _validityIntervalExplicit
+                , _witnessCount
+                ) = decodeTx
+                        txLayer anyCardanoEra AnyWitnessCountCtx signedSealedTx
+
+        let meta = case applyOurTxToUTxO
+                            (Slot.at $ currentTip wallet ^. #slotNo)
+                            (currentTip wallet ^. #blockHeight)
+                            (getState wallet)
+                            tx
+                            (wallet ^. #utxo) of
+                Nothing -> error $ unwords
+                    [ "buildAndSignTransactionNew:"
+                    , "Can't apply constructed transaction."
+                    ]
+                Just ((_tx, appliedMeta), _deltaUtxo, _nextUtxo) ->
+                    appliedMeta
+                        { status = Pending
+                        , expiry = Just (snd (txValidityInterval txCtx))
+                        }
+        tipTime <- liftIO $ tipSlotStartTime $ currentTip wallet
+
+        -- tx coming from `decodeTx` doesn't contain previous tx outputs that
+        -- correspond to this tx inputs, so its inputs aren't "resolved".
+        -- We restore corresponding outputs by searching them in the UTxO again.
+        let resolveInputs :: [(TxIn, Maybe TxOut)] -> [(TxIn, Maybe TxOut)]
+            resolveInputs = fmap (\(txIn, _) ->
+                (txIn, UTxO.lookup txIn (wallet ^. #utxo)))
+            txResolved = tx
+                { resolvedInputs =
+                    resolveInputs  (resolvedInputs tx)
+                , resolvedCollateralInputs =
+                    resolveInputs  (resolvedCollateralInputs tx)
+                }
+
+        pure (txResolved, meta, tipTime, signedSealedTx)
+  where
+    errorToException f = either (throwIO . ExceptionConstructTx . f) pure
+    anyCardanoEra = WriteTx.fromAnyRecentEra era
+    tipSlotStartTime tipHeader = interpretQuery
+        (neverFails
+            "buildAndSignTransactionNew: slot is ahead of the node tip"
+            (hoistTimeInterpreter except ti)
+        )
+        (slotToUTCTime (tipHeader ^. #slotNo))
+
+    balanceTx
+        :: WriteTx.IsRecentEra era
+        => ProtocolParameters
+        -> (UTxOIndex WalletUTxO, Wallet s, Set Tx)
+        -> Cardano.TxBody era
+        -> IO (Cardano.Tx era)
+    balanceTx protocolParams utxo unsignedTxBody = do
+        let protocolParameters =
+                ( protocolParams
+                , fromJust $ currentNodeProtocolParameters protocolParams
+                )
+            partialTx = PartialTx
+                (Cardano.Tx unsignedTxBody [])(Cardano.UTxO mempty) mempty
+        either (throwIO . ExceptionBalanceTx) pure <=< runExceptT $
+            balanceTransaction @_ @_ @s @k @ktype
+                tr txLayer changeGen protocolParameters ti utxo partialTx
+
+    signBalancedTx
+        :: Cardano.IsCardanoEra era
+        => Wallet s -> Cardano.Tx era -> IO SealedTx
+    signBalancedTx wallet unsignedBalancedTx =
+        either (throwIO . ExceptionWitnessTx) pure <=< runExceptT $ do
+            let wrapError = ErrWitnessTxWithRootKey
+            withRootKey db walletId pwd wrapError $ \rootKey scheme -> do
+                let keyWithPassphrase = (rootKey, preparePassphrase scheme pwd)
+                pure $ signTransaction @k @ktype txLayer
+                    anyCardanoEra
+                    (isOwned (getState wallet) keyWithPassphrase)
+                    keyWithPassphrase
+                    (wallet ^. #utxo)
+                    (sealedTxFromCardano $ inAnyCardanoEra unsignedBalancedTx)
+
+    -- HACK: 'mkUnsignedTransaction' takes a reward account 'XPub' even when the
+    -- wallet is a Byron wallet, and doesn't actually have a reward account.
+    --
+    -- 'buildAndSignTransaction' achieves this by deriving the 'XPub' regardless
+    -- of wallet type, from the root key. To avoid requiring another
+    -- 'withRootKey' call, and to make the sketchy behaviour more explicit, we
+    -- make 'buildAndSignTransactionNew' partial instead.
+    unsafeShelleyOnlyGetRewardXPub :: Wallet s -> XPub
+    unsafeShelleyOnlyGetRewardXPub wallet = fromMaybe notShelleyWallet $ do
+        Refl <- isSeqState
+        Refl <- isShelleyKey
+        pure $ getRawKey $ Seq.rewardAccountKey $ getState wallet
+      where
+        isSeqState = testEquality (typeRep @s) (typeRep @(SeqState n k))
+        isShelleyKey = testEquality (typeRep @k) (typeRep @(ShelleyKey))
+        notShelleyWallet = error $ unwords
+            [ "buildAndSignTransactionNew:"
+            , "can't delegate using non-shelley wallet"
+            ]
 
 -- | Produce witnesses and construct a transaction from a given selection.
 --

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
@@ -73,7 +73,7 @@ import Prelude
 import Cardano.Pool.Types
     ( PoolId )
 import Cardano.Wallet.Primitive.Model
-    ( Wallet, currentTip, utxo )
+    ( Wallet, currentTip )
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter, epochOf, interpretQuery, slotToUTCTime )
 import Cardano.Wallet.Primitive.Types
@@ -109,8 +109,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxMeta (..)
     , TxStatus (..)
     )
-import Cardano.Wallet.Primitive.Types.UTxO
-    ( UTxO (..) )
 import Control.DeepSeq
     ( NFData )
 import Control.Monad
@@ -484,11 +482,9 @@ mReadTxHistory ti wid minWithdrawal order range mstatus db@(Database wallets txs
         , txInfoFee =
             fee tx
         , txInfoInputs =
-            (\(inp, amt) -> (inp, amt, Map.lookup inp $ unUTxO $ utxo cp))
-                <$> resolvedInputs tx
+            resolvedInputs tx
         , txInfoCollateralInputs =
-            (\(inp, amt) -> (inp, amt, Map.lookup inp $ unUTxO $ utxo cp))
-                <$> resolvedCollateralInputs tx
+            resolvedCollateralInputs tx
         , txInfoOutputs =
             outputs tx
         , txInfoCollateralOutput =

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
@@ -479,7 +479,8 @@ mReadTxHistory ti wid minWithdrawal order range mstatus db@(Database wallets txs
     mkTransactionInfo cp (tx, meta) = TransactionInfo
         { txInfoId =
             view #txId tx
-        , txInfoCBOR = view #txCBOR tx
+        , txInfoCBOR =
+            view #txCBOR tx
         , txInfoFee =
             fee tx
         , txInfoInputs =
@@ -536,7 +537,8 @@ mReadDelegationRewardBalance
 mReadDelegationRewardBalance wid db@(Database wallets _) =
     (Right (maybe (Coin 0) rewardAccountBalance $ Map.lookup wid wallets), db)
 
-mPutLocalTxSubmission :: Ord wid => wid -> Hash "Tx" -> SealedTx -> SlotNo -> ModelOp wid s xprv ()
+mPutLocalTxSubmission ::
+    Ord wid => wid -> Hash "Tx" -> SealedTx -> SlotNo -> ModelOp wid s xprv ()
 mPutLocalTxSubmission wid tid tx sl = alterModelErr wid $ \wal ->
     case Map.lookup tid (txHistory wal) of
         Nothing -> (Left (NoSuchTx wid tid), wal)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -171,26 +171,26 @@ instance Delta DeltaTxSet where
     Type conversions
     From wallet types -> to database tables
 -------------------------------------------------------------------------------}
-mkTxIn :: TxId -> (Int, (W.TxIn, W.Coin)) -> TxIn
-mkTxIn tid (ix,(txIn,amt)) =
+mkTxIn :: TxId -> (Int, (W.TxIn, Maybe W.TxOut)) -> TxIn
+mkTxIn tid (ix, (txIn, txOut)) =
     TxIn
     { txInputTxId = tid
     , txInputOrder = ix
     , txInputSourceTxId = TxId (W.TxIn.inputId txIn)
     , txInputSourceIndex = W.TxIn.inputIx txIn
-    , txInputSourceAmount = amt
+    , txInputSourceAmount = maybe (W.Coin 0) W.TxOut.coin txOut
     }
 
 mkTxCollateral :: TxId
-    -> (Int, (W.TxIn, W.Coin))
+    -> (Int, (W.TxIn, Maybe W.TxOut))
     -> TxCollateral
-mkTxCollateral tid (ix,(txCollateral,amt)) =
+mkTxCollateral tid (ix, (txCollateral, txOut)) =
     TxCollateral
     { txCollateralTxId = tid
     , txCollateralOrder = ix
     , txCollateralSourceTxId = TxId $ W.TxIn.inputId txCollateral
     , txCollateralSourceIndex = W.TxIn.inputIx txCollateral
-    , txCollateralSourceAmount = amt
+    , txCollateralSourceAmount = maybe (W.Coin 0) W.TxOut.coin txOut
     }
 
 -- The key to sort TxCollateralOutToken

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -395,6 +395,5 @@ fromTxCBOR :: CBOR -> Either (CBOR, TxCBORRaw ) (TxId, TxCBOR)
 fromTxCBOR s@CBOR {..} = bimap (s ,) (cborTxId ,) $
     match eraValueSerialize $ (cborTxCBOR, cborTxEra) ^. fromIso i
 
-
 txCBORPrism :: Prism CBOR (CBOR, TxCBORRaw) (TxId, TxCBOR) (TxId, TxCBOR)
 txCBORPrism = prism toTxCBOR fromTxCBOR

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -201,7 +201,6 @@ mkTransactionInfo ti tip TxRelation{..} decor DB.TxMeta{..} = do
           { inputId = getTxId (txInputSourceTxId tx)
           , inputIx = txInputSourceIndex tx
           }
-        , txInputSourceAmount tx
         , lookupTxOutForTxIn tx decor
         )
     mkTxCollateral tx =
@@ -209,7 +208,6 @@ mkTransactionInfo ti tip TxRelation{..} decor DB.TxMeta{..} = do
           { inputId = getTxId (txCollateralSourceTxId tx)
           , inputIx = txCollateralSourceIndex tx
           }
-        , txCollateralSourceAmount tx
         , lookupTxOutForTxCollateral tx decor
         )
     mkTxWithdrawal w = (txWithdrawalAccount w, txWithdrawalAmount w)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Model.hs
@@ -435,9 +435,9 @@ availableUTxO pending (Wallet u _ _) = u `excluding` used
     -- UTxO which have been spent or committed as collateral in a pending
     -- transaction are not available to use in future transactions.
     getUsedTxIn :: Tx -> Set TxIn
-    getUsedTxIn tx = Set.fromList $ fst <$> mconcat
-        [ tx ^. #resolvedInputs
-        , tx ^. #resolvedCollateralInputs
+    getUsedTxIn tx = Set.fromList $ mconcat
+        [ fst <$> tx ^. #resolvedInputs
+        , fst <$> tx ^. #resolvedCollateralInputs
         ]
 
 -- | Computes the total 'UTxO' set of a wallet.

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -73,8 +73,8 @@ shrinkTx = shrinkMapBy txWithoutIdToTx txToTxWithoutId shrinkTxWithoutId
 
 data TxWithoutId = TxWithoutId
     { fee :: !(Maybe Coin)
-    , resolvedInputs :: ![(TxIn, Coin)]
-    , resolvedCollateralInputs :: ![(TxIn, Coin)]
+    , resolvedInputs :: ![(TxIn, Maybe TxOut)]
+    , resolvedCollateralInputs :: ![(TxIn, Maybe TxOut)]
     , outputs :: ![TxOut]
     , collateralOutput :: !(Maybe TxOut)
     , metadata :: !(Maybe TxMetadata)
@@ -86,8 +86,8 @@ data TxWithoutId = TxWithoutId
 genTxWithoutId :: Gen TxWithoutId
 genTxWithoutId = TxWithoutId
     <$> liftArbitrary genCoinPositive
-    <*> listOf1 (liftArbitrary2 genTxIn genCoinPositive)
-    <*> listOf1 (liftArbitrary2 genTxIn genCoinPositive)
+    <*> listOf1 (liftArbitrary2 genTxIn (pure Nothing))
+    <*> listOf1 (liftArbitrary2 genTxIn (pure Nothing))
     <*> listOf genTxOut
     <*> liftArbitrary genTxOut
     <*> liftArbitrary genNestedTxMetadata
@@ -97,8 +97,8 @@ genTxWithoutId = TxWithoutId
 shrinkTxWithoutId :: TxWithoutId -> [TxWithoutId]
 shrinkTxWithoutId = genericRoundRobinShrink
     <@> liftShrink shrinkCoinPositive
-    <:> shrinkList (liftShrink2 shrinkTxIn shrinkCoinPositive)
-    <:> shrinkList (liftShrink2 shrinkTxIn shrinkCoinPositive)
+    <:> shrinkList (liftShrink2 shrinkTxIn (liftShrink shrinkTxOut))
+    <:> shrinkList (liftShrink2 shrinkTxIn (liftShrink shrinkTxOut))
     <:> shrinkList shrinkTxOut
     <:> liftShrink shrinkTxOut
     <:> liftShrink shrinkTxMetadata

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TransactionInfo.hs
@@ -60,10 +60,10 @@ data TransactionInfo = TransactionInfo
     -- ^ Serialization of this transaction
     , txInfoFee :: Maybe Coin
     -- ^ Explicit transaction fee
-    , txInfoInputs :: [(TxIn, Coin, Maybe TxOut)]
+    , txInfoInputs :: [(TxIn, Maybe TxOut)]
     -- ^ Transaction inputs and (maybe) corresponding outputs of the
     -- source. Source information can only be provided for outgoing payments.
-    , txInfoCollateralInputs :: [(TxIn, Coin, Maybe TxOut)]
+    , txInfoCollateralInputs :: [(TxIn, Maybe TxOut)]
     -- ^ Collateral inputs and (maybe) corresponding outputs.
     , txInfoOutputs :: [TxOut]
     -- ^ Payment destination.
@@ -87,26 +87,21 @@ data TransactionInfo = TransactionInfo
 
 instance NFData TransactionInfo
 
--- | Reconstruct a transaction info from a transaction.
+-- | Reconstruct a transaction from a transaction info.
 fromTransactionInfo :: TransactionInfo -> Tx
 fromTransactionInfo info = Tx
     { txId = txInfoId info
     , txCBOR = txInfoCBOR info
     , fee = txInfoFee info
-    , resolvedInputs = drop3rd <$> txInfoInputs info
-    , resolvedCollateralInputs = drop3rd <$> txInfoCollateralInputs info
+    , resolvedInputs = txInfoInputs info
+    , resolvedCollateralInputs = txInfoCollateralInputs info
     , outputs = txInfoOutputs info
     , collateralOutput = txInfoCollateralOutput info
     , withdrawals = txInfoWithdrawals info
     , metadata = txInfoMetadata info
     , scriptValidity = txInfoScriptValidity info
     }
-  where
-    drop3rd :: (a, b, c) -> (a, b)
-    drop3rd (a, b, _) = (a, b)
-
 
 -- | Drop time-specific information
 toTxHistory :: TransactionInfo -> (Tx, TxMeta)
-toTxHistory info =
-    (fromTransactionInfo info, txInfoMeta info)
+toTxHistory info = (fromTransactionInfo info, txInfoMeta info)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
@@ -107,13 +107,13 @@ data Tx = Tx
         -- easily be re-computed from the delta between outputs and inputs.
 
     , resolvedInputs
-        :: ![(TxIn, Coin)]
+        :: ![(TxIn, Maybe TxOut)]
         -- ^ NOTE: Order of inputs matters in the transaction representation.
         -- The transaction id is computed from the binary representation of a
         -- tx, for which inputs are serialized in a specific order.
 
     , resolvedCollateralInputs
-        :: ![(TxIn, Coin)]
+        :: ![(TxIn, Maybe TxOut)]
         -- ^ NOTE: The order of collateral inputs matters in the transaction
         -- representation.  The transaction id is computed from the binary
         -- representation of a tx, for which collateral inputs are serialized

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
@@ -525,8 +525,8 @@ simpleTxIds = Hash . T.encodeUtf8 . T.pack . show <$> [0 :: Integer ..]
 
 canApplyTxToUTxO :: Tx -> UTxO -> Bool
 canApplyTxToUTxO tx u =  (&&)
-    (all inputRefIsValid (tx & Tx.resolvedInputs))
-    (all inputRefIsValid (tx & Tx.resolvedCollateralInputs))
+    (all inputRefIsValid (Tx.resolvedInputs tx))
+    (all inputRefIsValid (Tx.resolvedCollateralInputs tx))
   where
     inputRefIsValid :: (TxIn, Coin) -> Bool
     inputRefIsValid (ti, c) = case UTxO.lookup ti u of

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
@@ -111,7 +111,7 @@ import Prelude hiding
 import Cardano.Wallet.Primitive.Model
     ( applyTxToUTxO )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin )
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.StateDeltaSeq
@@ -124,6 +124,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..), txAssetIds, txMapAssetIds, txMapTxIds, txRemoveAssetId )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO )
 import Data.Bifoldable
@@ -528,10 +530,11 @@ canApplyTxToUTxO tx u =  (&&)
     (all inputRefIsValid (Tx.resolvedInputs tx))
     (all inputRefIsValid (Tx.resolvedCollateralInputs tx))
   where
-    inputRefIsValid :: (TxIn, Coin) -> Bool
-    inputRefIsValid (ti, c) = case UTxO.lookup ti u of
-        Nothing -> False
-        Just to -> TxOut.coin to == c
+    inputRefIsValid :: (TxIn, Maybe TxOut) -> Bool
+    inputRefIsValid (ti, c) =
+        case UTxO.lookup ti u of
+            Nothing -> False
+            Just c' -> TxOut.coin c' == maybe (Coin 0) TxOut.coin c
 
 safeAppendTx :: MonadFail m => UTxO -> Tx -> m UTxO
 safeAppendTx = flip safeApplyTxToUTxO

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq/Gen.hs
@@ -317,14 +317,10 @@ genTxFromUTxO genAddr u = do
         , Just TxScriptInvalid
         ]
     pure $ txWithoutIdToTx TxWithoutId
-        { fee =
-            Just feeCoin
-        , resolvedInputs =
-            fmap (TokenBundle.getCoin . tokens) <$> inputs
-        , resolvedCollateralInputs =
-            fmap (TokenBundle.getCoin . tokens) <$> collateralInputs
-        , outputs =
-            zipWith TxOut outputAddresses outputBundles
+        { fee = Just feeCoin
+        , resolvedInputs = fmap Just <$> inputs
+        , resolvedCollateralInputs = fmap Just <$> collateralInputs
+        , outputs = zipWith TxOut outputAddresses outputBundles
         , collateralOutput = listToMaybe $
             zipWith TxOut collateralOutputAddresses collateralOutputBundles
         , metadata = Nothing

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq/Gen.hs
@@ -327,8 +327,7 @@ genTxFromUTxO genAddr u = do
             zipWith TxOut outputAddresses outputBundles
         , collateralOutput = listToMaybe $
             zipWith TxOut collateralOutputAddresses collateralOutputBundles
-        , metadata =
-            Nothing
+        , metadata = Nothing
         , withdrawals
         , scriptValidity
         }

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Allegra.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Allegra.hs
@@ -65,7 +65,6 @@ import qualified Cardano.Ledger.Shelley.Tx as SL
 import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
 import qualified Cardano.Ledger.ShelleyMA.TxBody as MA
 import qualified Cardano.Wallet.Primitive.Types as W
-import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Data.Map.Strict as Map
@@ -91,7 +90,7 @@ fromAllegraTx tx =
         , fee =
             Just $ fromShelleyCoin fee
         , resolvedInputs =
-            map ((,W.Coin 0) . fromShelleyTxIn) (toList ins)
+            map ((,Nothing) . fromShelleyTxIn) (toList ins)
         , resolvedCollateralInputs =
             -- TODO: (ADP-957)
             []

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Alonzo.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Alonzo.hs
@@ -77,7 +77,6 @@ import qualified Cardano.Ledger.Core as SL.Core
 import qualified Cardano.Ledger.Mary.Value as SL
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Wallet.Primitive.Types as W
-import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
@@ -104,9 +103,9 @@ fromAlonzoTx tx@(Alonzo.ValidatedTx bod wits (Alonzo.IsValid isValid) aux) witCt
         , fee =
             Just $ fromShelleyCoin fee
         , resolvedInputs =
-            map ((,W.Coin 0) . fromShelleyTxIn) (toList ins)
+            map ((,Nothing) . fromShelleyTxIn) (toList ins)
         , resolvedCollateralInputs =
-            map ((,W.Coin 0) . fromShelleyTxIn) (toList collateral)
+            map ((,Nothing) . fromShelleyTxIn) (toList collateral)
         , outputs =
             map fromAlonzoTxOut (toList outs)
         , collateralOutput =

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Babbage.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Babbage.hs
@@ -80,7 +80,6 @@ import qualified Cardano.Ledger.Core as SL.Core
 import qualified Cardano.Ledger.Mary.Value as SL
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Wallet.Primitive.Types as W
-import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
@@ -107,9 +106,9 @@ fromBabbageTx tx@(Alonzo.ValidatedTx bod wits (Alonzo.IsValid isValid) aux) witC
         , fee =
             Just $ fromShelleyCoin fee
         , resolvedInputs =
-            map ((,W.Coin 0) . fromShelleyTxIn) (toList inps)
+            map ((,Nothing) . fromShelleyTxIn) (toList inps)
         , resolvedCollateralInputs =
-            map ((,W.Coin 0) . fromShelleyTxIn) (toList collateralInps)
+            map ((,Nothing) . fromShelleyTxIn) (toList collateralInps)
         , outputs =
             map (fromBabbageTxOut . sizedValue) (toList outs)
         , collateralOutput =

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Byron.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Byron.hs
@@ -35,7 +35,6 @@ import Control.Monad
 import qualified Cardano.Crypto.Hashing as CC
 import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
-import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
@@ -58,7 +57,7 @@ fromTxAux txAux = case taTx txAux of
 
         -- TODO: Review 'W.Tx' to not require resolved inputs but only inputs
         , resolvedInputs =
-            (, W.Coin 0) . fromTxIn <$> NE.toList inputs
+            (, Nothing) . fromTxIn <$> NE.toList inputs
 
         , resolvedCollateralInputs = []
 

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Mary.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Mary.hs
@@ -105,7 +105,7 @@ fromMaryTx tx witCtx =
         , fee =
             Just $ fromShelleyCoin fee
         , resolvedInputs =
-            map ((,W.Coin 0) . fromShelleyTxIn) (toList ins)
+            map ((,Nothing) . fromShelleyTxIn) (toList ins)
         , resolvedCollateralInputs =
             []
         , outputs =

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Shelley.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Shelley.hs
@@ -137,7 +137,7 @@ fromShelleyTx tx =
         , fee =
             Just $ fromShelleyCoin fee
         , resolvedInputs =
-            map ((,W.Coin 0) . fromShelleyTxIn) (toList ins)
+            (,Nothing) . fromShelleyTxIn <$> toList ins
         , resolvedCollateralInputs =
             []
         , outputs =

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -424,7 +424,7 @@ mkTx networkId payload ttl (rewardAcnt, pwdAcnt) addrResolver wdrl cs fees era =
             addrResolver inputResolver (unsigned, mkExtraWits unsigned)
 
     let withResolvedInputs (tx, _, _, _, _, _) = tx
-            { resolvedInputs = second TxOut.coin <$> F.toList (view #inputs cs)
+            { resolvedInputs = second Just <$> F.toList (view #inputs cs)
             }
     Right ( withResolvedInputs (fromCardanoTx AnyWitnessCountCtx signed)
           , sealedTxFromCardano' signed

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -136,7 +136,7 @@ import GHC.Generics
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Write.Tx as Write.Tx
+import qualified Cardano.Wallet.Write.Tx as WriteTx
 import qualified Data.Map.Strict as Map
 
 data TransactionLayer k ktype tx = TransactionLayer
@@ -184,7 +184,7 @@ data TransactionLayer k ktype tx = TransactionLayer
 
     , mkUnsignedTransaction
         :: forall era
-         . Write.Tx.IsRecentEra era
+         . WriteTx.IsRecentEra era
         => XPub
             -- Reward account public key
         -> ProtocolParameters

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
@@ -24,6 +25,7 @@ module Cardano.Wallet.Transaction
     -- * Interface
       TransactionLayer (..)
     , DelegationAction (..)
+    , TxValidityInterval
     , TransactionCtx (..)
     , PreSelection (..)
     , defaultTransactionCtx
@@ -368,6 +370,8 @@ data TxUpdate = TxUpdate
         -- ^ Set a new fee or use the old one.
     }
 
+type TxValidityInterval = (Maybe SlotNo, SlotNo)
+
 -- | Some additional context about a transaction. This typically contains
 -- details that are known upfront about the transaction and are used to
 -- construct it from inputs selected from the wallet's UTxO.
@@ -376,7 +380,7 @@ data TransactionCtx = TransactionCtx
     -- ^ Withdrawal amount from a reward account, can be zero.
     , txMetadata :: Maybe TxMetadata
     -- ^ User or application-defined metadata to embed in the transaction.
-    , txValidityInterval :: (Maybe SlotNo, SlotNo)
+    , txValidityInterval :: TxValidityInterval
     -- ^ Transaction optional starting slot and expiry (TTL) slot for which the
     -- transaction is valid.
     , txDelegationAction :: Maybe DelegationAction
@@ -402,7 +406,8 @@ data TransactionCtx = TransactionCtx
 
 -- | Represents a preliminary selection of tx outputs typically made by user.
 newtype PreSelection = PreSelection { outputs :: [TxOut] }
-    deriving (Generic, Eq, Show)
+    deriving stock (Generic, Show)
+    deriving newtype (Eq)
 
 data Withdrawal
     = WithdrawalSelf RewardAccount (NonEmpty DerivationIndex) Coin

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -134,6 +134,7 @@ import GHC.Generics
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Write.Tx as Write.Tx
 import qualified Data.Map.Strict as Map
 
 data TransactionLayer k ktype tx = TransactionLayer
@@ -180,9 +181,9 @@ data TransactionLayer k ktype tx = TransactionLayer
         -- function cannot fail.
 
     , mkUnsignedTransaction
-        :: AnyCardanoEra
-            -- Era for which the transaction should be created.
-        -> XPub
+        :: forall era
+         . Write.Tx.IsRecentEra era
+        => XPub
             -- Reward account public key
         -> ProtocolParameters
             -- Current protocol parameters
@@ -191,7 +192,7 @@ data TransactionLayer k ktype tx = TransactionLayer
         -> Either PreSelection (SelectionOf TxOut)
             -- A balanced coin selection where all change addresses have been
             -- assigned.
-        -> Either ErrMkTransaction tx
+        -> Either ErrMkTransaction (Cardano.TxBody era)
         -- ^ Construct a standard unsigned transaction
         --
         -- " Standard " here refers to the fact that we do not deal with redemption,

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -26,6 +26,7 @@ module Cardano.Wallet.Write.Tx
       RecentEra (..)
     , IsRecentEra (..)
     , toRecentEra
+    , fromRecentEra
     , LatestLedgerEra
     , LatestEra
 
@@ -40,6 +41,8 @@ module Cardano.Wallet.Write.Tx
     , AnyRecentEra (..)
     , InAnyRecentEra (..)
     , asAnyRecentEra
+    , fromAnyRecentEra
+    , withInAnyRecentEra
     , withRecentEra
 
     -- ** Misc
@@ -230,6 +233,11 @@ toRecentEra = \case
     Cardano.ShelleyEra -> Nothing
     Cardano.ByronEra   -> Nothing
 
+fromRecentEra :: RecentEra era -> Cardano.CardanoEra era
+fromRecentEra = \case
+  RecentEraBabbage -> Cardano.BabbageEra
+  RecentEraAlonzo -> Cardano.AlonzoEra
+
 instance IsRecentEra BabbageEra where
     recentEra = RecentEraBabbage
 
@@ -264,12 +272,11 @@ data InAnyRecentEra thing where
          -> thing era
          -> InAnyRecentEra thing
 
-withRecentEra
+withInAnyRecentEra
     :: InAnyRecentEra thing
     -> (forall era. IsRecentEra era => thing era -> a)
     -> a
-withRecentEra (InAnyRecentEra _era tx) f
-    = f tx
+withInAnyRecentEra (InAnyRecentEra _era tx) f = f tx
 
 -- | "Downcast" something existentially wrapped in 'Cardano.InAnyCardanoEra'.
 asAnyRecentEra
@@ -290,6 +297,13 @@ data AnyRecentEra where
 
 instance Show AnyRecentEra where
     show (AnyRecentEra era) = "AnyRecentEra " <> show era
+
+fromAnyRecentEra :: AnyRecentEra -> Cardano.AnyCardanoEra
+fromAnyRecentEra (AnyRecentEra era) = Cardano.AnyCardanoEra (fromRecentEra era)
+
+withRecentEra ::
+    AnyRecentEra -> (forall era. IsRecentEra era => RecentEra era -> a) -> a
+withRecentEra (AnyRecentEra era) f = f era
 
 --------------------------------------------------------------------------------
 -- TxIn

--- a/lib/wallet/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/wallet/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -137,8 +137,8 @@ dummyProtocolParameters = ProtocolParameters
 mkTx
     :: Maybe TxCBOR
     -> Maybe Coin
-    -> [(TxIn, Coin)]
-    -> [(TxIn, Coin)]
+    -> [(TxIn, Maybe TxOut)]
+    -> [(TxIn, Maybe TxOut)]
     -> [TxOut]
     -> Maybe TxOut
     -> Map RewardAccount Coin
@@ -161,7 +161,7 @@ mkTx cbor fees ins cins outs cout wdrls md validity =
 
 -- | txId calculation for testing purposes.
 mkTxId
-    :: [(TxIn, Coin)]
+    :: [(TxIn, Maybe TxOut)]
     -> [TxOut]
     -> Map RewardAccount Coin
     -> Maybe TxMetadata -> Hash "Tx"

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -18,6 +18,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE TupleSections #-}
 
 module Cardano.Wallet.DB.Arbitrary
     ( GenTxHistory (..)
@@ -438,8 +439,8 @@ instance Arbitrary Tx where
         ]
 
     arbitrary = do
-        ins <- fmap (L.nub . L.take 5 . getNonEmpty) arbitrary
-        cins <- fmap (L.nub . L.take 5 . getNonEmpty) arbitrary
+        ins <- fmap (,Nothing) . L.nub . L.take 5 . getNonEmpty <$> arbitrary
+        cins <- fmap (,Nothing) . L.nub . L.take 5 . getNonEmpty <$> arbitrary
         outs <- fmap (L.take 5 . getNonEmpty) arbitrary
         cout <- arbitrary
         wdrls <- fmap (Map.fromList . L.take 5) arbitrary

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -51,7 +51,6 @@ import Test.QuickCheck
 import Test.QuickCheck.Monadic
     ( forAllM )
 
-import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
     ( TxIn (TxIn) )
@@ -96,7 +95,7 @@ prop_DecorateLinksTxInToTxOuts = do
                     [ (txin, txout)
                     | Tx{txId,outputs} <- transactions
                     , (txOutPos, txout) <- zip [0 ..] outputs
-                    , let txin = (W.TxIn txId txOutPos, W.Coin 0)
+                    , let txin = (W.TxIn txId txOutPos, Just txout)
                     ]
             let guinea' = set #resolvedInputs txins guinea
             pure (guineaId, mkTxSet (guinea' : transactions), txouts)
@@ -123,7 +122,7 @@ prop_DecorateLinksTxCollateralsToTxOuts = do
                     [ (txin, txout)
                     | Tx{txId,outputs} <- transactions
                     , (txOutPos, txout) <- zip [0 ..] outputs
-                    , let txin = (W.TxIn txId txOutPos, W.Coin 0)
+                    , let txin = (W.TxIn txId txOutPos, Just txout)
                     ]
             let guinea' = set #resolvedCollateralInputs txins guinea
             pure (guineaId, mkTxSet (guinea' : transactions), txouts)

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -514,9 +514,9 @@ allInputsOfTxs :: Set Tx -> Set TxIn
 allInputsOfTxs = F.foldMap allInputsOfTx
   where
     allInputsOfTx :: Tx -> Set TxIn
-    allInputsOfTx tx = Set.fromList $ fst <$> mconcat
-        [ tx & resolvedInputs
-        , tx & resolvedCollateralInputs
+    allInputsOfTx tx = Set.fromList $ mconcat
+        [ fst <$> resolvedInputs tx
+        , fst <$> resolvedCollateralInputs tx
         ]
 
 prop_availableUTxO_isSubmap :: Property
@@ -1229,7 +1229,7 @@ instance Arbitrary (WithPending WalletState) where
                         { txId = arbitraryHash
                         , txCBOR = Nothing
                         , fee = Nothing
-                        , resolvedInputs = [(inp, TxOut.coin out)]
+                        , resolvedInputs = [(inp, Just out)]
                         -- TODO: (ADP-957)
                         , resolvedCollateralInputs = []
                         -- TODO: [ADP-1670]
@@ -1307,11 +1307,11 @@ blockchain =
                     [ (TxIn
                         { inputId = Hash "\199D\198\229\227\196\204\231\178\166m\226\134\211\DC1}\243[\204\DC4\171\213\230\246\SOHy\229\t\167\184\235g"
                         , inputIx = 0
-                        }, Coin 0)
+                        }, Nothing)
                     , (TxIn
                         { inputId = Hash "\a\241.\180(\a\148\201u$\229\251\147\224\f\166\159\EOT\166m\US\178dN\242\227\b\254\227G\169\RS"
                         , inputIx = 0
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -1348,7 +1348,7 @@ blockchain =
                     [ (TxIn
                         { inputId = Hash "+\253\232\DC3\132\"M\NULf\EM\228\bh)\STX\171W\215@#\198\a\228\229Z2]\156_fjg"
                         , inputIx = 0
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -1374,7 +1374,7 @@ blockchain =
                     [ (TxIn
                         { inputId = Hash "\137\150\&8\141\164l\v\ACK\132\198\SI\GS7\201\&3Dd\177fM,\GS)\EM\DC4\242#\211'3\233\163"
                         , inputIx = 0
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -1411,7 +1411,7 @@ blockchain =
                     [ (TxIn
                         { inputId = Hash "(\EM#\f\165\236\169=\227\163>MY\225ts\192\SYN\137=\145\155~\212.\252\130l\166v0\SOH"
                         , inputIx = 0
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -1437,7 +1437,7 @@ blockchain =
                     [ ( TxIn
                         { inputId = Hash "\128\168muc\212\EMP\238\\\173w\203\159N\205T:\230V\134\164w\143>\192\134\153\SUB$cD"
                         , inputIx = 0
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -1474,7 +1474,7 @@ blockchain =
                     [ (TxIn
                         { inputId = Hash "\164\254\137\218h\f\DLE\245\141u\SYN\248~\253n;\202\144\150\v\229\177\218\195\238\157\230\158\241O\153\215"
                         , inputIx = 0
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -1521,7 +1521,7 @@ blockchain =
                     [ (TxIn
                         { inputId = Hash "\187\199\161\240\222$\bZ\196\138R\238o\137\209\129QE\132Z\135\DC2TsP\167\228\146\&8Yt\171"
                         , inputIx = 0
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -1558,7 +1558,7 @@ blockchain =
                     [ (TxIn
                         { inputId = Hash "s\165\210\a@\213\DC1\224\DLE\144$\DEL\138\202\144\225\229PVBD\ETB25\161\164u\137\NUL{\158v"
                         , inputIx = 0
-                        }, Coin 0) ]
+                        }, Nothing) ]
                 , resolvedCollateralInputs = []
                 , outputs =
                     [ TxOut
@@ -1594,7 +1594,7 @@ blockchain =
                     [ (TxIn
                         { inputId = Hash "\177|\163\210\184\169\145\234F\128\209\235\217\148\n\ETXD\155\ESCba\251\230%\213\202\230Y\151&\234A"
                         , inputIx = 0
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -1641,11 +1641,11 @@ blockchain =
                     [ ( TxIn
                         { inputId = Hash "\195\242\DEL-\232v(c\SI+\172\163\245\142\189\214aiB#4\139\172\166\237\167\ETB9\246\150\185\219"
                         , inputIx = 1
-                        }, Coin 0)
+                        }, Nothing)
                     , ( TxIn
                         { inputId = Hash "8O\137\193\224w\243\252s\198\250\201\&04\169\129E\155{\n\DC3H<\199\208\154\214\237\141\128<+"
                         , inputIx = 1
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -1722,7 +1722,7 @@ blockchain =
                     [ ( TxIn
                         { inputId = Hash "\ETXX\189\235\195q81{D\DC3\DLE\228\237(\251\184`l\226\229\184\FSG\132\217\224\202\222\249\246J"
                         , inputIx = 1
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -1748,7 +1748,7 @@ blockchain =
                     [ ( TxIn
                         { inputId = Hash "\151\146\133\SYN\187\ENQ\252\226\&4\210n\153\178+.h\200\CANAs\SI\181\189\GS\131[g7O\GS\232\215"
                         , inputIx = 1
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -1785,7 +1785,7 @@ blockchain =
                     [ ( TxIn
                         { inputId = Hash "_>\240.\159\145\US\NUL1\158r\231\&8\214\241\134\&2\DC4\ETB\160\134\237z\143D\229d\DC4\245\208\DC3?"
                         , inputIx = 0
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -1811,7 +1811,7 @@ blockchain =
                     [ ( TxIn
                         { inputId = Hash "\187\177J\189\132K\n\175\130\148\&3[\150\193zL\153\191Qjcl\n\162B\241G)>\151\DC4\225"
                         , inputIx = 0
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -1908,7 +1908,7 @@ blockchain =
                     [ ( TxIn
                         { inputId = Hash "\150\225pI\SUB\251n\189W\159\213|v\198\132\242$6\248\204:\145#\151\221\177\201\197\ESC\134\251S"
                         , inputIx = 0
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -1934,7 +1934,7 @@ blockchain =
                     [ ( TxIn
                         { inputId = Hash "\249\DC2\146\&0\GSK\177\182\224@\206\205\255@0\149\155I\201^}\174\bw\130\221U\139\235\182f\138"
                         , inputIx = 0
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -1971,7 +1971,7 @@ blockchain =
                     [ (TxIn
                         { inputId = Hash "\194\157>\160\221\163\&4\218\149\215\178\161]p\185\246\208\198\ENQ \188\216\242\160\190\236\137\151\DC3\134\"\DC4"
                         , inputIx = 0
-                        }, Coin 0)
+                        }, Nothing)
                     ]
                 , resolvedCollateralInputs = []
                 , outputs =
@@ -2016,7 +2016,10 @@ blockchain =
                             { inputId = Hash "9c6fed8fef3b296d4dee6e62ca72b180bf0ed1c13eb5f0445099b2a146235e77"
                             , inputIx = 0
                             }
-                        , Coin 3823755953610
+                        , Just $ TxOut
+                            { address = Address "\130\216\CANXB\131X\FS\147\ACKn\246.n\DLE\233Y\166)\207c\v\248\183\235\212\EOTV\243h\192\190T\150'\196\161\SOHX\RSX\FS\202>U<\156c\197&\DC3S\235C\198\245\163\204=\214fa\201\t\205\248\204\226r%\NUL\SUB\174\187\&7\t"
+                            , tokens = coinToBundle 3823755953610
+                            }
                         )
                     ]
                 , resolvedCollateralInputs =
@@ -2024,7 +2027,7 @@ blockchain =
                             { inputId = Hash "9c6fed8fef3b296d4dee6e62ca72b180bf0ed1c13eb5f0445099b2a146235e77"
                             , inputIx = 1
                             }
-                        , Coin 19999800000
+                        , Nothing
                         )
                     ]
                 , outputs =
@@ -2068,7 +2071,10 @@ blockchain =
                             -- the collateral output:
                             , inputIx = 1
                             }
-                        , Coin (19999800000 - 1)
+                        , Just $ TxOut
+                            { address = Address "\130\216\CANXB\131X\FS\147\ACKn\246.n\DLE\233Y\166)\207c\v\248\183\235\212\EOTV\243h\192\190T\150'\196\161\SOHX\RSX\FS\202>U<\156c\197&\DC3S\235C\198\245\163\204=\214fa\201\t\205\248\204\226r%\NUL\SUB\174\187\&7\t"
+                            , tokens = coinToBundle (19999800000 - 1)
+                            }
                         )
                     ]
                 , resolvedCollateralInputs = []
@@ -2178,11 +2184,11 @@ prop_filterByAddress_balance_applyTxToUTxO f tx =
             then tokens output
             else mempty
 
-unit_applyTxToUTxO_spends_input :: Tx -> TxIn -> TxOut -> Coin -> Property
-unit_applyTxToUTxO_spends_input tx txin txout coin =
+unit_applyTxToUTxO_spends_input :: Tx -> TxIn -> TxOut -> Maybe TxOut -> Property
+unit_applyTxToUTxO_spends_input tx txin txout resolvedOut =
     let
         tx' = tx
-            { resolvedInputs = [(txin, coin)]
+            { resolvedInputs = [(txin, resolvedOut)]
             , scriptValidity = Nothing
             }
     in
@@ -2190,11 +2196,12 @@ unit_applyTxToUTxO_spends_input tx txin txout coin =
         === utxoFromTx tx' `excluding` Set.singleton txin
 
 unit_applyTxToUTxO_scriptValidity_Valid
-    :: Tx -> (TxIn, TxOut) -> (TxIn, TxOut) -> Coin -> Property
-unit_applyTxToUTxO_scriptValidity_Valid tx' (sIn, sOut) (cIn, cOut) coin =
+    :: Tx -> (TxIn, TxOut) -> (TxIn, TxOut) -> Property
+unit_applyTxToUTxO_scriptValidity_Valid tx'
+    (sIn, sOut) (cIn, cOut) =
     let tx = tx'
-            { resolvedCollateralInputs = [(cIn, coin)]
-            , resolvedInputs = [(sIn, coin)]
+            { resolvedCollateralInputs = [(cIn, Nothing)]
+            , resolvedInputs = [(sIn, Nothing)]
             , scriptValidity = Just TxScriptValid
             }
         utxo = UTxO $ Map.fromList [(sIn, sOut), (cIn, cOut)]
@@ -2204,11 +2211,11 @@ unit_applyTxToUTxO_scriptValidity_Valid tx' (sIn, sOut) (cIn, cOut) coin =
         (utxo `excluding` Set.singleton sIn) <> utxoFromTxOutputs tx
 
 unit_applyTxToUTxO_scriptValidity_Invalid
-    :: Tx -> (TxIn, TxOut) -> (TxIn, TxOut) -> Coin -> Property
-unit_applyTxToUTxO_scriptValidity_Invalid tx' (sIn, sOut) (cIn, cOut) coin =
+    :: Tx -> (TxIn, TxOut) -> (TxIn, TxOut) -> Property
+unit_applyTxToUTxO_scriptValidity_Invalid tx' (sIn, sOut) (cIn, cOut) =
     let tx = tx'
-            { resolvedCollateralInputs = [(cIn, coin)]
-            , resolvedInputs = [(sIn, coin)]
+            { resolvedCollateralInputs = [(cIn, Nothing)]
+            , resolvedInputs = [(sIn, Nothing)]
             , scriptValidity = Just TxScriptInvalid
             }
         utxo = UTxO $ Map.fromList [(sIn, sOut), (cIn, cOut)]
@@ -2218,11 +2225,11 @@ unit_applyTxToUTxO_scriptValidity_Invalid tx' (sIn, sOut) (cIn, cOut) coin =
         (utxo `excluding` Set.singleton cIn) <> utxoFromTxCollateralOutputs tx
 
 unit_applyTxToUTxO_scriptValidity_Unknown
-    :: Tx -> (TxIn, TxOut) -> (TxIn, TxOut) -> Coin -> Property
-unit_applyTxToUTxO_scriptValidity_Unknown tx' (sIn, sOut) (cIn, cOut) coin =
+    :: Tx -> (TxIn, TxOut) -> (TxIn, TxOut) -> Property
+unit_applyTxToUTxO_scriptValidity_Unknown tx' (sIn, sOut) (cIn, cOut) =
     let tx = tx'
-            { resolvedCollateralInputs = [(cIn, coin)]
-            , resolvedInputs = [(sIn, coin)]
+            { resolvedCollateralInputs = [(cIn, Nothing)]
+            , resolvedInputs = [(sIn, Nothing)]
             , scriptValidity = Nothing
             }
         utxo = UTxO $ Map.fromList [(sIn, sOut), (cIn, cOut)]

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -274,7 +274,6 @@ import qualified Cardano.Wallet.Primitive.Migration as Migration
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -1187,7 +1186,7 @@ setupFixture (wid, wname, wstate) = do
 dummyTransactionLayer :: TransactionLayer ShelleyKey 'CredFromKeyK SealedTx
 dummyTransactionLayer = TransactionLayer
     { mkTransaction = \_era _stakeCredentials keystore _pp _ctx cs -> do
-        let inps' = NE.toList $ second TxOut.coin <$> view #inputs cs
+        let inps' = NE.toList $ second Just <$> view #inputs cs
         -- TODO: (ADP-957)
         let cinps' = []
         let txId = mkTxId inps' (view #outputs cs) mempty Nothing


### PR DESCRIPTION
Made a modified version of the `buildAndSignTransaction` function that doesn't depend on the selected coins but instead relies on the `balanceTx` for the coin selection:
1. Creates an un-balanced tx.
2. Balances it (including coin selection).
3. Signs it.

### Issue Number

ADP-2442
