### PR TITLE
[ADP-3018] Remove reliance on `AllowAmbiguousTypes` for `DBLayer`.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
@@ -354,7 +354,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
 
     shelleyMigrations :: Server (ShelleyMigrations n)
     shelleyMigrations =
-             createMigrationPlan @_ @_ shelley (Just SelfWithdrawal)
+             createMigrationPlan shelley (Just SelfWithdrawal)
         :<|> migrateWallet shelley (Just SelfWithdrawal)
 
     stakePools :: Server (StakePools n)
@@ -522,8 +522,8 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     byronMigrations :: Server (ByronMigrations n)
     byronMigrations =
              (\wid postData -> withLegacyLayer wid
-                (byron , createMigrationPlan @_ @_ byron Nothing wid postData)
-                (icarus, createMigrationPlan @_ @_ icarus Nothing wid postData)
+                (byron , createMigrationPlan byron Nothing wid postData)
+                (icarus, createMigrationPlan icarus Nothing wid postData)
              )
         :<|> (\wid m -> withLegacyLayer wid
                 (byron , migrateWallet byron Nothing wid m)
@@ -607,7 +607,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
             (knownPools spl) (getPoolLifeCycleStatus spl)
         :<|> signTransaction apilayer
         :<|> decodeSharedTransaction apilayer
-        :<|> submitSharedTransaction @_ apilayer
+        :<|> submitSharedTransaction apilayer
         :<|>
             (\wid txId simpleMetadataFlag ->
                 getTransaction apilayer wid txId

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3175,13 +3175,13 @@ decodeTransaction
         (acct, _, acctPath) <-
             liftHandler $ W.shelleyOnlyReadRewardAccount @s db
         inputPaths <-
-            handler $ W.lookupTxIns @_ @s wrk $
+            handler $ W.lookupTxIns wrk $
             fst <$> resolvedInputs
         collateralInputPaths <-
-            handler $ W.lookupTxIns @_ @s wrk $
+            handler $ W.lookupTxIns wrk $
             fst <$> resolvedCollateralInputs
         outputPaths <-
-            handler $ W.lookupTxOuts @_ @s wrk outputs
+            handler $ W.lookupTxOuts wrk outputs
         pp <- liftIO $ NW.currentProtocolParameters (wrk ^. networkLayer)
         (minted, burned) <-
             convertApiAssetMintBurn wrk (toMint, toBurn)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3874,7 +3874,7 @@ migrateWallet ctx@ApiLayer{..} withdrawalType (ApiT wid) postData = do
                     , txDelegationAction = Nothing
                     }
             (tx, txMeta, txTime, sealedTx) <- liftHandler $
-                W.buildAndSignTransaction @_ @s
+                W.buildAndSignTransaction
                     wrk
                     wid
                     era

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -4025,7 +4025,7 @@ postExternalTransaction
     -> Handler ApiTxId
 postExternalTransaction ctx (ApiT sealed) = do
     tx <- liftHandler $ W.submitExternalTx
-            @_ @(CredFromOf s) @(KeyOf s) ctx sealed
+            (tracerTxSubmit ctx) (ctx ^. #netLayer) (ctx ^. #txLayer) sealed
     return $ ApiTxId (ApiT (tx ^. #txId))
 
 signMetadata

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2015,9 +2015,8 @@ getAssetDefault ctx wid pid = getAsset ctx wid pid (ApiT nullTokenName)
 -------------------------------------------------------------------------------}
 
 postRandomAddress
-    :: forall ctx s k n.
+    :: forall ctx s n.
         ( s ~ RndState n
-        , k ~ ByronKey
         , ctx ~ ApiLayer s
         , HasSNetworkId n
         )
@@ -2029,7 +2028,7 @@ postRandomAddress ctx (ApiT wid) body = do
     let pwd = coerce $ getApiT $ body ^. #passphrase
     let mix = getApiT <$> (body ^. #addressIndex)
     (addr, path) <- withWorkerCtx ctx wid liftE liftE
-        $ \wrk -> liftHandler $ W.createRandomAddress @_ @s @n wrk wid pwd mix
+        $ \wrk -> liftHandler $ W.createRandomAddress @_ @n wrk wid pwd mix
     pure $ coerceAddress (addr, Unused, path)
   where
     coerceAddress (a, s, p) =
@@ -2046,7 +2045,7 @@ putRandomAddress
     -> Handler NoContent
 putRandomAddress ctx (ApiT wid) (ApiAddress addr)  = do
     withWorkerCtx ctx wid liftE liftE
-        $ \wrk -> liftHandler $ W.importRandomAddresses @_ @s wrk [addr]
+        $ \wrk -> liftHandler $ W.importRandomAddresses wrk [addr]
     pure NoContent
 
 putRandomAddresses
@@ -2060,7 +2059,7 @@ putRandomAddresses
     -> Handler NoContent
 putRandomAddresses ctx (ApiT wid) (ApiPutAddressesData addrs)  = do
     withWorkerCtx ctx wid liftE liftE
-        $ \wrk -> liftHandler $ W.importRandomAddresses @_ @s wrk addrs'
+        $ \wrk -> liftHandler $ W.importRandomAddresses wrk addrs'
     pure NoContent
   where
     addrs' = apiAddress <$> addrs
@@ -2078,7 +2077,7 @@ listAddresses
     -> Handler [ApiAddressWithPath n]
 listAddresses ctx normalize (ApiT wid) stateFilter = do
     addrs <- withWorkerCtx ctx wid liftE liftE $ \wrk -> handler $
-        W.listAddresses @_ @s wrk normalize
+        W.listAddresses wrk normalize
     return $ coerceAddress <$> filter filterCondition addrs
   where
     filterCondition :: (Address, AddressState, NonEmpty DerivationIndex) -> Bool

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -4045,7 +4045,7 @@ signMetadata ctx (ApiT wid) (ApiT role_) (ApiT ix) body = do
     let pwd  = body ^. #passphrase . #getApiT
 
     withWorkerCtx @_ @s ctx wid liftE liftE $ \wrk -> liftHandler $ do
-        getSignature <$> W.signMetadataWith @_ @s
+        getSignature <$> W.signMetadataWith
             wrk wid (coerce pwd) (role_, ix) meta
 
 derivePublicKey

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1240,7 +1240,6 @@ patchSharedWallet
         , k ~ SharedKey
         , ctx ~ ApiLayer s
         , Shared.SupportsDiscovery n k
-        , HasDBFactory s ctx
         )
     => ctx
     -> (XPub -> k 'AccountK XPub)

--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -245,12 +245,12 @@ benchmarksSeq BenchmarkConfig{benchmarkName,ctx} = do
     (transactions, listTransactionsTime) <- bench "listTransactions"
         $ fmap (fromIntegral . length)
         $ unsafeRunExceptT
-        $ W.listTransactions @_ @s ctx
+        $ W.listTransactions ctx
             Nothing Nothing Nothing Descending Nothing
 
     (_, listTransactionsLimitedTime) <- bench "listTransactions (max_count=50)"
         $ unsafeRunExceptT
-        $ W.listTransactions @_ @s ctx
+        $ W.listTransactions ctx
             Nothing Nothing Nothing Descending (Just 50)
 
     (_, createMigrationPlanTime) <- bench "createMigrationPlan"
@@ -325,12 +325,12 @@ benchmarksShared BenchmarkConfig{benchmarkName,ctx} = do
     (transactions, listTransactionsTime) <- bench "listTransactions"
         $ fmap (fromIntegral . length)
         $ unsafeRunExceptT
-        $ W.listTransactions @_ @s ctx
+        $ W.listTransactions ctx
             Nothing Nothing Nothing Descending Nothing
 
     (_, listTransactionsLimitedTime) <- bench "listTransactions (max_count=50)"
         $ unsafeRunExceptT
-        $ W.listTransactions @_ @s ctx
+        $ W.listTransactions ctx
             Nothing Nothing Nothing Descending (Just 50)
 
     pure BenchSharedResults
@@ -394,12 +394,12 @@ benchmarksRnd BenchmarkConfig{benchmarkName,ctx} = do
     (transactions, listTransactionsTime) <- bench "listTransactions"
         $ fmap (fromIntegral . length)
         $ unsafeRunExceptT
-        $ W.listTransactions @_ @s ctx
+        $ W.listTransactions ctx
             Nothing Nothing Nothing Descending Nothing
 
     (_, listTransactionsLimitedTime) <- bench "listTransactions (max_count=50)"
         $ unsafeRunExceptT
-        $ W.listTransactions @_ @s ctx
+        $ W.listTransactions ctx
             Nothing Nothing Nothing Descending (Just 50)
 
     (_, createMigrationPlanTime) <- bench "createMigrationPlan"

--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -236,7 +236,7 @@ benchmarksSeq BenchmarkConfig{benchmarkName,ctx} = do
 
     (addresses, listAddressesTime) <- bench "listAddresses"
         $ fromIntegral . length
-        <$> W.listAddresses @_ @s ctx (const pure)
+        <$> W.listAddresses ctx (const pure)
 
     (_, listAssetsTime) <- bench "listAssets"
         $ length
@@ -316,7 +316,7 @@ benchmarksShared BenchmarkConfig{benchmarkName,ctx} = do
 
     (addresses, listAddressesTime) <- bench "listAddresses"
         $ fromIntegral . length
-        <$> W.listAddresses @_ @s ctx (const pure)
+        <$> W.listAddresses ctx (const pure)
 
     (_, listAssetsTime) <- bench "listAssets"
         $ length
@@ -385,7 +385,7 @@ benchmarksRnd BenchmarkConfig{benchmarkName,ctx} = do
 
     (addresses, listAddressesTime) <- bench "listAddresses"
         $ fromIntegral . length
-        <$> W.listAddresses @_ @s ctx (const pure)
+        <$> W.listAddresses ctx (const pure)
 
     (_, listAssetsTime) <- bench "listAssets"
         $ length

--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -45,7 +45,7 @@ import Cardano.BM.Data.Severity
 import Cardano.BM.Trace
     ( Trace )
 import Cardano.Wallet
-    ( readWalletMeta )
+    ( WalletLayer (..), readWalletMeta )
 import Cardano.Wallet.Address.Derivation
     ( DelegationAddress (..), Depth (..), delegationAddressS )
 import Cardano.Wallet.Address.Derivation.Shared
@@ -61,7 +61,7 @@ import Cardano.Wallet.Address.Discovery.Shared
 import Cardano.Wallet.BenchShared
     ( Time, bench, initBenchmarkLogging, runBenchmarks )
 import Cardano.Wallet.DB
-    ( DBFresh (..), DBLayer )
+    ( DBFresh (..) )
 import Cardano.Wallet.DB.Layer
     ( PersistAddressBook )
 import Cardano.Wallet.DummyTarget.Primitive.Types
@@ -71,7 +71,7 @@ import Cardano.Wallet.DummyTarget.Primitive.Types
     , dummyTimeInterpreter
     )
 import Cardano.Wallet.Flavor
-    ( CredFromOf, KeyOf, WalletFlavor (..), keyFlavorFromState )
+    ( KeyFlavor, KeyOf, WalletFlavor (..), keyFlavor )
 import Cardano.Wallet.Logging
     ( trMessageText )
 import Cardano.Wallet.Network
@@ -84,8 +84,6 @@ import Cardano.Wallet.Primitive.Types
     ( SortOrder (..), WalletId, WalletMetadata (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( SealedTx (..) )
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
     ( HistogramBar (..), UTxOStatistics (..) )
 import Cardano.Wallet.Read.NetworkId
@@ -98,8 +96,6 @@ import Cardano.Wallet.Read.NetworkId
     )
 import Cardano.Wallet.Shelley.Transaction
     ( TxWitnessTagFor (..), newTransactionLayer )
-import Cardano.Wallet.Transaction
-    ( TransactionLayer (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Control.Monad
@@ -262,7 +258,7 @@ benchmarksSeq BenchmarkConfig{benchmarkName,ctx} = do
 
     (_, delegationFeeTime) <- bench "delegationFee" $ do
         W.delegationFee
-            (dbLayer ctx) (networkLayer ctx) (transactionLayer ctx)
+            (W.dbLayer_ ctx) (W.networkLayer_ ctx) (W.transactionLayer_ ctx)
             (W.defaultChangeAddressGen (delegationAddressS @n))
 
     pure BenchSeqResults
@@ -433,7 +429,7 @@ data BenchmarkConfig (n :: NetworkDiscriminant) s =
     BenchmarkConfig
         { benchmarkName :: Text
         , networkId :: SNetworkId n
-        , ctx :: MockWalletLayer IO s
+        , ctx :: WalletLayer IO s
         , wid :: WalletId
         }
 
@@ -442,6 +438,7 @@ benchmarkWallets
     :: forall n s results
      . ( PersistAddressBook s
        , TxWitnessTagFor (KeyOf s)
+       , KeyFlavor (KeyOf s)
        , Buildable results
        , ToJSON results
        , WalletFlavor s
@@ -458,8 +455,7 @@ benchmarkWallets
     -> IO [SomeBenchmarkResults]
 benchmarkWallets benchName dir walletTr networkId action = do
     withWalletsFromDirectory dir walletTr networkId
-        $ \ctx@(MockWalletLayer{dbLayer=DB.DBLayer{atomically, walletState}})
-            wid
+        $ \ctx@(WalletLayer{dbLayer_=DB.DBLayer{atomically,walletState}}) wid
         -> do
             WalletMetadata{name} <- atomically $ readWalletMeta walletState
             let config = BenchmarkConfig
@@ -477,15 +473,6 @@ benchmarkWallets benchName dir walletTr networkId action = do
     saveBenchmarkPoints benchname =
         Aeson.encodeFile (T.unpack benchname <> ".json")
 
-data MockWalletLayer m s =
-    MockWalletLayer
-        { networkLayer :: NetworkLayer m Read.Block
-        , transactionLayer
-            :: TransactionLayer (KeyOf s) (CredFromOf s) SealedTx
-        , dbLayer :: DBLayer m s
-        , tracer :: Trace IO Text
-        } deriving (Generic)
-
 mockNetworkLayer :: NetworkLayer IO Read.Block
 mockNetworkLayer = dummyNetworkLayer
     { timeInterpreter = hoistTimeInterpreter liftIO mockTimeInterpreter
@@ -500,15 +487,16 @@ mockTimeInterpreter = dummyTimeInterpreter
 withWalletsFromDirectory
     :: forall n s k a
      . ( PersistAddressBook s
-       , TxWitnessTagFor k
        , WalletFlavor s
-       , KeyOf s ~ k
+       , k ~ KeyOf s
+       , TxWitnessTagFor k
+       , KeyFlavor k
        )
     => FilePath
         -- ^ Directory of database files
     -> Trace IO Text
     -> SNetworkId n
-    -> (MockWalletLayer IO s -> WalletId -> IO a)
+    -> (WalletLayer IO s -> WalletId -> IO a)
     -> IO [a]
 withWalletsFromDirectory dir tr networkId action = do
     DB.DBFactory{listDatabases,withDatabase}
@@ -520,10 +508,12 @@ withWalletsFromDirectory dir tr networkId action = do
             db <- unsafeRunExceptT loadDBLayer
             (flip action wid . mkMockWalletLayer) db
   where
-    mkMockWalletLayer db =
-        MockWalletLayer mockNetworkLayer tl db tr
+    mkMockWalletLayer =
+        WalletLayer (trMessageText tr) genesis mockNetworkLayer tl
+    genesis = error "not implemented: genesis data"
     ti = mockTimeInterpreter
-    tl = newTransactionLayer (keyFlavorFromState @s) (networkIdVal networkId)
+    tl = newTransactionLayer
+            (keyFlavor @k) (networkIdVal networkId)
     tr' = trMessageText tr
     migrationDefaultValues = Sqlite.DefaultFieldValues
         { Sqlite.defaultActiveSlotCoefficient = 1

--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -224,7 +224,7 @@ benchmarksSeq
     -> IO BenchSeqResults
 benchmarksSeq BenchmarkConfig{benchmarkName,ctx} = do
     ((cp, pending), readWalletTime) <- bench "readWallet" $ do
-        (cp, _, pending) <- W.readWallet @_ @s ctx
+        (cp, _, pending) <- W.readWallet ctx
         pure (cp, pending)
 
     (utxo, _) <- bench "utxo statistics" $
@@ -232,7 +232,7 @@ benchmarksSeq BenchmarkConfig{benchmarkName,ctx} = do
 
     (_, getWalletUtxoSnapshotTime) <- bench "getWalletUtxoSnapshot"
         $ length
-        <$> W.getWalletUtxoSnapshot @_ @s ctx
+        <$> W.getWalletUtxoSnapshot ctx
 
     (addresses, listAddressesTime) <- bench "listAddresses"
         $ fromIntegral . length
@@ -254,7 +254,7 @@ benchmarksSeq BenchmarkConfig{benchmarkName,ctx} = do
             Nothing Nothing Nothing Descending (Just 50)
 
     (_, createMigrationPlanTime) <- bench "createMigrationPlan"
-        $ W.createMigrationPlan @_ @s ctx Tx.NoWithdrawal
+        $ W.createMigrationPlan ctx Tx.NoWithdrawal
 
     (_, delegationFeeTime) <- bench "delegationFee" $ do
         W.delegationFee
@@ -304,7 +304,7 @@ benchmarksShared
     -> IO BenchSharedResults
 benchmarksShared BenchmarkConfig{benchmarkName,ctx} = do
     ((cp, pending), readWalletTime) <- bench "readWallet" $ do
-        (cp, _, pending) <- W.readWallet @_ @s ctx
+        (cp, _, pending) <- W.readWallet ctx
         pure (cp, pending)
 
     (utxo, _) <- bench "utxo statistics" $
@@ -312,7 +312,7 @@ benchmarksShared BenchmarkConfig{benchmarkName,ctx} = do
 
     (_, getWalletUtxoSnapshotTime) <- bench "getWalletUtxoSnapshot"
         $ length
-        <$> W.getWalletUtxoSnapshot @_ @s ctx
+        <$> W.getWalletUtxoSnapshot ctx
 
     (addresses, listAddressesTime) <- bench "listAddresses"
         $ fromIntegral . length
@@ -373,7 +373,7 @@ benchmarksRnd
     -> IO BenchRndResults
 benchmarksRnd BenchmarkConfig{benchmarkName,ctx} = do
     ((cp, pending), readWalletTime) <- bench "readWallet" $ do
-        (cp, _, pending) <- W.readWallet @_ @s ctx
+        (cp, _, pending) <- W.readWallet ctx
         pure (cp, pending)
 
     (utxo, _) <- bench "utxo statistics" $
@@ -381,7 +381,7 @@ benchmarksRnd BenchmarkConfig{benchmarkName,ctx} = do
 
     (_, getWalletUtxoSnapshotTime) <- bench "getWalletUtxoSnapshot"
         $ length
-        <$> W.getWalletUtxoSnapshot @_ @s ctx
+        <$> W.getWalletUtxoSnapshot ctx
 
     (addresses, listAddressesTime) <- bench "listAddresses"
         $ fromIntegral . length
@@ -403,7 +403,7 @@ benchmarksRnd BenchmarkConfig{benchmarkName,ctx} = do
             Nothing Nothing Nothing Descending (Just 50)
 
     (_, createMigrationPlanTime) <- bench "createMigrationPlan"
-        $ W.createMigrationPlan @_ @s ctx Tx.NoWithdrawal
+        $ W.createMigrationPlan ctx Tx.NoWithdrawal
 
     pure BenchRndResults
         { benchName = benchmarkName

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -474,7 +474,7 @@ benchmarksRnd network w wname
     (transactions, listTransactionsTime) <- bench "list transactions"
         $ fmap (fromIntegral . length)
         $ unsafeRunExceptT
-        $ W.listTransactions @_ @s w Nothing Nothing Nothing Descending
+        $ W.listTransactions w Nothing Nothing Nothing Descending
             Nothing
 
     -- To aid with debugging, write the current wallet state to the log:
@@ -487,7 +487,7 @@ benchmarksRnd network w wname
 
     (_, listTransactionsLimitedTime) <- bench "list transactions (max_count = 100)" $ do
         unsafeRunExceptT
-        $ W.listTransactions @_ @s w Nothing Nothing Nothing Descending
+        $ W.listTransactions w Nothing Nothing Nothing Descending
             (Just 100)
 
     estimateFeesTime <-
@@ -570,7 +570,7 @@ benchmarksSeq network w _wname
     (transactions, listTransactionsTime) <- bench "list transactions"
         $ fmap (fromIntegral . length)
         $ unsafeRunExceptT
-        $ W.listTransactions @_ @s w Nothing Nothing Nothing Descending
+        $ W.listTransactions w Nothing Nothing Nothing Descending
             Nothing
 
     -- To aid with debugging, write the current wallet state to the log:
@@ -583,7 +583,7 @@ benchmarksSeq network w _wname
 
     (_, listTransactionsLimitedTime) <- bench "list transactions (max_count = 100)" $ do
         unsafeRunExceptT
-        $ W.listTransactions @_ @s w Nothing Nothing Nothing Descending
+        $ W.listTransactions w Nothing Nothing Nothing Descending
             (Just 100)
 
     estimateFeesTime <-

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -737,7 +737,7 @@ bench_restoration
                     void
                         $ forkIO
                         $ unsafeRunExceptT
-                        $ W.restoreWallet @_ @s w
+                        $ W.restoreWallet w
 
                     -- NOTE: This is now the time to restore /all/ wallets.
                     (_, restorationTime) <- bench "restoration" $ do

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -497,12 +497,12 @@ benchmarksRnd network w wname
     oneAddress <- genAddresses 1 cp
     (_, importOneAddressTime) <- bench "import one addresses" $ do
         runExceptT $ withExceptT show $
-            W.importRandomAddresses @_ @s w oneAddress
+            W.importRandomAddresses w oneAddress
 
     manyAddresses <- genAddresses 1000 cp
     (_, importManyAddressesTime) <- bench "import many addresses" $ do
         runExceptT $ withExceptT show $
-            W.importRandomAddresses @_ @s w manyAddresses
+            W.importRandomAddresses w manyAddresses
 
     pure BenchRndResults
         { benchName = benchname

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -718,13 +718,14 @@ import qualified Data.Vector as V
 --
 -- __Fix__: Add type-applications at the call-site "@myFunction \@ctx \@s \\@k@"
 
-data WalletLayer m s
-    = WalletLayer
-        (Tracer m WalletWorkerLog)
-        (Block, NetworkParameters)
-        (NetworkLayer m Read.Block)
-        (TransactionLayer (KeyOf s) (CredFromOf s) SealedTx)
-        (DBLayer m s)
+data WalletLayer m s =
+    WalletLayer
+        { logger_ :: Tracer m WalletWorkerLog
+        , genesisData_ :: (Block, NetworkParameters)
+        , networkLayer_ :: NetworkLayer m Read.Block
+        , transactionLayer_ :: TransactionLayer (KeyOf s) (CredFromOf s) SealedTx
+        , dbLayer_ :: DBLayer m s
+        }
     deriving (Generic)
 
 {-------------------------------------------------------------------------------

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -3114,14 +3114,13 @@ withRootKey DBLayer{..} wid pwd embed action = do
 -- This is experimental, and will likely be replaced by a more robust to
 -- arbitrary message signing using COSE, or a subset of it.
 signMetadataWith
-    :: forall ctx s n k.
-        ( HasDBLayer IO s ctx
-        , HardDerivation k
+    :: forall s n k.
+        ( HardDerivation k
         , AddressIndexDerivationType k ~ 'Soft
         , WalletFlavor s
         , s ~ SeqState n k
         )
-    => ctx
+    => WalletLayer IO s
     -> WalletId
     -> Passphrase "user"
     -> (Role, DerivationIndex)
@@ -3143,7 +3142,7 @@ signMetadataWith ctx wid pwd (role_, ix) metadata = db & \DBLayer{..} -> do
             hash @ByteString @Blake2b_256 $
             serialiseToCBOR metadata
   where
-    db = ctx ^. dbLayer @IO @s
+    db = ctx ^. dbLayer
 
 derivePublicKey
     :: forall s k.

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -790,15 +790,13 @@ transactionLayer = typed @(TransactionLayer k ktype SealedTx)
 
 -- | Convenience to apply an 'Update' to the 'WalletState' via the 'DBLayer'.
 onWalletState
-    :: forall m s ctx r
-     . HasDBLayer m s ctx
-    => ctx
+    :: WalletLayer m s
     -> Delta.Update (WalletState.DeltaWalletState s) r
     -> m r
 onWalletState ctx update' = db & \DBLayer{..} ->
     atomically $ Delta.onDBVar walletState update'
   where
-    db = ctx ^. dbLayer @m @s
+    db = ctx ^. dbLayer
 
 {-------------------------------------------------------------------------------
                                    Wallet

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -968,12 +968,10 @@ putWalletMeta walletState wm = onDBVar walletState $ update $ \_ ->
 
 -- | Update a wallet's metadata with the given update function.
 updateWallet
-    :: forall ctx s
-     . HasDBLayer IO s ctx
-    => ctx
+    :: WalletLayer IO s
     -> (WalletMetadata -> WalletMetadata)
     -> IO ()
-updateWallet ctx f = onWalletState @IO @s ctx $ update $ \s ->
+updateWallet ctx f = onWalletState ctx $ update $ \s ->
     [ UpdateInfo
         $ UpdateWalletMetadata
         $ f
@@ -3265,19 +3263,18 @@ guardHardIndex ix =
     else pure (Index $ getDerivationIndex ix)
 
 updateCosigner
-    :: forall ctx s k n
+    :: forall s k n
      . ( s ~ SharedState n k
        , k ~ SharedKey
        , Shared.SupportsDiscovery n k
-       , HasDBLayer IO s ctx
        )
-    => ctx
+    => WalletLayer IO s
     -> k 'AccountK XPub
     -> Cosigner
     -> CredentialType
     -> ExceptT ErrAddCosignerKey IO ()
 updateCosigner ctx cosignerXPub cosigner cred =
-    ExceptT . onWalletState @IO @s ctx . Delta.updateWithError
+    ExceptT . onWalletState ctx . Delta.updateWithError
         $ updateCosigner'
   where
     kF = keyFlavorFromState @s

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -55,7 +55,6 @@ module Cardano.Wallet
 
     -- * Capabilities
     -- $Capabilities
-    , HasDBLayer
     , dbLayer
     , HasLogger
     , logger
@@ -683,7 +682,7 @@ import qualified Data.Vector as V
 -- lenses (see Cardano.Wallet#Capabilities). These components are extracted from the context
 -- in a @where@ clause according to the following naming convention:
 --
--- - @db = ctx ^. dbLayer \@s \\@k@ for the 'DBLayer'.
+-- - @db = ctx ^. dbLayer for the 'DBLayer'.
 -- - @tr = ctx ^. logger@ for the Logger.
 -- - @nw = ctx ^. networkLayer@ for the 'NetworkLayer'.
 -- - @tl = ctx ^. transactionLayer \\@k@ for the 'TransactionLayer'.
@@ -757,7 +756,6 @@ data WalletLayer m s =
 -- One can build an interface using only a subset of the wallet layer
 -- capabilities and functions, for instance, something to fiddle with wallets
 -- and their metadata does not require any networking layer.
-type HasDBLayer m s = HasType (DBLayer m s)
 
 type HasGenesisData = HasType (Block, NetworkParameters)
 
@@ -769,8 +767,8 @@ type HasNetworkLayer m = HasType (NetworkLayer m Read.Block)
 
 type HasTransactionLayer k ktype = HasType (TransactionLayer k ktype SealedTx)
 
-dbLayer :: forall m s ctx. HasDBLayer m s ctx => Lens' ctx (DBLayer m s)
-dbLayer = typed @(DBLayer m s)
+dbLayer :: Lens' (WalletLayer m s) (DBLayer m s)
+dbLayer = #dbLayer_
 
 genesisData ::
     forall ctx. HasGenesisData ctx => Lens' ctx (Block, NetworkParameters)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1502,18 +1502,15 @@ manageSharedRewardBalance tr' netLayer db = do
 -------------------------------------------------------------------------------}
 
 lookupTxIns
-    :: forall ctx s .
-        ( HasDBLayer IO s ctx
-        , IsOurs s Address
-        )
-    => ctx
+    :: IsOurs s Address
+    => WalletLayer IO s
     -> [TxIn]
     -> IO [(TxIn, Maybe (TxOut, NonEmpty DerivationIndex))]
 lookupTxIns ctx txins = db & \DBLayer{..} -> do
     cp <- atomically readCheckpoint
     pure $ map (\i -> (i, lookupTxIn cp i)) txins
   where
-    db = ctx ^. dbLayer @IO @s
+    db = ctx ^. dbLayer
 
 lookupTxIn
     :: IsOurs s Address
@@ -1525,11 +1522,8 @@ lookupTxIn wallet txIn = do
     (out,) <$> fst (isOurs addr (getState wallet))
 
 lookupTxOuts
-    :: forall ctx s .
-        ( HasDBLayer IO s ctx
-        , IsOurs s Address
-        )
-    => ctx
+    :: IsOurs s Address
+    => WalletLayer IO s
     -> [TxOut]
     -> IO [(TxOut, Maybe (NonEmpty DerivationIndex))]
 lookupTxOuts ctx txouts = db & \DBLayer{..} -> do
@@ -1541,7 +1535,7 @@ lookupTxOuts ctx txouts = db & \DBLayer{..} -> do
     pure $ flip evalState (getState cp) $ forM txouts $ \out@(TxOut addr _) ->
         (out,) <$> state (isOurs addr)
   where
-    db = ctx ^. dbLayer @IO @s
+    db = ctx ^. dbLayer
 
 -- | List all addresses of a wallet with their metadata. Addresses
 -- are ordered from the most-recently-discovered to the oldest known.

--- a/lib/wallet/src/Cardano/Wallet/Logging.hs
+++ b/lib/wallet/src/Cardano/Wallet/Logging.hs
@@ -41,7 +41,6 @@ module Cardano.Wallet.Logging
     , produceTimings
 
       -- * Tracer conversions
-    , unliftIOTracer
     , flatContramapTracer
     ) where
 
@@ -69,7 +68,7 @@ import Control.Monad.IO.Unlift
 import Control.Monad.Trans.Except
     ( ExceptT (..), runExceptT )
 import Control.Tracer
-    ( Tracer (..), contramap, natTracer, nullTracer, traceWith )
+    ( Tracer (..), contramap, nullTracer, traceWith )
 import Control.Tracer.Transformers.ObserveOutcome
     ( Outcome (..)
     , OutcomeFidelity (..)
@@ -397,11 +396,6 @@ produceTimings f trDiffTime = do
 {-------------------------------------------------------------------------------
                                Tracer conversions
 -------------------------------------------------------------------------------}
-
--- | Convert an IO tracer to a 'm' tracer.
-unliftIOTracer :: MonadIO m => Tracer IO a -> Tracer m a
-unliftIOTracer = natTracer liftIO
-
 -- | Conditional mapping of a 'Tracer'.
 flatContramapTracer
     :: Monad m

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -179,7 +179,7 @@ import Control.Monad.Trans.Reader
 import Control.Monad.Trans.State.Strict
     ( State, StateT (..), evalState, get, put, state )
 import Control.Tracer
-    ( Tracer (..), natTracer, nullTracer )
+    ( natTracer, nullTracer )
 import Crypto.Hash
     ( hash )
 import Data.Bifunctor
@@ -481,7 +481,7 @@ walletListTransactionsSorted wallet@(_, _, _) _order (_mstart, _mend) =
         WalletLayerFixture _ DBLayer{..} wl _ <- setupFixture dummyStateF wallet
         atomically $ putTxHistory history
         txs <- unsafeRunExceptT $
-            W.listTransactions @_ @_ wl Nothing Nothing Nothing
+            W.listTransactions wl Nothing Nothing Nothing
                 Descending Nothing
         length txs `shouldBe` L.length history
         -- With the 'Down'-wrapper, the sort is descending.
@@ -525,7 +525,7 @@ walletListTransactionsWithLimit wallet@(_, _, _) =
             WalletLayerFixture _ DBLayer{..} wl _ <- setupFixture dummyStateF wallet
             atomically $ putTxHistory history'
             txs <- unsafeRunExceptT $
-                W.listTransactions @_ @_ wl Nothing start stop order
+                W.listTransactions wl Nothing start stop order
                     $ Just limitNatural
             let times = [(txInfoId i, txInfoTime i) | i <- txs]
             shouldBe times $ take limit $ sortOn (dir . snd) $ do
@@ -754,13 +754,7 @@ instance Arbitrary SlottingParameters where
             { getActiveSlotCoefficient = ActiveSlotCoefficient f }
 
 -- | 'WalletLayer' context.
-data TxRetryTestCtx = TxRetryTestCtx
-    { ctxDbLayer :: DBLayer TxRetryTestM DummyState
-    , ctxNetworkLayer :: NetworkLayer TxRetryTestM Read.Block
-    , ctxRetryTracer :: Tracer TxRetryTestM W.WalletWorkerLog
-    , ctxTracer :: Tracer IO W.WalletWorkerLog
-    , ctxWalletId :: WalletId
-    } deriving (Generic)
+type TxRetryTestCtx = WalletLayer TxRetryTestM DummyState
 
 -- | Context of 'TxRetryTestM'.
 data TxRetryTestState = TxRetryTestState
@@ -768,6 +762,7 @@ data TxRetryTestState = TxRetryTestState
     , timeStep :: DiffTime
     , timeVar :: MVar Time
     } deriving (Generic)
+
 -- | Collected info from test execution.
 data TxRetryTestResult a = TxRetryTestResult
     { resLogs :: [W.WalletWorkerLog]
@@ -809,16 +804,16 @@ prop_localTxSubmission tc = monadicIO $ do
     st <- TxRetryTestState tc 2 <$> newMVar (Time 0)
     assert $ not $ null $ retryTestPool tc
     res <- run $ runTest st
-        $ \ctx@(TxRetryTestCtx dbl nl tr _ _) -> do
+        $ \ctx@(WalletLayer tr _ nl _ db) -> do
         unsafeRunExceptT
-            $ forM_ (retryTestPool tc) $ submitTx tr dbl nl
-        res0 <- W.readLocalTxSubmissionPending @_ @DummyState  ctx
+            $ forM_ (retryTestPool tc) $ submitTx tr db nl
+        res0 <- W.readLocalTxSubmissionPending ctx
         -- Run test
         let cfg = LocalTxSubmissionConfig (timeStep st) 10
-        W.runLocalTxSubmissionPool @_ @DummyState cfg ctx
+        W.runLocalTxSubmissionPool cfg ctx
 
         -- Gather state
-        res1 <- W.readLocalTxSubmissionPending @_ @DummyState ctx
+        res1 <- W.readLocalTxSubmissionPending ctx
         pure (res0, res1)
 
     let (resStart, resEnd) = resAction res
@@ -860,11 +855,14 @@ prop_localTxSubmission tc = monadicIO $ do
         submittedVar <- newMVar []
         (msgs, res) <- captureLogging' $ \tr -> do
             flip runReaderT st $ unTxRetryTestM $ do
-                WalletLayerFixture _ db _wl wid <-
+                WalletLayerFixture _ db _wl _wid <-
                     setupFixture dummyStateF $ retryTestWallet tc
-                let ctx = TxRetryTestCtx db (mockNetwork submittedVar)
-                        (natTracer liftIO tr) tr wid
-
+                let ctx = WalletLayer
+                        (natTracer liftIO tr)
+                        undefined
+                        (mockNetwork submittedVar)
+                        undefined
+                        db
                 testAction ctx
         TxRetryTestResult msgs res <$> readMVar submittedVar
 

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -402,7 +402,7 @@ walletUpdatePassphrase wallet new mxprv = monadicIO $ do
         let err = ErrUpdatePassphraseWithRootKey $ ErrWithRootKeyNoRootKey wid
         assert (attempt == Left err)
     prop_withPrivateKey wl wid (xprv, pwd) = do
-        run $ W.attachPrivateKeyFromPwd dummyStateF wl (xprv, pwd)
+        run $ W.attachPrivateKeyFromPwd wl (xprv, pwd)
         attempt <- run $ runExceptT
             $ W.updateWalletPassphraseWithOldPassphrase dummyStateF
                 wl wid (coerce pwd, new)
@@ -417,7 +417,7 @@ walletUpdatePassphraseWrong wallet (xprv, pwd) (old, new) =
     pwd /= coerce old ==> monadicIO $ do
         WalletLayerFixture _ _ wl wid <- run $ setupFixture dummyStateF wallet
         attempt <- run $ do
-            W.attachPrivateKeyFromPwd dummyStateF wl (xprv, pwd)
+            W.attachPrivateKeyFromPwd wl (xprv, pwd)
             runExceptT
                 $ W.updateWalletPassphraseWithOldPassphrase
                     dummyStateF wl wid (old, new)
@@ -453,7 +453,7 @@ walletUpdatePassphraseDate wallet (xprv, pwd) = monadicIO $ liftIO $ do
             return info
 
     void $ infoShouldSatisfy isNothing
-    W.attachPrivateKeyFromPwd dummyStateF wl (xprv, pwd)
+    W.attachPrivateKeyFromPwd wl (xprv, pwd)
     info <- infoShouldSatisfy isJust
     pause
     unsafeRunExceptT

--- a/scripts/cabal-lib.sh
+++ b/scripts/cabal-lib.sh
@@ -74,6 +74,7 @@ ghci_flags() {
 -fwarn-orphans
 -fprint-potential-instances
 -Wno-missing-home-modules
+-Wredundant-constraints
 EOF
 
     # Add all source directories to ghci command-line


### PR DESCRIPTION
### Overview

This pull request is about reducing the use of ambiguous types for definitions in `Cardano.Wallet`, as far as usage of `DBLayer` is concerned.

### Details

Many functions in `Cardano.Wallet` use the `HasDBLayer` constraint to retrieve the `DBLayer` for a wallet, for example

```hs
readWallet
    :: forall ctx s k. HasDBLayer IO s k ctx
    => ctx
    -> IO (Wallet s, (WalletMetadata, WalletDelegation), Set Tx)
```

This signature is ambiguous: The type variable `k` appears in the type-level arguments, but not in the value-level arguments. This introduces noise when extracting the `dbLayer` from the `ctx`, as we have to supply explicit type arguments, i.e. we have to write `db = ctx ^. dbLayer @IO @s @k` and cannot write `db = ctx ^. dbLayer`.

A better signature for readWallet is the following:

```hs
readWallet
    :: Monad m
    => WalletLayer m s k ktype
    -> m (Wallet s, (WalletMetadata, WalletDelegation), Set Tx)
```

Even though this type signature appears to be less modular — it only works for the composite `WalletLayer` record — in practice, even for testing, we always assemble a complete `WalletLayer` and don’t use more fine-grained types such as `ctx ~ DBLayer m s k`.

### Comments

* In order to limit the scope of this pull request, we focus on functions with the HasDBLayer constraint.

* One could argue that the signature

    ```hs
    readWallet
        :: Monad m
        => DBLayer m s k
        -> m (Wallet s, (WalletMetadata, WalletDelegation), Set Tx)
    ```

    is more modular, but it has the drawback of introducing noise on the value-level when we want to apply it to a `WalletLayer`. While this signature is not wrong — it is “simple Haskell” — it does not further our goals of modularity, as we want to get rid of `DBLayer` entirely.
### Issue number

ADP-3018