### PR TITLE
Narrow constraints to `IsRecentEra era` in `Shelley.Transaction` module

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -357,7 +357,9 @@ type RecentEraLedgerConstraints era =
 -- https://cardanofoundation.atlassian.net/browse/ADP-2353
 withConstraints
     :: RecentEra era
-    -> ((RecentEraLedgerConstraints (CardanoApi.ShelleyLedgerEra era)) => a)
+    -> ( ( IsRecentEra era
+         , (RecentEraLedgerConstraints (CardanoApi.ShelleyLedgerEra era))
+         ) => a)
     -> a
 withConstraints era a = case era of
     RecentEraBabbage -> a

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -348,6 +348,11 @@ type RecentEraLedgerConstraints era =
     , Shelley.EraUTxO era
     )
 
+type RecentEraConstraints era =
+    ( IsRecentEra era
+    , RecentEraLedgerConstraints (CardanoApi.ShelleyLedgerEra era)
+    )
+
 -- | Bring useful constraints into scope from a value-level
 -- 'RecentEra'.
 --
@@ -356,11 +361,7 @@ type RecentEraLedgerConstraints era =
 -- wallet code specifically with GHC 8.10.
 -- https://cardanofoundation.atlassian.net/browse/ADP-2353
 withConstraints
-    :: RecentEra era
-    -> ( ( IsRecentEra era
-         , (RecentEraLedgerConstraints (CardanoApi.ShelleyLedgerEra era))
-         ) => a)
-    -> a
+    :: RecentEra era -> (RecentEraConstraints era => a) -> a
 withConstraints era a = case era of
     RecentEraBabbage -> a
     RecentEraConway -> a

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -4133,7 +4133,6 @@ migrateWallet ctx@ApiLayer{..} withdrawalType (ApiT wid) postData = do
     withWorkerCtx ctx wid liftE liftE $ \wrk -> do
         let db = wrk ^. dbLayer
             tr = wrk ^. logger
-        era <- liftIO $ NW.currentNodeEra netLayer
         rewardWithdrawal <- case withdrawalType of
             Nothing -> pure NoWithdrawal
             Just pd ->
@@ -4159,7 +4158,6 @@ migrateWallet ctx@ApiLayer{..} withdrawalType (ApiT wid) postData = do
                 W.buildAndSignTransaction
                     wrk
                     wid
-                    era
                     mkRewardAccount
                     pwd
                     txContext

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2413,12 +2413,11 @@ buildAndSignTransaction ctx wid mkRwdAcct pwd txCtx sel = db & \DBLayer{..} ->
                         mapMaybe (`ourCoin` getState cp) (sel ^. #outputs)
                 amountIn :: Coin =
                     F.fold (NE.toList (TxOut.coin . snd <$> sel ^. #inputs))
-                    -- NOTE: In case where rewards were pulled from an external
-                    -- source, they aren't added to the calculation because the
-                    -- money is considered to come from outside of the wallet; which
-                    -- changes the way we look at transactions (in such case, a
-                    -- transaction is considered 'Incoming' since it brings extra money
-                    -- to the wallet from elsewhere).
+                    -- NOTE: In case where rewards are pulled from an external
+                    -- source, they aren't added to the calculation, as the
+                    -- money is considered to come from outside the wallet. In
+                    -- such cases, transactions are categorised as "incoming",
+                    -- as they bring extra money to the wallet from elsewhere.
                     & case txWithdrawal txCtx of
                         w@WithdrawalSelf{} -> Coin.add (withdrawalToCoin w)
                         WithdrawalExternal{} -> Prelude.id

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -590,7 +590,11 @@ newTransactionLayer keyF networkId = TransactionLayer
                                 policyResolver policyKeyM stakingScriptResolver
                                 addressResolver inputResolver (body, wits)
                             & sealedTxFromCardano'
-                        Nothing -> sealedTx
+                        Nothing ->
+                            error $ unwords
+                                [ "addVkWitnesses: cannot add witnesses to a"
+                                , "transaction from a non-recent era."
+                                ]
 
     , decodeTx = _decodeSealedTx
 

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -322,17 +322,17 @@ constructUnsignedTx
 
 mkTransaction
     :: forall era k. RecentEra era
-    -- Era for which the transaction should be created.
+    -- ^ Era for which the transaction should be created.
     -> Cardano.NetworkId
     -> KeyFlavorS k
     -> (XPrv, Passphrase "encryption")
-    -- Reward account
+    -- ^ Reward account.
     -> (Address -> Maybe (k 'CredFromKeyK XPrv, Passphrase "encryption"))
-    -- Key store
+    -- ^ Key store.
     -> TransactionCtx
-    -- An additional context about the transaction
+    -- ^ Additional context about the transaction.
     -> SelectionOf TxOut
-    -- A balanced coin selection where all change addresses have been
+    -- ^ A balanced coin selection where all change addresses have been
     -- assigned.
     -> Either ErrMkTransaction (Tx, SealedTx)
 mkTransaction era networkId keyF stakeCreds addrResolver ctx cs = do

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
@@ -35,16 +36,15 @@ module Cardano.Wallet.Shelley.Transaction
     ( newTransactionLayer
     , txConstraints
     , mkUnsignedTransaction
+    , mkTransaction
 
     -- * Internals
     , TxPayload (..)
     , TxWitnessTag (..)
-    , EraConstraints
     , _decodeSealedTx
     , mkDelegationCertificates
     , mkByronWitness
     , mkShelleyWitness
-    , mkTx
     , mkUnsignedTx
     , _txRewardWithdrawalCost
     , _txRewardWithdrawalSize
@@ -67,13 +67,10 @@ import Cardano.Address.Script
     )
 import Cardano.Api
     ( AnyCardanoEra (..)
-    , ByronEra
-    , CardanoEra (..)
     , InAnyCardanoEra (..)
     , IsShelleyBasedEra (..)
     , NetworkId
     , ShelleyBasedEra (..)
-    , ToCBOR
     )
 import Cardano.Binary
     ( serialize'
@@ -83,9 +80,6 @@ import Cardano.Crypto.Wallet
     )
 import Cardano.Ledger.Allegra.Core
     ( inputsTxBodyL
-    )
-import Cardano.Ledger.Crypto
-    ( DSIGN
     )
 import Cardano.Wallet.Address.Derivation
     ( Depth (..)
@@ -191,7 +185,6 @@ import Cardano.Wallet.Transaction
     )
 import Cardano.Wallet.Util
     ( HasCallStack
-    , internalError
     )
 import Control.Arrow
     ( left
@@ -229,15 +222,15 @@ import Data.Maybe
 import Data.Monoid.Monus
     ( Monus ((<\>))
     )
-import Data.Type.Equality
-    ( type (==)
-    )
 import Data.Word
     ( Word64
     , Word8
     )
 import Internal.Cardano.Write.ProtocolParameters
     ( ProtocolParameters (..)
+    )
+import Internal.Cardano.Write.Tx
+    ( RecentEra (..)
     )
 import Internal.Cardano.Write.Tx.SizeEstimation
     ( TxSkeleton (..)
@@ -256,7 +249,6 @@ import qualified Cardano.Api.Byron as Byron
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Crypto as CC
-import qualified Cardano.Crypto.DSIGN as DSIGN
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Crypto.Wallet as Crypto.HD
 import qualified Cardano.Ledger.Api as Ledger
@@ -294,17 +286,10 @@ data TxPayload era = TxPayload
       -- witnesses for what they're trying to do.
     }
 
-type EraConstraints era =
-    ( IsShelleyBasedEra era
-    , ToCBOR (Ledger.TxBody (Cardano.ShelleyLedgerEra era))
-    , DSIGN (Ledger.EraCrypto (Cardano.ShelleyLedgerEra era)) ~ DSIGN.Ed25519DSIGN
-    , (era == ByronEra) ~ 'False
-    )
-
 constructUnsignedTx
     :: forall era
-     . IsShelleyBasedEra era
-    => Cardano.NetworkId
+     . RecentEra era
+    -> Cardano.NetworkId
     -> (Maybe Cardano.TxMetadata, [Cardano.Certificate])
     -> (Maybe SlotNo, SlotNo)
     -- ^ Slot at which the transaction will optionally start and expire.
@@ -323,57 +308,61 @@ constructUnsignedTx
     -- ^ Delegation script
     -> Maybe (Script KeyHash)
     -- ^ Reference script
-    -> ShelleyBasedEra era
     -> Either ErrMkTransaction (Cardano.TxBody era)
 constructUnsignedTx
-    networkId (md, certs) ttl wdrl
-    cs fee toMint toBurn inpScripts stakingScriptM refScriptM era =
+    era networkId (md, certs) ttl wdrl
+    cs fee toMint toBurn =
         mkUnsignedTx
             era ttl cs md wdrls certs (toCardanoLovelace fee)
-            (fst toMint) (fst toBurn) mintingScripts inpScripts
-            stakingScriptM refScriptM
+            (fst toMint) (fst toBurn) mintingScripts
+
   where
     wdrls = mkWithdrawals networkId wdrl
     mintingScripts = Map.union (snd toMint) (snd toBurn)
 
-mkTx
-    :: forall k era
-     . EraConstraints era
-    => KeyFlavorS k
+mkTransaction
+    :: forall era k. RecentEra era
+        -- Era for which the transaction should be created.
     -> Cardano.NetworkId
-    -> TxPayload era
-    -> (Maybe SlotNo, SlotNo)
-    -- ^ Slot at which the transaction will start and expire.
+    -> KeyFlavorS k
     -> (XPrv, Passphrase "encryption")
-    -- ^ Reward account
+        -- Reward account
     -> (Address -> Maybe (k 'CredFromKeyK XPrv, Passphrase "encryption"))
-    -- ^ Key store
-    -> Withdrawal
-    -- ^ An optional withdrawal
+        -- Key store
+    -> TransactionCtx
+        -- An additional context about the transaction
     -> SelectionOf TxOut
-    -- ^ Finalized asset selection
-    -> Coin
-    -- ^ Explicit fee amount
-    -> ShelleyBasedEra era
+        -- A balanced coin selection where all change addresses have been
+        -- assigned.
     -> Either ErrMkTransaction (Tx, SealedTx)
-mkTx keyF networkId payload ttl (rewardAcnt, pwdAcnt) addrResolver wdrl cs fees era =
-    do
-
-    let TxPayload md certs mkExtraWits = payload
+mkTransaction era networkId keyF stakeCreds addrResolver ctx cs = do
+    let ttl   = txValidityInterval ctx
+    let wdrl = view #txWithdrawal ctx
+    let delta = selectionDelta cs
+    let md = view #txMetadata ctx
+    let certs =
+            case view #txDelegationAction ctx of
+                Nothing -> mempty
+                Just action ->
+                    let stakeXPub = toXPub $ fst stakeCreds
+                    in mkDelegationCertificates action (Left stakeXPub)
     let wdrls = mkWithdrawals networkId wdrl
 
     unsigned <- mkUnsignedTx era ttl (Right cs) md wdrls certs
-        (toCardanoLovelace fees)
+        (toCardanoLovelace delta)
         TokenMap.empty TokenMap.empty Map.empty Map.empty Nothing Nothing
-    let signed = signTransaction keyF networkId AnyWitnessCountCtx acctResolver
-            (const Nothing) Nothing (const Nothing) addrResolver inputResolver
-            (unsigned, mkExtraWits unsigned)
+    let
+        signed :: Cardano.Tx era
+        signed = Write.withConstraints era $
+            signTransaction @era keyF networkId AnyWitnessCountCtx acctResolver
+                (const Nothing) Nothing (const Nothing) addrResolver inputResolver
+                (unsigned, mempty)
 
     let withResolvedInputs (tx, _, _, _, _, _) = tx
             { resolvedInputs = second Just <$> F.toList (view #inputs cs)
             }
     Right ( withResolvedInputs (fromCardanoTx AnyWitnessCountCtx signed)
-          , sealedTxFromCardano' signed
+          , Write.withConstraints era $ sealedTxFromCardano' signed
           )
   where
     inputResolver :: TxIn -> Maybe Address
@@ -385,6 +374,7 @@ mkTx keyF networkId payload ttl (rewardAcnt, pwdAcnt) addrResolver wdrl cs fees 
 
     acctResolver :: RewardAccount -> Maybe (XPrv, Passphrase "encryption")
     acctResolver acct = do
+        let (rewardAcnt, pwdAcnt) = stakeCreds
         let acct' = toRewardAccountRaw $ toXPub rewardAcnt
         guard (acct == acct') $> (rewardAcnt, pwdAcnt)
 
@@ -394,8 +384,8 @@ mkTx keyF networkId payload ttl (rewardAcnt, pwdAcnt) addrResolver wdrl cs fees 
 --
 -- If a key for a given input isn't found, the input is skipped.
 signTransaction
-    :: forall k ktype era
-     . EraConstraints era
+    :: forall era k ktype
+     . Write.IsRecentEra era
     => KeyFlavorS k
     -> Cardano.NetworkId
     -- ^ Network identifier (e.g. mainnet, testnet)
@@ -551,24 +541,7 @@ newTransactionLayer
     -> NetworkId
     -> TransactionLayer k ktype SealedTx
 newTransactionLayer keyF networkId = TransactionLayer
-    { mkTransaction = \era stakeCreds keystore _pp ctx selection -> do
-        let ttl   = txValidityInterval ctx
-        let wdrl = view #txWithdrawal ctx
-        let delta = selectionDelta selection
-        case view #txDelegationAction ctx of
-            Nothing -> withShelleyBasedEra era $ do
-                let payload = TxPayload (view #txMetadata ctx) mempty mempty
-                mkTx keyF networkId payload ttl stakeCreds keystore wdrl
-                    selection delta
-
-            Just action -> withShelleyBasedEra era $ do
-                let stakeXPub = toXPub $ fst stakeCreds
-                let certs = mkDelegationCertificates action (Left stakeXPub)
-                let payload = TxPayload (view #txMetadata ctx) certs (const [])
-                mkTx keyF networkId payload ttl stakeCreds keystore wdrl
-                    selection delta
-
-    , addVkWitnesses =
+    { addVkWitnesses =
         \era witCountCtx stakeCreds policyCreds scriptStakingCredM addressResolver
         inputResolver sealedTx -> do
             let acctMap :: Map RewardAccount (XPrv, Passphrase "encryption")
@@ -600,32 +573,15 @@ newTransactionLayer keyF networkId = TransactionLayer
                     pure keyhash'
 
             case cardanoTxIdeallyNoLaterThan era sealedTx of
-                InAnyCardanoEra ByronEra _ ->
-                    sealedTx
-                InAnyCardanoEra ShelleyEra (Cardano.Tx body wits) ->
-                    signTransaction keyF networkId witCountCtx acctResolver (const Nothing)
-                    Nothing (const Nothing) addressResolver inputResolver (body, wits)
-                    & sealedTxFromCardano'
-                InAnyCardanoEra AllegraEra (Cardano.Tx body wits) ->
-                    signTransaction keyF networkId witCountCtx acctResolver (const Nothing)
-                    Nothing (const Nothing) addressResolver inputResolver (body, wits)
-                    & sealedTxFromCardano'
-                InAnyCardanoEra MaryEra (Cardano.Tx body wits) ->
-                    signTransaction keyF networkId witCountCtx acctResolver policyResolver
-                    policyKeyM stakingScriptResolver addressResolver inputResolver (body, wits)
-                    & sealedTxFromCardano'
-                InAnyCardanoEra AlonzoEra (Cardano.Tx body wits) ->
-                    signTransaction keyF networkId witCountCtx acctResolver policyResolver
-                    policyKeyM stakingScriptResolver addressResolver inputResolver (body, wits)
-                    & sealedTxFromCardano'
-                InAnyCardanoEra BabbageEra (Cardano.Tx body wits) ->
-                    signTransaction keyF networkId witCountCtx acctResolver policyResolver
-                    policyKeyM stakingScriptResolver addressResolver inputResolver (body, wits)
-                    & sealedTxFromCardano'
-                InAnyCardanoEra ConwayEra (Cardano.Tx body wits) ->
-                    signTransaction keyF networkId witCountCtx acctResolver policyResolver
-                    policyKeyM stakingScriptResolver addressResolver inputResolver (body, wits)
-                    & sealedTxFromCardano'
+                InAnyCardanoEra txEra (Cardano.Tx body wits) ->
+                    case Write.toRecentEra txEra of
+                        Just recentTxEra -> Write.withConstraints recentTxEra $
+                            signTransaction
+                                keyF networkId witCountCtx acctResolver
+                                policyResolver policyKeyM stakingScriptResolver
+                                addressResolver inputResolver (body, wits)
+                            & sealedTxFromCardano'
+                        Nothing -> sealedTx
 
     , decodeTx = _decodeSealedTx
 
@@ -642,8 +598,8 @@ newTransactionLayer keyF networkId = TransactionLayer
 --
 mkUnsignedTransaction
     :: forall era
-     . Write.IsRecentEra era
-    => NetworkId
+     . Write.RecentEra era
+    -> NetworkId
     -> Either XPub (Maybe (Script KeyHash))
     -- ^ Reward account public key or optional script hash.
     -> TransactionCtx
@@ -652,7 +608,7 @@ mkUnsignedTransaction
     -- ^ A balanced coin selection where all change addresses have been
     -- assigned.
     -> Either ErrMkTransaction (Cardano.TxBody era)
-mkUnsignedTransaction networkId stakeCred ctx selection = do
+mkUnsignedTransaction era networkId stakeCred ctx selection = do
     let ttl = txValidityInterval ctx
     let wdrl = view #txWithdrawal ctx
     let delta = case selection of
@@ -676,24 +632,21 @@ mkUnsignedTransaction networkId stakeCred ctx selection = do
                 WithdrawalSelf rewardAcct _ _ ->
                     if ourRewardAcctM == Just rewardAcct
                     then
-                        constructUnsignedTx
+                        constructUnsignedTx era
                             networkId (md, []) ttl wdrl selection delta
                             assetsToBeMinted assetsToBeBurned
                             inpsScripts stakingScriptM refScriptM
-                            (Write.shelleyBasedEraFromRecentEra Write.recentEra)
                     else
-                        constructUnsignedTx
+                        constructUnsignedTx era
                             networkId (md, []) ttl wdrl selection delta
                             assetsToBeMinted assetsToBeBurned
                             inpsScripts Nothing refScriptM
-                            (Write.shelleyBasedEraFromRecentEra Write.recentEra)
                 _ ->
-                    constructUnsignedTx
+                    constructUnsignedTx era
                         networkId (md, []) ttl wdrl
                         selection delta assetsToBeMinted assetsToBeBurned
                         inpsScripts
                     Nothing refScriptM
-                    (Write.shelleyBasedEraFromRecentEra Write.recentEra)
         Just action -> do
             let certs = case stakeCred of
                     Left xpub ->
@@ -707,10 +660,9 @@ mkUnsignedTransaction networkId stakeCred ctx selection = do
                             , "action"
                             ]
             let payload = (view #txMetadata ctx, certs)
-            constructUnsignedTx networkId payload ttl wdrl
+            constructUnsignedTx era networkId payload ttl wdrl
                 selection delta assetsToBeMinted assetsToBeBurned inpsScripts
                 stakingScriptM refScriptM
-                (Write.shelleyBasedEraFromRecentEra Write.recentEra)
 
 _decodeSealedTx
     :: AnyCardanoEra
@@ -742,22 +694,6 @@ mkDelegationCertificates da cred =
             ]
        Quit -> [toStakeKeyDeregCert cred]
 
-withShelleyBasedEra
-    :: forall a
-     . AnyCardanoEra
-    -> ( forall era. EraConstraints era
-         => ShelleyBasedEra era -> Either ErrMkTransaction a
-       )
-    -> Either ErrMkTransaction a
-withShelleyBasedEra era fn = case era of
-    AnyCardanoEra ByronEra    -> Left $ ErrMkTransactionInvalidEra era
-    AnyCardanoEra ShelleyEra  -> fn ShelleyBasedEraShelley
-    AnyCardanoEra AllegraEra  -> fn ShelleyBasedEraAllegra
-    AnyCardanoEra MaryEra     -> fn ShelleyBasedEraMary
-    AnyCardanoEra AlonzoEra   -> fn ShelleyBasedEraAlonzo
-    AnyCardanoEra BabbageEra  -> fn ShelleyBasedEraBabbage
-    AnyCardanoEra ConwayEra   -> fn ShelleyBasedEraConway
-
 -- FIXME: Make this a Allegra or Shelley transaction depending on the era we're
 -- in. However, quoting Duncan:
 --
@@ -768,8 +704,7 @@ withShelleyBasedEra era fn = case era of
 --
 -- Which suggests that we may get away with Shelley-only transactions for now?
 mkUnsignedTx
-    :: forall era. Cardano.IsCardanoEra era
-    => ShelleyBasedEra era
+    :: forall era. Write.RecentEra era
     -> (Maybe SlotNo, SlotNo)
     -> Either PreSelection (SelectionOf TxOut)
     -> Maybe Cardano.TxMetadata
@@ -797,7 +732,10 @@ mkUnsignedTx
     inpsScripts
     stakingScriptM
     refScriptM = extractValidatedOutputs cs >>= \outs ->
-    left toErrMkTx $ fmap removeDummyInput $ Cardano.createAndValidateTransactionBody
+    left toErrMkTx
+    $ fmap removeDummyInput
+    $ Write.withConstraints era
+    $ Cardano.createAndValidateTransactionBody
     Cardano.TxBodyContent
     { Cardano.txIns = inputWits
 
@@ -822,11 +760,13 @@ mkUnsignedTx
 
     , Cardano.txOuts = case refScriptM of
             Nothing ->
-                map (toCardanoTxOut era Nothing) outs
+                map (toCardanoTxOut shelleyEra Nothing) outs
             Just _ -> case outs of
                 firstOut:rest ->
-                    let cardanoFirstTxOut = toCardanoTxOut era refScriptM firstOut
-                    in cardanoFirstTxOut:(map (toCardanoTxOut era Nothing) rest)
+                    let cardanoFirstTxOut =
+                            toCardanoTxOut shelleyEra refScriptM firstOut
+                    in cardanoFirstTxOut :
+                        (map (toCardanoTxOut shelleyEra Nothing) rest)
                 _ ->
                     []
 
@@ -880,7 +820,7 @@ mkUnsignedTx
             in
                 Cardano.TxCertificates certSupported certs ctx
 
-    , Cardano.txFee = explicitFees era fees
+    , Cardano.txFee = explicitFees shelleyEra fees
 
     , Cardano.txValidityRange =
         let toLowerBound from = case txValidityLowerBoundSupported of
@@ -974,80 +914,46 @@ mkUnsignedTx
 
     metadataSupported :: Cardano.TxMetadataSupportedInEra era
     metadataSupported = case era of
-        ShelleyBasedEraShelley -> Cardano.TxMetadataInShelleyEra
-        ShelleyBasedEraAllegra -> Cardano.TxMetadataInAllegraEra
-        ShelleyBasedEraMary -> Cardano.TxMetadataInMaryEra
-        ShelleyBasedEraAlonzo -> Cardano.TxMetadataInAlonzoEra
-        ShelleyBasedEraBabbage -> Cardano.TxMetadataInBabbageEra
-        ShelleyBasedEraConway -> Cardano.TxMetadataInConwayEra
+        RecentEraBabbage -> Cardano.TxMetadataInBabbageEra
+        RecentEraConway -> Cardano.TxMetadataInConwayEra
 
     certSupported :: Cardano.CertificatesSupportedInEra era
     certSupported = case era of
-        ShelleyBasedEraShelley -> Cardano.CertificatesInShelleyEra
-        ShelleyBasedEraAllegra -> Cardano.CertificatesInAllegraEra
-        ShelleyBasedEraMary    -> Cardano.CertificatesInMaryEra
-        ShelleyBasedEraAlonzo -> Cardano.CertificatesInAlonzoEra
-        ShelleyBasedEraBabbage -> Cardano.CertificatesInBabbageEra
-        ShelleyBasedEraConway -> Cardano.CertificatesInConwayEra
+        RecentEraBabbage -> Cardano.CertificatesInBabbageEra
+        RecentEraConway -> Cardano.CertificatesInConwayEra
 
     wdrlsSupported :: Cardano.WithdrawalsSupportedInEra era
     wdrlsSupported = case era of
-        ShelleyBasedEraShelley -> Cardano.WithdrawalsInShelleyEra
-        ShelleyBasedEraAllegra -> Cardano.WithdrawalsInAllegraEra
-        ShelleyBasedEraMary    -> Cardano.WithdrawalsInMaryEra
-        ShelleyBasedEraAlonzo -> Cardano.WithdrawalsInAlonzoEra
-        ShelleyBasedEraBabbage -> Cardano.WithdrawalsInBabbageEra
-        ShelleyBasedEraConway -> Cardano.WithdrawalsInConwayEra
+        RecentEraBabbage -> Cardano.WithdrawalsInBabbageEra
+        RecentEraConway -> Cardano.WithdrawalsInConwayEra
 
     txValidityUpperBoundSupported :: Cardano.ValidityUpperBoundSupportedInEra era
     txValidityUpperBoundSupported = case era of
-        ShelleyBasedEraShelley -> Cardano.ValidityUpperBoundInShelleyEra
-        ShelleyBasedEraAllegra -> Cardano.ValidityUpperBoundInAllegraEra
-        ShelleyBasedEraMary -> Cardano.ValidityUpperBoundInMaryEra
-        ShelleyBasedEraAlonzo -> Cardano.ValidityUpperBoundInAlonzoEra
-        ShelleyBasedEraBabbage -> Cardano.ValidityUpperBoundInBabbageEra
-        ShelleyBasedEraConway -> Cardano.ValidityUpperBoundInConwayEra
+        RecentEraBabbage -> Cardano.ValidityUpperBoundInBabbageEra
+        RecentEraConway -> Cardano.ValidityUpperBoundInConwayEra
 
     txValidityLowerBoundSupported
         :: Maybe (Cardano.ValidityLowerBoundSupportedInEra era)
     txValidityLowerBoundSupported = case era of
-        ShelleyBasedEraShelley -> Nothing
-        ShelleyBasedEraAllegra -> Just Cardano.ValidityLowerBoundInAllegraEra
-        ShelleyBasedEraMary -> Just Cardano.ValidityLowerBoundInMaryEra
-        ShelleyBasedEraAlonzo -> Just Cardano.ValidityLowerBoundInAlonzoEra
-        ShelleyBasedEraBabbage -> Just Cardano.ValidityLowerBoundInBabbageEra
-        ShelleyBasedEraConway -> Just Cardano.ValidityLowerBoundInConwayEra
+        RecentEraBabbage -> Just Cardano.ValidityLowerBoundInBabbageEra
+        RecentEraConway -> Just Cardano.ValidityLowerBoundInConwayEra
 
     txMintingSupported :: Maybe (Cardano.MultiAssetSupportedInEra era)
     txMintingSupported = case era of
-        ShelleyBasedEraShelley -> Nothing
-        ShelleyBasedEraAllegra -> Nothing
-        ShelleyBasedEraMary -> Just Cardano.MultiAssetInMaryEra
-        ShelleyBasedEraAlonzo -> Just Cardano.MultiAssetInAlonzoEra
-        ShelleyBasedEraBabbage -> Just Cardano.MultiAssetInBabbageEra
-        ShelleyBasedEraConway -> Just Cardano.MultiAssetInConwayEra
+        RecentEraBabbage -> Just Cardano.MultiAssetInBabbageEra
+        RecentEraConway -> Just Cardano.MultiAssetInConwayEra
 
     scriptWitsSupported
         :: Cardano.ScriptLanguageInEra Cardano.SimpleScript' era
     scriptWitsSupported = case era of
-        ShelleyBasedEraShelley -> internalError
-            "scriptWitsSupported: we should be at least in Mary"
-        ShelleyBasedEraAllegra -> internalError
-            "scriptWitsSupported: we should be at least in Mary"
-        ShelleyBasedEraMary -> Cardano.SimpleScriptInMary
-        ShelleyBasedEraAlonzo -> Cardano.SimpleScriptInAlonzo
-        ShelleyBasedEraBabbage -> Cardano.SimpleScriptInBabbage
-        ShelleyBasedEraConway -> Cardano.SimpleScriptInConway
+        RecentEraBabbage -> Cardano.SimpleScriptInBabbage
+        RecentEraConway -> Cardano.SimpleScriptInConway
 
     referenceInpsSupported
         :: Maybe (Cardano.ReferenceTxInsScriptsInlineDatumsSupportedInEra era)
     referenceInpsSupported = case era of
-        ShelleyBasedEraShelley -> Nothing
-        ShelleyBasedEraAllegra -> Nothing
-        ShelleyBasedEraMary -> Nothing
-        ShelleyBasedEraAlonzo -> Nothing
-        ShelleyBasedEraBabbage -> Just Cardano.ReferenceTxInsScriptsInlineDatumsInBabbageEra
-        ShelleyBasedEraConway -> Just Cardano.ReferenceTxInsScriptsInlineDatumsInConwayEra
+        RecentEraBabbage -> Just Cardano.ReferenceTxInsScriptsInlineDatumsInBabbageEra
+        RecentEraConway -> Just Cardano.ReferenceTxInsScriptsInlineDatumsInConwayEra
 
     toScriptWitness :: Script KeyHash -> Cardano.ScriptWitness witctx era
     toScriptWitness script =
@@ -1078,6 +984,7 @@ mkUnsignedTx
         buildTxCommand
             = Cardano.BuildTxWith
             $ Cardano.KeyWitness Cardano.KeyWitnessForSpending
+    shelleyEra = Write.shelleyBasedEraFromRecentEra era
 
 -- TODO: ADP-2257
 -- cardano-node does not allow to construct tx without inputs at this moment.
@@ -1148,12 +1055,14 @@ mkShelleyWitness body key =
         $ Crypto.HD.xPrvChangePass pwd BS.empty xprv
 
 mkByronWitness
-    :: forall era. EraConstraints era
+    :: forall era. Write.IsRecentEra era
     => Cardano.TxBody era
     -> Cardano.NetworkId
     -> Address
     -> (XPrv, Passphrase "encryption")
     -> Cardano.KeyWitness era
+mkByronWitness (Byron.ByronTxBody _ :: Cardano.TxBody byronEra) _ _ _ =
+    case Write.recentEra @byronEra of {}
 mkByronWitness
     (Cardano.ShelleyTxBody era body _scripts _scriptData _auxData _scriptValidity)
     nw
@@ -1162,7 +1071,9 @@ mkByronWitness
     Cardano.ShelleyBootstrapWitness era $
         SL.makeBootstrapWitness txHash (unencrypt encryptedKey) addrAttr
   where
-    txHash = Crypto.castHash $ Crypto.hashWith serialize' body
+    txHash = case Write.recentEra @era of
+        RecentEraBabbage -> Crypto.castHash $ Crypto.hashWith serialize' body
+        RecentEraConway  -> Crypto.castHash $ Crypto.hashWith serialize' body
 
     unencrypt (xprv, pwd) = CC.SigningKey
         $ Crypto.HD.xPrvChangePass pwd BS.empty xprv

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -89,7 +89,6 @@ import Cardano.Wallet.Primitive.Slotting
     )
 import Cardano.Wallet.Primitive.Types
     ( Certificate
-    , ProtocolParameters
     , SlotNo (..)
     )
 import Cardano.Wallet.Primitive.Types.Address
@@ -126,6 +125,9 @@ import Cardano.Wallet.Primitive.Types.Tx.TxOut
     )
 import Control.DeepSeq
     ( NFData (..)
+    )
+import Data.Kind
+    ( Type
     )
 import Data.List.NonEmpty
     ( NonEmpty
@@ -168,31 +170,8 @@ import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map
 
-data TransactionLayer k ktype tx = TransactionLayer
-    { mkTransaction
-        :: AnyCardanoEra
-            -- Era for which the transaction should be created.
-        -> (XPrv, Passphrase "encryption")
-            -- Reward account
-        -> (Address -> Maybe (k 'CredFromKeyK XPrv, Passphrase "encryption"))
-            -- Key store
-        -> ProtocolParameters
-            -- Current protocol parameters
-        -> TransactionCtx
-            -- An additional context about the transaction
-        -> SelectionOf TxOut
-            -- A balanced coin selection where all change addresses have been
-            -- assigned.
-        -> Either ErrMkTransaction (Tx, tx)
-        -- ^ Construct a standard transaction
-        --
-        -- " Standard " here refers to the fact that we do not deal with redemption,
-        -- multisignature transactions, etc.
-        --
-        -- This expects as a first argument a mean to compute or lookup private
-        -- key corresponding to a particular address.
-
-    , addVkWitnesses
+data TransactionLayer (k :: Depth -> Type -> Type) ktype tx = TransactionLayer
+    { addVkWitnesses
         :: AnyCardanoEra
             -- Preferred latest era
         -> WitnessCountCtx


### PR DESCRIPTION
- Replace `IsShelleyBasedEra` and `IsCardanoEra` and similar with `IsRecentEra` / `RecentEra era`
- [x] Error appropriately from signTransaction with non-recent tx formats

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2353 — increase consistency first