### PR TITLE
Use `Write.Value` consistently in `cardano-balance-tx`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -589,7 +589,7 @@ modifyTxOutCoin era = modifyTxOutValue era . modifyCoin
 txOutValue
     :: RecentEra era
     -> TxOut (CardanoApi.ShelleyLedgerEra era)
-    -> MaryValue StandardCrypto
+    -> Value
 txOutValue RecentEraConway (Babbage.BabbageTxOut _ val _ _) = val
 txOutValue RecentEraBabbage (Babbage.BabbageTxOut _ val _ _) = val
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -329,7 +329,7 @@ type RecentEraLedgerConstraints era =
     , Core.EraCrypto era ~ StandardCrypto
     , Core.Script era ~ AlonzoScript era
     , Core.Tx era ~ Babbage.AlonzoTx era
-    , Core.Value era ~ MaryValue StandardCrypto
+    , Core.Value era ~ Value
     , Core.TxWits era ~ AlonzoTxWits era
     , ExtendedUTxO era
     , Alonzo.AlonzoEraPParams era

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -575,9 +575,9 @@ modifyTxOutValue
     -> TxOut (CardanoApi.ShelleyLedgerEra era)
     -> TxOut (CardanoApi.ShelleyLedgerEra era)
 modifyTxOutValue RecentEraConway f (BabbageTxOut addr val dat script) =
-        BabbageTxOut addr (f val) dat script
+    BabbageTxOut addr (f val) dat script
 modifyTxOutValue RecentEraBabbage f (BabbageTxOut addr val dat script) =
-        BabbageTxOut addr (f val) dat script
+    BabbageTxOut addr (f val) dat script
 
 modifyTxOutCoin
     :: RecentEra era
@@ -586,10 +586,7 @@ modifyTxOutCoin
     -> TxOut (CardanoApi.ShelleyLedgerEra era)
 modifyTxOutCoin era = modifyTxOutValue era . modifyCoin
 
-txOutValue
-    :: RecentEra era
-    -> TxOut (CardanoApi.ShelleyLedgerEra era)
-    -> Value
+txOutValue :: RecentEra era -> TxOut (CardanoApi.ShelleyLedgerEra era) -> Value
 txOutValue RecentEraConway (Babbage.BabbageTxOut _ val _ _) = val
 txOutValue RecentEraBabbage (Babbage.BabbageTxOut _ val _ _) = val
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -612,13 +612,13 @@ datumHashToBytes = Crypto.hashToBytes . extractHash
 
 -- | Type representing a TxOut in the latest or previous era.
 --
--- The underlying respresentation is isomorphic to 'TxOut LatestLedgerEra'.
+-- The underlying representation is isomorphic to 'TxOut LatestLedgerEra'.
 --
 -- Can be unwrapped using 'unwrapTxOutInRecentEra' or
 -- 'utxoFromTxOutsInRecentEra'.
 --
 -- Implementation assumes @TxOut latestEra ⊇ TxOut prevEra@ in the sense that
--- the latest era has not removed information from the @TxOut@. This is allows
+-- the latest era has not removed information from the @TxOut@. This allows
 -- e.g. @ToJSON@ / @FromJSON@ instances to be written for two eras using only
 -- one implementation.
 data TxOutInRecentEra =

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -627,7 +627,7 @@ datumHashToBytes = Crypto.hashToBytes . extractHash
 data TxOutInRecentEra =
     TxOutInRecentEra
         Address
-        (MaryValue StandardCrypto)
+        Value
         (Datum LatestLedgerEra)
         (Maybe (AlonzoScript LatestLedgerEra))
         -- Same contents as 'TxOut LatestLedgerEra'.

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -571,7 +571,7 @@ type TxOut era = Core.TxOut era
 
 modifyTxOutValue
     :: RecentEra era
-    -> (MaryValue StandardCrypto -> MaryValue StandardCrypto)
+    -> (Value -> Value)
     -> TxOut (CardanoApi.ShelleyLedgerEra era)
     -> TxOut (CardanoApi.ShelleyLedgerEra era)
 modifyTxOutValue RecentEraConway f (BabbageTxOut addr val dat script) =


### PR DESCRIPTION
## Issue

None. Noticed while browsing `cardano-balance-tx`.

## Description

The `Cardano.Write.Tx` module defines the following type synonym:
```hs
type Value = MaryValue StandardCrypto
```

This PR replaces all instances of the RHS with the LHS within `cardano-balance-tx`.