### PR TITLE
Simplify `Selection{Constraints,Params}`.

### DIFF
--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -285,9 +285,6 @@ data SelectionParams = SelectionParams
     , certificateDepositsTaken
         :: !Natural
         -- ^ Number of deposits for stake key registrations.
-    , certificateDepositsReturned
-        :: !Natural
-        -- ^ Number of deposits from stake key de-registrations.
     , collateralRequirement
         :: !SelectionCollateralRequirement
         -- ^ Specifies the collateral requirement for this selection.
@@ -320,6 +317,7 @@ toInternalSelectionParams SelectionParams {..} =
             Map.mapMaybeWithKey identifyCollateral utxoAvailableForCollateral
         , outputsToCover =
             (view #address &&& view #tokens) <$> outputsToCover
+        , certificateDepositsReturned = 0
         , ..
         }
   where

--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -282,9 +282,6 @@ data SelectionParams = SelectionParams
     , outputsToCover
         :: ![TxOut]
         -- ^ Specifies a set of outputs that must be paid for.
-    , certificateDepositsTaken
-        :: !Natural
-        -- ^ Number of deposits for stake key registrations.
     , collateralRequirement
         :: !SelectionCollateralRequirement
         -- ^ Specifies the collateral requirement for this selection.
@@ -317,6 +314,7 @@ toInternalSelectionParams SelectionParams {..} =
             Map.mapMaybeWithKey identifyCollateral utxoAvailableForCollateral
         , outputsToCover =
             (view #address &&& view #tokens) <$> outputsToCover
+        , certificateDepositsTaken = 0
         , ..
         }
   where

--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -217,10 +217,6 @@ data SelectionConstraints = SelectionConstraints
         -- what can be included in a transaction output. See documentation for
         -- the 'TokenBundleSizeAssessor' type to learn about the expected
         -- properties of this field.
-    , certificateDepositAmount
-        :: Coin
-        -- ^ Amount that should be taken from/returned back to the wallet for
-        -- each stake key registration/de-registration in the transaction.
     , computeMinimumAdaQuantity
         :: Address -> TokenMap -> Coin
         -- ^ Computes the minimum ada quantity required for a given output.

--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -317,7 +317,6 @@ toInternalSelectionParams SelectionParams {..} =
             Map.mapMaybeWithKey identifyCollateral utxoAvailableForCollateral
         , outputsToCover =
             (view #address &&& view #tokens) <$> outputsToCover
-        , certificateDepositsReturned = 0
         , ..
         }
   where

--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -282,9 +282,6 @@ data SelectionParams = SelectionParams
     , outputsToCover
         :: ![TxOut]
         -- ^ Specifies a set of outputs that must be paid for.
-    , rewardWithdrawal
-        :: !Coin
-        -- ^ Specifies the value of a withdrawal from a reward account.
     , certificateDepositsTaken
         :: !Natural
         -- ^ Number of deposits for stake key registrations.
@@ -323,6 +320,8 @@ toInternalSelectionParams SelectionParams {..} =
             Map.mapMaybeWithKey identifyCollateral utxoAvailableForCollateral
         , outputsToCover =
             (view #address &&& view #tokens) <$> outputsToCover
+        , rewardWithdrawal =
+            Coin 0
         , ..
         }
   where

--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -320,8 +320,6 @@ toInternalSelectionParams SelectionParams {..} =
             Map.mapMaybeWithKey identifyCollateral utxoAvailableForCollateral
         , outputsToCover =
             (view #address &&& view #tokens) <$> outputsToCover
-        , rewardWithdrawal =
-            Coin 0
         , ..
         }
   where

--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -314,7 +314,6 @@ toInternalSelectionParams SelectionParams {..} =
             Map.mapMaybeWithKey identifyCollateral utxoAvailableForCollateral
         , outputsToCover =
             (view #address &&& view #tokens) <$> outputsToCover
-        , certificateDepositsTaken = 0
         , ..
         }
   where

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -205,9 +205,6 @@ data SelectionParams ctx = SelectionParams
     , outputsToCover
         :: ![(Address ctx, TokenBundle)]
         -- ^ Specifies a set of outputs that must be paid for.
-    , rewardWithdrawal
-        :: !Coin
-        -- ^ Specifies the value of a withdrawal from a reward account.
     , certificateDepositsTaken
         :: !Natural
         -- ^ Number of deposits for stake key registrations.
@@ -452,7 +449,7 @@ toBalanceConstraintsParams (constraints, params) =
         , assetsToMint =
             view #assetsToMint params
         , extraCoinSource =
-            view #rewardWithdrawal params <> view #extraCoinIn params <>
+            view #extraCoinIn params <>
             mtimesDefault
                 (view #certificateDepositsReturned params)
                 (view #certificateDepositAmount constraints)

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -150,10 +150,6 @@ data SelectionConstraints ctx = SelectionConstraints
         -- what can be included in a transaction output. See documentation for
         -- the 'TokenBundleSizeAssessor' type to learn about the expected
         -- properties of this field.
-    , certificateDepositAmount
-        :: Coin
-        -- ^ Amount that should be taken from/returned back to the wallet for
-        -- each stake key registration/de-registration in the transaction.
     , computeMinimumAdaQuantity
         :: Address ctx -> TokenMap -> Coin
         -- ^ Computes the minimum ada quantity required for a given output.

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -205,9 +205,6 @@ data SelectionParams ctx = SelectionParams
     , outputsToCover
         :: ![(Address ctx, TokenBundle)]
         -- ^ Specifies a set of outputs that must be paid for.
-    , certificateDepositsTaken
-        :: !Natural
-        -- ^ Number of deposits for stake key registrations.
     , collateralRequirement
         :: !SelectionCollateralRequirement
         -- ^ Specifies the collateral requirement for this selection.
@@ -447,10 +444,8 @@ toBalanceConstraintsParams (constraints, params) =
             view #assetsToMint params
         , extraCoinSource =
             view #extraCoinIn params
-        , extraCoinSink = view #extraCoinOut params <>
-            mtimesDefault
-                (view #certificateDepositsTaken params)
-                (view #certificateDepositAmount constraints)
+        , extraCoinSink =
+            view #extraCoinOut params
         , outputsToCover =
             view #outputsToCover params
         , utxoAvailable =

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -208,9 +208,6 @@ data SelectionParams ctx = SelectionParams
     , certificateDepositsTaken
         :: !Natural
         -- ^ Number of deposits for stake key registrations.
-    , certificateDepositsReturned
-        :: !Natural
-        -- ^ Number of deposits from stake key de-registrations.
     , collateralRequirement
         :: !SelectionCollateralRequirement
         -- ^ Specifies the collateral requirement for this selection.
@@ -449,10 +446,7 @@ toBalanceConstraintsParams (constraints, params) =
         , assetsToMint =
             view #assetsToMint params
         , extraCoinSource =
-            view #extraCoinIn params <>
-            mtimesDefault
-                (view #certificateDepositsReturned params)
-                (view #certificateDepositAmount constraints)
+            view #extraCoinIn params
         , extraCoinSink = view #extraCoinOut params <>
             mtimesDefault
                 (view #certificateDepositsTaken params)

--- a/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
@@ -632,7 +632,6 @@ genSelectionParams = SelectionParams
     <*> genExtraCoinOut
     <*> genOutputsToCover
     <*> genCertificateDepositsTaken
-    <*> genCertificateDepositsReturned
     <*> genCollateralRequirement
     <*> genUTxOAvailableForCollateral
     <*> genUTxOAvailableForInputs
@@ -648,7 +647,6 @@ shrinkSelectionParams = genericRoundRobinShrink
     <:> shrinkExtraCoinOut
     <:> shrinkOutputsToCover
     <:> shrinkCerticateDepositsTaken
-    <:> shrinkCerticateDepositsReturned
     <:> shrinkCollateralRequirement
     <:> shrinkUTxOAvailableForCollateral
     <:> shrinkUTxOAvailableForInputs
@@ -763,14 +761,8 @@ tokenBundleHasNonZeroCoin b = TokenBundle.getCoin b /= Coin 0
 genCertificateDepositsTaken :: Gen Natural
 genCertificateDepositsTaken = chooseNatural (0, 3)
 
-genCertificateDepositsReturned :: Gen Natural
-genCertificateDepositsReturned = chooseNatural (0, 3)
-
 shrinkCerticateDepositsTaken :: Natural -> [Natural]
 shrinkCerticateDepositsTaken = shrinkNatural
-
-shrinkCerticateDepositsReturned :: Natural -> [Natural]
-shrinkCerticateDepositsReturned = shrinkNatural
 
 --------------------------------------------------------------------------------
 -- Collateral requirements

--- a/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
@@ -479,8 +479,6 @@ unitTests_computeMinimumCollateral = unitTests
 data MockSelectionConstraints = MockSelectionConstraints
     { assessTokenBundleSize
         :: MockAssessTokenBundleSize
-    , certificateDepositAmount
-        :: Coin
     , computeMinimumAdaQuantity
         :: MockComputeMinimumAdaQuantity
     , computeMinimumCost
@@ -499,7 +497,6 @@ data MockSelectionConstraints = MockSelectionConstraints
 genMockSelectionConstraints :: Gen MockSelectionConstraints
 genMockSelectionConstraints = MockSelectionConstraints
     <$> genMockAssessTokenBundleSize
-    <*> genCertificateDepositAmount
     <*> genMockComputeMinimumAdaQuantity
     <*> genMockComputeMinimumCost
     <*> genMaximumCollateralInputCount
@@ -511,7 +508,6 @@ shrinkMockSelectionConstraints
     :: MockSelectionConstraints -> [MockSelectionConstraints]
 shrinkMockSelectionConstraints = genericRoundRobinShrink
     <@> shrinkMockAssessTokenBundleSize
-    <:> shrinkCertificateDepositAmount
     <:> shrinkMockComputeMinimumAdaQuantity
     <:> shrinkMockComputeMinimumCost
     <:> shrinkMaximumCollateralInputCount
@@ -525,8 +521,6 @@ unMockSelectionConstraints
 unMockSelectionConstraints m = SelectionConstraints
     { assessTokenBundleSize =
         unMockAssessTokenBundleSize $ view #assessTokenBundleSize m
-    , certificateDepositAmount =
-        view #certificateDepositAmount m
     , computeMinimumAdaQuantity =
         unMockComputeMinimumAdaQuantity $ view #computeMinimumAdaQuantity m
     , isBelowMinimumAdaQuantity =
@@ -546,16 +540,6 @@ unMockSelectionConstraints m = SelectionConstraints
     , nullAddress =
         TestAddress 0x0
     }
-
---------------------------------------------------------------------------------
--- Certificate deposit amounts
---------------------------------------------------------------------------------
-
-genCertificateDepositAmount :: Gen Coin
-genCertificateDepositAmount = genCoinPositive
-
-shrinkCertificateDepositAmount :: Coin -> [Coin]
-shrinkCertificateDepositAmount = shrinkCoinPositive
 
 --------------------------------------------------------------------------------
 -- Minimum ada quantities

--- a/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
@@ -631,7 +631,6 @@ genSelectionParams = SelectionParams
     <*> genExtraCoinIn
     <*> genExtraCoinOut
     <*> genOutputsToCover
-    <*> genRewardWithdrawal
     <*> genCertificateDepositsTaken
     <*> genCertificateDepositsReturned
     <*> genCollateralRequirement
@@ -648,7 +647,6 @@ shrinkSelectionParams = genericRoundRobinShrink
     <:> shrinkExtraCoinIn
     <:> shrinkExtraCoinOut
     <:> shrinkOutputsToCover
-    <:> shrinkRewardWithdrawal
     <:> shrinkCerticateDepositsTaken
     <:> shrinkCerticateDepositsReturned
     <:> shrinkCollateralRequirement
@@ -757,16 +755,6 @@ shrinkOutputsToCover = shrinkList shrinkOutput
 
 tokenBundleHasNonZeroCoin :: TokenBundle -> Bool
 tokenBundleHasNonZeroCoin b = TokenBundle.getCoin b /= Coin 0
-
---------------------------------------------------------------------------------
--- Reward withdrawals
---------------------------------------------------------------------------------
-
-genRewardWithdrawal :: Gen Coin
-genRewardWithdrawal = genCoin
-
-shrinkRewardWithdrawal :: Coin -> [Coin]
-shrinkRewardWithdrawal = shrinkCoin
 
 --------------------------------------------------------------------------------
 -- Certificate deposits taken and returned

--- a/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
@@ -631,7 +631,6 @@ genSelectionParams = SelectionParams
     <*> genExtraCoinIn
     <*> genExtraCoinOut
     <*> genOutputsToCover
-    <*> genCertificateDepositsTaken
     <*> genCollateralRequirement
     <*> genUTxOAvailableForCollateral
     <*> genUTxOAvailableForInputs
@@ -646,7 +645,6 @@ shrinkSelectionParams = genericRoundRobinShrink
     <:> shrinkExtraCoinIn
     <:> shrinkExtraCoinOut
     <:> shrinkOutputsToCover
-    <:> shrinkCerticateDepositsTaken
     <:> shrinkCollateralRequirement
     <:> shrinkUTxOAvailableForCollateral
     <:> shrinkUTxOAvailableForInputs
@@ -753,16 +751,6 @@ shrinkOutputsToCover = shrinkList shrinkOutput
 
 tokenBundleHasNonZeroCoin :: TokenBundle -> Bool
 tokenBundleHasNonZeroCoin b = TokenBundle.getCoin b /= Coin 0
-
---------------------------------------------------------------------------------
--- Certificate deposits taken and returned
---------------------------------------------------------------------------------
-
-genCertificateDepositsTaken :: Gen Natural
-genCertificateDepositsTaken = chooseNatural (0, 3)
-
-shrinkCerticateDepositsTaken :: Natural -> [Natural]
-shrinkCerticateDepositsTaken = shrinkNatural
 
 --------------------------------------------------------------------------------
 -- Collateral requirements

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -1028,7 +1028,6 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             -- We don't use the following 3 fields because certs and
             -- withdrawals are already included in the balance (passed in
             -- above).
-            , certificateDepositsReturned = 0
             , certificateDepositsTaken = 0
 
             -- NOTE: It is important that coin selection has the correct

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -1028,7 +1028,6 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             -- We don't use the following 3 fields because certs and
             -- withdrawals are already included in the balance (passed in
             -- above).
-            , rewardWithdrawal = W.Coin 0
             , certificateDepositsReturned = 0
             , certificateDepositsTaken = 0
 

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -1024,12 +1024,6 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 <> adaInOutputs
                 <> fromCardanoLovelace fee0
             , extraCoinOut = negativeAda <> adaInInputs
-
-            -- We don't use the following 3 fields because certs and
-            -- withdrawals are already included in the balance (passed in
-            -- above).
-            , certificateDepositsTaken = 0
-
             -- NOTE: It is important that coin selection has the correct
             -- notion of fees, because it will be used to tell how much
             -- collateral is needed.

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -968,9 +968,6 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 $ case recentEra @era of
                     RecentEraBabbage -> pp ^. #_maxValSize
                     RecentEraConway -> pp ^. #_maxValSize
-            , certificateDepositAmount = W.toWallet $ case recentEra @era of
-                RecentEraBabbage -> getField @"_keyDeposit" pp
-                RecentEraConway -> getField @"_keyDeposit" pp
             , computeMinimumAdaQuantity = \addr tokens -> W.toWallet $
                 computeMinimumCoinForTxOut
                     (recentEra @era)


### PR DESCRIPTION
## Issue

ADP-3033

## Summary

This PR:
- removes the following fields from `SelectionParams`:
   - `rewardWithdrawal`
   - `certificateDepositsReturned`
   - `certificateDepositsTaken`
- removes the following newly-redundant field from `SelectionConstraints`:
   - `certificateDepositAmount`
- removes all the corresponding generators and shrinkers for these fields.

## Context

The following fields of `SelectionParams` are not used by `balanceTransaction`, and are always set to `0`:
   - `rewardWithdrawal`
   - `certificateDepositsReturned`
   - `certificateDepositsTaken`

Since:
- the `balanceTransaction` function already handles deposits and withdrawals.
- all wallet endpoints requiring coin selection now use `balanceTransaction`.

There's no longer a need for the coin selection library to handle deposits and withdrawals.

Therefore, we can simply remove these fields from the coin selection library.