### PR TITLE
[ADP-2647] let local tx resubmission engine test depend on new submissions store

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -360,6 +360,7 @@ library
     Cardano.Wallet.Submissions.TxStatus
     Cardano.Wallet.TokenMetadata
     Cardano.Wallet.Transaction
+    Cardano.Wallet.Transaction.Built
     Cardano.Wallet.Version
     Cardano.Wallet.Version.TH
     Cardano.Wallet.Write.Tx

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -459,6 +459,8 @@ import Cardano.Wallet.Transaction
     , defaultTransactionCtx
     , withdrawalToCoin
     )
+import Cardano.Wallet.Transaction.Built
+    ( BuiltTx (..) )
 import Cardano.Wallet.Write.Tx
     ( AnyRecentEra )
 import Cardano.Wallet.Write.Tx.Balance
@@ -1960,13 +1962,6 @@ buildSignSubmitTransaction ti db@DBLayer{..} netLayer txLayer pwd walletId
     wrapNoWalletForSubmit = ExceptionSubmitTx . ErrSubmitTxNoSuchWallet
     wrapNetworkError = ExceptionSubmitTx . ErrSubmitTxNetwork
     wrapBalanceConstructError = either ExceptionBalanceTx ExceptionConstructTx
-
-data BuiltTx = BuiltTx
-    { builtTx :: Tx
-    , builtTxMeta :: TxMeta
-    , builtSealedTx :: SealedTx
-    }
-    deriving (Show, Eq)
 
 buildAndSignTransactionPure
     :: forall k ktype s (n :: NetworkDiscriminant)

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -39,6 +39,7 @@ module Cardano.Wallet.DB
     , ErrRemoveTx (..)
     , ErrPutLocalTxSubmission (..)
     , getInSubmissionTransaction_
+    , hoistDBLayer
     ) where
 
 import Prelude
@@ -416,6 +417,9 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         :: forall a. stm a -> m a
         -- ^ Execute operations of the database in isolation and atomically.
     }
+
+hoistDBLayer :: (forall a . m a -> n a) -> DBLayer m s k -> DBLayer n s k
+hoistDBLayer f DBLayer{..} = DBLayer {atomically = f . atomically, ..}
 
 {-----------------------------------------------------------------------------
     Build DBLayer from smaller parts

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -321,15 +321,6 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         --
         -- If the wallet doesn't exist, this operation returns an error.
 
-    , putLocalTxSubmission
-        :: WalletId
-        -> Hash "Tx"
-        -> SealedTx
-        -> SlotNo
-        -> ExceptT ErrPutLocalTxSubmission stm ()
-        -- ^ Add or update a transaction in the local submission pool with the
-        -- most recent submission slot.
-
     , addTxSubmission
         :: WalletId
         -> BuiltTx
@@ -541,7 +532,6 @@ mkDBLayerFromParts ti DBLayerCollection{..} = DBLayer
                             (hoistTimeInterpreter liftIO ti)
                             (mkDecorator_ dbTxHistory) tip
             Nothing -> pure Nothing
-    , putLocalTxSubmission = putLocalTxSubmission_ dbPendingTxs
     , addTxSubmission = \wid a b -> wrapNoSuchWallet wid $
         addTxSubmission_ dbPendingTxs wid a b
     , readLocalTxSubmissionPending = readLocalTxSubmissionPending_ dbPendingTxs
@@ -762,15 +752,6 @@ data DBPendingTxs stm = DBPendingTxs
         :: WalletId
         -> stm ()
         -- ^ Add overwrite an empty submisison pool to the given wallet.
-
-    , putLocalTxSubmission_
-        :: WalletId
-        -> Hash "Tx"
-        -> SealedTx
-        -> SlotNo
-        -> ExceptT ErrPutLocalTxSubmission stm ()
-        -- ^ Add or update a transaction in the local submission pool with the
-        -- most recent submission slot.
 
     , addTxSubmission_
         :: WalletId

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -97,6 +97,8 @@ import Cardano.Wallet.Read.Tx.Hash
     ( getEraTxHash )
 import Cardano.Wallet.Submissions.Submissions
     ( TxStatusMeta (..) )
+import Cardano.Wallet.Transaction.Built
+    ( BuiltTx )
 import Control.Monad
     ( guard, join )
 import Control.Monad.IO.Class
@@ -329,7 +331,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
 
     , addTxSubmission
         :: WalletId
-        -> (Tx, TxMeta, SealedTx)
+        -> BuiltTx
         -> SlotNo
         -> ExceptT ErrNoSuchWallet stm ()
         -- ^ Add a /new/ transaction to the local submission pool
@@ -768,7 +770,7 @@ data DBPendingTxs stm = DBPendingTxs
 
     , addTxSubmission_
         :: WalletId
-        -> (Tx, TxMeta, SealedTx)
+        -> BuiltTx
         -> SlotNo
         -> stm ()
         -- ^ Add a /new/ transaction to the local submission pool

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -24,7 +24,6 @@ import Cardano.Address.Derivation
 import Cardano.Wallet.DB
     ( DBLayer (..)
     , ErrNoSuchTransaction (..)
-    , ErrPutLocalTxSubmission (..)
     , ErrRemoveTx (..)
     , ErrWalletAlreadyExists (..)
     )
@@ -192,10 +191,6 @@ newDBLayer timeInterpreter = do
         {-----------------------------------------------------------------------
                                        Pending Tx
         -----------------------------------------------------------------------}
-
-        , putLocalTxSubmission = \pk txid tx sl -> ExceptT $
-            alterDB (fmap ErrPutLocalTxSubmissionNoSuchWallet . errNoSuchWallet) db $
-            mPutLocalTxSubmission pk txid tx sl
 
         , addTxSubmission = error "addTxSubmission not implemented in old design"
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -47,7 +47,6 @@ import Cardano.Wallet.DB.Pure.Implementation
     , mReadCheckpoint
     , mReadDelegationRewardBalance
     , mReadGenesisParameters
-    , mReadLocalTxSubmissionPending
     , mReadPrivateKey
     , mReadTxHistory
     , mReadWalletMeta
@@ -195,7 +194,7 @@ newDBLayer timeInterpreter = do
         , addTxSubmission = error "addTxSubmission not implemented in old design"
 
         , readLocalTxSubmissionPending =
-            readDB db . mReadLocalTxSubmissionPending
+                error "readLocalTxSubmissionPending not implemented in old design"
 
         , resubmitTx = \wid txId sealed tip -> void $
             alterDB errNoSuchWallet db $ mPutLocalTxSubmission wid txId sealed tip

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
@@ -10,7 +10,7 @@
 
 module Cardano.Wallet.DB.Store.Submissions.Layer
     ( mkDbPendingTxs
-    )
+    , mkLocalTxSubmission)
     where
 
 import Prelude hiding
@@ -43,7 +43,7 @@ import Cardano.Wallet.Transaction.Built
 import Control.Category
     ( (.) )
 import Control.Lens
-    ( to, (^.), (^..) )
+    ( (^.), (^..) )
 import Control.Monad.Except
     ( ExceptT (ExceptT) )
 import Data.Bifunctor
@@ -97,15 +97,7 @@ mkDbPendingTxs dbvar = DBPendingTxs
             submissions <- readDBVar dbvar
             pure $ case Map.lookup wid submissions of
                 Nothing  -> []
-                Just xs -> xs ^.. transactionsL . traverse . to (fmap snd)
-
-    , readLocalTxSubmissionPending_ = \wid -> do
-            v <- readDBVar dbvar
-            pure $ case Map.lookup wid v of
-                Nothing -> []
-                Just sub -> do
-                    (_k, x) <- Map.assocs $ sub ^. transactionsL
-                    mkLocalTxSubmission x
+                Just xs -> xs ^.. transactionsL . traverse
 
     , rollForwardTxSubmissions_ = \wid tip txs ->
         updateDBVar dbvar

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}
 -- |
@@ -33,30 +34,16 @@ import Cardano.Wallet.DB.WalletState
     ( ErrNoSuchWallet (..) )
 import Cardano.Wallet.Primitive.Types
     ( SlotNo (SlotNo), WalletId )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( LocalTxSubmissionStatus (LocalTxSubmissionStatus), SealedTx )
-import Cardano.Wallet.Read.Eras
-    ( K (..) )
-import Cardano.Wallet.Read.Eras.EraFun
-    ( EraFun )
-import Cardano.Wallet.Read.Primitive.Tx.Features.Validity
-    ( getValidity )
-import Cardano.Wallet.Read.Tx.Cardano
-    ( anythingFromSealedTx )
-import Cardano.Wallet.Read.Tx.Hash
-    ( getEraTxHash )
-import Cardano.Wallet.Read.Tx.Validity
-    ( getEraValidity )
 import Cardano.Wallet.Submissions.Operations
     ( Operation (..) )
 import Cardano.Wallet.Submissions.Submissions
     ( TxStatusMeta (..), mkEmpty, transactions, transactionsL )
 import Cardano.Wallet.Submissions.TxStatus
-    ( TxStatus (..), getTx, status )
-import Cardano.Wallet.Transaction
-    ( ValidityIntervalExplicit (invalidHereafter) )
+    ( TxStatus (..), expirySlot, getTx, status )
+import Cardano.Wallet.Transaction.Built
+    ( BuiltTx (..) )
 import Control.Category
     ( (.) )
 import Control.Lens
@@ -69,12 +56,9 @@ import Data.DBVar
     ( DBVar, modifyDBMaybe, readDBVar, updateDBVar )
 import Data.DeltaMap
     ( DeltaMap (..) )
-import Data.Quantity
-    ( Quantity (..) )
 import Database.Persist.Sql
     ( SqlPersistT )
 
-import qualified Cardano.Wallet.Read.Tx as Read
 import qualified Data.Map.Strict as Map
 
 mkDbPendingTxs
@@ -99,12 +83,15 @@ mkDbPendingTxs dbvar = DBPendingTxs
                             $ error "pls pass meta to putLocalTxSubmission!"
                     in  (delta, Right ())
 
-    , addTxSubmission_ =  \wid (_ , meta, sealed) resubmitted -> do
-        let (expiry, txId) = extractPendingData sealed
+    , addTxSubmission_ =  \wid BuiltTx{..} resubmitted -> do
+        let txId = TxId $ builtTx ^. #txId
+            expiry = case builtTxMeta ^. #expiry of
+                Nothing -> SlotNo maxBound
+                Just slot -> slot
         updateDBVar dbvar
             $ Adjust wid
-            $ AddSubmission expiry (txId , sealed)
-            $ submissionMetaFromTxMeta meta resubmitted
+            $ AddSubmission expiry (txId, builtSealedTx)
+            $ submissionMetaFromTxMeta builtTxMeta resubmitted
 
     , resubmitTx_ = \wid (TxId -> txId) _sealed resubmitted -> do
         submissions <- readDBVar dbvar
@@ -114,15 +101,16 @@ mkDbPendingTxs dbvar = DBPendingTxs
             (TxStatusMeta datas meta) <-
                 Map.lookup txId $ walletSubmissions ^. transactionsL
             (_, sealed) <- getTx datas
-            let (expiry,_) = extractPendingData sealed
-            pure $ do
-                updateDBVar dbvar
-                    $ Adjust wid
-                    $ Forget txId
-                updateDBVar dbvar
-                    $ Adjust wid
-                    $ AddSubmission expiry (txId, sealed)
-                    $ meta{submissionMetaResubmitted = resubmitted}
+            pure $ case expirySlot datas of
+                Nothing -> pure ()
+                Just expiry -> do
+                    updateDBVar dbvar
+                        $ Adjust wid
+                        $ Forget txId
+                    updateDBVar dbvar
+                        $ Adjust wid
+                        $ AddSubmission expiry (txId, sealed)
+                        $ meta{submissionMetaResubmitted = resubmitted}
 
     , getInSubmissionTransactions_ = \wid -> do
             submissions <- readDBVar dbvar
@@ -174,15 +162,3 @@ mkLocalTxSubmission (TxStatusMeta status' SubmissionMeta{..})
             LocalTxSubmissionStatus (txId) sealed submissionMetaResubmitted
         )
         $ getTx status'
-
-extractPendingData :: SealedTx -> (SlotNo, TxId)
-extractPendingData sealed = let
-    value :: EraFun Read.Tx (K a) -> a
-    value f = anythingFromSealedTx f sealed
-
-    txId = TxId $ Hash $ value getEraTxHash
-    validity = value $ getValidity . getEraValidity
-
-    Quantity expiry = maybe (Quantity 0) invalidHereafter validity
-
-    in (SlotNo expiry, txId)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
@@ -17,11 +17,7 @@ import Prelude hiding
     ( (.) )
 
 import Cardano.Wallet.DB
-    ( DBPendingTxs (..)
-    , ErrNoSuchTransaction (..)
-    , ErrPutLocalTxSubmission (..)
-    , ErrRemoveTx (..)
-    )
+    ( DBPendingTxs (..), ErrNoSuchTransaction (..), ErrRemoveTx (..) )
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.Submissions.Operations
@@ -68,21 +64,6 @@ mkDbPendingTxs dbvar = DBPendingTxs
     { emptyTxSubmissions_ = \wid ->
         updateDBVar dbvar
             $ Insert wid $ mkEmpty 0
-
-    , putLocalTxSubmission_ = \wid txid tx sl -> do
-        let errNoSuchWallet = ErrPutLocalTxSubmissionNoSuchWallet $
-                ErrNoSuchWallet wid
-        ExceptT $ modifyDBMaybe dbvar $ \ws -> do
-            case Map.lookup wid ws of
-                Nothing -> (Nothing, Left errNoSuchWallet)
-                Just _  ->
-                    let
-                        delta = Just
-                            $ Adjust wid
-                            $ AddSubmission sl (TxId txid, tx)
-                            $ error "pls pass meta to putLocalTxSubmission!"
-                    in  (delta, Right ())
-
     , addTxSubmission_ =  \wid BuiltTx{..} resubmitted -> do
         let txId = TxId $ builtTx ^. #txId
             expiry = case builtTxMeta ^. #expiry of

--- a/lib/wallet/src/Cardano/Wallet/Submissions/TxStatus.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/TxStatus.hs
@@ -24,6 +24,7 @@ module Cardano.Wallet.Submissions.TxStatus
     , slotObservation
     , TxStatuses
     , getTx
+    , expirySlot
     ) where
 
 import Prelude
@@ -86,5 +87,12 @@ slotObservation :: TxStatus slot tx -> Maybe slot
 slotObservation = \case
     InSubmission s _ -> Just s
     InLedger _ s _ -> Just s
+    Expired s _ -> Just s
+    Unknown -> Nothing
+
+expirySlot :: TxStatus a tx -> Maybe a
+expirySlot = \case
+    InSubmission s _ -> Just s
+    InLedger s _ _ -> Just s
     Expired s _ -> Just s
     Unknown -> Nothing

--- a/lib/wallet/src/Cardano/Wallet/Transaction/Built.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction/Built.hs
@@ -1,0 +1,15 @@
+module Cardano.Wallet.Transaction.Built
+    ( BuiltTx (..)
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Tx
+    ( SealedTx, Tx, TxMeta )
+
+data BuiltTx = BuiltTx
+    { builtTx :: Tx
+    , builtTxMeta :: TxMeta
+    , builtSealedTx :: SealedTx
+    }
+    deriving (Show, Eq)

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -50,6 +50,8 @@ import Cardano.Wallet.DB
     ( DBLayer (..), hoistDBLayer, putTxHistory )
 import Cardano.Wallet.DB.Layer
     ( newDBLayerInMemory )
+import Cardano.Wallet.DB.Store.Submissions.Operations
+    ( TxSubmissionsStatus )
 import Cardano.Wallet.DB.WalletState
     ( ErrNoSuchWallet (..) )
 import Cardano.Wallet.DummyTarget.Primitive.Types
@@ -119,7 +121,6 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantityPositive )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
-    , LocalTxSubmissionStatus (..)
     , SealedTx (..)
     , TransactionInfo (..)
     , Tx (..)
@@ -275,6 +276,8 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Read as Read
+import qualified Cardano.Wallet.Submissions.Submissions as Smbs
+import qualified Cardano.Wallet.Submissions.TxStatus as Sbms
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -804,9 +807,9 @@ prop_localTxSubmission tc = monadicIO $ do
     assert' _msg True  = return ()
     assert' msg False = fail msg
     eqByTxIds
-        :: [LocalTxSubmissionStatus SealedTx]
-        -> [LocalTxSubmissionStatus SealedTx] -> Bool
-    eqByTxIds = (==) `on` (sort . fmap (view #txId))
+        :: [TxSubmissionsStatus]
+        -> [TxSubmissionsStatus] -> Bool
+    eqByTxIds = (==) `on` (sort . fmap (fmap fst . Sbms.getTx . view Smbs.txStatus))
     runTest
         :: TxRetryTestState
         -> (TxRetryTestCtx -> TxRetryTestM a)

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -270,6 +270,7 @@ import UnliftIO.Concurrent
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.Address.Book as Sqlite
+import qualified Cardano.Wallet.DB.Sqlite.Types as DB
 import qualified Cardano.Wallet.DB.Store.Checkpoints as Sqlite
 import qualified Cardano.Wallet.Primitive.Migration as Migration
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
@@ -795,7 +796,11 @@ prop_localTxSubmission tc = monadicIO $ do
     assert' "all txs in submissions pool were required"
         $ all requested $ resSubmittedTxs res
 
+    let inPool BuiltTx{builtTx} = (Just . DB.TxId $ builtTx ^. #txId)  `elem`
+            fmap (fmap fst . Sbms.getTx . view Smbs.txStatus) resEnd
 
+    assert' "all required txs are in submissions pool"
+        $ all inPool $ retryTestPool tc
 
     assert' "start submissions pool is not empty"
         $ not $ null resStart


### PR DESCRIPTION
ADP-2647

- remove the dependency from LocalTxSubmission dblayer methods for submitting
- remove `putLocalTxSubmission`
- rewrite `putLocalTxSubmission` call in `WalletSpec` in terms of `submitTx` from wallet layer
- change `addTxSubmission` parameters to use `BuiltTx` 
- move `BuiltTx` in Write hierarchy