### PR TITLE
Adjust `constructUTxOIndex` to accept `Write.UTxO`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -484,13 +484,16 @@ data UTxOIndex era = UTxOIndex
     , ledgerUTxO :: !(UTxO (ShelleyLedgerEra era))
     }
 
-constructUTxOIndex :: forall era. IsRecentEra era => W.UTxO -> UTxOIndex era
-constructUTxOIndex walletUTxO =
+constructUTxOIndex
+    :: forall era. IsRecentEra era
+    => UTxO (ShelleyLedgerEra era)
+    -> UTxOIndex era
+constructUTxOIndex ledgerUTxO =
     UTxOIndex {walletUTxO, walletUTxOIndex, ledgerUTxO}
   where
     era = recentEra @era
+    walletUTxO = toWalletUTxO era ledgerUTxO
     walletUTxOIndex = UTxOIndex.fromMap $ toInternalUTxOMap walletUTxO
-    ledgerUTxO = fromWalletUTxO era walletUTxO
 
 fromWalletUTxO
     :: RecentEra era

--- a/lib/balance-tx/lib/main/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/main/Cardano/Write/Tx.hs
@@ -19,8 +19,16 @@ module Cardano.Write.Tx
     , ErrBalanceTxUnableToCreateChangeError (..)
     , ErrUpdateSealedTx (..)
 
+    -- * UTxO-related types and functions
+    , UTxO
+    , UTxOAssumptions
+    , UTxOIndex
+    , constructUTxOIndex
     ) where
 
+import Internal.Cardano.Write.Tx
+    ( UTxO
+    )
 import Internal.Cardano.Write.Tx.Balance
     ( ErrAssignRedeemers (..)
     , ErrBalanceTx (..)
@@ -34,5 +42,8 @@ import Internal.Cardano.Write.Tx.Balance
     , ErrBalanceTxOutputTokenQuantityExceedsLimitError (..)
     , ErrBalanceTxUnableToCreateChangeError (..)
     , ErrUpdateSealedTx (..)
+    , UTxOAssumptions
+    , UTxOIndex
     , balanceTransaction
+    , constructUTxOIndex
     )

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3374,10 +3374,11 @@ balanceTransaction
     ctx@ApiLayer{..} argGenChange utxoAssumptions (ApiT wid) body = do
     (Write.InAnyRecentEra recentEra pp, timeTranslation)
         <- liftIO $ W.readNodeTipStateForTxWrite netLayer
-
     withWorkerCtx ctx wid liftE liftE $ \wrk -> do
         (utxo, wallet, _txs) <- handler $ W.readWalletUTxO wrk
-
+        let utxoIndex =
+                Write.constructUTxOIndex $
+                Write.fromWalletUTxO recentEra utxo
         partialTx <- parsePartialTx recentEra
         balancedTx <- liftHandler
             . fmap (Cardano.InAnyCardanoEra Write.cardanoEra . fst)
@@ -3385,7 +3386,7 @@ balanceTransaction
                 utxoAssumptions
                 pp
                 timeTranslation
-                (Write.constructUTxOIndex utxo)
+                utxoIndex
                 (W.defaultChangeAddressGen argGenChange)
                 (getState wallet)
                 partialTx

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2044,7 +2044,7 @@ addExtraTxIns extraIns =
 -- updated 'changeState'. Does /not/ specify mock values for things like
 -- protocol parameters. This is up to the caller to provide.
 balanceTx
-    :: IsRecentEra era
+    :: forall era. IsRecentEra era
     => Wallet'
     -> Write.ProtocolParameters era
     -> TimeTranslation
@@ -2063,11 +2063,13 @@ balanceTx
                 utxoAssumptions
                 protocolParameters
                 timeTranslation
-                (constructUTxOIndex utxo)
+                utxoIndex
                 genChange
                 s
                 partialTx
         pure transactionInEra
+  where
+    utxoIndex = constructUTxOIndex @era $ fromWalletUTxO (recentEra @era) utxo
 
 -- | Also returns the updated change state
 balanceTransactionWithDummyChangeState
@@ -2083,11 +2085,13 @@ balanceTransactionWithDummyChangeState utxoAssumptions utxo seed partialTx =
             utxoAssumptions
             mockPParamsForBalancing
             dummyTimeTranslation
-            (constructUTxOIndex utxo)
+            utxoIndex
             dummyChangeAddrGen
             (getState $ unsafeInitWallet utxo (W.Block.header block0)
                 DummyChangeState { nextUnusedIndex = 0 })
             partialTx
+  where
+    utxoIndex = constructUTxOIndex @era $ fromWalletUTxO (recentEra @era) utxo
 
 cardanoTx :: SealedTx -> CardanoApi.InAnyCardanoEra CardanoApi.Tx
 cardanoTx = cardanoTxIdeallyNoLaterThan maxBound


### PR DESCRIPTION
## Issue

ADP-3184

## Summary

This PR:
- adjusts `constructUTxOIndex` to take a value of type `Write.UTxO era` instead of `Primitive.Types.UTxO`.
- exports UTxO-related types and functions from the public `Cardano.Write.Tx` module.