### PR TITLE
Split out `Write.Era` module

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -396,6 +396,7 @@ library
     Cardano.Wallet.TypeLevel
     Cardano.Wallet.Version
     Cardano.Wallet.Version.TH
+    Cardano.Wallet.Write.Era
     Cardano.Wallet.Write.ProtocolParameters
     Cardano.Wallet.Write.Tx
     Cardano.Wallet.Write.Tx.Balance

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2061,7 +2061,7 @@ buildAndSignTransactionPure
             , builtSealedTx = signedTx
             }
   where
-    anyCardanoEra = Write.fromAnyRecentEra era
+    anyCardanoEra = Write.toAnyCardanoEra era
 
 buildTransaction
     :: forall s era.

--- a/lib/wallet/src/Cardano/Wallet/DB/Migration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Migration.hs
@@ -40,12 +40,10 @@ import Control.Monad.Reader
     ( ReaderT (runReaderT) )
 import Data.Proxy
     ( Proxy (..) )
-import GHC.Base
-    ( Nat )
 import GHC.Natural
     ( Natural )
 import GHC.TypeNats
-    ( type (+), KnownNat, natVal )
+    ( type (+), KnownNat, Nat, natVal )
 
 --------------------------------------------------------------------------------
 -------  public ----------------------------------------------------------------

--- a/lib/wallet/src/Cardano/Wallet/Write/Era.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Era.hs
@@ -1,0 +1,241 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2022 IOHK
+-- License: Apache-2.0
+--
+-- Module mainly for containing 'RecentEra' and related functionality.
+module Cardano.Wallet.Write.Era
+    (
+    -- ** RecentEra
+      RecentEra (..)
+    , IsRecentEra (..)
+    , toRecentEra
+    , fromRecentEra
+
+    , LatestLedgerEra
+    , LatestEra
+
+    , cardanoEra
+    , shelleyBasedEra
+    , ShelleyLedgerEra
+    , cardanoEraFromRecentEra
+    , shelleyBasedEraFromRecentEra
+
+    -- ** InAnyRecentEra
+    , InAnyRecentEra (..)
+    , withInAnyRecentEra
+
+    -- ** AnyRecentEra
+    , AnyRecentEra (..)
+    , asAnyRecentEra
+    , toAnyCardanoEra
+    , fromAnyCardanoEra
+    , withRecentEra
+
+    -- ** Misc
+    , StandardCrypto
+    , StandardBabbage
+    , StandardConway
+    )
+
+where
+
+import Prelude
+
+import Cardano.Api
+    ( BabbageEra, ConwayEra )
+import Cardano.Api.Shelley
+    ( ShelleyLedgerEra )
+import Data.Type.Equality
+    ( (:~:) (Refl), TestEquality (testEquality) )
+import Data.Typeable
+    ( Typeable )
+import Ouroboros.Consensus.Shelley.Eras
+    ( StandardBabbage, StandardConway, StandardCrypto )
+
+import qualified Cardano.Api as Cardano
+import Data.Maybe
+    ( fromMaybe, isJust )
+
+--------------------------------------------------------------------------------
+-- Eras
+--------------------------------------------------------------------------------
+
+type LatestEra = ConwayEra
+
+type LatestLedgerEra = StandardConway
+
+--------------------------------------------------------------------------------
+-- RecentEra
+--------------------------------------------------------------------------------
+
+-- | 'RecentEra' respresents the eras we care about constructing transactions
+-- for.
+--
+-- To have the same software constructing transactions just before and just
+-- after a hard-fork, we need to, at that time, support the two latest eras. We
+-- could get away with just supporting one era at other times, but for
+-- simplicity we stick with always supporting the two latest eras for now.
+--
+-- NOTE: We /could/ let 'era' refer to eras from the ledger rather than from
+-- cardano-api.
+data RecentEra era where
+    RecentEraBabbage :: RecentEra BabbageEra
+    RecentEraConway :: RecentEra ConwayEra
+
+deriving instance Eq (RecentEra era)
+deriving instance Show (RecentEra era)
+
+instance TestEquality RecentEra where
+    testEquality RecentEraBabbage RecentEraBabbage = Just Refl
+    testEquality RecentEraConway RecentEraConway = Just Refl
+    testEquality RecentEraBabbage RecentEraConway = Nothing
+    testEquality RecentEraConway RecentEraBabbage = Nothing
+
+class
+    ( Cardano.IsShelleyBasedEra era
+    , Typeable era
+    ) => IsRecentEra era where
+    recentEra :: RecentEra era
+
+-- | Return a proof that the wallet can create txs in this era, or @Nothing@.
+toRecentEra :: Cardano.CardanoEra era -> Maybe (RecentEra era)
+toRecentEra = \case
+    Cardano.ConwayEra  -> Just RecentEraConway
+    Cardano.BabbageEra -> Just RecentEraBabbage
+    Cardano.AlonzoEra  -> Nothing
+    Cardano.MaryEra    -> Nothing
+    Cardano.AllegraEra -> Nothing
+    Cardano.ShelleyEra -> Nothing
+    Cardano.ByronEra   -> Nothing
+
+fromRecentEra :: RecentEra era -> Cardano.CardanoEra era
+fromRecentEra = \case
+  RecentEraConway -> Cardano.ConwayEra
+  RecentEraBabbage -> Cardano.BabbageEra
+
+instance IsRecentEra BabbageEra where
+    recentEra = RecentEraBabbage
+
+instance IsRecentEra ConwayEra where
+    recentEra = RecentEraConway
+
+cardanoEraFromRecentEra :: RecentEra era -> Cardano.CardanoEra era
+cardanoEraFromRecentEra =
+    Cardano.shelleyBasedToCardanoEra
+    . shelleyBasedEraFromRecentEra
+
+shelleyBasedEraFromRecentEra :: RecentEra era -> Cardano.ShelleyBasedEra era
+shelleyBasedEraFromRecentEra = \case
+    RecentEraConway -> Cardano.ShelleyBasedEraConway
+    RecentEraBabbage -> Cardano.ShelleyBasedEraBabbage
+
+-- | For convenience working with 'IsRecentEra'. Similar to 'Cardano.cardanoEra,
+-- but with a 'IsRecentEra era' constraint instead of 'Cardano.IsCardanoEra.
+cardanoEra :: forall era. IsRecentEra era => Cardano.CardanoEra era
+cardanoEra = cardanoEraFromRecentEra $ recentEra @era
+
+-- | For convenience working with 'IsRecentEra'. Similar to
+-- 'Cardano.shelleyBasedEra, but with a 'IsRecentEra era' constraint instead of
+-- 'Cardano.IsShelleyBasedEra'.
+shelleyBasedEra :: forall era. IsRecentEra era => Cardano.ShelleyBasedEra era
+shelleyBasedEra = shelleyBasedEraFromRecentEra $ recentEra @era
+
+--------------------------------------------------------------------------------
+-- InAnyRecentEra
+--------------------------------------------------------------------------------
+
+data InAnyRecentEra thing where
+     InAnyRecentEra
+         :: IsRecentEra era -- Provide class constraint
+         => RecentEra era   -- and explicit value.
+         -> thing era
+         -> InAnyRecentEra thing
+
+withInAnyRecentEra
+    :: InAnyRecentEra thing
+    -> (forall era. IsRecentEra era => thing era -> a)
+    -> a
+withInAnyRecentEra (InAnyRecentEra _era tx) f = f tx
+
+-- | "Downcast" something existentially wrapped in 'Cardano.InAnyCardanoEra'.
+asAnyRecentEra
+    :: Cardano.InAnyCardanoEra a
+    -> Maybe (InAnyRecentEra a)
+asAnyRecentEra = \case
+    Cardano.InAnyCardanoEra Cardano.ByronEra _ ->
+        Nothing
+    Cardano.InAnyCardanoEra Cardano.ShelleyEra _ ->
+        Nothing
+    Cardano.InAnyCardanoEra Cardano.AllegraEra _ ->
+        Nothing
+    Cardano.InAnyCardanoEra Cardano.MaryEra _ ->
+        Nothing
+    Cardano.InAnyCardanoEra Cardano.AlonzoEra _ ->
+        Nothing
+    Cardano.InAnyCardanoEra Cardano.BabbageEra a ->
+        Just $ InAnyRecentEra RecentEraBabbage a
+    Cardano.InAnyCardanoEra Cardano.ConwayEra a ->
+        Just $ InAnyRecentEra RecentEraConway a
+
+--------------------------------------------------------------------------------
+-- AnyRecentEra
+--------------------------------------------------------------------------------
+
+-- | An existential type like 'AnyCardanoEra', but for 'RecentEra'.
+data AnyRecentEra where
+     AnyRecentEra :: IsRecentEra era -- Provide class constraint
+                  => RecentEra era   -- and explicit value.
+                  -> AnyRecentEra    -- and that's it.
+
+instance Enum AnyRecentEra where
+    -- NOTE: We're not starting at 0! 0 would be Byron, which is not a recent
+    -- era.
+    fromEnum = fromEnum . toAnyCardanoEra
+    toEnum n = fromMaybe err . fromAnyCardanoEra $ toEnum n
+      where
+        err = error $ unwords
+            [ "AnyRecentEra.toEnum:", show n
+            , "doesn't correspond to a recent era."
+            ]
+instance Bounded AnyRecentEra where
+    minBound = AnyRecentEra RecentEraBabbage
+    maxBound = AnyRecentEra RecentEraConway
+
+instance Show AnyRecentEra where
+    show (AnyRecentEra era) = "AnyRecentEra " <> show era
+
+instance Eq AnyRecentEra where
+    AnyRecentEra e1 == AnyRecentEra e2 =
+        isJust $ testEquality e1 e2
+
+toAnyCardanoEra :: AnyRecentEra -> Cardano.AnyCardanoEra
+toAnyCardanoEra (AnyRecentEra era) = Cardano.AnyCardanoEra (fromRecentEra era)
+
+fromAnyCardanoEra
+    :: Cardano.AnyCardanoEra
+    -> Maybe AnyRecentEra
+fromAnyCardanoEra = \case
+    Cardano.AnyCardanoEra Cardano.ByronEra -> Nothing
+    Cardano.AnyCardanoEra Cardano.ShelleyEra -> Nothing
+    Cardano.AnyCardanoEra Cardano.AllegraEra -> Nothing
+    Cardano.AnyCardanoEra Cardano.MaryEra -> Nothing
+    Cardano.AnyCardanoEra Cardano.AlonzoEra -> Nothing
+    Cardano.AnyCardanoEra Cardano.BabbageEra
+        -> Just $ AnyRecentEra RecentEraBabbage
+    Cardano.AnyCardanoEra Cardano.ConwayEra
+        -> Just $ AnyRecentEra RecentEraConway
+
+withRecentEra ::
+    AnyRecentEra -> (forall era. IsRecentEra era => RecentEra era -> a) -> a
+withRecentEra (AnyRecentEra era) f = f era

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -57,7 +57,7 @@ module Cardano.Wallet.Write.Tx
     , AnyRecentEra (..)
     , InAnyRecentEra (..)
     , asAnyRecentEra
-    , fromAnyRecentEra
+    , toAnyCardanoEra
     , withInAnyRecentEra
     , withRecentEra
 
@@ -384,8 +384,8 @@ data AnyRecentEra where
 instance Show AnyRecentEra where
     show (AnyRecentEra era) = "AnyRecentEra " <> show era
 
-fromAnyRecentEra :: AnyRecentEra -> Cardano.AnyCardanoEra
-fromAnyRecentEra (AnyRecentEra era) = Cardano.AnyCardanoEra (fromRecentEra era)
+toAnyCardanoEra :: AnyRecentEra -> Cardano.AnyCardanoEra
+toAnyCardanoEra (AnyRecentEra era) = Cardano.AnyCardanoEra (fromRecentEra era)
 
 withRecentEra ::
     AnyRecentEra -> (forall era. IsRecentEra era => RecentEra era -> a) -> a

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -200,7 +201,9 @@ import Data.Generics.Product
 import Data.IntCast
     ( intCast )
 import Data.Maybe
-    ( fromMaybe )
+    ( fromMaybe, isJust )
+import Data.Type.Equality
+    ( (:~:) (Refl), TestEquality (testEquality) )
 import Data.Typeable
     ( Typeable )
 import Numeric.Natural
@@ -258,6 +261,12 @@ data RecentEra era where
 
 deriving instance Eq (RecentEra era)
 deriving instance Show (RecentEra era)
+
+instance TestEquality RecentEra where
+    testEquality RecentEraBabbage RecentEraBabbage = Just Refl
+    testEquality RecentEraConway RecentEraConway = Just Refl
+    testEquality RecentEraBabbage RecentEraConway = Nothing
+    testEquality RecentEraConway RecentEraBabbage = Nothing
 
 class
     ( Cardano.IsShelleyBasedEra era
@@ -382,8 +391,26 @@ data AnyRecentEra where
                   => RecentEra era   -- and explicit value.
                   -> AnyRecentEra    -- and that's it.
 
+instance Enum AnyRecentEra where
+    -- NOTE: We're not starting at 0! 0 would be Byron, which is not a recent
+    -- era.
+    fromEnum = fromEnum . toAnyCardanoEra
+    toEnum n = fromMaybe err . fromAnyCardanoEra $ toEnum n
+      where
+        err = error $ unwords
+            [ "AnyRecentEra.toEnum:", show n
+            , "doesn't correspond to a recent era."
+            ]
+instance Bounded AnyRecentEra where
+    minBound = AnyRecentEra RecentEraBabbage
+    maxBound = AnyRecentEra RecentEraConway
+
 instance Show AnyRecentEra where
     show (AnyRecentEra era) = "AnyRecentEra " <> show era
+
+instance Eq AnyRecentEra where
+    AnyRecentEra e1 == AnyRecentEra e2 =
+        isJust $ testEquality e1 e2
 
 toAnyCardanoEra :: AnyRecentEra -> Cardano.AnyCardanoEra
 toAnyCardanoEra (AnyRecentEra era) = Cardano.AnyCardanoEra (fromRecentEra era)

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -58,6 +58,7 @@ module Cardano.Wallet.Write.Tx
     , InAnyRecentEra (..)
     , asAnyRecentEra
     , toAnyCardanoEra
+    , fromAnyCardanoEra
     , withInAnyRecentEra
     , withRecentEra
 
@@ -386,6 +387,20 @@ instance Show AnyRecentEra where
 
 toAnyCardanoEra :: AnyRecentEra -> Cardano.AnyCardanoEra
 toAnyCardanoEra (AnyRecentEra era) = Cardano.AnyCardanoEra (fromRecentEra era)
+
+fromAnyCardanoEra
+    :: Cardano.AnyCardanoEra
+    -> Maybe AnyRecentEra
+fromAnyCardanoEra = \case
+    Cardano.AnyCardanoEra Cardano.ByronEra -> Nothing
+    Cardano.AnyCardanoEra Cardano.ShelleyEra -> Nothing
+    Cardano.AnyCardanoEra Cardano.AllegraEra -> Nothing
+    Cardano.AnyCardanoEra Cardano.MaryEra -> Nothing
+    Cardano.AnyCardanoEra Cardano.AlonzoEra -> Nothing
+    Cardano.AnyCardanoEra Cardano.BabbageEra
+        -> Just $ AnyRecentEra RecentEraBabbage
+    Cardano.AnyCardanoEra Cardano.ConwayEra
+        -> Just $ AnyRecentEra RecentEraConway
 
 withRecentEra ::
     AnyRecentEra -> (forall era. IsRecentEra era => RecentEra era -> a) -> a

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -27,7 +27,7 @@
 module Cardano.Wallet.Write.Tx
     (
     -- * Eras
-    module Cardano.Wallet.Write.Era
+    module Cardano.Wallet.Write.Era -- until we create a Write umbrella module
 
     -- ** Key witness counts
     , KeyWitnessCount (..)

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -28,6 +28,7 @@ module Cardano.Wallet.Write.Tx
     (
     -- * Eras
     module Cardano.Wallet.Write.Era -- until we create a Write umbrella module
+    , withConstraints
 
     -- ** Key witness counts
     , KeyWitnessCount (..)


### PR DESCRIPTION
- [x] Split out Era related types and logic to make it easier to reason about
- [ ] Wanted to add some tests for these functions, but possibly for another PR

### Comments

- Could have gone with `Write.Eras` as module name instead.

### Issue

Triggered by ADP-2990