### PR TITLE
`balanceTx` uses pure `TimeTranslation` instead of an impure `TimeInterpreter`

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -385,6 +385,7 @@ library
     Cardano.Wallet.Write.Tx
     Cardano.Wallet.Write.Tx.Balance
     Cardano.Wallet.Write.Tx.Gen
+    Cardano.Wallet.Write.Tx.TimeTranslation
     Control.Concurrent.Concierge
     Control.Monad.Exception.Unchecked
     Control.Monad.Util

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/TimeTranslation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/TimeTranslation.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData #-}
+
+module Cardano.Wallet.Write.Tx.TimeTranslation
+    ( TimeTranslation
+    , timeTranslationFromEpochInfo
+    , systemStartTime
+    , epochInfo
+    ) where
+
+import Prelude
+
+import Cardano.Slotting.EpochInfo
+    ( EpochInfo )
+import Cardano.Slotting.Time
+    ( SystemStart )
+import Ouroboros.Consensus.HardFork.History
+    ( PastHorizonException )
+
+data TimeTranslation = TimeTranslation
+    (EpochInfo (Either PastHorizonException))
+    SystemStart
+
+timeTranslationFromEpochInfo
+    :: SystemStart
+    -> EpochInfo (Either PastHorizonException)
+    -> TimeTranslation
+timeTranslationFromEpochInfo systemStart info =
+    TimeTranslation info systemStart
+
+systemStartTime :: TimeTranslation -> SystemStart
+systemStartTime (TimeTranslation _epochInfo systemStart) = systemStart
+
+epochInfo :: TimeTranslation -> EpochInfo (Either PastHorizonException)
+epochInfo (TimeTranslation info _systemStart) = info


### PR DESCRIPTION
- [x] Create `TimeTranslation` opaque data type as a purer replacement for the `TimeInterpreter`
- [x] Provide a [temporary] constructor to create `TimeTranslation` from a `TimeInterpreter`
- [x] Replace usages of `TimeInterpreter` with the `TimeTranslation`

### Issue Number

ADP-2968
