### PR TITLE
Use `Write.Address` in `UTxOAssumptions`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -752,8 +752,11 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 AllKeyPaymentCredentials -> []
                 AllByronKeyPaymentCredentials -> []
                 AllScriptPaymentCredentialsFrom _template toInpScripts ->
-                    toInpScripts . view #address . snd <$>
-                        extraInputs <> extraCollateral'
+                    ( toInpScripts
+                    . Convert.toLedgerAddress
+                    . view #address
+                    . snd
+                    ) <$> extraInputs <> extraCollateral'
         extraCollateral = fst <$> extraCollateral'
         unsafeFromLovelace (CardanoApi.Lovelace l) = W.Coin.unsafeFromIntegral l
     candidateTx <- assembleTransaction $ TxUpdate

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/UTxOAssumptions.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/UTxOAssumptions.hs
@@ -27,7 +27,6 @@ import Internal.Cardano.Write.Tx
     )
 
 import qualified Cardano.Address.Script as CA
-import qualified Cardano.Wallet.Primitive.Types.Address as W
 
 -- | Assumptions about UTxOs that are needed for coin selection.
 data UTxOAssumptions
@@ -42,7 +41,7 @@ data UTxOAssumptions
     -- payment credentials, where the scripts are both derived
     -- from the 'ScriptTemplate' and can be looked up using the given function.
         !CA.ScriptTemplate
-        !(W.Address -> CA.Script CA.KeyHash)
+        !(Address -> CA.Script CA.KeyHash)
 
 assumedInputScriptTemplate :: UTxOAssumptions -> Maybe CA.ScriptTemplate
 assumedInputScriptTemplate = \case

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -894,6 +894,7 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Read as Read
 import qualified Cardano.Wallet.Registry as Registry
+import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Control.Concurrent.Concierge as Concierge
 import qualified Data.ByteString as BS
 import qualified Data.Foldable as F
@@ -3210,7 +3211,9 @@ constructSharedTransaction
                 balancedTx <-
                     balanceTransaction api argGenChange
                     (AllScriptPaymentCredentialsFrom
-                        (Shared.paymentTemplate (getState cp)) scriptLookup)
+                        (Shared.paymentTemplate (getState cp))
+                        (scriptLookup . Convert.toWalletAddress)
+                    )
                     (ApiT wid)
                         ApiBalanceTransactionPostData
                         { transaction =


### PR DESCRIPTION
## Issue

ADP-3184

## Description

This PR adjusts `UTxOAssumptions` to use the `Write.Address` type instead of the wallet primitive `Address` type.