### PR TITLE
[ADP-2959] Simplify delegation and payment address classes

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/MintBurn.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/MintBurn.hs
@@ -34,8 +34,6 @@ import Cardano.Wallet.Flavor
     ( WalletFlavor )
 import Cardano.Wallet.Primitive.Types
     ( WalletId )
-import Cardano.Wallet.Read.NetworkId
-    ( NetworkDiscriminant )
 import Cardano.Wallet.Transaction
     ( TokenMapWithScripts (..) )
 import Control.Category
@@ -51,7 +49,7 @@ import Servant
 
 -- | Promote mint and burn to their API type.
 convertApiAssetMintBurn
-    :: forall ctx s k (n :: NetworkDiscriminant)
+    :: forall ctx s k n
      . ( HasDBLayer IO s k ctx
        , WalletFlavor s n k
        )
@@ -73,7 +71,7 @@ convertApiAssetMintBurn ctx wid (mint, burn) = do
     pure (convert mint, convert burn)
 
 getTxApiAssetMintBurn
-    :: forall ctx s k (n :: NetworkDiscriminant)
+    :: forall ctx s k n
      . ( HasDBLayer IO s k ctx
        , WalletFlavor s n k
        )

--- a/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
@@ -53,12 +53,7 @@ import Cardano.Wallet.Network
 import Cardano.Wallet.Pools
     ( StakePoolLayer (..), withNodeStakePoolLayer, withStakePoolDbLayer )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( DelegationAddress (..)
-    , Depth (..)
-    , PaymentAddress
-    , PersistPrivateKey
-    , WalletKey
-    )
+    ( Depth (..), PersistPrivateKey, WalletKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -297,10 +292,7 @@ serveWallet
 
     startServer
         :: forall n.
-            ( PaymentAddress n IcarusKey 'CredFromKeyK
-            , PaymentAddress n ByronKey 'CredFromKeyK
-            , DelegationAddress n ShelleyKey 'CredFromKeyK
-            , HasSNetworkId n
+            ( HasSNetworkId n
             , Typeable n
             )
         => Proxy n

--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -66,6 +66,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , Depth (..)
     , PersistPrivateKey
     , WalletKey
+    , delegationAddressS
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
@@ -237,7 +238,7 @@ benchmarksSeq
         , k ~ ShelleyKey
         , ktype ~ 'CredFromKeyK
         , HasSNetworkId n
-        , DelegationAddress n k ktype
+        , DelegationAddress k ktype
         )
     => BenchmarkConfig n s k ktype
     -> IO BenchSeqResults
@@ -285,7 +286,7 @@ benchmarksSeq BenchmarkConfig{benchmarkName,ctx,wid} = do
             (dbLayer ctx) (networkLayer ctx) (transactionLayer ctx)
             (timeInterpreter (networkLayer ctx))
             (Write.AnyRecentEra Write.RecentEraBabbage)
-            (W.defaultChangeAddressGen (delegationAddress @n) (Proxy @k))
+            (W.defaultChangeAddressGen (delegationAddressS @n) (Proxy @k))
             wid
 
     (_, selectAssetsTime) <- bench "selectAssets"

--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -233,7 +233,7 @@ instance ToJSON BenchSeqResults where
     toJSON = genericToJSON Aeson.defaultOptions
 
 benchmarksSeq
-    :: forall (n :: NetworkDiscriminant) s k ktype.
+    :: forall n s k ktype.
         ( s ~ SeqState n k
         , k ~ ShelleyKey
         , ktype ~ 'CredFromKeyK
@@ -329,12 +329,12 @@ instance ToJSON BenchSharedResults where
     toJSON = genericToJSON Aeson.defaultOptions
 
 benchmarksShared
-    :: forall (n :: NetworkDiscriminant) s k ktype.
-        ( s ~ SharedState n k
-        , k ~ SharedKey
-        , ktype ~ 'CredFromScriptK
-        , HasSNetworkId n
-        )
+    :: forall n s k ktype
+     . ( s ~ SharedState n k
+       , k ~ SharedKey
+       , ktype ~ 'CredFromScriptK
+       , HasSNetworkId n
+       )
     => BenchmarkConfig n s k ktype
     -> IO BenchSharedResults
 benchmarksShared BenchmarkConfig{benchmarkName,ctx,wid} = do
@@ -410,12 +410,12 @@ instance ToJSON BenchRndResults where
     toJSON = genericToJSON Aeson.defaultOptions
 
 benchmarksRnd
-    :: forall (n :: NetworkDiscriminant) s k ktype.
-        ( s ~ RndState n
-        , k ~ ByronKey
-        , ktype ~ 'CredFromKeyK
-        , HasSNetworkId n
-        )
+    :: forall n s k ktype
+     . ( s ~ RndState n
+       , k ~ ByronKey
+       , ktype ~ 'CredFromKeyK
+       , HasSNetworkId n
+       )
     => BenchmarkConfig n s k ktype
     -> IO BenchRndResults
 benchmarksRnd BenchmarkConfig{benchmarkName,ctx,wid} = do
@@ -477,10 +477,10 @@ benchmarksRnd BenchmarkConfig{benchmarkName,ctx,wid} = do
     Custom Wallet API functions
 -------------------------------------------------------------------------------}
 selectAssets
-    :: forall (n :: NetworkDiscriminant) s (k :: Depth -> * -> *) ktype
-    .   ( HasSNetworkId n
-        , BoundedAddressLength k
-        )
+    :: forall n s (k :: Depth -> * -> *) ktype
+     . ( HasSNetworkId n
+       , BoundedAddressLength k
+       )
     => Proxy n
     -> MockWalletLayer IO s k ktype
     -> WalletId
@@ -509,7 +509,7 @@ selectAssets networkId ctx wid = do
         } $ \_state -> id
 
 dummyAddress
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . HasSNetworkId n
     => Proxy n
     -> Address
@@ -537,7 +537,7 @@ data BenchmarkConfig (n :: NetworkDiscriminant) s k ktype =
 
 -- | Run benchmarks on all wallet databases in a given directory.
 benchmarkWallets
-    :: forall (n :: NetworkDiscriminant) (k :: Depth -> * -> *) ktype s results
+    :: forall n (k :: Depth -> * -> *) ktype s results
      . ( PersistAddressBook s
        , WalletKey k
        , PersistPrivateKey (k 'RootK)
@@ -596,7 +596,7 @@ mockTimeInterpreter :: TimeInterpreter IO
 mockTimeInterpreter = dummyTimeInterpreter
 
 withWalletsFromDirectory
-    :: forall (n :: NetworkDiscriminant) s k ktype a
+    :: forall n s k ktype a
      . ( PersistAddressBook s
        , PersistPrivateKey (k 'RootK)
        , WalletKey k

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -143,7 +143,7 @@ import Cardano.Wallet.Primitive.Types.Tx.TxOut
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Read.NetworkId
-    ( NetworkDiscriminant (..) )
+    ( NetworkDiscriminant (..), SNetworkId (..) )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic, unsafeRunExceptT )
 import Control.DeepSeq
@@ -874,7 +874,7 @@ withMovingSlot i b@(Block h _ _) = b
 
 mkAddress :: Int -> Int -> Address
 mkAddress i j =
-    delegationAddress @'Mainnet
+    delegationAddress SMainnet
         (ShelleyKey $ unsafeXPub $ B8.pack $ take 64 $ randoms $ mkStdGen seed)
         rewardAccount
   where
@@ -885,7 +885,7 @@ mkAddress i j =
 
 mkByronAddress :: Int -> Int -> Address
 mkByronAddress i j =
-    paymentAddress @'Mainnet @ByronKey @'CredFromKeyK
+    paymentAddress @ByronKey @'CredFromKeyK SMainnet
         (ByronKey
             (unsafeXPub (B8.pack $ take 64 $ randoms g))
             (Index acctIx, Index addrIx)

--- a/lib/wallet/bench/latency-bench.hs
+++ b/lib/wallet/bench/latency-bench.hs
@@ -159,7 +159,8 @@ main = withUtf8Encoding $
         { apiServerTracer = trMessage $ contramap snd (traceInTVarIO tvar) }
 
 walletApiBench
-    :: forall (n :: NetworkDiscriminant). (n ~ 'Mainnet)
+    :: forall n
+    . (n ~ 'Mainnet)
     => LogCaptureFunc ApiLog ()
     -> Context
     -> IO ()

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -86,13 +86,7 @@ import Cardano.Wallet.Network
     , NetworkLayer (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
-    , PaymentAddress
-    , PersistPrivateKey
-    , WalletKey
-    , digest
-    , publicKey
-    )
+    ( Depth (..), PersistPrivateKey, WalletKey, digest, publicKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
@@ -450,7 +444,6 @@ benchmarksRnd
     :: forall (n :: NetworkDiscriminant) s k p.
         ( s ~ RndAnyState n p
         , k ~ ByronKey
-        , PaymentAddress n k 'CredFromKeyK
         , HasSNetworkId n
         , KnownNat p
         )
@@ -564,7 +557,6 @@ benchmarksSeq
         ( s ~ SeqAnyState n k p
         , k ~ ShelleyKey
         , HasSNetworkId n
-        , PaymentAddress n k 'CredFromKeyK
         , KnownNat p
         )
     => Proxy n

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -368,7 +368,7 @@ cardanoRestoreBench tr c socketFile = do
             (wid, WalletName wname, s)
 
     mkSeqAnyState'
-        :: forall (p :: Nat) (n :: NetworkDiscriminant). HasSNetworkId n
+        :: forall (p :: Nat) n. HasSNetworkId n
         => Proxy p
         -> Proxy n
         -> (ShelleyKey 'RootK XPrv, Passphrase "encryption")
@@ -379,7 +379,7 @@ cardanoRestoreBench tr c socketFile = do
 
 
     mkRndAnyState'
-        :: forall (p :: Nat) (n :: NetworkDiscriminant). ()
+        :: forall (p :: Nat) n. ()
         => Proxy p
         -> Proxy n
         -> ByronKey 'RootK XPrv
@@ -441,7 +441,7 @@ instance ToJSON BenchRndResults where
     toJSON = genericToJSON Aeson.defaultOptions
 
 benchmarksRnd
-    :: forall (n :: NetworkDiscriminant) s k p.
+    :: forall n s k p.
         ( s ~ RndAnyState n p
         , k ~ ByronKey
         , HasSNetworkId n
@@ -553,7 +553,7 @@ instance ToJSON BenchSeqResults where
     toJSON = genericToJSON Aeson.defaultOptions
 
 benchmarksSeq
-    :: forall (n :: NetworkDiscriminant) s k p.
+    :: forall n s k p.
         ( s ~ SeqAnyState n k p
         , k ~ ShelleyKey
         , HasSNetworkId n
@@ -638,7 +638,7 @@ instance ToJSON BenchBaselineResults where
 
 {- HLINT ignore bench_baseline_restoration "Use camelCase" -}
 bench_baseline_restoration
-    :: forall (n :: NetworkDiscriminant) .
+    :: forall n .
         ( HasSNetworkId n
         )
     => PipeliningStrategy (CardanoBlock StandardCrypto)
@@ -708,7 +708,7 @@ bench_baseline_restoration
 
 {- HLINT ignore bench_restoration "Use camelCase" -}
 bench_restoration
-    :: forall (n :: NetworkDiscriminant) (k :: Depth -> * -> *) s results.
+    :: forall n (k :: Depth -> * -> *) s results.
         ( IsOurs s RewardAccount
         , MaybeLight s
         , IsOwned s k 'CredFromKeyK
@@ -821,7 +821,7 @@ withWalletLayerTracer benchname pipelining traceToDisk act = do
         | otherwise -> act nullTracer
 
 dummyAddress
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n
+    :: forall n. HasSNetworkId n
     => Proxy n
     -> Address
 

--- a/lib/wallet/integration/src/Test/Integration/Faucet.hs
+++ b/lib/wallet/integration/src/Test/Integration/Faucet.hs
@@ -84,7 +84,7 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Read.NetworkId
-    ( NetworkDiscriminant (..) )
+    ( SNetworkId (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromText, unsafeMkMnemonic )
 import Control.Monad
@@ -2241,7 +2241,7 @@ byronAddresses mw =
         addrXPrv =
             Byron.deriveAddressPrivateKey pwd accXPrv
     in
-        [ paymentAddress @'Mainnet
+        [ paymentAddress SMainnet
             $ publicKey $ addrXPrv $ liftIndex @'Hardened ix
         | ix <- [minBound..maxBound]
         ]
@@ -2258,7 +2258,7 @@ icaAddresses mw =
         addrXPrv =
             deriveAddressPrivateKey pwd accXPrv UtxoExternal
     in
-        [ paymentAddress @'Mainnet $ publicKey $ addrXPrv ix
+        [ paymentAddress SMainnet $ publicKey $ addrXPrv ix
         | ix <- [minBound..maxBound]
         ]
 
@@ -2290,7 +2290,7 @@ genShelleyAddresses mw =
         addrXPrv =
             deriveAddressPrivateKey pwd accXPrv UtxoExternal
     in
-        [ paymentAddress @'Mainnet $ publicKey $ addrXPrv ix
+        [ paymentAddress SMainnet $ publicKey $ addrXPrv ix
         | ix <- [minBound..maxBound]
         ]
 

--- a/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
@@ -303,19 +303,15 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , DerivationType (..)
     , HardDerivation (..)
     , Index (..)
-    , PaymentAddress (..)
+    
     , PersistPublicKey (..)
     , Role (..)
     , WalletKey (..)
     , fromHex
-    , hex
+    , hex, paymentAddressS
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey (..) )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Shelley
-    ( ShelleyKey )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( coinTypeAda )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
@@ -2080,10 +2076,8 @@ fixtureRandomWallet
 fixtureRandomWallet = fmap fst . fixtureRandomWalletMws
 
 fixtureRandomWalletAddrs
-    :: forall (n :: NetworkDiscriminant) m.
-        ( PaymentAddress n ByronKey 'CredFromKeyK
-        , MonadUnliftIO m
-        )
+    :: forall (n :: NetworkDiscriminant) m
+     . (MonadUnliftIO m, HasSNetworkId n)
     => Context
     -> ResourceT m (ApiByronWallet, [Address])
 fixtureRandomWalletAddrs =
@@ -2098,11 +2092,8 @@ fixtureRandomWalletAddrs =
 --
 -- TODO: Remove duplication between Shelley / Byron fixtures.
 fixtureRandomWalletWith
-    :: forall (n :: NetworkDiscriminant) m.
-        ( HasSNetworkId n
-        , PaymentAddress n ByronKey 'CredFromKeyK
-        , MonadUnliftIO m
-        )
+    :: forall (n :: NetworkDiscriminant) m
+     . ( HasSNetworkId n , MonadUnliftIO m)
     => Context
     -> [Natural]
     -> ResourceT m ApiByronWallet
@@ -2136,10 +2127,8 @@ fixtureIcarusWallet
 fixtureIcarusWallet = fmap fst . fixtureIcarusWalletMws
 
 fixtureIcarusWalletAddrs
-    :: forall (n :: NetworkDiscriminant) m.
-        ( PaymentAddress n IcarusKey 'CredFromKeyK
-        , MonadUnliftIO m
-        )
+    :: forall (n :: NetworkDiscriminant) m
+     . ( HasSNetworkId n , MonadUnliftIO m)
     => Context
     -> ResourceT m (ApiByronWallet, [Address])
 fixtureIcarusWalletAddrs =
@@ -2154,11 +2143,8 @@ fixtureIcarusWalletAddrs =
 --
 -- TODO: Remove duplication between Shelley / Byron fixtures.
 fixtureIcarusWalletWith
-    :: forall (n :: NetworkDiscriminant) m.
-        ( HasSNetworkId n
-        , PaymentAddress n IcarusKey 'CredFromKeyK
-        , MonadUnliftIO m
-        )
+    :: forall (n :: NetworkDiscriminant) m
+     . ( HasSNetworkId n , MonadUnliftIO m)
     => Context
     -> [Natural]
     -> ResourceT m ApiByronWallet
@@ -2494,7 +2480,7 @@ delegationFee ctx w = do
 -- [addr]
 randomAddresses
     :: forall (n :: NetworkDiscriminant)
-     . PaymentAddress n ByronKey 'CredFromKeyK
+     . HasSNetworkId n
     => Mnemonic 12
     -> [Address]
 randomAddresses mw =
@@ -2508,7 +2494,7 @@ randomAddresses mw =
         addrXPrv =
             Byron.deriveAddressPrivateKey pwd accXPrv
     in
-        [ paymentAddress @n (publicKey $ addrXPrv ix)
+        [ paymentAddressS @n (publicKey $ addrXPrv ix)
         | ix <- [minBound..maxBound]
         ]
 
@@ -2520,7 +2506,7 @@ randomAddresses mw =
 -- [addr]
 icarusAddresses
     :: forall (n :: NetworkDiscriminant)
-     . PaymentAddress n IcarusKey 'CredFromKeyK
+     . HasSNetworkId n
     => Mnemonic 15
     -> [Address]
 icarusAddresses mw =
@@ -2534,7 +2520,7 @@ icarusAddresses mw =
         addrXPrv =
             deriveAddressPrivateKey pwd accXPrv UtxoExternal
     in
-        [ paymentAddress @n (publicKey $ addrXPrv ix)
+        [ paymentAddressS @n (publicKey $ addrXPrv ix)
         | ix <- [minBound..maxBound]
         ]
 
@@ -2546,7 +2532,7 @@ icarusAddresses mw =
 -- [addr]
 shelleyAddresses
     :: forall (n :: NetworkDiscriminant)
-     . PaymentAddress n ShelleyKey 'CredFromKeyK
+     . HasSNetworkId n
     => Mnemonic 15
     -> [Address]
 shelleyAddresses mw =
@@ -2560,7 +2546,7 @@ shelleyAddresses mw =
         addrXPrv =
             deriveAddressPrivateKey pwd accXPrv UtxoExternal
     in
-        [ paymentAddress @n (publicKey $ addrXPrv ix)
+        [ paymentAddressS @n (publicKey $ addrXPrv ix)
         | ix <- [minBound..maxBound]
         ]
 

--- a/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
@@ -303,12 +303,12 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , DerivationType (..)
     , HardDerivation (..)
     , Index (..)
-    
     , PersistPublicKey (..)
     , Role (..)
     , WalletKey (..)
     , fromHex
-    , hex, paymentAddressS
+    , hex
+    , paymentAddressS
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey (..) )
@@ -353,7 +353,7 @@ import Cardano.Wallet.Primitive.Types.UTxO
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
     ( HistogramBar (..), UTxOStatistics (..) )
 import Cardano.Wallet.Read.NetworkId
-    ( HasSNetworkId (..), NetworkDiscriminant )
+    ( HasSNetworkId (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( decodeAddress, encodeAddress )
 import "cardano-addresses" Codec.Binary.Encoding
@@ -1796,7 +1796,7 @@ emptySharedWalletDelegating ctx = do
    pure (getFromResponse Prelude.id rPostA, getFromResponse Prelude.id rPostB)
 
 fundSharedWallet
-    :: forall (n :: NetworkDiscriminant) m
+    :: forall n m
      . ( MonadUnliftIO m
        , HasSNetworkId n
        )
@@ -1847,7 +1847,7 @@ fundSharedWallet ctx amt sharedWals = do
            ]
 
 fixtureSharedWallet
-    :: forall (n :: NetworkDiscriminant) m
+    :: forall n m
      . ( MonadUnliftIO m
        , MonadFail m
        , HasSNetworkId n
@@ -1860,11 +1860,11 @@ fixtureSharedWallet ctx = do
    return wal
 
 fixtureSharedWalletDelegating
-    :: forall (n :: NetworkDiscriminant) m.
-    ( MonadUnliftIO m
-    , MonadFail m
-    , HasSNetworkId n
-    )
+    :: forall n m
+     . ( MonadUnliftIO m
+       , MonadFail m
+       , HasSNetworkId n
+       )
     => Context
     -> ResourceT m (ApiActiveSharedWallet, ApiActiveSharedWallet)
 fixtureSharedWalletDelegating ctx = do
@@ -2076,7 +2076,7 @@ fixtureRandomWallet
 fixtureRandomWallet = fmap fst . fixtureRandomWalletMws
 
 fixtureRandomWalletAddrs
-    :: forall (n :: NetworkDiscriminant) m
+    :: forall n m
      . (MonadUnliftIO m, HasSNetworkId n)
     => Context
     -> ResourceT m (ApiByronWallet, [Address])
@@ -2092,7 +2092,7 @@ fixtureRandomWalletAddrs =
 --
 -- TODO: Remove duplication between Shelley / Byron fixtures.
 fixtureRandomWalletWith
-    :: forall (n :: NetworkDiscriminant) m
+    :: forall n m
      . ( HasSNetworkId n , MonadUnliftIO m)
     => Context
     -> [Natural]
@@ -2127,7 +2127,7 @@ fixtureIcarusWallet
 fixtureIcarusWallet = fmap fst . fixtureIcarusWalletMws
 
 fixtureIcarusWalletAddrs
-    :: forall (n :: NetworkDiscriminant) m
+    :: forall n m
      . ( HasSNetworkId n , MonadUnliftIO m)
     => Context
     -> ResourceT m (ApiByronWallet, [Address])
@@ -2143,7 +2143,7 @@ fixtureIcarusWalletAddrs =
 --
 -- TODO: Remove duplication between Shelley / Byron fixtures.
 fixtureIcarusWalletWith
-    :: forall (n :: NetworkDiscriminant) m
+    :: forall n m
      . ( HasSNetworkId n , MonadUnliftIO m)
     => Context
     -> [Natural]
@@ -2289,7 +2289,8 @@ constFixtureWalletNoWait ctx = snd <$> allocate create free
         (Link.deleteWallet @'Shelley w) Default Empty
 
 -- | Move coins from a wallet to another
-moveByronCoins :: forall (n :: NetworkDiscriminant)
+moveByronCoins
+    :: forall n
      . HasSNetworkId n
     => Context
         -- ^ Api context
@@ -2479,7 +2480,7 @@ delegationFee ctx w = do
 -- >>> take 1 (randomAddresses @n)
 -- [addr]
 randomAddresses
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . HasSNetworkId n
     => Mnemonic 12
     -> [Address]
@@ -2505,7 +2506,7 @@ randomAddresses mw =
 -- >>> take 1 (icarusAddresses @n)
 -- [addr]
 icarusAddresses
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . HasSNetworkId n
     => Mnemonic 15
     -> [Address]
@@ -2531,7 +2532,7 @@ icarusAddresses mw =
 -- >>> take 1 (shelleyAddresses @n)
 -- [addr]
 shelleyAddresses
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . HasSNetworkId n
     => Mnemonic 15
     -> [Address]
@@ -3344,7 +3345,7 @@ unsafeResponse = either (error . show) id . snd
 -- Only intended to be used with well-known inputs in tests, so throws if
 -- anything goes unexpectedly.
 replaceStakeKey
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . HasSNetworkId n
     => ApiAddress n
     -> ApiAddress n

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
@@ -25,12 +25,6 @@ import Cardano.Wallet.Api.Types
     , ApiT (..)
     , WalletStyle (..)
     )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), PaymentAddress )
-import Cardano.Wallet.Primitive.AddressDerivation.Byron
-    ( ByronKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( purposeBIP44 )
 import Cardano.Wallet.Primitive.Types.Address
@@ -90,10 +84,7 @@ import qualified Network.HTTP.Types.Status as HTTP
 
 spec
     :: forall n
-     . ( HasSNetworkId n
-       , PaymentAddress n ByronKey 'CredFromKeyK
-       , PaymentAddress n IcarusKey 'CredFromKeyK
-       )
+     . HasSNetworkId n
     => SpecWith Context
 spec = do
     describe "BYRON_ADDRESSES" $ do
@@ -277,10 +268,8 @@ scenario_ADDRESS_CREATE_06 = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_CREATE_06 - Cannot create an address that already exists"
 
 scenario_ADDRESS_IMPORT_01
-    :: forall (n :: NetworkDiscriminant).
-        ( HasSNetworkId n
-        , PaymentAddress n ByronKey 'CredFromKeyK
-        )
+    :: forall (n :: NetworkDiscriminant)
+     . HasSNetworkId n
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context
 scenario_ADDRESS_IMPORT_01 fixture = it title $ \ctx -> runResourceT $ do
@@ -305,10 +294,8 @@ scenario_ADDRESS_IMPORT_01 fixture = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_IMPORT_01 - I can import an address from my wallet"
 
 scenario_ADDRESS_IMPORT_02
-    :: forall (n :: NetworkDiscriminant).
-        ( HasSNetworkId n
-        , PaymentAddress n IcarusKey 'CredFromKeyK
-        )
+    :: forall (n :: NetworkDiscriminant)
+     . HasSNetworkId n
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 15))
     -> SpecWith Context
 scenario_ADDRESS_IMPORT_02 fixture = it title $ \ctx -> runResourceT $ do
@@ -326,10 +313,8 @@ scenario_ADDRESS_IMPORT_02 fixture = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_IMPORT_02 - I can't import an address on an Icarus wallet"
 
 scenario_ADDRESS_IMPORT_03
-    :: forall (n :: NetworkDiscriminant).
-        ( HasSNetworkId n
-        , PaymentAddress n ByronKey 'CredFromKeyK
-        )
+    :: forall (n :: NetworkDiscriminant)
+     . HasSNetworkId n
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context
 scenario_ADDRESS_IMPORT_03 fixture = it title $ \ctx -> runResourceT $ do
@@ -376,10 +361,8 @@ scenario_ADDRESS_IMPORT_04 fixture = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_IMPORT_04 - I can import a used address (idempotence)"
 
 scenario_ADDRESS_IMPORT_05
-    :: forall (n :: NetworkDiscriminant).
-        ( HasSNetworkId n
-        , PaymentAddress n ByronKey 'CredFromKeyK
-        )
+    :: forall (n :: NetworkDiscriminant)
+     . HasSNetworkId n
     => Int
     -> (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context
@@ -409,10 +392,8 @@ scenario_ADDRESS_IMPORT_05 addrNum fixture = it title $ \ctx -> runResourceT $ d
     title = "ADDRESS_IMPORT_05 - I can import " <> show addrNum <>" of addresses"
 
 scenario_ADDRESS_IMPORT_06
-    :: forall (n :: NetworkDiscriminant).
-        ( HasSNetworkId n
-        , PaymentAddress n ByronKey 'CredFromKeyK
-        )
+    :: forall (n :: NetworkDiscriminant)
+     . HasSNetworkId n
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context
 scenario_ADDRESS_IMPORT_06 fixture = it title $ \ctx -> runResourceT $ do

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
@@ -30,7 +30,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.Types.Address
     ( AddressState (..) )
 import Cardano.Wallet.Read.NetworkId
-    ( HasSNetworkId (..), NetworkDiscriminant )
+    ( HasSNetworkId (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( encodeAddress )
 import Control.Monad
@@ -112,7 +112,7 @@ spec = do
         scenario_ADDRESS_IMPORT_06 @n emptyRandomWalletMws
 
 scenario_ADDRESS_LIST_01
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . HasSNetworkId n
     => (Context -> ResourceT IO ApiByronWallet)
     -> Int
@@ -133,7 +133,7 @@ scenario_ADDRESS_LIST_01 fixture derPathSize = it title $ \ctx -> runResourceT $
     title = "ADDRESS_LIST_01 - Can list known addresses on a default wallet"
 
 scenario_ADDRESS_LIST_02
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . HasSNetworkId n
     => (Context -> ResourceT IO ApiByronWallet)
     -> SpecWith Context
@@ -161,7 +161,7 @@ scenario_ADDRESS_LIST_02 fixture = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_LIST_02 - Can filter used and unused addresses"
 
 scenario_ADDRESS_LIST_04
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . HasSNetworkId n
     => (Context -> ResourceT IO ApiByronWallet)
     -> SpecWith Context
@@ -177,7 +177,7 @@ scenario_ADDRESS_LIST_04 fixture = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_LIST_04 - Delete wallet"
 
 scenario_ADDRESS_CREATE_01
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n => SpecWith Context
+    :: forall n. HasSNetworkId n => SpecWith Context
 scenario_ADDRESS_CREATE_01 = it title $ \ctx -> runResourceT $ do
     w <- emptyRandomWallet ctx
     let payload = Json [json| { "passphrase": #{fixturePassphrase} }|]
@@ -190,7 +190,7 @@ scenario_ADDRESS_CREATE_01 = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_CREATE_01 - Can create a random address without index"
 
 scenario_ADDRESS_CREATE_02
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n => SpecWith Context
+    :: forall n. HasSNetworkId n => SpecWith Context
 scenario_ADDRESS_CREATE_02 = it title $ \ctx -> runResourceT $ do
     w <- emptyIcarusWallet ctx
     let payload = Json [json| { "passphrase": #{fixturePassphrase} }|]
@@ -203,7 +203,7 @@ scenario_ADDRESS_CREATE_02 = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_CREATE_02 - Creation is forbidden on Icarus wallets"
 
 scenario_ADDRESS_CREATE_03
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n => SpecWith Context
+    :: forall n. HasSNetworkId n => SpecWith Context
 scenario_ADDRESS_CREATE_03 = it title $ \ctx -> runResourceT $ do
     w <- emptyRandomWallet ctx
     let payload = Json [json| { "passphrase": "Give me all your money." }|]
@@ -216,7 +216,7 @@ scenario_ADDRESS_CREATE_03 = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_CREATE_03 - Cannot create a random address with wrong passphrase"
 
 scenario_ADDRESS_CREATE_04
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n => SpecWith Context
+    :: forall n. HasSNetworkId n => SpecWith Context
 scenario_ADDRESS_CREATE_04 = it title $ \ctx -> runResourceT $ do
     w <- emptyRandomWallet ctx
 
@@ -234,7 +234,7 @@ scenario_ADDRESS_CREATE_04 = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_CREATE_04 - Can list address after creating it"
 
 scenario_ADDRESS_CREATE_05
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n => SpecWith Context
+    :: forall n. HasSNetworkId n => SpecWith Context
 scenario_ADDRESS_CREATE_05 = it title $ \ctx -> runResourceT $ do
     w <- emptyRandomWallet ctx
     let payload = Json [json|
@@ -250,7 +250,7 @@ scenario_ADDRESS_CREATE_05 = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_CREATE_05 - Can create an address and specify the index"
 
 scenario_ADDRESS_CREATE_06
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n => SpecWith Context
+    :: forall n. HasSNetworkId n => SpecWith Context
 scenario_ADDRESS_CREATE_06 = it title $ \ctx -> runResourceT $ do
     w <- emptyRandomWallet ctx
     let payload = Json [json|
@@ -268,7 +268,7 @@ scenario_ADDRESS_CREATE_06 = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_CREATE_06 - Cannot create an address that already exists"
 
 scenario_ADDRESS_IMPORT_01
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . HasSNetworkId n
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context
@@ -294,7 +294,7 @@ scenario_ADDRESS_IMPORT_01 fixture = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_IMPORT_01 - I can import an address from my wallet"
 
 scenario_ADDRESS_IMPORT_02
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . HasSNetworkId n
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 15))
     -> SpecWith Context
@@ -313,7 +313,7 @@ scenario_ADDRESS_IMPORT_02 fixture = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_IMPORT_02 - I can't import an address on an Icarus wallet"
 
 scenario_ADDRESS_IMPORT_03
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . HasSNetworkId n
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context
@@ -334,9 +334,8 @@ scenario_ADDRESS_IMPORT_03 fixture = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_IMPORT_03 - I can import an unused address multiple times"
 
 scenario_ADDRESS_IMPORT_04
-    :: forall (n :: NetworkDiscriminant).
-        ( HasSNetworkId n
-        )
+    :: forall n
+     . HasSNetworkId n
     => (Context -> ResourceT IO ApiByronWallet)
     -> SpecWith Context
 scenario_ADDRESS_IMPORT_04 fixture = it title $ \ctx -> runResourceT $ do
@@ -361,7 +360,7 @@ scenario_ADDRESS_IMPORT_04 fixture = it title $ \ctx -> runResourceT $ do
     title = "ADDRESS_IMPORT_04 - I can import a used address (idempotence)"
 
 scenario_ADDRESS_IMPORT_05
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . HasSNetworkId n
     => Int
     -> (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
@@ -392,7 +391,7 @@ scenario_ADDRESS_IMPORT_05 addrNum fixture = it title $ \ctx -> runResourceT $ d
     title = "ADDRESS_IMPORT_05 - I can import " <> show addrNum <>" of addresses"
 
 scenario_ADDRESS_IMPORT_06
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . HasSNetworkId n
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
@@ -33,14 +33,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
-    , HardDerivation (..)
-    , PaymentAddress
-    , PersistPublicKey (..)
-    , WalletKey (..)
-    )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
+    ( HardDerivation (..), PersistPublicKey (..), WalletKey (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( defaultAddressPoolGap, getAddressPoolGap )
 import Cardano.Wallet.Primitive.Types.Address
@@ -102,9 +95,7 @@ import qualified Network.HTTP.Types.Status as HTTP
 
 spec
     :: forall n
-     . ( HasSNetworkId n
-       , PaymentAddress n IcarusKey 'CredFromKeyK
-       )
+     . HasSNetworkId n
     => SpecWith Context
 spec = describe "BYRON_HW_WALLETS" $ do
     it "HW_WALLETS_01 - Restoration from account public key preserves funds" $ \ctx -> runResourceT $ do

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -30,12 +30,6 @@ import Cardano.Wallet.Api.Types
     , ApiWalletMigrationPlan (..)
     , WalletStyle (..)
     )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), PaymentAddress )
-import Cardano.Wallet.Primitive.AddressDerivation.Byron
-    ( ByronKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxStatus (..) )
 import Cardano.Wallet.Read.NetworkId
@@ -107,10 +101,7 @@ import qualified Test.Hspec as Hspec
 
 spec
     :: forall n
-     . ( HasSNetworkId n
-       , PaymentAddress n IcarusKey 'CredFromKeyK
-       , PaymentAddress n ByronKey 'CredFromKeyK
-       )
+     . HasSNetworkId n
     => SpecWith Context
 spec = describe "BYRON_MIGRATIONS" $ do
 

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -29,12 +29,6 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     , apiAddress
     )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), PaymentAddress )
-import Cardano.Wallet.Primitive.AddressDerivation.Byron
-    ( ByronKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -117,10 +111,7 @@ import qualified Test.Hspec as Hspec
 
 spec
     :: forall n
-     . ( HasSNetworkId n
-       , PaymentAddress n IcarusKey 'CredFromKeyK
-       , PaymentAddress n ByronKey 'CredFromKeyK
-       )
+     . HasSNetworkId n
     => SpecWith Context
 spec = describe "SHELLEY_MIGRATIONS" $ do
 

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -44,10 +44,6 @@ import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..) )
 import Cardano.Wallet.Api.Types.SchemaMetadata
     ( detailedMetadata )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), PaymentAddress )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
 import Cardano.Wallet.Primitive.Types
     ( SortOrder (..), WalletId )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -194,9 +190,7 @@ data TestCase a = TestCase
 
 spec
     :: forall n
-     . ( HasSNetworkId n
-       , PaymentAddress n IcarusKey 'CredFromKeyK
-       )
+     . HasSNetworkId n
     => SpecWith Context
 spec = describe "SHELLEY_TRANSACTIONS" $ do
 

--- a/lib/wallet/integration/src/Test/Integration/Scenario/CLI/Byron/Addresses.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/CLI/Byron/Addresses.hs
@@ -15,12 +15,6 @@ import Prelude
 
 import Cardano.Wallet.Api.Types
     ( ApiAddressWithPath, ApiByronWallet, ApiT (..) )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), PaymentAddress )
-import Cardano.Wallet.Primitive.AddressDerivation.Byron
-    ( ByronKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
 import Cardano.Wallet.Primitive.Types.Address
     ( AddressState (..) )
 import Cardano.Wallet.Read.NetworkId
@@ -71,10 +65,7 @@ import qualified Data.Text as T
 
 spec
     :: forall n
-     . ( HasSNetworkId n
-       , PaymentAddress n ByronKey 'CredFromKeyK
-       , PaymentAddress n IcarusKey 'CredFromKeyK
-       )
+     . HasSNetworkId n
     => SpecWith Context
 spec = do
     describe "BYRON_CLI_ADDRESSES" $ do
@@ -279,10 +270,8 @@ scenario_ADDRESS_CREATE_07 index expectedMsg = it index $ \ctx -> runResourceT @
     out `shouldBe` mempty
 
 scenario_ADDRESS_IMPORT_01
-    :: forall (n :: NetworkDiscriminant).
-        ( HasSNetworkId n
-        , PaymentAddress n ByronKey 'CredFromKeyK
-        )
+    :: forall (n :: NetworkDiscriminant)
+     . HasSNetworkId n
     => SpecWith Context
 scenario_ADDRESS_IMPORT_01 = it title $ \ctx -> runResourceT @IO $ do
     (w, mw) <- emptyRandomWalletMws ctx
@@ -295,10 +284,8 @@ scenario_ADDRESS_IMPORT_01 = it title $ \ctx -> runResourceT @IO $ do
     title = "CLI_ADDRESS_IMPORT_01 - I can import an address from my wallet"
 
 scenario_ADDRESS_IMPORT_02
-    :: forall (n :: NetworkDiscriminant).
-        ( HasSNetworkId n
-        , PaymentAddress n IcarusKey 'CredFromKeyK
-        )
+    :: forall (n :: NetworkDiscriminant)
+     . HasSNetworkId n
     => SpecWith Context
 scenario_ADDRESS_IMPORT_02 = it title $ \ctx -> runResourceT @IO $ do
     (w, mw) <- emptyIcarusWalletMws ctx

--- a/lib/wallet/integration/src/Test/Integration/Scenario/CLI/Byron/Addresses.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/CLI/Byron/Addresses.hs
@@ -18,7 +18,7 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( AddressState (..) )
 import Cardano.Wallet.Read.NetworkId
-    ( HasSNetworkId (..), NetworkDiscriminant )
+    ( HasSNetworkId (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( encodeAddress )
 import Control.Monad
@@ -107,7 +107,7 @@ spec = do
                 scenario_ADDRESS_CREATE_07 idx expectedMsginvalidIdx
 
 scenario_ADDRESS_LIST_01
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . HasSNetworkId n
     => String
     -> (Context -> ResourceT IO ApiByronWallet)
@@ -128,7 +128,7 @@ scenario_ADDRESS_LIST_01 walType fixture = it title $ \ctx -> runResourceT $ do
         ++ walType ++ " can list known addresses on a default wallet"
 
 scenario_ADDRESS_LIST_02
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . HasSNetworkId n
     => String
     -> (Context -> ResourceT IO ApiByronWallet)
@@ -177,7 +177,7 @@ scenario_ADDRESS_LIST_04 walType fixture = it title $ \ctx -> runResourceT $ do
     title = "CLI_ADDRESS_LIST_04 - " ++ walType ++ " deleted wallet"
 
 scenario_ADDRESS_CREATE_01
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n => SpecWith Context
+    :: forall n. HasSNetworkId n => SpecWith Context
 scenario_ADDRESS_CREATE_01 = it title $ \ctx -> runResourceT @IO $ do
     w <- emptyRandomWallet ctx
     let wid = T.unpack (w ^. walletId)
@@ -212,7 +212,7 @@ scenario_ADDRESS_CREATE_03 = it title $ \ctx -> runResourceT @IO $ do
     title = "ADDRESS_CREATE_03 - Cannot create a random address with wrong passphrase"
 
 scenario_ADDRESS_CREATE_04
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n => SpecWith Context
+    :: forall n. HasSNetworkId n => SpecWith Context
 scenario_ADDRESS_CREATE_04 = it title $ \ctx -> runResourceT @IO $ do
     w <- emptyRandomWallet ctx
     let wid = T.unpack (w ^. walletId)
@@ -230,7 +230,7 @@ scenario_ADDRESS_CREATE_04 = it title $ \ctx -> runResourceT @IO $ do
     title = "CLI_ADDRESS_CREATE_04 - Can list address after creating it"
 
 scenario_ADDRESS_CREATE_05
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n => SpecWith Context
+    :: forall n. HasSNetworkId n => SpecWith Context
 scenario_ADDRESS_CREATE_05 = it title $ \ctx -> runResourceT @IO $ do
     w <- emptyRandomWallet ctx
     let wid = T.unpack (w ^. walletId)
@@ -270,9 +270,7 @@ scenario_ADDRESS_CREATE_07 index expectedMsg = it index $ \ctx -> runResourceT @
     out `shouldBe` mempty
 
 scenario_ADDRESS_IMPORT_01
-    :: forall (n :: NetworkDiscriminant)
-     . HasSNetworkId n
-    => SpecWith Context
+    :: forall n . HasSNetworkId n => SpecWith Context
 scenario_ADDRESS_IMPORT_01 = it title $ \ctx -> runResourceT @IO $ do
     (w, mw) <- emptyRandomWalletMws ctx
     let wid = T.unpack (w ^. walletId)
@@ -284,9 +282,7 @@ scenario_ADDRESS_IMPORT_01 = it title $ \ctx -> runResourceT @IO $ do
     title = "CLI_ADDRESS_IMPORT_01 - I can import an address from my wallet"
 
 scenario_ADDRESS_IMPORT_02
-    :: forall (n :: NetworkDiscriminant)
-     . HasSNetworkId n
-    => SpecWith Context
+    :: forall n . HasSNetworkId n => SpecWith Context
 scenario_ADDRESS_IMPORT_02 = it title $ \ctx -> runResourceT @IO $ do
     (w, mw) <- emptyIcarusWalletMws ctx
     let wid = T.unpack (w ^. walletId)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -459,7 +459,7 @@ import Cardano.Wallet.Primitive.Types.UTxOSelection
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
     ( UTxOStatistics )
 import Cardano.Wallet.Read.NetworkId
-    ( HasSNetworkId (..), NetworkDiscriminant )
+    ( HasSNetworkId (..) )
 import Cardano.Wallet.Read.Tx.CBOR
     ( TxCBOR )
 import Cardano.Wallet.Shelley.Compatibility
@@ -1252,7 +1252,7 @@ mkExternalWithdrawal netLayer txLayer era mnemonic = do
         WithdrawalExternal rewardAccount derivationPath balance xprv
 
 mkSelfWithdrawal
-    :: forall ktype tx (n :: NetworkDiscriminant) block
+    :: forall ktype tx n block
      . NetworkLayer IO block
     -> TransactionLayer ShelleyKey ktype tx
     -> AnyCardanoEra
@@ -1272,7 +1272,7 @@ mkSelfWithdrawal netLayer txLayer era db wallet = do
 -- | Unsafe version of the `mkSelfWithdrawal` function that throws an exception
 -- when applied to a non-shelley or a non-sequential wallet.
 shelleyOnlyMkSelfWithdrawal
-    :: forall s k ktype tx (n :: NetworkDiscriminant) block
+    :: forall s k ktype tx n block
      . WalletFlavor s n k
     => NetworkLayer IO block
     -> TransactionLayer k ktype tx
@@ -1312,7 +1312,7 @@ checkRewardIsWorthTxCost txLayer pp era balance = do
         dummyPath = DerivationIndex 0 :| []
 
 readRewardAccount
-    :: forall (n :: NetworkDiscriminant)
+    :: forall n
      . DBLayer IO (SeqState n ShelleyKey) ShelleyKey
     -> WalletId
     -> ExceptT ErrReadRewardAccount IO
@@ -1335,7 +1335,7 @@ readRewardAccount db wid = do
 -- that throws error when applied to a non-sequential
 -- or a non-shelley wallet state.
 shelleyOnlyReadRewardAccount
-    :: forall s k (n :: NetworkDiscriminant)
+    :: forall s k n
      . WalletFlavor s n k
     => DBLayer IO s k
     -> WalletId
@@ -1347,7 +1347,7 @@ shelleyOnlyReadRewardAccount db wid = do
         _ -> throwE ErrReadRewardAccountNotAShelleyWallet
 
 readPolicyPublicKey
-    :: forall ctx s k (n :: NetworkDiscriminant)
+    :: forall ctx s k n
      . ( HasDBLayer IO s k ctx
        , WalletFlavor s n k
        )
@@ -1371,7 +1371,7 @@ readPolicyPublicKey ctx wid = db & \DBLayer{..} -> do
     db = ctx ^. dbLayer @IO @s @k
 
 manageRewardBalance
-    :: forall (n :: NetworkDiscriminant) block
+    :: forall n block
      . Tracer IO WalletWorkerLog
     -> NetworkLayer IO block
     -> DBLayer IO (SeqState n ShelleyKey) ShelleyKey
@@ -1492,7 +1492,6 @@ listAddresses ctx wid normalize = db & \DBLayer{..} -> do
 createRandomAddress
     :: forall ctx s k n .
         ( HasDBLayer IO s k ctx
-        , PaymentAddress k 'CredFromKeyK
         , RndStateLike s
         , k ~ ByronKey
         , AddressBookIso s
@@ -2011,7 +2010,7 @@ type MakeRewardAccountBuilder k =
 --
 -- Requires the encryption passphrase in order to decrypt the root private key.
 buildSignSubmitTransaction
-    :: forall k s (n :: NetworkDiscriminant)
+    :: forall k s n
      . ( WalletKey k
        , HardDerivation k
        , Bounded (Index (AddressIndexDerivationType k) (AddressCredential k))
@@ -2103,7 +2102,7 @@ buildSignSubmitTransaction ti db@DBLayer{..} netLayer txLayer pwd walletId
     wrapBalanceConstructError = either ExceptionBalanceTx ExceptionConstructTx
 
 buildAndSignTransactionPure
-    :: forall k s (n :: NetworkDiscriminant)
+    :: forall k s n
      . ( WalletKey k
        , HardDerivation k
        , Bounded (Index (AddressIndexDerivationType k) (AddressCredential k))
@@ -2203,7 +2202,7 @@ buildAndSignTransactionPure
     anyCardanoEra = WriteTx.fromAnyRecentEra era
 
 buildTransaction
-    :: forall s k (n :: NetworkDiscriminant) era
+    :: forall s k n era
     . ( WalletFlavor s n k
       , WriteTx.IsRecentEra era
       , AddressBookIso s
@@ -2252,7 +2251,7 @@ buildTransaction DBLayer{..} txLayer timeInterpreter walletId
                 & either (liftIO . throwIO) pure
 
 buildTransactionPure
-    :: forall s k (n :: NetworkDiscriminant) era
+    :: forall s k n era
      . ( WriteTx.IsRecentEra era
        , WalletFlavor s n k
        )
@@ -2306,7 +2305,7 @@ buildTransactionPure
 -- https://input-output.atlassian.net/browse/ADP-2933
 
 unsafeShelleyOnlyGetRewardXPub
-    :: forall s k (n :: NetworkDiscriminant)
+    :: forall s k n
      . WalletFlavor s n k
     => s -> XPub
 unsafeShelleyOnlyGetRewardXPub walletState =
@@ -2400,7 +2399,7 @@ buildAndSignTransaction ctx wid era mkRwdAcct pwd txCtx sel = db & \DBLayer{..} 
 
 -- | Construct an unsigned transaction from a given selection.
 constructTransaction
-    :: forall (n :: NetworkDiscriminant) ktype era block
+    :: forall n ktype era block
      . WriteTx.IsRecentEra era
     => TransactionLayer ShelleyKey ktype SealedTx
     -> NetworkLayer IO block
@@ -2417,7 +2416,7 @@ constructTransaction txLayer netLayer db wid txCtx preSel = do
         & withExceptT ErrConstructTxBody . except
 
 constructUnbalancedSharedTransaction
-    :: forall (n :: NetworkDiscriminant) ktype era block
+    :: forall n ktype era block
      . ( WriteTx.IsRecentEra era
        , HasSNetworkId n)
     => TransactionLayer SharedKey ktype SealedTx
@@ -2891,7 +2890,7 @@ data DelegationFee = DelegationFee
 instance NFData DelegationFee
 
 delegationFee
-    :: forall s k (n :: NetworkDiscriminant)
+    :: forall s k n
      . ( AddressBookIso s
        , WalletFlavor s n k
        )
@@ -2924,7 +2923,7 @@ delegationFee db@DBLayer{..} netLayer txLayer ti era changeAddressGen walletId =
     throwInIO = runExceptT >=> either (throwIO . ExceptionNoSuchWallet) pure
 
 transactionFee
-    :: forall s k (n :: NetworkDiscriminant) era
+    :: forall s k n era
      . ( AddressBookIso s
        , WriteTx.IsRecentEra era
        , WalletFlavor s n k
@@ -3302,10 +3301,10 @@ readAccountPublicKey ctx wid = db & \DBLayer{..} -> do
     db = ctx ^. dbLayer @IO @s @k
 
 writePolicyPublicKey
-    :: forall ctx s (n :: NetworkDiscriminant).
-        ( HasDBLayer IO s ShelleyKey ctx
-        , s ~ SeqState n ShelleyKey
-        )
+    :: forall ctx s n
+     . ( HasDBLayer IO s ShelleyKey ctx
+       , s ~ SeqState n ShelleyKey
+       )
     => ctx
     -> WalletId
     -> Passphrase "user"

--- a/lib/wallet/src/Cardano/Wallet/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation.hs
@@ -58,8 +58,6 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
-import Cardano.Wallet.Read.NetworkId
-    ( NetworkDiscriminant )
 import Cardano.Wallet.Transaction
     ( ErrCannotJoin (..)
     , TransactionCtx
@@ -224,7 +222,7 @@ quitStakePoolDelegationAction db@DBLayer{..} walletId withdrawal = do
     pure Tx.Quit
 
 quitStakePool
-    :: forall (n :: NetworkDiscriminant) block
+    :: forall n block
      . NetworkLayer IO block
     -> DBLayer IO (SeqState n ShelleyKey) ShelleyKey
     -> TimeInterpreter (ExceptT PastHorizonException IO)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
@@ -77,7 +77,7 @@ import Cardano.Wallet.Primitive.Types.ProtocolMagic
     ( ProtocolMagic (..), magicSNetworkId )
 import Cardano.Wallet.Read.NetworkId
     ( HasSNetworkId
-    , NetworkDiscriminant (..)
+    , NetworkDiscriminant
     , NetworkDiscriminantCheck (..)
     , SNetworkId (..)
     )
@@ -375,7 +375,7 @@ instance PaymentAddress IcarusKey 'CredFromKeyK where
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k) []
 
-    paymentAddress s@(STestnet pm) k = Address
+    paymentAddress s@(STestnet _) k = Address
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k)
             [ CBOR.encodeProtocolMagicAttr (magicSNetworkId s)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
@@ -63,6 +63,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , WalletKey (..)
     , fromHex
     , hex
+    , paymentAddressS
     )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( DiscoverTxs (..), GetPurpose (..), IsOurs (..), MaybeLight (..) )
@@ -73,9 +74,13 @@ import Cardano.Wallet.Primitive.Passphrase
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.ProtocolMagic
-    ( ProtocolMagic (..), testnetMagic )
+    ( ProtocolMagic (..), magicSNetworkId )
 import Cardano.Wallet.Read.NetworkId
-    ( NetworkDiscriminant (..), NetworkDiscriminantCheck (..) )
+    ( HasSNetworkId
+    , NetworkDiscriminant (..)
+    , NetworkDiscriminantCheck (..)
+    , SNetworkId (..)
+    )
 import Control.Arrow
     ( first, left )
 import Control.DeepSeq
@@ -106,8 +111,6 @@ import Data.Proxy
     ( Proxy (..) )
 import GHC.Generics
     ( Generic )
-import GHC.TypeLits
-    ( KnownNat )
 
 import qualified Cardano.Byron.Codec.Cbor as CBOR
 import qualified Cardano.Crypto.Wallet as CC
@@ -367,20 +370,17 @@ instance WalletKey IcarusKey where
 instance GetPurpose IcarusKey where
     getPurpose = purposeBIP44
 
-instance PaymentAddress 'Mainnet IcarusKey 'CredFromKeyK where
-    paymentAddress k = Address
+instance PaymentAddress IcarusKey 'CredFromKeyK where
+    paymentAddress SMainnet k= Address
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k) []
-    liftPaymentAddress (KeyFingerprint bytes) =
-        Address bytes
 
-instance KnownNat pm => PaymentAddress ('Testnet pm) IcarusKey 'CredFromKeyK where
-    paymentAddress k = Address
+    paymentAddress s@(STestnet pm) k = Address
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k)
-            [ CBOR.encodeProtocolMagicAttr (testnetMagic @pm)
+            [ CBOR.encodeProtocolMagicAttr (magicSNetworkId s)
             ]
-    liftPaymentAddress (KeyFingerprint bytes) =
+    liftPaymentAddress _ (KeyFingerprint bytes) =
         Address bytes
 
 instance MkKeyFingerprint IcarusKey Address where
@@ -389,13 +389,13 @@ instance MkKeyFingerprint IcarusKey Address where
             Just _  -> Right $ KeyFingerprint bytes
             Nothing -> Left $ ErrInvalidAddress addr (Proxy @IcarusKey)
 
-instance PaymentAddress n IcarusKey 'CredFromKeyK
-    => MkKeyFingerprint IcarusKey (Proxy (n :: NetworkDiscriminant), IcarusKey 'CredFromKeyK XPub)
+instance HasSNetworkId n => MkKeyFingerprint IcarusKey
+    (Proxy (n :: NetworkDiscriminant), IcarusKey 'CredFromKeyK XPub)
   where
     paymentKeyFingerprint (proxy, k) =
         bimap (const err) coerce
         . paymentKeyFingerprint @IcarusKey
-        . paymentAddress @n
+        . paymentAddressS @n
         $ k
       where
         err = ErrInvalidAddress (proxy, k) Proxy
@@ -403,8 +403,7 @@ instance PaymentAddress n IcarusKey 'CredFromKeyK
 instance IsOurs (SeqState n IcarusKey) RewardAccount where
     isOurs _account state = (Nothing, state)
 
-instance PaymentAddress n IcarusKey 'CredFromKeyK =>
-    MaybeLight (SeqState n IcarusKey)
+instance HasSNetworkId n => MaybeLight (SeqState n IcarusKey)
   where
     maybeDiscover = Just $ DiscoverTxs discoverSeq
 

--- a/lib/wallet/src/Cardano/Wallet/Primitive/AddressDerivation/Shared.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/AddressDerivation/Shared.hs
@@ -213,7 +213,13 @@ instance MkKeyFingerprint SharedKey Address where
            else
             Left $ ErrInvalidAddress addr (Proxy @SharedKey)
 
-instance MkKeyFingerprint SharedKey (Proxy (n :: NetworkDiscriminant), SharedKey 'CredFromScriptK XPub) where
+instance
+    MkKeyFingerprint
+        SharedKey
+        ( Proxy (n :: NetworkDiscriminant)
+        , SharedKey 'CredFromScriptK XPub
+        )
+    where
     paymentKeyFingerprint (_, paymentK) =
         Right $ KeyFingerprint $ blake2b224 $ xpubPublicKey $ getKey paymentK
 

--- a/lib/wallet/src/Cardano/Wallet/Primitive/AddressDerivation/SharedKey.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/AddressDerivation/SharedKey.hs
@@ -41,7 +41,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Read.NetworkId
-    ( HasSNetworkId (sNetworkId), NetworkDiscriminant (..), SNetworkId (..) )
+    ( HasSNetworkId (sNetworkId), SNetworkId (..) )
 import Control.DeepSeq
     ( NFData (..) )
 import Data.Maybe
@@ -83,7 +83,8 @@ newtype SharedKey (depth :: Depth) key =
 instance (NFData key) => NFData (SharedKey depth key)
 
 constructAddressFromIx
-    :: forall (n :: NetworkDiscriminant).  HasSNetworkId n
+    :: forall n
+     . HasSNetworkId n
     => Role
     -> ScriptTemplate
     -> Maybe ScriptTemplate
@@ -156,7 +157,7 @@ replaceCosignersWithVerKeys role' (ScriptTemplate xpubs scriptTemplate) ix =
 
 -- | Convert 'NetworkDiscriminant type parameter to
 -- 'Cardano.Address.NetworkTag'.
-toNetworkTag :: forall (n :: NetworkDiscriminant). HasSNetworkId n => CA.NetworkTag
+toNetworkTag :: forall n. HasSNetworkId n => CA.NetworkTag
 toNetworkTag = case sNetworkId @n of
     SMainnet -> CA.NetworkTag 1
     STestnet _ -> CA.NetworkTag 0 -- fixme: Not all testnets have NetworkTag=0

--- a/lib/wallet/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -365,7 +365,13 @@ instance MkKeyFingerprint ShelleyKey Address where
            else
             Left $ ErrInvalidAddress addr (Proxy @ShelleyKey)
 
-instance MkKeyFingerprint ShelleyKey (Proxy (n :: NetworkDiscriminant), ShelleyKey 'CredFromKeyK XPub) where
+instance
+    MkKeyFingerprint
+        ShelleyKey
+        ( Proxy (n :: NetworkDiscriminant)
+        , ShelleyKey 'CredFromKeyK XPub
+        )
+    where
     paymentKeyFingerprint (_, paymentK) =
         Right $ KeyFingerprint $ blake2b224 $ xpubPublicKey $ getKey paymentK
 

--- a/lib/wallet/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -273,10 +273,10 @@ instance Buildable (SeqAddressPool c k) where
 -- | Create a new Address pool from a list of addresses. Note that, the list is
 -- expected to be ordered in sequence (first indexes, first in the list).
 newSeqAddressPool
-    :: forall (n :: NetworkDiscriminant) c key.
-        ( SupportsDiscovery n key
-        , Typeable c
-        )
+    :: forall n c key
+     . ( SupportsDiscovery n key
+       , Typeable c
+       )
     => key 'AccountK XPub
     -> AddressPoolGap
     -> SeqAddressPool c key

--- a/lib/wallet/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
@@ -224,10 +224,11 @@ instance Buildable (SharedAddressPool c k) where
 
 -- | Create a new shared address pool from complete script templates.
 newSharedAddressPool
-    :: forall (n :: NetworkDiscriminant) c key.
-        ( key ~ SharedKey
-        , SupportsDiscovery n key
-        , Typeable c )
+    :: forall n c key
+     . ( key ~ SharedKey
+       , SupportsDiscovery n key
+       , Typeable c
+       )
     => AddressPoolGap
     -> ScriptTemplate
     -> Maybe ScriptTemplate
@@ -553,7 +554,7 @@ templatesComplete accXPub pTemplate dTemplate =
 -------------------------------------------------------------------------------}
 
 isShared
-    :: forall (n :: NetworkDiscriminant) k. SupportsDiscovery n k
+    :: forall n k. SupportsDiscovery n k
     => Address
     -> SharedState n k
     -> (Maybe (Index 'Soft 'CredFromScriptK, Role), SharedState n k)
@@ -708,7 +709,7 @@ instance FromText CredentialType where
             ]
 
 liftPaymentAddress
-    :: forall (n :: NetworkDiscriminant) (k :: Depth -> Type -> Type).
+    :: forall n (k :: Depth -> Type -> Type).
        HasSNetworkId n
     => KeyFingerprint "payment" k
     -> Address
@@ -718,7 +719,7 @@ liftPaymentAddress (KeyFingerprint fingerprint) =
     (PaymentFromScriptHash (ScriptHash fingerprint))
 
 liftDelegationAddress
-    :: forall (n :: NetworkDiscriminant) (k :: Depth -> Type -> Type).
+    :: forall n (k :: Depth -> Type -> Type).
        HasSNetworkId n
     => Index 'Soft 'CredFromScriptK
     -> ScriptTemplate

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/ProtocolMagic.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/ProtocolMagic.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -15,10 +16,13 @@ module Cardano.Wallet.Primitive.Types.ProtocolMagic
     ( ProtocolMagic (..)
     , mainnetMagic
     , testnetMagic
+    , magicSNetworkId
     ) where
 
 import Prelude
 
+import Cardano.Wallet.Read.NetworkId
+    ( SNetworkId (..), fromSNat )
 import Control.DeepSeq
     ( NFData (..) )
 import Data.Aeson
@@ -56,3 +60,7 @@ mainnetMagic =  ProtocolMagic 764824073
 -- | Derive testnet magic from a type-level Nat
 testnetMagic :: forall pm. KnownNat pm => ProtocolMagic
 testnetMagic = ProtocolMagic $ fromIntegral $ natVal $ Proxy @pm
+
+magicSNetworkId :: SNetworkId n -> ProtocolMagic
+magicSNetworkId SMainnet = ProtocolMagic  764824073
+magicSNetworkId (STestnet pm) = ProtocolMagic $ fromIntegral $ fromSNat pm

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Network/Discriminant.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Network/Discriminant.hs
@@ -22,14 +22,6 @@ import Prelude
 
 import Cardano.Api.Shelley
     ( NetworkId )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( DelegationAddress, Depth (..), PaymentAddress )
-import Cardano.Wallet.Primitive.AddressDerivation.Byron
-    ( ByronKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Shelley
-    ( ShelleyKey )
 import Cardano.Wallet.Read.NetworkId
     ( HasSNetworkId (sNetworkId)
     , NetworkDiscriminant (..)
@@ -50,14 +42,8 @@ import qualified Cardano.Ledger.BaseTypes as Ledger
 -- satisfy.
 data SomeNetworkDiscriminant where
     SomeNetworkDiscriminant
-        :: forall (n :: NetworkDiscriminant).
-            ( PaymentAddress n IcarusKey 'CredFromKeyK
-            , PaymentAddress n ByronKey 'CredFromKeyK
-            , PaymentAddress n ShelleyKey 'CredFromKeyK
-            , DelegationAddress n ShelleyKey 'CredFromKeyK
-            , HasSNetworkId n
-            , Typeable n
-            )
+        :: forall (n :: NetworkDiscriminant)
+         . (HasSNetworkId n, Typeable n)
         => Proxy n
         -> SomeNetworkDiscriminant
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1866,7 +1866,7 @@ instance HasSNetworkId n => Arbitrary (ApiTxInputGeneral n) where
         , WalletInput <$> arbitrary
         ]
 
-instance HasSNetworkId n => Arbitrary (ApiWithdrawalGeneral (n :: NetworkDiscriminant)) where
+instance HasSNetworkId n => Arbitrary (ApiWithdrawalGeneral n) where
     arbitrary = ApiWithdrawalGeneral
         <$> arbitrary
         <*> arbitrary
@@ -2833,11 +2833,11 @@ instance Typeable n => ToSchema (ApiConstructTransaction n) where
 instance ToSchema ApiMultiDelegationAction where
     declareNamedSchema _ = declareSchemaForDefinition "ApiMultiDelegationAction"
 
-type ApiTxInputsGeneral (n :: NetworkDiscriminant) = [ApiTxInputGeneral n]
+type ApiTxInputsGeneral n = [ApiTxInputGeneral n]
 
-type ApiTxOutputsGeneral (n :: NetworkDiscriminant) = [ApiTxOutputGeneral n]
+type ApiTxOutputsGeneral n = [ApiTxOutputGeneral n]
 
-type ApiWithdrawalsGeneral (n :: NetworkDiscriminant) = [ApiWithdrawalGeneral n]
+type ApiWithdrawalsGeneral n = [ApiWithdrawalGeneral n]
 
 instance Typeable n => ToSchema (ApiTxInputsGeneral n) where
     declareNamedSchema _ = declareSchemaForDefinition "ApiInputsGeneral"

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -314,7 +314,7 @@ stateMachineSpecRnd =
 stateMachineSpecShared =
     stateMachineSpec @SharedKey @(SharedState 'Mainnet SharedKey)
 
-instance PaymentAddress 'Mainnet SharedKey 'CredFromScriptK where
+instance PaymentAddress SharedKey 'CredFromScriptK where
     paymentAddress _ = error
         "does not make sense for SharedKey but want to use stateMachineSpec"
     liftPaymentAddress _ = error

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
@@ -44,7 +44,7 @@ import Cardano.Wallet.Primitive.Passphrase.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address )
 import Cardano.Wallet.Read.NetworkId
-    ( NetworkDiscriminant (..) )
+    ( SNetworkId (..) )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
@@ -123,7 +123,8 @@ prop_roundtripFingerprintLift
 prop_roundtripFingerprintLift addr =
     let
         fingerprint = paymentKeyFingerprint @IcarusKey addr
-        eAddr = liftPaymentAddress @'Mainnet @IcarusKey @'CredFromKeyK <$> fingerprint
+        eAddr = liftPaymentAddress @IcarusKey @'CredFromKeyK SMainnet
+            <$> fingerprint
     in
         eAddr === Right addr
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
@@ -46,7 +46,7 @@ import Cardano.Wallet.Primitive.Passphrase
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Read.NetworkId
-    ( NetworkDiscriminant (..) )
+    ( NetworkDiscriminant (..), SNetworkId (..) )
 import Control.Monad
     ( forM_ )
 import Data.ByteArray.Encoding
@@ -297,7 +297,7 @@ prop_derivedKeysAreOwned (Rnd st rk pwd) (Rnd st' rk' pwd') addrIx =
     .&&.
     isOwned @_ @_ @'CredFromKeyK st' (rk', pwd') addr === Nothing
   where
-    addr = paymentAddress @'Mainnet (publicKey addrKey)
+    addr = paymentAddress SMainnet (publicKey addrKey)
     addrKey = deriveAddressPrivateKey pwd acctKey addrIx
     acctKey = deriveAccountPrivateKey pwd rk (liftIndex $ accountIndex st)
 
@@ -369,4 +369,4 @@ mkAddress (Rnd (RndState _ accIx _ _ _) rk pwd) addrIx =
         acctKey = deriveAccountPrivateKey pwd rk (liftIndex accIx)
         addrKey = deriveAddressPrivateKey pwd acctKey addrIx
     in
-        paymentAddress @'Mainnet (publicKey addrKey)
+        paymentAddress SMainnet (publicKey addrKey)

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -77,7 +77,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Read.NetworkId
-    ( NetworkDiscriminant (..) )
+    ( NetworkDiscriminant (..), SNetworkId (..) )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic )
 import Cardano.Wallet.Util
@@ -372,7 +372,7 @@ prop_changeIsOnlyKnownAfterGeneration (intPool, extPool) =
         s0 = SeqState intPool extPool emptyPendingIxs ourAccount
              Nothing rewardAccount defaultPrefix
         addrs0 = pair' <$> knownAddresses s0
-        (change, s1) = genChange (\k _ -> paymentAddress @'Mainnet k) s0
+        (change, s1) = genChange (\k _ -> paymentAddress SMainnet k) s0
         addrs1 = fst' <$> knownAddresses s1
     in conjoin
         [ prop_addrsNotInInternalPool addrs0
@@ -441,7 +441,7 @@ instance AddressPoolTest IcarusKey where
     ourAddresses _proxy cc =
         mkAddress . deriveAddressPublicKey ourAccount cc <$> [minBound..maxBound]
       where
-        mkAddress = paymentAddress @'Mainnet @IcarusKey
+        mkAddress = paymentAddress @IcarusKey SMainnet
 
 instance AddressPoolTest ShelleyKey where
     ourAccount = publicKey $
@@ -452,7 +452,7 @@ instance AddressPoolTest ShelleyKey where
     ourAddresses _proxy cc =
         mkAddress . deriveAddressPublicKey ourAccount cc <$> [minBound..maxBound]
       where
-        mkAddress k = delegationAddress @'Mainnet k rewardAccount
+        mkAddress k = delegationAddress SMainnet k rewardAccount
 
 rewardAccount
     :: ShelleyKey 'CredFromKeyK XPub
@@ -466,7 +466,7 @@ changeAddresses
     -> SeqState 'Mainnet ShelleyKey
     -> ([Address], SeqState 'Mainnet ShelleyKey)
 changeAddresses as s =
-    let (a, s') = genChange (\k _ -> paymentAddress @'Mainnet k) s
+    let (a, s') = genChange (\k _ -> paymentAddress SMainnet k) s
     in if a `elem` as then (as, s) else changeAddresses (a:as) s'
 
 unsafeMkAddressPoolGap :: (Integral a, Show a) => a -> AddressPoolGap

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SharedSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SharedSpec.hs
@@ -119,7 +119,7 @@ spec = do
             (property prop_oursUnexpectedPrefix)
 
 prop_addressWithScriptFromOurVerKeyIxIn
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n
+    :: forall n. HasSNetworkId n
     => CatalystSharedState
     -> Index 'Soft 'CredFromScriptK
     -> Property
@@ -132,7 +132,7 @@ prop_addressWithScriptFromOurVerKeyIxIn (CatalystSharedState accXPub' accIx' pTe
     (Just (keyIx', _), _) = isShared @n addr sharedState
 
 prop_addressWithScriptFromOurVerKeyIxBeyond
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n
+    :: forall n. HasSNetworkId n
     => CatalystSharedState
     -> Index 'Soft 'CredFromScriptK
     -> Property
@@ -152,7 +152,7 @@ getAddrPool st = case ready st of
     Pending -> error "expected active state"
 
 prop_addressDiscoveryMakesAddressUsed
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n
+    :: forall n. HasSNetworkId n
     => CatalystSharedState
     -> Index 'Soft 'CredFromScriptK
     -> Property
@@ -167,7 +167,7 @@ prop_addressDiscoveryMakesAddressUsed (CatalystSharedState accXPub' accIx' pTemp
     ourAddrs = AddressPool.addresses (getAddrPool sharedState')
 
 prop_addressDoubleDiscovery
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n
+    :: forall n. HasSNetworkId n
     => CatalystSharedState
     -> Index 'Soft 'CredFromScriptK
     -> Property
@@ -182,7 +182,7 @@ prop_addressDoubleDiscovery (CatalystSharedState accXPub' accIx' pTemplate' dTem
     sharedState'' = isShared @n addr (snd sharedState')
 
 prop_addressDiscoveryImpossibleFromOtherAccXPub
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n
+    :: forall n. HasSNetworkId n
     => CatalystSharedState
     -> Index 'Soft 'CredFromScriptK
     -> SharedKey 'AccountK XPub
@@ -198,7 +198,7 @@ prop_addressDiscoveryImpossibleFromOtherAccXPub (CatalystSharedState _ accIx' pT
     sharedState = mkSharedStateFromAccountXPub @n accXPub' accIx' g pTemplate'' dTemplate'
 
 prop_addressDiscoveryImpossibleFromOtherAccountOfTheSameRootXPrv
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n
+    :: forall n. HasSNetworkId n
     => CatalystSharedState
     -> Index 'Soft 'CredFromScriptK
     -> (SharedKey 'RootK XPrv, Index 'Hardened 'AccountK, Index 'Hardened 'AccountK)
@@ -217,7 +217,7 @@ prop_addressDiscoveryImpossibleFromOtherAccountOfTheSameRootXPrv (CatalystShared
     addr = constructAddressFromIx @n UtxoExternal pTemplate''' dTemplate' keyIx
 
 prop_addressDiscoveryImpossibleWithinAccountButDifferentScript
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n
+    :: forall n. HasSNetworkId n
     => CatalystSharedState
     -> Index 'Soft 'CredFromScriptK
     -> OneCosignerScript
@@ -233,7 +233,7 @@ prop_addressDiscoveryImpossibleWithinAccountButDifferentScript (CatalystSharedSt
     addr = constructAddressFromIx @n UtxoExternal pTemplate'' dTemplate' keyIx
 
 prop_addressDiscoveryDoesNotChangeGapInvariance
-    :: forall (n :: NetworkDiscriminant). HasSNetworkId n
+    :: forall n. HasSNetworkId n
     => CatalystSharedState
     -> Index 'Soft 'CredFromScriptK
     -> Property

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
@@ -23,7 +23,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (AccountK, CredFromKeyK, RootK)
     , DerivationType (..)
     , Index
-    , PaymentAddress (..)
+    , paymentAddressS
     , publicKey
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
@@ -40,7 +40,7 @@ import Cardano.Wallet.Primitive.Passphrase
     , preparePassphrase
     )
 import Cardano.Wallet.Read.NetworkId
-    ( NetworkDiscriminant (..) )
+    ( HasSNetworkId, NetworkDiscriminant (..) )
 import Control.Monad
     ( replicateM )
 import Data.Maybe
@@ -80,7 +80,8 @@ spec = do
 -------------------------------------------------------------------------------}
 
 prop_derivedKeysAreOurs
-    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ByronKey 'CredFromKeyK)
+    :: forall n
+     . HasSNetworkId n
     => SomeMnemonic
     -> Passphrase "encryption"
     -> Index 'WholeDomain 'AccountK
@@ -96,7 +97,7 @@ prop_derivedKeysAreOurs seed encPwd accIx addrIx rk' =
     (resNeg, stNeg') = isOurs addr (mkRndState @n rk' 0)
     key = publicKey $ unsafeGenerateKeyFromSeed @'CredFromKeyK (accIx, addrIx) seed encPwd
     rootXPrv = generateKeyFromSeed seed encPwd
-    addr = paymentAddress @n key
+    addr = paymentAddressS @n key
 
 {-------------------------------------------------------------------------------
                              Arbitrary Instances

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Delegation/StateSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Delegation/StateSpec.hs
@@ -53,7 +53,7 @@ import Cardano.Wallet.Primitive.Types.Tx.TxIn
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..) )
 import Cardano.Wallet.Read.NetworkId
-    ( NetworkDiscriminant (..) )
+    ( SNetworkId (..) )
 import Control.Arrow
     ( first )
 import Crypto.Hash.Utils
@@ -312,9 +312,9 @@ instance SoftDerivation StakeKey' where
 instance MkKeyFingerprint StakeKey' Address where
     paymentKeyFingerprint (Address addr) = Right $ KeyFingerprint $ B8.drop 4 addr
 
-instance PaymentAddress 'Mainnet StakeKey' 'CredFromKeyK where
-    liftPaymentAddress (KeyFingerprint fp) = Address fp
-    paymentAddress k = Address $ "addr" <> unRewardAccount (toRewardAccount k)
+instance PaymentAddress StakeKey' 'CredFromKeyK where
+    liftPaymentAddress _ (KeyFingerprint fp) = Address fp
+    paymentAddress _ k = Address $ "addr" <> unRewardAccount (toRewardAccount k)
 
 instance MkKeyFingerprint StakeKey' (StakeKey' 'CredFromKeyK XPub) where
     paymentKeyFingerprint k =
@@ -470,8 +470,8 @@ stepCmd CmdOldWalletToggleFirstKey env =
             in tryApplyTx tx env
 stepCmd (CmdMimicPointerOutput (RewardAccount acc)) env =
             let
-                addr = liftPaymentAddress @'Mainnet @StakeKey' @'CredFromKeyK $
-                    KeyFingerprint acc
+                addr = liftPaymentAddress @StakeKey' @'CredFromKeyK SMainnet
+                    $ KeyFingerprint acc
                 c = Coin 1
                 out = TxOut addr (TB.fromCoin c)
                 tx = Tx [] [] [out]

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -75,12 +75,7 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
 import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     ( genTxOutTokenBundle )
 import Cardano.Wallet.Read.NetworkId
-    ( NetworkDiscriminant (..)
-    , NetworkId (..)
-    , SNetworkId (..)
-    , toSNat
-    , toSNetworkId
-    )
+    ( NetworkId (..), SNetworkId (..), toSNat, toSNetworkId )
 import Cardano.Wallet.Shelley.Compatibility
     ( CardanoBlock
     , StandardCrypto
@@ -205,28 +200,37 @@ spec = do
 
     describe "Shelley Addresses" $ do
         prop "(Mainnet) can be deserialised by shelley ledger spec" $ \k -> do
-            let Address addr = paymentAddress @'Mainnet @ShelleyKey @'CredFromKeyK k
+            let Address addr
+                    = paymentAddress @ShelleyKey @'CredFromKeyK SMainnet k
             case SL.deserialiseAddr @StandardCrypto addr of
                 Just _ -> property True
                 Nothing -> property False
 
         prop "Shelley addresses from bech32" $ \k ->
-            let addr@(Address bytes) = paymentAddress @'Mainnet @ShelleyKey @'CredFromKeyK k
+            let addr@(Address bytes)
+                    = paymentAddress @ShelleyKey @'CredFromKeyK SMainnet k
             in  decodeAddress SMainnet (bech32 bytes) === Right addr
                     & counterexample (show $ bech32 bytes)
 
         prop "Shelley addresses with delegation from bech32" $ \k1 k2 ->
-            let addr@(Address bytes) = delegationAddress @'Mainnet @ShelleyKey @'CredFromKeyK k1 k2
+            let addr@(Address bytes)
+                    = delegationAddress
+                        @ShelleyKey @'CredFromKeyK SMainnet k1 k2
             in  decodeAddress SMainnet (bech32 bytes) === Right addr
                     & counterexample (show $ bech32 bytes)
 
-        prop "Shelley addresses from bech32 - testnet" $ \k ->
-            let addr@(Address raw) = paymentAddress @('Testnet 0) @ShelleyKey @'CredFromKeyK k
-            in  toSNetworkId (NTestnet 0) $ \n -> decodeAddress n (bech32testnet raw) === Right addr
-                   & counterexample (show $ bech32testnet raw)
+        prop "Shelley addresses from bech32 - testnet"
+            $ \k -> toSNetworkId (NTestnet 0)
+                $ \n ->
+                    let addr@(Address raw) =
+                            paymentAddress @ShelleyKey @'CredFromKeyK n k
+                    in  decodeAddress n (bech32testnet raw)
+                            === Right addr
+                            & counterexample (show $ bech32testnet raw)
 
         prop "Byron addresses from base58" $ \k ->
-            let addr@(Address bytes) = paymentAddress @'Mainnet @ByronKey @'CredFromKeyK k
+            let addr@(Address bytes)
+                    = paymentAddress @ByronKey @'CredFromKeyK SMainnet k
             in  decodeAddress SMainnet (base58 bytes) === Right addr
                     & counterexample (show $ base58 bytes)
 


### PR DESCRIPTION
- [x] Remove `n` parameter from `PaymentAddress` and `DelegationAddress` classes and move it to the methods as singleton `SNetworkId n` parameter
- [x] Add some functions that simplify the call of the methods in the old way (forcing `@n`) so as not to change too much the call site
- [x]  Remove `:: NetworkDiscriminant` superfluous signature around
- [x] Remove redundant constraints on `PaymentAddress` and `DelegationAddress` now that `n` is removed

ADP-2959