### PR TITLE
Fix warnings on GHC 9.2

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1952,11 +1952,10 @@ data ErrGetAsset
 -- | All assets associated with this wallet, and their metadata (if metadata is
 -- available). This list may include assets which have already been spent.
 listAssets
-    :: forall ctx s k
+    :: forall ctx s
      . ( ctx ~ ApiLayer s 'CredFromKeyK
        , IsOurs s Address
        , HasTokenMetadataClient ctx
-       , k ~ KeyOf s
        )
     => ctx
     -> ApiT WalletId

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -27,7 +27,7 @@ import Cardano.Wallet.DB.Store.Transactions.Model
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter, interpretQuery, slotToUTCTime )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxCBOR, TxMeta (..) )
+    ( TxCBOR )
 import Cardano.Wallet.Read.Eras
     ( EraFun, EraValue, K, applyEraFun, extractEraValue )
 import Cardano.Wallet.Read.Primitive.Tx.Features.CollateralInputs


### PR DESCRIPTION
Fixes the following two warnings:

```
src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs:30:15: warning: [-Wunused-imports]
    The import of ÔTxMetaÕ
    from module ÔCardano.Wallet.Primitive.Types.TxÕ is redundant
   |
30 |     ( TxCBOR, TxMeta (..) )
   |               ^^^^^^^^^^^

api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs:1954:1: warning: [-Wredundant-constraints]
    ¥ Redundant constraint: k ~ KeyOf s
    ¥ In the type signature for:
           listAssets :: forall ctx s (k :: Depth -> * -> *).
                         (ctx ~ ApiLayer s 'CredFromKeyK, IsOurs s Address,
                          HasTokenMetadataClient ctx, k ~ KeyOf s) =>
                         ctx -> ApiT WalletId -> Handler [ApiAsset]
     |
1954 | listAssets
     | ^^^^^^^^^^...
```
