### PR TITLE
Actually use a fixed seed in `UTxOIndexBench`.

### DIFF
--- a/lib/primitive/bench/UTxOIndexBench.hs
+++ b/lib/primitive/bench/UTxOIndexBench.hs
@@ -34,9 +34,11 @@ import Data.Text.Format.Numbers
 import Numeric.Natural
     ( Natural )
 import Test.QuickCheck
-    ( Gen, choose, frequency, generate, oneof, variant, vectorOf )
+    ( choose, frequency, oneof, vectorOf )
 import Test.QuickCheck.Extra
-    ( chooseNatural )
+    ( GenSeed (GenSeed), GenSize (GenSize), chooseNatural, generateWith )
+import Test.QuickCheck.Gen
+    ( Gen (..) )
 import Test.Tasty.Bench
     ( Benchmark, bench, bgroup, defaultMain, nf )
 
@@ -64,9 +66,9 @@ benchmarkIndexFromMap = do
     let utxoMapNFTs__10_000 = makeUTxOMapNFTs  10_000
     let utxoMapNFTs_100_000 = makeUTxOMapNFTs 100_000
 
-    utxoMapDiverse___1_000 <- makeUTxOMapDiverse   1_000
-    utxoMapDiverse__10_000 <- makeUTxOMapDiverse  10_000
-    utxoMapDiverse_100_000 <- makeUTxOMapDiverse 100_000
+    let utxoMapDiverse___1_000 = makeUTxOMapDiverse   1_000
+    let utxoMapDiverse__10_000 = makeUTxOMapDiverse  10_000
+    let utxoMapDiverse_100_000 = makeUTxOMapDiverse 100_000
 
     -- Ensure the UTxO maps are fully evaluated (no thunks):
 
@@ -141,13 +143,11 @@ makeUTxOMapNFTs size =
 
 -- | Constructs a map with a diverse variety of different bundles.
 --
-makeUTxOMapDiverse :: UTxOMapSize -> IO UTxOMap
-makeUTxOMapDiverse =
-    generateWithSeed fixedSeed . genUTxOMapDiverse
-  where
-    -- A fixed PRNG seed to maximise consistency between benchmark runs.
-    fixedSeed :: Int
-    fixedSeed = 0
+makeUTxOMapDiverse :: UTxOMapSize -> UTxOMap
+makeUTxOMapDiverse size =
+    -- We use a fixed PRNG seed and QC size parameter to maximise consistency
+    -- between benchmark runs:
+    generateWith (GenSeed 0) (GenSize 30) (genUTxOMapDiverse size)
 
 -- | Generates a map with a diverse variety of different bundles.
 --
@@ -226,11 +226,6 @@ minimalTokenQuantity = TokenQuantity 1
 --------------------------------------------------------------------------------
 -- Utilities
 --------------------------------------------------------------------------------
-
--- | Generates values using a specific PRNG seed.
---
-generateWithSeed :: Int -> Gen a -> IO a
-generateWithSeed seed = generate . variant seed
 
 -- | Pretty-prints a number with separators.
 --

--- a/lib/primitive/bench/UTxOIndexBench.hs
+++ b/lib/primitive/bench/UTxOIndexBench.hs
@@ -36,7 +36,7 @@ import Numeric.Natural
 import Test.QuickCheck
     ( choose, frequency, oneof, vectorOf )
 import Test.QuickCheck.Extra
-    ( GenSeed (GenSeed), GenSize (GenSize), chooseNatural, generateWith )
+    ( GenSeed (GenSeed), chooseNatural, genSizeDefault, generateWith )
 import Test.QuickCheck.Gen
     ( Gen (..) )
 import Test.Tasty.Bench
@@ -147,7 +147,7 @@ makeUTxOMapDiverse :: UTxOMapSize -> UTxOMap
 makeUTxOMapDiverse mapSize =
     -- We use a fixed PRNG seed and QC size parameter to maximise consistency
     -- between benchmark runs:
-    generateWith (GenSeed 0) (GenSize 30) (genUTxOMapDiverse mapSize)
+    generateWith (GenSeed 0) genSizeDefault (genUTxOMapDiverse mapSize)
 
 -- | Generates a map with a diverse variety of different bundles.
 --

--- a/lib/primitive/bench/UTxOIndexBench.hs
+++ b/lib/primitive/bench/UTxOIndexBench.hs
@@ -122,8 +122,8 @@ type UTxOMapSize = Int
 -- | Constructs a map with ada-only token bundles.
 --
 makeUTxOMapAdaOnly :: UTxOMapSize -> UTxOMap
-makeUTxOMapAdaOnly size =
-    Map.fromList $ take size $ zip testUTxOMapKeys bundles
+makeUTxOMapAdaOnly mapSize =
+    Map.fromList $ take mapSize $ zip testUTxOMapKeys bundles
   where
     bundles :: [TokenBundle]
     bundles = repeat $ TokenBundle.fromCoin minimalCoin
@@ -131,8 +131,8 @@ makeUTxOMapAdaOnly size =
 -- | Constructs a map with bundles consisting of (ada, NFT) pairs.
 --
 makeUTxOMapNFTs :: UTxOMapSize -> UTxOMap
-makeUTxOMapNFTs size =
-    Map.fromList $ take size $ zip testUTxOMapKeys bundles
+makeUTxOMapNFTs mapSize =
+    Map.fromList $ take mapSize $ zip testUTxOMapKeys bundles
   where
     bundles :: [TokenBundle]
     bundles = makeBundle <$> testUTxOMapKeys
@@ -144,17 +144,17 @@ makeUTxOMapNFTs size =
 -- | Constructs a map with a diverse variety of different bundles.
 --
 makeUTxOMapDiverse :: UTxOMapSize -> UTxOMap
-makeUTxOMapDiverse size =
+makeUTxOMapDiverse mapSize =
     -- We use a fixed PRNG seed and QC size parameter to maximise consistency
     -- between benchmark runs:
-    generateWith (GenSeed 0) (GenSize 30) (genUTxOMapDiverse size)
+    generateWith (GenSeed 0) (GenSize 30) (genUTxOMapDiverse mapSize)
 
 -- | Generates a map with a diverse variety of different bundles.
 --
 genUTxOMapDiverse :: UTxOMapSize -> Gen UTxOMap
-genUTxOMapDiverse size =
+genUTxOMapDiverse mapSize =
     Map.fromList . zip testUTxOMapKeys <$>
-    vectorOf size genTokenBundle
+    vectorOf mapSize genTokenBundle
   where
     genTokenBundle :: Gen TokenBundle
     genTokenBundle = TokenBundle <$> genAdaQuantity <*> genTokenMap

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -25,6 +25,11 @@ module Test.QuickCheck.Extra
     , genSized2With
     , reasonablySized
 
+    -- * Generating values purely
+    , GenSeed (..)
+    , GenSize (..)
+    , generateWith
+
       -- * Shrinking
     , liftShrinker
     , shrinkBoundedEnum
@@ -124,8 +129,12 @@ import Test.QuickCheck
     , suchThatMap
     , (.&&.)
     )
+import Test.QuickCheck.Gen
+    ( Gen (MkGen) )
 import Test.QuickCheck.Gen.Unsafe
     ( promote )
+import Test.QuickCheck.Random
+    ( mkQCGen )
 import Test.Utils.Pretty
     ( pShowBuilder )
 import Text.Pretty.Simple
@@ -254,6 +263,29 @@ shrinkInterleaved (a, shrinkA) (b, shrinkB) = interleave
     interleave (x : xs) (y : ys) = x : y : interleave xs ys
     interleave xs [] = xs
     interleave [] ys = ys
+
+--------------------------------------------------------------------------------
+-- Generating values purely
+--------------------------------------------------------------------------------
+
+-- | Specifies a PRNG seed to use when generating a value.
+--
+newtype GenSeed = GenSeed Int
+
+-- | Specifies a size of value to generate.
+--
+-- (The QuickCheck size parameter.)
+--
+newtype GenSize = GenSize Int
+
+-- | Generates a value purely, according to the given parameters.
+--
+-- This function is an alternative to the standard QuickCheck 'generate'
+-- function.
+--
+generateWith :: GenSeed -> GenSize -> Gen a -> a
+generateWith (GenSeed seed) (GenSize size) (MkGen runGen) =
+    runGen (mkQCGen seed) size
 
 --------------------------------------------------------------------------------
 -- Evaluating shrinkers

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -28,6 +28,7 @@ module Test.QuickCheck.Extra
     -- * Generating values purely
     , GenSeed (..)
     , GenSize (..)
+    , genSizeDefault
     , generateWith
 
       -- * Shrinking
@@ -277,6 +278,12 @@ newtype GenSeed = GenSeed Int
 -- (The QuickCheck size parameter.)
 --
 newtype GenSize = GenSize Int
+
+-- | A value of 'GenSize' that's identical to the default QuickCheck size
+--   parameter.
+--
+genSizeDefault :: GenSize
+genSizeDefault = GenSize 30
 
 -- | Generates a value purely, according to the given parameters.
 --


### PR DESCRIPTION
## Issue Number

ADP-2975

## Summary

This PR fixes the generation of UTxO maps in `UTxOIndexBench`.

The previous method of generation assumed that it was possible to use the `QC.variant` function to generate values according to a fixed seed, but that assumption was flawed. This flaw would result in the benchmark generating different UTxO maps on every run, which could cause unwanted variance in the benchmark timings.

This PR:
- adds a new function `generateWith` to `Test.QuickCheck.Extra`.
- uses the `generateWith` function to repair the generation logic in `UTxOIndexBench`.