### PR TITLE
chore: extract address derivation from the Faucet module.

### DIFF
--- a/lib/local-cluster/lib/Cardano/Wallet/Faucet/Addresses.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Faucet/Addresses.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+-- `cardano-addresses` library marks byron functionality as deprecated
+-- but in a meaning that new projects shouldn't use it. However, we still
+-- need to support byron addresses in the wallet and make sure they work forever
+-- so for this purpose it isn't deprecated.
+-- This option allows to avoid a compiler warning;
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
+{- | Module contains functionality to generate addresses
+     of various styles for the faucet.
+-}
+module Cardano.Wallet.Faucet.Addresses
+    ( byron
+    , icarus
+    , shelley
+    , shelleyRewardAccount
+    ) where
+
+import Prelude
+
+import Cardano.Address
+    ( Address
+    )
+import Cardano.Address.Derivation
+    ( AccountIndexDerivationType
+    , AddressIndexDerivationType
+    , Depth (AccountK, DelegationK, PaymentK)
+    , DerivationType (Hardened)
+    , GenMasterKey (genMasterKeyFromMnemonic)
+    , Index
+    , XPrv
+    , XPub
+    , coerceWholeDomainIndex
+    , deriveAccountPrivateKey
+    , deriveAddressPrivateKey
+    , nextIndex
+    , toXPub
+    )
+import Cardano.Address.Style.Byron
+    ( Byron
+    )
+import Cardano.Address.Style.Icarus
+    ( Icarus
+    )
+import Cardano.Address.Style.Shelley
+    ( Shelley
+    )
+import Cardano.Mnemonic
+    ( Mnemonic
+    , SomeMnemonic (..)
+    )
+import Data.List
+    ( unfoldr
+    )
+import Data.Tuple.Extra
+    ( dupe
+    )
+import GHC.TypeLits
+    ( KnownNat
+    )
+
+import qualified Cardano.Address as CA
+import qualified Cardano.Address.Style.Byron as Byron
+import qualified Cardano.Address.Style.Icarus as Icarus
+import qualified Cardano.Address.Style.Shelley as Shelley
+
+byron :: KnownNat mw => CA.NetworkTag -> Mnemonic mw -> [Address]
+byron networkTag mw = mkPaymentAddrForIx <$> paymentKeyIxs
+  where
+    paymentKeyIxs :: [Index (AddressIndexDerivationType Byron) PaymentK] =
+        let firstIx = minBound
+        in firstIx : unfoldr (fmap dupe . nextIndex) firstIx
+    mkPaymentAddrForIx paymentAddrIx =
+        Byron.paymentAddress
+            (CA.RequiresNetworkTag, networkTag)
+            (toXPub <$> paymentKey)
+      where
+        secondFactor = ()
+        paymentKey =
+            deriveAddressPrivateKey accountKey secondFactor paymentAddrIx
+          where
+            accountKey = deriveAccountPrivateKey masterKey accountIx
+              where
+                masterKey =
+                    genMasterKeyFromMnemonic (SomeMnemonic mw) secondFactor
+                accountIx :: Index (AddressIndexDerivationType Byron) AccountK =
+                    coerceWholeDomainIndex (minBound :: Index Hardened AccountK)
+
+icarus :: CA.NetworkTag -> Mnemonic 15 -> [Address]
+icarus networkTag mw = mkPaymentAddrForIx <$> paymentKeyIxs
+  where
+    paymentKeyIxs :: [Index (AddressIndexDerivationType Icarus) PaymentK] =
+        let firstIx = minBound
+        in firstIx : unfoldr (fmap dupe . nextIndex) firstIx
+    mkPaymentAddrForIx paymentAddrIx =
+        Icarus.paymentAddress
+            (CA.RequiresNetworkTag, networkTag)
+            (toXPub <$> paymentKey)
+      where
+        paymentKey =
+            deriveAddressPrivateKey accountKey Icarus.UTxOExternal paymentAddrIx
+          where
+            accountKey = deriveAccountPrivateKey masterKey accountIx
+              where
+                accountIx :: Index (AccountIndexDerivationType Icarus) AccountK =
+                    minBound
+                masterKey = genMasterKeyFromMnemonic (SomeMnemonic mw) mempty
+
+shelley :: SomeMnemonic -> [Address]
+shelley mnemonic = mkPaymentAddrForIx <$> paymentKeyIxs
+  where
+    paymentKeyIxs :: [Index (AddressIndexDerivationType Shelley) PaymentK] =
+        let firstIx = minBound
+            in firstIx : unfoldr (fmap dupe . nextIndex) firstIx
+    mkPaymentAddrForIx paymentAddrIx =
+        Shelley.paymentAddress Shelley.shelleyTestnet credential
+      where
+        credential :: Shelley.Credential PaymentK =
+            Shelley.PaymentFromExtendedKey (toXPub <$> paymentKey)
+        paymentKey :: Shelley PaymentK XPrv =
+            deriveAddressPrivateKey
+                (deriveShelleyAccountKey mnemonic)
+                Shelley.UTxOExternal
+                paymentAddrIx
+
+shelleyRewardAccount
+    :: SomeMnemonic -> (Shelley DelegationK XPub, Shelley DelegationK XPrv)
+shelleyRewardAccount mnemonic = (toXPub <$> xPrv, xPrv)
+  where
+    xPrv = Shelley.deriveDelegationPrivateKey (deriveShelleyAccountKey mnemonic)
+
+deriveShelleyAccountKey :: SomeMnemonic -> Shelley AccountK XPrv
+deriveShelleyAccountKey mnemonic = deriveAccountPrivateKey masterKey accountIx
+  where
+    accountIx :: Index 'Hardened 'AccountK = minBound
+    masterKey = genMasterKeyFromMnemonic mnemonic mempty

--- a/lib/local-cluster/lib/Cardano/Wallet/Faucet/Writer.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Faucet/Writer.hs
@@ -26,11 +26,6 @@ import Cardano.Mnemonic
     , SomeMnemonic (..)
     , mnemonicToText
     )
-import Cardano.Wallet.Faucet
-    ( byronAddresses
-    , deriveShelleyAddresses
-    , icarusAddresses
-    )
 import Control.Monad
     ( forM
     , forM_
@@ -44,6 +39,7 @@ import Data.Text
     )
 
 import qualified Cardano.Address as CA
+import qualified Cardano.Wallet.Faucet.Addresses as Addresses
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as TIO
@@ -52,27 +48,27 @@ import qualified Data.Text.IO as TIO
 --
 -- >>> genMnemonics 100 >>= genByronFaucets "byron-faucets.yaml"
 genByronFaucets :: CA.NetworkTag -> FilePath -> [Mnemonic 12] -> IO [[Text]]
-genByronFaucets = genFaucet base58 . byronAddresses
+genByronFaucets = genFaucet base58 . Addresses.byron
 
 -- | Generate faucets addresses and mnemonics to a file.
 --
 -- >>> genMnemonics 100 >>= genIcarusFaucets (CA.NetworkTag 42) "icarus-faucets.yaml"
 genIcarusFaucets :: CA.NetworkTag -> FilePath -> [Mnemonic 15] -> IO [[Text]]
-genIcarusFaucets = genFaucet base58 . icarusAddresses
+genIcarusFaucets = genFaucet base58 . Addresses.icarus
 
 -- | Generate faucet addresses and mnemonics to a file.
 --
 -- >>> genMnemonics 100 >>= genShelleyFaucets "shelley-faucets.yaml"
 genShelleyFaucets :: FilePath -> [Mnemonic 15] -> IO [[Text]]
 genShelleyFaucets =
-    genFaucet encodeAddressHex (deriveShelleyAddresses . SomeMnemonic)
+    genFaucet encodeAddressHex (Addresses.shelley . SomeMnemonic)
 
 -- | Generate faucet addresses and mnemonics to a file.
 --
 -- >>> genMnemonics 100 >>= genMaryAllegraFaucets "ma-faucets.yaml"
 genMaryAllegraFaucets :: FilePath -> [Mnemonic 24] -> IO [[Text]]
 genMaryAllegraFaucets =
-    genFaucet encodeAddressHex (deriveShelleyAddresses . SomeMnemonic)
+    genFaucet encodeAddressHex (Addresses.shelley . SomeMnemonic)
 
 -- | Abstract function for generating a faucet as a YAML file.
 --

--- a/lib/local-cluster/lib/Cardano/Wallet/LocalCluster.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/LocalCluster.hs
@@ -33,7 +33,6 @@ import Cardano.Startup
     )
 import Cardano.Wallet.Faucet
     ( byronIntegrationTestFunds
-    , deriveShelleyRewardAccount
     , maryIntegrationTestFunds
     , shelleyIntegrationTestFunds
     )
@@ -73,6 +72,7 @@ import UnliftIO.Concurrent
 import qualified Cardano.Address.Style.Shelley as Shelley
 import qualified Cardano.Node.Cli.Launcher as NC
 import qualified Cardano.Wallet.Cli.Launcher as WC
+import qualified Cardano.Wallet.Faucet.Addresses as Addresses
 import qualified Cardano.Wallet.Faucet.Mnemonics as Mnemonics
 import qualified Cardano.Wallet.Launch.Cluster as Cluster
 import qualified Options.Applicative as O
@@ -262,7 +262,8 @@ main = withUtf8 $ do
                   , Coin (fromIntegral Cluster.oneMillionAda)
                   )
                 | m <- Mnemonics.mir
-                , let (xPub, _xPrv) = deriveShelleyRewardAccount (SomeMnemonic m)
+                , let (xPub, _xPrv) =
+                        Addresses.shelleyRewardAccount (SomeMnemonic m)
                 ]
             }
 

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -47,6 +47,7 @@ library
     Cardano.Wallet.Cli.Launcher
     Cardano.Wallet.Faucet
     Cardano.Wallet.Faucet.Writer
+    Cardano.Wallet.Faucet.Addresses
     Cardano.Wallet.Faucet.Mnemonics
     Cardano.Wallet.Faucet.Shelley
     Cardano.Wallet.Launch.Cluster

--- a/lib/wallet/bench/latency-bench.hs
+++ b/lib/wallet/bench/latency-bench.hs
@@ -68,7 +68,6 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Faucet
     ( byronIntegrationTestFunds
-    , deriveShelleyAddresses
     , maryIntegrationTestFunds
     , shelleyIntegrationTestFunds
     )
@@ -231,6 +230,7 @@ import UnliftIO.STM
     )
 
 import qualified Cardano.Wallet.Api.Link as Link
+import qualified Cardano.Wallet.Faucet.Addresses as Addresses
 import qualified Cardano.Wallet.Launch.Cluster as Cluster
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
@@ -656,7 +656,7 @@ massiveWalletFunds :: [(Address, Coin)]
 massiveWalletFunds =
     take massiveWalletUTxOSize
     . map (, massiveWalletAmt)
-    . deriveShelleyAddresses
+    . Addresses.shelley
     $ SomeMnemonic massiveWallet
 
 massiveWalletAmt :: Coin

--- a/lib/wallet/test/integration/shelley-integration-test.hs
+++ b/lib/wallet/test/integration/shelley-integration-test.hs
@@ -64,7 +64,6 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Faucet
     ( byronIntegrationTestFunds
-    , deriveShelleyRewardAccount
     , hwLedgerTestFunds
     , maryIntegrationTestFunds
     , seaHorseTestAssets
@@ -235,6 +234,7 @@ import qualified Cardano.BM.Backend.EKGView as EKG
 import qualified Cardano.CLI as CLI
 import qualified Cardano.Pool.DB as Pool
 import qualified Cardano.Pool.DB.Sqlite as Pool
+import qualified Cardano.Wallet.Faucet.Addresses as Addresses
 import qualified Cardano.Wallet.Faucet.Mnemonics as Mnemonics
 import qualified Cardano.Wallet.Launch.Cluster as Cluster
 import qualified Data.Text as T
@@ -471,7 +471,8 @@ specWithServer testnetMagic testDir (tr, tracers) = aroundAll withContext
               , Coin (fromIntegral oneMillionAda)
               )
             | m <- Mnemonics.mir
-            , let (xpub, _prv) = deriveShelleyRewardAccount (SomeMnemonic m)
+            , let (xpub, _prv) =
+                    Addresses.shelleyRewardAccount (SomeMnemonic m)
             ]
         }
 


### PR DESCRIPTION
I have extracted the address derivation functionality out of the `Carano.Wallet.Faucet` module into the `Cardano.Wallet.Faucet.Addresses` module.

### Issue Number

ADP-3137
