### PR TITLE
Fix documentation in `cardano-balance-tx`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -371,7 +371,9 @@ withConstraints era a = case era of
     RecentEraBabbage -> a
     RecentEraConway -> a
 
--- | Return a proof that the wallet can create txs in this era, or @Nothing@.
+-- | Returns a proof that the given era is a recent era.
+--
+-- Otherwise, returns @Nothing@.
 toRecentEra :: CardanoApi.CardanoEra era -> Maybe (RecentEra era)
 toRecentEra = \case
     CardanoApi.ConwayEra  -> Just RecentEraConway

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -1170,8 +1170,7 @@ selectAssets era (ProtocolParameters pp) utxoAssumptions outs redeemers
 data ChangeAddressGen s = ChangeAddressGen
     { getChangeAddressGen :: s -> (Address, s)
 
-    -- | Returns the longest address that the wallet can generate for a given
-    --   key.
+    -- | Returns a dummy change address of the maximum possible length.
     --
     -- This is useful in situations where we want to compute some function of
     -- an output under construction (such as a minimum UTxO value), but don't

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -1184,9 +1184,7 @@ data ChangeAddressGen s = ChangeAddressGen
     , maxLengthChangeAddress :: Address
     }
 
--- | Augments the given outputs with new outputs. These new outputs correspond
--- to change outputs to which new addresses have been assigned. This updates
--- the wallet state as it needs to keep track of new pending change addresses.
+-- | Assigns addresses to the change outputs of the given selection.
 assignChangeAddresses
     :: ChangeAddressGen s
     -> SelectionOf W.TokenBundle

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -1170,7 +1170,15 @@ selectAssets era (ProtocolParameters pp) utxoAssumptions outs redeemers
 data ChangeAddressGen s = ChangeAddressGen
     { getChangeAddressGen :: s -> (Address, s)
 
-    -- | Returns a dummy change address of the maximum possible length.
+    -- | Returns a /dummy/ change address of the maximum possible length for
+    --   this generator.
+    --
+    -- Implementations must satisfy the following property:
+    --
+    -- @
+    -- ∀ s. length (fst (getChangeAddressGen s)) <=
+    --      length maxLengthChangeAddress
+    -- @
     --
     -- This is useful in situations where we want to compute some function of
     -- an output under construction (such as a minimum UTxO value), but don't

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -1171,7 +1171,7 @@ data ChangeAddressGen s = ChangeAddressGen
     {
     -- | Generates a new change address.
     --
-    getChangeAddressGen :: s -> (Address, s)
+    genChangeAddress :: s -> (Address, s)
 
     -- | Returns a /dummy/ change address of the maximum possible length for
     --   this generator.
@@ -1179,7 +1179,7 @@ data ChangeAddressGen s = ChangeAddressGen
     -- Implementations must satisfy the following property:
     --
     -- @
-    -- ∀ s. length (fst (getChangeAddressGen s)) <=
+    -- ∀ s. length (fst (genChangeAddress s)) <=
     --      length maxLengthChangeAddress
     -- @
     --

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -1168,7 +1168,10 @@ selectAssets era (ProtocolParameters pp) utxoAssumptions outs redeemers
         extraBytes = 8
 
 data ChangeAddressGen s = ChangeAddressGen
-    { getChangeAddressGen :: s -> (Address, s)
+    {
+    -- | Generates a new change address.
+    --
+    getChangeAddressGen :: s -> (Address, s)
 
     -- | Returns a /dummy/ change address of the maximum possible length for
     --   this generator.

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -594,7 +594,7 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
         let expectedChange = fmap Convert.toWalletAddress <$>
                 flip evalState s0
                 $ replicateM nChange
-                $ state @Identity (getChangeAddressGen dummyChangeAddrGen)
+                $ state @Identity (genChangeAddress dummyChangeAddrGen)
 
         let address :: Babbage.BabbageTxOut StandardBabbage -> W.Address
             address (Babbage.BabbageTxOut addr _ _ _) = Convert.toWallet addr
@@ -2369,7 +2369,7 @@ costModelsForTesting = either (error . show) id $ do
 
 dummyChangeAddrGen :: ChangeAddressGen DummyChangeState
 dummyChangeAddrGen = ChangeAddressGen
-    { getChangeAddressGen = \(DummyChangeState i) ->
+    { genChangeAddress = \(DummyChangeState i) ->
         (addressAtIx $ toEnum i, DummyChangeState $ succ i)
     , maxLengthChangeAddress = addressAtIx minBound
     }


### PR DESCRIPTION
## Issue

ADP-3186

## Description

This PR fixes the documentation for selected functions in `cardano-balance-tx`.

In particular, references to "the wallet" have been removed.