### PR TITLE
Try setting NIX_BUILD_CORES=1 in buildkite

### DIFF
--- a/.buildkite/post-commit.yml
+++ b/.buildkite/post-commit.yml
@@ -1,6 +1,7 @@
 env:
   LC_ALL: "en_US.UTF-8"
   NIX_PATH: "channel:nixos-21.11"
+  NIX_BUILD_CORES: 1
 
   # Per-host variables - shared across containers on host
   CACHE_DIR: "/cache/cardano-wallet"
@@ -130,7 +131,7 @@ steps:
       system: x86_64-linux
 
   - label: 'HLS works'
-    depends_on: nix 
+    depends_on: nix
     command: |
         ln -sf hie-direnv.yaml hie.yaml
         nix develop --command bash -c "haskell-language-server lib/wallet/src/Cardano/Wallet.hs"

--- a/.buildkite/pre-merge.yml
+++ b/.buildkite/pre-merge.yml
@@ -1,6 +1,7 @@
 env:
   LC_ALL: "en_US.UTF-8"
   NIX_PATH: "channel:nixos-21.11"
+  NIX_BUILD_CORES: 1
 
   # Per-host variables - shared across containers on host
   CACHE_DIR: "/cache/cardano-wallet"


### PR DESCRIPTION
### Overview

- [x] Set NIX_BUILD_CORES=1 in buildkite

### Comments

The following jobs were killed when  [`ci-equinix-1-ci1`](https://buildkite.com/organizations/input-output-hk/agents/018516b2-bdb8-4e71-b699-953bbb50e727/jobs) ran out of memory:
- https://buildkite.com/input-output-hk/cardano-wallet-post-commit/builds/327#018534f3-890b-4928-9ec6-5d37d487d893
- https://buildkite.com/input-output-hk/cardano-wallet-post-commit/builds/327#018534f3-890d-40da-8122-e743aa13df2e
- https://buildkite.com/input-output-hk/cardano-wallet-post-commit/builds/327#018534f3-8909-4a0e-90b5-06ff29e440ff
- https://buildkite.com/input-output-hk/cardano-wallet-pre-merge/builds/287#018534f3-f376-4bf9-828c-39b51e17a9b4
- https://buildkite.com/input-output-hk/cardano-wallet-pre-merge/builds/288#018534f4-ca5b-47ce-ba48-4bc6c451d34f

The three nix builds all were compiling `Cardano.Wallet.Api.Types` as they were killed. This module is one of our bigger ones.

NIX_BUILD_CORES=1 should lower the memory usage of nix builds.

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->

N/A