### PR TITLE
[ADP-2515] restore macos integration tests

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -7,13 +7,25 @@ env:
   BUILD_DIR: "/build/cardano-wallet"
   STACK_ROOT: "/build/cardano-wallet.stack"
   CABAL_DIR: "/build/cardano-wallet.cabal"
-  XDG_STATE_HOME: "/build/cardano-wallet/.state"
-  XDG_CACHE_HOME: "/build/cardano-wallet/.cache"
 
   # Per-host variables - shared across containers on host
   CACHE_DIR: "/cache/cardano-wallet"
+  macos: "x86_64-darwin"
 
 steps:
+  - label: 'Check auto-generated Nix on macos'
+    key: macos-nix
+    commands:
+      - './nix/regenerate.sh'
+    agents:
+      system: ${macos}
+
+  - label: 'Run integration tests on macos'
+    depends_on: macos-nix
+    command: 'GC_DONT_GC=1 nix build -L .#ci.${macos}.tests.run.integration'
+    agents:
+      system: ${macos}
+      
   - label: 'Restore benchmark - cardano mainnet'
     command: "./.buildkite/bench-restore.sh mainnet"
     env:
@@ -71,3 +83,4 @@ steps:
   #   agents:
   #     system: x86_64-linux
   #   if: 'build.env("step") == null || build.env("step") =~ /migration-tests/'
+


### PR DESCRIPTION
- [x] add relevant steps to nightly buildkite pipeline
- [x] remove a limited number of env var naming `/build` which breaks macos steps


### Issue Number

ADP-2515
