### PR TITLE
Factor out `Write.UTxOAssumptions.validateAddress`

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -412,6 +412,7 @@ library
     Cardano.Wallet.Write.Tx.Balance
     Cardano.Wallet.Write.Tx.Gen
     Cardano.Wallet.Write.Tx.TimeTranslation
+    Cardano.Wallet.Write.UTxOAssumptions
     Control.Concurrent.Concierge
     Control.Monad.Exception.Unchecked
     Control.Monad.Util

--- a/lib/wallet/src/Cardano/Wallet/Address/Discovery/Random.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Discovery/Random.hs
@@ -112,7 +112,7 @@ import GHC.TypeLits
 import System.Random
     ( RandomGen, StdGen, mkStdGen, randomR )
 
-import qualified Cardano.Ledger.Address as Ledger
+import qualified Cardano.Wallet.Write.UTxOAssumptions as UTxOAssumptions
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -455,13 +455,10 @@ instance KnownNat p => IsOurs (RndAnyState n p) Address where
         double :: Integral a => a -> Double
         double = fromIntegral
 
-        -- ADP-3056: Consider making this implementation a part of a
-        -- @validate :: UTxOAssumptions -> Address -> Bool@ function
-        -- somewhere in the Write module hierarchy.
-        correctAddressType :: Bool
-        correctAddressType = case toLedger (Address bytes) of
-            Ledger.Addr _net _ _ -> False
-            Ledger.AddrBootstrap _ -> True
+        correctAddressType =
+            UTxOAssumptions.validateAddress
+                UTxOAssumptions.AllByronKeyPaymentCredentials
+                (toLedger $ Address bytes)
 
 instance IsOurs (RndAnyState n p) RewardAccount where
     isOurs _account state = (Nothing, state)

--- a/lib/wallet/src/Cardano/Wallet/Address/Discovery/Sequential.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Discovery/Sequential.hs
@@ -746,6 +746,7 @@ instance KnownNat p => IsOurs (SeqAnyState n k p) Address where
             Ledger.Addr _net (Ledger.KeyHashObj _) _ -> True
             Ledger.Addr _net (Ledger.ScriptHashObj _) _ -> True
             Ledger.AddrBootstrap _ -> False
+
 instance IsOurs (SeqAnyState n k p) RewardAccount where
     isOurs _account state = (Nothing, state)
 

--- a/lib/wallet/src/Cardano/Wallet/Address/Discovery/Sequential.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Discovery/Sequential.hs
@@ -163,9 +163,8 @@ import GHC.TypeLits
 import Type.Reflection
     ( Typeable )
 
-import qualified Cardano.Ledger.Address as Ledger
-import qualified Cardano.Ledger.Credential as Ledger
 import qualified Cardano.Wallet.Address.Pool as AddressPool
+import qualified Cardano.Wallet.Write.UTxOAssumptions as UTxOAssumptions
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
@@ -738,14 +737,10 @@ instance KnownNat p => IsOurs (SeqAnyState n k p) Address where
         double :: Integral a => a -> Double
         double = fromIntegral
 
-        -- ADP-3056: Consider making this implementation a part of a
-        -- @validate :: UTxOAssumptions -> Address -> Bool@ function
-        -- somewhere in the Write module hierarchy.
-        correctAddressType :: Bool
-        correctAddressType = case toLedger (Address bytes) of
-            Ledger.Addr _net (Ledger.KeyHashObj _) _ -> True
-            Ledger.Addr _net (Ledger.ScriptHashObj _) _ -> True
-            Ledger.AddrBootstrap _ -> False
+        correctAddressType =
+            UTxOAssumptions.validateAddress
+                UTxOAssumptions.AllKeyPaymentCredentials
+                (toLedger $ Address bytes)
 
 instance IsOurs (SeqAnyState n k p) RewardAccount where
     isOurs _account state = (Nothing, state)

--- a/lib/wallet/src/Cardano/Wallet/Write/UTxOAssumptions.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/UTxOAssumptions.hs
@@ -1,15 +1,24 @@
 {-# LANGUAGE LambdaCase #-}
 module Cardano.Wallet.Write.UTxOAssumptions
-    ( UTxOAssumptions (..)
+    (
+    -- * UTxOAssumptions
+      UTxOAssumptions (..)
     , assumedInputScriptTemplate
     , assumedTxWitnessTag
+
+    -- * Validation
+    , validateAddress
     )
     where
 
 import Prelude
 
+import Cardano.Ledger.Shelley.API
+    ( Addr (..), Credential (..) )
 import Cardano.Wallet.TxWitnessTag
     ( TxWitnessTag (..) )
+import Cardano.Wallet.Write.Tx
+    ( Address )
 
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Wallet.Primitive.Types.Address as W
@@ -40,3 +49,11 @@ assumedTxWitnessTag = \case
     AllKeyPaymentCredentials -> TxWitnessShelleyUTxO
     AllByronKeyPaymentCredentials -> TxWitnessByronUTxO
     AllScriptPaymentCredentialsFrom {} -> TxWitnessShelleyUTxO
+
+validateAddress :: UTxOAssumptions -> Address -> Bool
+validateAddress = valid
+  where
+    valid AllKeyPaymentCredentials          (Addr _ KeyHashObj{}    _) = True
+    valid AllScriptPaymentCredentialsFrom{} (Addr _ ScriptHashObj{} _) = True
+    valid AllByronKeyPaymentCredentials     (AddrBootstrap _)          = True
+    valid _                                 _                          = False

--- a/lib/wallet/src/Cardano/Wallet/Write/UTxOAssumptions.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/UTxOAssumptions.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE LambdaCase #-}
+module Cardano.Wallet.Write.UTxOAssumptions
+    ( UTxOAssumptions (..)
+    , assumedInputScriptTemplate
+    , assumedTxWitnessTag
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.TxWitnessTag
+    ( TxWitnessTag (..) )
+
+import qualified Cardano.Address.Script as CA
+import qualified Cardano.Wallet.Primitive.Types.Address as W
+
+-- | Assumptions about the UTxO which are needed for coin-selection.
+data UTxOAssumptions
+    = AllKeyPaymentCredentials
+    -- ^ Assumes all 'UTxO' entries have addresses with the post-Shelley
+    -- key payment credentials.
+    | AllByronKeyPaymentCredentials
+    -- ^ Assumes all 'UTxO' entries have addresses with the boostrap/byron
+    -- key payment credentials.
+    | AllScriptPaymentCredentialsFrom
+    -- ^ Assumes all 'UTxO' entries have addresses with script
+    -- payment credentials, where the scripts are both derived
+    -- from the 'ScriptTemplate' and can be looked up using the given function.
+        !CA.ScriptTemplate
+        !(W.Address -> CA.Script CA.KeyHash)
+
+assumedInputScriptTemplate :: UTxOAssumptions -> Maybe CA.ScriptTemplate
+assumedInputScriptTemplate = \case
+    AllKeyPaymentCredentials -> Nothing
+    AllByronKeyPaymentCredentials -> Nothing
+    AllScriptPaymentCredentialsFrom scriptTemplate _ -> Just scriptTemplate
+
+assumedTxWitnessTag :: UTxOAssumptions -> TxWitnessTag
+assumedTxWitnessTag = \case
+    AllKeyPaymentCredentials -> TxWitnessShelleyUTxO
+    AllByronKeyPaymentCredentials -> TxWitnessByronUTxO
+    AllScriptPaymentCredentialsFrom {} -> TxWitnessShelleyUTxO

--- a/lib/wallet/src/Cardano/Wallet/Write/UTxOAssumptions.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/UTxOAssumptions.hs
@@ -23,7 +23,7 @@ import Cardano.Wallet.Write.Tx
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Wallet.Primitive.Types.Address as W
 
--- | Assumptions about the UTxO which are needed for coin-selection.
+-- | Assumptions about UTxOs that are needed for coin selection.
 data UTxOAssumptions
     = AllKeyPaymentCredentials
     -- ^ Assumes all 'UTxO' entries have addresses with the post-Shelley

--- a/lib/wallet/src/Cardano/Wallet/Write/UTxOAssumptions.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/UTxOAssumptions.hs
@@ -1,4 +1,10 @@
 {-# LANGUAGE LambdaCase #-}
+
+-- |
+-- Copyright: © 2023 IOHK
+-- License: Apache-2.0
+--
+-- Module containing 'UTxOAssumptions' and related functionality.
 module Cardano.Wallet.Write.UTxOAssumptions
     (
     -- * UTxOAssumptions


### PR DESCRIPTION
- [x] Move `UTxOAssumptions` to a separate module
    - I didn't originally like this idea, as I thought it should be defined in some `CoinSelection` module next to `selectAssets`, but it seems to make sense now and here.
- [x] Define `Write.UTxOAssumptions.validateAddress` for use in bench-state `isOurs` in place of importing ledger modules directly.

### Comments

Targets #3974 

### Issue Number

ADP-3055
