### PR TITLE
Simplify `TokenQuantity`.

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
@@ -28,9 +28,6 @@ module Cardano.Wallet.Primitive.Types.TokenQuantity
     , isNonZero
     , isZero
 
-      -- * Unsafe operations
-    , unsafeSubtract
-
     ) where
 
 import Prelude hiding
@@ -236,16 +233,3 @@ isNonZero = (/= zero)
 
 isZero :: TokenQuantity -> Bool
 isZero = (== zero)
-
---------------------------------------------------------------------------------
--- Unsafe operations
---------------------------------------------------------------------------------
-
--- | Subtracts the second token quantity from the first.
---
--- Pre-condition: the first quantity is not less than the second quantity.
---
--- Throws a run-time exception if the pre-condition is violated.
---
-unsafeSubtract :: TokenQuantity -> TokenQuantity -> TokenQuantity
-unsafeSubtract (TokenQuantity x) (TokenQuantity y) = TokenQuantity $ x - y


### PR DESCRIPTION
## Issue

[ADP-3061](https://cardanofoundation.atlassian.net/browse/ADP-3061)

## Summary

This PR removes the `unsafeSubtract` function from `TokenQuantity`. (This function is made redundant by previous PRs.)