### PR TITLE
Extract crypto-hash-extra library that contains blake2b hashing functions

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -59,6 +59,7 @@ index-state:
 packages:
   lib/application-extras
   , lib/balance-tx/
+  , lib/crypto-hash-extra/
   , lib/coin-selection/
   , lib/delta-store/
   , lib/delta-table

--- a/lib/crypto-hash-extra/crypto-hash-extra.cabal
+++ b/lib/crypto-hash-extra/crypto-hash-extra.cabal
@@ -1,0 +1,32 @@
+cabal-version: 3.0
+name:          crypto-hash-extra
+version:       0.1.0.0
+synopsis:      Extra functionality for cryptographic hashing
+license:       Apache-2.0
+author:        HAL, Cardano Foundation
+maintainer:    hal@cardanofoundation.org
+build-type:    Simple
+
+library
+  default-language:   Haskell2010
+  default-extensions:
+    NoImplicitPrelude
+    DerivingStrategies
+    OverloadedStrings
+
+  ghc-options:
+    -O2 -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns
+    -Wunused-foralls -Wunused-foralls -fprint-explicit-foralls
+    -fprint-explicit-kinds -Wcompat -Widentities
+    -Werror=incomplete-patterns -Wredundant-constraints
+    -Wpartial-fields -Wtabs -fhelpful-errors -fprint-expanded-synonyms
+    -fwarn-unused-do-bind -fwarn-incomplete-uni-patterns
+    -freverse-errors
+
+  hs-source-dirs:     src
+  exposed-modules:    Crypto.Hash.Extra
+  build-depends:
+    , base                    ^>=4.14.3
+    , bytestring              ^>=0.10.12
+    , cryptonite              ^>=0.30
+    , memory                  ^>=0.18

--- a/lib/crypto-hash-extra/src/Crypto/Hash/Extra.hs
+++ b/lib/crypto-hash-extra/src/Crypto/Hash/Extra.hs
@@ -1,12 +1,6 @@
 {-# LANGUAGE TypeApplications #-}
 
--- |
--- Copyright: © 2018-2020 IOHK
--- License: Apache-2.0
---
--- Common hashing functions used and re-used across the codebase.
-
-module Crypto.Hash.Utils
+module Crypto.Hash.Extra
     ( blake2b256
     , blake2b224
     ) where

--- a/lib/wallet/address/Cardano/Wallet/Address/Derivation/Byron.hs
+++ b/lib/wallet/address/Cardano/Wallet/Address/Derivation/Byron.hs
@@ -80,7 +80,7 @@ import Control.Lens
     ( Lens, lens )
 import Crypto.Hash.Algorithms
     ( SHA512 (..) )
-import Crypto.Hash.Utils
+import Crypto.Hash.Extra
     ( blake2b256 )
 import Data.ByteArray
     ( ScrubbedBytes )

--- a/lib/wallet/address/Cardano/Wallet/Address/Derivation/Shared.hs
+++ b/lib/wallet/address/Cardano/Wallet/Address/Derivation/Shared.hs
@@ -73,10 +73,10 @@ import Control.Monad
     ( (<=<) )
 import Crypto.Hash.Algorithms
     ( Blake2b_224 (..) )
+import Crypto.Hash.Extra
+    ( blake2b224 )
 import Crypto.Hash.IO
     ( HashAlgorithm (hashDigestSize) )
-import Crypto.Hash.Utils
-    ( blake2b224 )
 import Data.ByteString
     ( ByteString )
 import Data.Proxy

--- a/lib/wallet/address/Cardano/Wallet/Address/Derivation/Shelley.hs
+++ b/lib/wallet/address/Cardano/Wallet/Address/Derivation/Shelley.hs
@@ -105,10 +105,10 @@ import Control.Monad
     ( guard, (<=<) )
 import Crypto.Hash.Algorithms
     ( Blake2b_224 (..) )
+import Crypto.Hash.Extra
+    ( blake2b224 )
 import Crypto.Hash.IO
     ( HashAlgorithm (hashDigestSize) )
-import Crypto.Hash.Utils
-    ( blake2b224 )
 import Data.Binary.Put
     ( putByteString, putWord8, runPut )
 import Data.ByteString

--- a/lib/wallet/address/Cardano/Wallet/Primitive/Passphrase/Legacy.hs
+++ b/lib/wallet/address/Cardano/Wallet/Primitive/Passphrase/Legacy.hs
@@ -38,7 +38,7 @@ import Prelude
 
 import Cardano.Wallet.Primitive.Passphrase.Types
     ( Passphrase (..), PassphraseHash (..) )
-import Crypto.Hash.Utils
+import Crypto.Hash.Extra
     ( blake2b256 )
 import Crypto.Random.Types
     ( MonadRandom (..) )

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Key.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Key.hs
@@ -46,7 +46,7 @@ import Codec.Binary.Bech32.TH
     ( humanReadablePart )
 import Control.DeepSeq
     ( NFData )
-import Crypto.Hash.Utils
+import Crypto.Hash.Extra
     ( blake2b224 )
 import Data.Aeson.Types
     ( FromJSON (..), ToJSON (..) )

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -184,7 +184,7 @@ import Control.Monad.Trans.Except
     ( runExceptT, withExceptT )
 import Control.Tracer
     ( Tracer (..), traceWith )
-import Crypto.Hash.Utils
+import Crypto.Hash.Extra
     ( blake2b256 )
 import Data.Aeson
     ( ToJSON (..), genericToJSON, (.=) )

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -102,6 +102,7 @@ library
     , cborg
     , containers
     , contra-tracer
+    , crypto-hash-extra
     , cryptonite
     , data-default
     , data-interval
@@ -419,6 +420,7 @@ library cardano-wallet-api-http
     , cborg
     , containers
     , contra-tracer
+    , crypto-hash-extra
     , data-default
     , deepseq
     , directory
@@ -534,6 +536,7 @@ library cardano-wallet-integration
     , cborg
     , command
     , containers
+    , crypto-hash-extra
     , cryptonite
     , deepseq
     , directory
@@ -748,6 +751,7 @@ test-suite unit
     , connection
     , containers
     , contra-tracer
+    , crypto-hash-extra
     , cryptonite
     , data-default
     , data-interval
@@ -999,6 +1003,7 @@ benchmark restore
     , cardano-wallet-primitive
     , containers
     , contra-tracer
+    , crypto-hash-extra
     , deepseq
     , filepath
     , fmt
@@ -1148,6 +1153,7 @@ library address-derivation
     , cardano-wallet-read
     , cborg
     , containers
+    , crypto-hash-extra
     , cryptonite
     , data-interval
     , deepseq
@@ -1193,7 +1199,6 @@ library address-derivation
     Cardano.Wallet.Primitive.Passphrase.Gen
     Cardano.Wallet.Primitive.Passphrase.Legacy
     Cardano.Wallet.Primitive.Passphrase.Types
-    Crypto.Hash.Utils
 
 library cardano-wallet-local-cluster
   import:          language, opts-lib
@@ -1225,6 +1230,7 @@ library cardano-wallet-local-cluster
     , cborg
     , containers
     , contra-tracer
+    , crypto-hash-extra
     , directory
     , filepath
     , int-cast

--- a/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
@@ -379,7 +379,7 @@ import Control.Retry
     ( capDelay, constantDelay, retrying )
 import Crypto.Hash
     ( Blake2b_160, Digest, digestFromByteString )
-import Crypto.Hash.Utils
+import Crypto.Hash.Extra
     ( blake2b224 )
 import Data.Aeson
     ( FromJSON, ToJSON, Value, (.=) )

--- a/lib/wallet/integration/src/Test/Integration/Plutus.hs
+++ b/lib/wallet/integration/src/Test/Integration/Plutus.hs
@@ -50,7 +50,7 @@ import Codec.Serialise
     ( serialise )
 import Control.Arrow
     ( left )
-import Crypto.Hash.Utils
+import Crypto.Hash.Extra
     ( blake2b224 )
 import Data.Aeson
     ( (.=) )

--- a/lib/wallet/local-cluster/Cardano/Wallet/Launch/Cluster.hs
+++ b/lib/wallet/local-cluster/Cardano/Wallet/Launch/Cluster.hs
@@ -169,7 +169,7 @@ import Control.Retry
     ( constantDelay, limitRetriesByCumulativeDelay, retrying )
 import Control.Tracer
     ( Tracer (..), contramap, traceWith )
-import Crypto.Hash.Utils
+import Crypto.Hash.Extra
     ( blake2b256 )
 import Data.Aeson
     ( object, toJSON, (.:), (.=) )

--- a/lib/wallet/src/Cardano/Pool/Metadata.hs
+++ b/lib/wallet/src/Cardano/Pool/Metadata.hs
@@ -66,7 +66,7 @@ import Control.Monad.Trans.Except
     ( ExceptT (..), except, runExceptT, throwE, withExceptT )
 import Control.Tracer
     ( Tracer, traceWith )
-import Crypto.Hash.Utils
+import Crypto.Hash.Extra
     ( blake2b256 )
 import Data.Aeson
     ( FromJSON

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/WalletKey.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/WalletKey.hs
@@ -49,7 +49,7 @@ import Control.Lens
     ( over, view, (^.) )
 import Crypto.Hash
     ( Digest, HashAlgorithm, hash )
-import Crypto.Hash.Utils
+import Crypto.Hash.Extra
     ( blake2b224 )
 
 -- | Re-encrypt a private key using a different passphrase.

--- a/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -68,7 +68,7 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     ( fromByronTxOut )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
-import Crypto.Hash.Utils
+import Crypto.Hash.Extra
     ( blake2b256 )
 import Data.Coerce
     ( coerce )

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -248,7 +248,7 @@ import Control.Applicative
     ( Const (..) )
 import Control.Lens
     ( view, (&), (^.) )
-import Crypto.Hash.Utils
+import Crypto.Hash.Extra
     ( blake2b224 )
 import Data.Array
     ( Array )

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Delegation/StateSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Delegation/StateSpec.hs
@@ -58,7 +58,7 @@ import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..) )
 import Control.Arrow
     ( first )
-import Crypto.Hash.Utils
+import Crypto.Hash.Extra
     ( blake2b224 )
 import Data.Map
     ( Map )

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -281,7 +281,7 @@ import Control.Monad.Trans.Except
     ( except, runExcept, runExceptT )
 import Control.Monad.Trans.State.Strict
     ( evalState, state )
-import Crypto.Hash.Utils
+import Crypto.Hash.Extra
     ( blake2b224 )
 import Data.ByteArray.Encoding
     ( Base (..), convertToBase )


### PR DESCRIPTION
Extracted former `Crypto.Hash.Utils` module into a separate package `crypto-hash-extra` such that any other package that needs them (e.g. `local-cluster`) doesn't have to depend on the whole `cardano-wallet`