### PR TITLE
[ADP-2665] Change `RemoveWallet` verb to imply `GarbageCollectTxWalletsHistory`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -691,6 +691,8 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = mdo
                                 $ Manipulate
                                 $ RollBackTxMetaHistory nearestPoint
                         in  (delta, Right ())
+                    ExceptT $ modifyDBMaybe transactionsDBVar $ \_ ->
+                        (Just GarbageCollectTxWalletsHistory, Right ())
                     lift $ rollBackSubmissions_ dbPendingTxs wid nearestPoint
                     pure
                         $ W.chainPointFromBlockHeader
@@ -703,8 +705,6 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = mdo
                     Just cp -> Right <$> do
                         let tip = cp ^. #currentTip
                         pruneCheckpoints wid epochStability tip
-            lift $ modifyDBMaybe transactionsDBVar $ \_ ->
-                (Just GarbageCollectTxWalletsHistory, ())
             lift $ pruneByFinality_ dbPendingTxs wid finalitySlot
 
         {-----------------------------------------------------------------------

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -584,10 +584,6 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = mdo
                         let
                             delta = Just $ RemoveWallet wid
                         in  (delta, Right ())
-            ExceptT $ modifyDBMaybe transactionsDBVar $ \_ ->
-                        let
-                            delta = Just GarbageCollectTxWalletsHistory
-                        in  (delta, Right ())
 
         , listWallets_ = map unWalletKey <$> selectKeysList [] [Asc WalId]
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -100,25 +100,31 @@ mkStoreTxWalletsHistory =
     , writeS = \(txSet,txMetaHistory) -> do
           writeS mkStoreTransactions txSet
           writeS mkStoreWalletsMeta txMetaHistory
-    , updateS = \(txh@(TxSet mtxh) ,mtxmh) -> \case
+    , updateS = \(txSet,wmetas) -> \case
             ChangeTxMetaWalletsHistory wid change
-                -> updateS mkStoreWalletsMeta mtxmh
+                -> updateS mkStoreWalletsMeta wmetas
                 $ Adjust wid change
-            GarbageCollectTxWalletsHistory -> mapM_
-                (updateS mkStoreTransactions txh . DeleteTx)
-                $ Map.keys
-                $ Map.withoutKeys mtxh
-                $ walletsLinkedTransactions mtxmh
-            RemoveWallet wid -> updateS mkStoreWalletsMeta mtxmh $ Delete wid
+            GarbageCollectTxWalletsHistory ->
+                garbageCollectTxWalletsHistory txSet wmetas
+            RemoveWallet wid -> do
+                updateS mkStoreWalletsMeta wmetas $ Delete wid
+                let wmetas2 = Map.delete wid wmetas
+                garbageCollectTxWalletsHistory txSet wmetas2
             ExpandTxWalletsHistory wid cs -> do
-                updateS mkStoreTransactions txh
+                updateS mkStoreTransactions txSet
                     $ Append
                     $ mkTxSet
                     $ fst <$> cs
-                updateS mkStoreWalletsMeta mtxmh
-                    $ case Map.lookup wid mtxmh of
+                updateS mkStoreWalletsMeta wmetas
+                    $ case Map.lookup wid wmetas of
                         Nothing -> Insert wid (mkTxMetaHistory wid cs)
                         Just _ -> Adjust wid
                             $ TxMetaStore.Expand
                             $ mkTxMetaHistory wid cs
     }
+  where
+    garbageCollectTxWalletsHistory txSet wmetas =
+        mapM_ (updateS mkStoreTransactions txSet . DeleteTx)
+            $ Map.keys
+            $ Map.withoutKeys (relations txSet)
+            $ walletsLinkedTransactions wmetas


### PR DESCRIPTION
### Overview

This pull request changes the semantics of` RemoveWallet` so that it implies `GarbageCollectTxWalletsHistory`.

This will enable us to eventually remove `GarbageCollectTxWalletsHistory`.

### Comments

* Removing `GarbageCollectTxWalletsHistory` from `prune_` may already provide some performance benefits for wallets with large transaction history, as garbage collection now only happens on rollbacks, not continuously.

### Issue Number

ADP-2665