### PR TITLE
Move definition of `txConstraints` to `cardano-wallet`.

### DIFF
--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -489,7 +489,7 @@ import Cardano.Wallet.Shelley.Compatibility
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( toLedgerAddress, toWallet, toWalletCoin )
 import Cardano.Wallet.Shelley.Transaction
-    ( txConstraints, txWitnessTagForKey )
+    ( txConstraints, txWitnessTagForKey, _txRewardWithdrawalCost )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , ErrCannotJoin (..)
@@ -521,7 +521,7 @@ import Cardano.Write.Tx.Balance
     , constructUTxOIndex
     )
 import Cardano.Write.Tx.SizeEstimation
-    ( TxWitnessTag (..), _txRewardWithdrawalCost )
+    ( TxWitnessTag (..) )
 import Cardano.Write.Tx.TimeTranslation
     ( TimeTranslation )
 import Control.Arrow

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -489,7 +489,7 @@ import Cardano.Wallet.Shelley.Compatibility
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( toLedgerAddress, toWallet, toWalletCoin )
 import Cardano.Wallet.Shelley.Transaction
-    ( txWitnessTagForKey )
+    ( txConstraints, txWitnessTagForKey )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , ErrCannotJoin (..)
@@ -656,7 +656,6 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Cardano.Wallet.Read as Read
 import qualified Cardano.Write.ProtocolParameters as Write
 import qualified Cardano.Write.Tx as Write
-import qualified Cardano.Write.Tx.SizeEstimation as Write
 import qualified Data.ByteArray as BA
 import qualified Data.Delta.Update as Delta
 import qualified Data.Foldable as F
@@ -1804,7 +1803,7 @@ calcMinimumCoinValues pp txLayer =
     uncurry (constraints ^. #txOutputMinimumAdaQuantity)
      . (\o -> (o ^. #address, o ^. #tokens . #tokens))
   where
-    constraints = Write.txConstraints pp $ transactionWitnessTag txLayer
+    constraints = txConstraints pp $ transactionWitnessTag txLayer
 
 signTransaction
   :: forall k ktype
@@ -2649,10 +2648,10 @@ createMigrationPlan
 createMigrationPlan ctx rewardWithdrawal = do
     (wallet, _, pending) <- readWallet ctx
     (Write.InAnyRecentEra _era pp, _) <- readNodeTipStateForTxWrite nl
-    let txConstraints = Write.txConstraints pp (transactionWitnessTag tl)
+    let constraints = txConstraints pp (transactionWitnessTag tl)
         utxo = availableUTxO pending wallet
     pure
-        $ Migration.createPlan txConstraints utxo
+        $ Migration.createPlan constraints utxo
         $ Migration.RewardWithdrawal
         $ withdrawalToCoin rewardWithdrawal
   where

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1180,7 +1180,13 @@ txConstraints (ProtocolParameters protocolParams) witnessTag = TxConstraints
         TxSize $ protocolParams ^. Ledger.ppMaxTxSizeL
 
     empty :: TxSkeleton
-    empty = emptyTxSkeleton witnessTag
+    empty = TxSkeleton
+        { txWitnessTag = witnessTag
+        , txInputCount = 0
+        , txOutputs = []
+        , txChange = []
+        , txPaymentTemplate = Nothing
+        }
 
     -- Computes the size difference between the given skeleton and an empty
     -- skeleton.
@@ -1210,19 +1216,6 @@ txConstraints (ProtocolParameters protocolParams) witnessTag = TxConstraints
 
         nullByte :: Word8
         nullByte = 0
-
--- | Constructs an empty transaction skeleton.
---
--- This may be used to estimate the size and cost of an empty transaction.
---
-emptyTxSkeleton :: TxWitnessTag -> TxSkeleton
-emptyTxSkeleton txWitnessTag = TxSkeleton
-    { txWitnessTag
-    , txInputCount = 0
-    , txOutputs = []
-    , txChange = []
-    , txPaymentTemplate = Nothing
-    }
 
 mkLedgerTxOut
     :: HasCallStack

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1217,18 +1217,18 @@ txConstraints (ProtocolParameters protocolParams) witnessTag = TxConstraints
         nullByte :: Word8
         nullByte = 0
 
-mkLedgerTxOut
-    :: HasCallStack
-    => Write.RecentEra era
-    -> Address
-    -> TokenBundle
-    -> Write.TxOut (Write.ShelleyLedgerEra era)
-mkLedgerTxOut txOutEra address bundle =
-    case txOutEra of
-        Write.RecentEraBabbage -> Convert.toBabbageTxOut txOut
-        Write.RecentEraConway -> Convert.toConwayTxOut txOut
-      where
-        txOut = TxOut address bundle
+    mkLedgerTxOut
+        :: HasCallStack
+        => Write.RecentEra era
+        -> Address
+        -> TokenBundle
+        -> Write.TxOut (Write.ShelleyLedgerEra era)
+    mkLedgerTxOut txOutEra address bundle =
+        case txOutEra of
+            Write.RecentEraBabbage -> Convert.toBabbageTxOut txOut
+            Write.RecentEraConway -> Convert.toConwayTxOut txOut
+          where
+            txOut = TxOut address bundle
 
 -- NOTE: Should probably not exist.  We could consider replacing it with
 -- `UTxOAssumptions`, which has the benefit of containing the script template we

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1162,13 +1162,13 @@ txConstraints (ProtocolParameters protocolParams) witnessTag = TxConstraints
         Write.computeMinimumCoinForTxOut
             era
             protocolParams
-            (mkLedgerTxOut era addr (TokenBundle txOutMaxCoin tokens))
+            (mkLedgerTxOut addr (TokenBundle txOutMaxCoin tokens))
 
     txOutputBelowMinimumAdaQuantity addr bundle =
         Write.isBelowMinimumCoinForTxOut
             era
             protocolParams
-            (mkLedgerTxOut era addr bundle)
+            (mkLedgerTxOut addr bundle)
 
     txRewardWithdrawalCost =
         _txRewardWithdrawalCost feePerByte (Right witnessTag)
@@ -1219,12 +1219,11 @@ txConstraints (ProtocolParameters protocolParams) witnessTag = TxConstraints
 
     mkLedgerTxOut
         :: HasCallStack
-        => Write.RecentEra era
-        -> Address
+        => Address
         -> TokenBundle
         -> Write.TxOut (Write.ShelleyLedgerEra era)
-    mkLedgerTxOut txOutEra address bundle =
-        case txOutEra of
+    mkLedgerTxOut address bundle =
+        case era of
             Write.RecentEraBabbage -> Convert.toBabbageTxOut txOut
             Write.RecentEraConway -> Convert.toConwayTxOut txOut
           where

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -120,6 +120,7 @@ import Cardano.Wallet.Shelley.Transaction
     , mkShelleyWitness
     , mkUnsignedTx
     , newTransactionLayer
+    , txConstraints
     )
 import Cardano.Wallet.Transaction
     ( SelectionOf (..)
@@ -140,7 +141,7 @@ import Cardano.Write.Tx.Balance
 import Cardano.Write.Tx.BalanceSpec
     ( mockPParamsForBalancing )
 import Cardano.Write.Tx.SizeEstimation
-    ( TxSkeleton (..), estimateTxSize, txConstraints )
+    ( TxSkeleton (..), estimateTxSize )
 import Control.Arrow
     ( first )
 import Control.Monad


### PR DESCRIPTION
## Issue

ADP-3185

## Description

This PR moves the definition of function `txConstraints` back to `cardano-wallet`.

The `txConstraints` function and `TxConstraints` type:

- are part of the transaction size and cost abstraction used by the wallet's **_balance migration algorithm_** (which is completely separate from the UTxO selection algorithm used by `balanceTransaction`);
- are **_only_** used by the wallet's **_balance migration algorithm_**;
- are **_not_** used at all within the `cardano-balance-tx` library.

So we can safely move the `txConstraints` function away from `cardano-balance-tx`.

This is consistent with our goal of minimising the public interface of `cardano-balance-tx`.

## Notes

An alternative approach to this PR would be to move `txConstraints` to the `Internal` module hierarchy of `cardano-balance-tx`, and then have `cardano-wallet` depend on the `Internal` module hierarchy. However, depending on an internal module seems unnecessary when we can just move this function to the only package that depends on it.