### PR TITLE
Coalesce consecutive `let` blocks to minimise nesting.

### DIFF
--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -1563,23 +1563,25 @@ assignCoinsToChangeMaps adaAvailable minCoinFor pairsAtStart
         pair :| pairs | adaAvailable >= adaRequired ->
             -- We have enough ada available to pay for the minimum required
             -- amount of every asset map that remains in our list:
-            let assetMapsRemaining = fst <$> (pair :| pairs) in
-            let bundlesForAssetsWithMinimumCoins =
-                    assignMinimumCoin minCoinFor <$> assetMapsRemaining in
-            -- Calculate the amount of ada that remains after assigning the
-            -- minimum amount to each map. This should be safe, as we have
-            -- already determined that we have enough ada available:
-            let adaRemaining = adaAvailable `Coin.distance` adaRequired in
-            -- Partition any remaining ada according to the weighted
-            -- distribution of output coins that remain in our list:
-            let outputCoinsRemaining = snd <$> (pair :| pairs) in
-            let bundlesForOutputCoins = TokenBundle.fromCoin <$>
-                    makeChangeForCoin outputCoinsRemaining adaRemaining in
-            -- Finally, combine the minimal coin asset bundles with the
-            -- bundles obtained by partitioning the remaining ada amount:
-            Right $ NE.toList $ NE.zipWith (<>)
-                bundlesForAssetsWithMinimumCoins
-                bundlesForOutputCoins
+            let
+                assetMapsRemaining = fst <$> (pair :| pairs)
+                bundlesForAssetsWithMinimumCoins =
+                    assignMinimumCoin minCoinFor <$> assetMapsRemaining
+                -- Calculate the amount of ada that remains after assigning the
+                -- minimum amount to each map. This should be safe, as we have
+                -- already determined that we have enough ada available:
+                adaRemaining = adaAvailable `Coin.distance` adaRequired
+                -- Partition any remaining ada according to the weighted
+                -- distribution of output coins that remain in our list:
+                outputCoinsRemaining = snd <$> (pair :| pairs)
+                bundlesForOutputCoins = TokenBundle.fromCoin <$>
+                    makeChangeForCoin outputCoinsRemaining adaRemaining
+            in
+                -- Finally, combine the minimal coin asset bundles with the
+                -- bundles obtained by partitioning the remaining ada amount:
+                Right $ NE.toList $ NE.zipWith (<>)
+                    bundlesForAssetsWithMinimumCoins
+                    bundlesForOutputCoins
 
         (m, _) :| (p : ps) | TokenMap.isEmpty m && adaAvailable < adaRequired ->
             -- We don't have enough ada available to pay for the minimum

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -1191,7 +1191,7 @@ prop_runSelection_UTxO_empty balanceRequested strategy = monadicIO $ do
             , selectionStrategy = strategy
             }
     let balanceSelected = UTxOSelection.selectedBalance result
-    let balanceLeftover = UTxOSelection.leftoverBalance result
+        balanceLeftover = UTxOSelection.leftoverBalance result
     assertWith
         "utxoAvailable `UTxOSelection.isSubSelectionOf` result"
         (utxoAvailable `UTxOSelection.isSubSelectionOf` result)
@@ -1214,7 +1214,7 @@ prop_runSelection_UTxO_notEnough utxoAvailable strategy = monadicIO $ do
             , selectionStrategy = strategy
             }
     let balanceSelected = UTxOSelection.selectedBalance result
-    let balanceLeftover = UTxOSelection.leftoverBalance result
+        balanceLeftover = UTxOSelection.leftoverBalance result
     assertWith
         "utxoAvailable `UTxOSelection.isSubSelectionOf` result"
         (utxoAvailable `UTxOSelection.isSubSelectionOf` result)
@@ -1238,7 +1238,7 @@ prop_runSelection_UTxO_exactlyEnough utxoAvailable strategy = monadicIO $ do
             , selectionStrategy = strategy
             }
     let balanceSelected = UTxOSelection.selectedBalance result
-    let balanceLeftover = UTxOSelection.leftoverBalance result
+        balanceLeftover = UTxOSelection.leftoverBalance result
     assertWith
         "utxoAvailable `UTxOSelection.isSubSelectionOf` result"
         (utxoAvailable `UTxOSelection.isSubSelectionOf` result)
@@ -1266,7 +1266,7 @@ prop_runSelection_UTxO_moreThanEnough utxoAvailable strategy = monadicIO $ do
             , selectionStrategy = strategy
             }
     let balanceSelected = UTxOSelection.selectedBalance result
-    let balanceLeftover = UTxOSelection.leftoverBalance result
+        balanceLeftover = UTxOSelection.leftoverBalance result
     monitor $ cover 80
         (assetsRequested `Set.isProperSubsetOf` assetsAvailable)
         "assetsRequested ⊂ assetsAvailable"
@@ -1314,7 +1314,7 @@ prop_runSelection_UTxO_muchMoreThanEnough (Blind (Large index)) strategy =
                 , selectionStrategy = strategy
                 }
         let balanceSelected = UTxOSelection.selectedBalance result
-        let balanceLeftover = UTxOSelection.leftoverBalance result
+            balanceLeftover = UTxOSelection.leftoverBalance result
         monitor $ cover 80
             (assetsRequested `Set.isProperSubsetOf` assetsAvailable)
             "assetsRequested ⊂ assetsAvailable"

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -412,7 +412,7 @@ balanceTransaction
             over #tx
                 (increaseZeroAdaOutputs (recentEra @era) (pparamsLedger pp))
                 partialTx
-    let balanceWith strategy =
+        balanceWith strategy =
             balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 @era @m @changeState
                 tr
@@ -617,9 +617,8 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 AllScriptPaymentCredentialsFrom _template toInpScripts ->
                     toInpScripts . view #address . snd <$>
                         extraInputs <> extraCollateral'
-
-    let extraCollateral = fst <$> extraCollateral'
-    let unsafeFromLovelace (Cardano.Lovelace l) = Coin.unsafeFromIntegral l
+        extraCollateral = fst <$> extraCollateral'
+        unsafeFromLovelace (Cardano.Lovelace l) = Coin.unsafeFromIntegral l
     candidateTx <- assembleTransaction $ TxUpdate
         { extraInputs
         , extraCollateral
@@ -644,8 +643,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     let feeAndChange = TxFeeAndChange
             (unsafeFromLovelace candidateMinFee)
             (extraOutputs)
-
-    let feePerByte = getFeePerByte (recentEra @era) pp
+        feePerByte = getFeePerByte (recentEra @era) pp
 
     -- @distributeSurplus@ should never fail becase we have provided enough
     -- padding in @selectAssets@.
@@ -696,7 +694,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                        Left i
                     Just o -> do
                         let i' = fromCardanoTxIn i
-                        let W.TxOut addr bundle = fromCardanoTxOut o
+                            W.TxOut addr bundle = fromCardanoTxOut o
                         pure (WalletUTxO i' addr, bundle)
 
         case partitionEithers res of
@@ -744,12 +742,12 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             (Cardano.Value, Cardano.Lovelace, KeyWitnessCount)
     balanceAfterSettingMinFee tx = ExceptT . pure $ do
         let witCount = estimateKeyWitnessCount combinedUTxO (getBody tx)
-        let minfee = W.toWalletCoin $ evaluateMinimumFee
+            minfee = W.toWalletCoin $ evaluateMinimumFee
                 (recentEra @era) pp (fromCardanoTx tx) witCount
-        let update = TxUpdate [] [] [] [] (UseNewTxFee minfee)
+            update = TxUpdate [] [] [] [] (UseNewTxFee minfee)
         tx' <- left ErrBalanceTxUpdateError $ updateTx tx update
         let balance = txBalance tx'
-        let minfee' = Cardano.Lovelace $ fromIntegral $ W.unCoin minfee
+            minfee' = Cardano.Lovelace $ fromIntegral $ W.unCoin minfee
         return (balance, minfee', witCount)
       where
         getBody (Cardano.Tx body _) = body
@@ -771,7 +769,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         let u = Map.mapKeys fromCardanoTxIn
                 . Map.map fromCardanoTxOut
                 $ (unUTxO u')
-        let conflicts = lefts $ flip map (Map.toList u) $ \(i, o) ->
+            conflicts = lefts $ flip map (Map.toList u) $ \(i, o) ->
                 case i `UTxO.lookup` walletUTxO of
                     Just o' -> unless (o == o') $ Left (o, o')
                     Nothing -> pure ()
@@ -833,7 +831,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         -- total balance. Because the wallet does not consider the network tag,
         -- it will drop one of the two, leading to a discrepancy.
         let networkOfWdrl ((Cardano.StakeAddress nw _), _, _) = nw
-        let conflictingWdrlNetworks = case Cardano.txWithdrawals body of
+            conflictingWdrlNetworks = case Cardano.txWithdrawals body of
                 Cardano.TxWithdrawalsNone -> False
                 Cardano.TxWithdrawals _ wdrls -> Set.size
                     (Set.fromList $ map networkOfWdrl wdrls) > 1


### PR DESCRIPTION
## Issue Number

ADP-2256

## Description

Using `fourmolu` to reformat multiple consecutive `let` blocks can result in multiple layers of nesting, which can harm readability.

For example:

https://github.com/cardano-foundation/cardano-wallet/blob/ad57b66411e5531007ba6b28c7296f3240a7cafb/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs#L1622-L1652

In many cases, consecutive `let` blocks can be replaced with a single `let` block that contains multiple definitions. This PR applies this transformation to a small selection of modules where it is safe to do so.