### PR TITLE
Export and import `ErrBalanceTx` via public API of `cardano-balance-tx`.

### DIFF
--- a/lib/balance-tx/lib/main/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/main/Cardano/Write/Tx.hs
@@ -3,8 +3,36 @@
 -- License: Apache-2.0
 --
 module Cardano.Write.Tx
-    ( balanceTransaction
+    (
+    -- * Balancing transactions
+      balanceTransaction
+    , ErrAssignRedeemers (..)
+    , ErrBalanceTx (..)
+    , ErrBalanceTxAssetsInsufficientError (..)
+    , ErrBalanceTxInsufficientCollateralError (..)
+    , ErrBalanceTxInternalError (..)
+    , ErrBalanceTxOutputAdaQuantityInsufficientError (..)
+    , ErrBalanceTxOutputError (..)
+    , ErrBalanceTxOutputErrorInfo (..)
+    , ErrBalanceTxOutputSizeExceedsLimitError (..)
+    , ErrBalanceTxOutputTokenQuantityExceedsLimitError (..)
+    , ErrBalanceTxUnableToCreateChangeError (..)
+    , ErrUpdateSealedTx (..)
+
     ) where
 
 import Internal.Cardano.Write.Tx.Balance
-    ( balanceTransaction )
+    ( ErrAssignRedeemers (..)
+    , ErrBalanceTx (..)
+    , ErrBalanceTxAssetsInsufficientError (..)
+    , ErrBalanceTxInsufficientCollateralError (..)
+    , ErrBalanceTxInternalError (..)
+    , ErrBalanceTxOutputAdaQuantityInsufficientError (..)
+    , ErrBalanceTxOutputError (..)
+    , ErrBalanceTxOutputErrorInfo (..)
+    , ErrBalanceTxOutputSizeExceedsLimitError (..)
+    , ErrBalanceTxOutputTokenQuantityExceedsLimitError (..)
+    , ErrBalanceTxUnableToCreateChangeError (..)
+    , ErrUpdateSealedTx (..)
+    , balanceTransaction
+    )

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -104,6 +104,17 @@ import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( Convert (toWallet), toWalletAddress, toWalletCoin, toWalletTokenBundle )
 import Cardano.Wallet.Transaction
     ( ErrSignTx (..) )
+import Cardano.Write.Tx
+    ( ErrAssignRedeemers (..)
+    , ErrBalanceTx (..)
+    , ErrBalanceTxInsufficientCollateralError (..)
+    , ErrBalanceTxInternalError (..)
+    , ErrBalanceTxOutputError (..)
+    , ErrBalanceTxOutputErrorInfo (..)
+    , ErrBalanceTxOutputSizeExceedsLimitError (..)
+    , ErrBalanceTxOutputTokenQuantityExceedsLimitError (..)
+    , ErrUpdateSealedTx (..)
+    )
 import Control.Monad.Except
     ( ExceptT, lift, withExceptT )
 import Control.Monad.Trans.Except
@@ -124,17 +135,6 @@ import Data.Word
     ( Word32 )
 import Fmt
     ( blockListF', build, fmt, listF, pretty )
-import Internal.Cardano.Write.Tx.Balance
-    ( ErrAssignRedeemers (..)
-    , ErrBalanceTx (..)
-    , ErrBalanceTxInsufficientCollateralError (..)
-    , ErrBalanceTxInternalError (..)
-    , ErrBalanceTxOutputError (..)
-    , ErrBalanceTxOutputErrorInfo (..)
-    , ErrBalanceTxOutputSizeExceedsLimitError (..)
-    , ErrBalanceTxOutputTokenQuantityExceedsLimitError (..)
-    , ErrUpdateSealedTx (..)
-    )
 import Internal.Cardano.Write.Tx.Sign
     ( KeyWitnessCount (..) )
 import Network.HTTP.Media

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -386,7 +386,7 @@ library cardano-wallet-api-http
     , cardano-addresses
     , cardano-addresses-cli
     , cardano-api
-    , cardano-balance-tx:internal
+    , cardano-balance-tx:{cardano-balance-tx,internal}
     , cardano-binary
     , cardano-cli
     , cardano-crypto
@@ -708,7 +708,7 @@ test-suite unit
     , cardano-addresses
     , cardano-api
     , cardano-api-extra
-    , cardano-balance-tx:internal
+    , cardano-balance-tx:{cardano-balance-tx,internal}
     , cardano-binary
     , cardano-coin-selection
     , cardano-crypto

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -509,7 +509,11 @@ import Cardano.Wallet.Transaction
 import Cardano.Wallet.Transaction.Built
     ( BuiltTx (..) )
 import Cardano.Write.Tx
-    ( balanceTransaction )
+    ( ErrBalanceTx (..)
+    , ErrBalanceTxInternalError (..)
+    , ErrBalanceTxUnableToCreateChangeError (..)
+    , balanceTransaction
+    )
 import Control.Arrow
     ( (>>>) )
 import Control.DeepSeq
@@ -612,9 +616,6 @@ import Internal.Cardano.Write.Tx
     ( recentEra )
 import Internal.Cardano.Write.Tx.Balance
     ( ChangeAddressGen (..)
-    , ErrBalanceTx (..)
-    , ErrBalanceTxInternalError (..)
-    , ErrBalanceTxUnableToCreateChangeError (..)
     , PartialTx (..)
     , UTxOAssumptions (..)
     , constructUTxOIndex

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -132,6 +132,8 @@ import Cardano.Wallet.Transaction
     )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
+import Cardano.Write.Tx
+    ( ErrBalanceTx (..), ErrBalanceTxUnableToCreateChangeError (..) )
 import Control.Arrow
     ( first )
 import Control.Monad
@@ -178,8 +180,6 @@ import Internal.Cardano.Write.Tx
     , cardanoEraFromRecentEra
     , shelleyBasedEraFromRecentEra
     )
-import Internal.Cardano.Write.Tx.Balance
-    ( ErrBalanceTx (..), ErrBalanceTxUnableToCreateChangeError (..) )
 import Internal.Cardano.Write.Tx.SizeEstimation
     ( TxSkeleton (..), estimateTxSize )
 import Numeric.Natural

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -148,6 +148,8 @@ import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Cardano.Wallet.Util
     ( HasCallStack )
+import Cardano.Write.Tx
+    ( ErrBalanceTx (..), ErrBalanceTxAssetsInsufficientError (..) )
 import Control.DeepSeq
     ( NFData (..) )
 import Control.Monad
@@ -208,8 +210,6 @@ import Data.Word
     ( Word64 )
 import GHC.Generics
     ( Generic )
-import Internal.Cardano.Write.Tx.Balance
-    ( ErrBalanceTx (..), ErrBalanceTxAssetsInsufficientError (..) )
 import Internal.Cardano.Write.Tx.SizeEstimation
     ( TxWitnessTag (..) )
 import System.Random


### PR DESCRIPTION
## Issue

[ADP-3185](https://cardanofoundation.atlassian.net/browse/ADP-3185)

## Description

This PR exports and imports `ErrBalanceTx` (and its related error types) via the public interface of the `cardano-balance-tx` library.