### PR TITLE
Fix redundant constraints in cardano-wallet-test-utils.

### DIFF
--- a/lib/launcher/test/unit/Cardano/StartupSpec.hs
+++ b/lib/launcher/test/unit/Cardano/StartupSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK

--- a/lib/numeric/test/unit/Cardano/Numeric/UtilSpec.hs
+++ b/lib/numeric/test/unit/Cardano/Numeric/UtilSpec.hs
@@ -85,7 +85,7 @@ spec = do
 --------------------------------------------------------------------------------
 
 prop_padCoalesce_length
-    :: (Monoid a, Ord a, Show a) => NonEmpty a -> NonEmpty () -> Property
+    :: (Monoid a, Ord a) => NonEmpty a -> NonEmpty () -> Property
 prop_padCoalesce_length source target =
     NE.length (padCoalesce source target) === NE.length target
 

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -24,6 +24,7 @@ library
       OverloadedStrings
   ghc-options:
       -Wall
+      -Wredundant-constraints
       -Wcompat
   if (flag(release))
     ghc-options:

--- a/lib/test-utils/src/Test/Hspec/Extra.hs
+++ b/lib/test-utils/src/Test/Hspec/Extra.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK

--- a/lib/test-utils/src/Test/Utils/Platform.hs
+++ b/lib/test-utils/src/Test/Utils/Platform.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 -- |
 -- Copyright: © 2018-2021 IOHK

--- a/lib/test-utils/src/Test/Utils/Trace.hs
+++ b/lib/test-utils/src/Test/Utils/Trace.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK

--- a/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
@@ -462,7 +462,7 @@ shrinkPartitionListData
 shrinkPartitionListData = genericShrink
 
 prop_partitionList_coverage
-    :: (Arbitrary a, Eq a, Show a) => PartitionListData a -> Property
+    :: (Eq a, Show a) => PartitionListData a -> Property
 prop_partitionList_coverage (PartitionListData (x, y) as) =
     forAll (partitionList (x, y) as) $ \rs ->
         checkCoverage $
@@ -487,19 +487,19 @@ prop_partitionList_coverage (PartitionListData (x, y) as) =
         property True
 
 prop_partitionList_identity
-    :: (Arbitrary a, Eq a, Show a) => [a] -> Property
+    :: (Eq a, Show a) => [a] -> Property
 prop_partitionList_identity as =
     forAll (partitionList (length as, length as) as)
         (=== [as | length as > 0])
 
 prop_partitionList_mconcat
-    :: (Arbitrary a, Eq a, Show a) => PartitionListData a -> Property
+    :: (Eq a, Show a) => PartitionListData a -> Property
 prop_partitionList_mconcat (PartitionListData (x, y) as) =
     forAll (partitionList (x, y) as)
         ((=== as) . mconcat)
 
 prop_partitionList_GE
-    :: (Arbitrary a, Eq a, Show a) => PartitionListData a -> Property
+    :: Show a => PartitionListData a -> Property
 prop_partitionList_GE (PartitionListData (x, y) as) =
     forAll (partitionList (x, y) as) $ \rs ->
         checkCoverage $
@@ -514,7 +514,7 @@ prop_partitionList_GE (PartitionListData (x, y) as) =
     x' = max 0 x
 
 prop_partitionList_LT
-    :: (Arbitrary a, Eq a, Show a) => PartitionListData a -> Property
+    :: Show a => PartitionListData a -> Property
 prop_partitionList_LT (PartitionListData (x, y) as) =
     forAll (partitionList (x, y) as) $ \rs ->
         checkCoverage $
@@ -609,7 +609,7 @@ prop_selectMapEntries_fromList m =
         (=== (m, mempty)) . first Map.fromList
 
 prop_selectMapEntries_length
-    :: forall k v. (Ord k, Show k, Eq v, Show v)
+    :: forall k v. (Ord k, Show k, Show v)
     => Map k v
     -> Positive (Small Int)
     -> Property
@@ -633,7 +633,7 @@ prop_selectMapEntries_nonPositive m (NonPositive (Small i)) =
     forAll (selectMapEntries m i) (== ([], m))
 
 prop_selectMapEntries_disjoint
-    :: (Ord k, Show k, Eq v, Show v)
+    :: (Ord k, Show k, Show v)
     => Map k v
     -> Positive (Small Int)
     -> Property
@@ -669,7 +669,7 @@ prop_selectMapEntries_union m0 (Positive (Small i)) =
 --------------------------------------------------------------------------------
 
 prop_genShrinkSequence_length
-    :: (Arbitrary a, Eq a, Show a) => a -> Property
+    :: (Arbitrary a, Show a) => a -> Property
 prop_genShrinkSequence_length a =
     forAll (genShrinkSequence shrink a) $ \as ->
         checkCoverage $
@@ -683,7 +683,7 @@ prop_genShrinkSequence_length a =
 -- cannot be shrunk.
 --
 prop_genShrinkSequence_empty
-    :: (Arbitrary a, Eq a, Show a) => a -> Property
+    :: (Arbitrary a, Show a) => a -> Property
 prop_genShrinkSequence_empty a =
     forAll (genShrinkSequence shrink a) $ \as ->
         null as === null (shrink a)
@@ -731,11 +731,11 @@ prop_shrinkSpace_complete a =
     ss = shrinkSpace shrink a
     twoSeconds = 2_000_000
 
-prop_shrinkSpace_empty :: (Arbitrary a, Ord a, Show a) => a -> Property
+prop_shrinkSpace_empty :: (Ord a, Show a) => a -> Property
 prop_shrinkSpace_empty a =
     shrinkSpace (const []) a === mempty
 
-prop_shrinkSpace_singleton :: (Arbitrary a, Ord a, Show a) => a -> Property
+prop_shrinkSpace_singleton :: (Ord a, Show a) => a -> Property
 prop_shrinkSpace_singleton a =
     shrinkSpace (const [a]) a === Set.singleton a
 


### PR DESCRIPTION
Make it possible to run `cabal -O1 -Wall -Wredundant-constraints` with no issues. `-Wredundant-constraints` requires -O1 to be effective

