### PR TITLE
Wallet uses `buildSignSubmitTransaction` when quitting a stake pool.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
@@ -369,7 +369,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     stakePools =
              listStakePools_
         :<|> joinStakePool shelley (knownPools spl) (getPoolLifeCycleStatus spl)
-        :<|> quitStakePool shelley
+        :<|> quitStakePool shelley (delegationAddress @n)
         :<|> (postPoolMaintenance :<|> getPoolMaintenance)
         :<|> delegationFee shelley
         :<|> listStakeKeys rewardAccountFromAddress shelley

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2587,7 +2587,7 @@ buildSignSubmitTransaction
        )
     => TimeInterpreter (ExceptT PastHorizonException IO)
     -> DBLayer IO s k
-    -> NetworkLayer IO Block
+    -> NetworkLayer IO Read.Block
     -> TransactionLayer k ktype SealedTx
     -> Passphrase "user"
     -> WalletId


### PR DESCRIPTION
Wallet uses `buildSignSubmitTransaction` when quitting a stake pool.

### Issue Number

ADP-2267