### PR TITLE
Derive arithmetic operations for `{Coin,TokenQuantity}`.

### DIFF
--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -65,6 +65,7 @@ library
     , lattices
     , memory
     , MonadRandom
+    , monoid-subclasses
     , network-uri
     , nothunks
     , OddWord

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -50,6 +50,7 @@ library
     , cardano-numeric
     , cardano-wallet-test-utils
     , cborg
+    , commutative-semigroups
     , containers
     , cryptonite
     , delta-types

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -70,7 +70,7 @@ import Data.Monoid.Cancellative
 import Data.Monoid.GCD
     ( GCDMonoid, LeftGCDMonoid, RightGCDMonoid )
 import Data.Monoid.Monus
-    ( Monus, OverlappingGCDMonoid )
+    ( Monus ((<\>)), OverlappingGCDMonoid )
 import Data.Monoid.Null
     ( MonoidNull )
 import Data.Quantity
@@ -271,7 +271,7 @@ add = (<>)
 -- Returns 'Coin 0' if the second coin is strictly greater than the first.
 --
 difference :: Coin -> Coin -> Coin
-difference a b = fromMaybe (Coin 0) (subtract a b)
+difference = (<\>)
 
 -- | Absolute difference between two coin amounts. The result is never negative.
 distance :: Coin -> Coin -> Coin

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -65,8 +65,18 @@ import Data.Maybe
     ( fromMaybe )
 import Data.Monoid
     ( Sum (..) )
+import Data.Monoid.Cancellative
+    ( LeftReductive, Reductive, RightReductive )
+import Data.Monoid.GCD
+    ( GCDMonoid, LeftGCDMonoid, RightGCDMonoid )
+import Data.Monoid.Monus
+    ( Monus, OverlappingGCDMonoid )
+import Data.Monoid.Null
+    ( MonoidNull )
 import Data.Quantity
     ( Quantity (..) )
+import Data.Semigroup.Commutative
+    ( Commutative )
 import Data.Text.Class
     ( FromText (..), ToText (..) )
 import Data.Word
@@ -97,7 +107,10 @@ newtype Coin = Coin
     }
     deriving stock (Ord, Eq, Generic)
     deriving (Read, Show) via Quiet Coin
-    deriving (Semigroup, Monoid) via Sum Natural
+    deriving (Commutative, Semigroup, Monoid, MonoidNull) via Sum Natural
+    deriving (LeftReductive, RightReductive, Reductive) via Sum Natural
+    deriving (LeftGCDMonoid, RightGCDMonoid, GCDMonoid) via Sum Natural
+    deriving (OverlappingGCDMonoid, Monus) via Sum Natural
 
 instance ToText Coin where
     toText (Coin c) = T.pack $ show c

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -66,7 +66,7 @@ import Data.Maybe
 import Data.Monoid
     ( Sum (..) )
 import Data.Monoid.Cancellative
-    ( LeftReductive, Reductive, RightReductive )
+    ( LeftReductive, Reductive ((</>)), RightReductive )
 import Data.Monoid.GCD
     ( GCDMonoid, LeftGCDMonoid, RightGCDMonoid )
 import Data.Monoid.Monus
@@ -259,9 +259,7 @@ unsafeToWord64 c = fromMaybe onError (toWord64Maybe c)
 -- Returns 'Nothing' if the second coin is strictly greater than the first.
 --
 subtract :: Coin -> Coin -> Maybe Coin
-subtract (Coin a) (Coin b)
-    | a >= b    = Just $ Coin (a - b)
-    | otherwise = Nothing
+subtract = (</>)
 
 -- | Calculates the combined value of two coins.
 --

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -266,7 +266,7 @@ subtract (Coin a) (Coin b)
 -- | Calculates the combined value of two coins.
 --
 add :: Coin -> Coin -> Coin
-add (Coin a) (Coin b) = Coin (a + b)
+add = (<>)
 
 -- | Subtracts the second coin from the first.
 --

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -94,7 +94,7 @@ newtype Coin = Coin
     { unCoin :: Natural
     }
     deriving stock (Ord, Eq, Generic)
-    deriving (Read, Show) via (Quiet Coin)
+    deriving (Read, Show) via Quiet Coin
 
 -- | The 'Semigroup' instance for 'Coin' corresponds to ordinary addition.
 --

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -275,7 +275,7 @@ difference = (<\>)
 
 -- | Absolute difference between two coin amounts. The result is never negative.
 distance :: Coin -> Coin -> Coin
-distance (Coin a) (Coin b) = if a < b then Coin (b - a) else Coin (a - b)
+distance a b = (a <\> b) <> (b <\> a)
 
 --------------------------------------------------------------------------------
 -- Partitioning

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -63,6 +63,8 @@ import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
     ( fromMaybe )
+import Data.Monoid
+    ( Sum (..) )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Text.Class
@@ -95,15 +97,7 @@ newtype Coin = Coin
     }
     deriving stock (Ord, Eq, Generic)
     deriving (Read, Show) via Quiet Coin
-
--- | The 'Semigroup' instance for 'Coin' corresponds to ordinary addition.
---
-instance Semigroup Coin where
-    -- Natural doesn't have a default Semigroup instance.
-    (<>) = add
-
-instance Monoid Coin where
-    mempty = Coin 0
+    deriving (Semigroup, Monoid) via Sum Natural
 
 instance ToText Coin where
     toText (Coin c) = T.pack $ show c

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
@@ -55,7 +55,7 @@ import Data.Monoid.Cancellative
 import Data.Monoid.GCD
     ( GCDMonoid, LeftGCDMonoid, RightGCDMonoid )
 import Data.Monoid.Monus
-    ( Monus, OverlappingGCDMonoid )
+    ( Monus ((<\>)), OverlappingGCDMonoid )
 import Data.Monoid.Null
     ( MonoidNull )
 import Data.Semigroup.Commutative
@@ -161,7 +161,7 @@ succ = (`add` TokenQuantity 1)
 -- Returns 'zero' if the first quantity is less than the second quantity.
 --
 difference :: TokenQuantity -> TokenQuantity -> TokenQuantity
-difference x y = fromMaybe zero $ subtract x y
+difference = (<\>)
 
 --------------------------------------------------------------------------------
 -- Partitioning

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
@@ -54,6 +54,16 @@ import Data.Maybe
     ( fromMaybe )
 import Data.Monoid
     ( Sum (..) )
+import Data.Monoid.Cancellative
+    ( LeftReductive, Reductive, RightReductive )
+import Data.Monoid.GCD
+    ( GCDMonoid, LeftGCDMonoid, RightGCDMonoid )
+import Data.Monoid.Monus
+    ( Monus, OverlappingGCDMonoid )
+import Data.Monoid.Null
+    ( MonoidNull )
+import Data.Semigroup.Commutative
+    ( Commutative )
 import Data.Text.Class
     ( FromText (..), ToText (..) )
 import Fmt
@@ -83,7 +93,10 @@ newtype TokenQuantity = TokenQuantity
     deriving stock (Eq, Ord, Generic)
     deriving anyclass (NFData, Hashable)
     deriving (Read, Show) via Quiet TokenQuantity
-    deriving (Semigroup, Monoid) via Sum Natural
+    deriving (Commutative, Semigroup, Monoid, MonoidNull) via Sum Natural
+    deriving (LeftReductive, RightReductive, Reductive) via Sum Natural
+    deriving (LeftGCDMonoid, RightGCDMonoid, GCDMonoid) via Sum Natural
+    deriving (OverlappingGCDMonoid, Monus) via Sum Natural
 
 --------------------------------------------------------------------------------
 -- Instances

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
@@ -52,6 +52,8 @@ import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
     ( fromMaybe )
+import Data.Monoid
+    ( Sum (..) )
 import Data.Text.Class
     ( FromText (..), ToText (..) )
 import Fmt
@@ -81,16 +83,11 @@ newtype TokenQuantity = TokenQuantity
     deriving stock (Eq, Ord, Generic)
     deriving anyclass (NFData, Hashable)
     deriving (Read, Show) via Quiet TokenQuantity
+    deriving (Semigroup, Monoid) via Sum Natural
 
 --------------------------------------------------------------------------------
 -- Instances
 --------------------------------------------------------------------------------
-
-instance Semigroup TokenQuantity where
-    (<>) = add
-
-instance Monoid TokenQuantity where
-    mempty = zero
 
 instance Buildable TokenQuantity where
     build = build . toText . unTokenQuantity

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
@@ -79,8 +79,8 @@ import Quiet
 newtype TokenQuantity = TokenQuantity
     { unTokenQuantity :: Natural }
     deriving stock (Eq, Ord, Generic)
-    deriving (Read, Show) via (Quiet TokenQuantity)
     deriving anyclass (NFData, Hashable)
+    deriving (Read, Show) via Quiet TokenQuantity
 
 --------------------------------------------------------------------------------
 -- Instances

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
@@ -40,12 +40,8 @@ import Cardano.Numeric.Util
     ( equipartitionNatural, partitionNatural )
 import Control.DeepSeq
     ( NFData (..) )
-import Control.Monad
-    ( guard )
 import Data.Aeson
     ( FromJSON (..), ToJSON (..) )
-import Data.Functor
-    ( ($>) )
 import Data.Hashable
     ( Hashable )
 import Data.List.NonEmpty
@@ -55,7 +51,7 @@ import Data.Maybe
 import Data.Monoid
     ( Sum (..) )
 import Data.Monoid.Cancellative
-    ( LeftReductive, Reductive, RightReductive )
+    ( LeftReductive, Reductive ((</>)), RightReductive )
 import Data.Monoid.GCD
     ( GCDMonoid, LeftGCDMonoid, RightGCDMonoid )
 import Data.Monoid.Monus
@@ -135,7 +131,7 @@ add = (<>)
 -- Returns 'Nothing' if the first quantity is less than the second quantity.
 --
 subtract :: TokenQuantity -> TokenQuantity -> Maybe TokenQuantity
-subtract x y = guard (x >= y) $> unsafeSubtract x y
+subtract = (</>)
 
 -- | Finds the predecessor of a given token quantity.
 --

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
@@ -128,7 +128,7 @@ zero = TokenQuantity 0
 --------------------------------------------------------------------------------
 
 add :: TokenQuantity -> TokenQuantity -> TokenQuantity
-add (TokenQuantity x) (TokenQuantity y) = TokenQuantity $ x + y
+add = (<>)
 
 -- | Subtracts the second token quantity from the first.
 --


### PR DESCRIPTION
## Summary

This PR uses classes defined by the [`monoid-subclasses`](https://hackage.haskell.org/package/monoid-subclasses-1.2.3#readme) library to derive the definitions of all arithmetic operations for the `Coin` and `TokenQuantity` types.

This takes advantage of the fact that both `Coin` and `TokenQuantity` have `Semigroup` and `Monoid` instances that are identical to those for `Sum Natural`.