### PR TITLE
Return `Write.Tx` from `balanceTransaction`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -143,6 +143,7 @@ import Control.Monad.Trans.State
     )
 import Data.Bifunctor
     ( bimap
+    , first
     , second
     )
 import Data.Bits
@@ -228,6 +229,7 @@ import Internal.Cardano.Write.Tx
     , evaluateMinimumFee
     , evaluateTransactionBalance
     , feeOfBytes
+    , fromCardanoApiTx
     , getFeePerByte
     , isBelowMinimumCoinForTxOut
     , maxScriptExecutionCost
@@ -564,7 +566,7 @@ balanceTransaction
     -> ChangeAddressGen changeState
     -> changeState
     -> PartialTx era
-    -> ExceptT (ErrBalanceTx era) m (CardanoApi.Tx era, changeState)
+    -> ExceptT (ErrBalanceTx era) m (Tx (ShelleyLedgerEra era), changeState)
 balanceTransaction
     utxoAssumptions
     pp
@@ -573,7 +575,7 @@ balanceTransaction
     genChange
     s
     partialTx
-    = do
+    = first fromCardanoApiTx <$> do
     let adjustedPartialTx = flip (over #tx) partialTx $
             assignMinimalAdaQuantitiesToOutputsWithoutAda
                 (recentEra @era)

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -143,7 +143,6 @@ import Control.Monad.Trans.State
     )
 import Data.Bifunctor
     ( bimap
-    , first
     , second
     )
 import Data.Bits
@@ -229,7 +228,6 @@ import Internal.Cardano.Write.Tx
     , evaluateMinimumFee
     , evaluateTransactionBalance
     , feeOfBytes
-    , fromCardanoApiTx
     , getFeePerByte
     , isBelowMinimumCoinForTxOut
     , maxScriptExecutionCost
@@ -575,7 +573,7 @@ balanceTransaction
     genChange
     s
     partialTx
-    = first fromCardanoApiTx <$> do
+    = do
     let adjustedPartialTx = flip (over #tx) partialTx $
             assignMinimalAdaQuantitiesToOutputsWithoutAda
                 (recentEra @era)
@@ -678,7 +676,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     -> changeState
     -> SelectionStrategy
     -> PartialTx era
-    -> ExceptT (ErrBalanceTx era) m (CardanoApi.Tx era, changeState)
+    -> ExceptT (ErrBalanceTx era) m (Tx (ShelleyLedgerEra era), changeState)
 balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     utxoAssumptions
     protocolParameters@(ProtocolParameters pp)
@@ -817,7 +815,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         (ExceptT . pure $
             distributeSurplus feePerByte surplus feeAndChange)
 
-    fmap ((, s') . toCardanoApiTx) . guardTxSize witCount
+    fmap ((, s')) . guardTxSize witCount
         =<< guardTxBalanced
         =<< assembleTransaction
         TxUpdate

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3380,7 +3380,7 @@ balanceTransaction
     -> Handler ApiSerialisedTransaction
 balanceTransaction
     ctx@ApiLayer{..} argGenChange utxoAssumptions (ApiT wid) body = do
-    (Write.InAnyRecentEra recentEra pp, timeTranslation)
+    (Write.InAnyRecentEra (recentEra :: Write.RecentEra era) pp, timeTranslation)
         <- liftIO $ W.readNodeTipStateForTxWrite netLayer
     withWorkerCtx ctx wid liftE liftE $ \wrk -> do
         (utxo, wallet, _txs) <- handler $ W.readWalletUTxO wrk
@@ -3389,7 +3389,11 @@ balanceTransaction
                 Write.fromWalletUTxO recentEra utxo
         partialTx <- parsePartialTx recentEra
         balancedTx <- liftHandler
-            . fmap (Cardano.InAnyCardanoEra Write.cardanoEra . fst)
+            . fmap
+                ( Cardano.InAnyCardanoEra Write.cardanoEra
+                . Write.toCardanoApiTx @era
+                . fst
+                )
             $ Write.balanceTransaction
                 utxoAssumptions
                 pp

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2348,6 +2348,7 @@ buildTransactionPure
             Write.constructUTxOIndex @era $
             Write.fromWalletUTxO (Write.recentEra @era) utxo
     withExceptT Left $
+        first Write.toCardanoApiTx <$>
         balanceTransaction @_ @_ @s
             (utxoAssumptionsForWallet (walletFlavor @s))
             pparams
@@ -2999,6 +3000,7 @@ transactionFee DBLayer{atomically, walletState} protocolParams
 
         wrapErrBalanceTx $ calculateFeePercentiles $ do
             res <- runExceptT $
+                first (Write.toCardanoApiTx @era) <$>
                     balanceTransaction @_ @_ @s
                         (utxoAssumptionsForWallet (walletFlavor @s))
                         protocolParams

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -168,6 +168,9 @@ import Control.Monad.Trans.State.Strict
     ( evalState
     , state
     )
+import Data.Bifunctor
+    ( first
+    )
 import Data.ByteArray.Encoding
     ( Base (Base16)
     , convertToBase
@@ -2070,7 +2073,7 @@ balanceTx
                 genChange
                 s
                 partialTx
-        pure transactionInEra
+        pure (Write.toCardanoApiTx transactionInEra)
   where
     utxoIndex = constructUTxOIndex @era $ fromWalletUTxO (recentEra @era) utxo
 
@@ -2084,6 +2087,7 @@ balanceTransactionWithDummyChangeState
     -> Either (ErrBalanceTx era) (CardanoApi.Tx era, DummyChangeState)
 balanceTransactionWithDummyChangeState utxoAssumptions utxo seed partialTx =
     (`evalRand` stdGenFromSeed seed) $ runExceptT $
+        first Write.toCardanoApiTx <$>
         balanceTransaction
             utxoAssumptions
             mockPParamsForBalancing


### PR DESCRIPTION
## Issue

ADP-3184

## Description

This PR adjusts `balanceTransaction` to return a value of type `Write.Tx era` instead of the equivalent `cardano-api` type.