### PR TITLE
Leverage `Cardano.unbundleLedgerShelleyBasedProtocolParams`

### DIFF
--- a/lib/wallet/src/Cardano/Api/Extra.hs
+++ b/lib/wallet/src/Cardano/Api/Extra.hs
@@ -12,12 +12,14 @@ module Cardano.Api.Extra
     , inAnyCardanoEra
     , asAnyShelleyBasedEra
     , fromShelleyBasedScript
+    , unbundleLedgerShelleyBasedProtocolParams
     ) where
 
 import Prelude
 
 import Cardano.Api
-    ( CardanoEra (..)
+    ( BundledProtocolParameters (..)
+    , CardanoEra (..)
     , InAnyCardanoEra (..)
     , InAnyShelleyBasedEra (..)
     , IsCardanoEra (cardanoEra)
@@ -135,3 +137,16 @@ fromShelleyBasedScript era script = case era of
                 ScriptInEra PlutusScriptV2InConway $
                 PlutusScript PlutusScriptV2 $
                 PlutusScriptSerialised s
+
+-- Not exposed by cardano-api
+unbundleLedgerShelleyBasedProtocolParams
+  :: ShelleyBasedEra era
+  -> BundledProtocolParameters era
+  -> Ledger.PParams (ShelleyLedgerEra era)
+unbundleLedgerShelleyBasedProtocolParams = \case
+  ShelleyBasedEraShelley -> \(BundleAsShelleyBasedProtocolParameters _ _ lpp) -> lpp
+  ShelleyBasedEraAllegra -> \(BundleAsShelleyBasedProtocolParameters _ _ lpp) -> lpp
+  ShelleyBasedEraMary -> \(BundleAsShelleyBasedProtocolParameters _ _ lpp) -> lpp
+  ShelleyBasedEraAlonzo -> \(BundleAsShelleyBasedProtocolParameters _ _ lpp) -> lpp
+  ShelleyBasedEraBabbage -> \(BundleAsShelleyBasedProtocolParameters _ _ lpp) -> lpp
+  ShelleyBasedEraConway -> \(BundleAsShelleyBasedProtocolParameters _ _ lpp) -> lpp

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -161,6 +161,7 @@ import Text.Pretty.Simple
 
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Api as Cardano
+import qualified Cardano.Api.Extra as Cardano
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
@@ -330,12 +331,9 @@ balanceTransaction
     -> ExceptT ErrBalanceTx m (Cardano.Tx era, s)
 balanceTransaction
     tr txLayer toInpScriptsM mScriptTemplate pp ti idx genChange s unadjustedPtx = do
-    -- TODO [ADP-1490] Take 'Ledger.PParams era' directly as argument, and avoid
-    -- converting to/from Cardano.ProtocolParameters. This may affect
-    -- performance. The addition of this one specific conversion seems to have
-    -- made the --match "balanceTransaction" unit tests 11% slower in CPU time.
-    let ledgerPP = Cardano.toLedgerPParams shelleyEra
-            (Cardano.unbundleProtocolParams (snd pp))
+    let ledgerPP = Cardano.unbundleLedgerShelleyBasedProtocolParams
+            shelleyEra
+            (snd pp)
     let adjustedPtx = over (#tx)
             (increaseZeroAdaOutputs (recentEra @era) ledgerPP)
             unadjustedPtx
@@ -656,9 +654,9 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         . Write.Tx.fromCardanoTx
 
     ledgerPP =
-        Cardano.toLedgerPParams
+        Cardano.unbundleLedgerShelleyBasedProtocolParams
             (Cardano.shelleyBasedEra @era)
-            (Cardano.unbundleProtocolParams nodePParams)
+            nodePParams
 
     balanceAfterSettingMinFee
         :: Cardano.Tx era


### PR DESCRIPTION
- [x] Replace all non-unit test calls to `Cardano.toLedgerPParams` with the much cheaper `Cardano.unbundleLedgerShelleyBasedProtocolParams`.

### Comments

Suggestion to #3812 

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
