### PR TITLE
Prototype branch: Continue relocating balanceTx helpers

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -112,8 +112,6 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( Flat (..) )
 import Cardano.Wallet.Primitive.Types.Tx.SealedTx
     ( serialisedTx )
-import Cardano.Wallet.Shelley.Transaction
-    ( KeyWitnessCount (..) )
 import Cardano.Wallet.Transaction
     ( ErrSignTx (..) )
 import Cardano.Wallet.Write.Tx.Balance
@@ -122,6 +120,8 @@ import Cardano.Wallet.Write.Tx.Balance
     , ErrBalanceTxInternalError (..)
     , ErrUpdateSealedTx (..)
     )
+import Cardano.Wallet.Write.Tx.Sign
+    ( KeyWitnessCount (..) )
 import Control.Monad.Except
     ( ExceptT, lift, withExceptT )
 import Control.Monad.Trans.Except

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -115,9 +115,10 @@ import Cardano.Wallet.Primitive.Types.Tx.SealedTx
 import Cardano.Wallet.Shelley.Transaction
     ( KeyWitnessCount (..) )
 import Cardano.Wallet.Transaction
-    ( ErrAssignRedeemers (..), ErrSignTx (..) )
+    ( ErrSignTx (..) )
 import Cardano.Wallet.Write.Tx.Balance
-    ( ErrBalanceTx (..)
+    ( ErrAssignRedeemers (..)
+    , ErrBalanceTx (..)
     , ErrBalanceTxInternalError (..)
     , ErrUpdateSealedTx (..)
     )

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2352,10 +2352,6 @@ postTransactionFeeOld ctx@ApiLayer{..} (ApiT walletId) body = do
     (Write.InAnyRecentEra era pp, timeTranslation)
         <- liftIO $ W.readNodeTipStateForTxWrite netLayer
 
-    -- Needed only for calcMinimumCoinValues. We'd ideally use the ledger @pp@
-    -- above instead.
-    walletPP <- liftIO $ currentProtocolParameters netLayer
-
     let mTTL = body ^? #timeToLive . traverse . #getQuantity
     withWorkerCtx ctx walletId liftE liftE $ \workerCtx -> do
         let db = workerCtx ^. dbLayer
@@ -2366,7 +2362,7 @@ postTransactionFeeOld ctx@ApiLayer{..} (ApiT walletId) body = do
                 shelleyOnlyMkWithdrawal @s
                     netLayer (txWitnessTagFor @k) db apiWdrl
         let outputs = F.toList $ addressAmountToTxOut <$> body ^. #payments
-            minCoins = W.calcMinimumCoinValues walletPP txLayer
+            minCoins = W.calcMinimumCoinValues pp txLayer
                 <$> outputs
         feePercentiles <- liftIO $ W.transactionFee @s
             db

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3099,7 +3099,6 @@ balanceTransaction
         balancedTx <- liftHandler
             . fmap (Cardano.InAnyCardanoEra Write.cardanoEra . fst)
             $ Write.balanceTransaction
-                (MsgWallet . W.MsgBalanceTx >$< wrk ^. W.logger)
                 utxoAssumptions
                 pp
                 timeTranslation

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -701,6 +701,7 @@ import qualified Cardano.Wallet.Registry as Registry
 import qualified Cardano.Wallet.Write.ProtocolParameters as Write
 import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Cardano.Wallet.Write.Tx.Balance as Write
+import qualified Cardano.Wallet.Write.Tx.Sign as Write
 import qualified Control.Concurrent.Concierge as Concierge
 import qualified Data.ByteString as BS
 import qualified Data.Foldable as F
@@ -3439,12 +3440,12 @@ submitSharedTransaction ctx apiw@(ApiT wid) apitx = do
                     if numberStakingNativeScripts == 0 then
                         0
                     else if numberStakingNativeScripts == 1 then
-                        Shared.estimateMinWitnessRequiredPerInput scriptD
+                        Write.estimateMinWitnessRequiredPerInput scriptD
                     else
                         error "wallet supports transactions with 0 or 1 staking script"
 
         let (ScriptTemplate _ scriptP) = Shared.paymentTemplate $ getState cp
-        let pWitsPerInput = Shared.estimateMinWitnessRequiredPerInput scriptP
+        let pWitsPerInput = Write.estimateMinWitnessRequiredPerInput scriptP
         let witsRequiredForInputs =
                 length $ L.nubBy samePaymentKey $
                 filter isInpOurs $

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -409,6 +409,7 @@ library
     Cardano.Wallet.Write.ProtocolParameters
     Cardano.Wallet.Write.Tx
     Cardano.Wallet.Write.Tx.Balance
+    Cardano.Wallet.Write.Tx.Balance.CoinSelection
     Cardano.Wallet.Write.Tx.Gen
     Cardano.Wallet.Write.Tx.Redeemers
     Cardano.Wallet.Write.Tx.TimeTranslation

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -410,6 +410,7 @@ library
     Cardano.Wallet.Write.Tx
     Cardano.Wallet.Write.Tx.Balance
     Cardano.Wallet.Write.Tx.Gen
+    Cardano.Wallet.Write.Tx.Redeemers
     Cardano.Wallet.Write.Tx.TimeTranslation
     Cardano.Wallet.Write.UTxOAssumptions
     Control.Concurrent.Concierge

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -412,6 +412,7 @@ library
     Cardano.Wallet.Write.Tx.Balance.CoinSelection
     Cardano.Wallet.Write.Tx.Gen
     Cardano.Wallet.Write.Tx.Redeemers
+    Cardano.Wallet.Write.Tx.Sign
     Cardano.Wallet.Write.Tx.TimeTranslation
     Cardano.Wallet.Write.UTxOAssumptions
     Control.Concurrent.Concierge

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -246,7 +246,7 @@ import Cardano.Api.Extra
 import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Data.Tracer
-    ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..), nullTracer )
+    ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Cardano.Crypto.Wallet
     ( toXPub )
 import Cardano.Mnemonic
@@ -519,8 +519,7 @@ import Cardano.Wallet.TxWitnessTag
 import Cardano.Wallet.Write.Tx
     ( recentEra )
 import Cardano.Wallet.Write.Tx.Balance
-    ( BalanceTxLog (..)
-    , ChangeAddressGen (..)
+    ( ChangeAddressGen (..)
     , ErrBalanceTx (..)
     , ErrBalanceTxInternalError (..)
     , ErrSelectAssets (..)
@@ -2233,7 +2232,6 @@ buildTransactionPure
 
     withExceptT Left $
         balanceTransaction @_ @_ @s
-            nullTracer
             (utxoAssumptionsForWallet (walletFlavor @s))
             pparams
             timeTranslation
@@ -2876,7 +2874,6 @@ transactionFee DBLayer{atomically, walletState} protocolParams txLayer
         wrapErrSelectAssets $ calculateFeePercentiles $ do
             res <- runExceptT $
                     balanceTransaction @_ @_ @s
-                        nullTracer
                         (utxoAssumptionsForWallet (walletFlavor @s))
                         protocolParams
                         timeTranslation
@@ -3601,8 +3598,7 @@ data WalletFollowLog
 
 -- | Log messages from API server actions running in a wallet worker context.
 data WalletLog
-    = MsgBalanceTx BalanceTxLog
-    | MsgMigrationUTxOBefore UTxOStatistics
+    = MsgMigrationUTxOBefore UTxOStatistics
     | MsgMigrationUTxOAfter UTxOStatistics
     | MsgRewardBalanceQuery BlockHeader
     | MsgRewardBalanceResult (Either ErrFetchRewards Coin)
@@ -3641,7 +3637,6 @@ instance ToText WalletFollowLog where
 
 instance ToText WalletLog where
     toText = \case
-        MsgBalanceTx msg -> toText msg
         MsgMigrationUTxOBefore summary ->
             "About to migrate the following distribution: \n" <> pretty summary
         MsgMigrationUTxOAfter summary ->
@@ -3675,7 +3670,6 @@ instance HasSeverityAnnotation WalletFollowLog where
 instance HasPrivacyAnnotation WalletLog
 instance HasSeverityAnnotation WalletLog where
     getSeverityAnnotation = \case
-        MsgBalanceTx msg -> getSeverityAnnotation msg
         MsgMigrationUTxOBefore _ -> Info
         MsgMigrationUTxOAfter _ -> Info
         MsgRewardBalanceQuery _ -> Debug

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -497,8 +497,6 @@ import Cardano.Wallet.Shelley.Compatibility
     )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( toWallet )
-import Cardano.Wallet.Shelley.Transaction
-    ( getFeePerByteFromWalletPParams, _txRewardWithdrawalCost )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , ErrCannotJoin (..)
@@ -532,6 +530,8 @@ import Cardano.Wallet.Write.Tx.Balance
     , balanceTransaction
     , constructUTxOIndex
     )
+import Cardano.Wallet.Write.Tx.Balance.CoinSelection
+    ( getFeePerByteFromWalletPParams, _txRewardWithdrawalCost )
 import Cardano.Wallet.Write.Tx.TimeTranslation
     ( TimeTranslation )
 import Control.Arrow
@@ -664,6 +664,7 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Cardano.Wallet.Read as Read
 import qualified Cardano.Wallet.Write.ProtocolParameters as Write
 import qualified Cardano.Wallet.Write.Tx as Write
+import qualified Cardano.Wallet.Write.Tx.Balance.CoinSelection as Write
 import qualified Data.ByteArray as BA
 import qualified Data.Delta.Update as Delta
 import qualified Data.Foldable as F
@@ -1026,7 +1027,7 @@ getWalletUtxoSnapshot ctx = do
         computeMinAdaQuantity :: TxOut -> Coin
         computeMinAdaQuantity (TxOut addr bundle) =
             view #txOutputMinimumAdaQuantity
-                (constraints tl pp)
+                (Write.txConstraints pp (transactionWitnessTag tl))
                 (addr)
                 (view #tokens bundle)
 
@@ -1834,8 +1835,10 @@ calcMinimumCoinValues
     -> TxOut
     -> Coin
 calcMinimumCoinValues pp txLayer =
-    uncurry (constraints txLayer pp ^. #txOutputMinimumAdaQuantity)
+    uncurry (constraints ^. #txOutputMinimumAdaQuantity)
      . (\o -> (o ^. #address, o ^. #tokens . #tokens))
+  where
+    constraints = Write.txConstraints pp $ transactionWitnessTag txLayer
 
 signTransaction
   :: forall k ktype
@@ -2679,7 +2682,7 @@ createMigrationPlan
 createMigrationPlan ctx rewardWithdrawal = do
     (wallet, _, pending) <- readWallet ctx
     pp <- currentProtocolParameters nl
-    let txConstraints = constraints tl pp
+    let txConstraints = Write.txConstraints pp (transactionWitnessTag tl)
     let utxo = availableUTxO pending wallet
     pure
         $ Migration.createPlan txConstraints utxo

--- a/lib/wallet/src/Cardano/Wallet/Address/Discovery/Shared.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Discovery/Shared.hs
@@ -40,8 +40,6 @@ module Cardano.Wallet.Address.Discovery.Shared
     , ErrScriptTemplate (..)
     , isShared
     , retrieveAllCosigners
-    , estimateMinWitnessRequiredPerInput
-    , estimateMaxWitnessRequiredPerInput
 
     , CredentialType (..)
     , liftPaymentAddress
@@ -590,56 +588,6 @@ isOwned st (rootPrv, pwd) addr = case isShared addr st of
                 )
     (Nothing, _) -> Nothing
 
-estimateMinWitnessRequiredPerInput :: Script k -> Natural
-estimateMinWitnessRequiredPerInput = \case
-    RequireSignatureOf _ -> 1
-    RequireAllOf xs      ->
-        sum $ map estimateMinWitnessRequiredPerInput xs
-    RequireAnyOf xs      ->
-        optimumIfNotEmpty minimum $ map estimateMinWitnessRequiredPerInput xs
-    RequireSomeOf m xs   ->
-        let smallestReqFirst =
-                L.sort $ map estimateMinWitnessRequiredPerInput xs
-        in sum $ take (fromIntegral m) smallestReqFirst
-    ActiveFromSlot _     -> 0
-    ActiveUntilSlot _    -> 0
-
-optimumIfNotEmpty :: (Foldable t, Num p) => (t a -> p) -> t a -> p
-optimumIfNotEmpty f xs =
-    if null xs then
-        0
-    else f xs
-
-estimateMaxWitnessRequiredPerInput :: Script k -> Natural
-estimateMaxWitnessRequiredPerInput = \case
-    RequireSignatureOf _ -> 1
-    RequireAllOf xs      ->
-        sum $ map estimateMaxWitnessRequiredPerInput xs
-    RequireAnyOf xs      ->
-        sum $ map estimateMaxWitnessRequiredPerInput xs
-    -- Estimate (and tx fees) could be lowered with:
-    --
-    -- optimumIfNotEmpty maximum $ map estimateMaxWitnessRequiredPerInput xs
-    -- however signTransaction
-    --
-    -- however we'd then need to adjust signTx accordingly such that it still
-    -- doesn't add more witnesses than we plan for.
-    --
-    -- Partially related task: https://input-output.atlassian.net/browse/ADP-2676
-    RequireSomeOf _m xs   ->
-        sum $ map estimateMaxWitnessRequiredPerInput xs
-    -- Estimate (and tx fees) could be lowered with:
-    --
-    -- let largestReqFirst =
-    --      reverse $ L.sort $ map estimateMaxWitnessRequiredPerInput xs
-    -- in sum $ take (fromIntegral m) largestReqFirst
-    --
-    -- however we'd then need to adjust signTx accordingly such that it still
-    -- doesn't add more witnesses than we plan for.
-    --
-    -- Partially related task: https://input-output.atlassian.net/browse/ADP-2676
-    ActiveFromSlot _     -> 0
-    ActiveUntilSlot _    -> 0
 
 instance AccountIxForStaking (SharedState n SharedKey) where
     getAccountIx st =

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -43,7 +43,6 @@ module Cardano.Wallet.Shelley.Transaction
     , sizeOfCoin
     , maximumCostOfIncreasingCoin
     , costOfIncreasingCoin
-    , assignScriptRedeemers
 
     -- * Internals
     , TxPayload (..)
@@ -96,14 +95,8 @@ import Cardano.Crypto.Wallet
     ( XPub )
 import Cardano.Ledger.Allegra.Core
     ( inputsTxBodyL, ppMinFeeAL )
-import Cardano.Ledger.Api
-    ( bodyTxL, rdmrsTxWitsL, scriptIntegrityHashTxBodyL, witsTxL )
 import Cardano.Ledger.Crypto
     ( DSIGN )
-import Cardano.Ledger.Shelley.API
-    ( StrictMaybe (..) )
-import Cardano.Slotting.EpochInfo
-    ( EpochInfo, hoistEpochInfo )
 import Cardano.Tx.Balance.Internal.CoinSelection
     ( SelectionOf (..)
     , SelectionOutputTokenQuantityExceedsLimitError (..)
@@ -137,8 +130,6 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
-import Cardano.Wallet.Primitive.Types.Redeemer
-    ( Redeemer, redeemerData )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
@@ -175,7 +166,6 @@ import Cardano.Wallet.Shelley.Compatibility
     , toCardanoTxOut
     , toCardanoValue
     , toHDPayloadAddress
-    , toScriptPurpose
     , toStakeKeyDeregCert
     , toStakeKeyRegCert
     , toStakePoolDlgCert
@@ -188,7 +178,6 @@ import Cardano.Wallet.Transaction
     ( AnyExplicitScript (..)
     , AnyScript (..)
     , DelegationAction (..)
-    , ErrAssignRedeemers (..)
     , ErrMkTransaction (..)
     , ErrMoreSurplusNeeded (ErrMoreSurplusNeeded)
     , PreSelection (..)
@@ -205,28 +194,19 @@ import Cardano.Wallet.Transaction
 import Cardano.Wallet.TxWitnessTag
     ( TxWitnessTag (..), TxWitnessTagFor (..) )
 import Cardano.Wallet.Util
-    ( HasCallStack, internalError, modifyM )
+    ( HasCallStack, internalError )
 import Cardano.Wallet.Write.Tx
     ( FeePerByte (..)
     , IsRecentEra (recentEra)
     , KeyWitnessCount (..)
     , RecentEra (..)
-    , fromCardanoUTxO
     )
-import Cardano.Wallet.Write.Tx.TimeTranslation
-    ( TimeTranslation, epochInfo, systemStartTime )
-import Codec.Serialise
-    ( deserialiseOrFail )
 import Control.Arrow
     ( left, second )
 import Control.Lens
-    ( over, (.~) )
+    ( over )
 import Control.Monad
-    ( forM, forM_, guard, when )
-import Control.Monad.Trans.Class
-    ( lift )
-import Control.Monad.Trans.State.Strict
-    ( StateT (..), execStateT, get, modify' )
+    ( forM_, guard, when )
 import Data.Bifunctor
     ( bimap )
 import Data.Function
@@ -240,7 +220,7 @@ import Data.Generics.Labels
 import Data.IntCast
     ( intCast )
 import Data.Map.Strict
-    ( Map, (!) )
+    ( Map )
 import Data.Maybe
     ( mapMaybe )
 import Data.Quantity
@@ -268,11 +248,7 @@ import qualified Cardano.Crypto as CC
 import qualified Cardano.Crypto.DSIGN as DSIGN
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Crypto.Wallet as Crypto.HD
-import qualified Cardano.Ledger.Alonzo.PlutusScriptApi as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
-import qualified Cardano.Ledger.Alonzo.Scripts.Data as Alonzo
-import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
-import qualified Cardano.Ledger.Alonzo.TxWits as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Ledger.Keys.Bootstrap as SL
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
@@ -285,11 +261,9 @@ import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BL
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.Map as Map
-import qualified Data.Map.Merge.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
 
@@ -936,143 +910,6 @@ estimateKeyWitnessCount utxo txbody@(Cardano.TxBody txbodycontent) =
                 [ "estimateMaxWitnessRequiredPerInput: input not in utxo."
                 , "Caller is expected to ensure this does not happen."
                 ]
-
-assignScriptRedeemers
-    :: forall era. Write.IsRecentEra era
-    => Write.PParams (Write.ShelleyLedgerEra era)
-    -> TimeTranslation
-    -> Cardano.UTxO era
-    -> [Redeemer]
-    -> Cardano.Tx era
-    -> Either ErrAssignRedeemers (Cardano.Tx era)
-assignScriptRedeemers pparams timeTranslation utxo redeemers tx =
-    Write.withConstraints (recentEra @era) $ do
-        let ledgerTx = Write.fromCardanoTx tx
-        ledgerTx' <- flip execStateT ledgerTx $ do
-            indexedRedeemers <- StateT assignNullRedeemers
-            executionUnits <- get
-                >>= lift . evaluateExecutionUnits indexedRedeemers
-            modifyM (assignExecutionUnits executionUnits)
-            modify' addScriptIntegrityHash
-        pure $ Cardano.ShelleyTx Write.shelleyBasedEra ledgerTx'
-  where
-    epochInformation :: EpochInfo (Either T.Text)
-    epochInformation =
-        hoistEpochInfo (left (T.pack . show)) $ epochInfo timeTranslation
-
-    systemStart = systemStartTime timeTranslation
-
-    -- | Assign redeemers with null execution units to the input transaction.
-    --
-    -- Redeemers are determined from the context given to the caller via the
-    -- 'Redeemer' type which is mapped to an 'Alonzo.ScriptPurpose'.
-    assignNullRedeemers
-        :: Write.RecentEraLedgerConstraints (Write.ShelleyLedgerEra era)
-        => Write.Tx (Write.ShelleyLedgerEra era)
-        -> Either ErrAssignRedeemers
-            ( Map Alonzo.RdmrPtr Redeemer
-            , Write.Tx (Write.ShelleyLedgerEra era)
-            )
-    assignNullRedeemers ledgerTx = do
-        (indexedRedeemers, nullRedeemers) <-
-            fmap unzip $ forM redeemers parseRedeemer
-        pure
-            ( Map.fromList indexedRedeemers
-            , ledgerTx
-                & witsTxL . rdmrsTxWitsL
-                    .~ (Alonzo.Redeemers (Map.fromList nullRedeemers))
-            )
-      where
-        parseRedeemer rd = do
-            let mPtr = Alonzo.rdptr
-                    (Write.txBody (recentEra @era) ledgerTx)
-                    (toScriptPurpose rd)
-            ptr <- case mPtr of
-                SNothing -> Left $ ErrAssignRedeemersTargetNotFound rd
-                SJust ptr -> pure ptr
-            let mDeserialisedData =
-                    deserialiseOrFail $ BL.fromStrict $ redeemerData rd
-            rData <- case mDeserialisedData of
-                Left e -> Left $ ErrAssignRedeemersInvalidData rd (show e)
-                Right d -> pure (Alonzo.Data d)
-            pure ((ptr, rd), (ptr, (rData, mempty)))
-
-    -- | Evaluate execution units of each script/redeemer in the transaction.
-    -- This may fail for each script.
-    evaluateExecutionUnits
-        :: Write.RecentEraLedgerConstraints (Write.ShelleyLedgerEra era)
-        => Map Alonzo.RdmrPtr Redeemer
-        -> Write.Tx (Cardano.ShelleyLedgerEra era)
-        -> Either ErrAssignRedeemers
-            (Map Alonzo.RdmrPtr (Either ErrAssignRedeemers Alonzo.ExUnits))
-    evaluateExecutionUnits indexedRedeemers ledgerTx = do
-        let res =
-                Ledger.evalTxExUnits
-                    pparams
-                    ledgerTx
-                    (fromCardanoUTxO utxo)
-                    epochInformation
-                    systemStart
-        case res of
-            Left translationError ->
-                Left $ ErrAssignRedeemersTranslationError translationError
-            Right report ->
-                Right $ hoistScriptFailure indexedRedeemers report
-
-    hoistScriptFailure
-        :: Show scriptFailure
-        => Map Alonzo.RdmrPtr Redeemer
-        -> Map Alonzo.RdmrPtr (Either scriptFailure a)
-        -> Map Alonzo.RdmrPtr (Either ErrAssignRedeemers a)
-    hoistScriptFailure indexedRedeemers = Map.mapWithKey $ \ptr -> left $ \e ->
-        ErrAssignRedeemersScriptFailure (indexedRedeemers ! ptr) (show e)
-
-    -- | Change execution units for each redeemers in the transaction to what
-    -- they ought to be.
-    assignExecutionUnits
-        :: Write.RecentEraLedgerConstraints (Write.ShelleyLedgerEra era)
-        => Map Alonzo.RdmrPtr (Either ErrAssignRedeemers Alonzo.ExUnits)
-        -> Write.Tx (Write.ShelleyLedgerEra era)
-        -> Either ErrAssignRedeemers (Write.Tx (Write.ShelleyLedgerEra era))
-    assignExecutionUnits exUnits ledgerTx = do
-        let Alonzo.Redeemers rdmrs = view (witsTxL . rdmrsTxWitsL) ledgerTx
-
-        rdmrs' <- Map.mergeA
-            Map.preserveMissing
-            Map.dropMissing
-            (Map.zipWithAMatched (const assignUnits))
-            rdmrs
-            exUnits
-
-        pure $ ledgerTx
-            & (witsTxL . rdmrsTxWitsL) .~ (Alonzo.Redeemers rdmrs')
-
-    assignUnits
-        :: (dat, Alonzo.ExUnits)
-        -> Either err Alonzo.ExUnits
-        -> Either err (dat, Alonzo.ExUnits)
-    assignUnits (dats, _zero) = fmap (dats,)
-
-    -- | Finally, calculate and add the script integrity hash with the new
-    -- final redeemers, if any.
-    addScriptIntegrityHash
-        :: Write.RecentEraLedgerConstraints (Write.ShelleyLedgerEra era)
-        => Write.Tx (Write.ShelleyLedgerEra era)
-        -> Write.Tx (Write.ShelleyLedgerEra era)
-    addScriptIntegrityHash ledgerTx =
-        ledgerTx & (bodyTxL . scriptIntegrityHashTxBodyL) .~
-            Alonzo.hashScriptIntegrity
-                (Set.fromList $ Alonzo.getLanguageView pparams <$> langs)
-                (Alonzo.txrdmrs wits)
-                (Alonzo.txdats wits)
-      where
-        wits = Alonzo.wits ledgerTx
-        langs =
-            [ l
-            | (_hash, script) <- Map.toList (Alonzo.txscripts wits)
-            , (not . Ledger.isNativeScript @(Write.ShelleyLedgerEra era)) script
-            , Just l <- [Alonzo.language script]
-            ]
 
 getFeePerByteFromWalletPParams
     :: ProtocolParameters

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
@@ -32,9 +31,6 @@ module Cardano.Wallet.Shelley.Transaction
     ( newTransactionLayer
 
     -- * For balancing (To be moved)
-    , estimateKeyWitnessCount
-    , estimateSignedTxSize
-    , KeyWitnessCount (..)
     , distributeSurplus
     , distributeSurplusDelta
     , sizeOfCoin
@@ -81,7 +77,7 @@ import Cardano.Binary
 import Cardano.Crypto.Wallet
     ( XPub )
 import Cardano.Ledger.Allegra.Core
-    ( inputsTxBodyL, ppMinFeeAL )
+    ( inputsTxBodyL )
 import Cardano.Ledger.Crypto
     ( DSIGN )
 import Cardano.Tx.Balance.Internal.CoinSelection
@@ -118,7 +114,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , Tx (..)
     , cardanoTxIdeallyNoLaterThan
     , sealedTxFromCardano'
-    , sealedTxFromCardanoBody
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxSize (..), txOutMaxTokenQuantity )
@@ -145,7 +140,9 @@ import Cardano.Wallet.Shelley.Compatibility
     , toStakePoolDlgCert
     )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( Convert (..), toWalletCoin, toWalletScript )
+    ( Convert (toLedger, toWallet) )
+import Cardano.Wallet.Shelley.MinimumUTxO
+    ( computeMinimumCoinForUTxO, isBelowMinimumCoinForUTxO )
 import Cardano.Wallet.Transaction
     ( AnyExplicitScript (..)
     , AnyScript (..)
@@ -168,7 +165,7 @@ import Cardano.Wallet.TxWitnessTag
 import Cardano.Wallet.Util
     ( HasCallStack, internalError )
 import Cardano.Wallet.Write.Tx
-    ( FeePerByte (..), IsRecentEra (..), KeyWitnessCount (..), RecentEra (..) )
+    ( FeePerByte (..) )
 import Control.Arrow
     ( left, second )
 import Control.Lens
@@ -191,8 +188,6 @@ import Data.Maybe
     ( mapMaybe )
 import Data.Type.Equality
     ( type (==) )
-import Numeric.Natural
-    ( Natural )
 import Ouroboros.Network.Block
     ( SlotNo )
 
@@ -205,11 +200,8 @@ import qualified Cardano.Crypto as CC
 import qualified Cardano.Crypto.DSIGN as DSIGN
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Crypto.Wallet as Crypto.HD
-import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Ledger.Keys.Bootstrap as SL
-import Cardano.Wallet.Address.Discovery.Shared
-    ( estimateMaxWitnessRequiredPerInput )
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
@@ -645,199 +637,6 @@ mkDelegationCertificates da cred =
             , toStakePoolDlgCert cred poolId
             ]
        Quit -> [toStakeKeyDeregCert cred]
-
--- | Estimate the size of the transaction (body) when fully signed.
-estimateSignedTxSize
-    :: forall era. Write.IsRecentEra era
-    => Write.PParams (Write.ShelleyLedgerEra era)
-    -> KeyWitnessCount
-    -> Cardano.TxBody era
-    -> TxSize
-estimateSignedTxSize pparams nWits body =
-    let
-        -- Hack which allows us to rely on the ledger to calculate the size of
-        -- witnesses:
-        feeOfWits :: Coin
-        feeOfWits = minfee nWits `Coin.difference` minfee mempty
-
-        sizeOfWits :: TxSize
-        sizeOfWits =
-            case feeOfWits `coinQuotRem` feePerByte of
-                (n, 0) -> TxSize n
-                (_, _) -> error $ unwords
-                    [ "estimateSignedTxSize:"
-                    , "the impossible happened!"
-                    , "Couldn't divide"
-                    , show feeOfWits
-                    , "lovelace (the fee contribution of"
-                    , show nWits
-                    , "witnesses) with"
-                    , show feePerByte
-                    , "lovelace/byte"
-                    ]
-        sizeOfTx :: TxSize
-        sizeOfTx = TxSize
-            . fromIntegral
-            . BS.length
-            . serialisedTx
-            $ sealedTxFromCardanoBody body
-    in
-        sizeOfTx <> sizeOfWits
-  where
-    coinQuotRem :: Coin -> Coin -> (Natural, Natural)
-    coinQuotRem (Coin p) (Coin q) = quotRem p q
-
-    minfee :: KeyWitnessCount -> Coin
-    minfee witCount = toWalletCoin $ Write.evaluateMinimumFee
-        (Write.recentEra @era) pparams (toLedgerTx body) witCount
-
-    toLedgerTx :: Cardano.TxBody era -> Write.Tx (Write.ShelleyLedgerEra era)
-    toLedgerTx b = case Cardano.Tx b [] of
-        Byron.ByronTx {} -> case Write.recentEra @era of {}
-        Cardano.ShelleyTx _era ledgerTx -> ledgerTx
-
-    feePerByte :: Coin
-    feePerByte = toWalletCoin $
-        case Write.recentEra @era of
-            Write.RecentEraBabbage -> pparams ^. ppMinFeeAL
-            Write.RecentEraConway -> pparams ^. ppMinFeeAL
-
-numberOfShelleyWitnesses :: Word -> KeyWitnessCount
-numberOfShelleyWitnesses n = KeyWitnessCount n 0
-
--- | Estimates the required number of Shelley-era witnesses.
---
--- Because we don't take into account whether two pieces of tx content will need
--- the same key for signing, the result may be an overestimate.
---
--- For instance, this may happen if:
--- 1. Multiple inputs share the same payment key (like in a single address
--- wallet)
--- 2. We are updating our delegation and withdrawing rewards at the same time.
---
--- FIXME [ADP-1515] Improve estimation
---
--- NOTE: Similar to 'estimateTransactionKeyWitnessCount' from cardano-api, which
--- we cannot use because it requires a 'TxBodyContent BuildTx era'.
-estimateKeyWitnessCount
-    :: forall era. IsRecentEra era
-    => Cardano.UTxO era
-    -- ^ Must contain all inputs from the 'TxBody' or
-    -- 'estimateKeyWitnessCount will 'error'.
-    -> Cardano.TxBody era
-    -> KeyWitnessCount
-estimateKeyWitnessCount utxo txbody@(Cardano.TxBody txbodycontent) =
-    let txIns = map fst $ Cardano.txIns txbodycontent
-        txInsCollateral =
-            case Cardano.txInsCollateral txbodycontent of
-                Cardano.TxInsCollateral _ ins -> ins
-                Cardano.TxInsCollateralNone -> []
-        vkInsUnique = L.nub $ filter (hasVkPaymentCred utxo) $
-            txIns ++ txInsCollateral
-        txExtraKeyWits = Cardano.txExtraKeyWits txbodycontent
-        txExtraKeyWits' = case txExtraKeyWits of
-            Cardano.TxExtraKeyWitnesses _ khs -> khs
-            _ -> []
-        txWithdrawals = Cardano.txWithdrawals txbodycontent
-        txWithdrawals' = case txWithdrawals of
-            Cardano.TxWithdrawals _ wdls ->
-                [ () | (_, _, Cardano.ViewTx) <- wdls ]
-            _ -> []
-        txUpdateProposal = Cardano.txUpdateProposal txbodycontent
-        txUpdateProposal' = case txUpdateProposal of
-            Cardano.TxUpdateProposal _
-                (Cardano.UpdateProposal updatePerGenesisKey _) ->
-                    Map.size updatePerGenesisKey
-            _ -> 0
-        txCerts = case Cardano.txCertificates txbodycontent of
-            Cardano.TxCertificatesNone -> 0
-            Cardano.TxCertificates _ certs _ ->
-                sumVia estimateDelegSigningKeys certs
-        scriptVkWitsUpperBound =
-            fromIntegral
-            $ sumVia estimateMaxWitnessRequiredPerInput
-            $ mapMaybe toTimelockScript scripts
-        nonInputWits = numberOfShelleyWitnesses $ fromIntegral $
-            length txExtraKeyWits' +
-            length txWithdrawals' +
-            txUpdateProposal' +
-            fromIntegral txCerts +
-            scriptVkWitsUpperBound
-        inputWits = KeyWitnessCount
-            { nKeyWits = fromIntegral
-                . length
-                $ filter (not . hasBootstrapAddr utxo) vkInsUnique
-            , nBootstrapWits = fromIntegral
-                . length
-                $ filter (hasBootstrapAddr utxo) vkInsUnique
-            }
-        in
-            nonInputWits <> inputWits
-  where
-    scripts = case txbody of
-        Cardano.ShelleyTxBody _ _ shelleyBodyScripts _ _ _ -> shelleyBodyScripts
-        Byron.ByronTxBody {} -> error "estimateKeyWitnessCount: ByronTxBody"
-
-    dummyKeyRole = Payment
-
-
-    estimateDelegSigningKeys :: Cardano.Certificate -> Integer
-    estimateDelegSigningKeys = \case
-        Cardano.StakeAddressRegistrationCertificate _ -> 0
-        Cardano.StakeAddressDeregistrationCertificate cred ->
-            estimateWitNumForCred cred
-        Cardano.StakeAddressPoolDelegationCertificate cred _ ->
-            estimateWitNumForCred cred
-        _ -> 1
-      where
-        -- Does not include the key witness needed for script credentials.
-        -- They are accounted for separately in @scriptVkWitsUpperBound@.
-        estimateWitNumForCred = \case
-            Cardano.StakeCredentialByKey _ -> 1
-            Cardano.StakeCredentialByScript _ -> 0
-
-
-    toTimelockScript
-        :: Ledger.Script (Cardano.ShelleyLedgerEra era)
-        -> Maybe (Script KeyHash)
-    toTimelockScript anyScript = case recentEra @era of
-        RecentEraConway ->
-            case anyScript of
-                Alonzo.TimelockScript timelock ->
-                    Just $ toWalletScript (const dummyKeyRole) timelock
-                Alonzo.PlutusScript _ _ -> Nothing
-        RecentEraBabbage ->
-            case anyScript of
-                Alonzo.TimelockScript timelock ->
-                    Just $ toWalletScript (const dummyKeyRole) timelock
-                Alonzo.PlutusScript _ _ -> Nothing
-
-    hasVkPaymentCred
-        :: Cardano.UTxO era
-        -> Cardano.TxIn
-        -> Bool
-    hasVkPaymentCred (Cardano.UTxO u) inp = case Map.lookup inp u of
-        Just (Cardano.TxOut addrInEra _ _ _) -> Cardano.isKeyAddress addrInEra
-        Nothing ->
-            error $ unwords
-                [ "estimateMaxWitnessRequiredPerInput: input not in utxo."
-                , "Caller is expected to ensure this does not happen."
-                ]
-
-    hasBootstrapAddr
-        :: Cardano.UTxO era
-        -> Cardano.TxIn
-        -> Bool
-    hasBootstrapAddr (Cardano.UTxO u) inp = case Map.lookup inp u of
-        Just (Cardano.TxOut addrInEra _ _ _) ->
-            case addrInEra of
-                Cardano.AddressInEra Cardano.ByronAddressInAnyEra _ -> True
-                _ -> False
-        Nothing ->
-            error $ unwords
-                [ "estimateMaxWitnessRequiredPerInput: input not in utxo."
-                , "Caller is expected to ensure this does not happen."
-                ]
 
 -- | Calculate the cost of increasing a CBOR-encoded Coin-value by another Coin
 -- with the lovelace/byte cost given by the 'FeePolicy'.

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE EmptyCase #-}
@@ -9,7 +8,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE Rank2Types #-}
@@ -45,23 +43,15 @@ module Cardano.Wallet.Shelley.Transaction
 
     -- * Internals
     , TxPayload (..)
-    , TxSkeleton (..)
     , TxWitnessTag (..)
     , TxWitnessTagFor (..)
     , EraConstraints
     , _decodeSealedTx
     , mkDelegationCertificates
-    , getFeePerByteFromWalletPParams
-    , _txRewardWithdrawalCost
-    , estimateTxCost
-    , estimateTxSize
     , mkByronWitness
     , mkShelleyWitness
     , mkTx
-    , mkTxSkeleton
     , mkUnsignedTx
-    , txConstraints
-    , sizeOf_BootstrapWitnesses
     ) where
 
 import Prelude
@@ -69,12 +59,10 @@ import Prelude
 import Cardano.Address.Derivation
     ( XPrv, toXPub )
 import Cardano.Address.Script
-    ( Cosigner
-    , KeyHash (..)
+    ( KeyHash (..)
     , KeyRole (..)
     , Script (..)
     , ScriptHash (..)
-    , ScriptTemplate (..)
     , foldScript
     , toScriptHash
     )
@@ -99,7 +87,6 @@ import Cardano.Ledger.Crypto
 import Cardano.Tx.Balance.Internal.CoinSelection
     ( SelectionOf (..)
     , SelectionOutputTokenQuantityExceedsLimitError (..)
-    , SelectionSkeleton (..)
     , selectionDelta
     )
 import Cardano.Wallet.Address.Derivation
@@ -108,8 +95,6 @@ import Cardano.Wallet.Address.Derivation.SharedKey
     ( replaceCosignersWithVerKeys )
 import Cardano.Wallet.Address.Derivation.Shelley
     ( toRewardAccountRaw )
-import Cardano.Wallet.Address.Discovery.Shared
-    ( estimateMaxWitnessRequiredPerInput )
 import Cardano.Wallet.Address.Keys.WalletKey
     ( getRawKey )
 import Cardano.Wallet.Flavor
@@ -117,12 +102,7 @@ import Cardano.Wallet.Flavor
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Certificate
-    , FeePolicy (..)
-    , LinearFunction (..)
-    , ProtocolParameters (..)
-    , TxParameters (..)
-    )
+    ( Certificate )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -133,10 +113,6 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..), TokenMap )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( TokenName (..) )
-import Cardano.Wallet.Primitive.Types.TokenQuantity
-    ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)
     , Tx (..)
@@ -145,7 +121,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , sealedTxFromCardanoBody
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TxConstraints (..), TxSize (..), txOutMaxTokenQuantity, txSizeDistance )
+    ( TxSize (..), txOutMaxTokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
@@ -169,9 +145,7 @@ import Cardano.Wallet.Shelley.Compatibility
     , toStakePoolDlgCert
     )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( toLedger, toWallet, toWalletCoin, toWalletScript )
-import Cardano.Wallet.Shelley.MinimumUTxO
-    ( computeMinimumCoinForUTxO, isBelowMinimumCoinForUTxO )
+    ( Convert (..), toWalletCoin, toWalletScript )
 import Cardano.Wallet.Transaction
     ( AnyExplicitScript (..)
     , AnyScript (..)
@@ -194,11 +168,7 @@ import Cardano.Wallet.TxWitnessTag
 import Cardano.Wallet.Util
     ( HasCallStack, internalError )
 import Cardano.Wallet.Write.Tx
-    ( FeePerByte (..)
-    , IsRecentEra (recentEra)
-    , KeyWitnessCount (..)
-    , RecentEra (..)
-    )
+    ( FeePerByte (..), IsRecentEra (..), KeyWitnessCount (..), RecentEra (..) )
 import Control.Arrow
     ( left, second )
 import Control.Lens
@@ -219,22 +189,13 @@ import Data.Map.Strict
     ( Map )
 import Data.Maybe
     ( mapMaybe )
-import Data.Quantity
-    ( Quantity (..) )
-import Data.Set
-    ( Set )
 import Data.Type.Equality
     ( type (==) )
-import Data.Word
-    ( Word64, Word8 )
-import GHC.Generics
-    ( Generic )
 import Numeric.Natural
     ( Natural )
 import Ouroboros.Network.Block
     ( SlotNo )
 
-import qualified Cardano.Address.Script as CA
 import qualified Cardano.Address.Style.Shelley as CA
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Byron as Byron
@@ -247,15 +208,13 @@ import qualified Cardano.Crypto.Wallet as Crypto.HD
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Ledger.Keys.Bootstrap as SL
+import Cardano.Wallet.Address.Discovery.Shared
+    ( estimateMaxWitnessRequiredPerInput )
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
-import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Ledger
 import qualified Cardano.Wallet.Write.Tx as Write
-import qualified Codec.CBOR.Encoding as CBOR
-import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteString as BS
 import qualified Data.Foldable as F
 import qualified Data.List as L
@@ -652,8 +611,6 @@ newTransactionLayer keyF networkId = TransactionLayer
     , tokenBundleSizeAssessor =
         Compatibility.tokenBundleSizeAssessor
 
-    , constraints = \pp -> txConstraints pp (txWitnessTagFor @k)
-
     , decodeTx = _decodeSealedTx
 
     , transactionWitnessTag = txWitnessTagFor @k
@@ -740,7 +697,7 @@ estimateSignedTxSize pparams nWits body =
         Cardano.ShelleyTx _era ledgerTx -> ledgerTx
 
     feePerByte :: Coin
-    feePerByte = Ledger.toWalletCoin $
+    feePerByte = toWalletCoin $
         case Write.recentEra @era of
             Write.RecentEraBabbage -> pparams ^. ppMinFeeAL
             Write.RecentEraConway -> pparams ^. ppMinFeeAL
@@ -881,214 +838,6 @@ estimateKeyWitnessCount utxo txbody@(Cardano.TxBody txbodycontent) =
                 [ "estimateMaxWitnessRequiredPerInput: input not in utxo."
                 , "Caller is expected to ensure this does not happen."
                 ]
-
-getFeePerByteFromWalletPParams
-    :: ProtocolParameters
-    -> FeePerByte
-getFeePerByteFromWalletPParams pp =
-    FeePerByte $ ceiling slope
-  where
-    LinearFee LinearFunction{slope} = getFeePolicy $ txParameters pp
-
--- | Like the 'TxConstraints' field 'txRewardWithdrawalCost', but with added
--- support for shared wallets via the 'CA.ScriptTemplate' argument.
---
--- We may or may not want to support shared wallets in the full txConstraints.
-_txRewardWithdrawalCost
-    :: Write.FeePerByte
-    -> Either CA.ScriptTemplate TxWitnessTag
-    -> Coin -- ^ Withdrawal amount
-    -> Coin
-_txRewardWithdrawalCost feePerByte witType =
-    toWallet
-    . Write.feeOfBytes feePerByte
-    . unTxSize
-    . _txRewardWithdrawalSize witType
-
--- | Like the 'TxConstraints' field 'txRewardWithdrawalSize', but with added
--- support for shared wallets via the 'CA.ScriptTemplate' argument.
---
--- We may or may not want to support shared wallets in the full txConstraints.
-_txRewardWithdrawalSize
-    :: Either CA.ScriptTemplate TxWitnessTag
-    -> Coin -- ^ Withdrawal amount
-    -> TxSize
-_txRewardWithdrawalSize _ (Coin 0) = TxSize 0
-_txRewardWithdrawalSize witType _ =
-        sizeOf_Withdrawals 1 <> witSize
-      where
-        witSize :: TxSize
-        witSize = case witType of
-            Right TxWitnessByronUTxO ->
-                sizeOf_BootstrapWitnesses 1
-            Right TxWitnessShelleyUTxO ->
-                sizeOf_VKeyWitnesses 1
-            Left scriptTemplate ->
-                let n = estimateMaxWitnessRequiredPerInput
-                        $ view #template scriptTemplate
-                in sizeOf_VKeyWitnesses n
-
-txConstraints
-    :: ProtocolParameters -> TxWitnessTag -> TxConstraints
-txConstraints protocolParams witnessTag = TxConstraints
-    { txBaseCost
-    , txBaseSize
-    , txInputCost
-    , txInputSize
-    , txOutputCost
-    , txOutputSize
-    , txOutputMaximumSize
-    , txOutputMaximumTokenQuantity
-    , txOutputMinimumAdaQuantity
-    , txOutputBelowMinimumAdaQuantity
-    , txRewardWithdrawalCost
-    , txRewardWithdrawalSize
-    , txMaximumSize
-    }
-  where
-    txBaseCost =
-        constantTxFee <> estimateTxCost feePerByte empty
-
-    constantTxFee = Coin $ ceiling intercept
-    feePerByte = getFeePerByteFromWalletPParams protocolParams
-    LinearFee LinearFunction {intercept}
-        = getFeePolicy $ txParameters protocolParams
-
-    txBaseSize =
-        estimateTxSize empty
-
-    txInputCost =
-        marginalCostOf empty {txInputCount = 1}
-
-    txInputSize =
-        marginalSizeOf empty {txInputCount = 1}
-
-    txOutputCost bundle =
-        marginalCostOf empty {txOutputs = [mkTxOut bundle]}
-
-    txOutputSize bundle =
-        marginalSizeOf empty {txOutputs = [mkTxOut bundle]}
-
-    txOutputMaximumSize = (<>)
-        (txOutputSize mempty)
-        (view
-            (#txParameters . #getTokenBundleMaxSize . #unTokenBundleMaxSize)
-            protocolParams)
-
-    txOutputMaximumTokenQuantity =
-        TokenQuantity $ fromIntegral $ maxBound @Word64
-
-    txOutputMinimumAdaQuantity =
-        computeMinimumCoinForUTxO (minimumUTxO protocolParams)
-
-    txOutputBelowMinimumAdaQuantity =
-        isBelowMinimumCoinForUTxO (minimumUTxO protocolParams)
-
-    txRewardWithdrawalCost =
-        _txRewardWithdrawalCost feePerByte (Right witnessTag)
-
-    txRewardWithdrawalSize =
-        _txRewardWithdrawalSize (Right witnessTag)
-
-    txMaximumSize = protocolParams
-        & view (#txParameters . #getTxMaxSize)
-        & getQuantity
-        & fromIntegral
-        & TxSize
-
-    empty :: TxSkeleton
-    empty = emptyTxSkeleton witnessTag
-
-    -- Computes the size difference between the given skeleton and an empty
-    -- skeleton.
-    marginalCostOf :: TxSkeleton -> Coin
-    marginalCostOf skeleton =
-        Coin.distance
-            (estimateTxCost feePerByte empty)
-            (estimateTxCost feePerByte skeleton)
-
-    -- Computes the size difference between the given skeleton and an empty
-    -- skeleton.
-    marginalSizeOf :: TxSkeleton -> TxSize
-    marginalSizeOf =
-        txSizeDistance txBaseSize . estimateTxSize
-
-    -- Constructs a real transaction output from a token bundle.
-    mkTxOut :: TokenBundle -> TxOut
-    mkTxOut = TxOut dummyAddress
-      where
-        dummyAddress :: Address
-        dummyAddress = Address $ BS.replicate dummyAddressLength nullByte
-
-        dummyAddressLength :: Int
-        dummyAddressLength = 57
-        -- Note: We are at liberty to overestimate the length of an address
-        -- (which is safe). Therefore, we can choose a length that we know is
-        -- greater than or equal to all address lengths.
-
-        nullByte :: Word8
-        nullByte = 0
-
--- | Includes just the parts of a transaction necessary to estimate its size.
---
--- In particular, this record type includes the minimal set of data needed for
--- the 'estimateTxCost' and 'estimateTxSize' functions to perform their
--- calculations, and nothing else.
---
--- The data included in 'TxSkeleton' is a subset of the data included in the
--- union of 'SelectionSkeleton' and 'TransactionCtx'.
---
-data TxSkeleton = TxSkeleton
-    { txWitnessTag :: !TxWitnessTag
-    , txInputCount :: !Int
-    , txOutputs :: ![TxOut]
-    , txChange :: ![Set AssetId]
-    , txPaymentTemplate :: !(Maybe (Script Cosigner))
-    }
-    deriving (Eq, Show, Generic)
-
--- | Constructs an empty transaction skeleton.
---
--- This may be used to estimate the size and cost of an empty transaction.
---
-emptyTxSkeleton :: TxWitnessTag -> TxSkeleton
-emptyTxSkeleton txWitnessTag = TxSkeleton
-    { txWitnessTag
-    , txInputCount = 0
-    , txOutputs = []
-    , txChange = []
-    , txPaymentTemplate = Nothing
-    }
-
--- | Constructs a transaction skeleton from wallet primitive types.
---
--- This function extracts a subset of the data included in 'SelectionSkeleton'
--- and 'TransactionCtx'.
---
-mkTxSkeleton
-    :: TxWitnessTag
-    -> TransactionCtx
-    -> SelectionSkeleton
-    -> TxSkeleton
-mkTxSkeleton witness context skeleton = TxSkeleton
-    { txWitnessTag = witness
-    , txInputCount = view #skeletonInputCount skeleton
-    , txOutputs = view #skeletonOutputs skeleton
-    , txChange = view #skeletonChange skeleton
-    , txPaymentTemplate =
-        template <$>
-        view #txPaymentCredentialScriptTemplate context
-    }
-
--- | Estimates the final cost of a transaction based on its skeleton.
---
--- The constant tx fee is /not/ included in the result of this function.
-estimateTxCost :: FeePerByte -> TxSkeleton -> Coin
-estimateTxCost (FeePerByte feePerByte) skeleton =
-    computeFee (estimateTxSize skeleton)
-  where
-    computeFee :: TxSize -> Coin
-    computeFee (TxSize size) = Coin $ feePerByte * size
 
 -- | Calculate the cost of increasing a CBOR-encoded Coin-value by another Coin
 -- with the lovelace/byte cost given by the 'FeePolicy'.
@@ -1274,395 +1023,6 @@ burnSurplusAsFees feePolicy surplus (TxFeeAndChange fee0 ())
   where
     costOfBurningSurplus = costOfIncreasingCoin feePolicy fee0 surplus
     shortfall = costOfBurningSurplus `Coin.difference` surplus
-
--- | Estimates the final size of a transaction based on its skeleton.
---
--- This function uses the upper bounds of CBOR serialized objects as the basis
--- for many of its calculations. The following document is used as a reference:
---
--- https://github.com/input-output-hk/cardano-ledger/blob/master/eras/shelley/test-suite/cddl-files/shelley.cddl
--- https://github.com/input-output-hk/cardano-ledger/blob/master/eras/shelley-ma/test-suite/cddl-files/shelley-ma.cddl
--- https://github.com/input-output-hk/cardano-ledger/blob/master/eras/alonzo/test-suite/cddl-files/alonzo.cddl
---
-estimateTxSize
-    :: TxSkeleton
-    -> TxSize
-estimateTxSize skeleton =
-    sizeOf_Transaction
-  where
-    TxSkeleton
-        { txWitnessTag
-        , txInputCount
-        , txOutputs
-        , txChange
-        , txPaymentTemplate
-        } = skeleton
-
-    numberOf_Inputs :: Natural
-    numberOf_Inputs
-        = fromIntegral txInputCount
-
-    numberOf_ScriptVkeyWitnessesForPayment
-        = maybe 0 estimateMaxWitnessRequiredPerInput txPaymentTemplate
-
-    numberOf_VkeyWitnesses
-        = case txWitnessTag of
-            TxWitnessByronUTxO -> 0
-            TxWitnessShelleyUTxO ->
-                -- there cannot be missing payment script if there is delegation script
-                -- the latter is optional
-                if numberOf_ScriptVkeyWitnessesForPayment == 0 then
-                    numberOf_Inputs
-                else
-                    (numberOf_Inputs * numberOf_ScriptVkeyWitnessesForPayment)
-
-    numberOf_BootstrapWitnesses
-        = case txWitnessTag of
-            TxWitnessByronUTxO -> numberOf_Inputs
-            TxWitnessShelleyUTxO -> 0
-
-    -- transaction =
-    --   [ transaction_body
-    --   , transaction_witness_set
-    --   , transaction_metadata / null
-    --   ]
-    sizeOf_Transaction
-        = sizeOf_SmallArray
-        + sizeOf_TransactionBody
-        + sizeOf_WitnessSet
-
-    -- transaction_body =
-    --   { 0 : set<transaction_input>
-    --   , 1 : [* transaction_output]
-    --   , 2 : coin ; fee
-    --   , 3 : uint ; ttl
-    --   , ? 4 : [* certificate]
-    --   , ? 5 : withdrawals
-    --   , ? 6 : update
-    --   , ? 7 : metadata_hash
-    --   , ? 8 : uint ; validity interval start
-    --   , ? 9 : mint
-    --   }
-    sizeOf_TransactionBody
-        = sizeOf_SmallMap
-        + sizeOf_Inputs
-        + sizeOf_Outputs
-        + sizeOf_Fee
-        + sizeOf_Ttl
-        + sizeOf_Update
-        + sizeOf_ValidityIntervalStart
-        + sizeOf_HistoricalPadding
-      where
-        -- Preserved out of caution during refactoring. We should be able to
-        -- drop this, but we may as well wait until we have completely
-        -- water-proof testing of the size estimation, e.g:
-        -- prop> forall baseTx update.
-        --      sizeOf_Update x >=
-        --          (serializedSize (update baseTx)
-        --          - serializedSize baseTx)
-        -- where update is something similar to 'TxUpdate' or 'TxSkeleton'.
-        sizeOf_HistoricalPadding = sizeOf_NoMetadata
-          where
-            -- When it's "empty", metadata are represented by a special
-            -- "null byte" in CBOR `F6`.
-            sizeOf_NoMetadata = 1
-
-        -- 0 => set<transaction_input>
-        sizeOf_Inputs
-            = sizeOf_SmallUInt
-            + sizeOf_Array
-            + sizeOf_Input * TxSize numberOf_Inputs
-
-        -- 1 => [* transaction_output]
-        sizeOf_Outputs
-            = sizeOf_SmallUInt
-            + sizeOf_Array
-            + F.sum (sizeOf_Output <$> txOutputs)
-            + F.sum (sizeOf_ChangeOutput <$> txChange)
-
-        -- 2 => fee
-        sizeOf_Fee
-            = sizeOf_SmallUInt
-            + sizeOf_UInt
-
-        -- 3 => ttl
-        sizeOf_Ttl
-            = sizeOf_SmallUInt
-            + sizeOf_UInt
-
-        -- ?6 => update
-        sizeOf_Update
-            = 0 -- Assuming no updates is running through cardano-wallet
-
-        -- ?8 => uint ; validity interval start
-        sizeOf_ValidityIntervalStart
-            = sizeOf_UInt
-
-    -- transaction_input =
-    --   [ transaction_id : $hash32
-    --   , index : uint
-    --   ]
-    sizeOf_Input
-        = sizeOf_SmallArray
-        + sizeOf_Hash32
-        + sizeOf_UInt
-
-    -- post_alonzo_transaction_output =
-    --   { 0 : address
-    --   , 1 : value
-    --   , ? 2 : datum_option ; New; datum option
-    --   , ? 3 : script_ref   ; New; script reference
-    --   }
-    -- value =
-    --   coin / [coin,multiasset<uint>]
-    sizeOf_PostAlonzoTransactionOutput TxOut {address, tokens}
-        = sizeOf_SmallMap
-        + sizeOf_SmallUInt
-        + sizeOf_Address address
-        + sizeOf_SmallUInt
-        + sizeOf_SmallArray
-        + sizeOf_Coin (TokenBundle.getCoin tokens)
-        + sumVia sizeOf_NativeAsset (TokenBundle.getAssets tokens)
-
-    sizeOf_Output
-        = sizeOf_PostAlonzoTransactionOutput
-
-    sizeOf_ChangeOutput :: Set AssetId -> TxSize
-    sizeOf_ChangeOutput
-        = sizeOf_PostAlonzoChangeOutput
-
-    -- post_alonzo_transaction_output =
-    --   { 0 : address
-    --   , 1 : value
-    --   , ? 2 : datum_option ; New; datum option
-    --   , ? 3 : script_ref   ; New; script reference
-    --   }
-    -- value =
-    --   coin / [coin,multiasset<uint>]
-    sizeOf_PostAlonzoChangeOutput :: Set AssetId -> TxSize
-    sizeOf_PostAlonzoChangeOutput xs
-        = sizeOf_SmallMap
-        + sizeOf_SmallUInt
-        + sizeOf_ChangeAddress
-        + sizeOf_SmallMap
-        + sizeOf_SmallUInt
-        + sizeOf_LargeUInt
-        + sumVia sizeOf_NativeAsset xs
-
-    -- We carry addresses already serialized, so it's a matter of measuring.
-    sizeOf_Address addr
-        = 2 + fromIntegral (BS.length (unAddress addr))
-
-    -- For change address, we consider the worst-case scenario based on the
-    -- given wallet scheme. Byron addresses are larger.
-    --
-    -- NOTE: we could do slightly better if we wanted to for Byron addresses and
-    -- discriminate based on the network as well since testnet addresses are
-    -- larger than mainnet ones. But meh.
-    sizeOf_ChangeAddress
-        = case txWitnessTag of
-            TxWitnessByronUTxO -> 85
-            TxWitnessShelleyUTxO -> 59
-
-    -- value = coin / [coin,multiasset<uint>]
-    -- We consider "native asset" to just be the "multiasset<uint>" part of the
-    -- above, hence why we don't also include the size of the coin. Where this
-    -- is used, the size of the coin and array are are added too.
-    sizeOf_NativeAsset AssetId{tokenName}
-        = sizeOf_MultiAsset sizeOf_LargeUInt tokenName
-
-    -- multiasset<a> = { * policy_id => { * asset_name => a } }
-    -- policy_id = scripthash
-    -- asset_name = bytes .size (0..32)
-    sizeOf_MultiAsset sizeOf_a name
-      = sizeOf_SmallMap -- NOTE: Assuming < 23 policies per output
-      + sizeOf_Hash28
-      + sizeOf_SmallMap -- NOTE: Assuming < 23 assets per policy
-      + sizeOf_AssetName name
-      + sizeOf_a
-
-    -- asset_name = bytes .size (0..32)
-    sizeOf_AssetName name
-        = 2 + fromIntegral (BS.length $ unTokenName name)
-
-    -- Coins can really vary so it's very punishing to always assign them the
-    -- upper bound. They will typically be between 3 and 9 bytes (only 6 bytes
-    -- difference, but on 20+ outputs, one starts feeling it).
-    --
-    -- So, for outputs, since we have the values, we can compute it accurately.
-    sizeOf_Coin
-        = TxSize
-        . fromIntegral
-        . BS.length
-        . CBOR.toStrictByteString
-        . CBOR.encodeWord64
-        . Coin.unsafeToWord64
-
-    determinePaymentTemplateSize scriptCosigner
-        = sizeOf_Array
-        + sizeOf_SmallUInt
-        + TxSize numberOf_Inputs * (sizeOf_NativeScript scriptCosigner)
-
-    -- transaction_witness_set =
-    --   { ?0 => [* vkeywitness ]
-    --   , ?1 => [* native_script ]
-    --   , ?2 => [* bootstrap_witness ]
-    --   }
-    sizeOf_WitnessSet
-        = sizeOf_SmallMap
-        + sizeOf_VKeyWitnesses numberOf_VkeyWitnesses
-        + maybe 0 determinePaymentTemplateSize txPaymentTemplate
-        -- FIXME: Payment template needs to be multiplied with number of inputs
-        + sizeOf_BootstrapWitnesses numberOf_BootstrapWitnesses
-
--- ?5 => withdrawals
-sizeOf_Withdrawals :: Natural -> TxSize
-sizeOf_Withdrawals n
-    = (if n > 0
-        then sizeOf_SmallUInt + sizeOf_SmallMap
-        else 0)
-    + sizeOf_Withdrawal * (TxSize n)
-
-  where
-    -- withdrawals =
-    --   { * reward_account => coin }
-    sizeOf_Withdrawal
-        = sizeOf_Hash28
-        + sizeOf_LargeUInt
-
--- ?0 => [* vkeywitness ]
-sizeOf_VKeyWitnesses :: Natural -> TxSize
-sizeOf_VKeyWitnesses n
-    = (if n > 0
-        then sizeOf_Array + sizeOf_SmallUInt else 0)
-    + sizeOf_VKeyWitness * (TxSize n)
-
--- ?2 => [* bootstrap_witness ]
-sizeOf_BootstrapWitnesses :: Natural -> TxSize
-sizeOf_BootstrapWitnesses n
-    = (if n > 0
-        then sizeOf_Array + sizeOf_SmallUInt
-        else 0)
-    + sizeOf_BootstrapWitness * (TxSize n)
-
--- vkeywitness =
---  [ $vkey
---  , $signature
---  ]
-sizeOf_VKeyWitness :: TxSize
-sizeOf_VKeyWitness
-    = sizeOf_SmallArray
-    + sizeOf_VKey
-    + sizeOf_Signature
-
--- bootstrap_witness =
---  [ public_key : $vkey
---  , signature  : $signature
---  , chain_code : bytes .size 32
---  , attributes : bytes
---  ]
-sizeOf_BootstrapWitness :: TxSize
-sizeOf_BootstrapWitness
-    = sizeOf_SmallArray
-    + sizeOf_VKey
-    + sizeOf_Signature
-    + sizeOf_ChainCode
-    + sizeOf_Attributes
-  where
-    sizeOf_ChainCode  = 34
-    sizeOf_Attributes = 45 -- NOTE: could be smaller by ~34 for Icarus
-
--- native_script =
---   [ script_pubkey      = (0, addr_keyhash)
---   // script_all        = (1, [ * native_script ])
---   // script_any        = (2, [ * native_script ])
---   // script_n_of_k     = (3, n: uint, [ * native_script ])
---   // invalid_before    = (4, uint)
---      ; Timelock validity intervals are half-open intervals [a, b).
---      ; This field specifies the left (included) endpoint a.
---   // invalid_hereafter = (5, uint)
---      ; Timelock validity intervals are half-open intervals [a, b).
---      ; This field specifies the right (excluded) endpoint b.
---   ]
-sizeOf_NativeScript :: Script object -> TxSize
-sizeOf_NativeScript = \case
-    RequireSignatureOf _ ->
-        sizeOf_SmallUInt + sizeOf_Hash28
-    RequireAllOf ss ->
-        sizeOf_SmallUInt + sizeOf_Array + sumVia sizeOf_NativeScript ss
-    RequireAnyOf ss ->
-        sizeOf_SmallUInt + sizeOf_Array + sumVia sizeOf_NativeScript ss
-    RequireSomeOf _ ss ->
-        sizeOf_SmallUInt
-            + sizeOf_UInt
-            + sizeOf_Array
-            + sumVia sizeOf_NativeScript ss
-    ActiveFromSlot _ ->
-        sizeOf_SmallUInt + sizeOf_UInt
-    ActiveUntilSlot _ ->
-        sizeOf_SmallUInt + sizeOf_UInt
-
--- A Blake2b-224 hash, resulting in a 28-byte digest wrapped in CBOR, so
--- with 2 bytes overhead (length <255, but length > 23)
-sizeOf_Hash28 :: TxSize
-sizeOf_Hash28
-    = 30
-
--- A Blake2b-256 hash, resulting in a 32-byte digest wrapped in CBOR, so
--- with 2 bytes overhead (length <255, but length > 23)
-sizeOf_Hash32 :: TxSize
-sizeOf_Hash32
-    = 34
-
--- A 32-byte Ed25519 public key, encoded as a CBOR-bytestring so with 2
--- bytes overhead (length < 255, but length > 23)
-sizeOf_VKey :: TxSize
-sizeOf_VKey
-    = 34
-
--- A 64-byte Ed25519 signature, encoded as a CBOR-bytestring so with 2
--- bytes overhead (length < 255, but length > 23)
-sizeOf_Signature :: TxSize
-sizeOf_Signature
-    = 66
-
--- A CBOR UInt which is less than 23 in value fits on a single byte. Beyond,
--- the first byte is used to encode the number of bytes necessary to encode
--- the number itself, followed by the number itself.
---
--- When considering a 'UInt', we consider the worst case scenario only where
--- the uint is encoded over 4 bytes, so up to 2^32 which is fine for most
--- cases but coin values.
-sizeOf_SmallUInt :: TxSize
-sizeOf_SmallUInt = 1
-
-sizeOf_UInt :: TxSize
-sizeOf_UInt = 5
-
-sizeOf_LargeUInt :: TxSize
-sizeOf_LargeUInt = 9
-
--- A CBOR array with less than 23 elements, fits on a single byte, followed
--- by each key-value pair (encoded as two concatenated CBOR elements).
-sizeOf_SmallMap :: TxSize
-sizeOf_SmallMap = 1
-
--- A CBOR array with less than 23 elements, fits on a single byte, followed
--- by each elements. Otherwise, the length of the array is encoded first,
--- very much like for UInt.
---
--- When considering an 'Array', we consider large scenarios where arrays can
--- have up to 65536 elements.
-sizeOf_SmallArray :: TxSize
-sizeOf_SmallArray = 1
-
-sizeOf_Array :: TxSize
-sizeOf_Array = 3
-
--- Small helper function for summing values. Given a list of values, get the sum
--- of the values, after the given function has been applied to each value.
-sumVia :: (Foldable t, Num m) => (a -> m) -> t a -> m
-sumVia f = F.foldl' (\t -> (t +) . f) 0
 
 withShelleyBasedEra
     :: forall a
@@ -2062,3 +1422,8 @@ explicitFees era = case era of
         Cardano.TxFeeExplicit Cardano.TxFeesExplicitInBabbageEra
     ShelleyBasedEraConway ->
         Cardano.TxFeeExplicit Cardano.TxFeesExplicitInConwayEra
+
+-- Small helper function for summing values. Given a list of values, get the sum
+-- of the values, after the given function has been applied to each value.
+sumVia :: (Foldable t, Num m) => (a -> m) -> t a -> m
+sumVia f = F.foldl' (\t -> (t +) . f) 0

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE RoleAnnotations #-}

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -52,7 +52,6 @@ module Cardano.Wallet.Transaction
     , ErrMkTransaction (..)
     , ErrCannotJoin (..)
     , ErrCannotQuit (..)
-    , ErrAssignRedeemers(..)
     , ErrMoreSurplusNeeded (..)
     ) where
 
@@ -66,10 +65,6 @@ import Cardano.Api
     ( AnyCardanoEra )
 import Cardano.Api.Extra
     ()
-import Cardano.Ledger.Alonzo.TxInfo
-    ( TranslationError (..) )
-import Cardano.Ledger.Crypto
-    ( StandardCrypto )
 import Cardano.Pool.Types
     ( PoolId )
 import Cardano.Tx.Balance.Internal.CoinSelection
@@ -92,8 +87,6 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
-import Cardano.Wallet.Primitive.Types.Redeemer
-    ( Redeemer )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount )
 import Cardano.Wallet.Primitive.Types.TokenMap
@@ -425,15 +418,6 @@ data ErrMkTransaction
     | ErrMkTransactionJoinStakePool ErrCannotJoin
     | ErrMkTransactionQuitStakePool ErrCannotQuit
     | ErrMkTransactionIncorrectTTL PastHorizonException
-    deriving (Generic, Eq, Show)
-
-data ErrAssignRedeemers
-    = ErrAssignRedeemersScriptFailure Redeemer String
-    | ErrAssignRedeemersTargetNotFound Redeemer
-    -- ^ The given redeemer target couldn't be located in the transaction.
-    | ErrAssignRedeemersInvalidData Redeemer String
-    -- ^ Redeemer's data isn't a valid Plutus' data.
-    | ErrAssignRedeemersTranslationError (TranslationError StandardCrypto)
     deriving (Generic, Eq, Show)
 
 -- | Possible signing error

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -91,7 +90,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenPolicyId )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessor, TxConstraints )
+    ( TokenBundleSizeAssessor )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
     ( Tx (..), TxMetadata )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
@@ -121,7 +120,6 @@ import GHC.Generics
 
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Write.ProtocolParameters as Write
 import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -121,6 +121,7 @@ import GHC.Generics
 
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Write.ProtocolParameters as Write
 import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -196,12 +196,6 @@ data TransactionLayer k ktype tx = TransactionLayer
         :: TokenBundleMaxSize -> TokenBundleSizeAssessor
         -- ^ A function to assess the size of a token bundle.
 
-    , constraints
-        :: ProtocolParameters
-        -- Current protocol parameters.
-        -> TxConstraints
-        -- The set of constraints that apply to all transactions.
-
     , decodeTx
         :: AnyCardanoEra
         -> WitnessCountCtx

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -39,8 +39,6 @@ module Cardano.Wallet.Transaction
     , PlutusVersion (..)
     , ScriptReference (..)
     , ReferenceInput (..)
-    , TxFeeAndChange (..)
-    , mapTxFeeAndChange
     , ValidityIntervalExplicit (..)
     , WitnessCount (..)
     , emptyWitnessCount
@@ -52,7 +50,6 @@ module Cardano.Wallet.Transaction
     , ErrMkTransaction (..)
     , ErrCannotJoin (..)
     , ErrCannotQuit (..)
-    , ErrMoreSurplusNeeded (..)
     ) where
 
 import Prelude
@@ -431,34 +428,6 @@ data ErrCannotQuit
     = ErrNotDelegatingOrAboutTo
     | ErrNonNullRewards Coin
     deriving (Eq, Show)
-
--- | Error for when its impossible for 'distributeSurplus' to distribute the
--- surplus. As long as the surplus is larger than 'costOfIncreasingCoin', this
--- should never happen.
-newtype ErrMoreSurplusNeeded = ErrMoreSurplusNeeded Coin
-    deriving (Generic, Eq, Show)
-
--- | Small helper record to disambiguate between a fee and change Coin values.
--- Used by 'distributeSurplus'.
-data TxFeeAndChange change = TxFeeAndChange
-    { fee :: Coin
-    , change :: change
-    }
-    deriving (Eq, Show)
-
--- | Manipulates a 'TxFeeAndChange' value.
---
-mapTxFeeAndChange
-    :: (Coin -> Coin)
-    -- ^ A function to transform the fee
-    -> (change1 -> change2)
-    -- ^ A function to transform the change
-    -> TxFeeAndChange change1
-    -- ^ The original fee and change
-    -> TxFeeAndChange change2
-    -- ^ The transformed fee and change
-mapTxFeeAndChange mapFee mapChange TxFeeAndChange {fee, change} =
-    TxFeeAndChange (mapFee fee) (mapChange change)
 
 data ValidityIntervalExplicit = ValidityIntervalExplicit
     { invalidBefore :: !(Quantity "slot" Word64)

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -30,6 +30,7 @@ module Cardano.Wallet.Write.Tx.Balance
     , ErrBalanceTxInternalError (..)
     , ErrSelectAssets (..)
     , ErrUpdateSealedTx (..)
+    , ErrAssignRedeemers (..)
 
     -- * Change addresses
     , ChangeAddressGen (..)
@@ -110,14 +111,13 @@ import Cardano.Wallet.Shelley.Compatibility
 import Cardano.Wallet.Shelley.Transaction
     ( KeyWitnessCount (..)
     , TxSkeleton (..)
-    , assignScriptRedeemers
     , distributeSurplus
     , estimateKeyWitnessCount
     , estimateSignedTxSize
     , estimateTxCost
     )
 import Cardano.Wallet.Transaction
-    ( ErrAssignRedeemers, ErrMoreSurplusNeeded (..), TxFeeAndChange (..) )
+    ( ErrMoreSurplusNeeded (..), TxFeeAndChange (..) )
 import Cardano.Wallet.Write.ProtocolParameters
     ( ProtocolParameters (..) )
 import Cardano.Wallet.Write.Tx
@@ -143,6 +143,8 @@ import Cardano.Wallet.Write.Tx
     , txBody
     , withConstraints
     )
+import Cardano.Wallet.Write.Tx.Redeemers
+    ( ErrAssignRedeemers (..), assignScriptRedeemers )
 import Cardano.Wallet.Write.Tx.TimeTranslation
     ( TimeTranslation )
 import Cardano.Wallet.Write.UTxOAssumptions

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -49,6 +49,7 @@ module Cardano.Wallet.Write.Tx.Balance
 
     -- * Utilities
     , posAndNegFromCardanoValue
+    , fromWalletUTxO
 
     -- ** updateTx
     , TxUpdate (..)
@@ -370,11 +371,15 @@ constructUTxOIndex walletUTxO =
   where
     era = recentEra @era
     walletUTxOIndex = UTxOIndex.fromMap $ toInternalUTxOMap walletUTxO
-    ledgerUTxO = fromWalletUTxO walletUTxO
+    ledgerUTxO = fromWalletUTxO era walletUTxO
 
-    fromWalletUTxO (W.UTxO m) = withConstraints era $ UTxO
-        $ Map.mapKeys W.toLedger
-        $ Map.map (toLedgerTxOut era) m
+fromWalletUTxO
+    :: RecentEra era
+    -> W.UTxO
+    -> UTxO (ShelleyLedgerEra era)
+fromWalletUTxO era (W.UTxO m) = withConstraints era $ UTxO
+    $ Map.mapKeys W.toLedger
+    $ Map.map (toLedgerTxOut era) m
 
 balanceTransaction
     :: forall era m changeState.

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -109,7 +109,7 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
 import Cardano.Wallet.Shelley.Compatibility
     ( fromCardanoTxIn, fromCardanoTxOut, toCardanoSimpleScript, toCardanoUTxO )
 import Cardano.Wallet.Shelley.Transaction
-    ( distributeSurplus, estimateKeyWitnessCount, estimateSignedTxSize )
+    ( distributeSurplus )
 import Cardano.Wallet.Transaction
     ( ErrMoreSurplusNeeded (..), TxFeeAndChange (..) )
 import Cardano.Wallet.Write.ProtocolParameters
@@ -142,6 +142,8 @@ import Cardano.Wallet.Write.Tx.Balance.CoinSelection
     ( TxSkeleton (..), estimateTxCost )
 import Cardano.Wallet.Write.Tx.Redeemers
     ( ErrAssignRedeemers (..), assignScriptRedeemers )
+import Cardano.Wallet.Write.Tx.Sign
+    ( estimateKeyWitnessCount, estimateSignedTxSize )
 import Cardano.Wallet.Write.Tx.TimeTranslation
     ( TimeTranslation )
 import Cardano.Wallet.Write.UTxOAssumptions

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -19,6 +19,7 @@
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 902
 {-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}
+{-# LANGUAGE NumericUnderscores #-}
 #endif
 
 module Cardano.Wallet.Write.Tx.Balance
@@ -48,11 +49,21 @@ module Cardano.Wallet.Write.Tx.Balance
 
     -- * Utilities
     , posAndNegFromCardanoValue
+
+    -- ** updateTx
     , TxUpdate (..)
     , noTxUpdate
     , updateTx
     , TxFeeUpdate (..)
 
+    -- ** distributeSurplus
+    , distributeSurplus
+    , distributeSurplusDelta
+    , sizeOfCoin
+    , maximumCostOfIncreasingCoin
+    , costOfIncreasingCoin
+    , TxFeeAndChange (..)
+    , ErrMoreSurplusNeeded (..)
     )
     where
 
@@ -108,15 +119,12 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     ( fromCardanoValue )
 import Cardano.Wallet.Shelley.Compatibility
     ( fromCardanoTxIn, fromCardanoTxOut, toCardanoSimpleScript, toCardanoUTxO )
-import Cardano.Wallet.Shelley.Transaction
-    ( distributeSurplus )
-import Cardano.Wallet.Transaction
-    ( ErrMoreSurplusNeeded (..), TxFeeAndChange (..) )
 import Cardano.Wallet.Write.ProtocolParameters
     ( ProtocolParameters (..) )
 import Cardano.Wallet.Write.Tx
-    ( IsRecentEra (..)
-    , KeyWitnessCount
+    ( FeePerByte (..)
+    , IsRecentEra (..)
+    , KeyWitnessCount (..)
     , PParams
     , RecentEra (..)
     , ShelleyLedgerEra
@@ -216,6 +224,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
@@ -223,6 +232,8 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as W
 import qualified Data.Foldable as F
+import Data.Functor
+    ( (<&>) )
 import qualified Data.List as L
 import qualified Data.Map as Map
 import qualified Data.Sequence.Strict as StrictSeq
@@ -1168,3 +1179,220 @@ modifyShelleyTxBody txUpdate era = withConstraints era $
         RecentEraBabbage -> W.toBabbageTxOut
         RecentEraConway -> W.toConwayTxOut
 
+--
+-- distributeSurplus
+--
+
+-- | Error for when its impossible for 'distributeSurplus' to distribute the
+-- surplus. As long as the surplus is larger than 'costOfIncreasingCoin', this
+-- should never happen.
+newtype ErrMoreSurplusNeeded = ErrMoreSurplusNeeded W.Coin
+    deriving (Generic, Eq, Show)
+
+-- | Small helper record to disambiguate between a fee and change Coin values.
+-- Used by 'distributeSurplus'.
+data TxFeeAndChange change = TxFeeAndChange
+    { fee :: W.Coin
+    , change :: change
+    }
+    deriving (Eq, Show)
+
+-- | Manipulates a 'TxFeeAndChange' value.
+--
+mapTxFeeAndChange
+    :: (W.Coin -> W.Coin)
+    -- ^ A function to transform the fee
+    -> (change1 -> change2)
+    -- ^ A function to transform the change
+    -> TxFeeAndChange change1
+    -- ^ The original fee and change
+    -> TxFeeAndChange change2
+    -- ^ The transformed fee and change
+mapTxFeeAndChange mapFee mapChange TxFeeAndChange {fee, change} =
+    TxFeeAndChange (mapFee fee) (mapChange change)
+
+
+-- | Calculate the cost of increasing a CBOR-encoded Coin-value by another Coin
+-- with the lovelace/byte cost given by the 'FeePolicy'.
+--
+-- Outputs values in the range of [0, 8 * perByteFee]
+--
+-- >>> let p = FeePolicy (Quantity 0) (Quantity 44)
+--
+-- >>> costOfIncreasingCoin p 4294967295 1
+-- Coin 176 -- (9 bytes - 5 bytes) * 44 lovelace/byte
+--
+-- >>> costOfIncreasingCoin p 0 4294967296
+-- Coin 352 -- 8 bytes * 44 lovelace/byte
+costOfIncreasingCoin
+    :: FeePerByte
+    -> W.Coin -- ^ Original coin
+    -> W.Coin -- ^ Increment
+    -> W.Coin
+costOfIncreasingCoin (FeePerByte perByte) from delta =
+    costOfCoin (from <> delta) `Coin.difference` costOfCoin from
+  where
+    costOfCoin = W.Coin . (perByte *) . unTxSize . sizeOfCoin
+
+-- The maximum cost increase 'costOfIncreasingCoin' can return, which is the
+-- cost of 8 bytes.
+maximumCostOfIncreasingCoin :: FeePerByte -> W.Coin
+maximumCostOfIncreasingCoin (FeePerByte perByte) = W.Coin $ 8 * perByte
+
+-- | Calculate the size of a coin when encoded as CBOR.
+sizeOfCoin :: W.Coin -> TxSize
+sizeOfCoin (W.Coin c)
+    | c >= 4_294_967_296 = TxSize 9 -- c >= 2^32
+    | c >=        65_536 = TxSize 5 -- c >= 2^16
+    | c >=           256 = TxSize 3 -- c >= 2^ 8
+    | c >=            24 = TxSize 2
+    | otherwise          = TxSize 1
+
+-- | Distributes a surplus transaction balance between the given change
+-- outputs and the given fee. This function is aware of the fact that
+-- any increase in a 'Coin' value could increase the size and fee
+-- requirement of a transaction.
+--
+-- When comparing the original fee and change outputs to the adjusted
+-- fee and change outputs, this function guarantees that:
+--
+--    - The number of the change outputs remains constant;
+--
+--    - The fee quantity either remains the same or increases.
+--
+--    - For each change output:
+--        - the ada quantity either remains constant or increases.
+--        - non-ada quantities remain the same.
+--
+--    - The surplus is conserved:
+--        The total increase in the fee and change ada quantities is
+--        exactly equal to the surplus.
+--
+--    - Any increase in cost is covered:
+--        If the total cost has increased by 𝛿c, then the fee value
+--        will have increased by at least 𝛿c.
+--
+-- If the cost of distributing the provided surplus is greater than the
+-- surplus itself, the function will return 'ErrMoreSurplusNeeded'. If
+-- the provided surplus is greater or equal to
+-- @maximumCostOfIncreasingCoin feePolicy@, the function will always
+-- return 'Right'.
+distributeSurplus
+    :: FeePerByte
+    -> W.Coin
+    -- ^ Surplus transaction balance to distribute.
+    -> TxFeeAndChange [W.TxOut]
+    -- ^ Original fee and change outputs.
+    -> Either ErrMoreSurplusNeeded (TxFeeAndChange [W.TxOut])
+    -- ^ Adjusted fee and change outputs.
+distributeSurplus feePolicy surplus fc@(TxFeeAndChange fee change) =
+    distributeSurplusDelta feePolicy surplus
+        (mapTxFeeAndChange id (fmap W.TxOut.coin) fc)
+    <&> mapTxFeeAndChange
+        (fee <>)
+        (zipWith (flip W.TxOut.addCoin) change)
+
+distributeSurplusDelta
+    :: FeePerByte
+    -> W.Coin
+    -- ^ Surplus to distribute
+    -> TxFeeAndChange [W.Coin]
+    -> Either ErrMoreSurplusNeeded (TxFeeAndChange [W.Coin])
+distributeSurplusDelta feePolicy surplus (TxFeeAndChange fee change) =
+    case change of
+        changeHead : changeTail ->
+            distributeSurplusDeltaWithOneChangeCoin feePolicy surplus
+                (TxFeeAndChange fee changeHead)
+            <&> mapTxFeeAndChange id
+                (: (W.Coin 0 <$ changeTail))
+        [] ->
+            burnSurplusAsFees feePolicy surplus
+                (TxFeeAndChange fee ())
+            <&> mapTxFeeAndChange id
+                (\() -> [])
+
+distributeSurplusDeltaWithOneChangeCoin
+    :: FeePerByte
+    -> W.Coin -- ^ Surplus to distribute
+    -> TxFeeAndChange W.Coin
+    -> Either ErrMoreSurplusNeeded (TxFeeAndChange W.Coin)
+distributeSurplusDeltaWithOneChangeCoin
+    feePolicy surplus fc@(TxFeeAndChange fee0 change0) =
+    let
+        -- We calculate the maximum possible fee increase, by assuming the
+        -- **entire** surplus is added to the change.
+        extraFee = findFixpointIncreasingFeeBy $
+            costOfIncreasingCoin feePolicy change0 surplus
+    in
+        case surplus `Coin.subtract` extraFee of
+            Just extraChange ->
+                Right $ TxFeeAndChange
+                    { fee = extraFee
+                    , change = extraChange
+                    }
+            Nothing ->
+                -- The fee increase from adding the surplus to the change was
+                -- greater than the surplus itself. This could happen if the
+                -- surplus is small.
+                burnSurplusAsFees feePolicy surplus
+                    (mapTxFeeAndChange id (const ()) fc)
+                        <&> mapTxFeeAndChange id (\() -> W.Coin 0)
+  where
+    -- Increasing the fee may itself increase the fee. If that is the case, this
+    -- function will increase the fee further. The process repeats until the fee
+    -- doesn't need to be increased.
+    --
+    -- The function will always converge because the result of
+    -- 'costOfIncreasingCoin' is bounded to @8 * feePerByte@.
+    --
+    -- On mainnet it seems unlikely that the function would recurse more than
+    -- one time, and certainly not more than twice. If the protocol parameters
+    -- are updated to allow for slightly more expensive txs, it might be
+    -- possible to hit the boundary at ≈4 ada where the fee would need 9 bytes
+    -- rather than 5. This is already the largest boundary.
+    --
+    -- Note that both the argument and the result of this function are increases
+    -- relative to 'fee0'.
+    --
+    -- == Example ==
+    --
+    -- In this more extreme example the fee is increased from increasing the fee
+    -- itself:
+    --
+    -- @@
+    --     let fee0 = 23
+    --     let feePolicy = -- 300 lovelace / byte
+    --
+    --     findFixpointIncreasingFeeBy 1 = go 0 1
+    --     -- Recurse:
+    --     = go (0 + 1) (costOfIncreasingCoin feePolicy (23 + 0) 1)
+    --     = go (0 + 1) 300
+    --     -- Recurse:
+    --     = go (1 + 300) (costOfIncreasingCoin feePolicy (23 + 1) 300)
+    --     = go 301 300
+    --     = go (301 + 300) (costOfIncreasingCoin feePolicy (23 + 301) 300)
+    --     = go (301 + 300) 0
+    --     = go 601 0
+    --     = 601
+    -- @@
+    findFixpointIncreasingFeeBy = go mempty
+      where
+        go :: W.Coin -> W.Coin -> W.Coin
+        go c (W.Coin 0) = c
+        go c increase = go
+            (c <> increase)
+            (costOfIncreasingCoin feePolicy (c <> fee0) increase)
+
+burnSurplusAsFees
+    :: FeePerByte
+    -> W.Coin -- Surplus
+    -> TxFeeAndChange ()
+    -> Either ErrMoreSurplusNeeded (TxFeeAndChange ())
+burnSurplusAsFees feePolicy surplus (TxFeeAndChange fee0 ())
+    | shortfall > W.Coin 0 =
+        Left $ ErrMoreSurplusNeeded shortfall
+    | otherwise =
+        Right $ TxFeeAndChange surplus ()
+  where
+    costOfBurningSurplus = costOfIncreasingCoin feePolicy fee0 surplus
+    shortfall = costOfBurningSurplus `Coin.difference` surplus

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -776,6 +776,8 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
       where
          unUTxO (Cardano.UTxO u) = u
 
+    combinedLedgerUTxO = fromCardanoUTxO combinedUTxO
+
     combinedUTxO :: Cardano.UTxO era
     combinedUTxO = Cardano.UTxO $ mconcat
          -- The @Cardano.UTxO@ can contain strictly more information than
@@ -808,7 +810,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         tx' <- left ErrBalanceTxUpdateError $ updateTx partialTx update
         left ErrBalanceTxAssignRedeemers $
             assignScriptRedeemers
-                pp timeTranslation combinedUTxO redeemers tx'
+                pp timeTranslation combinedLedgerUTxO redeemers tx'
 
     guardConflictingWithdrawalNetworks
         (Cardano.Tx (Cardano.TxBody body) _) = do

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -109,19 +109,14 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
 import Cardano.Wallet.Shelley.Compatibility
     ( fromCardanoTxIn, fromCardanoTxOut, toCardanoSimpleScript, toCardanoUTxO )
 import Cardano.Wallet.Shelley.Transaction
-    ( KeyWitnessCount (..)
-    , TxSkeleton (..)
-    , distributeSurplus
-    , estimateKeyWitnessCount
-    , estimateSignedTxSize
-    , estimateTxCost
-    )
+    ( distributeSurplus, estimateKeyWitnessCount, estimateSignedTxSize )
 import Cardano.Wallet.Transaction
     ( ErrMoreSurplusNeeded (..), TxFeeAndChange (..) )
 import Cardano.Wallet.Write.ProtocolParameters
     ( ProtocolParameters (..) )
 import Cardano.Wallet.Write.Tx
     ( IsRecentEra (..)
+    , KeyWitnessCount
     , PParams
     , RecentEra (..)
     , ShelleyLedgerEra
@@ -143,6 +138,8 @@ import Cardano.Wallet.Write.Tx
     , txBody
     , withConstraints
     )
+import Cardano.Wallet.Write.Tx.Balance.CoinSelection
+    ( TxSkeleton (..), estimateTxCost )
 import Cardano.Wallet.Write.Tx.Redeemers
     ( ErrAssignRedeemers (..), assignScriptRedeemers )
 import Cardano.Wallet.Write.Tx.TimeTranslation

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -737,7 +737,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         :: Cardano.Tx era
         -> ExceptT ErrBalanceTx m (Cardano.Value, Cardano.Lovelace, KeyWitnessCount)
     balanceAfterSettingMinFee tx = ExceptT . pure $ do
-        let witCount = estimateKeyWitnessCount combinedUTxO (getBody tx)
+        let witCount = estimateKeyWitnessCount combinedLedgerUTxO (getBody tx)
         let minfee = W.toWalletCoin $ evaluateMinimumFee
                 (recentEra @era) pp (fromCardanoTx tx) witCount
         let update = TxUpdate [] [] [] [] (UseNewTxFee minfee)

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/CoinSelection.hs
@@ -36,7 +36,6 @@ module Cardano.Wallet.Write.Tx.Balance.CoinSelection
     , txConstraints
 
       -- * Needed by the wallet
-    , getFeePerByteFromWalletPParams
     , _txRewardWithdrawalCost
     )
 
@@ -46,14 +45,10 @@ import Prelude
 
 import Cardano.Address.Script
     ( Script (..) )
+import Cardano.Ledger.Api
+    ( ppMaxTxSizeL, ppMaxValSizeL, ppMinFeeBL )
 import Cardano.Wallet.Address.Discovery.Shared
     ( estimateMaxWitnessRequiredPerInput )
-import Cardano.Wallet.Primitive.Types
-    ( FeePolicy (..)
-    , LinearFunction (..)
-    , ProtocolParameters (..)
-    , TxParameters (..)
-    )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -67,54 +62,52 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TxConstraints (..), TxSize (..), txSizeDistance )
-import Cardano.Wallet.Primitive.Types.Tx.TxOut
-    ( TxOut (..) )
+    ( TxConstraints (..), TxSize (..), txOutMaxCoin, txSizeDistance )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( Convert (..) )
-import Cardano.Wallet.Shelley.MinimumUTxO
-    ( computeMinimumCoinForUTxO, isBelowMinimumCoinForUTxO )
 import Cardano.Wallet.TxWitnessTag
     ( TxWitnessTag (..) )
+import Cardano.Wallet.Write.ProtocolParameters
+    ( ProtocolParameters (..) )
 import Cardano.Wallet.Write.Tx
-    ( FeePerByte (..) )
-import Data.Function
-    ( (&) )
+    ( FeePerByte (..)
+    , IsRecentEra (recentEra)
+    , RecentEra (..)
+    , ShelleyLedgerEra
+    , TxOut
+    , computeMinimumCoinForTxOut
+    , getFeePerByte
+    , isBelowMinimumCoinForTxOut
+    , withConstraints
+    )
+import Control.Lens
+    ( (^.) )
 import Data.Generics.Internal.VL.Lens
     ( view )
 import Data.Generics.Labels
     ()
-import Data.IntCast
-    ( intCastMaybe )
-import Data.Maybe
-    ( fromMaybe )
-import Data.Quantity
-    ( Quantity (..) )
 import Data.Set
     ( Set )
 import Data.Word
     ( Word64, Word8 )
 import GHC.Generics
     ( Generic )
+import GHC.Stack
+    ( HasCallStack )
 import Numeric.Natural
     ( Natural )
 
 import qualified Cardano.Address.Script as CA
+import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as W
 import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteString as BS
 import qualified Data.Foldable as F
-
-getFeePerByteFromWalletPParams
-    :: ProtocolParameters
-    -> FeePerByte
-getFeePerByteFromWalletPParams pp =
-    FeePerByte $ ceiling slope
-  where
-    LinearFee LinearFunction{slope} = getFeePolicy $ txParameters pp
 
 -- | Like the 'TxConstraints' field 'txRewardWithdrawalCost', but with added
 -- support for shared wallets via the 'CA.ScriptTemplate' argument.
@@ -155,8 +148,11 @@ _txRewardWithdrawalSize witType _ =
 
 
 txConstraints
-    :: ProtocolParameters -> TxWitnessTag -> TxConstraints
-txConstraints protocolParams witnessTag = TxConstraints
+    :: forall era. IsRecentEra era
+    => ProtocolParameters era
+    -> TxWitnessTag
+    -> TxConstraints
+txConstraints (ProtocolParameters protocolParams) witnessTag = TxConstraints
     { txBaseCost
     , txBaseSize
     , txInputCost
@@ -172,13 +168,15 @@ txConstraints protocolParams witnessTag = TxConstraints
     , txMaximumSize
     }
   where
+    era = recentEra @era
+
     txBaseCost =
         constantTxFee <> estimateTxCost feePerByte empty
 
-    constantTxFee = Coin $ ceiling intercept
-    feePerByte = getFeePerByteFromWalletPParams protocolParams
-    LinearFee LinearFunction {intercept}
-        = getFeePolicy $ txParameters protocolParams
+    constantTxFee = withConstraints era $
+        toWallet $ protocolParams ^. ppMinFeeBL
+
+    feePerByte = getFeePerByte (recentEra @era) protocolParams
 
     txBaseSize =
         estimateTxSize empty
@@ -195,20 +193,24 @@ txConstraints protocolParams witnessTag = TxConstraints
     txOutputSize bundle =
         marginalSizeOf empty {txOutputs = [mkTxOut bundle]}
 
-    txOutputMaximumSize = (<>)
+    txOutputMaximumSize = withConstraints era $ (<>)
         (txOutputSize mempty)
-        (view
-            (#txParameters . #getTokenBundleMaxSize . #unTokenBundleMaxSize)
-            protocolParams)
+        (TxSize (protocolParams ^. ppMaxValSizeL))
 
     txOutputMaximumTokenQuantity =
         TokenQuantity $ fromIntegral $ maxBound @Word64
 
-    txOutputMinimumAdaQuantity =
-        computeMinimumCoinForUTxO (minimumUTxO protocolParams)
+    txOutputMinimumAdaQuantity addr tokens = toWallet $
+        computeMinimumCoinForTxOut
+            era
+            protocolParams
+            (mkLedgerTxOut era addr (TokenBundle txOutMaxCoin tokens))
 
-    txOutputBelowMinimumAdaQuantity =
-        isBelowMinimumCoinForUTxO (minimumUTxO protocolParams)
+    txOutputBelowMinimumAdaQuantity addr bundle =
+            isBelowMinimumCoinForTxOut
+                era
+                protocolParams
+                (mkLedgerTxOut era addr bundle)
 
     txRewardWithdrawalCost =
         _txRewardWithdrawalCost feePerByte (Right witnessTag)
@@ -216,11 +218,8 @@ txConstraints protocolParams witnessTag = TxConstraints
     txRewardWithdrawalSize =
         _txRewardWithdrawalSize (Right witnessTag)
 
-    txMaximumSize = protocolParams
-        & view (#txParameters . #getTxMaxSize)
-        & getQuantity
-        & fromIntegral
-        & TxSize
+    txMaximumSize = withConstraints era $
+        TxSize $ protocolParams ^. ppMaxTxSizeL
 
     empty :: TxSkeleton
     empty = emptyTxSkeleton witnessTag
@@ -240,8 +239,8 @@ txConstraints protocolParams witnessTag = TxConstraints
         txSizeDistance txBaseSize . estimateTxSize
 
     -- Constructs a real transaction output from a token bundle.
-    mkTxOut :: TokenBundle -> TxOut
-    mkTxOut = TxOut dummyAddress
+    mkTxOut :: TokenBundle -> W.TxOut
+    mkTxOut = W.TxOut dummyAddress
       where
         dummyAddress :: Address
         dummyAddress = Address $ BS.replicate dummyAddressLength nullByte
@@ -273,7 +272,7 @@ txConstraints protocolParams witnessTag = TxConstraints
 data TxSkeleton = TxSkeleton
     { txWitnessTag :: !TxWitnessTag
     , txInputCount :: !Int
-    , txOutputs :: ![TxOut]
+    , txOutputs :: ![W.TxOut]
     , txChange :: ![Set AssetId]
     , txPaymentTemplate :: !(Maybe (CA.Script CA.Cosigner))
     }
@@ -442,7 +441,7 @@ estimateTxSize skeleton =
     --   }
     -- value =
     --   coin / [coin,multiasset<uint>]
-    sizeOf_PostAlonzoTransactionOutput TxOut {address, tokens}
+    sizeOf_PostAlonzoTransactionOutput W.TxOut {address, tokens}
         = sizeOf_SmallMap
         + sizeOf_SmallUInt
         + sizeOf_Address address
@@ -691,3 +690,15 @@ sizeOf_Array = 3
 sumVia :: (Foldable t, Num m) => (a -> m) -> t a -> m
 sumVia f = F.foldl' (\t -> (t +) . f) 0
 
+mkLedgerTxOut
+    :: HasCallStack
+    => RecentEra era
+    -> W.Address
+    -> TokenBundle
+    -> TxOut (ShelleyLedgerEra era)
+mkLedgerTxOut txOutEra address bundle =
+    case txOutEra of
+        RecentEraBabbage -> W.toBabbageTxOut txOut
+        RecentEraConway -> W.toConwayTxOut txOut
+      where
+        txOut = W.TxOut address bundle

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/CoinSelection.hs
@@ -47,8 +47,6 @@ import Cardano.Address.Script
     ( Script (..) )
 import Cardano.Ledger.Api
     ( ppMaxTxSizeL, ppMaxValSizeL, ppMinFeeBL )
-import Cardano.Wallet.Address.Discovery.Shared
-    ( estimateMaxWitnessRequiredPerInput )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -80,6 +78,8 @@ import Cardano.Wallet.Write.Tx
     , isBelowMinimumCoinForTxOut
     , withConstraints
     )
+import Cardano.Wallet.Write.Tx.Sign
+    ( estimateMaxWitnessRequiredPerInput )
 import Control.Lens
     ( (^.) )
 import Data.Generics.Internal.VL.Lens

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/CoinSelection.hs
@@ -1,0 +1,693 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{- HLINT ignore "Use <$>" -}
+{- HLINT ignore "Use camelCase" -}
+
+-- |
+-- Copyright: © 2023 IOHK
+-- License: Apache-2.0
+--
+--
+module Cardano.Wallet.Write.Tx.Balance.CoinSelection
+    ( -- Coin-selection for balanceTx
+      -- TODO: Move the actual coin-selection function to here
+      estimateTxSize
+    , estimateTxCost
+    , TxSkeleton (..)
+    , sizeOf_BootstrapWitnesses
+
+      -- * Needed For migration
+    , txConstraints
+
+      -- * Needed by the wallet
+    , getFeePerByteFromWalletPParams
+    , _txRewardWithdrawalCost
+    )
+
+    where
+
+import Prelude
+
+import Cardano.Address.Script
+    ( Script (..) )
+import Cardano.Wallet.Address.Discovery.Shared
+    ( estimateMaxWitnessRequiredPerInput )
+import Cardano.Wallet.Primitive.Types
+    ( FeePolicy (..)
+    , LinearFunction (..)
+    , ProtocolParameters (..)
+    , TxParameters (..)
+    )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle (..) )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( AssetId (..) )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenName (..) )
+import Cardano.Wallet.Primitive.Types.TokenQuantity
+    ( TokenQuantity (..) )
+import Cardano.Wallet.Primitive.Types.Tx.Constraints
+    ( TxConstraints (..), TxSize (..), txSizeDistance )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
+import Cardano.Wallet.Shelley.Compatibility.Ledger
+    ( Convert (..) )
+import Cardano.Wallet.Shelley.MinimumUTxO
+    ( computeMinimumCoinForUTxO, isBelowMinimumCoinForUTxO )
+import Cardano.Wallet.TxWitnessTag
+    ( TxWitnessTag (..) )
+import Cardano.Wallet.Write.Tx
+    ( FeePerByte (..) )
+import Data.Function
+    ( (&) )
+import Data.Generics.Internal.VL.Lens
+    ( view )
+import Data.Generics.Labels
+    ()
+import Data.IntCast
+    ( intCastMaybe )
+import Data.Maybe
+    ( fromMaybe )
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Set
+    ( Set )
+import Data.Word
+    ( Word64, Word8 )
+import GHC.Generics
+    ( Generic )
+import Numeric.Natural
+    ( Natural )
+
+import qualified Cardano.Address.Script as CA
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Write.Tx as Write
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Write as CBOR
+import qualified Data.ByteString as BS
+import qualified Data.Foldable as F
+
+getFeePerByteFromWalletPParams
+    :: ProtocolParameters
+    -> FeePerByte
+getFeePerByteFromWalletPParams pp =
+    FeePerByte $ ceiling slope
+  where
+    LinearFee LinearFunction{slope} = getFeePolicy $ txParameters pp
+
+-- | Like the 'TxConstraints' field 'txRewardWithdrawalCost', but with added
+-- support for shared wallets via the 'CA.ScriptTemplate' argument.
+--
+-- We may or may not want to support shared wallets in the full txConstraints.
+_txRewardWithdrawalCost
+    :: Write.FeePerByte
+    -> Either CA.ScriptTemplate TxWitnessTag
+    -> Coin
+    -> Coin
+_txRewardWithdrawalCost feePerByte witType =
+    toWallet
+    . Write.feeOfBytes feePerByte
+    . unTxSize
+    . _txRewardWithdrawalSize witType
+
+-- | Like the 'TxConstraints' field 'txRewardWithdrawalSize', but with added
+-- support for shared wallets via the 'CA.ScriptTemplate' argument.
+--
+-- We may or may not want to support shared wallets in the full txConstraints.
+_txRewardWithdrawalSize
+    :: Either CA.ScriptTemplate TxWitnessTag
+    -> Coin
+    -> TxSize
+_txRewardWithdrawalSize _ (Coin 0) = TxSize 0
+_txRewardWithdrawalSize witType _ =
+        sizeOf_Withdrawals 1 <> wits
+      where
+        wits = case witType of
+            Right TxWitnessByronUTxO ->
+                sizeOf_BootstrapWitnesses 1 - sizeOf_BootstrapWitnesses 0
+            Right TxWitnessShelleyUTxO ->
+                sizeOf_VKeyWitnesses 1
+            Left scriptTemplate ->
+                let n = fromIntegral $ estimateMaxWitnessRequiredPerInput
+                        $ view #template scriptTemplate
+                in sizeOf_VKeyWitnesses n
+
+
+txConstraints
+    :: ProtocolParameters -> TxWitnessTag -> TxConstraints
+txConstraints protocolParams witnessTag = TxConstraints
+    { txBaseCost
+    , txBaseSize
+    , txInputCost
+    , txInputSize
+    , txOutputCost
+    , txOutputSize
+    , txOutputMaximumSize
+    , txOutputMaximumTokenQuantity
+    , txOutputMinimumAdaQuantity
+    , txOutputBelowMinimumAdaQuantity
+    , txRewardWithdrawalCost
+    , txRewardWithdrawalSize
+    , txMaximumSize
+    }
+  where
+    txBaseCost =
+        constantTxFee <> estimateTxCost feePerByte empty
+
+    constantTxFee = Coin $ ceiling intercept
+    feePerByte = getFeePerByteFromWalletPParams protocolParams
+    LinearFee LinearFunction {intercept}
+        = getFeePolicy $ txParameters protocolParams
+
+    txBaseSize =
+        estimateTxSize empty
+
+    txInputCost =
+        marginalCostOf empty {txInputCount = 1}
+
+    txInputSize =
+        marginalSizeOf empty {txInputCount = 1}
+
+    txOutputCost bundle =
+        marginalCostOf empty {txOutputs = [mkTxOut bundle]}
+
+    txOutputSize bundle =
+        marginalSizeOf empty {txOutputs = [mkTxOut bundle]}
+
+    txOutputMaximumSize = (<>)
+        (txOutputSize mempty)
+        (view
+            (#txParameters . #getTokenBundleMaxSize . #unTokenBundleMaxSize)
+            protocolParams)
+
+    txOutputMaximumTokenQuantity =
+        TokenQuantity $ fromIntegral $ maxBound @Word64
+
+    txOutputMinimumAdaQuantity =
+        computeMinimumCoinForUTxO (minimumUTxO protocolParams)
+
+    txOutputBelowMinimumAdaQuantity =
+        isBelowMinimumCoinForUTxO (minimumUTxO protocolParams)
+
+    txRewardWithdrawalCost =
+        _txRewardWithdrawalCost feePerByte (Right witnessTag)
+
+    txRewardWithdrawalSize =
+        _txRewardWithdrawalSize (Right witnessTag)
+
+    txMaximumSize = protocolParams
+        & view (#txParameters . #getTxMaxSize)
+        & getQuantity
+        & fromIntegral
+        & TxSize
+
+    empty :: TxSkeleton
+    empty = emptyTxSkeleton witnessTag
+
+    -- Computes the size difference between the given skeleton and an empty
+    -- skeleton.
+    marginalCostOf :: TxSkeleton -> Coin
+    marginalCostOf skeleton =
+        Coin.distance
+            (estimateTxCost feePerByte empty)
+            (estimateTxCost feePerByte skeleton)
+
+    -- Computes the size difference between the given skeleton and an empty
+    -- skeleton.
+    marginalSizeOf :: TxSkeleton -> TxSize
+    marginalSizeOf =
+        txSizeDistance txBaseSize . estimateTxSize
+
+    -- Constructs a real transaction output from a token bundle.
+    mkTxOut :: TokenBundle -> TxOut
+    mkTxOut = TxOut dummyAddress
+      where
+        dummyAddress :: Address
+        dummyAddress = Address $ BS.replicate dummyAddressLength nullByte
+
+        dummyAddressLength :: Int
+        dummyAddressLength = 57
+        -- Note: We are at liberty to overestimate the length of an address
+        -- (which is safe). Therefore, we can choose a length that we know is
+        -- greater than or equal to all address lengths.
+
+        nullByte :: Word8
+        nullByte = 0
+
+
+--
+-- Size estimation
+--
+
+
+-- | Includes just the parts of a transaction necessary to estimate its size.
+--
+-- In particular, this record type includes the minimal set of data needed for
+-- the 'estimateTxCost' and 'estimateTxSize' functions to perform their
+-- calculations, and nothing else.
+--
+-- The data included in 'TxSkeleton' is a subset of the data included in the
+-- union of 'SelectionSkeleton' and 'TransactionCtx'.
+--
+data TxSkeleton = TxSkeleton
+    { txWitnessTag :: !TxWitnessTag
+    , txInputCount :: !Int
+    , txOutputs :: ![TxOut]
+    , txChange :: ![Set AssetId]
+    , txPaymentTemplate :: !(Maybe (CA.Script CA.Cosigner))
+    }
+    deriving (Eq, Show, Generic)
+
+-- | Constructs an empty transaction skeleton.
+--
+-- This may be used to estimate the size and cost of an empty transaction.
+--
+emptyTxSkeleton :: TxWitnessTag -> TxSkeleton
+emptyTxSkeleton txWitnessTag = TxSkeleton
+    { txWitnessTag
+    , txInputCount = 0
+    , txOutputs = []
+    , txChange = []
+    , txPaymentTemplate = Nothing
+    }
+
+-- | Estimates the final cost of a transaction based on its skeleton.
+--
+-- The constant tx fee is /not/ included in the result of this function.
+estimateTxCost :: FeePerByte -> TxSkeleton -> Coin
+estimateTxCost (FeePerByte feePerByte) skeleton =
+    computeFee (estimateTxSize skeleton)
+  where
+    computeFee :: TxSize -> Coin
+    computeFee (TxSize size) = Coin $ feePerByte * size
+
+-- | Estimates the final size of a transaction based on its skeleton.
+--
+-- This function uses the upper bounds of CBOR serialized objects as the basis
+-- for many of its calculations. The following document is used as a reference:
+--
+-- https://github.com/input-output-hk/cardano-ledger/blob/master/eras/shelley/test-suite/cddl-files/shelley.cddl
+-- https://github.com/input-output-hk/cardano-ledger/blob/master/eras/shelley-ma/test-suite/cddl-files/shelley-ma.cddl
+-- https://github.com/input-output-hk/cardano-ledger/blob/master/eras/alonzo/test-suite/cddl-files/alonzo.cddl
+--
+estimateTxSize
+    :: TxSkeleton
+    -> TxSize
+estimateTxSize skeleton =
+    sizeOf_Transaction
+  where
+    TxSkeleton
+        { txWitnessTag
+        , txInputCount
+        , txOutputs
+        , txChange
+        , txPaymentTemplate
+        } = skeleton
+
+    numberOf_Inputs :: Natural
+    numberOf_Inputs
+        = fromIntegral txInputCount
+
+    numberOf_ScriptVkeyWitnessesForPayment
+        = maybe 0 estimateMaxWitnessRequiredPerInput txPaymentTemplate
+
+    numberOf_VkeyWitnesses
+        = case txWitnessTag of
+            TxWitnessByronUTxO -> 0
+            TxWitnessShelleyUTxO ->
+                -- there cannot be missing payment script if there is delegation script
+                -- the latter is optional
+                if numberOf_ScriptVkeyWitnessesForPayment == 0 then
+                    numberOf_Inputs
+                else
+                    (numberOf_Inputs * numberOf_ScriptVkeyWitnessesForPayment)
+
+    numberOf_BootstrapWitnesses
+        = case txWitnessTag of
+            TxWitnessByronUTxO -> numberOf_Inputs
+            TxWitnessShelleyUTxO -> 0
+
+    -- transaction =
+    --   [ transaction_body
+    --   , transaction_witness_set
+    --   , transaction_metadata / null
+    --   ]
+    sizeOf_Transaction
+        = sizeOf_SmallArray
+        + sizeOf_TransactionBody
+        + sizeOf_WitnessSet
+
+    -- transaction_body =
+    --   { 0 : set<transaction_input>
+    --   , 1 : [* transaction_output]
+    --   , 2 : coin ; fee
+    --   , 3 : uint ; ttl
+    --   , ? 4 : [* certificate]
+    --   , ? 5 : withdrawals
+    --   , ? 6 : update
+    --   , ? 7 : metadata_hash
+    --   , ? 8 : uint ; validity interval start
+    --   , ? 9 : mint
+    --   }
+    sizeOf_TransactionBody
+        = sizeOf_SmallMap
+        + sizeOf_Inputs
+        + sizeOf_Outputs
+        + sizeOf_Fee
+        + sizeOf_Ttl
+        + sizeOf_Update
+        + sizeOf_ValidityIntervalStart
+        + sizeOf_HistoricalPadding
+      where
+        -- Preserved out of caution during refactoring. We should be able to
+        -- drop this, but we may as well wait until we have completely
+        -- water-proof testing of the size estimation, e.g:
+        -- prop> forall baseTx update.
+        --      sizeOf_Update x >=
+        --          (serializedSize (update baseTx)
+        --          - serializedSize baseTx)
+        -- where update is something similar to 'TxUpdate' or 'TxSkeleton'.
+        sizeOf_HistoricalPadding = sizeOf_NoMetadata
+          where
+            -- When it's "empty", metadata are represented by a special
+            -- "null byte" in CBOR `F6`.
+            sizeOf_NoMetadata = 1
+
+        -- 0 => set<transaction_input>
+        sizeOf_Inputs
+            = sizeOf_SmallUInt
+            + sizeOf_Array
+            + sizeOf_Input * TxSize numberOf_Inputs
+
+        -- 1 => [* transaction_output]
+        sizeOf_Outputs
+            = sizeOf_SmallUInt
+            + sizeOf_Array
+            + F.sum (sizeOf_Output <$> txOutputs)
+            + F.sum (sizeOf_ChangeOutput <$> txChange)
+
+        -- 2 => fee
+        sizeOf_Fee
+            = sizeOf_SmallUInt
+            + sizeOf_UInt
+
+        -- 3 => ttl
+        sizeOf_Ttl
+            = sizeOf_SmallUInt
+            + sizeOf_UInt
+
+        -- ?6 => update
+        sizeOf_Update
+            = 0 -- Assuming no updates is running through cardano-wallet
+
+        -- ?8 => uint ; validity interval start
+        sizeOf_ValidityIntervalStart
+            = sizeOf_UInt
+
+    -- transaction_input =
+    --   [ transaction_id : $hash32
+    --   , index : uint
+    --   ]
+    sizeOf_Input
+        = sizeOf_SmallArray
+        + sizeOf_Hash32
+        + sizeOf_UInt
+
+    -- post_alonzo_transaction_output =
+    --   { 0 : address
+    --   , 1 : value
+    --   , ? 2 : datum_option ; New; datum option
+    --   , ? 3 : script_ref   ; New; script reference
+    --   }
+    -- value =
+    --   coin / [coin,multiasset<uint>]
+    sizeOf_PostAlonzoTransactionOutput TxOut {address, tokens}
+        = sizeOf_SmallMap
+        + sizeOf_SmallUInt
+        + sizeOf_Address address
+        + sizeOf_SmallUInt
+        + sizeOf_SmallArray
+        + sizeOf_Coin (TokenBundle.getCoin tokens)
+        + sumVia sizeOf_NativeAsset (TokenBundle.getAssets tokens)
+
+    sizeOf_Output
+        = sizeOf_PostAlonzoTransactionOutput
+
+    sizeOf_ChangeOutput :: Set AssetId -> TxSize
+    sizeOf_ChangeOutput
+        = sizeOf_PostAlonzoChangeOutput
+
+    -- post_alonzo_transaction_output =
+    --   { 0 : address
+    --   , 1 : value
+    --   , ? 2 : datum_option ; New; datum option
+    --   , ? 3 : script_ref   ; New; script reference
+    --   }
+    -- value =
+    --   coin / [coin,multiasset<uint>]
+    sizeOf_PostAlonzoChangeOutput :: Set AssetId -> TxSize
+    sizeOf_PostAlonzoChangeOutput xs
+        = sizeOf_SmallMap
+        + sizeOf_SmallUInt
+        + sizeOf_ChangeAddress
+        + sizeOf_SmallMap
+        + sizeOf_SmallUInt
+        + sizeOf_LargeUInt
+        + sumVia sizeOf_NativeAsset xs
+
+    -- We carry addresses already serialized, so it's a matter of measuring.
+    sizeOf_Address addr
+        = 2 + fromIntegral (BS.length (unAddress addr))
+
+    -- For change address, we consider the worst-case scenario based on the
+    -- given wallet scheme. Byron addresses are larger.
+    --
+    -- NOTE: we could do slightly better if we wanted to for Byron addresses and
+    -- discriminate based on the network as well since testnet addresses are
+    -- larger than mainnet ones. But meh.
+    sizeOf_ChangeAddress
+        = case txWitnessTag of
+            TxWitnessByronUTxO -> 85
+            TxWitnessShelleyUTxO -> 59
+
+    -- value = coin / [coin,multiasset<uint>]
+    -- We consider "native asset" to just be the "multiasset<uint>" part of the
+    -- above, hence why we don't also include the size of the coin. Where this
+    -- is used, the size of the coin and array are are added too.
+    sizeOf_NativeAsset AssetId{tokenName}
+        = sizeOf_MultiAsset sizeOf_LargeUInt tokenName
+
+    -- multiasset<a> = { * policy_id => { * asset_name => a } }
+    -- policy_id = scripthash
+    -- asset_name = bytes .size (0..32)
+    sizeOf_MultiAsset sizeOf_a name
+      = sizeOf_SmallMap -- NOTE: Assuming < 23 policies per output
+      + sizeOf_Hash28
+      + sizeOf_SmallMap -- NOTE: Assuming < 23 assets per policy
+      + sizeOf_AssetName name
+      + sizeOf_a
+
+    -- asset_name = bytes .size (0..32)
+    sizeOf_AssetName name
+        = 2 + fromIntegral (BS.length $ unTokenName name)
+
+    -- Coins can really vary so it's very punishing to always assign them the
+    -- upper bound. They will typically be between 3 and 9 bytes (only 6 bytes
+    -- difference, but on 20+ outputs, one starts feeling it).
+    --
+    -- So, for outputs, since we have the values, we can compute it accurately.
+    sizeOf_Coin
+        = TxSize
+        . fromIntegral
+        . BS.length
+        . CBOR.toStrictByteString
+        . CBOR.encodeWord64
+        . Coin.unsafeToWord64
+
+    determinePaymentTemplateSize scriptCosigner
+        = sizeOf_Array
+        + sizeOf_SmallUInt
+        + TxSize numberOf_Inputs * (sizeOf_NativeScript scriptCosigner)
+
+    -- transaction_witness_set =
+    --   { ?0 => [* vkeywitness ]
+    --   , ?1 => [* native_script ]
+    --   , ?2 => [* bootstrap_witness ]
+    --   }
+    sizeOf_WitnessSet
+        = sizeOf_SmallMap
+        + sizeOf_VKeyWitnesses numberOf_VkeyWitnesses
+        + maybe 0 determinePaymentTemplateSize txPaymentTemplate
+        -- FIXME: Payment template needs to be multiplied with number of inputs
+        + sizeOf_BootstrapWitnesses numberOf_BootstrapWitnesses
+
+-- ?5 => withdrawals
+sizeOf_Withdrawals :: Natural -> TxSize
+sizeOf_Withdrawals n
+    = (if n > 0
+        then sizeOf_SmallUInt + sizeOf_SmallMap
+        else 0)
+    + sizeOf_Withdrawal * (TxSize n)
+
+  where
+    -- withdrawals =
+    --   { * reward_account => coin }
+    sizeOf_Withdrawal
+        = sizeOf_Hash28
+        + sizeOf_LargeUInt
+
+-- ?0 => [* vkeywitness ]
+sizeOf_VKeyWitnesses :: Natural -> TxSize
+sizeOf_VKeyWitnesses n
+    = (if n > 0
+        then sizeOf_Array + sizeOf_SmallUInt else 0)
+    + sizeOf_VKeyWitness * (TxSize n)
+
+-- ?2 => [* bootstrap_witness ]
+sizeOf_BootstrapWitnesses :: Natural -> TxSize
+sizeOf_BootstrapWitnesses n
+    = (if n > 0
+        then sizeOf_Array + sizeOf_SmallUInt
+        else 0)
+    + sizeOf_BootstrapWitness * (TxSize n)
+
+-- vkeywitness =
+--  [ $vkey
+--  , $signature
+--  ]
+sizeOf_VKeyWitness :: TxSize
+sizeOf_VKeyWitness
+    = sizeOf_SmallArray
+    + sizeOf_VKey
+    + sizeOf_Signature
+
+-- bootstrap_witness =
+--  [ public_key : $vkey
+--  , signature  : $signature
+--  , chain_code : bytes .size 32
+--  , attributes : bytes
+--  ]
+sizeOf_BootstrapWitness :: TxSize
+sizeOf_BootstrapWitness
+    = sizeOf_SmallArray
+    + sizeOf_VKey
+    + sizeOf_Signature
+    + sizeOf_ChainCode
+    + sizeOf_Attributes
+  where
+    sizeOf_ChainCode  = 34
+    sizeOf_Attributes = 45 -- NOTE: could be smaller by ~34 for Icarus
+
+-- native_script =
+--   [ script_pubkey      = (0, addr_keyhash)
+--   // script_all        = (1, [ * native_script ])
+--   // script_any        = (2, [ * native_script ])
+--   // script_n_of_k     = (3, n: uint, [ * native_script ])
+--   // invalid_before    = (4, uint)
+--      ; Timelock validity intervals are half-open intervals [a, b).
+--      ; This field specifies the left (included) endpoint a.
+--   // invalid_hereafter = (5, uint)
+--      ; Timelock validity intervals are half-open intervals [a, b).
+--      ; This field specifies the right (excluded) endpoint b.
+--   ]
+sizeOf_NativeScript :: Script object -> TxSize
+sizeOf_NativeScript = \case
+    RequireSignatureOf _ ->
+        sizeOf_SmallUInt + sizeOf_Hash28
+    RequireAllOf ss ->
+        sizeOf_SmallUInt + sizeOf_Array + sumVia sizeOf_NativeScript ss
+    RequireAnyOf ss ->
+        sizeOf_SmallUInt + sizeOf_Array + sumVia sizeOf_NativeScript ss
+    RequireSomeOf _ ss ->
+        sizeOf_SmallUInt
+            + sizeOf_UInt
+            + sizeOf_Array
+            + sumVia sizeOf_NativeScript ss
+    ActiveFromSlot _ ->
+        sizeOf_SmallUInt + sizeOf_UInt
+    ActiveUntilSlot _ ->
+        sizeOf_SmallUInt + sizeOf_UInt
+
+-- A Blake2b-224 hash, resulting in a 28-byte digest wrapped in CBOR, so
+-- with 2 bytes overhead (length <255, but length > 23)
+sizeOf_Hash28 :: TxSize
+sizeOf_Hash28
+    = 30
+
+-- A Blake2b-256 hash, resulting in a 32-byte digest wrapped in CBOR, so
+-- with 2 bytes overhead (length <255, but length > 23)
+sizeOf_Hash32 :: TxSize
+sizeOf_Hash32
+    = 34
+
+-- A 32-byte Ed25519 public key, encoded as a CBOR-bytestring so with 2
+-- bytes overhead (length < 255, but length > 23)
+sizeOf_VKey :: TxSize
+sizeOf_VKey
+    = 34
+
+-- A 64-byte Ed25519 signature, encoded as a CBOR-bytestring so with 2
+-- bytes overhead (length < 255, but length > 23)
+sizeOf_Signature :: TxSize
+sizeOf_Signature
+    = 66
+
+-- A CBOR UInt which is less than 23 in value fits on a single byte. Beyond,
+-- the first byte is used to encode the number of bytes necessary to encode
+-- the number itself, followed by the number itself.
+--
+-- When considering a 'UInt', we consider the worst case scenario only where
+-- the uint is encoded over 4 bytes, so up to 2^32 which is fine for most
+-- cases but coin values.
+sizeOf_SmallUInt :: TxSize
+sizeOf_SmallUInt = 1
+
+sizeOf_UInt :: TxSize
+sizeOf_UInt = 5
+
+sizeOf_LargeUInt :: TxSize
+sizeOf_LargeUInt = 9
+
+-- A CBOR array with less than 23 elements, fits on a single byte, followed
+-- by each key-value pair (encoded as two concatenated CBOR elements).
+sizeOf_SmallMap :: TxSize
+sizeOf_SmallMap = 1
+
+-- A CBOR array with less than 23 elements, fits on a single byte, followed
+-- by each elements. Otherwise, the length of the array is encoded first,
+-- very much like for UInt.
+--
+-- When considering an 'Array', we consider large scenarios where arrays can
+-- have up to 65536 elements.
+sizeOf_SmallArray :: TxSize
+sizeOf_SmallArray = 1
+
+sizeOf_Array :: TxSize
+sizeOf_Array = 3
+
+-- Small helper function for summing values. Given a list of values, get the sum
+-- of the values, after the given function has been applied to each value.
+sumVia :: (Foldable t, Num m) => (a -> m) -> t a -> m
+sumVia f = F.foldl' (\t -> (t +) . f) 0
+

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Redeemers.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Redeemers.hs
@@ -1,0 +1,237 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{- HLINT ignore "Use <$>" -}
+
+-- |
+-- Copyright: © 2023 IOHK
+-- License: Apache-2.0
+--
+-- Module containing 'assignRedeemers'
+module Cardano.Wallet.Write.Tx.Redeemers
+    ( assignScriptRedeemers
+    , ErrAssignRedeemers (..)
+    ) where
+
+import Prelude
+
+import Cardano.Ledger.Alonzo.TxInfo
+    ( TranslationError )
+import Cardano.Ledger.Api
+    ( Tx, bodyTxL, rdmrsTxWitsL, scriptIntegrityHashTxBodyL, witsTxL )
+import Cardano.Ledger.Shelley.API
+    ( StrictMaybe (..) )
+import Cardano.Slotting.EpochInfo
+    ( EpochInfo, hoistEpochInfo )
+import Cardano.Wallet.Primitive.Types.Redeemer
+    ( Redeemer, redeemerData )
+import Cardano.Wallet.Shelley.Compatibility
+    ( toScriptPurpose )
+import Cardano.Wallet.Write.Tx
+    ( IsRecentEra (recentEra)
+    , PParams
+    , RecentEraLedgerConstraints
+    , ShelleyLedgerEra
+    , StandardCrypto
+    , fromCardanoTx
+    , fromCardanoUTxO
+    , shelleyBasedEra
+    , txBody
+    , withConstraints
+    )
+import Cardano.Wallet.Write.Tx.TimeTranslation
+    ( TimeTranslation, epochInfo, systemStartTime )
+import Codec.Serialise
+    ( deserialiseOrFail )
+import Control.Arrow
+    ( left )
+import Control.Lens
+    ( (.~) )
+import Control.Monad
+    ( forM )
+import Control.Monad.Trans.Class
+    ( lift )
+import Control.Monad.Trans.State.Strict
+    ( StateT (..), execStateT, get, modify', put )
+import Data.Function
+    ( (&) )
+import Data.Generics.Internal.VL.Lens
+    ( view )
+import Data.Generics.Labels
+    ()
+import Data.Map.Strict
+    ( Map, (!) )
+import GHC.Generics
+    ( Generic )
+
+import qualified Cardano.Api as Cardano
+import qualified Cardano.Api.Shelley as Cardano
+import qualified Cardano.Ledger.Alonzo.PlutusScriptApi as Alonzo
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import qualified Cardano.Ledger.Alonzo.Scripts.Data as Alonzo
+import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
+import qualified Cardano.Ledger.Alonzo.TxWits as Alonzo
+import qualified Cardano.Ledger.Api as Ledger
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Map as Map
+import qualified Data.Map.Merge.Strict as Map
+import qualified Data.Set as Set
+import qualified Data.Text as T
+
+data ErrAssignRedeemers
+    = ErrAssignRedeemersScriptFailure Redeemer String
+    | ErrAssignRedeemersTargetNotFound Redeemer
+    -- ^ The given redeemer target couldn't be located in the transaction.
+    | ErrAssignRedeemersInvalidData Redeemer String
+    -- ^ Redeemer's data isn't a valid Plutus' data.
+    | ErrAssignRedeemersTranslationError (TranslationError StandardCrypto)
+    deriving (Generic, Eq, Show)
+
+assignScriptRedeemers
+    :: forall era. IsRecentEra era
+    => PParams (ShelleyLedgerEra era)
+    -> TimeTranslation
+    -> Cardano.UTxO era
+    -> [Redeemer]
+    -> Cardano.Tx era
+    -> Either ErrAssignRedeemers (Cardano.Tx era)
+assignScriptRedeemers pparams timeTranslation utxo redeemers tx =
+    withConstraints (recentEra @era) $ do
+        let ledgerTx = fromCardanoTx tx
+        ledgerTx' <- flip execStateT ledgerTx $ do
+            indexedRedeemers <- StateT assignNullRedeemers
+            executionUnits <- get
+                >>= lift . evaluateExecutionUnits indexedRedeemers
+            modifyM (assignExecutionUnits executionUnits)
+            modify' addScriptIntegrityHash
+        pure $ Cardano.ShelleyTx shelleyBasedEra ledgerTx'
+  where
+    epochInformation :: EpochInfo (Either T.Text)
+    epochInformation =
+        hoistEpochInfo (left (T.pack . show)) $ epochInfo timeTranslation
+
+    systemStart = systemStartTime timeTranslation
+
+    -- | Assign redeemers with null execution units to the input transaction.
+    --
+    -- Redeemers are determined from the context given to the caller via the
+    -- 'Redeemer' type which is mapped to an 'Alonzo.ScriptPurpose'.
+    assignNullRedeemers
+        :: RecentEraLedgerConstraints (ShelleyLedgerEra era)
+        => Tx (ShelleyLedgerEra era)
+        -> Either ErrAssignRedeemers
+            ( Map Alonzo.RdmrPtr Redeemer
+            , Tx (ShelleyLedgerEra era)
+            )
+    assignNullRedeemers ledgerTx = do
+        (indexedRedeemers, nullRedeemers) <-
+            fmap unzip $ forM redeemers parseRedeemer
+        pure
+            ( Map.fromList indexedRedeemers
+            , ledgerTx
+                & witsTxL . rdmrsTxWitsL
+                    .~ (Alonzo.Redeemers (Map.fromList nullRedeemers))
+            )
+      where
+        parseRedeemer rd = do
+            let mPtr = Alonzo.rdptr
+                    (txBody (recentEra @era) ledgerTx)
+                    (toScriptPurpose rd)
+            ptr <- case mPtr of
+                SNothing -> Left $ ErrAssignRedeemersTargetNotFound rd
+                SJust ptr -> pure ptr
+            let mDeserialisedData =
+                    deserialiseOrFail $ BL.fromStrict $ redeemerData rd
+            rData <- case mDeserialisedData of
+                Left e -> Left $ ErrAssignRedeemersInvalidData rd (show e)
+                Right d -> pure (Alonzo.Data d)
+            pure ((ptr, rd), (ptr, (rData, mempty)))
+
+    -- | Evaluate execution units of each script/redeemer in the transaction.
+    -- This may fail for each script.
+    evaluateExecutionUnits
+        :: RecentEraLedgerConstraints (ShelleyLedgerEra era)
+        => Map Alonzo.RdmrPtr Redeemer
+        -> Tx (Cardano.ShelleyLedgerEra era)
+        -> Either ErrAssignRedeemers
+            (Map Alonzo.RdmrPtr (Either ErrAssignRedeemers Alonzo.ExUnits))
+    evaluateExecutionUnits indexedRedeemers ledgerTx = do
+        let res =
+                Ledger.evalTxExUnits
+                    pparams
+                    ledgerTx
+                    (fromCardanoUTxO utxo)
+                    epochInformation
+                    systemStart
+        case res of
+            Left translationError ->
+                Left $ ErrAssignRedeemersTranslationError translationError
+            Right report ->
+                Right $ hoistScriptFailure indexedRedeemers report
+
+    hoistScriptFailure
+        :: Show scriptFailure
+        => Map Alonzo.RdmrPtr Redeemer
+        -> Map Alonzo.RdmrPtr (Either scriptFailure a)
+        -> Map Alonzo.RdmrPtr (Either ErrAssignRedeemers a)
+    hoistScriptFailure indexedRedeemers = Map.mapWithKey $ \ptr -> left $ \e ->
+        ErrAssignRedeemersScriptFailure (indexedRedeemers ! ptr) (show e)
+
+    -- | Change execution units for each redeemers in the transaction to what
+    -- they ought to be.
+    assignExecutionUnits
+        :: RecentEraLedgerConstraints (ShelleyLedgerEra era)
+        => Map Alonzo.RdmrPtr (Either ErrAssignRedeemers Alonzo.ExUnits)
+        -> Tx (ShelleyLedgerEra era)
+        -> Either ErrAssignRedeemers (Tx (ShelleyLedgerEra era))
+    assignExecutionUnits exUnits ledgerTx = do
+        let Alonzo.Redeemers rdmrs = view (witsTxL . rdmrsTxWitsL) ledgerTx
+
+        rdmrs' <- Map.mergeA
+            Map.preserveMissing
+            Map.dropMissing
+            (Map.zipWithAMatched (const assignUnits))
+            rdmrs
+            exUnits
+
+        pure $ ledgerTx
+            & (witsTxL . rdmrsTxWitsL) .~ (Alonzo.Redeemers rdmrs')
+
+    assignUnits
+        :: (dat, Alonzo.ExUnits)
+        -> Either err Alonzo.ExUnits
+        -> Either err (dat, Alonzo.ExUnits)
+    assignUnits (dats, _zero) = fmap (dats,)
+
+    -- | Finally, calculate and add the script integrity hash with the new
+    -- final redeemers, if any.
+    addScriptIntegrityHash
+        :: RecentEraLedgerConstraints (ShelleyLedgerEra era)
+        => Tx (ShelleyLedgerEra era)
+        -> Tx (ShelleyLedgerEra era)
+    addScriptIntegrityHash ledgerTx =
+        ledgerTx & (bodyTxL . scriptIntegrityHashTxBodyL) .~
+            Alonzo.hashScriptIntegrity
+                (Set.fromList $ Alonzo.getLanguageView pparams <$> langs)
+                (Alonzo.txrdmrs wits)
+                (Alonzo.txdats wits)
+      where
+        wits = Alonzo.wits ledgerTx
+        langs =
+            [ l
+            | (_hash, script) <- Map.toList (Alonzo.txscripts wits)
+            , (not . Ledger.isNativeScript @(ShelleyLedgerEra era)) script
+            , Just l <- [Alonzo.language script]
+            ]
+
+--
+-- Utils
+--
+
+-- | Effectfully modify the state of a state-monad transformer stack.
+modifyM  :: forall m s. (Monad m) => (s -> m s) -> StateT s m ()
+modifyM fn = get >>= lift . fn >>= put

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Redeemers.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Redeemers.hs
@@ -37,8 +37,8 @@ import Cardano.Wallet.Write.Tx
     , RecentEraLedgerConstraints
     , ShelleyLedgerEra
     , StandardCrypto
+    , UTxO
     , fromCardanoTx
-    , fromCardanoUTxO
     , shelleyBasedEra
     , txBody
     , withConstraints
@@ -95,7 +95,7 @@ assignScriptRedeemers
     :: forall era. IsRecentEra era
     => PParams (ShelleyLedgerEra era)
     -> TimeTranslation
-    -> Cardano.UTxO era
+    -> UTxO (ShelleyLedgerEra era)
     -> [Redeemer]
     -> Cardano.Tx era
     -> Either ErrAssignRedeemers (Cardano.Tx era)
@@ -164,7 +164,7 @@ assignScriptRedeemers pparams timeTranslation utxo redeemers tx =
                 Ledger.evalTxExUnits
                     pparams
                     ledgerTx
-                    (fromCardanoUTxO utxo)
+                    utxo
                     epochInformation
                     systemStart
         case res of

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
@@ -19,6 +19,9 @@ module Cardano.Wallet.Write.Tx.Sign
 
     , KeyWitnessCount (..)
     , estimateKeyWitnessCount
+
+    , estimateMaxWitnessRequiredPerInput
+    , estimateMinWitnessRequiredPerInput
     )
     where
 
@@ -26,8 +29,6 @@ import Prelude
 
 import Cardano.Ledger.Api
     ( ppMinFeeAL )
-import Cardano.Wallet.Address.Discovery.Shared
-    ( estimateMaxWitnessRequiredPerInput )
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -259,3 +260,54 @@ estimateKeyWitnessCount utxo txbody@(Cardano.TxBody txbodycontent) =
 -- of the values, after the given function has been applied to each value.
 sumVia :: (Foldable t, Num m) => (a -> m) -> t a -> m
 sumVia f = F.foldl' (\t -> (t +) . f) 0
+
+estimateMinWitnessRequiredPerInput :: CA.Script k -> Natural
+estimateMinWitnessRequiredPerInput = \case
+    CA.RequireSignatureOf _ -> 1
+    CA.RequireAllOf xs      ->
+        sum $ map estimateMinWitnessRequiredPerInput xs
+    CA.RequireAnyOf xs      ->
+        optimumIfNotEmpty minimum $ map estimateMinWitnessRequiredPerInput xs
+    CA.RequireSomeOf m xs   ->
+        let smallestReqFirst =
+                L.sort $ map estimateMinWitnessRequiredPerInput xs
+        in sum $ take (fromIntegral m) smallestReqFirst
+    CA.ActiveFromSlot _     -> 0
+    CA.ActiveUntilSlot _    -> 0
+
+optimumIfNotEmpty :: (Foldable t, Num p) => (t a -> p) -> t a -> p
+optimumIfNotEmpty f xs =
+    if null xs then
+        0
+    else f xs
+
+estimateMaxWitnessRequiredPerInput :: CA.Script k -> Natural
+estimateMaxWitnessRequiredPerInput = \case
+    CA.RequireSignatureOf _ -> 1
+    CA.RequireAllOf xs      ->
+        sum $ map estimateMaxWitnessRequiredPerInput xs
+    CA.RequireAnyOf xs      ->
+        sum $ map estimateMaxWitnessRequiredPerInput xs
+    -- Estimate (and tx fees) could be lowered with:
+    --
+    -- optimumIfNotEmpty maximum $ map estimateMaxWitnessRequiredPerInput xs
+    -- however signTransaction
+    --
+    -- however we'd then need to adjust signTx accordingly such that it still
+    -- doesn't add more witnesses than we plan for.
+    --
+    -- Partially related task: https://input-output.atlassian.net/browse/ADP-2676
+    CA.RequireSomeOf _m xs   ->
+        sum $ map estimateMaxWitnessRequiredPerInput xs
+    -- Estimate (and tx fees) could be lowered with:
+    --
+    -- let largestReqFirst =
+    --      reverse $ L.sort $ map estimateMaxWitnessRequiredPerInput xs
+    -- in sum $ take (fromIntegral m) largestReqFirst
+    --
+    -- however we'd then need to adjust signTx accordingly such that it still
+    -- doesn't add more witnesses than we plan for.
+    --
+    -- Partially related task: https://input-output.atlassian.net/browse/ADP-2676
+    CA.ActiveFromSlot _     -> 0
+    CA.ActiveUntilSlot _    -> 0

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
@@ -28,7 +28,7 @@ module Cardano.Wallet.Write.Tx.Sign
 import Prelude
 
 import Cardano.Ledger.Api
-    ( ppMinFeeAL )
+    ( Addr (..), addrTxOutL, ppMinFeeAL )
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -38,9 +38,16 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( toWalletCoin, toWalletScript )
 import Cardano.Wallet.Write.Tx
-    ( IsRecentEra (..), KeyWitnessCount (..), RecentEra (..) )
+    ( IsRecentEra (..)
+    , KeyWitnessCount (..)
+    , RecentEra (..)
+    , ShelleyLedgerEra
+    , TxIn
+    , UTxO
+    , withConstraints
+    )
 import Control.Lens
-    ( (^.) )
+    ( view, (^.) )
 import Data.Maybe
     ( mapMaybe )
 import Numeric.Natural
@@ -52,6 +59,10 @@ import qualified Cardano.Api.Byron as Byron
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
+import Cardano.Ledger.Credential
+    ( Credential (..) )
+import Cardano.Ledger.UTxO
+    ( txinLookup )
 import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Ledger
 import qualified Cardano.Wallet.Write.Tx as Write
@@ -135,7 +146,7 @@ numberOfShelleyWitnesses n = KeyWitnessCount n 0
 -- we cannot use because it requires a 'TxBodyContent BuildTx era'.
 estimateKeyWitnessCount
     :: forall era. IsRecentEra era
-    => Cardano.UTxO era
+    => UTxO (ShelleyLedgerEra era)
     -- ^ Must contain all inputs from the 'TxBody' or
     -- 'estimateKeyWitnessCount will 'error'.
     -> Cardano.TxBody era
@@ -147,6 +158,7 @@ estimateKeyWitnessCount utxo txbody@(Cardano.TxBody txbodycontent) =
                 Cardano.TxInsCollateral _ ins -> ins
                 Cardano.TxInsCollateralNone -> []
         vkInsUnique = L.nub $ filter (hasVkPaymentCred utxo) $
+            map Cardano.toShelleyTxIn $
             txIns ++ txInsCollateral
         txExtraKeyWits = Cardano.txExtraKeyWits txbodycontent
         txExtraKeyWits' = case txExtraKeyWits of
@@ -226,32 +238,33 @@ estimateKeyWitnessCount utxo txbody@(Cardano.TxBody txbodycontent) =
                 Alonzo.PlutusScript _ _ -> Nothing
 
     hasVkPaymentCred
-        :: Cardano.UTxO era
-        -> Cardano.TxIn
+        :: UTxO (ShelleyLedgerEra era)
+        -> TxIn
         -> Bool
-    hasVkPaymentCred (Cardano.UTxO u) inp = case Map.lookup inp u of
-        Just (Cardano.TxOut addrInEra _ _ _) -> Cardano.isKeyAddress addrInEra
-        Nothing ->
-            error $ unwords
-                [ "estimateMaxWitnessRequiredPerInput: input not in utxo."
-                , "Caller is expected to ensure this does not happen."
-                ]
+    hasVkPaymentCred u inp = withConstraints (recentEra @era) $
+        case view addrTxOutL <$> txinLookup inp u of
+            Just (Addr _ (KeyHashObj _) _) -> True
+            Just (Addr _ (ScriptHashObj _) _) -> False
+            Just (AddrBootstrap _) -> False
+            Nothing ->
+                error $ unwords
+                    [ "estimateMaxWitnessRequiredPerInput: input not in utxo."
+                    , "Caller is expected to ensure this does not happen."
+                    ]
 
     hasBootstrapAddr
-        :: Cardano.UTxO era
-        -> Cardano.TxIn
+        :: UTxO (ShelleyLedgerEra era)
+        -> TxIn
         -> Bool
-    hasBootstrapAddr (Cardano.UTxO u) inp = case Map.lookup inp u of
-        Just (Cardano.TxOut addrInEra _ _ _) ->
-            case addrInEra of
-                Cardano.AddressInEra Cardano.ByronAddressInAnyEra _ -> True
-                _ -> False
-        Nothing ->
-            error $ unwords
-                [ "estimateMaxWitnessRequiredPerInput: input not in utxo."
-                , "Caller is expected to ensure this does not happen."
-                ]
-
+    hasBootstrapAddr u inp = withConstraints (recentEra @era) $
+        case view addrTxOutL <$> txinLookup inp u of
+            Just Addr{} -> False
+            Just (AddrBootstrap _) -> True
+            Nothing ->
+                error $ unwords
+                    [ "estimateMaxWitnessRequiredPerInput: input not in utxo."
+                    , "Caller is expected to ensure this does not happen."
+                    ]
 --
 -- Helpers
 --

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
@@ -1,0 +1,261 @@
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2023 IOHK
+-- License: Apache-2.0
+--
+-- Module for 'signTx' and signing-related utilities for balancing.
+module Cardano.Wallet.Write.Tx.Sign
+    (
+    -- * Signing transactions
+    -- TODO: Move signTx function here
+
+    -- * Signing-related utilities required for balancing
+      estimateSignedTxSize
+
+    , KeyWitnessCount (..)
+    , estimateKeyWitnessCount
+    )
+    where
+
+import Prelude
+
+import Cardano.Ledger.Api
+    ( ppMinFeeAL )
+import Cardano.Wallet.Address.Discovery.Shared
+    ( estimateMaxWitnessRequiredPerInput )
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( sealedTxFromCardanoBody, serialisedTx )
+import Cardano.Wallet.Primitive.Types.Tx.Constraints
+    ( TxSize (..) )
+import Cardano.Wallet.Shelley.Compatibility.Ledger
+    ( toWalletCoin, toWalletScript )
+import Cardano.Wallet.Write.Tx
+    ( IsRecentEra (..), KeyWitnessCount (..), RecentEra (..) )
+import Control.Lens
+    ( (^.) )
+import Data.Maybe
+    ( mapMaybe )
+import Numeric.Natural
+    ( Natural )
+
+import qualified Cardano.Address.Script as CA
+import qualified Cardano.Api as Cardano
+import qualified Cardano.Api.Byron as Byron
+import qualified Cardano.Api.Shelley as Cardano
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import qualified Cardano.Ledger.Api as Ledger
+import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
+import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Ledger
+import qualified Cardano.Wallet.Write.Tx as Write
+import qualified Data.ByteString as BS
+import qualified Data.Foldable as F
+import qualified Data.List as L
+import qualified Data.Map as Map
+
+-- | Estimate the size of the transaction (body) when fully signed.
+estimateSignedTxSize
+    :: forall era. Write.IsRecentEra era
+    => Write.PParams (Write.ShelleyLedgerEra era)
+    -> KeyWitnessCount
+    -> Cardano.TxBody era
+    -> TxSize
+estimateSignedTxSize pparams nWits body =
+    let
+        -- Hack which allows us to rely on the ledger to calculate the size of
+        -- witnesses:
+        feeOfWits :: W.Coin
+        feeOfWits = minfee nWits `W.Coin.difference` minfee mempty
+
+        sizeOfWits :: TxSize
+        sizeOfWits =
+            case feeOfWits `coinQuotRem` feePerByte of
+                (n, 0) -> TxSize n
+                (_, _) -> error $ unwords
+                    [ "estimateSignedTxSize:"
+                    , "the impossible happened!"
+                    , "Couldn't divide"
+                    , show feeOfWits
+                    , "lovelace (the fee contribution of"
+                    , show nWits
+                    , "witnesses) with"
+                    , show feePerByte
+                    , "lovelace/byte"
+                    ]
+        sizeOfTx :: TxSize
+        sizeOfTx = TxSize
+            . fromIntegral
+            . BS.length
+            . serialisedTx
+            $ sealedTxFromCardanoBody body
+    in
+        sizeOfTx <> sizeOfWits
+  where
+    coinQuotRem :: W.Coin -> W.Coin -> (Natural, Natural)
+    coinQuotRem (W.Coin p) (W.Coin q) = quotRem p q
+
+    minfee :: KeyWitnessCount -> W.Coin
+    minfee witCount = toWalletCoin $ Write.evaluateMinimumFee
+        (recentEra @era) pparams (toLedgerTx body) witCount
+
+    toLedgerTx :: Cardano.TxBody era -> Write.Tx (Write.ShelleyLedgerEra era)
+    toLedgerTx b = case Cardano.Tx b [] of
+        Byron.ByronTx {} -> case Write.recentEra @era of {}
+        Cardano.ShelleyTx _era ledgerTx -> ledgerTx
+
+    feePerByte :: W.Coin
+    feePerByte = Ledger.toWalletCoin $
+        case Write.recentEra @era of
+            Write.RecentEraBabbage -> pparams ^. ppMinFeeAL
+            Write.RecentEraConway -> pparams ^. ppMinFeeAL
+
+numberOfShelleyWitnesses :: Word -> KeyWitnessCount
+numberOfShelleyWitnesses n = KeyWitnessCount n 0
+
+-- | Estimates the required number of Shelley-era witnesses.
+--
+-- Because we don't take into account whether two pieces of tx content will need
+-- the same key for signing, the result may be an overestimate.
+--
+-- For instance, this may happen if:
+-- 1. Multiple inputs share the same payment key (like in a single address
+-- wallet)
+-- 2. We are updating our delegation and withdrawing rewards at the same time.
+--
+-- FIXME [ADP-1515] Improve estimation
+--
+-- NOTE: Similar to 'estimateTransactionKeyWitnessCount' from cardano-api, which
+-- we cannot use because it requires a 'TxBodyContent BuildTx era'.
+estimateKeyWitnessCount
+    :: forall era. IsRecentEra era
+    => Cardano.UTxO era
+    -- ^ Must contain all inputs from the 'TxBody' or
+    -- 'estimateKeyWitnessCount will 'error'.
+    -> Cardano.TxBody era
+    -> KeyWitnessCount
+estimateKeyWitnessCount utxo txbody@(Cardano.TxBody txbodycontent) =
+    let txIns = map fst $ Cardano.txIns txbodycontent
+        txInsCollateral =
+            case Cardano.txInsCollateral txbodycontent of
+                Cardano.TxInsCollateral _ ins -> ins
+                Cardano.TxInsCollateralNone -> []
+        vkInsUnique = L.nub $ filter (hasVkPaymentCred utxo) $
+            txIns ++ txInsCollateral
+        txExtraKeyWits = Cardano.txExtraKeyWits txbodycontent
+        txExtraKeyWits' = case txExtraKeyWits of
+            Cardano.TxExtraKeyWitnesses _ khs -> khs
+            _ -> []
+        txWithdrawals = Cardano.txWithdrawals txbodycontent
+        txWithdrawals' = case txWithdrawals of
+            Cardano.TxWithdrawals _ wdls ->
+                [ () | (_, _, Cardano.ViewTx) <- wdls ]
+            _ -> []
+        txUpdateProposal = Cardano.txUpdateProposal txbodycontent
+        txUpdateProposal' = case txUpdateProposal of
+            Cardano.TxUpdateProposal _
+                (Cardano.UpdateProposal updatePerGenesisKey _) ->
+                    Map.size updatePerGenesisKey
+            _ -> 0
+        txCerts = case Cardano.txCertificates txbodycontent of
+            Cardano.TxCertificatesNone -> 0
+            Cardano.TxCertificates _ certs _ ->
+                sumVia estimateDelegSigningKeys certs
+        scriptVkWitsUpperBound =
+            fromIntegral
+            $ sumVia estimateMaxWitnessRequiredPerInput
+            $ mapMaybe toTimelockScript scripts
+        nonInputWits = numberOfShelleyWitnesses $ fromIntegral $
+            length txExtraKeyWits' +
+            length txWithdrawals' +
+            txUpdateProposal' +
+            fromIntegral txCerts +
+            scriptVkWitsUpperBound
+        inputWits = KeyWitnessCount
+            { nKeyWits = fromIntegral
+                . length
+                $ filter (not . hasBootstrapAddr utxo) vkInsUnique
+            , nBootstrapWits = fromIntegral
+                . length
+                $ filter (hasBootstrapAddr utxo) vkInsUnique
+            }
+        in
+            nonInputWits <> inputWits
+  where
+    scripts = case txbody of
+        Cardano.ShelleyTxBody _ _ shelleyBodyScripts _ _ _ -> shelleyBodyScripts
+        Byron.ByronTxBody {} -> error "estimateKeyWitnessCount: ByronTxBody"
+
+    dummyKeyRole = CA.Payment
+
+    estimateDelegSigningKeys :: Cardano.Certificate -> Integer
+    estimateDelegSigningKeys = \case
+        Cardano.StakeAddressRegistrationCertificate _ -> 0
+        Cardano.StakeAddressDeregistrationCertificate cred ->
+            estimateWitNumForCred cred
+        Cardano.StakeAddressPoolDelegationCertificate cred _ ->
+            estimateWitNumForCred cred
+        _ -> 1
+      where
+        -- Does not include the key witness needed for script credentials.
+        -- They are accounted for separately in @scriptVkWitsUpperBound@.
+        estimateWitNumForCred = \case
+            Cardano.StakeCredentialByKey _ -> 1
+            Cardano.StakeCredentialByScript _ -> 0
+
+
+    toTimelockScript
+        :: Ledger.Script (Cardano.ShelleyLedgerEra era)
+        -> Maybe (CA.Script CA.KeyHash)
+    toTimelockScript anyScript = case recentEra @era of
+        RecentEraConway ->
+            case anyScript of
+                Alonzo.TimelockScript timelock ->
+                    Just $ toWalletScript (const dummyKeyRole) timelock
+                Alonzo.PlutusScript _ _ -> Nothing
+        RecentEraBabbage ->
+            case anyScript of
+                Alonzo.TimelockScript timelock ->
+                    Just $ toWalletScript (const dummyKeyRole) timelock
+                Alonzo.PlutusScript _ _ -> Nothing
+
+    hasVkPaymentCred
+        :: Cardano.UTxO era
+        -> Cardano.TxIn
+        -> Bool
+    hasVkPaymentCred (Cardano.UTxO u) inp = case Map.lookup inp u of
+        Just (Cardano.TxOut addrInEra _ _ _) -> Cardano.isKeyAddress addrInEra
+        Nothing ->
+            error $ unwords
+                [ "estimateMaxWitnessRequiredPerInput: input not in utxo."
+                , "Caller is expected to ensure this does not happen."
+                ]
+
+    hasBootstrapAddr
+        :: Cardano.UTxO era
+        -> Cardano.TxIn
+        -> Bool
+    hasBootstrapAddr (Cardano.UTxO u) inp = case Map.lookup inp u of
+        Just (Cardano.TxOut addrInEra _ _ _) ->
+            case addrInEra of
+                Cardano.AddressInEra Cardano.ByronAddressInAnyEra _ -> True
+                _ -> False
+        Nothing ->
+            error $ unwords
+                [ "estimateMaxWitnessRequiredPerInput: input not in utxo."
+                , "Caller is expected to ensure this does not happen."
+                ]
+
+--
+-- Helpers
+--
+
+-- Small helper function for summing values. Given a list of values, get the sum
+-- of the values, after the given function has been applied to each value.
+sumVia :: (Foldable t, Num m) => (a -> m) -> t a -> m
+sumVia f = F.foldl' (\t -> (t +) . f) 0

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -106,7 +106,6 @@ import Cardano.Tx.Balance.Internal.CoinSelection
     , SelectionOutputError (..)
     , SelectionOutputErrorInfo (..)
     , UnableToConstructChangeError (..)
-    , emptySkeleton
     , selectionDelta
     )
 import Cardano.Wallet
@@ -234,27 +233,23 @@ import Cardano.Wallet.Shelley.Compatibility
     )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( toBabbageTxOut, toLedger, toLedgerTokenBundle, toWallet )
+
 import Cardano.Wallet.Shelley.Transaction
     ( EraConstraints
-    , KeyWitnessCount (KeyWitnessCount)
-    , TxSkeleton (..)
+    , KeyWitnessCount (..)
     , TxWitnessTag (..)
     , costOfIncreasingCoin
     , distributeSurplus
     , distributeSurplusDelta
     , estimateKeyWitnessCount
     , estimateSignedTxSize
-    , estimateTxSize
     , maximumCostOfIncreasingCoin
     , mkByronWitness
     , mkDelegationCertificates
     , mkShelleyWitness
-    , mkTxSkeleton
     , mkUnsignedTx
     , newTransactionLayer
     , sizeOfCoin
-    , sizeOf_BootstrapWitnesses
-    , txConstraints
     , _decodeSealedTx
     )
 import Cardano.Wallet.Transaction
@@ -263,7 +258,6 @@ import Cardano.Wallet.Transaction
     , TransactionLayer (..)
     , TxFeeAndChange (TxFeeAndChange)
     , WitnessCountCtx (..)
-    , defaultTransactionCtx
     )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
@@ -291,6 +285,12 @@ import Cardano.Wallet.Write.Tx.Balance
     , noTxUpdate
     , posAndNegFromCardanoValue
     , updateTx
+    )
+import Cardano.Wallet.Write.Tx.Balance.CoinSelection
+    ( TxSkeleton (..)
+    , estimateTxSize
+    , sizeOf_BootstrapWitnesses
+    , txConstraints
     )
 import Cardano.Wallet.Write.Tx.TimeTranslation
     ( TimeTranslation, timeTranslationFromEpochInfo )
@@ -1679,10 +1679,8 @@ dummyProtocolParameters = ProtocolParameters
 --------------------------------------------------------------------------------
 
 emptyTxSkeleton :: TxSkeleton
-emptyTxSkeleton = mkTxSkeleton
-    TxWitnessShelleyUTxO
-    defaultTransactionCtx
-    emptySkeleton
+emptyTxSkeleton =
+    TxSkeleton TxWitnessShelleyUTxO 0 [] [] Nothing
 
 mockFeePolicy :: FeePolicy
 mockFeePolicy = LinearFee $ LinearFunction

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -69,8 +69,6 @@ import Cardano.Api.Shelley
     ( fromShelleyLovelace )
 import Cardano.Binary
     ( ToCBOR, serialize', unsafeDeserialize' )
-import Cardano.BM.Data.Tracer
-    ( nullTracer )
 import Cardano.Ledger.Alonzo.Genesis
     ( AlonzoGenesis (..) )
 import Cardano.Ledger.Alonzo.TxInfo
@@ -2996,7 +2994,6 @@ balanceTx
     = (`evalRand` stdGenFromSeed seed) $ runExceptT $ do
         (transactionInEra, _nextChangeState) <-
             balanceTransaction
-                nullTracer
                 utxoAssumptions
                 protocolParameters
                 timeTranslation
@@ -3017,7 +3014,6 @@ balanceTransactionWithDummyChangeState
 balanceTransactionWithDummyChangeState utxoAssumptions utxo seed partialTx =
     (`evalRand` stdGenFromSeed seed) $ runExceptT $
         balanceTransaction
-            nullTracer
             utxoAssumptions
             mockPParamsForBalancing
             dummyTimeTranslation

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -237,23 +237,19 @@ import Cardano.Wallet.Shelley.Compatibility.Ledger
 import Cardano.Wallet.Shelley.Transaction
     ( EraConstraints
     , TxWitnessTag (..)
-    , costOfIncreasingCoin
-    , distributeSurplus
-    , distributeSurplusDelta
-    , maximumCostOfIncreasingCoin
+    , TxWitnessTagFor (txWitnessTagFor)
     , mkByronWitness
     , mkDelegationCertificates
     , mkShelleyWitness
     , mkUnsignedTx
     , newTransactionLayer
-    , sizeOfCoin
     , _decodeSealedTx
     )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
-    , ErrMoreSurplusNeeded (..)
+    , TransactionCtx (..)
     , TransactionLayer (..)
-    , TxFeeAndChange (TxFeeAndChange)
+    , Withdrawal (..)
     , WitnessCountCtx (..)
     )
 import Cardano.Wallet.Unsafe
@@ -271,16 +267,23 @@ import Cardano.Wallet.Write.Tx.Balance
     , ErrAssignRedeemers (..)
     , ErrBalanceTx (..)
     , ErrBalanceTxInternalError (..)
+    , ErrMoreSurplusNeeded (..)
     , ErrSelectAssets (..)
     , ErrUpdateSealedTx (..)
     , PartialTx (..)
+    , TxFeeAndChange (..)
     , TxFeeUpdate (..)
     , TxUpdate (..)
     , UTxOAssumptions (..)
     , balanceTransaction
     , constructUTxOIndex
+    , costOfIncreasingCoin
+    , distributeSurplus
+    , distributeSurplusDelta
+    , maximumCostOfIncreasingCoin
     , noTxUpdate
     , posAndNegFromCardanoValue
+    , sizeOfCoin
     , updateTx
     )
 import Cardano.Wallet.Write.Tx.Balance.CoinSelection

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -84,7 +84,7 @@ import Cardano.Ledger.Api
     , ValidityInterval (..)
     , bootAddrTxWitsL
     , ppCoinsPerUTxOByteL
-    , ppCoinsPerUTxOWordL
+    , ppMaxTxSizeL
     , ppMinFeeAL
     , scriptTxWitsL
     , witsTxL
@@ -153,16 +153,7 @@ import Cardano.Wallet.Primitive.Passphrase
 import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..)
-    , BlockHeader (..)
-    , ExecutionUnitPrices (..)
-    , ExecutionUnits (..)
-    , FeePolicy (..)
-    , LinearFunction (..)
-    , ProtocolParameters (..)
-    , TokenBundleMaxSize (..)
-    , TxParameters (..)
-    )
+    ( Block (..), BlockHeader (..), TokenBundleMaxSize (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -173,8 +164,6 @@ import Cardano.Wallet.Primitive.Types.Credentials
     ( ClearCredentials, RootCredentials (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..), mockHash )
-import Cardano.Wallet.Primitive.Types.MinimumUTxO
-    ( minimumUTxOForShelleyBasedEra )
 import Cardano.Wallet.Primitive.Types.MinimumUTxO.Gen
     ( testParameter_coinsPerUTxOByte_Babbage
     , testParameter_coinsPerUTxOWord_Alonzo
@@ -237,7 +226,6 @@ import Cardano.Wallet.Shelley.Compatibility.Ledger
 import Cardano.Wallet.Shelley.Transaction
     ( EraConstraints
     , TxWitnessTag (..)
-    , TxWitnessTagFor (txWitnessTagFor)
     , mkByronWitness
     , mkDelegationCertificates
     , mkShelleyWitness
@@ -246,12 +234,7 @@ import Cardano.Wallet.Shelley.Transaction
     , _decodeSealedTx
     )
 import Cardano.Wallet.Transaction
-    ( DelegationAction (..)
-    , TransactionCtx (..)
-    , TransactionLayer (..)
-    , Withdrawal (..)
-    , WitnessCountCtx (..)
-    )
+    ( DelegationAction (..), TransactionLayer (..), WitnessCountCtx (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Cardano.Wallet.Write.Tx
@@ -1652,29 +1635,6 @@ dummyWit b =
 dummyTxId :: Hash "Tx"
 dummyTxId = Hash $ BS.pack $ replicate 32 0
 
-dummyProtocolParameters :: ProtocolParameters
-dummyProtocolParameters = ProtocolParameters
-    { decentralizationLevel =
-        error "dummyProtocolParameters: decentralizationLevel"
-    , txParameters =
-        error "dummyProtocolParameters: txParameters"
-    , desiredNumberOfStakePools =
-        error "dummyProtocolParameters: desiredNumberOfStakePools"
-    , minimumUTxO =
-        error "dummyProtocolParameters: minimumUTxO"
-    , stakeKeyDeposit =
-        error "dummyProtocolParameters: stakeKeyDeposit"
-    , eras =
-        error "dummyProtocolParameters: eras"
-    , maximumCollateralInputCount =
-        error "dummyProtocolParameters: maximumCollateralInputCount"
-    , minimumCollateralPercentage =
-        error "dummyProtocolParameters: minimumCollateralPercentage"
-    , executionUnitPrices =
-        error "dummyProtocolParameters: executionUnitPrices"
-    , currentLedgerProtocolParameters =
-        error "dummyProtocolParameters: currentLedgerProtocolParameters"
-    }
 
 --------------------------------------------------------------------------------
 -- Transaction constraints
@@ -1684,33 +1644,11 @@ emptyTxSkeleton :: TxSkeleton
 emptyTxSkeleton =
     TxSkeleton TxWitnessShelleyUTxO 0 [] [] Nothing
 
-mockFeePolicy :: FeePolicy
-mockFeePolicy = LinearFee $ LinearFunction
-    { intercept = 155_381
-    , slope = 44
-    }
-
-mockProtocolParameters :: ProtocolParameters
-mockProtocolParameters = dummyProtocolParameters
-    { executionUnitPrices = Just $ ExecutionUnitPrices
-        (721 % 10_000_000)
-        (577 %     10_000)
-    , txParameters = TxParameters
-        { getFeePolicy = mockFeePolicy
-        , getTxMaxSize = Quantity 16_384
-        , getTokenBundleMaxSize = TokenBundleMaxSize $ TxSize 4_000
-        , getMaxExecutionUnits = ExecutionUnits 10_000_000_000 14_000_000
-        }
-    , minimumUTxO
-        = minimumUTxOForShelleyBasedEra Cardano.ShelleyBasedEraAlonzo
-            $ def & ppCoinsPerUTxOWordL .~ testParameter_coinsPerUTxOWord_Alonzo
-    , maximumCollateralInputCount = 3
-    , minimumCollateralPercentage = 150
-    }
-
 mockTxConstraints :: TxConstraints
 mockTxConstraints =
-    txConstraints mockProtocolParameters TxWitnessShelleyUTxO
+    txConstraints
+        (mockPParamsForBalancing @Cardano.BabbageEra)
+        TxWitnessShelleyUTxO
 
 data MockSelection = MockSelection
     { txInputCount :: Int
@@ -3482,8 +3420,7 @@ prop_balanceTransactionValid
                 estimateSignedTxSize ledgerPParams
                     (estimateKeyWitnessCount utxo body)
                     body
-        let limit = fromIntegral $ getQuantity $
-                view (#txParameters . #getTxMaxSize) mockProtocolParameters
+        let limit = ledgerPParams ^. ppMaxTxSizeL
         let msg = unwords
                 [ "The tx size "
                 , show size

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3218,7 +3218,7 @@ txMinFee tx@(Cardano.Tx body _) u =
             RecentEraBabbage
             (Write.pparamsLedger $ mockPParamsForBalancing @Cardano.BabbageEra)
             (Write.fromCardanoTx tx)
-            (estimateKeyWitnessCount u body)
+            (estimateKeyWitnessCount (Write.fromCardanoUTxO u) body)
 
 -- NOTE: 'balanceTransaction' relies on estimating the number of witnesses that
 -- will be needed. The correctness of this estimation is not tested here.
@@ -3418,7 +3418,7 @@ prop_balanceTransactionValid
     prop_validSize tx@(Cardano.Tx body _) utxo = do
         let (TxSize size) =
                 estimateSignedTxSize ledgerPParams
-                    (estimateKeyWitnessCount utxo body)
+                    (estimateKeyWitnessCount (Write.fromCardanoUTxO utxo) body)
                     body
         let limit = ledgerPParams ^. ppMaxTxSizeL
         let msg = unwords
@@ -3486,7 +3486,7 @@ prop_balanceTransactionValid
     minFee tx@(Cardano.Tx body _) utxo = Write.toCardanoLovelace
         $ Write.evaluateMinimumFee (recentEra @era) ledgerPParams
             (Write.fromCardanoTx tx)
-            (estimateKeyWitnessCount utxo body)
+            (estimateKeyWitnessCount (Write.fromCardanoUTxO utxo) body)
 
     txBalance
         :: Cardano.Tx era
@@ -3804,7 +3804,7 @@ estimateSignedTxSizeSpec = describe "estimateSignedTxSize" $ do
     test _name bs tx@(Cardano.Tx (body :: Cardano.TxBody era) _) = do
         let pparams = Write.pparamsLedger $ mockPParamsForBalancing @era
             utxo = utxoPromisingInputsHaveVkPaymentCreds body
-            witCount = estimateKeyWitnessCount utxo body
+            witCount = estimateKeyWitnessCount (Write.fromCardanoUTxO utxo) body
 
             ledgerTx :: Write.Tx (Write.ShelleyLedgerEra era)
             ledgerTx = Write.fromCardanoTx @era tx

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -236,13 +236,10 @@ import Cardano.Wallet.Shelley.Compatibility.Ledger
 
 import Cardano.Wallet.Shelley.Transaction
     ( EraConstraints
-    , KeyWitnessCount (..)
     , TxWitnessTag (..)
     , costOfIncreasingCoin
     , distributeSurplus
     , distributeSurplusDelta
-    , estimateKeyWitnessCount
-    , estimateSignedTxSize
     , maximumCostOfIncreasingCoin
     , mkByronWitness
     , mkDelegationCertificates
@@ -292,6 +289,8 @@ import Cardano.Wallet.Write.Tx.Balance.CoinSelection
     , sizeOf_BootstrapWitnesses
     , txConstraints
     )
+import Cardano.Wallet.Write.Tx.Sign
+    ( KeyWitnessCount (..), estimateKeyWitnessCount, estimateSignedTxSize )
 import Cardano.Wallet.Write.Tx.TimeTranslation
     ( TimeTranslation, timeTranslationFromEpochInfo )
 import Control.Arrow

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -260,7 +260,6 @@ import Cardano.Wallet.Shelley.Transaction
     )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
-    , ErrAssignRedeemers (..)
     , ErrMoreSurplusNeeded (..)
     , TransactionLayer (..)
     , TxFeeAndChange (TxFeeAndChange)
@@ -279,6 +278,7 @@ import Cardano.Wallet.Write.Tx
     )
 import Cardano.Wallet.Write.Tx.Balance
     ( ChangeAddressGen (..)
+    , ErrAssignRedeemers (..)
     , ErrBalanceTx (..)
     , ErrBalanceTxInternalError (..)
     , ErrSelectAssets (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -245,7 +245,6 @@ import Cardano.Wallet.Shelley.Transaction
     , estimateKeyWitnessCount
     , estimateSignedTxSize
     , estimateTxSize
-    , evaluateMinimumFee
     , maximumCostOfIncreasingCoin
     , mkByronWitness
     , mkDelegationCertificates
@@ -3275,16 +3274,13 @@ txMinFee
     :: Cardano.Tx Cardano.BabbageEra
     -> Cardano.UTxO Cardano.BabbageEra
     -> Cardano.Lovelace
-txMinFee (Cardano.Tx body _) u =
-    toCardanoLovelace
-        $ evaluateMinimumFee
-            ( either (error . show) id $
-                Cardano.bundleProtocolParams
-                    Cardano.BabbageEra
-                    mockCardanoApiPParamsForBalancing
-            )
+txMinFee tx@(Cardano.Tx body _) u =
+    Write.toCardanoLovelace
+        $ Write.evaluateMinimumFee
+            RecentEraBabbage
+            (Write.pparamsLedger $ mockPParamsForBalancing @Cardano.BabbageEra)
+            (Write.fromCardanoTx tx)
             (estimateKeyWitnessCount u body)
-            body
 
 -- NOTE: 'balanceTransaction' relies on estimating the number of witnesses that
 -- will be needed. The correctness of this estimation is not tested here.

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -1296,8 +1296,6 @@ dummyTransactionLayer = TransactionLayer
         error "dummyTransactionLayer: mkUnsignedTransaction not implemented"
     , tokenBundleSizeAssessor =
         error "dummyTransactionLayer: tokenBundleSizeAssessor not implemented"
-    , constraints =
-        error "dummyTransactionLayer: constraints not implemented"
     , decodeTx = \_era _witCtx _sealed ->
         ( Tx
             { txId = Hash ""


### PR DESCRIPTION
## `Write.Tx.Balance.CoinSelection`
```haskell
module Cardano.Wallet.Write.Tx.Balance.CoinSelection
    ( -- Coin-selection for balanceTx
      -- TODO: Move the actual coin-selection function to here
      estimateTxSize
    , estimateTxCost
    , TxSkeleton (..)
    , sizeOf_BootstrapWitnesses

      -- * Needed For migration
    , txConstraints

      -- * Needed by the wallet
    , _txRewardWithdrawalCost
    )
```

## `Write.Tx.Sign`
```haskell
-- Module for 'signTx' and signing-related utilities for balancing.
module Cardano.Wallet.Write.Tx.Sign
    (
    -- * Signing transactions
    -- TODO: Move signTx function here

    -- * Signing-related utilities required for balancing
      estimateSignedTxSize

    , KeyWitnessCount (..)
    , estimateKeyWitnessCount

    , estimateMaxWitnessRequiredPerInput
    , estimateMinWitnessRequiredPerInput
    )
    where
```

### Comments

- Preceding PR: #4030 
- Preceding PR: #4031 

### Issue Number

ADP-3081
