### PR TITLE
Add `Cardano.Wallet.DB.Store.Transactions.Layer` to cabal file.

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -237,6 +237,7 @@ library
     Cardano.Wallet.DB.Store.Meta.Store
     Cardano.Wallet.DB.Store.Submissions.Model
     Cardano.Wallet.DB.Store.Submissions.Store
+    Cardano.Wallet.DB.Store.Transactions.Layer
     Cardano.Wallet.DB.Store.Transactions.Model
     Cardano.Wallet.DB.Store.Transactions.Store
     Cardano.Wallet.DB.Store.Wallets.Model


### PR DESCRIPTION
## Issue Number

ADP-2256

## Summary

This PR adds `Cardano.Wallet.DB.Store.Transactions.Layer` to the `cardano-wallet` cabal file.

For some reason, this module was not listed.