### PR TITLE
Use nixpkgs-unstable for the openapi-spec-validator dependency

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -946,6 +946,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable_2": {
+      "locked": {
+        "lastModified": 1679172431,
+        "narHash": "sha256-XEh5gIt5otaUbEAPUY5DILUTyWe1goAyeqQtmwaFPyI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1603d11595a232205f03d46e635d919d1e1ec5b9",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
     "nixpkgs_10": {
       "locked": {
         "lastModified": 1678872516,
@@ -1167,7 +1182,8 @@
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
-        ]
+        ],
+        "nixpkgs-unstable": "nixpkgs-unstable_2"
       }
     },
     "stackage": {

--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,7 @@
   ############################################################################
 
   inputs = {
+    nixpkgs-unstable.url = "nixpkgs/nixos-unstable";
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     hostNixpkgs.follows = "nixpkgs";
     CHaP = {
@@ -156,7 +157,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, hostNixpkgs, flake-utils, haskellNix, iohkNix, CHaP, customConfig, emanote, ... }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, hostNixpkgs, flake-utils, haskellNix, iohkNix, CHaP, customConfig, emanote, ... }:
     let
       inherit (nixpkgs) lib;
       config = import ./nix/config.nix lib customConfig;
@@ -225,7 +226,11 @@
             collectChecks
             check;
 
-          project = (import ./nix/haskell.nix CHaP pkgs.haskell-nix).appendModule [{
+          project = (import ./nix/haskell.nix
+              CHaP
+              pkgs.haskell-nix
+              nixpkgs-unstable.legacyPackages.${system}
+            ).appendModule [{
             gitrev =
               if config.gitrev != null
               then config.gitrev
@@ -456,7 +461,7 @@
                   (keepIntegrationChecks packages.checks);
             };
         };
-      
+
       systems = eachSystem supportedSystems mkOutputs;
     in
       lib.recursiveUpdate systems {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -1,7 +1,7 @@
 ############################################################################
 # Builds Haskell packages with Haskell.nix
 ############################################################################
-CHaP: haskell-nix: haskell-nix.cabalProject' [
+CHaP: haskell-nix: nixpkgs-recent: haskell-nix.cabalProject' [
   ({ lib, pkgs, buildProject, ... }: {
     options = {
       gitrev = lib.mkOption {
@@ -131,7 +131,7 @@ CHaP: haskell-nix: haskell-nix.cabalProject' [
           go-jira
           haskellPackages.ghcid
           pkgconfig
-          python3Packages.openapi-spec-validator
+          nixpkgs-recent.python3Packages.openapi-spec-validator
           (ruby_3_1.withPackages (ps: [ ps.rake ps.thor ]))
           sqlite-interactive
           curlFull


### PR DESCRIPTION
Slightly hacky way to bring in the newest available version of the `openapi-spec-validator`