### PR TITLE
Drop rarely used tracer from balanceTx

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3116,7 +3116,6 @@ balanceTransaction
         balancedTx <- liftHandler
             . fmap (Cardano.InAnyCardanoEra Write.cardanoEra . fst)
             $ Write.balanceTransaction
-                (MsgWallet . W.MsgBalanceTx >$< wrk ^. W.logger)
                 utxoAssumptions
                 pp
                 timeTranslation

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -247,7 +247,7 @@ import Cardano.Api.Extra
 import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Data.Tracer
-    ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..), nullTracer )
+    ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Cardano.Crypto.Wallet
     ( toXPub )
 import Cardano.Mnemonic
@@ -522,8 +522,7 @@ import Cardano.Wallet.TxWitnessTag
 import Cardano.Wallet.Write.Tx
     ( recentEra )
 import Cardano.Wallet.Write.Tx.Balance
-    ( BalanceTxLog (..)
-    , ChangeAddressGen (..)
+    ( ChangeAddressGen (..)
     , ErrBalanceTx (..)
     , ErrBalanceTxInternalError (..)
     , ErrSelectAssets (..)
@@ -2269,7 +2268,6 @@ buildTransactionPure
 
     withExceptT Left $
         balanceTransaction @_ @_ @s
-            nullTracer
             (utxoAssumptionsForWallet (walletFlavor @s))
             pparams
             timeTranslation
@@ -2913,7 +2911,6 @@ transactionFee DBLayer{atomically, walletState} protocolParams txLayer
         wrapErrSelectAssets $ calculateFeePercentiles $ do
             res <- runExceptT $
                     balanceTransaction @_ @_ @s
-                        nullTracer
                         (utxoAssumptionsForWallet (walletFlavor @s))
                         protocolParams
                         timeTranslation
@@ -3638,8 +3635,7 @@ data WalletFollowLog
 
 -- | Log messages from API server actions running in a wallet worker context.
 data WalletLog
-    = MsgBalanceTx BalanceTxLog
-    | MsgMigrationUTxOBefore UTxOStatistics
+    = MsgMigrationUTxOBefore UTxOStatistics
     | MsgMigrationUTxOAfter UTxOStatistics
     | MsgRewardBalanceQuery BlockHeader
     | MsgRewardBalanceResult (Either ErrFetchRewards Coin)
@@ -3678,7 +3674,6 @@ instance ToText WalletFollowLog where
 
 instance ToText WalletLog where
     toText = \case
-        MsgBalanceTx msg -> toText msg
         MsgMigrationUTxOBefore summary ->
             "About to migrate the following distribution: \n" <> pretty summary
         MsgMigrationUTxOAfter summary ->
@@ -3712,7 +3707,6 @@ instance HasSeverityAnnotation WalletFollowLog where
 instance HasPrivacyAnnotation WalletLog
 instance HasSeverityAnnotation WalletLog where
     getSeverityAnnotation = \case
-        MsgBalanceTx msg -> getSeverityAnnotation msg
         MsgMigrationUTxOBefore _ -> Info
         MsgMigrationUTxOAfter _ -> Info
         MsgRewardBalanceQuery _ -> Debug

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -26,7 +26,6 @@ module Cardano.Wallet.Write.Tx.Balance
     (
     -- * Balancing transactions
       balanceTransaction
-    , BalanceTxLog (..)
     , ErrBalanceTx (..)
     , ErrBalanceTxInternalError (..)
     , ErrSelectAssets (..)
@@ -70,10 +69,6 @@ module Cardano.Wallet.Write.Tx.Balance
 
 import Prelude
 
-import Cardano.BM.Data.Tracer
-    ( HasPrivacyAnnotation, HasSeverityAnnotation, Tracer )
-import Cardano.BM.Tracing
-    ( HasSeverityAnnotation (..), Severity (..), traceWith )
 import Cardano.Ledger.Alonzo.Core
     ( ppCollateralPercentageL, ppMaxCollateralInputsL )
 import Cardano.Ledger.Api
@@ -94,13 +89,9 @@ import Cardano.Tx.Balance.Internal.CoinSelection
     , SelectionOf (change)
     , SelectionOutputError (..)
     , SelectionParams (..)
-    , SelectionReportDetailed
-    , SelectionReportSummarized
     , SelectionStrategy (..)
     , WalletSelectionContext
     , WalletUTxO (..)
-    , makeSelectionReportDetailed
-    , makeSelectionReportSummarized
     , performSelection
     , toInternalUTxOMap
     )
@@ -161,8 +152,6 @@ import Control.Monad
     ( forM, unless, when )
 import Control.Monad.Random
     ( MonadRandom, evalRand )
-import Control.Monad.Trans.Class
-    ( lift )
 import Control.Monad.Trans.Except
     ( ExceptT (ExceptT), catchE, except, runExceptT, throwE, withExceptT )
 import Control.Monad.Trans.State
@@ -185,22 +174,10 @@ import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
     ( fromMaybe )
-import Data.Text.Class
-    ( ToText (..) )
 import Data.Type.Equality
     ( (:~:) (..), testEquality )
 import Fmt
-    ( Buildable
-    , Builder
-    , blockListF'
-    , build
-    , nameF
-    , pretty
-    , (+|)
-    , (+||)
-    , (|+)
-    , (||+)
-    )
+    ( Buildable, Builder, blockListF', build, nameF, pretty )
 import GHC.Generics
     ( Generic )
 import GHC.Stack
@@ -256,40 +233,6 @@ instance Eq (BuildableInAnyEra a) where
 
 instance Buildable (BuildableInAnyEra a) where
     build (BuildableInAnyEra _ x) = build x
-
-data BalanceTxLog
-    = MsgSelectionForBalancingStart Int (BuildableInAnyEra PartialTx)
-    | MsgSelectionStart Int [W.TxOut]
-    | MsgSelectionError (SelectionError WalletSelectionContext)
-    | MsgSelectionReportSummarized SelectionReportSummarized
-    | MsgSelectionReportDetailed SelectionReportDetailed
-    deriving (Eq, Show)
-
-instance ToText BalanceTxLog where
-    toText = \case
-        MsgSelectionStart utxoSize recipients ->
-            "Starting coin selection " <>
-            "|utxo| = "+|utxoSize|+" " <>
-            "#recipients = "+|length recipients|+""
-        MsgSelectionForBalancingStart utxoSize partialTx ->
-            "Starting coin selection for balancing " <>
-            "|utxo| = "+|utxoSize|+" " <>
-            "partialTx = "+|partialTx|+""
-        MsgSelectionError e ->
-            "Failed to select assets:\n"+|| e ||+""
-        MsgSelectionReportSummarized s ->
-            "Selection report (summarized):\n"+| s |+""
-        MsgSelectionReportDetailed s ->
-            "Selection report (detailed):\n"+| s |+""
-
-instance HasPrivacyAnnotation BalanceTxLog
-instance HasSeverityAnnotation BalanceTxLog where
-    getSeverityAnnotation = \case
-        MsgSelectionStart{} -> Debug
-        MsgSelectionForBalancingStart{} -> Debug
-        MsgSelectionError{} -> Debug
-        MsgSelectionReportSummarized{} -> Info
-        MsgSelectionReportDetailed{} -> Debug
 
 data ErrSelectAssets
     = ErrSelectAssetsPrepareOutputsError
@@ -370,8 +313,7 @@ balanceTransaction
         ( MonadRandom m
         , IsRecentEra era
         )
-    => Tracer m BalanceTxLog
-    -> UTxOAssumptions
+    => UTxOAssumptions
     -> ProtocolParameters era
     -- ^ 'Cardano.ProtocolParameters' can be retrieved via a Local State Query
     -- to a local node.
@@ -399,7 +341,6 @@ balanceTransaction
     -> PartialTx era
     -> ExceptT ErrBalanceTx m (Cardano.Tx era, changeState)
 balanceTransaction
-    tr
     utxoAssumptions
     pp
     timeTranslation
@@ -415,7 +356,6 @@ balanceTransaction
         balanceWith strategy =
             balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 @era @m @changeState
-                tr
                 utxoAssumptions
                 pp
                 timeTranslation
@@ -500,8 +440,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         ( MonadRandom m
         , IsRecentEra era
         )
-    => Tracer m BalanceTxLog
-    -> UTxOAssumptions
+    => UTxOAssumptions
     -> ProtocolParameters era
     -> TimeTranslation
     -> UTxOIndex era
@@ -511,7 +450,6 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     -> PartialTx era
     -> ExceptT ErrBalanceTx m (Cardano.Tx era, changeState)
 balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
-    tr
     utxoAssumptions
     protocolParameters@(ProtocolParameters pp)
     timeTranslation
@@ -558,10 +496,6 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                     , s'
                     )
 
-        lift $ traceWith tr $ MsgSelectionForBalancingStart
-            (UTxOIndex.size internalUtxoAvailable)
-            (BuildableInAnyEra Cardano.cardanoEra ptx)
-
         externalSelectedUtxo <- extractExternallySelectedUTxO ptx
 
         let mSel = selectAssets
@@ -577,14 +511,6 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 randomSeed
                 genChange
                 selectionStrategy
-
-        case mSel of
-            Left e -> lift $ traceWith tr $ MsgSelectionError e
-            Right sel -> lift $ do
-                traceWith tr $ MsgSelectionReportSummarized
-                    $ makeSelectionReportSummarized sel
-                traceWith tr $ MsgSelectionReportDetailed
-                    $ makeSelectionReportDetailed sel
 
         withExceptT (ErrBalanceTxSelectAssets . ErrSelectAssetsSelectionError)
             . except

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -69,8 +69,6 @@ import Cardano.Api.Shelley
     ( fromShelleyLovelace )
 import Cardano.Binary
     ( ToCBOR, serialize', unsafeDeserialize' )
-import Cardano.BM.Data.Tracer
-    ( nullTracer )
 import Cardano.Ledger.Alonzo.Genesis
     ( AlonzoGenesis (..) )
 import Cardano.Ledger.Alonzo.TxInfo
@@ -3050,7 +3048,6 @@ balanceTx
     = (`evalRand` stdGenFromSeed seed) $ runExceptT $ do
         (transactionInEra, _nextChangeState) <-
             balanceTransaction
-                nullTracer
                 utxoAssumptions
                 protocolParameters
                 timeTranslation
@@ -3071,7 +3068,6 @@ balanceTransactionWithDummyChangeState
 balanceTransactionWithDummyChangeState utxoAssumptions utxo seed partialTx =
     (`evalRand` stdGenFromSeed seed) $ runExceptT $
         balanceTransaction
-            nullTracer
             utxoAssumptions
             mockPParamsForBalancing
             dummyTimeTranslation


### PR DESCRIPTION
[Drop rarely used tracer from balanceTx](https://github.com/cardano-foundation/cardano-wallet/pull/4082/commits/8c8fa05430326fe86aee71eb1517b4fbfbe98d66)

[8c8fa05](https://github.com/cardano-foundation/cardano-wallet/pull/4082/commits/8c8fa05430326fe86aee71eb1517b4fbfbe98d66)
1. It's unused for most wallet tx construction. The balanceTx endpoint
   is the only one setting it.
2. Value seems unclear
3. Removing will make refactoring simpler

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

None.
