### PR TITLE
Simplify treatment of extra input and output value within `balanceTx`.

### DIFF
--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -98,7 +98,7 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( Flat (..), TokenBundle )
+    ( Flat (..), TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId, TokenMap )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
@@ -263,18 +263,12 @@ toInternalSelectionConstraints SelectionConstraints {..} =
 -- | Specifies all parameters that are specific to a given selection.
 --
 data SelectionParams = SelectionParams
-    { assetsToBurn
-        :: !TokenMap
-        -- ^ Specifies a set of assets to burn.
-    , assetsToMint
-        :: !TokenMap
-        -- ^ Specifies a set of assets to mint.
-    , extraCoinIn
-        :: !Coin
-       -- ^ Specifies extra 'Coin' in.
-    , extraCoinOut
-        :: !Coin
-        -- ^ Specifies extra 'Coin' out.
+    { extraValueIn
+        :: !TokenBundle
+        -- ^ Specifies extra value on the input side.
+    , extraValueOut
+        :: !TokenBundle
+        -- ^ Specifies extra value on the output side.
     , outputsToCover
         :: ![TxOut]
         -- ^ Specifies a set of outputs that must be paid for.
@@ -313,6 +307,9 @@ toInternalSelectionParams SelectionParams {..} =
         , ..
         }
   where
+    TokenBundle extraCoinIn  assetsToMint = extraValueIn
+    TokenBundle extraCoinOut assetsToBurn = extraValueOut
+
     identifyCollateral :: WalletUTxO -> TokenBundle -> Maybe Coin
     identifyCollateral (WalletUTxO _ a) b = asCollateral (TxOut a b)
 

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -963,9 +963,8 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
             , TokenBundle.fromCoin fee0
             ]
         , extraValueOut = mconcat
-            [ TokenBundle.fromTokenMap negativeTokens
+            [ negativeBundle
             , TokenBundle.fromTokenMap tokensInInputs
-            , TokenBundle.fromCoin negativeAda
             , TokenBundle.fromCoin adaInInputs
             ]
         -- NOTE: It is important that coin selection has the correct
@@ -1001,7 +1000,6 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
             else SelectionCollateralNotRequired
 
     (positiveBundle, negativeBundle) = posAndNegFromCardanoValue balance
-    TokenBundle negativeAda negativeTokens = negativeBundle
     adaInOutputs = F.foldMap (TokenBundle.getCoin . view #tokens) outs
     tokensInOutputs = F.foldMap (TokenBundle.tokens . view #tokens) outs
     TokenBundle adaInInputs tokensInInputs =

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -956,11 +956,19 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
         -- algorithm's notion of balance by @balance0 - sum inputs + sum
         -- outputs + fee0@ where @balance0@ is the balance of the
         -- partial tx.
-        { assetsToMint = positiveTokens <> tokensInOutputs
-        , assetsToBurn = negativeTokens <> tokensInInputs
-        , extraCoinIn = positiveAda <> adaInOutputs <> fee0
-        , extraCoinOut = negativeAda <> adaInInputs
-
+        { extraValueIn = mconcat
+            [ TokenBundle.fromTokenMap positiveTokens
+            , TokenBundle.fromTokenMap tokensInOutputs
+            , TokenBundle.fromCoin positiveAda
+            , TokenBundle.fromCoin adaInOutputs
+            , TokenBundle.fromCoin fee0
+            ]
+        , extraValueOut = mconcat
+            [ TokenBundle.fromTokenMap negativeTokens
+            , TokenBundle.fromTokenMap tokensInInputs
+            , TokenBundle.fromCoin negativeAda
+            , TokenBundle.fromCoin adaInInputs
+            ]
         -- NOTE: It is important that coin selection has the correct
         -- notion of fees, because it will be used to tell how much
         -- collateral is needed.

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -1000,8 +1000,9 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
             else SelectionCollateralNotRequired
 
     (positiveBundle, negativeBundle) = posAndNegFromCardanoValue balance
-    adaInOutputs = F.foldMap (TokenBundle.getCoin . view #tokens) outs
-    tokensInOutputs = F.foldMap (TokenBundle.tokens . view #tokens) outs
+    valueOfOutputs = F.foldMap (view #tokens) outs
+    adaInOutputs = view #coin valueOfOutputs
+    tokensInOutputs = view #tokens valueOfOutputs
     TokenBundle adaInInputs tokensInInputs =
         UTxOSelection.selectedBalance utxoSelection
 

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -974,6 +974,10 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
         , utxoAvailableForInputs = utxoSelection
         , selectionStrategy = selectionStrategy
         }
+      where
+        (positiveBundle, negativeBundle) = posAndNegFromCardanoValue balance
+        valueOfOutputs = F.foldMap (view #tokens) outs
+        valueOfInputs = UTxOSelection.selectedBalance utxoSelection
 
     mkLedgerTxOut
         :: RecentEra era
@@ -996,10 +1000,6 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
         if txPlutusScriptExecutionCost > W.Coin 0
             then SelectionCollateralRequired
             else SelectionCollateralNotRequired
-
-    (positiveBundle, negativeBundle) = posAndNegFromCardanoValue balance
-    valueOfOutputs = F.foldMap (view #tokens) outs
-    valueOfInputs = UTxOSelection.selectedBalance utxoSelection
 
     feePerByte = getFeePerByte era pp
 

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -957,9 +957,8 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
         -- outputs + fee0@ where @balance0@ is the balance of the
         -- partial tx.
         { extraValueIn = mconcat
-            [ TokenBundle.fromTokenMap positiveTokens
+            [ positiveBundle
             , TokenBundle.fromTokenMap tokensInOutputs
-            , TokenBundle.fromCoin positiveAda
             , TokenBundle.fromCoin adaInOutputs
             , TokenBundle.fromCoin fee0
             ]
@@ -1002,7 +1001,6 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
             else SelectionCollateralNotRequired
 
     (positiveBundle, negativeBundle) = posAndNegFromCardanoValue balance
-    TokenBundle positiveAda positiveTokens = positiveBundle
     TokenBundle negativeAda negativeTokens = negativeBundle
     adaInOutputs = F.foldMap (TokenBundle.getCoin . view #tokens) outs
     tokensInOutputs = F.foldMap (TokenBundle.tokens . view #tokens) outs

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -971,7 +971,7 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
         }
       where
         (balancePositive, balanceNegative) = posAndNegFromCardanoValue balance
-        valueOfOutputs = F.foldMap (view #tokens) outs
+        valueOfOutputs = F.foldMap' (view #tokens) outs
         valueOfInputs = UTxOSelection.selectedBalance utxoSelection
 
     mkLedgerTxOut

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -963,8 +963,7 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
             ]
         , extraValueOut = mconcat
             [ negativeBundle
-            , TokenBundle.fromTokenMap tokensInInputs
-            , TokenBundle.fromCoin adaInInputs
+            , valueOfInputs
             ]
         -- NOTE: It is important that coin selection has the correct
         -- notion of fees, because it will be used to tell how much
@@ -1000,8 +999,7 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
 
     (positiveBundle, negativeBundle) = posAndNegFromCardanoValue balance
     valueOfOutputs = F.foldMap (view #tokens) outs
-    TokenBundle adaInInputs tokensInInputs =
-        UTxOSelection.selectedBalance utxoSelection
+    valueOfInputs = UTxOSelection.selectedBalance utxoSelection
 
     feePerByte = getFeePerByte era pp
 

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -958,8 +958,7 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
         -- partial tx.
         { extraValueIn = mconcat
             [ positiveBundle
-            , TokenBundle.fromTokenMap tokensInOutputs
-            , TokenBundle.fromCoin adaInOutputs
+            , valueOfOutputs
             , TokenBundle.fromCoin fee0
             ]
         , extraValueOut = mconcat
@@ -1001,8 +1000,6 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
 
     (positiveBundle, negativeBundle) = posAndNegFromCardanoValue balance
     valueOfOutputs = F.foldMap (view #tokens) outs
-    adaInOutputs = view #coin valueOfOutputs
-    tokensInOutputs = view #tokens valueOfOutputs
     TokenBundle adaInInputs tokensInInputs =
         UTxOSelection.selectedBalance utxoSelection
 

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -956,15 +956,10 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
         -- algorithm's notion of balance by @balance0 - sum inputs + sum
         -- outputs + fee0@ where @balance0@ is the balance of the
         -- partial tx.
-        { extraValueIn = mconcat
-            [ positiveBundle
-            , valueOfOutputs
-            , TokenBundle.fromCoin fee0
-            ]
-        , extraValueOut = mconcat
-            [ negativeBundle
-            , valueOfInputs
-            ]
+        { extraValueIn =
+            positiveBundle <> valueOfOutputs <> TokenBundle.fromCoin fee0
+        , extraValueOut =
+            negativeBundle <> valueOfInputs
         -- NOTE: It is important that coin selection has the correct
         -- notion of fees, because it will be used to tell how much
         -- collateral is needed.

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -957,9 +957,9 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
         -- outputs + fee0@ where @balance0@ is the balance of the
         -- partial tx.
         { extraValueIn =
-            positiveBundle <> valueOfOutputs <> TokenBundle.fromCoin fee0
+            balancePositive <> valueOfOutputs <> TokenBundle.fromCoin fee0
         , extraValueOut =
-            negativeBundle <> valueOfInputs
+            balanceNegative <> valueOfInputs
         -- NOTE: It is important that coin selection has the correct
         -- notion of fees, because it will be used to tell how much
         -- collateral is needed.
@@ -970,7 +970,7 @@ selectAssets era (ProtocolParameters pp) txWitnessTag outs redeemers
         , selectionStrategy = selectionStrategy
         }
       where
-        (positiveBundle, negativeBundle) = posAndNegFromCardanoValue balance
+        (balancePositive, balanceNegative) = posAndNegFromCardanoValue balance
         valueOfOutputs = F.foldMap (view #tokens) outs
         valueOfInputs = UTxOSelection.selectedBalance utxoSelection
 


### PR DESCRIPTION
## Issue

None. Spotted an opportunity for simplification while reviewing PRs.

## Summary

In this PR, we:
- Coalesce four "extra value" fields of `SelectionParams` to just a pair of fields: `extraValue{In,Out}`. These fields are used to adjust the coin selection algorithm's notion of extra value on the input and output sides of a transaction.
    - Before this PR, the `{ada,tokens}InOutputs` values were computed separately and passed separately.
    - With this PR, the value of the outputs can be computed with a single traversal.
- Move definitions of extra input and output value closer to their usage sites.

## Potential Future Work

In the future, we can consider pushing this simplification further into the coin selection algorithm. But that's probably best left for another day, in order to keep this PR simple.