### PR TITLE
Support bootstrap/byron witnesses in `evaluateMinimumFee`

### DIFF
--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -76,7 +76,6 @@ module Test.QuickCheck.Extra
     , ScaleDiv (..)
     , ScaleMod (..)
 
-
       -- * Utilities
     , interleaveRoundRobin
 

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -65,6 +65,9 @@ module Test.QuickCheck.Extra
     , report
     , verify
 
+      -- * Expectations
+    , (.>=.)
+
       -- * Pretty-printing
     , Pretty (..)
 
@@ -72,6 +75,7 @@ module Test.QuickCheck.Extra
     , NotNull (..)
     , ScaleDiv (..)
     , ScaleMod (..)
+
 
       -- * Utilities
     , interleaveRoundRobin
@@ -641,6 +645,14 @@ verify condition conditionTitle =
     (.&&.) (counterexample counterexampleText $ property condition)
   where
     counterexampleText = "Condition violated: " <> conditionTitle
+
+--------------------------------------------------------------------------------
+-- Expectations
+--------------------------------------------------------------------------------
+
+(.>=.) :: (Show a, Ord a) => a -> a -> Property
+a .>=. b = counterexample (show a <> " < " <> show b)
+    $ property $ a >= b
 
 --------------------------------------------------------------------------------
 -- Pretty-printing

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1009,7 +1009,6 @@ evaluateMinimumFee pp (KeyWitnessCount nWits nBootWits) body =
         bytes :: Natural
         bytes = fromIntegral $ sizeOf_BootstrapWitnesses $ intCast nBootWits
 
-
 -- | Estimate the size of the transaction (body) when fully signed.
 estimateSignedTxSize
     :: Cardano.IsShelleyBasedEra era

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -23,6 +23,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 {- HLINT ignore "Use <$>" -}
+{- HLINT ignore "Use camelCase" -}
 
 -- |
 -- Copyright: © 2020 IOHK
@@ -68,6 +69,7 @@ module Cardano.Wallet.Shelley.Transaction
     , mkTxSkeleton
     , mkUnsignedTx
     , txConstraints
+    , sizeOf_BootstrapWitnesses
     ) where
 
 import Prelude
@@ -997,14 +999,16 @@ evaluateMinimumFee
     -> Coin
 evaluateMinimumFee pp (KeyWitnessCount nWits nBootWits) body =
     fromCardanoLovelace (Cardano.evaluateTransactionFee pp body nWits 0)
-    <> bootWitFees
-  where
+        <> bootWitFees
     -- NOTE: Cardano.evaluateTransactionFee will error if passed non-zero
     -- nBootWits, so we need to account for it separately.
-    bootWitFees =
-        if nBootWits > 0
-        then error "evaluateMinimumFee: bootstrap wits not yet supported"
-        else mempty
+  where
+    bootWitFees = Coin.fromNatural $
+        Cardano.protocolParamTxFeePerByte pp * bytes
+      where
+        bytes :: Natural
+        bytes = fromIntegral $ sizeOf_BootstrapWitnesses $ intCast nBootWits
+
 
 -- | Estimate the size of the transaction (body) when fully signed.
 estimateSignedTxSize
@@ -2257,7 +2261,7 @@ estimateTxSize era skeleton =
         + sizeOf_VKeyWitnesses
         + sizeOf_NativeScripts txMintOrBurnScripts
         + maybe 0 (determinePaymentTemplateSize txMintOrBurnScripts) txPaymentTemplate
-        + sizeOf_BootstrapWitnesses
+        + sizeOf_BootstrapWitnesses numberOf_BootstrapWitnesses
       where
         -- ?0 => [* vkeywitness ]
         sizeOf_VKeyWitnesses
@@ -2268,117 +2272,134 @@ estimateTxSize era skeleton =
         -- ?1 => [* native_script ]
 
         -- ?2 => [* bootstrap_witness ]
-        sizeOf_BootstrapWitnesses
-            = (if numberOf_BootstrapWitnesses > 0
-                then sizeOf_Array + sizeOf_SmallUInt
-                else 0)
-            + sizeOf_BootstrapWitness * numberOf_BootstrapWitnesses
+sizeOf_BootstrapWitnesses :: Integer -> Integer
+sizeOf_BootstrapWitnesses n
+    = (if n > 0
+        then sizeOf_Array + sizeOf_SmallUInt
+        else 0)
+    + sizeOf_BootstrapWitness * n
 
-    -- vkeywitness =
-    --  [ $vkey
-    --  , $signature
-    --  ]
-    sizeOf_VKeyWitness
-        = sizeOf_SmallArray
-        + sizeOf_VKey
-        + sizeOf_Signature
+-- vkeywitness =
+--  [ $vkey
+--  , $signature
+--  ]
+sizeOf_VKeyWitness :: Integer
+sizeOf_VKeyWitness
+    = sizeOf_SmallArray
+    + sizeOf_VKey
+    + sizeOf_Signature
 
-    -- bootstrap_witness =
-    --  [ public_key : $vkey
-    --  , signature  : $signature
-    --  , chain_code : bytes .size 32
-    --  , attributes : bytes
-    --  ]
-    sizeOf_BootstrapWitness
-        = sizeOf_SmallArray
-        + sizeOf_VKey
-        + sizeOf_Signature
-        + sizeOf_ChainCode
-        + sizeOf_Attributes
-      where
-        sizeOf_ChainCode  = 34
-        sizeOf_Attributes = 45 -- NOTE: could be smaller by ~34 for Icarus
+-- bootstrap_witness =
+--  [ public_key : $vkey
+--  , signature  : $signature
+--  , chain_code : bytes .size 32
+--  , attributes : bytes
+--  ]
+sizeOf_BootstrapWitness :: Integer
+sizeOf_BootstrapWitness
+    = sizeOf_SmallArray
+    + sizeOf_VKey
+    + sizeOf_Signature
+    + sizeOf_ChainCode
+    + sizeOf_Attributes
+  where
+    sizeOf_ChainCode  = 34
+    sizeOf_Attributes = 45 -- NOTE: could be smaller by ~34 for Icarus
 
-    -- native_script =
-    --   [ script_pubkey      = (0, addr_keyhash)
-    --   // script_all        = (1, [ * native_script ])
-    --   // script_any        = (2, [ * native_script ])
-    --   // script_n_of_k     = (3, n: uint, [ * native_script ])
-    --   // invalid_before    = (4, uint)
-    --      ; Timelock validity intervals are half-open intervals [a, b).
-    --      ; This field specifies the left (included) endpoint a.
-    --   // invalid_hereafter = (5, uint)
-    --      ; Timelock validity intervals are half-open intervals [a, b).
-    --      ; This field specifies the right (excluded) endpoint b.
-    --   ]
-    sizeOf_NativeScript :: Script object -> Integer
-    sizeOf_NativeScript = \case
-        RequireSignatureOf _ ->
-            sizeOf_SmallUInt + sizeOf_Hash28
-        RequireAllOf ss ->
-            sizeOf_SmallUInt + sizeOf_Array + sumVia sizeOf_NativeScript ss
-        RequireAnyOf ss ->
-            sizeOf_SmallUInt + sizeOf_Array + sumVia sizeOf_NativeScript ss
-        RequireSomeOf _ ss ->
-            sizeOf_SmallUInt
-                + sizeOf_UInt
-                + sizeOf_Array
-                + sumVia sizeOf_NativeScript ss
-        ActiveFromSlot _ ->
-            sizeOf_SmallUInt + sizeOf_UInt
-        ActiveUntilSlot _ ->
-            sizeOf_SmallUInt + sizeOf_UInt
+-- native_script =
+--   [ script_pubkey      = (0, addr_keyhash)
+--   // script_all        = (1, [ * native_script ])
+--   // script_any        = (2, [ * native_script ])
+--   // script_n_of_k     = (3, n: uint, [ * native_script ])
+--   // invalid_before    = (4, uint)
+--      ; Timelock validity intervals are half-open intervals [a, b).
+--      ; This field specifies the left (included) endpoint a.
+--   // invalid_hereafter = (5, uint)
+--      ; Timelock validity intervals are half-open intervals [a, b).
+--      ; This field specifies the right (excluded) endpoint b.
+--   ]
+sizeOf_NativeScript :: Script object -> Integer
+sizeOf_NativeScript = \case
+    RequireSignatureOf _ ->
+        sizeOf_SmallUInt + sizeOf_Hash28
+    RequireAllOf ss ->
+        sizeOf_SmallUInt + sizeOf_Array + sumVia sizeOf_NativeScript ss
+    RequireAnyOf ss ->
+        sizeOf_SmallUInt + sizeOf_Array + sumVia sizeOf_NativeScript ss
+    RequireSomeOf _ ss ->
+        sizeOf_SmallUInt
+            + sizeOf_UInt
+            + sizeOf_Array
+            + sumVia sizeOf_NativeScript ss
+    ActiveFromSlot _ ->
+        sizeOf_SmallUInt + sizeOf_UInt
+    ActiveUntilSlot _ ->
+        sizeOf_SmallUInt + sizeOf_UInt
 
-    -- A Blake2b-224 hash, resulting in a 28-byte digest wrapped in CBOR, so
-    -- with 2 bytes overhead (length <255, but length > 23)
-    sizeOf_Hash28
-        = 30
+-- A Blake2b-224 hash, resulting in a 28-byte digest wrapped in CBOR, so
+-- with 2 bytes overhead (length <255, but length > 23)
+sizeOf_Hash28 :: Integer
+sizeOf_Hash28
+    = 30
 
-    -- A Blake2b-256 hash, resulting in a 32-byte digest wrapped in CBOR, so
-    -- with 2 bytes overhead (length <255, but length > 23)
-    sizeOf_Hash32
-        = 34
+-- A Blake2b-256 hash, resulting in a 32-byte digest wrapped in CBOR, so
+-- with 2 bytes overhead (length <255, but length > 23)
+sizeOf_Hash32 :: Integer
+sizeOf_Hash32
+    = 34
 
-    -- A 32-byte Ed25519 public key, encoded as a CBOR-bytestring so with 2
-    -- bytes overhead (length < 255, but length > 23)
-    sizeOf_VKey
-        = 34
+-- A 32-byte Ed25519 public key, encoded as a CBOR-bytestring so with 2
+-- bytes overhead (length < 255, but length > 23)
+sizeOf_VKey :: Integer
+sizeOf_VKey
+    = 34
 
-    -- A 64-byte Ed25519 signature, encoded as a CBOR-bytestring so with 2
-    -- bytes overhead (length < 255, but length > 23)
-    sizeOf_Signature
-        = 66
+-- A 64-byte Ed25519 signature, encoded as a CBOR-bytestring so with 2
+-- bytes overhead (length < 255, but length > 23)
+sizeOf_Signature :: Integer
+sizeOf_Signature
+    = 66
 
-    -- A CBOR UInt which is less than 23 in value fits on a single byte. Beyond,
-    -- the first byte is used to encode the number of bytes necessary to encode
-    -- the number itself, followed by the number itself.
-    --
-    -- When considering a 'UInt', we consider the worst case scenario only where
-    -- the uint is encoded over 4 bytes, so up to 2^32 which is fine for most
-    -- cases but coin values.
-    sizeOf_SmallUInt = 1
-    sizeOf_UInt = 5
-    sizeOf_LargeUInt = 9
+-- A CBOR UInt which is less than 23 in value fits on a single byte. Beyond,
+-- the first byte is used to encode the number of bytes necessary to encode
+-- the number itself, followed by the number itself.
+--
+-- When considering a 'UInt', we consider the worst case scenario only where
+-- the uint is encoded over 4 bytes, so up to 2^32 which is fine for most
+-- cases but coin values.
+sizeOf_SmallUInt :: Integer
+sizeOf_SmallUInt = 1
 
-    -- A CBOR Int which is less than 23 in value fits on a single byte. Beyond,
-    -- the first byte is used to encode the number of bytes necessary to encode
-    -- the number, followed by the number itself. In this case, 8 bytes are used
-    -- to encode an int64, plus one byte to encode the number of bytes
-    -- necessary.
-    sizeOf_Int64 = 9
+sizeOf_UInt :: Integer
+sizeOf_UInt = 5
 
-    -- A CBOR array with less than 23 elements, fits on a single byte, followed
-    -- by each key-value pair (encoded as two concatenated CBOR elements).
-    sizeOf_SmallMap = 1
+sizeOf_LargeUInt :: Integer
+sizeOf_LargeUInt = 9
 
-    -- A CBOR array with less than 23 elements, fits on a single byte, followed
-    -- by each elements. Otherwise, the length of the array is encoded first,
-    -- very much like for UInt.
-    --
-    -- When considering an 'Array', we consider large scenarios where arrays can
-    -- have up to 65536 elements.
-    sizeOf_SmallArray = 1
-    sizeOf_Array = 3
+-- A CBOR Int which is less than 23 in value fits on a single byte. Beyond,
+-- the first byte is used to encode the number of bytes necessary to encode
+-- the number, followed by the number itself. In this case, 8 bytes are used
+-- to encode an int64, plus one byte to encode the number of bytes
+-- necessary.
+sizeOf_Int64 :: Integer
+sizeOf_Int64 = 9
+
+-- A CBOR array with less than 23 elements, fits on a single byte, followed
+-- by each key-value pair (encoded as two concatenated CBOR elements).
+sizeOf_SmallMap :: Integer
+sizeOf_SmallMap = 1
+
+-- A CBOR array with less than 23 elements, fits on a single byte, followed
+-- by each elements. Otherwise, the length of the array is encoded first,
+-- very much like for UInt.
+--
+-- When considering an 'Array', we consider large scenarios where arrays can
+-- have up to 65536 elements.
+sizeOf_SmallArray :: Integer
+sizeOf_SmallArray = 1
+
+sizeOf_Array :: Integer
+sizeOf_Array = 3
 
 -- Small helper function for summing values. Given a list of values, get the sum
 -- of the values, after the given function has been applied to each value.

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -138,35 +138,62 @@ module Cardano.Wallet.Write.Tx
 
 import Prelude
 
-import Cardano.Api ( AlonzoEra, BabbageEra, ConwayEra )
-import Cardano.Api.Shelley ( ShelleyLedgerEra )
-import Cardano.Crypto.Hash ( Hash (UnsafeHash) )
-import Cardano.Ledger.Alonzo.Data ( BinaryData, Datum (..) )
-import Cardano.Ledger.Alonzo.Scripts ( AlonzoScript (..) )
-import Cardano.Ledger.BaseTypes ( maybeToStrictMaybe )
-import Cardano.Ledger.Coin ( Coin (..) )
-import Cardano.Ledger.Crypto ( StandardCrypto )
-import Cardano.Ledger.Era ( Crypto )
-import Cardano.Ledger.Mary ( MaryValue )
-import Cardano.Ledger.SafeHash ( SafeHash, extractHash, unsafeMakeSafeHash )
-import Cardano.Ledger.Serialization ( Sized (..), mkSized )
-import Cardano.Ledger.Shelley.API ( CLI (evaluateMinLovelaceOutput) )
-import Cardano.Ledger.Val ( coin, modifyCoin )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints ( txOutMaxCoin )
-import Cardano.Wallet.Shelley.Compatibility.Ledger ( toLedger )
-import Control.Monad ( forM )
-import Data.ByteString ( ByteString )
-import Data.ByteString.Short ( toShort )
-import Data.Coerce ( coerce )
-import Data.Foldable ( toList )
-import Data.Generics.Internal.VL.Lens ( (^.) )
+import Cardano.Api
+    ( AlonzoEra, BabbageEra, ConwayEra )
+import Cardano.Api.Shelley
+    ( ShelleyLedgerEra )
+import Cardano.Crypto.Hash
+    ( Hash (UnsafeHash) )
+import Cardano.Ledger.Alonzo.Data
+    ( BinaryData, Datum (..) )
+import Cardano.Ledger.Alonzo.Scripts
+    ( AlonzoScript (..) )
+import Cardano.Ledger.BaseTypes
+    ( maybeToStrictMaybe )
+import Cardano.Ledger.Coin
+    ( Coin (..) )
+import Cardano.Ledger.Crypto
+    ( StandardCrypto )
+import Cardano.Ledger.Era
+    ( Crypto )
+import Cardano.Ledger.Mary
+    ( MaryValue )
+import Cardano.Ledger.SafeHash
+    ( SafeHash, extractHash, unsafeMakeSafeHash )
+import Cardano.Ledger.Serialization
+    ( Sized (..), mkSized )
+import Cardano.Ledger.Shelley.API
+    ( CLI (evaluateMinLovelaceOutput) )
+import Cardano.Ledger.Val
+    ( coin, modifyCoin )
+import Cardano.Wallet.Primitive.Types.Tx.Constraints
+    ( txOutMaxCoin )
+import Cardano.Wallet.Shelley.Compatibility.Ledger
+    ( toLedger )
+import Control.Monad
+    ( forM )
+import Data.ByteString
+    ( ByteString )
+import Data.ByteString.Short
+    ( toShort )
+import Data.Coerce
+    ( coerce )
+import Data.Foldable
+    ( toList )
+import Data.Generics.Internal.VL.Lens
+    ( (^.) )
 import Data.Generics.Labels
     ()
-import Data.IntCast ( intCast )
-import Data.Maybe ( fromMaybe )
-import Data.Maybe.Strict ( StrictMaybe (..) )
-import Data.Typeable ( Typeable )
-import Numeric.Natural ( Natural )
+import Data.IntCast
+    ( intCast )
+import Data.Maybe
+    ( fromMaybe )
+import Data.Maybe.Strict
+    ( StrictMaybe (..) )
+import Data.Typeable
+    ( Typeable )
+import Numeric.Natural
+    ( Natural )
 import Ouroboros.Consensus.Shelley.Eras
     ( StandardAlonzo, StandardBabbage, StandardConway )
 
@@ -783,10 +810,7 @@ modifyLedgerBody f (Cardano.Tx body keyWits) = Cardano.Tx body' keyWits
                         auxData
                         validity
 
-
-emptyTx
-    :: RecentEra era
-    -> Core.Tx (ShelleyLedgerEra era)
+emptyTx :: RecentEra era -> Core.Tx (ShelleyLedgerEra era)
 emptyTx RecentEraConway = Core.mkBasicTx Core.mkBasicTxBody
 emptyTx RecentEraBabbage = Core.mkBasicTx Core.mkBasicTxBody
 emptyTx RecentEraAlonzo = Core.mkBasicTx Core.mkBasicTxBody
@@ -811,6 +835,7 @@ toCardanoTx
     => Core.Tx (Cardano.ShelleyLedgerEra era)
     -> Cardano.Tx era
 toCardanoTx = Cardano.ShelleyTx (shelleyBasedEraFromRecentEra $ recentEra @era)
+
 -- | NOTE: The roundtrip
 -- @
 --     toCardanoUTxO . fromCardanoUTxO

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -148,12 +148,9 @@ import Cardano.Ledger.Coin ( Coin (..) )
 import Cardano.Ledger.Crypto ( StandardCrypto )
 import Cardano.Ledger.Era ( Crypto )
 import Cardano.Ledger.Mary ( MaryValue )
-
-import Cardano.Ledger.Core ( EraTx (mkBasicTx) )
 import Cardano.Ledger.SafeHash ( SafeHash, extractHash, unsafeMakeSafeHash )
 import Cardano.Ledger.Serialization ( Sized (..), mkSized )
-import Cardano.Ledger.Shelley.API ( CLI (evaluateMinLovelaceOutput), Wdrl (..) )
-import Cardano.Ledger.ShelleyMA.TxBody ( ValidityInterval (ValidityInterval) )
+import Cardano.Ledger.Shelley.API ( CLI (evaluateMinLovelaceOutput) )
 import Cardano.Ledger.Val ( coin, modifyCoin )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints ( txOutMaxCoin )
 import Cardano.Wallet.Shelley.Compatibility.Ledger ( toLedger )
@@ -814,8 +811,6 @@ toCardanoTx
     => Core.Tx (Cardano.ShelleyLedgerEra era)
     -> Cardano.Tx era
 toCardanoTx = Cardano.ShelleyTx (shelleyBasedEraFromRecentEra $ recentEra @era)
-
-
 -- | NOTE: The roundtrip
 -- @
 --     toCardanoUTxO . fromCardanoUTxO
@@ -879,10 +874,10 @@ evaluateMinimumFee era pp tx kwc =
 
     bootWitnessFee :: Coin
     bootWitnessFee = Coin $
-        intCast $ feePerByte * bytes
+        intCast $ feePerByte * byteCount
       where
-        bytes :: Natural
-        bytes = sizeOf_BootstrapWitnesses $ intCast nBootstrapWits
+        byteCount :: Natural
+        byteCount = sizeOf_BootstrapWitnesses $ intCast nBootstrapWits
 
         -- Matching implementation in "Cardano.Wallet.Shelley.Transaction".
         -- Equivalence is tested in property.

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -4158,7 +4158,7 @@ prop_bootstrapWitnesses
         -- Start incrementing the ixs upward, and if we reach 'maxBound', loop
         -- around, to ensure we always have 'n' unique indices.
         addrIxs = take (fromIntegral n)
-            $ [addr0Ix .. maxBound] ++ [minBound .. addr0Ix]
+            $ [addr0Ix .. maxBound] ++ filter (< addr0Ix) [minBound .. addr0Ix]
         body = emptyCardanoTxBody
         wits :: [Cardano.KeyWitness era]
         wits = map (dummyWitForIx body) addrIxs

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -52,7 +52,8 @@ import Cardano.Api
     , ShelleyBasedEra (..)
     , TxOutValue (TxOutAdaOnly, TxOutValue)
     )
-import Cardano.Api.Extra ( asAnyShelleyBasedEra, withShelleyBasedTx )
+import Cardano.Api.Extra
+    ( asAnyShelleyBasedEra, withShelleyBasedTx )
 import Cardano.Api.Gen
     ( genAddressInEra
     , genEncodingBoundaryLovelace
@@ -66,18 +67,26 @@ import Cardano.Api.Gen
     , genValueForTxOut
     , genWitnesses
     )
-import Cardano.Binary ( FromCBOR, ToCBOR, serialize', unsafeDeserialize' )
-import Cardano.BM.Data.Tracer ( nullTracer )
-import Cardano.Ledger.Alonzo.Genesis ( AlonzoGenesis (costmdls) )
-import Cardano.Ledger.Alonzo.TxInfo ( TranslationError (..) )
-import Cardano.Ledger.Era ( Era )
-import Cardano.Ledger.Shelley.API ( StrictMaybe (SJust, SNothing), Wdrl (..) )
+import Cardano.Binary
+    ( FromCBOR, ToCBOR, serialize', unsafeDeserialize' )
+import Cardano.BM.Data.Tracer
+    ( nullTracer )
+import Cardano.Ledger.Alonzo.Genesis
+    ( AlonzoGenesis (costmdls) )
+import Cardano.Ledger.Alonzo.TxInfo
+    ( TranslationError (..) )
+import Cardano.Ledger.Era
+    ( Era )
+import Cardano.Ledger.Shelley.API
+    ( StrictMaybe (SJust, SNothing), Wdrl (..) )
 import Cardano.Ledger.ShelleyMA.Timelocks
     ( ValidityInterval (ValidityInterval) )
 import Cardano.Mnemonic
     ( SomeMnemonic (SomeMnemonic), entropyToMnemonic, mkEntropy )
-import Cardano.Numeric.Util ( power )
-import Cardano.Pool.Types ( PoolId (..) )
+import Cardano.Numeric.Util
+    ( power )
+import Cardano.Pool.Types
+    ( PoolId (..) )
 import Cardano.Tx.Balance.Internal.CoinSelection
     ( SelectionBalanceError (..)
     , SelectionError (..)
@@ -97,8 +106,10 @@ import Cardano.Wallet
     , defaultChangeAddressGen
     , signTransaction
     )
-import Cardano.Wallet.Byron.Compatibility ( maryTokenBundleMaxSize )
-import Cardano.Wallet.Gen ( genMnemonic, genScript )
+import Cardano.Wallet.Byron.Compatibility
+    ( maryTokenBundleMaxSize )
+import Cardano.Wallet.Gen
+    ( genMnemonic, genScript )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DelegationAddress (delegationAddress)
     , Depth (..)
@@ -114,8 +125,10 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , paymentAddress
     , publicKey
     )
-import Cardano.Wallet.Primitive.AddressDerivation.Byron ( ByronKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus ( IcarusKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Byron
+    ( ByronKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Icarus
+    ( IcarusKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey, generateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
@@ -127,7 +140,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( estimateMaxWitnessRequiredPerInput )
-import Cardano.Wallet.Primitive.Model ( Wallet (..), unsafeInitWallet )
+import Cardano.Wallet.Primitive.Model
+    ( Wallet (..), unsafeInitWallet )
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase (..)
     , PassphraseMaxLength (..)
@@ -160,19 +174,24 @@ import Cardano.Wallet.Primitive.Types
     , TxParameters (..)
     , getGenesisBlockDate
     )
-import Cardano.Wallet.Primitive.Types.Address ( Address (..) )
-import Cardano.Wallet.Primitive.Types.Coin ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoin, genCoinPositive, shrinkCoin, shrinkCoinPositive )
-import Cardano.Wallet.Primitive.Types.Hash ( Hash (..), mockHash )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..), mockHash )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO
     ( minimumUTxOForShelleyBasedEra )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
     ( testParameter_coinsPerUTxOByte_Babbage
     , testParameter_coinsPerUTxOWord_Alonzo
     )
-import Cardano.Wallet.Primitive.Types.Redeemer ( Redeemer (..) )
-import Cardano.Wallet.Primitive.Types.RewardAccount ( RewardAccount (..) )
+import Cardano.Wallet.Primitive.Types.Redeemer
+    ( Redeemer (..) )
+import Cardano.Wallet.Primitive.Types.RewardAccount
+    ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( AssetId, TokenBundle, tokenName )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
@@ -198,14 +217,22 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxConstraints (..), TxSize (..) )
-import Cardano.Wallet.Primitive.Types.Tx.TxIn ( TxIn (..) )
-import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen ( genTxIn )
-import Cardano.Wallet.Primitive.Types.Tx.TxOut ( TxOut (..) )
-import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen ( genTxOutTokenBundle )
-import Cardano.Wallet.Primitive.Types.UTxO ( UTxO (..) )
-import Cardano.Wallet.Primitive.Types.UTxOIndex ( UTxOIndex )
-import Cardano.Wallet.Read.Primitive.Tx.Features.Integrity ( txIntegrity )
-import Cardano.Wallet.Read.Tx.Cardano ( fromCardanoApiTx )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
+    ( genTxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
+    ( genTxOutTokenBundle )
+import Cardano.Wallet.Primitive.Types.UTxO
+    ( UTxO (..) )
+import Cardano.Wallet.Primitive.Types.UTxOIndex
+    ( UTxOIndex )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Integrity
+    ( txIntegrity )
+import Cardano.Wallet.Read.Tx.Cardano
+    ( fromCardanoApiTx )
 import Cardano.Wallet.Shelley.Compatibility
     ( computeTokenBundleSerializedLengthBytes
     , fromCardanoLovelace
@@ -223,8 +250,6 @@ import Cardano.Wallet.Shelley.Transaction
     , TxUpdate (..)
     , TxWitnessTag (..)
     , TxWitnessTagFor
-    , _decodeSealedTx
-    , _estimateMaxNumberOfInputs
     , costOfIncreasingCoin
     , distributeSurplus
     , distributeSurplusDelta
@@ -246,6 +271,8 @@ import Cardano.Wallet.Shelley.Transaction
     , sizeOf_BootstrapWitnesses
     , txConstraints
     , updateSealedTx
+    , _decodeSealedTx
+    , _estimateMaxNumberOfInputs
     )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
@@ -259,7 +286,8 @@ import Cardano.Wallet.Transaction
     , WitnessCountCtx (..)
     , defaultTransactionCtx
     )
-import Cardano.Wallet.Unsafe ( unsafeFromHex )
+import Cardano.Wallet.Unsafe
+    ( unsafeFromHex )
 import Cardano.Wallet.Write.Tx
     ( AnyRecentEra (..)
     , RecentEra (..)
@@ -275,8 +303,10 @@ import Cardano.Wallet.Write.Tx.Balance
     , balanceTransaction
     , posAndNegFromCardanoValue
     )
-import Control.Arrow ( first )
-import Control.Monad ( forM, forM_, replicateM )
+import Control.Arrow
+    ( first )
+import Control.Monad
+    ( forM, forM_, replicateM )
 import Control.Monad.Random
     ( MonadRandom (..)
     , Rand
@@ -285,45 +315,82 @@ import Control.Monad.Random
     , random
     , randoms
     )
-import Control.Monad.Random.Strict ( StdGen )
-import Control.Monad.Trans.Except ( except, runExceptT )
-import Control.Monad.Trans.State.Strict ( evalState, state )
-import Crypto.Hash.Utils ( blake2b224 )
-import Data.ByteArray.Encoding ( Base (..), convertToBase )
-import Data.ByteString ( ByteString )
-import Data.Default ( Default (..) )
-import Data.Either ( isLeft, isRight )
-import Data.Function ( on, (&) )
-import Data.Functor.Identity ( Identity, runIdentity )
-import Data.Generics.Internal.VL.Lens ( over, view )
-import Data.Generics.Product ( setField )
-import Data.IntCast ( intCast )
-import Data.List ( isSuffixOf, nub )
-import Data.List.NonEmpty ( NonEmpty (..) )
-import Data.Map.Strict ( Map )
-import Data.Maybe ( fromJust, fromMaybe, isJust )
-import Data.Ord ( comparing )
-import Data.Proxy ( Proxy (..) )
-import Data.Quantity ( Quantity (..) )
-import Data.Ratio ( (%) )
-import Data.Semigroup ( Sum (Sum), getSum, mtimesDefault )
-import Data.Set ( Set )
-import Data.Text ( Text )
-import Data.Time.Clock.POSIX ( posixSecondsToUTCTime )
-import Data.Typeable ( Typeable, typeRep )
-import Data.Word ( Word16, Word64, Word8 )
-import Fmt ( Buildable (..), blockListF', fmt, nameF, pretty, (+||), (||+) )
-import Numeric.Natural ( Natural )
+import Control.Monad.Random.Strict
+    ( StdGen )
+import Control.Monad.Trans.Except
+    ( except, runExceptT )
+import Control.Monad.Trans.State.Strict
+    ( evalState, state )
+import Crypto.Hash.Utils
+    ( blake2b224 )
+import Data.ByteArray.Encoding
+    ( Base (..), convertToBase )
+import Data.ByteString
+    ( ByteString )
+import Data.Default
+    ( Default (..) )
+import Data.Either
+    ( isLeft, isRight )
+import Data.Function
+    ( on, (&) )
+import Data.Functor.Identity
+    ( Identity, runIdentity )
+import Data.Generics.Internal.VL.Lens
+    ( over, view )
+import Data.Generics.Product
+    ( setField )
+import Data.IntCast
+    ( intCast )
+import Data.List
+    ( isSuffixOf, nub )
+import Data.List.NonEmpty
+    ( NonEmpty (..) )
+import Data.Map.Strict
+    ( Map )
+import Data.Maybe
+    ( fromJust, fromMaybe, isJust )
+import Data.Ord
+    ( comparing )
+import Data.Proxy
+    ( Proxy (..) )
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Ratio
+    ( (%) )
+import Data.Semigroup
+    ( Sum (Sum), getSum, mtimesDefault )
+import Data.Set
+    ( Set )
+import Data.Text
+    ( Text )
+import Data.Time.Clock.POSIX
+    ( posixSecondsToUTCTime )
+import Data.Typeable
+    ( Typeable, typeRep )
+import Data.Word
+    ( Word16, Word64, Word8 )
+import Fmt
+    ( Buildable (..), blockListF', fmt, nameF, pretty, (+||), (||+) )
+import Numeric.Natural
+    ( Natural )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
     ( RelativeTime (..), mkSlotLength )
-import Ouroboros.Consensus.Config ( SecurityParam (..) )
-import Ouroboros.Consensus.Shelley.Eras ( StandardBabbage )
-import Ouroboros.Consensus.Util.Counting ( exactlyOne )
-import Ouroboros.Network.Block ( SlotNo (..) )
-import System.Directory ( listDirectory )
-import System.FilePath ( takeExtension, (</>) )
-import System.IO.Unsafe ( unsafePerformIO )
-import System.Random.StdGenSeed ( StdGenSeed (..), stdGenFromSeed )
+import Ouroboros.Consensus.Config
+    ( SecurityParam (..) )
+import Ouroboros.Consensus.Shelley.Eras
+    ( StandardBabbage )
+import Ouroboros.Consensus.Util.Counting
+    ( exactlyOne )
+import Ouroboros.Network.Block
+    ( SlotNo (..) )
+import System.Directory
+    ( listDirectory )
+import System.FilePath
+    ( takeExtension, (</>) )
+import System.IO.Unsafe
+    ( unsafePerformIO )
+import System.Random.StdGenSeed
+    ( StdGenSeed (..), stdGenFromSeed )
 import Test.Hspec
     ( Spec
     , SpecWith
@@ -335,9 +402,12 @@ import Test.Hspec
     , shouldBe
     , shouldSatisfy
     )
-import Test.Hspec.Core.Spec ( SpecM )
-import Test.Hspec.Golden ( Golden (..) )
-import Test.Hspec.QuickCheck ( prop )
+import Test.Hspec.Core.Spec
+    ( SpecM )
+import Test.Hspec.Golden
+    ( Golden (..) )
+import Test.Hspec.QuickCheck
+    ( prop )
 import Test.QuickCheck
     ( Arbitrary (..)
     , Blind (..)
@@ -385,10 +455,14 @@ import Test.QuickCheck.Extra
     , shrinkNonEmpty
     , (.>=.)
     )
-import Test.QuickCheck.Gen ( Gen (..), listOf1 )
-import Test.QuickCheck.Random ( QCGen, mkQCGen )
-import Test.Utils.Paths ( getTestData )
-import Test.Utils.Pretty ( Pretty (..), (====) )
+import Test.QuickCheck.Gen
+    ( Gen (..), listOf1 )
+import Test.QuickCheck.Random
+    ( QCGen, mkQCGen )
+import Test.Utils.Paths
+    ( getTestData )
+import Test.Utils.Pretty
+    ( Pretty (..), (====) )
 
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Gen as Cardano
@@ -2396,14 +2470,14 @@ balanceTransactionSpec = describe "balanceTransaction" $ do
         $ property prop_balanceTransactionValid
 
     describe "bootstrap witnesses" $ do
-        -- Used in 'estimateTxSize' in turn used by coin-selection
+        -- Used in 'estimateTxSize', and in turn used by coin-selection
         let coinSelectionEstimatedSize :: Natural -> Natural
             coinSelectionEstimatedSize
                 = fromIntegral . sizeOf_BootstrapWitnesses . fromIntegral
 
         let measuredWitSize :: IsCardanoEra era => Cardano.Tx era -> Natural
-            measuredWitSize (Cardano.Tx body wits) = fromIntegral $
-                  serializedSize (Cardano.Tx body wits)
+            measuredWitSize (Cardano.Tx body wits) = fromIntegral
+                $ serializedSize (Cardano.Tx body wits)
                 - serializedSize (Cardano.Tx body [])
 
         let evaluateMinimumFeeSize
@@ -2425,8 +2499,8 @@ balanceTransactionSpec = describe "balanceTransaction" $ do
                     RecentEraBabbage -> setField @"_minfeeA" 1 def
                     RecentEraAlonzo  -> setField @"_minfeeA" 1 def
 
-        let evaluateMinimumFeeDerivedWitSize (Cardano.Tx body wits) =
-                  evaluateMinimumFeeSize (Cardano.Tx body wits)
+        let evaluateMinimumFeeDerivedWitSize (Cardano.Tx body wits)
+                = evaluateMinimumFeeSize (Cardano.Tx body wits)
                 - evaluateMinimumFeeSize (Cardano.Tx body [])
 
         it "coin-selection's size estimation == balanceTx's size estimation"

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2691,10 +2691,8 @@ balanceTransactionSpec = describe "balanceTransaction" $ do
             outs = map (TxOut dummyAddr . TokenBundle.fromCoin) coins
             dummyHash = Hash $ B8.replicate 32 '0'
 
-    dummyRootK = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
-      where
-        mw = SomeMnemonic $ either (error . show) id
-            (entropyToMnemonic @12 <$> mkEntropy "0000000000000000")
+    dummyRootK
+        = Shelley.unsafeGenerateKeyFromSeed (dummyMnemonic, Nothing) mempty
 
     dummyAddr = Address $ unsafeFromHex
         "60b1e5e0fb74c86c801f646841e07cdb42df8b82ef3ce4e57cb5412e77"
@@ -3596,10 +3594,8 @@ dummyChangeAddrGen = ChangeAddressGen $ \(DummyChangeState i) ->
                 Cardano.Wallet.Primitive.AddressDerivation.UtxoInternal
                 ix
 
-        mw = SomeMnemonic $ either (error . show) id
-            (entropyToMnemonic @12 <$> mkEntropy "0000000000000000")
         pwd = Passphrase ""
-        rootK = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
+        rootK = Shelley.unsafeGenerateKeyFromSeed (dummyMnemonic, Nothing) pwd
         acctK = Shelley.deriveAccountPrivateKeyShelley
                     purposeBIP44
                     pwd
@@ -3779,9 +3775,8 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
         outs = map (TxOut addr . TokenBundle.fromCoin) coins
         dummyHash = Hash $ B8.replicate 32 '0'
 
-    mw = SomeMnemonic $ either (error . show) id
-        (entropyToMnemonic @12 <$> mkEntropy "0000000000000000")
-    rootK = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
+    rootK =
+        Shelley.unsafeGenerateKeyFromSeed (dummyMnemonic, Nothing) mempty
     addr = Address $ unsafeFromHex
         "60b1e5e0fb74c86c801f646841e07cdb42df8b82ef3ce4e57cb5412e77"
 
@@ -4169,9 +4164,7 @@ prop_bootstrapWitnesses
       where
         Cardano.Tx body _ = WriteTx.toCardanoTx @era $ WriteTx.emptyTx era
 
-    mw = SomeMnemonic $ either (error . show) id
-        (entropyToMnemonic @12 <$> mkEntropy "0000000000000000")
-    rootK = Byron.generateKeyFromSeed mw mempty
+    rootK = Byron.generateKeyFromSeed dummyMnemonic mempty
     pwd = mempty
 
     dummyWitForIx
@@ -4781,3 +4774,7 @@ cardanoTx = cardanoTxIdeallyNoLaterThan maxBound
 
 dummyPolicyK :: KeyHash
 dummyPolicyK = KeyHash Policy (BS.replicate 32 0)
+
+dummyMnemonic :: SomeMnemonic
+dummyMnemonic = SomeMnemonic $ either (error . show) id
+    (entropyToMnemonic @12 <$> mkEntropy "0000000000000000")

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -52,8 +52,7 @@ import Cardano.Api
     , ShelleyBasedEra (..)
     , TxOutValue (TxOutAdaOnly, TxOutValue)
     )
-import Cardano.Api.Extra
-    ( asAnyShelleyBasedEra, withShelleyBasedTx )
+import Cardano.Api.Extra ( asAnyShelleyBasedEra, withShelleyBasedTx )
 import Cardano.Api.Gen
     ( genAddressInEra
     , genEncodingBoundaryLovelace
@@ -67,26 +66,18 @@ import Cardano.Api.Gen
     , genValueForTxOut
     , genWitnesses
     )
-import Cardano.Binary
-    ( FromCBOR, ToCBOR, serialize', unsafeDeserialize' )
-import Cardano.BM.Data.Tracer
-    ( nullTracer )
-import Cardano.Ledger.Alonzo.Genesis
-    ( AlonzoGenesis (costmdls) )
-import Cardano.Ledger.Alonzo.TxInfo
-    ( TranslationError (..) )
-import Cardano.Ledger.Era
-    ( Era )
-import Cardano.Ledger.Shelley.API
-    ( StrictMaybe (SJust, SNothing), Wdrl (..) )
+import Cardano.Binary ( FromCBOR, ToCBOR, serialize', unsafeDeserialize' )
+import Cardano.BM.Data.Tracer ( nullTracer )
+import Cardano.Ledger.Alonzo.Genesis ( AlonzoGenesis (costmdls) )
+import Cardano.Ledger.Alonzo.TxInfo ( TranslationError (..) )
+import Cardano.Ledger.Era ( Era )
+import Cardano.Ledger.Shelley.API ( StrictMaybe (SJust, SNothing), Wdrl (..) )
 import Cardano.Ledger.ShelleyMA.Timelocks
     ( ValidityInterval (ValidityInterval) )
 import Cardano.Mnemonic
     ( SomeMnemonic (SomeMnemonic), entropyToMnemonic, mkEntropy )
-import Cardano.Numeric.Util
-    ( power )
-import Cardano.Pool.Types
-    ( PoolId (..) )
+import Cardano.Numeric.Util ( power )
+import Cardano.Pool.Types ( PoolId (..) )
 import Cardano.Tx.Balance.Internal.CoinSelection
     ( SelectionBalanceError (..)
     , SelectionError (..)
@@ -106,15 +97,13 @@ import Cardano.Wallet
     , defaultChangeAddressGen
     , signTransaction
     )
-import Cardano.Wallet.Byron.Compatibility
-    ( maryTokenBundleMaxSize )
-import Cardano.Wallet.Gen
-    ( genMnemonic, genScript )
+import Cardano.Wallet.Byron.Compatibility ( maryTokenBundleMaxSize )
+import Cardano.Wallet.Gen ( genMnemonic, genScript )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DelegationAddress (delegationAddress)
     , Depth (..)
     , DerivationIndex (..)
-    , DerivationType (Soft)
+    , DerivationType (..)
     , Index
     , NetworkDiscriminant (..)
     , Role (..)
@@ -125,10 +114,8 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , paymentAddress
     , publicKey
     )
-import Cardano.Wallet.Primitive.AddressDerivation.Byron
-    ( ByronKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Byron ( ByronKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Icarus ( IcarusKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey, generateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
@@ -140,8 +127,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( estimateMaxWitnessRequiredPerInput )
-import Cardano.Wallet.Primitive.Model
-    ( Wallet (..), unsafeInitWallet )
+import Cardano.Wallet.Primitive.Model ( Wallet (..), unsafeInitWallet )
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase (..)
     , PassphraseMaxLength (..)
@@ -174,24 +160,19 @@ import Cardano.Wallet.Primitive.Types
     , TxParameters (..)
     , getGenesisBlockDate
     )
-import Cardano.Wallet.Primitive.Types.Address
-    ( Address (..) )
-import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Address ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Coin ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoin, genCoinPositive, shrinkCoin, shrinkCoinPositive )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..), mockHash )
+import Cardano.Wallet.Primitive.Types.Hash ( Hash (..), mockHash )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO
     ( minimumUTxOForShelleyBasedEra )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
     ( testParameter_coinsPerUTxOByte_Babbage
     , testParameter_coinsPerUTxOWord_Alonzo
     )
-import Cardano.Wallet.Primitive.Types.Redeemer
-    ( Redeemer (..) )
-import Cardano.Wallet.Primitive.Types.RewardAccount
-    ( RewardAccount (..) )
+import Cardano.Wallet.Primitive.Types.Redeemer ( Redeemer (..) )
+import Cardano.Wallet.Primitive.Types.RewardAccount ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( AssetId, TokenBundle, tokenName )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
@@ -217,22 +198,14 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxConstraints (..), TxSize (..) )
-import Cardano.Wallet.Primitive.Types.Tx.TxIn
-    ( TxIn (..) )
-import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
-    ( genTxIn )
-import Cardano.Wallet.Primitive.Types.Tx.TxOut
-    ( TxOut (..) )
-import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
-    ( genTxOutTokenBundle )
-import Cardano.Wallet.Primitive.Types.UTxO
-    ( UTxO (..) )
-import Cardano.Wallet.Primitive.Types.UTxOIndex
-    ( UTxOIndex )
-import Cardano.Wallet.Read.Primitive.Tx.Features.Integrity
-    ( txIntegrity )
-import Cardano.Wallet.Read.Tx.Cardano
-    ( fromCardanoApiTx )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn ( TxIn (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen ( genTxIn )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut ( TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen ( genTxOutTokenBundle )
+import Cardano.Wallet.Primitive.Types.UTxO ( UTxO (..) )
+import Cardano.Wallet.Primitive.Types.UTxOIndex ( UTxOIndex )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Integrity ( txIntegrity )
+import Cardano.Wallet.Read.Tx.Cardano ( fromCardanoApiTx )
 import Cardano.Wallet.Shelley.Compatibility
     ( computeTokenBundleSerializedLengthBytes
     , fromCardanoLovelace
@@ -245,10 +218,13 @@ import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( toBabbageTxOut, toLedgerTokenBundle, toWallet )
 import Cardano.Wallet.Shelley.Transaction
     ( EraConstraints
+    , KeyWitnessCount (KeyWitnessCount)
     , TxSkeleton (..)
     , TxUpdate (..)
     , TxWitnessTag (..)
     , TxWitnessTagFor
+    , _decodeSealedTx
+    , _estimateMaxNumberOfInputs
     , costOfIncreasingCoin
     , distributeSurplus
     , distributeSurplusDelta
@@ -267,10 +243,9 @@ import Cardano.Wallet.Shelley.Transaction
     , newTransactionLayer
     , noTxUpdate
     , sizeOfCoin
+    , sizeOf_BootstrapWitnesses
     , txConstraints
     , updateSealedTx
-    , _decodeSealedTx
-    , _estimateMaxNumberOfInputs
     )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
@@ -284,8 +259,7 @@ import Cardano.Wallet.Transaction
     , WitnessCountCtx (..)
     , defaultTransactionCtx
     )
-import Cardano.Wallet.Unsafe
-    ( unsafeFromHex )
+import Cardano.Wallet.Unsafe ( unsafeFromHex )
 import Cardano.Wallet.Write.Tx
     ( AnyRecentEra (..)
     , RecentEra (..)
@@ -301,10 +275,8 @@ import Cardano.Wallet.Write.Tx.Balance
     , balanceTransaction
     , posAndNegFromCardanoValue
     )
-import Control.Arrow
-    ( first )
-import Control.Monad
-    ( forM, forM_, replicateM )
+import Control.Arrow ( first )
+import Control.Monad ( forM, forM_, replicateM )
 import Control.Monad.Random
     ( MonadRandom (..)
     , Rand
@@ -313,76 +285,44 @@ import Control.Monad.Random
     , random
     , randoms
     )
-import Control.Monad.Random.Strict
-    ( StdGen )
-import Control.Monad.Trans.Except
-    ( except, runExceptT )
-import Control.Monad.Trans.State.Strict
-    ( evalState, state )
-import Crypto.Hash.Utils
-    ( blake2b224 )
-import Data.ByteArray.Encoding
-    ( Base (..), convertToBase )
-import Data.ByteString
-    ( ByteString )
-import Data.Default
-    ( Default (..) )
-import Data.Either
-    ( isLeft, isRight )
-import Data.Function
-    ( on, (&) )
-import Data.Functor.Identity
-    ( Identity, runIdentity )
-import Data.Generics.Internal.VL.Lens
-    ( over, view )
-import Data.List
-    ( isSuffixOf, nub )
-import Data.List.NonEmpty
-    ( NonEmpty (..) )
-import Data.Map.Strict
-    ( Map )
-import Data.Maybe
-    ( fromJust, fromMaybe, isJust )
-import Data.Ord
-    ( comparing )
-import Data.Proxy
-    ( Proxy (..) )
-import Data.Quantity
-    ( Quantity (..) )
-import Data.Ratio
-    ( (%) )
-import Data.Semigroup
-    ( Sum (Sum), getSum, mtimesDefault )
-import Data.Set
-    ( Set )
-import Data.Text
-    ( Text )
-import Data.Time.Clock.POSIX
-    ( posixSecondsToUTCTime )
-import Data.Typeable
-    ( Typeable, typeRep )
-import Data.Word
-    ( Word16, Word64, Word8 )
-import Fmt
-    ( Buildable (..), blockListF', fmt, nameF, pretty, (+||), (||+) )
-import GHC.IO.Unsafe
-    ( unsafePerformIO )
+import Control.Monad.Random.Strict ( StdGen )
+import Control.Monad.Trans.Except ( except, runExceptT )
+import Control.Monad.Trans.State.Strict ( evalState, state )
+import Crypto.Hash.Utils ( blake2b224 )
+import Data.ByteArray.Encoding ( Base (..), convertToBase )
+import Data.ByteString ( ByteString )
+import Data.Default ( Default (..) )
+import Data.Either ( isLeft, isRight )
+import Data.Function ( on, (&) )
+import Data.Functor.Identity ( Identity, runIdentity )
+import Data.Generics.Internal.VL.Lens ( over, view )
+import Data.IntCast ( intCast )
+import Data.List ( isSuffixOf, nub )
+import Data.List.NonEmpty ( NonEmpty (..) )
+import Data.Map.Strict ( Map )
+import Data.Maybe ( fromJust, fromMaybe, isJust )
+import Data.Ord ( comparing )
+import Data.Proxy ( Proxy (..) )
+import Data.Quantity ( Quantity (..) )
+import Data.Ratio ( (%) )
+import Data.Semigroup ( Sum (Sum), getSum, mtimesDefault )
+import Data.Set ( Set )
+import Data.Text ( Text )
+import Data.Time.Clock.POSIX ( posixSecondsToUTCTime )
+import Data.Typeable ( Typeable, typeRep )
+import Data.Word ( Word16, Word64, Word8 )
+import Fmt ( Buildable (..), blockListF', fmt, nameF, pretty, (+||), (||+) )
+import GHC.IO.Unsafe ( unsafePerformIO )
+import Numeric.Natural ( Natural )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
     ( RelativeTime (..), mkSlotLength )
-import Ouroboros.Consensus.Config
-    ( SecurityParam (..) )
-import Ouroboros.Consensus.Shelley.Eras
-    ( StandardBabbage )
-import Ouroboros.Consensus.Util.Counting
-    ( exactlyOne )
-import Ouroboros.Network.Block
-    ( SlotNo (..) )
-import System.Directory
-    ( listDirectory )
-import System.FilePath
-    ( takeExtension, (</>) )
-import System.Random.StdGenSeed
-    ( StdGenSeed (..), stdGenFromSeed )
+import Ouroboros.Consensus.Config ( SecurityParam (..) )
+import Ouroboros.Consensus.Shelley.Eras ( StandardBabbage )
+import Ouroboros.Consensus.Util.Counting ( exactlyOne )
+import Ouroboros.Network.Block ( SlotNo (..) )
+import System.Directory ( listDirectory )
+import System.FilePath ( takeExtension, (</>) )
+import System.Random.StdGenSeed ( StdGenSeed (..), stdGenFromSeed )
 import Test.Hspec
     ( Spec
     , SpecWith
@@ -394,12 +334,9 @@ import Test.Hspec
     , shouldBe
     , shouldSatisfy
     )
-import Test.Hspec.Core.Spec
-    ( SpecM )
-import Test.Hspec.Golden
-    ( Golden (..) )
-import Test.Hspec.QuickCheck
-    ( prop )
+import Test.Hspec.Core.Spec ( SpecM )
+import Test.Hspec.Golden ( Golden (..) )
+import Test.Hspec.QuickCheck ( prop )
 import Test.QuickCheck
     ( Arbitrary (..)
     , Blind (..)
@@ -408,6 +345,7 @@ import Test.QuickCheck
     , Positive (..)
     , Property
     , Testable
+    , arbitraryBoundedEnum
     , arbitraryPrintableChar
     , checkCoverage
     , choose
@@ -428,6 +366,7 @@ import Test.QuickCheck
     , shrinkList
     , shrinkMapBy
     , suchThat
+    , tabulate
     , vector
     , vectorOf
     , withMaxSuccess
@@ -438,15 +377,11 @@ import Test.QuickCheck
     , (==>)
     )
 import Test.QuickCheck.Extra
-    ( chooseNatural, genNonEmpty, report, shrinkNonEmpty )
-import Test.QuickCheck.Gen
-    ( Gen (..), listOf1 )
-import Test.QuickCheck.Random
-    ( QCGen, mkQCGen )
-import Test.Utils.Paths
-    ( getTestData )
-import Test.Utils.Pretty
-    ( Pretty (..), (====) )
+    ( chooseNatural, report, shrinkBoundedEnum, shrinkNonEmpty )
+import Test.QuickCheck.Gen ( Gen (..), listOf1 )
+import Test.QuickCheck.Random ( QCGen, mkQCGen )
+import Test.Utils.Paths ( getTestData )
+import Test.Utils.Pretty ( Pretty (..), (====) )
 
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Gen as Cardano
@@ -468,6 +403,7 @@ import qualified Cardano.Ledger.Serialization as Ledger
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Ledger.Val as Value
 import qualified Cardano.Tx.Balance.Internal.CoinSelection as CS
+import qualified Cardano.Wallet.Primitive.AddressDerivation.Byron as Byron
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Shelley
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
@@ -484,6 +420,7 @@ import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Foldable as F
+import Data.Generics.Product ( setField )
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
@@ -2038,9 +1975,9 @@ instance Arbitrary (ForByron DecodeSetup) where
         pure $ ForByron (test { metadata = Nothing })
 
 instance Arbitrary Cardano.NetworkId where
-    arbitrary = elements
-        [ Cardano.Mainnet
-        , Cardano.Testnet $ Cardano.NetworkMagic 42
+    arbitrary = oneof
+        [ pure Cardano.Mainnet
+        , Cardano.Testnet . Cardano.NetworkMagic <$> arbitrary
         ]
 
 instance Arbitrary SlotNo where
@@ -2451,6 +2388,65 @@ balanceTransactionSpec = describe "balanceTransaction" $ do
 
     it "produces valid transactions or fails"
         $ property prop_balanceTransactionValid
+
+    describe "bootstrap witnesses" $ do
+        -- Used in 'estimateTxSize' in turn used by coin-selection
+        let coinSelectionEstimatedSize :: Natural -> Natural
+            coinSelectionEstimatedSize
+                = fromIntegral . sizeOf_BootstrapWitnesses . fromIntegral
+
+        let measuredWitSize :: IsCardanoEra era => Cardano.Tx era -> Natural
+            measuredWitSize (Cardano.Tx body wits) = fromIntegral $
+                  serializedSize (Cardano.Tx body wits)
+                - serializedSize (Cardano.Tx body [])
+
+        let evaluateMinimumFeeSize
+                :: forall era. WriteTx.IsRecentEra era
+                => Cardano.Tx era
+                -> Natural
+            evaluateMinimumFeeSize (Cardano.Tx body wits) = fromIntegral
+                $ WriteTx.unCoin
+                $ WriteTx.evaluateMinimumFee
+                    (WriteTx.recentEra @era)
+                    pp
+                    (WriteTx.fromCardanoTx (Cardano.Tx body []))
+                    (KeyWitnessCount 0 (fromIntegral $ length wits))
+              where
+                -- Dummy PParams to ensure a Coin-delta corresponds to a
+                -- size-delta.
+                pp = case WriteTx.recentEra @era of
+                    RecentEraBabbage -> setField @"_minfeeA" 1 def
+                    RecentEraAlonzo  -> setField @"_minfeeA" 1 def
+
+        let evaluateMinimumFeeDerivedWitSize (Cardano.Tx body wits) =
+                  evaluateMinimumFeeSize (Cardano.Tx body wits)
+                - evaluateMinimumFeeSize (Cardano.Tx body [])
+
+        it "coin-selection's size estimation == balanceTx's size estimation"
+            $ property
+            $ prop_bootstrapWitnesses
+            $ \n (WriteTx.InAnyRecentEra _era tx) -> do
+                let balance = evaluateMinimumFeeDerivedWitSize tx
+                let cs = coinSelectionEstimatedSize $ intCast n
+                balance === cs -- >= would suffice, but we can be stronger
+
+        it "balanceTx's size estimation >= measured serialized size"
+            $ property
+            $ prop_bootstrapWitnesses
+            $ \n (WriteTx.InAnyRecentEra _era tx) -> do
+                let estimated = evaluateMinimumFeeDerivedWitSize tx
+                let measured = measuredWitSize tx
+                let overestimation
+                        | estimated > measured = estimated - measured
+                        | otherwise            = 0
+
+                let tabulateOverestimation = tabulate "overestimation/wit" $
+                        if n == 0
+                        then [show overestimation <> " (but with no wits)"]
+                        else [show $ overestimation `div` fromIntegral n]
+
+                estimated .>= measured
+                    & tabulateOverestimation
 
     balanceTransactionGoldenSpec
 
@@ -3548,6 +3544,10 @@ shrinkStrictMaybe = \case
     SNothing -> []
     SJust _ -> [SNothing]
 
+instance Arbitrary (Index 'WholeDomain depth) where
+    arbitrary = arbitraryBoundedEnum
+    shrink = shrinkBoundedEnum
+
 balanceTransaction'
     :: WriteTx.IsRecentEra era
     => Wallet'
@@ -4130,6 +4130,80 @@ prop_balanceTransactionExistingReturnCollateral
         case balanceTransaction' wallet seed partialTx of
             Left err -> ErrBalanceTxExistingReturnCollateral === err
             e -> counterexample (show e) False
+
+prop_bootstrapWitnesses
+    :: (Word8 -> WriteTx.InAnyRecentEra Cardano.Tx -> Property)
+    -> Word8
+    -- ^ Number of bootstrap witnesses.
+    --
+    -- Testing with [0, 255] should be sufficient.
+    -> AnyRecentEra
+    -> Cardano.NetworkId
+    -- ^ Network - will be encoded inside the witness.
+    -> Index 'WholeDomain 'AccountK
+    -- ^ Account index - will be encoded inside the witness.
+    -> Index 'WholeDomain 'CredFromKeyK
+    -- ^ Index for the first of the 'n' addresses.
+    -> Property
+prop_bootstrapWitnesses
+    p n (AnyRecentEra (era :: RecentEra era)) net accIx addr0Ix =
+    let
+        -- Start incrementing the ixs upward, and if we reach 'maxBound', loop
+        -- around, to ensure we always have 'n' unique indicies.
+        addrIxs = take (fromIntegral n)
+                $ [addr0Ix .. maxBound] ++ [minBound .. addr0Ix]
+        body = emptyCardanoTxBody
+        wits :: [Cardano.KeyWitness era]
+        wits = map (dummyWitForIx body) addrIxs
+    in
+        p n (WriteTx.InAnyRecentEra era $ Cardano.Tx body wits)
+  where
+    emptyCardanoTxBody =
+        let
+            Cardano.Tx body _ = WriteTx.toCardanoTx @era $ WriteTx.emptyTx era
+        in body
+
+    mw = SomeMnemonic $ either (error . show) id
+        (entropyToMnemonic @12 <$> mkEntropy "0000000000000000")
+    rootK = Byron.generateKeyFromSeed mw mempty
+    pwd = mempty
+
+    dummyWitForIx
+        :: Cardano.TxBody era
+        -> Index 'WholeDomain 'CredFromKeyK
+        -> Cardano.KeyWitness era
+    dummyWitForIx body ix =
+        let
+            accK = Byron.deriveAccountPrivateKey pwd rootK accIx
+            addrKeyAtIx i = Byron.deriveAddressPrivateKey pwd accK i
+
+            addrK = addrKeyAtIx $ toEnum $ fromEnum ix
+            addr = case net of
+                Cardano.Mainnet ->
+                    paymentAddress @'Mainnet $ publicKey addrK
+                Cardano.Testnet _magic ->
+                    -- The choice of network magic here is not important. The
+                    -- size of the witness will not be affected by it. What may
+                    -- affect the size, is the 'Cardano.NetworkId' we pass to
+                    -- 'mkByronWitness' above.
+                    paymentAddress @('Testnet 0) $ publicKey addrK
+        in
+            case era of
+                RecentEraBabbage ->
+                    mkByronWitness body net addr (getRawKey addrK, pwd)
+                RecentEraAlonzo  ->
+                    mkByronWitness body net addr (getRawKey addrK, pwd)
+
+
+serializedSize :: forall era. Cardano.IsCardanoEra era => Cardano.Tx era -> Int
+serializedSize = BS.length
+    . serialisedTx
+    . sealedTxFromCardano
+    . Cardano.InAnyCardanoEra (Cardano.cardanoEra @era)
+
+(.>=) :: (Show a, Ord a) => a -> a -> Property
+a .>= b = counterexample (show a <> " < " <> show b)
+        $ property $ a >= b
 
 hasInsCollateral :: Cardano.Tx era -> Bool
 hasInsCollateral (Cardano.Tx (Cardano.TxBody content) _) =


### PR DESCRIPTION
- [x] Support bootstrap witnesses in `Cardano.Wallet.Write.Tx.evaluateMinimumFee`
- [x] Support bootstrap witnesses in the temporarily remaining `Cardano.Wallet.Shelley.Transactions.evaluateMinimumFee`
- [x] Re-use the exact same size estimation as the underlying coin-selection
- [x] Test that this size estimation doesn't underestimate w.r.t. the actual serialised size of the boot wits

### Comments

```
    bootstrap witnesses
      coin-selection's size estimation == balanceTx's size estimation [✔] (1697ms)
        +++ OK, passed 100 tests.
      balanceTx's size estimation >= measured serialized size [✔] (1824ms)
        +++ OK, passed 100 tests.

        overestimation/wit (100 in total):
        48% 9
        30% 2
         7% 4
         3% 0 (but with no wits)
         3% 5
         3% 6
         2% 11
         2% 8
         1% 10
         1% 7
```

### Issue Number

[ADP-2613](https://input-output.atlassian.net/browse/ADP-2613)

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
