### PR TITLE
[ADP-2367] expand submissions table to hold metadata

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
@@ -34,7 +34,13 @@ import Cardano.Pool.Types
 import Cardano.Slotting.Slot
     ( SlotNo )
 import Cardano.Wallet.DB.Sqlite.Types
-    ( BlockId, HDPassphrase, TxId, TxSubmissionStatusEnum (..), sqlSettings' )
+    ( BlockHeight
+    , BlockId
+    , HDPassphrase
+    , TxId
+    , TxSubmissionStatusEnum (..)
+    , sqlSettings'
+    )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( CredentialType )
 import Data.Quantity
@@ -492,12 +498,16 @@ CBOR
     deriving Show Generic Eq
 
 Submissions
-    submissionTxId TxId  sql=tx_id
-    submissionTx W.SealedTx sql=tx
-    submissionExpiration SlotNo sql=expiration
-    submissionAcceptance (Maybe SlotNo) sql=acceptance
-    submissionWallet W.WalletId sql=wallet_id
-    submissionStatus TxSubmissionStatusEnum sql=status
+    submissionTxId                  TxId                sql=tx_id
+    submissionTx                    W.SealedTx          sql=tx
+    submissionExpiration            SlotNo              sql=expiration
+    submissionAcceptance            (Maybe SlotNo)      sql=acceptance
+    submissionWallet                W.WalletId          sql=wallet_id
+    submissionStatus                TxSubmissionStatusEnum sql=status
+    submissionMetaSlot              SlotNo              sql=slot
+    submissionMetaBlockHeight       BlockHeight         sql=block_height
+    submissionMetaAmount            W.Coin              sql=amount
+    submissionMetaDirection         W.Direction         sql=direction
 
     Primary submissionTxId
     deriving Show Generic Eq

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -94,7 +94,7 @@ import Data.Maybe
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
-    ( Percentage )
+    ( Percentage, Quantity (..) )
 import Data.Text
     ( Text )
 import Data.Text.Class.Extended
@@ -731,9 +731,20 @@ instance MonadFail EitherText where
 data TxSubmissionStatusEnum = InSubmissionE | InLedgerE | ExpiredE
     deriving (Eq, Show, Enum, Generic)
 
+
+
 instance PersistField TxSubmissionStatusEnum where
     toPersistValue = toPersistValue . fromEnum
     fromPersistValue = fmap toEnum . fromPersistValue
 
 instance PersistFieldSql TxSubmissionStatusEnum where
     sqlType _ = sqlType (Proxy @Int)
+
+type BlockHeight = Quantity "block" Word32
+
+instance PersistField BlockHeight where
+    toPersistValue = toPersistValue . getQuantity
+    fromPersistValue = fmap Quantity . fromPersistValue
+
+instance PersistFieldSql BlockHeight where
+    sqlType _ = sqlType (Proxy @Word32)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
@@ -1,0 +1,41 @@
+-- |
+-- Copyright: © 2022 IOHK
+-- License: Apache-2.0
+--
+-- An implementation of the DBPendingTxs which uses Persistent and SQLite.
+
+module Cardano.Wallet.DB.Store.Submissions.New.Layer
+    ( mkDbPendingTxs
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.DB
+    ( DBPendingTxs (..) )
+import Cardano.Wallet.DB.Store.Submissions.New.Operations
+    ( DeltaTxSubmissions )
+import Cardano.Wallet.Primitive.Types
+    ( WalletId )
+import Control.Monad.Except
+    ( ExceptT (ExceptT) )
+import Data.DBVar
+    ( DBVar )
+import Data.DeltaMap
+    ( DeltaMap )
+import Database.Persist.Sql
+    ( SqlPersistT )
+
+mkDbPendingTxs
+    :: DBVar (SqlPersistT IO) (DeltaMap WalletId DeltaTxSubmissions)
+    -> DBPendingTxs stm
+mkDbPendingTxs dbvar = DBPendingTxs
+    { putLocalTxSubmission_ = \wid txid tx sl ->
+        error "putLocalTxSubmissions not implemented"
+    , readLocalTxSubmissionPending_
+        = error "readLocalTxSubmissionPending_ not implemented"
+    , updatePendingTxForExpiry_ = \wid tip -> ExceptT $
+        error "updatePendingTxForExpiry_ not implemented"
+    , removePendingOrExpiredTx_ = \wid txId ->
+        error "removePendingOrExpiredTx_ not implemented"
+    }

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Operations.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -20,6 +21,7 @@ module Cardano.Wallet.DB.Store.Submissions.New.Operations
     , syncSubmissions
     , mkStoreSubmissions
     , DeltaTxSubmissions
+    , SubmissionMeta (..)
     ) where
 
 import Prelude
@@ -50,23 +52,35 @@ import Data.Delta
     ( Delta (..) )
 import Data.Map.Strict
     ( Map )
-import qualified Data.Map.Strict as Map
+import Data.Quantity
+    ( Quantity )
+import Data.Word
+    ( Word32 )
 import Database.Persist
     ( Entity (Entity), PersistStoreWrite (delete, repsert), selectList, (==.) )
 import Database.Persist.Sql
     ( SqlPersistT )
 
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Submissions.Operations as Sbm
 import qualified Cardano.Wallet.Submissions.Submissions as Sbm
 import qualified Cardano.Wallet.Submissions.TxStatus as Sbm
+import qualified Data.Map.Strict as Map
+
+data SubmissionMeta  = SubmissionMeta
+    { submissionMetaSlot :: SlotNo
+    , submissionMetaHeight :: Quantity "block" Word32
+    , submissionMetaAmount :: W.Coin
+    , submissionMetaDirection :: W.Direction
+    } deriving (Show, Eq)
 
 type TxSubmissions
-    = Sbm.Submissions () SlotNo (TxId, W.SealedTx)
+    = Sbm.Submissions SubmissionMeta SlotNo (TxId, W.SealedTx)
 type TxSubmissionsStatus
-    = Sbm.TxStatusMeta () SlotNo (TxId, W.SealedTx)
+    = Sbm.TxStatusMeta SubmissionMeta SlotNo (TxId, W.SealedTx)
 type DeltaTxSubmissions
-    = Sbm.Operation () SlotNo (TxId, W.SealedTx)
+    = Sbm.Operation SubmissionMeta SlotNo (TxId, W.SealedTx)
 
 
 syncSubmissions :: WalletId -> TxSubmissions -> TxSubmissions -> SqlPersistT IO ()
@@ -77,7 +91,7 @@ syncSubmissions wid old new = do
 
     let repserts = new ^. transactionsL
     forM_ (Map.assocs repserts) $
-        \(iden, TxStatusMeta status () ) -> do
+        \(iden, TxStatusMeta status SubmissionMeta{..} ) -> do
             let result = case status of
                     Sbm.Expired expiring (_, sealed)
                         -> Just (sealed, expiring, Nothing, ExpiredE)
@@ -91,6 +105,10 @@ syncSubmissions wid old new = do
                     (SubmissionsKey iden)
                     (Submissions iden sealed expiring
                         acceptance wid statusNumber
+                        submissionMetaSlot
+                        submissionMetaHeight
+                        submissionMetaAmount
+                        submissionMetaDirection
                     )
                 Nothing -> pure ()
     repsert
@@ -130,15 +148,18 @@ mkStoreAnySubmissions wid =
 mkTransactions :: [Entity Submissions] -> Map TxId TxSubmissionsStatus
 mkTransactions xs = Map.fromList $ do
     Entity _
-        (Submissions iden sealed expiration acceptance _ status)
+        (Submissions iden sealed expiration acceptance _ status
+            slot height amount direction)
             <- xs
     pure
         ( iden
-        , mkStatusMeta () iden sealed expiration acceptance status
+        , mkStatusMeta
+            (SubmissionMeta slot height amount direction)
+                iden sealed expiration acceptance status
         )
 
 mkStatusMeta
-    :: ()
+    :: SubmissionMeta
     -> TxId
     -> W.SealedTx
     -> SlotNo

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Operations.hs
@@ -20,47 +20,47 @@ import Prelude
 
 import Cardano.Wallet.Submissions.Primitives
     ( Primitive (MoveFinality, MoveTip), applyPrimitive )
-import Data.Foldable
-    ( Foldable (..) )
-
-import qualified Cardano.Wallet.Submissions.Primitives as DP
 import Cardano.Wallet.Submissions.Submissions
     ( Submissions )
 import Cardano.Wallet.Submissions.TxStatus
     ( HasTxId (..) )
+import Data.Foldable
+    ( Foldable (..) )
+
+import qualified Cardano.Wallet.Submissions.Primitives as DP
 
 -- High Level, invariant respectful operations over the 'Submissions' store.
-data Operation slot tx where
+data Operation meta slot tx where
     -- | Insert tx new transaction in the local submission store.
-    AddSubmission :: slot -> tx -> Operation slot tx
+    AddSubmission :: slot -> tx -> meta -> Operation meta slot tx
     -- | Move transactions in the in-ledger state, removing them from
     -- in-submission.
     RollForward
       :: slot -- ^ New tip.
       -> [(slot, tx)] -- ^ Transactions that were found in the ledder.
-      -> Operation slot tx
+      -> Operation meta slot tx
     -- | Move transactions from the in-ledger state to in-submission state,
     -- when their acceptance slot falls after the new tip.
     RollBack
       :: slot -- ^ new tip
-      -> Operation slot tx
+      -> Operation meta slot tx
     -- | Remove transactions that cannot be rolled back in the ledger
     -- and transaction that cannot make it to the ledger due to expiration
     -- and max rollback time.
-    Prune :: slot -> Operation slot tx
+    Prune :: slot -> Operation meta slot tx
     -- | Remove a transaction from the tracked set.
-    Forget :: tx -> Operation slot tx
+    Forget :: tx -> Operation meta slot tx
     deriving (Show)
 
 
 -- | Apply a high level operation to the submission store.
 applyOperations
     :: (Ord slot, Ord (TxId tx), HasTxId tx)
-    => Operation slot tx
-    -> Submissions slot tx
-    -> Submissions slot tx
-applyOperations (AddSubmission expiring tx)
-    = applyPrimitive (DP.AddSubmission expiring tx)
+    => Operation meta slot tx
+    -> Submissions meta slot tx
+    -> Submissions meta slot tx
+applyOperations (AddSubmission expiring tx meta)
+    = applyPrimitive (DP.AddSubmission expiring tx meta)
 applyOperations (RollForward newtip txs) = \x ->
     applyPrimitive (MoveTip newtip)
         . foldl'

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Primitives.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Primitives.hs
@@ -24,61 +24,64 @@ import Prelude
 
 import Cardano.Wallet.Submissions.Submissions
     ( Submissions
+    , TxStatusMeta (..)
     , finality
     , finalityL
     , tip
     , tipL
     , transactions
     , transactionsL
+    , txStatus
     )
 import Cardano.Wallet.Submissions.TxStatus
     ( HasTxId (..), TxStatus (Expired, InLedger, InSubmission) )
 import Control.Lens
-    ( (%~), (&), (.~) )
+    ( ix, (%~), (&), (.~) )
 import Data.Foldable
     ( Foldable (..) )
 
 import qualified Data.Map.Strict as Map
 
 -- | Primitive operations to change a 'Submissions' store.
-data Primitive slot tx where
+data Primitive meta slot tx where
     -- | Insert tx new transaction in the local submission store.
     AddSubmission ::
-        {_expiring :: slot, _transaction :: tx} ->
-        Primitive slot tx
+        {_expiring :: slot, _transaction :: tx, _meta :: meta} ->
+        Primitive meta slot tx
     -- | Change a transaction state to 'InLedger'.
     MoveToLedger ::
         {_acceptance :: slot, _transaction :: tx} ->
-        Primitive slot tx
+        Primitive meta slot tx
     -- | Move the submission store tip slot.
     MoveTip ::
         {_tip :: slot} ->
-        Primitive slot tx
+        Primitive meta slot tx
     -- | Move the submission store finality slot.
     MoveFinality ::
         {_finality :: slot} ->
-        Primitive slot tx
+        Primitive meta slot tx
     -- | Remove a transaction from tracking in the submissions store.
     Forget ::
         {_transaction :: tx} ->
-        Primitive slot tx
+        Primitive meta slot tx
     deriving (Show)
 
 -- | Apply a 'Primitive' to a submission, according to the specification.
 applyPrimitive
-    :: forall slot tx
+    :: forall meta slot tx
     .  (Ord slot, Ord (TxId tx), HasTxId tx)
-    => Primitive slot tx
-    -> Submissions slot tx
-    -> Submissions slot tx
-applyPrimitive (AddSubmission expiring tx) s
+    => Primitive meta slot tx
+    -> Submissions meta slot tx
+    -> Submissions meta slot tx
+applyPrimitive (AddSubmission expiring tx meta ) s
     | expiring > tip s
       && Map.notMember (txId tx) (transactions s)
-        = s & transactionsL %~ Map.insert (txId tx) (InSubmission expiring tx)
+        = s & transactionsL %~ Map.insert (txId tx)
+                (TxStatusMeta (InSubmission expiring tx) meta)
     | otherwise
         = s
 applyPrimitive (MoveToLedger acceptance tx) s =
-    s & transactionsL %~ Map.adjust f (txId tx)
+    s & transactionsL . ix (txId tx) . txStatus %~ f
   where
     f x@(InSubmission expiring tx')
         | acceptance > (tip s) && acceptance <= expiring =
@@ -88,7 +91,7 @@ applyPrimitive (MoveToLedger acceptance tx) s =
 applyPrimitive (MoveTip newTip) s =
     s & (finalityL .~ if newTip <= finality s then newTip else finality s)
         . (tipL .~ newTip)
-        . (transactionsL %~ fmap f)
+        . (transactionsL . traverse . txStatus %~ f)
   where
     f :: TxStatus slot tx -> TxStatus slot tx
     f status@(InLedger expiring acceptance tx)
@@ -109,8 +112,10 @@ applyPrimitive (MoveFinality newFinality) s =
         | newFinality >= tip s = tip s
         | newFinality <= finality s = finality s
         | otherwise = newFinality
-    g fin m = foldl' (flip $ Map.update f) m (Map.keys m)
+    g fin m = foldl' (flip $ Map.update f') m (Map.keys m)
       where
+        f' (TxStatusMeta status meta)
+            = (`TxStatusMeta` meta) <$> f status
         f :: TxStatus slot tx -> Maybe (TxStatus slot tx)
         f status@(InLedger _expiring acceptance _tx)
             | acceptance <= fin = Nothing

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Common.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Common.hs
@@ -43,13 +43,19 @@ verify :: Testable t => Prop t a -> Property
 verify = conjoin . execWriter
 
 -- | Encode a change of the store, for inspection
-data Step delta slot tx = Step
-    { _oldState :: Submissions slot tx
-    , _newState :: Submissions slot tx
-    , _deltaState :: delta slot tx
+data Step delta meta slot tx = Step
+    { _oldState :: Submissions meta slot tx
+    , _newState :: Submissions meta slot tx
+    , _deltaState :: delta meta slot tx
     }
 
-deriving instance (Show slot, HasTxId tx, Show tx,  Show (delta slot tx))
-    => Show (Step delta slot tx)
+deriving instance
+    ( Show slot
+    , HasTxId tx
+    , Show tx
+    , Show (delta meta slot tx)
+    , Show meta
+    )
+    => Show (Step delta meta slot tx)
 
 makeLenses ''Step

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Operations.hs
@@ -21,7 +21,7 @@ import Data.Function
 import Test.QuickCheck
     ( Property, counterexample, property, (.&.) )
 
-status' :: Ord (TxId tx) => TxId tx -> Submissions slot tx -> TxStatus slot tx
+status' :: Ord (TxId tx) => TxId tx -> Submissions meta slot tx -> TxStatus slot tx
 status' x = status x . transactions
 
 -- | As described in the specification:
@@ -31,7 +31,7 @@ status' x = status x . transactions
 -- will partition the transaction statuses.
 properties
     :: (Ord (TxId tx), Ord slot, Show (TxId tx))
-    => Step Operation slot tx -> Property
+    => Step Operation () slot tx -> Property
 properties (Step _ xs' _)
     = counterexample "submissions invariants" $ verify $ do
         that "finality precedes tip"

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Primitives.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Primitives.hs
@@ -29,15 +29,15 @@ import Test.QuickCheck
 
 import qualified Data.Map.Strict as Map
 
-txIds :: Submissions slot tx -> Set (TxId tx)
+txIds :: Submissions meta slot tx -> Set (TxId tx)
 txIds = Map.keysSet . transactions
 
 -- | Translations of primitive properties from specifications.
 properties
     :: (Ord (TxId tx), Eq tx, HasTxId tx
         , Ord slot, Show slot, Show tx)
-    => Step Primitive slot tx -> Property
-properties (Step xs xs' (AddSubmission expiring x)) = do
+    => Step Primitive meta slot tx -> Property
+properties (Step xs xs' (AddSubmission expiring x _)) = do
     let world = txIds xs <> txIds xs' <> singleton (txId x)
     counterexample "on add-submission" $ verify $ do
         that "tip and finality are not changed"

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/New/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/New/StoreSpec.hs
@@ -61,7 +61,7 @@ prop_SingleWalletStoreLawsOperations = withInitializedWalletProp
             runQ
             (mkStoreSubmissions wid)
             (pure $ Submissions mempty 0 0)
-            (logScale . genOperationsDelta)
+            (logScale . genOperationsDelta (pure ()))
 
 {-------------------------------------------------------------------------------
     Arbitrary instances

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/New/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/New/StoreSpec.hs
@@ -18,17 +18,23 @@ import Cardano.Wallet.DB.Fixtures
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.Submissions.New.Operations
-    ( DeltaTxSubmissions, mkStoreSubmissions )
+    ( DeltaTxSubmissions, SubmissionMeta (..), mkStoreSubmissions )
 import Cardano.Wallet.Primitive.Types
     ( SlotNo (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (Coin) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..), mockSealedTx )
+import Cardano.Wallet.Primitive.Types.Tx.TxMeta
+    ( Direction (Outgoing) )
 import Cardano.Wallet.Submissions.OperationsSpec
     ( genOperationsDelta )
 import Cardano.Wallet.Submissions.Submissions
     ( Submissions (..) )
 import Control.Monad
     ( replicateM, void )
+import Data.Quantity
+    ( Quantity (..) )
 import Fmt
     ( Buildable (..) )
 import System.Random
@@ -54,6 +60,9 @@ instance Buildable DeltaTxSubmissions where
 
 deriving instance Random SlotNo
 
+dummyMetadata :: SubmissionMeta
+dummyMetadata = SubmissionMeta 0 (Quantity 0) (Coin 0) Outgoing
+
 prop_SingleWalletStoreLawsOperations :: WalletProperty
 prop_SingleWalletStoreLawsOperations = withInitializedWalletProp
     $ \wid runQ -> do
@@ -61,7 +70,7 @@ prop_SingleWalletStoreLawsOperations = withInitializedWalletProp
             runQ
             (mkStoreSubmissions wid)
             (pure $ Submissions mempty 0 0)
-            (logScale . genOperationsDelta (pure ()))
+            (logScale . genOperationsDelta (pure dummyMetadata))
 
 {-------------------------------------------------------------------------------
     Arbitrary instances

--- a/lib/wallet/test/unit/Cardano/Wallet/Submissions/OperationsSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Submissions/OperationsSpec.hs
@@ -15,6 +15,8 @@ import Cardano.Wallet.Submissions.Properties.Operations
     ( properties )
 import Cardano.Wallet.Submissions.Submissions
     ( Submissions )
+import Cardano.Wallet.Submissions.TxStatus
+    ( HasTxId (..) )
 import System.Random
     ( Random )
 import Test.Hspec
@@ -31,15 +33,16 @@ spec = do
                 genOperationsSubmissionsHistory
 
 genOperationsDelta
-    :: (Arbitrary tx, Random slot, Num slot)
-    => Submissions slot tx
-    -> Gen (Operation slot tx )
-genOperationsDelta s =
+    :: (Arbitrary tx, Random slot, Num slot, HasTxId tx)
+    => Gen meta
+    -> Submissions meta slot tx
+    -> Gen (Operation meta slot tx )
+genOperationsDelta genMeta s =
     frequency
         [ (2, do
                 tx <- genTx 4 1 1 1 s
                 expiration <- genSlot 1 1 4 s
-                pure $ AddSubmission expiration tx
+                AddSubmission expiration tx <$> genMeta
         )
         , (4, do
                 txs <- scale (`div` 4) $ listOf $ genTx 1 6 1 1 s
@@ -63,6 +66,6 @@ genOperationsDelta s =
 genOperationsSubmissionsHistory :: GenSubmissionsHistory Operation
 genOperationsSubmissionsHistory = GenSubmissionsHistory
     { stepProperties = properties
-    , genDelta = genOperationsDelta
+    , genDelta = genOperationsDelta (pure ())
     , applyDelta = applyOperations
     }

--- a/lib/wallet/test/unit/Cardano/Wallet/Submissions/PrimitivesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Submissions/PrimitivesSpec.hs
@@ -16,6 +16,8 @@ import Cardano.Wallet.Submissions.Properties.Primitives
     ( properties )
 import Cardano.Wallet.Submissions.Submissions
     ( Submissions )
+import Cardano.Wallet.Submissions.TxStatus
+    ( HasTxId (..) )
 import System.Random
     ( Random )
 import Test.Hspec
@@ -31,15 +33,16 @@ spec = do
                 $ prop_submissionHistory genPrimitiveSubmissionsHistory
 
 genPrimitiveDelta
-    :: (Arbitrary tx, Random slot, Num slot)
-    => Submissions slot tx
-    -> Gen (Primitive slot tx)
-genPrimitiveDelta s =
+    :: (Arbitrary tx, Random slot, Num slot, HasTxId tx)
+    => Gen meta
+    -> Submissions meta slot tx
+    -> Gen (Primitive meta slot tx)
+genPrimitiveDelta genMeta s =
     frequency
         [ (2 , do
             tx <- genTx 4 1 1 1 s
             expiration <- genSlot 1 1 4 s
-            pure $ AddSubmission expiration tx
+            AddSubmission expiration tx <$> genMeta
           )
         , (4, do
             tx <- genTx 1 6 1 1 s
@@ -63,6 +66,6 @@ genPrimitiveDelta s =
 genPrimitiveSubmissionsHistory :: GenSubmissionsHistory Primitive
 genPrimitiveSubmissionsHistory = GenSubmissionsHistory
     { stepProperties = properties
-    , genDelta = genPrimitiveDelta
+    , genDelta = genPrimitiveDelta (pure ())
     , applyDelta = applyPrimitive
     }


### PR DESCRIPTION
This is a change to the  submission store to stay compatible with TxHistory in computing `TransactionInfo`

- added metadata to the submissions store
   - direction
   - slot (submission  slot)
   - height (submission block-height)
   - amount 
- modified the specifications to ignore the metadata
- fixed the store tests to play with fake metadata

ADP-2367