### PR TITLE
Use consistent namespace for `ShelleyLedgerEra` in `cardano-balance-tx`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/TokenBundleSize.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/TokenBundleSize.hs
@@ -31,12 +31,12 @@ import Data.IntCast
 import Internal.Cardano.Write.Tx
     ( PParams
     , RecentEra
-    , ShelleyLedgerEra
     , Value
     , Version
     , withConstraints
     )
 
+import qualified Cardano.Api.Shelley as CardanoApi
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle
     )
@@ -53,7 +53,7 @@ import qualified Data.ByteString.Lazy as BL
 --
 mkTokenBundleSizeAssessor
     :: RecentEra era
-    -> PParams (ShelleyLedgerEra era)
+    -> PParams (CardanoApi.ShelleyLedgerEra era)
     -> TokenBundleSizeAssessor
 mkTokenBundleSizeAssessor era pp = TokenBundleSizeAssessor $ \tb ->
     if computeTokenBundleSerializedLengthBytes tb ver > maxValSize

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
@@ -99,7 +99,6 @@ import Internal.Cardano.Write.Tx
     ( PParams
     , RecentEra
     , RecentEraLedgerConstraints
-    , ShelleyLedgerEra
     , StandardCrypto
     , UTxO
     , txBody
@@ -141,12 +140,12 @@ data ErrAssignRedeemers
 
 assignScriptRedeemers
     :: forall era. RecentEra era
-    -> PParams (ShelleyLedgerEra era)
+    -> PParams (CardanoApi.ShelleyLedgerEra era)
     -> TimeTranslation
-    -> UTxO (ShelleyLedgerEra era)
+    -> UTxO (CardanoApi.ShelleyLedgerEra era)
     -> [Redeemer]
-    -> Tx (ShelleyLedgerEra era)
-    -> Either ErrAssignRedeemers (Tx (ShelleyLedgerEra era))
+    -> Tx (CardanoApi.ShelleyLedgerEra era)
+    -> Either ErrAssignRedeemers (Tx (CardanoApi.ShelleyLedgerEra era))
 assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
     withConstraints era $ do
         flip execStateT tx $ do
@@ -167,11 +166,11 @@ assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
     -- Redeemers are determined from the context given to the caller via the
     -- 'Redeemer' type which is mapped to an 'Alonzo.ScriptPurpose'.
     assignNullRedeemers
-        :: RecentEraLedgerConstraints (ShelleyLedgerEra era)
-        => Tx (ShelleyLedgerEra era)
+        :: RecentEraLedgerConstraints (CardanoApi.ShelleyLedgerEra era)
+        => Tx (CardanoApi.ShelleyLedgerEra era)
         -> Either ErrAssignRedeemers
             ( Map Alonzo.RdmrPtr Redeemer
-            , Tx (ShelleyLedgerEra era)
+            , Tx (CardanoApi.ShelleyLedgerEra era)
             )
     assignNullRedeemers ledgerTx = do
         (indexedRedeemers, nullRedeemers) <-
@@ -200,7 +199,7 @@ assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
     -- | Evaluate execution units of each script/redeemer in the transaction.
     -- This may fail for each script.
     evaluateExecutionUnits
-        :: RecentEraLedgerConstraints (ShelleyLedgerEra era)
+        :: RecentEraLedgerConstraints (CardanoApi.ShelleyLedgerEra era)
         => Map Alonzo.RdmrPtr Redeemer
         -> Tx (CardanoApi.ShelleyLedgerEra era)
         -> Either ErrAssignRedeemers
@@ -223,10 +222,10 @@ assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
     -- | Change execution units for each redeemers in the transaction to what
     -- they ought to be.
     assignExecutionUnits
-        :: RecentEraLedgerConstraints (ShelleyLedgerEra era)
+        :: RecentEraLedgerConstraints (CardanoApi.ShelleyLedgerEra era)
         => Map Alonzo.RdmrPtr (Either ErrAssignRedeemers Alonzo.ExUnits)
-        -> Tx (ShelleyLedgerEra era)
-        -> Either ErrAssignRedeemers (Tx (ShelleyLedgerEra era))
+        -> Tx (CardanoApi.ShelleyLedgerEra era)
+        -> Either ErrAssignRedeemers (Tx (CardanoApi.ShelleyLedgerEra era))
     assignExecutionUnits exUnits ledgerTx = do
         let Alonzo.Redeemers rdmrs = view (witsTxL . rdmrsTxWitsL) ledgerTx
 
@@ -249,9 +248,9 @@ assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
     -- | Finally, calculate and add the script integrity hash with the new
     -- final redeemers, if any.
     addScriptIntegrityHash
-        :: RecentEraLedgerConstraints (ShelleyLedgerEra era)
-        => Tx (ShelleyLedgerEra era)
-        -> Tx (ShelleyLedgerEra era)
+        :: RecentEraLedgerConstraints (CardanoApi.ShelleyLedgerEra era)
+        => Tx (CardanoApi.ShelleyLedgerEra era)
+        -> Tx (CardanoApi.ShelleyLedgerEra era)
     addScriptIntegrityHash ledgerTx =
         ledgerTx & (bodyTxL . scriptIntegrityHashTxBodyL) .~
             Alonzo.hashScriptIntegrity
@@ -263,7 +262,9 @@ assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
         langs =
             [ l
             | (_hash, script) <- Map.toList (Alonzo.txscripts wits)
-            , (not . Ledger.isNativeScript @(ShelleyLedgerEra era)) script
+            , ( not
+              . Ledger.isNativeScript @(CardanoApi.ShelleyLedgerEra era)
+              ) script
             , Just l <- [Alonzo.language script]
             ]
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -58,7 +58,6 @@ import Internal.Cardano.Write.Tx
     , KeyWitnessCount (..)
     , PParams
     , RecentEra (..)
-    , ShelleyLedgerEra
     , Tx
     , TxIn
     , UTxO
@@ -91,9 +90,10 @@ import qualified Internal.Cardano.Write.Tx as Write
 -- NOTE: Existing key witnesses in the tx are ignored.
 estimateSignedTxSize
     :: forall era. RecentEra era
-    -> PParams (ShelleyLedgerEra era)
+    -> PParams (CardanoApi.ShelleyLedgerEra era)
     -> KeyWitnessCount
-    -> Tx (ShelleyLedgerEra era) -- ^ existing wits in tx are ignored
+    -> Tx (CardanoApi.ShelleyLedgerEra era)
+    -- ^ existing wits in tx are ignored
     -> W.TxSize
 estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
     let
@@ -125,7 +125,7 @@ estimateSignedTxSize era pparams nWits txWithWits = withConstraints era $
     in
         sizeOfTx <> sizeOfWits
   where
-    unsignedTx :: Tx (ShelleyLedgerEra era)
+    unsignedTx :: Tx (CardanoApi.ShelleyLedgerEra era)
     unsignedTx = withConstraints era $
         txWithWits
             & (witsTxL . addrTxWitsL) .~ mempty
@@ -161,7 +161,7 @@ numberOfShelleyWitnesses n = KeyWitnessCount n 0
 -- we cannot use because it requires a 'TxBodyContent BuildTx era'.
 estimateKeyWitnessCount
     :: forall era. IsRecentEra era
-    => UTxO (ShelleyLedgerEra era)
+    => UTxO (CardanoApi.ShelleyLedgerEra era)
     -- ^ Must contain all inputs from the 'TxBody' or
     -- 'estimateKeyWitnessCount will 'error'.
     -> CardanoApi.TxBody era
@@ -265,7 +265,7 @@ estimateKeyWitnessCount utxo txbody@(CardanoApi.TxBody txbodycontent) =
                 Alonzo.PlutusScript _ _ -> Nothing
 
     hasScriptCred
-        :: UTxO (ShelleyLedgerEra era)
+        :: UTxO (CardanoApi.ShelleyLedgerEra era)
         -> TxIn
         -> Bool
     hasScriptCred u inp = withConstraints (recentEra @era) $
@@ -280,7 +280,7 @@ estimateKeyWitnessCount utxo txbody@(CardanoApi.TxBody txbodycontent) =
                     ]
 
     hasBootstrapAddr
-        :: UTxO (ShelleyLedgerEra era)
+        :: UTxO (CardanoApi.ShelleyLedgerEra era)
         -> TxIn
         -> Bool
     hasBootstrapAddr u inp = withConstraints (recentEra @era) $

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -33,7 +33,6 @@ import Data.Word
 import Internal.Cardano.Write.Tx
     ( ProtVer (..)
     , RecentEra (..)
-    , ShelleyLedgerEra
     , StandardBabbage
     , StandardConway
     , Version
@@ -69,6 +68,7 @@ import Test.QuickCheck
     , (==>)
     )
 
+import qualified Cardano.Api.Shelley as CardanoApi
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle
@@ -282,7 +282,7 @@ instance Arbitrary PParamsInRecentEra where
       where
         genPParams
             :: RecentEra era
-            -> Gen (PParams (ShelleyLedgerEra era))
+            -> Gen (PParams (CardanoApi.ShelleyLedgerEra era))
         genPParams era = withConstraints era $ do
             ver <- arbitrary
             maxSize <- genMaxSizeBytes

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -249,7 +249,6 @@ import Internal.Cardano.Write.Tx
     , InAnyRecentEra (..)
     , IsRecentEra (..)
     , RecentEra (..)
-    , ShelleyLedgerEra
     , Tx
     , TxIn
     , TxOut
@@ -1108,7 +1107,7 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
                 body
             era = recentEra @era
 
-            tx :: Tx (ShelleyLedgerEra era)
+            tx :: Tx (CardanoApi.ShelleyLedgerEra era)
             tx = fromCardanoApiTx @era cTx
 
             noScripts = withConstraints (recentEra @era)
@@ -1170,8 +1169,8 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
         :: forall era. HasCallStack
         => RecentEra era
         -> W.Address
-        -> Tx (ShelleyLedgerEra era)
-        -> UTxO (ShelleyLedgerEra era)
+        -> Tx (CardanoApi.ShelleyLedgerEra era)
+        -> UTxO (CardanoApi.ShelleyLedgerEra era)
     utxoPromisingInputsHaveAddress era addr tx =
         utxoFromTxOutsInRecentEra era $
             [ (i
@@ -1185,7 +1184,7 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
             ]
       where
         allInputs
-            :: Tx (ShelleyLedgerEra era)
+            :: Tx (CardanoApi.ShelleyLedgerEra era)
             -> [TxIn]
         allInputs body = withConstraints era
             $ Set.toList
@@ -1487,7 +1486,7 @@ prop_balanceTransactionValid
     prop_expectFeeExcessSmallerThan
         :: CardanoApi.Lovelace
         -> CardanoApi.Tx era
-        -> UTxO (ShelleyLedgerEra era)
+        -> UTxO (CardanoApi.ShelleyLedgerEra era)
         -> Property
     prop_expectFeeExcessSmallerThan lim tx utxo = do
         let fee = txFee tx
@@ -1506,7 +1505,7 @@ prop_balanceTransactionValid
 
     prop_minfeeIsCovered
         :: CardanoApi.Tx era
-        -> UTxO (ShelleyLedgerEra era)
+        -> UTxO (CardanoApi.ShelleyLedgerEra era)
         -> Property
     prop_minfeeIsCovered tx utxo = do
         let fee = txFee tx
@@ -1525,7 +1524,7 @@ prop_balanceTransactionValid
 
     prop_validSize
         :: CardanoApi.Tx era
-        -> UTxO (ShelleyLedgerEra era)
+        -> UTxO (CardanoApi.ShelleyLedgerEra era)
         -> Property
     prop_validSize tx@(CardanoApi.Tx body _) utxo = do
         let era = recentEra @era
@@ -1593,7 +1592,7 @@ prop_balanceTransactionValid
 
     minFee
         :: CardanoApi.Tx era
-        -> UTxO (ShelleyLedgerEra era)
+        -> UTxO (CardanoApi.ShelleyLedgerEra era)
         -> CardanoApi.Lovelace
     minFee tx@(CardanoApi.Tx body _) utxo = Write.toCardanoApiLovelace
         $ Write.evaluateMinimumFee (recentEra @era) ledgerPParams
@@ -1602,7 +1601,7 @@ prop_balanceTransactionValid
 
     txBalance
         :: CardanoApi.Tx era
-        -> UTxO (ShelleyLedgerEra era)
+        -> UTxO (CardanoApi.ShelleyLedgerEra era)
         -> CardanoApi.Value
     txBalance tx u = Write.toCardanoApiValue @era $
         Write.evaluateTransactionBalance
@@ -2295,7 +2294,7 @@ cardanoToWalletTxOut
 cardanoToWalletTxOut =
     toWallet . CardanoApi.toShelleyTxOut (Write.shelleyBasedEra @era)
   where
-    toWallet :: TxOut (ShelleyLedgerEra era) -> W.TxOut
+    toWallet :: TxOut (CardanoApi.ShelleyLedgerEra era) -> W.TxOut
     toWallet x = case recentEra @era of
         RecentEraBabbage -> Convert.fromBabbageTxOut x
         RecentEraConway -> Convert.fromConwayTxOut x
@@ -2816,8 +2815,8 @@ shrinkInputResolution
         ( IsRecentEra era
         , Arbitrary (CardanoApi.TxOut CardanoApi.CtxUTxO era)
         )
-    => Write.UTxO (ShelleyLedgerEra era)
-    -> [Write.UTxO (ShelleyLedgerEra era)]
+    => Write.UTxO (CardanoApi.ShelleyLedgerEra era)
+    -> [Write.UTxO (CardanoApi.ShelleyLedgerEra era)]
 shrinkInputResolution =
     shrinkMapBy utxoFromList utxoToList shrinkUTxOEntries
    where


### PR DESCRIPTION
## Issue

ADP-3184

This PR follows on from #4185 and #4229.

## Description

This PR:
- corrects an inconsistency between `Cardano.Write.Tx` and other modules in the `cardano-balance-tx` library.
- arranges that `ShelleyLedgerEra` is always imported into the `CardanoApi` namespace.
