### PR TITLE
Fix expected error message TRANSMETA_ESTIMATE_03

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -520,7 +520,7 @@ instance IsServerError ErrBalanceTx where
                 ]
         ErrBalanceTxInternalError e -> toServerError e
         ErrBalanceTxMaxSizeLimitExceeded ->
-            apiError err403 BalanceTxMaxSizeLimitExceeded $ T.unwords
+            apiError err403 TransactionIsTooBig $ T.unwords
                 [ "I was not able to balance the transaction without exceeding"
                 , "the maximum transaction size."
                 ]

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Error.hs
@@ -92,7 +92,6 @@ data ApiErrorInfo
     | BalanceTxInlineDatumsNotSupportedInAlonzo
     | BalanceTxInlineScriptsNotSupportedInAlonzo
     | BalanceTxInternalError
-    | BalanceTxMaxSizeLimitExceeded
     | BalanceTxUnderestimatedFee
         ApiErrorBalanceTxUnderestimatedFee
     | CannotCoverFee

--- a/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
@@ -371,9 +371,8 @@ errMsg403EmptyUTxO =
 
 errMsg403TxTooBig :: String
 errMsg403TxTooBig =
-    "I am not able to finalize the transaction because I need to select \
-    \additional inputs and doing so will make the transaction too big. \
-    \Try sending a smaller amount."
+    "I was not able to balance the transaction \
+    \without exceeding the maximum transaction size."
 
 errMsg400MalformedTxPayload :: String
 errMsg400MalformedTxPayload =

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -111,6 +111,7 @@ import Test.Integration.Framework.DSL
     , emptyRandomWallet
     , emptyWallet
     , eventually
+    , expectErrorCode
     , expectErrorMessage
     , expectField
     , expectListField
@@ -1282,7 +1283,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         verify r
             [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403TxTooBig
+            , expectErrorCode "transaction_is_too_big"
             ]
 
     describe "TRANS_ESTIMATE_08 - Bad payload" $ do

--- a/lib/wallet/test/data/Cardano/Wallet/Api/ApiError.json
+++ b/lib/wallet/test/data/Cardano/Wallet/Api/ApiError.json
@@ -193,10 +193,6 @@
             "message": "𡡥􎳛'b_#q\u0006e*\nC∝𤈓􌽶i\u001fmT\u000em+𫃋7V"
         },
         {
-            "code": "balance_tx_max_size_limit_exceeded",
-            "message": "<?󽄒"
-        },
-        {
             "code": "address_already_exists",
             "message": "rK-pB\u0016_L\u001b~18􈆱<\u0018i_\u0016襏e"
         },
@@ -382,10 +378,6 @@
         {
             "code": "bad_request",
             "message": "n>\u001fOxL\u0011d;"
-        },
-        {
-            "code": "balance_tx_max_size_limit_exceeded",
-            "message": "V:\u001dP\u001f.󳙤I\rk𮖵E\u0002𫩯A\u00061\u0003]pcc\u001a5"
         },
         {
             "code": "not_delegating_to",

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -4834,19 +4834,6 @@ x-errBalanceTxInternalError: &errBalanceTxInternalError
       type: string
       enum: ["balance_tx_internal_error"]
 
-x-errBalanceTxMaxSizeLimitExceeded: &errBalanceTxMaxSizeLimitExceeded
-  <<: *responsesErr
-  title: balance_tx_max_size_limit_exceeded
-  properties:
-    message:
-      type: string
-      description: |
-        I was not able to balance the transaction without exceeding
-        the maximum transaction size.
-    code:
-      type: string
-      enum: ["balance_tx_max_size_limit_exceeded"]
-
 x-errBalanceTxUnderestimatedFee: &errBalanceTxUnderestimatedFee
   <<: *responsesErr
   title: balance_tx_underestimated_fee
@@ -6189,7 +6176,6 @@ x-responsesBalanceTransaction: &responsesBalanceTransaction
             - <<: *errBalanceTxExistingReturnCollateral
             - <<: *errBalanceTxExistingTotalCollateral
             - <<: *errBalanceTxInternalError
-            - <<: *errBalanceTxMaxSizeLimitExceeded
             - <<: *errCannotCoverFee
             - <<: *errInsufficientCollateral
             - <<: *errInvalidWalletType


### PR DESCRIPTION
- [x] Use `TransactionIsTooBig` not `BalanceTxMaxSizeExceeded` for error responses.
- [x] Expectation is based on error code not message.
- [x] Adjust error message too.

### Issue Number

ADP-2269
