### PR TITLE
Use `Write.Value` in `ErrBalanceTxInternalError`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -414,7 +414,7 @@ data ErrBalanceTxAssetsInsufficientError = ErrBalanceTxAssetsInsufficientError
 
 data ErrBalanceTxInternalError
     = ErrUnderestimatedFee Coin SealedTx KeyWitnessCount
-    | ErrFailedBalancing CardanoApi.Value
+    | ErrFailedBalancing Value
     deriving (Show, Eq)
 
 -- | Errors that can occur when balancing transactions.
@@ -861,8 +861,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             then pure tx
             else throwE
                 $ ErrBalanceTxInternalError
-                $ ErrFailedBalancing
-                $ CardanoApi.fromMaryValue bal
+                $ ErrFailedBalancing bal
 
     txBalance :: Tx (ShelleyLedgerEra era) -> Value
     txBalance


### PR DESCRIPTION
## Issue

ADP-3184

## Description

This PR changes `ErrBalanceTxInternalError.ErrFailedBalancing` to use `Write.Value` instead of `CardanoApi.Value`.