### PR TITLE
Let assignScriptRedeemers take Ledger.UTxO

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -766,6 +766,8 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
       where
          unUTxO (Cardano.UTxO u) = u
 
+    combinedLedgerUTxO = fromCardanoUTxO combinedUTxO
+
     combinedUTxO :: Cardano.UTxO era
     combinedUTxO = Cardano.UTxO $ mconcat
          -- The @Cardano.UTxO@ can contain strictly more information than
@@ -798,7 +800,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         tx' <- left ErrBalanceTxUpdateError $ updateTx partialTx update
         left ErrBalanceTxAssignRedeemers $
             assignScriptRedeemers
-                pp timeTranslation combinedUTxO redeemers tx'
+                pp timeTranslation combinedLedgerUTxO redeemers tx'
 
     guardConflictingWithdrawalNetworks
         (Cardano.Tx (Cardano.TxBody body) _) = do

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Redeemers.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Redeemers.hs
@@ -37,8 +37,8 @@ import Cardano.Wallet.Write.Tx
     , RecentEraLedgerConstraints
     , ShelleyLedgerEra
     , StandardCrypto
+    , UTxO
     , fromCardanoTx
-    , fromCardanoUTxO
     , shelleyBasedEra
     , txBody
     , withConstraints
@@ -97,7 +97,7 @@ assignScriptRedeemers
     :: forall era. IsRecentEra era
     => PParams (ShelleyLedgerEra era)
     -> TimeTranslation
-    -> Cardano.UTxO era
+    -> UTxO (ShelleyLedgerEra era)
     -> [Redeemer]
     -> Cardano.Tx era
     -> Either ErrAssignRedeemers (Cardano.Tx era)
@@ -163,7 +163,7 @@ assignScriptRedeemers pparams timeTranslation utxo redeemers tx =
             (Map Alonzo.RdmrPtr (Either ErrAssignRedeemers Alonzo.ExUnits))
     evaluateExecutionUnits indexedRedeemers ledgerTx =
         Ledger.evalTxExUnits
-            pparams ledgerTx (fromCardanoUTxO utxo) epochInformation systemStart
+            pparams ledgerTx utxo epochInformation systemStart
         & bimap
             ErrAssignRedeemersTranslationError
             (hoistScriptFailure indexedRedeemers)


### PR DESCRIPTION
As part of move from `cardano-api` to `ledger` types.

### Issue Number

ADP-3081, but a bit unrelated
