### PR TITLE
Use correct markdown syntax in `MAINTAINERS.md`.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,10 +4,10 @@ If you were a maintainer and would like to add your name to the Emeritus list, p
 
 See CONTRIBUTING.md for general contribution guidelines.
 
-== Active Maintainers (in alphabetical order)
+## Active Maintainers (in alphabetical order)
 
 | Name                | Username              |
-+---------------------+-----------------------|
+|:--------------------|:----------------------|
 | Heinrich Apfelmus   | @HeinrichApfelmus     |
 | Johannes Lund       | @Anviking             |
 | Jonathan Knowles    | @jonathanknowles      |
@@ -16,10 +16,10 @@ See CONTRIBUTING.md for general contribution guidelines.
 | Piotr Stachyra      | @piotr-iohk           |
 | Yuriy Lazaryev      | @Unisay               |
 
-== Emeritus Maintainers (in alphabetical order)
+## Emeritus Maintainers (in alphabetical order)
 
 | Name                | Username              |
-+---------------------+-----------------------|
+|:--------------------|:----------------------|
 | Ante Kegalj         | @akegalj              |
 | Julian Ospald       | @hasufell             |
 | Matthias Benkort    | @KtorZ                |


### PR DESCRIPTION
PR https://github.com/input-output-hk/cardano-wallet/pull/3972 added a `MAINTANERS.md` file.

This PR revises that file to use the correct syntax for GitHub markdown.

See [here](https://github.com/input-output-hk/cardano-wallet/blob/72290e69b9a068b0ef92f2b0376accc92affbb73/MAINTAINERS.md) to view the rendered version.