### PR TITLE
Strengthen property tests for `applyBlocks`.

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq/Gen.hs
@@ -317,6 +317,8 @@ genTxFromUTxO genAddr u = do
         , Just TxScriptInvalid
         ]
     pure $ txWithoutIdToTx TxWithoutId
+        -- TODO: https://input-output.atlassian.net/browse/ADP-2895
+        -- We currently do not cover the case where fees are 'Nothing':
         { fee = Just feeCoin
         , resolvedInputs = fmap Just <$> inputs
         , resolvedCollateralInputs = fmap Just <$> collateralInputs

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -2659,10 +2659,7 @@ prop_applyBlocks_filteredTxs_someOurs
     -> Pretty BlockSeq
     -> Property
 prop_applyBlocks_filteredTxs_someOurs (Pretty someOurs) (Pretty blockSeq)
-    -- TODO: we currently ignore transaction fees, as under some circumstances
-    -- the 'applyBlocks' function can modify fee values:
-    = fmap (set #fee Nothing) ourTxsReturned ====
-      fmap (set #fee Nothing) ourTxsExpected
+    = ourTxsReturned ==== ourTxsExpected
     & labelInterval 10
         "length allTxsProvided"
         (length allTxsProvided)

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -134,7 +134,7 @@ import Data.Functor
 import Data.Functor.Identity
     ( Identity (..) )
 import Data.Generics.Internal.VL.Lens
-    ( over, set, view, (^.) )
+    ( over, view, (^.) )
 import Data.Generics.Labels
     ()
 import Data.List
@@ -2683,10 +2683,7 @@ prop_applyBlocks_filteredTxs_someOurs (Pretty someOurs) (Pretty blockSeq)
 --
 prop_applyBlocks_filteredTxs_allOurs :: Pretty BlockSeq -> Property
 prop_applyBlocks_filteredTxs_allOurs (Pretty blockSeq) =
-    -- TODO: we currently ignore transaction fees, as under some circumstances
-    -- the 'applyBlocks' function can modify fee values:
-    fmap (set #fee Nothing) ourTxsReturned ====
-    fmap (set #fee Nothing) ourTxsExpected
+    ourTxsReturned ==== ourTxsExpected
   where
     ourHeadUTxOProvided = blockSeqHeadUTxO blockSeq
     ourTxsExpected = blockSeqOurTxs AllOurs blockSeq


### PR DESCRIPTION
## Issue

ADP-2840 / #3785

## Summary

The `applyBlocks` function was recently changed so that fees of incoming transactions, if present (i.e., not `Nothing`), are no longer stripped away (i.e., no longer replaced with `Nothing`).

The following commits are relevant:

- https://github.com/input-output-hk/cardano-wallet/commit/120c7decdc662607758de60c7c8690845baeb22b
- https://github.com/input-output-hk/cardano-wallet/commit/634265eb4bb13bc0c7782c889753affce62e1760

Consequently, it is now more straightforward to test our expectations about the `fee` field within our property tests for `applyBlocks`. In particular, we now test that `applyBlocks` does not modify the `fee` field in any way (if it is not `Nothing`), whereas before, the `fee` field was deliberately excluded from the test.

Note that this does rely on the fact that our transaction sequence generator never generates transactions with fees that are `Nothing`:

https://github.com/input-output-hk/cardano-wallet/blob/4af4c184a2f986a51c44c0f93a5eef7e7fa31acf/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq/Gen.hs#L319-L320

If in future we revise this generator to also cover transactions where fees can be `Nothing`, we will have to also revise these property tests.

This PR adjusts the following property tests, which test that `applyBlocks` returns all transactions that are relevant to the wallet (and no others), and that they are returned in the same order that they appear in the blockchain:

- [`prop_applyBlocks_filteredTxs_someOurs`](https://github.com/input-output-hk/cardano-wallet/blob/76f09ef7fda58418710b8394603d75d677b34425/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs#L2657)
    tests `applyBlocks` in scenarios where **_only some_** transactions in an arbitrary block sequence are relevant to a wallet.
- [`prop_applyBlocks_filteredTxs_allOurs`](https://github.com/input-output-hk/cardano-wallet/blob/76f09ef7fda58418710b8394603d75d677b34425/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs#L2687)
    tests `applyBlocks` in scenarios where **_all_** transactions in an arbitrary block sequence are relevant to a wallet.