### PR TITLE
[ADP-3054] integrate new delegation certificate store

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -115,6 +115,7 @@ library
     , filepath
     , fmt
     , foldl
+    , formatting
     , free
     , generic-arbitrary
     , generic-lens

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -266,8 +266,10 @@ library
     Cardano.Wallet.DB.Sqlite.Schema
     Cardano.Wallet.DB.Sqlite.Types
     Cardano.Wallet.DB.Store.Checkpoints.Store
+    Cardano.Wallet.DB.Store.Delegations.Layer
     Cardano.Wallet.DB.Store.Delegations.Migration
     Cardano.Wallet.DB.Store.Delegations.Migration.Schema
+    Cardano.Wallet.DB.Store.Delegations.Model
     Cardano.Wallet.DB.Store.Delegations.Schema
     Cardano.Wallet.DB.Store.Delegations.Store
     Cardano.Wallet.DB.Store.Info.Store

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -115,7 +115,6 @@ library
     , filepath
     , fmt
     , foldl
-    , formatting
     , free
     , generic-arbitrary
     , generic-lens

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -224,8 +224,6 @@ data DBLayer m s = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
 
     , readDelegation :: stm WalletDelegation
 
-    , isStakeKeyRegistered :: stm Bool
-
     , putDelegationCertificate
         :: DelegationCertificate
         -> SlotNo
@@ -405,7 +403,6 @@ mkDBLayerFromParts ti wid_ DBLayerCollection{..} = DBLayer
             currentEpoch <- liftIO $
                 interpretQuery ti (epochOf $ cp ^. #currentTip . #slotNo)
             readDelegation_ dbDelegation currentEpoch
-    , isStakeKeyRegistered = isStakeKeyRegistered_ dbDelegation
     , putDelegationCertificate = putDelegationCertificate_ dbDelegation
     , putDelegationRewardBalance = putDelegationRewardBalance_ dbDelegation
     , readDelegationRewardBalance = readDelegationRewardBalance_ dbDelegation
@@ -502,10 +499,7 @@ data DBCheckpoints stm s = DBCheckpoints
 -- | A database layer for storing delegation certificates
 -- and the reward balance.
 data DBDelegation stm = DBDelegation
-    { isStakeKeyRegistered_
-        :: stm Bool
-
-    , putDelegationCertificate_
+    { putDelegationCertificate_
         :: DelegationCertificate
         -> SlotNo
         -> stm ()

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -60,13 +60,11 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader
     , ChainPoint
-    , EpochNo (..)
     , GenesisParameters
     , Range (..)
     , Slot
     , SlotNo (..)
     , SortOrder (..)
-    , WalletDelegation (..)
     , WalletId
     , WalletMetadata (..)
     )
@@ -487,9 +485,7 @@ data DBDelegation stm = DBDelegation
         -- ^ Get the reward account balance.
         --
         -- Returns zero if the wallet hasn't delegated stake.
-    , readDelegation_
-        :: EpochNo
-        -> stm WalletDelegation
+
     }
 
 -- | A database layer that stores the transaction history.

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -691,22 +691,12 @@ mkDBDelegation ::
     TimeInterpreter IO -> W.WalletId -> DBDelegation (SqlPersistT IO)
 mkDBDelegation ti wid =
     DBDelegation
-        { isStakeKeyRegistered_
-        , putDelegationCertificate_
+        { putDelegationCertificate_
         , putDelegationRewardBalance_
         , readDelegationRewardBalance_
         , readDelegation_
         }
   where
-    isStakeKeyRegistered_ :: SqlPersistT IO Bool
-    isStakeKeyRegistered_ = do
-        val <- fmap entityVal <$>
-            selectFirst [StakeKeyCertWalletId ==. wid] [Desc StakeKeyCertSlot]
-        pure $
-            case val of
-                Nothing -> False
-                Just (StakeKeyCertificate _ _ status) ->
-                    status == W.StakeKeyRegistration
 
     putDelegationCertificate_ ::
         W.DelegationCertificate -> W.SlotNo -> SqlPersistT IO ()

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -691,32 +691,11 @@ mkDBDelegation ::
     TimeInterpreter IO -> W.WalletId -> DBDelegation (SqlPersistT IO)
 mkDBDelegation ti wid =
     DBDelegation
-        { putDelegationCertificate_
-        , putDelegationRewardBalance_
+        { putDelegationRewardBalance_
         , readDelegationRewardBalance_
         , readDelegation_
         }
   where
-
-    putDelegationCertificate_ ::
-        W.DelegationCertificate -> W.SlotNo -> SqlPersistT IO ()
-    putDelegationCertificate_ cert sl =
-        case cert of
-            W.CertDelegateNone _ -> do
-                repsert
-                    (DelegationCertificateKey wid sl)
-                    (DelegationCertificate wid sl Nothing)
-                repsert
-                    (StakeKeyCertificateKey wid sl)
-                    (StakeKeyCertificate wid sl W.StakeKeyDeregistration)
-            W.CertDelegateFull _ pool ->
-                repsert
-                    (DelegationCertificateKey wid sl)
-                    (DelegationCertificate wid sl (Just pool))
-            W.CertRegisterKey _ ->
-                repsert
-                    (StakeKeyCertificateKey wid sl)
-                    (StakeKeyCertificate wid sl W.StakeKeyRegistration)
 
     putDelegationRewardBalance_ :: Coin.Coin -> SqlPersistT IO ()
     putDelegationRewardBalance_ amount =

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -29,7 +29,6 @@ import Cardano.Wallet.DB.Pure.Implementation
     , ModelOp
     , mInitializeWallet
     , mListCheckpoints
-    , mPutDelegationCertificate
     , mPutDelegationRewardBalance
     , mPutTxHistory
     , mReadCheckpoint
@@ -117,8 +116,6 @@ newDBFresh timeInterpreter wid = do
 
         , readDelegation = error "MVar.readDelegation: not implemented"
 
-        , putDelegationCertificate = \cert sl -> noErrorAlterDB db $
-            mPutDelegationCertificate cert sl
 
         {-----------------------------------------------------------------------
                                      Tx History

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -114,8 +114,6 @@ newDBFresh timeInterpreter wid = do
 
         -- , putWalletMeta = noErrorAlterDB db .  mPutWalletMeta
 
-        , readDelegation = error "MVar.readDelegation: not implemented"
-
 
         {-----------------------------------------------------------------------
                                      Tx History

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -28,7 +28,6 @@ import Cardano.Wallet.DB.Pure.Implementation
     , Err (..)
     , ModelOp
     , mInitializeWallet
-    , mIsStakeKeyRegistered
     , mListCheckpoints
     , mPutDelegationCertificate
     , mPutDelegationRewardBalance
@@ -120,8 +119,6 @@ newDBFresh timeInterpreter wid = do
 
         , putDelegationCertificate = \cert sl -> noErrorAlterDB db $
             mPutDelegationCertificate cert sl
-
-        , isStakeKeyRegistered = throwErrorReadDB db mIsStakeKeyRegistered
 
         {-----------------------------------------------------------------------
                                      Tx History

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/New.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/New.hs
@@ -18,6 +18,8 @@ import Cardano.Wallet.DB.Migration
     )
 import Cardano.Wallet.DB.Sqlite.Migration.Old
     ( getSchemaVersion, putSchemaVersion )
+import Cardano.Wallet.DB.Store.Delegations.Migration
+    ( migrateDelegations )
 import Control.Category
     ( Category (id), (.) )
 import Control.Monad.Reader
@@ -68,4 +70,5 @@ _useSqlBackend = hoistMigration $ withReaderT dbBackend
 
 runNewStyleMigrations :: Tracer IO DBLog -> FilePath -> IO ()
 runNewStyleMigrations tr fp =
-    runMigrations (newMigrationInterface tr) fp noMigrations
+    runMigrations (newMigrationInterface tr) fp
+        $ migrateDelegations . noMigrations

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
@@ -30,8 +30,6 @@ import Prelude
 
 import Cardano.Address.Script
     ( Cosigner, Script )
-import Cardano.Pool.Types
-    ( PoolId )
 import Cardano.Slotting.Slot
     ( SlotNo )
 import Cardano.Wallet.Address.Discovery.Shared
@@ -263,26 +261,6 @@ ProtocolParameters
 
     Primary protocolParametersWalletId
     Foreign Wallet OnDeleteCascade fk_wallet_protocol_parameters protocolParametersWalletId
-    deriving Show Generic
-
--- Track whether the wallet's stake key is registered or not.
-StakeKeyCertificate
-    stakeKeyCertWalletId             W.WalletId            sql=wallet_id
-    stakeKeyCertSlot                 SlotNo                sql=slot
-    stakeKeyCertType                 W.StakeKeyCertificate sql=type
-
-    Primary stakeKeyCertWalletId stakeKeyCertSlot
-    Foreign Wallet OnDeleteCascade stakeKeyRegistration stakeKeyCertWalletId
-    deriving Show Generic
-
--- Store known delegation certificates for a particular wallet
-DelegationCertificate
-    certWalletId             W.WalletId     sql=wallet_id
-    certSlot                 SlotNo         sql=slot
-    certPoolId               PoolId Maybe sql=delegation
-
-    Primary certWalletId certSlot
-    Foreign Wallet OnDeleteCascade delegationCertificate certWalletId
     deriving Show Generic
 
 -- Latest balance of the reward account associated with

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Layer.hs
@@ -9,12 +9,21 @@ import Prelude
 
 import Cardano.Wallet.DB.Store.Delegations.Model
     ( Delegations, DeltaDelegations )
+import Cardano.Wallet.Delegation.Model
+    ( Status (..) )
 import Cardano.Wallet.Primitive.Types
     ( DelegationCertificate, SlotNo, WalletDelegation )
+import Data.Map.Strict
+    ( lookupMax )
+import Data.Maybe
+    ( fromMaybe )
 
 
+-- | Check whether the stake key is registered in the delegation state.
 isStakeKeyRegistered :: Delegations -> Bool
-isStakeKeyRegistered = error "TODO: isStakeKeyRegistered"
+isStakeKeyRegistered m = fromMaybe False $ do
+    (_, v) <- lookupMax m
+    pure $ v /= Inactive
 
 -- ^ Binds a stake pool id to a wallet. This will have an influence on
 -- the wallet metadata: the last known certificate will indicate to

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Layer.hs
@@ -1,23 +1,42 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Cardano.Wallet.DB.Store.Delegations.Layer
     ( isStakeKeyRegistered
     , putDelegationCertificate
     , readDelegation
+    , ReadDelegationSlots (..)
+    , mkReadDelegationSlots
     )
 where
 
 import Prelude
 
+import Cardano.Pool.Types
+    ( PoolId )
 import Cardano.Wallet.DB.Store.Delegations.Model
     ( Delegations, DeltaDelegations )
 import Cardano.Wallet.Delegation.Model
-    ( Status (..) )
+    ( Operation (..), Status (..) )
+import Cardano.Wallet.Primitive.Slotting
+    ( TimeInterpreter, firstSlotInEpoch, interpretQuery )
 import Cardano.Wallet.Primitive.Types
-    ( DelegationCertificate, SlotNo, WalletDelegation )
+    ( DelegationCertificate (..)
+    , EpochNo
+    , SlotNo
+    , WalletDelegation (..)
+    , WalletDelegationNext (..)
+    , WalletDelegationStatus (..)
+    )
+import Data.Foldable
+    ( find )
+import Data.Function
+    ( (&) )
 import Data.Map.Strict
     ( lookupMax )
+import qualified Data.Map.Strict as Map
 import Data.Maybe
-    ( fromMaybe )
-
+    ( catMaybes, fromMaybe )
 
 -- | Check whether the stake key is registered in the delegation state.
 isStakeKeyRegistered :: Delegations -> Bool
@@ -25,7 +44,7 @@ isStakeKeyRegistered m = fromMaybe False $ do
     (_, v) <- lookupMax m
     pure $ v /= Inactive
 
--- ^ Binds a stake pool id to a wallet. This will have an influence on
+-- | Binds a stake pool id to a wallet. This will have an influence on
 -- the wallet metadata: the last known certificate will indicate to
 -- which pool a wallet is currently delegating.
 --
@@ -35,11 +54,85 @@ isStakeKeyRegistered m = fromMaybe False $ do
 -- 1. Stored on-chain.
 -- 2. Affected by rollbacks (or said differently, tied to a 'SlotNo').
 putDelegationCertificate
-  :: DelegationCertificate
-  -> SlotNo
-  -> DeltaDelegations
-putDelegationCertificate = error "TODO: putDelegationCertificate"
+    :: DelegationCertificate
+    -> SlotNo
+    -> DeltaDelegations
+putDelegationCertificate cert sl = case cert of
+    CertDelegateNone _ -> [Deregister sl]
+    CertDelegateFull _ pool -> [Delegate pool sl, Register sl]
+    CertRegisterKey _ -> [Register sl]
 
+-- | Arguments to 'readDelegation'.
+data ReadDelegationSlots = ReadDelegationSlots
+    { currentEpoch :: EpochNo
+    -- ^ The current epoch.
+    , currentEpochStartSlot :: SlotNo
+    -- ^ The current epoch start slot.
+    , previousEpochStartSlot :: Maybe SlotNo
+    -- ^ The previous epoch start slot, if any.
+    }
 
-readDelegation :: SlotNo -> Delegations -> WalletDelegation
-readDelegation = error "TODO: readDelegation"
+-- | Read the delegation status of a wallet.
+readDelegation :: ReadDelegationSlots -> Delegations -> WalletDelegation
+readDelegation (ReadDelegationSlots epoch cur Nothing) hist =
+    WalletDelegation currentDelegation nextDelegations
+  where
+    currentDelegation = NotDelegating
+    nextDelegations =
+        catMaybes
+            [ nextDelegation (epoch + 2)
+                $ readDelegationStatus (>= cur) hist
+            ]
+readDelegation (ReadDelegationSlots epoch cur (Just prev)) hist =
+    WalletDelegation currentDelegation nextDelegations
+  where
+    currentDelegation = readDelegationStatus (< prev) hist
+        & fromMaybe NotDelegating
+    nextDelegations =
+        catMaybes
+            [ nextDelegation (epoch + 1)
+                $ readDelegationStatus (\sl -> sl >= prev && sl < cur) hist
+            , nextDelegation (epoch + 2)
+                $ readDelegationStatus (>= cur) hist
+            ]
+
+nextDelegation
+    :: Functor f
+    => EpochNo
+    -> f WalletDelegationStatus
+    -> f WalletDelegationNext
+nextDelegation = fmap . WalletDelegationNext
+
+readDelegationStatus
+    :: (SlotNo -> Bool)
+    -> Delegations
+    -> Maybe WalletDelegationStatus
+readDelegationStatus cond =
+    fmap (walletDelegationStatus . snd)
+        . find (cond . fst)
+        . reverse
+        . Map.assocs
+
+walletDelegationStatus :: Status PoolId -> WalletDelegationStatus
+walletDelegationStatus = \case
+    Inactive -> NotDelegating
+    Registered -> NotDelegating
+    Active pid -> Delegating pid
+
+-- | Construct 'ReadDelegationSlots' from an 'EpochNo' using a 'TimeInterpreter'
+-- .
+mkReadDelegationSlots
+    :: forall m
+     . Monad m
+    => TimeInterpreter m
+    -> EpochNo
+    -> m ReadDelegationSlots
+mkReadDelegationSlots ti epoch =
+    ReadDelegationSlots epoch
+        <$> slotOf epoch
+        <*> case epoch of
+            0 -> pure Nothing
+            epoch' -> Just <$> slotOf (epoch' - 1)
+  where
+    slotOf :: EpochNo -> m SlotNo
+    slotOf = interpretQuery ti . firstSlotInEpoch

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Layer.hs
@@ -1,0 +1,36 @@
+module Cardano.Wallet.DB.Store.Delegations.Layer
+    ( isStakeKeyRegistered
+    , putDelegationCertificate
+    , readDelegation
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.DB.Store.Delegations.Model
+    ( Delegations, DeltaDelegations )
+import Cardano.Wallet.Primitive.Types
+    ( DelegationCertificate, SlotNo, WalletDelegation )
+
+
+isStakeKeyRegistered :: Delegations -> Bool
+isStakeKeyRegistered = error "TODO: isStakeKeyRegistered"
+
+-- ^ Binds a stake pool id to a wallet. This will have an influence on
+-- the wallet metadata: the last known certificate will indicate to
+-- which pool a wallet is currently delegating.
+--
+-- This is done separately from 'putWalletMeta' because certificate
+-- declarations are:
+--
+-- 1. Stored on-chain.
+-- 2. Affected by rollbacks (or said differently, tied to a 'SlotNo').
+putDelegationCertificate
+  :: DelegationCertificate
+  -> SlotNo
+  -> DeltaDelegations
+putDelegationCertificate = error "TODO: putDelegationCertificate"
+
+
+readDelegation :: SlotNo -> Delegations -> WalletDelegation
+readDelegation = error "TODO: readDelegation"

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Model.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+
 module Cardano.Wallet.DB.Store.Delegations.Model
     ( Delegations
     , DeltaDelegations
     ) where
-
 
 import Prelude
 
@@ -15,10 +15,8 @@ import Cardano.Wallet.Delegation.Model
     ( History, Operation (..) )
 import Cardano.Wallet.Primitive.Types
     ( SlotNo )
-import Formatting
-    ( bformat, intercalated, later )
-import Formatting.Buildable
-    ( Buildable (..) )
+import Fmt
+    ( Buildable (..), listF' )
 
 -- | Wallet delegation history
 type Delegations = History SlotNo PoolId
@@ -28,8 +26,10 @@ type Delegations = History SlotNo PoolId
 type DeltaDelegations = [Operation SlotNo PoolId]
 
 instance Buildable DeltaDelegations where
-    build = bformat $ intercalated ", " $ later $ \case
-        Register slot -> "Register " <> build slot
-        Deregister slot -> "Deregister " <> build slot
-        Delegate pool slot -> "Delegate " <> build pool <> " " <> build slot
-        Rollback slot -> "Rollback " <> build slot
+    build = listF' build1
+      where
+        build1 = \case
+            Register slot -> "Register " <> build slot
+            Deregister slot -> "Deregister " <> build slot
+            Delegate pool slot -> "Delegate " <> build pool <> " " <> build slot
+            Rollback slot -> "Rollback " <> build slot

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Model.hs
@@ -14,5 +14,6 @@ import Cardano.Wallet.Primitive.Types
 -- | Wallet delegation history
 type Delegations = History SlotNo PoolId
 
--- | Delta of wallet delegation history
-type DeltaDelegations  = Operation SlotNo PoolId
+-- | Delta of wallet delegation history. As always with deltas, the
+-- order of the operations matters and it's reversed! (ask the architects)
+type DeltaDelegations = [Operation SlotNo PoolId]

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Model.hs
@@ -1,15 +1,24 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 module Cardano.Wallet.DB.Store.Delegations.Model
     ( Delegations
     , DeltaDelegations
     ) where
 
 
+import Prelude
+
 import Cardano.Pool.Types
     ( PoolId )
 import Cardano.Wallet.Delegation.Model
-    ( History, Operation )
+    ( History, Operation (..) )
 import Cardano.Wallet.Primitive.Types
     ( SlotNo )
+import Formatting
+    ( bformat, intercalated, later )
+import Formatting.Buildable
+    ( Buildable (..) )
 
 -- | Wallet delegation history
 type Delegations = History SlotNo PoolId
@@ -17,3 +26,10 @@ type Delegations = History SlotNo PoolId
 -- | Delta of wallet delegation history. As always with deltas, the
 -- order of the operations matters and it's reversed! (ask the architects)
 type DeltaDelegations = [Operation SlotNo PoolId]
+
+instance Buildable DeltaDelegations where
+    build = bformat $ intercalated ", " $ later $ \case
+        Register slot -> "Register " <> build slot
+        Deregister slot -> "Deregister " <> build slot
+        Delegate pool slot -> "Delegate " <> build pool <> " " <> build slot
+        Rollback slot -> "Rollback " <> build slot

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Model.hs
@@ -1,0 +1,18 @@
+module Cardano.Wallet.DB.Store.Delegations.Model
+    ( Delegations
+    , DeltaDelegations
+    ) where
+
+
+import Cardano.Pool.Types
+    ( PoolId )
+import Cardano.Wallet.Delegation.Model
+    ( History, Operation )
+import Cardano.Wallet.Primitive.Types
+    ( SlotNo )
+
+-- | Wallet delegation history
+type Delegations = History SlotNo PoolId
+
+-- | Delta of wallet delegation history
+type DeltaDelegations  = Operation SlotNo PoolId

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Schema.hs
@@ -71,8 +71,8 @@ mkPersist sqlSettings'
 delegationMigration :: Migration
 delegationMigration = migrateModels [entityDef (Proxy :: Proxy Delegations)]
 
-migrateDeletions :: MonadIO m => SqlPersistT m ()
-migrateDeletions = void $ runMigrationUnsafeQuiet delegationMigration
+migrateDelegations :: MonadIO m => SqlPersistT m ()
+migrateDelegations = void $ runMigrationUnsafeQuiet delegationMigration
 
 dropDelegationTable :: MonadIO m => SqlPersistT m ()
 dropDelegationTable = rawExecute "DROP TABLE IF EXISTS \"delegations\";" []
@@ -80,4 +80,4 @@ dropDelegationTable = rawExecute "DROP TABLE IF EXISTS \"delegations\";" []
 resetDelegationTable :: MonadIO m => SqlPersistT m ()
 resetDelegationTable = do
     dropDelegationTable
-    migrateDeletions
+    migrateDelegations

--- a/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/WalletState.hs
@@ -50,6 +50,8 @@ import Cardano.Wallet.Address.Derivation
     ( Depth (RootK) )
 import Cardano.Wallet.Checkpoints
     ( Checkpoints )
+import Cardano.Wallet.DB.Store.Delegations.Model
+    ( Delegations, DeltaDelegations )
 import Cardano.Wallet.DB.Store.Info.Store
     ( DeltaWalletInfo, WalletInfo (..) )
 import Cardano.Wallet.DB.Store.PrivateKey.Store
@@ -135,6 +137,7 @@ data WalletState s = WalletState
     , submissions :: !TxSubmissions
     , info :: !WalletInfo
     , credentials :: Maybe (HashedCredentials (KeyOf s))
+    , delegations :: Delegations
     } deriving (Generic)
 
 deriving instance
@@ -156,6 +159,7 @@ fromGenesis cp winfo
                 , submissions = emptyTxSubmissions
                 , info = winfo
                 , credentials = Nothing
+                , delegations = mempty
                 }
     | otherwise = Nothing
   where
@@ -184,6 +188,7 @@ data DeltaWalletState1 s
     | UpdateSubmissions DeltaTxSubmissions
     | UpdateInfo DeltaWalletInfo
     | UpdateCredentials (DeltaPrivateKey (KeyOf s))
+    | UpdateDelegations DeltaDelegations
 
 instance Delta (DeltaWalletState1 s) where
     type Base (DeltaWalletState1 s) = WalletState s
@@ -192,6 +197,7 @@ instance Delta (DeltaWalletState1 s) where
     apply (UpdateSubmissions d) = over #submissions $ apply d
     apply (UpdateInfo d) = over #info $ apply d
     apply (UpdateCredentials d) = over #credentials $ apply d
+    apply (UpdateDelegations d) = over #delegations $ apply d
 
 instance Buildable (DeltaWalletState1 s) where
     build (ReplacePrologue _) = "ReplacePrologue …"
@@ -199,6 +205,7 @@ instance Buildable (DeltaWalletState1 s) where
     build (UpdateSubmissions d) = "UpdateSubmissions (" <> build d <> ")"
     build (UpdateInfo d) = "UpdateInfo (" <> build d <> ")"
     build (UpdateCredentials _d) = "UpdatePrivateKey"
+    build (UpdateDelegations d) = "UpdateDelegations (" <> build d <> ")"
 
 instance Show (DeltaWalletState1 s) where
     show = pretty

--- a/lib/wallet/src/Cardano/Wallet/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation.hs
@@ -33,6 +33,7 @@ import Cardano.Wallet
     , WalletException (..)
     , WalletLog (..)
     , fetchRewardBalance
+    , isStakeKeyRegistered
     , readRewardAccount
     , transactionExpirySlot
     )
@@ -122,7 +123,7 @@ joinStakePoolDelegationAction
     (walletDelegation, stakeKeyIsRegistered) <-
         atomically $
             (,) <$> readDelegation
-                <*> isStakeKeyRegistered
+                <*> isStakeKeyRegistered walletState
 
     let retirementInfo =
             PoolRetirementEpochInfo currentEpoch . view #retirementEpoch <$>


### PR DESCRIPTION
- [x] add Layer module to support pure state modifications and reading
- [x] add the store to the wallet state
- [x] remove  `isStakeKeyRegistered` function from the DBLayer
- [x] remove  `putDelegationCertificate` function from the DBLayer
- [x] remove  `readDelegation` function from the DBLayer
- [x] migrate delegation tables

ADP-3054
