### PR TITLE
Only run macOS nix regen on master & more buildkite tweaks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -106,28 +106,30 @@ steps:
     agents:
       system: ${linux}
 
-  - block: "Check nix (macOS)"
+  - block: "macOS checks"
     if: 'build.branch != "master"'
-    key: trigger-macos-nix
+    key: trigger-macos
 
   - label: 'Check nix (macos)'
     key: macos-nix
-    depends_on: trigger-macos-nix
+    depends_on: trigger-macos
     commands:
       - './nix/regenerate.sh'
     agents:
       system: ${macos}
 
-  - block: "Run unit test (macos)"
-    if: 'build.branch != "master"'
-    key: trigger-macos-unit
-    depends_on:
-      - macos-nix
-
-  - label: 'Run unit tests (macos)'
-    depends_on: [macos-nix, trigger-macos-unit]
+  - label: 'Run unit tests (macOS)'
+    depends_on: macos-nix
     key: macos-build-tests
     command: 'GC_DONT_GC=1 nix build --max-silent-time 0 --max-jobs 1 -L .#ci.${macos}.tests.run.unit'
+    agents:
+      system: ${macos}
+
+  - label: 'Build package (macOS)'
+    depends_on: macos-nix
+    key: build-macos
+    command: nix build --max-silent-time 0 --max-jobs 1 -o result/macos-intel .#ci.artifacts.macos-intel.release
+    artifact_paths: [ "./result/macos-intel/**" ]
     agents:
       system: ${macos}
 
@@ -167,16 +169,3 @@ steps:
     agents:
       system: ${linux}
 
-  - block: 'Build package (macos)'
-    if: 'build.branch != "master"'
-    key: trigger-build-macos-artifacts
-    depends_on:
-      - macos-nix
-
-  - label: 'Build package (macos)'
-    depends_on: [nix, trigger-build-macos-artifacts]
-    key: build-macos
-    command: nix build --max-silent-time 0 --max-jobs 1 -o result/macos-intel .#ci.artifacts.macos-intel.release
-    artifact_paths: [ "./result/macos-intel/**" ]
-    agents:
-      system: ${macos}

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -110,7 +110,7 @@ steps:
     if: 'build.branch != "master"'
     key: trigger-macos
 
-  - label: 'Check nix (macos)'
+  - label: 'Check nix (macOS)'
     key: macos-nix
     depends_on: trigger-macos
     commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,12 +25,6 @@ steps:
     agents:
       system: ${linux}
 
-  - label: 'Check nix (macos)'
-    key: macos-nix
-    commands:
-      - './nix/regenerate.sh'
-    agents:
-      system: ${macos}
 
   - label: 'Build bench and run unit tests (linux)'
     depends_on: nix
@@ -112,14 +106,26 @@ steps:
     agents:
       system: ${linux}
 
+  - block: "Check nix (macOS)"
+    if: 'build.branch != "master"'
+    key: trigger-macos-nix
+
+  - label: 'Check nix (macos)'
+    key: macos-nix
+    depends_on: trigger-macos-nix
+    commands:
+      - './nix/regenerate.sh'
+    agents:
+      system: ${macos}
+
   - block: "Run unit test (macos)"
     if: 'build.branch != "master"'
-    key: trigger-macos
+    key: trigger-macos-unit
     depends_on:
       - macos-nix
 
   - label: 'Run unit tests (macos)'
-    depends_on: [macos-nix, trigger-macos]
+    depends_on: [macos-nix, trigger-macos-unit]
     key: macos-build-tests
     command: 'GC_DONT_GC=1 nix build --max-silent-time 0 --max-jobs 1 -L .#ci.${macos}.tests.run.unit'
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -94,7 +94,7 @@ steps:
       system: ${linux}
 
   - block: 'Run integration tests (linux)'
-    if: '(build.branch != "staging") && (build.branch != "trying")'
+    if: '(build.branch != "staging") && (build.branch != "trying") && (build.branch != "master")'
     key: trigger-linux
     depends_on:
       - linux-nix


### PR DESCRIPTION
- [x] Don't require macOS nix regen before merge => instead run on `master`
- [x] Move all macOS checks under the same block/prompt for simplicity
- [x] Run integration tests automatically on `master`, such that they affect the README CI badge

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2541