### PR TITLE
[ADP-3060] Remove `putCheckpoint` from `DBLayer`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Checkpoints.hs
+++ b/lib/wallet/src/Cardano/Wallet/Checkpoints.hs
@@ -135,8 +135,9 @@ type DeltasCheckpoints a = [DeltaCheckpoints a]
 
 data DeltaCheckpoints a
     = PutCheckpoint W.Slot a
+        -- ^ Insert a checkpoint at a specified slot.
     | RollbackTo W.Slot
-        -- Rolls back to the latest checkpoint at or before this slot.
+        -- ^ Rolls back to the latest checkpoint at or before this slot.
     | RestrictTo [W.Slot]
         -- ^ Restrict to the intersection of this list with
         -- the checkpoints that are already present.

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -214,12 +214,6 @@ data DBLayer m s = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , transactionsStore :: Store stm QueryTxWalletsHistory DeltaTxWalletsHistory
         -- ^ 'Store' containing all transactions of all wallets in the database.
 
-    , putCheckpoint :: Wallet s -> stm ()
-        -- ^ Replace the current checkpoint for a given wallet. We do not handle
-        -- rollbacks yet, and therefore only stores the latest available
-        -- checkpoint.
-        --
-
     , readCheckpoint :: stm (Wallet s)
         -- ^ Fetch the most recent checkpoint of a given wallet.
 
@@ -404,7 +398,6 @@ mkDBLayerFromParts ti wid_ DBLayerCollection{..} = DBLayer
     { walletId_ = wid_
     , walletState = walletsDB_ dbCheckpoints
     , transactionsStore = transactionsStore_
-    , putCheckpoint = putCheckpoint_ dbCheckpoints
     , readCheckpoint = readCheckpoint'
     , listCheckpoints = listCheckpoints_ dbCheckpoints
     , readDelegation = do
@@ -490,11 +483,6 @@ data DBCheckpoints stm s = DBCheckpoints
         --
         -- Intended to replace 'putCheckpoint' and 'readCheckpoint' in the short-term,
         -- and all other functions in the long-term.
-
-    , putCheckpoint_ :: Wallet s -> stm ()
-        -- ^ Replace the current checkpoint for a given wallet. We do not handle
-        -- rollbacks yet, and therefore only stores the latest available
-        -- checkpoint.
 
     , readCheckpoint_ :: stm (Wallet s)
         -- ^ Fetch the most recent checkpoint of a given wallet.

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -130,9 +130,7 @@ import Cardano.Wallet.DB.WalletState
     , DeltaWalletState1 (..)
     , findNearestPoint
     , fromGenesis
-    , fromWallet
     , getLatest
-    , getSlot
     )
 import Cardano.Wallet.Flavor
     ( KeyFlavorS, WalletFlavorS, keyOfWallet )
@@ -563,14 +561,6 @@ newDBFreshFromDBOpen wF ti wid_ DBOpen{atomically=atomically_} =
         -----------------------------------------------------------------------}
         dbCheckpoints = DBCheckpoints
             { walletsDB_ = walletState
-
-            , putCheckpoint_ = \cp ->
-                Delta.onDBVar walletState $ Delta.update $ \_ ->
-                    let (prologue, wcp) = fromWallet cp
-                        slot = getSlot wcp
-                    in  [ UpdateCheckpoints [ PutCheckpoint slot wcp ]
-                        , ReplacePrologue prologue
-                        ]
 
             , readCheckpoint_ = readCheckpoint
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
@@ -47,7 +47,6 @@ module Cardano.Wallet.DB.Pure.Implementation
     -- * Model database functions
     , mInitializeWallet
     , mGetWalletId
-    , mPutCheckpoint
     , mReadCheckpoint
     , mListCheckpoints
     , mRollbackTo
@@ -221,10 +220,6 @@ mInitializeWallet wid (DBLayerParams cp meta txs0 gp) =
 mGetWalletId :: ModelOp wid s xprv wid
 mGetWalletId db@(Database wid _wallet _) = (Right wid, db)
 
-mPutCheckpoint
-    :: Wallet s -> ModelOp wid s xprv ()
-mPutCheckpoint cp = alterModelNoTxs' $ \wal
-    -> wal { checkpoints = Map.insert (tip cp) cp (checkpoints wal) }
 
 mReadCheckpoint
     :: ModelOp wid s xprv (Wallet s)

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -30,7 +30,6 @@ import Cardano.Wallet.DB.Pure.Implementation
     , mInitializeWallet
     , mIsStakeKeyRegistered
     , mListCheckpoints
-    , mPutCheckpoint
     , mPutDelegationCertificate
     , mPutDelegationRewardBalance
     , mPutTxHistory
@@ -104,7 +103,7 @@ newDBFresh timeInterpreter wid = do
         , walletState = error "MVar.walletState: not implemented"
         , transactionsStore = error "MVar.transactionsStore: not implemented"
 
-        , putCheckpoint = noErrorAlterDB  db .  mPutCheckpoint
+        , putCheckpoint = error "MVar.putCheckpoint: implementation deleted"
 
         , readCheckpoint = throwErrorReadDB db mReadCheckpoint
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -103,8 +103,6 @@ newDBFresh timeInterpreter wid = do
         , walletState = error "MVar.walletState: not implemented"
         , transactionsStore = error "MVar.transactionsStore: not implemented"
 
-        , putCheckpoint = error "MVar.putCheckpoint: implementation deleted"
-
         , readCheckpoint = throwErrorReadDB db mReadCheckpoint
 
         , listCheckpoints = fromMaybe [] <$> readDBMaybe db mListCheckpoints

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -547,13 +547,6 @@ fileModeSpec =  do
                 )
                 (reverse testTxs) -- expected after opening db
 
-        it "put and read checkpoint" $ \f -> do
-            withShelleyFileDBFresh f $ \DBFresh{bootDBLayer} -> do
-                DBLayer{atomically, putCheckpoint} <-
-                    unsafeRunExceptT $ bootDBLayer testDBLayerParams
-                atomically $ putCheckpoint testCp
-            testReopening f readCheckpoint' testCp
-
         describe "Golden rollback scenarios" $ do
             let dummyHash x = Hash $
                     x <> BS.pack (replicate (32 - (BS.length x)) 0)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -577,6 +577,15 @@ fileModeSpec =  do
                                 (view $ #currentTip . #blockHeight)
                                 epochStability
                                 (currentTip cpB ^. #blockHeight)
+                    let putCheckpoint cp =
+                              Delta.onDBVar walletState
+                            $ Delta.update $ \_ ->
+                                let (prologue, wcp) = WalletState.fromWallet cp
+                                    slot = WalletState.getSlot wcp
+                                in  [ WalletState.UpdateCheckpoints
+                                        [ Checkpoints.PutCheckpoint slot wcp ]
+                                    , WalletState.ReplacePrologue prologue
+                                    ]
 
                     atomically $ do
                         putCheckpoint cpB

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -151,12 +151,6 @@ properties withFreshDB = describe "DB.Properties" $ do
             $ prop_createWalletTwice withFreshDB
 
     describe "put . read yields a result" $ do
-        it "Checkpoint"
-            $ property
-            $ prop_readAfterPut
-                testOnLayer
-                (\DBLayer{..} _wid -> lift . atomically . putCheckpoint)
-                (\DBLayer{..} _wid -> Identity <$> atomically readCheckpoint)
         it "Tx History"
             $ property
             $ prop_readAfterPut
@@ -173,14 +167,6 @@ properties withFreshDB = describe "DB.Properties" $ do
             $ prop_getTxAfterPutInvalidTxId testOnLayer
 
     describe "sequential puts replace values in order" $ do
-        it "Checkpoint"
-            $ checkCoverage
-            $ prop_sequentialPut
-                testOnLayer
-                (\DBLayer{..} _wid -> lift . atomically . putCheckpoint)
-                (\DBLayer{..} _-> Identity <$> atomically readCheckpoint)
-                (Identity . last)
-                . sortOn (currentTip . unShowFmt)
         it "Tx History"
             $ checkCoverage
             $ prop_sequentialPut


### PR DESCRIPTION
### Overview

This pull request is about removing the function `putCheckpoint` from the `DBLayer`.

After this change, adding a checkpoint will involve apply a delta to the `walletState` directly.

### Comments

* In some tests, we continue to use `putCheckpoint`, but by inlining the previous definition.

### Issue number

ADP-3060