### PR TITLE
[ADP-2741] Switch transaction history to `QueryStore`

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Hash.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Hash.hs
@@ -18,6 +18,7 @@ module Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     , hashFromText
     , mockHash
+    , mockHashRewardAccount
     ) where
 
 import Prelude
@@ -27,7 +28,7 @@ import Cardano.Wallet.Util
 import Control.DeepSeq
     ( NFData (..) )
 import Crypto.Hash
-    ( Blake2b_256, hash )
+    ( Blake2b_224, Blake2b_256, hash )
 import Data.ByteArray
     ( ByteArrayAccess )
 import Data.ByteArray.Encoding
@@ -111,7 +112,13 @@ hashFromText len text = case decoded of
 --
 mockHash :: Show a => a -> Hash whatever
 mockHash = Hash . blake2b256 . B8.pack . show
-  where
-     blake2b256 :: ByteString -> ByteString
-     blake2b256 =
-         BA.convert . hash @_ @Blake2b_256
+
+blake2b256 :: ByteString -> ByteString
+blake2b256 = BA.convert . hash @_ @Blake2b_256
+
+-- | Construct a hash that is good enough for testing (28 byte length).
+mockHashRewardAccount :: Show a => a -> Hash "RewardAccount"
+mockHashRewardAccount = Hash . blake2b224 . B8.pack . show
+
+blake2b224 :: ByteString -> ByteString
+blake2b224 = BA.convert . hash @_ @Blake2b_224

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -104,16 +104,20 @@ import Cardano.Wallet.DB.Store.Checkpoints
     ( PersistAddressBook (..), blockHeaderFromEntity, mkStoreWallets )
 import Cardano.Wallet.DB.Store.Meta.Model
     ( TxMetaHistory (..) )
+import Cardano.Wallet.DB.Store.QueryStore
+    ( QueryStore (..) )
 import Cardano.Wallet.DB.Store.Submissions.Layer
     ( pruneByFinality, rollBackSubmissions )
 import Cardano.Wallet.DB.Store.Transactions.Decoration
     ( TxInDecorator, decorateTxInsForReadTx, decorateTxInsForRelation )
 import Cardano.Wallet.DB.Store.Transactions.Model
-    ( TxSet (..) )
+    ( TxRelation (..) )
 import Cardano.Wallet.DB.Store.Transactions.Store
     ( mkStoreTransactions )
 import Cardano.Wallet.DB.Store.Transactions.TransactionInfo
     ( mkTransactionInfoFromRelation )
+import Cardano.Wallet.DB.Store.Wallets.Layer
+    ( QueryStoreTxWalletsHistory, QueryTxWalletsHistory (..) )
 import Cardano.Wallet.DB.Store.Wallets.Model
     ( TxWalletsHistory )
 import Cardano.Wallet.DB.Store.Wallets.Store
@@ -133,7 +137,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Passphrase.Types
     ( PassphraseHash )
 import Cardano.Wallet.Primitive.Slotting
-    ( TimeInterpreter, firstSlotInEpoch, interpretQuery )
+    ( TimeInterpreter, firstSlotInEpoch, hoistTimeInterpreter, interpretQuery )
 import Cardano.Wallet.Read.Eras
     ( EraValue )
 import Control.Exception
@@ -151,7 +155,7 @@ import Control.Tracer
 import Data.Coerce
     ( coerce )
 import Data.DBVar
-    ( DBVar, loadDBVar, modifyDBMaybe, readDBVar, updateDBVar )
+    ( loadDBVar, modifyDBMaybe, readDBVar, updateDBVar )
 import Data.Either
     ( isRight )
 import Data.Foldable
@@ -627,20 +631,22 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = mdo
             updateDBVar transactionsDBVar . ExpandTxWalletsHistory wid
 
         , readTxHistory_ = \wid range status tip -> do
-            txHistory@(txSet,_) <- readDBVar transactionsDBVar
+            txHistory <- readDBVar transactionsDBVar
             let whichMeta DB.TxMeta{..} = and $ catMaybes
                     [ (txMetaSlot >=) <$> W.inclusiveLowerBound range
                     , (txMetaSlot <=) <$> W.inclusiveUpperBound range
                     , (txMetaStatus ==) <$> status
                     ]
             let transactions = filter whichMeta $ getTxMetas wid txHistory
-            lift $ forM transactions $ selectTransactionInfo ti tip txSet
+            lift $ forM transactions $ selectTransactionInfo ti tip
+                $ error "not implemented"
 
         , getTx_ = \wid txid tip -> do
-            txHistory@(txSet,_) <- readDBVar transactionsDBVar
+            txHistory <- readDBVar transactionsDBVar
             let transactions = lookupTxMeta wid (TxId txid) txHistory
-            lift $ forM transactions $ selectTransactionInfo ti tip txSet
-        , mkDecorator_ = mkDecorator transactionsDBVar
+            lift $ forM transactions $ selectTransactionInfo ti tip
+                $ error "not implemented"
+        , mkDecorator_ = mkDecorator $ error "not implemented"
         }
 
     let rollbackTo_ wid requestedPoint = do
@@ -734,11 +740,13 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = mdo
     pure $ mkDBLayerFromParts ti DBLayerCollection{..}
 
 mkDecorator
-    :: DBVar (SqlPersistT IO) DeltaTxWalletsHistory
+    :: QueryStoreTxWalletsHistory
     -> TxInDecorator (EraValue Read.Tx) (SqlPersistT IO)
-mkDecorator transactionsDBVar tx = do
-    (txSet,_) <- readDBVar transactionsDBVar
-    pure $ decorateTxInsForReadTx txSet tx
+mkDecorator transactionsQS =
+    decorateTxInsForReadTx lookupTx
+  where
+    lookupTx = queryS transactionsQS . GetByTxId
+
 
 readWalletMetadata
     :: W.WalletId
@@ -988,19 +996,20 @@ lookupTxMeta wid txid (_,wmetas) = do
 -- but the function will not attempt to look up all possible outputs.
 -- This approach typically provides enough information
 -- for /outgoing/ payments, but less so for /ingoing/ payments.
+
 selectTransactionInfo
-    :: Monad m
-    => TimeInterpreter m
+    :: (Monad m, MonadIO m)
+    => TimeInterpreter IO
     -> W.BlockHeader
-    -> TxSet
+    -> (TxId -> m (Maybe TxRelation))
     -> TxMeta
     -> m W.TransactionInfo
-selectTransactionInfo ti tip txSet meta =
+selectTransactionInfo ti tip lookupTx meta = do
     let err = error $ "Transaction not found: " <> show meta
-        transaction = fromMaybe err $
-            Map.lookup (txMetaTxId meta) (view #relations txSet)
-        decoration = decorateTxInsForRelation txSet transaction
-    in  mkTransactionInfoFromRelation ti tip transaction decoration meta
+    transaction <- fromMaybe err <$> lookupTx (txMetaTxId meta)
+    decoration <- decorateTxInsForRelation lookupTx transaction
+    mkTransactionInfoFromRelation
+        (hoistTimeInterpreter liftIO ti) tip transaction decoration meta
 
 selectPrivateKey
     :: (MonadIO m, PersistPrivateKey (k 'RootK))

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -89,16 +89,5 @@ newQueryStoreTxWalletsHistory = do
 
     pure QueryStore
         { queryS = query
-        , store = Store
-            { loadS = loadS storeTxWalletsHistory
-            , writeS = writeS storeTxWalletsHistory
-            , updateS = \_ da -> do
-                -- BUG: The following operations are very expensive for large
-                -- wallets.
-                -- Solution: Do not load `txSet` or `storeWalletsMeta`
-                -- into memory.
-                Right txSet <- loadS (store txsQueryStore)
-                Right wmetas <- loadS storeWalletsMeta
-                updateS storeTxWalletsHistory (Just (txSet,wmetas)) da
-            }
+        , store = storeTxWalletsHistory
         }

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -33,7 +33,7 @@ import Cardano.Wallet.DB.Store.Wallets.Model
 import Cardano.Wallet.DB.Store.Wallets.Store
     ( mkStoreTxWalletsHistory, mkStoreWalletsMeta )
 import Data.DBVar
-    ( Store (..) )
+    ( Store (..), newCachedStore )
 import Data.Foldable
     ( toList )
 import Database.Persist.Sql
@@ -63,10 +63,10 @@ newQueryStoreTxWalletsHistory
 newQueryStoreTxWalletsHistory = do
     let txsQueryStore = TxSet.mkDBTxSet
 
-    let storeWalletsMeta = mkStoreWalletsMeta
+    storeWalletsMeta <- newCachedStore mkStoreWalletsMeta
     let storeTxWalletsHistory = mkStoreTxWalletsHistory
             (store txsQueryStore)   -- on disk
-            storeWalletsMeta        -- on disk
+            storeWalletsMeta        -- in memory
 
     let readAllMetas :: W.WalletId -> m [TxMeta]
         readAllMetas wid = do

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/RewardAccount/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/RewardAccount/Gen.hs
@@ -6,6 +6,8 @@ module Cardano.Wallet.Primitive.Types.RewardAccount.Gen
 
 import Prelude
 
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..), mockHashRewardAccount )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Test.QuickCheck
@@ -35,4 +37,6 @@ addresses = mkRewardAccount <$> ['0' ..]
 --------------------------------------------------------------------------------
 
 mkRewardAccount :: Char -> RewardAccount
-mkRewardAccount c = RewardAccount $ "Reward" `B8.snoc` c
+mkRewardAccount c
+    = RewardAccount . getHash
+    . mockHashRewardAccount $ "Reward" `B8.snoc` c


### PR DESCRIPTION
### Overview

This pull request switches `Cardano.Wallet.DB.Layer` to use `newQueryStoreTxWalletsHistory` for the transaction history.

### Comments

* This pull request obsoletes #3698 and #3739.
* This pull request improves RAM usage for large wallets, as `newQueryStoreTxWalletsHistory` stores the transaction content (`TxSet`) on disk.
* However, the transaction metadata (`WalletsMeta`) is kept in memory for now.
* ⚠️ @piotr-iohk  reports that `GET transaction` now causes a memory spike. I believe that this due to input decoration loading the whole transaction into memory as opposed to loading only the outputs. As a temporary fix, I will move the `TxSet` back to memory by merging #3760 afterwards.

### Issue number

ADP-2741