### PR TITLE
Fix `IsRecentEra era` type inference with GHC 8.10

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -322,10 +322,6 @@ instance TestEquality RecentEra where
 
 class
     ( CardanoApi.IsShelleyBasedEra era
-    , Core.Era (CardanoApi.ShelleyLedgerEra era)
-    , Eq (TxOut (CardanoApi.ShelleyLedgerEra era))
-    , Ledger.Crypto (Core.EraCrypto (CardanoApi.ShelleyLedgerEra era))
-    , Show (TxOut (CardanoApi.ShelleyLedgerEra era))
     , Typeable era
     ) => IsRecentEra era where
     recentEra :: RecentEra era
@@ -346,6 +342,9 @@ type RecentEraLedgerConstraints era =
     , Alonzo.AlonzoEraPParams era
     , Ledger.AlonzoEraTx era
     , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+    , Eq (TxOut era)
+    , Ledger.Crypto (Core.EraCrypto era)
+    , Show (TxOut era)
     , Babbage.BabbageEraTxBody era
     , Shelley.EraUTxO era
     )

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -454,8 +454,8 @@ data ErrBalanceTx era
     --   - the given UTxO index is empty.
     -- A transaction must have at least one input in order to be valid.
 
-deriving instance IsRecentEra era => Eq (ErrBalanceTx era)
-deriving instance IsRecentEra era => Show (ErrBalanceTx era)
+deriving instance Eq (ErrBalanceTx era)
+deriving instance Show (ErrBalanceTx era)
 
 -- | A 'PartialTx' is an an unbalanced 'SealedTx' along with the necessary
 -- information to balance it.

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2650,7 +2650,6 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
     withWorkerCtx api walletId liftE liftE $ \wrk -> do
         let db = wrk ^. dbLayer
             netLayer = wrk ^. networkLayer
-            trWorker :: Tracer IO W.WalletLog
             trWorker = MsgWallet >$< wrk ^. logger
 
         (Write.InAnyRecentEra (_era :: Write.RecentEra era) pp, _)
@@ -3159,7 +3158,6 @@ constructSharedTransaction
     withWorkerCtx api wid liftE liftE $ \wrk -> do
         let db = wrk ^. dbLayer
             netLayer = wrk ^. networkLayer
-            trWorker :: Tracer IO W.WalletLog
             trWorker = MsgWallet >$< wrk ^. logger
 
         currentEpochSlotting <- liftIO $ getCurrentEpochSlotting netLayer

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1149,7 +1149,7 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
             -> CardanoApi.Tx era
             -> IO ())
         -> Spec
-    forAllGoldens goldens f = forM_ goldens $ \(name, bs) -> itIO name $
+    forAllGoldens goldens f = forM_ goldens $ \(name, bs) -> it name $
         Write.withInAnyRecentEra (recentEraTxFromBytes bs) $ \tx ->
             let
                 msg = unlines
@@ -1217,7 +1217,7 @@ spec_updateTx = describe "updateTx" $ do
         forM_ txs $ \(filepath, sealedTx) -> do
             let anyRecentEraTx
                     = fromJust $ Write.asAnyRecentEra $ cardanoTx sealedTx
-            itIO ("without TxUpdate: " <> filepath) $ do
+            it ("without TxUpdate: " <> filepath) $ do
                 Write.withInAnyRecentEra anyRecentEraTx
                     $ \(tx :: CardanoApi.Tx era) -> do
                     let res = toCardanoApiTx <$> updateTx
@@ -1269,7 +1269,7 @@ spec_updateTx = describe "updateTx" $ do
 
         signedTxs <- runIO signedTxTestData
 
-        itIO "returns `Left err` with noTxUpdate" $ do
+        it "returns `Left err` with noTxUpdate" $ do
             -- Could be argued that it should instead return `Right tx`.
             let anyRecentEraTx = recentEraTxFromBytes
                     $ snd $ head signedTxs
@@ -1283,7 +1283,7 @@ spec_updateTx = describe "updateTx" $ do
 
                     res `shouldBe` Left (ErrExistingKeyWitnesses 1)
 
-        itIO "returns `Left err` when extra body content is non-empty" $ do
+        it "returns `Left err` when extra body content is non-empty" $ do
             pendingWith "todo: add test data"
   where
     readTestTransactions :: SpecM a [(FilePath, SealedTx)]
@@ -2121,16 +2121,6 @@ hasTotalCollateral (CardanoApi.Tx (CardanoApi.TxBody content) _) =
     case CardanoApi.txTotalCollateral content of
         CardanoApi.TxTotalCollateralNone -> False
         CardanoApi.TxTotalCollateral _ _ -> True
-
--- | A type-constrained variant of 'it'.
---
--- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2353
---
--- We should consider removing this function and replacing usages of it with
--- the ordinary 'Hspec.it' function.
---
-itIO :: String -> IO () -> Spec
-itIO = it
 
 mkTestWallet :: W.UTxO -> Wallet'
 mkTestWallet utxo =


### PR DESCRIPTION
Follow-up to #4178

Instead of capturing the relevant constraints as superclass constraints to `IsRecentEra era`:

```haskell
class
     ( CardanoApi.IsShelleyBasedEra era
     , Core.Era (CardanoApi.ShelleyLedgerEra era)
     , Eq (TxOut (CardanoApi.ShelleyLedgerEra era))
     , Ledger.Crypto (Core.EraCrypto (CardanoApi.ShelleyLedgerEra era))
     , Show (TxOut (CardanoApi.ShelleyLedgerEra era))
     , Typeable era
     ) => IsRecentEra era where
```
we can capture them in the `ErrBalanceTx era` constructors themselves:

```haskell
  | RecentEraLedgerConstraints (ShelleyLedgerEra era)
         => ErrBalanceTxInsufficientCollateral
```


### Comments

Preliminary next steps: 
1. Create a `IsRecentLedgerEra era`
2. Rename `IsRecentLedgerEra` to `IsRecentEra`
3. Create a wrapping cardano-api and/or wallet version of `balanceTx` and its arguments

### Issue Number

ADP-2353
