### PR TITLE
[ADP-2587] Change `NetworkLayer` to apply to `Cardano.Wallet.Read.Block`

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api.hs
@@ -312,6 +312,7 @@ import Servant.API.Verbs
     )
 
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Read as Read
 
 type ApiV2 n = "v2" :> Api n
 
@@ -1190,7 +1191,7 @@ data ApiLayer s (k :: Depth -> Type -> Type) ktype
         { tracerTxSubmit :: Tracer IO TxSubmitLog
         , tracerWalletWorker :: Tracer IO (WorkerLog WalletId WalletWorkerLog)
         , netParams :: (Block, NetworkParameters)
-        , netLayer :: NetworkLayer IO Block
+        , netLayer :: NetworkLayer IO Read.Block
         , txLayer :: TransactionLayer k ktype SealedTx
         , _dbFactory :: DBFactory IO s k
         , _workerRegistry :: WorkerRegistry WalletId (DBLayer IO s k)

--- a/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
@@ -103,7 +103,7 @@ import Cardano.Wallet.Registry
 import Cardano.Wallet.Shelley.BlockchainSource
     ( BlockchainSource (..) )
 import Cardano.Wallet.Shelley.Compatibility
-    ( CardanoBlock, StandardCrypto, fromCardanoBlock )
+    ( CardanoBlock, StandardCrypto )
 import Cardano.Wallet.Shelley.Network
     ( withNetworkLayer )
 import Cardano.Wallet.Shelley.Network.Discriminant
@@ -216,7 +216,6 @@ serveWallet
   blockchainSource
   netParams@NetworkParameters
     { protocolParameters
-    , genesisParameters
     , slottingParameters
     }
   pipeliningStrategy
@@ -296,7 +295,7 @@ serveWallet
         lift $ apiLayer (newTransactionLayer netId) netLayer $
             Server.manageRewardBalance
                 <$> view typed
-                <*> view typed
+                <*> pure netLayer
                 <*> view typed
 
     withMultisigApi netLayer =
@@ -392,7 +391,7 @@ serveWallet
         Server.newApiLayer
             walletEngineTracer
             (block0, netParams)
-            (fromCardanoBlock genesisParameters <$> netLayer)
+            netLayer
             txLayer
             dbFactory
             tokenMetaClient

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -774,9 +774,7 @@ bench_restoration
     let tl = newTransactionLayer @k networkId
     let gp = genesisParameters np
     withNetworkLayer (trMessageText wlTr) pipeliningStrat
-        np socket vData sTol $ \nw' -> do
-            let convert = fromCardanoBlock gp
-            let nw = convert <$> nw'
+        np socket vData sTol $ \nw -> do
             let ti = neverFails "bench db shouldn't forecast into future"
                     $ timeInterpreter nw
             withBenchDBLayer ti wlTr

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -297,6 +297,7 @@ library
     Cardano.Wallet.Primitive.Types.Tx.TxSeq.Gen
     Cardano.Wallet.Primitive.Types.UTxOStatistics
     Cardano.Wallet.Read
+    Cardano.Wallet.Read.Block
     Cardano.Wallet.Read.Eras
     Cardano.Wallet.Read.Eras.EraFun
     Cardano.Wallet.Read.Eras.EraValue

--- a/lib/wallet/src/Cardano/Wallet/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation.hs
@@ -51,8 +51,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException, TimeInterpreter )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..)
-    , IsDelegatingTo (..)
+    ( IsDelegatingTo (..)
     , PoolLifeCycleStatus
     , WalletDelegation (..)
     , WalletId (..)
@@ -193,8 +192,8 @@ quitStakePoolDelegationAction db@DBLayer{..} walletId withdrawal = do
     pure Tx.Quit
 
 quitStakePool
-    :: forall (n :: NetworkDiscriminant)
-     . NetworkLayer IO Block
+    :: forall (n :: NetworkDiscriminant) block
+     . NetworkLayer IO block
     -> DBLayer IO (SeqState n ShelleyKey) ShelleyKey
     -> TimeInterpreter (ExceptT PastHorizonException IO)
     -> WalletId

--- a/lib/wallet/src/Cardano/Wallet/Read.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read.hs
@@ -13,7 +13,9 @@ import qualified Cardano.Wallet.Read as Read
 @
 -}
 module Cardano.Wallet.Read
-    ( module Cardano.Wallet.Read.Tx
+    ( module Cardano.Wallet.Read.Block
+    , module Cardano.Wallet.Read.Tx
     ) where
 
+import Cardano.Wallet.Read.Block
 import Cardano.Wallet.Read.Tx

--- a/lib/wallet/src/Cardano/Wallet/Read/Block.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Block.hs
@@ -1,0 +1,18 @@
+{- |
+Copyright: © 2022 IOHK
+License: Apache-2.0
+
+The 'Block' type represents blocks as they are read from the mainnet ledger.
+It is compatible with the era-specific types from @cardano-ledger@.
+-}
+module Cardano.Wallet.Read.Block
+    ( Block
+    ) where
+
+import qualified Ouroboros.Consensus.Cardano.Block as O
+
+{-------------------------------------------------------------------------------
+    Block type
+-------------------------------------------------------------------------------}
+-- | Type synonym for 'CardanoBlock' with cryptography as used on mainnet.
+type Block = O.CardanoBlock O.StandardCrypto

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -87,7 +87,6 @@ import Cardano.Wallet.Primitive.Passphrase.Current
     ( preparePassphrase )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
-    , Block
     , BlockHeader (BlockHeader)
     , NetworkParameters (..)
     , SlotNo (..)
@@ -274,6 +273,7 @@ import qualified Cardano.Wallet.Primitive.Migration as Migration
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Read as Read
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -732,7 +732,7 @@ instance Arbitrary SlottingParameters where
 -- | 'WalletLayer' context.
 data TxRetryTestCtx = TxRetryTestCtx
     { ctxDbLayer :: DBLayer TxRetryTestM DummyState ShelleyKey
-    , ctxNetworkLayer :: NetworkLayer TxRetryTestM Block
+    , ctxNetworkLayer :: NetworkLayer TxRetryTestM Read.Block
     , ctxTracer :: Tracer IO W.WalletWorkerLog
     , ctxWalletId :: WalletId
     } deriving (Generic)
@@ -823,7 +823,7 @@ prop_localTxSubmission tc = monadicIO $ do
                 testAction ctx
         TxRetryTestResult msgs res <$> readMVar submittedVar
 
-    mockNetwork :: MVar [SealedTx] -> NetworkLayer TxRetryTestM Block
+    mockNetwork :: MVar [SealedTx] -> NetworkLayer TxRetryTestM Read.Block
     mockNetwork var = dummyNetworkLayer
         { currentSlottingParameters = pure (testSlottingParameters tc)
         , postTx = \tx -> ExceptT $ do


### PR DESCRIPTION
### Overview

This pull request performs a small refactoring where the `NetworkLayer` is now applied to the block type from the ledger (here: re-exported from `Cardano.Wallet.Read.Block`) as opposed to the home-made `Block` type from `Cardano.Wallet.Primitive.Types`.

Put differently, the conversion from ledger type to home-made type is moved further downstream to the `restoreBlocks` function. This is a step towards the removal of the home-grown type.

### Issue number

ADP-2587