### PR TITLE
Make `balanceTx` the sole consumer of `cardano-coin-selection`.

### DIFF
--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -58,9 +58,6 @@ module Cardano.Tx.Balance.Internal.CoinSelection
     , SelectionBalanceError (..)
     , SelectionCollateralError (..)
     , UnableToConstructChangeError (..)
-
-    -- * Selection deltas
-    , selectionDelta
     )
     where
 
@@ -434,18 +431,3 @@ performSelection cs ps =
     Internal.performSelection @m @WalletSelectionContext
         (toInternalSelectionConstraints cs)
         (toInternalSelectionParams ps)
-
---------------------------------------------------------------------------------
--- Selection deltas
---------------------------------------------------------------------------------
-
--- | Computes the ada surplus of a selection, assuming there is a surplus.
---
-selectionDelta
-    :: (change -> Coin)
-    -- ^ A function to extract the coin value from a change value.
-    -> SelectionOf change
-    -> Coin
-selectionDelta getChangeCoin
-    = Internal.selectionSurplusCoin
-    . toInternalSelection (TokenBundle.fromCoin . getChangeCoin)

--- a/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
+++ b/lib/balance-tx/lib/Cardano/Tx/Balance/Internal/CoinSelection.hs
@@ -59,12 +59,6 @@ module Cardano.Tx.Balance.Internal.CoinSelection
     , SelectionCollateralError (..)
     , UnableToConstructChangeError (..)
 
-    -- * Selection reports
-    , makeSelectionReportDetailed
-    , makeSelectionReportSummarized
-    , SelectionReportDetailed
-    , SelectionReportSummarized
-
     -- * Selection deltas
     , selectionDelta
     )
@@ -112,7 +106,7 @@ import Control.Monad.Random.Class
 import Control.Monad.Trans.Except
     ( ExceptT (..) )
 import Data.Generics.Internal.VL.Lens
-    ( over, view )
+    ( view )
 import Data.List.NonEmpty
     ( NonEmpty )
 import Data.Map.Strict
@@ -120,7 +114,7 @@ import Data.Map.Strict
 import Data.Set
     ( Set )
 import Fmt
-    ( Buildable (..), genericF )
+    ( Buildable (..) )
 import GHC.Generics
     ( Generic )
 import GHC.Stack
@@ -133,9 +127,7 @@ import Prelude
 import qualified Cardano.CoinSelection as Internal
 import qualified Cardano.CoinSelection.Context as SC
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
-import qualified Data.Foldable as F
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
 
 --------------------------------------------------------------------------------
 -- Selection contexts
@@ -457,119 +449,3 @@ selectionDelta
 selectionDelta getChangeCoin
     = Internal.selectionSurplusCoin
     . toInternalSelection (TokenBundle.fromCoin . getChangeCoin)
-
---------------------------------------------------------------------------------
--- Reporting
---------------------------------------------------------------------------------
-
--- | Includes both summarized and detailed information about a selection.
---
-data SelectionReport = SelectionReport
-    { summary :: SelectionReportSummarized
-    , detail :: SelectionReportDetailed
-    }
-    deriving (Eq, Generic, Show)
-
--- | Includes summarized information about a selection.
---
--- Each data point can be serialized as a single line of text.
---
-data SelectionReportSummarized = SelectionReportSummarized
-    { computedFee :: Coin
-    , adaBalanceOfSelectedInputs :: Coin
-    , adaBalanceOfExtraCoinSource :: Coin
-    , adaBalanceOfExtraCoinSink :: Coin
-    , adaBalanceOfRequestedOutputs :: Coin
-    , adaBalanceOfGeneratedChangeOutputs :: Coin
-    , numberOfSelectedInputs :: Int
-    , numberOfSelectedCollateralInputs :: Int
-    , numberOfRequestedOutputs :: Int
-    , numberOfGeneratedChangeOutputs :: Int
-    , numberOfUniqueNonAdaAssetsInSelectedInputs :: Int
-    , numberOfUniqueNonAdaAssetsInRequestedOutputs :: Int
-    , numberOfUniqueNonAdaAssetsInGeneratedChangeOutputs :: Int
-    }
-    deriving (Eq, Generic, Show)
-
--- | Includes detailed information about a selection.
---
-data SelectionReportDetailed = SelectionReportDetailed
-    { selectedInputs :: [(TxIn, TxOut)]
-    , selectedCollateral :: [(TxIn, TxOut)]
-    , requestedOutputs :: [TxOut]
-    , generatedChangeOutputs :: [TokenBundle.Flat TokenBundle]
-    }
-    deriving (Eq, Generic, Show)
-
-instance Buildable SelectionReport where
-    build = genericF
-instance Buildable SelectionReportSummarized where
-    build = genericF
-instance Buildable SelectionReportDetailed where
-    build = genericF
-
-makeSelectionReport :: Selection -> SelectionReport
-makeSelectionReport s = SelectionReport
-    { summary = makeSelectionReportSummarized s
-    , detail = makeSelectionReportDetailed s
-    }
-
-makeSelectionReportSummarized :: Selection -> SelectionReportSummarized
-makeSelectionReportSummarized s = SelectionReportSummarized {..}
-  where
-    computedFee
-        = selectionDelta TokenBundle.getCoin s
-    adaBalanceOfSelectedInputs
-        = F.foldMap (view (#tokens . #coin) . snd) $ view #inputs s
-    adaBalanceOfExtraCoinSource
-        = view #extraCoinSource s
-    adaBalanceOfExtraCoinSink
-        = view #extraCoinSink s
-    adaBalanceOfGeneratedChangeOutputs
-        = F.foldMap (view #coin) $ view #change s
-    adaBalanceOfRequestedOutputs
-        = F.foldMap (view (#tokens . #coin)) $ view #outputs s
-    numberOfSelectedInputs
-        = length $ view #inputs s
-    numberOfSelectedCollateralInputs
-        = length $ view #collateral s
-    numberOfRequestedOutputs
-        = length $ view #outputs s
-    numberOfGeneratedChangeOutputs
-        = length $ view #change s
-    numberOfUniqueNonAdaAssetsInSelectedInputs
-        = Set.size
-        $ F.foldMap (TokenBundle.getAssets . view #tokens . snd)
-        $ view #inputs s
-    numberOfUniqueNonAdaAssetsInRequestedOutputs
-        = Set.size
-        $ F.foldMap (TokenBundle.getAssets . view #tokens)
-        $ view #outputs s
-    numberOfUniqueNonAdaAssetsInGeneratedChangeOutputs
-        = Set.size
-        $ F.foldMap TokenBundle.getAssets
-        $ view #change s
-
-makeSelectionReportDetailed :: Selection -> SelectionReportDetailed
-makeSelectionReportDetailed s = SelectionReportDetailed
-    { selectedInputs
-        = F.toList $ view #inputs s
-    , selectedCollateral
-        = F.toList $ view #collateral s
-    , requestedOutputs
-        = view #outputs s
-    , generatedChangeOutputs
-        = TokenBundle.Flat <$> view #change s
-    }
-
--- A convenience instance for 'Buildable' contexts that include a nested
--- 'SelectionOf TokenBundle' value.
-instance Buildable (SelectionOf TokenBundle) where
-    build = build . makeSelectionReport
-
--- A convenience instance for 'Buildable' contexts that include a nested
--- 'SelectionOf TxOut' value.
-instance Buildable (SelectionOf TxOut) where
-    build = build
-        . makeSelectionReport
-        . over #change (fmap $ view #tokens)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -157,8 +157,6 @@ import Cardano.Mnemonic
     ( SomeMnemonic )
 import Cardano.Pool.Types
     ( PoolId )
-import Cardano.Tx.Balance.Internal.CoinSelection
-    ( SelectionOf (..) )
 import Cardano.Wallet
     ( BuiltTx (..)
     , DelegationFee (feePercentiles)
@@ -682,6 +680,7 @@ import UnliftIO.Exception
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Address.Style.Shelley as CA
 import qualified Cardano.Api as Cardano
+import qualified Cardano.Tx.Balance.Internal.CoinSelection as CS.Internal
 import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
 import qualified Cardano.Wallet.Address.Derivation.Icarus as Icarus
@@ -3837,7 +3836,7 @@ mkApiWalletMigrationPlan s addresses rewardWithdrawal plan =
     maybeUnsignedTxs = fmap mkUnsignedTx <$> maybeSelectionWithdrawals
       where
         mkUnsignedTx (selection, withdrawal) = W.selectionToUnsignedTx
-            withdrawal (selection {change = []}) s
+            withdrawal (selection {CS.Internal.change = []}) s
 
     totalFee :: Quantity "lovelace" Natural
     totalFee = Coin.toQuantity $ view #totalFee plan
@@ -3924,7 +3923,7 @@ migrateWallet ctx@ApiLayer{..} withdrawalType (ApiT wid) postData = do
                     mkRewardAccount
                     pwd
                     txContext
-                    (selection {change = []})
+                    (selection {CS.Internal.change = []})
 
             liftHandler $ W.submitTx tr db netLayer
                 BuiltTx

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -547,6 +547,7 @@ import Cardano.Wallet.Transaction
     ( AnyExplicitScript (..)
     , DelegationAction (..)
     , PreSelection (..)
+    , SelectionOf (..)
     , TransactionCtx (..)
     , TransactionLayer (..)
     , Withdrawal (..)
@@ -680,7 +681,6 @@ import UnliftIO.Exception
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Address.Style.Shelley as CA
 import qualified Cardano.Api as Cardano
-import qualified Cardano.Tx.Balance.Internal.CoinSelection as CS.Internal
 import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
 import qualified Cardano.Wallet.Address.Derivation.Icarus as Icarus
@@ -3836,7 +3836,7 @@ mkApiWalletMigrationPlan s addresses rewardWithdrawal plan =
     maybeUnsignedTxs = fmap mkUnsignedTx <$> maybeSelectionWithdrawals
       where
         mkUnsignedTx (selection, withdrawal) = W.selectionToUnsignedTx
-            withdrawal (selection {CS.Internal.change = []}) s
+            withdrawal (selection {change = []}) s
 
     totalFee :: Quantity "lovelace" Natural
     totalFee = Coin.toQuantity $ view #totalFee plan
@@ -3923,7 +3923,7 @@ migrateWallet ctx@ApiLayer{..} withdrawalType (ApiT wid) postData = do
                     mkRewardAccount
                     pwd
                     txContext
-                    (selection {CS.Internal.change = []})
+                    (selection {change = []})
 
             liftHandler $ W.submitTx tr db netLayer
                 BuiltTx

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -259,8 +259,6 @@ import Cardano.Mnemonic
     ( SomeMnemonic )
 import Cardano.Slotting.Slot
     ( SlotNo (..) )
-import Cardano.Tx.Balance.Internal.CoinSelection
-    ( SelectionOf (..) )
 import Cardano.Wallet.Address.Book
     ( AddressBookIso, Prologue (..), getDiscoveries, getPrologue )
 import Cardano.Wallet.Address.Derivation
@@ -637,6 +635,7 @@ import qualified Cardano.Address.Style.Shelley as CAShelley
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Slotting.Slot as Slot
+import qualified Cardano.Tx.Balance.Internal.CoinSelection as CS.Internal
 import qualified Cardano.Wallet.Address.Discovery.Random as Rnd
 import qualified Cardano.Wallet.Address.Discovery.Sequential as Seq
 import qualified Cardano.Wallet.Address.Discovery.Shared as Shared
@@ -1659,7 +1658,7 @@ selectionToUnsignedTx
         , withdrawal ~ (RewardAccount, Coin, NonEmpty DerivationIndex)
         )
     => Withdrawal
-    -> SelectionOf TxOut
+    -> CS.Internal.SelectionOf TxOut
     -> s
     -> (UnsignedTx input output change withdrawal)
 selectionToUnsignedTx wdrl sel s =
@@ -2253,7 +2252,7 @@ buildAndSignTransaction
     -> MakeRewardAccountBuilder k
     -> Passphrase "user"
     -> TransactionCtx
-    -> SelectionOf TxOut
+    -> CS.Internal.SelectionOf TxOut
     -> ExceptT ErrSignPayment IO (Tx, TxMeta, UTCTime, SealedTx)
 buildAndSignTransaction ctx wid era mkRwdAcct pwd txCtx sel = db & \DBLayer{..} ->
     withRootKey db wid pwd ErrSignPaymentWithRootKey $ \xprv scheme -> do
@@ -2660,7 +2659,7 @@ createMigrationPlan ctx rewardWithdrawal = do
     nl = ctx ^. networkLayer
     tl = transactionLayer_ ctx
 
-type SelectionWithoutChange = SelectionOf Void
+type SelectionWithoutChange = CS.Internal.SelectionOf Void
 
 migrationPlanToSelectionWithdrawals
     :: MigrationPlan
@@ -2685,7 +2684,7 @@ migrationPlanToSelectionWithdrawals plan rewardWithdrawal outputAddressesToCycle
         , outputAddressesRemaining
         )
       where
-        selection = Selection
+        selection = CS.Internal.Selection
             { inputs = view #inputIds migrationSelection
             , collateral = []
             , outputs

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -497,6 +497,7 @@ import Cardano.Wallet.Transaction
     , ErrMkTransaction (..)
     , ErrSignTx (..)
     , PreSelection (..)
+    , SelectionOf (..)
     , TransactionCtx (..)
     , TransactionLayer (..)
     , TxValidityInterval
@@ -635,7 +636,6 @@ import qualified Cardano.Address.Style.Shelley as CAShelley
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Slotting.Slot as Slot
-import qualified Cardano.Tx.Balance.Internal.CoinSelection as CS.Internal
 import qualified Cardano.Wallet.Address.Discovery.Random as Rnd
 import qualified Cardano.Wallet.Address.Discovery.Sequential as Seq
 import qualified Cardano.Wallet.Address.Discovery.Shared as Shared
@@ -1658,7 +1658,7 @@ selectionToUnsignedTx
         , withdrawal ~ (RewardAccount, Coin, NonEmpty DerivationIndex)
         )
     => Withdrawal
-    -> CS.Internal.SelectionOf TxOut
+    -> SelectionOf TxOut
     -> s
     -> (UnsignedTx input output change withdrawal)
 selectionToUnsignedTx wdrl sel s =
@@ -2252,7 +2252,7 @@ buildAndSignTransaction
     -> MakeRewardAccountBuilder k
     -> Passphrase "user"
     -> TransactionCtx
-    -> CS.Internal.SelectionOf TxOut
+    -> SelectionOf TxOut
     -> ExceptT ErrSignPayment IO (Tx, TxMeta, UTCTime, SealedTx)
 buildAndSignTransaction ctx wid era mkRwdAcct pwd txCtx sel = db & \DBLayer{..} ->
     withRootKey db wid pwd ErrSignPaymentWithRootKey $ \xprv scheme -> do
@@ -2659,7 +2659,7 @@ createMigrationPlan ctx rewardWithdrawal = do
     nl = ctx ^. networkLayer
     tl = transactionLayer_ ctx
 
-type SelectionWithoutChange = CS.Internal.SelectionOf Void
+type SelectionWithoutChange = SelectionOf Void
 
 migrationPlanToSelectionWithdrawals
     :: MigrationPlan
@@ -2684,7 +2684,7 @@ migrationPlanToSelectionWithdrawals plan rewardWithdrawal outputAddressesToCycle
         , outputAddressesRemaining
         )
       where
-        selection = CS.Internal.Selection
+        selection = Selection
             { inputs = view #inputIds migrationSelection
             , collateral = []
             , outputs

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -138,7 +138,6 @@ module Cardano.Wallet
     , readWalletUTxO
     , defaultChangeAddressGen
     , dummyChangeAddressGen
-    , assignChangeAddressesAndUpdateDb
     , selectionToUnsignedTx
     , readNodeTipStateForTxWrite
     , buildSignSubmitTransaction
@@ -261,7 +260,7 @@ import Cardano.Mnemonic
 import Cardano.Slotting.Slot
     ( SlotNo (..) )
 import Cardano.Tx.Balance.Internal.CoinSelection
-    ( Selection, SelectionOf (..) )
+    ( SelectionOf (..) )
 import Cardano.Wallet.Address.Book
     ( AddressBookIso, Prologue (..), getDiscoveries, getPrologue )
 import Cardano.Wallet.Address.Derivation
@@ -521,7 +520,6 @@ import Cardano.Wallet.Write.Tx.Balance
     , ErrBalanceTxUnableToCreateChangeError (..)
     , PartialTx (..)
     , UTxOAssumptions (..)
-    , assignChangeAddresses
     , balanceTransaction
     , constructUTxOIndex
     )
@@ -1651,30 +1649,6 @@ normalizeDelegationAddress s addr = do
     pure
         $ liftDelegationAddressS @n fingerprint
         $ Seq.rewardAccountKey s
-
-assignChangeAddressesAndUpdateDb
-    :: ( GenChange s
-       , AddressBookIso s
-       , WalletFlavor s
-       )
-    => WalletLayer IO s
-    -> ArgGenChange s
-    -> Selection
-    -> IO (SelectionOf TxOut)
-assignChangeAddressesAndUpdateDb ctx argGenChange selection =
-    onWalletState ctx . Delta.updateWithResult
-        $ assignChangeAddressesAndUpdateDb'
-  where
-    assignChangeAddressesAndUpdateDb' wallet =
-        -- Newly generated change addresses only change the Prologue
-        ([ReplacePrologue $ getPrologue stateUpdated], selectionUpdated)
-      where
-        s = getState $ getLatest wallet
-        (selectionUpdated, stateUpdated) =
-            assignChangeAddresses
-                (defaultChangeAddressGen argGenChange )
-                selection
-                s
 
 selectionToUnsignedTx
     :: forall s input output change withdrawal.

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -139,7 +139,6 @@ module Cardano.Wallet
     , defaultChangeAddressGen
     , dummyChangeAddressGen
     , assignChangeAddressesAndUpdateDb
-    , assignChangeAddressesWithoutDbUpdate
     , selectionToUnsignedTx
     , readNodeTipStateForTxWrite
     , buildSignSubmitTransaction
@@ -1676,27 +1675,6 @@ assignChangeAddressesAndUpdateDb ctx argGenChange selection =
                 (defaultChangeAddressGen argGenChange )
                 selection
                 s
-
-assignChangeAddressesWithoutDbUpdate
-    :: forall s
-     . ( GenChange s
-       , WalletFlavor s
-       )
-    => WalletLayer IO s
-    -> ArgGenChange s
-    -> Selection
-    -> IO (SelectionOf TxOut)
-assignChangeAddressesWithoutDbUpdate ctx argGenChange selection =
-    db & \DBLayer{..} -> atomically $ do
-        cp <- readCheckpoint
-        let (selectionUpdated, _) =
-                assignChangeAddresses
-                    (defaultChangeAddressGen argGenChange)
-                    selection
-                    (getState cp)
-        pure selectionUpdated
-  where
-    db = ctx ^. dbLayer
 
 selectionToUnsignedTx
     :: forall s input output change withdrawal.

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -141,6 +141,7 @@ import Cardano.Wallet.Transaction
     , ErrMkTransaction (..)
     , ErrMkTransactionOutputTokenQuantityExceedsLimitError (..)
     , PreSelection (..)
+    , SelectionOf (..)
     , TokenMapWithScripts
     , TransactionCtx (..)
     , TransactionLayer (..)
@@ -190,7 +191,6 @@ import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Crypto.Wallet as Crypto.HD
 import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Ledger.Keys.Bootstrap as SL
-import qualified Cardano.Tx.Balance.Internal.CoinSelection as CS.Internal
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
 import qualified Cardano.Wallet.Write.Tx as Write
@@ -238,7 +238,7 @@ constructUnsignedTx
     -> (Maybe SlotNo, SlotNo)
     -- ^ Slot at which the transaction will optionally start and expire.
     -> Withdrawal
-    -> Either PreSelection (CS.Internal.SelectionOf TxOut)
+    -> Either PreSelection (SelectionOf TxOut)
     -- ^ Finalized asset selection
     -> Coin
     -- ^ Explicit fee amount
@@ -277,7 +277,7 @@ mkTx
     -- ^ Key store
     -> Withdrawal
     -- ^ An optional withdrawal
-    -> CS.Internal.SelectionOf TxOut
+    -> SelectionOf TxOut
     -- ^ Finalized asset selection
     -> Coin
     -- ^ Explicit fee amount
@@ -649,7 +649,7 @@ mkUnsignedTx
     :: forall era. Cardano.IsCardanoEra era
     => ShelleyBasedEra era
     -> (Maybe SlotNo, SlotNo)
-    -> Either PreSelection (CS.Internal.SelectionOf TxOut)
+    -> Either PreSelection (SelectionOf TxOut)
     -> Maybe Cardano.TxMetadata
     -> [(Cardano.StakeAddress, Cardano.Lovelace)]
     -> [Cardano.Certificate]
@@ -789,7 +789,7 @@ mkUnsignedTx
     --     duplicating.
     -- - Remove validation from coin-selection itself
     extractValidatedOutputs
-        :: Either PreSelection (CS.Internal.SelectionOf TxOut)
+        :: Either PreSelection (SelectionOf TxOut)
         -> Either ErrMkTransaction [TxOut]
     extractValidatedOutputs sel =
         mapM validateOut $ case sel of

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -148,6 +148,7 @@ import Cardano.Wallet.Transaction
     , Withdrawal (..)
     , WitnessCount (..)
     , WitnessCountCtx (..)
+    , selectionDelta
     )
 import Cardano.Wallet.TxWitnessTag
     ( TxWitnessTag (..) )
@@ -471,7 +472,7 @@ newTransactionLayer keyF networkId = TransactionLayer
     { mkTransaction = \era stakeCreds keystore _pp ctx selection -> do
         let ttl   = txValidityInterval ctx
         let wdrl = view #txWithdrawal ctx
-        let delta = CS.Internal.selectionDelta TxOut.coin selection
+        let delta = selectionDelta TxOut.coin selection
         case view #txDelegationAction ctx of
             Nothing -> withShelleyBasedEra era $ do
                 let payload = TxPayload (view #txMetadata ctx) mempty mempty
@@ -541,7 +542,7 @@ newTransactionLayer keyF networkId = TransactionLayer
         let ttl   = txValidityInterval ctx
         let wdrl  = view #txWithdrawal ctx
         let delta = case selection of
-                Right selOf -> CS.Internal.selectionDelta TxOut.coin selOf
+                Right selOf -> selectionDelta TxOut.coin selOf
                 Left _preSel -> Coin 0
         let assetsToBeMinted = view #txAssetsToMint ctx
         let assetsToBeBurned = view #txAssetsToBurn ctx

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -192,7 +192,6 @@ import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Ledger.Keys.Bootstrap as SL
 import qualified Cardano.Tx.Balance.Internal.CoinSelection as CS.Internal
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
 import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Data.ByteString as BS
@@ -472,7 +471,7 @@ newTransactionLayer keyF networkId = TransactionLayer
     { mkTransaction = \era stakeCreds keystore _pp ctx selection -> do
         let ttl   = txValidityInterval ctx
         let wdrl = view #txWithdrawal ctx
-        let delta = selectionDelta TxOut.coin selection
+        let delta = selectionDelta selection
         case view #txDelegationAction ctx of
             Nothing -> withShelleyBasedEra era $ do
                 let payload = TxPayload (view #txMetadata ctx) mempty mempty
@@ -542,7 +541,7 @@ newTransactionLayer keyF networkId = TransactionLayer
         let ttl   = txValidityInterval ctx
         let wdrl  = view #txWithdrawal ctx
         let delta = case selection of
-                Right selOf -> selectionDelta TxOut.coin selOf
+                Right selOf -> selectionDelta selOf
                 Left _preSel -> Coin 0
         let assetsToBeMinted = view #txAssetsToMint ctx
         let assetsToBeBurned = view #txAssetsToBurn ctx

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -142,7 +142,7 @@ data TransactionLayer k ktype tx = TransactionLayer
             -- Current protocol parameters
         -> TransactionCtx
             -- An additional context about the transaction
-        -> CS.Internal.SelectionOf TxOut
+        -> SelectionOf TxOut
             -- A balanced coin selection where all change addresses have been
             -- assigned.
         -> Either ErrMkTransaction (Tx, tx)
@@ -183,7 +183,7 @@ data TransactionLayer k ktype tx = TransactionLayer
             -- Reward account public key or optional script hash
         -> TransactionCtx
             -- An additional context about the transaction
-        -> Either PreSelection (CS.Internal.SelectionOf TxOut)
+        -> Either PreSelection (SelectionOf TxOut)
             -- A balanced coin selection where all change addresses have been
             -- assigned.
         -> Either ErrMkTransaction (Cardano.TxBody era)
@@ -272,7 +272,7 @@ instance NFData change => NFData (SelectionOf change)
 --
 -- If there is no surplus, this function returns 'Coin 0'.
 --
-selectionDelta :: CS.Internal.SelectionOf TxOut -> Coin
+selectionDelta :: SelectionOf TxOut -> Coin
 selectionDelta selection =
     balanceIn <\> balanceOut
   where
@@ -286,7 +286,7 @@ selectionDelta selection =
         F.foldMap TxOut.coin change
         <>
         extraCoinSink
-    CS.Internal.Selection
+    Selection
         {inputs, outputs, change, extraCoinSource, extraCoinSink} = selection
 
 data Withdrawal

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -122,7 +122,6 @@ import GHC.Generics
     ( Generic )
 
 import qualified Cardano.Api as Cardano
-import qualified Cardano.Tx.Balance.Internal.CoinSelection as CS.Internal
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Write.Tx as Write
@@ -235,8 +234,6 @@ data TransactionCtx = TransactionCtx
     -- ^ Script template regulating delegation credentials
     , txNativeScriptInputs :: Map TxIn (Script KeyHash)
     -- ^ A map of script hashes related to inputs. Only for multisig wallets
-    , txCollateralRequirement :: CS.Internal.SelectionCollateralRequirement
-    -- ^ The collateral requirement.
     } deriving Generic
 
 -- | Represents a preliminary selection of tx outputs typically made by user.
@@ -318,7 +315,6 @@ defaultTransactionCtx = TransactionCtx
     , txPaymentCredentialScriptTemplate = Nothing
     , txStakingCredentialScriptTemplate = Nothing
     , txNativeScriptInputs = Map.empty
-    , txCollateralRequirement = CS.Internal.SelectionCollateralNotRequired
     }
 
 -- | User-requested action related to a delegation

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -64,8 +64,6 @@ import Cardano.Api.Extra
     ()
 import Cardano.Pool.Types
     ( PoolId )
-import Cardano.Tx.Balance.Internal.CoinSelection
-    ( SelectionCollateralRequirement (..), SelectionOf (..) )
 import Cardano.Wallet.Address.Derivation
     ( Depth (..), DerivationIndex )
 import Cardano.Wallet.Primitive.Passphrase.Types
@@ -116,6 +114,7 @@ import GHC.Generics
     ( Generic )
 
 import qualified Cardano.Api as Cardano
+import qualified Cardano.Tx.Balance.Internal.CoinSelection as CS.Internal
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Data.List as L
@@ -133,7 +132,7 @@ data TransactionLayer k ktype tx = TransactionLayer
             -- Current protocol parameters
         -> TransactionCtx
             -- An additional context about the transaction
-        -> SelectionOf TxOut
+        -> CS.Internal.SelectionOf TxOut
             -- A balanced coin selection where all change addresses have been
             -- assigned.
         -> Either ErrMkTransaction (Tx, tx)
@@ -174,7 +173,7 @@ data TransactionLayer k ktype tx = TransactionLayer
             -- Reward account public key or optional script hash
         -> TransactionCtx
             -- An additional context about the transaction
-        -> Either PreSelection (SelectionOf TxOut)
+        -> Either PreSelection (CS.Internal.SelectionOf TxOut)
             -- A balanced coin selection where all change addresses have been
             -- assigned.
         -> Either ErrMkTransaction (Cardano.TxBody era)
@@ -226,7 +225,7 @@ data TransactionCtx = TransactionCtx
     -- ^ Script template regulating delegation credentials
     , txNativeScriptInputs :: Map TxIn (Script KeyHash)
     -- ^ A map of script hashes related to inputs. Only for multisig wallets
-    , txCollateralRequirement :: SelectionCollateralRequirement
+    , txCollateralRequirement :: CS.Internal.SelectionCollateralRequirement
     -- ^ The collateral requirement.
     } deriving Generic
 
@@ -264,7 +263,7 @@ defaultTransactionCtx = TransactionCtx
     , txPaymentCredentialScriptTemplate = Nothing
     , txStakingCredentialScriptTemplate = Nothing
     , txNativeScriptInputs = Map.empty
-    , txCollateralRequirement = SelectionCollateralNotRequired
+    , txCollateralRequirement = CS.Internal.SelectionCollateralNotRequired
     }
 
 -- | User-requested action related to a delegation

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -100,8 +99,6 @@ import Cardano.Wallet.TxWitnessTag
     ( TxWitnessTag )
 import Control.DeepSeq
     ( NFData (..) )
-import Data.Generics.Internal.VL.Lens
-    ( view )
 import Data.List.NonEmpty
     ( NonEmpty )
 import Data.Map.Strict
@@ -270,19 +267,15 @@ instance NFData change => NFData (SelectionOf change)
 -- If there is no surplus, this function returns 'Coin 0'.
 --
 selectionDelta :: SelectionOf TxOut -> Coin
-selectionDelta selection =
-    balanceIn <\> balanceOut
+selectionDelta selection = balanceIn <\> balanceOut
   where
     balanceIn =
-        F.foldMap (view (#tokens . #coin) . snd) inputs
-        <>
         extraCoinSource
+        <> F.foldMap (TxOut.coin . snd) inputs
     balanceOut =
-        F.foldMap (view (#tokens . #coin)) outputs
-        <>
-        F.foldMap TxOut.coin change
-        <>
         extraCoinSink
+        <> F.foldMap TxOut.coin outputs
+        <> F.foldMap TxOut.coin change
     Selection
         {inputs, outputs, change, extraCoinSource, extraCoinSink} = selection
 

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -29,6 +29,7 @@ module Cardano.Wallet.Transaction
     , TxValidityInterval
     , TransactionCtx (..)
     , PreSelection (..)
+    , SelectionOf (..)
     , selectionDelta
     , defaultTransactionCtx
     , Withdrawal (..)
@@ -242,6 +243,30 @@ data TransactionCtx = TransactionCtx
 newtype PreSelection = PreSelection { outputs :: [TxOut] }
     deriving stock (Generic, Show)
     deriving newtype (Eq)
+
+-- | Represents a balanced selection.
+--
+data SelectionOf change = Selection
+    { inputs :: !(NonEmpty (TxIn, TxOut))
+        -- ^ Selected inputs.
+    , collateral :: ![(TxIn, TxOut)]
+        -- ^ Selected collateral inputs.
+    , outputs :: ![TxOut]
+        -- ^ User-specified outputs
+    , change :: ![change]
+        -- ^ Generated change outputs.
+    , assetsToMint :: !TokenMap
+        -- ^ Assets to mint.
+    , assetsToBurn :: !TokenMap
+        -- ^ Assets to burn.
+    , extraCoinSource :: !Coin
+        -- ^ An extra source of ada.
+    , extraCoinSink :: !Coin
+        -- ^ An extra sink for ada.
+    }
+    deriving (Eq, Generic, Show)
+
+instance NFData change => NFData (SelectionOf change)
 
 -- | Computes the ada surplus of a selection, assuming there is a surplus.
 --

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -123,6 +123,7 @@ import GHC.Generics
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Tx.Balance.Internal.CoinSelection as CS.Internal
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Write.Tx as Write
 import qualified Data.Foldable as F
 import qualified Data.List as L
@@ -246,12 +247,8 @@ newtype PreSelection = PreSelection { outputs :: [TxOut] }
 --
 -- If there is no surplus, this function returns 'Coin 0'.
 --
-selectionDelta
-    :: (change -> Coin)
-    -- ^ A function to extract the coin value from a change value.
-    -> CS.Internal.SelectionOf change
-    -> Coin
-selectionDelta getChangeCoin selection =
+selectionDelta :: CS.Internal.SelectionOf TxOut -> Coin
+selectionDelta selection =
     balanceIn <\> balanceOut
   where
     balanceIn =
@@ -261,7 +258,7 @@ selectionDelta getChangeCoin selection =
     balanceOut =
         F.foldMap (view (#tokens . #coin)) outputs
         <>
-        F.foldMap getChangeCoin change
+        F.foldMap TxOut.coin change
         <>
         extraCoinSink
     CS.Internal.Selection

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -215,6 +215,7 @@ import Cardano.Wallet.Shelley.Transaction
     )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
+    , SelectionOf (..)
     , TransactionLayer (..)
     , WitnessCountCtx (..)
     , selectionDelta
@@ -446,7 +447,6 @@ import qualified Cardano.Ledger.Val as Value
 import qualified Cardano.Slotting.EpochInfo as Slotting
 import qualified Cardano.Slotting.Slot as Slotting
 import qualified Cardano.Slotting.Time as Slotting
-import qualified Cardano.Tx.Balance.Internal.CoinSelection as CS.Internal
 import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
@@ -1396,7 +1396,7 @@ binaryCalculationsSpec' era = describe ("calculateBinary - "+||era||+"") $ do
               mkUnsignedTx (shelleyBasedEraFromRecentEra era)
                 (Nothing, slotNo) (Right cs) md mempty [] fee
               TokenMap.empty TokenMap.empty Map.empty Map.empty Nothing
-          cs = CS.Internal.Selection
+          cs = Selection
             { inputs = NE.fromList inps
             , collateral = []
             , extraCoinSource = Coin 0
@@ -1452,7 +1452,7 @@ makeShelleyTx era testCase = Cardano.makeSignedTransaction addrWits unsigned
         mkUnsignedTx era (Nothing, slotNo) (Right cs) md mempty [] fee
         TokenMap.empty TokenMap.empty Map.empty Map.empty Nothing
     addrWits = map (mkShelleyWitness unsigned) pairs
-    cs = CS.Internal.Selection
+    cs = Selection
         { inputs = NE.fromList inps
         , collateral = []
         , extraCoinSource = Coin 0

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -214,7 +214,11 @@ import Cardano.Wallet.Shelley.Transaction
     , _decodeSealedTx
     )
 import Cardano.Wallet.Transaction
-    ( DelegationAction (..), TransactionLayer (..), WitnessCountCtx (..) )
+    ( DelegationAction (..)
+    , TransactionLayer (..)
+    , WitnessCountCtx (..)
+    , selectionDelta
+    )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Cardano.Wallet.Write.Tx
@@ -1387,7 +1391,7 @@ binaryCalculationsSpec' era = describe ("calculateBinary - "+||era||+"") $ do
           mkByronWitness' unsignedTx (_, (TxOut addr _)) =
               mkByronWitness @era unsignedTx net addr
           addrWits = zipWith (mkByronWitness' unsigned) inps pairs
-          fee = toCardanoLovelace $ CS.Internal.selectionDelta TxOut.coin cs
+          fee = toCardanoLovelace $ selectionDelta TxOut.coin cs
           unsigned = either (error . show) id $
               mkUnsignedTx (shelleyBasedEraFromRecentEra era)
                 (Nothing, slotNo) (Right cs) md mempty [] fee
@@ -1443,7 +1447,7 @@ makeShelleyTx era testCase = Cardano.makeSignedTransaction addrWits unsigned
   where
     DecodeSetup utxo outs md slotNo pairs _netwk = testCase
     inps = Map.toList $ unUTxO utxo
-    fee = toCardanoLovelace $ CS.Internal.selectionDelta TxOut.coin cs
+    fee = toCardanoLovelace $ selectionDelta TxOut.coin cs
     unsigned = either (error . show) id $
         mkUnsignedTx era (Nothing, slotNo) (Right cs) md mempty [] fee
         TokenMap.empty TokenMap.empty Map.empty Map.empty Nothing

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -98,8 +98,6 @@ import Cardano.Numeric.Util
     ( power )
 import Cardano.Pool.Types
     ( PoolId (..) )
-import Cardano.Tx.Balance.Internal.CoinSelection
-    ( SelectionOf (..), selectionDelta )
 import Cardano.Wallet
     ( Fee (..)
     , Percentile (..)
@@ -444,6 +442,7 @@ import qualified Cardano.Ledger.Val as Value
 import qualified Cardano.Slotting.EpochInfo as Slotting
 import qualified Cardano.Slotting.Slot as Slotting
 import qualified Cardano.Slotting.Time as Slotting
+import qualified Cardano.Tx.Balance.Internal.CoinSelection as CS.Internal
 import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
@@ -1388,12 +1387,12 @@ binaryCalculationsSpec' era = describe ("calculateBinary - "+||era||+"") $ do
           mkByronWitness' unsignedTx (_, (TxOut addr _)) =
               mkByronWitness @era unsignedTx net addr
           addrWits = zipWith (mkByronWitness' unsigned) inps pairs
-          fee = toCardanoLovelace $ selectionDelta TxOut.coin cs
+          fee = toCardanoLovelace $ CS.Internal.selectionDelta TxOut.coin cs
           unsigned = either (error . show) id $
               mkUnsignedTx (shelleyBasedEraFromRecentEra era)
                 (Nothing, slotNo) (Right cs) md mempty [] fee
               TokenMap.empty TokenMap.empty Map.empty Map.empty Nothing
-          cs = Selection
+          cs = CS.Internal.Selection
             { inputs = NE.fromList inps
             , collateral = []
             , extraCoinSource = Coin 0
@@ -1444,12 +1443,12 @@ makeShelleyTx era testCase = Cardano.makeSignedTransaction addrWits unsigned
   where
     DecodeSetup utxo outs md slotNo pairs _netwk = testCase
     inps = Map.toList $ unUTxO utxo
-    fee = toCardanoLovelace $ selectionDelta TxOut.coin cs
+    fee = toCardanoLovelace $ CS.Internal.selectionDelta TxOut.coin cs
     unsigned = either (error . show) id $
         mkUnsignedTx era (Nothing, slotNo) (Right cs) md mempty [] fee
         TokenMap.empty TokenMap.empty Map.empty Map.empty Nothing
     addrWits = map (mkShelleyWitness unsigned) pairs
-    cs = Selection
+    cs = CS.Internal.Selection
         { inputs = NE.fromList inps
         , collateral = []
         , extraCoinSource = Coin 0

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1391,7 +1391,7 @@ binaryCalculationsSpec' era = describe ("calculateBinary - "+||era||+"") $ do
           mkByronWitness' unsignedTx (_, (TxOut addr _)) =
               mkByronWitness @era unsignedTx net addr
           addrWits = zipWith (mkByronWitness' unsigned) inps pairs
-          fee = toCardanoLovelace $ selectionDelta TxOut.coin cs
+          fee = toCardanoLovelace $ selectionDelta cs
           unsigned = either (error . show) id $
               mkUnsignedTx (shelleyBasedEraFromRecentEra era)
                 (Nothing, slotNo) (Right cs) md mempty [] fee
@@ -1447,7 +1447,7 @@ makeShelleyTx era testCase = Cardano.makeSignedTransaction addrWits unsigned
   where
     DecodeSetup utxo outs md slotNo pairs _netwk = testCase
     inps = Map.toList $ unUTxO utxo
-    fee = toCardanoLovelace $ selectionDelta TxOut.coin cs
+    fee = toCardanoLovelace $ selectionDelta cs
     unsigned = either (error . show) id $
         mkUnsignedTx era (Nothing, slotNo) (Right cs) md mempty [] fee
         TokenMap.empty TokenMap.empty Map.empty Map.empty Nothing


### PR DESCRIPTION
## Issues

ADP-1449
ADP-3124

## Summary

This PR makes `balanceTransaction` (and the module hierarchy that contains it) the **sole consumer** of types and functions from `cardano-coin-selection`.

## Details

This PR:
- Moves the `selectionDelta` function to `Cardano.Wallet.Transaction` and simplifies it.
- Clones the `SelectionOf` type to `Cardano.Wallet.Transaction`.
- Adjusts the `TransactionLayer` to use `Cardano.Wallet.Transaction.SelectionOf`.
- Deletes multiple unused functions, fields, and types that are no longer used.

## Motivation

1. Completely hide the use of `cardano-coin-selection` behind the abstraction provided by `balanceTransaction`.
1. Future PRs will make changes to the `SelectionOf` type found within `cardano-coin-selection`. These changes will render it incompatible with the usages found in `Cardano.Wallet.Transaction`.