### PR TITLE
Simplify `UTxOIndex`.

### DIFF
--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -66,6 +66,7 @@ library
     , memory
     , MonadRandom
     , monoid-subclasses
+    , monoidmap
     , network-uri
     , nothunks
     , OddWord

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -130,10 +130,10 @@ import Data.Map.Strict
     ( Map )
 import Data.Maybe
     ( isJust )
+import Data.MonoidMap
+    ( MonoidMap )
 import Data.Set
     ( Set )
-import Data.Set.Strict.NonEmptySet
-    ( NonEmptySet )
 import GHC.Generics
     ( Generic )
 
@@ -143,8 +143,8 @@ import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
+import qualified Data.MonoidMap as MonoidMap
 import qualified Data.Set as Set
-import qualified Data.Set.Strict.NonEmptySet as NonEmptySet
 
 --------------------------------------------------------------------------------
 -- Public Interface
@@ -175,14 +175,14 @@ import qualified Data.Set.Strict.NonEmptySet as NonEmptySet
 --
 data UTxOIndex u = UTxOIndex
     { indexAll
-        :: !(Map Asset (NonEmptySet u))
+        :: !(MonoidMap Asset (Set u))
         -- An index of all entries that contain the given asset.
     , indexSingletons
-        :: !(Map Asset (NonEmptySet u))
+        :: !(MonoidMap Asset (Set u))
         -- An index of all entries that contain the given asset and no other
         -- assets.
     , indexPairs
-        :: !(Map Asset (NonEmptySet u))
+        :: !(MonoidMap Asset (Set u))
         -- An index of all entries that contain the given asset and exactly
         -- one other asset.
     , balance
@@ -204,9 +204,9 @@ instance NFData u => NFData (UTxOIndex u)
 --
 empty :: UTxOIndex u
 empty = UTxOIndex
-    { indexAll = Map.empty
-    , indexSingletons = Map.empty
-    , indexPairs = Map.empty
+    { indexAll = MonoidMap.empty
+    , indexSingletons = MonoidMap.empty
+    , indexPairs = MonoidMap.empty
     , balance = TokenBundle.empty
     , universe = Map.empty
     }
@@ -324,10 +324,10 @@ delete u i =
 
     deleteEntry
         :: Ord asset
-        => Map asset (NonEmptySet u)
+        => MonoidMap asset (Set u)
         -> asset
-        -> Map asset (NonEmptySet u)
-    deleteEntry m a = Map.update (NonEmptySet.delete u) a m
+        -> MonoidMap asset (Set u)
+    deleteEntry m a = MonoidMap.adjust (Set.delete u) a m
 
 -- | Deletes multiple entries from an index.
 --
@@ -357,7 +357,7 @@ partition f = bimap fromSequence fromSequence . L.partition (f . fst) . toList
 -- | Returns the complete set of all assets contained in an index.
 --
 assets :: UTxOIndex u -> Set Asset
-assets = Map.keysSet . indexAll
+assets = MonoidMap.nonNullKeys . indexAll
 
 -- | Returns the value corresponding to the given UTxO identifier.
 --
@@ -454,8 +454,7 @@ selectRandom i selectionFilter =
         SelectAny ->
             Map.keysSet (universe i)
       where
-        a `lookupWith` index =
-            maybe mempty NonEmptySet.toSet $ Map.lookup a $ index i
+        a `lookupWith` index = MonoidMap.get a $ index i
 
 -- | Selects an entry at random from the index according to the given filters.
 --
@@ -598,14 +597,10 @@ insertUnsafe u b i = i
   where
     insertEntry
         :: Ord asset
-        => Map asset (NonEmptySet u)
+        => MonoidMap asset (Set u)
         -> asset
-        -> Map asset (NonEmptySet u)
-    insertEntry m a =
-        Map.alter (maybe (Just createNew) (Just . updateOld)) a m
-      where
-        createNew = NonEmptySet.singleton u
-        updateOld = NonEmptySet.insert u
+        -> MonoidMap asset (Set u)
+    insertEntry m a = MonoidMap.adjust (Set.insert u) a m
 
 -- | Selects an element at random from the given set.
 --
@@ -717,10 +712,10 @@ indexIsComplete i =
         :: Ord asset
         => asset
         -> u
-        -> (UTxOIndex u -> Map asset (NonEmptySet u))
+        -> (UTxOIndex u -> MonoidMap asset (Set u))
         -> Bool
     hasEntryForAsset asset u assetsMap =
-        maybe False (NonEmptySet.member u) $ Map.lookup asset $ assetsMap i
+        Set.member u $ MonoidMap.get asset $ assetsMap i
 
 -- | Checks that every indexed entry is required by some entry in the 'universe'
 --   map.
@@ -728,13 +723,13 @@ indexIsComplete i =
 indexIsMinimal :: forall u. Ord u => UTxOIndex u -> Bool
 indexIsMinimal i = F.and
     [ indexAll i
-        & Map.toList
+        & MonoidMap.toList
         & F.all (\(a, u) -> F.all (entryHasAsset a) u)
     , indexSingletons i
-        & Map.toList
+        & MonoidMap.toList
         & F.all (\(a, u) -> F.all (entryHasOneAsset a) u)
     , indexPairs i
-        & Map.toList
+        & MonoidMap.toList
         & F.all (\(a, u) -> F.all (entryHasTwoAssetsWith a) u)
     ]
   where
@@ -761,32 +756,12 @@ indexIsMinimal i = F.and
 indexIsConsistent :: Ord u => UTxOIndex u -> Bool
 indexIsConsistent i = F.and
     [ indexSingletons i
-        `isDisjointTo` indexPairs i
+        `MonoidMap.disjoint` indexPairs i
     , indexSingletons i
-        `isSubmapOf` indexAll i
+        `MonoidMap.isSubmapOf` indexAll i
     , indexPairs i
-        `isSubmapOf` indexAll i
+        `MonoidMap.isSubmapOf` indexAll i
     ]
-  where
-    isDisjointTo
-        :: Ord u
-        => Map a (NonEmptySet u)
-        -> Map a (NonEmptySet u)
-        -> Bool
-    isDisjointTo m1 m2 = s1 `Set.disjoint` s2
-      where
-        s1 = F.foldMap NonEmptySet.toSet m1
-        s2 = F.foldMap NonEmptySet.toSet m2
-
-    isSubmapOf
-        :: (Ord a, Ord u)
-        => Map a (NonEmptySet u)
-        -> Map a (NonEmptySet u)
-        -> Bool
-    isSubmapOf = Map.isSubmapOfBy isNonEmptySubsetOf
-      where
-        isNonEmptySubsetOf s1 s2 =
-            NonEmptySet.toSet s1 `Set.isSubsetOf` NonEmptySet.toSet s2
 
 -- | Checks that the asset sets are consistent.
 --
@@ -798,11 +773,11 @@ indexIsConsistent i = F.and
 --
 assetsConsistent :: UTxOIndex u -> Bool
 assetsConsistent i = and
-    [ Map.keysSet (indexAll i)
+    [ MonoidMap.nonNullKeys (indexAll i)
         == balanceAssets
-    , Map.keysSet (indexSingletons i)
+    , MonoidMap.nonNullKeys (indexSingletons i)
         `Set.isSubsetOf` balanceAssets
-    , Map.keysSet (indexPairs i)
+    , MonoidMap.nonNullKeys (indexPairs i)
         `Set.isSubsetOf` balanceAssets
     ]
   where

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -696,26 +696,25 @@ indexIsComplete i =
         BundleWithNoAssets ->
             True
         BundleWithOneAsset a -> and
-            [ hasEntryForAsset a u indexAll
-            , hasEntryForAsset a u indexSingletons
+            [ hasEntryForAsset a indexAll
+            , hasEntryForAsset a indexSingletons
             ]
         BundleWithTwoAssets (a1, a2) -> and
-            [ hasEntryForAsset a1 u indexAll
-            , hasEntryForAsset a2 u indexAll
-            , hasEntryForAsset a1 u indexPairs
-            , hasEntryForAsset a2 u indexPairs
+            [ hasEntryForAsset a1 indexAll
+            , hasEntryForAsset a2 indexAll
+            , hasEntryForAsset a1 indexPairs
+            , hasEntryForAsset a2 indexPairs
             ]
         BundleWithMultipleAssets as ->
-            F.all (\a -> hasEntryForAsset a u indexAll) as
-
-    hasEntryForAsset
-        :: Ord asset
-        => asset
-        -> u
-        -> (UTxOIndex u -> MonoidMap asset (Set u))
-        -> Bool
-    hasEntryForAsset asset u assetsMap =
-        Set.member u $ MonoidMap.get asset $ assetsMap i
+            F.all (\a -> hasEntryForAsset a indexAll) as
+      where
+        hasEntryForAsset
+            :: Ord asset
+            => asset
+            -> (UTxOIndex u -> MonoidMap asset (Set u))
+            -> Bool
+        hasEntryForAsset asset assetsMap =
+            Set.member u $ MonoidMap.get asset $ assetsMap i
 
 -- | Checks that every indexed entry is required by some entry in the 'universe'
 --   map.


### PR DESCRIPTION
## Issue

ADP-3061

## Summary

This PR removes the use of `NonEmptySet` from `UTxOIndex`, and redefines it in terms of [`MonoidMap`](https://hackage.haskell.org/package/monoidmap/docs/Data-MonoidMap.html) and `Set`:
```patch
  data UTxOIndex u = UTxOIndex
      { indexAll
-         :: !(      Map Asset (NonEmptySet u))
+         :: !(MonoidMap Asset         (Set u))
      , indexSingletons
-         :: !(      Map Asset (NonEmptySet u))
+         :: !(MonoidMap Asset         (Set u))
      , indexPairs
-         :: !(      Map Asset (NonEmptySet u))
+         :: !(MonoidMap Asset         (Set u))
```

This enables us to simplify several functions. For example:
```patch
- insertEntry m a =
-     Map.alter (maybe (Just createNew) (Just . updateOld)) a m
-   where
-     createNew = NonEmptySet.singleton u
-     updateOld = NonEmptySet.insert u
+ insertEntry m a = MonoidMap.adjust (Set.insert u) a m
```

It also allows us to remove one of our dependencies on the `strict-non-empty-containers` library. (We eventually remove this in https://github.com/input-output-hk/cardano-wallet/pull/3984.)

## Performance

A very slight performance improvement was observed over 10 consecutive runs of the `utxo-index` benchmark compiled with GHC `8.10.7` and an optimisation level of `-O1`:
| Benchmark<br/>`utxo-index`| Mean total run time<br/>over 10 runs (3SF) |
| :-- | :-- |
| `master` | `11.0` seconds |
| After applying this PR | `10.7` seconds |

## Sample benchmark runs

### Before applying this PR
```
Benchmark utxo-index: RUNNING...
All
  Constructing a UTxO index from a map with ada-only bundles
    with 1,000 entries:   OK (1.39s)
      1.07 ms ±  39 μs
    with 10,000 entries:  OK (0.59s)
      14.3 ms ± 1.2 ms
    with 100,000 entries: OK (0.70s)
      171  ms ± 7.9 ms
  Constructing a UTxO index from a map with (ada, NFT) bundles
    with 1,000 entries:   OK (0.80s)
      3.51 ms ± 277 μs
    with 10,000 entries:  OK (0.34s)
      51.5 ms ± 3.4 ms
    with 100,000 entries: OK (2.26s)
      682  ms ± 5.3 ms
  Constructing a UTxO index from a map with diverse bundles
    with 1,000 entries:   OK (0.61s)
      4.54 ms ± 391 μs
    with 10,000 entries:  OK (0.70s)
      71.0 ms ± 4.2 ms
    with 100,000 entries: OK (3.56s)
      1.116 s ±  42 ms
```

### After applying this PR
```
Benchmark utxo-index: RUNNING...
All
  Constructing a UTxO index from a map with ada-only bundles
    with 1,000 entries:   OK (1.02s)
      1.02 ms ±  86 μs
    with 10,000 entries:  OK (0.54s)
      12.9 ms ± 768 μs
    with 100,000 entries: OK (0.68s)
      167  ms ± 7.2 ms
  Constructing a UTxO index from a map with (ada, NFT) bundles
    with 1,000 entries:   OK (0.76s)
      3.44 ms ± 195 μs
    with 10,000 entries:  OK (0.33s)
      51.0 ms ± 3.7 ms
    with 100,000 entries: OK (2.24s)
      674  ms ± 9.7 ms
  Constructing a UTxO index from a map with diverse bundles
    with 1,000 entries:   OK (0.74s)
      4.41 ms ± 204 μs
    with 10,000 entries:  OK (0.40s)
      69.4 ms ± 5.7 ms
    with 100,000 entries: OK (3.33s)
      1.072 s ±  49 ms
```