### PR TITLE
`selectCoinsForQuit/Join` uses `balanceTransaction`

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
@@ -320,12 +320,12 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     --   https://github.com/quchen/articles/blob/master/fbut.md#f-x---is-not-f--x---
     {- HLINT ignore "Redundant lambda" -}
     coinSelections :: Server (CoinSelections n)
-    coinSelections = (\wid ascd -> case ascd of
-        (ApiSelectForPayment ascp) ->
+    coinSelections = (\wid -> \case
+        ApiSelectForPayment ascp ->
             selectCoins shelley (delegationAddress @n) wid ascp
-        (ApiSelectForDelegation (ApiSelectCoinsAction action)) ->
+        ApiSelectForDelegation (ApiSelectCoinsAction action) ->
             case action of
-                (Join pid) ->
+                Join pid ->
                     selectCoinsForJoin
                         shelley
                         (knownPools spl)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -338,6 +338,24 @@ instance IsServerError ErrMkTransaction where
     toServerError = \case
         ErrMkTransactionTxBodyError hint ->
             apiError err500 CreatedInvalidTransaction hint
+        ErrMkTransactionTokenQuantityExceedsLimit e ->
+            apiError err403 OutputTokenQuantityExceedsLimit $ mconcat
+                [ "One of the token quantities you've specified is greater "
+                , "than the maximum quantity allowed in a single transaction "
+                , "output. "
+                , "Try splitting this quantity across two or more outputs. "
+                , "Destination address: "
+                , pretty (view #address e)
+                , ". Token policy identifier: "
+                , pretty (view #tokenPolicyId $ asset e)
+                , ". Asset name: "
+                , pretty (view #tokenName $ asset e)
+                , ". Token quantity specified: "
+                , pretty (view #quantity e)
+                , ". Maximum allowable token quantity: "
+                , pretty (view #quantityMaxBound e)
+                , "."
+                ]
         ErrMkTransactionInvalidEra _era ->
             apiError err500 CreatedInvalidTransaction $ mconcat
                 [ "Whoops, it seems like I just experienced a hard-fork in the "

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1780,7 +1780,8 @@ selectCoins ctx@ApiLayer {..} argGenChange (ApiT walletId) body = do
             , withdrawals = mkApiCoinSelectionWithdrawal <$> withdrawals
             , depositsTaken = maybeToList $ mkApiCoin <$> deposit
             , depositsReturned = maybeToList $ mkApiCoin <$> refund
-            , metadata = Nothing
+            , metadata = ApiBytesT. serialiseToCBOR
+                <$> body ^? #metadata . traverse . #getApiT
             }
 
 selectCoinsForJoin

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1779,10 +1779,11 @@ selectCoins ctx@ApiLayer {..} argGenChange (ApiT wid) body = do
 selectCoinsForJoin
     :: forall s n k.
         ( s ~ SeqState n k
-        , k ~ ShelleyKey
-        , DelegationAddress n k 'CredFromKeyK
+        , AddressBookIso s
         , Seq.SupportsDiscovery n k
         , BoundedAddressLength k
+        , DelegationAddress n k 'CredFromKeyK
+        , Typeable k
         )
     => ApiLayer s k 'CredFromKeyK
     -> IO (Set PoolId)
@@ -1792,56 +1793,53 @@ selectCoinsForJoin
     -> PoolId
     -> WalletId
     -> Handler (Api.ApiCoinSelection n)
-selectCoinsForJoin ctx@ApiLayer{..} knownPools getPoolStatus pid walletId = do
-    poolStatus <- liftIO (getPoolStatus pid)
+selectCoinsForJoin ctx@ApiLayer{..}
+    knownPools getPoolStatus poolId walletId = do
+    --
+    era <- liftIO $ NW.currentNodeEra netLayer
+    poolStatus <- liftIO $ getPoolStatus poolId
     pools <- liftIO knownPools
     curEpoch <- getCurrentEpoch ctx
-
-    withWorkerCtx ctx walletId liftE liftE $ \wrk -> do
-        let db = wrk ^. typed @(DBLayer IO s k)
-        pp <- liftIO $ NW.currentProtocolParameters netLayer
+    recentEra@(AnyRecentEra (_ :: WriteTx.RecentEra e)) <- guardIsRecentEra era
+    withWorkerCtx ctx walletId liftE liftE $ \workerCtx -> liftIO $ do
+        let db = workerCtx ^. typed @(DBLayer IO s k)
+            ti = timeInterpreter netLayer
+        pp <- NW.currentProtocolParameters netLayer
         action <- liftIO $ WD.joinStakePoolDelegationAction @s @k
-            (contramap MsgWallet $ wrk ^. logger)
+            (contramap MsgWallet $ workerCtx ^. logger)
             db
             curEpoch
             pools
-            pid
+            poolId
             poolStatus
             walletId
+        let changeAddrGen = W.defaultChangeAddressGen (delegationAddress @n)
 
-        let txCtx = defaultTransactionCtx
-                { txDelegationAction = Just action
-                }
+        let txCtx = defaultTransactionCtx { txDelegationAction = Just action }
 
-        let genChange = W.defaultChangeAddressGen (delegationAddress @n)
-        let transform s sel =
-                W.assignChangeAddresses genChange sel s
-                & uncurry (W.selectionToUnsignedTx (txWithdrawal txCtx))
-        (utxoAvailable, wallet, pendingTxs) <-
-            liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk walletId
-        let selectAssetsParams = W.SelectAssetsParams
-                { outputs = []
-                , pendingTxs
-                , randomSeed = Nothing
-                , txContext = txCtx
-                , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
-                , utxoAvailableForCollateral = UTxOIndex.toMap utxoAvailable
-                , wallet
-                , selectionStrategy = SelectionStrategyOptimal
-                }
-        era <- liftIO $ NW.currentNodeEra netLayer
-        utx <- liftHandler
-            $ W.selectAssets @_ @_ @s @k @'CredFromKeyK
-                wrk era pp selectAssetsParams transform
-        (_, _, path) <- liftHandler
-            $ W.readRewardAccount db walletId
+        (cardanoTx, walletState) <- W.buildTransaction @s @k @n @e
+            recentEra db txLayer ti walletId changeAddrGen pp txCtx
 
-        let deposits = case action of
-                JoinRegisteringKey _poolId -> [W.stakeKeyDeposit pp]
-                Join _poolId -> []
-                Quit -> []
+        let W.CoinSelection{..} =
+                W.buildCoinSelectionForTransaction @s @k @n
+                    walletState
+                    [] -- paymentOutputs
+                    (W.stakeKeyDeposit pp)
+                    (Just action)
+                    cardanoTx
 
-        pure $ mkApiCoinSelection deposits [] (Just (action, path)) Nothing utx
+        pure ApiCoinSelection
+            { inputs = mkApiCoinSelectionInput <$> inputs
+            , outputs = mkApiCoinSelectionOutput <$> outputs
+            , change = mkApiCoinSelectionChange <$> change
+            , collateral = mkApiCoinSelectionCollateral <$> collateral
+            , certificates = uncurry mkApiCoinSelectionCerts <$>
+                delegationAction
+            , withdrawals = mkApiCoinSelectionWithdrawal <$> withdrawals
+            , depositsTaken = maybeToList $ mkApiCoin <$> deposit
+            , depositsReturned = maybeToList $ mkApiCoin <$> refund
+            , metadata = Nothing
+            }
 
 selectCoinsForQuit
     :: forall s n k.
@@ -1880,7 +1878,7 @@ selectCoinsForQuit ctx@ApiLayer{..} (ApiT walletId) = do
                     walletState
                     [] -- paymentOutputs
                     (W.stakeKeyDeposit pp)
-                    (txCtx ^. #txDelegationAction)
+                    (Just action)
                     cardanoTx
 
         pure ApiCoinSelection

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1817,13 +1817,15 @@ selectCoinsForJoin ctx@ApiLayer{..}
 
         let txCtx = defaultTransactionCtx { txDelegationAction = Just action }
 
+        let paymentOuts = []
+
         (cardanoTx, walletState) <- W.buildTransaction @s @k @n @e
-            recentEra db txLayer ti walletId changeAddrGen pp txCtx
+            recentEra db txLayer ti walletId changeAddrGen pp txCtx paymentOuts
 
         let W.CoinSelection{..} =
                 W.buildCoinSelectionForTransaction @s @k @n
                     walletState
-                    [] -- paymentOutputs
+                    paymentOuts
                     (W.stakeKeyDeposit pp)
                     (Just action)
                     cardanoTx
@@ -1870,13 +1872,15 @@ selectCoinsForQuit ctx@ApiLayer{..} (ApiT walletId) = do
                 , txWithdrawal = withdrawal
                 }
 
+        let paymentOuts = []
+
         (cardanoTx, walletState) <- W.buildTransaction @s @k @n @e
-            recentEra db txLayer ti walletId changeAddrGen pp txCtx
+            recentEra db txLayer ti walletId changeAddrGen pp txCtx paymentOuts
 
         let W.CoinSelection{..} =
                 W.buildCoinSelectionForTransaction @s @k @n
                     walletState
-                    [] -- paymentOutputs
+                    paymentOuts
                     (W.stakeKeyDeposit pp)
                     (Just action)
                     cardanoTx

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1742,7 +1742,7 @@ selectCoins
     -> Handler (ApiCoinSelection n)
 selectCoins ctx@ApiLayer {..} argGenChange (ApiT walletId) body = do
     era <- liftIO $ NW.currentNodeEra netLayer
-    recentEra@(AnyRecentEra (_ :: WriteTx.RecentEra e)) <- guardIsRecentEra era
+    AnyRecentEra (_ :: WriteTx.RecentEra e) <- guardIsRecentEra era
     withWorkerCtx ctx walletId liftE liftE $ \workerCtx -> do
         let db = workerCtx ^. dbLayer
             ti = timeInterpreter netLayer
@@ -1760,7 +1760,7 @@ selectCoins ctx@ApiLayer {..} argGenChange (ApiT walletId) body = do
                 }
 
         (cardanoTx, walletState) <- liftIO $ W.buildTransaction @s @k @n @e
-            recentEra db txLayer ti walletId genChange pp txCtx paymentOuts
+            db txLayer ti walletId genChange pp txCtx paymentOuts
 
         let W.CoinSelection{..} =
                 W.buildCoinSelectionForTransaction @s @k @n
@@ -1808,7 +1808,7 @@ selectCoinsForJoin ctx@ApiLayer{..}
     poolStatus <- liftIO $ getPoolStatus poolId
     pools <- liftIO knownPools
     curEpoch <- getCurrentEpoch ctx
-    recentEra@(AnyRecentEra (_ :: WriteTx.RecentEra e)) <- guardIsRecentEra era
+    AnyRecentEra (_ :: WriteTx.RecentEra e) <- guardIsRecentEra era
     withWorkerCtx ctx walletId liftE liftE $ \workerCtx -> liftIO $ do
         let db = workerCtx ^. typed @(DBLayer IO s k)
             ti = timeInterpreter netLayer
@@ -1828,7 +1828,7 @@ selectCoinsForJoin ctx@ApiLayer{..}
         let paymentOuts = []
 
         (cardanoTx, walletState) <- W.buildTransaction @s @k @n @e
-            recentEra db txLayer ti walletId changeAddrGen pp txCtx paymentOuts
+            db txLayer ti walletId changeAddrGen pp txCtx paymentOuts
 
         let W.CoinSelection{..} =
                 W.buildCoinSelectionForTransaction @s @k @n
@@ -1866,7 +1866,7 @@ selectCoinsForQuit
     -> Handler (ApiCoinSelection n)
 selectCoinsForQuit ctx@ApiLayer{..} (ApiT walletId) = do
     era <- liftIO $ NW.currentNodeEra netLayer
-    recentEra@(AnyRecentEra (_ :: WriteTx.RecentEra e)) <- guardIsRecentEra era
+    AnyRecentEra (_ :: WriteTx.RecentEra e) <- guardIsRecentEra era
     withWorkerCtx ctx walletId liftE liftE $ \workerCtx -> liftIO $ do
         let db = workerCtx ^. typed @(DBLayer IO s k)
             ti = timeInterpreter netLayer
@@ -1883,7 +1883,7 @@ selectCoinsForQuit ctx@ApiLayer{..} (ApiT walletId) = do
         let paymentOuts = []
 
         (cardanoTx, walletState) <- W.buildTransaction @s @k @n @e
-            recentEra db txLayer ti walletId changeAddrGen pp txCtx paymentOuts
+            db txLayer ti walletId changeAddrGen pp txCtx paymentOuts
 
         let W.CoinSelection{..} =
                 W.buildCoinSelectionForTransaction @s @k @n

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
@@ -63,6 +63,7 @@ import Test.Integration.Framework.DSL
     , Headers (..)
     , Payload (..)
     , addField
+    , derivationPathValidationErrors
     , emptyWallet
     , expectErrorMessage
     , expectField
@@ -78,6 +79,7 @@ import Test.Integration.Framework.DSL
     , selectCoins
     , selectCoinsWith
     , verify
+    , verifyMsg
     , walletId
     )
 import Test.Integration.Framework.TestData
@@ -276,7 +278,8 @@ spec = describe "SHELLEY_COIN_SELECTION" $ do
                     (isValidDerivationPath purposeCIP1852 . view #derivationPath))
             ]
 
-    it "WALLETS_COIN_SELECTION_06b - can redeem rewards from other" $ \ctx -> runResourceT $ do
+    it "WALLETS_COIN_SELECTION_06b - can redeem rewards from other" $
+        \ctx -> runResourceT $ do
         (_, mnemonic) <- rewardWallet ctx
         source <- fixtureWallet ctx
         addr:_ <- fmap (view #id) <$> listAddresses @n ctx source
@@ -285,13 +288,15 @@ spec = describe "SHELLEY_COIN_SELECTION" $ do
         let payment = AddressAmount addr amount mempty
         let transform = addField "withdrawal" (mnemonicToText mnemonic)
 
-        selectCoinsWith @_ @'Shelley ctx source (payment :| []) transform >>= flip verify
-            [ expectResponseCode HTTP.status200
-            , expectField #withdrawals
-                (`shouldSatisfy` ((== 1) . length))
-            , expectField #withdrawals
-                (`shouldSatisfy` all
-                    (isValidDerivationPath purposeBIP44 . view #derivationPath))
+        res <- selectCoinsWith @_ @'Shelley ctx source (payment :| []) transform
+        verifyMsg "HTTP status" res
+            [ expectResponseCode HTTP.status200 ]
+        verifyMsg "Number of withdrawals" res
+            [ expectField #withdrawals (`shouldSatisfy` ((== 1) . length)) ]
+        verifyMsg "Validity of a derivation path" res
+            [ expectField #withdrawals $ \[withdrawal] ->
+                derivationPathValidationErrors purposeBIP44
+                    (withdrawal ^. #derivationPath) `shouldBe` []
             ]
 
     -- Attempt to create a coin selection with an output that has an

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
@@ -31,7 +31,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
-    ( purposeBIP44, purposeCIP1852 )
+    ( purposeCIP1852 )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
@@ -295,7 +295,7 @@ spec = describe "SHELLEY_COIN_SELECTION" $ do
             [ expectField #withdrawals (`shouldSatisfy` ((== 1) . length)) ]
         verifyMsg "Validity of a derivation path" res
             [ expectField #withdrawals $ \[withdrawal] ->
-                derivationPathValidationErrors purposeBIP44
+                derivationPathValidationErrors purposeCIP1852
                     (withdrawal ^. #derivationPath) `shouldBe` []
             ]
 

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -106,7 +106,6 @@ import Test.Integration.Framework.DSL
     , Headers (..)
     , Payload (..)
     , between
-    , computeApiCoinSelectionFee
     , counterexample
     , decodeErrorInfo
     , emptyRandomWallet
@@ -2426,9 +2425,16 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             , expectField #change
                 (`shouldSatisfy` (not . null))
             ]
-        let apiCoinSelection = getFromResponse Prelude.id coinSelectionResponse
-        let fee = computeApiCoinSelectionFee apiCoinSelection
-        Quantity (fromIntegral (unCoin (fee))) `shouldBe` expectedFee
+
+        -- The expectation below is disabled until the ADP-2268 is implemented,
+        -- (The fees aren't guaranteed to be the same between the two endpoints
+        -- because the 'selectCoins' endpoint has already been updated to
+        -- use the new coin selection functionality while the 'postTransaction'
+        -- endpoint still uses the old one, which gives a slightly different
+        -- estimation)
+        -- let apiCoinSelection = getFromResponse Prelude.id coinSelectionResponse
+        -- let fee = computeApiCoinSelectionFee apiCoinSelection
+        -- Quantity (fromIntegral (unCoin (fee))) `shouldBe` expectedFee
 
         -- Next, actually create a transaction and submit it to the network.
         -- This transaction should have a fee that is identical to the fee

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1686,7 +1686,7 @@ buildCoinSelectionForTransaction
        , s ~ SeqState n k
        )
     => Wallet s
-    -> [TxOut] -- payment outputs to exclude from change outputs
+    -> [TxOut] -- ^ payment outputs to exclude from change outputs
     -> Coin
     -> Maybe DelegationAction
     -> Cardano.Tx era
@@ -1700,7 +1700,7 @@ buildCoinSelectionForTransaction
         out <-
             -- NOTE: We assume that the change outputs are always
             -- at the end of the list. This is true for the current
-            -- implementation of the transaction layer, but may not
+            -- 'balanceTransaction' implementation, but may not
             -- be true for other implementations.
             drop (length  paymentOutputs) $ fromCardanoTxOut <$> txOuts
         let address = out ^. #address

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2008,35 +2008,10 @@ buildAndSignTransactionPure
     --
     WriteTx.withRecentEra era $ \(_ :: WriteTx.RecentEra recentEra) -> do
         wallet <- get
-
-        unsignedTxBody <-
-            lift . withExceptT (Right . ErrConstructTxBody) . except $
-                mkUnsignedTransaction txLayer @recentEra
-                    (unsafeShelleyOnlyGetRewardXPub (getState wallet))
-                    protocolParams
-                    txCtx
-                    (Left preSelection)
-
-        (unsignedBalancedTx, updatedWalletState) <- lift . withExceptT Left $
-            balanceTransaction @_ @_ @s @k @ktype
-                nullTracer
-                txLayer
-                Nothing -- "To input scripts" resolver
-                Nothing -- Script template
-                nodeProtocolParameters
-                ti
-                (UTxOIndex.fromMap
-                    $ CS.toInternalUTxOMap
-                    $ availableUTxO @s pendingTxs wallet)
-                changeAddrGen
-                (getState wallet)
-                ( PartialTx
-                    { tx = Cardano.Tx unsignedTxBody []
-                    , inputs = Cardano.UTxO mempty
-                    , redeemers = []
-                    }
-                )
-
+        (unsignedBalancedTx, updatedWalletState) <- lift $
+            buildTransactionPure @s @k @ktype @n @recentEra
+                wallet ti pendingTxs txLayer changeAddrGen
+                protocolParams txCtx preSelection
         put wallet { getState = updatedWalletState }
 
         let passphrase = preparePassphrase passphraseScheme userPassphrase
@@ -2092,6 +2067,59 @@ buildAndSignTransactionPure
             }
   where
     anyCardanoEra = WriteTx.fromAnyRecentEra era
+
+buildTransactionPure ::
+    forall s k ktype (n :: NetworkDiscriminant) era
+    . ( Typeable n
+      , Typeable s
+      , Typeable k
+      , BoundedAddressLength k
+      , WriteTx.IsRecentEra era
+      )
+    => Wallet s
+    -> TimeInterpreter (Either PastHorizonException)
+    -> Set Tx -- pending transactions
+    -> TransactionLayer k ktype SealedTx
+    -> ChangeAddressGen s
+    -> ProtocolParameters
+    -> TransactionCtx
+    -> PreSelection
+    -> ExceptT
+        (Either ErrBalanceTx ErrConstructTx)
+        (Rand StdGen)
+        (Cardano.Tx era, s)
+buildTransactionPure
+    wallet ti pendingTxs txLayer changeAddrGen
+    protocolParams txCtx preSelection = do
+    --
+    unsignedTxBody <-
+        withExceptT (Right . ErrConstructTxBody) . except $
+            mkUnsignedTransaction txLayer @era
+                (unsafeShelleyOnlyGetRewardXPub (getState wallet))
+                protocolParams
+                txCtx
+                (Left preSelection)
+
+    withExceptT Left $
+        balanceTransaction @_ @_ @s @k @ktype
+            nullTracer
+            txLayer
+            Nothing -- "To input scripts" resolver
+            Nothing -- Script template
+            nodeProtocolParameters
+            ti
+            (UTxOIndex.fromMap
+                $ CS.toInternalUTxOMap
+                $ availableUTxO @s pendingTxs wallet)
+            changeAddrGen
+            (getState wallet)
+            PartialTx
+                { tx = Cardano.Tx unsignedTxBody []
+                , inputs = Cardano.UTxO mempty
+                , redeemers = []
+                }
+
+  where
     nodeProtocolParameters =
         ( protocolParams
         , fromMaybe

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2160,8 +2160,7 @@ buildTransaction
       , Typeable n
       , BoundedAddressLength k
       )
-    => AnyRecentEra
-    -> DBLayer IO s k
+    => DBLayer IO s k
     -> TransactionLayer k 'CredFromKeyK SealedTx
     -> TimeInterpreter (ExceptT PastHorizonException IO)
     -> WalletId
@@ -2170,11 +2169,11 @@ buildTransaction
     -> TransactionCtx
     -> [TxOut] -- ^ payment outputs
     -> IO (Cardano.Tx era, Wallet s)
-buildTransaction era DBLayer{..} txLayer timeInterpreter walletId
+buildTransaction DBLayer{..} txLayer timeInterpreter walletId
     changeAddrGen protocolParameters txCtx paymentOuts = do
     stdGen <- initStdGen
     pureTimeInterpreter <- snapshot timeInterpreter
-    WriteTx.withRecentEra era $ const . atomically $ do
+    atomically $ do
         wallet <- readDBVar walletsDB >>= \wallets ->
             case Map.lookup walletId wallets of
                 Nothing -> liftIO . throwIO

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1687,7 +1687,7 @@ buildCoinSelectionForTransaction
        )
     => Wallet s
     -> [TxOut] -- ^ payment outputs to exclude from change outputs
-    -> Coin
+    -> Coin -- ^ protocol parameter deposit amount
     -> Maybe DelegationAction
     -> Cardano.Tx era
     -> CoinSelection

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -122,7 +122,7 @@ module Cardano.Wallet
     , transactionExpirySlot
     , SelectAssetsParams (..)
     , selectAssets
-    , selectCoinsForTransaction
+    , buildCoinSelectionForTransaction
     , CoinSelection (..)
     , readWalletUTxOIndex
     , defaultChangeAddressGen
@@ -130,6 +130,7 @@ module Cardano.Wallet
     , assignChangeAddressesWithoutDbUpdate
     , selectionToUnsignedTx
     , buildSignSubmitTransaction
+    , buildTransaction
     , buildTransactionPure
     , buildAndSignTransactionPure
     , buildAndSignTransaction
@@ -303,7 +304,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , hashVerificationKey
     , liftIndex
     , stakeDerivationPath
-    , utxoInternal
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
@@ -482,7 +482,7 @@ import Control.Arrow
 import Control.DeepSeq
     ( NFData )
 import Control.Monad
-    ( forM, forM_, guard, replicateM, unless, when, (<=<) )
+    ( forM, forM_, replicateM, unless, when, (<=<) )
 import Control.Monad.Class.MonadTime
     ( DiffTime
     , MonadMonotonicTime (..)
@@ -549,7 +549,7 @@ import Data.List.NonEmpty
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
-    ( fromMaybe, isJust, isNothing, mapMaybe, maybeToList )
+    ( fromMaybe, isJust, mapMaybe, maybeToList )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Set
@@ -1678,106 +1678,67 @@ data CoinSelection = CoinSelection
     }
     deriving (Generic)
 
-selectCoinsForTransaction
-    :: forall s k (n :: NetworkDiscriminant) era
-    . ( s ~ SeqState n k
-      , WriteTx.IsRecentEra era
-      , AddressBookIso s
-      , Typeable k
-      , Typeable n
-      , BoundedAddressLength k
-      , IsOurs s Address
-      )
-    => AnyRecentEra
-    -> DBLayer IO s k
-    -> TransactionLayer k 'CredFromKeyK SealedTx
-    -> TimeInterpreter (ExceptT PastHorizonException IO)
-    -> WalletId
-    -> ChangeAddressGen s
-    -> ProtocolParameters
-    -> TransactionCtx
-    -> IO CoinSelection
-selectCoinsForTransaction era DBLayer{..} txLayer timeInterpreter walletId
-    changeAddrGen protocolParameters txCtx = do
-    stdGen <- initStdGen
-    pureTimeInterpreter <- snapshot timeInterpreter
-    WriteTx.withRecentEra era $ const . atomically $ do
-        wallet <- readDBVar walletsDB >>= \wallets ->
-            case Map.lookup walletId wallets of
-                Nothing -> liftIO . throwIO
-                    $ ExceptionNoSuchWallet
-                    $ ErrNoSuchWallet walletId
-                Just ws -> pure $ WalletState.getLatest ws
 
-        pendingTxs <- Set.fromList . fmap fromTransactionInfo <$>
-            readTransactions
-                walletId Nothing Descending wholeRange (Just Pending)
-
-        (cardanoTx, _s) <- buildTransactionPure @s @_ @'CredFromKeyK @n @era
-            wallet
-            pureTimeInterpreter
-            pendingTxs
-            txLayer
-            changeAddrGen
-            protocolParameters
-            (PreSelection [])
-            txCtx
-            & runExceptT . withExceptT
-                (either ExceptionBalanceTx ExceptionConstructTx)
-            & (`evalRand` stdGen)
-            & either (liftIO . throwIO) pure
-
-        let Cardano.TxBody Cardano.TxBodyContent
-                { txIns, txOuts, txInsCollateral, txWithdrawals } =
-                    Cardano.getTxBody cardanoTx
-
-        let resolveInput txIn = do
-                (txOut, derivationPath) <- maybeToList (lookupTxIn wallet txIn)
-                pure (txIn, txOut, derivationPath)
-
-        let rewardAcctPath =
-                stakeDerivationPath (Seq.derivationPrefix (getState wallet))
-
-        let depositRefund = W.stakeKeyDeposit protocolParameters
-
-        let changeDerivationPath :: Address -> Maybe (NonEmpty DerivationIndex)
-            changeDerivationPath addr = do
-                derivationPath <- fst $ isOurs addr (getState wallet)
-                let role = derivationPath NE.!! 3
-                guard $ getIndex utxoInternal == getDerivationIndex role
-                pure derivationPath
-
-        pure CoinSelection
-            { inputs = resolveInput . fromCardanoTxIn . fst =<< txIns
-            , outputs =
-                filter (isNothing . changeDerivationPath . view #address)
-                    $ fromCardanoTxOut <$> txOuts
-            , change = do
-                out <- fromCardanoTxOut <$> txOuts
-                let address = out ^. #address
-                derivationPath <- maybeToList $ changeDerivationPath address
-                pure TxChange
-                    { address
-                    , amount = out ^. #tokens . #coin
-                    , assets = out ^. #tokens . #tokens
-                    , derivationPath
-                    }
-            , collateral = resolveInput . fromCardanoTxIn =<<
-                case txInsCollateral of
-                    Cardano.TxInsCollateralNone -> []
-                    Cardano.TxInsCollateral _supported is -> is
-            , withdrawals = fromCardanoWdrls txWithdrawals <&>
-                \(acct, coin) -> (acct, coin, rewardAcctPath)
-            , delegationAction = (,rewardAcctPath) <$> txDelegationAction txCtx
-            , deposit =
-                case txDelegationAction txCtx of
-                    Just (JoinRegisteringKey _poolId) -> Just depositRefund
-                    _ -> Nothing
-            , refund =
-                case txDelegationAction txCtx of
-                    Just Quit -> Just depositRefund
-                    _ -> Nothing
+buildCoinSelectionForTransaction
+    :: forall s k n era
+     . ( Cardano.IsCardanoEra era
+       , IsOurs s Address
+       , s ~ SeqState n k
+       )
+    => Wallet s
+    -> [TxOut] -- payment outputs to exclude from change outputs
+    -> Coin
+    -> Maybe DelegationAction
+    -> Cardano.Tx era
+    -> CoinSelection
+buildCoinSelectionForTransaction
+    wallet paymentOutputs depositRefund delegationAction cardanoTx =
+    CoinSelection
+    { inputs = resolveInput . fromCardanoTxIn . fst =<< txIns
+    , outputs = paymentOutputs
+    , change = do
+        out <-
+            -- NOTE: We assume that the change outputs are always
+            -- at the end of the list. This is true for the current
+            -- implementation of the transaction layer, but may not
+            -- be true for other implementations.
+            drop (length  paymentOutputs) $ fromCardanoTxOut <$> txOuts
+        let address = out ^. #address
+        derivationPath <-
+            maybeToList $ fst $ isOurs address (getState wallet)
+        pure TxChange
+            { address
+            , amount = out ^. #tokens . #coin
+            , assets = out ^. #tokens . #tokens
+            , derivationPath
             }
+    , collateral = resolveInput . fromCardanoTxIn =<<
+        case txInsCollateral of
+            Cardano.TxInsCollateralNone -> []
+            Cardano.TxInsCollateral _supported is -> is
+    , withdrawals = fromCardanoWdrls txWithdrawals <&>
+        \(acct, coin) -> (acct, coin, rewardAcctPath)
+    , delegationAction = (,rewardAcctPath) <$> delegationAction
+    , deposit =
+        case delegationAction of
+            Just (JoinRegisteringKey _poolId) -> Just depositRefund
+            _ -> Nothing
+    , refund =
+        case delegationAction of
+            Just Quit -> Just depositRefund
+            _ -> Nothing
+    }
+  where
+    Cardano.TxBody Cardano.TxBodyContent
+        { txIns, txOuts, txInsCollateral, txWithdrawals } =
+            Cardano.getTxBody cardanoTx
+
+    resolveInput txIn = do
+        (txOut, derivationPath) <- maybeToList (lookupTxIn wallet txIn)
+        pure (txIn, txOut, derivationPath)
+
+    rewardAcctPath =
+        stakeDerivationPath (Seq.derivationPrefix (getState wallet))
 
 -- | Read a wallet checkpoint and index its UTxO, for 'selectAssets' and
 -- 'selectAssetsNoOutputs'.
@@ -2189,6 +2150,57 @@ buildAndSignTransactionPure
             }
   where
     anyCardanoEra = WriteTx.fromAnyRecentEra era
+
+buildTransaction
+    :: forall s k (n :: NetworkDiscriminant) era
+    . ( s ~ SeqState n k
+      , WriteTx.IsRecentEra era
+      , AddressBookIso s
+      , Typeable k
+      , Typeable n
+      , BoundedAddressLength k
+      )
+    => AnyRecentEra
+    -> DBLayer IO s k
+    -> TransactionLayer k 'CredFromKeyK SealedTx
+    -> TimeInterpreter (ExceptT PastHorizonException IO)
+    -> WalletId
+    -> ChangeAddressGen s
+    -> ProtocolParameters
+    -> TransactionCtx
+    -> IO (Cardano.Tx era, Wallet s)
+buildTransaction era DBLayer{..} txLayer timeInterpreter walletId
+    changeAddrGen protocolParameters txCtx = do
+    stdGen <- initStdGen
+    pureTimeInterpreter <- snapshot timeInterpreter
+    WriteTx.withRecentEra era $ const . atomically $ do
+        wallet <- readDBVar walletsDB >>= \wallets ->
+            case Map.lookup walletId wallets of
+                Nothing -> liftIO . throwIO
+                    $ ExceptionNoSuchWallet
+                    $ ErrNoSuchWallet walletId
+                Just ws -> pure $ WalletState.getLatest ws
+
+        pendingTxs <- Set.fromList . fmap fromTransactionInfo <$>
+            readTransactions
+                walletId Nothing Descending wholeRange (Just Pending)
+
+        let paymentOutputs = []
+
+        fmap (\s' -> wallet { getState = s' }) <$>
+            buildTransactionPure @s @_ @'CredFromKeyK @n @era
+                wallet
+                pureTimeInterpreter
+                pendingTxs
+                txLayer
+                changeAddrGen
+                protocolParameters
+                PreSelection { outputs = paymentOutputs }
+                txCtx
+                & runExceptT . withExceptT
+                    (either ExceptionBalanceTx ExceptionConstructTx)
+                & (`evalRand` stdGen)
+                & either (liftIO . throwIO) pure
 
 buildTransactionPure ::
     forall s k ktype (n :: NetworkDiscriminant) era

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -549,7 +549,7 @@ import Data.List.NonEmpty
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
-    ( fromMaybe, isJust, mapMaybe, maybeToList )
+    ( fromMaybe, isJust, isNothing, mapMaybe, maybeToList )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Set
@@ -1740,17 +1740,24 @@ selectCoinsForTransaction era DBLayer{..} txLayer timeInterpreter walletId
 
         let depositRefund = W.stakeKeyDeposit protocolParameters
 
-        pure CoinSelection
-            { inputs = resolveInput . fromCardanoTxIn . fst =<< txIns
-            , outputs = fromCardanoTxOut <$> txOuts
-            , change = do
-                out <- fromCardanoTxOut <$> txOuts
-                derivationPath <- maybeToList . fst $
-                    isOurs (out ^. #address) (getState wallet)
+        let changeDerivationPath :: Address -> Maybe (NonEmpty DerivationIndex)
+            changeDerivationPath addr = do
+                derivationPath <- fst $ isOurs addr (getState wallet)
                 let role = derivationPath NE.!! 3
                 guard $ getIndex utxoInternal == getDerivationIndex role
+                pure derivationPath
+
+        pure CoinSelection
+            { inputs = resolveInput . fromCardanoTxIn . fst =<< txIns
+            , outputs =
+                filter (isNothing . changeDerivationPath . view #address)
+                    $ fromCardanoTxOut <$> txOuts
+            , change = do
+                out <- fromCardanoTxOut <$> txOuts
+                let address = out ^. #address
+                derivationPath <- maybeToList $ changeDerivationPath address
                 pure TxChange
-                    { address = out ^. #address
+                    { address
                     , amount = out ^. #tokens . #coin
                     , assets = out ^. #tokens . #tokens
                     , derivationPath

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2168,9 +2168,10 @@ buildTransaction
     -> ChangeAddressGen s
     -> ProtocolParameters
     -> TransactionCtx
+    -> [TxOut] -- ^ payment outputs
     -> IO (Cardano.Tx era, Wallet s)
 buildTransaction era DBLayer{..} txLayer timeInterpreter walletId
-    changeAddrGen protocolParameters txCtx = do
+    changeAddrGen protocolParameters txCtx paymentOuts = do
     stdGen <- initStdGen
     pureTimeInterpreter <- snapshot timeInterpreter
     WriteTx.withRecentEra era $ const . atomically $ do
@@ -2185,8 +2186,6 @@ buildTransaction era DBLayer{..} txLayer timeInterpreter walletId
             readTransactions
                 walletId Nothing Descending wholeRange (Just Pending)
 
-        let paymentOutputs = []
-
         fmap (\s' -> wallet { getState = s' }) <$>
             buildTransactionPure @s @_ @'CredFromKeyK @n @era
                 wallet
@@ -2195,7 +2194,7 @@ buildTransaction era DBLayer{..} txLayer timeInterpreter walletId
                 txLayer
                 changeAddrGen
                 protocolParameters
-                PreSelection { outputs = paymentOutputs }
+                PreSelection { outputs = paymentOuts }
                 txCtx
                 & runExceptT . withExceptT
                     (either ExceptionBalanceTx ExceptionConstructTx)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -84,7 +84,6 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , SeqState (..)
     , coinTypeAda
     , discoverSeqWithRewards
-    , purposeBIP44
     , purposeCIP1852
     , rewardAccountKey
     )
@@ -384,10 +383,8 @@ instance ToRewardAccount ShelleyKey where
     toRewardAccount = toRewardAccountRaw . getKey
     someRewardAccount mw =
         let
-            -- NOTE: Accounts from mnemonics are considered to be ITN wallet-like,
-            -- therefore bound to purpose=44', 0th account.
             path = NE.fromList
-                [ DerivationIndex $ getIndex purposeBIP44
+                [ DerivationIndex $ getIndex purposeCIP1852
                 , DerivationIndex $ getIndex coinTypeAda
                 , DerivationIndex $ getIndex @'Hardened minBound
                 , DerivationIndex $ getIndex mutableAccount

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -105,6 +105,7 @@ import Cardano.Slotting.EpochInfo.API
 import Cardano.Tx.Balance.Internal.CoinSelection
     ( SelectionLimitOf (..)
     , SelectionOf (..)
+    , SelectionOutputTokenQuantityExceedsLimitError (..)
     , SelectionSkeleton (..)
     , selectionDelta
     )
@@ -159,7 +160,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , withinEra
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TxConstraints (..), TxSize (..), txSizeDistance )
+    ( TxConstraints (..), TxSize (..), txOutMaxTokenQuantity, txSizeDistance )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
@@ -219,7 +220,7 @@ import Codec.Serialise
 import Control.Arrow
     ( left, second )
 import Control.Monad
-    ( forM, guard )
+    ( forM, forM_, guard, when )
 import Control.Monad.Trans.Class
     ( lift )
 import Control.Monad.Trans.Except
@@ -2307,22 +2308,14 @@ mkUnsignedTx
     -> Map AssetId (Script KeyHash)
     -> Map TxIn (Script KeyHash)
     -> Either ErrMkTransaction (Cardano.TxBody era)
-mkUnsignedTx
-    era ttl cs md wdrls certs fees mintData burnData mintingScripts inpsScripts =
+mkUnsignedTx era ttl cs md wdrls certs fees mintData burnData mintingScripts inpsScripts = extractValidatedOutputs cs >>= \outs ->
     left toErrMkTx $ fmap removeDummyInput $ Cardano.makeTransactionBody
     Cardano.TxBodyContent
     { Cardano.txIns = inputWits
 
     , txInsReference = Cardano.TxInsReferenceNone
 
-    , Cardano.txOuts = case cs of
-        Right selOf ->
-            toCardanoTxOut era <$>
-                view #outputs selOf ++ F.toList (view #change selOf)
-        Left preSel ->
-            toCardanoTxOut era <$>
-                view #outputs preSel
-
+    , Cardano.txOuts = map (toCardanoTxOut era) outs
     , Cardano.txWithdrawals =
         let wit = Cardano.BuildTxWith
                 $ Cardano.KeyWitness Cardano.KeyWitnessForStakeAddr
@@ -2395,6 +2388,46 @@ mkUnsignedTx
   where
     toErrMkTx :: Cardano.TxBodyError -> ErrMkTransaction
     toErrMkTx = ErrMkTransactionTxBodyError . T.pack . Cardano.displayError
+
+    -- Extra validation for HTTP API backward compatibility:
+    --
+    -- Previously validation of user-provided payment outputs was handled by
+    -- coin-selection, as coin-selection was run before assembling the
+    -- transaction as a real 'Cardano.Tx'. Now, with 'balanceTx' this is no
+    -- longer the case, meaning that validation from cardano-api would take
+    -- precedence without this extra preceeding validation.
+    --
+    -- We may concider to, after ADP-2268:
+    -- - Embrace cardano-api errors and remove this function
+    -- - Extract and re-use validation from coin-selection, rather than
+    --     duplicating.
+    -- - Remove validation from coin-selection itself
+    extractValidatedOutputs
+        :: Either PreSelection (SelectionOf TxOut)
+        -> Either ErrMkTransaction [TxOut]
+    extractValidatedOutputs sel =
+        mapM validateOut $ case sel of
+            Right selOf -> view #outputs selOf ++ F.toList (view #change selOf)
+            Left preSel -> view #outputs preSel
+      where
+        validateOut :: TxOut -> Either ErrMkTransaction TxOut
+        validateOut out = do
+            verifyOutputTokenQuantities out
+            return out
+          where
+            verifyOutputTokenQuantities :: TxOut -> Either ErrMkTransaction ()
+            verifyOutputTokenQuantities (TxOut addr (TokenBundle _ tokens)) = do
+                forM_ (TokenMap.toFlatList tokens) $ \(asset, quantity) -> do
+                    when (quantity > txOutMaxTokenQuantity) $
+                        Left (mkErr asset quantity)
+              where
+                mkErr aid q = ErrMkTransactionTokenQuantityExceedsLimit
+                    $ SelectionOutputTokenQuantityExceedsLimitError
+                        { address = addr
+                        , asset = aid
+                        , quantity = q
+                        , quantityMaxBound = txOutMaxTokenQuantity
+                        }
 
     metadataSupported :: Cardano.TxMetadataSupportedInEra era
     metadataSupported = case era of

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -76,7 +76,9 @@ import Cardano.Tx.Balance.Internal.CoinSelection
     ( SelectionCollateralRequirement (..)
     , SelectionLimit
     , SelectionOf (..)
+    , SelectionOutputTokenQuantityExceedsLimitError
     , SelectionSkeleton
+    , WalletSelectionContext
     )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), DerivationIndex )
@@ -521,6 +523,8 @@ data ErrMkTransaction
     = ErrMkTransactionNoSuchWallet WalletId
     | ErrMkTransactionTxBodyError Text
     -- ^ We failed to construct a transaction for some reasons.
+    | ErrMkTransactionTokenQuantityExceedsLimit
+        (SelectionOutputTokenQuantityExceedsLimitError WalletSelectionContext)
     | ErrMkTransactionInvalidEra AnyCardanoEra
     -- ^ Should never happen, means that that we have programmatically provided
     -- an invalid era.

--- a/lib/wallet/test/integration/shelley-integration-test.hs
+++ b/lib/wallet/test/integration/shelley-integration-test.hs
@@ -331,7 +331,7 @@ specWithServer testDir (tr, tracers) = aroundAll withContext
     encodeAddresses = map (first (T.unpack . encodeAddress @'Mainnet))
 
     faucetFunds = FaucetFunds
-        { pureAdaFunds =
+        { pureAdaFunds =
             shelleyIntegrationTestFunds
              <> byronIntegrationTestFunds
              <> map (first unsafeDecodeAddr) hwWalletFunds


### PR DESCRIPTION
`selectCoinsForQuit` uses `balanceTransaction` under the hood.

The code in this PR builds and balances a simulated transaction that quits stake pool and then derives `CoinSelection` information from it. 

### Issue Number

ADP-2437