### PR TITLE
Build with GHC `9.2.8`.

### DIFF
--- a/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Derivation.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Derivation.hs
@@ -155,8 +155,8 @@ import Data.Text.Class
     , toTextFromBoundedEnum
     )
 import Data.Type.Equality
-    ( (:~:) (..)
-    , testEquality
+    ( testEquality
+    , (:~:) (..)
     )
 import Data.Word
     ( Word32

--- a/lib/application-extras/cardano-wallet-application-extras.cabal
+++ b/lib/application-extras/cardano-wallet-application-extras.cabal
@@ -31,7 +31,7 @@ library
 
   hs-source-dirs:     lib
   build-depends:
-    , base                   ^>=4.14.3.0
+    , base                    >=4.14.3.0
     , contra-tracer          ^>=0.1.0.2
     , iohk-monitoring        ^>=0.1.11.3
     , iohk-monitoring-extra  ^>=0.1

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -237,8 +237,8 @@ import Data.Maybe
     , isJust
     )
 import Data.Type.Equality
-    ( (:~:) (Refl)
-    , TestEquality (testEquality)
+    ( TestEquality (testEquality)
+    , (:~:) (Refl)
     )
 import Data.Typeable
     ( Typeable

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -184,8 +184,8 @@ import Data.Semigroup.Cancellative
     ( Reductive ((</>))
     )
 import Data.Type.Equality
-    ( (:~:) (..)
-    , testEquality
+    ( testEquality
+    , (:~:) (..)
     )
 import Fmt
     ( Buildable
@@ -290,18 +290,18 @@ import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
 import qualified Cardano.Wallet.Primitive.Types.Address as W
     ( Address
     )
-import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..)
     )
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle (..)
     )
-import qualified Cardano.Wallet.Primitive.Types.TokenMap as W.TokenMap
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
     ( AssetId (..)
     )
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as W.TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
     ( TokenQuantity (..)
     )
@@ -313,14 +313,14 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
     ( TxIn
     )
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (..)
     )
-import qualified Cardano.Wallet.Primitive.Types.UTxO as W.UTxO
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
     ( UTxO (..)
     )
+import qualified Cardano.Wallet.Primitive.Types.UTxO as W.UTxO
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.Map as Map

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -128,10 +128,10 @@ import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin
     )
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle (..)
     )
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
     ( AssetId
     , TokenMap

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -68,10 +68,10 @@ import Test.QuickCheck
     , (==>)
     )
 
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle
     )
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
     ( TxSize (..)

--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
@@ -145,14 +145,14 @@ import GHC.Generics
     ( Generic
     )
 
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle
     )
-import qualified Cardano.Wallet.Primitive.Types.TokenMap as W.TokenMap
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
     ( AssetId
     )
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as W.TokenMap
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE

--- a/lib/crypto-hash-extra/crypto-hash-extra.cabal
+++ b/lib/crypto-hash-extra/crypto-hash-extra.cabal
@@ -26,7 +26,7 @@ library
   hs-source-dirs:     src
   exposed-modules:    Crypto.Hash.Extra
   build-depends:
-    , base                    ^>=4.14.3
-    , bytestring              ^>=0.10.12
-    , cryptonite              ^>=0.30
-    , memory                  ^>=0.18
+    , base                    >=4.14.3
+    , bytestring              >=0.10.12
+    , cryptonite              >=0.30
+    , memory                  >=0.18

--- a/lib/delta-table/src/Database/Persist/Delta.hs
+++ b/lib/delta-table/src/Database/Persist/Delta.hs
@@ -60,10 +60,10 @@ import Database.Persist.Sql
     , toSqlKey
     )
 import Database.Schema
-    ( (:.) (..)
-    , Col (..)
+    ( Col (..)
     , IsRow
     , Primary (..)
+    , (:.) (..)
     )
 import Say
     ( say

--- a/lib/delta-table/src/Demo/Database.hs
+++ b/lib/delta-table/src/Demo/Database.hs
@@ -93,10 +93,10 @@ import Database.Persist.TH
     , sqlSettings
     )
 import Database.Schema
-    ( (:.) (..)
-    , Col (..)
+    ( Col (..)
     , Primary
     , Table (..)
+    , (:.) (..)
     )
 import GHC.Generics
     ( Generic

--- a/lib/iohk-monitoring-extra/iohk-monitoring-extra.cabal
+++ b/lib/iohk-monitoring-extra/iohk-monitoring-extra.cabal
@@ -27,18 +27,18 @@ library
   hs-source-dirs:     src
   exposed-modules:    Cardano.BM.Extra
   build-depends:
-    , aeson                ^>=2.1.2.1
-    , base                 ^>=4.14.3
-    , bytestring           ^>=0.10.12
-    , contra-tracer        ^>=0.1.0.2
-    , deepseq              ^>=1.4.4
-    , exceptions           ^>=0.10.4
-    , fmt                  ^>=0.6.3
-    , iohk-monitoring      ^>=0.1.11.3
-    , text                 ^>=1.2.4.1
-    , text-class           ^>=2023.7.18
-    , time                 ^>=1.9.3
-    , tracer-transformers  ^>=0.1.0.4
-    , transformers         ^>=0.5.6.2
-    , unliftio             ^>=0.2.24
-    , unliftio-core        ^>=0.2.1
+    , aeson                >=2.1.2.1
+    , base                 >=4.14.3
+    , bytestring           >=0.10.12
+    , contra-tracer        >=0.1.0.2
+    , deepseq              >=1.4.4
+    , exceptions           >=0.10.4
+    , fmt                  >=0.6.3
+    , iohk-monitoring      >=0.1.11.3
+    , text                 >=1.2.4.1
+    , text-class           >=2023.7.18
+    , time                 >=1.9.3
+    , tracer-transformers  >=0.1.0.4
+    , transformers         >=0.5.6.2
+    , unliftio             >=0.2.24
+    , unliftio-core        >=0.2.1

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -54,19 +54,19 @@ library
 
   hs-source-dirs:  lib
   build-depends:
-    , aeson                              ^>=2.1.2.1
-    , aeson-qq                           ^>=0.8.4
+    , aeson                              >=2.1.2.1
+    , aeson-qq                           >=0.8.4
     , base
-    , base58-bytestring                  ^>=0.1
-    , bech32                             ^>=1.1.2
+    , base58-bytestring                  >=0.1
+    , bech32                             >=1.1.2
     , bech32-th
-    , binary                             ^>=0.8.8
-    , bytestring                         ^>=0.10.12
+    , binary                             >=0.8.8
+    , bytestring                         >=0.10.12
     , cardano-addresses
     , cardano-api
-    , cardano-binary                     ^>=1.7.0.1
+    , cardano-binary                     >=1.7.0.1
     , cardano-cli
-    , cardano-crypto                     ^>=1.1.2
+    , cardano-crypto                     >=1.1.2
     , cardano-data
     , cardano-ledger-api
     , cardano-ledger-core
@@ -75,40 +75,40 @@ library
     , cardano-wallet-launcher
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
-    , cborg                              ^>=0.2.9
-    , containers                         ^>=0.6.5
+    , cborg                              >=0.2.9
+    , containers                         >=0.6.5
     , contra-tracer
-    , crypto-hash-extra                  ^>=0.1
-    , cryptonite                         ^>=0.30
+    , crypto-hash-extra                  >=0.1
+    , cryptonite                         >=0.30
     , directory
-    , extra                              ^>=1.7
+    , extra                              >=1.7
     , filepath
-    , generic-lens                       ^>=2.2.2
-    , int-cast                           ^>=0.2
+    , generic-lens                       >=2.2.2
+    , int-cast                           >=0.2
     , iohk-monitoring
     , iohk-monitoring-extra
-    , lens                               ^>=5.1.1
+    , lens                               >=5.1.1
     , lobemo-backend-ekg
-    , memory                             ^>=0.18
-    , network-uri                        ^>=2.6.4.2
-    , OddWord                            ^>=1.0.1
+    , memory                             >=0.18
+    , network-uri                        >=2.6.4.2
+    , OddWord                            >=1.0.1
     , optparse-applicative
-    , ouroboros-network                  ^>=0.8.1
-    , ouroboros-network-api              ^>=0.5
-    , path                               ^>=0.9.2
-    , path-io                            ^>=1.7.0
-    , resourcet                          ^>=1.3
-    , retry                              ^>=0.9.3.1
-    , tagged                             ^>=0.8.7
-    , temporary                          ^>=1.3
+    , ouroboros-network                  >=0.8.1
+    , ouroboros-network-api              >=0.5
+    , path                               >=0.9.2
+    , path-io                            >=1.7.0
+    , resourcet                          >=1.3
+    , retry                              >=0.9.3.1
+    , tagged                             >=0.8.7
+    , temporary                          >=1.3
     , temporary-extra
     , text
     , text-class
-    , time                               ^>=1.9.3
-    , typed-process                      ^>=0.2.11
-    , unliftio                           ^>=0.2
-    , with-utf8                          ^>=1.0.2.4
-    , yaml                               ^>=0.11.11
+    , time                               >=1.9.3
+    , typed-process                      >=0.2.11
+    , unliftio                           >=0.2
+    , with-utf8                          >=1.0.2.4
+    , yaml                               >=0.11.11
 
 executable local-cluster
   import:         language, opts-exe

--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -33,7 +33,7 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:
-    , base                           ^>=4.14.3.0
+    , base                           >=4.14.3.0
     , bytestring
     , cardano-api
     , cardano-balance-tx:internal

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Mint.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Mint.hs
@@ -71,9 +71,9 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Read.Eras
-    ( (:*:) (..)
-    , EraFun (..)
+    ( EraFun (..)
     , K (..)
+    , (:*:) (..)
     )
 import Cardano.Wallet.Read.Tx.Mint
     ( Mint (..)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -304,8 +304,8 @@ import Data.Quantity
     , mkPercentage
     )
 import Data.Type.Equality
-    ( (:~:) (..)
-    , testEquality
+    ( testEquality
+    , (:~:) (..)
     )
 import Data.Word
     ( Word16

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/SealedTx.hs
@@ -83,8 +83,8 @@ import Data.Text
     ( Text
     )
 import Data.Type.Equality
-    ( (:~:) (..)
-    , testEquality
+    ( testEquality
+    , (:~:) (..)
     )
 import Fmt
     ( Buildable (..)

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Txs.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Txs.hs
@@ -18,8 +18,8 @@ import Cardano.Wallet.Read.Block
     ( Block (..)
     )
 import Cardano.Wallet.Read.Eras
-    ( (:.:) (..)
-    , EraFun (..)
+    ( EraFun (..)
+    , (:.:) (..)
     )
 import Cardano.Wallet.Read.Tx
     ( Tx (..)

--- a/lib/read/lib/Cardano/Wallet/Read/Eras.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Eras.hs
@@ -74,9 +74,9 @@ import Cardano.Wallet.Read.Eras.KnownEras
     , knownEraIndices
     )
 import Generics.SOP
-    ( (:.:) (..)
-    , K (..)
+    ( K (..)
     , unK
+    , (:.:) (..)
     )
 import GHC.Generics
     ( (:*:) (..)

--- a/lib/read/lib/Cardano/Wallet/Read/Eras/EraFun.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Eras/EraFun.hs
@@ -90,11 +90,11 @@ import Control.Category
     ( Category (..)
     )
 import Generics.SOP
-    ( (:.:) (..)
-    , K (..)
+    ( K (..)
     , NP
     , unComp
     , unK
+    , (:.:) (..)
     )
 import Generics.SOP.Classes
 import Generics.SOP.NP

--- a/lib/read/lib/Cardano/Wallet/Read/Eras/EraValue.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Eras/EraValue.hs
@@ -76,8 +76,7 @@ import Data.Generics.Internal.VL
     , prism
     )
 import Generics.SOP
-    ( (:.:)
-    , All
+    ( All
     , Compose
     , K (..)
     , NP (..)
@@ -87,6 +86,7 @@ import Generics.SOP
     , injections
     , unComp
     , unK
+    , (:.:)
     )
 import Generics.SOP.Classes
 import Generics.SOP.NP

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/CBOR.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/CBOR.hs
@@ -41,13 +41,13 @@ import Cardano.Ledger.Binary.Decoding
     , shelleyProtVer
     )
 import Cardano.Wallet.Read.Eras
-    ( (:.:) (..)
-    , EraFun (..)
+    ( EraFun (..)
     , EraValue
     , K (..)
     , applyEraFun
     , extractEraValue
     , sequenceEraValue
+    , (:.:) (..)
     )
 import Cardano.Wallet.Read.Tx
     ( Tx (..)

--- a/lib/temporary-extra/temporary-extra.cabal
+++ b/lib/temporary-extra/temporary-extra.cabal
@@ -27,7 +27,7 @@ library
   hs-source-dirs:     src
   exposed-modules:    System.IO.Temp.Extra
   build-depends:
-    , base                   ^>=4.14.3.0
+    , base                    >=4.14.3.0
     , iohk-monitoring        ^>=0.1.11.3
     , iohk-monitoring-extra  ^>=0.1
     , temporary              ^>=1.3

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -116,10 +116,10 @@ import Fmt
     )
 import Generics.SOP
 import GHC.TypeNats
-    ( type (<=)
-    , KnownNat
+    ( KnownNat
     , Nat
     , natVal
+    , type (<=)
     )
 import Numeric.Natural
     ( Natural

--- a/lib/wai-middleware-logging/test/Network/Wai/Middleware/LoggingSpec.hs
+++ b/lib/wai-middleware-logging/test/Network/Wai/Middleware/LoggingSpec.hs
@@ -98,9 +98,7 @@ import Network.Wai.Middleware.Logging
     , withApiLogger
     )
 import Servant
-    ( (:<|>) (..)
-    , (:>)
-    , Application
+    ( Application
     , DeleteNoContent
     , Get
     , JSON
@@ -114,6 +112,8 @@ import Servant
     , err503
     , serve
     , throwError
+    , (:<|>) (..)
+    , (:>)
     )
 import Servant.Server
     ( Handler

--- a/lib/wallet-e2e/cardano-wallet-e2e.cabal
+++ b/lib/wallet-e2e/cardano-wallet-e2e.cabal
@@ -55,37 +55,37 @@ common options
 
 common dependencies
   build-depends:
-    , base     ^>=4.14.3.0
-    , path     ^>=0.9.2
-    , path-io  ^>=1.7.0
-    , relude   ^>=1.2.0.0
-    , sydtest  ^>=0.15
-    , tagged   ^>=0.8.7
-    , text     ^>=1.2.4.1
+    , base     >=4.14.3.0
+    , path     >=0.9.2
+    , path-io  >=1.7.0
+    , relude   >=1.2.0.0
+    , sydtest  >=0.15
+    , tagged   >=0.8.7
+    , text     >=1.2.4.1
 
 library
   import:          options, dependencies
   hs-source-dirs:  src
   build-depends:
-    , aeson                  ^>=2.1.2.1
-    , base58-bytestring      ^>=0.1
-    , cardano-addresses      ^>=3.12
-    , cardano-crypto         ^>=1.1.2
-    , cardano-wallet-client  ^>=0.1
-    , effectful              ^>=2.2.2.0
-    , effectful-th           ^>=1.0.0.1
-    , http-client            ^>=0.7.13.1
-    , http-types             ^>=0.12.3
-    , local-cluster          ^>=0.1
-    , memory                 ^>=0.18
-    , random                 ^>=1.2.1.1
-    , resourcet              ^>=1.3
-    , retry                  ^>=0.9.3.1
-    , scientific             ^>=0.3.7
-    , tagged                 ^>=0.8.7
-    , time                   ^>=1.9.3
-    , timespan               ^>=0.4
-    , typed-process          ^>=0.2.11
+    , aeson                  >=2.1.2.1
+    , base58-bytestring      >=0.1
+    , cardano-addresses      >=3.12
+    , cardano-crypto         >=1.1.2
+    , cardano-wallet-client  >=0.1
+    , effectful              >=2.2.2.0
+    , effectful-th           >=1.0.0.1
+    , http-client            >=0.7.13.1
+    , http-types             >=0.12.3
+    , local-cluster          >=0.1
+    , memory                 >=0.18
+    , random                 >=1.2.1.1
+    , resourcet              >=1.3
+    , retry                  >=0.9.3.1
+    , scientific             >=0.3.7
+    , tagged                 >=0.8.7
+    , time                   >=1.9.3
+    , timespan               >=0.4
+    , typed-process          >=0.2.11
 
   exposed-modules:
     Cardano.Wallet.Spec
@@ -123,7 +123,7 @@ executable wallet-e2e
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   build-depends:
     , cardano-wallet-e2e
-    , optparse-applicative         ^>=0.17.1
-    , prettyprinter                ^>=1.7.1
-    , prettyprinter-ansi-terminal  ^>=1.1.3
-    , with-utf8                    ^>=1.0.2.4
+    , optparse-applicative         >=0.17.1
+    , prettyprinter                >=1.7.1
+    , prettyprinter-ansi-terminal  >=1.1.3
+    , with-utf8                    >=1.0.2.4

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Assert.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Assert.hs
@@ -16,9 +16,9 @@ import Cardano.Wallet.Spec.Effect.Trace
     , trace
     )
 import Effectful
-    ( (:>)
-    , Eff
+    ( Eff
     , Effect
+    , (:>)
     )
 import Effectful.Dispatch.Dynamic
     ( interpret

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Http.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Http.hs
@@ -14,10 +14,10 @@ import Control.Exception
     ( try
     )
 import Effectful
-    ( (:>)
-    , Eff
+    ( Eff
     , Effect
     , IOE
+    , (:>)
     )
 import Effectful.Dispatch.Dynamic
     ( interpret

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Query.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Query.hs
@@ -57,9 +57,9 @@ import Cardano.Wallet.Spec.Network.Configured
     ( ConfiguredNetwork (..)
     )
 import Effectful
-    ( (:>)
-    , Eff
+    ( Eff
     , Effect
+    , (:>)
     )
 import Effectful.Dispatch.Dynamic
     ( interpret

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Random.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Random.hs
@@ -28,9 +28,9 @@ import Data.Tagged
     ( Tagged (..)
     )
 import Effectful
-    ( (:>)
-    , Eff
+    ( Eff
     , Effect
+    , (:>)
     )
 import Effectful.Dispatch.Dynamic
     ( interpret

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Timeout.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Timeout.hs
@@ -21,10 +21,10 @@ import Data.Time.TimeSpan
     , timeoutTS
     )
 import Effectful
-    ( (:>)
-    , Eff
+    ( Eff
     , Effect
     , IOE
+    , (:>)
     )
 import Effectful.Dispatch.Dynamic
     ( interpret

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec/Stories/Language.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec/Stories/Language.hs
@@ -1,8 +1,8 @@
 module Cardano.Wallet.Spec.Stories.Language (FxStory) where
 
 import Effectful
-    ( (:>)
-    , Eff
+    ( Eff
+    , (:>)
     )
 
 type FxStory otherEffects knownEffects a =

--- a/lib/wallet/api/http/Cardano/Wallet/Api.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api.hs
@@ -330,14 +330,14 @@ import GHC.Generics
     ( Generic
     )
 import Servant.API
-    ( (:<|>)
-    , (:>)
-    , Capture
+    ( Capture
     , JSON
     , OctetStream
     , QueryFlag
     , QueryParam
     , ReqBody
+    , (:<|>)
+    , (:>)
     )
 import Servant.API.Verbs
     ( DeleteAccepted

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Client.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Client.hs
@@ -137,9 +137,9 @@ import Data.Text
     ( Text
     )
 import Servant
-    ( (:<|>) (..)
+    ( NoContent
+    , (:<|>) (..)
     , (:>)
-    , NoContent
     )
 import Servant.Client
     ( ClientM

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
@@ -265,11 +265,11 @@ import Network.Ntp
     ( NtpClient
     )
 import Servant
-    ( (:<|>) (..)
-    , Handler (..)
+    ( Handler (..)
     , NoContent (..)
     , Server
     , err400
+    , (:<|>) (..)
     )
 import Servant.Server
     ( ServerError (..)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/TxCBOR.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/TxCBOR.hs
@@ -37,14 +37,14 @@ import Cardano.Wallet.Read
     ( Tx (..)
     )
 import Cardano.Wallet.Read.Eras
-    ( (:.:)
-    , EraFun (..)
+    ( EraFun (..)
     , K (..)
     , applyEraFun
     , extractEraValue
     , sequenceEraValue
     , (*&&&*)
     , (*.**)
+    , (:.:)
     )
 import Cardano.Wallet.Read.Eras.EraFun
     ( EraFunK (..)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Link.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Link.hs
@@ -200,8 +200,7 @@ import Numeric.Natural
     ( Natural
     )
 import Servant.API
-    ( (:>)
-    , Capture'
+    ( Capture'
     , Header'
     , IsElem
     , NoContentVerb
@@ -210,6 +209,7 @@ import Servant.API
     , ReflectMethod (..)
     , ReqBody
     , Verb
+    , (:>)
     )
 import Servant.Links
     ( HasLink (..)

--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -175,8 +175,8 @@ import Say
     ( sayErr
     )
 
-import qualified Cardano.Api as Cardano
 import qualified Cardano.Api as C
+import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.DB as DB
 import qualified Cardano.Wallet.DB.Layer as DB

--- a/lib/wallet/mock-token-metadata/src/Cardano/Wallet/TokenMetadata/MockServer.hs
+++ b/lib/wallet/mock-token-metadata/src/Cardano/Wallet/TokenMetadata/MockServer.hs
@@ -106,10 +106,10 @@ import Network.Wai.Handler.Warp
     , withApplication
     )
 import Servant.API
-    ( (:>)
-    , JSON
+    ( JSON
     , Post
     , ReqBody
+    , (:>)
     )
 import Servant.Server
     ( Handler (..)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -567,11 +567,11 @@ import Cardano.Wallet.Read.Tx.CBOR
     ( TxCBOR
     )
 import Cardano.Wallet.Shelley.Transaction
-    ( mkTransaction
+    ( _txRewardWithdrawalCost
+    , mkTransaction
     , mkUnsignedTransaction
     , txConstraints
     , txWitnessTagForKey
-    , _txRewardWithdrawalCost
     )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)

--- a/lib/wallet/src/Cardano/Wallet/Compat.hs
+++ b/lib/wallet/src/Cardano/Wallet/Compat.hs
@@ -17,7 +17,7 @@ import Data.Monoid
     ( First (..)
     )
 import Data.Profunctor.Unsafe
-    ( ( #. )
+    ( (#.)
     )
 
 infixl 8 ^?

--- a/lib/wallet/src/Cardano/Wallet/DB/Migration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Migration.hs
@@ -59,10 +59,10 @@ import GHC.Natural
     ( Natural
     )
 import GHC.TypeNats
-    ( type (+)
-    , KnownNat
+    ( KnownNat
     , Nat
     , natVal
+    , type (+)
     )
 
 --------------------------------------------------------------------------------

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
@@ -68,10 +68,10 @@ import Cardano.Wallet.Submissions.Submissions
     )
 import Cardano.Wallet.Submissions.TxStatus
     ( TxStatus (..)
+    , _InSubmission
     , expirySlot
     , getTx
     , status
-    , _InSubmission
     )
 import Cardano.Wallet.Transaction.Built
     ( BuiltTx (..)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/StateDeltaSeq.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/StateDeltaSeq.hs
@@ -134,7 +134,7 @@ import Data.List.NonEmpty
     ( NonEmpty (..)
     )
 import Data.Sequence
-    ( Seq ((:<|), (:|>), Empty)
+    ( Seq (Empty, (:<|), (:|>))
     )
 
 import qualified Data.Foldable as F

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -132,9 +132,7 @@ import Cardano.Wallet.Primitive.Types.ValidityIntervalExplicit
     )
 import Cardano.Wallet.Primitive.Types.WitnessCount
     ( WitnessCount (..)
-    , WitnessCount (..)
     , WitnessCountCtx (..)
-    , emptyWitnessCount
     , emptyWitnessCount
     , toKeyRole
     )

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -566,9 +566,7 @@ import Numeric.Natural
     ( Natural
     )
 import Servant
-    ( (:<|>)
-    , (:>)
-    , Capture
+    ( Capture
     , Header'
     , JSON
     , PostNoContent
@@ -577,6 +575,8 @@ import Servant
     , ReqBody
     , StdMethod (..)
     , Verb
+    , (:<|>)
+    , (:>)
     )
 import Servant.API.Verbs
     ( NoContentVerb

--- a/lib/wallet/test/unit/Cardano/Wallet/ApiSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/ApiSpec.hs
@@ -93,8 +93,8 @@ import Data.Tuple
     ( swap
     )
 import Data.Type.Equality
-    ( (:~:) (..)
-    , testEquality
+    ( testEquality
+    , (:~:) (..)
     )
 import Data.Typeable
     ( Typeable
@@ -151,10 +151,10 @@ import Servant
     , serve
     )
 import Servant.API
-    ( (:<|>) (..)
-    , (:>)
-    , Capture
+    ( Capture
     , OctetStream
+    , (:<|>) (..)
+    , (:>)
     )
 import Servant.API.Verbs
     ( NoContentVerb

--- a/lib/wallet/test/unit/Cardano/Wallet/Submissions/Gen.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Submissions/Gen.hs
@@ -29,20 +29,20 @@ import Cardano.Wallet.Submissions.Submissions
     )
 import Cardano.Wallet.Submissions.TxStatus
     ( HasTxId (..)
-    , getTx
     , _Expired
     , _InLedger
     , _InSubmission
+    , getTx
     )
 import Control.Arrow
     ( (&&&)
     )
 import Control.Lens
-    ( lastOf
+    ( _2
+    , lastOf
     , to
     , view
     , (&)
-    , _2
     )
 import Control.Lens.Extras
     ( is

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -257,7 +257,6 @@ import Internal.Cardano.Write.Tx
     , TxIn
     , TxOut
     , TxOutInRecentEra (..)
-    , TxOutInRecentEra (..)
     , UTxO
     , fromCardanoApiTx
     , fromCardanoApiUTxO
@@ -426,10 +425,10 @@ import qualified Cardano.Wallet.Primitive.Types as W.Block
 import qualified Cardano.Wallet.Primitive.Types.Address as W
     ( Address (..)
     )
-import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..)
     )
+import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
 import qualified Cardano.Wallet.Primitive.Types.Coin.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.Credentials as W
     ( RootCredentials (..)
@@ -438,20 +437,20 @@ import qualified Cardano.Wallet.Primitive.Types.Hash as W
     ( Hash (..)
     , mockHash
     )
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle
     )
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
     ( TxSize (..)
     )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen as W
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (..)
     )
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
 import qualified Codec.CBOR.Encoding as CBOR

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -146,7 +146,7 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: haskell-nix.cabalProject' [
           nixWrapped
           mdbook
           (haskell-nix.tool "ghc928" "hp2pretty" "latest")
-          (haskell-nix.tool "ghc928" "stylish-haskell" "0.11.0.3")
+          (haskell-nix.tool "ghc928" "stylish-haskell" "0.14.5.0")
           (haskell-nix.tool "ghc928" "hlint" "3.6.1")
           (haskell-nix.tool "ghc928" "fourmolu" "0.13.1.0")
           (haskell-nix.tool "ghc928" "haskell-language-server" ({pkgs, ...}: rec {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -147,7 +147,7 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: haskell-nix.cabalProject' [
           mdbook
           (haskell-nix.tool "ghc928" "hp2pretty" "latest")
           (haskell-nix.tool "ghc928" "stylish-haskell" "0.11.0.3")
-          (haskell-nix.tool "ghc928" "hlint" "3.3")
+          (haskell-nix.tool "ghc928" "hlint" "3.6.1")
           (haskell-nix.tool "ghc928" "fourmolu" "0.13.1.0")
           (haskell-nix.tool "ghc928" "haskell-language-server" ({pkgs, ...}: rec {
             # Use the github source of HLS that is tested with haskell.nix CI

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -122,7 +122,7 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: haskell-nix.cabalProject' [
           lentil = { index-state = indexState; };
           weeder = {
             index-state = indexState;
-            version = "2.2.0";
+            version = "2.4.0";
            };
         };
         nativeBuildInputs = with buildProject.hsPkgs; [

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -100,7 +100,7 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: haskell-nix.cabalProject' [
       localClusterConfigs = config.src + /lib/local-cluster/test/data/cluster-configs;
     in {
       name = "cardano-wallet";
-      compiler-nix-name = "ghc8107";
+      compiler-nix-name = "ghc928";
 
       src = haskellLib.cleanSourceWith {
         name = "cardano-wallet-src";
@@ -145,11 +145,11 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: haskell-nix.cabalProject' [
           yq
           nixWrapped
           mdbook
-          (haskell-nix.tool "ghc8107" "hp2pretty" "latest")
-          (haskell-nix.tool "ghc8107" "stylish-haskell" "0.11.0.3")
-          (haskell-nix.tool "ghc8107" "hlint" "3.3")
+          (haskell-nix.tool "ghc928" "hp2pretty" "latest")
+          (haskell-nix.tool "ghc928" "stylish-haskell" "0.11.0.3")
+          (haskell-nix.tool "ghc928" "hlint" "3.3")
           (haskell-nix.tool "ghc928" "fourmolu" "0.13.1.0")
-          (haskell-nix.tool "ghc8107" "haskell-language-server" ({pkgs, ...}: rec {
+          (haskell-nix.tool "ghc928" "haskell-language-server" ({pkgs, ...}: rec {
             # Use the github source of HLS that is tested with haskell.nix CI
             src = pkgs.haskell-nix.sources."hls-2.0";
             # `tool` normally ignores the `cabal.project` (if there is one in the hackage source).

--- a/prototypes/light-mode-test/light-mode-test.cabal
+++ b/prototypes/light-mode-test/light-mode-test.cabal
@@ -38,7 +38,7 @@ library
     default-extensions:
         OverloadedStrings
     build-depends:
-        base ^>=4.14.3.0
+        base >=4.14.3.0
       , blockfrost-api
       , blockfrost-client
       , blockfrost-client-core


### PR DESCRIPTION
### Summary

This PR adjusts our `nix` configuration to build with GHC version `9.2.8` by default.

### Related Issues

- https://github.com/cardano-foundation/cardano-wallet/pull/4172
- https://github.com/cardano-foundation/cardano-wallet/pull/4173
- https://github.com/cardano-foundation/cardano-wallet/pull/4181