### PR TITLE
[ADP-2664] Simplify the semantics of `RollBackTxMetaHistory`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Model.hs
@@ -19,9 +19,9 @@ module Cardano.Wallet.DB.Store.Meta.Model
     , ManipulateTxMetaHistory(..)
     , TxMetaHistory(..)
     , mkTxMetaHistory
+    , rollbackTxMetaHistory
     , WalletsMeta
-    )
-    where
+    ) where
 
 import Prelude
 
@@ -29,8 +29,6 @@ import Cardano.Wallet.DB.Sqlite.Schema
     ( TxMeta (..) )
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
-import Control.Monad
-    ( MonadPlus (mzero) )
 import Data.Delta
     ( Delta (..) )
 import Data.Functor
@@ -51,6 +49,9 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Data.Map.Strict as Map
 
+{-----------------------------------------------------------------------------
+    Type
+------------------------------------------------------------------------------}
 -- | A collection of `TxMeta`, indexed by transaction identifier.
 newtype TxMetaHistory =
     TxMetaHistory { relations :: Map TxId TxMeta }
@@ -61,6 +62,9 @@ instance Buildable TxMetaHistory where
         "TxMetaHistory "
         <> build (length $ relations txs)
 
+{-----------------------------------------------------------------------------
+    Operations
+------------------------------------------------------------------------------}
 -- | Verbs for 'TxMeta' changes
 -- that can be issued independently from the transaction store.
 data ManipulateTxMetaHistory
@@ -108,21 +112,27 @@ instance Delta ManipulateTxMetaHistory where
       where
         isExpired Nothing = False
         isExpired (Just tip') = tip' <= tip
-    apply (RollBackTxMetaHistory point) (TxMetaHistory txs) =
-        TxMetaHistory $ Map.mapMaybe rescheduleOrForget txs
-      where
-        rescheduleOrForget :: TxMeta -> Maybe TxMeta
-        rescheduleOrForget meta =
-            let
-                isAfter = txMetaSlot meta > point
-                isIncoming = txMetaDirection meta == W.Incoming
-            in case (isAfter, isIncoming) of
-                   (True,True) -> mzero
-                   (True,False) -> Just
-                       $ meta
-                       { txMetaSlot = point, txMetaStatus = W.Pending }
-                   _ -> Just meta
+    apply (RollBackTxMetaHistory point) metas =
+        fst $ rollbackTxMetaHistory point metas
 
+-- | Rollback a 'TxMetaHistory' to a given slot.
+-- Returns the new 'TxMetaHistory' as well as the 'TxId's that
+-- have been /deleted/ due to the rollback.
+rollbackTxMetaHistory
+    :: W.SlotNo -> TxMetaHistory -> (TxMetaHistory, [TxId])
+rollbackTxMetaHistory point (TxMetaHistory txs) =
+    (TxMetaHistory new, Map.keys deleted)
+  where
+    (deleted, new) = Map.mapEither keepOrForget txs
+
+    keepOrForget :: TxMeta -> Either () TxMeta
+    keepOrForget meta
+        | txMetaSlot meta > point = Left ()
+        | otherwise = Right meta
+
+{-----------------------------------------------------------------------------
+    Type conversion helpers
+------------------------------------------------------------------------------}
 mkTxMetaEntity :: W.WalletId -> W.Tx -> W.TxMeta -> TxMeta
 mkTxMetaEntity wid tx derived =
     TxMeta

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Store.hs
@@ -80,19 +80,11 @@ update wid _ change = case change of
         ]
         [TxMetaStatus =. W.Expired]
     Manipulate (RollBackTxMetaHistory point) -> do
-        let
-          isAfter = TxMetaSlot >. point
-          isIncoming = TxMetaDirection ==. W.Incoming
-          notIncoming = TxMetaDirection ==. W.Outgoing
+        let isAfter = TxMetaSlot >. point
         deleteWhere
             [ TxMetaWalletId ==. wid
-            , isAfter, isIncoming
+            , isAfter
             ]
-        updateWhere
-            [ TxMetaWalletId ==. wid
-            , isAfter, notIncoming
-            ]
-            [ TxMetaSlot =. point, TxMetaStatus =. W.Pending ]
 
 write :: WalletId -> TxMetaHistory -> SqlPersistT IO ()
 write wid txs = do


### PR DESCRIPTION
### Overview

This pull request simplifies the semantics of `RollbackTxMetaHistory` — we no longer have to consider `Pending` or `Expired` transactions as part of the `TxMetaHistory`.

### Issue number

ADP-2664