### PR TITLE
Replace `over` with ordinary record updates in `UTxOIndex`

### DIFF
--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
@@ -582,7 +582,7 @@ insertUnsafe
 insertUnsafe u b i = i
     & over #balance (`W.TokenBundle.add` b)
     & over #universe (Map.insert u b)
-    & case categorizeTokenBundle b of
+    & case bundleCategory of
         BundleWithNoAssets -> id
         BundleWithOneAsset a -> id
             . over #indexAll (`insertEntry` a)
@@ -595,6 +595,9 @@ insertUnsafe u b i = i
         BundleWithMultipleAssets as -> id
             . over #indexAll (flip (F.foldl' insertEntry) as)
   where
+    bundleCategory :: BundleCategory Asset
+    bundleCategory = categorizeTokenBundle b
+
     insertEntry
         :: Ord asset
         => MonoidMap asset (Set u)

--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
@@ -309,7 +309,7 @@ delete u i =
         -- greater than or equal to the value of this output:
         & over #balance (`W.TokenBundle.difference` b)
         & over #universe (Map.delete u)
-        & case categorizeTokenBundle b of
+        & case bundleCategory of
             BundleWithNoAssets -> id
             BundleWithOneAsset a -> id
                 . over #indexAll (`deleteEntry` a)
@@ -321,6 +321,9 @@ delete u i =
                 . over #indexPairs (`deleteEntry` a2)
             BundleWithMultipleAssets as -> id
                 . over #indexAll (flip (F.foldl' deleteEntry) as)
+      where
+        bundleCategory :: BundleCategory Asset
+        bundleCategory = categorizeTokenBundle b
 
     deleteEntry
         :: Ord asset


### PR DESCRIPTION
## Issue

ADP-1419

## Description

This PR replaces the use of `over` (from `generic-lens`) with ordinary Haskell record updates in the `insert` and `delete` functions of `UTxOIndex`.

## Performance

This has no significant impact on performance.

Average time to run the `utxo-index` bench  compiled with `-O1` over 10 consecutive runs:
```
Before: 10.1 s
After:  10.0 s
```