### PR TITLE
Use buildAndSignTransactionNew in quitStakePool

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
@@ -369,7 +369,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     stakePools =
              listStakePools_
         :<|> joinStakePool shelley (knownPools spl) (getPoolLifeCycleStatus spl)
-        :<|> quitStakePool shelley
+        :<|> quitStakePool shelley (delegationAddress @n)
         :<|> (postPoolMaintenance :<|> getPoolMaintenance)
         :<|> delegationFee shelley
         :<|> listStakeKeys rewardAccountFromAddress shelley

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -210,6 +210,7 @@ instance IsServerError WalletException where
         ExceptionWitnessTx e -> toServerError e
         ExceptionDecodeTx e -> toServerError e
         ExceptionSubmitTx e -> toServerError e
+        ExceptionNoSuchWallet e -> toServerError e
         ExceptionUpdatePassphrase e -> toServerError e
         ExceptionWithRootKey e -> toServerError e
         ExceptionListTransactions e -> toServerError e

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2848,8 +2848,11 @@ constructSharedTransaction
                                 pure []
 
                         (sel', utx, fee') <- liftHandler $ runSelection outs
-                        sel <- liftHandler $
-                            W.assignChangeAddressesWithoutDbUpdate wrk wid genChange utx
+                        let (sel, _s') =
+                                W.assignChangeAddresses
+                                    genChange
+                                    utx
+                                    (getState cp)
                         (FeeEstimation estMin _) <- liftHandler $ W.estimateFee (pure fee')
                         pure (sel, sel', estMin)
 
@@ -3004,7 +3007,7 @@ balanceTransaction ctx@ApiLayer{..} genChange (ApiT wid) body = do
                 => W.PartialTx era
                 -> Handler (Cardano.Tx era)
             balanceTx partialTx =
-                liftHandler $ W.balanceTransaction @_ @IO @s @k @ktype
+                fmap fst $ liftHandler $ W.balanceTransaction @_ @IO @s @k @ktype
                     (MsgWallet >$< wrk ^. W.logger)
                     (ctx ^. typed)
                     genChange
@@ -3505,7 +3508,7 @@ quitStakePool ctx@ApiLayer{..} genChange (ApiT walletId) body = do
                 Nothing ->
                     liftHandler $ throwE ErrReadRewardAccountNotAShelleyWallet
                 Just Refl -> liftIO $ WD.quitStakePool netLayer db ti walletId
-            (tx, txMeta, txTime, sealedTx) <- liftIO $ do
+            (tx, txMeta, txTime, sealedTx, _s') <- liftIO $ do
                 pureTimeInterpreter <- snapshot $ timeInterpreter netLayer
                 W.buildAndSignTransactionNew @k @'CredFromKeyK @s @n
                     (MsgWallet >$< wrk ^. W.logger)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1629,7 +1629,7 @@ balanceTransaction
     -- ^ TODO [ADP-1789] Replace with @Cardano.UTxO@ and something simpler than
     -- @Wallet s@ for change address generation.
     -> PartialTx era
-    -> ExceptT ErrBalanceTx m (Cardano.Tx era)
+    -> ExceptT ErrBalanceTx m ((Cardano.Tx era, s))
 balanceTransaction tr txLayer change pp ti wallet unadjustedPtx = do
     -- TODO [ADP-1490] Take 'Ledger.PParams era' directly as argument, and avoid
     -- converting to/from Cardano.ProtocolParameters. This may affect
@@ -1717,6 +1717,7 @@ increaseZeroAdaOutputs era pp = WriteTx.modifyLedgerBody $
             then WriteTx.computeMinimumCoinForTxOut era pp out
             else c
 
+
 -- | Internal helper to 'balanceTransaction'
 balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     :: forall era m s k ktype.
@@ -1733,7 +1734,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     -> (UTxOIndex WalletUTxO, Wallet s, Set Tx)
     -> SelectionStrategy
     -> PartialTx era
-    -> ExceptT ErrBalanceTx m (Cardano.Tx era)
+    -> ExceptT ErrBalanceTx m (Cardano.Tx era, s)
 balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     tr
     txLayer
@@ -1754,7 +1755,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 
     (balance0, minfee0) <- balanceAfterSettingMinFee partialTx
 
-    (extraInputs, extraCollateral, extraOutputs) <- do
+    (extraInputs, extraCollateral, extraOutputs, s') <- do
 
         -- NOTE: It is not possible to know the script execution cost in
         -- advance because it actually depends on the final transaction. Inputs
@@ -1767,13 +1768,14 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 
         randomSeed <- stdGenSeed
         let
-            transform :: s -> Selection -> ([(TxIn, TxOut)], [TxIn], [TxOut])
+            transform :: s -> Selection -> ([(TxIn, TxOut)], [TxIn], [TxOut], s)
             transform s sel =
-                let (sel', _) = assignChangeAddresses generateChange sel s
+                let (sel', s') = assignChangeAddresses generateChange sel s
                     inputs = F.toList (sel' ^. #inputs)
                 in  ( inputs
                     , fst <$> (sel' ^. #collateral)
                     , sel' ^. #change
+                    , s'
                     )
 
         lift $ traceWith tr $ MsgSelectionForBalancingStart
@@ -1854,12 +1856,13 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         (ExceptT . pure $
             distributeSurplus txLayer feePolicy surplus feeAndChange)
 
-    guardTxSize =<< guardTxBalanced =<< assembleTransaction TxUpdate
-        { extraInputs
-        , extraCollateral
-        , extraOutputs = updatedChange
-        , feeUpdate = UseNewTxFee updatedFee
-        }
+    fmap (,s') . guardTxSize =<< guardTxBalanced =<< assembleTransaction
+        TxUpdate
+            { extraInputs
+            , extraCollateral
+            , extraOutputs = updatedChange
+            , feeUpdate = UseNewTxFee updatedFee
+            }
   where
     toSealed :: Cardano.Tx era -> SealedTx
     toSealed = sealedTxFromCardano . Cardano.InAnyCardanoEra Cardano.cardanoEra
@@ -2561,7 +2564,7 @@ buildAndSignTransactionNew
     -> Passphrase "user"
     -> PreSelection
     -> TransactionCtx
-    -> IO (Tx, TxMeta, UTCTime, SealedTx)
+    -> IO (Tx, TxMeta, UTCTime, SealedTx, s)
 buildAndSignTransactionNew
     tr ti db netLayer txLayer walletId changeGen era pwd preSelection txCtx =
     WriteTx.withRecentEra era $ \(_ :: WriteTx.RecentEra recentEra) -> do
@@ -2576,7 +2579,8 @@ buildAndSignTransactionNew
                     (unsafeShelleyOnlyGetRewardXPub wallet)
                     protocolParams txCtx (Left preSelection)
 
-        unsignedBalancedTx <- balanceTx protocolParams utxo unsignedTxBody
+        (unsignedBalancedTx, s')
+            <- balanceTx protocolParams utxo unsignedTxBody
         signedSealedTx <- signBalancedTx wallet unsignedBalancedTx
 
         let ( tx
@@ -2618,7 +2622,7 @@ buildAndSignTransactionNew
                     resolveInputs  (resolvedCollateralInputs tx)
                 }
 
-        pure (txResolved, meta, tipTime, signedSealedTx)
+        pure (txResolved, meta, tipTime, signedSealedTx, s')
   where
     errorToException f = either (throwIO . ExceptionConstructTx . f) pure
     anyCardanoEra = WriteTx.fromAnyRecentEra era
@@ -2634,7 +2638,7 @@ buildAndSignTransactionNew
         => ProtocolParameters
         -> (UTxOIndex WalletUTxO, Wallet s, Set Tx)
         -> Cardano.TxBody era
-        -> IO (Cardano.Tx era)
+        -> IO (Cardano.Tx era, s)
     balanceTx protocolParams utxo unsignedTxBody = do
         let protocolParameters =
                 ( protocolParams

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -127,7 +127,6 @@ module Cardano.Wallet
     , readWalletUTxOIndex
     , assignChangeAddresses
     , assignChangeAddressesAndUpdateDb
-    , assignChangeAddressesWithoutDbUpdate
     , selectionToUnsignedTx
     , buildAndSignTransactionNew
     , buildAndSignTransaction
@@ -208,6 +207,7 @@ module Cardano.Wallet
     , WalletFollowLog (..)
     , WalletLog (..)
     , TxSubmitLog (..)
+    , writeChangeAddressStateToDb
     ) where
 
 import Prelude hiding
@@ -2201,6 +2201,8 @@ assignChangeAddresses argGenChange sel = runState $ do
         pure $ TxOut addr bundle
     pure $ sel { change = changeOuts }
 
+-- TODO [ADP-1489] Remove once all call-sites have been updated to use
+-- balanceTransaction and 'writeChangeAddressStateToDb'.
 assignChangeAddressesAndUpdateDb
     :: forall ctx s k.
         ( GenChange s
@@ -2226,25 +2228,21 @@ assignChangeAddressesAndUpdateDb ctx wid generateChange selection =
         (selectionUpdated, stateUpdated) =
             assignChangeAddresses generateChange selection s
 
-assignChangeAddressesWithoutDbUpdate
-    :: forall ctx s k.
-        ( GenChange s
-        , HasDBLayer IO s k ctx
-        )
-    => ctx
+-- | For use with the returned updated 's' of 'balanceTransaction'.
+writeChangeAddressStateToDb
+    :: AddressBookIso s
+    => DBLayer IO s k
     -> WalletId
-    -> ArgGenChange s
-    -> Selection
-    -> ExceptT ErrConstructTx IO (SelectionOf TxOut)
-assignChangeAddressesWithoutDbUpdate ctx wid generateChange selection =
-    db & \DBLayer{..} -> mapExceptT atomically $ do
-        cp <- withExceptT ErrConstructTxNoSuchWallet $
-            withNoSuchWallet wid $ readCheckpoint wid
-        let (selectionUpdated, _) =
-                assignChangeAddresses generateChange selection (getState cp)
-        pure selectionUpdated
+    -> s
+    -> IO ()
+writeChangeAddressStateToDb DBLayer{..} wid s = throwInIO $
+    atomically $ modifyDBMaybe walletsDB $
+        adjustNoSuchWallet wid id $ \_wallet ->
+            -- Newly generated change addresses only change the Prologue
+            Right ([ReplacePrologue $ getPrologue s], ())
   where
-    db = ctx ^. dbLayer @IO @s @k
+    throwInIO :: IO (Either ErrNoSuchWallet a) -> IO a
+    throwInIO act = act >>= either (throwIO . ExceptionNoSuchWallet) pure
 
 selectionToUnsignedTx
     :: forall s input output change withdrawal.
@@ -3972,6 +3970,7 @@ data WalletException
     | ExceptionCreateRandomAddress ErrCreateRandomAddress
     | ExceptionImportRandomAddress ErrImportRandomAddress
     | ExceptionNotASequentialWallet ErrNotASequentialWallet
+    | ExceptionNoSuchWallet ErrNoSuchWallet
     | ExceptionReadRewardAccount ErrReadRewardAccount
     | ExceptionWithdrawalNotBeneficial ErrWithdrawalNotBeneficial
     | ExceptionReadPolicyPublicKey ErrReadPolicyPublicKey


### PR DESCRIPTION
Wallet uses `buildAndSignTransactionNew` when quitting a stake pool.

### Issue Number

ADP-2267
