### PR TITLE
[ADP-3229] Move retrieval of recent era pparams to network layer

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -116,7 +116,6 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (TxOut)
     )
 import qualified Data.Map.Strict as Map
-import qualified Internal.Cardano.Write.Tx as Write
 import qualified Ouroboros.Consensus.Block as O
 
 --------------------------------------------------------------------------------
@@ -167,7 +166,6 @@ mainnetNetworkParameters =
                   maximumCollateralInputCount = 0
                 , minimumCollateralPercentage = 0
                 , executionUnitPrices = Nothing
-                , currentLedgerProtocolParameters = Write.InNonRecentEraByron
                 }
         }
 
@@ -310,7 +308,6 @@ protocolParametersFromPP eraInfo pp =
           maximumCollateralInputCount = 0
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing
-        , currentLedgerProtocolParameters = Write.InNonRecentEraByron
         }
   where
     fromBound (Bound _relTime _slotNo (O.EpochNo e)) =

--- a/lib/wallet/src/Cardano/Wallet/Network.hs
+++ b/lib/wallet/src/Cardano/Wallet/Network.hs
@@ -123,6 +123,9 @@ import Fmt
 import GHC.Generics
     ( Generic
     )
+import Internal.Cardano.Write.Tx
+    ( MaybeInRecentEra
+    )
 import NoThunks.Class
     ( AllowThunksIn (..)
     , NoThunks (..)
@@ -141,6 +144,7 @@ import UnliftIO.Concurrent
     )
 
 import qualified Data.List.NonEmpty as NE
+import qualified Internal.Cardano.Write.ProtocolParameters as Write
 
 {-------------------------------------------------------------------------------
     ChainSync
@@ -176,6 +180,10 @@ data NetworkLayer m block = NetworkLayer
         :: m ProtocolParameters
         -- ^ Get the last known protocol parameters. In principle, these can
         -- only change once per epoch.
+
+    , currentProtocolParametersInRecentEras
+        :: m (MaybeInRecentEra Write.ProtocolParameters)
+        -- ^ Get the last known protocol parameters for recent eras.
 
     , currentSlottingParameters
         :: m SlottingParameters

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
@@ -307,9 +307,6 @@ import GHC.Generics
 import GHC.Stack
     ( HasCallStack
     )
-import Internal.Cardano.Write.Tx
-    ( MaybeInRecentEra
-    )
 import Network.URI
     ( URI (..)
     , uriToString
@@ -327,7 +324,6 @@ import Test.QuickCheck
 
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
-import qualified Internal.Cardano.Write.ProtocolParameters as Write
 
 {-------------------------------------------------------------------------------
                              Wallet Metadata
@@ -947,10 +943,6 @@ data ProtocolParameters = ProtocolParameters
         -- used to determine the fee for the use of a script within a
         -- transaction, based on the 'ExecutionUnits' needed by the use of
         -- the script.
-    , currentLedgerProtocolParameters
-        :: MaybeInRecentEra Write.ProtocolParameters
-        -- ^ The full, raw ledger protocol parameters for writing (constructing)
-        -- transactions in case the node is in a recent era.
     } deriving (Eq, Generic, Show)
 
 instance NFData ProtocolParameters where

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -414,8 +414,6 @@ import qualified Data.ByteString.Short as SBS
 import qualified Data.ListMap as ListMap
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import qualified Internal.Cardano.Write.ProtocolParameters as Write
-import qualified Internal.Cardano.Write.Tx as Write
 import qualified Ouroboros.Consensus.Protocol.Praos as Consensus
 import qualified Ouroboros.Consensus.Protocol.Praos.Header as Consensus
 import qualified Ouroboros.Consensus.Protocol.TPraos as Consensus
@@ -632,7 +630,6 @@ fromShelleyPParams eraInfo pp =
         , maximumCollateralInputCount = 0
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing
-        , currentLedgerProtocolParameters = Write.InNonRecentEraShelley
         }
 
 fromAllegraPParams
@@ -653,7 +650,6 @@ fromAllegraPParams eraInfo pp =
         , maximumCollateralInputCount = 0
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing
-        , currentLedgerProtocolParameters = Write.InNonRecentEraAllegra
         }
 
 fromMaryPParams
@@ -674,7 +670,6 @@ fromMaryPParams eraInfo pp =
         , maximumCollateralInputCount = 0
         , minimumCollateralPercentage = 0
         , executionUnitPrices = Nothing
-        , currentLedgerProtocolParameters = Write.InNonRecentEraMary
         }
 
 fromBoundToEpochNo :: Bound -> W.EpochNo
@@ -703,7 +698,6 @@ fromAlonzoPParams eraInfo pp =
             pp ^. ppCollateralPercentageL
         , executionUnitPrices =
             Just $ executionUnitPricesFromPParams pp
-        , currentLedgerProtocolParameters = Write.InNonRecentEraAlonzo
         }
 
 fromBabbagePParams
@@ -729,8 +723,6 @@ fromBabbagePParams eraInfo pp =
             pp ^. ppCollateralPercentageL
         , executionUnitPrices =
             Just $ executionUnitPricesFromPParams pp
-        , currentLedgerProtocolParameters =
-            Write.InRecentEraBabbage $ Write.ProtocolParameters pp
         }
 
 fromConwayPParams
@@ -755,8 +747,6 @@ fromConwayPParams eraInfo pp =
                     (error "Maximum count of collateral inputs exceeds 2^16")
         , minimumCollateralPercentage = pp ^. ppCollateralPercentageL
         , executionUnitPrices = Just $ executionUnitPricesFromPParams pp
-        , currentLedgerProtocolParameters =
-            Write.InRecentEraConway $ Write.ProtocolParameters pp
         }
 
 -- | Extract the current network decentralization level from the given set of

--- a/lib/wallet/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/wallet/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -98,8 +98,6 @@ import GHC.Stack
 
 import qualified Cardano.Api.Shelley as C
 import qualified Data.ByteString.Char8 as B8
-import qualified Internal.Cardano.Write.ProtocolParameters as Write
-import qualified Internal.Cardano.Write.Tx as Write
 
 {-----------------------------------------------------------------------------
     Dummy values
@@ -168,12 +166,6 @@ dummyProtocolParameters = ProtocolParameters
             { pricePerStep = 7.21e-5
             , pricePerMemoryUnit = 0.057_7
             }
-    , currentLedgerProtocolParameters =
-        Write.InRecentEraBabbage . Write.ProtocolParameters $
-            either (error . show) id $
-                C.toLedgerPParams
-                    C.ShelleyBasedEraBabbage
-                    dummyNodeProtocolParameters
     }
 
 -- | Dummy parameters that are consistent with the @dummy*@ parameters.
@@ -227,6 +219,8 @@ dummyNetworkLayer = NetworkLayer
     , currentNodeTip = err "currentNodeTip"
     , watchNodeTip = err "watchNodeTip"
     , currentProtocolParameters = err "currentProtocolParameters"
+    , currentProtocolParametersInRecentEras
+        = err "currentProtocolParametersInRecentEras"
     , currentSlottingParameters = err "currentSlottingParameters"
     , postTx = err "postTx"
     , stakeDistribution = err "stakeDistribution"

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -341,7 +341,6 @@ import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map
-import qualified Internal.Cardano.Write.Tx as Write
 
 {-------------------------------------------------------------------------------
                                  Modifiers
@@ -815,7 +814,6 @@ instance Arbitrary ProtocolParameters where
         <:> shrink
         <:> shrink
         <:> shrink
-        <:> const []
         <:> Nil
     arbitrary = ProtocolParameters
         <$> arbitrary
@@ -826,7 +824,6 @@ instance Arbitrary ProtocolParameters where
         <*> genMaximumCollateralInputCount
         <*> genMinimumCollateralPercentage
         <*> arbitrary
-        <*> pure Write.InNonRecentEraAlonzo
       where
         genMaximumCollateralInputCount :: Gen Word16
         genMaximumCollateralInputCount = arbitrarySizedNatural


### PR DESCRIPTION
- [x] remove `currentLedgerProtocolParameters` from ProtocolParameters
- [x] add `currentProtocolParametersInRecentEras` to NetworkLayer

ADP-3229