### PR TITLE
Use `cabal` cradle for HLS in CI.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -106,13 +106,11 @@ steps:
   - label: 'Check HLS works'
     depends_on: linux-nix
     command: |
-        ln -sf hie-direnv.yaml hie.yaml
         nix develop --command bash -c "haskell-language-server lib/wallet/src/Cardano/Wallet.hs"
     agents:
       system: ${linux}
     env:
       TMPDIR: "/cache"
-
 
   - block: 'Run benchmark (api)'
     depends_on: linux-nix


### PR DESCRIPTION
## Issue

ADP-2256

## Description

This enables HLS to correctly pick up on default language extensions included in `cabal` files.