### PR TITLE
Update dependency on `cardano-addresses` to latest version.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -95,8 +95,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-addresses
-    tag: bee48c1ac9df21309e702585bfad7db6134d7517
-    --sha256: 1zl6l3qyf2zh1vi0qm00nxk8y8lx7rfbca2zcv0xx515w98j644b
+    tag: 44d5a9eb3505b6bfbf281d40fa88531c3253b771
+    --sha256: 16rja48ryfjw3531kf15w0h3cdmscqgs8l1z1i2mvahq1vlhr2y6
     subdir: command-line
             core
 


### PR DESCRIPTION
## Issue

Follow-on from:
- https://github.com/input-output-hk/cardano-addresses/pull/228
- https://github.com/cardano-foundation/cardano-wallet/pull/4076

## Description

This PR updates the dependency on `cardano-addresses` to the latest version of `master`.