### PR TITLE
[ADP-3017] Add `Update` computation type

### DIFF
--- a/lib/delta-store/delta-store.cabal
+++ b/lib/delta-store/delta-store.cabal
@@ -45,6 +45,7 @@ library
       src
   exposed-modules:
       Data.DBVar
+      Data.Delta.Update
       Data.Store
       Test.Store
 

--- a/lib/delta-store/src/Data/Delta/Update.hs
+++ b/lib/delta-store/src/Data/Delta/Update.hs
@@ -1,0 +1,154 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+-- |
+-- Copyright: © 2023 IOHK
+-- License: Apache-2.0
+module Data.Delta.Update (
+    -- * Synopsis
+    -- | 'Update' represents a computation which produces a delta and
+    -- a result.
+    --
+    -- Note: This module is preliminary.
+
+    -- * Update
+    -- ** Type
+      Update
+    -- ** View
+    , runUpdate
+    , applyUpdate
+    , onDBVar
+    -- ** Combinators
+    , nop
+    , update
+    , updateWithResult
+    -- ** Helpers
+    , updateWithError
+    , updateWithResultAndError
+    , updateMany
+    , updateField
+    ) where
+
+import Prelude
+
+import Data.DBVar
+    ( DBVar, modifyDBMaybe )
+import Data.Delta
+    ( Delta (..) )
+
+{-------------------------------------------------------------------------------
+    Update
+    Type, View
+-------------------------------------------------------------------------------}
+-- | A computation which inspects a value @a ~ Base da@
+-- and produces a delta @da@ and a result of type @r@.
+--
+-- Similar to the 'Control.Monad.Trans.State.State' computation,
+-- but involving 'Delta' types.
+newtype Update da r = Update { runUpdate_ :: Base da -> (Maybe da, r) }
+
+-- | Run the 'Update' computation.
+runUpdate :: (a ~ Base da) => Update da r -> a -> (Maybe da, r)
+runUpdate = runUpdate_
+
+-- | Semantics.
+applyUpdate
+    :: (Delta da, a ~ Base da)
+    => Update da r -> a -> (a,r)
+applyUpdate (Update g) a =
+    case g a of
+        (da, r) -> (da `apply` a, r)
+
+-- | Apply an 'Update' to a 'DBVar'.
+onDBVar
+    :: (Monad m, Delta da)
+    => DBVar m da -> Update da r -> m r
+onDBVar dbvar = modifyDBMaybe dbvar . runUpdate
+
+{-------------------------------------------------------------------------------
+    Combinators
+-------------------------------------------------------------------------------}
+-- | Map results.
+instance Functor (Update da) where
+    fmap f (Update g) = Update $ \a ->
+        case g a of
+            (da, r) -> (da, f r)
+
+-- | No operation.
+--
+-- Use the 'Functor' instance, specifically '(<$)'
+-- to add results other than '()'.
+nop :: Update da ()
+nop = Update $ const (Nothing, ())
+
+-- | Compute a delta.
+update :: (a ~ Base da) => (a -> da) -> Update da ()
+update f = Update $ \a -> (Just (f a), ())
+
+-- | Compute a delta with result.
+updateWithResult
+    :: (a ~ Base da)
+    => (a -> (da, r)) -- Delta with result.
+    -> Update da r
+updateWithResult f = Update $ \a ->
+    case f a of
+        (da, r) -> (Just da, r)
+
+-- | Computer a delta or fail.
+updateWithError
+    :: (a ~ Base da)
+    => (a -> Either e da)
+    -> Update da (Either e ())
+updateWithError f = Update $ \a ->
+    case f a of
+        Left e -> (Nothing, Left e)
+        Right da -> (Just da, Right ())
+
+-- | Compute a delta with result or fail.
+updateWithResultAndError
+    :: (a ~ Base da)
+    => (a -> Either e (da, r))
+    -> Update da (Either e r)
+updateWithResultAndError f = Update $ \a ->
+    case f a of
+        Left e -> (Nothing, Left e)
+        Right (da,r) -> (Just da, Right r)
+
+-- | Lift an update for a single delta to a list of deltas.
+updateMany
+    :: Update da r
+    -> Update [da] r
+updateMany (Update g) = Update $ \a ->
+    case g a of
+        (Nothing, r) -> (Nothing, r)
+        (Just da, r) -> (Just [da], r)
+
+{- | Helper function for lifting the 'Update' from a
+record field to the record.
+
+Example:
+
+@
+data Pair a b = Pair a b
+first :: Pair a b -> a
+
+data DeltaPair da db
+    = UpdateFirst da
+    | UpdateSecond db
+
+updateField first UpdateFirst
+    :: (a -> Update da r)
+    -> (Pair a b -> Update (DeltaPair da db) r)
+@
+-}
+updateField
+    :: (a ~ Base da, b ~ Base db)
+    => (b -> a)
+        -- ^ View field.
+    -> (da -> db)
+        -- ^ Lift delta to
+    -> Update da r
+    -> Update db r
+updateField view embed (Update g) =
+    Update $ lift . g . view
+  where
+    lift (mda, r) = (embed <$> mda, r)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -543,7 +543,7 @@ import Crypto.Hash
 import Data.ByteString
     ( ByteString )
 import Data.DBVar
-    ( modifyDBMaybe, readDBVar )
+    ( readDBVar )
 import Data.Either
     ( partitionEithers )
 import Data.Either.Extra
@@ -635,6 +635,7 @@ import qualified Cardano.Wallet.Write.ProtocolParameters as Write
 import qualified Cardano.Wallet.Write.Tx as WriteTx
 import qualified Cardano.Wallet.Write.Tx.Balance as Write
 import qualified Data.ByteArray as BA
+import qualified Data.Delta.Update as Delta
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
@@ -2375,8 +2376,9 @@ forgetTx
 forgetTx ctx txid = db & \DBLayer{..} ->
     ExceptT
         . atomically
-        . modifyDBMaybe walletsDB
-        . WalletState.updateSubmissionsEither
+        . Delta.onDBVar walletsDB
+        . WalletState.updateSubmissions
+        . Delta.updateWithError
         $ Submissions.removePendingOrExpiredTx txid
   where
     db = ctx ^. dbLayer @IO @s @k

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -333,7 +333,6 @@ import Cardano.Wallet.DB.WalletState
     , getSlot
     , updateState
     , updateStateWithResult
-    , updateStateWithResultNoError
     )
 import Cardano.Wallet.Flavor
     ( WalletFlavor (..), WalletFlavorS (..) )
@@ -1562,10 +1561,9 @@ assignChangeAddressesAndUpdateDb
 assignChangeAddressesAndUpdateDb ctx argGenChange selection =
     db & \DBLayer{..} ->
         atomically
-            $ updateStateWithResultNoError
-                id
-                walletsDB
-                assignChangeAddressesAndUpdateDb'
+            . Delta.onDBVar walletsDB
+            . Delta.updateWithResult
+            $ assignChangeAddressesAndUpdateDb'
   where
     db = ctx ^. dbLayer @IO @s @k
     assignChangeAddressesAndUpdateDb' wallet =

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -141,7 +141,6 @@ import Cardano.Wallet.DB.WalletState
     , getBlockHeight
     , getLatest
     , getSlot
-    , updateStateWithResultNoError
     )
 import Cardano.Wallet.Primitive.Passphrase.Types
     ( PassphraseHash )
@@ -614,7 +613,9 @@ newDBFreshFromDBOpen ti wid_ DBOpen{atomically=atomically_} =
             }
 
         rollbackTo_ requestedPoint = do
-            nearestCheckpoint <- updateStateWithResultNoError id walletsDB
+            nearestCheckpoint
+                <- Delta.onDBVar walletsDB
+                $ Delta.updateWithResult
                 $ \wal ->
                 case findNearestPoint wal requestedPoint of
                     Nothing -> throw $ ErrNoOlderCheckpoint wid_ requestedPoint

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -141,7 +141,6 @@ import Cardano.Wallet.DB.WalletState
     , getBlockHeight
     , getLatest
     , getSlot
-    , updateStateNoErrors
     , updateStateWithResultNoError
     )
 import Cardano.Wallet.Primitive.Passphrase.Types
@@ -221,15 +220,14 @@ import UnliftIO.MVar
     ( modifyMVar, modifyMVar_, newMVar, readMVar, withMVar )
 
 import qualified Cardano.Wallet.Primitive.Model as W
-import qualified Cardano.Wallet.Primitive.Passphrase.Types as W
-    ( PassphraseHash )
+import qualified Cardano.Wallet.Primitive.Passphrase as W
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TransactionInfo as W
-    ( TransactionInfo )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 import qualified Cardano.Wallet.Read.Tx as Read
+import qualified Data.Delta.Update as Delta
 import qualified Data.Generics.Internal.VL as L
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -569,8 +567,7 @@ newDBFreshFromDBOpen ti wid_ DBOpen{atomically=atomically_} =
       where
         transactionsStore_ = transactionsQS
         putWalletMeta_ wm =
-            updateStateNoErrors id walletsDB $ \_ ->
-                [ UpdateInfo $ UpdateWalletMetadata wm ]
+            updateDBVar walletsDB [ UpdateInfo $ UpdateWalletMetadata wm ]
 
         readWalletMeta_ = do
             walletMeta . info <$> readDBVar walletsDB
@@ -586,7 +583,7 @@ newDBFreshFromDBOpen ti wid_ DBOpen{atomically=atomically_} =
             let heights = Set.fromList $ sparseCheckpoints
                     (defaultSparseCheckpointsConfig epochStability)
                     (tip ^. #blockHeight)
-            updateStateNoErrors id walletsDB $ \ wal ->
+            Delta.onDBVar walletsDB $ Delta.update $ \ wal ->
                 let willKeep cp = getBlockHeight cp `Set.member` heights
                     slots = Map.filter willKeep
                         $ wal ^. #checkpoints . #checkpoints
@@ -599,7 +596,7 @@ newDBFreshFromDBOpen ti wid_ DBOpen{atomically=atomically_} =
             { walletsDB_ = walletsDB
 
             , putCheckpoint_ = \cp ->
-                updateStateNoErrors id walletsDB $ \_ ->
+                Delta.onDBVar walletsDB $ Delta.update $ \_ ->
                     let (prologue, wcp) = fromWallet cp
                         slot = getSlot wcp
                     in  [ UpdateCheckpoints [ PutCheckpoint slot wcp ]

--- a/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
@@ -34,8 +34,6 @@ module Cardano.Wallet.DB.WalletState
 
     -- * Helpers
     , updateSubmissions
-
-    , updateStateWithResult
     ) where
 
 import Prelude
@@ -54,10 +52,6 @@ import Cardano.Wallet.Primitive.Types
     ( BlockHeader )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO )
-import Control.Monad.Except
-    ( ExceptT (..) )
-import Data.DBVar
-    ( DBVar, modifyDBMaybe )
 import Data.Delta
     ( Delta (..) )
 import Data.Delta.Update
@@ -191,28 +185,7 @@ instance Show (DeltaWalletState1 s) where
 {-------------------------------------------------------------------------------
     Helper functions
 -------------------------------------------------------------------------------}
-modifyRight
-    :: (a -> Either e (da, b))
-    -> (a -> (Maybe da, Either e b))
-modifyRight update a =
-    case update a of
-        Left e -> (Nothing, Left e)
-        Right (da, b) -> (Just da, Right b)
-
 updateSubmissions
     :: Update [DeltaTxSubmissions] r
     -> Update (DeltaWalletState s) r
 updateSubmissions = updateField submissions ((:[]) . UpdateSubmissions)
-
-updateStateWithResult :: (Delta da, Monad m)
-    => (Base da -> w)
-    -- ^ Get the part of the state that we want to update
-    -> DBVar m da
-    -- ^ The state variable
-    -> (w -> Either e (da, b))
-    -- ^ The update function
-    -> ExceptT e m b
-updateStateWithResult d state use =
-    ExceptT
-        $ modifyDBMaybe state
-        $ modifyRight use . d

--- a/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- |
@@ -36,7 +35,6 @@ module Cardano.Wallet.DB.WalletState
     -- * Helpers
     , updateSubmissions
 
-    , updateState
     , updateStateWithResult
     ) where
 
@@ -57,7 +55,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO )
 import Control.Monad.Except
-    ( ExceptT (..), runExceptT )
+    ( ExceptT (..) )
 import Data.DBVar
     ( DBVar, modifyDBMaybe )
 import Data.Delta
@@ -218,14 +216,3 @@ updateStateWithResult d state use =
     ExceptT
         $ modifyDBMaybe state
         $ modifyRight use . d
-
-updateState
-    :: (Delta da, Monad m)
-    => (Base da -> w)
-    -- ^ Get the part of the state that we want to update
-    -> DBVar m da
-    -- ^ The state variable
-    -> (w -> Either e da)
-    -- ^ The update function
-    -> ExceptT e m ()
-updateState d state use = updateStateWithResult d state $ fmap (,()) . use

--- a/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
@@ -38,7 +38,6 @@ module Cardano.Wallet.DB.WalletState
 
     , updateState
     , updateStateWithResult
-    , updateStateWithResultNoError
     ) where
 
 import Prelude
@@ -230,17 +229,3 @@ updateState
     -- ^ The update function
     -> ExceptT e m ()
 updateState d state use = updateStateWithResult d state $ fmap (,()) . use
-
-updateStateWithResultNoError :: (Delta da, Monad m)
-    => (Base da -> w)
-    -- ^ Get the part of the state that we want to update
-    -> DBVar m da
-    -- ^ The state variable
-    -> (w -> (da, b))
-    -- ^ The update function
-    -> m b
-updateStateWithResultNoError d state use = do
-    er <- runExceptT $ updateStateWithResult d state $ fmap Right use
-    case er of
-        Left _ -> error "updateStateWithResultNoError: impossible"
-        Right r -> pure r

--- a/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
@@ -34,8 +34,7 @@ module Cardano.Wallet.DB.WalletState
     , DeltaWalletState
 
     -- * Helpers
-    , modifyRight
-    , updateSubmissionsEither
+    , updateSubmissions
 
     , updateState
     , updateStateWithResult
@@ -65,6 +64,8 @@ import Data.DBVar
     ( DBVar, modifyDBMaybe )
 import Data.Delta
     ( Delta (..) )
+import Data.Delta.Update
+    ( Update, updateField )
 import Data.Generics.Internal.VL
     ( withIso )
 import Data.Generics.Internal.VL.Lens
@@ -202,12 +203,10 @@ modifyRight update a =
         Left e -> (Nothing, Left e)
         Right (da, b) -> (Just da, Right b)
 
-updateSubmissionsEither
-    :: (TxSubmissions -> Either e [DeltaTxSubmissions])
-    -> (WalletState s -> (Maybe (DeltaWalletState s), Either e ()))
-updateSubmissionsEither f =
-    modifyRight $
-        fmap ((,()) . (:[]) . UpdateSubmissions) . f . submissions
+updateSubmissions
+    :: Update [DeltaTxSubmissions] r
+    -> Update (DeltaWalletState s) r
+updateSubmissions = updateField submissions ((:[]) . UpdateSubmissions)
 
 updateStateWithResult :: (Delta da, Monad m)
     => (Base da -> w)

--- a/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
@@ -38,7 +38,6 @@ module Cardano.Wallet.DB.WalletState
 
     , updateState
     , updateStateWithResult
-    , updateStateNoErrors
     , updateStateWithResultNoError
     ) where
 
@@ -59,7 +58,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO )
 import Control.Monad.Except
-    ( ExceptT (..), runExceptT, void )
+    ( ExceptT (..), runExceptT )
 import Data.DBVar
     ( DBVar, modifyDBMaybe )
 import Data.Delta
@@ -245,15 +244,3 @@ updateStateWithResultNoError d state use = do
     case er of
         Left _ -> error "updateStateWithResultNoError: impossible"
         Right r -> pure r
-
-updateStateNoErrors
-    :: (Delta da, Monad m)
-    => (Base da -> w)
-    -- ^ Get the part of the state that we want to update
-    -> DBVar m da
-    -- ^ The state variable
-    -> (w -> da)
-    -- ^ The update function
-    -> m ()
-updateStateNoErrors d state use = void
-    $ runExceptT $ updateState d state (Right . use)


### PR DESCRIPTION
### Overview

We want to remove functions from the `DBLayer` record until essentially all DB access is done through the `walletsDB :: DBVar`.

This task is about creating a data type `Update` that encapsulates pure computations on the WalletState and which pairs conveniently with `walletsDB`. In other words, `Update` is similar to a pure `State` monad, but it works with delta types.

The main purpose of this type is to simplify code in `Cardano.Wallet`.

### Issue number

ADP-3017