### PR TITLE
Consistently use `Cardano` qualifier for `cardano-api`-related things in `cardano-balance-tx`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -743,8 +743,8 @@ outputs RecentEraConway = map sizedValue . toList . Conway.ctbOutputs
 outputs RecentEraBabbage = map sizedValue . toList . Babbage.btbOutputs
 
 -- NOTE: To reduce the need for the caller to deal with @CardanoApiEra
--- (Cardano.ShelleyLedgerEra era) ~ era@, we quantify this function over @cardanoEra@
--- instead of @era@.
+-- (Cardano.ShelleyLedgerEra era) ~ era@, we quantify this function over
+-- @cardanoEra@ instead of @era@.
 --
 -- TODO [ADP-2353] Move to @cardano-api@ related module
 modifyLedgerBody

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -48,7 +48,7 @@ module Internal.Cardano.Write.Tx
     -- ** Helpers for cardano-api compatibility
     , cardanoEra
     , shelleyBasedEra
-    , ShelleyLedgerEra
+    , Cardano.ShelleyLedgerEra
     , cardanoEraFromRecentEra
     , shelleyBasedEraFromRecentEra
     , fromCardanoTx
@@ -148,13 +148,6 @@ module Internal.Cardano.Write.Tx
 
 import Prelude
 
-import Cardano.Api
-    ( BabbageEra
-    , ConwayEra
-    )
-import Cardano.Api.Shelley
-    ( ShelleyLedgerEra
-    )
 import Cardano.Crypto.Hash
     ( Hash (UnsafeHash)
     )
@@ -288,7 +281,7 @@ import qualified Data.Map as Map
 -- Eras
 --------------------------------------------------------------------------------
 
-type LatestEra = ConwayEra
+type LatestEra = Cardano.ConwayEra
 
 type LatestLedgerEra = StandardConway
 
@@ -308,8 +301,8 @@ type LatestLedgerEra = StandardConway
 -- NOTE: We /could/ let 'era' refer to eras from the ledger rather than from
 -- cardano-api.
 data RecentEra era where
-    RecentEraBabbage :: RecentEra BabbageEra
-    RecentEraConway :: RecentEra ConwayEra
+    RecentEraBabbage :: RecentEra Cardano.BabbageEra
+    RecentEraConway :: RecentEra Cardano.ConwayEra
 
 deriving instance Eq (RecentEra era)
 deriving instance Show (RecentEra era)
@@ -356,7 +349,7 @@ type RecentEraLedgerConstraints era =
 -- https://cardanofoundation.atlassian.net/browse/ADP-2353
 withConstraints
     :: RecentEra era
-    -> ((RecentEraLedgerConstraints (ShelleyLedgerEra era)) => a)
+    -> ((RecentEraLedgerConstraints (Cardano.ShelleyLedgerEra era)) => a)
     -> a
 withConstraints era a = case era of
     RecentEraBabbage -> a
@@ -378,10 +371,10 @@ fromRecentEra = \case
   RecentEraConway -> Cardano.ConwayEra
   RecentEraBabbage -> Cardano.BabbageEra
 
-instance IsRecentEra BabbageEra where
+instance IsRecentEra Cardano.BabbageEra where
     recentEra = RecentEraBabbage
 
-instance IsRecentEra ConwayEra where
+instance IsRecentEra Cardano.ConwayEra where
     recentEra = RecentEraConway
 
 cardanoEraFromRecentEra :: RecentEra era -> Cardano.CardanoEra era
@@ -411,12 +404,12 @@ data MaybeInRecentEra (thing :: Type -> Type)
     | InNonRecentEraAllegra
     | InNonRecentEraMary
     | InNonRecentEraAlonzo
-    | InRecentEraBabbage (thing BabbageEra)
-    | InRecentEraConway (thing ConwayEra)
+    | InRecentEraBabbage (thing Cardano.BabbageEra)
+    | InRecentEraConway (thing Cardano.ConwayEra)
 
-deriving instance (Eq (a BabbageEra), (Eq (a ConwayEra)))
+deriving instance (Eq (a Cardano.BabbageEra), (Eq (a Cardano.ConwayEra)))
     => Eq (MaybeInRecentEra a)
-deriving instance (Show (a BabbageEra), (Show (a ConwayEra)))
+deriving instance (Show (a Cardano.BabbageEra), (Show (a Cardano.ConwayEra)))
     => Show (MaybeInRecentEra a)
 
 toRecentEraGADT
@@ -556,8 +549,8 @@ type TxOut era = Core.TxOut era
 modifyTxOutValue
     :: RecentEra era
     -> (MaryValue StandardCrypto -> MaryValue StandardCrypto)
-    -> TxOut (ShelleyLedgerEra era)
-    -> TxOut (ShelleyLedgerEra era)
+    -> TxOut (Cardano.ShelleyLedgerEra era)
+    -> TxOut (Cardano.ShelleyLedgerEra era)
 modifyTxOutValue RecentEraConway f (BabbageTxOut addr val dat script) =
         BabbageTxOut addr (f val) dat script
 modifyTxOutValue RecentEraBabbage f (BabbageTxOut addr val dat script) =
@@ -566,13 +559,13 @@ modifyTxOutValue RecentEraBabbage f (BabbageTxOut addr val dat script) =
 modifyTxOutCoin
     :: RecentEra era
     -> (Coin -> Coin)
-    -> TxOut (ShelleyLedgerEra era)
-    -> TxOut (ShelleyLedgerEra era)
+    -> TxOut (Cardano.ShelleyLedgerEra era)
+    -> TxOut (Cardano.ShelleyLedgerEra era)
 modifyTxOutCoin era = modifyTxOutValue era . modifyCoin
 
 txOutValue
     :: RecentEra era
-    -> TxOut (ShelleyLedgerEra era)
+    -> TxOut (Cardano.ShelleyLedgerEra era)
     -> MaryValue StandardCrypto
 txOutValue RecentEraConway (Babbage.BabbageTxOut _ val _ _) = val
 txOutValue RecentEraBabbage (Babbage.BabbageTxOut _ val _ _) = val
@@ -619,7 +612,7 @@ data TxOutInRecentEra
 unwrapTxOutInRecentEra
     :: RecentEra era
     -> TxOutInRecentEra
-    -> (TxOut (ShelleyLedgerEra era))
+    -> (TxOut (Cardano.ShelleyLedgerEra era))
 unwrapTxOutInRecentEra era recentEraTxOut = case era of
     RecentEraConway -> recentEraToConwayTxOut recentEraTxOut
     RecentEraBabbage -> recentEraToBabbageTxOut recentEraTxOut
@@ -676,23 +669,23 @@ recentEraToBabbageTxOut (TxOutInRecentEra addr val datum mscript) =
 computeMinimumCoinForTxOut
     :: forall era. RecentEra era
     -- FIXME [ADP-2353] Replace 'RecentEra' with 'IsRecentEra'
-    -> Core.PParams (ShelleyLedgerEra era)
-    -> TxOut (ShelleyLedgerEra era)
+    -> Core.PParams (Cardano.ShelleyLedgerEra era)
+    -> TxOut (Cardano.ShelleyLedgerEra era)
     -> Coin
 computeMinimumCoinForTxOut era pp out = withConstraints era $
     Core.getMinCoinTxOut pp (withMaxLengthSerializedCoin out)
   where
     withMaxLengthSerializedCoin
-        :: TxOut (ShelleyLedgerEra era)
-        -> TxOut (ShelleyLedgerEra era)
+        :: TxOut (Cardano.ShelleyLedgerEra era)
+        -> TxOut (Cardano.ShelleyLedgerEra era)
     withMaxLengthSerializedCoin =
         modifyTxOutCoin era (const $ Convert.toLedger txOutMaxCoin)
 
 isBelowMinimumCoinForTxOut
     :: forall era. RecentEra era
     -- FIXME [ADP-2353] Replace 'RecentEra' with 'IsRecentEra'
-    -> Core.PParams (ShelleyLedgerEra era)
-    -> TxOut (ShelleyLedgerEra era)
+    -> Core.PParams (Cardano.ShelleyLedgerEra era)
+    -> TxOut (Cardano.ShelleyLedgerEra era)
     -> Bool
 isBelowMinimumCoinForTxOut era pp out =
     actualCoin < requiredMin
@@ -702,7 +695,7 @@ isBelowMinimumCoinForTxOut era pp out =
     requiredMin = withConstraints era $ Core.getMinCoinTxOut pp out
     actualCoin = getCoin era out
 
-    getCoin :: RecentEra era -> TxOut (ShelleyLedgerEra era) -> Coin
+    getCoin :: RecentEra era -> TxOut (Cardano.ShelleyLedgerEra era) -> Coin
     getCoin RecentEraConway (Babbage.BabbageTxOut _ val _ _) = coin val
     getCoin RecentEraBabbage (Babbage.BabbageTxOut _ val _ _) = coin val
 
@@ -713,8 +706,8 @@ isBelowMinimumCoinForTxOut era pp out =
 -- | Construct a 'UTxO era' using 'TxIn's and 'TxOut's in said era.
 utxoFromTxOuts
     :: RecentEra era
-    -> [(TxIn, Core.TxOut (ShelleyLedgerEra era))]
-    -> (Shelley.UTxO (ShelleyLedgerEra era))
+    -> [(TxIn, Core.TxOut (Cardano.ShelleyLedgerEra era))]
+    -> (Shelley.UTxO (Cardano.ShelleyLedgerEra era))
 utxoFromTxOuts era = withConstraints era $
     Shelley.UTxO . Map.fromList
 
@@ -725,7 +718,7 @@ utxoFromTxOuts era = withConstraints era $
 utxoFromTxOutsInRecentEra
     :: forall era. RecentEra era
     -> [(TxIn, TxOutInRecentEra)]
-    -> Shelley.UTxO (ShelleyLedgerEra era)
+    -> Shelley.UTxO (Cardano.ShelleyLedgerEra era)
 utxoFromTxOutsInRecentEra era = withConstraints era $
     Shelley.UTxO . Map.fromList . map (second (unwrapTxOutInRecentEra era))
 
@@ -735,8 +728,8 @@ utxoFromTxOutsInRecentEra era = withConstraints era $
 
 txBody
     :: RecentEra era
-    -> Core.Tx (ShelleyLedgerEra era)
-    -> Core.TxBody (ShelleyLedgerEra era)
+    -> Core.Tx (Cardano.ShelleyLedgerEra era)
+    -> Core.TxBody (Cardano.ShelleyLedgerEra era)
 txBody era = case era of
     RecentEraBabbage -> Babbage.body -- same type for babbage
     RecentEraConway -> Babbage.body -- same type for conway
@@ -744,19 +737,19 @@ txBody era = case era of
 -- Until we have convenient lenses to use
 outputs
     :: RecentEra era
-    -> Core.TxBody (ShelleyLedgerEra era)
-    -> [TxOut (ShelleyLedgerEra era)]
+    -> Core.TxBody (Cardano.ShelleyLedgerEra era)
+    -> [TxOut (Cardano.ShelleyLedgerEra era)]
 outputs RecentEraConway = map sizedValue . toList . Conway.ctbOutputs
 outputs RecentEraBabbage = map sizedValue . toList . Babbage.btbOutputs
 
 -- NOTE: To reduce the need for the caller to deal with @CardanoApiEra
--- (ShelleyLedgerEra era) ~ era@, we quantify this function over @cardanoEra@
+-- (Cardano.ShelleyLedgerEra era) ~ era@, we quantify this function over @cardanoEra@
 -- instead of @era@.
 --
 -- TODO [ADP-2353] Move to @cardano-api@ related module
 modifyLedgerBody
-    :: (Core.TxBody (ShelleyLedgerEra cardanoEra)
-        -> Core.TxBody (ShelleyLedgerEra cardanoEra))
+    :: (Core.TxBody (Cardano.ShelleyLedgerEra cardanoEra)
+        -> Core.TxBody (Cardano.ShelleyLedgerEra cardanoEra))
     -> Cardano.Tx cardanoEra
     -> Cardano.Tx cardanoEra
 modifyLedgerBody f (Cardano.Tx body keyWits) = Cardano.Tx body' keyWits
@@ -764,7 +757,7 @@ modifyLedgerBody f (Cardano.Tx body keyWits) = Cardano.Tx body' keyWits
     body' =
         case body of
             Cardano.ByronTxBody {} ->
-                error "Impossible: ByronTxBody in ShelleyLedgerEra"
+                error "Impossible: ByronTxBody in Cardano.ShelleyLedgerEra"
             Cardano.ShelleyTxBody
                 shelleyEra
                 ledgerBody
@@ -780,7 +773,7 @@ modifyLedgerBody f (Cardano.Tx body keyWits) = Cardano.Tx body' keyWits
                         auxData
                         validity
 
-emptyTx :: RecentEra era -> Core.Tx (ShelleyLedgerEra era)
+emptyTx :: RecentEra era -> Core.Tx (Cardano.ShelleyLedgerEra era)
 emptyTx era = withConstraints era $ Core.mkBasicTx Core.mkBasicTxBody
 
 --------------------------------------------------------------------------------
@@ -806,7 +799,7 @@ toCardanoTx = Cardano.ShelleyTx (shelleyBasedEraFromRecentEra $ recentEra @era)
 
 toCardanoUTxO
     :: forall era. IsRecentEra era
-    => Shelley.UTxO (ShelleyLedgerEra era)
+    => Shelley.UTxO (Cardano.ShelleyLedgerEra era)
     -> Cardano.UTxO era
 toCardanoUTxO = withConstraints (recentEra @era) $
     Cardano.UTxO
@@ -828,7 +821,7 @@ fromCardanoUTxO = withConstraints (recentEra @era) $
 
 toCardanoValue
     :: forall era. IsRecentEra era
-    => Core.Value (ShelleyLedgerEra era)
+    => Core.Value (Cardano.ShelleyLedgerEra era)
     -> Cardano.Value
 toCardanoValue = withConstraints (recentEra @era) Cardano.fromMaryValue
 
@@ -870,7 +863,7 @@ txscriptfee :: ExUnitPrices -> ExUnits -> Coin
 txscriptfee = Alonzo.txscriptfee
 
 maxScriptExecutionCost
-    :: RecentEra era -> Core.PParams (ShelleyLedgerEra era) -> Coin
+    :: RecentEra era -> Core.PParams (Cardano.ShelleyLedgerEra era) -> Coin
 maxScriptExecutionCost era pp = withConstraints era $
     txscriptfee (pp ^. Alonzo.ppPricesL) (pp ^. Alonzo.ppMaxTxExUnitsL)
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -282,7 +282,6 @@ import Text.Pretty.Simple
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Byron as Cardano
-import qualified Cardano.Api.Byron as Byron
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.CoinSelection.UTxOIndex as UTxOIndex
 import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
@@ -1265,7 +1264,7 @@ updateTx (Cardano.Tx body existingKeyWits) extraContent = do
                 scriptData
                 aux
                 val
-        Byron.ByronTxBody _ -> case Cardano.shelleyBasedEra @era of {}
+        Cardano.ByronTxBody _ -> case Cardano.shelleyBasedEra @era of {}
 
     TxUpdate _ _ _ extraInputScripts _ = extraContent
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
@@ -22,10 +22,6 @@ module Internal.Cardano.Write.Tx.Redeemers
 
 import Prelude
 
-import Cardano.Api
-    ( StakeAddress
-    , serialiseToBech32
-    )
 import Cardano.Crypto.Hash.Class
     ( Hash
     )
@@ -286,7 +282,7 @@ assignScriptRedeemers pparams timeTranslation utxo redeemers tx =
 data Redeemer
     = RedeemerSpending ByteString W.TxIn
     | RedeemerMinting ByteString TokenPolicyId
-    | RedeemerRewarding ByteString StakeAddress
+    | RedeemerRewarding ByteString Cardano.StakeAddress
     deriving (Eq, Generic, Show)
 
 instance Buildable Redeemer where
@@ -296,7 +292,7 @@ instance Buildable Redeemer where
         RedeemerMinting _ pid ->
             "minting(" <> build pid <> ")"
         RedeemerRewarding _ addr ->
-            "rewarding(" <> build (serialiseToBech32 addr) <> ")"
+            "rewarding(" <> build (Cardano.serialiseToBech32 addr) <> ")"
 
 redeemerData :: Redeemer -> ByteString
 redeemerData = \case

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -198,11 +198,11 @@ estimateKeyWitnessCount utxo txbody@(Cardano.TxBody txbodycontent) =
             fromIntegral
             $ sumVia estimateMaxWitnessRequiredPerInput
             $ mapMaybe toTimelockScript scripts
-        -- when wallets uses reference input it means script containing
-        -- its policy key was already published in previous tx
-        -- if so we need to add one witness that will stem from policy signing
-        -- key. As it is not allowed to publish and consume in the same transaction
-        -- we are not going to double count.
+        -- when wallets uses reference input it means script containing its
+        -- policy key was already published in previous tx if so we need to add
+        -- one witness that will stem from policy signing key. As it is not
+        -- allowed to publish and consume in the same transaction we are not
+        -- going to double count.
         txRefInpsWit = case Cardano.txInsReference txbodycontent of
             Cardano.TxInsReferenceNone -> 0
             Cardano.TxInsReference{} ->
@@ -335,7 +335,8 @@ estimateMaxWitnessRequiredPerInput = \case
     -- however we'd then need to adjust signTx accordingly such that it still
     -- doesn't add more witnesses than we plan for.
     --
-    -- Partially related task: https://cardanofoundation.atlassian.net/browse/ADP-2676
+    -- Partially related task:
+    -- https://cardanofoundation.atlassian.net/browse/ADP-2676
     CA.RequireSomeOf _m xs   ->
         sum $ map estimateMaxWitnessRequiredPerInput xs
     -- Estimate (and tx fees) could be lowered with:
@@ -347,6 +348,7 @@ estimateMaxWitnessRequiredPerInput = \case
     -- however we'd then need to adjust signTx accordingly such that it still
     -- doesn't add more witnesses than we plan for.
     --
-    -- Partially related task: https://cardanofoundation.atlassian.net/browse/ADP-2676
+    -- Partially related task:
+    -- https://cardanofoundation.atlassian.net/browse/ADP-2676
     CA.ActiveFromSlot _     -> 0
     CA.ActiveUntilSlot _    -> 0

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -76,7 +76,7 @@ import Numeric.Natural
 
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Api as Cardano
-import qualified Cardano.Api.Byron as Byron
+import qualified Cardano.Api.Byron as Cardano
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
@@ -229,7 +229,7 @@ estimateKeyWitnessCount utxo txbody@(Cardano.TxBody txbodycontent) =
   where
     scripts = case txbody of
         Cardano.ShelleyTxBody _ _ shelleyBodyScripts _ _ _ -> shelleyBodyScripts
-        Byron.ByronTxBody {} -> error "estimateKeyWitnessCount: ByronTxBody"
+        Cardano.ByronTxBody {} -> error "estimateKeyWitnessCount: ByronTxBody"
 
     dummyKeyRole = CA.Payment
 

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/TxSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/TxSpec.hs
@@ -10,9 +10,6 @@ module Internal.Cardano.Write.TxSpec where
 
 import Prelude
 
-import Cardano.Api.Gen
-    ( genTxIn
-    )
 import Cardano.Ledger.Api
     ( ppCoinsPerUTxOByteL
     )
@@ -148,7 +145,7 @@ instance Arbitrary (Cardano.UTxO Cardano.BabbageEra) where
     arbitrary = Cardano.UTxO . Map.fromList <$> liftArbitrary genTxInOutEntry
       where
         genTxInOutEntry = (,)
-            <$> genTxIn
+            <$> Cardano.genTxIn
             <*> Cardano.genTxOut Cardano.BabbageEra
 
 --------------------------------------------------------------------------------

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -505,7 +505,10 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
         let coinSelectionEstimatedSize :: Natural -> Natural
             coinSelectionEstimatedSize = unTxSize . sizeOf_BootstrapWitnesses
 
-        let measuredWitSize :: Cardano.IsCardanoEra era => Cardano.Tx era -> Natural
+        let measuredWitSize
+                :: Cardano.IsCardanoEra era
+                => Cardano.Tx era
+                -> Natural
             measuredWitSize (Cardano.Tx body wits) = fromIntegral
                 $ serializedSize (Cardano.Tx body wits)
                 - serializedSize (Cardano.Tx body [])
@@ -2557,10 +2560,16 @@ instance Arbitrary AnyRecentEra where
         , AnyRecentEra RecentEraConway
         ]
 
-instance Cardano.IsCardanoEra era => Arbitrary (Cardano.AddressInEra era) where
+instance
+    Cardano.IsCardanoEra era =>
+    Arbitrary (Cardano.AddressInEra era)
+  where
     arbitrary = Cardano.genAddressInEra Cardano.cardanoEra
 
-instance Cardano.IsCardanoEra era => Arbitrary (Cardano.TxOutDatum ctx era) where
+instance
+    Cardano.IsCardanoEra era =>
+    Arbitrary (Cardano.TxOutDatum ctx era)
+  where
     arbitrary = Cardano.genTxOutDatum Cardano.cardanoEra
 
 instance Arbitrary Cardano.NetworkId where


### PR DESCRIPTION
## Issue

ADP-3184

## Description

Most imports from the `Cardano.Api` module hierarchy (from `cardano-api`) are already imported into the `Cardano` namespace.

However, there are a few exceptions to this rule.
 
This PR fixes the exceptions, so that **all** symbols from the `Cardano.Api` module hierarchy are imported into the `Cardano` namespace.
