### PR TITLE
Use consistent source of truth for `maximumOutputTokenQuantity` in `cardano-coin-selection`.

### DIFF
--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -78,8 +78,6 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId, TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( txOutMaxTokenQuantity )
 import Control.Monad.Random.Class
     ( MonadRandom (..) )
 import Control.Monad.Random.NonRandom
@@ -1212,10 +1210,12 @@ verifyOutputTokenQuantities
     :: SelectionConstraints ctx
     -> (Address ctx, TokenBundle)
     -> [SelectionOutputTokenQuantityExceedsLimitError ctx]
-verifyOutputTokenQuantities _cs out =
+verifyOutputTokenQuantities cs out =
     [ SelectionOutputTokenQuantityExceedsLimitError
-        {address, asset, quantity, quantityMaxBound = txOutMaxTokenQuantity}
+        {address, asset, quantity, quantityMaxBound}
     | let address = fst out
     , (asset, quantity) <- TokenMap.toFlatList $ (snd out) ^. #tokens
-    , quantity > txOutMaxTokenQuantity
+    , quantity > quantityMaxBound
     ]
+  where
+    quantityMaxBound = maximumOutputTokenQuantity cs

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -778,7 +778,7 @@ verifySelectionOutputTokenQuantitiesWithinLimit cs _ps selection =
     verifyEmpty errors FailureToVerifySelectionOutputTokenQuantitiesWithinLimit
   where
     errors :: [SelectionOutputTokenQuantityExceedsLimitError ctx]
-    errors = verifyOutputTokenQuantities =<<
+    errors = verifyOutputTokenQuantities cs =<<
         selectionChangeOutputsWithDummyAddresses cs selection
 
 --------------------------------------------------------------------------------
@@ -1209,9 +1209,10 @@ deriving instance SelectionContext ctx =>
 -- protocol.
 --
 verifyOutputTokenQuantities
-    :: (Address ctx, TokenBundle)
+    :: SelectionConstraints ctx
+    -> (Address ctx, TokenBundle)
     -> [SelectionOutputTokenQuantityExceedsLimitError ctx]
-verifyOutputTokenQuantities out =
+verifyOutputTokenQuantities _cs out =
     [ SelectionOutputTokenQuantityExceedsLimitError
         {address, asset, quantity, quantityMaxBound = txOutMaxTokenQuantity}
     | let address = fst out

--- a/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
@@ -77,8 +77,6 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genAssetId, genTokenMap, shrinkTokenMap )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( txOutMaxTokenQuantity )
 import Control.Monad
     ( forM_ )
 import Control.Monad.Trans.Except
@@ -611,7 +609,7 @@ genOutputsToCover = do
             ]
       where
         limit :: Natural
-        limit = unTokenQuantity txOutMaxTokenQuantity
+        limit = unTokenQuantity testMaximumOutputTokenQuantity
 
 shrinkOutputsToCover
     :: [(TestAddress, TokenBundle)] -> [[(TestAddress, TokenBundle)]]


### PR DESCRIPTION
## Issue

None. (Noticed while looking at ADP-3185.)

## Description

This PR adjusts the `cardano-coin-selection` library to use a consistent source of truth for the maximum quantity of any individual asset allowed in a transaction output. This is currently defined by the `SelectionConstraints.maximumOutputTokenQuantity` field.

In `CoinSelectionSpec`, this field is currently hard-wired to the value of `testMaximumOutputTokenQuantity`, which has a value of `maxBound @Word64`.