### PR TITLE
Reduce usage of `unsafeSubtract`.

### DIFF
--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -1338,7 +1338,7 @@ makeChange criteria
     -- that the total input value is greater than the total output
     -- value:
     excess :: TokenBundle
-    excess = totalInputValue `TokenBundle.unsafeSubtract` totalOutputValue
+    excess = totalInputValue `TokenBundle.difference` totalOutputValue
 
     (excessCoin, excessAssets) = TokenBundle.toFlatList excess
 

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -2806,7 +2806,7 @@ prop_makeChange_success_delta p change =
             totalOutputValue
             (F.fold change)
 
-        delta = TokenBundle.unsafeSubtract totalInputValue totalOutputWithChange
+        delta = TokenBundle.difference totalInputValue totalOutputWithChange
     in
         (delta === TokenBundle.fromCoin (view #requiredCost p))
             & counterexample counterExampleText
@@ -2890,7 +2890,7 @@ prop_makeChange_fail_costTooBig
     -> Property
 prop_makeChange_fail_costTooBig p =
     let
-        deltaCoin = TokenBundle.getCoin $ TokenBundle.unsafeSubtract
+        deltaCoin = TokenBundle.getCoin $ TokenBundle.difference
             totalInputValue
             totalOutputValue
     in
@@ -2947,7 +2947,7 @@ prop_makeChange_fail_minValueTooBig p =
                 , "totalMinCoinDeposit:"
                 , pretty totalMinCoinDeposit
                 ]
-            deltaCoin = TokenBundle.getCoin $ TokenBundle.unsafeSubtract
+            deltaCoin = TokenBundle.getCoin $ TokenBundle.difference
                 totalInputValue
                 totalOutputValue
             minCoinValueFor =

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -307,7 +307,7 @@ delete u i =
         -- This operation is safe, since we have already determined that the
         -- entry is a member of the index, and therefore the balance must be
         -- greater than or equal to the value of this output:
-        & over #balance (`TokenBundle.unsafeSubtract` b)
+        & over #balance (`TokenBundle.difference` b)
         & over #universe (Map.delete u)
         & case categorizeTokenBundle b of
             BundleWithNoAssets -> id

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
@@ -17,14 +17,7 @@ import Algebra.PartialOrd
 import Cardano.Numeric.Util
     ( inAscendingPartialOrder )
 import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( Lexicographic (..)
-    , TokenBundle (..)
-    , add
-    , difference
-    , isCoin
-    , subtract
-    , unsafeSubtract
-    )
+    ( Lexicographic (..), TokenBundle (..), add, difference, isCoin, subtract )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundlePartition
     , genTokenBundleSmallRange
@@ -165,8 +158,8 @@ prop_difference_equality x y = checkCoverage $
         "reduced bundles are not coins" $
     xReduced === yReduced
   where
-    xReduced = x `unsafeSubtract` xExcess
-    yReduced = y `unsafeSubtract` yExcess
+    xReduced = x `difference` xExcess
+    yReduced = y `difference` yExcess
     xExcess = x `difference` y
     yExcess = y `difference` x
 

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -559,8 +559,8 @@ prop_difference_equality x y = checkCoverage $
         "reduced maps are not empty" $
     xReduced === yReduced
   where
-    xReduced = x `TokenMap.unsafeSubtract` xExcess
-    yReduced = y `TokenMap.unsafeSubtract` yExcess
+    xReduced = x `TokenMap.difference` xExcess
+    yReduced = y `TokenMap.difference` yExcess
     xExcess = x `TokenMap.difference` y
     yExcess = y `TokenMap.difference` x
 
@@ -812,7 +812,7 @@ prop_equipartitionQuantities_fair m count = property $
     --  - the greatest quantity of that token in the resulting maps.
     --
     differences :: TokenMap
-    differences = NE.last results `TokenMap.unsafeSubtract` NE.head results
+    differences = NE.last results `TokenMap.difference` NE.head results
 
     isZeroOrOne :: TokenQuantity -> Bool
     isZeroOrOne (TokenQuantity q) = q == 0 || q == 1

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -279,7 +279,7 @@ prop_delete_balance u i =
         Nothing ->
             UTxOIndex.balance i
         Just b ->
-            UTxOIndex.balance i `TokenBundle.unsafeSubtract` b
+            UTxOIndex.balance i `TokenBundle.difference` b
 
 prop_delete_lookup
     :: u ~ Size 4 TestUTxO => u -> UTxOIndex u -> Property
@@ -318,7 +318,7 @@ prop_insert_balance u b i =
         Nothing ->
             UTxOIndex.balance i
         Just b' ->
-            UTxOIndex.balance i `TokenBundle.unsafeSubtract` b'
+            UTxOIndex.balance i `TokenBundle.difference` b'
 
 prop_insert_delete
     :: u ~ Size 4 TestUTxO => u -> TokenBundle -> UTxOIndex u -> Property

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -2364,7 +2364,7 @@ prop_spendTx_balance tx u =
     lhs === rhs
   where
     lhs = balance (spendTx tx u)
-    rhs = TokenBundle.unsafeSubtract
+    rhs = TokenBundle.difference
         (balance u)
         (balance (u `UTxO.restrictedBy` inputsSpentByTx tx))
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -987,7 +987,7 @@ prop_2_6_2 (ins, u) =
     prop =
         balance (u `excluding` ins)
             ===
-        balance u `TokenBundle.unsafeSubtract` balance (u `restrictedBy` ins)
+        balance u `TokenBundle.difference` balance (u `restrictedBy` ins)
 
 {-------------------------------------------------------------------------------
                         UTxO statistics Properties


### PR DESCRIPTION
## Issue

None. Noticed during code review.

## Summary

Where applicable and safe to do so, this PR converts certain expressions that manipulate `TokenBundle` and `TokenMap` values to use `difference` instead of `unsafeSubtract`.

Given a partial order `>=`,  we can write ``a `difference` b`` in cases where either:
   - we do care that ``a >= b`` holds and have already verified it to be true; or
   - we don't care whether or not ``a >= b`` holds.
       - i.e., we only care about computing the part of `a` that is in excess of `b`.

The `difference` operation behaves analogously to:
- truncated subtraction of natural numbers.
- ordinary set difference.

More generally, the `difference` operation is an example of [monus](https://en.wikipedia.org/wiki/Monus) subtraction for commutative monoids.

## Future work

Remove the `unsafeSubtract` operation, or restrict it to test suites. We can't yet do this, because various `subtract` operations are defined in terms of `unsafeSubtract`.