### PR TITLE
[ADP-3214] Rename `Cardano.Pool.DB.Sqlite` to `Cardano.Pool.DB.Layer`

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
@@ -217,7 +217,7 @@ import System.IOManager
     ( withIOManager
     )
 
-import qualified Cardano.Pool.DB.Sqlite as Pool
+import qualified Cardano.Pool.DB.Layer as Pool
 import qualified Cardano.Wallet.Api.Http.Shelley.Server as Server
 import qualified Cardano.Wallet.DB.Layer as Sqlite
 import qualified Network.Wai.Handler.Warp as Warp

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -222,7 +222,7 @@ library
     Cardano.Pool.DB.Log
     Cardano.Pool.DB.Model
     Cardano.Pool.DB.MVar
-    Cardano.Pool.DB.Sqlite
+    Cardano.Pool.DB.Layer
     Cardano.Pool.DB.Sqlite.TH
     Cardano.Pool.Metadata
     Cardano.Pool.Metadata.Types
@@ -856,7 +856,7 @@ test-suite unit
     Cardano.Pool.DB.Arbitrary
     Cardano.Pool.DB.MVarSpec
     Cardano.Pool.DB.Properties
-    Cardano.Pool.DB.SqliteSpec
+    Cardano.Pool.DB.LayerSpec
     Cardano.Pool.RankSpec
     Cardano.Wallet.Address.Derivation.ByronSpec
     Cardano.Wallet.Address.Derivation.IcarusSpec

--- a/lib/wallet/src/Cardano/Pool/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Layer.hs
@@ -21,7 +21,7 @@
 -- License: Apache-2.0
 --
 -- An implementation of the DBLayer which uses Persistent and SQLite.
-module Cardano.Pool.DB.Sqlite
+module Cardano.Pool.DB.Layer
     ( newDBLayer
     , withDBLayer
     , withDecoratedDBLayer

--- a/lib/wallet/src/Cardano/Wallet/Pools.hs
+++ b/lib/wallet/src/Cardano/Wallet/Pools.hs
@@ -290,7 +290,7 @@ import UnliftIO.STM
     )
 
 import qualified Cardano.Pool.DB as PoolDb
-import qualified Cardano.Pool.DB.Sqlite as Pool
+import qualified Cardano.Pool.DB.Layer as Pool
 import qualified Cardano.Wallet.Checkpoints.Policy as CP
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Data.List as L

--- a/lib/wallet/test/integration/shelley-integration-test.hs
+++ b/lib/wallet/test/integration/shelley-integration-test.hs
@@ -228,7 +228,7 @@ import qualified Cardano.Address.Style.Shelley as Shelley
 import qualified Cardano.BM.Backend.EKGView as EKG
 import qualified Cardano.CLI as CLI
 import qualified Cardano.Pool.DB as Pool
-import qualified Cardano.Pool.DB.Sqlite as Pool
+import qualified Cardano.Pool.DB.Layer as Pool
 import qualified Cardano.Wallet.Faucet.Addresses as Addresses
 import qualified Cardano.Wallet.Faucet.Mnemonics as Mnemonics
 import qualified Cardano.Wallet.Launch.Cluster as Cluster

--- a/lib/wallet/test/unit/Cardano/Pool/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Pool/DB/LayerSpec.hs
@@ -7,7 +7,7 @@
 --
 -- DBLayer tests for SQLite implementation.
 
-module Cardano.Pool.DB.SqliteSpec
+module Cardano.Pool.DB.LayerSpec
     ( spec
     ) where
 
@@ -22,14 +22,14 @@ import Cardano.DB.Sqlite
 import Cardano.Pool.DB
     ( DBLayer (..)
     )
+import Cardano.Pool.DB.Layer
+    ( withDBLayer
+    )
 import Cardano.Pool.DB.Log
     ( PoolDbLog (..)
     )
 import Cardano.Pool.DB.Properties
     ( properties
-    )
-import Cardano.Pool.DB.Sqlite
-    ( withDBLayer
     )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( dummyTimeInterpreter


### PR DESCRIPTION
This pull request renames `Cardano.Pool.DB.Sqlite` → `Cardano.Pool.DB.Layer` for consistency with `Cardano.Wallet.DB.Layer`.

### Issue number

ADP-3214