### PR TITLE
Run `macOS` build & unit tests *after* merging rather than *before*

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -113,7 +113,7 @@ steps:
       system: ${linux}
 
   - block: "Run unit test (macos)"
-    if: '(build.branch != "staging") && (build.branch != "trying")'
+    if: 'build.branch != "master"'
     key: trigger-macos
     depends_on:
       - macos-nix
@@ -162,7 +162,7 @@ steps:
       system: ${linux}
 
   - block: 'Build package (macos)'
-    if: '(build.branch != "staging") && (build.branch != "trying")'
+    if: 'build.branch != "master"'
     key: trigger-build-macos-artifacts
     depends_on:
       - macos-nix


### PR DESCRIPTION
- [x] Don't require `Build package (macOS)` and `Run unit tests (macOS)` on bors `staging` / `trying`.
- [x] Instead automatically run `Build package (macOS)` and `Run unit tests (macOS)` on `master`.

### Motivation

- Make it easier to merge PRs for the team until we fix the builds on macOS

### Comments

- ℹ️ The build badge in the readme will show as _failing_ until these Mac builds are fixed. If this is not desirable, we could move the Mac steps to a separate pipeline, with a separate readme badge. I suspect we could see if we manage to fix them first though.

```
With this change, macOS unit tests and builds are no longer required to merge a PR into master. However, they are now run on `master`, i.e. /after/ a PR is merged.

To be sure a PR doesn't break mac builds ahead of merging, we can still manually unblock the steps in buildkite. This could be useful for node bumps etc.
```
<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2541
