### PR TITLE
[ADP-2573] patch tx history with submissions

### DIFF
--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -540,7 +540,7 @@ benchReadTxHistory
     -> DBLayerBench
     -> IO [TransactionInfo]
 benchReadTxHistory sortOrder (inf, sup) mstatus DBLayer{..} =
-    atomically $ readTxHistory testWid Nothing sortOrder range mstatus
+    atomically $ readTransactions testWid Nothing sortOrder range mstatus
   where
     range = Range
         (SlotNo . fromIntegral <$> inf)

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -234,6 +234,7 @@ library
     Cardano.Wallet.DB.Store.Meta.Model
     Cardano.Wallet.DB.Store.Meta.Store
     Cardano.Wallet.DB.Store.Submissions.Model
+    Cardano.Wallet.DB.Store.Submissions.New.Layer
     Cardano.Wallet.DB.Store.Submissions.New.Operations
     Cardano.Wallet.DB.Store.Submissions.Store
     Cardano.Wallet.DB.Store.Transactions.Decoration

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -273,7 +273,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         --
         -- If the wallet doesn't exist, this operation returns an error.
 
-    , readTxHistory
+    , readTransactions
         :: WalletId
         -> Maybe Coin
         -> SortOrder
@@ -468,7 +468,7 @@ mkDBLayerFromParts ti DBLayerCollection{..} = DBLayer
         readDelegationRewardBalance_ (dbDelegation wid)
     , putTxHistory = \wid a -> wrapNoSuchWallet wid $
         putTxHistory_ dbTxHistory wid a
-    , readTxHistory = \wid minWithdrawal order range status ->
+    , readTransactions = \wid minWithdrawal order range status ->
         readCurrentTip wid >>= \case
             Just tip -> do
                 tinfos <- (readTxHistory_ dbTxHistory) wid range status tip

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
@@ -176,7 +176,7 @@ data WalletDatabase s xprv = WalletDatabase
 -- | Shorthand for the putTxHistory argument type.
 type TxHistoryMap = Map (Hash "Tx") (Tx, TxMeta)
 
--- | Shorthand for the readTxHistory result type.
+-- | Shorthand for the readTransactions result type.
 type TxHistory = [(Tx, TxMeta)]
 
 -- | Produces an empty model database.

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -149,7 +149,7 @@ newDBLayer timeInterpreter = do
             alterDB errNoSuchWallet db $
             mPutTxHistory pk txh
 
-        , readTxHistory = \pk minWithdrawal order range mstatus ->
+        , readTransactions = \pk minWithdrawal order range mstatus ->
             readDB db $
                 mReadTxHistory
                     timeInterpreter

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
@@ -21,6 +21,7 @@ module Cardano.Wallet.DB.Store.Transactions.Decoration
    , mkTxOutKey
    , mkTxOutKeyCollateral
    , TxOutKey
+   , TxInDecorator
    ) where
 
 import Prelude hiding
@@ -141,3 +142,6 @@ decorateTxInsForReadTx txSet tx
   where
     undoWTxIn :: W.TxIn -> (TxId, Word32)
     undoWTxIn (W.TxIn k n) = (TxId k,n)
+
+-- | A decorator that can handle the 'TxSet' inside 'm'. Just a stub for now
+type TxInDecorator a m = a -> m DecoratedTxIns

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
@@ -15,7 +15,7 @@
 --
 module Cardano.Wallet.Primitive.Types.Tx.SealedTx (
      -- * Types
-    SealedTx (serialisedTx)
+    SealedTx (serialisedTx, unsafeCardanoTx)
     , cardanoTxIdeallyNoLaterThan
     , sealedTxFromBytes
     , sealedTxFromBytes'

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TransactionInfo.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -17,6 +18,7 @@ module Cardano.Wallet.Primitive.Types.Tx.TransactionInfo
     ( TransactionInfo (..)
     , fromTransactionInfo
     , toTxHistory
+    , hasStatus
     )
     where
 
@@ -33,7 +35,7 @@ import Cardano.Wallet.Primitive.Types.Tx.Tx
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn )
 import Cardano.Wallet.Primitive.Types.Tx.TxMeta
-    ( TxMeta )
+    ( TxMeta, TxStatus, status )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut )
 import Cardano.Wallet.Read.Tx.CBOR
@@ -105,3 +107,8 @@ fromTransactionInfo info = Tx
 -- | Drop time-specific information
 toTxHistory :: TransactionInfo -> (Tx, TxMeta)
 toTxHistory info = (fromTransactionInfo info, txInfoMeta info)
+
+hasStatus :: TxStatus -> TransactionInfo -> Bool
+hasStatus s TransactionInfo{txInfoMeta}
+    | status txInfoMeta == s = True
+    | otherwise = False

--- a/lib/wallet/src/Cardano/Wallet/Read/Eras/EraValue.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Eras/EraValue.hs
@@ -37,6 +37,7 @@ module Cardano.Wallet.Read.Eras.EraValue
   -- * Specials
   , sequenceEraValue
   , witnessEra
+  , hoistEraValue
 
   -- * Internals
   , cardanoEras
@@ -79,7 +80,7 @@ import Generics.SOP
     )
 import Generics.SOP.Classes
 import Generics.SOP.NP
-    ( cmap_NP, zipWith_NP )
+    ( cmap_NP, pure_NP, zipWith_NP )
 import Generics.SOP.NS
     ( ap_NS, collapse_NS, index_NS, sequence'_NS )
 
@@ -191,3 +192,7 @@ renderEraValue e = (extractEraValue e, indexEraValue e)
 -- era expressed as Int, starting from 0, see 'KnownEras'.
 eraValueSerialize :: Prism' (a, Int) (EraValue (K a))
 eraValueSerialize = prism renderEraValue parseEraValue
+
+-- | change unconditionally the functor
+hoistEraValue :: (forall a. f a -> g a)  -> EraValue f -> EraValue g
+hoistEraValue f (EraValue ns) = EraValue $ ap_NS (pure_NP $ Fn f) ns

--- a/lib/wallet/src/Cardano/Wallet/Read/Tx/Cardano.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Tx/Cardano.hs
@@ -8,10 +8,15 @@
 
 module Cardano.Wallet.Read.Tx.Cardano
     ( fromCardanoApiTx
+    , fromSealedTx
     ) where
 
 import Prelude
 
+import Cardano.Api
+    ( InAnyCardanoEra (..) )
+import Cardano.Wallet.Primitive.Types.Tx.SealedTx
+    ( SealedTx (unsafeCardanoTx) )
 import Cardano.Wallet.Read.Eras
     ( EraValue, allegra, alonzo, babbage, byron, inject, mary, shelley )
 import Cardano.Wallet.Read.Tx
@@ -22,6 +27,7 @@ import Control.Monad
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Byron as Cardano
 import qualified Cardano.Api.Shelley as Cardano
+import qualified Cardano.Wallet.Primitive.Types.Tx.SealedTx as W
 
 fromCardanoApiTx :: Cardano.Tx era -> EraValue Tx
 fromCardanoApiTx = \case
@@ -32,3 +38,8 @@ fromCardanoApiTx = \case
         Cardano.ShelleyBasedEraAlonzo -> inject alonzo $ Tx tx
         Cardano.ShelleyBasedEraBabbage -> inject babbage $ Tx tx
     Cardano.ByronTx tx -> inject byron $ Tx $ void tx
+
+fromSealedTx:: W.SealedTx -> EraValue Tx
+fromSealedTx sealed =
+    case unsafeCardanoTx sealed of
+        InAnyCardanoEra _ce tx -> fromCardanoApiTx tx

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Submissions.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Submissions.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTSyntax #-}
 {-# LANGUAGE LambdaCase #-}
@@ -39,7 +40,7 @@ data TxStatusMeta meta slot tx = TxStatusMeta
     { _txStatus :: TxStatus slot tx
     , _txStatusMeta :: meta
     }
-    deriving (Show, Eq)
+    deriving (Show, Eq, Functor)
 
 makeLenses ''TxStatusMeta
 

--- a/lib/wallet/src/Cardano/Wallet/Submissions/TxStatus.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/TxStatus.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTSyntax #-}
 {-# LANGUAGE LambdaCase #-}
@@ -61,7 +62,7 @@ data TxStatus slot tx where
       -> TxStatus slot tx
     -- | A transaction which is not tracked by the submissions store.
     Unknown :: TxStatus slot tx
-    deriving (Show, Eq)
+    deriving (Show, Eq, Functor)
 
 makePrisms ''TxStatus
 

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -534,7 +534,7 @@ runIO db@DBLayer{..} = fmap Resp . go
         ReadTxHistory wid minWith order range status ->
             fmap (Right . TxHistory) $
             atomically $
-            readTxHistory wid minWith order range status
+            readTransactions wid minWith order range status
         GetTx wid tid ->
             catchNoSuchWallet (TxHistory . maybe [] pure) $
             mapExceptT atomically $ getTx wid tid
@@ -1154,8 +1154,8 @@ tag = Foldl.fold $ catMaybes <$> sequenceA
     , createWalletTwice
     , removeWalletTwice
     , createThenList
-    , readTxHistory (not . null) SuccessfulReadTxHistory
-    , readTxHistory null UnsuccessfulReadTxHistory
+    , readTransactions (not . null) SuccessfulReadTxHistory
+    , readTransactions null UnsuccessfulReadTxHistory
     , txUnsorted inputs TxUnsortedInputs
     , txUnsorted outputs TxUnsortedOutputs
     , readCheckpoint isJust SuccessfulReadCheckpoint
@@ -1291,11 +1291,11 @@ tag = Foldl.fold $ catMaybes <$> sequenceA
             | or created = Just CreateThenList
             | otherwise = Nothing
 
-    readTxHistory
+    readTransactions
         :: ([TransactionInfo] -> Bool)
         -> Tag
         -> Fold (Event s Symbolic) (Maybe Tag)
-    readTxHistory check res = Fold update False (extractf res)
+    readTransactions check res = Fold update False (extractf res)
       where
         update :: Bool -> Event s Symbolic -> Bool
         update didRead ev = didRead || case (cmd ev, mockResp ev) of


### PR DESCRIPTION
- add a getPendingTransactions_ field to `DBPendingTxs` record
- implement getPendingTransactions_ which produces TransactionInfo from the Submissions encoding (`SealedTx`)
- rename readTxHistory in the final layer in readTransactions
- fix readTransactions to incorporate pending from submissions
ADP-2573