### PR TITLE
Relocate validation of user-specified outputs for `balanceTx`.

### DIFF
--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -320,12 +320,6 @@ performSelection
     :: (HasCallStack, MonadRandom m, SelectionContext ctx)
     => PerformSelection m ctx (Selection ctx)
 performSelection cs ps = do
-    performSelectionInner cs ps
-
-performSelectionInner
-    :: (HasCallStack, MonadRandom m, SelectionContext ctx)
-    => PerformSelection m ctx (Selection ctx)
-performSelectionInner cs ps = do
     balanceResult <- performSelectionBalance cs ps
     collateralResult <- performSelectionCollateral balanceResult cs ps
     pure $ mkSelection ps balanceResult collateralResult

--- a/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
@@ -228,15 +228,6 @@ prop_performSelection_coverage params r innerProperty =
     cover 0.1
         (isSelectionCollateralError r)
         "isSelectionCollateralError" $
-    cover 0.1
-        (isSelectionOutputError_SelectionOutputCoinInsufficient r)
-        "isSelectionOutputError_SelectionOutputCoinInsufficient" $
-    cover 0.1
-        (isSelectionOutputError_SelectionOutputSizeExceedsLimit r)
-        "isSelectionOutputError_SelectionOutputSizeExceedsLimit" $
-    cover 0.1
-        (isSelectionOutputError_SelectionOutputTokenQuantityExceedsLimit r)
-        "isSelectionOutputError_SelectionOutputTokenQuantityExceedsLimit" $
     property innerProperty
   where
     isSelection = isRight
@@ -251,30 +242,6 @@ prop_performSelection_coverage params r innerProperty =
             -> True; _ -> False
     isSelectionCollateralError = \case
         Left (SelectionCollateralErrorOf _)
-            -> True; _ -> False
-    isSelectionOutputError_SelectionOutputCoinInsufficient = \case
-        Left
-            (SelectionOutputErrorOf
-                (SelectionOutputError _index
-                    SelectionOutputCoinInsufficient {}
-                )
-            )
-            -> True; _ -> False
-    isSelectionOutputError_SelectionOutputSizeExceedsLimit = \case
-        Left
-            (SelectionOutputErrorOf
-                (SelectionOutputError _index
-                    SelectionOutputSizeExceedsLimit {}
-                )
-            )
-            -> True; _ -> False
-    isSelectionOutputError_SelectionOutputTokenQuantityExceedsLimit = \case
-        Left
-            (SelectionOutputErrorOf
-                (SelectionOutputError _index
-                    SelectionOutputTokenQuantityExceedsLimit {}
-                )
-            )
             -> True; _ -> False
 
     -- Provides an exhaustiveness check for all possible constructors of

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -974,7 +974,6 @@ instance IsServerError ErrCreateMigrationPlan where
 
 instance IsServerError ErrSelectAssets where
     toServerError = \case
-        ErrSelectAssetsPrepareOutputsError e -> toServerError e
         ErrSelectAssetsAlreadyWithdrawing tx ->
             apiError err403 AlreadyWithdrawing $ mconcat
                 [ "I already know of a pending transaction with withdrawals: "

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -765,6 +765,8 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 pp timeTranslation combinedUTxO redeemers tx'
 
     guardConflictingWithdrawalNetworks
+        :: Cardano.Tx era -> ExceptT ErrBalanceTx m ()
+    guardConflictingWithdrawalNetworks
         (Cardano.Tx (Cardano.TxBody body) _) = do
         -- Use of withdrawals with different networks breaks balancing.
         --
@@ -786,6 +788,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         when conflictingWdrlNetworks $
             throwE ErrBalanceTxConflictingNetworks
 
+    guardExistingCollateral :: Cardano.Tx era -> ExceptT ErrBalanceTx m ()
     guardExistingCollateral (Cardano.Tx (Cardano.TxBody body) _) = do
         -- Coin selection does not support pre-defining collateral. In Sep 2021
         -- consensus was that we /could/ allow for it with just a day's work or
@@ -797,12 +800,14 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             Cardano.TxInsCollateral _ _ ->
                 throwE ErrBalanceTxExistingCollateral
 
+    guardExistingTotalCollateral :: Cardano.Tx era -> ExceptT ErrBalanceTx m ()
     guardExistingTotalCollateral (Cardano.Tx (Cardano.TxBody body) _) =
         case Cardano.txTotalCollateral body of
             Cardano.TxTotalCollateralNone -> return ()
             Cardano.TxTotalCollateral _ _ ->
                throwE ErrBalanceTxExistingTotalCollateral
 
+    guardExistingReturnCollateral :: Cardano.Tx era -> ExceptT ErrBalanceTx m ()
     guardExistingReturnCollateral (Cardano.Tx (Cardano.TxBody body) _) =
         case Cardano.txReturnCollateral body of
             Cardano.TxReturnCollateralNone -> return ()

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -1408,17 +1408,14 @@ validateTxOutputSize
     :: SelectionConstraints
     -> (W.Address, TokenBundle)
     -> Maybe (SelectionOutputSizeExceedsLimitError WalletSelectionContext)
-validateTxOutputSize cs out
-    | withinLimit =
+validateTxOutputSize cs out = case sizeAssessment of
+    TokenBundleSizeWithinLimit ->
         Nothing
-    | otherwise =
+    TokenBundleSizeExceedsLimit ->
         Just $ SelectionOutputSizeExceedsLimitError out
   where
-    withinLimit :: Bool
-    withinLimit =
-        case (cs ^. #assessTokenBundleSize) (snd out) of
-            TokenBundleSizeWithinLimit -> True
-            TokenBundleSizeExceedsLimit -> False
+    sizeAssessment :: TokenBundleSizeAssessment
+    sizeAssessment = (cs ^. #assessTokenBundleSize) (snd out)
 
 -- | Validates the token quantities of a transaction output.
 --

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -250,9 +250,7 @@ instance Buildable (BuildableInAnyEra a) where
     build (BuildableInAnyEra _ x) = build x
 
 data ErrSelectAssets
-    = ErrSelectAssetsPrepareOutputsError
-        (SelectionOutputError WalletSelectionContext)
-    | ErrSelectAssetsAlreadyWithdrawing W.Tx
+    = ErrSelectAssetsAlreadyWithdrawing W.Tx
     | ErrSelectAssetsSelectionError (SelectionError WalletSelectionContext)
     deriving (Generic, Eq, Show)
 


### PR DESCRIPTION
## Issue

ADP-2425

## Description

This PR moves the validation of user-specified outputs from `Cardano.CoinSelection.performSelection` to `Write.Tx.Balance.selectAssets`.

The `selectAssets` function is **_currently_** the most straightforward place to locate this validation logic, as it already has access to `SelectionConstraints` and `SelectionParams` objects. Therefore, the existing validation functions (which require these objects) can be moved without significant changes.

## Future work

Future PRs will:
- move the definitions of user-specified output validation errors to the `Write.Tx.Balance` module.
- specialise the types of these errors so that they are not parameterised by a `SelectionContext`.
- adjust the definitions of validation functions to use ledger types and functions, rather than primitive types.
- convert the validation functions into guards, in the same style that we already use within `balanceTx`.