### PR TITLE
[ADP-3002] Remove no such wallet conditions

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -652,7 +652,6 @@ instance IsServerError ErrNoSuchTransaction where
 
 instance IsServerError ErrStakePoolDelegation where
     toServerError = \case
-        ErrStakePoolDelegationNoSuchWallet e -> toServerError e
         ErrStakePoolJoin e -> toServerError e
         ErrStakePoolQuit e -> toServerError e
 
@@ -946,7 +945,7 @@ instance IsServerError ErrCreateMigrationPlan where
                 , "any of the funds to be migrated. Try adding some ada to "
                 , "your wallet before trying again."
                 ]
-                
+
 instance IsServerError ErrSelectAssets where
     toServerError = \case
         ErrSelectAssetsPrepareOutputsError e -> toServerError e

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -639,7 +639,6 @@ instance IsServerError PastHorizonException where
 
 instance IsServerError ErrGetTransaction where
     toServerError = \case
-        ErrGetTransactionNoSuchWallet e -> toServerError e
         ErrGetTransactionNoSuchTransaction e -> toServerError e
 
 instance IsServerError ErrNoSuchTransaction where

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -599,10 +599,6 @@ instance IsServerError ErrSubmitTransaction where
 instance IsServerError ErrSubmitTx where
     toServerError = \case
         ErrSubmitTxNetwork e -> toServerError e
-        ErrSubmitTxNoSuchWallet e@ErrNoSuchWallet{} -> (toServerError e)
-            { errHTTPCode = 404
-            , errReasonPhrase = errReasonPhrase err404
-            }
         ErrSubmitTxImpossible e -> toServerError e
 
 instance IsServerError ErrUpdatePassphrase where

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -602,7 +602,6 @@ instance IsServerError ErrSubmitTx where
 
 instance IsServerError ErrUpdatePassphrase where
     toServerError = \case
-        ErrUpdatePassphraseNoSuchWallet e -> toServerError e
         ErrUpdatePassphraseWithRootKey e  -> toServerError e
 
 instance IsServerError ErrListTransactions where

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -606,7 +606,6 @@ instance IsServerError ErrUpdatePassphrase where
 
 instance IsServerError ErrListTransactions where
     toServerError = \case
-        ErrListTransactionsNoSuchWallet e -> toServerError e
         ErrListTransactionsStartTimeLaterThanEndTime e -> toServerError e
         ErrListTransactionsMinWithdrawalWrong ->
             apiError err400 MinWithdrawalWrong
@@ -770,19 +769,16 @@ instance IsServerError ErrWithdrawalNotBeneficial where
 instance IsServerError ErrSignMetadataWith where
     toServerError = \case
         ErrSignMetadataWithRootKey e -> toServerError e
-        ErrSignMetadataWithNoSuchWallet e -> toServerError e
         ErrSignMetadataWithInvalidIndex e -> toServerError e
 
 instance IsServerError ErrReadAccountPublicKey where
     toServerError = \case
         ErrReadAccountPublicKeyRootKey e -> toServerError e
-        ErrReadAccountPublicKeyNoSuchWallet e -> toServerError e
         ErrReadAccountPublicKeyInvalidAccountIndex e -> toServerError e
         ErrReadAccountPublicKeyInvalidPurposeIndex e -> toServerError e
 
 instance IsServerError ErrDerivePublicKey where
     toServerError = \case
-        ErrDerivePublicKeyNoSuchWallet e -> toServerError e
         ErrDerivePublicKeyInvalidIndex e -> toServerError e
 
 instance IsServerError ErrAddCosignerKey where

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -547,7 +547,6 @@ instance IsServerError ErrBalanceTxInternalError where
 
 instance IsServerError ErrRemoveTx where
     toServerError = \case
-        ErrRemoveTxNoSuchWallet wid -> toServerError wid
         ErrRemoveTxNoSuchTransaction (ErrNoSuchTransaction tid) ->
             apiError err404 NoSuchTransaction $ mconcat
                 [ "I couldn't find a transaction with the given id: "

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -49,7 +49,6 @@ import Cardano.Wallet
     , ErrConstructTx (..)
     , ErrCreateMigrationPlan (..)
     , ErrCreateRandomAddress (..)
-    , ErrDecodeTx (..)
     , ErrDerivePublicKey (..)
     , ErrFetchRewards (..)
     , ErrGetPolicyId (..)
@@ -58,7 +57,6 @@ import Cardano.Wallet
     , ErrImportRandomAddress (..)
     , ErrInvalidDerivationIndex (..)
     , ErrListTransactions (..)
-    , ErrListUTxOStatistics (..)
     , ErrMkTransaction (..)
     , ErrNoSuchTransaction (..)
     , ErrNoSuchWallet (..)
@@ -214,7 +212,6 @@ instance IsServerError WalletException where
         ExceptionAddCosignerKey e -> toServerError e
         ExceptionConstructSharedWallet e -> toServerError e
         ExceptionReadAccountPublicKey e -> toServerError e
-        ExceptionListUTxOStatistics e -> toServerError e
         ExceptionSignPayment e -> toServerError e
         ExceptionBalanceTx e -> toServerError e
         ExceptionBalanceTxInternalError e -> toServerError e
@@ -222,7 +219,6 @@ instance IsServerError WalletException where
         ExceptionConstructTx e -> toServerError e
         ExceptionGetPolicyId e -> toServerError e
         ExceptionWitnessTx e -> toServerError e
-        ExceptionDecodeTx e -> toServerError e
         ExceptionSubmitTx e -> toServerError e
         ExceptionUpdatePassphrase e -> toServerError e
         ExceptionWithRootKey e -> toServerError e
@@ -308,10 +304,6 @@ instance IsServerError ErrWithRootKey where
                 , toText s <> " scheme used by the given wallet: "
                 , toText wid
                 ]
-
-instance IsServerError ErrListUTxOStatistics where
-    toServerError = \case
-        ErrListUTxOStatisticsNoSuchWallet e -> toServerError e
 
 instance IsServerError ErrSignPayment where
     toServerError = \case
@@ -470,13 +462,6 @@ instance IsServerError ErrGetPolicyId where
             , "from cosigner#0."
             ]
 
-instance IsServerError ErrDecodeTx where
-    toServerError = \case
-        ErrDecodeTxNoSuchWallet e -> (toServerError e)
-            { errHTTPCode = 404
-            , errReasonPhrase = errReasonPhrase err404
-            }
-
 instance IsServerError ErrBalanceTx where
     toServerError = \case
         ErrOldEraNotSupported (Cardano.AnyCardanoEra era) ->
@@ -592,10 +577,6 @@ instance IsServerError ErrPostTx where
 
 instance IsServerError ErrSubmitTransaction where
     toServerError = \case
-        ErrSubmitTransactionNoSuchWallet e -> (toServerError e)
-            { errHTTPCode = 404
-            , errReasonPhrase = errReasonPhrase err404
-            }
         ErrSubmitTransactionForeignWallet ->
             apiError err403 ForeignTransaction $ mconcat
                 [ "The transaction to be submitted is foreign to the current wallet "
@@ -965,8 +946,7 @@ instance IsServerError ErrCreateMigrationPlan where
                 , "any of the funds to be migrated. Try adding some ada to "
                 , "your wallet before trying again."
                 ]
-        ErrCreateMigrationPlanNoSuchWallet e -> toServerError e
-
+                
 instance IsServerError ErrSelectAssets where
     toServerError = \case
         ErrSelectAssetsPrepareOutputsError e -> toServerError e

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/MintBurn.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/MintBurn.hs
@@ -32,8 +32,6 @@ import Cardano.Wallet.Api.Types.MintBurn
     ( ApiAssetMintBurn (..), includePolicyKeyInfo, policyIx, toApiTokens )
 import Cardano.Wallet.Flavor
     ( WalletFlavor )
-import Cardano.Wallet.Primitive.Types
-    ( WalletId )
 import Cardano.Wallet.Transaction
     ( TokenMapWithScripts (..) )
 import Control.Category
@@ -54,12 +52,11 @@ convertApiAssetMintBurn
        , WalletFlavor s n k
        )
     => ctx
-    -> WalletId
     -> (TokenMapWithScripts, TokenMapWithScripts)
     -> Handler (ApiAssetMintBurn, ApiAssetMintBurn)
-convertApiAssetMintBurn ctx wid (mint, burn) = do
+convertApiAssetMintBurn ctx (mint, burn) = do
     xpubM <- fmap (fmap fst . eitherToMaybe)
-        <$> liftIO . runExceptT $ readPolicyPublicKey @ctx @s @k @n ctx wid
+        <$> liftIO . runExceptT $ readPolicyPublicKey @ctx @s @k @n ctx
     let  convert tokenWithScripts =  ApiAssetMintBurn
             { tokens = toApiTokens tokenWithScripts
             , walletPolicyKeyHash =
@@ -76,8 +73,7 @@ getTxApiAssetMintBurn
        , WalletFlavor s n k
        )
     => ctx
-    -> WalletId
     -> ParsedTxCBOR
     -> (Handler (ApiAssetMintBurn, ApiAssetMintBurn))
-getTxApiAssetMintBurn ctx wid ParsedTxCBOR{..} =
-    convertApiAssetMintBurn @ctx @s @k @n ctx wid mintBurn
+getTxApiAssetMintBurn ctx ParsedTxCBOR{..} =
+    convertApiAssetMintBurn @ctx @s @k @n ctx mintBurn

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3338,7 +3338,7 @@ submitTransaction ctx apiw@(ApiT wid) apitx = do
                 , txWithdrawal = wdrl
                 }
         txMeta <- handler $ W.constructTxMeta db txCtx ourInps ourOuts
-        liftHandler $ W.submitTx (wrk ^. logger) db nl wid
+        liftHandler $ W.submitTx (wrk ^. logger) db nl
             BuiltTx
                 { builtTx = tx
                 , builtTxMeta = txMeta
@@ -3477,7 +3477,7 @@ submitSharedTransaction ctx apiw@(ApiT wid) apitx = do
                 }
         let db = wrk ^. dbLayer
         txMeta <- handler $ W.constructTxMeta db txCtx ourInps ourOuts
-        liftHandler $ W.submitTx (wrk ^. logger) db nl wid
+        liftHandler $ W.submitTx (wrk ^. logger) db nl
             BuiltTx
                 { builtTx = tx
                 , builtTxMeta = txMeta
@@ -3900,7 +3900,7 @@ migrateWallet ctx@ApiLayer{..} withdrawalType (ApiT wid) postData = do
                     txContext
                     (selection {change = []})
 
-            liftHandler $ W.submitTx tr db netLayer wid
+            liftHandler $ W.submitTx tr db netLayer
                 BuiltTx
                     { builtTx = tx
                     , builtTxMeta = txMeta

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2292,7 +2292,7 @@ getTransaction
     -> Handler (ApiTransaction n)
 getTransaction ctx (ApiT wid) (ApiTxId (ApiT (tid))) metadataSchema =
     withWorkerCtx ctx wid liftE liftE $ \wrk -> do
-        tx <- liftHandler $ W.getTransaction wrk wid tid
+        tx <- liftHandler $ W.getTransaction wrk tid
         depo <- liftIO $ W.stakeKeyDeposit <$>
             NW.currentProtocolParameters (wrk ^. networkLayer)
         mkApiTransactionFromInfo

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -843,7 +843,7 @@ postWallet
 postWallet ctx generateKey liftKey (WalletOrAccountPostData body) = case body of
     Left body' -> postShelleyWallet ctx generateKey body'
     Right body' ->
-        let action workerCtx =
+        let action workerCtx _ =
                 W.manageRewardBalance
                     (workerCtx ^. typed @(Tracer IO WalletWorkerLog))
                     (workerCtx ^. networkLayer)
@@ -876,7 +876,6 @@ postShelleyWallet ctx generateKey body = do
             (workerCtx ^. typed)
             (workerCtx ^. networkLayer)
             (workerCtx ^. typed @(DBLayer IO (SeqState n ShelleyKey) k))
-            wid
         )
     withWorkerCtx @_ @s @k ctx wid liftE liftE $ \wrk -> liftHandler $
         W.attachPrivateKeyFromPwd @_ @s @k wrk wid (rootXPrv, pwd)
@@ -1075,7 +1074,6 @@ postSharedWalletFromRootXPrv ctx generateKey body = do
             (workerCtx ^. typed)
             (workerCtx ^. networkLayer)
             (workerCtx ^. typed @(DBLayer IO (SharedState n SharedKey) k))
-            wid
         )
     withWorkerCtx @_ @s @k ctx wid liftE liftE $ \wrk -> liftHandler $
         W.attachPrivateKeyFromPwd @_ @s @k wrk wid (rootXPrv, pwd)
@@ -1143,7 +1141,6 @@ postSharedWalletFromAccountXPub ctx liftKey body = do
             (workerCtx ^. typed)
             (workerCtx ^. networkLayer)
             (workerCtx ^. typed @(DBLayer IO (SharedState n SharedKey) k))
-            wid
         )
     fst <$> getWallet ctx (mkSharedWallet @_ @s @k) (ApiT wid)
   where

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -170,7 +170,6 @@ import Cardano.Tx.Balance.Internal.CoinSelection
 import Cardano.Wallet
     ( BuiltTx (..)
     , DelegationFee (feePercentiles)
-    , ErrCheckWalletIntegrity (..)
     , ErrConstructSharedWallet (..)
     , ErrConstructTx (..)
     , ErrCreateMigrationPlan (..)
@@ -4713,10 +4712,9 @@ startWalletWorker ctx coworker = void . registerWorker ctx before coworker
         case edb of
             Left _ ->
                 throwIO
-                    $ ErrCheckWalletIntegrityNoSuchWallet
                     $ ErrNoSuchWallet wid
             Right db -> do
-                W.checkWalletIntegrity db wid gp
+                W.checkWalletIntegrity db gp
                 pure db
     (_, NetworkParameters gp _ _) = ctx ^. genesisData
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1854,7 +1854,6 @@ selectCoinsForJoin ctx@ApiLayer{..}
             pools
             poolId
             poolStatus
-            walletId
         let changeAddrGen = W.defaultChangeAddressGen (delegationAddressS @n)
                 (Proxy @k)
 
@@ -2482,7 +2481,7 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
             forM delegationRequest $
                 WD.handleDelegationRequest
                     trWorker db epoch knownPools
-                    poolStatus walletId withdrawal
+                    poolStatus withdrawal
 
         let transactionCtx1 =
                 case optionalDelegationAction of
@@ -2891,7 +2890,7 @@ constructSharedTransaction
             forM delegationRequest $
                 WD.handleDelegationRequest
                     trWorker db epoch knownPools
-                    getPoolStatus wid NoWithdrawal
+                    getPoolStatus NoWithdrawal
 
         let txCtx = defaultTransactionCtx
                 { txWithdrawal = NoWithdrawal
@@ -3565,7 +3564,6 @@ joinStakePool
                     pools
                     poolId
                     poolStatus
-                    walletId
 
         pp <- liftIO $ NW.currentProtocolParameters netLayer
         mkApiTransaction ti wrk #pendingSince

--- a/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
@@ -279,11 +279,12 @@ serveWallet
         lift $ apiLayer (newTransactionLayer netId) netLayer Server.idleWorker
 
     withShelleyApi netId netLayer =
-        lift $ apiLayer (newTransactionLayer netId) netLayer $
+        lift $ apiLayer (newTransactionLayer netId) netLayer $ \wrk _ ->
             Server.manageRewardBalance
                 <$> view typed
                 <*> pure netLayer
                 <*> view typed
+                $ wrk
 
     withMultisigApi netId netLayer =
         lift $ apiLayer (newTransactionLayer netId) netLayer Server.idleWorker

--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -246,14 +246,12 @@ benchmarksSeq BenchmarkConfig{benchmarkName,ctx,wid} = do
         $ W.getWalletUtxoSnapshot @_ @s @k @ktype ctx wid
 
     (addresses, listAddressesTime) <- bench "listAddresses"
-        $ fmap (fromIntegral . length)
-        $ unsafeRunExceptT
-        $ W.listAddresses @_ @s @k ctx wid (const pure)
+        $ fromIntegral . length
+        <$> W.listAddresses @_ @s @k ctx (const pure)
 
     (_, listAssetsTime) <- bench "listAssets"
-        $ fmap length
-        $ unsafeRunExceptT
-        $ W.listAssets @s @k ctx wid
+        $ length
+        <$> W.listAssets @s @k ctx
 
     (transactions, listTransactionsTime) <- bench "listTransactions"
         $ fmap (fromIntegral . length)
@@ -338,14 +336,12 @@ benchmarksShared BenchmarkConfig{benchmarkName,ctx,wid} = do
         $ W.getWalletUtxoSnapshot @_ @s @k @ktype ctx wid
 
     (addresses, listAddressesTime) <- bench "listAddresses"
-        $ fmap (fromIntegral . length)
-        $ unsafeRunExceptT
-        $ W.listAddresses @_ @s @k ctx wid (const pure)
+        $ fromIntegral . length
+        <$> W.listAddresses @_ @s @k ctx (const pure)
 
     (_, listAssetsTime) <- bench "listAssets"
-        $ fmap length
-        $ unsafeRunExceptT
-        $ W.listAssets @s @k ctx wid
+        $ length
+        <$> W.listAssets @s @k ctx
 
     (transactions, listTransactionsTime) <- bench "listTransactions"
         $ fmap (fromIntegral . length)
@@ -413,14 +409,12 @@ benchmarksRnd BenchmarkConfig{benchmarkName,ctx,wid} = do
         $ W.getWalletUtxoSnapshot @_ @s @k @ktype ctx wid
 
     (addresses, listAddressesTime) <- bench "listAddresses"
-        $ fmap (fromIntegral . length)
-        $ unsafeRunExceptT
-        $ W.listAddresses @_ @s @k ctx wid (const pure)
+        $ fromIntegral . length
+        <$> W.listAddresses @_ @s @k ctx (const pure)
 
     (_, listAssetsTime) <- bench "listAssets"
-        $ fmap length
-        $ unsafeRunExceptT
-        $ W.listAssets @s @k ctx wid
+        $ length
+        <$> W.listAssets @s @k ctx
 
     (transactions, listTransactionsTime) <- bench "listTransactions"
         $ fmap (fromIntegral . length)

--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -234,16 +234,15 @@ benchmarksSeq
     -> IO BenchSeqResults
 benchmarksSeq BenchmarkConfig{benchmarkName,ctx,wid} = do
     ((cp, pending), readWalletTime) <- bench "readWallet" $ do
-        (cp, _, pending) <- unsafeRunExceptT $ W.readWallet @_ @s @k ctx wid
+        (cp, _, pending) <- W.readWallet @_ @s @k ctx
         pure (cp, pending)
 
     (utxo, _) <- bench "utxo statistics" $
         pure $ UTxOStatistics.compute (totalUTxO pending cp)
 
     (_, getWalletUtxoSnapshotTime) <- bench "getWalletUtxoSnapshot"
-        $ fmap length
-        $ unsafeRunExceptT
-        $ W.getWalletUtxoSnapshot @_ @s @k @ktype ctx wid
+        $ length
+        <$> W.getWalletUtxoSnapshot @_ @s @k @ktype ctx
 
     (addresses, listAddressesTime) <- bench "listAddresses"
         $ fromIntegral . length
@@ -266,8 +265,7 @@ benchmarksSeq BenchmarkConfig{benchmarkName,ctx,wid} = do
 
     let era = Cardano.anyCardanoEra Cardano.BabbageEra
     (_, createMigrationPlanTime) <- bench "createMigrationPlan"
-        $ unsafeRunExceptT
-        $ W.createMigrationPlan @_ @k @s ctx era wid Tx.NoWithdrawal
+        $ W.createMigrationPlan @_ @k @s ctx era Tx.NoWithdrawal
 
     (_, delegationFeeTime) <- bench "delegationFee" $ do
         timeTranslation <-
@@ -322,18 +320,17 @@ benchmarksShared
        )
     => BenchmarkConfig n s k ktype
     -> IO BenchSharedResults
-benchmarksShared BenchmarkConfig{benchmarkName,ctx,wid} = do
+benchmarksShared BenchmarkConfig{benchmarkName,ctx} = do
     ((cp, pending), readWalletTime) <- bench "readWallet" $ do
-        (cp, _, pending) <- unsafeRunExceptT $ W.readWallet @_ @s @k ctx wid
+        (cp, _, pending) <- W.readWallet @_ @s @k ctx
         pure (cp, pending)
 
     (utxo, _) <- bench "utxo statistics" $
         pure $ UTxOStatistics.compute (totalUTxO pending cp)
 
     (_, getWalletUtxoSnapshotTime) <- bench "getWalletUtxoSnapshot"
-        $ fmap length
-        $ unsafeRunExceptT
-        $ W.getWalletUtxoSnapshot @_ @s @k @ktype ctx wid
+        $ length
+        <$> W.getWalletUtxoSnapshot @_ @s @k @ktype ctx
 
     (addresses, listAddressesTime) <- bench "listAddresses"
         $ fromIntegral . length
@@ -395,18 +392,17 @@ benchmarksRnd
        )
     => BenchmarkConfig n s k ktype
     -> IO BenchRndResults
-benchmarksRnd BenchmarkConfig{benchmarkName,ctx,wid} = do
+benchmarksRnd BenchmarkConfig{benchmarkName,ctx} = do
     ((cp, pending), readWalletTime) <- bench "readWallet" $ do
-        (cp, _, pending) <- unsafeRunExceptT $ W.readWallet @_ @s @k ctx wid
+        (cp, _, pending) <- W.readWallet @_ @s @k ctx
         pure (cp, pending)
 
     (utxo, _) <- bench "utxo statistics" $
         pure $ UTxOStatistics.compute (totalUTxO pending cp)
 
     (_, getWalletUtxoSnapshotTime) <- bench "getWalletUtxoSnapshot"
-        $ fmap length
-        $ unsafeRunExceptT
-        $ W.getWalletUtxoSnapshot @_ @s @k @ktype ctx wid
+        $ length
+        <$> W.getWalletUtxoSnapshot @_ @s @k @ktype ctx
 
     (addresses, listAddressesTime) <- bench "listAddresses"
         $ fromIntegral . length
@@ -429,8 +425,7 @@ benchmarksRnd BenchmarkConfig{benchmarkName,ctx,wid} = do
 
     let era = Cardano.anyCardanoEra Cardano.BabbageEra
     (_, createMigrationPlanTime) <- bench "createMigrationPlan"
-        $ unsafeRunExceptT
-        $ W.createMigrationPlan @_ @k @s ctx era wid Tx.NoWithdrawal
+        $ W.createMigrationPlan @_ @k @s ctx era Tx.NoWithdrawal
 
     pure BenchRndResults
         { benchName = benchmarkName
@@ -484,7 +479,7 @@ benchmarkWallets benchName dir walletTr networkId action = do
     withWalletsFromDirectory dir walletTr networkId
         $ \ctx@(MockWalletLayer{dbLayer=DB.DBLayer{atomically,readWalletMeta}}) wid
         -> do
-            Just (WalletMetadata{name},_) <- atomically readWalletMeta
+            (WalletMetadata{name},_) <- atomically readWalletMeta
             let config = BenchmarkConfig
                     { benchmarkName = benchName <> " " <> pretty name
                     , networkId = networkId

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -141,8 +141,6 @@ import Control.DeepSeq
     ( NFData (..), force )
 import Control.Monad
     ( join )
-import Control.Monad.Trans.Except
-    ( mapExceptT )
 import Criterion.Main
     ( Benchmark
     , Benchmarkable
@@ -511,7 +509,7 @@ benchPutTxHistory
     -> IO ()
 benchPutTxHistory numTxs numInputs numOutputs numAssets range DBLayer{..} = do
     let txs = mkTxHistory numTxs numInputs numOutputs numAssets range
-    unsafeRunExceptT $ mapExceptT atomically $ putTxHistory txs
+    atomically $ putTxHistory txs
 
 benchReadTxHistory
     :: SortOrder
@@ -618,7 +616,7 @@ txHistoryFixture  bSize nAssets range dbf = do
     db@DBLayer{..} <- walletFixture dbf
     let (nInps, nOuts) = (20, 20)
     let txs = mkTxHistory bSize nInps nOuts nAssets range
-    atomically $ unsafeRunExceptT $ putTxHistory txs
+    atomically $ putTxHistory txs
     pure db
 
 walletFixture :: DBFreshBench -> IO DBLayerBench

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -302,7 +302,7 @@ mkCheckpoints numCheckpoints utxoSize numAssets =
         (map fst $ mkInputs i utxoSize)
         (mkOutputs i utxoSize numAssets)
 
-benchReadUTxO :: DBLayerBench -> IO (Maybe WalletBench)
+benchReadUTxO :: DBLayerBench -> IO WalletBench
 benchReadUTxO DBLayer{..} = atomically readCheckpoint
 
 utxoFixture ::  Int -> Int -> Int -> DBFreshBench -> IO DBLayerBench

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -282,7 +282,7 @@ bgroupReadUTxO tr = bgroup "UTxO (Read)"
 benchPutUTxO :: Int -> Int -> Int -> DBLayerBench -> IO ()
 benchPutUTxO numCheckpoints utxoSize numAssets DBLayer{..} = do
     let cps = mkCheckpoints numCheckpoints utxoSize numAssets
-    unsafeRunExceptT $ mapExceptT atomically $ mapM_ putCheckpoint cps
+    atomically $ mapM_ putCheckpoint cps
 
 mkCheckpoints :: Int -> Int -> Int -> [WalletBench]
 mkCheckpoints numCheckpoints utxoSize numAssets =
@@ -309,7 +309,7 @@ utxoFixture ::  Int -> Int -> Int -> DBFreshBench -> IO DBLayerBench
 utxoFixture  numCheckpoints utxoSize numAssets dbf = do
     db@DBLayer{atomically, putCheckpoint} <- walletFixture dbf
     let cps = mkCheckpoints numCheckpoints utxoSize numAssets
-    unsafeRunExceptT $ mapM_ (mapExceptT atomically . putCheckpoint) cps
+    mapM_ (atomically . putCheckpoint) cps
     pure db
 
 ----------------------------------------------------------------------------
@@ -340,8 +340,7 @@ bgroupWriteSeqState tr = bgroup "SeqState"
             ]
 
 benchPutSeqState :: DBLayerBench -> [WalletBench] -> IO ()
-benchPutSeqState DBLayer{..} cps = do
-    unsafeRunExceptT $ mapExceptT atomically $ mapM_ putCheckpoint cps
+benchPutSeqState DBLayer{..} cps = atomically $ mapM_ putCheckpoint cps
 
 mkSeqState :: Int -> Int -> SeqState 'Mainnet ShelleyKey
 mkSeqState numAddrs _ = s
@@ -394,8 +393,7 @@ bgroupWriteRndState tr = bgroup "RndState"
             ]
 
 benchPutRndState :: DBLayerBenchByron -> [Wallet (RndState 'Mainnet)] -> IO ()
-benchPutRndState DBLayer{..} cps =
-    unsafeRunExceptT $ mapExceptT atomically $ mapM_ putCheckpoint cps
+benchPutRndState DBLayer{..} cps = atomically $ mapM_ putCheckpoint cps
 
 ----------------------------------------------------------------------------
 -- Tx history Benchmarks

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -463,9 +463,8 @@ benchmarksRnd network w@(WalletLayer _ _ netLayer txLayer dbLayer) wid wname
         pure $ UTxOStatistics.compute (totalUTxO pending cp)
 
     (addresses, listAddressesTime) <- bench "list addresses"
-        $ fmap (fromIntegral . length)
-        $ unsafeRunExceptT
-        $ W.listAddresses w wid (const pure)
+        $ fromIntegral . length
+        <$> W.listAddresses w (const pure)
 
     (transactions, listTransactionsTime) <- bench "list transactions"
         $ fmap (fromIntegral . length)
@@ -571,9 +570,7 @@ benchmarksSeq network w@(WalletLayer _ _ netLayer txLayer dbLayer) wid _wname
         pure $ UTxOStatistics.compute (totalUTxO pending cp)
 
     (addresses, listAddressesTime) <- bench "list addresses"
-        $ fmap (fromIntegral . length)
-        $ unsafeRunExceptT
-        $ W.listAddresses w wid (const pure)
+        $ fromIntegral . length <$> W.listAddresses w (const pure)
 
     (transactions, listTransactionsTime) <- bench "list transactions"
         $ fmap (fromIntegral . length)

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -456,7 +456,7 @@ benchmarksRnd
 benchmarksRnd network w@(WalletLayer _ _ netLayer txLayer dbLayer) wid wname
     benchname restoreTime = do
     ((cp, pending), readWalletTime) <- bench "read wallet" $ do
-        (cp, _, pending) <- unsafeRunExceptT $ W.readWallet w wid
+        (cp, _, pending) <- W.readWallet w
         pure (cp, pending)
 
     (utxo, _) <- bench "utxo statistics" $
@@ -564,7 +564,7 @@ benchmarksSeq
 benchmarksSeq network w@(WalletLayer _ _ netLayer txLayer dbLayer) wid _wname
     benchname restoreTime = do
     ((cp, pending), readWalletTime) <- bench "read wallet" $ do
-        (cp, _, pending) <- unsafeRunExceptT $ W.readWallet w wid
+        (cp, _, pending) <- W.readWallet w
         pure (cp, pending)
     (utxo, _) <- bench "utxo statistics" $
         pure $ UTxOStatistics.compute (totalUTxO pending cp)
@@ -897,7 +897,7 @@ waitForWalletSyncTo
 waitForWalletSyncTo targetSync tr proxy walletLayer wid gp vData = do
     posixNow <- utcTimeToPOSIXSeconds <$> getCurrentTime
     progress <-  do
-        w <- fmap fst' <$> unsafeRunExceptT $ W.readWallet walletLayer wid
+        w <- fst' <$> W.readWallet walletLayer
         syncProgress nl (slotNo $ currentTip w)
     traceWith tr $ MsgRestorationTick posixNow progress
     threadDelay 1000000

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -822,11 +822,10 @@ createIcarusWallet
 
 
 -- | Check whether a wallet is in good shape when restarting a worker.
-checkWalletIntegrity :: DBLayer IO s k -> WalletId -> GenesisParameters -> IO ()
-checkWalletIntegrity db walletId gp = db & \DBLayer{..} -> do
+checkWalletIntegrity :: DBLayer IO s k -> GenesisParameters -> IO ()
+checkWalletIntegrity db gp = db & \DBLayer{..} -> do
     gp' <- atomically readGenesisParameters >>= do
-        let noSuchWallet = ErrNoSuchWallet walletId
-        maybe (throwIO $ ErrCheckWalletIntegrityNoSuchWallet noSuchWallet) pure
+        maybe (throwIO ErrCheckWalletIntegrityNoGenesisParameters) pure
     when ( (gp ^. #getGenesisBlockHash /= gp' ^. #getGenesisBlockHash) ||
            (gp ^. #getGenesisBlockDate /= gp' ^. #getGenesisBlockDate) )
         (throwIO $ ErrCheckIntegrityDifferentGenesis
@@ -3390,7 +3389,7 @@ data ErrFetchRewards
     deriving (Generic, Eq, Show)
 
 data ErrCheckWalletIntegrity
-    = ErrCheckWalletIntegrityNoSuchWallet ErrNoSuchWallet
+    = ErrCheckWalletIntegrityNoGenesisParameters
     | ErrCheckIntegrityDifferentGenesis (Hash "Genesis") (Hash "Genesis")
     deriving (Eq, Show)
 

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1178,8 +1178,7 @@ restoreBlocks ctx tr wid blocks nodeTip = db & \DBLayer{..} ->
 
     lift $ putTxHistory txs
 
-    mkNoSuchWalletError wid
-        $ rollForwardTxSubmissions (localTip ^. #slotNo)
+    lift $ rollForwardTxSubmissions (localTip ^. #slotNo)
         $ fmap (\(tx,meta) -> (meta ^. #slotNo, txId tx)) txs
 
     lift $ forM_ slotPoolDelegations $ \delegation@(slotNo, cert) -> do

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1183,10 +1183,11 @@ restoreBlocks ctx tr wid blocks nodeTip = db & \DBLayer{..} ->
 
     liftIO $ mapM_ logCheckpoint cpsKeep
 
+    -- TODO: ADP-3003 remove the ExceptT layer in this function
     ExceptT $ modifyDBMaybe walletsDB $
         adjustNoSuchWallet wid id $ \_ -> Right ( delta, () )
 
-    mkNoSuchWalletError wid $ prune epochStability finalitySlot
+    lift $ prune epochStability finalitySlot
 
     liftIO $ do
         traceWith tr $ MsgDiscoveredTxs txs

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1377,15 +1377,10 @@ handleRewardAccountQuery
 handleRewardAccountQuery tr wid DBLayer{..} query = do
     traceWith tr $ MsgRewardBalanceResult query
     case query of
-       Right amt -> do
-           res <- atomically $ runExceptT $ mkNoSuchWalletError wid $
-               putDelegationRewardBalance amt
+       Right amt -> atomically $ putDelegationRewardBalance amt
            -- It can happen that the wallet doesn't exist _yet_, whereas we
            -- already have a reward balance. If that's the case, we log and
            -- move on.
-           case res of
-               Left err -> traceWith tr $ MsgRewardBalanceNoSuchWallet err
-               Right () -> pure ()
        Left _err ->
            -- Occasionally failing to query is generally not fatal. It will
            -- just update the balance next time the tip changes.

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -884,7 +884,7 @@ updateWallet
     -> ExceptT ErrNoSuchWallet IO ()
 updateWallet ctx wid modify = db & \DBLayer{..} -> mapExceptT atomically $ do
     meta <- fmap fst . withNoSuchWallet wid $ readWalletMeta
-    mkNoSuchWalletError wid $ putWalletMeta (modify meta)
+    lift $ putWalletMeta (modify meta)
   where
     db = ctx ^. dbLayer @IO @s @k
 
@@ -3040,7 +3040,7 @@ attachPrivateKey db wid (xprv, hpwd) scheme = db & \DBLayer{..} -> do
                     , passphraseScheme = scheme
                     }
                 }
-        mkNoSuchWalletError wid $ putWalletMeta (modify $ fst meta)
+        lift $ putWalletMeta (modify $ fst meta)
 
 -- | Execute an action which requires holding a root XPrv.
 --

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2462,15 +2462,7 @@ runLocalTxSubmissionPool cfg ctx = db & \DBLayer{..} -> do
         forM_ (filter (isScheduled sp sl) pendingOldStyle) $ \st -> do
             _ <- runExceptT $ traceResult (trRetry (st ^. #txId)) $
                 postTx nw (st ^. #submittedTx )
-            atomically $ do
-                result <- runExceptT $ resubmitTx
-                    (st ^. #txId)
-                    (st ^. #submittedTx)
-                    sl
-                case result of
-                    Left _  -> error
-                        "runLocalTxSubmissionPool: wallet not found"
-                    Right () -> pure ()
+            atomically $ resubmitTx (st ^. #txId) (st ^. #submittedTx) sl
     watchNodeTip nw submitPending
   where
     nw = ctx ^. networkLayer @m

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1182,8 +1182,7 @@ restoreBlocks ctx tr wid blocks nodeTip = db & \DBLayer{..} ->
         $ rollForwardTxSubmissions (localTip ^. #slotNo)
         $ fmap (\(tx,meta) -> (meta ^. #slotNo, txId tx)) txs
 
-    mkNoSuchWalletError wid
-        $ forM_ slotPoolDelegations $ \delegation@(slotNo, cert) -> do
+    lift $ forM_ slotPoolDelegations $ \delegation@(slotNo, cert) -> do
             liftIO $ logDelegation delegation
             putDelegationCertificate cert slotNo
 

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -497,7 +497,7 @@ import Control.Arrow
 import Control.DeepSeq
     ( NFData )
 import Control.Monad
-    ( forM, forM_, replicateM, unless, when, (<=<), (>=>) )
+    ( forM, forM_, replicateM, unless, when, (<=<) )
 import Control.Monad.Class.MonadTime
     ( DiffTime
     , MonadMonotonicTime (..)
@@ -2751,14 +2751,10 @@ delegationFee db@DBLayer{..} netLayer txLayer timeTranslation era
             -- previously, and the difference should be negligible.
             (PreSelection [])
         deposit <- liftIO
-            $ throwInIO . mkNoSuchWalletError walletId
-            $ mapExceptT atomically isStakeKeyRegistered <&> \case
+            $ atomically isStakeKeyRegistered <&> \case
                 False -> stakeKeyDeposit (Write.pparamsWallet protocolParams)
                 True -> Coin 0
         pure DelegationFee { feePercentiles, deposit }
-  where
-    throwInIO :: ExceptT ErrNoSuchWallet IO a -> IO a
-    throwInIO = runExceptT >=> either (throwIO . ExceptionNoSuchWallet) pure
 
 transactionFee
     :: forall s k n era
@@ -3427,8 +3423,7 @@ data ErrCreateMigrationPlan
     deriving (Generic, Eq, Show)
 
 data ErrStakePoolDelegation
-    = ErrStakePoolDelegationNoSuchWallet ErrNoSuchWallet
-    | ErrStakePoolJoin ErrCannotJoin
+    = ErrStakePoolJoin ErrCannotJoin
     | ErrStakePoolQuit ErrCannotQuit
     deriving (Show)
 

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -258,7 +258,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , putDelegationCertificate
         :: DelegationCertificate
         -> SlotNo
-        -> ExceptT ErrWalletNotInitialized stm ()
+        -> stm ()
         -- ^ Binds a stake pool id to a wallet. This will have an influence on
         -- the wallet metadata: the last known certificate will indicate to
         -- which pool a wallet is currently delegating.
@@ -529,8 +529,7 @@ mkDBLayerFromParts ti wid_ wrapNoSuchWallet DBLayerCollection{..} = DBLayer
                 wm <- readWalletMeta_ dbWalletMeta
                 pure (wm, del)
     , isStakeKeyRegistered = isStakeKeyRegistered_ dbDelegation
-    , putDelegationCertificate = \a b -> wrapNoSuchWallet $
-        putDelegationCertificate_ dbDelegation a b
+    , putDelegationCertificate = putDelegationCertificate_ dbDelegation
     , putDelegationRewardBalance = \a -> wrapNoSuchWallet $
         putDelegationRewardBalance_ dbDelegation a
     , readDelegationRewardBalance = readDelegationRewardBalance_ dbDelegation

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -578,7 +578,8 @@ mkDBLayerFromParts ti wid_ wrapNoSuchWallet DBLayerCollection{..} = DBLayer
             $ updateSubmissions' wid_ id
             $ \_ -> Right [Sbms.rollForwardTxSubmissions tip txs]
     , removePendingOrExpiredTx = \txid ->
-            updateSubmissions' wid_ (ErrRemoveTxNoSuchWallet . mapNoSuchWallet)
+            updateSubmissions' wid_
+                (const $ error "removePendingOrExpiredTx: no such wallet to be removed in ADP-3003")
                 $ \xs ->
                 pure <$> Sbms.removePendingOrExpiredTx xs txid
     , putPrivateKey = \a -> wrapNoSuchWallet $
@@ -596,7 +597,6 @@ mkDBLayerFromParts ti wid_ wrapNoSuchWallet DBLayerCollection{..} = DBLayer
         case mstate of
             Nothing -> pure def
             Just state -> action $ submissions state
-    mapNoSuchWallet _ = ErrWalletNotInitialized
     updateSubmissions' = updateSubmissions dbCheckpoints
     readCheckpoint' = readCheckpoint_ dbCheckpoints
     readCurrentTip :: stm BlockHeader

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -234,9 +234,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -- Intended to replace 'putCheckpoint' and 'readCheckpoint' in the short-term,
         -- and all other functions in the long-term.
 
-    , putCheckpoint
-        :: Wallet s
-        -> ExceptT ErrWalletNotInitialized stm ()
+    , putCheckpoint :: Wallet s -> stm ()
         -- ^ Replace the current checkpoint for a given wallet. We do not handle
         -- rollbacks yet, and therefore only stores the latest available
         -- checkpoint.
@@ -677,9 +675,7 @@ data DBCheckpoints stm s = DBCheckpoints
         -- Intended to replace 'putCheckpoint' and 'readCheckpoint' in the short-term,
         -- and all other functions in the long-term.
 
-    , putCheckpoint_
-        :: Wallet s
-        -> ExceptT ErrWalletNotInitialized stm ()
+    , putCheckpoint_ :: Wallet s -> stm ()
         -- ^ Replace the current checkpoint for a given wallet. We do not handle
         -- rollbacks yet, and therefore only stores the latest available
         -- checkpoint.

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -283,15 +283,11 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -- Returns zero if the wallet isn't found or if wallet hasn't delegated
         -- stake.
 
-    , putTxHistory
-        :: [(Tx, TxMeta)]
-        -> ExceptT ErrWalletNotInitialized stm ()
+    , putTxHistory :: [(Tx, TxMeta)] -> stm ()
         -- ^ Augments the transaction history for a known wallet.
         --
         -- If an entry for a particular transaction already exists it is not
         -- altered nor merged (just ignored).
-        --
-        -- If the wallet doesn't exist, this operation returns an error.
 
     , readTransactions
         :: Maybe Coin
@@ -530,8 +526,7 @@ mkDBLayerFromParts ti wid_ wrapNoSuchWallet DBLayerCollection{..} = DBLayer
     , putDelegationCertificate = putDelegationCertificate_ dbDelegation
     , putDelegationRewardBalance = putDelegationRewardBalance_ dbDelegation
     , readDelegationRewardBalance = readDelegationRewardBalance_ dbDelegation
-    , putTxHistory = \a -> wrapNoSuchWallet $
-        putTxHistory_ dbTxHistory a
+    , putTxHistory = putTxHistory_ dbTxHistory
     , readTransactions = \minWithdrawal order range status limit ->
         readCurrentTip >>= \tip -> do
                 inLedgers <- if status `elem` [Nothing, Just WTxMeta.InLedger]

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -371,7 +371,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , prune
         :: Quantity "block" Word32
         -> SlotNo
-        -> ExceptT ErrWalletNotInitialized stm ()
+        -> stm ()
         -- ^ Prune database entities and remove entities that can be discarded.
         --
         -- The second argument represents the stability window, or said
@@ -460,7 +460,7 @@ data DBLayerCollection stm m s k = DBLayerCollection
     , prune_
         :: Quantity "block" Word32
         -> SlotNo
-        -> ExceptT ErrWalletNotInitialized stm ()
+        -> stm ()
     , atomically_
         :: forall a. stm a -> m a
     }

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -359,7 +359,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
 
     , rollbackTo
         :: Slot
-        -> ExceptT ErrWalletNotInitialized stm ChainPoint
+        -> stm ChainPoint
         -- ^ Drops all checkpoints and transaction data which
         -- have appeared after the given 'ChainPoint'.
         --
@@ -456,7 +456,7 @@ data DBLayerCollection stm m s k = DBLayerCollection
     -- and distributed the smaller layer parts as well.
     , rollbackTo_
         :: Slot
-        -> ExceptT ErrWalletNotInitialized stm ChainPoint
+        -> stm ChainPoint
     , prune_
         :: Quantity "block" Word32
         -> SlotNo

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -248,12 +248,8 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -- ^ List all known checkpoint tips, ordered by slot ids from the oldest
         -- to the newest.
 
-    , putWalletMeta
-        :: WalletMetadata
-        -> ExceptT ErrWalletNotInitialized stm ()
+    , putWalletMeta :: WalletMetadata -> stm ()
         -- ^ Replace an existing wallet metadata with the given one.
-        --
-        -- If the wallet doesn't exist, this operation returns an error
 
     , readWalletMeta
         :: stm (Maybe (WalletMetadata, WalletDelegation))
@@ -686,12 +682,8 @@ data DBCheckpoints stm s = DBCheckpoints
 
 -- | A database layer for storing 'WalletMetadata'.
 data DBWalletMeta stm = DBWalletMeta
-    { putWalletMeta_
-        :: WalletMetadata
-        -> ExceptT ErrWalletNotInitialized stm ()
+    { putWalletMeta_ :: WalletMetadata -> stm ()
         -- ^ Replace an existing wallet metadata with the given one.
-        --
-        -- If the wallet doesn't exist, this operation returns an error
 
     , readWalletMeta_
         :: stm (Maybe WalletMetadata)

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -298,8 +298,6 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -> stm [TransactionInfo]
         -- ^ Fetch the current transaction history of a known wallet, ordered by
         -- descending slot number.
-        --
-        -- Returns an empty list if the wallet isn't found.
 
     , getTx
         :: Hash "Tx"
@@ -736,8 +734,6 @@ data DBTxHistory stm = DBTxHistory
         -> stm [TransactionInfo]
         -- ^ Fetch the current transaction history of a known wallet, ordered by
         -- descending slot number.
-        --
-        -- Returns an empty list if the wallet isn't found.
 
     , getTx_
         :: Hash "Tx"

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -269,9 +269,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -- 1. Stored on-chain.
         -- 2. Affected by rollbacks (or said differently, tied to a 'SlotNo').
 
-    , putDelegationRewardBalance
-        :: Coin
-        -> ExceptT ErrWalletNotInitialized stm ()
+    , putDelegationRewardBalance :: Coin -> stm ()
         -- ^ Store the latest known reward account balance.
         --
         -- This is separate from checkpoints because the data corresponds to the
@@ -530,8 +528,7 @@ mkDBLayerFromParts ti wid_ wrapNoSuchWallet DBLayerCollection{..} = DBLayer
                 pure (wm, del)
     , isStakeKeyRegistered = isStakeKeyRegistered_ dbDelegation
     , putDelegationCertificate = putDelegationCertificate_ dbDelegation
-    , putDelegationRewardBalance = \a -> wrapNoSuchWallet $
-        putDelegationRewardBalance_ dbDelegation a
+    , putDelegationRewardBalance = putDelegationRewardBalance_ dbDelegation
     , readDelegationRewardBalance = readDelegationRewardBalance_ dbDelegation
     , putTxHistory = \a -> wrapNoSuchWallet $
         putTxHistory_ dbTxHistory a

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -253,8 +253,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , readWalletMeta :: stm (WalletMetadata, WalletDelegation)
         -- ^ Fetch a wallet metadata, if they exist.
 
-    , isStakeKeyRegistered
-        :: ExceptT ErrWalletNotInitialized stm Bool
+    , isStakeKeyRegistered :: stm Bool
 
     , putDelegationCertificate
         :: DelegationCertificate
@@ -529,8 +528,7 @@ mkDBLayerFromParts ti wid_ wrapNoSuchWallet DBLayerCollection{..} = DBLayer
                 del <- readDelegation_ dbDelegation currentEpoch
                 wm <- readWalletMeta_ dbWalletMeta
                 pure (wm, del)
-    , isStakeKeyRegistered = wrapNoSuchWallet $
-        isStakeKeyRegistered_ dbDelegation
+    , isStakeKeyRegistered = isStakeKeyRegistered_ dbDelegation
     , putDelegationCertificate = \a b -> wrapNoSuchWallet $
         putDelegationCertificate_ dbDelegation a b
     , putDelegationRewardBalance = \a -> wrapNoSuchWallet $

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -331,7 +331,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , rollForwardTxSubmissions
         :: SlotNo
         -> [(SlotNo, Hash "Tx")]
-        -> ExceptT ErrWalletNotInitialized stm ()
+        -> stm ()
         -- ^ Removes any expired transactions from the pending set and marks
         -- their status as expired.
 
@@ -574,8 +574,8 @@ mkDBLayerFromParts ti wid_ wrapNoSuchWallet DBLayerCollection{..} = DBLayer
     , resubmitTx = \hash _ slotNo -> abortNoSuchWallet
             $ updateSubmissions' wid_ id
             $ Right . Sbms.resubmitTx hash slotNo
-    , rollForwardTxSubmissions = \tip txs -> updateSubmissions' wid_
-            mapNoSuchWallet
+    , rollForwardTxSubmissions = \tip txs -> abortNoSuchWallet
+            $ updateSubmissions' wid_ id
             $ \_ -> Right [Sbms.rollForwardTxSubmissions tip txs]
     , removePendingOrExpiredTx = \txid ->
             updateSubmissions' wid_ (ErrRemoveTxNoSuchWallet . mapNoSuchWallet)

--- a/lib/wallet/src/Cardano/Wallet/DB/Errors.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Errors.hs
@@ -48,6 +48,8 @@ newtype ErrNoSuchWallet
     = ErrNoSuchWallet WalletId -- Wallet is gone or doesn't exist yet
     deriving (Eq, Show)
 
+instance Exception ErrNoSuchWallet
+
 -- | Can't perform given operation because there's no wallet in the db
 data ErrWalletNotInitialized = ErrWalletNotInitialized
     deriving (Eq, Show)

--- a/lib/wallet/src/Cardano/Wallet/DB/Errors.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Errors.hs
@@ -28,8 +28,7 @@ data ErrPutLocalTxSubmission
 
 -- | Can't remove pending or expired transaction.
 data ErrRemoveTx
-    = ErrRemoveTxNoSuchWallet ErrWalletNotInitialized
-    | ErrRemoveTxNoSuchTransaction ErrNoSuchTransaction
+    = ErrRemoveTxNoSuchTransaction ErrNoSuchTransaction
     | ErrRemoveTxAlreadyInLedger (Hash "Tx")
     deriving (Eq, Show)
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Errors.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Errors.hs
@@ -48,7 +48,6 @@ newtype ErrNoSuchWallet
     = ErrNoSuchWallet WalletId -- Wallet is gone or doesn't exist yet
     deriving (Eq, Show)
 
-instance Exception ErrNoSuchWallet
 
 -- | Can't perform given operation because there's no wallet in the db
 data ErrWalletNotInitialized = ErrWalletNotInitialized

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -731,13 +731,8 @@ newDBFreshFromDBOpen ti wid_ DBOpen{atomically=runQuery} = mdo
         -----------------------------------------------------------------------}
     let
       dbWalletMeta = DBWalletMeta
-        { putWalletMeta_ = \meta -> ExceptT $ do
-            selectWallet wid_ >>= \case
-                Nothing -> pure $ Left ErrWalletNotInitialized
-                Just _ -> do
-                    updateWhere [WalId ==. wid_]
-                        (mkWalletMetadataUpdate meta)
-                    pure $ Right ()
+        { putWalletMeta_ = \meta ->
+            updateWhere [WalId ==. wid_] (mkWalletMetadataUpdate meta)
 
         , readWalletMeta_ = readWalletMetadata wid_
         }
@@ -956,10 +951,6 @@ privateKeyFromEntity (PrivateKey _ k h) =
 {-------------------------------------------------------------------------------
     SQLite database operations
 -------------------------------------------------------------------------------}
-
-selectWallet :: MonadIO m => W.WalletId -> SqlPersistT m (Maybe Wallet)
-selectWallet wid =
-    fmap entityVal <$> selectFirst [WalId ==. wid] []
 
 -- | Delete stake key certificates for a wallet.
 deleteStakeKeyCerts

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -156,7 +156,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans
     ( lift )
 import Control.Monad.Trans.Except
-    ( ExceptT (..), runExceptT, throwE )
+    ( runExceptT, throwE )
 import Control.Tracer
     ( Tracer, contramap, traceWith )
 import Data.Coerce
@@ -714,11 +714,10 @@ newDBFreshFromDBOpen ti wid_ DBOpen{atomically=runQuery} = mdo
                         $ view #currentTip wcp
 
     let prune_ epochStability finalitySlot = do
-            ExceptT $ do
-                readCheckpoint >>= \cp -> Right <$> do
+            readCheckpoint >>= \cp -> do
                         let tip = cp ^. #currentTip
                         pruneCheckpoints wid_ epochStability tip
-            lift $ updateDBVar walletsDB $ Adjust wid_
+            updateDBVar walletsDB $ Adjust wid_
                 [ UpdateSubmissions [pruneByFinality finalitySlot]
                 ]
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -621,18 +621,18 @@ newDBFreshFromDBOpen ti wid_ DBOpen{atomically=runQuery} = mdo
       dbCheckpoints = DBCheckpoints
         { walletsDB_ = walletsDB
 
-        , putCheckpoint_ = \cp -> ExceptT $ do
+        , putCheckpoint_ = \cp -> do
             modifyDBMaybe walletsDB $ \ws ->
                 if null ws
-                    then (Nothing, Left ErrWalletNotInitialized)
+                    then (Nothing, ())
                     else
                         let (prologue, wcp) = fromWallet cp
                             slot = getSlot wcp
-                            delta = Just $ Adjust wid_
+                            delta = Adjust wid_
                                 [ UpdateCheckpoints [ PutCheckpoint slot wcp ]
                                 , ReplacePrologue prologue
                                 ]
-                        in  (delta, Right ())
+                        in  (Just delta, ())
 
         , readCheckpoint_ = readCheckpoint
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -568,9 +568,9 @@ newDBFreshFromDBOpen ti wid_ DBOpen{atomically=runQuery} = mdo
 
     -- Retrieve the latest checkpoint from the DBVar
     let readCheckpoint
-            ::  SqlPersistT IO (Maybe (W.Wallet s))
+            ::  SqlPersistT IO (W.Wallet s)
         readCheckpoint =
-            fmap (getLatest . snd). Map.lookupMin <$> readDBVar walletsDB
+            getLatest . snd . Map.findMin <$> readDBVar walletsDB
 
     let pruneCheckpoints
             :: W.WalletId
@@ -715,9 +715,7 @@ newDBFreshFromDBOpen ti wid_ DBOpen{atomically=runQuery} = mdo
 
     let prune_ epochStability finalitySlot = do
             ExceptT $ do
-                readCheckpoint >>= \case
-                    Nothing -> pure $ Left ErrWalletNotInitialized
-                    Just cp -> Right <$> do
+                readCheckpoint >>= \cp -> Right <$> do
                         let tip = cp ^. #currentTip
                         pruneCheckpoints wid_ epochStability tip
             lift $ updateDBVar walletsDB $ Adjust wid_

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -731,10 +731,13 @@ newDBFreshFromDBOpen ti wid_ DBOpen{atomically=runQuery} = mdo
         -----------------------------------------------------------------------}
     let
       dbWalletMeta = DBWalletMeta
-        { putWalletMeta_ = \meta ->
-            updateWhere [WalId ==. wid_] (mkWalletMetadataUpdate meta)
+        { putWalletMeta_ = updateWhere [WalId ==. wid_] . mkWalletMetadataUpdate
 
-        , readWalletMeta_ = readWalletMetadata wid_
+        , readWalletMeta_ = do
+            mr <- readWalletMetadata wid_
+            case mr of
+                Nothing -> error "readWalletMeta_: not found"
+                Just r -> pure r
         }
 
         {-----------------------------------------------------------------------

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
@@ -238,12 +238,12 @@ mPutCheckpoint cp = alterModelNoTxs' $ \wal
     -> wal { checkpoints = Map.insert (tip cp) cp (checkpoints wal) }
 
 mReadCheckpoint
-    :: ModelOp wid s xprv (Maybe (Wallet s))
+    :: ModelOp wid s xprv (Wallet s)
 mReadCheckpoint db@(Database _ wallet _)
     = (Right (mostRecentCheckpoint wallet), db)
 
-mostRecentCheckpoint :: WalletDatabase s xprv -> Maybe (Wallet s)
-mostRecentCheckpoint = fmap snd . Map.lookupMax . checkpoints
+mostRecentCheckpoint :: WalletDatabase s xprv -> Wallet s
+mostRecentCheckpoint = snd . Map.findMax . checkpoints
 
 mListCheckpoints
     :: ModelOp wid s xprv [ChainPoint]

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -211,8 +211,7 @@ newDBFresh timeInterpreter wid = do
                                  Delegation Rewards
         -----------------------------------------------------------------------}
 
-        , putDelegationRewardBalance = ExceptT
-            . alterDB errWalletNotInitialized db
+        , putDelegationRewardBalance = noErrorAlterDB db
             . mPutDelegationRewardBalance
 
         , readDelegationRewardBalance = fromMaybe (Coin 0)

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -140,9 +140,7 @@ newDBFresh timeInterpreter wid = do
                                      Tx History
         -----------------------------------------------------------------------}
 
-        , putTxHistory = ExceptT
-            . alterDB errWalletNotInitialized db
-            . mPutTxHistory
+        , putTxHistory = noErrorAlterDB db . mPutTxHistory
 
         , readTransactions = \minWithdrawal order range mstatus _mlimit ->
             fmap (fromMaybe []) $

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -168,9 +168,7 @@ newDBFresh timeInterpreter wid = do
                                        Keystore
         -----------------------------------------------------------------------}
 
-        , putPrivateKey = ExceptT
-            . alterDB errWalletNotInitialized db
-            . mPutPrivateKey
+        , putPrivateKey = noErrorAlterDB db . mPutPrivateKey
 
         , readPrivateKey = join <$> readDBMaybe db mReadPrivateKey
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -128,8 +128,7 @@ newDBFresh timeInterpreter wid = do
 
         , putWalletMeta = noErrorAlterDB db .  mPutWalletMeta
 
-        , readWalletMeta = fmap join
-            $ readDBMaybe db
+        , readWalletMeta = throwErrorReadDB db
             $ mReadWalletMeta timeInterpreter
 
         , putDelegationCertificate = \cert sl -> ExceptT $

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -135,8 +135,7 @@ newDBFresh timeInterpreter wid = do
             alterDB errWalletNotInitialized db $
             mPutDelegationCertificate cert sl
 
-        , isStakeKeyRegistered =
-            ExceptT . alterDB errWalletNotInitialized db $ mIsStakeKeyRegistered
+        , isStakeKeyRegistered = throwErrorReadDB db mIsStakeKeyRegistered
 
         {-----------------------------------------------------------------------
                                      Tx History

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -131,8 +131,7 @@ newDBFresh timeInterpreter wid = do
         , readWalletMeta = throwErrorReadDB db
             $ mReadWalletMeta timeInterpreter
 
-        , putDelegationCertificate = \cert sl -> ExceptT $
-            alterDB errWalletNotInitialized db $
+        , putDelegationCertificate = \cert sl -> noErrorAlterDB db $
             mPutDelegationCertificate cert sl
 
         , isStakeKeyRegistered = throwErrorReadDB db mIsStakeKeyRegistered

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -126,9 +126,7 @@ newDBFresh timeInterpreter wid = do
                                    Wallet Metadata
         -----------------------------------------------------------------------}
 
-        , putWalletMeta = ExceptT
-            .  alterDB errWalletNotInitialized db
-            .  mPutWalletMeta
+        , putWalletMeta = noErrorAlterDB db .  mPutWalletMeta
 
         , readWalletMeta = fmap join
             $ readDBMaybe db

--- a/lib/wallet/src/Cardano/Wallet/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation.hs
@@ -229,9 +229,7 @@ quitStakePool
     -> WalletId
     -> IO TransactionCtx
 quitStakePool netLayer db timeInterpreter walletId = do
-    (rewardAccount, _, derivationPath) <-
-        runExceptT (readRewardAccount db walletId)
-            >>= either (throwIO . ExceptionReadRewardAccount) pure
+    (rewardAccount, _, derivationPath) <- readRewardAccount db
     withdrawal <- WithdrawalSelf rewardAccount derivationPath
         <$> getCachedRewardAccountBalance netLayer rewardAccount
     action <- quitStakePoolDelegationAction db walletId withdrawal

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -591,8 +591,7 @@ fileModeSpec =  do
                     atomically $ do
                         putCheckpoint cpB
                         putTxHistory txs
-                        unsafeRunExceptT
-                            $ prune (Quantity 2_160) $ 2_160 * 3 * 20
+                        prune (Quantity 2_160) $ 2_160 * 3 * 20
 
             it "Should spend collateral inputs and create spendable collateral \
                 \outputs if validation fails" $

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -802,8 +802,7 @@ fileModeSpec =  do
                 getAvailableBalance db `shouldReturn` 2
                 getTxsInLedger db `shouldReturn` [(Outgoing, 2), (Incoming, 4)]
 
-                atomically . void . unsafeRunExceptT $
-                    rollbackTo (At $ SlotNo 200)
+                atomically . void $ rollbackTo (At $ SlotNo 200)
                 cp <- atomically readCheckpoint
                 view #slotNo (currentTip cp) `shouldBe` (SlotNo 0)
 

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -531,7 +531,7 @@ fileModeSpec =  do
                     $ bootDBLayer
                         testDBLayerParams{dBLayerParamsMetadata = meta}
                 return (meta, WalletDelegation NotDelegating [])
-            testReopening f readWalletMeta' (Just meta)
+            testReopening f readWalletMeta' meta
 
         it "create and get private key" $ \f -> do
             (k, h) <- withShelleyFileDBFresh f $ \DBFresh{bootDBLayer} -> do
@@ -953,7 +953,7 @@ readCheckpoint' DBLayer{..} = atomically readCheckpoint
 
 readWalletMeta'
     :: DBLayer m s k
-    -> m (Maybe (WalletMetadata, WalletDelegation))
+    -> m (WalletMetadata, WalletDelegation)
 readWalletMeta' DBLayer{..} = atomically readWalletMeta
 
 readTransactions'
@@ -1316,9 +1316,7 @@ testMigrationPassphraseScheme1 = do
     -- after the migration, both should now be `Just`.
     (logs, a) <- withDBLayerFromCopiedFile @ShelleyKey
         "passphraseScheme/she.17ca0ed41a372e483f2968aa386a4b6b0ca6b5ee.sqlite"
-        $ \DBLayer{..} -> atomically $ do
-            Just a <- readWalletMeta
-            pure (fst a)
+        $ \DBLayer{..} -> atomically $ fst <$> readWalletMeta
 
     -- Migration is visible from the logs
     let migrationMsg = filter isMsgManualMigrationPw logs
@@ -1331,9 +1329,7 @@ testMigrationPassphraseScheme2 = do
     -- scheme set to use PBKDF2. Nothing should have changed.
     (logs, a) <- withDBLayerFromCopiedFile @ShelleyKey
         "passphraseScheme/she.2e8353d2bb937445948669a1dcc69ec9628a558c.sqlite"
-        $ \DBLayer{..} -> atomically $ do
-            Just a <- readWalletMeta
-            pure (fst a)
+        $ \DBLayer{..} -> atomically $ fst <$> readWalletMeta
 
     let migrationMsg = filter isMsgManualMigrationPw logs
     length migrationMsg `shouldBe` 1
@@ -1345,9 +1341,7 @@ testMigrationPassphraseScheme3 = do
     -- scheme. Nothing should have changed.
     (logs, a) <- withDBLayerFromCopiedFile @ShelleyKey
         "passphraseScheme/she.899abf7137aa8b3200d55d70474f6fdd2649fa2f.sqlite"
-        $ \DBLayer{..} -> atomically $ do
-            Just a <- readWalletMeta
-            pure (fst a)
+        $ \DBLayer{..} -> atomically $ fst <$> readWalletMeta
 
     let migrationMsg = filter isMsgManualMigrationPw logs
     length migrationMsg `shouldBe` 1
@@ -1359,9 +1353,7 @@ testMigrationPassphraseScheme4 = do
     -- account public key), so it should still have NO scheme.
     (logs, a ) <- withDBLayerFromCopiedFile @ShelleyKey
         "passphraseScheme/she.be92ab4ec9399449e53b94378e6cb6724691f8b3.sqlite"
-        $ \DBLayer{..} -> atomically $ do
-            Just a <- readWalletMeta
-            pure (fst a)
+        $ \DBLayer{..} -> atomically $ fst <$> readWalletMeta
 
     let migrationMsg = filter isMsgManualMigrationPw logs
     length migrationMsg `shouldBe` 1

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -569,7 +569,7 @@ fileModeSpec =  do
             withShelleyFileDBFresh f $ \DBFresh{bootDBLayer} -> do
                 DBLayer{atomically, putCheckpoint} <-
                     unsafeRunExceptT $ bootDBLayer testDBLayerParams
-                atomically $ unsafeRunExceptT $ putCheckpoint testCp
+                atomically $ putCheckpoint testCp
             testReopening f readCheckpoint' (Just testCp)
 
         describe "Golden rollback scenarios" $ do
@@ -597,7 +597,7 @@ fileModeSpec =  do
                     let (FilteredBlock{transactions=txs}, (_,cpB)) =
                             applyBlock fakeBlock cpA
                     atomically $ do
-                        unsafeRunExceptT $ putCheckpoint cpB
+                        putCheckpoint cpB
                         unsafeRunExceptT $ putTxHistory txs
                         unsafeRunExceptT
                             $ prune (Quantity 2_160) $ 2_160 * 3 * 20
@@ -852,7 +852,7 @@ prop_randomOpChunks (NonEmpty (p : pairs)) =
         -> (Wallet s, WalletMetadata)
         -> IO ()
     insertPair DBLayer{..} (cp, meta) = atomically $ do
-            unsafeRunExceptT $ putCheckpoint cp
+            putCheckpoint cp
             unsafeRunExceptT $ putWalletMeta meta
 
     imposeGenesisState :: Wallet s -> Wallet s

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -852,8 +852,8 @@ prop_randomOpChunks (NonEmpty (p : pairs)) =
         -> (Wallet s, WalletMetadata)
         -> IO ()
     insertPair DBLayer{..} (cp, meta) = atomically $ do
-            putCheckpoint cp
-            unsafeRunExceptT $ putWalletMeta meta
+        putCheckpoint cp
+        putWalletMeta meta
 
     imposeGenesisState :: Wallet s -> Wallet s
     imposeGenesisState = over #currentTip $ \(BlockHeader _ _ h _) ->

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -545,7 +545,7 @@ fileModeSpec =  do
             withShelleyFileDBFresh f $ \DBFresh{bootDBLayer} -> do
                 DBLayer{atomically, putTxHistory} <-
                     unsafeRunExceptT $ bootDBLayer testDBLayerParams
-                atomically $ unsafeRunExceptT $ putTxHistory testTxs
+                atomically $ putTxHistory testTxs
             testReopening
                 f
                 ( \db' ->
@@ -557,7 +557,7 @@ fileModeSpec =  do
             withShelleyFileDBFresh f $ \DBFresh{bootDBLayer} -> do
                 DBLayer{atomically, putTxHistory} <-
                     unsafeRunExceptT $ bootDBLayer testDBLayerParams
-                atomically $ unsafeRunExceptT $ putTxHistory testTxs
+                atomically $ putTxHistory testTxs
             testReopening
                 f
                 ( \db' ->
@@ -598,7 +598,7 @@ fileModeSpec =  do
                             applyBlock fakeBlock cpA
                     atomically $ do
                         putCheckpoint cpB
-                        unsafeRunExceptT $ putTxHistory txs
+                        putTxHistory txs
                         unsafeRunExceptT
                             $ prune (Quantity 2_160) $ 2_160 * 3 * 20
 

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -368,7 +368,7 @@ prop_getTxAfterPutValidTxId test txGen = test $ \DBLayer {..} _ -> do
     run $ atomically $ putTxHistory txs
     forM_ txs $ \(Tx {txId}, txMeta) -> do
         (Just (TransactionInfo {txInfoId, txInfoMeta})) <-
-            run $ atomically $ unsafeRunExceptT $ getTx txId
+            run $ atomically $ getTx txId
         monitor
             $ counterexample
             $ "\nInserted\n"
@@ -393,7 +393,7 @@ prop_getTxAfterPutInvalidTxId
 prop_getTxAfterPutInvalidTxId test txGen txId' = test $ \DBLayer {..} _ -> do
     let txs = unGenTxHistory txGen
     run $ atomically $ putTxHistory txs
-    res <- run $ atomically $ unsafeRunExceptT $ getTx txId'
+    res <- run $ atomically $ getTx txId'
     assertWith
         "Irrespective of Inserted, Read is Nothing for invalid tx id"
         (isNothing res)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -163,7 +163,7 @@ properties withFreshDB = describe "DB.Properties" $ do
             $ property
             $ prop_readAfterPut
                 testOnLayer
-                (\DBLayer{..} _wid -> mapExceptT atomically . putWalletMeta)
+                (\DBLayer{..} _wid -> lift . atomically . putWalletMeta)
                 (\DBLayer{..} _ -> atomically . fmap (fmap fst)
                     $ readWalletMeta)
         it "Tx History"
@@ -200,7 +200,7 @@ properties withFreshDB = describe "DB.Properties" $ do
             $ property
             $ prop_isolation
                 testOnLayer
-                (\DBLayer{..} _wid -> mapExceptT atomically . putWalletMeta)
+                (\DBLayer{..} _wid -> lift . atomically . putWalletMeta)
                 (\db _ -> readTxHistory_ db)
                 (\DBLayer{..} _ -> atomically readCheckpoint)
                 (\DBLayer{..} _wid -> atomically readPrivateKey)
@@ -228,7 +228,7 @@ properties withFreshDB = describe "DB.Properties" $ do
             $ checkCoverage
             $ prop_sequentialPut
                 testOnLayer
-                (\DBLayer{..} _wid -> mapExceptT atomically . putWalletMeta)
+                (\DBLayer{..} _wid -> lift . atomically . putWalletMeta)
                 (\DBLayer{..} _ -> atomically . fmap (fmap fst)
                     $ readWalletMeta)
                 lastMay

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -175,7 +175,7 @@ properties withFreshDB = describe "DB.Properties" $ do
             $ property
             $ prop_readAfterPut
                 testOnLayer
-                (\DBLayer{..} _wid -> mapExceptT atomically . putPrivateKey)
+                (\DBLayer{..} _wid -> lift . atomically . putPrivateKey)
                 (\DBLayer{..} _wid -> atomically readPrivateKey)
 
     describe "getTx properties" $ do
@@ -246,7 +246,7 @@ properties withFreshDB = describe "DB.Properties" $ do
             $ checkCoverage
             $ prop_sequentialPut
                 testOnLayer
-                (\DBLayer{..} _wid -> mapExceptT atomically . putPrivateKey)
+                (\DBLayer{..} _wid -> lift . atomically . putPrivateKey)
                 (\DBLayer{..} _wid -> atomically readPrivateKey)
                 lastMay
 

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -164,8 +164,7 @@ properties withFreshDB = describe "DB.Properties" $ do
             $ prop_readAfterPut
                 testOnLayer
                 (\DBLayer{..} _wid -> lift . atomically . putWalletMeta)
-                (\DBLayer{..} _ -> atomically . fmap (fmap fst)
-                    $ readWalletMeta)
+                (\DBLayer{..} _ -> Identity . fst <$>  atomically readWalletMeta)
         it "Tx History"
             $ property
             $ prop_readAfterPut
@@ -229,8 +228,7 @@ properties withFreshDB = describe "DB.Properties" $ do
             $ prop_sequentialPut
                 testOnLayer
                 (\DBLayer{..} _wid -> lift . atomically . putWalletMeta)
-                (\DBLayer{..} _ -> atomically . fmap (fmap fst)
-                    $ readWalletMeta)
+                (\DBLayer{..} _ -> Just . fst <$> atomically readWalletMeta)
                 lastMay
         it "Tx History"
             $ checkCoverage

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -69,7 +69,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans
     ( lift )
 import Control.Monad.Trans.Except
-    ( ExceptT, mapExceptT, runExceptT )
+    ( ExceptT, runExceptT )
 import Crypto.Hash
     ( hash )
 import Data.ByteString
@@ -509,10 +509,8 @@ prop_rollbackCheckpoint test (InitialCheckpoint cp0) (MockChain chain) =
                         $ DBLayerParams cp0 meta mempty gp
                 atomically $ forM_ cps putCheckpoint
                 let tip = currentTip point
-                point' <-
-                    atomically
-                        $ unsafeRunExceptT
-                        $ rollbackTo (toSlot $ chainPointFromBlockHeader tip)
+                point' <- atomically
+                    $ rollbackTo (toSlot $ chainPointFromBlockHeader tip)
                 cp <- atomically readCheckpoint
                 pure (tip, cp, point')
             let str = pretty cp
@@ -551,10 +549,7 @@ prop_rollbackTxHistory test (InitialCheckpoint cp0) (GenTxHistory txs0) = do
                     $ bootDBLayer
                     $ DBLayerParams cp0 meta mempty gp
             atomically $ putTxHistory txs0
-            point <-
-                unsafeRunExceptT
-                    $ mapExceptT atomically
-                    $ rollbackTo (At requestedPoint)
+            point <- atomically $ rollbackTo (At requestedPoint)
             txs <-
                 atomically
                     $ fmap toTxHistory

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -494,8 +494,7 @@ runIO DBLayer{..} = fmap Resp . go
             atomically $
             readTransactions minWith order range status Nothing
         GetTx tid ->
-            catchNoSuchWallet (TxHistory . maybe [] pure) $
-            runDB atomically $ getTx tid
+            runDBSuccess atomically (TxHistory . maybe [] pure) $ getTx tid
         PutPrivateKey pk -> catchNoSuchWallet Unit $
             runDB atomically $
             putPrivateKey (fromMockPrivKey pk)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -484,8 +484,8 @@ runIO DBLayer{..} = fmap Resp . go
         PutWalletMeta meta ->
             runDBSuccess atomically Unit $ putWalletMeta meta
         ReadWalletMeta -> Right . (Metadata . fst) <$> atomically readWalletMeta
-        PutDelegationCertificate pool sl -> catchNoSuchWallet Unit $
-            runDB atomically $ putDelegationCertificate pool sl
+        PutDelegationCertificate pool sl ->
+            runDBSuccess atomically Unit $ putDelegationCertificate pool sl
         IsStakeKeyRegistered _wid ->
             runDBSuccess atomically StakeKeyStatus isStakeKeyRegistered
         PutTxHistory txs -> catchNoSuchWallet Unit $

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -507,7 +507,7 @@ runIO DBLayer{..} = fmap Resp . go
         fmap (bimap errNoSuchWallet f) . runExceptT
 
     errNoSuchWallet :: ErrNoSuchWallet -> Err
-    errNoSuchWallet (ErrNoSuchWallet _wid) = WalletAlreadyInitialized
+    errNoSuchWallet (ErrNoSuchWallet _wid) = WalletNotInitialized
 
 {-------------------------------------------------------------------------------
   Working with references

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -488,8 +488,7 @@ runIO DBLayer{..} = fmap Resp . go
             runDBSuccess atomically Unit $ putDelegationCertificate pool sl
         IsStakeKeyRegistered _wid ->
             runDBSuccess atomically StakeKeyStatus isStakeKeyRegistered
-        PutTxHistory txs -> catchNoSuchWallet Unit $
-            runDB atomically $ putTxHistory txs
+        PutTxHistory txs -> runDBSuccess atomically Unit $ putTxHistory txs
         ReadTxHistory minWith order range status ->
             fmap (Right . TxHistory) $
             atomically $

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -504,8 +504,7 @@ runIO DBLayer{..} = fmap Resp . go
             atomically readPrivateKey
         ReadGenesisParameters -> Right . GenesisParams <$>
             atomically readGenesisParameters
-        PutDelegationRewardBalance _wid amt -> catchNoSuchWallet Unit $
-            runDB atomically $
+        PutDelegationRewardBalance _wid amt -> runDBSuccess atomically Unit $
             putDelegationRewardBalance amt
         ReadDelegationRewardBalance -> Right . DelegationRewardBalance <$>
             atomically readDelegationRewardBalance

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -486,8 +486,8 @@ runIO DBLayer{..} = fmap Resp . go
         ReadWalletMeta -> Right . (Metadata . fst) <$> atomically readWalletMeta
         PutDelegationCertificate pool sl -> catchNoSuchWallet Unit $
             runDB atomically $ putDelegationCertificate pool sl
-        IsStakeKeyRegistered _wid -> catchNoSuchWallet StakeKeyStatus $
-            runDB atomically isStakeKeyRegistered
+        IsStakeKeyRegistered _wid ->
+            runDBSuccess atomically StakeKeyStatus isStakeKeyRegistered
         PutTxHistory txs -> catchNoSuchWallet Unit $
             runDB atomically $ putTxHistory txs
         ReadTxHistory minWith order range status ->

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -482,8 +482,8 @@ runIO DBLayer{..} = fmap Resp . go
             atomically readCheckpoint
         ListCheckpoints -> Right . ChainPoints <$>
             atomically listCheckpoints
-        PutWalletMeta meta -> catchNoSuchWallet Unit $
-            runDB atomically $ putWalletMeta meta
+        PutWalletMeta meta ->
+            runDBSuccess atomically Unit $ putWalletMeta meta
         ReadWalletMeta -> Right . (Metadata . fmap fst) <$>
             atomically readWalletMeta
         PutDelegationCertificate pool sl -> catchNoSuchWallet Unit $

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -495,8 +495,8 @@ runIO DBLayer{..} = fmap Resp . go
             readTransactions minWith order range status Nothing
         GetTx tid ->
             runDBSuccess atomically (TxHistory . maybe [] pure) $ getTx tid
-        PutPrivateKey pk -> catchNoSuchWallet Unit $
-            runDB atomically $
+        PutPrivateKey pk ->
+            runDBSuccess atomically  Unit $
             putPrivateKey (fromMockPrivKey pk)
         ReadPrivateKey -> Right . PrivateKey . fmap toMockPrivKey <$>
             atomically readPrivateKey

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -371,7 +371,7 @@ data Success s wid
     | NewWallet wid
     | WalletId' wid
     | Checkpoint (Wallet s)
-    | Metadata (Maybe WalletMetadata)
+    | Metadata WalletMetadata
     | TxHistory [TransactionInfo]
     | LocalTxSubmission [LocalTxSubmissionStatus (Hash "Tx")]
     | PrivateKey (Maybe MPrivKey)
@@ -412,8 +412,7 @@ runMock = \case
     PutWalletMeta meta ->
         first (Resp . fmap Unit) . mPutWalletMeta meta
     ReadWalletMeta ->
-        first (Resp . fmap (Metadata . fmap fst) )
-            . mReadWalletMeta timeInterpreter
+        first (Resp . fmap (Metadata . fst) ) . mReadWalletMeta timeInterpreter
     PutDelegationCertificate cert sl ->
         first (Resp . fmap Unit) . mPutDelegationCertificate cert sl
     IsStakeKeyRegistered _wid ->
@@ -484,8 +483,7 @@ runIO DBLayer{..} = fmap Resp . go
             atomically listCheckpoints
         PutWalletMeta meta ->
             runDBSuccess atomically Unit $ putWalletMeta meta
-        ReadWalletMeta -> Right . (Metadata . fmap fst) <$>
-            atomically readWalletMeta
+        ReadWalletMeta -> Right . (Metadata . fst) <$> atomically readWalletMeta
         PutDelegationCertificate pool sl -> catchNoSuchWallet Unit $
             runDB atomically $ putDelegationCertificate pool sl
         IsStakeKeyRegistered _wid -> catchNoSuchWallet StakeKeyStatus $

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -478,7 +478,7 @@ walletListTransactionsSorted wallet@(_, _, _) _order (_mstart, _mend) =
     forAll (logScale' 1.5 arbitrary) $ \history ->
     monadicIO $ liftIO $ do
         WalletLayerFixture _ DBLayer{..} wl _ <- setupFixture wallet
-        atomically $ unsafeRunExceptT $ putTxHistory history
+        atomically $ putTxHistory history
         txs <- unsafeRunExceptT $
             W.listTransactions @_ @_ @_ wl Nothing Nothing Nothing
                 Descending Nothing
@@ -522,7 +522,7 @@ walletListTransactionsWithLimit wallet@(_, _, _) =
         limitNatural = fromIntegral limit
         test start stop order dir cut = liftIO @(PropertyM IO) $ do
             WalletLayerFixture _ DBLayer{..} wl _ <- setupFixture wallet
-            atomically $ unsafeRunExceptT $ putTxHistory history'
+            atomically $ putTxHistory history'
             txs <- unsafeRunExceptT $
                 W.listTransactions @_ @_ @_ wl Nothing start stop order
                     $ Just limitNatural
@@ -597,7 +597,7 @@ walletListsOnlyRelatedAssets txId txMeta =
     forAll genOuts $ \(out1, out2, wallet) -> monadicIO $ do
         WalletLayerFixture _ DBLayer{..} wl _ <- liftIO $ setupFixture wallet
         let listHistoricalAssets hry = do
-                liftIO . atomically . unsafeRunExceptT $ putTxHistory hry
+                liftIO . atomically $ putTxHistory hry
                 liftIO $ W.listAssets wl
         let tx = Tx
                 { txId

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -35,7 +35,6 @@ import Cardano.Tx.Balance.Internal.CoinSelection
     )
 import Cardano.Wallet
     ( ErrSignPayment (..)
-    , ErrSubmitTx (..)
     , ErrUpdatePassphrase (..)
     , ErrWithRootKey (..)
     , LocalTxSubmissionConfig (..)
@@ -297,7 +296,6 @@ spec = describe "Cardano.WalletSpec" $ do
     describe "Pointless mockEventSource to cover 'Show' instances for errors" $ do
         let wid = WalletId (hash @ByteString "arbitrary")
         it (show $ ErrSignPaymentNoSuchWallet (ErrNoSuchWallet wid)) True
-        it (show $ ErrSubmitTxNoSuchWallet (ErrNoSuchWallet wid)) True
         it (show $ ErrUpdatePassphraseNoSuchWallet (ErrNoSuchWallet wid)) True
         it (show $ ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase) True
 
@@ -795,9 +793,9 @@ prop_localTxSubmission tc = monadicIO $ do
     st <- TxRetryTestState tc 2 <$> newMVar (Time 0)
     assert $ not $ null $ retryTestPool tc
     res <- run $ runTest st
-        $ \ctx@(TxRetryTestCtx dbl@(DBLayer{..}) nl tr _ wid) -> do
+        $ \ctx@(TxRetryTestCtx dbl@(DBLayer{..}) nl tr _ _) -> do
         unsafeRunExceptT
-            $ forM_ (retryTestPool tc) $ submitTx tr dbl nl wid
+            $ forM_ (retryTestPool tc) $ submitTx tr dbl nl
         res0 <- atomically readLocalTxSubmissionPending
         -- Run test
         let cfg = LocalTxSubmissionConfig (timeStep st) 10


### PR DESCRIPTION
Massive removal of code. By cleaning up the WalletNotInitialized condition from DBLayer, almost all NoSuchWallet errors are removed from the wallet api.
- [x] remove WalletNotInitialized from pure implementation of DBLayer 
- [x] remove NoSuchWallet exception where applicable (see commit list)
- [x] add TODOs for ADP-3003 to remove unused `Err....` constructors

      



