### PR TITLE
Greatly reduce time needed to test `prop_performSelection`.

### DIFF
--- a/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
@@ -662,7 +662,7 @@ genCoinMostly0 = frequency
     ]
 
 genExtraCoinIn :: Gen Coin
-genExtraCoinIn = genCoinMostly0
+genExtraCoinIn = genCoin
 
 genExtraCoinOut :: Gen Coin
 genExtraCoinOut = genCoinMostly0
@@ -756,7 +756,7 @@ genUTxOAvailableForCollateral = genMapWith (arbitrary @TestUTxO) genCoinPositive
 
 genUTxOAvailableForInputs :: Gen (UTxOSelection TestUTxO)
 genUTxOAvailableForInputs = frequency
-    [ (49, genUTxOSelection (arbitrary @TestUTxO))
+    [ (24, genUTxOSelection (arbitrary @TestUTxO))
     , (01, pure UTxOSelection.empty)
     ]
 


### PR DESCRIPTION
This PR makes a pair of small adjustments to generators within `CoinSelectionSpec`.

This greatly reduces the number of iterations (and overall run time) required to satisfy the coverage checks for `prop_performSelection`.

**Before: 25,600 iterations, ~220 seconds 😱**
```
Cardano.CoinSelection
  Cardano.CoinSelectionSpec
    Performing selections
      prop_performSelection [✔] (219672ms)
        +++ OK, passed 25600 tests:
        50.012% not $ selectionCollateralRequired params
        49.988% selectionCollateralRequired params
        36.867% isSelection r
        24.004% isSelectionOutputError_SelectionOutputCoinInsufficient
        22.816% isSelectionBalanceError_BalanceInsufficient
         8.773% isSelectionCollateralError
         3.535% isSelectionOutputError_SelectionOutputTokenQuantityExceedsLimit
         2.211% isSelectionOutputError_SelectionOutputSizeExceedsLimit
         1.586% isSelectionBalanceError_UnableToConstructChange
         0.207% isSelectionBalanceError_EmptyUTxO

Finished in 219.6732 seconds, used 541.3387 seconds of CPU time
```

**After: 800 iterations, ~5 seconds 🚀**
```
Cardano.CoinSelection
  Cardano.CoinSelectionSpec
    Performing selections
      prop_performSelection [✔] (4508ms)
        +++ OK, passed 800 tests:
        51.5% not $ selectionCollateralRequired params
        48.5% selectionCollateralRequired params
        35.5% isSelection r
        24.8% isSelectionBalanceError_BalanceInsufficient
        24.0% isSelectionOutputError_SelectionOutputCoinInsufficient
         7.5% isSelectionCollateralError
         4.0% isSelectionOutputError_SelectionOutputTokenQuantityExceedsLimit
         1.8% isSelectionOutputError_SelectionOutputSizeExceedsLimit
         1.2% isSelectionBalanceError_EmptyUTxO
         1.2% isSelectionBalanceError_UnableToConstructChange

Finished in 4.5086 seconds, used 10.6630 seconds of CPU time
```