### PR TITLE
get rid of potential race condition in TRANS_GET_04

### DIFF
--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -1953,20 +1953,11 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
             wDest
             amt
-        let txid = getFromResponse #id rMkTx
-            oneTx = Link.getTransaction @'Shelley
-                    wSrc (ApiTxId txid)
-        r0 <- request @(ApiTransaction n) ctx oneTx Default Empty
-        verify r0
-                [ expectResponseCode HTTP.status200
-                , expectField (#status . #getApiT) (`shouldBe` Pending)
-                ]
-        let listTxs = Link.listTransactions @'Shelley wSrc
-        request @[ApiTransaction n] ctx listTxs Default Empty >>= flip verify
-            [ expectListField 0
-                (#direction . #getApiT) (`shouldBe` Outgoing)
-            , expectListField 0
-                (#status . #getApiT) (`shouldBe` Pending)
+        verify rMkTx
+            [ expectSuccess
+            , expectResponseCode HTTP.status202
+            , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+            , expectField (#status . #getApiT) (`shouldBe` Pending)
             ]
 
     it "TRANS_DELETE_01 -\


### PR DESCRIPTION

- [x] get rid of potential race condition in TRANS_GET_04

### Comments

For instance:
 - https://buildkite.com/input-output-hk/cardano-wallet/builds/24488#0187753b-71ff-49bb-b3b9-4540dda9e903
 - https://buildkite.com/input-output-hk/cardano-wallet/builds/24492#01877555-4342-4da7-929f-4f13bdc67995

It appears that checking if tx is `pending` may cause race conditions because transaction may go `in_ledger` state before we make an assertion. This change eases the expectation and checks for `pending` directly in submission tx response.

### Issue Number

ADP-2909
