### PR TITLE
Replace use of `ViewPatterns` with case pattern match in `decodeSealedTx`.

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -715,8 +715,8 @@ mkUnsignedTransaction networkId stakeCred ctx selection = do
 _decodeSealedTx
     :: AnyCardanoEra
     -> WitnessCountCtx
-    -> SealedTx ->
-        ( Tx
+    -> SealedTx
+    ->  ( Tx
         , TokenMapWithScripts
         , TokenMapWithScripts
         , [Certificate]

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -723,8 +723,10 @@ _decodeSealedTx
         , Maybe ValidityIntervalExplicit
         , WitnessCount
         )
-_decodeSealedTx preferredLatestEra witCtx (cardanoTxIdeallyNoLaterThan preferredLatestEra -> Cardano.InAnyCardanoEra _ tx) =
-    fromCardanoTx witCtx tx
+_decodeSealedTx preferredLatestEra witCtx sealedTx =
+    case cardanoTxIdeallyNoLaterThan preferredLatestEra sealedTx of
+        Cardano.InAnyCardanoEra _ tx ->
+            fromCardanoTx witCtx tx
 
 mkDelegationCertificates
     :: DelegationAction

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -18,7 +18,6 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns #-}
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Use camelCase" -}
 


### PR DESCRIPTION
## Issue

None. Noticed while browsing the code.

## Description

This PR replaces an (arguably) awkward use of `ViewPatterns` with an ordinary case pattern match in `decodeSealedTx`.