### PR TITLE
Move `mkUnsignedTransaction` out of `TransactionLayer`

### DIFF
--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -311,7 +311,7 @@ benchmarksSeq BenchmarkConfig{benchmarkName,ctx} = do
 
     (_, delegationFeeTime) <- bench "delegationFee" $ do
         W.delegationFee
-            (W.dbLayer_ ctx) (W.networkLayer_ ctx) (W.transactionLayer_ ctx)
+            (W.dbLayer_ ctx) (W.networkLayer_ ctx)
             (W.defaultChangeAddressGen (delegationAddressS @n))
 
     pure BenchSeqResults

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -133,10 +133,10 @@ import Cardano.Wallet.DB.Layer
     , withDBFresh
     )
 import Cardano.Wallet.Flavor
-    ( CredFromOf
-    , Excluding
+    ( Excluding
     , KeyFlavorS (..)
     , KeyOf
+    , NetworkOf
     , WalletFlavor (..)
     , keyFlavorFromState
     )
@@ -1143,12 +1143,12 @@ benchEstimateTxFee
         ( AddressBookIso s
         , WalletFlavor s
         , Excluding '[SharedKey] (KeyOf s)
-        , CredFromOf s ~ 'CredFromKeyK
+        , HasSNetworkId (NetworkOf s)
         )
     => SNetworkId n
     -> WalletLayer IO s
     -> IO Time
-benchEstimateTxFee network (WalletLayer _ _ netLayer txLayer dbLayer) =
+benchEstimateTxFee network (WalletLayer _ _ netLayer _ dbLayer) =
     fmap snd <$> bench "estimate tx fee" $ do
         (Write.InAnyRecentEra _era protocolParams, timeTranslation)
             <- W.readNodeTipStateForTxWrite netLayer
@@ -1160,7 +1160,6 @@ benchEstimateTxFee network (WalletLayer _ _ netLayer txLayer dbLayer) =
         W.transactionFee @s
             dbLayer
             protocolParams
-            txLayer
             timeTranslation
             dummyChangeAddressGen
             defaultTransactionCtx

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -634,7 +634,6 @@ newTransactionLayer keyF networkId = TransactionLayer
     , transactionWitnessTag = txWitnessTagForKey keyF
     }
 
-
 mkUnsignedTransaction
     :: forall era
      . Write.IsRecentEra era
@@ -654,8 +653,8 @@ mkUnsignedTransaction
     --
     -- The function returns CBOR-ed transaction body to be signed in another step.
 mkUnsignedTransaction networkId stakeCred ctx selection = do
-    let ttl   = txValidityInterval ctx
-    let wdrl  = view #txWithdrawal ctx
+    let ttl = txValidityInterval ctx
+    let wdrl = view #txWithdrawal ctx
     let delta = case selection of
             Right selOf -> selectionDelta selOf
             Left _preSel -> Coin 0
@@ -669,22 +668,30 @@ mkUnsignedTransaction networkId stakeCred ctx selection = do
     case view #txDelegationAction ctx of
         Nothing -> do
             let md = view #txMetadata ctx
-            let ourRewardAcctM = FromScriptHash . unScriptHash . toScriptHash <$> stakingScriptM
+            let ourRewardAcctM
+                    = FromScriptHash
+                    . unScriptHash
+                    . toScriptHash <$> stakingScriptM
             case wdrl of
                 WithdrawalSelf rewardAcct _ _ ->
-                    if ourRewardAcctM == Just rewardAcct then
-                        constructUnsignedTx networkId (md, []) ttl wdrl
-                        selection delta assetsToBeMinted assetsToBeBurned inpsScripts
-                        stakingScriptM refScriptM
-                        (Write.shelleyBasedEraFromRecentEra Write.recentEra)
+                    if ourRewardAcctM == Just rewardAcct
+                    then
+                        constructUnsignedTx
+                            networkId (md, []) ttl wdrl selection delta
+                            assetsToBeMinted assetsToBeBurned
+                            inpsScripts stakingScriptM refScriptM
+                            (Write.shelleyBasedEraFromRecentEra Write.recentEra)
                     else
-                        constructUnsignedTx networkId (md, []) ttl wdrl
-                        selection delta assetsToBeMinted assetsToBeBurned inpsScripts
-                        Nothing refScriptM
-                        (Write.shelleyBasedEraFromRecentEra Write.recentEra)
+                        constructUnsignedTx
+                            networkId (md, []) ttl wdrl selection delta
+                            assetsToBeMinted assetsToBeBurned
+                            inpsScripts Nothing refScriptM
+                            (Write.shelleyBasedEraFromRecentEra Write.recentEra)
                 _ ->
-                    constructUnsignedTx networkId (md, []) ttl wdrl
-                    selection delta assetsToBeMinted assetsToBeBurned inpsScripts
+                    constructUnsignedTx
+                        networkId (md, []) ttl wdrl
+                        selection delta assetsToBeMinted assetsToBeBurned
+                        inpsScripts
                     Nothing refScriptM
                     (Write.shelleyBasedEraFromRecentEra Write.recentEra)
         Just action -> do
@@ -694,14 +701,16 @@ mkUnsignedTransaction networkId stakeCred ctx selection = do
                     Right (Just script) ->
                         mkDelegationCertificates action (Right script)
                     Right Nothing ->
-                        error $ "stakeCred in mkUnsignedTransaction must be either "
-                        <> "xpub or script when there is delegation action"
+                        error $ unwords
+                            [ "stakeCred in mkUnsignedTransaction must be"
+                            , "either xpub or script when there is delegation"
+                            , "action"
+                            ]
             let payload = (view #txMetadata ctx, certs)
             constructUnsignedTx networkId payload ttl wdrl
                 selection delta assetsToBeMinted assetsToBeBurned inpsScripts
                 stakingScriptM refScriptM
                 (Write.shelleyBasedEraFromRecentEra Write.recentEra)
-
 
 _decodeSealedTx
     :: AnyCardanoEra

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -634,24 +634,26 @@ newTransactionLayer keyF networkId = TransactionLayer
     , transactionWitnessTag = txWitnessTagForKey keyF
     }
 
+-- | Construct a standard unsigned transaction.
+--
+-- The term "standard" refers to the fact that we do not deal with redemption,
+-- multi-signature transactions, etc.
+--
+-- This function returns a CBOR-ed transaction body, which should be signed
+-- in separate step.
+--
 mkUnsignedTransaction
     :: forall era
      . Write.IsRecentEra era
     => NetworkId
     -> Either XPub (Maybe (Script KeyHash))
-        -- Reward account public key or optional script hash
+    -- ^ Reward account public key or optional script hash.
     -> TransactionCtx
-        -- An additional context about the transaction
+    -- ^ Additional context about the transaction.
     -> Either PreSelection (SelectionOf TxOut)
-        -- A balanced coin selection where all change addresses have been
-        -- assigned.
+    -- ^ A balanced coin selection where all change addresses have been
+    -- assigned.
     -> Either ErrMkTransaction (Cardano.TxBody era)
-    -- ^ Construct a standard unsigned transaction
-    --
-    -- " Standard " here refers to the fact that we do not deal with redemption,
-    -- multisignature transactions, etc.
-    --
-    -- The function returns CBOR-ed transaction body to be signed in another step.
 mkUnsignedTransaction networkId stakeCred ctx selection = do
     let ttl = txValidityInterval ctx
     let wdrl = view #txWithdrawal ctx

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -61,7 +61,6 @@ import Prelude
 
 import Cardano.Address.Derivation
     ( XPrv
-    , XPub
     )
 import Cardano.Address.Script
     ( KeyHash (..)
@@ -163,13 +162,11 @@ import Internal.Cardano.Write.Tx.SizeEstimation
     ( TxWitnessTag
     )
 
-import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map
-import qualified Internal.Cardano.Write.Tx as Write
 
 data TransactionLayer k ktype tx = TransactionLayer
     { mkTransaction
@@ -216,24 +213,6 @@ data TransactionLayer k ktype tx = TransactionLayer
         --
         -- If inputs can't be resolved, they are simply skipped, hence why this
         -- function cannot fail.
-
-    , mkUnsignedTransaction
-        :: forall era
-         . Write.IsRecentEra era
-        => Either XPub (Maybe (Script KeyHash))
-            -- Reward account public key or optional script hash
-        -> TransactionCtx
-            -- An additional context about the transaction
-        -> Either PreSelection (SelectionOf TxOut)
-            -- A balanced coin selection where all change addresses have been
-            -- assigned.
-        -> Either ErrMkTransaction (Cardano.TxBody era)
-        -- ^ Construct a standard unsigned transaction
-        --
-        -- " Standard " here refers to the fact that we do not deal with redemption,
-        -- multisignature transactions, etc.
-        --
-        -- The function returns CBOR-ed transaction body to be signed in another step.
 
     , decodeTx
         :: AnyCardanoEra

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -1425,8 +1425,6 @@ dummyTransactionLayer = TransactionLayer
 
     , addVkWitnesses =
         error "dummyTransactionLayer: addVkWitnesses not implemented"
-    , mkUnsignedTransaction =
-        error "dummyTransactionLayer: mkUnsignedTransaction not implemented"
     , decodeTx = \_era _witCtx _sealed ->
         ( Tx
             { txId = Hash ""


### PR DESCRIPTION
- Move `mkUnsignedTransaction` out of `TransactionLayer` by adding `NetworkId` as argument.
- Replace `TransactionLayer` with `HasSNetworkId (NetworkOf s)` in Wallet and Server functions as needed.

### Comments

- Turned out this wasn't really needed, but I believe it's the right direction to get rid of the `TransactionLayer` anyway.

### Issue Number

Side-quest to ADP-2353
