### PR TITLE
[ADP-2367] Add comment on a corner case in `mkTransactionInfo`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -849,6 +849,10 @@ mkTransactionInfo ti decorator tip = \case
             -> make WTxMeta.Expired tx meta
         ( TxStatusMeta ( Subm.InLedger _ _slot tx) meta)
             -> make WTxMeta.InLedger tx meta
+            -- Note: `meta` will contain the slot and block height
+            -- when the transaction was submitted,
+            -- not the slot or block height when the transaction
+            -- was accepted into the ledger.
         _ -> pure Nothing
   where
     make s tx meta = do


### PR DESCRIPTION
This pull request adds a comment concerning a corner case of the `mkTransactionInfo` function. We record this here because it could turn into a bug if refactoring in the future.

### Issue number

ADP-2367