### PR TITLE
Drop class `TxWitnessTagFor`

### DIFF
--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -95,7 +95,7 @@ import Cardano.Wallet.Read.NetworkId
     , withSNetworkId
     )
 import Cardano.Wallet.Shelley.Transaction
-    ( TxWitnessTagFor (..), newTransactionLayer )
+    ( newTransactionLayer )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Control.Monad
@@ -437,7 +437,6 @@ data BenchmarkConfig (n :: NetworkDiscriminant) s =
 benchmarkWallets
     :: forall n s results
      . ( PersistAddressBook s
-       , TxWitnessTagFor (KeyOf s)
        , KeyFlavor (KeyOf s)
        , Buildable results
        , ToJSON results
@@ -489,7 +488,6 @@ withWalletsFromDirectory
      . ( PersistAddressBook s
        , WalletFlavor s
        , k ~ KeyOf s
-       , TxWitnessTagFor k
        , KeyFlavor k
        )
     => FilePath

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -159,7 +159,7 @@ import Cardano.Wallet.Shelley.Compatibility
 import Cardano.Wallet.Shelley.Network.Node
     ( withNetworkLayer )
 import Cardano.Wallet.Shelley.Transaction
-    ( TxWitnessTagFor (..), newTransactionLayer )
+    ( newTransactionLayer )
 import Cardano.Wallet.Transaction
     ( PreSelection (..), defaultTransactionCtx )
 import Cardano.Wallet.Unsafe
@@ -184,8 +184,6 @@ import Data.Aeson
     ( ToJSON (..), genericToJSON, (.=) )
 import Data.Functor.Contravariant
     ( contramap )
-import Data.Kind
-    ( Type )
 import Data.List
     ( foldl' )
 import Data.Proxy
@@ -683,14 +681,12 @@ bench_baseline_restoration
 
 {- HLINT ignore bench_restoration "Use camelCase" -}
 bench_restoration
-    :: forall n (k :: Depth -> Type -> Type) s results.
+    :: forall n s results.
         ( IsOurs s RewardAccount
         , MaybeLight s
         , PersistAddressBook s
         , WalletFlavor s
-        , KeyOf s ~ k
         , HasSNetworkId n
-        , TxWitnessTagFor k
         , Buildable results
         , ToJSON results
         , IsOurs s Address

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -220,6 +220,7 @@ module Cardano.Wallet
     , throttle
     , guardHardIndex
     , utxoAssumptionsForWallet
+    , txWitnessTagForKey
 
     -- * Logging
     , WalletWorkerLog (..)
@@ -497,6 +498,8 @@ import Cardano.Wallet.Shelley.Compatibility
     )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( toWallet )
+import Cardano.Wallet.Shelley.Transaction
+    ( txWitnessTagForKey )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , ErrCannotJoin (..)
@@ -515,7 +518,7 @@ import Cardano.Wallet.Transaction
 import Cardano.Wallet.Transaction.Built
     ( BuiltTx (..) )
 import Cardano.Wallet.TxWitnessTag
-    ( TxWitnessTag )
+    ( TxWitnessTag (..) )
 import Cardano.Wallet.Write.Tx
     ( recentEra )
 import Cardano.Wallet.Write.Tx.Balance

--- a/lib/wallet/src/Cardano/Wallet/Address/Derivation/Byron.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Derivation/Byron.hs
@@ -74,8 +74,6 @@ import Cardano.Wallet.Primitive.Types.ProtocolMagic
     ( magicSNetworkId )
 import Cardano.Wallet.Read.NetworkId
     ( SNetworkId (..) )
-import Cardano.Wallet.TxWitnessTag
-    ( TxWitnessTag (..), TxWitnessTagFor (..) )
 import Control.DeepSeq
     ( NFData )
 import Control.Lens
@@ -123,10 +121,6 @@ byronKey = lens getKey (\x k -> x { getKey = k })
 instance (NFData key, NFData (DerivationPathFrom depth)) => NFData (ByronKey depth key)
 deriving instance (Show key, Show (DerivationPathFrom depth)) => Show (ByronKey depth key)
 deriving instance (Eq key, Eq (DerivationPathFrom depth)) => Eq (ByronKey depth key)
-
-instance TxWitnessTagFor ByronKey where
-    txWitnessTagFor = TxWitnessByronUTxO
-
 -- | The hierarchical derivation indices for a given level/depth.
 type family DerivationPathFrom (depth :: Depth) :: Type where
     -- The root key is generated from the seed.

--- a/lib/wallet/src/Cardano/Wallet/Address/Derivation/Icarus.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Derivation/Icarus.hs
@@ -77,8 +77,6 @@ import Cardano.Wallet.Read.NetworkId
     , NetworkDiscriminantCheck (..)
     , SNetworkId (..)
     )
-import Cardano.Wallet.TxWitnessTag
-    ( TxWitnessTag (..), TxWitnessTagFor (..) )
 import Control.Arrow
     ( first, left )
 import Control.DeepSeq
@@ -136,9 +134,6 @@ icarusKey :: Iso (IcarusKey depth key) (IcarusKey depth key') key key'
 icarusKey = iso getKey IcarusKey
 
 instance NFData key => NFData (IcarusKey depth key)
-
-instance TxWitnessTagFor IcarusKey where
-    txWitnessTagFor = TxWitnessByronUTxO
 
 -- | The minimum seed length for 'generateKeyFromSeed' and 'unsafeGenerateKeyFromSeed'.
 minSeedLengthBytes :: Int

--- a/lib/wallet/src/Cardano/Wallet/Address/Derivation/SharedKey.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Derivation/SharedKey.hs
@@ -43,8 +43,6 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Read.NetworkId
     ( HasSNetworkId (sNetworkId), SNetworkId (..) )
-import Cardano.Wallet.TxWitnessTag
-    ( TxWitnessTag (..), TxWitnessTagFor (..) )
 import Control.DeepSeq
     ( NFData (..) )
 import Control.Lens
@@ -89,9 +87,6 @@ sharedKey :: Iso (SharedKey depth key) (SharedKey depth1 key') key key'
 sharedKey = iso getKey SharedKey
 
 instance NFData key => NFData (SharedKey depth key)
-
-instance TxWitnessTagFor SharedKey where
-    txWitnessTagFor = TxWitnessShelleyUTxO
 
 constructAddressFromIx
     :: forall n

--- a/lib/wallet/src/Cardano/Wallet/Address/Derivation/Shelley.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Derivation/Shelley.hs
@@ -99,8 +99,6 @@ import Cardano.Wallet.Read.NetworkId
     , SNetworkId (..)
     , networkDiscriminantBits
     )
-import Cardano.Wallet.TxWitnessTag
-    ( TxWitnessTag (..), TxWitnessTagFor (..) )
 import Control.DeepSeq
     ( NFData (..) )
 import Control.Lens
@@ -149,9 +147,6 @@ shelleyKey :: Iso (ShelleyKey depth key) (ShelleyKey depth key') key key'
 shelleyKey = iso getKey ShelleyKey
 
 instance NFData key => NFData (ShelleyKey depth key)
-
-instance TxWitnessTagFor ShelleyKey where
-    txWitnessTagFor = TxWitnessShelleyUTxO
 
 -- | The minimum seed length for 'generateKeyFromSeed' and
 -- 'unsafeGenerateKeyFromSeed'.

--- a/lib/wallet/src/Cardano/Wallet/TxWitnessTag.hs
+++ b/lib/wallet/src/Cardano/Wallet/TxWitnessTag.hs
@@ -1,23 +1,8 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE KindSignatures #-}
-
 module Cardano.Wallet.TxWitnessTag where
 
 import Prelude
-
-import Cardano.Wallet.Address.Derivation
-    ( Depth )
-import Data.Kind
-    ( Type )
 
 data TxWitnessTag
     = TxWitnessByronUTxO
     | TxWitnessShelleyUTxO
     deriving (Show, Eq)
-
--- | Provide a transaction witness for a given private key. The type of witness
--- is different between types of keys and, with backward-compatible support, we
--- need to support many types for one backend target.
-class TxWitnessTagFor (k :: Depth -> Type -> Type) where
-    txWitnessTagFor :: TxWitnessTag


### PR DESCRIPTION
- [x] Replace the `TxWitnessTagFor` class with a function `WitnessTagForKey :: KeyFlavorS a -> TxWitnessTag`

### Motivation

This will allow the `TxWitnessTag` module to be moved into the `cardano-balance-tx` library. The class used to depend on `Depth`. We can remove `TxWitnessTag` from the wallet/balanceTx interface at a later stage.

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-3081
