### PR TITLE
Stop exporting internal error types from `cardano-coin-selection`.

### DIFF
--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -59,11 +59,6 @@ module Cardano.Tx.Balance.Internal.CoinSelection
     , SelectionCollateralError
     , UnableToConstructChangeError (..)
 
-    -- TODO: ADP-3129
-    -- Remove this export after redefining `ErrMkTransaction` to not depend on
-    -- this type:
-    , SelectionOutputTokenQuantityExceedsLimitError (..)
-
     -- * Selection reports
     , makeSelectionReportDetailed
     , makeSelectionReportSummarized
@@ -79,7 +74,6 @@ import Cardano.CoinSelection
     ( SelectionCollateralError
     , SelectionCollateralRequirement (..)
     , SelectionError (..)
-    , SelectionOutputTokenQuantityExceedsLimitError (..)
     )
 import Cardano.CoinSelection.Balance
     ( BalanceInsufficientError (..)

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -24,11 +24,6 @@ module Cardano.CoinSelection
     , SelectionParams (..)
     , SelectionSkeleton (..)
 
-    -- TODO: ADP-3129
-    -- Remove this export after redefining `ErrMkTransaction` to not depend on
-    -- this type:
-    , SelectionOutputTokenQuantityExceedsLimitError (..)
-
     -- * Verification of post conditions
     , VerificationResult (..)
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -354,7 +354,7 @@ instance IsServerError ErrMkTransaction where
     toServerError = \case
         ErrMkTransactionTxBodyError hint ->
             apiError err500 CreatedInvalidTransaction hint
-        ErrMkTransactionTokenQuantityExceedsLimit e ->
+        ErrMkTransactionOutputTokenQuantityExceedsLimit e ->
             apiError err403 OutputTokenQuantityExceedsLimit $ mconcat
                 [ "One of the token quantities you've specified is greater "
                 , "than the maximum quantity allowed in a single transaction "

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -78,10 +78,7 @@ import Cardano.Ledger.Allegra.Core
 import Cardano.Ledger.Crypto
     ( DSIGN )
 import Cardano.Tx.Balance.Internal.CoinSelection
-    ( SelectionOf (..)
-    , SelectionOutputTokenQuantityExceedsLimitError (..)
-    , selectionDelta
-    )
+    ( SelectionOf (..), selectionDelta )
 import Cardano.Wallet.Address.Derivation
     ( Depth (..), RewardAccount (..) )
 import Cardano.Wallet.Address.Derivation.SharedKey
@@ -143,6 +140,7 @@ import Cardano.Wallet.Transaction
     , AnyScript (..)
     , DelegationAction (..)
     , ErrMkTransaction (..)
+    , ErrMkTransactionOutputTokenQuantityExceedsLimitError (..)
     , PreSelection (..)
     , TokenMapWithScripts
     , TransactionCtx (..)
@@ -809,8 +807,9 @@ mkUnsignedTx
                     when (quantity > txOutMaxTokenQuantity) $
                         Left (mkErr asset quantity)
               where
-                mkErr aid q = ErrMkTransactionTokenQuantityExceedsLimit
-                    $ SelectionOutputTokenQuantityExceedsLimitError
+                mkErr aid q
+                    = ErrMkTransactionTokenQuantityExceedsLimit
+                    $ ErrMkTransactionOutputTokenQuantityExceedsLimitError
                         { address = addr
                         , asset = aid
                         , quantity = q

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -808,7 +808,7 @@ mkUnsignedTx
                         Left (mkErr asset quantity)
               where
                 mkErr aid q
-                    = ErrMkTransactionTokenQuantityExceedsLimit
+                    = ErrMkTransactionOutputTokenQuantityExceedsLimit
                     $ ErrMkTransactionOutputTokenQuantityExceedsLimitError
                         { address = addr
                         , asset = aid

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -47,6 +47,7 @@ module Cardano.Wallet.Transaction
     -- * Errors
     , ErrSignTx (..)
     , ErrMkTransaction (..)
+    , ErrMkTransactionOutputTokenQuantityExceedsLimitError (..)
     , ErrCannotJoin (..)
     , ErrCannotQuit (..)
     ) where
@@ -64,11 +65,7 @@ import Cardano.Api.Extra
 import Cardano.Pool.Types
     ( PoolId )
 import Cardano.Tx.Balance.Internal.CoinSelection
-    ( SelectionCollateralRequirement (..)
-    , SelectionOf (..)
-    , SelectionOutputTokenQuantityExceedsLimitError
-    , WalletSelectionContext
-    )
+    ( SelectionCollateralRequirement (..), SelectionOf (..) )
 import Cardano.Wallet.Address.Derivation
     ( Depth (..), DerivationIndex )
 import Cardano.Wallet.Primitive.Passphrase.Types
@@ -397,7 +394,7 @@ data ErrMkTransaction
     =  ErrMkTransactionTxBodyError Text
     -- ^ We failed to construct a transaction for some reasons.
     | ErrMkTransactionTokenQuantityExceedsLimit
-        (SelectionOutputTokenQuantityExceedsLimitError WalletSelectionContext)
+        ErrMkTransactionOutputTokenQuantityExceedsLimitError
     | ErrMkTransactionInvalidEra AnyCardanoEra
     -- ^ Should never happen, means that that we have programmatically provided
     -- an invalid era.

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -89,6 +89,8 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId, TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenPolicyId )
+import Cardano.Wallet.Primitive.Types.TokenQuantity
+    ( TokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
     ( Tx (..), TxMetadata )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
@@ -403,6 +405,19 @@ data ErrMkTransaction
     | ErrMkTransactionQuitStakePool ErrCannotQuit
     | ErrMkTransactionIncorrectTTL PastHorizonException
     deriving (Generic, Eq, Show)
+
+data ErrMkTransactionOutputTokenQuantityExceedsLimitError =
+    ErrMkTransactionOutputTokenQuantityExceedsLimitError
+    { address :: Address
+      -- ^ The address to which this token quantity was to be sent.
+    , asset :: AssetId
+      -- ^ The asset identifier to which this token quantity corresponds.
+    , quantity :: TokenQuantity
+      -- ^ The token quantity that exceeded the bound.
+    , quantityMaxBound :: TokenQuantity
+      -- ^ The maximum allowable token quantity.
+    }
+    deriving (Eq, Generic, Show)
 
 -- | Possible signing error
 data ErrSignTx

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -393,7 +393,7 @@ toKeyRole witCtx (Hash key) = case witCtx of
 data ErrMkTransaction
     =  ErrMkTransactionTxBodyError Text
     -- ^ We failed to construct a transaction for some reasons.
-    | ErrMkTransactionTokenQuantityExceedsLimit
+    | ErrMkTransactionOutputTokenQuantityExceedsLimit
         ErrMkTransactionOutputTokenQuantityExceedsLimitError
     | ErrMkTransactionInvalidEra AnyCardanoEra
     -- ^ Should never happen, means that that we have programmatically provided


### PR DESCRIPTION
## Issue

ADP-3129

## Description

This PR:
- adjusts the public API of `cardano-coin-selection` so that the `SelectionOutputTokenQuantityExceedsLimitError` type is no longer exported.
    - This type is meant to be an internal error type, and not meant for export.
    - We might delete this type in a future PR.
- adjusts `ErrMkTransaction` to use its own dedicated error type for the case where an output token quantity exceeds the maximum limit allowed by the protocol. 