### PR TITLE
[ADP-2367] Change `updatePendingTxForExpiry` to `rollForwardTxSubmissions`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1170,7 +1170,9 @@ restoreBlocks ctx tr wid blocks nodeTip = db & \DBLayer{..} ->
 
     putTxHistory wid txs
 
-    updatePendingTxForExpiry wid (view #slotNo localTip)
+    rollForwardTxSubmissions wid (localTip ^. #slotNo)
+        $ fmap (\(tx,meta) -> (meta ^. #slotNo, txId tx)) txs
+
     forM_ slotPoolDelegations $ \delegation@(slotNo, cert) -> do
         liftIO $ logDelegation delegation
         putDelegationCertificate wid cert slotNo

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -757,7 +757,7 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
             fmap (map localTxSubmissionFromEntity)
             . listPendingLocalTxSubmissionQuery
 
-        , updatePendingTxForExpiry_ = \wid tip ->
+        , rollForwardTxSubmissions_ = \wid tip _txs ->
             selectWallet wid >>= \case
                 Nothing -> pure () -- non-existent wallet caught outside
                 Just _ -> modifyDBMaybe transactionsDBVar $ \_ ->

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -198,9 +198,14 @@ newDBLayer timeInterpreter = do
         , readLocalTxSubmissionPending =
             readDB db . mReadLocalTxSubmissionPending
 
-        , updatePendingTxForExpiry = \pk tip -> ExceptT $
+        , rollForwardTxSubmissions = \pk tip _txs -> ExceptT $
             alterDB errNoSuchWallet db $
             mUpdatePendingTxForExpiry pk tip
+                -- FIXME ADP-2367 by DELETION:
+                -- These tests will become obsolete once
+                -- the new Submission storage has been integrated.
+                -- In order to keep them running, we ignore the first argument
+                -- here.
 
         , removePendingOrExpiredTx = \pk tid -> ExceptT $
             alterDB errCannotRemovePendingTx db $

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
@@ -42,6 +42,8 @@ import Control.Lens
     ( (^.) )
 import Control.Monad.Except
     ( ExceptT (ExceptT) )
+import Data.Bifunctor
+    ( second )
 import Data.DBVar
     ( DBVar, modifyDBMaybe, readDBVar, updateDBVar )
 import Data.DeltaMap
@@ -78,10 +80,9 @@ mkDbPendingTxs dbvar = DBPendingTxs
                     (_k, x) <- Map.assocs $ sub ^. transactionsL
                     mkLocalTxSubmission x
 
-    , updatePendingTxForExpiry_ = \wid tip ->
+    , rollForwardTxSubmissions_ = \wid tip txs ->
         updateDBVar dbvar
-            $ Adjust wid $ RollForward tip
-            $ error "needs transactions for rollforward"
+            $ Adjust wid $ RollForward tip (second TxId <$> txs)
 
     , removePendingOrExpiredTx_ = \wid txId -> do
         let errNoSuchWallet = ErrRemoveTxNoSuchWallet

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Operations.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTSyntax #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {- |
@@ -39,7 +40,7 @@ data Operation meta slot tx where
     -- in-submission.
     RollForward
       :: slot -- ^ New tip.
-      -> [(slot, tx)] -- ^ Transactions that were found in the ledder.
+      -> [(slot, TxId tx)] -- ^ Transactions that were found in the ledder.
       -> Operation meta slot tx
     -- | Move transactions from the in-ledger state to in-submission state,
     -- when their acceptance slot falls after the new tip.

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -546,7 +546,10 @@ runIO db@DBLayer{..} = fmap Resp . go
             Right . LocalTxSubmission . map (fmap reMockTxId) <$>
             atomically (readLocalTxSubmissionPending wid)
         UpdatePendingTxForExpiry wid sl -> catchNoSuchWallet Unit $
-            mapExceptT atomically $ updatePendingTxForExpiry wid sl
+            mapExceptT atomically $ rollForwardTxSubmissions wid sl
+                []  -- FIXME ADP-2367 by DELETION:
+                    -- These tests will become obsolete. In order to run
+                    -- them on the old code, we use an empty list here.
         RemovePendingOrExpiredTx wid tid ->
             (catchCannotRemovePendingTx wid) Unit $
             mapExceptT atomically $

--- a/lib/wallet/test/unit/Cardano/Wallet/Submissions/OperationsSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Submissions/OperationsSpec.hs
@@ -48,7 +48,7 @@ genOperationsDelta genMeta s =
                 txs <- scale (`div` 4) $ listOf $ genTx 1 6 1 1 s
                 slots <- scale (`div` 4) $ listOf $ genSlot 1 1 4 s
                 acceptance <- genSlot 1 1 4 s
-                pure $ RollForward acceptance $ zip slots txs
+                pure $ RollForward acceptance $ zip slots $ txId <$> txs
         )
         , (2, do
                 newtip <- genSlot 1 3 3 s

--- a/lib/wallet/test/unit/Cardano/Wallet/Submissions/PrimitivesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Submissions/PrimitivesSpec.hs
@@ -47,7 +47,7 @@ genPrimitiveDelta genMeta s =
         , (4, do
             tx <- genTx 1 6 1 1 s
             acceptance <- genSlot 1 1 4 s
-            pure $ MoveToLedger acceptance tx
+            pure $ MoveToLedger acceptance $ txId tx
           )
         , (2, do
             newtip <- genSlot 1 3 3 s


### PR DESCRIPTION
### Overview

This pull request cherry-picks changes from #3673 for the purpose of merging them.

Here, we change the semantics of `updatePendingTxForExpiry` and rename it to `rollForwardTxSubmissions`.

* Previously, in `restoreBlocks`, the function `updatePendingTxForExpiry` was given the local tip and marked all pending transactions as expired. The previous call to `putTxHistory` was responsible for moving transactions with status `Pending` to status `InLedger`. 
* Now, `rollForwardTxSubmissions` has the responsibility to mark transactions with status `Pending` as either `Expired` or `InLedger`, depending on whether they appear in the argument list or not.

This re-imagining is necessary to separate the concerns of "keeping track of the transaction history in the ledger" and "submitting transactions to the ledger".

### Comments

* As this change touches a code path that is "live", we do not yet decommission the State Machine tests, but we do change them to ignore the additional argument. This is sufficient for the old semantics.

### Issue number

ADP-2367, ADP-2567