### PR TITLE
Remove `distributeSurplus`'s indirect dependency on `W.ProtocolParameters`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1623,7 +1623,6 @@ estimateTxCost era pp skeleton =
         let LinearFee LinearFunction {..} = getFeePolicy $ txParameters pp
         in Coin $ ceiling $ intercept + slope * fromIntegral size
 
-
 -- | Calculate the cost of increasing a CBOR-encoded Coin-value by another Coin
 -- with the lovelace/byte cost given by the 'FeePolicy'.
 --

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -851,6 +851,7 @@ toCardanoValue = withConstraints (recentEra @era) Cardano.fromMaryValue
 -- PParams
 --------------------------------------------------------------------------------
 
+-- | The 'minfeeA' protocol parameter in unit @lovelace/byte@.
 newtype FeePerByte = FeePerByte Natural
     deriving (Show, Eq)
 

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -68,7 +68,7 @@ module Cardano.Wallet.Write.Tx
     -- * PParams
     , Core.PParams
     , FeePerByte (..)
-    , feePerByte
+    , getFeePerByte
 
     -- * Tx
     , Core.Tx
@@ -854,11 +854,11 @@ toCardanoValue = withConstraints (recentEra @era) Cardano.fromMaryValue
 newtype FeePerByte = FeePerByte Natural
     deriving (Show, Eq)
 
-feePerByte
+getFeePerByte
     :: RecentEra era
     -> Core.PParams (Cardano.ShelleyLedgerEra era)
     -> FeePerByte
-feePerByte era pp = FeePerByte $ case era of
+getFeePerByte era pp = FeePerByte $ case era of
     RecentEraConway -> pp ^. #_minfeeA
     RecentEraBabbage -> pp ^. #_minfeeA
 
@@ -883,11 +883,11 @@ evaluateMinimumFee era pp tx kwc =
     mainFee = withConstraints era $
         Shelley.evaluateTransactionFee pp tx nKeyWits
 
-    FeePerByte feePerByte' = feePerByte era pp
+    FeePerByte feePerByte = getFeePerByte era pp
 
     bootWitnessFee :: Coin
     bootWitnessFee = Coin $
-        intCast $ feePerByte' * byteCount
+        intCast $ feePerByte * byteCount
       where
         byteCount :: Natural
         byteCount = sizeOf_BootstrapWitnesses $ intCast nBootstrapWits

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -132,7 +132,7 @@ import Cardano.Wallet.Write.Tx
     , ShelleyLedgerEra
     , TxOut
     , computeMinimumCoinForTxOut
-    , feePerByte
+    , getFeePerByte
     , modifyLedgerBody
     , modifyTxOutCoin
     , modifyTxOutputs
@@ -657,7 +657,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             (unsafeFromLovelace candidateMinFee)
             (extraOutputs)
 
-    let feePerByte' = feePerByte (recentEra @era) ledgerPP
+    let feePerByte = getFeePerByte (recentEra @era) ledgerPP
 
     -- @distributeSurplus@ should never fail becase we have provided enough
     -- padding in @selectAssets'@.
@@ -666,7 +666,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             ErrBalanceTxInternalError $
                 ErrUnderestimatedFee c (toSealed candidateTx) witCount)
         (ExceptT . pure $
-            distributeSurplus feePerByte' surplus feeAndChange)
+            distributeSurplus feePerByte surplus feeAndChange)
 
     fmap (, s') . guardTxSize witCount =<< guardTxBalanced =<< assembleTransaction
         TxUpdate

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -132,6 +132,7 @@ import Cardano.Wallet.Write.Tx
     , ShelleyLedgerEra
     , TxOut
     , computeMinimumCoinForTxOut
+    , feePerByte
     , modifyLedgerBody
     , modifyTxOutCoin
     , modifyTxOutputs
@@ -655,7 +656,8 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     let feeAndChange = TxFeeAndChange
             (unsafeFromLovelace candidateMinFee)
             (extraOutputs)
-    let feePolicy = view (#txParameters . #getFeePolicy) pp
+
+    let feePerByte' = feePerByte (recentEra @era) ledgerPP
 
     -- @distributeSurplus@ should never fail becase we have provided enough
     -- padding in @selectAssets'@.
@@ -664,7 +666,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             ErrBalanceTxInternalError $
                 ErrUnderestimatedFee c (toSealed candidateTx) witCount)
         (ExceptT . pure $
-            distributeSurplus feePolicy surplus feeAndChange)
+            distributeSurplus feePerByte' surplus feeAndChange)
 
     fmap (, s') . guardTxSize witCount =<< guardTxBalanced =<< assembleTransaction
         TxUpdate

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -286,6 +286,7 @@ import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Cardano.Wallet.Write.Tx
     ( AnyRecentEra (..)
+    , FeePerByte (..)
     , RecentEra (..)
     , cardanoEraFromRecentEra
     , recentEra
@@ -464,6 +465,7 @@ import Test.QuickCheck.Extra
     , genNonEmpty
     , report
     , shrinkBoundedEnum
+    , shrinkNatural
     , shrinkNonEmpty
     , (.>=.)
     )
@@ -2805,16 +2807,14 @@ distributeSurplusSpec = do
     describe "costOfIncreasingCoin" $ do
         it "costs 176 lovelace to increase 4294.967295 ada (2^32 - 1 lovelace) \
            \by 1 lovelace on mainnet" $ do
-            let feePolicy = LinearFee $ LinearFunction
-                    { intercept = 150_000, slope = 44 }
             let expectedCostIncrease = Coin 176
-            costOfIncreasingCoin feePolicy (Coin $ 2 `power` 32 - 1) (Coin 1)
+            let mainnet = mainnetFeePerByte
+            costOfIncreasingCoin mainnet (Coin $ 2 `power` 32 - 1) (Coin 1)
                 `shouldBe` expectedCostIncrease
 
         it "produces results in the range [0, 8 * feePerByte]" $
             property $ \c increase -> do
-                let feePolicy = LinearFee $ LinearFunction 1 0
-                let res = costOfIncreasingCoin feePolicy c increase
+                let res = costOfIncreasingCoin (FeePerByte 1) c increase
                 counterexample (show res <> "out of bounds") $
                     res >= Coin 0 && res <= Coin 8
 
@@ -2850,18 +2850,13 @@ distributeSurplusSpec = do
 
     describe "distributeSurplusDelta" $ do
 
-        let simplestFeePolicy = LinearFee $ LinearFunction
-                { intercept = 0, slope = 1 }
-        let mainnetFeePolicy = LinearFee $ LinearFunction
-                { intercept = 150_000, slope = 44 }
-
         -- NOTE: The test values below make use of 255 being encoded as 2 bytes,
         -- and 256 as 3 bytes.
 
         describe "when increasing change increases fee" $
             it "will increase fee (99 lovelace for change, 1 for fee)" $
                 distributeSurplusDelta
-                    simplestFeePolicy
+                    (FeePerByte 1)
                     (Coin 100)
                     (TxFeeAndChange (Coin 200) [Coin 200])
                     `shouldBe`
@@ -2870,7 +2865,7 @@ distributeSurplusSpec = do
         describe "when increasing fee increases fee" $
             it "will increase fee (98 lovelace for change, 2 for fee)" $ do
                 distributeSurplusDelta
-                    simplestFeePolicy
+                    (FeePerByte 1)
                     (Coin 100)
                     (TxFeeAndChange (Coin 255) [Coin 200])
                     `shouldBe`
@@ -2883,7 +2878,7 @@ distributeSurplusSpec = do
                 ]) $ do
             it "will try burning the surplus as fees" $ do
                 distributeSurplusDelta
-                    mainnetFeePolicy
+                    mainnetFeePerByte
                     (Coin 10)
                     (TxFeeAndChange (Coin 200) [Coin 255])
                     `shouldBe`
@@ -2891,7 +2886,7 @@ distributeSurplusSpec = do
 
             it "will fail if neither the fee can be increased" $ do
                 distributeSurplusDelta
-                    mainnetFeePolicy
+                    mainnetFeePerByte
                     (Coin 10)
                     (TxFeeAndChange (Coin 255) [Coin 255])
                     `shouldBe`
@@ -2901,7 +2896,7 @@ distributeSurplusSpec = do
             it "will burn surplus as excess fees" $
                 property $ \surplus fee0 -> do
                     distributeSurplusDelta
-                        simplestFeePolicy
+                        (FeePerByte 1)
                         surplus
                         (TxFeeAndChange fee0 [])
                         `shouldBe`
@@ -2921,7 +2916,7 @@ distributeSurplusSpec = do
 --        - feeDelta + sum changeDeltas == surplus
 --
 prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
-    :: FeePolicy -> Coin -> Coin -> [Coin] -> Property
+    :: FeePerByte -> Coin -> Coin -> [Coin] -> Property
 prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
     feePolicy surplus fee0 change0 =
     checkCoverage $
@@ -2962,31 +2957,24 @@ prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
 -- Properties for 'distributeSurplus'
 --------------------------------------------------------------------------------
 
-instance Arbitrary FeePolicy where
+instance Arbitrary FeePerByte where
     arbitrary = frequency
-        [ (1, feePolicyMainnet)
-        , (7, feePolicyGeneral)
+        [ (1, pure mainnetFeePerByte)
+        , (7, anyFeePerByte)
         ]
       where
-        feePolicyMainnet :: Gen FeePolicy
-        feePolicyMainnet = pure $ LinearFee $ LinearFunction
-            {intercept = 150_000, slope = 44}
-
-        feePolicyGeneral :: Gen FeePolicy
-        feePolicyGeneral = do
-            intercept <- frequency
-                [ (1, pure 0.0)
-                , (3, getPositive <$> arbitrary)
+        anyFeePerByte :: Gen FeePerByte
+        anyFeePerByte = FeePerByte <$>
+            frequency
+                [ (1, pure 0)
+                , (3, fromIntegral @Int @Natural . getPositive <$> arbitrary)
                 ]
-            slope <- frequency
-                [ (1, pure 0.0)
-                , (3, getPositive <$> arbitrary)
-                ]
-            pure $ LinearFee LinearFunction {intercept, slope}
 
-    shrink (LinearFee LinearFunction {intercept, slope}) =
-        LinearFee . uncurry LinearFunction
-            <$> shrink (intercept, slope)
+    shrink (FeePerByte x) =
+        FeePerByte <$> shrinkNatural x
+
+mainnetFeePerByte :: FeePerByte
+mainnetFeePerByte = FeePerByte 44
 
 newtype TxBalanceSurplus a = TxBalanceSurplus {unTxBalanceSurplus :: a}
     deriving (Eq, Show)
@@ -3022,12 +3010,12 @@ instance Arbitrary (TxFeeAndChange [TxOut]) where
 --
 prop_distributeSurplus_onSuccess
     :: Testable prop
-    => (FeePolicy
+    => (FeePerByte
         -> Coin
         -> TxFeeAndChange [TxOut]
         -> TxFeeAndChange [TxOut]
         -> prop)
-    -> FeePolicy
+    -> FeePerByte
     -> TxBalanceSurplus Coin
     -> TxFeeAndChange [TxOut]
     -> Property
@@ -3079,7 +3067,7 @@ prop_distributeSurplus_onSuccess propertyToTest policy txSurplus fc =
 -- to the given surplus.
 --
 prop_distributeSurplus_onSuccess_conservesSurplus
-    :: FeePolicy -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
+    :: FeePerByte -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
 prop_distributeSurplus_onSuccess_conservesSurplus =
     prop_distributeSurplus_onSuccess $ \_policy surplus
         (TxFeeAndChange feeOriginal changeOriginal)
@@ -3095,7 +3083,7 @@ prop_distributeSurplus_onSuccess_conservesSurplus =
 -- fee value should have increased by at least 𝛿c.
 --
 prop_distributeSurplus_onSuccess_coversCostIncrease
-    :: FeePolicy -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
+    :: FeePerByte -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
 prop_distributeSurplus_onSuccess_coversCostIncrease =
     prop_distributeSurplus_onSuccess $ \policy _surplus
         (TxFeeAndChange feeOriginal changeOriginal)
@@ -3116,7 +3104,7 @@ prop_distributeSurplus_onSuccess_coversCostIncrease =
 -- decrease.
 --
 prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues
-    :: FeePolicy -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
+    :: FeePerByte -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
 prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues =
     prop_distributeSurplus_onSuccess $ \_policy _surplus
         (TxFeeAndChange _feeOriginal changeOriginal)
@@ -3129,7 +3117,7 @@ prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues =
 -- less than the original value.
 --
 prop_distributeSurplus_onSuccess_doesNotReduceFeeValue
-    :: FeePolicy -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
+    :: FeePerByte -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
 prop_distributeSurplus_onSuccess_doesNotReduceFeeValue =
     prop_distributeSurplus_onSuccess $ \_policy _surplus
         (TxFeeAndChange feeOriginal _changeOriginal)
@@ -3141,7 +3129,7 @@ prop_distributeSurplus_onSuccess_doesNotReduceFeeValue =
 -- destroy change outputs.
 --
 prop_distributeSurplus_onSuccess_preservesChangeLength
-    :: FeePolicy -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
+    :: FeePerByte -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
 prop_distributeSurplus_onSuccess_preservesChangeLength =
     prop_distributeSurplus_onSuccess $ \_policy _surplus
         (TxFeeAndChange _feeOriginal changeOriginal)
@@ -3152,7 +3140,7 @@ prop_distributeSurplus_onSuccess_preservesChangeLength =
 -- outputs.
 --
 prop_distributeSurplus_onSuccess_preservesChangeAddresses
-    :: FeePolicy -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
+    :: FeePerByte -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
 prop_distributeSurplus_onSuccess_preservesChangeAddresses =
     prop_distributeSurplus_onSuccess $ \_policy _surplus
         (TxFeeAndChange _feeOriginal changeOriginal)
@@ -3164,7 +3152,7 @@ prop_distributeSurplus_onSuccess_preservesChangeAddresses =
 -- assets.
 --
 prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets
-    :: FeePolicy -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
+    :: FeePerByte -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
 prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets =
     prop_distributeSurplus_onSuccess $ \_policy _surplus
         (TxFeeAndChange _feeOriginal changeOriginal)
@@ -3185,7 +3173,7 @@ prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets =
 -- value, as expected.
 --
 prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue
-    :: FeePolicy -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
+    :: FeePerByte -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
 prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue =
     prop_distributeSurplus_onSuccess $ \_policy _surplus
         (TxFeeAndChange _feeOriginal changeOriginal)
@@ -3203,7 +3191,7 @@ prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue =
 -- original fee and change values.
 --
 prop_distributeSurplus_onSuccess_increasesValuesByDelta
-    :: FeePolicy -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
+    :: FeePerByte -> TxBalanceSurplus Coin -> TxFeeAndChange [TxOut] -> Property
 prop_distributeSurplus_onSuccess_increasesValuesByDelta =
     prop_distributeSurplus_onSuccess $ \policy surplus
         (TxFeeAndChange feeOriginal changeOriginal)

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -426,11 +426,11 @@ import Test.QuickCheck
     , Blind (..)
     , InfiniteList (..)
     , NonEmptyList (..)
-    , Positive (..)
     , Property
     , Testable
     , arbitraryBoundedEnum
     , arbitraryPrintableChar
+    , arbitrarySizedNatural
     , checkCoverage
     , choose
     , classify
@@ -2960,15 +2960,8 @@ prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
 instance Arbitrary FeePerByte where
     arbitrary = frequency
         [ (1, pure mainnetFeePerByte)
-        , (7, anyFeePerByte)
+        , (7, FeePerByte <$> arbitrarySizedNatural)
         ]
-      where
-        anyFeePerByte :: Gen FeePerByte
-        anyFeePerByte = FeePerByte <$>
-            frequency
-                [ (1, pure 0)
-                , (3, fromIntegral @Int @Natural . getPositive <$> arbitrary)
-                ]
 
     shrink (FeePerByte x) =
         FeePerByte <$> shrinkNatural x


### PR DESCRIPTION
- [x] Take a `FeePerByte` instead of `FeePolicy` in `distributeSurplus`
- [x] Add function `feePerByte :: RecentEra era -> PParam era -> FeePerByte`
 
### Comments

- I left `distributeSurplus` where it is for now. We could move it to some `Write.Tx.{Fees,Size,Balance,}` module later.

### Issue Number

ADP-2459

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
