### PR TITLE
add windows release bundle to tests dependencies

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,7 +39,7 @@ steps:
       system: x86_64-linux
 
   - label: 'Build Windows testing bundle'
-    depends_on: nix
+    depends_on: [nix, build_windows]
     command: nix build -o result/windows-tests .#ci.artifacts.win64.tests
     artifact_paths: [ "./result/windows-tests/**" ]
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,7 +39,7 @@ steps:
       system: x86_64-linux
 
   - label: 'Build Windows testing bundle'
-    depends_on: [nix, build_windows]
+    depends_on: build_windows
     command: nix build -o result/windows-tests .#ci.artifacts.win64.tests
     artifact_paths: [ "./result/windows-tests/**" ]
     agents:


### PR DESCRIPTION
circumvent flaky nix failures on buiding win64.tests


- [x] add a CI pipeline dependency between windows build steps


