### PR TITLE
Remove balanceTx dependency on `TransactionCtx`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -59,7 +59,6 @@ module Cardano.Wallet.Shelley.Transaction
     , EraConstraints
     , _decodeSealedTx
     , mkDelegationCertificates
-    , calculateMinimumFee
     , getFeePerByteFromWalletPParams
     , _txRewardWithdrawalCost
     , estimateTxCost
@@ -1508,22 +1507,6 @@ estimateTxCost (FeePerByte feePerByte) skeleton =
   where
     computeFee :: TxSize -> Coin
     computeFee (TxSize size) = Coin $ feePerByte * size
-
--- | Calculates a minimal fee amount necessary to pay for a given selection
--- including necessary deposits.
---
--- The constant tx fee is /not/ included in the result of this function.
-calculateMinimumFee
-    :: FeePerByte
-    -> TxWitnessTag
-    -- ^ Witness tag
-    -> TransactionCtx
-    -- ^ Additional information about the transaction
-    -> SelectionSkeleton
-    -- ^ An intermediate representation of an ongoing selection
-    -> Coin
-calculateMinimumFee feePerByte witnessTag ctx skeleton =
-    estimateTxCost feePerByte (mkTxSkeleton witnessTag ctx skeleton)
 
 -- | Calculate the cost of increasing a CBOR-encoded Coin-value by another Coin
 -- with the lovelace/byte cost given by the 'FeePolicy'.

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1768,7 +1768,22 @@ estimateTxSize skeleton =
         + sizeOf_Ttl
         + sizeOf_Update
         + sizeOf_ValidityIntervalStart
+        + sizeOf_HistoricalPadding
       where
+        -- Preserved out of caution during refactoring. We should be able to
+        -- drop this, but we may as well wait until we wave completely
+        -- water-proof testing of the size estimation, e.g:
+        -- prop> forall baseTx update.
+        --      sizeOf_Update x >=
+        --          (serializedSize (update baseTx)
+        --          - serializedSize baseTx)
+        -- where update is something similar to 'TxUpdate' or 'TxSkeleton'.
+        sizeOf_HistoricalPadding = sizeOf_NoMetadata
+          where
+            -- When it's "empty", metadata are represented by a special
+            -- "null byte" in CBOR `F6`.
+            sizeOf_NoMetadata = 1
+
         -- 0 => set<transaction_input>
         sizeOf_Inputs
             = sizeOf_SmallUInt

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1460,7 +1460,6 @@ txConstraints protocolParams witnessTag = TxConstraints
 --
 data TxSkeleton = TxSkeleton
     { txDelegationAction :: !(Maybe DelegationAction)
-    , txRewardWithdrawal :: !Coin
     , txWitnessTag :: !TxWitnessTag
     , txInputCount :: !Int
     , txOutputs :: ![TxOut]
@@ -1479,7 +1478,6 @@ data TxSkeleton = TxSkeleton
 emptyTxSkeleton :: TxWitnessTag -> TxSkeleton
 emptyTxSkeleton txWitnessTag = TxSkeleton
     { txDelegationAction = Nothing
-    , txRewardWithdrawal = Coin 0
     , txWitnessTag
     , txInputCount = 0
     , txOutputs = []
@@ -1501,7 +1499,6 @@ mkTxSkeleton
     -> TxSkeleton
 mkTxSkeleton witness context skeleton = TxSkeleton
     { txDelegationAction = view #txDelegationAction context
-    , txRewardWithdrawal = withdrawalToCoin $ view #txWithdrawal context
     , txWitnessTag = witness
     , txInputCount = view #skeletonInputCount skeleton
     , txOutputs = view #skeletonOutputs skeleton
@@ -1745,7 +1742,6 @@ estimateTxSize skeleton =
   where
     TxSkeleton
         { txDelegationAction
-        , txRewardWithdrawal
         , txWitnessTag
         , txInputCount
         , txOutputs
@@ -1760,9 +1756,6 @@ estimateTxSize skeleton =
 
     numberOf_CertificateSignatures
         = maybe 0 (const 1) txDelegationAction
-
-    numberOf_Withdrawals
-        = if txRewardWithdrawal > Coin 0 then 1 else 0
 
     -- Total number of signatures the scripts require
     numberOf_MintingWitnesses
@@ -1779,12 +1772,10 @@ estimateTxSize skeleton =
                 -- the latter is optional
                 if numberOf_ScriptVkeyWitnessesForPayment == 0 then
                     numberOf_Inputs
-                    + numberOf_Withdrawals
                     + numberOf_CertificateSignatures
                     + numberOf_MintingWitnesses
                 else
                     (numberOf_Inputs * numberOf_ScriptVkeyWitnessesForPayment)
-                    + numberOf_Withdrawals
                     + numberOf_CertificateSignatures
                     + numberOf_MintingWitnesses
 
@@ -1822,7 +1813,6 @@ estimateTxSize skeleton =
         + sizeOf_Fee
         + sizeOf_Ttl
         + sizeOf_Certificates
-        + sizeOf_Withdrawals numberOf_Withdrawals
         + sizeOf_Update
         + sizeOf_ValidityIntervalStart
         + sumVia sizeOf_Mint (F.toList txAssetsToMintOrBurn)

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1796,7 +1796,7 @@ estimateTxSize skeleton =
         + sizeOf_Fee
         + sizeOf_Ttl
         + sizeOf_Certificates
-        + sizeOf_Withdrawals
+        + sizeOf_Withdrawals numberOf_Withdrawals
         + sizeOf_Update
         + sizeOf_MetadataHash
         + sizeOf_ValidityIntervalStart
@@ -1843,13 +1843,6 @@ estimateTxSize skeleton =
                     sizeOf_SmallUInt
                     + sizeOf_SmallArray
                     + sizeOf_StakeDeregistration
-
-        -- ?5 => withdrawals
-        sizeOf_Withdrawals
-            = (if numberOf_Withdrawals > 0
-                then sizeOf_SmallUInt + sizeOf_SmallMap
-                else 0)
-            + sizeOf_Withdrawal * numberOf_Withdrawals
 
         -- ?6 => update
         sizeOf_Update
@@ -2002,12 +1995,6 @@ estimateTxSize skeleton =
         . CBOR.encodeWord64
         . Coin.unsafeToWord64
 
-    -- withdrawals =
-    --   { * reward_account => coin }
-    sizeOf_Withdrawal
-        = sizeOf_Hash28
-        + sizeOf_LargeUInt
-
     -- [* native_script ]
     sizeOf_NativeScripts []
         = 0
@@ -2041,9 +2028,25 @@ estimateTxSize skeleton =
                 then sizeOf_Array + sizeOf_SmallUInt else 0)
             + sizeOf_VKeyWitness * numberOf_VkeyWitnesses
 
-        -- ?1 => [* native_script ]
 
-        -- ?2 => [* bootstrap_witness ]
+-- ?5 => withdrawals
+sizeOf_Withdrawals :: Integer -> Integer
+sizeOf_Withdrawals n
+    = (if n > 0
+        then sizeOf_SmallUInt + sizeOf_SmallMap
+        else 0)
+    + sizeOf_Withdrawal * n
+
+  where
+    -- withdrawals =
+    --   { * reward_account => coin }
+    sizeOf_Withdrawal
+        = sizeOf_Hash28
+        + sizeOf_LargeUInt
+
+
+
+-- ?2 => [* bootstrap_witness ]
 sizeOf_BootstrapWitnesses :: Integer -> Integer
 sizeOf_BootstrapWitnesses n
     = (if n > 0

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2103,16 +2103,15 @@ prop_txConstraints_txSize mock =
         , result <= upperBound
         ]
   where
-    MockSelection {txInputCount, txOutputs, txRewardWithdrawal} = mock
+    MockSelection {txInputCount, txOutputs} = mock
     result :: TxSize
     result = mconcat
         [ txBaseSize mockTxConstraints
         , txInputCount `mtimesDefault` txInputSize mockTxConstraints
         , F.foldMap (txOutputSize mockTxConstraints . tokens) txOutputs
-        , txRewardWithdrawalSize mockTxConstraints txRewardWithdrawal
         ]
     lowerBound = estimateTxSize emptyTxSkeleton
-        {txInputCount, txOutputs, txRewardWithdrawal}
+        {txInputCount, txOutputs }
     -- We allow a small amount of overestimation due to the slight variation in
     -- the marginal size of an input:
     upperBound = lowerBound <> txInputCount `mtimesDefault` TxSize 4

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -120,7 +120,6 @@ import Cardano.Wallet
 import Cardano.Wallet.Address.Derivation
     ( DelegationAddress (delegationAddress)
     , Depth (..)
-    , DerivationIndex (..)
     , DerivationType (..)
     , Index
     , Role (..)
@@ -184,8 +183,6 @@ import Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
     )
 import Cardano.Wallet.Primitive.Types.Redeemer
     ( Redeemer (..) )
-import Cardano.Wallet.Primitive.Types.RewardAccount
-    ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( AssetId, TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
@@ -205,7 +202,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , sealedTxFromCardano
     , sealedTxFromCardano'
     , serialisedTx
-    , txMetadataIsNull
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxConstraints (..), TxSize (..) )
@@ -246,7 +242,6 @@ import Cardano.Wallet.Shelley.Transaction
     , TxSkeleton (..)
     , TxUpdate (..)
     , TxWitnessTag (..)
-    , TxWitnessTagFor (txWitnessTagFor)
     , costOfIncreasingCoin
     , distributeSurplus
     , distributeSurplusDelta
@@ -272,10 +267,8 @@ import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , ErrAssignRedeemers (..)
     , ErrMoreSurplusNeeded (..)
-    , TransactionCtx (..)
     , TransactionLayer (..)
     , TxFeeAndChange (TxFeeAndChange)
-    , Withdrawal (..)
     , WitnessCountCtx (..)
     , defaultTransactionCtx
     )

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1194,26 +1194,6 @@ feeCalculationSpec = describe "fee calculations" $ do
             & counterexample ("cost with: " <> show costWith)
             & counterexample ("cost without: " <> show costWithout)
 
-    it "minting incurs fees" $ property $ \assets ->
-        let
-            costWith =
-                minFeeSkeleton $ emptyTxSkeleton
-                    { txAssetsToMintOrBurn = Set.fromList assets }
-            costWithout =
-                minFeeSkeleton emptyTxSkeleton
-
-            marginalCost :: Integer
-            marginalCost = costWith - costWithout
-        in
-            (if null assets
-                then property $ marginalCost == 0
-                else property $ marginalCost > 0
-            )
-            & classify (null assets) "null minting assets"
-            & counterexample ("marginal cost: " <> show marginalCost)
-            & counterexample ("cost with: " <> show costWith)
-            & counterexample ("cost without: " <> show costWithout)
-
     it "scripts incur fees" $ property $ \scripts ->
         let
             costWith =
@@ -1232,35 +1212,6 @@ feeCalculationSpec = describe "fee calculations" $ do
             & counterexample ("marginal cost: " <> show marginalCost)
             & counterexample ("cost with: " <> show costWith)
             & counterexample ("cost without: " <> show costWithout)
-
-    it "increasing mint increases tx size at least proportianally to asset names"
-        $ property $ \mints ->
-        let
-            assetNameLength = BS.length . unTokenName . tokenName
-
-            lengthAssetNames = fromIntegral . getSum $
-                F.foldMap (Sum . assetNameLength) mints
-
-            sizeWith =
-                estimateTxSize' $ emptyTxSkeleton
-                    { txAssetsToMintOrBurn = Set.fromList mints }
-            sizeWithout =
-                estimateTxSize' emptyTxSkeleton
-
-            marginalSize :: Integer
-            marginalSize = sizeWith - sizeWithout
-        in
-            -- Larger asset names means more bytes in the tx which should
-            -- mean a more expensive tx. Adding the mints should increase
-            -- the marginal size at least as much as the size of the asset
-            -- names.
-            property (marginalSize >= lengthAssetNames)
-            & classify (null mints) "null minting assets"
-            & counterexample
-                ("asset names length: " <> show lengthAssetNames)
-            & counterexample ("marginal size: " <> show marginalSize)
-            & counterexample ("size with: " <> show sizeWith)
-            & counterexample ("size without: " <> show sizeWithout)
 
     it "increasing scripts increases fee at least proportionate to size of CBOR script"
         $ property $ \scripts ->
@@ -1339,26 +1290,6 @@ feeCalculationSpec = describe "fee calculations" $ do
                 & counterexample ("cost with: " <> show costWith)
                 & counterexample ("cost without: " <> show costWithout)
 
-        it "minting incurs fees" $ property $ \assets ->
-            let
-                costWith =
-                    minFeeSkeleton $ emptyTxSkeleton
-                        { txAssetsToMintOrBurn = Set.fromList assets }
-                costWithout =
-                    minFeeSkeleton emptyTxSkeleton
-
-                marginalCost :: Integer
-                marginalCost = costWith - costWithout
-            in
-                (if null assets
-                    then property $ marginalCost == 0
-                    else property $ marginalCost > 0
-                )
-                & classify (null assets) "null minting assets"
-                & counterexample ("marginal cost: " <> show marginalCost)
-                & counterexample ("cost with: " <> show costWith)
-                & counterexample ("cost without: " <> show costWithout)
-
         it "scripts incur fees" $ property $ \scripts ->
             let
                 costWith =
@@ -1377,35 +1308,6 @@ feeCalculationSpec = describe "fee calculations" $ do
                 & counterexample ("marginal cost: " <> show marginalCost)
                 & counterexample ("cost with: " <> show costWith)
                 & counterexample ("cost without: " <> show costWithout)
-
-        it "increasing mint increases tx size at least proportianally to asset names"
-            $ property $ \mints ->
-            let
-                assetNameLength = BS.length . unTokenName . tokenName
-
-                lengthAssetNames = fromIntegral . getSum $
-                    F.foldMap (Sum . assetNameLength) mints
-
-                sizeWith =
-                    estimateTxSize' $ emptyTxSkeleton
-                        { txAssetsToMintOrBurn = Set.fromList mints }
-                sizeWithout =
-                    estimateTxSize' emptyTxSkeleton
-
-                marginalSize :: Integer
-                marginalSize = sizeWith - sizeWithout
-            in
-                -- Larger asset names means more bytes in the tx which should
-                -- mean a more expensive tx. Adding the mints should increase
-                -- the marginal size at least as much as the size of the asset
-                -- names.
-                property (marginalSize >= lengthAssetNames)
-                & classify (null mints) "null minting assets"
-                & counterexample
-                    ("asset names length: " <> show lengthAssetNames)
-                & counterexample ("marginal size: " <> show marginalSize)
-                & counterexample ("size with: " <> show sizeWith)
-                & counterexample ("size without: " <> show sizeWithout)
 
         it "increasing scripts increases fee at least proportionate to size of CBOR script"
             $ property $ \scripts ->


### PR DESCRIPTION
- [x] Create new `_txRewardWithdrawalSize` function for the wallet to use, instead of going through `estimateTxSize`.
- [x] Drop unneeded things from `TxSkeleton` and `estimateTxSize`.
- [x] Have `balanceTx` construct a `TxSkeleton` directly instead of going via `TransactionCtx` when calling `estimateTxCost`.
    - `TransactionCtx` is still used by the wallet for tx construction
    - `TxSkeleton` is only needed for `balanceTx` and can easily be moved into the library.

### Comments

For follow-up PRs:
- Move `balanceTx`-related helpers from `Shelley.Transaction` into modules in the `Write` hierarchy.
- Reduce dependency on cardano-api and conversion functions from `Cardano.Wallet.Shelley.Compatibility`.

### Issue Number

ADP-3053, ADP-3016
