### PR TITLE
[ADP-3214] Put responsibility for migrations into `withLoadDBLayerFromFile`

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -257,6 +257,7 @@ library
     Cardano.Wallet.DB.Pure.Layer
     Cardano.Wallet.DB.Sqlite.Migration.New
     Cardano.Wallet.DB.Sqlite.Migration.Old
+    Cardano.Wallet.DB.Sqlite.Migration.SchemaVersion1
     Cardano.Wallet.DB.Sqlite.Schema
     Cardano.Wallet.DB.Sqlite.Types
     Cardano.Wallet.DB.Store.Checkpoints.Store

--- a/lib/wallet/src/Cardano/DB/Sqlite.hs
+++ b/lib/wallet/src/Cardano/DB/Sqlite.hs
@@ -36,6 +36,10 @@ module Cardano.DB.Sqlite
     , dbFile
     , dbBackend
 
+      -- * Migrations
+    , runManualOldMigrations
+    , matchWrongVersionError
+
       -- * Helpers
     , chunkSize
     , dbChunked

--- a/lib/wallet/src/Cardano/Pool/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Layer.hs
@@ -282,12 +282,10 @@ withDecoratedDBLayer dbDecorator tr mDatabaseDir ti action = do
                     fp
                     createViews
                     migrateAll
-                    newMigrations
                     $ action . decorateDBLayer dbDecorator . newDBLayer tr ti
             either throwIO pure res
   where
     tr' = contramap MsgGeneric tr
-    newMigrations _ _ = pure ()
 
 -- | Sets up a connection to the SQLite database.
 --

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -522,9 +522,6 @@ migrateDBFile tr walletF defaultFieldValues fp = runExceptT $ do
 noAutoMigrations :: Sqlite.Migration
 noAutoMigrations = pure ()
 
-noNewStyleMigrations :: Tracer IO DBLog -> FilePath -> IO ()
-noNewStyleMigrations _ _ = pure ()
-
 throwMigrationError :: Either MigrationError a -> IO a
 throwMigrationError = either throwIO pure
 
@@ -562,7 +559,6 @@ withLoadDBLayerFromFile wF tr ti wid defaultFieldValues dbFile action = do
         dbFile
         noManualMigration
         noAutoMigrations
-        noNewStyleMigrations
         $ \ctx -> do
             dblayer <- loadDBLayerFromSqliteContext wF ti wid ctx
             action dblayer
@@ -596,13 +592,11 @@ withBootDBLayerFromFile
 withBootDBLayerFromFile wF tr ti wid _defaultFieldValues params dbFile action =
   do
     let trDB = contramap MsgDB tr
-        noNewStyleMigrations _ _ = pure ()
     res <- withSqliteContextFile
         trDB
         dbFile
         createSchemaVersionTableIfMissing'
         migrateAll
-        noNewStyleMigrations
         $ \ctx -> do
             dblayer <- bootDBLayerFromSqliteContext wF ti wid params ctx
             action dblayer
@@ -875,7 +869,6 @@ withTestLoadDBLayerFromFile tr ti dbFile action = do
             dbFile
             noManualMigration
             noMigration
-            noNewStyleMigrations
             (`runQuery` readWalletId)
     case mwid of
         Nothing -> fail "No wallet id found in database"
@@ -890,7 +883,6 @@ withTestLoadDBLayerFromFile tr ti dbFile action = do
                 action
   where
     noMigration = pure ()
-    noNewStyleMigrations _ _ = pure ()
 
 -- | Default field values used when testing,
 -- in the context of 'withLoadDBLayerFromFile'.

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/Old.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/Old.hs
@@ -208,6 +208,7 @@ migrateManually tr key defaultFieldValues =
     , createSchemaVersion1TablesIfMissing
     , removeOldSubmissions
     , removeMetasOfSubmissions
+    , createSubmissionsTable
     , createAndPopulateSubmissionsSlotTable
     ]
   where
@@ -873,13 +874,32 @@ migrateManually tr key defaultFieldValues =
                             [ "DELETE FROM " <> tableName t
                             , "WHERE tx_id = '" <> txId <> "';"
                             ]
+
+    createSubmissionsTable :: Sqlite.Connection -> IO ()
+    createSubmissionsTable conn = void $ runSql conn
+        [i|
+            CREATE TABLE IF NOT EXISTS "submissions"
+                ( "tx_id" VARCHAR NOT NULL
+                , "tx" BLOB NOT NULL
+                , "expiration" INTEGER NOT NULL
+                , "acceptance" INTEGER NULL
+                , "wallet_id" VARCHAR NOT NULL
+                , "status" INTEGER NOT NULL
+                , "slot" INTEGER NOT NULL
+                , "block_height" INTEGER NOT NULL
+                , "amount" INTEGER NOT NULL
+                , "direction" BOOLEAN NOT NULL
+                , "resubmitted" INTEGER NOT NULL
+                , PRIMARY KEY ("tx_id")
+                )
+        |]
+
     createAndPopulateSubmissionsSlotTable :: Sqlite.Connection -> IO ()
     createAndPopulateSubmissionsSlotTable conn = do
-
         let action = do
                 void $ runSql conn
                     [i|
-                        CREATE TABLE "submissions_slots"
+                        CREATE TABLE IF NOT EXISTS "submissions_slots"
                             (   "finality" INTEGER NOT NULL
                             ,   "tip" INTEGER NOT NULL
                             ,   "wallet_id" VARCHAR NOT NULL

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/Old.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/Old.hs
@@ -44,6 +44,9 @@ import Cardano.DB.Sqlite.Migration.Old
     , foldMigrations
     , tableName
     )
+import Cardano.Wallet.DB.Sqlite.Migration.SchemaVersion1
+    ( sqlCreateSchemaVersion1TablesIfMissing
+    )
 import Cardano.Wallet.DB.Sqlite.Schema
     ( EntityField (..)
     )
@@ -199,6 +202,7 @@ migrateManually tr key defaultFieldValues =
     , moveRndUnusedAddresses
     , cleanupSeqStateTable
     , addPolicyXPubIfMissing
+    , createSchemaVersion1TablesIfMissing
     , removeOldSubmissions
     , removeMetasOfSubmissions
     , createAndPopulateSubmissionsSlotTable
@@ -794,6 +798,10 @@ migrateManually tr key defaultFieldValues =
       where
         value = "NULL"
 
+    -- | Create any table of SchemaVersion 1 that is still missing.
+    createSchemaVersion1TablesIfMissing :: Sqlite.Connection -> IO ()
+    createSchemaVersion1TablesIfMissing =
+        forM_ sqlCreateSchemaVersion1TablesIfMissing . runSql
 
     -- | This table is replaced by Submissions talbles.
     removeOldSubmissions :: Sqlite.Connection -> IO ()

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/SchemaVersion1.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/SchemaVersion1.hs
@@ -1,0 +1,394 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- |
+-- Copyright: © 2023 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Historical record of SchemaVersion 1.
+-- Necessary for migrations.
+
+module Cardano.Wallet.DB.Sqlite.Migration.SchemaVersion1
+    ( sqlCreateSchemaVersion1TablesIfMissing
+    ) where
+
+import Prelude
+
+import Data.String.Interpolate
+    ( i
+    )
+import Data.Text
+    ( Text
+    , split
+    )
+
+-- | List of raw SQL queries that
+-- create any missing tables from SchemaVersion 1.
+sqlCreateSchemaVersion1TablesIfMissing :: [Text]
+sqlCreateSchemaVersion1TablesIfMissing =
+  split (== ';')
+    [i|
+CREATE TABLE IF NOT EXISTS database_schema_version
+  (
+    name    TEXT PRIMARY KEY,
+    version INTEGER NOT NULL
+  );
+
+CREATE TABLE IF NOT EXISTS "wallet"
+  (
+    "wallet_id"                  VARCHAR NOT NULL,
+    "creation_time"              TIMESTAMP NOT NULL,
+    "name"                       VARCHAR NOT NULL,
+    "passphrase_last_updated_at" TIMESTAMP NULL,
+    "passphrase_scheme"          VARCHAR NULL,
+    "genesis_hash"               VARCHAR NOT NULL,
+    "genesis_start"              TIMESTAMP NOT NULL,
+    PRIMARY KEY ("wallet_id")
+  );
+
+CREATE TABLE IF NOT EXISTS "private_key"
+  (
+    "wallet_id" VARCHAR NOT NULL,
+    "root"      BLOB NOT NULL,
+    "hash"      BLOB NOT NULL,
+    PRIMARY KEY ("wallet_id"),
+    CONSTRAINT "private_keyfk_wallet_private_key"
+        FOREIGN KEY("wallet_id")
+        REFERENCES "wallet"("wallet_id")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "tx_meta"
+  (
+    "tx_id"           VARCHAR NOT NULL,
+    "wallet_id"       VARCHAR NOT NULL,
+    "status"          VARCHAR NOT NULL,
+    "direction"       BOOLEAN NOT NULL,
+    "slot"            INTEGER NOT NULL,
+    "block_height"    INTEGER NOT NULL,
+    "amount"          INTEGER NOT NULL,
+    "data"            VARCHAR NULL,
+    "slot_expires"    INTEGER NULL,
+    "fee"             INTEGER NULL,
+    "script_validity" BOOLEAN NULL,
+    PRIMARY KEY ("tx_id", "wallet_id"),
+    CONSTRAINT "tx_metafk_wallet_tx_meta"
+        FOREIGN KEY("wallet_id")
+        REFERENCES "wallet"("wallet_id")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "tx_in"
+(
+    "tx_id"         VARCHAR NOT NULL,
+    "order"         INTEGER NOT NULL,
+    "source_tx_id"  VARCHAR NOT NULL,
+    "source_index"  INTEGER NOT NULL,
+    "source_amount" INTEGER NOT NULL,
+    PRIMARY KEY ("tx_id", "source_tx_id", "source_index")
+);
+
+CREATE TABLE IF NOT EXISTS "tx_collateral"
+(
+    "tx_id"         VARCHAR NOT NULL,
+    "order"         INTEGER NOT NULL,
+    "source_tx_id"  VARCHAR NOT NULL,
+    "source_index"  INTEGER NOT NULL,
+    "source_amount" INTEGER NOT NULL,
+    PRIMARY KEY ("tx_id", "source_tx_id", "source_index")
+);
+
+CREATE TABLE IF NOT EXISTS "tx_out"
+(
+    "tx_id"   VARCHAR NOT NULL,
+    "index"   INTEGER NOT NULL,
+    "address" VARCHAR NOT NULL,
+    "amount"  INTEGER NOT NULL,
+    PRIMARY KEY ("tx_id", "index")
+);
+
+CREATE TABLE IF NOT EXISTS "tx_out_token"
+(
+    "tx_id"           VARCHAR NOT NULL,
+    "tx_index"        INTEGER NOT NULL,
+    "token_policy_id" VARCHAR NOT NULL,
+    "token_name"      VARCHAR NOT NULL,
+    "token_quantity"  VARCHAR NOT NULL,
+    PRIMARY KEY ("tx_id", "tx_index", "token_policy_id", "token_name"),
+    CONSTRAINT "tx_out_tokentx_out"
+        FOREIGN KEY("tx_id", "tx_index")
+        REFERENCES "tx_out"("tx_id", "index")
+        ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "tx_collateral_out"
+(
+    "tx_id"   VARCHAR NOT NULL,
+    "address" VARCHAR NOT NULL,
+    "amount"  INTEGER NOT NULL,
+    PRIMARY KEY ("tx_id")
+);
+
+CREATE TABLE IF NOT EXISTS "tx_collateral_out_token"
+(
+    "tx_id"           VARCHAR NOT NULL,
+    "token_policy_id" VARCHAR NOT NULL,
+    "token_name"      VARCHAR NOT NULL,
+    "token_quantity"  VARCHAR NOT NULL,
+    PRIMARY KEY ("tx_id", "token_policy_id", "token_name"),
+    CONSTRAINT "tx_collateral_out_tokentx_collateral_out"
+        FOREIGN KEY("tx_id")
+        REFERENCES "tx_collateral_out"("tx_id")
+        ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "tx_withdrawal"
+  (
+    "tx_id"   VARCHAR NOT NULL,
+    "amount"  INTEGER NOT NULL,
+    "account" VARCHAR NOT NULL,
+    PRIMARY KEY ("tx_id", "account")
+  );
+
+CREATE TABLE IF NOT EXISTS "local_tx_submission"
+  (
+     "tx_id"     VARCHAR NOT NULL,
+     "wallet_id" VARCHAR NOT NULL,
+     "last_slot" INTEGER NOT NULL,
+     "tx"        BLOB NOT NULL,
+     PRIMARY KEY ("tx_id", "wallet_id"),
+     CONSTRAINT "unique_local_tx_submission"
+        UNIQUE ("tx_id", "wallet_id"),
+     CONSTRAINT "local_tx_submissionfk_tx_meta"
+        FOREIGN KEY("tx_id", "wallet_id")
+        REFERENCES "tx_meta"("tx_id", "wallet_id")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "checkpoint"
+  (
+     "wallet_id"          VARCHAR NOT NULL,
+     "slot"               INTEGER NOT NULL,
+     "header_hash"        VARCHAR NOT NULL,
+     "parent_header_hash" VARCHAR NOT NULL,
+     "block_height"       INTEGER NOT NULL,
+     PRIMARY KEY ("wallet_id", "slot"),
+     CONSTRAINT "checkpointcheckpoint"
+        FOREIGN KEY("wallet_id")
+        REFERENCES "wallet"("wallet_id")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "protocol_parameters"
+  (
+     "wallet_id"              VARCHAR NOT NULL,
+     "fee_policy"             VARCHAR NOT NULL,
+     "tx_max_size"            INTEGER NOT NULL,
+     "decentralization_level" NUMERIC(32, 20) NOT NULL,
+     "desired_pool_number"    INTEGER NOT NULL,
+     "minimum_utxo_value"     INTEGER NOT NULL,
+     "hardfork_epoch"         INTEGER NULL,
+     "key_deposit"            INTEGER NOT NULL,
+     PRIMARY KEY ("wallet_id"),
+     CONSTRAINT "protocol_parametersfk_wallet_protocol_parameters"
+        FOREIGN KEY("wallet_id")
+        REFERENCES "wallet"("wallet_id")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "stake_key_certificate"
+  (
+     "wallet_id" VARCHAR NOT NULL,
+     "slot"      INTEGER NOT NULL,
+     "type"      VARCHAR NOT NULL,
+     PRIMARY KEY ("wallet_id", "slot"),
+     CONSTRAINT "stake_key_certificatestake_key_registration"
+        FOREIGN KEY("wallet_id")
+        REFERENCES "wallet"("wallet_id")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "delegation_certificate"
+  (
+     "wallet_id"  VARCHAR NOT NULL,
+     "slot"       INTEGER NOT NULL,
+     "delegation" VARCHAR NULL,
+     PRIMARY KEY ("wallet_id", "slot"),
+     CONSTRAINT "delegation_certificatedelegation_certificate"
+        FOREIGN KEY("wallet_id")
+        REFERENCES "wallet"("wallet_id")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "delegation_reward"
+  (
+     "wallet_id"       VARCHAR NOT NULL,
+     "account_balance" INTEGER NOT NULL,
+     PRIMARY KEY ("wallet_id"),
+     CONSTRAINT "delegation_rewarddelegation_reward"
+        FOREIGN KEY("wallet_id")
+        REFERENCES "wallet"("wallet_id")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "utxo"
+  (
+     "wallet_id"      VARCHAR NOT NULL,
+     "slot"           INTEGER NOT NULL,
+     "input_tx_id"    VARCHAR NOT NULL,
+     "input_index"    INTEGER NOT NULL,
+     "output_address" VARCHAR NOT NULL,
+     "output_coin"    INTEGER NOT NULL,
+     PRIMARY KEY ("wallet_id", "slot", "input_tx_id", "input_index"),
+     CONSTRAINT "u_tx_outxo"
+        FOREIGN KEY("wallet_id", "slot")
+        REFERENCES "checkpoint"("wallet_id", "slot")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "utxo_token"
+  (
+     "id"              INTEGER PRIMARY KEY,
+     "wallet_id"       VARCHAR NOT NULL,
+     "slot"            INTEGER NOT NULL,
+     "tx_id"           VARCHAR NOT NULL,
+     "tx_index"        INTEGER NOT NULL,
+     "token_policy_id" VARCHAR NOT NULL,
+     "token_name"      VARCHAR NOT NULL,
+     "token_quantity"  VARCHAR NOT NULL,
+     CONSTRAINT "u_tx_o_tokenutxot"
+        FOREIGN KEY("wallet_id", "slot") REFERENCES
+         "checkpoint"("wallet_id", "slot") ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "seq_state"
+  (
+     "wallet_id"         VARCHAR NOT NULL,
+     "external_gap"      INTEGER NOT NULL,
+     "internal_gap"      INTEGER NOT NULL,
+     "account_xpub"      BLOB NOT NULL,
+     "policy_xpub"       BLOB NULL,
+     "reward_xpub"       BLOB NOT NULL,
+     "derivation_prefix" VARCHAR NOT NULL,
+     PRIMARY KEY ("wallet_id"),
+     CONSTRAINT "seq_stateseq_state"
+        FOREIGN KEY("wallet_id")
+        REFERENCES "wallet"("wallet_id")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "seq_state_address"
+  (
+     "id"         INTEGER PRIMARY KEY,
+     "wallet_id"  VARCHAR NOT NULL,
+     "slot"       INTEGER NOT NULL,
+     "address"    VARCHAR NOT NULL,
+     "address_ix" INTEGER NOT NULL,
+     "role"       VARCHAR NOT NULL,
+     "status"     VARCHAR NOT NULL,
+     CONSTRAINT "seq_state_addressseq_state_address"
+        FOREIGN KEY("wallet_id", "slot")
+        REFERENCES "checkpoint"("wallet_id", "slot")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "seq_state_pending"
+  (
+     "wallet_id"  VARCHAR NOT NULL,
+     "pending_ix" INTEGER NOT NULL,
+     PRIMARY KEY ("wallet_id", "pending_ix"),
+     CONSTRAINT "seq_state_pending_ixseq_state_address_pending"
+        FOREIGN KEY("wallet_id")
+        REFERENCES "wallet"("wallet_id")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "rnd_state"
+  (
+     "wallet_id"     VARCHAR NOT NULL,
+     "account_ix"    INTEGER NOT NULL,
+     "gen"           VARCHAR NOT NULL,
+     "hd_passphrase" BLOB NOT NULL,
+     PRIMARY KEY ("wallet_id"),
+     CONSTRAINT "rnd_staternd_state"
+        FOREIGN KEY("wallet_id")
+        REFERENCES "wallet"("wallet_id")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "rnd_state_address"
+  (
+     "id"         INTEGER PRIMARY KEY,
+     "wallet_id"  VARCHAR NOT NULL,
+     "slot"       INTEGER NOT NULL,
+     "account_ix" INTEGER NOT NULL,
+     "address_ix" INTEGER NOT NULL,
+     "address"    VARCHAR NOT NULL,
+     "status"     VARCHAR NOT NULL,
+     CONSTRAINT "rnd_state_addressrnd_state_address"
+        FOREIGN KEY("wallet_id", "slot")
+        REFERENCES "checkpoint"("wallet_id", "slot")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "rnd_state_pending_address"
+  (
+     "id"         INTEGER PRIMARY KEY,
+     "wallet_id"  VARCHAR NOT NULL,
+     "account_ix" INTEGER NOT NULL,
+     "address_ix" INTEGER NOT NULL,
+     "address"    VARCHAR NOT NULL,
+     CONSTRAINT "rnd_state_pending_addressrnd_state_pending_address"
+        FOREIGN KEY ("wallet_id")
+        REFERENCES "wallet"("wallet_id")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "shared_state"
+  (
+     "wallet_id"         VARCHAR NOT NULL,
+     "account_xpub"      BLOB NOT NULL,
+     "pool_gap"          INTEGER NOT NULL,
+     "payment_script"    VARCHAR NOT NULL,
+     "delegation_script" VARCHAR NULL,
+     "derivation_prefix" VARCHAR NOT NULL,
+     PRIMARY KEY ("wallet_id"),
+     CONSTRAINT "shared_stateshared_state"
+        FOREIGN KEY("wallet_id")
+        REFERENCES "wallet"("wallet_id")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "shared_state_pending"
+  (
+     "wallet_id"  VARCHAR NOT NULL,
+     "pending_ix" INTEGER NOT NULL,
+     PRIMARY KEY ("wallet_id", "pending_ix"),
+     CONSTRAINT "shared_state_pending_ixshared_state_address_pending"
+        FOREIGN KEY("wallet_id")
+        REFERENCES "wallet"("wallet_id")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "cosigner_key"
+  (
+     "id"             INTEGER PRIMARY KEY,
+     "wallet_id"      VARCHAR NOT NULL,
+     "credential"     VARCHAR NOT NULL,
+     "account_xpub"   BLOB NOT NULL,
+     "cosigner_index" INTEGER NOT NULL,
+     CONSTRAINT "cosigner_keycosigner_key"
+        FOREIGN KEY("wallet_id")
+        REFERENCES "wallet"("wallet_id")
+        ON DELETE CASCADE
+  );
+
+CREATE TABLE IF NOT EXISTS "c_b_o_r"
+  (
+     "tx_id"   VARCHAR NOT NULL,
+     "tx_cbor" BLOB NOT NULL,
+     "tx_era"  INTEGER NOT NULL,
+     PRIMARY KEY ("tx_id")
+  )
+|]
+-- Don't put a semicolon ';' after the last "CREATE" statement,
+-- or the list created by 'split' will contain an empty statement.

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migration.hs
@@ -125,8 +125,16 @@ migration store = do
     conn <- asks dbConn
     r <- liftIO $ isFieldPresent conn $ DBField StakeKeyCertSlot
     case r of
-        TableMissing -> return ()
-        ColumnMissing -> return ()
+        TableMissing -> fail $ unwords
+            [ "Database migration from version 2 to version 3 failed:"
+            , "Expected TABLE stake_key_certificate"
+            , "to exist in database_schema_version 2"
+            ]
+        ColumnMissing -> fail $ unwords
+            [ "Database migration from version 2 to version 3 failed:"
+            , "Expected COLUMN slot of TABLE stake_key_certificate"
+            , "to exist in database_schema_version 2"
+            ]
         ColumnPresent -> withReaderT dbBackend $ do
             old <- readOldEncoding
             writeS store old

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Fixtures.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Fixtures.hs
@@ -140,11 +140,9 @@ withDBFromFile dbFile action =
             dbFile
             noManualMigration
             noMigration
-            noNewStyleMigrations
             action
   where
     noMigration = pure ()
-    noNewStyleMigrations _ _ = pure ()
 
 initializeWalletTable :: WalletId -> SqlPersistT IO ()
 initializeWalletTable wid = do


### PR DESCRIPTION
In order to improve the database initialization logic, this pull request refactors the `withLoadDBLayerFromFile` function to take full responsibility for running migrations on the database file.

- [x] A function `migrateDBFile` does what its name suggests.
- [x] `withLoadDBLayerFromFile ` calls `withSqliteContextFile` with empty migrations
- [x] The new-style migrations are removed from `withSqliteContextFile`

As the auto-migrations are no longer run when loading a database, we also need to adjust the `Migrations.Old` to explicitly create tables and columns in order to migrate a pre-version database to `SchemaVersion 1`.

As a result of these changes, we can make the migration from `SchemaVersion 2` to `SchemaVersion 3` more strict — it will now fail if a table that should be present in `SchemaVersion 2` cannot be found.

### Comments

* In a future pull request, `withBootDBLayerFromFile` and `newBootDBLayerInMemory` need to be adjusted as well, so that they call `withSqliteContextFile` with empty migrations.

### Issue

ADP-3214