### PR TITLE
Replace `modifyLedgerBody` with ledger-api lens

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -231,7 +231,6 @@ import Internal.Cardano.Write.Tx
     , getFeePerByte
     , isBelowMinimumCoinForTxOut
     , maxScriptExecutionCost
-    , modifyLedgerBody
     , modifyTxOutCoin
     , outputs
     , toCardanoApiTx
@@ -657,8 +656,7 @@ assignMinimalAdaQuantitiesToOutputsWithoutAda
     -> Tx (CardanoApi.ShelleyLedgerEra era)
 assignMinimalAdaQuantitiesToOutputsWithoutAda era pp =
     withConstraints era
-        $ modifyLedgerBody @era
-        $ over outputsTxBodyL
+        $ over (bodyTxL . outputsTxBodyL)
         $ fmap modifyTxOut
   where
     modifyTxOut out = flip (modifyTxOutCoin era) out $ \c ->

--- a/lib/read/lib/Cardano/Wallet/Read/Block.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2038,9 +2038,7 @@ addExtraTxIns
     -> PartialTx CardanoApi.BabbageEra
     -> PartialTx CardanoApi.BabbageEra
 addExtraTxIns extraIns =
-    #tx %~
-        Write.asCardanoApiTx
-        (modifyBabbageTxBody (inputsTxBodyL %~ (<> toLedgerInputs extraIns)))
+    #tx . bodyTxL . inputsTxBodyL %~ (<> toLedgerInputs extraIns)
   where
     toLedgerInputs =
         Set.map Convert.toLedger . Set.fromList
@@ -2153,34 +2151,6 @@ mockPParamsForBalancing =
         CardanoApi.toLedgerPParams
             (Write.shelleyBasedEra @era)
             mockCardanoApiPParamsForBalancing
-
--- Ideally merge with 'updateTx'
-modifyBabbageTxBody
-    :: ( Babbage.BabbageTxBody StandardBabbage ->
-         Babbage.BabbageTxBody StandardBabbage
-       )
-    -> CardanoApi.Tx CardanoApi.BabbageEra
-    -> CardanoApi.Tx CardanoApi.BabbageEra
-modifyBabbageTxBody
-    f
-    (CardanoApi.Tx
-        (CardanoApi.ShelleyTxBody
-            era
-            body
-            scripts
-            scriptData
-            auxData
-            scriptValidity)
-        keyWits)
-    = CardanoApi.Tx
-        (CardanoApi.ShelleyTxBody
-            era
-            (f body)
-            scripts
-            scriptData
-            auxData
-            scriptValidity)
-        keyWits
 
 paymentPartialTx :: [W.TxOut] -> PartialTx CardanoApi.BabbageEra
 paymentPartialTx txouts =
@@ -2307,8 +2277,7 @@ withValidityInterval
     :: ValidityInterval
     -> PartialTx CardanoApi.BabbageEra
     -> PartialTx CardanoApi.BabbageEra
-withValidityInterval vi = #tx %~
-    Write.asCardanoApiTx (modifyBabbageTxBody (vldtTxBodyL .~ vi))
+withValidityInterval vi = #tx . bodyTxL %~ vldtTxBodyL .~ vi
 
 walletToCardanoValue :: W.TokenBundle -> CardanoApi.Value
 walletToCardanoValue = CardanoApi.fromMaryValue . Convert.toLedger


### PR DESCRIPTION
Suggestion to #4235

- Fix compilation for GHC 9.2
- Replace `modifyLedgerBody` with ledger-api lens
