### PR TITLE
Use consistent namespace for primitive types in `cardano-balance-tx`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -212,9 +212,6 @@ import Cardano.Ledger.Val
     ( coin
     , modifyCoin
     )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( txOutMaxCoin
-    )
 import Control.Arrow
     ( second
     , (>>>)
@@ -284,6 +281,9 @@ import qualified Cardano.Ledger.Keys as Ledger
 import qualified Cardano.Ledger.Shelley.API.Wallet as Shelley
 import qualified Cardano.Ledger.Shelley.UTxO as Shelley
 import qualified Cardano.Ledger.TxIn as Ledger
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+    ( txOutMaxCoin
+    )
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Data.Map as Map
 
@@ -716,7 +716,7 @@ computeMinimumCoinForTxOut era pp out = withConstraints era $
         :: TxOut (CardanoApi.ShelleyLedgerEra era)
         -> TxOut (CardanoApi.ShelleyLedgerEra era)
     withMaxLengthSerializedCoin =
-        modifyTxOutCoin era (const $ Convert.toLedger txOutMaxCoin)
+        modifyTxOutCoin era (const $ Convert.toLedger W.txOutMaxCoin)
 
 isBelowMinimumCoinForTxOut
     :: forall era. RecentEra era

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -85,9 +85,6 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin
     , txOutMaxTokenQuantity
     )
-import Cardano.Wallet.Primitive.Types.UTxO
-    ( UTxO (..)
-    )
 import Control.Arrow
     ( (&&&)
     )
@@ -149,6 +146,9 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (..)
     )
+import qualified Cardano.Wallet.Primitive.Types.UTxO as W
+    ( UTxO (..)
+    )
 import qualified Data.Map.Strict as Map
 
 --------------------------------------------------------------------------------
@@ -186,14 +186,14 @@ instance Buildable (WalletUTxO, W.TokenBundle) where
 toExternalUTxO :: (WalletUTxO, W.TokenBundle) -> (W.TxIn, W.TxOut)
 toExternalUTxO = toExternalUTxO' id
 
-toExternalUTxOMap :: Map WalletUTxO W.TokenBundle -> UTxO
-toExternalUTxOMap = UTxO . Map.fromList . fmap toExternalUTxO . Map.toList
+toExternalUTxOMap :: Map WalletUTxO W.TokenBundle -> W.UTxO
+toExternalUTxOMap = W.UTxO . Map.fromList . fmap toExternalUTxO . Map.toList
 
 toInternalUTxO :: (W.TxIn, W.TxOut) -> (WalletUTxO, W.TokenBundle)
 toInternalUTxO = toInternalUTxO' id
 
-toInternalUTxOMap :: UTxO -> Map WalletUTxO W.TokenBundle
-toInternalUTxOMap = Map.fromList . fmap toInternalUTxO . Map.toList . unUTxO
+toInternalUTxOMap :: W.UTxO -> Map WalletUTxO W.TokenBundle
+toInternalUTxOMap = Map.fromList . fmap toInternalUTxO . Map.toList . W.unUTxO
 
 toExternalUTxO' :: (b -> W.TokenBundle) -> (WalletUTxO, b) -> (W.TxIn, W.TxOut)
 toExternalUTxO' f (WalletUTxO i a, b) = (i, W.TxOut a (f b))

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -81,9 +81,6 @@ import Cardano.CoinSelection.UTxOSelection
 import Cardano.Wallet.Primitive.Collateral
     ( asCollateral
     )
-import Cardano.Wallet.Primitive.Types.Address
-    ( Address (..)
-    )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin
     , txOutMaxTokenQuantity
@@ -138,6 +135,9 @@ import Prelude
 
 import qualified Cardano.CoinSelection as Internal
 import qualified Cardano.CoinSelection.Context as SC
+import qualified Cardano.Wallet.Primitive.Types.Address as W
+    ( Address (..)
+    )
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin
     )
@@ -160,7 +160,7 @@ import qualified Data.Map.Strict as Map
 data WalletSelectionContext
 
 instance SC.SelectionContext WalletSelectionContext where
-    type Address WalletSelectionContext = Address
+    type Address WalletSelectionContext = W.Address
     type UTxO WalletSelectionContext = WalletUTxO
 
 --------------------------------------------------------------------------------
@@ -173,7 +173,7 @@ data WalletUTxO = WalletUTxO
     { txIn
         :: !TxIn
     , address
-        :: !Address
+        :: !W.Address
     }
     deriving (Eq, Generic, Ord, Show)
 
@@ -222,10 +222,10 @@ data SelectionConstraints = SelectionConstraints
         -- ^ Assesses the size of a token bundle relative to the upper limit of
         -- what can be included in a transaction output.
     , computeMinimumAdaQuantity
-        :: Address -> W.TokenMap -> W.Coin
+        :: W.Address -> W.TokenMap -> W.Coin
         -- ^ Computes the minimum ada quantity required for a given output.
     , isBelowMinimumAdaQuantity
-        :: Address -> W.TokenBundle -> Bool
+        :: W.Address -> W.TokenBundle -> Bool
       -- ^ Returns 'True' if the given 'TokenBundle' has a 'Coin' value that is
       -- below the minimum required.
     , computeMinimumCost
@@ -240,7 +240,7 @@ data SelectionConstraints = SelectionConstraints
         -- ^ Specifies the minimum required amount of collateral as a
         -- percentage of the total transaction fee.
     , maximumLengthChangeAddress
-        :: Address
+        :: W.Address
     }
     deriving Generic
 
@@ -256,7 +256,7 @@ toInternalSelectionConstraints SelectionConstraints {..} =
         , maximumOutputTokenQuantity =
             txOutMaxTokenQuantity
         , nullAddress =
-            Address ""
+            W.Address ""
         , ..
         }
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -89,7 +89,6 @@ import Cardano.Wallet.Primitive.Types.Coin
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId
-    , TokenMap
     )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin
@@ -148,6 +147,9 @@ import qualified Cardano.CoinSelection.Context as SC
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle (..)
+    )
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
+    ( TokenMap
     )
 import qualified Data.Map.Strict as Map
 
@@ -222,7 +224,7 @@ data SelectionConstraints = SelectionConstraints
         -- ^ Assesses the size of a token bundle relative to the upper limit of
         -- what can be included in a transaction output.
     , computeMinimumAdaQuantity
-        :: Address -> TokenMap -> Coin
+        :: Address -> W.TokenMap -> Coin
         -- ^ Computes the minimum ada quantity required for a given output.
     , isBelowMinimumAdaQuantity
         :: Address -> W.TokenBundle -> Bool
@@ -380,10 +382,10 @@ data SelectionOf change = Selection
         :: ![change]
         -- ^ Generated change outputs.
     , assetsToMint
-        :: !TokenMap
+        :: !W.TokenMap
         -- ^ Assets to mint.
     , assetsToBurn
-        :: !TokenMap
+        :: !W.TokenMap
         -- ^ Assets to burn.
     , extraCoinSource
         :: !Coin

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -84,9 +84,6 @@ import Cardano.Wallet.Primitive.Collateral
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     )
-import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..)
-    )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin
     , txOutMaxTokenQuantity
@@ -141,6 +138,9 @@ import Prelude
 
 import qualified Cardano.CoinSelection as Internal
 import qualified Cardano.CoinSelection.Context as SC
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+    ( Coin
+    )
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle (..)
@@ -222,14 +222,14 @@ data SelectionConstraints = SelectionConstraints
         -- ^ Assesses the size of a token bundle relative to the upper limit of
         -- what can be included in a transaction output.
     , computeMinimumAdaQuantity
-        :: Address -> W.TokenMap -> Coin
+        :: Address -> W.TokenMap -> W.Coin
         -- ^ Computes the minimum ada quantity required for a given output.
     , isBelowMinimumAdaQuantity
         :: Address -> W.TokenBundle -> Bool
       -- ^ Returns 'True' if the given 'TokenBundle' has a 'Coin' value that is
       -- below the minimum required.
     , computeMinimumCost
-        :: SelectionSkeleton -> Coin
+        :: SelectionSkeleton -> W.Coin
         -- ^ Computes the minimum cost of a given selection skeleton.
     , maximumCollateralInputCount
         :: Int
@@ -314,7 +314,7 @@ toInternalSelectionParams SelectionParams {..} =
     W.TokenBundle extraCoinIn  assetsToMint = extraValueIn
     W.TokenBundle extraCoinOut assetsToBurn = extraValueOut
 
-    identifyCollateral :: WalletUTxO -> W.TokenBundle -> Maybe Coin
+    identifyCollateral :: WalletUTxO -> W.TokenBundle -> Maybe W.Coin
     identifyCollateral (WalletUTxO _ a) b = asCollateral (TxOut a b)
 
 --------------------------------------------------------------------------------
@@ -386,10 +386,10 @@ data SelectionOf change = Selection
         :: !W.TokenMap
         -- ^ Assets to burn.
     , extraCoinSource
-        :: !Coin
+        :: !W.Coin
         -- ^ An extra source of ada.
     , extraCoinSink
-        :: !Coin
+        :: !W.Coin
         -- ^ An extra sink for ada.
     }
     deriving (Generic, Eq, Show)

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -81,10 +81,6 @@ import Cardano.CoinSelection.UTxOSelection
 import Cardano.Wallet.Primitive.Collateral
     ( asCollateral
     )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( txOutMaxCoin
-    , txOutMaxTokenQuantity
-    )
 import Control.Arrow
     ( (&&&)
     )
@@ -139,6 +135,10 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
     ( AssetId
     , TokenMap
+    )
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+    ( txOutMaxCoin
+    , txOutMaxTokenQuantity
     )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
     ( TxIn (..)
@@ -252,9 +252,9 @@ toInternalSelectionConstraints SelectionConstraints {..} =
         { computeMinimumCost =
             computeMinimumCost . toExternalSelectionSkeleton
         , maximumOutputAdaQuantity =
-            txOutMaxCoin
+            W.txOutMaxCoin
         , maximumOutputTokenQuantity =
-            txOutMaxTokenQuantity
+            W.txOutMaxTokenQuantity
         , nullAddress =
             W.Address ""
         , ..

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -87,9 +87,6 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId
-    )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin
     , txOutMaxTokenQuantity
@@ -149,7 +146,8 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle (..)
     )
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
-    ( TokenMap
+    ( AssetId
+    , TokenMap
     )
 import qualified Data.Map.Strict as Map
 
@@ -339,7 +337,7 @@ data SelectionSkeleton = SelectionSkeleton
     , skeletonOutputs
         :: ![TxOut]
     , skeletonChange
-        :: ![Set AssetId]
+        :: ![Set W.AssetId]
     }
     deriving (Eq, Generic, Show)
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -85,9 +85,6 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( txOutMaxCoin
     , txOutMaxTokenQuantity
     )
-import Cardano.Wallet.Primitive.Types.Tx.TxIn
-    ( TxIn
-    )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
     )
@@ -149,6 +146,9 @@ import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
     ( AssetId
     , TokenMap
     )
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
+    ( TxIn (..)
+    )
 import qualified Data.Map.Strict as Map
 
 --------------------------------------------------------------------------------
@@ -171,7 +171,7 @@ instance SC.SelectionContext WalletSelectionContext where
 --
 data WalletUTxO = WalletUTxO
     { txIn
-        :: !TxIn
+        :: !W.TxIn
     , address
         :: !W.Address
     }
@@ -183,22 +183,22 @@ instance Buildable WalletUTxO where
 instance Buildable (WalletUTxO, W.TokenBundle) where
     build (u, b) = build u <> ":" <> build (W.TokenBundle.Flat b)
 
-toExternalUTxO :: (WalletUTxO, W.TokenBundle) -> (TxIn, TxOut)
+toExternalUTxO :: (WalletUTxO, W.TokenBundle) -> (W.TxIn, TxOut)
 toExternalUTxO = toExternalUTxO' id
 
 toExternalUTxOMap :: Map WalletUTxO W.TokenBundle -> UTxO
 toExternalUTxOMap = UTxO . Map.fromList . fmap toExternalUTxO . Map.toList
 
-toInternalUTxO :: (TxIn, TxOut) -> (WalletUTxO, W.TokenBundle)
+toInternalUTxO :: (W.TxIn, TxOut) -> (WalletUTxO, W.TokenBundle)
 toInternalUTxO = toInternalUTxO' id
 
 toInternalUTxOMap :: UTxO -> Map WalletUTxO W.TokenBundle
 toInternalUTxOMap = Map.fromList . fmap toInternalUTxO . Map.toList . unUTxO
 
-toExternalUTxO' :: (b -> W.TokenBundle) -> (WalletUTxO, b) -> (TxIn, TxOut)
+toExternalUTxO' :: (b -> W.TokenBundle) -> (WalletUTxO, b) -> (W.TxIn, TxOut)
 toExternalUTxO' f (WalletUTxO i a, b) = (i, TxOut a (f b))
 
-toInternalUTxO' :: (W.TokenBundle -> b) -> (TxIn, TxOut) -> (WalletUTxO, b)
+toInternalUTxO' :: (W.TokenBundle -> b) -> (W.TxIn, TxOut) -> (WalletUTxO, b)
 toInternalUTxO' f (i, TxOut a b) = (WalletUTxO i a, f b)
 
 --------------------------------------------------------------------------------
@@ -368,10 +368,10 @@ toExternalSelectionSkeleton Internal.SelectionSkeleton {..} =
 --
 data SelectionOf change = Selection
     { inputs
-        :: !(NonEmpty (TxIn, TxOut))
+        :: !(NonEmpty (W.TxIn, TxOut))
         -- ^ Selected inputs.
     , collateral
-        :: ![(TxIn, TxOut)]
+        :: ![(W.TxIn, TxOut)]
         -- ^ Selected collateral inputs.
     , outputs
         :: ![TxOut]

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection/Gen.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection/Gen.hs
@@ -9,11 +9,6 @@ module Internal.Cardano.Write.Tx.Balance.CoinSelection.Gen
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
-    ( genTxIn
-    , genTxInLargeRange
-    , shrinkTxIn
-    )
 import Generics.SOP
     ( NP (..)
     )
@@ -33,6 +28,7 @@ import Test.QuickCheck.Extra
     )
 
 import qualified Cardano.Wallet.Primitive.Types.Address.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen as W
 
 --------------------------------------------------------------------------------
 -- Wallet UTxO identifiers chosen according to the size parameter
@@ -42,11 +38,11 @@ coarbitraryWalletUTxO :: WalletUTxO -> Gen a -> Gen a
 coarbitraryWalletUTxO = coarbitrary . show
 
 genWalletUTxO :: Gen WalletUTxO
-genWalletUTxO = uncurry WalletUTxO <$> genSized2 genTxIn W.genAddress
+genWalletUTxO = uncurry WalletUTxO <$> genSized2 W.genTxIn W.genAddress
 
 shrinkWalletUTxO :: WalletUTxO -> [WalletUTxO]
 shrinkWalletUTxO = genericRoundRobinShrink
-    <@> shrinkTxIn
+    <@> W.shrinkTxIn
     <:> W.shrinkAddress
     <:> Nil
 
@@ -58,4 +54,4 @@ genWalletUTxOFunction = genFunction coarbitraryWalletUTxO
 --------------------------------------------------------------------------------
 
 genWalletUTxOLargeRange :: Gen WalletUTxO
-genWalletUTxOLargeRange = WalletUTxO <$> genTxInLargeRange <*> W.genAddress
+genWalletUTxOLargeRange = WalletUTxO <$> W.genTxInLargeRange <*> W.genAddress

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection/Gen.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection/Gen.hs
@@ -9,10 +9,6 @@ module Internal.Cardano.Write.Tx.Balance.CoinSelection.Gen
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.Address.Gen
-    ( genAddress
-    , shrinkAddress
-    )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
     ( genTxIn
     , genTxInLargeRange
@@ -36,6 +32,8 @@ import Test.QuickCheck.Extra
     , (<@>)
     )
 
+import qualified Cardano.Wallet.Primitive.Types.Address.Gen as W
+
 --------------------------------------------------------------------------------
 -- Wallet UTxO identifiers chosen according to the size parameter
 --------------------------------------------------------------------------------
@@ -44,12 +42,12 @@ coarbitraryWalletUTxO :: WalletUTxO -> Gen a -> Gen a
 coarbitraryWalletUTxO = coarbitrary . show
 
 genWalletUTxO :: Gen WalletUTxO
-genWalletUTxO = uncurry WalletUTxO <$> genSized2 genTxIn genAddress
+genWalletUTxO = uncurry WalletUTxO <$> genSized2 genTxIn W.genAddress
 
 shrinkWalletUTxO :: WalletUTxO -> [WalletUTxO]
 shrinkWalletUTxO = genericRoundRobinShrink
     <@> shrinkTxIn
-    <:> shrinkAddress
+    <:> W.shrinkAddress
     <:> Nil
 
 genWalletUTxOFunction :: Gen a -> Gen (WalletUTxO -> a)
@@ -60,4 +58,4 @@ genWalletUTxOFunction = genFunction coarbitraryWalletUTxO
 --------------------------------------------------------------------------------
 
 genWalletUTxOLargeRange :: Gen WalletUTxO
-genWalletUTxOLargeRange = WalletUTxO <$> genTxInLargeRange <*> genAddress
+genWalletUTxOLargeRange = WalletUTxO <$> genTxInLargeRange <*> W.genAddress

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/TokenBundleSize.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/TokenBundleSize.hs
@@ -22,9 +22,6 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary
     ( serialize
     )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TxSize (..)
-    )
 import Control.Lens
     ( (^.)
     )
@@ -43,6 +40,9 @@ import Internal.Cardano.Write.Tx
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle
     )
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+    ( TxSize (..)
+    )
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Data.ByteString.Lazy as BL
 
@@ -60,8 +60,8 @@ mkTokenBundleSizeAssessor era pp = TokenBundleSizeAssessor $ \tb ->
     then TokenBundleSizeExceedsLimit
     else TokenBundleSizeWithinLimit
   where
-    maxValSize :: TxSize
-    maxValSize = TxSize $ withConstraints era $ pp ^. ppMaxValSizeL
+    maxValSize :: W.TxSize
+    maxValSize = W.TxSize $ withConstraints era $ pp ^. ppMaxValSizeL
 
     ver :: Version
     ver = withConstraints era $ pvMajor $ pp ^. ppProtocolVersionL
@@ -69,11 +69,11 @@ mkTokenBundleSizeAssessor era pp = TokenBundleSizeAssessor $ \tb ->
 computeTokenBundleSerializedLengthBytes
     :: W.TokenBundle
     -> Version
-    -> TxSize
+    -> W.TxSize
 computeTokenBundleSerializedLengthBytes tb ver = serSize (Convert.toLedger tb)
   where
-    serSize :: Value -> TxSize
-    serSize v = maybe err TxSize
+    serSize :: Value -> W.TxSize
+    serSize v = maybe err W.TxSize
         . intCastMaybe
         . BL.length
         $ serialize ver v

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/TokenBundleSize.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/TokenBundleSize.hs
@@ -40,7 +40,9 @@ import Internal.Cardano.Write.Tx
     , withConstraints
     )
 
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
+    ( TokenBundle
+    )
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Data.ByteString.Lazy as BL
 
@@ -65,7 +67,7 @@ mkTokenBundleSizeAssessor era pp = TokenBundleSizeAssessor $ \tb ->
     ver = withConstraints era $ pvMajor $ pp ^. ppProtocolVersionL
 
 computeTokenBundleSerializedLengthBytes
-    :: TokenBundle.TokenBundle
+    :: W.TokenBundle
     -> Version
     -> TxSize
 computeTokenBundleSerializedLengthBytes tb ver = serSize (Convert.toLedger tb)

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
@@ -46,9 +46,6 @@ import Cardano.Slotting.EpochInfo
     ( EpochInfo
     , hoistEpochInfo
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( TokenPolicyId
-    )
 import Codec.Serialise
     ( deserialiseOrFail
     )
@@ -277,7 +274,7 @@ assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
 
 data Redeemer
     = RedeemerSpending ByteString W.TxIn
-    | RedeemerMinting ByteString TokenPolicyId
+    | RedeemerMinting ByteString W.TokenPolicyId
     | RedeemerRewarding ByteString CardanoApi.StakeAddress
     deriving (Eq, Generic, Show)
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -41,9 +41,6 @@ import Cardano.Ledger.Credential
 import Cardano.Ledger.UTxO
     ( txinLookup
     )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TxSize (..)
-    )
 import Control.Lens
     ( view
     , (&)
@@ -80,6 +77,9 @@ import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..)
     )
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+    ( TxSize (..)
+    )
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Data.Foldable as F
 import qualified Data.List as L
@@ -94,7 +94,7 @@ estimateSignedTxSize
     -> PParams (ShelleyLedgerEra era)
     -> KeyWitnessCount
     -> Tx (ShelleyLedgerEra era) -- ^ existing wits in tx are ignored
-    -> TxSize
+    -> W.TxSize
 estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
     let
         -- Hack which allows us to rely on the ledger to calculate the size of
@@ -102,10 +102,10 @@ estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
         feeOfWits :: W.Coin
         feeOfWits = minfee nWits <\> minfee mempty
 
-        sizeOfWits :: TxSize
+        sizeOfWits :: W.TxSize
         sizeOfWits =
             case feeOfWits `coinQuotRem` feePerByte of
-                (n, 0) -> TxSize n
+                (n, 0) -> W.TxSize n
                 (_, _) -> error $ unwords
                     [ "estimateSignedTxSize:"
                     , "the impossible happened!"
@@ -118,9 +118,9 @@ estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
                     , "lovelace/byte"
                     ]
 
-        sizeOfTx :: TxSize
+        sizeOfTx :: W.TxSize
         sizeOfTx = withConstraints era
-            $ fromIntegral @Integer @TxSize
+            $ fromIntegral @Integer @W.TxSize
             $ unsignedTx ^. sizeTxF
     in
         sizeOfTx <> sizeOfWits

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -41,9 +41,6 @@ import Cardano.Ledger.Credential
 import Cardano.Ledger.UTxO
     ( txinLookup
     )
-import qualified Cardano.Wallet.Primitive.Types.Coin as W
-    ( Coin (..)
-    )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxSize (..)
     )
@@ -80,6 +77,9 @@ import qualified Cardano.Api.Byron as CardanoApi
 import qualified Cardano.Api.Shelley as CardanoApi
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+    ( Coin (..)
+    )
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Data.Foldable as F
 import qualified Data.List as L

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -48,9 +48,6 @@ import Prelude
 import Cardano.Address.Script
     ( Script (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( TokenName (..)
-    )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxSize (..)
     )
@@ -87,6 +84,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
     ( AssetId (..)
     )
+import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
@@ -333,7 +331,7 @@ estimateTxSize skeleton =
 
     -- asset_name = bytes .size (0..32)
     sizeOf_AssetName name
-        = 2 + fromIntegral (BS.length $ unTokenName name)
+        = 2 + fromIntegral (BS.length $ W.unTokenName name)
 
     -- Coins can really vary so it's very punishing to always assign them the
     -- upper bound. They will typically be between 3 and 9 bytes (only 6 bytes

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -54,9 +54,6 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
-    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (..)
     )
@@ -87,6 +84,10 @@ import Numeric.Natural
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
+    ( AssetId
+    , TokenMap
+    )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
@@ -110,7 +111,7 @@ data TxSkeleton = TxSkeleton
     { txWitnessTag :: !TxWitnessTag
     , txInputCount :: !Int
     , txOutputs :: ![W.TxOut]
-    , txChange :: ![Set AssetId]
+    , txChange :: ![Set W.AssetId]
     , txPaymentTemplate :: !(Maybe (CA.Script CA.Cosigner))
     }
     deriving (Eq, Show, Generic)

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -86,7 +86,7 @@ import Numeric.Natural
 
 import qualified Cardano.Address.Script as CA
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
@@ -271,8 +271,8 @@ estimateTxSize skeleton =
         + sizeOf_Address address
         + sizeOf_SmallUInt
         + sizeOf_SmallArray
-        + sizeOf_Coin (TokenBundle.getCoin tokens)
-        + sumVia sizeOf_NativeAsset (TokenBundle.getAssets tokens)
+        + sizeOf_Coin (W.TokenBundle.getCoin tokens)
+        + sumVia sizeOf_NativeAsset (W.TokenBundle.getAssets tokens)
 
     sizeOf_Output
         = sizeOf_PostAlonzoTransactionOutput

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -48,9 +48,6 @@ import Prelude
 import Cardano.Address.Script
     ( Script (..)
     )
-import Cardano.Wallet.Primitive.Types.Address
-    ( Address (..)
-    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (..)
     )
@@ -79,6 +76,9 @@ import Numeric.Natural
     )
 
 import qualified Cardano.Address.Script as CA
+import qualified Cardano.Wallet.Primitive.Types.Address as W
+    ( Address (..)
+    )
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..)
     )
@@ -301,7 +301,7 @@ estimateTxSize skeleton =
 
     -- We carry addresses already serialized, so it's a matter of measuring.
     sizeOf_Address addr
-        = 2 + fromIntegral (BS.length (unAddress addr))
+        = 2 + fromIntegral (BS.length (W.unAddress addr))
 
     -- For change address, we consider the worst-case scenario based on the
     -- given wallet scheme. Byron addresses are larger.

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -51,9 +51,6 @@ import Cardano.Address.Script
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     )
-import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..)
-    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (..)
     )
@@ -82,7 +79,10 @@ import Numeric.Natural
     )
 
 import qualified Cardano.Address.Script as CA
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+    ( Coin (..)
+    )
+import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
     ( AssetId (..)
@@ -118,12 +118,12 @@ data TxSkeleton = TxSkeleton
 -- | Estimates the final cost of a transaction based on its skeleton.
 --
 -- The constant tx fee is /not/ included in the result of this function.
-estimateTxCost :: FeePerByte -> TxSkeleton -> Coin
+estimateTxCost :: FeePerByte -> TxSkeleton -> W.Coin
 estimateTxCost (FeePerByte feePerByte) skeleton =
     computeFee (estimateTxSize skeleton)
   where
-    computeFee :: TxSize -> Coin
-    computeFee (TxSize size) = Coin $ feePerByte * size
+    computeFee :: TxSize -> W.Coin
+    computeFee (TxSize size) = W.Coin $ feePerByte * size
 
 -- | Estimates the final size of a transaction based on its skeleton.
 --
@@ -346,7 +346,7 @@ estimateTxSize skeleton =
         . BS.length
         . CBOR.toStrictByteString
         . CBOR.encodeWord64
-        . Coin.unsafeToWord64
+        . W.Coin.unsafeToWord64
 
     determinePaymentTemplateSize scriptCosigner
         = sizeOf_Array

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -85,8 +85,7 @@ import qualified Cardano.Address.Script as CA
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
-    ( AssetId
-    , TokenMap
+    ( AssetId (..)
     )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 import qualified Codec.CBOR.Encoding as CBOR
@@ -278,7 +277,7 @@ estimateTxSize skeleton =
     sizeOf_Output
         = sizeOf_PostAlonzoTransactionOutput
 
-    sizeOf_ChangeOutput :: Set AssetId -> TxSize
+    sizeOf_ChangeOutput :: Set W.AssetId -> TxSize
     sizeOf_ChangeOutput
         = sizeOf_PostAlonzoChangeOutput
 
@@ -290,7 +289,7 @@ estimateTxSize skeleton =
     --   }
     -- value =
     --   coin / [coin,multiasset<uint>]
-    sizeOf_PostAlonzoChangeOutput :: Set AssetId -> TxSize
+    sizeOf_PostAlonzoChangeOutput :: Set W.AssetId -> TxSize
     sizeOf_PostAlonzoChangeOutput xs
         = sizeOf_SmallMap
         + sizeOf_SmallUInt
@@ -319,7 +318,7 @@ estimateTxSize skeleton =
     -- We consider "native asset" to just be the "multiasset<uint>" part of the
     -- above, hence why we don't also include the size of the coin. Where this
     -- is used, the size of the coin and array are are added too.
-    sizeOf_NativeAsset AssetId{tokenName}
+    sizeOf_NativeAsset W.AssetId {tokenName}
         = sizeOf_MultiAsset sizeOf_LargeUInt tokenName
 
     -- multiasset<a> = { * policy_id => { * asset_name => a } }

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
@@ -9,10 +9,6 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Address.Gen
     ( genAddress
     )
-import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoin
-    , shrinkCoin
-    )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn
     )
@@ -81,6 +77,7 @@ import Test.Utils.Pretty
     ( (====)
     )
 
+import qualified Cardano.Wallet.Primitive.Types.Coin.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap.Gen as W
@@ -144,9 +141,10 @@ genSelection = Selection
     genChange = listOf W.genTokenBundle
     genAssetsToMint = W.genTokenMap
     genAssetsToBurn = W.genTokenMap
-    genExtraCoinSource = genCoin
-    genExtraCoinSink = genCoin
-    genTxOutCoin = TxOut <$> genAddress <*> (W.TokenBundle.fromCoin <$> genCoin)
+    genExtraCoinSource = W.genCoin
+    genExtraCoinSink = W.genCoin
+    genTxOutCoin =
+        TxOut <$> genAddress <*> (W.TokenBundle.fromCoin <$> W.genCoin)
 
 shrinkSelection :: Selection -> [Selection]
 shrinkSelection = genericRoundRobinShrink
@@ -166,8 +164,8 @@ shrinkSelection = genericRoundRobinShrink
     shrinkChange = shrinkList W.shrinkTokenBundle
     shrinkAssetsToMint = W.shrinkTokenMap
     shrinkAssetsToBurn = W.shrinkTokenMap
-    shrinkExtraCoinSource = shrinkCoin
-    shrinkExtraCoinSink = shrinkCoin
+    shrinkExtraCoinSource = W.shrinkCoin
+    shrinkExtraCoinSink = W.shrinkCoin
 
 --------------------------------------------------------------------------------
 -- Arbitrary instances

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
@@ -13,10 +13,6 @@ import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoin
     , shrinkCoin
     )
-import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genTokenMap
-    , shrinkTokenMap
-    )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn
     )
@@ -87,6 +83,7 @@ import Test.Utils.Pretty
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.TokenMap.Gen as W
 
 spec :: Spec
 spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
@@ -145,8 +142,8 @@ genSelection = Selection
     genCollateral = listOf ((,) <$> genTxIn <*> genTxOutCoin)
     genOutputs = listOf genTxOut
     genChange = listOf W.genTokenBundle
-    genAssetsToMint = genTokenMap
-    genAssetsToBurn = genTokenMap
+    genAssetsToMint = W.genTokenMap
+    genAssetsToBurn = W.genTokenMap
     genExtraCoinSource = genCoin
     genExtraCoinSink = genCoin
     genTxOutCoin = TxOut <$> genAddress <*> (W.TokenBundle.fromCoin <$> genCoin)
@@ -167,8 +164,8 @@ shrinkSelection = genericRoundRobinShrink
     shrinkCollateral = shrinkList (liftShrink2 shrinkTxIn shrinkTxOut)
     shrinkOutputs = shrinkList shrinkTxOut
     shrinkChange = shrinkList W.shrinkTokenBundle
-    shrinkAssetsToMint = shrinkTokenMap
-    shrinkAssetsToBurn = shrinkTokenMap
+    shrinkAssetsToMint = W.shrinkTokenMap
+    shrinkAssetsToBurn = W.shrinkTokenMap
     shrinkExtraCoinSource = shrinkCoin
     shrinkExtraCoinSink = shrinkCoin
 

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
@@ -6,14 +6,6 @@ module Internal.Cardano.Write.Tx.Balance.CoinSelectionSpec
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.UTxO
-    ( UTxO
-    )
-import Cardano.Wallet.Primitive.Types.UTxO.Gen
-    ( genUTxO
-    , genUTxOLarge
-    , shrinkUTxO
-    )
 import Data.Function
     ( (&)
     )
@@ -69,12 +61,16 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.UTxO as W
+    ( UTxO (..)
+    )
+import qualified Cardano.Wallet.Primitive.Types.UTxO.Gen as W
 
 spec :: Spec
 spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
 
     parallel $ describe
-        "Conversion between external (wallet) and internal UTxOs" $ do
+        "Conversion between external (wallet) and internal W.UTxOs" $ do
 
         it "prop_toInternalUTxO_toExternalUTxO" $
             prop_toInternalUTxO_toExternalUTxO & property
@@ -96,7 +92,7 @@ prop_toInternalUTxO_toExternalUTxO :: W.TxIn -> W.TxOut -> Property
 prop_toInternalUTxO_toExternalUTxO i o =
     (toExternalUTxO . toInternalUTxO) (i, o) === (i, o)
 
-prop_toInternalUTxOMap_toExternalUTxOMap :: UTxO -> Property
+prop_toInternalUTxOMap_toExternalUTxOMap :: W.UTxO -> Property
 prop_toInternalUTxOMap_toExternalUTxOMap u =
     (toExternalUTxOMap . toInternalUTxOMap) u === u
 
@@ -171,9 +167,9 @@ instance Arbitrary W.TxOut where
     arbitrary = W.genTxOut
     shrink = W.shrinkTxOut
 
-instance Arbitrary UTxO where
+instance Arbitrary W.UTxO where
     arbitrary = oneof
-        [ genUTxO
-        , genUTxOLarge
+        [ W.genUTxO
+        , W.genUTxOLarge
         ]
-    shrink = shrinkUTxO
+    shrink = W.shrinkUTxO

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
@@ -6,13 +6,6 @@ module Internal.Cardano.Write.Tx.Balance.CoinSelectionSpec
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.Tx.TxOut
-    ( TxOut (..)
-    )
-import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
-    ( genTxOut
-    , shrinkTxOut
-    )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO
     )
@@ -74,6 +67,8 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as W
 
 spec :: Spec
 spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
@@ -97,7 +92,7 @@ spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
 -- Conversion between external (wallet) and internal UTxOs
 --------------------------------------------------------------------------------
 
-prop_toInternalUTxO_toExternalUTxO :: W.TxIn -> TxOut -> Property
+prop_toInternalUTxO_toExternalUTxO :: W.TxIn -> W.TxOut -> Property
 prop_toInternalUTxO_toExternalUTxO i o =
     (toExternalUTxO . toInternalUTxO) (i, o) === (i, o)
 
@@ -128,16 +123,16 @@ genSelection = Selection
     <*> genExtraCoinSource
     <*> genExtraCoinSink
   where
-    genInputs = genNonEmpty ((,) <$> W.genTxIn <*> genTxOut)
+    genInputs = genNonEmpty ((,) <$> W.genTxIn <*> W.genTxOut)
     genCollateral = listOf ((,) <$> W.genTxIn <*> genTxOutCoin)
-    genOutputs = listOf genTxOut
+    genOutputs = listOf W.genTxOut
     genChange = listOf W.genTokenBundle
     genAssetsToMint = W.genTokenMap
     genAssetsToBurn = W.genTokenMap
     genExtraCoinSource = W.genCoin
     genExtraCoinSink = W.genCoin
     genTxOutCoin =
-        TxOut <$> W.genAddress <*> (W.TokenBundle.fromCoin <$> W.genCoin)
+        W.TxOut <$> W.genAddress <*> (W.TokenBundle.fromCoin <$> W.genCoin)
 
 shrinkSelection :: Selection -> [Selection]
 shrinkSelection = genericRoundRobinShrink
@@ -151,9 +146,9 @@ shrinkSelection = genericRoundRobinShrink
     <:> shrinkExtraCoinSink
     <:> Nil
   where
-    shrinkInputs = shrinkNonEmpty (liftShrink2 W.shrinkTxIn shrinkTxOut)
-    shrinkCollateral = shrinkList (liftShrink2 W.shrinkTxIn shrinkTxOut)
-    shrinkOutputs = shrinkList shrinkTxOut
+    shrinkInputs = shrinkNonEmpty (liftShrink2 W.shrinkTxIn W.shrinkTxOut)
+    shrinkCollateral = shrinkList (liftShrink2 W.shrinkTxIn W.shrinkTxOut)
+    shrinkOutputs = shrinkList W.shrinkTxOut
     shrinkChange = shrinkList W.shrinkTokenBundle
     shrinkAssetsToMint = W.shrinkTokenMap
     shrinkAssetsToBurn = W.shrinkTokenMap
@@ -172,9 +167,9 @@ instance Arbitrary W.TxIn where
     arbitrary = W.genTxIn
     shrink = W.shrinkTxIn
 
-instance Arbitrary TxOut where
-    arbitrary = genTxOut
-    shrink = shrinkTxOut
+instance Arbitrary W.TxOut where
+    arbitrary = W.genTxOut
+    shrink = W.shrinkTxOut
 
 instance Arbitrary UTxO where
     arbitrary = oneof

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
@@ -6,9 +6,6 @@ module Internal.Cardano.Write.Tx.Balance.CoinSelectionSpec
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.Address.Gen
-    ( genAddress
-    )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn
     )
@@ -77,6 +74,7 @@ import Test.Utils.Pretty
     ( (====)
     )
 
+import qualified Cardano.Wallet.Primitive.Types.Address.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.Coin.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
@@ -144,7 +142,7 @@ genSelection = Selection
     genExtraCoinSource = W.genCoin
     genExtraCoinSink = W.genCoin
     genTxOutCoin =
-        TxOut <$> genAddress <*> (W.TokenBundle.fromCoin <$> W.genCoin)
+        TxOut <$> W.genAddress <*> (W.TokenBundle.fromCoin <$> W.genCoin)
 
 shrinkSelection :: Selection -> [Selection]
 shrinkSelection = genericRoundRobinShrink

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
@@ -6,13 +6,6 @@ module Internal.Cardano.Write.Tx.Balance.CoinSelectionSpec
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.Tx.TxIn
-    ( TxIn
-    )
-import Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen
-    ( genTxIn
-    , shrinkTxIn
-    )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
     )
@@ -79,6 +72,8 @@ import qualified Cardano.Wallet.Primitive.Types.Coin.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen as W
 
 spec :: Spec
 spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
@@ -102,7 +97,7 @@ spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
 -- Conversion between external (wallet) and internal UTxOs
 --------------------------------------------------------------------------------
 
-prop_toInternalUTxO_toExternalUTxO :: TxIn -> TxOut -> Property
+prop_toInternalUTxO_toExternalUTxO :: W.TxIn -> TxOut -> Property
 prop_toInternalUTxO_toExternalUTxO i o =
     (toExternalUTxO . toInternalUTxO) (i, o) === (i, o)
 
@@ -133,8 +128,8 @@ genSelection = Selection
     <*> genExtraCoinSource
     <*> genExtraCoinSink
   where
-    genInputs = genNonEmpty ((,) <$> genTxIn <*> genTxOut)
-    genCollateral = listOf ((,) <$> genTxIn <*> genTxOutCoin)
+    genInputs = genNonEmpty ((,) <$> W.genTxIn <*> genTxOut)
+    genCollateral = listOf ((,) <$> W.genTxIn <*> genTxOutCoin)
     genOutputs = listOf genTxOut
     genChange = listOf W.genTokenBundle
     genAssetsToMint = W.genTokenMap
@@ -156,8 +151,8 @@ shrinkSelection = genericRoundRobinShrink
     <:> shrinkExtraCoinSink
     <:> Nil
   where
-    shrinkInputs = shrinkNonEmpty (liftShrink2 shrinkTxIn shrinkTxOut)
-    shrinkCollateral = shrinkList (liftShrink2 shrinkTxIn shrinkTxOut)
+    shrinkInputs = shrinkNonEmpty (liftShrink2 W.shrinkTxIn shrinkTxOut)
+    shrinkCollateral = shrinkList (liftShrink2 W.shrinkTxIn shrinkTxOut)
     shrinkOutputs = shrinkList shrinkTxOut
     shrinkChange = shrinkList W.shrinkTokenBundle
     shrinkAssetsToMint = W.shrinkTokenMap
@@ -173,9 +168,9 @@ instance Arbitrary Selection where
     arbitrary = genSelection
     shrink = shrinkSelection
 
-instance Arbitrary TxIn where
-    arbitrary = genTxIn
-    shrink = shrinkTxIn
+instance Arbitrary W.TxIn where
+    arbitrary = W.genTxIn
+    shrink = W.shrinkTxIn
 
 instance Arbitrary TxOut where
     arbitrary = genTxOut

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
@@ -13,10 +13,6 @@ import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoin
     , shrinkCoin
     )
-import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
-    ( genTokenBundle
-    , shrinkTokenBundle
-    )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genTokenMap
     , shrinkTokenMap
@@ -89,7 +85,8 @@ import Test.Utils.Pretty
     ( (====)
     )
 
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
 
 spec :: Spec
 spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
@@ -147,12 +144,12 @@ genSelection = Selection
     genInputs = genNonEmpty ((,) <$> genTxIn <*> genTxOut)
     genCollateral = listOf ((,) <$> genTxIn <*> genTxOutCoin)
     genOutputs = listOf genTxOut
-    genChange = listOf genTokenBundle
+    genChange = listOf W.genTokenBundle
     genAssetsToMint = genTokenMap
     genAssetsToBurn = genTokenMap
     genExtraCoinSource = genCoin
     genExtraCoinSink = genCoin
-    genTxOutCoin = TxOut <$> genAddress <*> (TokenBundle.fromCoin <$> genCoin)
+    genTxOutCoin = TxOut <$> genAddress <*> (W.TokenBundle.fromCoin <$> genCoin)
 
 shrinkSelection :: Selection -> [Selection]
 shrinkSelection = genericRoundRobinShrink
@@ -169,7 +166,7 @@ shrinkSelection = genericRoundRobinShrink
     shrinkInputs = shrinkNonEmpty (liftShrink2 shrinkTxIn shrinkTxOut)
     shrinkCollateral = shrinkList (liftShrink2 shrinkTxIn shrinkTxOut)
     shrinkOutputs = shrinkList shrinkTxOut
-    shrinkChange = shrinkList shrinkTokenBundle
+    shrinkChange = shrinkList W.shrinkTokenBundle
     shrinkAssetsToMint = shrinkTokenMap
     shrinkAssetsToBurn = shrinkTokenMap
     shrinkExtraCoinSource = shrinkCoin

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -22,9 +22,6 @@ import Cardano.Wallet.Primitive.Types.Tx.Constraints
     , txOutMaxCoin
     , txOutMinCoin
     )
-import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
-    ( genTxOutTokenBundle
-    )
 import Control.Lens
     ( (&)
     , (.~)
@@ -82,6 +79,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle
     )
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as W
 
 spec :: Spec
 spec = describe "Assessing the sizes of token bundles" $ do
@@ -244,19 +242,19 @@ newtype VariableSize1024 a = VariableSize1024 { unVariableSize1024 :: a}
     deriving (Eq, Show)
 
 instance Arbitrary (FixedSize32 W.TokenBundle) where
-    arbitrary = FixedSize32 <$> genTxOutTokenBundle 32
+    arbitrary = FixedSize32 <$> W.genTxOutTokenBundle 32
     -- No shrinking
 
 instance Arbitrary (FixedSize48 W.TokenBundle) where
-    arbitrary = FixedSize48 <$> genTxOutTokenBundle 48
+    arbitrary = FixedSize48 <$> W.genTxOutTokenBundle 48
     -- No shrinking
 
 instance Arbitrary (FixedSize64 W.TokenBundle) where
-    arbitrary = FixedSize64 <$> genTxOutTokenBundle 64
+    arbitrary = FixedSize64 <$> W.genTxOutTokenBundle 64
     -- No shrinking
 
 instance Arbitrary (FixedSize128 W.TokenBundle) where
-    arbitrary = FixedSize128 <$> genTxOutTokenBundle 128
+    arbitrary = FixedSize128 <$> W.genTxOutTokenBundle 128
     -- No shrinking
 
 instance Arbitrary (VariableSize16 W.TokenBundle) where

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -17,11 +17,6 @@ import Cardano.Ledger.Api.PParams
     , ppMaxValSizeL
     , ppProtocolVersionL
     )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TxSize (..)
-    , txOutMaxCoin
-    , txOutMinCoin
-    )
 import Control.Lens
     ( (&)
     , (.~)
@@ -79,6 +74,11 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle
     )
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+    ( TxSize (..)
+    , txOutMaxCoin
+    , txOutMinCoin
+    )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as W
 
 spec :: Spec
@@ -112,7 +112,7 @@ prop_assessTokenBundleSize_enlarge b1' b2' pp =
     assess b1 == TokenBundleSizeExceedsLimit ==> conjoin
         [ assess (b1 <> b2)
             === TokenBundleSizeExceedsLimit
-        , assess (b1 `W.TokenBundle.setCoin` txOutMaxCoin)
+        , assess (b1 `W.TokenBundle.setCoin` W.txOutMaxCoin)
             === TokenBundleSizeExceedsLimit
         ]
   where
@@ -132,7 +132,7 @@ prop_assessTokenBundleSize_shrink b1' b2' pp =
     assess b1 == TokenBundleSizeWithinLimit ==> conjoin
         [ assess (b1 <\> b2)
             === TokenBundleSizeWithinLimit
-        , assess (b1 `W.TokenBundle.setCoin` txOutMinCoin)
+        , assess (b1 `W.TokenBundle.setCoin` W.txOutMinCoin)
             === TokenBundleSizeWithinLimit
         ]
   where
@@ -152,9 +152,9 @@ unit_assessTokenBundleSize_fixedSizeBundle
     -- ^ Expected size assessment
     -> TokenBundleSizeAssessor
     -- ^ W.TokenBundle assessor function
-    -> TxSize
+    -> W.TxSize
     -- ^ Expected min length (bytes)
-    -> TxSize
+    -> W.TxSize
     -- ^ Expected max length (bytes)
     -> Property
 unit_assessTokenBundleSize_fixedSizeBundle
@@ -193,7 +193,7 @@ unit_assessTokenBundleSize_fixedSizeBundle_32 (Blind (FixedSize32 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle b
         TokenBundleSizeWithinLimit
         babbageTokenBundleSizeAssessor
-        (TxSize 2116) (TxSize 2380)
+        (W.TxSize 2116) (W.TxSize 2380)
 
 unit_assessTokenBundleSize_fixedSizeBundle_48
     :: Blind (FixedSize48 W.TokenBundle) -> Property
@@ -201,7 +201,7 @@ unit_assessTokenBundleSize_fixedSizeBundle_48 (Blind (FixedSize48 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle b
         TokenBundleSizeWithinLimit
         babbageTokenBundleSizeAssessor
-        (TxSize 3172) (TxSize 3564)
+        (W.TxSize 3172) (W.TxSize 3564)
 
 unit_assessTokenBundleSize_fixedSizeBundle_64
     :: Blind (FixedSize64 W.TokenBundle) -> Property
@@ -209,7 +209,7 @@ unit_assessTokenBundleSize_fixedSizeBundle_64 (Blind (FixedSize64 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle b
         TokenBundleSizeExceedsLimit
         babbageTokenBundleSizeAssessor
-        (TxSize 4228) (TxSize 4748)
+        (W.TxSize 4228) (W.TxSize 4748)
 
 unit_assessTokenBundleSize_fixedSizeBundle_128
     :: Blind (FixedSize128 W.TokenBundle) -> Property
@@ -217,7 +217,7 @@ unit_assessTokenBundleSize_fixedSizeBundle_128 (Blind (FixedSize128 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle b
         TokenBundleSizeExceedsLimit
         babbageTokenBundleSizeAssessor
-        (TxSize 8452) (TxSize 9484)
+        (W.TxSize 8452) (W.TxSize 9484)
 
 instance Arbitrary W.TokenBundle where
     arbitrary = W.genTokenBundleSmallRange

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -17,14 +17,6 @@ import Cardano.Ledger.Api.PParams
     , ppMaxValSizeL
     , ppProtocolVersionL
     )
-import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( TokenBundle
-    )
-import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
-    ( genTokenBundle
-    , genTokenBundleSmallRange
-    , shrinkTokenBundleSmallRange
-    )
 import Cardano.Wallet.Primitive.Types.Tx.Constraints
     ( TxSize (..)
     , txOutMaxCoin
@@ -85,7 +77,11 @@ import Test.QuickCheck
     , (==>)
     )
 
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
+    ( TokenBundle
+    )
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
 
 spec :: Spec
 spec = describe "Assessing the sizes of token bundles" $ do
@@ -110,15 +106,15 @@ spec = describe "Assessing the sizes of token bundles" $ do
 -- bundle that is still over the size limit.
 --
 prop_assessTokenBundleSize_enlarge
-    :: Blind (VariableSize1024 TokenBundle)
-    -> Blind (VariableSize16 TokenBundle)
+    :: Blind (VariableSize1024 W.TokenBundle)
+    -> Blind (VariableSize16 W.TokenBundle)
     -> PParamsInRecentEra
     -> Property
 prop_assessTokenBundleSize_enlarge b1' b2' pp =
     assess b1 == TokenBundleSizeExceedsLimit ==> conjoin
         [ assess (b1 <> b2)
             === TokenBundleSizeExceedsLimit
-        , assess (b1 `TokenBundle.setCoin` txOutMaxCoin)
+        , assess (b1 `W.TokenBundle.setCoin` txOutMaxCoin)
             === TokenBundleSizeExceedsLimit
         ]
   where
@@ -130,15 +126,15 @@ prop_assessTokenBundleSize_enlarge b1' b2' pp =
 -- bundle that is still within the size limit.
 --
 prop_assessTokenBundleSize_shrink
-    :: Blind (VariableSize1024 TokenBundle)
-    -> Blind (VariableSize16 TokenBundle)
+    :: Blind (VariableSize1024 W.TokenBundle)
+    -> Blind (VariableSize16 W.TokenBundle)
     -> PParamsInRecentEra
     -> Property
 prop_assessTokenBundleSize_shrink b1' b2' pp =
     assess b1 == TokenBundleSizeWithinLimit ==> conjoin
         [ assess (b1 <\> b2)
             === TokenBundleSizeWithinLimit
-        , assess (b1 `TokenBundle.setCoin` txOutMinCoin)
+        , assess (b1 `W.TokenBundle.setCoin` txOutMinCoin)
             === TokenBundleSizeWithinLimit
         ]
   where
@@ -152,12 +148,12 @@ prop_assessTokenBundleSize_shrink b1' b2' pp =
 -- Policy identifiers, asset names, token quantities are all allowed to vary.
 --
 unit_assessTokenBundleSize_fixedSizeBundle
-    :: TokenBundle
+    :: W.TokenBundle
     -- ^ Fixed size bundle
     -> TokenBundleSizeAssessment
     -- ^ Expected size assessment
     -> TokenBundleSizeAssessor
-    -- ^ TokenBundle assessor function
+    -- ^ W.TokenBundle assessor function
     -> TxSize
     -- ^ Expected min length (bytes)
     -> TxSize
@@ -194,7 +190,7 @@ unit_assessTokenBundleSize_fixedSizeBundle
         ]
 
 unit_assessTokenBundleSize_fixedSizeBundle_32
-    :: Blind (FixedSize32 TokenBundle) -> Property
+    :: Blind (FixedSize32 W.TokenBundle) -> Property
 unit_assessTokenBundleSize_fixedSizeBundle_32 (Blind (FixedSize32 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle b
         TokenBundleSizeWithinLimit
@@ -202,7 +198,7 @@ unit_assessTokenBundleSize_fixedSizeBundle_32 (Blind (FixedSize32 b)) =
         (TxSize 2116) (TxSize 2380)
 
 unit_assessTokenBundleSize_fixedSizeBundle_48
-    :: Blind (FixedSize48 TokenBundle) -> Property
+    :: Blind (FixedSize48 W.TokenBundle) -> Property
 unit_assessTokenBundleSize_fixedSizeBundle_48 (Blind (FixedSize48 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle b
         TokenBundleSizeWithinLimit
@@ -210,7 +206,7 @@ unit_assessTokenBundleSize_fixedSizeBundle_48 (Blind (FixedSize48 b)) =
         (TxSize 3172) (TxSize 3564)
 
 unit_assessTokenBundleSize_fixedSizeBundle_64
-    :: Blind (FixedSize64 TokenBundle) -> Property
+    :: Blind (FixedSize64 W.TokenBundle) -> Property
 unit_assessTokenBundleSize_fixedSizeBundle_64 (Blind (FixedSize64 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle b
         TokenBundleSizeExceedsLimit
@@ -218,16 +214,16 @@ unit_assessTokenBundleSize_fixedSizeBundle_64 (Blind (FixedSize64 b)) =
         (TxSize 4228) (TxSize 4748)
 
 unit_assessTokenBundleSize_fixedSizeBundle_128
-    :: Blind (FixedSize128 TokenBundle) -> Property
+    :: Blind (FixedSize128 W.TokenBundle) -> Property
 unit_assessTokenBundleSize_fixedSizeBundle_128 (Blind (FixedSize128 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle b
         TokenBundleSizeExceedsLimit
         babbageTokenBundleSizeAssessor
         (TxSize 8452) (TxSize 9484)
 
-instance Arbitrary TokenBundle where
-    arbitrary = genTokenBundleSmallRange
-    shrink = shrinkTokenBundleSmallRange
+instance Arbitrary W.TokenBundle where
+    arbitrary = W.genTokenBundleSmallRange
+    shrink = W.shrinkTokenBundleSmallRange
 
 newtype FixedSize32 a = FixedSize32 { unFixedSize32 :: a }
     deriving (Eq, Show)
@@ -247,28 +243,28 @@ newtype VariableSize16 a = VariableSize16 { unVariableSize16 :: a}
 newtype VariableSize1024 a = VariableSize1024 { unVariableSize1024 :: a}
     deriving (Eq, Show)
 
-instance Arbitrary (FixedSize32 TokenBundle) where
+instance Arbitrary (FixedSize32 W.TokenBundle) where
     arbitrary = FixedSize32 <$> genTxOutTokenBundle 32
     -- No shrinking
 
-instance Arbitrary (FixedSize48 TokenBundle) where
+instance Arbitrary (FixedSize48 W.TokenBundle) where
     arbitrary = FixedSize48 <$> genTxOutTokenBundle 48
     -- No shrinking
 
-instance Arbitrary (FixedSize64 TokenBundle) where
+instance Arbitrary (FixedSize64 W.TokenBundle) where
     arbitrary = FixedSize64 <$> genTxOutTokenBundle 64
     -- No shrinking
 
-instance Arbitrary (FixedSize128 TokenBundle) where
+instance Arbitrary (FixedSize128 W.TokenBundle) where
     arbitrary = FixedSize128 <$> genTxOutTokenBundle 128
     -- No shrinking
 
-instance Arbitrary (VariableSize16 TokenBundle) where
-    arbitrary = VariableSize16 <$> resize 16 genTokenBundle
+instance Arbitrary (VariableSize16 W.TokenBundle) where
+    arbitrary = VariableSize16 <$> resize 16 W.genTokenBundle
     -- No shrinking
 
-instance Arbitrary (VariableSize1024 TokenBundle) where
-    arbitrary = VariableSize1024 <$> resize 1024 genTokenBundle
+instance Arbitrary (VariableSize1024 W.TokenBundle) where
+    arbitrary = VariableSize1024 <$> resize 1024 W.genTokenBundle
     -- No shrinking
 
 instance Arbitrary Version where

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -133,9 +133,6 @@ import Cardano.Wallet.Primitive.Passphrase
 import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException
     )
-import Cardano.Wallet.Primitive.Types.Credentials
-    ( RootCredentials (..)
-    )
 import Cardano.Wallet.Shelley.Transaction
     ( mkByronWitness
     , mkDelegationCertificates
@@ -429,6 +426,9 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..)
     )
 import qualified Cardano.Wallet.Primitive.Types.Coin.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Credentials as W
+    ( RootCredentials (..)
+    )
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
     ( Hash (..)
     , mockHash
@@ -2424,7 +2424,7 @@ dummyShelleyChangeAddressGen = AnyChangeAddressGenWithState
         (delegationAddress @ShelleyKey SMainnet)
         )
     (mkSeqStateFromRootXPrv ShelleyKeyS
-        (RootCredentials rootK pwd)
+        (W.RootCredentials rootK pwd)
         purposeCIP1852
         defaultAddressPoolGap)
   where

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -144,9 +144,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , sealedTxFromCardano'
     , serialisedTx
     )
-import Cardano.Wallet.Primitive.Types.Tx.Constraints
-    ( TxSize (..)
-    )
 import Cardano.Wallet.Shelley.Transaction
     ( mkByronWitness
     , mkDelegationCertificates
@@ -449,6 +446,9 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle
     )
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+    ( TxSize (..)
+    )
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
@@ -504,7 +504,7 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
     describe "bootstrap witnesses" $ do
         -- Used in 'estimateTxSize', and in turn used by coin-selection
         let coinSelectionEstimatedSize :: Natural -> Natural
-            coinSelectionEstimatedSize = unTxSize . sizeOf_BootstrapWitnesses
+            coinSelectionEstimatedSize = W.unTxSize . sizeOf_BootstrapWitnesses
 
         let measuredWitSize
                 :: CardanoApi.IsCardanoEra era
@@ -942,7 +942,7 @@ spec_distributeSurplus = describe "distributeSurplus" $ do
     describe "sizeOfCoin" $ do
         let coinToWord64Clamped = fromMaybe maxBound . W.Coin.toWord64Maybe
         let cborSizeOfCoin =
-                TxSize
+                W.TxSize
                 . fromIntegral
                 . BS.length
                 . CBOR.toStrictByteString
@@ -962,26 +962,26 @@ spec_distributeSurplus = describe "distributeSurplus" $ do
                     -- ensure we see /some/ amount of every size.
                     let coverSize s = cover 0.01 (s == expected) (show s)
                     sizeOfCoin c === expected
-                        & coverSize (TxSize 1)
-                        & coverSize (TxSize 2)
-                        & coverSize (TxSize 3)
-                        & coverSize (TxSize 5)
-                        & coverSize (TxSize 9)
+                        & coverSize (W.TxSize 1)
+                        & coverSize (W.TxSize 2)
+                        & coverSize (W.TxSize 3)
+                        & coverSize (W.TxSize 5)
+                        & coverSize (W.TxSize 9)
                         & cover 0.5 (isBoundary c) "boundary case"
 
         describe "boundary case goldens" $ do
             it "1 byte to 2 byte boundary" $ do
-                sizeOfCoin (W.Coin 23) `shouldBe` TxSize 1
-                sizeOfCoin (W.Coin 24) `shouldBe` TxSize 2
+                sizeOfCoin (W.Coin 23) `shouldBe` W.TxSize 1
+                sizeOfCoin (W.Coin 24) `shouldBe` W.TxSize 2
             it "2 byte to 3 byte boundary" $ do
-                sizeOfCoin (W.Coin $ 2 `power` 8 - 1) `shouldBe` TxSize 2
-                sizeOfCoin (W.Coin $ 2 `power` 8    ) `shouldBe` TxSize 3
+                sizeOfCoin (W.Coin $ 2 `power` 8 - 1) `shouldBe` W.TxSize 2
+                sizeOfCoin (W.Coin $ 2 `power` 8    ) `shouldBe` W.TxSize 3
             it "3 byte to 5 byte boundary" $ do
-                sizeOfCoin (W.Coin $ 2 `power` 16 - 1) `shouldBe` TxSize 3
-                sizeOfCoin (W.Coin $ 2 `power` 16    ) `shouldBe` TxSize 5
+                sizeOfCoin (W.Coin $ 2 `power` 16 - 1) `shouldBe` W.TxSize 3
+                sizeOfCoin (W.Coin $ 2 `power` 16    ) `shouldBe` W.TxSize 5
             it "5 byte to 9 byte boundary" $ do
-                sizeOfCoin (W.Coin $ 2 `power` 32 - 1) `shouldBe` TxSize 5
-                sizeOfCoin (W.Coin $ 2 `power` 32    ) `shouldBe` TxSize 9
+                sizeOfCoin (W.Coin $ 2 `power` 32 - 1) `shouldBe` W.TxSize 5
+                sizeOfCoin (W.Coin $ 2 `power` 32    ) `shouldBe` W.TxSize 9
 
     describe "costOfIncreasingCoin" $ do
         it "costs 176 lovelace to increase 4294.967295 ada (2^32 - 1 lovelace) \
@@ -1116,7 +1116,7 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
             testDoesNotYetSupport x =
                 pendingWith $ "Test setup does not work for txs with " <> x
 
-            signedBinarySize = TxSize $ fromIntegral $ BS.length bs
+            signedBinarySize = W.TxSize $ fromIntegral $ BS.length bs
 
         case (noScripts, noBootWits) of
                 (True, True) -> do
@@ -1138,7 +1138,7 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
         -- Apparently the cbor encoding used by the ledger for size checks
         -- (`toCBORForSizeComputation`) is a few bytes smaller than the actual
         -- serialized size for these goldens.
-        correction = TxSize 6
+        correction = W.TxSize 6
 
     forAllGoldens
         :: [(String, ByteString)]
@@ -1207,7 +1207,7 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
     --
     -- NOTE: If we had access to the real UTxO set for the inputs of the test
     -- txs, we wouldn't need this fuzziness. Related: ADP-2987.
-    bootWitsCanBeLongerBy = TxSize 45
+    bootWitsCanBeLongerBy = W.TxSize 45
 
 spec_updateTx :: Spec
 spec_updateTx = describe "updateTx" $ do
@@ -1525,7 +1525,7 @@ prop_balanceTransactionValid
         -> Property
     prop_validSize tx@(CardanoApi.Tx body _) utxo = do
         let era = recentEra @era
-        let (TxSize size) =
+        let (W.TxSize size) =
                 estimateSignedTxSize era ledgerPParams
                     (estimateKeyWitnessCount utxo body)
                     (fromCardanoApiTx tx)

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -136,14 +136,6 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.Types.Credentials
     ( RootCredentials (..)
     )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( SealedTx (..)
-    , cardanoTxIdeallyNoLaterThan
-    , sealedTxFromBytes
-    , sealedTxFromCardano
-    , sealedTxFromCardano'
-    , serialisedTx
-    )
 import Cardano.Wallet.Shelley.Transaction
     ( mkByronWitness
     , mkDelegationCertificates
@@ -446,6 +438,14 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle
     )
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Tx as W
+    ( SealedTx (..)
+    , cardanoTxIdeallyNoLaterThan
+    , sealedTxFromBytes
+    , sealedTxFromCardano
+    , sealedTxFromCardano'
+    , serialisedTx
+    )
 import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
     ( TxSize (..)
     )
@@ -638,7 +638,7 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
                 let (wtx, _, _, _, _, _) =
                         _decodeSealedTx maxBound
                         (ShelleyWalletCtx dummyPolicyK)
-                        (sealedTxFromCardano' tx)
+                        (W.sealedTxFromCardano' tx)
                 in
                     F.foldMap (view (#tokens . #coin)) (view #outputs wtx)
                     <> fromMaybe (W.Coin 0) (view #fee wtx)
@@ -820,8 +820,9 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
                     dummyTimeTranslation
                     testStdGenSeed
                     ptx
-            let serializeTx = serialisedTx
-                    . sealedTxFromCardano
+            let serializeTx
+                    = W.serialisedTx
+                    . W.sealedTxFromCardano
                     . CardanoApi.InAnyCardanoEra CardanoApi.BabbageEra
 
             let name = "pingPong_2"
@@ -1154,7 +1155,7 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
                 msg = unlines
                     [ B8.unpack $ hex bs
                     , pretty
-                        $ sealedTxFromCardano
+                        $ W.sealedTxFromCardano
                         $ CardanoApi.InAnyCardanoEra CardanoApi.cardanoEra tx
                     ]
             in
@@ -1285,7 +1286,7 @@ spec_updateTx = describe "updateTx" $ do
         it "returns `Left err` when extra body content is non-empty" $ do
             pendingWith "todo: add test data"
   where
-    readTestTransactions :: SpecM a [(FilePath, SealedTx)]
+    readTestTransactions :: SpecM a [(FilePath, W.SealedTx)]
     readTestTransactions = runIO $ do
         let dir = $(getTestData) </> "plutus"
         paths <- listDirectory dir
@@ -1990,9 +1991,9 @@ prop_updateTx
             , collateralIns tx' === collateralIns tx <> Set.fromList extraCol
             ]
   where
-    inputs = sealedInputs . sealedTxFromCardano'
-    outputs = sealedOutputs . sealedTxFromCardano'
-    collateralIns = sealedCollateralInputs . sealedTxFromCardano'
+    inputs = sealedInputs . W.sealedTxFromCardano'
+    outputs = sealedOutputs . W.sealedTxFromCardano'
+    collateralIns = sealedCollateralInputs . W.sealedTxFromCardano'
 
 --------------------------------------------------------------------------------
 -- Utility types
@@ -2092,8 +2093,8 @@ balanceTransactionWithDummyChangeState utxoAssumptions utxo seed partialTx =
   where
     utxoIndex = constructUTxOIndex @era $ fromWalletUTxO (recentEra @era) utxo
 
-cardanoTx :: SealedTx -> CardanoApi.InAnyCardanoEra CardanoApi.Tx
-cardanoTx = cardanoTxIdeallyNoLaterThan maxBound
+cardanoTx :: W.SealedTx -> CardanoApi.InAnyCardanoEra CardanoApi.Tx
+cardanoTx = W.cardanoTxIdeallyNoLaterThan maxBound
 
 deserializeBabbageTx :: ByteString -> CardanoApi.Tx CardanoApi.BabbageEra
 deserializeBabbageTx = either (error . show) id
@@ -2181,7 +2182,7 @@ recentEraTxFromBytes bytes =
         anyEraTx
             = cardanoTx
             $ either (error . show) id
-            $ sealedTxFromBytes bytes
+            $ W.sealedTxFromBytes bytes
     in
         case Write.asAnyRecentEra anyEraTx of
             Just recentEraTx -> recentEraTx
@@ -2207,7 +2208,7 @@ restrictResolution (PartialTx tx inputs redeemers) =
     inputsInTx (CardanoApi.Tx (CardanoApi.TxBody bod) _) =
         Set.fromList $ map fst $ CardanoApi.txIns bod
 
-sealedCollateralInputs :: SealedTx -> Set W.TxIn
+sealedCollateralInputs :: W.SealedTx -> Set W.TxIn
 sealedCollateralInputs =
     Set.fromList
     . map fst
@@ -2223,9 +2224,9 @@ sealedFee =
     view #fee
     . fst6
     . _decodeSealedTx maxBound (ShelleyWalletCtx dummyPolicyK)
-    . sealedTxFromCardano'
+    . W.sealedTxFromCardano'
 
-sealedInputs :: SealedTx -> Set W.TxIn
+sealedInputs :: W.SealedTx -> Set W.TxIn
 sealedInputs =
     Set.fromList
     . map fst
@@ -2233,7 +2234,7 @@ sealedInputs =
     . fst6
     . _decodeSealedTx maxBound (ShelleyWalletCtx dummyPolicyK)
 
-sealedOutputs :: SealedTx -> Set W.TxOut
+sealedOutputs :: W.SealedTx -> Set W.TxOut
 sealedOutputs =
     Set.fromList
     . view #outputs
@@ -2245,8 +2246,8 @@ serializedSize
     => CardanoApi.Tx era
     -> Int
 serializedSize = BS.length
-    . serialisedTx
-    . sealedTxFromCardano
+    . W.serialisedTx
+    . W.sealedTxFromCardano
     . CardanoApi.InAnyCardanoEra (CardanoApi.cardanoEra @era)
 
 -- | Checks for membership in the given closed interval [a, b]
@@ -2272,10 +2273,10 @@ txMinFee tx@(CardanoApi.Tx body _) u =
         (fromCardanoApiTx tx)
         (estimateKeyWitnessCount (fromCardanoApiUTxO u) body)
 
-unsafeSealedTxFromHex :: ByteString -> IO SealedTx
+unsafeSealedTxFromHex :: ByteString -> IO W.SealedTx
 unsafeSealedTxFromHex =
     either (fail . show) pure
-        . sealedTxFromBytes
+        . W.sealedTxFromBytes
         . unsafeFromHex
         . BS.dropWhileEnd isNewlineChar
   where

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -455,7 +455,7 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (..)
     )
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as TxOutGen
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
 import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Codec.CBOR.Encoding as CBOR
@@ -2725,14 +2725,14 @@ instance Arbitrary (TxFeeAndChange [W.TxOut]) where
         fee <- W.genCoin
         change <- frequency
             [ (1, pure [])
-            , (1, (: []) <$> TxOutGen.genTxOut)
-            , (6, listOf TxOutGen.genTxOut)
+            , (1, (: []) <$> W.genTxOut)
+            , (6, listOf W.genTxOut)
             ]
         pure $ TxFeeAndChange fee change
     shrink (TxFeeAndChange fee change) =
         uncurry TxFeeAndChange <$> liftShrink2
             (W.shrinkCoin)
-            (shrinkList TxOutGen.shrinkTxOut)
+            (shrinkList W.shrinkTxOut)
             (fee, change)
 
 instance Arbitrary W.TxIn where


### PR DESCRIPTION
## Issue

ADP-3184

This PR follows on from #4161 and #4229.

## Description

This PR:
- corrects an inconsistency between `Cardano.Wallet.Tx.Balance` and other modules in the `cardano-balance-tx` library.
- arranges that all symbols from the `Cardano.Wallet.Primitive.Types` module hierarchy are imported into the `W` namespace.

As before, the intention is to make it easier for readers to distinguish (visually) between similarly-named types and functions imported from the following libraries:
- `cardano-api`
- `cardano-ledger`
- `cardano-wallet-primitive`

(all of which are generally incompatible, at least without the use of conversion functions)

Where appropriate, certain symbols are imported into a nested namespace.

Examples:
```hs
import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
```

This allows functions for a given type (with its own well-defined family of functions) to be qualified as `W.Type.functionName`.

Examples:
```hs
W.Coin.fromNatural
W.TokenBundle.getAssets
```