### PR TITLE
Remove unused `Write.Tx.Gen.genTxOut`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Gen.hs
@@ -7,28 +7,18 @@
 --
 module Cardano.Wallet.Write.Tx.Gen
     ( genDatumHash
-    , genTxOut
     )
     where
 
 import Prelude
 
 import Cardano.Wallet.Write.Tx
-    ( DatumHash
-    , RecentEra
-    , ShelleyLedgerEra
-    , TxOut
-    , cardanoEraFromRecentEra
-    , datumHashFromBytes
-    , shelleyBasedEraFromRecentEra
-    )
+    ( DatumHash, datumHashFromBytes )
 import Data.Maybe
     ( fromMaybe )
 import Test.QuickCheck
     ( Gen, arbitrary, vectorOf )
 
-import qualified Cardano.Api.Gen as Cardano
-import qualified Cardano.Api.Shelley as Cardano
 import qualified Data.ByteString as BS
 
 genDatumHash :: Gen DatumHash
@@ -36,7 +26,3 @@ genDatumHash =
     fromMaybe (error "genDatumHash should always generate valid hashes")
     . datumHashFromBytes
     . BS.pack <$> vectorOf 32 arbitrary
-
-genTxOut :: RecentEra era -> Gen (TxOut (ShelleyLedgerEra era))
-genTxOut era = Cardano.toShelleyTxOut (shelleyBasedEraFromRecentEra era)
-    <$> Cardano.genTxOut (cardanoEraFromRecentEra era)


### PR DESCRIPTION
```
This removes the Write.Tx.Gen dependency on Cardano.Api.Gen. In the
future, let's re-add it, and remove the dependency on cardano-api types
even for generators.
```

### Issue Number

ADP-3081
