### PR TITLE
`selectCoinsForJoin` uses `balanceTransaction`

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
@@ -320,14 +320,15 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     --   https://github.com/quchen/articles/blob/master/fbut.md#f-x---is-not-f--x---
     {- HLINT ignore "Redundant lambda" -}
     coinSelections :: Server (CoinSelections n)
-    coinSelections = (\wid ascd -> case ascd of
-        (ApiSelectForPayment ascp) ->
+    coinSelections = (\wid -> \case
+        ApiSelectForPayment ascp ->
             selectCoins shelley (delegationAddress @n) wid ascp
-        (ApiSelectForDelegation (ApiSelectCoinsAction action)) ->
+        ApiSelectForDelegation (ApiSelectCoinsAction action) ->
             case action of
-                (Join pid) ->
+                Join pid ->
                     selectCoinsForJoin
                         shelley
+                        (delegationAddress @n)
                         (knownPools spl)
                         (getPoolLifeCycleStatus spl)
                         (getApiT pid)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1776,15 +1776,14 @@ selectCoins ctx@ApiLayer {..} genChange (ApiT wid) body = do
         pure $ mkApiCoinSelection [] [] Nothing md utx
 
 selectCoinsForJoin
-    :: forall ctx s n k.
+    :: forall s n k.
         ( s ~ SeqState n k
         , k ~ ShelleyKey
-        , ctx ~ ApiLayer s k 'CredFromKeyK
         , DelegationAddress n k 'CredFromKeyK
         , Seq.SupportsDiscovery n k
         , BoundedAddressLength k
         )
-    => ctx
+    => ApiLayer s k 'CredFromKeyK
     -> IO (Set PoolId)
        -- ^ Known pools
        -- We could maybe replace this with a @IO (PoolId -> Bool)@
@@ -1792,14 +1791,13 @@ selectCoinsForJoin
     -> PoolId
     -> WalletId
     -> Handler (Api.ApiCoinSelection n)
-selectCoinsForJoin ctx knownPools getPoolStatus pid wid = do
+selectCoinsForJoin ctx@ApiLayer{..} knownPools getPoolStatus pid walletId = do
     poolStatus <- liftIO (getPoolStatus pid)
     pools <- liftIO knownPools
     curEpoch <- getCurrentEpoch ctx
 
-    withWorkerCtx ctx wid liftE liftE $ \wrk -> do
+    withWorkerCtx ctx walletId liftE liftE $ \wrk -> do
         let db = wrk ^. typed @(DBLayer IO s k)
-            netLayer = wrk ^. networkLayer
         pp <- liftIO $ NW.currentProtocolParameters netLayer
         action <- liftIO $ WD.joinStakePoolDelegationAction @s @k
             (contramap MsgWallet $ wrk ^. logger)
@@ -1808,7 +1806,7 @@ selectCoinsForJoin ctx knownPools getPoolStatus pid wid = do
             pools
             pid
             poolStatus
-            wid
+            walletId
 
         let txCtx = defaultTransactionCtx
                 { txDelegationAction = Just action
@@ -1818,7 +1816,7 @@ selectCoinsForJoin ctx knownPools getPoolStatus pid wid = do
                 W.assignChangeAddresses (delegationAddress @n) sel s
                 & uncurry (W.selectionToUnsignedTx (txWithdrawal txCtx))
         (utxoAvailable, wallet, pendingTxs) <-
-            liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk wid
+            liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk walletId
         let selectAssetsParams = W.SelectAssetsParams
                 { outputs = []
                 , pendingTxs
@@ -1834,7 +1832,7 @@ selectCoinsForJoin ctx knownPools getPoolStatus pid wid = do
             $ W.selectAssets @_ @_ @s @k @'CredFromKeyK
                 wrk era pp selectAssetsParams transform
         (_, _, path) <- liftHandler
-            $ W.readRewardAccount db wid
+            $ W.readRewardAccount db walletId
 
         let deposits = case action of
                 JoinRegisteringKey _poolId -> [W.stakeKeyDeposit pp]


### PR DESCRIPTION
`selectCoinsForJoin` uses `balanceTransaction` under the hood.

The code in this PR builds and balances a simulated transaction that joins a stake pool and then derives `CoinSelection` information from it. 

### Issue Number

ADP-2436