### PR TITLE
[ADP-3198] Compute primitive block via erafun

### DIFF
--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -54,6 +54,7 @@ library
     Cardano.Wallet.Read.Block.Gen.Shelley
     Cardano.Wallet.Read.Block.HeaderHash
     Cardano.Wallet.Read.Block.SlotNo
+    Cardano.Wallet.Read.Block.Txs
     Cardano.Wallet.Read.Eras
     Cardano.Wallet.Read.Eras.EraFun
     Cardano.Wallet.Read.Eras.EraValue

--- a/lib/read/lib/Cardano/Wallet/Read/Block.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block.hs
@@ -1,9 +1,6 @@
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- |
@@ -16,7 +13,6 @@ module Cardano.Wallet.Read.Block
     ( ConsensusBlock
     , Block (..)
     , fromConsensusBlock
-    , getTxs
     , toConsensusBlock
     ) where
 
@@ -34,31 +30,18 @@ import Cardano.Api
 import Cardano.Ledger.Api
     ( StandardCrypto
     )
-import Cardano.Ledger.Binary
-    ( EncCBOR
-    )
 import Cardano.Wallet.Read.Eras
-    ( (:.:) (..)
-    , EraFun (..)
+    ( EraFun (..)
     , EraValue
     , K (..)
     , allegra
     , alonzo
-    , applyEraFun
     , babbage
     , byron
     , conway
     , inject
     , mary
-    , sequenceEraValue
     , shelley
-    )
-import Cardano.Wallet.Read.Tx
-    ( Tx (..)
-    , TxT
-    )
-import Data.Foldable
-    ( toList
     )
 import Ouroboros.Consensus.Protocol.Praos
     ( Praos
@@ -66,23 +49,11 @@ import Ouroboros.Consensus.Protocol.Praos
 import Ouroboros.Consensus.Protocol.TPraos
     ( TPraos
     )
-import Ouroboros.Consensus.Shelley.Protocol.Abstract
-    ( ShelleyProtocolHeader
-    )
 
-import qualified Cardano.Chain.Block as Byron
-import qualified Cardano.Chain.UTxO as Byron
-import qualified Cardano.Ledger.Api as Ledger
-import qualified Cardano.Ledger.Era as Shelley
-import qualified Cardano.Ledger.Shelley.API as Shelley
-import qualified Ouroboros.Consensus.Byron.Ledger as Byron
 import qualified Ouroboros.Consensus.Byron.Ledger as O
 import qualified Ouroboros.Consensus.Cardano.Block as O
 import qualified Ouroboros.Consensus.Shelley.Ledger as O
 
-{-------------------------------------------------------------------------------
-    Block type
--------------------------------------------------------------------------------}
 -- | Type synonym for 'CardanoBlock' with cryptography as used on mainnet.
 type ConsensusBlock = O.CardanoBlock O.StandardCrypto
 
@@ -107,35 +78,6 @@ newtype Block era = Block {unBlock :: BlockT era}
 deriving instance Show (BlockT era) => Show (Block era)
 deriving instance Eq (BlockT era) => Eq (Block era)
 
--- | Get sequence of transactions in the block.
-txsFromBlockE :: EraFun Block ([] :.: Tx)
-txsFromBlockE =
-    EraFun
-        { byronFun = getTxs' getTxsFromBlockByron
-        , shelleyFun = getTxs' getTxsFromBlockShelleyAndOn
-        , maryFun = getTxs' getTxsFromBlockShelleyAndOn
-        , allegraFun = getTxs' getTxsFromBlockShelleyAndOn
-        , alonzoFun = getTxs' getTxsFromBlockShelleyAndOn
-        , babbageFun = getTxs' getTxsFromBlockShelleyAndOn
-        , conwayFun = getTxs' getTxsFromBlockShelleyAndOn
-        }
-  where
-    getTxs' f (Block block) = Comp $ Tx <$> f block
-
-getTxsFromBlockByron :: O.ByronBlock -> [TxT ByronEra]
-getTxsFromBlockByron block =
-    case Byron.byronBlockRaw block of
-        Byron.ABOBBlock b ->
-            map (() <$) . Byron.unTxPayload . Byron.blockTxPayload $ b
-        Byron.ABOBBoundary _ -> []
-
-getTxsFromBlockShelleyAndOn
-    :: (Shelley.EraSegWits era, EncCBOR (ShelleyProtocolHeader proto))
-    => O.ShelleyBlock proto era
-    -> [Ledger.Tx era]
-getTxsFromBlockShelleyAndOn (O.ShelleyBlock (Shelley.Block _ txs) _) =
-    toList (Shelley.fromTxSeq txs)
-
 -- | Convert block as received from cardano-node
 -- via Haskell library of mini-protocol.
 fromConsensusBlock :: ConsensusBlock -> EraValue Block
@@ -148,16 +90,14 @@ fromConsensusBlock = \case
     O.BlockBabbage block -> inject babbage $ Block block
     O.BlockConway block -> inject conway $ Block block
 
-getTxs :: O.CardanoBlock StandardCrypto -> [EraValue Tx]
-getTxs = sequenceEraValue . applyEraFun txsFromBlockE . fromConsensusBlock
-
 toConsensusBlock :: EraFun Block (K ConsensusBlock)
-toConsensusBlock = EraFun
-    { byronFun = K . O.BlockByron . unBlock
-    , shelleyFun = K . O.BlockShelley . unBlock
-    , allegraFun = K . O.BlockAllegra . unBlock
-    , maryFun = K . O.BlockMary . unBlock
-    , alonzoFun = K . O.BlockAlonzo . unBlock
-    , babbageFun = K . O.BlockBabbage . unBlock
-    , conwayFun = K . O.BlockConway . unBlock
-    }
+toConsensusBlock =
+    EraFun
+        { byronFun = K . O.BlockByron . unBlock
+        , shelleyFun = K . O.BlockShelley . unBlock
+        , allegraFun = K . O.BlockAllegra . unBlock
+        , maryFun = K . O.BlockMary . unBlock
+        , alonzoFun = K . O.BlockAlonzo . unBlock
+        , babbageFun = K . O.BlockBabbage . unBlock
+        , conwayFun = K . O.BlockConway . unBlock
+        }

--- a/lib/read/lib/Cardano/Wallet/Read/Block/HeaderHash.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/HeaderHash.hs
@@ -61,6 +61,7 @@ import qualified Ouroboros.Consensus.Shelley.Ledger.Block as O
 import qualified Ouroboros.Consensus.Shelley.Protocol.Abstract as Shelley
 import qualified Ouroboros.Network.Block as O
 
+-- | Era-specific header hash type from the ledger
 type family HeaderHashT era where
     HeaderHashT ByronEra = ByronHash
     HeaderHashT ShelleyEra = ShelleyHash StandardCrypto
@@ -70,6 +71,7 @@ type family HeaderHashT era where
     HeaderHashT BabbageEra = ShelleyHash StandardCrypto
     HeaderHashT ConwayEra = ShelleyHash StandardCrypto
 
+-- | Era-specific header hash type from the ledger
 newtype HeaderHash era = HeaderHash (HeaderHashT era)
 
 getEraHeaderHash :: EraFun Block HeaderHash
@@ -96,6 +98,7 @@ getHeaderHashShelley
 getHeaderHashShelley
     (O.ShelleyBlock (Shelley.Block header _) _) = Shelley.pHeaderHash header
 
+-- | Era-specific previous header hash type from the ledger
 type family PrevHeaderHashT era where
     PrevHeaderHashT ByronEra = O.ChainHash ByronBlock
     PrevHeaderHashT ShelleyEra = PrevHash StandardCrypto
@@ -105,6 +108,7 @@ type family PrevHeaderHashT era where
     PrevHeaderHashT BabbageEra = PrevHash StandardCrypto
     PrevHeaderHashT ConwayEra = PrevHash StandardCrypto
 
+-- | Era-specific previous header hash type from the ledger
 newtype PrevHeaderHash era = PrevHeaderHash (PrevHeaderHashT era)
 
 getPrevHeaderHashShelley

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Txs.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Txs.hs
@@ -59,8 +59,7 @@ getEraTransactions =
 getTxsFromBlockByron :: O.ByronBlock -> [TxT ByronEra]
 getTxsFromBlockByron block =
     case Byron.byronBlockRaw block of
-        Byron.ABOBBlock b ->
-            map (() <$) . Byron.unTxPayload . Byron.blockTxPayload $ b
+        Byron.ABOBBlock b -> Byron.unTxPayload . Byron.blockTxPayload $ b
         Byron.ABOBBoundary _ -> []
 
 getTxsFromBlockShelleyAndOn

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Txs.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Txs.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Wallet.Read.Block.Txs
+    ( getTxs
+    , getTxsForEra
+    , txsFromBlock
+    ) where
+
+import Prelude
+
+import Cardano.Api
+    ( ByronEra
+    )
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
+import Cardano.Ledger.Binary
+    ( EncCBOR
+    )
+import Cardano.Wallet.Read.Block
+    ( Block (..)
+    , fromConsensusBlock
+    )
+import Cardano.Wallet.Read.Eras
+    ( (:.:) (..)
+    , EraFun (..)
+    , EraValue
+    , MkEraValue
+    , applyEraFun
+    , project
+    )
+import Cardano.Wallet.Read.Tx
+    ( Tx (..)
+    , TxT
+    )
+import Data.Foldable
+    ( toList
+    )
+import Generics.SOP
+    ( unComp
+    )
+import Ouroboros.Consensus.Shelley.Protocol.Abstract
+    ( ShelleyProtocolHeader
+    )
+
+import qualified Cardano.Chain.Block as Byron
+import qualified Cardano.Chain.UTxO as Byron
+import qualified Cardano.Ledger.Api as Ledger
+import qualified Cardano.Ledger.Era as Shelley
+import qualified Cardano.Ledger.Shelley.API as Shelley
+import qualified Ouroboros.Consensus.Byron.Ledger as Byron
+import qualified Ouroboros.Consensus.Byron.Ledger as O
+import qualified Ouroboros.Consensus.Cardano.Block as O
+import qualified Ouroboros.Consensus.Shelley.Ledger as O
+
+-- | Get sequence of transactions in the block.
+txsFromBlock :: EraFun Block ([] :.: Tx)
+txsFromBlock =
+    EraFun
+        { byronFun = getTxs' getTxsFromBlockByron
+        , shelleyFun = getTxs' getTxsFromBlockShelleyAndOn
+        , maryFun = getTxs' getTxsFromBlockShelleyAndOn
+        , allegraFun = getTxs' getTxsFromBlockShelleyAndOn
+        , alonzoFun = getTxs' getTxsFromBlockShelleyAndOn
+        , babbageFun = getTxs' getTxsFromBlockShelleyAndOn
+        , conwayFun = getTxs' getTxsFromBlockShelleyAndOn
+        }
+  where
+    getTxs' f (Block block) = Comp $ Tx <$> f block
+
+getTxsFromBlockByron :: O.ByronBlock -> [TxT ByronEra]
+getTxsFromBlockByron block =
+    case Byron.byronBlockRaw block of
+        Byron.ABOBBlock b ->
+            map (() <$) . Byron.unTxPayload . Byron.blockTxPayload $ b
+        Byron.ABOBBoundary _ -> []
+
+getTxsFromBlockShelleyAndOn
+    :: (Shelley.EraSegWits era, EncCBOR (ShelleyProtocolHeader proto))
+    => O.ShelleyBlock proto era
+    -> [Ledger.Tx era]
+getTxsFromBlockShelleyAndOn (O.ShelleyBlock (Shelley.Block _ txs) _) =
+    toList (Shelley.fromTxSeq txs)
+
+getTxs :: O.CardanoBlock StandardCrypto -> EraValue ([] :.: Tx)
+getTxs = applyEraFun txsFromBlock . fromConsensusBlock
+
+getTxsForEra
+    :: MkEraValue ([] :.: Tx) p
+    -> O.CardanoBlock StandardCrypto
+    -> Maybe [Tx p]
+getTxsForEra ew = fmap unComp . project ew . getTxs

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/TxCBOR.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Handlers/TxCBOR.hs
@@ -120,7 +120,7 @@ data ParsedTxCBOR = ParsedTxCBOR
 parser :: EraFun Tx (K ParsedTxCBOR)
 parser = fromEraFunK
     $ ParsedTxCBOR
-        <$> EraFunK (Feature.certificates <<< getEraCertificates)
+        <$> EraFunK (Feature.primitiveCertificates <<< getEraCertificates)
         <*> EraFunK (Feature.mint <<<
             getEraMint *&&&* getEraWitnesses *&&&* getEraReferenceInputs)
         <*> EraFunK (Feature.getValidity <<< getEraValidity)

--- a/lib/wallet/bench/EraFun.hs
+++ b/lib/wallet/bench/EraFun.hs
@@ -28,7 +28,6 @@ import Data.Time.Clock.POSIX
 
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Read.Primitive.Block as New
-import qualified Cardano.Wallet.Shelley.Compatibility as Old
 import qualified Data.ByteString.Char8 as B8
 
 -- Our benchmark harness.
@@ -38,21 +37,14 @@ main =
         [ bgroup
             "fib"
             [ bench "1 new" $ nf (run new) 1
-            , bench "1 old" $ nf (run old) 1
             , bench "10 new" $ nf (run new) 10
-            , bench "10 old" $ nf (run old) 10
             , bench "100 new" $ nf (run new) 100
-            , bench "100 old" $ nf (run old) 100
             , bench "1000 new" $ nf (run new) 1000
-            , bench "1000 old" $ nf (run old) 1000
             ]
         ]
 
 new :: GenesisParameters -> ConsensusBlock -> W.Block
 new gp = fst . New.fromCardanoBlock (getGenesisBlockHash gp)
-
-old :: GenesisParameters -> ConsensusBlock -> W.Block
-old = Old.fromCardanoBlock
 
 run :: (GenesisParameters -> ConsensusBlock -> W.Block) -> Int -> [W.Block]
 run f n = f dummyGenesisParameters <$> take n exampleBlocks

--- a/lib/wallet/bench/EraFun.hs
+++ b/lib/wallet/bench/EraFun.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE DataKinds #-}
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types
+    ( GenesisParameters (..)
+    , StartTime (..)
+    , getGenesisBlockHash
+    )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..)
+    )
+import Cardano.Wallet.Read.Block
+    ( ConsensusBlock
+    )
+import Cardano.Wallet.Read.Block.Gen.Build
+    ( exampleBlocks
+    )
+import Criterion.Main
+    ( bench
+    , bgroup
+    , defaultMain
+    , nf
+    )
+import Data.Time.Clock.POSIX
+    ( posixSecondsToUTCTime
+    )
+
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Read.Primitive.Block as New
+import qualified Cardano.Wallet.Shelley.Compatibility as Old
+import qualified Data.ByteString.Char8 as B8
+
+-- Our benchmark harness.
+main :: IO ()
+main =
+    defaultMain
+        [ bgroup
+            "fib"
+            [ bench "1 new" $ nf (run new) 1
+            , bench "1 old" $ nf (run old) 1
+            , bench "10 new" $ nf (run new) 10
+            , bench "10 old" $ nf (run old) 10
+            , bench "100 new" $ nf (run new) 100
+            , bench "100 old" $ nf (run old) 100
+            , bench "1000 new" $ nf (run new) 1000
+            , bench "1000 old" $ nf (run old) 1000
+            ]
+        ]
+
+new :: GenesisParameters -> ConsensusBlock -> W.Block
+new gp = fst . New.fromCardanoBlock (getGenesisBlockHash gp)
+
+old :: GenesisParameters -> ConsensusBlock -> W.Block
+old = Old.fromCardanoBlock
+
+run :: (GenesisParameters -> ConsensusBlock -> W.Block) -> Int -> [W.Block]
+run f n = f dummyGenesisParameters <$> take n exampleBlocks
+
+dummyGenesisParameters :: GenesisParameters
+dummyGenesisParameters =
+    GenesisParameters
+        { getGenesisBlockHash = dummyGenesisHash
+        , getGenesisBlockDate = StartTime $ posixSecondsToUTCTime 0
+        }
+
+dummyGenesisHash :: Hash "Genesis"
+dummyGenesisHash = Hash (B8.replicate 32 '1')

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -207,13 +207,15 @@ import Cardano.Wallet.Primitive.Types.Tx.TxOut
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
     ( UTxOStatistics (..)
     )
+import Cardano.Wallet.Read.Primitive.Block
+    ( fromCardanoBlock
+    )
 import Cardano.Wallet.Shelley.Compatibility
     ( AnyCardanoEra (..)
     , CardanoBlock
     , NodeToClientVersionData
     , StandardCrypto
     , emptyGenesis
-    , fromCardanoBlock
     , numberOfTransactionsInBlock
     )
 import Cardano.Wallet.Shelley.Network.Node
@@ -366,6 +368,7 @@ import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.Checkpoints.Policy as CP
 import qualified Cardano.Wallet.DB.Sqlite.Migration.Old as Sqlite
+import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
@@ -992,8 +995,8 @@ prepareNode tr proxy socketPath np vData = do
             tunedForMainnetPipeliningStrategy
             np socketPath vData sTol $ \nw' -> do
         let gp = genesisParameters np
-        let convert = fromCardanoBlock gp
-        let nw = convert <$> nw'
+        let convert = fromCardanoBlock (W.getGenesisBlockHash gp)
+        let nw = fst . convert <$> nw'
         waitForNodeSync tr nw
     traceWith tr $ MsgSyncCompleted proxy sl
 

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -310,6 +310,7 @@ library
     Cardano.Wallet.Primitive.Types.Tx.TxSeq
     Cardano.Wallet.Primitive.Types.Tx.TxSeq.Gen
     Cardano.Wallet.Primitive.Types.UTxOStatistics
+    Cardano.Wallet.Read.Primitive.Block
     Cardano.Wallet.Read.Primitive.Block.Header
     Cardano.Wallet.Read.Primitive.Tx
     Cardano.Wallet.Read.Primitive.Tx.Allegra

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -310,6 +310,7 @@ library
     Cardano.Wallet.Primitive.Types.Tx.TxSeq
     Cardano.Wallet.Primitive.Types.Tx.TxSeq.Gen
     Cardano.Wallet.Primitive.Types.UTxOStatistics
+    Cardano.Wallet.Read.Primitive.Block.Header
     Cardano.Wallet.Read.Primitive.Tx
     Cardano.Wallet.Read.Primitive.Tx.Allegra
     Cardano.Wallet.Read.Primitive.Tx.Alonzo

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -1123,3 +1123,21 @@ benchmark api
     , with-utf8
 
   other-modules:  Cardano.Wallet.DummyTarget.Primitive.Types
+
+benchmark erafun-benchmark
+  import:           language, opts-exe
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   bench
+  main-is:          EraFun.hs
+  build-depends:
+    , base
+    , bytestring
+    , cardano-crypto
+    , cardano-wallet
+    , cardano-wallet-primitive
+    , cardano-wallet-read
+    , criterion
+    , random
+    , time
+
+  default-language: Haskell2010

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -543,12 +543,14 @@ import Cardano.Wallet.Primitive.Types.UTxO
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
     ( UTxOStatistics
     )
+import Cardano.Wallet.Read.Primitive.Block
+    ( fromCardanoBlock
+    )
 import Cardano.Wallet.Read.Tx.CBOR
     ( TxCBOR
     )
 import Cardano.Wallet.Shelley.Compatibility
-    ( fromCardanoBlock
-    , fromCardanoLovelace
+    ( fromCardanoLovelace
     , fromCardanoTxIn
     , fromCardanoTxOut
     , fromCardanoWdrls
@@ -1208,7 +1210,12 @@ restoreWallet ctx = db & \DBLayer{..} ->
                 { checkpointPolicy
                 , readChainPoints
                 , rollForward = \blocks tip ->
-                    rollForward' (List $ fromCardanoBlock gp <$> blocks) tip
+                    rollForward'
+                        (List
+                            $ fst . fromCardanoBlock (W.getGenesisBlockHash gp)
+                            <$> blocks
+                        )
+                        tip
                 , rollBackward
                 }
   where

--- a/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -25,10 +25,7 @@ module Cardano.Wallet.Byron.Compatibility
     , genesisBlockFromTxOuts
 
       -- * Conversions
-    , fromBlockNo
     , fromByronBlock
-    , fromByronHash
-    , fromChainHash
     , fromGenesisData
     , byronCodecConfig
     , fromProtocolMagicId

--- a/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -27,7 +27,6 @@ module Cardano.Wallet.Byron.Compatibility
       -- * Conversions
     , fromBlockNo
     , fromByronBlock
-    , toByronBlockHeader
     , fromByronHash
     , fromChainHash
     , fromGenesisData

--- a/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -14,7 +13,6 @@
 -- License: Apache-2.0
 --
 -- Conversion functions and static chain settings for Byron.
-
 module Cardano.Wallet.Byron.Compatibility
     ( -- * Chain Parameters
       mainnetNetworkParameters
@@ -25,7 +23,6 @@ module Cardano.Wallet.Byron.Compatibility
     , genesisBlockFromTxOuts
 
       -- * Conversions
-    , fromByronBlock
     , fromGenesisData
     , byronCodecConfig
     , fromProtocolMagicId
@@ -37,10 +34,6 @@ module Cardano.Wallet.Byron.Compatibility
 
 import Prelude
 
-import Cardano.Chain.Block
-    ( ABlockOrBoundary (..)
-    , blockTxPayload
-    )
 import Cardano.Chain.Common
     ( BlockCount (..)
     , Lovelace
@@ -61,7 +54,6 @@ import Cardano.Chain.Update
     )
 import Cardano.Chain.UTxO
     ( TxOut (..)
-    , unTxPayload
     )
 import Cardano.Crypto.ProtocolMagic
     ( ProtocolMagicId
@@ -93,17 +85,12 @@ import Data.Time.Clock.POSIX
     )
 import Data.Word
     ( Word16
-    , Word32
     )
 import Numeric.Natural
     ( Natural
     )
-import Ouroboros.Consensus.Block.Abstract
-    ( headerPrevHash
-    )
 import Ouroboros.Consensus.Byron.Ledger
     ( ByronBlock (..)
-    , ByronHash (..)
     )
 import Ouroboros.Consensus.Byron.Ledger.Config
     ( CodecConfig (..)
@@ -112,9 +99,7 @@ import Ouroboros.Consensus.HardFork.History.Summary
     ( Bound (..)
     )
 import Ouroboros.Network.Block
-    ( BlockNo (..)
-    , ChainHash
-    , SlotNo (..)
+    ( SlotNo (..)
     )
 
 import qualified Cardano.Chain.Update as Update
@@ -139,45 +124,52 @@ import qualified Ouroboros.Consensus.Block as O
 -- Chain Parameters
 
 mainnetNetworkParameters :: W.NetworkParameters
-mainnetNetworkParameters = W.NetworkParameters
-    { genesisParameters = W.GenesisParameters
-        { getGenesisBlockHash = W.Hash $ unsafeFromHex
-            "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
-        , getGenesisBlockDate =
-            W.StartTime $ posixSecondsToUTCTime 1_506_203_091
+mainnetNetworkParameters =
+    W.NetworkParameters
+        { genesisParameters =
+            W.GenesisParameters
+                { getGenesisBlockHash =
+                    W.Hash
+                        $ unsafeFromHex
+                            "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
+                , getGenesisBlockDate =
+                    W.StartTime $ posixSecondsToUTCTime 1_506_203_091
+                }
+        , slottingParameters =
+            W.SlottingParameters
+                { getSlotLength =
+                    W.SlotLength 20
+                , getEpochLength =
+                    W.EpochLength 21_600
+                , getActiveSlotCoefficient =
+                    W.ActiveSlotCoefficient 1.0
+                , getSecurityParameter =
+                    Quantity 2_160
+                }
+        , protocolParameters =
+            W.ProtocolParameters
+                { decentralizationLevel =
+                    minBound
+                , txParameters =
+                    W.TxParameters
+                        { getFeePolicy =
+                            W.LinearFee
+                                $ W.LinearFunction{intercept = 155_381, slope = 43.946}
+                        , getTxMaxSize =
+                            Quantity 4_096
+                        , getTokenBundleMaxSize = maryTokenBundleMaxSize
+                        , getMaxExecutionUnits = W.ExecutionUnits 0 0
+                        }
+                , desiredNumberOfStakePools = 0
+                , stakeKeyDeposit = W.Coin 0
+                , eras = W.emptyEraInfo
+                , -- Collateral inputs were not supported or required in Byron:
+                  maximumCollateralInputCount = 0
+                , minimumCollateralPercentage = 0
+                , executionUnitPrices = Nothing
+                , currentLedgerProtocolParameters = Write.InNonRecentEraByron
+                }
         }
-    , slottingParameters = W.SlottingParameters
-        { getSlotLength =
-            W.SlotLength 20
-        , getEpochLength =
-            W.EpochLength 21_600
-        , getActiveSlotCoefficient =
-            W.ActiveSlotCoefficient 1.0
-        , getSecurityParameter =
-            Quantity 2_160
-        }
-    , protocolParameters = W.ProtocolParameters
-        { decentralizationLevel =
-            minBound
-        , txParameters = W.TxParameters
-            { getFeePolicy =
-                W.LinearFee $
-                    W.LinearFunction { intercept = 155_381, slope = 43.946 }
-            , getTxMaxSize =
-                Quantity 4_096
-            , getTokenBundleMaxSize = maryTokenBundleMaxSize
-            , getMaxExecutionUnits = W.ExecutionUnits 0 0
-            }
-        , desiredNumberOfStakePools = 0
-        , stakeKeyDeposit = W.Coin 0
-        , eras = W.emptyEraInfo
-        -- Collateral inputs were not supported or required in Byron:
-        , maximumCollateralInputCount = 0
-        , minimumCollateralPercentage = 0
-        , executionUnitPrices = Nothing
-        , currentLedgerProtocolParameters = Write.InNonRecentEraByron
-        }
-    }
 
 -- | The max size of token bundles hard-coded in Mary.
 --
@@ -198,20 +190,22 @@ maryTokenBundleMaxSize = W.TokenBundleMaxSize $ W.TxSize 4_000
 -- This assumption is _true_ for any user using HD wallets (sequential or
 -- random) which means, any user of cardano-wallet.
 emptyGenesis :: W.GenesisParameters -> W.Block
-emptyGenesis gp = W.Block
-    { transactions = []
-    , delegations  = []
-    , header = W.BlockHeader
-        { slotNo =
-            W.SlotNo 0
-        , blockHeight =
-            Quantity 0
-        , headerHash =
-            coerce $ W.getGenesisBlockHash gp
-        , parentHeaderHash =
-            Nothing
+emptyGenesis gp =
+    W.Block
+        { transactions = []
+        , delegations = []
+        , header =
+            W.BlockHeader
+                { slotNo =
+                    W.SlotNo 0
+                , blockHeight =
+                    Quantity 0
+                , headerHash =
+                    coerce $ W.getGenesisBlockHash gp
+                , parentHeaderHash =
+                    Nothing
+                }
         }
-    }
 
 --------------------------------------------------------------------------------
 --
@@ -222,33 +216,36 @@ emptyGenesis gp = W.Block
 -- The genesis data on haskell nodes is not a block at all, unlike the block0 on
 -- jormungandr. This function is a method to deal with the discrepancy.
 genesisBlockFromTxOuts :: W.GenesisParameters -> [W.TxOut] -> W.Block
-genesisBlockFromTxOuts gp outs = W.Block
-    { delegations  = []
-    , header = W.BlockHeader
-        { slotNo =
-            SlotNo 0
-        , blockHeight =
-            Quantity 0
-        , headerHash =
-            coerce $ W.getGenesisBlockHash gp
-        , parentHeaderHash =
-            Nothing
+genesisBlockFromTxOuts gp outs =
+    W.Block
+        { delegations = []
+        , header =
+            W.BlockHeader
+                { slotNo =
+                    SlotNo 0
+                , blockHeight =
+                    Quantity 0
+                , headerHash =
+                    coerce $ W.getGenesisBlockHash gp
+                , parentHeaderHash =
+                    Nothing
+                }
+        , transactions = mkTx <$> outs
         }
-    , transactions = mkTx <$> outs
-    }
   where
-    mkTx out@(W.TxOut (W.Address bytes) _) = W.Tx
-        { txId = W.Hash $ blake2b256 bytes
-        , txCBOR = Nothing
-        , fee = Nothing
-        , resolvedInputs = []
-        , resolvedCollateralInputs = []
-        , outputs = [out]
-        , collateralOutput = Nothing
-        , withdrawals = mempty
-        , metadata = Nothing
-        , scriptValidity = Nothing
-        }
+    mkTx out@(W.TxOut (W.Address bytes) _) =
+        W.Tx
+            { txId = W.Hash $ blake2b256 bytes
+            , txCBOR = Nothing
+            , fee = Nothing
+            , resolvedInputs = []
+            , resolvedCollateralInputs = []
+            , outputs = [out]
+            , collateralOutput = Nothing
+            , withdrawals = mempty
+            , metadata = Nothing
+            , scriptValidity = Nothing
+            }
 
 --------------------------------------------------------------------------------
 --
@@ -262,56 +259,13 @@ byronCodecConfig :: W.SlottingParameters -> CodecConfig ByronBlock
 byronCodecConfig W.SlottingParameters{getEpochLength} =
     ByronCodecConfig (toEpochSlots getEpochLength)
 
-fromByronBlock :: W.GenesisParameters -> ByronBlock -> W.Block
-fromByronBlock gp byronBlk = case byronBlockRaw byronBlk of
-  ABOBBlock blk  ->
-    mkBlock $ fromTxAux <$> unTxPayload (blockTxPayload blk)
-  ABOBBoundary _ ->
-    mkBlock []
-  where
-    mkBlock :: [W.Tx] -> W.Block
-    mkBlock txs = W.Block
-        { header = toByronBlockHeader gp byronBlk
-        , transactions = txs
-        , delegations  = []
-        }
-
-toByronBlockHeader
-    :: W.GenesisParameters
-    -> ByronBlock
-    -> W.BlockHeader
-toByronBlockHeader gp blk = W.BlockHeader
-    { slotNo =
-        O.blockSlot blk
-    , blockHeight =
-        fromBlockNo $ O.blockNo blk
-    , headerHash =
-        fromByronHash $ O.blockHash blk
-    , parentHeaderHash = Just $
-        fromChainHash (W.getGenesisBlockHash gp) $
-        headerPrevHash (O.getHeader blk)
-    }
-
-fromByronHash :: ByronHash -> W.Hash "BlockHeader"
-fromByronHash =
-    W.Hash . CC.hashToBytes . unByronHash
-
-fromChainHash :: W.Hash "Genesis" -> ChainHash ByronBlock -> W.Hash "BlockHeader"
-fromChainHash genesisHash = \case
-    O.GenesisHash -> coerce genesisHash
-    O.BlockHash h -> fromByronHash h
-
--- FIXME unsafe conversion (Word64 -> Word32)
-fromBlockNo :: BlockNo -> Quantity "block" Word32
-fromBlockNo (BlockNo h) =
-    Quantity (fromIntegral h)
-
 fromTxFeePolicy :: TxFeePolicy -> W.FeePolicy
 fromTxFeePolicy (TxFeePolicyTxSizeLinear (TxSizeLinear a b)) =
-    W.LinearFee $ W.LinearFunction
-        { intercept = lovelaceToDouble a
-        , slope = rationalToDouble b
-        }
+    W.LinearFee
+        $ W.LinearFunction
+            { intercept = lovelaceToDouble a
+            , slope = rationalToDouble b
+            }
   where
     lovelaceToDouble :: Lovelace -> Double
     lovelaceToDouble = fromIntegral . unsafeGetLovelace
@@ -321,7 +275,7 @@ fromTxFeePolicy (TxFeePolicyTxSizeLinear (TxSizeLinear a b)) =
 
 fromSlotDuration :: Natural -> W.SlotLength
 fromSlotDuration =
-    W.SlotLength . toEnum . (*1_000_000_000) . fromIntegral
+    W.SlotLength . toEnum . (* 1_000_000_000) . fromIntegral
 
 -- NOTE: Unsafe conversion from Word64 -> Word32 here.
 --
@@ -342,17 +296,18 @@ protocolParametersFromPP
 protocolParametersFromPP eraInfo pp =
     W.ProtocolParameters
         { decentralizationLevel = minBound
-        , txParameters = W.TxParameters
-            { getFeePolicy = fromTxFeePolicy $ Update.ppTxFeePolicy pp
-            , getTxMaxSize = fromMaxSize $ Update.ppMaxTxSize pp
-            , getTokenBundleMaxSize = maryTokenBundleMaxSize
-            , getMaxExecutionUnits = W.ExecutionUnits 0 0
-            }
+        , txParameters =
+            W.TxParameters
+                { getFeePolicy = fromTxFeePolicy $ Update.ppTxFeePolicy pp
+                , getTxMaxSize = fromMaxSize $ Update.ppMaxTxSize pp
+                , getTokenBundleMaxSize = maryTokenBundleMaxSize
+                , getMaxExecutionUnits = W.ExecutionUnits 0 0
+                }
         , desiredNumberOfStakePools = 0
         , stakeKeyDeposit = W.Coin 0
         , eras = fromBound <$> eraInfo
-        -- Collateral inputs were not supported or required in Byron:
-        , maximumCollateralInputCount = 0
+        , -- Collateral inputs were not supported or required in Byron:
+          maximumCollateralInputCount = 0
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing
         , currentLedgerProtocolParameters = Write.InNonRecentEraByron
@@ -379,24 +334,28 @@ fromNonAvvmBalances (GenesisNonAvvmBalances m) =
 fromGenesisData :: (GenesisData, GenesisHash) -> (W.NetworkParameters, [W.TxOut])
 fromGenesisData (genesisData, genesisHash) =
     ( W.NetworkParameters
-        { genesisParameters = W.GenesisParameters
-            { getGenesisBlockHash =
-                W.Hash . CC.hashToBytes . unGenesisHash $ genesisHash
-            , getGenesisBlockDate =
-                W.StartTime . gdStartTime $ genesisData
-            }
-        , slottingParameters = W.SlottingParameters
-            { getSlotLength = fromSlotDuration . ppSlotDuration $
-                gdProtocolParameters genesisData
-            , getEpochLength = fromBlockCount . gdK $ genesisData
-            , getActiveSlotCoefficient = W.ActiveSlotCoefficient 1.0
-            , getSecurityParameter = Quantity . fromIntegral . unBlockCount $
-                gdK genesisData
-            }
+        { genesisParameters =
+            W.GenesisParameters
+                { getGenesisBlockHash =
+                    W.Hash . CC.hashToBytes . unGenesisHash $ genesisHash
+                , getGenesisBlockDate =
+                    W.StartTime . gdStartTime $ genesisData
+                }
+        , slottingParameters =
+            W.SlottingParameters
+                { getSlotLength =
+                    fromSlotDuration . ppSlotDuration
+                        $ gdProtocolParameters genesisData
+                , getEpochLength = fromBlockCount . gdK $ genesisData
+                , getActiveSlotCoefficient = W.ActiveSlotCoefficient 1.0
+                , getSecurityParameter =
+                    Quantity . fromIntegral . unBlockCount
+                        $ gdK genesisData
+                }
         , protocolParameters =
             -- emptyEraInfo contains no info about byron. Should we add it?
-            protocolParametersFromPP W.emptyEraInfo $
-                gdProtocolParameters genesisData
+            protocolParametersFromPP W.emptyEraInfo
+                $ gdProtocolParameters genesisData
         }
     , fromNonAvvmBalances . gdNonAvvmBalances $ genesisData
     )

--- a/lib/wallet/src/Cardano/Wallet/Pools.hs
+++ b/lib/wallet/src/Cardano/Wallet/Pools.hs
@@ -77,9 +77,6 @@ import Cardano.Pool.Types
     ( PoolId (..)
     , StakePoolsSummary (..)
     )
-import Cardano.Wallet.Byron.Compatibility
-    ( toByronBlockHeader
-    )
 import Cardano.Wallet.Network
     ( ChainFollowLog (..)
     , ChainFollower (..)
@@ -119,6 +116,9 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
+import Cardano.Wallet.Read.Primitive.Block.Header
+    ( getBlockHeader
+    )
 import Cardano.Wallet.Registry
     ( AfterThreadLog
     , traceAfterThread
@@ -134,9 +134,6 @@ import Cardano.Wallet.Shelley.Compatibility
     , getBabbageProducer
     , getConwayProducer
     , getProducer
-    , toBabbageBlockHeader
-    , toConwayBlockHeader
-    , toShelleyBlockHeader
     )
 import Cardano.Wallet.Unsafe
     ( unsafeMkPercentage
@@ -748,21 +745,7 @@ monitorStakePools tr (NetworkParameters gp sp _pp) genesisPools nl DBLayer{..} =
                 forEachShelleyBlock
                     (fromConwayBlock gp blk) (getConwayProducer blk)
 
-        forLastBlock = \case
-            BlockByron blk ->
-                putHeader (toByronBlockHeader gp blk)
-            BlockShelley blk ->
-                putHeader (toShelleyBlockHeader getGenesisBlockHash blk)
-            BlockAllegra blk ->
-                putHeader (toShelleyBlockHeader getGenesisBlockHash blk)
-            BlockMary blk ->
-                putHeader (toShelleyBlockHeader getGenesisBlockHash blk)
-            BlockAlonzo blk ->
-                putHeader (toShelleyBlockHeader getGenesisBlockHash blk)
-            BlockBabbage blk ->
-                putHeader (toBabbageBlockHeader getGenesisBlockHash blk)
-            BlockConway blk ->
-                putHeader (toConwayBlockHeader getGenesisBlockHash blk)
+        forLastBlock = putHeader . getBlockHeader getGenesisBlockHash
 
         forEachShelleyBlock (blk, certificates) poolId = do
             let header = view #header blk

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Block.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Block.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.Wallet.Read.Primitive.Block
+    ( primitiveBlock
+    , fromCardanoBlock
+    )
+where
+
+import Prelude hiding
+    ( id
+    , (.)
+    )
+
+import Cardano.Wallet.Read
+    ( Block
+    , ConsensusBlock
+    , fromConsensusBlock
+    )
+import Cardano.Wallet.Read.Block.Txs
+    ( getEraTransactions
+    )
+import Cardano.Wallet.Read.Eras
+    ( K
+    , applyEraFun
+    , extractEraValue
+    , (*.**)
+    )
+import Cardano.Wallet.Read.Eras.EraFun
+    ( CollectTuple (..)
+    , EraFun
+    , EraFunK (..)
+    , liftK
+    , mapOnEraFun
+    , (*&&&*)
+    , (*****)
+    )
+import Cardano.Wallet.Read.Primitive.Block.Header
+    ( primitiveBlockHeader
+    )
+import Cardano.Wallet.Read.Primitive.Tx
+    ( primitiveTx
+    )
+import Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
+    ( primitiveCertificates
+    )
+import Cardano.Wallet.Read.Tx.Certificates
+    ( getEraCertificates
+    )
+import Control.Category
+    ( Category (..)
+    )
+import Control.Error
+    ( partitionEithers
+    )
+
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Hash as W
+import qualified Cardano.Wallet.Primitive.Types.Tx as W
+
+-- | Compute a wallet primitive  'W.Block' from a ledger 'Block'
+primitiveBlock
+    :: W.Hash "Genesis"
+    -> EraFun Block (K (W.Block, [W.PoolCertificate]))
+primitiveBlock hg = fromEraFunK $ do
+    header <- EraFunK $ primitiveBlockHeader hg
+    (transactions, certificates) <- unzip <$> EraFunK getTxsAndCertificates
+    pure
+        $ let
+            (delegations, pools) = pickWalletCertificates $ concat certificates
+          in
+            ( W.Block header transactions delegations
+            , pools
+            )
+
+getTxsAndCertificates :: EraFun Block (K [(W.Tx, [W.Certificate])])
+getTxsAndCertificates =
+    liftK
+        $ mapOnEraFun collectTuple (primitiveTx ***** primitiveCertificates)
+            *.** (id *&&&* getEraCertificates)
+            *.** getEraTransactions
+
+pickWalletCertificates
+    :: [W.Certificate]
+    -> ([W.DelegationCertificate], [W.PoolCertificate])
+pickWalletCertificates xs = partitionEithers $ do
+    x <- xs
+    case x of
+        W.CertificateOfDelegation cert -> pure $ Left cert
+        W.CertificateOfPool cert -> pure $ Right cert
+        _otherCerts -> []
+
+fromCardanoBlock
+    :: W.Hash "Genesis"
+    -> ConsensusBlock
+    -> (W.Block, [W.PoolCertificate])
+fromCardanoBlock gp =
+    let primitiveBlock' = primitiveBlock gp
+    in  extractEraValue
+            . applyEraFun primitiveBlock'
+            . fromConsensusBlock

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Block/Header.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Block/Header.hs
@@ -1,0 +1,146 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.Wallet.Read.Primitive.Block.Header
+    ( getBlockHeader
+    )
+where
+
+import Prelude hiding
+    ( (.)
+    )
+
+import Cardano.Crypto.Hash.Class
+    ( hashToBytes
+    )
+import Cardano.Ledger.Crypto
+    ( StandardCrypto
+    )
+import Cardano.Wallet.Read
+    ( Block
+    , ConsensusBlock
+    , fromConsensusBlock
+    )
+import Cardano.Wallet.Read.Block.BlockNo
+    ( BlockNo (..)
+    , getEraBlockNo
+    )
+import Cardano.Wallet.Read.Block.HeaderHash
+    ( HeaderHash (..)
+    , HeaderHashT
+    , PrevHeaderHash (..)
+    , PrevHeaderHashT
+    , getEraHeaderHash
+    , getEraPrevHeaderHash
+    )
+import Cardano.Wallet.Read.Block.SlotNo
+    ( SlotNo (..)
+    , getEraSlotNo
+    )
+import Cardano.Wallet.Read.Eras
+    ( EraFun
+    , applyEraFun
+    , extractEraValue
+    )
+import Cardano.Wallet.Read.Eras.EraFun
+    ( EraFun (..)
+    , EraFunK (..)
+    )
+import Control.Category
+    ( (.)
+    )
+import Data.Coerce
+    ( coerce
+    )
+import Data.Quantity
+    ( Quantity (..)
+    )
+import Data.Word
+    ( Word32
+    )
+import Generics.SOP
+    ( K (..)
+    )
+import Ouroboros.Consensus.Byron.Ledger.Block
+    ( ByronHash (..)
+    )
+import Ouroboros.Consensus.Shelley.Protocol.Abstract
+    ( ShelleyHash (..)
+    )
+
+import qualified Cardano.Crypto.Hashing as CC
+import qualified Cardano.Protocol.TPraos.BHeader as SL
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Hash as W
+import qualified Ouroboros.Network.Block as O
+
+fromByronHash :: ByronHash -> W.Hash tag
+fromByronHash = W.Hash . CC.hashToBytes . unByronHash
+
+getBlockHeader :: W.Hash "Genesis" -> ConsensusBlock -> W.BlockHeader
+getBlockHeader gp =
+    extractEraValue
+        . applyEraFun (fromEraFunK $ getBlockHeaderEra gp)
+        . fromConsensusBlock
+
+getBlockHeaderEra :: W.Hash "Genesis" -> EraFunK Block W.BlockHeader
+getBlockHeaderEra gp =
+    W.BlockHeader
+        <$> (O.SlotNo . fromIntegral . unSlotNo <$> EraFunK getEraSlotNo)
+        <*> getEraBlockNoK
+        <*> EraFunK (primitiveHash . getEraHeaderHash)
+        <*> (Just <$> EraFunK (primitivePrevHash gp . getEraPrevHeaderHash))
+
+getEraBlockNoK :: EraFunK Block (Quantity "block" Word32)
+getEraBlockNoK = fromBlockNo <$> EraFunK getEraBlockNo
+  where
+    fromBlockNo (BlockNo h) = Quantity (fromIntegral h)
+
+primitiveHash :: EraFun HeaderHash (K (W.Hash "BlockHeader"))
+primitiveHash =
+    EraFun
+        { byronFun = \(HeaderHash h) -> K . fromByronHash $ h
+        , shelleyFun = mkHashShelley
+        , allegraFun = mkHashShelley
+        , maryFun = mkHashShelley
+        , alonzoFun = mkHashShelley
+        , babbageFun = mkHashShelley
+        , conwayFun = mkHashShelley
+        }
+  where
+    mkHashShelley
+        :: HeaderHashT era ~ ShelleyHash crypto
+        => HeaderHash era
+        -> K (W.Hash "BlockHeader") era
+    mkHashShelley (HeaderHash (ShelleyHash h)) = K . W.Hash . hashToBytes $ h
+
+primitivePrevHash
+    :: W.Hash "Genesis"
+    -> EraFun PrevHeaderHash (K (W.Hash "BlockHeader"))
+primitivePrevHash gp =
+    EraFun
+        { byronFun = \(PrevHeaderHash h) -> K . fromChainHash $ h
+        , shelleyFun = mkPrevHashShelley
+        , allegraFun = mkPrevHashShelley
+        , maryFun = mkPrevHashShelley
+        , alonzoFun = mkPrevHashShelley
+        , babbageFun = mkPrevHashShelley
+        , conwayFun = mkPrevHashShelley
+        }
+  where
+    mkPrevHashShelley
+        :: (SL.PrevHash StandardCrypto ~ PrevHeaderHashT era)
+        => PrevHeaderHash era
+        -> K (W.Hash "BlockHeader") era
+    mkPrevHashShelley (PrevHeaderHash h) = K . fromPrevHash $ h
+    genesisHash = coerce gp :: W.Hash "BlockHeader"
+    fromChainHash = \case
+        O.GenesisHash -> genesisHash
+        O.BlockHash h -> fromByronHash h
+    fromPrevHash
+        :: SL.PrevHash StandardCrypto
+        -> W.Hash "BlockHeader"
+    fromPrevHash = \case
+        SL.GenesisHash -> genesisHash
+        SL.BlockHash (SL.HashHeader h) -> W.Hash (hashToBytes h)

--- a/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Certificates.hs
+++ b/lib/wallet/src/Cardano/Wallet/Read/Primitive/Tx/Features/Certificates.hs
@@ -6,15 +6,13 @@
 -- |
 -- Copyright: © 2020 IOHK
 -- License: Apache-2.0
---
-
 module Cardano.Wallet.Read.Primitive.Tx.Features.Certificates
-    ( certificates
+    ( primitiveCertificates
     , anyEraCerts
     , fromStakeCredential
     , fromConwayCerts
     )
- where
+where
 
 import Prelude
 
@@ -94,18 +92,21 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
 import qualified Data.Set as Set
 
-certificates :: EraFun Certificates (K [W.Certificate])
-certificates = EraFun
-    { byronFun = const $ K []
-    , shelleyFun = mkShelleyCertsK
-    , allegraFun = mkShelleyCertsK
-    , maryFun = mkShelleyCertsK
-    , alonzoFun = mkShelleyCertsK
-    , babbageFun = mkShelleyCertsK
-    , conwayFun = mkConwayCertsK
-    }
+-- | Compute wallet primitive certificates from ledger certificates
+primitiveCertificates :: EraFun Certificates (K [W.Certificate])
+primitiveCertificates =
+    EraFun
+        { byronFun = const $ K []
+        , shelleyFun = mkShelleyCertsK
+        , allegraFun = mkShelleyCertsK
+        , maryFun = mkShelleyCertsK
+        , alonzoFun = mkShelleyCertsK
+        , babbageFun = mkShelleyCertsK
+        , conwayFun = mkConwayCertsK
+        }
 
-mkConwayCertsK :: Certificates ConwayEra
+mkConwayCertsK
+    :: Certificates ConwayEra
     -> K [W.Certificate] ConwayEra
 mkConwayCertsK (Certificates cs) = K $ fromConwayCerts <$> toList cs
 
@@ -115,14 +116,15 @@ fromConwayCerts = \case
         ConwayDeleg _cre _del _co -> error "TODO: ConwayDeleg, ADP-3065"
         ConwayReDeleg _cre _del -> error "TODO: ConwayReDeleg, ADP-3065"
         ConwayUnDeleg cre _co -> mkDelegationNone cre
-            -- "TODO: ConwayUnDeleg, ADP-3065"
+    -- "TODO: ConwayUnDeleg, ADP-3065"
     ConwayDCertPool pc -> case pc of
         RegPool pp -> mkPoolRegistrationCertificate pp
         RetirePool kh en -> mkPoolRetirementCertificate kh en
     ConwayDCertConstitutional _cdc ->
         error "TODO: ConwayDCertConstitutional, ADP-3065"
 
-mkShelleyCertsK :: (Foldable t, CertificatesType era ~ t (DCert crypto))
+mkShelleyCertsK
+    :: (Foldable t, CertificatesType era ~ t (DCert crypto))
     => Certificates era
     -> K [W.Certificate] b
 mkShelleyCertsK (Certificates cs) = K . anyEraCerts $ cs
@@ -147,10 +149,12 @@ mkPoolRegistrationCertificate pp =
 
 mkPoolRetirementCertificate :: (SL.KeyHash rol sc) -> EpochNo -> W.Certificate
 mkPoolRetirementCertificate pid (EpochNo e) =
-    W.CertificateOfPool $ Retirement $ PoolRetirementCertificate
-        { poolId = fromPoolKeyHash pid
-        , retirementEpoch = W.EpochNo $ fromIntegral e
-        }
+    W.CertificateOfPool
+        $ Retirement
+        $ PoolRetirementCertificate
+            { poolId = fromPoolKeyHash pid
+            , retirementEpoch = W.EpochNo $ fromIntegral e
+            }
 
 mkRegisterKeyCertificate :: SL.Credential 'SL.Staking crypto -> W.Certificate
 mkRegisterKeyCertificate =
@@ -159,30 +163,26 @@ mkRegisterKeyCertificate =
         . fromStakeCredential
 
 mkDelegationNone :: SL.Credential 'SL.Staking crypto -> W.Certificate
-mkDelegationNone credentials = W.CertificateOfDelegation
-    $ W.CertDelegateNone (fromStakeCredential credentials)
+mkDelegationNone credentials =
+    W.CertificateOfDelegation
+        $ W.CertDelegateNone (fromStakeCredential credentials)
 
 fromShelleyCert
     :: SL.DCert crypto
     -> W.Certificate
 fromShelleyCert = \case
-    SL.DCertDeleg (SL.Delegate delegation)  ->
-        W.CertificateOfDelegation $ W.CertDelegateFull
-            (fromStakeCredential (SL.dDelegator delegation))
-            (fromPoolKeyHash (SL.dDelegatee delegation))
-
+    SL.DCertDeleg (SL.Delegate delegation) ->
+        W.CertificateOfDelegation
+            $ W.CertDelegateFull
+                (fromStakeCredential (SL.dDelegator delegation))
+                (fromPoolKeyHash (SL.dDelegatee delegation))
     SL.DCertDeleg (SL.DeRegKey credentials) -> mkDelegationNone credentials
-
     SL.DCertDeleg (SL.RegKey cred) -> mkRegisterKeyCertificate cred
-
     SL.DCertPool (SL.RegPool pp) -> mkPoolRegistrationCertificate pp
-
     SL.DCertPool (SL.RetirePool pid en) ->
         mkPoolRetirementCertificate pid en
-
     SL.DCertGenesis{} -> W.CertificateOther W.GenesisCertificate
-
-    SL.DCertMir{}     -> W.CertificateOther W.MIRCertificate
+    SL.DCertMir{} -> W.CertificateOther W.MIRCertificate
 
 fromPoolMetadata :: SL.PoolMetadata -> (StakePoolMetadataUrl, StakePoolMetadataHash)
 fromPoolMetadata meta =
@@ -194,7 +194,6 @@ fromPoolMetadata meta =
 --
 -- Unlike with Jörmungandr, the reward account payload doesn't represent a
 -- public key but a HASH of a public key.
---
 fromStakeCredential :: SL.Credential 'SL.Staking crypto -> W.RewardAccount
 fromStakeCredential = \case
     SL.ScriptHashObj (SL.ScriptHash h) ->
@@ -214,8 +213,9 @@ fromUnitInterval :: HasCallStack => SL.UnitInterval -> Percentage
 fromUnitInterval x =
     either bomb id . mkPercentage . toRational . SL.unboundRational $ x
   where
-    bomb = internalError $
-        "fromUnitInterval: encountered invalid parameter value: "+||x||+""
+    bomb =
+        internalError
+            $ "fromUnitInterval: encountered invalid parameter value: " +|| x ||+ ""
 
 toWalletCoin :: HasCallStack => SL.Coin -> W.Coin
 toWalletCoin (SL.Coin c) = Coin.unsafeFromIntegral c

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -101,7 +101,6 @@ module Cardano.Wallet.Shelley.Compatibility
     , optimumNumberOfPools
     , getProducer
     , fromBlockNo
-    , fromCardanoBlock
     , toCardanoEra
     , fromShelleyHash
     , fromShelleyTxOut
@@ -112,13 +111,7 @@ module Cardano.Wallet.Shelley.Compatibility
     , fromTip
     , fromTip'
     , toTip
-    , fromShelleyBlock
-    , fromAllegraBlock
     , slottingParametersFromGenesis
-    , fromMaryBlock
-    , fromAlonzoBlock
-    , fromBabbageBlock
-    , fromConwayBlock
     , getBabbageProducer
     , getConwayProducer
 
@@ -236,8 +229,7 @@ import Cardano.Wallet.Address.Encoding
     ( fromStakeCredential
     )
 import Cardano.Wallet.Byron.Compatibility
-    ( fromByronBlock
-    , fromTxAux
+    ( fromTxAux
     , maryTokenBundleMaxSize
     )
 import Cardano.Wallet.Primitive.Types
@@ -247,18 +239,6 @@ import Cardano.Wallet.Primitive.Types
     , ProtocolParameters (txParameters)
     , TxParameters (getTokenBundleMaxSize)
     )
-import Cardano.Wallet.Read.Primitive.Tx.Allegra
-    ( fromAllegraTx
-    )
-import Cardano.Wallet.Read.Primitive.Tx.Alonzo
-    ( fromAlonzoTx
-    )
-import Cardano.Wallet.Read.Primitive.Tx.Babbage
-    ( fromBabbageTx
-    )
-import Cardano.Wallet.Read.Primitive.Tx.Conway
-    ( fromConwayTx
-    )
 import Cardano.Wallet.Read.Primitive.Tx.Features.Inputs
     ( fromShelleyTxIn
     )
@@ -267,17 +247,8 @@ import Cardano.Wallet.Read.Primitive.Tx.Features.Outputs
     , fromShelleyAddress
     , fromShelleyTxOut
     )
-import Cardano.Wallet.Read.Primitive.Tx.Mary
-    ( fromMaryTx
-    )
-import Cardano.Wallet.Read.Primitive.Tx.Shelley
-    ( fromShelleyTx
-    )
 import Cardano.Wallet.Read.Tx.Hash
     ( fromShelleyTxId
-    )
-import Cardano.Wallet.Transaction
-    ( WitnessCountCtx (..)
     )
 import Cardano.Wallet.Unsafe
     ( unsafeIntToWord
@@ -317,15 +288,9 @@ import Data.Coerce
 import Data.Either.Extra
     ( eitherToMaybe
     )
-import Data.Foldable
-    ( toList
-    )
 import Data.IntCast
     ( intCast
     , intCastMaybe
-    )
-import Data.List
-    ( unzip6
     )
 import Data.Map.Strict
     ( Map
@@ -385,8 +350,7 @@ import Ouroboros.Consensus.Shelley.Eras
     ( StandardCrypto
     )
 import Ouroboros.Consensus.Shelley.Ledger
-    ( ShelleyCompatible
-    , ShelleyHash (..)
+    ( ShelleyHash (..)
     )
 import Ouroboros.Consensus.Shelley.Ledger.Block
     ( ShelleyBlock (..)
@@ -412,8 +376,6 @@ import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Ledger.Address as SL
-import qualified Cardano.Ledger.Allegra as Allegra
-import qualified Cardano.Ledger.Alonzo as Alonzo
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxSeq as Alonzo
@@ -425,8 +387,6 @@ import qualified Cardano.Ledger.Conway as Conway
 import qualified Cardano.Ledger.Credential as SL
 import qualified Cardano.Ledger.Crypto as SL
 import qualified Cardano.Ledger.Keys as Ledger
-import qualified Cardano.Ledger.Mary as Mary
-import qualified Cardano.Ledger.Shelley as Shelley
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Ledger.Shelley.API as SLAPI
 import qualified Cardano.Ledger.Shelley.BlockChain as SL
@@ -468,7 +428,6 @@ import qualified Ouroboros.Consensus.Protocol.Praos as Consensus
 import qualified Ouroboros.Consensus.Protocol.Praos.Header as Consensus
 import qualified Ouroboros.Consensus.Protocol.TPraos as Consensus
 import qualified Ouroboros.Consensus.Shelley.Ledger as O
-import qualified Ouroboros.Consensus.Shelley.Protocol.Abstract as Consensus
 import qualified Ouroboros.Network.Block as O
 import qualified Ouroboros.Network.Point as Point
 
@@ -524,59 +483,6 @@ fromPoint :: O.Point (CardanoBlock sc) -> W.ChainPoint
 fromPoint O.GenesisPoint = ChainPointAtGenesis
 fromPoint (O.BlockPoint slot h) = ChainPoint slot (fromCardanoHash h)
 
-toShelleyBlockHeader
-    :: (ShelleyCompatible (Consensus.TPraos StandardCrypto) era)
-    => W.Hash "Genesis"
-    -> ShelleyBlock (Consensus.TPraos StandardCrypto) era
-    -> W.BlockHeader
-toShelleyBlockHeader genesisHash blk =
-    let
-        ShelleyBlock (SL.Block header _txSeq) _headerHash = blk
-    in
-        W.BlockHeader
-            { slotNo =
-                Consensus.pHeaderSlot header
-            , blockHeight =
-                fromBlockNo $ Consensus.pHeaderBlock header
-            , headerHash =
-                fromShelleyHash $ Consensus.pHeaderHash header
-            , parentHeaderHash = Just $
-                fromPrevHash (coerce genesisHash) $
-                    Consensus.pHeaderPrevHash header
-            }
-
-toBabbageBlockHeader
-    :: (ShelleyCompatible (Consensus.Praos StandardCrypto) era)
-    => W.Hash "Genesis"
-    -> ShelleyBlock (Consensus.Praos StandardCrypto) era
-    -> W.BlockHeader
-toBabbageBlockHeader genesisHash blk =
-    W.BlockHeader
-        { slotNo = Consensus.pHeaderSlot header
-        , blockHeight = fromBlockNo $ Consensus.pHeaderBlock header
-        , headerHash = fromShelleyHash $ Consensus.pHeaderHash header
-        , parentHeaderHash = Just $ fromPrevHash (coerce genesisHash) $
-            Consensus.pHeaderPrevHash header
-        }
-  where
-    ShelleyBlock (SL.Block header _txSeq) _headerHash = blk
-
-toConwayBlockHeader
-    :: (ShelleyCompatible (Consensus.Praos StandardCrypto) era)
-    => W.Hash "Genesis"
-    -> ShelleyBlock (Consensus.Praos StandardCrypto) era
-    -> W.BlockHeader
-toConwayBlockHeader genesisHash blk =
-    W.BlockHeader
-        { slotNo = Consensus.pHeaderSlot header
-        , blockHeight = fromBlockNo $ Consensus.pHeaderBlock header
-        , headerHash = fromShelleyHash $ Consensus.pHeaderHash header
-        , parentHeaderHash = Just $ fromPrevHash (coerce genesisHash) $
-            Consensus.pHeaderPrevHash header
-        }
-  where
-    ShelleyBlock (SL.Block header _txSeq) _headerHash = blk
-
 getProducer
     :: (Era era, EncCBORGroup (TxSeq era))
     => ShelleyBlock (Consensus.TPraos StandardCrypto) era -> PoolId
@@ -594,26 +500,6 @@ getConwayProducer
     => ShelleyBlock (Consensus.Praos StandardCrypto) era -> PoolId
 getConwayProducer (ShelleyBlock (SL.Block (Consensus.Header header _) _) _) =
     fromPoolKeyHash $ SL.hashKey (Consensus.hbVk header)
-
-fromCardanoBlock
-    :: W.GenesisParameters
-    -> CardanoBlock StandardCrypto
-    -> W.Block
-fromCardanoBlock gp = \case
-    BlockByron blk ->
-        fromByronBlock gp blk
-    BlockShelley blk ->
-        fst $ fromShelleyBlock gp blk
-    BlockAllegra blk ->
-        fst $ fromAllegraBlock gp blk
-    BlockMary blk ->
-        fst $ fromMaryBlock gp blk
-    BlockAlonzo blk ->
-        fst $ fromAlonzoBlock gp blk
-    BlockBabbage blk ->
-        fst $ fromBabbageBlock gp blk
-    BlockConway blk ->
-        fst $ fromConwayBlock gp blk
 
 numberOfTransactionsInBlock
     :: CardanoBlock StandardCrypto -> (Int, (Quantity "block" Word32, O.SlotNo))
@@ -688,137 +574,6 @@ toCardanoEra = \case
     BlockAlonzo{}  -> AnyCardanoEra AlonzoEra
     BlockBabbage{} -> AnyCardanoEra BabbageEra
     BlockConway{}  -> AnyCardanoEra ConwayEra
-
-fromShelleyBlock
-    :: W.GenesisParameters
-    -> ShelleyBlock
-        (Consensus.TPraos StandardCrypto)
-        (Shelley.ShelleyEra StandardCrypto)
-    -> (W.Block, [PoolCertificate])
-fromShelleyBlock gp blk@(ShelleyBlock (SL.Block _ (SL.ShelleyTxSeq txs')) _) =
-    let
-       (txs, certs, _, _, _, _) = unzip6 $ map fromShelleyTx $ toList txs'
-       certs' = mconcat certs
-    in
-        ( W.Block
-            { header = toShelleyBlockHeader (W.getGenesisBlockHash gp) blk
-            , transactions = txs
-            , delegations  = toDelegationCertificates certs'
-            }
-        , toPoolCertificates certs'
-        )
-
-fromAllegraBlock
-    :: W.GenesisParameters
-    -> ShelleyBlock
-        (Consensus.TPraos StandardCrypto)
-        (Allegra.AllegraEra StandardCrypto)
-    -> (W.Block, [PoolCertificate])
-fromAllegraBlock gp blk@(ShelleyBlock (SL.Block _ (SL.ShelleyTxSeq txs')) _) =
-    let
-       (txs, certs, _, _, _, _) = unzip6 $ map fromAllegraTx $ toList txs'
-       certs' = mconcat certs
-    in
-        ( W.Block
-            { header = toShelleyBlockHeader (W.getGenesisBlockHash gp) blk
-            , transactions = txs
-            , delegations  = toDelegationCertificates certs'
-            }
-        , toPoolCertificates certs'
-        )
-
-fromMaryBlock
-    :: W.GenesisParameters
-    -> ShelleyBlock
-        (Consensus.TPraos StandardCrypto)
-        (Mary.MaryEra StandardCrypto)
-    -> (W.Block, [PoolCertificate])
-fromMaryBlock gp blk@(ShelleyBlock (SL.Block _ (SL.ShelleyTxSeq txs')) _) =
-    let
-       (txs, certs, _, _, _, _) = unzip6 $
-           map (`fromMaryTx` AnyWitnessCountCtx) $ toList txs'
-       certs' = mconcat certs
-    in
-        ( W.Block
-            { header = toShelleyBlockHeader (W.getGenesisBlockHash gp) blk
-            , transactions = txs
-            , delegations  = toDelegationCertificates certs'
-            }
-        , toPoolCertificates certs'
-        )
-
--- TODO: We could use the cardano-api `Block` pattern to very elegently get the
--- header and txs of any era block.
---
--- We would need to remove the previous block hash from our `W.BlockHeader`,
--- which shouldn't be needed modulo some hacks w.r.t. the genesis point which
--- would need to be cleaned up too. We probably will need to use `Point block`,
--- in all chain followers (including the DBLayer).
-fromAlonzoBlock
-    :: ShelleyCompatible
-        (Consensus.TPraos StandardCrypto)
-        (Alonzo.AlonzoEra StandardCrypto)
-    => W.GenesisParameters
-    -> ShelleyBlock
-        (Consensus.TPraos StandardCrypto)
-        (Alonzo.AlonzoEra StandardCrypto)
-    -> (W.Block, [PoolCertificate])
-fromAlonzoBlock gp blk@(ShelleyBlock (SL.Block _ txSeq) _) =
-    let
-        Alonzo.AlonzoTxSeq txs' = txSeq
-        (txs, certs, _, _, _, _) = unzip6 $
-            map (`fromAlonzoTx` AnyWitnessCountCtx) $ toList txs'
-        certs' = mconcat certs
-    in
-        ( W.Block
-            { header = toShelleyBlockHeader (W.getGenesisBlockHash gp) blk
-            , transactions = txs
-            , delegations  = toDelegationCertificates certs'
-            }
-        , toPoolCertificates certs'
-        )
-
-fromBabbageBlock
-    :: W.GenesisParameters
-    -> ShelleyBlock
-        (Consensus.Praos StandardCrypto)
-        (Babbage.BabbageEra StandardCrypto)
-    -> (W.Block, [PoolCertificate])
-fromBabbageBlock gp blk@(ShelleyBlock (SL.Block _ txSeq) _) =
-    let
-        Alonzo.AlonzoTxSeq txs' = txSeq
-        (txs, certs, _, _, _, _) = unzip6 $
-            map (`fromBabbageTx` AnyWitnessCountCtx) $ toList txs'
-        certs' = mconcat certs
-    in
-        ( W.Block
-            { header = toBabbageBlockHeader (W.getGenesisBlockHash gp) blk
-            , transactions = txs
-            , delegations  = toDelegationCertificates certs'
-            }
-        , toPoolCertificates certs'
-        )
-
-fromConwayBlock
-    :: W.GenesisParameters
-    -> ShelleyBlock
-        (Consensus.Praos StandardCrypto)
-        (Conway.ConwayEra StandardCrypto)
-    -> (W.Block, [PoolCertificate])
-fromConwayBlock gp blk@(ShelleyBlock (SL.Block _ txSeq) _) =
-    let
-        Alonzo.AlonzoTxSeq txs' = txSeq
-        (txs, certs, _, _, _, _) = unzip6 $
-            map (`fromConwayTx` AnyWitnessCountCtx) $ toList txs'
-        certs' = mconcat certs
-    in
-        ( W.Block
-            { header = toConwayBlockHeader (W.getGenesisBlockHash gp) blk
-            , transactions = txs
-            , delegations  = toDelegationCertificates certs'
-            }
-        , toPoolCertificates certs'
-        )
 
 fromShelleyHash :: ShelleyHash crypto -> W.Hash "BlockHeader"
 fromShelleyHash (ShelleyHash h) = W.Hash (hashToBytes h)
@@ -1296,24 +1051,6 @@ fromCardanoLovelace =
     Coin.unsafeFromIntegral . unQuantity . Cardano.lovelaceToQuantity
   where
     unQuantity (Cardano.Quantity q) = q
-
-toDelegationCertificates
-    :: [W.Certificate]
-    -> [W.DelegationCertificate]
-toDelegationCertificates = mapMaybe isDelCert
-  where
-      isDelCert = \case
-          W.CertificateOfDelegation cert -> Just cert
-          _ -> Nothing
-
-toPoolCertificates
-    :: [W.Certificate]
-    -> [PoolCertificate]
-toPoolCertificates = mapMaybe isPoolCert
-  where
-      isPoolCert = \case
-          W.CertificateOfPool cert -> Just cert
-          _ -> Nothing
 
 toWalletCoin :: HasCallStack => SL.Coin -> W.Coin
 toWalletCoin (SL.Coin c) = Coin.unsafeFromIntegral c

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -102,7 +102,6 @@ module Cardano.Wallet.Shelley.Compatibility
     , getProducer
     , fromBlockNo
     , toCardanoEra
-    , fromShelleyHash
     , fromShelleyTxOut
     , fromCardanoHash
     , fromChainHash
@@ -349,9 +348,6 @@ import Ouroboros.Consensus.HardFork.History.Summary
 import Ouroboros.Consensus.Shelley.Eras
     ( StandardCrypto
     )
-import Ouroboros.Consensus.Shelley.Ledger
-    ( ShelleyHash (..)
-    )
 import Ouroboros.Consensus.Shelley.Ledger.Block
     ( ShelleyBlock (..)
     )
@@ -574,9 +570,6 @@ toCardanoEra = \case
     BlockAlonzo{}  -> AnyCardanoEra AlonzoEra
     BlockBabbage{} -> AnyCardanoEra BabbageEra
     BlockConway{}  -> AnyCardanoEra ConwayEra
-
-fromShelleyHash :: ShelleyHash crypto -> W.Hash "BlockHeader"
-fromShelleyHash (ShelleyHash h) = W.Hash (hashToBytes h)
 
 fromCardanoHash :: O.HeaderHash (CardanoBlock sc) -> W.Hash "BlockHeader"
 fromCardanoHash = W.Hash . fromShort . getOneEraHash

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -103,7 +103,6 @@ module Cardano.Wallet.Shelley.Compatibility
     , fromBlockNo
     , fromCardanoBlock
     , toCardanoEra
-    , toCardanoBlockHeader
     , toShelleyBlockHeader
     , toBabbageBlockHeader
     , toConwayBlockHeader
@@ -243,7 +242,6 @@ import Cardano.Wallet.Byron.Compatibility
     ( fromByronBlock
     , fromTxAux
     , maryTokenBundleMaxSize
-    , toByronBlockHeader
     )
 import Cardano.Wallet.Primitive.Types
     ( ChainPoint (..)
@@ -528,26 +526,6 @@ toPoint (ChainPoint slot h) = O.BlockPoint slot (toCardanoHash h)
 fromPoint :: O.Point (CardanoBlock sc) -> W.ChainPoint
 fromPoint O.GenesisPoint = ChainPointAtGenesis
 fromPoint (O.BlockPoint slot h) = ChainPoint slot (fromCardanoHash h)
-
-toCardanoBlockHeader
-    :: W.GenesisParameters
-    -> CardanoBlock StandardCrypto
-    -> W.BlockHeader
-toCardanoBlockHeader gp = \case
-    BlockByron blk ->
-        toByronBlockHeader gp blk
-    BlockShelley blk ->
-        toShelleyBlockHeader (W.getGenesisBlockHash gp) blk
-    BlockAllegra blk ->
-        toShelleyBlockHeader (W.getGenesisBlockHash gp) blk
-    BlockMary blk ->
-        toShelleyBlockHeader (W.getGenesisBlockHash gp) blk
-    BlockAlonzo blk ->
-        toShelleyBlockHeader (W.getGenesisBlockHash gp) blk
-    BlockBabbage blk ->
-        toBabbageBlockHeader (W.getGenesisBlockHash gp) blk
-    BlockConway blk ->
-        toBabbageBlockHeader (W.getGenesisBlockHash gp) blk
 
 toShelleyBlockHeader
     :: (ShelleyCompatible (Consensus.TPraos StandardCrypto) era)

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -103,9 +103,6 @@ module Cardano.Wallet.Shelley.Compatibility
     , fromBlockNo
     , toCardanoEra
     , fromShelleyTxOut
-    , fromCardanoHash
-    , fromChainHash
-    , fromPrevHash
     , fromGenesisData
     , fromTip
     , fromTip'
@@ -353,7 +350,6 @@ import Ouroboros.Consensus.Shelley.Ledger.Block
     )
 import Ouroboros.Network.Block
     ( BlockNo (..)
-    , ChainHash
     , Point (..)
     , Tip (..)
     , getTipPoint
@@ -573,22 +569,6 @@ toCardanoEra = \case
 
 fromCardanoHash :: O.HeaderHash (CardanoBlock sc) -> W.Hash "BlockHeader"
 fromCardanoHash = W.Hash . fromShort . getOneEraHash
-
-fromPrevHash
-    :: W.Hash "BlockHeader"
-    -> SL.PrevHash crypto
-    -> W.Hash "BlockHeader"
-fromPrevHash genesisHash = \case
-    SL.GenesisHash -> genesisHash
-    SL.BlockHash (SL.HashHeader h) -> W.Hash (hashToBytes h)
-
-fromChainHash
-    :: W.Hash "Genesis"
-    -> ChainHash (CardanoBlock sc)
-    -> W.Hash "BlockHeader"
-fromChainHash genesisHash = \case
-    O.GenesisHash -> coerce genesisHash
-    O.BlockHash (OneEraHash h) -> W.Hash $ fromShort h
 
 -- FIXME unsafe conversion (Word64 -> Word32)
 fromBlockNo :: BlockNo -> Quantity "block" Word32
@@ -860,7 +840,8 @@ slottingParametersFromGenesis g =
         , getEpochLength =
             W.EpochLength . fromIntegral . unEpochSize $ sgEpochLength g
         , getActiveSlotCoefficient =
-            W.ActiveSlotCoefficient . fromRational . SL.unboundRational $ sgActiveSlotsCoeff g
+            W.ActiveSlotCoefficient . fromRational . SL.unboundRational
+                $ sgActiveSlotsCoeff g
         , getSecurityParameter =
             Quantity . fromIntegral $ sgSecurityParam g
         }

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -103,9 +103,6 @@ module Cardano.Wallet.Shelley.Compatibility
     , fromBlockNo
     , fromCardanoBlock
     , toCardanoEra
-    , toShelleyBlockHeader
-    , toBabbageBlockHeader
-    , toConwayBlockHeader
     , fromShelleyHash
     , fromShelleyTxOut
     , fromCardanoHash

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Network/Node.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Network/Node.hs
@@ -91,6 +91,9 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)
     )
+import Cardano.Wallet.Read.Primitive.Block.Header
+    ( getBlockHeader
+    )
 import Cardano.Wallet.Shelley.Compatibility
     ( StandardCrypto
     , fromAllegraPParams
@@ -108,7 +111,6 @@ import Cardano.Wallet.Shelley.Compatibility
     , nodeToClientVersions
     , optimumNumberOfPools
     , slottingParametersFromGenesis
-    , toCardanoBlockHeader
     , toCardanoEra
     , toLedgerStakeCredential
     , toPoint
@@ -487,7 +489,7 @@ withNodeNetworkLayerBase
                                 trFollowLog
                                 (_syncProgress interpreterVar)
                     withStats $ \trChainSyncLog -> do
-                        let mapB = toCardanoBlockHeader gp
+                        let mapB = getBlockHeader getGenesisBlockHash
                             mapP = fromPoint
                         let blockHeader = fromTip' gp
                         let client =


### PR DESCRIPTION
- [x] add block to primitive block era fun
- [x] encode `fromCardanoBlock` as an era dependent application

Benchmark note:

To prove that the change is not damaging performance too much I added a benchmark covering the translation from ledger block to primitive block that compares the previous version against the new one. Because the old version is not more accessible at the end of the PR, this is the link to the commit to checkout and re-run it https://github.com/cardano-foundation/cardano-wallet/pull/4192/commits/4a3c328a2970934ee30afe93e412185d95814a21 via  `cabal bench -O2 cardano-wallet:benchmark:era-fun`

ADP-3198 ADP-3217
