### PR TITLE
Simplify multi-asset value conversions.

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/CollateralOutputs.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/CollateralOutputs.hs
@@ -10,15 +10,16 @@ import Prelude
 import Cardano.Wallet.Read.Eras
     ( EraFun (..), K (..) )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
-    ( fromCardanoValue, fromShelleyAddress )
+    ( fromShelleyAddress )
 import Cardano.Wallet.Read.Tx.CollateralOutputs
     ( CollateralOutputs (..) )
+import Cardano.Wallet.Shelley.Compatibility.Ledger
+    ( toWalletTokenBundle )
 import Data.Maybe.Strict
     ( strictMaybeToMaybe )
 import Ouroboros.Consensus.Shelley.Eras
     ( StandardBabbage, StandardConway )
 
-import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Ledger.Babbage as Babbage
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
@@ -40,12 +41,10 @@ fromBabbageTxOut
     :: Babbage.BabbageTxOut StandardBabbage
     -> W.TxOut
 fromBabbageTxOut (Babbage.BabbageTxOut addr value _datum _refScript) =
-    W.TxOut (fromShelleyAddress addr) $
-    fromCardanoValue $ Cardano.fromMaryValue value
+    W.TxOut (fromShelleyAddress addr) (toWalletTokenBundle value)
 
 fromConwayTxOut
     :: Babbage.BabbageTxOut StandardConway
     -> W.TxOut
 fromConwayTxOut (Babbage.BabbageTxOut addr value _datum _refScript) =
-    W.TxOut (fromShelleyAddress addr) $
-    fromCardanoValue $ Cardano.fromMaryValue value
+    W.TxOut (fromShelleyAddress addr) (toWalletTokenBundle value)

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Outputs.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Outputs.hs
@@ -28,6 +28,8 @@ import Cardano.Wallet.Read.Eras
     ( EraFun (..), K (..) )
 import Cardano.Wallet.Read.Tx.Outputs
     ( Outputs (..) )
+import Cardano.Wallet.Shelley.Compatibility.Ledger
+    ( toWalletTokenBundle )
 import Cardano.Wallet.Util
     ( internalError )
 import Data.Foldable
@@ -89,22 +91,19 @@ fromAllegraTxOut (SL.ShelleyTxOut addr amount) = W.TxOut
 
 fromMaryTxOut :: SL.ShelleyTxOut StandardMary -> W.TxOut
 fromMaryTxOut (SL.ShelleyTxOut addr value) =
-    W.TxOut (fromShelleyAddress addr) $
-    fromCardanoValue $ Cardano.fromMaryValue value
+    W.TxOut (fromShelleyAddress addr) (toWalletTokenBundle value)
 
 fromAlonzoTxOut
     :: Alonzo.AlonzoTxOut StandardAlonzo
     -> W.TxOut
 fromAlonzoTxOut (Alonzo.AlonzoTxOut addr value _) =
-    W.TxOut (fromShelleyAddress addr) $
-    fromCardanoValue $ Cardano.fromMaryValue value
+    W.TxOut (fromShelleyAddress addr) (toWalletTokenBundle value)
 
 fromBabbageTxOut
     :: Babbage.BabbageTxOut StandardBabbage
     -> (W.TxOut, Maybe (AlonzoScript (Babbage.BabbageEra SL.StandardCrypto)))
 fromBabbageTxOut (Babbage.BabbageTxOut addr value _datum refScript) =
-    ( W.TxOut (fromShelleyAddress addr) $
-      fromCardanoValue $ Cardano.fromMaryValue value
+    ( W.TxOut (fromShelleyAddress addr) (toWalletTokenBundle value)
     , case refScript of
           SJust s -> Just s
           SNothing -> Nothing
@@ -114,8 +113,7 @@ fromConwayTxOut
     :: Babbage.BabbageTxOut StandardConway
     -> (W.TxOut, Maybe (AlonzoScript (Conway.ConwayEra SL.StandardCrypto)))
 fromConwayTxOut (Babbage.BabbageTxOut addr value _datum refScript) =
-    ( W.TxOut (fromShelleyAddress addr) $
-      fromCardanoValue $ Cardano.fromMaryValue value
+    ( W.TxOut (fromShelleyAddress addr) (toWalletTokenBundle value)
     , case refScript of
           SJust s -> Just s
           SNothing -> Nothing


### PR DESCRIPTION
## Issue

None. Noticed while browsing the code.

## Summary

This PR makes the following simplification in several places:
    
```patch
- fromCardanoValue . Cardano.fromMaryValue
+ toWalletTokenBundle
```
  
The original expression performs a two-step conversion of multi-asset (MA) values:
    
1. From a `cardano-ledger` MA value (nested map) to a `cardano-api` MA value (flat map)
2. From a `cardano-api` MA value (flat map) to a `cardano-wallet` MA value (nested map)
    
The `toWalletTokenBundle` function performs this conversion in a single step, and doesn't require the creation of an intermediate `cardano-api` MA value.
