### PR TITLE
[ADP-2565] Add shrinker to `prop_StoreUpdate`

### DIFF
--- a/lib/delta-store/test/unit/Data/StoreSpec.hs
+++ b/lib/delta-store/test/unit/Data/StoreSpec.hs
@@ -24,7 +24,7 @@ import Test.QuickCheck.Gen
 import Test.QuickCheck.Monadic
     ( monadicIO, run )
 import Test.Store
-    ( prop_StoreUpdates )
+    ( prop_StoreUpdate )
 
 spec :: Spec
 spec = do
@@ -32,15 +32,17 @@ spec = do
         it "Dummy test, to be expanded"
             True
     describe "CachedStore" $ do
-        it "respects store laws" $ monadicIO $ do
-            cachedStore <- run $ do
-                testStore <- newTestStore
-                resetTestStoreBase testStore
-                newCachedStore testStore
-            prop_StoreUpdates run
-                cachedStore
-                (pure emptyTestStore)
-                $ const genTestStoreDeltas
+        it "respects store laws" $
+            let setupStore = do
+                    testStore <- newTestStore
+                    resetTestStoreBase testStore
+                    newCachedStore testStore
+            in  prop_StoreUpdate
+                    id
+                    setupStore
+                    (pure emptyTestStore)
+                    $ const genTestStoreDeltas
+
         it "behaves like the cached one" $ monadicIO $ run $ do
 
             das <- generate $ listOf genTestStoreDeltas

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Fixtures.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Fixtures.hs
@@ -8,7 +8,7 @@
 
 module Cardano.Wallet.DB.Fixtures
     ( withDBInMemory
-    , initializeWallet
+    , initializeWalletTable
     , assertWith
     , RunQuery
     , unsafeLoadS
@@ -88,8 +88,8 @@ withDBInMemory disableFK action = bracket (newDBInMemory disableFK) fst (action 
 newDBInMemory :: ForeignKeysSetting -> IO (IO (), SqliteContext)
 newDBInMemory = newInMemorySqliteContext nullTracer [] migrateAll
 
-initializeWallet :: WalletId -> SqlPersistT IO ()
-initializeWallet wid = do
+initializeWalletTable :: WalletId -> SqlPersistT IO ()
+initializeWalletTable wid = do
     deleteWhere [TH.WalId ==. wid] -- triggers delete cascade
     insertWalletTable wid
 
@@ -175,7 +175,7 @@ withInitializedWalletProp
 withInitializedWalletProp prop db wid = monadicIO $ do
     let runQ :: SqlPersistT IO a -> PropertyM IO a
         runQ = run . runQuery db
-    runQ $ initializeWallet wid
+    runQ $ initializeWalletTable wid
     prop wid runQ
 
 -- store unsafe ops

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Checkpoints/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Checkpoints/StoreSpec.hs
@@ -29,7 +29,7 @@ import Cardano.Wallet.Checkpoints
 import Cardano.Wallet.DB.Arbitrary
     ()
 import Cardano.Wallet.DB.Fixtures
-    ( initializeWallet, withDBInMemory )
+    ( initializeWalletTable, withDBInMemory )
 import Cardano.Wallet.DB.Store.Checkpoints.Store
     ( PersistAddressBook (..) )
 import Cardano.Wallet.Primitive.Types
@@ -83,7 +83,7 @@ prop_prologue_load_write preprocess db (wid, s) =
     monadicIO $ run (toIO setup) >> prop
   where
     toIO = runQuery db
-    setup = initializeWallet wid
+    setup = initializeWalletTable wid
     prop = prop_loadAfterWrite toIO (insertPrologue wid) (loadPrologue wid) pro
     pro = getPrologue $ preprocess s
     -- FIXME during ADP-1043: See note at 'multisigPoolAbsent'

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Checkpoints/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Checkpoints/StoreSpec.hs
@@ -11,7 +11,7 @@ module Cardano.Wallet.DB.Store.Checkpoints.StoreSpec
 import Prelude
 
 import Cardano.DB.Sqlite
-    ( ForeignKeysSetting (..), SqliteContext (runQuery) )
+    ( ForeignKeysSetting (..), SqliteContext, runQuery )
 import Cardano.Wallet.Address.Book
     ( AddressBookIso (..), Prologue, getPrologue )
 import Cardano.Wallet.Address.Derivation.Shared

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -14,7 +14,7 @@ module Cardano.Wallet.DB.Store.Transactions.StoreSpec
 import Prelude
 
 import Cardano.DB.Sqlite
-    ( ForeignKeysSetting (..) )
+    ( ForeignKeysSetting (..), runQuery )
 import Cardano.Wallet.DB.Arbitrary
     ()
 import Cardano.Wallet.DB.Fixtures
@@ -73,7 +73,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Monadic
     ( forAllM, pick )
 import Test.Store
-    ( GenDelta, prop_StoreUpdates )
+    ( GenDelta, prop_StoreUpdate )
 
 import qualified Cardano.Wallet.DB.Store.Transactions.Layer as TxSet
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
@@ -86,7 +86,7 @@ spec = do
     around (withDBInMemory ForeignKeysEnabled) $ do
         describe "Transactions store" $ do
             it "respects store laws" $
-                property . prop_StoreLaws
+                property . prop_StoreTransactionsLaws
         describe "selectTx" $
             it "retrieves transaction that was written" $
                 property . prop_selectTx
@@ -169,11 +169,11 @@ prop_DecorateLinksTxCollateralsToTxOuts = do
             ]
             === map Just txouts
 
-prop_StoreLaws :: StoreProperty
-prop_StoreLaws = withStoreProp $ \runQ ->
-    prop_StoreUpdates
-        runQ
-        mkStoreTransactions
+prop_StoreTransactionsLaws :: StoreProperty
+prop_StoreTransactionsLaws db =
+    prop_StoreUpdate
+        (runQuery db)
+        (pure mkStoreTransactions)
         (pure mempty)
         (logScale . genDeltas)
 

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/WalletState/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/WalletState/StoreSpec.hs
@@ -20,7 +20,7 @@ import Cardano.Wallet.Address.Derivation
 import Cardano.Wallet.DB.Arbitrary
     ( GenState, InitialCheckpoint (..) )
 import Cardano.Wallet.DB.Fixtures
-    ( initializeWallet, withDBInMemory )
+    ( initializeWalletTable, withDBInMemory )
 import Cardano.Wallet.DB.Store.Checkpoints.Store
     ( PersistAddressBook (..) )
 import Cardano.Wallet.DB.Store.Checkpoints.StoreSpec
@@ -80,7 +80,7 @@ prop_StoreWallet wF db (wid, InitialCheckpoint cp0) =
     monadicIO (setup >> prop)
   where
     toIO = runQuery db
-    setup = run . toIO $ initializeWallet wid
+    setup = run . toIO $ initializeWalletTable wid
     genState = do
         wi <-
             WalletInfo wid

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/WalletState/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/WalletState/StoreSpec.hs
@@ -4,12 +4,15 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 module Cardano.Wallet.DB.Store.WalletState.StoreSpec
     ( spec
     ) where
 
 import Prelude
 
+import Cardano.Address.Derivation
+    ( XPrv )
 import Cardano.DB.Sqlite
     ( ForeignKeysSetting (..), SqliteContext (runQuery) )
 import Cardano.Wallet.Address.Derivation
@@ -27,7 +30,12 @@ import Cardano.Wallet.DB.Store.Info.Store
 import Cardano.Wallet.DB.Store.WalletState.Store
     ( mkStoreWallet )
 import Cardano.Wallet.DB.WalletState
-    ( DeltaWalletState, DeltaWalletState1 (..), fromGenesis, fromWallet )
+    ( DeltaWalletState
+    , DeltaWalletState1 (..)
+    , WalletState
+    , fromGenesis
+    , fromWallet
+    )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( dummyGenesisParameters )
 import Cardano.Wallet.Flavor
@@ -36,36 +44,18 @@ import Cardano.Wallet.Primitive.Types
     ( WalletId (..) )
 import Cardano.Wallet.Read.NetworkId
     ( NetworkDiscriminant (..) )
-import Control.Monad
-    ( forM_ )
-import Data.Delta
-    ( Base, Delta (..) )
 import Data.Generics.Internal.VL.Lens
     ( over, (^.) )
 import Data.Maybe
     ( fromJust )
-import Data.Store
-    ( Store (..) )
-import Fmt
-    ( Buildable (..), listF, pretty )
 import Test.Hspec
     ( Spec, around, describe, it )
 import Test.QuickCheck
-    ( Arbitrary (..)
-    , Blind (..)
-    , Gen
-    , Property
-    , counterexample
-    , property
-    , sized
-    )
+    ( Arbitrary (..), Property, property )
 import Test.QuickCheck.Monadic
-    ( PropertyM, assert, monadicIO, monitor, pick, run )
-import UnliftIO.Exception
-    ( impureThrow )
-
-import Cardano.Address.Derivation
-    ( XPrv )
+    ( monadicIO, run )
+import Test.Store
+    ( GenDelta, prop_StoreUpdates )
 
 spec :: Spec
 spec = do
@@ -97,9 +87,9 @@ prop_StoreWallet wF db (wid, InitialCheckpoint cp0) =
                 <$> arbitrary
                 <*> pure dummyGenesisParameters
         pure $ fromJust . fromGenesis cp0 $ wi
-    prop = do
+    prop =
         prop_StoreUpdates
-            toIO
+            (run . toIO)
             (mkStoreWallet wF wid)
             genState
             genDeltaWalletState
@@ -117,62 +107,5 @@ genDeltaWalletState =
         cp <- over (#currentTip . #slotNo) (const slotNo) <$> arbitrary
         pure . snd $ fromWallet cp
 
--- | Given a value, generate a random delta starting from this value.
-type GenDelta da = Base da -> Gen da
-
--- | A sequence of updates and values after updating.
--- The update that is applied *last* appears in the list *first*.
-newtype Updates da = Updates [(Base da, da)]
-
-instance Show da => Show (Updates da) where
-    show (Updates xs) = show . map snd $ xs
-
--- | Randomly generate a sequence of updates
-genUpdates :: Delta da => Gen (Base da) -> GenDelta da -> Gen (Updates da)
-genUpdates gen0 more = sized $ \n -> go n [] =<< gen0
-  where
-    go 0 das _  = pure $ Updates das
-    go n das a0 = do
-        da <- more a0
-        let a1 = apply da a0
-        go (n-1) ((a1,da):das) a1
-
--- | Test whether 'updateS' and 'loadS' behave as expected.
---
--- TODO: Shrinking of the update sequence.
-prop_StoreUpdates
-    :: ( Monad m, Delta da, Eq (Base da), Buildable da )
-    => (forall b. m b -> IO b)
-    -- ^ Function to embed the monad in 'IO'
-    -> Store m qa da
-    -- ^ Store that is to be tested.
-    -> Gen (Base da)
-    -- ^ Generator for the initial value.
-    -> GenDelta da
-    -- ^ Generator for deltas.
-    -> PropertyM IO ()
-prop_StoreUpdates toIO store gen0 more = do
-    let runs = run . toIO
-
-    -- randomly generate a sequence of updates
-    Blind a0 <- pick $ Blind <$> gen0
-    Blind (Updates adas) <- pick $ Blind <$> genUpdates (pure a0) more
-    let as  = map fst adas ++ [a0]
-        das = map snd adas
-
-    monitor $ counterexample $
-        "\nUpdates applied:\n" <> pretty (listF das)
-
-    -- apply those updates
-    ea <- runs $ do
-        writeS store a0
-        -- first update is applied last!
-        let updates = reverse $ zip das (drop 1 as)
-        forM_ updates $ \(da,a) -> updateS store (Just a) da
-        loadS store
-
-    -- check whether the last value is correct
-    case ea of
-        Left err -> impureThrow err
-        Right a  -> do
-            assert $ a == head as
+instance Show (WalletState s) where
+    show _ = "WalletState{…}"

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/LayerSpec.hs
@@ -12,7 +12,7 @@ import Prelude
 import Cardano.DB.Sqlite
     ( ForeignKeysSetting (..) )
 import Cardano.Wallet.DB.Fixtures
-    ( WalletProperty, logScale, withDBInMemory, withInitializedWalletProp )
+    ( WalletProperty, logScale, withDBInMemory, initializeWalletTable )
 import Cardano.Wallet.DB.Store.Wallets.Layer
     ( newQueryStoreTxWalletsHistory )
 import Cardano.Wallet.DB.Store.Wallets.StoreSpec

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Wallets/LayerSpec.hs
@@ -10,9 +10,9 @@ module Cardano.Wallet.DB.Store.Wallets.LayerSpec
 import Prelude
 
 import Cardano.DB.Sqlite
-    ( ForeignKeysSetting (..) )
+    ( ForeignKeysSetting (..), runQuery )
 import Cardano.Wallet.DB.Fixtures
-    ( WalletProperty, logScale, withDBInMemory, initializeWalletTable )
+    ( WalletProperty, logScale, withDBInMemory )
 import Cardano.Wallet.DB.Store.Wallets.Layer
     ( newQueryStoreTxWalletsHistory )
 import Cardano.Wallet.DB.Store.Wallets.StoreSpec
@@ -22,7 +22,7 @@ import Test.Hspec
 import Test.QuickCheck
     ( property )
 import Test.Store
-    ( prop_StoreUpdates )
+    ( prop_StoreUpdate )
 
 spec :: Spec
 spec = do
@@ -31,11 +31,9 @@ spec = do
             it "respects store laws" $ property . prop_StoreWalletsLaws
 
 prop_StoreWalletsLaws :: WalletProperty
-prop_StoreWalletsLaws =
-  withInitializedWalletProp $ \wid runQ -> do
-    let qs = newQueryStoreTxWalletsHistory
-    prop_StoreUpdates
-      runQ
-      qs
-      (pure mempty)
-      (logScale . genDeltaTxWallets wid)
+prop_StoreWalletsLaws db wid =
+    prop_StoreUpdate
+        (runQuery db)
+        (pure newQueryStoreTxWalletsHistory)
+        (pure mempty)
+        (logScale . genDeltaTxWallets wid)


### PR DESCRIPTION
### Overview

This task is about adding a shrinker to `prop_StoreUpdate`. This makes the development of custom `Store` easier, as the automatic check now produces smaller counterexamples in the case of a bug.

### Comments

* The type signature of `prop_StoreUpdate` changes which requires all dependent code to adapt.

### Issue number

ADP-3064