### PR TITLE
Update links to JIRA tickets.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,7 @@ body:
 
 
         If you know that the issue is already tracked in
-        [IOHK Jira](https://cardanofoundation.atlassian.net/) (i.e. has an `ADP-` issue number)
+        [Jira](https://cardanofoundation.atlassian.net/) (i.e. has an `ADP-` issue number)
         then please do not also submit it here. See the
         [release notes](https://github.com/input-output-hk/cardano-wallet/releases)
         for known issues.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,7 @@ body:
 
 
         If you know that the issue is already tracked in
-        [IOHK Jira](https://input-output.atlassian.net/) (i.e. has an `ADP-` issue number)
+        [IOHK Jira](https://cardanofoundation.atlassian.net/) (i.e. has an `ADP-` issue number)
         then please do not also submit it here. See the
         [release notes](https://github.com/input-output-hk/cardano-wallet/releases)
         for known issues.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # This should create an empty release draft
       # TODO: get artifacts from Buildkite to be attached to the draft
-      # Task: https://input-output.atlassian.net/browse/ADP-2502
+      # Task: https://cardanofoundation.atlassian.net/browse/ADP-2502
       - name: '🚀 Release'
         uses: softprops/action-gh-release@v1
         with:

--- a/.jira.d/config.yml
+++ b/.jira.d/config.yml
@@ -16,7 +16,7 @@
 #    authentication-method: api-token
 #    login: your.name@iohk.io
 #    password-source: keyring
-#    password-name: input-output.atlassian.net/your.name@iohk.io
+#    password-name: cardanofoundation.atlassian.net/your.name@iohk.io
 #
 #    For those who aren't using an explicit keyring, pass can also be used as a
 #    password source, the advantage of this is that it's lightweight way of
@@ -26,7 +26,7 @@
 #    authentication-method: api-token
 #    login: your.name@iohk.io
 #    password-source: pass
-#    password-name: input-output.atlassian.net/your.name@iohk.io
+#    password-name: cardanofoundation.atlassian.net/your.name@iohk.io
 #
 #    # gpg --list-keys
 #    /home/alice/.gnupg/pubring.kbx
@@ -36,15 +36,15 @@
 #    uid                   [ultimate] Alice Bloggs <alice@iohk.io>
 #
 #    # pass init "0x4404B986C4C026D4" # KEY_ID of YubiKey key, or other GPG key
-#    # pass insert input-output.atlassian.net/your.name@iohk.io
+#    # pass insert cardanofoundation.atlassian.net/your.name@iohk.io
 #    # pass list
 #    Password Store
-#    └── input-output.atlassian.net
+#    └── cardanofoundation.atlassian.net
 #        └── your.name@iohk.io
 #
 ######################################################################
 
-endpoint: https://input-output.atlassian.net
+endpoint: https://cardanofoundation.atlassian.net
 project: ADP
 
 custom-commands:

--- a/.jira.d/templates/sprint-full
+++ b/.jira.d/templates/sprint-full
@@ -1,5 +1,5 @@
 {{ range .issues }}
-h1. [{{ .key }}|https://input-output.atlassian.net/browse/{{ .key }}] {{ .fields.summary }}
+h1. [{{ .key }}|https://cardanofoundation.atlassian.net/browse/{{ .key }}] {{ .fields.summary }}
 
 |Type|{{ .fields.issuetype.name }}|
 |Priority|{{ if .fields.priority }}{{ .fields.priority.name }}{{ end }}|

--- a/docs/site/src/contributor/what/nix-flake.md
+++ b/docs/site/src/contributor/what/nix-flake.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted - [ADP-983](https://input-output.atlassian.net/browse/ADP-983)
+Accepted - [ADP-983](https://cardanofoundation.atlassian.net/browse/ADP-983)
 
 ## Context
 

--- a/docs/site/src/design/concepts/eras.md
+++ b/docs/site/src/design/concepts/eras.md
@@ -16,7 +16,7 @@ The roadmap is actually divided into _phases_, under which one or more eras (har
 
 The mechanism whereby the Cardano Node operates in different modes - depending on which slot it is up to - is called the "Hard Fork Combinator".
 
-The following [seminars](https://cardanofoundation.atlassian.net/wiki/spaces/EN/pages/718962750/IOHK+Research+Engineering+Seminar) (company internal use only) are a good introduction:
+The following [seminars](https://input-output.atlassian.net/wiki/spaces/EN/pages/718962750/IOHK+Research+Engineering+Seminar) (company internal use only) are a good introduction:
 
 | Date | Title | Description |
 | --- | --- | --- |

--- a/docs/site/src/design/concepts/eras.md
+++ b/docs/site/src/design/concepts/eras.md
@@ -16,7 +16,7 @@ The roadmap is actually divided into _phases_, under which one or more eras (har
 
 The mechanism whereby the Cardano Node operates in different modes - depending on which slot it is up to - is called the "Hard Fork Combinator".
 
-The following [seminars](https://input-output.atlassian.net/wiki/spaces/EN/pages/718962750/IOHK+Research+Engineering+Seminar) (company internal use only) are a good introduction:
+The following [seminars](https://cardanofoundation.atlassian.net/wiki/spaces/EN/pages/718962750/IOHK+Research+Engineering+Seminar) (company internal use only) are a good introduction:
 
 | Date | Title | Description |
 | --- | --- | --- |

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -16,7 +16,7 @@
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 {- HLINT ignore "Use camelCase" -}
 
--- TODO: https://input-output.atlassian.net/browse/ADP-2841
+-- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 902
 {-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}
@@ -1939,7 +1939,7 @@ boundaryTest_largeTokenQuantities_4 = BoundaryTestData
 -- the change generation algorithm terminates after only a subset of the UTxO
 -- has been selected.
 --
--- See: https://input-output.atlassian.net/browse/ADP-890
+-- See: https://cardanofoundation.atlassian.net/browse/ADP-890
 --
 boundaryTest_largeTokenQuantities_5 :: BoundaryTestData
 boundaryTest_largeTokenQuantities_5 = BoundaryTestData
@@ -1978,7 +1978,7 @@ boundaryTest_largeTokenQuantities_5 = BoundaryTestData
 -- the change generation algorithm terminates after only a subset of the UTxO
 -- has been selected.
 --
--- See: https://input-output.atlassian.net/browse/ADP-890
+-- See: https://cardanofoundation.atlassian.net/browse/ADP-890
 --
 boundaryTest_largeTokenQuantities_6 :: BoundaryTestData
 boundaryTest_largeTokenQuantities_6 = BoundaryTestData

--- a/lib/delta-table/src/Database/Schema.hs
+++ b/lib/delta-table/src/Database/Schema.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
--- TODO: https://input-output.atlassian.net/browse/ADP-2841
+-- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 module Database.Schema (

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -21,7 +21,7 @@
 
 {-# HLINT ignore "Use record patterns" #-}
 
--- TODO: https://input-output.atlassian.net/browse/ADP-2841
+-- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 902
 {-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}

--- a/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
@@ -705,7 +705,7 @@ errMsg403ValidityIntervalNotInsideScriptTimelock = unwords
 
 -- | Transaction metadata for ADP-1005.
 --
--- See https://input-output.atlassian.net/browse/ADP-1005
+-- See https://cardanofoundation.atlassian.net/browse/ADP-1005
 --
 txMetadata_ADP_1005 :: TxMetadata
 txMetadata_ADP_1005 = TxMetadata $ Map.fromList

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shared/Wallets.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shared/Wallets.hs
@@ -1448,7 +1448,7 @@ spec = describe "SHARED_WALLETS" $ do
         rTx <- request @(ApiTransaction n) ctx (ep wShelley) Default payloadTx
         expectResponseCode HTTP.status202 rTx
 
-        -- TODO Drop expectation https://input-output.atlassian.net/browse/ADP-2935
+        -- TODO Drop expectation https://cardanofoundation.atlassian.net/browse/ADP-2935
         expectField
             (#fee . #getQuantity)
             (between (feeMin, feeMax))

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -75,7 +75,7 @@ spec = describe "SHELLEY_NETWORK" $ do
                     ApiMary -> expectField (#eras . #mary) toBe
                     ApiAlonzo -> expectField (#eras . #alonzo) toBe
                     ApiBabbage -> expectField (#eras . #babbage) toBe
-                    ApiConway -> const $ pure () -- TODO https://input-output.atlassian.net/browse/ADP-2841
+                    ApiConway -> const $ pure () -- TODO https://cardanofoundation.atlassian.net/browse/ADP-2841
 
         let knownEras = [minBound .. _mainEra ctx]
         let unknownEras = [minBound .. maxBound] \\ knownEras

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -2131,7 +2131,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             , expectField (#amount . #getQuantity)
                 (`shouldBe` (oneMillionAda - fee))
 
-            -- TODO: Drop https://input-output.atlassian.net/browse/ADP-2935
+            -- TODO: Drop https://cardanofoundation.atlassian.net/browse/ADP-2935
             , expectField (#fee . #getQuantity)
                 (between (estimatedFeeMin, estimatedFeeMax))
             ]
@@ -2487,7 +2487,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         -- TODO Consider replacing with golden tests on the unit level
         -- for fee values.
         --
-        -- Related to https://input-output.atlassian.net/browse/ADP-2935
+        -- Related to https://cardanofoundation.atlassian.net/browse/ADP-2935
         liftIO $ withinToleranceTo
             expectedFee
             1_000
@@ -2519,7 +2519,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 -- TODO Consider replacing with golden tests on the unit level
                 -- for fee values.
                 --
-                -- Related to https://input-output.atlassian.net/browse/ADP-2935
+                -- Related to https://cardanofoundation.atlassian.net/browse/ADP-2935
             ]
 
         eventually "metadata is confirmed in transaction list" $ do

--- a/lib/wallet/src/Cardano/DB/Sqlite.hs
+++ b/lib/wallet/src/Cardano/DB/Sqlite.hs
@@ -14,7 +14,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
--- TODO: https://input-output.atlassian.net/browse/ADP-2841
+-- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 
 {- HLINT ignore "Redundant flip" -}

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2290,7 +2290,7 @@ buildTransactionPure
 -- 'withRootKey' call, and to make the sketchy behaviour more explicit, we
 -- make 'buildAndSignTransactionPure' partial instead.
 --
--- https://input-output.atlassian.net/browse/ADP-2933
+-- https://cardanofoundation.atlassian.net/browse/ADP-2933
 
 unsafeShelleyOnlyGetRewardXPub
     :: forall s

--- a/lib/wallet/src/Cardano/Wallet/Address/Discovery/Shared.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Discovery/Shared.hs
@@ -625,7 +625,7 @@ estimateMaxWitnessRequiredPerInput = \case
     -- however we'd then need to adjust signTx accordingly such that it still
     -- doesn't add more witnesses than we plan for.
     --
-    -- Partially related task: https://input-output.atlassian.net/browse/ADP-2676
+    -- Partially related task: https://cardanofoundation.atlassian.net/browse/ADP-2676
     RequireSomeOf _m xs   ->
         sum $ map estimateMaxWitnessRequiredPerInput xs
     -- Estimate (and tx fees) could be lowered with:
@@ -637,7 +637,7 @@ estimateMaxWitnessRequiredPerInput = \case
     -- however we'd then need to adjust signTx accordingly such that it still
     -- doesn't add more witnesses than we plan for.
     --
-    -- Partially related task: https://input-output.atlassian.net/browse/ADP-2676
+    -- Partially related task: https://cardanofoundation.atlassian.net/browse/ADP-2676
     ActiveFromSlot _     -> 0
     ActiveUntilSlot _    -> 0
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
@@ -16,7 +16,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE UndecidableInstances #-}
 
--- TODO: https://input-output.atlassian.net/browse/ADP-2841
+-- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 902
 {-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq/Gen.hs
@@ -317,7 +317,7 @@ genTxFromUTxO genAddr u = do
         , Just TxScriptInvalid
         ]
     pure $ txWithoutIdToTx TxWithoutId
-        -- TODO: https://input-output.atlassian.net/browse/ADP-2895
+        -- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2895
         -- We currently do not cover the case where fees are 'Nothing':
         { fee = Just feeCoin
         , resolvedInputs = fmap Just <$> inputs

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx.hs
@@ -307,7 +307,7 @@ type RecentEraLedgerConstraints era =
 -- TODO [ADP-2354] Make 'RecentEraLedgerConstraints' superclass of
 -- 'IsRecentEra'. Currently this would cause weird type-inference errors in the
 -- wallet code specifically with GHC 8.10.
--- https://input-output.atlassian.net/browse/ADP-2353
+-- https://cardanofoundation.atlassian.net/browse/ADP-2353
 withConstraints
     :: RecentEra era
     -> ((RecentEraLedgerConstraints (ShelleyLedgerEra era)) => a)

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -16,7 +16,7 @@
 
 {- HLINT ignore "Use ||" -}
 
--- TODO: https://input-output.atlassian.net/browse/ADP-2841
+-- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 902
 {-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}

--- a/lib/wallet/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/wallet/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -8,7 +8,7 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
--- TODO: https://input-output.atlassian.net/browse/ADP-2841
+-- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 902
 {-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}

--- a/lib/wallet/test/unit/Cardano/Wallet/Address/Discovery/SequentialSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Address/Discovery/SequentialSpec.hs
@@ -17,7 +17,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
--- TODO: https://input-output.atlassian.net/browse/ADP-2841
+-- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
 {-# OPTIONS_GHC -fno-warn-star-is-type #-}
 
 module Cardano.Wallet.Address.Discovery.SequentialSpec

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -28,7 +28,7 @@
 -- API servant type. These tests enforces that the API behaves as expected when
 -- present with malformed data, and do so consistently across each endpoint.
 
--- TODO: https://input-output.atlassian.net/browse/ADP-2841
+-- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
 {-# OPTIONS_GHC -fno-warn-star-is-type #-}
 
 -- TODO: Temporary until all 'integration' scenarios have been move here.

--- a/lib/wallet/test/unit/Cardano/Wallet/ApiSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/ApiSpec.hs
@@ -27,7 +27,7 @@
 -- mount an existing request body in a request.
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 
--- TODO: https://input-output.atlassian.net/browse/ADP-2841
+-- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
 {-# OPTIONS_GHC -fno-warn-star-is-type #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -13,7 +13,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
--- TODO: https://input-output.atlassian.net/browse/ADP-2841
+-- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
 #if __GLASGOW_HASKELL__ >= 902
 {-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}
 #endif

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -24,7 +24,7 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
--- TODO: https://input-output.atlassian.net/browse/ADP-2841
+-- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 902
 {-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}
@@ -3283,7 +3283,7 @@ txMinFee tx@(Cardano.Tx body _) u =
 prop_balanceTransactionValid
     :: forall era. era ~ Cardano.BabbageEra
     -- TODO [ADP-2997] Test with all RecentEras
-    -- https://input-output.atlassian.net/browse/ADP-2997
+    -- https://cardanofoundation.atlassian.net/browse/ADP-2997
     => Wallet'
     -> ShowBuildable (PartialTx Cardano.BabbageEra)
     -> StdGenSeed


### PR DESCRIPTION
## Issue

None

## Details

This PR updates all links to Jira tickets across the whole repository.

These are now hosted at `cardanofoundation.atlassian.net` instead of `input-output-hk.atlassian.net`.