### PR TITLE
[ADP-3063] Remove `ConnectionPool`

### DIFF
--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -58,7 +58,7 @@ import Cardano.BM.Data.Tracer
 import Cardano.BM.Setup
     ( setupTrace_, shutdown )
 import Cardano.DB.Sqlite
-    ( ConnectionPool, SqliteContext (..) )
+    ( SqliteContext (..) )
 import Cardano.Mnemonic
     ( EntropySize, SomeMnemonic (..), entropyToMnemonic, genEntropy )
 import Cardano.Startup
@@ -788,9 +788,6 @@ instance NFData (DBLayer m s) where
     rnf _ = ()
 
 instance NFData SqliteContext where
-    rnf _ = ()
-
-instance NFData ConnectionPool where
     rnf _ = ()
 
 testCp :: WalletBench

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -169,7 +169,6 @@ library
     , quiet
     , random
     , random-shuffle
-    , resource-pool
     , retry
     , safe
     , safe-money

--- a/lib/wallet/test/unit/Cardano/Pool/DB/SqliteSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Pool/DB/SqliteSpec.hs
@@ -70,12 +70,12 @@ test_migrationFromv20191216 =
             let databaseResetMsg = filter (== MsgGeneric MsgDatabaseReset) logs
             let migrationErrMsg  = filter isMsgMigrationError logs
 
-            length databaseConnMsg  `shouldBe` 6
+            length databaseConnMsg  `shouldBe` 8
             length databaseResetMsg `shouldBe` 1
             length migrationErrMsg  `shouldBe` 1
 
 isMsgOpenDB :: PoolDbLog -> Bool
-isMsgOpenDB (MsgGeneric (MsgStartConnectionPool _)) = True
+isMsgOpenDB (MsgGeneric (MsgOpenSingleConnection _)) = True
 isMsgOpenDB _ = False
 
 isMsgMigrationError :: PoolDbLog -> Bool


### PR DESCRIPTION
### Overview

This task is about removing the `ConnectionPool` type and `withConnectionPool` function.

Historically, the `ConnectionPool` was an attempt to enable concurrent reading from a database file. However, the present state of the code is that only a single connection is ever used per database file.

### Comments

* This fixes an issue where `runQuery` would close and open the database connection all the time — instead of working with a `pool :: ConnectionPool`, this function would work with a `fp :: FilePath`.

### Issue number

ADP-3063
