### PR TITLE
Refactor: UTxOAssumptions as a Sum type

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
@@ -39,6 +39,7 @@ import Cardano.Wallet
     , networkLayer
     , normalizeDelegationAddress
     , normalizeSharedAddress
+    , utxoAssumptionsForWallet
     )
 import Cardano.Wallet.Address.Derivation
     ( Depth (..), Role (..), delegationAddressS, paymentAddressS )
@@ -185,6 +186,8 @@ import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..) )
 import Cardano.Wallet.Api.Types.SchemaMetadata
     ( TxMetadataSchema (..), parseSimpleMetadataFlag )
+import Cardano.Wallet.Flavor
+    ( WalletFlavorS (..) )
 import Cardano.Wallet.Pools
     ( StakePoolLayer (..) )
 import Cardano.Wallet.Primitive.Types
@@ -195,8 +198,6 @@ import Cardano.Wallet.Shelley.BlockchainSource
     ( BlockchainSource (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( inspectAddress, rewardAccountFromAddress )
-import Cardano.Wallet.Write.Tx.Balance
-    ( UTxOAssumptions (AllKeyPaymentCredentials) )
 import Control.Applicative
     ( liftA2 )
 import Control.Monad
@@ -347,7 +348,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
         :<|> postTransactionOld shelley (delegationAddressS @n)
         :<|> postTransactionFeeOld shelley
         :<|> balanceTransaction
-            shelley (delegationAddressS @n) AllKeyPaymentCredentials
+            shelley (delegationAddressS @n) (utxoAssumptionsForWallet ShelleyWallet)
         :<|> decodeTransaction shelley
         :<|> submitTransaction @_ @_ @_ @n shelley
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
@@ -195,6 +195,8 @@ import Cardano.Wallet.Shelley.BlockchainSource
     ( BlockchainSource (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( inspectAddress, rewardAccountFromAddress )
+import Cardano.Wallet.Write.Tx.Balance
+    ( UTxOAssumptions (AllKeyPaymentCredentials) )
 import Control.Applicative
     ( liftA2 )
 import Control.Monad
@@ -344,7 +346,8 @@ server byron icarus shelley multisig spl ntp blockchainSource =
         :<|> deleteTransaction shelley
         :<|> postTransactionOld shelley (delegationAddressS @n)
         :<|> postTransactionFeeOld shelley
-        :<|> balanceTransaction shelley (delegationAddressS @n) Nothing Nothing
+        :<|> balanceTransaction
+            shelley (delegationAddressS @n) AllKeyPaymentCredentials
         :<|> decodeTransaction shelley
         :<|> submitTransaction @_ @_ @_ @n shelley
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2555,11 +2555,11 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
         balancedTx <-
             balanceTransaction api argGenChange Nothing Nothing apiWalletId
                 ApiBalanceTransactionPostData
-                { transaction = ApiT (sealedTxFromCardanoBody unbalancedTx)
-                , inputs = []
-                , redeemers = []
-                , encoding = body ^. #encoding
-                }
+                    { transaction = ApiT (sealedTxFromCardanoBody unbalancedTx)
+                    , inputs = []
+                    , redeemers = []
+                    , encoding = body ^. #encoding
+                    }
 
         apiDecoded <- decodeTransaction @_ @n api apiWalletId balancedTx
 
@@ -3049,12 +3049,11 @@ decodeSharedTransaction ctx (ApiT wid) (ApiSerialisedTransaction (ApiT sealed) _
         }
 
 balanceTransaction
-    :: forall s k ktype n
-     . ( GenChange s
-       , WalletFlavor s
-       , TxWitnessTagFor k
-       , k ~ KeyOf s
-       )
+    :: forall s k ktype n.
+        ( GenChange s
+        , WalletFlavor s
+        , k ~ KeyOf s
+        )
     => ApiLayer s ktype
     -> ArgGenChange s
     -> Maybe (Address -> Script KeyHash)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -142,7 +142,6 @@ import Cardano.Address.Script
     ( Cosigner (..)
     , KeyHash (..)
     , KeyRole (..)
-    , Script
     , ScriptTemplate (..)
     , ValidationLevel (..)
     , foldScript
@@ -550,7 +549,7 @@ import Cardano.Wallet.Unsafe
 import Cardano.Wallet.Write.Tx
     ( AnyRecentEra (..) )
 import Cardano.Wallet.Write.Tx.Balance
-    ( constructUTxOIndex )
+    ( UTxOAssumptions (..), constructUTxOIndex )
 import Control.Arrow
     ( second, (&&&) )
 import Control.DeepSeq
@@ -2553,7 +2552,11 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
                     PreSelection { outputs = outs <> mintingOuts }
 
         balancedTx <-
-            balanceTransaction api argGenChange Nothing Nothing apiWalletId
+            balanceTransaction
+                api
+                argGenChange
+                AllKeyPaymentCredentials
+                apiWalletId
                 ApiBalanceTransactionPostData
                     { transaction = ApiT (sealedTxFromCardanoBody unbalancedTx)
                     , inputs = []
@@ -2905,8 +2908,10 @@ constructSharedTransaction
                     txLayer db txCtx PreSelection {outputs = outs}
 
                 balancedTx <-
-                    balanceTransaction api argGenChange (Just scriptLookup)
-                    (Just (Shared.paymentTemplate $ getState cp)) (ApiT wid)
+                    balanceTransaction api argGenChange
+                    (AllScriptPaymentCredentialsFrom
+                        (Shared.paymentTemplate (getState cp)) scriptLookup)
+                    (ApiT wid)
                         ApiBalanceTransactionPostData
                         { transaction =
                             ApiT $ sealedTxFromCardanoBody unbalancedTx
@@ -3056,18 +3061,12 @@ balanceTransaction
         )
     => ApiLayer s ktype
     -> ArgGenChange s
-    -> Maybe (Address -> Script KeyHash)
-    -> Maybe ScriptTemplate
+    -> UTxOAssumptions
     -> ApiT WalletId
     -> ApiBalanceTransactionPostData n
     -> Handler ApiSerialisedTransaction
 balanceTransaction
-    ctx@ApiLayer{..}
-    argGenChange
-    genInpScripts
-    mScriptTemplate
-    (ApiT wid)
-    body = do
+    ctx@ApiLayer{..} argGenChange utxoAssumptions (ApiT wid) body = do
     -- NOTE: Ideally we'd read @pp@ and @era@ atomically.
     pp <- liftIO $ NW.currentProtocolParameters nl
     era <- liftIO $ NW.currentNodeEra nl
@@ -3125,10 +3124,8 @@ balanceTransaction
             balanceTx partialTx =
                 liftHandler $ fst <$> Write.balanceTransaction @_ @IO @s
                     (MsgWallet . W.MsgBalanceTx >$< wrk ^. W.logger)
-                    (Write.UTxOAssumptions
-                        genInpScripts
-                        mScriptTemplate
-                        (txWitnessTagFor @k))
+                    (transactionWitnessTag txLayer)
+                    utxoAssumptions
                     (Write.unsafeFromWalletProtocolParameters pp)
                     timeTranslation
                     (constructUTxOIndex walletUTxO)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3124,7 +3124,6 @@ balanceTransaction
             balanceTx partialTx =
                 liftHandler $ fst <$> Write.balanceTransaction @_ @IO @s
                     (MsgWallet . W.MsgBalanceTx >$< wrk ^. W.logger)
-                    (transactionWitnessTag txLayer)
                     utxoAssumptions
                     (Write.unsafeFromWalletProtocolParameters pp)
                     timeTranslation

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -62,6 +62,8 @@ import Cardano.Wallet.Address.Derivation
     ( Depth (..), WalletKey, digest, publicKey )
 import Cardano.Wallet.Address.Derivation.Byron
     ( ByronKey )
+import Cardano.Wallet.Address.Derivation.Shared
+    ( SharedKey )
 import Cardano.Wallet.Address.Derivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Address.Discovery
@@ -91,7 +93,7 @@ import Cardano.Wallet.DB
 import Cardano.Wallet.DB.Layer
     ( PersistAddressBook, withDBFresh )
 import Cardano.Wallet.Flavor
-    ( KeyOf, WalletFlavor )
+    ( Excluding, KeyOf, WalletFlavor )
 import Cardano.Wallet.Launch
     ( CardanoNodeConn, NetworkConfiguration (..), parseGenesisData )
 import Cardano.Wallet.Logging
@@ -275,8 +277,7 @@ cardanoRestoreBench
     -> CardanoNodeConn
     -> IO ()
 cardanoRestoreBench tr c socketFile = do
-    (networkId, np, vData, _b)
-        <- unsafeRunExceptT $ parseGenesisData c
+    (networkId, np, vData, _b) <- unsafeRunExceptT $ parseGenesisData c
     (_, walletTr) <- initBenchmarkLogging "wallet" Notice
 
     withSNetworkId networkId $ \(sNetwork :: SNetworkId n)-> do
@@ -1021,7 +1022,11 @@ withNonEmptyUTxO wallet pendingTxs failure action
     emptyUTxO = UTxO.null (availableUTxO pendingTxs wallet)
 
 benchEstimateTxFee
-    :: forall n s. (AddressBookIso s, WalletFlavor s)
+    :: forall n s.
+        ( AddressBookIso s
+        , WalletFlavor s
+        , Excluding '[SharedKey] (KeyOf s)
+        )
     => SNetworkId n
     -> WalletLayer IO s 'CredFromKeyK
     -> IO Time

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2114,7 +2114,6 @@ buildTransactionPure
     withExceptT Left $
         balanceTransaction @_ @_ @s
             nullTracer
-            (transactionWitnessTag txLayer)
             utxoAssumptions
             pparams
             timeTranslation
@@ -2789,7 +2788,6 @@ transactionFee DBLayer{atomically, walletState} protocolParams txLayer
             res <- runExceptT $
                     balanceTransaction @_ @_ @s
                         nullTracer
-                        (transactionWitnessTag txLayer)
                         AllKeyPaymentCredentials
                         protocolParams
                         timeTranslation

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -3675,7 +3675,7 @@ instance HasSeverityAnnotation TxSubmitLog where
 
 -- | Construct the default 'ChangeAddressGen s' for a given 's'.
 defaultChangeAddressGen
-    :: forall s .
+    :: forall s.
         ( GenChange s
         , WalletFlavor s
         )
@@ -3688,18 +3688,15 @@ defaultChangeAddressGen arg =
 
 -- WARNING: Must never be used to create real transactions for submission to the
 -- blockchain as funds sent to a dummy change address would be irrecoverable.
-dummyChangeAddressGen
-    :: forall s
-     . WalletFlavor s
-    => ChangeAddressGen s
+dummyChangeAddressGen :: forall s. WalletFlavor s => ChangeAddressGen s
 dummyChangeAddressGen =
     ChangeAddressGen
         (maxLengthAddressFor (keyFlavor @s),)
         (maxLengthAddressFor (keyFlavor @s))
 
 utxoAssumptionsForWallet
-    :: forall s
-     . Excluding '[SharedKey] (KeyOf s)
+    :: forall s.
+        Excluding '[SharedKey] (KeyOf s)
     => WalletFlavorS s
     -> UTxOAssumptions
 utxoAssumptionsForWallet = keyOfWallet >>> \case

--- a/lib/wallet/src/Cardano/Wallet/Address/Derivation/Icarus.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Derivation/Icarus.hs
@@ -136,7 +136,7 @@ newtype IcarusKey (depth :: Depth) key =
 instance NFData key => NFData (IcarusKey depth key)
 
 instance TxWitnessTagFor IcarusKey where
-    txWitnessTagFor = TxWitnessByronIcarusUTxO
+    txWitnessTagFor = TxWitnessByronUTxO
 
 -- | The minimum seed length for 'generateKeyFromSeed' and 'unsafeGenerateKeyFromSeed'.
 minSeedLengthBytes :: Int

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -546,8 +546,6 @@ signTransaction
                 mkShelleyWitness body (getRawKey k, pwd)
             TxWitnessByronUTxO ->
                 mkByronWitness body networkId addr (getRawKey k, pwd)
-            TxWitnessByronIcarusUTxO ->
-                mkByronWitness body networkId addr (getRawKey k, pwd)
 
     mkWdrlCertWitness :: RewardAccount -> Maybe (Cardano.KeyWitness era)
     mkWdrlCertWitness a =
@@ -1745,7 +1743,6 @@ estimateTxSize era skeleton =
     numberOf_VkeyWitnesses
         = case txWitnessTag of
             TxWitnessByronUTxO -> 0
-            TxWitnessByronIcarusUTxO -> 0
             TxWitnessShelleyUTxO ->
                 if numberOf_ScriptVkeyWitnesses == 0 then
                     numberOf_Inputs
@@ -1761,7 +1758,6 @@ estimateTxSize era skeleton =
     numberOf_BootstrapWitnesses
         = case txWitnessTag of
             TxWitnessByronUTxO -> numberOf_Inputs
-            TxWitnessByronIcarusUTxO -> numberOf_Inputs
             TxWitnessShelleyUTxO -> 0
 
     -- transaction =
@@ -1992,7 +1988,6 @@ estimateTxSize era skeleton =
     sizeOf_ChangeAddress
         = case txWitnessTag of
             TxWitnessByronUTxO -> 85
-            TxWitnessByronIcarusUTxO -> 85
             TxWitnessShelleyUTxO -> 59
 
     -- value = coin / [coin,multiasset<uint>]

--- a/lib/wallet/src/Cardano/Wallet/TxWitnessTag.hs
+++ b/lib/wallet/src/Cardano/Wallet/TxWitnessTag.hs
@@ -13,7 +13,6 @@ import Data.Kind
 
 data TxWitnessTag
     = TxWitnessByronUTxO
-    | TxWitnessByronIcarusUTxO
     | TxWitnessShelleyUTxO
     deriving (Show, Eq)
 

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -353,13 +353,13 @@ constructUTxOIndex walletUTxO =
 -- | Assumptions about the UTxO which are needed for coin-selection.
 data UTxOAssumptions
     = AllKeyPaymentCredentials
-    -- Assumes all 'UTxO' entries have addresses with the post-Shelley
+    -- ^ Assumes all 'UTxO' entries have addresses with the post-Shelley
     -- key payment credentials.
     | AllByronKeyPaymentCredentials
-    -- Assumes all 'UTxO' entries have addresses with the boostrap/byron
+    -- ^ Assumes all 'UTxO' entries have addresses with the boostrap/byron
     -- key payment credentials.
     | AllScriptPaymentCredentialsFrom
-    -- Assumes all 'UTxO' entries have addresses with script
+    -- ^ Assumes all 'UTxO' entries have addresses with script
     -- payment credentials, where the scripts are both derived
     -- from the 'ScriptTemplate' and can be looked up using the given function.
         !ScriptTemplate

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3391,17 +3391,17 @@ balanceTx
     seed
     partialTx
     = (`evalRand` stdGenFromSeed seed) $ runExceptT $ do
-            (transactionInEra, _nextChangeState) <-
-                balanceTransaction
-                    nullTracer
-                    utxoAssumptions
-                    protocolParameters
-                    timeTranslation
-                    (constructUTxOIndex utxo)
-                    genChange
-                    s
-                    partialTx
-            pure transactionInEra
+        (transactionInEra, _nextChangeState) <-
+            balanceTransaction
+                nullTracer
+                utxoAssumptions
+                protocolParameters
+                timeTranslation
+                (constructUTxOIndex utxo)
+                genChange
+                s
+                partialTx
+        pure transactionInEra
 
 -- | Also returns the updated change state
 balanceTransactionWithDummyChangeState

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -121,8 +121,6 @@ import Cardano.Wallet.Address.Derivation
     , paymentAddress
     , publicKey
     )
-import Cardano.Wallet.Address.Derivation.Byron
-    ( ByronKey )
 import Cardano.Wallet.Address.Derivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Address.Discovery.Random

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3016,8 +3016,7 @@ instance MonadRandom Gen where
     getRandomR range = mkGen (fst . randomR range)
     getRandomRs range = mkGen (randomRs range)
 
-data Wallet' =
-    Wallet' TxWitnessTag UTxOAssumptions UTxO AnyChangeAddressGenWithState
+data Wallet' = Wallet' UTxOAssumptions UTxO AnyChangeAddressGenWithState
     deriving Show via (ShowBuildable Wallet')
 
 instance Buildable UTxOAssumptions where
@@ -3038,31 +3037,20 @@ instance Buildable AnyChangeAddressGenWithState where
             ]
 
 instance Buildable Wallet' where
-    build (Wallet' witnessTag assumptions utxo changeAddressGen) =
+    build (Wallet' assumptions utxo changeAddressGen) =
         nameF "Wallet" $ mconcat
-            [ nameF "txWitnessTag" $ build witnessTag
-            , nameF "assumptions" $ build assumptions
+            [ nameF "assumptions" $ build assumptions
             , nameF "changeAddressGen" $ build changeAddressGen
             , nameF "utxo" $ pretty utxo
             ]
 
-instance Buildable TxWitnessTag where
-    build = \case
-        TxWitnessByronUTxO -> "TxWitnessByronUTxO"
-        TxWitnessByronIcarusUTxO -> "TxWitnessByronIcarusUTxO"
-        TxWitnessShelleyUTxO -> "TxWitnessShelleyUTxO"
-
 instance Arbitrary Wallet' where
     arbitrary = oneof
-        [ Wallet'
-            TxWitnessShelleyUTxO
-            AllKeyPaymentCredentials
+        [ Wallet' AllKeyPaymentCredentials
             <$> genWalletUTxO genShelleyVkAddr
             <*> pure dummyShelleyChangeAddressGen
 
-        , Wallet'
-            TxWitnessByronUTxO
-            AllByronKeyPaymentCredentials
+        , Wallet' AllByronKeyPaymentCredentials
             <$> genWalletUTxO genByronVkAddr
             <*> pure dummyByronChangeAddressGen
         ]
@@ -3096,10 +3084,10 @@ instance Arbitrary Wallet' where
                   where
                     era = Cardano.BabbageEra
 
-    shrink ( Wallet' witnessTag utxoAssumptions utxo changeAddressGen ) =
-            [ Wallet' witnessTag utxoAssumptions utxo' changeAddressGen
-            | utxo' <- shrinkUTxO utxo
-            ]
+    shrink (Wallet' utxoAssumptions utxo changeAddressGen) =
+        [ Wallet' utxoAssumptions utxo' changeAddressGen
+        | utxo' <- shrinkUTxO utxo
+        ]
       where
         -- We cannot use 'Cardano.Wallet.Primitive.Types.UTxO.Gen.shrinkUTxO'
         -- because it will shrink to invalid addresses.
@@ -3114,11 +3102,7 @@ instance Arbitrary Wallet' where
 
 mkTestWallet :: UTxO -> Wallet'
 mkTestWallet utxo =
-    Wallet'
-        TxWitnessShelleyUTxO
-        AllKeyPaymentCredentials
-        utxo
-        dummyShelleyChangeAddressGen
+    Wallet' AllKeyPaymentCredentials utxo dummyShelleyChangeAddressGen
 
 newtype ShowBuildable a = ShowBuildable a
     deriving newtype Arbitrary
@@ -3403,7 +3387,7 @@ balanceTx
     -> PartialTx era
     -> Either ErrBalanceTx (Cardano.Tx era)
 balanceTx
-    (Wallet' witnessTag utxoAssumptions utxo (AnyChangeAddressGenWithState genChange s))
+    (Wallet' utxoAssumptions utxo (AnyChangeAddressGenWithState genChange s))
     protocolParameters
     timeTranslation
     seed
@@ -3412,7 +3396,6 @@ balanceTx
             (transactionInEra, _nextChangeState) <-
                 balanceTransaction
                     nullTracer
-                    witnessTag
                     utxoAssumptions
                     protocolParameters
                     timeTranslation
@@ -3431,11 +3414,9 @@ balanceTransactionWithDummyChangeState
     -> PartialTx era
     -> Either ErrBalanceTx (Cardano.Tx era, DummyChangeState)
 balanceTransactionWithDummyChangeState utxoAssumptions utxo seed partialTx =
-    (`evalRand` stdGenFromSeed seed) $ runExceptT $ do
-        let txLayer = newTransactionLayer @ShelleyKey Cardano.Mainnet
+    (`evalRand` stdGenFromSeed seed) $ runExceptT $
         balanceTransaction
             nullTracer
-            (transactionWitnessTag txLayer)
             utxoAssumptions
             mockPParamsForBalancing
             dummyTimeTranslation
@@ -3670,7 +3651,7 @@ prop_balanceTransactionValid
     -> StdGenSeed
     -> Property
 prop_balanceTransactionValid
-    wallet@(Wallet' _ _ walletUTxO _) (ShowBuildable partialTx) seed =
+    wallet@(Wallet' _ walletUTxO _) (ShowBuildable partialTx) seed =
         withMaxSuccess 1_000 $ do
         let combinedUTxO =
                 view #inputs partialTx

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -292,7 +292,6 @@ import Cardano.Wallet.Write.Tx.Balance
     , ErrSelectAssets (..)
     , PartialTx (..)
     , UTxOAssumptions (..)
-    , allKeyPaymentCredentials
     , balanceTransaction
     , constructUTxOIndex
     , posAndNegFromCardanoValue
@@ -304,15 +303,7 @@ import Control.Arrow
 import Control.Monad
     ( forM, forM_, replicateM )
 import Control.Monad.Random
-    ( MonadRandom (..)
-    , Rand
-    , Random (randomR, randomRs)
-    , evalRand
-    , random
-    , randoms
-    )
-import Control.Monad.Random.Strict
-    ( StdGen )
+    ( MonadRandom (..), Random (randomR, randomRs), evalRand, random, randoms )
 import Control.Monad.Trans.Except
     ( except, runExcept, runExceptT )
 import Control.Monad.Trans.State.Strict
@@ -2348,7 +2339,7 @@ balanceTransactionSpec = describe "balanceTransaction" $ do
     describe "change address generation" $ do
         let balance' =
                 balanceTransactionWithDummyChangeState
-                    (allKeyPaymentCredentials testTxLayer)
+                    AllKeyPaymentCredentials
                     dustUTxO
                     testStdGenSeed
 
@@ -3025,15 +3016,17 @@ instance MonadRandom Gen where
     getRandomR range = mkGen (fst . randomR range)
     getRandomRs range = mkGen (randomRs range)
 
-data Wallet' = Wallet'
-    UTxOAssumptions
-    UTxO
-    AnyChangeAddressGenWithState
+data Wallet' =
+    Wallet' TxWitnessTag UTxOAssumptions UTxO AnyChangeAddressGenWithState
     deriving Show via (ShowBuildable Wallet')
 
 instance Buildable UTxOAssumptions where
-    build (UTxOAssumptions _scriptLookup scriptTemplate _txWitnessTag) =
-        blockListF [ nameF "scriptTemplate" $ build scriptTemplate ]
+    build = \case
+        AllKeyPaymentCredentials -> "AllKeyPaymentCredentials"
+        AllByronKeyPaymentCredentials -> "AllByronKeyPaymentCredentials"
+        AllScriptPaymentCredentialsFrom scriptTemplate _scriptLookup ->
+            nameF "AllScriptPaymentCredentialsFrom" $
+                blockListF [ nameF "scriptTemplate" $ build scriptTemplate ]
 
 instance Buildable AnyChangeAddressGenWithState where
     build (AnyChangeAddressGenWithState (ChangeAddressGen g maxLengthAddr) s0) =
@@ -3045,29 +3038,35 @@ instance Buildable AnyChangeAddressGenWithState where
             ]
 
 instance Buildable Wallet' where
-    build (Wallet' assumptions utxo changeAddressGen) =
+    build (Wallet' witnessTag assumptions utxo changeAddressGen) =
         nameF "Wallet" $ mconcat
-            [ nameF "assumptions" $ build assumptions
+            [ nameF "txWitnessTag" $ build witnessTag
+            , nameF "assumptions" $ build assumptions
             , nameF "changeAddressGen" $ build changeAddressGen
             , nameF "utxo" $ pretty utxo
             ]
 
+instance Buildable TxWitnessTag where
+    build = \case
+        TxWitnessByronUTxO -> "TxWitnessByronUTxO"
+        TxWitnessByronIcarusUTxO -> "TxWitnessByronIcarusUTxO"
+        TxWitnessShelleyUTxO -> "TxWitnessShelleyUTxO"
+
 instance Arbitrary Wallet' where
     arbitrary = oneof
-        [ Wallet' allShelleyPaymentKeyCredentials
-            <$> (genWalletUTxO genShelleyVkAddr)
-            <*> (pure dummyShelleyChangeAddressGen)
+        [ Wallet'
+            TxWitnessShelleyUTxO
+            AllKeyPaymentCredentials
+            <$> genWalletUTxO genShelleyVkAddr
+            <*> pure dummyShelleyChangeAddressGen
 
-        , Wallet' allByronPaymentKeyCredentials
-            <$> (genWalletUTxO genByronVkAddr)
-            <*> (pure dummyByronChangeAddressGen)
+        , Wallet'
+            TxWitnessByronUTxO
+            AllByronKeyPaymentCredentials
+            <$> genWalletUTxO genByronVkAddr
+            <*> pure dummyByronChangeAddressGen
         ]
       where
-        allShelleyPaymentKeyCredentials = allKeyPaymentCredentials $
-            newTransactionLayer @ShelleyKey Cardano.Mainnet
-
-        allByronPaymentKeyCredentials = allKeyPaymentCredentials $
-            newTransactionLayer @ByronKey Cardano.Mainnet
 
         genShelleyVkAddr :: Gen (Cardano.AddressInEra Cardano.BabbageEra)
         genShelleyVkAddr = Cardano.shelleyAddressInEra
@@ -3097,10 +3096,10 @@ instance Arbitrary Wallet' where
                   where
                     era = Cardano.BabbageEra
 
-    shrink (Wallet' utxoAssumptions utxo changeAddressGen) =
-        [ Wallet' utxoAssumptions utxo' changeAddressGen
-        | utxo' <- shrinkUTxO utxo
-        ]
+    shrink ( Wallet' witnessTag utxoAssumptions utxo changeAddressGen ) =
+            [ Wallet' witnessTag utxoAssumptions utxo' changeAddressGen
+            | utxo' <- shrinkUTxO utxo
+            ]
       where
         -- We cannot use 'Cardano.Wallet.Primitive.Types.UTxO.Gen.shrinkUTxO'
         -- because it will shrink to invalid addresses.
@@ -3114,10 +3113,12 @@ instance Arbitrary Wallet' where
         shrinkEntry _ = []
 
 mkTestWallet :: UTxO -> Wallet'
-mkTestWallet utxo = Wallet'
-    (allKeyPaymentCredentials (newTransactionLayer @ShelleyKey Cardano.Mainnet))
-    utxo
-    dummyShelleyChangeAddressGen
+mkTestWallet utxo =
+    Wallet'
+        TxWitnessShelleyUTxO
+        AllKeyPaymentCredentials
+        utxo
+        dummyShelleyChangeAddressGen
 
 newtype ShowBuildable a = ShowBuildable a
     deriving newtype Arbitrary
@@ -3402,7 +3403,7 @@ balanceTx
     -> PartialTx era
     -> Either ErrBalanceTx (Cardano.Tx era)
 balanceTx
-    (Wallet' utxoAssumptions utxo (AnyChangeAddressGenWithState genChange s))
+    (Wallet' witnessTag utxoAssumptions utxo (AnyChangeAddressGenWithState genChange s))
     protocolParameters
     timeTranslation
     seed
@@ -3411,6 +3412,7 @@ balanceTx
             (transactionInEra, _nextChangeState) <-
                 balanceTransaction
                     nullTracer
+                    witnessTag
                     utxoAssumptions
                     protocolParameters
                     timeTranslation
@@ -3427,24 +3429,21 @@ balanceTransactionWithDummyChangeState
     -> UTxO
     -> StdGenSeed
     -> PartialTx era
-    -> Either
-        ErrBalanceTx
-        (Cardano.Tx era, DummyChangeState)
-balanceTransactionWithDummyChangeState cs utxo seed ptx =
-    flip evalRand (stdGenFromSeed seed) $ runExceptT $
-        balanceTransaction @_ @(Rand StdGen)
-            (nullTracer @(Rand StdGen))
-            cs
+    -> Either ErrBalanceTx (Cardano.Tx era, DummyChangeState)
+balanceTransactionWithDummyChangeState utxoAssumptions utxo seed partialTx =
+    (`evalRand` stdGenFromSeed seed) $ runExceptT $ do
+        let txLayer = newTransactionLayer @ShelleyKey Cardano.Mainnet
+        balanceTransaction
+            nullTracer
+            (transactionWitnessTag txLayer)
+            utxoAssumptions
             mockPParamsForBalancing
             dummyTimeTranslation
             (constructUTxOIndex utxo)
             dummyChangeAddrGen
-            (getState wal)
-            ptx
-  where
-    wal = unsafeInitWallet utxo (header block0) s
-      where
-        s = DummyChangeState { nextUnusedIndex = 0 }
+            (getState $ unsafeInitWallet utxo (header block0)
+                DummyChangeState { nextUnusedIndex = 0 })
+            partialTx
 
 prop_posAndNegFromCardanoValueRoundtrip :: Property
 prop_posAndNegFromCardanoValueRoundtrip = forAll genSignedValue $ \v ->
@@ -3670,21 +3669,15 @@ prop_balanceTransactionValid
     -> ShowBuildable (PartialTx Cardano.BabbageEra)
     -> StdGenSeed
     -> Property
-prop_balanceTransactionValid wallet@(Wallet' _ walletUTxO _) (ShowBuildable partialTx) seed
-    = withMaxSuccess 1_000 $ do
-        let combinedUTxO = mconcat
-                [ view #inputs partialTx
-                , Compatibility.toCardanoUTxO (shelleyBasedEra @era) walletUTxO
-                ]
-        let originalBalance = txBalance (view #tx partialTx) combinedUTxO
-        let res = balanceTx
-                wallet
-                mockPParamsForBalancing
-                dummyTimeTranslation
-                seed
-                partialTx
-        let originalOuts = txOutputs (view #tx partialTx)
+prop_balanceTransactionValid
+    wallet@(Wallet' _ _ walletUTxO _) (ShowBuildable partialTx) seed =
+        withMaxSuccess 1_000 $ do
+        let combinedUTxO =
+                view #inputs partialTx
+                <> Compatibility.toCardanoUTxO (shelleyBasedEra @era) walletUTxO
 
+        let originalBalance = txBalance (view #tx partialTx) combinedUTxO
+        let originalOuts = txOutputs (view #tx partialTx)
         let classifications =
                 classify (hasZeroAdaOutputs $ view #tx partialTx)
                     "partial tx had zero ada outputs"
@@ -3701,6 +3694,13 @@ prop_balanceTransactionValid wallet@(Wallet' _ walletUTxO _) (ShowBuildable part
                 . classify (length originalOuts > 100)
                     ">100 payment outputs"
 
+        let res =
+                balanceTx
+                    wallet
+                    mockPParamsForBalancing
+                    dummyTimeTranslation
+                    seed
+                    partialTx
         classifications $ case res of
             Right tx -> counterexample ("\nResult: " <> show (Pretty tx)) $ do
                 label "success"


### PR DESCRIPTION
Refactor `UTxOAssumptions` from a record type + smart constructors to a sum type with regular constructors.

This requires to declare/pass types like `TxWitnessTag`, `TokenBundleMaxSize -> TokenBundleSizeAssessor` separately from `UTxOAssumptions` as explicit parameters to the `balanceTransaction`, however this is a temporary state of things: the plan is to remove these params in subsequent PRs.

### Comments

It was originally published and reviewed here https://github.com/input-output-hk/cardano-wallet/pull/3911 but I am splitting it into a separate PR.

### Issue Number

ADP-2967
