### PR TITLE
[ADP-3037] Remove n parameter from WalletFlavor.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
@@ -282,9 +282,9 @@ server byron icarus shelley multisig spl ntp blockchainSource =
         :<|> signMetadata shelley
         :<|> postAccountPublicKey shelley ApiAccountKey
         :<|> getAccountPublicKey shelley ApiAccountKey
-        :<|> getPolicyKey @_ @_ @n shelley
+        :<|> getPolicyKey shelley
         :<|> postPolicyKey shelley
-        :<|> postPolicyId @_ @_ @_ @n shelley
+        :<|> postPolicyId shelley
 
     assets :: Server Assets
     assets =

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/MintBurn.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/MintBurn.hs
@@ -47,16 +47,16 @@ import Servant
 
 -- | Promote mint and burn to their API type.
 convertApiAssetMintBurn
-    :: forall ctx s n
+    :: forall ctx s
      . ( HasDBLayer IO s ctx
-       , WalletFlavor s n
+       , WalletFlavor s
        )
     => ctx
     -> (TokenMapWithScripts, TokenMapWithScripts)
     -> Handler (ApiAssetMintBurn, ApiAssetMintBurn)
 convertApiAssetMintBurn ctx (mint, burn) = do
     xpubM <- fmap (fmap fst . eitherToMaybe)
-        <$> liftIO . runExceptT $ readPolicyPublicKey @ctx @s @n ctx
+        <$> liftIO . runExceptT $ readPolicyPublicKey @ctx @s ctx
     let  convert tokenWithScripts =  ApiAssetMintBurn
             { tokens = toApiTokens tokenWithScripts
             , walletPolicyKeyHash =
@@ -68,12 +68,12 @@ convertApiAssetMintBurn ctx (mint, burn) = do
     pure (convert mint, convert burn)
 
 getTxApiAssetMintBurn
-    :: forall ctx s n
+    :: forall ctx s
      . ( HasDBLayer IO s ctx
-       , WalletFlavor s n
+       , WalletFlavor s
        )
     => ctx
     -> ParsedTxCBOR
     -> (Handler (ApiAssetMintBurn, ApiAssetMintBurn))
 getTxApiAssetMintBurn ctx ParsedTxCBOR{..} =
-    convertApiAssetMintBurn @ctx @s @n ctx mintBurn
+    convertApiAssetMintBurn @ctx @s ctx mintBurn

--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -274,7 +274,7 @@ benchmarksSeq BenchmarkConfig{benchmarkName,ctx} = do
     (_, delegationFeeTime) <- bench "delegationFee" $ do
         timeTranslation <-
             toTimeTranslation (timeInterpreter (networkLayer ctx))
-        W.delegationFee @_ @n
+        W.delegationFee
             (dbLayer ctx) (networkLayer ctx) (transactionLayer ctx)
             timeTranslation
             (Write.AnyRecentEra Write.RecentEraBabbage)

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -487,7 +487,7 @@ benchmarksRnd network w@(WalletLayer _ _ netLayer txLayer dbLayer) wname
         -- before balancing the transaction and computing the fee:
         let bundleWithZeroAda = TokenBundle.fromCoin (Coin 0)
         let outputWithZeroAda = TxOut (dummyAddress network) bundleWithZeroAda
-        W.transactionFee @s @n
+        W.transactionFee @s
             dbLayer
             (Write.unsafeFromWalletProtocolParameters protocolParameters)
             txLayer
@@ -590,7 +590,7 @@ benchmarksSeq network w@(WalletLayer _ _ netLayer txLayer dbLayer) _wname
         (protocolParameters, _bundledProtocolParameters) <-
             W.toBalanceTxPParams @era <$> currentProtocolParameters netLayer
         timeTranslation <- toTimeTranslation (timeInterpreter netLayer)
-        W.transactionFee @s @n
+        W.transactionFee @s
             dbLayer
             (Write.unsafeFromWalletProtocolParameters protocolParameters)
             txLayer
@@ -627,9 +627,8 @@ instance ToJSON BenchBaselineResults where
 
 {- HLINT ignore bench_baseline_restoration "Use camelCase" -}
 bench_baseline_restoration
-    :: forall n .
-        ( HasSNetworkId n
-        )
+    :: forall n
+     . HasSNetworkId n
     => PipeliningStrategy (CardanoBlock StandardCrypto)
     -> SNetworkId n
     -> Tracer IO (BenchmarkLog n)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1279,15 +1279,15 @@ mkSelfWithdrawal netLayer txWitnessTag era db = do
 -- | Unsafe version of the `mkSelfWithdrawal` function that throws an exception
 -- when applied to a non-shelley or a non-sequential wallet.
 shelleyOnlyMkSelfWithdrawal
-    :: forall s n block
-     . WalletFlavor s n
+    :: forall s block
+     . WalletFlavor s
     => NetworkLayer IO block
     -> TxWitnessTag
     -> AnyCardanoEra
     -> DBLayer IO s
     -> IO Withdrawal
 shelleyOnlyMkSelfWithdrawal netLayer txWitnessTag era db =
-    case walletFlavor @s @n  of
+    case walletFlavor @s  of
         ShelleyWallet -> mkSelfWithdrawal netLayer txWitnessTag era db
         _ -> notShelleyWallet
   where
@@ -1351,26 +1351,26 @@ readSharedRewardAccount db = do
 -- that throws error when applied to a non-sequential
 -- or a non-shelley wallet state.
 shelleyOnlyReadRewardAccount
-    :: forall s n
-     . WalletFlavor s n
+    :: forall s
+     . WalletFlavor s
     => DBLayer IO s
     -> ExceptT ErrReadRewardAccount IO
         (RewardAccount, XPub, NonEmpty DerivationIndex)
 shelleyOnlyReadRewardAccount db = do
-    case walletFlavor @s @n of
+    case walletFlavor @s of
         ShelleyWallet -> lift $ readRewardAccount db
         _ -> throwE ErrReadRewardAccountNotAShelleyWallet
 
 readPolicyPublicKey
-    :: forall ctx s n
+    :: forall ctx s
      . ( HasDBLayer IO s ctx
-       , WalletFlavor s n
+       , WalletFlavor s
        )
     => ctx
     -> ExceptT ErrReadPolicyPublicKey IO (XPub, NonEmpty DerivationIndex)
 readPolicyPublicKey ctx = db & \DBLayer{..} -> do
     cp <- lift $ atomically readCheckpoint
-    case walletFlavor @s @n of
+    case walletFlavor @s of
         ShelleyWallet -> do
             let s = getState cp
             case Seq.policyXPub s of
@@ -1879,14 +1879,14 @@ type MakeRewardAccountBuilder k =
 --
 -- Requires the encryption passphrase in order to decrypt the root private key.
 buildSignSubmitTransaction
-    :: forall s n k
+    :: forall s k
      . ( WalletKey k
        , HardDerivation k
        , Bounded (Index (AddressIndexDerivationType k) (AddressCredential k))
        , IsOwned s k 'CredFromKeyK
        , IsOurs s RewardAccount
        , AddressBookIso s
-       , WalletFlavor s n
+       , WalletFlavor s
        , k ~ KeyOf s
        )
     => DBLayer IO s
@@ -1922,7 +1922,7 @@ buildSignSubmitTransaction db@DBLayer{..} netLayer txLayer pwd walletId
                 \s -> do
                     let wallet = WalletState.getLatest s
                     let utxo = availableUTxO @s (Set.fromList pendingTxs) wallet
-                    buildAndSignTransactionPure @k @s @n
+                    buildAndSignTransactionPure @k @s
                         timeTranslation
                         utxo
                         rootKey
@@ -1968,13 +1968,13 @@ buildSignSubmitTransaction db@DBLayer{..} netLayer txLayer pwd walletId
     wrapBalanceConstructError = either ExceptionBalanceTx ExceptionConstructTx
 
 buildAndSignTransactionPure
-    :: forall k s n
+    :: forall k s
      . ( WalletKey k
        , HardDerivation k
        , Bounded (Index (AddressIndexDerivationType k) (AddressCredential k))
        , IsOwned s k 'CredFromKeyK
        , IsOurs s RewardAccount
-       , WalletFlavor s n
+       , WalletFlavor s
        , k ~ KeyOf s
        )
     => TimeTranslation
@@ -1999,7 +1999,7 @@ buildAndSignTransactionPure
     Write.withRecentEra era $ \(_ :: Write.RecentEra recentEra) -> do
         wallet <- get
         (unsignedBalancedTx, updatedWalletState) <- lift $
-            buildTransactionPure @s @n @recentEra
+            buildTransactionPure @s @recentEra
                 wallet timeTranslation utxo txLayer changeAddrGen
                 (Write.unsafeFromWalletProtocolParameters protocolParams)
                 preSelection txCtx
@@ -2069,8 +2069,8 @@ buildAndSignTransactionPure
     anyCardanoEra = Write.fromAnyRecentEra era
 
 buildTransaction
-    :: forall s n era
-    . ( WalletFlavor s n
+    :: forall s era
+    . ( WalletFlavor s
       , Write.IsRecentEra era
       , AddressBookIso s
       )
@@ -2095,7 +2095,7 @@ buildTransaction DBLayer{..} txLayer timeTranslation changeAddrGen
         let utxo = availableUTxO @s pendingTxs wallet
 
         fmap (\s' -> wallet { getState = s' }) <$>
-            buildTransactionPure @s @n @era
+            buildTransactionPure @s @era
                 wallet
                 timeTranslation
                 utxo
@@ -2110,9 +2110,9 @@ buildTransaction DBLayer{..} txLayer timeTranslation changeAddrGen
                 & either (liftIO . throwIO) pure
 
 buildTransactionPure
-    :: forall s n era
+    :: forall s era
      . ( Write.IsRecentEra era
-       , WalletFlavor s n
+       , WalletFlavor s
        )
     => Wallet s
     -> TimeTranslation
@@ -2133,7 +2133,7 @@ buildTransactionPure
     unsignedTxBody <-
         withExceptT (Right . ErrConstructTxBody) . except $
             mkUnsignedTransaction txLayer @era
-                (Left $ unsafeShelleyOnlyGetRewardXPub @s @n (getState wallet))
+                (Left $ unsafeShelleyOnlyGetRewardXPub @s (getState wallet))
                 txCtx
                 (Left preSelection)
 
@@ -2163,11 +2163,11 @@ buildTransactionPure
 -- https://input-output.atlassian.net/browse/ADP-2933
 
 unsafeShelleyOnlyGetRewardXPub
-    :: forall s n
-     . WalletFlavor s n
+    :: forall s
+     . WalletFlavor s
     => s -> XPub
 unsafeShelleyOnlyGetRewardXPub walletState =
-    case walletFlavor @s @n of
+    case walletFlavor @s of
         ShelleyWallet -> getRawKey $ Seq.rewardAccountKey walletState
         _  -> error $ unwords
             [ "buildAndSignTransactionPure:"
@@ -2728,9 +2728,9 @@ data DelegationFee = DelegationFee
 instance NFData DelegationFee
 
 delegationFee
-    :: forall s n
+    :: forall s
      . ( AddressBookIso s
-       , WalletFlavor s n
+       , WalletFlavor s
        )
     => DBLayer IO s
     -> NetworkLayer IO Read.Block
@@ -2744,7 +2744,7 @@ delegationFee db@DBLayer{..} netLayer txLayer timeTranslation era
     Write.withRecentEra era $ \(recentEra :: Write.RecentEra era) -> do
         protocolParams <- Write.unsafeFromWalletProtocolParameters
             <$> liftIO (currentProtocolParameters netLayer)
-        feePercentiles <- transactionFee @s @n
+        feePercentiles <- transactionFee @s
             db protocolParams txLayer timeTranslation recentEra changeAddressGen
             defaultTransactionCtx
             -- It would seem that we should add a delegation action
@@ -2760,10 +2760,10 @@ delegationFee db@DBLayer{..} netLayer txLayer timeTranslation era
         pure DelegationFee { feePercentiles, deposit }
 
 transactionFee
-    :: forall s n era
+    :: forall s era
      . ( AddressBookIso s
        , Write.IsRecentEra era
-       , WalletFlavor s n
+       , WalletFlavor s
        )
     => DBLayer IO s
     -> Write.ProtocolParameters era
@@ -2796,7 +2796,7 @@ transactionFee DBLayer{atomically, walletState} protocolParams txLayer
             evaluate $ constructUTxOIndex $ availableUTxO @s mempty wallet
         unsignedTxBody <- wrapErrMkTransaction $
             mkUnsignedTransaction txLayer @era
-                (Left $ unsafeShelleyOnlyGetRewardXPub @s @n (getState wallet))
+                (Left $ unsafeShelleyOnlyGetRewardXPub @s (getState wallet))
                 txCtx
                 (Left preSelection)
 

--- a/lib/wallet/src/Cardano/Wallet/Flavor.hs
+++ b/lib/wallet/src/Cardano/Wallet/Flavor.hs
@@ -1,8 +1,10 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Cardano.Wallet.Flavor
@@ -36,33 +38,33 @@ import Data.Kind
 import GHC.Generics
     ( Generic )
 
-data WalletFlavorS s n where
-    ShelleyWallet :: WalletFlavorS (SeqState n ShelleyKey) n
-    IcarusWallet :: WalletFlavorS (SeqState n IcarusKey) n
-    ByronWallet :: WalletFlavorS (RndState n) n
-    SharedWallet :: WalletFlavorS (SharedState n SharedKey) n
-    BenchByronWallet :: WalletFlavorS (RndAnyState n p) n
-    BenchShelleyWallet :: WalletFlavorS (SeqAnyState n ShelleyKey p) n
+data WalletFlavorS s where
+    ShelleyWallet :: WalletFlavorS (SeqState n ShelleyKey)
+    IcarusWallet :: WalletFlavorS (SeqState n IcarusKey)
+    ByronWallet :: WalletFlavorS (RndState n)
+    SharedWallet :: WalletFlavorS (SharedState n SharedKey)
+    BenchByronWallet :: WalletFlavorS (RndAnyState n p)
+    BenchShelleyWallet :: WalletFlavorS (SeqAnyState n ShelleyKey p)
 
-class WalletFlavor s n where
-    walletFlavor :: WalletFlavorS s n
+class WalletFlavor s where
+    walletFlavor :: WalletFlavorS s
 
-instance WalletFlavor (SeqState n IcarusKey) n where
+instance WalletFlavor (SeqState n IcarusKey) where
     walletFlavor = IcarusWallet
 
-instance WalletFlavor (SeqState n ShelleyKey) n where
+instance WalletFlavor (SeqState n ShelleyKey) where
     walletFlavor = ShelleyWallet
 
-instance WalletFlavor (RndState n) n where
+instance WalletFlavor (RndState n) where
     walletFlavor = ByronWallet
 
-instance WalletFlavor (SeqAnyState n ShelleyKey p) n where
+instance WalletFlavor (SeqAnyState n ShelleyKey p) where
     walletFlavor = BenchShelleyWallet
 
-instance WalletFlavor (RndAnyState n p) n where
+instance WalletFlavor (RndAnyState n p) where
     walletFlavor = BenchByronWallet
 
-instance WalletFlavor (SharedState n SharedKey) n where
+instance WalletFlavor (SharedState n SharedKey) where
     walletFlavor = SharedWallet
 
 newtype TestState s (k :: (Depth -> Type -> Type)) = TestState s


### PR DESCRIPTION
- [x] remove `n` parameter from WalletFlavor and WalletFlavorS
- [x] remove redundant `n` from signatures because of the change

ADP-3037
