### PR TITLE
Remove redundant arithmetic property tests.

### DIFF
--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/CoinSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/CoinSpec.hs
@@ -42,21 +42,6 @@ import qualified Test.QuickCheck as QC
 spec :: Spec
 spec = describe "Cardano.Wallet.Primitive.Types.CoinSpec" $ do
 
-    describe "Arithmetic operations" $ do
-
-        it "prop_add_toNatural" $ do
-            property prop_add_toNatural
-        it "prop_add_subtract" $ do
-            property prop_add_subtract
-        it "prop_difference_distance" $ do
-            property prop_difference_distance
-        it "prop_difference_subtract" $ do
-            property prop_difference_subtract
-        it "prop_distance_commutative" $ do
-            property prop_distance_commutative
-        it "prop_subtract_toNatural" $ do
-            property prop_subtract_toNatural
-
     describe "Partitioning" $ do
 
         it "prop_partitionDefault_fold" $
@@ -88,57 +73,6 @@ spec = describe "Cardano.Wallet.Primitive.Types.CoinSpec" $ do
             prop_genCoinPartition_length & property
         it "prop_genCoinPartition_nonPositive" $
             prop_genCoinPartition_nonPositive & property
-
---------------------------------------------------------------------------------
--- Arithmetic operations
---------------------------------------------------------------------------------
-
-prop_add_subtract :: Coin -> Coin -> Property
-prop_add_subtract a b =
-    checkCoverageCoin a b $
-    conjoin
-    [ (a `Coin.add` b) `Coin.subtract` b === Just a
-    , (b `Coin.add` a) `Coin.subtract` a === Just b
-    ]
-
-prop_add_toNatural :: Coin -> Coin -> Property
-prop_add_toNatural a b =
-    checkCoverageCoin a b $
-    (===)
-        (Coin.toNatural (a `Coin.add` b))
-        (Coin.toNatural a + Coin.toNatural b)
-
-prop_difference_distance :: Coin -> Coin -> Property
-prop_difference_distance a b =
-    checkCoverageCoin a b $
-    if (a >= b)
-    then a `Coin.distance` b == a `Coin.difference` b
-    else a `Coin.distance` b == b `Coin.difference` a
-
-prop_difference_subtract :: Coin -> Coin -> Property
-prop_difference_subtract a b =
-    checkCoverageCoin a b $
-    if (a >= b)
-    then a `Coin.subtract` b === Just (a `Coin.difference` b)
-    else a `Coin.subtract` b === Nothing
-
-prop_distance_commutative :: Coin -> Coin -> Property
-prop_distance_commutative a b =
-    checkCoverageCoin a b $
-    a `Coin.distance` b === b `Coin.distance` a
-
-prop_subtract_toNatural :: Coin -> Coin -> Property
-prop_subtract_toNatural a b =
-    checkCoverageCoin a b $
-    if (a >= b)
-    then
-        (Coin.toNatural <$> (a `Coin.subtract` b))
-        ===
-        (Just (Coin.toNatural a - Coin.toNatural b))
-    else
-        (Coin.toNatural <$> (b `Coin.subtract` a))
-        ===
-        (Just (Coin.toNatural b - Coin.toNatural a))
 
 --------------------------------------------------------------------------------
 -- Partitioning

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenQuantitySpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenQuantitySpec.hs
@@ -41,8 +41,6 @@ import Test.QuickCheck
     ( Arbitrary (..)
     , Property
     , checkCoverage
-    , conjoin
-    , counterexample
     , cover
     , forAll
     , property
@@ -100,18 +98,6 @@ spec =
             property prop_predZero_difference
         it "prop_predZero_pred" $
             property prop_predZero_pred
-        it "prop_difference_zero (x - 0 = x)" $
-            property prop_difference_zero
-        it "prop_difference_zero2 (0 - x = 0)" $
-            property prop_difference_zero2
-        it "prop_difference_zero3 (x - x = 0)" $
-            property prop_difference_zero3
-        it "prop_difference_leq (x - y <= x)" $
-            property prop_difference_leq
-        it "prop_difference_add ((x - y) + y >= x)" $
-            property prop_difference_add
-        it "prop_add_difference ((x + y) - y = x)" $
-            property prop_add_difference
 
     describe "Partitioning" $ do
 
@@ -174,47 +160,6 @@ prop_predZero_pred q =
     if q == TokenQuantity.zero
     then TokenQuantity.predZero q === TokenQuantity.zero
     else Just (TokenQuantity.predZero q) === TokenQuantity.pred q
-
-prop_difference_zero :: TokenQuantity -> Property
-prop_difference_zero x =
-    x `TokenQuantity.difference` TokenQuantity.zero === x
-
-prop_difference_zero2 :: TokenQuantity -> Property
-prop_difference_zero2 x =
-    TokenQuantity.zero `TokenQuantity.difference` x === TokenQuantity.zero
-
-prop_difference_zero3 :: TokenQuantity -> Property
-prop_difference_zero3 x =
-    x `TokenQuantity.difference` x === TokenQuantity.zero
-
-prop_difference_leq :: TokenQuantity -> TokenQuantity -> Property
-prop_difference_leq x y =
-    let
-        delta = x `TokenQuantity.difference` y
-    in
-      counterexample ("x = " <> show x) $
-      counterexample ("y = " <> show y) $
-      counterexample ("x - y = " <> show delta) $
-      counterexample ("x - y is not <= " <> show x) $
-      property $ delta <= x
-
-prop_difference_add :: TokenQuantity -> TokenQuantity -> Property
-prop_difference_add x y =
-    let
-        delta = x `TokenQuantity.difference` y
-        yAndDelta = delta `TokenQuantity.add` y
-    in
-        counterexample ("x - y = " <> show delta) $
-        counterexample ("(x - y) + y = " <> show yAndDelta) $
-        counterexample ("x is not <= " <> show yAndDelta) $
-        property $ x <= yAndDelta
-
-prop_add_difference :: TokenQuantity -> TokenQuantity -> Property
-prop_add_difference x y =
-    conjoin
-        [ (x `TokenQuantity.add` y) `TokenQuantity.difference` y === x
-        , (x `TokenQuantity.add` y) `TokenQuantity.difference` x === y
-        ]
 
 --------------------------------------------------------------------------------
 -- Partitioning


### PR DESCRIPTION
## Issue

Follow-on from ADP-3061.

## Summary

This PR removes various (**redundant**) arithmetic property tests for the following types:
- `Coin`
- `TokenQuantity`
- `TokenMap`
- `TokenBundle`

These property tests are now **redundant**, as:
- All arithmetic operations for the above types are now just **synonyms** of various operations provided by subclasses of `Semigroup` and `Monoid`:
    ```rust
    add          = Semigroup.(<>)
    subtract     = Reductive.(</>)
    difference   = Monus    .(<\>)
    intersection = GCDMonoid.gcd
    union        = LCMMonoid.lcm
    ```
- Instances of the above classes are derived **automatically** using `deriving via`, with the sole exception of `TokenBundle`, whose instances we test with the `quickcheck-monoid-subclasses` library:
    https://github.com/cardano-foundation/cardano-wallet/blob/bf22a1b1ebbdcb8e5ec46d633abaf9b9239bddb4/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs#L80-L96