### PR TITLE
Use `QuickCheck` implementation of `shrinkBoundedEnum`.

### DIFF
--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -33,7 +33,6 @@ module Test.QuickCheck.Extra
 
       -- * Shrinking
     , liftShrinker
-    , shrinkBoundedEnum
     , shrinkInterleaved
     , shrinkMapWith
     , groundRobinShrink
@@ -220,36 +219,6 @@ genSized2With f genA genB = uncurry f <$> genSized2 genA genB
 --
 interleaveRoundRobin :: [[a]] -> [a]
 interleaveRoundRobin = concat . L.transpose
-
--- | Shrinks a 'Bounded' 'Enum' value.
---
--- Example:
---
--- @
--- data MyEnum = A0 | A1 | A2 | A3 | A4 | A5 | A6 | A7
---    deriving (Bounded, Enum, Eq, Ord, Show)
--- @
---
--- >>> shrinkBoundedEnum A7
--- [A0,A4,A6]
---
--- >>> shrinkBoundedEnum A4
--- [A0,A2,A3]
---
--- >>> shrinkBoundedEnum A0
--- []
---
--- See 'arbitraryBoundedEnum'.
---
-shrinkBoundedEnum :: forall a. (Eq a, Enum a, Bounded a) => a -> [a]
-shrinkBoundedEnum a
-    | a == minBound =
-        []
-    | otherwise =
-        toEnum <$> filter (>= minBoundInt) (shrinkIntegral $ fromEnum a)
-  where
-    minBoundInt :: Int
-    minBoundInt = fromEnum (minBound @a)
 
 -- | Shrink the given pair in interleaved fashion.
 --

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -164,7 +164,7 @@ library
     , plutus-ledger-api
     , pretty-simple
     , profunctors
-    , QuickCheck
+    , QuickCheck ^>= 2.14.3
     , quickcheck-instances
     , quiet
     , random

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -488,6 +488,7 @@ import Test.QuickCheck
     , oneof
     , property
     , scale
+    , shrinkBoundedEnum
     , shrinkIntegral
     , shrinkMapBy
     , sized
@@ -499,7 +500,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Arbitrary.Generic
     ( genericArbitrary, genericShrink )
 import Test.QuickCheck.Extra
-    ( reasonablySized, shrinkBoundedEnum )
+    ( reasonablySized )
 import Test.QuickCheck.Gen
     ( sublistOf )
 import Test.QuickCheck.Instances

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -441,6 +441,7 @@ import Test.QuickCheck
     , oneof
     , property
     , scale
+    , shrinkBoundedEnum
     , shrinkList
     , shrinkMapBy
     , suchThat
@@ -457,7 +458,6 @@ import Test.QuickCheck.Extra
     ( chooseNatural
     , genNonEmpty
     , report
-    , shrinkBoundedEnum
     , shrinkNatural
     , shrinkNonEmpty
     , (.>=.)

--- a/lib/wallet/test/unit/Cardano/Wallet/Write/TxSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Write/TxSpec.hs
@@ -47,12 +47,11 @@ import Test.QuickCheck
     , conjoin
     , counterexample
     , property
+    , shrinkBoundedEnum
     , (===)
     )
 import Test.QuickCheck.Classes
     ( boundedEnumLaws, eqLaws, showLaws )
-import Test.QuickCheck.Extra
-    ( shrinkBoundedEnum )
 import Test.Utils.Laws
     ( testLawsMany )
 


### PR DESCRIPTION
## Summary

This PR removes our implementation of [`shrinkBoundedEnum`](https://github.com/input-output-hk/cardano-wallet/blob/master/lib/test-utils/src/Test/QuickCheck/Extra.hs#L224) and replaces it with an upstreamed version of the same function. (We upstreamed our implementation in [this PR](https://github.com/nick8325/quickcheck/pull/350).)

Therefore, we can remove our implementation and just use the version provided by `QuickCheck`.

## Note

This PR cannot be merged until the [hackage index state](https://github.com/input-output-hk/cardano-wallet/blob/cd5a76376090f99a0fd169c1bc09744dbcf30e27/cabal.project#L56) is updated.

## Future work

We have many `Arbitrary` instances defined like this:
```hs
instance Arbitrary SomeEnum where
    arbitrary = arbitraryBoundedEnum
    shrink _ = []
```

Perhaps we can make another PR that changes these to use `shrinkBoundedEnum` (where appropriate):
```hs
instance Arbitrary SomeEnum where
    arbitrary = arbitraryBoundedEnum
    shrink = shrinkBoundedEnum
```