### PR TITLE
[ADP-3219] Add `Cardano.WalletExperiment` proving `prop-create-get`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ Makefile
 *.olean
 leanpkg.path
 
+## Agda
+*.agdai
+
 ## Artifacts
 bench-wallet
 memory-time.txt

--- a/lib/customer-deposit-wallet/spec/Cardano/WalletExperiment.agda
+++ b/lib/customer-deposit-wallet/spec/Cardano/WalletExperiment.agda
@@ -1,0 +1,116 @@
+{-# OPTIONS --erasure #-}
+
+-- Experimental wallet implementation
+-- with proofs for the specification.
+module Cardano.WalletExperiment where
+
+open import Haskell.Prelude
+open import Haskell.Data.Maybe
+import Haskell.Data.Map as Map
+
+{-----------------------------------------------------------------------------
+    Assumptions
+------------------------------------------------------------------------------}
+Address = Nat
+Slot = Nat
+TxId = Nat
+
+Value = Integer
+Customer = Nat
+
+{-----------------------------------------------------------------------------
+    Type definition
+------------------------------------------------------------------------------}
+record WalletState : Set where
+  field
+    addresses : Map.Map Address Customer
+open WalletState
+
+{-----------------------------------------------------------------------------
+    Mapping between Customers and Address
+------------------------------------------------------------------------------}
+-- Operations
+
+-- Helper function
+swap : ∀ {a b : Set} → a × b → b × a
+swap (x , y) = (y , x)
+
+listCustomers : WalletState → List (Customer × Address)
+listCustomers = map swap ∘ Map.toAscList ∘ addresses
+
+deriveAddress : Nat → Address
+deriveAddress ix = suc ix
+
+createAddress : Customer → WalletState → (Address × WalletState)
+createAddress c s0 = ( addr , s1 )
+  where
+    addr = deriveAddress c
+    s1 = record { addresses = Map.insert addr c (addresses s0) }
+
+-- Properties
+
+-- Specification
+knownCustomerAddress : Address → WalletState → Bool
+knownCustomerAddress address = elem address ∘ map snd ∘ listCustomers
+
+-- alternate definition of knownCustomerAddress
+knownCustomerAddress' : Address → WalletState → Bool
+knownCustomerAddress' address =
+    elem address ∘ map fst ∘ Map.toAscList ∘ addresses
+
+-- alternate definition and original definition are equal
+lemma-known-known'
+  : ∀ (a : Address) (s : WalletState)
+  → knownCustomerAddress a s ≡ knownCustomerAddress' a s
+lemma-known-known' a s =
+  begin
+    (elem a ∘ map snd ∘ listCustomers) s
+  ≡⟨⟩
+    (elem a ∘ map snd ∘ map swap ∘ Map.toAscList ∘ addresses) s
+  ≡⟨ cong (elem a) (sym (map-∘ snd swap (Map.toAscList (addresses s)))) ⟩
+    (elem a ∘ map (snd ∘ swap) ∘ Map.toAscList ∘ addresses) s
+  ≡⟨⟩
+    (elem a ∘ map fst ∘ Map.toAscList ∘ addresses) s
+  ∎
+
+-- lemma about converting == to ≡
+lemma-lookup-insert-same
+    : ∀ (a : Address) (c : Customer) (m : Map.Map Address Customer)
+    → Map.lookup a (Map.insert a c m) ≡ Just c
+lemma-lookup-insert-same a c m =
+  begin
+    Map.lookup a (Map.insert a c m)
+  ≡⟨ Map.prop-lookup-insert a a c m ⟩
+    (if (a == a) then Just c else Map.lookup a m)
+  ≡⟨ Map.lemma-if-True a a (equality' a a refl) ⟩
+    Just c
+  ∎
+
+-- Specification
+prop-create-known
+  : ∀ (c : Customer) (s0 : WalletState)
+  → let (address , s1) = createAddress c s0
+    in  knownCustomerAddress address s1 ≡ True
+prop-create-known c s0 =
+  let (a , s1) = createAddress c s0
+  in
+    begin
+      knownCustomerAddress a s1
+    ≡⟨ lemma-known-known' a s1 ⟩
+      knownCustomerAddress' a s1
+    ≡⟨ Map.prop-lookup-toAscList-Just a c (addresses s1)
+        (lemma-lookup-insert-same a c (addresses s0))
+      ⟩
+      True
+    ∎
+
+{-----------------------------------------------------------------------------
+    Address derivation
+------------------------------------------------------------------------------}
+
+-- Specification
+prop-create-derive
+  : ∀ (c : Customer) (s0 : WalletState)
+  → let (address , _) = createAddress c s0
+    in  deriveAddress c ≡ address
+prop-create-derive = λ c s0 → refl

--- a/lib/customer-deposit-wallet/spec/Haskell/Data/Map.agda
+++ b/lib/customer-deposit-wallet/spec/Haskell/Data/Map.agda
@@ -1,0 +1,95 @@
+{-# OPTIONS --erasure #-}
+
+-- Formalization of Data.Map
+module Haskell.Data.Map where
+
+open import Haskell.Prelude hiding (lookup; null; map)
+import Haskell.Prelude as L using (map)
+
+-- These lemmas are obvious substitutions,
+-- but substitution in a subterm is sometimes cumbersome
+-- with equational reasoning.
+lemma-if-True
+  : ∀ {A B : Set} {{_ : Eq A}} (x x' : A) {t f : B}
+  → (x == x') ≡ True
+  → (if (x == x') then t else f) ≡ t
+lemma-if-True _ _ eq1 rewrite eq1 = refl
+
+lemma-if-False
+  : ∀ {A B : Set} {{_ : Eq A}} (x x' : A) {t f : B}
+  → (x == x') ≡ False
+  → (if (x == x') then t else f) ≡ f
+lemma-if-False _ _ eq1 rewrite eq1 = refl
+
+-- Data.Map
+
+postulate
+  Map : ∀ (k : Set) {{iOrd : Ord k}} → Set → Set
+
+module
+    OperationsAndProperties
+      {k a : Set}
+      {{iOrd : Ord k}}
+  where
+  postulate
+    lookup : k → Map k a → Maybe a
+    null      : Map k a → Bool
+
+    empty     : Map k a
+    insert    : k → a → Map k a → Map k a
+    delete    : k → Map k a → Map k a
+    toAscList : Map k a → List (k × a)
+    fromList  : List (k × a) → Map k a
+    fromListWith : (a → a → a) → List (k × a) → Map k a
+    unionWith    : (a → a → a) → Map k a → Map k a → Map k a
+
+    instance
+      iMapFunctor : Functor (Map k)
+
+    prop-lookup-empty
+      : ∀ (key : k)
+      → lookup key empty ≡ Nothing
+
+    prop-lookup-insert
+      : ∀ (key keyi : k) (x : a) (m : Map k a)
+      → lookup key (insert keyi x m)
+        ≡ (if (key == keyi) then Just x else lookup key m)
+
+    prop-lookup-delete
+      : ∀ (key keyi : k) (m : Map k a)
+      → lookup key (delete keyi m)
+        ≡ (if (key == keyi) then Nothing else lookup key m)
+
+    prop-lookup-toAscList-Just
+      : ∀ (key : k) (x : a) (m : Map k a)
+      → lookup key m ≡ Just x
+      → (elem key ∘ L.map fst ∘ toAscList) m ≡ True
+
+    prop-lookup-toAscList-Nothing
+      : ∀ (key : k) (x : a) (m : Map k a)
+      → lookup key m ≡ Nothing
+      → (elem key ∘ L.map fst ∘ toAscList) m ≡ False
+
+
+  map : ∀ {b : Set} → (a → b) → Map k a → Map k b
+  map = fmap
+
+  singleton : k → a → Map k a
+  singleton = λ k x → insert k x empty
+
+  prop-lookup-singleton
+    : ∀ (key keyi : k) (x : a)
+    → lookup key (singleton keyi x)
+      ≡ (if (key == keyi) then Just x else Nothing)
+  prop-lookup-singleton key keyi x =
+    begin
+      lookup key (singleton keyi x)
+    ≡⟨⟩
+      lookup key (insert keyi x empty)
+    ≡⟨ prop-lookup-insert key keyi x empty ⟩
+      (if (key == keyi) then Just x else lookup key empty)
+    ≡⟨ cong (λ f → if (key == keyi) then Just x else f) (prop-lookup-empty key) ⟩
+      (if (key == keyi) then Just x else Nothing)
+    ∎
+
+open OperationsAndProperties public

--- a/lib/customer-deposit-wallet/spec/Haskell/Data/Maybe.agda
+++ b/lib/customer-deposit-wallet/spec/Haskell/Data/Maybe.agda
@@ -1,0 +1,18 @@
+{-# OPTIONS --erasure #-}
+
+module Haskell.Data.Maybe where
+
+open import Haskell.Prelude
+
+isNothing : ∀ {a : Set} → Maybe a → Bool
+isNothing (Just _) = False
+isNothing Nothing = True
+
+isJust : ∀ {a : Set} → Maybe a → Bool
+isJust (Just _) = True
+isJust Nothing = False
+
+catMaybes : ∀ {a : Set} → List (Maybe a) → List a
+catMaybes [] = []
+catMaybes (Nothing ∷ xs) = catMaybes xs
+catMaybes (Just x ∷ xs) = x ∷ catMaybes xs

--- a/lib/customer-deposit-wallet/spec/customer-deposit-wallet.lagda.md
+++ b/lib/customer-deposit-wallet/spec/customer-deposit-wallet.lagda.md
@@ -195,7 +195,7 @@ The two operations are related by the property
 ```agda
     field
 
-      prop_create-get
+      prop-create-known
         : ∀(c : Customer) (s0 : WalletState)
         → let (address , s1) = createAddress c s0
           in  knownCustomerAddress address s1 ≡ True


### PR DESCRIPTION
This experimental pull request adds an Agda module `Cardano.WalletExperiment` where we prove the property `prop-create-get` from the specification.

This implementation uses `Data.Map`. In order to do the proof, we need to postulate several of its properties. We do so in the Agda module `Haskell.Data.Map`.

### Comments

* I have named the property `prop-create-get` instead of `prop_create-get` because underscores have a reserved meaning in Agda.

### Issue number

ADP-3219