### PR TITLE
Fix unused match warning in `memory-benchmark.hs`.

### DIFF
--- a/lib/wallet-benchmarks/bench/memory-benchmark.hs
+++ b/lib/wallet-benchmarks/bench/memory-benchmark.hs
@@ -150,7 +150,7 @@ copyNodeSnapshot snapshot tmp = do
     Cardano commands
 ------------------------------------------------------------------------------}
 getLatestBlockHeight :: Tracer IO Text -> C.CardanoWalletConn -> IO Int
-getLatestBlockHeight tr wallet = do
+getLatestBlockHeight _tr wallet = do
     fmap (fromMaybe 0 . readMaybe)
         . flip S.readCreateProcess ""
         . S.shell


### PR DESCRIPTION
This PR fixes the following warning:
```
bench/memory-benchmark.hs:153:22: error: [-Wunused-matches, -Werror=unused-matches]
    Defined but not used: `tr'
    |
153 | getLatestBlockHeight tr wallet = do
```