### PR TITLE
[ADP-3214] Refactor `Cardano.Wallet.DB.Sqlite`

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -217,6 +217,7 @@ library
     Cardano.DB.Sqlite
     Cardano.DB.Sqlite.Delete
     Cardano.DB.Sqlite.ForeignKeys
+    Cardano.DB.Sqlite.Migration.Old
     Cardano.Pool.DB
     Cardano.Pool.DB.Log
     Cardano.Pool.DB.Model

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -216,6 +216,7 @@ library
     Cardano.Api.Extra
     Cardano.DB.Sqlite
     Cardano.DB.Sqlite.Delete
+    Cardano.DB.Sqlite.ForeignKeys
     Cardano.Pool.DB
     Cardano.Pool.DB.Log
     Cardano.Pool.DB.Model

--- a/lib/wallet/src/Cardano/DB/Sqlite.hs
+++ b/lib/wallet/src/Cardano/DB/Sqlite.hs
@@ -65,12 +65,10 @@ import Cardano.DB.Sqlite.ForeignKeys
     , withForeignKeysDisabled
     )
 import Cardano.DB.Sqlite.Migration.Old
-    ( DBField (..)
+    ( DBMigrationOldLog (..)
     , ManualMigration (..)
     , MatchMigrationError (..)
     , MigrationError (..)
-    , fieldName
-    , tableName
     )
 import Cardano.Wallet.DB.Migration
     ( ErrWrongVersion (..)
@@ -464,6 +462,7 @@ runAllMigrations tr fp old auto new = runExceptT $ do
 
 data DBLog
     = MsgMigrations (Either MigrationError Int)
+    | MsgMigrationOld DBMigrationOldLog
     | MsgQuery Text Severity
     | MsgRun BracketLog
     | MsgOpenSingleConnection FilePath
@@ -471,9 +470,6 @@ data DBLog
     | MsgDatabaseReset
     | MsgIsAlreadyClosed Text
     | MsgStatementAlreadyFinalized Text
-    | MsgManualMigrationNeeded DBField Text
-    | MsgExpectedMigration DBLog
-    | MsgManualMigrationNotNeeded DBField
     | MsgUpdatingForeignKeysSetting ForeignKeysSetting
     | MsgRetryOnBusy Int RetryLog
     deriving (Generic, Show, Eq, ToJSON)
@@ -487,15 +483,13 @@ instance HasSeverityAnnotation DBLog where
         MsgMigrations (Right 0) -> Debug
         MsgMigrations (Right _) -> Notice
         MsgMigrations (Left _) -> Error
+        MsgMigrationOld msg -> getSeverityAnnotation msg
         MsgQuery _ sev -> sev
         MsgRun _ -> Debug
         MsgCloseSingleConnection _ -> Info
-        MsgExpectedMigration _ -> Debug
         MsgDatabaseReset -> Notice
         MsgIsAlreadyClosed _ -> Warning
         MsgStatementAlreadyFinalized _ -> Warning
-        MsgManualMigrationNeeded{} -> Notice
-        MsgManualMigrationNotNeeded{} -> Debug
         MsgUpdatingForeignKeysSetting{} -> Debug
         MsgRetryOnBusy n _
             | n <= 1 -> Debug
@@ -525,24 +519,7 @@ instance ToText DBLog where
             "Attempted to close an already closed connection: " <> msg
         MsgStatementAlreadyFinalized msg ->
             "Statement already finalized: " <> msg
-        MsgExpectedMigration msg -> "Expected: " <> toText msg
-        MsgManualMigrationNeeded field value ->
-            mconcat
-                [ tableName field
-                , " table does not contain required field '"
-                , fieldName field
-                , "'. "
-                , "Adding this field with a default value of "
-                , value
-                , "."
-                ]
-        MsgManualMigrationNotNeeded field ->
-            mconcat
-                [ tableName field
-                , " table already contains required field '"
-                , fieldName field
-                , "'."
-                ]
+        MsgMigrationOld msg -> toText msg
         MsgUpdatingForeignKeysSetting value ->
             mconcat
                 [ "Updating the foreign keys setting to: "

--- a/lib/wallet/src/Cardano/DB/Sqlite.hs
+++ b/lib/wallet/src/Cardano/DB/Sqlite.hs
@@ -71,6 +71,10 @@ import Cardano.BM.Extra
     ( BracketLog
     , bracketTracer
     )
+import Cardano.DB.Sqlite.ForeignKeys
+    ( ForeignKeysSetting (..)
+    , withForeignKeysDisabled
+    )
 import Cardano.Wallet.DB.Migration
     ( ErrWrongVersion (..)
     )
@@ -81,7 +85,6 @@ import Control.Lens
 import Control.Monad
     ( join
     , void
-    , when
     )
 import Control.Monad.IO.Unlift
     ( MonadUnliftIO (..)
@@ -193,7 +196,6 @@ import UnliftIO.Compat
 import UnliftIO.Exception
     ( Exception
     , bracket
-    , bracket_
     , handleJust
     , tryJust
     )
@@ -247,9 +249,11 @@ newInMemorySqliteContext tr manualMigrations autoMigration disableFK = do
     -- concurrent accesses and ensure database integrity in case where multiple
     -- threads would be reading/writing from/to it.
     lock <- newMVar unsafeBackend
-    let useForeignKeys :: IO a -> IO a
+    let trFK = contramap MsgUpdatingForeignKeysSetting tr
+        useForeignKeys :: IO a -> IO a
         useForeignKeys
-            | disableFK == ForeignKeysDisabled = withForeignKeysDisabled tr conn
+            | disableFK == ForeignKeysDisabled =
+                withForeignKeysDisabled trFK conn
             | otherwise = id
         runQuery :: forall a. SqlPersistT IO a -> IO a
         runQuery cmd =
@@ -422,87 +426,6 @@ retryOnBusy tr timeout action =
             $ MsgRetryOnBusy rsIterNumber m
 
 {-------------------------------------------------------------------------------
-    Foreign key settings
--------------------------------------------------------------------------------}
-
--- | Run the given task in a context where foreign key constraints are
---   /temporarily disabled/, before re-enabling them.
-withForeignKeysDisabled
-    :: Tracer IO DBLog
-    -> Sqlite.Connection
-    -> IO a
-    -> IO a
-withForeignKeysDisabled t c =
-    bracket_
-        (updateForeignKeysSetting t c ForeignKeysDisabled)
-        (updateForeignKeysSetting t c ForeignKeysEnabled)
-
--- | Specifies whether or not foreign key constraints are enabled, equivalent
---   to the Sqlite 'foreign_keys' setting.
---
--- When foreign key constraints are /enabled/, the database will enforce
--- referential integrity, and cascading deletes are enabled.
---
--- When foreign keys constraints are /disabled/, the database will not enforce
--- referential integrity, and cascading deletes are disabled.
---
--- See the following resource for more information:
--- https://www.sqlite.org/foreignkeys.html#fk_enable
-data ForeignKeysSetting
-    = -- | Foreign key constraints are /enabled/.
-      ForeignKeysEnabled
-    | -- | Foreign key constraints are /disabled/.
-      ForeignKeysDisabled
-    deriving (Eq, Generic, ToJSON, Show)
-
--- | Read the current value of the Sqlite 'foreign_keys' setting.
-readForeignKeysSetting :: Sqlite.Connection -> IO ForeignKeysSetting
-readForeignKeysSetting connection = do
-    query <- Sqlite.prepare connection "PRAGMA foreign_keys"
-    state <- Sqlite.step query >> Sqlite.columns query
-    Sqlite.finalize query
-    case state of
-        [Persist.PersistInt64 0] -> pure ForeignKeysDisabled
-        [Persist.PersistInt64 1] -> pure ForeignKeysEnabled
-        unexpectedValue ->
-            error
-                $ mconcat
-                    [ "Unexpected result when querying the current value of "
-                    , "the Sqlite 'foreign_keys' setting: "
-                    , show unexpectedValue
-                    , "."
-                    ]
-
--- | Update the current value of the Sqlite 'foreign_keys' setting.
-updateForeignKeysSetting
-    :: Tracer IO DBLog
-    -> Sqlite.Connection
-    -> ForeignKeysSetting
-    -> IO ()
-updateForeignKeysSetting trace connection desiredValue = do
-    traceWith trace $ MsgUpdatingForeignKeysSetting desiredValue
-    query <-
-        Sqlite.prepare connection
-            $ "PRAGMA foreign_keys = " <> valueToWrite <> ";"
-    _ <- Sqlite.step query
-    Sqlite.finalize query
-    finalValue <- readForeignKeysSetting connection
-    when (desiredValue /= finalValue)
-        $ error
-        $ mconcat
-            [ "Unexpected error when updating the value of the Sqlite "
-            , "'foreign_keys' setting. Attempted to write the value "
-            , show desiredValue
-            , " but retrieved the final value "
-            , show finalValue
-            , "."
-            ]
-  where
-    valueToWrite = case desiredValue of
-        ForeignKeysEnabled -> "ON"
-        ForeignKeysDisabled -> "OFF"
-
-{-------------------------------------------------------------------------------
     Database migrations
     old style and new style
 -------------------------------------------------------------------------------}
@@ -556,7 +479,8 @@ runAutoMigration tr autoMigration DBHandle{dbConn, dbBackend} = do
             runSqlConn
                 (runMigrationUnsafeQuiet autoMigration)
                 dbBackend
-    migrationResult <- withForeignKeysDisabled tr dbConn $ do
+        trFK = contramap MsgUpdatingForeignKeysSetting tr
+    migrationResult <- withForeignKeysDisabled trFK dbConn $ do
         executeAutoMigration
             & tryJust (matchMigrationError @PersistException)
             & tryJust (matchMigrationError @SqliteException)
@@ -570,7 +494,8 @@ runManualOldMigrations
     -> DBHandle
     -> IO (Either MigrationError ())
 runManualOldMigrations tr manualMigration DBHandle{dbConn} = do
-    withForeignKeysDisabled tr dbConn
+    let trFK = contramap MsgUpdatingForeignKeysSetting tr
+    withForeignKeysDisabled trFK dbConn
         $ Right
             <$> (`executeManualMigration` dbConn) manualMigration
 

--- a/lib/wallet/src/Cardano/DB/Sqlite/ForeignKeys.hs
+++ b/lib/wallet/src/Cardano/DB/Sqlite/ForeignKeys.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK, 2023 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Helper functions for enabling / disabling foreign keys
+-- on an SQLite database.
+--
+-- Depends on "Database.Sqlite" from @persistent-sqlite@.
+module Cardano.DB.Sqlite.ForeignKeys
+    ( ForeignKeysSetting (..)
+    , withForeignKeysDisabled
+    ) where
+
+import Prelude
+
+import Control.Monad
+    ( when
+    )
+import Control.Tracer
+    ( Tracer
+    , traceWith
+    )
+import Data.Aeson
+    ( ToJSON (..)
+    )
+import GHC.Generics
+    ( Generic
+    )
+import UnliftIO.Exception
+    ( bracket_
+    )
+
+import qualified Database.Persist.Sql as Persist
+import qualified Database.Sqlite as Sqlite
+
+{-------------------------------------------------------------------------------
+    Foreign key settings
+-------------------------------------------------------------------------------}
+
+-- | Run the given task in a context where foreign key constraints are
+--   /temporarily disabled/, before re-enabling them.
+withForeignKeysDisabled
+    :: Tracer IO ForeignKeysSetting
+    -> Sqlite.Connection
+    -> IO a
+    -> IO a
+withForeignKeysDisabled t c =
+    bracket_
+        (updateForeignKeysSetting t c ForeignKeysDisabled)
+        (updateForeignKeysSetting t c ForeignKeysEnabled)
+
+-- | Specifies whether or not foreign key constraints are enabled, equivalent
+--   to the Sqlite 'foreign_keys' setting.
+--
+-- When foreign key constraints are /enabled/, the database will enforce
+-- referential integrity, and cascading deletes are enabled.
+--
+-- When foreign keys constraints are /disabled/, the database will not enforce
+-- referential integrity, and cascading deletes are disabled.
+--
+-- See the following resource for more information:
+-- https://www.sqlite.org/foreignkeys.html#fk_enable
+data ForeignKeysSetting
+    = -- | Foreign key constraints are /enabled/.
+      ForeignKeysEnabled
+    | -- | Foreign key constraints are /disabled/.
+      ForeignKeysDisabled
+    deriving (Eq, Generic, ToJSON, Show)
+
+-- | Read the current value of the Sqlite 'foreign_keys' setting.
+readForeignKeysSetting :: Sqlite.Connection -> IO ForeignKeysSetting
+readForeignKeysSetting connection = do
+    query <- Sqlite.prepare connection "PRAGMA foreign_keys"
+    state <- Sqlite.step query >> Sqlite.columns query
+    Sqlite.finalize query
+    case state of
+        [Persist.PersistInt64 0] -> pure ForeignKeysDisabled
+        [Persist.PersistInt64 1] -> pure ForeignKeysEnabled
+        unexpectedValue ->
+            error
+                $ mconcat
+                    [ "Unexpected result when querying the current value of "
+                    , "the Sqlite 'foreign_keys' setting: "
+                    , show unexpectedValue
+                    , "."
+                    ]
+
+-- | Update the current value of the Sqlite 'foreign_keys' setting.
+updateForeignKeysSetting
+    :: Tracer IO ForeignKeysSetting
+    -> Sqlite.Connection
+    -> ForeignKeysSetting
+    -> IO ()
+updateForeignKeysSetting trace connection desiredValue = do
+    traceWith trace desiredValue
+    query <-
+        Sqlite.prepare connection
+            $ "PRAGMA foreign_keys = " <> valueToWrite <> ";"
+    _ <- Sqlite.step query
+    Sqlite.finalize query
+    finalValue <- readForeignKeysSetting connection
+    when (desiredValue /= finalValue)
+        $ error
+        $ mconcat
+            [ "Unexpected error when updating the value of the Sqlite "
+            , "'foreign_keys' setting. Attempted to write the value "
+            , show desiredValue
+            , " but retrieved the final value "
+            , show finalValue
+            , "."
+            ]
+  where
+    valueToWrite = case desiredValue of
+        ForeignKeysEnabled -> "ON"
+        ForeignKeysDisabled -> "OFF"

--- a/lib/wallet/src/Cardano/DB/Sqlite/Migration/Old.hs
+++ b/lib/wallet/src/Cardano/DB/Sqlite/Migration/Old.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Copyright: © 2018-2022 IOHK, 2023 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Old-style manual migrations.
+--
+-- Depends on "Database.Sqlite" from @persistent-sqlite@.
+module Cardano.DB.Sqlite.Migration.Old
+    ( -- * Old-style Manual Migration
+      ManualMigration (..)
+    , noManualMigration
+    , foldMigrations
+
+    , MigrationError (..)
+    , MatchMigrationError (..)
+
+    -- * Migration helpers
+    , DBField (..)
+    , tableName
+    , fieldName
+    , fieldType
+    ) where
+
+import Prelude
+
+import Control.Exception
+    ( Exception
+    )
+import Data.Aeson
+    ( ToJSON (..)
+    )
+import Data.List
+    ( isInfixOf
+    )
+import Data.Proxy
+    ( Proxy (..)
+    )
+import Data.Text
+    ( Text
+    )
+import Database.Persist.EntityDef
+    ( getEntityDBName
+    )
+import Database.Persist.Sql
+    ( EntityField
+    , PersistEntity (..)
+    , PersistException
+    , SqlType (..)
+    , fieldDB
+    , fieldSqlType
+    , unEntityNameDB
+    , unFieldNameDB
+    )
+import Database.Sqlite
+    ( Error (ErrorConstraint)
+    , SqliteException (SqliteException)
+    )
+import GHC.Generics
+    ( Generic
+    )
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Text as T
+import qualified Database.Sqlite as Sqlite
+
+{-----------------------------------------------------------------------------
+    Type
+------------------------------------------------------------------------------}
+
+-- | Encapsulates an old-style manual migration action
+--   (or sequence of actions) to be
+--   performed immediately after an SQL connection is initiated.
+newtype ManualMigration = ManualMigration
+    {executeManualMigration :: Sqlite.Connection -> IO ()}
+
+noManualMigration :: ManualMigration
+noManualMigration = ManualMigration $ const $ pure ()
+
+foldMigrations :: [Sqlite.Connection -> IO ()] -> ManualMigration
+foldMigrations ms = ManualMigration $ \conn -> mapM_ ($ conn) ms
+
+{-----------------------------------------------------------------------------
+    Helpers
+------------------------------------------------------------------------------}
+
+data DBField where
+    DBField
+        :: forall record typ
+         . (PersistEntity record)
+        => EntityField record typ
+        -> DBField
+
+tableName :: DBField -> Text
+tableName (DBField (_ :: EntityField record typ)) =
+    unEntityNameDB $ getEntityDBName $ entityDef (Proxy :: Proxy record)
+
+fieldName :: DBField -> Text
+fieldName (DBField field) =
+    unFieldNameDB $ fieldDB $ persistFieldDef field
+
+fieldType :: DBField -> Text
+fieldType (DBField field) =
+    showSqlType $ fieldSqlType $ persistFieldDef field
+
+showSqlType :: SqlType -> Text
+showSqlType = \case
+    SqlString -> "VARCHAR"
+    SqlInt32 -> "INTEGER"
+    SqlInt64 -> "INTEGER"
+    SqlReal -> "REAL"
+    SqlDay -> "DATE"
+    SqlTime -> "TIME"
+    SqlDayTime -> "TIMESTAMP"
+    SqlBlob -> "BLOB"
+    SqlBool -> "BOOLEAN"
+    SqlOther t -> t
+    SqlNumeric precision scale ->
+        T.concat
+            [ "NUMERIC("
+            , T.pack (show precision)
+            , ","
+            , T.pack (show scale)
+            , ")"
+            ]
+
+instance Show DBField where
+    show field = T.unpack (tableName field <> "." <> fieldName field)
+
+instance Eq DBField where
+    field0 == field1 = show field0 == show field1
+
+instance ToJSON DBField where
+    toJSON = Aeson.String . T.pack . show
+
+{-----------------------------------------------------------------------------
+    Errors
+------------------------------------------------------------------------------}
+
+-- | Error type for when migrations go wrong after opening a database.
+newtype MigrationError = MigrationError
+    {getMigrationErrorMessage :: Text}
+    deriving (Show, Eq, Generic, ToJSON)
+
+instance Exception MigrationError
+
+class Exception e => MatchMigrationError e where
+    -- | Exception predicate for migration errors.
+    matchMigrationError :: e -> Maybe MigrationError
+
+instance MatchMigrationError PersistException where
+    matchMigrationError e
+        | mark `isInfixOf` msg = Just $ MigrationError $ T.pack msg
+        | otherwise = Nothing
+      where
+        msg = show e
+        mark = "Database migration: manual intervention required."
+
+instance MatchMigrationError SqliteException where
+    matchMigrationError (SqliteException ErrorConstraint _ msg) =
+        Just $ MigrationError msg
+    matchMigrationError _ =
+        Nothing

--- a/lib/wallet/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Sqlite.hs
@@ -38,18 +38,20 @@ import Cardano.BM.Extra
     ( bracketTracer
     )
 import Cardano.DB.Sqlite
-    ( DBField (..)
-    , DBLog (..)
+    ( DBLog (..)
     , ForeignKeysSetting (ForeignKeysEnabled)
-    , ManualMigration (..)
-    , MigrationError
     , SqliteContext (..)
-    , fieldName
-    , foldMigrations
     , handleConstraint
     , newInMemorySqliteContext
-    , tableName
     , withSqliteContextFile
+    )
+import Cardano.DB.Sqlite.Migration.Old
+    ( DBField (..)
+    , ManualMigration (..)
+    , MigrationError (..)
+    , fieldName
+    , foldMigrations
+    , tableName
     )
 import Cardano.Pool.DB
     ( DBLayer (..)

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -51,7 +51,6 @@ import Cardano.BM.Data.Tracer
 import Cardano.DB.Sqlite
     ( DBLog (..)
     , ForeignKeysSetting (ForeignKeysEnabled)
-    , ManualMigration (..)
     , SqliteContext (..)
     , newInMemorySqliteContext
     , withSqliteContextFile
@@ -62,6 +61,9 @@ import Cardano.DB.Sqlite.Delete
     , newRefCount
     , waitForFree
     , withRef
+    )
+import Cardano.DB.Sqlite.Migration.Old
+    ( ManualMigration (..)
     )
 import Cardano.Slotting.Slot
     ( WithOrigin (..)

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -622,10 +622,11 @@ withDBOpenFromFile
     -> IO a
 withDBOpenFromFile walletF tr defaultFieldValues dbFile action = do
     let trDB = contramap MsgDB tr
+        trManualMigrations = contramap MsgMigrationOld trDB
     let manualMigrations =
             maybe
                 createSchemaVersionTableIfMissing'
-                (migrateManually trDB $ keyOfWallet walletF)
+                (migrateManually trManualMigrations $ keyOfWallet walletF)
                 defaultFieldValues
     let autoMigrations   = migrateAll
     res <- withSqliteContextFile trDB dbFile

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/Old.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/Old.hs
@@ -36,8 +36,10 @@ module Cardano.Wallet.DB.Sqlite.Migration.Old
 import Prelude
 
 import Cardano.DB.Sqlite
+    ( DBLog (..)
+    )
+import Cardano.DB.Sqlite.Migration.Old
     ( DBField (..)
-    , DBLog (..)
     , ManualMigration (..)
     , fieldName
     , fieldType

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/Old.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/Old.hs
@@ -35,11 +35,9 @@ module Cardano.Wallet.DB.Sqlite.Migration.Old
 
 import Prelude
 
-import Cardano.DB.Sqlite
-    ( DBLog (..)
-    )
 import Cardano.DB.Sqlite.Migration.Old
     ( DBField (..)
+    , DBMigrationOldLog (..)
     , ManualMigration (..)
     , fieldName
     , fieldType
@@ -173,7 +171,7 @@ onlyOnSchemaForOldMigrations (ManualMigration m) = ManualMigration $ \conn -> do
 -- | Executes any manual database migration steps that may be required on
 -- startup.
 migrateManually
-    :: Tracer IO DBLog
+    :: Tracer IO DBMigrationOldLog
     -> KeyFlavorS k
     -> DefaultFieldValues
     -> ManualMigration

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migration.hs
@@ -9,10 +9,12 @@ module Cardano.Wallet.DB.Store.Delegations.Migration
 import Prelude
 
 import Cardano.DB.Sqlite
-    ( DBField (..)
-    , ReadDBHandle
+    ( ReadDBHandle
     , dbBackend
     , dbConn
+    )
+import Cardano.DB.Sqlite.Migration.Old
+    ( DBField (..)
     )
 import Cardano.Pool.Types
     ( PoolId

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Fixtures.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Fixtures.hs
@@ -32,9 +32,11 @@ import Cardano.DB.Sqlite
     ( ForeignKeysSetting
     , SqliteContext
     , newInMemorySqliteContext
-    , noManualMigration
     , runQuery
     , withSqliteContextFile
+    )
+import Cardano.DB.Sqlite.Migration.Old
+    ( noManualMigration
     )
 import Cardano.Wallet.DB.Sqlite.Schema
     ( Wallet (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -57,8 +57,10 @@ import Cardano.Crypto.Wallet
     ( XPrv
     )
 import Cardano.DB.Sqlite
+    ( DBLog (..)
+    )
+import Cardano.DB.Sqlite.Migration.Old
     ( DBField
-    , DBLog (..)
     , fieldName
     )
 import Cardano.Mnemonic

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -61,6 +61,7 @@ import Cardano.DB.Sqlite
     )
 import Cardano.DB.Sqlite.Migration.Old
     ( DBField
+    , DBMigrationOldLog (..)
     , fieldName
     )
 import Cardano.Mnemonic
@@ -1384,8 +1385,11 @@ testMigrationTxMetaFee dbName expectedLength caseByCase = do
 
 matchMsgManualMigration :: (DBField -> Bool) -> WalletDBLog -> Bool
 matchMsgManualMigration p = \case
-    MsgDB (MsgManualMigrationNeeded field _) -> p field
-    MsgDB (MsgExpectedMigration (MsgManualMigrationNeeded field _)) -> p field
+    MsgDB (MsgMigrationOld (MsgManualMigrationNeeded field _)) -> p field
+    MsgDB
+        ( MsgMigrationOld
+            (MsgExpectedMigration (MsgManualMigrationNeeded field _))
+        ) -> p field
     _ -> False
 
 testMigrationCleanupCheckpoints


### PR DESCRIPTION
In preparation for the improvement of the database initialization logic, this pull request refactors the `Cardano.Wallet.DB.Sqlite` module.

- [x] split off a module `Cardano.DB.Sqlite.ForeignKeys`
- [x] split off a module `Cardano.DB.Sqlite.Migration.Old`
- [x] move `handleConstraint` to its only usage site
- [x] Restructure the logging type for the old manual migrations 
- [x] Change `newInMemorySqliteContext` to use `run*Migration`
- [x] Split `destroyDBHandle` into retrying and non-retrying close

### Issue number

ADP-3214