### PR TITLE
Remove `calcMinimumCost`'s dependence on `W.ProtocolParameters`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -461,7 +461,7 @@ import Cardano.Wallet.Shelley.Compatibility
     , fromCardanoWdrls
     )
 import Cardano.Wallet.Shelley.Transaction
-    ( calculateMinimumFee )
+    ( calculateMinimumFee, getFeePerByteFromWalletPParams )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , ErrCannotJoin (..)
@@ -1250,13 +1250,14 @@ checkRewardIsWorthTxCost txWitnessTag pp era balance = do
     when (balance == Coin 0)
         $ Left ErrWithdrawalNotBeneficial
     let minimumCost txCtx =
-            calculateMinimumFee era pp txWitnessTag txCtx emptySkeleton
+            calculateMinimumFee era feePerByte txWitnessTag txCtx emptySkeleton
         costWith = minimumCost $ mkTxCtx balance
         costWithout = minimumCost $ mkTxCtx $ Coin 0
         worthOfWithdrawal = Coin.toInteger costWith - Coin.toInteger costWithout
     when (Coin.toInteger balance < 2 * worthOfWithdrawal)
         $ Left ErrWithdrawalNotBeneficial
   where
+    feePerByte = getFeePerByteFromWalletPParams pp
     mkTxCtx wdrl = defaultTransactionCtx
         { txWithdrawal = WithdrawalSelf dummyAcct dummyPath wdrl }
       where

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1308,11 +1308,9 @@ getFeePerByteFromWalletPParams
     :: ProtocolParameters
     -> FeePerByte
 getFeePerByteFromWalletPParams pp =
-    let
-        LinearFee LinearFunction {slope}
-            = getFeePolicy $ txParameters pp
-    in
-        FeePerByte $ ceiling slope
+    FeePerByte $ ceiling slope
+  where
+    LinearFee LinearFunction{slope} = getFeePolicy $ txParameters pp
 
 txConstraints
     :: AnyCardanoEra -> ProtocolParameters -> TxWitnessTag -> TxConstraints

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -246,9 +246,6 @@ data TransactionCtx = TransactionCtx
     -- transaction is valid.
     , txDelegationAction :: Maybe DelegationAction
     -- ^ An additional delegation to take.
-    , txPlutusScriptExecutionCost :: Coin
-    -- ^ Total execution cost of plutus scripts, determined by their execution units
-    -- and prices obtained from network.
     , txAssetsToMint :: (TokenMap, Map AssetId (Script KeyHash))
     -- ^ The assets to mint.
     , txAssetsToBurn :: (TokenMap, Map AssetId (Script KeyHash))
@@ -261,10 +258,6 @@ data TransactionCtx = TransactionCtx
     -- ^ A map of script hashes related to inputs. Only for multisig wallets
     , txCollateralRequirement :: SelectionCollateralRequirement
     -- ^ The collateral requirement.
-    , txFeePadding :: !Coin
-    -- ^ Extra fees. Some parts of a transaction are not representable using
-    -- cardano-wallet types, which makes it useful to account for them like
-    -- this. For instance: datums.
     } deriving Generic
 
 -- | Represents a preliminary selection of tx outputs typically made by user.
@@ -296,14 +289,12 @@ defaultTransactionCtx = TransactionCtx
     , txMetadata = Nothing
     , txValidityInterval = (Nothing, maxBound)
     , txDelegationAction = Nothing
-    , txPlutusScriptExecutionCost = Coin 0
     , txAssetsToMint = (TokenMap.empty, Map.empty)
     , txAssetsToBurn = (TokenMap.empty, Map.empty)
     , txPaymentCredentialScriptTemplate = Nothing
     , txStakingCredentialScriptTemplate = Nothing
     , txNativeScriptInputs = Map.empty
     , txCollateralRequirement = SelectionCollateralNotRequired
-    , txFeePadding = Coin 0
     }
 
 -- | User-requested action related to a delegation

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -957,14 +957,14 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             , computeMinimumCost = \skeleton -> mconcat
                 [ feePadding
                 , fromCardanoLovelace fee0
+                , txPlutusScriptExecutionCost
                 , calculateMinimumFee
                     era
                     pp
                     txWitnessTag
                     (defaultTransactionCtx
                         { txPaymentCredentialScriptTemplate = mScriptTemplate
-                        , txPlutusScriptExecutionCost =
-                            txPlutusScriptExecutionCost })
+                        })
                     skeleton
                 ] `Coin.difference` boringFee
             , computeSelectionLimit = \_ -> NoLimit

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -113,7 +113,6 @@ import Cardano.Wallet.Shelley.Transaction
     , distributeSurplus
     , estimateKeyWitnessCount
     , estimateSignedTxSize
-    , maxScriptExecutionCost
     , updateTx
     )
 import Cardano.Wallet.Transaction
@@ -135,6 +134,7 @@ import Cardano.Wallet.Write.Tx
     , TxOut
     , computeMinimumCoinForTxOut
     , getFeePerByte
+    , maxScriptExecutionCost
     , modifyLedgerBody
     , modifyTxOutCoin
     , modifyTxOutputs
@@ -893,7 +893,12 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             $ runExceptT
             $ performSelection selectionConstraints selectionParams
       where
-        txPlutusScriptExecutionCost = maxScriptExecutionCost pp redeemers
+        txPlutusScriptExecutionCost = W.toWallet @W.Coin $
+            if null redeemers then
+                mempty
+            else
+                maxScriptExecutionCost (recentEra @era) ledgerPP
+
         colReq =
             if txPlutusScriptExecutionCost > W.Coin 0
                 then SelectionCollateralRequired

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -912,10 +912,12 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         TokenBundle adaInInputs tokensInInputs =
             UTxOSelection.selectedBalance utxoSelection
 
+        feePerByte = getFeePerByte (recentEra @era) ledgerPP
+
         boringFee =
             calculateMinimumFee
                 era
-                pp
+                feePerByte
                 txWitnessTag
                 defaultTransactionCtx
                 SelectionSkeleton
@@ -965,7 +967,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 , txPlutusScriptExecutionCost
                 , calculateMinimumFee
                     era
-                    pp
+                    feePerByte
                     txWitnessTag
                     (defaultTransactionCtx
                         { txPaymentCredentialScriptTemplate = mScriptTemplate


### PR DESCRIPTION
- [x] Move concern of ExUnit cost outside of `calcMinimumCost`
- [x] Reimplement `maxScriptExecutionCost` using ledger types
- [x]  Switch `calcMinimumCost` to take `FeePerByte` rather than `W.ProtocolParameters`

### Issue Number

ADP-2459
