### PR TITLE
Test class laws for `AnyRecentEra`.

### DIFF
--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -51,11 +51,7 @@ import Cardano.BM.Trace
 import Cardano.Mnemonic
     ( SomeMnemonic (..), entropyToMnemonic )
 import Cardano.Wallet
-    ( WalletException (..)
-    , WalletLayer (..)
-    , WalletWorkerLog (..)
-    , dummyChangeAddressGen
-    )
+    ( WalletLayer (..), WalletWorkerLog (..), dummyChangeAddressGen )
 import Cardano.Wallet.Address.Book
     ( AddressBookIso )
 import Cardano.Wallet.Address.Derivation

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -2170,9 +2170,6 @@ selectFromPreparedBinaries = elements $ toByteString <$>
         let (Right bs) = fromHex $ T.encodeUtf8 txt
         in bs
 
-genWits :: Gen ByteString
-genWits = BS.pack <$> Test.QuickCheck.scale (min 32) (listOf arbitrary)
-
 deriving instance Arbitrary a => Arbitrary (ApiAsArray s a)
 
 instance Arbitrary (ApiBytesT base ByteString) where

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -483,7 +483,6 @@ import Test.QuickCheck
     , forAll
     , frequency
     , liftArbitrary
-    , listOf
     , oneof
     , property
     , scale

--- a/lib/wallet/test/unit/Cardano/Wallet/Write/TxSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Write/TxSpec.hs
@@ -18,7 +18,8 @@ import Cardano.Ledger.Babbage.TxBody
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Cardano.Wallet.Write.Tx
-    ( BinaryData
+    ( AnyRecentEra
+    , BinaryData
     , RecentEra (..)
     , Script
     , StandardBabbage
@@ -59,11 +60,18 @@ import Test.QuickCheck
     ( Arbitrary (..)
     , Arbitrary1 (liftArbitrary)
     , Property
+    , arbitraryBoundedEnum
     , conjoin
     , counterexample
     , property
     , (===)
     )
+import Test.QuickCheck.Classes
+    ( boundedEnumLaws, eqLaws, showLaws )
+import Test.QuickCheck.Extra
+    ( shrinkBoundedEnum )
+import Test.Utils.Laws
+    ( testLawsMany )
 
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Gen as Cardano
@@ -75,6 +83,15 @@ import qualified Data.Map as Map
 
 spec :: Spec
 spec = do
+
+    describe "AnyRecentEra" $ do
+        describe "Class instances obey laws" $ do
+            testLawsMany @AnyRecentEra
+                [ boundedEnumLaws
+                , eqLaws
+                , showLaws
+                ]
+
     describe "BinaryData" $ do
         it "BinaryData is isomorphic to Cardano.ScriptData" $
             testIsomorphism
@@ -264,6 +281,14 @@ testIsomorphism (NamedFun f fName) (NamedFun g gName) normalize =
             (gName <> " . " <> gName <> " == id")
             (property $ \x -> g (f x) === x)
         ]
+
+--------------------------------------------------------------------------------
+-- Arbitrary instances
+--------------------------------------------------------------------------------
+
+instance Arbitrary AnyRecentEra where
+    arbitrary = arbitraryBoundedEnum
+    shrink = shrinkBoundedEnum
 
 --------------------------------------------------------------------------------
 -- Test Data


### PR DESCRIPTION
## Issue

ADP-2990

## Summary

This PR tests that `AnyRecentEra` has lawful instances of:
- `Bounded` + `Enum`
- `Eq`
- `Show`

## Test Output

```hs
Cardano.Wallet.Write.Tx
  AnyRecentEra
    Class instances obey laws
      Testing Enum laws for type AnyRecentEra
        Succ Pred Identity [✔]
          +++ OK, passed 100 tests; 104 discarded.
        Pred Succ Identity [✔]
          +++ OK, passed 100 tests; 93 discarded.
      Testing Eq laws for type AnyRecentEra
        Transitive [✔] (3ms)
          +++ OK, passed 100 tests.
        Symmetric [✔] (3ms)
          +++ OK, passed 100 tests.
        Reflexive [✔]
          +++ OK, passed 100 tests.
      Testing Show laws for type AnyRecentEra
        Show [✔] (2ms)
          +++ OK, passed 100 tests.
        Equivariance: showsPrec [✔] (3ms)
          +++ OK, passed 100 tests.
        Equivariance: showList [✔] (5ms)
          +++ OK, passed 100 tests.

Finished in 0.0094 seconds, used 0.0232 seconds of CPU time
8 examples, 0 failures
```