### PR TITLE
Bump release v2022-12-14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,25 +12,16 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/release/v') }}
     runs-on: ubuntu-20.04
     steps:
-      - name: '❄ Wait for Hydra build'
-        uses: rvl/hydra-build-products-action@master
-        id: hydra
-        with:
-          hydra: 'https://hydra.iohk.io'
-          jobs: 'linux.musl.cardano-wallet-linux64 macos.intel.cardano-wallet-macos-intel linux.windows.cardano-wallet-win64'
-
-      - name: '🍒 Fetch release files'
-        run: |
-          wget ${{ steps.hydra.outputs.buildProducts }}
-
+      # Creates an empty release draft
+      # TODO: get artifacts from Buildkite to be attached to the draft
       - name: '🚀 Release'
         uses: softprops/action-gh-release@v1
         with:
           draft: true
-          fail_on_unmatched_files: true
-          files: |
-            *.tar.gz
-            *.zip
+          # fail_on_unmatched_files: true
+          # files: |
+          #   *.tar.gz
+          #   *.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,9 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/release/v') }}
     runs-on: ubuntu-20.04
     steps:
-      # Creates an empty release draft
+      # This should create an empty release draft
       # TODO: get artifacts from Buildkite to be attached to the draft
+      # Task: https://input-output.atlassian.net/browse/ADP-2502
       - name: '🚀 Release'
         uses: softprops/action-gh-release@v1
         with:

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ See **Installation Instructions** for each available [release](https://github.co
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
 > | `master` branch | [1.35.4](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.4) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
+> | [v2022-12-14](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-12-14) | [1.35.4](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.4) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-10-06](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-10-06) | [1.35.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 > | [v2022-08-16](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-08-16) | [1.35.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
-> | [v2022-07-01](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-07-01) | [1.35.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.0) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
 
 ## How to build from sources
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:1.35.3-configs
+    image: inputoutput/cardano-node:1.35.4
     environment:
       NETWORK:
       CARDANO_NODE_SOCKET_PATH: /ipc/node.socket
@@ -18,7 +18,7 @@ services:
         max-size: "50m"
 
   cardano-wallet:
-    image: inputoutput/cardano-wallet:2022.10.6
+    image: inputoutput/cardano-wallet:2022.12.14
     volumes:
       - wallet-${NETWORK}-db:/wallet-db
       - node-ipc:/ipc

--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               cardano-balance-tx
-version:            2022.10.6
+version:            2022.12.14
 synopsis:           Balancing transactions for the Cardano blockchain.
 description:        Please see README.md.
 homepage:           https://github.com/input-output-hk/cardano-wallet

--- a/lib/coin-selection/cardano-coin-selection.cabal
+++ b/lib/coin-selection/cardano-coin-selection.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               cardano-coin-selection
-version:            2022.10.6
+version:            2022.12.14
 synopsis:           Coin selection algorithms for the Cardano blockchain.
 description:        Please see README.md.
 homepage:           https://github.com/input-output-hk/cardano-wallet

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-launcher
-version:             2022.10.6
+version:             2022.12.14
 synopsis:            Utilities for a building commands launcher
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               cardano-wallet-primitive
-version:            2022.10.6
+version:            2022.12.14
 synopsis:           Selected primitive types for Cardano Wallet.
 description:        Please see README.md.
 homepage:           https://github.com/input-output-hk/cardano-wallet

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-test-utils
-version:             2022.10.6
+version:             2022.12.14
 synopsis:            Shared utilities for writing unit and property tests.
 description:         Shared utilities for writing unit and property tests.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -1,5 +1,5 @@
 name:                text-class
-version:             2022.10.6
+version:             2022.12.14
 synopsis:            Extra helpers to convert data-types to and from Text
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               cardano-wallet
-version:            2022.10.6
+version:            2022.12.14
 synopsis:           The Wallet Backend for a Cardano node.
 description:        Please see README.md
 homepage:           https://github.com/input-output-hk/cardano-wallet

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -21,9 +21,9 @@ SCRIPT=$(realpath "$0")
 ################################################################################
 # Release-specific parameters. Can be changed interactively by running the script.
 # Release tags must follow format vYYYY-MM-DD.
-GIT_TAG="v2022-10-06"
-OLD_GIT_TAG="v2022-08-16"
-CARDANO_NODE_TAG="1.35.3"
+GIT_TAG="v2022-12-14"
+OLD_GIT_TAG="v2022-10-06"
+CARDANO_NODE_TAG="1.35.4"
 
 ################################################################################
 # Tag munging functions
@@ -132,10 +132,10 @@ echo "Generating changelog into $CHANGELOG..."
 echo ""
 
 echo "Generating unresolved issues list into $KNOWN_ISSUES..."
-if ! jira release-notes-bugs > "$KNOWN_ISSUES"; then
-  echo "The \"jira release-notes-bugs\" command didn't work."
-  echo TBD > "$KNOWN_ISSUES"
-fi
+# if ! jira release-notes-bugs > "$KNOWN_ISSUES"; then
+#   echo "The \"jira release-notes-bugs\" command didn't work."
+#   echo TBD > "$KNOWN_ISSUES"
+# fi
 echo ""
 
 echo "Filling in template into ${release_notes}..."

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -132,10 +132,10 @@ echo "Generating changelog into $CHANGELOG..."
 echo ""
 
 echo "Generating unresolved issues list into $KNOWN_ISSUES..."
-# if ! jira release-notes-bugs > "$KNOWN_ISSUES"; then
-#   echo "The \"jira release-notes-bugs\" command didn't work."
-#   echo TBD > "$KNOWN_ISSUES"
-# fi
+if ! jira release-notes-bugs > "$KNOWN_ISSUES"; then
+  echo "The \"jira release-notes-bugs\" command didn't work."
+  echo TBD > "$KNOWN_ISSUES"
+fi
 echo ""
 
 echo "Filling in template into ${release_notes}..."

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Cardano Wallet Backend API
-  version: v2022-10-06
+  version: v2022-12-14
   license:
     name: Apache-2.0
     url: https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/LICENSE


### PR DESCRIPTION
- [x] Bump version from 2022.10.6 to 2022.12.14 (7eba8f6a183b67e205e830b80962545809eecbd0) 
- [x] remove hydra from release pipeline (8f32fee95cdc00696f2bd13a2cab819669237d1b) 

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
