### PR TITLE
Fix the relative order of haskell.nix and iohk-nix overlays

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -194,11 +194,11 @@
             inherit system;
             inherit (haskellNix) config;
             overlays = [
-              haskellNix.overlay
               iohkNix.overlays.utils
               iohkNix.overlays.crypto
               iohkNix.overlays.haskell-nix-extra
               iohkNix.overlays.cardano-lib
+              haskellNix.overlay
               # Cardano deployments
               (import ./nix/overlays/cardano-deployments.nix)
               # Other packages overlay


### PR DESCRIPTION
It's a wart of the current architecture that haskell.nix overlay has to go after iohk-nix's one.

See https://github.com/input-output-hk/haskell.nix/issues/1954


<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->


- [ ] I have ...

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
