### PR TITLE
HIE shouldn't ignore single word modules like 'Spec', 'Service', etc.

### DIFF
--- a/scripts/cabal-lib.sh
+++ b/scripts/cabal-lib.sh
@@ -89,6 +89,6 @@ EOF
 
 # List all modules for ghci command-line
 list_modules() {
-    list_sources | sed -e 's/^[^A-Z]*\(.*\)\.hs$/\1/' | grep / | sed 'y=/=.='
+    list_sources | sed -e 's/^[^A-Z]*\(.*\)\.hs$/\1/' | grep -v '^[[:space:]]*$' | sed 'y=/=.='
     list_packages | sed -e 'y/-/_/' -e 's/^/Paths_/'
 }


### PR DESCRIPTION
For some unknown reason our `scripts/hie-bios.sh` setup was filtering out Haskell module files that don't contain a `/` slash in their relative path. For this reason the `lib/local-cluster/lib/Service.hs` was ignored by HIE.

This PR changes the `scripts/hie-bios.sh` to only filter out empty lines, not slashless-files.
