### PR TITLE
Update links in `CONTRIBUTING.md`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
-If you find a bug or you'd like to propose a feature, please feel free to raise an issue on our [issue tracker](https://github.com/input-output-hk/cardano-wallet/issues).
+If you find a bug or you'd like to propose a feature, please feel free to raise an issue on our [issue tracker](https://github.com/cardano-foundation/cardano-wallet/issues).
 
 Pull requests are welcome!
 
 When creating a pull request, please make sure that your code adheres to our [coding standards](https://github.com/input-output-hk/adrestia/blob/master/docs/code/Coding-Standards.md).
 
-For more information, please consult our [contributors' guide](https://input-output-hk.github.io/cardano-wallet/contributing).
+For more information, please consult our [contributors' guide](https://cardano-foundation.github.io/cardano-wallet/contributing).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,4 @@ Pull requests are welcome!
 
 When creating a pull request, please make sure that your code adheres to our [coding standards](https://github.com/input-output-hk/adrestia/blob/master/docs/code/Coding-Standards.md).
 
-For more information, please consult our [contributors' guide](https://cardano-foundation.github.io/cardano-wallet/contributing).
+For more information, please consult our [Contributor Manual](https://cardano-foundation.github.io/cardano-wallet/contributor).


### PR DESCRIPTION
## Issue

#4064

## Description

This PR updates all but one of the links within `CONTRIBUTING.md` to point to `cardano-foundation` rather than `input-output-hk`.

The remaining link (to our coding standards) must remain unchanged, as this is **_still_** the location of our coding standards, and will be until we complete https://cardanofoundation.atlassian.net/browse/ADP-2256.