### PR TITLE
Use truncated subtraction in `assignCoinsToChangeMaps`.

### DIFF
--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -1572,7 +1572,7 @@ assignCoinsToChangeMaps adaAvailable minCoinFor pairsAtStart
                 -- Calculate the amount of ada that remains after assigning the
                 -- minimum amount to each map. This should be safe, as we have
                 -- already determined that we have enough ada available:
-                adaRemaining = adaAvailable `Coin.distance` adaRequired
+                adaRemaining = adaAvailable <\> adaRequired
                 -- Partition any remaining ada according to the weighted
                 -- distribution of output coins that remain in our list:
                 outputCoinsRemaining = snd <$> (pair :| pairs)
@@ -1590,7 +1590,7 @@ assignCoinsToChangeMaps adaAvailable minCoinFor pairsAtStart
             -- required amount of every asset map, but we do have an empty
             -- asset map that is safe to drop. This will reduce the amount of
             -- ada required by a small amount:
-            let adaRequired' = adaRequired `Coin.distance` minCoinFor m in
+            let adaRequired' = adaRequired <\> minCoinFor m in
             loop adaRequired' (p :| ps)
 
         (m, _) :| [] | TokenMap.isEmpty m && adaAvailable < adaRequired ->


### PR DESCRIPTION
## Issues

- Follow-on from #4110
- ADP-1449

## Description

This PR replaces the use of `Coin.distance` with [`Monus.<\>`](https://hackage.haskell.org/package/monoid-subclasses-1.2.3/docs/Data-Monoid-Monus.html#v:-60--92--62-), which (in the case of `Coin` arguments) performs truncated subtraction of the second argument from the first.