### PR TITLE
[ADP-2741] Move `TxSet` back into memory in `newQueryStoreTxWalletsHistory`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Model.hs
@@ -39,6 +39,8 @@ import Data.Map.Strict
     ( Map )
 import Data.Quantity
     ( Quantity (getQuantity) )
+import Data.Set
+    ( Set )
 import Fmt
     ( Buildable (build) )
 import GHC.Generics
@@ -119,9 +121,9 @@ instance Delta ManipulateTxMetaHistory where
 -- Returns the new 'TxMetaHistory' as well as the 'TxId's that
 -- have been /deleted/ due to the rollback.
 rollbackTxMetaHistory
-    :: W.SlotNo -> TxMetaHistory -> (TxMetaHistory, [TxId])
+    :: W.SlotNo -> TxMetaHistory -> (TxMetaHistory, Set TxId)
 rollbackTxMetaHistory point (TxMetaHistory txs) =
-    (TxMetaHistory new, Map.keys deleted)
+    (TxMetaHistory new, Map.keysSet deleted)
   where
     (deleted, new) = Map.mapEither keepOrForget txs
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -103,6 +103,7 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Generics.Internal.VL as L
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 {- | A low level definition of a transaction covering all transaction content
  by collecting all related-to-index database rows.
@@ -142,8 +143,8 @@ data DeltaTxSet
     = Append TxSet
     -- ^ Add new set of transactions.
     -- /Overwrites/ transactions whose id is already present in the 'TxSet'.
-    | DeleteTx TxId
-    -- ^ Try to remove the transaction at the given transaction id.
+    | DeleteTxs (Set.Set TxId)
+    -- ^ Try to remove the transactions with the given transaction ids.
     deriving ( Show, Eq, Generic )
 
 instance Buildable DeltaTxSet where
@@ -154,8 +155,8 @@ instance Delta DeltaTxSet where
     -- transactions are immutable so here there should happen no rewriting
     -- but we mimic the repsert in the store
     apply (Append txs) h = txs <> h
-    apply (DeleteTx tid) (TxSet txs) =
-        TxSet $ Map.delete tid txs
+    apply (DeleteTxs tids) (TxSet txs) =
+        TxSet $ Map.withoutKeys txs tids
 
 {-------------------------------------------------------------------------------
     Type conversions

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
@@ -77,10 +77,12 @@ import Database.Persist.Sql
     , keyFromRecordM
     , repsertMany
     , selectList
+    , (<-.)
     , (==.)
     )
 
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 mkStoreTransactions
     :: Store (SqlPersistT IO) DeltaTxSet
@@ -94,15 +96,16 @@ mkStoreTransactions =
 updateTxSet :: DeltaTxSet -> SqlPersistT IO ()
 updateTxSet change = case change of
     Append txs -> putTxSet txs
-    DeleteTx tid -> do
-        deleteWhere [TxInputTxId ==. tid ]
-        deleteWhere [TxCollateralTxId ==. tid ]
-        deleteWhere [TxOutTokenTxId ==. tid ]
-        deleteWhere [TxOutputTxId ==. tid ]
-        deleteWhere [TxCollateralOutTokenTxId ==. tid ]
-        deleteWhere [TxCollateralOutTxId ==. tid ]
-        deleteWhere [TxWithdrawalTxId ==. tid ]
-        deleteWhere [CborTxId ==. tid ]
+    DeleteTxs tidSet -> do
+        let tids = Set.toList tidSet
+        deleteWhere [TxInputTxId <-. tids ]
+        deleteWhere [TxCollateralTxId <-. tids ]
+        deleteWhere [TxOutTokenTxId <-. tids ]
+        deleteWhere [TxOutputTxId <-. tids ]
+        deleteWhere [TxCollateralOutTokenTxId <-. tids ]
+        deleteWhere [TxCollateralOutTxId <-. tids ]
+        deleteWhere [TxWithdrawalTxId <-. tids ]
+        deleteWhere [CborTxId <-. tids ]
 
 write :: TxSet -> SqlPersistT IO ()
 write txs = do

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -40,6 +40,7 @@ import Database.Persist.Sql
     ( SqlPersistT )
 
 import qualified Cardano.Wallet.DB.Store.Transactions.Layer as TxSet
+import qualified Cardano.Wallet.DB.Store.Transactions.Model as TxSet
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.Map.Strict as Map
 
@@ -64,8 +65,9 @@ newQueryStoreTxWalletsHistory = do
     let txsQueryStore = TxSet.mkDBTxSet
 
     storeWalletsMeta <- newCachedStore mkStoreWalletsMeta
+    storeTransactions <- newCachedStore $ store txsQueryStore
     let storeTxWalletsHistory = mkStoreTxWalletsHistory
-            (store txsQueryStore)   -- on disk
+            storeTransactions       -- in memory
             storeWalletsMeta        -- in memory
 
     let readAllMetas :: W.WalletId -> m [TxMeta]
@@ -77,8 +79,11 @@ newQueryStoreTxWalletsHistory = do
 
         query :: forall a. QueryTxWalletsHistory a -> SqlPersistT IO a
         query = \case
-            GetByTxId txid ->
-                queryS txsQueryStore $ TxSet.GetByTxId txid
+            GetByTxId txid -> do
+                -- queryS txsQueryStore $ TxSet.GetByTxId txid
+                Right txSet <- loadS storeTransactions
+                pure $ Map.lookup txid (TxSet.relations txSet)
+
             One wid txid -> do
                 Right wmetas <- loadS storeWalletsMeta
                 pure $ do

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -32,7 +32,7 @@ import Cardano.Wallet.DB.Store.Meta.Model
 import Cardano.Wallet.DB.Store.Meta.Store
     ( mkStoreMetaTransactions )
 import Cardano.Wallet.DB.Store.Transactions.Model
-    ( DeltaTxSet (Append, DeleteTx), mkTxSet )
+    ( DeltaTxSet (..), mkTxSet )
 import Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaTxWalletsHistory (..)
     , transactionsToDeleteOnRemoveWallet
@@ -116,14 +116,14 @@ mkStoreTxWalletsHistory storeTransactions storeWalletsMeta =
                     $ TxMetaStore.Manipulate
                     $ TxMetaStore.RollBackTxMetaHistory slot
                 let deletions = transactionsToDeleteOnRollback wid slot wmetas
-                forM_ deletions
-                    $ updateS storeTransactions mTxSet . DeleteTx
+                updateS storeTransactions mTxSet
+                    $ DeleteTxs deletions
             RemoveWallet wid -> do
                 wmetas <- loadWhenNothing mWmetas storeWalletsMeta
                 updateS storeWalletsMeta (Just wmetas) $ Delete wid
                 let deletions = transactionsToDeleteOnRemoveWallet wid wmetas
-                forM_ deletions
-                    $ updateS storeTransactions mTxSet . DeleteTx
+                updateS storeTransactions mTxSet
+                    $ DeleteTxs deletions
             ExpandTxWalletsHistory wid cs -> do
                 wmetas <- loadWhenNothing mWmetas storeWalletsMeta
                 updateS storeTransactions mTxSet

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -53,13 +53,23 @@ import Test.DBVar
 import Test.Hspec
     ( Spec, around, describe, it )
 import Test.QuickCheck
-    ( Gen, Property, arbitrary, elements, forAll, frequency, property, (===) )
+    ( Gen
+    , Property
+    , arbitrary
+    , elements
+    , forAll
+    , frequency
+    , property
+    , vectorOf
+    , (===)
+    )
 import Test.QuickCheck.Monadic
     ( forAllM )
 
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 spec :: Spec
 spec = do
@@ -164,13 +174,15 @@ genDeltas :: GenDelta DeltaTxSet
 genDeltas (TxSet pile) =
     frequency
         [ (8, Append . mkTxSet <$> (arbitrary >>= mapM addCBOR))
-        , (1, DeleteTx . TxId <$> arbitrary)
+        , (1, DeleteTxs . Set.singleton . TxId <$> arbitrary)
         ,
             ( 2
-            , DeleteTx
+            , DeleteTxs
                 <$> if null pile
-                    then TxId <$> arbitrary
-                    else elements (Map.keys pile)
+                    then Set.singleton. TxId <$> arbitrary
+                    else do
+                        k <- elements [1,3]
+                        fmap Set.fromList . vectorOf k . elements $ Map.keys pile
             )
         ]
 

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/ModelSpec.hs
@@ -35,7 +35,6 @@ import qualified Cardano.Wallet.DB.Store.Wallets.Model as TxWallets
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
 import qualified Test.QuickCheck as Q
 
 spec :: Spec
@@ -68,7 +67,7 @@ prop_RollbackCollectsGarbage = \GenRollback{wid,slot,history} ->
             )
 
     rollbackB wid slot (Txs.TxSet x, wmetas) =
-        Txs.TxSet $ Map.withoutKeys x (Set.fromList deletions)
+        Txs.TxSet $ Map.withoutKeys x deletions
       where
         deletions = TxWallets.transactionsToDeleteOnRollback wid slot wmetas
 
@@ -82,7 +81,7 @@ prop_RemoveWalletCollectsGarbage = \GenRollback{wid,history} ->
             (x, Map.delete wid wmetas)
 
     removeWalletB wid (Txs.TxSet x, wmetas) =
-        Txs.TxSet $ Map.withoutKeys x (Set.fromList deletions)
+        Txs.TxSet $ Map.withoutKeys x deletions
       where
         deletions = TxWallets.transactionsToDeleteOnRemoveWallet wid wmetas
 


### PR DESCRIPTION
### Overview

This pull request moves the `TxSet` back into memory in `newQueryStoreTxWalletsHistory`, due to a memory spike when calling `GET transactions`.

This pull request also fixes an issue with the use of `DeleteTx` in `mkStoreTxWalletsHistory`, which only becomes visible when `updateS` uses the in-memory value `mTxSet` — the problem is that `mTxSet` would need to be updated when calling `updateS` repeatedly.

### Comments

* Moving the `TxSet` on disk and addressing the memory spike will be tackled in a subsequent pull request.

### Issue Number

ADP-2741