### PR TITLE
Rewrite of the getDelegationFee endpoint

### DIFF
--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -535,7 +535,7 @@ benchmarksRnd _ w wid wname benchname restoreTime = do
                 , wallet
                 , selectionStrategy = SelectionStrategyOptimal
                 } $ \_state -> W.Fee . selectionDelta TokenBundle.getCoin
-        runExceptT $ withExceptT show $ W.calculateFeeSpread estimateFee
+        runExceptT $ withExceptT show $ W.calculateFeePercentiles estimateFee
 
     oneAddress <- genAddresses 1 cp
     (_, importOneAddressTime) <- bench "import one addresses" $ do
@@ -641,7 +641,7 @@ benchmarksSeq _ w wid _wname benchname restoreTime = do
                 , wallet
                 , selectionStrategy = SelectionStrategyOptimal
                 } $ \_state -> W.Fee . selectionDelta TokenBundle.getCoin
-        runExceptT $ withExceptT show $ W.calculateFeeSpread estimateFee
+        runExceptT $ withExceptT show $ W.calculateFeePercentiles estimateFee
 
     let walletOverview = WalletOverview{utxo,addresses,transactions}
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -91,8 +91,8 @@ import Cardano.Tx.Balance.Internal.CoinSelection
 import Cardano.Wallet
     ( ErrUpdateSealedTx (..)
     , Fee (..)
-    , FeeSpread (..)
-    , calculateFeeSpread
+    , Percentile (..)
+    , calculateFeePercentiles
     , defaultChangeAddressGen
     , signTransaction
     )
@@ -1468,7 +1468,7 @@ feeEstimationRegressionSpec :: Spec
 feeEstimationRegressionSpec = describe "Regression tests" $ do
     it "#1740 Fee estimation at the boundaries" $ do
         let requiredCost = Fee (Coin.fromNatural 166_029)
-        let runSelection = except $ Left
+        let estimateFee = except $ Left
                 $ ErrSelectAssetsSelectionError
                 $ SelectionBalanceErrorOf
                 $ UnableToConstructChange
@@ -1476,8 +1476,11 @@ feeEstimationRegressionSpec = describe "Regression tests" $ do
                     { requiredCost = feeToCoin requiredCost
                     , shortfall = Coin 100_000
                     }
-        result <- runExceptT (calculateFeeSpread runSelection)
-        result `shouldBe` Right (FeeSpread requiredCost requiredCost)
+        result <- runExceptT (calculateFeePercentiles estimateFee)
+        result `shouldBe` Right
+            ( Percentile requiredCost
+            , Percentile requiredCost
+            )
 
 binaryCalculationsSpec :: AnyRecentEra -> Spec
 binaryCalculationsSpec (AnyRecentEra era) =

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -90,9 +90,10 @@ import Cardano.Tx.Balance.Internal.CoinSelection
     )
 import Cardano.Wallet
     ( ErrUpdateSealedTx (..)
-    , FeeEstimation (..)
+    , Fee (..)
+    , FeeSpread (..)
+    , calculateFeeSpread
     , defaultChangeAddressGen
-    , estimateFee
     , signTransaction
     )
 import Cardano.Wallet.Byron.Compatibility
@@ -1466,17 +1467,17 @@ feeCalculationSpec era = describe "fee calculations" $ do
 feeEstimationRegressionSpec :: Spec
 feeEstimationRegressionSpec = describe "Regression tests" $ do
     it "#1740 Fee estimation at the boundaries" $ do
-        let requiredCost = 166_029
+        let requiredCost = Fee (Coin.fromNatural 166_029)
         let runSelection = except $ Left
                 $ ErrSelectAssetsSelectionError
                 $ SelectionBalanceErrorOf
                 $ UnableToConstructChange
                 $ UnableToConstructChangeError
-                    { requiredCost = Coin.fromWord64 requiredCost
+                    { requiredCost = feeToCoin requiredCost
                     , shortfall = Coin 100_000
                     }
-        result <- runExceptT (estimateFee runSelection)
-        result `shouldBe` Right (FeeEstimation requiredCost requiredCost)
+        result <- runExceptT (calculateFeeSpread runSelection)
+        result `shouldBe` Right (FeeSpread requiredCost requiredCost)
 
 binaryCalculationsSpec :: AnyRecentEra -> Spec
 binaryCalculationsSpec (AnyRecentEra era) =

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -273,7 +273,6 @@ import qualified Cardano.Wallet.Address.Book as Sqlite
 import qualified Cardano.Wallet.DB.Sqlite.Types as DB
 import qualified Cardano.Wallet.DB.Store.Checkpoints as Sqlite
 import qualified Cardano.Wallet.Primitive.Migration as Migration
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Read as Read
@@ -330,9 +329,9 @@ spec = parallel $ describe "Cardano.WalletSpec" $ do
         it "Wallet won't list unrelated assets used in related transactions"
             (property walletListsOnlyRelatedAssets)
 
-    describe "Tx fee estimation" $
-        it "Fee estimates are sound"
-            (property prop_estimateFee)
+    describe "Tx fee estimation spread" $
+        it "Estimated fee spreads are sound"
+            (property prop_calculateFeeSpread)
 
     describe "LocalTxSubmission" $ do
         it "LocalTxSubmission pool retries pending transactions"
@@ -615,20 +614,18 @@ walletListsOnlyRelatedAssets txId txMeta =
 -- 1. There is no coin selection with a fee above the estimated maximum.
 -- 2. The minimum estimated fee is no greater than the maximum estimated fee.
 -- 3. Around 10% of fees are below the estimated minimum.
-prop_estimateFee
-    :: NonEmptyList (Maybe Coin)
-    -> Property
-prop_estimateFee (NonEmpty coins) =
-    case evalState (runExceptT $ W.estimateFee runSelection) 0 of
+prop_calculateFeeSpread :: NonEmptyList (Maybe Coin) -> Property
+prop_calculateFeeSpread (NonEmpty coins) =
+    case evalState (runExceptT $ W.calculateFeeSpread estimateFee) 0 of
         Left err ->
             label "errors: all" $ err === genericError
 
-        Right estimation@(W.FeeEstimation minFee maxFee) ->
+        Right spread@(W.FeeSpread minFee maxFee) ->
             label ("errors: " <> if any isNothing coins then "some" else "none") $
-            counterexample (show estimation) $ conjoin
-                [ property $ Coin.fromWord64 maxFee <= maximum (catMaybes coins)
+            counterexample (show spread) $ conjoin
+                [ property $ W.feeToCoin maxFee <= maximum (catMaybes coins)
                 , property $ minFee <= maxFee
-                , proportionBelow (Coin.fromWord64 minFee) coins
+                , proportionBelow (W.feeToCoin minFee) coins
                     `closeTo` (1/10 :: Double)
                 ]
   where
@@ -642,14 +639,13 @@ prop_estimateFee (NonEmpty coins) =
             TokenBundle.empty
             TokenBundle.empty
 
-    runSelection
-        :: ExceptT W.ErrSelectAssets (State Int) Coin
-    runSelection = do
+    estimateFee :: ExceptT W.ErrSelectAssets (State Int) W.Fee
+    estimateFee = do
         i <- lift get
         lift $ put $ (i + 1) `mod` length coins
         case (coins !! i) of
             Nothing -> except $ Left genericError
-            Just c  -> except $ Right c
+            Just c  -> except $ Right $ W.Fee c
 
     proportionBelow :: Coin -> [Maybe Coin] -> Double
     proportionBelow minFee xs =


### PR DESCRIPTION
Rewrite of the `getDelegationFee` endpoint so that:
1.  it uses balanceTransaction as its primary means of transaction balancing;
2.  it no longer directly depends upon the internal coin selection library.
 
### Issue Number

ADP-2264
