### PR TITLE
Remove redundant use of `NoMonoLocalBinds`.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE NoMonoLocalBinds #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}


### PR DESCRIPTION
## Issue

ADP-2256

## Description

This PR removes a redundant usage of the `NoMonoLocalBinds` extension.

This use of `NoMonoLocalBinds` is made redundant by a subsequent use of the `TypeFamilies` extension. Since `TypeFamilies` implies `MonoLocalBinds`, this cancels out the effect of the earlier `NoMonoLocalBinds`.

Therefore, we can remove `NoMonoLocalBinds`.