### PR TITLE
Rework of the Tx deposit/refund detection logic.

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -92,9 +92,7 @@ import qualified Prelude
 -- The 'Coin' type has 'Semigroup' and 'Monoid' instances that correspond
 -- to ordinary addition and summation.
 --
-newtype Coin = Coin
-    { unCoin :: Natural
-    }
+newtype Coin = Coin { unCoin :: Natural }
     deriving stock (Ord, Eq, Generic)
     deriving (Read, Show) via (Quiet Coin)
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2198,27 +2198,23 @@ postTransactionOld ctx@ApiLayer{..} genChange (ApiT wid) body = do
                     , builtSealedTx = sealedTx
                     }
             pure (sel, tx, txMeta, txTime, pp)
-        mkApiTransaction
-            (timeInterpreter netLayer)
-            wrk wid
-            #pendingSince
-            MkApiTransactionParams
-                { txId = tx ^. #txId
-                , txFee = tx ^. #fee
-                , txInputs = NE.toList $ second Just <$> sel ^. #inputs
-                -- TODO: ADP-957:
-                , txCollateralInputs = []
-                , txOutputs = tx ^. #outputs
-                , txCollateralOutput = tx ^. #collateralOutput
-                , txWithdrawals = tx ^. #withdrawals
-                , txMeta
-                , txMetadata = tx ^. #metadata
-                , txTime
-                , txScriptValidity = tx ^. #scriptValidity
-                , txDeposit = W.stakeKeyDeposit pp
-                , txMetadataSchema = TxMetadataDetailedSchema
-                , txCBOR = tx ^. #txCBOR
-                }
+        mkApiTransaction ti wrk wid #pendingSince MkApiTransactionParams
+            { txId = tx ^. #txId
+            , txFee = tx ^. #fee
+            , txInputs = NE.toList $ second Just <$> sel ^. #inputs
+            -- TODO: ADP-957:
+            , txCollateralInputs = []
+            , txOutputs = tx ^. #outputs
+            , txCollateralOutput = tx ^. #collateralOutput
+            , txWithdrawals = tx ^. #withdrawals
+            , txMeta
+            , txMetadata = tx ^. #metadata
+            , txTime
+            , txScriptValidity = tx ^. #scriptValidity
+            , txDeposit = W.stakeKeyDeposit pp
+            , txMetadataSchema = TxMetadataDetailedSchema
+            , txCBOR = tx ^. #txCBOR
+            }
   where
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
     ti = timeInterpreter (ctx ^. networkLayer)

--- a/lib/wallet/src/Cardano/Wallet/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation.hs
@@ -61,12 +61,11 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Transaction
     ( ErrCannotJoin (..)
-    , TransactionCtx
+    , TransactionCtx (..)
     , Withdrawal (..)
     , defaultTransactionCtx
     , txDelegationAction
     , txValidityInterval
-    , txWithdrawal
     )
 import Control.Error
     ( lastMay )


### PR DESCRIPTION
Rework of the Tx deposit/refund detection logic:
- takes collateral inputs/outputs into account;
- take fee  into account if it is recorded (https://github.com/input-output-hk/cardano-wallet/pull/3785).

### Issue Number

ADP-2298
