### PR TITLE
[ADP-3031] Simplify checkpoint pruning, take 3

### DIFF
--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1197,7 +1197,10 @@ restoreBlocks ctx tr blocks nodeTip = db & \DBLayer{..} -> atomically $ do
                 getSlot
                 (fromIntegral . getBlockHeight)
                 (sparseArithmetic epochStability')
-                (fromIntegral $ getQuantity $ nodeTip ^. #blockHeight)
+                (fromIntegral $ getQuantity $ localTip ^. #blockHeight)
+                    -- nodeTip instead of localTip should work as well,
+                    -- but for some reason, the integration tests
+                    -- become flakier.
                 wcps
                 (checkpoints wallet)
 

--- a/lib/wallet/src/Cardano/Wallet/Checkpoints.hs
+++ b/lib/wallet/src/Cardano/Wallet/Checkpoints.hs
@@ -182,11 +182,11 @@ extendAndPrune
         -- ^ Current checkpoints.
     -> DeltasCheckpoints a
 extendAndPrune getSlot getHeight policy nodeTip xs (Checkpoints cps) =
-    prunes ++ additions
+    additions <> pruneOld
   where
     additions = reverse -- latest slot needs to be applied last
         [ PutCheckpoint (getSlot x) x | x <- new ]
-    prunes = [ RestrictTo $ map getSlot (old ++ new) ]
+    pruneOld = [ RestrictTo $ map getSlot old ]
 
     new = filter willKeep (NE.toList xs)
     old = filter willKeep (Map.elems cps)

--- a/lib/wallet/test/unit/Cardano/Wallet/Checkpoints/PolicySpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Checkpoints/PolicySpec.hs
@@ -6,7 +6,12 @@ module Cardano.Wallet.Checkpoints.PolicySpec
 import Prelude
 
 import Cardano.Wallet.Checkpoints.Policy
-    ( BlockHeight, CheckpointPolicy, nextCheckpoint, toListAtTip )
+    ( BlockHeight
+    , CheckpointPolicy
+    , keepWhereTip
+    , nextCheckpoint
+    , toListAtTip
+    )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
@@ -59,6 +64,10 @@ spec = do
 
         it "trailingArithmetic checkpoints are located at grid points" $
             property prop_trailingGrid
+
+        it "sparseArithmetic has genesis" $
+            property $ \(GenHeightContext epochStability tip) ->
+                keepWhereTip (CP.sparseArithmetic epochStability) tip 0
 
         it "sparseArithmetic checkpoints after genesis are close to tip" $
             property $ \(GenHeightContext epochStability tip) ->

--- a/lib/wallet/test/unit/Cardano/Wallet/CheckpointsSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/CheckpointsSpec.hs
@@ -10,14 +10,11 @@ import Prelude
 import Cardano.Wallet.Checkpoints
     ( Checkpoints
     , DeltaCheckpoints (..)
-    , SparseCheckpointsConfig (..)
     , checkpoints
     , extendAndPrune
     , fromGenesis
-    , gapSize
     , getLatest
     , loadCheckpoints
-    , sparseCheckpoints
     )
 import Cardano.Wallet.Checkpoints.Policy
     ( sparseArithmetic )
@@ -27,275 +24,30 @@ import Cardano.Wallet.Primitive.Types
     ( Slot, SlotNo (..), WithOrigin (..) )
 import Data.Delta
     ( Delta (..) )
-import Data.Function
-    ( (&) )
-import Data.Quantity
-    ( Quantity (..) )
-import Data.Word
-    ( Word32 )
 import Test.Hspec
-    ( Spec, describe, it, shouldBe )
+    ( Spec, describe, it )
 import Test.QuickCheck
     ( Arbitrary (..)
-    , Gen
     , Property
     , choose
-    , conjoin
-    , counterexample
     , forAll
     , frequency
     , getPositive
     , listOf
     , property
-    , (.&&.)
     , (===)
-    , (==>)
     )
 
-import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 
 spec :: Spec
 spec = do
-    describe "sparseCheckpoints" $ do
-        it "k=2160, h=42" $ \_ -> do
-            let cfg = SparseCheckpointsConfig
-                    { edgeSize = 10
-                    , epochStability = 2160
-                    }
-            let h = Quantity 42
-
-            -- First unstable block: 0
-            sparseCheckpoints cfg h `shouldBe`
-                [ 0
-                , 32,33,34,35,36,37,38,39,40,41 -- Short-term checkpoints
-                , 42 -- Tip
-                ]
-
-        it "k=2160, h=2414" $ \_ -> do
-            let cfg = SparseCheckpointsConfig
-                    { edgeSize = 10
-                    , epochStability = 2160
-                    }
-            let h = Quantity 2714
-            -- First unstable block: 554
-            sparseCheckpoints cfg h `shouldBe`
-                [ 0
-                , 720, 1440, 2160               -- Long-term checkpoints
-
-                , 2704, 2705, 2706, 2707, 2708  -- Short-term checkpoints
-                , 2709, 2710, 2711, 2712, 2713  -- edgeSize = 10
-
-                , 2714  -- Tip
-                ]
-
-        it "k=2160, h=2414" $ \_ -> do
-            let cfg = SparseCheckpointsConfig
-                    { edgeSize = 0
-                    , epochStability = 2160
-                    }
-            let h = Quantity 2714
-            -- First unstable block: 554
-            sparseCheckpoints cfg h `shouldBe`
-                [ 0
-                , 720, 1440, 2160               -- Long-term checkpoints
-                , 2714  -- Tip
-                ]
-
-        it "The tip is always a checkpoint" $ \_ ->
-            property prop_sparseCheckpointTipAlwaysThere
-
-        it "There's at least (min h edgeSize) checkpoints" $ \_ ->
-            property prop_sparseCheckpointMinimum
-
-        it "∀ cfg. sparseCheckpoints (cfg { edgeSize = 0 }) ⊆ sparseCheckpoints cfg" $ \_ ->
-            property prop_sparseCheckpointEdgeSize0
-
-        it "Checkpoints are eventually stored in a sparse manner" $ \_ ->
-            property prop_checkpointsEventuallyEqual
-
     describe "extendAndPrune" $ do
         it "actually prunes checkpoints" $
             property prop_doesPrune
         it "keeps the tip of the chain" $
             property prop_keepTip
-
-{-------------------------------------------------------------------------------
-    Checkpoint hygiene
--------------------------------------------------------------------------------}
--- | No matter what, the current tip is always a checkpoint.
-prop_sparseCheckpointTipAlwaysThere
-    :: GenSparseCheckpointsArgs
-    -> Property
-prop_sparseCheckpointTipAlwaysThere (GenSparseCheckpointsArgs cfg h) = prop
-    & counterexample ("Checkpoints: " <> show cps)
-    & counterexample ("h=" <> show h)
-  where
-    cps = sparseCheckpoints cfg (Quantity h)
-
-    prop :: Property
-    prop = property $ fromIntegral h `elem` cps
-
--- | Check that sparseCheckpoints always return at least edgeSize checkpoints (or
--- exactly the current height if h < edgeSize).
-prop_sparseCheckpointMinimum
-    :: GenSparseCheckpointsArgs
-    -> Property
-prop_sparseCheckpointMinimum (GenSparseCheckpointsArgs cfg h) = prop
-    & counterexample ("Checkpoints: " <> show cps)
-    & counterexample ("h=" <> show h)
-  where
-    cps = sparseCheckpoints cfg (Quantity h)
-
-    prop :: Property
-    prop = property $ fromIntegral (length cps) >= min e h
-      where
-        e = fromIntegral $ edgeSize cfg
-
--- | This property checks that, the checkpoints kept for an edge size of 0 are
--- included in the list with a non-null edge size, all else equals.
-prop_sparseCheckpointEdgeSize0
-    :: GenSparseCheckpointsArgs
-    -> Property
-prop_sparseCheckpointEdgeSize0 (GenSparseCheckpointsArgs cfg h) = prop
-    & counterexample ("Checkpoints: " <> show cps)
-    & counterexample ("h=" <> show h)
-  where
-    cps  = sparseCheckpoints cfg (Quantity h)
-    cps' = sparseCheckpoints (cfg { edgeSize = 0 }) (Quantity h)
-
-    prop :: Property
-    prop = property (cps' `L.isSubsequenceOf` cps)
-
--- | This property shows that, for all possible cuts (i.e. non-null batches) of
--- a sequence of blocks, the following steps:
---
---  For all batch B in sequence:
---
---  - Keep all checkpoints in B yielded by sparseCheckpoint with and
---    edge size of 0.
---
---  - Keep the last checkpoint of the batch regardless
---
---  - Prune all checkpoints not yielded by sparseCheckpoint with a non-null edge
---    size
---
--- are equivalent to calling `sparseCheckpoints` on the flattened batch
--- sequence.
---
--- Note that the batch creation mimics the way blocks are served by the network
--- layer to wallets: first by batches of arbitrary size, and then one by one.
---
--- The property shows that regardless of how batches are served, after
--- 'edgeSize' one-by-one step, the end result is the same as if the entire
--- stream of blocks had been processed in one go.
-prop_checkpointsEventuallyEqual
-    :: GenSparseCheckpointsArgs
-    -> Property
-prop_checkpointsEventuallyEqual args@(GenSparseCheckpointsArgs cfg h) =
-    h > epochStability cfg ==> forAll (genBatches args) $ \(Batches batches) ->
-        let
-            tip =
-                Quantity $ last $ mconcat batches
-            emptyDB =
-                SparseCheckpointsDB []
-            dbs =
-                L.scanl (\db batch -> prune $ step batch db) emptyDB batches
-        in
-            ( prop_eventuallyReachesExpectedTip tip dbs
-              .&&.
-              prop_canNeverRollbackMoreThanKPlusGap tip dbs
-            )
-  where
-    prop_eventuallyReachesExpectedTip
-        :: Quantity "block" Word32
-        -> [SparseCheckpointsDB]
-        -> Property
-    prop_eventuallyReachesExpectedTip tip dbs =
-        last dbs === SparseCheckpointsDB (sparseCheckpoints cfg tip)
-
-    prop_canNeverRollbackMoreThanKPlusGap
-        :: Quantity "block" Word32
-        -> [SparseCheckpointsDB]
-        -> Property
-    prop_canNeverRollbackMoreThanKPlusGap (Quantity tip) dbs =
-        conjoin (forEachStep <$> L.tail dbs)
-      where
-        forEachStep (SparseCheckpointsDB db) =
-            let
-                -- db' contains all the _stable checkpoints_ in the database,
-                -- i.e. those that are in the interval [0; network tip - k)
-                --
-                -- So, if we are asked to rollback for a full k, we'll end up
-                -- rolling back to the closest checkpoint from that interval.
-                db' = filter (< (tip - epochStability cfg)) db
-                farthestRollback = last db - last db'
-            in
-                property
-                    (farthestRollback <= epochStability cfg + gapSize cfg)
-                & counterexample
-                    ("database: " <> show db)
-                & counterexample
-                    ("stable checkpoints: " <> show db')
-
-    step :: [Word32] -> SparseCheckpointsDB -> SparseCheckpointsDB
-    step cps (SparseCheckpointsDB db) =
-        let
-            toKeep =
-                sparseCheckpoints (cfg { edgeSize = 0 }) (Quantity h)
-            cps' =
-                last cps : (toKeep `L.intersect` cps)
-        in
-            SparseCheckpointsDB $ L.sort $ cps' ++ db
-
-    prune :: SparseCheckpointsDB -> SparseCheckpointsDB
-    prune (SparseCheckpointsDB db) =
-        let
-            tip =
-                Quantity $ last db
-            db' =
-                sparseCheckpoints cfg tip `L.intersect` db
-        in
-            SparseCheckpointsDB db'
-
-newtype Batches = Batches [[Word32]] deriving Show
-
-newtype SparseCheckpointsDB = SparseCheckpointsDB [Word32] deriving (Show, Eq)
-
-data GenSparseCheckpointsArgs
-    = GenSparseCheckpointsArgs SparseCheckpointsConfig Word32
-    deriving Show
-
-instance Arbitrary GenSparseCheckpointsArgs where
-    arbitrary = do
-        k <- (\x -> 10 + (x `mod` 1000)) <$> arbitrary
-        h <- (`mod` 10000) <$> arbitrary
-        cfg <- SparseCheckpointsConfig <$> arbitrary <*> pure k
-        pure $ GenSparseCheckpointsArgs cfg h
-
--- This functions generate `h` "block header" (modeled as a Word32), grouped in
--- batches of arbitrary (albeit meaningful) sizes.
---
--- Batches always end with `edgeSize` "block header" in singleton batches, to
--- simulate a fast and slow mode.
-genBatches
-    :: GenSparseCheckpointsArgs
-    -> Gen Batches
-genBatches (GenSparseCheckpointsArgs cfg h) = do
-    bs <- go [0..h] []
-    let e = fromIntegral $ edgeSize cfg
-    let oneByOne = pure <$> [h+1..h+e]
-    pure (Batches (bs ++ oneByOne))
-  where
-    go :: [Word32] -> [[Word32]] -> Gen [[Word32]]
-    go []     batches = pure $ reverse batches
-    go source batches = do
-        -- NOTE:
-        -- Generate batches that can be larger than the chosen gap size, to make
-        -- sure we generate realistic cases.
-        n <- fromIntegral <$> choose (1, 3 * gapSize cfg)
-        go (drop n source) (take n source : batches)
 
 {-------------------------------------------------------------------------------
     Properties of extendAndPrune


### PR DESCRIPTION
### Overview


In this pull request, we consolidate and simplify the creation and pruning of checkpoints.

Specifically, we introduce a function `extendAndPrune` that computes a delta which

* adds new checkpoints
* prunes the existing checkpoints

based on their block height.

### Details

* The mechanism for creating checkpoints has changed. Specifically, when synchronizing the chain far away from the `tip`, at most two checkpoints are kept: genesis and the latest synchronization point. We only keep multiple checkpoints when we are within `epochStability` of the tip, as we expect rollbacks only then.
* The `CheckpointPolicy` is tested in the existing module `Cardano.Wallet.Checkpoints.PolicySpec`.

### Comments

* This task evolved out of ADP-1497. Previous attempts to implement this are
    * #3159
    * #3369 

### Issue Number

ADP-3031