### PR TITLE
Add more context to ErrUnderestimatedFee error

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -526,11 +526,15 @@ instance IsServerError ErrBalanceTx where
 
 instance IsServerError ErrBalanceTxInternalError where
     toServerError = \case
-        ErrUnderestimatedFee coin _st ->
+        ErrUnderestimatedFee coin candidateTx nWits ->
             apiError err500 BalanceTxUnderestimatedFee $ T.unwords
                 [ "I have somehow underestimated the fee of the transaction by"
                 , pretty coin
                 , "and cannot finish balancing."
+                , "I have assumed the transaction needs" <> T.pack (show nWits)
+                , "verification key witnesses.\n\n"
+                , "The candidate tx is:"
+                , T.pack (show candidateTx)
                 ]
         ErrFailedBalancing v ->
             apiError err500 BalanceTxInternalError $ T.unwords

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -85,10 +85,13 @@ import Cardano.Wallet
     , ErrWrongPassphrase (..)
     , WalletException (..)
     )
+import Cardano.Wallet.Api.Hex
+    ( hexText )
 import Cardano.Wallet.Api.Types
     ( ApiCosignerIndex (..), ApiCredentialType (..), Iso8601Time (..) )
 import Cardano.Wallet.Api.Types.Error
     ( ApiError (..)
+    , ApiErrorBalanceTxUnderestimatedFee (..)
     , ApiErrorInfo (..)
     , ApiErrorMessage (..)
     , ApiErrorSharedWalletNoSuchCosigner (..)
@@ -102,6 +105,10 @@ import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( Flat (..) )
+import Cardano.Wallet.Primitive.Types.Tx.SealedTx
+    ( serialisedTx )
+import Cardano.Wallet.Shelley.Transaction
+    ( KeyWitnessCount (..) )
 import Cardano.Wallet.Transaction
     ( ErrAssignRedeemers (..), ErrSignTx (..) )
 import Cardano.Wallet.Write.Tx.Balance
@@ -113,11 +120,13 @@ import Control.Monad.Trans.Except
 import Data.Generics.Internal.VL
     ( view, (^.) )
 import Data.IntCast
-    ( intCastMaybe )
+    ( intCast, intCastMaybe )
 import Data.List
     ( isInfixOf, isPrefixOf, isSubsequenceOf )
 import Data.Maybe
     ( isJust )
+import Data.Quantity
+    ( Quantity (Quantity) )
 import Data.Text
     ( Text )
 import Data.Text.Class
@@ -526,16 +535,20 @@ instance IsServerError ErrBalanceTx where
 
 instance IsServerError ErrBalanceTxInternalError where
     toServerError = \case
-        ErrUnderestimatedFee coin candidateTx nWits ->
-            apiError err500 BalanceTxUnderestimatedFee $ T.unwords
+        ErrUnderestimatedFee coin candidateTx (KeyWitnessCount nWits nBootWits) ->
+            apiError err500 (BalanceTxUnderestimatedFee info) $ T.unwords
                 [ "I have somehow underestimated the fee of the transaction by"
-                , pretty coin
-                , "and cannot finish balancing."
-                , "I have assumed the transaction needs" <> T.pack (show nWits)
-                , "verification key witnesses.\n\n"
-                , "The candidate tx is:"
-                , T.pack (show candidateTx)
+                , pretty coin, "and cannot finish balancing."
                 ]
+
+          where
+            info = ApiErrorBalanceTxUnderestimatedFee
+                { underestimation = Quantity $ Coin.toNatural coin
+                , candidateTxHex = hexText $ serialisedTx candidateTx
+                , candidateTxReadable = T.pack (show candidateTx)
+                , estimatedNumberOfKeyWits = intCast nWits
+                , estimatedNumberOfBootstrapKeyWits = intCast nBootWits
+                }
         ErrFailedBalancing v ->
             apiError err500 BalanceTxInternalError $ T.unwords
                 [ "I have somehow failed to balance the transaction."

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Error.hs
@@ -22,6 +22,7 @@ module Cardano.Wallet.Api.Types.Error
     -- * Specific API error types
     , ApiErrorSharedWalletNoSuchCosigner (..)
     , ApiErrorTxOutputLovelaceInsufficient (..)
+    , ApiErrorBalanceTxUnderestimatedFee (..)
     )
     where
 
@@ -93,6 +94,7 @@ data ApiErrorInfo
     | BalanceTxInternalError
     | BalanceTxMaxSizeLimitExceeded
     | BalanceTxUnderestimatedFee
+        ApiErrorBalanceTxUnderestimatedFee
     | CannotCoverFee
     | CreatedInvalidTransaction
     | CreatedMultiaccountTransaction
@@ -207,4 +209,16 @@ data ApiErrorTxOutputLovelaceInsufficient = ApiErrorTxOutputLovelaceInsufficient
     deriving (Data, Eq, Generic, Show, Typeable)
     deriving (FromJSON, ToJSON)
         via DefaultRecord ApiErrorTxOutputLovelaceInsufficient
+    deriving anyclass NFData
+
+data ApiErrorBalanceTxUnderestimatedFee = ApiErrorBalanceTxUnderestimatedFee
+    { underestimation :: !(Quantity "lovelace" Natural)
+    , estimatedNumberOfKeyWits :: Natural
+    , estimatedNumberOfBootstrapKeyWits :: Natural
+    , candidateTxHex :: Text
+    , candidateTxReadable :: Text
+    }
+    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON)
+        via DefaultRecord ApiErrorBalanceTxUnderestimatedFee
     deriving anyclass NFData

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -69,9 +69,7 @@ import Cardano.Wallet.Primitive.Types.UTxOSelection
 import Cardano.Wallet.Shelley.Compatibility
     ( fromCardanoTxIn, fromCardanoTxOut, toCardanoUTxO )
 import Cardano.Wallet.Shelley.Transaction
-    ( KeyWitnessCount (..), TxUpdate (..) )
-import Cardano.Wallet.Shelley.Transaction
-    ( estimateNumberOfWitnesses )
+    ( KeyWitnessCount (..), TxUpdate (..), estimateKeyWitnessCount )
 import Cardano.Wallet.Transaction
     ( ErrAssignRedeemers
     , ErrMoreSurplusNeeded (..)
@@ -653,7 +651,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         let balance = txBalance tx'
         let minfee' = Cardano.Lovelace $ fromIntegral $ W.unCoin minfee
         let Cardano.Tx txBody' _ = tx'
-        let witCount = estimateNumberOfWitnesses combinedUTxO txBody'
+        let witCount = estimateKeyWitnessCount combinedUTxO txBody'
         return (balance, minfee', witCount)
 
     -- | Ensure the wallet UTxO is consistent with a provided @Cardano.UTxO@.

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -69,7 +69,9 @@ import Cardano.Wallet.Primitive.Types.UTxOSelection
 import Cardano.Wallet.Shelley.Compatibility
     ( fromCardanoTxIn, fromCardanoTxOut, toCardanoUTxO )
 import Cardano.Wallet.Shelley.Transaction
-    ( TxUpdate (..) )
+    ( KeyWitnessCount (..), TxUpdate (..) )
+import Cardano.Wallet.Shelley.Transaction
+    ( estimateNumberOfWitnesses )
 import Cardano.Wallet.Transaction
     ( ErrAssignRedeemers
     , ErrMoreSurplusNeeded (..)
@@ -224,7 +226,7 @@ data ErrSelectAssets
     deriving (Generic, Eq, Show)
 
 data ErrBalanceTxInternalError
-    = ErrUnderestimatedFee W.Coin SealedTx
+    = ErrUnderestimatedFee W.Coin SealedTx KeyWitnessCount
     | ErrFailedBalancing Cardano.Value
     deriving (Show, Eq)
 
@@ -441,7 +443,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 
     let era = Cardano.anyCardanoEra $ Cardano.cardanoEra @era
 
-    (balance0, minfee0) <- balanceAfterSettingMinFee partialTx
+    (balance0, minfee0, _) <- balanceAfterSettingMinFee partialTx
 
     (extraInputs, extraCollateral', extraOutputs, s') <- do
 
@@ -530,7 +532,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         , feeUpdate = UseNewTxFee $ unsafeFromLovelace minfee0
         }
 
-    (balance, candidateMinFee) <- balanceAfterSettingMinFee candidateTx
+    (balance, candidateMinFee, witCount) <- balanceAfterSettingMinFee candidateTx
     surplus <- case Cardano.selectLovelace balance of
         (Cardano.Lovelace c)
             | c >= 0 ->
@@ -540,6 +542,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 ErrUnderestimatedFee
                     (Coin.unsafeFromIntegral (-c))
                     (toSealed candidateTx)
+                    witCount
 
     let feeAndChange = TxFeeAndChange
             (unsafeFromLovelace candidateMinFee)
@@ -551,7 +554,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     TxFeeAndChange updatedFee updatedChange <- withExceptT
         (\(ErrMoreSurplusNeeded c) ->
             ErrBalanceTxInternalError $
-                ErrUnderestimatedFee c (toSealed candidateTx))
+                ErrUnderestimatedFee c (toSealed candidateTx) witCount)
         (ExceptT . pure $
             distributeSurplus txLayer feePolicy surplus feeAndChange)
 
@@ -640,7 +643,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 
     balanceAfterSettingMinFee
         :: Cardano.Tx era
-        -> ExceptT ErrBalanceTx m (Cardano.Value, Cardano.Lovelace)
+        -> ExceptT ErrBalanceTx m (Cardano.Value, Cardano.Lovelace, KeyWitnessCount)
     balanceAfterSettingMinFee tx = ExceptT . pure $ do
         -- NOTE: evaluateMinimumFee relies on correctly estimating the required
         -- number of witnesses.
@@ -649,7 +652,9 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         tx' <- left ErrBalanceTxUpdateError $ updateTx txLayer tx update
         let balance = txBalance tx'
         let minfee' = Cardano.Lovelace $ fromIntegral $ W.unCoin minfee
-        return (balance, minfee')
+        let Cardano.Tx txBody' _ = tx'
+        let witCount = estimateNumberOfWitnesses combinedUTxO txBody'
+        return (balance, minfee', witCount)
 
     -- | Ensure the wallet UTxO is consistent with a provided @Cardano.UTxO@.
     --

--- a/lib/wallet/test/data/Cardano/Wallet/Api/ApiError.json
+++ b/lib/wallet/test/data/Cardano/Wallet/Api/ApiError.json
@@ -616,6 +616,16 @@
         },
         {
             "code": "balance_tx_underestimated_fee",
+            "info": {
+                "candidate_tx_hex": "v\u0001]𒂱\\",
+                "candidate_tx_readable": "𡫰𭽮󳖾Z\"a!u\u0008V V",
+                "estimated_number_of_bootstrap_key_wits": 18,
+                "estimated_number_of_key_wits": 7,
+                "underestimation": {
+                    "quantity": 45,
+                    "unit": "lovelace"
+                }
+            },
             "message": " 0"
         },
         {

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -216,6 +216,7 @@ import Cardano.Wallet.Api.Types.BlockHeader
     ( ApiBlockHeader )
 import Cardano.Wallet.Api.Types.Error
     ( ApiError (..)
+    , ApiErrorBalanceTxUnderestimatedFee (..)
     , ApiErrorInfo (..)
     , ApiErrorMessage (..)
     , ApiErrorSharedWalletNoSuchCosigner (..)
@@ -2204,6 +2205,10 @@ instance Arbitrary ApiErrorSharedWalletNoSuchCosigner where
     shrink = genericShrink
 
 instance Arbitrary ApiErrorTxOutputLovelaceInsufficient where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary ApiErrorBalanceTxUnderestimatedFee where
     arbitrary = genericArbitrary
     shrink = genericShrink
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3798,12 +3798,11 @@ prop_balanceTransactionValid wallet (ShowBuildable partialTx) seed
                 (SelectionBalanceErrorOf EmptyUTxO))) ->
                 label "empty UTxO" $ property True
             Left (ErrBalanceTxInternalError
-                 (ErrUnderestimatedFee delta candidateTx)) ->
-                let counterexampleText = mconcat
-                        [ "underestimated fee by "
-                        , pretty delta
-                        , "\n candidate tx: "
-                        , pretty candidateTx
+                 (ErrUnderestimatedFee delta candidateTx nWits)) ->
+                let counterexampleText = unlines
+                        [ "underestimated fee by " <> pretty delta
+                        , "candidate tx: " <> pretty candidateTx
+                        , "assuming key witness count: " <> show nWits
                         ]
                 in
                     counterexample counterexampleText $ property False


### PR DESCRIPTION
- [x] Return `candidateTx` and estimated `witnessCount` in API 500 error `ErrUnderestimatedFee`
    - This is useful for debugging in case of errors

### Comments

- Byron part of `KeyWitnessCount` will be used in #3765 

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->

[ADP-2268](https://input-output.atlassian.net/browse/ADP-2268) / [ADP-2613](https://input-output.atlassian.net/browse/ADP-2613)