### PR TITLE
Use `sizeTxF` instead of `length $ serializedTx`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -680,12 +680,13 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         :: KeyWitnessCount
         -> Cardano.Tx era
         -> ExceptT ErrBalanceTx m (Cardano.Tx era)
-    guardTxSize witCount tx@(Cardano.Tx body _noKeyWits) =
-        withConstraints (recentEra @era) $ do
+    guardTxSize witCount cardanoTx =
+        withConstraints era $ do
+            let tx = fromCardanoTx cardanoTx
             let maxSize = TxSize (pp ^. ppMaxTxSizeL)
-            when (estimateSignedTxSize pp witCount body > maxSize) $
+            when (estimateSignedTxSize era pp witCount tx > maxSize) $
                 throwE ErrBalanceTxMaxSizeLimitExceeded
-            pure tx
+            pure cardanoTx
 
     guardTxBalanced :: Cardano.Tx era -> ExceptT ErrBalanceTx m (Cardano.Tx era)
     guardTxBalanced tx = do
@@ -697,8 +698,8 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     txBalance :: Cardano.Tx era -> Cardano.Value
     txBalance
         = toCardanoValue @era
-        . evaluateTransactionBalance (recentEra @era) pp combinedUTxO
-        . txBody (recentEra @era)
+        . evaluateTransactionBalance era pp combinedUTxO
+        . txBody era
         . fromCardanoTx
 
     balanceAfterSettingMinFee
@@ -708,7 +709,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     balanceAfterSettingMinFee tx = ExceptT . pure $ do
         let witCount = estimateKeyWitnessCount combinedUTxO (getBody tx)
             minfee = W.toWalletCoin $ evaluateMinimumFee
-                (recentEra @era) pp (fromCardanoTx tx) witCount
+                era pp (fromCardanoTx tx) witCount
             update = TxUpdate [] [] [] [] (UseNewTxFee minfee)
         tx' <- left ErrBalanceTxUpdateError $ updateTx tx update
         let balance = txBalance tx'
@@ -754,14 +755,14 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
          ]
 
     extractOutputsFromTx :: Cardano.Tx era -> [W.TxOut]
-    extractOutputsFromTx (Cardano.ByronTx _) = case recentEra @era of {}
+    extractOutputsFromTx (Cardano.ByronTx _) = case era of {}
     extractOutputsFromTx (Cardano.ShelleyTx _ tx) =
         map fromLedgerTxOut
-        $ outputs (recentEra @era)
-        $ txBody (recentEra @era) tx
+        $ outputs era
+        $ txBody era tx
       where
         fromLedgerTxOut :: TxOut (ShelleyLedgerEra era) -> W.TxOut
-        fromLedgerTxOut o = case recentEra @era of
+        fromLedgerTxOut o = case era of
            RecentEraBabbage -> W.fromBabbageTxOut o
            RecentEraConway -> W.fromConwayTxOut o
 

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
@@ -29,7 +29,13 @@ import Prelude
 import Cardano.Ledger.Alonzo.Tx
     ( sizeAlonzoTxF )
 import Cardano.Ledger.Api
-    ( Addr (..), addrTxOutL, addrTxWitsL, ppMinFeeAL, witsTxL )
+    ( Addr (..)
+    , addrTxOutL
+    , addrTxWitsL
+    , bootAddrTxWitsL
+    , ppMinFeeAL
+    , witsTxL
+    )
 import Cardano.Ledger.Credential
     ( Credential (..) )
 import Cardano.Ledger.UTxO
@@ -116,7 +122,9 @@ estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
   where
     unsignedTx :: Tx (ShelleyLedgerEra era)
     unsignedTx = withConstraints era $
-        txWithWits & (witsTxL . addrTxWitsL) .~ mempty
+        txWithWits
+            & (witsTxL . addrTxWitsL) .~ mempty
+            & (witsTxL . bootAddrTxWitsL) .~ mempty
 
     coinQuotRem :: W.Coin -> W.Coin -> (Natural, Natural)
     coinQuotRem (W.Coin p) (W.Coin q) = quotRem p q

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
@@ -26,14 +26,13 @@ module Cardano.Wallet.Write.Tx.Sign
 
 import Prelude
 
-import Cardano.Ledger.Alonzo.Tx
-    ( sizeAlonzoTxF )
 import Cardano.Ledger.Api
     ( Addr (..)
     , addrTxOutL
     , addrTxWitsL
     , bootAddrTxWitsL
     , ppMinFeeAL
+    , sizeTxF
     , witsTxL
     )
 import Cardano.Ledger.Credential
@@ -113,8 +112,8 @@ estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
         -- /necessarily/ protect against calling the wrong function.
         sizeOfTx :: TxSize
         sizeOfTx = fromIntegral @Integer @TxSize $ case era of
-            RecentEraBabbage -> unsignedTx ^. sizeAlonzoTxF
-            RecentEraConway -> unsignedTx ^. sizeAlonzoTxF
+            RecentEraBabbage -> unsignedTx ^. sizeTxF
+            RecentEraConway -> unsignedTx ^. sizeTxF
     in
         sizeOfTx <> sizeOfWits
   where

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
@@ -108,8 +108,6 @@ estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
                     , show feePerByte
                     , "lovelace/byte"
                     ]
-
-
         -- When updating to a new era, check that the choice of encoding still
         -- seems right w.r.t the ledger. Types will /probably/ but not
         -- /necessarily/ protect against calling the wrong function.

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
@@ -107,13 +107,11 @@ estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
                     , show feePerByte
                     , "lovelace/byte"
                     ]
-        -- When updating to a new era, check that the choice of encoding still
-        -- seems right w.r.t the ledger. Types will /probably/ but not
-        -- /necessarily/ protect against calling the wrong function.
+
         sizeOfTx :: TxSize
-        sizeOfTx = fromIntegral @Integer @TxSize $ case era of
-            RecentEraBabbage -> unsignedTx ^. sizeTxF
-            RecentEraConway -> unsignedTx ^. sizeTxF
+        sizeOfTx = withConstraints era
+            $ fromIntegral @Integer @TxSize
+            $ unsignedTx ^. sizeTxF
     in
         sizeOfTx <> sizeOfWits
   where

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Sign.hs
@@ -129,10 +129,8 @@ estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
         era pparams unsignedTx witCount
 
     feePerByte :: W.Coin
-    feePerByte = Ledger.toWalletCoin $
-        case era of
-            Write.RecentEraBabbage -> pparams ^. ppMinFeeAL
-            Write.RecentEraConway -> pparams ^. ppMinFeeAL
+    feePerByte = withConstraints era $ Ledger.toWalletCoin $
+        pparams ^. ppMinFeeAL
 
 numberOfShelleyWitnesses :: Word -> KeyWitnessCount
 numberOfShelleyWitnesses n = KeyWitnessCount n 0

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3757,10 +3757,15 @@ estimateSignedTxSizeSpec = describe "estimateSignedTxSize" $ do
                 (True, True) -> do
                     estimateSignedTxSize era pparams witCount ledgerTx
                         `shouldBe`
-                        TxSize (fromIntegral (BS.length bs))
+                        TxSize (fromIntegral (BS.length bs) - correction)
                 (False, False) -> testDoesNotYetSupport "bootstrap wits + scripts"
                 (True, False) -> testDoesNotYetSupport "bootstrap wits"
                 (False, True) -> testDoesNotYetSupport "scripts"
+      where
+        -- Apparently the cbor encoding used by the ledger for size-checks
+        -- (`toCBORForSizeComputation`) is a few bytes smaller than the actual
+        -- serialized size for these goldens.
+        correction = 3
 
     forAllGoldens
         :: [(String, ByteString)]

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3737,7 +3737,7 @@ estimateSignedTxSizeSpec = describe "estimateSignedTxSize" $ do
         -> ByteString
         -> Cardano.Tx era
         -> IO ()
-    test _name bs cardanoTx@(Cardano.Tx body _) = do
+    test _name bs cTx@(Cardano.Tx body _) = do
         let pparams = Write.pparamsLedger $ mockPParamsForBalancing @era
             witCount dummyAddr = estimateKeyWitnessCount
                     (Write.fromCardanoUTxO
@@ -3746,7 +3746,7 @@ estimateSignedTxSizeSpec = describe "estimateSignedTxSize" $ do
             era = recentEra @era
 
             tx :: Write.Tx (Write.ShelleyLedgerEra era)
-            tx = Write.fromCardanoTx @era cardanoTx
+            tx = Write.fromCardanoTx @era cTx
 
             noScripts = Write.withConstraints (recentEra @era) $
                 Map.null $ tx ^. witsTxL . scriptTxWitsL

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3737,20 +3737,21 @@ estimateSignedTxSizeSpec = describe "estimateSignedTxSize" $ do
         -> ByteString
         -> Cardano.Tx era
         -> IO ()
-    test _name bs tx@(Cardano.Tx body _) = do
+    test _name bs cardanoTx@(Cardano.Tx body _) = do
         let pparams = Write.pparamsLedger $ mockPParamsForBalancing @era
-            utxo = utxoPromisingInputsHaveAddress vkCredAddr body
-            witCount = estimateKeyWitnessCount (Write.fromCardanoUTxO utxo) body
-            witCountBoot = estimateKeyWitnessCount (Write.fromCardanoUTxO $ utxoPromisingInputsHaveAddress bootAddr body) body
+            witCount dummyAddr = estimateKeyWitnessCount
+                    (Write.fromCardanoUTxO
+                        $ utxoPromisingInputsHaveAddress dummyAddr body)
+                    body
             era = recentEra @era
 
-            ledgerTx :: Write.Tx (Write.ShelleyLedgerEra era)
-            ledgerTx = Write.fromCardanoTx @era tx
+            tx :: Write.Tx (Write.ShelleyLedgerEra era)
+            tx = Write.fromCardanoTx @era cardanoTx
 
             noScripts = Write.withConstraints (recentEra @era) $
-                Map.null $ ledgerTx ^. witsTxL . scriptTxWitsL
+                Map.null $ tx ^. witsTxL . scriptTxWitsL
             noBootWits = Write.withConstraints (recentEra @era) $
-                Set.null $ ledgerTx ^. witsTxL . bootAddrTxWitsL
+                Set.null $ tx ^. witsTxL . bootAddrTxWitsL
             testDoesNotYetSupport x =
                 pendingWith $ "Test setup does not work for txs with " <> x
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3808,7 +3808,6 @@ estimateSignedTxSizeSpec = describe "estimateSignedTxSize" $ do
             in
                 Hspec.counterexample msg $ f name bs tx
 
-
     -- estimateSignedTxSize now depends upon being able to resolve inputs. To
     -- keep tese tests working, we can create a UTxO with dummy values as long
     -- as estimateSignedTxSize can tell that all inputs in the tx correspond to

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3740,9 +3740,9 @@ estimateSignedTxSizeSpec = describe "estimateSignedTxSize" $ do
     test _name bs cTx@(Cardano.Tx body _) = do
         let pparams = Write.pparamsLedger $ mockPParamsForBalancing @era
             witCount dummyAddr = estimateKeyWitnessCount
-                    (Write.fromCardanoUTxO
-                        $ utxoPromisingInputsHaveAddress dummyAddr body)
-                    body
+                (Write.fromCardanoUTxO
+                    $ utxoPromisingInputsHaveAddress dummyAddr body)
+                body
             era = recentEra @era
 
             tx :: Write.Tx (Write.ShelleyLedgerEra era)
@@ -3764,7 +3764,8 @@ estimateSignedTxSizeSpec = describe "estimateSignedTxSize" $ do
                         ( signedBinarySize - correction
                         , signedBinarySize
                         )
-                (False, False) -> testDoesNotYetSupport "bootstrap wits + scripts"
+                (False, False) ->
+                    testDoesNotYetSupport "bootstrap wits + scripts"
                 (True, False) ->
                     estimateSignedTxSize era pparams (witCount bootAddr) tx
                         `shouldBeInclusivelyWithin`
@@ -3851,7 +3852,7 @@ estimateSignedTxSizeSpec = describe "estimateSignedTxSize" $ do
     --
     -- NOTE: If we had access to the real UTxO set for the inputs of the test
     -- txs, we wouldn't need this fuzziness. Related: ADP-2987.
-    bootWitsCanBeLongerBy = 45
+    bootWitsCanBeLongerBy = TxSize 45
 
 fst6 :: (a, b, c, d, e, f) -> a
 fst6 (a,_,_,_,_,_) = a

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3775,7 +3775,7 @@ estimateSignedTxSizeSpec = describe "estimateSignedTxSize" $ do
                         )
                 (False, True) -> testDoesNotYetSupport "scripts"
       where
-        -- Apparently the cbor encoding used by the ledger for size-checks
+        -- Apparently the cbor encoding used by the ledger for size checks
         -- (`toCBORForSizeComputation`) is a few bytes smaller than the actual
         -- serialized size for these goldens.
         correction = TxSize 6

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3754,18 +3754,17 @@ estimateSignedTxSizeSpec = describe "estimateSignedTxSize" $ do
             testDoesNotYetSupport x =
                 pendingWith $ "Test setup does not work for txs with " <> x
 
-
             signedBinarySize = TxSize $ fromIntegral $ BS.length bs
 
         case (noScripts, noBootWits) of
                 (True, True) -> do
-                    estimateSignedTxSize era pparams witCount ledgerTx
-                        `shouldBeWithin`
+                    estimateSignedTxSize era pparams (witCount vkCredAddr) tx
+                        `shouldBeInclusivelyWithin`
                         (signedBinarySize - correction, signedBinarySize)
                 (False, False) -> testDoesNotYetSupport "bootstrap wits + scripts"
                 (True, False) ->
-                    estimateSignedTxSize era pparams witCountBoot ledgerTx
-                        `shouldBeWithin`
+                    estimateSignedTxSize era pparams (witCount bootAddr) tx
+                        `shouldBeInclusivelyWithin`
                         ( signedBinarySize - correction
                         , signedBinarySize + TxSize 45
                         -- For txs with bootstrap witnesses we accept that the
@@ -3781,7 +3780,7 @@ estimateSignedTxSizeSpec = describe "estimateSignedTxSize" $ do
         correction = TxSize 6
 
     -- | Checks for membership in the given closed interval [a, b]
-    x `shouldBeWithin` (a, b) =
+    x `shouldBeInclusivelyWithin` (a, b) =
         if a <= x && x <= b
         then pure ()
         else expectationFailure $ unwords


### PR DESCRIPTION
- [x] Remove dependency on `Cardano.Wallet.Primitive.Types.Tx.{sealedTxFromCardanoBody, serialisedTx}` by instead using `Ledger.sizeAlonzoTxF`

### Comments


### Issue Number

ADP-3081
