### PR TITLE
[ADP-2367] separate local submission tx store from tx history/meta store

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -234,6 +234,7 @@ library
     Cardano.Wallet.DB.Store.Meta.Model
     Cardano.Wallet.DB.Store.Meta.Store
     Cardano.Wallet.DB.Store.Submissions.Model
+    Cardano.Wallet.DB.Store.Submissions.New.Layer
     Cardano.Wallet.DB.Store.Submissions.New.Operations
     Cardano.Wallet.DB.Store.Submissions.Store
     Cardano.Wallet.DB.Store.Transactions.Layer

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -405,6 +405,7 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , WithOrigin (..)
     , dlgCertPoolId
+    , stabilityWindowShelley
     , toSlot
     , wholeRange
     )
@@ -1072,7 +1073,7 @@ restoreBlocks
 restoreBlocks ctx tr wid blocks nodeTip@BlockHeader{slotNo}
   = db & \DBLayer{..} ->
   mapExceptT atomically $ do
-    sp  <- liftIO $ currentSlottingParameters nl
+    slottingParams  <- liftIO $ currentSlottingParameters nl
     cp0 <- withNoSuchWallet wid (readCheckpoint wid)
     unless (cp0 `isParentOf` firstHeader blocks) $ fail $ T.unpack $ T.unwords
         [ "restoreBlocks: given chain isn't a valid continuation."
@@ -1098,8 +1099,11 @@ restoreBlocks ctx tr wid blocks nodeTip@BlockHeader{slotNo}
         pseudoSlotNo Origin = 0
         pseudoSlotNo (At sl) = sl
     let txs = foldMap (view #transactions) filteredBlocks
-    let epochStability = (3*) <$> getSecurityParameter sp
+    let epochStability = (3*) <$> getSecurityParameter slottingParams
     let localTip = currentTip $ NE.last cps
+
+    let finalitySlot = nodeTip ^. #slotNo
+            - stabilityWindowShelley slottingParams
 
     -- FIXME LATER during ADP-1403
     -- We need to rethink checkpoint creation and consider the case
@@ -1160,10 +1164,11 @@ restoreBlocks ctx tr wid blocks nodeTip@BlockHeader{slotNo}
         putDelegationCertificate wid cert slot
 
     liftIO $ mapM_ logCheckpoint cpsKeep
+
     ExceptT $ modifyDBMaybe walletsDB $
         adjustNoSuchWallet wid id $ \_ -> Right ( delta, () )
 
-    prune wid epochStability
+    prune wid epochStability finalitySlot
 
     liftIO $ do
         traceWith tr $ MsgDiscoveredTxs txs

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -352,11 +352,15 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , prune
         :: WalletId
         -> Quantity "block" Word32
+        -> SlotNo
         -> ExceptT ErrNoSuchWallet stm ()
         -- ^ Prune database entities and remove entities that can be discarded.
         --
         -- The second argument represents the stability window, or said
         -- length of the deepest rollback.
+        --
+        -- The third argument is the finality slot, or said
+        -- most recent stable slot
 
     , atomically
         :: forall a. stm a -> m a
@@ -407,6 +411,7 @@ data DBLayerCollection stm m s k = DBLayerCollection
     , prune_
         :: WalletId
         -> Quantity "block" Word32
+        -> SlotNo
         -> ExceptT ErrNoSuchWallet stm ()
     , atomically_
         :: forall a. stm a -> m a
@@ -689,6 +694,12 @@ data DBPendingTxs stm = DBPendingTxs
         -> SlotNo
         -> ExceptT ErrNoSuchWallet stm ()
         -- ^ Rollback submissions store
+
+    , pruneByFinality_
+        :: WalletId
+        -> SlotNo
+        -> ExceptT ErrNoSuchWallet stm ()
+        -- ^ Prune by finality change the submissions store
     }
 
 -- | A database layer for storing the private key.

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -683,6 +683,12 @@ data DBPendingTxs stm = DBPendingTxs
         -> Hash "Tx"
         -> ExceptT ErrRemoveTx stm ()
         -- ^ Manually remove a pending transaction.
+
+    , rollBackSubmissions_
+        :: WalletId
+        -> SlotNo
+        -> ExceptT ErrNoSuchWallet stm ()
+        -- ^ Rollback submissions store
     }
 
 -- | A database layer for storing the private key.

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -306,6 +306,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , updatePendingTxForExpiry
         :: WalletId
         -> SlotNo
+        -> [(SlotNo, Hash "Tx")]
         -> ExceptT ErrNoSuchWallet stm ()
         -- ^ Removes any expired transactions from the pending set and marks
         -- their status as expired.
@@ -672,6 +673,7 @@ data DBPendingTxs stm = DBPendingTxs
     , updatePendingTxForExpiry_
         :: WalletId
         -> SlotNo
+        -> [(SlotNo, Hash "Tx")]
         -> ExceptT ErrNoSuchWallet stm ()
         -- ^ Removes any expired transactions from the pending set and marks
         -- their status as expired.

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -74,7 +74,6 @@ import Cardano.Wallet.DB
     , DBFactory (..)
     , DBLayer
     , DBLayerCollection (..)
-    , DBPendingTxs (..)
     , DBPrivateKey (..)
     , DBTxHistory (..)
     , DBWalletMeta (..)
@@ -105,6 +104,8 @@ import Cardano.Wallet.DB.Store.Meta.Model
     , ManipulateTxMetaHistory (..)
     , TxMetaHistory (..)
     )
+import Cardano.Wallet.DB.Store.Submissions.New.Layer
+    ( mkDbPendingTxs )
 import Cardano.Wallet.DB.Store.Submissions.New.Operations
     ( mkStoreWalletsSubmissions )
 import Cardano.Wallet.DB.Store.Transactions.Model
@@ -711,21 +712,7 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
         {-----------------------------------------------------------------------
                                     Pending Txs
         -----------------------------------------------------------------------}
-    let
-      dbPendingTxs = DBPendingTxs
-        { putLocalTxSubmission_
-            = error "putLocalTxSubmissions_ not implemented"
-
-        , readLocalTxSubmissionPending_
-            = error "readLocalTxSubmissionPending_ not implemented"
-
-        , updatePendingTxForExpiry_ =
-            error "updatePendingTxForExpiry_ not implemented"
-
-        , removePendingOrExpiredTx_ =
-            error "removePendingOrExpiredTx_ not implemented"
-        }
-
+    let dbPendingTxs = mkDbPendingTxs submissionsDBVar
         {-----------------------------------------------------------------------
                                        Keystore
         -----------------------------------------------------------------------}

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -105,6 +105,8 @@ import Cardano.Wallet.DB.Store.Meta.Model
     , ManipulateTxMetaHistory (..)
     , TxMetaHistory (..)
     )
+import Cardano.Wallet.DB.Store.Submissions.New.Operations
+    ( mkStoreWalletsSubmissions )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( TxSet (..), decorateTxIns )
 import Cardano.Wallet.DB.Store.Wallets.Model
@@ -497,6 +499,7 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
     --   Handle the case where loading the database fails.
     walletsDB <- runQuery $ loadDBVar mkStoreWallets
     transactionsDBVar <- runQuery $ loadDBVar mkStoreTxWalletsHistory
+    submissionsDBVar <- runQuery $ loadDBVar mkStoreWalletsSubmissions
 
     -- NOTE
     -- The cache will not work properly unless 'atomically' is protected by a

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
@@ -560,7 +560,7 @@ mReadLocalTxSubmissionPending wid = readWalletModel wid $ \wal ->
         | status == Pending = Just (txid, slotNo)
         | otherwise = Nothing
 
-    getSubmission wal (tid, sl0) = make <$> Map.lookup tid (submittedTxs wal)
+    getSubmission wal (tid, _sl0) = make <$> Map.lookup tid (submittedTxs wal)
       where
         make (tx, sl1) = LocalTxSubmissionStatus tid tx sl1
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
@@ -562,7 +562,7 @@ mReadLocalTxSubmissionPending wid = readWalletModel wid $ \wal ->
 
     getSubmission wal (tid, sl0) = make <$> Map.lookup tid (submittedTxs wal)
       where
-        make (tx, sl1) = LocalTxSubmissionStatus tid tx sl0 sl1
+        make (tx, sl1) = LocalTxSubmissionStatus tid tx sl1
 
 {-------------------------------------------------------------------------------
                              Model function helpers

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -198,7 +198,7 @@ newDBLayer timeInterpreter = do
         , readLocalTxSubmissionPending =
             readDB db . mReadLocalTxSubmissionPending
 
-        , updatePendingTxForExpiry = \pk tip -> ExceptT $
+        , updatePendingTxForExpiry = \pk tip _xs -> ExceptT $
             alterDB errNoSuchWallet db $
             mUpdatePendingTxForExpiry pk tip
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
@@ -34,7 +34,13 @@ import Cardano.Pool.Types
 import Cardano.Slotting.Slot
     ( SlotNo )
 import Cardano.Wallet.DB.Sqlite.Types
-    ( BlockId, HDPassphrase, TxId, TxSubmissionStatusEnum (..), sqlSettings' )
+    ( BlockHeight
+    , BlockId
+    , HDPassphrase
+    , TxId
+    , TxSubmissionStatusEnum (..)
+    , sqlSettings'
+    )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( CredentialType )
 import Data.Quantity
@@ -492,12 +498,16 @@ CBOR
     deriving Show Generic Eq
 
 Submissions
-    submissionTxId TxId  sql=tx_id
-    submissionTx W.SealedTx sql=tx
-    submissionExpiration SlotNo sql=expiration
-    submissionAcceptance (Maybe SlotNo) sql=acceptance
-    submissionWallet W.WalletId sql=wallet_id
-    submissionStatus TxSubmissionStatusEnum sql=status
+    submissionTxId                  TxId                sql=tx_id
+    submissionTx                    W.SealedTx          sql=tx
+    submissionExpiration            SlotNo              sql=expiration
+    submissionAcceptance            (Maybe SlotNo)      sql=acceptance
+    submissionWallet                W.WalletId          sql=wallet_id
+    submissionStatus                TxSubmissionStatusEnum sql=status
+    submissionMetaDirection         W.Direction         sql=direction
+    submissionMetaSlot              SlotNo              sql=slot
+    submissionMetaBlockHeight       BlockHeight         sql=block_height
+    submissionMetaAmount            W.Coin              sql=amount
 
     Primary submissionTxId
     deriving Show Generic Eq

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
@@ -508,6 +508,7 @@ Submissions
     submissionMetaSlot              SlotNo              sql=slot
     submissionMetaBlockHeight       BlockHeight         sql=block_height
     submissionMetaAmount            W.Coin              sql=amount
+    submissionMetaResubmitted       SlotNo              sql=slot
 
     Primary submissionTxId
     deriving Show Generic Eq

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -94,7 +94,7 @@ import Data.Maybe
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
-    ( Percentage )
+    ( Percentage, Quantity (..) )
 import Data.Text
     ( Text )
 import Data.Text.Class.Extended
@@ -731,9 +731,20 @@ instance MonadFail EitherText where
 data TxSubmissionStatusEnum = InSubmissionE | InLedgerE | ExpiredE
     deriving (Eq, Show, Enum, Generic)
 
+
+
 instance PersistField TxSubmissionStatusEnum where
     toPersistValue = toPersistValue . fromEnum
     fromPersistValue = fmap toEnum . fromPersistValue
 
 instance PersistFieldSql TxSubmissionStatusEnum where
     sqlType _ = sqlType (Proxy @Int)
+
+type BlockHeight = Quantity "block" Word32
+
+instance PersistField BlockHeight where
+    toPersistValue = toPersistValue . getQuantity
+    fromPersistValue = fmap Quantity . fromPersistValue
+
+instance PersistFieldSql BlockHeight where
+    sqlType _ = sqlType (Proxy @Word32)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Model.hs
@@ -19,6 +19,7 @@ module Cardano.Wallet.DB.Store.Meta.Model
     , ManipulateTxMetaHistory(..)
     , TxMetaHistory(..)
     , mkTxMetaHistory
+    , WalletsMeta
     )
     where
 
@@ -149,4 +150,4 @@ mkTxMetaHistory wid txs = TxMetaHistory $
             | (tx, meta) <- txs
         ]
 
-
+type WalletsMeta = Map W.WalletId TxMetaHistory

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
@@ -107,8 +107,10 @@ mkDbPendingTxs dbvar = let
                     $ \_ -> (Just $ Adjust wid $ Forget (TxId txId), Right ())
     ,   rollBackSubmissions_ =
             \wid slot -> missingWallet wid
-                $ \_ -> (Just $ Adjust wid $ RollBack slot , Right ())
-
+                $ \_ -> (Just $ Adjust wid $ RollBack slot, Right ())
+    ,   pruneByFinality_ =
+            \wid slot -> missingWallet wid
+                $ \_ -> (Just $ Adjust wid $ Prune slot, Right ())
     }
 
 mkLocalTxSubmission

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
@@ -99,12 +99,16 @@ mkDbPendingTxs dbvar = let
                         Just $
                         Adjust wid $
                             RollForward tip (second TxId <$> xs)
-                in (delta, Right ()),
-        removePendingOrExpiredTx_ =
+                in (delta, Right ())
+    ,   removePendingOrExpiredTx_ =
             \wid txId ->
                 withExceptT ErrRemoveTxNoSuchWallet
                     $ missingWallet wid
                     $ \_ -> (Just $ Adjust wid $ Forget (TxId txId), Right ())
+    ,   rollBackSubmissions_ =
+            \wid slot -> missingWallet wid
+                $ \_ -> (Just $ Adjust wid $ RollBack slot , Right ())
+
     }
 
 mkLocalTxSubmission

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
@@ -1,0 +1,41 @@
+-- |
+-- Copyright: © 2022 IOHK
+-- License: Apache-2.0
+--
+-- An implementation of the DBPendingTxs which uses Persistent and SQLite.
+
+module Cardano.Wallet.DB.Store.Submissions.New.Layer
+    ( mkDbPendingTxs
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.DB
+    ( DBPendingTxs (..) )
+import Cardano.Wallet.DB.Store.Submissions.New.Operations
+    ( DeltaTxSubmissions )
+import Cardano.Wallet.Primitive.Types
+    ( WalletId )
+import Control.Monad.Except
+    ( ExceptT (ExceptT) )
+import Data.DBVar
+    ( DBVar )
+import Data.DeltaMap
+    ( DeltaMap )
+import Database.Persist.Sql
+    ( SqlPersistT )
+
+mkDbPendingTxs
+    :: DBVar (SqlPersistT IO) (DeltaMap WalletId DeltaTxSubmissions)
+    -> DBPendingTxs stm
+mkDbPendingTxs dbvar = DBPendingTxs
+    { putLocalTxSubmission_ = \wid txid tx sl ->
+        error "putLocalTxSubmissions not implemented"
+    , readLocalTxSubmissionPending_
+        = error "readLocalTxSubmissionPending_ not implemented"
+    , updatePendingTxForExpiry_ = \wid tip -> ExceptT $
+        error "updatePendingTxForExpiry_ not implemented"
+    , removePendingOrExpiredTx_ = \wid txId ->
+        error "removePendingOrExpiredTx_ not implemented"
+    }

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 -- |
 -- Copyright: © 2022 IOHK
 -- License: Apache-2.0
@@ -13,29 +14,60 @@ import Prelude
 
 import Cardano.Wallet.DB
     ( DBPendingTxs (..) )
+import Cardano.Wallet.DB.Sqlite.Types
+    ( TxId (..) )
 import Cardano.Wallet.DB.Store.Submissions.New.Operations
-    ( DeltaTxSubmissions )
+    ( DeltaTxSubmissions
+    , SubmissionMeta (SubmissionMeta, submissionMetaResubmitted)
+    , TxSubmissionsStatus
+    )
 import Cardano.Wallet.Primitive.Types
     ( WalletId )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( LocalTxSubmissionStatus (LocalTxSubmissionStatus), SealedTx )
+import Cardano.Wallet.Submissions.Submissions
+    ( TxStatusMeta (..), transactionsL )
+import Cardano.Wallet.Submissions.TxStatus
+    ( getTx )
+import Control.Lens
+    ( (^.) )
 import Control.Monad.Except
     ( ExceptT (ExceptT) )
 import Data.DBVar
-    ( DBVar )
+    ( DBVar, readDBVar )
 import Data.DeltaMap
     ( DeltaMap )
 import Database.Persist.Sql
     ( SqlPersistT )
 
+import qualified Data.Map.Strict as Map
+
 mkDbPendingTxs
     :: DBVar (SqlPersistT IO) (DeltaMap WalletId DeltaTxSubmissions)
-    -> DBPendingTxs stm
+    -> DBPendingTxs (SqlPersistT IO)
 mkDbPendingTxs dbvar = DBPendingTxs
-    { putLocalTxSubmission_ = \wid txid tx sl ->
+    { putLocalTxSubmission_ = \_wid _txid _tx _sl ->
         error "putLocalTxSubmissions not implemented"
-    , readLocalTxSubmissionPending_
-        = error "readLocalTxSubmissionPending_ not implemented"
-    , updatePendingTxForExpiry_ = \wid tip -> ExceptT $
+    , readLocalTxSubmissionPending_ = \wid -> do
+            v <- readDBVar dbvar
+            pure $ case Map.lookup wid v of
+                Nothing -> [] -- shouldn't we be throwing an exception here ?
+                Just sub -> do
+                    (_k, x) <- Map.assocs $ sub ^. transactionsL
+                    mkLocalTxSubmission x
+    , updatePendingTxForExpiry_ = \_wid _tip -> ExceptT $
         error "updatePendingTxForExpiry_ not implemented"
-    , removePendingOrExpiredTx_ = \wid txId ->
+    , removePendingOrExpiredTx_ = \_wid _txId ->
         error "removePendingOrExpiredTx_ not implemented"
     }
+
+mkLocalTxSubmission
+    ::  TxSubmissionsStatus
+    -> [LocalTxSubmissionStatus SealedTx]
+mkLocalTxSubmission (TxStatusMeta status SubmissionMeta{..})
+    = maybe
+        []
+        (\(TxId txId, sealed) -> pure $
+            LocalTxSubmissionStatus (txId) sealed submissionMetaResubmitted
+        )
+        $ getTx status

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
@@ -12,8 +12,12 @@ module Cardano.Wallet.DB.Store.Submissions.New.Layer
 
 import Prelude
 
+import Cardano.Wallet
+    ( ErrNoSuchWallet (..) )
 import Cardano.Wallet.DB
-    ( DBPendingTxs (..) )
+    ( DBPendingTxs (..)
+    , ErrPutLocalTxSubmission (ErrPutLocalTxSubmissionNoSuchWallet)
+    )
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.Submissions.New.Operations
@@ -25,6 +29,8 @@ import Cardano.Wallet.Primitive.Types
     ( WalletId )
 import Cardano.Wallet.Primitive.Types.Tx
     ( LocalTxSubmissionStatus (LocalTxSubmissionStatus), SealedTx )
+import Cardano.Wallet.Submissions.Operations
+    ( Operation (..) )
 import Cardano.Wallet.Submissions.Submissions
     ( TxStatusMeta (..), transactionsL )
 import Cardano.Wallet.Submissions.TxStatus
@@ -34,9 +40,9 @@ import Control.Lens
 import Control.Monad.Except
     ( ExceptT (ExceptT) )
 import Data.DBVar
-    ( DBVar, readDBVar )
+    ( DBVar, modifyDBMaybe, readDBVar )
 import Data.DeltaMap
-    ( DeltaMap )
+    ( DeltaMap (..) )
 import Database.Persist.Sql
     ( SqlPersistT )
 
@@ -46,8 +52,19 @@ mkDbPendingTxs
     :: DBVar (SqlPersistT IO) (DeltaMap WalletId DeltaTxSubmissions)
     -> DBPendingTxs (SqlPersistT IO)
 mkDbPendingTxs dbvar = DBPendingTxs
-    { putLocalTxSubmission_ = \_wid _txid _tx _sl ->
-        error "putLocalTxSubmissions not implemented"
+    { putLocalTxSubmission_ = \wid txid tx sl -> do
+        let errNoSuchWallet = ErrPutLocalTxSubmissionNoSuchWallet $
+                ErrNoSuchWallet wid
+        ExceptT $ modifyDBMaybe dbvar $ \ws -> do
+            case Map.lookup wid ws of
+                Nothing -> (Nothing, Left errNoSuchWallet)
+                Just _  ->
+                    let
+                        delta = Just
+                            $ Adjust wid
+                            $ AddSubmission sl (TxId txid, tx) $ error "pls pass meta to putLocalTxSubmission!"
+                    in  (delta, Right ())
+
     , readLocalTxSubmissionPending_ = \wid -> do
             v <- readDBVar dbvar
             pure $ case Map.lookup wid v of

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Operations.hs
@@ -22,6 +22,7 @@ module Cardano.Wallet.DB.Store.Submissions.New.Operations
     , mkStoreSubmissions
     , DeltaTxSubmissions
     , SubmissionMeta (..)
+    , WalletSubmissions
     ) where
 
 import Prelude
@@ -184,3 +185,5 @@ instance Delta DeltaTxSubmissions where
 
 mkStoreSubmissions :: WalletId -> Store (SqlPersistT IO) DeltaTxSubmissions
 mkStoreSubmissions = mkStoreAnySubmissions
+
+type WalletSubmissions = Map WalletId TxSubmissions

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Operations.hs
@@ -165,7 +165,7 @@ mkTransactions :: [Entity Submissions] -> Map TxId TxSubmissionsStatus
 mkTransactions xs = Map.fromList $ do
     Entity _
         (Submissions iden sealed expiration acceptance _ status
-            direction slot height amount)
+            direction slot height amount resubmitted)
             <- xs
     pure
         ( iden
@@ -176,6 +176,7 @@ mkTransactions xs = Map.fromList $ do
 
 mkStatusMeta
     :: SubmissionMeta
+
     -> TxId
     -> W.SealedTx
     -> SlotNo

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Operations.hs
@@ -23,6 +23,7 @@ module Cardano.Wallet.DB.Store.Submissions.New.Operations
     , syncSubmissions
     , mkStoreSubmissions
     , DeltaTxSubmissions
+    , TxSubmissionsStatus
     , SubmissionMeta (..)
     , mkStoreWalletsSubmissions
     ) where
@@ -89,6 +90,7 @@ data SubmissionMeta  = SubmissionMeta
     , submissionMetaSlot :: SlotNo
     , submissionMetaHeight :: Quantity "block" Word32
     , submissionMetaAmount :: W.Coin
+    , submissionMetaResubmitted :: SlotNo
     } deriving (Show, Eq)
 
 type TxSubmissions
@@ -125,6 +127,7 @@ syncSubmissions wid old new = do
                         submissionMetaSlot
                         submissionMetaHeight
                         submissionMetaAmount
+                        submissionMetaResubmitted
                     )
                 Nothing -> pure ()
     repsert
@@ -170,13 +173,12 @@ mkTransactions xs = Map.fromList $ do
     pure
         ( iden
         , mkStatusMeta
-            (SubmissionMeta direction slot height amount)
+            (SubmissionMeta direction slot height amount resubmitted)
                 iden sealed expiration acceptance status
         )
 
 mkStatusMeta
     :: SubmissionMeta
-
     -> TxId
     -> W.SealedTx
     -> SlotNo

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -38,6 +38,7 @@ module Cardano.Wallet.DB.Store.Transactions.Model
     , fromTxOut
     , fromTxCollateralOut
     , txCBORPrism
+    , WalletTransactions
     ) where
 
 import Prelude
@@ -99,6 +100,7 @@ import Fmt
 import GHC.Generics
     ( Generic )
 
+import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W.Tx
@@ -398,3 +400,5 @@ fromTxCBOR s@CBOR {..} = bimap (s ,) (cborTxId ,) $
 
 txCBORPrism :: Prism CBOR (CBOR, TxCBORRaw) (TxId, TxCBOR) (TxId, TxCBOR)
 txCBORPrism = prism toTxCBOR fromTxCBOR
+
+type WalletTransactions = Map W.WalletId TxSet

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -16,7 +16,6 @@ in a collection of wallets.
 -}
 module Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaTxWalletsHistory (..)
-    , DeltaWalletsMetaWithSubmissions (..)
     , TxWalletsHistory
     , mkTransactionInfo
     , walletsLinkedTransactions
@@ -29,9 +28,11 @@ import Cardano.Wallet.DB.Sqlite.Schema
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.Meta.Model
-    ( DeltaTxMetaHistory (..), TxMetaHistory (..), mkTxMetaHistory )
-import Cardano.Wallet.DB.Store.Submissions.Model
-    ( DeltaTxLocalSubmission (..), TxLocalSubmissionHistory (..) )
+    ( DeltaTxMetaHistory (..)
+    , TxMetaHistory (..)
+    , WalletsMeta
+    , mkTxMetaHistory
+    )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( DecoratedTxIns
     , TxRelation (..)
@@ -58,7 +59,7 @@ import Data.Function
 import Data.Functor
     ( (<&>) )
 import Data.Generics.Internal.VL
-    ( over, view, (^.) )
+    ( view, (^.) )
 import Data.Map.Strict
     ( Map )
 import Data.Quantity
@@ -83,7 +84,7 @@ import qualified Data.Set as Set
 
 data DeltaTxWalletsHistory
     = ExpandTxWalletsHistory W.WalletId [(WT.Tx, WT.TxMeta)]
-    | ChangeTxMetaWalletsHistory W.WalletId DeltaWalletsMetaWithSubmissions
+    | ChangeTxMetaWalletsHistory W.WalletId DeltaTxMetaHistory
     | GarbageCollectTxWalletsHistory
     | RemoveWallet W.WalletId
     deriving ( Show, Eq )
@@ -91,39 +92,18 @@ data DeltaTxWalletsHistory
 instance Buildable DeltaTxWalletsHistory where
     build = build . show
 
-data DeltaWalletsMetaWithSubmissions
-    = ChangeMeta DeltaTxMetaHistory
-    | ChangeSubmissions DeltaTxLocalSubmission
-    deriving ( Show, Eq )
-
-type MetasAndSubmissionsHistory = (TxMetaHistory, TxLocalSubmissionHistory)
-
-constraintSubmissions
-    :: MetasAndSubmissionsHistory -> MetasAndSubmissionsHistory
-constraintSubmissions (metas,submissions) =
-    ( metas
-    , over #relations (\m -> Map.restrictKeys m
-                       $ Map.keysSet (metas ^. #relations)) submissions)
-
-instance Delta DeltaWalletsMetaWithSubmissions where
-    type Base DeltaWalletsMetaWithSubmissions = MetasAndSubmissionsHistory
-    apply (ChangeMeta cm) (metas,submissions) =
-        constraintSubmissions (apply cm metas, submissions)
-    apply (ChangeSubmissions cs) (metas,submissions) =
-        constraintSubmissions (metas, apply cs submissions)
 
 type TxWalletsHistory =
-    (TxSet, Map W.WalletId MetasAndSubmissionsHistory)
+    (TxSet, WalletsMeta)
 
 instance Delta DeltaTxWalletsHistory where
     type Base DeltaTxWalletsHistory = TxWalletsHistory
     apply (ExpandTxWalletsHistory wid cs) (txh,mtxmh) =
         ( apply (TxStore.Append $ mkTxSet $ fst <$> cs) txh
         , flip apply mtxmh $ case Map.lookup wid mtxmh of
-              Nothing -> Insert wid (mkTxMetaHistory wid cs, mempty)
+              Nothing -> Insert wid (mkTxMetaHistory wid cs)
               Just _ ->
                   Adjust wid
-                  $ ChangeMeta
                   $ TxMetaStore.Expand
                   $ mkTxMetaHistory wid cs)
     apply (ChangeTxMetaWalletsHistory wid change) (txh, mtxmh) =
@@ -142,15 +122,15 @@ instance Delta DeltaTxWalletsHistory where
 -- necessary because database will not distinguish between
 -- a missing wallet in the map
 -- and a wallet that has no meta-transactions
-garbageCollectEmptyWallets :: Map k MetasAndSubmissionsHistory
-    -> Map k MetasAndSubmissionsHistory
-garbageCollectEmptyWallets = Map.filter (not . null . view #relations . fst)
+garbageCollectEmptyWallets :: Map k TxMetaHistory
+    -> Map k TxMetaHistory
+garbageCollectEmptyWallets = Map.filter (not . null . view #relations)
 
-linkedTransactions :: MetasAndSubmissionsHistory -> Set TxId
-linkedTransactions (TxMetaHistory m,_) = Map.keysSet m
+linkedTransactions :: TxMetaHistory -> Set TxId
+linkedTransactions (TxMetaHistory m) = Map.keysSet m
 
 walletsLinkedTransactions
-    :: Map W.WalletId MetasAndSubmissionsHistory -> Set TxId
+    :: Map W.WalletId TxMetaHistory -> Set TxId
 walletsLinkedTransactions = Set.unions . toList . fmap linkedTransactions
 
 -- | Compute a high level view of a transaction known as 'TransactionInfo'

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
@@ -765,15 +765,15 @@ instance NFData SlottingParameters
 
 -- | In Byron, this stability window is equal to 2k slots, where _k_ is the
 --  'getSecurityParameter'
-stabilityWindowByron :: SlottingParameters -> Quantity "block" Word64
-stabilityWindowByron sp = Quantity (2 * k)
+stabilityWindowByron :: SlottingParameters -> SlotNo
+stabilityWindowByron sp = SlotNo (2 * k)
   where
     k = fromIntegral $ getQuantity $ getSecurityParameter sp
 
 -- | In Shelley, this stability window is equal to _3k/f_ slots where _k_ is the
 -- 'getSecurityParameter' and _f_ is the 'ActiveSlotCoefficient'.
-stabilityWindowShelley :: SlottingParameters -> Quantity "block" Word64
-stabilityWindowShelley sp = Quantity len
+stabilityWindowShelley :: SlottingParameters -> SlotNo
+stabilityWindowShelley sp = SlotNo len
   where
     len = ceiling (3 * k / f)
     k = fromIntegral $ getQuantity $ getSecurityParameter sp
@@ -792,8 +792,8 @@ instance Buildable SlottingParameters where
 
 newtype ActiveSlotCoefficient
     = ActiveSlotCoefficient { unActiveSlotCoefficient :: Double }
-    deriving stock (Generic, Eq, Show)
-    deriving newtype (Buildable, Num, Fractional)
+        deriving stock (Generic, Eq, Show)
+        deriving newtype (Buildable, Num, Fractional, Real, Ord, RealFrac)
 
 instance NFData ActiveSlotCoefficient
 

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -181,8 +181,6 @@ data UnsignedTx input output change withdrawal = UnsignedTx
 data LocalTxSubmissionStatus tx = LocalTxSubmissionStatus
     { txId :: Hash "Tx"
     , submittedTx :: tx
-    , firstSubmission :: SlotNo
-    -- ^ Time of first successful submission to the local node.
     , latestSubmission :: SlotNo
     -- ^ Time of most recent resubmission attempt.
     } deriving stock (Generic, Show, Eq, Functor)

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Operations.hs
@@ -20,47 +20,47 @@ import Prelude
 
 import Cardano.Wallet.Submissions.Primitives
     ( Primitive (MoveFinality, MoveTip), applyPrimitive )
-import Data.Foldable
-    ( Foldable (..) )
-
-import qualified Cardano.Wallet.Submissions.Primitives as DP
 import Cardano.Wallet.Submissions.Submissions
     ( Submissions )
 import Cardano.Wallet.Submissions.TxStatus
     ( HasTxId (..) )
+import Data.Foldable
+    ( Foldable (..) )
+
+import qualified Cardano.Wallet.Submissions.Primitives as DP
 
 -- High Level, invariant respectful operations over the 'Submissions' store.
-data Operation slot tx where
+data Operation meta slot tx where
     -- | Insert tx new transaction in the local submission store.
-    AddSubmission :: slot -> tx -> Operation slot tx
+    AddSubmission :: slot -> tx -> meta -> Operation meta slot tx
     -- | Move transactions in the in-ledger state, removing them from
     -- in-submission.
     RollForward
       :: slot -- ^ New tip.
       -> [(slot, tx)] -- ^ Transactions that were found in the ledder.
-      -> Operation slot tx
+      -> Operation meta slot tx
     -- | Move transactions from the in-ledger state to in-submission state,
     -- when their acceptance slot falls after the new tip.
     RollBack
       :: slot -- ^ new tip
-      -> Operation slot tx
+      -> Operation meta slot tx
     -- | Remove transactions that cannot be rolled back in the ledger
     -- and transaction that cannot make it to the ledger due to expiration
     -- and max rollback time.
-    Prune :: slot -> Operation slot tx
+    Prune :: slot -> Operation meta slot tx
     -- | Remove a transaction from the tracked set.
-    Forget :: tx -> Operation slot tx
+    Forget :: tx -> Operation meta slot tx
     deriving (Show)
 
 
 -- | Apply a high level operation to the submission store.
 applyOperations
     :: (Ord slot, Ord (TxId tx), HasTxId tx)
-    => Operation slot tx
-    -> Submissions slot tx
-    -> Submissions slot tx
-applyOperations (AddSubmission expiring tx)
-    = applyPrimitive (DP.AddSubmission expiring tx)
+    => Operation meta slot tx
+    -> Submissions meta slot tx
+    -> Submissions meta slot tx
+applyOperations (AddSubmission expiring tx meta)
+    = applyPrimitive (DP.AddSubmission expiring tx meta)
 applyOperations (RollForward newtip txs) = \x ->
     applyPrimitive (MoveTip newtip)
         . foldl'

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Operations.hs
@@ -52,7 +52,7 @@ data Operation meta slot tx where
     -- and max rollback time.
     Prune :: slot -> Operation meta slot tx
     -- | Remove a transaction from the tracked set.
-    Forget :: tx -> Operation meta slot tx
+    Forget :: TxId tx -> Operation meta slot tx
 
 deriving instance
     ( Show (TxId tx)

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Operations.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTSyntax #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {- |
 Copyright: © 2022 IOHK
@@ -37,7 +40,7 @@ data Operation meta slot tx where
     -- in-submission.
     RollForward
       :: slot -- ^ New tip.
-      -> [(slot, tx)] -- ^ Transactions that were found in the ledder.
+      -> [(slot, TxId tx)] -- ^ Transactions that were found in the ledder.
       -> Operation meta slot tx
     -- | Move transactions from the in-ledger state to in-submission state,
     -- when their acceptance slot falls after the new tip.
@@ -50,7 +53,13 @@ data Operation meta slot tx where
     Prune :: slot -> Operation meta slot tx
     -- | Remove a transaction from the tracked set.
     Forget :: tx -> Operation meta slot tx
-    deriving (Show)
+
+deriving instance
+    ( Show (TxId tx)
+    , Show meta
+    , Show tx
+    , Show slot)
+    => Show (Operation meta slot tx)
 
 
 -- | Apply a high level operation to the submission store.

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Primitives.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Primitives.hs
@@ -65,7 +65,7 @@ data Primitive meta slot tx where
         Primitive meta slot tx
     -- | Remove a transaction from tracking in the submissions store.
     Forget ::
-        {_transaction :: tx} ->
+        {_transactionId :: TxId tx} ->
         Primitive meta slot tx
 
 deriving instance
@@ -137,4 +137,4 @@ applyPrimitive (MoveFinality newFinality) s =
             | expiring <= fin = Nothing
             | otherwise = Just status
         f status = Just status
-applyPrimitive (Forget tx) s = s & transactionsL %~ Map.delete (txId tx)
+applyPrimitive (Forget tx) s = s & transactionsL %~ Map.delete tx

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Primitives.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Primitives.hs
@@ -24,61 +24,64 @@ import Prelude
 
 import Cardano.Wallet.Submissions.Submissions
     ( Submissions
+    , TxStatusMeta (..)
     , finality
     , finalityL
     , tip
     , tipL
     , transactions
     , transactionsL
+    , txStatus
     )
 import Cardano.Wallet.Submissions.TxStatus
     ( HasTxId (..), TxStatus (Expired, InLedger, InSubmission) )
 import Control.Lens
-    ( (%~), (&), (.~) )
+    ( ix, (%~), (&), (.~) )
 import Data.Foldable
     ( Foldable (..) )
 
 import qualified Data.Map.Strict as Map
 
 -- | Primitive operations to change a 'Submissions' store.
-data Primitive slot tx where
+data Primitive meta slot tx where
     -- | Insert tx new transaction in the local submission store.
     AddSubmission ::
-        {_expiring :: slot, _transaction :: tx} ->
-        Primitive slot tx
+        {_expiring :: slot, _transaction :: tx, _meta :: meta} ->
+        Primitive meta slot tx
     -- | Change a transaction state to 'InLedger'.
     MoveToLedger ::
         {_acceptance :: slot, _transaction :: tx} ->
-        Primitive slot tx
+        Primitive meta slot tx
     -- | Move the submission store tip slot.
     MoveTip ::
         {_tip :: slot} ->
-        Primitive slot tx
+        Primitive meta slot tx
     -- | Move the submission store finality slot.
     MoveFinality ::
         {_finality :: slot} ->
-        Primitive slot tx
+        Primitive meta slot tx
     -- | Remove a transaction from tracking in the submissions store.
     Forget ::
         {_transaction :: tx} ->
-        Primitive slot tx
+        Primitive meta slot tx
     deriving (Show)
 
 -- | Apply a 'Primitive' to a submission, according to the specification.
 applyPrimitive
-    :: forall slot tx
+    :: forall meta slot tx
     .  (Ord slot, Ord (TxId tx), HasTxId tx)
-    => Primitive slot tx
-    -> Submissions slot tx
-    -> Submissions slot tx
-applyPrimitive (AddSubmission expiring tx) s
+    => Primitive meta slot tx
+    -> Submissions meta slot tx
+    -> Submissions meta slot tx
+applyPrimitive (AddSubmission expiring tx meta ) s
     | expiring > tip s
       && Map.notMember (txId tx) (transactions s)
-        = s & transactionsL %~ Map.insert (txId tx) (InSubmission expiring tx)
+        = s & transactionsL %~ Map.insert (txId tx)
+                (TxStatusMeta (InSubmission expiring tx) meta)
     | otherwise
         = s
 applyPrimitive (MoveToLedger acceptance tx) s =
-    s & transactionsL %~ Map.adjust f (txId tx)
+    s & transactionsL . ix (txId tx) . txStatus %~ f
   where
     f x@(InSubmission expiring tx')
         | acceptance > (tip s) && acceptance <= expiring =
@@ -88,7 +91,7 @@ applyPrimitive (MoveToLedger acceptance tx) s =
 applyPrimitive (MoveTip newTip) s =
     s & (finalityL .~ if newTip <= finality s then newTip else finality s)
         . (tipL .~ newTip)
-        . (transactionsL %~ fmap f)
+        . (transactionsL . traverse . txStatus %~ f)
   where
     f :: TxStatus slot tx -> TxStatus slot tx
     f status@(InLedger expiring acceptance tx)
@@ -109,8 +112,10 @@ applyPrimitive (MoveFinality newFinality) s =
         | newFinality >= tip s = tip s
         | newFinality <= finality s = finality s
         | otherwise = newFinality
-    g fin m = foldl' (flip $ Map.update f) m (Map.keys m)
+    g fin m = foldl' (flip $ Map.update f') m (Map.keys m)
       where
+        f' (TxStatusMeta status meta)
+            = (`TxStatusMeta` meta) <$> f status
         f :: TxStatus slot tx -> Maybe (TxStatus slot tx)
         f status@(InLedger _expiring acceptance _tx)
             | acceptance <= fin = Nothing

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Common.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Common.hs
@@ -43,13 +43,19 @@ verify :: Testable t => Prop t a -> Property
 verify = conjoin . execWriter
 
 -- | Encode a change of the store, for inspection
-data Step delta slot tx = Step
-    { _oldState :: Submissions slot tx
-    , _newState :: Submissions slot tx
-    , _deltaState :: delta slot tx
+data Step delta meta slot tx = Step
+    { _oldState :: Submissions meta slot tx
+    , _newState :: Submissions meta slot tx
+    , _deltaState :: delta meta slot tx
     }
 
-deriving instance (Show slot, HasTxId tx, Show tx,  Show (delta slot tx))
-    => Show (Step delta slot tx)
+deriving instance
+    ( Show slot
+    , HasTxId tx
+    , Show tx
+    , Show (delta meta slot tx)
+    , Show meta
+    )
+    => Show (Step delta meta slot tx)
 
 makeLenses ''Step

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Operations.hs
@@ -21,7 +21,7 @@ import Data.Function
 import Test.QuickCheck
     ( Property, counterexample, property, (.&.) )
 
-status' :: Ord (TxId tx) => TxId tx -> Submissions slot tx -> TxStatus slot tx
+status' :: Ord (TxId tx) => TxId tx -> Submissions meta slot tx -> TxStatus slot tx
 status' x = status x . transactions
 
 -- | As described in the specification:
@@ -31,7 +31,7 @@ status' x = status x . transactions
 -- will partition the transaction statuses.
 properties
     :: (Ord (TxId tx), Ord slot, Show (TxId tx))
-    => Step Operation slot tx -> Property
+    => Step Operation () slot tx -> Property
 properties (Step _ xs' _)
     = counterexample "submissions invariants" $ verify $ do
         that "finality precedes tip"

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Primitives.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Primitives.hs
@@ -29,15 +29,15 @@ import Test.QuickCheck
 
 import qualified Data.Map.Strict as Map
 
-txIds :: Submissions slot tx -> Set (TxId tx)
+txIds :: Submissions meta slot tx -> Set (TxId tx)
 txIds = Map.keysSet . transactions
 
 -- | Translations of primitive properties from specifications.
 properties
     :: (Ord (TxId tx), Eq tx, HasTxId tx
         , Ord slot, Show slot, Show tx)
-    => Step Primitive slot tx -> Property
-properties (Step xs xs' (AddSubmission expiring x)) = do
+    => Step Primitive meta slot tx -> Property
+properties (Step xs xs' (AddSubmission expiring x _)) = do
     let world = txIds xs <> txIds xs' <> singleton (txId x)
     counterexample "on add-submission" $ verify $ do
         that "tip and finality are not changed"

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Primitives.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Primitives.hs
@@ -127,7 +127,7 @@ properties (Step xs xs' (MoveFinality newFinality)) = do
                         & counterexample "expired should have been pruned"
                 _ -> new === old
 properties (Step xs xs' (Forget x)) = do
-    let world = txIds xs <> txIds xs' <> singleton (txId x)
+    let world = txIds xs <> txIds xs' <> singleton x
     counterexample "on move-tip" $ verify $ do
         that "tip shouldn't have changed" $ tip xs === tip xs'
         that "finality shouldn't have changed" $ finality xs === finality xs'
@@ -135,7 +135,7 @@ properties (Step xs xs' (Forget x)) = do
             let old = status y $ transactions xs
                 new = status y $ transactions xs'
             in case old of
-                _ | txId x == y
+                _ | x == y
                     ->
                         new === Unknown
                         & counterexample "transaction should have been removed"

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Submissions.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Submissions.hs
@@ -56,7 +56,7 @@ data Submissions meta slot tx = Submissions
     }
 
 deriving instance
-    (Show slot, HasTxId tx, Show tx, Show meta) =>
+    (HasTxId tx, Show slot, Show tx, Show meta) =>
     (Show (Submissions meta slot tx))
 
 deriving instance

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -567,6 +567,7 @@ fileModeSpec =  do
                         unsafeRunExceptT $ putCheckpoint testWid cpB
                         unsafeRunExceptT $ putTxHistory testWid txs
                         unsafeRunExceptT $ prune testWid (Quantity 2_160)
+                            $ 2_160 * 3 * 20
 
             it "Should spend collateral inputs and create spendable collateral \
                 \outputs if validation fails" $

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -547,6 +547,8 @@ runIO db@DBLayer{..} = fmap Resp . go
             atomically (readLocalTxSubmissionPending wid)
         UpdatePendingTxForExpiry wid sl -> catchNoSuchWallet Unit $
             mapExceptT atomically $ updatePendingTxForExpiry wid sl
+                $ error
+                "State machine is not compatible with new submissions design"
         RemovePendingOrExpiredTx wid tid ->
             (catchCannotRemovePendingTx wid) Unit $
             mapExceptT atomically $

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/New/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/New/StoreSpec.hs
@@ -61,7 +61,7 @@ prop_SingleWalletStoreLawsOperations = withInitializedWalletProp
             runQ
             (mkStoreSubmissions wid)
             (pure $ Submissions mempty 0 0)
-            (logScale . genOperationsDelta)
+            (logScale . genOperationsDelta (pure ()))
 
 {-------------------------------------------------------------------------------
     Arbitrary instances

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/New/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/New/StoreSpec.hs
@@ -18,17 +18,23 @@ import Cardano.Wallet.DB.Fixtures
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.Submissions.New.Operations
-    ( DeltaTxSubmissions, mkStoreSubmissions )
+    ( DeltaTxSubmissions, SubmissionMeta (..), mkStoreSubmissions )
 import Cardano.Wallet.Primitive.Types
     ( SlotNo (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (Coin) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..), mockSealedTx )
+import Cardano.Wallet.Primitive.Types.Tx.TxMeta
+    ( Direction (Outgoing) )
 import Cardano.Wallet.Submissions.OperationsSpec
     ( genOperationsDelta )
 import Cardano.Wallet.Submissions.Submissions
     ( Submissions (..) )
 import Control.Monad
     ( replicateM, void )
+import Data.Quantity
+    ( Quantity (..) )
 import Fmt
     ( Buildable (..) )
 import System.Random
@@ -54,6 +60,9 @@ instance Buildable DeltaTxSubmissions where
 
 deriving instance Random SlotNo
 
+dummyMetadata :: SubmissionMeta
+dummyMetadata = SubmissionMeta Outgoing 0 (Quantity 0) (Coin 0)
+
 prop_SingleWalletStoreLawsOperations :: WalletProperty
 prop_SingleWalletStoreLawsOperations = withInitializedWalletProp
     $ \wid runQ -> do
@@ -61,7 +70,7 @@ prop_SingleWalletStoreLawsOperations = withInitializedWalletProp
             runQ
             (mkStoreSubmissions wid)
             (pure $ Submissions mempty 0 0)
-            (logScale . genOperationsDelta (pure ()))
+            (logScale . genOperationsDelta (pure dummyMetadata))
 
 {-------------------------------------------------------------------------------
     Arbitrary instances

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/New/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/New/StoreSpec.hs
@@ -61,7 +61,7 @@ instance Buildable DeltaTxSubmissions where
 deriving instance Random SlotNo
 
 dummyMetadata :: SubmissionMeta
-dummyMetadata = SubmissionMeta Outgoing 0 (Quantity 0) (Coin 0)
+dummyMetadata = SubmissionMeta Outgoing 0 (Quantity 0) (Coin 0) 0
 
 prop_SingleWalletStoreLawsOperations :: WalletProperty
 prop_SingleWalletStoreLawsOperations = withInitializedWalletProp

--- a/lib/wallet/test/unit/Cardano/Wallet/Submissions/OperationsSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Submissions/OperationsSpec.hs
@@ -48,7 +48,7 @@ genOperationsDelta metaG s =
                 txs <- scale (`div` 4) $ listOf $ genTx 1 6 1 1 s
                 slots <- scale (`div` 4) $ listOf $ genSlot 1 1 4 s
                 acceptance <- genSlot 1 1 4 s
-                pure $ RollForward acceptance $ zip slots txs
+                pure $ RollForward acceptance $ zip slots $ txId <$> txs
         )
         , (2, do
                 newtip <- genSlot 1 3 3 s

--- a/lib/wallet/test/unit/Cardano/Wallet/Submissions/OperationsSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Submissions/OperationsSpec.hs
@@ -60,7 +60,7 @@ genOperationsDelta metaG s =
         )
         , (1, do
                 tx <- genTx 1 2 2 2 s
-                pure $ Forget tx
+                pure $ Forget $ txId tx
         )]
 
 genOperationsSubmissionsHistory :: GenSubmissionsHistory Operation

--- a/lib/wallet/test/unit/Cardano/Wallet/Submissions/OperationsSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Submissions/OperationsSpec.hs
@@ -15,6 +15,8 @@ import Cardano.Wallet.Submissions.Properties.Operations
     ( properties )
 import Cardano.Wallet.Submissions.Submissions
     ( Submissions )
+import Cardano.Wallet.Submissions.TxStatus
+    ( HasTxId (..) )
 import System.Random
     ( Random )
 import Test.Hspec
@@ -31,15 +33,16 @@ spec = do
                 genOperationsSubmissionsHistory
 
 genOperationsDelta
-    :: (Arbitrary tx, Random slot, Num slot)
-    => Submissions slot tx
-    -> Gen (Operation slot tx )
-genOperationsDelta s =
+    :: (Arbitrary tx, Random slot, Num slot, HasTxId tx)
+    => Gen meta
+    -> Submissions meta slot tx
+    -> Gen (Operation meta slot tx )
+genOperationsDelta metaG s =
     frequency
         [ (2, do
                 tx <- genTx 4 1 1 1 s
                 expiration <- genSlot 1 1 4 s
-                pure $ AddSubmission expiration tx
+                AddSubmission expiration tx <$> metaG
         )
         , (4, do
                 txs <- scale (`div` 4) $ listOf $ genTx 1 6 1 1 s
@@ -63,6 +66,6 @@ genOperationsDelta s =
 genOperationsSubmissionsHistory :: GenSubmissionsHistory Operation
 genOperationsSubmissionsHistory = GenSubmissionsHistory
     { stepProperties = properties
-    , genDelta = genOperationsDelta
+    , genDelta = genOperationsDelta (pure ())
     , applyDelta = applyOperations
     }

--- a/lib/wallet/test/unit/Cardano/Wallet/Submissions/PrimitivesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Submissions/PrimitivesSpec.hs
@@ -16,6 +16,8 @@ import Cardano.Wallet.Submissions.Properties.Primitives
     ( properties )
 import Cardano.Wallet.Submissions.Submissions
     ( Submissions )
+import Cardano.Wallet.Submissions.TxStatus
+    ( HasTxId (..) )
 import System.Random
     ( Random )
 import Test.Hspec
@@ -31,15 +33,16 @@ spec = do
                 $ prop_submissionHistory genPrimitiveSubmissionsHistory
 
 genPrimitiveDelta
-    :: (Arbitrary tx, Random slot, Num slot)
-    => Submissions slot tx
-    -> Gen (Primitive slot tx)
-genPrimitiveDelta s =
+    :: (Arbitrary tx, Random slot, Num slot, HasTxId tx)
+    => Gen meta
+    -> Submissions meta slot tx
+    -> Gen (Primitive meta slot tx)
+genPrimitiveDelta genMeta s =
     frequency
         [ (2 , do
             tx <- genTx 4 1 1 1 s
             expiration <- genSlot 1 1 4 s
-            pure $ AddSubmission expiration tx
+            AddSubmission expiration tx <$> genMeta
           )
         , (4, do
             tx <- genTx 1 6 1 1 s
@@ -63,6 +66,6 @@ genPrimitiveDelta s =
 genPrimitiveSubmissionsHistory :: GenSubmissionsHistory Primitive
 genPrimitiveSubmissionsHistory = GenSubmissionsHistory
     { stepProperties = properties
-    , genDelta = genPrimitiveDelta
+    , genDelta = genPrimitiveDelta (pure ())
     , applyDelta = applyPrimitive
     }

--- a/lib/wallet/test/unit/Cardano/Wallet/Submissions/PrimitivesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Submissions/PrimitivesSpec.hs
@@ -59,7 +59,7 @@ genPrimitiveDelta genMeta s =
           )
         , (1, do
             tx <- genTx 1 2 2 2 s
-            pure $ Forget tx
+            pure $ Forget $ txId tx
           )
         ]
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Submissions/PrimitivesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Submissions/PrimitivesSpec.hs
@@ -47,7 +47,7 @@ genPrimitiveDelta genMeta s =
         , (4, do
             tx <- genTx 1 6 1 1 s
             acceptance <- genSlot 1 1 4 s
-            pure $ MoveToLedger acceptance tx
+            pure $ MoveToLedger acceptance $ txId tx
           )
         , (2, do
             newtip <- genSlot 1 3 3 s

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -722,7 +722,7 @@ mkLocalTxSubmissionStatus = mapMaybe getStatus . getTxHistory
       where
         i = tx ^. #txId
         sl = txMeta ^. #slotNo
-        st = LocalTxSubmissionStatus i (fakeSealedTx (tx, [])) sl sl
+        st = LocalTxSubmissionStatus i (fakeSealedTx (tx, [])) sl
 
 instance Arbitrary SlottingParameters where
     arbitrary = mk <$> choose (0.5, 1)
@@ -778,7 +778,7 @@ prop_localTxSubmission tc = monadicIO $ do
         atomically $ do
             let txHistory = getTxHistory (retryTestTxHistory tc)
             unsafeRunExceptT $ putTxHistory wid txHistory
-            forM_ (retryTestPool tc) $ \(LocalTxSubmissionStatus i tx _ sl) ->
+            forM_ (retryTestPool tc) $ \(LocalTxSubmissionStatus i tx sl) ->
                 unsafeRunExceptT $ putLocalTxSubmission wid i tx sl
 
         -- Run test

--- a/specifications/Cardano/Wallet/Submissions/migration.md
+++ b/specifications/Cardano/Wallet/Submissions/migration.md
@@ -1,0 +1,51 @@
+
+# Overarching plan
+
+Use `Submissions` table for storing transactions that are pending 
+
+No longer use the `TxMeta` + `TxHistory`  tables for storing these transactions.
+
+## Rewrite `readLocalTxSubmissionPending_` 
+
+Use the `Submissions` `Store` or `DBVar`.
+
+## Re-imagine `putLocalTxSubmission`
+
+In `submitTx`, remove the call to `putTxHistory`, as the transactions in the
+submission database are no longer part of the `TxHistory` or the `TxMeta` table.
+
+## Re-imagine `pruneLocalTxSubmission`
+
+Use the block height of `tip` minus `epochStability`.  (Don't worry about the
+distinction between block height and `Slot`.)
+
+## Re-imagine `removePendingOrExpiredTx_` as `forget`
+
+## Re-imagine `updatePendingTxForExpiry_` as `rollForward`
+
+- In `restoreBlocks`, the `Tx` need to be taken out of `blocks`.  
+- In `restoreBlocks`, assume that a pattern match of `blocks` on a `List` 
+  constructor always succeeds, as we are not using light-mode.
+
+## Integrate `Submissions` into `rollbackTo_`
+
+Change the rollback to perform two separate rollbacks:
+
+- Rollback on the `TxMeta` table and `TxHistory` simply forgets about any
+transaction that was rolled back, i.e. no longer moves it to `Pending`.  
+- Rollback on the `Submissions` table.  
+
+## Implement migration from TxMeta table to separate Submissions table
+
+We don't convert to new encoding, we just pretend that all pending 
+  transactions have expired.
+
+
+- Remove all transactions whose txMetaStatus is not `InLedger` from TxMeta 
+  and TxHistory
+- Drop the `LocalTxSubmission` table.
+
+## Testing: End-2-End test by Piotr
+
+- migrations leaves only in ledger transactions in the history 
+  - should this break API tests about get transactions list ?


### PR DESCRIPTION
- added a migration plan overarching document
- reduce the TxHistory store to hold only transactions and metadata 
- separate Submissions wallet-indexed store 
- expand the `Submissions` store and schema to hold metadata (specifically the last resubmission slot) 
- extract the layer implementation of the submissions to its own module
- implement layer operations in terms of the new store 


### Comments

### Issue Number

ADP-2367
