### PR TITLE
[ADP-2878] change listWallets field to getWalletId

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -77,6 +77,7 @@ import Cardano.Wallet
     , ErrUpdatePassphrase (..)
     , ErrUpdateSealedTx (..)
     , ErrWalletAlreadyExists (..)
+    , ErrWalletNotInitialized (..)
     , ErrWalletNotResponding (..)
     , ErrWithRootKey (..)
     , ErrWithdrawalNotBeneficial (..)
@@ -245,6 +246,13 @@ instance IsServerError ErrNoSuchWallet where
             apiError err404 NoSuchWallet $ mconcat
                 [ "I couldn't find a wallet with the given id: "
                 , toText wid
+                ]
+
+instance IsServerError ErrWalletNotInitialized where
+    toServerError = \case
+        ErrWalletNotInitialized ->
+            apiError err404 NoSuchWallet $ mconcat
+                [ "The database for the requested wallet is not initialized. "
                 ]
 
 instance IsServerError ErrWalletNotResponding where

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -185,7 +185,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -> WalletMetadata
         -> [(Tx, TxMeta)]
         -> GenesisParameters
-        -> ExceptT ErrWalletAlreadyExists stm ()
+        -> ExceptT ErrWalletAlreadyInitialized stm ()
         -- ^ Initialize a database entry for a given wallet. 'putCheckpoint',
         -- 'putWalletMeta', 'putTxHistory' or 'putProtocolParameters' will
         -- actually all fail if they are called _first_ on a wallet.
@@ -601,7 +601,7 @@ data DBWallets stm s = DBWallets
         -> WalletMetadata
         -> [(Tx, TxMeta)]
         -> GenesisParameters
-        -> ExceptT ErrWalletAlreadyExists stm ()
+        -> ExceptT ErrWalletAlreadyInitialized stm ()
         -- ^ Initialize a database entry for a given wallet. 'putCheckpoint',
         -- 'putWalletMeta', 'putTxHistory' or 'putProtocolParameters' will
         -- actually all fail if they are called _first_ on a wallet.

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -206,7 +206,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , putCheckpoint
         :: WalletId
         -> Wallet s
-        -> ExceptT ErrNoSuchWallet stm ()
+        -> ExceptT ErrWalletNotInitialized stm ()
         -- ^ Replace the current checkpoint for a given wallet. We do not handle
         -- rollbacks yet, and therefore only stores the latest available
         -- checkpoint.
@@ -229,7 +229,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , putWalletMeta
         :: WalletId
         -> WalletMetadata
-        -> ExceptT ErrNoSuchWallet stm ()
+        -> ExceptT ErrWalletNotInitialized stm ()
         -- ^ Replace an existing wallet metadata with the given one.
         --
         -- If the wallet doesn't exist, this operation returns an error
@@ -243,13 +243,13 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
 
     , isStakeKeyRegistered
         :: WalletId
-        -> ExceptT ErrNoSuchWallet stm Bool
+        -> ExceptT ErrWalletNotInitialized stm Bool
 
     , putDelegationCertificate
         :: WalletId
         -> DelegationCertificate
         -> SlotNo
-        -> ExceptT ErrNoSuchWallet stm ()
+        -> ExceptT ErrWalletNotInitialized stm ()
         -- ^ Binds a stake pool id to a wallet. This will have an influence on
         -- the wallet metadata: the last known certificate will indicate to
         -- which pool a wallet is currently delegating.
@@ -263,7 +263,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , putDelegationRewardBalance
         :: WalletId
         -> Coin
-        -> ExceptT ErrNoSuchWallet stm ()
+        -> ExceptT ErrWalletNotInitialized stm ()
         -- ^ Store the latest known reward account balance.
         --
         -- This is separate from checkpoints because the data corresponds to the
@@ -281,7 +281,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , putTxHistory
         :: WalletId
         -> [(Tx, TxMeta)]
-        -> ExceptT ErrNoSuchWallet stm ()
+        -> ExceptT ErrWalletNotInitialized stm ()
         -- ^ Augments the transaction history for a known wallet.
         --
         -- If an entry for a particular transaction already exists it is not
@@ -305,7 +305,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , getTx
         :: WalletId
         -> Hash "Tx"
-        -> ExceptT ErrNoSuchWallet stm (Maybe TransactionInfo)
+        -> ExceptT ErrWalletNotInitialized stm (Maybe TransactionInfo)
         -- ^ Fetch the latest transaction by id, returns Nothing when the
         -- transaction isn't found.
         --
@@ -315,7 +315,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         :: WalletId
         -> BuiltTx
         -> SlotNo
-        -> ExceptT ErrNoSuchWallet stm ()
+        -> ExceptT ErrWalletNotInitialized stm ()
         -- ^ Add a /new/ transaction to the local submission pool
         -- with the most recent submission slot.
 
@@ -324,7 +324,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -> Hash "Tx"
         -> SealedTx -- TODO: ADP-2596 really not needed
         -> SlotNo
-        -> ExceptT ErrNoSuchWallet stm ()
+        -> ExceptT ErrWalletNotInitialized stm ()
         -- ^ Resubmit a transaction.
 
     , readLocalTxSubmissionPending
@@ -339,7 +339,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         :: WalletId
         -> SlotNo
         -> [(SlotNo, Hash "Tx")]
-        -> ExceptT ErrNoSuchWallet stm ()
+        -> ExceptT ErrWalletNotInitialized stm ()
         -- ^ Removes any expired transactions from the pending set and marks
         -- their status as expired.
 
@@ -352,7 +352,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , putPrivateKey
         :: WalletId
         -> (k 'RootK XPrv, PassphraseHash)
-        -> ExceptT ErrNoSuchWallet stm ()
+        -> ExceptT ErrWalletNotInitialized stm ()
         -- ^ Store or replace a private key for a given wallet. Note that wallet
         -- _could_ be stored and manipulated without any private key associated
         -- to it. A private key is only seldomly required for very specific
@@ -372,7 +372,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , rollbackTo
         :: WalletId
         -> Slot
-        -> ExceptT ErrNoSuchWallet stm ChainPoint
+        -> ExceptT ErrWalletNotInitialized stm ChainPoint
         -- ^ Drops all checkpoints and transaction data which
         -- have appeared after the given 'ChainPoint'.
         --
@@ -385,7 +385,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         :: WalletId
         -> Quantity "block" Word32
         -> SlotNo
-        -> ExceptT ErrNoSuchWallet stm ()
+        -> ExceptT ErrWalletNotInitialized stm ()
         -- ^ Prune database entities and remove entities that can be discarded.
         --
         -- The second argument represents the stability window, or said
@@ -441,12 +441,12 @@ data DBLayerCollection stm m s k = DBLayerCollection
     , rollbackTo_
         :: WalletId
         -> Slot
-        -> ExceptT ErrNoSuchWallet stm ChainPoint
+        -> ExceptT ErrWalletNotInitialized stm ChainPoint
     , prune_
         :: WalletId
         -> Quantity "block" Word32
         -> SlotNo
-        -> ExceptT ErrNoSuchWallet stm ()
+        -> ExceptT ErrWalletNotInitialized stm ()
     , atomically_
         :: forall a. stm a -> m a
     }
@@ -530,17 +530,20 @@ mkDBLayerFromParts ti DBLayerCollection{..} = DBLayer
                             (mkDecorator_ dbTxHistory) tip
                                 . fmap snd
             Nothing -> pure Nothing
-    , addTxSubmission = \wid builtTx slotNo  -> updateSubmissions' wid id
+    , addTxSubmission = \wid builtTx slotNo  -> updateSubmissions' wid
+            mapNoSuchWallet
             $ \_ -> Right [Sbms.addTxSubmission builtTx slotNo]
     , readLocalTxSubmissionPending = \wid -> withSubmissions wid [] $ \xs -> do
         pure $ filter (has $ txStatus . _InSubmission) $
             getInSubmissionTransactions xs
-    , resubmitTx = \wid hash _ slotNo -> updateSubmissions' wid id
+    , resubmitTx = \wid hash _ slotNo -> updateSubmissions' wid mapNoSuchWallet
             $ Right . Sbms.resubmitTx hash slotNo
-    , rollForwardTxSubmissions = \wid tip txs -> updateSubmissions' wid id
+    , rollForwardTxSubmissions = \wid tip txs -> updateSubmissions' wid
+            mapNoSuchWallet
             $ \_ -> Right [Sbms.rollForwardTxSubmissions tip txs]
     , removePendingOrExpiredTx = \wid txid ->
-            updateSubmissions' wid ErrRemoveTxNoSuchWallet $ \xs ->
+            updateSubmissions' wid (ErrRemoveTxNoSuchWallet . mapNoSuchWallet)
+                $ \xs ->
                 pure <$> Sbms.removePendingOrExpiredTx xs wid txid
     , putPrivateKey = \wid a -> wrapNoSuchWallet wid $
         putPrivateKey_ (dbPrivateKey wid) a
@@ -558,16 +561,16 @@ mkDBLayerFromParts ti DBLayerCollection{..} = DBLayer
         case mstate of
             Nothing -> pure def
             Just state -> action $ submissions state
-
+    mapNoSuchWallet _ = ErrWalletNotInitialized
     updateSubmissions' = updateSubmissions dbCheckpoints
     readCheckpoint' = readCheckpoint_ dbCheckpoints
     wrapNoSuchWallet
         :: WalletId
         -> stm a
-        -> ExceptT ErrNoSuchWallet stm a
+        -> ExceptT ErrWalletNotInitialized stm a
     wrapNoSuchWallet wid action = ExceptT $
         hasWallet_ dbWallets wid >>= \case
-            False -> pure $ Left $ ErrNoSuchWallet wid
+            False -> pure $ Left ErrWalletNotInitialized
             True  -> Right <$> action
 
     readCurrentTip :: WalletId -> stm (Maybe BlockHeader)
@@ -633,7 +636,7 @@ data DBCheckpoints stm s = DBCheckpoints
     , putCheckpoint_
         :: WalletId
         -> Wallet s
-        -> ExceptT ErrNoSuchWallet stm ()
+        -> ExceptT ErrWalletNotInitialized stm ()
         -- ^ Replace the current checkpoint for a given wallet. We do not handle
         -- rollbacks yet, and therefore only stores the latest available
         -- checkpoint.
@@ -659,7 +662,7 @@ data DBWalletMeta stm = DBWalletMeta
     { putWalletMeta_
         :: WalletId
         -> WalletMetadata
-        -> ExceptT ErrNoSuchWallet stm ()
+        -> ExceptT ErrWalletNotInitialized stm ()
         -- ^ Replace an existing wallet metadata with the given one.
         --
         -- If the wallet doesn't exist, this operation returns an error

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -190,8 +190,8 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -- 'putWalletMeta', 'putTxHistory' or 'putProtocolParameters' will
         -- actually all fail if they are called _first_ on a wallet.
 
-    , listWallets
-        :: stm [WalletId]
+    , getWalletId
+        :: ExceptT ErrWalletNotInitialized stm WalletId
         -- ^ Get the list of all known wallets in the DB, possibly empty.
 
     , walletsDB
@@ -460,7 +460,7 @@ mkDBLayerFromParts
     -> DBLayer m s k
 mkDBLayerFromParts ti DBLayerCollection{..} = DBLayer
     { initializeWallet = initializeWallet_ dbWallets
-    , listWallets = listWallets_ dbWallets
+    , getWalletId = getWalletId_ dbWallets
     , walletsDB = walletsDB_ dbCheckpoints
     , putCheckpoint = putCheckpoint_ dbCheckpoints
     , readCheckpoint = readCheckpoint'
@@ -611,9 +611,9 @@ data DBWallets stm s = DBWallets
         -> stm (Maybe GenesisParameters)
         -- ^ Read the *Byron* genesis parameters.
 
-    , listWallets_
-        :: stm [WalletId]
-        -- ^ Get the list of all known wallets in the DB, possibly empty.
+    , getWalletId_
+        :: ExceptT ErrWalletNotInitialized stm WalletId
+        -- ^ Get the 'WalletId' of the wallet stored in the DB.
 
     , hasWallet_
         :: WalletId

--- a/lib/wallet/src/Cardano/Wallet/DB/Errors.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Errors.hs
@@ -52,3 +52,7 @@ newtype ErrNoSuchWallet
 -- | Can't perform given operation because there's no wallet in the db
 data ErrWalletNotInitialized = ErrWalletNotInitialized
     deriving (Eq, Show)
+
+-- | Can't perform given operation because there's already a wallet in the db
+data ErrWalletAlreadyInitialized = ErrWalletAlreadyInitialized
+    deriving (Eq, Show)

--- a/lib/wallet/src/Cardano/Wallet/DB/Errors.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Errors.hs
@@ -22,13 +22,13 @@ instance Exception ErrBadFormat
 
 -- | Can't add a transaction to the local tx submission pool.
 data ErrPutLocalTxSubmission
-    = ErrPutLocalTxSubmissionNoSuchWallet ErrNoSuchWallet
+    = ErrPutLocalTxSubmissionNoSuchWallet ErrWalletNotInitialized
     | ErrPutLocalTxSubmissionNoSuchTransaction ErrNoSuchTransaction
     deriving (Eq, Show)
 
 -- | Can't remove pending or expired transaction.
 data ErrRemoveTx
-    = ErrRemoveTxNoSuchWallet ErrNoSuchWallet
+    = ErrRemoveTxNoSuchWallet ErrWalletNotInitialized
     | ErrRemoveTxNoSuchTransaction ErrNoSuchTransaction
     | ErrRemoveTxAlreadyInLedger (Hash "Tx")
     deriving (Eq, Show)
@@ -47,4 +47,8 @@ newtype ErrWalletAlreadyExists
 -- | Can't perform given operation because there's no wallet
 newtype ErrNoSuchWallet
     = ErrNoSuchWallet WalletId -- Wallet is gone or doesn't exist yet
+    deriving (Eq, Show)
+
+-- | Can't perform given operation because there's no wallet in the db
+data ErrWalletNotInitialized = ErrWalletNotInitialized
     deriving (Eq, Show)

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -79,7 +79,7 @@ import Cardano.Wallet.DB
     , DBTxHistory (..)
     , DBWalletMeta (..)
     , DBWallets (..)
-    , ErrWalletAlreadyExists (..)
+    , ErrWalletAlreadyInitialized (ErrWalletAlreadyInitialized)
     , ErrWalletNotInitialized (..)
     , mkDBLayerFromParts
     )
@@ -578,7 +578,7 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = mdo
                     insertCheckpointGenesis wid cp
                     updateS (store transactionsQS) Nothing $
                                 ExpandTxWalletsHistory wid txs
-                Right _ -> throwE $ ErrWalletAlreadyExists wid
+                Right _ -> throwE ErrWalletAlreadyInitialized
 
         , readGenesisParameters_ = selectGenesisParameters
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -160,7 +160,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans
     ( lift )
 import Control.Monad.Trans.Except
-    ( ExceptT (..) )
+    ( ExceptT (..), throwE )
 import Control.Tracer
     ( Tracer, contramap, traceWith )
 import Data.Coerce
@@ -585,7 +585,11 @@ newDBLayerWith _cacheBehavior _tr ti SqliteContext{runQuery} = mdo
 
         , readGenesisParameters_ = selectGenesisParameters
 
-        , listWallets_ = map unWalletKey <$> selectKeysList [] [Asc WalId]
+        , getWalletId_ = do
+            ws <- lift $ map unWalletKey <$> selectKeysList [] [Asc WalId]
+            case ws of
+                [w] -> pure w
+                _ -> throwE ErrWalletNotInitialized
 
         , hasWallet_ = fmap isJust . selectWallet
         }

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -102,8 +102,7 @@ newDBLayer timeInterpreter = do
                 alterDB errWalletAlreadyExists db $
                 mInitializeWallet pk cp meta txs gp
 
-        , getWalletId = ExceptT
-            $ alterDB errWalletNotInitialized db mGetWalletId
+        , getWalletId = getWalletId'
 
         {-----------------------------------------------------------------------
                                     Checkpoints

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -22,7 +22,10 @@ import Prelude
 import Cardano.Address.Derivation
     ( XPrv )
 import Cardano.Wallet.DB
-    ( DBLayer (..), ErrWalletAlreadyExists (..), ErrWalletNotInitialized (..) )
+    ( DBLayer (..)
+    , ErrWalletAlreadyInitialized (..)
+    , ErrWalletNotInitialized (..)
+    )
 import Cardano.Wallet.DB.Pure.Implementation
     ( Database
     , Err (..)
@@ -89,7 +92,7 @@ newDBLayer timeInterpreter = do
                 alterDB errWalletAlreadyExists db $
                 mInitializeWallet pk cp meta txs gp
 
-        , getWalletId = ExceptT 
+        , getWalletId = ExceptT
             $ alterDB errWalletNotInitialized db mGetWalletId
 
         {-----------------------------------------------------------------------
@@ -242,18 +245,13 @@ readDB
     -> m a
 readDB db op = alterDB Just db op >>= either (throwIO . MVarDBError) pure
 
-noWallet :: a
-noWallet = error "wallet not initialized"
-
 errWalletNotInitialized :: Err -> Maybe ErrWalletNotInitialized
 errWalletNotInitialized WalletNotInitialized = Just ErrWalletNotInitialized
 errWalletNotInitialized _ = Nothing
 
-errWalletAlreadyExists
-    :: Err
-    -> Maybe ErrWalletAlreadyExists
-errWalletAlreadyExists WalletAlreadyInitialized  =
-    Just (ErrWalletAlreadyExists noWallet)
+errWalletAlreadyExists :: Err -> Maybe ErrWalletAlreadyInitialized
+errWalletAlreadyExists WalletAlreadyInitialized
+    = Just ErrWalletAlreadyInitialized
 errWalletAlreadyExists _ = Nothing
 
 -- | Error which happens when model returns an unexpected value.

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -89,7 +89,8 @@ newDBLayer timeInterpreter = do
                 alterDB errWalletAlreadyExists db $
                 mInitializeWallet pk cp meta txs gp
 
-        , listWallets = pure <$> readDB db mGetWalletId
+        , getWalletId = ExceptT 
+            $ alterDB errWalletNotInitialized db mGetWalletId
 
         {-----------------------------------------------------------------------
                                     Checkpoints

--- a/lib/wallet/src/Cardano/Wallet/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation.hs
@@ -35,6 +35,7 @@ import Cardano.Wallet
     , WalletException (..)
     , WalletLog (..)
     , fetchRewardBalance
+    , mkNoSuchWalletError
     , readRewardAccount
     , transactionExpirySlot
     , withNoSuchWallet
@@ -133,7 +134,7 @@ joinStakePoolDelegationAction
     (walletDelegation, stakeKeyIsRegistered) <-
         atomically . throwInIO ErrStakePoolDelegationNoSuchWallet $
             (,) <$> withNoSuchWallet wid (fmap snd <$> readWalletMeta wid)
-                <*> isStakeKeyRegistered wid
+                <*> mkNoSuchWalletError wid (isStakeKeyRegistered wid)
 
     let retirementInfo =
             PoolRetirementEpochInfo currentEpoch . view #retirementEpoch <$>

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -153,8 +153,6 @@ import Cardano.Wallet.Unsafe
     ( someDummyMnemonic, unsafeMkPercentage )
 import Cardano.Wallet.Util
     ( ShowFmt (..) )
-import Control.Arrow
-    ( second )
 import Control.DeepSeq
     ( NFData )
 import Crypto.Hash
@@ -168,7 +166,7 @@ import Data.Functor.Identity
 import Data.Generics.Internal.VL
     ( match )
 import Data.Generics.Internal.VL.Lens
-    ( view, (^.) )
+    ( (^.) )
 import Data.Generics.Labels
     ()
 import Data.List
@@ -278,14 +276,6 @@ instance (Arbitrary k, Ord k, Arbitrary v) => Arbitrary (KeyValPairs k v) where
         pairs <- choose (1, 10) >>= vector
         pure $ KeyValPairs $ L.sortOn fst pairs
 
--- | For checkpoints, we make sure to generate them in order.
-instance {-# OVERLAPS #-} (Arbitrary k, Ord k, GenState s)
-    => Arbitrary (KeyValPairs k (ShowFmt (Wallet s))) where
-    shrink = genericShrink
-    arbitrary = do
-        pairs <- choose (1, 10) >>= vector
-        pure $ KeyValPairs $ second ShowFmt
-           <$> L.sortOn (\(k,cp) -> (k, view #slotNo (currentTip cp))) pairs
 
 instance Arbitrary GenTxHistory where
     shrink (GenTxHistory txs) = GenTxHistory <$> shrinkList shrinkOne txs

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -54,6 +54,8 @@ import Cardano.DB.Sqlite
     ( DBField, DBLog (..), SqliteContext, fieldName, newInMemorySqliteContext )
 import Cardano.Mnemonic
     ( SomeMnemonic (..) )
+import Cardano.Wallet
+    ( mkNoSuchWalletError )
 import Cardano.Wallet.DB
     ( DBFactory (..), DBLayer (..) )
 import Cardano.Wallet.DB.Arbitrary
@@ -968,7 +970,7 @@ attachPrivateKey DBLayer{..} wid = do
     seed <- liftIO $ generate $ SomeMnemonic <$> genMnemonic @15
     (scheme, h) <- liftIO $ encryptPassphrase pwd
     let k = generateKeyFromSeed (seed, Nothing) (preparePassphrase scheme pwd)
-    mapExceptT atomically $ putPrivateKey wid (k, h)
+    mkNoSuchWalletError wid $ mapExceptT atomically $ putPrivateKey wid (k, h)
     return (k, h)
 
 cutRandomly :: [a] -> IO [[a]]

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -160,21 +160,21 @@ properties = describe "DB.Properties" $ do
         it "Checkpoint"
             $ property
                 . prop_readAfterPut
-                    ( \DBLayer {..} wid ->
+                    ( \DBLayer{..} wid ->
                         mkNoSuchWalletError wid
                             . mapExceptT atomically
                             . putCheckpoint wid
                     )
-                    (\DBLayer {..} -> atomically . readCheckpoint)
+                    (\DBLayer{..} -> atomically . readCheckpoint)
         it "Wallet Metadata"
             $ property
                 . prop_readAfterPut
-                    ( \DBLayer {..} wid ->
+                    ( \DBLayer{..} wid ->
                         mkNoSuchWalletError wid
                             . mapExceptT atomically
                             . putWalletMeta wid
                     )
-                    ( \DBLayer {..} ->
+                    ( \DBLayer{..} ->
                         atomically
                             . fmap (fmap fst)
                             . readWalletMeta
@@ -187,12 +187,12 @@ properties = describe "DB.Properties" $ do
         it "Private Key"
             $ property
                 . prop_readAfterPut
-                    ( \DBLayer {..} wid ->
+                    ( \DBLayer{..} wid ->
                         mkNoSuchWalletError wid
                             . mapExceptT atomically
                             . putPrivateKey wid
                     )
-                    (\DBLayer {..} -> atomically . readPrivateKey)
+                    (\DBLayer{..} -> atomically . readPrivateKey)
 
     describe "getTx properties" $ do
         it "can read after putting tx history for valid tx id"
@@ -206,22 +206,22 @@ properties = describe "DB.Properties" $ do
         it "Checkpoint"
             $ property
                 . prop_putBeforeInit
-                    ( \DBLayer {..} wid ->
+                    ( \DBLayer{..} wid ->
                         mkNoSuchWalletError wid
                             . mapExceptT atomically
                             . putCheckpoint wid
                     )
-                    (\DBLayer {..} -> atomically . readCheckpoint)
+                    (\DBLayer{..} -> atomically . readCheckpoint)
                     Nothing
         it "Wallet Metadata"
             $ property
                 . prop_putBeforeInit
-                    ( \DBLayer {..} wid ->
+                    ( \DBLayer{..} wid ->
                         mkNoSuchWalletError wid
                             . mapExceptT atomically
                             . putWalletMeta wid
                     )
-                    ( \DBLayer {..} ->
+                    ( \DBLayer{..} ->
                         atomically
                             . fmap (fmap fst)
                             . readWalletMeta
@@ -236,57 +236,57 @@ properties = describe "DB.Properties" $ do
         it "Private Key"
             $ property
                 . prop_putBeforeInit
-                    ( \DBLayer {..} wid ->
+                    ( \DBLayer{..} wid ->
                         mkNoSuchWalletError wid
                             . mapExceptT atomically
                             . putPrivateKey wid
                     )
-                    (\DBLayer {..} -> atomically . readPrivateKey)
+                    (\DBLayer{..} -> atomically . readPrivateKey)
                     Nothing
 
     describe "put doesn't affect other resources" $ do
         it "Checkpoint vs Wallet Metadata & Tx History & Private Key"
             $ property
                 . prop_isolation
-                    ( \DBLayer {..} wid ->
+                    ( \DBLayer{..} wid ->
                         mkNoSuchWalletError wid
                             . mapExceptT atomically
                             . putCheckpoint wid
                     )
-                    (\DBLayer {..} -> atomically . readWalletMeta)
+                    (\DBLayer{..} -> atomically . readWalletMeta)
                     readTxHistory_
-                    (\DBLayer {..} -> atomically . readPrivateKey)
+                    (\DBLayer{..} -> atomically . readPrivateKey)
         it "Wallet Metadata vs Tx History & Checkpoint & Private Key"
             $ property
                 . prop_isolation
-                    ( \DBLayer {..} wid ->
+                    ( \DBLayer{..} wid ->
                         mkNoSuchWalletError wid
                             . mapExceptT atomically
                             . putWalletMeta wid
                     )
                     readTxHistory_
-                    (\DBLayer {..} -> atomically . readCheckpoint)
-                    (\DBLayer {..} -> atomically . readPrivateKey)
+                    (\DBLayer{..} -> atomically . readCheckpoint)
+                    (\DBLayer{..} -> atomically . readPrivateKey)
         it "Tx History vs Checkpoint & Wallet Metadata & Private Key"
             $ property
                 . prop_isolation
                     putTxHistory_
-                    (\DBLayer {..} -> atomically . readCheckpoint)
-                    (\DBLayer {..} -> atomically . readWalletMeta)
-                    (\DBLayer {..} -> atomically . readPrivateKey)
+                    (\DBLayer{..} -> atomically . readCheckpoint)
+                    (\DBLayer{..} -> atomically . readWalletMeta)
+                    (\DBLayer{..} -> atomically . readPrivateKey)
 
     describe "sequential puts replace values in order" $ do
         it "Checkpoint"
             $ checkCoverage
                 . prop_sequentialPut
-                    (\DBLayer {..} wid -> mkNoSuchWalletError wid . mapExceptT atomically . putCheckpoint wid)
-                    (\DBLayer {..} -> atomically . readCheckpoint)
+                    (\DBLayer{..} wid -> mkNoSuchWalletError wid . mapExceptT atomically . putCheckpoint wid)
+                    (\DBLayer{..} -> atomically . readCheckpoint)
                     lrp
         it "Wallet Metadata"
             $ checkCoverage
                 . prop_sequentialPut
-                    (\DBLayer {..} wid -> mkNoSuchWalletError wid . mapExceptT atomically . putWalletMeta wid)
-                    (\DBLayer {..} -> atomically . fmap (fmap fst) . readWalletMeta)
+                    (\DBLayer{..} wid -> mkNoSuchWalletError wid . mapExceptT atomically . putWalletMeta wid)
+                    (\DBLayer{..} -> atomically . fmap (fmap fst) . readWalletMeta)
                     lrp
         it "Tx History"
             $ checkCoverage
@@ -297,22 +297,22 @@ properties = describe "DB.Properties" $ do
         it "Private Key"
             $ checkCoverage
                 . prop_sequentialPut
-                    (\DBLayer {..} wid -> mkNoSuchWalletError wid . mapExceptT atomically . putPrivateKey wid)
-                    (\DBLayer {..} -> atomically . readPrivateKey)
+                    (\DBLayer{..} wid -> mkNoSuchWalletError wid . mapExceptT atomically . putPrivateKey wid)
+                    (\DBLayer{..} -> atomically . readPrivateKey)
                     lrp
 
     describe "parallel puts replace values in _any_ order" $ do
         it "Checkpoint"
             $ checkCoverage
                 . prop_parallelPut
-                    (\DBLayer {..} wid -> mkNoSuchWalletError wid . mapExceptT atomically . putCheckpoint wid)
-                    (\DBLayer {..} -> atomically . readCheckpoint)
+                    (\DBLayer{..} wid -> mkNoSuchWalletError wid . mapExceptT atomically . putCheckpoint wid)
+                    (\DBLayer{..} -> atomically . readCheckpoint)
                     (length . lrp @Maybe)
         it "Wallet Metadata"
             $ checkCoverage
                 . prop_parallelPut
-                    (\DBLayer {..} wid -> mkNoSuchWalletError wid . mapExceptT atomically . putWalletMeta wid)
-                    (\DBLayer {..} -> atomically . fmap (fmap fst) . readWalletMeta)
+                    (\DBLayer{..} wid -> mkNoSuchWalletError wid . mapExceptT atomically . putWalletMeta wid)
+                    (\DBLayer{..} -> atomically . fmap (fmap fst) . readWalletMeta)
                     (length . lrp @Maybe)
         it "Tx History"
             $ checkCoverage
@@ -323,8 +323,8 @@ properties = describe "DB.Properties" $ do
         it "Private Key"
             $ checkCoverage
                 . prop_parallelPut
-                    (\DBLayer {..} wid -> mkNoSuchWalletError wid . mapExceptT atomically . putPrivateKey wid)
-                    (\DBLayer {..} -> atomically . readPrivateKey)
+                    (\DBLayer{..} wid -> mkNoSuchWalletError wid . mapExceptT atomically . putPrivateKey wid)
+                    (\DBLayer{..} -> atomically . readPrivateKey)
                     (length . lrp @Maybe)
 
     describe "rollback" $ do
@@ -440,16 +440,16 @@ assertWith lbl condition = do
 -- | Can list created wallets
 prop_createListWallet
     :: DBLayer IO s ShelleyKey
-    -> KeyValPairs WalletId (InitialCheckpoint s, WalletMetadata)
+    -> WalletId
+    -> (InitialCheckpoint s, WalletMetadata)
     -> Property
-prop_createListWallet DBLayer{..} (KeyValPairs pairs) =
+prop_createListWallet DBLayer{..} wid (InitialCheckpoint cp0, meta) =
     monadicIO prop
   where
     prop = liftIO $ do
-        res <- once pairs $ \(k, (InitialCheckpoint cp0, meta)) ->
-            atomically $ unsafeRunExceptT $
-            initializeWallet k cp0 meta mempty gp
-        (length <$> atomically listWallets) `shouldReturn` length res
+        atomically $ unsafeRunExceptT $
+            initializeWallet wid cp0 meta mempty gp
+        atomically (unsafeRunExceptT getWalletId) `shouldReturn` wid
 
 -- | Trying to create a same wallet twice should yield an error
 prop_createWalletTwice

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -32,7 +32,7 @@ import Cardano.Wallet
     ( mkNoSuchWalletError )
 import Cardano.Wallet.DB
     ( DBLayer (..)
-    , ErrWalletAlreadyExists (..)
+    , ErrWalletAlreadyInitialized (ErrWalletAlreadyInitialized)
     , ErrWalletNotInitialized (ErrWalletNotInitialized)
     )
 import Cardano.Wallet.DB.Arbitrary
@@ -463,7 +463,7 @@ prop_createWalletTwice DBLayer{..} (wid, InitialCheckpoint cp0, meta) =
     monadicIO prop
   where
     prop = liftIO $ do
-        let err = ErrWalletAlreadyExists wid
+        let err = ErrWalletAlreadyInitialized
         atomically (runExceptT $ initializeWallet wid cp0 meta mempty gp)
             `shouldReturn` Right ()
         atomically (runExceptT $ initializeWallet wid cp0 meta mempty gp)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Pure/ImplementationSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Pure/ImplementationSpec.hs
@@ -31,6 +31,8 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address )
 import Control.DeepSeq
     ( NFData )
+import Control.Monad.IO.Class
+    ( liftIO )
 import Test.Hspec
     ( Spec, before, describe )
 import Test.QuickCheck
@@ -43,10 +45,10 @@ import qualified Cardano.Wallet.DB.Pure.Layer as PureLayer
 spec :: Spec
 spec =
     before (pendingOnMacOS "#2472: timeouts in CI mac builds")
-    $ before (PureLayer.newDBLayer @IO @(SeqState 'Mainnet ShelleyKey) ti)
-    $ describe "PureLayer" properties
-  where
-    ti = dummyTimeInterpreter
+    $ describe "PureLayer"
+    $ properties
+        (liftIO (PureLayer.newDBLayer @_ @(SeqState 'Mainnet ShelleyKey)
+            dummyTimeInterpreter) >>=)
 
 newtype DummyStatePureLayer = DummyStatePureLayer Int
     deriving (Show, Eq)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -60,7 +60,7 @@ import Cardano.Pool.Types
 import Cardano.Wallet
     ( mkNoSuchWalletError )
 import Cardano.Wallet.DB
-    ( DBLayer (..), ErrWalletAlreadyExists (..) )
+    ( DBLayer (..), ErrWalletAlreadyInitialized (ErrWalletAlreadyInitialized) )
 import Cardano.Wallet.DB.Arbitrary
     ( GenState, GenTxHistory (..), InitialCheckpoint (..) )
 import Cardano.Wallet.DB.Pure.Implementation
@@ -518,8 +518,8 @@ runIO DBLayer{..} = fmap Resp . go
     errNoSuchWallet :: ErrNoSuchWallet -> Err
     errNoSuchWallet (ErrNoSuchWallet _wid) = WalletAlreadyInitialized
 
-    errWalletAlreadyExists :: ErrWalletAlreadyExists -> Err
-    errWalletAlreadyExists (ErrWalletAlreadyExists _wid) = WalletAlreadyInitialized
+    errWalletAlreadyExists :: ErrWalletAlreadyInitialized -> Err
+    errWalletAlreadyExists ErrWalletAlreadyInitialized = WalletAlreadyInitialized
 
 {-------------------------------------------------------------------------------
   Working with references


### PR DESCRIPTION
This is part of the epic to remove (unused) multi-wallet support in DBLayer

- [x] remove submissions-related unused pure model functions
- [x] change listWallets to getWalletId and return the wallet-id or fail if DB is not initialized
- [x] change all pure implementations of the DBLayer methods to reflect the single wallet purpose
   - they do not need a wallet-id as an argument , apart from initializeWallet
   - they do not fail reporting the requested wallet-id when the wallet is not initialized
 - [x] fix the implementation of initializeWallet, so that now it will fail if we try to reinitialize it even with a different wallet


ADP-2878
