### PR TITLE
Use `Tx era` instead of `SealedTx` in `ErrBalanceTxInternalError`

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -40,6 +40,7 @@ module Internal.Cardano.Write.Tx
     , LatestLedgerEra
     , LatestEra
     , withConstraints
+    , RecentEraConstraints
     , RecentEraLedgerConstraints
 
     -- ** Key witness counts

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -89,6 +89,7 @@ module Internal.Cardano.Write.Tx
     , outputs
     , modifyLedgerBody
     , emptyTx
+    , serializeTx
 
     -- * TxId
     , Ledger.TxId
@@ -345,6 +346,8 @@ type RecentEraLedgerConstraints era =
     , Eq (TxOut era)
     , Ledger.Crypto (Core.EraCrypto era)
     , Show (TxOut era)
+    , Show (Core.Tx era)
+    , Eq (Core.Tx era)
     , Babbage.BabbageEraTxBody era
     , Shelley.EraUTxO era
     )
@@ -758,6 +761,12 @@ utxoFromTxOutsInRecentEra era = withConstraints era $
 --------------------------------------------------------------------------------
 -- Tx
 --------------------------------------------------------------------------------
+
+serializeTx
+    :: forall era. IsRecentEra era
+    => Core.Tx (CardanoApi.ShelleyLedgerEra era)
+    -> ByteString
+serializeTx tx = CardanoApi.serialiseToCBOR $ toCardanoApiTx @era tx
 
 txBody
     :: RecentEra era

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -220,6 +220,7 @@ import Internal.Cardano.Write.Tx
     , PParams
     , PolicyId
     , RecentEra (..)
+    , RecentEraConstraints
     , RecentEraLedgerConstraints
     , ShelleyLedgerEra
     , Tx
@@ -419,7 +420,7 @@ data ErrBalanceTxAssetsInsufficientError = ErrBalanceTxAssetsInsufficientError
     deriving (Eq, Generic, Show)
 
 data ErrBalanceTxInternalError era
-    = (RecentEraLedgerConstraints (ShelleyLedgerEra era), IsRecentEra era) =>
+    = RecentEraConstraints era =>
         ErrUnderestimatedFee Coin (Tx (ShelleyLedgerEra era)) KeyWitnessCount
     | ErrFailedBalancing Value
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -424,8 +424,8 @@ data ErrBalanceTxInternalError era
         ErrUnderestimatedFee Coin (Tx (ShelleyLedgerEra era)) KeyWitnessCount
     | ErrFailedBalancing Value
 
-deriving instance Show (ErrBalanceTxInternalError era)
 deriving instance Eq (ErrBalanceTxInternalError era)
+deriving instance Show (ErrBalanceTxInternalError era)
 
 -- | Errors that can occur when balancing transactions.
 data ErrBalanceTx era

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -107,9 +107,6 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( Flat (..)
     )
-import Cardano.Wallet.Primitive.Types.Tx.SealedTx
-    ( serialisedTx
-    )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( Convert (toWallet)
     , toWalletAddress
@@ -612,7 +609,7 @@ instance Write.IsRecentEra era => IsServerError (ErrBalanceTx era) where
                 , "or sending a smaller amount."
                 ]
 
-instance IsServerError ErrBalanceTxInternalError where
+instance forall era. IsServerError (ErrBalanceTxInternalError era) where
     toServerError = \case
         ErrUnderestimatedFee coin candidateTx (KeyWitnessCount nWits nBootWits) ->
             apiError err500 (BalanceTxUnderestimatedFee info) $ T.unwords
@@ -623,7 +620,7 @@ instance IsServerError ErrBalanceTxInternalError where
           where
             info = ApiErrorBalanceTxUnderestimatedFee
                 { underestimation = Coin.toQuantity $ toWalletCoin coin
-                , candidateTxHex = hexText $ serialisedTx candidateTx
+                , candidateTxHex = hexText $ Write.serializeTx @era candidateTx
                 , candidateTxReadable = T.pack (show candidateTx)
                 , estimatedNumberOfKeyWits = intCast nWits
                 , estimatedNumberOfBootstrapKeyWits = intCast nBootWits

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -262,7 +262,6 @@ instance IsServerError WalletException where
         ExceptionSignPayment e -> toServerError e
         ExceptionBalanceTx e -> toServerError e
         ExceptionWriteTxEra e -> toServerError e
-        ExceptionBalanceTxInternalError e -> toServerError e
         ExceptionSubmitTransaction e -> toServerError e
         ExceptionConstructTx e -> toServerError e
         ExceptionGetPolicyId e -> toServerError e

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -3641,7 +3641,6 @@ data WalletException
     | ExceptionSignPayment ErrSignPayment
     | forall era. Write.IsRecentEra era => ExceptionBalanceTx (ErrBalanceTx era)
     | ExceptionWriteTxEra ErrWriteTxEra
-    | ExceptionBalanceTxInternalError ErrBalanceTxInternalError
     | ExceptionSubmitTransaction ErrSubmitTransaction
     | ExceptionConstructTx ErrConstructTx
     | ExceptionGetPolicyId ErrGetPolicyId

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -588,7 +588,6 @@ import Cardano.Wallet.Transaction.Built
     )
 import Cardano.Write.Tx
     ( ErrBalanceTx (..)
-    , ErrBalanceTxInternalError (..)
     , ErrBalanceTxUnableToCreateChangeError (..)
     , balanceTransaction
     )

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1457,7 +1457,7 @@ prop_balanceTransactionValid
                 let counterexampleText = unlines
                         [ "underestimated fee by "
                             <> pretty (Convert.toWalletCoin delta)
-                        , "candidate tx: " <> pretty candidateTx
+                        , "candidate tx: " <> show (Pretty candidateTx)
                         , "assuming key witness count: " <> show nWits
                         ]
                 in


### PR DESCRIPTION
- Drop unused `ExceptionBalanceTxInternalError`
- Use `Tx era` instead of `SealedTx` in `ErrBalanceTxInternalError`

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2353
