### PR TITLE
[ADP-3214] Specialize SQL operations for `Cardano.Pool.DB`

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
@@ -217,7 +217,7 @@ import System.IOManager
     ( withIOManager
     )
 
-import qualified Cardano.Pool.DB.Sqlite as Pool
+import qualified Cardano.Pool.DB.Layer as Pool
 import qualified Cardano.Wallet.Api.Http.Shelley.Server as Server
 import qualified Cardano.Wallet.DB.Layer as Sqlite
 import qualified Network.Wai.Handler.Warp as Warp

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -217,6 +217,7 @@ library
     Cardano.DB.Sqlite
     Cardano.DB.Sqlite.Delete
     Cardano.DB.Sqlite.ForeignKeys
+    Cardano.DB.Sqlite.Migration.Old
     Cardano.Pool.DB
     Cardano.Pool.DB.Log
     Cardano.Pool.DB.Model

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -221,6 +221,7 @@ library
     Cardano.Pool.DB.Model
     Cardano.Pool.DB.MVar
     Cardano.Pool.DB.Layer
+    Cardano.Pool.DB.Sqlite
     Cardano.Pool.DB.Sqlite.TH
     Cardano.Pool.Metadata
     Cardano.Pool.Metadata.Types

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -220,7 +220,7 @@ library
     Cardano.Pool.DB.Log
     Cardano.Pool.DB.Model
     Cardano.Pool.DB.MVar
-    Cardano.Pool.DB.Sqlite
+    Cardano.Pool.DB.Layer
     Cardano.Pool.DB.Sqlite.TH
     Cardano.Pool.Metadata
     Cardano.Pool.Metadata.Types
@@ -852,7 +852,7 @@ test-suite unit
     Cardano.Pool.DB.Arbitrary
     Cardano.Pool.DB.MVarSpec
     Cardano.Pool.DB.Properties
-    Cardano.Pool.DB.SqliteSpec
+    Cardano.Pool.DB.LayerSpec
     Cardano.Pool.RankSpec
     Cardano.Wallet.Address.Derivation.ByronSpec
     Cardano.Wallet.Address.Derivation.IcarusSpec

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -216,6 +216,7 @@ library
     Cardano.Api.Extra
     Cardano.DB.Sqlite
     Cardano.DB.Sqlite.Delete
+    Cardano.DB.Sqlite.ForeignKeys
     Cardano.Pool.DB
     Cardano.Pool.DB.Log
     Cardano.Pool.DB.Model

--- a/lib/wallet/src/Cardano/DB/Sqlite.hs
+++ b/lib/wallet/src/Cardano/DB/Sqlite.hs
@@ -468,7 +468,6 @@ data DBLog
     | MsgRun BracketLog
     | MsgOpenSingleConnection FilePath
     | MsgCloseSingleConnection FilePath
-    | MsgDatabaseReset
     | MsgIsAlreadyClosed Text
     | MsgStatementAlreadyFinalized Text
     | MsgManualMigrationNeeded DBField Text
@@ -491,7 +490,6 @@ instance HasSeverityAnnotation DBLog where
         MsgRun _ -> Debug
         MsgCloseSingleConnection _ -> Info
         MsgExpectedMigration _ -> Debug
-        MsgDatabaseReset -> Notice
         MsgIsAlreadyClosed _ -> Warning
         MsgStatementAlreadyFinalized _ -> Warning
         MsgManualMigrationNeeded{} -> Notice
@@ -514,9 +512,6 @@ instance ToText DBLog where
         MsgQuery stmt _ -> stmt
         MsgRun b ->
             "Running database action - " <> toText b
-        MsgDatabaseReset ->
-            "Non backward compatible database found. Removing old database \
-            \and re-creating it from scratch. Ignore the previous error."
         MsgOpenSingleConnection fp ->
             "Opening single database connection (" +| fp |+ ")"
         MsgCloseSingleConnection fp ->

--- a/lib/wallet/src/Cardano/DB/Sqlite.hs
+++ b/lib/wallet/src/Cardano/DB/Sqlite.hs
@@ -43,19 +43,9 @@ module Cardano.DB.Sqlite
     , dbChunked'
     , handleConstraint
 
-      -- * Old-style Manual Migration
-    , ManualMigration (..)
-    , noManualMigration
-    , MigrationError (..)
-    , DBField (..)
-    , tableName
-    , fieldName
-    , fieldType
-
       -- * Logging
     , DBLog (..)
     , ReadDBHandle
-    , foldMigrations
     ) where
 
 import Prelude
@@ -75,6 +65,14 @@ import Cardano.DB.Sqlite.ForeignKeys
     ( ForeignKeysSetting (..)
     , withForeignKeysDisabled
     )
+import Cardano.DB.Sqlite.Migration.Old
+    ( DBField (..)
+    , ManualMigration (..)
+    , MatchMigrationError (..)
+    , MigrationError (..)
+    , fieldName
+    , tableName
+    )
 import Cardano.Wallet.DB.Migration
     ( ErrWrongVersion (..)
     )
@@ -85,7 +83,6 @@ import Control.Lens
 import Control.Monad
     ( join
     , void
-    , when
     )
 import Control.Monad.IO.Unlift
     ( MonadUnliftIO (..)
@@ -122,9 +119,6 @@ import Data.Functor
     ( ($>)
     , (<&>)
     )
-import Data.List
-    ( isInfixOf
-    )
 import Data.List.Split
     ( chunksOf
     )
@@ -144,24 +138,15 @@ import Data.Time.Clock
     ( NominalDiffTime
     )
 import Database.Persist.EntityDef
-    ( getEntityDBName
-    , getEntityFields
-    )
-import Database.Persist.Names
-    ( EntityNameDB (..)
-    , unFieldNameDB
+    ( getEntityFields
     )
 import Database.Persist.Sql
-    ( EntityField
-    , LogFunc
+    ( LogFunc
     , Migration
     , PersistEntity (..)
     , PersistException
     , SqlPersistT
-    , SqlType (..)
     , close'
-    , fieldDB
-    , fieldSqlType
     , runMigrationUnsafeQuiet
     , runSqlConn
     )
@@ -195,9 +180,7 @@ import UnliftIO.Compat
     ( handleIf
     )
 import UnliftIO.Exception
-    ( Exception
-    , bracket
-    , bracket_
+    ( bracket
     , handleJust
     , tryJust
     )
@@ -207,7 +190,6 @@ import UnliftIO.MVar
     , withMVarMasked
     )
 
-import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -432,45 +414,6 @@ retryOnBusy tr timeout action =
     old style and new style
 -------------------------------------------------------------------------------}
 
--- | Error type for when migrations go wrong after opening a database.
-newtype MigrationError = MigrationError
-    {getMigrationErrorMessage :: Text}
-    deriving (Show, Eq, Generic, ToJSON)
-
-instance Exception MigrationError
-
-class Exception e => MatchMigrationError e where
-    -- | Exception predicate for migration errors.
-    matchMigrationError :: e -> Maybe MigrationError
-
-instance MatchMigrationError PersistException where
-    matchMigrationError e
-        | mark `isInfixOf` msg = Just $ MigrationError $ T.pack msg
-        | otherwise = Nothing
-      where
-        msg = show e
-        mark = "Database migration: manual intervention required."
-
-instance MatchMigrationError SqliteException where
-    matchMigrationError (SqliteException ErrorConstraint _ msg) =
-        Just $ MigrationError msg
-    matchMigrationError _ =
-        Nothing
-
-matchWrongVersionError :: ErrWrongVersion -> Maybe MigrationError
-matchWrongVersionError =
-    Just
-        . MigrationError
-        . view strict
-        . toLazyText
-        . build
-
--- | Encapsulates an old-style manual migration action
---   (or sequence of actions) to be
---   performed immediately after an SQL connection is initiated.
-newtype ManualMigration = ManualMigration
-    {executeManualMigration :: Sqlite.Connection -> IO ()}
-
 runAutoMigration
     :: Tracer IO DBLog
     -> Migration
@@ -510,6 +453,14 @@ runManualNewMigrations tr fp newMigrations =
     newMigrations tr fp
         & tryJust matchWrongVersionError
 
+matchWrongVersionError :: ErrWrongVersion -> Maybe MigrationError
+matchWrongVersionError =
+    Just
+        . MigrationError
+        . view strict
+        . toLazyText
+        . build
+
 runAllMigrations
     :: Tracer IO DBLog
     -> FilePath
@@ -521,65 +472,6 @@ runAllMigrations tr fp old auto new = runExceptT $ do
     ExceptT $ withDBHandle tr fp $ runManualOldMigrations tr old
     ExceptT $ withDBHandle tr fp $ runAutoMigration tr auto
     ExceptT $ runManualNewMigrations tr fp new
-
-{-------------------------------------------------------------------------------
-    Database migration helpers
--------------------------------------------------------------------------------}
-
-noManualMigration :: ManualMigration
-noManualMigration = ManualMigration $ const $ pure ()
-
-foldMigrations :: [Sqlite.Connection -> IO ()] -> ManualMigration
-foldMigrations ms = ManualMigration $ \conn -> mapM_ ($ conn) ms
-
-data DBField where
-    DBField
-        :: forall record typ
-         . (PersistEntity record)
-        => EntityField record typ
-        -> DBField
-
-tableName :: DBField -> Text
-tableName (DBField (_ :: EntityField record typ)) =
-    unEntityNameDB $ getEntityDBName $ entityDef (Proxy @record)
-
-fieldName :: DBField -> Text
-fieldName (DBField field) =
-    unFieldNameDB $ fieldDB $ persistFieldDef field
-
-fieldType :: DBField -> Text
-fieldType (DBField field) =
-    showSqlType $ fieldSqlType $ persistFieldDef field
-
-showSqlType :: SqlType -> Text
-showSqlType = \case
-    SqlString -> "VARCHAR"
-    SqlInt32 -> "INTEGER"
-    SqlInt64 -> "INTEGER"
-    SqlReal -> "REAL"
-    SqlDay -> "DATE"
-    SqlTime -> "TIME"
-    SqlDayTime -> "TIMESTAMP"
-    SqlBlob -> "BLOB"
-    SqlBool -> "BOOLEAN"
-    SqlOther t -> t
-    SqlNumeric precision scale ->
-        T.concat
-            [ "NUMERIC("
-            , T.pack (show precision)
-            , ","
-            , T.pack (show scale)
-            , ")"
-            ]
-
-instance Show DBField where
-    show field = T.unpack (tableName field <> "." <> fieldName field)
-
-instance Eq DBField where
-    field0 == field1 = show field0 == show field1
-
-instance ToJSON DBField where
-    toJSON = Aeson.String . T.pack . show
 
 {-------------------------------------------------------------------------------
                                     Logging

--- a/lib/wallet/src/Cardano/DB/Sqlite.hs
+++ b/lib/wallet/src/Cardano/DB/Sqlite.hs
@@ -71,6 +71,10 @@ import Cardano.BM.Extra
     ( BracketLog
     , bracketTracer
     )
+import Cardano.DB.Sqlite.ForeignKeys
+    ( ForeignKeysSetting (..)
+    , withForeignKeysDisabled
+    )
 import Cardano.Wallet.DB.Migration
     ( ErrWrongVersion (..)
     )
@@ -247,9 +251,11 @@ newInMemorySqliteContext tr manualMigrations autoMigration disableFK = do
     -- concurrent accesses and ensure database integrity in case where multiple
     -- threads would be reading/writing from/to it.
     lock <- newMVar unsafeBackend
-    let useForeignKeys :: IO a -> IO a
+    let trFK = contramap MsgUpdatingForeignKeysSetting tr
+        useForeignKeys :: IO a -> IO a
         useForeignKeys
-            | disableFK == ForeignKeysDisabled = withForeignKeysDisabled tr conn
+            | disableFK == ForeignKeysDisabled =
+                withForeignKeysDisabled trFK conn
             | otherwise = id
         runQuery :: forall a. SqlPersistT IO a -> IO a
         runQuery cmd =
@@ -422,87 +428,6 @@ retryOnBusy tr timeout action =
             $ MsgRetryOnBusy rsIterNumber m
 
 {-------------------------------------------------------------------------------
-    Foreign key settings
--------------------------------------------------------------------------------}
-
--- | Run the given task in a context where foreign key constraints are
---   /temporarily disabled/, before re-enabling them.
-withForeignKeysDisabled
-    :: Tracer IO DBLog
-    -> Sqlite.Connection
-    -> IO a
-    -> IO a
-withForeignKeysDisabled t c =
-    bracket_
-        (updateForeignKeysSetting t c ForeignKeysDisabled)
-        (updateForeignKeysSetting t c ForeignKeysEnabled)
-
--- | Specifies whether or not foreign key constraints are enabled, equivalent
---   to the Sqlite 'foreign_keys' setting.
---
--- When foreign key constraints are /enabled/, the database will enforce
--- referential integrity, and cascading deletes are enabled.
---
--- When foreign keys constraints are /disabled/, the database will not enforce
--- referential integrity, and cascading deletes are disabled.
---
--- See the following resource for more information:
--- https://www.sqlite.org/foreignkeys.html#fk_enable
-data ForeignKeysSetting
-    = -- | Foreign key constraints are /enabled/.
-      ForeignKeysEnabled
-    | -- | Foreign key constraints are /disabled/.
-      ForeignKeysDisabled
-    deriving (Eq, Generic, ToJSON, Show)
-
--- | Read the current value of the Sqlite 'foreign_keys' setting.
-readForeignKeysSetting :: Sqlite.Connection -> IO ForeignKeysSetting
-readForeignKeysSetting connection = do
-    query <- Sqlite.prepare connection "PRAGMA foreign_keys"
-    state <- Sqlite.step query >> Sqlite.columns query
-    Sqlite.finalize query
-    case state of
-        [Persist.PersistInt64 0] -> pure ForeignKeysDisabled
-        [Persist.PersistInt64 1] -> pure ForeignKeysEnabled
-        unexpectedValue ->
-            error
-                $ mconcat
-                    [ "Unexpected result when querying the current value of "
-                    , "the Sqlite 'foreign_keys' setting: "
-                    , show unexpectedValue
-                    , "."
-                    ]
-
--- | Update the current value of the Sqlite 'foreign_keys' setting.
-updateForeignKeysSetting
-    :: Tracer IO DBLog
-    -> Sqlite.Connection
-    -> ForeignKeysSetting
-    -> IO ()
-updateForeignKeysSetting trace connection desiredValue = do
-    traceWith trace $ MsgUpdatingForeignKeysSetting desiredValue
-    query <-
-        Sqlite.prepare connection
-            $ "PRAGMA foreign_keys = " <> valueToWrite <> ";"
-    _ <- Sqlite.step query
-    Sqlite.finalize query
-    finalValue <- readForeignKeysSetting connection
-    when (desiredValue /= finalValue)
-        $ error
-        $ mconcat
-            [ "Unexpected error when updating the value of the Sqlite "
-            , "'foreign_keys' setting. Attempted to write the value "
-            , show desiredValue
-            , " but retrieved the final value "
-            , show finalValue
-            , "."
-            ]
-  where
-    valueToWrite = case desiredValue of
-        ForeignKeysEnabled -> "ON"
-        ForeignKeysDisabled -> "OFF"
-
-{-------------------------------------------------------------------------------
     Database migrations
     old style and new style
 -------------------------------------------------------------------------------}
@@ -556,7 +481,8 @@ runAutoMigration tr autoMigration DBHandle{dbConn, dbBackend} = do
             runSqlConn
                 (runMigrationUnsafeQuiet autoMigration)
                 dbBackend
-    migrationResult <- withForeignKeysDisabled tr dbConn $ do
+        trFK = contramap MsgUpdatingForeignKeysSetting tr
+    migrationResult <- withForeignKeysDisabled trFK dbConn $ do
         executeAutoMigration
             & tryJust (matchMigrationError @PersistException)
             & tryJust (matchMigrationError @SqliteException)
@@ -570,7 +496,8 @@ runManualOldMigrations
     -> DBHandle
     -> IO (Either MigrationError ())
 runManualOldMigrations tr manualMigration DBHandle{dbConn} = do
-    withForeignKeysDisabled tr dbConn
+    let trFK = contramap MsgUpdatingForeignKeysSetting tr
+    withForeignKeysDisabled trFK dbConn
         $ Right
             <$> (`executeManualMigration` dbConn) manualMigration
 

--- a/lib/wallet/src/Cardano/DB/Sqlite/ForeignKeys.hs
+++ b/lib/wallet/src/Cardano/DB/Sqlite/ForeignKeys.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK, 2023 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Helper functions for enabling / disabling foreign keys
+-- on an SQLite database.
+--
+-- Depends on "Database.Sqlite" from @persistent-sqlite@.
+module Cardano.DB.Sqlite.ForeignKeys
+    ( ForeignKeysSetting (..)
+    , withForeignKeysDisabled
+    ) where
+
+import Prelude
+
+import Control.Monad
+    ( when
+    )
+import Control.Tracer
+    ( Tracer
+    , traceWith
+    )
+import Data.Aeson
+    ( ToJSON (..)
+    )
+import GHC.Generics
+    ( Generic
+    )
+import UnliftIO.Exception
+    ( bracket_
+    )
+
+import qualified Database.Persist.Sql as Persist
+import qualified Database.Sqlite as Sqlite
+
+{-------------------------------------------------------------------------------
+    Foreign key settings
+-------------------------------------------------------------------------------}
+
+-- | Run the given task in a context where foreign key constraints are
+--   /temporarily disabled/, before re-enabling them.
+withForeignKeysDisabled
+    :: Tracer IO ForeignKeysSetting
+    -> Sqlite.Connection
+    -> IO a
+    -> IO a
+withForeignKeysDisabled t c =
+    bracket_
+        (updateForeignKeysSetting t c ForeignKeysDisabled)
+        (updateForeignKeysSetting t c ForeignKeysEnabled)
+
+-- | Specifies whether or not foreign key constraints are enabled, equivalent
+--   to the Sqlite 'foreign_keys' setting.
+--
+-- When foreign key constraints are /enabled/, the database will enforce
+-- referential integrity, and cascading deletes are enabled.
+--
+-- When foreign keys constraints are /disabled/, the database will not enforce
+-- referential integrity, and cascading deletes are disabled.
+--
+-- See the following resource for more information:
+-- https://www.sqlite.org/foreignkeys.html#fk_enable
+data ForeignKeysSetting
+    = -- | Foreign key constraints are /enabled/.
+      ForeignKeysEnabled
+    | -- | Foreign key constraints are /disabled/.
+      ForeignKeysDisabled
+    deriving (Eq, Generic, ToJSON, Show)
+
+-- | Read the current value of the Sqlite 'foreign_keys' setting.
+readForeignKeysSetting :: Sqlite.Connection -> IO ForeignKeysSetting
+readForeignKeysSetting connection = do
+    query <- Sqlite.prepare connection "PRAGMA foreign_keys"
+    state <- Sqlite.step query >> Sqlite.columns query
+    Sqlite.finalize query
+    case state of
+        [Persist.PersistInt64 0] -> pure ForeignKeysDisabled
+        [Persist.PersistInt64 1] -> pure ForeignKeysEnabled
+        unexpectedValue ->
+            error
+                $ mconcat
+                    [ "Unexpected result when querying the current value of "
+                    , "the Sqlite 'foreign_keys' setting: "
+                    , show unexpectedValue
+                    , "."
+                    ]
+
+-- | Update the current value of the Sqlite 'foreign_keys' setting.
+updateForeignKeysSetting
+    :: Tracer IO ForeignKeysSetting
+    -> Sqlite.Connection
+    -> ForeignKeysSetting
+    -> IO ()
+updateForeignKeysSetting trace connection desiredValue = do
+    traceWith trace desiredValue
+    query <-
+        Sqlite.prepare connection
+            $ "PRAGMA foreign_keys = " <> valueToWrite <> ";"
+    _ <- Sqlite.step query
+    Sqlite.finalize query
+    finalValue <- readForeignKeysSetting connection
+    when (desiredValue /= finalValue)
+        $ error
+        $ mconcat
+            [ "Unexpected error when updating the value of the Sqlite "
+            , "'foreign_keys' setting. Attempted to write the value "
+            , show desiredValue
+            , " but retrieved the final value "
+            , show finalValue
+            , "."
+            ]
+  where
+    valueToWrite = case desiredValue of
+        ForeignKeysEnabled -> "ON"
+        ForeignKeysDisabled -> "OFF"

--- a/lib/wallet/src/Cardano/DB/Sqlite/Migration/Old.hs
+++ b/lib/wallet/src/Cardano/DB/Sqlite/Migration/Old.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK, 2023 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Old-style manual migrations.
+--
+-- Depends on "Database.Sqlite" from @persistent-sqlite@.
+module Cardano.DB.Sqlite.Migration.Old
+    ( -- * Old-style Manual Migration
+      ManualMigration (..)
+    , noManualMigration
+    , foldMigrations
+
+    , MigrationError (..)
+    , MatchMigrationError (..)
+
+    -- * Migration helpers
+    , DBField (..)
+    , tableName
+    , fieldName
+    , fieldType
+    ) where
+
+import Prelude
+
+import Control.Exception
+    ( Exception
+    )
+import Data.Aeson
+    ( ToJSON (..)
+    )
+import Data.List
+    ( isInfixOf
+    )
+import Data.Proxy
+    ( Proxy (..)
+    )
+import Data.Text
+    ( Text
+    )
+import Database.Persist.EntityDef
+    ( getEntityDBName
+    )
+import Database.Persist.Sql
+    ( EntityField
+    , PersistEntity (..)
+    , PersistException
+    , SqlType (..)
+    , fieldDB
+    , fieldSqlType
+    , unEntityNameDB
+    , unFieldNameDB
+    )
+import Database.Sqlite
+    ( Error (ErrorConstraint)
+    , SqliteException (SqliteException)
+    )
+import GHC.Generics
+    ( Generic
+    )
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Text as T
+import qualified Database.Sqlite as Sqlite
+
+{-----------------------------------------------------------------------------
+    Type
+------------------------------------------------------------------------------}
+
+-- | Encapsulates an old-style manual migration action
+--   (or sequence of actions) to be
+--   performed immediately after an SQL connection is initiated.
+newtype ManualMigration = ManualMigration
+    {executeManualMigration :: Sqlite.Connection -> IO ()}
+
+noManualMigration :: ManualMigration
+noManualMigration = ManualMigration $ const $ pure ()
+
+foldMigrations :: [Sqlite.Connection -> IO ()] -> ManualMigration
+foldMigrations ms = ManualMigration $ \conn -> mapM_ ($ conn) ms
+
+{-----------------------------------------------------------------------------
+    Helpers
+------------------------------------------------------------------------------}
+
+data DBField where
+    DBField
+        :: forall record typ
+         . (PersistEntity record)
+        => EntityField record typ
+        -> DBField
+
+tableName :: DBField -> Text
+tableName (DBField (_ :: EntityField record typ)) =
+    unEntityNameDB $ getEntityDBName $ entityDef (Proxy :: Proxy record)
+
+fieldName :: DBField -> Text
+fieldName (DBField field) =
+    unFieldNameDB $ fieldDB $ persistFieldDef field
+
+fieldType :: DBField -> Text
+fieldType (DBField field) =
+    showSqlType $ fieldSqlType $ persistFieldDef field
+
+showSqlType :: SqlType -> Text
+showSqlType = \case
+    SqlString -> "VARCHAR"
+    SqlInt32 -> "INTEGER"
+    SqlInt64 -> "INTEGER"
+    SqlReal -> "REAL"
+    SqlDay -> "DATE"
+    SqlTime -> "TIME"
+    SqlDayTime -> "TIMESTAMP"
+    SqlBlob -> "BLOB"
+    SqlBool -> "BOOLEAN"
+    SqlOther t -> t
+    SqlNumeric precision scale ->
+        T.concat
+            [ "NUMERIC("
+            , T.pack (show precision)
+            , ","
+            , T.pack (show scale)
+            , ")"
+            ]
+
+instance Show DBField where
+    show field = T.unpack (tableName field <> "." <> fieldName field)
+
+instance Eq DBField where
+    field0 == field1 = show field0 == show field1
+
+instance ToJSON DBField where
+    toJSON = Aeson.String . T.pack . show
+
+{-----------------------------------------------------------------------------
+    Errors
+------------------------------------------------------------------------------}
+
+-- | Error type for when migrations go wrong after opening a database.
+newtype MigrationError = MigrationError
+    {getMigrationErrorMessage :: Text}
+    deriving (Show, Eq, Generic, ToJSON)
+
+instance Exception MigrationError
+
+class Exception e => MatchMigrationError e where
+    -- | Exception predicate for migration errors.
+    matchMigrationError :: e -> Maybe MigrationError
+
+instance MatchMigrationError PersistException where
+    matchMigrationError e
+        | mark `isInfixOf` msg = Just $ MigrationError $ T.pack msg
+        | otherwise = Nothing
+      where
+        msg = show e
+        mark = "Database migration: manual intervention required."
+
+instance MatchMigrationError SqliteException where
+    matchMigrationError (SqliteException ErrorConstraint _ msg) =
+        Just $ MigrationError msg
+    matchMigrationError _ =
+        Nothing

--- a/lib/wallet/src/Cardano/Pool/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Layer.hs
@@ -21,7 +21,7 @@
 -- License: Apache-2.0
 --
 -- An implementation of the DBLayer which uses Persistent and SQLite.
-module Cardano.Pool.DB.Sqlite
+module Cardano.Pool.DB.Layer
     ( newDBLayer
     , withDBLayer
     , withDecoratedDBLayer

--- a/lib/wallet/src/Cardano/Pool/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Layer.hs
@@ -37,7 +37,16 @@ import Prelude
 import Cardano.BM.Extra
     ( bracketTracer
     )
-import Cardano.DB.Sqlite
+import Cardano.Pool.DB
+    ( DBLayer (..)
+    , ErrPointAlreadyExists (..)
+    , determinePoolLifeCycleStatus
+    )
+import Cardano.Pool.DB.Log
+    ( ParseFailure (..)
+    , PoolDbLog (..)
+    )
+import Cardano.Pool.DB.Sqlite
     ( DBField (..)
     , DBLog (..)
     , ForeignKeysSetting (ForeignKeysEnabled)
@@ -50,15 +59,6 @@ import Cardano.DB.Sqlite
     , newInMemorySqliteContext
     , tableName
     , withSqliteContextFile
-    )
-import Cardano.Pool.DB
-    ( DBLayer (..)
-    , ErrPointAlreadyExists (..)
-    , determinePoolLifeCycleStatus
-    )
-import Cardano.Pool.DB.Log
-    ( ParseFailure (..)
-    , PoolDbLog (..)
     )
 import Cardano.Pool.DB.Sqlite.TH hiding
     ( BlockHeader

--- a/lib/wallet/src/Cardano/Pool/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Layer.hs
@@ -49,7 +49,6 @@ import Cardano.Pool.DB.Log
 import Cardano.Pool.DB.Sqlite
     ( DBField (..)
     , DBLog (..)
-    , ForeignKeysSetting (ForeignKeysEnabled)
     , ManualMigration (..)
     , MigrationError
     , SqliteContext (..)
@@ -262,7 +261,6 @@ withDecoratedDBLayer dbDecorator tr mDatabaseDir ti action = do
                     tr'
                     createViews
                     migrateAll
-                    ForeignKeysEnabled
                 )
                 fst
                 (action . decorateDBLayer dbDecorator . newDBLayer tr ti . snd)

--- a/lib/wallet/src/Cardano/Pool/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Layer.hs
@@ -37,6 +37,14 @@ import Prelude
 import Cardano.BM.Extra
     ( bracketTracer
     )
+import Cardano.DB.Sqlite.Migration.Old
+    ( DBField (..)
+    , ManualMigration (..)
+    , MigrationError
+    , fieldName
+    , foldMigrations
+    , tableName
+    )
 import Cardano.Pool.DB
     ( DBLayer (..)
     , ErrPointAlreadyExists (..)
@@ -47,16 +55,10 @@ import Cardano.Pool.DB.Log
     , PoolDbLog (..)
     )
 import Cardano.Pool.DB.Sqlite
-    ( DBField (..)
-    , DBLog (..)
-    , ManualMigration (..)
-    , MigrationError
+    ( DBLog (..)
     , SqliteContext (..)
-    , fieldName
-    , foldMigrations
     , handleConstraint
     , newInMemorySqliteContext
-    , tableName
     , withSqliteContextFile
     )
 import Cardano.Pool.DB.Sqlite.TH hiding

--- a/lib/wallet/src/Cardano/Pool/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Layer.hs
@@ -271,12 +271,10 @@ withDecoratedDBLayer dbDecorator tr mDatabaseDir ti action = do
                     fp
                     createViews
                     migrateAll
-                    newMigrations
                     $ action . decorateDBLayer dbDecorator . newDBLayer tr ti
             either throwIO pure res
   where
     tr' = contramap MsgGeneric tr
-    newMigrations _ _ = pure ()
 
 -- | Sets up a connection to the SQLite database.
 --

--- a/lib/wallet/src/Cardano/Pool/DB/Log.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Log.hs
@@ -23,7 +23,7 @@ import Cardano.BM.Data.Tracer
 import Cardano.BM.Extra
     ( BracketLog
     )
-import Cardano.DB.Sqlite
+import Cardano.Pool.DB.Sqlite
     ( DBLog (..)
     )
 import Cardano.Pool.Types

--- a/lib/wallet/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Sqlite.hs
@@ -401,9 +401,6 @@ data DBLog
     | MsgDatabaseReset
     | MsgIsAlreadyClosed Text
     | MsgStatementAlreadyFinalized Text
-    | MsgManualMigrationNeeded DBField Text
-    | MsgExpectedMigration DBLog
-    | MsgManualMigrationNotNeeded DBField
     | MsgUpdatingForeignKeysSetting ForeignKeysSetting
     | MsgRetryOnBusy Int RetryLog
     deriving (Generic, Show, Eq, ToJSON)
@@ -420,12 +417,9 @@ instance HasSeverityAnnotation DBLog where
         MsgQuery _ sev -> sev
         MsgRun _ -> Debug
         MsgCloseSingleConnection _ -> Info
-        MsgExpectedMigration _ -> Debug
         MsgDatabaseReset -> Notice
         MsgIsAlreadyClosed _ -> Warning
         MsgStatementAlreadyFinalized _ -> Warning
-        MsgManualMigrationNeeded{} -> Notice
-        MsgManualMigrationNotNeeded{} -> Debug
         MsgUpdatingForeignKeysSetting{} -> Debug
         MsgRetryOnBusy n _
             | n <= 1 -> Debug
@@ -455,24 +449,6 @@ instance ToText DBLog where
             "Attempted to close an already closed connection: " <> msg
         MsgStatementAlreadyFinalized msg ->
             "Statement already finalized: " <> msg
-        MsgExpectedMigration msg -> "Expected: " <> toText msg
-        MsgManualMigrationNeeded field value ->
-            mconcat
-                [ tableName field
-                , " table does not contain required field '"
-                , fieldName field
-                , "'. "
-                , "Adding this field with a default value of "
-                , value
-                , "."
-                ]
-        MsgManualMigrationNotNeeded field ->
-            mconcat
-                [ tableName field
-                , " table already contains required field '"
-                , fieldName field
-                , "'."
-                ]
         MsgUpdatingForeignKeysSetting value ->
             mconcat
                 [ "Updating the foreign keys setting to: "

--- a/lib/wallet/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Sqlite.hs
@@ -58,6 +58,10 @@ import Cardano.BM.Extra
     ( BracketLog
     , bracketTracer
     )
+import Cardano.DB.Sqlite.ForeignKeys
+    ( ForeignKeysSetting (..)
+    , withForeignKeysDisabled
+    )
 import Cardano.Wallet.DB.Migration
     ( ErrWrongVersion (..)
     )
@@ -393,87 +397,6 @@ retryOnBusy tr timeout action =
             $ MsgRetryOnBusy rsIterNumber m
 
 {-------------------------------------------------------------------------------
-    Foreign key settings
--------------------------------------------------------------------------------}
-
--- | Run the given task in a context where foreign key constraints are
---   /temporarily disabled/, before re-enabling them.
-withForeignKeysDisabled
-    :: Tracer IO DBLog
-    -> Sqlite.Connection
-    -> IO a
-    -> IO a
-withForeignKeysDisabled t c =
-    bracket_
-        (updateForeignKeysSetting t c ForeignKeysDisabled)
-        (updateForeignKeysSetting t c ForeignKeysEnabled)
-
--- | Specifies whether or not foreign key constraints are enabled, equivalent
---   to the Sqlite 'foreign_keys' setting.
---
--- When foreign key constraints are /enabled/, the database will enforce
--- referential integrity, and cascading deletes are enabled.
---
--- When foreign keys constraints are /disabled/, the database will not enforce
--- referential integrity, and cascading deletes are disabled.
---
--- See the following resource for more information:
--- https://www.sqlite.org/foreignkeys.html#fk_enable
-data ForeignKeysSetting
-    = -- | Foreign key constraints are /enabled/.
-      ForeignKeysEnabled
-    | -- | Foreign key constraints are /disabled/.
-      ForeignKeysDisabled
-    deriving (Eq, Generic, ToJSON, Show)
-
--- | Read the current value of the Sqlite 'foreign_keys' setting.
-readForeignKeysSetting :: Sqlite.Connection -> IO ForeignKeysSetting
-readForeignKeysSetting connection = do
-    query <- Sqlite.prepare connection "PRAGMA foreign_keys"
-    state <- Sqlite.step query >> Sqlite.columns query
-    Sqlite.finalize query
-    case state of
-        [Persist.PersistInt64 0] -> pure ForeignKeysDisabled
-        [Persist.PersistInt64 1] -> pure ForeignKeysEnabled
-        unexpectedValue ->
-            error
-                $ mconcat
-                    [ "Unexpected result when querying the current value of "
-                    , "the Sqlite 'foreign_keys' setting: "
-                    , show unexpectedValue
-                    , "."
-                    ]
-
--- | Update the current value of the Sqlite 'foreign_keys' setting.
-updateForeignKeysSetting
-    :: Tracer IO DBLog
-    -> Sqlite.Connection
-    -> ForeignKeysSetting
-    -> IO ()
-updateForeignKeysSetting trace connection desiredValue = do
-    traceWith trace $ MsgUpdatingForeignKeysSetting desiredValue
-    query <-
-        Sqlite.prepare connection
-            $ "PRAGMA foreign_keys = " <> valueToWrite <> ";"
-    _ <- Sqlite.step query
-    Sqlite.finalize query
-    finalValue <- readForeignKeysSetting connection
-    when (desiredValue /= finalValue)
-        $ error
-        $ mconcat
-            [ "Unexpected error when updating the value of the Sqlite "
-            , "'foreign_keys' setting. Attempted to write the value "
-            , show desiredValue
-            , " but retrieved the final value "
-            , show finalValue
-            , "."
-            ]
-  where
-    valueToWrite = case desiredValue of
-        ForeignKeysEnabled -> "ON"
-        ForeignKeysDisabled -> "OFF"
-
-{-------------------------------------------------------------------------------
     Database migrations
     old style and new style
 -------------------------------------------------------------------------------}
@@ -527,7 +450,8 @@ runAutoMigration tr autoMigration DBHandle{dbConn, dbBackend} = do
             runSqlConn
                 (runMigrationUnsafeQuiet autoMigration)
                 dbBackend
-    migrationResult <- withForeignKeysDisabled tr dbConn $ do
+    let trFK = contramap MsgUpdatingForeignKeysSetting tr
+    migrationResult <- withForeignKeysDisabled trFK dbConn $ do
         executeAutoMigration
             & tryJust (matchMigrationError @PersistException)
             & tryJust (matchMigrationError @SqliteException)
@@ -541,7 +465,8 @@ runManualOldMigrations
     -> DBHandle
     -> IO (Either MigrationError ())
 runManualOldMigrations tr manualMigration DBHandle{dbConn} = do
-    withForeignKeysDisabled tr dbConn
+    let trFK = contramap MsgUpdatingForeignKeysSetting tr
+    withForeignKeysDisabled trFK dbConn
         $ Right
             <$> (`executeManualMigration` dbConn) manualMigration
 

--- a/lib/wallet/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Sqlite.hs
@@ -1,0 +1,847 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+-- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+
+{- HLINT ignore "Redundant flip" -}
+
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- A wrapper for SQLite database connections, to be used with 'persistent'.
+module Cardano.Pool.DB.Sqlite
+    ( SqliteContext (..)
+    , withSqliteContextFile
+    , newInMemorySqliteContext
+    , ForeignKeysSetting (..)
+
+      -- * DB Connections
+    , DBHandle
+    , withDBHandle
+    , dbConn
+    , dbFile
+    , dbBackend
+
+      -- * Helpers
+    , chunkSize
+    , dbChunked
+    , dbChunkedFor
+    , dbChunked'
+    , handleConstraint
+
+      -- * Old-style Manual Migration
+    , ManualMigration (..)
+    , noManualMigration
+    , MigrationError (..)
+    , DBField (..)
+    , tableName
+    , fieldName
+    , fieldType
+
+      -- * Logging
+    , DBLog (..)
+    , ReadDBHandle
+    , foldMigrations
+    ) where
+
+import Prelude
+
+import Cardano.BM.Data.Severity
+    ( Severity (..)
+    )
+import Cardano.BM.Data.Tracer
+    ( HasPrivacyAnnotation (..)
+    , HasSeverityAnnotation (..)
+    )
+import Cardano.BM.Extra
+    ( BracketLog
+    , bracketTracer
+    )
+import Cardano.Wallet.DB.Migration
+    ( ErrWrongVersion (..)
+    )
+import Control.Lens
+    ( strict
+    , view
+    )
+import Control.Monad
+    ( join
+    , void
+    , when
+    )
+import Control.Monad.IO.Unlift
+    ( MonadUnliftIO (..)
+    )
+import Control.Monad.Logger
+    ( LogLevel (..)
+    )
+import Control.Monad.Reader
+    ( ReaderT
+    )
+import Control.Monad.Trans.Except
+    ( ExceptT (..)
+    , runExceptT
+    )
+import Control.Retry
+    ( RetryStatus (..)
+    , constantDelay
+    , limitRetriesByCumulativeDelay
+    , logRetries
+    , recovering
+    )
+import Control.Tracer
+    ( Tracer
+    , contramap
+    , traceWith
+    )
+import Data.Aeson
+    ( ToJSON (..)
+    )
+import Data.Function
+    ( (&)
+    )
+import Data.Functor
+    ( ($>)
+    , (<&>)
+    )
+import Data.List
+    ( isInfixOf
+    )
+import Data.List.Split
+    ( chunksOf
+    )
+import Data.Proxy
+    ( Proxy (..)
+    )
+import Data.Text
+    ( Text
+    )
+import Data.Text.Class
+    ( ToText (..)
+    )
+import Data.Text.Lazy.Builder
+    ( toLazyText
+    )
+import Data.Time.Clock
+    ( NominalDiffTime
+    )
+import Database.Persist.EntityDef
+    ( getEntityDBName
+    , getEntityFields
+    )
+import Database.Persist.Names
+    ( EntityNameDB (..)
+    , unFieldNameDB
+    )
+import Database.Persist.Sql
+    ( EntityField
+    , LogFunc
+    , Migration
+    , PersistEntity (..)
+    , PersistException
+    , SqlPersistT
+    , SqlType (..)
+    , close'
+    , fieldDB
+    , fieldSqlType
+    , runMigrationUnsafeQuiet
+    , runSqlConn
+    )
+import Database.Persist.Sqlite
+    ( SqlBackend
+    , wrapConnection
+    )
+import Database.Sqlite
+    ( Error (ErrorConstraint)
+    , SqliteException (SqliteException)
+    )
+import Fmt
+    ( Buildable (..)
+    , fmt
+    , ordinalF
+    , (+|)
+    , (+||)
+    , (|+)
+    , (||+)
+    )
+import GHC.Generics
+    ( Generic
+    )
+import System.Environment
+    ( lookupEnv
+    )
+import System.Log.FastLogger
+    ( fromLogStr
+    )
+import UnliftIO.Compat
+    ( handleIf
+    )
+import UnliftIO.Exception
+    ( Exception
+    , bracket
+    , bracket_
+    , handleJust
+    , tryJust
+    )
+import UnliftIO.MVar
+    ( newMVar
+    , withMVar
+    , withMVarMasked
+    )
+
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Database.Persist.Sql as Persist
+import qualified Database.Sqlite as Sqlite
+
+{-------------------------------------------------------------------------------
+                            Sqlite connection set up
+-------------------------------------------------------------------------------}
+
+-- | 'SqliteContext' is a facility to run database queries.
+newtype SqliteContext = SqliteContext
+    { runQuery :: forall a. SqlPersistT IO a -> IO a
+    }
+
+-- | Run an action, and convert any Sqlite constraints exception into the given
+-- error result. No other exceptions are handled.
+handleConstraint :: MonadUnliftIO m => e -> m a -> m (Either e a)
+handleConstraint e = handleJust select handler . fmap Right
+  where
+    select (SqliteException ErrorConstraint _ _) = Just ()
+    select _ = Nothing
+    handler = const . pure . Left $ e
+
+newInMemorySqliteContext
+    :: Tracer IO DBLog
+    -> ManualMigration
+    -> Migration
+    -> ForeignKeysSetting
+    -> IO (IO (), SqliteContext)
+newInMemorySqliteContext tr manualMigrations autoMigration disableFK = do
+    conn <- Sqlite.open ":memory:"
+    executeManualMigration manualMigrations conn
+    unsafeBackend <- wrapConnection conn (queryLogFunc tr)
+    void $ runSqlConn (runMigrationUnsafeQuiet autoMigration) unsafeBackend
+
+    let observe :: forall a. IO a -> IO a
+        observe = bracketTracer (contramap MsgRun tr)
+
+    -- We still use a lock with the in-memory database to protect it from
+    -- concurrent accesses and ensure database integrity in case where multiple
+    -- threads would be reading/writing from/to it.
+    lock <- newMVar unsafeBackend
+    let useForeignKeys :: IO a -> IO a
+        useForeignKeys
+            | disableFK == ForeignKeysDisabled = withForeignKeysDisabled tr conn
+            | otherwise = id
+        runQuery :: forall a. SqlPersistT IO a -> IO a
+        runQuery cmd =
+            withMVarMasked
+                lock
+                (observe . useForeignKeys . runSqlConn cmd)
+
+    return (close' unsafeBackend, SqliteContext{runQuery})
+
+-- | Sets up query logging and timing, runs schema migrations if necessary and
+-- provide a safe 'SqliteContext' for interacting with the database.
+withSqliteContextFile
+    :: Tracer IO DBLog
+    -- ^ Logging
+    -> FilePath
+    -- ^ Database file
+    -> ManualMigration
+    -- ^ Manual migrations
+    -> Migration
+    -- ^ Auto migration
+    -> (Tracer IO DBLog -> FilePath -> IO ())
+    -- ^ New style migrations
+    -> (SqliteContext -> IO a)
+    -> IO (Either MigrationError a)
+withSqliteContextFile tr fp old auto new action = do
+    migrationResult <- runAllMigrations tr fp old auto new
+    case migrationResult of
+        Left e -> pure $ Left e
+        Right{} -> do
+            lock <- newMVar ()
+            withDBHandle tr fp $ \DBHandle{dbBackend} ->
+                let
+                    -- Run a query on the open database,
+                    -- but retry on busy.
+                    runQuery :: SqlPersistT IO a -> IO a
+                    runQuery cmd =
+                        observe
+                            . retryOnBusy tr retryOnBusyTimeout
+                            $ withMVar lock
+                            $ const
+                            $ runSqlConn cmd dbBackend
+                in
+                    Right <$> action (SqliteContext{runQuery})
+  where
+    observe :: IO a -> IO a
+    observe = bracketTracer (contramap MsgRun tr)
+
+{-------------------------------------------------------------------------------
+    SQL connection life-cycle
+    low level
+-------------------------------------------------------------------------------}
+data DBHandle = DBHandle
+    { dbConn :: Sqlite.Connection
+    , dbBackend :: SqlBackend
+    , dbFile :: FilePath
+    }
+
+type ReadDBHandle m = ReaderT DBHandle m
+
+withDBHandle
+    :: Tracer IO DBLog
+    -> FilePath
+    -> (DBHandle -> IO a)
+    -> IO a
+withDBHandle tr fp =
+    bracket (newDBHandle tr fp) (destroyDBHandle tr)
+
+newDBHandle
+    :: Tracer IO DBLog
+    -> FilePath
+    -> IO DBHandle
+newDBHandle tr dbFile = do
+    traceWith tr $ MsgOpenSingleConnection dbFile
+    dbConn <- Sqlite.open (T.pack dbFile)
+    dbBackend <- wrapConnection dbConn (queryLogFunc tr)
+    pure $ DBHandle{dbFile, dbConn, dbBackend}
+
+-- | Finalize database statements and close the database connection.
+-- If the database connection is still in use, it will retry for up to a minute,
+-- to let other threads finish up.
+--
+-- This function is idempotent: if the database connection has already been
+-- closed, calling this function will exit without doing anything.
+destroyDBHandle
+    :: Tracer IO DBLog
+    -> DBHandle
+    -> IO ()
+destroyDBHandle tr DBHandle{dbFile, dbBackend = sqlBackend} = do
+    traceWith tr (MsgCloseSingleConnection dbFile)
+
+    -- Hack for ADP-827: timeout earlier in integration tests.
+    --
+    -- There seem to be some concurrency problem causing persistent-sqlite to
+    -- leak unfinalized statements, causing SQLITE_BUSY when we try to close the
+    -- connection. In this case, retrying 2 or 60 seconds would have no
+    -- difference.
+    --
+    -- But in production, the longer timeout isn't as much of a problem, and
+    -- might be needed for windows.
+    timeoutSec <-
+        lookupEnv "CARDANO_WALLET_TEST_INTEGRATION" <&> \case
+            Just _ -> 2
+            Nothing -> retryOnBusyTimeout
+
+    retryOnBusy tr timeoutSec (close' sqlBackend)
+        & handleIf
+            isAlreadyClosed
+            (traceWith tr . MsgIsAlreadyClosed . showT)
+        & handleIf
+            statementAlreadyFinalized
+            (traceWith tr . MsgStatementAlreadyFinalized . showT)
+  where
+    isAlreadyClosed = \case
+        -- Thrown when an attempt is made to close a connection that is already
+        -- in the closed state:
+        Sqlite.SqliteException Sqlite.ErrorMisuse _ _ -> True
+        Sqlite.SqliteException{} -> False
+
+    statementAlreadyFinalized = \case
+        -- Thrown
+        Persist.StatementAlreadyFinalized{} -> True
+        Persist.Couldn'tGetSQLConnection{} -> False
+
+    showT :: Show a => a -> Text
+    showT = T.pack . show
+
+-- | Default timeout for `retryOnBusy`
+retryOnBusyTimeout :: NominalDiffTime
+retryOnBusyTimeout = 60
+
+-- | Retry an action if the database yields an 'SQLITE_BUSY' error.
+--
+-- From <https://www.sqlite.org/rescode.html#busy>
+--
+--     The SQLITE_BUSY result code indicates that the database file could not be
+--     written (or in some cases read) because of concurrent activity by some
+--     other database connection, usually a database connection in a separate
+--     process.
+--
+--     For example, if process A is in the middle of a large write transaction
+--     and at the same time process B attempts to start a new write transaction,
+--     process B will get back an SQLITE_BUSY result because SQLite only supports
+--     one writer at a time. Process B will need to wait for process A to finish
+--     its transaction before starting a new transaction. The sqlite3_busy_timeout()
+--     and sqlite3_busy_handler() interfaces and the busy_timeout pragma are
+--     available to process B to help it deal with SQLITE_BUSY errors.
+retryOnBusy
+    :: Tracer IO DBLog
+    -- ^ Logging
+    -> NominalDiffTime
+    -- ^ Timeout
+    -> IO a
+    -- ^ Action to retry
+    -> IO a
+retryOnBusy tr timeout action =
+    recovering
+        policy
+        [logRetries isBusy traceRetries]
+        (\st -> action <* trace MsgRetryDone st)
+  where
+    policy = limitRetriesByCumulativeDelay usTimeout $ constantDelay (25 * ms)
+    usTimeout = truncate (timeout * 1_000_000)
+    ms = 1_000 -- microseconds in a millisecond
+    isBusy (SqliteException name _ _) = pure (name == Sqlite.ErrorBusy)
+
+    traceRetries retr _ = trace $ if retr then MsgRetry else MsgRetryGaveUp
+
+    trace m RetryStatus{rsIterNumber} =
+        traceWith tr
+            $ MsgRetryOnBusy rsIterNumber m
+
+{-------------------------------------------------------------------------------
+    Foreign key settings
+-------------------------------------------------------------------------------}
+
+-- | Run the given task in a context where foreign key constraints are
+--   /temporarily disabled/, before re-enabling them.
+withForeignKeysDisabled
+    :: Tracer IO DBLog
+    -> Sqlite.Connection
+    -> IO a
+    -> IO a
+withForeignKeysDisabled t c =
+    bracket_
+        (updateForeignKeysSetting t c ForeignKeysDisabled)
+        (updateForeignKeysSetting t c ForeignKeysEnabled)
+
+-- | Specifies whether or not foreign key constraints are enabled, equivalent
+--   to the Sqlite 'foreign_keys' setting.
+--
+-- When foreign key constraints are /enabled/, the database will enforce
+-- referential integrity, and cascading deletes are enabled.
+--
+-- When foreign keys constraints are /disabled/, the database will not enforce
+-- referential integrity, and cascading deletes are disabled.
+--
+-- See the following resource for more information:
+-- https://www.sqlite.org/foreignkeys.html#fk_enable
+data ForeignKeysSetting
+    = -- | Foreign key constraints are /enabled/.
+      ForeignKeysEnabled
+    | -- | Foreign key constraints are /disabled/.
+      ForeignKeysDisabled
+    deriving (Eq, Generic, ToJSON, Show)
+
+-- | Read the current value of the Sqlite 'foreign_keys' setting.
+readForeignKeysSetting :: Sqlite.Connection -> IO ForeignKeysSetting
+readForeignKeysSetting connection = do
+    query <- Sqlite.prepare connection "PRAGMA foreign_keys"
+    state <- Sqlite.step query >> Sqlite.columns query
+    Sqlite.finalize query
+    case state of
+        [Persist.PersistInt64 0] -> pure ForeignKeysDisabled
+        [Persist.PersistInt64 1] -> pure ForeignKeysEnabled
+        unexpectedValue ->
+            error
+                $ mconcat
+                    [ "Unexpected result when querying the current value of "
+                    , "the Sqlite 'foreign_keys' setting: "
+                    , show unexpectedValue
+                    , "."
+                    ]
+
+-- | Update the current value of the Sqlite 'foreign_keys' setting.
+updateForeignKeysSetting
+    :: Tracer IO DBLog
+    -> Sqlite.Connection
+    -> ForeignKeysSetting
+    -> IO ()
+updateForeignKeysSetting trace connection desiredValue = do
+    traceWith trace $ MsgUpdatingForeignKeysSetting desiredValue
+    query <-
+        Sqlite.prepare connection
+            $ "PRAGMA foreign_keys = " <> valueToWrite <> ";"
+    _ <- Sqlite.step query
+    Sqlite.finalize query
+    finalValue <- readForeignKeysSetting connection
+    when (desiredValue /= finalValue)
+        $ error
+        $ mconcat
+            [ "Unexpected error when updating the value of the Sqlite "
+            , "'foreign_keys' setting. Attempted to write the value "
+            , show desiredValue
+            , " but retrieved the final value "
+            , show finalValue
+            , "."
+            ]
+  where
+    valueToWrite = case desiredValue of
+        ForeignKeysEnabled -> "ON"
+        ForeignKeysDisabled -> "OFF"
+
+{-------------------------------------------------------------------------------
+    Database migrations
+    old style and new style
+-------------------------------------------------------------------------------}
+
+-- | Error type for when migrations go wrong after opening a database.
+newtype MigrationError = MigrationError
+    {getMigrationErrorMessage :: Text}
+    deriving (Show, Eq, Generic, ToJSON)
+
+instance Exception MigrationError
+
+class Exception e => MatchMigrationError e where
+    -- | Exception predicate for migration errors.
+    matchMigrationError :: e -> Maybe MigrationError
+
+instance MatchMigrationError PersistException where
+    matchMigrationError e
+        | mark `isInfixOf` msg = Just $ MigrationError $ T.pack msg
+        | otherwise = Nothing
+      where
+        msg = show e
+        mark = "Database migration: manual intervention required."
+
+instance MatchMigrationError SqliteException where
+    matchMigrationError (SqliteException ErrorConstraint _ msg) =
+        Just $ MigrationError msg
+    matchMigrationError _ =
+        Nothing
+
+matchWrongVersionError :: ErrWrongVersion -> Maybe MigrationError
+matchWrongVersionError =
+    Just
+        . MigrationError
+        . view strict
+        . toLazyText
+        . build
+
+-- | Encapsulates an old-style manual migration action
+--   (or sequence of actions) to be
+--   performed immediately after an SQL connection is initiated.
+newtype ManualMigration = ManualMigration
+    {executeManualMigration :: Sqlite.Connection -> IO ()}
+
+runAutoMigration
+    :: Tracer IO DBLog
+    -> Migration
+    -> DBHandle
+    -> IO (Either MigrationError ())
+runAutoMigration tr autoMigration DBHandle{dbConn, dbBackend} = do
+    let executeAutoMigration =
+            runSqlConn
+                (runMigrationUnsafeQuiet autoMigration)
+                dbBackend
+    migrationResult <- withForeignKeysDisabled tr dbConn $ do
+        executeAutoMigration
+            & tryJust (matchMigrationError @PersistException)
+            & tryJust (matchMigrationError @SqliteException)
+            & fmap join
+    traceWith tr $ MsgMigrations $ length <$> migrationResult
+    return $ migrationResult $> ()
+
+runManualOldMigrations
+    :: Tracer IO DBLog
+    -> ManualMigration
+    -> DBHandle
+    -> IO (Either MigrationError ())
+runManualOldMigrations tr manualMigration DBHandle{dbConn} = do
+    withForeignKeysDisabled tr dbConn
+        $ Right
+            <$> (`executeManualMigration` dbConn) manualMigration
+
+runManualNewMigrations
+    :: Tracer IO DBLog
+    -> FilePath
+    -> (Tracer IO DBLog -> FilePath -> IO ())
+    -> IO (Either MigrationError ())
+runManualNewMigrations tr fp newMigrations =
+    newMigrations tr fp
+        & tryJust matchWrongVersionError
+
+runAllMigrations
+    :: Tracer IO DBLog
+    -> FilePath
+    -> ManualMigration
+    -> Migration
+    -> (Tracer IO DBLog -> FilePath -> IO ())
+    -> IO (Either MigrationError ())
+runAllMigrations tr fp old auto new = runExceptT $ do
+    ExceptT $ withDBHandle tr fp $ runManualOldMigrations tr old
+    ExceptT $ withDBHandle tr fp $ runAutoMigration tr auto
+    ExceptT $ runManualNewMigrations tr fp new
+
+{-------------------------------------------------------------------------------
+    Database migration helpers
+-------------------------------------------------------------------------------}
+
+noManualMigration :: ManualMigration
+noManualMigration = ManualMigration $ const $ pure ()
+
+foldMigrations :: [Sqlite.Connection -> IO ()] -> ManualMigration
+foldMigrations ms = ManualMigration $ \conn -> mapM_ ($ conn) ms
+
+data DBField where
+    DBField
+        :: forall record typ
+         . (PersistEntity record)
+        => EntityField record typ
+        -> DBField
+
+tableName :: DBField -> Text
+tableName (DBField (_ :: EntityField record typ)) =
+    unEntityNameDB $ getEntityDBName $ entityDef (Proxy @record)
+
+fieldName :: DBField -> Text
+fieldName (DBField field) =
+    unFieldNameDB $ fieldDB $ persistFieldDef field
+
+fieldType :: DBField -> Text
+fieldType (DBField field) =
+    showSqlType $ fieldSqlType $ persistFieldDef field
+
+showSqlType :: SqlType -> Text
+showSqlType = \case
+    SqlString -> "VARCHAR"
+    SqlInt32 -> "INTEGER"
+    SqlInt64 -> "INTEGER"
+    SqlReal -> "REAL"
+    SqlDay -> "DATE"
+    SqlTime -> "TIME"
+    SqlDayTime -> "TIMESTAMP"
+    SqlBlob -> "BLOB"
+    SqlBool -> "BOOLEAN"
+    SqlOther t -> t
+    SqlNumeric precision scale ->
+        T.concat
+            [ "NUMERIC("
+            , T.pack (show precision)
+            , ","
+            , T.pack (show scale)
+            , ")"
+            ]
+
+instance Show DBField where
+    show field = T.unpack (tableName field <> "." <> fieldName field)
+
+instance Eq DBField where
+    field0 == field1 = show field0 == show field1
+
+instance ToJSON DBField where
+    toJSON = Aeson.String . T.pack . show
+
+{-------------------------------------------------------------------------------
+                                    Logging
+-------------------------------------------------------------------------------}
+
+data DBLog
+    = MsgMigrations (Either MigrationError Int)
+    | MsgQuery Text Severity
+    | MsgRun BracketLog
+    | MsgOpenSingleConnection FilePath
+    | MsgCloseSingleConnection FilePath
+    | MsgDatabaseReset
+    | MsgIsAlreadyClosed Text
+    | MsgStatementAlreadyFinalized Text
+    | MsgManualMigrationNeeded DBField Text
+    | MsgExpectedMigration DBLog
+    | MsgManualMigrationNotNeeded DBField
+    | MsgUpdatingForeignKeysSetting ForeignKeysSetting
+    | MsgRetryOnBusy Int RetryLog
+    deriving (Generic, Show, Eq, ToJSON)
+
+data RetryLog = MsgRetry | MsgRetryGaveUp | MsgRetryDone
+    deriving (Generic, Show, Eq, ToJSON)
+
+instance HasPrivacyAnnotation DBLog
+instance HasSeverityAnnotation DBLog where
+    getSeverityAnnotation ev = case ev of
+        MsgMigrations (Right 0) -> Debug
+        MsgMigrations (Right _) -> Notice
+        MsgMigrations (Left _) -> Error
+        MsgQuery _ sev -> sev
+        MsgRun _ -> Debug
+        MsgCloseSingleConnection _ -> Info
+        MsgExpectedMigration _ -> Debug
+        MsgDatabaseReset -> Notice
+        MsgIsAlreadyClosed _ -> Warning
+        MsgStatementAlreadyFinalized _ -> Warning
+        MsgManualMigrationNeeded{} -> Notice
+        MsgManualMigrationNotNeeded{} -> Debug
+        MsgUpdatingForeignKeysSetting{} -> Debug
+        MsgRetryOnBusy n _
+            | n <= 1 -> Debug
+            | n <= 3 -> Notice
+            | otherwise -> Warning
+        MsgOpenSingleConnection _ -> Debug
+
+instance ToText DBLog where
+    toText = \case
+        MsgMigrations (Right 0) ->
+            "No database migrations were necessary."
+        MsgMigrations (Right n) ->
+            fmt $ "" +|| n ||+ " migrations were applied to the database."
+        MsgMigrations (Left err) ->
+            "Failed to migrate the database: " <> getMigrationErrorMessage err
+        MsgQuery stmt _ -> stmt
+        MsgRun b ->
+            "Running database action - " <> toText b
+        MsgDatabaseReset ->
+            "Non backward compatible database found. Removing old database \
+            \and re-creating it from scratch. Ignore the previous error."
+        MsgOpenSingleConnection fp ->
+            "Opening single database connection (" +| fp |+ ")"
+        MsgCloseSingleConnection fp ->
+            "Closing single database connection (" +| fp |+ ")"
+        MsgIsAlreadyClosed msg ->
+            "Attempted to close an already closed connection: " <> msg
+        MsgStatementAlreadyFinalized msg ->
+            "Statement already finalized: " <> msg
+        MsgExpectedMigration msg -> "Expected: " <> toText msg
+        MsgManualMigrationNeeded field value ->
+            mconcat
+                [ tableName field
+                , " table does not contain required field '"
+                , fieldName field
+                , "'. "
+                , "Adding this field with a default value of "
+                , value
+                , "."
+                ]
+        MsgManualMigrationNotNeeded field ->
+            mconcat
+                [ tableName field
+                , " table already contains required field '"
+                , fieldName field
+                , "'."
+                ]
+        MsgUpdatingForeignKeysSetting value ->
+            mconcat
+                [ "Updating the foreign keys setting to: "
+                , T.pack $ show value
+                , "."
+                ]
+        MsgRetryOnBusy n msg -> case msg of
+            MsgRetry
+                | n <= 10 ->
+                    "Retrying db query because db was busy "
+                        <> "for the " +| ordinalF n |+ " time."
+                | n == 11 ->
+                    "No more logs until it finishes..."
+                | otherwise -> ""
+            MsgRetryGaveUp -> "Gave up on retrying the db query."
+            MsgRetryDone
+                | n > 3 -> "DB query succeeded after " +| n |+ " attempts."
+                | otherwise -> ""
+
+-- | Produce a persistent 'LogFunc' backed by 'Tracer IO DBLog'
+queryLogFunc :: Tracer IO DBLog -> LogFunc
+queryLogFunc tr _loc _source level str = traceWith tr (MsgQuery msg sev)
+  where
+    -- Filter out parameters which appear after the statement semicolon.
+    -- They will contain sensitive material that we don't want in the log.
+    stmt = B8.takeWhile (/= ';') $ fromLogStr str
+    msg = T.decodeUtf8 stmt
+    sev = case level of
+        LevelDebug -> Debug
+        LevelInfo -> Info
+        LevelWarn -> Warning
+        LevelError -> Error
+        LevelOther _ -> Warning
+
+{-------------------------------------------------------------------------------
+                               Extra DB Helpers
+-------------------------------------------------------------------------------}
+
+-- | Convert a single DB "updateMany" (or similar) query into multiple
+-- updateMany queries with smaller lists of values.
+--
+-- This is to prevent too many variables appearing in the SQL statement.
+-- SQLITE_MAX_VARIABLE_NUMBER is 999 by default, and we will get a
+-- "too many SQL variables" exception if that is exceeded.
+--
+-- We choose a conservative value 'chunkSize' << 999 because there can be
+-- multiple variables per row updated.
+dbChunked
+    :: forall record b
+     . PersistEntity record
+    => ([record] -> SqlPersistT IO b)
+    -> [record]
+    -> SqlPersistT IO ()
+dbChunked = dbChunkedFor @record
+
+-- | Like 'dbChunked', but generalized for the case where the input list is not
+-- the same type as the record.
+dbChunkedFor
+    :: forall record a b
+     . PersistEntity record
+    => ([a] -> SqlPersistT IO b)
+    -> [a]
+    -> SqlPersistT IO ()
+dbChunkedFor = chunkedM (chunkSizeFor @record)
+
+-- | Like 'dbChunked', but allows bundling elements with a 'Key'. Useful when
+-- used with 'repsertMany'.
+dbChunked'
+    :: forall record b
+     . PersistEntity record
+    => ([(Key record, record)] -> SqlPersistT IO b)
+    -> [(Key record, record)]
+    -> SqlPersistT IO ()
+dbChunked' = chunkedM (chunkSizeFor @record)
+
+-- | Given an action which takes a list of items, and a list of items, run that
+-- action multiple times with the input list cut into chunks.
+chunkedM
+    :: Monad m
+    => Int
+    -- ^ Chunk size
+    -> ([a] -> m b)
+    -- ^ Action to run on values
+    -> [a]
+    -- ^ The values
+    -> m ()
+chunkedM n f = mapM_ f . chunksOf n
+
+-- | Maximum number of variables allowed in a single SQL statement
+--
+-- See also 'dbChunked'.
+chunkSize :: Int
+chunkSize = 999
+
+-- | Size of chunks when inserting, updating or deleting many rows at once.
+-- Worst-case is when all columns of a particular table gets updated / inserted,
+-- thus to be safe we must ensure that we do not act on more than `chunkSize /
+-- cols` variables.
+--
+-- See also 'dbChunked'.
+chunkSizeFor :: forall record. PersistEntity record => Int
+chunkSizeFor = chunkSize `div` cols
+  where
+    cols = length $ getEntityFields $ entityDef (Proxy @record)
+
+-- TODO: Does getEntityFields differ from the past entityFields?

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -620,10 +620,11 @@ withDBOpenFromFile
     -> IO a
 withDBOpenFromFile walletF tr defaultFieldValues dbFile action = do
     let trDB = contramap MsgDB tr
+        trManualMigrations = contramap MsgMigrationOld trDB
     let manualMigrations =
             maybe
                 createSchemaVersionTableIfMissing'
-                (migrateManually trDB $ keyOfWallet walletF)
+                (migrateManually trManualMigrations $ keyOfWallet walletF)
                 defaultFieldValues
     let autoMigrations   = migrateAll
     res <- withSqliteContextFile trDB dbFile

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/Old.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/Old.hs
@@ -36,8 +36,10 @@ module Cardano.Wallet.DB.Sqlite.Migration.Old
 import Prelude
 
 import Cardano.DB.Sqlite
+    ( DBLog (..)
+    )
+import Cardano.DB.Sqlite.Migration.Old
     ( DBField (..)
-    , DBLog (..)
     , ManualMigration (..)
     , fieldName
     , fieldType

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/Old.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/Old.hs
@@ -35,11 +35,9 @@ module Cardano.Wallet.DB.Sqlite.Migration.Old
 
 import Prelude
 
-import Cardano.DB.Sqlite
-    ( DBLog (..)
-    )
 import Cardano.DB.Sqlite.Migration.Old
     ( DBField (..)
+    , DBMigrationOldLog (..)
     , ManualMigration (..)
     , fieldName
     , fieldType
@@ -173,7 +171,7 @@ onlyOnSchemaForOldMigrations (ManualMigration m) = ManualMigration $ \conn -> do
 -- | Executes any manual database migration steps that may be required on
 -- startup.
 migrateManually
-    :: Tracer IO DBLog
+    :: Tracer IO DBMigrationOldLog
     -> KeyFlavorS k
     -> DefaultFieldValues
     -> ManualMigration

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migration.hs
@@ -9,10 +9,12 @@ module Cardano.Wallet.DB.Store.Delegations.Migration
 import Prelude
 
 import Cardano.DB.Sqlite
-    ( DBField (..)
-    , ReadDBHandle
+    ( ReadDBHandle
     , dbBackend
     , dbConn
+    )
+import Cardano.DB.Sqlite.Migration.Old
+    ( DBField (..)
     )
 import Cardano.Pool.Types
     ( PoolId

--- a/lib/wallet/src/Cardano/Wallet/Pools.hs
+++ b/lib/wallet/src/Cardano/Wallet/Pools.hs
@@ -296,7 +296,7 @@ import UnliftIO.STM
     )
 
 import qualified Cardano.Pool.DB as PoolDb
-import qualified Cardano.Pool.DB.Sqlite as Pool
+import qualified Cardano.Pool.DB.Layer as Pool
 import qualified Cardano.Wallet.Checkpoints.Policy as CP
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Data.List as L

--- a/lib/wallet/test/integration/shelley-integration-test.hs
+++ b/lib/wallet/test/integration/shelley-integration-test.hs
@@ -228,7 +228,7 @@ import qualified Cardano.Address.Style.Shelley as Shelley
 import qualified Cardano.BM.Backend.EKGView as EKG
 import qualified Cardano.CLI as CLI
 import qualified Cardano.Pool.DB as Pool
-import qualified Cardano.Pool.DB.Sqlite as Pool
+import qualified Cardano.Pool.DB.Layer as Pool
 import qualified Cardano.Wallet.Faucet.Addresses as Addresses
 import qualified Cardano.Wallet.Faucet.Mnemonics as Mnemonics
 import qualified Cardano.Wallet.Launch.Cluster as Cluster

--- a/lib/wallet/test/unit/Cardano/Pool/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Pool/DB/LayerSpec.hs
@@ -16,9 +16,6 @@ import Prelude
 import Cardano.BM.Trace
     ( nullTracer
     )
-import Cardano.DB.Sqlite
-    ( DBLog (..)
-    )
 import Cardano.Pool.DB
     ( DBLayer (..)
     )
@@ -30,6 +27,9 @@ import Cardano.Pool.DB.Log
     )
 import Cardano.Pool.DB.Properties
     ( properties
+    )
+import Cardano.Pool.DB.Sqlite
+    ( DBLog (..)
     )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( dummyTimeInterpreter

--- a/lib/wallet/test/unit/Cardano/Pool/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Pool/DB/LayerSpec.hs
@@ -7,7 +7,7 @@
 --
 -- DBLayer tests for SQLite implementation.
 
-module Cardano.Pool.DB.SqliteSpec
+module Cardano.Pool.DB.LayerSpec
     ( spec
     ) where
 
@@ -22,14 +22,14 @@ import Cardano.DB.Sqlite
 import Cardano.Pool.DB
     ( DBLayer (..)
     )
+import Cardano.Pool.DB.Layer
+    ( withDBLayer
+    )
 import Cardano.Pool.DB.Log
     ( PoolDbLog (..)
     )
 import Cardano.Pool.DB.Properties
     ( properties
-    )
-import Cardano.Pool.DB.Sqlite
-    ( withDBLayer
     )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( dummyTimeInterpreter


### PR DESCRIPTION
In preparation for the improvement of the database initialization logic, this pull request duplicates and specializes the `SqliteContext`-related code in `Cardano.Pool.DB.Sqlite`.

This allows us to refactor the module `Cardano.DB.Sqlite` independently later. In particular, we want to avoid performing migrations at database opening time in the main wallet, but this refactoring is not worth doing for the pool database.

This pull request also performs a sequence of follow-up refactorings where we

1. split off a module `Cardano.DB.Sqlite.ForeignKeys`
2. split off a module `Cardano.DB.Sqlite.Migration.Old`
3. move `handleConstraint` to its usage site
4. remove / restructure the (formerly duplicated) `DBLog` types
 
### Issue number

ADP-3214