### PR TITLE
Don't differentiate Icarus from Byron in `TxWitnessTag`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Address/Derivation/Icarus.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Derivation/Icarus.hs
@@ -136,7 +136,7 @@ newtype IcarusKey (depth :: Depth) key =
 instance NFData key => NFData (IcarusKey depth key)
 
 instance TxWitnessTagFor IcarusKey where
-    txWitnessTagFor = TxWitnessByronIcarusUTxO
+    txWitnessTagFor = TxWitnessByronUTxO
 
 -- | The minimum seed length for 'generateKeyFromSeed' and 'unsafeGenerateKeyFromSeed'.
 minSeedLengthBytes :: Int

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -546,8 +546,6 @@ signTransaction
                 mkShelleyWitness body (getRawKey k, pwd)
             TxWitnessByronUTxO ->
                 mkByronWitness body networkId addr (getRawKey k, pwd)
-            TxWitnessByronIcarusUTxO ->
-                mkByronWitness body networkId addr (getRawKey k, pwd)
 
     mkWdrlCertWitness :: RewardAccount -> Maybe (Cardano.KeyWitness era)
     mkWdrlCertWitness a =
@@ -1745,7 +1743,6 @@ estimateTxSize era skeleton =
     numberOf_VkeyWitnesses
         = case txWitnessTag of
             TxWitnessByronUTxO -> 0
-            TxWitnessByronIcarusUTxO -> 0
             TxWitnessShelleyUTxO ->
                 if numberOf_ScriptVkeyWitnesses == 0 then
                     numberOf_Inputs
@@ -1761,7 +1758,6 @@ estimateTxSize era skeleton =
     numberOf_BootstrapWitnesses
         = case txWitnessTag of
             TxWitnessByronUTxO -> numberOf_Inputs
-            TxWitnessByronIcarusUTxO -> numberOf_Inputs
             TxWitnessShelleyUTxO -> 0
 
     -- transaction =
@@ -1992,7 +1988,6 @@ estimateTxSize era skeleton =
     sizeOf_ChangeAddress
         = case txWitnessTag of
             TxWitnessByronUTxO -> 85
-            TxWitnessByronIcarusUTxO -> 85
             TxWitnessShelleyUTxO -> 59
 
     -- value = coin / [coin,multiasset<uint>]

--- a/lib/wallet/src/Cardano/Wallet/TxWitnessTag.hs
+++ b/lib/wallet/src/Cardano/Wallet/TxWitnessTag.hs
@@ -13,7 +13,6 @@ import Data.Kind
 
 data TxWitnessTag
     = TxWitnessByronUTxO
-    | TxWitnessByronIcarusUTxO
     | TxWitnessShelleyUTxO
     deriving (Show, Eq)
 


### PR DESCRIPTION
The differentiation between TxWitnessByronUTxO and TxWitnessByronIcarusUTxO isn't needed. Where we case-switch the logic appears to be exactly the same.

Context and motivation: At a high level we're moving from

```
Proxy k -> TxWitnessTag
```

(modulo constraints) to

```
Proxy k -> UTxOAssumptions -> TxWitnessTag
```

where `UTxOAssumptions` treats Byron and Icarus the same, and maps it to the same `TxWitnessTag`.

By showing the byron-icarus differentiation in `TxWitnessTag` is unneeded we can be assured that it is also unneeded in `UTxOAssumptions`, and we can get by without adding a new Icarus-specific `UTxOAssumptions` constructor.


### Comments

Targets #3937 
