### PR TITLE
GHC 9.2 compatibility fixes.

### DIFF
--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Trace.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Trace.hs
@@ -35,6 +35,7 @@ import Path.IO
 import Prelude hiding
     ( modify
     , runState
+    , trace
     )
 
 data FxTrace :: Effect where

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -14,8 +15,11 @@
 {-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
--- {-# OPTIONS_GHC -Wno-ambiguous-fields #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+#if __GLASGOW_HASKELL__ >= 902
+{-# OPTIONS_GHC -Wno-ambiguous-fields #-}
+#endif
 
 -- |
 -- Copyright: © 2018-2020 IOHK

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 module Test.Integration.Scenario.API.Shelley.StakePools (spec) where
 

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_GHC -Wno-unused-imports #-} -- temportary, until addRequiredSigners is fixed
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 module Test.Integration.Scenario.API.Shelley.TransactionsNew (spec) where
 


### PR DESCRIPTION
This PR includes a small number of patches that enable compatibility with GHC 9.2, while retaining compatibility with GHC 8.10.7.

(Note that this PR does **_not_** change the GHC version used in our nix environment, which remains at 8.10.7. For a PR that changes our nix environment to use GHC version 9.2.8, see: https://github.com/cardano-foundation/cardano-wallet/pull/4171)