### PR TITLE
Minor formatting fixes for `Write.Tx` module hierarchy.

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -279,8 +279,8 @@ class
 
 -- | Convenient constraints. Constraints may be dropped as we move to new eras.
 --
--- Adding too many constraints shouldn't be a concern as the point of 'RecentEra'
--- is to work with a small closed set of eras, anyway.
+-- Adding too many constraints shouldn't be a concern as the point of
+-- 'RecentEra' is to work with a small closed set of eras, anyway.
 type RecentEraLedgerConstraints era =
     ( Core.Era era
     , Core.EraTx era

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -391,7 +391,8 @@ balanceTransaction
     --
     -- It is unclear whether an incorrect value could cause collateral to be
     -- forfeited. We should ideally investigate and clarify as part of ADP-1544
-    -- or similar ticket. Relevant ledger code: https://github.com/input-output-hk/cardano-ledger/blob/fdec04e8c071060a003263cdcb37e7319fb4dbf3/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs#L428-L440
+    -- or similar ticket. Relevant ledger code:
+    -- https://github.com/input-output-hk/cardano-ledger/blob/fdec04e8c071060a003263cdcb37e7319fb4dbf3/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs#L428-L440
     -> UTxOIndex era
     -- ^ TODO [ADP-1789] Replace with @Cardano.UTxO@
     -> ChangeAddressGen changeState
@@ -409,7 +410,9 @@ balanceTransaction
     partialTx
     = do
     let adjustedPartialTx =
-            over #tx (increaseZeroAdaOutputs (recentEra @era) (pparamsLedger pp)) partialTx
+            over #tx
+                (increaseZeroAdaOutputs (recentEra @era) (pparamsLedger pp))
+                partialTx
     let balanceWith strategy =
             balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 @era @m @changeState
@@ -626,7 +629,8 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         , feeUpdate = UseNewTxFee $ unsafeFromLovelace minfee0
         }
 
-    (balance, candidateMinFee, witCount) <- balanceAfterSettingMinFee candidateTx
+    (balance, candidateMinFee, witCount) <-
+        balanceAfterSettingMinFee candidateTx
     surplus <- case Cardano.selectLovelace balance of
         (Cardano.Lovelace c)
             | c >= 0 ->
@@ -653,7 +657,9 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         (ExceptT . pure $
             distributeSurplus feePerByte surplus feeAndChange)
 
-    fmap (, s') . guardTxSize witCount =<< guardTxBalanced =<< assembleTransaction
+    fmap (, s') . guardTxSize witCount
+        =<< guardTxBalanced
+        =<< assembleTransaction
         TxUpdate
             { extraInputs
             , extraCollateral
@@ -735,7 +741,8 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 
     balanceAfterSettingMinFee
         :: Cardano.Tx era
-        -> ExceptT ErrBalanceTx m (Cardano.Value, Cardano.Lovelace, KeyWitnessCount)
+        -> ExceptT ErrBalanceTx m
+            (Cardano.Value, Cardano.Lovelace, KeyWitnessCount)
     balanceAfterSettingMinFee tx = ExceptT . pure $ do
         let witCount = estimateKeyWitnessCount combinedUTxO (getBody tx)
         let minfee = W.toWalletCoin $ evaluateMinimumFee

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/SizeEstimation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/SizeEstimation.hs
@@ -330,8 +330,8 @@ estimateTxSize skeleton =
         = case txWitnessTag of
             TxWitnessByronUTxO -> 0
             TxWitnessShelleyUTxO ->
-                -- there cannot be missing payment script if there is delegation script
-                -- the latter is optional
+                -- there cannot be missing payment script if there is
+                -- delegation script the latter is optional
                 if numberOf_ScriptVkeyWitnessesForPayment == 0 then
                     numberOf_Inputs
                 else


### PR DESCRIPTION
This PR makes a few minor formatting fixes for the `Write.Tx` module hierarchy.