### PR TITLE
Use `Write.TxIn` in `ErrBalanceTxUnresolvedInputs`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -430,7 +430,7 @@ data ErrBalanceTx era
     | ErrBalanceTxAssignRedeemers ErrAssignRedeemers
     | ErrBalanceTxInternalError ErrBalanceTxInternalError
     | ErrBalanceTxInputResolutionConflicts (NonEmpty (W.TxOut, W.TxOut))
-    | ErrBalanceTxUnresolvedInputs (NonEmpty W.TxIn)
+    | ErrBalanceTxUnresolvedInputs (NonEmpty TxIn)
     | ErrBalanceTxOutputError ErrBalanceTxOutputError
     | ErrBalanceTxUnableToCreateChange ErrBalanceTxUnableToCreateChangeError
     | ErrBalanceTxUnableToCreateInput
@@ -834,7 +834,6 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 (unresolvedInsHead:unresolvedInsTail, _) ->
                     throwE
                     . ErrBalanceTxUnresolvedInputs
-                    . fmap Convert.toWallet
                     $ (unresolvedInsHead :| unresolvedInsTail)
       where
         txIns :: [TxIn]

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -582,7 +582,7 @@ instance IsServerError (ErrBalanceTx era) where
             apiError err400 UnresolvedInputs $ T.unwords
                 [ "There are inputs in the transaction for which corresponding"
                 , "outputs could not be found:\n"
-                , pretty $ NE.toList ins
+                , pretty $ NE.toList $ show <$> ins
                 ]
         ErrBalanceTxInputResolutionConflicts conflicts -> do
             let conflictF (a, b) = build a <> "\nvs\n" <> build b

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -666,7 +666,6 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
     describe "when passed unresolved inputs" $ do
         it "fails with ErrBalanceTxUnresolvedTxIn" $ do
             let txin = W.TxIn (W.Hash $ B8.replicate 32 '3') 10
-
             -- 1 output, 1 input without utxo entry
             let partialTx :: PartialTx CardanoApi.BabbageEra
                 partialTx = addExtraTxIns [txin] $
@@ -676,7 +675,8 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
                         ]
             balance partialTx
                 `shouldBe`
-                Left (ErrBalanceTxUnresolvedInputs (txin :| []))
+                Left
+                    (ErrBalanceTxUnresolvedInputs (Convert.toLedger txin :| []))
 
         describe "with redeemers" $
             it "fails with ErrBalanceTxUnresolvedInputs" $ do
@@ -686,7 +686,7 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
                 balance (withNoUTxO pingPong_2)
                     `shouldBe` Left
                         (ErrBalanceTxUnresolvedInputs $ NE.fromList
-                            [ W.TxIn
+                            [ Convert.toLedger $ W.TxIn
                                 (W.Hash "11111111111111111111111111111111") 0
                             ]
                         )

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -664,7 +664,7 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
             tx `shouldBe` Left ErrBalanceTxMaxSizeLimitExceeded
 
     describe "when passed unresolved inputs" $ do
-        it "fails with ErrBalanceTxUnresolvedTxIn" $ do
+        it "fails with ErrBalanceTxUnresolvedInputs" $ do
             let txin = W.TxIn (W.Hash $ B8.replicate 32 '3') 10
             -- 1 output, 1 input without utxo entry
             let partialTx :: PartialTx CardanoApi.BabbageEra


### PR DESCRIPTION
## Issue

ADP-3184

## Description

This PR adjusts `ErrBalanceTxUnresolvedInputs` to use the `Write.TxIn` type.