### PR TITLE
Revise import qualifiers for wallet primitive types in `Write.Tx.Balance`.

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -718,7 +718,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             update = TxUpdate [] [] [] [] (UseNewTxFee minfee)
         tx' <- left ErrBalanceTxUpdateError $ updateTx tx update
         let balance = txBalance tx'
-            minfee' = Cardano.Lovelace $ fromIntegral $ W.unCoin minfee
+            minfee' = Cardano.Lovelace $ W.Coin.toInteger minfee
         return (balance, minfee', witCount)
       where
         getBody (Cardano.Tx body _) = body


### PR DESCRIPTION
## Issue

Follow-on from #4094.

## Description

This PR revises our import qualifiers for **wallet primitive types** in the `Write.Tx.Balance` module.
  
We adopt the qualifier `W` for all wallet primitive types.
  
## Example

For example, we import the `Cardano.Wallet.Primitive.Types.UTxO` module (and type) as follows:
  
```hs
import qualified Cardano.Wallet.Primitive.Types.UTxO as W.UTxO
import qualified Cardano.Wallet.Primitive.Types.UTxO as W
    ( UTxO (..) )
```
  
This lets us write:
  
| Term | Refers to |
|--|--|
| `W.UTxO` | the `UTxO` type itself |
| `W.UTxO utxo` | the `UTxO` type's default data constructor |
| `W.UTxO.lookup` | the `lookup` function exported by the `UTxO` module |