### PR TITLE
Clone the test utility function `cardanoTx`.

### DIFF
--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -87,6 +87,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)
     , TxMetadata (..)
     , TxMetadataValue (..)
+    , cardanoTxIdeallyNoLaterThan
     , getSealedTxWitnesses
     , sealedTxFromBytes
     , sealedTxFromBytes'
@@ -137,7 +138,7 @@ import Cardano.Write.Tx
 import Cardano.Write.Tx.Balance
     ( ErrBalanceTx (..), ErrBalanceTxUnableToCreateChangeError (..) )
 import Cardano.Write.Tx.BalanceSpec
-    ( cardanoTx, mockPParamsForBalancing )
+    ( mockPParamsForBalancing )
 import Cardano.Write.Tx.SizeEstimation
     ( TxSkeleton (..), estimateTxSize, txConstraints )
 import Control.Arrow
@@ -1337,6 +1338,9 @@ dummyWit b =
 
 dummyTxId :: Hash "Tx"
 dummyTxId = Hash $ BS.pack $ replicate 32 0
+
+cardanoTx :: SealedTx -> InAnyCardanoEra Cardano.Tx
+cardanoTx = cardanoTxIdeallyNoLaterThan maxBound
 
 testTxLayer :: TransactionLayer ShelleyKey 'CredFromKeyK SealedTx
 testTxLayer = newTransactionLayer ShelleyKeyS Cardano.Mainnet

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1402,7 +1402,7 @@ instance Arbitrary MockSelection where
     arbitrary = genMockSelection
     shrink = shrinkMockSelection
 
--- Tests that using 'txBaseSize' to estimate the size of an empty selection                                                                        ....
+-- Tests that using 'txBaseSize' to estimate the size of an empty selection
 -- produces a result that is consistent with the result of using
 -- 'estimateTxSize'.
 --

--- a/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
@@ -35,7 +35,6 @@ module Cardano.Write.Tx.BalanceSpec
     -- to balanceTx that have not yet been relocated to this module. Once all
     -- balanceTx-related tests have been relocated to this module, we should
     -- remove these exports:
-    , cardanoTx
     , mockPParamsForBalancing
     ----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Issue

ADP-3171

## Description

This PR clones the test utility function `cardanoTx` from `Cardano.Write.Tx.BalanceSpec` to `Cardano.Wallet.Shelley.TransactionSpec`.
    
This test utility function is simple enough that it doesn't matter too much if we duplicate its definition across test suites.

In this particular case, the duplication allows us to reduce the number of exports from `BalanceSpec` to `TransactionSpec`, and brings us one step closer to being able to move `BalanceSpec` to the `cardano-balance-tx` library.