### PR TITLE
Remove the input selection limit from coin selection.

### DIFF
--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -235,10 +235,6 @@ data SelectionConstraints = SelectionConstraints
     , computeMinimumCost
         :: SelectionSkeleton -> Coin
         -- ^ Computes the minimum cost of a given selection skeleton.
-    , computeSelectionLimit
-        :: [TxOut] -> SelectionLimit
-        -- ^ Computes an upper bound for the number of ordinary inputs to
-        -- select, given a current set of outputs.
     , maximumCollateralInputCount
         :: Int
         -- ^ Specifies an inclusive upper bound on the number of unique inputs
@@ -259,8 +255,6 @@ toInternalSelectionConstraints SelectionConstraints {..} =
     Internal.SelectionConstraints
         { computeMinimumCost =
             computeMinimumCost . toExternalSelectionSkeleton
-        , computeSelectionLimit =
-            computeSelectionLimit . fmap (uncurry TxOut)
         , maximumOutputAdaQuantity =
             txOutMaxCoin
         , maximumOutputTokenQuantity =

--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -45,8 +45,6 @@ module Cardano.Tx.Balance.Internal.CoinSelection
     , SelectionCollateralRequirement (..)
     , SelectionConstraints (..)
     , SelectionError (..)
-    , SelectionLimit
-    , SelectionLimitOf (..)
     , SelectionOf (..)
     , SelectionParams (..)
     , SelectionStrategy (..)
@@ -90,8 +88,6 @@ import Cardano.CoinSelection
 import Cardano.CoinSelection.Balance
     ( BalanceInsufficientError (..)
     , SelectionBalanceError (..)
-    , SelectionLimit
-    , SelectionLimitOf (..)
     , SelectionStrategy (..)
     , UnableToConstructChangeError (..)
     )

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -413,7 +413,6 @@ toBalanceConstraintsParams (constraints, params) =
                 & adjustComputeMinimumCost
         , computeSelectionLimit =
             view #computeSelectionLimit constraints
-                & adjustComputeSelectionLimit
         , assessTokenBundleSize =
             view #assessTokenBundleSize constraints
         , maximumOutputAdaQuantity =
@@ -453,23 +452,6 @@ toBalanceConstraintsParams (constraints, params) =
                 -> SelectionSkeleton ctx
             adjustSelectionSkeleton = over #skeletonInputCount
                 (+ view #maximumCollateralInputCount constraints)
-
-        adjustComputeSelectionLimit
-            :: ([(Address ctx, TokenBundle)] -> SelectionLimit)
-            -> ([(Address ctx, TokenBundle)] -> SelectionLimit)
-        adjustComputeSelectionLimit =
-            whenCollateralRequired params (fmap adjustSelectionLimit)
-          where
-            -- When collateral is required, we reserve space for collateral
-            -- inputs ahead of time by subtracting the maximum allowed number
-            -- of collateral inputs (defined by 'maximumCollateralInputCount')
-            -- from the selection limit.
-            --
-            -- This ensures that when we come to perform collateral selection,
-            -- there is still space available.
-            --
-            adjustSelectionLimit :: SelectionLimit -> SelectionLimit
-            adjustSelectionLimit = id
 
     balanceParams = Balance.SelectionParams
         { assetsToBurn =

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -914,8 +914,6 @@ verifySelectionBalanceError cs ps = \case
         verifyEmptyUTxOError cs ps ()
     Balance.UnableToConstructChange e->
         verifyUnableToConstructChangeError cs ps e
-    Balance.SelectionLimitReached e ->
-        verifySelectionLimitReachedError cs ps e
 
 --------------------------------------------------------------------------------
 -- Selection error verification: balance insufficient errors
@@ -1008,36 +1006,6 @@ data FailureToVerifySelectionLimitReachedError u =
             -- ^ The selection limit after accounting for collateral inputs.
         }
     deriving (Eq, Show)
-
--- | Verifies a 'Balance.SelectionLimitReachedError'.
---
--- This function verifies that the number of the selected inputs is correct
--- given the amount of space we expect to be reserved for collateral inputs.
---
-verifySelectionLimitReachedError
-    :: forall ctx. SelectionContext ctx
-    => VerifySelectionError (Balance.SelectionLimitReachedError ctx) ctx
-verifySelectionLimitReachedError cs ps e =
-    verify
-        (True)
-        (FailureToVerifySelectionLimitReachedError {..})
-  where
-    selectedInputs :: [(UTxO ctx, TokenBundle)]
-    selectedInputs = e ^. #inputsSelected
-
-    selectedInputCount :: Int
-    selectedInputCount = F.length selectedInputs
-
-    selectionLimitAdjusted :: SelectionLimit
-    selectionLimitAdjusted = toBalanceConstraintsParams (cs, ps)
-        & fst
-        & view #computeSelectionLimit
-        & ($ F.toList $ e ^. #outputsToCover)
-
-    selectionLimitOriginal :: SelectionLimit
-    selectionLimitOriginal = cs
-        & view #computeSelectionLimit
-        & ($ F.toList $ e ^. #outputsToCover)
 
 --------------------------------------------------------------------------------
 -- Selection error verification: change construction errors

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -957,27 +957,6 @@ verifySelectionOutputCoinInsufficientError cs _ps e =
         (snd reportedOutput ^. #tokens)
 
 --------------------------------------------------------------------------------
--- Selection error verification: selection limit errors
---------------------------------------------------------------------------------
-
-data FailureToVerifySelectionLimitReachedError u =
-    FailureToVerifySelectionLimitReachedError
-        { selectedInputs
-            :: [(u, TokenBundle)]
-            -- ^ The inputs that were actually selected.
-        , selectedInputCount
-            :: Int
-            -- ^ The number of inputs that were actually selected.
-        , selectionLimitOriginal
-            :: SelectionLimit
-            -- ^ The selection limit before accounting for collateral inputs.
-        , selectionLimitAdjusted
-            :: SelectionLimit
-            -- ^ The selection limit after accounting for collateral inputs.
-        }
-    deriving (Eq, Show)
-
---------------------------------------------------------------------------------
 -- Selection error verification: change construction errors
 --------------------------------------------------------------------------------
 

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -469,8 +469,7 @@ toBalanceConstraintsParams (constraints, params) =
             -- there is still space available.
             --
             adjustSelectionLimit :: SelectionLimit -> SelectionLimit
-            adjustSelectionLimit = flip Balance.reduceSelectionLimitBy
-                (view #maximumCollateralInputCount constraints)
+            adjustSelectionLimit = id
 
     balanceParams = Balance.SelectionParams
         { assetsToBurn =

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -788,7 +788,7 @@ data FailureToVerifySelectionInputCountWithinLimit =
 verifySelectionInputCountWithinLimit :: VerifySelection ctx
 verifySelectionInputCountWithinLimit cs _ps selection =
     verify
-        (Balance.MaximumInputLimit totalInputCount <= selectionLimit)
+        (True)
         (FailureToVerifySelectionInputCountWithinLimit {..})
   where
     collateralInputCount = length (selection ^. #collateral)
@@ -1019,7 +1019,7 @@ verifySelectionLimitReachedError
     => VerifySelectionError (Balance.SelectionLimitReachedError ctx) ctx
 verifySelectionLimitReachedError cs ps e =
     verify
-        (Balance.MaximumInputLimit selectedInputCount >= selectionLimitAdjusted)
+        (True)
         (FailureToVerifySelectionLimitReachedError {..})
   where
     selectedInputs :: [(UTxO ctx, TokenBundle)]

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -682,7 +682,6 @@ verifySelection = mconcat
     [ verifySelectionCollateralSufficient
     , verifySelectionCollateralSuitable
     , verifySelectionDeltaValid
-    , verifySelectionInputCountWithinLimit
     , verifySelectionOutputCoinsSufficient
     , verifySelectionOutputSizesWithinLimit
     , verifySelectionOutputTokenQuantitiesWithinLimit
@@ -766,34 +765,6 @@ verifySelectionDeltaValid cs ps selection =
     delta = selectionDeltaAllAssets selection
     minimumCost = selectionMinimumCost cs ps selection
     maximumCost = selectionMaximumCost cs ps selection
-
---------------------------------------------------------------------------------
--- Selection verification: selection limit
---------------------------------------------------------------------------------
-
-data FailureToVerifySelectionInputCountWithinLimit =
-    FailureToVerifySelectionInputCountWithinLimit
-    { collateralInputCount
-        :: Int
-    , ordinaryInputCount
-        :: Int
-    , totalInputCount
-        :: Int
-    , selectionLimit
-        :: SelectionLimit
-    }
-    deriving (Eq, Show)
-
-verifySelectionInputCountWithinLimit :: VerifySelection ctx
-verifySelectionInputCountWithinLimit cs _ps selection =
-    verify
-        (True)
-        (FailureToVerifySelectionInputCountWithinLimit {..})
-  where
-    collateralInputCount = length (selection ^. #collateral)
-    ordinaryInputCount = length (selection ^. #inputs)
-    totalInputCount = collateralInputCount + ordinaryInputCount
-    selectionLimit = (cs ^. #computeSelectionLimit) (selection ^. #outputs)
 
 --------------------------------------------------------------------------------
 -- Selection verification: minimum ada quantities

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -69,7 +69,6 @@ import Algebra.PartialOrd
 import Cardano.CoinSelection.Balance
     ( SelectionBalanceError (..)
     , SelectionDelta (..)
-    , SelectionLimit
     , SelectionSkeleton
     , SelectionStrategy (..)
     )
@@ -165,10 +164,6 @@ data SelectionConstraints ctx = SelectionConstraints
     , computeMinimumCost
         :: SelectionSkeleton ctx -> Coin
         -- ^ Computes the minimum cost of a given selection skeleton.
-    , computeSelectionLimit
-        :: [(Address ctx, TokenBundle)] -> SelectionLimit
-        -- ^ Computes an upper bound for the number of ordinary inputs to
-        -- select, given a current set of outputs.
     , maximumCollateralInputCount
         :: Int
         -- ^ Specifies an inclusive upper bound on the number of unique inputs
@@ -411,8 +406,6 @@ toBalanceConstraintsParams (constraints, params) =
         , computeMinimumCost =
             view #computeMinimumCost constraints
                 & adjustComputeMinimumCost
-        , computeSelectionLimit =
-            view #computeSelectionLimit constraints
         , assessTokenBundleSize =
             view #assessTokenBundleSize constraints
         , maximumOutputAdaQuantity =
@@ -1027,7 +1020,6 @@ verifyUnableToConstructChangeError cs ps errorOriginal =
         cs' = cs
             { computeMinimumAdaQuantity = const $ const $ Coin 0
             , computeMinimumCost = const $ Coin 0
-            , computeSelectionLimit = const Balance.NoLimit
             }
 
 --------------------------------------------------------------------------------

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -1224,16 +1224,10 @@ selectMatchingQuantity
     -> m (Maybe (UTxOSelectionNonEmpty u))
         -- ^ An updated selection state that includes a matching UTxO entry,
         -- or 'Nothing' if no such entry could be found.
-selectMatchingQuantity filters limit s
-    | limitReached =
-        pure Nothing
-    | otherwise =
-        (updateState =<<) <$> UTxOIndex.selectRandomWithPriority
-            (UTxOSelection.leftoverIndex s) filters
+selectMatchingQuantity filters _limit s =
+    (updateState =<<) <$> UTxOIndex.selectRandomWithPriority
+        (UTxOSelection.leftoverIndex s) filters
   where
-    limitReached = case limit of
-        NoLimit -> False
-
     updateState
         :: ((u, TokenBundle), UTxOIndex u) -> Maybe (UTxOSelectionNonEmpty u)
     updateState ((i, _b), _remaining) = UTxOSelection.select i s

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -48,7 +48,6 @@ module Cardano.CoinSelection.Balance
     -- * Selection limits
     , SelectionLimit
     , SelectionLimitOf (..)
-    , selectionLimitExceeded
     , SelectionLimitReachedError (..)
     , reduceSelectionLimitBy
 
@@ -470,12 +469,6 @@ instance Ord a => Ord (SelectionLimitOf a) where
     compare a b = case (a, b) of
         (NoLimit, NoLimit) -> EQ
 
--- | Indicates whether or not the given selection limit has been exceeded.
---
-selectionLimitExceeded :: s u -> SelectionLimit -> Bool
-selectionLimitExceeded _ = \case
-    NoLimit -> False
-
 -- | Reduces a selection limit by a given reduction amount.
 --
 -- If the given reduction amount is positive, then this function will reduce
@@ -879,9 +872,6 @@ performSelectionNonEmpty constraints params
                 pure $ Left EmptyUTxO
             Nothing ->
                 selectionLimitReachedError []
-            Just selection | selectionLimitExceeded selection selectionLimit ->
-                selectionLimitReachedError $ F.toList $
-                    UTxOSelection.selectedList selection
             Just selection -> do
                 let utxoSelected = UTxOSelection.selectedIndex selection
                 let utxoBalanceSelected = UTxOIndex.balance utxoSelected

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -1189,7 +1189,7 @@ selectQuantityOf
     -> SelectionLimit
     -> utxoSelection u
     -> m (Maybe (UTxOSelectionNonEmpty u))
-selectQuantityOf a = selectMatchingQuantity
+selectQuantityOf a _limit = selectMatchingQuantity
     [ SelectSingleton a
     , SelectPairWith a
     , SelectAnyWith a
@@ -1217,14 +1217,12 @@ selectMatchingQuantity
     => NonEmpty (SelectionFilter Asset)
         -- ^ A list of selection filters to be traversed from left-to-right,
         -- in descending order of priority.
-    -> SelectionLimit
-        -- ^ A limit to adhere to when selecting entries.
     -> utxoSelection u
         -- ^ The current selection state.
     -> m (Maybe (UTxOSelectionNonEmpty u))
         -- ^ An updated selection state that includes a matching UTxO entry,
         -- or 'Nothing' if no such entry could be found.
-selectMatchingQuantity filters _limit s =
+selectMatchingQuantity filters s =
     (updateState =<<) <$> UTxOIndex.selectRandomWithPriority
         (UTxOSelection.leftoverIndex s) filters
   where

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -1146,7 +1146,7 @@ runSelection params =
         assetSelector = runSelectionStep .
             assetSelectionLens selectionLimit selectionStrategy
         coinSelector = runSelectionStep $
-            coinSelectionLens selectionLimit selectionStrategy
+            coinSelectionLens selectionStrategy
             minimumCoinQuantity
 
     (minimumCoinQuantity, minimumAssetQuantities) =
@@ -1168,12 +1168,11 @@ assetSelectionLens _limit strategy (asset, minimumAssetQuantity) = SelectionLens
 
 coinSelectionLens
     :: (MonadRandom m, Ord u)
-    => SelectionLimit
-    -> SelectionStrategy
+    => SelectionStrategy
     -> Coin
     -- ^ Minimum coin quantity.
     -> SelectionLens m (UTxOSelection u) (UTxOSelectionNonEmpty u)
-coinSelectionLens _limit strategy minimumCoinQuantity = SelectionLens
+coinSelectionLens strategy minimumCoinQuantity = SelectionLens
     { currentQuantity = selectedCoinQuantity
     , updatedQuantity = selectedCoinQuantity
     , minimumQuantity = intCast $ unCoin minimumCoinQuantity

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -862,8 +862,7 @@ performSelectionNonEmpty constraints params
 
     | otherwise = do
         maybeSelection <- runSelectionNonEmpty RunSelectionParams
-            { selectionLimit
-            , utxoAvailable
+            { utxoAvailable
             , minimumBalance = utxoBalanceRequired
             , selectionStrategy
             }
@@ -884,7 +883,6 @@ performSelectionNonEmpty constraints params
         { assessTokenBundleSize
         , computeMinimumAdaQuantity
         , computeMinimumCost
-        , computeSelectionLimit
         , maximumOutputAdaQuantity
         , maximumOutputTokenQuantity
         , maximumLengthChangeAddress
@@ -907,9 +905,6 @@ performSelectionNonEmpty constraints params
             , utxoBalanceRequired
             , outputsToCover
             }
-
-    selectionLimit :: SelectionLimit
-    selectionLimit = computeSelectionLimit $ F.toList outputsToCover
 
     utxoBalanceAvailable :: TokenBundle
     utxoBalanceAvailable = computeUTxOBalanceAvailable params
@@ -1091,9 +1086,7 @@ performSelectionNonEmpty constraints params
 -- | Parameters for 'runSelection'.
 --
 data RunSelectionParams u = RunSelectionParams
-    { selectionLimit :: SelectionLimit
-        -- ^ A limit to adhere to when performing a selection.
-    , utxoAvailable :: (UTxOSelection u)
+    { utxoAvailable :: (UTxOSelection u)
         -- ^ UTxO entries available for selection.
     , minimumBalance :: TokenBundle
         -- ^ Minimum balance to cover.

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -219,10 +219,6 @@ data SelectionConstraints ctx = SelectionConstraints
     , computeMinimumCost
         :: SelectionSkeleton ctx -> Coin
         -- ^ Computes the minimum cost of a given selection skeleton.
-    , computeSelectionLimit
-        :: [(Address ctx, TokenBundle)] -> SelectionLimit
-        -- ^ Computes an upper bound for the number of ordinary inputs to
-        -- select, given a current set of outputs.
     , maximumLengthChangeAddress
         :: Address ctx
     , maximumOutputAdaQuantity

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -464,23 +464,17 @@ type SelectionLimit = SelectionLimitOf Int
 data SelectionLimitOf a
     = NoLimit
       -- ^ Indicates that there is no limit.
-    | MaximumInputLimit a
-      -- ^ Indicates a maximum limit on the number of inputs to select.
     deriving (Eq, Functor, Show)
 
 instance Ord a => Ord (SelectionLimitOf a) where
     compare a b = case (a, b) of
-        (NoLimit            , NoLimit            ) -> EQ
-        (MaximumInputLimit _, NoLimit            ) -> LT
-        (NoLimit            , MaximumInputLimit _) -> GT
-        (MaximumInputLimit x, MaximumInputLimit y) -> compare x y
+        (NoLimit, NoLimit) -> EQ
 
 -- | Indicates whether or not the given selection limit has been exceeded.
 --
-selectionLimitExceeded :: IsUTxOSelection s u => s u -> SelectionLimit -> Bool
-selectionLimitExceeded s = \case
+selectionLimitExceeded :: s u -> SelectionLimit -> Bool
+selectionLimitExceeded _ = \case
     NoLimit -> False
-    MaximumInputLimit n -> UTxOSelection.selectedSize s > n
 
 -- | Reduces a selection limit by a given reduction amount.
 --
@@ -1248,7 +1242,6 @@ selectMatchingQuantity filters limit s
             (UTxOSelection.leftoverIndex s) filters
   where
     limitReached = case limit of
-        MaximumInputLimit m -> UTxOSelection.selectedSize s >= m
         NoLimit -> False
 
     updateState

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -45,10 +45,6 @@ module Cardano.CoinSelection.Balance
     , BalanceInsufficientError (..)
     , UnableToConstructChangeError (..)
 
-    -- * Selection limits
-    , SelectionLimit
-    , SelectionLimitOf (..)
-
     -- * Querying selections
     , SelectionDelta (..)
     , selectionDeltaAllAssets
@@ -449,19 +445,6 @@ data SelectionSkeleton ctx = SelectionSkeleton
 
 deriving instance SelectionContext ctx => Eq (SelectionSkeleton ctx)
 deriving instance SelectionContext ctx => Show (SelectionSkeleton ctx)
-
--- | Specifies a limit to adhere to when performing a selection.
---
-type SelectionLimit = SelectionLimitOf Int
-
-data SelectionLimitOf a
-    = NoLimit
-      -- ^ Indicates that there is no limit.
-    deriving (Eq, Functor, Show)
-
-instance Ord a => Ord (SelectionLimitOf a) where
-    compare a b = case (a, b) of
-        (NoLimit, NoLimit) -> EQ
 
 type SelectionResult = SelectionResultOf []
 

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -48,7 +48,6 @@ module Cardano.CoinSelection.Balance
     -- * Selection limits
     , SelectionLimit
     , SelectionLimitOf (..)
-    , reduceSelectionLimitBy
 
     -- * Querying selections
     , SelectionDelta (..)
@@ -467,21 +466,6 @@ data SelectionLimitOf a
 instance Ord a => Ord (SelectionLimitOf a) where
     compare a b = case (a, b) of
         (NoLimit, NoLimit) -> EQ
-
--- | Reduces a selection limit by a given reduction amount.
---
--- If the given reduction amount is positive, then this function will reduce
--- the selection limit by that amount.
---
--- If the given reduction amount is zero or negative, then this function will
--- return the original limit unchanged.
---
-reduceSelectionLimitBy :: SelectionLimit -> Int -> SelectionLimit
-reduceSelectionLimitBy limit reduction
-    | reduction <= 0 =
-        limit
-    | otherwise =
-        subtract reduction <$> limit
 
 type SelectionResult = SelectionResultOf []
 

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -1129,8 +1129,7 @@ runSelection params =
     runRoundRobinM utxoAvailable UTxOSelection.fromNonEmpty selectors
   where
     RunSelectionParams
-        { selectionLimit
-        , utxoAvailable
+        { utxoAvailable
         , minimumBalance
         , selectionStrategy
         } = params
@@ -1144,7 +1143,7 @@ runSelection params =
         reverse (coinSelector : fmap assetSelector minimumAssetQuantities)
       where
         assetSelector = runSelectionStep .
-            assetSelectionLens selectionLimit selectionStrategy
+            assetSelectionLens selectionStrategy
         coinSelector = runSelectionStep $
             coinSelectionLens selectionStrategy
             minimumCoinQuantity
@@ -1154,11 +1153,10 @@ runSelection params =
 
 assetSelectionLens
     :: (MonadRandom m, Ord u)
-    => SelectionLimit
-    -> SelectionStrategy
+    => SelectionStrategy
     -> (AssetId, TokenQuantity)
     -> SelectionLens m (UTxOSelection u) (UTxOSelectionNonEmpty u)
-assetSelectionLens _limit strategy (asset, minimumAssetQuantity) = SelectionLens
+assetSelectionLens strategy (asset, minimumAssetQuantity) = SelectionLens
     { currentQuantity = selectedAssetQuantity asset
     , updatedQuantity = selectedAssetQuantity asset
     , minimumQuantity = unTokenQuantity minimumAssetQuantity

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance/Gen.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance/Gen.hs
@@ -55,14 +55,11 @@ import qualified Data.Set as Set
 
 genSelectionLimit :: Gen SelectionLimit
 genSelectionLimit = oneof
-    [ MaximumInputLimit . getNonNegative <$> arbitrary
-    , pure NoLimit
+    [ pure NoLimit
     ]
 
 shrinkSelectionLimit :: SelectionLimit -> [SelectionLimit]
 shrinkSelectionLimit = \case
-    MaximumInputLimit n ->
-        MaximumInputLimit . getNonNegative <$> shrink (NonNegative n)
     NoLimit ->
         []
 

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance/Gen.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance/Gen.hs
@@ -2,10 +2,8 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.CoinSelection.Balance.Gen
-    ( genSelectionLimit
-    , genSelectionSkeleton
+    ( genSelectionSkeleton
     , genSelectionStrategy
-    , shrinkSelectionLimit
     , shrinkSelectionSkeleton
     , shrinkSelectionStrategy
     )
@@ -14,11 +12,7 @@ module Cardano.CoinSelection.Balance.Gen
 import Prelude
 
 import Cardano.CoinSelection.Balance
-    ( SelectionLimit
-    , SelectionLimitOf (..)
-    , SelectionSkeleton (..)
-    , SelectionStrategy (..)
-    )
+    ( SelectionSkeleton (..), SelectionStrategy (..) )
 import Cardano.CoinSelection.Context
     ( SelectionContext (..) )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -37,7 +31,6 @@ import Test.QuickCheck
     , arbitrary
     , arbitraryBoundedEnum
     , listOf
-    , oneof
     , shrink
     , shrinkList
     , shrinkMapBy
@@ -48,20 +41,6 @@ import Test.QuickCheck.Extra
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Data.Set as Set
-
---------------------------------------------------------------------------------
--- Selection limits
---------------------------------------------------------------------------------
-
-genSelectionLimit :: Gen SelectionLimit
-genSelectionLimit = oneof
-    [ pure NoLimit
-    ]
-
-shrinkSelectionLimit :: SelectionLimit -> [SelectionLimit]
-shrinkSelectionLimit = \case
-    NoLimit ->
-        []
 
 --------------------------------------------------------------------------------
 -- Selection skeletons

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -762,8 +762,8 @@ prop_performSelection_small mockConstraints (Blind (Small params)) =
         "Some minted assets were neither spent nor burned" $
 
     prop_performSelection mockConstraints params $ \result ->
-        cover 10 (selectionUnlimited && selectionSufficient result)
-            "selection unlimited and sufficient"
+        cover 10 (selectionSufficient result)
+            "selection sufficient"
   where
     utxoHasAtLeastOneAsset = not
         . Set.null
@@ -777,9 +777,6 @@ prop_performSelection_small mockConstraints (Blind (Small params)) =
             . F.toList
             . fmap snd
             $ view #outputsToCover params
-
-    selectionUnlimited :: Bool
-    selectionUnlimited = True
 
     selectionSufficient :: PerformSelectionResult -> Bool
     selectionSufficient = \case

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -26,22 +26,18 @@ module Cardano.CoinSelection.BalanceSpec
     , MockAssessTokenBundleSize
     , MockComputeMinimumAdaQuantity
     , MockComputeMinimumCost
-    , MockComputeSelectionLimit
     , TestAddress (..)
     , TestSelectionContext
     , TestUTxO
     , genMockAssessTokenBundleSize
     , genMockComputeMinimumAdaQuantity
     , genMockComputeMinimumCost
-    , genMockComputeSelectionLimit
     , shrinkMockAssessTokenBundleSize
     , shrinkMockComputeMinimumAdaQuantity
     , shrinkMockComputeMinimumCost
-    , shrinkMockComputeSelectionLimit
     , unMockAssessTokenBundleSize
     , unMockComputeMinimumAdaQuantity
     , unMockComputeMinimumCost
-    , unMockComputeSelectionLimit
     ) where
 
 import Prelude
@@ -57,8 +53,6 @@ import Cardano.CoinSelection.Balance
     , SelectionBalanceError (..)
     , SelectionConstraints (..)
     , SelectionLens (..)
-    , SelectionLimit
-    , SelectionLimitOf (..)
     , SelectionParams
     , SelectionParamsOf (..)
     , SelectionResult
@@ -102,11 +96,7 @@ import Cardano.CoinSelection.Balance
     , ungroupByKey
     )
 import Cardano.CoinSelection.Balance.Gen
-    ( genSelectionLimit
-    , genSelectionStrategy
-    , shrinkSelectionLimit
-    , shrinkSelectionStrategy
-    )
+    ( genSelectionStrategy, shrinkSelectionStrategy )
 import Cardano.Numeric.Util
     ( inAscendingPartialOrder )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -269,10 +259,6 @@ spec = describe "Cardano.CoinSelection.BalanceSpec" $
     describe "Class instances respect laws" $ do
 
         testLawsMany @(AssetCount TokenMap)
-            [ eqLaws
-            , ordLaws
-            ]
-        testLawsMany @SelectionLimit
             [ eqLaws
             , ordLaws
             ]
@@ -2501,32 +2487,6 @@ computeMinimumCostLinear s
     + F.sum (Set.size <$> skeletonChange s)
 
 --------------------------------------------------------------------------------
--- Computing selection limits
---------------------------------------------------------------------------------
-
-data MockComputeSelectionLimit
-    = MockComputeSelectionLimitNone
-    deriving (Eq, Show)
-
-genMockComputeSelectionLimit :: Gen MockComputeSelectionLimit
-genMockComputeSelectionLimit = oneof
-    [ pure MockComputeSelectionLimitNone
-    ]
-
-shrinkMockComputeSelectionLimit
-    :: MockComputeSelectionLimit -> [MockComputeSelectionLimit]
-shrinkMockComputeSelectionLimit = \case
-    MockComputeSelectionLimitNone ->
-        []
-
-unMockComputeSelectionLimit
-    :: MockComputeSelectionLimit
-    -> ([(TestAddress, TokenBundle)] -> SelectionLimit)
-unMockComputeSelectionLimit = \case
-    MockComputeSelectionLimitNone ->
-        const NoLimit
-
---------------------------------------------------------------------------------
 -- Assessing token bundle sizes
 --------------------------------------------------------------------------------
 
@@ -4353,10 +4313,6 @@ genTokenMapLarge = do
     genAssetQuantity = (,)
         <$> genAssetIdLargeRange
         <*> genTokenQuantityPositive
-
-instance Arbitrary SelectionLimit where
-    arbitrary = genSelectionLimit
-    shrink = shrinkSelectionLimit
 
 instance Arbitrary TokenMap where
     arbitrary = genTokenMapSmallRange

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -1761,7 +1761,7 @@ prop_coinSelectionLens_givesPriorityToCoins (Blind (Small u)) =
     entryCount = UTxOIndex.size u
     initialState = UTxOSelection.fromIndex u
     lens = coinSelectionLens
-        NoLimit SelectionStrategyOptimal minimumCoinQuantity
+        SelectionStrategyOptimal minimumCoinQuantity
     minimumCoinQuantity = Coin 1
 
 --------------------------------------------------------------------------------

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -778,11 +778,8 @@ prop_performSelection_small mockConstraints (Blind (Small params)) =
             . fmap snd
             $ view #outputsToCover params
 
-    selectionLimited :: Bool
-    selectionLimited = False
-
     selectionUnlimited :: Bool
-    selectionUnlimited = not selectionLimited
+    selectionUnlimited = True
 
     selectionSufficient :: PerformSelectionResult -> Bool
     selectionSufficient = \case

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -86,7 +86,6 @@ import Cardano.CoinSelection.Balance
     , mapMaybe
     , performSelection
     , performSelectionEmpty
-    , reduceSelectionLimitBy
     , reduceTokenQuantities
     , removeBurnValueFromChangeMaps
     , removeBurnValuesFromChangeMaps
@@ -200,7 +199,6 @@ import Test.QuickCheck
     , CoArbitrary (..)
     , Fun
     , Gen
-    , Negative (..)
     , Positive (..)
     , Property
     , applyFun
@@ -459,17 +457,6 @@ spec = describe "Cardano.CoinSelection.BalanceSpec" $
             property $ prop_runRoundRobin_generationCount @TokenName @Word8
         it "prop_runRoundRobin_generationOrder" $
             property $ prop_runRoundRobin_generationOrder @TokenName @Word8
-
-    describe "Selection limits" $ do
-
-        it "prop_reduceSelectionLimitBy_lessThanOrEqual" $
-            property prop_reduceSelectionLimitBy_lessThanOrEqual
-        it "prop_reduceSelectionLimitBy_reductionNegative" $
-            property prop_reduceSelectionLimitBy_reductionNegative
-        it "prop_reduceSelectionLimitBy_reductionZero" $
-            property prop_reduceSelectionLimitBy_reductionZero
-        it "prop_reduceSelectionLimitBy_reductionPositive" $
-            property prop_reduceSelectionLimitBy_reductionPositive
 
     describe "Utility functions" $ do
 
@@ -4090,59 +4077,6 @@ prop_runRoundRobin_generationOrder initialState = property $
         & fmap swap
         & groupByKey
         & fmap (Set.fromList . F.toList)
-
---------------------------------------------------------------------------------
--- Selection limits
---------------------------------------------------------------------------------
-
-prop_reduceSelectionLimitBy_coverage_limit :: SelectionLimit -> Property
-prop_reduceSelectionLimitBy_coverage_limit limit =
-    checkCoverage $
-    cover 10 (haveLimit)
-        "have limit" $
-    cover 10 (not haveLimit)
-        "do not have limit" $
-    property True
-  where
-    haveLimit :: Bool
-    haveLimit = case limit of
-        NoLimit -> False
-
-prop_reduceSelectionLimitBy_coverage_reduction :: Int -> Property
-prop_reduceSelectionLimitBy_coverage_reduction reduction =
-    checkCoverage $
-    cover 10 (reduction < 0)
-        "reduction < 0" $
-    cover 1 (reduction == 0)
-        "reduction = 0" $
-    cover 10 (reduction > 0)
-        "reduction > 0" $
-    property True
-
-prop_reduceSelectionLimitBy_lessThanOrEqual
-    :: SelectionLimit -> Int -> Property
-prop_reduceSelectionLimitBy_lessThanOrEqual limit reduction =
-    prop_reduceSelectionLimitBy_coverage_limit limit .&&.
-    prop_reduceSelectionLimitBy_coverage_reduction reduction .&&.
-    limit `reduceSelectionLimitBy` reduction <= limit
-
-prop_reduceSelectionLimitBy_reductionNegative
-    :: SelectionLimit -> Negative Int -> Property
-prop_reduceSelectionLimitBy_reductionNegative limit (Negative reduction) =
-    prop_reduceSelectionLimitBy_coverage_limit limit .&&.
-    limit `reduceSelectionLimitBy` reduction == limit
-
-prop_reduceSelectionLimitBy_reductionZero
-    :: SelectionLimit -> Property
-prop_reduceSelectionLimitBy_reductionZero limit =
-    prop_reduceSelectionLimitBy_coverage_limit limit .&&.
-    limit `reduceSelectionLimitBy` 0 == limit
-
-prop_reduceSelectionLimitBy_reductionPositive
-    :: SelectionLimit -> Positive Int -> Property
-prop_reduceSelectionLimitBy_reductionPositive limit (Positive reduction) =
-    prop_reduceSelectionLimitBy_coverage_limit limit .&&.
-    limit == fmap (+ reduction) (limit `reduceSelectionLimitBy` reduction)
 
 --------------------------------------------------------------------------------
 -- Testing utility functions

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -1729,7 +1729,7 @@ prop_assetSelectionLens_givesPriorityToSingletonAssets (Blind (Small u)) =
     nonAdaAssetCount = Set.size (utxoIndexNonAdaAssets u)
     initialState = UTxOSelection.fromIndex u
     lens = assetSelectionLens
-        NoLimit SelectionStrategyOptimal (nonAdaAsset, minimumAssetQuantity)
+        SelectionStrategyOptimal (nonAdaAsset, minimumAssetQuantity)
     minimumAssetQuantity = TokenQuantity 1
 
 prop_coinSelectionLens_givesPriorityToCoins

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -852,8 +852,6 @@ prop_performSelection mockConstraints params coverage =
         "extraCoinSource" $
     report extraCoinSink
         "extraCoinSink" $
-    report selectionLimit
-        "selectionLimit" $
     report assetsToMint
         "assetsToMint" $
     report assetsToBurn
@@ -867,8 +865,7 @@ prop_performSelection mockConstraints params coverage =
     constraints = unMockSelectionConstraints mockConstraints
 
     SelectionParams
-        { outputsToCover
-        , extraCoinSource
+        { extraCoinSource
         , extraCoinSink
         , assetsToMint
         , assetsToBurn
@@ -922,9 +919,7 @@ prop_performSelection mockConstraints params coverage =
         verify
             (view #extraCoinSink result == view #extraCoinSink params)
             "view #extraCoinSink result == view #extraCoinSink params" $
-        case selectionLimit of
-            NoLimit ->
-                property True
+        property True
       where
         initialSelectionIsSubsetOfFinalSelection :: Bool
         initialSelectionIsSubsetOfFinalSelection =
@@ -1010,7 +1005,6 @@ prop_performSelection mockConstraints params coverage =
                     , computeMinimumAdaQuantity =
                         const computeMinimumAdaQuantityZero
                     , computeMinimumCost = computeMinimumCostZero
-                    , computeSelectionLimit = const NoLimit
                     } :: SelectionConstraints TestSelectionContext
             performSelection' = performSelection constraints' params
         in
@@ -1032,8 +1026,6 @@ prop_performSelection mockConstraints params coverage =
             "view #utxoAvailable params == UTxOSelection.empty" $
         property True
 
-    selectionLimit = view #computeSelectionLimit constraints $
-        F.toList outputsToCover
     utxoBalanceAvailable = computeUTxOBalanceAvailable params
     utxoBalanceRequired = computeUTxOBalanceRequired params
     utxoBalanceSufficiencyInfo = computeUTxOBalanceSufficiencyInfo params
@@ -1770,7 +1762,6 @@ mkBoundaryTestExpectation (BoundaryTestData params expectedResult) = do
         , computeMinimumCost = computeMinimumCostZero
         , assessTokenBundleSize = unMockAssessTokenBundleSize $
             boundaryTestBundleSizeAssessor params
-        , computeSelectionLimit = const NoLimit
         , maximumOutputAdaQuantity = testMaximumOutputAdaQuantity
         , maximumOutputTokenQuantity = testMaximumOutputTokenQuantity
         , maximumLengthChangeAddress = TestAddress 0x0
@@ -2371,8 +2362,6 @@ data MockSelectionConstraints = MockSelectionConstraints
         :: MockComputeMinimumAdaQuantity
     , computeMinimumCost
         :: MockComputeMinimumCost
-    , computeSelectionLimit
-        :: MockComputeSelectionLimit
     } deriving (Eq, Generic, Show)
 
 genMockSelectionConstraints :: Gen MockSelectionConstraints
@@ -2380,7 +2369,6 @@ genMockSelectionConstraints = MockSelectionConstraints
     <$> genMockAssessTokenBundleSize
     <*> genMockComputeMinimumAdaQuantity
     <*> genMockComputeMinimumCost
-    <*> genMockComputeSelectionLimit
 
 shrinkMockSelectionConstraints
     :: MockSelectionConstraints -> [MockSelectionConstraints]
@@ -2388,7 +2376,6 @@ shrinkMockSelectionConstraints = genericRoundRobinShrink
     <@> shrinkMockAssessTokenBundleSize
     <:> shrinkMockComputeMinimumAdaQuantity
     <:> shrinkMockComputeMinimumCost
-    <:> shrinkMockComputeSelectionLimit
     <:> Nil
 
 unMockSelectionConstraints
@@ -2401,8 +2388,6 @@ unMockSelectionConstraints m = SelectionConstraints
         unMockComputeMinimumAdaQuantity $ view #computeMinimumAdaQuantity m
     , computeMinimumCost =
         unMockComputeMinimumCost $ view #computeMinimumCost m
-    , computeSelectionLimit =
-        unMockComputeSelectionLimit $ view #computeSelectionLimit m
     , maximumOutputAdaQuantity =
         testMaximumOutputAdaQuantity
     , maximumOutputTokenQuantity =

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -972,7 +972,6 @@ prop_performSelection mockConstraints params coverage =
         --        the maximum token bundle size, so it's necessary to break
         --        them up, but there isn't enough ada to pay for either the fee
         --        or the minimum ada quantities of the broken-up outputs.
-        --    4.  The input selection limit has been reached.
         --
         -- So to test that our expectation is really true, we run the selection
         -- again with modified constraints that:
@@ -980,7 +979,6 @@ prop_performSelection mockConstraints params coverage =
         --    1.  Require no fee.
         --    2.  Require no minimum ada quantity.
         --    3.  Impose no maximum token bundle size.
-        --    4.  Impose no selection limit.
         --
         -- We expect that the selection should succeed.
         --

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -778,17 +778,8 @@ prop_performSelection_small mockConstraints (Blind (Small params)) =
             . fmap snd
             $ view #outputsToCover params
 
-    constraints :: SelectionConstraints TestSelectionContext
-    constraints = unMockSelectionConstraints mockConstraints
-
-    selectionLimit :: SelectionLimit
-    selectionLimit = view #computeSelectionLimit constraints
-        $ F.toList
-        $ view #outputsToCover params
-
     selectionLimited :: Bool
-    selectionLimited = case selectionLimit of
-        NoLimit -> False
+    selectionLimited = False
 
     selectionUnlimited :: Bool
     selectionUnlimited = not selectionLimited

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -59,7 +59,6 @@ import Cardano.CoinSelection.Balance
     , SelectionLens (..)
     , SelectionLimit
     , SelectionLimitOf (..)
-    , SelectionLimitReachedError (..)
     , SelectionParams
     , SelectionParamsOf (..)
     , SelectionResult
@@ -952,8 +951,6 @@ prop_performSelection mockConstraints params coverage =
     onFailure = \case
         BalanceInsufficient e ->
             onBalanceInsufficient e
-        SelectionLimitReached e ->
-            onSelectionLimitReached e
         UnableToConstructChange e ->
             onUnableToConstructChange e
         EmptyUTxO ->
@@ -988,27 +985,6 @@ prop_performSelection mockConstraints params coverage =
             errorBalanceAvailable
             errorBalanceRequired
             errorBalanceShortfall = e
-
-    onSelectionLimitReached
-        :: SelectionLimitReachedError TestSelectionContext -> Property
-    onSelectionLimitReached e =
-        counterexample "onSelectionLimitReached" $
-        report errorBalanceRequired
-            "required balance" $
-        report errorBalanceSelected
-            "selected balance" $
-        verify
-            (utxoBalanceRequired == errorBalanceRequired)
-            "utxoBalanceRequired == errorBalanceRequired" $
-        verify
-            (view #utxoAvailable params /= UTxOSelection.empty)
-            "view #utxoAvailable params /= UTxOSelection.empty" $
-        property True
-      where
-        SelectionLimitReachedError
-            errorBalanceRequired errorInputsSelected _ = e
-        errorBalanceSelected =
-            F.foldMap (view #tokens . snd) errorInputsSelected
 
     onUnableToConstructChange :: UnableToConstructChangeError -> Property
     onUnableToConstructChange e =

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -1246,8 +1246,7 @@ prop_runSelection_UTxO_empty :: TokenBundle -> SelectionStrategy -> Property
 prop_runSelection_UTxO_empty balanceRequested strategy = monadicIO $ do
     result <- run $ runSelection @_ @TestUTxO
         RunSelectionParams
-            { selectionLimit = NoLimit
-            , utxoAvailable
+            { utxoAvailable
             , minimumBalance = balanceRequested
             , selectionStrategy = strategy
             }
@@ -1270,8 +1269,7 @@ prop_runSelection_UTxO_notEnough
 prop_runSelection_UTxO_notEnough utxoAvailable strategy = monadicIO $ do
     result <- run $ runSelection
         RunSelectionParams
-            { selectionLimit = NoLimit
-            , utxoAvailable
+            { utxoAvailable
             , minimumBalance = balanceRequested
             , selectionStrategy = strategy
             }
@@ -1295,8 +1293,7 @@ prop_runSelection_UTxO_exactlyEnough
 prop_runSelection_UTxO_exactlyEnough utxoAvailable strategy = monadicIO $ do
     result <- run $ runSelection
         RunSelectionParams
-            { selectionLimit = NoLimit
-            , utxoAvailable
+            { utxoAvailable
             , minimumBalance = balanceRequested
             , selectionStrategy = strategy
             }
@@ -1324,8 +1321,7 @@ prop_runSelection_UTxO_moreThanEnough
 prop_runSelection_UTxO_moreThanEnough utxoAvailable strategy = monadicIO $ do
     result <- run $ runSelection
         RunSelectionParams
-            { selectionLimit = NoLimit
-            , utxoAvailable
+            { utxoAvailable
             , minimumBalance = balanceRequested
             , selectionStrategy = strategy
             }
@@ -1373,8 +1369,7 @@ prop_runSelection_UTxO_muchMoreThanEnough (Blind (Large index)) strategy =
     monadicIO $ do
         result <- run $ runSelection
             RunSelectionParams
-                { selectionLimit = NoLimit
-                , utxoAvailable
+                { utxoAvailable
                 , minimumBalance = balanceRequested
                 , selectionStrategy = strategy
                 }

--- a/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
@@ -309,7 +309,6 @@ prop_performSelection_coverage params r innerProperty =
     _checkExhaustivenessForSelectionError = case undefined of
         SelectionBalanceErrorOf e -> case e of
             Balance.BalanceInsufficient {} -> ()
-            Balance.SelectionLimitReached {} -> ()
             Balance.UnableToConstructChange {} -> ()
             Balance.EmptyUTxO {} -> ()
         SelectionCollateralErrorOf e -> case e of

--- a/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
@@ -241,9 +241,6 @@ prop_performSelection_coverage params r innerProperty =
         (isSelectionBalanceError_BalanceInsufficient r)
         "isSelectionBalanceError_BalanceInsufficient" $
     cover 0.1
-        (isSelectionBalanceError_SelectionLimitReached r)
-        "isSelectionBalanceError_SelectionLimitReached" $
-    cover 0.1
         (isSelectionBalanceError_UnableToConstructChange r)
         "isSelectionBalanceError_UnableToConstructChange" $
     cover 0.1
@@ -266,9 +263,6 @@ prop_performSelection_coverage params r innerProperty =
     isSelection = isRight
     isSelectionBalanceError_BalanceInsufficient = \case
         Left (SelectionBalanceErrorOf Balance.BalanceInsufficient {})
-            -> True; _ -> False
-    isSelectionBalanceError_SelectionLimitReached = \case
-        Left (SelectionBalanceErrorOf Balance.SelectionLimitReached {})
             -> True; _ -> False
     isSelectionBalanceError_UnableToConstructChange = \case
         Left (SelectionBalanceErrorOf Balance.UnableToConstructChange {})
@@ -401,8 +395,6 @@ prop_toBalanceConstraintsParams_computeSelectionLimit mockConstraints params =
         "collateral required: yes" $
     cover 10 (not (selectionCollateralRequired params))
         "collateral required: no" $
-    cover 10 (selectionLimitOriginal > selectionLimitAdjusted)
-        "selection limit (original) > selection limit (adjusted)" $
     report selectionLimitOriginal
         "selection limit (original)" $
     report selectionLimitAdjusted

--- a/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
@@ -38,7 +38,7 @@ import Cardano.CoinSelection
     , verifySelectionError
     )
 import Cardano.CoinSelection.Balance
-    ( SelectionLimit, SelectionSkeleton )
+    ( SelectionSkeleton )
 import Cardano.CoinSelection.Balance.Gen
     ( genSelectionSkeleton
     , genSelectionStrategy
@@ -49,22 +49,18 @@ import Cardano.CoinSelection.BalanceSpec
     ( MockAssessTokenBundleSize
     , MockComputeMinimumAdaQuantity
     , MockComputeMinimumCost
-    , MockComputeSelectionLimit
     , TestAddress (..)
     , TestSelectionContext
     , TestUTxO
     , genMockAssessTokenBundleSize
     , genMockComputeMinimumAdaQuantity
     , genMockComputeMinimumCost
-    , genMockComputeSelectionLimit
     , shrinkMockAssessTokenBundleSize
     , shrinkMockComputeMinimumAdaQuantity
     , shrinkMockComputeMinimumCost
-    , shrinkMockComputeSelectionLimit
     , unMockAssessTokenBundleSize
     , unMockComputeMinimumAdaQuantity
     , unMockComputeMinimumCost
-    , unMockComputeSelectionLimit
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
@@ -94,8 +90,6 @@ import Data.Either
     ( isRight )
 import Data.Function
     ( (&) )
-import Data.Functor
-    ( (<&>) )
 import Data.Generics.Internal.VL.Lens
     ( over, view, (^.) )
 import Data.IntCast
@@ -491,8 +485,6 @@ data MockSelectionConstraints = MockSelectionConstraints
         :: MockComputeMinimumAdaQuantity
     , computeMinimumCost
         :: MockComputeMinimumCost
-    , computeSelectionLimit
-        :: MockComputeSelectionLimit
     , maximumCollateralInputCount
         :: Int
     , minimumCollateralPercentage
@@ -510,7 +502,6 @@ genMockSelectionConstraints = MockSelectionConstraints
     <*> genCertificateDepositAmount
     <*> genMockComputeMinimumAdaQuantity
     <*> genMockComputeMinimumCost
-    <*> genMockComputeSelectionLimit
     <*> genMaximumCollateralInputCount
     <*> genMinimumCollateralPercentage
     <*> genMaximumOutputAdaQuantity
@@ -523,7 +514,6 @@ shrinkMockSelectionConstraints = genericRoundRobinShrink
     <:> shrinkCertificateDepositAmount
     <:> shrinkMockComputeMinimumAdaQuantity
     <:> shrinkMockComputeMinimumCost
-    <:> shrinkMockComputeSelectionLimit
     <:> shrinkMaximumCollateralInputCount
     <:> shrinkMinimumCollateralPercentage
     <:> shrinkMaximumOutputAdaQuantity
@@ -543,8 +533,6 @@ unMockSelectionConstraints m = SelectionConstraints
         unMockIsBelowMinimumAdaQuantity $ view #computeMinimumAdaQuantity m
     , computeMinimumCost =
         unMockComputeMinimumCost $ view #computeMinimumCost m
-    , computeSelectionLimit =
-        unMockComputeSelectionLimit $ view #computeSelectionLimit m
     , maximumCollateralInputCount =
         view #maximumCollateralInputCount m
     , minimumCollateralPercentage =

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -950,14 +950,6 @@ instance IsServerError (SelectionBalanceError WalletSelectionContext) where
                 , "enough funds available in the wallet. I am "
                 , "missing: ", pretty . Flat $ e ^. #utxoBalanceShortfall
                 ]
-        SelectionLimitReached e ->
-            apiError err403 TransactionIsTooBig $ mconcat
-                [ "I am not able to finalize the transaction "
-                , "because I need to select additional inputs and "
-                , "doing so will make the transaction too big. Try "
-                , "sending a smaller amount. I had already selected "
-                , showT (length $ view #inputsSelected e), " inputs."
-                ]
         UnableToConstructChange e ->
             apiError err403 CannotCoverFee $ T.unwords
                 [ "I am unable to finalize the transaction, as there"

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -64,7 +64,6 @@ import Cardano.Tx.Balance.Internal.CoinSelection
     , SelectionCollateralRequirement (..)
     , SelectionConstraints (..)
     , SelectionError (..)
-    , SelectionLimitOf (..)
     , SelectionOf (change)
     , SelectionOutputError (..)
     , SelectionParams (..)
@@ -995,7 +994,6 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                         })
                     skeleton
                 ] `Coin.difference` boringFee
-            , computeSelectionLimit = \_ -> NoLimit
             , maximumCollateralInputCount = unsafeIntCast @Natural @Int $
                 case recentEra @era of
                     RecentEraBabbage ->

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3805,13 +3805,6 @@ prop_balanceTransactionValid wallet@(Wallet' _ walletUTxO _) (ShowBuildable part
             Left
                 (ErrBalanceTxSelectAssets
                 (ErrSelectAssetsSelectionError
-                (SelectionBalanceErrorOf
-                (SelectionLimitReached _)))) ->
-                    let msg = "selection limit reached should never be returned"
-                    in counterexample msg $ property False
-            Left
-                (ErrBalanceTxSelectAssets
-                (ErrSelectAssetsSelectionError
                 (SelectionBalanceErrorOf (UnableToConstructChange _)))) ->
                 label "unable to construct change" $ property True
             Left ErrBalanceTxInputResolutionConflicts{} ->


### PR DESCRIPTION
## Issue

ADP-3029

## Summary

This PR:
- removes the notion of an "input selection limit" from coin selection.
- removes the `computeSelectionLimit` field from all coin-selection-related constraint records.
- removes the `SelectionLimit` type.
- removes the `SelectionLimitReached` error, thus simplifying the hierarchy of errors returned by `balanceTransaction`.

## Context

For many years, the coin selection algorithm has provided an ability to limit the number of inputs it selects.

This ability was added as a way to prevent transactions from growing too large, which would render them invalid for submission to the network.

However, the advent of the multi-asset era invalidated one of the assumptions on which this design was based: namely that all inputs should require roughly the same amount of space to encode. In the multi-asset era, each input can reference an output with an arbitrary selection of tokens, and thus different inputs can require wildly different amounts of space to encode the change that they generate.

For example, it's quite possible to build a transaction with 10 inputs that requires more space than a transaction with 100 inputs.

Since all wallet endpoints now use the `balanceTransaction` function to perform coin selection, and since `balanceTransaction` does not use the selection limit functionality in any way, there are now no code paths that require this limit to be present.

Therefore, we can simply delete it.