### PR TITLE
Split up the `MaybeInRecentEra` type.

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -151,7 +151,7 @@ mainnetNetworkParameters = W.NetworkParameters
         , maximumCollateralInputCount = 0
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing
-        , currentLedgerProtocolParameters = Write.InNonRecentEraByron
+        , currentLedgerProtocolParameters = Write.InBygoneEra Write.InEraByron
         }
     }
 
@@ -333,7 +333,7 @@ protocolParametersFromPP eraInfo pp =
         , maximumCollateralInputCount = 0
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing
-        , currentLedgerProtocolParameters = Write.InNonRecentEraByron
+        , currentLedgerProtocolParameters = Write.InBygoneEra Write.InEraByron
         }
   where
     fromBound (Bound _relTime _slotNo (O.EpochNo e)) =

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -893,7 +893,8 @@ fromShelleyPParams eraInfo pp =
         , maximumCollateralInputCount = 0
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing
-        , currentLedgerProtocolParameters = Write.InNonRecentEraShelley
+        , currentLedgerProtocolParameters =
+            Write.InBygoneEra Write.InEraShelley
         }
 
 fromAllegraPParams
@@ -917,7 +918,8 @@ fromAllegraPParams eraInfo pp =
         , maximumCollateralInputCount = 0
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing
-        , currentLedgerProtocolParameters = Write.InNonRecentEraAllegra
+        , currentLedgerProtocolParameters =
+            Write.InBygoneEra Write.InEraAllegra
         }
 
 fromMaryPParams
@@ -941,7 +943,8 @@ fromMaryPParams eraInfo pp =
         , maximumCollateralInputCount = 0
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing
-        , currentLedgerProtocolParameters = Write.InNonRecentEraMary
+        , currentLedgerProtocolParameters =
+            Write.InBygoneEra Write.InEraMary
         }
 
 fromBoundToEpochNo :: Bound -> W.EpochNo
@@ -973,7 +976,8 @@ fromAlonzoPParams eraInfo pp =
             Alonzo._collateralPercentage pp
         , executionUnitPrices =
             Just $ executionUnitPricesFromPParams pp
-        , currentLedgerProtocolParameters = Write.InNonRecentEraAlonzo
+        , currentLedgerProtocolParameters =
+            Write.InBygoneEra Write.InEraAlonzo
         }
 
 fromBabbagePParams
@@ -1002,7 +1006,7 @@ fromBabbagePParams eraInfo pp =
         , executionUnitPrices =
             Just $ executionUnitPricesFromPParams pp
         , currentLedgerProtocolParameters =
-            Write.InRecentEraBabbage $ Write.ProtocolParameters pp
+            Write.InRecentEra $ Write.InEraBabbage $ Write.ProtocolParameters pp
         }
 
 fromConwayPParams
@@ -1026,7 +1030,7 @@ fromConwayPParams eraInfo pp =
         , minimumCollateralPercentage = Conway._collateralPercentage pp
         , executionUnitPrices = Just $ executionUnitPricesFromPParams pp
         , currentLedgerProtocolParameters =
-            Write.InRecentEraConway $ Write.ProtocolParameters pp
+            Write.InRecentEra $ Write.InEraConway $ Write.ProtocolParameters pp
         }
 
 -- | Extract the current network decentralization level from the given set of

--- a/lib/wallet/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/wallet/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -148,7 +148,8 @@ dummyProtocolParameters = ProtocolParameters
             , pricePerMemoryUnit = 0.0577
             }
     , currentLedgerProtocolParameters =
-        Write.InRecentEraBabbage
+        Write.InRecentEra
+        $ Write.InEraBabbage
         $ Write.ProtocolParameters
         $ C.toLedgerPParams C.ShelleyBasedEraBabbage dummyNodeProtocolParameters
     }

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -724,7 +724,7 @@ instance Arbitrary ProtocolParameters where
         <*> genMaximumCollateralInputCount
         <*> genMinimumCollateralPercentage
         <*> arbitrary
-        <*> pure Write.InNonRecentEraAlonzo
+        <*> pure (Write.InBygoneEra Write.InEraAlonzo)
       where
         genMaximumCollateralInputCount :: Gen Word16
         genMaximumCollateralInputCount = arbitrarySizedNatural


### PR DESCRIPTION
## Issue

Follow-on from https://github.com/input-output-hk/cardano-wallet/pull/3874#discussion_r1209708374.

## Details

This PR introduces the following terminological distinction:
- a `RecentEra` is either the current era or the next era;
- a `BygoneEra` era is any era from the past that's **not** a recent era.

These two sets are **disjoint**.

The term "bygone era" is a natural idiom ([source](https://dictionary.cambridge.org/dictionary/english/bygone)) for an era in the past, and somewhat more concise than "non-recent era".

When we upgrade the code to handle a new era, we can:
- add a new constructor to `InRecentEra`;
- move the least recent constructor from `InRecentEra` to `InBygoneEra`;
- fix up all the compile errors.