### PR TITLE
Complete removal of `Cardano.ProtocolParameters` dependency for tx construction

### DIFF
--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -79,7 +79,7 @@ import Cardano.Wallet.Network
 import Cardano.Wallet.Primitive.Model
     ( totalUTxO )
 import Cardano.Wallet.Primitive.Slotting
-    ( TimeInterpreter, hoistTimeInterpreter, toTimeTranslation )
+    ( TimeInterpreter, hoistTimeInterpreter )
 import Cardano.Wallet.Primitive.Types
     ( SortOrder (..), WalletId, WalletMetadata (..) )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -129,7 +129,6 @@ import qualified Cardano.Wallet.DB.Layer as Sqlite
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Cardano.Wallet.Read as Read
 import qualified Cardano.Wallet.Transaction as Tx
-import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Data.Aeson as Aeson
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
@@ -260,12 +259,8 @@ benchmarksSeq BenchmarkConfig{benchmarkName,ctx} = do
         $ W.createMigrationPlan @_ @s ctx Tx.NoWithdrawal
 
     (_, delegationFeeTime) <- bench "delegationFee" $ do
-        timeTranslation <-
-            toTimeTranslation (timeInterpreter (networkLayer ctx))
         W.delegationFee
             (dbLayer ctx) (networkLayer ctx) (transactionLayer ctx)
-            timeTranslation
-            (Write.AnyRecentEra Write.RecentEraBabbage)
             (W.defaultChangeAddressGen (delegationAddressS @n))
 
     pure BenchSeqResults

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
@@ -175,6 +175,8 @@ import Cardano.Wallet.Primitive.Types.Tx.Tx
     ( Tx (..) )
 import Cardano.Wallet.Util
     ( ShowFmt (..), parseURI, uriToText )
+import Cardano.Wallet.Write.Tx
+    ( MaybeInRecentEra )
 import Control.Arrow
     ( left, right )
 import Control.DeepSeq
@@ -256,7 +258,7 @@ import Numeric.Natural
 import Test.QuickCheck
     ( Arbitrary (..), oneof )
 
-import qualified Cardano.Api.Shelley as Node
+import qualified Cardano.Wallet.Write.ProtocolParameters as Write
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 
@@ -883,10 +885,10 @@ data ProtocolParameters = ProtocolParameters
         -- used to determine the fee for the use of a script within a
         -- transaction, based on the 'ExecutionUnits' needed by the use of
         -- the script.
-    , currentNodeProtocolParameters
-        :: Maybe Node.ProtocolParameters
-        -- ^ Get the last known node's protocol parameters.
-        -- In principle, these can only change once per epoch.
+    , currentLedgerProtocolParameters
+        :: MaybeInRecentEra Write.ProtocolParameters
+        -- ^ The full, raw ledger protocol parameters for writing (constructing)
+        -- transactions in case the node is in a recent era.
     } deriving (Eq, Generic, Show)
 
 instance NFData ProtocolParameters where
@@ -900,7 +902,7 @@ instance NFData ProtocolParameters where
         , rnf maximumCollateralInputCount
         , rnf minimumCollateralPercentage
         , rnf executionUnitPrices
-        -- currentNodeProtocolParameters is omitted
+        -- currentLedgerProtocolParameters is omitted
         ]
 
 instance Buildable ProtocolParameters where

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -894,7 +894,6 @@ fromShelleyPParams eraInfo pp =
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing
         , currentLedgerProtocolParameters = Write.InNonRecentEraShelley
-
         }
 
 fromAllegraPParams

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -416,6 +416,8 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (TxOut) )
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
+import qualified Cardano.Wallet.Write.ProtocolParameters as Write
+import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32
 import qualified Codec.CBOR.Decoding as CBOR
@@ -872,10 +874,9 @@ fromMaxSize = Quantity . fromIntegral
 
 fromShelleyPParams
     :: W.EraInfo Bound
-    -> Maybe Cardano.ProtocolParameters
     -> Shelley.ShelleyPParams StandardShelley
     -> W.ProtocolParameters
-fromShelleyPParams eraInfo currentNodeProtocolParameters pp =
+fromShelleyPParams eraInfo pp =
     W.ProtocolParameters
         { decentralizationLevel =
             decentralizationLevelFromPParams pp
@@ -892,15 +893,15 @@ fromShelleyPParams eraInfo currentNodeProtocolParameters pp =
         , maximumCollateralInputCount = 0
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing
-        , currentNodeProtocolParameters
+        , currentLedgerProtocolParameters = Write.InNonRecentEraShelley
+
         }
 
 fromAllegraPParams
     :: W.EraInfo Bound
-    -> Maybe Cardano.ProtocolParameters
     -> Shelley.ShelleyPParams StandardAllegra
     -> W.ProtocolParameters
-fromAllegraPParams eraInfo currentNodeProtocolParameters pp =
+fromAllegraPParams eraInfo pp =
     W.ProtocolParameters
         { decentralizationLevel =
             decentralizationLevelFromPParams pp
@@ -917,15 +918,14 @@ fromAllegraPParams eraInfo currentNodeProtocolParameters pp =
         , maximumCollateralInputCount = 0
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing
-        , currentNodeProtocolParameters
+        , currentLedgerProtocolParameters = Write.InNonRecentEraAllegra
         }
 
 fromMaryPParams
     :: W.EraInfo Bound
-    -> Maybe Cardano.ProtocolParameters
     -> Mary.ShelleyPParams StandardMary
     -> W.ProtocolParameters
-fromMaryPParams eraInfo currentNodeProtocolParameters pp =
+fromMaryPParams eraInfo pp =
     W.ProtocolParameters
         { decentralizationLevel =
             decentralizationLevelFromPParams pp
@@ -942,7 +942,7 @@ fromMaryPParams eraInfo currentNodeProtocolParameters pp =
         , maximumCollateralInputCount = 0
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing
-        , currentNodeProtocolParameters
+        , currentLedgerProtocolParameters = Write.InNonRecentEraMary
         }
 
 fromBoundToEpochNo :: Bound -> W.EpochNo
@@ -952,10 +952,9 @@ fromBoundToEpochNo (Bound _relTime _slotNo (EpochNo e)) =
 fromAlonzoPParams
     :: HasCallStack
     => W.EraInfo Bound
-    -> Maybe Cardano.ProtocolParameters
     -> Alonzo.AlonzoPParams StandardAlonzo
     -> W.ProtocolParameters
-fromAlonzoPParams eraInfo currentNodeProtocolParameters pp =
+fromAlonzoPParams eraInfo pp =
     W.ProtocolParameters
         { decentralizationLevel =
             decentralizationLevelFromPParams pp
@@ -975,16 +974,15 @@ fromAlonzoPParams eraInfo currentNodeProtocolParameters pp =
             Alonzo._collateralPercentage pp
         , executionUnitPrices =
             Just $ executionUnitPricesFromPParams pp
-        , currentNodeProtocolParameters
+        , currentLedgerProtocolParameters = Write.InNonRecentEraAlonzo
         }
 
 fromBabbagePParams
     :: HasCallStack
     => W.EraInfo Bound
-    -> Maybe Cardano.ProtocolParameters
     -> Babbage.BabbagePParams StandardBabbage
     -> W.ProtocolParameters
-fromBabbagePParams eraInfo currentNodeProtocolParameters pp =
+fromBabbagePParams eraInfo pp =
     W.ProtocolParameters
         { decentralizationLevel =
             decentralizationLevelFromPParams pp
@@ -1004,16 +1002,16 @@ fromBabbagePParams eraInfo currentNodeProtocolParameters pp =
             Babbage._collateralPercentage pp
         , executionUnitPrices =
             Just $ executionUnitPricesFromPParams pp
-        , currentNodeProtocolParameters
+        , currentLedgerProtocolParameters =
+            Write.InRecentEraBabbage $ Write.ProtocolParameters pp
         }
 
 fromConwayPParams
     :: HasCallStack
     => W.EraInfo Bound
-    -> Maybe Cardano.ProtocolParameters
     -> Babbage.BabbagePParams StandardConway
     -> W.ProtocolParameters
-fromConwayPParams eraInfo currentNodeProtocolParameters pp =
+fromConwayPParams eraInfo pp =
     W.ProtocolParameters
         { decentralizationLevel = decentralizationLevelFromPParams pp
         , txParameters = txParametersFromPParams
@@ -1028,7 +1026,8 @@ fromConwayPParams eraInfo currentNodeProtocolParameters pp =
             unsafeIntToWord $ Conway._maxCollateralInputs pp
         , minimumCollateralPercentage = Conway._collateralPercentage pp
         , executionUnitPrices = Just $ executionUnitPricesFromPParams pp
-        , currentNodeProtocolParameters
+        , currentLedgerProtocolParameters =
+            Write.InRecentEraConway $ Write.ProtocolParameters pp
         }
 
 -- | Extract the current network decentralization level from the given set of
@@ -1154,7 +1153,7 @@ fromGenesisData g =
             }
         , slottingParameters = slottingParametersFromGenesis g
         , protocolParameters =
-            fromShelleyPParams W.emptyEraInfo Nothing $ sgProtocolParams g
+            fromShelleyPParams W.emptyEraInfo $ sgProtocolParams g
         }
     , genesisBlockFromTxOuts (ListMap.toList $ sgInitialFunds g)
     , poolCerts $ sgStaking g

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Network/Node.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Network/Node.hs
@@ -279,7 +279,6 @@ import UnliftIO.Concurrent
 import UnliftIO.Exception
     ( Handler (..), IOException )
 
-import qualified Cardano.Api as Cardano
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
 import qualified Cardano.Ledger.Babbage.PParams as Babbage
@@ -710,35 +709,20 @@ mkWalletToNodeProtocols
                 ((slottingParametersFromGenesis . getCompactGenesis)
                     <$> LSQry Shelley.GetGenesisConfig)
 
-            ppNode <- onAnyEra
-                (pure Nothing)
-                (Just . Cardano.fromLedgerPParams Cardano.ShelleyBasedEraShelley
-                    <$> LSQry Shelley.GetCurrentPParams)
-                (Just . Cardano.fromLedgerPParams Cardano.ShelleyBasedEraAllegra
-                    <$> LSQry Shelley.GetCurrentPParams)
-                (Just . Cardano.fromLedgerPParams Cardano.ShelleyBasedEraMary
-                    <$> LSQry Shelley.GetCurrentPParams)
-                (Just . Cardano.fromLedgerPParams Cardano.ShelleyBasedEraAlonzo
-                    <$> LSQry Shelley.GetCurrentPParams)
-                (Just . Cardano.fromLedgerPParams Cardano.ShelleyBasedEraBabbage
-                    <$> LSQry Shelley.GetCurrentPParams)
-                (Just . Cardano.fromLedgerPParams Cardano.ShelleyBasedEraConway
-                    <$> LSQry Shelley.GetCurrentPParams)
-
             pp <- onAnyEra
-                (protocolParametersFromUpdateState eraBounds ppNode
+                (protocolParametersFromUpdateState eraBounds
                     <$> LSQry Byron.GetUpdateInterfaceState)
-                (fromShelleyPParams eraBounds ppNode
+                (fromShelleyPParams eraBounds
                     <$> LSQry Shelley.GetCurrentPParams)
-                (fromAllegraPParams eraBounds ppNode
+                (fromAllegraPParams eraBounds
                     <$> LSQry Shelley.GetCurrentPParams)
-                (fromMaryPParams eraBounds ppNode
+                (fromMaryPParams eraBounds
                     <$> LSQry Shelley.GetCurrentPParams)
-                (fromAlonzoPParams eraBounds ppNode
+                (fromAlonzoPParams eraBounds
                     <$> LSQry Shelley.GetCurrentPParams)
-                (fromBabbagePParams eraBounds ppNode
+                (fromBabbagePParams eraBounds
                     <$> LSQry Shelley.GetCurrentPParams)
-                (fromConwayPParams eraBounds ppNode
+                (fromConwayPParams eraBounds
                     <$> LSQry Shelley.GetCurrentPParams)
 
             return (pp, sp)

--- a/lib/wallet/src/Cardano/Wallet/Write/ProtocolParameters.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/ProtocolParameters.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- |
 -- Copyright: © 2023 IOHK
@@ -9,14 +11,10 @@
 --
 module Cardano.Wallet.Write.ProtocolParameters
     ( ProtocolParameters (..)
-    , unsafeFromWalletProtocolParameters
     ) where
 
 import Prelude
 
-import qualified Cardano.Api as CardanoApi
-import qualified Cardano.Api.Extra as CardanoApi
-import qualified Cardano.Wallet.Primitive.Types as Wallet
 import qualified Cardano.Wallet.Write.Tx as Write
 
 -- TODO:
@@ -27,24 +25,6 @@ newtype ProtocolParameters era = ProtocolParameters
         :: Write.PParams (Write.ShelleyLedgerEra era)
     }
 
--- TODO: ADP-2459 - replace with something nicer.
-unsafeFromWalletProtocolParameters
-    :: forall era. CardanoApi.IsShelleyBasedEra era
-    => Wallet.ProtocolParameters
-    -> ProtocolParameters era
-unsafeFromWalletProtocolParameters pparamsWallet = ProtocolParameters $
-    maybe
-        (error missingNodeParamsError)
-        unbundleParameters
-        (Wallet.currentNodeProtocolParameters pparamsWallet)
-  where
-    unbundleParameters
-                = CardanoApi.unbundleLedgerShelleyBasedProtocolParams
-                    (CardanoApi.shelleyBasedEra @era)
-                . CardanoApi.bundleProtocolParams
-                    (CardanoApi.cardanoEra @era)
-    missingNodeParamsError = unwords
-        [ "unsafeFromWalletProtocolParameters: no nodePParams."
-        , "This should only be possible in Byron, where IsShelleyBasedEra"
-        , "should prevent this from being reached."
-        ]
+deriving instance Eq (Write.PParams (Write.ShelleyLedgerEra era)) => Eq (ProtocolParameters era)
+deriving instance Show (Write.PParams (Write.ShelleyLedgerEra era)) => Show (ProtocolParameters era)
+

--- a/lib/wallet/src/Cardano/Wallet/Write/ProtocolParameters.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/ProtocolParameters.hs
@@ -25,6 +25,9 @@ newtype ProtocolParameters era = ProtocolParameters
         :: Write.PParams (Write.ShelleyLedgerEra era)
     }
 
-deriving instance Eq (Write.PParams (Write.ShelleyLedgerEra era)) => Eq (ProtocolParameters era)
-deriving instance Show (Write.PParams (Write.ShelleyLedgerEra era)) => Show (ProtocolParameters era)
-
+deriving instance
+    Eq (Write.PParams (Write.ShelleyLedgerEra era)) =>
+    Eq (ProtocolParameters era)
+deriving instance
+    Show (Write.PParams (Write.ShelleyLedgerEra era)) =>
+    Show (ProtocolParameters era)

--- a/lib/wallet/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/wallet/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -75,6 +75,8 @@ import Data.Time.Clock.POSIX
     ( posixSecondsToUTCTime )
 
 import qualified Cardano.Api.Shelley as C
+import qualified Cardano.Wallet.Write.ProtocolParameters as Write
+import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Data.ByteString.Char8 as B8
 
 {-----------------------------------------------------------------------------
@@ -145,7 +147,10 @@ dummyProtocolParameters = ProtocolParameters
             { pricePerStep = 7.21e-5
             , pricePerMemoryUnit = 0.0577
             }
-    , currentNodeProtocolParameters = Just dummyNodeProtocolParameters
+    , currentLedgerProtocolParameters =
+        Write.InRecentEraBabbage
+        $ Write.ProtocolParameters
+        $ C.toLedgerPParams C.ShelleyBasedEraBabbage dummyNodeProtocolParameters
     }
 
 -- | Dummy parameters that are consistent with the @dummy*@ parameters.

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -230,6 +230,7 @@ import qualified Cardano.Wallet.Address.Discovery.Sequential as Seq
 import qualified Cardano.Wallet.Address.Discovery.Shared as Shared
 import Cardano.Wallet.Address.Keys.WalletKey
     ( getRawKey, liftRawKey, publicKey )
+import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -723,7 +724,7 @@ instance Arbitrary ProtocolParameters where
         <*> genMaximumCollateralInputCount
         <*> genMinimumCollateralPercentage
         <*> arbitrary
-        <*> pure Nothing
+        <*> pure Write.InNonRecentEraAlonzo
       where
         genMaximumCollateralInputCount :: Gen Word16
         genMaximumCollateralInputCount = arbitrarySizedNatural

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1976,8 +1976,8 @@ dummyProtocolParameters = ProtocolParameters
         error "dummyProtocolParameters: minimumCollateralPercentage"
     , executionUnitPrices =
         error "dummyProtocolParameters: executionUnitPrices"
-    , currentNodeProtocolParameters =
-        error "dummyProtocolParameters: currentNodeProtocolParameters"
+    , currentLedgerProtocolParameters =
+        error "dummyProtocolParameters: currentLedgerProtocolParameters"
     }
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
### Comments

- Seem to save 15-30 ms per postTransaction call.
- Code becomes nicer with `PParams era` as only source of era
- Requires (minor) API breaking change in `balanceTx` to drop support for balancing in future eras (by e.g. upcasting the PParams) -> done by #3923 
- No performance gains in e.g. `postTransactionFee`, so not highest priority to complete

### Issue Number

ADP-2990
