### PR TITLE
Reduce dependency on `Shelley.Compatibility` module

### DIFF
--- a/lib/wallet/address/Cardano/Wallet/Address/Discovery/Shared.hs
+++ b/lib/wallet/address/Cardano/Wallet/Address/Discovery/Shared.hs
@@ -129,8 +129,6 @@ import Fmt
     ( Buildable (..), blockListF', indentF )
 import GHC.Generics
     ( Generic )
-import Numeric.Natural
-    ( Natural )
 import Type.Reflection
     ( Typeable )
 

--- a/lib/wallet/address/Cardano/Wallet/Address/Discovery/Shared.hs
+++ b/lib/wallet/address/Cardano/Wallet/Address/Discovery/Shared.hs
@@ -40,8 +40,6 @@ module Cardano.Wallet.Address.Discovery.Shared
     , ErrScriptTemplate (..)
     , isShared
     , retrieveAllCosigners
-    , estimateMinWitnessRequiredPerInput
-    , estimateMaxWitnessRequiredPerInput
 
     , CredentialType (..)
     , liftPaymentAddress
@@ -585,57 +583,6 @@ isOwned st (rootPrv, pwd) addr = case isShared addr st of
                 , pwd
                 )
     (Nothing, _) -> Nothing
-
-estimateMinWitnessRequiredPerInput :: Script k -> Natural
-estimateMinWitnessRequiredPerInput = \case
-    RequireSignatureOf _ -> 1
-    RequireAllOf xs      ->
-        sum $ map estimateMinWitnessRequiredPerInput xs
-    RequireAnyOf xs      ->
-        optimumIfNotEmpty minimum $ map estimateMinWitnessRequiredPerInput xs
-    RequireSomeOf m xs   ->
-        let smallestReqFirst =
-                L.sort $ map estimateMinWitnessRequiredPerInput xs
-        in sum $ take (fromIntegral m) smallestReqFirst
-    ActiveFromSlot _     -> 0
-    ActiveUntilSlot _    -> 0
-
-optimumIfNotEmpty :: (Foldable t, Num p) => (t a -> p) -> t a -> p
-optimumIfNotEmpty f xs =
-    if null xs then
-        0
-    else f xs
-
-estimateMaxWitnessRequiredPerInput :: Script k -> Natural
-estimateMaxWitnessRequiredPerInput = \case
-    RequireSignatureOf _ -> 1
-    RequireAllOf xs      ->
-        sum $ map estimateMaxWitnessRequiredPerInput xs
-    RequireAnyOf xs      ->
-        sum $ map estimateMaxWitnessRequiredPerInput xs
-    -- Estimate (and tx fees) could be lowered with:
-    --
-    -- optimumIfNotEmpty maximum $ map estimateMaxWitnessRequiredPerInput xs
-    -- however signTransaction
-    --
-    -- however we'd then need to adjust signTx accordingly such that it still
-    -- doesn't add more witnesses than we plan for.
-    --
-    -- Partially related task: https://cardanofoundation.atlassian.net/browse/ADP-2676
-    RequireSomeOf _m xs   ->
-        sum $ map estimateMaxWitnessRequiredPerInput xs
-    -- Estimate (and tx fees) could be lowered with:
-    --
-    -- let largestReqFirst =
-    --      reverse $ L.sort $ map estimateMaxWitnessRequiredPerInput xs
-    -- in sum $ take (fromIntegral m) largestReqFirst
-    --
-    -- however we'd then need to adjust signTx accordingly such that it still
-    -- doesn't add more witnesses than we plan for.
-    --
-    -- Partially related task: https://cardanofoundation.atlassian.net/browse/ADP-2676
-    ActiveFromSlot _     -> 0
-    ActiveUntilSlot _    -> 0
 
 instance AccountIxForStaking (SharedState n SharedKey) where
     getAccountIx st =

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -704,6 +704,7 @@ import qualified Cardano.Wallet.Registry as Registry
 import qualified Cardano.Wallet.Write.ProtocolParameters as Write
 import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Cardano.Wallet.Write.Tx.Balance as Write
+import qualified Cardano.Wallet.Write.Tx.Sign as Write
 import qualified Control.Concurrent.Concierge as Concierge
 import qualified Data.ByteString as BS
 import qualified Data.Foldable as F
@@ -3468,12 +3469,12 @@ submitSharedTransaction ctx apiw@(ApiT wid) apitx = do
                     if numberStakingNativeScripts == 0 then
                         0
                     else if numberStakingNativeScripts == 1 then
-                        Shared.estimateMinWitnessRequiredPerInput scriptD
+                        Write.estimateMinWitnessRequiredPerInput scriptD
                     else
                         error "wallet supports transactions with 0 or 1 staking script"
 
         let (ScriptTemplate _ scriptP) = Shared.paymentTemplate $ getState cp
-        let pWitsPerInput = Shared.estimateMinWitnessRequiredPerInput scriptP
+        let pWitsPerInput = Write.estimateMinWitnessRequiredPerInput scriptP
         let witsRequiredForInputs =
                 length $ L.nubBy samePaymentKey $
                 filter isInpOurs $

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -729,6 +729,7 @@ test-suite unit
     , cardano-crypto-wrapper
     , cardano-ledger-alonzo
     , cardano-ledger-alonzo-test
+    , cardano-ledger-allegra:{cardano-ledger-allegra, testlib}
     , cardano-ledger-api
     , cardano-ledger-babbage:{cardano-ledger-babbage, testlib}
     , cardano-ledger-byron

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/SizeEstimation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/SizeEstimation.hs
@@ -49,8 +49,6 @@ import Cardano.Address.Script
     ( Script (..) )
 import Cardano.Ledger.Api
     ( ppMaxTxSizeL, ppMaxValSizeL, ppMinFeeBL )
-import Cardano.Wallet.Address.Discovery.Shared
-    ( estimateMaxWitnessRequiredPerInput )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -82,6 +80,8 @@ import Cardano.Wallet.Write.Tx
     , isBelowMinimumCoinForTxOut
     , withConstraints
     )
+import Cardano.Wallet.Write.Tx.Sign
+    ( estimateMaxWitnessRequiredPerInput )
 import Control.Lens
     ( (^.) )
 import Data.Generics.Internal.VL.Lens

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
@@ -66,15 +66,15 @@ spec = describe "Cardano.Wallet.Shelley.Compatibility.LedgerSpec" $
         ledgerRoundtrip $ Proxy @TokenQuantity
         ledgerRoundtrip $ Proxy @TxIn
 
-    describe "Timelock roundtrips" $ do
+    describe "Timelock roundtrips (toLedgerTimelockScript, toWalletScript)" $ do
         let ledger = toLedgerTimelockScript @StandardBabbage
         let wallet = toWalletScript (const Unknown)
 
-        it "toWalletScript . toLedgerTimelockScript == id" $ property $ \s -> do
+        it "ledger . wallet . ledger == ledger" $ property $ \s -> do
             -- Ignore key role by doing one extra conversion
             ledger (wallet $ ledger s) === ledger s
 
-        it "toLedgerTimelockScript . toWalletScript == id" $ property $ \s -> do
+        it "ledger . wallet == id" $ property $ \s -> do
             ledger (wallet s) === s
 
 --------------------------------------------------------------------------------

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
@@ -9,6 +9,10 @@ module Cardano.Wallet.Shelley.Compatibility.LedgerSpec
 
 import Prelude
 
+import Cardano.Address.Script
+    ( KeyHash (..), KeyRole (..), Script )
+import Cardano.Wallet.Gen
+    ( genScript )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -30,17 +34,23 @@ import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
 import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     ( genTxOutCoin, shrinkTxOutCoin )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( Convert (..) )
+    ( Convert (..), toLedgerTimelockScript, toWalletScript )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Typeable
     ( Typeable, typeRep )
+import Ouroboros.Consensus.Shelley.Eras
+    ( StandardBabbage )
+import Test.Cardano.Ledger.Allegra.Arbitrary
+    ()
 import Test.Hspec
     ( Spec, describe, it )
 import Test.Hspec.Core.QuickCheck
     ( modifyMaxSuccess )
 import Test.QuickCheck
-    ( Arbitrary (..), property, (===) )
+    ( Arbitrary (..), elements, property, vectorOf, (===) )
+
+import qualified Data.ByteString as BS
 
 spec :: Spec
 spec = describe "Cardano.Wallet.Shelley.Compatibility.LedgerSpec" $
@@ -55,6 +65,17 @@ spec = describe "Cardano.Wallet.Shelley.Compatibility.LedgerSpec" $
         ledgerRoundtrip $ Proxy @TokenPolicyId
         ledgerRoundtrip $ Proxy @TokenQuantity
         ledgerRoundtrip $ Proxy @TxIn
+
+    describe "Timelock roundtrips" $ do
+        let ledger = toLedgerTimelockScript @StandardBabbage
+        let wallet = toWalletScript (const Unknown)
+
+        it "toWalletScript . toLedgerTimelockScript == id" $ property $ \s -> do
+            -- Ignore key role by doing one extra conversion
+            ledger (wallet $ ledger s) === ledger s
+
+        it "toLedgerTimelockScript . toWalletScript == id" $ property $ \s -> do
+            ledger (wallet s) === s
 
 --------------------------------------------------------------------------------
 -- Utilities
@@ -102,3 +123,13 @@ instance Arbitrary TokenQuantity where
 instance Arbitrary TxIn where
     arbitrary = genTxIn
     shrink = shrinkTxIn
+
+instance Arbitrary (Script KeyHash) where
+    arbitrary = do
+        keyHashes <- vectorOf 10 arbitrary
+        genScript keyHashes
+
+instance Arbitrary KeyHash where
+    arbitrary = do
+        cred <- elements [Payment, Delegation, Policy, Unknown]
+        KeyHash cred . BS.pack <$> vectorOf 28 arbitrary


### PR DESCRIPTION
- [x] Move `estimate{Min, Max}WitnessRequiredPerInput` from `AddressDerivation.Shared` to `Write.Tx.Sign` module
- [x] Remove `Write.Tx.Balance` dependency on `Shelley.Compatibility.fromCardanoTx{In, Out}` 

### Motivation

The new `cardano-balance-tx` library cannot depend on `AddressDerivation.Shared`, and it's easier if we avoid depending on `Shelley.Compatibility`. NB: We will need to bring the `Shelley.Compatibility.Ledger` along (either to `cardano-balance-tx` or to `primitive`).

### Issue Number

ADP-3081
