### PR TITLE
Move `UTxO{Index,Selection}` types to `cardano-coin-selection` library.

### DIFF
--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -87,6 +87,8 @@ import Cardano.CoinSelection.Balance
     , SelectionStrategy (..)
     , UnableToConstructChangeError (..)
     )
+import Cardano.CoinSelection.UTxOSelection
+    ( UTxOSelection )
 import Cardano.Wallet.Primitive.Collateral
     ( asCollateral )
 import Cardano.Wallet.Primitive.Types.Address
@@ -105,8 +107,6 @@ import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
-import Cardano.Wallet.Primitive.Types.UTxOSelection
-    ( UTxOSelection )
 import Control.Arrow
     ( (&&&) )
 import Control.DeepSeq

--- a/lib/coin-selection/bench/UTxOIndexBench.hs
+++ b/lib/coin-selection/bench/UTxOIndexBench.hs
@@ -42,9 +42,9 @@ import Test.QuickCheck.Gen
 import Test.Tasty.Bench
     ( Benchmark, bench, bgroup, defaultMain, nf )
 
+import qualified Cardano.CoinSelection.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 

--- a/lib/coin-selection/cardano-coin-selection.cabal
+++ b/lib/coin-selection/cardano-coin-selection.cabal
@@ -62,6 +62,8 @@ library
     Cardano.CoinSelection.Balance.Gen
     Cardano.CoinSelection.Collateral
     Cardano.CoinSelection.Context
+    Cardano.CoinSelection.UTxOSelection
+    Cardano.CoinSelection.UTxOSelection.Gen
 
 test-suite test
   import:             language, opts-exe
@@ -97,6 +99,7 @@ test-suite test
   other-modules:
     Cardano.CoinSelection.BalanceSpec
     Cardano.CoinSelection.CollateralSpec
+    Cardano.CoinSelection.UTxOSelectionSpec
     Cardano.CoinSelectionSpec
     Spec
     SpecHook

--- a/lib/coin-selection/cardano-coin-selection.cabal
+++ b/lib/coin-selection/cardano-coin-selection.cabal
@@ -44,6 +44,7 @@ library
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
     , containers
+    , deepseq
     , exact-combinatorics
     , extra
     , fmt
@@ -53,6 +54,7 @@ library
     , lattices
     , math-functions
     , MonadRandom
+    , monoidmap
     , QuickCheck
     , transformers
 
@@ -62,6 +64,9 @@ library
     Cardano.CoinSelection.Balance.Gen
     Cardano.CoinSelection.Collateral
     Cardano.CoinSelection.Context
+    Cardano.CoinSelection.UTxOIndex
+    Cardano.CoinSelection.UTxOIndex.Gen
+    Cardano.CoinSelection.UTxOIndex.Internal
     Cardano.CoinSelection.UTxOSelection
     Cardano.CoinSelection.UTxOSelection.Gen
 
@@ -87,6 +92,7 @@ test-suite test
     , hspec-core
     , int-cast
     , lattices
+    , MonadRandom
     , pretty-simple
     , QuickCheck
     , quickcheck-classes
@@ -99,7 +105,30 @@ test-suite test
   other-modules:
     Cardano.CoinSelection.BalanceSpec
     Cardano.CoinSelection.CollateralSpec
+    Cardano.CoinSelection.UTxOIndexSpec
     Cardano.CoinSelection.UTxOSelectionSpec
     Cardano.CoinSelectionSpec
     Spec
     SpecHook
+
+benchmark utxo-index
+    default-language:
+        Haskell2010
+    type:
+        exitcode-stdio-1.0
+    hs-source-dirs:
+        bench
+    main-is:
+        UTxOIndexBench.hs
+    build-depends:
+      , base
+      , cardano-coin-selection
+      , cardano-wallet-primitive
+      , cardano-wallet-test-utils
+      , containers
+      , deepseq
+      , format-numbers
+      , QuickCheck
+      , tasty-bench
+      , tasty-hunit
+      , text

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -71,6 +71,8 @@ import Cardano.CoinSelection.Balance
     )
 import Cardano.CoinSelection.Context
     ( SelectionContext (..) )
+import Cardano.CoinSelection.UTxOSelection
+    ( UTxOSelection )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -81,8 +83,6 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TokenBundleSizeAssessment (..), txOutMaxTokenQuantity )
-import Cardano.Wallet.Primitive.Types.UTxOSelection
-    ( UTxOSelection )
 import Control.Monad.Random.Class
     ( MonadRandom (..) )
 import Control.Monad.Random.NonRandom
@@ -116,9 +116,9 @@ import Numeric.Natural
 
 import qualified Cardano.CoinSelection.Balance as Balance
 import qualified Cardano.CoinSelection.Collateral as Collateral
+import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -120,6 +120,8 @@ import Algebra.PartialOrd
     ( PartialOrd (..) )
 import Cardano.CoinSelection.Context
     ( SelectionContext (..) )
+import Cardano.CoinSelection.UTxOIndex
+    ( Asset (..), SelectionFilter (..), UTxOIndex (..) )
 import Cardano.CoinSelection.UTxOSelection
     ( IsUTxOSelection, UTxOSelection, UTxOSelectionNonEmpty )
 import Cardano.Numeric.Util
@@ -134,8 +136,6 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TokenBundleSizeAssessment (..), TokenBundleSizeAssessor (..) )
-import Cardano.Wallet.Primitive.Types.UTxOIndex
-    ( Asset (..), SelectionFilter (..), UTxOIndex (..) )
 import Control.Monad.Extra
     ( andM, (<=<) )
 import Control.Monad.Random.Class
@@ -175,12 +175,12 @@ import GHC.Stack
 import Numeric.Natural
     ( Natural )
 
+import qualified Cardano.CoinSelection.UTxOIndex as UTxOIndex
 import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
-import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -120,6 +120,8 @@ import Algebra.PartialOrd
     ( PartialOrd (..) )
 import Cardano.CoinSelection.Context
     ( SelectionContext (..) )
+import Cardano.CoinSelection.UTxOSelection
+    ( IsUTxOSelection, UTxOSelection, UTxOSelectionNonEmpty )
 import Cardano.Numeric.Util
     ( padCoalesce )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -134,8 +136,6 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TokenBundleSizeAssessment (..), TokenBundleSizeAssessor (..) )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( Asset (..), SelectionFilter (..), UTxOIndex (..) )
-import Cardano.Wallet.Primitive.Types.UTxOSelection
-    ( IsUTxOSelection, UTxOSelection, UTxOSelectionNonEmpty )
 import Control.Monad.Extra
     ( andM, (<=<) )
 import Control.Monad.Random.Class
@@ -175,12 +175,12 @@ import GHC.Stack
 import Numeric.Natural
     ( Natural )
 
+import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
-import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE

--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex.hs
@@ -13,9 +13,9 @@
 --
 -- This module is meant to be imported qualified. For example:
 --
--- >>> import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
+-- >>> import qualified Cardano.CoinSelection.UTxOIndex as UTxOIndex
 --
-module Cardano.Wallet.Primitive.Types.UTxOIndex
+module Cardano.CoinSelection.UTxOIndex
     (
     -- * Type
       UTxOIndex
@@ -63,4 +63,4 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex
 
     ) where
 
-import Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
+import Cardano.CoinSelection.UTxOIndex.Internal

--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Gen.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Gen.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
+module Cardano.CoinSelection.UTxOIndex.Gen
     ( genUTxOIndex
     , genUTxOIndexLarge
     , genUTxOIndexLargeN
@@ -9,12 +9,12 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
 
 import Prelude
 
+import Cardano.CoinSelection.UTxOIndex
+    ( UTxOIndex )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRangePositive, shrinkTokenBundleSmallRangePositive )
-import Cardano.Wallet.Primitive.Types.UTxOIndex
-    ( UTxOIndex )
 import Control.Monad
     ( replicateM )
 import Generics.SOP
@@ -24,7 +24,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Extra
     ( genericRoundRobinShrink, (<:>), (<@>) )
 
-import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
+import qualified Cardano.CoinSelection.UTxOIndex as UTxOIndex
 
 --------------------------------------------------------------------------------
 -- Indices generated according to the size parameter

--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
@@ -22,7 +22,7 @@
 --
 -- See the documentation for 'UTxOIndex' for more details.
 --
-module Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
+module Cardano.CoinSelection.UTxOIndex.Internal
     (
     ----------------------------------------------------------------------------
     -- Public Interface

--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOSelection.hs
@@ -86,10 +86,10 @@ module Cardano.CoinSelection.UTxOSelection
 
 import Prelude
 
+import Cardano.CoinSelection.UTxOIndex
+    ( UTxOIndex )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
-import Cardano.Wallet.Primitive.Types.UTxOIndex
-    ( UTxOIndex )
 import Control.Monad
     ( ap, (<=<) )
 import Data.Bool
@@ -111,7 +111,7 @@ import Data.Tuple
 import GHC.Generics
     ( Generic )
 
-import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
+import qualified Cardano.CoinSelection.UTxOIndex as UTxOIndex
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map

--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOSelection.hs
@@ -34,7 +34,7 @@
 -- either use the 'toNonEmpty' function to assert that it is non-empty, or use
 -- the 'select' function to select a single entry.
 --
-module Cardano.Wallet.Primitive.Types.UTxOSelection
+module Cardano.CoinSelection.UTxOSelection
     (
       -- * Classes
       IsUTxOSelection

--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOSelection/Gen.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOSelection/Gen.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
+module Cardano.CoinSelection.UTxOSelection.Gen
     ( genUTxOSelection
     , genUTxOSelectionNonEmpty
     , shrinkUTxOSelection
@@ -11,10 +11,10 @@ module Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
 
 import Prelude
 
+import Cardano.CoinSelection.UTxOSelection
+    ( UTxOSelection, UTxOSelectionNonEmpty )
 import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
     ( genUTxOIndex, shrinkUTxOIndex )
-import Cardano.Wallet.Primitive.Types.UTxOSelection
-    ( UTxOSelection, UTxOSelectionNonEmpty )
 import Data.Maybe
     ( mapMaybe )
 import Test.QuickCheck
@@ -22,7 +22,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Extra
     ( genFunction )
 
-import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
+import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
 
 --------------------------------------------------------------------------------
 -- Selections that may be empty

--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOSelection/Gen.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOSelection/Gen.hs
@@ -11,10 +11,10 @@ module Cardano.CoinSelection.UTxOSelection.Gen
 
 import Prelude
 
+import Cardano.CoinSelection.UTxOIndex.Gen
+    ( genUTxOIndex, shrinkUTxOIndex )
 import Cardano.CoinSelection.UTxOSelection
     ( UTxOSelection, UTxOSelectionNonEmpty )
-import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
-    ( genUTxOIndex, shrinkUTxOIndex )
 import Data.Maybe
     ( mapMaybe )
 import Test.QuickCheck

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -98,6 +98,10 @@ import Cardano.CoinSelection.Balance
     )
 import Cardano.CoinSelection.Balance.Gen
     ( genSelectionStrategy, shrinkSelectionStrategy )
+import Cardano.CoinSelection.UTxOIndex
+    ( Asset (..), SelectionFilter (..), UTxOIndex )
+import Cardano.CoinSelection.UTxOIndex.Gen
+    ( genUTxOIndex, genUTxOIndexLarge, genUTxOIndexLargeN, shrinkUTxOIndex )
 import Cardano.CoinSelection.UTxOSelection
     ( UTxOSelection, UTxOSelectionNonEmpty )
 import Cardano.CoinSelection.UTxOSelection.Gen
@@ -136,10 +140,6 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantityPositive, shrinkTokenQuantityPositive )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TokenBundleSizeAssessment (..), TokenBundleSizeAssessor (..) )
-import Cardano.Wallet.Primitive.Types.UTxOIndex
-    ( Asset (..), SelectionFilter (..), UTxOIndex )
-import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
-    ( genUTxOIndex, genUTxOIndexLarge, genUTxOIndexLargeN, shrinkUTxOIndex )
 import Control.Monad
     ( forM_, replicateM )
 import Data.Bifunctor
@@ -232,12 +232,12 @@ import Test.Utils.Pretty
     ( Pretty (..) )
 
 import qualified Cardano.CoinSelection.Context as SC
+import qualified Cardano.CoinSelection.UTxOIndex as UTxOIndex
 import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
-import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -98,6 +98,10 @@ import Cardano.CoinSelection.Balance
     )
 import Cardano.CoinSelection.Balance.Gen
     ( genSelectionStrategy, shrinkSelectionStrategy )
+import Cardano.CoinSelection.UTxOSelection
+    ( UTxOSelection, UTxOSelectionNonEmpty )
+import Cardano.CoinSelection.UTxOSelection.Gen
+    ( genUTxOSelection, shrinkUTxOSelection )
 import Cardano.Numeric.Util
     ( inAscendingPartialOrder )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -136,10 +140,6 @@ import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( Asset (..), SelectionFilter (..), UTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
     ( genUTxOIndex, genUTxOIndexLarge, genUTxOIndexLargeN, shrinkUTxOIndex )
-import Cardano.Wallet.Primitive.Types.UTxOSelection
-    ( UTxOSelection, UTxOSelectionNonEmpty )
-import Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
-    ( genUTxOSelection, shrinkUTxOSelection )
 import Control.Monad
     ( forM_, replicateM )
 import Data.Bifunctor
@@ -232,12 +232,12 @@ import Test.Utils.Pretty
     ( Pretty (..) )
 
 import qualified Cardano.CoinSelection.Context as SC
+import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
-import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOIndexSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOIndexSpec.hs
@@ -11,23 +11,15 @@
 {- HLINT ignore "Use camelCase" -}
 {- HLINT ignore "Hoist not" -}
 
-module Cardano.Wallet.Primitive.Types.UTxOIndexSpec
+module Cardano.CoinSelection.UTxOIndexSpec
     ( spec
     ) where
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( TokenBundle )
-import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
-    ( genTokenBundleSmallRangePositive, shrinkTokenBundleSmallRangePositive )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId )
-import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetId, shrinkAssetId )
-import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
+import Cardano.CoinSelection.UTxOIndex.Gen
     ( genUTxOIndex, shrinkUTxOIndex )
-import Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
+import Cardano.CoinSelection.UTxOIndex.Internal
     ( Asset (..)
     , BundleCategory (..)
     , InvariantStatus (..)
@@ -36,6 +28,14 @@ import Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
     , categorizeTokenBundle
     , checkInvariant
     )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle )
+import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
+    ( genTokenBundleSmallRangePositive, shrinkTokenBundleSmallRangePositive )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( AssetId )
+import Cardano.Wallet.Primitive.Types.TokenMap.Gen
+    ( genAssetId, shrinkAssetId )
 import Control.Monad
     ( void )
 import Control.Monad.Random.Class
@@ -81,8 +81,8 @@ import Test.QuickCheck.Quid
 import Test.Utils.Laws
     ( testLawsMany )
 
+import qualified Cardano.CoinSelection.UTxOIndex.Internal as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
-import qualified Cardano.Wallet.Primitive.Types.UTxOIndex.Internal as UTxOIndex
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map
@@ -90,7 +90,7 @@ import qualified Data.Set as Set
 
 spec :: Spec
 spec =
-    describe "Cardano.Wallet.Primitive.Types.UTxOIndexSpec" $ do
+    describe "Cardano.CoinSelection.UTxOIndexSpec" $ do
 
     describe "Class instances obey laws" $ do
         testLawsMany @(UTxOIndex TestUTxO)

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOSelectionSpec.hs
@@ -8,24 +8,24 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {- HLINT ignore "Use camelCase" -}
 
-module Cardano.Wallet.Primitive.Types.UTxOSelectionSpec
+module Cardano.CoinSelection.UTxOSelectionSpec
     ( spec
     ) where
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.UTxOIndex
-    ( UTxOIndex )
-import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
-    ( genUTxOIndex, shrinkUTxOIndex )
-import Cardano.Wallet.Primitive.Types.UTxOSelection
+import Cardano.CoinSelection.UTxOSelection
     ( IsUTxOSelection, UTxOSelection, UTxOSelectionNonEmpty )
-import Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
+import Cardano.CoinSelection.UTxOSelection.Gen
     ( genUTxOSelection
     , genUTxOSelectionNonEmpty
     , shrinkUTxOSelection
     , shrinkUTxOSelectionNonEmpty
     )
+import Cardano.Wallet.Primitive.Types.UTxOIndex
+    ( UTxOIndex )
+import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
+    ( genUTxOIndex, shrinkUTxOIndex )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
@@ -43,15 +43,15 @@ import Test.QuickCheck
 import Test.QuickCheck.Quid
     ( Hexadecimal (..), Quid, Size (..) )
 
+import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
-import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Data.Foldable as F
 import qualified Data.Map.Strict as Map
 
 spec :: Spec
 spec =
-    describe "Cardano.Wallet.Primitive.Types.UTxOSelectionSpec" $ do
+    describe "Cardano.CoinSelection.UTxOSelectionSpec" $ do
 
     describe "Generators and shrinkers" $ do
 

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOSelectionSpec.hs
@@ -14,6 +14,10 @@ module Cardano.CoinSelection.UTxOSelectionSpec
 
 import Prelude
 
+import Cardano.CoinSelection.UTxOIndex
+    ( UTxOIndex )
+import Cardano.CoinSelection.UTxOIndex.Gen
+    ( genUTxOIndex, shrinkUTxOIndex )
 import Cardano.CoinSelection.UTxOSelection
     ( IsUTxOSelection, UTxOSelection, UTxOSelectionNonEmpty )
 import Cardano.CoinSelection.UTxOSelection.Gen
@@ -22,10 +26,6 @@ import Cardano.CoinSelection.UTxOSelection.Gen
     , shrinkUTxOSelection
     , shrinkUTxOSelectionNonEmpty
     )
-import Cardano.Wallet.Primitive.Types.UTxOIndex
-    ( UTxOIndex )
-import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
-    ( genUTxOIndex, shrinkUTxOIndex )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
@@ -43,9 +43,9 @@ import Test.QuickCheck
 import Test.QuickCheck.Quid
     ( Hexadecimal (..), Quid, Size (..) )
 
+import qualified Cardano.CoinSelection.UTxOIndex as UTxOIndex
 import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
-import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Data.Foldable as F
 import qualified Data.Map.Strict as Map
 

--- a/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
@@ -59,6 +59,10 @@ import Cardano.CoinSelection.BalanceSpec
     , unMockComputeMinimumAdaQuantity
     , unMockComputeMinimumCost
     )
+import Cardano.CoinSelection.UTxOSelection
+    ( UTxOSelection )
+import Cardano.CoinSelection.UTxOSelection.Gen
+    ( genUTxOSelection, shrinkUTxOSelection )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
@@ -75,10 +79,6 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxTokenQuantity )
-import Cardano.Wallet.Primitive.Types.UTxOSelection
-    ( UTxOSelection )
-import Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
-    ( genUTxOSelection, shrinkUTxOSelection )
 import Control.Monad
     ( forM_ )
 import Control.Monad.Trans.Except
@@ -140,9 +140,9 @@ import Test.QuickCheck.Monadic
     ( monadicIO, run )
 
 import qualified Cardano.CoinSelection.Balance as Balance
+import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 
 spec :: Spec
 spec = describe "Cardano.CoinSelectionSpec" $ do

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -122,9 +122,6 @@ library
     Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     Cardano.Wallet.Primitive.Types.UTxO
     Cardano.Wallet.Primitive.Types.UTxO.Gen
-    Cardano.Wallet.Primitive.Types.UTxOIndex
-    Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
-    Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
     Cardano.Wallet.Unsafe
     Cardano.Wallet.Util
     Control.Monad.Random.NonRandom
@@ -183,29 +180,7 @@ test-suite test
     Cardano.Wallet.Primitive.Types.TokenPolicySpec
     Cardano.Wallet.Primitive.Types.TokenQuantitySpec
     Cardano.Wallet.Primitive.Types.TxSpec
-    Cardano.Wallet.Primitive.Types.UTxOIndexSpec
     Cardano.Wallet.Primitive.Types.UTxOSpec
     Data.QuantitySpec
     Spec
     SpecHook
-
-benchmark utxo-index
-    default-language:
-        Haskell2010
-    type:
-        exitcode-stdio-1.0
-    hs-source-dirs:
-        bench
-    main-is:
-        UTxOIndexBench.hs
-    build-depends:
-      , base
-      , cardano-wallet-primitive
-      , cardano-wallet-test-utils
-      , containers
-      , deepseq
-      , format-numbers
-      , QuickCheck
-      , tasty-bench
-      , tasty-hunit
-      , text

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -125,8 +125,6 @@ library
     Cardano.Wallet.Primitive.Types.UTxOIndex
     Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
     Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
-    Cardano.Wallet.Primitive.Types.UTxOSelection
-    Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
     Cardano.Wallet.Unsafe
     Cardano.Wallet.Util
     Control.Monad.Random.NonRandom
@@ -186,7 +184,6 @@ test-suite test
     Cardano.Wallet.Primitive.Types.TokenQuantitySpec
     Cardano.Wallet.Primitive.Types.TxSpec
     Cardano.Wallet.Primitive.Types.UTxOIndexSpec
-    Cardano.Wallet.Primitive.Types.UTxOSelectionSpec
     Cardano.Wallet.Primitive.Types.UTxOSpec
     Data.QuantitySpec
     Spec

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -71,6 +71,7 @@ library
     , cardano-balance-tx
     , cardano-binary
     , cardano-cli
+    , cardano-coin-selection
     , cardano-crypto
     , cardano-crypto-class
     , cardano-crypto-test

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -211,6 +211,7 @@ import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Byron as Cardano
 import qualified Cardano.Api.Byron as Byron
 import qualified Cardano.Api.Shelley as Cardano
+import qualified Cardano.CoinSelection.UTxOIndex as UTxOIndex
 import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Wallet.Primitive.Types.Address as W
@@ -224,7 +225,6 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
-import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as W
 import qualified Data.Foldable as F
 import qualified Data.List as L

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -75,6 +75,8 @@ module Cardano.Wallet.Write.Tx.Balance
 
 import Prelude
 
+import Cardano.CoinSelection.UTxOSelection
+    ( UTxOSelection )
 import Cardano.Ledger.Alonzo.Core
     ( ppCollateralPercentageL, ppMaxCollateralInputsL )
 import Cardano.Ledger.Alonzo.Scripts
@@ -118,8 +120,6 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
     , txOutMaxCoin
     , txOutMaxTokenQuantity
     )
-import Cardano.Wallet.Primitive.Types.UTxOSelection
-    ( UTxOSelection )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     ( fromCardanoValue )
 import Cardano.Wallet.Write.ProtocolParameters
@@ -211,6 +211,7 @@ import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Byron as Cardano
 import qualified Cardano.Api.Byron as Byron
 import qualified Cardano.Api.Shelley as Cardano
+import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
@@ -224,7 +225,6 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
-import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as W
 import qualified Data.Foldable as F
 import qualified Data.List as L


### PR DESCRIPTION
## Issues

ADP-3130
ADP-3131

## Description

This PR moves the following types from the `cardano-wallet-primitive` library to the `cardano-coin-selection` library:
- `UTxOIndex`
- `UTxOSelection`

These types:
- are completely specific to and only used by coin selection
- are not really "wallet primitive types"