### PR TITLE
Use consistent import qualifiers in `cardano-balance-tx`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -210,9 +210,6 @@ import Cardano.Ledger.Val
     ( coin
     , modifyCoin
     )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( txOutMaxCoin
-    )
 import Control.Arrow
     ( second
     , (>>>)
@@ -282,6 +279,7 @@ import qualified Cardano.Ledger.Keys as Ledger
 import qualified Cardano.Ledger.Shelley.API.Wallet as Shelley
 import qualified Cardano.Ledger.Shelley.UTxO as Shelley
 import qualified Cardano.Ledger.TxIn as Ledger
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Data.Map as Map
 
@@ -712,7 +710,7 @@ computeMinimumCoinForTxOut era pp out = withConstraints era $
         :: TxOut (CardanoApi.ShelleyLedgerEra era)
         -> TxOut (CardanoApi.ShelleyLedgerEra era)
     withMaxLengthSerializedCoin =
-        modifyTxOutCoin era (const $ Convert.toLedger txOutMaxCoin)
+        modifyTxOutCoin era (const $ Convert.toLedger W.txOutMaxCoin)
 
 isBelowMinimumCoinForTxOut
     :: forall era. RecentEra era

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -117,10 +117,6 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.UTxO
     ( txinLookup
     )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( SealedTx
-    , sealedTxFromCardano
-    )
 import Control.Arrow
     ( left
     )
@@ -319,6 +315,10 @@ import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
     ( TokenQuantity (..)
     )
+import qualified Cardano.Wallet.Primitive.Types.Tx as W
+    ( SealedTx
+    , sealedTxFromCardano
+    )
 import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
     ( TxSize (..)
     , txOutMaxCoin
@@ -422,7 +422,7 @@ data ErrBalanceTxAssetsInsufficientError = ErrBalanceTxAssetsInsufficientError
     deriving (Eq, Generic, Show)
 
 data ErrBalanceTxInternalError
-    = ErrUnderestimatedFee Coin SealedTx KeyWitnessCount
+    = ErrUnderestimatedFee Coin W.SealedTx KeyWitnessCount
     | ErrFailedBalancing Value
     deriving (Show, Eq)
 
@@ -828,8 +828,8 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 
     partialLedgerTx = fromCardanoApiTx partialTx
 
-    toSealed :: Tx (CardanoApi.ShelleyLedgerEra era) -> SealedTx
-    toSealed = sealedTxFromCardano
+    toSealed :: Tx (CardanoApi.ShelleyLedgerEra era) -> W.SealedTx
+    toSealed = W.sealedTxFromCardano
         . CardanoApi.InAnyCardanoEra CardanoApi.cardanoEra
         . toCardanoApiTx @era
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -121,11 +121,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx
     , sealedTxFromCardano
     )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TxSize (..)
-    , txOutMaxCoin
-    , txOutMaxTokenQuantity
-    )
 import Control.Arrow
     ( left
     )
@@ -323,6 +318,11 @@ import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
     )
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
     ( TokenQuantity (..)
+    )
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+    ( TxSize (..)
+    , txOutMaxCoin
+    , txOutMaxTokenQuantity
     )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
     ( TxIn
@@ -881,7 +881,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         -> ExceptT (ErrBalanceTx era) m (Tx (CardanoApi.ShelleyLedgerEra era))
     guardTxSize witCount tx =
         withConstraints era $ do
-            let maxSize = TxSize (pp ^. ppMaxTxSizeL)
+            let maxSize = W.TxSize (pp ^. ppMaxTxSizeL)
             when (estimateSignedTxSize era pp witCount tx > maxSize) $
                 throwE ErrBalanceTxMaxSizeLimitExceeded
             pure tx
@@ -1064,7 +1064,7 @@ selectAssets era (ProtocolParameters pp) utxoAssumptions outs redeemers
             computeMinimumCoinForTxOut
                 era
                 pp
-                (mkLedgerTxOut era addr (W.TokenBundle txOutMaxCoin tokens))
+                (mkLedgerTxOut era addr (W.TokenBundle W.txOutMaxCoin tokens))
         , isBelowMinimumAdaQuantity = \addr bundle ->
             isBelowMinimumCoinForTxOut
                 era
@@ -1389,7 +1389,7 @@ costOfIncreasingCoin
 costOfIncreasingCoin (FeePerByte perByte) from delta =
     costOfCoin (from <> delta) <\> costOfCoin from
   where
-    costOfCoin = W.Coin . (perByte *) . unTxSize . sizeOfCoin
+    costOfCoin = W.Coin . (perByte *) . W.unTxSize . sizeOfCoin
 
 -- The maximum cost increase 'costOfIncreasingCoin' can return, which is the
 -- cost of 8 bytes.
@@ -1397,13 +1397,13 @@ maximumCostOfIncreasingCoin :: FeePerByte -> W.Coin
 maximumCostOfIncreasingCoin (FeePerByte perByte) = W.Coin $ 8 * perByte
 
 -- | Calculate the size of a coin when encoded as CBOR.
-sizeOfCoin :: W.Coin -> TxSize
+sizeOfCoin :: W.Coin -> W.TxSize
 sizeOfCoin (W.Coin c)
-    | c >= 4_294_967_296 = TxSize 9 -- c >= 2^32
-    | c >=        65_536 = TxSize 5 -- c >= 2^16
-    | c >=           256 = TxSize 3 -- c >= 2^ 8
-    | c >=            24 = TxSize 2
-    | otherwise          = TxSize 1
+    | c >= 4_294_967_296 = W.TxSize 9 -- c >= 2^32
+    | c >=        65_536 = W.TxSize 5 -- c >= 2^16
+    | c >=           256 = W.TxSize 3 -- c >= 2^ 8
+    | c >=            24 = W.TxSize 2
+    | otherwise          = W.TxSize 1
 
 -- | Distributes a surplus transaction balance between the given change
 -- outputs and the given fee. This function is aware of the fact that
@@ -1726,7 +1726,7 @@ validateTxOutputTokenQuantities out =
     , quantity > quantityMaxBound
     ]
   where
-    quantityMaxBound = W.unTokenQuantity txOutMaxTokenQuantity
+    quantityMaxBound = W.unTokenQuantity W.txOutMaxTokenQuantity
 
 -- | Validates the ada quantity associated with a transaction output.
 --

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -85,9 +85,6 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin
     , txOutMaxTokenQuantity
     )
-import Cardano.Wallet.Primitive.Types.UTxO
-    ( UTxO (..)
-    )
 import Control.Arrow
     ( (&&&)
     )
@@ -149,6 +146,9 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (..)
     )
+import qualified Cardano.Wallet.Primitive.Types.UTxO as W
+    ( UTxO (..)
+    )
 import qualified Data.Map.Strict as Map
 
 --------------------------------------------------------------------------------
@@ -186,14 +186,14 @@ instance Buildable (WalletUTxO, W.TokenBundle) where
 toExternalUTxO :: (WalletUTxO, W.TokenBundle) -> (W.TxIn, W.TxOut)
 toExternalUTxO = toExternalUTxO' id
 
-toExternalUTxOMap :: Map WalletUTxO W.TokenBundle -> UTxO
-toExternalUTxOMap = UTxO . Map.fromList . fmap toExternalUTxO . Map.toList
+toExternalUTxOMap :: Map WalletUTxO W.TokenBundle -> W.UTxO
+toExternalUTxOMap = W.UTxO . Map.fromList . fmap toExternalUTxO . Map.toList
 
 toInternalUTxO :: (W.TxIn, W.TxOut) -> (WalletUTxO, W.TokenBundle)
 toInternalUTxO = toInternalUTxO' id
 
-toInternalUTxOMap :: UTxO -> Map WalletUTxO W.TokenBundle
-toInternalUTxOMap = Map.fromList . fmap toInternalUTxO . Map.toList . unUTxO
+toInternalUTxOMap :: W.UTxO -> Map WalletUTxO W.TokenBundle
+toInternalUTxOMap = Map.fromList . fmap toInternalUTxO . Map.toList . W.unUTxO
 
 toExternalUTxO' :: (b -> W.TokenBundle) -> (WalletUTxO, b) -> (W.TxIn, W.TxOut)
 toExternalUTxO' f (WalletUTxO i a, b) = (i, W.TxOut a (f b))

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -81,9 +81,6 @@ import Cardano.CoinSelection.UTxOSelection
 import Cardano.Wallet.Primitive.Collateral
     ( asCollateral
     )
-import Cardano.Wallet.Primitive.Types.Address
-    ( Address (..)
-    )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin
     , txOutMaxTokenQuantity
@@ -138,6 +135,9 @@ import Prelude
 
 import qualified Cardano.CoinSelection as Internal
 import qualified Cardano.CoinSelection.Context as SC
+import qualified Cardano.Wallet.Primitive.Types.Address as W
+    ( Address (..)
+    )
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin
     )
@@ -160,7 +160,7 @@ import qualified Data.Map.Strict as Map
 data WalletSelectionContext
 
 instance SC.SelectionContext WalletSelectionContext where
-    type Address WalletSelectionContext = Address
+    type Address WalletSelectionContext = W.Address
     type UTxO WalletSelectionContext = WalletUTxO
 
 --------------------------------------------------------------------------------
@@ -173,7 +173,7 @@ data WalletUTxO = WalletUTxO
     { txIn
         :: !TxIn
     , address
-        :: !Address
+        :: !W.Address
     }
     deriving (Eq, Generic, Ord, Show)
 
@@ -222,10 +222,10 @@ data SelectionConstraints = SelectionConstraints
         -- ^ Assesses the size of a token bundle relative to the upper limit of
         -- what can be included in a transaction output.
     , computeMinimumAdaQuantity
-        :: Address -> W.TokenMap -> W.Coin
+        :: W.Address -> W.TokenMap -> W.Coin
         -- ^ Computes the minimum ada quantity required for a given output.
     , isBelowMinimumAdaQuantity
-        :: Address -> W.TokenBundle -> Bool
+        :: W.Address -> W.TokenBundle -> Bool
       -- ^ Returns 'True' if the given 'TokenBundle' has a 'Coin' value that is
       -- below the minimum required.
     , computeMinimumCost
@@ -240,7 +240,7 @@ data SelectionConstraints = SelectionConstraints
         -- ^ Specifies the minimum required amount of collateral as a
         -- percentage of the total transaction fee.
     , maximumLengthChangeAddress
-        :: Address
+        :: W.Address
     }
     deriving Generic
 
@@ -256,7 +256,7 @@ toInternalSelectionConstraints SelectionConstraints {..} =
         , maximumOutputTokenQuantity =
             txOutMaxTokenQuantity
         , nullAddress =
-            Address ""
+            W.Address ""
         , ..
         }
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -89,7 +89,6 @@ import Cardano.Wallet.Primitive.Types.Coin
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId
-    , TokenMap
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin
@@ -148,6 +147,9 @@ import qualified Cardano.CoinSelection.Context as SC
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle (..)
+    )
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
+    ( TokenMap
     )
 import qualified Data.Map.Strict as Map
 
@@ -222,7 +224,7 @@ data SelectionConstraints = SelectionConstraints
         -- ^ Assesses the size of a token bundle relative to the upper limit of
         -- what can be included in a transaction output.
     , computeMinimumAdaQuantity
-        :: Address -> TokenMap -> Coin
+        :: Address -> W.TokenMap -> Coin
         -- ^ Computes the minimum ada quantity required for a given output.
     , isBelowMinimumAdaQuantity
         :: Address -> W.TokenBundle -> Bool
@@ -380,10 +382,10 @@ data SelectionOf change = Selection
         :: ![change]
         -- ^ Generated change outputs.
     , assetsToMint
-        :: !TokenMap
+        :: !W.TokenMap
         -- ^ Assets to mint.
     , assetsToBurn
-        :: !TokenMap
+        :: !W.TokenMap
         -- ^ Assets to burn.
     , extraCoinSource
         :: !Coin

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -84,9 +84,6 @@ import Cardano.Wallet.Primitive.Collateral
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     )
-import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..)
-    )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin
     , txOutMaxTokenQuantity
@@ -141,6 +138,9 @@ import Prelude
 
 import qualified Cardano.CoinSelection as Internal
 import qualified Cardano.CoinSelection.Context as SC
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+    ( Coin
+    )
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle (..)
@@ -222,14 +222,14 @@ data SelectionConstraints = SelectionConstraints
         -- ^ Assesses the size of a token bundle relative to the upper limit of
         -- what can be included in a transaction output.
     , computeMinimumAdaQuantity
-        :: Address -> W.TokenMap -> Coin
+        :: Address -> W.TokenMap -> W.Coin
         -- ^ Computes the minimum ada quantity required for a given output.
     , isBelowMinimumAdaQuantity
         :: Address -> W.TokenBundle -> Bool
       -- ^ Returns 'True' if the given 'TokenBundle' has a 'Coin' value that is
       -- below the minimum required.
     , computeMinimumCost
-        :: SelectionSkeleton -> Coin
+        :: SelectionSkeleton -> W.Coin
         -- ^ Computes the minimum cost of a given selection skeleton.
     , maximumCollateralInputCount
         :: Int
@@ -314,7 +314,7 @@ toInternalSelectionParams SelectionParams {..} =
     W.TokenBundle extraCoinIn  assetsToMint = extraValueIn
     W.TokenBundle extraCoinOut assetsToBurn = extraValueOut
 
-    identifyCollateral :: WalletUTxO -> W.TokenBundle -> Maybe Coin
+    identifyCollateral :: WalletUTxO -> W.TokenBundle -> Maybe W.Coin
     identifyCollateral (WalletUTxO _ a) b = asCollateral (TxOut a b)
 
 --------------------------------------------------------------------------------
@@ -386,10 +386,10 @@ data SelectionOf change = Selection
         :: !W.TokenMap
         -- ^ Assets to burn.
     , extraCoinSource
-        :: !Coin
+        :: !W.Coin
         -- ^ An extra source of ada.
     , extraCoinSink
-        :: !Coin
+        :: !W.Coin
         -- ^ An extra sink for ada.
     }
     deriving (Generic, Eq, Show)

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -81,10 +81,6 @@ import Cardano.CoinSelection.UTxOSelection
 import Cardano.Wallet.Primitive.Collateral
     ( asCollateral
     )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( txOutMaxCoin
-    , txOutMaxTokenQuantity
-    )
 import Control.Arrow
     ( (&&&)
     )
@@ -139,6 +135,10 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
     ( AssetId
     , TokenMap
+    )
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+    ( txOutMaxCoin
+    , txOutMaxTokenQuantity
     )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
     ( TxIn (..)
@@ -252,9 +252,9 @@ toInternalSelectionConstraints SelectionConstraints {..} =
         { computeMinimumCost =
             computeMinimumCost . toExternalSelectionSkeleton
         , maximumOutputAdaQuantity =
-            txOutMaxCoin
+            W.txOutMaxCoin
         , maximumOutputTokenQuantity =
-            txOutMaxTokenQuantity
+            W.txOutMaxTokenQuantity
         , nullAddress =
             W.Address ""
         , ..

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -87,9 +87,6 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId
-    )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin
     , txOutMaxTokenQuantity
@@ -149,7 +146,8 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle (..)
     )
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
-    ( TokenMap
+    ( AssetId
+    , TokenMap
     )
 import qualified Data.Map.Strict as Map
 
@@ -339,7 +337,7 @@ data SelectionSkeleton = SelectionSkeleton
     , skeletonOutputs
         :: ![TxOut]
     , skeletonChange
-        :: ![Set AssetId]
+        :: ![Set W.AssetId]
     }
     deriving (Eq, Generic, Show)
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -85,9 +85,6 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin
     , txOutMaxTokenQuantity
     )
-import Cardano.Wallet.Primitive.Types.Tx.TxIn
-    ( TxIn
-    )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
     )
@@ -149,6 +146,9 @@ import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
     ( AssetId
     , TokenMap
     )
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
+    ( TxIn (..)
+    )
 import qualified Data.Map.Strict as Map
 
 --------------------------------------------------------------------------------
@@ -171,7 +171,7 @@ instance SC.SelectionContext WalletSelectionContext where
 --
 data WalletUTxO = WalletUTxO
     { txIn
-        :: !TxIn
+        :: !W.TxIn
     , address
         :: !W.Address
     }
@@ -183,22 +183,22 @@ instance Buildable WalletUTxO where
 instance Buildable (WalletUTxO, W.TokenBundle) where
     build (u, b) = build u <> ":" <> build (W.TokenBundle.Flat b)
 
-toExternalUTxO :: (WalletUTxO, W.TokenBundle) -> (TxIn, TxOut)
+toExternalUTxO :: (WalletUTxO, W.TokenBundle) -> (W.TxIn, TxOut)
 toExternalUTxO = toExternalUTxO' id
 
 toExternalUTxOMap :: Map WalletUTxO W.TokenBundle -> UTxO
 toExternalUTxOMap = UTxO . Map.fromList . fmap toExternalUTxO . Map.toList
 
-toInternalUTxO :: (TxIn, TxOut) -> (WalletUTxO, W.TokenBundle)
+toInternalUTxO :: (W.TxIn, TxOut) -> (WalletUTxO, W.TokenBundle)
 toInternalUTxO = toInternalUTxO' id
 
 toInternalUTxOMap :: UTxO -> Map WalletUTxO W.TokenBundle
 toInternalUTxOMap = Map.fromList . fmap toInternalUTxO . Map.toList . unUTxO
 
-toExternalUTxO' :: (b -> W.TokenBundle) -> (WalletUTxO, b) -> (TxIn, TxOut)
+toExternalUTxO' :: (b -> W.TokenBundle) -> (WalletUTxO, b) -> (W.TxIn, TxOut)
 toExternalUTxO' f (WalletUTxO i a, b) = (i, TxOut a (f b))
 
-toInternalUTxO' :: (W.TokenBundle -> b) -> (TxIn, TxOut) -> (WalletUTxO, b)
+toInternalUTxO' :: (W.TokenBundle -> b) -> (W.TxIn, TxOut) -> (WalletUTxO, b)
 toInternalUTxO' f (i, TxOut a b) = (WalletUTxO i a, f b)
 
 --------------------------------------------------------------------------------
@@ -368,10 +368,10 @@ toExternalSelectionSkeleton Internal.SelectionSkeleton {..} =
 --
 data SelectionOf change = Selection
     { inputs
-        :: !(NonEmpty (TxIn, TxOut))
+        :: !(NonEmpty (W.TxIn, TxOut))
         -- ^ Selected inputs.
     , collateral
-        :: ![(TxIn, TxOut)]
+        :: ![(W.TxIn, TxOut)]
         -- ^ Selected collateral inputs.
     , outputs
         :: ![TxOut]

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection/Gen.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection/Gen.hs
@@ -9,11 +9,6 @@ module Internal.Cardano.Write.Tx.Balance.CoinSelection.Gen
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
-    ( genTxIn
-    , genTxInLargeRange
-    , shrinkTxIn
-    )
 import Generics.SOP
     ( NP (..)
     )
@@ -33,6 +28,7 @@ import Test.QuickCheck.Extra
     )
 
 import qualified Cardano.Wallet.Primitive.Types.Address.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen as W
 
 --------------------------------------------------------------------------------
 -- Wallet UTxO identifiers chosen according to the size parameter
@@ -42,11 +38,11 @@ coarbitraryWalletUTxO :: WalletUTxO -> Gen a -> Gen a
 coarbitraryWalletUTxO = coarbitrary . show
 
 genWalletUTxO :: Gen WalletUTxO
-genWalletUTxO = uncurry WalletUTxO <$> genSized2 genTxIn W.genAddress
+genWalletUTxO = uncurry WalletUTxO <$> genSized2 W.genTxIn W.genAddress
 
 shrinkWalletUTxO :: WalletUTxO -> [WalletUTxO]
 shrinkWalletUTxO = genericRoundRobinShrink
-    <@> shrinkTxIn
+    <@> W.shrinkTxIn
     <:> W.shrinkAddress
     <:> Nil
 
@@ -58,4 +54,4 @@ genWalletUTxOFunction = genFunction coarbitraryWalletUTxO
 --------------------------------------------------------------------------------
 
 genWalletUTxOLargeRange :: Gen WalletUTxO
-genWalletUTxOLargeRange = WalletUTxO <$> genTxInLargeRange <*> W.genAddress
+genWalletUTxOLargeRange = WalletUTxO <$> W.genTxInLargeRange <*> W.genAddress

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection/Gen.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection/Gen.hs
@@ -9,10 +9,6 @@ module Internal.Cardano.Write.Tx.Balance.CoinSelection.Gen
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.Address.Gen
-    ( genAddress
-    , shrinkAddress
-    )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxIn
     , genTxInLargeRange
@@ -36,6 +32,8 @@ import Test.QuickCheck.Extra
     , (<@>)
     )
 
+import qualified Cardano.Wallet.Primitive.Types.Address.Gen as W
+
 --------------------------------------------------------------------------------
 -- Wallet UTxO identifiers chosen according to the size parameter
 --------------------------------------------------------------------------------
@@ -44,12 +42,12 @@ coarbitraryWalletUTxO :: WalletUTxO -> Gen a -> Gen a
 coarbitraryWalletUTxO = coarbitrary . show
 
 genWalletUTxO :: Gen WalletUTxO
-genWalletUTxO = uncurry WalletUTxO <$> genSized2 genTxIn genAddress
+genWalletUTxO = uncurry WalletUTxO <$> genSized2 genTxIn W.genAddress
 
 shrinkWalletUTxO :: WalletUTxO -> [WalletUTxO]
 shrinkWalletUTxO = genericRoundRobinShrink
     <@> shrinkTxIn
-    <:> shrinkAddress
+    <:> W.shrinkAddress
     <:> Nil
 
 genWalletUTxOFunction :: Gen a -> Gen (WalletUTxO -> a)
@@ -60,4 +58,4 @@ genWalletUTxOFunction = genFunction coarbitraryWalletUTxO
 --------------------------------------------------------------------------------
 
 genWalletUTxOLargeRange :: Gen WalletUTxO
-genWalletUTxOLargeRange = WalletUTxO <$> genTxInLargeRange <*> genAddress
+genWalletUTxOLargeRange = WalletUTxO <$> genTxInLargeRange <*> W.genAddress

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/TokenBundleSize.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/TokenBundleSize.hs
@@ -34,12 +34,12 @@ import Data.IntCast
 import Internal.Cardano.Write.Tx
     ( PParams
     , RecentEra
-    , ShelleyLedgerEra
     , Value
     , Version
     , withConstraints
     )
 
+import qualified Cardano.Api.Shelley as CardanoApi
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Data.ByteString.Lazy as BL
@@ -51,7 +51,7 @@ import qualified Data.ByteString.Lazy as BL
 --
 mkTokenBundleSizeAssessor
     :: RecentEra era
-    -> PParams (ShelleyLedgerEra era)
+    -> PParams (CardanoApi.ShelleyLedgerEra era)
     -> TokenBundleSizeAssessor
 mkTokenBundleSizeAssessor era pp = TokenBundleSizeAssessor $ \tb ->
     if computeTokenBundleSerializedLengthBytes tb ver > maxValSize

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/TokenBundleSize.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/TokenBundleSize.hs
@@ -22,9 +22,6 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary
     ( serialize
     )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TxSize (..)
-    )
 import Control.Lens
     ( (^.)
     )
@@ -43,6 +40,9 @@ import qualified Cardano.Api.Shelley as CardanoApi
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle
     )
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+    ( TxSize (..)
+    )
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Data.ByteString.Lazy as BL
 
@@ -60,8 +60,8 @@ mkTokenBundleSizeAssessor era pp = TokenBundleSizeAssessor $ \tb ->
     then TokenBundleSizeExceedsLimit
     else TokenBundleSizeWithinLimit
   where
-    maxValSize :: TxSize
-    maxValSize = TxSize $ withConstraints era $ pp ^. ppMaxValSizeL
+    maxValSize :: W.TxSize
+    maxValSize = W.TxSize $ withConstraints era $ pp ^. ppMaxValSizeL
 
     ver :: Version
     ver = withConstraints era $ pvMajor $ pp ^. ppProtocolVersionL
@@ -69,11 +69,11 @@ mkTokenBundleSizeAssessor era pp = TokenBundleSizeAssessor $ \tb ->
 computeTokenBundleSerializedLengthBytes
     :: W.TokenBundle
     -> Version
-    -> TxSize
+    -> W.TxSize
 computeTokenBundleSerializedLengthBytes tb ver = serSize (Convert.toLedger tb)
   where
-    serSize :: Value -> TxSize
-    serSize v = maybe err TxSize
+    serSize :: Value -> W.TxSize
+    serSize v = maybe err W.TxSize
         . intCastMaybe
         . BL.length
         $ serialize ver v

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/TokenBundleSize.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/TokenBundleSize.hs
@@ -40,7 +40,9 @@ import Internal.Cardano.Write.Tx
     )
 
 import qualified Cardano.Api.Shelley as CardanoApi
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
+    ( TokenBundle
+    )
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Data.ByteString.Lazy as BL
 
@@ -65,7 +67,7 @@ mkTokenBundleSizeAssessor era pp = TokenBundleSizeAssessor $ \tb ->
     ver = withConstraints era $ pvMajor $ pp ^. ppProtocolVersionL
 
 computeTokenBundleSerializedLengthBytes
-    :: TokenBundle.TokenBundle
+    :: W.TokenBundle
     -> Version
     -> TxSize
 computeTokenBundleSerializedLengthBytes tb ver = serSize (Convert.toLedger tb)

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
@@ -102,7 +102,6 @@ import Internal.Cardano.Write.Tx
     ( PParams
     , RecentEra
     , RecentEraLedgerConstraints
-    , ShelleyLedgerEra
     , StandardCrypto
     , UTxO
     , txBody
@@ -144,12 +143,12 @@ data ErrAssignRedeemers
 
 assignScriptRedeemers
     :: forall era. RecentEra era
-    -> PParams (ShelleyLedgerEra era)
+    -> PParams (CardanoApi.ShelleyLedgerEra era)
     -> TimeTranslation
-    -> UTxO (ShelleyLedgerEra era)
+    -> UTxO (CardanoApi.ShelleyLedgerEra era)
     -> [Redeemer]
-    -> Tx (ShelleyLedgerEra era)
-    -> Either ErrAssignRedeemers (Tx (ShelleyLedgerEra era))
+    -> Tx (CardanoApi.ShelleyLedgerEra era)
+    -> Either ErrAssignRedeemers (Tx (CardanoApi.ShelleyLedgerEra era))
 assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
     withConstraints era $ do
         flip execStateT tx $ do
@@ -170,11 +169,11 @@ assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
     -- Redeemers are determined from the context given to the caller via the
     -- 'Redeemer' type which is mapped to an 'Alonzo.ScriptPurpose'.
     assignNullRedeemers
-        :: RecentEraLedgerConstraints (ShelleyLedgerEra era)
-        => Tx (ShelleyLedgerEra era)
+        :: RecentEraLedgerConstraints (CardanoApi.ShelleyLedgerEra era)
+        => Tx (CardanoApi.ShelleyLedgerEra era)
         -> Either ErrAssignRedeemers
             ( Map Alonzo.RdmrPtr Redeemer
-            , Tx (ShelleyLedgerEra era)
+            , Tx (CardanoApi.ShelleyLedgerEra era)
             )
     assignNullRedeemers ledgerTx = do
         (indexedRedeemers, nullRedeemers) <-
@@ -203,7 +202,7 @@ assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
     -- | Evaluate execution units of each script/redeemer in the transaction.
     -- This may fail for each script.
     evaluateExecutionUnits
-        :: RecentEraLedgerConstraints (ShelleyLedgerEra era)
+        :: RecentEraLedgerConstraints (CardanoApi.ShelleyLedgerEra era)
         => Map Alonzo.RdmrPtr Redeemer
         -> Tx (CardanoApi.ShelleyLedgerEra era)
         -> Either ErrAssignRedeemers
@@ -226,10 +225,10 @@ assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
     -- | Change execution units for each redeemers in the transaction to what
     -- they ought to be.
     assignExecutionUnits
-        :: RecentEraLedgerConstraints (ShelleyLedgerEra era)
+        :: RecentEraLedgerConstraints (CardanoApi.ShelleyLedgerEra era)
         => Map Alonzo.RdmrPtr (Either ErrAssignRedeemers Alonzo.ExUnits)
-        -> Tx (ShelleyLedgerEra era)
-        -> Either ErrAssignRedeemers (Tx (ShelleyLedgerEra era))
+        -> Tx (CardanoApi.ShelleyLedgerEra era)
+        -> Either ErrAssignRedeemers (Tx (CardanoApi.ShelleyLedgerEra era))
     assignExecutionUnits exUnits ledgerTx = do
         let Alonzo.Redeemers rdmrs = view (witsTxL . rdmrsTxWitsL) ledgerTx
 
@@ -252,9 +251,9 @@ assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
     -- | Finally, calculate and add the script integrity hash with the new
     -- final redeemers, if any.
     addScriptIntegrityHash
-        :: RecentEraLedgerConstraints (ShelleyLedgerEra era)
-        => Tx (ShelleyLedgerEra era)
-        -> Tx (ShelleyLedgerEra era)
+        :: RecentEraLedgerConstraints (CardanoApi.ShelleyLedgerEra era)
+        => Tx (CardanoApi.ShelleyLedgerEra era)
+        -> Tx (CardanoApi.ShelleyLedgerEra era)
     addScriptIntegrityHash ledgerTx =
         ledgerTx & (bodyTxL . scriptIntegrityHashTxBodyL) .~
             Alonzo.hashScriptIntegrity
@@ -266,7 +265,9 @@ assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
         langs =
             [ l
             | (_hash, script) <- Map.toList (Alonzo.txscripts wits)
-            , (not . Ledger.isNativeScript @(ShelleyLedgerEra era)) script
+            , ( not
+              . Ledger.isNativeScript @(CardanoApi.ShelleyLedgerEra era)
+              ) script
             , Just l <- [Alonzo.language script]
             ]
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
@@ -46,9 +46,6 @@ import Cardano.Slotting.EpochInfo
     ( EpochInfo
     , hoistEpochInfo
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( TokenPolicyId
-    )
 import Codec.Serialise
     ( deserialiseOrFail
     )
@@ -278,7 +275,7 @@ assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
 
 data Redeemer
     = RedeemerSpending ByteString W.TxIn
-    | RedeemerMinting ByteString TokenPolicyId
+    | RedeemerMinting ByteString W.TokenPolicyId
     | RedeemerRewarding ByteString CardanoApi.StakeAddress
     deriving (Eq, Generic, Show)
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -41,9 +41,6 @@ import Cardano.Ledger.Credential
 import Cardano.Ledger.UTxO
     ( txinLookup
     )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TxSize (..)
-    )
 import Control.Lens
     ( view
     , (&)
@@ -79,6 +76,9 @@ import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..)
     )
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+    ( TxSize (..)
+    )
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Data.Foldable as F
 import qualified Data.List as L
@@ -94,7 +94,7 @@ estimateSignedTxSize
     -> KeyWitnessCount
     -> Tx (CardanoApi.ShelleyLedgerEra era)
     -- ^ existing wits in tx are ignored
-    -> TxSize
+    -> W.TxSize
 estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
     let
         -- Hack which allows us to rely on the ledger to calculate the size of
@@ -102,10 +102,10 @@ estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
         feeOfWits :: W.Coin
         feeOfWits = minfee nWits <\> minfee mempty
 
-        sizeOfWits :: TxSize
+        sizeOfWits :: W.TxSize
         sizeOfWits =
             case feeOfWits `coinQuotRem` feePerByte of
-                (n, 0) -> TxSize n
+                (n, 0) -> W.TxSize n
                 (_, _) -> error $ unwords
                     [ "estimateSignedTxSize:"
                     , "the impossible happened!"
@@ -118,9 +118,9 @@ estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
                     , "lovelace/byte"
                     ]
 
-        sizeOfTx :: TxSize
+        sizeOfTx :: W.TxSize
         sizeOfTx = withConstraints era
-            $ fromIntegral @Integer @TxSize
+            $ fromIntegral @Integer @W.TxSize
             $ unsignedTx ^. sizeTxF
     in
         sizeOfTx <> sizeOfWits

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -64,7 +64,6 @@ import Internal.Cardano.Write.Tx
     , KeyWitnessCount (..)
     , PParams
     , RecentEra (..)
-    , ShelleyLedgerEra
     , Tx
     , TxIn
     , UTxO
@@ -91,9 +90,10 @@ import qualified Internal.Cardano.Write.Tx as Write
 -- NOTE: Existing key witnesses in the tx are ignored.
 estimateSignedTxSize
     :: forall era. RecentEra era
-    -> PParams (ShelleyLedgerEra era)
+    -> PParams (CardanoApi.ShelleyLedgerEra era)
     -> KeyWitnessCount
-    -> Tx (ShelleyLedgerEra era) -- ^ existing wits in tx are ignored
+    -> Tx (CardanoApi.ShelleyLedgerEra era)
+    -- ^ existing wits in tx are ignored
     -> TxSize
 estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
     let
@@ -125,7 +125,7 @@ estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
     in
         sizeOfTx <> sizeOfWits
   where
-    unsignedTx :: Tx (ShelleyLedgerEra era)
+    unsignedTx :: Tx (CardanoApi.ShelleyLedgerEra era)
     unsignedTx = withConstraints era $
         txWithWits
             & (witsTxL . addrTxWitsL) .~ mempty
@@ -161,7 +161,7 @@ numberOfShelleyWitnesses n = KeyWitnessCount n 0
 -- we cannot use because it requires a 'TxBodyContent BuildTx era'.
 estimateKeyWitnessCount
     :: forall era. IsRecentEra era
-    => UTxO (ShelleyLedgerEra era)
+    => UTxO (CardanoApi.ShelleyLedgerEra era)
     -- ^ Must contain all inputs from the 'TxBody' or
     -- 'estimateKeyWitnessCount will 'error'.
     -> CardanoApi.TxBody era
@@ -265,7 +265,7 @@ estimateKeyWitnessCount utxo txbody@(CardanoApi.TxBody txbodycontent) =
                 Alonzo.PlutusScript _ _ -> Nothing
 
     hasScriptCred
-        :: UTxO (ShelleyLedgerEra era)
+        :: UTxO (CardanoApi.ShelleyLedgerEra era)
         -> TxIn
         -> Bool
     hasScriptCred u inp = withConstraints (recentEra @era) $
@@ -280,7 +280,7 @@ estimateKeyWitnessCount utxo txbody@(CardanoApi.TxBody txbodycontent) =
                     ]
 
     hasBootstrapAddr
-        :: UTxO (ShelleyLedgerEra era)
+        :: UTxO (CardanoApi.ShelleyLedgerEra era)
         -> TxIn
         -> Bool
     hasBootstrapAddr u inp = withConstraints (recentEra @era) $

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -41,9 +41,6 @@ import Cardano.Ledger.Credential
 import Cardano.Ledger.UTxO
     ( txinLookup
     )
-import qualified Cardano.Wallet.Primitive.Types.Coin as W
-    ( Coin (..)
-    )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxSize (..)
     )
@@ -79,6 +76,9 @@ import qualified Cardano.Api.Byron as CardanoApi
 import qualified Cardano.Api.Shelley as CardanoApi
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+    ( Coin (..)
+    )
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Data.Foldable as F
 import qualified Data.List as L

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -48,9 +48,6 @@ import Prelude
 import Cardano.Address.Script
     ( Script (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( TokenName (..)
-    )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxSize (..)
     )
@@ -87,6 +84,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
     ( AssetId (..)
     )
+import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
@@ -333,7 +331,7 @@ estimateTxSize skeleton =
 
     -- asset_name = bytes .size (0..32)
     sizeOf_AssetName name
-        = 2 + fromIntegral (BS.length $ unTokenName name)
+        = 2 + fromIntegral (BS.length $ W.unTokenName name)
 
     -- Coins can really vary so it's very punishing to always assign them the
     -- upper bound. They will typically be between 3 and 9 bytes (only 6 bytes

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -54,9 +54,6 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
-    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (..)
     )
@@ -87,6 +84,10 @@ import Numeric.Natural
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
+    ( AssetId
+    , TokenMap
+    )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
@@ -110,7 +111,7 @@ data TxSkeleton = TxSkeleton
     { txWitnessTag :: !TxWitnessTag
     , txInputCount :: !Int
     , txOutputs :: ![W.TxOut]
-    , txChange :: ![Set AssetId]
+    , txChange :: ![Set W.AssetId]
     , txPaymentTemplate :: !(Maybe (CA.Script CA.Cosigner))
     }
     deriving (Eq, Show, Generic)

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -86,7 +86,7 @@ import Numeric.Natural
 
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
@@ -271,8 +271,8 @@ estimateTxSize skeleton =
         + sizeOf_Address address
         + sizeOf_SmallUInt
         + sizeOf_SmallArray
-        + sizeOf_Coin (TokenBundle.getCoin tokens)
-        + sumVia sizeOf_NativeAsset (TokenBundle.getAssets tokens)
+        + sizeOf_Coin (W.TokenBundle.getCoin tokens)
+        + sumVia sizeOf_NativeAsset (W.TokenBundle.getAssets tokens)
 
     sizeOf_Output
         = sizeOf_PostAlonzoTransactionOutput

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -48,9 +48,6 @@ import Prelude
 import Cardano.Address.Script
     ( Script (..)
     )
-import Cardano.Wallet.Primitive.Types.Address
-    ( Address (..)
-    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (..)
     )
@@ -79,6 +76,9 @@ import Numeric.Natural
     )
 
 import qualified Cardano.Address.Script as CA
+import qualified Cardano.Wallet.Primitive.Types.Address as W
+    ( Address (..)
+    )
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..)
     )
@@ -301,7 +301,7 @@ estimateTxSize skeleton =
 
     -- We carry addresses already serialized, so it's a matter of measuring.
     sizeOf_Address addr
-        = 2 + fromIntegral (BS.length (unAddress addr))
+        = 2 + fromIntegral (BS.length (W.unAddress addr))
 
     -- For change address, we consider the worst-case scenario based on the
     -- given wallet scheme. Byron addresses are larger.

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -51,9 +51,6 @@ import Cardano.Address.Script
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     )
-import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..)
-    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (..)
     )
@@ -82,7 +79,10 @@ import Numeric.Natural
     )
 
 import qualified Cardano.Address.Script as CA
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+    ( Coin (..)
+    )
+import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
     ( AssetId (..)
@@ -118,12 +118,12 @@ data TxSkeleton = TxSkeleton
 -- | Estimates the final cost of a transaction based on its skeleton.
 --
 -- The constant tx fee is /not/ included in the result of this function.
-estimateTxCost :: FeePerByte -> TxSkeleton -> Coin
+estimateTxCost :: FeePerByte -> TxSkeleton -> W.Coin
 estimateTxCost (FeePerByte feePerByte) skeleton =
     computeFee (estimateTxSize skeleton)
   where
-    computeFee :: TxSize -> Coin
-    computeFee (TxSize size) = Coin $ feePerByte * size
+    computeFee :: TxSize -> W.Coin
+    computeFee (TxSize size) = W.Coin $ feePerByte * size
 
 -- | Estimates the final size of a transaction based on its skeleton.
 --
@@ -346,7 +346,7 @@ estimateTxSize skeleton =
         . BS.length
         . CBOR.toStrictByteString
         . CBOR.encodeWord64
-        . Coin.unsafeToWord64
+        . W.Coin.unsafeToWord64
 
     determinePaymentTemplateSize scriptCosigner
         = sizeOf_Array

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -85,8 +85,7 @@ import qualified Cardano.Address.Script as CA
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
-    ( AssetId
-    , TokenMap
+    ( AssetId (..)
     )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 import qualified Codec.CBOR.Encoding as CBOR
@@ -278,7 +277,7 @@ estimateTxSize skeleton =
     sizeOf_Output
         = sizeOf_PostAlonzoTransactionOutput
 
-    sizeOf_ChangeOutput :: Set AssetId -> TxSize
+    sizeOf_ChangeOutput :: Set W.AssetId -> TxSize
     sizeOf_ChangeOutput
         = sizeOf_PostAlonzoChangeOutput
 
@@ -290,7 +289,7 @@ estimateTxSize skeleton =
     --   }
     -- value =
     --   coin / [coin,multiasset<uint>]
-    sizeOf_PostAlonzoChangeOutput :: Set AssetId -> TxSize
+    sizeOf_PostAlonzoChangeOutput :: Set W.AssetId -> TxSize
     sizeOf_PostAlonzoChangeOutput xs
         = sizeOf_SmallMap
         + sizeOf_SmallUInt
@@ -319,7 +318,7 @@ estimateTxSize skeleton =
     -- We consider "native asset" to just be the "multiasset<uint>" part of the
     -- above, hence why we don't also include the size of the coin. Where this
     -- is used, the size of the coin and array are are added too.
-    sizeOf_NativeAsset AssetId{tokenName}
+    sizeOf_NativeAsset W.AssetId {tokenName}
         = sizeOf_MultiAsset sizeOf_LargeUInt tokenName
 
     -- multiasset<a> = { * policy_id => { * asset_name => a } }

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
@@ -9,10 +9,6 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Address.Gen
     ( genAddress
     )
-import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoin
-    , shrinkCoin
-    )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn
     )
@@ -81,6 +77,7 @@ import Test.Utils.Pretty
     ( (====)
     )
 
+import qualified Cardano.Wallet.Primitive.Types.Coin.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap.Gen as W
@@ -144,9 +141,10 @@ genSelection = Selection
     genChange = listOf W.genTokenBundle
     genAssetsToMint = W.genTokenMap
     genAssetsToBurn = W.genTokenMap
-    genExtraCoinSource = genCoin
-    genExtraCoinSink = genCoin
-    genTxOutCoin = TxOut <$> genAddress <*> (W.TokenBundle.fromCoin <$> genCoin)
+    genExtraCoinSource = W.genCoin
+    genExtraCoinSink = W.genCoin
+    genTxOutCoin =
+        TxOut <$> genAddress <*> (W.TokenBundle.fromCoin <$> W.genCoin)
 
 shrinkSelection :: Selection -> [Selection]
 shrinkSelection = genericRoundRobinShrink
@@ -166,8 +164,8 @@ shrinkSelection = genericRoundRobinShrink
     shrinkChange = shrinkList W.shrinkTokenBundle
     shrinkAssetsToMint = W.shrinkTokenMap
     shrinkAssetsToBurn = W.shrinkTokenMap
-    shrinkExtraCoinSource = shrinkCoin
-    shrinkExtraCoinSink = shrinkCoin
+    shrinkExtraCoinSource = W.shrinkCoin
+    shrinkExtraCoinSink = W.shrinkCoin
 
 --------------------------------------------------------------------------------
 -- Arbitrary instances

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
@@ -13,10 +13,6 @@ import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoin
     , shrinkCoin
     )
-import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genTokenMap
-    , shrinkTokenMap
-    )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn
     )
@@ -87,6 +83,7 @@ import Test.Utils.Pretty
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.TokenMap.Gen as W
 
 spec :: Spec
 spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
@@ -145,8 +142,8 @@ genSelection = Selection
     genCollateral = listOf ((,) <$> genTxIn <*> genTxOutCoin)
     genOutputs = listOf genTxOut
     genChange = listOf W.genTokenBundle
-    genAssetsToMint = genTokenMap
-    genAssetsToBurn = genTokenMap
+    genAssetsToMint = W.genTokenMap
+    genAssetsToBurn = W.genTokenMap
     genExtraCoinSource = genCoin
     genExtraCoinSink = genCoin
     genTxOutCoin = TxOut <$> genAddress <*> (W.TokenBundle.fromCoin <$> genCoin)
@@ -167,8 +164,8 @@ shrinkSelection = genericRoundRobinShrink
     shrinkCollateral = shrinkList (liftShrink2 shrinkTxIn shrinkTxOut)
     shrinkOutputs = shrinkList shrinkTxOut
     shrinkChange = shrinkList W.shrinkTokenBundle
-    shrinkAssetsToMint = shrinkTokenMap
-    shrinkAssetsToBurn = shrinkTokenMap
+    shrinkAssetsToMint = W.shrinkTokenMap
+    shrinkAssetsToBurn = W.shrinkTokenMap
     shrinkExtraCoinSource = shrinkCoin
     shrinkExtraCoinSink = shrinkCoin
 

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
@@ -6,14 +6,6 @@ module Internal.Cardano.Write.Tx.Balance.CoinSelectionSpec
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.UTxO
-    ( UTxO
-    )
-import Cardano.Wallet.Primitive.Types.UTxO.Gen
-    ( genUTxO
-    , genUTxOLarge
-    , shrinkUTxO
-    )
 import Data.Function
     ( (&)
     )
@@ -69,12 +61,16 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.UTxO as W
+    ( UTxO (..)
+    )
+import qualified Cardano.Wallet.Primitive.Types.UTxO.Gen as W
 
 spec :: Spec
 spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
 
     parallel $ describe
-        "Conversion between external (wallet) and internal UTxOs" $ do
+        "Conversion between external (wallet) and internal W.UTxOs" $ do
 
         it "prop_toInternalUTxO_toExternalUTxO" $
             prop_toInternalUTxO_toExternalUTxO & property
@@ -96,7 +92,7 @@ prop_toInternalUTxO_toExternalUTxO :: W.TxIn -> W.TxOut -> Property
 prop_toInternalUTxO_toExternalUTxO i o =
     (toExternalUTxO . toInternalUTxO) (i, o) === (i, o)
 
-prop_toInternalUTxOMap_toExternalUTxOMap :: UTxO -> Property
+prop_toInternalUTxOMap_toExternalUTxOMap :: W.UTxO -> Property
 prop_toInternalUTxOMap_toExternalUTxOMap u =
     (toExternalUTxOMap . toInternalUTxOMap) u === u
 
@@ -171,9 +167,9 @@ instance Arbitrary W.TxOut where
     arbitrary = W.genTxOut
     shrink = W.shrinkTxOut
 
-instance Arbitrary UTxO where
+instance Arbitrary W.UTxO where
     arbitrary = oneof
-        [ genUTxO
-        , genUTxOLarge
+        [ W.genUTxO
+        , W.genUTxOLarge
         ]
-    shrink = shrinkUTxO
+    shrink = W.shrinkUTxO

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
@@ -6,13 +6,6 @@ module Internal.Cardano.Write.Tx.Balance.CoinSelectionSpec
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.Tx.TxOut
-    ( TxOut (..)
-    )
-import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
-    ( genTxOut
-    , shrinkTxOut
-    )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO
     )
@@ -74,6 +67,8 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as W
 
 spec :: Spec
 spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
@@ -97,7 +92,7 @@ spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
 -- Conversion between external (wallet) and internal UTxOs
 --------------------------------------------------------------------------------
 
-prop_toInternalUTxO_toExternalUTxO :: W.TxIn -> TxOut -> Property
+prop_toInternalUTxO_toExternalUTxO :: W.TxIn -> W.TxOut -> Property
 prop_toInternalUTxO_toExternalUTxO i o =
     (toExternalUTxO . toInternalUTxO) (i, o) === (i, o)
 
@@ -128,16 +123,16 @@ genSelection = Selection
     <*> genExtraCoinSource
     <*> genExtraCoinSink
   where
-    genInputs = genNonEmpty ((,) <$> W.genTxIn <*> genTxOut)
+    genInputs = genNonEmpty ((,) <$> W.genTxIn <*> W.genTxOut)
     genCollateral = listOf ((,) <$> W.genTxIn <*> genTxOutCoin)
-    genOutputs = listOf genTxOut
+    genOutputs = listOf W.genTxOut
     genChange = listOf W.genTokenBundle
     genAssetsToMint = W.genTokenMap
     genAssetsToBurn = W.genTokenMap
     genExtraCoinSource = W.genCoin
     genExtraCoinSink = W.genCoin
     genTxOutCoin =
-        TxOut <$> W.genAddress <*> (W.TokenBundle.fromCoin <$> W.genCoin)
+        W.TxOut <$> W.genAddress <*> (W.TokenBundle.fromCoin <$> W.genCoin)
 
 shrinkSelection :: Selection -> [Selection]
 shrinkSelection = genericRoundRobinShrink
@@ -151,9 +146,9 @@ shrinkSelection = genericRoundRobinShrink
     <:> shrinkExtraCoinSink
     <:> Nil
   where
-    shrinkInputs = shrinkNonEmpty (liftShrink2 W.shrinkTxIn shrinkTxOut)
-    shrinkCollateral = shrinkList (liftShrink2 W.shrinkTxIn shrinkTxOut)
-    shrinkOutputs = shrinkList shrinkTxOut
+    shrinkInputs = shrinkNonEmpty (liftShrink2 W.shrinkTxIn W.shrinkTxOut)
+    shrinkCollateral = shrinkList (liftShrink2 W.shrinkTxIn W.shrinkTxOut)
+    shrinkOutputs = shrinkList W.shrinkTxOut
     shrinkChange = shrinkList W.shrinkTokenBundle
     shrinkAssetsToMint = W.shrinkTokenMap
     shrinkAssetsToBurn = W.shrinkTokenMap
@@ -172,9 +167,9 @@ instance Arbitrary W.TxIn where
     arbitrary = W.genTxIn
     shrink = W.shrinkTxIn
 
-instance Arbitrary TxOut where
-    arbitrary = genTxOut
-    shrink = shrinkTxOut
+instance Arbitrary W.TxOut where
+    arbitrary = W.genTxOut
+    shrink = W.shrinkTxOut
 
 instance Arbitrary UTxO where
     arbitrary = oneof

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
@@ -6,9 +6,6 @@ module Internal.Cardano.Write.Tx.Balance.CoinSelectionSpec
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.Address.Gen
-    ( genAddress
-    )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn
     )
@@ -77,6 +74,7 @@ import Test.Utils.Pretty
     ( (====)
     )
 
+import qualified Cardano.Wallet.Primitive.Types.Address.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.Coin.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
@@ -144,7 +142,7 @@ genSelection = Selection
     genExtraCoinSource = W.genCoin
     genExtraCoinSink = W.genCoin
     genTxOutCoin =
-        TxOut <$> genAddress <*> (W.TokenBundle.fromCoin <$> W.genCoin)
+        TxOut <$> W.genAddress <*> (W.TokenBundle.fromCoin <$> W.genCoin)
 
 shrinkSelection :: Selection -> [Selection]
 shrinkSelection = genericRoundRobinShrink

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
@@ -6,13 +6,6 @@ module Internal.Cardano.Write.Tx.Balance.CoinSelectionSpec
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.Tx.TxIn
-    ( TxIn
-    )
-import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
-    ( genTxIn
-    , shrinkTxIn
-    )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
     )
@@ -79,6 +72,8 @@ import qualified Cardano.Wallet.Primitive.Types.Coin.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen as W
 
 spec :: Spec
 spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
@@ -102,7 +97,7 @@ spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
 -- Conversion between external (wallet) and internal UTxOs
 --------------------------------------------------------------------------------
 
-prop_toInternalUTxO_toExternalUTxO :: TxIn -> TxOut -> Property
+prop_toInternalUTxO_toExternalUTxO :: W.TxIn -> TxOut -> Property
 prop_toInternalUTxO_toExternalUTxO i o =
     (toExternalUTxO . toInternalUTxO) (i, o) === (i, o)
 
@@ -133,8 +128,8 @@ genSelection = Selection
     <*> genExtraCoinSource
     <*> genExtraCoinSink
   where
-    genInputs = genNonEmpty ((,) <$> genTxIn <*> genTxOut)
-    genCollateral = listOf ((,) <$> genTxIn <*> genTxOutCoin)
+    genInputs = genNonEmpty ((,) <$> W.genTxIn <*> genTxOut)
+    genCollateral = listOf ((,) <$> W.genTxIn <*> genTxOutCoin)
     genOutputs = listOf genTxOut
     genChange = listOf W.genTokenBundle
     genAssetsToMint = W.genTokenMap
@@ -156,8 +151,8 @@ shrinkSelection = genericRoundRobinShrink
     <:> shrinkExtraCoinSink
     <:> Nil
   where
-    shrinkInputs = shrinkNonEmpty (liftShrink2 shrinkTxIn shrinkTxOut)
-    shrinkCollateral = shrinkList (liftShrink2 shrinkTxIn shrinkTxOut)
+    shrinkInputs = shrinkNonEmpty (liftShrink2 W.shrinkTxIn shrinkTxOut)
+    shrinkCollateral = shrinkList (liftShrink2 W.shrinkTxIn shrinkTxOut)
     shrinkOutputs = shrinkList shrinkTxOut
     shrinkChange = shrinkList W.shrinkTokenBundle
     shrinkAssetsToMint = W.shrinkTokenMap
@@ -173,9 +168,9 @@ instance Arbitrary Selection where
     arbitrary = genSelection
     shrink = shrinkSelection
 
-instance Arbitrary TxIn where
-    arbitrary = genTxIn
-    shrink = shrinkTxIn
+instance Arbitrary W.TxIn where
+    arbitrary = W.genTxIn
+    shrink = W.shrinkTxIn
 
 instance Arbitrary TxOut where
     arbitrary = genTxOut

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
@@ -13,10 +13,6 @@ import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoin
     , shrinkCoin
     )
-import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
-    ( genTokenBundle
-    , shrinkTokenBundle
-    )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genTokenMap
     , shrinkTokenMap
@@ -89,7 +85,8 @@ import Test.Utils.Pretty
     ( (====)
     )
 
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
 
 spec :: Spec
 spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
@@ -147,12 +144,12 @@ genSelection = Selection
     genInputs = genNonEmpty ((,) <$> genTxIn <*> genTxOut)
     genCollateral = listOf ((,) <$> genTxIn <*> genTxOutCoin)
     genOutputs = listOf genTxOut
-    genChange = listOf genTokenBundle
+    genChange = listOf W.genTokenBundle
     genAssetsToMint = genTokenMap
     genAssetsToBurn = genTokenMap
     genExtraCoinSource = genCoin
     genExtraCoinSink = genCoin
-    genTxOutCoin = TxOut <$> genAddress <*> (TokenBundle.fromCoin <$> genCoin)
+    genTxOutCoin = TxOut <$> genAddress <*> (W.TokenBundle.fromCoin <$> genCoin)
 
 shrinkSelection :: Selection -> [Selection]
 shrinkSelection = genericRoundRobinShrink
@@ -169,7 +166,7 @@ shrinkSelection = genericRoundRobinShrink
     shrinkInputs = shrinkNonEmpty (liftShrink2 shrinkTxIn shrinkTxOut)
     shrinkCollateral = shrinkList (liftShrink2 shrinkTxIn shrinkTxOut)
     shrinkOutputs = shrinkList shrinkTxOut
-    shrinkChange = shrinkList shrinkTokenBundle
+    shrinkChange = shrinkList W.shrinkTokenBundle
     shrinkAssetsToMint = shrinkTokenMap
     shrinkAssetsToBurn = shrinkTokenMap
     shrinkExtraCoinSource = shrinkCoin

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -49,7 +49,6 @@ import Data.Word
 import Internal.Cardano.Write.Tx
     ( ProtVer (..)
     , RecentEra (..)
-    , ShelleyLedgerEra
     , StandardBabbage
     , StandardConway
     , Version
@@ -85,6 +84,7 @@ import Test.QuickCheck
     , (==>)
     )
 
+import qualified Cardano.Api.Shelley as CardanoApi
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 
 spec :: Spec
@@ -288,7 +288,7 @@ instance Arbitrary PParamsInRecentEra where
       where
         genPParams
             :: RecentEra era
-            -> Gen (PParams (ShelleyLedgerEra era))
+            -> Gen (PParams (CardanoApi.ShelleyLedgerEra era))
         genPParams era = withConstraints era $ do
             ver <- arbitrary
             maxSize <- genMaxSizeBytes

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -22,9 +22,6 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
     , txOutMaxCoin
     , txOutMinCoin
     )
-import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
-    ( genTxOutTokenBundle
-    )
 import Control.Lens
     ( (&)
     , (.~)
@@ -82,6 +79,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle
     )
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as W
 
 spec :: Spec
 spec = describe "Assessing the sizes of token bundles" $ do
@@ -244,19 +242,19 @@ newtype VariableSize1024 a = VariableSize1024 { unVariableSize1024 :: a}
     deriving (Eq, Show)
 
 instance Arbitrary (FixedSize32 W.TokenBundle) where
-    arbitrary = FixedSize32 <$> genTxOutTokenBundle 32
+    arbitrary = FixedSize32 <$> W.genTxOutTokenBundle 32
     -- No shrinking
 
 instance Arbitrary (FixedSize48 W.TokenBundle) where
-    arbitrary = FixedSize48 <$> genTxOutTokenBundle 48
+    arbitrary = FixedSize48 <$> W.genTxOutTokenBundle 48
     -- No shrinking
 
 instance Arbitrary (FixedSize64 W.TokenBundle) where
-    arbitrary = FixedSize64 <$> genTxOutTokenBundle 64
+    arbitrary = FixedSize64 <$> W.genTxOutTokenBundle 64
     -- No shrinking
 
 instance Arbitrary (FixedSize128 W.TokenBundle) where
-    arbitrary = FixedSize128 <$> genTxOutTokenBundle 128
+    arbitrary = FixedSize128 <$> W.genTxOutTokenBundle 128
     -- No shrinking
 
 instance Arbitrary (VariableSize16 W.TokenBundle) where

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -17,11 +17,6 @@ import Cardano.Ledger.Api.PParams
     , ppMaxValSizeL
     , ppProtocolVersionL
     )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TxSize (..)
-    , txOutMaxCoin
-    , txOutMinCoin
-    )
 import Control.Lens
     ( (&)
     , (.~)
@@ -79,6 +74,11 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle
     )
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+    ( TxSize (..)
+    , txOutMaxCoin
+    , txOutMinCoin
+    )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as W
 
 spec :: Spec
@@ -112,7 +112,7 @@ prop_assessTokenBundleSize_enlarge b1' b2' pp =
     assess b1 == TokenBundleSizeExceedsLimit ==> conjoin
         [ assess (b1 <> b2)
             === TokenBundleSizeExceedsLimit
-        , assess (b1 `W.TokenBundle.setCoin` txOutMaxCoin)
+        , assess (b1 `W.TokenBundle.setCoin` W.txOutMaxCoin)
             === TokenBundleSizeExceedsLimit
         ]
   where
@@ -132,7 +132,7 @@ prop_assessTokenBundleSize_shrink b1' b2' pp =
     assess b1 == TokenBundleSizeWithinLimit ==> conjoin
         [ assess (b1 <\> b2)
             === TokenBundleSizeWithinLimit
-        , assess (b1 `W.TokenBundle.setCoin` txOutMinCoin)
+        , assess (b1 `W.TokenBundle.setCoin` W.txOutMinCoin)
             === TokenBundleSizeWithinLimit
         ]
   where
@@ -152,9 +152,9 @@ unit_assessTokenBundleSize_fixedSizeBundle
     -- ^ Expected size assessment
     -> TokenBundleSizeAssessor
     -- ^ W.TokenBundle assessor function
-    -> TxSize
+    -> W.TxSize
     -- ^ Expected min length (bytes)
-    -> TxSize
+    -> W.TxSize
     -- ^ Expected max length (bytes)
     -> Property
 unit_assessTokenBundleSize_fixedSizeBundle
@@ -193,7 +193,7 @@ unit_assessTokenBundleSize_fixedSizeBundle_32 (Blind (FixedSize32 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle b
         TokenBundleSizeWithinLimit
         babbageTokenBundleSizeAssessor
-        (TxSize 2116) (TxSize 2380)
+        (W.TxSize 2116) (W.TxSize 2380)
 
 unit_assessTokenBundleSize_fixedSizeBundle_48
     :: Blind (FixedSize48 W.TokenBundle) -> Property
@@ -201,7 +201,7 @@ unit_assessTokenBundleSize_fixedSizeBundle_48 (Blind (FixedSize48 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle b
         TokenBundleSizeWithinLimit
         babbageTokenBundleSizeAssessor
-        (TxSize 3172) (TxSize 3564)
+        (W.TxSize 3172) (W.TxSize 3564)
 
 unit_assessTokenBundleSize_fixedSizeBundle_64
     :: Blind (FixedSize64 W.TokenBundle) -> Property
@@ -209,7 +209,7 @@ unit_assessTokenBundleSize_fixedSizeBundle_64 (Blind (FixedSize64 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle b
         TokenBundleSizeExceedsLimit
         babbageTokenBundleSizeAssessor
-        (TxSize 4228) (TxSize 4748)
+        (W.TxSize 4228) (W.TxSize 4748)
 
 unit_assessTokenBundleSize_fixedSizeBundle_128
     :: Blind (FixedSize128 W.TokenBundle) -> Property
@@ -217,7 +217,7 @@ unit_assessTokenBundleSize_fixedSizeBundle_128 (Blind (FixedSize128 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle b
         TokenBundleSizeExceedsLimit
         babbageTokenBundleSizeAssessor
-        (TxSize 8452) (TxSize 9484)
+        (W.TxSize 8452) (W.TxSize 9484)
 
 instance Arbitrary W.TokenBundle where
     arbitrary = W.genTokenBundleSmallRange

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -133,9 +133,6 @@ import Cardano.Wallet.Primitive.Passphrase
 import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException
     )
-import Cardano.Wallet.Primitive.Types.Credentials
-    ( RootCredentials (..)
-    )
 import Cardano.Wallet.Shelley.Transaction
     ( mkByronWitness
     , mkDelegationCertificates
@@ -428,6 +425,9 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..)
     )
 import qualified Cardano.Wallet.Primitive.Types.Coin.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Credentials as W
+    ( RootCredentials (..)
+    )
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
     ( Hash (..)
     , mockHash
@@ -2423,7 +2423,7 @@ dummyShelleyChangeAddressGen = AnyChangeAddressGenWithState
         (delegationAddress @ShelleyKey SMainnet)
         )
     (mkSeqStateFromRootXPrv ShelleyKeyS
-        (RootCredentials rootK pwd)
+        (W.RootCredentials rootK pwd)
         purposeCIP1852
         defaultAddressPoolGap)
   where

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -262,7 +262,6 @@ import Internal.Cardano.Write.Tx
     , InAnyRecentEra (..)
     , IsRecentEra (..)
     , RecentEra (..)
-    , ShelleyLedgerEra
     , Tx
     , TxIn
     , TxOut
@@ -1106,7 +1105,7 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
                 body
             era = recentEra @era
 
-            tx :: Tx (ShelleyLedgerEra era)
+            tx :: Tx (CardanoApi.ShelleyLedgerEra era)
             tx = fromCardanoApiTx @era cTx
 
             noScripts = withConstraints (recentEra @era)
@@ -1168,8 +1167,8 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
         :: forall era. HasCallStack
         => RecentEra era
         -> W.Address
-        -> Tx (ShelleyLedgerEra era)
-        -> UTxO (ShelleyLedgerEra era)
+        -> Tx (CardanoApi.ShelleyLedgerEra era)
+        -> UTxO (CardanoApi.ShelleyLedgerEra era)
     utxoPromisingInputsHaveAddress era addr tx =
         utxoFromTxOutsInRecentEra era $
             [ (i
@@ -1183,7 +1182,7 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
             ]
       where
         allInputs
-            :: Tx (ShelleyLedgerEra era)
+            :: Tx (CardanoApi.ShelleyLedgerEra era)
             -> [TxIn]
         allInputs body = withConstraints era
             $ Set.toList
@@ -1483,7 +1482,7 @@ prop_balanceTransactionValid
     prop_expectFeeExcessSmallerThan
         :: CardanoApi.Lovelace
         -> CardanoApi.Tx era
-        -> UTxO (ShelleyLedgerEra era)
+        -> UTxO (CardanoApi.ShelleyLedgerEra era)
         -> Property
     prop_expectFeeExcessSmallerThan lim tx utxo = do
         let fee = txFee tx
@@ -1502,7 +1501,7 @@ prop_balanceTransactionValid
 
     prop_minfeeIsCovered
         :: CardanoApi.Tx era
-        -> UTxO (ShelleyLedgerEra era)
+        -> UTxO (CardanoApi.ShelleyLedgerEra era)
         -> Property
     prop_minfeeIsCovered tx utxo = do
         let fee = txFee tx
@@ -1521,7 +1520,7 @@ prop_balanceTransactionValid
 
     prop_validSize
         :: CardanoApi.Tx era
-        -> UTxO (ShelleyLedgerEra era)
+        -> UTxO (CardanoApi.ShelleyLedgerEra era)
         -> Property
     prop_validSize tx@(CardanoApi.Tx body _) utxo = do
         let era = recentEra @era
@@ -1589,7 +1588,7 @@ prop_balanceTransactionValid
 
     minFee
         :: CardanoApi.Tx era
-        -> UTxO (ShelleyLedgerEra era)
+        -> UTxO (CardanoApi.ShelleyLedgerEra era)
         -> CardanoApi.Lovelace
     minFee tx@(CardanoApi.Tx body _) utxo = Write.toCardanoApiLovelace
         $ Write.evaluateMinimumFee (recentEra @era) ledgerPParams
@@ -1598,7 +1597,7 @@ prop_balanceTransactionValid
 
     txBalance
         :: CardanoApi.Tx era
-        -> UTxO (ShelleyLedgerEra era)
+        -> UTxO (CardanoApi.ShelleyLedgerEra era)
         -> CardanoApi.Value
     txBalance tx u = Write.toCardanoApiValue @era $
         Write.evaluateTransactionBalance
@@ -2303,7 +2302,7 @@ cardanoToWalletTxOut
 cardanoToWalletTxOut =
     toWallet . CardanoApi.toShelleyTxOut (Write.shelleyBasedEra @era)
   where
-    toWallet :: TxOut (ShelleyLedgerEra era) -> W.TxOut
+    toWallet :: TxOut (CardanoApi.ShelleyLedgerEra era) -> W.TxOut
     toWallet x = case recentEra @era of
         RecentEraBabbage -> Convert.fromBabbageTxOut x
         RecentEraConway -> Convert.fromConwayTxOut x
@@ -2820,8 +2819,8 @@ shrinkInputResolution
         ( IsRecentEra era
         , Arbitrary (CardanoApi.TxOut CardanoApi.CtxUTxO era)
         )
-    => Write.UTxO (ShelleyLedgerEra era)
-    -> [Write.UTxO (ShelleyLedgerEra era)]
+    => Write.UTxO (CardanoApi.ShelleyLedgerEra era)
+    -> [Write.UTxO (CardanoApi.ShelleyLedgerEra era)]
 shrinkInputResolution =
     shrinkMapBy utxoFromList utxoToList shrinkUTxOEntries
    where

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -454,7 +454,7 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (..)
     )
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as TxOutGen
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Codec.CBOR.Encoding as CBOR
@@ -2724,14 +2724,14 @@ instance Arbitrary (TxFeeAndChange [W.TxOut]) where
         fee <- W.genCoin
         change <- frequency
             [ (1, pure [])
-            , (1, (: []) <$> TxOutGen.genTxOut)
-            , (6, listOf TxOutGen.genTxOut)
+            , (1, (: []) <$> W.genTxOut)
+            , (6, listOf W.genTxOut)
             ]
         pure $ TxFeeAndChange fee change
     shrink (TxFeeAndChange fee change) =
         uncurry TxFeeAndChange <$> liftShrink2
             (W.shrinkCoin)
-            (shrinkList TxOutGen.shrinkTxOut)
+            (shrinkList W.shrinkTxOut)
             (fee, change)
 
 instance Arbitrary W.TxIn where


### PR DESCRIPTION
## Issue

ADP-3184

## Description

This PR is about improving the readability of code in `cardano-balance-tx`.

Where possible, this PR arranges that:

- symbols from `Cardano.Wallet.Primitive.Types` are imported into the `W` namespace.
- symbols from `Cardano.Api` are imported into the `CardanoApi` namespace.

The intention is to make it easier for readers to distinguish (visually) between similarly-named types and functions imported from the following libraries:
- `cardano-api`
- `cardano-ledger`
- `cardano-wallet-primitive`

(all of which are generally incompatible, at least without the use of conversion functions)

Where appropriate, certain symbols are imported into a nested namespace. For example:
```hs
import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
```
This allows functions for a particular type (with its own well-defined family of functions) to be qualified as `W.Type.functionName`.