### PR TITLE
[ADP-3030] Remove `prune` from `DBLayer`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1199,6 +1199,9 @@ restoreBlocks ctx tr blocks nodeTip = db & \DBLayer{..} -> atomically $ do
 
     rollForwardTxSubmissions (localTip ^. #slotNo)
         $ fmap (\(tx,meta) -> (meta ^. #slotNo, txId tx)) txs
+    let deltaPruneSubmissions =
+            [ UpdateSubmissions [Submissions.pruneByFinality finalitySlot]
+            ]
 
     forM_ slotPoolDelegations $ \delegation@(slotNo, cert) -> do
             liftIO $ logDelegation delegation
@@ -1209,6 +1212,7 @@ restoreBlocks ctx tr blocks nodeTip = db & \DBLayer{..} -> atomically $ do
     Delta.onDBVar walletState $ Delta.update $ \_wallet ->
         deltaPrologue
         <> [ UpdateCheckpoints deltaPutCheckpoints ]
+        <> deltaPruneSubmissions
 
     prune epochStability finalitySlot
 

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -114,14 +114,10 @@ import Data.Maybe
     ( catMaybes )
 import Data.Ord
     ( Down (..) )
-import Data.Quantity
-    ( Quantity (..) )
 import Data.Store
     ( Store (..) )
 import Data.Traversable
     ( for )
-import Data.Word
-    ( Word32 )
 import GHC.Num
     ( Natural )
 
@@ -345,18 +341,6 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -- point of rollback but can't be guaranteed to be exactly the same
         -- because the database may only keep sparse checkpoints.
 
-    , prune
-        :: Quantity "block" Word32
-        -> SlotNo
-        -> stm ()
-        -- ^ Prune database entities and remove entities that can be discarded.
-        --
-        -- The second argument represents the stability window, or said
-        -- length of the deepest rollback.
-        --
-        -- The third argument is the finality slot, or said
-        -- most recent stable slot
-
     , atomically
         :: forall a. stm a -> m a
         -- ^ Execute operations of the database in isolation and atomically.
@@ -433,10 +417,6 @@ data DBLayerCollection stm m s k = DBLayerCollection
     , rollbackTo_
         :: Slot
         -> stm ChainPoint
-    , prune_
-        :: Quantity "block" Word32
-        -> SlotNo
-        -> stm ()
     , atomically_
         :: forall a. stm a -> m a
     , transactionsStore_
@@ -521,7 +501,6 @@ mkDBLayerFromParts ti wid_ DBLayerCollection{..} = DBLayer
     , readPrivateKey = readPrivateKey_ dbPrivateKey
     , readGenesisParameters = readGenesisParameters_ dbCheckpoints
     , rollbackTo = rollbackTo_
-    , prune = prune_
     , atomically = atomically_
     }
   where

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -644,9 +644,6 @@ newDBFreshFromDBOpen ti wid_ DBOpen{atomically=atomically_} =
             readCheckpoint >>= \cp -> do
                 let tip = cp ^. #currentTip
                 pruneCheckpoints epochStability tip
-            updateDBVar walletState
-                [ UpdateSubmissions [pruneByFinality finalitySlot]
-                ]
 
         {-----------------------------------------------------------------------
                                      Tx History

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -67,10 +67,7 @@ import Cardano.Slotting.Slot
 import Cardano.Wallet.Address.Derivation
     ( Depth (..), PersistPrivateKey (..), WalletKey (..) )
 import Cardano.Wallet.Checkpoints
-    ( DeltaCheckpoints (..)
-    , defaultSparseCheckpointsConfig
-    , sparseCheckpoints
-    )
+    ( DeltaCheckpoints (..) )
 import Cardano.Wallet.DB
     ( DBCheckpoints (..)
     , DBDelegation (..)
@@ -112,7 +109,7 @@ import Cardano.Wallet.DB.Store.Info.Store
 import Cardano.Wallet.DB.Store.Meta.Model
     ( mkTxMetaFromEntity )
 import Cardano.Wallet.DB.Store.Submissions.Layer
-    ( pruneByFinality, rollBackSubmissions )
+    ( rollBackSubmissions )
 import Cardano.Wallet.DB.Store.Submissions.Operations
     ( submissionMetaFromTxMeta )
 import Cardano.Wallet.DB.Store.Transactions.Decoration
@@ -137,7 +134,6 @@ import Cardano.Wallet.DB.WalletState
     , findNearestPoint
     , fromGenesis
     , fromWallet
-    , getBlockHeight
     , getLatest
     , getSlot
     )
@@ -168,7 +164,7 @@ import Data.Bifunctor
 import Data.Coerce
     ( coerce )
 import Data.DBVar
-    ( DBVar, initDBVar, loadDBVar, readDBVar, updateDBVar )
+    ( DBVar, initDBVar, loadDBVar, readDBVar )
 import Data.Functor
     ( (<&>) )
 import Data.Generics.Internal.VL.Lens
@@ -177,8 +173,6 @@ import Data.Maybe
     ( catMaybes, fromMaybe, maybeToList )
 import Data.Proxy
     ( Proxy (..) )
-import Data.Quantity
-    ( Quantity (..) )
 import Data.Store
     ( Store (..), UpdateStore )
 import Data.Text
@@ -228,7 +222,6 @@ import qualified Cardano.Wallet.Read.Tx as Read
 import qualified Data.Delta.Update as Delta
 import qualified Data.Generics.Internal.VL as L
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
 import qualified Data.Text as T
 
 {-------------------------------------------------------------------------------
@@ -569,19 +562,6 @@ newDBFreshFromDBOpen ti wid_ DBOpen{atomically=atomically_} =
             ::  SqlPersistT IO (W.Wallet s)
         readCheckpoint = getLatest <$> readDBVar walletState
 
-        pruneCheckpoints
-            :: Quantity "block" Word32 -> W.BlockHeader
-            -> SqlPersistT IO ()
-        pruneCheckpoints epochStability tip = do
-            let heights = Set.fromList $ sparseCheckpoints
-                    (defaultSparseCheckpointsConfig epochStability)
-                    (tip ^. #blockHeight)
-            Delta.onDBVar walletState $ Delta.update $ \ wal ->
-                let willKeep cp = getBlockHeight cp `Set.member` heights
-                    slots = Map.filter willKeep
-                        $ wal ^. #checkpoints . #checkpoints
-                in [ UpdateCheckpoints [ RestrictTo $ Map.keys slots ] ]
-
         {-----------------------------------------------------------------------
                                     Checkpoints
         -----------------------------------------------------------------------}
@@ -640,10 +620,7 @@ newDBFreshFromDBOpen ti wid_ DBOpen{atomically=atomically_} =
                 RollbackTxWalletsHistory nearestPoint
             pure $ W.chainPointFromBlockHeader currentTip
 
-        prune_ epochStability finalitySlot = do
-            readCheckpoint >>= \cp -> do
-                let tip = cp ^. #currentTip
-                pruneCheckpoints epochStability tip
+        prune_ epochStability finalitySlot = pure ()
 
         {-----------------------------------------------------------------------
                                      Tx History

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -620,8 +620,6 @@ newDBFreshFromDBOpen ti wid_ DBOpen{atomically=atomically_} =
                 RollbackTxWalletsHistory nearestPoint
             pure $ W.chainPointFromBlockHeader currentTip
 
-        prune_ epochStability finalitySlot = pure ()
-
         {-----------------------------------------------------------------------
                                      Tx History
         -----------------------------------------------------------------------}

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -114,8 +114,6 @@ newDBFresh timeInterpreter wid = do
         , rollbackTo = noErrorAlterDB db
             . mRollbackTo
 
-        , prune = \_ _ -> error "MVar.prune: not implemented"
-
         {-----------------------------------------------------------------------
                                    Wallet Metadata
         -----------------------------------------------------------------------}

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
@@ -131,7 +131,10 @@ removePendingOrExpiredTx txId walletSubmissions = do
 rollBackSubmissions :: SlotNo -> DeltaTxSubmissions
 rollBackSubmissions = RollBack
 
-pruneByFinality :: SlotNo -> DeltaTxSubmissions
+pruneByFinality
+    :: SlotNo
+        -- ^ Finality slot = most recent stable slot.
+    -> DeltaTxSubmissions
 pruneByFinality = Prune
 
 mkLocalTxSubmission

--- a/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
@@ -33,6 +33,7 @@ module Cardano.Wallet.DB.WalletState
     , DeltaWalletState
 
     -- * Helpers
+    , updateCheckpoints
     , updateSubmissions
     ) where
 
@@ -185,6 +186,11 @@ instance Show (DeltaWalletState1 s) where
 {-------------------------------------------------------------------------------
     Helper functions
 -------------------------------------------------------------------------------}
+updateCheckpoints
+    :: Update (CPS.DeltasCheckpoints (WalletCheckpoint s)) r
+    -> Update (DeltaWalletState s) r
+updateCheckpoints = updateField checkpoints ((:[]) . UpdateCheckpoints)
+
 updateSubmissions
     :: Update [DeltaTxSubmissions] r
     -> Update (DeltaWalletState s) r

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -266,12 +266,15 @@ import UnliftIO.Temporary
 import Cardano.Wallet
     ( readWalletMeta )
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Seq
+import qualified Cardano.Wallet.Checkpoints as Checkpoints
 import qualified Cardano.Wallet.DB.Sqlite.Schema as DB
 import qualified Cardano.Wallet.DB.Sqlite.Types as DB
+import qualified Cardano.Wallet.DB.WalletState as WalletState
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
+import qualified Data.Delta.Update as Delta
 import qualified Data.List as L
 import qualified Data.Set as Set
 import qualified Data.Text as T
@@ -570,10 +573,19 @@ fileModeSpec =  do
                             mempty
                     let (FilteredBlock{transactions=txs}, (_,cpB)) =
                             applyBlock fakeBlock cpA
+                        epochStability = Quantity 2160
+                        deltaPruneCheckpoints =
+                            Checkpoints.pruneCheckpoints
+                                (view $ #currentTip . #blockHeight)
+                                epochStability
+                                (currentTip cpB ^. #blockHeight)
+
                     atomically $ do
                         putCheckpoint cpB
                         putTxHistory txs
-                        prune (Quantity 2_160) $ 2_160 * 3 * 20
+                        Delta.onDBVar walletState
+                            $ WalletState.updateCheckpoints
+                            $ Delta.update deltaPruneCheckpoints
 
             it "Should spend collateral inputs and create spendable collateral \
                 \outputs if validation fails" $


### PR DESCRIPTION
### Overview

We want to remove functions from the `DBLayer` record until essentially all DB access is done through the `walletsState :: DBVar`.

This task is about removing `prune` from the `DBLayer` record.

### Issue number

ADP-3030