### PR TITLE
Improve coverage in `balanceTx` `produces valid transactions or fails` property

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -750,6 +750,7 @@ test-suite unit
     , cardano-balance-tx
     , cardano-binary
     , cardano-crypto
+    , set-algebra
     , cardano-crypto-class
     , cardano-crypto-wrapper
     , cardano-ledger-alonzo
@@ -760,6 +761,7 @@ test-suite unit
     , cardano-ledger-core
     , cardano-ledger-shelley
     , cardano-ledger-shelley-ma
+    , validation-selective
     , cardano-ledger-shelley-test
     , cardano-numeric
     , cardano-sl-x509

--- a/lib/wallet/src/Cardano/Api/Gen.hs
+++ b/lib/wallet/src/Cardano/Api/Gen.hs
@@ -422,18 +422,18 @@ genTxTotalCollateral :: CardanoEra era -> Gen (TxTotalCollateral era)
 genTxTotalCollateral era =
     case totalAndReturnCollateralSupportedInEra era of
         Nothing -> pure TxTotalCollateralNone
-        Just supported -> oneof
-            [ pure TxTotalCollateralNone
-            , TxTotalCollateral supported <$> genLovelace
+        Just supported -> frequency
+            [ (90, pure TxTotalCollateralNone)
+            , (10, TxTotalCollateral supported <$> genLovelace)
             ]
 
 genTxReturnCollateral :: CardanoEra era -> Gen (TxReturnCollateral ctx era)
 genTxReturnCollateral era =
     case totalAndReturnCollateralSupportedInEra era of
         Nothing -> pure TxReturnCollateralNone
-        Just supported -> oneof
-            [ pure TxReturnCollateralNone
-            , TxReturnCollateral supported <$> genTxOut era
+        Just supported -> frequency
+            [ (90, pure TxReturnCollateralNone)
+            , (10, TxReturnCollateral supported <$> genTxOut era)
             ]
 
 genPlutusScript :: PlutusScriptVersion lang -> Gen (PlutusScript lang)

--- a/lib/wallet/src/Cardano/Api/Gen.hs
+++ b/lib/wallet/src/Cardano/Api/Gen.hs
@@ -423,8 +423,8 @@ genTxTotalCollateral era =
     case totalAndReturnCollateralSupportedInEra era of
         Nothing -> pure TxTotalCollateralNone
         Just supported -> frequency
-            [ (90, pure TxTotalCollateralNone)
-            , (10, TxTotalCollateral supported <$> genLovelace)
+            [ (50, pure TxTotalCollateralNone)
+            , (50, TxTotalCollateral supported <$> genLovelace)
             ]
 
 genTxReturnCollateral :: CardanoEra era -> Gen (TxReturnCollateral ctx era)
@@ -432,8 +432,8 @@ genTxReturnCollateral era =
     case totalAndReturnCollateralSupportedInEra era of
         Nothing -> pure TxReturnCollateralNone
         Just supported -> frequency
-            [ (90, pure TxReturnCollateralNone)
-            , (10, TxReturnCollateral supported <$> genTxOut era)
+            [ (50, pure TxReturnCollateralNone)
+            , (50, TxReturnCollateral supported <$> genTxOut era)
             ]
 
 genPlutusScript :: PlutusScriptVersion lang -> Gen (PlutusScript lang)

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -82,6 +82,9 @@ module Cardano.Wallet.Write.Tx
     , modifyTxOutputs
     , modifyLedgerBody
     , emptyTx
+    , Babbage.totalCollateralBabbageTxBodyL
+    , Babbage.collateralReturnBabbageTxBodyL
+    , Babbage.collateralInputsBabbageTxBodyL
 
     -- * TxOut
     , Core.TxOut
@@ -105,6 +108,7 @@ module Cardano.Wallet.Write.Tx
     , modifyCoin
     , coin
     , Coin (..)
+    , (<->)
 
     -- ** Datum
     , Datum (..)
@@ -137,6 +141,13 @@ module Cardano.Wallet.Write.Tx
     , Shelley.UTxO (..)
     , utxoFromTxOutsInRecentEra
     , utxoFromTxOuts
+    , Shelley.txins
+    , Shelley.txinLookup
+    , Shelley.txouts
+    , Shelley.balance
+    , Shelley.sumAllValue
+    , Shelley.verifyWitVKey
+    , Shelley.getScriptHash
 
     -- * Balancing
     , evaluateMinimumFee
@@ -175,7 +186,7 @@ import Cardano.Ledger.Serialization
 import Cardano.Ledger.Shelley.API
     ( CLI (evaluateMinLovelaceOutput) )
 import Cardano.Ledger.Val
-    ( coin, modifyCoin )
+    ( Val ((<->)), coin, modifyCoin )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
@@ -282,6 +293,7 @@ type RecentEraLedgerConstraints era =
     , HasField' "_prices" (Core.PParams era) ExUnitPrices
     , HasField' "_maxTxExUnits" (Core.PParams era) ExUnits
     , HasField' "_keyDeposit" (Core.PParams era) Coin
+    , Babbage.BabbageEraTxBody era
     )
 
 -- | Bring useful constraints into scope from a value-level

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -446,7 +446,7 @@ type TxOut era = Core.TxOut era
 
 modifyTxOutValue
     :: RecentEra era
-    -> (MaryValue StandardCrypto -> MaryValue StandardCrypto)
+    -> (Value -> Value)
     -> TxOut (ShelleyLedgerEra era)
     -> TxOut (ShelleyLedgerEra era)
 modifyTxOutValue RecentEraConway f (BabbageTxOut addr val dat script) =
@@ -473,7 +473,7 @@ type TxOutInBabbage = Babbage.BabbageTxOut (Babbage.BabbageEra StandardCrypto)
 type Address = Ledger.Addr StandardCrypto
 
 type Script = AlonzoScript
-type Value = MaryValue
+type Value = MaryValue StandardCrypto
 
 unsafeAddressFromBytes :: ByteString -> Address
 unsafeAddressFromBytes bytes = case Ledger.deserialiseAddr bytes of


### PR DESCRIPTION
- [x] Tweak generators to generate fewer txs with total collateral and collateral return
    - Brings `success` coverage from 3% to 10%
    - Reduces `existing total collateral` from 50% to 10%
    - Reduces `existing collateral return outputs` from 26% to 9% 

Now:

```
    Cardano.Wallet.Shelley.Transaction
      balanceTransaction
        produces valid transactions or fails [?] (11248ms)
          +++ OK, passed 1000 tests:
          100.0% has payment outputs
          54.6% >5 payment outputs
          32.4% >10 payment outputs
          10.1% partial tx had zero ada outputs
           9.6% >20 payment outputs

          31.9% output below minCoinValue
          16.3% missing tokens
          15.0% conflicting networks
    ====> 10.1% success
           9.9% existing total collateral
           8.5% existing collateral return outputs
           3.4% missing coin
           2.2% missing coin and tokens
           1.6% maxTxSize limit exceeded
           0.5% existing collateral
           0.4% failed with ByronTxOutInContext
           0.1% ReferenceScriptsNotSupported
           0.1% unable to construct change

    Finished in 11.2487 seconds, used 12.2860 seconds of CPU time
```

Previously:

```
    Cardano.Wallet.Shelley.Transaction
      balanceTransaction
        produces valid transactions or fails [?] (11278ms)
          +++ OK, passed 1000 tests:
          100.0% has payment outputs
          55.0% >5 payment outputs
          33.8% >10 payment outputs
           9.6% >20 payment outputs
           9.1% partial tx had zero ada outputs

          49.1% existing total collateral
          26.1% existing collateral return outputs
          10.1% output below minCoinValue
           5.6% missing tokens
           3.9% conflicting networks
    =====> 3.1% success
           0.7% missing coin
           0.5% existing collateral
           0.4% maxTxSize limit exceeded
           0.3% missing coin and tokens
           0.1% ReferenceScriptsNotSupported
           0.1% failed with ByronTxOutInContext

    Finished in 11.2793 seconds, used 12.2644 seconds of CPU time
    1 example, 0 failures
 ```

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
