### PR TITLE
Make API error expectations compiler-checkable.

### DIFF
--- a/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
@@ -34,6 +34,7 @@ module Test.Integration.Framework.DSL
     , expectError
     , expectErrorMessage
     , expectErrorCode
+    , expectErrorInfo
     , expectField
     , expectListField
     , expectListSize
@@ -558,6 +559,15 @@ expectErrorCode expectedErrCode = snd >>> \case
         expectationFailure $
             "Expected a 'ClientError' with code " <> show expectedErrCode
             <> " but got " <> show otherError
+
+-- | Defines an expectation about an API error, assuming it can successfully
+--   be decoded as an 'ApiErrorInfo' object.
+expectErrorInfo
+    :: (HasCallStack, Show a)
+    => (ApiErrorInfo -> m ())
+    -> (s, Either RequestException a)
+    -> m ()
+expectErrorInfo f = f . decodeErrorInfo
 
 -- | Decodes the information about an error into an 'ApiErrorInfo' value.
 decodeErrorInfo

--- a/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
@@ -33,7 +33,6 @@ module Test.Integration.Framework.DSL
     , expectSuccess
     , expectError
     , expectErrorMessage
-    , expectErrorCode
     , expectErrorInfo
     , expectField
     , expectListField
@@ -363,7 +362,7 @@ import Cardano.Wallet.Shelley.Compatibility
 import "cardano-addresses" Codec.Binary.Encoding
     ( AbstractEncoding (..), encode )
 import Control.Arrow
-    ( second, (>>>) )
+    ( second )
 import Control.Monad
     ( forM_, join, replicateM, unless, void, (>=>) )
 import Control.Monad.IO.Unlift
@@ -497,7 +496,6 @@ import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
-import qualified Data.Aeson.KeyMap as Key
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -538,27 +536,6 @@ expectErrorMessage want = either expectation wantedErrorButSuccess . snd
         ClientError val       -> BL8.unpack $ Aeson.encode val
         RawClientError val    -> BL8.unpack val
         HttpException err     -> show err
-
--- | Expect an error identified by its code.
-expectErrorCode
-    :: (HasCallStack, MonadIO m, Show a)
-    => String
-    -> (s, Either RequestException a)
-    -> m ()
-expectErrorCode expectedErrCode = snd >>> \case
-    Right a -> wantedErrorButSuccess a
-    Left (ClientError payload) ->
-        case payload of
-            Aeson.Object object ->
-                Key.lookup "code" object `shouldBe`
-                    Just (Aeson.String (T.pack expectedErrCode))
-            _otherTypeOfPayload -> expectationFailure $
-                "Expected a 'ClientError' with a JSON object payload \
-                \but got something else: " <> show payload
-    Left otherError ->
-        expectationFailure $
-            "Expected a 'ClientError' with code " <> show expectedErrCode
-            <> " but got " <> show otherError
 
 -- | Defines an expectation about an API error, assuming it can successfully
 --   be decoded as an 'ApiErrorInfo' object.

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -108,6 +108,7 @@ import Test.Integration.Framework.DSL
     , emptyWallet
     , eventually
     , expectErrorCode
+    , expectErrorInfo
     , expectErrorMessage
     , expectField
     , expectListField
@@ -1142,7 +1143,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             (Link.createTransactionOld @'Shelley wa) Default payload
 
         expectResponseCode HTTP.status403 r
-        expectErrorCode "transaction_is_too_big" r
+        expectErrorInfo (`shouldBe` TransactionIsTooBig) r
 
     it "TRANSMETA_ESTIMATE_01a - \
         \fee estimation includes metadata" $

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -107,7 +107,6 @@ import Test.Integration.Framework.DSL
     , emptyRandomWallet
     , emptyWallet
     , eventually
-    , expectErrorCode
     , expectErrorInfo
     , expectErrorMessage
     , expectField
@@ -1277,7 +1276,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         verify r
             [ expectResponseCode HTTP.status403
-            , expectErrorCode "transaction_is_too_big"
+            , expectErrorInfo (`shouldBe` TransactionIsTooBig)
             ]
 
     describe "TRANS_ESTIMATE_08 - Bad payload" $ do


### PR DESCRIPTION
Follow-on from https://github.com/input-output-hk/cardano-wallet/pull/3824 ([ADP-2269](https://input-output.atlassian.net/browse/ADP-2269)).

## Summary

This PR replaces `expectErrorCode`, which creates expectations based on string comparisons, with `expectErrorInfo`, which creates expectations based on `ApiErrorInfo` objects.

This has two advantages:
- expectation expressions can be checked statically by the compiler.
- it's possible to express richer expectations based on internal fields of errors (not all errors are just simple values -- some have nested records), using combinators provided by `hspec`.

## Context

In our test suite we test at least two kinds of mapping:

- The mapping between API types and their serialised JSON representations: for all API types, the JSON encoding should be consistent with the OpenAPI specification, and the round trip property `(decode . encode == id)` should hold for all values.
- The mapping from (API call, inputs, state) to API response values: i.e, that API calls return the responses we expect, given appropriate inputs and the current (implicit) wallet state.

Up until now, the approach we've used in `cardano-wallet` is to separate the above two concerns into **different test suites**, i.e., to:

- test expectations about our JSON serialisation logic in specialised tests for just that purpose (JSON golden round trip tests and the test suite for the OpenAPI spec).
- within other test suites (such as the integration test suite), **assume** the correctness of our JSON serialisation logic, and express expectations in terms of ordinary (decoded) Haskell values.

API errors have, up until now, been a sort of exception to this separation of concerns, because until recently we didn't have a good way to create structured errors.

But since merging #3557, which provides support for structured errors and the accompanying [decodeErrorInfo](https://github.com/input-output-hk/cardano-wallet/blob/504774f0f08f4ec74fa91106bc004d8e7b97f875/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs#L559) function, we've gradually been converting expectations about API errors to use the same style as we use for ordinary values returned by the API, which is to express expectations in terms of ordinary Haskell expressions, and to avoid writing expectations in terms of hard-coded strings.

For example, for ordinary (non-error) API responses, we typically write expectations like this:
https://github.com/input-output-hk/cardano-wallet/blob/7af6d54d21443146320eab04452eefb75b3d553e/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs#L297-L299