### PR TITLE
Revise terminology in test for `ErrBalanceTxAssetsInsufficient`.

### DIFF
--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3232,18 +3232,18 @@ prop_balanceTransactionValid
                         -- , prop_outputsSatisfyMinAdaRequirement tx
                         ]
             Left (ErrBalanceTxAssetsInsufficient err) -> do
-                let missing = view #shortfall err
-                let missingCoin = Value.coin missing == mempty
-                let missingTokens = Value.isAdaOnly missing
-                case (missingCoin, missingTokens) of
+                let shortfall = view #shortfall err
+                let shortfallCoin = Value.coin shortfall == mempty
+                let shortfallTokens = Value.isAdaOnly shortfall
+                case (shortfallCoin, shortfallTokens) of
                     (False, False) ->
-                        label "missing coin and tokens" $
+                        label "shortfall coin and tokens" $
                         property True
                     (False, True) ->
-                        label "missing coin" $
+                        label "shortfall coin" $
                         property True
                     (True, False) ->
-                        label "missing tokens" $
+                        label "shortfall tokens" $
                         counterexample (show err) $ property True
                     (True, True) ->
                         property False


### PR DESCRIPTION
## Issue

Follow-on PR from review of #4134.

## Summary

This PR revises the terminology used within the test for `ErrBalanceTxAssetsInsufficient`.