### PR TITLE
[ADP-2660] Add `RollbackTxWalletsHistory` verb

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -849,6 +849,7 @@ test-suite unit
     Cardano.Wallet.DB.Store.Meta.StoreSpec
     Cardano.Wallet.DB.Store.Submissions.StoreSpec
     Cardano.Wallet.DB.Store.Transactions.StoreSpec
+    Cardano.Wallet.DB.Store.Wallets.ModelSpec
     Cardano.Wallet.DB.Store.Wallets.StoreSpec
     Cardano.Wallet.DelegationSpec
     Cardano.Wallet.DummyTarget.Primitive.Types

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -29,11 +29,7 @@ import Prelude
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.Meta.Model
-    ( DeltaTxMetaHistory (..)
-    , TxMetaHistory (..)
-    , WalletsMeta
-    , mkTxMetaHistory
-    )
+    ( TxMetaHistory (..), WalletsMeta, mkTxMetaHistory )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( TxSet (..), mkTxSet )
 import Data.Delta
@@ -42,8 +38,6 @@ import Data.DeltaMap
     ( DeltaMap (Adjust, Insert) )
 import Data.Foldable
     ( toList )
-import Data.Function
-    ( (&) )
 import Data.Generics.Internal.VL
     ( view )
 import Data.Map.Strict
@@ -62,7 +56,6 @@ import qualified Data.Set as Set
 
 data DeltaTxWalletsHistory
     = ExpandTxWalletsHistory W.WalletId [(WT.Tx, WT.TxMeta)]
-    | ChangeTxMetaWalletsHistory W.WalletId DeltaTxMetaHistory
     | RollbackTxWalletsHistory W.WalletId W.SlotNo
         -- ^ Roll back a single wallet
     | GarbageCollectTxWalletsHistory
@@ -85,10 +78,6 @@ instance Delta DeltaTxWalletsHistory where
                   Adjust wid
                   $ TxMetaStore.Expand
                   $ mkTxMetaHistory wid cs)
-    apply (ChangeTxMetaWalletsHistory wid change) (txh, mtxmh) =
-        (txh, garbageCollectEmptyWallets
-            $ mtxmh & apply (Adjust wid change)
-            )
     apply (RollbackTxWalletsHistory wid slot) (x, mtxmh) =
         -- Roll back all wallets to a given slot (number)
         -- and garbage collect transactions that no longer

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -58,7 +58,6 @@ data DeltaTxWalletsHistory
     = ExpandTxWalletsHistory W.WalletId [(WT.Tx, WT.TxMeta)]
     | RollbackTxWalletsHistory W.WalletId W.SlotNo
         -- ^ Roll back a single wallet
-    | GarbageCollectTxWalletsHistory
     | RemoveWallet W.WalletId
     deriving ( Show, Eq )
 
@@ -90,7 +89,6 @@ instance Delta DeltaTxWalletsHistory where
             $ TxMetaStore.RollBackTxMetaHistory slot
     apply (RemoveWallet wid) (x , mtxmh) =
         garbageCollectTxWalletsHistory (x, Map.delete wid mtxmh)
-    apply GarbageCollectTxWalletsHistory x = garbageCollectTxWalletsHistory x
 
 -- | Garbage collect all transactions that are no longer referenced
 -- by any 'TxMeta'.

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -104,9 +104,6 @@ mkStoreTxWalletsHistory =
           writeS mkStoreTransactions txSet
           writeS mkStoreWalletsMeta txMetaHistory
     , updateS = \(txSet,wmetas) -> \case
-            ChangeTxMetaWalletsHistory wid change
-                -> updateS mkStoreWalletsMeta wmetas
-                $ Adjust wid change
             RollbackTxWalletsHistory wid slot -> do
                 updateS mkStoreWalletsMeta wmetas
                     $ Adjust wid

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -112,8 +112,6 @@ mkStoreTxWalletsHistory =
                 let deletions = transactionsToDeleteOnRollback wid slot wmetas
                 forM_ deletions
                     $ updateS mkStoreTransactions txSet . DeleteTx
-            GarbageCollectTxWalletsHistory ->
-                garbageCollectTxWalletsHistory txSet wmetas
             RemoveWallet wid -> do
                 updateS mkStoreWalletsMeta wmetas $ Delete wid
                 let wmetas2 = Map.delete wid wmetas

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -104,6 +104,8 @@ mkStoreTxWalletsHistory =
             ChangeTxMetaWalletsHistory wid change
                 -> updateS mkStoreWalletsMeta wmetas
                 $ Adjust wid change
+            RollbackTxWalletsHistory{} ->
+                error "RollbackTxWalletsHistory not implemented yet"
             GarbageCollectTxWalletsHistory ->
                 garbageCollectTxWalletsHistory txSet wmetas
             RemoveWallet wid -> do

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/ModelSpec.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{- |
+ Copyright: © 2018-2022 IOHK
+ License: Apache-2.0
+
+Unit tests for `Cardano.Wallet.DB.Store.Wallets.Model`.
+-}
+module Cardano.Wallet.DB.Store.Wallets.ModelSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.DB.Arbitrary
+    ()
+import Cardano.Wallet.DB.Sqlite.Schema
+    ( TxMeta (..) )
+import Cardano.Wallet.DB.Sqlite.Types
+    ( TxId (..) )
+import Control.Monad
+    ( replicateM )
+import Data.Delta
+    ( apply )
+import Data.DeltaMap
+    ( DeltaMap (Adjust) )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Arbitrary, Gen, Property, arbitrary, property, (===) )
+
+import qualified Cardano.Wallet.DB.Store.Meta.Model as TxMetas
+import qualified Cardano.Wallet.DB.Store.Transactions.Model as Txs
+import qualified Cardano.Wallet.DB.Store.Wallets.Model as TxWallets
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Tx as W
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import qualified Test.QuickCheck as Q
+
+spec :: Spec
+spec = do
+    describe "wallets-transactions" $ do
+        it "rollback collects the right amount of garbage" $
+            property prop_RollbackCollectsGarbage
+
+{-----------------------------------------------------------------------------
+    Properties
+------------------------------------------------------------------------------}
+prop_RollbackCollectsGarbage :: GenRollback -> Property
+prop_RollbackCollectsGarbage = \GenRollback{wid,slot,history} ->
+        rollbackA wid slot history
+    === rollbackB wid slot history
+  where
+    rollbackMetas wid slot = apply (Adjust wid change)
+      where
+        change
+            = TxMetas.Manipulate
+            $ TxMetas.RollBackTxMetaHistory slot
+
+    rollbackA wid slot (x, wmetas) =
+        fst $ TxWallets.garbageCollectTxWalletsHistory
+            ( x
+            , TxWallets.garbageCollectEmptyWallets
+                $ rollbackMetas wid slot wmetas
+            )
+
+    rollbackB wid slot (Txs.TxSet x, wmetas) =
+        Txs.TxSet $ Map.withoutKeys x (Set.fromList deletions)
+      where
+        deletions = TxWallets.transactionsToDeleteOnRollback wid slot wmetas
+
+{-----------------------------------------------------------------------------
+    Generators
+------------------------------------------------------------------------------}
+instance Arbitrary GenRollback where
+    arbitrary = genRollback
+
+data GenRollback = GenRollback
+    { wid :: W.WalletId
+    , slot :: W.SlotNo
+    , history :: TxWallets.TxWalletsHistory
+    } deriving (Show)
+
+genRollback :: Gen GenRollback
+genRollback = do
+    (wid, wid2) <- arbitrary
+    slot <- genSlotNo
+    wmetas <- fmap mkTxMetaHistory
+        <$> genMapWithKeys [wid,wid2] genTxMeta
+    tx <- mkTxRelation <$> arbitrary
+    let txIdSet = TxWallets.walletsLinkedTransactions wmetas
+        txSet = Map.fromSet (const tx) txIdSet
+        history = (Txs.TxSet txSet, wmetas)
+    pure GenRollback{wid,slot,history}
+  where
+    mkTxRelation :: W.Tx -> Txs.TxRelation
+    mkTxRelation tx = snd $ Map.findMin m
+      where
+        Txs.TxSet m = Txs.mkTxSet [tx]
+
+mkTxMetaHistory :: [TxMeta] -> TxMetas.TxMetaHistory
+mkTxMetaHistory =
+    TxMetas.TxMetaHistory . Map.fromList . fmap (\x -> (txMetaTxId x,x))
+
+genTxMeta :: Gen TxMeta
+genTxMeta = do
+    meta <- arbitrary
+    slot' <- genSlotNo
+    pure $ meta{txMetaSlot=slot'}
+
+instance Arbitrary TxMeta where
+    arbitrary = TxMeta
+        <$> (TxId <$> arbitrary)
+        <*> arbitrary
+        <*> arbitrary
+        <*> pure W.Outgoing
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+
+genSlotNo :: Gen W.SlotNo
+genSlotNo = W.SlotNo <$> Q.choose (1,100)
+
+-- | Generate a 'Map' from a small list of keys.
+genMapWithKeys :: Ord key => [key] -> Gen v -> Gen (Map.Map key [v])
+genMapWithKeys keys genValue = do
+    n <- Q.getSize
+    Map.unionsWith (<>) <$> replicateM n genOne
+  where
+    one x = [x]
+    genOne = Map.singleton <$> Q.elements keys <*> (one <$> genValue)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
@@ -13,10 +13,6 @@ import Cardano.Wallet.DB.Arbitrary
     ()
 import Cardano.Wallet.DB.Fixtures
     ( WalletProperty, logScale, withDBInMemory, withInitializedWalletProp )
-import Cardano.Wallet.DB.Store.Meta.Model
-    ( DeltaTxMetaHistory (..) )
-import Cardano.Wallet.DB.Store.Meta.ModelSpec
-    ( genDeltasForManipulate )
 import Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaTxWalletsHistory (..) )
 import Cardano.Wallet.DB.Store.Wallets.Store
@@ -54,12 +50,8 @@ genDeltaTxWallets wid (_, metaMap) = do
   let metaGens = case Map.lookup wid metaMap of
         Nothing -> []
         Just metas ->
-          [ ( 10,
-              ChangeTxMetaWalletsHistory wid . Manipulate
-                <$> frequency (genDeltasForManipulate metas)
-            ),
-            (5, pure GarbageCollectTxWalletsHistory),
-            (1, pure $ RemoveWallet wid)
+          [ (5, pure GarbageCollectTxWalletsHistory)
+          , (1, pure $ RemoveWallet wid)
           ]
   frequency $
     (10, ExpandTxWalletsHistory wid . getNonEmpty <$> arbitrary) :

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
@@ -54,8 +54,7 @@ genDeltaTxWallets wid (_,metaMap) = do
   let metaGens = case Map.lookup wid metaMap of
         Nothing -> []
         Just metas ->
-          [ (5, pure GarbageCollectTxWalletsHistory)
-          , (5, RollbackTxWalletsHistory wid . txMetaSlot
+          [ (5, RollbackTxWalletsHistory wid . txMetaSlot
                 <$> chooseFromMap (relations metas) )
           , (1, pure $ RemoveWallet wid)
           ]

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
@@ -13,6 +13,10 @@ import Cardano.Wallet.DB.Arbitrary
     ()
 import Cardano.Wallet.DB.Fixtures
     ( WalletProperty, logScale, withDBInMemory, withInitializedWalletProp )
+import Cardano.Wallet.DB.Sqlite.Schema
+    ( TxMeta (..) )
+import Cardano.Wallet.DB.Store.Meta.Model
+    ( TxMetaHistory (..) )
 import Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaTxWalletsHistory (..) )
 import Cardano.Wallet.DB.Store.Wallets.Store
@@ -22,7 +26,7 @@ import Test.DBVar
 import Test.Hspec
     ( Spec, around, describe, it )
 import Test.QuickCheck
-    ( NonEmptyList (getNonEmpty), arbitrary, frequency, property )
+    ( Gen, NonEmptyList (..), arbitrary, choose, frequency, property )
 
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.Map.Strict as Map
@@ -46,13 +50,18 @@ prop_StoreWalletsLaws =
       (logScale . genDeltaTxWallets wid)
 
 genDeltaTxWallets :: W.WalletId -> GenDelta DeltaTxWalletsHistory
-genDeltaTxWallets wid (_, metaMap) = do
+genDeltaTxWallets wid (_,metaMap) = do
   let metaGens = case Map.lookup wid metaMap of
         Nothing -> []
         Just metas ->
           [ (5, pure GarbageCollectTxWalletsHistory)
+          , (5, RollbackTxWalletsHistory wid . txMetaSlot
+                <$> chooseFromMap (relations metas) )
           , (1, pure $ RemoveWallet wid)
           ]
   frequency $
     (10, ExpandTxWalletsHistory wid . getNonEmpty <$> arbitrary) :
     metaGens
+
+chooseFromMap :: Map.Map k a -> Gen a
+chooseFromMap m = snd . (`Map.elemAt` m) <$> choose (0, Map.size m-1)


### PR DESCRIPTION
### Overview

This pull request implements a verb `RollbackTxWalletsHistory` for the `TxWalletsHistory` that will roll back the `TxMeta`s, and also delete the corresponding transactions from the `TxSet` — unless they are referenced by another wallet.

In this way, we can avoid `GarbageCollectTxWalletsHistory`, which is an expensive operation once the transactions are moved back to disk.

### Comments

* This pull request still assumes that the `TxSet` is in memory.
* A new unit test in `Cardano.Wallet.DB.Store.Wallets.ModelSpec` checks that `transactionsToDeleteOnRollback` has the same effect as `garbageCollectEmptyWallets`

### Issue number

ADP-2660