### PR TITLE
Downgrade OddWord for GHC 9.2 support

### DIFF
--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -90,7 +90,7 @@ library
     , lobemo-backend-ekg
     , memory                             ^>=0.18
     , network-uri                        ^>=2.6.4.2
-    , OddWord                            ^>=1.0.2
+    , OddWord                            ^>=1.0.1
     , ouroboros-network                  ^>=0.8.1
     , ouroboros-network-api              ^>=0.5
     , path                               ^>=0.9.2


### PR DESCRIPTION
Now works for me locally with 9.2 outside nix shell with the following `cabal.project.local`:

```
allow-newer:
  , iohk-monitoring-extra:*
  , temporary-extra:*
  , cardano-wallet-application-extras:*
  , crypto-hash-extra:*
  , cardano-wallet-e2e:*
  , bech32:*
  , local-cluster:*
constraints:
    optparse-applicative == 0.17.1.0
```

### Issue Number

None.
