### PR TITLE
[ADP-2660] Draft of `RollbackTxWalletsHistory` verb

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -241,6 +241,7 @@ library
     Cardano.Wallet.DB.Store.Transactions.Model
     Cardano.Wallet.DB.Store.Transactions.Store
     Cardano.Wallet.DB.Store.Transactions.TransactionInfo
+    Cardano.Wallet.DB.Store.Wallets.Layer
     Cardano.Wallet.DB.Store.Wallets.Model
     Cardano.Wallet.DB.Store.Wallets.Store
     Cardano.Wallet.DB.WalletState

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -849,6 +849,7 @@ test-suite unit
     Cardano.Wallet.DB.Store.Meta.StoreSpec
     Cardano.Wallet.DB.Store.Submissions.StoreSpec
     Cardano.Wallet.DB.Store.Transactions.StoreSpec
+    Cardano.Wallet.DB.Store.Wallets.LayerSpec
     Cardano.Wallet.DB.Store.Wallets.StoreSpec
     Cardano.Wallet.DelegationSpec
     Cardano.Wallet.DummyTarget.Primitive.Types

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -582,8 +582,6 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = mdo
 
                         updateS (store transactionsQS) undefined
                             $ RemoveWallet wid
-                        updateS (store transactionsQS) undefined
-                            GarbageCollectTxWalletsHistory
 
         , listWallets_ = map unWalletKey <$> selectKeysList [] [Asc WalId]
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -686,11 +686,7 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = mdo
                         [ StakeKeyCertSlot >. nearestPoint
                         ]
                     lift $ updateS (store transactionsQS) undefined
-                        $ ChangeTxMetaWalletsHistory wid
-                        $ Manipulate
-                        $ RollBackTxMetaHistory nearestPoint
-                    lift $ updateS (store transactionsQS) undefined
-                        GarbageCollectTxWalletsHistory
+                        $ RollbackTxWalletsHistory wid nearestPoint
                     lift $ rollBackSubmissions_ dbPendingTxs wid nearestPoint
                     pure
                         $ W.chainPointFromBlockHeader

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -691,6 +691,8 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = mdo
                         $ ChangeTxMetaWalletsHistory wid
                         $ Manipulate
                         $ RollBackTxMetaHistory nearestPoint
+                    lift $ updateS (store transactionsQS) undefined
+                        GarbageCollectTxWalletsHistory
                     lift $ rollBackSubmissions_ dbPendingTxs wid nearestPoint
                     pure
                         $ W.chainPointFromBlockHeader
@@ -703,8 +705,6 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = mdo
                     Just cp -> Right <$> do
                         let tip = cp ^. #currentTip
                         pruneCheckpoints wid epochStability tip
-            lift $ updateS (store transactionsQS) undefined
-                GarbageCollectTxWalletsHistory
             lift $ pruneByFinality_ dbPendingTxs wid finalitySlot
 
         {-----------------------------------------------------------------------

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Model.hs
@@ -19,9 +19,9 @@ module Cardano.Wallet.DB.Store.Meta.Model
     , ManipulateTxMetaHistory(..)
     , TxMetaHistory(..)
     , mkTxMetaHistory
+    , rollbackTxMetaHistory
     , WalletsMeta
-    )
-    where
+    ) where
 
 import Prelude
 
@@ -29,8 +29,6 @@ import Cardano.Wallet.DB.Sqlite.Schema
     ( TxMeta (..) )
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
-import Control.Monad
-    ( MonadPlus (mzero) )
 import Data.Delta
     ( Delta (..) )
 import Data.Functor
@@ -51,6 +49,9 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Data.Map.Strict as Map
 
+{-----------------------------------------------------------------------------
+    Type
+------------------------------------------------------------------------------}
 -- | A collection of `TxMeta`, indexed by transaction identifier.
 newtype TxMetaHistory =
     TxMetaHistory { relations :: Map TxId TxMeta }
@@ -61,6 +62,9 @@ instance Buildable TxMetaHistory where
         "TxMetaHistory "
         <> build (length $ relations txs)
 
+{-----------------------------------------------------------------------------
+    Operations
+------------------------------------------------------------------------------}
 -- | Verbs for 'TxMeta' changes
 -- that can be issued independently from the transaction store.
 data ManipulateTxMetaHistory
@@ -108,21 +112,27 @@ instance Delta ManipulateTxMetaHistory where
       where
         isExpired Nothing = False
         isExpired (Just tip') = tip' <= tip
-    apply (RollBackTxMetaHistory point) (TxMetaHistory txs) =
-        TxMetaHistory $ Map.mapMaybe rescheduleOrForget txs
-      where
-        rescheduleOrForget :: TxMeta -> Maybe TxMeta
-        rescheduleOrForget meta =
-            let
-                isAfter = txMetaSlot meta > point
-                isIncoming = txMetaDirection meta == W.Incoming
-            in case (isAfter, isIncoming) of
-                   (True,True) -> mzero
-                   (True,False) -> Just
-                       $ meta
-                       { txMetaSlot = point, txMetaStatus = W.Pending }
-                   _ -> Just meta
+    apply (RollBackTxMetaHistory point) metas =
+        fst $ rollbackTxMetaHistory point metas
 
+-- | Rollback a 'TxMetaHistory' to a given slot.
+-- Returns the new 'TxMetaHistory' as well as the 'TxId's that
+-- have been /deleted/ due to the rollback.
+rollbackTxMetaHistory
+    :: W.SlotNo -> TxMetaHistory -> (TxMetaHistory, [TxId])
+rollbackTxMetaHistory point (TxMetaHistory txs) =
+    (TxMetaHistory new, Map.keys deleted)
+  where
+    (deleted, new) = Map.mapEither keepOrForget txs
+
+    keepOrForget :: TxMeta -> Either () TxMeta
+    keepOrForget meta
+        | txMetaSlot meta > point = Left ()
+        | otherwise = Right meta
+
+{-----------------------------------------------------------------------------
+    Type conversion helpers
+------------------------------------------------------------------------------}
 mkTxMetaEntity :: W.WalletId -> W.Tx -> W.TxMeta -> TxMeta
 mkTxMetaEntity wid tx derived =
     TxMeta

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Store.hs
@@ -80,19 +80,11 @@ update wid _ change = case change of
         ]
         [TxMetaStatus =. W.Expired]
     Manipulate (RollBackTxMetaHistory point) -> do
-        let
-          isAfter = TxMetaSlot >. point
-          isIncoming = TxMetaDirection ==. W.Incoming
-          notIncoming = TxMetaDirection ==. W.Outgoing
+        let isAfter = TxMetaSlot >. point
         deleteWhere
             [ TxMetaWalletId ==. wid
-            , isAfter, isIncoming
+            , isAfter
             ]
-        updateWhere
-            [ TxMetaWalletId ==. wid
-            , isAfter, notIncoming
-            ]
-            [ TxMetaSlot =. point, TxMetaStatus =. W.Pending ]
 
 write :: WalletId -> TxMetaHistory -> SqlPersistT IO ()
 write wid txs = do

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -89,8 +89,6 @@ newQueryStoreTxWalletsHistory = do
 
     let updateTxSet = updateS (store txsQueryStore) undefined
         update = \case
-            ChangeTxMetaWalletsHistory wid change ->
-                updateDBVar transactionsDBVar $ Adjust wid change
             RemoveWallet wid -> do
                 updateDBVar transactionsDBVar $ Delete wid
                 update $ GarbageCollectTxWalletsHistory

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -107,8 +107,12 @@ newQueryStoreTxWalletsHistory = do
                         $ mkTxMetaHistory wid cs
                     , ()
                     )
-            RollbackTxWalletsHistory{} ->
-                error "RollbackTxWalletsHistory not implemented yet"
+            RollbackTxWalletsHistory wid slot -> do
+                updateDBVar transactionsDBVar
+                    $ Adjust wid
+                    $ TxMetaStore.Manipulate
+                    $ TxMetaStore.RollBackTxMetaHistory slot
+                update undefined GarbageCollectTxWalletsHistory
 
             -- TODO as part of ADP-1043
             -- Remove GarbageCollectTxWalletsHistory

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{- |
+Copyright: © 2022 IOHK
+License: Apache-2.0
+
+Implementation of a 'QueryStore' for 'TxWalletsHistory'.
+-}
+module Cardano.Wallet.DB.Store.Wallets.Layer
+    ( QueryTxWalletsHistory (..)
+    , QueryStoreTxWalletsHistory
+    , newQueryStoreTxWalletsHistory
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.DB.Sqlite.Schema
+    ( TxMeta (..) )
+import Cardano.Wallet.DB.Sqlite.Types
+    ( TxId (..) )
+import Cardano.Wallet.DB.Store.Meta.Model
+    ( TxMetaHistory (relations), mkTxMetaHistory )
+import Cardano.Wallet.DB.Store.QueryStore
+    ( QueryStore (..) )
+import Cardano.Wallet.DB.Store.Transactions.Model
+    ( DeltaTxSet (..), TxRelation, mkTxSet )
+import Cardano.Wallet.DB.Store.Wallets.Model
+    ( DeltaTxWalletsHistory (..), walletsLinkedTransactions )
+import Cardano.Wallet.DB.Store.Wallets.Store
+    ( mkStoreTxWalletsHistory, mkStoreWalletsMeta )
+import Data.DBVar
+    ( Store (..), loadDBVar, modifyDBVar, readDBVar, updateDBVar )
+import Data.DeltaMap
+    ( DeltaMap (..) )
+import Data.Foldable
+    ( toList )
+import Database.Persist.Sql
+    ( SqlPersistT )
+
+import qualified Cardano.Wallet.DB.Store.Meta.Model as TxMetaStore
+import qualified Cardano.Wallet.DB.Store.Transactions.Layer as TxSet
+import qualified Cardano.Wallet.DB.Store.Transactions.Model as TxSet
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Data.Map.Strict as Map
+
+{-----------------------------------------------------------------------------
+    Query type
+------------------------------------------------------------------------------}
+data QueryTxWalletsHistory b where
+    GetByTxId :: TxId -> QueryTxWalletsHistory (Maybe TxRelation)
+    One :: W.WalletId -> TxId -> QueryTxWalletsHistory (Maybe TxMeta)
+    All :: W.WalletId -> QueryTxWalletsHistory [TxMeta]
+
+{-----------------------------------------------------------------------------
+    Query Store type
+------------------------------------------------------------------------------}
+type QueryStoreTxWalletsHistory =
+    QueryStore (SqlPersistT IO) QueryTxWalletsHistory DeltaTxWalletsHistory
+
+newQueryStoreTxWalletsHistory
+    :: forall m. m ~ SqlPersistT IO
+    => m QueryStoreTxWalletsHistory
+newQueryStoreTxWalletsHistory = do
+    let txsQueryStore = TxSet.mkDBTxSet
+    transactionsDBVar <- loadDBVar mkStoreWalletsMeta
+
+    let readAllMetas :: W.WalletId -> m [TxMeta]
+        readAllMetas wid = do
+            wmetas <- readDBVar transactionsDBVar
+            pure
+                . maybe [] (toList . relations)
+                $ Map.lookup wid wmetas
+
+        query :: forall a. QueryTxWalletsHistory a -> SqlPersistT IO a
+        query = \case
+            GetByTxId txid ->
+                queryS txsQueryStore $ TxSet.GetByTxId txid
+            One wid txid -> do
+                wmetas <- readDBVar transactionsDBVar
+                pure $ do
+                    metas <- Map.lookup wid wmetas
+                    Map.lookup txid . relations $ metas
+            All wid ->
+                readAllMetas wid
+
+    let updateTxSet = updateS (store txsQueryStore) undefined
+        update _ = \case
+            ChangeTxMetaWalletsHistory wid change ->
+                updateDBVar transactionsDBVar $ Adjust wid change
+            RemoveWallet wid ->
+                updateDBVar transactionsDBVar $ Delete wid
+            ExpandTxWalletsHistory wid cs -> do
+                updateTxSet
+                    . Append
+                    . mkTxSet
+                    $ fst <$> cs
+                modifyDBVar transactionsDBVar $ \mtxmh ->
+                    ( case Map.lookup wid mtxmh of
+                    Nothing -> Insert wid (mkTxMetaHistory wid cs)
+                    Just _ -> Adjust wid
+                        $ TxMetaStore.Expand
+                        $ mkTxMetaHistory wid cs
+                    , ()
+                    )
+
+            -- TODO as part of ADP-1043
+            -- Remove GarbageCollectTxWalletsHistory
+            -- in favor of `RollbackTo` + separate storage for Submissions
+            GarbageCollectTxWalletsHistory -> do
+                mtxmh <- readDBVar transactionsDBVar
+                -- BUG: The following operation is very expensive for large
+                -- wallets. Apply TODO above instead.
+                Right mtxh <- loadS (store txsQueryStore)
+                let txsToDelete
+                        = Map.keys
+                        . Map.withoutKeys (TxSet.relations mtxh)
+                            -- needs info about existing transactions
+                        $ walletsLinkedTransactions mtxmh
+                mapM_ (updateTxSet . DeleteTx) txsToDelete
+
+    pure QueryStore
+        { queryS = query
+        , store = Store
+            { loadS = loadS mkStoreTxWalletsHistory
+            , writeS = writeS mkStoreTxWalletsHistory
+            , updateS = update
+            }
+        }

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -107,6 +107,8 @@ newQueryStoreTxWalletsHistory = do
                         $ mkTxMetaHistory wid cs
                     , ()
                     )
+            RollbackTxWalletsHistory{} ->
+                error "RollbackTxWalletsHistory not implemented yet"
 
             -- TODO as part of ADP-1043
             -- Remove GarbageCollectTxWalletsHistory

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -88,11 +88,12 @@ newQueryStoreTxWalletsHistory = do
                 readAllMetas wid
 
     let updateTxSet = updateS (store txsQueryStore) undefined
-        update _ = \case
+        update = \case
             ChangeTxMetaWalletsHistory wid change ->
                 updateDBVar transactionsDBVar $ Adjust wid change
-            RemoveWallet wid ->
+            RemoveWallet wid -> do
                 updateDBVar transactionsDBVar $ Delete wid
+                update $ GarbageCollectTxWalletsHistory
             ExpandTxWalletsHistory wid cs -> do
                 updateTxSet
                     . Append
@@ -127,6 +128,6 @@ newQueryStoreTxWalletsHistory = do
         , store = Store
             { loadS = loadS mkStoreTxWalletsHistory
             , writeS = writeS mkStoreTxWalletsHistory
-            , updateS = update
+            , updateS = const update
             }
         }

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -56,7 +56,6 @@ import qualified Data.Set as Set
 
 data DeltaTxWalletsHistory
     = ExpandTxWalletsHistory W.WalletId [(WT.Tx, WT.TxMeta)]
-    | ChangeTxMetaWalletsHistory W.WalletId DeltaTxMetaHistory
     | RollbackTxWalletsHistory W.WalletId W.SlotNo
         -- ^ Roll back a single wallet
     | GarbageCollectTxWalletsHistory
@@ -79,10 +78,6 @@ instance Delta DeltaTxWalletsHistory where
                   Adjust wid
                   $ TxMetaStore.Expand
                   $ mkTxMetaHistory wid cs)
-    apply (ChangeTxMetaWalletsHistory wid change) (txh, mtxmh) =
-        (txh, garbageCollectEmptyWallets
-            $ mtxmh & apply (Adjust wid change)
-            )
     apply (RollbackTxWalletsHistory wid slot) (x, mtxmh) =
         -- Roll back all wallets to a given slot (number)
         -- and garbage collect transactions that no longer

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -16,6 +16,7 @@ module Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaTxWalletsHistory (..)
     , TxWalletsHistory
     , walletsLinkedTransactions
+    , inAnyWallet
     ) where
 
 import Prelude
@@ -23,8 +24,7 @@ import Prelude
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.Meta.Model
-    ( DeltaTxMetaHistory (..)
-    , TxMetaHistory (..)
+    ( TxMetaHistory (..)
     , WalletsMeta
     , mkTxMetaHistory
     )
@@ -36,8 +36,6 @@ import Data.DeltaMap
     ( DeltaMap (Adjust, Insert) )
 import Data.Foldable
     ( toList )
-import Data.Function
-    ( (&) )
 import Data.Generics.Internal.VL
     ( view )
 import Data.Map.Strict
@@ -113,3 +111,12 @@ linkedTransactions (TxMetaHistory m) = Map.keysSet m
 walletsLinkedTransactions
     :: Map W.WalletId TxMetaHistory -> Set TxId
 walletsLinkedTransactions = Set.unions . toList . fmap linkedTransactions
+
+-- | Is a transaction present in any wallet?
+inAnyWallet
+    :: TxId
+    -> Map W.WalletId TxMetaHistory
+    -> Bool
+inAnyWallet txid = any inAnyTxMetaHistory
+  where
+    inAnyTxMetaHistory (TxMetaHistory m) = Map.member txid m

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -19,6 +19,7 @@ Implementation of a store for 'TxWalletsHistory'
 module Cardano.Wallet.DB.Store.Wallets.Store
     ( mkStoreTxWalletsHistory
     , DeltaTxWalletsHistory(..)
+    , mkStoreWalletsMeta
     ) where
 
 import Prelude

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -105,6 +105,8 @@ mkStoreTxWalletsHistory =
             ChangeTxMetaWalletsHistory wid change
                 -> updateS mkStoreWalletsMeta wmetas
                 $ Adjust wid change
+            RollbackTxWalletsHistory{} ->
+                error "RollbackTxWalletsHistory not implemented yet"
             GarbageCollectTxWalletsHistory ->
                 garbageCollectTxWalletsHistory txSet wmetas
             RemoveWallet wid -> do

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -102,9 +102,6 @@ mkStoreTxWalletsHistory =
           writeS mkStoreTransactions txSet
           writeS mkStoreWalletsMeta txMetaHistory
     , updateS = \(txSet,wmetas) -> \case
-            ChangeTxMetaWalletsHistory wid change
-                -> updateS mkStoreWalletsMeta wmetas
-                $ Adjust wid change
             RollbackTxWalletsHistory{} ->
                 error "RollbackTxWalletsHistory not implemented yet"
             GarbageCollectTxWalletsHistory ->

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/ModelSpec.hs
@@ -42,8 +42,6 @@ import Data.Delta
     ( Delta (..) )
 import Data.Foldable
     ( foldl', toList )
-import Data.Generics.Internal.VL
-    ( over )
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
@@ -67,18 +65,10 @@ spec = do
             $ property prop_PruneToAllInLedger
         it "can mark pending transactions as expired based on current slot"
             $ property prop_AgeAllPending2Expire
-        it
-            "can mark past pending transactions as expired based on current slot"
+        it "can mark past pending transactions as expired based on current slot"
             $ property prop_AgeSomePending2Expire
-        it "can roll back to a given slot, removing all incoming transactions"
+        it "can roll back to a given slot, removing all transactions"
             $ property prop_RollBackRemoveAfterSlot
-        it
-            "can roll back to a given slot, switching all outgoing transactions \
-            \ after slot in pending state"
-            $ property prop_RollBackSwitchOutgoing
-        it
-            "can roll back to a given slot, preserving all outgoing transactions"
-            $ property prop_RollBackPreserveOutgoing
         it "can roll back to a given slot, leaving past untouched"
             $ property prop_RollBackDoNotTouchPast
 
@@ -152,39 +142,11 @@ prop_RollBackRemoveAfterSlot =
     withPropRollBack $ \((_afterBoot,_beforeBoot),(afterNew,_beforeNew)) _
     -> property $ null $ relations afterNew
 
-prop_RollBackSwitchOutgoing :: WithWalletProperty
-prop_RollBackSwitchOutgoing =
-    withPropRollBack $ \((_afterBoot,beforeBoot),(_afterNew,beforeNew)) _ -> do
-        let future = overTxMetaHistory beforeNew $ \beforeMap
-                -> Map.difference beforeMap $ relations beforeBoot
-        property
-            $ all
-                ((&&) <$> ((==) Pending . txMetaStatus)
-                 <*> ((==) Outgoing . txMetaDirection))
-                (relations future)
-
-prop_RollBackPreserveOutgoing :: WithWalletProperty
-prop_RollBackPreserveOutgoing =
-    withPropRollBack $ \((afterBoot,beforeBoot),(_afterNew,beforeNew)) _ -> do
-        let future = overTxMetaHistory beforeNew $ \beforeMap
-                -> Map.difference beforeMap $ relations beforeBoot
-        property
-            $ (==)
-                (Map.keys $ allOutgoing afterBoot)
-                (Map.keys $ relations future)
-
 prop_RollBackDoNotTouchPast :: WithWalletProperty
 prop_RollBackDoNotTouchPast =
-    withPropRollBack $ \((afterBoot,beforeBoot),(_afterNew,beforeNew)) _ -> do
-        let past = overTxMetaHistory beforeNew $ \beforeMap
-                -> Map.difference beforeMap $ relations afterBoot
-        property $ past == beforeBoot
-
-overTxMetaHistory
-    :: TxMetaHistory
-    -> (Map TxId TxMeta -> Map TxId TxMeta)
-    -> TxMetaHistory
-overTxMetaHistory = flip $ over #relations
+    withPropRollBack $ \((afterBoot,beforeBoot),(_afterNew,beforeNew)) _ ->
+        let past = (relations beforeNew) `Map.difference` (relations afterBoot)
+        in  property $ TxMetaHistory past == beforeBoot
 
 allWithDirection :: Direction -> TxMetaHistory -> Map TxId TxMeta
 allWithDirection dir (TxMetaHistory txs) =

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/LayerSpec.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Wallet.DB.Store.Wallets.LayerSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.DB.Sqlite
+    ( ForeignKeysSetting (..) )
+import Cardano.Wallet.DB.Fixtures
+    ( WalletProperty, logScale, withDBInMemory, withInitializedWalletProp )
+import Cardano.Wallet.DB.Store.QueryStore
+    ( QueryStore (store) )
+import Cardano.Wallet.DB.Store.Wallets.Layer
+    ( newQueryStoreTxWalletsHistory )
+import Cardano.Wallet.DB.Store.Wallets.StoreSpec
+    ( genDeltaTxWallets )
+import Test.DBVar
+    ( prop_StoreUpdates )
+import Test.Hspec
+    ( Spec, around, describe, it )
+import Test.QuickCheck
+    ( property )
+
+spec :: Spec
+spec = do
+    around (withDBInMemory ForeignKeysDisabled) $ do
+        describe "newQueryStoreTxWalletsHistory" $ do
+            it "respects store laws" $ property . prop_StoreWalletsLaws
+
+prop_StoreWalletsLaws :: WalletProperty
+prop_StoreWalletsLaws =
+  withInitializedWalletProp $ \wid runQ -> do
+    qs <- runQ newQueryStoreTxWalletsHistory
+    prop_StoreUpdates
+      runQ
+      (store qs)
+      (pure mempty)
+      (logScale . genDeltaTxWallets wid)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
@@ -13,10 +13,6 @@ import Cardano.Wallet.DB.Arbitrary
     ()
 import Cardano.Wallet.DB.Fixtures
     ( WalletProperty, logScale, withDBInMemory, withInitializedWalletProp )
-import Cardano.Wallet.DB.Store.Meta.Model
-    ( DeltaTxMetaHistory (..) )
-import Cardano.Wallet.DB.Store.Meta.ModelSpec
-    ( genDeltasForManipulate )
 import Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaTxWalletsHistory (..) )
 import Cardano.Wallet.DB.Store.Wallets.Store
@@ -54,12 +50,8 @@ genDeltaTxWallets wid (_, metaMap) = do
   let metaGens = case Map.lookup wid metaMap of
         Nothing -> []
         Just metas ->
-          [ ( 10,
-              ChangeTxMetaWalletsHistory wid . Manipulate
-                <$> frequency (genDeltasForManipulate metas)
-            ),
-            (5, pure GarbageCollectTxWalletsHistory),
-            (1, pure $ RemoveWallet wid)
+          [ (5, pure GarbageCollectTxWalletsHistory)
+          , (1, pure $ RemoveWallet wid)
           ]
   frequency $
     (10, ExpandTxWalletsHistory wid . getNonEmpty <$> arbitrary) :

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
@@ -17,10 +17,12 @@ import Cardano.Wallet.DB.Sqlite.Schema
     ( TxMeta (..) )
 import Cardano.Wallet.DB.Store.Meta.Model
     ( TxMetaHistory (..) )
+import Cardano.Wallet.DB.Store.Transactions.Store
+    ( mkStoreTransactions )
 import Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaTxWalletsHistory (..) )
 import Cardano.Wallet.DB.Store.Wallets.Store
-    ( mkStoreTxWalletsHistory )
+    ( mkStoreWalletsMeta, mkStoreTxWalletsHistory )
 import Test.DBVar
     ( GenDelta, prop_StoreUpdates )
 import Test.Hspec
@@ -45,9 +47,12 @@ prop_StoreWalletsLaws =
   withInitializedWalletProp $ \wid runQ ->
     prop_StoreUpdates
       runQ
-      mkStoreTxWalletsHistory
+      storeTxWalletsHistory
       (pure mempty)
       (logScale . genDeltaTxWallets wid)
+  where
+    storeTxWalletsHistory =
+        mkStoreTxWalletsHistory mkStoreTransactions mkStoreWalletsMeta
 
 genDeltaTxWallets :: W.WalletId -> GenDelta DeltaTxWalletsHistory
 genDeltaTxWallets wid (_,metaMap) = do

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
@@ -13,6 +13,10 @@ import Cardano.Wallet.DB.Arbitrary
     ()
 import Cardano.Wallet.DB.Fixtures
     ( WalletProperty, logScale, withDBInMemory, withInitializedWalletProp )
+import Cardano.Wallet.DB.Sqlite.Schema
+    ( TxMeta (..) )
+import Cardano.Wallet.DB.Store.Meta.Model
+    ( TxMetaHistory (..) )
 import Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaTxWalletsHistory (..) )
 import Cardano.Wallet.DB.Store.Wallets.Store
@@ -22,7 +26,7 @@ import Test.DBVar
 import Test.Hspec
     ( Spec, around, describe, it )
 import Test.QuickCheck
-    ( NonEmptyList (getNonEmpty), arbitrary, frequency, property )
+    ( Gen, NonEmptyList (..), arbitrary, choose, frequency, property )
 
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.Map.Strict as Map
@@ -46,13 +50,18 @@ prop_StoreWalletsLaws =
       (logScale . genDeltaTxWallets wid)
 
 genDeltaTxWallets :: W.WalletId -> GenDelta DeltaTxWalletsHistory
-genDeltaTxWallets wid (_, metaMap) = do
+genDeltaTxWallets wid (_,metaMap) = do
   let metaGens = case Map.lookup wid metaMap of
         Nothing -> []
         Just metas ->
           [ (5, pure GarbageCollectTxWalletsHistory)
+          , (5, RollbackTxWalletsHistory wid . txMetaSlot
+                <$> chooseFromMap (relations metas) )
           , (1, pure $ RemoveWallet wid)
           ]
   frequency $
     (10, ExpandTxWalletsHistory wid . getNonEmpty <$> arbitrary) :
     metaGens
+
+chooseFromMap :: Map.Map k a -> Gen a
+chooseFromMap m = snd . (`Map.elemAt` m) <$> choose (0, Map.size m-1)


### PR DESCRIPTION
### Overview

This pull requests represents the current progress on the `newQueryStoreTxWalletsHistory`. It needs to be cherry-picked.

Specifically, this pull request focuses on implementing a verb `RollbackTxWalletsHistory` with `DeltaTxWalletsHistory` that also performs garbage collection of unused transactions.

### Issue number

ADP-2660