### PR TITLE
Move `estimateTxSize` etc to separate module

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -410,9 +410,9 @@ library
     Cardano.Wallet.Write.ProtocolParameters
     Cardano.Wallet.Write.Tx
     Cardano.Wallet.Write.Tx.Balance
-    Cardano.Wallet.Write.Tx.Balance.CoinSelection
     Cardano.Wallet.Write.Tx.Gen
     Cardano.Wallet.Write.Tx.Redeemers
+    Cardano.Wallet.Write.Tx.SizeEstimation
     Cardano.Wallet.Write.Tx.TimeTranslation
     Cardano.Wallet.Write.UTxOAssumptions
     Control.Concurrent.Concierge

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -410,6 +410,7 @@ library
     Cardano.Wallet.Write.ProtocolParameters
     Cardano.Wallet.Write.Tx
     Cardano.Wallet.Write.Tx.Balance
+    Cardano.Wallet.Write.Tx.Balance.CoinSelection
     Cardano.Wallet.Write.Tx.Gen
     Cardano.Wallet.Write.Tx.Redeemers
     Cardano.Wallet.Write.Tx.TimeTranslation

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -497,8 +497,6 @@ import Cardano.Wallet.Shelley.Compatibility
     )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( toWallet )
-import Cardano.Wallet.Shelley.Transaction
-    ( getFeePerByteFromWalletPParams, _txRewardWithdrawalCost )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , ErrCannotJoin (..)
@@ -532,6 +530,8 @@ import Cardano.Wallet.Write.Tx.Balance
     , balanceTransaction
     , constructUTxOIndex
     )
+import Cardano.Wallet.Write.Tx.Balance.CoinSelection
+    ( getFeePerByteFromWalletPParams, _txRewardWithdrawalCost )
 import Cardano.Wallet.Write.Tx.TimeTranslation
     ( TimeTranslation )
 import Control.Arrow
@@ -664,6 +664,7 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Cardano.Wallet.Read as Read
 import qualified Cardano.Wallet.Write.ProtocolParameters as Write
 import qualified Cardano.Wallet.Write.Tx as Write
+import qualified Cardano.Wallet.Write.Tx.Balance.CoinSelection as Write
 import qualified Data.ByteArray as BA
 import qualified Data.Delta.Update as Delta
 import qualified Data.Foldable as F
@@ -1026,7 +1027,7 @@ getWalletUtxoSnapshot ctx = do
         computeMinAdaQuantity :: TxOut -> Coin
         computeMinAdaQuantity (TxOut addr bundle) =
             view #txOutputMinimumAdaQuantity
-                (constraints tl pp)
+                (Write.txConstraints pp (transactionWitnessTag tl))
                 (addr)
                 (view #tokens bundle)
 
@@ -1852,8 +1853,10 @@ calcMinimumCoinValues
     -> TxOut
     -> Coin
 calcMinimumCoinValues pp txLayer =
-    uncurry (constraints txLayer pp ^. #txOutputMinimumAdaQuantity)
+    uncurry (constraints ^. #txOutputMinimumAdaQuantity)
      . (\o -> (o ^. #address, o ^. #tokens . #tokens))
+  where
+    constraints = Write.txConstraints pp $ transactionWitnessTag txLayer
 
 signTransaction
   :: forall k ktype
@@ -2697,7 +2700,7 @@ createMigrationPlan
 createMigrationPlan ctx rewardWithdrawal = do
     (wallet, _, pending) <- readWallet ctx
     pp <- currentProtocolParameters nl
-    let txConstraints = constraints tl pp
+    let txConstraints = Write.txConstraints pp (transactionWitnessTag tl)
     let utxo = availableUTxO pending wallet
     pure
         $ Migration.createPlan txConstraints utxo

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -530,7 +530,7 @@ import Cardano.Wallet.Write.Tx.Balance
     , balanceTransaction
     , constructUTxOIndex
     )
-import Cardano.Wallet.Write.Tx.Balance.CoinSelection
+import Cardano.Wallet.Write.Tx.SizeEstimation
     ( getFeePerByteFromWalletPParams, _txRewardWithdrawalCost )
 import Cardano.Wallet.Write.Tx.TimeTranslation
     ( TimeTranslation )
@@ -664,7 +664,7 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Cardano.Wallet.Read as Read
 import qualified Cardano.Wallet.Write.ProtocolParameters as Write
 import qualified Cardano.Wallet.Write.Tx as Write
-import qualified Cardano.Wallet.Write.Tx.Balance.CoinSelection as Write
+import qualified Cardano.Wallet.Write.Tx.SizeEstimation as Write
 import qualified Data.ByteArray as BA
 import qualified Data.Delta.Update as Delta
 import qualified Data.Foldable as F

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE EmptyCase #-}
@@ -24,6 +23,9 @@
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Use camelCase" -}
 
+-- NamedFieldPuns needed to suppress warnings:
+{- HLINT ignore "Unused LANGUAGE pragma" -}
+
 -- |
 -- Copyright: © 2020 IOHK
 -- License: Apache-2.0
@@ -45,23 +47,15 @@ module Cardano.Wallet.Shelley.Transaction
 
     -- * Internals
     , TxPayload (..)
-    , TxSkeleton (..)
     , TxWitnessTag (..)
     , TxWitnessTagFor (..)
     , EraConstraints
     , _decodeSealedTx
     , mkDelegationCertificates
-    , getFeePerByteFromWalletPParams
-    , _txRewardWithdrawalCost
-    , estimateTxCost
-    , estimateTxSize
     , mkByronWitness
     , mkShelleyWitness
     , mkTx
-    , mkTxSkeleton
     , mkUnsignedTx
-    , txConstraints
-    , sizeOf_BootstrapWitnesses
     ) where
 
 import Prelude
@@ -69,12 +63,10 @@ import Prelude
 import Cardano.Address.Derivation
     ( XPrv, toXPub )
 import Cardano.Address.Script
-    ( Cosigner
-    , KeyHash (..)
+    ( KeyHash (..)
     , KeyRole (..)
     , Script (..)
     , ScriptHash (..)
-    , ScriptTemplate (..)
     , foldScript
     , toScriptHash
     )
@@ -99,7 +91,6 @@ import Cardano.Ledger.Crypto
 import Cardano.Tx.Balance.Internal.CoinSelection
     ( SelectionOf (..)
     , SelectionOutputTokenQuantityExceedsLimitError (..)
-    , SelectionSkeleton (..)
     , selectionDelta
     )
 import Cardano.Wallet.Address.Derivation
@@ -108,8 +99,6 @@ import Cardano.Wallet.Address.Derivation.SharedKey
     ( replaceCosignersWithVerKeys )
 import Cardano.Wallet.Address.Derivation.Shelley
     ( toRewardAccountRaw )
-import Cardano.Wallet.Address.Discovery.Shared
-    ( estimateMaxWitnessRequiredPerInput )
 import Cardano.Wallet.Address.Keys.WalletKey
     ( getRawKey )
 import Cardano.Wallet.Flavor
@@ -117,12 +106,7 @@ import Cardano.Wallet.Flavor
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Certificate
-    , FeePolicy (..)
-    , LinearFunction (..)
-    , ProtocolParameters (..)
-    , TxParameters (..)
-    )
+    ( Certificate )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -133,10 +117,6 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..), TokenMap )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( TokenName (..) )
-import Cardano.Wallet.Primitive.Types.TokenQuantity
-    ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)
     , Tx (..)
@@ -145,7 +125,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , sealedTxFromCardanoBody
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TxConstraints (..), TxSize (..), txOutMaxTokenQuantity, txSizeDistance )
+    ( TxSize (..), txOutMaxTokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn (..) )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
@@ -169,9 +149,7 @@ import Cardano.Wallet.Shelley.Compatibility
     , toStakePoolDlgCert
     )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( toLedger, toWallet, toWalletCoin, toWalletScript )
-import Cardano.Wallet.Shelley.MinimumUTxO
-    ( computeMinimumCoinForUTxO, isBelowMinimumCoinForUTxO )
+    ( Convert (..), toWalletCoin, toWalletScript )
 import Cardano.Wallet.Transaction
     ( AnyExplicitScript (..)
     , AnyScript (..)
@@ -194,11 +172,7 @@ import Cardano.Wallet.TxWitnessTag
 import Cardano.Wallet.Util
     ( HasCallStack, internalError )
 import Cardano.Wallet.Write.Tx
-    ( FeePerByte (..)
-    , IsRecentEra (recentEra)
-    , KeyWitnessCount (..)
-    , RecentEra (..)
-    )
+    ( FeePerByte (..), IsRecentEra (..), KeyWitnessCount (..), RecentEra (..) )
 import Control.Arrow
     ( left, second )
 import Control.Lens
@@ -219,22 +193,13 @@ import Data.Map.Strict
     ( Map )
 import Data.Maybe
     ( mapMaybe )
-import Data.Quantity
-    ( Quantity (..) )
-import Data.Set
-    ( Set )
 import Data.Type.Equality
     ( type (==) )
-import Data.Word
-    ( Word64, Word8 )
-import GHC.Generics
-    ( Generic )
 import Numeric.Natural
     ( Natural )
 import Ouroboros.Network.Block
     ( SlotNo )
 
-import qualified Cardano.Address.Script as CA
 import qualified Cardano.Address.Style.Shelley as CA
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Byron as Byron
@@ -247,15 +212,13 @@ import qualified Cardano.Crypto.Wallet as Crypto.HD
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Ledger.Keys.Bootstrap as SL
+import Cardano.Wallet.Address.Discovery.Shared
+    ( estimateMaxWitnessRequiredPerInput )
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
-import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Ledger
 import qualified Cardano.Wallet.Write.Tx as Write
-import qualified Codec.CBOR.Encoding as CBOR
-import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteString as BS
 import qualified Data.Foldable as F
 import qualified Data.List as L
@@ -652,8 +615,6 @@ newTransactionLayer keyF networkId = TransactionLayer
     , tokenBundleSizeAssessor =
         Compatibility.tokenBundleSizeAssessor
 
-    , constraints = \pp -> txConstraints pp (txWitnessTagFor @k)
-
     , decodeTx = _decodeSealedTx
 
     , transactionWitnessTag = txWitnessTagFor @k
@@ -740,7 +701,7 @@ estimateSignedTxSize pparams nWits body =
         Cardano.ShelleyTx _era ledgerTx -> ledgerTx
 
     feePerByte :: Coin
-    feePerByte = Ledger.toWalletCoin $
+    feePerByte = toWalletCoin $
         case Write.recentEra @era of
             Write.RecentEraBabbage -> pparams ^. ppMinFeeAL
             Write.RecentEraConway -> pparams ^. ppMinFeeAL
@@ -881,214 +842,6 @@ estimateKeyWitnessCount utxo txbody@(Cardano.TxBody txbodycontent) =
                 [ "estimateMaxWitnessRequiredPerInput: input not in utxo."
                 , "Caller is expected to ensure this does not happen."
                 ]
-
-getFeePerByteFromWalletPParams
-    :: ProtocolParameters
-    -> FeePerByte
-getFeePerByteFromWalletPParams pp =
-    FeePerByte $ ceiling slope
-  where
-    LinearFee LinearFunction{slope} = getFeePolicy $ txParameters pp
-
--- | Like the 'TxConstraints' field 'txRewardWithdrawalCost', but with added
--- support for shared wallets via the 'CA.ScriptTemplate' argument.
---
--- We may or may not want to support shared wallets in the full txConstraints.
-_txRewardWithdrawalCost
-    :: Write.FeePerByte
-    -> Either CA.ScriptTemplate TxWitnessTag
-    -> Coin -- ^ Withdrawal amount
-    -> Coin
-_txRewardWithdrawalCost feePerByte witType =
-    toWallet
-    . Write.feeOfBytes feePerByte
-    . unTxSize
-    . _txRewardWithdrawalSize witType
-
--- | Like the 'TxConstraints' field 'txRewardWithdrawalSize', but with added
--- support for shared wallets via the 'CA.ScriptTemplate' argument.
---
--- We may or may not want to support shared wallets in the full txConstraints.
-_txRewardWithdrawalSize
-    :: Either CA.ScriptTemplate TxWitnessTag
-    -> Coin -- ^ Withdrawal amount
-    -> TxSize
-_txRewardWithdrawalSize _ (Coin 0) = TxSize 0
-_txRewardWithdrawalSize witType _ =
-        sizeOf_Withdrawals 1 <> witSize
-      where
-        witSize :: TxSize
-        witSize = case witType of
-            Right TxWitnessByronUTxO ->
-                sizeOf_BootstrapWitnesses 1
-            Right TxWitnessShelleyUTxO ->
-                sizeOf_VKeyWitnesses 1
-            Left scriptTemplate ->
-                let n = estimateMaxWitnessRequiredPerInput
-                        $ view #template scriptTemplate
-                in sizeOf_VKeyWitnesses n
-
-txConstraints
-    :: ProtocolParameters -> TxWitnessTag -> TxConstraints
-txConstraints protocolParams witnessTag = TxConstraints
-    { txBaseCost
-    , txBaseSize
-    , txInputCost
-    , txInputSize
-    , txOutputCost
-    , txOutputSize
-    , txOutputMaximumSize
-    , txOutputMaximumTokenQuantity
-    , txOutputMinimumAdaQuantity
-    , txOutputBelowMinimumAdaQuantity
-    , txRewardWithdrawalCost
-    , txRewardWithdrawalSize
-    , txMaximumSize
-    }
-  where
-    txBaseCost =
-        constantTxFee <> estimateTxCost feePerByte empty
-
-    constantTxFee = Coin $ ceiling intercept
-    feePerByte = getFeePerByteFromWalletPParams protocolParams
-    LinearFee LinearFunction {intercept}
-        = getFeePolicy $ txParameters protocolParams
-
-    txBaseSize =
-        estimateTxSize empty
-
-    txInputCost =
-        marginalCostOf empty {txInputCount = 1}
-
-    txInputSize =
-        marginalSizeOf empty {txInputCount = 1}
-
-    txOutputCost bundle =
-        marginalCostOf empty {txOutputs = [mkTxOut bundle]}
-
-    txOutputSize bundle =
-        marginalSizeOf empty {txOutputs = [mkTxOut bundle]}
-
-    txOutputMaximumSize = (<>)
-        (txOutputSize mempty)
-        (view
-            (#txParameters . #getTokenBundleMaxSize . #unTokenBundleMaxSize)
-            protocolParams)
-
-    txOutputMaximumTokenQuantity =
-        TokenQuantity $ fromIntegral $ maxBound @Word64
-
-    txOutputMinimumAdaQuantity =
-        computeMinimumCoinForUTxO (minimumUTxO protocolParams)
-
-    txOutputBelowMinimumAdaQuantity =
-        isBelowMinimumCoinForUTxO (minimumUTxO protocolParams)
-
-    txRewardWithdrawalCost =
-        _txRewardWithdrawalCost feePerByte (Right witnessTag)
-
-    txRewardWithdrawalSize =
-        _txRewardWithdrawalSize (Right witnessTag)
-
-    txMaximumSize = protocolParams
-        & view (#txParameters . #getTxMaxSize)
-        & getQuantity
-        & fromIntegral
-        & TxSize
-
-    empty :: TxSkeleton
-    empty = emptyTxSkeleton witnessTag
-
-    -- Computes the size difference between the given skeleton and an empty
-    -- skeleton.
-    marginalCostOf :: TxSkeleton -> Coin
-    marginalCostOf skeleton =
-        Coin.distance
-            (estimateTxCost feePerByte empty)
-            (estimateTxCost feePerByte skeleton)
-
-    -- Computes the size difference between the given skeleton and an empty
-    -- skeleton.
-    marginalSizeOf :: TxSkeleton -> TxSize
-    marginalSizeOf =
-        txSizeDistance txBaseSize . estimateTxSize
-
-    -- Constructs a real transaction output from a token bundle.
-    mkTxOut :: TokenBundle -> TxOut
-    mkTxOut = TxOut dummyAddress
-      where
-        dummyAddress :: Address
-        dummyAddress = Address $ BS.replicate dummyAddressLength nullByte
-
-        dummyAddressLength :: Int
-        dummyAddressLength = 57
-        -- Note: We are at liberty to overestimate the length of an address
-        -- (which is safe). Therefore, we can choose a length that we know is
-        -- greater than or equal to all address lengths.
-
-        nullByte :: Word8
-        nullByte = 0
-
--- | Includes just the parts of a transaction necessary to estimate its size.
---
--- In particular, this record type includes the minimal set of data needed for
--- the 'estimateTxCost' and 'estimateTxSize' functions to perform their
--- calculations, and nothing else.
---
--- The data included in 'TxSkeleton' is a subset of the data included in the
--- union of 'SelectionSkeleton' and 'TransactionCtx'.
---
-data TxSkeleton = TxSkeleton
-    { txWitnessTag :: !TxWitnessTag
-    , txInputCount :: !Int
-    , txOutputs :: ![TxOut]
-    , txChange :: ![Set AssetId]
-    , txPaymentTemplate :: !(Maybe (Script Cosigner))
-    }
-    deriving (Eq, Show, Generic)
-
--- | Constructs an empty transaction skeleton.
---
--- This may be used to estimate the size and cost of an empty transaction.
---
-emptyTxSkeleton :: TxWitnessTag -> TxSkeleton
-emptyTxSkeleton txWitnessTag = TxSkeleton
-    { txWitnessTag
-    , txInputCount = 0
-    , txOutputs = []
-    , txChange = []
-    , txPaymentTemplate = Nothing
-    }
-
--- | Constructs a transaction skeleton from wallet primitive types.
---
--- This function extracts a subset of the data included in 'SelectionSkeleton'
--- and 'TransactionCtx'.
---
-mkTxSkeleton
-    :: TxWitnessTag
-    -> TransactionCtx
-    -> SelectionSkeleton
-    -> TxSkeleton
-mkTxSkeleton witness context skeleton = TxSkeleton
-    { txWitnessTag = witness
-    , txInputCount = view #skeletonInputCount skeleton
-    , txOutputs = view #skeletonOutputs skeleton
-    , txChange = view #skeletonChange skeleton
-    , txPaymentTemplate =
-        template <$>
-        view #txPaymentCredentialScriptTemplate context
-    }
-
--- | Estimates the final cost of a transaction based on its skeleton.
---
--- The constant tx fee is /not/ included in the result of this function.
-estimateTxCost :: FeePerByte -> TxSkeleton -> Coin
-estimateTxCost (FeePerByte feePerByte) skeleton =
-    computeFee (estimateTxSize skeleton)
-  where
-    computeFee :: TxSize -> Coin
-    computeFee (TxSize size) = Coin $ feePerByte * size
 
 -- | Calculate the cost of increasing a CBOR-encoded Coin-value by another Coin
 -- with the lovelace/byte cost given by the 'FeePolicy'.
@@ -1274,395 +1027,6 @@ burnSurplusAsFees feePolicy surplus (TxFeeAndChange fee0 ())
   where
     costOfBurningSurplus = costOfIncreasingCoin feePolicy fee0 surplus
     shortfall = costOfBurningSurplus `Coin.difference` surplus
-
--- | Estimates the final size of a transaction based on its skeleton.
---
--- This function uses the upper bounds of CBOR serialized objects as the basis
--- for many of its calculations. The following document is used as a reference:
---
--- https://github.com/input-output-hk/cardano-ledger/blob/master/eras/shelley/test-suite/cddl-files/shelley.cddl
--- https://github.com/input-output-hk/cardano-ledger/blob/master/eras/shelley-ma/test-suite/cddl-files/shelley-ma.cddl
--- https://github.com/input-output-hk/cardano-ledger/blob/master/eras/alonzo/test-suite/cddl-files/alonzo.cddl
---
-estimateTxSize
-    :: TxSkeleton
-    -> TxSize
-estimateTxSize skeleton =
-    sizeOf_Transaction
-  where
-    TxSkeleton
-        { txWitnessTag
-        , txInputCount
-        , txOutputs
-        , txChange
-        , txPaymentTemplate
-        } = skeleton
-
-    numberOf_Inputs :: Natural
-    numberOf_Inputs
-        = fromIntegral txInputCount
-
-    numberOf_ScriptVkeyWitnessesForPayment
-        = maybe 0 estimateMaxWitnessRequiredPerInput txPaymentTemplate
-
-    numberOf_VkeyWitnesses
-        = case txWitnessTag of
-            TxWitnessByronUTxO -> 0
-            TxWitnessShelleyUTxO ->
-                -- there cannot be missing payment script if there is delegation script
-                -- the latter is optional
-                if numberOf_ScriptVkeyWitnessesForPayment == 0 then
-                    numberOf_Inputs
-                else
-                    (numberOf_Inputs * numberOf_ScriptVkeyWitnessesForPayment)
-
-    numberOf_BootstrapWitnesses
-        = case txWitnessTag of
-            TxWitnessByronUTxO -> numberOf_Inputs
-            TxWitnessShelleyUTxO -> 0
-
-    -- transaction =
-    --   [ transaction_body
-    --   , transaction_witness_set
-    --   , transaction_metadata / null
-    --   ]
-    sizeOf_Transaction
-        = sizeOf_SmallArray
-        + sizeOf_TransactionBody
-        + sizeOf_WitnessSet
-
-    -- transaction_body =
-    --   { 0 : set<transaction_input>
-    --   , 1 : [* transaction_output]
-    --   , 2 : coin ; fee
-    --   , 3 : uint ; ttl
-    --   , ? 4 : [* certificate]
-    --   , ? 5 : withdrawals
-    --   , ? 6 : update
-    --   , ? 7 : metadata_hash
-    --   , ? 8 : uint ; validity interval start
-    --   , ? 9 : mint
-    --   }
-    sizeOf_TransactionBody
-        = sizeOf_SmallMap
-        + sizeOf_Inputs
-        + sizeOf_Outputs
-        + sizeOf_Fee
-        + sizeOf_Ttl
-        + sizeOf_Update
-        + sizeOf_ValidityIntervalStart
-        + sizeOf_HistoricalPadding
-      where
-        -- Preserved out of caution during refactoring. We should be able to
-        -- drop this, but we may as well wait until we have completely
-        -- water-proof testing of the size estimation, e.g:
-        -- prop> forall baseTx update.
-        --      sizeOf_Update x >=
-        --          (serializedSize (update baseTx)
-        --          - serializedSize baseTx)
-        -- where update is something similar to 'TxUpdate' or 'TxSkeleton'.
-        sizeOf_HistoricalPadding = sizeOf_NoMetadata
-          where
-            -- When it's "empty", metadata are represented by a special
-            -- "null byte" in CBOR `F6`.
-            sizeOf_NoMetadata = 1
-
-        -- 0 => set<transaction_input>
-        sizeOf_Inputs
-            = sizeOf_SmallUInt
-            + sizeOf_Array
-            + sizeOf_Input * TxSize numberOf_Inputs
-
-        -- 1 => [* transaction_output]
-        sizeOf_Outputs
-            = sizeOf_SmallUInt
-            + sizeOf_Array
-            + F.sum (sizeOf_Output <$> txOutputs)
-            + F.sum (sizeOf_ChangeOutput <$> txChange)
-
-        -- 2 => fee
-        sizeOf_Fee
-            = sizeOf_SmallUInt
-            + sizeOf_UInt
-
-        -- 3 => ttl
-        sizeOf_Ttl
-            = sizeOf_SmallUInt
-            + sizeOf_UInt
-
-        -- ?6 => update
-        sizeOf_Update
-            = 0 -- Assuming no updates is running through cardano-wallet
-
-        -- ?8 => uint ; validity interval start
-        sizeOf_ValidityIntervalStart
-            = sizeOf_UInt
-
-    -- transaction_input =
-    --   [ transaction_id : $hash32
-    --   , index : uint
-    --   ]
-    sizeOf_Input
-        = sizeOf_SmallArray
-        + sizeOf_Hash32
-        + sizeOf_UInt
-
-    -- post_alonzo_transaction_output =
-    --   { 0 : address
-    --   , 1 : value
-    --   , ? 2 : datum_option ; New; datum option
-    --   , ? 3 : script_ref   ; New; script reference
-    --   }
-    -- value =
-    --   coin / [coin,multiasset<uint>]
-    sizeOf_PostAlonzoTransactionOutput TxOut {address, tokens}
-        = sizeOf_SmallMap
-        + sizeOf_SmallUInt
-        + sizeOf_Address address
-        + sizeOf_SmallUInt
-        + sizeOf_SmallArray
-        + sizeOf_Coin (TokenBundle.getCoin tokens)
-        + sumVia sizeOf_NativeAsset (TokenBundle.getAssets tokens)
-
-    sizeOf_Output
-        = sizeOf_PostAlonzoTransactionOutput
-
-    sizeOf_ChangeOutput :: Set AssetId -> TxSize
-    sizeOf_ChangeOutput
-        = sizeOf_PostAlonzoChangeOutput
-
-    -- post_alonzo_transaction_output =
-    --   { 0 : address
-    --   , 1 : value
-    --   , ? 2 : datum_option ; New; datum option
-    --   , ? 3 : script_ref   ; New; script reference
-    --   }
-    -- value =
-    --   coin / [coin,multiasset<uint>]
-    sizeOf_PostAlonzoChangeOutput :: Set AssetId -> TxSize
-    sizeOf_PostAlonzoChangeOutput xs
-        = sizeOf_SmallMap
-        + sizeOf_SmallUInt
-        + sizeOf_ChangeAddress
-        + sizeOf_SmallMap
-        + sizeOf_SmallUInt
-        + sizeOf_LargeUInt
-        + sumVia sizeOf_NativeAsset xs
-
-    -- We carry addresses already serialized, so it's a matter of measuring.
-    sizeOf_Address addr
-        = 2 + fromIntegral (BS.length (unAddress addr))
-
-    -- For change address, we consider the worst-case scenario based on the
-    -- given wallet scheme. Byron addresses are larger.
-    --
-    -- NOTE: we could do slightly better if we wanted to for Byron addresses and
-    -- discriminate based on the network as well since testnet addresses are
-    -- larger than mainnet ones. But meh.
-    sizeOf_ChangeAddress
-        = case txWitnessTag of
-            TxWitnessByronUTxO -> 85
-            TxWitnessShelleyUTxO -> 59
-
-    -- value = coin / [coin,multiasset<uint>]
-    -- We consider "native asset" to just be the "multiasset<uint>" part of the
-    -- above, hence why we don't also include the size of the coin. Where this
-    -- is used, the size of the coin and array are are added too.
-    sizeOf_NativeAsset AssetId{tokenName}
-        = sizeOf_MultiAsset sizeOf_LargeUInt tokenName
-
-    -- multiasset<a> = { * policy_id => { * asset_name => a } }
-    -- policy_id = scripthash
-    -- asset_name = bytes .size (0..32)
-    sizeOf_MultiAsset sizeOf_a name
-      = sizeOf_SmallMap -- NOTE: Assuming < 23 policies per output
-      + sizeOf_Hash28
-      + sizeOf_SmallMap -- NOTE: Assuming < 23 assets per policy
-      + sizeOf_AssetName name
-      + sizeOf_a
-
-    -- asset_name = bytes .size (0..32)
-    sizeOf_AssetName name
-        = 2 + fromIntegral (BS.length $ unTokenName name)
-
-    -- Coins can really vary so it's very punishing to always assign them the
-    -- upper bound. They will typically be between 3 and 9 bytes (only 6 bytes
-    -- difference, but on 20+ outputs, one starts feeling it).
-    --
-    -- So, for outputs, since we have the values, we can compute it accurately.
-    sizeOf_Coin
-        = TxSize
-        . fromIntegral
-        . BS.length
-        . CBOR.toStrictByteString
-        . CBOR.encodeWord64
-        . Coin.unsafeToWord64
-
-    determinePaymentTemplateSize scriptCosigner
-        = sizeOf_Array
-        + sizeOf_SmallUInt
-        + TxSize numberOf_Inputs * (sizeOf_NativeScript scriptCosigner)
-
-    -- transaction_witness_set =
-    --   { ?0 => [* vkeywitness ]
-    --   , ?1 => [* native_script ]
-    --   , ?2 => [* bootstrap_witness ]
-    --   }
-    sizeOf_WitnessSet
-        = sizeOf_SmallMap
-        + sizeOf_VKeyWitnesses numberOf_VkeyWitnesses
-        + maybe 0 determinePaymentTemplateSize txPaymentTemplate
-        -- FIXME: Payment template needs to be multiplied with number of inputs
-        + sizeOf_BootstrapWitnesses numberOf_BootstrapWitnesses
-
--- ?5 => withdrawals
-sizeOf_Withdrawals :: Natural -> TxSize
-sizeOf_Withdrawals n
-    = (if n > 0
-        then sizeOf_SmallUInt + sizeOf_SmallMap
-        else 0)
-    + sizeOf_Withdrawal * (TxSize n)
-
-  where
-    -- withdrawals =
-    --   { * reward_account => coin }
-    sizeOf_Withdrawal
-        = sizeOf_Hash28
-        + sizeOf_LargeUInt
-
--- ?0 => [* vkeywitness ]
-sizeOf_VKeyWitnesses :: Natural -> TxSize
-sizeOf_VKeyWitnesses n
-    = (if n > 0
-        then sizeOf_Array + sizeOf_SmallUInt else 0)
-    + sizeOf_VKeyWitness * (TxSize n)
-
--- ?2 => [* bootstrap_witness ]
-sizeOf_BootstrapWitnesses :: Natural -> TxSize
-sizeOf_BootstrapWitnesses n
-    = (if n > 0
-        then sizeOf_Array + sizeOf_SmallUInt
-        else 0)
-    + sizeOf_BootstrapWitness * (TxSize n)
-
--- vkeywitness =
---  [ $vkey
---  , $signature
---  ]
-sizeOf_VKeyWitness :: TxSize
-sizeOf_VKeyWitness
-    = sizeOf_SmallArray
-    + sizeOf_VKey
-    + sizeOf_Signature
-
--- bootstrap_witness =
---  [ public_key : $vkey
---  , signature  : $signature
---  , chain_code : bytes .size 32
---  , attributes : bytes
---  ]
-sizeOf_BootstrapWitness :: TxSize
-sizeOf_BootstrapWitness
-    = sizeOf_SmallArray
-    + sizeOf_VKey
-    + sizeOf_Signature
-    + sizeOf_ChainCode
-    + sizeOf_Attributes
-  where
-    sizeOf_ChainCode  = 34
-    sizeOf_Attributes = 45 -- NOTE: could be smaller by ~34 for Icarus
-
--- native_script =
---   [ script_pubkey      = (0, addr_keyhash)
---   // script_all        = (1, [ * native_script ])
---   // script_any        = (2, [ * native_script ])
---   // script_n_of_k     = (3, n: uint, [ * native_script ])
---   // invalid_before    = (4, uint)
---      ; Timelock validity intervals are half-open intervals [a, b).
---      ; This field specifies the left (included) endpoint a.
---   // invalid_hereafter = (5, uint)
---      ; Timelock validity intervals are half-open intervals [a, b).
---      ; This field specifies the right (excluded) endpoint b.
---   ]
-sizeOf_NativeScript :: Script object -> TxSize
-sizeOf_NativeScript = \case
-    RequireSignatureOf _ ->
-        sizeOf_SmallUInt + sizeOf_Hash28
-    RequireAllOf ss ->
-        sizeOf_SmallUInt + sizeOf_Array + sumVia sizeOf_NativeScript ss
-    RequireAnyOf ss ->
-        sizeOf_SmallUInt + sizeOf_Array + sumVia sizeOf_NativeScript ss
-    RequireSomeOf _ ss ->
-        sizeOf_SmallUInt
-            + sizeOf_UInt
-            + sizeOf_Array
-            + sumVia sizeOf_NativeScript ss
-    ActiveFromSlot _ ->
-        sizeOf_SmallUInt + sizeOf_UInt
-    ActiveUntilSlot _ ->
-        sizeOf_SmallUInt + sizeOf_UInt
-
--- A Blake2b-224 hash, resulting in a 28-byte digest wrapped in CBOR, so
--- with 2 bytes overhead (length <255, but length > 23)
-sizeOf_Hash28 :: TxSize
-sizeOf_Hash28
-    = 30
-
--- A Blake2b-256 hash, resulting in a 32-byte digest wrapped in CBOR, so
--- with 2 bytes overhead (length <255, but length > 23)
-sizeOf_Hash32 :: TxSize
-sizeOf_Hash32
-    = 34
-
--- A 32-byte Ed25519 public key, encoded as a CBOR-bytestring so with 2
--- bytes overhead (length < 255, but length > 23)
-sizeOf_VKey :: TxSize
-sizeOf_VKey
-    = 34
-
--- A 64-byte Ed25519 signature, encoded as a CBOR-bytestring so with 2
--- bytes overhead (length < 255, but length > 23)
-sizeOf_Signature :: TxSize
-sizeOf_Signature
-    = 66
-
--- A CBOR UInt which is less than 23 in value fits on a single byte. Beyond,
--- the first byte is used to encode the number of bytes necessary to encode
--- the number itself, followed by the number itself.
---
--- When considering a 'UInt', we consider the worst case scenario only where
--- the uint is encoded over 4 bytes, so up to 2^32 which is fine for most
--- cases but coin values.
-sizeOf_SmallUInt :: TxSize
-sizeOf_SmallUInt = 1
-
-sizeOf_UInt :: TxSize
-sizeOf_UInt = 5
-
-sizeOf_LargeUInt :: TxSize
-sizeOf_LargeUInt = 9
-
--- A CBOR array with less than 23 elements, fits on a single byte, followed
--- by each key-value pair (encoded as two concatenated CBOR elements).
-sizeOf_SmallMap :: TxSize
-sizeOf_SmallMap = 1
-
--- A CBOR array with less than 23 elements, fits on a single byte, followed
--- by each elements. Otherwise, the length of the array is encoded first,
--- very much like for UInt.
---
--- When considering an 'Array', we consider large scenarios where arrays can
--- have up to 65536 elements.
-sizeOf_SmallArray :: TxSize
-sizeOf_SmallArray = 1
-
-sizeOf_Array :: TxSize
-sizeOf_Array = 3
-
--- Small helper function for summing values. Given a list of values, get the sum
--- of the values, after the given function has been applied to each value.
-sumVia :: (Foldable t, Num m) => (a -> m) -> t a -> m
-sumVia f = F.foldl' (\t -> (t +) . f) 0
 
 withShelleyBasedEra
     :: forall a
@@ -2062,3 +1426,8 @@ explicitFees era = case era of
         Cardano.TxFeeExplicit Cardano.TxFeesExplicitInBabbageEra
     ShelleyBasedEraConway ->
         Cardano.TxFeeExplicit Cardano.TxFeesExplicitInConwayEra
+
+-- Small helper function for summing values. Given a list of values, get the sum
+-- of the values, after the given function has been applied to each value.
+sumVia :: (Foldable t, Num m) => (a -> m) -> t a -> m
+sumVia f = F.foldl' (\t -> (t +) . f) 0

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -99,6 +99,8 @@ import Cardano.Wallet.Address.Derivation.SharedKey
     ( replaceCosignersWithVerKeys )
 import Cardano.Wallet.Address.Derivation.Shelley
     ( toRewardAccountRaw )
+import Cardano.Wallet.Address.Discovery.Shared
+    ( estimateMaxWitnessRequiredPerInput )
 import Cardano.Wallet.Address.Keys.WalletKey
     ( getRawKey )
 import Cardano.Wallet.Flavor
@@ -212,8 +214,6 @@ import qualified Cardano.Crypto.Wallet as Crypto.HD
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Ledger.Keys.Bootstrap as SL
-import Cardano.Wallet.Address.Discovery.Shared
-    ( estimateMaxWitnessRequiredPerInput )
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -94,7 +94,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenPolicyId )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessor, TxConstraints )
+    ( TokenBundleSizeAssessor )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
     ( Tx (..), TxMetadata )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
@@ -195,12 +195,6 @@ data TransactionLayer k ktype tx = TransactionLayer
     , tokenBundleSizeAssessor
         :: TokenBundleMaxSize -> TokenBundleSizeAssessor
         -- ^ A function to assess the size of a token bundle.
-
-    , constraints
-        :: ProtocolParameters
-        -- Current protocol parameters.
-        -> TxConstraints
-        -- The set of constraints that apply to all transactions.
 
     , decodeTx
         :: AnyCardanoEra

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -138,10 +138,10 @@ import Cardano.Wallet.Write.Tx
     , txBody
     , withConstraints
     )
-import Cardano.Wallet.Write.Tx.Balance.CoinSelection
-    ( TxSkeleton (..), estimateTxCost )
 import Cardano.Wallet.Write.Tx.Redeemers
     ( ErrAssignRedeemers (..), assignScriptRedeemers )
+import Cardano.Wallet.Write.Tx.SizeEstimation
+    ( TxSkeleton (..), estimateTxCost )
 import Cardano.Wallet.Write.Tx.TimeTranslation
     ( TimeTranslation )
 import Cardano.Wallet.Write.UTxOAssumptions

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -109,19 +109,14 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
 import Cardano.Wallet.Shelley.Compatibility
     ( fromCardanoTxIn, fromCardanoTxOut, toCardanoSimpleScript, toCardanoUTxO )
 import Cardano.Wallet.Shelley.Transaction
-    ( KeyWitnessCount (..)
-    , TxSkeleton (..)
-    , distributeSurplus
-    , estimateKeyWitnessCount
-    , estimateSignedTxSize
-    , estimateTxCost
-    )
+    ( distributeSurplus, estimateKeyWitnessCount, estimateSignedTxSize )
 import Cardano.Wallet.Transaction
     ( ErrMoreSurplusNeeded (..), TxFeeAndChange (..) )
 import Cardano.Wallet.Write.ProtocolParameters
     ( ProtocolParameters (..) )
 import Cardano.Wallet.Write.Tx
     ( IsRecentEra (..)
+    , KeyWitnessCount
     , PParams
     , RecentEra (..)
     , ShelleyLedgerEra
@@ -143,6 +138,8 @@ import Cardano.Wallet.Write.Tx
     , txBody
     , withConstraints
     )
+import Cardano.Wallet.Write.Tx.Balance.CoinSelection
+    ( TxSkeleton (..), estimateTxCost )
 import Cardano.Wallet.Write.Tx.Redeemers
     ( ErrAssignRedeemers (..), assignScriptRedeemers )
 import Cardano.Wallet.Write.Tx.TimeTranslation

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/CoinSelection.hs
@@ -1,0 +1,691 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{- HLINT ignore "Use <$>" -}
+{- HLINT ignore "Use camelCase" -}
+
+-- |
+-- Copyright: © 2023 IOHK, 2023 Cardano Foundation
+-- License: Apache-2.0
+--
+--
+module Cardano.Wallet.Write.Tx.Balance.CoinSelection
+    ( -- * Coin-selection for use with balanceTx
+      -- TODO: Move the actual coin-selection function to here, and don't expose
+      -- this group of functions / types.
+      estimateTxSize
+    , estimateTxCost
+    , TxSkeleton (..)
+
+     -- * Additional exposed functionality
+     -- ** For migration
+    , txConstraints
+
+     -- ** For estimateSignedTxSize
+    , sizeOf_BootstrapWitnesses
+
+      -- ** For the wallet
+    , _txRewardWithdrawalCost
+    , getFeePerByteFromWalletPParams
+    )
+
+    where
+
+import Prelude
+
+import Cardano.Address.Script
+    ( Script (..) )
+import Cardano.Wallet.Address.Discovery.Shared
+    ( estimateMaxWitnessRequiredPerInput )
+import Cardano.Wallet.Primitive.Types
+    ( FeePolicy (..)
+    , LinearFunction (..)
+    , ProtocolParameters (..)
+    , TxParameters (..)
+    )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle (..) )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( AssetId (..) )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenName (..) )
+import Cardano.Wallet.Primitive.Types.TokenQuantity
+    ( TokenQuantity (..) )
+import Cardano.Wallet.Primitive.Types.Tx.Constraints
+    ( TxConstraints (..), TxSize (..), txSizeDistance )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut
+    ( TxOut (..) )
+import Cardano.Wallet.Shelley.Compatibility.Ledger
+    ( Convert (..) )
+import Cardano.Wallet.Shelley.MinimumUTxO
+    ( computeMinimumCoinForUTxO, isBelowMinimumCoinForUTxO )
+import Cardano.Wallet.TxWitnessTag
+    ( TxWitnessTag (..) )
+import Cardano.Wallet.Write.Tx
+    ( FeePerByte (..) )
+import Data.Function
+    ( (&) )
+import Data.Generics.Internal.VL.Lens
+    ( view )
+import Data.Generics.Labels
+    ()
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Set
+    ( Set )
+import Data.Word
+    ( Word64, Word8 )
+import GHC.Generics
+    ( Generic )
+import Numeric.Natural
+    ( Natural )
+
+import qualified Cardano.Address.Script as CA
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Write.Tx as Write
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Write as CBOR
+import qualified Data.ByteString as BS
+import qualified Data.Foldable as F
+
+getFeePerByteFromWalletPParams
+    :: ProtocolParameters
+    -> FeePerByte
+getFeePerByteFromWalletPParams pp =
+    FeePerByte $ ceiling slope
+  where
+    LinearFee LinearFunction{slope} = getFeePolicy $ txParameters pp
+
+-- | Like the 'TxConstraints' field 'txRewardWithdrawalCost', but with added
+-- support for shared wallets via the 'CA.ScriptTemplate' argument.
+--
+-- We may or may not want to support shared wallets in the full txConstraints.
+_txRewardWithdrawalCost
+    :: Write.FeePerByte
+    -> Either CA.ScriptTemplate TxWitnessTag
+    -> Coin
+    -> Coin
+_txRewardWithdrawalCost feePerByte witType =
+    toWallet
+    . Write.feeOfBytes feePerByte
+    . unTxSize
+    . _txRewardWithdrawalSize witType
+
+-- | Like the 'TxConstraints' field 'txRewardWithdrawalSize', but with added
+-- support for shared wallets via the 'CA.ScriptTemplate' argument.
+--
+-- We may or may not want to support shared wallets in the full txConstraints.
+_txRewardWithdrawalSize
+    :: Either CA.ScriptTemplate TxWitnessTag
+    -> Coin
+    -> TxSize
+_txRewardWithdrawalSize _ (Coin 0) = TxSize 0
+_txRewardWithdrawalSize witType _ =
+        sizeOf_Withdrawals 1 <> wits
+      where
+        wits = case witType of
+            Right TxWitnessByronUTxO ->
+                sizeOf_BootstrapWitnesses 1 - sizeOf_BootstrapWitnesses 0
+            Right TxWitnessShelleyUTxO ->
+                sizeOf_VKeyWitnesses 1
+            Left scriptTemplate ->
+                let n = fromIntegral $ estimateMaxWitnessRequiredPerInput
+                        $ view #template scriptTemplate
+                in sizeOf_VKeyWitnesses n
+
+
+txConstraints
+    :: ProtocolParameters -> TxWitnessTag -> TxConstraints
+txConstraints protocolParams witnessTag = TxConstraints
+    { txBaseCost
+    , txBaseSize
+    , txInputCost
+    , txInputSize
+    , txOutputCost
+    , txOutputSize
+    , txOutputMaximumSize
+    , txOutputMaximumTokenQuantity
+    , txOutputMinimumAdaQuantity
+    , txOutputBelowMinimumAdaQuantity
+    , txRewardWithdrawalCost
+    , txRewardWithdrawalSize
+    , txMaximumSize
+    }
+  where
+    txBaseCost =
+        constantTxFee <> estimateTxCost feePerByte empty
+
+    constantTxFee = Coin $ ceiling intercept
+    feePerByte = getFeePerByteFromWalletPParams protocolParams
+    LinearFee LinearFunction {intercept}
+        = getFeePolicy $ txParameters protocolParams
+
+    txBaseSize =
+        estimateTxSize empty
+
+    txInputCost =
+        marginalCostOf empty {txInputCount = 1}
+
+    txInputSize =
+        marginalSizeOf empty {txInputCount = 1}
+
+    txOutputCost bundle =
+        marginalCostOf empty {txOutputs = [mkTxOut bundle]}
+
+    txOutputSize bundle =
+        marginalSizeOf empty {txOutputs = [mkTxOut bundle]}
+
+    txOutputMaximumSize = (<>)
+        (txOutputSize mempty)
+        (view
+            (#txParameters . #getTokenBundleMaxSize . #unTokenBundleMaxSize)
+            protocolParams)
+
+    txOutputMaximumTokenQuantity =
+        TokenQuantity $ fromIntegral $ maxBound @Word64
+
+    txOutputMinimumAdaQuantity =
+        computeMinimumCoinForUTxO (minimumUTxO protocolParams)
+
+    txOutputBelowMinimumAdaQuantity =
+        isBelowMinimumCoinForUTxO (minimumUTxO protocolParams)
+
+    txRewardWithdrawalCost =
+        _txRewardWithdrawalCost feePerByte (Right witnessTag)
+
+    txRewardWithdrawalSize =
+        _txRewardWithdrawalSize (Right witnessTag)
+
+    txMaximumSize = protocolParams
+        & view (#txParameters . #getTxMaxSize)
+        & getQuantity
+        & fromIntegral
+        & TxSize
+
+    empty :: TxSkeleton
+    empty = emptyTxSkeleton witnessTag
+
+    -- Computes the size difference between the given skeleton and an empty
+    -- skeleton.
+    marginalCostOf :: TxSkeleton -> Coin
+    marginalCostOf skeleton =
+        Coin.distance
+            (estimateTxCost feePerByte empty)
+            (estimateTxCost feePerByte skeleton)
+
+    -- Computes the size difference between the given skeleton and an empty
+    -- skeleton.
+    marginalSizeOf :: TxSkeleton -> TxSize
+    marginalSizeOf =
+        txSizeDistance txBaseSize . estimateTxSize
+
+    -- Constructs a real transaction output from a token bundle.
+    mkTxOut :: TokenBundle -> TxOut
+    mkTxOut = TxOut dummyAddress
+      where
+        dummyAddress :: Address
+        dummyAddress = Address $ BS.replicate dummyAddressLength nullByte
+
+        dummyAddressLength :: Int
+        dummyAddressLength = 57
+        -- Note: We are at liberty to overestimate the length of an address
+        -- (which is safe). Therefore, we can choose a length that we know is
+        -- greater than or equal to all address lengths.
+
+        nullByte :: Word8
+        nullByte = 0
+
+--------------------------------------------------------------------------------
+-- Size estimation
+--------------------------------------------------------------------------------
+
+-- | Includes just the parts of a transaction necessary to estimate its size.
+--
+-- In particular, this record type includes the minimal set of data needed for
+-- the 'estimateTxCost' and 'estimateTxSize' functions to perform their
+-- calculations, and nothing else.
+--
+-- The data included in 'TxSkeleton' is a subset of the data included in the
+-- union of 'SelectionSkeleton' and 'TransactionCtx'.
+--
+data TxSkeleton = TxSkeleton
+    { txWitnessTag :: !TxWitnessTag
+    , txInputCount :: !Int
+    , txOutputs :: ![TxOut]
+    , txChange :: ![Set AssetId]
+    , txPaymentTemplate :: !(Maybe (CA.Script CA.Cosigner))
+    }
+    deriving (Eq, Show, Generic)
+
+-- | Constructs an empty transaction skeleton.
+--
+-- This may be used to estimate the size and cost of an empty transaction.
+--
+emptyTxSkeleton :: TxWitnessTag -> TxSkeleton
+emptyTxSkeleton txWitnessTag = TxSkeleton
+    { txWitnessTag
+    , txInputCount = 0
+    , txOutputs = []
+    , txChange = []
+    , txPaymentTemplate = Nothing
+    }
+
+-- | Estimates the final cost of a transaction based on its skeleton.
+--
+-- The constant tx fee is /not/ included in the result of this function.
+estimateTxCost :: FeePerByte -> TxSkeleton -> Coin
+estimateTxCost (FeePerByte feePerByte) skeleton =
+    computeFee (estimateTxSize skeleton)
+  where
+    computeFee :: TxSize -> Coin
+    computeFee (TxSize size) = Coin $ feePerByte * size
+
+-- | Estimates the final size of a transaction based on its skeleton.
+--
+-- This function uses the upper bounds of CBOR serialized objects as the basis
+-- for many of its calculations. The following document is used as a reference:
+--
+-- https://github.com/input-output-hk/cardano-ledger/blob/master/eras/shelley/test-suite/cddl-files/shelley.cddl
+-- https://github.com/input-output-hk/cardano-ledger/blob/master/eras/shelley-ma/test-suite/cddl-files/shelley-ma.cddl
+-- https://github.com/input-output-hk/cardano-ledger/blob/master/eras/alonzo/test-suite/cddl-files/alonzo.cddl
+--
+estimateTxSize
+    :: TxSkeleton
+    -> TxSize
+estimateTxSize skeleton =
+    sizeOf_Transaction
+  where
+    TxSkeleton
+        { txWitnessTag
+        , txInputCount
+        , txOutputs
+        , txChange
+        , txPaymentTemplate
+        } = skeleton
+
+    numberOf_Inputs :: Natural
+    numberOf_Inputs
+        = fromIntegral txInputCount
+
+    numberOf_ScriptVkeyWitnessesForPayment
+        = maybe 0 estimateMaxWitnessRequiredPerInput txPaymentTemplate
+
+    numberOf_VkeyWitnesses
+        = case txWitnessTag of
+            TxWitnessByronUTxO -> 0
+            TxWitnessShelleyUTxO ->
+                -- there cannot be missing payment script if there is delegation script
+                -- the latter is optional
+                if numberOf_ScriptVkeyWitnessesForPayment == 0 then
+                    numberOf_Inputs
+                else
+                    (numberOf_Inputs * numberOf_ScriptVkeyWitnessesForPayment)
+
+    numberOf_BootstrapWitnesses
+        = case txWitnessTag of
+            TxWitnessByronUTxO -> numberOf_Inputs
+            TxWitnessShelleyUTxO -> 0
+
+    -- transaction =
+    --   [ transaction_body
+    --   , transaction_witness_set
+    --   , transaction_metadata / null
+    --   ]
+    sizeOf_Transaction
+        = sizeOf_SmallArray
+        + sizeOf_TransactionBody
+        + sizeOf_WitnessSet
+
+    -- transaction_body =
+    --   { 0 : set<transaction_input>
+    --   , 1 : [* transaction_output]
+    --   , 2 : coin ; fee
+    --   , 3 : uint ; ttl
+    --   , ? 4 : [* certificate]
+    --   , ? 5 : withdrawals
+    --   , ? 6 : update
+    --   , ? 7 : metadata_hash
+    --   , ? 8 : uint ; validity interval start
+    --   , ? 9 : mint
+    --   }
+    sizeOf_TransactionBody
+        = sizeOf_SmallMap
+        + sizeOf_Inputs
+        + sizeOf_Outputs
+        + sizeOf_Fee
+        + sizeOf_Ttl
+        + sizeOf_Update
+        + sizeOf_ValidityIntervalStart
+        + sizeOf_HistoricalPadding
+      where
+        -- Preserved out of caution during refactoring. We should be able to
+        -- drop this, but we may as well wait until we have completely
+        -- water-proof testing of the size estimation, e.g:
+        -- prop> forall baseTx update.
+        --      sizeOf_Update x >=
+        --          (serializedSize (update baseTx)
+        --          - serializedSize baseTx)
+        -- where update is something similar to 'TxUpdate' or 'TxSkeleton'.
+        sizeOf_HistoricalPadding = sizeOf_NoMetadata
+          where
+            -- When it's "empty", metadata are represented by a special
+            -- "null byte" in CBOR `F6`.
+            sizeOf_NoMetadata = 1
+
+        -- 0 => set<transaction_input>
+        sizeOf_Inputs
+            = sizeOf_SmallUInt
+            + sizeOf_Array
+            + sizeOf_Input * TxSize numberOf_Inputs
+
+        -- 1 => [* transaction_output]
+        sizeOf_Outputs
+            = sizeOf_SmallUInt
+            + sizeOf_Array
+            + F.sum (sizeOf_Output <$> txOutputs)
+            + F.sum (sizeOf_ChangeOutput <$> txChange)
+
+        -- 2 => fee
+        sizeOf_Fee
+            = sizeOf_SmallUInt
+            + sizeOf_UInt
+
+        -- 3 => ttl
+        sizeOf_Ttl
+            = sizeOf_SmallUInt
+            + sizeOf_UInt
+
+        -- ?6 => update
+        sizeOf_Update
+            = 0 -- Assuming no updates is running through cardano-wallet
+
+        -- ?8 => uint ; validity interval start
+        sizeOf_ValidityIntervalStart
+            = sizeOf_UInt
+
+    -- transaction_input =
+    --   [ transaction_id : $hash32
+    --   , index : uint
+    --   ]
+    sizeOf_Input
+        = sizeOf_SmallArray
+        + sizeOf_Hash32
+        + sizeOf_UInt
+
+    -- post_alonzo_transaction_output =
+    --   { 0 : address
+    --   , 1 : value
+    --   , ? 2 : datum_option ; New; datum option
+    --   , ? 3 : script_ref   ; New; script reference
+    --   }
+    -- value =
+    --   coin / [coin,multiasset<uint>]
+    sizeOf_PostAlonzoTransactionOutput TxOut {address, tokens}
+        = sizeOf_SmallMap
+        + sizeOf_SmallUInt
+        + sizeOf_Address address
+        + sizeOf_SmallUInt
+        + sizeOf_SmallArray
+        + sizeOf_Coin (TokenBundle.getCoin tokens)
+        + sumVia sizeOf_NativeAsset (TokenBundle.getAssets tokens)
+
+    sizeOf_Output
+        = sizeOf_PostAlonzoTransactionOutput
+
+    sizeOf_ChangeOutput :: Set AssetId -> TxSize
+    sizeOf_ChangeOutput
+        = sizeOf_PostAlonzoChangeOutput
+
+    -- post_alonzo_transaction_output =
+    --   { 0 : address
+    --   , 1 : value
+    --   , ? 2 : datum_option ; New; datum option
+    --   , ? 3 : script_ref   ; New; script reference
+    --   }
+    -- value =
+    --   coin / [coin,multiasset<uint>]
+    sizeOf_PostAlonzoChangeOutput :: Set AssetId -> TxSize
+    sizeOf_PostAlonzoChangeOutput xs
+        = sizeOf_SmallMap
+        + sizeOf_SmallUInt
+        + sizeOf_ChangeAddress
+        + sizeOf_SmallMap
+        + sizeOf_SmallUInt
+        + sizeOf_LargeUInt
+        + sumVia sizeOf_NativeAsset xs
+
+    -- We carry addresses already serialized, so it's a matter of measuring.
+    sizeOf_Address addr
+        = 2 + fromIntegral (BS.length (unAddress addr))
+
+    -- For change address, we consider the worst-case scenario based on the
+    -- given wallet scheme. Byron addresses are larger.
+    --
+    -- NOTE: we could do slightly better if we wanted to for Byron addresses and
+    -- discriminate based on the network as well since testnet addresses are
+    -- larger than mainnet ones. But meh.
+    sizeOf_ChangeAddress
+        = case txWitnessTag of
+            TxWitnessByronUTxO -> 85
+            TxWitnessShelleyUTxO -> 59
+
+    -- value = coin / [coin,multiasset<uint>]
+    -- We consider "native asset" to just be the "multiasset<uint>" part of the
+    -- above, hence why we don't also include the size of the coin. Where this
+    -- is used, the size of the coin and array are are added too.
+    sizeOf_NativeAsset AssetId{tokenName}
+        = sizeOf_MultiAsset sizeOf_LargeUInt tokenName
+
+    -- multiasset<a> = { * policy_id => { * asset_name => a } }
+    -- policy_id = scripthash
+    -- asset_name = bytes .size (0..32)
+    sizeOf_MultiAsset sizeOf_a name
+      = sizeOf_SmallMap -- NOTE: Assuming < 23 policies per output
+      + sizeOf_Hash28
+      + sizeOf_SmallMap -- NOTE: Assuming < 23 assets per policy
+      + sizeOf_AssetName name
+      + sizeOf_a
+
+    -- asset_name = bytes .size (0..32)
+    sizeOf_AssetName name
+        = 2 + fromIntegral (BS.length $ unTokenName name)
+
+    -- Coins can really vary so it's very punishing to always assign them the
+    -- upper bound. They will typically be between 3 and 9 bytes (only 6 bytes
+    -- difference, but on 20+ outputs, one starts feeling it).
+    --
+    -- So, for outputs, since we have the values, we can compute it accurately.
+    sizeOf_Coin
+        = TxSize
+        . fromIntegral
+        . BS.length
+        . CBOR.toStrictByteString
+        . CBOR.encodeWord64
+        . Coin.unsafeToWord64
+
+    determinePaymentTemplateSize scriptCosigner
+        = sizeOf_Array
+        + sizeOf_SmallUInt
+        + TxSize numberOf_Inputs * (sizeOf_NativeScript scriptCosigner)
+
+    -- transaction_witness_set =
+    --   { ?0 => [* vkeywitness ]
+    --   , ?1 => [* native_script ]
+    --   , ?2 => [* bootstrap_witness ]
+    --   }
+    sizeOf_WitnessSet
+        = sizeOf_SmallMap
+        + sizeOf_VKeyWitnesses numberOf_VkeyWitnesses
+        + maybe 0 determinePaymentTemplateSize txPaymentTemplate
+        -- FIXME: Payment template needs to be multiplied with number of inputs
+        + sizeOf_BootstrapWitnesses numberOf_BootstrapWitnesses
+
+-- ?5 => withdrawals
+sizeOf_Withdrawals :: Natural -> TxSize
+sizeOf_Withdrawals n
+    = (if n > 0
+        then sizeOf_SmallUInt + sizeOf_SmallMap
+        else 0)
+    + sizeOf_Withdrawal * (TxSize n)
+
+  where
+    -- withdrawals =
+    --   { * reward_account => coin }
+    sizeOf_Withdrawal
+        = sizeOf_Hash28
+        + sizeOf_LargeUInt
+
+-- ?0 => [* vkeywitness ]
+sizeOf_VKeyWitnesses :: Natural -> TxSize
+sizeOf_VKeyWitnesses n
+    = (if n > 0
+        then sizeOf_Array + sizeOf_SmallUInt else 0)
+    + sizeOf_VKeyWitness * (TxSize n)
+
+-- ?2 => [* bootstrap_witness ]
+sizeOf_BootstrapWitnesses :: Natural -> TxSize
+sizeOf_BootstrapWitnesses n
+    = (if n > 0
+        then sizeOf_Array + sizeOf_SmallUInt
+        else 0)
+    + sizeOf_BootstrapWitness * (TxSize n)
+
+-- vkeywitness =
+--  [ $vkey
+--  , $signature
+--  ]
+sizeOf_VKeyWitness :: TxSize
+sizeOf_VKeyWitness
+    = sizeOf_SmallArray
+    + sizeOf_VKey
+    + sizeOf_Signature
+
+-- bootstrap_witness =
+--  [ public_key : $vkey
+--  , signature  : $signature
+--  , chain_code : bytes .size 32
+--  , attributes : bytes
+--  ]
+sizeOf_BootstrapWitness :: TxSize
+sizeOf_BootstrapWitness
+    = sizeOf_SmallArray
+    + sizeOf_VKey
+    + sizeOf_Signature
+    + sizeOf_ChainCode
+    + sizeOf_Attributes
+  where
+    sizeOf_ChainCode  = 34
+    sizeOf_Attributes = 45 -- NOTE: could be smaller by ~34 for Icarus
+
+-- native_script =
+--   [ script_pubkey      = (0, addr_keyhash)
+--   // script_all        = (1, [ * native_script ])
+--   // script_any        = (2, [ * native_script ])
+--   // script_n_of_k     = (3, n: uint, [ * native_script ])
+--   // invalid_before    = (4, uint)
+--      ; Timelock validity intervals are half-open intervals [a, b).
+--      ; This field specifies the left (included) endpoint a.
+--   // invalid_hereafter = (5, uint)
+--      ; Timelock validity intervals are half-open intervals [a, b).
+--      ; This field specifies the right (excluded) endpoint b.
+--   ]
+sizeOf_NativeScript :: Script object -> TxSize
+sizeOf_NativeScript = \case
+    RequireSignatureOf _ ->
+        sizeOf_SmallUInt + sizeOf_Hash28
+    RequireAllOf ss ->
+        sizeOf_SmallUInt + sizeOf_Array + sumVia sizeOf_NativeScript ss
+    RequireAnyOf ss ->
+        sizeOf_SmallUInt + sizeOf_Array + sumVia sizeOf_NativeScript ss
+    RequireSomeOf _ ss ->
+        sizeOf_SmallUInt
+            + sizeOf_UInt
+            + sizeOf_Array
+            + sumVia sizeOf_NativeScript ss
+    ActiveFromSlot _ ->
+        sizeOf_SmallUInt + sizeOf_UInt
+    ActiveUntilSlot _ ->
+        sizeOf_SmallUInt + sizeOf_UInt
+
+-- A Blake2b-224 hash, resulting in a 28-byte digest wrapped in CBOR, so
+-- with 2 bytes overhead (length <255, but length > 23)
+sizeOf_Hash28 :: TxSize
+sizeOf_Hash28
+    = 30
+
+-- A Blake2b-256 hash, resulting in a 32-byte digest wrapped in CBOR, so
+-- with 2 bytes overhead (length <255, but length > 23)
+sizeOf_Hash32 :: TxSize
+sizeOf_Hash32
+    = 34
+
+-- A 32-byte Ed25519 public key, encoded as a CBOR-bytestring so with 2
+-- bytes overhead (length < 255, but length > 23)
+sizeOf_VKey :: TxSize
+sizeOf_VKey
+    = 34
+
+-- A 64-byte Ed25519 signature, encoded as a CBOR-bytestring so with 2
+-- bytes overhead (length < 255, but length > 23)
+sizeOf_Signature :: TxSize
+sizeOf_Signature
+    = 66
+
+-- A CBOR UInt which is less than 23 in value fits on a single byte. Beyond,
+-- the first byte is used to encode the number of bytes necessary to encode
+-- the number itself, followed by the number itself.
+--
+-- When considering a 'UInt', we consider the worst case scenario only where
+-- the uint is encoded over 4 bytes, so up to 2^32 which is fine for most
+-- cases but coin values.
+sizeOf_SmallUInt :: TxSize
+sizeOf_SmallUInt = 1
+
+sizeOf_UInt :: TxSize
+sizeOf_UInt = 5
+
+sizeOf_LargeUInt :: TxSize
+sizeOf_LargeUInt = 9
+
+-- A CBOR array with less than 23 elements, fits on a single byte, followed
+-- by each key-value pair (encoded as two concatenated CBOR elements).
+sizeOf_SmallMap :: TxSize
+sizeOf_SmallMap = 1
+
+-- A CBOR array with less than 23 elements, fits on a single byte, followed
+-- by each elements. Otherwise, the length of the array is encoded first,
+-- very much like for UInt.
+--
+-- When considering an 'Array', we consider large scenarios where arrays can
+-- have up to 65536 elements.
+sizeOf_SmallArray :: TxSize
+sizeOf_SmallArray = 1
+
+sizeOf_Array :: TxSize
+sizeOf_Array = 3
+
+-- Small helper function for summing values. Given a list of values, get the sum
+-- of the values, after the given function has been applied to each value.
+sumVia :: (Foldable t, Num m) => (a -> m) -> t a -> m
+sumVia f = F.foldl' (\t -> (t +) . f) 0
+

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/SizeEstimation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/SizeEstimation.hs
@@ -23,20 +23,18 @@
 -- Copyright: © 2023 IOHK, 2023 Cardano Foundation
 -- License: Apache-2.0
 --
---
-module Cardano.Wallet.Write.Tx.Balance.CoinSelection
-    ( -- * Coin-selection for use with balanceTx
-      -- TODO: Move the actual coin-selection function to here, and don't expose
-      -- this group of functions / types.
+-- Module containing logic relating to size estimation as needed, mainly for
+-- the purpose of coin-selection.
+module Cardano.Wallet.Write.Tx.SizeEstimation
+    ( -- * Needed for normal coin-selection for balanceTx
       estimateTxSize
     , estimateTxCost
     , TxSkeleton (..)
 
-     -- * Additional exposed functionality
-     -- ** For migration
+     -- ** Needed for migration
     , txConstraints
 
-     -- ** For estimateSignedTxSize
+     -- ** Needed for estimateSignedTxSize
     , sizeOf_BootstrapWitnesses
 
       -- ** For the wallet
@@ -688,4 +686,3 @@ sizeOf_Array = 3
 -- of the values, after the given function has been applied to each value.
 sumVia :: (Foldable t, Num m) => (a -> m) -> t a -> m
 sumVia f = F.foldl' (\t -> (t +) . f) 0
-

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/SizeEstimation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/SizeEstimation.hs
@@ -24,14 +24,14 @@
 -- License: Apache-2.0
 --
 -- Module containing logic relating to size estimation as needed, mainly for
--- the purpose of coin-selection.
+-- the purpose of coin selection.
 module Cardano.Wallet.Write.Tx.SizeEstimation
-    ( -- * Needed for normal coin-selection for balanceTx
+    ( -- * Needed for normal coin selection for balanceTx
       estimateTxSize
     , estimateTxCost
     , TxSkeleton (..)
 
-     -- ** Needed for migration
+     -- ** Needed for balance migration
     , txConstraints
 
      -- ** Needed for estimateSignedTxSize
@@ -139,19 +139,17 @@ _txRewardWithdrawalSize
     -> TxSize
 _txRewardWithdrawalSize _ (Coin 0) = TxSize 0
 _txRewardWithdrawalSize witType _ =
-        sizeOf_Withdrawals 1 <> wits
-      where
-        wits = case witType of
-            Right TxWitnessByronUTxO ->
-                sizeOf_BootstrapWitnesses 1 - sizeOf_BootstrapWitnesses 0
-            Right TxWitnessShelleyUTxO ->
-                sizeOf_VKeyWitnesses 1
-            Left scriptTemplate ->
-                let n = fromIntegral $ estimateMaxWitnessRequiredPerInput
-                        $ view #template scriptTemplate
-                in sizeOf_VKeyWitnesses n
-
-
+    sizeOf_Withdrawals 1 <> wits
+  where
+    wits = case witType of
+        Right TxWitnessByronUTxO ->
+            sizeOf_BootstrapWitnesses 1 - sizeOf_BootstrapWitnesses 0
+        Right TxWitnessShelleyUTxO ->
+            sizeOf_VKeyWitnesses 1
+        Left scriptTemplate ->
+            let n = fromIntegral $ estimateMaxWitnessRequiredPerInput
+                    $ view #template scriptTemplate
+            in sizeOf_VKeyWitnesses n
 txConstraints
     :: ProtocolParameters -> TxWitnessTag -> TxConstraints
 txConstraints protocolParams witnessTag = TxConstraints
@@ -628,26 +626,22 @@ sizeOf_NativeScript = \case
 -- A Blake2b-224 hash, resulting in a 28-byte digest wrapped in CBOR, so
 -- with 2 bytes overhead (length <255, but length > 23)
 sizeOf_Hash28 :: TxSize
-sizeOf_Hash28
-    = 30
+sizeOf_Hash28 = 30
 
 -- A Blake2b-256 hash, resulting in a 32-byte digest wrapped in CBOR, so
 -- with 2 bytes overhead (length <255, but length > 23)
 sizeOf_Hash32 :: TxSize
-sizeOf_Hash32
-    = 34
+sizeOf_Hash32 = 34
 
 -- A 32-byte Ed25519 public key, encoded as a CBOR-bytestring so with 2
 -- bytes overhead (length < 255, but length > 23)
 sizeOf_VKey :: TxSize
-sizeOf_VKey
-    = 34
+sizeOf_VKey = 34
 
 -- A 64-byte Ed25519 signature, encoded as a CBOR-bytestring so with 2
 -- bytes overhead (length < 255, but length > 23)
 sizeOf_Signature :: TxSize
-sizeOf_Signature
-    = 66
+sizeOf_Signature = 66
 
 -- A CBOR UInt which is less than 23 in value fits on a single byte. Beyond,
 -- the first byte is used to encode the number of bytes necessary to encode

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -106,7 +106,6 @@ import Cardano.Tx.Balance.Internal.CoinSelection
     , SelectionOutputError (..)
     , SelectionOutputErrorInfo (..)
     , UnableToConstructChangeError (..)
-    , emptySkeleton
     , selectionDelta
     )
 import Cardano.Wallet
@@ -234,27 +233,23 @@ import Cardano.Wallet.Shelley.Compatibility
     )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( toBabbageTxOut, toLedger, toLedgerTokenBundle, toWallet )
+
 import Cardano.Wallet.Shelley.Transaction
     ( EraConstraints
-    , KeyWitnessCount (KeyWitnessCount)
-    , TxSkeleton (..)
+    , KeyWitnessCount (..)
     , TxWitnessTag (..)
     , costOfIncreasingCoin
     , distributeSurplus
     , distributeSurplusDelta
     , estimateKeyWitnessCount
     , estimateSignedTxSize
-    , estimateTxSize
     , maximumCostOfIncreasingCoin
     , mkByronWitness
     , mkDelegationCertificates
     , mkShelleyWitness
-    , mkTxSkeleton
     , mkUnsignedTx
     , newTransactionLayer
     , sizeOfCoin
-    , sizeOf_BootstrapWitnesses
-    , txConstraints
     , _decodeSealedTx
     )
 import Cardano.Wallet.Transaction
@@ -263,7 +258,6 @@ import Cardano.Wallet.Transaction
     , TransactionLayer (..)
     , TxFeeAndChange (TxFeeAndChange)
     , WitnessCountCtx (..)
-    , defaultTransactionCtx
     )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
@@ -291,6 +285,12 @@ import Cardano.Wallet.Write.Tx.Balance
     , noTxUpdate
     , posAndNegFromCardanoValue
     , updateTx
+    )
+import Cardano.Wallet.Write.Tx.Balance.CoinSelection
+    ( TxSkeleton (..)
+    , estimateTxSize
+    , sizeOf_BootstrapWitnesses
+    , txConstraints
     )
 import Cardano.Wallet.Write.Tx.TimeTranslation
     ( TimeTranslation, timeTranslationFromEpochInfo )
@@ -1679,10 +1679,8 @@ dummyProtocolParameters = ProtocolParameters
 --------------------------------------------------------------------------------
 
 emptyTxSkeleton :: TxSkeleton
-emptyTxSkeleton = mkTxSkeleton
-    TxWitnessShelleyUTxO
-    defaultTransactionCtx
-    emptySkeleton
+emptyTxSkeleton =
+    TxSkeleton TxWitnessShelleyUTxO 0 [] [] Nothing
 
 mockFeePolicy :: FeePolicy
 mockFeePolicy = LinearFee $ LinearFunction

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -286,7 +286,7 @@ import Cardano.Wallet.Write.Tx.Balance
     , posAndNegFromCardanoValue
     , updateTx
     )
-import Cardano.Wallet.Write.Tx.Balance.CoinSelection
+import Cardano.Wallet.Write.Tx.SizeEstimation
     ( TxSkeleton (..)
     , estimateTxSize
     , sizeOf_BootstrapWitnesses

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -1296,8 +1296,6 @@ dummyTransactionLayer = TransactionLayer
         error "dummyTransactionLayer: mkUnsignedTransaction not implemented"
     , tokenBundleSizeAssessor =
         error "dummyTransactionLayer: tokenBundleSizeAssessor not implemented"
-    , constraints =
-        error "dummyTransactionLayer: constraints not implemented"
     , decodeTx = \_era _witCtx _sealed ->
         ( Tx
             { txId = Hash ""


### PR DESCRIPTION
Move to the following module:
```haskell
module Cardano.Wallet.Write.Tx.Balance.CoinSelection
    ( -- * Coin-selection for use with balanceTx
      -- TODO: Move the actual coin-selection function to here, and don't expose
      -- this group of functions / types.
      estimateTxSize
    , estimateTxCost
    , TxSkeleton (..)

     -- * Additional exposed functionality
     -- ** For migration
    , txConstraints

     -- ** For estimateSignedTxSize
    , sizeOf_BootstrapWitnesses

      -- ** For the wallet
    , _txRewardWithdrawalCost
    , getFeePerByteFromWalletPParams
    )
```


### Comments

Depends on #4030 

### Issue Number

ADP-3081