### PR TITLE
[ADP-2565] Export `Store` from `Data.Store` only

### DIFF
--- a/lib/delta-store/delta-store.cabal
+++ b/lib/delta-store/delta-store.cabal
@@ -46,7 +46,7 @@ library
   exposed-modules:
       Data.DBVar
       Data.Store
-      Test.DBVar
+      Test.Store
 
 test-suite unit
   default-language:

--- a/lib/delta-store/src/Data/DBVar.hs
+++ b/lib/delta-store/src/Data/DBVar.hs
@@ -19,18 +19,6 @@ module Data.DBVar (
       DBVar
     , readDBVar, updateDBVar, modifyDBVar, modifyDBMaybe
     , initDBVar, loadDBVar
-
-    -- * Store re-exports
-    , Store (..)
-    , newStore
-    , NotInitialized (..)
-    -- $EitherSomeException
-    , embedStore, pairStores
-
-    -- * Testing
-    , embedStore'
-    , updateLoad
-    , newCachedStore
     ) where
 
 import Prelude
@@ -42,15 +30,7 @@ import Control.Monad.Class.MonadThrow
 import Data.Delta
     ( Delta (..) )
 import Data.Store
-    ( NotInitialized (..)
-    , Store (..)
-    , embedStore
-    , embedStore'
-    , newCachedStore
-    , newStore
-    , pairStores
-    , updateLoad
-    )
+    ( Store (..) )
 
 {-------------------------------------------------------------------------------
     DBVar

--- a/lib/delta-store/src/Data/Store.hs
+++ b/lib/delta-store/src/Data/Store.hs
@@ -14,15 +14,19 @@ module Data.Store (
 
     -- * Store
       Store (..)
-    , newStore
-    , NotInitialized (..)
     -- $EitherSomeException
-    , embedStore, pairStores
+
+    -- * Helpers
+    , updateLoad
+
+    -- * Combinators
+    , embedStore
+    , pairStores
+    , newCachedStore
 
     -- * Testing
     , embedStore'
-    , updateLoad
-    , newCachedStore
+    , newStore, NotInitialized (..)
     ) where
 
 import Prelude

--- a/lib/delta-store/src/Test/DBVar.hs
+++ b/lib/delta-store/src/Test/DBVar.hs
@@ -13,10 +13,10 @@ import Control.Exception.Safe
     ( impureThrow )
 import Control.Monad
     ( forM_ )
-import Data.DBVar
-    ( Store (loadS, updateS, writeS) )
 import Data.Delta
     ( Delta (..) )
+import Data.Store
+    ( Store (loadS, updateS, writeS) )
 import Fmt
     ( Buildable, listF, pretty )
 import Test.QuickCheck

--- a/lib/delta-store/src/Test/Store.hs
+++ b/lib/delta-store/src/Test/Store.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
-module Test.DBVar
+module Test.Store
     ( genUpdates
     , prop_StoreUpdates
     , GenDelta

--- a/lib/delta-store/test/unit/Data/StoreSpec.hs
+++ b/lib/delta-store/test/unit/Data/StoreSpec.hs
@@ -8,10 +8,10 @@ module Data.StoreSpec
 
 import Prelude
 
-import Data.DBVar
-    ( Store (..), newCachedStore, newStore )
 import Data.Delta
     ( Delta (..) )
+import Data.Store
+    ( Store (..), newCachedStore, newStore )
 import Fmt
     ( Buildable (..) )
 import Test.DBVar

--- a/lib/delta-store/test/unit/Data/StoreSpec.hs
+++ b/lib/delta-store/test/unit/Data/StoreSpec.hs
@@ -14,8 +14,6 @@ import Data.Store
     ( Store (..), newCachedStore, newStore )
 import Fmt
     ( Buildable (..) )
-import Test.DBVar
-    ( prop_StoreUpdates )
 import Test.Hspec
     ( Spec, describe, it, parallel )
 import Test.QuickCheck
@@ -24,6 +22,8 @@ import Test.QuickCheck.Gen
     ( Gen, listOf )
 import Test.QuickCheck.Monadic
     ( monadicIO, run )
+import Test.Store
+    ( prop_StoreUpdates )
 
 spec :: Spec
 spec = do

--- a/lib/delta-table/src/Database/Persist/Delta.hs
+++ b/lib/delta-table/src/Database/Persist/Delta.hs
@@ -23,12 +23,12 @@ import Control.Monad.IO.Class
     ( MonadIO, liftIO )
 import Data.Bifunctor
     ( first )
-import Data.DBVar
-    ( Store (..), updateLoad )
 import Data.Delta
     ( Delta (..) )
 import Data.Proxy
     ( Proxy (..) )
+import Data.Store
+    ( Store (..), updateLoad )
 import Data.Table
     ( DeltaDB (..), Pile (..), Table (..) )
 import Database.Persist

--- a/lib/delta-table/src/Demo/Database.hs
+++ b/lib/delta-table/src/Demo/Database.hs
@@ -85,6 +85,7 @@ import qualified Database.Schema as Sql
 
 import Data.DBVar
 import Data.Delta
+import Data.Store
 
 {-------------------------------------------------------------------------------
     (Mock) address type

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -163,7 +163,7 @@ import Control.Tracer
 import Data.Coerce
     ( coerce )
 import Data.DBVar
-    ( Store (..), loadDBVar, modifyDBMaybe, readDBVar, updateDBVar )
+    ( loadDBVar, modifyDBMaybe, readDBVar, updateDBVar )
 import Data.Functor
     ( (<&>) )
 import Data.Generics.Internal.VL.Lens
@@ -174,6 +174,8 @@ import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
     ( Quantity (..) )
+import Data.Store
+    ( Store (..) )
 import Data.Text
     ( Text )
 import Data.Text.Class

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Checkpoints.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Checkpoints.hs
@@ -125,8 +125,6 @@ import Control.Monad.Trans.Maybe
     ( MaybeT (..) )
 import Data.Bifunctor
     ( bimap, second )
-import Data.DBVar
-    ( Store (..) )
 import Data.Foldable
     ( for_ )
 import Data.Functor
@@ -143,6 +141,8 @@ import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
     ( Quantity (..) )
+import Data.Store
+    ( Store (..) )
 import Data.Type.Equality
     ( type (==) )
 import Data.Typeable

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Store.hs
@@ -22,14 +22,14 @@ import Control.Arrow
     ( (&&&) )
 import Control.Exception
     ( SomeException )
-import Data.DBVar
-    ( Store (Store, loadS, updateS, writeS) )
 import Data.Foldable
     ( Foldable (toList) )
 import Data.List.Split
     ( chunksOf )
 import Data.Maybe
     ( fromJust )
+import Data.Store
+    ( Store (Store, loadS, updateS, writeS) )
 import Database.Persist.Sql
     ( Entity (entityVal)
     , PersistEntity (keyFromRecordM)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/QueryStore.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/QueryStore.hs
@@ -16,10 +16,11 @@ import Control.Exception
     ( SomeException (..), throwIO )
 import Control.Monad.IO.Class
     ( MonadIO (liftIO) )
-import Data.DBVar
-    ( Store (loadS) )
 import Data.Delta
     ( Delta (Base) )
+import Data.Store
+    ( Store (loadS) )
+
 {-----------------------------------------------------------------------------
     General QueryStore abstraction
 ------------------------------------------------------------------------------}

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Operations.hs
@@ -50,14 +50,14 @@ import Control.Monad
     ( forM_ )
 import Control.Monad.Class.MonadThrow
     ( throwIO )
-import Data.DBVar
-    ( Store (..), updateLoad )
 import Data.Delta
     ( Delta (..) )
 import Data.Map.Strict
     ( Map )
 import Data.Quantity
     ( Quantity )
+import Data.Store
+    ( Store (..), updateLoad )
 import Data.Word
     ( Word32 )
 import Database.Persist

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
@@ -52,8 +52,6 @@ import Control.Arrow
     ( Arrow ((&&&)) )
 import Control.Monad.Reader
     ( MonadIO, ReaderT )
-import Data.DBVar
-    ( Store (..) )
 import Data.Foldable
     ( fold, toList )
 import Data.Functor
@@ -68,6 +66,8 @@ import Data.Maybe
     ( listToMaybe, maybeToList )
 import Data.Monoid
     ( First (..), getFirst )
+import Data.Store
+    ( Store (..) )
 import Data.Word
     ( Word32 )
 import Database.Persist.Sql

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -31,7 +31,7 @@ import Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaTxWalletsHistory (..) )
 import Control.Applicative
     ( liftA2 )
-import Data.DBVar
+import Data.Store
     ( Store (..) )
 import Database.Persist.Sql
     ( SqlPersistT )

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Fixtures.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Fixtures.hs
@@ -45,12 +45,12 @@ import Control.Tracer
     ( nullTracer )
 import Data.Bifunctor
     ( second )
-import Data.DBVar
-    ( Store (loadS, updateS) )
 import Data.Delta
     ( Delta (Base) )
 import Data.Either
     ( fromRight )
+import Data.Store
+    ( Store (loadS, updateS) )
 import Data.Time.Clock
     ( UTCTime )
 import Data.Time.Clock.POSIX

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Sqlite/StoresSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Sqlite/StoresSpec.hs
@@ -48,12 +48,12 @@ import Control.Monad
     ( forM_ )
 import Data.Bifunctor
     ( second )
-import Data.DBVar
-    ( Store (..) )
 import Data.Delta
     ( Base, Delta (..) )
 import Data.Generics.Internal.VL.Lens
     ( over, (^.) )
+import Data.Store
+    ( Store (..) )
 import Fmt
     ( Buildable (..), listF, pretty )
 import Test.Hspec

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/StoreSpec.hs
@@ -41,10 +41,10 @@ import Cardano.Wallet.Primitive.Types
     ( Range (..), SortOrder (Ascending, Descending), WalletId )
 import Control.Monad
     ( forM_, (<=<) )
-import Data.DBVar
-    ( Store (..) )
 import Data.Foldable
     ( toList )
+import Data.Store
+    ( Store (..) )
 import GHC.Natural
     ( Natural )
 import Test.DBVar

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/StoreSpec.hs
@@ -47,14 +47,14 @@ import Data.Store
     ( Store (..) )
 import GHC.Natural
     ( Natural )
-import Test.DBVar
-    ( prop_StoreUpdates )
 import Test.Hspec
     ( Spec, around, describe, it )
 import Test.QuickCheck
     ( Gen, arbitrary, elements, frequency, property )
 import Test.QuickCheck.Monadic
     ( forAllM, pick )
+import Test.Store
+    ( prop_StoreUpdates )
 
 import qualified Data.Map.Strict as Map
 

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Submissions/StoreSpec.hs
@@ -37,12 +37,12 @@ import Data.Quantity
     ( Quantity (..) )
 import System.Random
     ( Random )
-import Test.DBVar
-    ( prop_StoreUpdates )
 import Test.Hspec
     ( Spec, around, describe, it )
 import Test.QuickCheck
     ( Arbitrary (..), property )
+import Test.Store
+    ( prop_StoreUpdates )
 
 import qualified Data.ByteString as BS
 

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -50,14 +50,14 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..) )
 import Control.Monad
     ( forM_, (<=<) )
-import Data.DBVar
-    ( Store (..) )
 import Data.Delta
     ( Delta (..) )
 import Data.Functor.Identity
     ( Identity (..) )
 import Data.Generics.Internal.VL
     ( set )
+import Data.Store
+    ( Store (..) )
 import Test.DBVar
     ( GenDelta, prop_StoreUpdates )
 import Test.Hspec

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -58,8 +58,6 @@ import Data.Generics.Internal.VL
     ( set )
 import Data.Store
     ( Store (..) )
-import Test.DBVar
-    ( GenDelta, prop_StoreUpdates )
 import Test.Hspec
     ( Spec, around, describe, it )
 import Test.QuickCheck
@@ -76,6 +74,8 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Monadic
     ( forAllM, pick )
+import Test.Store
+    ( GenDelta, prop_StoreUpdates )
 
 import qualified Cardano.Wallet.DB.Store.Transactions.Layer as TxSet
 import qualified Cardano.Wallet.Primitive.Types.Tx as W

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/LayerSpec.hs
@@ -19,12 +19,12 @@ import Cardano.Wallet.DB.Store.Wallets.Layer
     ( newQueryStoreTxWalletsHistory )
 import Cardano.Wallet.DB.Store.Wallets.StoreSpec
     ( genDeltaTxWallets )
-import Test.DBVar
-    ( prop_StoreUpdates )
 import Test.Hspec
     ( Spec, around, describe, it )
 import Test.QuickCheck
     ( property )
+import Test.Store
+    ( prop_StoreUpdates )
 
 spec :: Spec
 spec = do

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
@@ -28,12 +28,12 @@ import Cardano.Wallet.DB.Store.Wallets.Store
     ( mkStoreTxWalletsHistory )
 import Data.Store
     ( newStore )
-import Test.DBVar
-    ( GenDelta, prop_StoreUpdates )
 import Test.Hspec
     ( Spec, around, describe, it )
 import Test.QuickCheck
     ( Gen, NonEmptyList (..), arbitrary, choose, frequency, property )
+import Test.Store
+    ( GenDelta, prop_StoreUpdates )
 
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.Map.Strict as Map

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/StoreSpec.hs
@@ -26,7 +26,7 @@ import Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaTxWalletsHistory (..) )
 import Cardano.Wallet.DB.Store.Wallets.Store
     ( mkStoreTxWalletsHistory )
-import Data.DBVar
+import Data.Store
     ( newStore )
 import Test.DBVar
     ( GenDelta, prop_StoreUpdates )


### PR DESCRIPTION
### Overview

This pull request changes the `Data.DBVar` module to no longer export the `Store` type. This pull request also renames `Test.DBVar` to `Test.Store`.

This is a pure refactoring of module exports and imports.

### Issue number

ADP-2565
