### PR TITLE
Move TokenBundleSizeAssessor

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -352,6 +352,8 @@ library
     Cardano.Wallet.Write.ProtocolParameters
     Cardano.Wallet.Write.Tx
     Cardano.Wallet.Write.Tx.Balance
+    Cardano.Wallet.Write.Tx.Balance.TokenBundleSize
+    Cardano.Wallet.Write.Tx.Balance.TokenBundleSize.Gen
     Cardano.Wallet.Write.Tx.Gen
     Cardano.Wallet.Write.Tx.Redeemers
     Cardano.Wallet.Write.Tx.Sign
@@ -911,6 +913,7 @@ test-suite unit
     Cardano.Wallet.Submissions.OperationsSpec
     Cardano.Wallet.Submissions.PrimitivesSpec
     Cardano.Wallet.TokenMetadataSpec
+    Cardano.Wallet.Write.Tx.Balance.TokenBundleSizeSpec
     Cardano.Wallet.Write.TxSpec
     Cardano.WalletSpec
     Control.Concurrent.ConciergeSpec

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -587,9 +587,6 @@ newTransactionLayer keyF networkId = TransactionLayer
                     stakingScriptM
                     (Write.shelleyBasedEraFromRecentEra Write.recentEra)
 
-    , tokenBundleSizeAssessor =
-        Compatibility.tokenBundleSizeAssessor
-
     , decodeTx = _decodeSealedTx
 
     , transactionWitnessTag = txWitnessTagForKey keyF

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -76,7 +76,7 @@ import Cardano.Wallet.Primitive.Passphrase.Types
 import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException )
 import Cardano.Wallet.Primitive.Types
-    ( Certificate, ProtocolParameters, SlotNo (..), TokenBundleMaxSize (..) )
+    ( Certificate, ProtocolParameters, SlotNo (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -89,8 +89,6 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId, TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenPolicyId )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessor )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
     ( Tx (..), TxMetadata )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
@@ -187,10 +185,6 @@ data TransactionLayer k ktype tx = TransactionLayer
         -- multisignature transactions, etc.
         --
         -- The function returns CBOR-ed transaction body to be signed in another step.
-
-    , tokenBundleSizeAssessor
-        :: TokenBundleMaxSize -> TokenBundleSizeAssessor
-        -- ^ A function to assess the size of a token bundle.
 
     , decodeTx
         :: AnyCardanoEra

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/TokenBundleSize.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/TokenBundleSize.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | Assessing sizes of token bundles
+module Cardano.Wallet.Write.Tx.Balance.TokenBundleSize
+    ( TokenBundleSizeAssessor (..)
+    , TokenBundleMaxSize (..)
+    , computeTokenBundleSerializedLengthBytes
+    , tokenBundleSizeAssessor
+    , getTokenBundleMaxSize
+    )
+    where
+
+import Prelude
+
+import Cardano.Ledger.Api
+    ( ppMaxValSizeL )
+import Cardano.Ledger.Binary
+    ( serialize', shelleyProtVer )
+import Cardano.Wallet.Primitive.Types.Tx.Constraints
+    ( TokenBundleSizeAssessment (..)
+    , TokenBundleSizeAssessor (..)
+    , TxSize (..)
+    )
+import Cardano.Wallet.Shelley.Compatibility
+    ( toCardanoValue )
+import Cardano.Wallet.Write.Tx
+    ( PParams, RecentEra, ShelleyLedgerEra, withConstraints )
+import Control.DeepSeq
+    ( NFData )
+import Control.Lens
+    ( (^.) )
+import GHC.Generics
+    ( Generic )
+import Numeric.Natural
+    ( Natural )
+
+import qualified Cardano.Api.Shelley as Cardano
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Data.ByteString as BS
+
+-- | The maximum size of a serialized 'TokenBundle'.
+-- ('_maxValSize' in the Alonzo ledger)
+newtype TokenBundleMaxSize = TokenBundleMaxSize
+    { unTokenBundleMaxSize :: TxSize }
+    deriving (Eq, Generic, Show)
+
+instance NFData TokenBundleMaxSize
+
+-- | Assesses a token bundle size in relation to the maximum size that can be
+--   included in a transaction output.
+--
+-- See 'W.TokenBundleSizeAssessor' for the expected properties of this function.
+--
+tokenBundleSizeAssessor :: TokenBundleMaxSize -> TokenBundleSizeAssessor
+tokenBundleSizeAssessor maxSize =
+    TokenBundleSizeAssessor { assessTokenBundleSize }
+  where
+    assessTokenBundleSize tb
+        | serializedLengthBytes <= maxSize' =
+            TokenBundleSizeWithinLimit
+        | otherwise =
+            TokenBundleSizeExceedsLimit
+      where
+        serializedLengthBytes :: TxSize
+        serializedLengthBytes = computeTokenBundleSerializedLengthBytes tb
+
+        maxSize' :: TxSize
+        maxSize' = unTokenBundleMaxSize maxSize
+
+computeTokenBundleSerializedLengthBytes :: TokenBundle.TokenBundle -> TxSize
+computeTokenBundleSerializedLengthBytes =
+    TxSize
+        . safeCast
+        . BS.length
+        . serialize' shelleyProtVer
+        . Cardano.toMaryValue
+        . toCardanoValue
+  where
+    safeCast :: Int -> Natural
+    safeCast = fromIntegral
+
+-- | Get a 'TokenBundleMaxSize' from a 'PParam era'.
+getTokenBundleMaxSize
+    :: RecentEra era
+    -> PParams (ShelleyLedgerEra era)
+    -> TokenBundleMaxSize
+getTokenBundleMaxSize era pp = withConstraints era $
+    TokenBundleMaxSize $ TxSize $ pp ^. ppMaxValSizeL

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/TokenBundleSize/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/TokenBundleSize/Gen.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2023 Cardano Foundation
+-- License: Apache-2.0
+module Cardano.Wallet.Write.Tx.Balance.TokenBundleSize.Gen
+    ( genTokenBundleMaxSize
+    , shrinkTokenBundleMaxSize
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Tx.Constraints
+    ( TxSize (..) )
+import Cardano.Wallet.Write.Tx.Balance.TokenBundleSize
+    ( TokenBundleMaxSize (..) )
+import Data.Word
+    ( Word64 )
+import Test.QuickCheck
+    ( Arbitrary (arbitrary, shrink), Gen, oneof )
+
+genTokenBundleMaxSize :: Gen TokenBundleMaxSize
+genTokenBundleMaxSize = TokenBundleMaxSize . TxSize <$>
+    oneof
+        -- Generate values close to the mainnet value of 4000 (and guard
+        -- against underflow)
+        [ fromIntegral . max 0 . (4000 +) <$> arbitrary @Int
+
+        -- Generate more extreme values (both small and large)
+        , fromIntegral <$> arbitrary @Word64
+        ]
+
+shrinkTokenBundleMaxSize :: TokenBundleMaxSize -> [TokenBundleMaxSize]
+shrinkTokenBundleMaxSize (TokenBundleMaxSize (TxSize s)) =
+    map (TokenBundleMaxSize . TxSize . fromIntegral)
+    . shrink @Word64 -- Safe w.r.t the generator, despite TxSize wrapping a
+                     -- Natural
+    $ fromIntegral s

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -47,14 +47,12 @@ import Cardano.Wallet.Address.Derivation.Shelley
     ( ShelleyKey (..) )
 import Cardano.Wallet.Address.Keys.WalletKey
     ( publicKey )
-import Cardano.Wallet.Byron.Compatibility
-    ( maryTokenBundleMaxSize )
 import Cardano.Wallet.Flavor
     ( KeyFlavor, keyFlavor )
 import Cardano.Wallet.Primitive.NetworkId
     ( NetworkId (..), SNetworkId (..), withSNetworkId )
 import Cardano.Wallet.Primitive.Types
-    ( SlotId (..), TokenBundleMaxSize (..), getDecentralizationLevel )
+    ( SlotId (..), getDecentralizationLevel )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -67,19 +65,11 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundle, genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessment (..)
-    , TokenBundleSizeAssessor (..)
-    , TxSize (..)
-    , txOutMaxCoin
-    , txOutMinCoin
-    )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     ( genTxOutTokenBundle )
 import Cardano.Wallet.Shelley.Compatibility
     ( CardanoBlock
     , StandardCrypto
-    , computeTokenBundleSerializedLengthBytes
     , decentralizationLevelFromPParams
     , decodeAddress
     , decodeStakeAddress
@@ -93,7 +83,6 @@ import Cardano.Wallet.Shelley.Compatibility
     , toCardanoHash
     , toCardanoValue
     , toTip
-    , tokenBundleSizeAssessor
     )
 import Cardano.Wallet.Unsafe
     ( unsafeIntToWord, unsafeMkEntropy )
@@ -139,7 +128,6 @@ import Test.Hspec.QuickCheck
     ( prop )
 import Test.QuickCheck
     ( Arbitrary (..)
-    , Blind (..)
     , Gen
     , NonNegative (..)
     , Property
@@ -147,7 +135,6 @@ import Test.QuickCheck
     , checkCoverage
     , choose
     , chooseInt
-    , conjoin
     , counterexample
     , cover
     , frequency
@@ -155,9 +142,7 @@ import Test.QuickCheck
     , property
     , resize
     , vector
-    , withMaxSuccess
     , (===)
-    , (==>)
     )
 import Test.QuickCheck.Monadic
     ( assert, monadicIO, monitor, run )
@@ -266,22 +251,6 @@ spec = do
             cover 10 (length (snd $ TokenBundle.toFlatList tb) > 3)
                 "has some assets" $
             fromCardanoValue (toCardanoValue tb) === tb
-
-
-    describe "Assessing the sizes of token bundles" $ do
-
-        it "prop_assessTokenBundleSize_enlarge" $
-            property prop_assessTokenBundleSize_enlarge
-        it "prop_assessTokenBundleSize_shrink" $
-            property prop_assessTokenBundleSize_shrink
-        it "unit_assessTokenBundleSize_fixedSizeBundle_32" $
-            property unit_assessTokenBundleSize_fixedSizeBundle_32
-        it "unit_assessTokenBundleSize_fixedSizeBundle_48" $
-            property unit_assessTokenBundleSize_fixedSizeBundle_48
-        it "unit_assessTokenBundleSize_fixedSizeBundle_64" $
-            property unit_assessTokenBundleSize_fixedSizeBundle_64
-        it "unit_assessTokenBundleSize_fixedSizeBundle_128" $
-            property unit_assessTokenBundleSize_fixedSizeBundle_128
 
     describe "Utilities" $ do
 
@@ -407,130 +376,6 @@ instance (Arbitrary n, Integral n, Num w) => Arbitrary (TrickyInt n w) where
         s <- frequency [(20, pure 1), (5, pure (-1)), (1, pure 0)]
         let n = s * ((2 ^ x) + d)
         pure $ TrickyInt n (fromIntegral n)
-
---------------------------------------------------------------------------------
--- Assessing the sizes of token bundles
---------------------------------------------------------------------------------
-
--- Enlarging a token bundle that is over the size limit should yield a token
--- bundle that is still over the size limit.
---
-prop_assessTokenBundleSize_enlarge
-    :: Blind (VariableSize1024 TokenBundle)
-    -> Blind (VariableSize16 TokenBundle)
-    -> Property
-prop_assessTokenBundleSize_enlarge b1' b2' =
-    assess b1 == TokenBundleSizeExceedsLimit ==> conjoin
-        [ assess (b1 `TokenBundle.add` b2)
-            === TokenBundleSizeExceedsLimit
-        , assess (b1 `TokenBundle.setCoin` txOutMaxCoin)
-            === TokenBundleSizeExceedsLimit
-        ]
-  where
-    assess = assessTokenBundleSize
-        $ tokenBundleSizeAssessor maryTokenBundleMaxSize
-    b1 = unVariableSize1024 $ getBlind b1'
-    b2 = unVariableSize16 $ getBlind b2'
-
--- Shrinking a token bundle that is within the size limit should yield a token
--- bundle that is still within the size limit.
---
-prop_assessTokenBundleSize_shrink
-    :: Blind (VariableSize1024 TokenBundle)
-    -> Blind (VariableSize16 TokenBundle)
-    -> TokenBundleMaxSize
-    -> Property
-prop_assessTokenBundleSize_shrink b1' b2' maxSize =
-    assess b1 == TokenBundleSizeWithinLimit ==> conjoin
-        [ assess (b1 `TokenBundle.difference` b2)
-            === TokenBundleSizeWithinLimit
-        , assess (b1 `TokenBundle.setCoin` txOutMinCoin)
-            === TokenBundleSizeWithinLimit
-        ]
-  where
-    assess = assessTokenBundleSize (tokenBundleSizeAssessor maxSize)
-    b1 = unVariableSize1024 $ getBlind b1'
-    b2 = unVariableSize16 $ getBlind b2'
-
--- | Creates a test to assess the size of a token bundle with a fixed number of
---   assets, where the expected result is a constant.
---
--- Policy identifiers, asset names, token quantities are all allowed to vary.
---
-unit_assessTokenBundleSize_fixedSizeBundle
-    :: TokenBundle
-    -- ^ Fixed size bundle
-    -> TokenBundleSizeAssessment
-    -- ^ Expected size assessment
-    -> TokenBundleMaxSize
-    -- ^ TokenBundle assessor function
-    -> TxSize
-    -- ^ Expected min length (bytes)
-    -> TxSize
-    -- ^ Expected max length (bytes)
-    -> Property
-unit_assessTokenBundleSize_fixedSizeBundle
-    bundle
-    expectedAssessment
-    maxSize
-    expectedMinLengthBytes
-    expectedMaxLengthBytes =
-        withMaxSuccess 100 $
-        counterexample counterexampleText $
-        conjoin . fmap property $
-            [ actualAssessment  == expectedAssessment
-            , actualLengthBytes >= expectedMinLengthBytes
-            , actualLengthBytes <= expectedMaxLengthBytes
-            ]
-  where
-    actualAssessment = assessTokenBundleSize
-        (tokenBundleSizeAssessor maxSize)
-        bundle
-    actualLengthBytes = computeTokenBundleSerializedLengthBytes bundle
-    counterexampleText = unlines
-        [ "Expected min length bytes:"
-        , show expectedMinLengthBytes
-        , "Expected max length bytes:"
-        , show expectedMaxLengthBytes
-        , "Actual length bytes:"
-        , show actualLengthBytes
-        , "Expected assessment:"
-        , show expectedAssessment
-        , "Actual assessment:"
-        , show actualAssessment
-        ]
-
-unit_assessTokenBundleSize_fixedSizeBundle_32
-    :: Blind (FixedSize32 TokenBundle) -> Property
-unit_assessTokenBundleSize_fixedSizeBundle_32 (Blind (FixedSize32 b)) =
-    unit_assessTokenBundleSize_fixedSizeBundle b
-        TokenBundleSizeWithinLimit
-        maryTokenBundleMaxSize
-        (TxSize 2116) (TxSize 2380)
-
-unit_assessTokenBundleSize_fixedSizeBundle_48
-    :: Blind (FixedSize48 TokenBundle) -> Property
-unit_assessTokenBundleSize_fixedSizeBundle_48 (Blind (FixedSize48 b)) =
-    unit_assessTokenBundleSize_fixedSizeBundle b
-        TokenBundleSizeWithinLimit
-        maryTokenBundleMaxSize
-        (TxSize 3172) (TxSize 3564)
-
-unit_assessTokenBundleSize_fixedSizeBundle_64
-    :: Blind (FixedSize64 TokenBundle) -> Property
-unit_assessTokenBundleSize_fixedSizeBundle_64 (Blind (FixedSize64 b)) =
-    unit_assessTokenBundleSize_fixedSizeBundle b
-        TokenBundleSizeExceedsLimit
-        maryTokenBundleMaxSize
-        (TxSize 4228) (TxSize 4748)
-
-unit_assessTokenBundleSize_fixedSizeBundle_128
-    :: Blind (FixedSize128 TokenBundle) -> Property
-unit_assessTokenBundleSize_fixedSizeBundle_128 (Blind (FixedSize128 b)) =
-    unit_assessTokenBundleSize_fixedSizeBundle b
-        TokenBundleSizeExceedsLimit
-        maryTokenBundleMaxSize
-        (TxSize 8452) (TxSize 9484)
 
 toKeyHash :: Text -> Script KeyHash
 toKeyHash txt = case fromBase16 (T.encodeUtf8 txt) of

--- a/lib/wallet/test/unit/Cardano/Wallet/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -1,0 +1,230 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Cardano.Wallet.Write.Tx.Balance.TokenBundleSizeSpec where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle )
+import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
+    ( genTokenBundle, genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
+import Cardano.Wallet.Primitive.Types.Tx.Constraints
+    ( TokenBundleSizeAssessment (..), TxSize (..), txOutMaxCoin, txOutMinCoin )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
+    ( genTxOutTokenBundle )
+import Cardano.Wallet.Write.Tx.Balance.TokenBundleSize
+    ( TokenBundleMaxSize (TokenBundleMaxSize)
+    , assessTokenBundleSize
+    , computeTokenBundleSerializedLengthBytes
+    , tokenBundleSizeAssessor
+    )
+import Cardano.Wallet.Write.Tx.Balance.TokenBundleSize.Gen
+    ( genTokenBundleMaxSize, shrinkTokenBundleMaxSize )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Blind (..)
+    , Property
+    , conjoin
+    , counterexample
+    , property
+    , resize
+    , withMaxSuccess
+    , (===)
+    , (==>)
+    )
+
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+
+spec :: Spec
+spec = describe "Assessing the sizes of token bundles" $ do
+    it "prop_assessTokenBundleSize_enlarge" $
+        property prop_assessTokenBundleSize_enlarge
+    it "prop_assessTokenBundleSize_shrink" $
+        property prop_assessTokenBundleSize_shrink
+    it "unit_assessTokenBundleSize_fixedSizeBundle_32" $
+        property unit_assessTokenBundleSize_fixedSizeBundle_32
+    it "unit_assessTokenBundleSize_fixedSizeBundle_48" $
+        property unit_assessTokenBundleSize_fixedSizeBundle_48
+    it "unit_assessTokenBundleSize_fixedSizeBundle_64" $
+        property unit_assessTokenBundleSize_fixedSizeBundle_64
+    it "unit_assessTokenBundleSize_fixedSizeBundle_128" $
+        property unit_assessTokenBundleSize_fixedSizeBundle_128
+
+--------------------------------------------------------------------------------
+-- Assessing the sizes of token bundles
+--------------------------------------------------------------------------------
+
+-- Enlarging a token bundle that is over the size limit should yield a token
+-- bundle that is still over the size limit.
+--
+prop_assessTokenBundleSize_enlarge
+    :: Blind (VariableSize1024 TokenBundle)
+    -> Blind (VariableSize16 TokenBundle)
+    -> Property
+prop_assessTokenBundleSize_enlarge b1' b2' =
+    assess b1 == TokenBundleSizeExceedsLimit ==> conjoin
+        [ assess (b1 `TokenBundle.add` b2)
+            === TokenBundleSizeExceedsLimit
+        , assess (b1 `TokenBundle.setCoin` txOutMaxCoin)
+            === TokenBundleSizeExceedsLimit
+        ]
+  where
+    assess = assessTokenBundleSize
+        $ tokenBundleSizeAssessor maryTokenBundleMaxSize
+    b1 = unVariableSize1024 $ getBlind b1'
+    b2 = unVariableSize16 $ getBlind b2'
+
+-- Shrinking a token bundle that is within the size limit should yield a token
+-- bundle that is still within the size limit.
+--
+prop_assessTokenBundleSize_shrink
+    :: Blind (VariableSize1024 TokenBundle)
+    -> Blind (VariableSize16 TokenBundle)
+    -> TokenBundleMaxSize
+    -> Property
+prop_assessTokenBundleSize_shrink b1' b2' maxSize =
+    assess b1 == TokenBundleSizeWithinLimit ==> conjoin
+        [ assess (b1 `TokenBundle.difference` b2)
+            === TokenBundleSizeWithinLimit
+        , assess (b1 `TokenBundle.setCoin` txOutMinCoin)
+            === TokenBundleSizeWithinLimit
+        ]
+  where
+    assess = assessTokenBundleSize (tokenBundleSizeAssessor maxSize)
+    b1 = unVariableSize1024 $ getBlind b1'
+    b2 = unVariableSize16 $ getBlind b2'
+
+-- | Creates a test to assess the size of a token bundle with a fixed number of
+--   assets, where the expected result is a constant.
+--
+-- Policy identifiers, asset names, token quantities are all allowed to vary.
+--
+unit_assessTokenBundleSize_fixedSizeBundle
+    :: TokenBundle
+    -- ^ Fixed size bundle
+    -> TokenBundleSizeAssessment
+    -- ^ Expected size assessment
+    -> TokenBundleMaxSize
+    -- ^ TokenBundle assessor function
+    -> TxSize
+    -- ^ Expected min length (bytes)
+    -> TxSize
+    -- ^ Expected max length (bytes)
+    -> Property
+unit_assessTokenBundleSize_fixedSizeBundle
+    bundle
+    expectedAssessment
+    maxSize
+    expectedMinLengthBytes
+    expectedMaxLengthBytes =
+        withMaxSuccess 100 $
+        counterexample counterexampleText $
+        conjoin . fmap property $
+            [ actualAssessment  == expectedAssessment
+            , actualLengthBytes >= expectedMinLengthBytes
+            , actualLengthBytes <= expectedMaxLengthBytes
+            ]
+  where
+    actualAssessment = assessTokenBundleSize
+        (tokenBundleSizeAssessor maxSize)
+        bundle
+    actualLengthBytes = computeTokenBundleSerializedLengthBytes bundle
+    counterexampleText = unlines
+        [ "Expected min length bytes:"
+        , show expectedMinLengthBytes
+        , "Expected max length bytes:"
+        , show expectedMaxLengthBytes
+        , "Actual length bytes:"
+        , show actualLengthBytes
+        , "Expected assessment:"
+        , show expectedAssessment
+        , "Actual assessment:"
+        , show actualAssessment
+        ]
+
+unit_assessTokenBundleSize_fixedSizeBundle_32
+    :: Blind (FixedSize32 TokenBundle) -> Property
+unit_assessTokenBundleSize_fixedSizeBundle_32 (Blind (FixedSize32 b)) =
+    unit_assessTokenBundleSize_fixedSizeBundle b
+        TokenBundleSizeWithinLimit
+        maryTokenBundleMaxSize
+        (TxSize 2116) (TxSize 2380)
+
+unit_assessTokenBundleSize_fixedSizeBundle_48
+    :: Blind (FixedSize48 TokenBundle) -> Property
+unit_assessTokenBundleSize_fixedSizeBundle_48 (Blind (FixedSize48 b)) =
+    unit_assessTokenBundleSize_fixedSizeBundle b
+        TokenBundleSizeWithinLimit
+        maryTokenBundleMaxSize
+        (TxSize 3172) (TxSize 3564)
+
+unit_assessTokenBundleSize_fixedSizeBundle_64
+    :: Blind (FixedSize64 TokenBundle) -> Property
+unit_assessTokenBundleSize_fixedSizeBundle_64 (Blind (FixedSize64 b)) =
+    unit_assessTokenBundleSize_fixedSizeBundle b
+        TokenBundleSizeExceedsLimit
+        maryTokenBundleMaxSize
+        (TxSize 4228) (TxSize 4748)
+
+unit_assessTokenBundleSize_fixedSizeBundle_128
+    :: Blind (FixedSize128 TokenBundle) -> Property
+unit_assessTokenBundleSize_fixedSizeBundle_128 (Blind (FixedSize128 b)) =
+    unit_assessTokenBundleSize_fixedSizeBundle b
+        TokenBundleSizeExceedsLimit
+        maryTokenBundleMaxSize
+        (TxSize 8452) (TxSize 9484)
+
+instance Arbitrary TokenBundle where
+    arbitrary = genTokenBundleSmallRange
+    shrink = shrinkTokenBundleSmallRange
+
+instance Arbitrary TokenBundleMaxSize where
+    arbitrary = genTokenBundleMaxSize
+    shrink = shrinkTokenBundleMaxSize
+
+newtype FixedSize32 a = FixedSize32 { unFixedSize32 :: a }
+    deriving (Eq, Show)
+
+newtype FixedSize48 a = FixedSize48 { unFixedSize48 :: a }
+    deriving (Eq, Show)
+
+newtype FixedSize64 a = FixedSize64 { unFixedSize64 :: a }
+    deriving (Eq, Show)
+
+newtype FixedSize128 a = FixedSize128 { unFixedSize128 :: a }
+    deriving (Eq, Show)
+
+newtype VariableSize16 a = VariableSize16 { unVariableSize16 :: a}
+    deriving (Eq, Show)
+
+newtype VariableSize1024 a = VariableSize1024 { unVariableSize1024 :: a}
+    deriving (Eq, Show)
+
+instance Arbitrary (FixedSize32 TokenBundle) where
+    arbitrary = FixedSize32 <$> genTxOutTokenBundle 32
+    -- No shrinking
+
+instance Arbitrary (FixedSize48 TokenBundle) where
+    arbitrary = FixedSize48 <$> genTxOutTokenBundle 48
+    -- No shrinking
+
+instance Arbitrary (FixedSize64 TokenBundle) where
+    arbitrary = FixedSize64 <$> genTxOutTokenBundle 64
+    -- No shrinking
+
+instance Arbitrary (FixedSize128 TokenBundle) where
+    arbitrary = FixedSize128 <$> genTxOutTokenBundle 128
+    -- No shrinking
+
+instance Arbitrary (VariableSize16 TokenBundle) where
+    arbitrary = VariableSize16 <$> resize 16 genTokenBundle
+    -- No shrinking
+
+instance Arbitrary (VariableSize1024 TokenBundle) where
+    arbitrary = VariableSize1024 <$> resize 1024 genTokenBundle
+    -- No shrinking
+
+maryTokenBundleMaxSize :: TokenBundleMaxSize
+maryTokenBundleMaxSize = TokenBundleMaxSize 4000

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -1291,8 +1291,6 @@ dummyTransactionLayer = TransactionLayer
         error "dummyTransactionLayer: addVkWitnesses not implemented"
     , mkUnsignedTransaction =
         error "dummyTransactionLayer: mkUnsignedTransaction not implemented"
-    , tokenBundleSizeAssessor =
-        error "dummyTransactionLayer: tokenBundleSizeAssessor not implemented"
     , decodeTx = \_era _witCtx _sealed ->
         ( Tx
             { txId = Hash ""


### PR DESCRIPTION
- [x] Move `TokenBundleSizeAssessor` to new `Cardano.Wallet.Write.Tx.Balance.TokenBundleSizeAssessor` module.
    - I left a version of the `TokenBundleMaxSize` newtype in `Primitive.Types`, as it is entangled with one remaining thing: the protocol parameters API endpoint.

### Comments

### Issue Number

ADP-3081
