### PR TITLE
Fix inconsistency between the current epoch in the tip and delegation status within the wallet API response

### DIFF
--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
@@ -1101,7 +1101,7 @@ generateGenesis Config{..} initialFunds genesisMods = do
     If it's slightly before the actual starts, some slots will be missed,
     but it shouldn't be critical as long as less than k slots are missed.
 
-    Empirically, 5 seconds seems to be a good value: enough for a cluster to
+    Empirically, 10 seconds seems to be a good value: enough for a cluster to
     initialize itself before producing any blocks, but not too much to wait for.
 
     Lower values (e.g. 1 second) might cause custer to start but not produce
@@ -1109,7 +1109,7 @@ generateGenesis Config{..} initialFunds genesisMods = do
     happens then node logs contain TraceNoLedgerView message and wallet log says
     "Current tip is [point genesis]. (not applying blocks)"
     -}
-    systemStart <- addUTCTime 5 <$> getCurrentTime
+    systemStart <- addUTCTime 10 <$> getCurrentTime
 
     let sgProtocolParams = Ledger.emptyPParams
             & ppMinFeeAL .~ Ledger.Coin 100

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1164,7 +1164,7 @@ mkShelleyWallet ctx@ApiLayer{..} wid cp meta delegation pending progress = do
     apiDelegation <- liftIO $ toApiWalletDelegation delegation
         (unsafeExtendSafeZone ti)
 
-    tip' <- liftIO $ getWalletTip
+    tip <- liftIO $ getWalletTip
         (neverFails "getWalletTip wallet tip should be behind node tip" ti)
         cp
     let available = availableBalance pending cp
@@ -1186,7 +1186,7 @@ mkShelleyWallet ctx@ApiLayer{..} wid cp meta delegation pending progress = do
         , passphrase = ApiWalletPassphraseInfo
             <$> fmap (view #lastUpdatedAt) (meta ^. #passphraseInfo)
         , state = ApiT progress
-        , tip = tip'
+        , tip
         }
 
 toApiWalletDelegation

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1089,7 +1089,7 @@ readWallet ctx = do
     db & \DBLayer{..} -> atomically $ do
         cp <- readCheckpoint
         meta <- readWalletMeta walletState
-        dele <- readDelegation walletState
+        calculateWalletDelegations <- readDelegation walletState
         pending <-
             readTransactions
                 Nothing
@@ -1098,7 +1098,11 @@ readWallet ctx = do
                 (Just Pending)
                 Nothing
                 Nothing
-        pure (cp, (meta, dele currentEpochSlotting), Set.fromList (fromTransactionInfo <$> pending))
+        pure
+            ( cp
+            , (meta, calculateWalletDelegations currentEpochSlotting)
+            , Set.fromList (fromTransactionInfo <$> pending)
+            )
   where
     db = ctx ^. dbLayer
     nl = ctx ^. networkLayer


### PR DESCRIPTION
- [x] refactor: improve code readability around the wallet delegation info;
- [x] fix: don't rely on the epoch information obtained via a relative time (current UTC time - blockchain start time) as it could be inconsistent with the wallet state, always calculate current epoch from the latest node tip (which is consistent with the wallet state)

### Issue Number

ADP-3216
