### PR TITLE
Simplify `TokenMap`.

### DIFF
--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -148,6 +148,7 @@ test-suite test
     , QuickCheck
     , quickcheck-classes
     , quickcheck-instances
+    , quickcheck-monoid-subclasses
     , quickcheck-quid
     , should-not-typecheck
     , string-qq

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -97,8 +97,6 @@ import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Map.Strict
     ( Map )
-import Data.Map.Strict.NonEmptyMap
-    ( NonEmptyMap )
 import Data.Ord
     ( comparing )
 import Data.Set
@@ -221,7 +219,7 @@ fromNestedList
 fromNestedList c = TokenBundle c . TokenMap.fromNestedList
 
 fromNestedMap
-    :: (Coin, Map TokenPolicyId (NonEmptyMap TokenName TokenQuantity))
+    :: (Coin, Map TokenPolicyId (Map TokenName TokenQuantity))
     -> TokenBundle
 fromNestedMap (c, m) = TokenBundle c (TokenMap.fromNestedMap m)
 

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -113,7 +113,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Control.DeepSeq
     ( NFData )
 import Control.Monad
-    ( guard, when, (<=<) )
+    ( when, (<=<) )
 import Data.Aeson
     ( FromJSON (..), ToJSON (..), camelTo2, genericParseJSON, genericToJSON )
 import Data.Aeson.Types
@@ -122,8 +122,6 @@ import Data.Bifunctor
     ( first )
 import Data.Function
     ( on )
-import Data.Functor
-    ( ($>) )
 import Data.Hashable
     ( Hashable (..), hashUsing )
 import Data.List.NonEmpty
@@ -133,7 +131,7 @@ import Data.Map.Strict
 import Data.Maybe
     ( mapMaybe )
 import Data.Monoid.Cancellative
-    ( LeftReductive, Reductive, RightReductive )
+    ( LeftReductive, Reductive ((</>)), RightReductive )
 import Data.Monoid.GCD
     ( GCDMonoid, LeftGCDMonoid, RightGCDMonoid )
 import Data.Monoid.Monus
@@ -546,7 +544,7 @@ add = (<>)
 -- map when compared with the `leq` function.
 --
 subtract :: TokenMap -> TokenMap -> Maybe TokenMap
-subtract a b = guard (b `leq` a) $> unsafeSubtract a b
+subtract = (</>)
 
 -- | Analogous to @Set.difference@, return the difference between two token
 -- maps.

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -168,7 +168,6 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Map.Strict as Map
 import qualified Data.Monoid.Null as MonoidNull
 import qualified Data.MonoidMap as MonoidMap
 import qualified Data.Set as Set
@@ -670,20 +669,7 @@ removeQuantity m asset = setQuantity m asset TokenQuantity.zero
 -- | Get the largest quantity from this map.
 --
 maximumQuantity :: TokenMap -> TokenQuantity
-maximumQuantity
-    = Map.foldl' (\a -> Map.foldr findMaximum a . MonoidMap.toMap) zero
-    . MonoidMap.toMap
-    . unTokenMap
-  where
-    zero :: TokenQuantity
-    zero = TokenQuantity 0
-
-    findMaximum :: TokenQuantity -> TokenQuantity -> TokenQuantity
-    findMaximum challenger champion
-        | challenger > champion =
-            challenger
-        | otherwise =
-            champion
+maximumQuantity = F.foldl' (F.foldl' max) mempty . unTokenMap
 
 --------------------------------------------------------------------------------
 -- Partitioning

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -120,6 +120,8 @@ import Data.Aeson.Types
     ( Options (..), Parser )
 import Data.Bifunctor
     ( first )
+import Data.Function
+    ( on )
 import Data.Functor
     ( ($>) )
 import Data.Hashable
@@ -268,9 +270,7 @@ instance TypeError ('Text "Ord not supported for token maps")
 -- In the above example, map 'x' is strictly less than map 'y'.
 --
 instance PartialOrd TokenMap where
-    m1 `leq` m2 = F.all
-        (\a -> getQuantity m1 a <= getQuantity m2 a)
-        (getAssets m1 `Set.union` getAssets m2)
+    leq = MonoidMap.isSubmapOf `on` unTokenMap
 
 -- | Defines a lexicographic ordering.
 --

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -603,7 +603,7 @@ isEmpty = MonoidNull.null
 -- | Returns true if and only if the given map is not empty.
 --
 isNotEmpty :: TokenMap -> Bool
-isNotEmpty = (/= empty)
+isNotEmpty = not . MonoidNull.null
 
 --------------------------------------------------------------------------------
 -- Quantities

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -166,6 +166,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Monoid.GCD as GCDMonoid
 import qualified Data.Monoid.Null as MonoidNull
 import qualified Data.MonoidMap as MonoidMap
 import qualified Data.Set as Set
@@ -579,16 +580,7 @@ difference = (<\>)
 --          [          ("b", 2), ("c", 2)          ]
 --
 intersection :: TokenMap -> TokenMap -> TokenMap
-intersection m1 m2 =
-    fromFlatList (getMinimumQuantity <$> F.toList sharedAssets)
-  where
-    getMinimumQuantity :: AssetId -> (AssetId, TokenQuantity)
-    getMinimumQuantity a = (a, ) $ min
-        (getQuantity m1 a)
-        (getQuantity m2 a)
-
-    sharedAssets :: Set AssetId
-    sharedAssets = Set.intersection (getAssets m1) (getAssets m2)
+intersection = GCDMonoid.gcd
 
 --------------------------------------------------------------------------------
 -- Queries

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -539,10 +539,7 @@ filter f = fromFlatList . L.filter (f . fst) . toFlatList
 -- | Adds one token map to another.
 --
 add :: TokenMap -> TokenMap -> TokenMap
-add a b = F.foldl' acc a $ toFlatList b
-  where
-    acc c (asset, quantity) =
-        adjustQuantity c asset (`TokenQuantity.add` quantity)
+add = (<>)
 
 -- | Subtracts the second token map from the first.
 --

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -127,8 +127,6 @@ import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Map.Strict
     ( Map )
-import Data.Map.Strict.NonEmptyMap
-    ( NonEmptyMap )
 import Data.Maybe
     ( mapMaybe )
 import Data.MonoidMap
@@ -158,7 +156,6 @@ import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
-import qualified Data.Map.Strict.NonEmptyMap as NEMap
 import qualified Data.Monoid.Null as MonoidNull
 import qualified Data.MonoidMap as MonoidMap
 import qualified Data.Set as Set
@@ -490,10 +487,8 @@ fromNestedList entries = fromFlatList
 
 -- | Creates a token map from a nested map.
 --
-fromNestedMap
-    :: Map TokenPolicyId (NonEmptyMap TokenName TokenQuantity)
-    -> TokenMap
-fromNestedMap = fromNestedList . Map.toList . fmap NEMap.toList
+fromNestedMap :: Map TokenPolicyId (Map TokenName TokenQuantity) -> TokenMap
+fromNestedMap = TokenMap . MonoidMap.fromMap . fmap MonoidMap.fromMap
 
 --------------------------------------------------------------------------------
 -- Deconstruction
@@ -518,11 +513,8 @@ toNestedList (TokenMap m) =
 
 -- | Converts a token map to a nested map.
 --
-toNestedMap
-    :: TokenMap
-    -> Map TokenPolicyId (NonEmptyMap TokenName TokenQuantity)
-toNestedMap (TokenMap m) =
-    Map.mapMaybe NEMap.fromMap $ MonoidMap.toMap <$> MonoidMap.toMap m
+toNestedMap :: TokenMap -> Map TokenPolicyId (Map TokenName TokenQuantity)
+toNestedMap (TokenMap m) = MonoidMap.toMap <$> MonoidMap.toMap m
 
 --------------------------------------------------------------------------------
 -- Filtering

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -160,6 +160,8 @@ import Numeric.Natural
     ( Natural )
 import Quiet
     ( Quiet (..) )
+import Safe
+    ( fromJustNote )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
 import qualified Data.Aeson as Aeson
@@ -783,7 +785,4 @@ mapAssetIds f m = fromFlatList $ first f <$> toFlatList m
 -- Throws a run-time exception if the pre-condition is violated.
 --
 unsafeSubtract :: TokenMap -> TokenMap -> TokenMap
-unsafeSubtract a b = F.foldl' acc a $ toFlatList b
-  where
-    acc c (asset, quantity) =
-        adjustQuantity c asset (`TokenQuantity.unsafeSubtract` quantity)
+unsafeSubtract b1 b2 = fromJustNote "TokenMap.unsafeSubtract" $ b1 </> b2

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -187,16 +188,11 @@ newtype TokenMap = TokenMap
     }
     deriving stock (Eq, Generic)
     deriving (Read, Show) via (Quiet TokenMap)
+    deriving newtype (Semigroup, Monoid)
 
 instance NFData TokenMap
 instance Hashable TokenMap where
     hashWithSalt = hashUsing toNestedList
-
-instance Semigroup TokenMap where
-    (<>) = add
-
-instance Monoid TokenMap where
-    mempty = empty
 
 -- | A combination of a token policy identifier and a token name that can be
 --   used as a compound identifier.

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -657,8 +657,8 @@ adjustQuantity
     -> AssetId
     -> (TokenQuantity -> TokenQuantity)
     -> TokenMap
-adjustQuantity m asset adjust =
-    setQuantity m asset $ adjust $ getQuantity m asset
+adjustQuantity (TokenMap m) (AssetId policy token) f =
+    TokenMap $ MonoidMap.adjust (MonoidMap.adjust f token) policy m
 
 -- | Removes the quantity associated with the given asset.
 --

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -135,7 +135,7 @@ import Data.Monoid.Cancellative
 import Data.Monoid.GCD
     ( GCDMonoid, LeftGCDMonoid, RightGCDMonoid )
 import Data.Monoid.Monus
-    ( Monus, OverlappingGCDMonoid )
+    ( Monus ((<\>)), OverlappingGCDMonoid )
 import Data.Monoid.Null
     ( MonoidNull )
 import Data.MonoidMap
@@ -563,11 +563,9 @@ subtract = (</>)
 -- >>> let oneToken = singleton aid (TokenQuantity 1)
 -- >>> (mempty `difference` oneToken) `add` oneToken
 -- oneToken
+--
 difference :: TokenMap -> TokenMap -> TokenMap
-difference m1 m2 = L.foldl' reduce m1 (toFlatList m2)
-  where
-    reduce :: TokenMap -> (AssetId, TokenQuantity) -> TokenMap
-    reduce m (a, q) = adjustQuantity m a (`TokenQuantity.difference` q)
+difference = (<\>)
 
 -- | Computes the intersection of two token maps.
 --

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -130,12 +130,22 @@ import Data.Map.Strict
     ( Map )
 import Data.Maybe
     ( mapMaybe )
+import Data.Monoid.Cancellative
+    ( LeftReductive, Reductive, RightReductive )
+import Data.Monoid.GCD
+    ( GCDMonoid, LeftGCDMonoid, RightGCDMonoid )
+import Data.Monoid.Monus
+    ( Monus, OverlappingGCDMonoid )
+import Data.Monoid.Null
+    ( MonoidNull )
 import Data.MonoidMap
     ( MonoidMap )
 import Data.Ord
     ( comparing )
 import Data.Ratio
     ( (%) )
+import Data.Semigroup.Commutative
+    ( Commutative )
 import Data.Set
     ( Set )
 import Data.Text.Class
@@ -188,7 +198,10 @@ newtype TokenMap = TokenMap
     }
     deriving stock (Eq, Generic)
     deriving (Read, Show) via (Quiet TokenMap)
-    deriving newtype (Semigroup, Monoid)
+    deriving newtype (Commutative, Semigroup, Monoid, MonoidNull)
+    deriving newtype (LeftReductive, RightReductive, Reductive)
+    deriving newtype (LeftGCDMonoid, RightGCDMonoid, GCDMonoid)
+    deriving newtype (OverlappingGCDMonoid, Monus)
 
 instance NFData TokenMap
 instance Hashable TokenMap where

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -21,22 +21,6 @@
 module Cardano.Wallet.Primitive.Types.TokenMap
     (
     -- * Types
-
-      -- Important:
-      --
-      -- The default data constructor for 'TokenMap' is not exported, by design,
-      -- as the internal data structure has an invariant that must be preserved
-      -- across all operations.
-      --
-      -- Exporting the default constructor would make it possible for functions
-      -- outside the 'TokenMap' module to break the invariant, opening the door
-      -- to subtle regressions.
-      --
-      -- See the definition of 'TokenMap' for more details of the invariant.
-      --
-      -- To construct a 'TokenMap', use one of the provided constructors, all
-      -- of which are tested to check that they respect the invariant.
-      --
       TokenMap
     , AssetId (..)
 

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -598,7 +598,7 @@ size = Set.size . getAssets
 -- | Returns true if and only if the given map is empty.
 --
 isEmpty :: TokenMap -> Bool
-isEmpty = (== empty)
+isEmpty = MonoidNull.null
 
 -- | Returns true if and only if the given map is not empty.
 --

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -180,35 +180,6 @@ spec =
             , ordLaws
             ]
 
-    describe
-        "All operations preserve the invariant: \
-        \all token quantities held within a map are non-zero" $ do
-
-        it "prop_arbitrary_invariant" $
-            property prop_arbitrary_invariant
-        it "prop_shrink_invariant" $
-            property prop_shrink_invariant
-        it "prop_empty_invariant" $
-            property prop_empty_invariant
-        it "prop_singleton_invariant" $
-            property prop_singleton_invariant
-        it "prop_fromFlatList_invariant" $
-            property prop_fromFlatList_invariant
-        it "prop_fromNestedList_invariant" $
-            property prop_fromNestedList_invariant
-        it "prop_add_invariant" $
-            property prop_add_invariant
-        it "prop_subtract_invariant" $
-            property prop_subtract_invariant
-        it "prop_difference_invariant" $
-            property prop_difference_invariant
-        it "prop_intersection_invariant" $
-            property prop_intersection_invariant
-        it "prop_setQuantity_invariant" $
-            property prop_setQuantity_invariant
-        it "prop_adjustQuantity_invariant" $
-            property prop_adjustQuantity_invariant
-
     describe "Construction and deconstruction" $ do
 
         it "prop_fromFlatList" $
@@ -364,69 +335,6 @@ spec =
             property testPrettyFlat
         it "Nested style" $
             property testPrettyNested
-
---------------------------------------------------------------------------------
--- Invariant properties
---------------------------------------------------------------------------------
-
--- Tests that all quantities within the given map are non-zero.
---
-invariantHolds :: TokenMap -> Bool
-invariantHolds b =
-    all TokenQuantity.isNonZero $ getQuantity <$> TokenMap.toFlatList b
-  where
-    getQuantity (_, q) = q
-
-prop_arbitrary_invariant :: TokenMap -> Property
-prop_arbitrary_invariant = property . invariantHolds
-
-prop_shrink_invariant :: TokenMap -> Property
-prop_shrink_invariant b = property $ all invariantHolds $ shrink b
-
-prop_empty_invariant :: Property
-prop_empty_invariant = property $ invariantHolds TokenMap.empty
-
-prop_singleton_invariant :: (AssetId, TokenQuantity) -> Property
-prop_singleton_invariant (asset, quantity) = property $
-    invariantHolds $ TokenMap.singleton asset quantity
-
-prop_fromFlatList_invariant :: [(AssetId, TokenQuantity)] -> Property
-prop_fromFlatList_invariant entries =
-    property $ invariantHolds $ TokenMap.fromFlatList entries
-
-prop_fromNestedList_invariant
-    :: [(TokenPolicyId, NonEmpty (TokenName, TokenQuantity))] -> Property
-prop_fromNestedList_invariant entries =
-    property $ invariantHolds $ TokenMap.fromNestedList entries
-
-prop_add_invariant :: TokenMap -> TokenMap -> Property
-prop_add_invariant b1 b2 = property $ invariantHolds $ TokenMap.add b1 b2
-
-prop_subtract_invariant :: TokenMap -> TokenMap -> Property
-prop_subtract_invariant m1 m2 = property $
-    m2 `leq` m1 ==> invariantHolds result
-  where
-    result =
-        case TokenMap.subtract m1 m2 of
-            Nothing -> error "prop_subtract_invariant"
-            Just r -> r
-
-prop_difference_invariant :: TokenMap -> TokenMap -> Property
-prop_difference_invariant m1 m2 =
-    property $ invariantHolds $ TokenMap.difference m1 m2
-
-prop_intersection_invariant :: TokenMap -> TokenMap -> Property
-prop_intersection_invariant m1 m2 =
-    property $ invariantHolds $ TokenMap.intersection m1 m2
-
-prop_setQuantity_invariant
-    :: TokenMap -> AssetId -> TokenQuantity -> Property
-prop_setQuantity_invariant b asset quantity = property $
-    invariantHolds $ TokenMap.setQuantity b asset quantity
-
-prop_adjustQuantity_invariant :: TokenMap -> AssetId -> Property
-prop_adjustQuantity_invariant b asset = property $
-    invariantHolds $ TokenMap.adjustQuantity b asset TokenQuantity.predZero
 
 --------------------------------------------------------------------------------
 -- Construction and deconstruction properties

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -284,6 +284,8 @@ spec =
             property prop_adjustQuantity_hasQuantity
         it "prop_maximumQuantity_all" $
             property prop_maximumQuantity_all
+        it "prop_maximumQuantity_mempty" $
+            property prop_maximumQuantity_mempty
 
     describe "Queries" $ do
 
@@ -727,6 +729,9 @@ prop_maximumQuantity_all b =
     property $ all (<= maxQ) (snd <$> TokenMap.toFlatList b)
   where
     maxQ = TokenMap.maximumQuantity b
+
+prop_maximumQuantity_mempty :: Property
+prop_maximumQuantity_mempty = TokenMap.maximumQuantity mempty === mempty
 
 --------------------------------------------------------------------------------
 -- Queries

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -120,6 +120,18 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Classes
     ( eqLaws, monoidLaws, ordLaws, semigroupLaws, semigroupMonoidLaws )
+import Test.QuickCheck.Classes.Monoid.GCD
+    ( gcdMonoidLaws
+    , leftGCDMonoidLaws
+    , overlappingGCDMonoidLaws
+    , rightGCDMonoidLaws
+    )
+import Test.QuickCheck.Classes.Monoid.Monus
+    ( monusLaws )
+import Test.QuickCheck.Classes.Monoid.Null
+    ( monoidNullLaws )
+import Test.QuickCheck.Classes.Semigroup.Cancellative
+    ( commutativeLaws, leftReductiveLaws, reductiveLaws, rightReductiveLaws )
 import Test.QuickCheck.Instances.ByteString
     ()
 import Test.Utils.Laws
@@ -147,9 +159,19 @@ spec =
 
     describe "Class instances obey laws" $ do
         testLawsMany @TokenMap
-            [ eqLaws
+            [ commutativeLaws
+            , eqLaws
+            , gcdMonoidLaws
+            , leftGCDMonoidLaws
+            , leftReductiveLaws
             , monoidLaws
+            , monoidNullLaws
+            , monusLaws
+            , overlappingGCDMonoidLaws
             , partialOrdLaws
+            , reductiveLaws
+            , rightGCDMonoidLaws
+            , rightReductiveLaws
             , semigroupLaws
             , semigroupMonoidLaws
             ]

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Mint.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Mint.hs
@@ -91,7 +91,6 @@ import qualified Cardano.Ledger.Mary.Value as SL
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.Map.Strict as Map
-import qualified Data.Map.Strict.NonEmptyMap as NonEmptyMap
 
 mint :: EraFun
     (Mint :*: Witnesses :*: ReferenceInputs)
@@ -189,14 +188,12 @@ fromLedgerMintValue (MultiAsset ledgerTokens) = (assetsToMint, assetsToBurn)
         & Map.map (Map.filter (> 0))
         & Map.mapKeys toWalletTokenPolicyId
         & Map.map mapInner
-        & Map.mapMaybe NonEmptyMap.fromMap
         & TokenMap.fromNestedMap
 
     assetsToBurn = ledgerTokens
         & Map.map (Map.mapMaybe (\n -> if n > 0 then Nothing else Just (-n)))
         & Map.mapKeys toWalletTokenPolicyId
         & Map.map mapInner
-        & Map.mapMaybe NonEmptyMap.fromMap
         & TokenMap.fromNestedMap
 
     mapInner inner = inner

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility/Ledger.hs
@@ -114,7 +114,6 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.Map.Strict as Map
-import qualified Data.Map.Strict.NonEmptyMap as NonEmptyMap
 import qualified Ouroboros.Network.Block as O
 
 --------------------------------------------------------------------------------
@@ -177,7 +176,6 @@ toLedgerTokenBundle bundle =
         & Map.map mapInner
         & Ledger.MultiAsset
     mapInner inner = inner
-        & NonEmptyMap.toMap
         & Map.mapKeys toLedgerTokenName
         & Map.map toLedgerTokenQuantity
 
@@ -190,7 +188,6 @@ toWalletTokenBundle
     walletTokens = ledgerTokens
         & Map.mapKeys toWalletTokenPolicyId
         & Map.map mapInner
-        & Map.mapMaybe NonEmptyMap.fromMap
     mapInner inner = inner
         & Map.mapKeys toWalletTokenName
         & Map.map toWalletTokenQuantity

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -242,6 +242,7 @@ import UnliftIO.Exception
 
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet.Address.Pool as AddressPool
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Control.Foldl as Foldl
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString.Char8 as B8
@@ -782,7 +783,7 @@ instance ToExpr TokenBundle where
     toExpr = genericToExpr
 
 instance ToExpr TokenMap where
-    toExpr = genericToExpr
+    toExpr = genericToExpr . TokenMap.toNestedList
 
 instance ToExpr TokenName where
     toExpr = genericToExpr


### PR DESCRIPTION
## Issue

ADP-3061

## Summary

This PR removes the use of `NonEmptyMap` from `TokenMap`, and redefines it in terms of [`MonoidMap`](https://hackage.haskell.org/package/monoidmap/docs/Data-MonoidMap.html):
```patch
- newtype TokenMap = TokenMap (      Map TokenPolicyId (NonEmptyMap TokenName TokenQuantity))
+ newtype TokenMap = TokenMap (MonoidMap TokenPolicyId (  MonoidMap TokenName TokenQuantity))
```

This enables us to simplify several functions. For example:
```patch
  setQuantity :: TokenMap -> AssetId -> TokenQuantity -> TokenMap
- setQuantity originalMap@(TokenMap m) (AssetId policy token) quantity =
-     case getPolicyMap originalMap policy of
-         Nothing | TokenQuantity.isZero quantity ->
-             originalMap
-         Nothing ->
-             createPolicyMap
-         Just policyMap | TokenQuantity.isZero quantity ->
-             removeQuantityFromPolicyMap policyMap
-         Just policyMap ->
-             updateQuantityInPolicyMap policyMap
-   where
-     createPolicyMap = TokenMap
-         $ flip (Map.insert policy) m
-         $ NEMap.singleton token quantity
-
-     removeQuantityFromPolicyMap policyMap =
-         case NEMap.delete token policyMap of
-             Nothing ->
-                 TokenMap $ Map.delete policy m
-             Just newPolicyMap ->
-                 TokenMap $ Map.insert policy newPolicyMap m
-
-     updateQuantityInPolicyMap policyMap = TokenMap
-         $ flip (Map.insert policy) m
-         $ NEMap.insert token quantity policyMap
+ setQuantity (TokenMap m) (AssetId policy token) quantity =
+     TokenMap $ MonoidMap.adjust (MonoidMap.set token quantity) policy m
```

It also allows us to remove one of our dependencies on the `strict-non-empty-containers` library. (We eventually remove this in https://github.com/input-output-hk/cardano-wallet/pull/3984.)

## Performance

A slight performance improvement was observed over 10 consecutive runs of the `utxo-index` benchmark compiled with GHC `8.10.7` and an optimisation level of `-O1`:
| Benchmark<br/>`utxo-index`| Mean total run time<br/>over 10 runs (3SF) |
| :-- | :-- |
| `master` | `11.0` seconds |
| After applying #3980  | `10.7` seconds |
| After applying #3980 + this PR | `10.4` seconds |
