### PR TITLE
Suggestions for PR 3928.

### DIFF
--- a/lib/wallet/src/Cardano/Api/Gen.hs
+++ b/lib/wallet/src/Cardano/Api/Gen.hs
@@ -201,7 +201,7 @@ import Test.QuickCheck
     , vectorOf
     )
 import Test.QuickCheck.Extra
-    ( GenSeed (..), GenSize (..), generateWith )
+    ( GenSeed (..), genSizeDefault, generateWith )
 import Test.QuickCheck.Hedgehog
     ( hedgehog )
 import Test.QuickCheck.Instances.ByteString
@@ -1073,7 +1073,9 @@ protocolParametersForHashing =
     generateWithSeed <$> [0 .. 50]
   where
     generateWithSeed seed =
-        generateWith (GenSeed seed) (GenSize 30) genRecentEraProtocolParameters
+        generateWith (GenSeed seed)
+            genSizeDefault
+            genRecentEraProtocolParameters
 
     -- | With 'Just' as necessary to be convertible to @Ledger.PParams era@
     -- for 'IsRecentEra' eras, and keep our tests from throwing exceptions.

--- a/lib/wallet/src/Cardano/Api/Gen.hs
+++ b/lib/wallet/src/Cardano/Api/Gen.hs
@@ -1058,24 +1058,22 @@ genCostModels = do
 genExecutionUnitPrices :: Gen ExecutionUnitPrices
 genExecutionUnitPrices = ExecutionUnitPrices <$> genRational <*> genRational
 
--- | A generator which only selects between two values for the sake of being
--- fast. This is useful for generating values for @Cardano.TxBodyContent@,
--- which only purpose is being hashed to produce part of the script integrity
--- hash in the transaction.
+-- | A generator which only selects from predefined values for the sake of
+-- being fast.
+--
+-- This is useful for generating values for @Cardano.TxBodyContent@, which only
+-- purpose is being hashed to produce part of the script integrity hash in the
+-- transaction.
 genProtocolParametersForHashing :: Gen ProtocolParameters
-genProtocolParametersForHashing = elements
-    [ variantA
-    , variantB
-    ]
+genProtocolParametersForHashing = elements protocolParametersForHashing
 
+{-# NOINLINE protocolParametersForHashing #-}
+protocolParametersForHashing :: [ProtocolParameters]
+protocolParametersForHashing =
+    generateWithSeed <$> [0 .. 50]
   where
-    variantA :: ProtocolParameters
-    variantA = generateWith (GenSeed 0) (GenSize 30)
-        genRecentEraProtocolParameters
-
-    variantB :: ProtocolParameters
-    variantB = generateWith (GenSeed 1) (GenSize 30)
-        genRecentEraProtocolParameters
+    generateWithSeed seed =
+        generateWith (GenSeed seed) (GenSize 30) genRecentEraProtocolParameters
 
     -- | With 'Just' as necessary to be convertible to @Ledger.PParams era@
     -- for 'IsRecentEra' eras, and keep our tests from throwing exceptions.

--- a/lib/wallet/src/Cardano/Api/Gen.hs
+++ b/lib/wallet/src/Cardano/Api/Gen.hs
@@ -1077,37 +1077,37 @@ protocolParametersForHashing =
             genSizeDefault
             genRecentEraProtocolParameters
 
-    -- | With 'Just' as necessary to be convertible to @Ledger.PParams era@
-    -- for 'IsRecentEra' eras, and keep our tests from throwing exceptions.
-    genRecentEraProtocolParameters :: Gen ProtocolParameters
-    genRecentEraProtocolParameters =
-      ProtocolParameters
-        <$> ((,) <$> genNat <*> genNat)
-        <*> (Just <$> genRational)
-        <*> liftArbitrary genPraosNonce
-        <*> genNat
-        <*> genNat
-        <*> genNat
-        <*> genNat
-        <*> genNat
-        <*> liftArbitrary genLovelace
-        <*> genLovelace
-        <*> genLovelace
-        <*> genLovelace
-        <*> genEpochNo
-        <*> genNat
-        <*> genRationalInt64
-        <*> genRational
-        <*> genRational
-        <*> (Just <$> genLovelace)
-        <*> genCostModels
-        <*> (Just <$> genExecutionUnitPrices)
-        <*> (Just <$> genExecutionUnits)
-        <*> (Just <$> genExecutionUnits)
-        <*> (Just <$> genNat)
-        <*> (Just <$> genNat)
-        <*> (Just <$> genNat)
-        <*> (Just <$> genLovelace)
+-- | With 'Just' as necessary to be convertible to @Ledger.PParams era@
+-- for 'IsRecentEra' eras, and keep our tests from throwing exceptions.
+genRecentEraProtocolParameters :: Gen ProtocolParameters
+genRecentEraProtocolParameters =
+  ProtocolParameters
+    <$> ((,) <$> genNat <*> genNat)
+    <*> (Just <$> genRational)
+    <*> liftArbitrary genPraosNonce
+    <*> genNat
+    <*> genNat
+    <*> genNat
+    <*> genNat
+    <*> genNat
+    <*> liftArbitrary genLovelace
+    <*> genLovelace
+    <*> genLovelace
+    <*> genLovelace
+    <*> genEpochNo
+    <*> genNat
+    <*> genRationalInt64
+    <*> genRational
+    <*> genRational
+    <*> (Just <$> genLovelace)
+    <*> genCostModels
+    <*> (Just <$> genExecutionUnitPrices)
+    <*> (Just <$> genExecutionUnits)
+    <*> (Just <$> genExecutionUnits)
+    <*> (Just <$> genNat)
+    <*> (Just <$> genNat)
+    <*> (Just <$> genNat)
+    <*> (Just <$> genLovelace)
 
 genWitnessNetworkIdOrByronAddress :: Gen WitnessNetworkIdOrByronAddress
 genWitnessNetworkIdOrByronAddress =


### PR DESCRIPTION
## Summary

This PR makes a few suggestions for PR #3928:
- Select from a wider range of pre-defined protocol parameters instead of just a pair.
- Reuse the `genSizeDefault` constant instead of hard-coding `GenSize 30`.
- Move `genRecentEraProtocolParameters` to the top level so that it can be invoked from `ghci`.