### PR TITLE
Simplify types exported by `Write.Tx`.

### DIFF
--- a/lib/balance-tx/lib/Cardano/Wallet/Write/Tx.hs
+++ b/lib/balance-tx/lib/Cardano/Wallet/Write/Tx.hs
@@ -94,7 +94,7 @@ module Cardano.Wallet.Write.Tx
     , Ledger.TxId
 
     -- * TxOut
-    , Core.TxOut
+    , TxOut
     , BabbageTxOut (..)
     , TxOutInBabbage
     , TxOutInRecentEra (..)

--- a/lib/balance-tx/lib/Cardano/Wallet/Write/Tx.hs
+++ b/lib/balance-tx/lib/Cardano/Wallet/Write/Tx.hs
@@ -515,9 +515,9 @@ modifyTxOutValue
     -> TxOut era
     -> TxOut era
 modifyTxOutValue RecentEraConway f (BabbageTxOut addr val dat script) =
-        BabbageTxOut addr (f val) dat script
+    BabbageTxOut addr (f val) dat script
 modifyTxOutValue RecentEraBabbage f (BabbageTxOut addr val dat script) =
-        BabbageTxOut addr (f val) dat script
+    BabbageTxOut addr (f val) dat script
 
 modifyTxOutCoin
     :: RecentEra era

--- a/lib/balance-tx/lib/Cardano/Wallet/Write/Tx.hs
+++ b/lib/balance-tx/lib/Cardano/Wallet/Write/Tx.hs
@@ -669,7 +669,7 @@ isBelowMinimumCoinForTxOut era pp out =
 -- | Construct a 'UTxO era' using 'TxIn's and 'TxOut's in said era.
 utxoFromTxOuts
     :: RecentEra era
-    -> [(TxIn, Core.TxOut (ShelleyLedgerEra era))]
+    -> [(TxIn, TxOut era)]
     -> (Shelley.UTxO (ShelleyLedgerEra era))
 utxoFromTxOuts era = withConstraints era $
     Shelley.UTxO . Map.fromList

--- a/lib/balance-tx/lib/Cardano/Wallet/Write/Tx.hs
+++ b/lib/balance-tx/lib/Cardano/Wallet/Write/Tx.hs
@@ -509,27 +509,16 @@ unsafeMkTxIn hash ix = Ledger.mkTxInPartial
 
 type TxOut era = Core.TxOut (ShelleyLedgerEra era)
 
-modifyTxOutValue
-    :: RecentEra era
-    -> (Value -> Value)
-    -> TxOut era
-    -> TxOut era
+modifyTxOutValue :: RecentEra era -> (Value -> Value) -> TxOut era -> TxOut era
 modifyTxOutValue RecentEraConway f (BabbageTxOut addr val dat script) =
     BabbageTxOut addr (f val) dat script
 modifyTxOutValue RecentEraBabbage f (BabbageTxOut addr val dat script) =
     BabbageTxOut addr (f val) dat script
 
-modifyTxOutCoin
-    :: RecentEra era
-    -> (Coin -> Coin)
-    -> TxOut era
-    -> TxOut era
+modifyTxOutCoin :: RecentEra era -> (Coin -> Coin) -> TxOut era -> TxOut era
 modifyTxOutCoin era = modifyTxOutValue era . modifyCoin
 
-txOutValue
-    :: RecentEra era
-    -> TxOut era
-    -> Value
+txOutValue :: RecentEra era -> TxOut era -> Value
 txOutValue RecentEraConway (Babbage.BabbageTxOut _ val _ _) = val
 txOutValue RecentEraBabbage (Babbage.BabbageTxOut _ val _ _) = val
 
@@ -572,10 +561,7 @@ data TxOutInRecentEra
         (Maybe (AlonzoScript LatestLedgerEra))
         -- Same contents as 'TxOut LatestLedgerEra'.
 
-unwrapTxOutInRecentEra
-    :: RecentEra era
-    -> TxOutInRecentEra
-    -> TxOut era
+unwrapTxOutInRecentEra :: RecentEra era -> TxOutInRecentEra -> TxOut era
 unwrapTxOutInRecentEra era recentEraTxOut = case era of
     RecentEraConway -> recentEraToConwayTxOut recentEraTxOut
     RecentEraBabbage -> recentEraToBabbageTxOut recentEraTxOut
@@ -638,9 +624,7 @@ computeMinimumCoinForTxOut
 computeMinimumCoinForTxOut era pp out = withConstraints era $
     Core.getMinCoinTxOut pp (withMaxLengthSerializedCoin out)
   where
-    withMaxLengthSerializedCoin
-        :: TxOut era
-        -> TxOut era
+    withMaxLengthSerializedCoin :: TxOut era -> TxOut era
     withMaxLengthSerializedCoin =
         modifyTxOutCoin era (const $ toLedger txOutMaxCoin)
 
@@ -698,10 +682,7 @@ txBody era = case era of
     RecentEraConway -> Babbage.body -- same type for conway
 
 -- Until we have convenient lenses to use
-outputs
-    :: RecentEra era
-    -> Core.TxBody (ShelleyLedgerEra era)
-    -> [TxOut era]
+outputs :: RecentEra era -> Core.TxBody (ShelleyLedgerEra era) -> [TxOut era]
 outputs RecentEraConway = map sizedValue . toList . Conway.ctbOutputs
 outputs RecentEraBabbage = map sizedValue . toList . Babbage.btbOutputs
 

--- a/lib/balance-tx/lib/Cardano/Wallet/Write/Tx.hs
+++ b/lib/balance-tx/lib/Cardano/Wallet/Write/Tx.hs
@@ -292,7 +292,7 @@ type RecentEraLedgerConstraints era =
     , Core.EraCrypto era ~ StandardCrypto
     , Core.Script era ~ AlonzoScript era
     , Core.Tx era ~ Babbage.AlonzoTx era
-    , Core.Value era ~ MaryValue StandardCrypto
+    , Core.Value era ~ Value
     , Core.TxWits era ~ AlonzoTxWits era
     , ExtendedUTxO era
     , Alonzo.AlonzoEraPParams era
@@ -511,7 +511,7 @@ type TxOut era = Core.TxOut (ShelleyLedgerEra era)
 
 modifyTxOutValue
     :: RecentEra era
-    -> (MaryValue StandardCrypto -> MaryValue StandardCrypto)
+    -> (Value -> Value)
     -> TxOut era
     -> TxOut era
 modifyTxOutValue RecentEraConway f (BabbageTxOut addr val dat script) =
@@ -529,7 +529,7 @@ modifyTxOutCoin era = modifyTxOutValue era . modifyCoin
 txOutValue
     :: RecentEra era
     -> TxOut era
-    -> MaryValue StandardCrypto
+    -> Value
 txOutValue RecentEraConway (Babbage.BabbageTxOut _ val _ _) = val
 txOutValue RecentEraBabbage (Babbage.BabbageTxOut _ val _ _) = val
 
@@ -567,7 +567,7 @@ datumHashToBytes = Crypto.hashToBytes . extractHash
 data TxOutInRecentEra
     = TxOutInRecentEra
         Address
-        (MaryValue StandardCrypto)
+        Value
         (Datum LatestLedgerEra)
         (Maybe (AlonzoScript LatestLedgerEra))
         -- Same contents as 'TxOut LatestLedgerEra'.

--- a/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/Balance.hs
@@ -821,7 +821,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         $ outputs era
         $ txBody era tx
       where
-        fromLedgerTxOut :: TxOut (ShelleyLedgerEra era) -> W.TxOut
+        fromLedgerTxOut :: TxOut era -> W.TxOut
         fromLedgerTxOut o = case era of
            RecentEraBabbage -> W.fromBabbageTxOut o
            RecentEraConway -> W.fromConwayTxOut o
@@ -989,7 +989,7 @@ selectAssets era (ProtocolParameters pp) utxoAssumptions outs redeemers
         => RecentEra era
         -> W.Address
         -> W.TokenBundle
-        -> TxOut (ShelleyLedgerEra era)
+        -> TxOut era
     mkLedgerTxOut txOutEra address bundle =
         case txOutEra of
             RecentEraBabbage -> W.toBabbageTxOut txOut
@@ -1428,7 +1428,7 @@ toLedgerTxOut
     :: HasCallStack
     => RecentEra era
     -> W.TxOut
-    -> TxOut (ShelleyLedgerEra era)
+    -> TxOut era
 toLedgerTxOut txOutEra txOut =
     case txOutEra of
         RecentEraBabbage -> W.toBabbageTxOut txOut
@@ -1436,7 +1436,7 @@ toLedgerTxOut txOutEra txOut =
 
 toWalletTxOut
     :: RecentEra era
-    -> TxOut (ShelleyLedgerEra era)
+    -> TxOut era
     -> W.TxOut
 toWalletTxOut RecentEraBabbage = W.fromBabbageTxOut
 toWalletTxOut RecentEraConway = W.fromConwayTxOut

--- a/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/Balance.hs
@@ -1424,20 +1424,13 @@ burnSurplusAsFees feePolicy surplus (TxFeeAndChange fee0 ())
     costOfBurningSurplus = costOfIncreasingCoin feePolicy fee0 surplus
     shortfall = costOfBurningSurplus `W.Coin.difference` surplus
 
-toLedgerTxOut
-    :: HasCallStack
-    => RecentEra era
-    -> W.TxOut
-    -> TxOut era
+toLedgerTxOut :: HasCallStack => RecentEra era -> W.TxOut -> TxOut era
 toLedgerTxOut txOutEra txOut =
     case txOutEra of
         RecentEraBabbage -> W.toBabbageTxOut txOut
         RecentEraConway -> W.toConwayTxOut txOut
 
-toWalletTxOut
-    :: RecentEra era
-    -> TxOut era
-    -> W.TxOut
+toWalletTxOut :: RecentEra era -> TxOut era -> W.TxOut
 toWalletTxOut RecentEraBabbage = W.fromBabbageTxOut
 toWalletTxOut RecentEraConway = W.fromConwayTxOut
 

--- a/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/Cardano/Wallet/Write/Tx/SizeEstimation.hs
@@ -75,7 +75,6 @@ import Cardano.Wallet.Write.Tx
     ( FeePerByte (..)
     , IsRecentEra (recentEra)
     , RecentEra (..)
-    , ShelleyLedgerEra
     , TxOut
     , computeMinimumCoinForTxOut
     , getFeePerByte
@@ -694,7 +693,7 @@ mkLedgerTxOut
     => RecentEra era
     -> W.Address
     -> TokenBundle
-    -> TxOut (ShelleyLedgerEra era)
+    -> TxOut era
 mkLedgerTxOut txOutEra address bundle =
     case txOutEra of
         RecentEraBabbage -> W.toBabbageTxOut txOut

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -3363,7 +3363,7 @@ prop_balanceTransactionValid
       where
         era = recentEra @era
 
-        valid :: Write.TxOut (Cardano.ShelleyLedgerEra era) -> Property
+        valid :: Write.TxOut era -> Property
         valid out = counterexample msg $ property $
             not $ Write.isBelowMinimumCoinForTxOut era ledgerPParams out
           where


### PR DESCRIPTION
## Issue

ADP-3157

## Description

This PR:
- Redefines `Write.TxOut era` in terms of `Core.TxOut (ShelleyLedgerEra era)`.
- Uses `Write.Value` to replace usages of `MaryValue StandardCrypto`.

This allows us to simplify several type signatures.