### PR TITLE
refactor: inline token bundle size assessor in balanceTx

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3132,7 +3132,6 @@ balanceTransaction
                 liftHandler $ fst <$> Write.balanceTransaction @_ @IO @s
                     (MsgWallet . W.MsgBalanceTx >$< wrk ^. W.logger)
                     (Write.UTxOAssumptions
-                        txLayer
                         genInpScripts
                         mScriptTemplate
                         (txWitnessTagFor @k))

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3037,7 +3037,7 @@ data Wallet' = Wallet'
     deriving Show via (ShowBuildable Wallet')
 
 instance Buildable UTxOAssumptions where
-    build (UTxOAssumptions _tl _scriptLookup scriptTemplate _txWitnessTag) =
+    build (UTxOAssumptions _scriptLookup scriptTemplate _txWitnessTag) =
         blockListF [ nameF "scriptTemplate" $ build scriptTemplate ]
 
 instance Buildable AnyChangeAddressGenWithState where


### PR DESCRIPTION
Refactor `balanceTransaction` not to depend on the `txLayer` but use `Compatibility.tokenBundleSizeAssessor` directly.

This is to simplify further work on `UTxOAssumptions`: this makes it easier to rewrite it as a sum-type[ in the other PR.](https://github.com/input-output-hk/cardano-wallet/pull/3937)

### Issue Number

ADP-2967
