### PR TITLE
Don't take `AnyCardanoEra` for tx size estimations

### DIFF
--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -256,9 +256,8 @@ benchmarksSeq BenchmarkConfig{benchmarkName,ctx} = do
         $ W.listTransactions @_ @s ctx
             Nothing Nothing Nothing Descending (Just 50)
 
-    let era = Cardano.anyCardanoEra Cardano.BabbageEra
     (_, createMigrationPlanTime) <- bench "createMigrationPlan"
-        $ W.createMigrationPlan @_ @s ctx era Tx.NoWithdrawal
+        $ W.createMigrationPlan @_ @s ctx Tx.NoWithdrawal
 
     (_, delegationFeeTime) <- bench "delegationFee" $ do
         timeTranslation <-
@@ -410,9 +409,8 @@ benchmarksRnd BenchmarkConfig{benchmarkName,ctx} = do
         $ W.listTransactions @_ @s ctx
             Nothing Nothing Nothing Descending (Just 50)
 
-    let era = Cardano.anyCardanoEra Cardano.BabbageEra
     (_, createMigrationPlanTime) <- bench "createMigrationPlan"
-        $ W.createMigrationPlan @_ @s ctx era Tx.NoWithdrawal
+        $ W.createMigrationPlan @_ @s ctx Tx.NoWithdrawal
 
     pure BenchRndResults
         { benchName = benchmarkName

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -205,9 +205,7 @@ data TransactionLayer k ktype tx = TransactionLayer
         -- ^ A function to assess the size of a token bundle.
 
     , constraints
-        :: AnyCardanoEra
-        -- Era for which the transaction should be created.
-        -> ProtocolParameters
+        :: ProtocolParameters
         -- Current protocol parameters.
         -> TxConstraints
         -- The set of constraints that apply to all transactions.

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -129,7 +129,6 @@ import Cardano.Wallet.Write.Tx
     , feeOfBytes
     , fromCardanoTx
     , fromCardanoUTxO
-    , fromRecentEra
     , getFeePerByte
     , isBelowMinimumCoinForTxOut
     , maxScriptExecutionCost
@@ -879,9 +878,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 -- transaction. For this, and other reasons, the selection may include too
 -- much ada.
 selectAssets
-    :: forall era changeState
-     . Cardano.IsCardanoEra era
-    => RecentEra era
+    :: forall era changeState. RecentEra era
     -> ProtocolParameters era
     -> UTxOAssumptions
     -> [W.TxOut]
@@ -925,7 +922,6 @@ selectAssets era (ProtocolParameters pp) utxoAssumptions outs redeemers
             , fee0
             , txPlutusScriptExecutionCost
             , calculateMinimumFee
-                (Cardano.AnyCardanoEra (fromRecentEra era))
                 feePerByte
                 (assumedTxWitnessTag utxoAssumptions)
                 (defaultTransactionCtx
@@ -996,7 +992,6 @@ selectAssets era (ProtocolParameters pp) utxoAssumptions outs redeemers
 
     boringFee =
         calculateMinimumFee
-            (Cardano.AnyCardanoEra (fromRecentEra era))
             feePerByte
             (assumedTxWitnessTag utxoAssumptions)
             defaultTransactionCtx


### PR DESCRIPTION
- [x] Don't depend on `AnyCardanoEra` for tx size estimation. We're always in a recent era.*

### Comments

- Preparation which makes #3874 nicer
- *) Except such a check may not exist for migration, but the impact of anything going wrong would be low regardless.

### Issue Number

ADP-2990
