### PR TITLE
Notify #hal-dev-alert in case of the nightly pipeline failure

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -5,6 +5,16 @@ env:
   # Per-host variables - shared across containers on host
   macos: "x86_64-darwin"
 
+notify:
+  - slack:
+      if: "build.state == 'failing'"
+      channels: [ "#hal-dev-alert" ]
+      message: "Nightly pipeline failing..."
+  - slack:
+      if: "build.state == 'failed'"
+      channels: [ "#hal-dev-alert" ]
+      message: "Nightly pipeline failed."
+
 steps:
   - label: 'Check auto-generated Nix on macos'
     key: macos-nix


### PR DESCRIPTION
- [x] I have configured the nightly buildkite pipeline to send a slack notification in case of a build failure;

### Comments

As per https://buildkite.com/docs/pipelines/notifications#slack-channel-and-direct-messages

