### PR TITLE
Tweak generators for 8x speedup of balanceTx property

### DIFF
--- a/lib/wallet/src/Cardano/Api/Gen.hs
+++ b/lib/wallet/src/Cardano/Api/Gen.hs
@@ -1058,18 +1058,20 @@ genCostModels = do
 genExecutionUnitPrices :: Gen ExecutionUnitPrices
 genExecutionUnitPrices = ExecutionUnitPrices <$> genRational <*> genRational
 
--- | Dummy value for suitable for being included in the pre-image of the script
+-- | Dummy value suitable for being included in the pre-image of the script
 -- integrity hash.
 {-# NOINLINE protocolParametersForHashing #-}
 protocolParametersForHashing :: ProtocolParameters
-protocolParametersForHashing = generateWith (GenSeed 0) genSizeDefault
-    genRecentEraProtocolParameters
+protocolParametersForHashing =
+    generateWith (GenSeed 0) genSizeDefault
+        genRecentEraProtocolParameters
 
--- | With 'Just' as necessary to be convertible to @Ledger.PParams era@
+-- | Generates a set of protocol parameters for a recent era.
+--
+-- Uses 'Just' as necessary to be convertible to @Ledger.PParams era@
 -- for 'IsRecentEra' eras, and keep our tests from throwing exceptions.
 genRecentEraProtocolParameters :: Gen ProtocolParameters
-genRecentEraProtocolParameters =
-  ProtocolParameters
+genRecentEraProtocolParameters = ProtocolParameters
     <$> ((,) <$> genNat <*> genNat)
     <*> (Just <$> genRational)
     <*> liftArbitrary genPraosNonce

--- a/lib/wallet/src/Cardano/Api/Gen.hs
+++ b/lib/wallet/src/Cardano/Api/Gen.hs
@@ -38,7 +38,6 @@ module Cardano.Api.Gen
     , genPlutusScript
     , genPolicyId
     , genPoolId
-    , genProtocolParameters
     , genProtocolParametersUpdate
     , genPtr
     , genRational
@@ -1057,35 +1056,6 @@ genCostModels = do
 genExecutionUnitPrices :: Gen ExecutionUnitPrices
 genExecutionUnitPrices = ExecutionUnitPrices <$> genRational <*> genRational
 
-genProtocolParameters :: Gen ProtocolParameters
-genProtocolParameters =
-  ProtocolParameters
-    <$> ((,) <$> genNat <*> genNat)
-    <*> (Just <$> genRational)
-    <*> liftArbitrary genPraosNonce
-    <*> genNat
-    <*> genNat
-    <*> genNat
-    <*> genNat
-    <*> genNat
-    <*> liftArbitrary genLovelace
-    <*> genLovelace
-    <*> genLovelace
-    <*> genLovelace
-    <*> genEpochNo
-    <*> genNat
-    <*> genRationalInt64
-    <*> genRational
-    <*> genRational
-    <*> liftArbitrary genLovelace
-    <*> genCostModels
-    <*> liftArbitrary genExecutionUnitPrices
-    <*> liftArbitrary genExecutionUnits
-    <*> liftArbitrary genExecutionUnits
-    <*> liftArbitrary genNat
-    <*> liftArbitrary genNat
-    <*> liftArbitrary genNat
-    <*> liftArbitrary genLovelace
 
 genProtocolParametersWithAlonzoScripts :: Gen ProtocolParameters
 genProtocolParametersWithAlonzoScripts =

--- a/lib/wallet/src/Cardano/Api/Gen.hs
+++ b/lib/wallet/src/Cardano/Api/Gen.hs
@@ -1399,9 +1399,9 @@ genUpdateProposal era =
         Nothing ->
             pure TxUpdateProposalNone
         Just supported ->
-            oneof
-                [ pure TxUpdateProposalNone
-                , TxUpdateProposal supported
+            frequency
+                [ (95, pure TxUpdateProposalNone)
+                , (5, TxUpdateProposal supported
                   <$> ( UpdateProposal
                         <$> ( Map.fromList
                               <$> scale (`div` 3) (listOf ( (,)
@@ -1411,6 +1411,7 @@ genUpdateProposal era =
                             )
                         <*> genEpochNo
                       )
+                    )
                 ]
 
 genTxBodyContent :: CardanoEra era -> Gen (TxBodyContent BuildTx era)

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -50,6 +50,7 @@ module Cardano.Wallet.Write.Tx
     , toCardanoUTxO
     , fromCardanoUTxO
     , toCardanoValue
+    , toCardanoLovelace
     , toCardanoTx
 
     -- ** Existential wrapper
@@ -852,6 +853,11 @@ toCardanoValue
     => Core.Value (ShelleyLedgerEra era)
     -> Cardano.Value
 toCardanoValue = withConstraints (recentEra @era) Cardano.fromMaryValue
+
+toCardanoLovelace
+    :: Coin
+    -> Cardano.Lovelace
+toCardanoLovelace = Cardano.fromShelleyLovelace
 
 --------------------------------------------------------------------------------
 -- PParams

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -854,9 +854,7 @@ toCardanoValue
     -> Cardano.Value
 toCardanoValue = withConstraints (recentEra @era) Cardano.fromMaryValue
 
-toCardanoLovelace
-    :: Coin
-    -> Cardano.Lovelace
+toCardanoLovelace :: Coin -> Cardano.Lovelace
 toCardanoLovelace = Cardano.fromShelleyLovelace
 
 --------------------------------------------------------------------------------

--- a/lib/wallet/test/unit/Cardano/Api/GenSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Api/GenSpec.hs
@@ -1642,14 +1642,14 @@ genUpdateProposalCoverage era proposal = checkCoverage
         Just _ ->
             case proposal of
                 TxUpdateProposalNone ->
-                    cover 5 True "no update proposal" True
+                    cover 60 True "no update proposal" True
                 TxUpdateProposal _ (UpdateProposal m _epoch) ->
                     True
-                    & cover 30 True
+                    & cover 3 True
                         "update proposal"
                     & cover 0.4 (null m)
                         "empty protocol updates"
-                    & cover 10 (not $ null m)
+                    & cover 1 (not $ null m)
                         "non-empty protocol updates"
                 _ ->
                     error "uncovered case"


### PR DESCRIPTION
- [x] Rely less on CardanoApi in prop_balanceTransactionValid
- [x] Generate fewer PParam updates in tests
- [x] Use cheaper PParam gen for the sake of hashing

### Comments


`cabal test cardano-wallet:unit --test-options='-j 8 --match "valid transactions or fails"'`

#### This PR

```
Cardano.Wallet.Shelley.Transaction
  balanceTransaction
    produces valid transactions or fails [✔] (11278ms)
      +++ OK, passed 1000 tests:
      100.0% has payment outputs
      55.0% >5 payment outputs
      33.8% >10 payment outputs
       9.6% >20 payment outputs
       9.1% partial tx had zero ada outputs

      49.1% existing total collateral
      26.1% existing collateral return outputs
      10.1% output below minCoinValue
       5.6% missing tokens
       3.9% conflicting networks
       3.1% success
       0.7% missing coin
       0.5% existing collateral
       0.4% maxTxSize limit exceeded
       0.3% missing coin and tokens
       0.1% ReferenceScriptsNotSupported
       0.1% failed with ByronTxOutInContext

Finished in 11.2793 seconds, used 12.2644 seconds of CPU time
1 example, 0 failures
```

#### Master (376280e420)

```
Cardano.Wallet.Shelley.Transaction
  balanceTransaction
    produces valid transactions or fails [✔] (77431ms)
      +++ OK, passed 1000 tests:
      100.0% has payment outputs
      55.8% >5 payment outputs
      35.3% >10 payment outputs
      10.1% partial tx had zero ada outputs
       9.3% >20 payment outputs

      50.9% existing total collateral
      24.9% existing collateral return outputs
      10.8% output below minCoinValue
       4.7% missing tokens
       4.0% conflicting networks
       2.7% success
       1.0% missing coin
       0.5% missing coin and tokens
       0.2% existing collateral
       0.1% failed with ByronTxOutInContext
       0.1% maxTxSize limit exceeded
       0.1% unable to construct change

Finished in 77.4322 seconds, used 84.2236 seconds of CPU time
1 example, 0 failures
```

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
