### PR TITLE
[ADP-2565] Move `QueryStore` to `delta-store` library

### DIFF
--- a/lib/delta-store/delta-store.cabal
+++ b/lib/delta-store/delta-store.cabal
@@ -46,6 +46,7 @@ library
   exposed-modules:
       Data.DBVar
       Data.Store
+      Data.QueryStore
       Test.Store
 
 test-suite unit

--- a/lib/delta-store/src/Data/QueryStore.hs
+++ b/lib/delta-store/src/Data/QueryStore.hs
@@ -3,7 +3,10 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Cardano.Wallet.DB.Store.QueryStore
+-- |
+-- Copyright: © 2023 IOHK
+-- License: Apache-2.0
+module Data.QueryStore
     ( QueryStore (..)
     , Query (..)
     , queryStoreProperty

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -256,7 +256,6 @@ library
     Cardano.Wallet.DB.Store.Meta.Layer
     Cardano.Wallet.DB.Store.Meta.Model
     Cardano.Wallet.DB.Store.Meta.Store
-    Cardano.Wallet.DB.Store.QueryStore
     Cardano.Wallet.DB.Store.Submissions.Layer
     Cardano.Wallet.DB.Store.Submissions.Operations
     Cardano.Wallet.DB.Store.Transactions.Decoration

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -106,8 +106,6 @@ import Cardano.Wallet.DB.Store.Checkpoints
     ( PersistAddressBook (..), blockHeaderFromEntity, mkStoreWallets )
 import Cardano.Wallet.DB.Store.Meta.Model
     ( mkTxMetaFromEntity )
-import Cardano.Wallet.DB.Store.QueryStore
-    ( QueryStore (..) )
 import Cardano.Wallet.DB.Store.Submissions.Layer
     ( pruneByFinality, rollBackSubmissions )
 import Cardano.Wallet.DB.Store.Submissions.Operations
@@ -174,6 +172,8 @@ import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
     ( Quantity (..) )
+import Data.QueryStore
+    ( QueryStore (..) )
 import Data.Store
     ( Store (..) )
 import Data.Text

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Layer.hs
@@ -22,8 +22,6 @@ import Cardano.Wallet.DB.Store.Meta.Model
     ( DeltaTxMetaHistory, TxMetaHistory (..) )
 import Cardano.Wallet.DB.Store.Meta.Store
     ( mkStoreMetaTransactions )
-import Cardano.Wallet.DB.Store.QueryStore
-    ( Query (..), QueryStore (..) )
 import Cardano.Wallet.Primitive.Types
     ( Range (..), SortOrder (..) )
 import Data.Foldable
@@ -34,6 +32,8 @@ import Data.Maybe
     ( catMaybes )
 import Data.Ord
     ( Down (..) )
+import Data.QueryStore
+    ( Query (..), QueryStore (..) )
 import Data.Set
     ( Set )
 import Database.Persist.Sql

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Layer.hs
@@ -22,14 +22,14 @@ import Cardano.Wallet.DB.Sqlite.Schema
     ( CBOR )
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId )
-import Cardano.Wallet.DB.Store.QueryStore
-    ( Query (..), QueryStore (..) )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( DeltaTxSet, TxRelation (..), TxSet (..), fromTxCollateralOut, fromTxOut )
 import Control.Applicative
     ( (<|>) )
 import Data.Maybe
     ( maybeToList )
+import Data.QueryStore
+    ( Query (..), QueryStore (..) )
 import Data.Word
     ( Word32 )
 import Database.Persist.Sql

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -26,8 +26,6 @@ import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..) )
 import Cardano.Wallet.DB.Store.Meta.Layer
     ( QueryTxMeta (..), mkQueryStoreTxMeta )
-import Cardano.Wallet.DB.Store.QueryStore
-    ( QueryStore (..) )
 import Cardano.Wallet.DB.Store.Transactions.Layer
     ( mkQueryStoreTxSet )
 import Cardano.Wallet.DB.Store.Transactions.Model
@@ -38,6 +36,8 @@ import Cardano.Wallet.DB.Store.Wallets.Store
     ( mkStoreTxWalletsHistory )
 import Cardano.Wallet.Primitive.Types
     ( Range (..), SortOrder )
+import Data.QueryStore
+    ( QueryStore (..) )
 import Data.Word
     ( Word32 )
 import Database.Persist.Sql

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -23,14 +23,14 @@ import Cardano.Wallet.DB.Store.Meta.Layer
     ( QueryTxMeta (..) )
 import Cardano.Wallet.DB.Store.Meta.Model
     ( DeltaTxMetaHistory, mkTxMetaHistory )
-import Cardano.Wallet.DB.Store.QueryStore
-    ( QueryStore (..) )
 import Cardano.Wallet.DB.Store.Transactions.Model
     ( DeltaTxSet (..), mkTxSet )
 import Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaTxWalletsHistory (..) )
 import Control.Applicative
     ( liftA2 )
+import Data.QueryStore
+    ( QueryStore (..) )
 import Data.Store
     ( Store (..) )
 import Database.Persist.Sql

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Fixtures.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Fixtures.hs
@@ -33,8 +33,6 @@ import Cardano.Wallet.DB.Sqlite.Schema
     ( Wallet (..), migrateAll )
 import Cardano.Wallet.DB.Sqlite.Types
     ( BlockId (..) )
-import Cardano.Wallet.DB.Store.QueryStore
-    ( Query (..), QueryStore (..), World )
 import Cardano.Wallet.Primitive.Types
     ( WalletId (..) )
 import Cardano.Wallet.Primitive.Types.Hash
@@ -49,6 +47,8 @@ import Data.Delta
     ( Delta (Base) )
 import Data.Either
     ( fromRight )
+import Data.QueryStore
+    ( Query (..), QueryStore (..), World )
 import Data.Store
     ( Store (loadS, updateS) )
 import Data.Time.Clock

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/StoreSpec.hs
@@ -35,14 +35,14 @@ import Cardano.Wallet.DB.Store.Meta.ModelSpec
     ( genExpand, genRollback )
 import Cardano.Wallet.DB.Store.Meta.Store
     ( mkStoreMetaTransactions )
-import Cardano.Wallet.DB.Store.QueryStore
-    ( QueryStore (..) )
 import Cardano.Wallet.Primitive.Types
     ( Range (..), SortOrder (Ascending, Descending), WalletId )
 import Control.Monad
     ( forM_, (<=<) )
 import Data.Foldable
     ( toList )
+import Data.QueryStore
+    ( QueryStore (..) )
 import Data.Store
     ( Store (..) )
 import GHC.Natural

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -27,8 +27,6 @@ import Cardano.Wallet.DB.Fixtures
     )
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (TxId) )
-import Cardano.Wallet.DB.Store.QueryStore
-    ( QueryStore (..) )
 import Cardano.Wallet.DB.Store.Transactions.Decoration
     ( DecoratedTxIns
     , decorateTxInsForRelation
@@ -56,6 +54,8 @@ import Data.Functor.Identity
     ( Identity (..) )
 import Data.Generics.Internal.VL
     ( set )
+import Data.QueryStore
+    ( QueryStore (..) )
 import Data.Store
     ( Store (..) )
 import Test.Hspec

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/LayerSpec.hs
@@ -13,12 +13,12 @@ import Cardano.DB.Sqlite
     ( ForeignKeysSetting (..) )
 import Cardano.Wallet.DB.Fixtures
     ( WalletProperty, logScale, withDBInMemory, withInitializedWalletProp )
-import Cardano.Wallet.DB.Store.QueryStore
-    ( QueryStore (store) )
 import Cardano.Wallet.DB.Store.Wallets.Layer
     ( newQueryStoreTxWalletsHistory )
 import Cardano.Wallet.DB.Store.Wallets.StoreSpec
     ( genDeltaTxWallets )
+import Data.QueryStore
+    ( QueryStore (store) )
 import Test.Hspec
     ( Spec, around, describe, it )
 import Test.QuickCheck


### PR DESCRIPTION
### Overview

This pull request renames the module `Cardano.Wallet.DB.Store.QueryStore` to `Data.QueryStore` and moves it into the `delta-store` library.

This pull request is a pure refactoring.

### Issue number

ADP-2565