### PR TITLE
[ADP-3010] Remove `readLocalTxSubmissionPending` from `DBLayer`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -178,6 +178,7 @@ module Cardano.Wallet
     , getTransaction
     , submitExternalTx
     , submitTx
+    , readLocalTxSubmissionPending
     , LocalTxSubmissionConfig (..)
     , defaultLocalTxSubmissionConfig
     , runLocalTxSubmissionPool
@@ -2451,7 +2452,7 @@ runLocalTxSubmissionPool
 runLocalTxSubmissionPool cfg ctx = db & \DBLayer{..} -> do
     submitPending <- rateLimited $ \bh -> bracketTracer trBracket $ do
         sp <- currentSlottingParameters nw
-        pending <- atomically readLocalTxSubmissionPending
+        pending <- readLocalTxSubmissionPending @m @s @k ctx
         let sl = bh ^. #slotNo
             pendingOldStyle = pending >>= mkLocalTxSubmission
         -- Re-submit transactions due, ignore errors

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -323,6 +323,8 @@ import Cardano.Wallet.DB.Errors
     ( ErrNoSuchWallet (..) )
 import Cardano.Wallet.DB.Store.Submissions.Layer
     ( mkLocalTxSubmission )
+import Cardano.Wallet.DB.Store.Submissions.Operations
+    ( TxSubmissionsStatus )
 import Cardano.Wallet.DB.WalletState
     ( DeltaWalletState1 (..)
     , fromWallet
@@ -2377,6 +2379,27 @@ forgetTx ctx txid = db & \DBLayer{..} ->
         $ Submissions.removePendingOrExpiredTx txid
   where
     db = ctx ^. dbLayer @IO @s @k
+
+-- | List all transactions from the local submission pool which are
+-- still pending as of the latest checkpoint of the given wallet. The
+-- slot numbers for first submission and most recent submission are
+-- included.
+readLocalTxSubmissionPending
+    :: forall m s k ctx.
+        ( HasDBLayer m s k ctx
+        )
+    => ctx
+    -> m [TxSubmissionsStatus]
+readLocalTxSubmissionPending ctx = db & \DBLayer{..} ->
+    atomically
+        $ readLocalTxSubmissionPending' <$> readDBVar walletsDB
+  where
+    db = ctx ^. dbLayer @m @s @k
+
+    readLocalTxSubmissionPending' =
+          filter Submissions.isInSubmission
+        . Submissions.getInSubmissionTransactions
+        . WalletState.submissions
 
 -- | Given a LocalTxSubmission record, calculate the slot when it should be
 -- retried next.

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -308,13 +308,6 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -> stm ()
         -- ^ Resubmit a transaction.
 
-    , readLocalTxSubmissionPending
-        :: stm [TxSubmissionsStatus]
-        -- ^ List all transactions from the local submission pool which are
-        -- still pending as of the latest checkpoint of the given wallet. The
-        -- slot numbers for first submission and most recent submission are
-        -- included.
-
     , rollForwardTxSubmissions
         :: SlotNo
         -> [(SlotNo, Hash "Tx")]
@@ -518,9 +511,6 @@ mkDBLayerFromParts ti wid_ DBLayerCollection{..} = DBLayer
             updateSubmissionsNoError dbCheckpoints
                 $ \_ -> mkUpdateSubmissions
                     [Sbms.addTxSubmission builtTx slotNo]
-    , readLocalTxSubmissionPending = withSubmissions $ \xs -> do
-        pure $ filter (has $ txStatus . _InSubmission) $
-            getInSubmissionTransactions xs
     , resubmitTx = \hash _ slotNo ->
             updateSubmissionsNoError dbCheckpoints
                 $ mkUpdateSubmissions . Sbms.resubmitTx hash slotNo

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -177,9 +177,6 @@ newDBFresh timeInterpreter wid = do
         , addTxSubmission =
             error "addTxSubmission not tested in State Machine tests"
 
-        , readLocalTxSubmissionPending =
-            error "readLocalTxSubmissionPending not tested in State Machine tests"
-
         , resubmitTx =
             error "resubmitTx not tested in State Machine tests"
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
@@ -24,6 +24,7 @@ module Cardano.Wallet.DB.Store.Submissions.Layer
     , pruneByFinality
     , addTxSubmission
     , getInSubmissionTransaction
+    , isInSubmission
     )
     where
 
@@ -50,15 +51,15 @@ import Cardano.Wallet.Primitive.Types.Tx
 import Cardano.Wallet.Submissions.Operations
     ( Operation (..) )
 import Cardano.Wallet.Submissions.Submissions
-    ( TxStatusMeta (..), mkEmpty, transactions, transactionsL )
+    ( TxStatusMeta (..), mkEmpty, transactions, transactionsL, txStatus )
 import Cardano.Wallet.Submissions.TxStatus
-    ( TxStatus (..), expirySlot, getTx, status )
+    ( TxStatus (..), expirySlot, getTx, status, _InSubmission )
 import Cardano.Wallet.Transaction.Built
     ( BuiltTx (..) )
 import Control.Category
     ( (.) )
 import Control.Lens
-    ( ix, (^.), (^..), (^?) )
+    ( has, ix, (^.), (^..), (^?) )
 import Data.Bifunctor
     ( second )
 import Data.Maybe
@@ -99,6 +100,8 @@ resubmitTx (TxId -> txId) resubmitted walletSubmissions
                 , Forget txId
                 ]
 
+isInSubmission :: TxSubmissionsStatus -> Bool
+isInSubmission = has (txStatus . _InSubmission)
 
 getInSubmissionTransactions :: TxSubmissions -> [TxSubmissionsStatus]
 getInSubmissionTransactions submissions

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -40,7 +40,6 @@ import Cardano.Wallet
     , SelectionWithoutChange
     , WalletLayer (..)
     , migrationPlanToSelectionWithdrawals
-    , runLocalTxSubmissionPool
     , submitTx
     , throttle
     )
@@ -788,16 +787,16 @@ prop_localTxSubmission tc = monadicIO $ do
     st <- TxRetryTestState tc 2 <$> newMVar (Time 0)
     assert $ not $ null $ retryTestPool tc
     res <- run $ runTest st
-        $ \ctx@(TxRetryTestCtx dbl@(DBLayer{..}) nl tr _ _) -> do
+        $ \ctx@(TxRetryTestCtx dbl nl tr _ _) -> do
         unsafeRunExceptT
             $ forM_ (retryTestPool tc) $ submitTx tr dbl nl
-        res0 <- atomically readLocalTxSubmissionPending
+        res0 <- W.readLocalTxSubmissionPending @_ @DummyState @ShelleyKey ctx
         -- Run test
         let cfg = LocalTxSubmissionConfig (timeStep st) 10
-        runLocalTxSubmissionPool @_ @DummyState @ShelleyKey cfg ctx
+        W.runLocalTxSubmissionPool @_ @DummyState @ShelleyKey cfg ctx
 
         -- Gather state
-        res1 <- atomically readLocalTxSubmissionPending
+        res1 <- W.readLocalTxSubmissionPending @_ @DummyState @ShelleyKey ctx
         pure (res0, res1)
 
     let (resStart, resEnd) = resAction res


### PR DESCRIPTION
### Overview

We want to remove functions from the `DBLayer` record until essentially all DB access is done through the `walletsDB :: DBVar` .

This task is about removing `readLocalTxSubmissionPending` from the `DBLayer` record.

As this function is tested in a unit test in `WalletSpec`, we add it to `Cardano.Wallet` instead.

### Issue number

ADP-3010