### PR TITLE
Make fields of `WalletUTxO` strict.

### DIFF
--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -167,9 +167,9 @@ instance SC.SelectionContext WalletSelectionContext where
 --
 data WalletUTxO = WalletUTxO
     { txIn
-        :: TxIn
+        :: !TxIn
     , address
-        :: Address
+        :: !Address
     }
     deriving (Eq, Generic, Ord, Show)
 


### PR DESCRIPTION
This PR makes the fields of `WalletUTxO` strict. (There's no good reason for them to be lazy.)