### PR TITLE
[ADP-3109] fix local cluster in nix flake

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -187,8 +187,6 @@ steps:
       system: ${linux}
     env:
       TMPDIR: "/cache"
-    soft_fail:
-      - exit_status: '*'
 
   - block: "Build windows artifacts"
     depends_on: linux-nix

--- a/flake.nix
+++ b/flake.nix
@@ -242,7 +242,8 @@
                   backend = self.cardano-node;
                 };
                 # Local test cluster and mock metadata server
-                inherit (project.hsPkgs.cardano-wallet.components.exes) local-cluster mock-token-metadata-server;
+                inherit (project.hsPkgs.cardano-wallet.components.exes) mock-token-metadata-server;
+                inherit (project.hsPkgs.local-cluster.components.exes) local-cluster;
 
                 # Adrestia tool belt
                 inherit (project.hsPkgs.bech32.components.exes) bech32;


### PR DESCRIPTION
- [x] Fix flake.nix to inherit local-cluster executable from local-cluster lib
- [x] Force buildkite pipeline to fail on docker step failure (remove soft-fail)

ADP-3109
