### PR TITLE
Add debugging to the restore benchmark.

### DIFF
--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -215,7 +215,7 @@ import Numeric
 import Ouroboros.Network.Client.Wallet
     ( PipeliningStrategy, tunedForMainnetPipeliningStrategy )
 import Say
-    ( sayErr )
+    ( sayErr, sayShow )
 import System.Exit
     ( exitWith )
 import System.FilePath
@@ -470,6 +470,15 @@ benchmarksRnd network w@(WalletLayer _ _ netLayer txLayer dbLayer) wname
         $ unsafeRunExceptT
         $ W.listTransactions @_ @s w Nothing Nothing Nothing Descending
             Nothing
+
+    -- To aid with debugging, write the current wallet state to the log:
+    let walletOverview = WalletOverview{utxo,addresses,transactions}
+    sayShow $ unlines
+        [ "Wallet overview (rnd):"
+        , show benchname
+        , show walletOverview
+        ]
+
     (_, listTransactionsLimitedTime) <- bench "list transactions (max_count = 100)" $ do
         unsafeRunExceptT
         $ W.listTransactions @_ @s w Nothing Nothing Nothing Descending
@@ -505,8 +514,6 @@ benchmarksRnd network w@(WalletLayer _ _ netLayer txLayer dbLayer) wname
     (_, importManyAddressesTime) <- bench "import many addresses" $ do
         runExceptT $ withExceptT show $
             W.importRandomAddresses @_ @s w manyAddresses
-
-    let walletOverview = WalletOverview{utxo,addresses,transactions}
 
     pure BenchRndResults
         { benchName = benchname
@@ -578,6 +585,15 @@ benchmarksSeq network w@(WalletLayer _ _ netLayer txLayer dbLayer) _wname
         $ unsafeRunExceptT
         $ W.listTransactions @_ @s w Nothing Nothing Nothing Descending
             Nothing
+
+    -- To aid with debugging, write the current wallet state to the log:
+    let walletOverview = WalletOverview{utxo,addresses,transactions}
+    sayShow $ unlines
+        [ "Wallet overview (seq):"
+        , show benchname
+        , show walletOverview
+        ]
+
     (_, listTransactionsLimitedTime) <- bench "list transactions (max_count = 100)" $ do
         unsafeRunExceptT
         $ W.listTransactions @_ @s w Nothing Nothing Nothing Descending
@@ -603,8 +619,6 @@ benchmarksSeq network w@(WalletLayer _ _ netLayer txLayer dbLayer) _wname
             dummyChangeAddressGen
             defaultTransactionCtx
             (PreSelection [outputWithZeroAda])
-
-    let walletOverview = WalletOverview{utxo,addresses,transactions}
 
     pure BenchSeqResults
         { benchName = benchname

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -593,6 +593,7 @@ benchmarksSeq network w@(WalletLayer _ _ netLayer txLayer dbLayer) _wname
         -- automatically assign a minimal amount of lovelace to the output
         -- before balancing the transaction and computing the fee:
         let bundleWithZeroAda = TokenBundle.fromCoin (Coin 0)
+        let outputWithZeroAda = TxOut (dummyAddress network) bundleWithZeroAda
         W.transactionFee @s
             dbLayer
             (Write.unsafeFromWalletProtocolParameters protocolParameters)
@@ -601,8 +602,7 @@ benchmarksSeq network w@(WalletLayer _ _ netLayer txLayer dbLayer) _wname
             recentEra
             dummyChangeAddressGen
             defaultTransactionCtx
-            (PreSelection
-                [TxOut (dummyAddress network) bundleWithZeroAda])
+            (PreSelection [outputWithZeroAda])
 
     let walletOverview = WalletOverview{utxo,addresses,transactions}
 


### PR DESCRIPTION
## Issue

ADP-3011

## Summary

This PR adjusts the restore benchmark so that we compute and print out an overview of the wallet state (including UTxO distribution) before attempting to call the `estimateTxFee` endpoint.

## Motivation

The `estimateTxFee` endpoint currently fails with an error that indicates there are no funds available. We'd like to learn more about state the wallet is in just before `estimateTxFee` is called.

Sample error:

```hs
ExceptionSelectAssets
  (ErrSelectAssetsSelectionError
  (SelectionBalanceErrorOf
  (BalanceInsufficient
  (BalanceInsufficientError
    { utxoBalanceAvailable = TokenBundle
      { coin = Coin 0
      , tokens = TokenMap (fromList [])
      }
    , utxoBalanceRequired = TokenBundle
      { coin = Coin 995610
      , tokens = TokenMap (fromList [])
      }
    , utxoBalanceShortfall = TokenBundle
      { coin = Coin 995610
      , tokens = TokenMap (fromList [])
      }
    }
 ))))
```