### PR TITLE
Add buildkite pipeline for unit tests

### DIFF
--- a/.buildkite/checks-compiled-commit.yml
+++ b/.buildkite/checks-compiled-commit.yml
@@ -1,0 +1,34 @@
+env:
+  LC_ALL: "en_US.UTF-8"
+  NIX_PATH: "channel:nixos-21.11"
+
+  # Per-container variables
+  SCRATCH_DIR: "/scratch/cardano-wallet"
+  BUILD_DIR: "/build/cardano-wallet"
+  CABAL_DIR: "/build/cardano-wallet.cabal"
+  XDG_STATE_HOME: "/build/cardano-wallet/.state"
+  XDG_CACHE_HOME: "/build/cardano-wallet/.cache"
+  TESTS_LOGDIR: "/build/cardano-wallet/integration-test-logs"
+
+  # Per-host variables - shared across containers on host
+  CACHE_DIR: "/cache/cardano-wallet"
+
+steps:
+  - label: 'Check auto-generated Nix'
+    key: nix
+    commands:
+      - './nix/regenerate.sh'
+    agents:
+      system: x86_64-linux
+
+  - label: 'Build tests'
+    depends_on: nix
+    command: 'nix build .#tests.cardano-wallet.unit'
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run unit tests'
+    depends_on: nix
+    command: 'nix build -L .#checks.cardano-wallet.unit'
+    agents:
+      system: x86_64-linux

--- a/.buildkite/checks.yml
+++ b/.buildkite/checks.yml
@@ -21,14 +21,16 @@ steps:
     agents:
       system: x86_64-linux
 
-  - label: 'Run unit tests'
+  - block: "Proceed with integration tests"
+    prompt: "Clicking this button will proceed with integration tests"
+    key: 'trigger_integration_tests'
     depends_on: nix
-    command: 'nix build .#checks.cardano-wallet.unit'
-    agents:
-      system: x86_64-linux
+    # allow_dependency_failure: true
+    # depends_on: [] # allows triggering this step even if previous steps failed
 
   - label: 'Run integration tests'
-    depends_on: nix
+    depends_on: trigger_integration_tests
     command: 'nix build .#checks.cardano-wallet.integration'
     agents:
       system: x86_64-linux
+

--- a/.buildkite/checks.yml
+++ b/.buildkite/checks.yml
@@ -26,3 +26,9 @@ steps:
     command: 'nix build .#checks.cardano-wallet.unit'
     agents:
       system: x86_64-linux
+
+  - label: 'Run integration tests'
+    depends_on: nix
+    command: 'nix build .#checks.cardano-wallet.integration'
+    agents:
+      system: x86_64-linux

--- a/.buildkite/checks.yml
+++ b/.buildkite/checks.yml
@@ -1,0 +1,28 @@
+env:
+  LC_ALL: "en_US.UTF-8"
+  NIX_PATH: "channel:nixos-21.11"
+
+  # Per-container variables
+  SCRATCH_DIR: "/scratch/cardano-wallet"
+  BUILD_DIR: "/build/cardano-wallet"
+  CABAL_DIR: "/build/cardano-wallet.cabal"
+  XDG_STATE_HOME: "/build/cardano-wallet/.state"
+  XDG_CACHE_HOME: "/build/cardano-wallet/.cache"
+  TESTS_LOGDIR: "/build/cardano-wallet/integration-test-logs"
+
+  # Per-host variables - shared across containers on host
+  CACHE_DIR: "/cache/cardano-wallet"
+
+steps:
+  - label: 'Check auto-generated Nix'
+    key: nix
+    commands:
+      - './nix/regenerate.sh'
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run unit tests'
+    depends_on: nix
+    command: 'nix build .#checks.cardano-wallet.unit'
+    agents:
+      system: x86_64-linux


### PR DESCRIPTION
- [x] Add a buildkite pipeline that executes the cardano-wallet unit tests

### Comments

As the nix cache appears to be working on builkite now, let's try to run our unit tests there.

### Issue Number

ADP-2464