### PR TITLE
[ADP-2780] Specialized input decoration for on-disk transactions

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -137,8 +137,10 @@ import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter, firstSlotInEpoch, hoistTimeInterpreter, interpretQuery )
 import Cardano.Wallet.Read.Eras
     ( EraValue )
+import Control.DeepSeq
+    ( force )
 import Control.Exception
-    ( throw )
+    ( evaluate, throw )
 import Control.Monad
     ( forM, unless, when, (<=<) )
 import Control.Monad.IO.Class
@@ -979,7 +981,7 @@ selectTransactionInfo ti tip lookupTx meta = do
     let err = error $ "Transaction not found: " <> show meta
     transaction <- fromMaybe err <$> lookupTx (txMetaTxId meta)
     decoration <- decorateTxInsForRelation lookupTx transaction
-    mkTransactionInfoFromRelation
+    liftIO . evaluate . force =<< mkTransactionInfoFromRelation
         (hoistTimeInterpreter liftIO ti) tip transaction decoration meta
 
 selectPrivateKey

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/QueryStore.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/QueryStore.hs
@@ -4,8 +4,11 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Cardano.Wallet.DB.Store.QueryStore
-    (QueryStore (..), queryStoreProperty, untry)
-    where
+    ( QueryStore (..)
+    , Query (..)
+    , queryStoreProperty
+    , untry
+    ) where
 
 import Prelude
 
@@ -60,10 +63,10 @@ class Query qa where
 
 queryStoreProperty
     :: (Monad m, Eq b, Query qa, MonadFail m, Base da ~ World qa)
-    => qa b
-    -> QueryStore m qa da
+    => QueryStore m qa da
+    -> qa b
     -> m Bool
-queryStoreProperty r QueryStore{store, queryS} = do
+queryStoreProperty QueryStore{store, queryS} r = do
     Right z <- loadS store
     (query r z ==) <$> queryS r
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Layer.hs
@@ -8,12 +8,12 @@
 Copyright: © 2022 IOHK
 License: Apache-2.0
 
-Implementation of a 'DB' for 'TxSet'.
+Implementation of a 'QueryStore' for 'TxSet'.
 
 -}
 module Cardano.Wallet.DB.Store.Transactions.Layer
     ( ReadTxSet (..)
-    , mkDBTxSet
+    , mkQueryStoreTxSet
     ) where
 
 import Prelude
@@ -35,9 +35,9 @@ import qualified Cardano.Wallet.DB.Store.Transactions.Store as TxSet
 data ReadTxSet b where
     GetByTxId :: TxId -> ReadTxSet (Maybe TxRelation)
 
--- | Implementation of a 'DB' for 'TxSet'.
-mkDBTxSet :: QueryStore (SqlPersistT IO) ReadTxSet DeltaTxSet
-mkDBTxSet = QueryStore
+-- | Implementation of a 'QueryStore' for 'TxSet'.
+mkQueryStoreTxSet :: QueryStore (SqlPersistT IO) ReadTxSet DeltaTxSet
+mkQueryStoreTxSet = QueryStore
     { queryS = \case
         GetByTxId txid -> TxSet.selectTx txid
     , store = TxSet.mkStoreTransactions

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Layer.hs
@@ -21,24 +21,36 @@ import Prelude
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId )
 import Cardano.Wallet.DB.Store.Transactions.Model
-    ( DeltaTxSet, TxRelation )
+    ( DeltaTxSet, TxRelation, fromTxCollateralOut, fromTxOut )
+import Control.Applicative
+    ( (<|>) )
+import Data.Word
+    ( Word32 )
 import Database.Persist.Sql
     ( SqlPersistT )
 
 import Cardano.Wallet.DB.Store.QueryStore
     ( QueryStore (..) )
 import qualified Cardano.Wallet.DB.Store.Transactions.Store as TxSet
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 
 {-----------------------------------------------------------------------------
     DB for 'TxSet'
 ------------------------------------------------------------------------------}
 data QueryTxSet b where
     GetByTxId :: TxId -> QueryTxSet (Maybe TxRelation)
+    GetTxOut :: (TxId, Word32) -> QueryTxSet (Maybe W.TxOut)
 
 -- | Implementation of a 'QueryStore' for 'TxSet'.
 mkQueryStoreTxSet :: QueryStore (SqlPersistT IO) QueryTxSet DeltaTxSet
 mkQueryStoreTxSet = QueryStore
     { queryS = \case
         GetByTxId txid -> TxSet.selectTx txid
+        GetTxOut key -> do
+            mout <- TxSet.selectTxOut key
+            mcollateralOut <- TxSet.selectTxCollateralOut key
+            pure $
+                    (fromTxOut <$> mout)
+                <|> (fromTxCollateralOut <$> mcollateralOut)
     , store = TxSet.mkStoreTransactions
     }

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Layer.hs
@@ -12,7 +12,7 @@ Implementation of a 'QueryStore' for 'TxSet'.
 
 -}
 module Cardano.Wallet.DB.Store.Transactions.Layer
-    ( ReadTxSet (..)
+    ( QueryTxSet (..)
     , mkQueryStoreTxSet
     ) where
 
@@ -32,11 +32,11 @@ import qualified Cardano.Wallet.DB.Store.Transactions.Store as TxSet
 {-----------------------------------------------------------------------------
     DB for 'TxSet'
 ------------------------------------------------------------------------------}
-data ReadTxSet b where
-    GetByTxId :: TxId -> ReadTxSet (Maybe TxRelation)
+data QueryTxSet b where
+    GetByTxId :: TxId -> QueryTxSet (Maybe TxRelation)
 
 -- | Implementation of a 'QueryStore' for 'TxSet'.
-mkQueryStoreTxSet :: QueryStore (SqlPersistT IO) ReadTxSet DeltaTxSet
+mkQueryStoreTxSet :: QueryStore (SqlPersistT IO) QueryTxSet DeltaTxSet
 mkQueryStoreTxSet = QueryStore
     { queryS = \case
         GetByTxId txid -> TxSet.selectTx txid

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -62,7 +62,7 @@ newQueryStoreTxWalletsHistory
     :: forall m. m ~ SqlPersistT IO
     => m QueryStoreTxWalletsHistory
 newQueryStoreTxWalletsHistory = do
-    let txsQueryStore = TxSet.mkDBTxSet
+    let txsQueryStore = TxSet.mkQueryStoreTxSet
 
     storeWalletsMeta <- newCachedStore mkStoreWalletsMeta
     storeTransactions <- newCachedStore $ store txsQueryStore

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -36,11 +36,14 @@ import Data.DBVar
     ( Store (..), newCachedStore )
 import Data.Foldable
     ( toList )
+import Data.Word
+    ( Word32 )
 import Database.Persist.Sql
     ( SqlPersistT )
 
 import qualified Cardano.Wallet.DB.Store.Transactions.Layer as TxSet
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 import qualified Data.Map.Strict as Map
 
 {-----------------------------------------------------------------------------
@@ -48,6 +51,7 @@ import qualified Data.Map.Strict as Map
 ------------------------------------------------------------------------------}
 data QueryTxWalletsHistory b where
     GetByTxId :: TxId -> QueryTxWalletsHistory (Maybe TxRelation)
+    GetTxOut :: (TxId, Word32) -> QueryTxWalletsHistory (Maybe W.TxOut)
     One :: W.WalletId -> TxId -> QueryTxWalletsHistory (Maybe TxMeta)
     All :: W.WalletId -> QueryTxWalletsHistory [TxMeta]
 
@@ -80,7 +84,9 @@ newQueryStoreTxWalletsHistory = do
         query = \case
             GetByTxId txid -> do
                 queryS txsQueryStore $ TxSet.GetByTxId txid
-                
+            GetTxOut key -> do
+                queryS txsQueryStore $ TxSet.GetTxOut key
+
             One wid txid -> do
                 Right wmetas <- loadS storeWalletsMeta
                 pure $ do


### PR DESCRIPTION
### Overview

This pull request adds a `GetTxOut` query to the `QueryStore` for the transaction content, and uses it to decorate transactions when showing the transaction history.

This pull request also moves the `TxSet` to disk.

### Issue number

ADP-2780