### PR TITLE
Add latency benchmark for a 10k utxo wallet

### DIFF
--- a/lib/wallet/bench/latency-bench.hs
+++ b/lib/wallet/bench/latency-bench.hs
@@ -22,6 +22,8 @@ import Cardano.BM.Trace
     ( traceInTVarIO )
 import Cardano.CLI
     ( Port (..) )
+import Cardano.Mnemonic
+    ( Mnemonic, SomeMnemonic (..), mnemonicToText )
 import Cardano.Startup
     ( withUtf8Encoding )
 import Cardano.Wallet.Api.Types
@@ -59,6 +61,8 @@ import Cardano.Wallet.Pools
     ( StakePool )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Read.NetworkId
@@ -70,7 +74,7 @@ import Cardano.Wallet.Shelley.BlockchainSource
 import Cardano.Wallet.Shelley.Faucet
     ( initFaucet )
 import Cardano.Wallet.Unsafe
-    ( unsafeFromText )
+    ( unsafeFromText, unsafeMkMnemonic )
 import Control.Monad
     ( replicateM, replicateM_ )
 import Control.Monad.IO.Class
@@ -83,6 +87,8 @@ import Data.Generics.Internal.VL.Lens
     ( (^.) )
 import Data.List.NonEmpty
     ( NonEmpty ((:|)) )
+import Fmt
+    ( build )
 import Network.HTTP.Client
     ( defaultManagerSettings
     , managerResponseTimeout
@@ -104,6 +110,7 @@ import Test.Hspec
     ( shouldBe )
 import Test.Integration.Faucet
     ( byronIntegrationTestFunds
+    , genShelleyAddresses
     , maryIntegrationTestAssets
     , shelleyIntegrationTestFunds
     )
@@ -121,10 +128,12 @@ import Test.Integration.Framework.DSL
     , fixturePassphrase
     , fixtureWallet
     , fixtureWalletWith
+    , getFromResponse
     , json
     , minUTxOValue
     , mkTxPayloadMA
     , pickAnAsset
+    , postWallet
     , request
     , runResourceT
     , unsafeRequest
@@ -139,6 +148,7 @@ import UnliftIO.STM
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Text as T
 import qualified Network.HTTP.Types.Status as HTTP
 
 main :: forall n. (n ~ 'Mainnet) => IO ()
@@ -199,6 +209,10 @@ walletApiBench capture ctx = do
 
     fmtTitle "Latencies for 2 fixture wallets with 1000 utxos scenario"
     runScenario (nFixtureWalletWithUTxOs 2 1_000)
+    fmtTitle $ "Latencies for 2 fixture wallets with "
+        <> build massiveWalletUTxOSize
+        <> " utxos scenario"
+    runScenario massiveFixtureWallet
   where
 
     -- Creates n fixture wallets and return 3 of them
@@ -250,6 +264,27 @@ walletApiBench capture ctx = do
                 (Link.getUTxOsStatistics @'Shelley wal1) Default Empty
         expectResponseCode HTTP.status200 rStat
         expectWalletUTxO (fromIntegral <$> utxoExp) (snd rStat)
+        pure (wal1, wal2, walMA, maWalletToMigrate)
+
+    massiveFixtureWallet = do
+        (_, wal2, walMA, maWalletToMigrate) <- nFixtureWallet 2
+        let payload = Json [json| {
+                "name": "Massive wallet",
+                "mnemonic_sentence": #{mnemonicToText massiveWallet},
+                "passphrase": #{fixturePassphrase},
+                "address_pool_gap": #{massiveWalletUTxOSize}
+                } |]
+        -- Because the funds for the wallet is located in the genesis file, it
+        -- will be discovered as part of the postWallet call, and we don't need
+        -- to wait with 'eventually'.
+        rWal <- postWallet ctx payload
+        verify rWal
+            [ expectSuccess
+            , expectField
+                    (#balance . #available . #getQuantity)
+                    (`shouldBe` (fromIntegral massiveWalletUTxOSize * unCoin massiveWalletAmt))
+            ]
+        let wal1 = getFromResponse Prelude.id rWal
         pure (wal1, wal2, walMA, maWalletToMigrate)
 
     repeatPostTx wDest amtToSend batchSize amtExp = do
@@ -465,6 +500,7 @@ withShelleyServer tracers action = do
         { pureAdaFunds =
             shelleyIntegrationTestFunds
              <> byronIntegrationTestFunds
+             <> massiveWalletFunds
         , maFunds =
             maryIntegrationTestAssets (Coin 10_000_000)
         , mirFunds = [] -- not needed
@@ -488,6 +524,28 @@ withShelleyServer tracers action = do
             Nothing
             block0
             (act np)
+
+-- | A special Shelley Wallet with a massive UTxO set
+massiveWallet :: Mnemonic 15
+massiveWallet = unsafeMkMnemonic $ T.words
+    "interest ready music wet trophy ten boss topple fitness fold \
+    \saddle finish update someone pause"
+
+massiveWalletUTxOSize :: Int
+massiveWalletUTxOSize = 10_000
+
+massiveWalletFunds :: [(Address, Coin)]
+massiveWalletFunds =
+    take massiveWalletUTxOSize
+    . map (, massiveWalletAmt)
+    . genShelleyAddresses
+    . SomeMnemonic
+    $ massiveWallet
+
+massiveWalletAmt :: Coin
+massiveWalletAmt = ada 1_000
+  where
+    ada x = Coin $ x * 1000_000
 
 era :: ApiEra
 era = maxBound

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -1018,6 +1018,7 @@ benchmark latency
   build-depends:
     , aeson
     , base
+    , cardano-addresses
     , cardano-wallet
     , cardano-wallet-api-http
     , cardano-wallet-integration


### PR DESCRIPTION
- [x] Add new scenario for a 10k utxo wallet in the latency benchmark

### Comments

That said, I'm not completely sure how realistic 10k UTxOs would be and whether it's worth testing or not.

#### Without balanceTx https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1774#0187a34f-135d-4bc6-acdd-90fdcf2fdf53

```
Latencies for 2 fixture wallets with 10000 utxos scenario
    postTransaction     - 535.9 ms
```


#### With balanceTx https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1775#0187a34f-bd45-4433-a26d-660acf7ba506

```
Latencies for 2 fixture wallets with 10000 utxos scenario
    postTransaction     - 717.3 ms
```

### Issue Number

ADP-2268, #3746 
