### PR TITLE
[ADP-2367] Implementation of  `DBPendingTxs` using a `DBVar` for `DeltaTxSubmissions`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -466,7 +466,8 @@ mkDBLayerFromParts ti DBLayerCollection{..} = DBLayer
         (getTx_ dbTxHistory) wid txid tip
     , putLocalTxSubmission = putLocalTxSubmission_ dbPendingTxs
     , readLocalTxSubmissionPending = readLocalTxSubmissionPending_ dbPendingTxs
-    , updatePendingTxForExpiry = updatePendingTxForExpiry_ dbPendingTxs
+    , updatePendingTxForExpiry = \wid tip -> wrapNoSuchWallet wid $
+        updatePendingTxForExpiry_ dbPendingTxs wid tip
     , removePendingOrExpiredTx = removePendingOrExpiredTx_ dbPendingTxs
     , putPrivateKey = \wid a -> wrapNoSuchWallet wid $
         putPrivateKey_ (dbPrivateKey wid) a
@@ -677,7 +678,7 @@ data DBPendingTxs stm = DBPendingTxs
     , updatePendingTxForExpiry_
         :: WalletId
         -> SlotNo
-        -> ExceptT ErrNoSuchWallet stm ()
+        -> stm ()
         -- ^ Removes any expired transactions from the pending set and marks
         -- their status as expired.
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -757,9 +757,9 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
             fmap (map localTxSubmissionFromEntity)
             . listPendingLocalTxSubmissionQuery
 
-        , updatePendingTxForExpiry_ = \wid tip -> ExceptT $
+        , updatePendingTxForExpiry_ = \wid tip ->
             selectWallet wid >>= \case
-                Nothing -> pure $ Left $ ErrNoSuchWallet wid
+                Nothing -> pure () -- non-existent wallet caught outside
                 Just _ -> modifyDBMaybe transactionsDBVar $ \_ ->
                     let
                         delta = Just
@@ -767,7 +767,7 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
                             $ ChangeMeta
                             $ Manipulate
                             $ AgeTxMetaHistory tip
-                    in  (delta, Right ())
+                    in  (delta, ())
 
         , removePendingOrExpiredTx_ = \wid txId ->
             let noTx =

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
@@ -508,6 +508,7 @@ Submissions
     submissionMetaBlockHeight       BlockHeight         sql=block_height
     submissionMetaAmount            W.Coin              sql=amount
     submissionMetaDirection         W.Direction         sql=direction
+    submissionMetaResubmitted       SlotNo              sql=resubmitted
 
     Primary submissionTxId
     deriving Show Generic Eq

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
@@ -12,8 +12,12 @@ module Cardano.Wallet.DB.Store.Submissions.New.Layer
 
 import Prelude
 
+import Cardano.Wallet
+    ( ErrNoSuchWallet (..) )
 import Cardano.Wallet.DB
-    ( DBPendingTxs (..) )
+    ( DBPendingTxs (..)
+    , ErrPutLocalTxSubmission (ErrPutLocalTxSubmissionNoSuchWallet)
+    )
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.Submissions.New.Operations
@@ -25,6 +29,8 @@ import Cardano.Wallet.Primitive.Types
     ( WalletId )
 import Cardano.Wallet.Primitive.Types.Tx
     ( LocalTxSubmissionStatus (LocalTxSubmissionStatus), SealedTx )
+import Cardano.Wallet.Submissions.Operations
+    ( Operation (..) )
 import Cardano.Wallet.Submissions.Submissions
     ( TxStatusMeta (..), transactionsL )
 import Cardano.Wallet.Submissions.TxStatus
@@ -34,9 +40,9 @@ import Control.Lens
 import Control.Monad.Except
     ( ExceptT (ExceptT) )
 import Data.DBVar
-    ( DBVar, readDBVar )
+    ( DBVar, modifyDBMaybe, readDBVar )
 import Data.DeltaMap
-    ( DeltaMap )
+    ( DeltaMap (..) )
 import Database.Persist.Sql
     ( SqlPersistT )
 
@@ -47,8 +53,20 @@ mkDbPendingTxs
     :: DBVar (SqlPersistT IO) (DeltaMap WalletId DeltaTxSubmissions)
     -> DBPendingTxs (SqlPersistT IO)
 mkDbPendingTxs dbvar = DBPendingTxs
-    { putLocalTxSubmission_ = \wid txid tx sl ->
-        error "putLocalTxSubmissions not implemented"
+    { putLocalTxSubmission_ = \wid txid tx sl -> do
+        let errNoSuchWallet = ErrPutLocalTxSubmissionNoSuchWallet $
+                ErrNoSuchWallet wid
+        ExceptT $ modifyDBMaybe dbvar $ \ws -> do
+            case Map.lookup wid ws of
+                Nothing -> (Nothing, Left errNoSuchWallet)
+                Just _  ->
+                    let
+                        delta = Just
+                            $ Adjust wid
+                            $ AddSubmission sl (TxId txid, tx)
+                            $ error "pls pass meta to putLocalTxSubmission!"
+                    in  (delta, Right ())
+
     , readLocalTxSubmissionPending_ = \wid -> do
             v <- readDBVar dbvar
             pure $ case Map.lookup wid v of

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
@@ -26,6 +26,7 @@ import Data.DeltaMap
 import Database.Persist.Sql
     ( SqlPersistT )
 
+-- TODO: This implementation is not completed / fully tested yet.
 mkDbPendingTxs
     :: DBVar (SqlPersistT IO) (DeltaMap WalletId DeltaTxSubmissions)
     -> DBPendingTxs stm

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 -- |
 -- Copyright: © 2022 IOHK
 -- License: Apache-2.0
@@ -13,30 +14,61 @@ import Prelude
 
 import Cardano.Wallet.DB
     ( DBPendingTxs (..) )
+import Cardano.Wallet.DB.Sqlite.Types
+    ( TxId (..) )
 import Cardano.Wallet.DB.Store.Submissions.New.Operations
-    ( DeltaTxSubmissions )
+    ( DeltaTxSubmissions
+    , SubmissionMeta (SubmissionMeta, submissionMetaResubmitted)
+    , TxSubmissionsStatus
+    )
 import Cardano.Wallet.Primitive.Types
     ( WalletId )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( LocalTxSubmissionStatus (LocalTxSubmissionStatus), SealedTx )
+import Cardano.Wallet.Submissions.Submissions
+    ( TxStatusMeta (..), transactionsL )
+import Cardano.Wallet.Submissions.TxStatus
+    ( getTx )
+import Control.Lens
+    ( (^.) )
 import Control.Monad.Except
     ( ExceptT (ExceptT) )
 import Data.DBVar
-    ( DBVar )
+    ( DBVar, readDBVar )
 import Data.DeltaMap
     ( DeltaMap )
 import Database.Persist.Sql
     ( SqlPersistT )
 
+import qualified Data.Map.Strict as Map
+
 -- TODO: This implementation is not completed / fully tested yet.
 mkDbPendingTxs
     :: DBVar (SqlPersistT IO) (DeltaMap WalletId DeltaTxSubmissions)
-    -> DBPendingTxs stm
+    -> DBPendingTxs (SqlPersistT IO)
 mkDbPendingTxs dbvar = DBPendingTxs
     { putLocalTxSubmission_ = \wid txid tx sl ->
         error "putLocalTxSubmissions not implemented"
-    , readLocalTxSubmissionPending_
-        = error "readLocalTxSubmissionPending_ not implemented"
+    , readLocalTxSubmissionPending_ = \wid -> do
+            v <- readDBVar dbvar
+            pure $ case Map.lookup wid v of
+                Nothing -> [] -- shouldn't we be throwing an exception here ?
+                Just sub -> do
+                    (_k, x) <- Map.assocs $ sub ^. transactionsL
+                    mkLocalTxSubmission x
     , updatePendingTxForExpiry_ = \wid tip -> ExceptT $
         error "updatePendingTxForExpiry_ not implemented"
     , removePendingOrExpiredTx_ = \wid txId ->
         error "removePendingOrExpiredTx_ not implemented"
     }
+
+mkLocalTxSubmission
+    :: TxSubmissionsStatus
+    -> [LocalTxSubmissionStatus SealedTx]
+mkLocalTxSubmission (TxStatusMeta status SubmissionMeta{..})
+    = maybe
+        []
+        (\(TxId txId, sealed) -> pure $
+            LocalTxSubmissionStatus (txId) sealed submissionMetaResubmitted
+        )
+        $ getTx status

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Operations.hs
@@ -23,6 +23,7 @@ module Cardano.Wallet.DB.Store.Submissions.New.Operations
     , syncSubmissions
     , mkStoreSubmissions
     , DeltaTxSubmissions
+    , TxSubmissionsStatus
     , SubmissionMeta (..)
     , mkStoreWalletsSubmissions
     ) where
@@ -89,6 +90,7 @@ data SubmissionMeta  = SubmissionMeta
     , submissionMetaHeight :: Quantity "block" Word32
     , submissionMetaAmount :: W.Coin
     , submissionMetaDirection :: W.Direction
+    , submissionMetaResubmitted :: SlotNo
     } deriving (Show, Eq)
 
 type TxSubmissions
@@ -125,6 +127,7 @@ syncSubmissions wid old new = do
                         submissionMetaHeight
                         submissionMetaAmount
                         submissionMetaDirection
+                        submissionMetaResubmitted
                     )
                 Nothing -> pure ()
     repsert
@@ -165,12 +168,12 @@ mkTransactions :: [Entity Submissions] -> Map TxId TxSubmissionsStatus
 mkTransactions xs = Map.fromList $ do
     Entity _
         (Submissions iden sealed expiration acceptance _ status
-            slot height amount direction)
+            slot height amount direction resubmitted)
             <- xs
     pure
         ( iden
         , mkStatusMeta
-            (SubmissionMeta slot height amount direction)
+            (SubmissionMeta slot height amount direction resubmitted)
                 iden sealed expiration acceptance status
         )
 

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Operations.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTSyntax #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {- |
 Copyright: © 2022 IOHK
@@ -49,8 +51,14 @@ data Operation meta slot tx where
     -- and max rollback time.
     Prune :: slot -> Operation meta slot tx
     -- | Remove a transaction from the tracked set.
-    Forget :: tx -> Operation meta slot tx
-    deriving (Show)
+    Forget :: TxId tx -> Operation meta slot tx
+
+deriving instance
+    ( Show (TxId tx)
+    , Show meta
+    , Show tx
+    , Show slot)
+    => Show (Operation meta slot tx)
 
 
 -- | Apply a high level operation to the submission store.

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Primitives.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Primitives.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTSyntax #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {- |
 Copyright: © 2022 IOHK
@@ -62,9 +64,15 @@ data Primitive meta slot tx where
         Primitive meta slot tx
     -- | Remove a transaction from tracking in the submissions store.
     Forget ::
-        {_transaction :: tx} ->
+        {_transactionId :: TxId tx} ->
         Primitive meta slot tx
-    deriving (Show)
+
+deriving instance
+    ( Show (TxId tx)
+    , Show meta
+    , Show tx
+    , Show slot)
+    => Show (Primitive meta slot tx)
 
 -- | Apply a 'Primitive' to a submission, according to the specification.
 applyPrimitive
@@ -124,4 +132,4 @@ applyPrimitive (MoveFinality newFinality) s =
             | expiring <= fin = Nothing
             | otherwise = Just status
         f status = Just status
-applyPrimitive (Forget tx) s = s & transactionsL %~ Map.delete (txId tx)
+applyPrimitive (Forget txid) s = s & transactionsL %~ Map.delete txid

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Primitives.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Properties/Primitives.hs
@@ -128,7 +128,7 @@ properties (Step xs xs' (MoveFinality newFinality)) = do
                         & counterexample "expired should have been pruned"
                 _ -> new === old
 properties (Step xs xs' (Forget x)) = do
-    let world = txIds xs <> txIds xs' <> singleton (txId x)
+    let world = txIds xs <> txIds xs' <> singleton x
     counterexample "on move-tip" $ verify $ do
         that "tip shouldn't have changed" $ tip xs === tip xs'
         that "finality shouldn't have changed" $ finality xs === finality xs'
@@ -136,7 +136,7 @@ properties (Step xs xs' (Forget x)) = do
             let old = status y $ transactions xs
                 new = status y $ transactions xs'
             in case old of
-                _ | txId x == y
+                _ | x == y
                     ->
                         new === Unknown
                         & counterexample "transaction should have been removed"

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Submissions.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Submissions.hs
@@ -56,7 +56,7 @@ data Submissions meta slot tx = Submissions
     }
 
 deriving instance
-    (Show slot, HasTxId tx, Show tx, Show meta) =>
+    (HasTxId tx, Show slot, Show tx, Show meta) =>
     (Show (Submissions meta slot tx))
 
 deriving instance

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/New/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/New/StoreSpec.hs
@@ -61,7 +61,7 @@ instance Buildable DeltaTxSubmissions where
 deriving instance Random SlotNo
 
 dummyMetadata :: SubmissionMeta
-dummyMetadata = SubmissionMeta 0 (Quantity 0) (Coin 0) Outgoing
+dummyMetadata = SubmissionMeta 0 (Quantity 0) (Coin 0) Outgoing 0
 
 prop_SingleWalletStoreLawsOperations :: WalletProperty
 prop_SingleWalletStoreLawsOperations = withInitializedWalletProp

--- a/lib/wallet/test/unit/Cardano/Wallet/Submissions/OperationsSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Submissions/OperationsSpec.hs
@@ -60,7 +60,7 @@ genOperationsDelta genMeta s =
         )
         , (1, do
                 tx <- genTx 1 2 2 2 s
-                pure $ Forget tx
+                pure $ Forget $ txId tx
         )]
 
 genOperationsSubmissionsHistory :: GenSubmissionsHistory Operation

--- a/lib/wallet/test/unit/Cardano/Wallet/Submissions/PrimitivesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Submissions/PrimitivesSpec.hs
@@ -59,7 +59,7 @@ genPrimitiveDelta genMeta s =
           )
         , (1, do
             tx <- genTx 1 2 2 2 s
-            pure $ Forget tx
+            pure $ Forget $ txId tx
           )
         ]
 


### PR DESCRIPTION
### Overview

This pull request cherry-picks changes from #3673 for the purpose of merging them.

Here, we extract an implementation of the `DBPendingTxs` interface given a `DBVar` for the `TxSubmissions` data type. This implementation is *partial* in that it still contains calls to `error` which need to be resolved — however, this requires changes to the interface at the usage site.

Also, this pull request does not yet make an attempt at integrating this implementation of `DBPendingTxs` with the rest of the wallet.

### Issue Number

ADP-2367, ADP-2566