### PR TITLE
Drop support for balancing transactions in eras more recent than the node tip

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -82,6 +82,7 @@ import Cardano.Wallet
     , ErrWithdrawalNotBeneficial (..)
     , ErrWitnessTx (..)
     , ErrWritePolicyPublicKey (..)
+    , ErrWriteTxEra (..)
     , ErrWrongPassphrase (..)
     , WalletException (..)
     )
@@ -214,6 +215,7 @@ instance IsServerError WalletException where
         ExceptionReadAccountPublicKey e -> toServerError e
         ExceptionSignPayment e -> toServerError e
         ExceptionBalanceTx e -> toServerError e
+        ExceptionWriteTxEra e -> toServerError e
         ExceptionBalanceTxInternalError e -> toServerError e
         ExceptionSubmitTransaction e -> toServerError e
         ExceptionConstructTx e -> toServerError e
@@ -453,13 +455,16 @@ instance IsServerError ErrGetPolicyId where
             , "from cosigner#0."
             ]
 
-instance IsServerError ErrBalanceTx where
+instance IsServerError ErrWriteTxEra where
     toServerError = \case
         ErrOldEraNotSupported (Cardano.AnyCardanoEra era) ->
             apiError err403 BalanceTxEraNotSupported $ T.unwords
                 [ "Balancing in ", showT era, " "
                 , "is not supported."
                 ]
+
+instance IsServerError ErrBalanceTx where
+    toServerError = \case
         ErrBalanceTxUpdateError (ErrExistingKeyWitnesses n) ->
             apiError err403 BalanceTxExistingKeyWitnesses $ mconcat
                 [ "The transaction could not be balanced, because it contains "

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -93,12 +93,17 @@ import Cardano.Wallet.Address.Discovery.Shared
 import Cardano.Wallet.Api.Hex
     ( hexText )
 import Cardano.Wallet.Api.Types
-    ( ApiCosignerIndex (..), ApiCredentialType (..), Iso8601Time (..) )
+    ( ApiCosignerIndex (..)
+    , ApiCredentialType (..)
+    , Iso8601Time (..)
+    , toApiEra
+    )
 import Cardano.Wallet.Api.Types.Error
     ( ApiError (..)
     , ApiErrorBalanceTxUnderestimatedFee (..)
     , ApiErrorInfo (..)
     , ApiErrorMessage (..)
+    , ApiErrorNodeNotYetInRecentEra (..)
     , ApiErrorSharedWalletNoSuchCosigner (..)
     , ApiErrorTxOutputLovelaceInsufficient (..)
     )
@@ -162,6 +167,7 @@ import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
@@ -457,11 +463,20 @@ instance IsServerError ErrGetPolicyId where
 
 instance IsServerError ErrWriteTxEra where
     toServerError = \case
-        ErrOldEraNotSupported (Cardano.AnyCardanoEra era) ->
-            apiError err403 BalanceTxEraNotSupported $ T.unwords
-                [ "Balancing in ", showT era, " "
-                , "is not supported."
+        ErrNodeNotYetInRecentEra (Cardano.AnyCardanoEra era) ->
+            apiError err403 (NodeNotYetInRecentEra info) $ T.unwords
+                [ "This operation requires the node to be synchronised to a"
+                , "recent era, but the node is currently only synchronised to the"
+                , showT era
+                , "era. Please wait until the node is fully synchronised and"
+                , "try again."
                 ]
+          where
+            info = ApiErrorNodeNotYetInRecentEra
+                { nodeEra = toApiEra $ Cardano.AnyCardanoEra era
+                , supportedRecentEras =
+                    map (toApiEra . Write.toAnyCardanoEra) [minBound .. maxBound]
+                }
 
 instance IsServerError ErrBalanceTx where
     toServerError = \case

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -477,6 +477,19 @@ instance IsServerError ErrWriteTxEra where
                 , supportedRecentEras =
                     map (toApiEra . Write.toAnyCardanoEra) [minBound .. maxBound]
                 }
+        ErrPartialTxNotInNodeEra nodeEra ->
+            apiError err403 TxNotInNodeEra $ T.unwords
+                [ "The provided transaction could be deserialised, just not in"
+                , showT nodeEra <> ","
+                , "the era the local node is currently in."
+                , "If the node is not yet fully synchronised, try waiting."
+                , "If you're constructing a transaction for a future era for"
+                , "testing purposes, try doing so on a testnet in that era"
+                , "instead."
+                , "If you're attempting to balance a partial transaction from"
+                , "an old era, please recreate your transaction so that it is"
+                , "compatible with a recent era."
+                ]
 
 instance IsServerError ErrBalanceTx where
     toServerError = \case

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -156,10 +156,6 @@ import Cardano.Api
     , toNetworkMagic
     , unNetworkMagic
     )
-import Cardano.Api.Extra
-    ( inAnyCardanoEra )
-import Cardano.Api.Shelley
-    ( ShelleyLedgerEra )
 import Cardano.BM.Tracing
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Cardano.Mnemonic
@@ -520,7 +516,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxChange (..)
     , TxStatus (..)
     , UnsignedTx (..)
-    , cardanoTxIdeallyNoLaterThan
+    , cardanoTxInExactEra
     , getSealedTxWitnesses
     , sealedTxFromCardanoBody
     )
@@ -561,7 +557,7 @@ import Cardano.Wallet.Unsafe
 import Cardano.Wallet.Write.Tx
     ( AnyRecentEra (..) )
 import Cardano.Wallet.Write.Tx.Balance
-    ( UTxOAssumptions (..), constructUTxOIndex )
+    ( UTxOAssumptions (..) )
 import Control.Arrow
     ( second, (&&&) )
 import Control.DeepSeq
@@ -569,7 +565,7 @@ import Control.DeepSeq
 import Control.Error.Util
     ( failWith )
 import Control.Monad
-    ( forM, forever, join, void, when, (<=<), (>=>) )
+    ( forM, forever, join, void, when, (>=>) )
 import Control.Monad.Error.Class
     ( throwError )
 import Control.Monad.IO.Class
@@ -3086,90 +3082,59 @@ balanceTransaction
 balanceTransaction
     ctx@ApiLayer{..} argGenChange utxoAssumptions (ApiT wid) body = do
     -- NOTE: Ideally we'd read @pp@ and @era@ atomically.
-    pp <- liftIO $ NW.currentProtocolParameters nl
-    era <- liftIO $ NW.currentNodeEra nl
+    pp <- liftIO $ currentProtocolParameters netLayer
+    era <- liftIO $ NW.currentNodeEra netLayer
+    Write.AnyRecentEra recentEra <- guardIsRecentEra era
+
     withWorkerCtx ctx wid liftE liftE $ \wrk -> do
-        (walletUTxO, wallet, _txs) <- handler $ W.readWalletUTxO @_ @s wrk
+        (utxo, wallet, _txs) <- handler $ W.readWalletUTxO wrk
         timeTranslation <- liftIO $ toTimeTranslation (timeInterpreter netLayer)
-        let mkPartialTx
-                :: forall era. Write.IsRecentEra era => Cardano.Tx era
-                -> Handler (Write.PartialTx era)
-            mkPartialTx tx = do
-                utxo <- fmap Write.toCardanoUTxO $ mkLedgerUTxO $ body ^. #inputs
-                pure $ Write.PartialTx
-                    tx
-                    utxo
-                    (fromApiRedeemer <$> body ^. #redeemers)
-              where
-                -- NOTE: There are a couple of spread-out pieces of logic
-                -- dealing with the choice of era, most prominantly: tx, utxo,
-                -- pparams / current node era. It /might/ be neater to have a
-                -- single function dedicated to this choice instead; something
-                -- like
-                -- @@
-                --      chooseEra
-                --          :: InRecentEra Tx
-                --          -> InRecentEra UTxO
-                --          -> InRecentEra PParams
-                --          -> (IsRecentEra era
-                --              => Tx era
-                --              -> UTxO era
-                --              -> PParams era
-                --              -> res)
-                --          -> res
-                -- @@
 
-                mkRecentEra :: Handler (Write.RecentEra era)
-                mkRecentEra = case Cardano.cardanoEra @era of
-                    Cardano.ConwayEra -> pure Write.RecentEraConway
-                    Cardano.BabbageEra -> pure Write.RecentEraBabbage
-                    _ -> liftHandler $ throwE $ W.ErrOldEraNotSupported era
+        partialTx <- parsePartialTx recentEra
 
-                mkLedgerUTxO
-                    :: [ApiExternalInput n]
-                    -> Handler (Write.UTxO (ShelleyLedgerEra era))
-                mkLedgerUTxO ins = do
-                    recentEra <- mkRecentEra
-                    pure
-                        . Write.utxoFromTxOutsInRecentEra recentEra
-                        . map fromExternalInput
-                        $ ins
-
-        let balanceTx
-                :: forall era. Write.IsRecentEra era
-                => Write.PartialTx era
-                -> Handler (Cardano.Tx era)
-            balanceTx partialTx =
-                liftHandler $ fst <$> Write.balanceTransaction @_ @IO @s
-                    (MsgWallet . W.MsgBalanceTx >$< wrk ^. W.logger)
-                    utxoAssumptions
-                    (Write.unsafeFromWalletProtocolParameters pp)
-                    timeTranslation
-                    (constructUTxOIndex walletUTxO)
-                    (W.defaultChangeAddressGen argGenChange)
-                    (getState wallet)
-                    partialTx
-
-        anyRecentTx <- maybeToHandler (W.ErrOldEraNotSupported era)
-            . Write.asAnyRecentEra
-            . cardanoTxIdeallyNoLaterThan era
-            . getApiT $ body ^. #transaction
-
-        res <- Write.withInAnyRecentEra anyRecentTx
-            (fmap inAnyCardanoEra . balanceTx <=< mkPartialTx)
+        balancedTx <- liftHandler
+            . fmap (Cardano.InAnyCardanoEra Write.cardanoEra . fst)
+            $ Write.balanceTransaction
+                (MsgWallet . W.MsgBalanceTx >$< wrk ^. W.logger)
+                utxoAssumptions
+                (Write.unsafeFromWalletProtocolParameters pp)
+                timeTranslation
+                (Write.constructUTxOIndex utxo)
+                (W.defaultChangeAddressGen argGenChange)
+                (getState wallet)
+                partialTx
 
         case body ^. #encoding of
             Just HexEncoded ->
                 pure $ ApiSerialisedTransaction
-                (ApiT $ W.sealedTxFromCardano res) HexEncoded
+                (ApiT $ W.sealedTxFromCardano balancedTx) HexEncoded
             _ -> pure $ ApiSerialisedTransaction
-                (ApiT $ W.sealedTxFromCardano res) Base64Encoded
+                (ApiT $ W.sealedTxFromCardano balancedTx) Base64Encoded
   where
-    nl = ctx ^. networkLayer
+    parsePartialTx
+        :: Write.IsRecentEra era
+        => Write.RecentEra era
+        -> Handler (Write.PartialTx era)
+    parsePartialTx era = do
+        let externalUTxO = Write.toCardanoUTxO
+                $ Write.utxoFromTxOutsInRecentEra era
+                $ map fromExternalInput
+                $ body ^. #inputs
 
-    maybeToHandler :: IsServerError e => e -> Maybe a -> Handler a
-    maybeToHandler _ (Just a) = pure a
-    maybeToHandler e Nothing  = liftHandler $ throwE e
+        tx <- maybe
+                (liftHandler
+                    . throwE
+                    . W.ErrPartialTxNotInNodeEra
+                    $ AnyRecentEra era)
+                pure
+            . cardanoTxInExactEra (Write.cardanoEraFromRecentEra era)
+            . getApiT
+            $ body ^. #transaction
+
+        pure $ Write.PartialTx
+            tx
+            externalUTxO
+            (fromApiRedeemer <$> body ^. #redeemers)
 
 decodeTransaction
     :: forall s n
@@ -4250,7 +4215,7 @@ guardIsRecentEra (Cardano.AnyCardanoEra era) = case era of
     Cardano.ShelleyEra -> liftE invalidEra
     Cardano.ByronEra   -> liftE invalidEra
   where
-    invalidEra = W.ErrOldEraNotSupported $ Cardano.AnyCardanoEra era
+    invalidEra = W.ErrNodeNotYetInRecentEra $ Cardano.AnyCardanoEra era
 
 mkWithdrawal
     :: forall n block

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3123,7 +3123,7 @@ balanceTransaction
                 mkRecentEra = case Cardano.cardanoEra @era of
                     Cardano.ConwayEra -> pure Write.RecentEraConway
                     Cardano.BabbageEra -> pure Write.RecentEraBabbage
-                    _ -> liftHandler $ throwE $ Write.ErrOldEraNotSupported era
+                    _ -> liftHandler $ throwE $ W.ErrOldEraNotSupported era
 
                 mkLedgerUTxO
                     :: [ApiExternalInput n]
@@ -3150,7 +3150,7 @@ balanceTransaction
                     (getState wallet)
                     partialTx
 
-        anyRecentTx <- maybeToHandler (Write.ErrOldEraNotSupported era)
+        anyRecentTx <- maybeToHandler (W.ErrOldEraNotSupported era)
             . Write.asAnyRecentEra
             . cardanoTxIdeallyNoLaterThan era
             . getApiT $ body ^. #transaction
@@ -4250,7 +4250,7 @@ guardIsRecentEra (Cardano.AnyCardanoEra era) = case era of
     Cardano.ShelleyEra -> liftE invalidEra
     Cardano.ByronEra   -> liftE invalidEra
   where
-    invalidEra = Write.ErrOldEraNotSupported $ Cardano.AnyCardanoEra era
+    invalidEra = W.ErrOldEraNotSupported $ Cardano.AnyCardanoEra era
 
 mkWithdrawal
     :: forall n block

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -1426,7 +1426,7 @@ data ApiEra
     | ApiAlonzo
     | ApiBabbage
     | ApiConway
-    deriving (Show, Eq, Generic, Enum, Ord, Bounded)
+    deriving (Data, Show, Eq, Generic, Enum, Ord, Bounded)
     deriving anyclass NFData
 
 toApiEra :: AnyCardanoEra -> ApiEra

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Error.hs
@@ -89,6 +89,7 @@ data ApiErrorInfo
     | BalanceTxExistingCollateral
     | BalanceTxExistingKeyWitnesses
     | BalanceTxExistingReturnCollateral
+    | TxNotInNodeEra
     | BalanceTxExistingTotalCollateral
     | BalanceTxInternalError
     | BalanceTxUnderestimatedFee

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Error.hs
@@ -24,6 +24,7 @@ module Cardano.Wallet.Api.Types.Error
     , ApiErrorSharedWalletNoSuchCosigner (..)
     , ApiErrorTxOutputLovelaceInsufficient (..)
     , ApiErrorBalanceTxUnderestimatedFee (..)
+    , ApiErrorNodeNotYetInRecentEra (..)
     )
     where
 
@@ -32,7 +33,7 @@ import Prelude
 import Cardano.Wallet.Api.Lib.Options
     ( DefaultRecord (..), defaultSumTypeOptions )
 import Cardano.Wallet.Api.Types
-    ( ApiCosignerIndex (..), ApiCredentialType (..) )
+    ( ApiCosignerIndex (..), ApiCredentialType (..), ApiEra )
 import Control.DeepSeq
     ( NFData (..) )
 import Data.Aeson
@@ -85,7 +86,6 @@ data ApiErrorInfo
     | AssetNotPresent
     | BadRequest
     | BalanceTxConflictingNetworks
-    | BalanceTxEraNotSupported
     | BalanceTxExistingCollateral
     | BalanceTxExistingKeyWitnesses
     | BalanceTxExistingReturnCollateral
@@ -120,6 +120,8 @@ data ApiErrorInfo
     | NetworkMisconfigured
     | NetworkQueryFailed
     | NetworkUnreachable
+    | NodeNotYetInRecentEra
+        !ApiErrorNodeNotYetInRecentEra
     | NoRootKey
     | NoSuchPool
     | NoSuchTransaction
@@ -221,4 +223,13 @@ data ApiErrorBalanceTxUnderestimatedFee = ApiErrorBalanceTxUnderestimatedFee
     deriving (Data, Eq, Generic, Show, Typeable)
     deriving (FromJSON, ToJSON)
         via DefaultRecord ApiErrorBalanceTxUnderestimatedFee
+    deriving anyclass NFData
+
+data ApiErrorNodeNotYetInRecentEra = ApiErrorNodeNotYetInRecentEra
+    { nodeEra :: ApiEra
+    , supportedRecentEras :: [ApiEra]
+    }
+    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON)
+        via DefaultRecord ApiErrorNodeNotYetInRecentEra
     deriving anyclass NFData

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -1010,7 +1010,7 @@ guardIsRecentEra (Cardano.AnyCardanoEra era) = case era of
     Cardano.ShelleyEra -> invalidEra
     Cardano.ByronEra -> invalidEra
     where
-    invalidEra = throwIO $ W.ExceptionWriteTxEra $ W.ErrOldEraNotSupported $
+    invalidEra = throwIO $ W.ExceptionWriteTxEra $ W.ErrNodeNotYetInRecentEra $
         Cardano.AnyCardanoEra era
 
 withNonEmptyUTxO :: Wallet s -> Set Tx -> e -> IO a -> IO (Either e a)

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -51,11 +51,7 @@ import Cardano.BM.Trace
 import Cardano.Mnemonic
     ( SomeMnemonic (..), entropyToMnemonic )
 import Cardano.Wallet
-    ( WalletException (..)
-    , WalletLayer (..)
-    , WalletWorkerLog (..)
-    , dummyChangeAddressGen
-    )
+    ( WalletLayer (..), WalletWorkerLog (..), dummyChangeAddressGen )
 import Cardano.Wallet.Address.Book
     ( AddressBookIso )
 import Cardano.Wallet.Address.Derivation
@@ -253,7 +249,6 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Cardano.Wallet.Shelley.Compatibility as Cardano
 import qualified Cardano.Wallet.Write.ProtocolParameters as Write
 import qualified Cardano.Wallet.Write.Tx as Write
-import qualified Cardano.Wallet.Write.Tx.Balance as Write
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -1015,7 +1010,7 @@ guardIsRecentEra (Cardano.AnyCardanoEra era) = case era of
     Cardano.ShelleyEra -> invalidEra
     Cardano.ByronEra -> invalidEra
     where
-    invalidEra = throwIO $ ExceptionBalanceTx $ Write.ErrOldEraNotSupported $
+    invalidEra = throwIO $ W.ExceptionWriteTxEra $ W.ErrOldEraNotSupported $
         Cardano.AnyCardanoEra era
 
 withNonEmptyUTxO :: Wallet s -> Set Tx -> e -> IO a -> IO (Either e a)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -195,6 +195,7 @@ module Cardano.Wallet
     , ErrNoSuchTransaction (..)
     , ErrStartTimeLaterThanEndTime (..)
     , ErrWitnessTx (..)
+    , ErrWriteTxEra (..)
 
     -- ** Root Key
     , withRootKey
@@ -1866,6 +1867,10 @@ signTransaction key tl preferredLatestEra witCountCtx keyLookup mextraRewardAcc
 type MakeRewardAccountBuilder k =
     (k 'RootK XPrv, Passphrase "encryption") -> (XPrv, Passphrase "encryption")
 
+data ErrWriteTxEra
+    = ErrOldEraNotSupported Cardano.AnyCardanoEra
+    deriving (Show, Eq)
+
 -- | Build, Sign, Submit transaction.
 --
 -- Requires the encryption passphrase in order to decrypt the root private key.
@@ -3469,6 +3474,7 @@ data WalletException
     | ExceptionReadAccountPublicKey ErrReadAccountPublicKey
     | ExceptionSignPayment ErrSignPayment
     | ExceptionBalanceTx ErrBalanceTx
+    | ExceptionWriteTxEra ErrWriteTxEra
     | ExceptionBalanceTxInternalError ErrBalanceTxInternalError
     | ExceptionSubmitTransaction ErrSubmitTransaction
     | ExceptionConstructTx ErrConstructTx

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1870,6 +1870,15 @@ type MakeRewardAccountBuilder k =
 data ErrWriteTxEra
     = ErrNodeNotYetInRecentEra Cardano.AnyCardanoEra
     -- ^ Node is not synced enough or on an unsupported testnet in an older era.
+    | ErrPartialTxNotInNodeEra
+        Write.AnyRecentEra -- node era
+    -- ^ The provided partial tx is not deserialisable as a tx in the era of the
+    -- node.
+    --
+    -- NOTE: In general we don't have /one/ known tx era. The tx could in theory
+    -- be deserialisable in all other eras than the one node era we need.
+    -- Exposing a 'Set AnyCardanoEra' of the candidate tx eras /could/ be done,
+    -- but would require some work.
     deriving (Show, Eq)
 
 -- | Build, Sign, Submit transaction.

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1868,7 +1868,8 @@ type MakeRewardAccountBuilder k =
     (k 'RootK XPrv, Passphrase "encryption") -> (XPrv, Passphrase "encryption")
 
 data ErrWriteTxEra
-    = ErrOldEraNotSupported Cardano.AnyCardanoEra
+    = ErrNodeNotYetInRecentEra Cardano.AnyCardanoEra
+    -- ^ Node is not synced enough or on an unsupported testnet in an older era.
     deriving (Show, Eq)
 
 -- | Build, Sign, Submit transaction.
@@ -2067,7 +2068,7 @@ buildAndSignTransactionPure
             , builtSealedTx = signedTx
             }
   where
-    anyCardanoEra = Write.fromAnyRecentEra era
+    anyCardanoEra = Write.toAnyCardanoEra era
 
 buildTransaction
     :: forall s era.

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -34,6 +34,7 @@ module Cardano.Wallet.Primitive.Types.Tx
     -- * Serialisation
     , SealedTx (serialisedTx)
     , cardanoTxIdeallyNoLaterThan
+    , cardanoTxInExactEra
     , sealedTxFromBytes
     , sealedTxFromBytes'
     , sealedTxFromCardano
@@ -91,6 +92,7 @@ import Cardano.Wallet.Primitive.Types.Tx.SealedTx
     ( SealedTx (..)
     , SerialisedTx (..)
     , cardanoTxIdeallyNoLaterThan
+    , cardanoTxInExactEra
     , getSealedTxBody
     , getSealedTxWitnesses
     , mockSealedTx

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -299,7 +299,6 @@ data ErrBalanceTx
     | ErrBalanceTxInternalError ErrBalanceTxInternalError
     | ErrBalanceTxInputResolutionConflicts (NonEmpty (W.TxOut, W.TxOut))
     | ErrBalanceTxUnresolvedInputs (NonEmpty W.TxIn)
-    | ErrOldEraNotSupported Cardano.AnyCardanoEra
     deriving (Show, Eq)
 
 -- | A 'PartialTx' is an an unbalanced 'SealedTx' along with the necessary

--- a/lib/wallet/test/data/Cardano/Wallet/Api/ApiError.json
+++ b/lib/wallet/test/data/Cardano/Wallet/Api/ApiError.json
@@ -1,45 +1,54 @@
 {
     "samples": [
         {
-            "code": "balance_tx_era_not_supported",
-            "message": "%􂹡pO&aἵ"
+            "code": "network_misconfigured",
+            "message": "U\t"
+        },
+        {
+            "code": "balance_tx_existing_collateral",
+            "message": "'᎗*L􀛽vlﾽ󲅄අ󼊆"
+        },
+        {
+            "code": "not_synced",
+            "message": "\u001ch\u000f6𘈳QG\u001f"
+        },
+        {
+            "code": "redeemer_script_failure",
+            "message": "F𓉴)缺O\u0013"
         },
         {
             "code": "wallet_already_exists",
-            "message": "2\u0003>\u000bj"
-        },
-        {
-            "code": "invalid_coin_selection",
             "message": ""
         },
         {
-            "code": "withdrawal_not_beneficial",
-            "message": "􀳵n󲶛#Z󳎷\u000f1\u0013𡽑"
+            "code": "asset_not_present",
+            "message": "\u0005[\u001b\u0005 n{=5"
         },
         {
-            "code": "translation_error",
-            "message": "?;n 􏪫iH󸕴{@튬\u0017w\u001a"
+            "code": "node_not_yet_in_recent_era",
+            "info": {
+                "node_era": "allegra",
+                "supported_recent_eras": [
+                    "shelley",
+                    "alonzo",
+                    "mary",
+                    "shelley"
+                ]
+            },
+            "message": "U"
         },
         {
-            "code": "foreign_transaction",
-            "message": "󹵎LUe􅱋𬼳𝂝H?𧿛\u0007c$"
+            "code": "mempool_is_full",
+            "message": "~<znw𬻠􆇨nZ󰐍\u0008"
         },
         {
-            "code": "wallet_already_exists",
-            "message": "󱡉_&𢵈󵒂v\u000f;!\u0004!󺺼l1"
+            "code": "delegation_invalid",
+            "message": "vn𰋈o\u0004D𡭣󳝃7􍷌v!\u0010k"
         },
         {
-            "code": "mint_or_burn_asset_quantity_out_of_bounds",
-            "message": ""
-        },
-        {
-            "code": "network_unreachable",
-            "message": "\u000c\u001b=𑲰􈁸1$"
-        },
-        {
-            "code": "no_such_wallet",
-            "message": "􂗵o5􁓁牄\u0003"
+            "code": "pool_already_joined",
+            "message": "+H_TSB􄗟𣕄𖬀$-"
         }
     ],
-    "seed": -715238823
+    "seed": 531934170
 }

--- a/lib/wallet/test/data/Cardano/Wallet/Api/ApiErrorBalanceTxUnderestimatedFee.json
+++ b/lib/wallet/test/data/Cardano/Wallet/Api/ApiErrorBalanceTxUnderestimatedFee.json
@@ -1,0 +1,105 @@
+{
+    "samples": [
+        {
+            "candidate_tx_hex": "",
+            "candidate_tx_readable": "DNz|qr",
+            "estimated_number_of_bootstrap_key_wits": 1,
+            "estimated_number_of_key_wits": 5,
+            "underestimation": {
+                "quantity": 6,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "candidate_tx_hex": "4󶙃g~\u001f>",
+            "candidate_tx_readable": "𧫅",
+            "estimated_number_of_bootstrap_key_wits": 5,
+            "estimated_number_of_key_wits": 1,
+            "underestimation": {
+                "quantity": 8,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "candidate_tx_hex": "M𠤍B\u0017",
+            "candidate_tx_readable": "\"]󸄍",
+            "estimated_number_of_bootstrap_key_wits": 3,
+            "estimated_number_of_key_wits": 6,
+            "underestimation": {
+                "quantity": 7,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "candidate_tx_hex": "𧟃0\u00115Z\u001f",
+            "candidate_tx_readable": "EN􎡤$!",
+            "estimated_number_of_bootstrap_key_wits": 4,
+            "estimated_number_of_key_wits": 0,
+            "underestimation": {
+                "quantity": 7,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "candidate_tx_hex": "B仰",
+            "candidate_tx_readable": "\u0018Q󹺲􆦈𣐔y",
+            "estimated_number_of_bootstrap_key_wits": 2,
+            "estimated_number_of_key_wits": 0,
+            "underestimation": {
+                "quantity": 5,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "candidate_tx_hex": "",
+            "candidate_tx_readable": "\u0004s",
+            "estimated_number_of_bootstrap_key_wits": 3,
+            "estimated_number_of_key_wits": 0,
+            "underestimation": {
+                "quantity": 1,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "candidate_tx_hex": "HF􌁲(",
+            "candidate_tx_readable": "xPSX𢋛",
+            "estimated_number_of_bootstrap_key_wits": 1,
+            "estimated_number_of_key_wits": 6,
+            "underestimation": {
+                "quantity": 6,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "candidate_tx_hex": "P~|􂜚3",
+            "candidate_tx_readable": "􊉫􀩳Z\u0010>\u001e",
+            "estimated_number_of_bootstrap_key_wits": 3,
+            "estimated_number_of_key_wits": 3,
+            "underestimation": {
+                "quantity": 2,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "candidate_tx_hex": "?.R\u0011\u0018p",
+            "candidate_tx_readable": "n\u0019{^𝌈h",
+            "estimated_number_of_bootstrap_key_wits": 3,
+            "estimated_number_of_key_wits": 6,
+            "underestimation": {
+                "quantity": 7,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "candidate_tx_hex": "+\u0014󾵡s\u0007𨛡",
+            "candidate_tx_readable": " (\u0005$i",
+            "estimated_number_of_bootstrap_key_wits": 0,
+            "estimated_number_of_key_wits": 0,
+            "underestimation": {
+                "quantity": 8,
+                "unit": "lovelace"
+            }
+        }
+    ],
+    "seed": -1754547698
+}

--- a/lib/wallet/test/data/Cardano/Wallet/Api/ApiErrorNodeNotYetInRecentEra.json
+++ b/lib/wallet/test/data/Cardano/Wallet/Api/ApiErrorNodeNotYetInRecentEra.json
@@ -1,0 +1,105 @@
+{
+    "samples": [
+        {
+            "node_era": "babbage",
+            "supported_recent_eras": [
+                "babbage"
+            ]
+        },
+        {
+            "node_era": "babbage",
+            "supported_recent_eras": []
+        },
+        {
+            "node_era": "byron",
+            "supported_recent_eras": [
+                "conway",
+                "allegra",
+                "alonzo",
+                "alonzo",
+                "babbage",
+                "conway",
+                "alonzo"
+            ]
+        },
+        {
+            "node_era": "allegra",
+            "supported_recent_eras": [
+                "alonzo",
+                "babbage"
+            ]
+        },
+        {
+            "node_era": "allegra",
+            "supported_recent_eras": [
+                "babbage",
+                "alonzo"
+            ]
+        },
+        {
+            "node_era": "shelley",
+            "supported_recent_eras": [
+                "conway",
+                "shelley",
+                "shelley",
+                "byron",
+                "alonzo"
+            ]
+        },
+        {
+            "node_era": "alonzo",
+            "supported_recent_eras": [
+                "alonzo",
+                "alonzo",
+                "shelley",
+                "byron",
+                "alonzo",
+                "byron",
+                "mary",
+                "babbage",
+                "conway"
+            ]
+        },
+        {
+            "node_era": "alonzo",
+            "supported_recent_eras": [
+                "allegra",
+                "byron",
+                "alonzo",
+                "alonzo",
+                "mary",
+                "mary",
+                "mary",
+                "shelley",
+                "allegra",
+                "babbage"
+            ]
+        },
+        {
+            "node_era": "alonzo",
+            "supported_recent_eras": [
+                "conway",
+                "byron",
+                "babbage",
+                "allegra"
+            ]
+        },
+        {
+            "node_era": "byron",
+            "supported_recent_eras": [
+                "allegra",
+                "babbage",
+                "byron",
+                "shelley",
+                "allegra",
+                "mary",
+                "allegra",
+                "babbage",
+                "byron",
+                "alonzo",
+                "allegra"
+            ]
+        }
+    ],
+    "seed": -445804426
+}

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -245,6 +245,7 @@ import Cardano.Wallet.Api.Types.Error
     , ApiErrorBalanceTxUnderestimatedFee (..)
     , ApiErrorInfo (..)
     , ApiErrorMessage (..)
+    , ApiErrorNodeNotYetInRecentEra (..)
     , ApiErrorSharedWalletNoSuchCosigner (..)
     , ApiErrorTxOutputLovelaceInsufficient (..)
     )
@@ -622,6 +623,7 @@ spec = do
         jsonTest @ApiErrorSharedWalletNoSuchCosigner
         jsonTest @ApiErrorTxOutputLovelaceInsufficient
         jsonTest @ApiErrorBalanceTxUnderestimatedFee
+        jsonTest @ApiErrorNodeNotYetInRecentEra
         jsonTest @ApiFee
         jsonTest @ApiHealthCheck
         jsonTest @ApiIncompleteSharedWallet
@@ -2215,6 +2217,10 @@ instance Arbitrary ApiErrorTxOutputLovelaceInsufficient where
     shrink = genericShrink
 
 instance Arbitrary ApiErrorBalanceTxUnderestimatedFee where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary ApiErrorNodeNotYetInRecentEra where
     arbitrary = genericArbitrary
     shrink = genericShrink
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -621,6 +621,7 @@ spec = do
         jsonTest @ApiError
         jsonTest @ApiErrorSharedWalletNoSuchCosigner
         jsonTest @ApiErrorTxOutputLovelaceInsufficient
+        jsonTest @ApiErrorBalanceTxUnderestimatedFee
         jsonTest @ApiFee
         jsonTest @ApiHealthCheck
         jsonTest @ApiIncompleteSharedWallet

--- a/lib/wallet/test/unit/Cardano/Wallet/Write/TxSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Write/TxSpec.hs
@@ -203,6 +203,15 @@ spec = do
                     "fromCardanoUTxO")
                 id
 
+--------------------------------------------------------------------------------
+-- Arbitrary instances
+--------------------------------------------------------------------------------
+
+instance Arbitrary AnyRecentEra where
+    arbitrary = arbitraryBoundedEnum
+    shrink = shrinkBoundedEnum
+
+
 instance Arbitrary Cardano.HashableScriptData where
      arbitrary = genHashableScriptData
      shrink = const []
@@ -281,14 +290,6 @@ testIsomorphism (NamedFun f fName) (NamedFun g gName) normalize =
             (gName <> " . " <> gName <> " == id")
             (property $ \x -> g (f x) === x)
         ]
-
---------------------------------------------------------------------------------
--- Arbitrary instances
---------------------------------------------------------------------------------
-
-instance Arbitrary AnyRecentEra where
-    arbitrary = arbitraryBoundedEnum
-    shrink = shrinkBoundedEnum
 
 --------------------------------------------------------------------------------
 -- Test Data

--- a/lib/wallet/test/unit/Cardano/Wallet/Write/TxSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Write/TxSpec.hs
@@ -18,7 +18,8 @@ import Cardano.Ledger.Babbage.TxBody
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Cardano.Wallet.Write.Tx
-    ( BinaryData
+    ( AnyRecentEra
+    , BinaryData
     , RecentEra (..)
     , Script
     , StandardBabbage
@@ -59,11 +60,18 @@ import Test.QuickCheck
     ( Arbitrary (..)
     , Arbitrary1 (liftArbitrary)
     , Property
+    , arbitraryBoundedEnum
     , conjoin
     , counterexample
     , property
     , (===)
     )
+import Test.QuickCheck.Classes
+    ( boundedEnumLaws, eqLaws, showLaws )
+import Test.QuickCheck.Extra
+    ( shrinkBoundedEnum )
+import Test.Utils.Laws
+    ( testLawsMany )
 
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Gen as Cardano
@@ -75,6 +83,15 @@ import qualified Data.Map as Map
 
 spec :: Spec
 spec = do
+
+    describe "AnyRecentEra" $ do
+        describe "Class instances obey laws" $ do
+            testLawsMany @AnyRecentEra
+                [ boundedEnumLaws
+                , eqLaws
+                , showLaws
+                ]
+
     describe "BinaryData" $ do
         it "BinaryData is isomorphic to Cardano.ScriptData" $
             testIsomorphism
@@ -264,6 +281,14 @@ testIsomorphism (NamedFun f fName) (NamedFun g gName) normalize =
             (gName <> " . " <> gName <> " == id")
             (property $ \x -> g (f x) === x)
         ]
+
+--------------------------------------------------------------------------------
+-- Arbitrary instances
+--------------------------------------------------------------------------------
+
+instance Arbitrary AnyRecentEra where
+    arbitrary = arbitraryBoundedEnum
+    shrink = shrinkBoundedEnum
 
 --------------------------------------------------------------------------------
 -- Test Data

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -4737,16 +4737,27 @@ x-errBadRequest: &errBadRequest
       type: string
       enum: ['bad_request']
 
-x-errBalanceTxEraNotSupported: &errBalanceTxEraNotSupported
+x-errNodeNotYetInRecentEra: &errNodeNotYetInRecentEra
   <<: *responsesErr
-  title: balance_tx_era_not_supported
+  title: node_not_yet_in_recent_era
+  description: Occurs when the operation requires the node to be in a recent era, but is not.
   properties:
     message:
       type: string
-      description: Balancing transactions is not supported in this era.
     code:
       type: string
-      enum: ["balance_tx_era_not_supported"]
+      enum: ['node_not_yet_in_recent_era']
+    info:
+      type: object
+      required:
+        - node_era
+        - recent_eras
+      properties:
+          node_era: *ApiEra
+          recent_eras:
+            type: array
+            items: *ApiEra
+
 
 x-errBalanceTxConflictingNetworks: &errBalanceTxConflictingNetworks
   <<: *responsesErr
@@ -6177,7 +6188,7 @@ x-responsesBalanceTransaction: &responsesBalanceTransaction
         schema:
           oneOf:
             - <<: *errAlreadyWithdrawing
-            - <<: *errBalanceTxEraNotSupported
+            - <<: *errNodeNotYetInRecentEra
             - <<: *errBalanceTxConflictingNetworks
             - <<: *errBalanceTxExistingCollateral
             - <<: *errBalanceTxExistingKeyWitnesses

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -4758,6 +4758,16 @@ x-errNodeNotYetInRecentEra: &errNodeNotYetInRecentEra
             type: array
             items: *ApiEra
 
+x-errTxNotInNodeEra: &errTxNotInNodeEra
+  <<: *responsesErr
+  title: tx_not_in_node_era
+  properties:
+    message:
+      type: string
+      description: The transaction could be deserialised, just not in the era of the local node.
+    code:
+      type: string
+      enum: ["tx_not_in_node_era"]
 
 x-errBalanceTxConflictingNetworks: &errBalanceTxConflictingNetworks
   <<: *responsesErr
@@ -6202,6 +6212,7 @@ x-responsesBalanceTransaction: &responsesBalanceTransaction
             - <<: *errTransactionAlreadyBalanced
             - <<: *errTransactionIsTooBig
             - <<: *errUtxoTooSmall
+            - <<: *errTxNotInNodeEra
 
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406


### PR DESCRIPTION
- [x] Always balance transactions in the era of the local node tip

### Comments

Previously we used to leverage the conversion between `Cardano.ProtocolParameters` and `Ledger.PParams era` to potentially "upcast" the current protocol parameters to `Ledger.PParams` to a newer era.

This may have been useful for testing features in new eras on mainnet before a HF, even if the resulting txs would have been unsubmittable. Instead of doing this one can test on a public testnet, local cluster or on the unit level.

### Issue Number

ADP-2990