### PR TITLE
Disable specialisation in large API modules.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -28,6 +28,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -fno-specialise #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Error.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# OPTIONS_GHC -fno-specialise #-}
 
 -- |
 -- Copyright: © 2018-2022 IOHK

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -24,6 +24,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+{-# OPTIONS_GHC -fno-specialise #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -fconstraint-solver-iterations=0 #-}
 


### PR DESCRIPTION
# Issue

ADP-2973

# Summary

This PR disables specialisation when compiling certain large API modules. This greatly reduces the amount of time and memory needed to compile these modules.

# Overall compilation time

All data relate to (clean) compilation of `cardano-wallet` with the following GHC options:
```
+RTS -A64m -n4m -RTS -O2 -j -Wall -Werror -dshow-passes -ddump-timings
```

### Before
```
real    11m22.857s
user    47m54.215s
sys     2m52.259s
```

### After
```
real    7m46.911s
user    40m32.150s
sys     2m36.121s
```

# Memory usage

All memory allocation values relate to the greatest allocations of each pass recorded.

Values below `100 megabytes` are omitted.

## `Cardano.Wallet.Api.Types`

### Before:
```
Specialise          finished in 15592.63 milliseconds, allocated 35404.144 megabytes
Simplifier          finished in 41184.71 milliseconds, allocated 25696.991 megabytes
CodeGen             finished in 13964.89 milliseconds, allocated 17079.458 megabytes
Renamer/typechecker finished in  7109.09 milliseconds, allocated  7334.013 megabytes
CoreTidy            finished in  1483.92 milliseconds, allocated   972.479 megabytes
SpecConstr          finished in   436.86 milliseconds, allocated   631.040 megabytes
Desugar             finished in    82.29 milliseconds, allocated   123.053 megabytes
```

### After:
```
CodeGen             finished in  9666.60 milliseconds, allocated  9521.074 megabytes
Simplifier          finished in 13193.64 milliseconds, allocated  7849.071 megabytes
Renamer/typechecker finished in  7096.26 milliseconds, allocated  7332.666 megabytes
CoreTidy            finished in   436.11 milliseconds, allocated   431.388 megabytes
SpecConstr          finished in   152.00 milliseconds, allocated   193.128 megabytes
Desugar             finished in    86.76 milliseconds, allocated   123.096 megabytes
```

## `Cardano.Wallet.Api.Types.Error`

### Before

```
Simplifier          finished in 20082.14 milliseconds, allocated 15517.430 megabytes
CodeGen             finished in  3682.71 milliseconds, allocated  4168.017 megabytes
Demand analysis     finished in  2858.26 milliseconds, allocated  3722.868 megabytes
SpecConstr          finished in   618.39 milliseconds, allocated   800.084 megabytes
CoreTidy            finished in  1268.32 milliseconds, allocated   711.218 megabytes
Renamer/typechecker finished in   750.24 milliseconds, allocated   694.287 megabytes
Specialise          finished in   534.01 milliseconds, allocated   405.535 megabytes
```

### After

```
CodeGen             finished in  4907.78 milliseconds, allocated  1573.970 megabytes
Simplifier          finished in  2674.16 milliseconds, allocated   803.276 megabytes
Renamer/typechecker finished in  1095.20 milliseconds, allocated   694.431 megabytes
CoreTidy            finished in   252.00 milliseconds, allocated   121.877 megabytes
```

## `Cardano.Wallet.Api.TypesSpec`

### Before

```
Simplifier          finished in 121275.79 milliseconds, allocated 10546.327 megabytes
CodeGen             finished in   8163.34 milliseconds, allocated  8426.935 megabytes
Renamer/typechecker finished in  57510.55 milliseconds, allocated  2171.472 megabytes
CoreTidy            finished in   1346.31 milliseconds, allocated   592.469 megabytes
SpecConstr          finished in    302.81 milliseconds, allocated   242.241 megabytes
Demand analysis     finished in    860.79 milliseconds, allocated   788.724 megabytes
```

### After

```
CodeGen             finished in 12143.74 milliseconds, allocated   7219.178 megabytes
Simplifier          finished in 65171.91 milliseconds, allocated   3978.014 megabytes
Renamer/typechecker finished in 39463.01 milliseconds, allocated   2169.221 megabytes
CoreTidy            finished in  2555.98 milliseconds, allocated    507.024 megabytes
SpecConstr          finished in   320.39 milliseconds, allocated    150.626 megabytes
Demand analysis     finished in   938.43 milliseconds, allocated    517.606 megabytes
```