### PR TITLE
[E2e tests] Temporary/ad-hoc config changes for cardano-node

### DIFF
--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -278,13 +278,15 @@ task :get_latest_configs, [:env] do |_task, args|
     config_edited = config.gsub(/#{env}-/, '')
     File.open(config_file, 'w') { |file| file.puts config_edited }
 
-    # Turn off p2p
-    # topology from https://book.world.dev.cardano.org/environments.html is no longer compatible with cardano-node 1.35.4
-    # so we need to turn off p2p for now
+    # Temporary/ad-hoc config changes for cardano-node:
+    #  - disable P2P
+    #  - use conway-genesis.json
     config_dir = File.join(CONFIGS, args[:env])
     config_json = JSON.parse(File.read("#{config_dir}/config.json"))
     config_json['EnableP2P'] = false
+    config_json['ConwayGenesisFile'] = 'conway-genesis.json'
     File.write("#{config_dir}/config.json", JSON.pretty_generate(config_json))
+
     topology = %({
           "Producers": [
             {
@@ -295,6 +297,10 @@ task :get_latest_configs, [:env] do |_task, args|
           ]
         })
     File.write("#{config_dir}/topology.json", topology)
+
+    # Add conway-genesis.json
+    File.write("#{config_dir}/conway-genesis.json", ' { "genDelegs": {} }')
+
   end
 end
 


### PR DESCRIPTION
- [x] I have added conway-genesis to e2e tests node config

### Comments

After https://github.com/input-output-hk/cardano-wallet/pull/3736 we build cardano-node 1.36.0. Probably until we target 1.35.6 the changes in the configs are needed

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
