### PR TITLE
[ADP-3076] fix benchmarks, after new migration library

### DIFF
--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -194,7 +194,7 @@ import GHC.Num
 import System.Directory
     ( doesFileExist, getFileSize )
 import System.FilePath
-    ( takeFileName )
+    ( takeFileName, (</>) )
 import System.IO.Unsafe
     ( unsafePerformIO )
 import System.Random
@@ -204,7 +204,7 @@ import Test.Utils.Resource
 import UnliftIO.Exception
     ( bracket )
 import UnliftIO.Temporary
-    ( withSystemTempFile )
+    ( withSystemTempDirectory )
 
 import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.BM.Data.BackendKind as CM
@@ -729,7 +729,10 @@ instance NFData (BenchEnv s) where
     rnf _ = ()
 
 withTempSqliteFile :: (FilePath -> IO a) -> IO a
-withTempSqliteFile action = withSystemTempFile "bench.db" $ \fp _ -> action fp
+withTempSqliteFile action =
+    withSystemTempDirectory "bench-db" $ \dir -> do
+        let path = dir </> "bench.db"
+        action path
 
 setupDB
     :: forall s

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -88,6 +88,8 @@ import Cardano.Wallet.Address.Keys.SequentialAny
     ( mkSeqStateFromRootXPrv )
 import Cardano.Wallet.Address.Keys.WalletKey
     ( publicKey )
+import Cardano.Wallet.BenchShared
+    ( withTempSqliteFile )
 import Cardano.Wallet.DB
     ( DBFresh (..), DBLayer (..), DBLayerParams (..) )
 import Cardano.Wallet.DB.Layer
@@ -194,7 +196,7 @@ import GHC.Num
 import System.Directory
     ( doesFileExist, getFileSize )
 import System.FilePath
-    ( takeFileName, (</>) )
+    ( takeFileName )
 import System.IO.Unsafe
     ( unsafePerformIO )
 import System.Random
@@ -203,8 +205,6 @@ import Test.Utils.Resource
     ( unBracket )
 import UnliftIO.Exception
     ( bracket )
-import UnliftIO.Temporary
-    ( withSystemTempDirectory )
 
 import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.BM.Data.BackendKind as CM
@@ -727,12 +727,6 @@ data BenchEnv s = BenchEnv
 instance NFData (BenchEnv s) where
     rnf :: BenchEnv s -> ()
     rnf _ = ()
-
-withTempSqliteFile :: (FilePath -> IO a) -> IO a
-withTempSqliteFile action =
-    withSystemTempDirectory "bench-db" $ \dir -> do
-        let path = dir </> "bench.db"
-        action path
 
 setupDB
     :: forall s

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -6,12 +6,14 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
@@ -89,7 +91,11 @@ import Cardano.Wallet.Address.Keys.WalletKey
 import Cardano.Wallet.DB
     ( DBFresh (..), DBLayer (..), DBLayerParams (..) )
 import Cardano.Wallet.DB.Layer
-    ( PersistAddressBook, WalletDBLog (..), withDBFresh )
+    ( DefaultFieldValues (..)
+    , PersistAddressBook
+    , WalletDBLog (..)
+    , withDBFresh
+    )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( block0, dummyGenesisParameters, mkTxId )
 import Cardano.Wallet.Flavor
@@ -738,7 +744,7 @@ setupDB tr = do
   where
     withSetup action = withTempSqliteFile $ \fp -> do
         withDBFresh (walletFlavor @s)
-            tr Nothing fp singleEraInterpreter testWid
+            tr (Just defaultFieldValues) fp singleEraInterpreter testWid
                 $ \db -> action (fp, db)
 
 singleEraInterpreter :: TimeInterpreter IO
@@ -774,6 +780,14 @@ withCleanDB tr f g = perRunEnvWithCleanup setup (dbDown . fst) $
         x <- f dbFresh
         pure (be , x)
 
+defaultFieldValues :: DefaultFieldValues
+defaultFieldValues = DefaultFieldValues
+    { defaultActiveSlotCoefficient = ActiveSlotCoefficient 1.0
+    , defaultDesiredNumberOfPool = 0
+    , defaultMinimumUTxOValue = Coin 1_000_000
+    , defaultHardforkEpoch = Nothing
+    , defaultKeyDeposit = Coin 2_000_000
+    }
 ----------------------------------------------------------------------------
 -- Mock data to use for benchmarks
 

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -82,6 +82,7 @@ import Cardano.Wallet.BenchShared
     , execBenchWithNode
     , initBenchmarkLogging
     , runBenchmarks
+    , withTempSqliteFile
     )
 import Cardano.Wallet.DB
     ( DBFresh )
@@ -235,8 +236,6 @@ import UnliftIO.Concurrent
     ( forkIO, threadDelay )
 import UnliftIO.Exception
     ( evaluate, throwString )
-import UnliftIO.Temporary
-    ( withSystemTempFile )
 
 import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
@@ -832,7 +831,7 @@ withBenchDBLayer
     -> (DBFresh IO s -> IO a)
     -> IO a
 withBenchDBLayer ti tr wid action =
-    withSystemTempFile "bench.db" $ \dbFile _ ->
+    withTempSqliteFile $ \dbFile ->
         withDBFresh (walletFlavor @s) tr'
             (Just migrationDefaultValues) dbFile ti wid action
   where

--- a/lib/wallet/bench/src/Cardano/Wallet/BenchShared.hs
+++ b/lib/wallet/bench/src/Cardano/Wallet/BenchShared.hs
@@ -25,6 +25,7 @@ module Cardano.Wallet.BenchShared
     , runBenchmarks
     , bench
     , Time
+    , withTempSqliteFile
     ) where
 
 import Prelude
@@ -285,3 +286,9 @@ initBenchmarkLogging name minSeverity = do
     CM.setSetupBackends c [CM.KatipBK, CM.AggregationBK]
     (tr, _sb) <- setupTrace_ c name
     pure (c, tr)
+
+withTempSqliteFile :: (FilePath -> IO a) -> IO a
+withTempSqliteFile action =
+    withSystemTempDirectory "bench-restoration" $ \dir -> do
+        let path = dir </> "restoration.db"
+        action path

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -1094,6 +1094,7 @@ benchmark db
     , cardano-api
     , cardano-crypto
     , cardano-wallet
+    , cardano-wallet-bench
     , cardano-wallet-launcher
     , cardano-wallet-primitive
     , cardano-wallet-test-utils


### PR DESCRIPTION
Fix a side effect of the new migrations in the benchmarks.

With new migrations, we store a backup of the database before migrating. In this PR, we switch from a temporary file to a temporary directory to avoid the lock that prevents backup.

ADP-3076
