### PR TITLE
Move PParam conversion and partialTx construction outside `delegationFee` loop

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3514,7 +3514,7 @@ delegationFee
 delegationFee ctx@ApiLayer{..} (ApiT walletId) = do
     era <- liftIO $ NW.currentNodeEra netLayer
     AnyRecentEra (recentEra :: WriteTx.RecentEra era) <- guardIsRecentEra era
-    withWorkerCtx ctx walletId liftE liftE $ \workerCtx -> liftHandler $ do
+    withWorkerCtx ctx walletId liftE liftE $ \workerCtx -> liftIO $ do
         W.DelegationFee {feePercentiles, deposit} <-
             W.delegationFee
                 (workerCtx ^. dbLayer)

--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -289,7 +289,6 @@ benchmarksSeq BenchmarkConfig{benchmarkName,ctx,wid} = do
         $ W.createMigrationPlan @_ @k @s ctx era wid Tx.NoWithdrawal
 
     (_, delegationFeeTime) <- bench "delegationFee"
-        $ unsafeRunExceptT
         $ W.delegationFee @_ @k @n
             (dbLayer ctx) (networkLayer ctx) (transactionLayer ctx)
             (timeInterpreter (networkLayer ctx))

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2871,7 +2871,6 @@ data DelegationFee = DelegationFee
 
 instance NFData DelegationFee
 
-
 delegationFee
     :: forall s k (n :: NetworkDiscriminant)
      . ( AddressBookIso s
@@ -2912,10 +2911,10 @@ delegationFee db@DBLayer{atomically, walletsDB} netLayer
                     (Left $ PreSelection [])
 
         let ptx = PartialTx
-                            { tx = Cardano.Tx unsignedTxBody []
-                            , inputs = Cardano.UTxO mempty
-                            , redeemers = []
-                            }
+                { tx = Cardano.Tx unsignedTxBody []
+                , inputs = Cardano.UTxO mempty
+                , redeemers = []
+                }
         feePercentiles <- calculateFeePercentiles $ do
             Right (Cardano.Tx (Cardano.TxBody bodyContent) _, _updatedWallet) <-
                 runExceptT $
@@ -3879,8 +3878,8 @@ toBalanceTxPParams pp =
     , maybe
         (error $ unwords
             [ "toBalanceTxPParams: no nodePParams."
-            , "should only be possible in Byron, where"
-            , "withRecentEra should prevent this to be reached."
+            , "This should only be possible in Byron, where withRecentEra"
+            , "should prevent this from being reached."
             ])
         (Cardano.bundleProtocolParams
             (WriteTx.fromRecentEra (WriteTx.recentEra @era)))

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2906,8 +2906,9 @@ delegationFee db@DBLayer{atomically, walletsDB} netLayer
                     (unsafeShelleyOnlyGetRewardXPub (getState wallet))
                     (fst protocolParams)
                     defaultTransactionCtx
-                    -- FIXME: Shouldn't there be a delegation action added here?
-                    -- 😅
+                    -- It would seem that we should add a delegation action
+                    -- to the partial tx we construct, this was not done
+                    -- previously, and the difference should be negligible.
                     (Left $ PreSelection [])
 
         let ptx = PartialTx
@@ -3868,7 +3869,7 @@ defaultChangeAddressGen arg proxy =
         (genChange arg)
         (maxLengthAddressFor proxy)
 
--- | TODO: ADP-2459
+-- TODO: ADP-2459 - replace with something nicer.
 toBalanceTxPParams
     :: forall era. WriteTx.IsRecentEra era
     => ProtocolParameters

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2278,6 +2278,8 @@ buildTransactionPure
     -- of wallet type, from the root key. To avoid requiring another
     -- 'withRootKey' call, and to make the sketchy behaviour more explicit, we
     -- make 'buildAndSignTransactionPure' partial instead.
+    --
+    -- https://input-output.atlassian.net/browse/ADP-2933
     unsafeShelleyOnlyGetRewardXPub :: s -> XPub
     unsafeShelleyOnlyGetRewardXPub walletState =
         fromMaybe notShelleyWallet $ do
@@ -2941,6 +2943,8 @@ delegationFee db@DBLayer{atomically, walletsDB} netLayer
     -- of wallet type, from the root key. To avoid requiring another
     -- 'withRootKey' call, and to make the sketchy behaviour more explicit, we
     -- make 'buildAndSignTransactionPure' partial instead.
+    --
+    -- https://input-output.atlassian.net/browse/ADP-2933
     unsafeShelleyOnlyGetRewardXPub :: s -> XPub
     unsafeShelleyOnlyGetRewardXPub walletState =
         fromMaybe notShelleyWallet $ do


### PR DESCRIPTION
- [x] Move `Cardano.bundleProtocolParams` outside `calculateFeePercentiles` loop (may not have had an effect)
- [x] Move `mkUnsignedTx` partial tx construction outside `calculateFeePercentiles` loop (did have an effect)

### Comments

Me testing locally:

> Last commit improved it from 1.6s to 0.07s for me (CARDANO_WALLET_TRACING_MIN_SEVERITY=Info cabal test cardano-wallet:integration --test-options '--match "STAKE_POOLS_ESTIMATE_FEE_01"' | grep "delegation-fees 200 OK in")

[Piotr's findings](https://input-output-rnd.slack.com/archives/GBT05825V/p1680276602919599?thread_ts=1680186151.494539&cid=GBT05825V) - 0.227s, down from [2.5s](https://input-output.atlassian.net/browse/ADP-2903?focusedCommentId=164865). Though we're still up in total from last release where it was [0.03s](https://input-output.atlassian.net/browse/ADP-2903)

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2903
