### PR TITLE
[ADP-3008] Remove `removePendingOrExpiredTx` from `DBLayer`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -319,11 +319,12 @@ import Cardano.Wallet.DB
     , ErrWalletAlreadyExists (..)
     , ErrWalletNotInitialized (..)
     )
+import Cardano.Wallet.DB.Errors
+    ( ErrNoSuchWallet (..) )
 import Cardano.Wallet.DB.Store.Submissions.Layer
     ( mkLocalTxSubmission )
 import Cardano.Wallet.DB.WalletState
     ( DeltaWalletState1 (..)
-    , ErrNoSuchWallet (..)
     , fromWallet
     , getLatest
     , getSlot

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -186,9 +186,6 @@ newDBFresh timeInterpreter wid = do
         , rollForwardTxSubmissions =
             error "rollForwardTxSubmissions not tested in State Machine tests"
 
-        , removePendingOrExpiredTx = error
-            "removePendingOrExpiredTx not implemented in State Machine tests"
-
         {-----------------------------------------------------------------------
                                  Protocol Parameters
         -----------------------------------------------------------------------}

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
@@ -112,16 +112,18 @@ rollForwardTxSubmissions
     :: SlotNo -> [(SlotNo, Hash "Tx")] -> DeltaTxSubmissions
 rollForwardTxSubmissions tip txs = RollForward tip (second TxId <$> txs)
 
-removePendingOrExpiredTx :: TxSubmissions -> Hash "Tx"
-    -> Either ErrRemoveTx DeltaTxSubmissions
-removePendingOrExpiredTx walletSubmissions txId = do
+removePendingOrExpiredTx
+    :: Hash "Tx"
+    -> TxSubmissions
+    -> Either ErrRemoveTx [DeltaTxSubmissions]
+removePendingOrExpiredTx txId walletSubmissions = do
     let
         errNoTx = ErrRemoveTxNoSuchTransaction $ ErrNoSuchTransaction txId
         errInLedger = ErrRemoveTxAlreadyInLedger txId
     case status (TxId txId) (transactions walletSubmissions) of
         Unknown -> Left errNoTx
         InLedger{} -> Left errInLedger
-        _ -> Right $ Forget (TxId txId)
+        _ -> Right [Forget (TxId txId)]
 
 rollBackSubmissions :: SlotNo -> DeltaTxSubmissions
 rollBackSubmissions = RollBack

--- a/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
@@ -35,7 +35,6 @@ module Cardano.Wallet.DB.WalletState
 
     -- * Multiple wallets
     , DeltaMap (..)
-    , ErrNoSuchWallet (..)
     , adjustWallet
     , updateState
     , updateStateWithResult
@@ -49,8 +48,6 @@ import Cardano.Wallet.Address.Book
     ( AddressBookIso (..), Discoveries, Prologue )
 import Cardano.Wallet.Checkpoints
     ( Checkpoints )
-import Cardano.Wallet.DB.Errors
-    ( ErrNoSuchWallet (..) )
 import Cardano.Wallet.DB.Store.Submissions.Layer
     ( emptyTxSubmissions )
 import Cardano.Wallet.DB.Store.Submissions.Operations

--- a/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
@@ -35,6 +35,7 @@ module Cardano.Wallet.DB.WalletState
 
     -- * Helpers
     , modifyRight
+    , updateSubmissionsEither
 
     , updateState
     , updateStateWithResult
@@ -188,6 +189,13 @@ modifyRight update a =
     case update a of
         Left e -> (Nothing, Left e)
         Right (da, b) -> (Just da, Right b)
+
+updateSubmissionsEither
+    :: (TxSubmissions -> Either e [DeltaTxSubmissions])
+    -> (WalletState s -> (Maybe (DeltaWalletState s), Either e ()))
+updateSubmissionsEither f =
+    modifyRight $
+        fmap ((,()) . (:[]) . UpdateSubmissions) . f . submissions
 
 updateStateWithResult :: (Delta da, Monad m)
     => (Base da -> w)

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/ServerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/ServerSpec.hs
@@ -26,7 +26,7 @@ import Cardano.Wallet.Api.Http.Shelley.Server
     )
 import Cardano.Wallet.Api.Types
     ( ApiNetworkInformation (..), ApiWalletMode (..) )
-import Cardano.Wallet.DB.WalletState
+import Cardano.Wallet.DB.Errors
     ( ErrNoSuchWallet (..) )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( dummyNetworkLayer )


### PR DESCRIPTION
### Overview

We want to remove functions from the `DBLayer` record until essentially all DB access is done through the `walletsDB :: DBVar`.

This pull request removes `removePendingOrExpiredTx` from the `DBLayer` record.

### Issue number

ADP-3008