### PR TITLE
Update broken links to `input-output-hk.github.io/cardano-wallet/*`.

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -34,7 +34,7 @@ Compatible with [`cardano-node@{{CARDANO_NODE_TAG}}`](https://github.com/input-o
 
 | :closed_book: | :computer: | :whale: |
 | -- | -- | -- |
-| [API Documentation](https://input-output-hk.github.io/cardano-wallet/releases/{{GIT_TAG}}/api) | [CLI Manual](https://input-output-hk.github.io/cardano-wallet/releases/{{GIT_TAG}}/user-guide/cli) | [Docker Manual](https://input-output-hk.github.io/cardano-wallet/releases/{{GIT_TAG}}/user-guide/Docker) |
+| [API Documentation](https://cardano-foundation.github.io/cardano-wallet/releases/{{GIT_TAG}}/api) | [CLI Manual](https://cardano-foundation.github.io/cardano-wallet/releases/{{GIT_TAG}}/user-guide/cli) | [Docker Manual](https://cardano-foundation.github.io/cardano-wallet/releases/{{GIT_TAG}}/user-guide/Docker) |
 
 ## Installation Instructions
 

--- a/docs/site/src/contributor/what/coding-standards.md
+++ b/docs/site/src/contributor/what/coding-standards.md
@@ -657,7 +657,7 @@ We should keep an eye out out-of-date comments. For instance when creating and r
 > Try seaching for `applyBlocks` or `switchToFork`. What is the difference between `DB.Spec.Update.switchToFork` and `DB.AcidState.switchToFork`?
 >
 > Having a comment at the top of each module would be an easy-to-follow rule to better document this. It is also very appropriate for
-> generated [haddock docs](https://input-output-hk.github.io/cardano-wallet/haddock/).
+> generated [haddock docs](https://cardano-foundation.github.io/cardano-wallet/haddock/).
 >
 > If we re-design a module and forget to update the comment, the comment is no longer useful.
 
@@ -687,7 +687,7 @@ We should keep an eye out out-of-date comments. For instance when creating and r
 -- intermediary between the three.
 ```
 
-(https://input-output-hk.github.io/cardano-wallet/haddock/cardano-wallet-2.0.0/Cardano-WalletLayer.html)
+(https://cardano-foundation.github.io/cardano-wallet/haddock/cardano-wallet-2.0.0/Cardano-WalletLayer.html)
 
 </details>
 

--- a/docs/site/src/design/concepts/coin-selection.md
+++ b/docs/site/src/design/concepts/coin-selection.md
@@ -65,8 +65,8 @@ number of available UTXOs, the API returns a 'UTXONotEnoughFragmented' error.
 
 To make sure the source account has a sufficient level of UTXO fragmentation
 (i.e. number of UTXOs), the state of the UTXOs can be monitored via following wallet endpoints:
- - [UTxO Statistics](https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/getUTxOsStatistics)
- - [UTxO Snapshot](https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/getWalletUtxoSnapshot)
+ - [UTxO Statistics](https://cardano-foundation.github.io/cardano-wallet/api/edge/#operation/getUTxOsStatistics)
+ - [UTxO Snapshot](https://cardano-foundation.github.io/cardano-wallet/api/edge/#operation/getWalletUtxoSnapshot)
 
 The number of wallet UTXOs should be no less than the transaction outputs, and
 the sum of all UTXOs should be enough to cover the total transaction amount,

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
   #   - dockerImage - tarball of the docker image
   #
   # Other documentation:
-  #   https://input-output-hk.github.io/cardano-wallet/dev/Building#nix-build
+  #   https://cardano-foundation.github.io/cardano-wallet/dev/Building#nix-build
   #
   ############################################################################
 

--- a/reports/security/2020-01-21.md
+++ b/reports/security/2020-01-21.md
@@ -71,7 +71,7 @@ GRANT SELECT, INSERT ON table1, table2 TO restricted_api_user;
 
 ### OWASP risk : Improper Assets Management
 
-**Conclusion**: Each endpoint, its corresponding inputs and outputs is documented, and updated upon development in https://input-output-hk.github.io/cardano-wallet/api/edge/
+**Conclusion**: Each endpoint, its corresponding inputs and outputs is documented, and updated upon development in https://cardano-foundation.github.io/cardano-wallet/api/edge/
 There are no undocumented and bogus endpoints operative.
 
 ### OWASP risk : Insufficient Logging & Monitoring

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -11,7 +11,7 @@ info:
     </p>
 externalDocs:
   description: Need more? Click here to access our API guide and walkthrough.
-  url: https://input-output-hk.github.io/cardano-wallet/
+  url: https://cardano-foundation.github.io/cardano-wallet/
 
 servers:
   - url: https://localhost:8090/v2/


### PR DESCRIPTION
## Issue

None

## Description

This PR makes the following replacement across the entire repository:
```patch
-    input-output-hk.github.io/cardano-wallet
+ cardano-foundation.github.io/cardano-wallet
```