### PR TITLE
Adjust location of wallet balance migration algorithm.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -423,6 +423,8 @@ import Cardano.Wallet.Api.Types.Transaction
     , fromApiLimit
     , mkApiWitnessCount
     )
+import Cardano.Wallet.Balance.Migration
+    ( MigrationPlan (..) )
 import Cardano.Wallet.Compat
     ( (^?) )
 import Cardano.Wallet.DB
@@ -445,8 +447,6 @@ import Cardano.Wallet.Pools
     ( EpochInfo (..), toEpochInfo )
 import Cardano.Wallet.Primitive.Delegation.UTxO
     ( stakeKeyCoinDistr )
-import Cardano.Wallet.Primitive.Migration
-    ( MigrationPlan (..) )
 import Cardano.Wallet.Primitive.Model
     ( Wallet
     , availableBalance

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -239,6 +239,9 @@ library
     Cardano.Wallet.Address.Keys.WitnessCount
     Cardano.Wallet.Address.MaybeLight
     Cardano.Wallet.Address.States.IsOwned
+    Cardano.Wallet.Balance.Migration
+    Cardano.Wallet.Balance.Migration.Planning
+    Cardano.Wallet.Balance.Migration.Selection
     Cardano.Wallet.Byron.Compatibility
     Cardano.Wallet.Checkpoints
     Cardano.Wallet.Checkpoints.Policy
@@ -295,9 +298,6 @@ library
     Cardano.Wallet.Primitive.BlockSummary
     Cardano.Wallet.Primitive.Delegation.State
     Cardano.Wallet.Primitive.Delegation.UTxO
-    Cardano.Wallet.Primitive.Migration
-    Cardano.Wallet.Primitive.Migration.Planning
-    Cardano.Wallet.Primitive.Migration.Selection
     Cardano.Wallet.Primitive.Model
     Cardano.Wallet.Primitive.Slotting
     Cardano.Wallet.Primitive.SyncProgress
@@ -868,6 +868,9 @@ test-suite unit
     Cardano.Wallet.Api.ServerSpec
     Cardano.Wallet.Api.TypesSpec
     Cardano.Wallet.ApiSpec
+    Cardano.Wallet.Balance.MigrationSpec
+    Cardano.Wallet.Balance.Migration.PlanningSpec
+    Cardano.Wallet.Balance.Migration.SelectionSpec
     Cardano.Wallet.Checkpoints.PolicySpec
     Cardano.Wallet.CheckpointsSpec
     Cardano.Wallet.DB.Arbitrary
@@ -903,9 +906,6 @@ test-suite unit
     Cardano.Wallet.NetworkSpec
     Cardano.Wallet.Primitive.BlockSummarySpec
     Cardano.Wallet.Primitive.Delegation.StateSpec
-    Cardano.Wallet.Primitive.Migration.PlanningSpec
-    Cardano.Wallet.Primitive.Migration.SelectionSpec
-    Cardano.Wallet.Primitive.MigrationSpec
     Cardano.Wallet.Primitive.ModelSpec
     Cardano.Wallet.Primitive.Passphrase.LegacySpec
     Cardano.Wallet.Primitive.PassphraseSpec

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -326,6 +326,8 @@ import Cardano.Wallet.Address.MaybeLight
     ( MaybeLight (maybeDiscover) )
 import Cardano.Wallet.Address.States.IsOwned
     ( isOwned )
+import Cardano.Wallet.Balance.Migration
+    ( MigrationPlan (..) )
 import Cardano.Wallet.Checkpoints
     ( DeltaCheckpoints (..), extendCheckpoints, pruneCheckpoints )
 import Cardano.Wallet.DB
@@ -378,8 +380,6 @@ import Cardano.Wallet.Network
     )
 import Cardano.Wallet.Primitive.BlockSummary
     ( ChainEvents )
-import Cardano.Wallet.Primitive.Migration
-    ( MigrationPlan (..) )
 import Cardano.Wallet.Primitive.Model
     ( BlockData (..)
     , Wallet
@@ -639,12 +639,12 @@ import qualified Cardano.Slotting.Slot as Slot
 import qualified Cardano.Wallet.Address.Discovery.Random as Rnd
 import qualified Cardano.Wallet.Address.Discovery.Sequential as Seq
 import qualified Cardano.Wallet.Address.Discovery.Shared as Shared
+import qualified Cardano.Wallet.Balance.Migration as Migration
 import qualified Cardano.Wallet.Checkpoints.Policy as CP
 import qualified Cardano.Wallet.DB.Store.Delegations.Layer as Dlgs
 import qualified Cardano.Wallet.DB.Store.Submissions.Layer as Submissions
 import qualified Cardano.Wallet.DB.WalletState as WalletState
 import qualified Cardano.Wallet.DB.WalletState as WS
-import qualified Cardano.Wallet.Primitive.Migration as Migration
 import qualified Cardano.Wallet.Primitive.Slotting as Slotting
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin

--- a/lib/wallet/src/Cardano/Wallet/Balance/Migration.hs
+++ b/lib/wallet/src/Cardano/Wallet/Balance/Migration.hs
@@ -10,7 +10,7 @@
 --
 -- Use 'createPlan' to create a migration plan.
 --
-module Cardano.Wallet.Primitive.Migration
+module Cardano.Wallet.Balance.Migration
     (
     -- * Creating a migration plan
       createPlan
@@ -22,7 +22,7 @@ module Cardano.Wallet.Primitive.Migration
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Migration.Selection
+import Cardano.Wallet.Balance.Migration.Selection
     ( RewardWithdrawal (..), Selection (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin )
@@ -43,7 +43,7 @@ import Data.Generics.Labels
 import GHC.Generics
     ( Generic )
 
-import qualified Cardano.Wallet.Primitive.Migration.Planning as Planning
+import qualified Cardano.Wallet.Balance.Migration.Planning as Planning
 
 -- | Represents a plan for migrating a 'UTxO' set.
 --

--- a/lib/wallet/src/Cardano/Wallet/Balance/Migration.hs
+++ b/lib/wallet/src/Cardano/Wallet/Balance/Migration.hs
@@ -3,10 +3,11 @@
 {-# LANGUAGE OverloadedLabels #-}
 
 -- |
--- Copyright: © 2021 IOHK
+-- Copyright: © 2021–2023 IOHK, 2023 Cardano Foundation
 -- License: Apache-2.0
 --
--- This module provides a public API for planning wallet migrations.
+-- This module provides an algorithm for migrating the entire balance of a
+-- wallet. (This is also known as "sweeping" a wallet.)
 --
 -- Use 'createPlan' to create a migration plan.
 --

--- a/lib/wallet/src/Cardano/Wallet/Balance/Migration/Planning.hs
+++ b/lib/wallet/src/Cardano/Wallet/Balance/Migration/Planning.hs
@@ -20,7 +20,7 @@
 --
 -- Use 'createPlan' to create a migration plan.
 --
-module Cardano.Wallet.Primitive.Migration.Planning
+module Cardano.Wallet.Balance.Migration.Planning
     (
     -- * Migration planning
       createPlan
@@ -39,7 +39,7 @@ module Cardano.Wallet.Primitive.Migration.Planning
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Migration.Selection
+import Cardano.Wallet.Balance.Migration.Selection
     ( RewardWithdrawal (..), Selection (..), SelectionError (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
@@ -64,7 +64,7 @@ import Data.Generics.Labels
 import GHC.Generics
     ( Generic )
 
-import qualified Cardano.Wallet.Primitive.Migration.Selection as Selection
+import qualified Cardano.Wallet.Balance.Migration.Selection as Selection
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Data.Foldable as F
 import qualified Data.List as L

--- a/lib/wallet/src/Cardano/Wallet/Balance/Migration/Selection.hs
+++ b/lib/wallet/src/Cardano/Wallet/Balance/Migration/Selection.hs
@@ -19,7 +19,7 @@
 -- Use 'create' to create a selection with one or more inputs.
 -- Use 'extend' to extend a selection with an additional input.
 --
-module Cardano.Wallet.Primitive.Migration.Selection
+module Cardano.Wallet.Balance.Migration.Selection
     (
     -- * Types
       Selection (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Balance/Migration/PlanningSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Balance/Migration/PlanningSpec.hs
@@ -5,12 +5,12 @@
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Cardano.Wallet.Primitive.Migration.PlanningSpec
+module Cardano.Wallet.Balance.Migration.PlanningSpec
     where
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Migration.Planning
+import Cardano.Wallet.Balance.Migration.Planning
     ( CategorizedUTxO (..)
     , MigrationPlan (..)
     , UTxOEntryCategory (..)
@@ -19,9 +19,9 @@ import Cardano.Wallet.Primitive.Migration.Planning
     , createPlan
     , uncategorizeUTxOEntries
     )
-import Cardano.Wallet.Primitive.Migration.Selection
+import Cardano.Wallet.Balance.Migration.Selection
     ( RewardWithdrawal (..), Selection (..) )
-import Cardano.Wallet.Primitive.Migration.SelectionSpec
+import Cardano.Wallet.Balance.Migration.SelectionSpec
     ( MockInputId
     , MockTxConstraints (..)
     , genMockInput
@@ -73,7 +73,7 @@ import Test.QuickCheck.Extra
 import Test.Utils.Pretty
     ( Pretty (..) )
 
-import qualified Cardano.Wallet.Primitive.Migration.Selection as Selection
+import qualified Cardano.Wallet.Balance.Migration.Selection as Selection
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Data.Foldable as F
 import qualified Data.List as L
@@ -81,7 +81,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as Set
 
 spec :: Spec
-spec = describe "Cardano.Wallet.Primitive.Migration.PlanningSpec" $
+spec = describe "Cardano.Wallet.Balance.Migration.PlanningSpec" $
 
     modifyMaxSuccess (const 1_000) $ do
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Balance/Migration/SelectionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Balance/Migration/SelectionSpec.hs
@@ -9,12 +9,12 @@
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Cardano.Wallet.Primitive.Migration.SelectionSpec
+module Cardano.Wallet.Balance.Migration.SelectionSpec
     where
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Migration.Selection
+import Cardano.Wallet.Balance.Migration.Selection
     ( RewardWithdrawal (..)
     , Selection (..)
     , SelectionCorrectness (..)
@@ -105,7 +105,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Extra
     ( report, verify )
 
-import qualified Cardano.Wallet.Primitive.Migration.Selection as Selection
+import qualified Cardano.Wallet.Balance.Migration.Selection as Selection
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
@@ -116,7 +116,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Text.Encoding as T
 
 spec :: Spec
-spec = describe "Cardano.Wallet.Primitive.Migration.SelectionSpec" $
+spec = describe "Cardano.Wallet.Balance.Migration.SelectionSpec" $
 
     modifyMaxSuccess (const 1_000) $ do
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Balance/MigrationSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Balance/MigrationSpec.hs
@@ -1,16 +1,16 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedLabels #-}
 
-module Cardano.Wallet.Primitive.MigrationSpec
+module Cardano.Wallet.Balance.MigrationSpec
     where
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Migration
+import Cardano.Wallet.Balance.Migration
     ( RewardWithdrawal (..), createPlan )
-import Cardano.Wallet.Primitive.Migration.Planning
+import Cardano.Wallet.Balance.Migration.Planning
     ( categorizeUTxO, uncategorizeUTxO )
-import Cardano.Wallet.Primitive.Migration.SelectionSpec
+import Cardano.Wallet.Balance.Migration.SelectionSpec
     ( MockTxConstraints
     , genRewardWithdrawal
     , genTokenBundleMixed
@@ -42,13 +42,13 @@ import Test.QuickCheck
 import Test.QuickCheck.Extra
     ( verify )
 
-import qualified Cardano.Wallet.Primitive.Migration.Planning as Planning
+import qualified Cardano.Wallet.Balance.Migration.Planning as Planning
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 
 spec :: Spec
 spec =
-    describe "Cardano.Wallet.Primitive.MigrationSpec" $
+    describe "Cardano.Wallet.Balance.MigrationSpec" $
 
         describe "Creating migration plans (with concrete wallet types)" $ do
 

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -59,6 +59,8 @@ import Cardano.Wallet.Address.States.Features
     ( TestFeatures (..), defaultTestFeatures )
 import Cardano.Wallet.Address.States.Test.State
     ( TestState (..) )
+import Cardano.Wallet.Balance.Migration.SelectionSpec
+    ( MockTxConstraints (..), genTokenBundleMixed, unMockTxConstraints )
 import Cardano.Wallet.DB
     ( DBFresh, DBLayer (..), hoistDBFresh, hoistDBLayer, putTxHistory )
 import Cardano.Wallet.DB.Fixtures
@@ -81,8 +83,6 @@ import Cardano.Wallet.Gen
     ( genMnemonic, genSlotNo )
 import Cardano.Wallet.Network
     ( NetworkLayer (..) )
-import Cardano.Wallet.Primitive.Migration.SelectionSpec
-    ( MockTxConstraints (..), genTokenBundleMixed, unMockTxConstraints )
 import Cardano.Wallet.Primitive.NetworkId
     ( NetworkDiscriminant (Mainnet) )
 import Cardano.Wallet.Primitive.Passphrase
@@ -269,9 +269,9 @@ import UnliftIO.Concurrent
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.Address.Book as Sqlite
+import qualified Cardano.Wallet.Balance.Migration as Migration
 import qualified Cardano.Wallet.DB.Sqlite.Types as DB
 import qualified Cardano.Wallet.DB.Store.Checkpoints.Store as Sqlite
-import qualified Cardano.Wallet.Primitive.Migration as Migration
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Read as Read


### PR DESCRIPTION
## Issue

None. Noticed while looking at ADP-3171 and ADP-3185.

## Description

This PR adjusts the location of the wallet balance migration algorithm:

```patch
- Cardano.Wallet.Primitive.Migration
+ Cardano.Wallet.Balance.Migration
```

The new module location is more consistent with its purpose, which is to provide an algorithm capable of migrating the entire **_balance_** of a wallet, and not some other kind of migration (for example, database migration).