### PR TITLE
Fix the restoration benchmark.

### DIFF
--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -481,6 +481,11 @@ benchmarksRnd network w@(WalletLayer _ _ netLayer txLayer dbLayer) wname
         (protocolParameters, _bundledProtocolParameters) <-
             W.toBalanceTxPParams @era <$> currentProtocolParameters netLayer
         timeTranslation <- toTimeTranslation (timeInterpreter netLayer)
+        -- For an output with zero ada, the transactionFee function should
+        -- automatically assign a minimal amount of lovelace to the output
+        -- before balancing the transaction and computing the fee:
+        let bundleWithZeroAda = TokenBundle.fromCoin (Coin 0)
+        let outputWithZeroAda = TxOut (dummyAddress network) bundleWithZeroAda
         W.transactionFee @s @k @n
             dbLayer
             (Write.unsafeFromWalletProtocolParameters protocolParameters)
@@ -489,8 +494,7 @@ benchmarksRnd network w@(WalletLayer _ _ netLayer txLayer dbLayer) wname
             recentEra
             (dummyChangeAddressGen @k)
             defaultTransactionCtx
-            (PreSelection
-                [TxOut (dummyAddress network) (TokenBundle.fromCoin (Coin 1))])
+            (PreSelection [outputWithZeroAda])
 
     oneAddress <- genAddresses 1 cp
     (_, importOneAddressTime) <- bench "import one addresses" $ do


### PR DESCRIPTION
## Issue

ADP-3011

## Summary

This PR attempts to fix the `estimate tx fee` section of the restoration benchmark.

## Details

The `estimate tx fee` section of the restoration benchmark is currently failing with errors similar to:

```hs
ExceptionSelectAssets
  (ErrSelectAssetsSelectionError
  (SelectionOutputErrorOf
  (SelectionOutputError
  { outputIndex = 0
  , outputErrorInfo =
    SelectionOutputCoinInsufficient
      (SelectionOutputCoinInsufficientError
        { minimumExpectedCoin = Coin 995610
        , output =
          ( Address ".."
          , TokenBundle {coin = Coin 1, tokens = TokenMap (fromList [])}
          )
        }
      )
    })))
```

This error occurs when a user-specified output has a lovelace quantity that is greater than zero, but lower than the minimum value that would be acceptable to the ledger. In this case, `balanceTx` will refuse to balance the transaction, returning an error similar to the one above. (Note that `1` lovelace is lower than `995610` lovelace, which is the minimum accceptable amount of lovelace for this particular output.)

This PR changes the user-specified output to have a lovelace quantity of zero. If an output has a lovelace quantity of zero, then `balanceTx` (which is called by `transactionFee`) should automatically assign a minimal quantity of lovelace to that output before balancing the transaction and computing the fee.