### PR TITLE
Call ledger version of `evaluateTxBalance` from `balanceTx`.

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -674,8 +674,6 @@ newTransactionLayer networkId = TransactionLayer
     , evaluateMinimumFee =
         _evaluateMinimumFee
 
-    , evaluateTransactionBalance = _evaluateTransactionBalance
-
     , computeSelectionLimit = \era pp ctx outputsToCover ->
         let txMaxSize = getTxMaxSize $ txParameters pp in
         MaximumInputLimit $
@@ -704,26 +702,6 @@ _decodeSealedTx
         )
 _decodeSealedTx preferredLatestEra witCtx (cardanoTxIdeallyNoLaterThan preferredLatestEra -> Cardano.InAnyCardanoEra _ tx) =
     fromCardanoTx witCtx tx
-
-_evaluateTransactionBalance
-    :: forall era. IsShelleyBasedEra era
-    => Cardano.Tx era
-    -> Cardano.ProtocolParameters
-    -> Cardano.UTxO era
-    -> Cardano.Value
-_evaluateTransactionBalance (Cardano.Tx body _) pp utxo =
-    lovelaceFromCardanoTxOutValue
-        $ Cardano.evaluateTransactionBalance
-            pp
-            mempty
-            utxo
-            body
-  where
-    lovelaceFromCardanoTxOutValue
-        :: Cardano.TxOutValue era -> Cardano.Value
-    lovelaceFromCardanoTxOutValue = \case
-        Cardano.TxOutAdaOnly _ ada -> Cardano.lovelaceToValue ada
-        Cardano.TxOutValue _ val   -> val
 
 mkDelegationCertificates
     :: DelegationAction

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -245,24 +245,6 @@ data TransactionLayer k ktype tx = TransactionLayer
         -> TxSize
         -- ^ Estimate the size of the transaction when fully signed.
 
-    , evaluateTransactionBalance
-        :: forall era. Cardano.IsShelleyBasedEra era
-        => Cardano.Tx era
-        -> Cardano.ProtocolParameters
-        -> Cardano.UTxO era
-        -> Cardano.Value
-        -- ^ Evaluate the balance of a transaction using the ledger. The balance
-        -- is defined as @(value consumed by transaction) - (value produced by
-        -- transaction)@. For a transaction to be valid, it must have a balance
-        -- of zero.
-        --
-        -- Note that the fee-field of the transaction affects the balance, and
-        -- is not automatically the minimum fee.
-        --
-        -- The function takes two UTxOs of different types and merges them. The
-        -- reason is to workaround that wallet 'UTxO' type doesn't support
-        -- Datum hashes
-
     , distributeSurplus
         :: FeePolicy
         -> Coin

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -121,7 +121,7 @@ module Cardano.Wallet.Write.Tx
     , fromCardanoTx
     , toCardanoUTxO
     , fromCardanoUTxO
-    , cardanoValueFromCoreValue
+    , toCardanoValue
 
     -- * Balancing
     , evaluateTransactionBalance
@@ -771,11 +771,11 @@ fromCardanoUTxO = withStandardCryptoConstraint (recentEra @era) $
   where
     unCardanoUTxO (Cardano.UTxO m) = m
 
-cardanoValueFromCoreValue
+toCardanoValue
     :: forall era. IsRecentEra era
     => Core.Value (ShelleyLedgerEra era)
     -> Cardano.Value
-cardanoValueFromCoreValue = case recentEra @era of
+toCardanoValue = case recentEra @era of
     RecentEraBabbage -> Cardano.fromMaryValue
     RecentEraAlonzo -> Cardano.fromMaryValue
 

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -120,6 +121,7 @@ module Cardano.Wallet.Write.Tx
     , fromCardanoTx
     , toCardanoUTxO
     , fromCardanoUTxO
+    , cardanoValueFromCoreValue
 
     -- * Balancing
     , evaluateTransactionBalance
@@ -768,6 +770,14 @@ fromCardanoUTxO = withStandardCryptoConstraint (recentEra @era) $
     . unCardanoUTxO
   where
     unCardanoUTxO (Cardano.UTxO m) = m
+
+cardanoValueFromCoreValue
+    :: forall era. IsRecentEra era
+    => Core.Value (ShelleyLedgerEra era)
+    -> Cardano.Value
+cardanoValueFromCoreValue = case recentEra @era of
+    RecentEraBabbage -> Cardano.fromMaryValue
+    RecentEraAlonzo -> Cardano.fromMaryValue
 
 --------------------------------------------------------------------------------
 -- Balancing

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -116,6 +117,7 @@ module Cardano.Wallet.Write.Tx
     , utxoFromTxOutsInRecentEra
     , utxoFromTxOutsInLatestEra
     , utxoFromTxOuts
+    , fromCardanoTx
     , toCardanoUTxO
     , fromCardanoUTxO
 
@@ -172,6 +174,7 @@ import Test.Cardano.Ledger.Alonzo.Examples.Consensus
     ( StandardAlonzo )
 
 import qualified Cardano.Api as Cardano
+import qualified Cardano.Api.Byron as Cardano
 import qualified Cardano.Api.Extra as Cardano
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Binary as CBOR
@@ -713,6 +716,17 @@ modifyLedgerBody f (Cardano.Tx body keyWits) =
 --------------------------------------------------------------------------------
 -- Compatibility
 --------------------------------------------------------------------------------
+
+fromCardanoTx
+    :: forall era. IsRecentEra era
+    => Cardano.Tx era
+    -> Core.Tx (Cardano.ShelleyLedgerEra era)
+fromCardanoTx = \case
+    Cardano.ShelleyTx _era tx ->
+        tx
+    Cardano.ByronTx {} ->
+        case (recentEra @era) of
+            {}
 
 -- | NOTE: The roundtrip
 -- @

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -629,7 +629,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 
     txBalance :: Cardano.Tx era -> Cardano.Value
     txBalance
-        = Write.Tx.cardanoValueFromCoreValue @era
+        = Write.Tx.toCardanoValue @era
         . Write.Tx.evaluateTransactionBalance (recentEra @era) ledgerPP
             (Write.Tx.fromCardanoUTxO combinedUTxO)
         . Write.Tx.txBody (recentEra @era)

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -159,6 +159,7 @@ import qualified Cardano.Wallet.Primitive.Types.UTxO as W
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
+import qualified Cardano.Wallet.Write.Tx as Write.Tx
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 
@@ -627,8 +628,15 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             else throwE $ ErrBalanceTxInternalError $ ErrFailedBalancing bal
 
     txBalance :: Cardano.Tx era -> Cardano.Value
-    txBalance tx =
-        evaluateTransactionBalance txLayer tx nodePParams combinedUTxO
+    txBalance
+        = Write.Tx.cardanoValueFromCoreValue @era
+        . Write.Tx.evaluateTransactionBalance (recentEra @era) ledgerPP
+            (Write.Tx.fromCardanoUTxO combinedUTxO)
+        . Write.Tx.txBody (recentEra @era)
+        . Write.Tx.fromCardanoTx
+
+    ledgerPP =
+        Cardano.toLedgerPParams (Cardano.shelleyBasedEra @era) nodePParams
 
     balanceAfterSettingMinFee
         :: Cardano.Tx era
@@ -639,7 +647,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         let minfee = evaluateMinimumFee txLayer nodePParams combinedUTxO tx
         let update = TxUpdate [] [] [] [] (UseNewTxFee minfee)
         tx' <- left ErrBalanceTxUpdateError $ updateTx txLayer tx update
-        let balance = evaluateTransactionBalance txLayer tx' nodePParams combinedUTxO
+        let balance = txBalance tx'
         let minfee' = Cardano.Lovelace $ fromIntegral $ W.unCoin minfee
         return (balance, minfee')
 

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -1240,8 +1240,6 @@ dummyTransactionLayer = TransactionLayer
     , estimateSignedTxSize =
         error "dummyTransactionLayer: \
               \estimateSignedTxSize not implemented"
-    , evaluateTransactionBalance =
-        error "dummyTransactionLayer: dummyTransactionLayer not implemented"
     , computeSelectionLimit =
         error "dummyTransactionLayer: computeSelectionLimit not implemented"
     , tokenBundleSizeAssessor =


### PR DESCRIPTION
## Issue Number

https://input-output.atlassian.net/browse/ADP-2651

## Summary

This PR:
- adjusts `balanceTx` (and inner functions) to call the `cardano-ledger` version of the `evaluateTxBalance` function instead of the `cardano-api` version.
- removes `evaluateTxBalance` from `TxLayer`.