### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
   <a href="https://buildkite.com/input-output-hk/cardano-wallet"><img src="https://img.shields.io/buildkite/7ea3dac7a16f066d8dfc8f426a9a9f7a2131e899cd96c444cf/master?label=BUILD&style=for-the-badge"/></a>
   <a href="https://buildkite.com/input-output-hk/cardano-wallet-nightly"><img src="https://img.shields.io/buildkite/59ea9363b8526e867005ca8839db47715bc5f661f36e490143/master?label=BENCHMARK&style=for-the-badge" /></a>
   <a href="https://github.com/input-output-hk/cardano-wallet/actions?query=workflow%3Awindows"><img src="https://img.shields.io/github/workflow/status/input-output-hk/cardano-wallet/windows?label=Windows&style=for-the-badge" /></a>
-  <a href="https://hydra.iohk.io/jobset/Cardano/cardano-wallet#tabs-jobs"><img src="https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fhydra.iohk.io%2Fjob%2FCardano%2Fcardano-wallet%2Frequired%2Fshield" /></a>
   <a href="https://github.com/input-output-hk/cardano-wallet/actions/workflows/publish.yml"><img src="https://img.shields.io/github/workflow/status/input-output-hk/cardano-wallet/Publish%20Docs?label=Docs&style=for-the-badge" /></a>
 
   <!--

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/input-output-hk/cardano-wallet/releases"><img src="https://img.shields.io/github/release-pre/input-output-hk/cardano-wallet.svg?style=for-the-badge" /></a>
+  <a href="https://github.com/input-output-hk/cardano-wallet/releases"><img src="https://img.shields.io/github/release-pre/input-output-hk/cardano-wallet.svg?style=for-the-badge"  /></a>
   <a href="https://buildkite.com/input-output-hk/cardano-wallet"><img src="https://img.shields.io/buildkite/7ea3dac7a16f066d8dfc8f426a9a9f7a2131e899cd96c444cf/master?label=BUILD&style=for-the-badge"/></a>
-  <a href="https://buildkite.com/input-output-hk/cardano-wallet-nightly"><img src="https://img.shields.io/buildkite/59ea9363b8526e867005ca8839db47715bc5f661f36e490143/master?label=BENCHMARK&style=for-the-badge" /></a>
-  <a href="https://github.com/input-output-hk/cardano-wallet/actions?query=workflow%3Awindows"><img src="https://img.shields.io/github/workflow/status/input-output-hk/cardano-wallet/windows?label=Windows&style=for-the-badge" /></a>
-  <a href="https://github.com/input-output-hk/cardano-wallet/actions/workflows/publish.yml"><img src="https://img.shields.io/github/workflow/status/input-output-hk/cardano-wallet/Publish%20Docs?label=Docs&style=for-the-badge" /></a>
+  <a href="https://buildkite.com/input-output-hk/cardano-wallet-nightly"><img src="https://img.shields.io/buildkite/59ea9363b8526e867005ca8839db47715bc5f661f36e490143/master?label=BENCHMARK&style=for-the-badge"  /></a>
+  <a href="https://github.com/input-output-hk/cardano-wallet/actions?query=workflow%3Awindows"><img src="https://img.shields.io/github/actions/workflow/status/input-output-hk/cardano-wallet/windows.yml?label=Windows&style=for-the-badge&branch=master"  /></a>
+  <a href="https://github.com/input-output-hk/cardano-wallet/actions/workflows/publish.yml"><img src="https://img.shields.io/github/actions/workflow/status/input-output-hk/cardano-wallet/publish.yml?label=Docs&style=for-the-badge&branch=master"  /></a>
 
   <!--
   <a href="https://coveralls.io/github/input-output-hk/cardano-wallet?branch=HEAD"><img src="https://img.shields.io/coveralls/github/input-output-hk/cardano-wallet/HEAD?style=for-the-badge" /></a>

--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ See **Installation Instructions** for each available [release](https://github.co
 
 > ### Latest releases
 >
-> | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
-> | --- | --- | ---
-> | `master` branch | [1.35.4](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.4) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
-> | [v2022-12-14](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-12-14) | [1.35.4](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.4) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
-> | [v2022-10-06](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-10-06) | [1.35.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
-> | [v2022-08-16](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-08-16) | [1.35.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3) | [1.6.1](https://github.com/input-output-hk/smash/releases/tag/1.6.1)
+> | cardano-wallet | cardano-node (compatible versions) |
+> | --- | --- |
+> | `master` branch | [1.35.4](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.4) |
+> | [v2022-12-14](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-12-14) | [1.35.4](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.4) |
+> | [v2022-10-06](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-10-06) | [1.35.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3) |
+> | [v2022-08-16](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2022-08-16) | [1.35.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.3) |
 
 ## How to build from sources
 


### PR DESCRIPTION
- [x] remove hydra badge (8cfe1c24784f99c9fbf3f9f1a190b288a6865087) 
- [x] remove SMASH from compatibility column (8e5ca92f91e9d4c72555d53d6993e74aba9fad7f) 
- [x] Update badges due to https://github.com/badges/shields/issues/8671 (510e9a73df391cb00afa0f1917600b1b66bc5bea) 

### Comments

[Smash](https://github.com/input-output-hk/smash) is archived with the note:

>:warning: This project is deprecated, and only supports up to cardano-node 1.30.1, for newer versions of cardano-node use the SMASH server in https://github.com/input-output-hk/cardano-db-sync. Do not use anymore, it is here for historical purpose.


### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
