### PR TITLE
Building and signing a Tx needs to be used atomically with persisting updated change state.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -162,7 +162,8 @@ import Cardano.Pool.Types
 import Cardano.Tx.Balance.Internal.CoinSelection
     ( SelectionOf (..), SelectionStrategy (..), selectionDelta )
 import Cardano.Wallet
-    ( ErrAddCosignerKey (..)
+    ( BuiltTx (..)
+    , ErrAddCosignerKey (..)
     , ErrBalanceTx (..)
     , ErrConstructSharedWallet (..)
     , ErrConstructTx (..)
@@ -2160,8 +2161,12 @@ postTransactionOld ctx@ApiLayer{..} genChange (ApiT wid) body = do
             (tx, txMeta, txTime, sealedTx) <- liftHandler
                 $ W.buildAndSignTransaction @_ @s @k
                     wrk wid era mkRwdAcct pwd txCtx sel'
-            liftHandler
-                $ W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
+            liftHandler $ W.submitTx (wrk ^. logger) db netLayer wid
+                BuiltTx
+                    { builtTx = tx
+                    , builtTxMeta = txMeta
+                    , builtSealedTx = sealedTx
+                    }
             pure (sel, tx, txMeta, txTime, pp)
         mkApiTransaction
             (timeInterpreter netLayer)
@@ -2182,7 +2187,7 @@ postTransactionOld ctx@ApiLayer{..} genChange (ApiT wid) body = do
                 , txScriptValidity = tx ^. #scriptValidity
                 , txDeposit = W.stakeKeyDeposit pp
                 , txMetadataSchema = TxMetadataDetailedSchema
-                , txCBOR  = tx ^. #txCBOR
+                , txCBOR = tx ^. #txCBOR
                 }
   where
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
@@ -3220,9 +3225,13 @@ submitTransaction ctx apiw@(ApiT wid) apitx = do
                 , txWithdrawal = wdrl
                 }
         txMeta <- liftHandler $ W.constructTxMeta db wid txCtx ourInps ourOuts
-        liftHandler
-            $ W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
-    return $ ApiTxId (apiDecoded ^. #id)
+        liftHandler $ W.submitTx (wrk ^. logger) db nl wid
+            BuiltTx
+                { builtTx = tx
+                , builtTxMeta = txMeta
+                , builtSealedTx = sealedTx
+                }
+    pure $ ApiTxId (apiDecoded ^. #id)
   where
     tl = ctx ^. W.transactionLayer @k @'CredFromKeyK
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
@@ -3335,12 +3344,17 @@ submitSharedTransaction ctx apiw@(ApiT wid) apitx = do
                 }
         let db = wrk ^. dbLayer
         txMeta <- liftHandler $ W.constructTxMeta db wid txCtx ourInps ourOuts
-        liftHandler $ W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
+        liftHandler $ W.submitTx (wrk ^. logger) db nl wid
+            BuiltTx
+                { builtTx = tx
+                , builtTxMeta = txMeta
+                , builtSealedTx = sealedTx
+                }
     pure $ ApiTxId (apiDecoded ^. #id)
   where
+    nl = ctx ^. networkLayer
     tl = ctx ^. W.transactionLayer @k @'CredFromScriptK
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
-    nl = ctx ^. networkLayer
     ti = timeInterpreter nl
 
 joinStakePool
@@ -3376,11 +3390,14 @@ joinStakePool ctx knownPools getPoolStatus apiPool (ApiT wid) body = do
     pools <- liftIO knownPools
     curEpoch <- getCurrentEpoch ctx
     withWorkerCtx ctx wid liftE liftE $ \wrk -> do
-        pp <- liftIO $ NW.currentProtocolParameters (wrk ^. networkLayer)
+        let netLayer = wrk ^. networkLayer
+            tr = wrk ^. logger
+            db = wrk ^. dbLayer
+        pp <- liftIO $ NW.currentProtocolParameters netLayer
         action <- liftHandler
             $ WD.joinStakePoolDelegationAction @s @k
-                (contramap MsgWallet $ wrk ^. logger)
-                (wrk ^. dbLayer)
+                (MsgWallet >$< tr)
+                db
                 curEpoch
                 pools
                 poolId
@@ -3397,7 +3414,7 @@ joinStakePool ctx knownPools getPoolStatus apiPool (ApiT wid) body = do
             liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk wid
         -- FIXME [ADP-1489] pp and era are not guaranteed to be consistent,
         -- which could cause problems under exceptional circumstances.
-        era <- liftIO $ NW.currentNodeEra (wrk ^. networkLayer)
+        era <- liftIO $ NW.currentNodeEra netLayer
         let selectAssetsParams = W.SelectAssetsParams
                 { outputs = []
                 , pendingTxs
@@ -3417,11 +3434,13 @@ joinStakePool ctx knownPools getPoolStatus apiPool (ApiT wid) body = do
             let pwd = coerce $ getApiT $ body ^. #passphrase
             W.buildAndSignTransaction @_ @s @k
                 wrk wid era selfRewardAccountBuilder pwd txCtx sel'
-        liftHandler $ W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
-        mkApiTransaction
-            (timeInterpreter (ctx ^. networkLayer))
-            wrk wid
-            #pendingSince
+        liftHandler $ W.submitTx tr db netLayer wid
+            BuiltTx
+                { builtTx = tx
+                , builtTxMeta = txMeta
+                , builtSealedTx = sealedTx
+                }
+        mkApiTransaction ti wrk wid #pendingSince
             MkApiTransactionParams
                 { txId = tx ^. #txId
                 , txFee = tx ^. #fee
@@ -3437,7 +3456,7 @@ joinStakePool ctx knownPools getPoolStatus apiPool (ApiT wid) body = do
                 , txScriptValidity = tx ^. #scriptValidity
                 , txDeposit = W.stakeKeyDeposit pp
                 , txMetadataSchema = TxMetadataDetailedSchema
-                , txCBOR  = tx ^. #txCBOR
+                , txCBOR = tx ^. #txCBOR
                 }
   where
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
@@ -3505,9 +3524,10 @@ quitStakePool
 quitStakePool ctx@ApiLayer{..} (ApiT walletId) body =
     withWorkerCtx ctx walletId liftE liftE $ \wrk -> do
         let db = wrk ^. typed @(DBLayer IO s k)
+            tr = wrk ^. logger
             notShelleyWallet =
                 liftHandler $ throwE ErrReadRewardAccountNotAShelleyWallet
-        pp <- liftIO $ NW.currentProtocolParameters (wrk ^. networkLayer)
+        pp <- liftIO $ NW.currentProtocolParameters netLayer
         txCtx <-
             case testEquality (typeRep @s) (typeRep @(SeqState n k)) of
                 Nothing -> notShelleyWallet
@@ -3518,7 +3538,7 @@ quitStakePool ctx@ApiLayer{..} (ApiT walletId) body =
                         liftIO $ WD.quitStakePool netLayer db ti walletId
         (utxoAvailable, wallet, pendingTxs) <-
             liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk walletId
-        era <- liftIO $ NW.currentNodeEra (wrk ^. networkLayer)
+        era <- liftIO $ NW.currentNodeEra netLayer
         sel <- liftHandler
             $ W.selectAssets @_ @_ @s @k @'CredFromKeyK wrk era pp
                 W.SelectAssetsParams
@@ -3539,8 +3559,12 @@ quitStakePool ctx@ApiLayer{..} (ApiT walletId) body =
             let pwd = coerce $ getApiT $ body ^. #passphrase
             liftHandler $ W.buildAndSignTransaction @_ @s @k
                 wrk walletId era selfRewardAccountBuilder pwd txCtx sel'
-        liftHandler
-            $ W.submitTx @_ @s @k wrk walletId (tx, txMeta, sealedTx)
+        liftHandler $ W.submitTx tr db netLayer walletId
+            BuiltTx
+                { builtTx = tx
+                , builtTxMeta = txMeta
+                , builtSealedTx = sealedTx
+                }
         mkApiTransaction ti wrk walletId #pendingSince
             MkApiTransactionParams
                 { txId = tx ^. #txId
@@ -3773,6 +3797,7 @@ migrateWallet ctx@ApiLayer{..} withdrawalType (ApiT wid) postData = do
                 either liftE pure $ shelleyOnlyRewardAccountBuilder @s @_ @n w
     withWorkerCtx ctx wid liftE liftE $ \wrk -> do
         let db = wrk ^. dbLayer
+            tr = wrk ^. logger
         era <- liftIO $ NW.currentNodeEra netLayer
         rewardWithdrawal <- case withdrawalType of
             Nothing -> pure NoWithdrawal
@@ -3798,13 +3823,16 @@ migrateWallet ctx@ApiLayer{..} withdrawalType (ApiT wid) postData = do
                     era
                     mkRewardAccount
                     pwd
-                    txContext (selection {change = []})
-            liftHandler $
-                W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
-            mkApiTransaction
-                (timeInterpreter netLayer)
-                wrk wid
-                #pendingSince
+                    txContext
+                    (selection {change = []})
+
+            liftHandler $ W.submitTx tr db netLayer wid
+                BuiltTx
+                    { builtTx = tx
+                    , builtTxMeta = txMeta
+                    , builtSealedTx = sealedTx
+                    }
+            mkApiTransaction ti wrk wid #pendingSince
                 MkApiTransactionParams
                     { txId = tx ^. #txId
                     , txFee = tx ^. #fee
@@ -3821,7 +3849,7 @@ migrateWallet ctx@ApiLayer{..} withdrawalType (ApiT wid) postData = do
                     , txScriptValidity = tx ^. #scriptValidity
                     , txDeposit = W.stakeKeyDeposit pp
                     , txMetadataSchema = TxMetadataDetailedSchema
-                    , txCBOR  = tx ^. #txCBOR
+                    , txCBOR = tx ^. #txCBOR
                     }
   where
     addresses = getApiT . fst <$> view #addresses postData

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
-{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}


### PR DESCRIPTION
At the moment new `buildAndSignTransactionNew` function uses some UTxO and change addresses but doesn’t persist updated UTxO and change address state in one atomic unit of work; This can lead to a situation when 2 concurrent invocations overlap and use the same UTxO or change index twice. This is problematic esp. for the random wallets that dedicate different change addresses to different clients. Change address re-use is a no go in this case.

The idea is to to have an `atomically` wrapper around:
1.  `buildAndSignTransactionPure`, which is a `buildAndSignTransactionNew` rewritten as a pure function such that it could be used as a `DBVar` update.
2. a call to persist change address state.
3. a call to persist updated UTxO (subtracting new pending indexes)

### Issue Number

ADP-2583