### PR TITLE
Use marginal subtractions in definition of `txConstraints`.

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Constraints.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Constraints.hs
@@ -131,12 +131,9 @@ newtype TxSize = TxSize { unTxSize :: Natural }
     deriving stock (Eq, Ord, Generic)
     deriving Show via (Quiet TxSize)
     deriving Num via Natural
-    deriving Semigroup via Sum Natural
+    deriving (Semigroup, Monoid) via Sum Natural
 
 instance NFData TxSize
-
-instance Monoid TxSize where
-    mempty = TxSize 0
 
 -- | Computes the absolute distance between two transaction size quantities.
 --

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Constraints.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Constraints.hs
@@ -49,6 +49,16 @@ import Data.Int
     ( Int64 )
 import Data.Monoid
     ( Sum (..) )
+import Data.Monoid.Cancellative
+    ( LeftReductive, Reductive, RightReductive )
+import Data.Monoid.GCD
+    ( GCDMonoid, LeftGCDMonoid, RightGCDMonoid )
+import Data.Monoid.Monus
+    ( Monus, OverlappingGCDMonoid )
+import Data.Monoid.Null
+    ( MonoidNull )
+import Data.Semigroup.Commutative
+    ( Commutative )
 import Data.Word
     ( Word64 )
 import GHC.Generics
@@ -131,7 +141,10 @@ newtype TxSize = TxSize { unTxSize :: Natural }
     deriving stock (Eq, Ord, Generic)
     deriving Show via (Quiet TxSize)
     deriving Num via Natural
-    deriving (Semigroup, Monoid) via Sum Natural
+    deriving (Commutative, Semigroup, Monoid, MonoidNull) via Sum Natural
+    deriving (LeftReductive, RightReductive, Reductive) via Sum Natural
+    deriving (LeftGCDMonoid, RightGCDMonoid, GCDMonoid) via Sum Natural
+    deriving (OverlappingGCDMonoid, Monus) via Sum Natural
 
 instance NFData TxSize
 

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Constraints.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Constraints.hs
@@ -22,7 +22,6 @@ module Cardano.Wallet.Primitive.Types.Tx.Constraints
     , txOutputHasValidSize
     , txOutputHasValidTokenQuantities
     , TxSize (..)
-    , txSizeDistance
     , txOutMinCoin
     , txOutMaxCoin
     , txOutMinTokenQuantity
@@ -147,13 +146,6 @@ newtype TxSize = TxSize { unTxSize :: Natural }
     deriving (OverlappingGCDMonoid, Monus) via Sum Natural
 
 instance NFData TxSize
-
--- | Computes the absolute distance between two transaction size quantities.
---
-txSizeDistance :: TxSize -> TxSize -> TxSize
-txSizeDistance (TxSize a) (TxSize b)
-    | a >= b    = TxSize (a - b)
-    | otherwise = TxSize (b - a)
 
 --------------------------------------------------------------------------------
 -- Constants

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Constraints.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Constraints.hs
@@ -47,6 +47,8 @@ import Control.DeepSeq
     ( NFData (..) )
 import Data.Int
     ( Int64 )
+import Data.Monoid
+    ( Sum (..) )
 import Data.Word
     ( Word64 )
 import GHC.Generics
@@ -129,11 +131,9 @@ newtype TxSize = TxSize { unTxSize :: Natural }
     deriving stock (Eq, Ord, Generic)
     deriving Show via (Quiet TxSize)
     deriving Num via Natural
+    deriving Semigroup via Sum Natural
 
 instance NFData TxSize
-
-instance Semigroup TxSize where
-    TxSize a <> TxSize b = TxSize (a + b)
 
 instance Monoid TxSize where
     mempty = TxSize 0

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -777,6 +777,7 @@ test-suite unit
     , memory
     , mock-token-metadata
     , MonadRandom
+    , monoid-subclasses
     , mtl
     , network
     , network-uri

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -143,6 +143,7 @@ library
     , monad-control
     , monad-logger
     , MonadRandom
+    , monoid-subclasses
     , mtl
     , network
     , network-mux

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/SizeEstimation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/SizeEstimation.hs
@@ -230,9 +230,8 @@ txConstraints (ProtocolParameters protocolParams) witnessTag = TxConstraints
     -- skeleton.
     marginalCostOf :: TxSkeleton -> Coin
     marginalCostOf skeleton =
-        Coin.distance
-            (estimateTxCost feePerByte empty)
-            (estimateTxCost feePerByte skeleton)
+        estimateTxCost feePerByte skeleton <\>
+        estimateTxCost feePerByte empty
 
     -- Computes the size difference between the given skeleton and an empty
     -- skeleton.

--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/SizeEstimation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/SizeEstimation.hs
@@ -62,7 +62,7 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TxConstraints (..), TxSize (..), txOutMaxCoin, txSizeDistance )
+    ( TxConstraints (..), TxSize (..), txOutMaxCoin )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( Convert (..) )
 import Cardano.Wallet.TxWitnessTag
@@ -88,6 +88,8 @@ import Data.Generics.Internal.VL.Lens
     ( view )
 import Data.Generics.Labels
     ()
+import Data.Monoid.Monus
+    ( Monus ((<\>)) )
 import Data.Set
     ( Set )
 import Data.Word
@@ -236,7 +238,7 @@ txConstraints (ProtocolParameters protocolParams) witnessTag = TxConstraints
     -- skeleton.
     marginalSizeOf :: TxSkeleton -> TxSize
     marginalSizeOf =
-        txSizeDistance txBaseSize . estimateTxSize
+        (<\> txBaseSize) . estimateTxSize
 
     -- Constructs a real transaction output from a token bundle.
     mkTxOut :: TokenBundle -> W.TxOut


### PR DESCRIPTION
## Issue

ADP-3141

## Summary

This PR:
- replaces the absolute distance calculations in `Write.Tx.SizeEstimation.txConstraints.marginal{Cost,Size}Of` with true marginal subtractions.
- replaces other usages of `txSizeDistance` with true marginal subtractions.
- removes the `txSizeDistance` function, which is now unused.