### PR TITLE
Use ledger types in constructors of `Redeemer`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -128,6 +128,9 @@ module Internal.Cardano.Write.Tx
     , datumHashFromBytes
     , datumHashToBytes
 
+    -- ** Rewards
+    , RewardAccount
+
     -- ** Script
     , Script
     , Alonzo.isPlutusScript
@@ -610,6 +613,7 @@ type TxOutInBabbage = Babbage.BabbageTxOut (Babbage.BabbageEra StandardCrypto)
 
 type Address = Ledger.Addr StandardCrypto
 
+type RewardAccount = Ledger.RewardAcnt StandardCrypto
 type Script = AlonzoScript
 type Value = MaryValue StandardCrypto
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
@@ -18,14 +18,10 @@ module Internal.Cardano.Write.Tx.Redeemers
     ( assignScriptRedeemers
     , ErrAssignRedeemers (..)
     , Redeemer (..)
-    , toPolicyID
     ) where
 
 import Prelude
 
-import Cardano.Crypto.Hash.Class
-    ( Hash
-    )
 import Cardano.Ledger.Alonzo.TxInfo
     ( TranslationError
     )
@@ -36,12 +32,8 @@ import Cardano.Ledger.Api
     , scriptIntegrityHashTxBodyL
     , witsTxL
     )
-import Cardano.Ledger.Mary.Value
-    ( PolicyID (..)
-    )
 import Cardano.Ledger.Shelley.API
-    ( ScriptHash (..)
-    , StrictMaybe (..)
+    ( StrictMaybe (..)
     )
 import Cardano.Slotting.EpochInfo
     ( EpochInfo
@@ -87,9 +79,6 @@ import Data.Map.Strict
     ( Map
     , (!)
     )
-import Data.Maybe
-    ( fromMaybe
-    )
 import Fmt
     ( Buildable (..)
     )
@@ -116,15 +105,12 @@ import Internal.Cardano.Write.Tx.TimeTranslation
 
 import qualified Cardano.Api as CardanoApi
 import qualified Cardano.Api.Shelley as CardanoApi
-import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Ledger.Alonzo.PlutusScriptApi as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts.Data as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxWits as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
-import qualified Cardano.Wallet.Primitive.Types.Hash as W
-import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map as Map
 import qualified Data.Map.Merge.Strict as Map
@@ -302,15 +288,6 @@ toScriptPurpose = \case
         Alonzo.Minting pid
     RedeemerRewarding _ (CardanoApi.StakeAddress ntwrk acct) ->
         Alonzo.Rewarding (Ledger.RewardAcnt ntwrk acct)
-
-toPolicyID :: W.TokenPolicyId -> PolicyID StandardCrypto
-toPolicyID (W.UnsafeTokenPolicyId (W.Hash bytes)) =
-    PolicyID (ScriptHash (unsafeHashFromBytes bytes))
-  where
-    unsafeHashFromBytes :: Crypto.HashAlgorithm h => ByteString -> Hash h a
-    unsafeHashFromBytes =
-        fromMaybe (error "unsafeHashFromBytes: wrong length")
-        . Crypto.hashFromBytes
 
 --------------------------------------------------------------------------------
 -- Utils

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
@@ -101,6 +101,7 @@ import Internal.Cardano.Write.Tx
     , RecentEraLedgerConstraints
     , ShelleyLedgerEra
     , StandardCrypto
+    , TxIn
     , UTxO
     , txBody
     , withConstraints
@@ -122,8 +123,6 @@ import qualified Cardano.Ledger.Alonzo.TxWits as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
-import qualified Cardano.Wallet.Shelley.Compatibility.Ledger as Convert
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map as Map
 import qualified Data.Map.Merge.Strict as Map
@@ -273,7 +272,7 @@ assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
 --
 
 data Redeemer
-    = RedeemerSpending ByteString W.TxIn
+    = RedeemerSpending ByteString TxIn
     | RedeemerMinting ByteString W.TokenPolicyId
     | RedeemerRewarding ByteString CardanoApi.StakeAddress
     deriving (Eq, Generic, Show)
@@ -281,7 +280,7 @@ data Redeemer
 instance Buildable Redeemer where
     build = \case
         RedeemerSpending _ input ->
-            "spending(" <> build input <> ")"
+            "spending(" <> build (show input) <> ")"
         RedeemerMinting _ pid ->
             "minting(" <> build pid <> ")"
         RedeemerRewarding _ addr ->
@@ -296,7 +295,7 @@ redeemerData = \case
 toScriptPurpose :: Redeemer -> Alonzo.ScriptPurpose StandardCrypto
 toScriptPurpose = \case
     RedeemerSpending _ txin ->
-        Alonzo.Spending (Convert.toLedger txin)
+        Alonzo.Spending txin
     RedeemerMinting _ pid ->
         Alonzo.Minting (toPolicyID pid)
     RedeemerRewarding _ (CardanoApi.StakeAddress ntwrk acct) ->

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
@@ -18,6 +18,7 @@ module Internal.Cardano.Write.Tx.Redeemers
     ( assignScriptRedeemers
     , ErrAssignRedeemers (..)
     , Redeemer (..)
+    , toPolicyID
     ) where
 
 import Prelude
@@ -97,6 +98,7 @@ import GHC.Generics
     )
 import Internal.Cardano.Write.Tx
     ( PParams
+    , PolicyId
     , RecentEra
     , RecentEraLedgerConstraints
     , ShelleyLedgerEra
@@ -273,7 +275,7 @@ assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
 
 data Redeemer
     = RedeemerSpending ByteString TxIn
-    | RedeemerMinting ByteString W.TokenPolicyId
+    | RedeemerMinting ByteString PolicyId
     | RedeemerRewarding ByteString CardanoApi.StakeAddress
     deriving (Eq, Generic, Show)
 
@@ -282,7 +284,7 @@ instance Buildable Redeemer where
         RedeemerSpending _ input ->
             "spending(" <> build (show input) <> ")"
         RedeemerMinting _ pid ->
-            "minting(" <> build pid <> ")"
+            "minting(" <> build (show pid) <> ")"
         RedeemerRewarding _ addr ->
             "rewarding(" <> build (CardanoApi.serialiseToBech32 addr) <> ")"
 
@@ -297,7 +299,7 @@ toScriptPurpose = \case
     RedeemerSpending _ txin ->
         Alonzo.Spending txin
     RedeemerMinting _ pid ->
-        Alonzo.Minting (toPolicyID pid)
+        Alonzo.Minting pid
     RedeemerRewarding _ (CardanoApi.StakeAddress ntwrk acct) ->
         Alonzo.Rewarding (Ledger.RewardAcnt ntwrk acct)
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
@@ -90,6 +90,7 @@ import Internal.Cardano.Write.Tx
     , PolicyId
     , RecentEra
     , RecentEraLedgerConstraints
+    , RewardAccount
     , ShelleyLedgerEra
     , StandardCrypto
     , TxIn
@@ -103,7 +104,6 @@ import Internal.Cardano.Write.Tx.TimeTranslation
     , systemStartTime
     )
 
-import qualified Cardano.Api as CardanoApi
 import qualified Cardano.Api.Shelley as CardanoApi
 import qualified Cardano.Ledger.Alonzo.PlutusScriptApi as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
@@ -262,7 +262,7 @@ assignScriptRedeemers era pparams timeTranslation utxo redeemers tx =
 data Redeemer
     = RedeemerSpending ByteString TxIn
     | RedeemerMinting ByteString PolicyId
-    | RedeemerRewarding ByteString CardanoApi.StakeAddress
+    | RedeemerRewarding ByteString RewardAccount
     deriving (Eq, Generic, Show)
 
 instance Buildable Redeemer where
@@ -271,8 +271,8 @@ instance Buildable Redeemer where
             "spending(" <> build (show input) <> ")"
         RedeemerMinting _ pid ->
             "minting(" <> build (show pid) <> ")"
-        RedeemerRewarding _ addr ->
-            "rewarding(" <> build (CardanoApi.serialiseToBech32 addr) <> ")"
+        RedeemerRewarding _ acc ->
+            "rewarding(" <> build (show acc) <> ")"
 
 redeemerData :: Redeemer -> ByteString
 redeemerData = \case
@@ -286,8 +286,8 @@ toScriptPurpose = \case
         Alonzo.Spending txin
     RedeemerMinting _ pid ->
         Alonzo.Minting pid
-    RedeemerRewarding _ (CardanoApi.StakeAddress ntwrk acct) ->
-        Alonzo.Rewarding (Ledger.RewardAcnt ntwrk acct)
+    RedeemerRewarding _ acc ->
+        Alonzo.Rewarding acc
 
 --------------------------------------------------------------------------------
 -- Utils

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -4934,7 +4934,7 @@ fromApiRedeemer = \case
     ApiRedeemerSpending (ApiBytesT bytes) (ApiT i) ->
         RedeemerSpending bytes (toLedger i)
     ApiRedeemerMinting (ApiBytesT bytes) (ApiT p) ->
-        RedeemerMinting bytes p
+        RedeemerMinting bytes (toLedger p)
     ApiRedeemerRewarding (ApiBytesT bytes) r ->
         RedeemerRewarding bytes r
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -4932,7 +4932,7 @@ fromExternalInput ApiExternalInput
 fromApiRedeemer :: ApiRedeemer n -> Redeemer
 fromApiRedeemer = \case
     ApiRedeemerSpending (ApiBytesT bytes) (ApiT i) ->
-        RedeemerSpending bytes i
+        RedeemerSpending bytes (toLedger i)
     ApiRedeemerMinting (ApiBytesT bytes) (ApiT p) ->
         RedeemerMinting bytes p
     ApiRedeemerRewarding (ApiBytesT bytes) r ->

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -160,9 +160,15 @@ import Cardano.Api
     , toNetworkMagic
     , unNetworkMagic
     )
+import Cardano.Api.Shelley
+    ( StakeAddress (..)
+    )
 import Cardano.BM.Tracing
     ( HasPrivacyAnnotation (..)
     , HasSeverityAnnotation (..)
+    )
+import Cardano.Ledger.Address
+    ( RewardAcnt (..)
     )
 import Cardano.Mnemonic
     ( SomeMnemonic
@@ -4935,8 +4941,8 @@ fromApiRedeemer = \case
         RedeemerSpending bytes (toLedger i)
     ApiRedeemerMinting (ApiBytesT bytes) (ApiT p) ->
         RedeemerMinting bytes (toLedger p)
-    ApiRedeemerRewarding (ApiBytesT bytes) r ->
-        RedeemerRewarding bytes r
+    ApiRedeemerRewarding (ApiBytesT bytes) (StakeAddress x y) ->
+        RedeemerRewarding bytes (RewardAcnt x y)
 
 {-------------------------------------------------------------------------------
                                 Api Layer

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -741,7 +741,9 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
             -- With ix 1 instead of 0, making it point to an input which
             -- doesn't exist in the tx.
             let faultyRedeemer =
-                    RedeemerSpending (unsafeFromHex "D87A80") (W.TxIn tid 1)
+                    RedeemerSpending
+                        (unsafeFromHex "D87A80")
+                        (Convert.toLedger (W.TxIn tid 1))
 
             let withFaultyRedeemer =
                     over #redeemers $ mapFirst $ const faultyRedeemer
@@ -2538,7 +2540,9 @@ pingPong_2 = PartialTx
           )
         ]
     , redeemers =
-        [ RedeemerSpending (unsafeFromHex "D87A80") (W.TxIn (W.Hash tid) 0)
+        [ RedeemerSpending
+            (unsafeFromHex "D87A80")
+            (Convert.toLedger (W.TxIn (W.Hash tid) 0))
         ]
     }
   where


### PR DESCRIPTION
## Issue

ADP-3184

## Description

This PR adjusts the `Redeemer` type so that its constructors use ledger types, thus eliminating usages of types from:
- `cardano-api`;
- `cardano-wallet-primitive`.