### PR TITLE
[ADP-3214] Remove `withDatabase`

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -488,7 +488,6 @@ import Cardano.Wallet.DB
     ( DBFactory (..)
     , DBFresh
     , DBLayer
-    , loadDBLayer
     )
 import Cardano.Wallet.Flavor
     ( CredFromOf
@@ -1799,9 +1798,9 @@ getWallet ctx mkApiWallet (ApiT wid) = do
         (, meta ^. #creationTime)
             <$> mkApiWallet ctx wid cp meta delegation pending progress
 
-    whenNotResponding _ = Handler $ ExceptT $ withDatabase dbfa wid
-        $ \df -> runHandler $ do
-            db <- liftHandler $ loadDBLayer df
+    whenNotResponding _ = Handler $ ExceptT
+        $ withDatabaseLoad dbfa wid
+        $ \db -> runHandler $ do
             let wrk = hoistResource db (MsgFromWorker wid) ctx
             (cp, (meta, delegation), pending)
                 <- handler $ W.readWallet wrk

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -133,7 +133,7 @@ import Cardano.Wallet.DB.Layer
     ( DefaultFieldValues (..)
     , PersistAddressBook
     , WalletDBLog (..)
-    , withDBFresh
+    , withDBFreshFromFile
     )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( block0
@@ -844,8 +844,12 @@ setupDB tr = do
     uncurry (BenchEnv destroyPool) <$> createPool
   where
     withSetup action = withTempSqliteFile $ \fp -> do
-        withDBFresh (walletFlavor @s)
-            tr (Just defaultFieldValues) fp singleEraInterpreter testWid
+        withDBFreshFromFile (walletFlavor @s)
+            tr
+            singleEraInterpreter
+            testWid
+            (Just defaultFieldValues)
+            fp
                 $ \db -> action (fp, db)
 
 singleEraInterpreter :: TimeInterpreter IO

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -126,11 +126,11 @@ import Cardano.Wallet.BenchShared
     , withTempSqliteFile
     )
 import Cardano.Wallet.DB
-    ( DBFresh
+    ( DBLayer
     )
 import Cardano.Wallet.DB.Layer
     ( PersistAddressBook
-    , withDBFreshFromFile
+    , withBootDBLayerFromFile
     )
 import Cardano.Wallet.Flavor
     ( Excluding
@@ -841,12 +841,11 @@ bench_restoration
         np socket vData sTol $ \nw -> do
             let ti = neverFails "bench db shouldn't forecast into future"
                     $ timeInterpreter nw
-            withBenchDBLayer @s ti wlTr wid
-                $ \dbf -> withWalletLayerTracer
+            let gps = (emptyGenesis gp, np)
+            withBenchDBLayer @s wlTr ti wid wname gps s
+                $ \db -> withWalletLayerTracer
                     benchname pipeliningStrat traceToDisk
                 $ \progressTrace -> do
-                    let gps = (emptyGenesis gp, np)
-                    db <- unsafeRunExceptT $ W.createWallet gps dbf wid wname s
                     let tracer =
                             trMessageText wlTr <>
                             contramap walletWorkerLogToBlockHeight progressTrace
@@ -945,20 +944,27 @@ withBenchDBLayer
     :: forall s a
      . ( PersistAddressBook s
        , WalletFlavor s
+       , IsOurs s Address
+       , IsOurs s RewardAccount
        )
-    => TimeInterpreter IO
-    -> Trace IO Text
+    => Trace IO Text
+    -> TimeInterpreter IO
     -> WalletId
-    -> (DBFresh IO s -> IO a)
+    -> WalletName
+    -> (Block, NetworkParameters)
+    -> s
+    -> (DBLayer IO s -> IO a)
     -> IO a
-withBenchDBLayer ti tr wid action =
-    withTempSqliteFile $ \dbFile ->
-        withDBFreshFromFile
+withBenchDBLayer tr ti wid wname gps s action =
+    withTempSqliteFile $ \dbFile -> do
+        params <- W.createWallet gps wid wname s
+        withBootDBLayerFromFile
+            (walletFlavor @s)
             tr'
             ti
-            (walletFlavor @s)
             wid
             (Just migrationDefaultValues)
+            params
             dbFile
             action
   where

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -130,7 +130,7 @@ import Cardano.Wallet.DB
     )
 import Cardano.Wallet.DB.Layer
     ( PersistAddressBook
-    , withDBFresh
+    , withDBFreshFromFile
     )
 import Cardano.Wallet.Flavor
     ( Excluding
@@ -953,8 +953,14 @@ withBenchDBLayer
     -> IO a
 withBenchDBLayer ti tr wid action =
     withTempSqliteFile $ \dbFile ->
-        withDBFresh (walletFlavor @s) tr'
-            (Just migrationDefaultValues) dbFile ti wid action
+        withDBFreshFromFile
+            tr'
+            ti
+            (walletFlavor @s)
+            wid
+            (Just migrationDefaultValues)
+            dbFile
+            action
   where
     migrationDefaultValues = Sqlite.DefaultFieldValues
         { Sqlite.defaultActiveSlotCoefficient = 1

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -185,6 +185,12 @@ data DBFactory m s = DBFactory
         -- ^ Open an existing database, maintaining an open
         -- connection so long as necessary.
 
+    , withDatabaseBoot
+        :: forall a
+         . WalletId -> DBLayerParams s -> (DBLayer m s -> IO a) -> IO a
+        -- ^ Creates a new database, maintaining an open
+        -- connection so long as necessary.
+
     , removeDatabase :: WalletId -> IO ()
         -- ^ Erase any trace of the database
 

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -181,6 +181,10 @@ data DBFactory m s = DBFactory
         -- ^ Creates a new or use an existing database, maintaining an open
         -- connection so long as necessary
 
+    , withDatabaseLoad :: forall a. WalletId -> (DBLayer m s -> IO a) -> IO a
+        -- ^ Open an existing database, maintaining an open
+        -- connection so long as necessary.
+
     , removeDatabase :: WalletId -> IO ()
         -- ^ Erase any trace of the database
 

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -177,11 +177,7 @@ import qualified Data.Map.Strict as Map
 -- In our use case, this will typically be a directory of database files,
 -- or a 'Map' of in-memory SQLite databases.
 data DBFactory m s = DBFactory
-    { withDatabase :: forall a. WalletId -> (DBFresh m s -> IO a) -> IO a
-        -- ^ Creates a new or use an existing database, maintaining an open
-        -- connection so long as necessary
-
-    , withDatabaseLoad :: forall a. WalletId -> (DBLayer m s -> IO a) -> IO a
+    { withDatabaseLoad :: forall a. WalletId -> (DBLayer m s -> IO a) -> IO a
         -- ^ Open an existing database, maintaining an open
         -- connection so long as necessary.
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Errors.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Errors.hs
@@ -52,6 +52,8 @@ newtype ErrNoSuchWallet
     = ErrNoSuchWallet WalletId -- Wallet is gone or doesn't exist yet
     deriving (Eq, Show)
 
+instance Exception ErrNoSuchWallet
+
 -- | Can't perform given operation because there's no wallet in the db
 data ErrWalletNotInitialized = ErrWalletNotInitialized
     deriving (Eq, Show)

--- a/lib/wallet/src/Cardano/Wallet/DB/Errors.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Errors.hs
@@ -62,6 +62,8 @@ instance Exception ErrWalletNotInitialized
 data ErrWalletAlreadyInitialized = ErrWalletAlreadyInitialized
     deriving (Eq, Show)
 
+instance Exception ErrWalletAlreadyInitialized
+
 newtype ErrNotGenesisBlockHeader = ErrNotGenesisBlockHeader BlockHeader
     deriving (Eq, Show)
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -30,7 +30,7 @@ module Cardano.Wallet.DB.Layer
     , newDBFreshInMemory
 
     -- * Open a database for testing
-    , withLoadDBLayerFromFile
+    , withTestLoadDBLayerFromFile
     , WalletDBLog (..)
     , DefaultFieldValues (..)
 
@@ -781,7 +781,7 @@ mkDecorator transactionsQS =
 -- (possibly triggering migrations), and run an action on it.
 --
 -- Useful for testing the logs and results of migrations.
-withLoadDBLayerFromFile
+withTestLoadDBLayerFromFile
     :: forall s a.
         ( PersistAddressBook s
         , WalletFlavor s
@@ -796,7 +796,7 @@ withLoadDBLayerFromFile
         -- ^ Action to run.
     -> IO a
         -- ^ Result of the action.
-withLoadDBLayerFromFile tr ti path action =
+withTestLoadDBLayerFromFile tr ti path action =
     withDBOpenFromFile (walletFlavor @s) tr (Just testDefaultFieldValues) path
     $ \db -> do
         mwid <- retrieveWalletId db

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -121,7 +121,7 @@ import Cardano.Wallet.DB.Layer
     , newDBFreshInMemory
     , withDBFreshFromFile
     , withDBFreshInMemory
-    , withLoadDBLayerFromFile
+    , withTestLoadDBLayerFromFile
     )
 import Cardano.Wallet.DB.Properties
     ( properties
@@ -1338,7 +1338,7 @@ withDBLayerFromCopiedFile
         -- ^ (logs, result of the action)
 withDBLayerFromCopiedFile dbName action =
     withinCopiedFile dbName $ \path tr ->
-        withLoadDBLayerFromFile tr dummyTimeInterpreter path action
+        withTestLoadDBLayerFromFile tr dummyTimeInterpreter path action
 
 withinCopiedFile
     :: FilePath

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -80,9 +80,7 @@ import Cardano.Wallet.Balance.Migration.SelectionSpec
     , unMockTxConstraints
     )
 import Cardano.Wallet.DB
-    ( DBFresh
-    , DBLayer (..)
-    , hoistDBFresh
+    ( DBLayer (..)
     , hoistDBLayer
     , putTxHistory
     )
@@ -480,16 +478,16 @@ walletIdDeterministic
     :: (WalletId, WalletName, DummyState)
     -> Property
 walletIdDeterministic newWallet = monadicIO $ do
-    WalletLayerFixture _ _ _ widsA <- run $ setupFixture dummyStateF newWallet
-    WalletLayerFixture _ _ _ widsB <- run $ setupFixture dummyStateF newWallet
+    WalletLayerFixture _ _ widsA <- run $ setupFixture dummyStateF newWallet
+    WalletLayerFixture _ _ widsB <- run $ setupFixture dummyStateF newWallet
     assert (widsA == widsB)
 
 walletIdInjective
     :: ((WalletId, WalletName, DummyState), (WalletId, WalletName, DummyState))
     -> Property
 walletIdInjective (walletA, walletB) = monadicIO $ do
-    WalletLayerFixture _ _ _ widsA <- run $ setupFixture dummyStateF walletA
-    WalletLayerFixture _ _ _ widsB <- run $ setupFixture dummyStateF walletB
+    WalletLayerFixture _ _ widsA <- run $ setupFixture dummyStateF walletA
+    WalletLayerFixture _ _ widsB <- run $ setupFixture dummyStateF walletB
     assert (widsA /= widsB)
 
 walletUpdateName
@@ -498,7 +496,7 @@ walletUpdateName
     -> Property
 walletUpdateName wallet wName = monadicIO $ do
     wName' <- run $ do
-        WalletLayerFixture _ _ wl _ <- setupFixture dummyStateF wallet
+        WalletLayerFixture _ wl _ <- setupFixture dummyStateF wallet
         W.updateWallet wl (\x -> x { name = wName })
         (name . (\(_, (b, _), _) -> b)) <$> W.readWallet wl
     assert (wName == wName')
@@ -509,7 +507,7 @@ walletUpdatePassphrase
     -> Maybe (ShelleyKey 'RootK XPrv, Passphrase "user")
     -> Property
 walletUpdatePassphrase wallet new mxprv = monadicIO $ do
-    WalletLayerFixture _ _ wl wid <- run $ setupFixture dummyStateF wallet
+    WalletLayerFixture _ wl wid <- run $ setupFixture dummyStateF wallet
     case mxprv of
         Nothing -> prop_withoutPrivateKey wl wid
         Just (xprv, pwd) -> prop_withPrivateKey wl wid (xprv, pwd)
@@ -533,7 +531,7 @@ walletUpdatePassphraseWrong
     -> Property
 walletUpdatePassphraseWrong wallet (xprv, pwd) (old, new) =
     pwd /= coerce old ==> monadicIO $ do
-        WalletLayerFixture _ _ wl wid <- run $ setupFixture dummyStateF wallet
+        WalletLayerFixture _ wl wid <- run $ setupFixture dummyStateF wallet
         attempt <- run $ do
             W.attachPrivateKeyFromPwd wl (xprv, pwd)
             runExceptT
@@ -551,7 +549,7 @@ walletUpdatePassphraseNoRootKey
     -> Property
 walletUpdatePassphraseNoRootKey wallet@(wid', _, _) wid (old, new) =
     wid /= wid' ==> monadicIO $ do
-        WalletLayerFixture _ _ wl _ <- run $ setupFixture dummyStateF wallet
+        WalletLayerFixture _ wl _ <- run $ setupFixture dummyStateF wallet
         attempt <- run $ runExceptT
             $ W.updateWalletPassphraseWithOldPassphrase
                 dummyStateF wl wid (old, new)
@@ -563,7 +561,7 @@ walletUpdatePassphraseDate
     -> (ShelleyKey 'RootK XPrv, Passphrase "user")
     -> Property
 walletUpdatePassphraseDate wallet (xprv, pwd) = monadicIO $ liftIO $ do
-    WalletLayerFixture _ _ wl wid  <- liftIO $ setupFixture dummyStateF wallet
+    WalletLayerFixture _ wl wid  <- liftIO $ setupFixture dummyStateF wallet
     let infoShouldSatisfy predicate = do
             info <- (passphraseInfo . (\(_, (b, _), _) -> b))
                 <$> W.readWallet wl
@@ -596,7 +594,7 @@ walletListTransactionsSorted
 walletListTransactionsSorted wallet@(_, _, _) _order (_mstart, _mend) =
     forAll (logScale' 1.5 arbitrary) $ \history ->
     monadicIO $ liftIO $ do
-        WalletLayerFixture _ DBLayer{..} wl _ <- setupFixture dummyStateF wallet
+        WalletLayerFixture DBLayer{..} wl _ <- setupFixture dummyStateF wallet
         atomically $ putTxHistory history
         txs <- unsafeRunExceptT $
             W.listTransactions wl Nothing Nothing Nothing
@@ -639,7 +637,7 @@ walletListTransactionsWithLimit wallet@(_, _, _) =
             -> PropertyM IO ()
         limitNatural = fromIntegral limit
         test start stop order dir cut = liftIO @(PropertyM IO) $ do
-            WalletLayerFixture _ DBLayer{..} wl _ <- setupFixture dummyStateF wallet
+            WalletLayerFixture DBLayer{..} wl _ <- setupFixture dummyStateF wallet
             atomically $ putTxHistory history'
             txs <- unsafeRunExceptT $
                 W.listTransactions wl Nothing start stop order
@@ -713,7 +711,7 @@ instance Sqlite.PersistAddressBook DummyStateWithAddresses where
 walletListsOnlyRelatedAssets :: Hash "Tx" -> TxMeta -> Property
 walletListsOnlyRelatedAssets txId txMeta =
     forAll genOuts $ \(out1, out2, wallet) -> monadicIO $ do
-        WalletLayerFixture _ DBLayer{..} wl _ <- liftIO
+        WalletLayerFixture DBLayer{..} wl _ <- liftIO
             $ setupFixture dummyStateWithAddressesF wallet
         let listHistoricalAssets hry = do
                 liftIO . atomically $ putTxHistory hry
@@ -966,7 +964,7 @@ prop_localTxSubmission tc = monadicIO $ do
         submittedVar <- newMVar []
         (msgs, res) <- captureLogging' $ \tr -> do
             flip runReaderT st $ unTxRetryTestM $ do
-                WalletLayerFixture _ db _wl _wid <-
+                WalletLayerFixture db _wl _wid <-
                     setupFixture dummyStateF $ retryTestWallet tc
                 let ctx = WalletLayer
                         (natTracer liftIO tr)
@@ -1320,8 +1318,7 @@ instance Arbitrary UTxO where
         return $ UTxO $ Map.fromList utxo
 
 data WalletLayerFixture s m = WalletLayerFixture
-    { _fixtureDBFresh :: DBFresh m s
-    , _fixtureDBLayer :: DBLayer m s
+    { _fixtureDBLayer :: DBLayer m s
     , _fixtureWalletLayer :: WalletLayer m s
     , _fixtureWallet :: WalletId
     }
@@ -1356,7 +1353,7 @@ setupFixture wF (wid,wname,wstate) = do
                 dummyTransactionLayer
                 db'
         wal = walletId_ db
-    pure $ WalletLayerFixture (error "DBFresh no longer in use") db' wl wal
+    pure $ WalletLayerFixture db' wl wal
 
 slotNoTime :: SlotNo -> UTCTime
 slotNoTime = posixSecondsToUTCTime . fromIntegral . unSlotNo

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -280,9 +280,6 @@ import Data.ByteString
 import Data.Coerce
     ( coerce
     )
-import Data.Either
-    ( isLeft
-    )
 import Data.Function
     ( on
     )
@@ -434,8 +431,6 @@ spec = describe "Cardano.WalletSpec" $ do
         it (show $ ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase) True
 
     describe "WalletLayer works as expected" $ do
-        it "Wallet cannot be created more than once"
-            (property walletDoubleCreationProp)
         it "Two wallets with same mnemonic have a same public id"
             (property walletIdDeterministic)
         it "Two wallets with different mnemonic have a different public id"
@@ -480,16 +475,6 @@ spec = describe "Cardano.WalletSpec" $ do
 {-------------------------------------------------------------------------------
                                     Properties
 -------------------------------------------------------------------------------}
-
-walletDoubleCreationProp
-    :: (WalletId, WalletName, DummyState)
-    -> Property
-walletDoubleCreationProp newWallet =
-    monadicIO $ do
-        WalletLayerFixture dbf _db _wl _walletIds
-            <- run $ setupFixture dummyStateF newWallet
-        secondTrial <- run $ runExceptT $ createFixtureWallet dbf newWallet
-        assert (isLeft secondTrial)
 
 walletIdDeterministic
     :: (WalletId, WalletName, DummyState)
@@ -1340,18 +1325,6 @@ data WalletLayerFixture s m = WalletLayerFixture
     , _fixtureWalletLayer :: WalletLayer m s
     , _fixtureWallet :: WalletId
     }
-
-createFixtureWallet
-    :: ( MonadUnliftIO m
-       , MonadTime m
-       , IsOurs s Address
-       , IsOurs s RewardAccount
-       )
-    => DBFresh m s
-    -> (WalletId, WalletName, s)
-    -> ExceptT W.ErrWalletAlreadyExists m (DBLayer m s)
-createFixtureWallet dbf (wid, wname, wstate) =
-    W.createWallet (block0, dummyNetworkParameters) dbf wid wname wstate
 
 setupFixture
     :: forall s m


### PR DESCRIPTION
In preparation for the improvement of the database initialization logic, this pull request removes `withDatabase` in favor of two distinct functions

* `withDatabaseLoad` — responsible for **loading** a `DBLayer` from a file.
* `withDatabaseBoot` — responsible for **creating** a new `DBLayer` from a file or in memory.

At the moment, these functions are implemented using existing functionality. Later on, we intend to change the implementation so that `*Load` only performs migrations, while `*Boot` never performs migrations, and only creates tables.

### Issue number

ADP-3214