### PR TITLE
[ADP-3014] Remove `addTxSubmission` from `DBLayer`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1209,8 +1209,7 @@ restoreBlocks ctx tr blocks nodeTip = db & \DBLayer{..} -> atomically $ do
     rollForwardTxSubmissions (localTip ^. #slotNo)
         $ fmap (\(tx,meta) -> (meta ^. #slotNo, txId tx)) txs
     let deltaPruneSubmissions =
-            [ UpdateSubmissions [Submissions.pruneByFinality finalitySlot]
-            ]
+            [ UpdateSubmissions $ Submissions.pruneByFinality finalitySlot ]
 
     forM_ slotPoolDelegations $ \delegation@(slotNo, cert) -> do
             liftIO $ logDelegation delegation

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -486,7 +486,7 @@ mkDBLayerFromParts ti wid_ DBLayerCollection{..} = DBLayer
                 $ Sbms.resubmitTx hash slotNo
     , rollForwardTxSubmissions = \tip txs ->
             updateSubmissionsNoError dbCheckpoints
-                $ \_ -> [Sbms.rollForwardTxSubmissions tip txs]
+                $ \_ -> Sbms.rollForwardTxSubmissions tip txs
     , putPrivateKey = putPrivateKey_ dbPrivateKey
     , readPrivateKey = readPrivateKey_ dbPrivateKey
     , readGenesisParameters = readGenesisParameters_ dbCheckpoints

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -94,8 +94,6 @@ import Cardano.Wallet.Submissions.Submissions
     ( TxStatusMeta (..), txStatus )
 import Cardano.Wallet.Submissions.TxStatus
     ( _Expired, _InSubmission )
-import Cardano.Wallet.Transaction.Built
-    ( BuiltTx )
 import Control.Lens
     ( has )
 import Control.Monad
@@ -294,13 +292,6 @@ data DBLayer m s = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -- ^ Fetch the latest transaction by id, returns Nothing when the
         -- transaction isn't found.
 
-    , addTxSubmission
-        :: BuiltTx
-        -> SlotNo
-        -> stm ()
-        -- ^ Add a /new/ transaction to the local submission pool
-        -- with the most recent submission slot.
-
     , resubmitTx
         :: Hash "Tx"
         -> SealedTx -- TODO: ADP-2596 really not needed
@@ -490,9 +481,6 @@ mkDBLayerFromParts ti wid_ DBLayerCollection{..} = DBLayer
                     (hoistTimeInterpreter liftIO ti)
                     (mkDecorator_ dbTxHistory) tip
                         . fmap snd
-    , addTxSubmission = \builtTx slotNo ->
-            updateSubmissionsNoError dbCheckpoints
-                $ \_ -> [Sbms.addTxSubmission builtTx slotNo]
     , resubmitTx = \hash _ slotNo ->
             updateSubmissionsNoError dbCheckpoints
                 $ Sbms.resubmitTx hash slotNo

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -607,10 +607,9 @@ newDBFreshFromDBOpen ti wid_ DBOpen{atomically=atomically_} =
                         (  [ UpdateCheckpoints
                                 [ RollbackTo nearestPoint ]
                             , UpdateSubmissions
-                                [ rollBackSubmissions $
-                                        case nearestPoint of
+                                $ rollBackSubmissions $
+                                    case nearestPoint of
                                         { At s -> s; Origin -> 0 }
-                                ]
                             ]
                         ,   case Map.lookup nearestPoint
                                     (wal ^. #checkpoints . #checkpoints) of

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -171,9 +171,6 @@ newDBFresh timeInterpreter wid = do
                                        Pending Tx
         -----------------------------------------------------------------------}
 
-        , addTxSubmission =
-            error "addTxSubmission not tested in State Machine tests"
-
         , resubmitTx =
             error "resubmitTx not tested in State Machine tests"
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
@@ -73,14 +73,15 @@ emptyTxSubmissions = mkEmpty 0
 addTxSubmission
     :: BuiltTx
     -> SlotNo
-    -> DeltaTxSubmissions
+    -> [DeltaTxSubmissions]
 addTxSubmission BuiltTx{..} resubmitted =
     let txId = TxId $ builtTx ^. #txId
         expiry = case builtTxMeta ^. #expiry of
             Nothing -> SlotNo maxBound
             Just slot -> slot
-    in AddSubmission expiry (txId, builtSealedTx)
-        $ submissionMetaFromTxMeta builtTxMeta resubmitted
+    in  [ AddSubmission expiry (txId, builtSealedTx)
+          $ submissionMetaFromTxMeta builtTxMeta resubmitted
+        ]
 
 resubmitTx
     :: Hash "Tx"

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
@@ -70,6 +70,8 @@ import qualified Data.Map.Strict as Map
 emptyTxSubmissions :: TxSubmissions
 emptyTxSubmissions = mkEmpty 0
 
+-- | Add a /new/ transaction to the local submission pool
+-- with the most recent submission slot.
 addTxSubmission
     :: BuiltTx
     -> SlotNo

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
@@ -75,7 +75,7 @@ emptyTxSubmissions = mkEmpty 0
 addTxSubmission
     :: BuiltTx
     -> SlotNo
-    -> [DeltaTxSubmissions]
+    -> DeltaTxSubmissions
 addTxSubmission BuiltTx{..} resubmitted =
     let txId = TxId $ builtTx ^. #txId
         expiry = case builtTxMeta ^. #expiry of
@@ -89,7 +89,7 @@ resubmitTx
     :: Hash "Tx"
     -> SlotNo
     -> TxSubmissions
-    -> [DeltaTxSubmissions]
+    -> DeltaTxSubmissions
 resubmitTx (TxId -> txId) resubmitted walletSubmissions
     = fromMaybe [] $ do
         (TxStatusMeta datas meta) <-
@@ -116,12 +116,12 @@ getInSubmissionTransaction txId submissions
 
 rollForwardTxSubmissions
     :: SlotNo -> [(SlotNo, Hash "Tx")] -> DeltaTxSubmissions
-rollForwardTxSubmissions tip txs = RollForward tip (second TxId <$> txs)
+rollForwardTxSubmissions tip txs = [ RollForward tip (second TxId <$> txs) ]
 
 removePendingOrExpiredTx
     :: Hash "Tx"
     -> TxSubmissions
-    -> Either ErrRemoveTx [DeltaTxSubmissions]
+    -> Either ErrRemoveTx DeltaTxSubmissions
 removePendingOrExpiredTx txId walletSubmissions = do
     let
         errNoTx = ErrRemoveTxNoSuchTransaction $ ErrNoSuchTransaction txId
@@ -132,13 +132,13 @@ removePendingOrExpiredTx txId walletSubmissions = do
         _ -> Right [Forget (TxId txId)]
 
 rollBackSubmissions :: SlotNo -> DeltaTxSubmissions
-rollBackSubmissions = RollBack
+rollBackSubmissions slot = [ RollBack slot ]
 
 pruneByFinality
     :: SlotNo
         -- ^ Finality slot = most recent stable slot.
     -> DeltaTxSubmissions
-pruneByFinality = Prune
+pruneByFinality finality = [ Prune finality ]
 
 mkLocalTxSubmission
     :: TxSubmissionsStatus

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Operations.hs
@@ -79,12 +79,14 @@ type TxSubmissions
     = Sbm.Submissions SubmissionMeta SlotNo (TxId, W.SealedTx)
 type TxSubmissionsStatus
     = Sbm.TxStatusMeta SubmissionMeta SlotNo (TxId, W.SealedTx)
-type DeltaTxSubmissions
+type DeltaTxSubmissions1
     = Sbm.Operation SubmissionMeta SlotNo (TxId, W.SealedTx)
+type DeltaTxSubmissions
+    = [DeltaTxSubmissions1]
 
-instance Delta DeltaTxSubmissions where
-  type Base DeltaTxSubmissions = TxSubmissions
-  apply = applyOperations
+instance Delta DeltaTxSubmissions1 where
+    type Base DeltaTxSubmissions1 = TxSubmissions
+    apply = applyOperations
 
 {-----------------------------------------------------------------------------
     Data types
@@ -212,5 +214,5 @@ mkStatus _ _ _ _ _
 
 mkStoreSubmissions
     :: WalletId
-    -> UpdateStore (SqlPersistT IO) DeltaTxSubmissions
+    -> UpdateStore (SqlPersistT IO) DeltaTxSubmissions1
 mkStoreSubmissions = mkStoreAnySubmissions

--- a/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
@@ -164,7 +164,7 @@ data DeltaWalletState1 s
     -- ^ Replace the prologue of the address discovery state
     | UpdateCheckpoints (CPS.DeltasCheckpoints (WalletCheckpoint s))
     -- ^ Update the wallet checkpoints.
-    | UpdateSubmissions [DeltaTxSubmissions]
+    | UpdateSubmissions DeltaTxSubmissions
     | UpdateInfo DeltaWalletInfo
 
 instance Delta (DeltaWalletState1 s) where
@@ -192,6 +192,6 @@ updateCheckpoints
 updateCheckpoints = updateField checkpoints ((:[]) . UpdateCheckpoints)
 
 updateSubmissions
-    :: Update [DeltaTxSubmissions] r
+    :: Update DeltaTxSubmissions r
     -> Update (DeltaWalletState s) r
 updateSubmissions = updateField submissions ((:[]) . UpdateSubmissions)


### PR DESCRIPTION
### Overview

We want to remove functions from the `DBLayer` record until essentially all DB access is done through the `walletsDB :: DBVar`.

This task is about removing `addTxSubmission` from the `DBLayer` record.

### Issue number

ADP-3014