### PR TITLE
[ADP-3214] Trim `DBOpen` and add `getSchemaVersion`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -24,18 +24,15 @@ module Cardano.Wallet.DB.Layer
     , findDatabases
     , DBFactoryLog (..)
 
-    -- * Open a database
-    , withLoadDBLayerFromFile
-    , newDBOpenInMemory
-    , retrieveWalletId
-    , WalletDBLog (..)
-    , DefaultFieldValues (..)
-
-    -- * Database for a specific 'WalletId'
+    -- * Open a database for a specific 'WalletId'
     , withDBFresh
     , withDBFreshInMemory
     , newDBFreshInMemory
-    , withDBFreshFromDBOpen
+
+    -- * Open a database for testing
+    , withLoadDBLayerFromFile
+    , WalletDBLog (..)
+    , DefaultFieldValues (..)
 
     -- * Interfaces
     , PersistAddressBook (..)

--- a/lib/wallet/src/Cardano/Wallet/DB/Migration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Migration.hs
@@ -18,15 +18,16 @@
 module Cardano.Wallet.DB.Migration
     ( -- * Build migrations
       Migration
-    , mkMigration
     , VersionT
+    , mkMigration
+    , hoistMigration
 
       -- * Run migrations
     , Version (..)
+    , getTargetVersion
     , MigrationInterface (..)
     , runMigrations
     , ErrWrongVersion (..)
-    , hoistMigration
     ) where
 
 import Prelude hiding
@@ -97,6 +98,14 @@ mkMigration m = Migration [m]
 instance Category (Migration m) where
     id = Migration []
     Migration s2 . Migration s1 = Migration (s1 <> s2)
+
+-- | Target version of a 'Migration', on the value level.
+getTargetVersion
+    :: forall m vmin vtarget
+     . KnownNat vtarget
+    => Migration m vmin vtarget
+    -> Version
+getTargetVersion _ = Version $ natVal (Proxy :: Proxy vtarget)
 
 -- | Functions to interact with the database.
 data MigrationInterface m handle = MigrationInterface

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -125,12 +125,6 @@ newDBFresh timeInterpreter wid = do
             . mRollbackTo
 
         {-----------------------------------------------------------------------
-                                   Wallet Metadata
-        -----------------------------------------------------------------------}
-
-        -- , putWalletMeta = noErrorAlterDB db .  mPutWalletMeta
-
-        {-----------------------------------------------------------------------
                                      Tx History
         -----------------------------------------------------------------------}
 
@@ -182,6 +176,9 @@ newDBFresh timeInterpreter wid = do
         {-----------------------------------------------------------------------
                                       Execution
         -----------------------------------------------------------------------}
+
+        , getSchemaVersion =
+            error "getSchemaVersion not tested in State Machine tests"
 
         , atomically = \action -> withMVar lock $ \() -> action
         }

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -120,7 +120,6 @@ import Cardano.Wallet.DB.Layer
     , newDBFactory
     , newDBFreshInMemory
     , withDBFresh
-    , withDBFreshFromDBOpen
     , withDBFreshInMemory
     , withLoadDBLayerFromFile
     )


### PR DESCRIPTION
In preparation for the improvement of the database initialization logic, this pull request

- [x] Trims the export list of `Cardano.Wallet.DB.Layer`, essentially removing all references to `DBOpen` in favor of `DBFresh`.
- [x] Adds a `getSchemaVersion` function to `DBLayer`, with unit test. This function is meant for internal use.

### Implementation details

The idea is that in the future,

* `bootDBLayer` should be solely responsible for creating the tables for the current schema, including the `database_schema_version` for keeping track of the schema version.
    → This pull request prepares the creation of the `database_schema_version` table.
* `loadDBLayer` should migrate from previous database schemas, but should not be responsible for creating any new tables beyond that.
    → This pull request removes external access to `DBOpen`, which had previously intermingled these two concerns.

### Issue number

ADP-3214