### PR TITLE
Simplify `TokenBundle`.

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -129,10 +129,11 @@ data TokenBundle = TokenBundle
     deriving anyclass (NFData, Hashable)
 
 instance Semigroup TokenBundle where
-    (<>) = add
+    TokenBundle c1 m1 <> TokenBundle c2 m2 =
+        TokenBundle (c1 <> c2) (m1 <> m2)
 
 instance Monoid TokenBundle where
-    mempty = empty
+    mempty = TokenBundle mempty mempty
 
 --------------------------------------------------------------------------------
 -- Ordering

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -242,7 +242,7 @@ buildMap = blockMapF . fmap (first $ id @String)
 -- | The empty token bundle.
 --
 empty :: TokenBundle
-empty = TokenBundle (Coin 0) mempty
+empty = mempty
 
 -- | Creates a token bundle from a coin and a flat list of token quantities.
 --

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -85,12 +85,8 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Control.DeepSeq
     ( NFData )
-import Control.Monad
-    ( guard )
 import Data.Bifunctor
     ( first )
-import Data.Functor
-    ( ($>) )
 import Data.Hashable
     ( Hashable )
 import Data.List.NonEmpty
@@ -335,7 +331,7 @@ add = (<>)
 -- bundle when compared with the `leq` function.
 --
 subtract :: TokenBundle -> TokenBundle -> Maybe TokenBundle
-subtract a b = guard (b `leq` a) $> unsafeSubtract a b
+subtract = (</>)
 
 -- | Analogous to @Set.difference@, return the difference between two token
 -- maps.

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -327,8 +327,7 @@ setCoin b c = b { coin = c }
 -- | Adds one token bundle to another.
 --
 add :: TokenBundle -> TokenBundle -> TokenBundle
-add (TokenBundle (Coin c1) m1) (TokenBundle (Coin c2) m2) =
-    TokenBundle (Coin $ c1 + c2) (TokenMap.add m1 m2)
+add = (<>)
 
 -- | Subtracts the second token bundle from the first.
 --

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -352,10 +352,7 @@ subtract = (</>)
 -- oneToken
 --
 difference :: TokenBundle -> TokenBundle -> TokenBundle
-difference (TokenBundle c1 m1) (TokenBundle c2 m2) =
-    TokenBundle
-        (Coin.difference c1 c2)
-        (TokenMap.difference m1 m2)
+difference = (<\>)
 
 --------------------------------------------------------------------------------
 -- Quantities

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -118,6 +118,8 @@ import GHC.Generics
     ( Generic )
 import GHC.TypeLits
     ( ErrorMessage (..), TypeError )
+import Safe
+    ( fromJustNote )
 
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
@@ -454,5 +456,4 @@ mapAssetIds f (TokenBundle c m) = TokenBundle c (TokenMap.mapAssetIds f m)
 -- Throws a run-time exception if the pre-condition is violated.
 --
 unsafeSubtract :: TokenBundle -> TokenBundle -> TokenBundle
-unsafeSubtract (TokenBundle (Coin c1) m1) (TokenBundle (Coin c2) m2) =
-    TokenBundle (Coin $ c1 - c2) (TokenMap.unsafeSubtract m1 m2)
+unsafeSubtract b1 b2 = fromJustNote "TokenBundle.unsafeSubtract" $ b1 </> b2

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
@@ -48,6 +48,18 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Classes
     ( eqLaws, monoidLaws, ordLaws, semigroupLaws, semigroupMonoidLaws )
+import Test.QuickCheck.Classes.Monoid.GCD
+    ( gcdMonoidLaws
+    , leftGCDMonoidLaws
+    , overlappingGCDMonoidLaws
+    , rightGCDMonoidLaws
+    )
+import Test.QuickCheck.Classes.Monoid.Monus
+    ( monusLaws )
+import Test.QuickCheck.Classes.Monoid.Null
+    ( monoidNullLaws )
+import Test.QuickCheck.Classes.Semigroup.Cancellative
+    ( commutativeLaws, leftReductiveLaws, reductiveLaws, rightReductiveLaws )
 import Test.Utils.Laws
     ( testLawsMany )
 import Test.Utils.Laws.PartialOrd
@@ -66,9 +78,19 @@ spec =
 
     describe "Class instances obey laws" $ do
         testLawsMany @TokenBundle
-            [ eqLaws
+            [ commutativeLaws
+            , eqLaws
+            , gcdMonoidLaws
+            , leftGCDMonoidLaws
+            , leftReductiveLaws
             , monoidLaws
+            , monoidNullLaws
+            , monusLaws
+            , overlappingGCDMonoidLaws
             , partialOrdLaws
+            , reductiveLaws
+            , rightGCDMonoidLaws
+            , rightReductiveLaws
             , semigroupLaws
             , semigroupMonoidLaws
             ]


### PR DESCRIPTION
## Issue

[ADP-3061](https://cardanofoundation.atlassian.net/browse/ADP-3061)

## Summary

This PR:
- defines instances of several subclasses of `Semigroup` and `Monoid` for `TokenBundle`.
- tests the lawfulness of these instances with `quickcheck-monoid-subclasses`. (See [here](https://github.com/input-output-hk/cardano-wallet/blob/e529b733972b5d1ce7c98fd974a2c501f132b021/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs#L80-L96).)
- redefines all arithmetic operations of `TokenBundle` in terms of these instances.

## Future work

The test suite for `TokenBundle` contains several property tests for various arithmetic operations provided by `TokenBundle`, such as `add`, `subtract`, and `intersection`. (See [here](https://github.com/input-output-hk/cardano-wallet/blob/4711f93163006e07aada927da0b3061add403554/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs#L80-L94).)

Many of these tests are now redundant, and can be removed in a future PR.