### PR TITLE
Drop `W.ProtocolParameters` from `Write.ProtocolParameters`

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2557,7 +2557,7 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
 
         unbalancedTx <- liftHandler $
             W.constructTransaction @n @'CredFromKeyK @era
-                txLayer netLayer db transactionCtx2
+                txLayer db transactionCtx2
                     PreSelection { outputs = outs <> mintingOuts }
 
         balancedTx <-
@@ -2910,7 +2910,7 @@ constructSharedTransaction
                             F.toList (addressAmountToTxOut <$> content)
                 (unbalancedTx, scriptLookup) <- liftHandler $
                     W.constructUnbalancedSharedTransaction @n @'CredFromScriptK @era
-                    txLayer netLayer db txCtx PreSelection {outputs = outs}
+                    txLayer db txCtx PreSelection {outputs = outs}
 
                 balancedTx <-
                     balanceTransaction api argGenChange (Just scriptLookup)

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -651,7 +651,7 @@ newTransactionLayer networkId = TransactionLayer
                     stakingScriptResolver addressResolver inputResolver (body, wits)
                     & sealedTxFromCardano'
 
-    , mkUnsignedTransaction = \stakeCred _pp ctx selection -> do
+    , mkUnsignedTransaction = \stakeCred ctx selection -> do
         let ttl   = txValidityInterval ctx
         let wdrl  = view #txWithdrawal ctx
         let delta = case selection of

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -188,8 +188,6 @@ data TransactionLayer k ktype tx = TransactionLayer
          . WriteTx.IsRecentEra era
         => Either XPub (Maybe (Script KeyHash))
             -- Reward account public key or optional script hash
-        -> ProtocolParameters
-            -- Current protocol parameters
         -> TransactionCtx
             -- An additional context about the transaction
         -> Either PreSelection (SelectionOf TxOut)

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -69,6 +69,7 @@ module Cardano.Wallet.Write.Tx
     , Core.PParams
     , FeePerByte (..)
     , getFeePerByte
+    , feeOfBytes
     , maxScriptExecutionCost
 
     -- * Tx
@@ -866,6 +867,12 @@ getFeePerByte
 getFeePerByte era pp = FeePerByte $ case era of
     RecentEraConway -> pp ^. #_minfeeA
     RecentEraBabbage -> pp ^. #_minfeeA
+
+feeOfBytes
+    :: FeePerByte
+    -> Natural
+    -> Coin
+feeOfBytes (FeePerByte perByte) bytes = Coin $ intCast $ perByte * bytes
 
 type ExUnitPrices = Alonzo.Prices
 

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -278,6 +278,7 @@ type RecentEraLedgerConstraints era =
     , HasField' "_minfeeA" (Core.PParams era) Natural
     , HasField' "_prices" (Core.PParams era) ExUnitPrices
     , HasField' "_maxTxExUnits" (Core.PParams era) ExUnits
+    , HasField' "_keyDeposit" (Core.PParams era) Coin
     )
 
 -- | Bring useful constraints into scope from a value-level

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -71,6 +71,7 @@ module Cardano.Wallet.Write.Tx
     , getFeePerByte
     , feeOfBytes
     , maxScriptExecutionCost
+    , stakeKeyDeposit
 
     -- * Tx
     , Core.Tx
@@ -887,6 +888,13 @@ maxScriptExecutionCost
     -> Coin
 maxScriptExecutionCost era pp = withConstraints era $
     txscriptfee (pp ^. #_prices) (pp ^. #_maxTxExUnits)
+
+stakeKeyDeposit
+    :: RecentEra era
+    -> Core.PParams (Cardano.ShelleyLedgerEra era)
+    -> Coin
+stakeKeyDeposit era pp = withConstraints era $
+    pp ^. #_keyDeposit
 
 --------------------------------------------------------------------------------
 -- Balancing

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -84,7 +84,10 @@ import Cardano.Wallet.Address.Derivation
 import Cardano.Wallet.Address.Derivation.Shared
     ( SharedKey (..) )
 import Cardano.Wallet.Primitive.Types
-    ( FeePolicy (LinearFee), LinearFunction (LinearFunction) )
+    ( FeePolicy (LinearFee)
+    , LinearFunction (LinearFunction)
+    , TokenBundleMaxSize (TokenBundleMaxSize)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Redeemer
@@ -960,9 +963,13 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 
         selectionConstraints = SelectionConstraints
             { assessTokenBundleSize =
-                view #assessTokenBundleSize $
-                tokenBundleSizeAssessor txLayer $
-                pp ^. #txParameters . #getTokenBundleMaxSize
+                view #assessTokenBundleSize
+                $ tokenBundleSizeAssessor txLayer
+                $ TokenBundleMaxSize
+                $ TxSize
+                $ case recentEra @era of
+                    RecentEraBabbage -> ledgerPP ^. #_maxValSize
+                    RecentEraConway -> ledgerPP ^. #_maxValSize
             , certificateDepositAmount = W.toWallet $ case recentEra @era of
                 RecentEraBabbage -> getField @"_keyDeposit" ledgerPP
                 RecentEraConway -> getField @"_keyDeposit" ledgerPP

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -963,8 +963,9 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 view #assessTokenBundleSize $
                 tokenBundleSizeAssessor txLayer $
                 pp ^. #txParameters . #getTokenBundleMaxSize
-            , certificateDepositAmount =
-                pp ^. #stakeKeyDeposit
+            , certificateDepositAmount = W.toWallet $ case recentEra @era of
+                RecentEraBabbage -> getField @"_keyDeposit" ledgerPP
+                RecentEraConway -> getField @"_keyDeposit" ledgerPP
             , computeMinimumAdaQuantity = \addr tokens -> W.toWallet $
                 computeMinimumCoinForTxOut
                     (recentEra @era)


### PR DESCRIPTION
- [x] Get `_maxTxSize` from `ledgerPP`
- [x] Don't rely on `W.LinearFee`
- [x] `_maxValSize` from ledgerPP
- [x] `_keyDeposit` from ledgerPP
- [x] Drop dep on W.ProtocolParameters for minAdaQuantity calculations
- [x] Drop `W.ProtocolParameters` from `Write.ProtocolParameters` 🎉 

### Comments

Depends on #3894

### Issue Number

ADP-2459
