### PR TITLE
Evaluate `UTxOIndex` value to WHNF outside of `transactionFee` loop.

### DIFF
--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -614,7 +614,7 @@ import Statistics.Quantile
 import System.Random.StdGenSeed
     ( StdGenSeed (..), stdGenFromSeed, stdGenSeed )
 import UnliftIO.Exception
-    ( Exception, catch, throwIO )
+    ( Exception, catch, evaluate, throwIO )
 import UnliftIO.MVar
     ( modifyMVar_, newMVar )
 
@@ -2943,8 +2943,10 @@ transactionFee DBLayer{atomically, walletsDB} protocolParams txLayer
                     $ ExceptionNoSuchWallet
                     $ ErrNoSuchWallet walletId
                 Just ws -> pure $ WalletState.getLatest ws
-        let utxoIndex = UTxOIndex.fromMap . CS.toInternalUTxOMap $
-                availableUTxO @s mempty wallet
+        utxoIndex <- evaluate
+            $ UTxOIndex.fromMap
+            $ CS.toInternalUTxOMap
+            $ availableUTxO @s mempty wallet
         unsignedTxBody <- wrapErrMkTransaction $
             mkUnsignedTransaction txLayer @era
                 (Left $ unsafeShelleyOnlyGetRewardXPub @s @k @n (getState wallet))

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2943,10 +2943,25 @@ transactionFee DBLayer{atomically, walletsDB} protocolParams txLayer
                     $ ExceptionNoSuchWallet
                     $ ErrNoSuchWallet walletId
                 Just ws -> pure $ WalletState.getLatest ws
-        utxoIndex <- evaluate
-            $ UTxOIndex.fromMap
-            $ CS.toInternalUTxOMap
-            $ availableUTxO @s mempty wallet
+        utxoIndex <-
+            -- Important:
+            --
+            -- Since it's potentially expensive to construct a UTxO index, we
+            -- really want to avoid constructing the index more than once.
+            --
+            -- In order to avoid accidentally passing an unevaluated thunk to
+            -- the 'calculateFeePercentiles' function (which might lead to
+            -- repeatedly evaluating the index on every iteration of the fee
+            -- calculation loop), we first evaluate the index to WHNF.
+            --
+            -- Evaluating to WHNF should be enough to ensure that the index is
+            -- fully evaluated, as all fields of the 'UTxOIndex' type are
+            -- strict, and each field is defined in terms of 'Data.Map.Strict'.
+            --
+            evaluate
+                $ UTxOIndex.fromMap
+                $ CS.toInternalUTxOMap
+                $ availableUTxO @s mempty wallet
         unsignedTxBody <- wrapErrMkTransaction $
             mkUnsignedTransaction txLayer @era
                 (Left $ unsafeShelleyOnlyGetRewardXPub @s @k @n (getState wallet))


### PR DESCRIPTION
## Issue

ADP-2975

## Summary

This PR adjusts `transactionFee` so that the `UTxOIndex` value is evaluated to WHNF before evaluating `calculateFeePercentiles`.

As a result, the total time to evaluate `postTransactionFee` is reduced by approximately 55% in the case of a wallet with 1,000 ada-only UTxOs.

## Details

The `UTxOIndex` type is a record with strict fields, where each field is defined in terms of the `Data.Map.Strict` data type.

Therefore, evaluating a value of type `UTxOIndex` to WHNF should be enough to ensure that all constituent fields are fully evaluated, assuming of course that there are no unevaluated thunks within the internal maps.

## Benchmark Results

Detailed benchmark results shown below (everything compiled with `-O2`):

### Before
```
    Latencies for 2 fixture wallets with 100 utxos scenario
        postTransactionFee  - 78.4 ms
        postTransactionFee  - 77.5 ms
        postTransactionFee  - 69.2 ms
        postTransactionFee  - 68.4 ms
    Latencies for 2 fixture wallets with 200 utxos scenario
        postTransactionFee  - 92.1 ms
        postTransactionFee  - 98.4 ms
        postTransactionFee  - 101.1 ms
        postTransactionFee  - 106.5 ms
    Latencies for 2 fixture wallets with 500 utxos scenario
        postTransactionFee  - 225.7 ms
        postTransactionFee  - 209.6 ms
        postTransactionFee  - 206.4 ms
        postTransactionFee  - 222.3 ms
    Latencies for 2 fixture wallets with 1000 utxos scenario
        postTransactionFee  - 396.9 ms
        postTransactionFee  - 426.3 ms
        postTransactionFee  - 412.7 ms
        postTransactionFee  - 385.2 ms
```

### After
```
    Latencies for 2 fixture wallets with 100 utxos scenario
        postTransactionFee  - 59.4 ms
        postTransactionFee  - 57.6 ms
        postTransactionFee  - 55.7 ms
        postTransactionFee  - 56.6 ms
    Latencies for 2 fixture wallets with 200 utxos scenario
        postTransactionFee  - 67.9 ms
        postTransactionFee  - 70.3 ms
        postTransactionFee  - 70.9 ms
        postTransactionFee  - 72.6 ms
    Latencies for 2 fixture wallets with 500 utxos scenario
        postTransactionFee  - 104.3 ms
        postTransactionFee  - 103.4 ms
        postTransactionFee  - 105.9 ms
        postTransactionFee  - 101.9 ms
    Latencies for 2 fixture wallets with 1000 utxos scenario
        postTransactionFee  - 197.9 ms
        postTransactionFee  - 172.4 ms
        postTransactionFee  - 189.8 ms
        postTransactionFee  - 178.1 ms
```