### PR TITLE
Add `UTxOAssumptions` abstraction to `balanceTransaction` interface

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -682,7 +682,7 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Read as Read
 import qualified Cardano.Wallet.Registry as Registry
 import qualified Cardano.Wallet.Write.Tx as WriteTx
-import qualified Cardano.Wallet.Write.Tx.Balance as W
+import qualified Cardano.Wallet.Write.Tx.Balance as Write
 import qualified Control.Concurrent.Concierge as Concierge
 import qualified Data.ByteString as BS
 import qualified Data.Foldable as F
@@ -3009,10 +3009,10 @@ balanceTransaction
 
         let mkPartialTx
                 :: forall era. WriteTx.IsRecentEra era => Cardano.Tx era
-                -> Handler (W.PartialTx era)
+                -> Handler (Write.PartialTx era)
             mkPartialTx tx = do
                 utxo <- fmap WriteTx.toCardanoUTxO $ mkLedgerUTxO $ body ^. #inputs
-                pure $ W.PartialTx
+                pure $ Write.PartialTx
                     tx
                     utxo
                     (fromApiRedeemer <$> body ^. #redeemers)
@@ -3039,7 +3039,7 @@ balanceTransaction
                 mkRecentEra = case Cardano.cardanoEra @era of
                     Cardano.BabbageEra -> pure WriteTx.RecentEraBabbage
                     Cardano.AlonzoEra -> pure WriteTx.RecentEraAlonzo
-                    _ -> liftHandler $ throwE $ W.ErrOldEraNotSupported era
+                    _ -> liftHandler $ throwE $ Write.ErrOldEraNotSupported era
 
                 mkLedgerUTxO
                     :: [ApiExternalInput n]
@@ -3055,10 +3055,10 @@ balanceTransaction
 
         let balanceTx
                 :: forall era. WriteTx.IsRecentEra era
-                => W.PartialTx era
+                => Write.PartialTx era
                 -> Handler (Cardano.Tx era)
             balanceTx partialTx =
-                liftHandler $ fst <$> W.balanceTransaction @_ @IO @s @k @ktype
+                liftHandler $ fst <$> Write.balanceTransaction @_ @IO @s @k @ktype
                     (MsgWallet . W.MsgBalanceTx >$< wrk ^. W.logger)
                     (ctx ^. typed)
                     genInpScripts
@@ -3078,7 +3078,7 @@ balanceTransaction
                         ])
                     $ W.currentNodeProtocolParameters pp
 
-        anyRecentTx <- maybeToHandler (W.ErrOldEraNotSupported era)
+        anyRecentTx <- maybeToHandler (Write.ErrOldEraNotSupported era)
             . WriteTx.asAnyRecentEra
             . cardanoTxIdeallyNoLaterThan era
             . getApiT $ body ^. #transaction
@@ -4150,7 +4150,7 @@ guardIsRecentEra (Cardano.AnyCardanoEra era) = case era of
     Cardano.ShelleyEra -> liftE invalidEra
     Cardano.ByronEra   -> liftE invalidEra
   where
-    invalidEra = W.ErrOldEraNotSupported $ Cardano.AnyCardanoEra era
+    invalidEra = Write.ErrOldEraNotSupported $ Cardano.AnyCardanoEra era
 
 mkWithdrawal
     :: forall (n :: NetworkDiscriminant) ktype tx block

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3058,11 +3058,13 @@ balanceTransaction
                 => Write.PartialTx era
                 -> Handler (Cardano.Tx era)
             balanceTx partialTx =
-                liftHandler $ fst <$> Write.balanceTransaction @_ @IO @s @k @ktype
+                liftHandler $ fst <$> Write.balanceTransaction @_ @IO @s
                     (MsgWallet . W.MsgBalanceTx >$< wrk ^. W.logger)
-                    (ctx ^. typed)
-                    genInpScripts
-                    mScriptTemplate
+                    (Write.UTxOAssumptions
+                        txLayer
+                        genInpScripts
+                        mScriptTemplate
+                        "<either script or key payment credentials>")
                     (pp, nodePParams)
                     ti
                     utxoIndex
@@ -3450,7 +3452,7 @@ joinStakePool
             ti = timeInterpreter netLayer
 
         (BuiltTx{..}, txTime) <- liftIO $
-            W.buildSignSubmitTransaction @k @'CredFromKeyK @s @n
+            W.buildSignSubmitTransaction @k @s @n
                 ti
                 db
                 netLayer
@@ -3548,7 +3550,7 @@ quitStakePool ctx@ApiLayer{..} argGenChange (ApiT walletId) body = do
             Just Refl -> liftIO $ WD.quitStakePool netLayer db ti walletId
             _ -> liftHandler $ throwE ErrReadRewardAccountNotAShelleyWallet
         (BuiltTx{..}, txTime) <- liftIO $ do
-            W.buildSignSubmitTransaction @k @'CredFromKeyK @s @n
+            W.buildSignSubmitTransaction @k @s @n
                 ti
                 db
                 netLayer

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2874,7 +2874,7 @@ constructSharedTransaction
                     txLayer netLayer db wid txCtx PreSelection {outputs = outs}
 
                 balancedTx <-
-                    balanceTransaction ctx argGenChange scriptLookup
+                    balanceTransaction ctx argGenChange (Just scriptLookup)
                     (Just (Shared.paymentTemplate $ getState cp)) (ApiT wid)
                         ApiBalanceTransactionPostData
                         { transaction =
@@ -2987,7 +2987,7 @@ balanceTransaction
      . (GenChange s, BoundedAddressLength k)
     => ApiLayer s k ktype
     -> ArgGenChange s
-    -> Maybe ([(TxIn, TxOut)] -> [Script KeyHash])
+    -> Maybe (Address -> Script KeyHash)
     -> Maybe ScriptTemplate
     -> ApiT WalletId
     -> ApiBalanceTransactionPostData n

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3063,8 +3063,7 @@ balanceTransaction
                     (Write.UTxOAssumptions
                         txLayer
                         genInpScripts
-                        mScriptTemplate
-                        "<either script or key payment credentials>")
+                        mScriptTemplate)
                     (pp, nodePParams)
                     ti
                     utxoIndex

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -743,14 +743,13 @@ noTxUpdate :: TxUpdate
 noTxUpdate = TxUpdate [] [] [] [] UseOldTxFee
 
 -- | Method to use when updating the fee of a transaction.
-data TxFeeUpdate = UseOldTxFee
-                 -- ^ Instead of updating the fee, just use the old fee of the
-                 -- Tx (no-op for fee update).
-                 | UseNewTxFee Coin
-                 -- ^ Specify a new fee to use instead.
+data TxFeeUpdate
+    = UseOldTxFee
+        -- ^ Instead of updating the fee, just use the old fee of the
+        -- Tx (no-op for fee update).
+    | UseNewTxFee Coin
+        -- ^ Specify a new fee to use instead.
     deriving (Eq, Show)
-
-
 -- Used to add inputs and outputs when balancing a transaction.
 --
 -- If the transaction contains existing key witnesses, it will return `Left`,

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -31,8 +31,6 @@ module Cardano.Wallet.Transaction
     , defaultTransactionCtx
     , Withdrawal (..)
     , withdrawalToCoin
-    , TxUpdate (..)
-    , TxFeeUpdate(..)
     , TokenMapWithScripts (..)
     , emptyTokenMapWithScripts
     , AnyExplicitScript (..)
@@ -249,33 +247,6 @@ data TransactionLayer k ktype tx = TransactionLayer
             , WitnessCount
             )
     -- ^ Decode an externally-created transaction.
-
-    , updateTx
-        :: forall era. Cardano.IsShelleyBasedEra era
-        => Cardano.Tx era
-        -> TxUpdate
-        -> Either ErrUpdateSealedTx (Cardano.Tx era)
-        -- ^ Update tx by adding additional inputs and outputs
-    }
-
--- | Method to use when updating the fee of a transaction.
-data TxFeeUpdate = UseOldTxFee
-                 -- ^ Instead of updating the fee, just use the old fee of the
-                 -- Tx (no-op for fee update).
-                 | UseNewTxFee Coin
-                 -- ^ Specify a new fee to use instead.
-    deriving (Eq, Show)
-
--- | Describes modifications that can be made to a `Tx` using `updateTx`.
-data TxUpdate = TxUpdate
-    { extraInputs :: [(TxIn, TxOut)]
-    , extraCollateral :: [TxIn]
-       -- ^ Only used in the Alonzo era and later. Will be silently ignored in
-       -- previous eras.
-    , extraOutputs :: [TxOut]
-    , extraInputScripts :: [Script KeyHash]
-    , feeUpdate :: TxFeeUpdate
-        -- ^ Set a new fee or use the old one.
     }
 
 type TxValidityInterval = (Maybe SlotNo, SlotNo)

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -316,7 +316,6 @@ data UTxOAssumptions = forall k ktype. UTxOAssumptions
         :: Maybe (W.Address -> (CA.Script KeyHash))
     , inputScriptTemplate
         :: Maybe ScriptTemplate
-    , description :: String
     }
 
 -- | Assumes all 'UTxO' entries have addresses with key payment credentials;
@@ -329,7 +328,6 @@ allKeyPaymentCredentials tl = UTxOAssumptions
     { txLayer = tl
     , inputScriptLookup = Nothing
     , inputScriptTemplate = Nothing
-    , description = "allKeyPaymentCredentials"
     }
 
 -- | Assumes all 'UTxO' entries have addresses with script payment credentials,
@@ -344,7 +342,6 @@ allScriptPaymentCredentials scriptLookup template tl = UTxOAssumptions
     { txLayer = tl
     , inputScriptLookup = Just scriptLookup
     , inputScriptTemplate = Just template
-    , description = "allScriptPaymentCredentials"
     }
 
 balanceTransaction
@@ -486,8 +483,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     (UTxOAssumptions
         txLayer
         toInpScriptsM
-        mScriptTemplate
-        _desc)
+        mScriptTemplate)
     (pp, nodePParams)
     ti
     internalUtxoAvailable

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -313,7 +313,7 @@ data UTxOAssumptions = forall k ktype. UTxOAssumptions
         :: TransactionLayer k ktype SealedTx
         -- TODO: Replace with smaller and smaller parts of 'TransactionLayer'
     , inputScriptLookup
-        :: Maybe ([(W.TxIn, W.TxOut)] -> [CA.Script KeyHash])
+        :: Maybe (W.Address -> (CA.Script KeyHash))
     , inputScriptTemplate
         :: Maybe ScriptTemplate
     , description :: String
@@ -336,7 +336,7 @@ allKeyPaymentCredentials tl = UTxOAssumptions
 -- where the scripts are both derived from the 'ScriptTemplate' and can be
 -- looked up using the given function.
 allScriptPaymentCredentials
-    :: ([(W.TxIn, W.TxOut)] -> [CA.Script KeyHash])
+    :: (W.Address -> (CA.Script KeyHash))
     -> ScriptTemplate
     -> TransactionLayer SharedKey 'CredFromScriptK SealedTx
     -> UTxOAssumptions
@@ -584,7 +584,8 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 
     let extraInputScripts = case toInpScriptsM of
             Just toInpScripts ->
-                toInpScripts $ extraInputs <> extraCollateral'
+                map (toInpScripts . (view #address) . snd)
+                $ extraInputs <> extraCollateral'
             Nothing ->
                 []
     let extraCollateral = fst <$> extraCollateral'

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -78,12 +78,14 @@ import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( toWalletCoin )
 import Cardano.Wallet.Shelley.Transaction
     ( KeyWitnessCount (..)
+    , TxFeeUpdate (..)
     , TxUpdate (..)
     , assignScriptRedeemers
     , distributeSurplus
     , estimateKeyWitnessCount
     , estimateSignedTxSize
     , maxScriptExecutionCost
+    , updateTx
     )
 import Cardano.Wallet.Transaction
     ( ErrAssignRedeemers
@@ -92,7 +94,6 @@ import Cardano.Wallet.Transaction
     , TransactionCtx (..)
     , TransactionLayer (..)
     , TxFeeAndChange (..)
-    , TxFeeUpdate (UseNewTxFee)
     , WitnessCountCtx (..)
     , defaultTransactionCtx
     )
@@ -665,7 +666,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         let minfee = toWalletCoin $ Write.Tx.evaluateMinimumFee
                 (recentEra @era) ledgerPP (Write.Tx.fromCardanoTx tx) witCount
         let update = TxUpdate [] [] [] [] (UseNewTxFee minfee)
-        tx' <- left ErrBalanceTxUpdateError $ updateTx txLayer tx update
+        tx' <- left ErrBalanceTxUpdateError $ updateTx tx update
         let balance = txBalance tx'
         let minfee' = Cardano.Lovelace $ fromIntegral $ W.unCoin minfee
         return (balance, minfee', witCount)
@@ -722,7 +723,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         :: TxUpdate
         -> ExceptT ErrBalanceTx m (Cardano.Tx era)
     assembleTransaction update = ExceptT . pure $ do
-        tx' <- left ErrBalanceTxUpdateError $ updateTx txLayer partialTx update
+        tx' <- left ErrBalanceTxUpdateError $ updateTx partialTx update
         left ErrBalanceTxAssignRedeemers $ assignScriptRedeemers
             nodePParams ti combinedUTxO redeemers tx'
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2752,7 +2752,9 @@ balanceTransactionSpec = describe "balanceTransaction" $ do
             mockProtocolParametersForBalancing
             (dummyTimeInterpreterWithHorizon horizon)
             utxoIndex
-            (defaultChangeAddressGen $ delegationAddress @'Mainnet)
+            (defaultChangeAddressGen
+                (delegationAddress @'Mainnet)
+                (Proxy @ShelleyKey))
             (getState wal)
             tx
       where
@@ -3643,7 +3645,9 @@ balanceTransaction' (Wallet' utxoIndex wallet _pending) seed tx  =
             mockProtocolParametersForBalancing
             dummyTimeInterpreter
             utxoIndex
-            (defaultChangeAddressGen $ delegationAddress @'Mainnet)
+            (defaultChangeAddressGen
+                (delegationAddress @'Mainnet)
+                (Proxy @ShelleyKey))
             (getState wallet)
             tx
 
@@ -3651,8 +3655,11 @@ newtype DummyChangeState = DummyChangeState { nextUnusedIndex :: Int }
     deriving (Show, Eq)
 
 dummyChangeAddrGen :: ChangeAddressGen DummyChangeState
-dummyChangeAddrGen = ChangeAddressGen $ \(DummyChangeState i) ->
+dummyChangeAddrGen = ChangeAddressGen
+    { getChangeAddressGen = \(DummyChangeState i) ->
         (addressAtIx $ toEnum i, DummyChangeState $ succ i)
+    , maxLengthChangeAddress = addressAtIx minBound
+    }
       where
         addressAtIx
             :: Index

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -1326,8 +1326,6 @@ dummyTransactionLayer = TransactionLayer
         , Nothing
         , emptyWitnessCount
         )
-    , updateTx = \sealed _update ->
-        pure sealed
     }
   where
     forMaybe :: [a] -> (a -> Maybe b) -> [b]


### PR DESCRIPTION
- [x] `BoundedAddressLength` matters only for change generation, so let's embed it inside `ChangeAddressGen`.
- [x] Bundle together`TransactionLayer k ktype SealedTx` and shared-wallet-specific arguments inside a new `UTxOAssumptions` record.
- [x] Get CI fully green
- [x] Remaining: look over doc comments for new abstractions in `.Balance` module

### Overall strategy

- Reduce type parameters of `balanceTransaction`. This PR changes it from `era m s k ktype` to `era m changeState`

### Comments

- Setup for #3765 where pairs of `UTxO` and `UTxOAssumptions` will be generated in both shelley, byron and shared wallet styles in the property tests.
- Designed to be reviewed commit per commit

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2613

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
