### PR TITLE
Remove duplicated imports.

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/wallet/src/Cardano/Wallet/Write/Tx/Balance.hs
@@ -91,14 +91,12 @@ import Cardano.Ledger.Api
     , feeTxBodyL
     , inputsTxBodyL
     , outputsTxBodyL
-    , outputsTxBodyL
     , ppMaxTxSizeL
     )
 import Cardano.Ledger.UTxO
     ( txinLookup )
 import Cardano.Tx.Balance.Internal.CoinSelection
     ( Selection
-    , SelectionBalanceError (..)
     , SelectionBalanceError (..)
     , SelectionCollateralError (..)
     , SelectionCollateralRequirement (..)


### PR DESCRIPTION
This PR removes a couple of duplicated imports. (It seems that `stylish-haskell` doesn't automatically remove duplicates.)