### PR TITLE
Enable redundant-constraint warning in opts-exe.

### DIFF
--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -105,8 +105,6 @@ import Cardano.Wallet.Transaction
     ( TransactionLayer (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
-import Control.DeepSeq
-    ( NFData )
 import Control.Monad
     ( forM )
 import Control.Monad.IO.Class
@@ -479,10 +477,7 @@ benchmarksRnd BenchmarkConfig{benchmarkName,ctx,wid} = do
 -------------------------------------------------------------------------------}
 selectAssets
     :: forall (n :: NetworkDiscriminant) s (k :: Depth -> * -> *) ktype
-    .   ( WalletKey k
-        , NFData s
-        , Show s
-        , HasSNetworkId n
+    .   ( HasSNetworkId n
         , BoundedAddressLength k
         )
     => Proxy n
@@ -542,9 +537,7 @@ data BenchmarkConfig (n :: NetworkDiscriminant) s k ktype =
 -- | Run benchmarks on all wallet databases in a given directory.
 benchmarkWallets
     :: forall (n :: NetworkDiscriminant) (k :: Depth -> * -> *) ktype s results
-     . ( NFData s
-       , Show s
-       , PersistAddressBook s
+     . ( PersistAddressBook s
        , WalletKey k
        , PersistPrivateKey (k 'RootK)
        , TxWitnessTagFor k

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -740,7 +740,6 @@ setupDB
     :: forall s k.
         ( PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
-        , WalletKey k
         )
     => Tracer IO WalletDBLog
     -> IO (BenchEnv s k)
@@ -771,7 +770,6 @@ withCleanDB
     :: ( NFData c
        , PersistAddressBook s
        , PersistPrivateKey (k 'RootK)
-       , WalletKey k
        , NFData b
        )
     => Tracer IO WalletDBLog

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -98,13 +98,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Byron
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Primitive.AddressDiscovery
-    ( CompareDiscovery
-    , GenChange (..)
-    , IsOurs
-    , IsOwned
-    , KnownAddresses
-    , MaybeLight
-    )
+    ( GenChange (..), IsOurs, IsOwned, MaybeLight )
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndAnyState, mkRndAnyState )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
@@ -172,8 +166,6 @@ import Cardano.Wallet.Unsafe
     ( unsafeMkEntropy, unsafeMkPercentage, unsafeRunExceptT )
 import Control.Arrow
     ( first )
-import Control.DeepSeq
-    ( NFData )
 import Control.Monad
     ( unless, void )
 import Control.Monad.IO.Class
@@ -725,16 +717,11 @@ bench_baseline_restoration
 {- HLINT ignore bench_restoration "Use camelCase" -}
 bench_restoration
     :: forall (n :: NetworkDiscriminant) (k :: Depth -> * -> *) s results.
-        ( IsOurs s Address
-        , IsOurs s RewardAccount
+        ( IsOurs s RewardAccount
         , MaybeLight s
         , IsOwned s k 'CredFromKeyK
         , WalletKey k
-        , NFData s
-        , Show s
         , PersistAddressBook s
-        , CompareDiscovery s
-        , KnownAddresses s
         , PersistPrivateKey (k 'RootK)
         , HasSNetworkId n
         , TxWitnessTagFor k
@@ -873,12 +860,7 @@ traceBlockHeadersProgressForPlotting t0  tr = Tracer $ \bs -> do
 
 withBenchDBLayer
     :: forall s k a.
-        ( IsOwned s k 'CredFromKeyK
-        , NFData s
-        , Show s
-        , PersistAddressBook s
-        , IsOurs s RewardAccount
-        , IsOurs s Address
+        ( PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
         , WalletKey k
         )
@@ -962,8 +944,7 @@ reportProgress nw tr targetSync readSlot =  do
 -- | Poll the network tip until it reaches the slot corresponding to the current
 -- time.
 waitForNodeSync
-    :: forall n
-    . Tracer IO (BenchmarkLog n)
+    :: forall n. Tracer IO (BenchmarkLog n)
     -> NetworkLayer IO Block
     -> IO SlotNo
 waitForNodeSync tr nw = loop 960 -- allow 240 minutes for first tip

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -22,13 +22,13 @@ common language
 
 common opts-lib
   ghc-options:
-    -Wall -Wcompat -fwarn-redundant-constraints
+    -Wall -Wcompat -Wredundant-constraints
 
   if flag(release)
     ghc-options: -O2 -Werror
 
 common opts-exe
-  ghc-options: -threaded -rtsopts -Wall
+  ghc-options: -threaded -rtsopts -Wall -Wredundant-constraints
 
   if flag(release)
     ghc-options: -O2 -Werror

--- a/lib/wallet/test/unit/Cardano/Wallet/Address/PoolSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Address/PoolSpec.hs
@@ -178,7 +178,7 @@ genPool pool = fromUsage pool <$> genUsageForGap (AddressPool.gap pool)
 -- | Generate a sequence of addresses as they may appear on the blockchain.
 -- This sequence may contain duplicates,
 -- but respects the address gap of the given pool.
-genAddresses :: (Ord addr, Enum ix) => Pool addr ix -> Gen [addr]
+genAddresses :: Enum ix => Pool addr ix -> Gen [addr]
 genAddresses pool = sized $ go 0
   where
     gap = AddressPool.gap pool

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Fixtures.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Fixtures.hs
@@ -192,7 +192,7 @@ unsafeUpdateS :: Applicative m => Store m da -> Base da -> da -> m (Base da)
 unsafeUpdateS store ba da = updateS store (Just ba) da *> unsafeLoadS store
 
 -- | Property that a pure query returns the same result as the store one.
-queryLaw :: (Monad m, Eq b, Query qa, MonadFail m, Base da ~ World qa, Show b)
+queryLaw :: (Monad m, Eq b, Query qa)
     => QueryStore m qa da -- ^ the store to test
   -> World qa -- ^ the world to query
   -> qa b -- ^ the query to run

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Fixtures.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Fixtures.hs
@@ -193,9 +193,13 @@ unsafeUpdateS store ba da = updateS store (Just ba) da *> unsafeLoadS store
 
 -- | Property that a pure query returns the same result as the store one.
 queryLaw :: (Monad m, Eq b, Query qa)
-    => QueryStore m qa da -- ^ the store to test
-  -> World qa -- ^ the world to query
-  -> qa b -- ^ the query to run
-  -> m Bool -- ^ if the pure query returns the same result as the store one
+    => QueryStore m qa da
+    -- ^ the store to test
+    -> World qa
+    -- ^ the world to query
+    -> qa b
+    -- ^ the query to run
+    -> m Bool
+    -- ^ if the pure query returns the same result as the store one
 queryLaw QueryStore{queryS} z r =
     (query r z ==) <$> queryS r

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -298,11 +298,8 @@ spec =
             manualMigrationsSpec
 
 stateMachineSpec
-    :: forall k s ktype.
-        ( WalletKey k
-        , PersistPrivateKey (k 'RootK)
-        , PaymentAddress 'Mainnet k ktype
-        , PersistAddressBook s
+    :: forall k s .
+        ( PersistAddressBook s
         , TestConstraints s k
         , Typeable s
         )
@@ -313,9 +310,9 @@ stateMachineSpec = describe ("State machine test (" ++ showState @s ++ ")") $ do
     it "Sequential" $ prop_sequential newDB
 
 stateMachineSpecSeq, stateMachineSpecRnd, stateMachineSpecShared :: Spec
-stateMachineSpecSeq = stateMachineSpec @ShelleyKey @(SeqState 'Mainnet ShelleyKey) @'CredFromKeyK
-stateMachineSpecRnd = stateMachineSpec @ByronKey @(RndState 'Mainnet) @'CredFromKeyK
-stateMachineSpecShared = stateMachineSpec @SharedKey @(SharedState 'Mainnet SharedKey) @'CredFromScriptK
+stateMachineSpecSeq = stateMachineSpec @ShelleyKey @(SeqState 'Mainnet ShelleyKey)
+stateMachineSpecRnd = stateMachineSpec @ByronKey @(RndState 'Mainnet)
+stateMachineSpecShared = stateMachineSpec @SharedKey @(SharedState 'Mainnet SharedKey)
 
 instance PaymentAddress 'Mainnet SharedKey 'CredFromScriptK where
     paymentAddress _ = error "does not make sense for SharedKey but want to use stateMachineSpec"
@@ -364,7 +361,7 @@ loggingSpec = withLoggingDB @(SeqState 'Mainnet ShelleyKey) $ do
             length msgs `shouldBe` count * 2
 
 withLoggingDB
-    :: (Show s, PersistAddressBook s)
+    :: PersistAddressBook s
     => SpecWith (IO [DBLog], DBLayer IO s ShelleyKey)
     -> Spec
 withLoggingDB = around f . beforeWith clean
@@ -1255,7 +1252,6 @@ testMigrationSeqStateDerivationPrefix
         , WalletKey k
         , PersistAddressBook s
         , PersistPrivateKey (k 'RootK)
-        , Show s
         )
     => String
     -> ( Index 'Hardened 'PurposeK

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -310,13 +310,18 @@ stateMachineSpec = describe ("State machine test (" ++ showState @s ++ ")") $ do
     it "Sequential" $ prop_sequential newDB
 
 stateMachineSpecSeq, stateMachineSpecRnd, stateMachineSpecShared :: Spec
-stateMachineSpecSeq = stateMachineSpec @ShelleyKey @(SeqState 'Mainnet ShelleyKey)
-stateMachineSpecRnd = stateMachineSpec @ByronKey @(RndState 'Mainnet)
-stateMachineSpecShared = stateMachineSpec @SharedKey @(SharedState 'Mainnet SharedKey)
+stateMachineSpecSeq =
+    stateMachineSpec @ShelleyKey @(SeqState 'Mainnet ShelleyKey)
+stateMachineSpecRnd =
+    stateMachineSpec @ByronKey @(RndState 'Mainnet)
+stateMachineSpecShared =
+    stateMachineSpec @SharedKey @(SharedState 'Mainnet SharedKey)
 
 instance PaymentAddress 'Mainnet SharedKey 'CredFromScriptK where
-    paymentAddress _ = error "does not make sense for SharedKey but want to use stateMachineSpec"
-    liftPaymentAddress _ = error "does not make sense for SharedKey but want to use stateMachineSpec"
+    paymentAddress _ = error
+        "does not make sense for SharedKey but want to use stateMachineSpec"
+    liftPaymentAddress _ = error
+        "does not make sense for SharedKey but want to use stateMachineSpec"
 
 showState :: forall s. Typeable s => String
 showState = show (typeOf @s undefined)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -32,8 +32,6 @@ import Cardano.Wallet.DB
     )
 import Cardano.Wallet.DB.Arbitrary
     ( GenState, GenTxHistory (..), InitialCheckpoint (..), MockChain (..) )
-import Cardano.Wallet.DB.Layer
-    ( PersistAddressBook )
 import Cardano.Wallet.DB.Pure.Implementation
     ( filterTxHistory )
 import Cardano.Wallet.DummyTarget.Primitive.Types
@@ -127,7 +125,7 @@ type TestOnLayer s =
 
 -- | Wallet properties.
 properties
-    :: (GenState s, PersistAddressBook s)
+    :: GenState s
     => WithFreshDB s
     -> SpecWith ()
 properties withFreshDB = describe "DB.Properties" $ do
@@ -360,7 +358,7 @@ prop_createWalletTwice test (wid, InitialCheckpoint cp0, meta) = monadicIO
 
 -- | Checks that a given resource can be read after having been inserted in DB.
 prop_readAfterPut
-    :: (Buildable (f a), Eq (f a), Applicative f, GenState s)
+    :: (Buildable (f a), Eq (f a), Applicative f)
     => TestOnLayer s
     -> ( DBLayer IO s ShelleyKey
          -> WalletId
@@ -385,8 +383,7 @@ prop_readAfterPut test putOp readOp a = test $ \db wid -> do
     assertWith "Inserted == Read" (res == fa)
 
 prop_getTxAfterPutValidTxId
-    :: GenState s
-    => TestOnLayer s
+    :: TestOnLayer s
     -> GenTxHistory
     -> Property
 prop_getTxAfterPutValidTxId test txGen = test $ \DBLayer {..} wid -> do
@@ -412,8 +409,7 @@ prop_getTxAfterPutValidTxId test txGen = test $ \DBLayer {..} wid -> do
             (txMeta == txInfoMeta && txId == txInfoId)
 
 prop_getTxAfterPutInvalidTxId
-    :: GenState s
-    => TestOnLayer s
+    :: TestOnLayer s
     -> GenTxHistory
     -> (Hash "Tx")
     -> Property
@@ -442,7 +438,7 @@ prop_getTxAfterPutInvalidWalletId test wid txGen =
 
 -- | Can't put resource before a wallet has been initialized
 prop_putBeforeInit
-    :: (Buildable (f a), Eq (f a), GenState s)
+    :: (Buildable (f a), Eq (f a))
     => WithFreshDB s
     -> ( DBLayer IO s ShelleyKey
          -> WalletId
@@ -477,9 +473,6 @@ prop_isolation
        , Eq (g c)
        , Buildable (h d)
        , Eq (h d)
-       , GenState s
-       , Show s
-       , PersistAddressBook s
        )
     => TestOnLayer s
     -> ( DBLayer IO s ShelleyKey
@@ -525,7 +518,7 @@ prop_isolation test putA readB readC readD (ShowFmt a) =
 
 -- | Check that the DB supports multiple sequential puts for a given resource
 prop_sequentialPut
-    :: (Buildable (f a), Eq (f a), GenState s, PersistAddressBook s)
+    :: (Buildable (f a), Eq (f a))
     => TestOnLayer s
     -> ( DBLayer IO s ShelleyKey
          -> WalletId
@@ -557,7 +550,7 @@ prop_sequentialPut test putOp readOp resolve as =
 -- | Can rollback to any particular checkpoint previously stored
 prop_rollbackCheckpoint
     :: forall s
-     . (GenState s, Eq s)
+     . GenState s
     => WithFreshDB s
     -> InitialCheckpoint s
     -> MockChain

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Sqlite/StoresSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Sqlite/StoresSpec.hs
@@ -104,7 +104,6 @@ prop_prologue_load_write
     :: forall s.
     ( PersistAddressBook s
     , Buildable (Prologue s)
-    , Eq (Prologue s)
     )
     => (s -> s) -> SqliteContext -> (WalletId, s) -> Property
 prop_prologue_load_write preprocess db (wid, s) =
@@ -157,7 +156,7 @@ prop_StoreWallet db (wid, InitialCheckpoint cp0) =
         prop_StoreUpdates toIO (mkStoreWallet wid) (pure w0) genDeltaWalletState
 
 genDeltaWalletState
-    :: (GenState s, AddressBookIso s)
+    :: GenState s
     => GenDelta (DeltaWalletState s)
 genDeltaWalletState wallet = frequency . map (second updateCheckpoints) $
     [ (8, genPutCheckpoint)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -225,7 +225,7 @@ import GHC.Generics
 import System.Random
     ( getStdRandom, randomR )
 import Test.Hspec
-    ( HasCallStack, SpecWith, describe, expectationFailure, it )
+    ( SpecWith, describe, expectationFailure, it )
 import Test.QuickCheck
     ( Arbitrary (..)
     , Args (..)
@@ -402,7 +402,7 @@ instance Traversable (Resp s) where
   Interpreter: mock implementation
 -------------------------------------------------------------------------------}
 
-runMock :: HasCallStack => Cmd s MWid -> Mock s -> (Resp s MWid, Mock s)
+runMock :: Cmd s MWid -> Mock s -> (Resp s MWid, Mock s)
 runMock = \case
     CreateWallet wid wal meta txs gp ->
         first (Resp . fmap (const (NewWallet wid)))
@@ -619,7 +619,7 @@ declareGenerator
 declareGenerator name f gen = (name, (f, gen))
 
 generatorWithoutId
-    :: forall s r. (Arbitrary (Wallet s), GenState s)
+    :: forall s r. GenState s
     => [(String, (Int, Gen (Cmd s (Reference WalletId r))))]
 generatorWithoutId =
     [ declareGenerator "CreateWallet" 5
@@ -635,7 +635,7 @@ generatorWithoutId =
     genId = MWid <$> elements ["a", "b", "c"]
 
 generatorWithWid
-    :: forall s r. (Arbitrary (Wallet s), GenState s)
+    :: forall s r. Arbitrary (Wallet s)
     => [Reference WalletId r]
     -> [(String, (Int, Gen (Cmd s (Reference WalletId r))))]
 generatorWithWid wids =

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -222,6 +222,8 @@ import Data.TreeDiff
     ( ToExpr (..), defaultExprViaShow, genericToExpr )
 import GHC.Generics
     ( Generic, Generic1 )
+import GHC.Stack
+    ( HasCallStack, callStack )
 import System.Random
     ( getStdRandom, randomR )
 import Test.Hspec
@@ -402,7 +404,7 @@ instance Traversable (Resp s) where
   Interpreter: mock implementation
 -------------------------------------------------------------------------------}
 
-runMock :: Cmd s MWid -> Mock s -> (Resp s MWid, Mock s)
+runMock :: HasCallStack => Cmd s MWid -> Mock s -> (Resp s MWid, Mock s)
 runMock = \case
     CreateWallet wid wal meta txs gp ->
         first (Resp . fmap (const (NewWallet wid)))
@@ -448,6 +450,7 @@ runMock = \case
     RollbackTo _wid point ->
         first (Resp . fmap Point) . mRollbackTo point
   where
+    _requireCallStack = callStack
     timeInterpreter = dummyTimeInterpreter
 
 {-------------------------------------------------------------------------------

--- a/lib/wallet/test/unit/Cardano/Wallet/Network/LightSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Network/LightSpec.hs
@@ -311,8 +311,7 @@ latest = NE.head
 
 -- | Make a 'ChainFollower' for 'FollowerState'.
 mkFollower
-    :: Monad m
-    => (forall a. State FollowerState a -> m a)
+    :: (forall a. State FollowerState a -> m a)
     -> ChainFollower m ChainPoint BlockHeader
         (LightBlocks m Block addr txs)
 mkFollower lift = ChainFollower

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -525,7 +525,6 @@ instance
     ( Typeable c
     , SupportsDiscovery 'Mainnet k
     , AddressPoolTest k
-    , GetPurpose k
     , (k == SharedKey) ~ 'False
     ) => Arbitrary (SeqAddressPool c k) where
     shrink (SeqAddressPool pool) =

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -1006,7 +1006,7 @@ prop_discoverFromBlockData (ApplyBlocks s _ blocks) =
     -- may reveal this.
     summary = summarizeOnTxOut blocks
     discoverState
-        :: (IsOurs s Address, IsOurs s RewardAccount, MaybeLight s)
+        :: (IsOurs s Address, IsOurs s RewardAccount)
         => BlockData Identity (Either Address RewardAccount) ChainEvents s
         -> s -> s
     discoverState bs = snd . runIdentity . discoverFromBlockData bs

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3495,8 +3495,7 @@ instance Arbitrary (PartialTx Cardano.BabbageEra) where
 
 shrinkInputResolution
     :: forall era.
-        ( Cardano.IsCardanoEra era
-        , Arbitrary (Cardano.TxOut Cardano.CtxUTxO era)
+        ( Arbitrary (Cardano.TxOut Cardano.CtxUTxO era)
         )
     => Cardano.UTxO era
     -> [Cardano.UTxO era]

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -1237,7 +1237,6 @@ data WalletLayerFixture s m = WalletLayerFixture
 setupFixture
     :: forall s m
      . ( MonadUnliftIO m
-       , MonadFail m
        , MonadTime m
        , IsOurs s Address
        , IsOurs s RewardAccount


### PR DESCRIPTION

Fix redundant constraints in tests and exes

