### PR TITLE
🚮 Remove `adaMinimum` field from `ApiWalletUtxoSnapshotEntry` type.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1746,15 +1746,14 @@ getWalletUtxoSnapshot ctx (ApiT wid) = do
         W.getWalletUtxoSnapshot wrk
     return $ mkApiWalletUtxoSnapshot entries
   where
-    mkApiWalletUtxoSnapshot :: [(TokenBundle, Coin)] -> ApiWalletUtxoSnapshot
+    mkApiWalletUtxoSnapshot :: [TokenBundle] -> ApiWalletUtxoSnapshot
     mkApiWalletUtxoSnapshot bundleMinCoins = ApiWalletUtxoSnapshot
         { entries = mkApiWalletUtxoSnapshotEntry <$> bundleMinCoins }
 
     mkApiWalletUtxoSnapshotEntry
-        :: (TokenBundle, Coin) -> ApiWalletUtxoSnapshotEntry
-    mkApiWalletUtxoSnapshotEntry (bundle, minCoin) = ApiWalletUtxoSnapshotEntry
+        :: TokenBundle -> ApiWalletUtxoSnapshotEntry
+    mkApiWalletUtxoSnapshotEntry bundle = ApiWalletUtxoSnapshotEntry
         { ada = Coin.toQuantity $ view #coin bundle
-        , adaMinimum = Coin.toQuantity minCoin
         , assets = ApiT $ view #tokens bundle
         }
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -887,7 +887,6 @@ newtype ApiWalletUtxoSnapshot = ApiWalletUtxoSnapshot
 
 data ApiWalletUtxoSnapshotEntry = ApiWalletUtxoSnapshotEntry
     { ada :: !(Quantity "lovelace" Natural)
-    , adaMinimum :: !(Quantity "lovelace" Natural)
     , assets :: !(ApiT TokenMap)
     }
     deriving (Eq, Generic, Show)

--- a/lib/wallet/test/data/Cardano/Wallet/Api/ApiWalletUtxoSnapshot.json
+++ b/lib/wallet/test/data/Cardano/Wallet/Api/ApiWalletUtxoSnapshot.json
@@ -7,19 +7,11 @@
                         "quantity": 22,
                         "unit": "lovelace"
                     },
-                    "ada_minimum": {
-                        "quantity": 18,
-                        "unit": "lovelace"
-                    },
                     "assets": []
                 },
                 {
                     "ada": {
                         "quantity": 24,
-                        "unit": "lovelace"
-                    },
-                    "ada_minimum": {
-                        "quantity": 14,
                         "unit": "lovelace"
                     },
                     "assets": [
@@ -69,10 +61,6 @@
                         "quantity": 12,
                         "unit": "lovelace"
                     },
-                    "ada_minimum": {
-                        "quantity": 5,
-                        "unit": "lovelace"
-                    },
                     "assets": [
                         {
                             "asset_name": "546f6b656e42",
@@ -119,10 +107,6 @@
                 {
                     "ada": {
                         "quantity": 18,
-                        "unit": "lovelace"
-                    },
-                    "ada_minimum": {
-                        "quantity": 3,
                         "unit": "lovelace"
                     },
                     "assets": [
@@ -193,19 +177,11 @@
                         "quantity": 29,
                         "unit": "lovelace"
                     },
-                    "ada_minimum": {
-                        "quantity": 3,
-                        "unit": "lovelace"
-                    },
                     "assets": []
                 },
                 {
                     "ada": {
                         "quantity": 23,
-                        "unit": "lovelace"
-                    },
-                    "ada_minimum": {
-                        "quantity": 11,
                         "unit": "lovelace"
                     },
                     "assets": []
@@ -219,10 +195,6 @@
                         "quantity": 7,
                         "unit": "lovelace"
                     },
-                    "ada_minimum": {
-                        "quantity": 2,
-                        "unit": "lovelace"
-                    },
                     "assets": []
                 }
             ]
@@ -234,10 +206,6 @@
                         "quantity": 22,
                         "unit": "lovelace"
                     },
-                    "ada_minimum": {
-                        "quantity": 10,
-                        "unit": "lovelace"
-                    },
                     "assets": []
                 }
             ]
@@ -247,10 +215,6 @@
                 {
                     "ada": {
                         "quantity": 23,
-                        "unit": "lovelace"
-                    },
-                    "ada_minimum": {
-                        "quantity": 21,
                         "unit": "lovelace"
                     },
                     "assets": [
@@ -321,10 +285,6 @@
                         "quantity": 24,
                         "unit": "lovelace"
                     },
-                    "ada_minimum": {
-                        "quantity": 12,
-                        "unit": "lovelace"
-                    },
                     "assets": []
                 }
             ]
@@ -336,19 +296,11 @@
                         "quantity": 16,
                         "unit": "lovelace"
                     },
-                    "ada_minimum": {
-                        "quantity": 8,
-                        "unit": "lovelace"
-                    },
                     "assets": []
                 },
                 {
                     "ada": {
                         "quantity": 6,
-                        "unit": "lovelace"
-                    },
-                    "ada_minimum": {
-                        "quantity": 1,
                         "unit": "lovelace"
                     },
                     "assets": [
@@ -384,10 +336,6 @@
                         "quantity": 13,
                         "unit": "lovelace"
                     },
-                    "ada_minimum": {
-                        "quantity": 8,
-                        "unit": "lovelace"
-                    },
                     "assets": []
                 }
             ]
@@ -402,19 +350,11 @@
                         "quantity": 16,
                         "unit": "lovelace"
                     },
-                    "ada_minimum": {
-                        "quantity": 2,
-                        "unit": "lovelace"
-                    },
                     "assets": []
                 },
                 {
                     "ada": {
                         "quantity": 29,
-                        "unit": "lovelace"
-                    },
-                    "ada_minimum": {
-                        "quantity": 26,
                         "unit": "lovelace"
                     },
                     "assets": [
@@ -430,10 +370,6 @@
                         "quantity": 25,
                         "unit": "lovelace"
                     },
-                    "ada_minimum": {
-                        "quantity": 12,
-                        "unit": "lovelace"
-                    },
                     "assets": [
                         {
                             "asset_name": "546f6b656e45",
@@ -445,10 +381,6 @@
                 {
                     "ada": {
                         "quantity": 17,
-                        "unit": "lovelace"
-                    },
-                    "ada_minimum": {
-                        "quantity": 12,
                         "unit": "lovelace"
                     },
                     "assets": []
@@ -463,10 +395,6 @@
                 {
                     "ada": {
                         "quantity": 28,
-                        "unit": "lovelace"
-                    },
-                    "ada_minimum": {
-                        "quantity": 18,
                         "unit": "lovelace"
                     },
                     "assets": [
@@ -490,10 +418,6 @@
                 {
                     "ada": {
                         "quantity": 19,
-                        "unit": "lovelace"
-                    },
-                    "ada_minimum": {
-                        "quantity": 11,
                         "unit": "lovelace"
                     },
                     "assets": [
@@ -567,10 +491,6 @@
                 {
                     "ada": {
                         "quantity": 16,
-                        "unit": "lovelace"
-                    },
-                    "ada_minimum": {
-                        "quantity": 14,
                         "unit": "lovelace"
                     },
                     "assets": [

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -2364,11 +2364,9 @@ instance Arbitrary ApiWalletUtxoSnapshot where
             -- The actual ada quantity of an output's token bundle must be
             -- greater than or equal to the minimum permissible ada quantity:
             let ada = Coin.toQuantity $ max adaValue1 adaValue2
-            let adaMinimum = Coin.toQuantity $ min adaValue1 adaValue2
             assets <- ApiT <$> genTokenMapSmallRange
             pure ApiWalletUtxoSnapshotEntry
                 { ada
-                , adaMinimum
                 , assets
                 }
 

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -3221,18 +3221,12 @@ components:
       type: object
       required:
         - ada
-        - ada_minimum
         - assets
       properties:
         ada:
           <<: *amount
           description: |
             The ada quantity associated with this UTxO entry.
-        ada_minimum:
-          <<: *amount
-          description: |
-            The minimum ada quantity permitted by the ledger for this UTxO
-            entry.
         assets:
           <<: *walletAssets
           description: |


### PR DESCRIPTION
## Issue

ADP-3122

## Summary

This PR removes the `adaMinimum` field from the `ApiWalletUtxoSnapshotEntry` type.

## Context

The original purpose of this field was to aid debugging, and specifically to answer the following question:

> “For a given UTxO that already exists, what would the ledger have required the minimum quantity of ada to be at the time the UTxO was originally created?”

In general this question is quite hard to answer, as for every historical UTxO that belongs to the wallet, we’d need to know:

- in which era was this UTxO created?
- at which slot (within an era) was this UTxO created?
- what were the values of the protocol parameters at the time the UTxO was created?

This is because the minimum UTxO function can change:
- as we transition from one era to another; and/or
- whenever the protocol parameters are updated.

Finally, since:
- this field is for debugging purposes only;
- it has maintenance burden that is hard to satisfy; 
- it is an obstacle to ongoing work in other areas; and since
- there is little evidence of user demand for this field,

We should feel free to remove it.