### PR TITLE
[ADP-2942] Remove key types equalities

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/MintBurn.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/MintBurn.hs
@@ -32,8 +32,6 @@ import Cardano.Wallet.Api.Types.MintBurn
     ( ApiAssetMintBurn (..), includePolicyKeyInfo, policyIx, toApiTokens )
 import Cardano.Wallet.Flavor
     ( WalletFlavor )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( WalletKey )
 import Cardano.Wallet.Primitive.Types
     ( WalletId )
 import Cardano.Wallet.Read.NetworkId
@@ -56,7 +54,6 @@ convertApiAssetMintBurn
     :: forall ctx s k (n :: NetworkDiscriminant)
      . ( HasDBLayer IO s k ctx
        , WalletFlavor s n k
-       , WalletKey k
        )
     => ctx
     -> WalletId
@@ -79,7 +76,6 @@ getTxApiAssetMintBurn
     :: forall ctx s k (n :: NetworkDiscriminant)
      . ( HasDBLayer IO s k ctx
        , WalletFlavor s n k
-       , WalletKey k
        )
     => ctx
     -> WalletId

--- a/lib/wallet/src/Cardano/Wallet/Flavor.hs
+++ b/lib/wallet/src/Cardano/Wallet/Flavor.hs
@@ -1,20 +1,18 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
 
 module Cardano.Wallet.Flavor (WalletFlavorS (..), WalletFlavor (..))
     where
 
+import Cardano.Wallet.Primitive.AddressDerivation.Byron
+    ( ByronKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Icarus
+    ( IcarusKey (..) )
+import Cardano.Wallet.Primitive.AddressDerivation.SharedKey
+    ( SharedKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Shelley
+    ( ShelleyKey )
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
@@ -23,18 +21,22 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( SharedState (..) )
 
 data WalletFlavorS s n k  where
-    ShelleyWallet :: WalletFlavorS (SeqState n k) n k
-    ByronWallet :: WalletFlavorS (RndState n) n k
-    SharedWallet :: WalletFlavorS (SharedState n k) n k
+    ShelleyWallet :: WalletFlavorS (SeqState n ShelleyKey) n ShelleyKey
+    IcarusWallet :: WalletFlavorS (SeqState n IcarusKey) n IcarusKey
+    ByronWallet :: WalletFlavorS (RndState n) n ByronKey
+    SharedWallet :: WalletFlavorS (SharedState n k) n SharedKey
 
 class WalletFlavor s n k where
     walletFlavor :: WalletFlavorS s n k
 
-instance WalletFlavor (SeqState n k) n k where
+instance WalletFlavor (SeqState n IcarusKey) n IcarusKey where
+    walletFlavor = IcarusWallet
+
+instance WalletFlavor (SeqState n ShelleyKey) n ShelleyKey where
     walletFlavor = ShelleyWallet
 
-instance WalletFlavor (RndState n) n k where
+instance WalletFlavor (RndState n) n ByronKey where
     walletFlavor = ByronWallet
 
-instance WalletFlavor (SharedState n k) n k where
+instance WalletFlavor (SharedState n SharedKey) n SharedKey where
     walletFlavor = SharedWallet


### PR DESCRIPTION
Follow up on #3847

- [x] fix key types in the wallet flavors
- [x]  add icarus flavor
- [x] remove key type equalities in Wallet and server modules

ADP-2942
