### PR TITLE
[ADP-2706] Add `QueryStore` for `TxWalletsHistory`

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -850,6 +850,7 @@ test-suite unit
     Cardano.Wallet.DB.Store.Meta.StoreSpec
     Cardano.Wallet.DB.Store.Submissions.StoreSpec
     Cardano.Wallet.DB.Store.Transactions.StoreSpec
+    Cardano.Wallet.DB.Store.Wallets.LayerSpec
     Cardano.Wallet.DB.Store.Wallets.ModelSpec
     Cardano.Wallet.DB.Store.Wallets.StoreSpec
     Cardano.Wallet.DelegationSpec

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -241,6 +241,7 @@ library
     Cardano.Wallet.DB.Store.Transactions.Model
     Cardano.Wallet.DB.Store.Transactions.Store
     Cardano.Wallet.DB.Store.Transactions.TransactionInfo
+    Cardano.Wallet.DB.Store.Wallets.Layer
     Cardano.Wallet.DB.Store.Wallets.Model
     Cardano.Wallet.DB.Store.Wallets.Store
     Cardano.Wallet.DB.WalletState

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -110,12 +110,14 @@ import Cardano.Wallet.DB.Store.Transactions.Decoration
     ( TxInDecorator, decorateTxInsForReadTx, decorateTxInsForRelation )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( TxSet (..) )
+import Cardano.Wallet.DB.Store.Transactions.Store
+    ( mkStoreTransactions )
 import Cardano.Wallet.DB.Store.Transactions.TransactionInfo
     ( mkTransactionInfoFromRelation )
 import Cardano.Wallet.DB.Store.Wallets.Model
     ( TxWalletsHistory )
 import Cardano.Wallet.DB.Store.Wallets.Store
-    ( DeltaTxWalletsHistory (..), mkStoreTxWalletsHistory )
+    ( DeltaTxWalletsHistory (..), mkStoreTxWalletsHistory, mkStoreWalletsMeta )
 import Cardano.Wallet.DB.WalletState
     ( DeltaMap (..)
     , DeltaWalletState1 (..)
@@ -506,7 +508,8 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = mdo
     -- FIXME LATER during ADP-1043:
     --   Handle the case where loading the database fails.
     walletsDB <- runQuery $ loadDBVar mkStoreWallets
-    transactionsDBVar <- runQuery $ loadDBVar mkStoreTxWalletsHistory
+    transactionsDBVar <- runQuery $ loadDBVar $
+        mkStoreTxWalletsHistory mkStoreTransactions mkStoreWalletsMeta
 
     -- NOTE
     -- The cache will not work properly unless 'atomically' is protected by a

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{- |
+Copyright: © 2022 IOHK
+License: Apache-2.0
+
+Implementation of a 'QueryStore' for 'TxWalletsHistory'.
+-}
+module Cardano.Wallet.DB.Store.Wallets.Layer
+    ( QueryTxWalletsHistory (..)
+    , QueryStoreTxWalletsHistory
+    , newQueryStoreTxWalletsHistory
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.DB.Sqlite.Schema
+    ( TxMeta (..) )
+import Cardano.Wallet.DB.Sqlite.Types
+    ( TxId (..) )
+import Cardano.Wallet.DB.Store.Meta.Model
+    ( TxMetaHistory (relations) )
+import Cardano.Wallet.DB.Store.QueryStore
+    ( QueryStore (..) )
+import Cardano.Wallet.DB.Store.Transactions.Model
+    ( TxRelation )
+import Cardano.Wallet.DB.Store.Wallets.Model
+    ( DeltaTxWalletsHistory (..) )
+import Cardano.Wallet.DB.Store.Wallets.Store
+    ( mkStoreTxWalletsHistory, mkStoreWalletsMeta )
+import Data.DBVar
+    ( Store (..) )
+import Data.Foldable
+    ( toList )
+import Database.Persist.Sql
+    ( SqlPersistT )
+
+import qualified Cardano.Wallet.DB.Store.Transactions.Layer as TxSet
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Data.Map.Strict as Map
+
+{-----------------------------------------------------------------------------
+    Query type
+------------------------------------------------------------------------------}
+data QueryTxWalletsHistory b where
+    GetByTxId :: TxId -> QueryTxWalletsHistory (Maybe TxRelation)
+    One :: W.WalletId -> TxId -> QueryTxWalletsHistory (Maybe TxMeta)
+    All :: W.WalletId -> QueryTxWalletsHistory [TxMeta]
+
+{-----------------------------------------------------------------------------
+    Query Store type
+------------------------------------------------------------------------------}
+type QueryStoreTxWalletsHistory =
+    QueryStore (SqlPersistT IO) QueryTxWalletsHistory DeltaTxWalletsHistory
+
+newQueryStoreTxWalletsHistory
+    :: forall m. m ~ SqlPersistT IO
+    => m QueryStoreTxWalletsHistory
+newQueryStoreTxWalletsHistory = do
+    let txsQueryStore = TxSet.mkDBTxSet
+
+    let storeWalletsMeta = mkStoreWalletsMeta
+    let storeTxWalletsHistory = mkStoreTxWalletsHistory
+            (store txsQueryStore)   -- on disk
+            storeWalletsMeta        -- on disk
+
+    let readAllMetas :: W.WalletId -> m [TxMeta]
+        readAllMetas wid = do
+            Right wmetas <- loadS storeWalletsMeta
+            pure
+                . maybe [] (toList . relations)
+                $ Map.lookup wid wmetas
+
+        query :: forall a. QueryTxWalletsHistory a -> SqlPersistT IO a
+        query = \case
+            GetByTxId txid ->
+                queryS txsQueryStore $ TxSet.GetByTxId txid
+            One wid txid -> do
+                Right wmetas <- loadS storeWalletsMeta
+                pure $ do
+                    metas <- Map.lookup wid wmetas
+                    Map.lookup txid . relations $ metas
+            All wid ->
+                readAllMetas wid
+
+    pure QueryStore
+        { queryS = query
+        , store = Store
+            { loadS = loadS storeTxWalletsHistory
+            , writeS = writeS storeTxWalletsHistory
+            , updateS = \_ da -> do
+                -- BUG: The following operations are very expensive for large
+                -- wallets.
+                -- Solution: Do not load `txSet` or `storeWalletsMeta`
+                -- into memory.
+                Right txSet <- loadS (store txsQueryStore)
+                Right wmetas <- loadS storeWalletsMeta
+                updateS storeTxWalletsHistory (Just (txSet,wmetas)) da
+            }
+        }

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/LayerSpec.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Wallet.DB.Store.Wallets.LayerSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.DB.Sqlite
+    ( ForeignKeysSetting (..) )
+import Cardano.Wallet.DB.Fixtures
+    ( WalletProperty, logScale, withDBInMemory, withInitializedWalletProp )
+import Cardano.Wallet.DB.Store.QueryStore
+    ( QueryStore (store) )
+import Cardano.Wallet.DB.Store.Wallets.Layer
+    ( newQueryStoreTxWalletsHistory )
+import Cardano.Wallet.DB.Store.Wallets.StoreSpec
+    ( genDeltaTxWallets )
+import Test.DBVar
+    ( prop_StoreUpdates )
+import Test.Hspec
+    ( Spec, around, describe, it )
+import Test.QuickCheck
+    ( property )
+
+spec :: Spec
+spec = do
+    around (withDBInMemory ForeignKeysDisabled) $ do
+        describe "newQueryStoreTxWalletsHistory" $ do
+            it "respects store laws" $ property . prop_StoreWalletsLaws
+
+prop_StoreWalletsLaws :: WalletProperty
+prop_StoreWalletsLaws =
+  withInitializedWalletProp $ \wid runQ -> do
+    qs <- runQ newQueryStoreTxWalletsHistory
+    prop_StoreUpdates
+      runQ
+      (store qs)
+      (pure mempty)
+      (logScale . genDeltaTxWallets wid)


### PR DESCRIPTION
### Overview

This pull request implements a `QueryStore` for the `TxWalletsHistory` by extending `mkStoreTxWalletsHistory` with a query.

Here, the `TxSet` and `WalletsMeta` are both on disk.

### Comments

* This pull request cherry-picks #3698 and #3739.
* The new `QueryStore` is not yet swapped into `Cardano.Wallet.DB.Layer`, this will be done in an upcoming pull request.
*  The fact that both `TxSet` and `WalletsMeta` are on disk leads to an expensive `loadS` operation during `updateS`. A future pull request will make this operation cheaper by:
    * changing `RemoveWallet` to not require the `txSet` in memory, and by
    * caching the `Store` for the `WalletsMeta` in memory.

### Issue Number

ADP-2706