### PR TITLE
[ADP-2878] remove remove wallet from dblayer

### DIFF
--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -831,8 +831,6 @@ bench_restoration
                     results <-
                         benchmarks proxy w wid0 wname0 benchname restorationTime
                     saveBenchmarkPoints benchname results
-                    forM_ wallets $ \(wid, _, _) ->
-                        unsafeRunExceptT (W.deleteWallet w wid)
                     pure $ SomeBenchmarkResults results
   where
     fst' (x,_,_) = x

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1218,8 +1218,8 @@ deleteWallet
     => ctx
     -> WalletId
     -> ExceptT ErrNoSuchWallet IO ()
-deleteWallet ctx wid = db & \DBLayer{..} -> do
-    mapExceptT atomically $ removeWallet wid
+deleteWallet ctx _wid = db & \DBLayer{..} -> do
+    mapExceptT atomically $ error "removeWallet deprecated"
   where
     db = ctx ^. dbLayer @IO @s @k
 

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -72,7 +72,6 @@ module Cardano.Wallet
     , getWalletUtxoSnapshot
     , listUtxoStatistics
     , readWallet
-    , deleteWallet
     , restoreWallet
     , updateWallet
     , updateWalletPassphraseWithOldPassphrase
@@ -1207,21 +1206,6 @@ restoreBlocks ctx tr wid blocks nodeTip = db & \DBLayer{..} ->
     isParentOf :: Wallet s -> BlockHeader -> Bool
     isParentOf cp = (== Just parent) . parentHeaderHash
       where parent = headerHash $ currentTip cp
-
--- | Remove an existing wallet. Note that there's no particular work to
--- be done regarding the restoration worker as it will simply terminate
--- on the next tick when noticing that the corresponding wallet is gone.
-deleteWallet
-    :: forall ctx s k.
-        ( HasDBLayer IO s k ctx
-        )
-    => ctx
-    -> WalletId
-    -> ExceptT ErrNoSuchWallet IO ()
-deleteWallet ctx _wid = db & \DBLayer{..} -> do
-    mapExceptT atomically $ error "removeWallet deprecated"
-  where
-    db = ctx ^. dbLayer @IO @s @k
 
 -- | Fetch the cached reward balance of a given wallet from the database.
 fetchRewardBalance :: forall s k. DBLayer IO s k -> WalletId -> IO Coin

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -190,12 +190,6 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -- 'putWalletMeta', 'putTxHistory' or 'putProtocolParameters' will
         -- actually all fail if they are called _first_ on a wallet.
 
-    , removeWallet
-        :: WalletId
-        -> ExceptT ErrNoSuchWallet stm ()
-        -- ^ Remove a given wallet and all its associated data (checkpoints,
-        -- metadata, tx history ...)
-
     , listWallets
         :: stm [WalletId]
         -- ^ Get the list of all known wallets in the DB, possibly empty.
@@ -466,7 +460,6 @@ mkDBLayerFromParts
     -> DBLayer m s k
 mkDBLayerFromParts ti DBLayerCollection{..} = DBLayer
     { initializeWallet = initializeWallet_ dbWallets
-    , removeWallet = removeWallet_ dbWallets
     , listWallets = listWallets_ dbWallets
     , walletsDB = walletsDB_ dbCheckpoints
     , putCheckpoint = putCheckpoint_ dbCheckpoints
@@ -614,12 +607,6 @@ data DBWallets stm s = DBWallets
         :: WalletId
         -> stm (Maybe GenesisParameters)
         -- ^ Read the *Byron* genesis parameters.
-
-    , removeWallet_
-        :: WalletId
-        -> ExceptT ErrNoSuchWallet stm ()
-        -- ^ Remove a given wallet and all its associated data (checkpoints,
-        -- metadata, tx history ...)
 
     , listWallets_
         :: stm [WalletId]

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
@@ -50,7 +50,6 @@ module Cardano.Wallet.DB.Pure.Implementation
     -- * Model database functions
     , mCleanDB
     , mInitializeWallet
-    , mRemoveWallet
     , mListWallets
     , mPutCheckpoint
     , mReadCheckpoint
@@ -240,12 +239,6 @@ mInitializeWallet wid cp meta txs0 gp db@Database{wallets,txs}
             history = Map.fromList $ first (view #txId) <$> txs0
         in
             (Right (), Database (Map.insert wid wal wallets) (txs <> txs'))
-
-mRemoveWallet :: Ord wid => wid -> ModelOp wid s xprv ()
-mRemoveWallet wid db@Database{wallets,txs}
-    | wid `Map.member` wallets =
-        (Right (), Database (Map.delete wid wallets) txs)
-    | otherwise = (Left (NoSuchWallet wid), db)
 
 mCheckWallet :: Ord wid => wid -> ModelOp wid s xprv ()
 mCheckWallet wid db@Database{wallets}

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -51,7 +51,6 @@ import Cardano.Wallet.DB.Pure.Implementation
     , mReadTxHistory
     , mReadWalletMeta
     , mRemovePendingOrExpiredTx
-    , mRemoveWallet
     , mRollbackTo
     , mUpdatePendingTxForExpiry
     )
@@ -100,8 +99,6 @@ newDBLayer timeInterpreter = do
         { initializeWallet = \pk cp meta txs gp -> ExceptT $
                 alterDB errWalletAlreadyExists db $
                 mInitializeWallet pk cp meta txs gp
-
-        , removeWallet = ExceptT . alterDB errNoSuchWallet db . mRemoveWallet
 
         , listWallets = readDB db mListWallets
 

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -207,7 +207,7 @@ import Data.Map
 import Data.Map.Strict.NonEmptyMap
     ( NonEmptyMap )
 import Data.Maybe
-    ( catMaybes, fromJust, isJust, isNothing )
+    ( catMaybes, fromJust, isJust )
 import Data.Quantity
     ( Percentage (..), Quantity (..) )
 import Data.Set
@@ -999,8 +999,6 @@ data Tag
       -- ^ Three different wallets created.
     | CreateWalletTwice
       -- ^ The same wallet id is used twice.
-    | RemoveWalletTwice
-      -- ^ The same wallet is removed twice.
     | CreateThenList
     | SuccessfulReadTxHistory
     | UnsuccessfulReadTxHistory
@@ -1009,12 +1007,8 @@ data Tag
     | TxUnsortedOutputs
     | SuccessfulReadCheckpoint
       -- ^ Read the checkpoint of a wallet that's been created.
-    | UnsuccessfulReadCheckpoint
-      -- ^ No such wallet error.
     | SuccessfulReadPrivateKey
       -- ^ Private key was written then read.
-    | ReadTxHistoryAfterDelete
-      -- ^ wallet deleted, then tx history read.
     | PutCheckpointTwice
       -- ^ Multiple checkpoints are successfully saved to a wallet.
     | RolledBackOnce
@@ -1037,7 +1031,6 @@ tag = Foldl.fold $ catMaybes <$> sequenceA
     , txUnsorted inputs TxUnsortedInputs
     , txUnsorted outputs TxUnsortedOutputs
     , readCheckpoint isJust SuccessfulReadCheckpoint
-    , readCheckpoint isNothing UnsuccessfulReadCheckpoint
     , countAction SuccessfulReadPrivateKey (>= 1) isReadPrivateKeySuccess
     , countAction PutCheckpointTwice (>= 2) isPutCheckpointSuccess
     , countAction RolledBackOnce (>= 1) isRollbackSuccess

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -82,7 +82,6 @@ import Cardano.Wallet.DB.Pure.Implementation
     , mReadPrivateKey
     , mReadTxHistory
     , mReadWalletMeta
-    , mRemoveWallet
     , mRollbackTo
     )
 import Cardano.Wallet.DB.WalletState
@@ -341,7 +340,6 @@ unMockPrivKeyHash = PassphraseHash .  BA.convert . B8.pack
 
 data Cmd s wid
     = CreateWallet MWid (Wallet s) WalletMetadata TxHistory GenesisParameters
-    | RemoveWallet wid
     | ListWallets
     | PutCheckpoint wid (Wallet s)
     | ReadCheckpoint wid
@@ -405,8 +403,6 @@ runMock = \case
     CreateWallet wid wal meta txs gp ->
         first (Resp . fmap (const (NewWallet wid)))
             . mInitializeWallet wid wal meta txs gp
-    RemoveWallet wid ->
-        first (Resp . fmap Unit) . mRemoveWallet wid
     ListWallets ->
         first (Resp . fmap WalletIds) . mListWallets
     PutCheckpoint wid wal ->
@@ -469,8 +465,6 @@ runIO DBLayer{..} = fmap Resp . go
             catchWalletAlreadyExists (const (NewWallet (unMockWid wid))) $
             mapExceptT atomically $
             initializeWallet (unMockWid wid) wal meta txs gp
-        RemoveWallet wid -> catchNoSuchWallet Unit $
-            mapExceptT atomically $ removeWallet wid
         ListWallets -> Right . WalletIds <$>
             atomically listWallets
         PutCheckpoint wid wal -> catchNoSuchWallet Unit $
@@ -639,9 +633,7 @@ generatorWithWid
     => [Reference WalletId r]
     -> [(String, (Int, Gen (Cmd s (Reference WalletId r))))]
 generatorWithWid wids =
-    [ declareGenerator "RemoveWallet" 3
-        $ RemoveWallet <$> genId
-    , declareGenerator "ListWallets" 5
+    [ declareGenerator "ListWallets" 5
         $ pure ListWallets
     , declareGenerator "PutCheckpoints" 5
         $ PutCheckpoint <$> genId <*> arbitrary
@@ -1039,7 +1031,6 @@ tag :: forall s. [Event s Symbolic] -> [Tag]
 tag = Foldl.fold $ catMaybes <$> sequenceA
     [ createThreeWallets
     , createWalletTwice
-    , removeWalletTwice
     , createThenList
     , readTransactions (not . null) SuccessfulReadTxHistory
     , readTransactions null UnsuccessfulReadTxHistory
@@ -1047,7 +1038,6 @@ tag = Foldl.fold $ catMaybes <$> sequenceA
     , txUnsorted outputs TxUnsortedOutputs
     , readCheckpoint isJust SuccessfulReadCheckpoint
     , readCheckpoint isNothing UnsuccessfulReadCheckpoint
-    , readAfterDelete
     , countAction SuccessfulReadPrivateKey (>= 1) isReadPrivateKeySuccess
     , countAction PutCheckpointTwice (>= 2) isPutCheckpointSuccess
     , countAction RolledBackOnce (>= 1) isRollbackSuccess
@@ -1060,33 +1050,6 @@ tag = Foldl.fold $ catMaybes <$> sequenceA
             Just (wids ! wid)
         _otherwise ->
             Nothing
-
-    readAfterDelete :: Fold (Event s Symbolic) (Maybe Tag)
-    readAfterDelete = Fold update mempty extract
-      where
-        update :: Map MWid Int -> Event s Symbolic -> Map MWid Int
-        update created ev =
-            case (isReadTxHistory ev, cmd ev, mockResp ev, before ev) of
-                (Just wid, _, _, _) ->
-                    Map.alter (fmap (+1)) wid created
-                (Nothing
-                    , At (RemoveWallet wid)
-                    , Resp (Right _)
-                    , Model _ wids) ->
-                        Map.insert (wids ! wid) 0 created
-                _otherwise ->
-                    created
-
-        extract :: Map MWid Int -> Maybe Tag
-        extract created | any (> 0) created = Just ReadTxHistoryAfterDelete
-                        | otherwise = Nothing
-
-    isReadTxHistory :: Event s Symbolic -> Maybe MWid
-    isReadTxHistory ev = case (cmd ev, mockResp ev, before ev) of
-        (At (ReadTxHistory wid _ _ _ _), Resp (Right (TxHistory _)), Model _ wids)
-            -> Just (wids ! wid)
-        _otherwise
-            -> Nothing
 
     createThreeWallets :: Fold (Event s Symbolic) (Maybe Tag)
     createThreeWallets = Fold update Set.empty extract
@@ -1111,15 +1074,6 @@ tag = Foldl.fold $ catMaybes <$> sequenceA
         match ev = case (cmd ev, mockResp ev) of
             (At (CreateWallet wid _ _ _ _), Resp _) -> Just wid
             _otherwise -> Nothing
-
-    removeWalletTwice :: Fold (Event s Symbolic) (Maybe Tag)
-    removeWalletTwice = countAction RemoveWalletTwice (>= 2) match
-      where
-        match ev = case (cmd ev, mockResp ev) of
-            (At (RemoveWallet wid), Resp _) ->
-                Just wid
-            _otherwise ->
-                Nothing
 
     countAction
         :: forall k. Ord k => Tag -> (Int -> Bool)


### PR DESCRIPTION
This is part of the epic to remove (unused) multi-wallet support in DBLayer

- [x] Remove removeWallet from DBLayer record
- [x] Remove deleteWallet functionality from Wallet module

ADP-2878
