### PR TITLE
[ADP-2367] Orthogonal changes concerning `finalitySlot`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -351,11 +351,15 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , prune
         :: WalletId
         -> Quantity "block" Word32
+        -> SlotNo
         -> ExceptT ErrNoSuchWallet stm ()
         -- ^ Prune database entities and remove entities that can be discarded.
         --
         -- The second argument represents the stability window, or said
         -- length of the deepest rollback.
+        --
+        -- The third argument is the finality slot, or said
+        -- most recent stable slot
 
     , atomically
         :: forall a. stm a -> m a
@@ -406,6 +410,7 @@ data DBLayerCollection stm m s k = DBLayerCollection
     , prune_
         :: WalletId
         -> Quantity "block" Word32
+        -> SlotNo
         -> ExceptT ErrNoSuchWallet stm ()
     , atomically_
         :: forall a. stm a -> m a

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -664,7 +664,7 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
                         $ W.chainPointFromBlockHeader
                         $ view #currentTip wcp
 
-    let prune_ wid epochStability = do
+    let prune_ wid epochStability _finalitySlot = do
             ExceptT $ do
                 readCheckpoint wid >>= \case
                     Nothing -> pure $ Left $ ErrNoSuchWallet wid

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -1074,8 +1074,8 @@ listPendingLocalTxSubmissionQuery wid = fmap unRaw <$> rawSql query params
 localTxSubmissionFromEntity
     :: (W.SlotNo, LocalTxSubmission)
     -> W.LocalTxSubmissionStatus W.SealedTx
-localTxSubmissionFromEntity (sl0, LocalTxSubmission (TxId txid) _ sl tx) =
-    W.LocalTxSubmissionStatus txid tx sl0 sl
+localTxSubmissionFromEntity (_sl0, LocalTxSubmission (TxId txid) _ sl tx) =
+    W.LocalTxSubmissionStatus txid tx sl
 
 -- | Remove transactions from the local submission pool once they can no longer
 -- be rolled back.

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
@@ -560,9 +560,9 @@ mReadLocalTxSubmissionPending wid = readWalletModel wid $ \wal ->
         | status == Pending = Just (txid, slotNo)
         | otherwise = Nothing
 
-    getSubmission wal (tid, sl0) = make <$> Map.lookup tid (submittedTxs wal)
+    getSubmission wal (tid, _sl0) = make <$> Map.lookup tid (submittedTxs wal)
       where
-        make (tx, sl1) = LocalTxSubmissionStatus tid tx sl0 sl1
+        make (tx, sl1) = LocalTxSubmissionStatus tid tx sl1
 
 {-------------------------------------------------------------------------------
                              Model function helpers

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
@@ -765,15 +765,15 @@ instance NFData SlottingParameters
 
 -- | In Byron, this stability window is equal to 2k slots, where _k_ is the
 --  'getSecurityParameter'
-stabilityWindowByron :: SlottingParameters -> Quantity "block" Word64
-stabilityWindowByron sp = Quantity (2 * k)
+stabilityWindowByron :: SlottingParameters -> SlotNo
+stabilityWindowByron sp = SlotNo (2 * k)
   where
     k = fromIntegral $ getQuantity $ getSecurityParameter sp
 
 -- | In Shelley, this stability window is equal to _3k/f_ slots where _k_ is the
 -- 'getSecurityParameter' and _f_ is the 'ActiveSlotCoefficient'.
-stabilityWindowShelley :: SlottingParameters -> Quantity "block" Word64
-stabilityWindowShelley sp = Quantity len
+stabilityWindowShelley :: SlottingParameters -> SlotNo
+stabilityWindowShelley sp = SlotNo len
   where
     len = ceiling (3 * k / f)
     k = fromIntegral $ getQuantity $ getSecurityParameter sp
@@ -792,8 +792,8 @@ instance Buildable SlottingParameters where
 
 newtype ActiveSlotCoefficient
     = ActiveSlotCoefficient { unActiveSlotCoefficient :: Double }
-    deriving stock (Generic, Eq, Show)
-    deriving newtype (Buildable, Num, Fractional)
+        deriving stock (Generic, Eq, Show)
+        deriving newtype (Buildable, Num, Fractional, Real, Ord, RealFrac)
 
 instance NFData ActiveSlotCoefficient
 

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -181,8 +181,6 @@ data UnsignedTx input output change withdrawal = UnsignedTx
 data LocalTxSubmissionStatus tx = LocalTxSubmissionStatus
     { txId :: Hash "Tx"
     , submittedTx :: tx
-    , firstSubmission :: SlotNo
-    -- ^ Time of first successful submission to the local node.
     , latestSubmission :: SlotNo
     -- ^ Time of most recent resubmission attempt.
     } deriving stock (Generic, Show, Eq, Functor)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -567,6 +567,7 @@ fileModeSpec =  do
                         unsafeRunExceptT $ putCheckpoint testWid cpB
                         unsafeRunExceptT $ putTxHistory testWid txs
                         unsafeRunExceptT $ prune testWid (Quantity 2_160)
+                            $ 2_160 * 3 * 20
 
             it "Should spend collateral inputs and create spendable collateral \
                 \outputs if validation fails" $

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -722,7 +722,7 @@ mkLocalTxSubmissionStatus = mapMaybe getStatus . getTxHistory
       where
         i = tx ^. #txId
         sl = txMeta ^. #slotNo
-        st = LocalTxSubmissionStatus i (fakeSealedTx (tx, [])) sl sl
+        st = LocalTxSubmissionStatus i (fakeSealedTx (tx, [])) sl
 
 instance Arbitrary SlottingParameters where
     arbitrary = mk <$> choose (0.5, 1)
@@ -778,7 +778,7 @@ prop_localTxSubmission tc = monadicIO $ do
         atomically $ do
             let txHistory = getTxHistory (retryTestTxHistory tc)
             unsafeRunExceptT $ putTxHistory wid txHistory
-            forM_ (retryTestPool tc) $ \(LocalTxSubmissionStatus i tx _ sl) ->
+            forM_ (retryTestPool tc) $ \(LocalTxSubmissionStatus i tx sl) ->
                 unsafeRunExceptT $ putLocalTxSubmission wid i tx sl
 
         -- Run test


### PR DESCRIPTION
### Overview

This pull request extracts a couple of changes from #3673 that are of independent interest and can be merged as is. These changes are:

* Computation of the `finalitySlot` as `3*k/f` with appropriate types.
* Remove of the field `firstSubmission` from the `LocalTxSubmissionStatus` type.

### Issue Number

ADP-2367