### PR TITLE
[ADP-2367] construct transaction info from CBOR encoded txs

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/TxCBOR.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/TxCBOR.hs
@@ -94,7 +94,7 @@ parser = fromEraFunK
     $ ParsedTxCBOR
         <$> EraFunK (Feature.certificates . getEraCertificates)
         <*> EraFunK (Feature.mint . (getEraMint *&&&* getEraWitnesses))
-        <*> EraFunK (Feature.validity . getEraValidity)
+        <*> EraFunK (Feature.getValidity . getEraValidity)
         <*> EraFunK (Feature.integrity . getEraIntegrity)
         <*> EraFunK (Feature.extraSigs . getEraExtraSigs)
 

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -309,6 +309,7 @@ library
     Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
     Cardano.Wallet.Read.Primitive.Tx.Features.CollateralInputs
     Cardano.Wallet.Read.Primitive.Tx.Features.ExtraSigs
+    Cardano.Wallet.Read.Primitive.Tx.Features.Fee
     Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     Cardano.Wallet.Read.Primitive.Tx.Features.Integrity
     Cardano.Wallet.Read.Primitive.Tx.Features.Mint

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -334,6 +334,7 @@ library
     Cardano.Wallet.Read.Tx.Outputs
     Cardano.Wallet.Read.Tx.Validity
     Cardano.Wallet.Read.Tx.Witnesses
+    Cardano.Wallet.Read.Tx.Withdrawals
     Cardano.Wallet.Registry
     Cardano.Wallet.Shelley.BlockchainSource
     Cardano.Wallet.Shelley.Compatibility

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -322,6 +322,7 @@ library
     Cardano.Wallet.Read.Tx.CBOR
     Cardano.Wallet.Read.Tx.Certificates
     Cardano.Wallet.Read.Tx.CollateralInputs
+    Cardano.Wallet.Read.Tx.CollateralOutputs
     Cardano.Wallet.Read.Tx.Eras
     Cardano.Wallet.Read.Tx.ExtraSigs
     Cardano.Wallet.Read.Tx.Fee

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -240,6 +240,7 @@ library
     Cardano.Wallet.DB.Store.Transactions.Layer
     Cardano.Wallet.DB.Store.Transactions.Model
     Cardano.Wallet.DB.Store.Transactions.Store
+    Cardano.Wallet.DB.Store.Transactions.TransactionInfo
     Cardano.Wallet.DB.Store.Wallets.Model
     Cardano.Wallet.DB.Store.Wallets.Store
     Cardano.Wallet.DB.WalletState

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -316,6 +316,7 @@ library
     Cardano.Wallet.Read.Tx.Cardano
     Cardano.Wallet.Read.Tx.CBOR
     Cardano.Wallet.Read.Tx.Certificates
+    Cardano.Wallet.Read.Tx.CollateralInputs
     Cardano.Wallet.Read.Tx.Eras
     Cardano.Wallet.Read.Tx.ExtraSigs
     Cardano.Wallet.Read.Tx.Hash

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -236,6 +236,7 @@ library
     Cardano.Wallet.DB.Store.Submissions.Model
     Cardano.Wallet.DB.Store.Submissions.New.Operations
     Cardano.Wallet.DB.Store.Submissions.Store
+    Cardano.Wallet.DB.Store.Transactions.Decoration
     Cardano.Wallet.DB.Store.Transactions.Layer
     Cardano.Wallet.DB.Store.Transactions.Model
     Cardano.Wallet.DB.Store.Transactions.Store

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -316,6 +316,7 @@ library
     Cardano.Wallet.Read.Primitive.Tx.Features.Mint
     Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     Cardano.Wallet.Read.Primitive.Tx.Features.Validity
+    Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
     Cardano.Wallet.Read.Primitive.Tx.Mary
     Cardano.Wallet.Read.Primitive.Tx.Shelley
     Cardano.Wallet.Read.Tx

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -313,6 +313,7 @@ library
     Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     Cardano.Wallet.Read.Primitive.Tx.Features.Integrity
     Cardano.Wallet.Read.Primitive.Tx.Features.Mint
+    Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     Cardano.Wallet.Read.Primitive.Tx.Mary
     Cardano.Wallet.Read.Primitive.Tx.Shelley
@@ -328,6 +329,7 @@ library
     Cardano.Wallet.Read.Tx.Inputs
     Cardano.Wallet.Read.Tx.Integrity
     Cardano.Wallet.Read.Tx.Mint
+    Cardano.Wallet.Read.Tx.Outputs
     Cardano.Wallet.Read.Tx.Validity
     Cardano.Wallet.Read.Tx.Witnesses
     Cardano.Wallet.Registry

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -316,6 +316,7 @@ library
     Cardano.Wallet.Read.Primitive.Tx.Features.Metadata
     Cardano.Wallet.Read.Primitive.Tx.Features.Mint
     Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
+    Cardano.Wallet.Read.Primitive.Tx.Features.ScriptValidity
     Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
     Cardano.Wallet.Read.Primitive.Tx.Mary

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -318,6 +318,7 @@ library
     Cardano.Wallet.Read.Tx.Eras
     Cardano.Wallet.Read.Tx.ExtraSigs
     Cardano.Wallet.Read.Tx.Hash
+    Cardano.Wallet.Read.Tx.Inputs
     Cardano.Wallet.Read.Tx.Integrity
     Cardano.Wallet.Read.Tx.Mint
     Cardano.Wallet.Read.Tx.Validity

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -308,6 +308,7 @@ library
     Cardano.Wallet.Read.Primitive.Tx.Byron
     Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
     Cardano.Wallet.Read.Primitive.Tx.Features.CollateralInputs
+    Cardano.Wallet.Read.Primitive.Tx.Features.CollateralOutputs
     Cardano.Wallet.Read.Primitive.Tx.Features.ExtraSigs
     Cardano.Wallet.Read.Primitive.Tx.Features.Fee
     Cardano.Wallet.Read.Primitive.Tx.Features.Inputs

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -306,6 +306,7 @@ library
     Cardano.Wallet.Read.Primitive.Tx.Byron
     Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
     Cardano.Wallet.Read.Primitive.Tx.Features.ExtraSigs
+    Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     Cardano.Wallet.Read.Primitive.Tx.Features.Integrity
     Cardano.Wallet.Read.Primitive.Tx.Features.Mint
     Cardano.Wallet.Read.Primitive.Tx.Features.Validity

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -305,6 +305,7 @@ library
     Cardano.Wallet.Read.Primitive.Tx.Babbage
     Cardano.Wallet.Read.Primitive.Tx.Byron
     Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
+    Cardano.Wallet.Read.Primitive.Tx.Features.CollateralInputs
     Cardano.Wallet.Read.Primitive.Tx.Features.ExtraSigs
     Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     Cardano.Wallet.Read.Primitive.Tx.Features.Integrity

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -322,6 +322,7 @@ library
     Cardano.Wallet.Read.Tx.CollateralInputs
     Cardano.Wallet.Read.Tx.Eras
     Cardano.Wallet.Read.Tx.ExtraSigs
+    Cardano.Wallet.Read.Tx.Fee
     Cardano.Wallet.Read.Tx.Hash
     Cardano.Wallet.Read.Tx.Inputs
     Cardano.Wallet.Read.Tx.Integrity

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -313,6 +313,7 @@ library
     Cardano.Wallet.Read.Primitive.Tx.Features.Fee
     Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     Cardano.Wallet.Read.Primitive.Tx.Features.Integrity
+    Cardano.Wallet.Read.Primitive.Tx.Features.Metadata
     Cardano.Wallet.Read.Primitive.Tx.Features.Mint
     Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     Cardano.Wallet.Read.Primitive.Tx.Features.Validity
@@ -331,6 +332,7 @@ library
     Cardano.Wallet.Read.Tx.Hash
     Cardano.Wallet.Read.Tx.Inputs
     Cardano.Wallet.Read.Tx.Integrity
+    Cardano.Wallet.Read.Tx.Metadata
     Cardano.Wallet.Read.Tx.Mint
     Cardano.Wallet.Read.Tx.Outputs
     Cardano.Wallet.Read.Tx.Validity

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -335,6 +335,7 @@ library
     Cardano.Wallet.Read.Tx.Metadata
     Cardano.Wallet.Read.Tx.Mint
     Cardano.Wallet.Read.Tx.Outputs
+    Cardano.Wallet.Read.Tx.ScriptValidity
     Cardano.Wallet.Read.Tx.Validity
     Cardano.Wallet.Read.Tx.Witnesses
     Cardano.Wallet.Read.Tx.Withdrawals

--- a/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -35,7 +35,7 @@ module Cardano.Wallet.Byron.Compatibility
     , fromProtocolMagicId
     , fromTxAux
     , fromByronTxIn
-    , fromTxOut
+    , fromByronTxOut
     , protocolParametersFromUpdateState
     ) where
 
@@ -63,9 +63,11 @@ import Cardano.Crypto.ProtocolMagic
 import Cardano.Wallet.Primitive.Types.MinimumUTxO
     ( minimumUTxONone )
 import Cardano.Wallet.Read.Primitive.Tx.Byron
-    ( fromTxAux, fromTxOut )
+    ( fromTxAux )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromByronTxIn )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
+    ( fromByronTxOut )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Crypto.Hash.Utils
@@ -351,7 +353,7 @@ protocolParametersFromUpdateState b ppNode =
 -- | Convert non AVVM balances to genesis UTxO.
 fromNonAvvmBalances :: GenesisNonAvvmBalances -> [W.TxOut]
 fromNonAvvmBalances (GenesisNonAvvmBalances m) =
-    fromTxOut . uncurry TxOut <$> Map.toList m
+    fromByronTxOut . uncurry TxOut <$> Map.toList m
 
 -- | Convert genesis data into blockchain params and an initial set of UTxO
 fromGenesisData :: (GenesisData, GenesisHash) -> (W.NetworkParameters, [W.TxOut])

--- a/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -34,9 +34,8 @@ module Cardano.Wallet.Byron.Compatibility
     , byronCodecConfig
     , fromProtocolMagicId
     , fromTxAux
-    , fromTxIn
+    , fromByronTxIn
     , fromTxOut
-
     , protocolParametersFromUpdateState
     ) where
 
@@ -64,7 +63,9 @@ import Cardano.Crypto.ProtocolMagic
 import Cardano.Wallet.Primitive.Types.MinimumUTxO
     ( minimumUTxONone )
 import Cardano.Wallet.Read.Primitive.Tx.Byron
-    ( fromTxAux, fromTxIn, fromTxOut )
+    ( fromTxAux, fromTxOut )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
+    ( fromByronTxIn )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Crypto.Hash.Utils

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -115,11 +115,10 @@ import Cardano.Wallet.DB.Store.Transactions.Decoration
     ( decorateTxInsForRelation )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( TxSet (..) )
+import Cardano.Wallet.DB.Store.Transactions.TransactionInfo
+    ( mkTransactionInfo )
 import Cardano.Wallet.DB.Store.Wallets.Model
-    ( DeltaWalletsMetaWithSubmissions (..)
-    , TxWalletsHistory
-    , mkTransactionInfo
-    )
+    ( DeltaWalletsMetaWithSubmissions (..), TxWalletsHistory )
 import Cardano.Wallet.DB.Store.Wallets.Store
     ( DeltaTxWalletsHistory (..), mkStoreTxWalletsHistory )
 import Cardano.Wallet.DB.WalletState

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -111,8 +111,10 @@ import Cardano.Wallet.DB.Store.Meta.Model
     )
 import Cardano.Wallet.DB.Store.Submissions.Model
     ( TxLocalSubmissionHistory (..) )
+import Cardano.Wallet.DB.Store.Transactions.Decoration
+    ( decorateTxIns )
 import Cardano.Wallet.DB.Store.Transactions.Model
-    ( TxSet (..), decorateTxIns )
+    ( TxSet (..) )
 import Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaWalletsMetaWithSubmissions (..)
     , TxWalletsHistory

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -112,7 +112,7 @@ import Cardano.Wallet.DB.Store.Meta.Model
 import Cardano.Wallet.DB.Store.Submissions.Model
     ( TxLocalSubmissionHistory (..) )
 import Cardano.Wallet.DB.Store.Transactions.Decoration
-    ( decorateTxIns )
+    ( decorateTxInsForRelation )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( TxSet (..) )
 import Cardano.Wallet.DB.Store.Wallets.Model
@@ -1057,7 +1057,7 @@ selectTransactionInfo ti tip txSet meta =
     let err = error $ "Transaction not found: " <> show meta
         transaction = fromMaybe err $
             Map.lookup (txMetaTxId meta) (view #relations txSet)
-        decoration = decorateTxIns txSet transaction
+        decoration = decorateTxInsForRelation txSet transaction
     in  mkTransactionInfo ti tip transaction decoration meta
 
 -- | Returns the initial submission slot and submission record for all pending

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -116,7 +116,7 @@ import Cardano.Wallet.DB.Store.Transactions.Decoration
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( TxSet (..) )
 import Cardano.Wallet.DB.Store.Transactions.TransactionInfo
-    ( mkTransactionInfo )
+    ( mkTransactionInfoFromRelation )
 import Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaWalletsMetaWithSubmissions (..), TxWalletsHistory )
 import Cardano.Wallet.DB.Store.Wallets.Store
@@ -1057,7 +1057,7 @@ selectTransactionInfo ti tip txSet meta =
         transaction = fromMaybe err $
             Map.lookup (txMetaTxId meta) (view #relations txSet)
         decoration = decorateTxInsForRelation txSet transaction
-    in  mkTransactionInfo ti tip transaction decoration meta
+    in  mkTransactionInfoFromRelation ti tip transaction decoration meta
 
 -- | Returns the initial submission slot and submission record for all pending
 -- transactions in the wallet.

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
@@ -15,7 +15,7 @@ corrisponding (known) tx outputs
 
 module Cardano.Wallet.DB.Store.Transactions.Decoration
    ( DecoratedTxIns
-   , decorateTxIns
+   , decorateTxInsForRelation
    , lookupTxOutForTxIn
    , lookupTxOutForTxCollateral
    ) where
@@ -82,9 +82,9 @@ lookupTxOutForTxCollateral tx =
 
 -- | Decorate the Tx inputs of a given 'TxRelation'
 -- by searching the 'TxSet' for corresponding output values.
-decorateTxIns
+decorateTxInsForRelation
     :: TxSet -> TxRelation -> DecoratedTxIns
-decorateTxIns (TxSet relations) TxRelation{ins,collateralIns} =
+decorateTxInsForRelation (TxSet relations) TxRelation{ins,collateralIns} =
     DecoratedTxIns . Map.fromList . catMaybes $
         (lookupOutput . toKeyTxIn <$> ins)
         ++ (lookupOutput . toKeyTxCollateral <$> collateralIns)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-deferred-out-of-scope-variables #-}
+
+{- |
+Copyright: © 2022 IOHK
+License: Apache-2.0
+
+Definition of the decoration of transactions to map tx inputs to the
+corrisponding (known) tx outputs
+-}
+
+module Cardano.Wallet.DB.Store.Transactions.Decoration
+   ( DecoratedTxIns
+   , decorateTxIns
+   , lookupTxOutForTxIn
+   , lookupTxOutForTxCollateral
+   ) where
+
+import Prelude
+
+import Cardano.Wallet.DB.Sqlite.Schema
+    ( TxCollateral (..), TxIn (..), TxOut (..) )
+import Cardano.Wallet.DB.Sqlite.Types
+    ( TxId (..) )
+import Cardano.Wallet.DB.Store.Transactions.Model
+    ( TxRelation (TxRelation, collateralIns, collateralOuts, ins, outs)
+    , TxSet (TxSet)
+    , fromTxCollateralOut
+    , fromTxOut
+    )
+import Control.Applicative
+    ( (<|>) )
+import Control.Monad
+    ( guard )
+import Data.List
+    ( find )
+import Data.Map.Strict
+    ( Map )
+import Data.Maybe
+    ( catMaybes )
+import Data.Word
+    ( Word32 )
+
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+import qualified Data.Map.Strict as Map
+
+type TxOutKey = (TxId, Word32)
+
+toKeyTxIn :: TxIn -> TxOutKey
+toKeyTxIn txin = (txInputSourceTxId txin, txInputSourceIndex txin)
+
+toKeyTxCollateral :: TxCollateral -> TxOutKey
+toKeyTxCollateral txcol =
+    (txCollateralSourceTxId txcol, txCollateralSourceIndex txcol)
+
+-- | A collection of Tx inputs
+-- (regular or collateral, refered to by input and order)
+-- that are decorated with the values of their corresponding Tx outputs.
+newtype DecoratedTxIns = DecoratedTxIns
+    { unDecoratedTxIns
+        :: Map TxOutKey W.TxOut
+    }
+
+instance Semigroup DecoratedTxIns where
+    (DecoratedTxIns a) <> (DecoratedTxIns b) = DecoratedTxIns (a <> b)
+
+instance Monoid DecoratedTxIns where
+    mempty = DecoratedTxIns mempty
+
+lookupTxOutForTxIn
+    :: TxIn -> DecoratedTxIns -> Maybe W.TxOut
+lookupTxOutForTxIn tx = Map.lookup (toKeyTxIn tx) . unDecoratedTxIns
+
+lookupTxOutForTxCollateral
+    :: TxCollateral -> DecoratedTxIns -> Maybe W.TxOut
+lookupTxOutForTxCollateral tx =
+    Map.lookup (toKeyTxCollateral tx) . unDecoratedTxIns
+
+-- | Decorate the Tx inputs of a given 'TxRelation'
+-- by searching the 'TxSet' for corresponding output values.
+decorateTxIns
+    :: TxSet -> TxRelation -> DecoratedTxIns
+decorateTxIns (TxSet relations) TxRelation{ins,collateralIns} =
+    DecoratedTxIns . Map.fromList . catMaybes $
+        (lookupOutput . toKeyTxIn <$> ins)
+        ++ (lookupOutput . toKeyTxCollateral <$> collateralIns)
+  where
+    lookupOutput key@(txid, index) = do
+        tx <- Map.lookup txid relations
+        out <- lookupTxOut tx index <|> lookupTxCollateralOut tx index
+        pure (key, out)
+
+    lookupTxOut tx index = fromTxOut <$>
+        find ((index ==) . txOutputIndex . fst) (outs tx)
+
+    lookupTxCollateralOut tx index = do
+        out <- collateralOuts tx
+        let collateralOutputIndex = toEnum $ length (outs tx)
+        guard $ index == collateralOutputIndex  -- Babbage leder spec
+        pure $ fromTxCollateralOut out

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
@@ -16,11 +16,15 @@ corrisponding (known) tx outputs
 module Cardano.Wallet.DB.Store.Transactions.Decoration
    ( DecoratedTxIns
    , decorateTxInsForRelation
-   , lookupTxOutForTxIn
-   , lookupTxOutForTxCollateral
+   , lookupTxOut
+   , decorateTxInsForReadTx
+   , mkTxOutKey
+   , mkTxOutKeyCollateral
+   , TxOutKey
    ) where
 
-import Prelude
+import Prelude hiding
+    ( (.) )
 
 import Cardano.Wallet.DB.Sqlite.Schema
     ( TxCollateral (..), TxIn (..), TxOut (..) )
@@ -32,8 +36,22 @@ import Cardano.Wallet.DB.Store.Transactions.Model
     , fromTxCollateralOut
     , fromTxOut
     )
+import Cardano.Wallet.Read.Eras
+    ( EraValue, extractEraValue )
+import Cardano.Wallet.Read.Eras.EraFun
+    ( applyEraFun )
+import Cardano.Wallet.Read.Primitive.Tx.Features.CollateralInputs
+    ( getCollateralInputs )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
+    ( getInputs )
+import Cardano.Wallet.Read.Tx.CollateralInputs
+    ( getEraCollateralInputs )
+import Cardano.Wallet.Read.Tx.Inputs
+    ( getEraInputs )
 import Control.Applicative
     ( (<|>) )
+import Control.Category
+    ( (.) )
 import Control.Monad
     ( guard )
 import Data.List
@@ -45,16 +63,18 @@ import Data.Maybe
 import Data.Word
     ( Word32 )
 
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+import qualified Cardano.Wallet.Read.Tx as Read
 import qualified Data.Map.Strict as Map
 
 type TxOutKey = (TxId, Word32)
 
-toKeyTxIn :: TxIn -> TxOutKey
-toKeyTxIn txin = (txInputSourceTxId txin, txInputSourceIndex txin)
+mkTxOutKey :: TxIn -> TxOutKey
+mkTxOutKey txin = (txInputSourceTxId txin, txInputSourceIndex txin)
 
-toKeyTxCollateral :: TxCollateral -> TxOutKey
-toKeyTxCollateral txcol =
+mkTxOutKeyCollateral :: TxCollateral -> TxOutKey
+mkTxOutKeyCollateral txcol =
     (txCollateralSourceTxId txcol, txCollateralSourceIndex txcol)
 
 -- | A collection of Tx inputs
@@ -71,34 +91,53 @@ instance Semigroup DecoratedTxIns where
 instance Monoid DecoratedTxIns where
     mempty = DecoratedTxIns mempty
 
-lookupTxOutForTxIn
-    :: TxIn -> DecoratedTxIns -> Maybe W.TxOut
-lookupTxOutForTxIn tx = Map.lookup (toKeyTxIn tx) . unDecoratedTxIns
+lookupTxOut
+    :: TxOutKey -> DecoratedTxIns -> Maybe W.TxOut
+lookupTxOut tx = Map.lookup tx . unDecoratedTxIns
 
-lookupTxOutForTxCollateral
-    :: TxCollateral -> DecoratedTxIns -> Maybe W.TxOut
-lookupTxOutForTxCollateral tx =
-    Map.lookup (toKeyTxCollateral tx) . unDecoratedTxIns
-
--- | Decorate the Tx inputs of a given 'TxRelation'
--- by searching the 'TxSet' for corresponding output values.
-decorateTxInsForRelation
-    :: TxSet -> TxRelation -> DecoratedTxIns
-decorateTxInsForRelation (TxSet relations) TxRelation{ins,collateralIns} =
+decorateTxInsInternal :: TxSet -> [(TxId, Word32)]
+    -> [(TxId, Word32)] -> DecoratedTxIns
+decorateTxInsInternal (TxSet relations) ins collateralIns =
     DecoratedTxIns . Map.fromList . catMaybes $
-        (lookupOutput . toKeyTxIn <$> ins)
-        ++ (lookupOutput . toKeyTxCollateral <$> collateralIns)
+        (lookupOutput <$> ins) <> (lookupOutput <$> collateralIns)
   where
+
+    lookupOutput :: (TxId, Word32) -> Maybe ((TxId, Word32), W.TxOut)
     lookupOutput key@(txid, index) = do
         tx <- Map.lookup txid relations
-        out <- lookupTxOut tx index <|> lookupTxCollateralOut tx index
+        out <- lookupTxOut' tx index <|> lookupTxCollateralOut tx index
         pure (key, out)
 
-    lookupTxOut tx index = fromTxOut <$>
+    lookupTxOut' :: TxRelation -> Word32 -> Maybe W.TxOut
+    lookupTxOut' tx index = fromTxOut <$>
         find ((index ==) . txOutputIndex . fst) (outs tx)
 
+    lookupTxCollateralOut :: (Enum a, Eq a) => TxRelation -> a -> Maybe W.TxOut
     lookupTxCollateralOut tx index = do
         out <- collateralOuts tx
         let collateralOutputIndex = toEnum $ length (outs tx)
         guard $ index == collateralOutputIndex  -- Babbage leder spec
         pure $ fromTxCollateralOut out
+
+-- | Decorate the Tx inputs of a given 'TxRelation'
+-- by searching the 'TxSet' for corresponding output values.
+decorateTxInsForRelation
+    :: TxSet -> TxRelation -> DecoratedTxIns
+decorateTxInsForRelation txSet TxRelation{ins,collateralIns} =
+    decorateTxInsInternal txSet (mkTxOutKey <$> ins)
+        (mkTxOutKeyCollateral <$> collateralIns)
+
+-- | Decorate the Tx inputs of a given 'TxRelation'
+-- by searching the 'TxSet' for corresponding output values.
+decorateTxInsForReadTx
+    :: TxSet -> EraValue Read.Tx -> DecoratedTxIns
+decorateTxInsForReadTx txSet tx
+  = decorateTxInsInternal txSet
+        (fmap undoWTxIn
+            $ extractEraValue $ applyEraFun (getInputs . getEraInputs) tx)
+        (fmap undoWTxIn
+            $ extractEraValue $ applyEraFun
+                (getCollateralInputs . getEraCollateralInputs) tx)
+  where
+    undoWTxIn :: W.TxIn -> (TxId, Word32)
+    undoWTxIn (W.TxIn k n) = (TxId k,n)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Cardano.Wallet.DB.Store.Transactions.TransactionInfo
+    ( mkTransactionInfo
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.DB.Sqlite.Schema
+    ( TxCollateral (..), TxIn (..), TxMeta (..), TxWithdrawal (..) )
+import Cardano.Wallet.DB.Sqlite.Types
+    ( TxId (..) )
+import Cardano.Wallet.DB.Store.Transactions.Decoration
+    ( DecoratedTxIns, lookupTxOutForTxCollateral, lookupTxOutForTxIn )
+import Cardano.Wallet.DB.Store.Transactions.Model
+    ( TxRelation (..), fromTxCollateralOut, fromTxOut, txCBORPrism )
+import Cardano.Wallet.Primitive.Slotting
+    ( TimeInterpreter, interpretQuery, slotToUTCTime )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxCBOR, TxMeta (..) )
+import Data.Functor
+    ( (<&>) )
+import Data.Generics.Internal.VL
+    ( (^.) )
+import Data.Quantity
+    ( Quantity (..) )
+
+import qualified Cardano.Wallet.DB.Sqlite.Schema as DB
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as WC
+import qualified Cardano.Wallet.Primitive.Types.Tx as WT
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as WT
+import qualified Data.Generics.Internal.VL as L
+import qualified Data.Map.Strict as Map
+
+-- | Compute a high level view of a transaction known as 'TransactionInfo'
+-- from a 'TxMeta' and a 'TxRelation'.
+-- Assumes that these data refer to the same 'TxId', does /not/ check this.
+mkTransactionInfo :: Monad m
+    => TimeInterpreter m
+    -> W.BlockHeader
+    -> TxRelation
+    -> DecoratedTxIns
+    -> DB.TxMeta
+    -> m WT.TransactionInfo
+mkTransactionInfo ti tip TxRelation{..} decor DB.TxMeta{..} = do
+    txTime <- interpretQuery ti . slotToUTCTime $ txMetaSlot
+    return
+        $ WT.TransactionInfo
+        { WT.txInfoId = getTxId txMetaTxId
+        , WT.txInfoCBOR = cbor >>= mkTxCBOR
+        , WT.txInfoFee = WC.Coin . fromIntegral <$> txMetaFee
+        , WT.txInfoInputs = mkTxIn <$> ins
+        , WT.txInfoCollateralInputs = mkTxCollateral <$> collateralIns
+        , WT.txInfoOutputs = fromTxOut <$> outs
+        , WT.txInfoCollateralOutput = fromTxCollateralOut <$> collateralOuts
+        , WT.txInfoWithdrawals = Map.fromList $ map mkTxWithdrawal withdrawals
+        , WT.txInfoMeta = WT.TxMeta
+              { WT.status = txMetaStatus
+              , WT.direction = txMetaDirection
+              , WT.slotNo = txMetaSlot
+              , WT.blockHeight = Quantity (txMetaBlockHeight)
+              , amount = txMetaAmount
+              , WT.expiry = txMetaSlotExpires
+              }
+        , WT.txInfoMetadata = txMetadata
+        , WT.txInfoDepth = Quantity
+              $ fromIntegral
+              $ if tipH > txMetaBlockHeight
+                  then tipH - txMetaBlockHeight
+                  else 0
+        , WT.txInfoTime = txTime
+        , WT.txInfoScriptValidity = txMetaScriptValidity <&> \case
+              False -> WT.TxScriptInvalid
+              True -> WT.TxScriptValid
+        }
+  where
+    tipH = getQuantity $ tip ^. #blockHeight
+    mkTxIn tx =
+        ( WT.TxIn
+          { inputId = getTxId (txInputSourceTxId tx)
+          , inputIx = txInputSourceIndex tx
+          }
+        , lookupTxOutForTxIn tx decor
+        )
+    mkTxCollateral tx =
+        ( WT.TxIn
+          { inputId = getTxId (txCollateralSourceTxId tx)
+          , inputIx = txCollateralSourceIndex tx
+          }
+        , lookupTxOutForTxCollateral tx decor
+        )
+    mkTxWithdrawal w = (txWithdrawalAccount w, txWithdrawalAmount w)
+
+    mkTxCBOR :: DB.CBOR -> Maybe TxCBOR
+    mkTxCBOR = either (const Nothing) (Just . snd) . L.match txCBORPrism

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -161,7 +161,8 @@ mkTransactionInfoFromReadTx :: Monad m
     -> SubmissionMeta
     -> W.TxStatus
     -> m WT.TransactionInfo
-mkTransactionInfoFromReadTx _ti tip decor tx SubmissionMeta{..} status = do
+mkTransactionInfoFromReadTx ti tip decor tx SubmissionMeta{..} status = do
+    txTime <- interpretQuery ti . slotToUTCTime $ submissionMetaSlot
     return
         $ WT.TransactionInfo
         { WT.txInfoId = W.Hash $ value getEraTxHash
@@ -189,7 +190,7 @@ mkTransactionInfoFromReadTx _ti tip decor tx SubmissionMeta{..} status = do
             if tipH > height
                   then tipH - height
                   else 0
-        , WT.txInfoTime = undefined
+        , WT.txInfoTime = txTime
         , WT.txInfoScriptValidity = undefined
         }
   where

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -36,6 +36,8 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( getInputs )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     ( getOutputs )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
+    ( getWithdrawals )
 import Cardano.Wallet.Read.Tx.CBOR
     ( renderTxToCBOR )
 import Cardano.Wallet.Read.Tx.CollateralInputs
@@ -50,8 +52,12 @@ import Cardano.Wallet.Read.Tx.Inputs
     ( getEraInputs )
 import Cardano.Wallet.Read.Tx.Outputs
     ( getEraOutputs )
+import Cardano.Wallet.Read.Tx.Withdrawals
+    ( getEraWithdrawals )
 import Control.Category
     ( (.) )
+import Data.Foldable
+    ( fold )
 import Data.Functor
     ( (<&>) )
 import Data.Generics.Internal.VL
@@ -69,6 +75,7 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as WT
 import qualified Cardano.Wallet.Read.Tx as Read
 import qualified Data.Generics.Internal.VL as L
 import qualified Data.Map.Strict as Map
+
 -- | Compute a high level view of a transaction known as 'TransactionInfo'
 -- from a 'TxMeta' and a 'TxRelation'.
 -- Assumes that these data refer to the same 'TxId', does /not/ check this.
@@ -152,7 +159,8 @@ mkTransactionInfoFromReadTx _ti tip decor tx _meta = do
         , WT.txInfoOutputs = value (getOutputs . getEraOutputs)
         , WT.txInfoCollateralOutput
             = value (getCollateralOutputs . getEraCollateralOutputs)
-        , WT.txInfoWithdrawals = undefined
+        , WT.txInfoWithdrawals = fold
+            $ value (getWithdrawals . getEraWithdrawals)
         , WT.txInfoMeta = WT.TxMeta
               { WT.status = undefined
               , WT.direction = undefined

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -15,7 +15,7 @@ import Cardano.Wallet.DB.Sqlite.Schema
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.Submissions.New.Operations
-    ( SubmissionMeta )
+    ( SubmissionMeta (..) )
 import Cardano.Wallet.DB.Store.Transactions.Decoration
     ( DecoratedTxIns, TxOutKey, lookupTxOut, mkTxOutKey, mkTxOutKeyCollateral )
 import Cardano.Wallet.DB.Store.Transactions.Model
@@ -151,7 +151,7 @@ mkTransactionInfoFromReadTx :: Monad m
     -> EraValue Read.Tx
     -> SubmissionMeta
     -> m WT.TransactionInfo
-mkTransactionInfoFromReadTx _ti tip decor tx _meta = do
+mkTransactionInfoFromReadTx _ti tip decor tx SubmissionMeta{..} = do
     return
         $ WT.TransactionInfo
         { WT.txInfoId = W.Hash $ value getEraTxHash
@@ -174,10 +174,9 @@ mkTransactionInfoFromReadTx _ti tip decor tx _meta = do
               , WT.expiry = undefined
               }
         , WT.txInfoMetadata = value $ getMetadata . getEraMetadata
-        , WT.txInfoDepth = Quantity
-              $ fromIntegral
-              $ if tipH > undefined
-                  then tipH - undefined
+        , WT.txInfoDepth = Quantity $ fromIntegral $
+            if tipH > submissionMetaHeight
+                  then tipH - submissionMetaHeight
                   else 0
         , WT.txInfoTime = undefined
         , WT.txInfoScriptValidity = undefined

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -13,7 +13,7 @@ import Cardano.Wallet.DB.Sqlite.Schema
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.Transactions.Decoration
-    ( DecoratedTxIns, lookupTxOutForTxCollateral, lookupTxOutForTxIn )
+    ( DecoratedTxIns, lookupTxOut, mkTxOutKey, mkTxOutKeyCollateral )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( TxRelation (..), fromTxCollateralOut, fromTxOut, txCBORPrism )
 import Cardano.Wallet.Primitive.Slotting
@@ -83,14 +83,14 @@ mkTransactionInfo ti tip TxRelation{..} decor DB.TxMeta{..} = do
           { inputId = getTxId (txInputSourceTxId tx)
           , inputIx = txInputSourceIndex tx
           }
-        , lookupTxOutForTxIn tx decor
+        , lookupTxOut (mkTxOutKey tx) decor
         )
     mkTxCollateral tx =
         ( WT.TxIn
           { inputId = getTxId (txCollateralSourceTxId tx)
           , inputIx = txCollateralSourceIndex tx
           }
-        , lookupTxOutForTxCollateral tx decor
+        , lookupTxOut (mkTxOutKeyCollateral tx) decor
         )
     mkTxWithdrawal w = (txWithdrawalAccount w, txWithdrawalAmount w)
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -32,6 +32,8 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
     ( getFee )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( getInputs )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
+    ( getOutputs )
 import Cardano.Wallet.Read.Tx.CBOR
     ( renderTxToCBOR )
 import Cardano.Wallet.Read.Tx.CollateralInputs
@@ -42,6 +44,8 @@ import Cardano.Wallet.Read.Tx.Hash
     ( getEraTxHash )
 import Cardano.Wallet.Read.Tx.Inputs
     ( getEraInputs )
+import Cardano.Wallet.Read.Tx.Outputs
+    ( getEraOutputs )
 import Control.Category
     ( (.) )
 import Data.Functor
@@ -61,7 +65,6 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as WT
 import qualified Cardano.Wallet.Read.Tx as Read
 import qualified Data.Generics.Internal.VL as L
 import qualified Data.Map.Strict as Map
-
 -- | Compute a high level view of a transaction known as 'TransactionInfo'
 -- from a 'TxMeta' and a 'TxRelation'.
 -- Assumes that these data refer to the same 'TxId', does /not/ check this.
@@ -142,7 +145,7 @@ mkTransactionInfoFromReadTx _ti tip decor tx _meta = do
         , WT.txInfoInputs = mkTxIn <$> value (getInputs . getEraInputs)
         , WT.txInfoCollateralInputs = mkTxIn
             <$> value (getCollateralInputs . getEraCollateralInputs)
-        , WT.txInfoOutputs = undefined
+        , WT.txInfoOutputs = value (getOutputs . getEraOutputs)
         , WT.txInfoCollateralOutput = undefined
         , WT.txInfoWithdrawals = undefined
         , WT.txInfoMeta = WT.TxMeta

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -26,10 +26,14 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( TxCBOR, TxMeta (..) )
 import Cardano.Wallet.Read.Eras
     ( EraFun, EraValue, K, applyEraFun, extractEraValue )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
+    ( getFee )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( getInputs )
 import Cardano.Wallet.Read.Tx.CBOR
     ( renderTxToCBOR )
+import Cardano.Wallet.Read.Tx.Fee
+    ( getEraFee )
 import Cardano.Wallet.Read.Tx.Hash
     ( getEraTxHash )
 import Cardano.Wallet.Read.Tx.Inputs
@@ -130,7 +134,7 @@ mkTransactionInfoFromReadTx _ti tip decor tx _meta = do
         $ WT.TransactionInfo
         { WT.txInfoId = W.Hash $ value getEraTxHash
         , WT.txInfoCBOR = Just $ renderTxToCBOR tx
-        , WT.txInfoFee = undefined
+        , WT.txInfoFee = value $ getFee . getEraFee
         , WT.txInfoInputs = mkTxIn <$> value (getInputs . getEraInputs)
         , WT.txInfoCollateralInputs = undefined
         , WT.txInfoOutputs = undefined

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -40,6 +40,8 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Metadata
     ( getMetadata )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     ( getOutputs )
+import Cardano.Wallet.Read.Primitive.Tx.Features.ScriptValidity
+    ( getScriptValidity )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( getValidity )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
@@ -60,6 +62,8 @@ import Cardano.Wallet.Read.Tx.Metadata
     ( getEraMetadata )
 import Cardano.Wallet.Read.Tx.Outputs
     ( getEraOutputs )
+import Cardano.Wallet.Read.Tx.ScriptValidity
+    ( getEraScriptValidity )
 import Cardano.Wallet.Read.Tx.Validity
     ( getEraValidity )
 import Cardano.Wallet.Read.Tx.Withdrawals
@@ -191,7 +195,8 @@ mkTransactionInfoFromReadTx ti tip decor tx SubmissionMeta{..} status = do
                   then tipH - height
                   else 0
         , WT.txInfoTime = txTime
-        , WT.txInfoScriptValidity = undefined
+        , WT.txInfoScriptValidity
+            = value $ getScriptValidity . getEraScriptValidity
         }
   where
     tipH = getQuantity $ tip ^. #blockHeight

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Cardano.Wallet.DB.Store.Transactions.TransactionInfo
-    ( mkTransactionInfo
+    ( mkTransactionInfoFromRelation
     ) where
 
 import Prelude
@@ -38,14 +38,14 @@ import qualified Data.Map.Strict as Map
 -- | Compute a high level view of a transaction known as 'TransactionInfo'
 -- from a 'TxMeta' and a 'TxRelation'.
 -- Assumes that these data refer to the same 'TxId', does /not/ check this.
-mkTransactionInfo :: Monad m
+mkTransactionInfoFromRelation :: Monad m
     => TimeInterpreter m
     -> W.BlockHeader
     -> TxRelation
     -> DecoratedTxIns
     -> DB.TxMeta
     -> m WT.TransactionInfo
-mkTransactionInfo ti tip TxRelation{..} decor DB.TxMeta{..} = do
+mkTransactionInfoFromRelation ti tip TxRelation{..} decor DB.TxMeta{..} = do
     txTime <- interpretQuery ti . slotToUTCTime $ txMetaSlot
     return
         $ WT.TransactionInfo

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -34,6 +34,8 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
     ( getFee )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( getInputs )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Metadata
+    ( getMetadata )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     ( getOutputs )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
@@ -50,6 +52,8 @@ import Cardano.Wallet.Read.Tx.Hash
     ( getEraTxHash )
 import Cardano.Wallet.Read.Tx.Inputs
     ( getEraInputs )
+import Cardano.Wallet.Read.Tx.Metadata
+    ( getEraMetadata )
 import Cardano.Wallet.Read.Tx.Outputs
     ( getEraOutputs )
 import Cardano.Wallet.Read.Tx.Withdrawals
@@ -169,7 +173,7 @@ mkTransactionInfoFromReadTx _ti tip decor tx _meta = do
               , amount = undefined
               , WT.expiry = undefined
               }
-        , WT.txInfoMetadata = undefined
+        , WT.txInfoMetadata = value $ getMetadata . getEraMetadata
         , WT.txInfoDepth = Quantity
               $ fromIntegral
               $ if tipH > undefined

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -25,6 +25,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( TxCBOR, TxMeta (..) )
 import Cardano.Wallet.Read.Eras
     ( EraFun, EraValue, K, applyEraFun, extractEraValue )
+import Cardano.Wallet.Read.Tx.Hash
+    ( getEraTxHash )
 import Data.Functor
     ( (<&>) )
 import Data.Generics.Internal.VL
@@ -35,6 +37,7 @@ import Data.Quantity
 import qualified Cardano.Wallet.DB.Sqlite.Schema as DB
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as WC
+import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as WT
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as WT
 import qualified Cardano.Wallet.Read.Tx as Read
@@ -115,7 +118,7 @@ mkTransactionInfoFromReadTx :: Monad m
 mkTransactionInfoFromReadTx _ti tip _decor tx _meta = do
     return
         $ WT.TransactionInfo
-        { WT.txInfoId = undefined
+        { WT.txInfoId = W.Hash $ value getEraTxHash
         , WT.txInfoCBOR = undefined
         , WT.txInfoFee = undefined
         , WT.txInfoInputs = undefined
@@ -142,5 +145,6 @@ mkTransactionInfoFromReadTx _ti tip _decor tx _meta = do
         }
   where
     tipH = getQuantity $ tip ^. #blockHeight
-    _value :: EraFun Read.Tx (K a) -> a
-    _value f = extractEraValue $ applyEraFun f tx
+    
+    value :: EraFun Read.Tx (K a) -> a
+    value f = extractEraValue $ applyEraFun f tx

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -25,6 +25,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( TxCBOR, TxMeta (..) )
 import Cardano.Wallet.Read.Eras
     ( EraFun, EraValue, K, applyEraFun, extractEraValue )
+import Cardano.Wallet.Read.Tx.CBOR
+    ( renderTxToCBOR )
 import Cardano.Wallet.Read.Tx.Hash
     ( getEraTxHash )
 import Data.Functor
@@ -119,7 +121,7 @@ mkTransactionInfoFromReadTx _ti tip _decor tx _meta = do
     return
         $ WT.TransactionInfo
         { WT.txInfoId = W.Hash $ value getEraTxHash
-        , WT.txInfoCBOR = undefined
+        , WT.txInfoCBOR = Just $ renderTxToCBOR tx
         , WT.txInfoFee = undefined
         , WT.txInfoInputs = undefined
         , WT.txInfoCollateralInputs = undefined
@@ -145,6 +147,6 @@ mkTransactionInfoFromReadTx _ti tip _decor tx _meta = do
         }
   where
     tipH = getQuantity $ tip ^. #blockHeight
-    
+
     value :: EraFun Read.Tx (K a) -> a
     value f = extractEraValue $ applyEraFun f tx

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -28,6 +28,8 @@ import Cardano.Wallet.Read.Eras
     ( EraFun, EraValue, K, applyEraFun, extractEraValue )
 import Cardano.Wallet.Read.Primitive.Tx.Features.CollateralInputs
     ( getCollateralInputs )
+import Cardano.Wallet.Read.Primitive.Tx.Features.CollateralOutputs
+    ( getCollateralOutputs )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
     ( getFee )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
@@ -38,6 +40,8 @@ import Cardano.Wallet.Read.Tx.CBOR
     ( renderTxToCBOR )
 import Cardano.Wallet.Read.Tx.CollateralInputs
     ( getEraCollateralInputs )
+import Cardano.Wallet.Read.Tx.CollateralOutputs
+    ( getEraCollateralOutputs )
 import Cardano.Wallet.Read.Tx.Fee
     ( getEraFee )
 import Cardano.Wallet.Read.Tx.Hash
@@ -146,7 +150,8 @@ mkTransactionInfoFromReadTx _ti tip decor tx _meta = do
         , WT.txInfoCollateralInputs = mkTxIn
             <$> value (getCollateralInputs . getEraCollateralInputs)
         , WT.txInfoOutputs = value (getOutputs . getEraOutputs)
-        , WT.txInfoCollateralOutput = undefined
+        , WT.txInfoCollateralOutput
+            = value (getCollateralOutputs . getEraCollateralOutputs)
         , WT.txInfoWithdrawals = undefined
         , WT.txInfoMeta = WT.TxMeta
               { WT.status = undefined

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -26,12 +26,16 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( TxCBOR, TxMeta (..) )
 import Cardano.Wallet.Read.Eras
     ( EraFun, EraValue, K, applyEraFun, extractEraValue )
+import Cardano.Wallet.Read.Primitive.Tx.Features.CollateralInputs
+    ( getCollateralInputs )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
     ( getFee )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( getInputs )
 import Cardano.Wallet.Read.Tx.CBOR
     ( renderTxToCBOR )
+import Cardano.Wallet.Read.Tx.CollateralInputs
+    ( getEraCollateralInputs )
 import Cardano.Wallet.Read.Tx.Fee
     ( getEraFee )
 import Cardano.Wallet.Read.Tx.Hash
@@ -136,7 +140,8 @@ mkTransactionInfoFromReadTx _ti tip decor tx _meta = do
         , WT.txInfoCBOR = Just $ renderTxToCBOR tx
         , WT.txInfoFee = value $ getFee . getEraFee
         , WT.txInfoInputs = mkTxIn <$> value (getInputs . getEraInputs)
-        , WT.txInfoCollateralInputs = undefined
+        , WT.txInfoCollateralInputs = mkTxIn
+            <$> value (getCollateralInputs . getEraCollateralInputs)
         , WT.txInfoOutputs = undefined
         , WT.txInfoCollateralOutput = undefined
         , WT.txInfoWithdrawals = undefined

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -32,14 +32,12 @@ import Cardano.Wallet.DB.Store.Meta.Model
     ( DeltaTxMetaHistory (..), TxMetaHistory (..), mkTxMetaHistory )
 import Cardano.Wallet.DB.Store.Submissions.Model
     ( DeltaTxLocalSubmission (..), TxLocalSubmissionHistory (..) )
+import Cardano.Wallet.DB.Store.Transactions.Decoration
 import Cardano.Wallet.DB.Store.Transactions.Model
-    ( DecoratedTxIns
-    , TxRelation (..)
+    ( TxRelation (..)
     , TxSet (..)
     , fromTxCollateralOut
     , fromTxOut
-    , lookupTxOutForTxCollateral
-    , lookupTxOutForTxIn
     , mkTxSet
     , txCBORPrism
     )

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLabels #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {- |
@@ -18,33 +16,19 @@ module Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaTxWalletsHistory (..)
     , DeltaWalletsMetaWithSubmissions (..)
     , TxWalletsHistory
-    , mkTransactionInfo
     , walletsLinkedTransactions
     ) where
 
 import Prelude
 
-import Cardano.Wallet.DB.Sqlite.Schema
-    ( TxCollateral (..), TxIn (..), TxMeta (..), TxWithdrawal (..) )
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.Meta.Model
     ( DeltaTxMetaHistory (..), TxMetaHistory (..), mkTxMetaHistory )
 import Cardano.Wallet.DB.Store.Submissions.Model
     ( DeltaTxLocalSubmission (..), TxLocalSubmissionHistory (..) )
-import Cardano.Wallet.DB.Store.Transactions.Decoration
 import Cardano.Wallet.DB.Store.Transactions.Model
-    ( TxRelation (..)
-    , TxSet (..)
-    , fromTxCollateralOut
-    , fromTxOut
-    , mkTxSet
-    , txCBORPrism
-    )
-import Cardano.Wallet.Primitive.Slotting
-    ( TimeInterpreter, interpretQuery, slotToUTCTime )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( TxCBOR, TxMeta (..) )
+    ( TxSet (..), mkTxSet )
 import Data.Delta
     ( Delta (..) )
 import Data.DeltaMap
@@ -53,29 +37,19 @@ import Data.Foldable
     ( toList )
 import Data.Function
     ( (&) )
-import Data.Functor
-    ( (<&>) )
 import Data.Generics.Internal.VL
     ( over, view, (^.) )
 import Data.Map.Strict
     ( Map )
-import Data.Quantity
-    ( Quantity (..) )
 import Data.Set
     ( Set )
 import Fmt
     ( Buildable, build )
 
-import qualified Cardano.Wallet.DB.Sqlite.Schema as DB
 import qualified Cardano.Wallet.DB.Store.Meta.Model as TxMetaStore
 import qualified Cardano.Wallet.DB.Store.Transactions.Model as TxStore
 import qualified Cardano.Wallet.Primitive.Types as W
-import qualified Cardano.Wallet.Primitive.Types.Coin as WC
 import qualified Cardano.Wallet.Primitive.Types.Tx as WT
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as WT
-    ( TxIn (TxIn) )
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as WT.TxIn
-import qualified Data.Generics.Internal.VL as L
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
@@ -150,65 +124,3 @@ linkedTransactions (TxMetaHistory m,_) = Map.keysSet m
 walletsLinkedTransactions
     :: Map W.WalletId MetasAndSubmissionsHistory -> Set TxId
 walletsLinkedTransactions = Set.unions . toList . fmap linkedTransactions
-
--- | Compute a high level view of a transaction known as 'TransactionInfo'
--- from a 'TxMeta' and a 'TxRelation'.
--- Assumes that these data refer to the same 'TxId', does /not/ check this.
-mkTransactionInfo :: Monad m
-    => TimeInterpreter m
-    -> W.BlockHeader
-    -> TxRelation
-    -> DecoratedTxIns
-    -> DB.TxMeta
-    -> m WT.TransactionInfo
-mkTransactionInfo ti tip TxRelation{..} decor DB.TxMeta{..} = do
-    txTime <- interpretQuery ti . slotToUTCTime $ txMetaSlot
-    return
-        $ WT.TransactionInfo
-        { WT.txInfoId = getTxId txMetaTxId
-        , WT.txInfoCBOR = cbor >>= mkTxCBOR
-        , WT.txInfoFee = WC.Coin . fromIntegral <$> txMetaFee
-        , WT.txInfoInputs = mkTxIn <$> ins
-        , WT.txInfoCollateralInputs = mkTxCollateral <$> collateralIns
-        , WT.txInfoOutputs = fromTxOut <$> outs
-        , WT.txInfoCollateralOutput = fromTxCollateralOut <$> collateralOuts
-        , WT.txInfoWithdrawals = Map.fromList $ map mkTxWithdrawal withdrawals
-        , WT.txInfoMeta = WT.TxMeta
-              { WT.status = txMetaStatus
-              , WT.direction = txMetaDirection
-              , WT.slotNo = txMetaSlot
-              , WT.blockHeight = Quantity (txMetaBlockHeight)
-              , amount = txMetaAmount
-              , WT.expiry = txMetaSlotExpires
-              }
-        , WT.txInfoMetadata = txMetadata
-        , WT.txInfoDepth = Quantity
-              $ fromIntegral
-              $ if tipH > txMetaBlockHeight
-                  then tipH - txMetaBlockHeight
-                  else 0
-        , WT.txInfoTime = txTime
-        , WT.txInfoScriptValidity = txMetaScriptValidity <&> \case
-              False -> WT.TxScriptInvalid
-              True -> WT.TxScriptValid
-        }
-  where
-    tipH = getQuantity $ tip ^. #blockHeight
-    mkTxIn tx =
-        ( WT.TxIn
-          { inputId = getTxId (txInputSourceTxId tx)
-          , inputIx = txInputSourceIndex tx
-          }
-        , lookupTxOutForTxIn tx decor
-        )
-    mkTxCollateral tx =
-        ( WT.TxIn
-          { inputId = getTxId (txCollateralSourceTxId tx)
-          , inputIx = txCollateralSourceIndex tx
-          }
-        , lookupTxOutForTxCollateral tx decor
-        )
-    mkTxWithdrawal w = (txWithdrawalAccount w, txWithdrawalAmount w)
-
-mkTxCBOR :: DB.CBOR -> Maybe TxCBOR
-mkTxCBOR = either (const Nothing) (Just . snd) . L.match txCBORPrism

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Allegra.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Allegra.hs
@@ -39,8 +39,10 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     ( fromAllegraTxOut )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
+    ( fromShelleyWdrl )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyMD, fromShelleyWdrl )
+    ( fromShelleyMD )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Allegra.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Allegra.hs
@@ -35,14 +35,14 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
     ( fromShelleyCoin )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromShelleyTxIn )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Metadata
+    ( fromAllegraMetadata )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     ( fromAllegraTxOut )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
     ( fromShelleyWdrl )
-import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyMD )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR
@@ -65,7 +65,6 @@ import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Ledger.BaseTypes as SL
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Ledger.Shelley.Tx as SL
-import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
 import qualified Cardano.Ledger.ShelleyMA.TxBody as MA
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
@@ -104,7 +103,7 @@ fromAllegraTx tx =
         , withdrawals =
             fromShelleyWdrl wdrls
         , metadata =
-            fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mmd
+            fromAllegraMetadata <$> SL.strictMaybeToMaybe mmd
         , scriptValidity =
             Nothing
         }
@@ -122,8 +121,3 @@ fromAllegraTx tx =
         (fromIntegral $ Set.size $ SL.addrWits wits)
         (Map.elems scriptMap)
         (fromIntegral $ Set.size $ SL.bootWits wits)
-
-    -- fixme: [ADP-525] It is fine for now since we do not look at script
-    -- pre-images. But this is precisely what we want as part of the
-    -- multisig/script balance reporting.
-    toSLMetadata (MA.AuxiliaryData blob _scripts) = SL.Metadata blob

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Allegra.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Allegra.hs
@@ -35,10 +35,12 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
     ( fromShelleyCoin )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromShelleyTxIn )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
+    ( fromAllegraTxOut )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyMD, fromShelleyTxOut, fromShelleyWdrl )
+    ( fromShelleyMD, fromShelleyWdrl )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR
@@ -68,7 +70,6 @@ import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-
 -- NOTE: For resolved inputs we have to pass in a dummy value of 0.
 
 fromAllegraTx
@@ -94,7 +95,7 @@ fromAllegraTx tx =
             -- TODO: (ADP-957)
             []
         , outputs =
-            map fromShelleyTxOut (toList outs)
+            map fromAllegraTxOut (toList outs)
         , collateralOutput =
             -- Collateral outputs are not supported in Allegra.
             Nothing

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Allegra.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Allegra.hs
@@ -31,12 +31,14 @@ import Cardano.Wallet.Read.Eras
     ( allegra, inject )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
     ( anyEraCerts )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
+    ( fromShelleyCoin )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromShelleyTxIn )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyCoin, fromShelleyMD, fromShelleyTxOut, fromShelleyWdrl )
+    ( fromShelleyMD, fromShelleyTxOut, fromShelleyWdrl )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Allegra.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Allegra.hs
@@ -31,15 +31,12 @@ import Cardano.Wallet.Read.Eras
     ( allegra, inject )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
     ( anyEraCerts )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
+    ( fromShelleyTxIn )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyCoin
-    , fromShelleyMD
-    , fromShelleyTxIn
-    , fromShelleyTxOut
-    , fromShelleyWdrl
-    )
+    ( fromShelleyCoin, fromShelleyMD, fromShelleyTxOut, fromShelleyWdrl )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Alonzo.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Alonzo.hs
@@ -32,12 +32,11 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromShelleyTxIn )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Mint
     ( alonzoMint )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
+    ( fromAlonzoTxOut )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
-import Cardano.Wallet.Read.Primitive.Tx.Mary
-    ( fromCardanoValue )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyAddress, fromShelleyMD, fromShelleyWdrl )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR
@@ -64,12 +63,10 @@ import Ouroboros.Consensus.Cardano.Block
     ( StandardAlonzo )
 
 import qualified Cardano.Api.Shelley as Cardano
-import qualified Cardano.Ledger.Alonzo as Alonzo
 import qualified Cardano.Ledger.Alonzo.Data as Alonzo
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
-import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxWitness as Alonzo
 import qualified Cardano.Ledger.BaseTypes as SL
 import qualified Cardano.Ledger.Core as SL.Core
@@ -78,8 +75,6 @@ import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
-    ( TxOut (TxOut) )
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
@@ -164,12 +159,6 @@ fromAlonzoTx tx@(Alonzo.ValidatedTx bod wits (Alonzo.IsValid isValid) aux) witCt
         toPlutusVer Alonzo.PlutusV1 = PlutusVersionV1
         toPlutusVer Alonzo.PlutusV2 = PlutusVersionV2
 
-    fromAlonzoTxOut
-        :: Alonzo.TxOut (Cardano.ShelleyLedgerEra AlonzoEra)
-        -> W.TxOut
-    fromAlonzoTxOut (Alonzo.TxOut addr value _) =
-        W.TxOut (fromShelleyAddress addr) $
-        fromCardanoValue $ Cardano.fromMaryValue value
 
     toSLMetadata (Alonzo.AuxiliaryData blob _scripts) = SL.Metadata blob
 
@@ -177,3 +166,4 @@ fromAlonzoTx tx@(Alonzo.ValidatedTx bod wits (Alonzo.IsValid isValid) aux) witCt
         if isValid
         then Just W.TxScriptValid
         else Just W.TxScriptInvalid
+

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Alonzo.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Alonzo.hs
@@ -26,6 +26,8 @@ import Cardano.Wallet.Read.Eras
     ( alonzo, inject )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
     ( anyEraCerts )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
+    ( fromShelleyTxIn )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Mint
     ( alonzoMint )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
@@ -33,12 +35,7 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
 import Cardano.Wallet.Read.Primitive.Tx.Mary
     ( fromCardanoValue )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyAddress
-    , fromShelleyCoin
-    , fromShelleyMD
-    , fromShelleyTxIn
-    , fromShelleyWdrl
-    )
+    ( fromShelleyAddress, fromShelleyCoin, fromShelleyMD, fromShelleyWdrl )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Alonzo.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Alonzo.hs
@@ -26,6 +26,8 @@ import Cardano.Wallet.Read.Eras
     ( alonzo, inject )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
     ( anyEraCerts )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
+    ( fromShelleyCoin )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromShelleyTxIn )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Mint
@@ -35,7 +37,7 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
 import Cardano.Wallet.Read.Primitive.Tx.Mary
     ( fromCardanoValue )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyAddress, fromShelleyCoin, fromShelleyMD, fromShelleyWdrl )
+    ( fromShelleyAddress, fromShelleyMD, fromShelleyWdrl )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Alonzo.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Alonzo.hs
@@ -30,6 +30,8 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
     ( fromShelleyCoin )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromShelleyTxIn )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Metadata
+    ( fromAlonzoMetadata )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Mint
     ( alonzoMint )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
@@ -38,8 +40,6 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
     ( fromShelleyWdrl )
-import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyMD )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR
@@ -66,7 +66,6 @@ import Ouroboros.Consensus.Cardano.Block
     ( StandardAlonzo )
 
 import qualified Cardano.Api.Shelley as Cardano
-import qualified Cardano.Ledger.Alonzo.Data as Alonzo
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
@@ -111,7 +110,7 @@ fromAlonzoTx tx@(Alonzo.ValidatedTx bod wits (Alonzo.IsValid isValid) aux) witCt
         , withdrawals =
             fromShelleyWdrl wdrls
         , metadata =
-            fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe aux
+            fromAlonzoMetadata<$> SL.strictMaybeToMaybe aux
         , scriptValidity =
             validity
         }
@@ -163,7 +162,6 @@ fromAlonzoTx tx@(Alonzo.ValidatedTx bod wits (Alonzo.IsValid isValid) aux) witCt
         toPlutusVer Alonzo.PlutusV2 = PlutusVersionV2
 
 
-    toSLMetadata (Alonzo.AuxiliaryData blob _scripts) = SL.Metadata blob
 
     validity =
         if isValid

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Alonzo.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Alonzo.hs
@@ -36,7 +36,10 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     ( fromAlonzoTxOut )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
+    ( fromShelleyWdrl )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
+    ( fromShelleyMD )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Babbage.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Babbage.hs
@@ -39,8 +39,10 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     ( fromBabbageTxOut )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
+    ( fromShelleyWdrl )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyMD, fromShelleyWdrl )
+    ( fromShelleyMD )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Babbage.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Babbage.hs
@@ -35,12 +35,12 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromShelleyTxIn )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Mint
     ( babbageMint )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
+    ( fromBabbageTxOut )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
-import Cardano.Wallet.Read.Primitive.Tx.Mary
-    ( fromCardanoValue )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyAddress, fromShelleyMD, fromShelleyWdrl )
+    ( fromShelleyMD, fromShelleyWdrl )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR
@@ -73,7 +73,6 @@ import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxWitness as Alonzo
-import qualified Cardano.Ledger.Babbage as Babbage
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import qualified Cardano.Ledger.BaseTypes as SL
 import qualified Cardano.Ledger.Core as SL.Core
@@ -82,8 +81,6 @@ import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
-    ( TxOut (TxOut) )
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
@@ -172,12 +169,6 @@ fromBabbageTx tx@(Alonzo.ValidatedTx bod wits (Alonzo.IsValid isValid) aux) witC
         toPlutusVer Alonzo.PlutusV1 = PlutusVersionV1
         toPlutusVer Alonzo.PlutusV2 = PlutusVersionV2
 
-    fromBabbageTxOut
-        :: Babbage.TxOut (Cardano.ShelleyLedgerEra BabbageEra)
-        -> W.TxOut
-    fromBabbageTxOut (Babbage.TxOut addr value _datum _refScript) =
-        W.TxOut (fromShelleyAddress addr) $
-        fromCardanoValue $ Cardano.fromMaryValue value
 
     toSLMetadata (Alonzo.AuxiliaryData blob _scripts) = SL.Metadata blob
 
@@ -185,3 +176,4 @@ fromBabbageTx tx@(Alonzo.ValidatedTx bod wits (Alonzo.IsValid isValid) aux) witC
         if isValid
         then Just W.TxScriptValid
         else Just W.TxScriptInvalid
+

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Babbage.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Babbage.hs
@@ -29,18 +29,15 @@ import Cardano.Wallet.Read.Eras
     ( babbage, inject )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
     ( anyEraCerts )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
+    ( fromShelleyTxIn )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Mint
     ( babbageMint )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
 import Cardano.Wallet.Read.Primitive.Tx.Mary
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyAddress
-    , fromShelleyCoin
-    , fromShelleyMD
-    , fromShelleyTxIn
-    , fromShelleyWdrl
-    )
+    ( fromShelleyAddress, fromShelleyCoin, fromShelleyMD, fromShelleyWdrl )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Babbage.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Babbage.hs
@@ -33,6 +33,8 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
     ( fromShelleyCoin )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromShelleyTxIn )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Metadata
+    ( fromBabbageMetadata )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Mint
     ( babbageMint )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
@@ -41,8 +43,6 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
     ( fromShelleyWdrl )
-import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyMD )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR
@@ -70,7 +70,6 @@ import Ouroboros.Consensus.Cardano.Block
     ( StandardBabbage )
 
 import qualified Cardano.Api.Shelley as Cardano
-import qualified Cardano.Ledger.Alonzo.Data as Alonzo
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
@@ -117,7 +116,7 @@ fromBabbageTx tx@(Alonzo.ValidatedTx bod wits (Alonzo.IsValid isValid) aux) witC
         , withdrawals =
             fromShelleyWdrl wdrls
         , metadata =
-            fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe aux
+            fromBabbageMetadata <$> SL.strictMaybeToMaybe aux
         , scriptValidity =
             validity
         }
@@ -171,8 +170,6 @@ fromBabbageTx tx@(Alonzo.ValidatedTx bod wits (Alonzo.IsValid isValid) aux) witC
         toPlutusVer Alonzo.PlutusV1 = PlutusVersionV1
         toPlutusVer Alonzo.PlutusV2 = PlutusVersionV2
 
-
-    toSLMetadata (Alonzo.AuxiliaryData blob _scripts) = SL.Metadata blob
 
     validity =
         if isValid

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Babbage.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Babbage.hs
@@ -29,6 +29,8 @@ import Cardano.Wallet.Read.Eras
     ( babbage, inject )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
     ( anyEraCerts )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
+    ( fromShelleyCoin )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromShelleyTxIn )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Mint
@@ -36,8 +38,9 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Mint
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
 import Cardano.Wallet.Read.Primitive.Tx.Mary
+    ( fromCardanoValue )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyAddress, fromShelleyCoin, fromShelleyMD, fromShelleyWdrl )
+    ( fromShelleyAddress, fromShelleyMD, fromShelleyWdrl )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Byron.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Byron.hs
@@ -8,7 +8,6 @@
 
 module Cardano.Wallet.Read.Primitive.Tx.Byron
     ( fromTxAux
-    , fromTxIn
     , fromTxOut
     )
     where
@@ -20,9 +19,11 @@ import Cardano.Binary
 import Cardano.Chain.Common
     ( unsafeGetLovelace )
 import Cardano.Chain.UTxO
-    ( ATxAux (..), Tx (..), TxIn (..), TxOut (..), taTx )
+    ( ATxAux (..), Tx (..), TxOut (..), taTx )
 import Cardano.Wallet.Read.Eras
     ( byron, inject )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
+    ( fromByronTxIn )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR
@@ -32,15 +33,11 @@ import Cardano.Wallet.Read.Tx.Hash
 import Control.Monad
     ( void )
 
-import qualified Cardano.Crypto.Hashing as CC
 import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
-    ( TxIn (TxIn) )
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W.TxIn
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (TxOut) )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
@@ -57,7 +54,7 @@ fromTxAux txAux = case taTx txAux of
 
         -- TODO: Review 'W.Tx' to not require resolved inputs but only inputs
         , resolvedInputs =
-            (, Nothing) . fromTxIn <$> NE.toList inputs
+            (, Nothing) . fromByronTxIn <$> NE.toList inputs
 
         , resolvedCollateralInputs = []
 
@@ -76,12 +73,6 @@ fromTxAux txAux = case taTx txAux of
         , scriptValidity =
             Nothing
         }
-
-fromTxIn :: TxIn -> W.TxIn
-fromTxIn (TxInUtxo id_ ix) = W.TxIn
-    { inputId = W.Hash $ CC.hashToBytes id_
-    , inputIx = fromIntegral ix
-    }
 
 fromTxOut :: TxOut -> W.TxOut
 fromTxOut (TxOut addr coin) = W.TxOut

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Byron.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Byron.hs
@@ -8,22 +8,19 @@
 
 module Cardano.Wallet.Read.Primitive.Tx.Byron
     ( fromTxAux
-    , fromTxOut
     )
     where
 
 import Prelude
 
-import Cardano.Binary
-    ( serialize' )
-import Cardano.Chain.Common
-    ( unsafeGetLovelace )
 import Cardano.Chain.UTxO
-    ( ATxAux (..), Tx (..), TxOut (..), taTx )
+    ( ATxAux (..), Tx (..), taTx )
 import Cardano.Wallet.Read.Eras
     ( byron, inject )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromByronTxIn )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
+    ( fromByronTxOut )
 import Cardano.Wallet.Read.Tx
     ( Tx (..) )
 import Cardano.Wallet.Read.Tx.CBOR
@@ -33,14 +30,8 @@ import Cardano.Wallet.Read.Tx.Hash
 import Control.Monad
     ( void )
 
-import qualified Cardano.Wallet.Primitive.Types.Address as W
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
-    ( TxOut (TxOut) )
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Data.List.NonEmpty as NE
 
 fromTxAux :: ATxAux a -> W.Tx
@@ -59,7 +50,7 @@ fromTxAux txAux = case taTx txAux of
         , resolvedCollateralInputs = []
 
         , outputs =
-            fromTxOut <$> NE.toList outputs
+            fromByronTxOut <$> NE.toList outputs
 
         , collateralOutput =
             Nothing
@@ -73,9 +64,3 @@ fromTxAux txAux = case taTx txAux of
         , scriptValidity =
             Nothing
         }
-
-fromTxOut :: TxOut -> W.TxOut
-fromTxOut (TxOut addr coin) = W.TxOut
-    { address = W.Address (serialize' addr)
-    , tokens = TokenBundle.fromCoin $ Coin.fromWord64 $ unsafeGetLovelace coin
-    }

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/CollateralInputs.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/CollateralInputs.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Wallet.Read.Primitive.Tx.Features.CollateralInputs
+    ( getCollateralInputs
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..), K (..) )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
+    ( fromShelleyTxIns )
+import Cardano.Wallet.Read.Tx.CollateralInputs
+    ( CollateralInputs (..), CollateralInputsType )
+
+import qualified Cardano.Ledger.Shelley.API as SH
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
+
+getCollateralInputs :: EraFun CollateralInputs (K [W.TxIn])
+getCollateralInputs = EraFun
+    { byronFun = \_ -> K []
+    , shelleyFun = \_ -> K []
+    , allegraFun = \_ -> K []
+    , maryFun = \_ -> K []
+    , alonzoFun = mkShelleyTxCollateralInputsIns
+    , babbageFun = mkShelleyTxCollateralInputsIns
+    }
+
+mkShelleyTxCollateralInputsIns
+    :: (Foldable t, CollateralInputsType era ~ t (SH.TxIn crypto))
+    => CollateralInputs era -- ^
+  -> K [W.TxIn] b
+mkShelleyTxCollateralInputsIns (CollateralInputs ins) = fromShelleyTxIns ins

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/CollateralOutputs.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/CollateralOutputs.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Wallet.Read.Primitive.Tx.Features.CollateralOutputs
+    ( getCollateralOutputs
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..), K (..) )
+import Cardano.Wallet.Read.Primitive.Tx.Mary
+    ( fromCardanoValue )
+import Cardano.Wallet.Read.Primitive.Tx.Shelley
+    ( fromShelleyAddress )
+import Cardano.Wallet.Read.Tx.CollateralOutputs
+    ( CollateralOutputs (..) )
+import Data.Maybe.Strict
+    ( strictMaybeToMaybe )
+import Ouroboros.Consensus.Shelley.Eras
+    ( StandardBabbage )
+
+import qualified Cardano.Api.Shelley as Cardano
+import qualified Cardano.Ledger.Babbage as Babbage
+import qualified Cardano.Ledger.Babbage.TxBody as Babbage
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+
+getCollateralOutputs :: EraFun CollateralOutputs (K (Maybe W.TxOut))
+getCollateralOutputs = EraFun
+    { byronFun = \_ -> K Nothing
+    , shelleyFun = \_ -> K Nothing
+    , allegraFun = \_ -> K Nothing
+    , maryFun = \_ -> K Nothing
+    , alonzoFun = \_ -> K Nothing
+    , babbageFun = \(CollateralOutputs mo)
+        -> K $ fromBabbageTxOut <$> strictMaybeToMaybe mo
+    }
+
+fromBabbageTxOut
+    :: Babbage.TxOut StandardBabbage
+    -> W.TxOut
+fromBabbageTxOut (Babbage.TxOut addr value _datum _refScript) =
+    W.TxOut (fromShelleyAddress addr) $
+    fromCardanoValue $ Cardano.fromMaryValue value

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/CollateralOutputs.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/CollateralOutputs.hs
@@ -9,10 +9,8 @@ import Prelude
 
 import Cardano.Wallet.Read.Eras
     ( EraFun (..), K (..) )
-import Cardano.Wallet.Read.Primitive.Tx.Mary
-    ( fromCardanoValue )
-import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyAddress )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
+    ( fromCardanoValue, fromShelleyAddress )
 import Cardano.Wallet.Read.Tx.CollateralOutputs
     ( CollateralOutputs (..) )
 import Data.Maybe.Strict

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Fee.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Fee.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Wallet.Read.Primitive.Tx.Features.Fee
+    ( getFee
+    , fromShelleyCoin
+    )
+    where
+
+import Prelude
+
+import Cardano.Ledger.Coin
+    ( Coin )
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..), K (..) )
+import Cardano.Wallet.Read.Tx.Fee
+    ( Fee (..), FeeType )
+
+import qualified Cardano.Ledger.Coin as SL
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+
+getFee :: EraFun Fee (K (Maybe W.Coin))
+getFee = EraFun
+    { byronFun = \_ -> K Nothing
+    , shelleyFun = mkShelleyTxFee
+    , allegraFun = mkShelleyTxFee
+    , maryFun = mkShelleyTxFee
+    , alonzoFun = mkShelleyTxFee
+    , babbageFun = mkShelleyTxFee
+    }
+
+mkShelleyTxFee :: (FeeType era ~ Coin)
+    => Fee era -- ^
+    -> K (Maybe W.Coin) b
+mkShelleyTxFee (Fee c) = K $ Just $ fromShelleyCoin c
+
+fromShelleyCoin :: SL.Coin -> W.Coin
+fromShelleyCoin (SL.Coin c) = Coin.unsafeFromIntegral c

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Inputs.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Inputs.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
+    ( getInputs
+    , fromByronTxIn
+    , fromShelleyTxIns
+    , fromShelleyTxIn
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..), K (..) )
+import Cardano.Wallet.Read.Tx.Hash
+    ( fromShelleyTxId )
+import Cardano.Wallet.Read.Tx.Inputs
+    ( Inputs (..), InputsType )
+import Data.Foldable
+    ( toList )
+import Data.Word
+    ( Word16, Word32, Word64 )
+
+import qualified Cardano.Chain.UTxO as BY
+import qualified Cardano.Crypto.Hashing as CC
+import qualified Cardano.Ledger.BaseTypes as SL
+import qualified Cardano.Ledger.Shelley.API as SH
+import qualified Cardano.Ledger.TxIn as SL
+import qualified Cardano.Wallet.Primitive.Types.Hash as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
+
+getInputs :: EraFun Inputs (K [W.TxIn])
+getInputs = EraFun
+    { byronFun = \(Inputs ins) -> K . fmap fromByronTxIn $ toList ins
+    , shelleyFun = mkShelleyTxInputsIns
+    , allegraFun = mkShelleyTxInputsIns
+    , maryFun = mkShelleyTxInputsIns
+    , alonzoFun = mkShelleyTxInputsIns
+    , babbageFun = mkShelleyTxInputsIns
+    }
+
+fromShelleyTxIns :: Foldable t => (t (SH.TxIn crypto)) -> K [W.TxIn] b
+fromShelleyTxIns ins = K . fmap fromShelleyTxIn $ toList ins
+
+mkShelleyTxInputsIns :: (Foldable t, InputsType era ~ t (SH.TxIn crypto))
+    => Inputs era -- ^
+  -> K [W.TxIn] b
+mkShelleyTxInputsIns (Inputs ins) = fromShelleyTxIns ins
+
+fromByronTxIn :: BY.TxIn -> W.TxIn
+fromByronTxIn (BY.TxInUtxo id_ ix) = W.TxIn
+    { inputId = W.Hash $ CC.hashToBytes id_
+    , inputIx = fromIntegral ix
+    }
+
+fromShelleyTxIn
+    :: SL.TxIn crypto
+    -> W.TxIn
+fromShelleyTxIn (SL.TxIn txid (SL.TxIx ix)) =
+    W.TxIn (W.Hash $ fromShelleyTxId txid) (unsafeCast ix)
+  where
+    -- During the Vasil hard-fork the cardano-ledger team moved from
+    -- representing transaction indices with Word16s, to using Word64s (see
+    -- commit
+    -- https://github.com/input-output-hk/cardano-ledger/commit/4097a9055e6ea57161755e6a8cbfcf719b65e9ab).
+    -- However, the valid range is still 0 <= x <= (maxBound :: Word16), so we
+    -- reflect that here.
+    unsafeCast :: Word64 -> Word32
+    unsafeCast txIx =
+        if txIx > fromIntegral (maxBound :: Word16)
+        then error $ "Value for wallet TxIx is out of a valid range: " <> show txIx
+        else fromIntegral txIx

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Metadata.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Metadata.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+-- Copyright: © 2020 IOHK
+-- License: Apache-2.0
+--
+
+module Cardano.Wallet.Read.Primitive.Tx.Features.Metadata
+    ( getMetadata
+    , fromShelleyMetadata
+    , fromAllegraMetadata
+    , fromMaryMetadata
+    , fromAlonzoMetadata
+    , fromBabbageMetadata
+    )
+    where
+
+import Prelude
+
+import Cardano.Ledger.BaseTypes
+    ( strictMaybeToMaybe )
+import Cardano.Ledger.Core
+    ( AuxiliaryData )
+import Cardano.Ledger.ShelleyMA
+    ( MaryOrAllegra (..), ShelleyMAEra )
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..), K (..) )
+import Cardano.Wallet.Read.Tx.Metadata
+    ( Metadata (..) )
+import Ouroboros.Consensus.Shelley.Eras
+    ( AlonzoEra, BabbageEra, StandardCrypto )
+
+import qualified Cardano.Api.Shelley as Cardano
+import qualified Cardano.Api.Shelley as CardanoAPI
+import qualified Cardano.Ledger.Alonzo.Data as AL
+import qualified Cardano.Ledger.Shelley.API as SL
+import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
+import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W
+
+getMetadata :: EraFun Metadata (K (Maybe (W.TxMetadata) ))
+getMetadata = EraFun
+    { byronFun = noMetadatas
+    , shelleyFun = yesMetadata fromShelleyMetadata
+    , allegraFun = yesMetadata fromAllegraMetadata
+    , maryFun = yesMetadata  fromMaryMetadata
+    , alonzoFun = yesMetadata fromAlonzoMetadata
+    , babbageFun = yesMetadata fromBabbageMetadata
+    }
+    where
+        noMetadatas _ = K Nothing
+        yesMetadata f (Metadata s) = K . fmap f $ strictMaybeToMaybe s
+
+fromShelleyMetadata :: SL.Metadata c ->  W.TxMetadata
+fromShelleyMetadata (SL.Metadata m) =
+    Cardano.makeTransactionMetadata . CardanoAPI.fromShelleyMetadata $ m
+
+-- fixme: [ADP-525] It is fine for now since we do not look at script
+-- pre-images. But this is precisely what we want as part of the
+-- multisig/script balance reporting.
+fromAllegraMetadata :: AuxiliaryData (ShelleyMAEra 'Allegra StandardCrypto)
+    -> W.TxMetadata
+fromAllegraMetadata (MA.AuxiliaryData blob _scripts)
+    = fromShelleyMetadata $ SL.Metadata blob
+
+fromMaryMetadata :: AuxiliaryData (ShelleyMAEra 'Mary StandardCrypto)
+    -> W.TxMetadata
+fromMaryMetadata (MA.AuxiliaryData blob _scripts)
+    = fromShelleyMetadata $ SL.Metadata blob
+
+fromAlonzoMetadata :: AuxiliaryData (AlonzoEra StandardCrypto) -> W.TxMetadata
+fromAlonzoMetadata (AL.AuxiliaryData blob _scripts)
+    = fromShelleyMetadata $ SL.Metadata blob
+
+fromBabbageMetadata :: AuxiliaryData (BabbageEra StandardCrypto) -> W.TxMetadata
+fromBabbageMetadata (AL.AuxiliaryData blob _scripts)
+    = fromShelleyMetadata $ SL.Metadata blob

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Outputs.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Outputs.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
+    ( getOutputs
+    , fromShelleyTxOut
+    , fromMaryTxOut
+    , fromAllegraTxOut
+    , fromAlonzoTxOut
+    , fromBabbageTxOut
+    , fromCardanoValue
+    , fromShelleyAddress
+    , fromByronTxOut
+    )
+    where
+
+import Prelude
+
+import Cardano.Binary
+    ( serialize' )
+import Cardano.Chain.Common
+    ( unsafeGetLovelace )
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..), K (..) )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
+    ( fromShelleyCoin )
+import Cardano.Wallet.Read.Tx.Outputs
+    ( Outputs (..) )
+import Cardano.Wallet.Util
+    ( internalError )
+import Data.Foldable
+    ( toList )
+import GHC.Stack
+    ( HasCallStack )
+import Ouroboros.Consensus.Shelley.Eras
+    ( StandardAllegra
+    , StandardAlonzo
+    , StandardBabbage
+    , StandardMary
+    , StandardShelley
+    )
+
+import qualified Cardano.Api.Shelley as Cardano
+import qualified Cardano.Chain.UTxO as Byron
+import qualified Cardano.Ledger.Address as SL
+import qualified Cardano.Ledger.Alonzo as Alonzo
+import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo
+import qualified Cardano.Ledger.Babbage as Babbage
+import qualified Cardano.Ledger.Babbage.TxBody as Babbage
+import qualified Cardano.Ledger.Shelley.API as SL
+import qualified Cardano.Wallet.Primitive.Types.Address as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+import qualified Cardano.Wallet.Primitive.Types.Hash as W
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
+import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+
+getOutputs :: EraFun Outputs (K [W.TxOut])
+getOutputs = EraFun
+    { byronFun = \(Outputs os) -> K . fmap fromByronTxOut $ toList os
+    , shelleyFun = \(Outputs os) -> K . fmap fromShelleyTxOut $ toList os
+    , allegraFun = \(Outputs os) -> K . fmap fromAllegraTxOut $ toList os
+    , maryFun = \(Outputs os) -> K . fmap fromMaryTxOut $ toList os
+    , alonzoFun = \(Outputs os) -> K . fmap fromAlonzoTxOut $ toList os
+    , babbageFun = \(Outputs os) -> K . fmap fromBabbageTxOut $ toList os
+    }
+
+fromShelleyAddress :: SL.Addr crypto -> W.Address
+fromShelleyAddress = W.Address . SL.serialiseAddr
+
+fromShelleyTxOut :: SL.TxOut StandardShelley -> W.TxOut
+fromShelleyTxOut (SL.TxOut addr amount) = W.TxOut
+    (fromShelleyAddress addr)
+    (TokenBundle.fromCoin $ fromShelleyCoin amount)
+
+fromAllegraTxOut :: SL.TxOut StandardAllegra -> W.TxOut
+fromAllegraTxOut (SL.TxOut addr amount) = W.TxOut
+    (fromShelleyAddress addr)
+    (TokenBundle.fromCoin $ fromShelleyCoin amount)
+
+fromMaryTxOut :: SL.TxOut StandardMary -> W.TxOut
+fromMaryTxOut (SL.TxOut addr value) =
+    W.TxOut (fromShelleyAddress addr) $
+    fromCardanoValue $ Cardano.fromMaryValue value
+
+fromAlonzoTxOut
+    :: Alonzo.TxOut StandardAlonzo
+    -> W.TxOut
+fromAlonzoTxOut (Alonzo.TxOut addr value _) =
+    W.TxOut (fromShelleyAddress addr) $
+    fromCardanoValue $ Cardano.fromMaryValue value
+
+fromBabbageTxOut
+    :: Babbage.TxOut StandardBabbage
+    -> W.TxOut
+fromBabbageTxOut (Babbage.TxOut addr value _datum _refScript) =
+    W.TxOut (fromShelleyAddress addr) $
+    fromCardanoValue $ Cardano.fromMaryValue value
+
+-- Lovelace to coin. Quantities from ledger should always fit in Word64.
+fromCardanoLovelace :: HasCallStack => Cardano.Lovelace -> W.Coin
+fromCardanoLovelace =
+    Coin.unsafeFromIntegral . unQuantity . Cardano.lovelaceToQuantity
+  where
+    unQuantity (Cardano.Quantity q) = q
+
+fromCardanoValue :: HasCallStack => Cardano.Value -> TokenBundle.TokenBundle
+fromCardanoValue = uncurry TokenBundle.fromFlatList . extract
+  where
+    extract value =
+        ( fromCardanoLovelace $ Cardano.selectLovelace value
+        , mkBundle $ Cardano.valueToList value
+        )
+
+    -- Do Integer to Natural conversion. Quantities from ledger TxOuts can
+    -- never be negative (but unminted values could be negative).
+    mkQuantity :: Integer -> W.TokenQuantity
+    mkQuantity = W.TokenQuantity . checkBounds
+      where
+        checkBounds n
+          | n >= 0 = fromIntegral n
+          | otherwise = internalError "negative token quantity"
+
+    mkBundle assets =
+        [ (TokenBundle.AssetId (mkPolicyId p) (mkTokenName n) , mkQuantity q)
+        | (Cardano.AssetId p n, Cardano.Quantity q) <- assets
+        ]
+
+    mkPolicyId = W.UnsafeTokenPolicyId . W.Hash . Cardano.serialiseToRawBytes
+    mkTokenName = W.UnsafeTokenName . Cardano.serialiseToRawBytes
+
+fromByronTxOut :: Byron.TxOut -> W.TxOut
+fromByronTxOut (Byron.TxOut addr coin) = W.TxOut
+    { W.address = W.Address (serialize' addr)
+    , W.tokens = TokenBundle.fromCoin $ Coin.fromWord64 $ unsafeGetLovelace coin
+    }

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/ScriptValidity.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/ScriptValidity.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+-- Copyright: © 2020 IOHK
+-- License: Apache-2.0
+--
+
+module Cardano.Wallet.Read.Primitive.Tx.Features.ScriptValidity
+    ( getScriptValidity
+    )
+    where
+
+import Prelude
+
+import Cardano.Ledger.Alonzo.Tx
+    ( IsValid (..) )
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..), K (..) )
+import Cardano.Wallet.Read.Tx.ScriptValidity
+    ( ScriptValidity (..) )
+
+import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W
+
+getScriptValidity :: EraFun ScriptValidity (K (Maybe (W.TxScriptValidity) ))
+getScriptValidity = EraFun
+    { byronFun = noScriptValidity
+    , shelleyFun = noScriptValidity
+    , allegraFun = noScriptValidity
+    , maryFun = noScriptValidity
+    , alonzoFun = yesScriptValidity
+    , babbageFun = yesScriptValidity
+    }
+    where
+        noScriptValidity _ = K Nothing
+        yesScriptValidity (ScriptValidity (IsValid b))
+            | b = K . Just $ W.TxScriptValid
+            | otherwise = K . Just $ W.TxScriptInvalid
+

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Validity.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Validity.hs
@@ -9,7 +9,7 @@
 --
 
 module Cardano.Wallet.Read.Primitive.Tx.Features.Validity
-    ( validity
+    ( getValidity
     , afterShelleyValidityInterval
     , shelleyValidityInterval
     )
@@ -29,8 +29,8 @@ import Data.Quantity
 import qualified Cardano.Ledger.ShelleyMA.TxBody as MA
 import qualified Ouroboros.Network.Block as O
 
-validity :: EraFun Validity (K (Maybe ValidityIntervalExplicit))
-validity = EraFun
+getValidity :: EraFun Validity (K (Maybe ValidityIntervalExplicit))
+getValidity = EraFun
     { byronFun = noValidity
     , shelleyFun = yesShelleyValidity
     , allegraFun = yesMaryValidity

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Withdrawals.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Withdrawals.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+-- Copyright: © 2020-2022 IOHK
+-- License: Apache-2.0
+--
+
+module Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
+    ( getWithdrawals
+    , fromShelleyWdrl
+    )
+    where
+
+import Prelude
+
+import Cardano.Ledger.Crypto
+    ( StandardCrypto )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin )
+import Cardano.Wallet.Primitive.Types.RewardAccount
+    ( RewardAccount )
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..), K (..) )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
+    ( fromStakeCredential )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
+    ( fromShelleyCoin )
+import Cardano.Wallet.Read.Tx.Withdrawals
+    ( Withdrawals (..) )
+import Data.Bifunctor
+    ( Bifunctor (..) )
+import Data.Map.Strict
+    ( Map )
+
+import qualified Cardano.Ledger.Shelley.TxBody as SL
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
+import qualified Data.Map.Strict as Map
+
+getWithdrawals :: EraFun Withdrawals (K (Maybe (Map RewardAccount Coin)))
+getWithdrawals = EraFun
+    { byronFun = noWithdrawals
+    , shelleyFun = yesWithdrawals
+    , allegraFun = yesWithdrawals
+    , maryFun = yesWithdrawals
+    , alonzoFun = yesWithdrawals
+    , babbageFun = yesWithdrawals
+    }
+    where
+        noWithdrawals = const $ K Nothing
+        yesWithdrawals (Withdrawals ttl)
+            = K . Just . fromShelleyWdrl $ ttl
+
+fromShelleyWdrl :: SL.Wdrl StandardCrypto -> Map W.RewardAccount W.Coin
+fromShelleyWdrl (SL.Wdrl wdrl) = Map.fromList $
+    bimap (fromStakeCredential . SL.getRwdCred) fromShelleyCoin
+        <$> Map.toList wdrl

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Mary.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Mary.hs
@@ -10,7 +10,6 @@
 
 module Cardano.Wallet.Read.Primitive.Tx.Mary
     ( fromMaryTx
-    , fromCardanoValue
     )
     where
 
@@ -26,14 +25,17 @@ import Cardano.Wallet.Read.Eras
     ( inject, mary )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
     ( anyEraCerts )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
+    ( fromShelleyCoin )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromShelleyTxIn )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Mint
     ( maryMint )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
+    ( fromMaryTxOut )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyAddress, fromShelleyCoin, fromShelleyMD, fromShelleyWdrl )
 import Cardano.Wallet.Read.Tx
     ( Tx (Tx) )
 import Cardano.Wallet.Read.Tx.CBOR
@@ -50,16 +52,11 @@ import Cardano.Wallet.Transaction
     , WitnessCountCtx
     , toKeyRole
     )
-import Cardano.Wallet.Util
-    ( internalError )
 import Data.Foldable
     ( toList )
 import Data.Map.Strict
     ( Map )
-import GHC.Stack
-    ( HasCallStack )
 
-import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Ledger.BaseTypes as SL
 import qualified Cardano.Ledger.Core as SL.Core
@@ -71,15 +68,8 @@ import qualified Cardano.Ledger.ShelleyMA as MA
 import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
 import qualified Cardano.Ledger.ShelleyMA.TxBody as MA
 import qualified Cardano.Wallet.Primitive.Types as W
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
-import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
-import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
-import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
-    ( TxOut (TxOut) )
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
@@ -137,14 +127,6 @@ fromMaryTx tx witCtx =
     -- pre-images. But this is precisely what we want as part of the
     -- multisig/script balance reporting.
     toSLMetadata (MA.AuxiliaryData blob _scripts) = SL.Metadata blob
-
-    fromMaryTxOut
-        :: SL.TxOut (Cardano.ShelleyLedgerEra MaryEra)
-        -> W.TxOut
-    fromMaryTxOut (SL.TxOut addr value) =
-        W.TxOut (fromShelleyAddress addr) $
-        fromCardanoValue $ Cardano.fromMaryValue value
-
     fromMaryScriptMap
         :: Map
             (SL.ScriptHash (Crypto (MA.ShelleyMAEra 'MA.Mary Crypto.StandardCrypto)))
@@ -153,35 +135,3 @@ fromMaryTx tx witCtx =
     fromMaryScriptMap =
         Map.map (NativeScript . toWalletScript (toKeyRole witCtx)) .
         Map.mapKeys (toWalletTokenPolicyId . SL.PolicyID)
-
--- Lovelace to coin. Quantities from ledger should always fit in Word64.
-fromCardanoLovelace :: HasCallStack => Cardano.Lovelace -> W.Coin
-fromCardanoLovelace =
-    Coin.unsafeFromIntegral . unQuantity . Cardano.lovelaceToQuantity
-  where
-    unQuantity (Cardano.Quantity q) = q
-
-fromCardanoValue :: HasCallStack => Cardano.Value -> TokenBundle.TokenBundle
-fromCardanoValue = uncurry TokenBundle.fromFlatList . extract
-  where
-    extract value =
-        ( fromCardanoLovelace $ Cardano.selectLovelace value
-        , mkBundle $ Cardano.valueToList value
-        )
-
-    -- Do Integer to Natural conversion. Quantities from ledger TxOuts can
-    -- never be negative (but unminted values could be negative).
-    mkQuantity :: Integer -> W.TokenQuantity
-    mkQuantity = W.TokenQuantity . checkBounds
-      where
-        checkBounds n
-          | n >= 0 = fromIntegral n
-          | otherwise = internalError "negative token quantity"
-
-    mkBundle assets =
-        [ (TokenBundle.AssetId (mkPolicyId p) (mkTokenName n) , mkQuantity q)
-        | (Cardano.AssetId p n, Cardano.Quantity q) <- assets
-        ]
-
-    mkPolicyId = W.UnsafeTokenPolicyId . W.Hash . Cardano.serialiseToRawBytes
-    mkTokenName = W.UnsafeTokenName . Cardano.serialiseToRawBytes

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Mary.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Mary.hs
@@ -35,7 +35,10 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     ( fromMaryTxOut )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
+    ( fromShelleyWdrl )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
+    ( fromShelleyMD )
 import Cardano.Wallet.Read.Tx
     ( Tx (Tx) )
 import Cardano.Wallet.Read.Tx.CBOR

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Mary.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Mary.hs
@@ -29,6 +29,8 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
     ( fromShelleyCoin )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromShelleyTxIn )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Metadata
+    ( fromMaryMetadata )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Mint
     ( maryMint )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
@@ -37,8 +39,6 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
     ( fromShelleyWdrl )
-import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyMD )
 import Cardano.Wallet.Read.Tx
     ( Tx (Tx) )
 import Cardano.Wallet.Read.Tx.CBOR
@@ -68,7 +68,6 @@ import qualified Cardano.Ledger.Mary.Value as SL
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Ledger.Shelley.Tx as Shelley
 import qualified Cardano.Ledger.ShelleyMA as MA
-import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
 import qualified Cardano.Ledger.ShelleyMA.TxBody as MA
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
@@ -106,7 +105,7 @@ fromMaryTx tx witCtx =
         , withdrawals =
             fromShelleyWdrl wdrls
         , metadata =
-            fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mad
+            fromMaryMetadata <$> SL.strictMaybeToMaybe mad
         , scriptValidity =
             Nothing
         }
@@ -126,10 +125,6 @@ fromMaryTx tx witCtx =
         (Map.elems scriptMap)
         (fromIntegral $ Set.size $ Shelley.bootWits wits)
 
-    -- fixme: [ADP-525] It is fine for now since we do not look at script
-    -- pre-images. But this is precisely what we want as part of the
-    -- multisig/script balance reporting.
-    toSLMetadata (MA.AuxiliaryData blob _scripts) = SL.Metadata blob
     fromMaryScriptMap
         :: Map
             (SL.ScriptHash (Crypto (MA.ShelleyMAEra 'MA.Mary Crypto.StandardCrypto)))

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Mary.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Mary.hs
@@ -26,17 +26,14 @@ import Cardano.Wallet.Read.Eras
     ( inject, mary )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
     ( anyEraCerts )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
+    ( fromShelleyTxIn )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Mint
     ( maryMint )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( afterShelleyValidityInterval )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyAddress
-    , fromShelleyCoin
-    , fromShelleyMD
-    , fromShelleyTxIn
-    , fromShelleyWdrl
-    )
+    ( fromShelleyAddress, fromShelleyCoin, fromShelleyMD, fromShelleyWdrl )
 import Cardano.Wallet.Read.Tx
     ( Tx (Tx) )
 import Cardano.Wallet.Read.Tx.CBOR

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Shelley.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Shelley.hs
@@ -10,8 +10,7 @@
 --
 
 module Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyWdrl
-    , fromShelleyMD
+    ( fromShelleyMD
     , fromShelleyTx
     )
     where

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Shelley.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Shelley.hs
@@ -35,6 +35,8 @@ import Cardano.Wallet.Read.Eras
     ( inject, shelley )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
     ( anyEraCerts, fromStakeCredential )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
+    ( fromShelleyCoin )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( shelleyValidityInterval )
 import Cardano.Wallet.Read.Tx
@@ -70,7 +72,6 @@ import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Ledger.Shelley.Tx as SL
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
@@ -114,8 +115,7 @@ fromShelleyTxOut (SL.TxOut addr amount) = W.TxOut
 fromShelleyAddress :: SL.Addr crypto -> W.Address
 fromShelleyAddress = W.Address . SL.serialiseAddr
 
-fromShelleyCoin :: SL.Coin -> W.Coin
-fromShelleyCoin (SL.Coin c) = Coin.unsafeFromIntegral c
+
 
 -- NOTE: For resolved inputs we have to pass in a dummy value of 0.
 fromShelleyTx

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Shelley.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Shelley.hs
@@ -10,8 +10,7 @@
 --
 
 module Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyTxIn
-    , fromShelleyTxOut
+    ( fromShelleyTxOut
     , fromShelleyCoin
     , fromShelleyWdrl
     , fromShelleyMD

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Shelley.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Shelley.hs
@@ -10,12 +10,9 @@
 --
 
 module Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyTxOut
-    , fromShelleyCoin
-    , fromShelleyWdrl
+    ( fromShelleyWdrl
     , fromShelleyMD
     , fromShelleyTx
-    , fromShelleyAddress
     )
     where
 
@@ -29,14 +26,14 @@ import Cardano.Api.Shelley
     ( fromShelleyMetadata )
 import Cardano.Crypto.Hash
     ( hashToBytes )
-import Cardano.Ledger.Era
-    ( Era (..) )
 import Cardano.Wallet.Read.Eras
     ( inject, shelley )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
     ( anyEraCerts, fromStakeCredential )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
     ( fromShelleyCoin )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
+    ( fromShelleyTxOut )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
     ( shelleyValidityInterval )
 import Cardano.Wallet.Read.Tx
@@ -65,22 +62,17 @@ import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Ledger.Address as SL
 import qualified Cardano.Ledger.BaseTypes as SL
-import qualified Cardano.Ledger.Core as SL.Core
 import qualified Cardano.Ledger.Crypto as SL
 import qualified Cardano.Ledger.Keys as SL
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Ledger.Shelley.Tx as SL
 import qualified Cardano.Wallet.Primitive.Types as W
-import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
     ( TxIn (TxIn) )
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
-    ( TxOut (TxOut) )
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
@@ -101,21 +93,6 @@ fromShelleyTxIn (SL.TxIn txid (SL.TxIx ix)) =
         if txIx > fromIntegral (maxBound :: Word16)
         then error $ "Value for wallet TxIx is out of a valid range: " <> show txIx
         else fromIntegral txIx
-
-fromShelleyTxOut
-    :: ( Era era
-       , SL.Core.Value era ~ SL.Coin
-       )
-    => SL.TxOut era
-    -> W.TxOut
-fromShelleyTxOut (SL.TxOut addr amount) = W.TxOut
-    (fromShelleyAddress addr)
-    (TokenBundle.fromCoin $ fromShelleyCoin amount)
-
-fromShelleyAddress :: SL.Addr crypto -> W.Address
-fromShelleyAddress = W.Address . SL.serialiseAddr
-
-
 
 -- NOTE: For resolved inputs we have to pass in a dummy value of 0.
 fromShelleyTx

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Shelley.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Shelley.hs
@@ -10,8 +10,7 @@
 --
 
 module Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyMD
-    , fromShelleyTx
+    ( fromShelleyTx
     )
     where
 
@@ -21,8 +20,6 @@ import Cardano.Address.Script
     ( KeyHash (..), KeyRole (..), Script (..) )
 import Cardano.Api
     ( ShelleyEra )
-import Cardano.Api.Shelley
-    ( fromShelleyMetadata )
 import Cardano.Crypto.Hash
     ( hashToBytes )
 import Cardano.Wallet.Read.Eras
@@ -31,6 +28,8 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
     ( anyEraCerts, fromStakeCredential )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
     ( fromShelleyCoin )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Metadata
+    ( fromShelleyMetadata )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     ( fromShelleyTxOut )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
@@ -57,7 +56,6 @@ import Data.Map.Strict
 import Data.Word
     ( Word16, Word32, Word64 )
 
-import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Ledger.Address as SL
 import qualified Cardano.Ledger.BaseTypes as SL
@@ -123,7 +121,7 @@ fromShelleyTx tx =
         , withdrawals =
             fromShelleyWdrl wdrls
         , metadata =
-            fromShelleyMD <$> SL.strictMaybeToMaybe mmd
+            fromShelleyMetadata <$> SL.strictMaybeToMaybe mmd
         , scriptValidity =
             Nothing
         }
@@ -145,9 +143,6 @@ fromShelleyWdrl (SL.Wdrl wdrl) = Map.fromList $
     bimap (fromStakeCredential . SL.getRwdCred) fromShelleyCoin
         <$> Map.toList wdrl
 
-fromShelleyMD :: SL.Metadata c -> Cardano.TxMetadata
-fromShelleyMD (SL.Metadata m) =
-    Cardano.makeTransactionMetadata . fromShelleyMetadata $ m
 
 fromLedgerScript
     :: SL.Crypto crypto

--- a/lib/wallet/src/Cardano/Wallet/Read/Tx/CollateralInputs.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Tx/CollateralInputs.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Copyright: © 2020-2022 IOHK
+-- License: Apache-2.0
+--
+-- Raw certificate data extraction from 'Tx'
+--
+
+module Cardano.Wallet.Read.Tx.CollateralInputs
+    ( CollateralInputsType
+    , CollateralInputs (..)
+    , getEraCollateralInputs
+    )
+    where
+
+import Prelude
+
+import Cardano.Api
+    ( AllegraEra, AlonzoEra, BabbageEra, ByronEra, MaryEra, ShelleyEra )
+import Cardano.Ledger.Crypto
+    ( StandardCrypto )
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..) )
+import Cardano.Wallet.Read.Tx
+    ( Tx (..) )
+import Cardano.Wallet.Read.Tx.Eras
+    ( onTx )
+import Data.Set
+    ( Set )
+import GHC.Records
+    ( HasField (..) )
+
+import qualified Cardano.Ledger.Alonzo.Tx as AL
+import qualified Cardano.Ledger.Shelley.API as SH
+
+type family CollateralInputsType era where
+    CollateralInputsType ByronEra = ()
+    CollateralInputsType ShelleyEra = ()
+    CollateralInputsType AllegraEra = ()
+    CollateralInputsType MaryEra = ()
+    CollateralInputsType AlonzoEra = Set (SH.TxIn StandardCrypto)
+    CollateralInputsType BabbageEra = Set (SH.TxIn StandardCrypto)
+
+newtype CollateralInputs era = CollateralInputs (CollateralInputsType era)
+
+deriving instance Show (CollateralInputsType era) => Show (CollateralInputs era)
+deriving instance Eq (CollateralInputsType era) => Eq (CollateralInputs era)
+
+getEraCollateralInputs :: EraFun Tx CollateralInputs
+getEraCollateralInputs
+    = EraFun
+        { byronFun =  \_ -> CollateralInputs ()
+        , shelleyFun = \_ -> CollateralInputs ()
+        , allegraFun = \_ -> CollateralInputs ()
+        , maryFun = \_ -> CollateralInputs ()
+        , alonzoFun = onTx $ \(AL.ValidatedTx b _ _ _) -> getCollateralInputs b
+        , babbageFun = onTx $ \(AL.ValidatedTx b _ _ _) -> getCollateralInputs b
+        }
+
+getCollateralInputs
+    :: ( HasField "collateral" a (CollateralInputsType b))
+    => a -> CollateralInputs b
+getCollateralInputs =  CollateralInputs . getField @"collateral"

--- a/lib/wallet/src/Cardano/Wallet/Read/Tx/CollateralOutputs.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Tx/CollateralOutputs.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Copyright: © 2020-2022 IOHK
+-- License: Apache-2.0
+--
+-- Raw certificate data extraction from 'Tx'
+--
+
+module Cardano.Wallet.Read.Tx.CollateralOutputs
+    ( CollateralOutputsType
+    , CollateralOutputs (..)
+    , getEraCollateralOutputs
+    )
+    where
+
+import Prelude
+
+import Cardano.Api
+    ( AllegraEra, AlonzoEra, BabbageEra, ByronEra, MaryEra, ShelleyEra )
+import Cardano.Ledger.Crypto
+    ( StandardCrypto )
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..) )
+import Cardano.Wallet.Read.Tx
+    ( Tx (..) )
+import Cardano.Wallet.Read.Tx.Eras
+    ( onTx )
+import Data.Maybe.Strict
+    ( StrictMaybe )
+import GHC.Records
+    ( HasField (..) )
+
+import qualified Cardano.Ledger.Alonzo.Tx as AL
+import qualified Cardano.Ledger.Babbage as BA
+
+type family CollateralOutputsType era where
+    CollateralOutputsType ByronEra = ()
+    CollateralOutputsType ShelleyEra = ()
+    CollateralOutputsType AllegraEra = ()
+    CollateralOutputsType MaryEra = ()
+    CollateralOutputsType AlonzoEra =  ()
+    CollateralOutputsType BabbageEra
+        = StrictMaybe (BA.TxOut (BA.BabbageEra StandardCrypto))
+
+newtype CollateralOutputs era = CollateralOutputs (CollateralOutputsType era)
+
+deriving instance Show (CollateralOutputsType era) => Show (CollateralOutputs era)
+deriving instance Eq (CollateralOutputsType era) => Eq (CollateralOutputs era)
+
+getEraCollateralOutputs :: EraFun Tx CollateralOutputs
+getEraCollateralOutputs
+    = EraFun
+        { byronFun =  \_ -> CollateralOutputs ()
+        , shelleyFun = \_ -> CollateralOutputs ()
+        , allegraFun = \_ -> CollateralOutputs ()
+        , maryFun = \_ -> CollateralOutputs ()
+        , alonzoFun = \_ -> CollateralOutputs ()
+        , babbageFun = onTx
+            $ \(AL.ValidatedTx b _ _ _) -> getCollateralOutputs b
+        }
+
+getCollateralOutputs
+    :: ( HasField "collateralReturn" a (CollateralOutputsType b))
+    => a -> CollateralOutputs b
+getCollateralOutputs =  CollateralOutputs . getField @"collateralReturn"

--- a/lib/wallet/src/Cardano/Wallet/Read/Tx/Fee.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Tx/Fee.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Copyright: © 2020-2022 IOHK
+-- License: Apache-2.0
+--
+-- Raw fee data extraction from 'Tx'
+--
+
+module Cardano.Wallet.Read.Tx.Fee
+    ( FeeType
+    , Fee (..)
+    , getEraFee
+    )
+    where
+
+import Prelude
+
+import Cardano.Api
+    ( AllegraEra, AlonzoEra, BabbageEra, ByronEra, MaryEra, ShelleyEra )
+import Cardano.Ledger.Coin
+    ( Coin )
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..) )
+import Cardano.Wallet.Read.Tx
+    ( Tx (..) )
+import Cardano.Wallet.Read.Tx.Eras
+    ( onTx )
+import GHC.Records
+    ( HasField (..) )
+
+import qualified Cardano.Ledger.Alonzo.Tx as AL
+import qualified Cardano.Ledger.Shelley.API as SH
+
+type family FeeType era where
+    FeeType ByronEra = ()
+    FeeType ShelleyEra = Coin
+    FeeType AllegraEra = Coin
+    FeeType MaryEra = Coin
+    FeeType AlonzoEra = Coin
+    FeeType BabbageEra = Coin
+
+newtype Fee era = Fee (FeeType era)
+
+deriving instance Show (FeeType era) => Show (Fee era)
+deriving instance Eq (FeeType era) => Eq (Fee era)
+
+getEraFee :: EraFun Tx Fee
+getEraFee
+    = EraFun
+        { byronFun =  onTx $ \_ -> Fee ()
+        , shelleyFun = onTx $ \((SH.Tx b _ _)) -> getFee b
+        , allegraFun = onTx $ \((SH.Tx b _ _)) -> getFee b
+        , maryFun = onTx $ \(SH.Tx b _ _) -> getFee b
+        , alonzoFun = onTx $ \(AL.ValidatedTx b _ _ _) -> getFee b
+        , babbageFun = onTx $ \(AL.ValidatedTx b _ _ _) -> getFee b
+        }
+
+getFee
+    :: ( HasField "txfee" a (FeeType b))
+    => a -> Fee b
+getFee =  Fee . getField @"txfee"

--- a/lib/wallet/src/Cardano/Wallet/Read/Tx/Inputs.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Tx/Inputs.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Copyright: © 2020-2022 IOHK
+-- License: Apache-2.0
+--
+-- Raw certificate data extraction from 'Tx'
+--
+
+module Cardano.Wallet.Read.Tx.Inputs
+    ( InputsType
+    , Inputs (..)
+    , getEraInputs
+    )
+    where
+
+import Prelude
+
+import Cardano.Api
+    ( AllegraEra, AlonzoEra, BabbageEra, ByronEra, MaryEra, ShelleyEra )
+import Cardano.Ledger.Crypto
+    ( StandardCrypto )
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..) )
+import Cardano.Wallet.Read.Tx
+    ( Tx (..) )
+import Cardano.Wallet.Read.Tx.Eras
+    ( onTx )
+import Data.List.NonEmpty
+    ( NonEmpty )
+import Data.Set
+    ( Set )
+import GHC.Records
+    ( HasField (..) )
+
+import qualified Cardano.Chain.UTxO as BY
+import qualified Cardano.Ledger.Alonzo.Tx as AL
+import qualified Cardano.Ledger.Shelley.API as SH
+
+type family InputsType era where
+    InputsType ByronEra = NonEmpty BY.TxIn
+    InputsType ShelleyEra = Set (SH.TxIn StandardCrypto)
+    InputsType AllegraEra = Set (SH.TxIn StandardCrypto)
+    InputsType MaryEra = Set (SH.TxIn StandardCrypto)
+    InputsType AlonzoEra = Set (SH.TxIn StandardCrypto)
+    InputsType BabbageEra = Set (SH.TxIn StandardCrypto)
+
+newtype Inputs era = Inputs (InputsType era)
+
+deriving instance Show (InputsType era) => Show (Inputs era)
+deriving instance Eq (InputsType era) => Eq (Inputs era)
+
+getEraInputs :: EraFun Tx Inputs
+getEraInputs
+    = EraFun
+        { byronFun =  onTx $ \tx -> Inputs $ BY.txInputs $ BY.taTx tx
+        , shelleyFun = onTx $ \((SH.Tx b _ _)) -> getInputs b
+        , allegraFun = onTx $ \((SH.Tx b _ _)) -> getInputs b
+        , maryFun = onTx $ \(SH.Tx b _ _) -> getInputs b
+        , alonzoFun = onTx $ \(AL.ValidatedTx b _ _ _) -> getInputs b
+        , babbageFun = onTx $ \(AL.ValidatedTx b _ _ _) -> getInputs b
+        }
+
+getInputs
+    :: ( HasField "inputs" a (InputsType b))
+    => a -> Inputs b
+getInputs =  Inputs . getField @"inputs"

--- a/lib/wallet/src/Cardano/Wallet/Read/Tx/Metadata.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Tx/Metadata.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Copyright: © 2020-2022 IOHK
+-- License: Apache-2.0
+--
+-- Raw mint data extraction from 'Tx'
+--
+
+module Cardano.Wallet.Read.Tx.Metadata
+    ( MetadataType
+    , Metadata (..)
+    , getEraMetadata
+    ) where
+
+import Prelude
+
+import Cardano.Api
+    ( AllegraEra, AlonzoEra, BabbageEra, ByronEra, MaryEra, ShelleyEra )
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..) )
+
+import Cardano.Ledger.Core
+    ( AuxiliaryData )
+import Cardano.Wallet.Read.Tx
+    ( Tx (..) )
+import Cardano.Wallet.Read.Tx.Eras
+    ( onTx )
+import Data.Maybe.Strict
+    ( StrictMaybe )
+import Ouroboros.Consensus.Shelley.Eras
+    ( StandardAllegra
+    , StandardAlonzo
+    , StandardBabbage
+    , StandardMary
+    , StandardShelley
+    )
+
+import qualified Cardano.Ledger.Alonzo.Tx as AL
+import qualified Cardano.Ledger.Shelley.API as SH
+
+type family MetadataType era where
+  MetadataType ByronEra = ()
+  MetadataType ShelleyEra = StrictMaybe (AuxiliaryData StandardShelley)
+  MetadataType AllegraEra = StrictMaybe (AuxiliaryData StandardAllegra)
+  MetadataType MaryEra = StrictMaybe (AuxiliaryData StandardMary)
+  MetadataType AlonzoEra = StrictMaybe (AuxiliaryData StandardAlonzo)
+  MetadataType BabbageEra = StrictMaybe (AuxiliaryData StandardBabbage)
+
+newtype Metadata era = Metadata (MetadataType era)
+
+deriving instance Show (MetadataType era) => Show (Metadata era)
+deriving instance Eq (MetadataType era) => Eq (Metadata era)
+
+getEraMetadata :: EraFun Tx Metadata
+getEraMetadata = EraFun
+    { byronFun = \_ -> Metadata ()
+    , shelleyFun =  onTx $ \(SH.Tx _ _ b) -> Metadata b
+    , allegraFun = onTx $ \(SH.Tx _ _ b) -> Metadata b
+    , maryFun = onTx $ \(SH.Tx _ _ b ) -> Metadata b
+    , alonzoFun = onTx $ \(AL.ValidatedTx _ _ _ b) -> Metadata b
+    , babbageFun = onTx $ \(AL.ValidatedTx _ _ _ b) -> Metadata b
+    }
+
+

--- a/lib/wallet/src/Cardano/Wallet/Read/Tx/Outputs.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Tx/Outputs.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Copyright: © 2020-2022 IOHK
+-- License: Apache-2.0
+--
+-- Raw era-dependent tx outputs data extraction from 'Tx'
+--
+
+module Cardano.Wallet.Read.Tx.Outputs
+    ( OutputsType
+    , Outputs (..)
+    , getEraOutputs
+    )
+    where
+
+import Prelude
+
+import Cardano.Api
+    ( AllegraEra, AlonzoEra, BabbageEra, ByronEra, MaryEra, ShelleyEra )
+import Cardano.Ledger.Crypto
+    ( StandardCrypto )
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..) )
+import Cardano.Wallet.Read.Tx
+    ( Tx (..) )
+import Cardano.Wallet.Read.Tx.Eras
+    ( onTx )
+import Data.List.NonEmpty
+    ( NonEmpty )
+import Data.Sequence.Strict
+    ( StrictSeq )
+import GHC.Records
+    ( HasField (..) )
+
+import qualified Cardano.Chain.UTxO as BY
+import qualified Cardano.Ledger.Alonzo as AL
+import qualified Cardano.Ledger.Alonzo.Tx as AL
+import qualified Cardano.Ledger.Babbage as BA
+import qualified Cardano.Ledger.Shelley as SH
+import qualified Cardano.Ledger.Shelley.Tx as SHTx
+import qualified Cardano.Ledger.ShelleyMA as SMA
+
+type family OutputsType era where
+    OutputsType ByronEra = NonEmpty BY.TxOut
+    OutputsType ShelleyEra
+        = StrictSeq (SH.TxOut (SH.ShelleyEra StandardCrypto))
+    OutputsType AllegraEra
+        = StrictSeq (SH.TxOut (SMA.ShelleyMAEra 'SMA.Allegra StandardCrypto))
+    OutputsType MaryEra
+        = StrictSeq (SH.TxOut (SMA.ShelleyMAEra 'SMA.Mary StandardCrypto))
+    OutputsType AlonzoEra
+        = StrictSeq (AL.TxOut (AL.AlonzoEra StandardCrypto))
+    OutputsType BabbageEra
+        = StrictSeq (BA.TxOut (BA.BabbageEra StandardCrypto))
+
+newtype Outputs era = Outputs (OutputsType era)
+
+deriving instance Show (OutputsType era) => Show (Outputs era)
+deriving instance Eq (OutputsType era) => Eq (Outputs era)
+
+getEraOutputs :: EraFun Tx Outputs
+getEraOutputs
+    = EraFun
+        { byronFun =  onTx $ \tx -> Outputs $ BY.txOutputs $ BY.taTx tx
+        , shelleyFun = onTx $ \((SHTx.Tx b _ _)) -> getOutputs b
+        , allegraFun = onTx $ \((SHTx.Tx b _ _)) -> getOutputs b
+        , maryFun = onTx $ \(SHTx.Tx b _ _) -> getOutputs b
+        , alonzoFun = onTx $ \(AL.ValidatedTx b _ _ _) -> getOutputs b
+        , babbageFun = onTx $ \(AL.ValidatedTx b _ _ _) -> getOutputs b
+        }
+
+getOutputs
+    :: ( HasField "outputs" a (OutputsType b))
+    => a -> Outputs b
+getOutputs =  Outputs . getField @"outputs"

--- a/lib/wallet/src/Cardano/Wallet/Read/Tx/ScriptValidity.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Tx/ScriptValidity.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Copyright: © 2020-2022 IOHK
+-- License: Apache-2.0
+--
+-- Raw mint data extraction from 'Tx'
+--
+
+module Cardano.Wallet.Read.Tx.ScriptValidity
+    ( ScriptValidityType
+    , ScriptValidity (..)
+    , getEraScriptValidity
+    ) where
+
+import Prelude
+
+import Cardano.Api
+    ( AllegraEra, AlonzoEra, BabbageEra, ByronEra, MaryEra, ShelleyEra )
+import Cardano.Ledger.Alonzo.Tx
+    ( IsValid )
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..) )
+import Cardano.Wallet.Read.Tx
+    ( Tx (..) )
+import Cardano.Wallet.Read.Tx.Eras
+    ( onTx )
+
+import qualified Cardano.Ledger.Alonzo.Tx as AL
+
+type family ScriptValidityType era where
+  ScriptValidityType ByronEra = ()
+  ScriptValidityType ShelleyEra = ()
+  ScriptValidityType AllegraEra = ()
+  ScriptValidityType MaryEra = ()
+  ScriptValidityType AlonzoEra = IsValid
+  ScriptValidityType BabbageEra = IsValid
+
+newtype ScriptValidity era = ScriptValidity (ScriptValidityType era)
+
+deriving instance Show (ScriptValidityType era) => Show (ScriptValidity era)
+deriving instance Eq (ScriptValidityType era) => Eq (ScriptValidity era)
+
+getEraScriptValidity :: EraFun Tx ScriptValidity
+getEraScriptValidity = EraFun
+    { byronFun = \_ -> ScriptValidity ()
+    , shelleyFun =  \_ -> ScriptValidity ()
+    , allegraFun = \_ -> ScriptValidity ()
+    , maryFun = \_ -> ScriptValidity ()
+    , alonzoFun = onTx $ \(AL.ValidatedTx _ _ b _) -> ScriptValidity b
+    , babbageFun = onTx $ \(AL.ValidatedTx _ _ b _) -> ScriptValidity b
+    }
+
+

--- a/lib/wallet/src/Cardano/Wallet/Read/Tx/Withdrawals.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Tx/Withdrawals.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Copyright: © 2020-2022 IOHK
+-- License: Apache-2.0
+--
+-- Raw witnesses data extraction from 'Tx'
+--
+
+module Cardano.Wallet.Read.Tx.Withdrawals
+    ( WithdrawalsType
+    , Withdrawals (..)
+    , getEraWithdrawals
+    ) where
+
+import Prelude
+
+import Cardano.Api
+    ( AllegraEra, AlonzoEra, BabbageEra, ByronEra, MaryEra, ShelleyEra )
+import Cardano.Ledger.Crypto
+    ( StandardCrypto )
+import Cardano.Wallet.Read.Eras
+    ( EraFun (..) )
+import Cardano.Wallet.Read.Tx
+    ( Tx (..) )
+import Cardano.Wallet.Read.Tx.Eras
+    ( onTx )
+import GHC.Records
+    ( HasField (getField) )
+
+import qualified Cardano.Ledger.Alonzo.Tx as AL
+import qualified Cardano.Ledger.Shelley.API as SH
+
+type family WithdrawalsType era where
+  WithdrawalsType ByronEra = ()
+  WithdrawalsType ShelleyEra = SH.Wdrl StandardCrypto
+  WithdrawalsType AllegraEra = SH.Wdrl StandardCrypto
+  WithdrawalsType MaryEra = SH.Wdrl StandardCrypto
+  WithdrawalsType AlonzoEra = SH.Wdrl StandardCrypto
+  WithdrawalsType BabbageEra = SH.Wdrl StandardCrypto
+
+newtype Withdrawals era = Withdrawals (WithdrawalsType era)
+
+deriving instance Show (WithdrawalsType era) => Show (Withdrawals era)
+deriving instance Eq (WithdrawalsType era) => Eq (Withdrawals era)
+
+getEraWithdrawals :: EraFun Tx Withdrawals
+getEraWithdrawals = EraFun
+    { byronFun = \_ -> Withdrawals ()
+    , shelleyFun = onTx $ \(SH.Tx b _ _ )  -> getWithdrawals b
+    , allegraFun = onTx $ \(SH.Tx b _ _ )  -> getWithdrawals b
+    , maryFun = onTx $ \(SH.Tx b _ _ ) -> getWithdrawals b
+    , alonzoFun = onTx $ \(AL.ValidatedTx b _ _ _) ->  getWithdrawals b
+    , babbageFun = onTx $ \(AL.ValidatedTx b _ _ _) -> getWithdrawals b
+    }
+
+getWithdrawals
+    :: ( HasField "wdrls" a (WithdrawalsType b))
+    => a -> Withdrawals b
+getWithdrawals =  Withdrawals . getField @"wdrls"

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -233,12 +233,14 @@ import Cardano.Wallet.Read.Primitive.Tx.Alonzo
     ( fromAlonzoTx )
 import Cardano.Wallet.Read.Primitive.Tx.Babbage
     ( fromBabbageTx )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
+    ( fromShelleyCoin )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromShelleyTxIn )
 import Cardano.Wallet.Read.Primitive.Tx.Mary
     ( fromCardanoValue, fromMaryTx )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyAddress, fromShelleyCoin, fromShelleyTx, fromShelleyTxOut )
+    ( fromShelleyAddress, fromShelleyTx, fromShelleyTxOut )
 import Cardano.Wallet.Read.Tx.Hash
     ( fromShelleyTxId )
 import Cardano.Wallet.Shelley.Network.Discriminant

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -233,15 +233,12 @@ import Cardano.Wallet.Read.Primitive.Tx.Alonzo
     ( fromAlonzoTx )
 import Cardano.Wallet.Read.Primitive.Tx.Babbage
     ( fromBabbageTx )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
+    ( fromShelleyTxIn )
 import Cardano.Wallet.Read.Primitive.Tx.Mary
     ( fromCardanoValue, fromMaryTx )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyAddress
-    , fromShelleyCoin
-    , fromShelleyTx
-    , fromShelleyTxIn
-    , fromShelleyTxOut
-    )
+    ( fromShelleyAddress, fromShelleyCoin, fromShelleyTx, fromShelleyTxOut )
 import Cardano.Wallet.Read.Tx.Hash
     ( fromShelleyTxId )
 import Cardano.Wallet.Shelley.Network.Discriminant

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -237,10 +237,11 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Fee
     ( fromShelleyCoin )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromShelleyTxIn )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
+    ( fromCardanoValue, fromShelleyAddress, fromShelleyTxOut )
 import Cardano.Wallet.Read.Primitive.Tx.Mary
-    ( fromCardanoValue, fromMaryTx )
+    ( fromMaryTx )
 import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyAddress, fromShelleyTx, fromShelleyTxOut )
 import Cardano.Wallet.Read.Tx.Hash
     ( fromShelleyTxId )
 import Cardano.Wallet.Shelley.Network.Discriminant

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -19,15 +19,14 @@ import Cardano.Wallet.DB.Fixtures
     ( StoreProperty, assertWith, logScale, withDBInMemory, withStoreProp )
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (TxId) )
+import Cardano.Wallet.DB.Store.Transactions.Decoration
+    ( decorateTxIns, lookupTxOutForTxCollateral, lookupTxOutForTxIn )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( DeltaTxSet (..)
     , TxRelation (..)
     , TxSet (..)
     , collateralIns
-    , decorateTxIns
     , ins
-    , lookupTxOutForTxCollateral
-    , lookupTxOutForTxIn
     , mkTxSet
     )
 import Cardano.Wallet.DB.Store.Transactions.Store

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -20,10 +20,7 @@ import Cardano.Wallet.DB.Fixtures
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (TxId) )
 import Cardano.Wallet.DB.Store.Transactions.Decoration
-    ( decorateTxInsForRelation
-    , lookupTxOutForTxCollateral
-    , lookupTxOutForTxIn
-    )
+    ( decorateTxInsForRelation, lookupTxOut, mkTxOutKey, mkTxOutKeyCollateral )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( DeltaTxSet (..)
     , TxRelation (..)
@@ -105,7 +102,7 @@ prop_DecorateLinksTxInToTxOuts = do
     forAll transactionsGen $ \(txid, TxSet pile, txouts) ->
         let guinea = pile Map.! txid
             deco   = decorateTxInsForRelation (TxSet pile) guinea
-        in  [ lookupTxOutForTxIn txin deco | txin <- ins guinea]
+        in  [ lookupTxOut (mkTxOutKey txin) deco | txin <- ins guinea]
             === map Just txouts
 
 {- | We check that `decorateTxInsForRelation` indeed decorates transaction inputs.
@@ -132,7 +129,7 @@ prop_DecorateLinksTxCollateralsToTxOuts = do
     forAll transactionsGen $ \(txid, TxSet pile, txouts) ->
         let guinea = pile Map.! txid
             deco   = decorateTxInsForRelation (TxSet pile) guinea
-        in  [ lookupTxOutForTxCollateral txcol deco
+        in  [ lookupTxOut (mkTxOutKeyCollateral txcol) deco
             | txcol <- collateralIns guinea
             ]
             === map Just txouts

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -20,7 +20,10 @@ import Cardano.Wallet.DB.Fixtures
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (TxId) )
 import Cardano.Wallet.DB.Store.Transactions.Decoration
-    ( decorateTxIns, lookupTxOutForTxCollateral, lookupTxOutForTxIn )
+    ( decorateTxInsForRelation
+    , lookupTxOutForTxCollateral
+    , lookupTxOutForTxIn
+    )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( DeltaTxSet (..)
     , TxRelation (..)
@@ -78,7 +81,7 @@ spec = do
 {-----------------------------------------------------------------------------
     Properties
 ------------------------------------------------------------------------------}
-{- | We check that `decorateTxIns` indeed decorates transaction inputs.
+{- | We check that `decorateTxInsForRelation` indeed decorates transaction inputs.
 We do this by generating a set of random transactions, as well as a
 "guinea pig" transaction, whose inputs point to all outputs
 of the other transactions. Then, we expect that decorating the history
@@ -101,11 +104,11 @@ prop_DecorateLinksTxInToTxOuts = do
 
     forAll transactionsGen $ \(txid, TxSet pile, txouts) ->
         let guinea = pile Map.! txid
-            deco   = decorateTxIns (TxSet pile) guinea
+            deco   = decorateTxInsForRelation (TxSet pile) guinea
         in  [ lookupTxOutForTxIn txin deco | txin <- ins guinea]
             === map Just txouts
 
-{- | We check that `decorateTxIns` indeed decorates transaction inputs.
+{- | We check that `decorateTxInsForRelation` indeed decorates transaction inputs.
 We do this by generating a set of random transactions, as well as a
 "guinea pig" transaction, whose collaterals point to all outputs
 of the other transactions. Then, we expect that decorating the history
@@ -128,7 +131,7 @@ prop_DecorateLinksTxCollateralsToTxOuts = do
 
     forAll transactionsGen $ \(txid, TxSet pile, txouts) ->
         let guinea = pile Map.! txid
-            deco   = decorateTxIns (TxSet pile) guinea
+            deco   = decorateTxInsForRelation (TxSet pile) guinea
         in  [ lookupTxOutForTxCollateral txcol deco
             | txcol <- collateralIns guinea
             ]


### PR DESCRIPTION
- abstract over transactions decorations to cover CBOR encoded ones
- add new Read.Tx features
   - inputs
   - collateral inputs
   - outputs
   - collateral outputs
   - fee
   - withdrawals
   - metadata
   - script validity
 - implement mkTransactionInfo for the  Read.Tx (CBOR encoded txs)
 
ADP-2367