### PR TITLE
[ADP-2377] QueryStore for `TxWalletsHistory`

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -241,6 +241,7 @@ library
     Cardano.Wallet.DB.Store.Transactions.Model
     Cardano.Wallet.DB.Store.Transactions.Store
     Cardano.Wallet.DB.Store.Transactions.TransactionInfo
+    Cardano.Wallet.DB.Store.Wallets.Layer
     Cardano.Wallet.DB.Store.Wallets.Model
     Cardano.Wallet.DB.Store.Wallets.Store
     Cardano.Wallet.DB.WalletState

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -849,6 +849,7 @@ test-suite unit
     Cardano.Wallet.DB.Store.Meta.StoreSpec
     Cardano.Wallet.DB.Store.Submissions.StoreSpec
     Cardano.Wallet.DB.Store.Transactions.StoreSpec
+    Cardano.Wallet.DB.Store.Wallets.LayerSpec
     Cardano.Wallet.DB.Store.Wallets.StoreSpec
     Cardano.Wallet.DelegationSpec
     Cardano.Wallet.DummyTarget.Primitive.Types

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{- |
+Copyright: © 2022 IOHK
+License: Apache-2.0
+
+Implementation of a 'QueryStore' for 'TxWalletsHistory'.
+-}
+module Cardano.Wallet.DB.Store.Wallets.Layer
+    ( QueryTxWalletsHistory (..)
+    , QueryStoreTxWalletsHistory
+    , newQueryStoreTxWalletsHistory
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.DB.Sqlite.Schema
+    ( TxMeta (..) )
+import Cardano.Wallet.DB.Sqlite.Types
+    ( TxId (..) )
+import Cardano.Wallet.DB.Store.Meta.Model
+    ( TxMetaHistory (relations), mkTxMetaHistory )
+import Cardano.Wallet.DB.Store.QueryStore
+    ( QueryStore (..) )
+import Cardano.Wallet.DB.Store.Transactions.Model
+    ( DeltaTxSet (..), TxRelation, mkTxSet )
+import Cardano.Wallet.DB.Store.Wallets.Model
+    ( DeltaTxWalletsHistory (..), walletsLinkedTransactions )
+import Cardano.Wallet.DB.Store.Wallets.Store
+    ( mkStoreTxWalletsHistory, mkStoreWalletsMeta )
+import Data.DBVar
+    ( Store (..), loadDBVar, modifyDBVar, readDBVar, updateDBVar )
+import Data.DeltaMap
+    ( DeltaMap (..) )
+import Data.Foldable
+    ( toList )
+import Database.Persist.Sql
+    ( SqlPersistT )
+
+import qualified Cardano.Wallet.DB.Store.Meta.Model as TxMetaStore
+import qualified Cardano.Wallet.DB.Store.Transactions.Layer as TxSet
+import qualified Cardano.Wallet.DB.Store.Transactions.Model as TxSet
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Data.Map.Strict as Map
+
+{-----------------------------------------------------------------------------
+    Query type
+------------------------------------------------------------------------------}
+data QueryTxWalletsHistory b where
+    GetByTxId :: TxId -> QueryTxWalletsHistory (Maybe TxRelation)
+    One :: W.WalletId -> TxId -> QueryTxWalletsHistory (Maybe TxMeta)
+    All :: W.WalletId -> QueryTxWalletsHistory [TxMeta]
+
+{-----------------------------------------------------------------------------
+    Query Store type
+------------------------------------------------------------------------------}
+type QueryStoreTxWalletsHistory =
+    QueryStore (SqlPersistT IO) QueryTxWalletsHistory DeltaTxWalletsHistory
+
+newQueryStoreTxWalletsHistory
+    :: forall m. m ~ SqlPersistT IO
+    => m QueryStoreTxWalletsHistory
+newQueryStoreTxWalletsHistory = do
+    let txsQueryStore = TxSet.mkDBTxSet
+    transactionsDBVar <- loadDBVar mkStoreWalletsMeta
+
+    let readAllMetas :: W.WalletId -> m [TxMeta]
+        readAllMetas wid = do
+            wmetas <- readDBVar transactionsDBVar
+            pure
+                . maybe [] (toList . relations)
+                $ Map.lookup wid wmetas
+
+        query :: forall a. QueryTxWalletsHistory a -> SqlPersistT IO a
+        query = \case
+            GetByTxId txid ->
+                queryS txsQueryStore $ TxSet.GetByTxId txid
+            One wid txid -> do
+                wmetas <- readDBVar transactionsDBVar
+                pure $ do
+                    metas <- Map.lookup wid wmetas
+                    Map.lookup txid . relations $ metas
+            All wid ->
+                readAllMetas wid
+
+    let updateTxSet = updateS (store txsQueryStore) undefined
+        update _ = \case
+            ChangeTxMetaWalletsHistory wid change ->
+                updateDBVar transactionsDBVar $ Adjust wid change
+            RemoveWallet wid ->
+                updateDBVar transactionsDBVar $ Delete wid
+            ExpandTxWalletsHistory wid cs -> do
+                updateTxSet
+                    . Append
+                    . mkTxSet
+                    $ fst <$> cs
+                modifyDBVar transactionsDBVar $ \mtxmh ->
+                    ( case Map.lookup wid mtxmh of
+                    Nothing -> Insert wid (mkTxMetaHistory wid cs)
+                    Just _ -> Adjust wid
+                        $ TxMetaStore.Expand
+                        $ mkTxMetaHistory wid cs
+                    , ()
+                    )
+
+            -- TODO as part of ADP-1043
+            -- Remove GarbageCollectTxWalletsHistory
+            -- in favor of `RollbackTo` + separate storage for Submissions
+            GarbageCollectTxWalletsHistory -> do
+                mtxmh <- readDBVar transactionsDBVar
+                -- BUG: The following operation is very expensive for large
+                -- wallets. Apply TODO above instead.
+                Right mtxh <- loadS (store txsQueryStore)
+                let txsToDelete
+                        = Map.keys
+                        . Map.withoutKeys (TxSet.relations mtxh)
+                            -- needs info about existing transactions
+                        $ walletsLinkedTransactions mtxmh
+                mapM_ (updateTxSet . DeleteTx) txsToDelete
+
+    pure QueryStore
+        { queryS = query
+        , store = Store
+            { loadS = loadS mkStoreTxWalletsHistory
+            , writeS = writeS mkStoreTxWalletsHistory
+            , updateS = update
+            }
+        }

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -19,6 +19,7 @@ Implementation of a store for 'TxWalletsHistory'
 module Cardano.Wallet.DB.Store.Wallets.Store
     ( mkStoreTxWalletsHistory
     , DeltaTxWalletsHistory(..)
+    , mkStoreWalletsMeta
     ) where
 
 import Prelude

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/LayerSpec.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Wallet.DB.Store.Wallets.LayerSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.DB.Sqlite
+    ( ForeignKeysSetting (..) )
+import Cardano.Wallet.DB.Fixtures
+    ( WalletProperty, logScale, withDBInMemory, withInitializedWalletProp )
+import Cardano.Wallet.DB.Store.QueryStore
+    ( QueryStore (store) )
+import Cardano.Wallet.DB.Store.Wallets.Layer
+    ( newQueryStoreTxWalletsHistory )
+import Cardano.Wallet.DB.Store.Wallets.StoreSpec
+    ( genDeltaTxWallets )
+import Test.DBVar
+    ( prop_StoreUpdates )
+import Test.Hspec
+    ( Spec, around, describe, it )
+import Test.QuickCheck
+    ( property )
+
+spec :: Spec
+spec = do
+    around (withDBInMemory ForeignKeysDisabled) $ do
+        describe "newQueryStoreTxWalletsHistory" $ do
+            it "respects store laws" $ property . prop_StoreWalletsLaws
+
+prop_StoreWalletsLaws :: WalletProperty
+prop_StoreWalletsLaws =
+  withInitializedWalletProp $ \wid runQ -> do
+    qs <- runQ newQueryStoreTxWalletsHistory
+    prop_StoreUpdates
+      runQ
+      (store qs)
+      (pure mempty)
+      (logScale . genDeltaTxWallets wid)


### PR DESCRIPTION
### Overview

This pull request implements a `QueryStore` for the `TxWalletsHistory` by storing the `TxSet` in the database on disk.
### Comments

* By storing the `TxSet` on disk, we should get back some RAM.
* We could reduce RAM usage further by keeping `MetasAndSubmissionsHistory` on disk. 

### Issue Number

ADP-2377