### PR TITLE
[ADP-3113] Mini-language for specifying ledger types in math notation

### DIFF
--- a/prototypes/cabal.project
+++ b/prototypes/cabal.project
@@ -15,8 +15,9 @@
 --
 --------------------------------------------------------------------------------
 
-index-state: 2022-01-01T00:00:00Z
+index-state: 2023-07-31T13:43:03Z
 with-compiler: ghc-8.10.7
 
 packages:
     light-mode-test/
+    ledger-types-test/

--- a/prototypes/ledger-types-test/CHANGELOG.md
+++ b/prototypes/ledger-types-test/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Revision history for ledger-types-test
+
+This package is a prototype and not intended to be released.

--- a/prototypes/ledger-types-test/README.md
+++ b/prototypes/ledger-types-test/README.md
@@ -1,0 +1,8 @@
+# Cardano ledger types
+
+This prototype explores whether the type definitions from the Cardano ledger specification can be put into a format that is
+
+* machine-readable
+* visually close to math notation
+
+The purpose is to export the types to other languages besides Haskell.

--- a/prototypes/ledger-types-test/data/Babbage.txt
+++ b/prototypes/ledger-types-test/data/Babbage.txt
@@ -1,0 +1,172 @@
+module Babbage where
+{-----------------------------------------------------------------------------
+    Types for the Babbage era of the Cardano ledger,
+    focusing on types relating to transactions.
+
+    The type definitions here are meant to satisfy two requirements:
+    1. Visually match the specification documents (PDF) for correctness.
+       (No renamings, no reorderings. The spec is law. 🧑🏻‍⚖️)
+       (Some filtering is necessary as later specs are written as updates.)
+    2. Be machine-readable in order to map them to a programming language.
+
+    TheCardano  ledger specifications are found at
+    https://github.com/input-output-hk/cardano-ledger/releases/latest/
+
+    In order to make the hash types more specific, we         
+    have also taken into account the binary format in `babbage.cddl`.
+------------------------------------------------------------------------------}
+
+Slot    = _;
+Network = _;
+Ix      = ℕ;
+
+ByteString = Bytes;
+
+{-----------------------------------------------------------------------------
+    Addresses
+------------------------------------------------------------------------------}
+Addr     = _; -- simplified in this document
+Addr_rws = Addr;
+
+DCert    = _; -- simplified in this document
+
+{-----------------------------------------------------------------------------
+    Cryptographic definitions
+    Shelley spec, Figure 2, filtered
+------------------------------------------------------------------------------}
+VKey = _;
+Sig  = _;
+
+{-----------------------------------------------------------------------------
+    Hashes
+    Shelley spec, Section A.1 Hashing
+------------------------------------------------------------------------------}
+Hash28 = _; -- 28 bytes. BLAKE2b-224
+Hash32 = _; -- 32 bytes. BLAKE2b-256
+
+{-----------------------------------------------------------------------------
+    Hashes
+    Alonzo spec, Figure 21
+------------------------------------------------------------------------------}
+ScriptHash = Hash28;
+KeyHash    = Hash28;
+DataHash   = Hash32;
+TxId       = _; -- simplified in this document
+
+{-----------------------------------------------------------------------------
+    Simple scripts
+------------------------------------------------------------------------------}
+Script^ph1 = _; -- simplified in this document
+
+{-----------------------------------------------------------------------------
+    Protocol parameters
+    Babbage spec, Figure 1
+------------------------------------------------------------------------------}
+ExUnits = ℕ × ℕ;
+
+{-----------------------------------------------------------------------------
+    Protocol parameters update
+------------------------------------------------------------------------------}
+Update = _; -- simplified in this document
+
+{-----------------------------------------------------------------------------
+    Plutus
+    Alonzo Spec, Figure 2
+------------------------------------------------------------------------------}
+-- Abstract types
+ScriptIntegrityHash = Hash32;       -- `script_data_hash` in babbage.cddl
+Script_plc = _;
+Data       = _;
+
+-- Script types
+Script^ph2 = Script_plc;
+Script     = Script^ph1 ⊎ Script^ph2;
+IsValid    = Bool;
+Datum      = Data;
+Redeemer   = Data;
+
+-- Derived types
+ValidityInterval = Slot? × Slot?;
+-- TxOut -- defined in Babbage
+Tag        = _; -- FIXME. Enum
+RdmrPtr    = Tag × Ix;
+ScriptHash = Hash28;                -- `scripthash` in babbage.cddl
+
+{-----------------------------------------------------------------------------
+    Value and Token Algebra
+    Mary spec, Figure 3, filtered
+------------------------------------------------------------------------------}
+AssetName = ByteString;
+PolicyID  = ScriptHash;
+AdaIDType = _;
+AssetID   = AdaIDType ⊎ (PolicyID × AssetName);
+Quantity  = ℤ;
+Value     = AssetID ↦0 Quantity;
+
+{-----------------------------------------------------------------------------
+    Transactions
+    Shelley spec, Figure 10, filtered
+------------------------------------------------------------------------------}
+-- Abstract types
+-- TxId -- defined elsewhere
+Metadatum = _;
+
+-- Derived types
+TxIn        = TxId × Ix;
+UTxO        = TxIn ↦ TxOut;
+Wdrl        = Addr_rwd ↦ Coin;
+Metadata    = ℕ ↦ Metadatum; 
+
+{-----------------------------------------------------------------------------
+    Transaction Body
+    Babbage spec, Figure 1
+------------------------------------------------------------------------------}
+TxOut = Addr × Value × (Datum ⊎ DataHash)? × Script?;
+
+TxBody =
+  { spendInputs         : ℙ TxIn
+  , collInputs          : ℙ TxIn
+  , refInputs           : ℙ TxIn
+  , txouts              : (Ix →∗ TxOut)
+  , collRet             : TxOut?
+  , txcoll              : Coin?
+  , txcerts             : DCert*
+  , mint                : Value
+  , txfee               : Coin
+  , txvldt              : ValidityInterval
+  , txwdrls             : Wdrl
+  , txUpdates           : Update?
+  , reqSignerHashes     : ℙ KeyHash
+  , scriptIntegrityHash : ScriptIntegrityHash?
+  , txADhash            : AuxiliaryDataHash?
+  , txnetworkid         : Network?
+  };
+
+{-----------------------------------------------------------------------------
+    AuxiliaryData
+    Mary spec, Figure 5, filtered
+------------------------------------------------------------------------------}
+AuxiliaryData =
+  { scripts : ℙ Script
+  , md      : Metadata? 
+  };
+
+AuxiliaryDataHash = Hash32; -- `auxiliary_data_hash` in babbage.cddl
+
+{-----------------------------------------------------------------------------
+    Transaction and witness
+    Alonzo spec, Figure 3, filtered
+------------------------------------------------------------------------------}
+TxWitness =
+  { txwitsVKey : VKey ↦ Sig
+  , txscripts  : ScriptHash ↦ Script
+  , txdats     : DataHash ↦ Datum
+  , txrdmrs    : RdmrPtr ↦ (Redeemer × ExUnits)
+  };
+
+Tx =
+  { txbody        : TxBody
+  , txwits        : TxWitness
+  , isValid       : IsValid
+  , auxiliaryData : AuxiliaryData?
+  };

--- a/prototypes/ledger-types-test/data/BabbageTxOut.txt
+++ b/prototypes/ledger-types-test/data/BabbageTxOut.txt
@@ -46,7 +46,7 @@ TxIn =
 TxOut =
   { address   : Addr
   , value     : Value
-  , datum     : (Datum ⊎ DataHash)?
+  , datum     : DatumOrHash?
   , scriptRef : Script?
   };
 

--- a/prototypes/ledger-types-test/data/BabbageTxOut.txt
+++ b/prototypes/ledger-types-test/data/BabbageTxOut.txt
@@ -1,0 +1,58 @@
+module BabbageTxOut where
+{-----------------------------------------------------------------------------
+    Elaboration of
+    some of the types from the Babbage era
+------------------------------------------------------------------------------}
+
+-- elaborate Babbage;
+
+Ix = ℕ;
+ByteString = Bytes;
+
+TxId = Bytes;
+
+ScriptHash = Bytes;
+Script^ph1 = Bytes;
+Script^ph2 = Bytes;
+Script     = Script^ph1 ⊎ Script^ph2;
+
+AssetName = ByteString;
+PolicyID  = ScriptHash;
+AdaIDType = Unit;
+
+Quantity  = ℤ;
+Value     = AssetID ↦0 Quantity;
+
+Addr     = Bytes;
+Datum    = Bytes;
+DataHash = Bytes;
+
+AssetIDNonAda =
+  { policyId  : PolicyID
+  , assetName : AssetName
+  };
+
+AssetID =
+  [+ ada   : AdaIDType
+  ,  asset : AssetIDNonAda
+  +];
+
+
+TxIn =
+  { id    : TxId
+  , index : Ix
+  };
+
+TxOut =
+  { address   : Addr
+  , value     : Value
+  , datum     : (Datum ⊎ DataHash)?
+  , scriptRef : Script?
+  };
+
+DatumOrHash =
+  [+ datum    : Datum
+  ,  dataHash : DataHash
+  +];
+
+UTxO = TxIn ↦ TxOut;

--- a/prototypes/ledger-types-test/data/json/UTxO.txt
+++ b/prototypes/ledger-types-test/data/json/UTxO.txt
@@ -1,0 +1,64 @@
+module UTxO where
+
+{-----------------------------------------------------------------------------
+    UTxO type in the Babbage era
+    close to the specification
+------------------------------------------------------------------------------}
+ByteString = Bytes;
+ScriptHash = Bytes;
+
+Addr     = Bytes;
+Script   = Bytes;
+Datum    = Bytes;
+DataHash = Bytes;
+
+{-----------------------------------------------------------------------------
+    Value and Token Algebra
+    Mary spec, Figure 3, filtered, annotated
+------------------------------------------------------------------------------}
+AssetName = ByteString;
+PolicyID  = ScriptHash;
+AdaIDType = Unit;
+
+AssetID =
+  [+ ada   : AdaIDType
+  ,  asset : AssetIDNonAda
+  +];
+
+AssetIDNonAda =
+  { policyId  : PolicyID
+  , assetName : AssetName
+  };
+
+Quantity  = ℤ;
+Value     = AssetID ↦0 Quantity;
+
+{-----------------------------------------------------------------------------
+    Transaction Body
+    Babbage spec, Figure 1, filtered, annotated
+------------------------------------------------------------------------------}
+TxOut =
+  { address   : Addr
+  , value     : Value
+  , datum     : DatumOrHash?
+  , scriptRef : Script?
+  };
+
+DatumOrHash =
+  [+ datum    : Datum
+  ,  dataHash : DataHash
+  +];
+
+{-----------------------------------------------------------------------------
+    Transactions
+    Shelley spec, Figure 10, filtered, annotated
+------------------------------------------------------------------------------}
+TxId = Bytes;
+Ix = ℕ;
+
+TxIn =
+  { id    : TxId
+  , index : Ix
+  };
+
+UTxO = TxIn ↦ TxOut;

--- a/prototypes/ledger-types-test/data/json/UTxO_JSON.txt
+++ b/prototypes/ledger-types-test/data/json/UTxO_JSON.txt
@@ -1,0 +1,67 @@
+module UTxO_JSON where
+
+{-----------------------------------------------------------------------------
+    UTxO type in the Babbage era
+    JSON-friendly
+------------------------------------------------------------------------------}
+
+ByteString = Bytes;
+ScriptHash = Bytes;
+
+Addr     = Bytes;
+Script   = Bytes;
+Datum    = Bytes;
+DataHash = Bytes;
+
+{-----------------------------------------------------------------------------
+    Value and Token Algebra
+------------------------------------------------------------------------------}
+
+Quantity = ℤ;
+
+Value =
+  { ada    : Quantity
+  , assets : Asset*
+  };
+
+PolicyID   = ScriptHash;
+AssetName  = ByteString;
+
+Asset =
+  { policyId  : PolicyID
+  , assetName : AssetName
+  , quantity  : Quantity
+  };
+
+{-----------------------------------------------------------------------------
+    TxOut
+------------------------------------------------------------------------------}
+TxOut =
+  { address   : Addr
+  , value     : Value
+  , datum     : DatumOrHash?
+  , scriptRef : Script?
+  };
+
+DatumOrHash =
+  [+ datum    : Datum
+  ,  dataHash : DataHash
+  +];
+
+{-----------------------------------------------------------------------------
+    Transactions
+    Shelley spec, Figure 10, filtered, annotated
+------------------------------------------------------------------------------}
+TxId = Bytes;
+Ix = ℕ;
+
+UTxO_1 =
+  { id        : TxId
+  , index     : Ix
+  , address   : Addr
+  , value     : Value
+  , datum     : DatumOrHash?
+  , scriptRef : Script?
+  };
+
+UTxO = UTxO_1*;

--- a/prototypes/ledger-types-test/ledger-types-test.cabal
+++ b/prototypes/ledger-types-test/ledger-types-test.cabal
@@ -31,6 +31,7 @@ library
       , parser-combinators
     exposed-modules:
         Demo
+        Elaborate
         Module
         Parser
         Type

--- a/prototypes/ledger-types-test/ledger-types-test.cabal
+++ b/prototypes/ledger-types-test/ledger-types-test.cabal
@@ -25,13 +25,18 @@ library
         NoImplicitPrelude
     build-depends:
         base ^>= 4.14.3
+      , aeson ^>= 2.1.2
       , bytestring
       , containers
       , megaparsec ^>= 9.2.1
       , parser-combinators
+      , text
+      , yaml
     exposed-modules:
         Demo
+        Demo.Export
         Elaborate
+        Export.OpenAPI
         Module
         Parser
         Type

--- a/prototypes/ledger-types-test/ledger-types-test.cabal
+++ b/prototypes/ledger-types-test/ledger-types-test.cabal
@@ -25,6 +25,7 @@ library
         NoImplicitPrelude
     build-depends:
         base ^>= 4.14.3
+      , bytestring
       , containers
       , megaparsec ^>= 9.2.1
       , parser-combinators
@@ -33,5 +34,6 @@ library
         Module
         Parser
         Type
+        Value
     hs-source-dirs:
         src

--- a/prototypes/ledger-types-test/ledger-types-test.cabal
+++ b/prototypes/ledger-types-test/ledger-types-test.cabal
@@ -1,0 +1,37 @@
+cabal-version:      3.0
+name:               ledger-types-test
+version:            0.1.0.0
+synopsis:           Machine-readable description of Cardano ledger types
+-- description:
+bug-reports:        https://github.com/cardano-foundation/cardano-wallet
+author:             HAL, Cardano Foundation
+maintainer:         hal@cardanofoundation.org
+copyright:          2023 Cardano Foundation
+license:            Apache-2.0
+category:           Cardano
+
+extra-source-files:
+    CHANGELOG.md
+    README.md
+data-files:
+    data/Babbage.txt
+    data/BabbageTxOut.txt
+
+library
+    default-language:
+        Haskell2010
+    default-extensions:
+        NamedFieldPuns
+        NoImplicitPrelude
+    build-depends:
+        base ^>= 4.14.3
+      , containers
+      , megaparsec ^>= 9.2.1
+      , parser-combinators
+    exposed-modules:
+        Demo
+        Module
+        Parser
+        Type
+    hs-source-dirs:
+        src

--- a/prototypes/ledger-types-test/ledger-types-test.cabal
+++ b/prototypes/ledger-types-test/ledger-types-test.cabal
@@ -37,8 +37,10 @@ library
       , yaml
     exposed-modules:
         Demo
+        Demo.Embedding
         Demo.Export
         Elaborate
+        Embedding
         Export.OpenAPI
         Export.OpenAPI.Value
         Module

--- a/prototypes/ledger-types-test/ledger-types-test.cabal
+++ b/prototypes/ledger-types-test/ledger-types-test.cabal
@@ -31,6 +31,7 @@ library
       , aeson ^>= 2.1.2
       , bytestring
       , containers
+      , haskell-src-exts ^>= 1.23.1
       , megaparsec ^>= 9.2.1
       , parser-combinators
       , text
@@ -41,6 +42,8 @@ library
         Demo.Export
         Elaborate
         Embedding
+        Export.Haskell
+        Export.Haskell.Language
         Export.OpenAPI
         Export.OpenAPI.Value
         Module

--- a/prototypes/ledger-types-test/ledger-types-test.cabal
+++ b/prototypes/ledger-types-test/ledger-types-test.cabal
@@ -25,6 +25,7 @@ library
         NoImplicitPrelude
     build-depends:
         base ^>= 4.14.3
+      , base16 ^>= 1.0
       , aeson ^>= 2.1.2
       , bytestring
       , containers
@@ -37,6 +38,7 @@ library
         Demo.Export
         Elaborate
         Export.OpenAPI
+        Export.OpenAPI.Value
         Module
         Parser
         Type

--- a/prototypes/ledger-types-test/ledger-types-test.cabal
+++ b/prototypes/ledger-types-test/ledger-types-test.cabal
@@ -16,6 +16,8 @@ extra-source-files:
 data-files:
     data/Babbage.txt
     data/BabbageTxOut.txt
+    data/json/UTxO.txt
+    data/json/UTxO_JSON.txt
 
 library
     default-language:

--- a/prototypes/ledger-types-test/ledger-types-test.cabal
+++ b/prototypes/ledger-types-test/ledger-types-test.cabal
@@ -44,6 +44,8 @@ library
         Embedding
         Export.Haskell
         Export.Haskell.Language
+        Export.Haskell.Value.Compiletime
+        Export.Haskell.Value.Runtime
         Export.OpenAPI
         Export.OpenAPI.Value
         Module

--- a/prototypes/ledger-types-test/src/Demo.hs
+++ b/prototypes/ledger-types-test/src/Demo.hs
@@ -19,5 +19,11 @@ main = do
     Just elaborated <-
         parseLedgerTypes <$> readFile "data/BabbageTxOut.txt"
 
+    let txout1 = moduleDeclarations babbage Map.! "TxOut"
+        txout1' = resolveVars (moduleDeclarations babbage) txout1
+        txout2 = moduleDeclarations elaborated Map.! "TxOut"
+        txout2' = resolveVars (moduleDeclarations elaborated) txout2
+
+    print $ txout2' `elaborates` txout1'
     print $ collectNotInScope babbage
     print $ collectNotInScope elaborated

--- a/prototypes/ledger-types-test/src/Demo.hs
+++ b/prototypes/ledger-types-test/src/Demo.hs
@@ -1,0 +1,23 @@
+module Demo where
+
+import Prelude
+
+import Elaborate
+import Module
+import Parser
+import Typ
+
+import qualified Data.Map as Map
+
+{-----------------------------------------------------------------------------
+    Demonstration
+    of the current ledger types.
+------------------------------------------------------------------------------}
+main :: IO ()
+main = do
+    Just babbage <- parseLedgerTypes <$> readFile "data/Babbage.txt"
+    Just elaborated <-
+        parseLedgerTypes <$> readFile "data/BabbageTxOut.txt"
+
+    print $ collectNotInScope babbage
+    print $ collectNotInScope elaborated

--- a/prototypes/ledger-types-test/src/Demo/Embedding.hs
+++ b/prototypes/ledger-types-test/src/Demo/Embedding.hs
@@ -1,0 +1,56 @@
+module Demo.Embedding where
+
+import Prelude
+
+import Embedding
+import Export.Haskell
+import Export.OpenAPI
+import Module
+import Parser
+import Typ
+import Value
+
+import qualified Data.Aeson as JS
+import qualified Data.List as L
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified Data.Yaml as Yaml
+
+{-----------------------------------------------------------------------------
+    Demonstration
+    of embedding of types
+------------------------------------------------------------------------------}
+main :: IO ()
+main = do
+    Just hs <- parseLedgerTypes <$> readFile "data/json/UTxO.txt"
+    Just js <- parseLedgerTypes <$> readFile "data/json/UTxO_JSON.txt"
+
+    let hsValue = forgetNames $ resolve hs "Value"
+        jsValue = forgetNames $ resolve js "Value"
+
+        zero = Zero (IntegerV 0)
+        emb = second' (map1 assocR <> representMap)
+            <> first' (unit0 zero)
+            <> exponential
+
+    print $ hsValue
+    print $ jsValue
+    print $ typecheck emb hsValue == Just jsValue
+
+-- | Resolve the 'Typ' corresponding to a name.
+-- The result will not contain 'Var'.
+resolve :: Module -> TypName -> Typ
+resolve m name = resolveVars declarations typ
+  where
+    typ = declarations Map.! name
+    declarations = moduleDeclarations m
+
+-- | Forget all field and constructor names.
+forgetNames :: Typ -> Typ
+forgetNames = everywhere forget
+  where
+    forget (Record nas@(_:_)) =
+        L.foldr (Binary Product) (snd $ last nas) (map snd $ init nas)
+    forget (Union  nas@(_:_)) =
+        L.foldr (Binary Sum) (snd $ last nas) (map snd $ init nas)
+    forget x = x

--- a/prototypes/ledger-types-test/src/Demo/Export.hs
+++ b/prototypes/ledger-types-test/src/Demo/Export.hs
@@ -2,6 +2,7 @@ module Demo.Export where
 
 import Prelude
 
+import Export.Haskell
 import Export.OpenAPI
 import Module
 import Parser
@@ -18,12 +19,15 @@ import qualified Data.Yaml as Yaml
 ------------------------------------------------------------------------------}
 main :: IO ()
 main = do
-    Just elaborated <-
-        parseLedgerTypes <$> readFile "data/BabbageTxOut.txt"
+    Just json <-
+        parseLedgerTypes <$> readFile "data/json/UTxO_JSON.txt"
 
-    Yaml.encodeFile "data/gen/BabbageTxOut.yaml"
+    Yaml.encodeFile "data/gen/UTxO_JSON.yaml"
         $ getOpenAPISchema
         $ schemaFromModule
-        $ elaborated {
-            moduleDeclarations = convertToJSON (moduleDeclarations elaborated)
-          }
+        $ json
+
+    writeFile "data/gen/UTxO_JSON.hs"
+        $ prettyPrint
+        $ haskellFromModule
+        $ json

--- a/prototypes/ledger-types-test/src/Demo/Export.hs
+++ b/prototypes/ledger-types-test/src/Demo/Export.hs
@@ -1,0 +1,29 @@
+module Demo.Export where
+
+import Prelude
+
+import Export.OpenAPI
+import Module
+import Parser
+import Typ
+
+import qualified Data.Aeson as JS
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified Data.Yaml as Yaml
+
+{-----------------------------------------------------------------------------
+    Demonstration
+    of exporting types to JSON and Haskell
+------------------------------------------------------------------------------}
+main :: IO ()
+main = do
+    Just elaborated <-
+        parseLedgerTypes <$> readFile "data/BabbageTxOut.txt"
+
+    Yaml.encodeFile "data/gen/BabbageTxOut.yaml"
+        $ getOpenAPISchema
+        $ schemaFromModule
+        $ elaborated {
+            moduleDeclarations = convertToJSON (moduleDeclarations elaborated)
+          }

--- a/prototypes/ledger-types-test/src/Demo/UTxO.hs
+++ b/prototypes/ledger-types-test/src/Demo/UTxO.hs
@@ -1,0 +1,76 @@
+module Demo.UTxO where
+
+import Prelude
+
+import Elaborate
+import Embedding
+import Export.Haskell
+import Export.OpenAPI
+import Module
+import Parser
+import Typ
+import Value
+
+import qualified Data.List as L
+import qualified Data.Map as Map
+import qualified Data.Yaml as Yaml
+
+{-----------------------------------------------------------------------------
+    Demonstration
+    of mapping Haskell types to JSON
+------------------------------------------------------------------------------}
+export :: IO ()
+export = do
+    Just hs <- parseLedgerTypes <$> readFile "data/json/UTxO.txt"
+    Just js <- parseLedgerTypes <$> readFile "data/json/UTxO_JSON.txt"
+
+    let hsValue = forgetNames $ resolve hs "Value"
+        jsValue = forgetNames $ resolve js "Value"
+
+    putStrLn $ "Check types"
+    print $
+        (jsValue `elaborates`) <$> typecheck hsIntoJs hsValue
+
+    Yaml.encodeFile "data/gen/UTxO_JSON.yaml"
+        $ getOpenAPISchema
+        $ schemaFromModule
+        $ js
+
+    writeFile "src/TestGen_UTxO.hs"
+        $ prettyPrint
+        $ haskellFromModule
+        $ hs { moduleName = "TestGen_UTxO" }
+
+load_Value_JSON :: IO Typ
+load_Value_JSON = do
+    Just js <- parseLedgerTypes <$> readFile "data/json/UTxO_JSON.txt"
+    pure $ resolve js "Value"
+
+hsIntoJs :: EmbeddingTyp
+hsIntoJs
+    = second' (map1 assocR <> representMap)
+    <> first' (unit0 zero)
+    <> exponential
+  where
+    zero = Zero (IntegerV 0)
+
+{-----------------------------------------------------------------------------
+    Helpers
+------------------------------------------------------------------------------}
+-- | Resolve the 'Typ' corresponding to a name.
+-- The result will not contain 'Var'.
+resolve :: Module -> TypName -> Typ
+resolve m name = resolveVars declarations typ
+  where
+    typ = declarations Map.! name
+    declarations = moduleDeclarations m
+
+-- | Forget all field and constructor names.
+forgetNames :: Typ -> Typ
+forgetNames = everywhere forget
+  where
+    forget (Record nas@(_:_)) =
+        L.foldr (Binary Product) (snd $ last nas) (map snd $ init nas)
+    forget (Union  nas@(_:_)) =
+        L.foldr (Binary Sum) (snd $ last nas) (map snd $ init nas)
+    forget x = x

--- a/prototypes/ledger-types-test/src/Demo/UTxO/Runtime.hs
+++ b/prototypes/ledger-types-test/src/Demo/UTxO/Runtime.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Demo.UTxO.Runtime where
+
+import Prelude
+
+import Demo.UTxO
+    ( hsIntoJs, load_Value_JSON )
+import Embedding
+    ( embed, to, exponential, unit0, first', unit0, second', representMap )
+import Export.Haskell.Value.Runtime
+    ( ToValue (..) )
+import Export.OpenAPI.Value
+    ( jsonFromValue )
+
+import TestGen_UTxO
+
+import qualified Value as V
+import qualified Data.Aeson as JS
+import qualified Data.Map
+
+main :: IO ()
+main = do
+    putStrLn "Converting example Cardano Value to JSON"
+
+    typ <- load_Value_JSON
+    let fromHaskell = jsonFromValue typ . to (embed hsIntoJs) . toValue
+    print $ fromHaskell example
+
+example :: Value
+example = Data.Map.fromList
+    [ (Ada (), 1000 )
+    , (Asset asset1, 42)
+    , (Asset asset2, 21)
+    ]
+
+asset1 :: AssetIDNonAda
+asset1 = AssetIDNonAda
+    { policyId = "1337"
+    , assetName = "Leetcoin"
+    }
+
+asset2 :: AssetIDNonAda
+asset2 = AssetIDNonAda
+    { policyId = "101"
+    , assetName = "Lolcoin"
+    }

--- a/prototypes/ledger-types-test/src/Elaborate.hs
+++ b/prototypes/ledger-types-test/src/Elaborate.hs
@@ -1,0 +1,68 @@
+module Elaborate
+    ( elaborates
+    ) where
+
+import Prelude
+
+import Typ
+    ( Typ (..), OpBinary (..), OpUnary (..) )
+
+{-----------------------------------------------------------------------------
+    Elaboration
+------------------------------------------------------------------------------}
+-- | Type A elaborates type B if it adds more specific information,
+-- such as field or constructor names, while representing the same structure.
+--
+-- Specifically,
+--
+-- * Every type elaborates 'Abstract'.
+-- * A record type with field names elaborates a product.
+-- * A sum type with constructor names elaborates a disjoint sum.
+elaborates :: Typ -> Typ -> Bool
+elaborates _ Abstract = True
+elaborates (Var name1) (Var name2) = name1 == name2
+elaborates (Unary op1 a1) (Unary op2 a2)
+    = op1 == op2 && elaborates a1 a2
+elaborates (Binary op1 a1 b1) (Binary op2 a2 b2)
+    = op1 == op2 && elaborates a1 a2 && elaborates b1 b2
+elaborates (Record fields) a
+    | Just components <- matchProduct a =
+        elaboratesSeq (map snd fields) components
+    | otherwise = False
+elaborates (Union fields) a
+    | Just summands <- matchSum a =
+        elaboratesSeq (map snd fields) summands
+    | otherwise = False
+elaborates _ _ = False
+
+-- | Check whether a sequence of types elaborates another sequence.
+elaboratesSeq:: [Typ] -> [Typ] -> Bool
+elaboratesSeq [] [] = True
+elaboratesSeq (x:xs) (y:ys) = elaborates x y && elaboratesSeq xs ys
+elaboratesSeq _ _ = False
+
+-- | Match a type @X@ against a product @A1 × A2 × … × An@
+-- with at least two components.
+--
+-- Association does not matter, i.e. @(A × B) × C = A × (B × C)@ have
+-- the same components.
+matchProduct :: Typ -> Maybe [Typ]
+matchProduct typ = case typ of
+    e@(Binary Product _ _) -> Just $ match e
+    _ -> Nothing
+  where
+    match (Binary Product a b) = match a <> match b
+    match e = [e]
+
+-- | Match a type @X@ against a sum @A1 ⊎ A2 ⊎ … ⊎ An@
+-- with at least two summands.
+--
+-- Association does not matter, i.e. @(A ⊎ B) ⊎ C = A ⊎ (B ⊎ C)@ have
+-- the same summands.
+matchSum :: Typ -> Maybe [Typ]
+matchSum typ = case typ of
+    e@(Binary Sum _ _) -> Just $ match e
+    _ -> Nothing
+  where
+    match (Binary Sum a b) = match a <> match b
+    match e = [e]

--- a/prototypes/ledger-types-test/src/Embedding.hs
+++ b/prototypes/ledger-types-test/src/Embedding.hs
@@ -1,0 +1,247 @@
+module Embedding where
+
+import Prelude
+
+import Typ
+import Value
+
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+
+{-----------------------------------------------------------------------------
+    Embedding
+------------------------------------------------------------------------------}
+-- | An 'Embedding' from a type A into a type B
+-- is a many-to-one correspondence from the second type to the first.
+--
+-- > from . to = id
+--
+-- See Wadler's introduction to Agda
+--  https://plfa.github.io/20.07/Isomorphism/#embedding
+data Embedding a b = Embedding
+    { to :: a -> b
+    , from :: b -> a
+    }
+
+-- | An 'EmbeddingV' is a dynamically typed embedding of 'Value' into 'Value'.
+--
+-- Specifically, if @a `hasTyp` ta@ and @typecheck e ta == Just tb@,
+-- then @to e a == b@ and @b `hasTyp tab@.
+--
+-- The result of @to e a@ can be 'undefined' if the value @a@ does
+-- not have the expected 'Typ', that is @typecheck e ta == Nothing tb@.
+data EmbeddingTyp = EmbeddingTyp
+    { embed :: Embedding Value Value
+        -- ^ Embedding of 'Value's from one 'Typ' into the other.
+    , typecheck :: Typ -> Maybe Typ
+        -- ^ Check whether the 'Embedding' works on the given 'Typ'.
+    }
+
+-- Design Question: Return the embedding as part of the type check?
+
+{-----------------------------------------------------------------------------
+    Functorial operations
+------------------------------------------------------------------------------}
+-- | Composition of embeddings. Right-to-left.
+--
+-- > to (embed (ebc <> eab)) = to (embed ebc) . to (embed eab)
+instance Semigroup EmbeddingTyp where
+    ebc <> eab = EmbeddingTyp
+        { embed = Embedding
+            { to = to (embed ebc) . to (embed eab)
+            , from = from (embed eab) . from (embed ebc)
+            }
+        , typecheck = \t -> typecheck eab t >>= typecheck ebc
+        }
+
+instance Monoid EmbeddingTyp where
+    mempty = EmbeddingTyp
+        { embed = Embedding { to = id, from = id }
+        , typecheck = Just
+        }
+
+-- | Operate on the argument of an unary operation.
+map1 :: EmbeddingTyp -> EmbeddingTyp
+map1 ee = EmbeddingTyp
+    { embed = Embedding
+        { to = \a -> case a of
+            One x -> One (fmap' (to e) x)
+            _ -> error "Typ(e) error in: map1, to"
+        , from = \b -> case b of
+            One x -> One (fmap' (from e) x)
+            _ -> error "Typ(e) error in: map1, from"
+        }
+    , typecheck = \t -> case t of
+        Unary op a -> Unary op <$> typecheck ee a
+        _ -> Nothing
+    }
+  where
+    e = embed ee
+
+    fmap' :: (Value -> Value) -> OneF Value -> OneF Value
+    fmap' f (OptionV a) = OptionV (f <$> a)
+    fmap' f (SequenceV a) = SequenceV (f <$> a)
+    fmap' f (PowerSetV a) = PowerSetV (Set.map f a)
+
+
+-- | Operate on the first argument of a 'Product' or 'Sum'.
+first' :: EmbeddingTyp -> EmbeddingTyp
+first' ee = EmbeddingTyp
+    { embed = Embedding
+        { to = \a -> case a of
+            ProductV [x,y] -> ProductV [to e x, y]
+            SumV 0 x -> SumV 0 $ to e x
+            SumV 1 _ -> a
+            _ -> error "Typ(e) error in: first', to"
+        , from = \b -> case b of
+            ProductV [x2,y2] -> ProductV [from e x2, y2]
+            SumV 0 x2 -> SumV 0 $ from e x2
+            SumV 1 _ -> b
+            _ -> error "Typ(e) error in: first', from"
+        }
+    , typecheck = \t -> case t of
+        Binary fun a0 b
+            | fun == Sum || fun == Product
+                -> (\a1 -> Binary fun a1 b) <$> typecheck ee a0
+        _ -> Nothing
+    }
+  where
+    e = embed ee
+
+-- | Operate on the first argument of a 'Product' or 'Sum'.
+second' :: EmbeddingTyp -> EmbeddingTyp
+second' ee = EmbeddingTyp
+    { embed = Embedding
+        { to = \a -> case a of
+            ProductV [x,y] -> ProductV [x, to e y]
+            SumV 0 _ -> a
+            SumV 1 y -> SumV 1 $ to e y
+            _ -> error "Typ(e) error in: second', to"
+        , from = \b -> case b of
+            ProductV [x2, y2] -> ProductV [x2, from e y2]
+            SumV 0 _ -> b
+            SumV 1 y2 -> SumV 1 $ from e y2
+            _ -> error "Typ(e) error in: second', from"
+        }
+    , typecheck = \t -> case t of
+        Binary fun a b0
+            | fun == Sum || fun == Product
+                -> (\b1 -> Binary fun a b1) <$> typecheck ee b0
+        _ -> Nothing
+    }
+  where
+    e = embed ee
+
+-- | Associative law for products.
+--
+-- > (A × B) × C  =>  A × (B × C)
+assocR :: EmbeddingTyp
+assocR = EmbeddingTyp
+    { embed = Embedding
+        { to = \a -> case a of
+            ProductV [ProductV [a,b],c] -> ProductV [a, ProductV [b,c]]
+            _ -> error "Typ(e) error in: assocR, to"
+        , from = \b -> case b of
+            ProductV [a, ProductV [b,c]] -> ProductV [ProductV [a,b],c]
+            _ -> error "Typ(e) error in: assocR, from"
+        }
+    , typecheck = \t -> case t of
+        Binary Product (Binary Product a b) c
+            -> Just $ Binary Product a (Binary Product b c)
+        _ -> Nothing
+    }
+
+{-----------------------------------------------------------------------------
+    Basic algebra
+------------------------------------------------------------------------------}
+-- | Unit law for a monoid.
+--
+-- > () ↦0 A  =>  A
+unit0 :: Value -> EmbeddingTyp
+unit0 zero = EmbeddingTyp
+    { embed = Embedding
+        { to = \a -> case a of
+            Two (FiniteMapV m)
+                -> Map.findWithDefault zero (Zero UnitV) m
+            _ -> error "Typ(e) error in: unit0, to"
+        , from = \b ->
+            Two . FiniteMapV $ Map.singleton (Zero UnitV) b
+        }
+    , typecheck = \t -> case t of
+        Binary FiniteSupport (Var "Unit") s -> Just s
+        _ -> Nothing
+    }
+
+-- | Exponential law(s)
+-- 
+-- > (A ⊎ B) ↦0 C  =>  (A ↦0 C) × (B ↦0 C)
+-- > (A ⊎ B) ↦  C  =>  (A ↦ C)  × (B ↦ C)
+exponential :: EmbeddingTyp
+exponential = EmbeddingTyp
+    { embed = Embedding
+        { to = \a -> case a of
+            Two (FiniteMapV m) ->
+                ProductV
+                    [ Two $ FiniteMapV (left m)
+                    , Two $ FiniteMapV (right m)
+                    ]
+            _ -> error "Typ(e) error in: exponential, to"
+        , from = \b -> case b of
+            ProductV
+                [ Two (FiniteMapV ml)
+                , Two (FiniteMapV mr)
+                ]
+                -> Two $ FiniteMapV (plus ml mr)
+            _ -> error "Typ(e) error in: exponential, from"
+        }
+    , typecheck = \t -> case t of
+        Binary fun (Binary Sum a b) c
+            | fun == FiniteSupport || fun == PartialFunction
+            -> Just $ Binary Product (Binary fun a c) (Binary fun b c)
+        _ -> Nothing
+    }
+  where
+    plus ml mr
+        = Map.mapKeys (SumV 0) ml <> Map.mapKeys (SumV 1) mr
+
+    left = withKeys matchLeft
+    right = withKeys matchRight
+
+    withKeys f
+        = Map.mapKeys (\(SumV _ x) -> x)
+        . Map.mapMaybeWithKey (\k v -> f k v)
+
+    matchLeft (SumV 0 _) v = Just v
+    matchLeft _ _ = Nothing
+
+    matchRight (SumV 1 _) v = Just v
+    matchRight _ _ = Nothing
+
+{-----------------------------------------------------------------------------
+    Conversions
+------------------------------------------------------------------------------}
+-- | Representation of finite maps as sequences of pairs.
+--
+-- > A ↦ B   =>  (A × B)*
+-- > A ↦0 B   =>  (A × B)*
+representMap :: EmbeddingTyp
+representMap = EmbeddingTyp
+    { embed = Embedding
+        { to = \a -> case a of
+            Two (FiniteMapV m) -> valueFromList (Map.toList m)
+            _ -> error "Typ(e) error in: representMap, to"
+        , from = \b -> case b of
+            One (SequenceV xs) ->
+                Two $ FiniteMapV
+                    $ Map.fromList [ (a,b) | ProductV [a,b] <- xs ]
+            _ -> error "Typ(e) error in: representMap, from"
+        }
+    , typecheck = \t -> case t of
+        Binary PartialFunction a b
+            -> Just $ Unary Sequence (Binary Product a b)
+        Binary FiniteSupport a b
+            -> Just $ Unary Sequence (Binary Product a b)
+        _ -> Nothing
+    }
+  where
+    valueFromList = One . SequenceV . map (\(a,b) -> ProductV [a,b])

--- a/prototypes/ledger-types-test/src/Export/Haskell.hs
+++ b/prototypes/ledger-types-test/src/Export/Haskell.hs
@@ -1,0 +1,140 @@
+-- | Export 'Typ' definitions to Haskell type definitions.
+module Export.Haskell
+    ( HsModule (..)
+    , prettyPrint
+
+    , haskellFromModule
+    ) where
+
+import Prelude
+
+import Export.Haskell.Language
+import Typ
+
+import qualified Data.Map as Map
+import qualified Language.Haskell.Exts as Hs
+
+{-----------------------------------------------------------------------------
+    Haskell
+------------------------------------------------------------------------------}
+newtype HsModule = HsModule { getHsModule :: Hs.Module Annotation }
+
+prettyPrint :: HsModule -> String
+prettyPrint = Hs.prettyPrint . getHsModule
+
+haskellFromModule :: Module -> HsModule
+haskellFromModule m =
+    HsModule
+    $ Hs.Module l (Just moduleHead) languageExtensions imports declarations
+  where
+    moduleHead =
+        Hs.ModuleHead l (Hs.ModuleName l $ moduleName m) Nothing Nothing
+    languageExtensions =
+        map (Hs.LanguagePragma l . (:[]) . Hs.Ident l)
+            [ "DeriveGeneric"
+            , "DerivingStrategies"  -- see Note [Deriving]
+            , "NoImplicitPrelude"
+            ]
+    imports =
+        map hsImportQualified
+            [ "Prelude"
+            , "Data.ByteString"
+            , "Data.Map"
+            , "Data.Set"
+            , "Data.Text"
+            , "GHC.Generics"
+            , "Numeric.Natural"
+            ]
+    declarations =
+        [ declarationFromTyp name typ
+        | (name, typ) <- Map.toList (moduleDeclarations m)
+        ]
+
+{-----------------------------------------------------------------------------
+    Convert Typ to Haskell declaration
+------------------------------------------------------------------------------}
+declarationFromTyp :: TypName -> Typ -> Hs.Decl Annotation
+declarationFromTyp name typ = case typ of
+    Record fields ->
+        Hs.DataDecl l (Hs.DataType l) Nothing declaredName
+            (declareRecord name fields)
+            derivingEqOrdGeneric
+    Union constructors ->
+        Hs.DataDecl l (Hs.DataType l) Nothing declaredName
+            (declareUnion name constructors)
+            derivingEqOrdGeneric
+    _ ->
+        Hs.TypeDecl l declaredName (typeFromTyp typ)
+  where
+    declaredName = Hs.DHead l $ Hs.Ident l name
+
+{- Note [Deriving]
+
+haskell-src-exts version 1.23.1 is not able to represent
+the Haskell98 deriving clause (`deriving (Eq,Ord,Generic)`).
+Instead, the generated code needs the `DerivingStrategies` extension.
+
+-}
+derivingEqOrdGeneric :: [Hs.Deriving Annotation]
+derivingEqOrdGeneric =
+    map derivingClass
+        [ "Prelude.Eq"
+        , "Prelude.Ord"
+        , "Prelude.Show"
+        , "GHC.Generics.Generic"
+        ]
+  where
+    derivingClass c =
+        Hs.Deriving l Nothing
+        [ Hs.IRule l Nothing Nothing (instanceHead c) ]
+    instanceHead = Hs.IHCon l . Hs.UnQual l . Hs.Ident l
+
+declareRecord
+    :: TypName
+    -> [(FieldName, Typ)]
+    -> [Hs.QualConDecl Annotation]
+declareRecord name fields =
+    [ Hs.QualConDecl l Nothing Nothing
+        $ Hs.RecDecl l
+            (Hs.Ident l name)
+            [ Hs.FieldDecl l [Hs.Ident l n] (typeFromTyp t) | (n,t) <- fields ]
+    ]
+
+declareUnion
+    :: TypName
+    -> [(ConstructorName, Typ)]
+    -> [Hs.QualConDecl Annotation]
+declareUnion name constructors =
+    [ Hs.QualConDecl l Nothing Nothing
+        $ Hs.ConDecl l (Hs.Ident l (raiseFirstLetter name)) [typeFromTyp typ]
+    | (name,typ) <- constructors
+    ]
+
+typeFromTyp :: Typ -> Hs.Type Annotation
+typeFromTyp = go
+  where
+    go Abstract = error "Abstract is not supported by Haskell"
+    go (Var "ℤ") = hsType "Prelude.Integer"
+    go (Var "ℕ") = hsType "Numeric.Natural.Natural"
+    go (Var "Bool") = hsType "Prelude.Bool"
+    go (Var "Bytes") = hsType "Data.ByteString.ByteString"
+    go (Var "Text") = hsType "Data.Text.Text"
+    go (Var "Unit") = hsUnit
+    go (Var name) = hsType name
+    go (Unary fun a) = fun1 `tyApp` go a
+      where
+        fun1 = case fun of
+            Option -> hsType "Prelude.Maybe"
+            Sequence -> hsList
+            PowerSet -> hsType "Data.Set.Set"
+    go (Binary fun a b) = (fun2 `tyApp` go a) `tyApp` go b
+      where
+        fun2 = case fun of
+            Sum -> hsType "Prelude.Either"
+            Product -> hsPair
+            PartialFunction -> hsType "Data.Map.Map"
+            FiniteSupport -> hsType "Data.Map.Map" -- Fixme: Ambiguous
+    go (Record fields) =
+        error "Nested Record is not supported by Haskell"
+    go (Union constructors) =
+        error "Nested Union is not supported by Haskell"

--- a/prototypes/ledger-types-test/src/Export/Haskell/Language.hs
+++ b/prototypes/ledger-types-test/src/Export/Haskell/Language.hs
@@ -1,0 +1,61 @@
+-- | Utilities concerning the Haskell language.
+module Export.Haskell.Language
+    ( Annotation
+    , l
+
+    , raiseFirstLetter
+
+    , tyApp
+    , hsType
+    , hsList
+    , hsUnit
+    , hsPair
+    , hsImportQualified
+    ) where
+
+import Prelude
+
+import Typ
+    ( TypName )
+
+import qualified Data.Char
+import qualified Language.Haskell.Exts as Hs
+
+{-----------------------------------------------------------------------------
+    Haskell language utilities
+------------------------------------------------------------------------------}
+type Annotation = ()
+l :: Annotation
+l = ()
+
+raiseFirstLetter :: String -> String
+raiseFirstLetter [] = []
+raiseFirstLetter (c:cs) = Data.Char.toUpper c : cs
+
+hsType :: TypName -> Hs.Type Annotation
+hsType = Hs.TyCon l . Hs.UnQual l . Hs.Ident l
+
+hsList :: Hs.Type Annotation
+hsList = Hs.TyCon l $ Hs.Special l $ Hs.ListCon l
+
+hsPair :: Hs.Type Annotation
+hsPair = Hs.TyCon l $ Hs.Special l $ Hs.TupleCon l Hs.Boxed 2
+
+hsUnit :: Hs.Type Annotation
+hsUnit = Hs.TyCon l $ Hs.Special l $ Hs.UnitCon l
+
+tyApp :: Hs.Type Annotation -> Hs.Type Annotation -> Hs.Type Annotation
+tyApp = Hs.TyApp l
+
+hsImportQualified :: String -> Hs.ImportDecl Annotation
+hsImportQualified name =
+    Hs.ImportDecl
+        { Hs.importAnn = l
+        , Hs.importModule = Hs.ModuleName l name
+        , Hs.importQualified = True
+        , Hs.importSrc = False
+        , Hs.importSafe = False
+        , Hs.importPkg = Nothing
+        , Hs.importAs = Nothing
+        , Hs.importSpecs = Nothing
+        }

--- a/prototypes/ledger-types-test/src/Export/Haskell/Value/Compiletime.hs
+++ b/prototypes/ledger-types-test/src/Export/Haskell/Value/Compiletime.hs
@@ -1,0 +1,89 @@
+-- | Export values of Haskell types to 'Value', generated at compile time.
+module Export.Haskell.Value.Compiletime
+    ( declareInstanceToValue
+    , declareToValueFunRecord
+    , declareToValueFunUnion
+    ) where
+
+import Prelude
+
+import Typ
+    ( ConstructorName, FieldName, Typ, TypName )
+import Export.Haskell.Language
+
+import qualified Language.Haskell.Exts as Hs
+
+{-----------------------------------------------------------------------------
+    Compile time definitions
+------------------------------------------------------------------------------}
+-- | Declare an @instance ToValue@ for a record type.
+declareInstanceToValue
+    :: TypName
+    -> Hs.Decl Annotation
+    -> Hs.Decl Annotation
+declareInstanceToValue name toValueDeclaration =
+    Hs.InstDecl l Nothing instanceRule (Just instanceDecls)
+  where
+    instanceRule = Hs.IRule l Nothing Nothing instanceHead
+    instanceHead = Hs.IHApp l (Hs.IHCon l className) (hsType name)
+    className = runtime "ToValue"
+    instanceDecls = [ Hs.InsDecl l toValueDeclaration ]
+
+-- | Declare the funcion `toValue` for a record type.
+declareToValueFunRecord
+    :: TypName
+    -> [(FieldName, Typ)]
+    -> Hs.Decl Annotation
+declareToValueFunRecord constructor fields =
+    Hs.FunBind l
+        [ Hs.Match l (Hs.Ident l "toValue") [pat] rhs Nothing ]
+  where
+    pat = Hs.PApp l (Hs.UnQual l $ Hs.Ident l constructor)
+        [ Hs.PVar l (Hs.Ident l $ field <> "_pat")
+        | (field,_) <- fields
+        ]
+    rhs = Hs.UnGuardedRhs l $ productV `app` (Hs.List l arguments)
+    arguments =
+        [ Hs.Var l (runtime "toValue") `app` var (field <> "_pat")
+        | (field,_) <- fields
+        ]
+    productV = Hs.Con l (runtime "ProductV")
+
+-- | Declare the funcion `toValue` for a sum type.
+declareToValueFunUnion
+    :: TypName
+    -> [(ConstructorName, Typ)]
+    -> Hs.Decl Annotation
+declareToValueFunUnion name constructors =
+    Hs.FunBind l
+        [ Hs.Match l
+            (Hs.Ident l "toValue")
+            [pat constructor]
+            (rhs ix)
+            Nothing
+        | (ix,(constructor,_)) <- zip [0..] constructors
+        ]
+  where
+    pat constructor =
+        Hs.PApp l
+            (Hs.UnQual l $ Hs.Ident l $ raiseFirstLetter constructor)
+            [ Hs.PVar l (Hs.Ident l "x") ]
+    rhs ix = Hs.UnGuardedRhs l $
+        (sumV `app` int ix)
+            `app` (Hs.Var l (runtime "toValue") `app` var "x")
+    int ix = Hs.Lit l $ Hs.Int l ix (show ix)
+    sumV = Hs.Con l (runtime "SumV")
+
+{-----------------------------------------------------------------------------
+    Expression utilities
+------------------------------------------------------------------------------}
+app :: Hs.Exp Annotation -> Hs.Exp Annotation -> Hs.Exp Annotation
+app = Hs.App l
+
+runtime :: String -> Hs.QName Annotation
+runtime
+    = Hs.Qual l (Hs.ModuleName l "Export.Haskell.Value.Runtime")
+    . Hs.Ident l
+
+var :: String -> Hs.Exp Annotation
+var = Hs.Var l . Hs.UnQual l . Hs.Ident l

--- a/prototypes/ledger-types-test/src/Export/Haskell/Value/Runtime.hs
+++ b/prototypes/ledger-types-test/src/Export/Haskell/Value/Runtime.hs
@@ -1,0 +1,59 @@
+-- | Export values of Haskell types to 'Value'.
+module Export.Haskell.Value.Runtime
+    ( ToValue (..)
+    , V.Value (..)
+    ) where
+
+import Prelude ((.))
+
+import qualified Value as V
+
+import qualified Data.ByteString
+import qualified Data.Map
+import qualified Data.Set
+import qualified Data.Text
+import qualified GHC.Generics
+import qualified Numeric.Natural
+import qualified Prelude
+
+{-----------------------------------------------------------------------------
+    Runtime definitions
+------------------------------------------------------------------------------}
+-- | Class of types that can be converted to 'Value'.
+--
+-- Note: The 'Ord' constraint is necessary to deal with 'Set'.
+class Prelude.Ord a => ToValue a where
+    toValue :: a -> V.Value
+
+z :: V.ZeroF -> V.Value
+z = V.Zero
+
+instance ToValue Prelude.Bool               where toValue = z . V.BoolV
+instance ToValue Data.ByteString.ByteString where toValue = z . V.BytesV
+instance ToValue Prelude.Integer            where toValue = z . V.IntegerV
+instance ToValue Numeric.Natural.Natural    where toValue = z . V.NaturalV
+instance ToValue Data.Text.Text             where toValue = z . V.TextV
+instance ToValue ()                         where toValue _ = z V.UnitV
+
+instance ToValue a => ToValue (Prelude.Maybe a) where
+    toValue = V.One . V.OptionV . Prelude.fmap toValue
+
+instance ToValue a => ToValue [a] where
+    toValue = V.One . V.SequenceV . Prelude.fmap toValue
+
+instance ToValue a => ToValue (Data.Set.Set a) where
+    toValue = V.One . V.PowerSetV . Data.Set.map toValue
+
+instance (ToValue a, ToValue b) => ToValue (Prelude.Either a b) where
+    toValue (Prelude.Left a) = V.SumV 0 (toValue a)
+    toValue (Prelude.Right b) = V.SumV 1 (toValue b)
+
+instance (ToValue a, ToValue b) => ToValue (a,b) where
+    toValue (a,b) = V.ProductV [toValue a, toValue b]
+
+instance (ToValue a, ToValue b) => ToValue (Data.Map.Map a b) where
+    toValue
+        = V.Two . V.FiniteMapV
+        . Data.Map.fromList
+        . Prelude.map (\(k,v) -> (toValue k, toValue v))
+        . Data.Map.toList

--- a/prototypes/ledger-types-test/src/Export/OpenAPI.hs
+++ b/prototypes/ledger-types-test/src/Export/OpenAPI.hs
@@ -1,0 +1,223 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Export type definitions to OpenAPI JSON schemas.
+--
+-- https://www.openapis.org
+module Export.OpenAPI
+    ( OpenAPISchema (..)
+
+    , schemaFromModule
+    , supportsJSON
+    , convertToJSON
+    ) where
+
+import Prelude
+
+import Data.Aeson
+    ( (.=) )
+import Data.Text
+    ( Text )
+import Module
+    ( resolveVars )
+import Typ
+
+import qualified Data.Aeson as JS
+import qualified Data.Aeson.Key as JS.Key
+import qualified Data.Aeson.Types as JS
+import qualified Data.Map as Map
+import qualified Data.Text as T
+
+{-----------------------------------------------------------------------------
+    OpenAPI
+------------------------------------------------------------------------------}
+newtype OpenAPISchema = OpenAPISchema { getOpenAPISchema :: JS.Value }
+
+-- | Export 
+--
+-- Assumes that the argument satisfies 'supportsJSON'.
+schemaFromModule :: Module -> OpenAPISchema
+schemaFromModule m =
+    OpenAPISchema
+        $ wrapSchemasInHeader (T.pack $ moduleName m)
+            [ (T.pack name, schemaFromTyp typ)
+            | (name, typ) <- Map.toList declarations
+            ]
+  where
+    declarations = moduleDeclarations m
+
+-- | Test whether a 'Module' only uses types supported by JSON.
+--
+-- JSON does not support finite maps such as @↦@, @↦0@, @→∗@.
+supportsJSON :: Module -> Bool
+supportsJSON =
+    and . Map.map isSupportedTyp . moduleDeclarations
+  where
+    isSupportedTyp = everything (&&) isSupported
+    isSupported (Binary fun _ _) =
+        not (fun `elem` [PartialFunction, FiniteSupport])
+    isSupported _ = True
+
+-- | Convert 'Typ' definitions to JSON.
+--
+-- The result satisfied 'supportsJSON'.
+--
+-- Note: For clarity, it is recommended to declare new types that
+-- explicitly supports JSON, and to provide evidence that
+-- these types elaborate the argument.
+convertToJSON :: Declarations -> Declarations
+convertToJSON declarations = Map.map (jsonify declarations) declarations
+
+{-----------------------------------------------------------------------------
+    Convert Typ to JSON schema
+------------------------------------------------------------------------------}
+wrapSchemasInHeader :: Text -> [(Text, JS.Value)] -> JS.Value
+wrapSchemasInHeader title xs =
+    object
+        [ "openapi" .= s "3.0.3"
+        , "info" .= object
+            [ "title" .= s title
+            , "version" .= s "1"
+            ]
+        , "components" .= object
+            [ "schemas" .= object
+                [ key name .= x
+                | (name,x) <- xs
+                ]
+            ]
+        , "paths" .= object []
+        ]
+
+schemaFromTyp :: Typ -> JS.Value
+schemaFromTyp = go
+  where
+    go Abstract = object
+        [ "type" .= s "object" ]
+    go (Var "ℤ") = object
+        [ "type" .= s "integer" ]
+    go (Var "ℕ") = object
+        [ "type" .= s "integer"
+        , "minimum" .= JS.toJSON (0 :: Int)
+        ]
+    go (Var "Bool") = object
+        [ "type" .= s "boolean"
+        ]
+    go (Var "Bytes") = object
+        [ "type" .= s "string"
+        , "format" .= s "base16"
+        ]
+    go (Var "Text") = object
+        [ "type" .= s "string" ]
+    go (Var "Unit") = object
+        [ "type" .= s "null"
+        ]
+    go (Var name) = object
+        [ "$ref" .= s (T.pack $ "#/components/schemas/" <> name) ]
+    go (Unary Option a) = object
+        [ "type" .= s "object"
+        , "properties" .= object [ "0" .= go a ]
+        ]
+    go (Unary Sequence a) = object
+        [ "type" .= s "array"
+        , "items" .= go a
+        ]
+    go (Unary PowerSet a) =
+        go (Unary Sequence a)
+    go (Binary Sum a b) =
+        schemaFromUnion [("0",a), ("1",b)]
+    go (Binary Product a b) = object
+        [ "type" .= s "object"
+        , "properties" .= object [ "0" .= go a, "1" .= go b ]
+        , "required" .= array [ s "0", s "1"]
+        ]
+    go (Binary PartialFunction _ _) =
+        error "PartialFunction is not supported by JSON schema"
+    go (Binary FiniteSupport a b) =
+        error "FiniteSupport is not supported by JSON schema"
+    go (Record fields) =
+        schemaFromRecord fields
+    go (Union constructors) =
+        schemaFromUnion constructors
+
+-- | Map a record type to a JSON schema.
+--
+-- Field that are option types (@?@) will be mapped to optional fields.
+schemaFromRecord :: [(FieldName, Typ)] -> JS.Value
+schemaFromRecord fields =
+    object
+        [ "type" .= s "object"
+        , "properties" .= object
+            [ key (T.pack name) .= schemaFromTyp (stripOption typ)
+            | (name,typ) <- fields
+            ]
+        , "required" .= array required
+        ]
+  where
+    required =
+        [ s (T.pack name)
+        | (name,typ) <- fields, not (isOption typ)
+        ]
+
+stripOption :: Typ -> Typ
+stripOption (Unary Option a) = a
+stripOption a = a
+
+isOption :: Typ -> Bool
+isOption (Unary Option _) = True
+isOption _ = False
+
+-- | Map a union type to a JSON.
+--
+-- The encoding corresponds to the 'ObjectWithSingleField' encoding.
+schemaFromUnion :: [(ConstructorName, Typ)] -> JS.Value
+schemaFromUnion constructors =
+    object [ "oneOf" .= array (map fromConstructor constructors) ]
+  where
+    fromConstructor (name,typ) =
+        object
+            [ "type" .= s "object"
+            , "title" .= s (T.pack name)
+            , "properties" .=
+                object [ key (T.pack name) .= schemaFromTyp typ ]
+            , "required" .= array [ s (T.pack name) ]
+            , "additionalProperties" .= JS.toJSON False
+            ]
+
+{-----------------------------------------------------------------------------
+    Preprocessing
+------------------------------------------------------------------------------}
+-- | Modify the 'Typ' to be closer to JSON.
+jsonify :: Declarations -> Typ -> Typ
+jsonify declarations =
+    mergeRecords . representFiniteMaps . resolveVars declarations
+
+representFiniteMaps :: Typ -> Typ
+representFiniteMaps = everywhere represent
+  where
+    represent x@(Binary op a b)
+        | op == FiniteSupport || op == PartialFunction =
+            Unary Sequence (Binary Product a b)
+        | otherwise =
+            x
+    represent x = x
+
+mergeRecords :: Typ -> Typ
+mergeRecords = everywhere merge
+  where
+    merge (Binary Product (Record a) (Record b)) =
+        Record (a <> b)
+    merge x = x
+
+{-----------------------------------------------------------------------------
+    JSON helpers
+------------------------------------------------------------------------------}
+key :: Text -> JS.Key
+key = JS.Key.fromText
+
+s :: Text -> JS.Value
+s = JS.String
+
+object :: [JS.Pair] -> JS.Value
+object = JS.object
+
+array :: [JS.Value] -> JS.Value
+array = JS.toJSON

--- a/prototypes/ledger-types-test/src/Export/OpenAPI/Value.hs
+++ b/prototypes/ledger-types-test/src/Export/OpenAPI/Value.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Export.OpenAPI.Value
+    ( jsonFromValue
+    ) where
+
+import Prelude
+
+import Data.Aeson
+    ( (.=) )
+import Data.Base16.Types
+    ( extractBase16 )
+import Data.ByteString
+    ( ByteString )
+import Data.Text
+    ( Text )
+import Module
+    ( resolveVars )
+import Typ
+import Value
+
+import qualified Data.Aeson as JS
+import qualified Data.Aeson.Key as JS.Key
+import qualified Data.Aeson.Types as JS
+import qualified Data.ByteString.Base16 as B
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import qualified Data.Text as T
+
+{-----------------------------------------------------------------------------
+    JSON export
+------------------------------------------------------------------------------}
+-- | Convert a 'Value' with a 'Typ' to a JSON value.
+--
+-- We need the 'Typ' of the 'Value' in order to add field names.
+jsonFromValue :: Typ -> Value -> JS.Value
+jsonFromValue = go
+  where
+    go :: Typ -> Value -> JS.Value
+    go (Binary Product ta tb) (ProductV [a,b])
+        = JS.object [ "0" .= go ta a, "1" .= go tb b ]
+    go (Record fields) x@(ProductV xs)
+        = jsonFromRecord fields
+            $ flattenBinaryProductV (length fields) x
+
+    go (Binary Sum ta _) (SumV 0 a)
+        = JS.object [ "0" .= go ta a ]
+    go (Binary Sum _ tb) (SumV 1 b)
+        = JS.object [ "1" .= go tb b ]
+    go (Union constructors) (SumV ix a)
+        = jsonFromUnion constructors ix a
+
+    go Abstract _ = error "jsonFromValue: Typ may not be abstract."
+    go (Var _) (Zero v) = go0 v
+    go (Unary op t) (One v) = go1 op t v
+    go (Binary op ta tb) (Two v) = go2 v
+
+    go _ _ = error "jsonFromValue: Typ error"
+
+    go0 :: ZeroF -> JS.Value
+    go0 (BoolV b) = JS.toJSON b
+    go0 (BytesV s) = JS.toJSON $ toHex s
+    go0 (IntegerV i) = JS.toJSON i
+    go0 (NaturalV n) = JS.toJSON n
+    go0 (TextV t) = JS.toJSON t
+    go0 (UnitV) = JS.Null
+
+    go1 :: OpUnary -> Typ -> OneF Value -> JS.Value
+    go1 Option t (OptionV (Just x)) = JS.object [ "0" .= go t x ]
+    go1 Option t (OptionV Nothing) = JS.object []
+    go1 Sequence t (SequenceV xs) = JS.toJSON $ map (go t) xs
+    go1 PowerSet t (PowerSetV xs) = JS.toJSON $ map (go t) $ Set.toList xs
+    go1 _ _ _ = error "jsonFromValue: Typ error"
+
+    go2 :: TwoF Value Value -> JS.Value
+    go2 (FiniteMapV _)
+        = error "FiniteMapV is not supported by JSON"
+
+-- | Flatten a chain of @n@ binary products to a single 'ProductV'.
+flattenBinaryProductV :: Int -> Value -> [Value]
+flattenBinaryProductV = flatten
+  where
+    flatten :: Int -> Value -> [Value]
+    flatten 1 x = [x]
+    flatten n (ProductV [x,y]) = x : flatten (n-1) y
+    flatten n x = [x]
+
+jsonFromRecord :: [(FieldName, Typ)] -> [Value] -> JS.Value
+jsonFromRecord fields xs
+    | length fields == length xs
+        = JS.object
+            [ key (T.pack field) .= jsonFromValue typ2 x2
+            | ((field,typ), x) <- zip fields xs
+            , omitNothingOption x
+            , let (typ2,x2) = skipJustOption (typ,x)
+            ]
+    | otherwise
+        = error "jsonFromRecord: field count of Value does not match Typ"
+  where
+    omitNothingOption = (One (OptionV Nothing) /=)
+
+    skipJustOption :: (Typ,Value) -> (Typ,Value)
+    skipJustOption (Unary Option typ, One (OptionV (Just x))) = (typ,x)
+    skipJustOption y = y
+
+jsonFromUnion :: [(ConstructorName, Typ)] -> Ix -> Value -> JS.Value
+jsonFromUnion constructors ix a
+    | 0 <= ix && ix < length constructors
+        = JS.object [ key (T.pack name) .= jsonFromValue typ a ]
+    | otherwise
+        = error "jsonFromUnion: index of Value does not match Typ"
+  where
+    (name, typ) = constructors !! ix
+
+{-----------------------------------------------------------------------------
+    Utilities
+------------------------------------------------------------------------------}
+toHex :: ByteString -> Text
+toHex = extractBase16 . B.encodeBase16
+
+key :: Text -> JS.Key
+key = JS.Key.fromText

--- a/prototypes/ledger-types-test/src/Module.hs
+++ b/prototypes/ledger-types-test/src/Module.hs
@@ -1,0 +1,41 @@
+-- | Module-level functions.
+module Module
+    ( collectNotInScope
+    , globalConstants
+    ) where
+
+import Prelude
+
+import Data.Set
+    ( Set )
+import Typ
+    ( Declarations, Module (..), Typ (..), TypName, everything, everywhere )
+
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+
+{-----------------------------------------------------------------------------
+    Module
+------------------------------------------------------------------------------}
+-- | Collect all type names that have not been defined in the 'Module'.
+collectNotInScope :: Module -> Set TypName
+collectNotInScope Module{moduleDeclarations=declarations} =
+    rhs Set.\\ (lhs <> globalConstants)
+  where
+    lhs = Map.keysSet declarations
+    rhs = mconcat . map collectVars $ Map.elems declarations
+
+-- | Globally known type identifiers.
+globalConstants :: Set TypName
+globalConstants = Set.fromList ["ℕ","ℤ","Bool","Bytes","Text","Unit"]
+
+-- | Collect all 'Var' in a type.
+collectVars :: Typ -> Set TypName
+collectVars = go
+  where
+    go Abstract = Set.empty
+    go (Var name) = Set.singleton name
+    go (Unary _ a) = go a
+    go (Binary _ a b) = go a <> go b
+    go (Record nameds) = mconcat $ map (go . snd) nameds
+    go (Union nameds) = mconcat $ map (go . snd) nameds

--- a/prototypes/ledger-types-test/src/Parser.hs
+++ b/prototypes/ledger-types-test/src/Parser.hs
@@ -1,0 +1,172 @@
+module Parser
+    ( parseLedgerTypes
+    ) where
+
+import Prelude
+
+import Control.Monad
+    ( void )
+import Data.Void
+    ( Void )
+import Text.Megaparsec
+    ( Parsec
+    , between
+    , endBy
+    , many
+    , parseMaybe
+    , satisfy
+    , sepBy
+    , try
+    , (<?>)
+    , (<|>)
+    )
+import Typ
+    ( ConstructorName
+    , Declarations
+    , FieldName
+    , Module (Module)
+    , OpBinary (..)
+    , OpUnary (..)
+    , Typ (..)
+    , TypName
+    )
+
+import qualified Control.Monad.Combinators.Expr as Parser.Expr
+import qualified Data.Map.Strict as Map
+import qualified Text.Megaparsec.Char as Parser.Char
+import qualified Text.Megaparsec.Char.Lexer as L
+
+{-----------------------------------------------------------------------------
+    Exported functions
+------------------------------------------------------------------------------}
+-- | Parse a 'String' containing mathematical types,
+-- as they appears in the Cardano ledger specification.
+parseLedgerTypes :: String -> Maybe Module
+parseLedgerTypes = parseMaybe document
+
+{-----------------------------------------------------------------------------
+    Parser
+------------------------------------------------------------------------------}
+{- Note
+For the design patterns used when implementing this parser, see
+  J. Willis, N. Wu, Design Patterns for Parser Combinators (Functional Pearl)
+  https://dl.acm.org/doi/10.1145/3471874.3472984
+-}
+
+type Parser = Parsec Void String
+
+document :: Parser Module
+document = space *> module'
+
+module' :: Parser Module
+module' =
+    Module
+        <$ symbol "module" <*> moduleName
+        <* symbol "where" <*> declarations
+
+declarations :: Parser Declarations
+declarations = mconcat <$> (declaration `endBy` symbol ";")
+
+-- | Parse a single declaration
+declaration :: Parser Declarations
+declaration =
+    Map.singleton <$> lhs <* symbol "=" <*> rhs
+  where
+    lhs = typName
+    rhs = try abstract <|> try record <|> try union <|> expr
+
+abstract :: Parser Typ
+abstract = Abstract <$ symbol "_"
+
+record :: Parser Typ
+record = Record <$> braces (field `sepBy` symbol ",")
+
+field :: Parser (FieldName, Typ)
+field = (\a b -> (a,b)) <$> fieldName <* symbol ":" <*> expr
+
+union :: Parser Typ
+union = Union <$> plusBrackets (constructor `sepBy` symbol ",")
+
+constructor :: Parser (FieldName, Typ)
+constructor = (\a b -> (a,b)) <$> constructorName <* symbol ":" <*> expr
+
+-- | Parse an expression.
+expr :: Parser Typ
+expr = Parser.Expr.makeExprParser atom tableOfOperators <?> "expression"
+
+atom :: Parser Typ
+atom = parens expr <|> (Var <$> (constants <|> typName)) <?> "atom"
+  where
+    constants = try (symbol "ℕ") <|> try (symbol "ℤ")
+
+tableOfOperators :: [[Parser.Expr.Operator Parser Typ]]
+tableOfOperators =
+    [ [ postfix "*" (Unary Sequence)
+      , postfix "?" (Unary Option)
+      ]
+    , [ prefix "ℙ" (Unary PowerSet)
+      ]
+    , [ binaryR "×" (Binary Product)
+      ]
+    , [ binaryR "⊎" (Binary Sum)
+      , binaryR "+" (Binary Sum)
+      ]
+    , [ binaryR "→∗" (Binary FiniteSupport)
+      , binaryR "↦0" (Binary FiniteSupport)
+      , binaryR "↦" (Binary PartialFunction)
+      ]
+    ]
+
+binaryR name f = Parser.Expr.InfixR  (f <$ symbol name)
+prefix  name f = Parser.Expr.Prefix  (f <$ symbol name)
+postfix name f = Parser.Expr.Postfix (f <$ symbol name)
+
+{-----------------------------------------------------------------------------
+    Lexer
+------------------------------------------------------------------------------}
+lineComment :: Parser ()
+lineComment = L.skipLineComment "--"
+
+blockComment :: Parser ()
+blockComment = L.skipBlockComment "{-" "-}"
+
+space :: Parser ()
+space = L.space Parser.Char.space1 lineComment blockComment
+
+{-
+space :: Parser ()
+space =
+    L.space
+        (void $ some $ satisfy (`elem` " \t"))
+        lineComment
+        empty
+-}
+symbol :: String -> Parser String
+symbol = L.symbol space
+
+moduleName :: Parser String
+moduleName = typName
+
+typName :: Parser TypName
+typName = L.lexeme space $
+    (:)
+    <$> Parser.Char.upperChar
+    <*> many (Parser.Char.alphaNumChar <|> satisfy (`elem` "_^"))
+
+constructorName :: Parser ConstructorName
+constructorName = fieldName
+
+fieldName :: Parser FieldName
+fieldName = L.lexeme space $
+    (:)
+    <$> Parser.Char.lowerChar
+    <*> many (Parser.Char.alphaNumChar <|> satisfy (`elem` "_^"))
+
+parens :: Parser a -> Parser a
+parens = between (symbol "(") (symbol ")")
+
+braces :: Parser a -> Parser a
+braces = between (symbol "{") (symbol "}")
+
+plusBrackets :: Parser a -> Parser a
+plusBrackets = between (symbol "[+") (symbol "+]")

--- a/prototypes/ledger-types-test/src/Typ.hs
+++ b/prototypes/ledger-types-test/src/Typ.hs
@@ -1,0 +1,65 @@
+module Type
+    ( TypName
+    , ConstructorName
+    , FieldName
+    , Module (..)
+    , Declarations
+    , Typ (..)
+    , OpUnary (..)
+    , OpBinary (..)
+    ) where
+
+import Prelude
+
+import Data.Map
+    ( Map )
+
+{-----------------------------------------------------------------------------
+    Mathematical types
+------------------------------------------------------------------------------}
+type TypName = String
+type ConstructorName = String
+type FieldName = String
+
+data Module = Module
+    { moduleName :: String
+    , moduleDeclarations :: Declarations
+    }
+
+type Declarations = Map TypName Typ
+
+-- | Types
+data Typ
+    = Abstract
+    | Var TypName
+    | Unary OpUnary Typ
+    | Binary OpBinary Typ Typ
+    | Record [(FieldName, Typ)]
+        -- ^ Cartesian product with names for components.
+    | Union [(ConstructorName, Typ)]
+        -- ^ Disjoint union with constructor names.
+    deriving (Eq, Show)
+
+data OpUnary
+    = Option
+        -- ^ An option type in type A is denoted as A?
+    | Sequence
+        -- ^ Given a set A, A* is the set of sequences
+        -- having elements taken from A.
+    | PowerSet
+        -- ^ Given a set A, ℙ A is the set of all the subsets of A.
+    deriving (Eq, Show)
+
+data OpBinary
+    = Sum
+        -- ^ A ⊎ B  denotes the disjoint union of A and B.
+    | Product
+        -- ^ A × B  denotes the cartesian product of A and B.
+    | PartialFunction
+        -- ^ A ↦ B  denotes a partial function from A to B,
+        -- which can be seen as a map (dictionary)
+        -- with keys in A and values in B.
+    | FiniteSupport
+        -- ^ We use the notation
+        -- f : A →∗ B to denote a finitely supported partial function.
+    deriving (Eq, Show)

--- a/prototypes/ledger-types-test/src/Value.hs
+++ b/prototypes/ledger-types-test/src/Value.hs
@@ -1,0 +1,106 @@
+module Value where
+
+import Prelude
+
+import Data.ByteString
+    ( ByteString )
+import Data.Text
+    ( Text )
+import Numeric.Natural
+    ( Natural )
+import Typ
+    ( Typ (..), OpBinary (..), OpUnary (..) )
+
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+
+{-----------------------------------------------------------------------------
+    Values corresponding to Typ
+------------------------------------------------------------------------------}
+type Ix = Int
+
+data Value
+    = Zero ZeroF
+    | One (OneF Value)
+    | Two (TwoF Value Value)
+    | ProductV [Value]
+        -- ^ N-ary products
+    | SumV Ix Value
+        -- ^ N-ary sums
+    deriving (Eq, Ord, Show)
+
+data ZeroF
+    = BoolV Bool
+    | BytesV ByteString
+    | IntegerV Integer
+    | NaturalV Natural
+    | TextV Text
+    | UnitV
+    deriving (Eq, Ord, Show)
+
+data OneF a
+    = OptionV (Maybe a)
+    | SequenceV [a]
+    | PowerSetV (Set.Set a)
+    deriving (Eq, Ord, Show)
+
+data TwoF a b
+    = FiniteMapV (Map.Map a b)
+    deriving (Eq, Ord, Show)
+
+{-----------------------------------------------------------------------------
+    Type checking
+------------------------------------------------------------------------------}
+-- | Check whether a 'Value' has the given 'Typ'.
+--
+-- Field and constructor names are ignored.
+hasTyp :: Value -> Typ -> Bool
+hasTyp (Zero a) (Var b)
+    = b == case a of
+        BoolV{} -> "Bool"
+        BytesV{} -> "Bytes"
+        IntegerV{} -> "ℤ"
+        NaturalV{} -> "ℕ"
+        TextV{} -> "Text"
+        UnitV -> "Unit"
+hasTyp (One a) (Unary op typ)
+    = hasTyp1 a op typ
+hasTyp (ProductV [a,b]) (Binary Product ta tb)
+    = (a `hasTyp` ta) && (b `hasTyp` tb)
+hasTyp (ProductV as) (Record fields)
+    | length as == length fields
+        = and (zipWith hasTyp as $ map snd fields)
+    | otherwise
+        = False
+hasTyp (SumV 0 a) (Binary Sum ta _)
+    = a `hasTyp` ta
+hasTyp (SumV 1 b) (Binary Sum _ tb)
+    = b `hasTyp` tb
+hasTyp (SumV ix a) (Union constructors)
+    | 0 <= ix && ix < length constructors
+        = a `hasTyp` (snd $ constructors !! ix)
+    | otherwise
+        = False
+hasTyp (Two a) (Binary op typ1 typ2)
+    = hasTyp2 a op typ1 typ2
+hasTyp _ _
+    = False
+
+hasTyp1 :: OneF Value -> OpUnary -> Typ -> Bool
+hasTyp1 (OptionV a) Option t
+    = all (`hasTyp` t) a
+hasTyp1 (SequenceV as) Sequence t
+    = all (`hasTyp` t) as
+hasTyp1 (PowerSetV as) PowerSet t
+    = all (`hasTyp` t) as
+hasTyp1 _ _ _
+    = False
+
+hasTyp2 :: TwoF Value Value -> OpBinary -> Typ -> Typ -> Bool
+hasTyp2 (FiniteMapV m) PartialFunction ta tb
+    = all (`hasTyp` ta) (Map.keys m)
+    && all (`hasTyp` tb) (Map.elems m)
+hasTyp2 (FiniteMapV m) FiniteSupport ta tb
+    = hasTyp2 (FiniteMapV m) PartialFunction ta tb
+hasTyp2 _ _ _ _
+    = False


### PR DESCRIPTION
### Overview

This pull requests adds a mini-language for specifying types as they appear in the ledger specification.

The mini-language should

* Visually match the ledger specification documents for correctness
* Be machine-parseable

Implemented:

- [x] Parser for the mini-language
- [x] Transaction types for the Babbage era
- [ ] Generation of Haskell types
- [ ] Generation of Java types

### Issue number

ADP-3113
