### PR TITLE
[ADP-2925] remove staging network support

### DIFF
--- a/docs/design/Eras.md
+++ b/docs/design/Eras.md
@@ -39,7 +39,7 @@ Only the hash of a genesis config is stored on-chain. For mainnet, the genesis h
 
 When `cardano-wallet` connects to its local `cardano-node`, it must provide the Byron genesis config hash. Hashes for subsequent genesis configs are contained on-chain within the voting system update proposals.
 
-For _mainnet_, we have hardcoded the genesis hash. It will never change. For _staging_ and _testnet_, users must supply a genesis config to the [[cli]], so that its hash may be used when connecting to the local node.
+For _mainnet_, we have hardcoded the genesis hash. It will never change. For _testnet_, users must supply a genesis config to the [[cli]], so that its hash may be used when connecting to the local node.
 
 ::: {.gotcha}
 #### Epoch Boundary Blocks

--- a/docs/design/Notes-about-BIP-44.md
+++ b/docs/design/Notes-about-BIP-44.md
@@ -107,27 +107,3 @@ Possible mitigations:
 
 1. Exchanges could make use of a larger gap limit, violating the classic BIP-44 default but, still following the same principle otherwise. Despite being inefficient, it could work for exchanges with a limited number of users.
 2. Another wallet scheme that would be better suited for exchanges should probably be considered.
-
-
-### Limit 2 - Error prone with staging networks
-
-A subtle issue with BIP-44 wallets would be to use a software to generate addresses on a given network, and use such generated addresses on a different albeit compatible network. This has been the case between the Cardano Mainnet and Staging networks recently. Let's run through the following example:
-
-1. A user creates a brand new wallet on the staging network. Following the default recommended gap limit, 20 unused addresses are generated for this wallet.
-
-2. The user also creates a wallet on the main network, using the same recovery phrase. Because both networks share the same address discimination policy, there's no difference between addresses of both networks. Addresses from the staging network are valid addresses on the main network.
-
-3. This user gives her 10th address to someone in order to receive some funds on the **staging network**. Eventually, she receives funds on her addresses which causes the **staging** wallet to generate 10 new addresses (as seen before).
-
-4. Then, she also needs to receive funds on her wallet from the **main network** but mistakenly takes an address from the **staging network**. Above all, she happens to take the 24th addresses of her staging wallet.
-
-5. Because addresses are valid on both networks, the transaction is successfully processed but never show up in her main wallet.
-
-
-What has happened? The **main** wallet only looks for addresses with indexes between 0 and 19 (incl.) and a transaction is made on an address with index `i=23`; it is therefore outside of what's currently observable by the main wallet. This is because, from the main wallet's perspective, one of the two BIP-44 invariants has been violated. It shouldn't have been possible to generate an address beyond the 20th index on the main network because no previous address had been used on this network.
-
-Possible mitigations:
-
-1. Having a different discrimination between staging and main networks would prevent addresses from one to be mistakenly used on another. In practice, we typically want such two networks to be as close as possible. Thus enforcing this discrimination simply in _client softwares_ could already be a sufficient for most users. More advanced users who would be crafting addresses themselves would still be able to by-pass this kind of safety net, but it comes with the "advanced" powers.
-
-2. Wallet could allow arbitrarily longer gaps to allow transactions to be discovered even if made outside of the default gap limit. In most cases, this would be sufficient with a slightly larger gap (e.g. 40 or 50) because typical users don't use large indexes anyway. We've used this technique with gap as high as 10.000 (with a following shrinking) during the ITN on Cardano to cope with the lack of blockchain history caused by the ITN snapshot.

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -110,7 +110,7 @@ Usage: cardano-wallet serve [--listen-address HOST]
                             [--random-port | --port INT] 
                             [--tls-ca-cert FILE --tls-sv-cert FILE
                               --tls-sv-key FILE] 
-                            (--mainnet | --testnet FILE | --staging FILE) 
+                            (--mainnet | --testnet FILE ) 
                             [--database DIR] [--shutdown-handler] 
                             [--pool-metadata-fetching ( none | direct | SMASH-URL )]
                             [--token-metadata-server URL] 
@@ -141,7 +141,6 @@ Available options:
                            certificate.
   --mainnet                Use Cardano mainnet protocol
   --testnet FILE           Path to the byron genesis data in JSON format.
-  --staging FILE           Path to the byron genesis data in JSON format.
   --database DIR           use this directory for storing wallets. Run in-memory
                            otherwise.
   --shutdown-handler       Enable the clean shutdown handler (exits when stdin

--- a/lib/wallet/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -567,7 +567,6 @@ hashVerificationKey
 hashVerificationKey keyRole =
     KeyHash keyRole . blake2b224 . xpubPublicKey . getRawKey
 
-
 {-------------------------------------------------------------------------------
                      Interface over keys / address types
 -------------------------------------------------------------------------------}
@@ -649,10 +648,6 @@ class MkKeyFingerprint key Address
             -- ^ Payment fingerprint
         -> Address
 
-instance PaymentAddress 'Mainnet k ktype => PaymentAddress ('Staging pm) k ktype where
-    paymentAddress = paymentAddress @'Mainnet @k @ktype
-    liftPaymentAddress = liftPaymentAddress @'Mainnet @k @ktype
-
 class PaymentAddress network key ktype
     => DelegationAddress (network :: NetworkDiscriminant) key ktype where
     -- | Convert a public key and a staking key to a delegation 'Address' valid
@@ -676,10 +671,6 @@ class PaymentAddress network key ktype
         -> key ktype XPub
             -- ^ Staking key / Reward account
         -> Address
-
-instance DelegationAddress 'Mainnet k ktype => DelegationAddress ('Staging pm) k ktype where
-    delegationAddress = delegationAddress @'Mainnet
-    liftDelegationAddress = liftDelegationAddress @'Mainnet
 
 -- | Operations for saving a private key into a database, and restoring it from
 -- a database. The keys should be encoded in hexadecimal strings.

--- a/lib/wallet/src/Cardano/Wallet/Read/NetworkId.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/NetworkId.hs
@@ -46,10 +46,7 @@ import qualified Data.Text as T
 --              addresses. Genesis file needs to be passed explicitly when
 --              starting the application.
 --
--- - @Staging@: very much like testnet, but like mainnet, assumes to no address
---              discrimination. Genesis file needs to be passed explicitly when
---              starting the application.
-data NetworkDiscriminant = Mainnet | Testnet Nat | Staging Nat
+data NetworkDiscriminant = Mainnet | Testnet Nat
     deriving (Typeable)
 
 class NetworkDiscriminantVal (n :: NetworkDiscriminant) where
@@ -63,10 +60,6 @@ instance KnownNat pm => NetworkDiscriminantVal ('Testnet pm) where
     networkDiscriminantVal =
         "testnet (" <> T.pack (show $ natVal $ Proxy @pm) <> ")"
 
-instance KnownNat pm => NetworkDiscriminantVal ('Staging pm) where
-    networkDiscriminantVal =
-        "staging (" <> T.pack (show $ natVal $ Proxy @pm) <> ")"
-
 class NetworkDiscriminantBits (n :: NetworkDiscriminant) where
     networkDiscriminantBits :: Word8
 
@@ -75,9 +68,6 @@ instance NetworkDiscriminantBits 'Mainnet where
 
 instance NetworkDiscriminantBits ('Testnet pm) where
     networkDiscriminantBits = 0b00000000
-
-instance NetworkDiscriminantBits ('Staging pm) where
-    networkDiscriminantBits = 0b00000001
 
 class NetworkDiscriminantCheck (n :: NetworkDiscriminant) k where
     networkDiscriminantCheck :: Word8 -> Bool

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Network/Discriminant.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Network/Discriminant.hs
@@ -85,28 +85,16 @@ deriving instance Show SomeNetworkDiscriminant
 class EncodeAddress (n :: NetworkDiscriminant) where
     encodeAddress :: Address -> Text
 
-instance EncodeAddress 'Mainnet => EncodeAddress ('Staging pm) where
-    encodeAddress = encodeAddress @'Mainnet
-
 -- | An abstract class to allow decoding of addresses depending on the target
 -- backend used.
 class DecodeAddress (n :: NetworkDiscriminant) where
     decodeAddress :: Text -> Either TextDecodingError Address
 
-instance DecodeAddress 'Mainnet => DecodeAddress ('Staging pm) where
-    decodeAddress = decodeAddress @'Mainnet
-
 class EncodeStakeAddress (n :: NetworkDiscriminant) where
     encodeStakeAddress :: W.RewardAccount -> Text
 
-instance EncodeStakeAddress 'Mainnet => EncodeStakeAddress ('Staging pm) where
-    encodeStakeAddress = encodeStakeAddress @'Mainnet
-
 class DecodeStakeAddress (n :: NetworkDiscriminant) where
     decodeStakeAddress :: Text -> Either TextDecodingError W.RewardAccount
-
-instance DecodeStakeAddress 'Mainnet => DecodeStakeAddress ('Staging pm) where
-    decodeStakeAddress = decodeStakeAddress @'Mainnet
 
 networkDiscriminantToId :: SomeNetworkDiscriminant -> NetworkId
 networkDiscriminantToId (SomeNetworkDiscriminant proxy) = networkIdVal proxy
@@ -128,6 +116,3 @@ instance KnownNat protocolMagic => HasNetworkId ('Testnet protocolMagic) where
       where
         networkMagic =
             Cardano.NetworkMagic . fromIntegral . natVal $ Proxy @protocolMagic
-
-instance HasNetworkId ('Staging protocolMagic) where
-    networkIdVal _ = Cardano.Mainnet

--- a/nix/nixos/cardano-wallet-service.nix
+++ b/nix/nixos/cardano-wallet-service.nix
@@ -89,9 +89,9 @@ in
     };
 
     walletMode = mkOption {
-      type = types.enum [ "mainnet" "staging" "testnet" ];
+      type = types.enum [ "mainnet" "testnet" ];
       default = "mainnet";
-      description = "Which mode to start wallet in: --mainnet, --staging or --testnet";
+      description = "Which mode to start wallet in: --mainnet or --testnet";
     };
 
     database = mkOption {

--- a/nix/overlays/cardano-deployments.nix
+++ b/nix/overlays/cardano-deployments.nix
@@ -5,7 +5,6 @@ pkgs: _: {
     environments = {
       inherit (pkgs.cardanoLib.environments)
         mainnet
-        staging
         shelley_qa
         preview
         preprod

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -25,7 +25,7 @@ let
             services.cardano-wallet = let cfg = config.services.cardano-wallet; in
               {
                 package = lib.mkDefault project.hsPkgs.cardano-wallet.components.exes.cardano-wallet;
-                walletMode = lib.mkDefault ({ mainnet = "mainnet"; staging = "staging"; }.${envConfig.name} or "testnet");
+                walletMode = lib.mkDefault ({ mainnet = "mainnet"; }.${envConfig.name} or "testnet");
                 genesisFile = lib.mkIf (cfg.walletMode != "mainnet")
                   (lib.mkDefault envConfig.nodeConfig.ByronGenesisFile);
                 database = lib.mkDefault null;


### PR DESCRIPTION
### Overview

Historical versions of Cardano featured so-called `Staging` networks, which were similar to `Testnet`s, but had the same address format that as `Mainnet`. These have been decommissioned for a long time now, and this pull request removes the corresponding code in `cardano-wallet`.

### Context

* According to [CIP 19][cip19], Shelly-format address have a 4-bit *network tag*, which is `0001` for testnets, and `0000` for mainnet.
* According to [Getting started with Cardano testnets][testnets], generating addresses on one of the current testnets requires the `--testnet` flag; this implies that the `0001` network tag is used for all addresses on current testnets.
* The `Staging` networks uses the network tag `0000`, but for testing purposes. This is now obsolete.

  [cip19]: https://cips.cardano.org/cips/cip19/#networktag
  [testnets]: https://docs.cardano.org/cardano-testnet/getting-started

### Checklist

With this PR we drop support from 
- [x] code
- [x] docs
- [x] nix scripts

### Issue number

ADP-2925
