### PR TITLE
[ADP-2367] Add function `addTxSubmission` to `DBLayer`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,7 @@ env:
   CACHE_DIR: "/cache/cardano-wallet"
   macos: "x86_64-darwin"
   linux: "x86_64-linux"
+  TMPDIR: "/cache"
 
 
 steps:

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -146,7 +146,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans
     ( lift )
 import Control.Monad.Trans.Except
-    ( ExceptT (..) )
+    ( ExceptT (..), runExceptT )
 import Control.Tracer
     ( Tracer, contramap, traceWith )
 import Data.Coerce
@@ -752,6 +752,11 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = do
                                             ]
                                     in  (delta, Right ())
 
+        , addTxSubmission_ = \wid (tx, meta, binary) sl -> do
+            putTxHistory_ dbTxHistory
+                wid [(tx, meta)]
+            void $ runExceptT $ putLocalTxSubmission_ dbPendingTxs
+                wid (tx ^. #txId) binary sl
 
         , readLocalTxSubmissionPending_ =
             fmap (map localTxSubmissionFromEntity)

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -195,6 +195,8 @@ newDBLayer timeInterpreter = do
             alterDB (fmap ErrPutLocalTxSubmissionNoSuchWallet . errNoSuchWallet) db $
             mPutLocalTxSubmission pk txid tx sl
 
+        , addTxSubmission = error "Not implemented in old design"
+
         , readLocalTxSubmissionPending =
             readDB db . mReadLocalTxSubmissionPending
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
@@ -72,6 +72,8 @@ mkDbPendingTxs dbvar = DBPendingTxs
                             $ error "pls pass meta to putLocalTxSubmission!"
                     in  (delta, Right ())
 
+    , addTxSubmission_ = error "todo implement"
+
     , readLocalTxSubmissionPending_ = \wid -> do
             v <- readDBVar dbvar
             pure $ case Map.lookup wid v of

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Layer.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RecordWildCards #-}
 -- |
 -- Copyright: © 2022 IOHK
@@ -27,6 +28,7 @@ import Cardano.Wallet.DB.Store.Submissions.New.Operations
     ( DeltaTxSubmissions
     , SubmissionMeta (SubmissionMeta, submissionMetaResubmitted)
     , TxSubmissionsStatus
+    , submissionMetaFromTxMeta
     )
 import Cardano.Wallet.Primitive.Types
     ( WalletId )
@@ -48,6 +50,8 @@ import Data.DBVar
     ( DBVar, modifyDBMaybe, readDBVar, updateDBVar )
 import Data.DeltaMap
     ( DeltaMap (..) )
+import Data.Maybe
+    ( fromJust )
 import Database.Persist.Sql
     ( SqlPersistT )
 
@@ -72,7 +76,16 @@ mkDbPendingTxs dbvar = DBPendingTxs
                             $ error "pls pass meta to putLocalTxSubmission!"
                     in  (delta, Right ())
 
-    , addTxSubmission_ = error "todo implement"
+    , addTxSubmission_ =  \wid (tx,meta,sealedTx) resubmitted ->
+        let expiry = fromJust (meta ^. #expiry)
+            -- FIXME ADP-2367: The value 'meta' supplied here is
+            -- constructed by 'Cardano.Wallet.mkTxMeta', where this
+            -- field is always a 'Just'. In the future, we should
+            -- the expiration slot directly from a @tx :: Read.Tx@.
+        in  updateDBVar dbvar
+                $ Adjust wid
+                $ AddSubmission expiry (TxId $ tx ^. #txId, sealedTx)
+                $ submissionMetaFromTxMeta meta resubmitted
 
     , readLocalTxSubmissionPending_ = \wid -> do
             v <- readDBVar dbvar

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/New/Operations.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -25,6 +26,7 @@ module Cardano.Wallet.DB.Store.Submissions.New.Operations
     , mkStoreWalletsSubmissions
 
     , SubmissionMeta (..)
+    , submissionMetaFromTxMeta
     ) where
 
 import Prelude
@@ -39,6 +41,8 @@ import Cardano.Wallet.DB.Sqlite.Types
     ( TxId, TxSubmissionStatusEnum (..) )
 import Cardano.Wallet.Primitive.Types
     ( SlotNo (..), WalletId )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxMeta (..) )
 import Cardano.Wallet.Submissions.Operations
     ( applyOperations )
 import Cardano.Wallet.Submissions.Submissions
@@ -108,6 +112,16 @@ data SubmissionMeta  = SubmissionMeta
     , submissionMetaDirection :: W.Direction
     , submissionMetaResubmitted :: SlotNo
     } deriving (Show, Eq)
+
+submissionMetaFromTxMeta :: TxMeta -> SlotNo -> SubmissionMeta
+submissionMetaFromTxMeta TxMeta{direction,blockHeight,slotNo,amount} resub =
+    SubmissionMeta
+        { submissionMetaSlot = slotNo
+        , submissionMetaHeight = blockHeight
+        , submissionMetaAmount = amount
+        , submissionMetaDirection = direction
+        , submissionMetaResubmitted = resub
+        }
 
 {-----------------------------------------------------------------------------
     Store for a single wallet


### PR DESCRIPTION
### Overview

This pull request supports the cherry-picking of #3673.

Here, we introduce a new function `addTxSubmission` in the `DBLayer`.

* Previously, `Cardano.Wallet.submitTx` was responsible for adding a new transaction to both the transaction history and the local tx submission pool.
* Now, the responsibility for keeping the transaction history and local tx submission in sync rests with `addTxSubmission` — and we are free to change that responsibility.

This change is necessary to separate the concerns of "keeping track of the transaction history in the ledger" and "submitting transactions to the ledger".

### Comments

* As we want to decommission the state machine tests, the function `addTxSubmission` is not tested as part of these tests.
* We provide an implemented `addTxSubmission` for the "live" database, which is a copy&paste from the previous implementation of `submitTx`. Both it's functionality and its implementation are subject to the same tests as before.
 
### Issue number

ADP-2367, ADP-2572