### PR TITLE
[ADP-3019] Add PrivateKey store.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -187,6 +187,7 @@ import Cardano.Wallet
     , logger
     , manageRewardBalance
     , networkLayer
+    , readPrivateKey
     , readWalletMeta
     , transactionLayer
     , utxoAssumptionsForWallet
@@ -1261,13 +1262,12 @@ patchSharedWallet ctx liftKey cred (ApiT wid) body = do
                 db & \W.DBLayer
                     { atomically
                     , readCheckpoint
-                    , readPrivateKey
                     , walletState
                     } -> do
                         cp <- atomically readCheckpoint
                         let state = getState cp
                         --could be for account and root key wallets
-                        prvKeyM <- atomically readPrivateKey
+                        prvKeyM <- atomically $ readPrivateKey walletState
                         meta <- atomically (readWalletMeta walletState)
                         pure (state, prvKeyM, meta)
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -494,6 +494,8 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( ClearCredentials, RootCredentials (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Redeemer
@@ -872,7 +874,7 @@ postShelleyWallet
     -> Handler ApiWallet
 postShelleyWallet ctx generateKey body = do
     let state = mkSeqStateFromRootXPrv
-            (keyFlavorFromState @s) (rootXPrv, pwdP) purposeCIP1852 g
+            (keyFlavorFromState @s) (RootCredentials rootXPrv pwdP) purposeCIP1852 g
     void $ liftHandler $ createWalletWorker @_ @s ctx wid
         (\dbf -> W.createWallet @_ @s genesisParams dbf wid wName state)
         (\workerCtx _ -> W.manageRewardBalance
@@ -1062,7 +1064,7 @@ postSharedWalletFromRootXPrv ctx generateKey body = do
     ix' <- liftHandler $ withExceptT ErrConstructSharedWalletInvalidIndex $
         W.guardHardIndex ix
     let state = mkSharedStateFromRootXPrv kF
-            (rootXPrv, pwdP) ix' g pTemplate dTemplateM
+            (RootCredentials rootXPrv pwdP) ix' g pTemplate dTemplateM
     let stateReadiness = state ^. #ready
     if stateReadiness == Shared.Pending
     then void $ liftHandler $ createNonRestoringWalletWorker @_ @s ctx wid
@@ -1453,7 +1455,7 @@ postIcarusWallet
 postIcarusWallet ctx body = do
     postLegacyWallet ctx (rootXPrv, pwd) $ \wrk wid ->
         W.createIcarusWallet @s genesisParams wrk wid wName
-            (rootXPrv, pwdP)
+            (RootCredentials rootXPrv pwdP)
   where
     wName    = body ^. #name . #getApiT
     seed     = body ^. #mnemonicSentence . #getApiMnemonicT
@@ -1475,7 +1477,7 @@ postTrezorWallet
 postTrezorWallet ctx body = do
     postLegacyWallet ctx (rootXPrv, pwd) $ \wrk wid ->
         W.createIcarusWallet @s genesisParams wrk wid wName
-            (rootXPrv, pwdP)
+            (RootCredentials rootXPrv pwdP)
   where
     wName    = body ^. #name . #getApiT
     seed     = body ^. #mnemonicSentence . #getApiMnemonicT
@@ -1497,7 +1499,7 @@ postLedgerWallet
 postLedgerWallet ctx body = do
     postLegacyWallet ctx (rootXPrv, pwd) $ \wrk wid ->
         W.createIcarusWallet @s genesisParams wrk wid wName
-            (rootXPrv, pwdP)
+            (RootCredentials rootXPrv pwdP)
   where
     wName    = body ^. #name . #getApiT
     mw       = body ^. #mnemonicSentence . #getApiMnemonicT
@@ -2138,7 +2140,7 @@ signTransaction ctx (ApiT wid) body = do
                     pure $ W.signTransaction
                         (keyFlavorFromState @s)
                         tl era witCountCtx keyLookup
-                        Nothing (rootK, pwdP) utxo accIxForStakingM sealedTx
+                        Nothing (RootCredentials rootK pwdP) utxo accIxForStakingM sealedTx
 
     -- TODO: The body+witnesses seem redundant with the sealedTx already. What's
     -- the use-case for having them provided separately? In the end, the client
@@ -4209,7 +4211,7 @@ rndStateChange ctx (ApiT wid) pwd =
             \xprv scheme -> pure (xprv, preparePassphrase scheme pwd)
 
 type RewardAccountBuilder k
-    =  (k 'RootK XPrv, Passphrase "encryption")
+    =  ClearCredentials k
     -> (XPrv, Passphrase "encryption")
 
 mkWithdrawal
@@ -4270,7 +4272,7 @@ selfRewardAccountBuilder
        )
     => KeyFlavorS k
     -> RewardAccountBuilder k
-selfRewardAccountBuilder keyF (rootK, pwdP) =
+selfRewardAccountBuilder keyF (RootCredentials rootK pwdP) =
     (getRawKey keyF (deriveRewardAccount pwdP rootK minBound), pwdP)
 
 -- | Makes an 'ApiCoinSelection' from the given 'UnsignedTx'.

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -119,6 +119,8 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( RootCredentials (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
@@ -800,7 +802,7 @@ testCpByron = snd $ initWallet block0 initDummyRndState
 {-# NOINLINE initDummySeqState #-}
 initDummySeqState :: SeqState 'Mainnet ShelleyKey
 initDummySeqState = mkSeqStateFromRootXPrv
-    ShelleyKeyS (xprv, mempty) purposeCIP1852 defaultAddressPoolGap
+    ShelleyKeyS (RootCredentials xprv mempty) purposeCIP1852 defaultAddressPoolGap
   where
     mnemonic = unsafePerformIO
         $ SomeMnemonic . entropyToMnemonic @15

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -107,8 +107,6 @@ import Cardano.Wallet.Network
     )
 import Cardano.Wallet.Primitive.Model
     ( Wallet, availableUTxO, currentTip, getState, totalUTxO )
-import Cardano.Wallet.Primitive.Passphrase.Types
-    ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter, neverFails )
 import Cardano.Wallet.Primitive.SyncProgress
@@ -128,6 +126,8 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( ClearCredentials, RootCredentials (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
@@ -358,9 +358,7 @@ cardanoRestoreBench tr c socketFile = do
 
     walletSeq
         :: Text
-        -> ((ShelleyKey 'RootK XPrv, Passphrase "encryption")
-            -> AddressPoolGap -> s
-            )
+        -> (ClearCredentials ShelleyKey -> AddressPoolGap -> s)
         -> (WalletId, WalletName, s)
     walletSeq wname mkState =
         let
@@ -368,7 +366,7 @@ cardanoRestoreBench tr c socketFile = do
             xprv = Shelley.generateKeyFromSeed (seed, Nothing) mempty
             wid = WalletId $ digest ShelleyKeyS $ publicKey ShelleyKeyS xprv
             Right gap = mkAddressPoolGap 20
-            s = mkState (xprv, mempty) gap
+            s = mkState (RootCredentials xprv mempty) gap
         in
             (wid, WalletName wname, s)
 
@@ -376,7 +374,7 @@ cardanoRestoreBench tr c socketFile = do
         :: forall (p :: Nat) n. HasSNetworkId n
         => Proxy p
         -> SNetworkId n
-        -> (ShelleyKey 'RootK XPrv, Passphrase "encryption")
+        -> ClearCredentials ShelleyKey
         -> AddressPoolGap
         -> SeqAnyState n ShelleyKey p
     mkSeqAnyState' _ _ credentials =

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -272,6 +272,7 @@ library
     Cardano.Wallet.DB.Store.Meta.Layer
     Cardano.Wallet.DB.Store.Meta.Model
     Cardano.Wallet.DB.Store.Meta.Store
+    Cardano.Wallet.DB.Store.PrivateKey.Store
     Cardano.Wallet.DB.Store.Submissions.Layer
     Cardano.Wallet.DB.Store.Submissions.Operations
     Cardano.Wallet.DB.Store.Transactions.Decoration

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -925,6 +925,7 @@ test-suite unit
     Cardano.Wallet.DB.Store.Info.StoreSpec
     Cardano.Wallet.DB.Store.Meta.ModelSpec
     Cardano.Wallet.DB.Store.Meta.StoreSpec
+    Cardano.Wallet.DB.Store.PrivateKey.StoreSpec
     Cardano.Wallet.DB.Store.Submissions.StoreSpec
     Cardano.Wallet.DB.Store.Transactions.StoreSpec
     Cardano.Wallet.DB.Store.UTxOHistory.ModelSpec

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -315,6 +315,7 @@ library
     Cardano.Wallet.Primitive.SyncProgress
     Cardano.Wallet.Primitive.Types
     Cardano.Wallet.Primitive.Types.Address.Constants
+    Cardano.Wallet.Primitive.Types.Credentials
     Cardano.Wallet.Primitive.Types.MinimumUTxO
     Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
     Cardano.Wallet.Primitive.Types.ProtocolMagic

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/SequentialAny.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/SequentialAny.hs
@@ -12,8 +12,6 @@ where
 
 import Prelude
 
-import Cardano.Crypto.Wallet
-    ( XPrv )
 import Cardano.Wallet.Address.Derivation
     ( Depth (..), DerivationType (..), HardDerivation (..), Index (..) )
 import Cardano.Wallet.Address.Derivation.MintBurn
@@ -29,8 +27,6 @@ import Cardano.Wallet.Address.Discovery.Sequential
     )
 import Cardano.Wallet.Flavor
     ( Excluding, KeyFlavorS )
-import Cardano.Wallet.Primitive.Passphrase.Types
-    ( Passphrase )
 import GHC.TypeLits
     ( Nat )
 
@@ -38,6 +34,9 @@ import Cardano.Wallet.Address.Derivation.Byron
     ( ByronKey (..) )
 import Cardano.Wallet.Address.Keys.WalletKey
     ( getRawKey, liftRawKey, publicKey )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( ClearCredentials, RootCredentials (..) )
+
 
 
 -- | Initialize the HD random address discovery state from a root key and RNG
@@ -52,7 +51,7 @@ mkSeqAnyState
         , Excluding '[SharedKey, ByronKey] k
         )
     => KeyFlavorS k
-    -> (k 'RootK XPrv, Passphrase "encryption")
+    -> ClearCredentials k
     -> Index 'Hardened 'PurposeK
     -> AddressPoolGap
     -> SeqAnyState n k p
@@ -68,11 +67,11 @@ mkSeqStateFromRootXPrv
         , Excluding '[ByronKey, SharedKey] k
         )
     => KeyFlavorS k
-    -> (k 'RootK XPrv, Passphrase "encryption")
+    -> ClearCredentials k
     -> Index 'Hardened 'PurposeK
     -> AddressPoolGap
     -> SeqState n k
-mkSeqStateFromRootXPrv kF (rootXPrv, pwd) =
+mkSeqStateFromRootXPrv kF (RootCredentials rootXPrv pwd) =
     mkSeqStateFromAccountXPub
         (publicKey kF $ deriveAccountPrivateKey pwd rootXPrv minBound)
             $ Just

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/Shared.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/Shared.hs
@@ -40,7 +40,7 @@ import Cardano.Address.Script
     , validateScriptTemplate
     )
 import Cardano.Crypto.Wallet
-    ( XPrv, XPub, unXPub )
+    ( XPub, unXPub )
 import Cardano.Wallet.Address.Derivation
     ( Depth (..)
     , DerivationPrefix (..)
@@ -69,8 +69,6 @@ import Cardano.Wallet.Address.Keys.WalletKey
     ( getRawKey, publicKey )
 import Cardano.Wallet.Flavor
     ( KeyFlavorS )
-import Cardano.Wallet.Primitive.Passphrase
-    ( Passphrase )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Control.Monad
@@ -85,6 +83,8 @@ import Data.Either.Combinators
 import Cardano.Address.Script.Parser
     ( scriptToText )
 import qualified Cardano.Address.Style.Shelley as CA
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( ClearCredentials, RootCredentials (..) )
 import qualified Data.Foldable as F
 import qualified Data.Map.Strict as Map
 import qualified Data.Text.Encoding as T
@@ -114,13 +114,13 @@ mkSharedStateFromAccountXPub kF accXPub accIx gap pTemplate dTemplateM =
 mkSharedStateFromRootXPrv
     :: (SupportsDiscovery n k, k ~ SharedKey)
     => KeyFlavorS k
-    -> (k 'RootK XPrv, Passphrase "encryption")
+    -> ClearCredentials k
     -> Index 'Hardened 'AccountK
     -> AddressPoolGap
     -> ScriptTemplate
     -> Maybe ScriptTemplate
     -> SharedState n k
-mkSharedStateFromRootXPrv kF (rootXPrv, pwd) accIx =
+mkSharedStateFromRootXPrv kF (RootCredentials rootXPrv pwd) accIx =
     mkSharedStateFromAccountXPub kF accXPub accIx
   where
     accXPub = publicKey kF $ deriveAccountPrivateKey pwd rootXPrv accIx

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -546,9 +546,9 @@ newDBFreshFromDBOpen
     -> DBOpen (SqlPersistT IO) IO s
     -- ^ A (thread-)safe wrapper for query execution.
     -> DBFresh IO s
-newDBFreshFromDBOpen wf ti wid_ DBOpen{atomically=atomically_} =
+newDBFreshFromDBOpen wF ti wid_ DBOpen{atomically=atomically_} =
     mkDBFreshFromParts ti wid_
-        getWalletId_ (mkStoreWallet wid_)
+        getWalletId_ (mkStoreWallet wF wid_)
             dbLayerCollection atomically_
   where
     transactionsQS = newQueryStoreTxWalletsHistory
@@ -649,7 +649,7 @@ newDBFreshFromDBOpen wf ti wid_ DBOpen{atomically=atomically_} =
     dbDelegation = mkDBDelegation ti wid_
 
 
-    dbPrivateKey = mkDBPrivateKey (keyOfWallet wf) wid_
+    dbPrivateKey = mkDBPrivateKey (keyOfWallet wF) wid_
 
 mkDBFreshFromParts
     :: forall stm m s

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -33,12 +33,10 @@ import Cardano.Wallet.DB.Pure.Implementation
     , mPutCheckpoint
     , mPutDelegationCertificate
     , mPutDelegationRewardBalance
-    , mPutPrivateKey
     , mPutTxHistory
     , mReadCheckpoint
     , mReadDelegationRewardBalance
     , mReadGenesisParameters
-    , mReadPrivateKey
     , mReadTxHistory
     , mRollbackTo
     )
@@ -158,14 +156,6 @@ newDBFresh timeInterpreter wid = do
                 case filter txPresent txInfos of
                     [] -> pure Nothing
                     t:_ -> pure $ Just t
-
-        {-----------------------------------------------------------------------
-                                       Keystore
-        -----------------------------------------------------------------------}
-
-        , putPrivateKey = noErrorAlterDB db . mPutPrivateKey
-
-        , readPrivateKey = join <$> readDBMaybe db mReadPrivateKey
 
         {-----------------------------------------------------------------------
                                        Pending Tx

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/PrivateKey/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/PrivateKey/Store.hs
@@ -10,8 +10,8 @@
 -- License: Apache-2.0
 module Cardano.Wallet.DB.Store.PrivateKey.Store
     ( mkStorePrivateKey
-    , StorePrivateKey
     , DeltaPrivateKey
+    , StorePrivateKey
     ) where
 
 import Prelude
@@ -66,7 +66,7 @@ mkStorePrivateKey kF wid = mkSimpleStore load write
             where
                 privateKeyFromEntity :: Schema.PrivateKey -> HashedCredentials k
                 privateKeyFromEntity (Schema.PrivateKey _ k h) =
-                    uncurry Credentials $ unsafeDeserializeXPrv kF (k, h)
+                    uncurry RootCredentials $ unsafeDeserializeXPrv kF (k, h)
 
         write :: Maybe (HashedCredentials k) -> SqlPersistT IO ()
         write (Just key) = do
@@ -74,7 +74,7 @@ mkStorePrivateKey kF wid = mkSimpleStore load write
             insert_ (mkPrivateKeyEntity key)
         write Nothing = deleteWhere ([] :: [Filter Schema.PrivateKey])
 
-        mkPrivateKeyEntity (Credentials k h) =
+        mkPrivateKeyEntity (RootCredentials k h) =
             Schema.PrivateKey
                 { Schema.privateKeyWalletId = wid
                 , Schema.privateKeyRootKey = root

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/PrivateKey/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/PrivateKey/Store.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+-- |
+-- Copyright: © 2023 IOHK
+-- License: Apache-2.0
+module Cardano.Wallet.DB.Store.PrivateKey.Store
+    ( mkStorePrivateKey
+    , DeltaPrivateKey
+    ) where
+
+import Prelude
+
+import Cardano.Address.Derivation
+    ( XPrv )
+import Cardano.Wallet.Address.Derivation
+    ( Depth (..) )
+import Cardano.Wallet.Address.Keys.PersistPrivateKey
+    ( serializeXPrv, unsafeDeserializeXPrv )
+import Cardano.Wallet.DB.Errors
+    ( ErrWalletNotInitialized (ErrWalletNotInitialized) )
+import Cardano.Wallet.Flavor
+    ( KeyFlavorS )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( PassphraseHash )
+import Cardano.Wallet.Primitive.Types
+    ( WalletId )
+import Control.Exception
+    ( SomeException (..) )
+import Data.Delta
+    ( Replace )
+import Data.Store
+    ( SimpleStore, mkSimpleStore )
+import Database.Persist
+    ( Entity (entityVal), Filter, PersistQueryRead (selectFirst), insert_ )
+import Database.Persist.Sql
+    ( SqlPersistT, deleteWhere )
+
+import qualified Cardano.Wallet.DB.Sqlite.Schema as Schema
+
+-- | A 'PrivateKey' for a given 'KeyFlavor'.
+data PrivateKey k = PrivateKey (k 'RootK XPrv) PassphraseHash
+
+-- | A 'Store' for 'PrivateKey'.
+type StorePrivateKey k = SimpleStore (SqlPersistT IO) (PrivateKey k)
+
+-- | A 'Delta' for 'PrivateKey'.
+type DeltaPrivateKey k = Replace (PrivateKey k)
+
+-- | Construct a 'StorePrivateKey' for a given 'KeyFlavor'.  ATM a WalletId is
+-- required to be able to store the private key.  This limitation is due to the
+-- fact that the table for the private key requires a foreign key to the table
+-- of the wallet.
+mkStorePrivateKey
+    :: forall k
+     . KeyFlavorS k
+    -> WalletId
+    -> StorePrivateKey k
+mkStorePrivateKey kF wid = mkSimpleStore load write
+    where
+        load :: SqlPersistT IO (Either SomeException (PrivateKey k))
+        load = do
+            keys <- selectFirst [] []
+            case keys of
+                Nothing -> pure $ Left $ SomeException ErrWalletNotInitialized
+                Just key -> pure $ Right $ privateKeyFromEntity $ entityVal key
+            where
+                privateKeyFromEntity :: Schema.PrivateKey -> PrivateKey k
+                privateKeyFromEntity (Schema.PrivateKey _ k h) =
+                    uncurry PrivateKey $ unsafeDeserializeXPrv kF (k, h)
+
+        write :: PrivateKey k -> SqlPersistT IO ()
+        write key = do
+            deleteWhere ([] :: [Filter Schema.PrivateKey])
+            insert_ (mkPrivateKeyEntity key)
+
+        mkPrivateKeyEntity (PrivateKey k h) =
+            Schema.PrivateKey
+                { Schema.privateKeyWalletId = wid
+                , Schema.privateKeyRootKey = root
+                , Schema.privateKeyHash = hash
+                }
+          where
+            (root, hash) = serializeXPrv kF (k, h)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/PrivateKey/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/PrivateKey/Store.hs
@@ -2,13 +2,18 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 -- |
 -- Copyright: © 2023 IOHK
 -- License: Apache-2.0
 module Cardano.Wallet.DB.Store.PrivateKey.Store
     ( mkStorePrivateKey
     , DeltaPrivateKey
+    , PrivateKey (..)
+    , StorePrivateKey
     ) where
 
 import Prelude
@@ -42,6 +47,9 @@ import qualified Cardano.Wallet.DB.Sqlite.Schema as Schema
 
 -- | A 'PrivateKey' for a given 'KeyFlavor'.
 data PrivateKey k = PrivateKey (k 'RootK XPrv) PassphraseHash
+
+deriving instance Eq (k 'RootK XPrv) => Eq (PrivateKey k)
+deriving instance Show (k 'RootK XPrv) => Show (PrivateKey k)
 
 -- | A 'Store' for 'PrivateKey'.
 type StorePrivateKey k = SimpleStore (SqlPersistT IO) (PrivateKey k)

--- a/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
@@ -193,7 +193,7 @@ instance Delta (DeltaWalletState1 s) where
     apply (UpdateInfo d) = over #info $ apply d
     apply (UpdateCredentials d) = over #credentials $ apply d
 
-instance  Buildable (DeltaWalletState1 s) where
+instance Buildable (DeltaWalletState1 s) where
     build (ReplacePrologue _) = "ReplacePrologue …"
     build (UpdateCheckpoints d) = "UpdateCheckpoints (" <> build d <> ")"
     build (UpdateSubmissions d) = "UpdateSubmissions (" <> build d <> ")"

--- a/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- |
 -- Copyright: © 2022 IOHK
@@ -39,18 +42,28 @@ module Cardano.Wallet.DB.WalletState
 
 import Prelude
 
+import Cardano.Address.Derivation
+    ( XPrv )
 import Cardano.Wallet.Address.Book
     ( AddressBookIso (..), Discoveries, Prologue )
+import Cardano.Wallet.Address.Derivation
+    ( Depth (RootK) )
 import Cardano.Wallet.Checkpoints
     ( Checkpoints )
 import Cardano.Wallet.DB.Store.Info.Store
     ( DeltaWalletInfo, WalletInfo (..) )
+import Cardano.Wallet.DB.Store.PrivateKey.Store
+    ( DeltaPrivateKey )
 import Cardano.Wallet.DB.Store.Submissions.Layer
     ( emptyTxSubmissions )
 import Cardano.Wallet.DB.Store.Submissions.Operations
     ( DeltaTxSubmissions, TxSubmissions )
+import Cardano.Wallet.Flavor
+    ( KeyOf )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( HashedCredentials )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO )
 import Data.Delta
@@ -121,9 +134,12 @@ data WalletState s = WalletState
     , checkpoints :: !(Checkpoints (WalletCheckpoint s))
     , submissions :: !TxSubmissions
     , info :: !WalletInfo
+    , credentials :: Maybe (HashedCredentials (KeyOf s))
     } deriving (Generic)
 
-deriving instance AddressBookIso s => Eq (WalletState s)
+deriving instance
+    (AddressBookIso s, Eq (KeyOf s 'RootK XPrv))
+    => Eq (WalletState s)
 
 -- | Create a wallet from the genesis block.
 fromGenesis
@@ -139,6 +155,7 @@ fromGenesis cp winfo
                 , checkpoints = CPS.fromGenesis checkpoint
                 , submissions = emptyTxSubmissions
                 , info = winfo
+                , credentials = Nothing
                 }
     | otherwise = Nothing
   where
@@ -166,6 +183,7 @@ data DeltaWalletState1 s
     -- ^ Update the wallet checkpoints.
     | UpdateSubmissions DeltaTxSubmissions
     | UpdateInfo DeltaWalletInfo
+    | UpdateCredentials (DeltaPrivateKey (KeyOf s))
 
 instance Delta (DeltaWalletState1 s) where
     type Base (DeltaWalletState1 s) = WalletState s
@@ -173,12 +191,14 @@ instance Delta (DeltaWalletState1 s) where
     apply (UpdateCheckpoints d) = over #checkpoints $ apply d
     apply (UpdateSubmissions d) = over #submissions $ apply d
     apply (UpdateInfo d) = over #info $ apply d
+    apply (UpdateCredentials d) = over #credentials $ apply d
 
-instance Buildable (DeltaWalletState1 s) where
+instance  Buildable (DeltaWalletState1 s) where
     build (ReplacePrologue _) = "ReplacePrologue …"
     build (UpdateCheckpoints d) = "UpdateCheckpoints (" <> build d <> ")"
     build (UpdateSubmissions d) = "UpdateSubmissions (" <> build d <> ")"
     build (UpdateInfo d) = "UpdateInfo (" <> build d <> ")"
+    build (UpdateCredentials _d) = "UpdatePrivateKey"
 
 instance Show (DeltaWalletState1 s) where
     show = pretty

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Wallet.Primitive.Types.Credentials
+    ( RootCredentials (..)
+    , HashedCredentials
+    , ClearCredentials
+    ) where
+
+import Prelude
+
+
+import Cardano.Address.Derivation
+    ( XPrv )
+import Cardano.Wallet.Address.Derivation
+    ( Depth (RootK) )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase, PassphraseHash )
+
+-- | A 'PrivateKey' for a given 'KeyFlavor'.
+data RootCredentials k pw = Credentials
+         { credentialsKey :: k 'RootK XPrv
+         , credentialsPassword :: pw
+         }
+
+deriving instance (Eq (k 'RootK XPrv), Eq pw) => Eq (RootCredentials k pw)
+deriving instance (Show (k 'RootK XPrv), Show pw) => Show (RootCredentials k pw)
+
+type HashedCredentials k = RootCredentials k PassphraseHash
+
+type ClearCredentials k = RootCredentials k (Passphrase "encryption")

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Credentials.hs
@@ -19,10 +19,10 @@ import Cardano.Wallet.Primitive.Passphrase.Types
     ( Passphrase, PassphraseHash )
 
 -- | A 'PrivateKey' for a given 'KeyFlavor'.
-data RootCredentials k pw = Credentials
-         { credentialsKey :: k 'RootK XPrv
-         , credentialsPassword :: pw
-         }
+data RootCredentials k pw = RootCredentials
+    { credentialsKey :: k 'RootK XPrv
+    , credentialsPassword :: pw
+    }
 
 deriving instance (Eq (k 'RootK XPrv), Eq pw) => Eq (RootCredentials k pw)
 deriving instance (Show (k 'RootK XPrv), Show pw) => Show (RootCredentials k pw)

--- a/lib/wallet/test/unit/Cardano/Wallet/Address/Discovery/SequentialSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Address/Discovery/SequentialSpec.hs
@@ -81,6 +81,8 @@ import Cardano.Wallet.Flavor
     ( KeyFlavorS (..), WalletFlavorS (ShelleyWallet) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( RootCredentials (..) )
 import Cardano.Wallet.Read.NetworkId
     ( NetworkDiscriminant (..), SNetworkId (..) )
 import Cardano.Wallet.Unsafe
@@ -264,7 +266,8 @@ prop_genChangeGapFromRootXPrv g = property $
   where
     mw = someDummyMnemonic (Proxy @12)
     key = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
-    s0 = mkSeqStateFromRootXPrv ShelleyKeyS (key, mempty) purposeCIP1852 g
+    s0 = mkSeqStateFromRootXPrv ShelleyKeyS
+        (RootCredentials key mempty) purposeCIP1852 g
 
 -- | We can always generate at exactly `gap` change addresses (on the internal
 -- chain) using mkSeqStateFromAccountXPub

--- a/lib/wallet/test/unit/Cardano/Wallet/Address/Discovery/SharedSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Address/Discovery/SharedSpec.hs
@@ -61,6 +61,8 @@ import Cardano.Wallet.Primitive.Passphrase.Gen
     ( genEncryptionPassphrase )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( RootCredentials (..) )
 import Cardano.Wallet.Read.NetworkId
     ( HasSNetworkId, NetworkDiscriminant (..) )
 import Cardano.Wallet.Unsafe
@@ -391,5 +393,6 @@ instance Arbitrary (SharedState 'Mainnet SharedKey) where
         pwd <- genEncryptionPassphrase
         accIx' <- arbitrary
         scriptTemplate <- genScriptTemplate
-        pure $ mkSharedStateFromRootXPrv SharedKeyS (rootXPrv, pwd) accIx'
+        pure $ mkSharedStateFromRootXPrv SharedKeyS
+            (RootCredentials rootXPrv pwd) accIx'
             defaultAddressPoolGap scriptTemplate Nothing

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -13,12 +13,12 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE TupleSections #-}
 
 module Cardano.Wallet.DB.Arbitrary
     ( GenTxHistory (..)
@@ -65,6 +65,8 @@ import Cardano.Wallet.Address.Discovery.Sequential
     )
 import Cardano.Wallet.Address.Discovery.Shared
     ( SharedAddressPools (..), SharedState (..) )
+import Cardano.Wallet.Address.Keys.WalletKey
+    ( getRawKey, liftRawKey, publicKey )
 import Cardano.Wallet.DB.Pure.Implementation
     ( TxHistory, filterTxHistory )
 import Cardano.Wallet.DummyTarget.Primitive.Types as DummyTarget
@@ -228,8 +230,6 @@ import qualified Cardano.Wallet.Address.Derivation.Shared as Shared
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.Address.Discovery.Sequential as Seq
 import qualified Cardano.Wallet.Address.Discovery.Shared as Shared
-import Cardano.Wallet.Address.Keys.WalletKey
-    ( getRawKey, liftRawKey, publicKey )
 import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -146,6 +146,8 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( RootCredentials (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..), mockHash )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -1471,7 +1473,8 @@ testCp = snd $ initWallet block0 initDummyState
   where
     initDummyState :: TestState
     initDummyState = mkSeqStateFromRootXPrv
-        ShelleyKeyS (xprv, mempty) purposeCIP1852 defaultAddressPoolGap
+        ShelleyKeyS (RootCredentials xprv mempty)
+        purposeCIP1852 defaultAddressPoolGap
       where
         mw = SomeMnemonic . unsafePerformIO . generate $ genMnemonic @15
         xprv = generateKeyFromSeed (mw, Nothing) mempty
@@ -1576,7 +1579,7 @@ testCpSeq = snd $ initWallet block0 initDummyStateSeq
 
 initDummyStateSeq :: TestState
 initDummyStateSeq = mkSeqStateFromRootXPrv
-    ShelleyKeyS (xprv, mempty) purposeCIP1852 defaultAddressPoolGap
+    ShelleyKeyS (RootCredentials xprv mempty) purposeCIP1852 defaultAddressPoolGap
   where
       mw = SomeMnemonic $ unsafePerformIO (generate $ genMnemonic @15)
       xprv = Seq.generateKeyFromSeed (mw, Nothing) mempty

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/PrivateKey/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/PrivateKey/StoreSpec.hs
@@ -40,7 +40,7 @@ import Cardano.Wallet.Flavor
 import Cardano.Wallet.Primitive.Types
     ( WalletId )
 import Cardano.Wallet.Primitive.Types.Credentials
-    ( Credentials (Credentials), HashedCredentials )
+    ( HashedCredentials, RootCredentials (RootCredentials) )
 import Data.Delta
     ( Replace (..) )
 import Fmt
@@ -85,7 +85,7 @@ propStore runQ wid kF =
         (logScale . genDelta)
 
 genPrivateKey :: Arbitrary (k 'RootK XPrv) => Gen (Maybe (HashedCredentials k))
-genPrivateKey = fmap Just $ Credentials <$> arbitrary <*> arbitrary
+genPrivateKey = fmap Just $ RootCredentials <$> arbitrary <*> arbitrary
 
 instance Buildable (DeltaPrivateKey k) where
     build _ = "DeltaPrivateKey"

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/PrivateKey/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/PrivateKey/StoreSpec.hs
@@ -34,11 +34,13 @@ import Cardano.Wallet.DB.Fixtures
     , withInitializedWalletProp
     )
 import Cardano.Wallet.DB.Store.PrivateKey.Store
-    ( DeltaPrivateKey, PrivateKey (..), mkStorePrivateKey )
+    ( DeltaPrivateKey, mkStorePrivateKey )
 import Cardano.Wallet.Flavor
     ( KeyFlavorS (..) )
 import Cardano.Wallet.Primitive.Types
     ( WalletId )
+import Cardano.Wallet.Primitive.Types.Credentials
+    ( Credentials (Credentials), HashedCredentials )
 import Data.Delta
     ( Replace (..) )
 import Fmt
@@ -82,14 +84,14 @@ propStore runQ wid kF =
         genPrivateKey
         (logScale . genDelta)
 
-genPrivateKey :: Arbitrary (k 'RootK XPrv) => Gen (PrivateKey k)
-genPrivateKey = PrivateKey <$> arbitrary <*> arbitrary
+genPrivateKey :: Arbitrary (k 'RootK XPrv) => Gen (Maybe (HashedCredentials k))
+genPrivateKey = fmap Just $ Credentials <$> arbitrary <*> arbitrary
 
 instance Buildable (DeltaPrivateKey k) where
     build _ = "DeltaPrivateKey"
 
 genDelta
     :: Arbitrary (k 'RootK XPrv)
-    => PrivateKey k
+    => (Maybe (HashedCredentials k))
     -> Gen (DeltaPrivateKey k)
 genDelta _ = Replace <$> genPrivateKey

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/PrivateKey/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/PrivateKey/StoreSpec.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE RankNTypes #-}
+
+-- |
+-- Copyright: © 2022–2023 IOHK
+-- License: Apache-2.0
+--
+-- Test properties of the privatekey 'Store'.
+module Cardano.Wallet.DB.Store.PrivateKey.StoreSpec
+    ( spec
+    )
+where
+
+import Prelude
+
+import Cardano.Address.Derivation
+    ( XPrv )
+import Cardano.DB.Sqlite
+    ( ForeignKeysSetting (ForeignKeysDisabled) )
+import Cardano.Wallet.Address.Derivation
+    ( Depth (RootK) )
+import Cardano.Wallet.DB.Arbitrary
+    ()
+import Cardano.Wallet.DB.Fixtures
+    ( RunQuery
+    , WalletProperty
+    , logScale
+    , withDBInMemory
+    , withInitializedWalletProp
+    )
+import Cardano.Wallet.DB.Store.PrivateKey.Store
+    ( DeltaPrivateKey, PrivateKey (..), mkStorePrivateKey )
+import Cardano.Wallet.Flavor
+    ( KeyFlavorS (..) )
+import Cardano.Wallet.Primitive.Types
+    ( WalletId )
+import Data.Delta
+    ( Replace (..) )
+import Fmt
+    ( Buildable (..) )
+import Test.Hspec
+    ( Spec, around, describe, it )
+import Test.QuickCheck
+    ( Arbitrary, Gen, arbitrary, property )
+import Test.QuickCheck.Monadic
+    ( PropertyM )
+import Test.Store
+    ( prop_StoreUpdates )
+
+spec :: Spec
+spec =
+    around (withDBInMemory ForeignKeysDisabled) $ do
+        describe "private-key store" $ do
+            it "respects store laws for ShelleyKeyS"
+                $ property . prop_SingleWalletStoreLaws ShelleyKeyS
+            it "respects store laws for ByronKeyS"
+                $ property . prop_SingleWalletStoreLaws ByronKeyS
+
+prop_SingleWalletStoreLaws
+    :: (Eq (k 'RootK XPrv), Show (k 'RootK XPrv), Arbitrary (k 'RootK XPrv))
+    => KeyFlavorS k
+    -> WalletProperty
+prop_SingleWalletStoreLaws kF = do
+    withInitializedWalletProp $ \wid runQ -> do
+        propStore runQ wid kF
+
+propStore
+    :: (Eq (k 'RootK XPrv), Show (k 'RootK XPrv), Arbitrary (k 'RootK XPrv))
+    => RunQuery
+    -> WalletId
+    -> KeyFlavorS k
+    -> PropertyM IO ()
+propStore runQ wid kF =
+    prop_StoreUpdates
+        runQ
+        (mkStorePrivateKey kF wid)
+        genPrivateKey
+        (logScale . genDelta)
+
+genPrivateKey :: Arbitrary (k 'RootK XPrv) => Gen (PrivateKey k)
+genPrivateKey = PrivateKey <$> arbitrary <*> arbitrary
+
+instance Buildable (DeltaPrivateKey k) where
+    build _ = "DeltaPrivateKey"
+
+genDelta
+    :: Arbitrary (k 'RootK XPrv)
+    => PrivateKey k
+    -> Gen (DeltaPrivateKey k)
+genDelta _ = Replace <$> genPrivateKey


### PR DESCRIPTION
- [x] introduce a primitive Credentials to substitute tuples to express private keys with decrypting password or hashed one
- [x] use Credentials everywhere, but in HardDerivation because of a cyclic dep. I would solve it, but there is a goal to remove that class, and that would be a better time maybe.
- [x] create and test a store for the private key (credentials)
- [x] add the new store to the wallet state
- [x] remove readPrivateKey and putPrivateKey from DB layer, and use the wallet state instead

For the sake of not exploding the scope of the PR I left out changing the tuples for the private key in the Derivation module which require extracting the Depth type to avoid cyclic deps. 

ADP-3019
