### PR TITLE
Add `CODEOWNERS` file.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in the repository.
+#
+# Unless a later match takes precedence, these owners will be requested for
+# review when someone opens a pull request.
+#
+* @Anviking @HeinrichApfelmus @jonathanknowles @paolino @paweljakubas @Unisay


### PR DESCRIPTION
## Issue

https://input-output.atlassian.net/browse/ADP-2785

## Summary

This PR adds a `CODEOWNERS` file, thus satisfying the requirement to identify the core maintainers of this repository.