### PR TITLE
fix: api benchmark uses mock node tip

### DIFF
--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -113,7 +113,9 @@ import Cardano.Wallet.Primitive.Slotting
     , hoistTimeInterpreter
     )
 import Cardano.Wallet.Primitive.Types
-    ( SortOrder (..)
+    ( BlockHeader (..)
+    , SlotNo (..)
+    , SortOrder (..)
     , WalletId
     , WalletMetadata (..)
     )
@@ -174,10 +176,14 @@ import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.DB as DB
 import qualified Cardano.Wallet.DB.Layer as DB
 import qualified Cardano.Wallet.DB.Layer as Sqlite
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..)
+    )
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Cardano.Wallet.Read as Read
 import qualified Cardano.Wallet.Transaction as Tx
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Char8 as B8
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified System.Environment as Sys
@@ -528,6 +534,12 @@ mockNetworkLayer = dummyNetworkLayer
     , currentSlottingParameters = pure dummySlottingParameters
     , currentProtocolParameters = pure dummyProtocolParameters
     , currentNodeEra = pure $ Cardano.anyCardanoEra Cardano.BabbageEra
+    , currentNodeTip = pure BlockHeader
+        { slotNo = SlotNo 8888
+        , blockHeight = Quantity 9999
+        , headerHash = Hash (B8.replicate 32 'a')
+        , parentHeaderHash = Just (Hash (B8.replicate 32 'b'))
+        }
     }
 
 mockTimeInterpreter :: TimeInterpreter IO

--- a/lib/wallet/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/wallet/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -92,6 +92,9 @@ import Data.Quantity
 import Data.Time.Clock.POSIX
     ( posixSecondsToUTCTime
     )
+import GHC.Stack
+    ( HasCallStack
+    )
 
 import qualified Cardano.Api.Shelley as C
 import qualified Data.ByteString.Char8 as B8
@@ -216,22 +219,25 @@ dummyNodeProtocolParameters = C.ProtocolParameters
     , C.protocolParamMaxCollateralInputs = Just 3
     }
 
-dummyNetworkLayer :: NetworkLayer m a
+dummyNetworkLayer :: HasCallStack => NetworkLayer m a
 dummyNetworkLayer = NetworkLayer
-    { chainSync = error "chainSync: not implemented"
+    { chainSync = err "chainSync"
     , lightSync = Nothing
-    , currentNodeEra = error "currentNodeEra: not implemented"
-    , currentNodeTip = error "currentNodeTip: not implemented"
-    , watchNodeTip = error "watchNodeTip: not implemented"
-    , currentProtocolParameters = error "currentProtocolParameters: not implemented"
-    , currentSlottingParameters = error "currentSlottingParameters: not implemented"
-    , postTx = error "postTx: not implemented"
-    , stakeDistribution = error "stakeDistribution: not implemented"
-    , getCachedRewardAccountBalance = error "getRewardCachedAccountBalance: not implemented"
-    , fetchRewardAccountBalances = error "fetchRewardAccountBalances: not implemented"
-    , timeInterpreter = error "timeInterpreter: not implemented"
-    , syncProgress = error "syncProgress: not implemented"
+    , currentNodeEra = err "currentNodeEra"
+    , currentNodeTip = err "currentNodeTip"
+    , watchNodeTip = err "watchNodeTip"
+    , currentProtocolParameters = err "currentProtocolParameters"
+    , currentSlottingParameters = err "currentSlottingParameters"
+    , postTx = err "postTx"
+    , stakeDistribution = err "stakeDistribution"
+    , getCachedRewardAccountBalance = err "getRewardCachedAccountBalance"
+    , fetchRewardAccountBalances = err "fetchRewardAccountBalances"
+    , timeInterpreter = err "timeInterpreter"
+    , syncProgress = err "syncProgress"
     }
+  where
+    err subject = error $
+        "`" <> subject <> "` is not implemented in the dummy network layer."
 
 {-----------------------------------------------------------------------------
     Convenience functions


### PR DESCRIPTION
I have mocked the `currentNodeTip` for the API benchmark not to crash.

### Issue Number

No issue, quickfix.
