### PR TITLE
Further optimise UTxO index construction.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -547,6 +547,8 @@ import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Cardano.Wallet.Write.Tx
     ( AnyRecentEra (..) )
+import Cardano.Wallet.Write.Tx.Balance
+    ( UTxOIndexForBalanceTx (..) )
 import Control.Arrow
     ( second, (&&&) )
 import Control.DeepSeq
@@ -3123,7 +3125,7 @@ balanceTransaction
                         mScriptTemplate)
                     (Write.unsafeFromWalletProtocolParameters pp)
                     timeTranslation
-                    utxoIndex
+                    (UTxOIndexForBalanceTx utxoIndex)
                     (W.defaultChangeAddressGen argGenChange (Proxy @k))
                     (getState wallet)
                     partialTx

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -548,7 +548,7 @@ import Cardano.Wallet.Unsafe
 import Cardano.Wallet.Write.Tx
     ( AnyRecentEra (..) )
 import Cardano.Wallet.Write.Tx.Balance
-    ( constructUTxOIndexForBalanceTx )
+    ( constructUTxOIndex )
 import Control.Arrow
     ( second, (&&&) )
 import Control.DeepSeq
@@ -3126,7 +3126,7 @@ balanceTransaction
                         mScriptTemplate)
                     (Write.unsafeFromWalletProtocolParameters pp)
                     timeTranslation
-                    (constructUTxOIndexForBalanceTx utxo)
+                    (constructUTxOIndex utxo)
                     (W.defaultChangeAddressGen argGenChange (Proxy @k))
                     (getState wallet)
                     partialTx

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -548,7 +548,7 @@ import Cardano.Wallet.Unsafe
 import Cardano.Wallet.Write.Tx
     ( AnyRecentEra (..) )
 import Cardano.Wallet.Write.Tx.Balance
-    ( UTxOIndexForBalanceTx (..) )
+    ( constructUTxOIndexForBalanceTx )
 import Control.Arrow
     ( second, (&&&) )
 import Control.DeepSeq
@@ -3125,7 +3125,7 @@ balanceTransaction
                         mScriptTemplate)
                     (Write.unsafeFromWalletProtocolParameters pp)
                     timeTranslation
-                    (UTxOIndexForBalanceTx utxoIndex)
+                    (constructUTxOIndexForBalanceTx utxoIndex)
                     (W.defaultChangeAddressGen argGenChange (Proxy @k))
                     (getState wallet)
                     partialTx

--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -494,9 +494,9 @@ selectAssets
 selectAssets networkId ctx wid = do
     let tr = trMessageText (tracer ctx)
     let out = TxOut (dummyAddress networkId) (TokenBundle.fromCoin $ Coin 1)
-    (utxoAvailable, wallet, pendingTxs) <-
+    (walletUTxO, wallet, pendingTxs) <-
         unsafeRunExceptT $ W.readWalletUTxO @_ @s @k ctx wid
-    let utxoIndex = UTxOIndex.fromMap $ toInternalUTxOMap utxoAvailable
+    let utxoAvailable = UTxOIndex.fromMap $ toInternalUTxOMap walletUTxO
     pp <- currentProtocolParameters (networkLayer ctx)
     era <- currentNodeEra (networkLayer ctx)
     runExceptT $ withExceptT show $ W.selectAssets @_ @s @k @ktype
@@ -509,8 +509,8 @@ selectAssets networkId ctx wid = do
         , pendingTxs
         , randomSeed = Nothing
         , txContext = Tx.defaultTransactionCtx
-        , utxoAvailableForInputs = UTxOSelection.fromIndex utxoIndex
-        , utxoAvailableForCollateral = UTxOIndex.toMap utxoIndex
+        , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
+        , utxoAvailableForCollateral = UTxOIndex.toMap utxoAvailable
         , wallet
         , selectionStrategy = CoinSelection.SelectionStrategyOptimal
         } $ \_state -> id

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -477,9 +477,9 @@ benchmarksRnd network w wid wname benchname restoreTime = do
     (_, estimateFeesTime) <- bench "estimate tx fee" $ do
         let out = TxOut (dummyAddress network) (TokenBundle.fromCoin $ Coin 1)
         let txCtx = defaultTransactionCtx
-        (utxoAvailable, wallet, pendingTxs) <-
+        (walletUTxO, wallet, pendingTxs) <-
             unsafeRunExceptT $ W.readWalletUTxO @_ @s @k w wid
-        let utxoIndex = UTxOIndex.fromMap $ toInternalUTxOMap utxoAvailable
+        let utxoAvailable = UTxOIndex.fromMap $ toInternalUTxOMap walletUTxO
         pp <- liftIO $ currentProtocolParameters (w ^. networkLayer)
         era <- liftIO $ currentNodeEra (w ^. networkLayer)
         let estimateFee = W.selectAssets @_ @s @k @'CredFromKeyK
@@ -492,8 +492,8 @@ benchmarksRnd network w wid wname benchname restoreTime = do
                 , pendingTxs
                 , randomSeed = Nothing
                 , txContext = txCtx
-                , utxoAvailableForInputs = UTxOSelection.fromIndex utxoIndex
-                , utxoAvailableForCollateral = UTxOIndex.toMap utxoIndex
+                , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
+                , utxoAvailableForCollateral = UTxOIndex.toMap utxoAvailable
                 , wallet
                 , selectionStrategy = SelectionStrategyOptimal
                 } $ \_state -> W.Fee . selectionDelta TokenBundle.getCoin
@@ -589,9 +589,9 @@ benchmarksSeq network w wid _wname benchname restoreTime = do
     (_, estimateFeesTime) <- bench "estimate tx fee" $ do
         let out = TxOut (dummyAddress network) (TokenBundle.fromCoin $ Coin 1)
         let txCtx = defaultTransactionCtx
-        (utxoAvailable, wallet, pendingTxs) <-
+        (walletUTxO, wallet, pendingTxs) <-
             unsafeRunExceptT $ W.readWalletUTxO w wid
-        let utxoIndex = UTxOIndex.fromMap $ toInternalUTxOMap utxoAvailable
+        let utxoAvailable = UTxOIndex.fromMap $ toInternalUTxOMap walletUTxO
         pp <- liftIO $ currentProtocolParameters (w ^. networkLayer)
         era <- liftIO $ currentNodeEra (w ^. networkLayer)
         let estimateFee = W.selectAssets @_ @s @k @'CredFromKeyK
@@ -604,8 +604,8 @@ benchmarksSeq network w wid _wname benchname restoreTime = do
                 , pendingTxs
                 , randomSeed = Nothing
                 , txContext = txCtx
-                , utxoAvailableForInputs = UTxOSelection.fromIndex utxoIndex
-                , utxoAvailableForCollateral = UTxOIndex.toMap utxoIndex
+                , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
+                , utxoAvailableForCollateral = UTxOIndex.toMap utxoAvailable
                 , wallet
                 , selectionStrategy = SelectionStrategyOptimal
                 } $ \_state -> W.Fee . selectionDelta TokenBundle.getCoin

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -127,7 +127,7 @@ module Cardano.Wallet
     , selectAssets
     , buildCoinSelectionForTransaction
     , CoinSelection (..)
-    , readWalletUTxOIndex
+    , readWalletUTxO
     , defaultChangeAddressGen
     , dummyChangeAddressGen
     , assignChangeAddressesAndUpdateDb
@@ -452,8 +452,6 @@ import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
-import Cardano.Wallet.Primitive.Types.UTxOIndex
-    ( UTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
@@ -624,7 +622,6 @@ import qualified Cardano.Address.Style.Shelley as CAShelley
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Slotting.Slot as Slot
-import qualified Cardano.Tx.Balance.Internal.CoinSelection as CS
 import qualified Cardano.Wallet.Address.Discovery.Random as Rnd
 import qualified Cardano.Wallet.Address.Discovery.Sequential as Seq
 import qualified Cardano.Wallet.Address.Discovery.Shared as Shared
@@ -639,7 +636,6 @@ import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as Tx
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
-import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Cardano.Wallet.Read as Read
@@ -1765,18 +1761,16 @@ buildCoinSelectionForTransaction
     rewardAcctPath =
         stakeDerivationPath (Seq.derivationPrefix (getState wallet))
 
--- | Read a wallet checkpoint and index its UTxO, for 'selectAssets' and
+-- | Read a wallet checkpoint and its UTxO, for 'selectAssets' and
 -- 'selectAssetsNoOutputs'.
-readWalletUTxOIndex
+readWalletUTxO
     :: forall ctx s k. HasDBLayer IO s k ctx
     => ctx
     -> WalletId
-    -> ExceptT ErrNoSuchWallet IO (UTxOIndex WalletUTxO, Wallet s, Set Tx)
-readWalletUTxOIndex ctx wid = do
+    -> ExceptT ErrNoSuchWallet IO (UTxO, Wallet s, Set Tx)
+readWalletUTxO ctx wid = do
     (cp, _, pending) <- readWallet @ctx @s @k ctx wid
-    let utxo = UTxOIndex.fromMap $
-            CS.toInternalUTxOMap $ availableUTxO @s pending cp
-    return (utxo, cp, pending)
+    return (availableUTxO @s pending cp, cp, pending)
 
 -- | Calculate the minimum coin values required for a bunch of specified
 -- outputs.
@@ -2054,13 +2048,10 @@ buildSignSubmitTransaction db@DBLayer{..} netLayer txLayer pwd walletId
                 throwOnErr <=< modifyDBMaybe walletsDB $
                 adjustNoSuchWallet walletId wrapNoWalletForConstruct $ \s -> do
                     let wallet = WalletState.getLatest s
-                    let utxoIndex = UTxOIndex.fromMap
-                            $ CS.toInternalUTxOMap
-                            $ availableUTxO @s (Set.fromList pendingTxs) wallet
-
+                    let utxo = availableUTxO @s (Set.fromList pendingTxs) wallet
                     buildAndSignTransactionPure @k @s @n
                         timeTranslation
-                        utxoIndex
+                        utxo
                         rootKey
                         scheme
                         pwd
@@ -2116,7 +2107,7 @@ buildAndSignTransactionPure
        , WalletFlavor s n k
        )
     => TimeTranslation
-    -> UTxOIndex WalletUTxO
+    -> UTxO
     -> k 'RootK XPrv
     -> PassphraseScheme
     -> Passphrase "user"
@@ -2131,14 +2122,14 @@ buildAndSignTransactionPure
         (ExceptT (Either ErrBalanceTx ErrConstructTx) (Rand StdGen))
         BuiltTx
 buildAndSignTransactionPure
-    timeTranslation utxoIndex rootKey passphraseScheme userPassphrase
+    timeTranslation utxo rootKey passphraseScheme userPassphrase
     protocolParams txLayer changeAddrGen era preSelection txCtx =
     --
     WriteTx.withRecentEra era $ \(_ :: WriteTx.RecentEra recentEra) -> do
         wallet <- get
         (unsignedBalancedTx, updatedWalletState) <- lift $
             buildTransactionPure @s @k @n @recentEra
-                wallet timeTranslation utxoIndex txLayer changeAddrGen
+                wallet timeTranslation utxo txLayer changeAddrGen
                 (Write.unsafeFromWalletProtocolParameters protocolParams)
                 preSelection txCtx
         put wallet { getState = updatedWalletState }
@@ -2236,14 +2227,13 @@ buildTransaction DBLayer{..} txLayer timeTranslation walletId changeAddrGen
             readTransactions
                 Nothing Descending wholeRange (Just Pending) Nothing
 
-        let utxoIndex = UTxOIndex.fromMap . CS.toInternalUTxOMap $
-                availableUTxO @s pendingTxs wallet
+        let utxo = availableUTxO @s pendingTxs wallet
 
         fmap (\s' -> wallet { getState = s' }) <$>
             buildTransactionPure @s @_ @n @era
                 wallet
                 timeTranslation
-                utxoIndex
+                utxo
                 txLayer
                 changeAddrGen
                 (Write.unsafeFromWalletProtocolParameters protocolParameters)
@@ -2261,7 +2251,7 @@ buildTransactionPure
        )
     => Wallet s
     -> TimeTranslation
-    -> UTxOIndex WalletUTxO
+    -> UTxO
     -> TransactionLayer k 'CredFromKeyK SealedTx
     -> ChangeAddressGen s
     -> Write.ProtocolParameters era
@@ -2272,7 +2262,7 @@ buildTransactionPure
         (Rand StdGen)
         (Cardano.Tx era, s)
 buildTransactionPure
-    wallet timeTranslation utxoIndex txLayer changeAddrGen
+    wallet timeTranslation utxo txLayer changeAddrGen
     pparams preSelection txCtx = do
     --
     unsignedTxBody <-
@@ -2289,7 +2279,7 @@ buildTransactionPure
             (Write.allKeyPaymentCredentials txLayer)
             pparams
             timeTranslation
-            (constructUTxOIndexForBalanceTx utxoIndex)
+            (constructUTxOIndexForBalanceTx utxo)
             changeAddrGen
             (getState wallet)
             PartialTx
@@ -2961,8 +2951,7 @@ transactionFee DBLayer{atomically, walletsDB} protocolParams txLayer
             -- strict, and each field is defined in terms of 'Data.Map.Strict'.
             --
             evaluate
-                $ UTxOIndex.fromMap
-                $ CS.toInternalUTxOMap
+                $ constructUTxOIndexForBalanceTx
                 $ availableUTxO @s mempty wallet
         unsignedTxBody <- wrapErrMkTransaction $
             mkUnsignedTransaction txLayer @era
@@ -2983,7 +2972,7 @@ transactionFee DBLayer{atomically, walletsDB} protocolParams txLayer
                         (Write.allKeyPaymentCredentials txLayer)
                         protocolParams
                         timeTranslation
-                        (constructUTxOIndexForBalanceTx utxoIndex)
+                        utxoIndex
                         changeAddressGen
                         (getState wallet)
                         ptx

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -496,7 +496,7 @@ import Cardano.Wallet.Write.Tx.Balance
     , PartialTx (..)
     , assignChangeAddresses
     , balanceTransaction
-    , constructUTxOIndexForBalanceTx
+    , constructUTxOIndex
     )
 import Cardano.Wallet.Write.Tx.TimeTranslation
     ( TimeTranslation )
@@ -2279,7 +2279,7 @@ buildTransactionPure
             (Write.allKeyPaymentCredentials txLayer)
             pparams
             timeTranslation
-            (constructUTxOIndexForBalanceTx utxo)
+            (constructUTxOIndex utxo)
             changeAddrGen
             (getState wallet)
             PartialTx
@@ -2950,9 +2950,7 @@ transactionFee DBLayer{atomically, walletsDB} protocolParams txLayer
             -- fully evaluated, as all fields of the 'UTxOIndex' type are
             -- strict, and each field is defined in terms of 'Data.Map.Strict'.
             --
-            evaluate
-                $ constructUTxOIndexForBalanceTx
-                $ availableUTxO @s mempty wallet
+            evaluate $ constructUTxOIndex $ availableUTxO @s mempty wallet
         unsignedTxBody <- wrapErrMkTransaction $
             mkUnsignedTransaction txLayer @era
                 (Left $ unsafeShelleyOnlyGetRewardXPub @s @k @n (getState wallet))

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -496,9 +496,9 @@ import Cardano.Wallet.Write.Tx.Balance
     , ErrBalanceTxInternalError (..)
     , ErrSelectAssets (..)
     , PartialTx (..)
-    , UTxOIndexForBalanceTx (..)
     , assignChangeAddresses
     , balanceTransaction
+    , constructUTxOIndexForBalanceTx
     )
 import Cardano.Wallet.Write.Tx.TimeTranslation
     ( TimeTranslation )
@@ -2289,7 +2289,7 @@ buildTransactionPure
             (Write.allKeyPaymentCredentials txLayer)
             pparams
             timeTranslation
-            (UTxOIndexForBalanceTx utxoIndex)
+            (constructUTxOIndexForBalanceTx utxoIndex)
             changeAddrGen
             (getState wallet)
             PartialTx
@@ -2983,7 +2983,7 @@ transactionFee DBLayer{atomically, walletsDB} protocolParams txLayer
                         (Write.allKeyPaymentCredentials txLayer)
                         protocolParams
                         timeTranslation
-                        (UTxOIndexForBalanceTx utxoIndex)
+                        (constructUTxOIndexForBalanceTx utxoIndex)
                         changeAddressGen
                         (getState wallet)
                         ptx

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -496,6 +496,7 @@ import Cardano.Wallet.Write.Tx.Balance
     , ErrBalanceTxInternalError (..)
     , ErrSelectAssets (..)
     , PartialTx (..)
+    , UTxOIndexForBalanceTx (..)
     , assignChangeAddresses
     , balanceTransaction
     )
@@ -2288,7 +2289,7 @@ buildTransactionPure
             (Write.allKeyPaymentCredentials txLayer)
             pparams
             timeTranslation
-            utxoIndex
+            (UTxOIndexForBalanceTx utxoIndex)
             changeAddrGen
             (getState wallet)
             PartialTx
@@ -2982,7 +2983,7 @@ transactionFee DBLayer{atomically, walletsDB} protocolParams txLayer
                         (Write.allKeyPaymentCredentials txLayer)
                         protocolParams
                         timeTranslation
-                        utxoIndex
+                        (UTxOIndexForBalanceTx utxoIndex)
                         changeAddressGen
                         (getState wallet)
                         ptx

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -321,14 +321,14 @@ data UTxOAssumptions = forall k ktype. UTxOAssumptions
         :: Maybe ScriptTemplate
     }
 
-data UTxOIndexForBalanceTx = UTxOIndexForBalanceTx
+data UTxOIndex = UTxOIndex
     { walletUTxO :: !W.UTxO
     , walletUTxOIndex :: !(UTxOIndex.UTxOIndex WalletUTxO)
     }
 
-constructUTxOIndexForBalanceTx :: W.UTxO -> UTxOIndexForBalanceTx
-constructUTxOIndexForBalanceTx walletUTxO =
-    UTxOIndexForBalanceTx {walletUTxO, walletUTxOIndex}
+constructUTxOIndex :: W.UTxO -> UTxOIndex
+constructUTxOIndex walletUTxO =
+    UTxOIndex {walletUTxO, walletUTxOIndex}
   where
     walletUTxOIndex = UTxOIndex.fromMap $ toInternalUTxOMap walletUTxO
 
@@ -384,7 +384,7 @@ balanceTransaction
     -- It is unclear whether an incorrect value could cause collateral to be
     -- forfeited. We should ideally investigate and clarify as part of ADP-1544
     -- or similar ticket. Relevant ledger code: https://github.com/input-output-hk/cardano-ledger/blob/fdec04e8c071060a003263cdcb37e7319fb4dbf3/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs#L428-L440
-    -> UTxOIndexForBalanceTx
+    -> UTxOIndex
     -- ^ TODO [ADP-1789] Replace with @Cardano.UTxO@
     -> ChangeAddressGen changeState
     -> changeState
@@ -481,7 +481,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     -> UTxOAssumptions
     -> ProtocolParameters era
     -> TimeTranslation
-    -> UTxOIndexForBalanceTx
+    -> UTxOIndex
     -> ChangeAddressGen changeState
     -> changeState
     -> SelectionStrategy
@@ -495,7 +495,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         mScriptTemplate)
     (ProtocolParameters pp ledgerPP)
     timeTranslation
-    (UTxOIndexForBalanceTx walletUTxO internalUtxoAvailable)
+    (UTxOIndex walletUTxO internalUtxoAvailable)
     genChange
     s
     selectionStrategy

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -71,8 +71,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx, sealedTxFromCardano )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxSize (..) )
-import Cardano.Wallet.Primitive.Types.UTxOIndex
-    ( UTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
 import Cardano.Wallet.Shelley.Compatibility
@@ -325,7 +323,7 @@ data UTxOAssumptions = forall k ktype. UTxOAssumptions
 
 data UTxOIndexForBalanceTx = UTxOIndexForBalanceTx
     { walletUTxO :: !W.UTxO
-    , walletUTxOIndex :: !(UTxOIndex WalletUTxO)
+    , walletUTxOIndex :: !(UTxOIndex.UTxOIndex WalletUTxO)
     }
 
 constructUTxOIndexForBalanceTx :: W.UTxO -> UTxOIndexForBalanceTx
@@ -662,7 +660,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     -- Left (ErrBalanceTxUnresolvedInputs [inA, inC])
     extractExternallySelectedUTxO
         :: PartialTx era
-        -> ExceptT ErrBalanceTx m (UTxOIndex WalletUTxO)
+        -> ExceptT ErrBalanceTx m (UTxOIndex.UTxOIndex WalletUTxO)
     extractExternallySelectedUTxO (PartialTx tx _ _rdms) = do
         let res = flip map txIns $ \(i, _) -> do
                 case Map.lookup i utxo of

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -49,7 +49,7 @@ import Cardano.Tx.Balance.Internal.CoinSelection
     , makeSelectionReportDetailed
     , makeSelectionReportSummarized
     , performSelection
-    , toExternalUTxOMap
+    , toInternalUTxOMap
     )
 import Cardano.Wallet.Address.Derivation
     ( Depth (..) )
@@ -328,11 +328,11 @@ data UTxOIndexForBalanceTx = UTxOIndexForBalanceTx
     , walletUTxOIndex :: !(UTxOIndex WalletUTxO)
     }
 
-constructUTxOIndexForBalanceTx :: UTxOIndex WalletUTxO -> UTxOIndexForBalanceTx
-constructUTxOIndexForBalanceTx walletUTxOIndex =
+constructUTxOIndexForBalanceTx :: W.UTxO -> UTxOIndexForBalanceTx
+constructUTxOIndexForBalanceTx walletUTxO =
     UTxOIndexForBalanceTx {walletUTxO, walletUTxOIndex}
   where
-    walletUTxO = toExternalUTxOMap $ UTxOIndex.toMap walletUTxOIndex
+    walletUTxOIndex = UTxOIndex.fromMap $ toInternalUTxOMap walletUTxO
 
 -- | Assumes all 'UTxO' entries have addresses with key payment credentials;
 -- either normal, post-Shelley credentials, or boostrap/byron credentials

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -323,6 +323,9 @@ data UTxOAssumptions = forall k ktype. UTxOAssumptions
         :: Maybe ScriptTemplate
     }
 
+newtype UTxOIndexForBalanceTx = UTxOIndexForBalanceTx
+    { walletUTxOIndex :: UTxOIndex WalletUTxO }
+
 -- | Assumes all 'UTxO' entries have addresses with key payment credentials;
 -- either normal, post-Shelley credentials, or boostrap/byron credentials
 -- depending on the 'k' of the supplied 'TransactionLayer'.
@@ -375,7 +378,7 @@ balanceTransaction
     -- It is unclear whether an incorrect value could cause collateral to be
     -- forfeited. We should ideally investigate and clarify as part of ADP-1544
     -- or similar ticket. Relevant ledger code: https://github.com/input-output-hk/cardano-ledger/blob/fdec04e8c071060a003263cdcb37e7319fb4dbf3/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs#L428-L440
-    -> UTxOIndex WalletUTxO
+    -> UTxOIndexForBalanceTx
     -- ^ TODO [ADP-1789] Replace with @Cardano.UTxO@
     -> ChangeAddressGen changeState
     -> changeState
@@ -472,7 +475,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     -> UTxOAssumptions
     -> ProtocolParameters era
     -> TimeTranslation
-    -> UTxOIndex WalletUTxO
+    -> UTxOIndexForBalanceTx
     -> ChangeAddressGen changeState
     -> changeState
     -> SelectionStrategy
@@ -486,7 +489,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         mScriptTemplate)
     (ProtocolParameters pp ledgerPP)
     timeTranslation
-    internalUtxoAvailable
+    (UTxOIndexForBalanceTx internalUtxoAvailable)
     genChange
     s
     selectionStrategy

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -20,7 +20,35 @@
 {-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}
 #endif
 
-module Cardano.Wallet.Write.Tx.Balance where
+module Cardano.Wallet.Write.Tx.Balance
+    (
+    -- * Balancing transactions
+      balanceTransaction
+    , BalanceTxLog (..)
+    , ErrBalanceTx (..)
+    , ErrBalanceTxInternalError (..)
+    , ErrSelectAssets (..)
+
+    -- * Change addresses
+    , ChangeAddressGen (..)
+    , assignChangeAddresses
+
+    -- * Partial transactions
+    , PartialTx (..)
+
+    -- * UTxO assumptions
+    , UTxOAssumptions (..)
+    , allKeyPaymentCredentials
+    , allScriptPaymentCredentials
+
+    -- * UTxO indices
+    , UTxOIndex
+    , constructUTxOIndex
+
+    -- * Utilities
+    , posAndNegFromCardanoValue
+    )
+    where
 
 import Prelude
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -303,9 +303,9 @@ import Cardano.Wallet.Write.Tx.Balance
     , ErrSelectAssets (..)
     , PartialTx (..)
     , UTxOAssumptions (..)
-    , UTxOIndexForBalanceTx (..)
     , allKeyPaymentCredentials
     , balanceTransaction
+    , constructUTxOIndexForBalanceTx
     , posAndNegFromCardanoValue
     )
 import Cardano.Wallet.Write.Tx.TimeTranslation
@@ -3789,7 +3789,7 @@ balanceTx
             utxoAssumptions
             pp
             timeTranslation
-            (UTxOIndexForBalanceTx utxoIndex)
+            (constructUTxOIndexForBalanceTx utxoIndex)
             genChange
             s
             ptx
@@ -3815,7 +3815,7 @@ balanceTransactionWithDummyChangeState cs utxo seed ptx =
                 Cardano.shelleyBasedEra @era
             )
             dummyTimeTranslation
-            (UTxOIndexForBalanceTx utxoIndex)
+            (constructUTxOIndexForBalanceTx utxoIndex)
             dummyChangeAddrGen
             (getState wal)
             ptx

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -305,7 +305,7 @@ import Cardano.Wallet.Write.Tx.Balance
     , UTxOAssumptions (..)
     , allKeyPaymentCredentials
     , balanceTransaction
-    , constructUTxOIndexForBalanceTx
+    , constructUTxOIndex
     , posAndNegFromCardanoValue
     )
 import Cardano.Wallet.Write.Tx.TimeTranslation
@@ -3787,7 +3787,7 @@ balanceTx
             utxoAssumptions
             pp
             timeTranslation
-            (constructUTxOIndexForBalanceTx utxo)
+            (constructUTxOIndex utxo)
             genChange
             s
             ptx
@@ -3811,7 +3811,7 @@ balanceTransactionWithDummyChangeState cs utxo seed ptx =
                 Cardano.shelleyBasedEra @era
             )
             dummyTimeTranslation
-            (constructUTxOIndexForBalanceTx utxo)
+            (constructUTxOIndex utxo)
             dummyChangeAddrGen
             (getState wal)
             ptx

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -303,6 +303,7 @@ import Cardano.Wallet.Write.Tx.Balance
     , ErrSelectAssets (..)
     , PartialTx (..)
     , UTxOAssumptions (..)
+    , UTxOIndexForBalanceTx (..)
     , allKeyPaymentCredentials
     , balanceTransaction
     , posAndNegFromCardanoValue
@@ -3788,7 +3789,7 @@ balanceTx
             utxoAssumptions
             pp
             timeTranslation
-            utxoIndex
+            (UTxOIndexForBalanceTx utxoIndex)
             genChange
             s
             ptx
@@ -3814,7 +3815,7 @@ balanceTransactionWithDummyChangeState cs utxo seed ptx =
                 Cardano.shelleyBasedEra @era
             )
             dummyTimeTranslation
-            utxoIndex
+            (UTxOIndexForBalanceTx utxoIndex)
             dummyChangeAddrGen
             (getState wal)
             ptx

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -506,7 +506,6 @@ import qualified Cardano.Ledger.Val as Value
 import qualified Cardano.Slotting.EpochInfo as Slotting
 import qualified Cardano.Slotting.Slot as Slotting
 import qualified Cardano.Slotting.Time as Slotting
-import qualified Cardano.Tx.Balance.Internal.CoinSelection as CS
 import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
@@ -514,7 +513,6 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as TxOutGen
-import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
 import qualified Cardano.Wallet.Write.ProtocolParameters as Write
 import qualified Cardano.Wallet.Write.Tx as WriteTx
@@ -3789,12 +3787,10 @@ balanceTx
             utxoAssumptions
             pp
             timeTranslation
-            (constructUTxOIndexForBalanceTx utxoIndex)
+            (constructUTxOIndexForBalanceTx utxo)
             genChange
             s
             ptx
-  where
-    utxoIndex = UTxOIndex.fromMap $ CS.toInternalUTxOMap utxo
 
 -- | Also returns the updated change state
 balanceTransactionWithDummyChangeState
@@ -3815,12 +3811,11 @@ balanceTransactionWithDummyChangeState cs utxo seed ptx =
                 Cardano.shelleyBasedEra @era
             )
             dummyTimeTranslation
-            (constructUTxOIndexForBalanceTx utxoIndex)
+            (constructUTxOIndexForBalanceTx utxo)
             dummyChangeAddrGen
             (getState wal)
             ptx
   where
-    utxoIndex = UTxOIndex.fromMap $ CS.toInternalUTxOMap utxo
     wal = unsafeInitWallet utxo (header block0) s
       where
         s = DummyChangeState { nextUnusedIndex = 0 }


### PR DESCRIPTION
## Issue

ADP-2975

## Summary

Applying this PR reduces the evaluation time of `transactionFee` by approximately 30% when applied to a wallet with 1,000 ada-only UTxO entries.

## Details

This PR moves the construction of all UTxO map objects:
- **_out_** of the `balanceTransaction` function;
- **_into_** a new function `constructUTxOIndex`, which is now also responsible for constructing the index.

The result of calling `constructUTxOIndex` can be fully evaluated **_before_** calling `balanceTx`, **_outside_** of any fee evaluation loop, and passed into `balanceTx`. This means that repeated calls to `balanceTx` will not result in repeated construction of UTxO maps, which are all constant in the context of the `transactionFee` evaluation loop.

Function `constructUTxOIndex` returns an object of type `Write.Tx.Balance.UTxOIndex era`, which:
- internally wraps the three types of UTxO map and index-related objects currently needed by `balanceTx`.
- is completely opaque to callers outside of the `Write.Tx.Balance` module, which means future PRs are free to change the internal definition in a way that suits `balanceTx`, without breaking the API.

## Benchmark data

All benchmark data produced from binaries built with `-O2`.

### Before applying this PR

```
    Latencies for 2 fixture wallets with 100 utxos scenario
        postTransactionFee  - 59.4 ms
        postTransactionFee  - 57.6 ms
        postTransactionFee  - 55.7 ms
        postTransactionFee  - 56.6 ms
    Latencies for 2 fixture wallets with 200 utxos scenario
        postTransactionFee  - 67.9 ms
        postTransactionFee  - 70.3 ms
        postTransactionFee  - 70.9 ms
        postTransactionFee  - 72.6 ms
    Latencies for 2 fixture wallets with 500 utxos scenario
        postTransactionFee  - 104.3 ms
        postTransactionFee  - 103.4 ms
        postTransactionFee  - 105.9 ms
        postTransactionFee  - 101.9 ms
    Latencies for 2 fixture wallets with 1000 utxos scenario
        postTransactionFee  - 197.9 ms
        postTransactionFee  - 172.4 ms
        postTransactionFee  - 189.8 ms
        postTransactionFee  - 178.1 ms
```

### After applying this PR
```
    Latencies for 2 fixture wallets with 100 utxos scenario
        postTransactionFee  - 55.2 ms
        postTransactionFee  - 62.7 ms
        postTransactionFee  - 54.4 ms
        postTransactionFee  - 57.2 ms
    Latencies for 2 fixture wallets with 200 utxos scenario
        postTransactionFee  - 57.7 ms
        postTransactionFee  - 60.5 ms
        postTransactionFee  - 62.2 ms
        postTransactionFee  - 57.9 ms
    Latencies for 2 fixture wallets with 500 utxos scenario
        postTransactionFee  - 76.8 ms
        postTransactionFee  - 92.3 ms
        postTransactionFee  - 83.0 ms
        postTransactionFee  - 79.2 ms
    Latencies for 2 fixture wallets with 1000 utxos scenario
        postTransactionFee  - 128.1 ms
        postTransactionFee  - 115.0 ms
        postTransactionFee  - 138.3 ms
        postTransactionFee  - 123.5 ms
```