### PR TITLE
Use function `withUtf8` to replace `withUtf8Encoding`.

### DIFF
--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -109,7 +109,6 @@ test-suite test
     , cardano-ledger-api
     , cardano-ledger-babbage:{cardano-ledger-babbage, testlib}
     , cardano-ledger-conway:{cardano-ledger-conway, testlib}
-    , cardano-wallet-launcher
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
     , containers

--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -120,6 +120,7 @@ test-suite test
     , lens
     , QuickCheck
     , quickcheck-classes
+    , with-utf8
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:
     Cardano.Write.Tx.Balance.TokenBundleSizeSpec

--- a/lib/balance-tx/test/spec/run-test-suite.hs
+++ b/lib/balance-tx/test/spec/run-test-suite.hs
@@ -2,12 +2,12 @@ module Main where
 
 import Prelude
 
-import Cardano.Startup
-    ( withUtf8Encoding )
+import Main.Utf8
+    ( withUtf8 )
 import Test.Hspec.Extra
     ( hspecMain )
 
 import qualified Spec
 
 main :: IO ()
-main = withUtf8Encoding $ hspecMain Spec.spec
+main = withUtf8 $ hspecMain Spec.spec

--- a/lib/cardano-api-extra/cardano-api-extra.cabal
+++ b/lib/cardano-api-extra/cardano-api-extra.cabal
@@ -88,6 +88,7 @@ test-suite test
     , hspec
     , QuickCheck
     , quickcheck-instances
+    , with-utf8
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:
     Cardano.Api.GenSpec

--- a/lib/cardano-api-extra/cardano-api-extra.cabal
+++ b/lib/cardano-api-extra/cardano-api-extra.cabal
@@ -82,7 +82,6 @@ test-suite test
     , cardano-ledger-byron
     , cardano-ledger-core
     , cardano-ledger-shelley
-    , cardano-wallet-launcher
     , cardano-wallet-test-utils
     , containers
     , hspec

--- a/lib/cardano-api-extra/test/spec/run-test-suite.hs
+++ b/lib/cardano-api-extra/test/spec/run-test-suite.hs
@@ -2,12 +2,12 @@ module Main where
 
 import Prelude
 
-import Cardano.Startup
-    ( withUtf8Encoding )
+import Main.Utf8
+    ( withUtf8 )
 import Test.Hspec.Extra
     ( hspecMain )
 
 import qualified Spec
 
 main :: IO ()
-main = withUtf8Encoding $ hspecMain Spec.spec
+main = withUtf8 $ hspecMain Spec.spec

--- a/lib/coin-selection/cardano-coin-selection.cabal
+++ b/lib/coin-selection/cardano-coin-selection.cabal
@@ -103,7 +103,7 @@ test-suite test
     , safe
     , text
     , transformers
-
+    , with-utf8
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:
     Cardano.CoinSelection.BalanceSpec

--- a/lib/coin-selection/cardano-coin-selection.cabal
+++ b/lib/coin-selection/cardano-coin-selection.cabal
@@ -83,7 +83,6 @@ test-suite test
     , bytestring
     , cardano-coin-selection
     , cardano-numeric
-    , cardano-wallet-launcher
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
     , containers

--- a/lib/coin-selection/test/spec/run-test-suite.hs
+++ b/lib/coin-selection/test/spec/run-test-suite.hs
@@ -2,12 +2,12 @@ module Main where
 
 import Prelude
 
-import Cardano.Startup
-    ( withUtf8Encoding )
+import Main.Utf8
+    ( withUtf8 )
 import Test.Hspec.Extra
     ( hspecMain )
 
 import qualified Spec
 
 main :: IO ()
-main = withUtf8Encoding $ hspecMain Spec.spec
+main = withUtf8 $ hspecMain Spec.spec

--- a/lib/conversions/cardano-wallet-conversions.cabal
+++ b/lib/conversions/cardano-wallet-conversions.cabal
@@ -72,7 +72,6 @@ test-suite test
     , cardano-addresses
     , cardano-ledger-allegra:{cardano-ledger-allegra, testlib}
     , cardano-wallet-conversions
-    , cardano-wallet-launcher
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
     , hspec

--- a/lib/conversions/cardano-wallet-conversions.cabal
+++ b/lib/conversions/cardano-wallet-conversions.cabal
@@ -79,6 +79,7 @@ test-suite test
     , hspec-core
     , ouroboros-consensus-cardano
     , QuickCheck
+    , with-utf8
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:
     Cardano.Wallet.Shelley.Compatibility.LedgerSpec

--- a/lib/conversions/test/spec/run-test-suite.hs
+++ b/lib/conversions/test/spec/run-test-suite.hs
@@ -2,12 +2,12 @@ module Main where
 
 import Prelude
 
-import Cardano.Startup
-    ( withUtf8Encoding )
+import Main.Utf8
+    ( withUtf8 )
 import Test.Hspec.Extra
     ( hspecMain )
 
 import qualified Spec
 
 main :: IO ()
-main = withUtf8Encoding $ hspecMain Spec.spec
+main = withUtf8 $ hspecMain Spec.spec

--- a/lib/launcher/src/Cardano/Startup.hs
+++ b/lib/launcher/src/Cardano/Startup.hs
@@ -11,8 +11,7 @@
 module Cardano.Startup
     (
     -- * Program startup
-      withUtf8Encoding
-    , setUtf8EncodingHandles
+      setUtf8EncodingHandles
 
     -- * Clean shutdown
     , withShutdownHandler
@@ -45,8 +44,6 @@ import GHC.IO.Encoding
     ( setFileSystemEncoding )
 import System.IO
     ( Handle, hIsOpen, hSetEncoding, mkTextEncoding, stderr, stdin, stdout )
-import System.IO.CodePage
-    ( withCP65001 )
 import UnliftIO.Async
     ( race )
 import UnliftIO.Concurrent
@@ -68,14 +65,6 @@ import qualified Data.Text as T
 {-------------------------------------------------------------------------------
                             Unicode Terminal Helpers
 -------------------------------------------------------------------------------}
-
--- | Force the locale text encoding to UTF-8. This is needed because the CLI
--- prints UTF-8 characters regardless of the @LANG@ environment variable or any
--- other settings.
---
--- On Windows the current console code page is changed to UTF-8.
-withUtf8Encoding :: IO a -> IO a
-withUtf8Encoding action = withCP65001 (setUtf8EncodingHandles >> action)
 
 setUtf8EncodingHandles :: IO ()
 setUtf8EncodingHandles = do

--- a/lib/launcher/src/Cardano/Startup.hs
+++ b/lib/launcher/src/Cardano/Startup.hs
@@ -10,11 +10,8 @@
 
 module Cardano.Startup
     (
-    -- * Program startup
-      setUtf8EncodingHandles
-
     -- * Clean shutdown
-    , withShutdownHandler
+      withShutdownHandler
     , withShutdownHandler'
     , installSignalHandlers
     , installSignalHandlersNoLogging
@@ -40,10 +37,8 @@ import Data.Either.Extra
     ( eitherToMaybe )
 import Data.Text.Class
     ( ToText (..) )
-import GHC.IO.Encoding
-    ( setFileSystemEncoding )
 import System.IO
-    ( Handle, hIsOpen, hSetEncoding, mkTextEncoding, stderr, stdin, stdout )
+    ( Handle, hIsOpen, stdin )
 import UnliftIO.Async
     ( race )
 import UnliftIO.Concurrent
@@ -61,16 +56,6 @@ import Cardano.Startup.POSIX
 
 import qualified Data.ByteString as BS
 import qualified Data.Text as T
-
-{-------------------------------------------------------------------------------
-                            Unicode Terminal Helpers
--------------------------------------------------------------------------------}
-
-setUtf8EncodingHandles :: IO ()
-setUtf8EncodingHandles = do
-    utf8' <- mkTextEncoding "UTF-8//TRANSLIT"
-    mapM_ (`hSetEncoding` utf8') [stdin, stdout, stderr]
-    setFileSystemEncoding utf8'
 
 {-------------------------------------------------------------------------------
                                Shutdown handlers

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -145,7 +145,6 @@ test-suite test
     , cardano-ledger-core:{cardano-ledger-core, testlib}
     , cardano-ledger-shelley-test
     , cardano-numeric
-    , cardano-wallet-launcher
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
     , containers

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -168,7 +168,7 @@ test-suite test
     , string-qq
     , text
     , text-class
-
+    , with-utf8
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:
     Cardano.Wallet.Primitive.CollateralSpec

--- a/lib/primitive/test/spec/run-test-suite.hs
+++ b/lib/primitive/test/spec/run-test-suite.hs
@@ -2,12 +2,12 @@ module Main where
 
 import Prelude
 
-import Cardano.Startup
-    ( withUtf8Encoding )
+import Main.Utf8
+    ( withUtf8 )
 import Test.Hspec.Extra
     ( hspecMain )
 
 import qualified Spec
 
 main :: IO ()
-main = withUtf8Encoding $ hspecMain Spec.spec
+main = withUtf8 $ hspecMain Spec.spec

--- a/lib/wallet-benchmarks/bench/memory-benchmark.hs
+++ b/lib/wallet-benchmarks/bench/memory-benchmark.hs
@@ -7,7 +7,7 @@ import Prelude
 import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Cardano.Startup
-    ( installSignalHandlers, withUtf8Encoding )
+    ( installSignalHandlers )
 import Control.Concurrent
     ( threadDelay )
 import Control.Monad
@@ -22,6 +22,8 @@ import Data.Text
     ( Text )
 import Data.Text.Class
     ( ToText (..) )
+import Main.Utf8
+    ( withUtf8 )
 import System.FilePath
     ( takeBaseName, (</>) )
 import System.IO.Temp
@@ -102,7 +104,7 @@ configInfo = O.info (configParser O.<**> O.helper) $ mconcat
     ]
 
 main :: IO ()
-main = withUtf8Encoding $ do
+main = withUtf8 $ do
     Config{..} <- O.execParser configInfo
     requireExecutable nodeExe "--version"
     requireExecutable walletExe "version"

--- a/lib/wallet-benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/wallet-benchmarks/cardano-wallet-benchmarks.cabal
@@ -45,3 +45,4 @@ benchmark memory
     , text-class
     , transformers
     , optparse-applicative
+    , with-utf8

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -66,8 +66,6 @@ import Cardano.DB.Sqlite
     ( SqliteContext (..) )
 import Cardano.Mnemonic
     ( EntropySize, SomeMnemonic (..), entropyToMnemonic, genEntropy )
-import Cardano.Startup
-    ( withUtf8Encoding )
 import Cardano.Wallet
     ( putWalletCheckpoints )
 import Cardano.Wallet.Address.Derivation
@@ -198,6 +196,8 @@ import Fmt
     ( build, padLeftF, padRightF, pretty, (+|), (|+) )
 import GHC.Num
     ( Natural )
+import Main.Utf8
+    ( withUtf8 )
 import System.Directory
     ( doesFileExist, getFileSize )
 import System.FilePath
@@ -226,7 +226,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 
 main :: IO ()
-main = withUtf8Encoding $ withLogging $ \trace -> do
+main = withUtf8 $ withLogging $ \trace -> do
     let tr = filterSeverity (pure . const Error) $ trMessageText trace
     defaultMain
         [ bgroupWriteUTxO tr

--- a/lib/wallet/bench/latency-bench.hs
+++ b/lib/wallet/bench/latency-bench.hs
@@ -30,8 +30,6 @@ import Cardano.CLI
     ( Port (..) )
 import Cardano.Mnemonic
     ( Mnemonic, SomeMnemonic (..), mnemonicToText )
-import Cardano.Startup
-    ( withUtf8Encoding )
 import Cardano.Wallet.Api.Http.Shelley.Server
     ( Listen (ListenOnRandomPort) )
 import Cardano.Wallet.Api.Types
@@ -99,6 +97,8 @@ import Data.Tagged
     ( Tagged (..) )
 import Fmt
     ( build )
+import Main.Utf8
+    ( withUtf8 )
 import Network.HTTP.Client
     ( defaultManagerSettings
     , managerResponseTimeout
@@ -161,7 +161,7 @@ import qualified Network.HTTP.Types.Status as HTTP
 import qualified Service as ClusterService
 
 main :: forall n. (n ~ 'Mainnet) => IO ()
-main = withUtf8Encoding $
+main = withUtf8 $
     withLatencyLogging setupTracers $ \tracers capture ->
         withShelleyServer tracers $ \ctx -> do
             walletApiBench @n capture ctx

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -1023,7 +1023,6 @@ benchmark latency
     , cardano-wallet-api-http
     , cardano-wallet-application-extras
     , cardano-wallet-integration
-    , cardano-wallet-launcher
     , cardano-wallet-primitive
     , directory
     , filepath
@@ -1060,7 +1059,6 @@ benchmark db
     , cardano-wallet
     , cardano-wallet-application-extras
     , cardano-wallet-bench
-    , cardano-wallet-launcher
     , cardano-wallet-primitive
     , cardano-wallet-read
     , cardano-wallet-test-utils

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -674,6 +674,7 @@ executable cardano-wallet
     , text-class
     , transformers
     , unliftio
+    , with-utf8
 
 -- Triggers this https://github.com/haskell/cabal/issues/6470
 -- if moved to an external library
@@ -834,6 +835,7 @@ test-suite unit
     , wai-extra
     , wai-middleware-logging
     , warp
+    , with-utf8
     , x509
     , x509-store
     , yaml
@@ -968,7 +970,7 @@ test-suite integration
     , text
     , text-class
     , unliftio
-
+    , with-utf8
   build-tool-depends: cardano-wallet:cardano-wallet
 
 benchmark restore
@@ -1039,7 +1041,7 @@ benchmark latency
     , time
     , unliftio
     , wai-middleware-logging
-
+    , with-utf8
   other-modules:  Cardano.Wallet.LatencyBenchShared
 
 benchmark db
@@ -1079,7 +1081,7 @@ benchmark db
     , time
     , transformers
     , unliftio
-
+    , with-utf8
   other-modules:  Cardano.Wallet.DummyTarget.Primitive.Types
 
 benchmark api

--- a/lib/wallet/exe/cardano-wallet.hs
+++ b/lib/wallet/exe/cardano-wallet.hs
@@ -69,11 +69,7 @@ import Cardano.CLI
 import Cardano.Launcher.Node
     ( CardanoNodeConn )
 import Cardano.Startup
-    ( ShutdownHandlerLog
-    , installSignalHandlers
-    , withShutdownHandler
-    , withUtf8Encoding
-    )
+    ( ShutdownHandlerLog, installSignalHandlers, withShutdownHandler )
 import Cardano.Wallet.Api.Client
     ( addressClient
     , networkClient
@@ -120,6 +116,8 @@ import Data.Text
     ( Text )
 import Data.Text.Class
     ( ToText (..) )
+import Main.Utf8
+    ( withUtf8 )
 import Network.URI
     ( URI )
 import "optparse-applicative" Options.Applicative
@@ -155,7 +153,7 @@ import qualified System.Info as I
 -------------------------------------------------------------------------------}
 
 main :: IO ()
-main = withUtf8Encoding $ do
+main = withUtf8 $ do
     enableWindowsANSI
     runCli $ cli $ mempty
         <> cmdServe

--- a/lib/wallet/test/integration/shelley-integration-test.hs
+++ b/lib/wallet/test/integration/shelley-integration-test.hs
@@ -39,10 +39,7 @@ import Cardano.Launcher
 import Cardano.Mnemonic
     ( SomeMnemonic (..) )
 import Cardano.Startup
-    ( installSignalHandlersNoLogging
-    , setDefaultFilePermissions
-    , withUtf8Encoding
-    )
+    ( installSignalHandlersNoLogging, setDefaultFilePermissions )
 import Cardano.Wallet.Api.Http.Shelley.Server
     ( walletListenFromEnv )
 import Cardano.Wallet.Api.Types
@@ -113,6 +110,8 @@ import Data.Text
     ( Text )
 import Data.Text.Class
     ( ToText (..) )
+import Main.Utf8
+    ( withUtf8 )
 import Network.HTTP.Client
     ( defaultManagerSettings
     , managerResponseTimeout
@@ -251,7 +250,7 @@ withTestsSetup action = do
     skipCleanup <- SkipCleanup <$> isEnvSet "NO_CLEANUP"
     -- Flush test output as soon as a line is printed.
     -- Set UTF-8, regardless of user locale.
-    withUtf8Encoding $
+    withUtf8 $
         -- This temporary directory will contain logs, and all other data
         -- produced by the integration tests.
         withSystemTempDir stdoutTextTracer "test" skipCleanup $ \testDir ->

--- a/lib/wallet/test/unit/core-unit-test.hs
+++ b/lib/wallet/test/unit/core-unit-test.hs
@@ -2,12 +2,12 @@ module Main where
 
 import Prelude
 
-import Cardano.Startup
-    ( withUtf8Encoding )
+import Main.Utf8
+    ( withUtf8 )
 import Test.Hspec.Extra
     ( hspecMain )
 
 import qualified Spec
 
 main :: IO ()
-main = withUtf8Encoding $ hspecMain Spec.spec
+main = withUtf8 $ hspecMain Spec.spec


### PR DESCRIPTION
## Issue

Follow-on from https://github.com/cardano-foundation/cardano-wallet/pull/4153#discussion_r1355057036

## Description

This PR uses the [`withUtf8`](https://hackage.haskell.org/package/with-utf8/docs/Main-Utf8.html#v:withUtf8) function (from the [`with-utf8`](https://hackage.haskell.org/package/with-utf8) package) to replace our own [`withUtf8Encoding`](https://github.com/cardano-foundation/cardano-wallet/blob/630c2707a754aa8781afc1ad9aceb44c6ad40aae/lib/launcher/src/Cardano/Startup.hs#L77) function (from the [`cardano-wallet-launcher`](https://github.com/cardano-foundation/cardano-wallet/blob/630c2707a754aa8781afc1ad9aceb44c6ad40aae/lib/launcher/cardano-wallet-launcher.cabal) package).

As a result, we can:
- reduce the number of dependencies on [`cardano-wallet-launcher`](https://github.com/cardano-foundation/cardano-wallet/blob/630c2707a754aa8781afc1ad9aceb44c6ad40aae/lib/launcher/cardano-wallet-launcher.cabal).
- remove the [`withUtf8Encoding`](https://github.com/cardano-foundation/cardano-wallet/blob/630c2707a754aa8781afc1ad9aceb44c6ad40aae/lib/launcher/src/Cardano/Startup.hs#L77) function, which is now redundant.
- remove the [`setUtf8EncodingHandles`](https://github.com/cardano-foundation/cardano-wallet/blob/630c2707a754aa8781afc1ad9aceb44c6ad40aae/lib/launcher/src/Cardano/Startup.hs#L80) function, which is now redundant.