### PR TITLE
Use `Write.TxOut` in `ErrBalanceTxInputResolutionConflicts`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -322,6 +322,8 @@ instance TestEquality RecentEra where
 
 class
     ( CardanoApi.IsShelleyBasedEra era
+    , Eq (TxOut (CardanoApi.ShelleyLedgerEra era))
+    , Show (TxOut (CardanoApi.ShelleyLedgerEra era))
     , Typeable era
     ) => IsRecentEra era where
     recentEra :: RecentEra era

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -904,11 +904,11 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         -> ExceptT (ErrBalanceTx era) m ()
     guardWalletUTxOConsistencyWith u' = do
         let W.UTxO u = toWalletUTxO (recentEra @era) $ fromCardanoApiUTxO u'
-        let conflicts = lefts $ flip map (Map.toList u) $ \(i, out1) ->
+        let conflicts = lefts $ flip map (Map.toList u) $ \(i, o1) ->
                 case i `W.UTxO.lookup` walletUTxO of
-                    Just out2 -> unless (out1 == out2) $ Left
-                        ( toLedgerTxOut era out1
-                        , toLedgerTxOut era out2
+                    Just o2 -> unless (o1 == o2) $ Left
+                        ( toLedgerTxOut era o1
+                        , toLedgerTxOut era o2
                         )
                     Nothing -> pure ()
         case conflicts of

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -902,9 +902,9 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         -> ExceptT (ErrBalanceTx era) m ()
     guardWalletUTxOConsistencyWith u' = do
         let W.UTxO u = toWalletUTxO (recentEra @era) $ fromCardanoApiUTxO u'
-        let conflicts = lefts $ flip map (Map.toList u) $ \(i, o) ->
+        let conflicts = lefts $ flip map (Map.toList u) $ \(i, out1) ->
                 case i `W.UTxO.lookup` walletUTxO of
-                    Just o' -> unless (o == o') $ Left (o, o')
+                    Just out2 -> unless (out1 == out2) $ Left (out1, out2)
                     Nothing -> pure ()
         case conflicts of
             [] -> return ()

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -906,10 +906,9 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 case i `W.UTxO.lookup` walletUTxO of
                     Just o' -> unless (o == o') $ Left (o, o')
                     Nothing -> pure ()
-
         case conflicts of
             [] -> return ()
-            (c:cs) -> throwE $ ErrBalanceTxInputResolutionConflicts (c :| cs)
+            (c : cs) -> throwE $ ErrBalanceTxInputResolutionConflicts (c :| cs)
 
     combinedUTxO :: UTxO (ShelleyLedgerEra era)
     combinedUTxO = withConstraints era $ mconcat

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -439,8 +439,8 @@ data ErrBalanceTx era
     --   - the given UTxO index is empty.
     -- A transaction must have at least one input in order to be valid.
 
-deriving instance Eq (ErrBalanceTx era)
-deriving instance Show (ErrBalanceTx era)
+deriving instance IsRecentEra era => Eq (ErrBalanceTx era)
+deriving instance IsRecentEra era => Show (ErrBalanceTx era)
 
 -- | A 'PartialTx' is an an unbalanced 'SealedTx' along with the necessary
 -- information to balance it.

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -34,7 +34,6 @@ import Cardano.Ledger.Alonzo.TxInfo
     )
 import Cardano.Wallet
     ( ErrAddCosignerKey (..)
-    , ErrBalanceTxInRecentEra (..)
     , ErrCannotJoin (..)
     , ErrCannotQuit (..)
     , ErrConstructSharedWallet (..)
@@ -532,9 +531,6 @@ instance IsServerError ErrWriteTxEra where
                 , "an old era, please recreate your transaction so that it is"
                 , "compatible with a recent era."
                 ]
-
-instance IsServerError ErrBalanceTxInRecentEra where
-    toServerError (ErrBalanceTxInRecentEra e) = toServerError e
 
 instance Write.IsRecentEra era => IsServerError (ErrBalanceTx era) where
     toServerError = \case

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -34,6 +34,7 @@ import Cardano.Ledger.Alonzo.TxInfo
     )
 import Cardano.Wallet
     ( ErrAddCosignerKey (..)
+    , ErrBalanceTxInRecentEra (..)
     , ErrCannotJoin (..)
     , ErrCannotQuit (..)
     , ErrConstructSharedWallet (..)
@@ -531,6 +532,9 @@ instance IsServerError ErrWriteTxEra where
                 , "an old era, please recreate your transaction so that it is"
                 , "compatible with a recent era."
                 ]
+
+instance IsServerError ErrBalanceTxInRecentEra where
+    toServerError (ErrBalanceTxInRecentEra e) = toServerError e
 
 instance IsServerError (ErrBalanceTx era) where
     toServerError = \case

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -536,7 +536,7 @@ instance IsServerError ErrWriteTxEra where
 instance IsServerError ErrBalanceTxInRecentEra where
     toServerError (ErrBalanceTxInRecentEra e) = toServerError e
 
-instance IsServerError (ErrBalanceTx era) where
+instance Write.IsRecentEra era => IsServerError (ErrBalanceTx era) where
     toServerError = \case
         ErrBalanceTxUpdateError (ErrExistingKeyWitnesses n) ->
             apiError err403 BalanceTxExistingKeyWitnesses $ mconcat
@@ -589,7 +589,7 @@ instance IsServerError (ErrBalanceTx era) where
                 , pretty $ NE.toList $ show <$> ins
                 ]
         ErrBalanceTxInputResolutionConflicts conflicts -> do
-            let conflictF (a, b) = build a <> "\nvs\n" <> build b
+            let conflictF (a, b) = build (show a) <> "\nvs\n" <> build (show b)
             apiError err400 InputResolutionConflicts $ mconcat
                 [ "At least one of the inputs you've told me about has an"
                 , "asset quantity or address that is different from that"

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2156,6 +2156,11 @@ buildSignSubmitTransaction db@DBLayer{..} netLayer txLayer
 
     wrapRootKeyError = ExceptionWitnessTx . ErrWitnessTxWithRootKey
     wrapNetworkError = ExceptionSubmitTx . ErrSubmitTxNetwork
+
+    wrapBalanceConstructError
+        :: Write.IsRecentEra era
+        => Either (ErrBalanceTx era) ErrConstructTx
+        -> WalletException
     wrapBalanceConstructError =
         either
             (ExceptionBalanceTx . ErrBalanceTxInRecentEra)
@@ -3615,7 +3620,8 @@ newtype ErrWritePolicyPublicKey
     deriving (Generic, Eq, Show)
 
 data ErrBalanceTxInRecentEra =
-    forall era. ErrBalanceTxInRecentEra (ErrBalanceTx era)
+    forall era. Write.IsRecentEra era =>
+    ErrBalanceTxInRecentEra (ErrBalanceTx era)
 
 deriving instance Show ErrBalanceTxInRecentEra
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -992,32 +992,24 @@ decodeSealedTxSpec = describe "SealedTx serialisation/deserialisation" $ do
         ]
 
 feeEstimationRegressionSpec :: AnyRecentEra -> Spec
-feeEstimationRegressionSpec (AnyRecentEra era) =
-    case era of
-        RecentEraConway ->
-            feeEstimationRegressionSpecInner @Cardano.ConwayEra era
-        RecentEraBabbage ->
-            feeEstimationRegressionSpecInner @Cardano.BabbageEra era
-
-feeEstimationRegressionSpecInner
-    :: forall era. Write.IsRecentEra era
-    => RecentEra era
-    -> Spec
-feeEstimationRegressionSpecInner _era = describe "Regression tests" $ do
-    it "#1740 Fee estimation at the boundaries" $ do
-        let requiredCostLovelace :: Natural
-            requiredCostLovelace = 166_029
-        let estimateFee = except $ Left
-                $ ErrBalanceTxUnableToCreateChange
-                $ ErrBalanceTxUnableToCreateChangeError
-                    { requiredCost = Ledger.Coin $ intCast requiredCostLovelace
-                    , shortfall = Ledger.Coin 100_000
-                    }
-        result <- runExceptT (calculateFeePercentiles @_ @era estimateFee)
-        result `shouldBe` Right
-            ( Percentile $ Fee $ Coin requiredCostLovelace
-            , Percentile $ Fee $ Coin requiredCostLovelace
-            )
+feeEstimationRegressionSpec (AnyRecentEra (_era :: RecentEra era)) =
+    describe "Regression tests" $ do
+        it "#1740 Fee estimation at the boundaries" $ do
+            let requiredCostLovelace :: Natural
+                requiredCostLovelace = 166_029
+            let estimateFee = except $ Left
+                    $ ErrBalanceTxUnableToCreateChange
+                    $ ErrBalanceTxUnableToCreateChangeError
+                        { requiredCost =
+                            Ledger.Coin $ intCast requiredCostLovelace
+                        , shortfall =
+                            Ledger.Coin 100_000
+                        }
+            result <- runExceptT (calculateFeePercentiles @_ @era estimateFee)
+            result `shouldBe` Right
+                ( Percentile $ Fee $ Coin requiredCostLovelace
+                , Percentile $ Fee $ Coin requiredCostLovelace
+                )
 
 binaryCalculationsSpec :: AnyRecentEra -> Spec
 binaryCalculationsSpec (AnyRecentEra era) =

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1000,7 +1000,8 @@ feeEstimationRegressionSpec (AnyRecentEra era) =
             feeEstimationRegressionSpecInner @Cardano.BabbageEra era
 
 feeEstimationRegressionSpecInner
-    :: forall era. RecentEra era
+    :: forall era. Write.IsRecentEra era
+    => RecentEra era
     -> Spec
 feeEstimationRegressionSpecInner _era = describe "Regression tests" $ do
     it "#1740 Fee estimation at the boundaries" $ do


### PR DESCRIPTION
## Issue

ADP-3184

## Description

This PR adjusts `ErrBalanceTxInputResolutionConflicts` to use `Write.TxOut` instead of the wallet primitive `TxOut` type.