### PR TITLE
Use `Write` types in `ErrBalanceTxOutputTokenQuantityExceedsLimitError`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -140,6 +140,9 @@ module Internal.Cardano.Write.Tx
     , utxoFromTxOutsInRecentEra
     , utxoFromTxOuts
 
+    -- * Policy and asset identifiers
+    , PolicyId
+
     -- * Balancing
     , evaluateMinimumFee
     , evaluateTransactionBalance
@@ -192,6 +195,9 @@ import Cardano.Ledger.Crypto
     )
 import Cardano.Ledger.Mary
     ( MaryValue
+    )
+import Cardano.Ledger.Mary.Value
+    ( PolicyID
     )
 import Cardano.Ledger.SafeHash
     ( SafeHash
@@ -971,3 +977,9 @@ evaluateTransactionBalance era pp utxo = withConstraints era $
         isRegPoolId _keyHash = True
 
     in Ledger.evalBalanceTxBody pp lookupRefund isRegPoolId utxo
+
+--------------------------------------------------------------------------------
+-- Policy and asset identifiers
+--------------------------------------------------------------------------------
+
+type PolicyId = PolicyID StandardCrypto

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -142,6 +142,7 @@ module Internal.Cardano.Write.Tx
 
     -- * Policy and asset identifiers
     , PolicyId
+    , AssetName
 
     -- * Balancing
     , evaluateMinimumFee
@@ -197,7 +198,8 @@ import Cardano.Ledger.Mary
     ( MaryValue
     )
 import Cardano.Ledger.Mary.Value
-    ( PolicyID
+    ( AssetName
+    , PolicyID
     )
 import Cardano.Ledger.SafeHash
     ( SafeHash

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -1017,9 +1017,9 @@ instance IsServerError ErrBalanceTxOutputTokenQuantityExceedsLimitError
         , ". Asset name: "
         , pretty (show (view #assetName e))
         , ". Token quantity specified: "
-        , pretty (view #quantity e)
+        , pretty (show (view #quantity e))
         , ". Maximum allowable token quantity: "
-        , pretty (view #quantityMaxBound e)
+        , pretty (show (view #quantityMaxBound e))
         , "."
         ]
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -1013,9 +1013,9 @@ instance IsServerError ErrBalanceTxOutputTokenQuantityExceedsLimitError
         , "Destination address: "
         , pretty (toWalletAddress (view #address e))
         , ". Token policy identifier: "
-        , pretty (view (#asset . #tokenPolicyId) e)
+        , pretty (show (view #policyId e))
         , ". Asset name: "
-        , pretty (view (#asset . #tokenName) e)
+        , pretty (show (view #assetName e))
         , ". Token quantity specified: "
         , pretty (view #quantity e)
         , ". Maximum allowable token quantity: "


### PR DESCRIPTION
## Issue

ADP-3184

## Description

This PR replaces the use of wallet primitive types with their `Write` equivalents in `ErrBalanceTxOutputTokenQuantityExceedsLimitError`.