### PR TITLE
[ADP-3045] Declassify IsOwned

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
@@ -42,7 +42,7 @@ import Cardano.Wallet
     , utxoAssumptionsForWallet
     )
 import Cardano.Wallet.Address.Derivation
-    ( Depth (..), Role (..), delegationAddressS, paymentAddressS )
+    ( Role (..), delegationAddressS, paymentAddressS )
 import Cardano.Wallet.Address.Derivation.Icarus
     ( IcarusKey (..) )
 import Cardano.Wallet.Address.Derivation.Shared
@@ -333,7 +333,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
                 (delegationAddressS @n)
                 (knownPools spl)
                 (getPoolLifeCycleStatus spl)
-        :<|> signTransaction @_ @_ @_ @'CredFromKeyK shelley
+        :<|> signTransaction shelley
         :<|>
             (\wid mMinWithdrawal mStart mEnd mOrder mLimit simpleMetadataFlag ->
                 listTransactions shelley wid mMinWithdrawal mStart mEnd mOrder mLimit
@@ -605,7 +605,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     sharedTransactions apilayer =
         constructSharedTransaction apilayer (constructAddressFromIx @n UtxoInternal)
             (knownPools spl) (getPoolLifeCycleStatus spl)
-        :<|> signTransaction @_ @_ @_ @'CredFromScriptK apilayer
+        :<|> signTransaction apilayer
         :<|> decodeSharedTransaction apilayer
         :<|> submitSharedTransaction @_ apilayer
         :<|>

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -430,6 +430,7 @@ import Cardano.Wallet.Flavor
     , WalletFlavor (..)
     , WalletFlavorS (..)
     , keyFlavorFromState
+    , keyOfWallet
     , shelleyOrShared
     )
 import Cardano.Wallet.Network
@@ -878,9 +879,10 @@ postShelleyWallet ctx generateKey body = do
             (workerCtx ^. typed @(DBLayer IO (SeqState n ShelleyKey)))
         )
     withWorkerCtx @_ @s ctx wid liftE liftE $ \wrk -> handler $
-        W.attachPrivateKeyFromPwd @_ @s wrk (rootXPrv, pwd)
+        W.attachPrivateKeyFromPwd wF wrk (rootXPrv, pwd)
     fst <$> getWallet ctx (mkShelleyWallet @_ @s) (ApiT wid)
   where
+    wF = walletFlavor @s
     seed = getApiMnemonicT (body ^. #mnemonicSentence)
     secondFactor = getApiMnemonicT <$> (body ^. #mnemonicSecondFactor)
     pwd = getApiT (body ^. #passphrase)
@@ -1048,8 +1050,7 @@ postSharedWalletFromRootXPrv
     -> ApiSharedWalletPostDataFromMnemonics
     -> Handler ApiSharedWallet
 postSharedWalletFromRootXPrv ctx generateKey body = do
-    let kF = keyFlavorFromState @s
-        wid = WalletId $ toSharedWalletId kF accXPub pTemplate dTemplateM
+    let wid = WalletId $ toSharedWalletId kF accXPub pTemplate dTemplateM
     validateScriptTemplates kF accXPub scriptValidation pTemplate dTemplateM
         & \case
             Left err -> liftHandler
@@ -1076,9 +1077,11 @@ postSharedWalletFromRootXPrv ctx generateKey body = do
             (workerCtx ^. typed @(DBLayer IO (SharedState n SharedKey)))
         )
     withWorkerCtx @_ @s ctx wid liftE liftE $ \wrk -> handler $
-        W.attachPrivateKeyFromPwd @_ @s wrk (rootXPrv, pwd)
+        W.attachPrivateKeyFromPwd wF wrk (rootXPrv, pwd)
     fst <$> getWallet ctx (mkSharedWallet @_ @s) (ApiT wid)
   where
+    kF = keyOfWallet wF
+    wF = walletFlavor @s
     seed = body ^. #mnemonicSentence . #getApiMnemonicT
     secondFactor = getApiMnemonicT <$> body ^. #mnemonicSecondFactor
     pwdP = preparePassphrase currentPassphraseScheme pwd
@@ -1316,10 +1319,11 @@ postLegacyWallet ctx (rootXPrv, pwd) createWallet = do
         (`createWallet` wid)
         idleWorker
     withWorkerCtx ctx wid liftE liftE $ \wrk -> handler $
-        W.attachPrivateKeyFromPwd wrk (rootXPrv, pwd)
+        W.attachPrivateKeyFromPwd wF wrk (rootXPrv, pwd)
     fst <$> getWallet ctx mkLegacyWallet (ApiT wid)
   where
-    kF = keyFlavorFromState @s
+    kF = keyOfWallet wF
+    wF = walletFlavor @s
     wid = WalletId
         $ digest kF
         $ publicKey kF rootXPrv
@@ -1679,7 +1683,8 @@ putWalletPassphrase ctx createKey getKey (ApiT wid)
                 (ApiT old)
                 (ApiT new)
             ) -> liftHandler
-                $ W.updateWalletPassphraseWithOldPassphrase wrk wid (old, new)
+                $ W.updateWalletPassphraseWithOldPassphrase
+                    (walletFlavor @s) wrk wid (old, new)
         Right
             (Api.WalletPutPassphraseMnemonicData
                     (ApiMnemonicT mnemonic) sndFactor (ApiT new)
@@ -1691,15 +1696,16 @@ putWalletPassphrase ctx createKey getKey (ApiT wid)
                     $ deriveAccountPrivateKey encrPass challengeKey minBound
             storedPubKey <- handler $ W.readAccountPublicKey wrk
             if getKey challengPubKey == getKey storedPubKey
-                then handler $ W.updateWalletPassphraseWithMnemonic wrk
+                then handler $ W.updateWalletPassphraseWithMnemonic wF wrk
                         (challengeKey, new)
                 else liftHandler
                     $ throwE
                     $ ErrUpdatePassphraseWithRootKey
                     $ ErrWithRootKeyWrongMnemonic wid
-    where
-        withWrk :: (WorkerCtx (ApiLayer s) -> Handler a) -> Handler a
-        withWrk = withWorkerCtx ctx wid liftE liftE
+  where
+    wF = walletFlavor @s
+    withWrk :: (WorkerCtx (ApiLayer s) -> Handler a) -> Handler a
+    withWrk = withWorkerCtx ctx wid liftE liftE
 
 putByronWalletPassphrase
     :: forall ctx s
@@ -1714,7 +1720,8 @@ putByronWalletPassphrase ctx (ApiT wid) body = do
     let (ByronWalletPutPassphraseData oldM (ApiT new)) = body
     withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $ do
         let old = maybe mempty (coerce . getApiT) oldM
-        W.updateWalletPassphraseWithOldPassphrase wrk wid (old, new)
+        W.updateWalletPassphraseWithOldPassphrase
+            (walletFlavor @s) wrk wid (old, new)
     return NoContent
 
 getUTxOsStatistics
@@ -2161,6 +2168,8 @@ postTransactionOld
         , KeyOf s ~ k
         , IsOurs s RewardAccount
         , CredFromOf s ~ 'CredFromKeyK
+        , HasSNetworkId (NetworkOf s)
+        , n ~ NetworkOf s
         )
     => ctx
     -> ArgGenChange s
@@ -3497,6 +3506,7 @@ joinStakePool
         , SoftDerivation k
         , AddressBookIso s
         , HasDelegation s
+        , HasSNetworkId n
         )
     => ApiLayer s
     -> ArgGenChange s
@@ -3588,6 +3598,7 @@ quitStakePool
         , IsOwned s k 'CredFromKeyK
         , AddressBookIso s
         , IsOurs (SeqState n k) RewardAccount
+        , HasSNetworkId n
         )
     => ApiLayer s
     -> ArgGenChange s
@@ -3824,6 +3835,8 @@ migrateWallet
         , HasDelegation s
         , k ~ KeyOf s
         , CredFromOf s ~ 'CredFromKeyK
+        , HasSNetworkId n
+        , n ~ NetworkOf s
         )
     => ApiLayer s
     -> Maybe ApiWithdrawalPostData

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -63,7 +63,7 @@ import Cardano.Wallet.Address.Derivation.Shared
 import Cardano.Wallet.Address.Derivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Address.Discovery
-    ( GenChange (..), IsOurs, IsOwned, MaybeLight )
+    ( GenChange (..), IsOurs, MaybeLight )
 import Cardano.Wallet.Address.Discovery.Random
     ( RndAnyState, mkRndAnyState )
 import Cardano.Wallet.Address.Discovery.Sequential
@@ -685,7 +685,6 @@ bench_restoration
     :: forall n (k :: Depth -> * -> *) s results.
         ( IsOurs s RewardAccount
         , MaybeLight s
-        , IsOwned s k 'CredFromKeyK
         , PersistAddressBook s
         , WalletFlavor s
         , KeyOf s ~ k
@@ -693,6 +692,7 @@ bench_restoration
         , TxWitnessTagFor k
         , Buildable results
         , ToJSON results
+        , IsOurs s Address
         )
     => PipeliningStrategy (CardanoBlock StandardCrypto)
     -> SNetworkId n

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -251,6 +251,7 @@ library
     Cardano.Wallet.Address.States.Families
     Cardano.Wallet.Address.States.Features
     Cardano.Wallet.Address.States.Test.State
+    Cardano.Wallet.Address.States.IsOwned
     Cardano.Wallet.Byron.Compatibility
     Cardano.Wallet.Checkpoints
     Cardano.Wallet.Checkpoints.Policy

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -248,6 +248,9 @@ library
     Cardano.Wallet.Address.Keys.WalletKey
     Cardano.Wallet.Address.Keys.WitnessCount
     Cardano.Wallet.Address.Pool
+    Cardano.Wallet.Address.States.Families
+    Cardano.Wallet.Address.States.Features
+    Cardano.Wallet.Address.States.Test.State
     Cardano.Wallet.Byron.Compatibility
     Cardano.Wallet.Checkpoints
     Cardano.Wallet.Checkpoints.Policy

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1939,6 +1939,7 @@ buildSignSubmitTransaction
        , AddressBookIso s
        , IsOurs s Address
        , WalletFlavor s
+       , CredFromOf s ~ 'CredFromKeyK
        , k ~ KeyOf s
        , CredFromOf s ~ 'CredFromKeyK
        , HasSNetworkId (NetworkOf s)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1942,11 +1942,7 @@ buildSignSubmitTransaction
        , k ~ KeyOf s
        , CredFromOf s ~ 'CredFromKeyK
        , HasSNetworkId (NetworkOf s)
-        , Excluding '[SharedKey] k
-        , Excluding '[SharedKey] k
-        , k ~ KeyOf s
        , Excluding '[SharedKey] k
-        , k ~ KeyOf s
        )
     => DBLayer IO s
     -> NetworkLayer IO Read.Block

--- a/lib/wallet/src/Cardano/Wallet/Address/Discovery.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Discovery.hs
@@ -21,7 +21,6 @@
 
 module Cardano.Wallet.Address.Discovery
     ( IsOurs(..)
-    , IsOwned(..)
     , GenChange(..)
     , CompareDiscovery(..)
     , KnownAddresses(..)
@@ -42,7 +41,7 @@ module Cardano.Wallet.Address.Discovery
 import Prelude
 
 import Cardano.Crypto.Wallet
-    ( XPrv, XPub )
+    ( XPub )
 import Cardano.Wallet.Address.Derivation
     ( Depth (..)
     , DerivationIndex (..)
@@ -53,8 +52,6 @@ import Cardano.Wallet.Address.Derivation
     )
 import Cardano.Wallet.Primitive.BlockSummary
     ( ChainEvents )
-import Cardano.Wallet.Primitive.Passphrase.Types
-    ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Control.DeepSeq
@@ -93,25 +90,6 @@ class IsOurs s entity where
         -> s
         -> (Maybe (NonEmpty DerivationIndex), s)
         -- ^ Returns derivation path if the entity is ours, otherwise Nothing.
-
--- | More powerful than 'isOurs', this abstractions offer the underlying state
--- the ability to find / compute the address private key corresponding to a
--- given known address.
---
--- Requiring 'IsOwned' as a constraint supposed that there is a way to recover
--- the root private key of a particular wallet. This isn't true for externally
--- owned wallet which would delegate its key management to a third party (like
--- a hardware Ledger or Trezor).
-class IsOurs s Address => IsOwned s key ktype where
-    isOwned
-        :: s
-        -> (key 'RootK XPrv, Passphrase "encryption")
-        -> Address
-        -> Maybe (key ktype XPrv, Passphrase "encryption")
-        -- ^ Derive the private key corresponding to an address. Careful, this
-        -- operation can be costly. Note that the state is discarded from this
-        -- function as we do not intend to discover any addresses from this
-        -- operation; This is merely a lookup from known addresses.
 
 -- | Abstracting over change address generation. In theory, this is only needed
 -- for sending transactions on a wallet following a particular scheme. This

--- a/lib/wallet/src/Cardano/Wallet/Address/Discovery/Random.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Discovery/Random.hs
@@ -28,7 +28,7 @@ module Cardano.Wallet.Address.Discovery.Random
     , mkRndState
     , DerivationPath
     , toDerivationIndexes
-    , isOwnedFunction
+    , isOwned
 
     -- ** Low-level API
     , importAddress
@@ -70,7 +70,6 @@ import Cardano.Wallet.Address.Discovery
     ( CompareDiscovery (..)
     , GenChange (..)
     , IsOurs (isOurs)
-    , IsOwned (..)
     , KnownAddresses (..)
     , MaybeLight (..)
     )
@@ -227,18 +226,15 @@ instance IsOurs (RndState n) Address where
 instance IsOurs (RndState n) RewardAccount where
     isOurs _account state = (Nothing, state)
 
-isOwnedFunction
+isOwned
     :: forall (network :: NetworkDiscriminant)
      . RndState network
     -> (ByronKey 'RootK XPrv, Passphrase "encryption")
     -> Address
     -> Maybe (ByronKey 'CredFromKeyK XPrv, Passphrase "encryption")
-isOwnedFunction st (key, pwd) addr =
+isOwned st (key, pwd) addr =
     (,pwd) . deriveCredFromKeyKeyFromPath key pwd
         <$> addressToPath addr (hdPassphrase st)
-
-instance IsOwned (RndState n) ByronKey 'CredFromKeyK where
-    isOwned = isOwnedFunction
 
 -- Updates a 'RndState' by adding an address and its derivation path to the
 -- set of discovered addresses. If the address was in the 'pendingAddresses' set
@@ -458,9 +454,6 @@ instance KnownNat p => IsOurs (RndAnyState n p) Address where
 
 instance IsOurs (RndAnyState n p) RewardAccount where
     isOurs _account state = (Nothing, state)
-
-instance KnownNat p => IsOwned (RndAnyState n p) ByronKey 'CredFromKeyK where
-    isOwned _ _ _ = Nothing
 
 instance HasSNetworkId n => GenChange (RndAnyState n p) where
     type ArgGenChange (RndAnyState n p) = ArgGenChange (RndState n)

--- a/lib/wallet/src/Cardano/Wallet/Address/Discovery/Shared.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Discovery/Shared.hs
@@ -34,7 +34,7 @@ module Cardano.Wallet.Address.Discovery.Shared
     , SharedAddressPools (..)
     , SharedAddressPool (..)
     , newSharedAddressPool
-    , isOwnedFunction
+    , isOwned
 
     , ErrAddCosigner (..)
     , ErrScriptTemplate (..)
@@ -94,7 +94,6 @@ import Cardano.Wallet.Address.Discovery
     , GenChange (..)
     , GetAccount (..)
     , IsOurs (..)
-    , IsOwned (..)
     , KnownAddresses (..)
     , MaybeLight (..)
     , PendingIxs
@@ -575,13 +574,13 @@ liftDelegationAddress ix dTemplate (KeyFingerprint fingerprint) =
     dScript =
         replaceCosignersWithVerKeys CA.Stake dTemplate ix
 
-isOwnedFunction
+isOwned
     :: HasSNetworkId n
     => SharedState n SharedKey
     -> (SharedKey 'RootK XPrv, Passphrase "encryption")
     -> Address
     -> Maybe (SharedKey 'CredFromScriptK XPrv, Passphrase "encryption")
-isOwnedFunction st (rootPrv, pwd) addr = case isShared addr st of
+isOwned st (rootPrv, pwd) addr = case isShared addr st of
     (Just (ix, role'), _) ->
         let DerivationPrefix (_, _, accIx) = derivationPrefix st
             accXPrv = deriveAccountPrivateKey pwd rootPrv accIx
@@ -590,10 +589,6 @@ isOwnedFunction st (rootPrv, pwd) addr = case isShared addr st of
                 , pwd
                 )
     (Nothing, _) -> Nothing
-
-instance ( key ~ SharedKey , SupportsDiscovery n key ) =>
-         IsOwned (SharedState n key) key 'CredFromScriptK where
-    isOwned = isOwnedFunction
 
 estimateMinWitnessRequiredPerInput :: Script k -> Natural
 estimateMinWitnessRequiredPerInput = \case

--- a/lib/wallet/src/Cardano/Wallet/Address/Discovery/Shared.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Discovery/Shared.hs
@@ -34,6 +34,7 @@ module Cardano.Wallet.Address.Discovery.Shared
     , SharedAddressPools (..)
     , SharedAddressPool (..)
     , newSharedAddressPool
+    , isOwnedFunction
 
     , ErrAddCosigner (..)
     , ErrScriptTemplate (..)
@@ -62,7 +63,7 @@ import Cardano.Address.Script
 import Cardano.Address.Style.Shelley
     ( Credential (..), delegationAddress, paymentAddress )
 import Cardano.Crypto.Wallet
-    ( XPub )
+    ( XPrv, XPub )
 import Cardano.Wallet.Address.Derivation
     ( AccountIxForStaking (..)
     , AddressParts (..)
@@ -84,12 +85,10 @@ import Cardano.Wallet.Address.Derivation
     , utxoExternal
     , utxoInternal
     )
+import Cardano.Wallet.Address.Derivation.Shared
+    ( SharedKey )
 import Cardano.Wallet.Address.Derivation.SharedKey
-    ( SharedKey (..)
-    , constructAddressFromIx
-    , replaceCosignersWithVerKeys
-    , toNetworkTag
-    )
+    ( constructAddressFromIx, replaceCosignersWithVerKeys, toNetworkTag )
 import Cardano.Wallet.Address.Discovery
     ( CompareDiscovery (..)
     , GenChange (..)
@@ -104,6 +103,8 @@ import Cardano.Wallet.Address.Discovery
     )
 import Cardano.Wallet.Address.Discovery.Sequential
     ( AddressPoolGap (..) )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
@@ -574,16 +575,25 @@ liftDelegationAddress ix dTemplate (KeyFingerprint fingerprint) =
     dScript =
         replaceCosignersWithVerKeys CA.Stake dTemplate ix
 
-instance ( key ~ SharedKey
-         , SupportsDiscovery n key ) =>
+isOwnedFunction
+    :: HasSNetworkId n
+    => SharedState n SharedKey
+    -> (SharedKey 'RootK XPrv, Passphrase "encryption")
+    -> Address
+    -> Maybe (SharedKey 'CredFromScriptK XPrv, Passphrase "encryption")
+isOwnedFunction st (rootPrv, pwd) addr = case isShared addr st of
+    (Just (ix, role'), _) ->
+        let DerivationPrefix (_, _, accIx) = derivationPrefix st
+            accXPrv = deriveAccountPrivateKey pwd rootPrv accIx
+        in  Just
+                ( deriveAddressPrivateKey pwd accXPrv role' ix
+                , pwd
+                )
+    (Nothing, _) -> Nothing
+
+instance ( key ~ SharedKey , SupportsDiscovery n key ) =>
          IsOwned (SharedState n key) key 'CredFromScriptK where
-    isOwned st (rootPrv, pwd) addr = case isShared addr st of
-        (Just (ix, role'), _) ->
-            let DerivationPrefix (_,_,accIx) = derivationPrefix st
-                accXPrv = deriveAccountPrivateKey pwd rootPrv accIx
-            in Just ( deriveAddressPrivateKey pwd accXPrv role' ix
-                    , pwd )
-        (Nothing, _) -> Nothing
+    isOwned = isOwnedFunction
 
 estimateMinWitnessRequiredPerInput :: Script k -> Natural
 estimateMinWitnessRequiredPerInput = \case

--- a/lib/wallet/src/Cardano/Wallet/Address/States/Families.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/States/Families.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Wallet.Address.States.Families where
+
+import Cardano.Wallet.Address.Derivation
+    ( Depth (..) )
+import Cardano.Wallet.Address.Derivation.Byron
+    ( ByronKey )
+import Cardano.Wallet.Address.Discovery.Random
+    ( RndAnyState, RndState )
+import Cardano.Wallet.Address.Discovery.Sequential
+    ( SeqAnyState, SeqState )
+import Cardano.Wallet.Address.Discovery.Shared
+    ( SharedState )
+import Cardano.Wallet.Address.States.Test.State
+    ( TestState )
+import Cardano.Wallet.Read.NetworkId
+    ( NetworkDiscriminant )
+import Data.Kind
+    ( Type )
+
+type family CredFromOf s where
+    CredFromOf (SharedState n key) = 'CredFromScriptK
+    CredFromOf (SeqState n key) = 'CredFromKeyK
+    CredFromOf (RndState n) = 'CredFromKeyK
+    CredFromOf (TestState s n key kt) = kt
+    CredFromOf (RndAnyState n p) = 'CredFromKeyK
+    CredFromOf (SeqAnyState n key p) = 'CredFromKeyK
+
+-- | A type family to get the key type from a state.
+type family KeyOf (s :: Type) :: (Depth -> Type -> Type) where
+    KeyOf (SeqState n k) = k
+    KeyOf (RndState n) = ByronKey
+    KeyOf (SharedState n k) = k
+    KeyOf (SeqAnyState n k p) = k
+    KeyOf (RndAnyState n p) = ByronKey
+    KeyOf (TestState s n k kt) = k
+
+type family NetworkOf (s :: Type) :: NetworkDiscriminant where
+    NetworkOf (SeqState n k) = n
+    NetworkOf (RndState n) = n
+    NetworkOf (SharedState n k) = n
+    NetworkOf (SeqAnyState n k p) = n
+    NetworkOf (RndAnyState n p) = n
+    NetworkOf (TestState s n k kt) = n

--- a/lib/wallet/src/Cardano/Wallet/Address/States/Features.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/States/Features.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.Wallet.Address.States.Features
+    ( IsOwned
+    , TestFeatures (..)
+    , defaultTestFeatures
+    )
+    where
+
+import Prelude
+
+import Cardano.Crypto.Wallet
+    ( XPrv )
+import Cardano.Wallet.Address.Derivation
+    ( Depth (..) )
+import Cardano.Wallet.Address.Derivation.Shared
+    ()
+import Cardano.Wallet.Address.States.Families
+    ( CredFromOf, KeyOf )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+
+type IsOwned s =
+    s
+    -> (KeyOf s 'RootK XPrv, Passphrase "encryption")
+    -> Address
+    -> Maybe (KeyOf s (CredFromOf s) XPrv, Passphrase "encryption")
+
+newtype TestFeatures s = TestFeatures
+    { isOwned :: IsOwned s
+    }
+
+defaultTestFeatures :: TestFeatures s
+defaultTestFeatures = TestFeatures
+    { isOwned = error "isOwned: not implemented"
+    }

--- a/lib/wallet/src/Cardano/Wallet/Address/States/Features.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/States/Features.hs
@@ -29,10 +29,10 @@ type IsOwned s =
     -> Maybe (KeyOf s (CredFromOf s) XPrv, Passphrase "encryption")
 
 newtype TestFeatures s = TestFeatures
-    { isOwned :: IsOwned s
+    { isOwnedTest :: IsOwned s
     }
 
 defaultTestFeatures :: TestFeatures s
 defaultTestFeatures = TestFeatures
-    { isOwned = error "isOwned: not implemented"
+    { isOwnedTest = error "isOwned: not implemented"
     }

--- a/lib/wallet/src/Cardano/Wallet/Address/States/IsOwned.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/States/IsOwned.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+
+module Cardano.Wallet.Address.States.IsOwned
+    ( isOwned
+    )
+    where
+import Prelude
+
+import Cardano.Crypto.Wallet
+    ( XPrv )
+import Cardano.Wallet.Address.Derivation
+    ( Depth (..) )
+import Cardano.Wallet.Address.Derivation.Shared
+    ()
+import Cardano.Wallet.Address.States.Families
+    ( CredFromOf, KeyOf, NetworkOf )
+import Cardano.Wallet.Address.States.Features
+    ( TestFeatures (isOwnedTest) )
+import Cardano.Wallet.Flavor
+    ( WalletFlavorS (..) )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+import Cardano.Wallet.Read.NetworkId
+    ( HasSNetworkId )
+
+import qualified Cardano.Wallet.Address.Discovery.Random as Rnd
+import qualified Cardano.Wallet.Address.Discovery.Sequential as Seq
+import qualified Cardano.Wallet.Address.Discovery.Shared as Sha
+
+-- | More powerful than 'isOurs', this abstractions offer the underlying state
+-- the ability to find / compute the address private key corresponding to a
+-- given known address.
+--
+-- Requiring 'IsOwned' as a constraint supposed that there is a way to recover
+-- the root private key of a particular wallet. This isn't true for externally
+-- owned wallet which would delegate its key management to a third party (like
+-- a hardware Ledger or Trezor).
+--
+-- Derive the private key corresponding to an address. Careful, this
+-- operation can be costly. Note that the state is discarded from this
+-- function as we do not intend to discover any addresses from this
+-- operation; This is merely a lookup from known addresses.
+isOwned
+    :: forall s
+     . HasSNetworkId (NetworkOf s)
+    => WalletFlavorS s
+    -> s
+    -> (KeyOf s 'RootK XPrv, Passphrase "encryption")
+    -> Address
+    -> Maybe (KeyOf s (CredFromOf s) XPrv, Passphrase "encryption")
+isOwned ByronWallet = Rnd.isOwnedFunction
+isOwned IcarusWallet = Seq.isOwnedFunction
+isOwned ShelleyWallet = Seq.isOwnedFunction
+isOwned SharedWallet = Sha.isOwnedFunction
+isOwned BenchByronWallet = \_ _ _ -> Nothing
+isOwned BenchShelleyWallet = \_ _ _ -> Nothing
+isOwned (TestStateS fs) = isOwnedTest fs

--- a/lib/wallet/src/Cardano/Wallet/Address/States/IsOwned.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/States/IsOwned.hs
@@ -55,10 +55,10 @@ isOwned
     -> (KeyOf s 'RootK XPrv, Passphrase "encryption")
     -> Address
     -> Maybe (KeyOf s (CredFromOf s) XPrv, Passphrase "encryption")
-isOwned ByronWallet = Rnd.isOwnedFunction
-isOwned IcarusWallet = Seq.isOwnedFunction
-isOwned ShelleyWallet = Seq.isOwnedFunction
-isOwned SharedWallet = Sha.isOwnedFunction
+isOwned ByronWallet = Rnd.isOwned
+isOwned IcarusWallet = Seq.isOwned
+isOwned ShelleyWallet = Seq.isOwned
+isOwned SharedWallet = Sha.isOwned
 isOwned BenchByronWallet = \_ _ _ -> Nothing
 isOwned BenchShelleyWallet = \_ _ _ -> Nothing
 isOwned (TestStateS fs) = isOwnedTest fs

--- a/lib/wallet/src/Cardano/Wallet/Address/States/Test/State.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/States/Test/State.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE KindSignatures #-}
+
+module Cardano.Wallet.Address.States.Test.State where
+
+import Prelude
+
+import Cardano.Wallet.Address.Derivation
+    ( Depth )
+import Cardano.Wallet.Read.NetworkId
+    ( NetworkDiscriminant )
+import Data.Kind
+    ( Type )
+import GHC.Generics
+    ( Generic )
+
+newtype
+    TestState
+        s
+        (n :: NetworkDiscriminant)
+        (k :: Depth -> Type -> Type)
+        (ktype :: Depth)
+    = TestState s
+    deriving (Generic, Show, Eq)

--- a/lib/wallet/src/Cardano/Wallet/Flavor.hs
+++ b/lib/wallet/src/Cardano/Wallet/Flavor.hs
@@ -78,7 +78,8 @@ data WalletFlavors
     | SharedF
     | BenchByronF
     | BenchShelleyF
-    | TestStateF
+    | TestAddressesWithCredsF
+    | TestOnlyAddressesF
 
 type family FlavorOf s where
     FlavorOf (SeqState n ShelleyKey) = 'ShelleyF
@@ -96,7 +97,8 @@ type AllFlavors =
      , 'SharedF
      , 'BenchByronF
      , 'BenchShelleyF
-     , 'TestStateF
+     , 'TestAddressesWithCredsF
+     , 'TestOnlyAddressesF
      ]
 
 type IncludingStates ss s = Including AllFlavors ss s

--- a/lib/wallet/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Address/Discovery/RandomSpec.hs
@@ -35,12 +35,15 @@ import Cardano.Wallet.Address.Derivation.Byron
 import Cardano.Wallet.Address.DerivationSpec
     ()
 import Cardano.Wallet.Address.Discovery
-    ( GenChange (..), IsOurs (..), IsOwned (..), KnownAddresses (..) )
+    ( GenChange (..), IsOurs (..), KnownAddresses (..) )
 import Cardano.Wallet.Address.Discovery.Random
     ( RndState (..), findUnusedPath, mkRndState )
 import Cardano.Wallet.Address.Keys.WalletKey
     ( publicKey )
+import Cardano.Wallet.Address.States.IsOwned
+    ( isOwned )
 import Cardano.Wallet.Flavor
+    ( KeyFlavorS (ByronKeyS), WalletFlavorS (ByronWallet) )
 import Cardano.Wallet.Gen
     ( genMnemonic )
 import Cardano.Wallet.Primitive.Passphrase
@@ -238,7 +241,7 @@ checkIsOurs GoldenTest{..} = do
 
 checkIsOwned :: GoldenTest -> Expectation
 checkIsOwned GoldenTest{..} = do
-    isOwned st (rndKey, pwd) addr' `shouldBe` expectation
+    isOwned ByronWallet st (rndKey, pwd) addr' `shouldBe` expectation
   where
     pwd = Passphrase ""
     Right addr' = Address <$> convertFromBase Base16 addr
@@ -295,9 +298,9 @@ prop_derivedKeysAreOwned
     -> Index 'WholeDomain 'CredFromKeyK
     -> Property
 prop_derivedKeysAreOwned (Rnd st rk pwd) (Rnd st' rk' pwd') addrIx =
-    isOwned @_ @_ @'CredFromKeyK st (rk, pwd) addr === Just (addrKey, pwd)
+    isOwned ByronWallet st (rk, pwd) addr === Just (addrKey, pwd)
     .&&.
-    isOwned @_ @_ @'CredFromKeyK st' (rk', pwd') addr === Nothing
+    isOwned ByronWallet st' (rk', pwd') addr === Nothing
   where
     addr = paymentAddress SMainnet (publicKey ByronKeyS addrKey)
     addrKey = deriveAddressPrivateKey pwd acctKey addrIx

--- a/lib/wallet/test/unit/Cardano/Wallet/Address/Discovery/SequentialSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Address/Discovery/SequentialSpec.hs
@@ -50,7 +50,6 @@ import Cardano.Wallet.Address.Discovery
     , GenChange (..)
     , GetPurpose
     , IsOurs (..)
-    , IsOwned (..)
     , KnownAddresses (..)
     , emptyPendingIxs
     , genChange
@@ -76,8 +75,10 @@ import Cardano.Wallet.Address.Keys.WalletKey
     ( publicKey )
 import Cardano.Wallet.Address.PoolSpec
     ( genPool, shrinkPool )
+import Cardano.Wallet.Address.States.IsOwned
+    ( isOwned )
 import Cardano.Wallet.Flavor
-    ( KeyFlavorS (..) )
+    ( KeyFlavorS (..), WalletFlavorS (ShelleyWallet) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Read.NetworkId
@@ -309,7 +310,7 @@ prop_lookupDiscovered (s0, addr) =
     mw = someDummyMnemonic (Proxy @12)
     key = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
     prop s = monadicIO $ liftIO $ do
-        unless (isJust $ isOwned @_ @_ @'CredFromKeyK s (key, mempty) addr) $ do
+        unless (isJust $ isOwned ShelleyWallet s (key, mempty) addr) $ do
             expectationFailure "couldn't find private key corresponding to addr"
 
 {-------------------------------------------------------------------------------

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -46,24 +46,16 @@ import Cardano.Wallet
 import Cardano.Wallet.Address.Derivation
     ( Depth (..)
     , DerivationIndex (..)
-    , DerivationIndex (..)
     , DerivationType (..)
     , HardDerivation (..)
-    , HardDerivation (..)
-    , Index (..)
     , Index (..)
     , Role (..)
-    , Role (..)
+    , deriveAccountPrivateKey
     )
 import Cardano.Wallet.Address.Derivation.Shelley
     ( ShelleyKey (..), generateKeyFromSeed )
 import Cardano.Wallet.Address.Discovery
-    ( CompareDiscovery (..)
-    , GenChange (..)
-    , IsOurs (..)
-    , IsOwned (..)
-    , KnownAddresses (..)
-    )
+    ( CompareDiscovery (..), GenChange (..), IsOurs (..), KnownAddresses (..) )
 import Cardano.Wallet.Address.Keys.WalletKey
     ( publicKey )
 import Cardano.Wallet.Address.States.Features
@@ -1379,14 +1371,6 @@ instance IsOurs DummyState Address where
 
 instance IsOurs DummyState RewardAccount where
     isOurs _ s = (Nothing, s)
-
-instance IsOwned DummyState ShelleyKey 'CredFromKeyK where
-    isOwned (TestState m) (rootK, pwd) addr = do
-        ix <- Map.lookup addr m
-        let accXPrv = deriveAccountPrivateKey pwd rootK minBound
-        let addrXPrv = deriveAddressPrivateKey pwd accXPrv UtxoExternal ix
-        return (addrXPrv, pwd)
-
 instance GenChange DummyState where
     type ArgGenChange DummyState = ()
     genChange _ s = (Address "dummy", s)

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -44,13 +44,7 @@ import Cardano.Wallet
     , throttle
     )
 import Cardano.Wallet.Address.Derivation
-    ( Depth (..)
-    , DerivationIndex (..)
-    , DerivationType (..)
-    , HardDerivation (..)
-    , Index
-    , Role (..)
-    )
+    ( Depth (..), DerivationIndex (..), HardDerivation (..), Role (..) )
 import Cardano.Wallet.Address.Derivation.Shelley
     ( ShelleyKey (..), generateKeyFromSeed )
 import Cardano.Wallet.Address.Discovery
@@ -202,8 +196,6 @@ import Data.List
     ( nubBy, sort, sortOn )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
-import Data.Map.Strict
-    ( Map )
 import Data.Maybe
     ( catMaybes, fromMaybe, isJust, isNothing, mapMaybe )
 import Data.Ord

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -62,6 +62,8 @@ import Cardano.Wallet.Address.Discovery
     )
 import Cardano.Wallet.Address.Keys.WalletKey
     ( publicKey )
+import Cardano.Wallet.Address.States.Test.State
+    ( TestState (..) )
 import Cardano.Wallet.DB
     ( DBFresh, DBLayer (..), hoistDBFresh, hoistDBLayer, putTxHistory )
 import Cardano.Wallet.DB.Fixtures
@@ -79,12 +81,7 @@ import Cardano.Wallet.DummyTarget.Primitive.Types
     , mkTxId
     )
 import Cardano.Wallet.Flavor
-    ( CredFromOf
-    , KeyFlavorS (ShelleyKeyS)
-    , KeyOf
-    , TestState (..)
-    , WalletFlavor (..)
-    )
+    ( CredFromOf, KeyFlavorS (ShelleyKeyS), KeyOf, WalletFlavor (..) )
 import Cardano.Wallet.Gen
     ( genMnemonic, genSlotNo )
 import Cardano.Wallet.Network
@@ -286,6 +283,8 @@ import qualified Cardano.Wallet.Primitive.Migration as Migration
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Read as Read
+import Cardano.Wallet.Read.NetworkId
+    ( NetworkDiscriminant (Mainnet) )
 import qualified Cardano.Wallet.Submissions.Submissions as Smbs
 import qualified Cardano.Wallet.Submissions.TxStatus as Sbms
 import qualified Data.ByteArray as BA
@@ -560,7 +559,7 @@ walletListTransactionsWithLimit wallet@(_, _, _) =
                 test (Just l) (Just r) Ascending Identity
                     $ \slot -> slot >= l && slot <= r
 
-type DummyStateWithAddresses = TestState [Address] ShelleyKey
+type DummyStateWithAddresses = TestState [Address] 'Mainnet ShelleyKey 'CredFromKeyK
 
 instance IsOurs DummyStateWithAddresses Address where
     isOurs a s@(TestState addr) =
@@ -1318,8 +1317,12 @@ mockNetworkLayer = dummyNetworkLayer
     dummyTip = BlockHeader (SlotNo 0) (Quantity 0) dummyHash (Just dummyHash)
     dummyHash = Hash "dummy hash"
 
-type DummyState
-    = TestState (Map Address (Index 'Soft 'CredFromKeyK)) ShelleyKey
+type DummyState =
+    TestState
+        (Map Address (Index 'Soft 'CredFromKeyK))
+        'Mainnet
+        ShelleyKey
+        'CredFromKeyK
 
 instance Sqlite.AddressBookIso DummyState where
     data Prologue DummyState = DummyPrologue


### PR DESCRIPTION
- [x] Move IsOwned class function to its module


Starting from the "bottom" classes made the process more painful. From this PR, I'm peeling off from the "top" classes whose functions are not used by other class instances.

The IsOwned class was implying other constraints that now are explicit where it was from the constraint. OTOH, they will all slowly disappear, so it's a temporary verbosity added to some application functions.

Some work has been done to allow access to the state in the tests.
- The wallet flavor `TestStateS` now contains a dictionary of all features of the state; for now only `IsOwned` feature is included
- The 2 Dummyxxx states IsOwned instances have been transformed in `isOwnedTest` fields of that dictionary.

As we can observe in the `State.IsOwned` and `States.Features` module , when implementing a new feature, we must 
- add a field named i.e. `<feature>Test` with the signature of the feature  in the Features module, with an error implementation to be overridden in tests
- pattern match on TestStateS to support testing in the new feature module and use the new feature test field there

In theory, this `TestStateS` could also absorb the Bench states, but I will face this later when all features of the state are declassified.

ADP-3045