### PR TITLE
Use ledger protocol parameters when evaluating minimum fees in `balanceTransaction`.

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -221,7 +221,7 @@ import Cardano.Wallet.Transaction
 import Cardano.Wallet.Util
     ( HasCallStack, internalError, modifyM )
 import Cardano.Wallet.Write.Tx
-    ( fromCardanoUTxO )
+    ( KeyWitnessCount (..), fromCardanoUTxO )
 import Codec.Serialise
     ( deserialiseOrFail )
 import Control.Arrow
@@ -1030,23 +1030,8 @@ estimateSignedTxSize pparams nWits body =
     feePerByte = Coin.fromNatural $
         view #protocolParamTxFeePerByte pparams
 
-data KeyWitnessCount = KeyWitnessCount
-    { nKeyWits :: Word
-    -- ^ "Normal" verification key witnesses introduced with the Shelley era.
-
-    , nBootstrapWits :: Word
-    -- ^ Bootstrap key witnesses, a.k.a Byron witnesses.
-    } deriving (Eq, Show)
-
 numberOfShelleyWitnesses :: Word -> KeyWitnessCount
 numberOfShelleyWitnesses n = KeyWitnessCount n 0
-
-instance Semigroup KeyWitnessCount where
-    (KeyWitnessCount s1 b1) <> (KeyWitnessCount s2 b2)
-        = KeyWitnessCount (s1 + s2) (b1 + b2)
-
-instance Monoid KeyWitnessCount where
-    mempty = KeyWitnessCount 0 0
 
 -- | Estimates the required number of Shelley-era witnesses.
 --

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -321,10 +321,10 @@ withRecentEra (AnyRecentEra era) f = f era
 --------------------------------------------------------------------------------
 
 data KeyWitnessCount = KeyWitnessCount
-    { nKeyWits :: Word
+    { nKeyWits :: !Word
     -- ^ "Normal" verification key witnesses introduced with the Shelley era.
 
-    , nBootstrapWits :: Word
+    , nBootstrapWits :: !Word
     -- ^ Bootstrap key witnesses, a.k.a Byron witnesses.
     } deriving (Eq, Show)
 

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -32,6 +32,9 @@ module Cardano.Wallet.Write.Tx
     , LatestLedgerEra
     , LatestEra
 
+    -- ** Key witness counts
+    , KeyWitnessCount (..)
+
     -- ** Helpers for cardano-api compatibility
     , cardanoEra
     , shelleyBasedEra
@@ -312,6 +315,25 @@ fromAnyRecentEra (AnyRecentEra era) = Cardano.AnyCardanoEra (fromRecentEra era)
 withRecentEra ::
     AnyRecentEra -> (forall era. IsRecentEra era => RecentEra era -> a) -> a
 withRecentEra (AnyRecentEra era) f = f era
+
+--------------------------------------------------------------------------------
+-- Key witness counts
+--------------------------------------------------------------------------------
+
+data KeyWitnessCount = KeyWitnessCount
+    { nKeyWits :: Word
+    -- ^ "Normal" verification key witnesses introduced with the Shelley era.
+
+    , nBootstrapWits :: Word
+    -- ^ Bootstrap key witnesses, a.k.a Byron witnesses.
+    } deriving (Eq, Show)
+
+instance Semigroup KeyWitnessCount where
+    (KeyWitnessCount s1 b1) <> (KeyWitnessCount s2 b2)
+        = KeyWitnessCount (s1 + s2) (b1 + b2)
+
+instance Monoid KeyWitnessCount where
+    mempty = KeyWitnessCount 0 0
 
 --------------------------------------------------------------------------------
 -- TxIn


### PR DESCRIPTION
## Issue Number

ADP-2653

## Summary

This PR:
- adds a ledger version of the function `evaluateMinimumFee`, accepting ledger protocol parameters.
- uses this function within `balanceTransaction` instead of the Cardano API equivalent.

## Not Included

This PR does **_not_** remove the [original `evaluateMinimumFee` function](https://github.com/input-output-hk/cardano-wallet/blob/cfac9eec88c0eb02da06fceac743bc836f1e41f5/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs#L966) from `Shelley.Transaction`, as this is still used within `TransactionSpec`. We can remove that function in a later PR.