### PR TITLE
Tx fee integration testing

### DIFF
--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -428,6 +428,8 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
                 , expectField (#status . #getApiT) (`shouldBe` InLedger)
                 , expectField (#metadata) (`shouldBe` Nothing)
+                , expectField (#fee . #getQuantity) $
+                    between (feeMin, feeMax)
                 ]
 
         let linkDest = Link.getTransaction @'Shelley wb (ApiTxId txid)
@@ -441,6 +443,8 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 , expectField (#direction . #getApiT) (`shouldBe` Incoming)
                 , expectField (#status . #getApiT) (`shouldBe` InLedger)
                 , expectField (#metadata) (`shouldBe` Nothing)
+                , expectField (#fee . #getQuantity) $
+                    between (feeMin, feeMax)
                 ]
 
         eventually "wa and wb balances are as expected" $ do


### PR DESCRIPTION
- [x] I have added integration tests/additional assertions around fees for incoming/outgoing transactions since it was not covered in the suite
- [x] I have added fee expectations for joining/quitting pool such that it reflects behavior after ADP-2840 (i.e. fee is presented on both join and quit pool txs)

### Comments

We used to show `fee` only for `outgoing` transactions and always show `fee == 0` for `incoming` ones. That changed and now we show `fee` for all transactions. The exception is that in old transactions that were done in the Byron era the `fee` is still presented as `0`. 
  
As a follow up from the discussion https://github.com/input-output-hk/cardano-wallet/pull/3806#discussion_r1145026139 I'm adding some integration testing to cover the new behavior. The exception is not tested here because all integration tests transactions are done in post-Byron.

### Issue Number

ADP-2840
