### PR TITLE
Fixes for `joinStakePool` using `balanceTx`

### DIFF
--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -42,6 +42,8 @@ import Cardano.Wallet.Primitive.Types
     ( FeePolicy (..), LinearFunction (..), PoolMetadataSource (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Tx.Constraints
+    ( TxSize (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxMeta
     ( Direction (..), TxStatus (..) )
 import Cardano.Wallet.Shelley.Network.Discriminant
@@ -76,8 +78,6 @@ import Data.Text
     ( Text )
 import Data.Text.Class
     ( showT, toText )
-import Data.Tuple.Extra
-    ( both )
 import Numeric.Natural
     ( Natural )
 import Test.Hspec
@@ -1422,21 +1422,20 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
     costOfJoining :: Context -> Natural
     costOfJoining ctx =
         if _mainEra ctx >= ApiBabbage
-        then costOf (\coeff cst -> 454 * coeff + cst) ctx
-        else costOf (\coeff cst -> 450 * coeff + cst) ctx
+        then costOf (TxSize 454) ctx
+        else costOf (TxSize 450) ctx
 
     costOfQuitting :: Context -> Natural
     costOfQuitting ctx =
         if _mainEra ctx >= ApiBabbage
-        then costOf (\coeff cst -> 305 * coeff + cst) ctx
-        else costOf (\coeff cst -> 303 * coeff + cst) ctx
+        then costOf (TxSize 305) ctx
+        else costOf (TxSize 303) ctx
 
-    costOf :: (Natural -> Natural -> Natural) -> Context -> Natural
-    costOf withCoefficients ctx =
-        withCoefficients coeff cst
+    costOf :: TxSize -> Context -> Natural
+    costOf (TxSize txSizeInBytes) ctx =
+        txSizeInBytes * round slope + round intercept
       where
         pp = ctx ^. #_networkParameters . #protocolParameters
-        (cst, coeff) = both round (intercept, slope)
         LinearFee LinearFunction {..} = pp ^. #txParameters . #getFeePolicy
 
 -- The complete set of pool identifiers in the static test pool cluster.

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -1422,14 +1422,14 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
     costOfJoining :: Context -> Natural
     costOfJoining ctx =
         if _mainEra ctx >= ApiBabbage
-        then costOf (TxSize 454) ctx
-        else costOf (TxSize 450) ctx
+        then costOf (TxSize 483) ctx
+        else costOf (TxSize 479) ctx
 
     costOfQuitting :: Context -> Natural
     costOfQuitting ctx =
         if _mainEra ctx >= ApiBabbage
-        then costOf (TxSize 305) ctx
-        else costOf (TxSize 303) ctx
+        then costOf (TxSize 334) ctx
+        else costOf (TxSize 332) ctx
 
     costOf :: TxSize -> Context -> Natural
     costOf (TxSize txSizeInBytes) ctx =

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1107,9 +1107,8 @@ estimateNumberOfWitnesses utxo txbody@(Cardano.TxBody txbodycontent) =
             _ -> 0
         txCerts = case Cardano.txCertificates txbodycontent of
             Cardano.TxCertificatesNone -> 0
-            Cardano.TxCertificates _ certs _ -> length certs
-            -- FIXME [ADP-1515] Not all certificates require witnesses. Will
-            -- over-estimate unnecessarily.
+            Cardano.TxCertificates _ certs _ ->
+                length $ filter (not . isStakeKeyRegCert) certs
         scriptVkWitsUpperBound =
             fromIntegral
             $ sumVia estimateMaxWitnessRequiredPerInput
@@ -1126,6 +1125,9 @@ estimateNumberOfWitnesses utxo txbody@(Cardano.TxBody txbodycontent) =
     (Cardano.ShelleyTxBody _ _ scripts _ _ _) = txbody
 
     dummyKeyRole = Payment
+
+    isStakeKeyRegCert (Cardano.StakeAddressRegistrationCertificate _) = True
+    isStakeKeyRegCert _ = False
 
     toTimelockScript
         :: Ledger.Script (Cardano.ShelleyLedgerEra era)

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -807,6 +807,9 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             feePadding =
                 let LinearFee LinearFunction {slope = perByte} =
                         view (#txParameters . #getFeePolicy) pp
+
+                    -- Could be made smarter by only padding for the script
+                    -- integrity hash when we intend to add one. [ADP-2621]
                     scriptIntegrityHashBytes = 32 + 2
 
                     -- Add padding to allow the fee value to increase.


### PR DESCRIPTION
- [x] Fix estimation of number of witnesses required to join a pool from 2 to 1 (key-reg certs don't require wits)
- [x] Increase `costOfJoining` / `costOfQuitting` expectations in the integration tests by 29 bytes (34-5) 

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2268

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
