### PR TITLE
Fix more fee-related integration tests for `postTransactionFee`

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2362,8 +2362,10 @@ postTransactionFeeOld ctx@ApiLayer{..} (ApiT walletId) body = do
     AnyRecentEra (recentEra :: WriteTx.RecentEra era) <- guardIsRecentEra era
     protocolParams@(protocolParameters, _bundledProtocolParameters) <- liftIO $
         W.toBalanceTxPParams @era <$> currentProtocolParameters netLayer
+    let mTTL = body ^? #timeToLive . traverse . #getQuantity
     withWorkerCtx ctx walletId liftE liftE $ \workerCtx -> do
         let db = workerCtx ^. dbLayer
+        ttl <- liftIO $ W.transactionExpirySlot (timeInterpreter netLayer) mTTL
         wdrl <- case body ^. #withdrawal of
             Nothing -> pure NoWithdrawal
             Just apiWdrl ->
@@ -2384,6 +2386,7 @@ postTransactionFeeOld ctx@ApiLayer{..} (ApiT walletId) body = do
                 { txWithdrawal = wdrl
                 , txMetadata = body
                     ^? #metadata . traverse . #txMetadataWithSchema_metadata
+                , txValidityInterval = (Nothing, ttl)
                 }
             PreSelection{outputs}
         pure

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2417,7 +2417,11 @@ postTransactionFeeOld ctx@ApiLayer{..} (ApiT walletId) body = do
     -- In the context of a mainnet `minfeeA` value of 44 lovelace/byte the
     -- padding is negligible - less than 1/1000 ada.
     padding :: Quantity "byte" Word
-    padding = Quantity 20
+    padding = Quantity $ 20 + tmpExtraPadding
+      where
+        -- TODO [ADP-2268] This padding should be droppable once postTransaction
+        -- also relies on balanceTx.
+        tmpExtraPadding = 5
 
 constructTransaction
     :: forall (n :: NetworkDiscriminant)

--- a/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
@@ -1187,7 +1187,7 @@ waitForTxImmutability _ctx = liftIO $ do
 
     threadDelay $ stabilityDelay + txInsertionDelay
 
-between :: (Ord a, Show a) => (a, a) -> a -> Expectation
+between :: (Ord a, Show a, HasCallStack) => (a, a) -> a -> Expectation
 between (min', max') x
     | min' <= x && x <= max'
         = return ()
@@ -1200,7 +1200,7 @@ between (min', max') x
             , show max'
             ]
 
-(.>) :: (Ord a, Show a) => a -> a -> Expectation
+(.>) :: (Ord a, Show a, HasCallStack) => a -> a -> Expectation
 x .> bound
     | x > bound
         = return ()
@@ -1212,7 +1212,7 @@ x .> bound
             , ")"
             ]
 
-(.<) :: (Ord a, Show a) => a -> a -> Expectation
+(.<) :: (Ord a, Show a, HasCallStack) => a -> a -> Expectation
 x .< bound
     | x < bound
         = return ()
@@ -1225,7 +1225,7 @@ x .< bound
             ]
 
 
-(.>=) :: (Ord a, Show a) => a -> a -> Expectation
+(.>=) :: (Ord a, Show a, HasCallStack) => a -> a -> Expectation
 a .>= b
     | a >= b
         = return ()
@@ -1237,7 +1237,7 @@ a .>= b
             , ")"
             ]
 
-(.<=) :: (Ord a, Show a) => a -> a -> Expectation
+(.<=) :: (Ord a, Show a, HasCallStack) => a -> a -> Expectation
 a .<= b
     | a <= b
         = return ()

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shared/Wallets.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shared/Wallets.hs
@@ -1449,6 +1449,8 @@ spec = describe "SHARED_WALLETS" $ do
         let ep = Link.createTransactionOld @'Shelley
         rTx <- request @(ApiTransaction n) ctx (ep wShelley) Default payloadTx
         expectResponseCode HTTP.status202 rTx
+
+        -- TODO Drop expectation https://input-output.atlassian.net/browse/ADP-2935
         expectField
             (#fee . #getQuantity)
             (between (feeMin, feeMax))

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shared/Wallets.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shared/Wallets.hs
@@ -92,6 +92,7 @@ import Test.Integration.Framework.DSL
     , MnemonicLength (..)
     , Payload (..)
     , bech32Text
+    , between
     , decodeErrorInfo
     , deleteSharedWallet
     , emptySharedWallet
@@ -1443,17 +1444,22 @@ spec = describe "SHARED_WALLETS" $ do
                 }],
                 "passphrase": #{fixturePassphrase}
             }|]
-        (_, ApiFee (Quantity _) (Quantity feeMax) _ _) <- unsafeRequest ctx
+        (_, ApiFee (Quantity feeMin) (Quantity feeMax) _ _) <- unsafeRequest ctx
             (Link.getTransactionFeeOld @'Shelley wShelley) payloadTx
         let ep = Link.createTransactionOld @'Shelley
         rTx <- request @(ApiTransaction n) ctx (ep wShelley) Default payloadTx
         expectResponseCode HTTP.status202 rTx
+        expectField
+            (#fee . #getQuantity)
+            (between (feeMin, feeMax))
+            rTx
+        let Quantity fee = getFromResponse #fee rTx
         eventually "wShelley balance is decreased" $ do
             ra <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wShelley) Default Empty
             expectField
                 (#balance . #available)
-                (`shouldBe` Quantity (faucetAmt - feeMax - amt)) ra
+                (`shouldBe` Quantity (faucetAmt - fee - amt)) ra
 
         rWal <- getSharedWallet ctx walShared
         verify (fmap (view #wallet) <$> rWal)

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -418,6 +418,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         let txid = getFromResponse #id rTx
         let linkSrc = Link.getTransaction @'Shelley wa (ApiTxId txid)
+        let Quantity fee = getFromResponse #fee rTx
         eventually "transaction is no longer pending on source wallet" $ do
             rSrc <- request @(ApiTransaction n) ctx linkSrc Default Empty
             verify rSrc
@@ -459,7 +460,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 (Link.getWallet @'Shelley wa) Default Empty
             expectField
                 (#balance . #available)
-                (`shouldBe` Quantity (initialAmt - feeMax - amt)) ra2
+                (`shouldBe` Quantity (initialAmt - fee - amt)) ra2
 
     it "TRANS_CREATE_02x - Multiple Output Tx to single wallet" $
         \ctx -> runResourceT $ do


### PR DESCRIPTION
- [x] Let the `ttl` contribute to the tx size when estimating fees.
- [x] Add extra temporary padding both in integration tests and in the implementation.

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
