### PR TITLE
[ADP-2826] Use decorateTxInsForReadTxFromLookupTxOut in mkDecorator

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -108,7 +108,7 @@ import Cardano.Wallet.DB.Store.Submissions.Layer
     ( pruneByFinality, rollBackSubmissions )
 import Cardano.Wallet.DB.Store.Transactions.Decoration
     ( TxInDecorator
-    , decorateTxInsForReadTx
+    , decorateTxInsForReadTxFromLookupTxOut
     , decorateTxInsForRelationFromLookupTxOut
     )
 import Cardano.Wallet.DB.Store.Transactions.Model
@@ -757,9 +757,9 @@ mkDecorator
     :: QueryStoreTxWalletsHistory
     -> TxInDecorator (EraValue Read.Tx) (SqlPersistT IO)
 mkDecorator transactionsQS =
-    decorateTxInsForReadTx lookupTx
+    decorateTxInsForReadTxFromLookupTxOut lookupTxOut
   where
-    lookupTx = queryS transactionsQS . GetByTxId
+    lookupTxOut = queryS transactionsQS . GetTxOut
 
 readWalletMetadata
     :: W.WalletId

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
@@ -27,6 +27,7 @@ module Cardano.Wallet.DB.Store.Transactions.Decoration
    , decorateTxInsForRelation
    , decorateTxInsForRelationFromLookupTxOut
    , decorateTxInsForReadTx
+   , decorateTxInsForReadTxFromLookupTxOut
    ) where
 
 import Prelude hiding
@@ -208,3 +209,21 @@ decorateTxInsForReadTx lookupTx tx
   where
     undoWTxIn :: W.TxIn -> (TxId, Word32)
     undoWTxIn (W.TxIn k n) = (TxId k,n)
+
+-- | Decorate the Tx inputs of a given 'TxRelation'
+-- by searching the 'TxSet' for corresponding output values.
+decorateTxInsForReadTxFromLookupTxOut
+    :: Monad m
+    => LookupFun m (TxId, Word32) W.TxOut
+    -> EraValue Read.Tx
+    -> m DecoratedTxIns
+decorateTxInsForReadTxFromLookupTxOut lookupTxOut' tx
+    = decorateTxInsInternal lookupTxOut'
+            (fmap undoWTxIn
+                $ extractEraValue $ applyEraFun (getInputs . getEraInputs) tx)
+            (fmap undoWTxIn
+                $ extractEraValue $ applyEraFun
+                    (getCollateralInputs . getEraCollateralInputs) tx)
+    where
+        undoWTxIn :: W.TxIn -> (TxId, Word32)
+        undoWTxIn (W.TxIn k n) = (TxId k,n)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
@@ -26,7 +26,6 @@ module Cardano.Wallet.DB.Store.Transactions.Decoration
    , TxInDecorator
    , decorateTxInsForRelation
    , decorateTxInsForRelationFromLookupTxOut
-   , decorateTxInsForReadTx
    , decorateTxInsForReadTxFromLookupTxOut
    ) where
 
@@ -191,24 +190,6 @@ decorateTxInsForRelation lookupTx TxRelation{ins,collateralIns} =
     decorateTxInsInternalLookupTxRelation lookupTx
         (mkTxOutKey <$> ins)
         (mkTxOutKeyCollateral <$> collateralIns)
-
--- | Decorate the Tx inputs of a given 'TxRelation'
--- by searching the 'TxSet' for corresponding output values.
-decorateTxInsForReadTx
-    :: Monad m
-    => LookupFun m TxId TxRelation
-    -> EraValue Read.Tx
-    -> m DecoratedTxIns
-decorateTxInsForReadTx lookupTx tx
-  = decorateTxInsInternalLookupTxRelation lookupTx
-        (fmap undoWTxIn
-            $ extractEraValue $ applyEraFun (getInputs . getEraInputs) tx)
-        (fmap undoWTxIn
-            $ extractEraValue $ applyEraFun
-                (getCollateralInputs . getEraCollateralInputs) tx)
-  where
-    undoWTxIn :: W.TxIn -> (TxId, Word32)
-    undoWTxIn (W.TxIn k n) = (TxId k,n)
 
 -- | Decorate the Tx inputs of a given 'TxRelation'
 -- by searching the 'TxSet' for corresponding output values.


### PR DESCRIPTION
- implement decorateTxInsForReadTxFromLookupTxOut
- use decorateTxInsForReadTxFromLookupTxOut in mkDecorator
- remove decorateTxInsForReadTx as unused

ADP-2826