### PR TITLE
Fix signing of external reward accounts in preparation for balanceTx reuse

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2122,7 +2122,7 @@ signTransaction ctx (ApiT wid) body = do
 
                 era <- liftIO $ NW.currentNodeEra nl
                 let sealedTx = body ^. #transaction . #getApiT
-                pure $ W.signTransaction tl era keyLookup (rootK, pwdP) utxo sealedTx
+                pure $ W.signTransaction tl era keyLookup Nothing (rootK, pwdP) utxo sealedTx
 
     -- TODO: The body+witnesses seem redundant with the sealedTx already. What's
     -- the use-case for having them provided separately? In the end, the client

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -167,8 +167,8 @@ data TransactionLayer k ktype tx = TransactionLayer
     , addVkWitnesses
         :: AnyCardanoEra
             -- Preferred latest era
-        -> (XPrv, Passphrase "encryption")
-            -- Reward account
+        -> [(XPrv, Passphrase "encryption")]
+            -- Reward accounts
         -> (KeyHash, XPrv, Passphrase "encryption")
             -- policy public and private key
         -> (Address -> Maybe (k ktype XPrv, Passphrase "encryption"))
@@ -281,7 +281,7 @@ data TransactionCtx = TransactionCtx
     -- ^ Extra fees. Some parts of a transaction are not representable using
     -- cardano-wallet types, which makes it useful to account for them like
     -- this. For instance: datums.
-    } deriving (Show, Generic, Eq)
+    } deriving Generic
 
 -- | Represents a preliminary selection of tx outputs typically made by user.
 newtype PreSelection = PreSelection { outputs :: [TxOut] }
@@ -290,14 +290,18 @@ newtype PreSelection = PreSelection { outputs :: [TxOut] }
 
 data Withdrawal
     = WithdrawalSelf RewardAccount (NonEmpty DerivationIndex) Coin
-    | WithdrawalExternal RewardAccount (NonEmpty DerivationIndex) Coin
+    | WithdrawalExternal
+        RewardAccount
+        (NonEmpty DerivationIndex)
+        Coin
+        XPrv
+        -- ^ The 'XPrv' to be used for signing. Must be unencrypted.
     | NoWithdrawal
-    deriving (Show, Eq)
 
 withdrawalToCoin :: Withdrawal -> Coin
 withdrawalToCoin = \case
     WithdrawalSelf _ _ c -> c
-    WithdrawalExternal _ _ c -> c
+    WithdrawalExternal _ _ c _ -> c
     NoWithdrawal -> Coin 0
 
 -- | A default context with sensible placeholder. Can be used to reduce

--- a/lib/wallet/test/unit/Cardano/Wallet/DelegationSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DelegationSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -10,6 +11,8 @@ module Cardano.Wallet.DelegationSpec
 
 import Prelude
 
+import Cardano.Address.Derivation
+    ( XPrv, xprvFromBytes, xprvToBytes )
 import Cardano.Pool.Types
     ( PoolId (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -28,10 +31,12 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Transaction
     ( Withdrawal (..) )
+import Data.Function
+    ( on )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
-    ( isNothing )
+    ( fromJust, isNothing )
 import Data.Word
     ( Word64 )
 import Data.Word.Odd
@@ -55,6 +60,7 @@ import Test.QuickCheck
     , property
     , shrinkIntegral
     , vector
+    , vectorOf
     , (.&&.)
     , (===)
     )
@@ -221,9 +227,20 @@ instance Arbitrary EpochNo => Arbitrary WalletDelegationNext where
 instance Arbitrary Withdrawal where
     arbitrary = oneof
         [ WithdrawalSelf <$> arbitrary <*> arbitrary <*> arbitrary
-        , WithdrawalExternal <$> arbitrary <*> arbitrary <*> arbitrary
+        , applyArbitrary4 WithdrawalExternal
         , pure NoWithdrawal
         ]
+
+instance Arbitrary XPrv where
+    arbitrary = fromJust . xprvFromBytes . BS.pack <$> vectorOf 96 arbitrary
+
+instance Show XPrv where
+    show = show . xprvToBytes
+
+instance Eq XPrv where
+    (==) = (==) `on` xprvToBytes
+
+deriving instance Show Withdrawal
 
 instance Arbitrary RewardAccount where
     arbitrary = RewardAccount . BS.pack <$> vector 28

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -699,7 +699,7 @@ prop_signTransaction_addsRewardAccountKey
 
                 sealedTx = sealedTxFromCardano' $ Cardano.Tx txBody wits
                 sealedTx' = signTransaction tl (AnyCardanoEra era)
-                    (const Nothing) rootK utxo sealedTx
+                    (const Nothing) Nothing rootK utxo sealedTx
 
                 expectedWits :: [InAnyCardanoEra Cardano.KeyWitness]
                 expectedWits = InAnyCardanoEra era <$>
@@ -776,6 +776,7 @@ prop_signTransaction_addsExtraKeyWitnesses
             sealedTx' = signTransaction tl
                 (AnyCardanoEra era)
                 (lookupFnFromKeys extraKeys)
+                Nothing
                 (first liftRawKey rootK)
                 utxo
                 sealedTx
@@ -910,6 +911,7 @@ prop_signTransaction_addsTxInWitnesses
                 sealedTx' = signTransaction tl
                     (AnyCardanoEra era)
                     (lookupFnFromKeys extraKeys)
+                    Nothing
                     (first liftRawKey rootK)
                     utxo
                     sealedTx
@@ -963,6 +965,7 @@ prop_signTransaction_addsTxInCollateralWitnesses
                     sealedTx' = signTransaction tl
                         (AnyCardanoEra era)
                         (lookupFnFromKeys extraKeys)
+                        Nothing
                         (first liftRawKey rootK)
                         utxo
                         sealedTx
@@ -999,6 +1002,7 @@ prop_signTransaction_neverRemovesWitnesses
             sealedTx' = signTransaction tl
                 (AnyCardanoEra era)
                 (lookupFnFromKeys extraKeys)
+                Nothing
                 (first liftRawKey rootK)
                 utxo
                 sealedTx
@@ -1031,6 +1035,7 @@ prop_signTransaction_neverChangesTxBody
             sealedTx' = signTransaction tl
                 (AnyCardanoEra era)
                 (lookupFnFromKeys extraKeys)
+                Nothing
                 (first liftRawKey rootK)
                 utxo
                 sealedTx
@@ -1068,6 +1073,7 @@ prop_signTransaction_preservesScriptIntegrity (AnyCardanoEra era) rootK utxo =
             sealedTx' = signTransaction tl
                 (AnyCardanoEra era)
                 (const Nothing)
+                Nothing
                 (first liftRawKey rootK)
                 utxo
                 sealedTx


### PR DESCRIPTION
- [x] Makes integration tests pass in the balanceTx re-use branch

### Comments

Non-goal: refactor signing. That's for https://input-output.atlassian.net/browse/ADP-2675

### Issue Number

ADP-2598
