### PR TITLE
Do not benchmark estimation of fees for empty wallets.

### DIFF
--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -484,7 +484,7 @@ benchmarksRnd network w wname
         $ W.listTransactions @_ @s w Nothing Nothing Nothing Descending
             (Just 100)
 
-    (_, estimateFeesTime) <- benchEstimateTxFee network w
+    estimateFeesTime <- benchEstimateTxFee network w
 
     oneAddress <- genAddresses 1 cp
     (_, importOneAddressTime) <- bench "import one addresses" $ do
@@ -578,7 +578,7 @@ benchmarksSeq network w _wname
         $ W.listTransactions @_ @s w Nothing Nothing Nothing Descending
             (Just 100)
 
-    (_, estimateFeesTime) <- benchEstimateTxFee network w
+    estimateFeesTime <- benchEstimateTxFee network w
 
     pure BenchSeqResults
         { benchName = benchname
@@ -1008,9 +1008,9 @@ benchEstimateTxFee
     :: forall n s. (AddressBookIso s, WalletFlavor s)
     => SNetworkId n
     -> WalletLayer IO s 'CredFromKeyK
-    -> IO ((W.Percentile 10 W.Fee, W.Percentile 90 W.Fee), Time)
+    -> IO Time
 benchEstimateTxFee network (WalletLayer _ _ netLayer txLayer dbLayer) =
-    bench "estimate tx fee" $ do
+    fmap snd <$> bench "estimate tx fee" $ do
         AnyRecentEra (recentEra :: Write.RecentEra era) <-
             guardIsRecentEra =<< currentNodeEra netLayer
         (protocolParameters, _bundledProtocolParameters) <-

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -21,7 +21,6 @@
 
 {- HLINT ignore "Redundant pure" -}
 
-
 -- | Benchmark measuring how long restoration takes for different wallets.
 --
 -- Easiest run using
@@ -37,7 +36,6 @@
 --
 -- since it relies on lots of configuration most most easily retrieved with nix.
 --
-
 module Main where
 
 import Prelude
@@ -536,8 +534,6 @@ benchmarksRnd network w@(WalletLayer _ _ netLayer txLayer dbLayer) wname
       where
         seed = dummySeedFromName $ getWalletName wname
         xprv = Byron.generateKeyFromSeed seed mempty
-
-
 
 data BenchSeqResults = BenchSeqResults
     { benchName :: Text

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -430,7 +430,7 @@ data BenchRndResults = BenchRndResults
     , listTransactionsLimitedTime :: Time
     , importOneAddressTime :: Time
     , importManyAddressesTime :: Time
-    , estimateFeesTime :: Time
+    , estimateFeesTime :: Either CannotEstimateFeeForWalletWithEmptyUTxO Time
     , walletOverview :: WalletOverview
     } deriving (Show, Generic)
 
@@ -503,7 +503,7 @@ benchmarksRnd network w wname
         , listAddressesTime
         , listTransactionsTime
         , listTransactionsLimitedTime
-        , estimateFeesTime
+        , estimateFeesTime = Right estimateFeesTime
         , importOneAddressTime
         , importManyAddressesTime
         , walletOverview
@@ -525,7 +525,7 @@ data BenchSeqResults = BenchSeqResults
     , listAddressesTime :: Time
     , listTransactionsTime :: Time
     , listTransactionsLimitedTime :: Time
-    , estimateFeesTime :: Time
+    , estimateFeesTime :: Either CannotEstimateFeeForWalletWithEmptyUTxO Time
     , walletOverview :: WalletOverview
     } deriving (Show, Generic)
 
@@ -587,7 +587,7 @@ benchmarksSeq network w _wname
         , listAddressesTime
         , listTransactionsTime
         , listTransactionsLimitedTime
-        , estimateFeesTime
+        , estimateFeesTime = Right estimateFeesTime
         , walletOverview
         }
 
@@ -1030,3 +1030,13 @@ benchEstimateTxFee network (WalletLayer _ _ netLayer txLayer dbLayer) =
             dummyChangeAddressGen
             defaultTransactionCtx
             (PreSelection [outputWithZeroAda])
+
+data CannotEstimateFeeForWalletWithEmptyUTxO =
+    CannotEstimateFeeForWalletWithEmptyUTxO
+    deriving (Show, Generic)
+
+instance Buildable CannotEstimateFeeForWalletWithEmptyUTxO where
+    build = genericF
+
+instance ToJSON CannotEstimateFeeForWalletWithEmptyUTxO where
+    toJSON = genericToJSON Aeson.defaultOptions

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -1009,6 +1009,7 @@ benchmark restore
     , cardano-wallet-bench
     , cardano-wallet-integration
     , cardano-wallet-primitive
+    , containers
     , contra-tracer
     , deepseq
     , filepath


### PR DESCRIPTION
## Issue

ADP-3011

## Summary

This PR adjusts the restoration benchmark so that it no longer attempts to estimate transaction fees for wallets with no UTxOs available.

## Context

Attempting to estimate a transaction fee for a wallet with no available UTxOs will always fail with an error similar to:
```hs
ExceptionSelectAssets
  (ErrSelectAssetsSelectionError
  (SelectionBalanceErrorOf
  (BalanceInsufficient
  (BalanceInsufficientError
    { utxoBalanceAvailable = TokenBundle {coin = Coin      0, tokens = TokenMap (fromList [])}
    , utxoBalanceRequired  = TokenBundle {coin = Coin 995610, tokens = TokenMap (fromList [])}
    , utxoBalanceShortfall = TokenBundle {coin = Coin 995610, tokens = TokenMap (fromList [])}
    }
  ))))
```

This error has caused recent benchmark runs to fail. For example:
- https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1806#01882c46-0871-441b-b750-3340dfe361e2