### PR TITLE
Specify UTF-8 encoding in CI "check code format" step.

### DIFF
--- a/.buildkite/check-code-format.sh
+++ b/.buildkite/check-code-format.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Force UTF-8 encoding:
+LANG=C.UTF-8
+
 echo "+++ Check code format: imports"
 
 stylish-haskell -v --config .stylish-haskell.yaml --inplace `git ls-files -- '*.hs'`


### PR DESCRIPTION
## Issue

None.

## Description

This PR tweaks the `.buildkite/check-code-format.sh` script so that `stylish-haskell` (and other tools) use UTF-8 encoding by default.