### PR TITLE
Add documentation explaining the reason for `SpecHook.hs` files.

### DIFF
--- a/lib/coin-selection/test/spec/SpecHook.hs
+++ b/lib/coin-selection/test/spec/SpecHook.hs
@@ -2,5 +2,9 @@ module SpecHook where
 
 import Test.Hspec
 
+-- Run all tests in parallel by default.
+--
+-- See: https://hspec.github.io/parallel-spec-execution.html
+--
 hook :: Spec -> Spec
 hook = parallel

--- a/lib/conversions/test/spec/SpecHook.hs
+++ b/lib/conversions/test/spec/SpecHook.hs
@@ -2,5 +2,9 @@ module SpecHook where
 
 import Test.Hspec
 
+-- Run all tests in parallel by default.
+--
+-- See: https://hspec.github.io/parallel-spec-execution.html
+--
 hook :: Spec -> Spec
 hook = parallel

--- a/lib/primitive/test/spec/SpecHook.hs
+++ b/lib/primitive/test/spec/SpecHook.hs
@@ -2,5 +2,9 @@ module SpecHook where
 
 import Test.Hspec
 
+-- Run all tests in parallel by default.
+--
+-- See: https://hspec.github.io/parallel-spec-execution.html
+--
 hook :: Spec -> Spec
 hook = parallel

--- a/lib/read/test/SpecHook.hs
+++ b/lib/read/test/SpecHook.hs
@@ -2,5 +2,9 @@ module SpecHook where
 
 import Test.Hspec
 
+-- Run all tests in parallel by default.
+--
+-- See: https://hspec.github.io/parallel-spec-execution.html
+--
 hook :: Spec -> Spec
 hook = parallel

--- a/lib/strict-non-empty-containers/test/unit/SpecHook.hs
+++ b/lib/strict-non-empty-containers/test/unit/SpecHook.hs
@@ -2,5 +2,9 @@ module SpecHook where
 
 import Test.Hspec
 
+-- Run all tests in parallel by default.
+--
+-- See: https://hspec.github.io/parallel-spec-execution.html
+--
 hook :: Spec -> Spec
 hook = parallel

--- a/lib/wallet/test/unit/SpecHook.hs
+++ b/lib/wallet/test/unit/SpecHook.hs
@@ -2,5 +2,9 @@ module SpecHook where
 
 import Test.Hspec
 
+-- Run all tests in parallel by default.
+--
+-- See: https://hspec.github.io/parallel-spec-execution.html
+--
 hook :: Spec -> Spec
 hook = parallel


### PR DESCRIPTION
## Issue

Follow-on from https://github.com/cardano-foundation/cardano-wallet/pull/4153#discussion_r1355054442

## Description

This PR adds documentation to all `SpecHook.hs` files explaining the reason for their existence: to make tests run in parallel by default. See https://hspec.github.io/parallel-spec-execution.html