### PR TITLE
Use monoidal arithmetic in `cardano-balance-tx`.

### DIFF
--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -117,6 +117,7 @@ test-suite test
     , hspec
     , hspec-core
     , lens
+    , monoid-subclasses
     , QuickCheck
     , quickcheck-classes
     , with-utf8

--- a/lib/balance-tx/lib/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/Cardano/Write/Tx/Balance.hs
@@ -174,6 +174,8 @@ import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
     ( fromMaybe, mapMaybe )
+import Data.Monoid.Monus
+    ( Monus ((<\>)) )
 import Data.Semigroup.Cancellative
     ( Reductive ((</>)) )
 import Data.Type.Equality
@@ -966,7 +968,7 @@ selectAssets era (ProtocolParameters pp) utxoAssumptions outs redeemers
                 , txPaymentTemplate = view #template <$>
                     assumedInputScriptTemplate utxoAssumptions
                 }
-            ] `W.Coin.difference` boringFee
+            ] <\> boringFee
         , maximumCollateralInputCount = withConstraints era $
             unsafeIntCast @Natural @Int $ pp ^. ppMaxCollateralInputsL
     , minimumCollateralPercentage =
@@ -1271,7 +1273,7 @@ costOfIncreasingCoin
     -> W.Coin -- ^ Increment
     -> W.Coin
 costOfIncreasingCoin (FeePerByte perByte) from delta =
-    costOfCoin (from <> delta) `W.Coin.difference` costOfCoin from
+    costOfCoin (from <> delta) <\> costOfCoin from
   where
     costOfCoin = W.Coin . (perByte *) . unTxSize . sizeOfCoin
 
@@ -1436,7 +1438,7 @@ burnSurplusAsFees feePolicy surplus (TxFeeAndChange fee0 ())
         Right $ TxFeeAndChange surplus ()
   where
     costOfBurningSurplus = costOfIncreasingCoin feePolicy fee0 surplus
-    shortfall = costOfBurningSurplus `W.Coin.difference` surplus
+    shortfall = costOfBurningSurplus <\> surplus
 
 toLedgerTxOut
     :: HasCallStack

--- a/lib/balance-tx/lib/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/Cardano/Write/Tx/Balance.hs
@@ -174,6 +174,8 @@ import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
     ( fromMaybe, mapMaybe )
+import Data.Semigroup.Cancellative
+    ( Reductive ((</>)) )
 import Data.Type.Equality
     ( (:~:) (..), testEquality )
 import Fmt
@@ -1363,7 +1365,7 @@ distributeSurplusDeltaWithOneChangeCoin
         extraFee = findFixpointIncreasingFeeBy $
             costOfIncreasingCoin feePolicy change0 surplus
     in
-        case surplus `W.Coin.subtract` extraFee of
+        case surplus </> extraFee of
             Just extraChange ->
                 Right $ TxFeeAndChange
                     { fee = extraFee

--- a/lib/balance-tx/lib/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/Cardano/Write/Tx/Sign.hs
@@ -58,6 +58,8 @@ import Control.Lens
     ( view, (&), (.~), (^.) )
 import Data.Maybe
     ( mapMaybe )
+import Data.Monoid.Monus
+    ( Monus ((<\>)) )
 import Numeric.Natural
     ( Natural )
 
@@ -67,7 +69,6 @@ import qualified Cardano.Api.Byron as Byron
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
-import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Cardano.Write.Tx as Write
 import qualified Data.Foldable as F
@@ -88,7 +89,7 @@ estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
         -- Hack which allows us to rely on the ledger to calculate the size of
         -- witnesses:
         feeOfWits :: W.Coin
-        feeOfWits = minfee nWits `W.Coin.difference` minfee mempty
+        feeOfWits = minfee nWits <\> minfee mempty
 
         sizeOfWits :: TxSize
         sizeOfWits =

--- a/lib/balance-tx/test/spec/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/balance-tx/test/spec/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -92,7 +92,7 @@ prop_assessTokenBundleSize_enlarge
     -> Property
 prop_assessTokenBundleSize_enlarge b1' b2' pp =
     assess b1 == TokenBundleSizeExceedsLimit ==> conjoin
-        [ assess (b1 `TokenBundle.add` b2)
+        [ assess (b1 <> b2)
             === TokenBundleSizeExceedsLimit
         , assess (b1 `TokenBundle.setCoin` txOutMaxCoin)
             === TokenBundleSizeExceedsLimit

--- a/lib/balance-tx/test/spec/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/balance-tx/test/spec/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -39,6 +39,8 @@ import Control.Lens
     ( (&), (.~) )
 import Data.Default
     ( def )
+import Data.Monoid.Monus
+    ( Monus ((<\>)) )
 import Data.Word
     ( Word64 )
 import Numeric.Natural
@@ -112,7 +114,7 @@ prop_assessTokenBundleSize_shrink
     -> Property
 prop_assessTokenBundleSize_shrink b1' b2' pp =
     assess b1 == TokenBundleSizeWithinLimit ==> conjoin
-        [ assess (b1 `TokenBundle.difference` b2)
+        [ assess (b1 <\> b2)
             === TokenBundleSizeWithinLimit
         , assess (b1 `TokenBundle.setCoin` txOutMinCoin)
             === TokenBundleSizeWithinLimit

--- a/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Write/Tx/BalanceSpec.hs
@@ -843,7 +843,7 @@ spec_distributeSurplus = describe "distributeSurplus" $ do
 
         let isBoundary c =
                 sizeOfCoin c /= sizeOfCoin (c `W.Coin.difference` W.Coin 1)
-                || sizeOfCoin c /= sizeOfCoin (c `W.Coin.add` W.Coin 1)
+                || sizeOfCoin c /= sizeOfCoin (c <> W.Coin 1)
 
         it "matches the size of the Word64 CBOR encoding" $
             property $ checkCoverage $


### PR DESCRIPTION
## Issue

Follow-on from #4110 

## Description

This PR makes the following replacements within the `cardano-balance-tx` library:

| Before | After |
| -- | -- |
| `{TokenBundle,TokenMap,TokenQuantity,Coin}.add` | `Semigroup.<>` |
| `{TokenBundle,TokenMap,TokenQuantity,Coin}.subtract` | `Reductive.</>` |
| `{TokenBundle,TokenMap,TokenQuantity,Coin}.difference` | `Monus.<\>` |

Functions on the LHS of the above table are already just synonyms of class methods on the RHS.

This takes us one small step closer to removing the dependency on types defined within `cardano-wallet-primitive`.