### PR TITLE
Include extra source files `*.lagda.md` instead of `*.agda`

### DIFF
--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -13,7 +13,7 @@ copyright:          2023 Cardano Foundation
 category:           Web
 
 extra-source-files:
-  spec/**/*.agda
+  spec/**/*.lagda.md
 
 common language
   default-language:


### PR DESCRIPTION
This pull request fixes an issue with `customer-deposit-wallet.cabal`.

Specifically, as the specification is written as a literal Agda/Markdown file, we need to include `*.lagda.md` instead of `*.agda` in the `extra-source-files` field.
