### PR TITLE
[ADP-2500] Change nix expressions for build artifacts

### DIFF
--- a/.buildkite/checks-compiled-commit.yml
+++ b/.buildkite/checks-compiled-commit.yml
@@ -2,14 +2,6 @@ env:
   LC_ALL: "en_US.UTF-8"
   NIX_PATH: "channel:nixos-21.11"
 
-  # Per-container variables
-  SCRATCH_DIR: "/scratch/cardano-wallet"
-  BUILD_DIR: "/build/cardano-wallet"
-  CABAL_DIR: "/build/cardano-wallet.cabal"
-  XDG_STATE_HOME: "/build/cardano-wallet/.state"
-  XDG_CACHE_HOME: "/build/cardano-wallet/.cache"
-  TESTS_LOGDIR: "/build/cardano-wallet/integration-test-logs"
-
   # Per-host variables - shared across containers on host
   CACHE_DIR: "/cache/cardano-wallet"
 

--- a/.buildkite/checks-compiled-merge.yml
+++ b/.buildkite/checks-compiled-merge.yml
@@ -2,14 +2,6 @@ env:
   LC_ALL: "en_US.UTF-8"
   NIX_PATH: "channel:nixos-21.11"
 
-  # Per-container variables
-  SCRATCH_DIR: "/scratch/cardano-wallet"
-  BUILD_DIR: "/build/cardano-wallet"
-  CABAL_DIR: "/build/cardano-wallet.cabal"
-  XDG_STATE_HOME: "/build/cardano-wallet/.state"
-  XDG_CACHE_HOME: "/build/cardano-wallet/.cache"
-  TESTS_LOGDIR: "/build/cardano-wallet/integration-test-logs"
-
   # Per-host variables - shared across containers on host
   CACHE_DIR: "/cache/cardano-wallet"
   macos: "x86_64-darwin"

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -9,7 +9,6 @@ env:
   CABAL_DIR: "/build/cardano-wallet.cabal"
   XDG_STATE_HOME: "/build/cardano-wallet/.state"
   XDG_CACHE_HOME: "/build/cardano-wallet/.cache"
-  TESTS_LOGDIR: "/build/cardano-wallet/integration-test-logs"
 
   # Per-host variables - shared across containers on host
   CACHE_DIR: "/cache/cardano-wallet"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,14 +33,14 @@ steps:
 
   - label: 'Build cardano-wallet package for Linux'
     depends_on: nix
-    command: nix build -o result/linux .#hydraJobs.linux.musl.cardano-wallet-linux64
+    command: nix build -o result/linux .#ci.x86_64-linux.artifacts.linux64.release
     artifact_paths: [ "./result/linux/**" ]
     agents:
       system: x86_64-linux
 
   - label: 'Build cardano-wallet package for Windows'
     depends_on: nix
-    command: nix build -o result/windows .#hydraJobs.linux.windows.cardano-wallet-win64
+    command: nix build -o result/windows .#ci.x86_64-linux.artifacts.win64.release
     artifact_paths: [ "./result/windows/**" ]
     agents:
       system: x86_64-linux

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -57,7 +57,7 @@ steps:
     agents:
       system: x86_64-linux
 
-  - label: 'HLint'
+  - label: 'Check HLint'
     depends_on: nix
     command: 'nix develop --command bash -c "echo +++ HLint ; hlint lib"'
     agents:
@@ -69,7 +69,7 @@ steps:
     agents:
       system: x86_64-linux
 
-  - label: 'Docker Image'
+  - label: 'Build Docker Image'
     depends_on: nix
     command:
       - "mkdir -p config && echo '{  outputs = _: { dockerHubRepoName = \"inputoutput/cardano-wallet\"; }; }'  > config/flake.nix"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,15 +2,6 @@ env:
   LC_ALL: "en_US.UTF-8"
   NIX_PATH: "channel:nixos-21.11"
 
-  # Per-container variables
-  SCRATCH_DIR: "/scratch/cardano-wallet"
-  BUILD_DIR: "/build/cardano-wallet"
-  STACK_ROOT: "/build/cardano-wallet.stack"
-  CABAL_DIR: "/build/cardano-wallet.cabal"
-  XDG_STATE_HOME: "/build/cardano-wallet/.state"
-  XDG_CACHE_HOME: "/build/cardano-wallet/.cache"
-  TESTS_LOGDIR: "/build/cardano-wallet/integration-test-logs"
-
   # Per-host variables - shared across containers on host
   CACHE_DIR: "/cache/cardano-wallet"
 
@@ -45,19 +36,14 @@ steps:
     agents:
       system: x86_64-linux
 
-  # BuildKite's mac agent fails this job:
-  # ```
-  # warning: unknown setting 'experimental-features'
-  # warning: unknown setting 'signed-binary-caches'
-  # error: creating directory '/build': Read-only file system
-  # ``` 
-  #
-  # - label: 'Build cardano-wallet package for Macos (Intel)'
-  #   depends_on: nix
-  #   command: nix-build -A hydraJobs.macos.intel.cardano-wallet-macos-intel -o result/macos/intel
-  #   artifact_paths: [ "./result/macos/intel/**" ]
-  #   agents:
-  #     system: x86_64-darwin
+  - label: 'Build cardano-wallet package for Macos (Intel)'
+    depends_on: nix
+    command:
+      - 'nix --version'
+      - 'nix-build -A ci.x86_64-darwin.artifacts.macos-intel.release -o result/macos-intel'
+    artifact_paths: [ "./result/macos-intel/**" ]
+    agents:
+      system: x86_64-darwin
 
   - label: 'Check Cabal Configure (Haskell.nix shellFor)'
     depends_on: nix

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,9 +38,7 @@ steps:
 
   - label: 'Build cardano-wallet package for Macos (Intel)'
     depends_on: nix
-    command:
-      - 'nix --version'
-      - 'nix-build -A ci.x86_64-darwin.artifacts.macos-intel.release -o result/macos-intel'
+    command: nix build -o result/macos-intel .#ci.x86_64-darwin.artifacts.macos-intel.release
     artifact_paths: [ "./result/macos-intel/**" ]
     agents:
       system: x86_64-darwin

--- a/docs/developers/Building.md
+++ b/docs/developers/Building.md
@@ -103,6 +103,9 @@ Use the [[Nix]] build if:
 
 Follow the instructions on the [[Nix]] page to install _and configure_ Nix.
 
+> :warning: As of 2022-12, the following information is out of date
+> as https://hydra.iohk.io/ has been decomissioned.
+
 **Note**: It must be stressed that, if you see GHC being built by Nix,
 then you don't have the IOHK Hydra binary cache configured correctly.
 

--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,8 @@
   #    outputs.ci.x86_64-linux.tests.build
   #    outputs.ci.x86_64-linux.tests.run.unit
   #    outputs.ci.x86_64-linux.benchmarks.build
+  #    outputs.ci.x86_64-linux.artifacts.linux64.release
+  #    outputs.ci.x86_64-linux.artifacts.win64.release
   #
   #  before each pull request merge:
   #    for each supported system:

--- a/flake.nix
+++ b/flake.nix
@@ -68,10 +68,6 @@
   #    outputs.ci.x86_64-linux.tests.build
   #    outputs.ci.x86_64-linux.tests.run.unit
   #    outputs.ci.x86_64-linux.benchmarks.build
-  #    for appropriate builder system:
-  #      outputs.ci.${system}.artifacts.linux
-  #      outputs.ci.${system}.artifacts.macos
-  #      outputs.ci.${system}.artifacts.windows
   #
   #  before each pull request merge:
   #    for each supported system:
@@ -348,6 +344,52 @@
             };
           };
 
+          # One ${system} can cross-compile artifacts for other platforms.
+          mkReleaseArtifacts = project:
+            lib.optionalAttrs buildPlatform.isLinux {
+              linux64.release =
+                let
+                  # compiling with musl gives us a statically linked executable
+                  linuxPackages = mkPackages project.projectCross.musl64;
+                in
+                import ./nix/release-package.nix {
+                  inherit pkgs;
+                  exes = releaseContents linuxPackages;
+                  platform = "linux64";
+                  format = "tar.gz";
+                };
+              win64.release =
+                let
+                  # windows is cross-compiled from linux
+                  windowsPackages = mkPackages project.projectCross.mingwW64;
+                in
+                import ./nix/release-package.nix {
+                  inherit pkgs;
+                  exes = releaseContents windowsPackages;
+                  platform = "win64";
+                  format = "zip";
+                };
+            }
+            # macos is never cross-compiled
+            // lib.optionalAttrs buildPlatform.isMacOS {
+              macos-intel = lib.optionalAttrs buildPlatform.isx86_64 {
+                release = import ./nix/release-package.nix {
+                  inherit pkgs;
+                  exes = releaseContents (mkPackages project);
+                  platform = "macos-intel";
+                  format = "tar.gz";
+                };
+              };
+              macos-silicon = lib.optionalAttrs buildPlatform.isAarch64 {
+                release = import ./nix/release-package.nix {
+                  inherit pkgs;
+                  exes = releaseContents (mkPackages project);
+                  platform = "macos-silicon";
+                  format = "tar.gz";
+                };
+              };
+            };
+
           mkSystemHydraJobs = hydraProject: lib.optionalAttrs buildPlatform.isLinux
             rec {
               linux = {
@@ -511,6 +553,7 @@
                 lib.collect lib.isDerivation
                   (keepIntegrationChecks packages.checks);
             };
+          ci.artifacts = mkReleaseArtifacts project;
 
           systemHydraJobs = mkSystemHydraJobs hydraProject;
           systemHydraJobsPr = mkSystemHydraJobs hydraProjectPr;

--- a/nix/Dockerfile
+++ b/nix/Dockerfile
@@ -61,7 +61,7 @@ WORKDIR cardano-wallet
 # Build
 
 # Build the wallet and node static binaries package, untar to "out" directory
-RUN nix --experimental-features "nix-command flakes" build .#hydraJobs.linux.musl.cardano-wallet-linux64
+RUN nix --experimental-features "nix-command flakes" build .#ci.x86_64-linux.artifacts.linux64.release
 RUN tar -xzvf result/*.tar.gz
 RUN rm result
 RUN mv cardano-wallet-* ../out


### PR DESCRIPTION
### Overview

The main purpose of this pull request is to clean up our `flake.nix` file and add build artifacts to the `ci."<system>".*` hierarchy.

This pull request also fixes the `nix-build` on macOS — by removing environment variables from the Buildkite pipeline, they were interfering with the non-sandboxed nix-build.

### Comments

* The documentation on building with Nix needs to be changed, this is left for a future pull request.

### Issue Number

ADP-2500