### PR TITLE
Parameterise `ErrBalanceTx` by `era`.

### DIFF
--- a/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/Balance.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -338,7 +339,9 @@ data ErrBalanceTx era
     --   - the given partial transaction has no existing inputs; and
     --   - the given UTxO index is empty.
     -- A transaction must have at least one input in order to be valid.
-    deriving (Show, Eq)
+
+deriving instance Eq (ErrBalanceTx era)
+deriving instance Show (ErrBalanceTx era)
 
 -- | A 'PartialTx' is an an unbalanced 'SealedTx' along with the necessary
 -- information to balance it.

--- a/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/Balance.hs
@@ -318,7 +318,7 @@ data ErrBalanceTxInternalError
     deriving (Show, Eq)
 
 -- | Errors that can occur when balancing transactions.
-data ErrBalanceTx
+data ErrBalanceTx era
     = ErrBalanceTxUpdateError ErrUpdateSealedTx
     | ErrBalanceTxAssetsInsufficient ErrBalanceTxAssetsInsufficientError
     | ErrBalanceTxMaxSizeLimitExceeded
@@ -435,7 +435,7 @@ balanceTransaction
     -> ChangeAddressGen changeState
     -> changeState
     -> PartialTx era
-    -> ExceptT ErrBalanceTx m (Cardano.Tx era, changeState)
+    -> ExceptT (ErrBalanceTx era) m (Cardano.Tx era, changeState)
 balanceTransaction
     utxoAssumptions
     pp
@@ -468,7 +468,7 @@ balanceTransaction
   where
     -- Determines whether or not the minimal selection strategy is worth trying.
     -- This depends upon the way in which the optimal selection strategy failed.
-    minimalStrategyIsWorthTrying :: ErrBalanceTx -> Bool
+    minimalStrategyIsWorthTrying :: ErrBalanceTx era -> Bool
     minimalStrategyIsWorthTrying e = or
         [ maxSizeLimitExceeded
         , unableToConstructChange
@@ -545,7 +545,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     -> changeState
     -> SelectionStrategy
     -> PartialTx era
-    -> ExceptT ErrBalanceTx m (Cardano.Tx era, changeState)
+    -> ExceptT (ErrBalanceTx era) m (Cardano.Tx era, changeState)
 balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     utxoAssumptions
     protocolParameters@(ProtocolParameters pp)
@@ -711,7 +711,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     -- Left (ErrBalanceTxUnresolvedInputs [inA, inC])
     extractExternallySelectedUTxO
         :: PartialTx era
-        -> ExceptT ErrBalanceTx m (UTxOIndex.UTxOIndex WalletUTxO)
+        -> ExceptT (ErrBalanceTx era) m (UTxOIndex.UTxOIndex WalletUTxO)
     extractExternallySelectedUTxO (PartialTx tx _ _rdms) =
         withConstraints era $ do
             let res = flip map txIns $ \i-> do
@@ -739,7 +739,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     guardTxSize
         :: KeyWitnessCount
         -> Cardano.Tx era
-        -> ExceptT ErrBalanceTx m (Cardano.Tx era)
+        -> ExceptT (ErrBalanceTx era) m (Cardano.Tx era)
     guardTxSize witCount cardanoTx =
         withConstraints era $ do
             let tx = fromCardanoTx cardanoTx
@@ -748,7 +748,9 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 throwE ErrBalanceTxMaxSizeLimitExceeded
             pure cardanoTx
 
-    guardTxBalanced :: Cardano.Tx era -> ExceptT ErrBalanceTx m (Cardano.Tx era)
+    guardTxBalanced
+        :: Cardano.Tx era
+        -> ExceptT (ErrBalanceTx era) m (Cardano.Tx era)
     guardTxBalanced tx = do
         let bal = txBalance tx
         if bal == mempty
@@ -764,7 +766,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 
     balanceAfterSettingMinFee
         :: Cardano.Tx era
-        -> ExceptT ErrBalanceTx m
+        -> ExceptT (ErrBalanceTx era) m
             (Cardano.Value, Cardano.Lovelace, KeyWitnessCount)
     balanceAfterSettingMinFee tx = ExceptT . pure $ do
         let witCount = estimateKeyWitnessCount combinedUTxO (getBody tx)
@@ -790,7 +792,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     -- check easier, even if it may be useful in other regards.
     guardWalletUTxOConsistencyWith
         :: Cardano.UTxO era
-        -> ExceptT ErrBalanceTx m ()
+        -> ExceptT (ErrBalanceTx era) m ()
     guardWalletUTxOConsistencyWith u' = do
         let W.UTxO u = toWalletUTxO (recentEra @era) $ fromCardanoUTxO u'
         let conflicts = lefts $ flip map (Map.toList u) $ \(i, o) ->
@@ -826,7 +828,9 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
            RecentEraBabbage -> W.fromBabbageTxOut o
            RecentEraConway -> W.fromConwayTxOut o
 
-    assembleTransaction :: TxUpdate -> ExceptT ErrBalanceTx m (Cardano.Tx era)
+    assembleTransaction
+        :: TxUpdate
+        -> ExceptT (ErrBalanceTx era) m (Cardano.Tx era)
     assembleTransaction update = ExceptT . pure $ do
         tx' <- left ErrBalanceTxUpdateError $ updateTx partialTx update
         left ErrBalanceTxAssignRedeemers $
@@ -834,7 +838,8 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 pp timeTranslation combinedUTxO redeemers tx'
 
     guardConflictingWithdrawalNetworks
-        :: Cardano.Tx era -> ExceptT ErrBalanceTx m ()
+        :: Cardano.Tx era
+        -> ExceptT (ErrBalanceTx era) m ()
     guardConflictingWithdrawalNetworks
         (Cardano.Tx (Cardano.TxBody body) _) = do
         -- Use of withdrawals with different networks breaks balancing.
@@ -857,7 +862,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         when conflictingWdrlNetworks $
             throwE ErrBalanceTxConflictingNetworks
 
-    guardExistingCollateral :: Cardano.Tx era -> ExceptT ErrBalanceTx m ()
+    guardExistingCollateral :: Cardano.Tx era -> ExceptT (ErrBalanceTx era) m ()
     guardExistingCollateral (Cardano.Tx (Cardano.TxBody body) _) = do
         -- Coin selection does not support pre-defining collateral. In Sep 2021
         -- consensus was that we /could/ allow for it with just a day's work or
@@ -869,14 +874,18 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             Cardano.TxInsCollateral _ _ ->
                 throwE ErrBalanceTxExistingCollateral
 
-    guardExistingTotalCollateral :: Cardano.Tx era -> ExceptT ErrBalanceTx m ()
+    guardExistingTotalCollateral
+        :: Cardano.Tx era
+        -> ExceptT (ErrBalanceTx era) m ()
     guardExistingTotalCollateral (Cardano.Tx (Cardano.TxBody body) _) =
         case Cardano.txTotalCollateral body of
             Cardano.TxTotalCollateralNone -> return ()
             Cardano.TxTotalCollateral _ _ ->
                throwE ErrBalanceTxExistingTotalCollateral
 
-    guardExistingReturnCollateral :: Cardano.Tx era -> ExceptT ErrBalanceTx m ()
+    guardExistingReturnCollateral
+        :: Cardano.Tx era
+        -> ExceptT (ErrBalanceTx era) m ()
     guardExistingReturnCollateral (Cardano.Tx (Cardano.TxBody body) _) =
         case Cardano.txReturnCollateral body of
             Cardano.TxReturnCollateralNone -> return ()
@@ -907,21 +916,21 @@ selectAssets
     -> ChangeAddressGen changeState
     -> SelectionStrategy
     -- ^ A function to assess the size of a token bundle.
-    -> Either ErrBalanceTx Selection
+    -> Either (ErrBalanceTx era) Selection
 selectAssets era (ProtocolParameters pp) utxoAssumptions outs redeemers
     utxoSelection balance fee0 seed changeGen selectionStrategy = do
         validateTxOutputs'
         performSelection'
   where
     validateTxOutputs'
-        :: Either ErrBalanceTx ()
+        :: Either (ErrBalanceTx era) ()
     validateTxOutputs'
         = left ErrBalanceTxOutputError
         $ validateTxOutputs selectionConstraints
             (outs <&> \out -> (view #address out, view #tokens out))
 
     performSelection'
-        :: Either ErrBalanceTx Selection
+        :: Either (ErrBalanceTx era) Selection
     performSelection'
         = left coinSelectionErrorToBalanceTxError
         $ (`evalRand` stdGenFromSeed seed) . runExceptT
@@ -1445,7 +1454,7 @@ toWalletTxOut RecentEraConway = W.fromConwayTxOut
 --
 coinSelectionErrorToBalanceTxError
     :: SelectionError WalletSelectionContext
-    -> ErrBalanceTx
+    -> ErrBalanceTx era
 coinSelectionErrorToBalanceTxError = \case
     SelectionBalanceErrorOf balanceErr ->
         case balanceErr of

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -489,7 +489,7 @@ instance IsServerError ErrWriteTxEra where
                 , "compatible with a recent era."
                 ]
 
-instance IsServerError ErrBalanceTx where
+instance IsServerError (ErrBalanceTx era) where
     toServerError = \case
         ErrBalanceTxUpdateError (ErrExistingKeyWitnesses n) ->
             apiError err403 BalanceTxExistingKeyWitnesses $ mconcat

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2043,7 +2043,7 @@ buildAndSignTransactionPure
     -> TransactionCtx
     -> StateT
         (Wallet s)
-        (ExceptT (Either ErrBalanceTx ErrConstructTx) (Rand StdGen))
+        (ExceptT (Either (ErrBalanceTx era) ErrConstructTx) (Rand StdGen))
         BuiltTx
 buildAndSignTransactionPure
     timeTranslation utxoIndex rootKey passphraseScheme userPassphrase
@@ -2182,7 +2182,7 @@ buildTransactionPure
     -> PreSelection
     -> TransactionCtx
     -> ExceptT
-        (Either ErrBalanceTx ErrConstructTx)
+        (Either (ErrBalanceTx era) ErrConstructTx)
         (Rand StdGen)
         (Cardano.Tx era, s)
 buildTransactionPure
@@ -2877,10 +2877,10 @@ transactionFee DBLayer{atomically, walletState} protocolParams txLayer
 -- returning 1st and 9nth decile (10nth and 90nth percentile) values of a
 -- recoded distribution.
 calculateFeePercentiles
-    :: forall m
+    :: forall m era
      . Monad m
-    => ExceptT ErrBalanceTx m Fee
-    -> ExceptT ErrBalanceTx m (Percentile 10 Fee, Percentile 90 Fee)
+    => ExceptT (ErrBalanceTx era) m Fee
+    -> ExceptT (ErrBalanceTx era) m (Percentile 10 Fee, Percentile 90 Fee)
 calculateFeePercentiles
     = fmap deciles
     . handleErrors
@@ -2920,7 +2920,7 @@ calculateFeePercentiles
     -- Therefore, we convert "cannot cover" errors into the necessary
     -- fee amount, even though there isn't enough in the wallet
     -- to cover for these fees.
-    handleCannotCover :: ErrBalanceTx -> ExceptT ErrBalanceTx m Fee
+    handleCannotCover :: ErrBalanceTx era -> ExceptT (ErrBalanceTx era) m Fee
     handleCannotCover = \case
         ErrBalanceTxUnableToCreateChange
             ErrBalanceTxUnableToCreateChangeError {requiredCost} ->
@@ -3477,7 +3477,7 @@ data WalletException
     | ExceptionConstructSharedWallet ErrConstructSharedWallet
     | ExceptionReadAccountPublicKey ErrReadAccountPublicKey
     | ExceptionSignPayment ErrSignPayment
-    | ExceptionBalanceTx ErrBalanceTx
+    | forall era. ExceptionBalanceTx (ErrBalanceTx era)
     | ExceptionWriteTxEra ErrWriteTxEra
     | ExceptionBalanceTxInternalError ErrBalanceTxInternalError
     | ExceptionSubmitTransaction ErrSubmitTransaction

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2918,7 +2918,7 @@ balanceTx
     -> TimeTranslation
     -> StdGenSeed
     -> PartialTx era
-    -> Either ErrBalanceTx (Cardano.Tx era)
+    -> Either (ErrBalanceTx era) (Cardano.Tx era)
 balanceTx
     (Wallet' utxoAssumptions utxo (AnyChangeAddressGenWithState genChange s))
     protocolParameters
@@ -2944,7 +2944,7 @@ balanceTransactionWithDummyChangeState
     -> UTxO
     -> StdGenSeed
     -> PartialTx era
-    -> Either ErrBalanceTx (Cardano.Tx era, DummyChangeState)
+    -> Either (ErrBalanceTx era) (Cardano.Tx era, DummyChangeState)
 balanceTransactionWithDummyChangeState utxoAssumptions utxo seed partialTx =
     (`evalRand` stdGenFromSeed seed) $ runExceptT $
         balanceTransaction

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -656,7 +656,7 @@ prop_calculateFeePercentiles (NonEmpty coins) =
                     `closeTo` (1/10 :: Double)
                 ]
   where
-    genericError :: ErrBalanceTx
+    genericError :: ErrBalanceTx era
     genericError
         = ErrBalanceTxAssetsInsufficient
         $ ErrBalanceTxAssetsInsufficientError
@@ -664,7 +664,7 @@ prop_calculateFeePercentiles (NonEmpty coins) =
             mempty
             mempty
 
-    estimateFee :: ExceptT ErrBalanceTx (State Int) W.Fee
+    estimateFee :: ExceptT (ErrBalanceTx era) (State Int) W.Fee
     estimateFee = do
         i <- lift get
         lift $ put $ (i + 1) `mod` length coins


### PR DESCRIPTION
## Issue

ADP-3157

## Description

This PR adds an `era` parameter to the `ErrBalanceTx` type. This makes it possible to convert more of the `ErrBalanceTx` constructors to use ledger types, which are often parameterised by an `era`.