### PR TITLE
[ADP-2509] Nix expressions for benchmarks and other artifacts

### DIFF
--- a/.buildkite/bench-db.sh
+++ b/.buildkite/bench-db.sh
@@ -8,7 +8,7 @@ bench_name=bench-db
 rm -rf $bench_name
 
 echo "--- Build"
-nix build .#benchmarks.cardano-wallet.db -o $bench_name
+nix build .#ci.benchmarks.db -o $bench_name
 
 echo "+++ Run benchmark"
 

--- a/.buildkite/bench-latency.sh
+++ b/.buildkite/bench-latency.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 
 echo "--- Build"
-nix build .#benchmarks.cardano-wallet.latency -o bench-latency-shelley
+nix build .#ci.benchmarks.latency -o bench-latency-shelley
 
 # Note: the tracing will not work if program output is piped
 # to another process (e.g. "tee").

--- a/.buildkite/bench-restore.sh
+++ b/.buildkite/bench-restore.sh
@@ -24,7 +24,7 @@ fi
 
 echo "--- Build"
 
-nix build .#benchmarks.cardano-wallet.restore -o bench-restore
+nix build .#ci.benchmarks.restore -o bench-restore
 
 bench="./bench-restore/bin/restore $network --node-db $node_db"
 

--- a/.buildkite/checks-compiled-commit.yml
+++ b/.buildkite/checks-compiled-commit.yml
@@ -19,6 +19,12 @@ steps:
     agents:
       system: x86_64-linux
 
+  - label: 'Build all benchmarks'
+    depends_on: nix
+    command: 'nix build .#ci.benchmarks.all'
+    agents:
+      system: x86_64-linux
+
   - label: 'Run unit tests on linux'
     depends_on: nix
     command: 'nix build -L .#ci.x86_64-linux.tests.run.unit'

--- a/.buildkite/checks-compiled-commit.yml
+++ b/.buildkite/checks-compiled-commit.yml
@@ -15,7 +15,7 @@ steps:
 
   - label: 'Build all tests'
     depends_on: nix
-    command: 'nix build .#ci.x86_64-linux.tests.build'
+    command: 'nix build .#ci.tests.all'
     agents:
       system: x86_64-linux
 

--- a/.buildkite/checks-compiled-merge.yml
+++ b/.buildkite/checks-compiled-merge.yml
@@ -43,7 +43,7 @@ steps:
 
   # - label: 'Build all tests on macos'
   #   depends_on: macos-nix
-  #   command: 'nix build .#ci.${macos}.tests.build'
+  #   command: 'nix build .#ci.tests.all'
   #   agents:
   #     system: ${macos}
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
   - label: 'Build cardano-wallet package for Linux'
     depends_on: nix
     key: build-linux
-    command: nix build -o result/linux .#ci.x86_64-linux.artifacts.linux64.release
+    command: nix build -o result/linux .#ci.artifacts.linux64.release
     artifact_paths: [ "./result/linux/**" ]
     agents:
       system: x86_64-linux
@@ -33,15 +33,22 @@ steps:
   - label: 'Build cardano-wallet package for Windows'
     depends_on: nix
     key: build-windows
-    command: nix build -o result/windows .#ci.x86_64-linux.artifacts.win64.release
+    command: nix build -o result/windows .#ci.artifacts.win64.release
     artifact_paths: [ "./result/windows/**" ]
+    agents:
+      system: x86_64-linux
+
+  - label: 'Build Windows testing bundle'
+    depends_on: nix
+    command: nix build -o result/windows-tests .#ci.artifacts.win64.tests
+    artifact_paths: [ "./result/windows-tests/**" ]
     agents:
       system: x86_64-linux
 
   - label: 'Build cardano-wallet package for Macos (Intel)'
     depends_on: nix
     key: build-macos
-    command: nix build -o result/macos-intel .#ci.x86_64-darwin.artifacts.macos-intel.release
+    command: nix build -o result/macos-intel .#ci.artifacts.macos-intel.release
     artifact_paths: [ "./result/macos-intel/**" ]
     agents:
       system: x86_64-darwin

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           hydra: 'https://hydra.iohk.io'
           jobs: 'linux.windows.cardano-wallet-tests-win64'
+          # TODO ADP-2503.
+          #  For reference, the new path is
+          #  nix build -o result/windows-tests .#ci.artifacts.win64.tests
       - name: 'Fetch Windows testing bundle'
         shell: powershell
         run: |

--- a/flake.nix
+++ b/flake.nix
@@ -33,55 +33,83 @@
   ############################################################################
 
   ############################################################################
-  # Continuous Integration
+  # Continuous Integration (CI)
   #
   # This flake contains a few outputs useful for continous integration.
+  # These outputs come in two flavors:
   #
-  # To build a derivation, use e.g.
+  #   outputs.packages."<system>".ci.*  - build a test, benchmark, …
+  #   outputs.apps."<system>".ci.*      - run a test, benchmark, …
   #
-  #   nix build .#ci."<system>".tests.run.unit
+  # For building, say all tests, use `nix build`:
   #
-  # (In some cases, this fails with a segmentation fault;
+  #   nix build .#ci.tests.all
+  #
+  # For running, say the unit tests use `nix run`:
+  #
+  #   nix run .#ci.tests.unit
+  #
+  # (Running an item will typically also build it if it has not been built
+  #  in the nix store already.)
+  #
+  # (In some cases, building or running fails with a segmentation fault;
   #  the nix garbage collection is likely to blame.
   #  Use `GC_DONT_GC=1 nix build …` as workaround.)
   #
-  # The derivations are:
   #
-  #  - outputs.ci."<system>"
-  #     - tests             - test executables
-  #       - build           - build all tests on this platform
-  #       - run.unit        - run the unit tests on this platform
-  #                            (implies build)
-  #       - run.integration - run the integration tests on this platform
-  #                            (implies build)
-  #     - TODO benchmarks
-  #       - build           - build benchmarks on this platform
-  #       - run             - run benchmarks on this platform (implies build)
-  #     - TODO artifacts
-  #       - dockerImage     - tarball of the docker image
-  #       - TODO the hydraJobs do contain cross-compiled artifacts,
-  #         but we need to put them into this structure here.
+  # The CI-related outputs are
+  #
+  #  - outputs.packages."<system>".ci.
+  #     - tests             - build all test executables
+  #     - benchmarks
+  #       - all             - build all benchmarks
+  #       - restore         - build individual benchmark
+  #       - …
+  #     - artifacts         - artifacts by platform
+  #       - linux64.release
+  #       - win64
+  #         - release
+  #         - tests         - bundle of executables for testing on Windows
+  #       - macos-intel.release
+  #       - macos-silicon.release
+  #       - dockerImage
+  #  - outputs.apps."<system>".ci.
+  #     - tests
+  #       - unit            - run the unit tests on this system
+  #       - integration     - run the integration tests on this system
+  #     - benchmarks
+  #       - restore
+  #       - …
   #
   # Recommended granularity:
   #
   #  after each commit:
-  #    outputs.ci.x86_64-linux.tests.build
-  #    outputs.ci.x86_64-linux.tests.run.unit
-  #    outputs.ci.x86_64-linux.benchmarks.build
-  #    outputs.ci.x86_64-linux.artifacts.linux64.release
-  #    outputs.ci.x86_64-linux.artifacts.win64.release
+  #    on x86_64-linux:
+  #      nix build .#ci.tests.all
+  #      nix build .#ci.benchmarks.all
+  #      nix build .#ci.artifacts.linux64.release
+  #      nix build .#ci.artifacts.win64.release
+  #      nix build .#ci.artifacts.win64.tests
+  #
+  #      nix run   .#ci.tests.unit
   #
   #  before each pull request merge:
-  #    for each supported system:
-  #      outputs.ci.${system}.benchmarks.build
-  #      outputs.ci.${system}.tests.build
-  #      outputs.ci.${system}.tests.run.unit
-  #      outputs.ci.${system}.tests.run.integration
+  #    on each supported system:
+  #      nix build .#ci.benchmarks.all
+  #      nix build .#ci.tests.all
+  #
+  #      nix run   .#ci.tests.unit
+  #      nix run   .#ci.tests.integration
   #
   #  nightly:
-  #    outputs.ci.x86_64-linux.benchmarks.run
-  #    outputs.ci.x86_64-linux.artifacts.dockerImage
-  #    … cross-compiled executables?
+  #    on x86_64-linux:
+  #      nix build  .#ci.artifacts.dockerImage
+  #
+  #      nix run    .#ci.benchmarks.restore
+  #      nix run    .#ci.benchmarks.…
+  #
+  #    on x65_64-darwin: (macos)
+  #      nix build .#ci.artifacts.win64.release
   #
   ############################################################################
 

--- a/flake.nix
+++ b/flake.nix
@@ -459,50 +459,12 @@
                     internal.roots = {
                       project = project.roots;
                     };
-                    cardano-wallet-linux64 = import ./nix/release-package.nix {
-                      inherit pkgs;
-                      exes = releaseContents packages;
-                      platform = "linux64";
-                      format = "tar.gz";
-                    };
-                  };
-                windows =
-                  let
-                    project = hydraProject.projectCross.mingwW64;
-                    # Remove the test coverage report - only generate that for Linux musl.
-                    windowsPackages = removeAttrs (mkPackages project) [ "testCoverageReport" ];
-                  in
-                  windowsPackages // {
-                    cardano-wallet-win64 = import ./nix/release-package.nix {
-                      inherit pkgs;
-                      exes = releaseContents windowsPackages;
-                      platform = "win64";
-                      format = "zip";
-                    };
-                    # This is used for testing the build on windows.
-                    cardano-wallet-tests-win64 = import ./nix/windows-testing-bundle.nix {
-                      inherit pkgs;
-                      cardano-wallet = windowsPackages.cardano-wallet;
-                      cardano-node = windowsPackages.cardano-node;
-                      cardano-cli = windowsPackages.cardano-cli;
-                      tests = lib.collect lib.isDerivation windowsPackages.tests;
-                      benchmarks = lib.collect lib.isDerivation windowsPackages.benchmarks;
-                    };
-                    internal.roots = {
-                      project = project.roots;
-                    };
                   };
               };
             } // (lib.optionalAttrs buildPlatform.isMacOS {
               macos.intel = lib.optionalAttrs buildPlatform.isx86_64 (let
                 packages = mkPackages hydraProject;
               in packages // {
-                cardano-wallet-macos-intel = import ./nix/release-package.nix {
-                  inherit pkgs;
-                  exes = releaseContents packages;
-                  platform = "macos-intel";
-                  format = "tar.gz";
-                };
                 shells = mkDevShells hydraProject // {
                   default = hydraProject.shell;
                 };
@@ -516,12 +478,6 @@
               macos.silicon = lib.optionalAttrs buildPlatform.isAarch64 (let
                 packages = mkPackages hydraProject;
               in packages // {
-                cardano-wallet-macos-silicon = import ./nix/release-package.nix {
-                  inherit pkgs;
-                  exes = releaseContents packages;
-                  platform = "macos-silicon";
-                  format = "tar.gz";
-                };
                 shells = mkDevShells hydraProject // {
                   default = hydraProject.shell;
                 };

--- a/flake.nix
+++ b/flake.nix
@@ -559,6 +559,14 @@
             };
           }) // {
             # Continuous integration builds
+            ci.benchmarks = packages.benchmarks.cardano-wallet // {
+              all = pkgs.releaseTools.aggregate {
+                name = "cardano-wallet-benchmarks";
+                meta.description = "Build all benchmarks";
+                constituents =
+                  lib.collect lib.isDerivation packages.benchmarks;
+              };
+            };
             ci.artifacts = mkReleaseArtifacts project // {
               dockerImage = packages.dockerImage;
             };

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,8 @@
   # The CI-related outputs are
   #
   #  - outputs.packages."<system>".ci.
-  #     - tests             - build all test executables
+  #     - tests
+  #       - all             - build all test executables
   #     - benchmarks
   #       - all             - build all benchmarks
   #       - restore         - build individual benchmark
@@ -559,6 +560,12 @@
             };
           }) // {
             # Continuous integration builds
+            ci.tests.all = pkgs.releaseTools.aggregate {
+              name = "cardano-wallet-tests";
+              meta.description = "Build (all) tests";
+              constituents =
+                lib.collect lib.isDerivation packages.tests;
+            };
             ci.benchmarks = packages.benchmarks.cardano-wallet // {
               all = pkgs.releaseTools.aggregate {
                 name = "cardano-wallet-benchmarks";
@@ -582,14 +589,6 @@
 
           devShells = mkDevShells project;
 
-          # Continuous integration
-          ci.tests.build = pkgs.releaseTools.aggregate
-            {
-              name = "tests.build";
-              meta.description = "Build (all) tests";
-              constituents =
-                lib.collect lib.isDerivation packages.tests;
-            };
           ci.tests.run.unit = pkgs.releaseTools.aggregate
             {
               name = "tests.run.unit";

--- a/flake.nix
+++ b/flake.nix
@@ -539,7 +539,11 @@
           # https://www.reddit.com/r/NixOS/comments/x5cjmz/comment/in0qqm6/?utm_source=share&utm_medium=web2x&context=3
           checks = packages.checks;
 
-          apps = lib.mapAttrs (n: p: { type = "app"; program = p.exePath or "${p}/bin/${p.name or n}"; }) packages;
+          mkApp = name: pkg: {
+              type = "app";
+              program = pkg.exePath or "${pkg}/bin/${pkg.name or name}";
+            };
+          apps = lib.mapAttrs mkApp packages;
 
           devShell = project.shell;
 

--- a/nix/Dockerfile
+++ b/nix/Dockerfile
@@ -42,7 +42,7 @@ RUN test -n "${USE_IOHK_CACHE}" && ( echo "Note: using IOHK nix cache" > /dev/st
 
 # Make a docker layer with a warm cache (helps re-use compilers for
 # subsequent builds).
-RUN nix --experimental-features "nix-command flakes" build github:input-output-hk/cardano-wallet#hydraJobs.linux.musl.cardano-wallet --no-link
+RUN nix --experimental-features "nix-command flakes" build github:input-output-hk/cardano-wallet#ci.artifacts.linux64.release --no-link
 
 
 ############################################################################
@@ -61,7 +61,7 @@ WORKDIR cardano-wallet
 # Build
 
 # Build the wallet and node static binaries package, untar to "out" directory
-RUN nix --experimental-features "nix-command flakes" build .#ci.x86_64-linux.artifacts.linux64.release
+RUN nix --experimental-features "nix-command flakes" build .#ci.artifacts.linux64.release
 RUN tar -xzvf result/*.tar.gz
 RUN rm result
 RUN mv cardano-wallet-* ../out


### PR DESCRIPTION
### Overview

The goal of this task is to clean up our `flake.nix` file a little bit and create a reasonable hierarchy that can be used with any CI system, be it Cicero or Buildkite.

I have changed the `ci.*` hierarchy introduced previously — the idea is that we use the standard flake commands `nix build` and `nix run` for building artifacts and running checks respectively, e.g.

```
nix build .#ci.tests.all
nix run   .#ci.tests.unit
```

This pull request implements the following parts of the new hierarchy:

- [x] Build `ci.artifacts`
- [x] Build `ci.benchmarks.*`
- [x] Build `ci.tests.all`

However, running tests will be implemented in a subsequent PR.

- Run `ci.tests.unit`
- Run `ci.tests.integration`

### Issue Number

ADP-2509