### PR TITLE
Use TxSize for `sizeOf` functions

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Constraints.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Constraints.hs
@@ -130,6 +130,7 @@ txOutputHasValidTokenQuantities constraints m =
 newtype TxSize = TxSize { unTxSize :: Natural }
     deriving stock (Eq, Ord, Generic)
     deriving Show via (Quiet TxSize)
+    deriving Num via Natural
 
 instance NFData TxSize
 

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -258,11 +258,11 @@ import Data.Generics.Internal.VL.Lens
 import Data.Generics.Labels
     ()
 import Data.IntCast
-    ( intCast, intCastMaybe )
+    ( intCast )
 import Data.Map.Strict
     ( Map, (!) )
 import Data.Maybe
-    ( fromMaybe, mapMaybe )
+    ( mapMaybe )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Set
@@ -887,7 +887,7 @@ evaluateMinimumFee pp (KeyWitnessCount nWits nBootWits) body =
                 $ Cardano.unbundleProtocolParams pp
 
         bytes :: Natural
-        bytes = fromIntegral $ sizeOf_BootstrapWitnesses $ intCast nBootWits
+        bytes = unTxSize $ sizeOf_BootstrapWitnesses $ intCast nBootWits
 
 -- | Estimate the size of the transaction (body) when fully signed.
 estimateSignedTxSize
@@ -1331,18 +1331,17 @@ _txRewardWithdrawalSize
     -> Coin -- ^ Withdrawal amount
     -> TxSize
 _txRewardWithdrawalSize _ (Coin 0) = TxSize 0
-_txRewardWithdrawalSize witType _ = TxSize
-        $ fromMaybe (error "txRewardWithdrawalSize: negative size")
-        $ intCastMaybe
-        $ sizeOf_Withdrawals 1 + witSize
+_txRewardWithdrawalSize witType _ =
+        sizeOf_Withdrawals 1 <> witSize
       where
+        witSize :: TxSize
         witSize = case witType of
             Right TxWitnessByronUTxO ->
                 sizeOf_BootstrapWitnesses 1
             Right TxWitnessShelleyUTxO ->
                 sizeOf_VKeyWitnesses 1
             Left scriptTemplate ->
-                let n = fromIntegral $ estimateMaxWitnessRequiredPerInput
+                let n = estimateMaxWitnessRequiredPerInput
                         $ view #template scriptTemplate
                 in sizeOf_VKeyWitnesses n
 
@@ -1706,7 +1705,7 @@ estimateTxSize
     :: TxSkeleton
     -> TxSize
 estimateTxSize skeleton =
-    TxSize $ fromIntegral sizeOf_Transaction
+    sizeOf_Transaction
   where
     TxSkeleton
         { txWitnessTag
@@ -1716,11 +1715,12 @@ estimateTxSize skeleton =
         , txPaymentTemplate
         } = skeleton
 
+    numberOf_Inputs :: Natural
     numberOf_Inputs
         = fromIntegral txInputCount
 
     numberOf_ScriptVkeyWitnessesForPayment
-        = intCast $ maybe 0 estimateMaxWitnessRequiredPerInput txPaymentTemplate
+        = maybe 0 estimateMaxWitnessRequiredPerInput txPaymentTemplate
 
     numberOf_VkeyWitnesses
         = case txWitnessTag of
@@ -1788,7 +1788,7 @@ estimateTxSize skeleton =
         sizeOf_Inputs
             = sizeOf_SmallUInt
             + sizeOf_Array
-            + sizeOf_Input * numberOf_Inputs
+            + sizeOf_Input * TxSize numberOf_Inputs
 
         -- 1 => [* transaction_output]
         sizeOf_Outputs
@@ -1844,7 +1844,7 @@ estimateTxSize skeleton =
     sizeOf_Output
         = sizeOf_PostAlonzoTransactionOutput
 
-    sizeOf_ChangeOutput :: Set AssetId -> Integer
+    sizeOf_ChangeOutput :: Set AssetId -> TxSize
     sizeOf_ChangeOutput
         = sizeOf_PostAlonzoChangeOutput
 
@@ -1856,7 +1856,7 @@ estimateTxSize skeleton =
     --   }
     -- value =
     --   coin / [coin,multiasset<uint>]
-    sizeOf_PostAlonzoChangeOutput :: Set AssetId -> Integer
+    sizeOf_PostAlonzoChangeOutput :: Set AssetId -> TxSize
     sizeOf_PostAlonzoChangeOutput xs
         = sizeOf_SmallMap
         + sizeOf_SmallUInt
@@ -1868,7 +1868,7 @@ estimateTxSize skeleton =
 
     -- We carry addresses already serialized, so it's a matter of measuring.
     sizeOf_Address addr
-        = 2 + toInteger (BS.length (unAddress addr))
+        = 2 + fromIntegral (BS.length (unAddress addr))
 
     -- For change address, we consider the worst-case scenario based on the
     -- given wallet scheme. Byron addresses are larger.
@@ -1900,7 +1900,7 @@ estimateTxSize skeleton =
 
     -- asset_name = bytes .size (0..32)
     sizeOf_AssetName name
-        = 2 + toInteger (BS.length $ unTokenName name)
+        = 2 + fromIntegral (BS.length $ unTokenName name)
 
     -- Coins can really vary so it's very punishing to always assign them the
     -- upper bound. They will typically be between 3 and 9 bytes (only 6 bytes
@@ -1908,7 +1908,8 @@ estimateTxSize skeleton =
     --
     -- So, for outputs, since we have the values, we can compute it accurately.
     sizeOf_Coin
-        = toInteger
+        = TxSize
+        . fromIntegral
         . BS.length
         . CBOR.toStrictByteString
         . CBOR.encodeWord64
@@ -1917,7 +1918,7 @@ estimateTxSize skeleton =
     determinePaymentTemplateSize scriptCosigner
         = sizeOf_Array
         + sizeOf_SmallUInt
-        + numberOf_Inputs * (sizeOf_NativeScript scriptCosigner)
+        + TxSize numberOf_Inputs * (sizeOf_NativeScript scriptCosigner)
 
     -- transaction_witness_set =
     --   { ?0 => [* vkeywitness ]
@@ -1932,12 +1933,12 @@ estimateTxSize skeleton =
         + sizeOf_BootstrapWitnesses numberOf_BootstrapWitnesses
 
 -- ?5 => withdrawals
-sizeOf_Withdrawals :: Integer -> Integer
+sizeOf_Withdrawals :: Natural -> TxSize
 sizeOf_Withdrawals n
     = (if n > 0
         then sizeOf_SmallUInt + sizeOf_SmallMap
         else 0)
-    + sizeOf_Withdrawal * n
+    + sizeOf_Withdrawal * (TxSize n)
 
   where
     -- withdrawals =
@@ -1947,25 +1948,25 @@ sizeOf_Withdrawals n
         + sizeOf_LargeUInt
 
 -- ?0 => [* vkeywitness ]
-sizeOf_VKeyWitnesses :: Integer -> Integer
+sizeOf_VKeyWitnesses :: Natural -> TxSize
 sizeOf_VKeyWitnesses n
     = (if n > 0
         then sizeOf_Array + sizeOf_SmallUInt else 0)
-    + sizeOf_VKeyWitness * n
+    + sizeOf_VKeyWitness * (TxSize n)
 
 -- ?2 => [* bootstrap_witness ]
-sizeOf_BootstrapWitnesses :: Integer -> Integer
+sizeOf_BootstrapWitnesses :: Natural -> TxSize
 sizeOf_BootstrapWitnesses n
     = (if n > 0
         then sizeOf_Array + sizeOf_SmallUInt
         else 0)
-    + sizeOf_BootstrapWitness * n
+    + sizeOf_BootstrapWitness * (TxSize n)
 
 -- vkeywitness =
 --  [ $vkey
 --  , $signature
 --  ]
-sizeOf_VKeyWitness :: Integer
+sizeOf_VKeyWitness :: TxSize
 sizeOf_VKeyWitness
     = sizeOf_SmallArray
     + sizeOf_VKey
@@ -1977,7 +1978,7 @@ sizeOf_VKeyWitness
 --  , chain_code : bytes .size 32
 --  , attributes : bytes
 --  ]
-sizeOf_BootstrapWitness :: Integer
+sizeOf_BootstrapWitness :: TxSize
 sizeOf_BootstrapWitness
     = sizeOf_SmallArray
     + sizeOf_VKey
@@ -2000,7 +2001,7 @@ sizeOf_BootstrapWitness
 --      ; Timelock validity intervals are half-open intervals [a, b).
 --      ; This field specifies the right (excluded) endpoint b.
 --   ]
-sizeOf_NativeScript :: Script object -> Integer
+sizeOf_NativeScript :: Script object -> TxSize
 sizeOf_NativeScript = \case
     RequireSignatureOf _ ->
         sizeOf_SmallUInt + sizeOf_Hash28
@@ -2020,25 +2021,25 @@ sizeOf_NativeScript = \case
 
 -- A Blake2b-224 hash, resulting in a 28-byte digest wrapped in CBOR, so
 -- with 2 bytes overhead (length <255, but length > 23)
-sizeOf_Hash28 :: Integer
+sizeOf_Hash28 :: TxSize
 sizeOf_Hash28
     = 30
 
 -- A Blake2b-256 hash, resulting in a 32-byte digest wrapped in CBOR, so
 -- with 2 bytes overhead (length <255, but length > 23)
-sizeOf_Hash32 :: Integer
+sizeOf_Hash32 :: TxSize
 sizeOf_Hash32
     = 34
 
 -- A 32-byte Ed25519 public key, encoded as a CBOR-bytestring so with 2
 -- bytes overhead (length < 255, but length > 23)
-sizeOf_VKey :: Integer
+sizeOf_VKey :: TxSize
 sizeOf_VKey
     = 34
 
 -- A 64-byte Ed25519 signature, encoded as a CBOR-bytestring so with 2
 -- bytes overhead (length < 255, but length > 23)
-sizeOf_Signature :: Integer
+sizeOf_Signature :: TxSize
 sizeOf_Signature
     = 66
 
@@ -2049,18 +2050,18 @@ sizeOf_Signature
 -- When considering a 'UInt', we consider the worst case scenario only where
 -- the uint is encoded over 4 bytes, so up to 2^32 which is fine for most
 -- cases but coin values.
-sizeOf_SmallUInt :: Integer
+sizeOf_SmallUInt :: TxSize
 sizeOf_SmallUInt = 1
 
-sizeOf_UInt :: Integer
+sizeOf_UInt :: TxSize
 sizeOf_UInt = 5
 
-sizeOf_LargeUInt :: Integer
+sizeOf_LargeUInt :: TxSize
 sizeOf_LargeUInt = 9
 
 -- A CBOR array with less than 23 elements, fits on a single byte, followed
 -- by each key-value pair (encoded as two concatenated CBOR elements).
-sizeOf_SmallMap :: Integer
+sizeOf_SmallMap :: TxSize
 sizeOf_SmallMap = 1
 
 -- A CBOR array with less than 23 elements, fits on a single byte, followed
@@ -2069,10 +2070,10 @@ sizeOf_SmallMap = 1
 --
 -- When considering an 'Array', we consider large scenarios where arrays can
 -- have up to 65536 elements.
-sizeOf_SmallArray :: Integer
+sizeOf_SmallArray :: TxSize
 sizeOf_SmallArray = 1
 
-sizeOf_Array :: Integer
+sizeOf_Array :: TxSize
 sizeOf_Array = 3
 
 -- Small helper function for summing values. Given a list of values, get the sum

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1941,8 +1941,7 @@ balanceTransactionSpec = describe "balanceTransaction" $ do
     describe "bootstrap witnesses" $ do
         -- Used in 'estimateTxSize', and in turn used by coin-selection
         let coinSelectionEstimatedSize :: Natural -> Natural
-            coinSelectionEstimatedSize
-                = fromIntegral . sizeOf_BootstrapWitnesses . fromIntegral
+            coinSelectionEstimatedSize = unTxSize . sizeOf_BootstrapWitnesses
 
         let measuredWitSize :: IsCardanoEra era => Cardano.Tx era -> Natural
             measuredWitSize (Cardano.Tx body wits) = fromIntegral


### PR DESCRIPTION
- [x] Make use of `TxSize` for the return types of all `sizeOf` functions.
- [x] Add `Num TxSize` instance - feel free to suggest something else

### Comments

- In response to request in #4009

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
