### PR TITLE
Make rnd restore bench faster by halving ownership

### DIFF
--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -461,7 +461,7 @@ cardanoRestoreBench tr c socketFile = do
                 tunedForMainnetPipeliningStrategy
             , benchRestoreSeqWithOwnership (Proxy @1)
                 tunedForMainnetPipeliningStrategy
-            , benchRestoreRndWithOwnership (Proxy @10)
+            , benchRestoreRndWithOwnership (Proxy @5)
                 tunedForMainnetPipeliningStrategy
             ]
   where


### PR DESCRIPTION
The rnd bench alone currently takes 6h30m.

As the chain grows, we need to lower the ownership ratio to keep the
restore benchmarks running in a reasonable time.

Recent master nightly: https://buildkite.com/cardano-foundation/cardano-wallet-nightly/builds/202#018b7dfd-107b-41d0-bf88-63ae0c2282fd

With this PR: https://buildkite.com/cardano-foundation/cardano-wallet-nightly/builds/205

### Issue Number

None
