### PR TITLE
[ADP-2686] fix migration of submissions

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- |
@@ -42,14 +43,20 @@ import Cardano.Wallet.Primitive.Passphrase.Types
     ( PassphraseScheme (..) )
 import Control.Monad
     ( forM_, guard, void, when )
+import Control.Monad.Trans
+    ( lift )
 import Control.Tracer
     ( Tracer, traceWith )
+import Data.Foldable
+    ( for_ )
 import Data.Functor
     ( (<&>) )
 import Data.Maybe
     ( mapMaybe )
 import Data.Proxy
     ( Proxy (..) )
+import Data.String.Interpolate
+    ( i )
 import Data.Text
     ( Text )
 import Data.Text.Class
@@ -61,6 +68,7 @@ import Database.Persist.Class
 import Database.Persist.Types
     ( PersistValue (..), fromPersistValueText )
 import List.Transformer
+    ( runListT, select )
 import Numeric.Natural
     ( Natural )
 import UnliftIO.Exception
@@ -147,6 +155,7 @@ migrateManually tr proxy defaultFieldValues =
     , addPolicyXPubIfMissing
     , removeOldSubmissions
     , removeMetasOfSubmissions
+    , createAndPopulateSubmissionsSlotTable
     ]
   where
     initializeSchemaVersionTable :: Sqlite.Connection -> IO ()
@@ -191,7 +200,8 @@ migrateManually tr proxy defaultFieldValues =
     getSchemaVersion :: Sqlite.Connection -> IO SchemaVersion
     getSchemaVersion conn =
         runSql conn "SELECT version FROM database_schema_version" >>= \case
-            [[PersistInt64 i]] | i >= 0 -> pure $ SchemaVersion $ fromIntegral i
+            [[PersistInt64 int]] | int >= 0 -> pure $ SchemaVersion
+                $ fromIntegral int
             _ -> throwString "Database metadata table is corrupt"
 
     -- NOTE
@@ -881,6 +891,34 @@ migrateManually tr proxy defaultFieldValues =
                             [ "DELETE FROM " <> tableName t
                             , "WHERE tx_id = '" <> txId <> "';"
                             ]
+    createAndPopulateSubmissionsSlotTable :: Sqlite.Connection -> IO ()
+    createAndPopulateSubmissionsSlotTable conn = do
+
+        let action = do
+                void $ runSql conn
+                    [i|
+                        CREATE TABLE "submissions_slots"
+                            (   "finality" INTEGER NOT NULL
+                            ,   "tip" INTEGER NOT NULL
+                            ,   "wallet_id" VARCHAR NOT NULL
+                            ,   PRIMARY KEY ("wallet_id")
+                            )
+                    |]
+                xs <- runSql conn ("SELECT wallet_id FROM wallet")
+                for_ xs $ \case
+                    [PersistText wid] -> do
+                        void $ runSql conn $ T.unwords
+                            [ "INSERT INTO submissions_slots"
+                            , "(finality, tip, wallet_id)"
+                            , "VALUES (0, 0, '" <> wid <> "');"
+                            ]
+                    _ -> error "migration failed for submissions_slots table \
+                               \ when reading wallet_id from wallet table."
+
+        isFieldPresent conn (DBField SubmissionsSlotsWallet) >>= \case
+            TableMissing -> onFieldPresent conn (DBField WalletId) action
+            ColumnMissing -> pure ()
+            ColumnPresent -> pure ()
 
 quotes :: Text -> Text
 quotes x = "\"" <> x <> "\""

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration.hs
@@ -845,11 +845,8 @@ migrateManually tr proxy defaultFieldValues =
 
     -- | This table is replaced by Submissions talbles.
     removeOldSubmissions :: Sqlite.Connection -> IO ()
-    removeOldSubmissions conn = do
-        dropTable' <-
-            Sqlite.prepare conn "DROP TABLE IF EXISTS local_tx_submission;"
-        void $ Sqlite.step dropTable'
-        Sqlite.finalize dropTable'
+    removeOldSubmissions conn = void $
+        runSql conn "DROP TABLE IF EXISTS local_tx_submission;"
 
     onFieldPresent :: Sqlite.Connection -> DBField -> IO () -> IO ()
     onFieldPresent conn field action = do
@@ -879,13 +876,11 @@ migrateManually tr proxy defaultFieldValues =
                     , DBField CborTxId
                     ]
                 lift $ do
-                    onFieldPresent conn t $ do
-                        query <- Sqlite.prepare conn $ T.unwords
+                    onFieldPresent conn t $
+                        void $ runSql conn $ T.unwords
                             [ "DELETE FROM " <> tableName t
                             , "WHERE tx_id = '" <> txId <> "';"
                             ]
-                        _ <- Sqlite.step query
-                        Sqlite.finalize query
 
 quotes :: Text -> Text
 quotes x = "\"" <> x <> "\""

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Operations.hs
@@ -258,8 +258,8 @@ mkStoreWalletsSubmissions =
             Just old' ->
                 updateS (mkStoreAnySubmissions wid) old' xda
     load = runExceptT $ do
-        wids <- lift $ fmap (view #submissionWallet . entityVal)
-            <$> selectList @Submissions [] []
+        wids <- lift $ fmap (view #submissionsSlotsWallet . entityVal)
+            <$> selectList @SubmissionsSlots [] []
         fmap Map.fromList
             $ forM (nub wids) $ \wid -> (wid,)
                 <$> ExceptT


### PR DESCRIPTION
- fix the issue with submissions migration
  - the submissions slots table was missing but required, populated with existing wallet ids
  - the load of the store was selecting the wallets by picking them up from the submissions table, which can be empty while the submissions slots table was not 
 - the definition of the submissions_slots table in the migration was taken verbatim from the definition produced by the sqlite browser. The idea seems brittle but we have no better alternatives as we manually migrate before automatically migrate .

ADP-2686

