### PR TITLE
🔮 Apply `hlint` suggestions from the future.

### DIFF
--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/CollateralSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/CollateralSpec.hs
@@ -881,7 +881,7 @@ prop_subsequencesOfSize =
                         == Set.size subsets
                     , Set.unions (F.toList subsets)
                         == xs
-                    , all (== k) (length <$> subsequences)
+                    , all ((== k) . length) subsequences
                     ]
       where
         n = Set.size xs

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOIndexSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOIndexSpec.hs
@@ -533,17 +533,28 @@ prop_selectRandom_all index f = monadicIO $
             , F.foldl' (flip (uncurry UTxOIndex.insert)) indexReduced selected
                 === index
             , property
-                $ all (`UTxOIndex.member` index)
-                $ fst <$> selected
+                $ all
+                    ((`UTxOIndex.member` index) . fst)
+                    selected
             , property
-                $ all (not . (`UTxOIndex.member` indexReduced))
-                $ fst <$> selected
+                $ all
+                    (not . (`UTxOIndex.member` indexReduced) . fst)
+                    selected
             , property
-                $ all (selectionFilterMatchesBundleCategory f)
-                $ categorizeTokenBundle . snd <$> selected
+                $ all
+                    ( selectionFilterMatchesBundleCategory f
+                    . categorizeTokenBundle
+                    . snd
+                    )
+                    selected
             , property
-                $ all (not . selectionFilterMatchesBundleCategory f)
-                $ categorizeTokenBundle . snd <$> UTxOIndex.toList indexReduced
+                $ all
+                    ( not
+                    . selectionFilterMatchesBundleCategory f
+                    . categorizeTokenBundle
+                    . snd
+                    )
+                    (UTxOIndex.toList indexReduced)
             ]
 
 -- | Verify that priority order is respected when selecting with more than

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
@@ -12,7 +12,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -501,7 +501,7 @@ toFlatList b =
 toNestedList
     :: TokenMap -> [(TokenPolicyId, NonEmpty (TokenName, TokenQuantity))]
 toNestedList (TokenMap m) =
-    mapMaybe (traverse NE.nonEmpty . fmap MonoidMap.toList) $ MonoidMap.toList m
+    mapMaybe (traverse (NE.nonEmpty . MonoidMap.toList)) $ MonoidMap.toList m
 
 -- | Converts a token map to a nested map.
 --

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -420,7 +420,7 @@ prop_adjustQuantity_hasQuantity b asset =
 prop_maximumQuantity_all
     :: TokenMap -> Property
 prop_maximumQuantity_all b =
-    property $ all (<= maxQ) (snd <$> TokenMap.toFlatList b)
+    property $ all ((<= maxQ) . snd) (TokenMap.toFlatList b)
   where
     maxQ = TokenMap.maximumQuantity b
 

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Random.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Random.hs
@@ -66,11 +66,14 @@ runRandom gen = reinterpret (evalState gen) \_ -> \case
     RandomMnemonic -> do
         randomByteString <- uniformByteStringM 32 stGen
         mnemonic <-
-            Mnemonic.unsafeFromList
-                . Cardano.mnemonicToText
-                . Cardano.entropyToMnemonic
-                <$> toEntropy @256 randomByteString
-                    & either (fail . show) pure
+            either
+                (fail . show)
+                (pure
+                    . Mnemonic.unsafeFromList
+                    . Cardano.mnemonicToText
+                    . Cardano.entropyToMnemonic
+                    )
+                (toEntropy @256 randomByteString)
         trace $ "Generated a random mnemonic: " <> Mnemonic.toText mnemonic
         pure mnemonic
     RandomWalletName (Tagged prefix) -> do

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/TxCBOR.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/TxCBOR.hs
@@ -59,8 +59,6 @@ import Cardano.Wallet.Transaction
     ( TokenMapWithScripts, ValidityIntervalExplicit )
 import Control.Category
     ( (<<<) )
-import Data.Function
-    ( (&) )
 import GHC.Generics
     ( Generic )
 import Servant.Server
@@ -111,5 +109,7 @@ txCBORParser = parser *.** deserializeTx
 -- | Parse CBOR to some values and throw a server deserialize error if failing.
 parseTxCBOR :: TxCBOR -> Handler ParsedTxCBOR
 parseTxCBOR cbor =
-    extractEraValue <$> sequenceEraValue (applyEraFun txCBORParser cbor)
-        & either (liftE . ErrParseCBOR) pure
+    either
+        (liftE . ErrParseCBOR)
+        (pure . extractEraValue)
+        (sequenceEraValue (applyEraFun txCBORParser cbor))

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -795,14 +795,13 @@ spec = describe "BYRON_TRANSACTIONS" $ do
                 rl3 <- request @([ApiTransaction n]) ctx linkList3 Default Empty
                 verify rl3 [expectListSize 2]
   where
-    listTransactionsFilteredByAddress wallet addrM =
+    listTransactionsFilteredByAddress wallet =
         Link.listTransactions' @'Byron wallet
         Nothing
         Nothing
         Nothing
         Nothing
         Nothing
-        addrM
 
     oneAda :: Integer
     oneAda = 1_000_000

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
@@ -2707,14 +2707,13 @@ spec = describe "SHARED_TRANSACTIONS" $ do
         rl1c <- request @([ApiTransaction n]) ctx linkList1a Default Empty
         verify rl1c [expectListSize 2]
   where
-     listTransactionsFilteredByAddress wallet addrM =
+     listTransactionsFilteredByAddress wallet =
          Link.listTransactions' @'Shared wallet
          Nothing
          Nothing
          Nothing
          Nothing
          Nothing
-         addrM
 
      oneAda :: Integer
      oneAda = 1_000_000

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -4486,14 +4486,13 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         rl1c <- request @([ApiTransaction n]) ctx query1 Default Empty
         verify rl1c [expectListSize 2]
   where
-    listTransactionsFilteredByAddress wallet addrM =
+    listTransactionsFilteredByAddress wallet =
         Link.listTransactions' @'Shelley wallet
         Nothing
         Nothing
         Nothing
         Nothing
         Nothing
-        addrM
 
     -- | Just one million Ada, in Lovelace.
     oneMillionAda :: Integer

--- a/lib/wallet/src/Cardano/DB/Sqlite.hs
+++ b/lib/wallet/src/Cardano/DB/Sqlite.hs
@@ -546,7 +546,7 @@ noManualMigration :: ManualMigration
 noManualMigration = ManualMigration $ const $ pure ()
 
 foldMigrations :: [Sqlite.Connection -> IO ()] -> ManualMigration
-foldMigrations ms = ManualMigration $ \conn -> sequence_ $ ms <&> ($ conn)
+foldMigrations ms = ManualMigration $ \conn -> mapM_ ($ conn) ms
 
 data DBField where
     DBField

--- a/lib/wallet/src/Data/Time/Text.hs
+++ b/lib/wallet/src/Data/Time/Text.hs
@@ -51,9 +51,14 @@ utcTimeToText f = T.pack . formatTime defaultTimeLocale (timeFormatPattern f)
 --   'Nothing' if none of the formats matched.
 --
 utcTimeFromText :: [TimeFormat] -> Text -> Maybe UTCTime
-utcTimeFromText fs t = foldr (<|>) Nothing $
-    flip (parseTimeM False defaultTimeLocale) (T.unpack t) . timeFormatPattern
-        <$> fs
+utcTimeFromText fs t =
+    foldr
+        ( (<|>)
+        . flip (parseTimeM False defaultTimeLocale) (T.unpack t)
+        . timeFormatPattern
+        )
+        Nothing
+        fs
 
 -- | Represents a particular way of representing a moment in time in text.
 data TimeFormat = TimeFormat

--- a/lib/wallet/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/wallet/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -249,7 +249,7 @@ isValidSinglePoolCertificateSequence
         firstCertificateIsNotRetirement
   where
     allCertificatesReferToSamePool =
-        all (== sharedPoolId) (getPoolCertificatePoolId <$> certificates)
+        all ((== sharedPoolId) . getPoolCertificatePoolId) certificates
     firstCertificateIsNotRetirement = case certificates of
         []                 -> True
         Registration _ : _ -> True

--- a/lib/wallet/test/unit/Cardano/Wallet/ApiSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/ApiSpec.hs
@@ -277,7 +277,7 @@ instance
             :: Applicative m
             => (l0 -> m l1) -> [(l0, r)] -> m [(l1, r)]
         traverseLeft fn xs =
-            fmap swap <$> traverse (traverse fn) (swap <$> xs)
+            fmap swap <$> traverse (traverse fn . swap) xs
 
 instance
     ( KnownSymbol h

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -1036,7 +1036,7 @@ validateGenerators = describe "Validate generators & shrinkers" $ do
 
     sanityCheckShrink = \case
         []  -> pure ()
-        [x] -> sanityCheckShrink (concatMap shrinker [x])
+        [x] -> sanityCheckShrink (shrinker x)
         xs  -> sanityCheckShrink (concatMap shrinker [head xs, last xs])
 
 dbLayerUnused :: DBLayer m s

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
@@ -274,8 +274,8 @@ prop_dropGroupBoundary_isValid (getTxSeq -> txSeq) =
 prop_dropGroupBoundary_toTxs :: ShrinkableTxSeq -> Property
 prop_dropGroupBoundary_toTxs (getTxSeq -> txSeq) =
     all
-        (== TxSeq.toTxList txSeq)
-        (TxSeq.toTxList <$> TxSeq.dropGroupBoundary txSeq)
+        ((== TxSeq.toTxList txSeq) . TxSeq.toTxList)
+        (TxSeq.dropGroupBoundary txSeq)
     === True
 
 prop_dropGroupBoundary_txGroupCount_length
@@ -291,8 +291,8 @@ prop_dropGroupBoundary_txGroupCount_pred (getTxSeq -> txSeq)
     | txGroupCount == 0 =
         TxSeq.dropGroupBoundary txSeq === []
     | otherwise =
-        all (== pred txGroupCount)
-            (TxSeq.txGroupCount <$> TxSeq.dropGroupBoundary txSeq)
+        all ((== pred txGroupCount) . TxSeq.txGroupCount)
+            (TxSeq.dropGroupBoundary txSeq)
         === True
   where
     txGroupCount = TxSeq.txGroupCount txSeq
@@ -396,7 +396,7 @@ prop_shrinkTxSeq_genShrinkSequence_isValid :: Property
 prop_shrinkTxSeq_genShrinkSequence_isValid =
     forAll (genShrinkSequence shrinkTxSeq =<< genTxSeq genUTxO genAddress) $
         \txSeqShrinks ->
-            all TxSeq.isValid (getTxSeq <$> txSeqShrinks)
+            all (TxSeq.isValid . getTxSeq) txSeqShrinks
 
 prop_shrinkTxSeq_genShrinkSequence_length :: Property
 prop_shrinkTxSeq_genShrinkSequence_length =

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -577,7 +577,7 @@ withBodyContent era modTxBody cont =
 checkSubsetOf :: (Eq a, Show a) => [a] -> [a] -> Property
 checkSubsetOf as bs = property
     $ counterexample counterexampleText
-    $ all (`Set.member` ys) (ShowOrd <$> as)
+    $ all ((`Set.member` ys) . ShowOrd) as
   where
     xs = Set.fromList (ShowOrd <$> as)
     ys = Set.fromList (ShowOrd <$> bs)

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2184,6 +2184,7 @@ block0 = W.Block
     , delegations = []
     }
 
+{- HLINT ignore costModelsForTesting "Use underscore" -}
 costModelsForTesting :: Alonzo.CostModels
 costModelsForTesting = either (error . show) id $ do
     v1 <- Alonzo.mkCostModel PlutusV1


### PR DESCRIPTION
## Issue

Related to https://github.com/cardano-foundation/cardano-wallet/pull/4171.

## Description

This PR selectively applies suggestions from the latest version of [`hlint`](https://github.com/ndmitchell/hlint) ([`3.6.1`](https://github.com/ndmitchell/hlint/releases/tag/v3.6.1)).

## Motivation

This will make it easier to upgrade our build environment to use GHC version `9.2` or later, which will require us to upgrade to a newer version of `hlint`.

Our `nix` environment is currently only configured to use version [`3.3`](https://github.com/ndmitchell/hlint/releases/tag/v3.3) of `hlint`, which was released on`2021-03-15`. Note that we can't upgrade to a newer version of `hlint` without also upgrading GHC to at least version `9.2`.