### PR TITLE
Fix for `WALLETS_COIN_SELECTION_07`

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -338,6 +338,24 @@ instance IsServerError ErrMkTransaction where
     toServerError = \case
         ErrMkTransactionTxBodyError hint ->
             apiError err500 CreatedInvalidTransaction hint
+        ErrMkTransactionTokenQuantityExceedsLimit e ->
+            apiError err403 OutputTokenQuantityExceedsLimit $ mconcat
+                [ "One of the token quantities you've specified is greater "
+                , "than the maximum quantity allowed in a single transaction "
+                , "output. "
+                , "Try splitting this quantity across two or more outputs. "
+                , "Destination address: "
+                , pretty (view #address e)
+                , ". Token policy identifier: "
+                , pretty (view #tokenPolicyId $ asset e)
+                , ". Asset name: "
+                , pretty (view #tokenName $ asset e)
+                , ". Token quantity specified: "
+                , pretty (view #quantity e)
+                , ". Maximum allowable token quantity: "
+                , pretty (view #quantityMaxBound e)
+                , "."
+                ]
         ErrMkTransactionInvalidEra _era ->
             apiError err500 CreatedInvalidTransaction $ mconcat
                 [ "Whoops, it seems like I just experienced a hard-fork in the "

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -76,7 +76,9 @@ import Cardano.Tx.Balance.Internal.CoinSelection
     ( SelectionCollateralRequirement (..)
     , SelectionLimit
     , SelectionOf (..)
+    , SelectionOutputTokenQuantityExceedsLimitError
     , SelectionSkeleton
+    , WalletSelectionContext
     )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), DerivationIndex )
@@ -539,6 +541,8 @@ data ErrMkTransaction
     = ErrMkTransactionNoSuchWallet WalletId
     | ErrMkTransactionTxBodyError Text
     -- ^ We failed to construct a transaction for some reasons.
+    | ErrMkTransactionTokenQuantityExceedsLimit
+        (SelectionOutputTokenQuantityExceedsLimitError WalletSelectionContext)
     | ErrMkTransactionInvalidEra AnyCardanoEra
     -- ^ Should never happen, means that that we have programmatically provided
     -- an invalid era.


### PR DESCRIPTION
- [x] Add extra duplicated validation before calling `Cardano.makeTransactionBody` in order to still get the same `TokenQuantityExceedsLimit` API error as previously. 

<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->

### Comments

Targets #3730; feel free to rework / only use as inspiration / go in another direction.

For fixing this:

```
cardano-wallet-test-integration>   integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs:318:19:
cardano-wallet-test-integration>   2) API Specifications, SHELLEY_COIN_SELECTION, WALLETS_COIN_SELECTION_07 - Single output with excessively high token quantity.
cardano-wallet-test-integration>        From the following response: Left
cardano-wallet-test-integration>            ( ClientError
cardano-wallet-test-integration>                ( Object
cardano-wallet-test-integration>                    ( fromList
cardano-wallet-test-integration>                        [
cardano-wallet-test-integration>                            ( "code"
cardano-wallet-test-integration>                            , String "created_invalid_transaction"
cardano-wallet-test-integration>                            )
cardano-wallet-test-integration>                        ,
cardano-wallet-test-integration>                            ( "message"
cardano-wallet-test-integration>                            , String "Quantity too large (18446744073709551616 >= 2^64) in transaction output: TxOutInAnyEra BabbageEra (TxOut (AddressInEra (ShelleyAddressInEra ShelleyBasedEraBabbage) (ShelleyAddress Mainnet (KeyHashObj (KeyHash "9649f1147db50bb2fa7ad2f844d9b3f74b1d2d159980e27c2de6aeeb")) (StakeRefBase (KeyHashObj (KeyHash "6a3988b127d10c491c4cc39fa6d696e4ce7e09f089a79cf7407e97dd"))))) (TxOutValue MultiAssetInBabbageEra (valueFromList [(AdaAssetId,978370),(AssetId "31323334353637383930313233343536373839303132333435363738" "1",18446744073709551616)])) TxOutDatumNone ReferenceScriptNone)"
cardano-wallet-test-integration>                            )
cardano-wallet-test-integration>                        ]
cardano-wallet-test-integration>                    )
cardano-wallet-test-integration>                )
cardano-wallet-test-integration>            )
cardano-wallet-test-integration>        While verifying value:
cardano-wallet-test-integration>          ( Status
cardano-wallet-test-integration>              { statusCode = 500
cardano-wallet-test-integration>              , statusMessage = "Internal Server Error"
cardano-wallet-test-integration>              }
cardano-wallet-test-integration>          , Left
cardano-wallet-test-integration>              ( ClientError
cardano-wallet-test-integration>                  ( Object
cardano-wallet-test-integration>                      ( fromList
cardano-wallet-test-integration>                          [
cardano-wallet-test-integration>                              ( "code"
cardano-wallet-test-integration>                              , String "created_invalid_transaction"
cardano-wallet-test-integration>                              )
cardano-wallet-test-integration>                          ,
cardano-wallet-test-integration>                              ( "message"
cardano-wallet-test-integration>                              , String "Quantity too large (18446744073709551616 >= 2^64) in transaction output: TxOutInAnyEra BabbageEra (TxOut (AddressInEra (ShelleyAddressInEra ShelleyBasedEraBabbage) (ShelleyAddress Mainnet (KeyHashObj (KeyHash "9649f1147db50bb2fa7ad2f844d9b3f74b1d2d159980e27c2de6aeeb")) (StakeRefBase (KeyHashObj (KeyHash "6a3988b127d10c491c4cc39fa6d696e4ce7e09f089a79cf7407e97dd"))))) (TxOutValue MultiAssetInBabbageEra (valueFromList [(AdaAssetId,978370),(AssetId "31323334353637383930313233343536373839303132333435363738" "1",18446744073709551616)])) TxOutDatumNone ReferenceScriptNone)"
cardano-wallet-test-integration>                              )
cardano-wallet-test-integration>                          ]
cardano-wallet-test-integration>                      )
cardano-wallet-test-integration>                  )
cardano-wallet-test-integration>              )
cardano-wallet-test-integration>          )
cardano-wallet-test-integration>        expected: Status {
cardano-wallet-test-integration>                    statusCode = 403,
cardano-wallet-test-integration>                    statusMessage = "Forbidden"
cardano-wallet-test-integration>                  }
cardano-wallet-test-integration>         but got: Status {
cardano-wallet-test-integration>                    statusCode = 500,
cardano-wallet-test-integration>                    statusMessage = "Internal Server Error"
cardano-wallet-test-integration>                  }
cardano-wallet-test-integration>   To rerun use: --match "/API Specifications/SHELLEY_COIN_SELECTION/WALLETS_COIN_SELECTION_07 - Single output with excessively high token quantity./"
```

### Issue Number

