### PR TITLE
Move `updateTx` specification to `Cardano.Write.Tx.BalanceSpec`.

### DIFF
--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1,24 +1,18 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {- HLINT ignore "Use null" -}
 {- HLINT ignore "Use camelCase" -}

--- a/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
@@ -373,12 +373,12 @@ import qualified Ouroboros.Consensus.HardFork.History as HF
 
 spec :: Spec
 spec = do
-    balanceTransactionSpec
-    distributeSurplusSpec
-    updateTxSpec
+    spec_balanceTransaction
+    spec_distributeSurplus
+    spec_updateTx
 
-balanceTransactionSpec :: Spec
-balanceTransactionSpec = describe "balanceTransaction" $ do
+spec_balanceTransaction :: Spec
+spec_balanceTransaction = describe "balanceTransaction" $ do
     -- TODO: Create a test to show that datums are passed through...
 
     it "doesn't balance transactions with existing 'totalCollateral'"
@@ -821,8 +821,8 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
             Cardano.TxFeeExplicit _ c -> c
             Cardano.TxFeeImplicit _ -> error "implicit fee"
 
-distributeSurplusSpec :: Spec
-distributeSurplusSpec = do
+spec_distributeSurplus :: Spec
+spec_distributeSurplus = do
     describe "sizeOfCoin" $ do
         let coinToWord64Clamped = fromMaybe maxBound . Coin.toWord64Maybe
         let cborSizeOfCoin =
@@ -971,8 +971,8 @@ distributeSurplusSpec = do
                 & withMaxSuccess 10_000
                 & property
 
-updateTxSpec :: Spec
-updateTxSpec = describe "updateTx" $ do
+spec_updateTx :: Spec
+spec_updateTx = describe "updateTx" $ do
     describe "no existing key witnesses" $ do
         txs <- readTestTransactions
         forM_ txs $ \(filepath, sealedTx) -> do

--- a/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
@@ -35,7 +35,6 @@ module Cardano.Write.Tx.BalanceSpec
     -- balanceTx-related tests have been relocated to this module, we should
     -- remove these exports:
     , cardanoTx
-    , dummyPolicyK
     , mockPParamsForBalancing
     , recentEraTxFromBytes
     , signedTxTestData

--- a/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
@@ -822,7 +822,7 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
             Cardano.TxFeeImplicit _ -> error "implicit fee"
 
 spec_distributeSurplus :: Spec
-spec_distributeSurplus = do
+spec_distributeSurplus = describe "distributeSurplus" $ do
     describe "sizeOfCoin" $ do
         let coinToWord64Clamped = fromMaybe maxBound . Coin.toWord64Maybe
         let cborSizeOfCoin =

--- a/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
@@ -1035,6 +1035,19 @@ updateTxSpec = describe "updateTx" $ do
 
         it "returns `Left err` when extra body content is non-empty" $ do
             pendingWith "todo: add test data"
+  where
+    readTestTransactions :: SpecM a [(FilePath, SealedTx)]
+    readTestTransactions = runIO $ do
+        let dir = $(getTestData) </> "plutus"
+        paths <- listDirectory dir
+        files <- flip foldMap paths $ \f ->
+            -- Ignore reject files
+            if ".rej" `isSuffixOf` takeExtension f
+            then pure []
+            else do
+                contents <- BS.readFile (dir </> f)
+                pure [(f, contents)]
+        traverse (\(f,bs) -> (f,) <$> unsafeSealedTxFromHex bs) files
 
 --------------------------------------------------------------------------------
 -- Properties
@@ -2207,19 +2220,6 @@ pingPong_2 = PartialTx
     }
   where
     tid = B8.replicate 32 '1'
-
-readTestTransactions :: SpecM a [(FilePath, SealedTx)]
-readTestTransactions = runIO $ do
-    let dir = $(getTestData) </> "plutus"
-    paths <- listDirectory dir
-    files <- flip foldMap paths $ \f ->
-        -- Ignore reject files
-        if ".rej" `isSuffixOf` takeExtension f
-        then pure []
-        else do
-            contents <- BS.readFile (dir </> f)
-            pure [(f, contents)]
-    traverse (\(f,bs) -> (f,) <$> unsafeSealedTxFromHex bs) files
 
 -- | A collection of signed transaction bytestrings useful for testing.
 --


### PR DESCRIPTION
## Issue

ADP-3171

## Description

This PR moves the specification for `updateTx` to `Cardano.Write.Tx.BalanceSpec`.

This PR also makes a few small adjustments, including:
- use a common `spec_` prefix for standalone specifications
    (similar to the common `prop_` prefix for standalone properties)
- make `readTestTransactions` an inner function of `spec_updateTx`
    (it's only used by this specification)