### PR TITLE
Use `W` namespace for wallet primitive types and related functions in `BalanceSpec`.

### DIFF
--- a/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
@@ -130,7 +130,7 @@ import Cardano.Wallet.Primitive.Passphrase
 import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), BlockHeader (..) )
+    ( BlockHeader (..) )
 import Cardano.Wallet.Primitive.Types.Credentials
     ( RootCredentials (..) )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -334,6 +334,10 @@ import qualified Cardano.Slotting.Slot as Slotting
 import qualified Cardano.Slotting.Time as Slotting
 import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
+import qualified Cardano.Wallet.Primitive.Types as W
+    ( Block (..) )
+import qualified Cardano.Wallet.Primitive.Types as W.Block
+    ( header )
 import qualified Cardano.Wallet.Primitive.Types.Address as W
     ( Address (..) )
 import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
@@ -1963,7 +1967,7 @@ balanceTransactionWithDummyChangeState utxoAssumptions utxo seed partialTx =
             dummyTimeTranslation
             (constructUTxOIndex utxo)
             dummyChangeAddrGen
-            (getState $ unsafeInitWallet utxo (header block0)
+            (getState $ unsafeInitWallet utxo (W.Block.header block0)
                 DummyChangeState { nextUnusedIndex = 0 })
             partialTx
 
@@ -2178,8 +2182,8 @@ cardanoToWalletTxOut =
 -- Test values
 --------------------------------------------------------------------------------
 
-block0 :: Block
-block0 = Block
+block0 :: W.Block
+block0 = W.Block
     { header = BlockHeader
         { slotNo = SlotNo 0
         , blockHeight = W.Quantity 0

--- a/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
@@ -238,8 +238,6 @@ import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
     ( catMaybes, fromJust, fromMaybe )
-import Data.Quantity
-    ( Quantity (..) )
 import Data.Ratio
     ( (%) )
 import Data.Set
@@ -366,6 +364,8 @@ import qualified Data.ByteString.Char8 as B8
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
+import qualified Data.Quantity as W
+    ( Quantity (..) )
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import qualified Data.Text as T
@@ -2182,7 +2182,7 @@ block0 :: Block
 block0 = Block
     { header = BlockHeader
         { slotNo = SlotNo 0
-        , blockHeight = Quantity 0
+        , blockHeight = W.Quantity 0
         , headerHash = W.Hash.mockHash $ SlotNo 0
         , parentHeaderHash = Nothing
         }

--- a/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
@@ -342,9 +342,8 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..) )
 import qualified Cardano.Wallet.Primitive.Types.Coin.Gen as W
-import qualified Cardano.Wallet.Primitive.Types.Hash as W.Hash
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
-    ( Hash (..) )
+    ( Hash (..), mockHash )
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle )
@@ -2185,7 +2184,7 @@ block0 = W.Block
     { header = W.BlockHeader
         { slotNo = SlotNo 0
         , blockHeight = W.Quantity 0
-        , headerHash = W.Hash.mockHash $ SlotNo 0
+        , headerHash = W.mockHash $ SlotNo 0
         , parentHeaderHash = Nothing
         }
     , transactions = []

--- a/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
@@ -147,8 +147,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxSize (..) )
-import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
-    ( genTxIn )
 import Cardano.Wallet.Shelley.Transaction
     ( mkByronWitness, mkDelegationCertificates, _decodeSealedTx )
 import Cardano.Wallet.Transaction
@@ -351,6 +349,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle )
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (..) )
@@ -2626,7 +2625,7 @@ instance Arbitrary Wallet' where
             genEntry = (,) <$> genIn <*> genOut
               where
                 genIn :: Gen W.TxIn
-                genIn = genTxIn
+                genIn = W.genTxIn
 
                 genOut :: Gen W.TxOut
                 genOut = cardanoToWalletTxOut <$>

--- a/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
@@ -131,8 +131,6 @@ import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException )
 import Cardano.Wallet.Primitive.Types
     ( Block (..), BlockHeader (..) )
-import Cardano.Wallet.Primitive.Types.Address
-    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Credentials
     ( RootCredentials (..) )
 import Cardano.Wallet.Primitive.Types.Hash
@@ -340,6 +338,8 @@ import qualified Cardano.Slotting.Slot as Slotting
 import qualified Cardano.Slotting.Time as Slotting
 import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
+import qualified Cardano.Wallet.Primitive.Types.Address as W
+    ( Address (..) )
 import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..) )
@@ -488,7 +488,7 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
                 $ replicateM nChange
                 $ state @Identity (getChangeAddressGen dummyChangeAddrGen)
 
-        let address :: Babbage.BabbageTxOut StandardBabbage -> Address
+        let address :: Babbage.BabbageTxOut StandardBabbage -> W.Address
             address (Babbage.BabbageTxOut addr _ _ _) = Convert.toWallet addr
 
         let (tx, s') =
@@ -679,7 +679,7 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
 
     utxo coins = utxoWithBundles $ map W.TokenBundle.fromCoin coins
 
-    dummyAddr = Address $ unsafeFromHex
+    dummyAddr = W.Address $ unsafeFromHex
         "60b1e5e0fb74c86c801f646841e07cdb42df8b82ef3ce4e57cb5412e77"
 
 balanceTransactionGoldenSpec :: Spec
@@ -792,7 +792,7 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
 
     rootK =
         Shelley.unsafeGenerateKeyFromSeed (dummyMnemonic, Nothing) mempty
-    addr = Address $ unsafeFromHex
+    addr = W.Address $ unsafeFromHex
         "60b1e5e0fb74c86c801f646841e07cdb42df8b82ef3ce4e57cb5412e77"
 
     payment :: PartialTx Cardano.BabbageEra
@@ -1057,7 +1057,7 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
     utxoPromisingInputsHaveAddress
         :: forall era. HasCallStack
         => RecentEra era
-        -> Address
+        -> W.Address
         -> Tx (ShelleyLedgerEra era)
         -> UTxO (ShelleyLedgerEra era)
     utxoPromisingInputsHaveAddress era addr tx =
@@ -1081,12 +1081,12 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
 
     -- An address with a vk payment credential. For the test above, this is the
     -- only aspect which matters.
-    vkCredAddr = Address $ unsafeFromHex
+    vkCredAddr = W.Address $ unsafeFromHex
         "6000000000000000000000000000000000000000000000000000000000"
 
     -- This is a short bootstrap address retrieved from
     -- "byron-address-format.md".
-    bootAddr = Address $ unsafeFromHex
+    bootAddr = W.Address $ unsafeFromHex
         "82d818582183581cba970ad36654d8dd8f74274b733452ddeab9a62a397746be3c42ccdda0001a9026da5b"
 
     -- With more attributes, the address can be longer. This value was chosen
@@ -2592,7 +2592,7 @@ instance Arbitrary W.TxOut where
     arbitrary =
         W.TxOut addr <$> scale (`mod` 4) W.genTokenBundleSmallRange
       where
-        addr = Address $ BS.pack (1:replicate 56 0)
+        addr = W.Address $ BS.pack (1:replicate 56 0)
     shrink (W.TxOut addr bundle) =
         [ W.TxOut addr bundle'
         | bundle' <- W.shrinkTokenBundleSmallRange bundle

--- a/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
@@ -129,8 +129,6 @@ import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException )
-import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..) )
 import Cardano.Wallet.Primitive.Types.Credentials
     ( RootCredentials (..) )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -335,7 +333,7 @@ import qualified Cardano.Slotting.Time as Slotting
 import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.Primitive.Types as W
-    ( Block (..) )
+    ( Block (..), BlockHeader (..) )
 import qualified Cardano.Wallet.Primitive.Types as W.Block
     ( header )
 import qualified Cardano.Wallet.Primitive.Types.Address as W
@@ -2184,7 +2182,7 @@ cardanoToWalletTxOut =
 
 block0 :: W.Block
 block0 = W.Block
-    { header = BlockHeader
+    { header = W.BlockHeader
         { slotNo = SlotNo 0
         , blockHeight = W.Quantity 0
         , headerHash = W.Hash.mockHash $ SlotNo 0

--- a/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
@@ -351,8 +351,9 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle )
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+    ( TxOut (..) )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as TxOutGen
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
@@ -1630,8 +1631,8 @@ prop_distributeSurplus_onSuccess_conservesSurplus =
         (TxFeeAndChange feeOriginal changeOriginal)
         (TxFeeAndChange feeModified changeModified) ->
         surplus === W.Coin.difference
-            (feeModified <> F.foldMap TxOut.coin changeModified)
-            (feeOriginal <> F.foldMap TxOut.coin changeOriginal)
+            (feeModified <> F.foldMap W.TxOut.coin changeModified)
+            (feeOriginal <> F.foldMap W.TxOut.coin changeOriginal)
 
 -- The 'distributeSurplus' function should cover the cost of any increases in
 -- 'Coin' values.
@@ -1648,8 +1649,8 @@ prop_distributeSurplus_onSuccess_coversCostIncrease =
     prop_distributeSurplus_onSuccess $ \policy _surplus
         (TxFeeAndChange feeOriginal changeOriginal)
         (TxFeeAndChange feeModified changeModified) -> do
-        let coinsOriginal = feeOriginal : (TxOut.coin <$> changeOriginal)
-        let coinsModified = feeModified : (TxOut.coin <$> changeModified)
+        let coinsOriginal = feeOriginal : (W.TxOut.coin <$> changeOriginal)
+        let coinsModified = feeModified : (W.TxOut.coin <$> changeModified)
         let coinDeltas = zipWith W.Coin.difference coinsModified coinsOriginal
         let costIncrease = F.foldMap
                 (uncurry $ costOfIncreasingCoin policy)
@@ -1673,8 +1674,8 @@ prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues =
         (TxFeeAndChange _feeOriginal changeOriginal)
         (TxFeeAndChange _feeModified changeModified) ->
             all (uncurry (<=)) $ zip
-                (TxOut.coin <$> changeOriginal)
-                (TxOut.coin <$> changeModified)
+                (W.TxOut.coin <$> changeOriginal)
+                (W.TxOut.coin <$> changeModified)
 
 -- The 'distributeSurplus' function should never return a 'fee' value that is
 -- less than the original value.
@@ -1713,11 +1714,11 @@ prop_distributeSurplus_onSuccess_increasesValuesByDelta =
                     $ distributeSurplusDelta policy surplus
                     $ TxFeeAndChange
                         (feeOriginal)
-                        (TxOut.coin <$> changeOriginal)
+                        (W.TxOut.coin <$> changeOriginal)
             in
             (TxFeeAndChange
                 (feeModified `W.Coin.difference` feeDelta)
-                (zipWith TxOut.subtractCoin changeDeltas changeModified)
+                (zipWith W.TxOut.subtractCoin changeDeltas changeModified)
             )
             ===
             TxFeeAndChange feeOriginal changeOriginal


### PR DESCRIPTION
## Issue

ADP-3171

## Summary

This PR adjusts the imports of `Cardano.Write.Tx.BalanceSpec` so that (most) wallet primitive types and related functions are imported within the `W` namespace.