### PR TITLE
Update documentation links in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,13 @@ Previously, during the Byron phase, the wallet was part of the [cardano-sl](http
 
 | Link                                                                                               | Audience                                                     |
 | ---                                                                                                | ---                                                          |
-| [User Guide](https://cardano-foundation.github.io/cardano-wallet/user-guide) | Users of Cardano Wallet                              |
-| [CLI Manual](https://cardano-foundation.github.io/cardano-wallet/user-guide/cli) | Users of the Cardano Wallet API                              |
-| [API Documentation](https://cardano-foundation.github.io/cardano-wallet/api/edge)                     | Users of the Cardano Wallet API                              |
-| [Cardano Wallet Documentation](https://cardano-foundation.github.io/cardano-wallet/)                                     | Anyone interested in the project and our development process |
+| [Documentation](https://cardano-foundation.github.io/cardano-wallet/)                                     |  |
+| • [User Manual](https://cardano-foundation.github.io/cardano-wallet/user) | Users of Cardano Wallet                              |
+| &nbsp;&nbsp;⤷ [CLI Manual](https://cardano-foundation.github.io/cardano-wallet/user/cli) | Users of the Cardano Wallet API                              |
+| &nbsp;&nbsp;⤷ [API Documentation](https://cardano-foundation.github.io/cardano-wallet/api/edge)                     | Users of the Cardano Wallet API                              |
+| • [Design Documents](https://cardano-foundation.github.io/cardano-wallet/design)                     | Anyone interested in wallet design and specifications|
+| &nbsp;&nbsp;⤷ [Specifications](https://cardano-foundation.github.io/cardano-wallet/design/specs)                     | Anyone interested in wallet design and specifications|
+| • [Contributor Manual](https://cardano-foundation.github.io/cardano-wallet/contributor)                     | Anyone interested in the project and our development process |
 | [Adrestia Documentation](https://input-output-hk.github.io/adrestia/)                                     | Anyone interested in the project and our development process |
 
 <hr/>

--- a/docs/site/src/design.md
+++ b/docs/site/src/design.md
@@ -1,4 +1,4 @@
-# Design
+# Design Documents
 
 Information about the design of the wallet.
 

--- a/docs/site/src/design/links.md
+++ b/docs/site/src/design/links.md
@@ -1,8 +1,5 @@
 # Other Resources
 
-- [Formal Specification for a Cardano Wallet](https://github.com/cardano-foundation/cardano-wallet/blob/master/specifications/wallet/formal-specification-for-a-cardano-wallet.pdf)
-- [Cardano Improvement Proposals (CIPs)](https://cips.cardano.org/)
-
 ## Cardano Node
 
 - [User Guide](https://docs.cardano.org/en/latest/)

--- a/docs/site/src/design/specs.md
+++ b/docs/site/src/design/specs.md
@@ -1,1 +1,11 @@
 # Specifications
+
+Precise specifications for
+
+* Parts of the wallet API
+* Data structures used in the wallet
+
+Additional information:
+
+- [Formal Specification for a Cardano Wallet](https://github.com/cardano-foundation/cardano-wallet/blob/master/specifications/wallet/formal-specification-for-a-cardano-wallet.pdf)
+- [Cardano Improvement Proposals (CIPs)](https://cips.cardano.org/)


### PR DESCRIPTION
This pull requests cleans up the documentation links in the Readme file. Specifically:

* It rearranges the table with documentation links.
* It adds more text to the destinations of these links.

Fixes #3527 .