### PR TITLE
Suggestions for #3822

### DIFF
--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2901,6 +2901,10 @@ delegationFee db@DBLayer{atomically, walletsDB} netLayer
                 Just ws -> pure $ WalletState.getLatest ws
         let utxoIndex = UTxOIndex.fromMap . CS.toInternalUTxOMap $
                 availableUTxO @s mempty wallet
+        when (UTxOIndex.null utxoIndex)
+            $ throwE
+            $ ErrSelectAssetsSelectionError
+            $ SelectionBalanceErrorOf EmptyUTxO
         pureTimeInterpreter <- lift $ snapshot ti
         unsignedTxBody <- either
             (liftIO . throwIO . ExceptionConstructTx . ErrConstructTxBody)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2905,7 +2905,6 @@ delegationFee db@DBLayer{atomically, walletsDB} netLayer
             $ throwE
             $ ErrSelectAssetsSelectionError
             $ SelectionBalanceErrorOf EmptyUTxO
-        pureTimeInterpreter <- lift $ snapshot ti
         unsignedTxBody <- either
             (liftIO . throwIO . ExceptionConstructTx . ErrConstructTxBody)
             pure $ mkUnsignedTransaction txLayer @era
@@ -2921,6 +2920,7 @@ delegationFee db@DBLayer{atomically, walletsDB} netLayer
                 , inputs = Cardano.UTxO mempty
                 , redeemers = []
                 }
+        pureTimeInterpreter <- lift $ snapshot ti
         feePercentiles <- calculateFeePercentiles $ do
             Right (Cardano.Tx (Cardano.TxBody bodyContent) _, _updatedWallet) <-
                 runExceptT $

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2902,16 +2902,16 @@ delegationFee db@DBLayer{atomically, walletsDB} netLayer
         let utxoIndex = UTxOIndex.fromMap . CS.toInternalUTxOMap $
                 availableUTxO @s mempty wallet
         pureTimeInterpreter <- lift $ snapshot ti
-        let unsignedTxBody = either (error .show) id $
-                mkUnsignedTransaction txLayer @era
-                    (unsafeShelleyOnlyGetRewardXPub (getState wallet))
-                    (fst protocolParams)
-                    defaultTransactionCtx
-                    -- It would seem that we should add a delegation action
-                    -- to the partial tx we construct, this was not done
-                    -- previously, and the difference should be negligible.
-                    (Left $ PreSelection [])
-
+        unsignedTxBody <- either
+            (liftIO . throwIO . ExceptionConstructTx . ErrConstructTxBody)
+            pure $ mkUnsignedTransaction txLayer @era
+                (unsafeShelleyOnlyGetRewardXPub (getState wallet))
+                (fst protocolParams)
+                defaultTransactionCtx
+                -- It would seem that we should add a delegation action
+                -- to the partial tx we construct, this was not done
+                -- previously, and the difference should be negligible.
+                (Left $ PreSelection [])
         let ptx = PartialTx
                 { tx = Cardano.Tx unsignedTxBody []
                 , inputs = Cardano.UTxO mempty


### PR DESCRIPTION
This PR contains a few suggestions for #3822.

In particular, it adds a guard for the case where the available UTxO set is completely empty, satisfying the expectations of `STAKE_POOLS_ESTIMATE_FEE_02`.

The integration test suite now passes.

Buildkite: https://buildkite.com/input-output-hk/cardano-wallet/builds/24428#01876e81-fe05-46c6-a152-ca9306200094

Locally:
```
Finished in 3178.8024 seconds, used 1131.6679 seconds of CPU time
994 examples, 0 failures, 11 pending

Slow spec items:
  integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs:2637:5: /API Specifications/NEW_SHELLEY_TRANSACTIONS/TRANS_NEW_JOIN_01a - Can join stakepool, rejoin another and quit/ (287527ms)
  integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs:2991:5: /API Specifications/NEW_SHELLEY_TRANSACTIONS/TRANS_NEW_JOIN_01e - Can re-join and withdraw at once/ (153530ms)
  integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs:555:5: /API Specifications/SHELLEY_STAKE_POOLS/STAKE_POOLS_JOIN_01 - Can rejoin another stakepool/ (149240ms)
  integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs:215:5: /API Specifications/SHELLEY_STAKE_POOLS/STAKE_POOLS_JOIN_01rewards - Can join a pool, earn rewards and collect them/ (135855ms)
  integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs:894:9: /API Specifications/SHELLEY_STAKE_POOLS/STAKE_POOLS_QUIT_01x - Fee boundary values/STAKE_POOLS_QUIT_01xx - I can quit if I have enough to cover fee/ (135490ms)
  integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs:624:5: /API Specifications/SHELLEY_STAKE_POOLS/STAKE_POOLS_JOIN_04 - Rewards accumulate/ (129183ms)
  integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs:954:9: /API Specifications/SHELLEY_STAKE_POOLS/STAKE_POOLS_QUIT_01x - Fee boundary values/STAKE_POOLS_QUIT_01x - I cannot quit if I have not enough to cover fees/ (64167ms)
  integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs:799:11: /API Specifications/SHELLEY_STAKE_POOLS/STAKE_POOLS_QUIT_UNSIGNED_01/Join/quit when already joined a pool/ (59549ms)
  integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs:3275:5: /API Specifications/NEW_SHELLEY_TRANSACTIONS/TRANS_NEW_CREATE_MULTI_TX - Tx including payments, delegation, metadata, withdrawals, validity_interval/ (54075ms)
  integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs:2370:5: /API Specifications/SHELLEY_TRANSACTIONS/SHELLEY_TX_REDEEM_07a - Can't redeem rewards if cannot cover fee/ (40543ms)
Test suite integration: PASS
```