### PR TITLE
Use monoidal arithmetic in `cardano-coin-selection`.

### DIFF
--- a/lib/coin-selection/cardano-coin-selection.cabal
+++ b/lib/coin-selection/cardano-coin-selection.cabal
@@ -54,6 +54,7 @@ library
     , lattices
     , math-functions
     , MonadRandom
+    , monoid-subclasses
     , monoidmap
     , QuickCheck
     , transformers
@@ -94,6 +95,7 @@ test-suite test
     , int-cast
     , lattices
     , MonadRandom
+    , monoid-subclasses
     , pretty-simple
     , QuickCheck
     , quickcheck-classes

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -575,7 +575,7 @@ selectionHasValidSurplus constraints selection =
     -- None of the non-ada assets can have a surplus.
     surplusHasNoNonAdaAssets :: TokenBundle -> Bool
     surplusHasNoNonAdaAssets surplus =
-        view #tokens surplus == TokenMap.empty
+        view #tokens surplus == mempty
 
     -- The surplus must not be less than the minimum cost.
     surplusNotBelowMinimumCost :: TokenBundle -> Bool
@@ -1416,7 +1416,7 @@ makeChange criteria
     changeForUserSpecifiedAssets = F.foldr
         (NE.zipWith (<>)
             . makeChangeForUserSpecifiedAsset outputMaps)
-        (TokenMap.empty <$ outputMaps)
+        (mempty <$ outputMaps)
         excessAssets
 
     -- Change for non-user-specified assets: assets that were not present
@@ -1697,7 +1697,7 @@ makeChangeForNonUserSpecifiedAssets
 makeChangeForNonUserSpecifiedAssets n nonUserSpecifiedAssetQuantities =
     F.foldr
         (NE.zipWith (<>) . makeChangeForNonUserSpecifiedAsset n)
-        (TokenMap.empty <$ n)
+        (mempty <$ n)
         (Map.toList nonUserSpecifiedAssetQuantities)
 
 -- | Constructs a list of ada change outputs based on the given distribution.

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -160,6 +160,8 @@ import Data.Map.Strict
     ( Map )
 import Data.Maybe
     ( fromMaybe )
+import Data.Monoid.Monus
+    ( Monus ((<\>)) )
 import Data.Ord
     ( comparing )
 import Data.Semigroup
@@ -375,9 +377,9 @@ computeDeficitInOut params =
     (deficitIn, deficitOut)
   where
     deficitIn =
-        TokenBundle.difference balanceOut balanceIn
+        balanceOut <\> balanceIn
     deficitOut =
-        TokenBundle.difference balanceIn balanceOut
+        balanceIn <\> balanceOut
     (balanceIn, balanceOut) =
         computeBalanceInOut params
 
@@ -406,8 +408,8 @@ computeUTxOBalanceSufficiencyInfo params =
         else UTxOBalanceInsufficient
     difference =
         if sufficiency == UTxOBalanceSufficient
-        then TokenBundle.difference available required
-        else TokenBundle.difference required available
+        then available <\> required
+        else required <\> available
 
 -- | Indicates whether or not the UTxO balance is sufficient.
 --
@@ -516,9 +518,9 @@ selectionDeltaAllAssets
     :: Foldable f => SelectionResultOf f ctx -> SelectionDelta TokenBundle
 selectionDeltaAllAssets result
     | balanceOut `leq` balanceIn =
-        SelectionSurplus $ TokenBundle.difference balanceIn balanceOut
+        SelectionSurplus $ balanceIn <\> balanceOut
     | otherwise =
-        SelectionDeficit $ TokenBundle.difference balanceOut balanceIn
+        SelectionDeficit $ balanceOut <\> balanceIn
   where
     balanceIn =
         TokenBundle.fromTokenMap assetsToMint
@@ -675,7 +677,7 @@ mkBalanceInsufficientError utxoBalanceAvailable utxoBalanceRequired =
         }
   where
     utxoBalanceShortfall =
-        TokenBundle.difference utxoBalanceRequired utxoBalanceAvailable
+        utxoBalanceRequired <\> utxoBalanceAvailable
 
 data UnableToConstructChangeError = UnableToConstructChangeError
     { requiredCost
@@ -1336,7 +1338,7 @@ makeChange criteria
     -- that the total input value is greater than the total output
     -- value:
     excess :: TokenBundle
-    excess = totalInputValue `TokenBundle.difference` totalOutputValue
+    excess = totalInputValue <\> totalOutputValue
 
     (excessCoin, excessAssets) = TokenBundle.toFlatList excess
 

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -360,13 +360,13 @@ computeBalanceInOut params =
   where
     balanceIn =
         TokenBundle.fromTokenMap (view #assetsToMint params)
-        `TokenBundle.add`
+        <>
         TokenBundle.fromCoin (view #extraCoinSource params)
     balanceOut =
         TokenBundle.fromTokenMap (view #assetsToBurn params)
-        `TokenBundle.add`
+        <>
         TokenBundle.fromCoin (view #extraCoinSink params)
-        `TokenBundle.add`
+        <>
         F.foldMap snd (view #outputsToCover params)
 
 computeDeficitInOut
@@ -522,17 +522,17 @@ selectionDeltaAllAssets result
   where
     balanceIn =
         TokenBundle.fromTokenMap assetsToMint
-        `TokenBundle.add`
+        <>
         TokenBundle.fromCoin extraCoinSource
-        `TokenBundle.add`
+        <>
         F.foldMap snd inputsSelected
     balanceOut =
         TokenBundle.fromTokenMap assetsToBurn
-        `TokenBundle.add`
+        <>
         TokenBundle.fromCoin extraCoinSink
-        `TokenBundle.add`
+        <>
         F.foldMap snd outputsCovered
-        `TokenBundle.add`
+        <>
         F.fold changeGenerated
     SelectionResult
         { assetsToMint

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -166,6 +166,8 @@ import Data.Ord
     ( comparing )
 import Data.Semigroup
     ( mtimesDefault )
+import Data.Semigroup.Cancellative
+    ( Reductive ((</>)) )
 import Data.Set
     ( Set )
 import Fmt
@@ -1316,7 +1318,7 @@ makeChange criteria
         first mkUnableToConstructChangeError $ do
             adaAvailable <- maybeToEither
                 (requiredCost <\> excessCoin)
-                (excessCoin `Coin.subtract` requiredCost)
+                (excessCoin </> requiredCost)
             assignCoinsToChangeMaps
                 adaAvailable minCoinFor changeMapOutputCoinPairs
   where

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -744,7 +744,7 @@ performSelectionEmpty performSelectionFn constraints params =
         -> SelectionParamsOf NonEmpty ctx
     transformParams p@SelectionParams {..} = p
         { extraCoinSource =
-            transform (`Coin.add` dummyCoin) (const id) extraCoinSource
+            transform (<> dummyCoin) (const id) extraCoinSource
         , outputsToCover =
             transform (const (dummyOutput :| [])) (const . id) outputsToCover
         }

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -1963,8 +1963,8 @@ reduceTokenQuantities reductionTarget quantities =
         | x >= b = reverse ys <> (x' : xs)
         | otherwise = burn b' xs (x' : ys)
       where
-        b' = b `TokenQuantity.difference` x
-        x' = x `TokenQuantity.difference` b
+        b' = b <\> x
+        x' = x <\> b
 
 -- | Removes burned values for multiple assets from a list of change maps.
 --

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -756,7 +756,7 @@ performSelectionEmpty performSelectionFn constraints params =
         -> SelectionResultOf []       ctx
     transformResult r@SelectionResult {..} = r
         { extraCoinSource =
-            transform (`Coin.difference` dummyCoin) (const id) extraCoinSource
+            transform (<\> dummyCoin) (const id) extraCoinSource
         , outputsCovered =
             transform (const []) (const . F.toList) outputsCovered
         }
@@ -1315,7 +1315,7 @@ makeChange criteria
     | otherwise =
         first mkUnableToConstructChangeError $ do
             adaAvailable <- maybeToEither
-                (requiredCost `Coin.difference` excessCoin)
+                (requiredCost <\> excessCoin)
                 (excessCoin `Coin.subtract` requiredCost)
             assignCoinsToChangeMaps
                 adaAvailable minCoinFor changeMapOutputCoinPairs
@@ -1601,7 +1601,7 @@ assignCoinsToChangeMaps adaAvailable minCoinFor pairsAtStart
         _ ->
             -- We don't have enough ada available, and there are no empty token
             -- maps available to drop. We have to give up at this point.
-            Left (adaRequired `Coin.difference` adaAvailable)
+            Left (adaRequired <\> adaAvailable)
 
     adaRequiredAtStart = F.fold $ minCoinFor . fst <$> pairsAtStart
 

--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
@@ -577,7 +577,7 @@ insertUnsafe
     -> UTxOIndex u
     -> UTxOIndex u
 insertUnsafe u b i = i
-    { balance = balance i `W.TokenBundle.add` b
+    { balance = balance i <> b
     , universe = Map.insert u b (universe i)
     , indexAll = insertAssets (indexAll i)
     , indexSingletons = indexSingletons i &

--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
@@ -204,7 +204,7 @@ empty = UTxOIndex
     { indexAll = MonoidMap.empty
     , indexSingletons = MonoidMap.empty
     , indexPairs = MonoidMap.empty
-    , balance = W.TokenBundle.empty
+    , balance = mempty
     , universe = Map.empty
     }
 

--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
@@ -121,6 +121,8 @@ import Data.Map.Strict
     ( Map )
 import Data.Maybe
     ( isJust )
+import Data.Monoid.Monus
+    ( Monus ((<\>)) )
 import Data.MonoidMap
     ( MonoidMap )
 import Data.Set
@@ -299,7 +301,7 @@ delete u i =
   where
     updateIndex :: W.TokenBundle -> UTxOIndex u
     updateIndex b = i
-        { balance = balance i `W.TokenBundle.difference` b
+        { balance = balance i <\> b
         -- The above operation is safe, since we have already determined that
         -- the entry is a member of the index, and therefore the balance must
         -- be greater than or equal to the value of this output.

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -762,9 +762,8 @@ prop_performSelection_small mockConstraints (Blind (Small params)) =
 
     allMintedAssetsEitherBurnedOrSpent :: Bool
     allMintedAssetsEitherBurnedOrSpent =
-        view #assetsToMint params `leq` TokenMap.add
-            (view #assetsToBurn params)
-            (assetsSpentByUserSpecifiedOutputs)
+        view #assetsToMint params `leq`
+            (view #assetsToBurn params <> assetsSpentByUserSpecifiedOutputs)
 
     someAssetsAreBothMintedAndBurned :: Bool
     someAssetsAreBothMintedAndBurned

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -2802,9 +2802,7 @@ prop_makeChange_success_delta
     -> Property
 prop_makeChange_success_delta p change =
     let
-        totalOutputWithChange = TokenBundle.add
-            totalOutputValue
-            (F.fold change)
+        totalOutputWithChange = totalOutputValue <> F.fold change
 
         delta = TokenBundle.difference totalInputValue totalOutputWithChange
     in

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -1197,11 +1197,11 @@ prop_runSelection_UTxO_empty balanceRequested strategy = monadicIO $ do
         "utxoAvailable `UTxOSelection.isSubSelectionOf` result"
         (utxoAvailable `UTxOSelection.isSubSelectionOf` result)
     assertWith
-        "balanceSelected == TokenBundle.empty"
-        (balanceSelected == TokenBundle.empty)
+        "balanceSelected == mempty"
+        (balanceSelected == mempty)
     assertWith
-        "balanceLeftover == TokenBundle.empty"
-        (balanceLeftover == TokenBundle.empty)
+        "balanceLeftover == mempty"
+        (balanceLeftover == mempty)
   where
     utxoAvailable = UTxOSelection.fromIndex UTxOIndex.empty
 
@@ -1223,8 +1223,8 @@ prop_runSelection_UTxO_notEnough utxoAvailable strategy = monadicIO $ do
         "balanceSelected == balanceAvailable"
         (balanceSelected == balanceAvailable)
     assertWith
-        "balanceLeftover == TokenBundle.empty"
-        (balanceLeftover == TokenBundle.empty)
+        "balanceLeftover == mempty"
+        (balanceLeftover == mempty)
   where
     balanceAvailable = UTxOSelection.availableBalance utxoAvailable
     balanceRequested = adjustAllTokenBundleQuantities (* 2) balanceAvailable
@@ -1244,12 +1244,12 @@ prop_runSelection_UTxO_exactlyEnough utxoAvailable strategy = monadicIO $ do
         "utxoAvailable `UTxOSelection.isSubSelectionOf` result"
         (utxoAvailable `UTxOSelection.isSubSelectionOf` result)
     assertWith
-        "balanceLeftover == TokenBundle.empty"
-        (balanceLeftover == TokenBundle.empty)
+        "balanceLeftover == mempty"
+        (balanceLeftover == mempty)
     if utxoAvailable == UTxOSelection.empty then
         assertWith
-            "balanceSelected == TokenBundle.empty"
-            (balanceSelected == TokenBundle.empty)
+            "balanceSelected == mempty"
+            (balanceSelected == mempty)
     else
         assertWith
             "balanceSelected == balanceRequested"
@@ -2610,7 +2610,7 @@ prop_makeChange_identity
     :: NonEmpty TokenBundle -> Property
 prop_makeChange_identity bundles = (===)
     (F.fold <$> makeChange criteria)
-    (Right TokenBundle.empty)
+    (Right mempty)
   where
     criteria = MakeChangeCriteria
         { minCoinFor = const (Coin 0)

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -2775,7 +2775,7 @@ prop_makeChange p =
 
     someAssetsAreMintedButNotSpentOrBurned :: Bool
         = TokenMap.isNotEmpty
-        $ assetsMinted `TokenMap.difference` assetsSpentOrBurned
+        $ assetsMinted <\> assetsSpentOrBurned
       where
         assetsMinted =
             view #assetsToMint p
@@ -4091,7 +4091,7 @@ prop_removeBurnValueFromChangeMaps_value
     -> NonEmpty TokenMap
     -> Property
 prop_removeBurnValueFromChangeMaps_value (assetId, qty) changeMaps =
-    F.fold changeMaps `TokenMap.difference` TokenMap.singleton assetId qty
+    F.fold changeMaps <\> TokenMap.singleton assetId qty
     ===
     F.fold (removeBurnValueFromChangeMaps (assetId, qty) changeMaps)
 

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -164,6 +164,8 @@ import Data.Map.Strict
     ( Map )
 import Data.Maybe
     ( fromMaybe, isJust, isNothing, listToMaybe )
+import Data.Monoid.Monus
+    ( Monus ((<\>)) )
 import Data.Set
     ( Set )
 import Data.Tuple
@@ -2803,7 +2805,7 @@ prop_makeChange_success_delta p change =
     let
         totalOutputWithChange = totalOutputValue <> F.fold change
 
-        delta = TokenBundle.difference totalInputValue totalOutputWithChange
+        delta = totalInputValue <\> totalOutputWithChange
     in
         (delta === TokenBundle.fromCoin (view #requiredCost p))
             & counterexample counterExampleText
@@ -2887,8 +2889,8 @@ prop_makeChange_fail_costTooBig
     -> Property
 prop_makeChange_fail_costTooBig p =
     let
-        deltaCoin = TokenBundle.getCoin $ TokenBundle.difference
-            totalInputValue
+        deltaCoin = TokenBundle.getCoin $
+            totalInputValue <\>
             totalOutputValue
     in
         deltaCoin < view #requiredCost p
@@ -2944,8 +2946,8 @@ prop_makeChange_fail_minValueTooBig p =
                 , "totalMinCoinDeposit:"
                 , pretty totalMinCoinDeposit
                 ]
-            deltaCoin = TokenBundle.getCoin $ TokenBundle.difference
-                totalInputValue
+            deltaCoin = TokenBundle.getCoin $
+                totalInputValue <\>
                 totalOutputValue
             minCoinValueFor =
                 unMockComputeMinimumAdaQuantity (minCoinFor p) (TestAddress 0x0)

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -4135,7 +4135,7 @@ prop_removeBurnValuesFromChangeMaps burns changeMaps =
 prop_reduceTokenQuantities_value
     :: TokenQuantity -> NonEmpty TokenQuantity -> Property
 prop_reduceTokenQuantities_value reduceQty qtys =
-    F.fold qtys `TokenQuantity.difference` reduceQty
+    F.fold qtys <\> reduceQty
     ===
     F.fold (reduceTokenQuantities reduceQty qtys)
 

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -2930,7 +2930,7 @@ prop_makeChange_fail_minValueTooBig p =
         Right change ->
             conjoin
                 [ deltaCoin <
-                    totalMinCoinDeposit `Coin.add` view #requiredCost p
+                    totalMinCoinDeposit <> view #requiredCost p
                 , deltaCoin >=
                     view #requiredCost p
                 ]
@@ -2949,7 +2949,7 @@ prop_makeChange_fail_minValueTooBig p =
                 totalOutputValue
             minCoinValueFor =
                 unMockComputeMinimumAdaQuantity (minCoinFor p) (TestAddress 0x0)
-            totalMinCoinDeposit = F.foldr Coin.add (Coin 0)
+            totalMinCoinDeposit = F.foldr (<>) (Coin 0)
                 (minCoinValueFor . view #tokens <$> change)
   where
     totalInputValue =
@@ -3279,7 +3279,7 @@ unit_assignCoinsToChangeMaps =
 
         -- Single Ada-only output, but not enough left to create a change
         , ( Coin 1
-          , (`Coin.add` Coin 1) . computeMinimumAdaQuantityLinear
+          , (<> Coin 1) . computeMinimumAdaQuantityLinear
           , m 42 [] :| []
           , Right []
           )
@@ -3333,7 +3333,7 @@ unit_assignCoinsToChangeMaps =
 
 prop_makeChangeForCoin_sum :: NonEmpty Coin -> Coin -> Property
 prop_makeChangeForCoin_sum weights surplus =
-    surplus === F.foldr Coin.add (Coin 0) changes
+    surplus === F.foldr (<>) (Coin 0) changes
   where
     changes = makeChangeForCoin weights surplus
 

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -3846,7 +3846,7 @@ prop_splitBundlesWithExcessiveAssetCounts_sum
 prop_splitBundlesWithExcessiveTokenQuantities_length
     :: NonEmpty TokenBundle -> TokenQuantity -> Property
 prop_splitBundlesWithExcessiveTokenQuantities_length input maxQuantityAllowed =
-    maxQuantityAllowed > TokenQuantity.zero ==> checkCoverage $ property $
+    maxQuantityAllowed > mempty ==> checkCoverage $ property $
         cover 5 (lengthOutput > lengthInput)
             "length has increased" $
         cover 5 (lengthOutput == lengthInput)
@@ -3875,7 +3875,7 @@ prop_splitBundlesWithExcessiveTokenQuantities_length input maxQuantityAllowed =
 prop_splitBundlesWithExcessiveTokenQuantities_sum
     :: NonEmpty TokenBundle -> TokenQuantity -> Property
 prop_splitBundlesWithExcessiveTokenQuantities_sum ms maxQuantity =
-    maxQuantity > TokenQuantity.zero ==>
+    maxQuantity > mempty ==>
         F.fold (splitBundlesWithExcessiveTokenQuantities ms maxQuantity)
             === F.fold ms
 
@@ -4162,7 +4162,7 @@ prop_reduceTokenQuantities_order reduceQty qtyDiffs =
     inAscendingOrder xs = NE.sort xs == xs
 
     -- A list of quantities already in ascending order.
-    qtys = NE.scanl (<>) TokenQuantity.zero qtyDiffs
+    qtys = NE.scanl (<>) mempty qtyDiffs
 
 --------------------------------------------------------------------------------
 -- Utility functions

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -703,13 +703,13 @@ prop_performSelection_small mockConstraints (Blind (Small params)) =
         "not nonZeroExtraCoinSource && not nonZeroExtraCoinSink" $
 
     -- Inspect the sets of minted and burned assets:
-    cover 20 (view #assetsToMint params /= TokenMap.empty)
+    cover 20 (view #assetsToMint params /= mempty)
         "Have some assets to mint" $
-    cover 20 (view #assetsToBurn params /= TokenMap.empty)
+    cover 20 (view #assetsToBurn params /= mempty)
         "Have some assets to burn" $
-    cover 2 (view #assetsToMint params == TokenMap.empty)
+    cover 2 (view #assetsToMint params == mempty)
         "Have no assets to mint" $
-    cover 2 (view #assetsToBurn params == TokenMap.empty)
+    cover 2 (view #assetsToBurn params == mempty)
         "Have no assets to burn" $
 
     -- Inspect the intersection between minted assets and burned assets:
@@ -1772,9 +1772,9 @@ encodeBoundaryTestCriteria c = SelectionParams
     , extraCoinSink =
         Coin 0
     , assetsToMint =
-        TokenMap.empty
+        mempty
     , assetsToBurn =
-        TokenMap.empty
+        mempty
     , selectionStrategy =
         boundaryTestSelectionStrategy c
     }
@@ -2621,8 +2621,8 @@ prop_makeChange_identity bundles = (===)
             mkTokenBundleSizeAssessor MockAssessTokenBundleSizeUnlimited
         , inputBundles = bundles
         , outputBundles = bundles
-        , assetsToMint = TokenMap.empty
-        , assetsToBurn = TokenMap.empty
+        , assetsToMint = mempty
+        , assetsToBurn = mempty
         , maximumOutputAdaQuantity = testMaximumOutputAdaQuantity
         , maximumOutputTokenQuantity = testMaximumOutputTokenQuantity
         }
@@ -2707,13 +2707,13 @@ prop_makeChange p =
     checkCoverage $
 
     -- Inspect the sets of minted and burned assets:
-    cover 20 (view #assetsToMint p /= TokenMap.empty)
+    cover 20 (view #assetsToMint p /= mempty)
         "Have some assets to mint" $
-    cover 20 (view #assetsToBurn p /= TokenMap.empty)
+    cover 20 (view #assetsToBurn p /= mempty)
         "Have some assets to burn" $
-    cover 2 (view #assetsToMint p == TokenMap.empty)
+    cover 2 (view #assetsToMint p == mempty)
         "Have no assets to mint" $
-    cover 2 (view #assetsToBurn p == TokenMap.empty)
+    cover 2 (view #assetsToBurn p == mempty)
         "Have no assets to burn" $
 
     -- Inspect the intersection between minted assets and burned assets:
@@ -2982,8 +2982,8 @@ unit_makeChange =
               , bundleSizeAssessor
               , inputBundles = i
               , outputBundles = o
-              , assetsToMint = TokenMap.empty
-              , assetsToBurn = TokenMap.empty
+              , assetsToMint = mempty
+              , assetsToBurn = mempty
               , maximumOutputAdaQuantity = testMaximumOutputAdaQuantity
               , maximumOutputTokenQuantity = testMaximumOutputTokenQuantity
               }
@@ -4070,7 +4070,7 @@ prop_addMintValueToChangeMaps_order mint changeMapDiffs =
         $ addMintValueToChangeMaps mint changeMaps
   where
     -- A list of change maps already in ascending partial order
-    changeMaps = NE.scanl (<>) TokenMap.empty changeMapDiffs
+    changeMaps = NE.scanl (<>) mempty changeMapDiffs
 
 -- The plural of this function is equivalent to calling the singular multiple
 -- times. This is an important property because we only test the properties on
@@ -4118,7 +4118,7 @@ prop_removeBurnValueFromChangeMaps_order burn changeMapDiffs =
         $ removeBurnValueFromChangeMaps burn changeMaps
   where
     -- A list of change maps already in ascending partial order
-    changeMaps = NE.scanl (<>) TokenMap.empty changeMapDiffs
+    changeMaps = NE.scanl (<>) mempty changeMapDiffs
 
 -- The plural of this function is equivalent to calling the singular multiple
 -- times. This is an important property because we only test the properties on

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOIndexSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOIndexSpec.hs
@@ -46,6 +46,8 @@ import Data.Map.Strict
     ( Map )
 import Data.Maybe
     ( isJust, isNothing )
+import Data.Monoid.Monus
+    ( Monus ((<\>)) )
 import Data.Ratio
     ( (%) )
 import Data.Word
@@ -82,7 +84,6 @@ import Test.Utils.Laws
     ( testLawsMany )
 
 import qualified Cardano.CoinSelection.UTxOIndex.Internal as UTxOIndex
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map
@@ -279,7 +280,7 @@ prop_delete_balance u i =
         Nothing ->
             UTxOIndex.balance i
         Just b ->
-            UTxOIndex.balance i `TokenBundle.difference` b
+            UTxOIndex.balance i <\> b
 
 prop_delete_lookup
     :: u ~ Size 4 TestUTxO => u -> UTxOIndex u -> Property
@@ -318,7 +319,7 @@ prop_insert_balance u b i =
         Nothing ->
             UTxOIndex.balance i
         Just b' ->
-            UTxOIndex.balance i `TokenBundle.difference` b'
+            UTxOIndex.balance i <\> b'
 
 prop_insert_delete
     :: u ~ Size 4 TestUTxO => u -> TokenBundle -> UTxOIndex u -> Property

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOIndexSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOIndexSpec.hs
@@ -314,7 +314,7 @@ prop_insert_balance u b i =
     checkCoverage_modify u i $
     UTxOIndex.balance (UTxOIndex.insert u b i) === expected
   where
-    expected = b `TokenBundle.add` case UTxOIndex.lookup u i of
+    expected = b <> case UTxOIndex.lookup u i of
         Nothing ->
             UTxOIndex.balance i
         Just b' ->

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOSelectionSpec.hs
@@ -45,7 +45,6 @@ import Test.QuickCheck.Quid
 
 import qualified Cardano.CoinSelection.UTxOIndex as UTxOIndex
 import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Data.Foldable as F
 import qualified Data.Map.Strict as Map
 
@@ -288,7 +287,7 @@ prop_leftoverBalance_selectedBalance s =
     checkCoverage_UTxOSelection s $
     (UTxOSelection.leftoverBalance s <> UTxOSelection.selectedBalance s)
     ===
-    TokenBundle.add
+    (<>)
         (UTxOIndex.balance (UTxOSelection.leftoverIndex s))
         (UTxOIndex.balance (UTxOSelection.selectedIndex s))
 


### PR DESCRIPTION
## Issue

ADP-1449

## Description

This PR makes the following replacements within the `cardano-coin-selection` library:

| Before | After |
| -- | -- |
| `{TokenBundle,TokenMap,TokenQuantity,Coin}.add` | `Semigroup.<>` |
| `{TokenBundle,TokenMap,TokenQuantity,Coin}.subtract` | `Reductive.</>` |
| `{TokenBundle,TokenMap,TokenQuantity,Coin}.difference` | `Monus.<\>` |
| `{TokenBundle,TokenMap}.empty` | `Monoid.mempty` |
| `{TokenQuantity,Coin}.zero` | `Monoid.mempty` |

Functions on the LHS of the above table are already just synonyms of class methods on the RHS.

This takes us one small step closer to removing the dependency on types defined within `cardano-wallet-primitive`.