### PR TITLE
Tidy the `TokenBundleSizeAssessor` API.

### DIFF
--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -82,7 +82,7 @@ import Cardano.CoinSelection.Balance
     , UnableToConstructChangeError (..)
     )
 import Cardano.CoinSelection.Size
-    ( TokenBundleSizeAssessment )
+    ( TokenBundleSizeAssessor (..) )
 import Cardano.CoinSelection.UTxOSelection
     ( UTxOSelection )
 import Cardano.Wallet.Primitive.Collateral
@@ -203,12 +203,10 @@ toInternalUTxO' f (i, TxOut a b) = (WalletUTxO i a, f b)
 --      selections that are acceptable to the ledger.
 --
 data SelectionConstraints = SelectionConstraints
-    { assessTokenBundleSize
-        :: TokenBundle -> TokenBundleSizeAssessment
+    { tokenBundleSizeAssessor
+        :: TokenBundleSizeAssessor
         -- ^ Assesses the size of a token bundle relative to the upper limit of
-        -- what can be included in a transaction output. See documentation for
-        -- the 'TokenBundleSizeAssessor' type to learn about the expected
-        -- properties of this field.
+        -- what can be included in a transaction output.
     , computeMinimumAdaQuantity
         :: Address -> TokenMap -> Coin
         -- ^ Computes the minimum ada quantity required for a given output.

--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -81,6 +81,8 @@ import Cardano.CoinSelection.Balance
     , SelectionStrategy (..)
     , UnableToConstructChangeError (..)
     )
+import Cardano.CoinSelection.Size
+    ( TokenBundleSizeAssessment )
 import Cardano.CoinSelection.UTxOSelection
     ( UTxOSelection )
 import Cardano.Wallet.Primitive.Collateral
@@ -94,7 +96,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId, TokenMap )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessment, txOutMaxCoin, txOutMaxTokenQuantity )
+    ( txOutMaxCoin, txOutMaxTokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut

--- a/lib/coin-selection/cardano-coin-selection.cabal
+++ b/lib/coin-selection/cardano-coin-selection.cabal
@@ -64,6 +64,7 @@ library
     Cardano.CoinSelection.Balance.Gen
     Cardano.CoinSelection.Collateral
     Cardano.CoinSelection.Context
+    Cardano.CoinSelection.Size
     Cardano.CoinSelection.UTxOIndex
     Cardano.CoinSelection.UTxOIndex.Gen
     Cardano.CoinSelection.UTxOIndex.Internal

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -1174,18 +1174,13 @@ verifyOutputSize
     :: SelectionConstraints ctx
     -> (Address ctx, TokenBundle)
     -> Maybe (SelectionOutputSizeExceedsLimitError ctx)
-verifyOutputSize cs out
-    | withinLimit =
+verifyOutputSize cs out = case isWithinLimit (snd out) of
+    TokenBundleSizeWithinLimit ->
         Nothing
-    | otherwise =
+    TokenBundleSizeExceedsLimit ->
         Just $ SelectionOutputSizeExceedsLimitError out
   where
-    withinLimit :: Bool
-    withinLimit = case isWithinLimit (snd out) of
-        TokenBundleSizeWithinLimit -> True
-        TokenBundleSizeExceedsLimit -> False
-    isWithinLimit =
-        cs ^. (#tokenBundleSizeAssessor . #assessTokenBundleSize)
+    isWithinLimit = cs ^. (#tokenBundleSizeAssessor . #assessTokenBundleSize)
 
 -- | Indicates that a token quantity exceeds the maximum quantity that can
 --   appear in a transaction output's token bundle.

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -66,6 +66,8 @@ import Cardano.CoinSelection.Balance
     )
 import Cardano.CoinSelection.Context
     ( SelectionContext (..) )
+import Cardano.CoinSelection.Size
+    ( TokenBundleSizeAssessment (..) )
 import Cardano.CoinSelection.UTxOSelection
     ( UTxOSelection )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -77,7 +79,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessment (..), txOutMaxTokenQuantity )
+    ( txOutMaxTokenQuantity )
 import Control.Monad.Random.Class
     ( MonadRandom (..) )
 import Control.Monad.Random.NonRandom

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -121,7 +121,7 @@ import Algebra.PartialOrd
 import Cardano.CoinSelection.Context
     ( SelectionContext (..) )
 import Cardano.CoinSelection.Size
-    ( TokenBundleSizeAssessor (..) )
+    ( TokenBundleSizeAssessment (..), TokenBundleSizeAssessor (..) )
 import Cardano.CoinSelection.UTxOIndex
     ( Asset (..), SelectionFilter (..), UTxOIndex (..) )
 import Cardano.CoinSelection.UTxOSelection
@@ -136,8 +136,6 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId, Lexicographic (..), TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessment (..) )
 import Control.Monad.Extra
     ( andM, (<=<) )
 import Control.Monad.Random.Class

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -203,12 +203,10 @@ import qualified Data.Set as Set
 --    - are not specific to a given selection.
 --
 data SelectionConstraints ctx = SelectionConstraints
-    { assessTokenBundleSize
-        :: TokenBundle -> TokenBundleSizeAssessment
+    { tokenBundleSizeAssessor
+        :: TokenBundleSizeAssessor
         -- ^ Assesses the size of a token bundle relative to the upper limit of
-        -- what can be included in a transaction output. See documentation for
-        -- the 'TokenBundleSizeAssessor' type to learn about the expected
-        -- properties of this field.
+        -- what can be included in a transaction output.
     , computeMinimumAdaQuantity
         :: Address ctx -> TokenMap -> Coin
         -- ^ Computes the minimum ada quantity required for a given output.
@@ -822,7 +820,7 @@ performSelectionNonEmpty constraints params
                 makeChangeRepeatedly selection
   where
     SelectionConstraints
-        { assessTokenBundleSize
+        { tokenBundleSizeAssessor
         , computeMinimumAdaQuantity
         , computeMinimumCost
         , maximumOutputAdaQuantity
@@ -882,7 +880,7 @@ performSelectionNonEmpty constraints params
         (fmap (TokenMap.getAssets . view #tokens))
         (makeChange MakeChangeCriteria
             { minCoinFor = noMinimumCoin
-            , bundleSizeAssessor = TokenBundleSizeAssessor assessTokenBundleSize
+            , bundleSizeAssessor = tokenBundleSizeAssessor
             , requiredCost = noCost
             , extraCoinSource
             , extraCoinSink
@@ -965,7 +963,7 @@ performSelectionNonEmpty constraints params
         mChangeGenerated :: Either UnableToConstructChangeError [TokenBundle]
         mChangeGenerated = makeChange MakeChangeCriteria
             { minCoinFor = computeMinimumAdaQuantity maximumLengthChangeAddress
-            , bundleSizeAssessor = TokenBundleSizeAssessor assessTokenBundleSize
+            , bundleSizeAssessor = tokenBundleSizeAssessor
             , requiredCost
             , extraCoinSource
             , extraCoinSink

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -120,6 +120,8 @@ import Algebra.PartialOrd
     ( PartialOrd (..) )
 import Cardano.CoinSelection.Context
     ( SelectionContext (..) )
+import Cardano.CoinSelection.Size
+    ( TokenBundleSizeAssessor (..) )
 import Cardano.CoinSelection.UTxOIndex
     ( Asset (..), SelectionFilter (..), UTxOIndex (..) )
 import Cardano.CoinSelection.UTxOSelection
@@ -135,7 +137,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessment (..), TokenBundleSizeAssessor (..) )
+    ( TokenBundleSizeAssessment (..) )
 import Control.Monad.Extra
     ( andM, (<=<) )
 import Control.Monad.Random.Class

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Size.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Size.hs
@@ -9,15 +9,16 @@
 --
 module Cardano.CoinSelection.Size
     ( TokenBundleSizeAssessor (..)
+    , TokenBundleSizeAssessment (..)
     )
     where
 
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessment (..) )
 import GHC.Generics
     ( Generic )
+
+import Prelude
 
 -- | A function capable of assessing the size of a token bundle relative to the
 --   upper limit of what can be included in a single transaction output.
@@ -43,3 +44,15 @@ newtype TokenBundleSizeAssessor = TokenBundleSizeAssessor
     { assessTokenBundleSize :: TokenBundle -> TokenBundleSizeAssessment
     }
     deriving Generic
+
+-- | Indicates the size of a token bundle relative to the upper limit of what
+--   can be included in a single transaction output.
+--
+data TokenBundleSizeAssessment
+    = TokenBundleSizeWithinLimit
+    -- ^ Indicates that the size of a token bundle does not exceed the maximum
+    -- size that can be included in a transaction output.
+    | TokenBundleSizeExceedsLimit
+    -- ^ Indicates that the size of a token bundle exceeds the maximum size
+    -- that can be included in a transaction output.
+    deriving (Eq, Generic, Show)

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Size.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Size.hs
@@ -1,0 +1,10 @@
+-- |
+-- Copyright: © 2023 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Types and functions relating to the coin selection algorithm's abstract size
+-- model.
+--
+module Cardano.CoinSelection.Size
+    ()
+    where

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Size.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Size.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 -- |
 -- Copyright: © 2023 Cardano Foundation
 -- License: Apache-2.0
@@ -6,5 +8,38 @@
 -- model.
 --
 module Cardano.CoinSelection.Size
-    ()
+    ( TokenBundleSizeAssessor (..)
+    )
     where
+
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle (..) )
+import Cardano.Wallet.Primitive.Types.Tx.Constraints
+    ( TokenBundleSizeAssessment (..) )
+import GHC.Generics
+    ( Generic )
+
+-- | A function capable of assessing the size of a token bundle relative to the
+--   upper limit of what can be included in a single transaction output.
+--
+-- In general, a token bundle size assessment function 'f' should satisfy the
+-- following properties:
+--
+--    * Enlarging a bundle that exceeds the limit should also result in a
+--      bundle that exceeds the limit:
+--      @
+--              f  b1           == TokenBundleSizeExceedsLimit
+--          ==> f (b1 `add` b2) == TokenBundleSizeExceedsLimit
+--      @
+--
+--    * Shrinking a bundle that's within the limit should also result in a
+--      bundle that's within the limit:
+--      @
+--              f  b1                  == TokenBundleWithinLimit
+--          ==> f (b1 `difference` b2) == TokenBundleWithinLimit
+--      @
+--
+newtype TokenBundleSizeAssessor = TokenBundleSizeAssessor
+    { assessTokenBundleSize :: TokenBundle -> TokenBundleSizeAssessment
+    }
+    deriving Generic

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -99,7 +99,7 @@ import Cardano.CoinSelection.Balance
 import Cardano.CoinSelection.Balance.Gen
     ( genSelectionStrategy, shrinkSelectionStrategy )
 import Cardano.CoinSelection.Size
-    ( TokenBundleSizeAssessor (..) )
+    ( TokenBundleSizeAssessment (..), TokenBundleSizeAssessor (..) )
 import Cardano.CoinSelection.UTxOIndex
     ( Asset (..), SelectionFilter (..), UTxOIndex )
 import Cardano.CoinSelection.UTxOIndex.Gen
@@ -140,8 +140,6 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantityPositive, shrinkTokenQuantityPositive )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessment (..) )
 import Control.Monad
     ( forM_, replicateM )
 import Data.Bifunctor

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -98,6 +98,8 @@ import Cardano.CoinSelection.Balance
     )
 import Cardano.CoinSelection.Balance.Gen
     ( genSelectionStrategy, shrinkSelectionStrategy )
+import Cardano.CoinSelection.Size
+    ( TokenBundleSizeAssessor (..) )
 import Cardano.CoinSelection.UTxOIndex
     ( Asset (..), SelectionFilter (..), UTxOIndex )
 import Cardano.CoinSelection.UTxOIndex.Gen
@@ -139,7 +141,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantityPositive, shrinkTokenQuantityPositive )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessment (..), TokenBundleSizeAssessor (..) )
+    ( TokenBundleSizeAssessment (..) )
 import Control.Monad
     ( forM_, replicateM )
 import Data.Bifunctor

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -985,7 +985,7 @@ prop_performSelection mockConstraints params coverage =
         --
         let constraints' =
                 constraints
-                    { assessTokenBundleSize = unMockAssessTokenBundleSize
+                    { tokenBundleSizeAssessor = unMockAssessTokenBundleSize
                         MockAssessTokenBundleSizeUnlimited
                     , computeMinimumAdaQuantity =
                         const computeMinimumAdaQuantityZero
@@ -1745,7 +1745,7 @@ mkBoundaryTestExpectation (BoundaryTestData params expectedResult) = do
     constraints = SelectionConstraints
         { computeMinimumAdaQuantity = const computeMinimumAdaQuantityZero
         , computeMinimumCost = computeMinimumCostZero
-        , assessTokenBundleSize = unMockAssessTokenBundleSize $
+        , tokenBundleSizeAssessor = unMockAssessTokenBundleSize $
             boundaryTestBundleSizeAssessor params
         , maximumOutputAdaQuantity = testMaximumOutputAdaQuantity
         , maximumOutputTokenQuantity = testMaximumOutputTokenQuantity
@@ -2367,7 +2367,7 @@ unMockSelectionConstraints
     :: MockSelectionConstraints
     -> SelectionConstraints TestSelectionContext
 unMockSelectionConstraints m = SelectionConstraints
-    { assessTokenBundleSize =
+    { tokenBundleSizeAssessor =
         unMockAssessTokenBundleSize $ view #assessTokenBundleSize m
     , computeMinimumAdaQuantity =
         unMockComputeMinimumAdaQuantity $ view #computeMinimumAdaQuantity m
@@ -2514,8 +2514,8 @@ shrinkMockAssessTokenBundleSize = \case
             <$> shrink (Positive n)
 
 unMockAssessTokenBundleSize
-    :: MockAssessTokenBundleSize -> (TokenBundle -> TokenBundleSizeAssessment)
-unMockAssessTokenBundleSize = \case
+    :: MockAssessTokenBundleSize -> TokenBundleSizeAssessor
+unMockAssessTokenBundleSize = TokenBundleSizeAssessor . \case
     MockAssessTokenBundleSizeUnlimited ->
         const TokenBundleSizeWithinLimit
     MockAssessTokenBundleSizeUpperLimit upperLimit ->
@@ -2528,8 +2528,7 @@ unMockAssessTokenBundleSize = \case
 
 mkTokenBundleSizeAssessor
     :: MockAssessTokenBundleSize -> TokenBundleSizeAssessor
-mkTokenBundleSizeAssessor =
-    TokenBundleSizeAssessor . unMockAssessTokenBundleSize
+mkTokenBundleSizeAssessor = unMockAssessTokenBundleSize
 
 --------------------------------------------------------------------------------
 -- Making change

--- a/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
@@ -408,7 +408,7 @@ shrinkMockSelectionConstraints = genericRoundRobinShrink
 unMockSelectionConstraints
     :: MockSelectionConstraints -> SelectionConstraints TestSelectionContext
 unMockSelectionConstraints m = SelectionConstraints
-    { assessTokenBundleSize =
+    { tokenBundleSizeAssessor =
         unMockAssessTokenBundleSize $ view #assessTokenBundleSize m
     , computeMinimumAdaQuantity =
         unMockComputeMinimumAdaQuantity $ view #computeMinimumAdaQuantity m

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Constraints.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Constraints.hs
@@ -23,7 +23,6 @@ module Cardano.Wallet.Primitive.Types.Tx.Constraints
     , txOutputHasValidTokenQuantities
     , TxSize (..)
     , txSizeDistance
-    , TokenBundleSizeAssessor (..)
     , TokenBundleSizeAssessment (..)
     , txOutMinCoin
     , txOutMaxCoin
@@ -152,31 +151,6 @@ txSizeDistance (TxSize a) (TxSize b)
 --
 -- Transaction outputs have a maximum size, defined by the protocol.
 --------------------------------------------------------------------------------
-
--- | A function capable of assessing the size of a token bundle relative to the
---   upper limit of what can be included in a single transaction output.
---
--- In general, a token bundle size assessment function 'f' should satisfy the
--- following properties:
---
---    * Enlarging a bundle that exceeds the limit should also result in a
---      bundle that exceeds the limit:
---      @
---              f  b1           == TokenBundleSizeExceedsLimit
---          ==> f (b1 `add` b2) == TokenBundleSizeExceedsLimit
---      @
---
---    * Shrinking a bundle that's within the limit should also result in a
---      bundle that's within the limit:
---      @
---              f  b1                  == TokenBundleWithinLimit
---          ==> f (b1 `difference` b2) == TokenBundleWithinLimit
---      @
---
-newtype TokenBundleSizeAssessor = TokenBundleSizeAssessor
-    { assessTokenBundleSize :: TokenBundle -> TokenBundleSizeAssessment
-    }
-    deriving Generic
 
 -- | Indicates the size of a token bundle relative to the upper limit of what
 --   can be included in a single transaction output, defined by the protocol.

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Constraints.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Constraints.hs
@@ -23,7 +23,6 @@ module Cardano.Wallet.Primitive.Types.Tx.Constraints
     , txOutputHasValidTokenQuantities
     , TxSize (..)
     , txSizeDistance
-    , TokenBundleSizeAssessment (..)
     , txOutMinCoin
     , txOutMaxCoin
     , txOutMinTokenQuantity
@@ -145,24 +144,6 @@ txSizeDistance :: TxSize -> TxSize -> TxSize
 txSizeDistance (TxSize a) (TxSize b)
     | a >= b    = TxSize (a - b)
     | otherwise = TxSize (b - a)
-
---------------------------------------------------------------------------------
--- Assessing the sizes of token bundles in the context of transaction outputs.
---
--- Transaction outputs have a maximum size, defined by the protocol.
---------------------------------------------------------------------------------
-
--- | Indicates the size of a token bundle relative to the upper limit of what
---   can be included in a single transaction output, defined by the protocol.
---
-data TokenBundleSizeAssessment
-    = TokenBundleSizeWithinLimit
-    -- ^ Indicates that the size of a token bundle does not exceed the maximum
-    -- size that can be included in a transaction output.
-    | TokenBundleSizeExceedsLimit
-    -- ^ Indicates that the size of a token bundle exceeds the maximum size
-    -- that can be included in a transaction output.
-    deriving (Eq, Generic, Show)
 
 --------------------------------------------------------------------------------
 -- Constants

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -708,6 +708,7 @@ test-suite unit
     , cardano-api
     , cardano-balance-tx
     , cardano-binary
+    , cardano-coin-selection
     , cardano-crypto
     , cardano-crypto-class
     , cardano-crypto-wrapper

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -200,7 +200,7 @@ import Cardano.Chain.Block
 import Cardano.Chain.UTxO
     ( unTxPayload )
 import Cardano.CoinSelection.Size
-    ( TokenBundleSizeAssessor (..) )
+    ( TokenBundleSizeAssessment (..), TokenBundleSizeAssessor (..) )
 import Cardano.Crypto.Hash.Class
     ( Hash (UnsafeHash), hashToBytes )
 import Cardano.Launcher.Node
@@ -248,8 +248,6 @@ import Cardano.Wallet.Primitive.Types
     , TokenBundleMaxSize (..)
     , TxParameters (getTokenBundleMaxSize)
     )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessment (..) )
 import Cardano.Wallet.Read.Primitive.Tx.Allegra
     ( fromAllegraTx )
 import Cardano.Wallet.Read.Primitive.Tx.Alonzo

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -199,6 +199,8 @@ import Cardano.Chain.Block
     ( ABlockOrBoundary (ABOBBlock, ABOBBoundary), blockTxPayload )
 import Cardano.Chain.UTxO
     ( unTxPayload )
+import Cardano.CoinSelection.Size
+    ( TokenBundleSizeAssessor (..) )
 import Cardano.Crypto.Hash.Class
     ( Hash (UnsafeHash), hashToBytes )
 import Cardano.Launcher.Node
@@ -247,7 +249,7 @@ import Cardano.Wallet.Primitive.Types
     , TxParameters (getTokenBundleMaxSize)
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessment (..), TokenBundleSizeAssessor (..) )
+    ( TokenBundleSizeAssessment (..) )
 import Cardano.Wallet.Read.Primitive.Tx.Allegra
     ( fromAllegraTx )
 import Cardano.Wallet.Read.Primitive.Tx.Alonzo

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -874,10 +874,8 @@ selectAssets era (ProtocolParameters pp) utxoAssumptions outs redeemers
         $ performSelection selectionConstraints selectionParams
 
     selectionConstraints = SelectionConstraints
-        { assessTokenBundleSize =
-            mkTokenBundleSizeAssessor
-                (getTokenBundleMaxSize era pp)
-                    ^. #assessTokenBundleSize
+        { tokenBundleSizeAssessor =
+            mkTokenBundleSizeAssessor (getTokenBundleMaxSize era pp)
         , computeMinimumAdaQuantity = \addr tokens -> W.toWallet $
             computeMinimumCoinForTxOut
                 era
@@ -1476,7 +1474,8 @@ validateTxOutputSize cs out = case sizeAssessment of
         Just $ ErrBalanceTxOutputSizeExceedsLimitError out
   where
     sizeAssessment :: TokenBundleSizeAssessment
-    sizeAssessment = (cs ^. #assessTokenBundleSize) (snd out)
+    sizeAssessment =
+        (cs ^. (#tokenBundleSizeAssessor . #assessTokenBundleSize)) (snd out)
 
 -- | Validates the token quantities of a transaction output.
 --

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -75,6 +75,8 @@ module Cardano.Wallet.Write.Tx.Balance
 
 import Prelude
 
+import Cardano.CoinSelection.Size
+    ( TokenBundleSizeAssessment (..) )
 import Cardano.CoinSelection.UTxOSelection
     ( UTxOSelection )
 import Cardano.Ledger.Alonzo.Core
@@ -109,11 +111,7 @@ import Cardano.Tx.Balance.Internal.CoinSelection
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx, sealedTxFromCardano )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessment (..)
-    , TxSize (..)
-    , txOutMaxCoin
-    , txOutMaxTokenQuantity
-    )
+    ( TxSize (..), txOutMaxCoin, txOutMaxTokenQuantity )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     ( fromCardanoValue )
 import Cardano.Wallet.Write.ProtocolParameters

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -146,7 +146,7 @@ import Cardano.Wallet.Write.Tx
     , withConstraints
     )
 import Cardano.Wallet.Write.Tx.Balance.TokenBundleSize
-    ( getTokenBundleMaxSize, tokenBundleSizeAssessor )
+    ( getTokenBundleMaxSize, mkTokenBundleSizeAssessor )
 import Cardano.Wallet.Write.Tx.Redeemers
     ( ErrAssignRedeemers (..), Redeemer (..), assignScriptRedeemers )
 import Cardano.Wallet.Write.Tx.Sign
@@ -877,9 +877,9 @@ selectAssets era (ProtocolParameters pp) utxoAssumptions outs redeemers
 
     selectionConstraints = SelectionConstraints
         { assessTokenBundleSize =
-                tokenBundleSizeAssessor
-                    (getTokenBundleMaxSize era pp)
-                        ^. #assessTokenBundleSize
+            mkTokenBundleSizeAssessor
+                (getTokenBundleMaxSize era pp)
+                    ^. #assessTokenBundleSize
         , computeMinimumAdaQuantity = \addr tokens -> W.toWallet $
             computeMinimumCoinForTxOut
                 era

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/TokenBundleSize.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/TokenBundleSize.hs
@@ -6,7 +6,7 @@ module Cardano.Wallet.Write.Tx.Balance.TokenBundleSize
     ( TokenBundleSizeAssessor (..)
     , TokenBundleMaxSize (..)
     , computeTokenBundleSerializedLengthBytes
-    , tokenBundleSizeAssessor
+    , mkTokenBundleSizeAssessor
     , getTokenBundleMaxSize
     )
     where
@@ -52,8 +52,8 @@ instance NFData TokenBundleMaxSize
 --
 -- See 'W.TokenBundleSizeAssessor' for the expected properties of this function.
 --
-tokenBundleSizeAssessor :: TokenBundleMaxSize -> TokenBundleSizeAssessor
-tokenBundleSizeAssessor maxSize =
+mkTokenBundleSizeAssessor :: TokenBundleMaxSize -> TokenBundleSizeAssessor
+mkTokenBundleSizeAssessor maxSize =
     TokenBundleSizeAssessor { assessTokenBundleSize }
   where
     assessTokenBundleSize tb

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/TokenBundleSize.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/TokenBundleSize.hs
@@ -14,13 +14,13 @@ module Cardano.Wallet.Write.Tx.Balance.TokenBundleSize
 import Prelude
 
 import Cardano.CoinSelection.Size
-    ( TokenBundleSizeAssessor (..) )
+    ( TokenBundleSizeAssessment (..), TokenBundleSizeAssessor (..) )
 import Cardano.Ledger.Api
     ( ppMaxValSizeL )
 import Cardano.Ledger.Binary
     ( serialize', shelleyProtVer )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessment (..), TxSize (..) )
+    ( TxSize (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( toCardanoValue )
 import Cardano.Wallet.Write.Tx

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/TokenBundleSize.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance/TokenBundleSize.hs
@@ -13,15 +13,14 @@ module Cardano.Wallet.Write.Tx.Balance.TokenBundleSize
 
 import Prelude
 
+import Cardano.CoinSelection.Size
+    ( TokenBundleSizeAssessor (..) )
 import Cardano.Ledger.Api
     ( ppMaxValSizeL )
 import Cardano.Ledger.Binary
     ( serialize', shelleyProtVer )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessment (..)
-    , TokenBundleSizeAssessor (..)
-    , TxSize (..)
-    )
+    ( TokenBundleSizeAssessment (..), TxSize (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( toCardanoValue )
 import Cardano.Wallet.Write.Tx

--- a/lib/wallet/test/unit/Cardano/Wallet/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -4,12 +4,14 @@ module Cardano.Wallet.Write.Tx.Balance.TokenBundleSizeSpec where
 
 import Prelude
 
+import Cardano.CoinSelection.Size
+    ( TokenBundleSizeAssessment (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundle, genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TokenBundleSizeAssessment (..), TxSize (..), txOutMaxCoin, txOutMinCoin )
+    ( TxSize (..), txOutMaxCoin, txOutMinCoin )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     ( genTxOutTokenBundle )
 import Cardano.Wallet.Write.Tx.Balance.TokenBundleSize

--- a/lib/wallet/test/unit/Cardano/Wallet/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -16,7 +16,7 @@ import Cardano.Wallet.Write.Tx.Balance.TokenBundleSize
     ( TokenBundleMaxSize (TokenBundleMaxSize)
     , assessTokenBundleSize
     , computeTokenBundleSerializedLengthBytes
-    , tokenBundleSizeAssessor
+    , mkTokenBundleSizeAssessor
     )
 import Cardano.Wallet.Write.Tx.Balance.TokenBundleSize.Gen
     ( genTokenBundleMaxSize, shrinkTokenBundleMaxSize )
@@ -72,7 +72,7 @@ prop_assessTokenBundleSize_enlarge b1' b2' =
         ]
   where
     assess = assessTokenBundleSize
-        $ tokenBundleSizeAssessor maryTokenBundleMaxSize
+        $ mkTokenBundleSizeAssessor maryTokenBundleMaxSize
     b1 = unVariableSize1024 $ getBlind b1'
     b2 = unVariableSize16 $ getBlind b2'
 
@@ -92,7 +92,7 @@ prop_assessTokenBundleSize_shrink b1' b2' maxSize =
             === TokenBundleSizeWithinLimit
         ]
   where
-    assess = assessTokenBundleSize (tokenBundleSizeAssessor maxSize)
+    assess = assessTokenBundleSize (mkTokenBundleSizeAssessor maxSize)
     b1 = unVariableSize1024 $ getBlind b1'
     b2 = unVariableSize16 $ getBlind b2'
 
@@ -128,7 +128,7 @@ unit_assessTokenBundleSize_fixedSizeBundle
             ]
   where
     actualAssessment = assessTokenBundleSize
-        (tokenBundleSizeAssessor maxSize)
+        (mkTokenBundleSizeAssessor maxSize)
         bundle
     actualLengthBytes = computeTokenBundleSerializedLengthBytes bundle
     counterexampleText = unlines


### PR DESCRIPTION
## Issue

ADP-3136

## Summary

This PR tidies the `TokenBundleSizeAssessor` API.

## Details

The `TokenBundleSize{Assessor,Assessment}` types are part of the coin selection API. These types provide the coin selection algorithm with a simple way to determine whether or not a given token bundle is excessively sized (and in need of partitioning into smaller bundles) without introducing a dependency on ledger functions and types. The caller of coin selection must supply a lawful implementation of `TokenBundleSizeAssessor` (as specified by the documentation for this type).

This PR moves the `TokenBundleSize{Assessor,Assessment}` types out of the `cardano-wallet-primitive` library and into the `cardano-coin-selection` library, where they really belong.

In addition, this PR makes the following simplification to the `SelectionConstraints` type(s):
```patch
  data SelectionConstraints = SelectionConstraints
-     { assessTokenBundleSize
-         :: TokenBundle -> TokenBundleSizeAssessment
+     { tokenBundleSizeAssessor
+         :: TokenBundleSizeAssessor
          -- ^ Assesses the size of a token bundle relative to the upper
          -- limit of what can be included in a transaction output.
-         -- See documentation for the 'TokenBundleSizeAssessor' type to
-         -- to learn about the expected properties of this field.
      }
```
As a result, the "see documentation" section is no longer necessary, because the `TokenBundleSizeAssessor` type is self-documenting.