### PR TITLE
[ADP-3214] Remove `DBFresh` from usage sites

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -25,8 +25,6 @@ module Cardano.Wallet.DB.Layer
     , DBFactoryLog (..)
 
     -- * Open a database for a specific 'WalletId'
-    , withDBFreshFromFile
-
     , withLoadDBLayerFromFile
     , withBootDBLayerFromFile
     , newBootDBLayerInMemory
@@ -679,36 +677,6 @@ withDBFreshFromDBOpen
     -- ^ Already opened database.
     -> IO a
 withDBFreshFromDBOpen wf ti wid action = action . newDBFreshFromDBOpen wf ti wid
-
--- | Runs an action with a connection to the SQLite database.
---
--- Database migrations are run to create tables if necessary.
---
--- If the given file path does not exist, it will be created by the sqlite
--- library.
-withDBFreshFromFile
-    :: forall s a
-     . PersistAddressBook s
-    => WalletFlavorS s
-        -- ^ Wallet flavor
-    -> Tracer IO WalletDBLog
-       -- ^ Logging object
-    -> TimeInterpreter IO
-       -- ^ Time interpreter for slot to time conversions.
-    -> W.WalletId
-         -- ^ Wallet ID of the database.
-    -> Maybe DefaultFieldValues
-       -- ^ Default database field values, used during manual migration.
-       -- Use 'Nothing' to skip manual migrations.
-    -> FilePath
-       -- ^ Path to database file
-    -> (DBFresh IO s -> IO a)
-       -- ^ Action to run.
-    -> IO a
-withDBFreshFromFile walletF tr ti wid defaultFieldValues dbFile action =
-    withDBOpenFromFile walletF tr defaultFieldValues dbFile
-        $  action . newDBFreshFromDBOpen walletF ti wid
-
 
 -- | From a 'DBOpen', create a database which can store the state
 -- of one wallet with a specific 'WalletId'.

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -32,6 +32,7 @@ module Cardano.Wallet.DB.Layer
     , withLoadDBLayerFromFile
     , withBootDBLayerFromFile
     , newBootDBLayerInMemory
+    , withBootDBLayerInMemory
 
     -- * Open a database for testing
     , withTestLoadDBLayerFromFile
@@ -584,6 +585,25 @@ newBootDBLayerInMemory wF tr ti wid params =
                 throw err
             Right dblayer ->
                 pure (destroy, dblayer)
+
+-- | Create a 'DBLayer' in memory.
+--
+-- Create tables corresponding to the current schema.
+--
+-- @with@ variant of 'newBootDBLayerInMemory'.
+withBootDBLayerInMemory
+    :: forall s a
+     . PersistAddressBook s
+    => WalletFlavorS s
+    -> Tracer IO WalletDBLog
+    -> TimeInterpreter IO
+    -> W.WalletId
+    -> DBLayerParams s
+    -> (DBLayer IO s -> IO a)
+    -> IO a
+withBootDBLayerInMemory wF tr ti wid params action =
+    bracket
+        (newBootDBLayerInMemory wF tr ti wid params) fst (action . snd)
 
 {-------------------------------------------------------------------------------
     DBOpen

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -26,7 +26,6 @@ module Cardano.Wallet.DB.Layer
 
     -- * Open a database for a specific 'WalletId'
     , withDBFreshFromFile
-    , newDBFreshInMemory
 
     , withLoadDBLayerFromFile
     , withBootDBLayerFromFile
@@ -214,9 +213,6 @@ import Control.Tracer
     ( Tracer
     , contramap
     , traceWith
-    )
-import Data.Bifunctor
-    ( second
     )
 import Data.Coerce
     ( coerce
@@ -713,24 +709,6 @@ withDBFreshFromFile walletF tr ti wid defaultFieldValues dbFile action =
     withDBOpenFromFile walletF tr defaultFieldValues dbFile
         $  action . newDBFreshFromDBOpen walletF ti wid
 
--- | Creates a 'DBFresh' backed by a sqlite in-memory database.
---
--- Returns a cleanup function which you should always use exactly once when
--- finished with the 'DBFresh'.
-newDBFreshInMemory
-    :: forall s
-     . PersistAddressBook s
-    => WalletFlavorS s
-    -- ^ Wallet flavor
-    -> Tracer IO WalletDBLog
-    -- ^ Logging object.
-    -> TimeInterpreter IO
-    -- ^ Time interpreter for slot to time conversions.
-    -> W.WalletId
-    -- ^ Wallet ID of the database.
-    -> IO (IO (), DBFresh IO s)
-newDBFreshInMemory wf tr ti wid = do
-    second (newDBFreshFromDBOpen wf ti wid) <$> newDBOpenInMemory tr
 
 -- | From a 'DBOpen', create a database which can store the state
 -- of one wallet with a specific 'WalletId'.

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -26,7 +26,6 @@ module Cardano.Wallet.DB.Layer
 
     -- * Open a database for a specific 'WalletId'
     , withDBFreshFromFile
-    , withDBFreshInMemory
     , newDBFreshInMemory
 
     , withLoadDBLayerFromFile
@@ -713,25 +712,6 @@ withDBFreshFromFile
 withDBFreshFromFile walletF tr ti wid defaultFieldValues dbFile action =
     withDBOpenFromFile walletF tr defaultFieldValues dbFile
         $  action . newDBFreshFromDBOpen walletF ti wid
-
--- | Runs an IO action with a new 'DBFresh' backed by a sqlite in-memory
--- database.
-withDBFreshInMemory
-    :: forall s a
-     . PersistAddressBook s
-    => WalletFlavorS s
-    -- ^ Wallet flavor
-    -> Tracer IO WalletDBLog
-    -- ^ Logging object.
-    -> TimeInterpreter IO
-    -- ^ Time interpreter for slot to time conversions
-    -> W.WalletId
-    -- ^ Wallet ID of the database.
-    -> (DBFresh IO s -> IO a)
-    -- ^ Action to run.
-    -> IO a
-withDBFreshInMemory wf tr ti wid action = bracket
-    (newDBFreshInMemory wf tr ti wid) fst (action . snd)
 
 -- | Creates a 'DBFresh' backed by a sqlite in-memory database.
 --

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -109,7 +109,6 @@ import Cardano.Wallet.Address.Keys.SequentialAny
     )
 import Cardano.Wallet.DB
     ( DBFactory (..)
-    , DBFresh (..)
     , DBLayer (..)
     , DBLayerParams (..)
     )
@@ -414,7 +413,7 @@ spec =
             propertiesSpecSeq
             loggingSpec
             fileModeSpec
-            dbFreshSpec
+            initializeDBSpec
             manualMigrationsSpec
 
 stateMachineSpec
@@ -554,7 +553,6 @@ findObserveDiffs = filter isObserveDiff
                                 File Mode Spec
 -------------------------------------------------------------------------------}
 
-type TestDBSeqFresh = DBFresh IO TestState
 type TestState = SeqState 'Mainnet ShelleyKey
 
 fileModeSpec :: Spec
@@ -1133,11 +1131,11 @@ cutRandomly = iter []
             iter (chunk:acc) (L.drop chunksNum rest)
 
 {-------------------------------------------------------------------------------
-    DBFresh tests
+    Tests about initializing the DBLayer
 -------------------------------------------------------------------------------}
 
-dbFreshSpec :: Spec
-dbFreshSpec = do
+initializeDBSpec :: Spec
+initializeDBSpec = do
     describe "withBootDBLayerInMemory" $ do
         it "Database schema version is up to date"
             testSchemaVersionUpToDate

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Pure/ImplementationSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Pure/ImplementationSpec.hs
@@ -39,9 +39,6 @@ import Cardano.Wallet.Primitive.Types.Address
 import Control.DeepSeq
     ( NFData
     )
-import Control.Monad.IO.Class
-    ( liftIO
-    )
 import Test.Hspec
     ( Spec
     , before
@@ -60,10 +57,11 @@ spec :: Spec
 spec =
     before (pendingOnMacOS "#2472: timeouts in CI mac builds")
     $ describe "PureLayer"
-    $ properties $ \wid test -> do
-        run <- liftIO $ PureLayer.newDBFresh @_ @(SeqState 'Mainnet ShelleyKey)
-            dummyTimeInterpreter wid
-        test run
+    $ properties $ \wid params ->
+        PureLayer.withBootDBLayer @_ @(SeqState 'Mainnet ShelleyKey)
+            dummyTimeInterpreter
+            wid
+            params
 
 newtype DummyStatePureLayer = DummyStatePureLayer Int
     deriving (Show, Eq)


### PR DESCRIPTION
In preparation for the improvement of the database initialization logic, this pull requests removes all usage sites of the `DBFresh` type (except in `Cardano.Wallet.DB.Layer`).

Instead of `bootDBLayer` and `loadDBLayer`, use the corresponding functions

*  `withBootDBLayerFromFile` or `newBootDBLayerInMemory`
* `withLoadDBLayerFromFile`

### Issue number

ADP-3214