### PR TITLE
Consolidate conversions between `Coin` and `Quantity`.

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -44,7 +44,6 @@ module Cardano.Wallet.Primitive.Types.Coin
     , partition
     , partitionDefault
     , unsafePartition
-    , coinToQuantity
     , coinFromQuantity
     ) where
 
@@ -184,9 +183,6 @@ toQuantityMaybe (Coin c) = Quantity <$> intCastMaybe c
 --
 toWord64Maybe :: Coin -> Maybe Word64
 toWord64Maybe (Coin c) = intCastMaybe c
-
-coinToQuantity :: Integral n => Coin -> Quantity "lovelace" n
-coinToQuantity = Quantity . Prelude.fromIntegral . unCoin
 
 coinFromQuantity :: Integral n => Quantity "lovelace" n -> Coin
 coinFromQuantity = Coin . Prelude.fromIntegral . getQuantity

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -44,7 +44,6 @@ module Cardano.Wallet.Primitive.Types.Coin
     , partition
     , partitionDefault
     , unsafePartition
-    , coinFromQuantity
     ) where
 
 import Prelude hiding
@@ -184,8 +183,6 @@ toQuantityMaybe (Coin c) = Quantity <$> intCastMaybe c
 toWord64Maybe :: Coin -> Maybe Word64
 toWord64Maybe (Coin c) = intCastMaybe c
 
-coinFromQuantity :: Integral n => Quantity "lovelace" n -> Coin
-coinFromQuantity = Coin . Prelude.fromIntegral . getQuantity
 --------------------------------------------------------------------------------
 -- Conversions (Unsafe)
 -------------------------------------------------------------------------------

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1807,8 +1807,8 @@ selectCoins ctx@ApiLayer {..} argGenChange (ApiT walletId) body = do
             , certificates = uncurry mkApiCoinSelectionCerts <$>
                 delegationAction
             , withdrawals = mkApiCoinSelectionWithdrawal <$> withdrawals
-            , depositsTaken = maybeToList $ mkApiCoin <$> deposit
-            , depositsReturned = maybeToList $ mkApiCoin <$> refund
+            , depositsTaken = maybeToList $ Coin.toQuantity <$> deposit
+            , depositsReturned = maybeToList $ Coin.toQuantity <$> refund
             , metadata = ApiBytesT. serialiseToCBOR
                 <$> body ^? #metadata . traverse . #getApiT
             }
@@ -1877,8 +1877,8 @@ selectCoinsForJoin ctx@ApiLayer{..}
             , certificates = uncurry mkApiCoinSelectionCerts <$>
                 delegationAction
             , withdrawals = mkApiCoinSelectionWithdrawal <$> withdrawals
-            , depositsTaken = maybeToList $ mkApiCoin <$> deposit
-            , depositsReturned = maybeToList $ mkApiCoin <$> refund
+            , depositsTaken = maybeToList $ Coin.toQuantity <$> deposit
+            , depositsReturned = maybeToList $ Coin.toQuantity <$> refund
             , metadata = Nothing
             }
 
@@ -1934,8 +1934,8 @@ selectCoinsForQuit ctx@ApiLayer{..} (ApiT walletId) = do
             , certificates = uncurry mkApiCoinSelectionCerts <$>
                 delegationAction
             , withdrawals = mkApiCoinSelectionWithdrawal <$> withdrawals
-            , depositsTaken = maybeToList $ mkApiCoin <$> deposit
-            , depositsReturned = maybeToList $ mkApiCoin <$> refund
+            , depositsTaken = maybeToList $ Coin.toQuantity <$> deposit
+            , depositsReturned = maybeToList $ Coin.toQuantity <$> refund
             , metadata = Nothing
             }
 
@@ -4316,9 +4316,9 @@ mkApiCoinSelection deps refunds mcerts metadata unsignedTx =
             <$> unsignedTx ^. #unsignedWithdrawals
         , certificates = uncurry mkApiCoinSelectionCerts
             <$> mcerts
-        , depositsTaken = mkApiCoin
+        , depositsTaken = Coin.toQuantity
             <$> deps
-        , depositsReturned = mkApiCoin
+        , depositsReturned = Coin.toQuantity
             <$> refunds
         , metadata = ApiBytesT. serialiseToCBOR
             <$> metadata
@@ -4541,17 +4541,14 @@ mkApiTransaction timeInterpreter wrk timeRefLens tx = do
         :: TxOut
         -> AddressAmountNoAssets (ApiAddress n)
     toAddressAmountNoAssets (TxOut addr (TokenBundle.TokenBundle coin _)) =
-        AddressAmountNoAssets (ApiAddress addr) (mkApiCoin coin)
+        AddressAmountNoAssets (ApiAddress addr) (Coin.toQuantity coin)
 
 toAddressAmount
     :: forall n
      . TxOut
     -> AddressAmount (ApiAddress n)
 toAddressAmount (TxOut addr (TokenBundle.TokenBundle coin assets)) =
-    AddressAmount (ApiAddress addr) (mkApiCoin coin) (ApiT assets)
-
-mkApiCoin :: Coin -> Quantity "lovelace" Natural
-mkApiCoin (Coin c) = Quantity $ fromIntegral c
+    AddressAmount (ApiAddress addr) (Coin.toQuantity coin) (ApiT assets)
 
 mkApiFee
     :: Maybe Coin
@@ -4569,7 +4566,7 @@ mkApiWithdrawal
     :: (RewardAccount, Coin)
     -> ApiWithdrawal n
 mkApiWithdrawal (acct, c) =
-    ApiWithdrawal (ApiRewardAccount acct) (mkApiCoin c)
+    ApiWithdrawal (ApiRewardAccount acct) (Coin.toQuantity c)
 
 addressAmountToTxOut
     :: AddressAmount (ApiAddress n)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
@@ -48,7 +48,7 @@ import Cardano.Wallet.Primitive.Types
     , unsafeEpochNo
     )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), coinFromQuantity )
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
@@ -318,7 +318,7 @@ instance FromJSON (ApiT W.TokenBundle) where
             <*> fmap getApiT (v .: "assets" .!= mempty)
       where
         validateCoin :: Quantity "lovelace" Word64 -> Aeson.Parser Coin
-        validateCoin (coinFromQuantity -> c)
+        validateCoin (Coin.fromQuantity -> c)
             | coinIsValidForTxOut c = pure c
             | otherwise = fail $
                 "invalid coin value: value has to be lower than or equal to "

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
@@ -48,7 +48,7 @@ import Cardano.Wallet.Primitive.Types
     , unsafeEpochNo
     )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), coinFromQuantity, coinToQuantity )
+    ( Coin (..), coinFromQuantity )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
@@ -101,8 +101,11 @@ import Data.Word
     ( Word32, Word64 )
 import Data.Word.Odd
     ( Word31 )
+import Numeric.Natural
+    ( Natural )
 
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
@@ -302,7 +305,7 @@ instance ToJSON (ApiT W.TokenMap) where
 instance ToJSON (ApiT W.TokenBundle) where
     -- TODO: consider other structures
     toJSON (ApiT (W.TokenBundle c ts)) = object
-        [ "amount" .= coinToQuantity @Word c
+        [ "amount" .= Coin.toQuantity @Natural c
         , "assets" .= toJSON (ApiT ts)
         ]
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Transaction.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Transaction.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- |
 -- Copyright: © 2018-2022 IOHK
@@ -58,7 +59,7 @@ import Cardano.Wallet.Primitive.Passphrase.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (unCoin), coinFromQuantity )
+    ( Coin (unCoin) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
@@ -117,6 +118,7 @@ import Quiet
 import Servant
     ( FromHttpApiData (..), ToHttpApiData (..) )
 
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
 import qualified Data.Aeson.Types as Aeson
 
@@ -274,7 +276,7 @@ instance FromJSON a => FromJSON (AddressAmount a) where
             <*> v .:? "assets" .!= mempty
       where
         validateCoin q
-            | coinIsValidForTxOut (coinFromQuantity q) = pure q
+            | coinIsValidForTxOut (Coin.fromQuantity q) = pure q
             | otherwise = fail $
                 "invalid coin value: value has to be lower than or equal to "
                 <> show (unCoin txOutMaxCoin) <> " lovelace."

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -102,6 +102,7 @@ import Test.Integration.Framework.TestData
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Api.Types as ApiTypes
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
@@ -1061,7 +1062,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 , expectField id
                     ((`shouldBe` 1) . apiPlanTotalOutputCount)
                 , expectField (#balanceSelected . #ada)
-                    (`shouldBe` coinToQuantity (view #coin sourceBalance))
+                    (`shouldBe` Coin.toQuantity (view #coin sourceBalance))
                 , expectField (#balanceLeftover . #ada . #getQuantity)
                     (`shouldBe` 0)
                 , expectField (#balanceSelected . #assets . #getApiT)
@@ -1263,6 +1264,3 @@ apiPlanTotalInputCount p =
 apiPlanTotalOutputCount :: ApiWalletMigrationPlan n -> Int
 apiPlanTotalOutputCount p =
     F.sum (length . view #outputs <$> view #selections p)
-
-coinToQuantity :: Coin -> Quantity "lovelace" Natural
-coinToQuantity = Quantity . fromIntegral . unCoin


### PR DESCRIPTION
## Issue

None. Noticed while working in the area.

## Summary

This PR consolidates several different functions that perform conversions between `Coin` and `Quantity`, leaving just:
- `Coin.fromQuantity`
- `Coin.toQuantity`

Some of the removed functions use `fromIntegral`, which is a potential footgun, as it performs silent truncation at runtime if the target type is not at least as wide as the source type.

The `Coin.{from,to}Quantity` functions use `intCast`, which is safer, as its type signature allows the compiler to check that the target type is at least as wide as the source type.