### PR TITLE
Encourage API error objects over hand-constructed error strings.

### DIFF
--- a/lib/integration/framework/Test/Integration/Framework/TestData.hs
+++ b/lib/integration/framework/Test/Integration/Framework/TestData.hs
@@ -79,7 +79,6 @@ module Test.Integration.Framework.TestData
     , errMsgNotInDictionary
     , errMsg400MinWithdrawalWrong
     , errMsg403WithdrawalNotBeneficial
-    , errMsg403MinUTxOValue
     , errMsg403CouldntIdentifyAddrAsMine
     , errMsg503PastHorizon
     , errMsg403WrongIndex
@@ -334,15 +333,6 @@ errMsg403InvalidConstructTx =
     "It looks like I've created an empty transaction that does not have \
      \any payments, withdrawals, delegations, metadata nor minting. \
      \Include at least one of them."
-
-errMsg403MinUTxOValue :: String
-errMsg403MinUTxOValue = unwords
-    [ "One of the outputs you've specified has an ada quantity that is"
-    , "below the minimum required. Either increase the ada quantity to"
-    , "at least the minimum, or specify an ada quantity of zero, in"
-    , "which case the wallet will automatically assign the correct"
-    , "minimum ada quantity to the output."
-    ]
 
 errMsg409WalletExists :: String -> String
 errMsg409WalletExists walId = "This operation would yield a wallet with the following\

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -30,6 +31,10 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Api.Types.Amount
     ( ApiAmount (ApiAmount)
+    )
+import Cardano.Wallet.Api.Types.Error
+    ( ApiErrorInfo (UtxoTooSmall)
+    , ApiErrorTxOutputLovelaceInsufficient (ApiErrorTxOutputLovelaceInsufficient)
     )
 import Cardano.Wallet.Api.Types.Transaction
     ( ApiLimit (..)
@@ -78,6 +83,7 @@ import Test.Hspec
 import Test.Hspec.Expectations.Lifted
     ( shouldBe
     , shouldNotBe
+    , shouldSatisfy
     )
 import Test.Hspec.Extra
     ( it
@@ -91,6 +97,7 @@ import Test.Integration.Framework.DSL
     , emptyRandomWallet
     , emptyWallet
     , eventually
+    , expectErrorInfo
     , expectErrorMessage
     , expectField
     , expectListField
@@ -124,7 +131,6 @@ import Test.Integration.Framework.Request
     )
 import Test.Integration.Framework.TestData
     ( errMsg400StartTimeLaterThanEndTime
-    , errMsg403MinUTxOValue
     , errMsg404NoAsset
     , errMsg404NoWallet
     , steveToken
@@ -201,8 +207,14 @@ spec = describe "BYRON_TRANSACTIONS" $ do
 
         rtx <- request @(ApiTransaction n) ctx
             (Link.createTransactionOld @'Byron wSrc) Default payload
-        expectResponseCode HTTP.status403 rtx
-        expectErrorMessage errMsg403MinUTxOValue rtx
+        verify rtx
+            [ expectResponseCode HTTP.status403
+            , expectErrorInfo $ flip shouldSatisfy $ \case
+                UtxoTooSmall ApiErrorTxOutputLovelaceInsufficient {} ->
+                    True
+                _anythingElse ->
+                    False
+            ]
 
     describe "BYRON_TRANS_ASSETS_CREATE_02a - Multi-asset transaction with no ADA" $
         forM_ [ (fixtureMultiAssetRandomWallet @n, "Byron wallet")

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -54,6 +54,7 @@ import Cardano.Wallet.Api.Types.Amount
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)
+    , ApiErrorTxOutputLovelaceInsufficient (ApiErrorTxOutputLovelaceInsufficient)
     )
 import Cardano.Wallet.Api.Types.SchemaMetadata
     ( detailedMetadata
@@ -219,7 +220,6 @@ import Test.Integration.Framework.TestData
     , errMsg400TxMetadataStringTooLong
     , errMsg403AlreadyInLedger
     , errMsg403Fee
-    , errMsg403MinUTxOValue
     , errMsg403WithdrawalNotBeneficial
     , errMsg403WrongPass
     , errMsg404CannotFindTx
@@ -994,9 +994,14 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                     (Link.createTransactionOld @'Shelley wSrc)
                     Default
                     payload
-            -- It should fail with InsufficientMinCoinValueError
-            expectResponseCode HTTP.status403 rtx
-            expectErrorMessage errMsg403MinUTxOValue rtx
+            verify rtx
+                [ expectResponseCode HTTP.status403
+                , expectErrorInfo $ flip shouldSatisfy $ \case
+                    UtxoTooSmall ApiErrorTxOutputLovelaceInsufficient {} ->
+                        True
+                    _anythingElse ->
+                        False
+                ]
 
     it "TRANS_ASSETS_CREATE_02a - Multi-asset transaction without Ada"
         $ \ctx -> runResourceT $ do

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -111,6 +111,7 @@ import Cardano.Wallet.Api.Types.Certificate
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)
+    , ApiErrorTxOutputLovelaceInsufficient (ApiErrorTxOutputLovelaceInsufficient)
     )
 import Cardano.Wallet.Api.Types.Transaction
     ( ApiAddress (..)
@@ -326,7 +327,6 @@ import Test.Integration.Framework.TestData
     , errMsg403ForeignTransaction
     , errMsg403InvalidConstructTx
     , errMsg403InvalidValidityBounds
-    , errMsg403MinUTxOValue
     , errMsg403MintOrBurnAssetQuantityOutOfBounds
     , errMsg403MissingWitsInTransaction
     , errMsg403MultiaccountTransaction
@@ -895,7 +895,11 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             (Link.createUnsignedTransaction @'Shelley wa) Default payload
         verify rTx
             [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403MinUTxOValue
+            , expectErrorInfo $ flip shouldSatisfy $ \case
+                UtxoTooSmall ApiErrorTxOutputLovelaceInsufficient {} ->
+                    True
+                _anythingElse ->
+                    False
             ]
 
     it "TRANS_NEW_CREATE_04c - Can't cover fee" $ \ctx -> runResourceT $ do
@@ -1160,7 +1164,11 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             (Link.createUnsignedTransaction @'Shelley wa) Default payload
         verify rTx
             [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403MinUTxOValue
+            , expectErrorInfo $ flip shouldSatisfy $ \case
+                UtxoTooSmall ApiErrorTxOutputLovelaceInsufficient {} ->
+                    True
+                _anythingElse ->
+                    False
             ]
 
     it "TRANS_NEW_ASSETS_CREATE_01c - Multi-asset tx without Ada" $ \ctx -> runResourceT $ do

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -284,6 +284,11 @@ apiError err info = err
     -- 'apiErrorOldDeprecated'.
     message = ApiErrorMessage ""
 
+-- | Old, deprecated way of creating API errors, relying on hand-built error
+--   message strings.
+--
+-- Please use 'apiError' instead.
+--
 apiErrorOldDeprecated :: ServerError -> ApiErrorInfo -> Text -> ServerError
 apiErrorOldDeprecated err info messageUnformatted = err
     { errBody = Aeson.encode ApiError {info, message}

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -613,15 +613,14 @@ instance Write.IsRecentEra era => IsServerError (ErrBalanceTx era) where
                 , "Please sign the transaction after it is balanced instead."
                 ]
         ErrBalanceTxAssetsInsufficient e ->
-            apiErrorOldDeprecated err403 (NotEnoughMoney info) $ mconcat
-                [ "I can't process this payment as there are not "
-                , "enough funds available in the wallet."
-                ]
-              where
-                info = ApiErrorNotEnoughMoney ApiErrorNotEnoughMoneyShortfall
+            apiError err403
+                $ NotEnoughMoney
+                $ ApiErrorNotEnoughMoney
+                $ ApiErrorNotEnoughMoneyShortfall
                     { ada = ApiAmount.fromCoin shortfallAda
                     , assets = ApiWalletAssets.fromTokenMap shortfallAssets
                     }
+              where
                 TokenBundle shortfallAda shortfallAssets =
                     toWalletTokenBundle $ e ^. #shortfall
         ErrBalanceTxAssignRedeemers err -> toServerError err

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -993,22 +993,12 @@ instance IsServerError ErrAddCosignerKey where
                 , "different key to each cosigner."
                 ]
         ErrAddCosignerKey (NoSuchCosigner credType (Cosigner cosignerIndex)) ->
-            let errorInfo = SharedWalletNoSuchCosigner
-                    ApiErrorSharedWalletNoSuchCosigner
-                        { cosignerIndex =
-                            ApiCosignerIndex cosignerIndex
-                        , credentialType =
-                            ApiCredentialType credType
-                        }
-                errorMessage = T.unwords
-                    [ "It looks like you've tried to add a cosigner key to a"
-                    , "shared wallet's"
-                    , toText credType
-                    , "template for a non-existing cosigner index:"
-                    , pretty cosignerIndex
-                    ]
-            in
-            apiErrorOldDeprecated err403 errorInfo errorMessage
+            apiError err403
+                $ SharedWalletNoSuchCosigner
+                $ ApiErrorSharedWalletNoSuchCosigner
+                    { cosignerIndex = ApiCosignerIndex cosignerIndex
+                    , credentialType = ApiCredentialType credType
+                    }
         ErrAddCosignerKey CannotUpdateSharedWalletKey ->
             apiErrorOldDeprecated err403 SharedWalletCannotUpdateKey $ T.unwords
                 [ "It looks like you've tried to update the key of a cosigner"

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/TxCBOR.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/TxCBOR.hs
@@ -20,7 +20,7 @@ import Cardano.Binary
     )
 import Cardano.Wallet.Api.Http.Server.Error
     ( IsServerError (..)
-    , apiError
+    , apiErrorOldDeprecated
     , liftE
     , showT
     )
@@ -102,7 +102,7 @@ newtype ErrParseCBOR = ErrParseCBOR DecoderError
 
 instance IsServerError ErrParseCBOR where
     toServerError (ErrParseCBOR decoderError) =
-        apiError err500 UnexpectedError $ T.unwords
+        apiErrorOldDeprecated err500 UnexpectedError $ T.unwords
             [ "Error while trying to parse a transaction CBOR from the database"
             , showT decoderError
             ]

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -117,7 +117,7 @@ module Cardano.Wallet.Api.Http.Shelley.Server
     -- * Server error responses
     , IsServerError(..)
     , liftHandler
-    , apiError
+    , apiErrorOldDeprecated
 
     -- * Internals
     , mkShelleyWallet
@@ -318,7 +318,7 @@ import Cardano.Wallet.Api
     )
 import Cardano.Wallet.Api.Http.Server.Error
     ( IsServerError (..)
-    , apiError
+    , apiErrorOldDeprecated
     , handler
     , liftE
     , liftHandler
@@ -5373,7 +5373,7 @@ data ErrTemporarilyDisabled = ErrTemporarilyDisabled
 instance IsServerError ErrCurrentEpoch where
     toServerError = \case
         ErrUnableToDetermineCurrentEpoch ->
-            apiError err500 UnableToDetermineCurrentEpoch $ mconcat
+            apiErrorOldDeprecated err500 UnableToDetermineCurrentEpoch $ mconcat
                 [ "I'm unable to determine the current epoch. "
                 , "Please wait a while for the node to sync and try again."
                 ]
@@ -5382,7 +5382,7 @@ instance IsServerError ErrCurrentEpoch where
 instance IsServerError ErrUnexpectedPoolIdPlaceholder where
     toServerError = \case
         ErrUnexpectedPoolIdPlaceholder ->
-            apiError err400 BadRequest $
+            apiErrorOldDeprecated err400 BadRequest $
                 case fromText @PoolId "INVALID" of
                     Left msg -> pretty msg
                     Right _ -> "Invalid pool id placeholder"
@@ -5391,7 +5391,7 @@ instance IsServerError ErrCreateWallet where
     toServerError = \case
         ErrCreateWalletAlreadyExists e -> toServerError e
         ErrCreateWalletFailedToCreateWorker ->
-            apiError err500 UnexpectedError $ mconcat
+            apiErrorOldDeprecated err500 UnexpectedError $ mconcat
                 [ "That's embarrassing. Your wallet looks good, but I couldn't "
                 , "open a new database to store its data. This is unexpected "
                 , "and likely not your fault. Perhaps, check your filesystem's "
@@ -5401,7 +5401,7 @@ instance IsServerError ErrCreateWallet where
 instance IsServerError ErrGetAsset where
     toServerError = \case
         ErrGetAssetNotPresent ->
-            apiError err404 AssetNotPresent $ mconcat
+            apiErrorOldDeprecated err404 AssetNotPresent $ mconcat
                 [ "The requested asset is not associated with this wallet."
                 ]
 


### PR DESCRIPTION
## Notice

**⚠️ This PR is on hold until we find a better solution.**

We've agreed to put this PR on hold for the moment.

Justification:
- we **_do_** wish to preserve a means of returning a human-readable description along with each error that is returned to the user
- the `apiError` function introduced by this PR prevents us from returning a human-readable description together with each error.

## Summary

This PR adjusts our HTTP API layer to:
- **_encourage_** the use of new-style API errors (with rich error info objects); and
- **_discourage_** the use of old-style API errors (with hand-constructed error strings).

It **_forks_** the `apiError` function into two:
- **`apiError`**
  - does **_not_** accept a hand-constructed error string;
  - **_does_** accept an optionally-rich error info object.
- **`apiErrorOldDeprecated`**
  - still allows hand-constructed error strings; but
  - has a name that is suitably obvious at call sites and during PR reviews;
  - has documentation encouraging people to use `apiError` instead.

The idea is that over time, we convert all call sites to use `apiError` instead of `apiErrorOldDeprecated`.

## Rationale

For each type of error `e` that may be returned by our HTTP API, we currently define a human-readable description for `e` in up to **_three_** different places:
1. in our OpenAPI specification
    (`swagger.yaml`)
2. in our server error handling code
    (`Http/Server/Error.hs`)
3. in our integration test suite
    (`Framework/TestData.hs`)

This requires us to maintain multiple sources of truth about what the human-readable description for an error should be.

> Example: `output_token_quantity_exceeds_limit` HTTP API error
>
> 1.  https://github.com/cardano-foundation/cardano-wallet/blob/af1b3b715048b3282e063097786c11490c40c306/specifications/api/swagger.yaml#L4704-L4713
> 2. https://github.com/cardano-foundation/cardano-wallet/blob/af1b3b715048b3282e063097786c11490c40c306/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs#L1013-L1031
> 3. https://github.com/cardano-foundation/cardano-wallet/blob/af1b3b715048b3282e063097786c11490c40c306/lib/integration/framework/Test/Integration/Framework/TestData.hs#L567-L583
>
> In the above example, each of these messages say more or less the same thing: that we have a quantity of some asset that exceeds the upper limit of what can be included in a single output.

## Future Direction

Instead of maintaining these multiple descriptions in different places (giving us multiple sources of truth that must be maintained and kept in sync), this PR moves us towards a future where we can:

- have a single source of truth for what the human-readable description of an error should be.
- locate this human-readable description within the OpenAPI specification.

In principle, it should be possible for a caller to understand any API error by:

1. Looking up the serialised name of the error in the swagger API specification. (For example `utxo_too_small`.)
2. Reading the human-readable description of the error, and its fields.
3. Examining the info object and its fields, which should carry any extra data necessary to interpret the error.

## Examples

### **New-style** error construction
https://github.com/cardano-foundation/cardano-wallet/blob/3314902711accf9030c467eea020c46c02575d23/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs#L935-L946

### **New-style** error deconstruction (integration test)
https://github.com/cardano-foundation/cardano-wallet/blob/3314902711accf9030c467eea020c46c02575d23/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs#L242-L248