### PR TITLE
Remove Advance linux-tests-pass and all-tests-pass branches

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -71,11 +71,3 @@ steps:
   #   agents:
   #     system: x86_64-linux
   #   if: 'build.env("step") == null || build.env("step") =~ /migration-tests/'
-
-  - wait
-
-  - label: "Advance linux-tests-pass and all-tests-pass branches"
-    command: "./.buildkite/push-branch.sh linux-tests-pass windows-tests-pass all-tests-pass"
-    agents:
-      system: x86_64-linux
-    if: 'build.env("step") == null'


### PR DESCRIPTION
- [x] remove Advance linux-tests-pass and all-tests-pass branches (a0794bef26c2a1f95492e4d154797867dd9607f4)

### Comments

It's failing and I don't think it has any practical use really.

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
