### PR TITLE
Use `Convert` namespace for conversions in `Cardano.Write.Tx` hierarchy.

### DIFF
--- a/lib/balance-tx/lib/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/Cardano/Write/Tx.hs
@@ -186,8 +186,6 @@ import Cardano.Ledger.Val
     ( coin, modifyCoin )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin )
-import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( toLedger )
 import Control.Arrow
     ( second, (>>>) )
 import Data.ByteString
@@ -238,6 +236,7 @@ import qualified Cardano.Ledger.Keys as Ledger
 import qualified Cardano.Ledger.Shelley.API.Wallet as Shelley
 import qualified Cardano.Ledger.Shelley.UTxO as Shelley
 import qualified Cardano.Ledger.TxIn as Ledger
+import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Data.Map as Map
 
 --------------------------------------------------------------------------------
@@ -642,7 +641,7 @@ computeMinimumCoinForTxOut era pp out = withConstraints era $
         :: TxOut (ShelleyLedgerEra era)
         -> TxOut (ShelleyLedgerEra era)
     withMaxLengthSerializedCoin =
-        modifyTxOutCoin era (const $ toLedger txOutMaxCoin)
+        modifyTxOutCoin era (const $ Convert.toLedger txOutMaxCoin)
 
 isBelowMinimumCoinForTxOut
     :: forall era. RecentEra era

--- a/lib/balance-tx/lib/Cardano/Write/Tx/Balance/TokenBundleSize.hs
+++ b/lib/balance-tx/lib/Cardano/Write/Tx/Balance/TokenBundleSize.hs
@@ -18,8 +18,6 @@ import Cardano.Ledger.Binary
     ( serialize )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxSize (..) )
-import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( toLedger )
 import Cardano.Write.Tx
     ( PParams, RecentEra, ShelleyLedgerEra, Value, Version, withConstraints )
 import Control.Lens
@@ -28,6 +26,7 @@ import Data.IntCast
     ( intCastMaybe )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Data.ByteString.Lazy as BL
 
 -- | Assesses a token bundle size in relation to the maximum size that can be
@@ -54,7 +53,7 @@ computeTokenBundleSerializedLengthBytes
     :: TokenBundle.TokenBundle
     -> Version
     -> TxSize
-computeTokenBundleSerializedLengthBytes tb ver = serSize (toLedger tb)
+computeTokenBundleSerializedLengthBytes tb ver = serSize (Convert.toLedger tb)
   where
     serSize :: Value -> TxSize
     serSize v = maybe err TxSize

--- a/lib/balance-tx/lib/Cardano/Write/Tx/Redeemers.hs
+++ b/lib/balance-tx/lib/Cardano/Write/Tx/Redeemers.hs
@@ -38,8 +38,6 @@ import Cardano.Slotting.EpochInfo
     ( EpochInfo, hoistEpochInfo )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenPolicyId )
-import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( Convert (..) )
 import Cardano.Write.Tx
     ( IsRecentEra (recentEra)
     , PParams
@@ -97,6 +95,7 @@ import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
+import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map as Map
 import qualified Data.Map.Merge.Strict as Map
@@ -271,7 +270,7 @@ redeemerData = \case
 toScriptPurpose :: Redeemer -> Alonzo.ScriptPurpose StandardCrypto
 toScriptPurpose = \case
     RedeemerSpending _ txin ->
-        Alonzo.Spending (toLedger txin)
+        Alonzo.Spending (Convert.toLedger txin)
     RedeemerMinting _ pid ->
         Alonzo.Minting (toPolicyID pid)
     RedeemerRewarding _ (Cardano.StakeAddress ntwrk acct) ->

--- a/lib/balance-tx/lib/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/Cardano/Write/Tx/Sign.hs
@@ -43,8 +43,6 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxSize (..) )
-import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( toWalletCoin, toWalletScript )
 import Cardano.Write.Tx
     ( IsRecentEra (..)
     , KeyWitnessCount (..)
@@ -70,7 +68,7 @@ import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
-import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Ledger
+import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Cardano.Write.Tx as Write
 import qualified Data.Foldable as F
 import qualified Data.List as L
@@ -125,11 +123,11 @@ estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
     coinQuotRem (W.Coin p) (W.Coin q) = quotRem p q
 
     minfee :: KeyWitnessCount -> W.Coin
-    minfee witCount = toWalletCoin $ Write.evaluateMinimumFee
+    minfee witCount = Convert.toWalletCoin $ Write.evaluateMinimumFee
         era pparams unsignedTx witCount
 
     feePerByte :: W.Coin
-    feePerByte = withConstraints era $ Ledger.toWalletCoin $
+    feePerByte = withConstraints era $ Convert.toWalletCoin $
         pparams ^. ppMinFeeAL
 
 numberOfShelleyWitnesses :: Word -> KeyWitnessCount
@@ -244,12 +242,12 @@ estimateKeyWitnessCount utxo txbody@(Cardano.TxBody txbodycontent) =
         RecentEraConway ->
             case anyScript of
                 Alonzo.TimelockScript timelock ->
-                    Just $ toWalletScript (const dummyKeyRole) timelock
+                    Just $ Convert.toWalletScript (const dummyKeyRole) timelock
                 Alonzo.PlutusScript _ _ -> Nothing
         RecentEraBabbage ->
             case anyScript of
                 Alonzo.TimelockScript timelock ->
-                    Just $ toWalletScript (const dummyKeyRole) timelock
+                    Just $ Convert.toWalletScript (const dummyKeyRole) timelock
                 Alonzo.PlutusScript _ _ -> Nothing
 
     hasScriptCred

--- a/lib/balance-tx/lib/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/Cardano/Write/Tx/SizeEstimation.hs
@@ -67,8 +67,6 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxConstraints (..), TxSize (..), txOutMaxCoin )
-import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( Convert (..) )
 import Cardano.Write.ProtocolParameters
     ( ProtocolParameters (..) )
 import Cardano.Write.Tx
@@ -110,7 +108,7 @@ import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
-import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as W
+import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Cardano.Write.Tx as Write
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
@@ -127,7 +125,7 @@ _txRewardWithdrawalCost
     -> Coin
     -> Coin
 _txRewardWithdrawalCost feePerByte witType =
-    toWallet
+    Convert.toWallet
     . Write.feeOfBytes feePerByte
     . unTxSize
     . _txRewardWithdrawalSize witType
@@ -180,7 +178,7 @@ txConstraints (ProtocolParameters protocolParams) witnessTag = TxConstraints
         constantTxFee <> estimateTxCost feePerByte empty
 
     constantTxFee = withConstraints era $
-        toWallet $ protocolParams ^. ppMinFeeBL
+        Convert.toWallet $ protocolParams ^. ppMinFeeBL
 
     feePerByte = getFeePerByte (recentEra @era) protocolParams
 
@@ -206,7 +204,7 @@ txConstraints (ProtocolParameters protocolParams) witnessTag = TxConstraints
     txOutputMaximumTokenQuantity =
         TokenQuantity $ fromIntegral $ maxBound @Word64
 
-    txOutputMinimumAdaQuantity addr tokens = toWallet $
+    txOutputMinimumAdaQuantity addr tokens = Convert.toWallet $
         computeMinimumCoinForTxOut
             era
             protocolParams
@@ -697,8 +695,8 @@ mkLedgerTxOut
     -> TxOut (ShelleyLedgerEra era)
 mkLedgerTxOut txOutEra address bundle =
     case txOutEra of
-        RecentEraBabbage -> W.toBabbageTxOut txOut
-        RecentEraConway -> W.toConwayTxOut txOut
+        RecentEraBabbage -> Convert.toBabbageTxOut txOut
+        RecentEraConway -> Convert.toConwayTxOut txOut
       where
         txOut = W.TxOut address bundle
 

--- a/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
@@ -166,16 +166,6 @@ import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..) )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
-import Cardano.Wallet.Shelley.Compatibility
-    ( fromCardanoLovelace, fromCardanoValue, toCardanoTxIn, toCardanoValue )
-import Cardano.Wallet.Shelley.Compatibility.Ledger
-    ( toBabbageTxOut
-    , toLedgerAddress
-    , toLedgerTokenBundle
-    , toWallet
-    , toWalletAddress
-    , toWalletCoin
-    )
 import Cardano.Wallet.Shelley.Transaction
     ( mkByronWitness, mkDelegationCertificates, _decodeSealedTx )
 import Cardano.Wallet.Transaction
@@ -353,7 +343,8 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as TxOutGen
-import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
+import qualified Cardano.Wallet.Shelley.Compatibility as Convert
+import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Cardano.Write.ProtocolParameters as Write
 import qualified Cardano.Write.Tx as Write
 import qualified Codec.CBOR.Encoding as CBOR
@@ -481,13 +472,13 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
         -- 'ErrBalanceTxMaxSizeLimitExceeded' or ErrMakeChange
         let nChange = max nPayments 1
         let s0 = DummyChangeState 0
-        let expectedChange = fmap toWalletAddress <$>
+        let expectedChange = fmap Convert.toWalletAddress <$>
                 flip evalState s0
                 $ replicateM nChange
                 $ state @Identity (getChangeAddressGen dummyChangeAddrGen)
 
         let address :: Babbage.BabbageTxOut StandardBabbage -> Address
-            address (Babbage.BabbageTxOut addr _ _ _) = toWallet addr
+            address (Babbage.BabbageTxOut addr _ _ _) = Convert.toWallet addr
 
         let (tx, s') =
                 either (error . show) id $ balance' ptx
@@ -514,7 +505,7 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
         Write.isBelowMinimumCoinForTxOut era pp (head outs)
             `shouldBe` False
 
-        head outs `shouldBe` (toBabbageTxOut out')
+        head outs `shouldBe` (Convert.toBabbageTxOut out')
 
     describe "effect of txMaxSize on coin selection" $ do
 
@@ -769,7 +760,7 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
                     ptx
                 combinedUTxO = mconcat
                         [ view #inputs ptx
-                        , Compatibility.toCardanoUTxO
+                        , Convert.toCardanoUTxO
                             Cardano.ShelleyBasedEraBabbage
                             walletUTxO
                         ]
@@ -843,7 +834,7 @@ spec_distributeSurplus = describe "distributeSurplus" $ do
         it "matches the size of the Word64 CBOR encoding" $
             property $ checkCoverage $
                 forAll genEncodingBoundaryLovelace $ \l -> do
-                    let c = fromCardanoLovelace l
+                    let c = Convert.fromCardanoLovelace l
                     let expected = cborSizeOfCoin c
 
                     -- Use a low coverage requirement of 0.01% just to
@@ -1061,7 +1052,7 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
     utxoPromisingInputsHaveAddress addr (Cardano.TxBody body) =
         Cardano.UTxO $ Map.fromList $
             [ (i
-              , Compatibility.toCardanoTxOut
+              , Convert.toCardanoTxOut
                   (shelleyBasedEra @era)
                   Nothing
                   (TxOut addr mempty)
@@ -1332,7 +1323,7 @@ prop_balanceTransactionValid
                  (ErrUnderestimatedFee delta candidateTx nWits)) ->
                 let counterexampleText = unlines
                         [ "underestimated fee by "
-                            <> pretty (toWalletCoin delta)
+                            <> pretty (Convert.toWalletCoin delta)
                         , "candidate tx: " <> pretty candidateTx
                         , "assuming key witness count: " <> show nWits
                         ]
@@ -1812,7 +1803,9 @@ prop_posAndNegFromCardanoValueRoundtrip = forAll genSignedValue $ \v ->
     let
         (pos, neg) = posAndNegFromCardanoValue v
     in
-        toCardanoValue pos <> (Cardano.negateValue (toCardanoValue neg)) === v
+        (Convert.toCardanoValue pos) <>
+        (Cardano.negateValue (Convert.toCardanoValue neg))
+        === v
 
 prop_updateTx
     :: Write.InAnyRecentEra Cardano.Tx
@@ -1882,7 +1875,7 @@ addExtraTxIns extraIns =
     #tx %~ modifyBabbageTxBody (inputsTxBodyL %~ (<> toLedgerInputs extraIns))
   where
     toLedgerInputs =
-        Set.map (Cardano.toShelleyTxIn . toCardanoTxIn) . Set.fromList
+        Set.map (Cardano.toShelleyTxIn . Convert.toCardanoTxIn) . Set.fromList
 
 -- | Wrapper for testing convenience. Does hide the monad 'm', tracing, and the
 -- updated 'changeState'. Does /not/ specify mock values for things like
@@ -2007,7 +2000,8 @@ paymentPartialTx txouts = PartialTx (Cardano.Tx body []) mempty []
     body = Cardano.ShelleyTxBody
         Cardano.ShelleyBasedEraBabbage
         ( mkBasicTxBody &
-            outputsTxBodyL .~ StrictSeq.fromList (toBabbageTxOut <$> txouts)
+            outputsTxBodyL .~
+            StrictSeq.fromList (Convert.toBabbageTxOut <$> txouts)
         )
         []
         Cardano.TxBodyNoScriptData
@@ -2188,7 +2182,7 @@ dummyChangeAddrGen = ChangeAddressGen
             'Cardano.Wallet.Address.Derivation.Soft
             'CredFromKeyK
         -> Write.Address
-    addressAtIx ix = toLedgerAddress
+    addressAtIx ix = Convert.toLedgerAddress
         $ paymentAddress @ShelleyKey @'CredFromKeyK SMainnet
         $ publicKey ShelleyKeyS
         $ Shelley.ShelleyKey
@@ -2338,7 +2332,8 @@ pingPong_2 = PartialTx
                   [ "714d72cf569a339a18a7d93023139"
                   , "83f56e0d96cd45bdcb1d6512dca6a"
                   ])
-              (toLedgerTokenBundle $ TokenBundle.fromCoin $ Coin 2_000_000)
+              (Convert.toLedgerTokenBundle
+                  $ TokenBundle.fromCoin $ Coin 2_000_000)
               (Write.DatumHash
                   $ fromJust
                   $ Write.datumHashFromBytes
@@ -2436,14 +2431,14 @@ instance IsCardanoEra era => Arbitrary (Cardano.TxOutValue era) where
     shrink (Cardano.TxOutValue Cardano.MultiAssetInAlonzoEra val) =
         map
             (Cardano.TxOutValue Cardano.MultiAssetInAlonzoEra
-                . toCardanoValue)
-            (shrink $ Compatibility.fromCardanoValue val)
+                . Convert.toCardanoValue)
+            (shrink $ Convert.fromCardanoValue val)
 
     shrink (Cardano.TxOutValue Cardano.MultiAssetInBabbageEra val) =
         map
             (Cardano.TxOutValue Cardano.MultiAssetInBabbageEra
-                . toCardanoValue)
-            (shrink $ fromCardanoValue val)
+                . Convert.toCardanoValue)
+            (shrink $ Convert.fromCardanoValue val)
     shrink _ =
         error "Arbitrary (TxOutValue era) is not implemented for old eras"
 
@@ -2573,7 +2568,7 @@ instance Arbitrary Wallet' where
                 genIn = genTxIn
 
                 genOut :: Gen TxOut
-                genOut = Compatibility.fromCardanoTxOut <$>
+                genOut = Convert.fromCardanoTxOut <$>
                   (Cardano.TxOut
                         <$> genAddr
                         <*> (scale (* 2) (genTxOutValue era))


### PR DESCRIPTION
## Issues

ADP-3171
ADP-3185

## Description

This PR adjusts all modules in the `Cardano.Write.Tx` hierarchy to use a common `Convert` namespace for conversion functions imported from the following modules:

- `Cardano.Wallet.Shelley.Compatibility`
- `Cardano.Wallet.Shelley.Compatibility.Ledger`

This allows us to get a clearer picture of exactly which conversion functions are actually required by the `Cardano.Write.Tx` module hierarchy:

```bash
$ git grep -o "Convert\.[a-zA-Z]*" | grep "Cardano.Write.Tx" | grep -o "Convert\.[a-zA-Z]*" | sort -u
```
Which yields:
```hs
Convert.fromBabbageTxOut
Convert.fromCardanoLovelace
Convert.fromCardanoTxOut
Convert.fromCardanoValue
Convert.fromConwayTxOut
Convert.toBabbageTxOut
Convert.toCardanoTxIn
Convert.toCardanoUTxO
Convert.toCardanoValue
Convert.toConwayTxOut
Convert.toLedger
Convert.toLedgerAddress
Convert.toLedgerCoin
Convert.toLedgerTimelockScript
Convert.toLedgerTokenBundle
Convert.toWallet
Convert.toWalletAddress
Convert.toWalletCoin
Convert.toWalletScript
Convert.toWalletTokenBundle
```

## Motivation

Both `cardano-wallet` and `cardano-balance-tx` depend on conversion functions from these compatibility modules. At some point, we'll need to decide exactly how to re-arrange these modules (and their dependencies) so that `cardano-wallet` and `cardano-balance-tx` do not need to depend on one another to supply conversion functions.