### PR TITLE
Increase memory limits for Cicero CI

### DIFF
--- a/nix/tullia.nix
+++ b/nix/tullia.nix
@@ -30,7 +30,7 @@ in rec {
         extra-system-features = kvm
       '';
 
-      memory = 1024 * 16;
+      memory = 1024 * 32;
       nomad.resources.cpu = 10000;
     };
   in


### PR DESCRIPTION
- 16 GB -> 32 GB
- Our builds have been failing with code 137 for a while, suggesting we're using more memory than allowed

### Comments

- Got the impression that changing the limits in this nix file won't have effect immediately, but want to check in case it does

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
