### PR TITLE
Use latest buildkite build for e2e test regardless of its state

### DIFF
--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -231,10 +231,11 @@ end
 task :get_latest_bins, [:branch, :state] do |_task, args|
   log ">> Getting latest node and wallet binaries from Buildkite into #{BINS}"
   branch = args[:branch] || 'master'
-  state = args[:state] || 'passed'
+  state = args[:state] || 'any'
+  filter = state == 'any' ? { branch: branch } : { branch: branch, state: state }
   bk = Buildkite.new
-  last_build = bk.last_build_number(branch: branch, state: state)
-  log "Latest passing buildkite '#{bk.pipeline}' pipeline for branch '#{branch}' is #{last_build}"
+  last_build = bk.last_build_number(filter)
+  log "Latest #{filter} buildkite '#{bk.pipeline}' pipeline build is #{last_build}"
   jobs = bk.jobs(last_build)
   mk_dir(BINS)
 


### PR DESCRIPTION

- [x] Use latest buildkite build for e2e test regardless of it's state

### Comments

MacOS buildkite is quite slow lately and seems to cancel or fail. Let's get latest build for e2e tests regardless if it passed or not for now.

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
