### PR TITLE
Test change address assignment in balanceTx

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -886,7 +886,8 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                     $ runExceptT
                     $ performSelection selectionConstraints selectionParams
 
-newtype ChangeAddressGen s = ChangeAddressGen (s -> (W.Address, s))
+newtype ChangeAddressGen s =
+    ChangeAddressGen { getChangeAddressGen ::  (s -> (W.Address, s)) }
 
 -- | Augments the given outputs with new outputs. These new outputs correspond
 -- to change outputs to which new addresses have been assigned. This updates

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -104,7 +104,10 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( DelegationAddress (delegationAddress)
     , Depth (..)
     , DerivationIndex (..)
+    , DerivationType (Soft)
+    , Index
     , NetworkDiscriminant (..)
+    , Role (..)
     , deriveRewardAccount
     , getRawKey
     , hex
@@ -119,7 +122,12 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey, generateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
-    ( SeqState, defaultAddressPoolGap, mkSeqStateFromRootXPrv, purposeCIP1852 )
+    ( SeqState
+    , defaultAddressPoolGap
+    , mkSeqStateFromRootXPrv
+    , purposeBIP44
+    , purposeCIP1852
+    )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( estimateMaxWitnessRequiredPerInput )
 import Cardano.Wallet.Primitive.Model
@@ -224,7 +232,7 @@ import Cardano.Wallet.Shelley.Compatibility
     , toCardanoValue
     )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( toBabbageTxOut, toLedgerTokenBundle )
+    ( toBabbageTxOut, toLedgerTokenBundle, toWallet )
 import Cardano.Wallet.Shelley.Transaction
     ( EraConstraints
     , TxSkeleton (..)
@@ -266,7 +274,8 @@ import Cardano.Wallet.Transaction
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Cardano.Wallet.Write.Tx.Balance
-    ( ErrBalanceTx (..)
+    ( ChangeAddressGen (..)
+    , ErrBalanceTx (..)
     , ErrBalanceTxInternalError (..)
     , ErrSelectAssets (..)
     , PartialTx (..)
@@ -278,9 +287,19 @@ import Control.Arrow
 import Control.Monad
     ( forM, forM_, replicateM )
 import Control.Monad.Random
-    ( MonadRandom (..), Random (randomR, randomRs), evalRand, random, randoms )
+    ( MonadRandom (..)
+    , Rand
+    , Random (randomR, randomRs)
+    , evalRand
+    , random
+    , randoms
+    )
+import Control.Monad.Random.Strict
+    ( StdGen )
 import Control.Monad.Trans.Except
     ( except, runExceptT )
+import Control.Monad.Trans.State.Strict
+    ( evalState, state )
 import Crypto.Hash.Utils
     ( blake2b224 )
 import Data.ByteArray.Encoding
@@ -294,7 +313,7 @@ import Data.Either
 import Data.Function
     ( on, (&) )
 import Data.Functor.Identity
-    ( runIdentity )
+    ( Identity, runIdentity )
 import Data.Generics.Internal.VL.Lens
     ( over, view )
 import Data.List
@@ -421,6 +440,7 @@ import qualified Cardano.Ledger.Alonzo.TxBody as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxWitness as Alonzo
 import qualified Cardano.Ledger.Babbage.PParams as Babbage
 import qualified Cardano.Ledger.Babbage.Tx as Babbage
+import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import qualified Cardano.Ledger.Coin as Ledger
 import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Crypto as Crypto
@@ -2343,6 +2363,60 @@ balanceTransactionSpec = describe "balanceTransaction" $ do
         it "roundtrips with toCardanoValue" $
             property prop_posAndNegFromCardanoValueRoundtrip
 
+    describe "change address generation" $ do
+        let walletUTxO = UTxO $ Map.fromList $
+                [ ( TxIn (Hash $ B8.replicate 32 '1') ix
+                  , TxOut dummyAddr (TokenBundle.fromCoin $ Coin 1_000_000)
+                  )
+                | ix <- [0 .. 500]
+                ]
+        let balance =
+                balanceTransactionWithDummyChangeState
+                    walletUTxO
+                    testStdGenSeed
+
+        -- We could generate arbitrary tx bodies to test with, but by
+        -- limiting ourselves to 'paymentPartialTx' with a fixed number of
+        -- payments 1) ensures balancing always succeeds 2) makes it easy to
+        -- have separate 'it' statements for different expectations of the same
+        -- test case.
+        let nPayments = 10
+        let paymentOuts = replicate nPayments $
+                TxOut
+                    dummyAddr
+                    (TokenBundle.fromCoin (Coin 1_000_000))
+        let ptx = paymentPartialTx paymentOuts
+
+        -- True for values of nPayments small enough not to cause
+        -- 'ErrBalanceTxMaxSizeLimitExceeded' or ErrMakeChange
+        let nChange = max nPayments 1
+        let s0 = DummyChangeState 0
+        let expectedChange = flip evalState s0
+                $ replicateM nChange
+                $ state @Identity (getChangeAddressGen dummyChangeAddrGen)
+
+        let address :: Babbage.TxOut StandardBabbage -> Address
+            address (Babbage.TxOut addr _ _ _) = toWallet addr
+
+        let outputs
+                :: Cardano.Tx Cardano.BabbageEra
+                -> [Babbage.TxOut StandardBabbage]
+            outputs
+                (Cardano.Tx
+                    (Cardano.ShelleyTxBody _ body _ _ _ _ )
+                _) = WriteTx.outputs RecentEraBabbage body
+
+        let (tx, s') =
+                either (error . show) id $ balance ptx
+
+        it "assigns change addresses as expected" $
+            map address (outputs tx)
+                `shouldBe`
+                (map (view #address) paymentOuts ++ expectedChange)
+
+        it "returns s' corresponding to which addresses were used" $ do
+            s' `shouldBe` DummyChangeState { nextUnusedIndex = nChange }
+
     it "increases zero-ada outputs to minimum" $ do
         pendingWith "Needs correct mock PParams for Babbage"
         let era = WriteTx.RecentEraBabbage
@@ -3393,6 +3467,64 @@ balanceTransaction' (Wallet' utxoIndex wallet _pending) seed tx  =
             (defaultChangeAddressGen $ delegationAddress @'Mainnet)
             (getState wallet)
             tx
+
+newtype DummyChangeState = DummyChangeState { nextUnusedIndex :: Int }
+    deriving (Show, Eq)
+
+dummyChangeAddrGen :: ChangeAddressGen DummyChangeState
+dummyChangeAddrGen = ChangeAddressGen $ \(DummyChangeState i) ->
+        (addressAtIx $ toEnum i, DummyChangeState $ succ i)
+      where
+        addressAtIx
+            :: Index
+                'Cardano.Wallet.Primitive.AddressDerivation.Soft
+                'CredFromKeyK
+            -> Address
+        addressAtIx ix = paymentAddress @'Mainnet @ShelleyKey @'CredFromKeyK
+            $ publicKey
+            $ Shelley.ShelleyKey
+            $ Shelley.deriveAddressPrivateKeyShelley
+                pwd
+                acctK
+                Cardano.Wallet.Primitive.AddressDerivation.UtxoInternal
+                ix
+
+        mw = SomeMnemonic $ either (error . show) id
+            (entropyToMnemonic @12 <$> mkEntropy "0000000000000000")
+        pwd = Passphrase ""
+        rootK = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
+        acctK = Shelley.deriveAccountPrivateKeyShelley
+                    purposeBIP44
+                    pwd
+                    (getRawKey rootK)
+                    minBound
+
+balanceTransactionWithDummyChangeState
+    :: WriteTx.IsRecentEra era
+    => UTxO
+    -> StdGenSeed
+    -> PartialTx era
+    -> Either
+        ErrBalanceTx
+        (Cardano.Tx era, DummyChangeState)
+balanceTransactionWithDummyChangeState utxo seed ptx =
+    flip evalRand (stdGenFromSeed seed) $ runExceptT $
+        balanceTransaction @_ @(Rand StdGen)
+            (nullTracer @(Rand StdGen))
+            testTxLayer
+            Nothing
+            Nothing
+            mockProtocolParametersForBalancing
+            dummyTimeInterpreter
+            utxoIndex
+            dummyChangeAddrGen
+            (getState wal)
+            ptx
+  where
+    utxoIndex = UTxOIndex.fromMap $ CS.toInternalUTxOMap utxo
+    wal = unsafeInitWallet utxo (header block0) s
+      where
+        s = DummyChangeState { nextUnusedIndex = 0 }
 
 prop_posAndNegFromCardanoValueRoundtrip :: Property
 prop_posAndNegFromCardanoValueRoundtrip = forAll genSignedValue $ \v ->


### PR DESCRIPTION
- [x] Test that change addresses are appended to the list of outputs as expected
- [x] Test that correct change address state `s` is returned by `balanceTx`

```
    change address generation
      assigns change addresses as expected [✔] (139ms)
      returns s' corresponding to which addresses were used [✔]
```

### Comments

- Depends on #3727 
- Extracted from reviewed #3691 which didn't make it to master

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2268
<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
