### PR TITLE
Add benchmark for `UTxOIndex` type.

### DIFF
--- a/lib/primitive/bench/UTxOIndexBench.hs
+++ b/lib/primitive/bench/UTxOIndexBench.hs
@@ -1,0 +1,241 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Copyright: © 2018-2023 IOHK
+-- License: Apache-2.0
+--
+-- A benchmark for the 'UTxOIndex' type.
+--
+module Main where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..), mockHash )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle (..) )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( AssetId (..), TokenMap )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenName (..), TokenPolicyId (..) )
+import Cardano.Wallet.Primitive.Types.TokenQuantity
+    ( TokenQuantity (..) )
+import Control.DeepSeq
+    ( rnf )
+import Control.Exception
+    ( evaluate )
+import Data.Map.Strict
+    ( Map )
+import Data.Text.Format.Numbers
+    ( prettyI )
+import Numeric.Natural
+    ( Natural )
+import Test.QuickCheck
+    ( Gen, choose, frequency, generate, oneof, variant, vectorOf )
+import Test.QuickCheck.Extra
+    ( chooseNatural )
+import Test.Tasty.Bench
+    ( Benchmark, bench, bgroup, defaultMain, nf )
+
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
+
+main :: IO ()
+main = benchmarkIndexFromMap
+
+-- | A benchmark for the 'UTxOIndex.fromMap' operation.
+--
+benchmarkIndexFromMap :: IO ()
+benchmarkIndexFromMap = do
+
+    -- Construct UTxO maps of various sizes:
+
+    let utxoMapAdaOnly___1_000 = makeUTxOMapAdaOnly   1_000
+    let utxoMapAdaOnly__10_000 = makeUTxOMapAdaOnly  10_000
+    let utxoMapAdaOnly_100_000 = makeUTxOMapAdaOnly 100_000
+
+    let utxoMapNFTs___1_000 = makeUTxOMapNFTs   1_000
+    let utxoMapNFTs__10_000 = makeUTxOMapNFTs  10_000
+    let utxoMapNFTs_100_000 = makeUTxOMapNFTs 100_000
+
+    utxoMapDiverse___1_000 <- makeUTxOMapDiverse   1_000
+    utxoMapDiverse__10_000 <- makeUTxOMapDiverse  10_000
+    utxoMapDiverse_100_000 <- makeUTxOMapDiverse 100_000
+
+    -- Ensure the UTxO maps are fully evaluated (no thunks):
+
+    evaluate $ rnf utxoMapAdaOnly___1_000
+    evaluate $ rnf utxoMapAdaOnly__10_000
+    evaluate $ rnf utxoMapAdaOnly_100_000
+
+    evaluate $ rnf utxoMapNFTs___1_000
+    evaluate $ rnf utxoMapNFTs__10_000
+    evaluate $ rnf utxoMapNFTs_100_000
+
+    evaluate $ rnf utxoMapDiverse___1_000
+    evaluate $ rnf utxoMapDiverse__10_000
+    evaluate $ rnf utxoMapDiverse_100_000
+
+    defaultMain
+        [ bgroup
+            "Constructing a UTxO index from a map with ada-only bundles"
+            [ makeBenchmark utxoMapAdaOnly___1_000
+            , makeBenchmark utxoMapAdaOnly__10_000
+            , makeBenchmark utxoMapAdaOnly_100_000
+            ]
+        , bgroup
+            "Constructing a UTxO index from a map with (ada, NFT) bundles"
+            [ makeBenchmark utxoMapNFTs___1_000
+            , makeBenchmark utxoMapNFTs__10_000
+            , makeBenchmark utxoMapNFTs_100_000
+            ]
+        , bgroup
+            "Constructing a UTxO index from a map with diverse bundles"
+            [ makeBenchmark utxoMapDiverse___1_000
+            , makeBenchmark utxoMapDiverse__10_000
+            , makeBenchmark utxoMapDiverse_100_000
+            ]
+        ]
+  where
+    makeBenchmark :: UTxOMap -> Benchmark
+    makeBenchmark testMap =
+        bench description $ nf UTxOIndex.fromMap testMap
+      where
+        description = unwords
+            [ "with"
+            , prettyInt (Map.size testMap)
+            , "entries"
+            ]
+
+type UTxOMap = Map UTxOMapKey TokenBundle
+type UTxOMapKey = Natural
+type UTxOMapSize = Int
+
+-- | Constructs a map with ada-only token bundles.
+--
+makeUTxOMapAdaOnly :: UTxOMapSize -> UTxOMap
+makeUTxOMapAdaOnly size =
+    Map.fromList $ take size $ zip testUTxOMapKeys bundles
+  where
+    bundles :: [TokenBundle]
+    bundles = repeat $ TokenBundle.fromCoin minimalCoin
+
+-- | Constructs a map with bundles consisting of (ada, NFT) pairs.
+--
+makeUTxOMapNFTs :: UTxOMapSize -> UTxOMap
+makeUTxOMapNFTs size =
+    Map.fromList $ take size $ zip testUTxOMapKeys bundles
+  where
+    bundles :: [TokenBundle]
+    bundles = makeBundle <$> testUTxOMapKeys
+
+    makeBundle :: Natural -> TokenBundle
+    makeBundle n = TokenBundle.fromFlatList minimalCoin
+        [(makeTestAssetId n, minimalTokenQuantity)]
+
+-- | Constructs a map with a diverse variety of different bundles.
+--
+makeUTxOMapDiverse :: UTxOMapSize -> IO UTxOMap
+makeUTxOMapDiverse =
+    generateWithSeed fixedSeed . genUTxOMapDiverse
+  where
+    -- A fixed PRNG seed to maximise consistency between benchmark runs.
+    fixedSeed :: Int
+    fixedSeed = 0
+
+-- | Generates a map with a diverse variety of different bundles.
+--
+genUTxOMapDiverse :: UTxOMapSize -> Gen UTxOMap
+genUTxOMapDiverse size =
+    Map.fromList . zip testUTxOMapKeys <$>
+    vectorOf size genTokenBundle
+  where
+    genTokenBundle :: Gen TokenBundle
+    genTokenBundle = TokenBundle <$> genAdaQuantity <*> genTokenMap
+
+    genAdaQuantity :: Gen Coin
+    genAdaQuantity = Coin <$> chooseNatural (1, 1_000_000_000)
+
+    genTokenMap :: Gen TokenMap
+    genTokenMap = do
+        tokenMapSize <- genTokenMapSize
+        TokenMap.fromFlatList <$> vectorOf tokenMapSize genAssetQuantity
+
+    genTokenMapSize :: Gen Int
+    genTokenMapSize =
+        -- Bias toward smaller bundles, but also allow larger bundles:
+        frequency
+            [ (3, choose (0, 2))
+            , (1, choose (3, 8))
+            ]
+
+    genAssetQuantity :: Gen (AssetId, TokenQuantity)
+    genAssetQuantity = oneof
+        [genAssetQuantityFungible, genAssetQuantityNonFungible]
+
+    genAssetQuantityFungible :: Gen (AssetId, TokenQuantity)
+    genAssetQuantityFungible =
+        (,) <$> genAssetIdFungible <*> genTokenQuantityFungible
+
+    genAssetQuantityNonFungible :: Gen (AssetId, TokenQuantity)
+    genAssetQuantityNonFungible =
+        (,) <$> genAssetIdNonFungible <*> genTokenQuantityNonFungible
+
+    genAssetIdFungible :: Gen AssetId
+    genAssetIdFungible =
+        makeTestAssetId <$> chooseNatural (0, 9)
+
+    genAssetIdNonFungible :: Gen AssetId
+    genAssetIdNonFungible =
+        makeTestAssetId <$> chooseNatural (10, 1_000_000_000)
+
+    genTokenQuantityFungible :: Gen TokenQuantity
+    genTokenQuantityFungible =
+        TokenQuantity <$> chooseNatural (1, 1_000)
+
+    genTokenQuantityNonFungible :: Gen TokenQuantity
+    genTokenQuantityNonFungible =
+        pure minimalTokenQuantity
+
+testUTxOMapKeys :: [UTxOMapKey]
+testUTxOMapKeys = [0 ..]
+
+makeTestAssetId :: Natural -> AssetId
+makeTestAssetId n = AssetId
+    (makeTestTokenPolicyId (n `div` 4))
+    (makeTestTokenName     (n `mod` 4))
+
+makeTestTokenPolicyId :: Natural -> TokenPolicyId
+makeTestTokenPolicyId = UnsafeTokenPolicyId . mockHash
+
+makeTestTokenName :: Natural -> TokenName
+makeTestTokenName = UnsafeTokenName . getHash . mockHash
+
+minimalCoin :: Coin
+minimalCoin = Coin 1
+
+minimalTokenQuantity :: TokenQuantity
+minimalTokenQuantity = TokenQuantity 1
+
+--------------------------------------------------------------------------------
+-- Utilities
+--------------------------------------------------------------------------------
+
+-- | Generates values using a specific PRNG seed.
+--
+generateWithSeed :: Int -> Gen a -> IO a
+generateWithSeed seed = generate . variant seed
+
+-- | Pretty-prints a number with separators.
+--
+-- >>> prettyInt 1_000_000
+-- "1,000,000"
+--
+prettyInt :: Int -> String
+prettyInt = T.unpack . prettyI (Just ',')

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -167,3 +167,24 @@ test-suite test
     Data.QuantitySpec
     Spec
     SpecHook
+
+benchmark utxo-index
+    default-language:
+        Haskell2010
+    type:
+        exitcode-stdio-1.0
+    hs-source-dirs:
+        bench
+    main-is:
+        UTxOIndexBench.hs
+    build-depends:
+      , base
+      , cardano-wallet-primitive
+      , cardano-wallet-test-utils
+      , containers
+      , deepseq
+      , format-numbers
+      , QuickCheck
+      , tasty-bench
+      , tasty-hunit
+      , text


### PR DESCRIPTION
## Issue

ADP-2975

## Summary

This PR adds a small benchmark targeting the `UTxOIndex` type, and the `fromMap` function in particular.

This allows speedy hypothesis testing of changes to `fromMap`, even with `-O2`. (It's only necessary to recompile the `cardano-wallet-primitive` library, which is fast.)

## Details

When compiled with `-O2`, this produces the following timings:

```
  Constructing a UTxO index from a map with ada-only bundles
    with 1,000 entries:   OK (0.80s)
      1.12 ms ±  89 μs
    with 10,000 entries:  OK (0.57s)
      14.6 ms ± 792 μs
    with 100,000 entries: OK (1.55s)
      181  ms ± 8.0 ms
  Constructing a UTxO index from a map with (ada, NFT) bundles
    with 1,000 entries:   OK (0.78s)
      3.46 ms ± 184 μs
    with 10,000 entries:  OK (1.00s)
      47.2 ms ± 1.7 ms
    with 100,000 entries: OK (2.21s)
      667  ms ± 7.7 ms
  Constructing a UTxO index from a map with diverse bundles
    with 1,000 entries:   OK (0.87s)
      4.73 ms ± 225 μs
    with 10,000 entries:  OK (0.77s)
      69.4 ms ± 4.3 ms
    with 100,000 entries: OK (3.38s)
      1.057 s ±  43 ms
```