### PR TITLE
Optimise `UTxOIndex.difference`.

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -380,10 +380,20 @@ size = Map.size . universe
 -- Set operations
 --------------------------------------------------------------------------------
 
+-- | Creates a new index by subtracting the second index from the first.
+--
+-- This operation is fast if the intersection of the first and second indices
+-- is small relative to the size of the first index.
+--
 difference :: Ord u => UTxOIndex u -> UTxOIndex u -> UTxOIndex u
-difference a b = fromSequence
-    $ Map.toList
-    $ Map.difference (universe a) (universe b)
+difference a b
+    | disjoint a b = a
+    | otherwise = deleteMany keysToDelete a
+  where
+    keysToDelete =
+        Set.intersection
+            (Map.keysSet (universe a))
+            (Map.keysSet (universe b))
 
 -- | Indicates whether a pair of UTxO indices are disjoint.
 --


### PR DESCRIPTION
## Issue

https://input-output.atlassian.net/browse/ADP-2975.

## Summary

This PR adjusts the `UTxOIndex.difference` function so that it does not reconstruct the entire index from scratch, and instead only deletes those entries that are necessary to delete.

This should be fast if the intersection of the two indices is relatively small w.r.t. to the size of the first index.

`UTxOIndex.difference` is called by `UTxOSelection.fromIndexPair`, which is called from `balanceTransaction` before it calls into the coin selection algorithm.