### PR TITLE
[ADP-2824] Remove obsoleted verbs from tx meta API

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Model.hs
@@ -70,9 +70,7 @@ instance Buildable TxMetaHistory where
 -- | Verbs for 'TxMeta' changes
 -- that can be issued independently from the transaction store.
 data ManipulateTxMetaHistory
-    = PruneTxMetaHistory TxId
-    -- ^ Remove a meta if it is /not/ in the ledger.
-    | AgeTxMetaHistory W.SlotNo
+    = AgeTxMetaHistory W.SlotNo
     -- ^ Change the state of any meta to 'Expired'
     -- if the given slot is equal or after its expiration slot.
     | RollBackTxMetaHistory W.SlotNo
@@ -97,14 +95,6 @@ instance Delta DeltaTxMetaHistory where
 
 instance Delta ManipulateTxMetaHistory where
     type Base ManipulateTxMetaHistory = TxMetaHistory
-    apply (PruneTxMetaHistory tid) (TxMetaHistory txs) =
-        TxMetaHistory $ Map.alter f tid txs
-      where
-        f (Just tx@(TxMeta {..})) =
-            if txMetaStatus == W.InLedger
-                then Just tx
-                else Nothing
-        f Nothing = Nothing
     apply (AgeTxMetaHistory tip) (TxMetaHistory txs) =
         TxMetaHistory
         $ txs <&> \meta@TxMeta {..} ->

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Model.hs
@@ -70,10 +70,7 @@ instance Buildable TxMetaHistory where
 -- | Verbs for 'TxMeta' changes
 -- that can be issued independently from the transaction store.
 data ManipulateTxMetaHistory
-    = AgeTxMetaHistory W.SlotNo
-    -- ^ Change the state of any meta to 'Expired'
-    -- if the given slot is equal or after its expiration slot.
-    | RollBackTxMetaHistory W.SlotNo
+    = RollBackTxMetaHistory W.SlotNo
     -- ^ Remove all incoming transactions created after the given slot and
     -- mark all outgoing transactions after the given slot as 'Pending'.
     deriving ( Eq, Show )
@@ -95,15 +92,6 @@ instance Delta DeltaTxMetaHistory where
 
 instance Delta ManipulateTxMetaHistory where
     type Base ManipulateTxMetaHistory = TxMetaHistory
-    apply (AgeTxMetaHistory tip) (TxMetaHistory txs) =
-        TxMetaHistory
-        $ txs <&> \meta@TxMeta {..} ->
-            if txMetaStatus == W.Pending && isExpired txMetaSlotExpires
-            then meta { txMetaStatus = W.Expired }
-            else meta
-      where
-        isExpired Nothing = False
-        isExpired (Just tip') = tip' <= tip
     apply (RollBackTxMetaHistory point) metas =
         fst $ rollbackTxMetaHistory point metas
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Store.hs
@@ -1,5 +1,4 @@
 
-{-# LANGUAGE LambdaCase #-}
 
 {- |
  Copyright: © 2018-2022 IOHK
@@ -17,10 +16,7 @@ import Prelude
 import Cardano.Wallet.DB.Sqlite.Schema
     ( EntityField (..), TxMeta (..) )
 import Cardano.Wallet.DB.Store.Meta.Model
-    ( DeltaTxMetaHistory (..)
-    , ManipulateTxMetaHistory (..)
-    , TxMetaHistory (..)
-    )
+    ( DeltaTxMetaHistory (..), TxMetaHistory (..) )
 import Cardano.Wallet.Primitive.Types
     ( WalletId )
 import Control.Arrow
@@ -60,7 +56,7 @@ update :: WalletId
     -> SqlPersistT IO ()
 update wid _ change = case change of
     Expand txs -> putMetas txs
-    Manipulate (RollBackTxMetaHistory point) -> do
+    Rollback point -> do
         let isAfter = TxMetaSlot >. point
         deleteWhere
             [ TxMetaWalletId ==. wid

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Store.hs
@@ -42,14 +42,10 @@ import Database.Persist.Sql
     , deleteWhere
     , repsertMany
     , selectList
-    , updateWhere
-    , (<=.)
-    , (=.)
     , (==.)
     , (>.)
     )
 
-import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Data.Map.Strict as Map
 
 -- | Create an SQL store to hold meta transactions for a wallet.
@@ -64,13 +60,6 @@ update :: WalletId
     -> SqlPersistT IO ()
 update wid _ change = case change of
     Expand txs -> putMetas txs
-
-    Manipulate (AgeTxMetaHistory tip) -> updateWhere
-        [ TxMetaWalletId ==. wid
-        , TxMetaStatus ==. W.Pending
-        , TxMetaSlotExpires <=. Just tip
-        ]
-        [TxMetaStatus =. W.Expired]
     Manipulate (RollBackTxMetaHistory point) -> do
         let isAfter = TxMetaSlot >. point
         deleteWhere

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Model.hs
@@ -86,8 +86,7 @@ instance Delta DeltaTxWalletsHistory where
             (x, garbageCollectEmptyWallets $ apply (Adjust wid change) mtxmh)
       where
         change
-            = TxMetaStore.Manipulate
-            $ TxMetaStore.RollBackTxMetaHistory slot
+            = TxMetaStore.Rollback slot
     apply (RemoveWallet wid) (x , mtxmh) =
         garbageCollectTxWalletsHistory (x, Map.delete wid mtxmh)
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -113,8 +113,7 @@ mkStoreTxWalletsHistory storeTransactions storeWalletsMeta =
                 wmetas <- loadWhenNothing mWmetas storeWalletsMeta
                 updateS storeWalletsMeta (Just wmetas)
                     $ Adjust wid
-                    $ TxMetaStore.Manipulate
-                    $ TxMetaStore.RollBackTxMetaHistory slot
+                    $ TxMetaStore.Rollback slot
                 let deletions = transactionsToDeleteOnRollback wid slot wmetas
                 updateS storeTransactions mTxSet
                     $ DeleteTxs deletions

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/ModelSpec.hs
@@ -52,9 +52,9 @@ spec :: Spec
 spec = do
     describe "meta-transactions delta instance" $ do
         it "can roll back to a given slot, removing all transactions"
-            $ property prop_RollBackRemoveAfterSlot
+            $ property prop_RollbackRemoveAfterSlot
         it "can roll back to a given slot, leaving past untouched"
-            $ property prop_RollBackDoNotTouchPast
+            $ property prop_RollbackDoNotTouchPast
 
 genExpand :: WalletId -> Gen [(W.Tx, W.TxMeta)] -> Gen TxMetaHistory
 genExpand wid g = mkTxMetaHistory wid <$> g
@@ -72,13 +72,13 @@ withExpanded wid expandG = do
 
 type WithWalletProperty = WalletId -> Property
 
-withPropRollBack
+withPropRollback
     :: (( (TxMetaHistory, TxMetaHistory) -- bootHistory split
         , (TxMetaHistory, TxMetaHistory) -- newHistory split
         )
         -> WithWalletProperty)
     -> WithWalletProperty
-withPropRollBack f wid = property $ do
+withPropRollback f wid = property $ do
     bootHistory <- withExpanded
         wid
         (listOf1 arbitrary)
@@ -97,14 +97,14 @@ withPropRollBack f wid = property $ do
             "outgoing transactions"
         $ f (splitHistory slotNo bootHistory, splitHistory slotNo newHistory)
 
-prop_RollBackRemoveAfterSlot :: WithWalletProperty
-prop_RollBackRemoveAfterSlot =
-    withPropRollBack $ \((_afterBoot,_beforeBoot),(afterNew,_beforeNew)) _
+prop_RollbackRemoveAfterSlot :: WithWalletProperty
+prop_RollbackRemoveAfterSlot =
+    withPropRollback $ \((_afterBoot,_beforeBoot),(afterNew,_beforeNew)) _
     -> property $ null $ relations afterNew
 
-prop_RollBackDoNotTouchPast :: WithWalletProperty
-prop_RollBackDoNotTouchPast =
-    withPropRollBack $ \((afterBoot,beforeBoot),(_afterNew,beforeNew)) _ ->
+prop_RollbackDoNotTouchPast :: WithWalletProperty
+prop_RollbackDoNotTouchPast =
+    withPropRollback $ \((afterBoot,beforeBoot),(_afterNew,beforeNew)) _ ->
         let past = (relations beforeNew) `Map.difference` (relations afterBoot)
         in  property $ TxMetaHistory past == beforeBoot
 

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/StoreSpec.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-
 module Cardano.Wallet.DB.Store.Meta.StoreSpec
     ( spec )
     where
@@ -20,7 +19,7 @@ import Cardano.Wallet.DB.Fixtures
 import Cardano.Wallet.DB.Store.Meta.Model
     ( DeltaTxMetaHistory (..), TxMetaHistory (..) )
 import Cardano.Wallet.DB.Store.Meta.ModelSpec
-    ( genDeltasForManipulate, genExpand )
+    ( genExpand, genRollback )
 import Cardano.Wallet.DB.Store.Meta.Store
     ( mkStoreMetaTransactions )
 import Cardano.Wallet.Primitive.Types
@@ -40,10 +39,10 @@ spec = around (withDBInMemory ForeignKeysEnabled) $ do
 
 genDeltas :: WalletId -> TxMetaHistory -> Gen DeltaTxMetaHistory
 genDeltas wid history =
-    frequency $
-        (10, Expand <$> genExpand wid arbitrary)
-            : fmap (fmap (fmap Manipulate)) (genDeltasForManipulate history)
-
+    frequency
+        [ (10, Expand <$> genExpand wid arbitrary)
+        , (3, genRollback history)
+        ]
 
 prop_StoreMetaLaws :: WalletProperty
 prop_StoreMetaLaws = withInitializedWalletProp $ \wid runQ ->

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/ModelSpec.hs
@@ -53,11 +53,7 @@ prop_RollbackCollectsGarbage = \GenRollback{wid,slot,history} ->
         rollbackA wid slot history
     === rollbackB wid slot history
   where
-    rollbackMetas wid slot = apply (Adjust wid change)
-      where
-        change
-            = TxMetas.Manipulate
-            $ TxMetas.RollBackTxMetaHistory slot
+    rollbackMetas wid slot = apply (Adjust wid  $ TxMetas.Rollback slot)
 
     rollbackA wid slot (x, wmetas) =
         fst $ TxWallets.garbageCollectTxWalletsHistory


### PR DESCRIPTION
-- remove unused operations on transactions metas (now they only store in-ledger txs)
-- compress operations on transactions metas (we do not need 2 levels)

ADP-2824
