### PR TITLE
Refactor: promote `selectAssets` closure to a top-level function.

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -958,8 +958,8 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
     }
 
     selectionParams = SelectionParams
-        -- The following fields are essensially adjusting the coin
-        -- selections notion of balance by @balance0 - sum inputs + sum
+        -- The following fields are essentially adjusting the coin selection
+        -- algorithm's notion of balance by @balance0 - sum inputs + sum
         -- outputs + fee0@ where @balance0@ is the balance of the
         -- partial tx.
         { assetsToMint = positiveTokens <> tokensInOutputs

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -137,6 +137,7 @@ import Cardano.Wallet.Write.Tx
     , feeOfBytes
     , fromCardanoTx
     , fromCardanoUTxO
+    , fromRecentEra
     , getFeePerByte
     , isBelowMinimumCoinForTxOut
     , maxScriptExecutionCost
@@ -220,7 +221,6 @@ import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as W
-import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Data.Foldable as F
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -936,7 +936,7 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
             , fee0
             , txPlutusScriptExecutionCost
             , calculateMinimumFee
-                (Cardano.AnyCardanoEra (Write.fromRecentEra era))
+                (Cardano.AnyCardanoEra (fromRecentEra era))
                 feePerByte
                 txWitnessTag
                 (defaultTransactionCtx
@@ -1011,7 +1011,7 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
 
     boringFee =
         calculateMinimumFee
-            (Cardano.AnyCardanoEra (Write.fromRecentEra era))
+            (Cardano.AnyCardanoEra (fromRecentEra era))
             feePerByte
             txWitnessTag
             defaultTransactionCtx

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -165,7 +165,6 @@ import Data.Bits
     ( Bits )
 import Data.Either
     ( lefts, partitionEithers )
-import qualified Data.Foldable as F
 import Data.Generics.Internal.VL.Lens
     ( over, view, (^.) )
 import Data.Generics.Labels
@@ -221,6 +220,7 @@ import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as W
+import qualified Data.Foldable as F
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 
@@ -836,7 +836,6 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             assignScriptRedeemers
                 pp timeTranslation combinedUTxO redeemers tx'
 
-
     guardConflictingWithdrawalNetworks
         (Cardano.Tx (Cardano.TxBody body) _) = do
         -- Use of withdrawals with different networks breaks balancing.
@@ -931,8 +930,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 txWitnessTag
                 defaultTransactionCtx
                 SelectionSkeleton
-                    { skeletonInputCount =
-                        UTxOSelection.selectedSize utxoSelection
+                { skeletonInputCount = UTxOSelection.selectedSize utxoSelection
                     , skeletonOutputs = outs
                     , skeletonChange = []
                     }
@@ -1033,7 +1031,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             }
 
 data ChangeAddressGen s = ChangeAddressGen
-    { getChangeAddressGen ::  (s -> (W.Address, s))
+    { getChangeAddressGen :: s -> (W.Address, s)
 
     -- | Returns the longest address that the wallet can generate for a given
     --   key.
@@ -1107,4 +1105,3 @@ unsafeIntCast
 unsafeIntCast x = fromMaybe err $ intCastMaybe x
   where
     err = error $ "unsafeIntCast failed for " <> show x
-

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -1021,25 +1021,24 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
                 , skeletonChange = []
                 }
 
-    feePadding =
-        let
-            -- Could be made smarter by only padding for the script
-            -- integrity hash when we intend to add one. [ADP-2621]
-            scriptIntegrityHashBytes = 32 + 2
+    feePadding
+        = W.toWallet . feeOfBytes feePerByte
+        $ extraBytes + scriptIntegrityHashBytes
+      where
+        -- Could be made smarter by only padding for the script
+        -- integrity hash when we intend to add one. [ADP-2621]
+        scriptIntegrityHashBytes = 32 + 2
 
-            -- Add padding to allow the fee value to increase.
-            -- Out of caution, assume it can increase by the theoretical
-            -- maximum of 8 bytes ('maximumCostOfIncreasingCoin').
-            --
-            -- NOTE: It's not convenient to import the constant at the
-            -- moment because of the package split.
-            --
-            -- Any overestimation will be reduced by 'distributeSurplus'
-            -- in the final stage of 'balanceTransaction'.
-            extraBytes = 8
-        in
-            W.toWallet . feeOfBytes feePerByte $
-                    extraBytes + scriptIntegrityHashBytes
+        -- Add padding to allow the fee value to increase.
+        -- Out of caution, assume it can increase by the theoretical
+        -- maximum of 8 bytes ('maximumCostOfIncreasingCoin').
+        --
+        -- NOTE: It's not convenient to import the constant at the
+        -- moment because of the package split.
+        --
+        -- Any overestimation will be reduced by 'distributeSurplus'
+        -- in the final stage of 'balanceTransaction'.
+        extraBytes = 8
 
 data ChangeAddressGen s = ChangeAddressGen
     { getChangeAddressGen :: s -> (W.Address, s)

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -97,7 +97,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx, sealedTxFromCardano )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TxSize (..), txOutMaxCoin )
+    ( TokenBundleSizeAssessor, TxSize (..), txOutMaxCoin )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
 import Cardano.Wallet.Shelley.Compatibility
@@ -209,8 +209,8 @@ import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Byron as Cardano
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Wallet.Primitive.Types.Address as W
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
@@ -220,6 +220,7 @@ import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as W
+import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Data.Foldable as F
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -432,16 +433,15 @@ balanceTransaction
     -> PartialTx era
     -> ExceptT ErrBalanceTx m (Cardano.Tx era, changeState)
 balanceTransaction
-    tr utxoAssumptions pp timeTranslation utxo genChange s unadjustedPtx = do
-    let adjustedPtx = over (#tx)
+    tr utxoAssumptions pp timeTranslation utxo genChange s partialTx = do
+    let adjustedPartialTx = over #tx
             (increaseZeroAdaOutputs (recentEra @era) (pparamsLedger pp))
-            unadjustedPtx
-
+            partialTx
     let balanceWith strategy =
             balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 @era @m @changeState
                 tr utxoAssumptions pp timeTranslation utxo
-                genChange s strategy adjustedPtx
+                genChange s strategy adjustedPartialTx
     balanceWith SelectionStrategyOptimal
         `catchE` \e ->
             if minimalStrategyIsWorthTrying e
@@ -531,7 +531,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     tr
     (UTxOAssumptions txLayer toInpScriptsM mScriptTemplate txWitnessTag)
-    (ProtocolParameters pp)
+    protocolParameters@(ProtocolParameters pp)
     timeTranslation
     (UTxOIndex walletUTxO internalUtxoAvailable cardanoUTxO)
     genChange
@@ -544,8 +544,6 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     guardExistingReturnCollateral partialTx
     guardConflictingWithdrawalNetworks partialTx
     guardWalletUTxOConsistencyWith inputUTxO
-
-    let era = Cardano.anyCardanoEra $ Cardano.cardanoEra @era
 
     (balance0, minfee0, _) <- balanceAfterSettingMinFee partialTx
 
@@ -584,18 +582,24 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 
         externalSelectedUtxo <- extractExternallySelectedUTxO ptx
 
-        let mSel = selectAssets'
-                era
+        let mSel = selectAssets
+                (recentEra @era)
+                protocolParameters
+                txWitnessTag
                 (extractOutputsFromTx partialTx)
+                redeemers
                 (UTxOSelection.fromIndexPair
                     (internalUtxoAvailable, externalSelectedUtxo))
                 balance0
-                minfee0
+                (fromCardanoLovelace minfee0)
                 randomSeed
+                mScriptTemplate
+                genChange
+                selectionStrategy
+                (tokenBundleSizeAssessor txLayer)
 
         case mSel of
-            Left e -> lift $
-                traceWith tr $ MsgSelectionError e
+            Left e -> lift $ traceWith tr $ MsgSelectionError e
             Right sel -> lift $ do
                 traceWith tr $ MsgSelectionReportSummarized
                     $ makeSelectionReportSummarized sel
@@ -661,7 +665,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     let feePerByte = getFeePerByte (recentEra @era) pp
 
     -- @distributeSurplus@ should never fail becase we have provided enough
-    -- padding in @selectAssets'@.
+    -- padding in @selectAssets@.
     TxFeeAndChange updatedFee updatedChange <- withExceptT
         (\(ErrMoreSurplusNeeded c) ->
             ErrBalanceTxInternalError $
@@ -822,13 +826,6 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
            RecentEraBabbage -> W.fromBabbageTxOut o
            RecentEraConway -> W.fromConwayTxOut o
 
-    toLedgerTxOut
-        :: W.TxOut
-        -> TxOut (ShelleyLedgerEra era)
-    toLedgerTxOut o = case recentEra @era of
-         RecentEraBabbage -> W.toBabbageTxOut o
-         RecentEraConway -> W.toConwayTxOut o
-
     assembleTransaction :: TxUpdate -> ExceptT ErrBalanceTx m (Cardano.Tx era)
     assembleTransaction update = ExceptT . pure $ do
         tx' <- left ErrBalanceTxUpdateError $ updateTx partialTx update
@@ -881,154 +878,168 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             Cardano.TxReturnCollateral _ _ ->
                throwE ErrBalanceTxExistingReturnCollateral
 
-    -- | Select assets to cover the specified balance and fee.
-    --
-    -- If the transaction contains redeemers, the function will also ensure the
-    -- selection covers the fees for the maximum allowed execution units of a
-    -- transaction. For this, and other reasons, the selection may include too
-    -- much ada.
-    selectAssets'
-        :: Cardano.AnyCardanoEra
-        -> [W.TxOut]
-        -> UTxOSelection WalletUTxO
-        -- ^ Describes which utxos are pre-selected, and which can be used as
-        -- inputs or collateral.
-        -> Cardano.Value -- Balance to cover
-        -> Cardano.Lovelace -- Current minfee (before selecting assets)
-        -> StdGenSeed
-        -> Either (SelectionError WalletSelectionContext) Selection
-    selectAssets' era outs utxoSelection balance fee0 seed =
-        flip evalRand (stdGenFromSeed seed)
-            $ runExceptT
+    fromCardanoLovelace (Cardano.Lovelace l) = Coin.unsafeFromIntegral l
+
+-- | Select assets to cover the specified balance and fee.
+--
+-- If the transaction contains redeemers, the function will also ensure the
+-- selection covers the fees for the maximum allowed execution units of a
+-- transaction. For this, and other reasons, the selection may include too
+-- much ada.
+selectAssets
+    :: forall era changeState
+     . Cardano.IsCardanoEra era
+    => RecentEra era
+    -> ProtocolParameters era
+    -> TxWitnessTag
+    -> [W.TxOut]
+    -> [Redeemer]
+    -> UTxOSelection WalletUTxO
+    -- ^ Describes which utxos are pre-selected, and which can be used as
+    -- inputs or collateral.
+    -> Cardano.Value -- Balance to cover
+    -> W.Coin -- Current minfee (before selecting assets)
+    -> StdGenSeed
+    -> Maybe ScriptTemplate
+    -> ChangeAddressGen changeState
+    -> SelectionStrategy
+    -> (TokenBundleMaxSize -> TokenBundleSizeAssessor)
+    -- ^ A function to assess the size of a token bundle.
+    -> Either (SelectionError WalletSelectionContext) Selection
+selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
+    utxoSelection balance fee0 seed inputScriptTemplate changeGen
+    selectionStrategy bundleSizeAssessor =
+        (`evalRand` stdGenFromSeed seed) . runExceptT
             $ performSelection selectionConstraints selectionParams
-      where
-        txPlutusScriptExecutionCost = W.toWallet @W.Coin $
-            if null redeemers then
-                mempty
-            else
-                maxScriptExecutionCost (recentEra @era) pp
-
-        colReq =
-            if txPlutusScriptExecutionCost > W.Coin 0
-                then SelectionCollateralRequired
-                else SelectionCollateralNotRequired
-
-        (positiveBundle, negativeBundle) = posAndNegFromCardanoValue balance
-        TokenBundle positiveAda positiveTokens = positiveBundle
-        TokenBundle negativeAda negativeTokens = negativeBundle
-        adaInOutputs = F.foldMap (TokenBundle.getCoin . view #tokens) outs
-        tokensInOutputs = F.foldMap (TokenBundle.tokens . view #tokens) outs
-        TokenBundle adaInInputs tokensInInputs =
-            UTxOSelection.selectedBalance utxoSelection
-
-        feePerByte = getFeePerByte (recentEra @era) pp
-
-        boringFee =
-            calculateMinimumFee
+  where
+    selectionConstraints = SelectionConstraints
+        { assessTokenBundleSize =
+            view #assessTokenBundleSize
+            $ bundleSizeAssessor
+            $ TokenBundleMaxSize
+            $ TxSize
+            $ case era of
+                RecentEraBabbage -> pp ^. #_maxValSize
+                RecentEraConway -> pp ^. #_maxValSize
+        , computeMinimumAdaQuantity = \addr tokens -> W.toWallet $
+            computeMinimumCoinForTxOut
                 era
+                pp
+                (mkLedgerTxOut era addr (TokenBundle txOutMaxCoin tokens))
+        , isBelowMinimumAdaQuantity = \addr bundle ->
+            isBelowMinimumCoinForTxOut
+                era
+                pp
+                (mkLedgerTxOut era addr bundle)
+        , computeMinimumCost = \skeleton -> mconcat
+            [ feePadding
+            , fee0
+            , txPlutusScriptExecutionCost
+            , calculateMinimumFee
+                (Cardano.AnyCardanoEra (Write.fromRecentEra era))
                 feePerByte
                 txWitnessTag
-                defaultTransactionCtx
-                SelectionSkeleton
+                (defaultTransactionCtx
+                    { txPaymentCredentialScriptTemplate = inputScriptTemplate })
+                skeleton
+            ] `Coin.difference` boringFee
+        , maximumCollateralInputCount = unsafeIntCast @Natural @Int $
+            case era of
+                RecentEraBabbage -> getField @"_maxCollateralInputs" pp
+                RecentEraConway -> getField @"_maxCollateralInputs" pp
+
+    , minimumCollateralPercentage =
+        case era of
+            -- case-statement avoids "Overlapping instances" problem.
+            -- May be avoidable with ADP-2353.
+            RecentEraBabbage -> getField @"_collateralPercentage" pp
+            RecentEraConway -> getField @"_collateralPercentage" pp
+    , maximumLengthChangeAddress = maxLengthChangeAddress changeGen
+    }
+
+    selectionParams = SelectionParams
+        -- The following fields are essensially adjusting the coin
+        -- selections notion of balance by @balance0 - sum inputs + sum
+        -- outputs + fee0@ where @balance0@ is the balance of the
+        -- partial tx.
+        { assetsToMint = positiveTokens <> tokensInOutputs
+        , assetsToBurn = negativeTokens <> tokensInInputs
+        , extraCoinIn = positiveAda <> adaInOutputs <> fee0
+        , extraCoinOut = negativeAda <> adaInInputs
+
+        -- NOTE: It is important that coin selection has the correct
+        -- notion of fees, because it will be used to tell how much
+        -- collateral is needed.
+        , collateralRequirement
+        , outputsToCover = outs
+        , utxoAvailableForCollateral = UTxOSelection.availableMap utxoSelection
+        , utxoAvailableForInputs = utxoSelection
+        , selectionStrategy = selectionStrategy
+        }
+
+    mkLedgerTxOut
+        :: RecentEra era
+        -> W.Address
+        -> TokenBundle
+        -> TxOut (ShelleyLedgerEra era)
+    mkLedgerTxOut txOutEra address bundle =
+        case txOutEra of
+            RecentEraBabbage -> W.toBabbageTxOut txOut
+            RecentEraConway -> W.toConwayTxOut txOut
+          where
+            txOut = W.TxOut address bundle
+
+    txPlutusScriptExecutionCost = W.toWallet @W.Coin $
+        if null redeemers
+            then mempty
+            else maxScriptExecutionCost era pp
+
+    collateralRequirement =
+        if txPlutusScriptExecutionCost > W.Coin 0
+            then SelectionCollateralRequired
+            else SelectionCollateralNotRequired
+
+    (positiveBundle, negativeBundle) = posAndNegFromCardanoValue balance
+    TokenBundle positiveAda positiveTokens = positiveBundle
+    TokenBundle negativeAda negativeTokens = negativeBundle
+    adaInOutputs = F.foldMap (TokenBundle.getCoin . view #tokens) outs
+    tokensInOutputs = F.foldMap (TokenBundle.tokens . view #tokens) outs
+    TokenBundle adaInInputs tokensInInputs =
+        UTxOSelection.selectedBalance utxoSelection
+
+    feePerByte = getFeePerByte era pp
+
+    boringFee =
+        calculateMinimumFee
+            (Cardano.AnyCardanoEra (Write.fromRecentEra era))
+            feePerByte
+            txWitnessTag
+            defaultTransactionCtx
+            SelectionSkeleton
                 { skeletonInputCount = UTxOSelection.selectedSize utxoSelection
-                    , skeletonOutputs = outs
-                    , skeletonChange = []
-                    }
+                , skeletonOutputs = outs
+                , skeletonChange = []
+                }
 
-        feePadding =
-            let
-                -- Could be made smarter by only padding for the script
-                -- integrity hash when we intend to add one. [ADP-2621]
-                scriptIntegrityHashBytes = 32 + 2
+    feePadding =
+        let
+            -- Could be made smarter by only padding for the script
+            -- integrity hash when we intend to add one. [ADP-2621]
+            scriptIntegrityHashBytes = 32 + 2
 
-                -- Add padding to allow the fee value to increase.
-                -- Out of caution, assume it can increase by the theoretical
-                -- maximum of 8 bytes ('maximumCostOfIncreasingCoin').
-                --
-                -- NOTE: It's not convenient to import the constant at the
-                -- moment because of the package split.
-                --
-                -- Any overestimation will be reduced by 'distributeSurplus'
-                -- in the final stage of 'balanceTransaction'.
-                extraBytes = 8
-            in
-                W.toWallet . feeOfBytes feePerByte $
+            -- Add padding to allow the fee value to increase.
+            -- Out of caution, assume it can increase by the theoretical
+            -- maximum of 8 bytes ('maximumCostOfIncreasingCoin').
+            --
+            -- NOTE: It's not convenient to import the constant at the
+            -- moment because of the package split.
+            --
+            -- Any overestimation will be reduced by 'distributeSurplus'
+            -- in the final stage of 'balanceTransaction'.
+            extraBytes = 8
+        in
+            W.toWallet . feeOfBytes feePerByte $
                     extraBytes + scriptIntegrityHashBytes
-
-        fromCardanoLovelace (Cardano.Lovelace l) = Coin.unsafeFromIntegral l
-
-        selectionConstraints = SelectionConstraints
-            { assessTokenBundleSize =
-                view #assessTokenBundleSize
-                $ tokenBundleSizeAssessor txLayer
-                $ TokenBundleMaxSize
-                $ TxSize
-                $ case recentEra @era of
-                    RecentEraBabbage -> pp ^. #_maxValSize
-                    RecentEraConway -> pp ^. #_maxValSize
-            , computeMinimumAdaQuantity = \addr tokens -> W.toWallet $
-                computeMinimumCoinForTxOut
-                    (recentEra @era)
-                    pp
-                    (toLedgerTxOut $ W.TxOut addr (TokenBundle txOutMaxCoin tokens))
-            , isBelowMinimumAdaQuantity = \addr bundle ->
-                isBelowMinimumCoinForTxOut
-                    (recentEra @era)
-                    pp
-                    (toLedgerTxOut $ W.TxOut addr bundle)
-            , computeMinimumCost = \skeleton -> mconcat
-                [ feePadding
-                , fromCardanoLovelace fee0
-                , txPlutusScriptExecutionCost
-                , calculateMinimumFee
-                    era
-                    feePerByte
-                    txWitnessTag
-                    (defaultTransactionCtx
-                        { txPaymentCredentialScriptTemplate = mScriptTemplate
-                        })
-                    skeleton
-                ] `Coin.difference` boringFee
-            , maximumCollateralInputCount = unsafeIntCast @Natural @Int $
-                case recentEra @era of
-                    RecentEraBabbage ->
-                        getField @"_maxCollateralInputs" pp
-                    RecentEraConway ->
-                        getField @"_maxCollateralInputs" pp
-
-            , minimumCollateralPercentage = case recentEra @era of
-                -- case-statement avoids "Overlapping instances" problem.
-                -- May be avoidable with ADP-2353.
-                RecentEraBabbage ->
-                    getField @"_collateralPercentage" pp
-                RecentEraConway ->
-                    getField @"_collateralPercentage" pp
-            , maximumLengthChangeAddress =
-                maxLengthChangeAddress genChange
-            }
-
-        selectionParams = SelectionParams
-            -- The following fields are essensially adjusting the coin
-            -- selections notion of balance by @balance0 - sum inputs + sum
-            -- outputs + fee0@ where @balance0@ is the balance of the
-            -- partial tx.
-            { assetsToMint = positiveTokens <> tokensInOutputs
-            , assetsToBurn = negativeTokens <> tokensInInputs
-            , extraCoinIn =
-                positiveAda
-                <> adaInOutputs
-                <> fromCardanoLovelace fee0
-            , extraCoinOut = negativeAda <> adaInInputs
-            -- NOTE: It is important that coin selection has the correct
-            -- notion of fees, because it will be used to tell how much
-            -- collateral is needed.
-            , collateralRequirement = colReq
-            , outputsToCover = outs
-            , utxoAvailableForCollateral =
-                UTxOSelection.availableMap utxoSelection
-            , utxoAvailableForInputs = utxoSelection
-            , selectionStrategy = selectionStrategy
-            }
 
 data ChangeAddressGen s = ChangeAddressGen
     { getChangeAddressGen :: s -> (W.Address, s)


### PR DESCRIPTION
By promoting `selectAssets` to a top level we make it movable to a separate module (potentially), and testable on its own with its own property.
 
### Comments

It was originally published and reviewed here https://github.com/input-output-hk/cardano-wallet/pull/3911 but I am splitting it into a separate PR.

### Issue Number

ADP-2967
