### PR TITLE
[ADP-2934] Change `DBLayer` to contain `WalletId`

### DIFF
--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -750,8 +750,9 @@ setupDB tr = do
     withSetup action = withTempSqliteFile $ \fp -> do
         let trDB = contramap MsgDB tr
         withConnectionPool trDB fp $ \pool -> do
-            ctx <- either throwIO pure =<< newSqliteContext trDB pool [] migrateAll
-            db <- newDBLayerWith NoCache tr singleEraInterpreter ctx
+            ctx <- either throwIO pure
+                =<< newSqliteContext trDB pool [] migrateAll
+            db <- newDBLayerWith NoCache tr singleEraInterpreter testWid ctx
             action (fp, db)
 
 singleEraInterpreter :: TimeInterpreter IO

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -758,7 +758,7 @@ bench_restoration
         np socket vData sTol $ \nw -> do
             let ti = neverFails "bench db shouldn't forecast into future"
                     $ timeInterpreter nw
-            withBenchDBLayer ti wlTr
+            withBenchDBLayer ti wlTr wid
                 $ \db -> withWalletLayerTracer
                     benchname pipeliningStrat traceToDisk
                 $ \progressTrace -> do
@@ -866,11 +866,12 @@ withBenchDBLayer
         )
     => TimeInterpreter IO
     -> Trace IO Text
+    -> WalletId
     -> (DBLayer IO s k -> IO a)
     -> IO a
-withBenchDBLayer ti tr action =
+withBenchDBLayer ti tr wid action =
     withSystemTempFile "bench.db" $ \dbFile _ ->
-        withDBLayer tr' migrationDefaultValues dbFile ti action
+        withDBLayer tr' migrationDefaultValues dbFile ti wid action
   where
     migrationDefaultValues = Sqlite.DefaultFieldValues
         { Sqlite.defaultActiveSlotCoefficient = 1

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -200,10 +200,6 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -- 'putWalletMeta', 'putTxHistory' or 'putProtocolParameters' will
         -- actually all fail if they are called _first_ on a wallet.
 
-    , getWalletId
-        :: ExceptT ErrWalletNotInitialized stm WalletId
-        -- ^ Get the list of all known wallets in the DB, possibly empty.
-
     , walletsDB
         :: DBVar stm (DeltaMap WalletId (DeltaWalletState s))
         -- ^ 'DBVar' containing the 'WalletState' of each wallet in the database.
@@ -503,7 +499,6 @@ mkDBLayerFromParts
 mkDBLayerFromParts ti wid_ DBLayerCollection{..} = DBLayer
     { walletId_ = wid_
     , initializeWallet = initializeWallet_ dbWallets
-    , getWalletId = getWalletId_ dbWallets
     , walletsDB = walletsDB_ dbCheckpoints
     , putCheckpoint = putCheckpoint_ dbCheckpoints
     , readCheckpoint = readCheckpoint'

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -188,7 +188,8 @@ newtype DBOpen stm m s (k :: Depth -> Type -> Type) = DBOpen
 -- but we often need additional constraints on the wallet state that allows us
 -- to serialize and unserialize it (e.g. @forall s. (Serialize s) => ...@).
 data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
-    { initializeWallet
+    { walletId_ :: WalletId
+    , initializeWallet
         :: WalletId
         -> Wallet s
         -> WalletMetadata
@@ -496,10 +497,12 @@ data DBLayerCollection stm m s k = DBLayerCollection
 mkDBLayerFromParts
     :: forall stm m s k. (MonadIO stm, MonadFail stm)
     => TimeInterpreter IO
+    -> WalletId
     -> DBLayerCollection stm m s k
     -> DBLayer m s k
-mkDBLayerFromParts ti DBLayerCollection{..} = DBLayer
-    { initializeWallet = initializeWallet_ dbWallets
+mkDBLayerFromParts ti wid_ DBLayerCollection{..} = DBLayer
+    { walletId_ = wid_
+    , initializeWallet = initializeWallet_ dbWallets
     , getWalletId = getWalletId_ dbWallets
     , walletsDB = walletsDB_ dbCheckpoints
     , putCheckpoint = putCheckpoint_ dbCheckpoints

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -413,19 +413,6 @@ withDBLayer tr defaultFieldValues dbFile ti action = do
         res <- newSqliteContext trDB pool manualMigrations autoMigrations
         either throwIO (action <=< newDBLayerWith CacheLatestCheckpoint tr ti) res
 
-newtype WalletDBLog
-    = MsgDB DBLog
-    deriving (Generic, Show, Eq)
-
-instance HasPrivacyAnnotation WalletDBLog
-instance HasSeverityAnnotation WalletDBLog where
-    getSeverityAnnotation = \case
-        MsgDB msg -> getSeverityAnnotation msg
-
-instance ToText WalletDBLog where
-    toText = \case
-        MsgDB msg -> toText msg
-
 -- | Runs an IO action with a new 'DBLayer' backed by a sqlite in-memory
 -- database.
 withDBLayerInMemory
@@ -1024,6 +1011,22 @@ selectGenesisParameters
 selectGenesisParameters wid = do
     gp <- selectFirst [WalId ==. wid] []
     pure $ (genesisParametersFromEntity . entityVal) <$> gp
+
+{-------------------------------------------------------------------------------
+    Logging
+-------------------------------------------------------------------------------}
+newtype WalletDBLog
+    = MsgDB DBLog
+    deriving (Generic, Show, Eq)
+
+instance HasPrivacyAnnotation WalletDBLog
+instance HasSeverityAnnotation WalletDBLog where
+    getSeverityAnnotation = \case
+        MsgDB msg -> getSeverityAnnotation msg
+
+instance ToText WalletDBLog where
+    toText = \case
+        MsgDB msg -> toText msg
 
 {-------------------------------------------------------------------------------
     Internal errors

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -107,8 +107,6 @@ newDBLayer timeInterpreter wid = do
                 alterDB errWalletAlreadyExists db $
                 mInitializeWallet pk cp meta txs gp
 
-        , getWalletId = getWalletId'
-
         {-----------------------------------------------------------------------
                                     Checkpoints
         -----------------------------------------------------------------------}

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -88,7 +88,10 @@ newDBLayer
     -> m (DBLayer m s k)
 newDBLayer timeInterpreter wid = do
     lock <- newMVar ()
-    db <- newMVar (emptyDatabase :: Database WalletId s (k 'RootK XPrv, PassphraseHash))
+    db <- newMVar
+            (emptyDatabase wid
+                :: Database WalletId s (k 'RootK XPrv, PassphraseHash)
+            )
     let getWalletId' = ExceptT
             $ alterDB errWalletNotInitialized db mGetWalletId
     let

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -84,8 +84,9 @@ newDBLayer
        ( MonadUnliftIO m
        , MonadFail m )
     => TimeInterpreter Identity
+    -> WalletId
     -> m (DBLayer m s k)
-newDBLayer timeInterpreter = do
+newDBLayer timeInterpreter wid = do
     lock <- newMVar ()
     db <- newMVar (emptyDatabase :: Database WalletId s (k 'RootK XPrv, PassphraseHash))
     let getWalletId' = ExceptT
@@ -98,7 +99,8 @@ newDBLayer timeInterpreter = do
                                       Wallets
         -----------------------------------------------------------------------}
 
-        { initializeWallet = \pk cp meta txs gp -> ExceptT $
+        { walletId_ = wid
+        , initializeWallet = \pk cp meta txs gp -> ExceptT $
                 alterDB errWalletAlreadyExists db $
                 mInitializeWallet pk cp meta txs gp
 

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -66,6 +66,10 @@ import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Except
     ( ExceptT, mapExceptT, runExceptT, withExceptT )
+import Crypto.Hash
+    ( hash )
+import Data.ByteString
+    ( ByteString )
 import Data.Foldable
     ( fold )
 import Data.Functor.Identity
@@ -99,22 +103,25 @@ import Test.QuickCheck.Monadic
 import qualified Data.List as L
 
 -- | How to boot a fresh database.
-type WithFreshDB s =
-    (DBLayer IO s ShelleyKey -> PropertyM IO ())
+type WithFreshDB s
+    = WalletId
+    -> (DBLayer IO s ShelleyKey -> PropertyM IO ())
     -> PropertyM IO ()
 
 withFreshWallet
     :: GenState s
-    => WithFreshDB s
+    => WalletId
+    -> WithFreshDB s
     -> (DBLayer IO s ShelleyKey -> WalletId -> PropertyM IO ())
     -> PropertyM IO ()
-withFreshWallet withFreshDB f = withFreshDB $ \db@DBLayer {..} -> do
-    (InitialCheckpoint cp0, meta, wid) <- pick arbitrary
-    run
-        $ atomically
-        $ unsafeRunExceptT
-        $ initializeWallet wid cp0 meta mempty gp
-    f db wid
+withFreshWallet wid withFreshDB f = do
+    withFreshDB wid $ \db@DBLayer {..} -> do
+        (InitialCheckpoint cp0, meta) <- pick arbitrary
+        run
+            $ atomically
+            $ unsafeRunExceptT
+            $ initializeWallet wid cp0 meta mempty gp
+        f db wid
 
 type TestOnLayer s =
     ( DBLayer IO s ShelleyKey
@@ -123,13 +130,16 @@ type TestOnLayer s =
     )
     -> Property
 
+testWid :: WalletId
+testWid = WalletId (hash ("test" :: ByteString))
+
 -- | Wallet properties.
 properties
     :: GenState s
     => WithFreshDB s
     -> SpecWith ()
 properties withFreshDB = describe "DB.Properties" $ do
-    let testOnLayer = monadicIO . withFreshWallet withFreshDB
+    let testOnLayer = monadicIO . withFreshWallet testWid withFreshDB
 
     describe "Extra Properties about DB initialization" $ do
         it "creating same wallet twice yields an error"
@@ -347,7 +357,7 @@ prop_createWalletTwice
        )
     -> Property
 prop_createWalletTwice test (wid, InitialCheckpoint cp0, meta) = monadicIO
-    $ test
+    $ test wid
     $ \DBLayer {..} -> do
         liftIO $ do
             let err = ErrWalletAlreadyInitialized
@@ -456,8 +466,8 @@ prop_putBeforeInit
     -> (WalletId, a)
     -- ^ Property arguments
     -> Property
-prop_putBeforeInit test putOp readOp empty (wid, a) = monadicIO $ test $ \db ->
-    liftIO $ do
+prop_putBeforeInit test putOp readOp empty (wid, a) = monadicIO $ test wid
+    $ \db -> liftIO $ do
         runExceptT (putOp db wid a) >>= \case
             Right _ ->
                 fail "expected put operation to fail but it succeeded!"
@@ -556,7 +566,7 @@ prop_rollbackCheckpoint
     -> MockChain
     -> Property
 prop_rollbackCheckpoint test (InitialCheckpoint cp0) (MockChain chain) = monadicIO
-    $ test
+    $ test testWid
     $ \DBLayer {..} -> do
         let cps :: [Wallet s]
             cps = flip unfoldr (chain, cp0) $ \case
@@ -600,7 +610,7 @@ prop_rollbackTxHistory
     -> GenTxHistory
     -> Property
 prop_rollbackTxHistory test (InitialCheckpoint cp0) (GenTxHistory txs0) = do
-    monadicIO $ test $ \DBLayer {..} -> do
+    monadicIO $ test testWid $ \DBLayer {..} -> do
         ShowFmt wid <- namedPick "Wallet ID" arbitrary
         ShowFmt meta <- namedPick "Wallet Metadata" arbitrary
         ShowFmt requestedPoint <- namedPick "Requested Rollback slot" arbitrary

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Pure/ImplementationSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Pure/ImplementationSpec.hs
@@ -46,9 +46,10 @@ spec :: Spec
 spec =
     before (pendingOnMacOS "#2472: timeouts in CI mac builds")
     $ describe "PureLayer"
-    $ properties
-        (liftIO (PureLayer.newDBLayer @_ @(SeqState 'Mainnet ShelleyKey)
-            dummyTimeInterpreter) >>=)
+    $ properties $ \wid test -> do
+        run <- liftIO $ PureLayer.newDBLayer @_ @(SeqState 'Mainnet ShelleyKey)
+            dummyTimeInterpreter wid
+        test run
 
 newtype DummyStatePureLayer = DummyStatePureLayer Int
     deriving (Show, Eq)

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -1232,6 +1232,9 @@ data WalletLayerFixture s m = WalletLayerFixture
     , _fixtureWallet :: [WalletId]
     }
 
+testWid :: WalletId
+testWid = WalletId (hash ("test" :: ByteString))
+
 setupFixture
     :: forall s m
      . ( MonadUnliftIO m
@@ -1246,7 +1249,7 @@ setupFixture (wid, wname, wstate) = do
     let nl = mockNetworkLayer
     let tl = dummyTransactionLayer
     (_kill, db) <-
-        liftIO $ newDBLayerInMemory nullTracer timeInterpreter
+        liftIO $ newDBLayerInMemory nullTracer timeInterpreter testWid
     let db' = hoistDBLayer liftIO db
         wl = WalletLayer nullTracer (block0, np) nl tl db'
     res <- runExceptT $ W.createWallet wl wid wname wstate


### PR DESCRIPTION
### Overview

This task is about adding a field `walletId :: W.WalletId` to the `DBLayer` type.

This represents a significant change in semantics:
* Previously, the `DBLayer` type represented an open database that can contain the state of a single wallet.
* Now, the `DBLayer` type represents an open database that can contain the state of a wallet with a specific id `WalletId`.

This change will allow us to simplify many type signatures in `Cardano.Wallet`, as we can drop the `WalletId` argument — they will be implied by the `DBLayer`. However, for some of the unit tests, we will need a type `DBOpen` that captures the old semantics.

### Issue number

ADP-2934