### PR TITLE
Use a strict record type for `ProtocolParameters`.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -681,6 +681,7 @@ import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex.Internal as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Read as Read
+import qualified Cardano.Wallet.Read.ProtocolParameters as Read
 import qualified Cardano.Wallet.Registry as Registry
 import qualified Cardano.Wallet.Write.Tx as WriteTx
 import qualified Cardano.Wallet.Write.Tx.Balance as Write
@@ -3061,7 +3062,7 @@ balanceTransaction
                         txLayer
                         genInpScripts
                         mScriptTemplate)
-                    (pp, nodePParams)
+                    (Read.ProtocolParameters pp nodePParams)
                     ti
                     utxoIndex
                     (W.defaultChangeAddressGen argGenChange (Proxy @k))

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -681,8 +681,8 @@ import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex.Internal as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Read as Read
-import qualified Cardano.Wallet.Read.ProtocolParameters as Read
 import qualified Cardano.Wallet.Registry as Registry
+import qualified Cardano.Wallet.Write.ProtocolParameters as Write
 import qualified Cardano.Wallet.Write.Tx as WriteTx
 import qualified Cardano.Wallet.Write.Tx.Balance as Write
 import qualified Control.Concurrent.Concierge as Concierge
@@ -3062,7 +3062,7 @@ balanceTransaction
                         txLayer
                         genInpScripts
                         mScriptTemplate)
-                    (Read.ProtocolParameters pp nodePParams)
+                    (Write.ProtocolParameters pp nodePParams)
                     ti
                     utxoIndex
                     (W.defaultChangeAddressGen argGenChange (Proxy @k))

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -337,6 +337,7 @@ library
     Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
     Cardano.Wallet.Read.Primitive.Tx.Mary
     Cardano.Wallet.Read.Primitive.Tx.Shelley
+    Cardano.Wallet.Read.ProtocolParameters
     Cardano.Wallet.Read.Tx
     Cardano.Wallet.Read.Tx.Cardano
     Cardano.Wallet.Read.Tx.CBOR

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -337,7 +337,6 @@ library
     Cardano.Wallet.Read.Primitive.Tx.Features.Withdrawals
     Cardano.Wallet.Read.Primitive.Tx.Mary
     Cardano.Wallet.Read.Primitive.Tx.Shelley
-    Cardano.Wallet.Read.ProtocolParameters
     Cardano.Wallet.Read.Tx
     Cardano.Wallet.Read.Tx.Cardano
     Cardano.Wallet.Read.Tx.CBOR
@@ -380,6 +379,7 @@ library
     Cardano.Wallet.Transaction.Built
     Cardano.Wallet.Version
     Cardano.Wallet.Version.TH
+    Cardano.Wallet.Write.ProtocolParameters
     Cardano.Wallet.Write.Tx
     Cardano.Wallet.Write.Tx.Balance
     Cardano.Wallet.Write.Tx.Gen

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -3852,7 +3852,7 @@ defaultChangeAddressGen arg proxy =
 
 -- TODO: ADP-2459 - replace with something nicer.
 toBalanceTxPParams
-    :: forall era. WriteTx.IsRecentEra era
+    :: forall era. Cardano.IsShelleyBasedEra era
     => ProtocolParameters
     -> Read.ProtocolParameters era
 toBalanceTxPParams pp = Read.ProtocolParameters
@@ -3860,10 +3860,9 @@ toBalanceTxPParams pp = Read.ProtocolParameters
     , pparamsNode = maybe
         (error $ unwords
             [ "toBalanceTxPParams: no nodePParams."
-            , "This should only be possible in Byron, where withRecentEra"
+            , "This should only be possible in Byron, where IsShelleyBasedEra"
             , "should prevent this from being reached."
             ])
-        (Cardano.bundleProtocolParams
-            (WriteTx.fromRecentEra (WriteTx.recentEra @era)))
-        $ currentNodeProtocolParameters pp
+        (Cardano.bundleProtocolParams (Cardano.cardanoEra @era))
+        (currentNodeProtocolParameters pp)
     }

--- a/lib/wallet/src/Cardano/Wallet/Read/ProtocolParameters.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/ProtocolParameters.hs
@@ -18,6 +18,7 @@ import Prelude
 import qualified Cardano.Api as CardanoApi
 import qualified Cardano.Wallet.Primitive.Types as Wallet
 
+-- TODO: Make this data type abstract: don't export the constructor.
 data ProtocolParameters era = ProtocolParameters
     { pparamsWallet
         :: !Wallet.ProtocolParameters

--- a/lib/wallet/src/Cardano/Wallet/Read/ProtocolParameters.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/ProtocolParameters.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
 -- |
 -- Copyright: © 2023 IOHK
 -- License: Apache-2.0
@@ -6,7 +9,10 @@
 --
 module Cardano.Wallet.Read.ProtocolParameters
     ( ProtocolParameters (..)
+    , unsafeFromWalletProtocolParameters
     ) where
+
+import Prelude
 
 import qualified Cardano.Api as CardanoApi
 import qualified Cardano.Wallet.Primitive.Types as Wallet
@@ -16,4 +22,21 @@ data ProtocolParameters era = ProtocolParameters
         :: !Wallet.ProtocolParameters
     , pparamsNode
         :: !(CardanoApi.BundledProtocolParameters era)
+    }
+
+-- TODO: ADP-2459 - replace with something nicer.
+unsafeFromWalletProtocolParameters
+    :: forall era. CardanoApi.IsShelleyBasedEra era
+    => Wallet.ProtocolParameters
+    -> ProtocolParameters era
+unsafeFromWalletProtocolParameters pp = ProtocolParameters
+    { pparamsWallet = pp
+    , pparamsNode = maybe
+        (error $ unwords
+            [ "unsafeFromWalletProtocolParameters: no nodePParams."
+            , "This should only be possible in Byron, where IsShelleyBasedEra"
+            , "should prevent this from being reached."
+            ])
+        (CardanoApi.bundleProtocolParams (CardanoApi.cardanoEra @era))
+        (Wallet.currentNodeProtocolParameters pp)
     }

--- a/lib/wallet/src/Cardano/Wallet/Read/ProtocolParameters.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/ProtocolParameters.hs
@@ -1,0 +1,19 @@
+-- |
+-- Copyright: © 2023 IOHK
+-- License: Apache-2.0
+--
+-- Provides protocol parameters.
+--
+module Cardano.Wallet.Read.ProtocolParameters
+    ( ProtocolParameters (..)
+    ) where
+
+import qualified Cardano.Api as CardanoApi
+import qualified Cardano.Wallet.Primitive.Types as Wallet
+
+data ProtocolParameters era = ProtocolParameters
+    { pparamsWallet
+        :: !Wallet.ProtocolParameters
+    , pparamsNode
+        :: !(CardanoApi.BundledProtocolParameters era)
+    }

--- a/lib/wallet/src/Cardano/Wallet/Read/ProtocolParameters.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/ProtocolParameters.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -29,14 +30,15 @@ unsafeFromWalletProtocolParameters
     :: forall era. CardanoApi.IsShelleyBasedEra era
     => Wallet.ProtocolParameters
     -> ProtocolParameters era
-unsafeFromWalletProtocolParameters pp = ProtocolParameters
-    { pparamsWallet = pp
-    , pparamsNode = maybe
-        (error $ unwords
-            [ "unsafeFromWalletProtocolParameters: no nodePParams."
-            , "This should only be possible in Byron, where IsShelleyBasedEra"
-            , "should prevent this from being reached."
-            ])
+unsafeFromWalletProtocolParameters pparamsWallet =
+    ProtocolParameters {pparamsWallet, pparamsNode}
+  where
+    pparamsNode = maybe
+        (error missingNodeParamsError)
         (CardanoApi.bundleProtocolParams (CardanoApi.cardanoEra @era))
-        (Wallet.currentNodeProtocolParameters pp)
-    }
+        (Wallet.currentNodeProtocolParameters pparamsWallet)
+    missingNodeParamsError = unwords
+        [ "unsafeFromWalletProtocolParameters: no nodePParams."
+        , "This should only be possible in Byron, where IsShelleyBasedEra"
+        , "should prevent this from being reached."
+        ]

--- a/lib/wallet/src/Cardano/Wallet/Write/ProtocolParameters.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/ProtocolParameters.hs
@@ -8,7 +8,7 @@
 --
 -- Provides protocol parameters.
 --
-module Cardano.Wallet.Read.ProtocolParameters
+module Cardano.Wallet.Write.ProtocolParameters
     ( ProtocolParameters (..)
     , unsafeFromWalletProtocolParameters
     ) where

--- a/lib/wallet/src/Cardano/Wallet/Write/ProtocolParameters.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/ProtocolParameters.hs
@@ -18,7 +18,9 @@ import Prelude
 import qualified Cardano.Api as CardanoApi
 import qualified Cardano.Wallet.Primitive.Types as Wallet
 
--- TODO: Make this data type abstract: don't export the constructor.
+-- TODO:
+--  - Make this data type abstract: don't export the constructor.
+--  - Replace this type with a re-exported 'Ledger.PParams era'.
 data ProtocolParameters era = ProtocolParameters
     { pparamsWallet
         :: !Wallet.ProtocolParameters

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -76,6 +76,8 @@ import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( UTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
+import Cardano.Wallet.Read.ProtocolParameters
+    ( ProtocolParameters (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( fromCardanoTxIn, fromCardanoTxOut, toCardanoUTxO )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
@@ -352,7 +354,7 @@ balanceTransaction
         )
     => Tracer m BalanceTxLog
     -> UTxOAssumptions
-    -> (W.ProtocolParameters, Cardano.BundledProtocolParameters era)
+    -> ProtocolParameters era
     -- ^ 'Cardano.ProtocolParameters' can be retrieved via a Local State Query
     -- to a local node.
     --
@@ -380,7 +382,7 @@ balanceTransaction
 balanceTransaction tr utxoAssumptions pp ti utxo genChange s unadjustedPtx = do
     let ledgerPP = Cardano.unbundleLedgerShelleyBasedProtocolParams
             shelleyEra
-            (snd pp)
+            (pparamsNode pp)
     let adjustedPtx = over (#tx)
             (increaseZeroAdaOutputs (recentEra @era) ledgerPP)
             unadjustedPtx
@@ -469,7 +471,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         )
     => Tracer m BalanceTxLog
     -> UTxOAssumptions
-    -> (W.ProtocolParameters, Cardano.BundledProtocolParameters era)
+    -> ProtocolParameters era
     -> TimeInterpreter (Either PastHorizonException)
     -> UTxOIndex WalletUTxO
     -> ChangeAddressGen changeState
@@ -483,7 +485,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         txLayer
         toInpScriptsM
         mScriptTemplate)
-    (pp, nodePParams)
+    (ProtocolParameters pp nodePParams)
     ti
     internalUtxoAvailable
     genChange

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -76,8 +76,6 @@ import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( UTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
-import Cardano.Wallet.Read.ProtocolParameters
-    ( ProtocolParameters (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( fromCardanoTxIn, fromCardanoTxOut, toCardanoUTxO )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
@@ -103,6 +101,8 @@ import Cardano.Wallet.Transaction
     , WitnessCountCtx (..)
     , defaultTransactionCtx
     )
+import Cardano.Wallet.Write.ProtocolParameters
+    ( ProtocolParameters (..) )
 import Cardano.Wallet.Write.Tx
     ( IsRecentEra (..)
     , PParams

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -508,8 +508,8 @@ import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as TxOutGen
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
-import qualified Cardano.Wallet.Read.ProtocolParameters as Read
 import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
+import qualified Cardano.Wallet.Write.ProtocolParameters as Write
 import qualified Cardano.Wallet.Write.Tx as WriteTx
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
@@ -3747,7 +3747,7 @@ dummyChangeAddrGen = ChangeAddressGen
 balanceTx
     :: WriteTx.IsRecentEra era
     => Wallet'
-    -> Read.ProtocolParameters era
+    -> Write.ProtocolParameters era
     -> TimeInterpreter (Either PastHorizonException)
     -> StdGenSeed
     -> PartialTx era
@@ -4008,7 +4008,7 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
         -> Cardano.UTxO Cardano.BabbageEra
         -> Cardano.Lovelace
     txMinFee (Cardano.Tx body _) u = toCardanoLovelace $ evaluateMinimumFee
-        (Read.pparamsNode
+        (Write.pparamsNode
             (mockBundledProtocolParametersForBalancing cardanoEra))
         (estimateKeyWitnessCount u body)
         body
@@ -4205,7 +4205,7 @@ prop_balanceTransactionValid wallet@(Wallet' _ walletUTxO _) (ShowBuildable part
     prop_validSize tx@(Cardano.Tx body _) utxo = do
         let (TxSize size) =
                 estimateSignedTxSize
-                    (Read.pparamsNode
+                    (Write.pparamsNode
                         (mockBundledProtocolParametersForBalancing cardanoEra))
                     (estimateKeyWitnessCount utxo body)
                     body
@@ -4291,7 +4291,7 @@ prop_balanceTransactionValid wallet@(Wallet' _ walletUTxO _) (ShowBuildable part
         TxOutAdaOnly _ coin -> Cardano.lovelaceToValue coin
         TxOutValue _ val -> val
 
-    nodePParams = Read.pparamsNode $
+    nodePParams = Write.pparamsNode $
         mockBundledProtocolParametersForBalancing cardanoEra
 
     ledgerPParams =
@@ -4478,8 +4478,8 @@ mockProtocolParametersForBalancing =
 
 mockBundledProtocolParametersForBalancing
     :: CardanoEra era
-    -> Read.ProtocolParameters era
-mockBundledProtocolParametersForBalancing era = Read.ProtocolParameters
+    -> Write.ProtocolParameters era
+mockBundledProtocolParametersForBalancing era = Write.ProtocolParameters
     { pparamsWallet =
         fst mockProtocolParametersForBalancing
     , pparamsNode =

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -508,6 +508,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as TxOutGen
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
+import qualified Cardano.Wallet.Read.ProtocolParameters as Read
 import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
 import qualified Cardano.Wallet.Write.Tx as WriteTx
 import qualified Codec.CBOR.Encoding as CBOR
@@ -3746,7 +3747,7 @@ dummyChangeAddrGen = ChangeAddressGen
 balanceTx
     :: WriteTx.IsRecentEra era
     => Wallet'
-    -> (ProtocolParameters, Cardano.BundledProtocolParameters era)
+    -> Read.ProtocolParameters era
     -> TimeInterpreter (Either PastHorizonException)
     -> StdGenSeed
     -> PartialTx era
@@ -4007,7 +4008,8 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
         -> Cardano.UTxO Cardano.BabbageEra
         -> Cardano.Lovelace
     txMinFee (Cardano.Tx body _) u = toCardanoLovelace $ evaluateMinimumFee
-        (snd (mockBundledProtocolParametersForBalancing cardanoEra))
+        (Read.pparamsNode
+            (mockBundledProtocolParametersForBalancing cardanoEra))
         (estimateKeyWitnessCount u body)
         body
 
@@ -4203,7 +4205,8 @@ prop_balanceTransactionValid wallet@(Wallet' _ walletUTxO _) (ShowBuildable part
     prop_validSize tx@(Cardano.Tx body _) utxo = do
         let (TxSize size) =
                 estimateSignedTxSize
-                    (snd (mockBundledProtocolParametersForBalancing cardanoEra))
+                    (Read.pparamsNode
+                        (mockBundledProtocolParametersForBalancing cardanoEra))
                     (estimateKeyWitnessCount utxo body)
                     body
         let limit = fromIntegral $ getQuantity $
@@ -4288,7 +4291,8 @@ prop_balanceTransactionValid wallet@(Wallet' _ walletUTxO _) (ShowBuildable part
         TxOutAdaOnly _ coin -> Cardano.lovelaceToValue coin
         TxOutValue _ val -> val
 
-    (_, nodePParams) = mockBundledProtocolParametersForBalancing cardanoEra
+    nodePParams = Read.pparamsNode $
+        mockBundledProtocolParametersForBalancing cardanoEra
 
     ledgerPParams =
         Cardano.toLedgerPParams Cardano.ShelleyBasedEraAlonzo
@@ -4474,9 +4478,14 @@ mockProtocolParametersForBalancing =
 
 mockBundledProtocolParametersForBalancing
     :: CardanoEra era
-    -> (ProtocolParameters, Cardano.BundledProtocolParameters era)
-mockBundledProtocolParametersForBalancing era =
-    Cardano.bundleProtocolParams era <$> mockProtocolParametersForBalancing
+    -> Read.ProtocolParameters era
+mockBundledProtocolParametersForBalancing era = Read.ProtocolParameters
+    { pparamsWallet =
+        fst mockProtocolParametersForBalancing
+    , pparamsNode =
+        Cardano.bundleProtocolParams era $
+        snd mockProtocolParametersForBalancing
+    }
 
 {-# NOINLINE costModelsForTesting #-}
 costModelsForTesting :: Alonzo.CostModels


### PR DESCRIPTION
## Issue

ADP-2903

## Summary

This PR replaces the use of a lazily-evaluated tuple with a strict `ProtocolParameters` record type.

## Details

The goal is to prevent repeated evaluation of the `BundledProtocolParameters` value in loops that may suffer from loss of sharing when compiled with all optimisations enabled (i.e., when compiled with `-O2`).

Since protocol parameters are "read" from the blockchain, we locate the `ProtocolParameters` type within the `Read` module hierarchy instead of the `Write` hierarchy.

## Future work

This PR does not make the `ProtocolParameters` type abstract in any way: the default constructor is currently exported. We can revise this in future, if and when necessary.