### PR TITLE
Remove `Write.withConstraints era` function

### DIFF
--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -31,12 +31,12 @@ import Data.Word
     ( Word64
     )
 import Internal.Cardano.Write.Tx
-    ( ProtVer (..)
+    ( IsRecentEra (..)
+    , ProtVer (..)
     , RecentEra (..)
     , StandardBabbage
     , StandardConway
     , Version
-    , withConstraints
     )
 import Internal.Cardano.Write.Tx.Balance.TokenBundleSize
     ( TokenBundleSizeAssessor
@@ -280,9 +280,10 @@ instance Arbitrary PParamsInRecentEra where
 
       where
         genPParams
-            :: RecentEra era
+            :: IsRecentEra era
+            => RecentEra era
             -> Gen (PParams era)
-        genPParams era = withConstraints era $ do
+        genPParams _era = do
             ver <- arbitrary
             maxSize <- genMaxSizeBytes
             return $ def

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/TxSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/TxSpec.hs
@@ -11,7 +11,8 @@ module Internal.Cardano.Write.TxSpec where
 import Prelude
 
 import Cardano.Ledger.Api
-    ( coinTxOutL
+    ( PParams
+    , coinTxOutL
     , ppCoinsPerUTxOByteL
     )
 import Control.Lens
@@ -27,7 +28,7 @@ import Data.Default
 import Internal.Cardano.Write.Tx
     ( AnyRecentEra
     , BabbageEra
-    , RecentEra (..)
+    , ConwayEra
     , computeMinimumCoinForTxOut
     , datumHashFromBytes
     , datumHashToBytes
@@ -106,20 +107,20 @@ spec = do
             it "isBelowMinimumCoinForTxOut (setCoin (result <> delta)) \
                \ == False (Babbage)"
                 $ property $ \out delta perByte -> do
-                    let pp = def & ppCoinsPerUTxOByteL .~ perByte
-                    let era = RecentEraBabbage
-                    let c = delta <> computeMinimumCoinForTxOut era pp out
-                    isBelowMinimumCoinForTxOut era pp
+                    let pp = (def :: PParams BabbageEra)
+                            & ppCoinsPerUTxOByteL .~ perByte
+                    let c = delta <> computeMinimumCoinForTxOut pp out
+                    isBelowMinimumCoinForTxOut pp
                         (out & coinTxOutL .~ c )
                         === False
 
             it "isBelowMinimumCoinForTxOut (setCoin (result <> delta)) \
                \ == False (Conway)"
                 $ property $ \out delta perByte -> do
-                    let pp = def & ppCoinsPerUTxOByteL .~ perByte
-                    let era = RecentEraConway
-                    let c = delta <> computeMinimumCoinForTxOut era pp out
-                    isBelowMinimumCoinForTxOut era pp
+                    let pp = (def :: PParams ConwayEra)
+                            & ppCoinsPerUTxOByteL .~ perByte
+                    let c = delta <> computeMinimumCoinForTxOut pp out
+                    isBelowMinimumCoinForTxOut pp
                         (out & coinTxOutL .~ c)
                         === False
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -1046,7 +1046,7 @@ instance
             , pretty $ listF $ L.sort
                 $ fmap (view #coin . view #tokens . snd)
                 $ UTxO.toList
-                $ Write.toWalletUTxO (Write.recentEra @era)
+                $ Write.toWalletUTxO
                 $ view #largestCombinationAvailable e
             , "To fix this, you'll need to add one or more pure ada UTxOs"
             , "to your wallet that can cover the minimum amount required."

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3408,7 +3408,7 @@ balanceTransaction
         (utxo, wallet, _txs) <- handler $ W.readWalletUTxO wrk
         let utxoIndex =
                 Write.constructUTxOIndex $
-                Write.fromWalletUTxO era utxo
+                Write.fromWalletUTxO utxo
         partialTx <- parsePartialTx era
         balancedTx <- liftHandler
             . fmap

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2343,7 +2343,7 @@ buildTransactionPure
                 (Left preSelection)
     let utxoIndex =
             Write.constructUTxOIndex @era $
-            Write.fromWalletUTxO (Write.recentEra @era) utxo
+            Write.fromWalletUTxO utxo
     withExceptT Left $
         first Write.toCardanoApiTx <$>
         balanceTransaction @_ @_ @s
@@ -2907,7 +2907,7 @@ getStakeKeyDeposit
     => Write.PParams era
     -> Coin
 getStakeKeyDeposit = toWallet
-    . Write.stakeKeyDeposit (recentEra @era)
+    . Write.stakeKeyDeposit
 
 isStakeKeyRegistered
     :: Functor stm
@@ -2929,7 +2929,7 @@ delegationFee
     -> ChangeAddressGen s
     -> IO DelegationFee
 delegationFee db@DBLayer{..} netLayer changeAddressGen = do
-    (Write.PParamsInAnyRecentEra era protocolParams, timeTranslation)
+    (Write.PParamsInAnyRecentEra _era protocolParams, timeTranslation)
         <- readNodeTipStateForTxWrite netLayer
     feePercentiles <- transactionFee
         db protocolParams timeTranslation changeAddressGen
@@ -2941,7 +2941,7 @@ delegationFee db@DBLayer{..} netLayer changeAddressGen = do
     deposit <- liftIO
         $ atomically (isStakeKeyRegistered walletState) <&> \case
             False -> toWallet
-                $ Write.stakeKeyDeposit era protocolParams
+                $ Write.stakeKeyDeposit protocolParams
             True -> Coin 0
     pure DelegationFee { feePercentiles, deposit }
 
@@ -2981,7 +2981,7 @@ transactionFee DBLayer{atomically, walletState} protocolParams
             --
             evaluate
                 $ Write.constructUTxOIndex @era
-                $ Write.fromWalletUTxO (Write.recentEra @era)
+                $ Write.fromWalletUTxO
                 $ availableUTxO mempty wallet
         unsignedTxBody <- wrapErrMkTransaction $
             mkUnsignedTransaction era

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1140,7 +1140,7 @@ mkShelleyWitness
     -> Cardano.TxBody (CardanoApiEra era)
     -> (XPrv, Passphrase "encryption")
     -> Cardano.KeyWitness (CardanoApiEra era)
-mkShelleyWitness era body key =
+mkShelleyWitness _era body key =
     Cardano.makeShelleyKeyWitness body (unencrypt key)
   where
     unencrypt (xprv, pwd) = Cardano.WitnessPaymentExtendedKey

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -263,6 +263,7 @@ import Fmt
 import Internal.Cardano.Write.Tx
     ( AnyRecentEra (..)
     , CardanoApiEra
+    , IsRecentEra
     , RecentEra (..)
     , ShelleyLedgerEra
     , cardanoEraFromRecentEra
@@ -526,8 +527,7 @@ prop_signTransaction_addsRewardAccountKey
                 expectedWits :: [InAnyCardanoEra Cardano.KeyWitness]
                 expectedWits = withCardanoApiConstraints era $
                     InAnyCardanoEra era <$>
-                        [ mkShelleyWitness
-                            recentEra txBody rawRewardK
+                        [ mkShelleyWitness recentEra txBody rawRewardK
                         ]
 
             expectedWits `checkSubsetOf` (getSealedTxWitnesses sealedTx')
@@ -1312,7 +1312,8 @@ prop_sealedTxRecentEraRoundtrip
     sealedTxB = sealedTxFromBytes' currentEra txBytes
 
 makeShelleyTx
-    :: RecentEra era
+    :: IsRecentEra era
+    => RecentEra era
     -> DecodeSetup
     -> Cardano.Tx (CardanoApiEra era)
 makeShelleyTx era testCase = Cardano.makeSignedTransaction addrWits unsigned
@@ -1710,7 +1711,9 @@ instance (Eq a, Show a) => Ord (ShowOrd a) where
 -- | Hack until signTransaction and properties are converted to ledger types
 withCardanoApiConstraints
     :: forall era a. CardanoEra era
-    -> ((CardanoApiEra (ShelleyLedgerEra era) ~ era) => a)
+    -> ( ( CardanoApiEra (ShelleyLedgerEra era) ~ era
+         , IsRecentEra (ShelleyLedgerEra era)
+         ) => a)
     -> a
 withCardanoApiConstraints e a = case e of
     Cardano.ConwayEra -> a

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -263,7 +263,6 @@ import Internal.Cardano.Write.Tx
     , toCardanoApiTx
     , toCardanoApiUTxO
     , utxoFromTxOutsInRecentEra
-    , withConstraints
     )
 import Internal.Cardano.Write.Tx.Balance
     ( ChangeAddressGen (..)
@@ -518,7 +517,6 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
             evaluateMinimumFeeSize tx = fromIntegral
                 $ Write.unCoin
                 $ Write.evaluateMinimumFee
-                    (recentEra @era)
                     pp
                     (withNoKeyWits tx)
                     (KeyWitnessCount 0 (fromIntegral $ length wits))
@@ -527,8 +525,7 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
 
                 -- Dummy PParams to ensure a Coin-delta corresponds to a
                 -- size-delta.
-                pp = withConstraints (recentEra @era) $
-                    Ledger.emptyPParams & set ppMinFeeAL (Ledger.Coin 1)
+                pp = Ledger.emptyPParams & set ppMinFeeAL (Ledger.Coin 1)
 
         let evaluateMinimumFeeDerivedWitSize tx
                 = evaluateMinimumFeeSize tx
@@ -610,17 +607,16 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
             s' `shouldBe` DummyChangeState { nextUnusedIndex = nChange }
 
     it "assigns minimal ada quantities to outputs without ada" $ do
-        let era = RecentEraBabbage
         let out = W.TxOut dummyAddr (W.TokenBundle.fromCoin (W.Coin 0))
         let out' = W.TxOut dummyAddr (W.TokenBundle.fromCoin (W.Coin 874_930))
         let CardanoApi.ShelleyTx _ tx = either (error . show) id
                 $ balance
                 $ paymentPartialTx [ out ]
-        let outs = Write.outputs era $ Write.txBody era tx
+        let outs = Write.outputs $ Write.txBody tx
 
         let pp = def
                 & ppCoinsPerUTxOByteL .~ testParameter_coinsPerUTxOByte_Babbage
-        Write.isBelowMinimumCoinForTxOut era pp (head outs)
+        Write.isBelowMinimumCoinForTxOut pp (head outs)
             `shouldBe` False
 
         head outs `shouldBe` (Convert.toBabbageTxOut out')
@@ -751,7 +747,7 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
         :: CardanoApi.Tx CardanoApi.BabbageEra
         -> [Babbage.BabbageTxOut StandardBabbage]
     outputs (CardanoApi.Tx (CardanoApi.ShelleyTxBody _ body _ _ _ _ ) _) =
-        Write.outputs RecentEraBabbage body
+        Write.outputs body
 
     mapFirst f (x:xs) = f x : xs
     mapFirst _ [] = error "mapFirst: empty list"
@@ -880,7 +876,7 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
                     ptx
                 combinedUTxO = toCardanoApiUTxO $ mconcat
                     [ view #inputs ptx
-                    , fromWalletUTxO RecentEraBabbage walletUTxO
+                    , fromWalletUTxO walletUTxO
                     ]
             in
                 case res of
@@ -1100,14 +1096,10 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
         let pparams = mockPParamsForBalancing @era
             CardanoApi.Tx cardanoApiBody _ = toCardanoApiTx tx
             witCount dummyAddr = estimateKeyWitnessCount
-                (utxoPromisingInputsHaveAddress era dummyAddr tx)
+                (utxoPromisingInputsHaveAddress dummyAddr tx)
                 (cardanoApiBody)
-            era = recentEra @era
-
-            noScripts = withConstraints (recentEra @era)
-                $ Map.null $ tx ^. witsTxL . scriptTxWitsL
-            noBootWits = withConstraints (recentEra @era)
-                $ Set.null $ tx ^. witsTxL . bootAddrTxWitsL
+            noScripts = Map.null $ tx ^. witsTxL . scriptTxWitsL
+            noBootWits = Set.null $ tx ^. witsTxL . bootAddrTxWitsL
             testDoesNotYetSupport x =
                 pendingWith $ "Test setup does not work for txs with " <> x
 
@@ -1115,7 +1107,7 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
 
         case (noScripts, noBootWits) of
                 (True, True) -> do
-                    estimateSignedTxSize era pparams (witCount vkCredAddr) tx
+                    estimateSignedTxSize pparams (witCount vkCredAddr) tx
                         `shouldBeInclusivelyWithin`
                         ( signedBinarySize - correction
                         , signedBinarySize
@@ -1123,7 +1115,7 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
                 (False, False) ->
                     testDoesNotYetSupport "bootstrap wits + scripts"
                 (True, False) ->
-                    estimateSignedTxSize era pparams (witCount bootAddr) tx
+                    estimateSignedTxSize pparams (witCount bootAddr) tx
                         `shouldBeInclusivelyWithin`
                         ( signedBinarySize - correction
                         , signedBinarySize + bootWitsCanBeLongerBy
@@ -1158,13 +1150,12 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
     -- as estimateSignedTxSize can tell that all inputs in the tx correspond to
     -- outputs with vk payment credentials.
     utxoPromisingInputsHaveAddress
-        :: forall era. HasCallStack
-        => RecentEra era
-        -> W.Address
+        :: forall era. (HasCallStack, IsRecentEra era)
+        => W.Address
         -> Tx era
         -> UTxO era
-    utxoPromisingInputsHaveAddress era addr tx =
-        utxoFromTxOutsInRecentEra era $
+    utxoPromisingInputsHaveAddress addr tx =
+        utxoFromTxOutsInRecentEra (recentEra @era) $
             [ (i
               , TxOutInRecentEra
                     (Convert.toLedger addr)
@@ -1178,8 +1169,8 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
         allInputs
             :: Tx era
             -> [TxIn]
-        allInputs body = withConstraints era
-            $ Set.toList
+        allInputs body =
+            Set.toList
             $ body ^. (bodyTxL . allInputsTxBodyF)
 
     -- An address with a vk payment credential. For the test above, this is the
@@ -1208,7 +1199,7 @@ spec_updateTx = describe "updateTx" $ do
         txs <- readTestTransactions
         forM_ txs $ \(filepath, tx :: Tx era) -> do
             it ("without TxUpdate: " <> filepath) $ do
-                    let res = updateTx (recentEra @era) tx noTxUpdate
+                    let res = updateTx tx noTxUpdate
                     case res of
                         Left e ->
                             expectationFailure $
@@ -1258,7 +1249,6 @@ spec_updateTx = describe "updateTx" $ do
             let tx = deserializeBabbageTx
                     $ snd $ head signedTxs
             let res = updateTx
-                    RecentEraBabbage
                     tx
                     noTxUpdate
 
@@ -1336,7 +1326,7 @@ prop_balanceTransactionValid
         withMaxSuccess 1_000 $ do
         let combinedUTxO =
                 view #inputs partialTx
-                <> fromWalletUTxO (recentEra @era) walletUTxO
+                <> fromWalletUTxO walletUTxO
         let originalTx = toCardanoApiTx (view #tx partialTx)
         let originalBalance = txBalance originalTx combinedUTxO
         let originalOuts = txOutputs originalTx
@@ -1508,9 +1498,8 @@ prop_balanceTransactionValid
         -> UTxO era
         -> Property
     prop_validSize tx@(CardanoApi.Tx body _) utxo = do
-        let era = recentEra @era
         let (W.TxSize size) =
-                estimateSignedTxSize era ledgerPParams
+                estimateSignedTxSize ledgerPParams
                     (estimateKeyWitnessCount utxo body)
                     (fromCardanoApiTx tx)
         let limit = ledgerPParams ^. ppMaxTxSizeL
@@ -1528,14 +1517,12 @@ prop_balanceTransactionValid
         :: CardanoApi.Tx (CardanoApiEra era)
         -> Property
     _prop_outputsSatisfyMinAdaRequirement (CardanoApi.ShelleyTx _ tx) = do
-        let outputs = Write.outputs era $ Write.txBody era tx
+        let outputs = Write.outputs $ Write.txBody tx
         conjoin $ map valid outputs
       where
-        era = recentEra @era
-
         valid :: TxOut era -> Property
         valid out = counterexample msg $ property $
-            not $ Write.isBelowMinimumCoinForTxOut era ledgerPParams out
+            not $ Write.isBelowMinimumCoinForTxOut ledgerPParams out
           where
             msg = unwords
                 [ "ada quantity is"
@@ -1545,16 +1532,14 @@ prop_balanceTransactionValid
                 , "\n"
                 , "Suggested ada quantity (may overestimate requirement):"
                 , show $ Write.computeMinimumCoinForTxOut
-                    (recentEra @era)
                     ledgerPParams
                     out
                 ]
 
     hasZeroAdaOutputs :: CardanoApi.Tx (CardanoApiEra era) -> Bool
     hasZeroAdaOutputs (CardanoApi.ShelleyTx _ tx) =
-        any hasZeroAda (Write.outputs era $ Write.txBody era tx)
+        any hasZeroAda (tx ^. bodyTxL . outputsTxBodyL)
       where
-        era = recentEra @era
         hasZeroAda (Write.BabbageTxOut _ val _ _) =
             Value.coin val == Ledger.Coin 0
 
@@ -1576,7 +1561,7 @@ prop_balanceTransactionValid
         -> UTxO era
         -> CardanoApi.Lovelace
     minFee tx@(CardanoApi.Tx body _) utxo = Write.toCardanoApiLovelace
-        $ Write.evaluateMinimumFee (recentEra @era) ledgerPParams
+        $ Write.evaluateMinimumFee ledgerPParams
             (fromCardanoApiTx tx)
             (estimateKeyWitnessCount utxo body)
 
@@ -1586,12 +1571,9 @@ prop_balanceTransactionValid
         -> CardanoApi.Value
     txBalance tx u = Write.toCardanoApiValue @era $
         Write.evaluateTransactionBalance
-            era
             ledgerPParams
             u
-            (Write.txBody era $ fromCardanoApiTx tx)
-      where
-        era = recentEra @era
+            (Write.txBody $ fromCardanoApiTx tx)
 
     ledgerPParams = mockPParamsForBalancing @era
 
@@ -1967,7 +1949,7 @@ prop_updateTx
 prop_updateTx tx extraIns extraCol extraOuts newFee = do
     let extra = TxUpdate extraIns extraCol extraOuts [] (UseNewTxFee newFee)
     let tx' = either (error . show) id
-            $ updateTx era tx extra
+            $ updateTx tx extra
     conjoin
         [ inputs tx' === inputs tx
             <> Set.fromList (fromWalletTxIn . fst <$> extraIns)
@@ -1984,16 +1966,12 @@ prop_updateTx tx extraIns extraCol extraOuts newFee = do
     fromWalletTxOut = case era of
         RecentEraBabbage -> Convert.toBabbageTxOut
 
-    fromWalletTxIn = Write.withConstraints era Convert.toLedger
+    fromWalletTxIn = Convert.toLedger
 
-    inputs = Write.withConstraints era $
-        view (bodyTxL . inputsTxBodyL)
-    outputs = Write.withConstraints era $
-        view (bodyTxL . outputsTxBodyL)
-    collateralIns = Write.withConstraints era $
-        view (bodyTxL . collateralInputsTxBodyL)
-    fee = Write.withConstraints era $
-        view (bodyTxL . feeTxBodyL)
+    inputs = view (bodyTxL . inputsTxBodyL)
+    outputs = view (bodyTxL . outputsTxBodyL)
+    collateralIns = view (bodyTxL . collateralInputsTxBodyL)
+    fee = view (bodyTxL . feeTxBodyL)
 
 --------------------------------------------------------------------------------
 -- Utility types
@@ -2069,7 +2047,7 @@ balanceTx
                 partialTx
         pure (Write.toCardanoApiTx transactionInEra)
   where
-    utxoIndex = constructUTxOIndex @era $ fromWalletUTxO (recentEra @era) utxo
+    utxoIndex = constructUTxOIndex @era $ fromWalletUTxO utxo
 
 -- | Also returns the updated change state
 balanceTransactionWithDummyChangeState
@@ -2094,7 +2072,7 @@ balanceTransactionWithDummyChangeState utxoAssumptions utxo seed partialTx =
                 DummyChangeState { nextUnusedIndex = 0 })
             partialTx
   where
-    utxoIndex = constructUTxOIndex @era $ fromWalletUTxO (recentEra @era) utxo
+    utxoIndex = constructUTxOIndex @era $ fromWalletUTxO utxo
 
 deserializeBabbageTx :: ByteString -> Tx Write.BabbageEra
 deserializeBabbageTx = fromCardanoApiTx @BabbageEra . either (error . show) id
@@ -2205,7 +2183,6 @@ txMinFee
 txMinFee tx@(CardanoApi.Tx body _) u =
     Write.toCardanoApiLovelace $
     Write.evaluateMinimumFee
-        RecentEraBabbage
         (mockPParamsForBalancing @Write.BabbageEra)
         (fromCardanoApiTx tx)
         (estimateKeyWitnessCount (fromCardanoApiUTxO u) body)


### PR DESCRIPTION
...and favor the constraint `IsRecentEra era` over the value `RecentEra era`.

Now that we use `PParams era` instead of `PParams (ShelleyLedgerEra era)` we can often infer the era, just requiring the `IsRecentEra` constraint.

And now all the constraints we are interested in are superclass constraints of `IsRecentEra`, so we don't need `withConstraints` to bring them into scope.

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-2353
