### PR TITLE
Revise qualified imports in `UTxOIndex`.

### DIFF
--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
@@ -106,8 +106,6 @@ module Cardano.CoinSelection.UTxOIndex.Internal
 import Prelude hiding
     ( filter, lookup, null )
 
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId )
 import Control.DeepSeq
     ( NFData )
 import Control.Monad.Extra
@@ -139,6 +137,8 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle )
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
+    ( AssetId )
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
@@ -499,7 +499,7 @@ selectRandomWithPriority i =
 --
 data Asset
     = AssetLovelace
-    | Asset AssetId
+    | Asset W.AssetId
     deriving (Eq, Generic, Ord, Read, Show)
 
 deriving instance NFData Asset

--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
@@ -136,7 +136,7 @@ import GHC.Generics
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle )
-import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as W.TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
     ( AssetId )
 import qualified Data.Foldable as F
@@ -528,7 +528,7 @@ tokenBundleAssets b = Set.union
 tokenBundleAssetCount :: W.TokenBundle -> Int
 tokenBundleAssetCount b = (+)
     (if W.TokenBundle.coin b /= mempty then 1 else 0)
-    (TokenMap.size (W.TokenBundle.tokens b))
+    (W.TokenMap.size (W.TokenBundle.tokens b))
 
 -- | Indicates whether or not a given bundle includes a given asset.
 --


### PR DESCRIPTION
## Issue

ADP-1419

## Description

This PR revises `UTxOIndex` so that types (and related functions) from `cardano-wallet-primitive` are always prefixed with the `W` qualifier.