### PR TITLE
Use `Cardano.Ledger.Coin` in type signature of `balanceTransaction`.

### DIFF
--- a/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/Balance.hs
@@ -119,7 +119,7 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
 import Cardano.Wallet.Write.ProtocolParameters
     ( ProtocolParameters (..) )
 import Cardano.Wallet.Write.Tx
-    ( Coin
+    ( Coin (..)
     , FeePerByte (..)
     , IsRecentEra (..)
     , KeyWitnessCount (..)
@@ -311,7 +311,7 @@ data ErrBalanceTxAssetsInsufficientError = ErrBalanceTxAssetsInsufficientError
     deriving (Eq, Generic, Show)
 
 data ErrBalanceTxInternalError
-    = ErrUnderestimatedFee W.Coin SealedTx KeyWitnessCount
+    = ErrUnderestimatedFee Coin SealedTx KeyWitnessCount
     | ErrFailedBalancing Cardano.Value
     deriving (Show, Eq)
 
@@ -655,7 +655,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             | otherwise ->
                 throwE . ErrBalanceTxInternalError $
                 ErrUnderestimatedFee
-                    (W.Coin.unsafeFromIntegral (-c))
+                    (Coin (-c))
                     (toSealed candidateTx)
                     witCount
 
@@ -669,7 +669,9 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     TxFeeAndChange updatedFee updatedChange <- withExceptT
         (\(ErrMoreSurplusNeeded c) ->
             ErrBalanceTxInternalError $
-                ErrUnderestimatedFee c (toSealed candidateTx) witCount)
+            ErrUnderestimatedFee
+                (W.toLedgerCoin c) (toSealed candidateTx) witCount
+        )
         (ExceptT . pure $
             distributeSurplus feePerByte surplus feeAndChange)
 

--- a/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/Balance.hs
@@ -119,7 +119,8 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
 import Cardano.Wallet.Write.ProtocolParameters
     ( ProtocolParameters (..) )
 import Cardano.Wallet.Write.Tx
-    ( FeePerByte (..)
+    ( Coin
+    , FeePerByte (..)
     , IsRecentEra (..)
     , KeyWitnessCount (..)
     , PParams
@@ -263,7 +264,7 @@ data ErrBalanceTxInsufficientCollateralError =
     ErrBalanceTxInsufficientCollateralError
     { largestCombinationAvailable :: W.UTxO
         -- ^ The largest available combination of pure ada UTxOs.
-    , minimumCollateralAmount :: W.Coin
+    , minimumCollateralAmount :: Coin
         -- ^ The minimum quantity of ada necessary for collateral.
     }
     deriving (Eq, Generic, Show)
@@ -1469,7 +1470,7 @@ coinSelectionErrorToBalanceTxError = \case
                 & fmap W.TokenBundle.fromCoin
                 & toExternalUTxOMap
             , minimumCollateralAmount
-                = minimumSelectionAmount
+                = W.toLedgerCoin minimumSelectionAmount
             }
 
 --------------------------------------------------------------------------------

--- a/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/Balance.hs
@@ -278,14 +278,14 @@ data ErrBalanceTxInsufficientCollateralError =
 --
 data ErrBalanceTxUnableToCreateChangeError =
     ErrBalanceTxUnableToCreateChangeError
-    { requiredCost :: !W.Coin
+    { requiredCost :: !Coin
         -- ^ An estimate of the minimal fee required for this transaction to
         -- be considered valid.
         --
         -- TODO: ADP-2547
         -- Investigate whether this field is really appropriate and necessary,
         -- and if not, remove it.
-    , shortfall :: !W.Coin
+    , shortfall :: !Coin
         -- ^ The total additional quantity of ada required to pay for the
         -- minimum ada quantities of all change outputs as well as the
         -- marginal fee for including these outputs in the transaction.
@@ -1456,7 +1456,9 @@ coinSelectionErrorToBalanceTxError = \case
                 UnableToConstructChangeError {shortfall, requiredCost} ->
                     ErrBalanceTxUnableToCreateChange
                     ErrBalanceTxUnableToCreateChangeError
-                        {shortfall, requiredCost}
+                        { shortfall = W.toLedgerCoin shortfall
+                        , requiredCost = W.toLedgerCoin requiredCost
+                        }
             EmptyUTxO ->
                 ErrBalanceTxUnableToCreateInput
     SelectionCollateralErrorOf SelectionCollateralError

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -14,15 +14,15 @@
 -- 'IsServerError' definition along with most instances
 --
 module Cardano.Wallet.Api.Http.Server.Error
-  ( IsServerError (..)
-  , liftHandler
-  , liftE
-  , apiError
-  , err425
-  , showT
-  , handler
-  )
-  where
+    ( IsServerError (..)
+    , liftHandler
+    , liftE
+    , apiError
+    , err425
+    , showT
+    , handler
+    )
+    where
 
 import Prelude
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -565,7 +565,7 @@ instance IsServerError ErrBalanceTx where
                 , "is not enough ada available to pay for the fee and"
                 , "also pay for the minimum ada quantities of all"
                 , "change outputs. I need approximately"
-                , pretty (view #shortfall e)
+                , pretty (toWalletCoin (view #shortfall e))
                 , "ada to proceed. Try increasing your wallet balance"
                 , "or sending a smaller amount."
                 ]

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -100,6 +100,8 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( Flat (..) )
 import Cardano.Wallet.Primitive.Types.Tx.SealedTx
     ( serialisedTx )
+import Cardano.Wallet.Shelley.Compatibility.Ledger
+    ( toWalletCoin )
 import Cardano.Wallet.Transaction
     ( ErrSignTx (..) )
 import Cardano.Wallet.Write.Tx.Balance
@@ -993,7 +995,7 @@ instance IsServerError ErrBalanceTxInsufficientCollateralError where
             , "of pure ada UTxOs in your wallet is insufficient to cover"
             , "the minimum amount of collateral required."
             , "I need an ada amount of at least:"
-            , pretty (view #minimumCollateralAmount e)
+            , pretty (toWalletCoin (view #minimumCollateralAmount e))
             , "The largest combination of pure ada UTxOs I could find is:"
             , pretty $ listF $ L.sort
                 $ fmap (view #coin . view #tokens . snd)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -129,8 +129,6 @@ import Data.List
     ( isInfixOf, isPrefixOf, isSubsequenceOf )
 import Data.Maybe
     ( isJust )
-import Data.Quantity
-    ( Quantity (Quantity) )
 import Data.Text
     ( Text )
 import Data.Text.Class
@@ -575,12 +573,12 @@ instance IsServerError ErrBalanceTxInternalError where
         ErrUnderestimatedFee coin candidateTx (KeyWitnessCount nWits nBootWits) ->
             apiError err500 (BalanceTxUnderestimatedFee info) $ T.unwords
                 [ "I have somehow underestimated the fee of the transaction by"
-                , pretty coin, "and cannot finish balancing."
+                , pretty (toWalletCoin coin), "and cannot finish balancing."
                 ]
 
           where
             info = ApiErrorBalanceTxUnderestimatedFee
-                { underestimation = Quantity $ Coin.toNatural coin
+                { underestimation = Coin.toQuantity $ toWalletCoin coin
                 , candidateTxHex = hexText $ serialisedTx candidateTx
                 , candidateTxReadable = T.pack (show candidateTx)
                 , estimatedNumberOfKeyWits = intCast nWits

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -487,7 +487,7 @@ import Cardano.Wallet.Shelley.Compatibility
     , fromCardanoWdrls
     )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( toWallet )
+    ( toWallet, toWalletCoin )
 import Cardano.Wallet.Shelley.Transaction
     ( txWitnessTagForKey )
 import Cardano.Wallet.Transaction
@@ -2922,7 +2922,7 @@ calculateFeePercentiles
     handleCannotCover = \case
         ErrBalanceTxUnableToCreateChange
             ErrBalanceTxUnableToCreateChangeError {requiredCost} ->
-                pure $ Fee requiredCost
+                pure $ Fee $ toWalletCoin requiredCost
         e -> throwE e
 
 -- | Make a pair of fee estimation percentiles more imprecise.

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -202,7 +202,7 @@ import Cardano.Wallet.Shelley.Compatibility
     , toCardanoValue
     )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( toBabbageTxOut, toLedger, toLedgerTokenBundle, toWallet )
+    ( toBabbageTxOut, toLedger, toLedgerTokenBundle, toWallet, toWalletCoin )
 import Cardano.Wallet.Shelley.Transaction
     ( EraConstraints
     , TxWitnessTag (..)
@@ -3260,7 +3260,8 @@ prop_balanceTransactionValid
             Left (ErrBalanceTxInternalError
                  (ErrUnderestimatedFee delta candidateTx nWits)) ->
                 let counterexampleText = unlines
-                        [ "underestimated fee by " <> pretty delta
+                        [ "underestimated fee by "
+                            <> pretty (toWalletCoin delta)
                         , "candidate tx: " <> pretty candidateTx
                         , "assuming key witness count: " <> show nWits
                         ]

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1112,17 +1112,18 @@ decodeSealedTxSpec = describe "SealedTx serialisation/deserialisation" $ do
 feeEstimationRegressionSpec :: Spec
 feeEstimationRegressionSpec = describe "Regression tests" $ do
     it "#1740 Fee estimation at the boundaries" $ do
-        let requiredCost = Fee (Coin.fromNatural 166_029)
+        let requiredCostLovelace :: Natural
+            requiredCostLovelace = 166_029
         let estimateFee = except $ Left
                 $ ErrBalanceTxUnableToCreateChange
                 $ ErrBalanceTxUnableToCreateChangeError
-                    { requiredCost = feeToCoin requiredCost
-                    , shortfall = Coin 100_000
+                    { requiredCost = Ledger.Coin $ intCast requiredCostLovelace
+                    , shortfall = Ledger.Coin 100_000
                     }
         result <- runExceptT (calculateFeePercentiles estimateFee)
         result `shouldBe` Right
-            ( Percentile requiredCost
-            , Percentile requiredCost
+            ( Percentile $ Fee $ Coin requiredCostLovelace
+            , Percentile $ Fee $ Coin requiredCostLovelace
             )
 
 binaryCalculationsSpec :: AnyRecentEra -> Spec


### PR DESCRIPTION
## Issue

ADP-3157

## Summary

This PR replaces the use of `Cardano.Wallet.Primitive.Types.Coin` with `Cardano.Ledger.Coin` in the type signature of `balanceTransaction`.