### PR TITLE
[ADP-2779] Test removing input decoration

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -107,7 +107,7 @@ import Cardano.Wallet.DB.Store.QueryStore
 import Cardano.Wallet.DB.Store.Submissions.Layer
     ( pruneByFinality, rollBackSubmissions )
 import Cardano.Wallet.DB.Store.Transactions.Decoration
-    ( TxInDecorator, decorateTxInsForReadTx, decorateTxInsForRelation )
+    ( TxInDecorator, decorateTxInsForReadTx )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( TxRelation (..) )
 import Cardano.Wallet.DB.Store.Transactions.TransactionInfo
@@ -978,7 +978,8 @@ selectTransactionInfo
 selectTransactionInfo ti tip lookupTx meta = do
     let err = error $ "Transaction not found: " <> show meta
     transaction <- fromMaybe err <$> lookupTx (txMetaTxId meta)
-    decoration <- decorateTxInsForRelation lookupTx transaction
+    -- decoration <- decorateTxInsForRelation lookupTx transaction
+    let decoration = mempty
     mkTransactionInfoFromRelation
         (hoistTimeInterpreter liftIO ti) tip transaction decoration meta
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -40,7 +40,6 @@ import Database.Persist.Sql
     ( SqlPersistT )
 
 import qualified Cardano.Wallet.DB.Store.Transactions.Layer as TxSet
-import qualified Cardano.Wallet.DB.Store.Transactions.Model as TxSet
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.Map.Strict as Map
 
@@ -65,7 +64,7 @@ newQueryStoreTxWalletsHistory = do
     let txsQueryStore = TxSet.mkDBTxSet
 
     storeWalletsMeta <- newCachedStore mkStoreWalletsMeta
-    storeTransactions <- newCachedStore $ store txsQueryStore
+    let storeTransactions = store txsQueryStore
     let storeTxWalletsHistory = mkStoreTxWalletsHistory
             storeTransactions       -- in memory
             storeWalletsMeta        -- in memory
@@ -80,9 +79,9 @@ newQueryStoreTxWalletsHistory = do
         query :: forall a. QueryTxWalletsHistory a -> SqlPersistT IO a
         query = \case
             GetByTxId txid -> do
-                -- queryS txsQueryStore $ TxSet.GetByTxId txid
-                Right txSet <- loadS storeTransactions
-                pure $ Map.lookup txid (TxSet.relations txSet)
+                queryS txsQueryStore $ TxSet.GetByTxId txid
+                -- Right txSet <- loadS storeTransactions
+                -- pure $ Map.lookup txid (TxSet.relations txSet)
 
             One wid txid -> do
                 Right wmetas <- loadS storeWalletsMeta


### PR DESCRIPTION
### Overview

This branch tests whether removing input decoration removes the memory spike in `GET transaction` when the transaction content is on disk.

### Issue Number

ADP-2779