### PR TITLE
Remove some `CardanoApi.Tx` usages in `balanceTx`

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -337,6 +337,7 @@ type RecentEraLedgerConstraints era =
     , Alonzo.AlonzoEraTxBody era
     , Babbage.ShelleyEraTxBody era
     , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+    , Babbage.BabbageEraTxBody era
     , Shelley.EraUTxO era
     )
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -334,8 +334,6 @@ type RecentEraLedgerConstraints era =
     , ExtendedUTxO era
     , Alonzo.AlonzoEraPParams era
     , Ledger.AlonzoEraTx era
-    , Alonzo.AlonzoEraTxBody era
-    , Babbage.ShelleyEraTxBody era
     , ScriptsNeeded era ~ AlonzoScriptsNeeded era
     , Babbage.BabbageEraTxBody era
     , Shelley.EraUTxO era

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -101,6 +101,9 @@ import Cardano.Ledger.Api
     , outputsTxBodyL
     , ppMaxTxSizeL
     )
+import Cardano.Ledger.BaseTypes
+    ( StrictMaybe (..)
+    )
 import Cardano.Ledger.UTxO
     ( txinLookup
     )
@@ -288,9 +291,6 @@ import qualified Cardano.Api.Byron as CardanoApi
 import qualified Cardano.Api.Shelley as CardanoApi
 import qualified Cardano.CoinSelection.UTxOIndex as UTxOIndex
 import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
-import Cardano.Ledger.BaseTypes
-    ( StrictMaybe (..)
-    )
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Wallet.Primitive.Types.Address as W
     ( Address

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -645,7 +645,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     selectionStrategy
     ptx@(PartialTx partialTx inputUTxO redeemers)
     = do
-    let partialLedgerTx = fromCardanoTx partialTx
+    let partialLedgerTx = fromCardanoApiTx partialTx
     guardExistingCollateral partialLedgerTx
     guardExistingTotalCollateral partialLedgerTx
     guardExistingReturnCollateral partialLedgerTx

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -33,8 +33,10 @@ module Internal.Cardano.Write.Tx.SizeEstimation
     , TxWitnessTag (..)
     , assumedTxWitnessTag
 
-     -- * Needed for estimateSignedTxSize
+     -- * Needed for estimateSignedTxSize and the wallet
     , sizeOf_BootstrapWitnesses
+
+     -- * Needed for the wallet
     , sizeOf_VKeyWitnesses
     , sizeOf_Withdrawals
     )


### PR DESCRIPTION
- Use ledger types in guardExistingCollateral
- Use ledger types in `guardExistingTotalCollateral`
- Use ledger types in `guardExistingReturnCollateral`
- Tweak `Write.Tx.SizeEstimation` export section
- Drop now unneeded `guardConflictingWithdrawalNetworks`


### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2353

