### PR TITLE
Simplify treatment of user-specified outputs without ada quantities

### DIFF
--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -1277,16 +1277,12 @@ prepareOutputsInternal
     :: forall ctx. SelectionConstraints ctx
     -> [(Address ctx, TokenBundle)]
     -> Either (SelectionOutputError ctx) [(Address ctx, TokenBundle)]
-prepareOutputsInternal constraints outputsUnprepared =
+prepareOutputsInternal constraints outputs =
     -- If we encounter an error, just report the first error we encounter:
     case errors of
         e : _ -> Left e
         []    -> pure outputs
   where
-    SelectionConstraints
-        { computeMinimumAdaQuantity
-        } = constraints
-
     errors :: [SelectionOutputError ctx]
     errors = uncurry SelectionOutputError <$> foldMap withOutputsIndexed
         [ (fmap . fmap) SelectionOutputSizeExceedsLimit
@@ -1298,9 +1294,6 @@ prepareOutputsInternal constraints outputsUnprepared =
         ]
       where
         withOutputsIndexed f = f $ zip [0 ..] outputs
-
-    outputs :: [(Address ctx, TokenBundle)]
-    outputs = prepareOutputsWith computeMinimumAdaQuantity outputsUnprepared
 
 -- | Assigns minimal ada quantities to outputs without ada quantities.
 --

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -335,7 +335,7 @@ validateOutputs :: Applicative m => PerformSelection m ctx (SelectionParams ctx)
 validateOutputs cs ps =
     withExceptT SelectionOutputErrorOf $ ExceptT $ pure $
     validateOutputsInternal cs (view #outputsToCover ps)
-        <&> \outputsToCover -> ps {outputsToCover}
+        <&> \() -> ps
 
 performSelectionBalance
     :: (HasCallStack, MonadRandom m, SelectionContext ctx)
@@ -1275,12 +1275,12 @@ computeMinimumCollateral params =
 validateOutputsInternal
     :: forall ctx. SelectionConstraints ctx
     -> [(Address ctx, TokenBundle)]
-    -> Either (SelectionOutputError ctx) [(Address ctx, TokenBundle)]
+    -> Either (SelectionOutputError ctx) ()
 validateOutputsInternal constraints outputs =
     -- If we encounter an error, just report the first error we encounter:
     case errors of
         e : _ -> Left e
-        []    -> pure outputs
+        []    -> pure ()
   where
     errors :: [SelectionOutputError ctx]
     errors = uncurry SelectionOutputError <$> foldMap withOutputsIndexed

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -25,7 +25,6 @@ module Cardano.CoinSelection
     , SelectionSkeleton (..)
 
     -- * Output preparation
-    , prepareOutputsWith
     , SelectionOutputError (..)
     , SelectionOutputErrorInfo (..)
     , SelectionOutputCoinInsufficientError (..)
@@ -99,7 +98,7 @@ import Data.Function
 import Data.Functor
     ( (<&>) )
 import Data.Generics.Internal.VL.Lens
-    ( over, set, view, (^.) )
+    ( over, view, (^.) )
 import Data.Generics.Labels
     ()
 import Data.List.NonEmpty
@@ -1294,25 +1293,6 @@ prepareOutputsInternal constraints outputs =
         ]
       where
         withOutputsIndexed f = f $ zip [0 ..] outputs
-
--- | Assigns minimal ada quantities to outputs without ada quantities.
---
--- This function only modifies outputs that have an ada quantity of zero.
--- Outputs that have non-zero ada quantities will not be modified.
---
-prepareOutputsWith
-    :: forall f address. Functor f
-    => (address -> TokenMap -> Coin)
-    -> f (address, TokenBundle)
-    -> f (address, TokenBundle)
-prepareOutputsWith minCoinValueFor =
-    fmap augmentBundle
-  where
-    augmentBundle :: (address, TokenBundle) -> (address, TokenBundle)
-    augmentBundle (addr, bundle) = (addr,) $
-        if TokenBundle.getCoin bundle == Coin 0
-        then bundle & set #coin (minCoinValueFor addr (view #tokens bundle))
-        else bundle
 
 -- | Indicates a problem when preparing outputs for a coin selection.
 --

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -372,10 +372,10 @@ balanceTransaction
     s
     partialTx
     = do
-    let adjustedPartialTx =
-            over #tx
-                (increaseZeroAdaOutputs (recentEra @era) (pparamsLedger pp))
-                partialTx
+    let adjustedPartialTx = flip (over #tx) partialTx $
+            assignMinimalAdaQuantitiesToOutputsWithoutAda
+                (recentEra @era)
+                (pparamsLedger pp)
         balanceWith strategy =
             balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 @era @m @changeState
@@ -451,13 +451,13 @@ balanceTransaction
 -- Minimal ada quantities are computed with the 'computeMinimumCoinForTxOut'
 -- function.
 --
-increaseZeroAdaOutputs
+assignMinimalAdaQuantitiesToOutputsWithoutAda
     :: forall era
      . RecentEra era
     -> PParams (Cardano.ShelleyLedgerEra era)
     -> Cardano.Tx era
     -> Cardano.Tx era
-increaseZeroAdaOutputs era pp = withConstraints era $
+assignMinimalAdaQuantitiesToOutputsWithoutAda era pp = withConstraints era $
     modifyLedgerBody $ over outputsTxBodyL $ fmap modifyTxOut
   where
     modifyTxOut out = flip (modifyTxOutCoin era) out $ \c ->

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -443,8 +443,14 @@ balanceTransaction
             _someOtherError ->
                 False
 
--- | Increases the ada value of any 0-ada outputs in the transaction to the
--- minimum according to 'computeMinimumCoinForTxOut'.
+-- | Assigns minimal ada quantities to outputs without ada.
+--
+-- This function only modifies outputs with ada quantities of zero. Outputs
+-- that have non-zero ada quantities will not be modified.
+--
+-- Minimal ada quantities are computed with the 'computeMinimumCoinForTxOut'
+-- function.
+--
 increaseZeroAdaOutputs
     :: forall era
      . RecentEra era

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1983,7 +1983,7 @@ balanceTransactionSpec = describe "balanceTransaction" $ do
         it "returns s' corresponding to which addresses were used" $ do
             s' `shouldBe` DummyChangeState { nextUnusedIndex = nChange }
 
-    it "increases zero-ada outputs to minimum" $ do
+    it "assigns minimal ada quantities to outputs without ada" $ do
         let era = Write.RecentEraBabbage
         let out = TxOut dummyAddr (TokenBundle.fromCoin (Coin 0))
         let out' = TxOut dummyAddr (TokenBundle.fromCoin (Coin 874_930))


### PR DESCRIPTION
## Issue

ADP-2425

## Summary

This PR simplifies the handling of user-specified outputs without ada quantities in `balanceTx`, so that the responsibility for assigning minimal ada quantities to such outputs belongs to `balanceTx` alone.