### PR TITLE
Add "ci/integration" action for integration tests

### DIFF
--- a/nix/tullia.nix
+++ b/nix/tullia.nix
@@ -3,7 +3,7 @@ let
   repository = "input-output-hk/cardano-wallet";
 in rec {
   tasks = let
-    mkTask = top: { config, lib, pkgs, ... }: {
+    mkTask = top: system: path: { config, lib, pkgs, ... }: {
       preset = {
         nix.enable = true;
 
@@ -19,7 +19,7 @@ in rec {
           echo '["x86_64-linux", "x86_64-darwin"]' | nix-systems -i \
           | jq 'with_entries(.key |= {"x86_64-linux": "linux", "x86_64-darwin": "macos"}[.])'
         '';
-        each.text = ''nix build -L .#${lib.escapeShellArg top}."$1".required'';
+        each.text = ''nix build -L .#${lib.escapeShellArg top}.${system}.${lib.escapeShellArg path}'';
         skippedDescription =  lib.escapeShellArg "No nix builder available for this platform";
       };
 
@@ -35,8 +35,10 @@ in rec {
     };
   in
     {
-      "ci/push" = mkTask "hydraJobs";
-      "ci/pr" = mkTask "hydraJobsPr";
+      "ci/push" = mkTask "hydraJobs" ''"$1"'' "required";
+      "ci/pr" = mkTask "hydraJobsPr" ''"$1"'' "required";
+      "ci/integration" =
+        mkTask "hydraJobsBors" "linux.musl" "checks.cardano-wallet.integration";
     };
 
   actions = {
@@ -51,6 +53,16 @@ in rec {
 
     "cardano-wallet/ci/pr" = {
       task = "ci/pr";
+      io = ''
+        #lib.io.github_pr
+        #input: "${ciInputName}"
+        #repo: "${repository}"
+        #target_default: false
+      '';
+    };
+
+    "cardano-wallet/ci/integration" = {
+      task = "ci/integration";
       io = ''
         #lib.io.github_pr
         #input: "${ciInputName}"


### PR DESCRIPTION
- [x] Create Cicero action `ci/integration` that takes information from this branch (`HeinrichApfelmus-cicero-test-integration`).
- [x] Edit `tullia.nix` to pick this up.

Issue Number

[ADP-2464](https://input-output.atlassian.net/browse/ADP-2464)