### PR TITLE
Move `estimateKeyWitnessCount` outside `evaluateMinimumFee`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -109,7 +109,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenPolicyId )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessor, TxConstraints, TxSize )
+    ( TokenBundleSizeAssessor, TxConstraints )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
     ( Tx (..), TxMetadata )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
@@ -224,28 +224,6 @@ data TransactionLayer k ktype tx = TransactionLayer
             -- Redeemers for this transaction
         -> Coin
         -- ^ Compute the maximum execution cost of scripts in a given transaction.
-
-    , evaluateMinimumFee
-        :: forall era. Cardano.IsShelleyBasedEra era
-        => Cardano.ProtocolParameters
-            -- Current protocol parameters
-        -> Cardano.UTxO era
-        -> Cardano.Tx era
-            -- The sealed transaction
-        -> Coin
-        -- ^ Evaluate a minimal fee amount necessary to pay for a given tx
-        -- using ledger's functionality
-        --
-        -- Will estimate how many witnesses there /should be/, so it works even
-        -- for unsigned transactions.
-
-    , estimateSignedTxSize
-        :: forall era. Cardano.IsShelleyBasedEra era
-        => Cardano.ProtocolParameters
-        -> Cardano.UTxO era
-        -> Cardano.Tx era
-        -> TxSize
-        -- ^ Estimate the size of the transaction when fully signed.
 
     , distributeSurplus
         :: FeePolicy

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -85,10 +85,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Passphrase.Types
     ( Passphrase )
 import Cardano.Wallet.Primitive.Slotting
-    ( PastHorizonException, TimeInterpreter )
+    ( PastHorizonException )
 import Cardano.Wallet.Primitive.Types
     ( Certificate
-    , FeePolicy
     , ProtocolParameters
     , SlotNo (..)
     , TokenBundleMaxSize (..)
@@ -136,7 +135,6 @@ import GHC.Generics
     ( Generic )
 
 import qualified Cardano.Api as Cardano
-import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Write.Tx as WriteTx
 import qualified Data.Map.Strict as Map
@@ -217,52 +215,6 @@ data TransactionLayer k ktype tx = TransactionLayer
         -- ^ Compute a minimal fee amount necessary to pay for a given selection
         -- This also includes necessary deposits.
 
-    , maxScriptExecutionCost
-        :: ProtocolParameters
-            -- Current protocol parameters
-        -> [Redeemer]
-            -- Redeemers for this transaction
-        -> Coin
-        -- ^ Compute the maximum execution cost of scripts in a given transaction.
-
-    , distributeSurplus
-        :: FeePolicy
-        -> Coin
-        -- Surplus transaction balance to distribute.
-        -> TxFeeAndChange [TxOut]
-        -- Original fee and change outputs.
-        -> Either ErrMoreSurplusNeeded (TxFeeAndChange [TxOut])
-        --
-        -- ^ Distributes a surplus transaction balance between the given change
-        -- outputs and the given fee. This function is aware of the fact that
-        -- any increase in a 'Coin' value could increase the size and fee
-        -- requirement of a transaction.
-        --
-        -- When comparing the original fee and change outputs to the adjusted
-        -- fee and change outputs, this function guarantees that:
-        --
-        --    - The number of the change outputs remains constant;
-        --
-        --    - The fee quantity either remains the same or increases.
-        --
-        --    - For each change output:
-        --        - the ada quantity either remains constant or increases.
-        --        - non-ada quantities remain the same.
-        --
-        --    - The surplus is conserved:
-        --        The total increase in the fee and change ada quantities is
-        --        exactly equal to the surplus.
-        --
-        --    - Any increase in cost is covered:
-        --        If the total cost has increased by 𝛿c, then the fee value
-        --        will have increased by at least 𝛿c.
-        --
-        -- If the cost of distributing the provided surplus is greater than the
-        -- surplus itself, the function will return 'ErrMoreSurplusNeeded'. If
-        -- the provided surplus is greater or equal to
-        -- @maximumCostOfIncreasingCoin feePolicy@, the function will always
-        -- return 'Right'.
-
     , computeSelectionLimit
         :: AnyCardanoEra
         -> ProtocolParameters
@@ -301,18 +253,6 @@ data TransactionLayer k ktype tx = TransactionLayer
         -> TxUpdate
         -> Either ErrUpdateSealedTx (Cardano.Tx era)
         -- ^ Update tx by adding additional inputs and outputs
-
-    , assignScriptRedeemers
-        :: forall era. Cardano.IsShelleyBasedEra era
-        => Cardano.ProtocolParameters
-            -- Current protocol parameters
-        -> TimeInterpreter (Either PastHorizonException)
-        -> Cardano.UTxO era
-        -> [Redeemer]
-            -- A list of redeemers to set on the transaction.
-        -> (Cardano.Tx era)
-            -- Transaction containing scripts
-        -> (Either ErrAssignRedeemers (Cardano.Tx era))
     }
 
 -- | Method to use when updating the fee of a transaction.

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -240,12 +240,14 @@ import Cardano.Wallet.Shelley.Transaction
     , TxWitnessTag (..)
     , TxWitnessTagFor
     , costOfIncreasingCoin
+    , distributeSurplus
     , distributeSurplusDelta
     , estimateKeyWitnessCount
     , estimateSignedTxSize
     , estimateTxCost
     , estimateTxSize
     , evaluateMinimumFee
+    , maxScriptExecutionCost
     , maximumCostOfIncreasingCoin
     , mkByronWitness
     , mkDelegationCertificates
@@ -258,9 +260,7 @@ import Cardano.Wallet.Shelley.Transaction
     , txConstraints
     , updateSealedTx
     , _decodeSealedTx
-    , _distributeSurplus
     , _estimateMaxNumberOfInputs
-    , _maxScriptExecutionCost
     )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
@@ -1293,11 +1293,11 @@ feeCalculationSpec era = describe "fee calculations" $ do
             let rdmrs = replicate (sealedNumberOfRedeemers tx) (error "Redeemer")
             if (null rdmrs) then do
                 it ("without redeemers: " <> filepath) $
-                    _maxScriptExecutionCost ppWithPrices rdmrs
+                    maxScriptExecutionCost ppWithPrices rdmrs
                         `shouldBe` (Coin 0)
             else do
                 it ("with redeemers: " <> filepath) $
-                    _maxScriptExecutionCost ppWithPrices rdmrs
+                    maxScriptExecutionCost ppWithPrices rdmrs
                         `shouldSatisfy` (> (Coin 0))
 
     describe "fee calculations" $ do
@@ -2920,7 +2920,7 @@ prop_distributeSurplus_onSuccess propertyToTest policy txSurplus fc =
     TxFeeAndChange feeOriginal changeOriginal = fc
 
     mResult :: Either ErrMoreSurplusNeeded (TxFeeAndChange [TxOut])
-    mResult = _distributeSurplus policy surplus fc
+    mResult = distributeSurplus policy surplus fc
 
 -- Verifies that the 'distributeSurplus' function conserves the surplus: the
 -- total increase in the fee and change ada quantities should be exactly equal

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -1225,12 +1225,6 @@ dummyTransactionLayer = TransactionLayer
         error "dummyTransactionLayer: mkUnsignedTransaction not implemented"
     , calcMinimumCost =
         error "dummyTransactionLayer: calcMinimumCost not implemented"
-    , maxScriptExecutionCost =
-        error "dummyTransactionLayer: maxScriptExecutionCost not implemented"
-    , assignScriptRedeemers =
-        error "dummyTransactionLayer: assignScriptRedeemers not implemented"
-    , distributeSurplus =
-        error "dummyTransactionLayer: distributeSurplus not implemented"
     , computeSelectionLimit =
         error "dummyTransactionLayer: computeSelectionLimit not implemented"
     , tokenBundleSizeAssessor =

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -1229,13 +1229,8 @@ dummyTransactionLayer = TransactionLayer
         error "dummyTransactionLayer: maxScriptExecutionCost not implemented"
     , assignScriptRedeemers =
         error "dummyTransactionLayer: assignScriptRedeemers not implemented"
-    , evaluateMinimumFee =
-        error "dummyTransactionLayer: evaluateMinimumFee not implemented"
     , distributeSurplus =
         error "dummyTransactionLayer: distributeSurplus not implemented"
-    , estimateSignedTxSize =
-        error "dummyTransactionLayer: \
-              \estimateSignedTxSize not implemented"
     , computeSelectionLimit =
         error "dummyTransactionLayer: computeSelectionLimit not implemented"
     , tokenBundleSizeAssessor =


### PR DESCRIPTION
- [x] Don't call `estimateKeyWitnessCount` inside of functions like `evaluateMinimumFee` or `estimateSignedTxSize`. Leave it to the caller, as there is no one correct key witness count estimation (not with timelock script inputs, at least).
- [x] **Extra:** Move balanceTx dependencies out of the `TransactionLayer`. They were previously there because of the `core/shelley` package split.
    - To minimise conflicts I didn't move the functions from `Cardano.Wallet.Transactions.Shelley` to the `Cardano.Wallet.Write.Tx` hierarchy. I imagine we'll potentially do that as part of https://input-output.atlassian.net/browse/ADP-2459
    - Reviewing per-commit may be helpful

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2268 / ADP-2613
