### PR TITLE
[ADP-2878] remove cleanDB from unit tests

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -18,7 +18,6 @@ module Cardano.Wallet.DB
     ( -- * Interface
       DBLayer (..)
     , DBFactory (..)
-    , cleanDB
 
     -- * DBLayer building blocks
     , DBLayerCollection (..)
@@ -104,7 +103,7 @@ import Control.Monad
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
 import Control.Monad.Trans.Except
-    ( ExceptT (..), runExceptT )
+    ( ExceptT (..) )
 import Data.DBVar
     ( DBVar, modifyDBMaybe, readDBVar )
 import Data.Functor
@@ -785,10 +784,6 @@ data DBPrivateKey stm k = DBPrivateKey
 {-----------------------------------------------------------------------------
     Helper functions
 ------------------------------------------------------------------------------}
--- | Clean a database by removing all wallets.
-cleanDB :: DBLayer m s k -> m ()
-cleanDB DBLayer{..} = atomically $
-    listWallets >>= mapM_ (runExceptT . removeWallet)
 
 -- | Sort transactions by slot number.
 sortTransactionsBySlot

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -75,7 +75,7 @@ import Cardano.Wallet.DB.Sqlite.Migration
     , currentSchemaVersion
     )
 import Cardano.Wallet.DB.StateMachine
-    ( TestConstraints, prop_parallel, prop_sequential, validateGenerators )
+    ( TestConstraints, prop_sequential, validateGenerators )
 import Cardano.Wallet.DB.WalletState
     ( ErrNoSuchWallet (..) )
 import Cardano.Wallet.DummyTarget.Primitive.Types
@@ -329,7 +329,6 @@ stateMachineSpec = describe ("State machine test (" ++ showState @s ++ ")") $ do
     validateGenerators @s
     let newDB = newDBLayerInMemory @s @k nullTracer dummyTimeInterpreter
     it "Sequential" $ prop_sequential newDB
-    xit "Parallel" $ prop_parallel newDB
 
 stateMachineSpecSeq, stateMachineSpecRnd, stateMachineSpecShared :: Spec
 stateMachineSpecSeq = stateMachineSpec @ShelleyKey @(SeqState 'Mainnet ShelleyKey) @'CredFromKeyK

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -66,7 +66,6 @@ import Cardano.Wallet.DB.Pure.Implementation
     , TxHistory
     , WalletDatabase (..)
     , emptyDatabase
-    , mCleanDB
     , mInitializeWallet
     , mIsStakeKeyRegistered
     , mListCheckpoints

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -43,7 +43,6 @@
 
 module Cardano.Wallet.DB.StateMachine
     ( prop_sequential
-    , prop_parallel
     , validateGenerators
     , showLabelledExamples
     , TestConstraints
@@ -258,15 +257,11 @@ import Test.StateMachine
     , forall
     , member
     , prettyCommands
-    , prettyParallelCommands
     , runCommands
-    , runParallelCommands
     , (.==)
     )
-import Test.StateMachine.Parallel
-    ( forAllParallelCommands )
 import Test.StateMachine.Types
-    ( Command (..), Commands (..), ParallelCommands, ParallelCommandsF (..) )
+    ( Commands (..) )
 import UnliftIO.Async
     ( race_ )
 import UnliftIO.Concurrent
@@ -1329,22 +1324,6 @@ prop_sequential newDB =
         matchedTags :: Set Tag
         matchedTags = Set.fromList $ tag $ execCmds cmds
 
-prop_parallel
-    :: forall s k. TestConstraints s k
-    => (IO (IO (), DBLayer IO s k))
-    -> Property
-prop_parallel newDB =
-    forAllParallelCommands (sm @IO @s @k dbLayerUnused) nThreads $ \cmds ->
-    monadicIO $ do
-        (destroyDB, db) <- run newDB
-        let sm' = sm db
-            cmds' = addCleanDB cmds
-        res <- runParallelCommands sm' cmds'
-        prettyParallelCommands cmds res
-        run destroyDB
-  where
-    nThreads = Just 4
-
 -- Controls that generators and shrinkers can run within a reasonable amount of
 -- time. We have been bitten several times already by generators which took much
 -- longer than what they should, causing timeouts in the test suite.
@@ -1400,18 +1379,6 @@ validateGenerators = describe "Validate generators & shrinkers" $ do
         []  -> pure ()
         [x] -> sanityCheckShrink (concatMap shrinker [x])
         xs  -> sanityCheckShrink (concatMap shrinker [head xs, last xs])
-
--- | The commands for parallel tests are run multiple times to detect
--- concurrency problems. We need to clean the database before every run. The
--- easiest way is to add a CleanDB command at the beginning of the prefix.
-addCleanDB
-    :: ParallelCommands (At (Cmd s)) (At (Resp s))
-    -> ParallelCommands (At (Cmd s)) (At (Resp s))
-addCleanDB (ParallelCommands p s) = ParallelCommands (clean <> p) s
-  where
-    clean = Commands [cmd resp mempty]
-    cmd = Command (At CleanDB)
-    resp = At (Resp (Right (Unit ())))
 
 dbLayerUnused :: DBLayer m s k
 dbLayerUnused = error "DBLayer not used during command generation"


### PR DESCRIPTION
This is part of the epic to remove (unused) multi-wallet support in DBLayer

Because we need to remove the removeWallet function in the DBLayer we need to remove cleanDB function which is based on it. A lot of testing/benching code depends on it to reuse the database instance for multiple subsequent operations. It turned out redundant at all call sites

- [x] remove cleanDB function use in tests
- [x] remove cleanDB function definition

ADP-2878