### PR TITLE
Optimise the `UTxOIndex.fromMap` operation.

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -240,7 +240,7 @@ fromSequence = flip insertMany empty
 -- @
 --
 fromMap :: Ord u => Map u TokenBundle -> UTxOIndex u
-fromMap = F.foldl' (\i (u, b) -> insert u b i) empty . Map.toList
+fromMap = F.foldl' (\i (u, b) -> insertUnsafe u b i) empty . Map.toList
 
 --------------------------------------------------------------------------------
 -- Deconstruction

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -240,7 +240,7 @@ fromSequence = flip insertMany empty
 -- @
 --
 fromMap :: Ord u => Map u TokenBundle -> UTxOIndex u
-fromMap = flip (flip $ F.foldl' $ \i (u, b) -> insert u b i) empty . Map.toList
+fromMap = F.foldl' (\i (u, b) -> insert u b i) empty . Map.toList
 
 --------------------------------------------------------------------------------
 -- Deconstruction

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -240,7 +240,7 @@ fromSequence = flip insertMany empty
 -- @
 --
 fromMap :: Ord u => Map u TokenBundle -> UTxOIndex u
-fromMap = flip insertMany empty . Map.toList
+fromMap = flip (flip $ F.foldl' $ \i (u, b) -> insert u b i) empty . Map.toList
 
 --------------------------------------------------------------------------------
 -- Deconstruction

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -240,7 +240,7 @@ fromSequence = flip insertMany empty
 -- @
 --
 fromMap :: Ord u => Map u TokenBundle -> UTxOIndex u
-fromMap = fromSequence . Map.toList
+fromMap = flip insertMany empty . Map.toList
 
 --------------------------------------------------------------------------------
 -- Deconstruction

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -233,6 +233,12 @@ fromSequence = flip insertMany empty
 -- Note that this operation is potentially expensive as it must construct an
 -- index from scratch, and therefore should only be used sparingly.
 --
+-- Satisfies the following property:
+--
+-- @
+-- 'fromMap' ≡ 'fromSequence' . 'Map.toList'
+-- @
+--
 fromMap :: Ord u => Map u TokenBundle -> UTxOIndex u
 fromMap = fromSequence . Map.toList
 

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -240,7 +240,7 @@ fromSequence = flip insertMany empty
 -- @
 --
 fromMap :: Ord u => Map u TokenBundle -> UTxOIndex u
-fromMap = F.foldl' (\i (u, b) -> insertUnsafe u b i) empty . Map.toList
+fromMap = Map.foldlWithKey' (\i u b -> insertUnsafe u b i) empty
 
 --------------------------------------------------------------------------------
 -- Deconstruction

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -42,6 +42,8 @@ import Control.Monad.Random.Class
     ( MonadRandom (..) )
 import Data.Function
     ( (&) )
+import Data.Map.Strict
+    ( Map )
 import Data.Maybe
     ( isJust, isNothing )
 import Data.Ratio
@@ -121,6 +123,8 @@ spec =
 
         it "prop_empty_toList" $
             property prop_empty_toList
+        it "prop_fromMap_fromSequence" $
+            property prop_fromMap_fromSequence
         it "prop_singleton_toList" $
             property prop_singleton_toList
         it "prop_toList_fromSequence" $
@@ -239,6 +243,10 @@ prop_selectRandom_invariant i f =
 prop_empty_toList :: Property
 prop_empty_toList =
     UTxOIndex.toList (UTxOIndex.empty @TestUTxO) === []
+
+prop_fromMap_fromSequence :: Map TestUTxO TokenBundle -> Property
+prop_fromMap_fromSequence m =
+    UTxOIndex.fromMap m === UTxOIndex.fromSequence (Map.toList m)
 
 prop_singleton_toList :: TestUTxO -> TokenBundle -> Property
 prop_singleton_toList u b =

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -106,6 +106,8 @@ spec =
             property prop_empty_invariant
         it "prop_singleton_invariant" $
             property prop_singleton_invariant
+        it "prop_fromMap_invariant" $
+            property prop_fromMap_invariant
         it "prop_fromSequence_invariant" $
             property prop_fromSequence_invariant
         it "prop_insert_invariant" $
@@ -194,6 +196,9 @@ prop_empty_invariant = invariantHolds (UTxOIndex.empty @TestUTxO)
 
 prop_singleton_invariant :: TestUTxO -> TokenBundle -> Property
 prop_singleton_invariant u b = invariantHolds $ UTxOIndex.singleton u b
+
+prop_fromMap_invariant :: Map TestUTxO TokenBundle -> Property
+prop_fromMap_invariant = invariantHolds . UTxOIndex.fromMap
 
 prop_fromSequence_invariant :: [(TestUTxO, TokenBundle)] -> Property
 prop_fromSequence_invariant = invariantHolds . UTxOIndex.fromSequence


### PR DESCRIPTION
## Issue

ADP-2975

## Details

The `UTxOIndex.fromMap` operation has been implicated as having slow performance in analyses of operations that use the `balanceTx` function.

This PR:
- replaces the existing definition of `fromMap` (which generates and consumes an intermediate list) with a definition based on `Map.foldlWithKey'`.
- replaces the use of `insert` with `insertUnsafe`.
- adds property tests to assert the equivalence between `fromMap` and `fromSequence`.

Further optimisations are possible, such as completely rewriting `fromMap` in a way that doesn't require it to repeatedly call `insertUnsafe`. However, this optimisation is relatively cheap to implement, and should be a strict improvement over `master`.