### PR TITLE
[ADP-2797] Improve performance of `readWallet`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -87,8 +87,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     ( Hash )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx, TransactionInfo (..), Tx (..), TxMeta (..), TxStatus )
-import Cardano.Wallet.Primitive.Types.Tx.TransactionInfo
-    ( hasStatus )
 import Cardano.Wallet.Read.Eras
     ( EraValue )
 import Cardano.Wallet.Read.Tx.Cardano
@@ -96,7 +94,7 @@ import Cardano.Wallet.Read.Tx.Cardano
 import Cardano.Wallet.Submissions.Submissions
     ( TxStatusMeta (..), txStatus )
 import Cardano.Wallet.Submissions.TxStatus
-    ( _InSubmission )
+    ( _Expired, _InSubmission )
 import Cardano.Wallet.Transaction.Built
     ( BuiltTx )
 import Control.Lens
@@ -501,8 +499,18 @@ mkDBLayerFromParts ti DBLayerCollection{..} = DBLayer
                 inLedgers <- if status `elem` [Nothing, Just WTxMeta.InLedger]
                     then readTxHistory_ dbTxHistory wid range tip limit order
                     else pure []
-                inSubmissionsRaw <- withSubmissions wid [] $ \submissions -> do
-                        pure $ getInSubmissionTransactions submissions
+                let isInSubmission = has (txStatus . _InSubmission)
+                    isExpired = has (txStatus . _Expired)
+                    whichSubmission :: TxSubmissionsStatus -> Bool
+                    whichSubmission = case status of
+                        Nothing -> (||) <$> isInSubmission <*> isExpired
+                        Just WTxMeta.Pending -> isInSubmission
+                        Just WTxMeta.Expired -> isExpired
+                        Just WTxMeta.InLedger -> const False
+                inSubmissionsRaw <- withSubmissions wid [] $
+                        pure
+                            . filter whichSubmission
+                            . getInSubmissionTransactions
                 inSubmissions :: [TransactionInfo] <- fmap catMaybes
                     $ for inSubmissionsRaw $
                         mkTransactionInfo
@@ -513,11 +521,7 @@ mkDBLayerFromParts ti DBLayerCollection{..} = DBLayer
                     . maybe id (take . fromIntegral) limit
                     . sortTransactionsBySlot order
                     . filterMinWithdrawal minWithdrawal
-                    $ inLedgers <> filter (
-                            (||)
-                            <$> hasStatus WTxMeta.Pending
-                            <*> hasStatus WTxMeta.Expired
-                            ) inSubmissions
+                    $ inLedgers <> inSubmissions
             Nothing -> pure []
     , getTx = \wid txid -> wrapNoSuchWallet wid $ do
         readCurrentTip wid >>= \case

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -634,12 +634,11 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = mdo
             updateS (store transactionsQS) Nothing
                 . ExpandTxWalletsHistory wid
 
-        , readTxHistory_ = \wid range status tip mlimit order -> do
+        , readTxHistory_ = \wid range tip mlimit order -> do
             allTransactions <- queryS transactionsQS $ All wid
             let whichMeta DB.TxMeta{..} = and $ catMaybes
                     [ (txMetaSlot >=) <$> W.inclusiveLowerBound range
                     , (txMetaSlot <=) <$> W.inclusiveUpperBound range
-                    , (txMetaStatus ==) <$> status
                     ]
                 reorder = case order of
                   Ascending -> sortOn txMetaSlot

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxMeta.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxMeta.hs
@@ -18,6 +18,7 @@ module Cardano.Wallet.Primitive.Types.Tx.TxMeta
     , Direction (..)
     , WithDirection (..)
     , isPending
+    , isInLedger
     )
     where
 
@@ -124,3 +125,7 @@ instance Buildable a => Buildable (WithDirection a) where
 -- | True if the given metadata refers to a pending transaction
 isPending :: TxMeta -> Bool
 isPending = (== Pending) . (status :: TxMeta -> TxStatus)
+
+-- | True if the given metadata refers to an 'InLedger' transaction
+isInLedger :: TxMeta -> Bool
+isInLedger = (== InLedger) . (status :: TxMeta -> TxStatus)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -136,7 +136,7 @@ import Cardano.Wallet.Primitive.Types.Tx.Tx
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxMeta
-    ( Direction (..), TxMeta (..), TxStatus (..), isPending )
+    ( Direction (..), TxMeta (..), TxStatus (..), isInLedger )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
@@ -294,10 +294,10 @@ instance Arbitrary GenTxHistory where
 
     arbitrary = GenTxHistory . sortTxHistory <$> do
         -- NOTE
-        -- We discard pending transaction from any 'GenTxHistory since,
-        -- inserting a pending transaction actually has an effect on the
-        -- checkpoint's pending transactions of the same wallet.
-        filter (not . isPending . snd) <$> scale (min 25) arbitrary
+        -- We only generate transactions that are `InLedger`
+        -- here, because the pending and expired transactions are
+        -- tracked as part of the WalletState.
+        filter (isInLedger . snd) <$> scale (min 25) arbitrary
       where
         sortTxHistory = filterTxHistory Nothing Descending wholeRange
 


### PR DESCRIPTION
### Overview

This pull request snatches low-hanging fruit that improves the performance of `readWallet`. 🍒 

1. `Cardano.Wallet.readWallet` retrieves the pending transactions by calling `readTransactions` and requesting all transactions with the `Just Pending status`. After separating the submitted transactions (`Pending`, `Expired`) from the transaction history (`InLedger`), we can now skip inspecting the potentially large history of in-ledger transactions.
2. `readTransactions` should filter the submitted transactions before decorating them, as decoration accessed the disk.

### Issue number

ADP-2797