### PR TITLE
[ADP-2868] Use cbor to deserialize transactions when present.

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -832,4 +832,4 @@ mkTransactionInfo ti decorator tip = \case
         let readTx = fromSealedTx tx
         decorate <- decorator readTx
         Just <$> mkTransactionInfoFromReadTx
-            ti tip decorate readTx meta s
+            ti tip readTx decorate meta s

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Model.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {- |
@@ -19,6 +20,7 @@ module Cardano.Wallet.DB.Store.Meta.Model
     , mkTxMetaHistory
     , rollbackTxMetaHistory
     , WalletsMeta
+    , mkTxMetaFromEntity
     ) where
 
 import Prelude
@@ -36,7 +38,7 @@ import Data.Generics.Internal.VL
 import Data.Map.Strict
     ( Map )
 import Data.Quantity
-    ( Quantity (getQuantity) )
+    ( Quantity (..) )
 import Data.Set
     ( Set )
 import Fmt
@@ -128,3 +130,13 @@ mkTxMetaHistory wid txs = TxMetaHistory $
         ]
 
 type WalletsMeta = Map W.WalletId TxMetaHistory
+
+mkTxMetaFromEntity :: TxMeta -> W.TxMeta
+mkTxMetaFromEntity TxMeta{..} = W.TxMeta
+    { W.status = txMetaStatus
+    , W.direction = txMetaDirection
+    , W.slotNo = txMetaSlot
+    , W.blockHeight = Quantity (txMetaBlockHeight)
+    , amount = txMetaAmount
+    , W.expiry = txMetaSlotExpires
+    }

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Layer.hs
@@ -18,6 +18,8 @@ module Cardano.Wallet.DB.Store.Transactions.Layer
 
 import Prelude
 
+import Cardano.Wallet.DB.Sqlite.Schema
+    ( CBOR )
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId )
 import Cardano.Wallet.DB.Store.QueryStore
@@ -43,7 +45,7 @@ import qualified Data.Map.Strict as Map
     DB for 'TxSet'
 ------------------------------------------------------------------------------}
 data QueryTxSet b where
-    GetByTxId :: TxId -> QueryTxSet (Maybe TxRelation)
+    GetByTxId :: TxId -> QueryTxSet (Maybe (Either TxRelation CBOR))
     GetTxOut :: (TxId, Word32) -> QueryTxSet (Maybe W.TxOut)
 
 -- | Implementation of a 'QueryStore' for 'TxSet'.
@@ -66,7 +68,7 @@ instance Query QueryTxSet where
 
 runQuery :: TxSet -> QueryTxSet b -> b
 runQuery (TxSet txs) = \case
-    GetByTxId txid -> Map.lookup txid txs
+    GetByTxId txid -> Left <$> Map.lookup txid txs
     GetTxOut (txid,index) -> do
         tx <- Map.lookup txid txs
         let outputs

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -19,7 +19,7 @@ module Cardano.Wallet.DB.Store.Wallets.Layer
 import Prelude
 
 import Cardano.Wallet.DB.Sqlite.Schema
-    ( TxMeta (..) )
+    ( CBOR, TxMeta (..) )
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.Meta.Model
@@ -50,7 +50,7 @@ import qualified Data.Map.Strict as Map
     Query type
 ------------------------------------------------------------------------------}
 data QueryTxWalletsHistory b where
-    GetByTxId :: TxId -> QueryTxWalletsHistory (Maybe TxRelation)
+    GetByTxId :: TxId -> QueryTxWalletsHistory (Maybe (Either TxRelation CBOR))
     GetTxOut :: (TxId, Word32) -> QueryTxWalletsHistory (Maybe W.TxOut)
     One :: W.WalletId -> TxId -> QueryTxWalletsHistory (Maybe TxMeta)
     All :: W.WalletId -> QueryTxWalletsHistory [TxMeta]

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -180,7 +180,7 @@ prop_selectTx =
             runQ $ writeS mkStoreTransactions txs
             forM_ (Map.assocs $ relations txs) $ \(txId, tx) -> do
                 Just tx' <- runQ $ selectTx txId
-                assertWith "relation is consistent" $ tx == tx'
+                assertWith "relation is consistent" $ Left tx == tx'
 
 prop_QueryLaw :: StoreProperty
 prop_QueryLaw =
@@ -211,7 +211,7 @@ queryLaw QueryStore{queryS} z r =
 ------------------------------------------------------------------------------}
 addCBOR :: Tx -> Gen Tx
 addCBOR tx = do
-    mcbor <- arbitrary
+    let mcbor = Nothing
     pure $ tx{txCBOR = mcbor}
 
 -- | Generate interesting changes to 'TxSet'.


### PR DESCRIPTION
### Overview

When listing all transactions, the wallet currently retrieves transaction data from the database by joining several tables. This task is about using the CBOR — when available — to retrieve the transaction content instead. We expect this to increase the running time of this operation.

### Comments

Storing the CBOR of transactions in the database is a fairly recent feature — wallets with very old databases may not benefit from the improved running time.

### Issue Number

ADP-2868