### PR TITLE
Revise `Range` module and test suite.

### DIFF
--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -207,6 +207,7 @@ test-suite test
     Cardano.Wallet.Primitive.Types.CoinSpec
     Cardano.Wallet.Primitive.Types.HashSpec
     Cardano.Wallet.Primitive.Types.PoolIdSpec
+    Cardano.Wallet.Primitive.Types.RangeSpec
     Cardano.Wallet.Primitive.Types.TokenBundleSpec
     Cardano.Wallet.Primitive.Types.TokenMapSpec
     Cardano.Wallet.Primitive.Types.TokenPolicySpec

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Range.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Range.hs
@@ -3,19 +3,19 @@
 module Cardano.Wallet.Primitive.Types.Range
     ( Range (..)
     , RangeBound (..)
-    , mapRangeLowerBound
-    , mapRangeUpperBound
-    , wholeRange
-    , isAfterRange
-    , isBeforeRange
-    , isWithinRange
-    , rangeHasLowerBound
-    , rangeHasUpperBound
-    , rangeIsFinite
-    , rangeIsSingleton
-    , rangeIsValid
-    , rangeLowerBound
-    , rangeUpperBound
+    , mapLowerBound
+    , mapUpperBound
+    , everything
+    , isAfter
+    , isBefore
+    , isWithin
+    , hasLowerBound
+    , hasUpperBound
+    , isFinite
+    , isSingleton
+    , isValid
+    , lowerBound
+    , upperBound
     , isSubrangeOf
     )
 where
@@ -54,12 +54,12 @@ data Range a = Range
     } deriving (Eq, Functor, Show)
 
 -- | Apply a function to the lower bound of a range.
-mapRangeLowerBound :: (a -> a) -> Range a -> Range a
-mapRangeLowerBound f (Range x y) = Range (f <$> x) y
+mapLowerBound :: (a -> a) -> Range a -> Range a
+mapLowerBound f (Range x y) = Range (f <$> x) y
 
 -- | Apply a function to the upper bound of a range.
-mapRangeUpperBound :: (a -> a) -> Range a -> Range a
-mapRangeUpperBound f (Range x y) = Range x (f <$> y)
+mapUpperBound :: (a -> a) -> Range a -> Range a
+mapUpperBound f (Range x y) = Range x (f <$> y)
 
 -- | Represents a range boundary.
 data RangeBound a
@@ -69,62 +69,62 @@ data RangeBound a
     deriving (Eq, Ord)
 
 -- | The range that includes everything.
-wholeRange :: Range a
-wholeRange = Range Nothing Nothing
+everything :: Range a
+everything = Range Nothing Nothing
 
 -- | Returns 'True' if (and only if) the given range has an upper bound and the
 --   specified value is greater than the upper bound.
-isAfterRange :: Ord a => a -> Range a -> Bool
-isAfterRange x (Range _ high) =
+isAfter :: Ord a => a -> Range a -> Bool
+isAfter x (Range _ high) =
     maybe False (x >) high
 
 -- | Returns 'True' if (and only if) the given range has a lower bound and the
 --   specified value is smaller than the lower bound.
-isBeforeRange :: Ord a => a -> Range a -> Bool
-isBeforeRange x (Range low _) =
+isBefore :: Ord a => a -> Range a -> Bool
+isBefore x (Range low _) =
     maybe False (x <) low
 
 -- | Returns 'True' if (and only if) the given value is not smaller than the
 --   lower bound (if present) of the given range and is not greater than the
 --   upper bound (if present) of the given range.
-isWithinRange :: Ord a => a -> Range a -> Bool
-isWithinRange x (Range low high) =
+isWithin :: Ord a => a -> Range a -> Bool
+isWithin x (Range low high) =
     (maybe True (x >=) low) &&
     (maybe True (x <=) high)
 
 -- | Returns 'True' if (and only if) the given range has a lower bound.
-rangeHasLowerBound :: Range a -> Bool
-rangeHasLowerBound = isJust . inclusiveLowerBound
+hasLowerBound :: Range a -> Bool
+hasLowerBound = isJust . inclusiveLowerBound
 
 -- | Returns 'True' if (and only if) the given range has an upper bound.
-rangeHasUpperBound :: Range a -> Bool
-rangeHasUpperBound = isJust . inclusiveUpperBound
+hasUpperBound :: Range a -> Bool
+hasUpperBound = isJust . inclusiveUpperBound
 
 -- | Returns 'True' if (and only if) the given range has both a lower and upper
 --   bound.
-rangeIsFinite :: Range a -> Bool
-rangeIsFinite r = rangeHasLowerBound r && rangeHasUpperBound r
+isFinite :: Range a -> Bool
+isFinite r = hasLowerBound r && hasUpperBound r
 
 -- | Returns 'True' if (and only if) the range covers exactly one value.
-rangeIsSingleton :: Eq a => Range a -> Bool
-rangeIsSingleton (Range a b) = ((==) <$> a <*> b) == Just True
+isSingleton :: Eq a => Range a -> Bool
+isSingleton (Range a b) = ((==) <$> a <*> b) == Just True
 
 -- | Returns 'True' if (and only if) the lower bound of a range is not greater
 --   than its upper bound.
-rangeIsValid :: Ord a => Range a -> Bool
-rangeIsValid (Range a b) = ((<=) <$> a <*> b) /= Just False
+isValid :: Ord a => Range a -> Bool
+isValid (Range a b) = ((<=) <$> a <*> b) /= Just False
 
 -- | Get the lower bound of a 'Range'.
-rangeLowerBound :: Range a -> RangeBound a
-rangeLowerBound = maybe NegativeInfinity InclusiveBound . inclusiveLowerBound
+lowerBound :: Range a -> RangeBound a
+lowerBound = maybe NegativeInfinity InclusiveBound . inclusiveLowerBound
 
 -- | Get the upper bound of a 'Range'.
-rangeUpperBound :: Range a -> RangeBound a
-rangeUpperBound = maybe PositiveInfinity InclusiveBound . inclusiveUpperBound
+upperBound :: Range a -> RangeBound a
+upperBound = maybe PositiveInfinity InclusiveBound . inclusiveUpperBound
 
 -- | Returns 'True' if (and only if) the first given range is a subrange of the
 --   second given range.
 isSubrangeOf :: Ord a => Range a -> Range a -> Bool
 isSubrangeOf r1 r2 =
-    rangeLowerBound r1 >= rangeLowerBound r2 &&
-    rangeUpperBound r1 <= rangeUpperBound r2
+    lowerBound r1 >= lowerBound r2 &&
+    upperBound r1 <= upperBound r2

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/RangeSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/RangeSpec.hs
@@ -1,0 +1,229 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.Primitive.Types.RangeSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Range
+    ( Range (..)
+    , RangeBound (..)
+    , isSubrangeOf
+    )
+import Data.Maybe
+    ( mapMaybe
+    )
+import Test.Hspec
+    ( Spec
+    , it
+    , shouldNotSatisfy
+    , shouldSatisfy
+    )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , checkCoverage
+    , cover
+    , infiniteList
+    , property
+    , withMaxSuccess
+    , (.&&.)
+    , (=/=)
+    , (===)
+    )
+
+import qualified Cardano.Wallet.Primitive.Types.Range as Range
+
+spec :: Spec
+spec = do
+
+    it "arbitrary ranges are valid" $
+        withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
+            checkCoverage $
+            cover 10 (Range.isFinite r) "finite range" $
+            Range.isValid r .&&.
+                all Range.isValid (shrink r)
+
+    it "arbitrary non-singleton ranges are valid" $
+        withMaxSuccess 1000 $ property $ \(nsr :: NonSingletonRange Int) ->
+            let isValidNonSingleton (NonSingletonRange r) =
+                    Range.isValid r && not (Range.isSingleton r)
+            in
+            checkCoverage $
+            cover 10 (Range.isFinite (getNonSingletonRange nsr))
+                "finite range" $
+            isValidNonSingleton nsr .&&.
+                all isValidNonSingleton (shrink nsr)
+
+    it "functions is{Before,Within,After}Range are mutually exclusive" $
+        withMaxSuccess 1000 $ property $ \(a :: Integer) r ->
+            let options =
+                    [ (Range.isBefore)
+                    , (Range.isWithin)
+                    , (Range.isAfter)
+                    ]
+            in
+            checkCoverage $
+            cover 10 (a `Range.isBefore` r) "Range.isBefore" $
+            cover 10 (a `Range.isWithin` r) "Range.isWithin" $
+            cover 10 (a `Range.isAfter`  r) "Range.isAfter"  $
+            1 === length (filter (\f -> f a r) options)
+
+    it "pred (Range.inclusiveLowerBound r) `Range.isBefore` r" $
+        withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
+            checkCoverage $
+            cover 10 (Range.hasLowerBound r) "has lower bound" $
+            ((`Range.isBefore` r) . pred <$> Range.inclusiveLowerBound r)
+                =/= Just False
+
+    it "Range.inclusiveLowerBound r `Range.isWithin` r" $
+        withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
+            checkCoverage $
+            cover 10 (Range.hasLowerBound r) "has lower bound" $
+            ((`Range.isWithin` r) <$> Range.inclusiveLowerBound r)
+                =/= Just False
+
+    it "Range.inclusiveUpperBound r `Range.isWithin` r" $
+        withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
+            checkCoverage $
+            cover 10 (Range.hasUpperBound r) "has upper bound" $
+            ((`Range.isWithin` r) <$> Range.inclusiveUpperBound r)
+                =/= Just False
+
+    it "succ (Range.inclusiveUpperBound r) `Range.isAfter` r" $
+        withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
+            checkCoverage $
+            cover 10 (Range.hasUpperBound r) "has upper bound" $
+            ((`Range.isAfter` r) . succ <$> Range.inclusiveUpperBound r)
+                =/= Just False
+
+    it "a `Range.isWithin` Range.everything == True" $
+        property $ \(a :: Integer) ->
+            a `Range.isWithin` Range.everything === True
+
+    it "Range.isSingleton (Range a a)" $
+        property $ \(a :: Int) ->
+            Range (Just a) (Just a) `shouldSatisfy` Range.isSingleton
+
+    it "not (Range.isSingleton (Range (pred a) a))" $
+        property $ \(a :: Int) ->
+            Range (Just (pred a)) (Just a)
+                `shouldNotSatisfy` Range.isSingleton
+
+    it "not (Range.isSingleton (Range a (succ a)))" $
+        property $ \(a :: Int) ->
+            Range (Just a) (Just (succ a))
+                `shouldNotSatisfy` Range.isSingleton
+
+    it "Range.lowerBound r = Range.upperBound r <=> Range.isSingleton r" $
+        property $ \(r :: Range Bool) ->
+            checkCoverage $
+            cover 10 (Range.isFinite r) "is finite" $
+            (Range.lowerBound r == Range.upperBound r)
+                === Range.isSingleton r
+
+    it "r `isSubrangeOf` r" $
+        property $ \(r :: Range Int) ->
+            r `isSubrangeOf` r
+
+    it "r `isSubrangeOf` Range.everything" $
+        property $ \(r :: Range Int) ->
+            checkCoverage $
+            cover 10 (Range.hasLowerBound r) "has lower bound" $
+            cover 10 (Range.hasUpperBound r) "has upper bound" $
+            cover 10 (Range.isFinite      r) "is finite" $
+            r `isSubrangeOf` Range.everything
+
+    it "Range (succ a) b `isSubrangeOf` Range a b" $
+        withMaxSuccess 1000 $ property $ \nsr ->
+            let r@(Range a b :: Range Int) = getNonSingletonRange nsr in
+            checkCoverage $
+            cover 10 (Range.hasLowerBound r) "has lower bound" $
+            cover 10 (Range.hasUpperBound r) "has upper bound" $
+            cover 10 (Range.isFinite      r) "is finite" $
+            Range (succ <$> a) b `isSubrangeOf` Range a b
+
+    it "Range a (pred b) `isSubrangeOf` Range a b" $
+        withMaxSuccess 1000 $ property $ \nsr ->
+            let r@(Range a b :: Range Int) = getNonSingletonRange nsr in
+            checkCoverage $
+            cover 10 (Range.hasLowerBound r) "has lower bound" $
+            cover 10 (Range.hasUpperBound r) "has upper bound" $
+            cover 10 (Range.isFinite      r) "is finite" $
+            Range a (pred <$> b) `isSubrangeOf` Range a b
+
+    it "Range a b `isSubrangeOf` Range (pred a) b" $
+        property $ \r@(Range a b :: Range Int) ->
+            checkCoverage $
+            cover 10 (Range.hasLowerBound r) "has lower bound" $
+            cover 10 (Range.hasUpperBound r) "has upper bound" $
+            cover 10 (Range.isFinite      r) "is finite" $
+            Range a b `isSubrangeOf` Range (pred <$> a) b
+
+    it "Range a b `isSubrangeOf` Range a (succ b)" $
+        property $ \r@(Range a b :: Range Int) ->
+            checkCoverage $
+            cover 10 (Range.hasLowerBound r) "has lower bound" $
+            cover 10 (Range.hasUpperBound r) "has upper bound" $
+            cover 10 (Range.isFinite      r) "is finite" $
+            Range a b `isSubrangeOf` Range a (succ <$> b)
+
+    it "NegativeInfinity < InclusiveBound a" $
+        property $ \(a :: Int) ->
+            NegativeInfinity < InclusiveBound a
+
+    it "InclusiveBound a < PositiveInfinity" $
+        property $ \(a :: Int) ->
+            InclusiveBound a < PositiveInfinity
+
+    it "compare (InclusiveBound a) (InclusiveBound b) = compare a b" $
+        property $ \(a :: Int) (b :: Int) ->
+            compare (InclusiveBound a) (InclusiveBound b) === compare a b
+
+--------------------------------------------------------------------------------
+-- Utilities
+--------------------------------------------------------------------------------
+
+-- Ensures that the start of a range is not greater than its end.
+makeRangeValid :: Ord a => Range a -> Range a
+makeRangeValid = \case
+    Range (Just p) (Just q) -> Range (Just $ min p q) (Just $ max p q)
+    r -> r
+
+-- Ensures that a range is not a singleton range.
+makeNonSingletonRangeValid
+    :: Ord a => NonSingletonRange a -> Maybe (NonSingletonRange a)
+makeNonSingletonRangeValid (NonSingletonRange r)
+    | Range.isSingleton r = Nothing
+    | otherwise = Just $ NonSingletonRange $ makeRangeValid r
+
+-- A range that contains more than a single element.
+newtype NonSingletonRange a = NonSingletonRange
+    { getNonSingletonRange :: Range a
+    } deriving Show
+
+--------------------------------------------------------------------------------
+-- Arbitrary instances
+--------------------------------------------------------------------------------
+
+instance (Arbitrary a, Ord a) => Arbitrary (Range a) where
+    arbitrary =
+        makeRangeValid . uncurry Range <$> arbitrary
+    shrink (Range p q) =
+        makeRangeValid . uncurry Range <$> shrink (p, q)
+
+instance (Arbitrary a, Ord a) => Arbitrary (NonSingletonRange a) where
+    arbitrary = do
+        -- Iterate through the infinite list of arbitrary ranges and return
+        -- the first range that is not a singleton range:
+        head . mapMaybe (makeNonSingletonRangeValid . NonSingletonRange)
+            <$> infiniteList
+    shrink (NonSingletonRange r) = mapMaybe
+        (makeNonSingletonRangeValid . NonSingletonRange) (shrink r)

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -165,7 +165,6 @@ import Cardano.Wallet.Primitive.Types
     , Block (..)
     , BlockHeader (..)
     , EpochLength (..)
-    , Range (..)
     , SlotLength (..)
     , SlotNo (..)
     , SlottingParameters (..)
@@ -187,6 +186,9 @@ import Cardano.Wallet.Primitive.Types.Credentials
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
+    )
+import Cardano.Wallet.Primitive.Types.Range
+    ( Range (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (..)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -509,7 +509,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     )
 import Cardano.Wallet.Primitive.Types.Range
     ( Range (..)
-    , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..)
@@ -815,6 +814,7 @@ import qualified Cardano.Wallet.DB.WalletState as WS
 import qualified Cardano.Wallet.Primitive.Slotting as Slotting
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+import qualified Cardano.Wallet.Primitive.Types.Range as Range
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
@@ -1086,7 +1086,7 @@ readWallet ctx = do
             readTransactions
                 Nothing
                 Descending
-                wholeRange
+                Range.everything
                 (Just Pending)
                 Nothing
                 Nothing
@@ -2107,7 +2107,7 @@ buildSignSubmitTransaction db@DBLayer{..} netLayer txLayer
                 readTransactions
                     Nothing
                     Descending
-                    wholeRange
+                    Range.everything
                     (Just Pending)
                     Nothing
                     Nothing
@@ -2297,7 +2297,7 @@ buildTransaction DBLayer{..} timeTranslation changeAddrGen
 
         pendingTxs <- Set.fromList . fmap fromTransactionInfo <$>
             readTransactions
-                Nothing Descending wholeRange (Just Pending) Nothing Nothing
+                Nothing Descending Range.everything (Just Pending) Nothing Nothing
 
         let utxo = availableUTxO @s pendingTxs wallet
 
@@ -2768,7 +2768,7 @@ listAssets ctx = db & \DBLayer{..} -> do
     txs <- atomically $
         let noMinWithdrawal = Nothing
             allTxStatuses = Nothing
-        in readTransactions noMinWithdrawal Ascending wholeRange
+        in readTransactions noMinWithdrawal Ascending Range.everything
             allTxStatuses Nothing Nothing
     let txAssets :: TransactionInfo -> Set TokenMap.AssetId
         txAssets = Set.unions

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -477,7 +477,6 @@ import Cardano.Wallet.Primitive.Types
     , DelegationCertificate (..)
     , GenesisParameters (..)
     , NetworkParameters (..)
-    , Range (..)
     , Signature (..)
     , Slot
     , SlottingParameters (..)
@@ -490,7 +489,6 @@ import Cardano.Wallet.Primitive.Types
     , dlgCertPoolId
     , stabilityWindowShelley
     , toSlot
-    , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
@@ -508,6 +506,10 @@ import Cardano.Wallet.Primitive.Types.Credentials
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
+    )
+import Cardano.Wallet.Primitive.Types.Range
+    ( Range (..)
+    , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..)

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -76,7 +76,6 @@ import Cardano.Wallet.Primitive.Types
     ( BlockHeader
     , ChainPoint
     , GenesisParameters
-    , Range (..)
     , Slot
     , SlotNo (..)
     , SortOrder (..)
@@ -91,6 +90,9 @@ import Cardano.Wallet.Primitive.Types.Coin
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash
+    )
+import Cardano.Wallet.Primitive.Types.Range
+    ( Range (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
@@ -87,7 +87,6 @@ import Cardano.Wallet.Primitive.Types
     , ChainPoint
     , DelegationCertificate (..)
     , GenesisParameters (..)
-    , Range (..)
     , Slot
     , SlotNo (..)
     , SortOrder (..)
@@ -95,7 +94,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , chainPointFromBlockHeader
     , dlgCertPoolId
-    , isWithinRange
     , toSlot
     )
 import Cardano.Wallet.Primitive.Types.Address
@@ -106,6 +104,10 @@ import Cardano.Wallet.Primitive.Types.Coin
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
+    )
+import Cardano.Wallet.Primitive.Types.Range
+    ( Range (..)
+    , isWithinRange
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
@@ -107,7 +107,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     )
 import Cardano.Wallet.Primitive.Types.Range
     ( Range (..)
-    , isWithinRange
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)
@@ -164,6 +163,7 @@ import GHC.Generics
     ( Generic
     )
 
+import qualified Cardano.Wallet.Primitive.Types.Range as Range
 import qualified Data.Map.Strict as Map
 
 {-------------------------------------------------------------------------------
@@ -539,7 +539,7 @@ filterTxHistory
 filterTxHistory minWithdrawal order range address =
     filter (filterAddress address)
     . filter (filterWithdrawals minWithdrawal)
-    . filter ((`isWithinRange` range) . (slotNo :: TxMeta -> SlotNo) . snd)
+    . filter ((`Range.isWithin` range) . (slotNo :: TxMeta -> SlotNo) . snd)
     . (case order of
         Ascending -> reverse
         Descending -> id)

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -41,7 +41,9 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.Types
     ( SortOrder (..)
     , WalletId
-    , wholeRange
+    )
+import Cardano.Wallet.Primitive.Types.Range
+    ( wholeRange
     )
 import Cardano.Wallet.Primitive.Types.Tx.TransactionInfo
     ( TransactionInfo (..)

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Layer.hs
@@ -42,9 +42,6 @@ import Cardano.Wallet.Primitive.Types
     ( SortOrder (..)
     , WalletId
     )
-import Cardano.Wallet.Primitive.Types.Range
-    ( wholeRange
-    )
 import Cardano.Wallet.Primitive.Types.Tx.TransactionInfo
     ( TransactionInfo (..)
     )
@@ -70,6 +67,8 @@ import UnliftIO.Exception
     ( Exception
     , throwIO
     )
+
+import qualified Cardano.Wallet.Primitive.Types.Range as Range
 
 -- | Instantiate a new in-memory "database" layer that simply stores data in
 -- a local MVar. Data vanishes if the software is shut down.
@@ -131,7 +130,7 @@ withBootDBLayer timeInterpreter wid params k = do
                         timeInterpreter
                         Nothing
                         Descending
-                        wholeRange
+                        Range.everything
                         Nothing
                         Nothing
                 let txPresent (TransactionInfo{..}) = txInfoId == tid

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Layer.hs
@@ -31,8 +31,10 @@ import Cardano.Wallet.DB.Store.Meta.Store
     ( mkStoreMetaTransactions
     )
 import Cardano.Wallet.Primitive.Types
+    ( SortOrder (..)
+    )
+import Cardano.Wallet.Primitive.Types.Range
     ( Range (..)
-    , SortOrder (..)
     )
 import Data.Foldable
     ( toList
@@ -71,7 +73,7 @@ import GHC.Natural
     )
 
 import qualified Cardano.Wallet.DB.Sqlite.Schema as DB
-import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Range as W
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Layer.hs
@@ -73,7 +73,7 @@ import GHC.Natural
     )
 
 import qualified Cardano.Wallet.DB.Sqlite.Schema as DB
-import qualified Cardano.Wallet.Primitive.Types.Range as W
+import qualified Cardano.Wallet.Primitive.Types.Range as Range
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
@@ -138,8 +138,10 @@ instance Query QueryTxMeta where
             let whichMeta DB.TxMeta{..} =
                     and
                         $ catMaybes
-                            [ (txMetaSlot >=) <$> W.inclusiveLowerBound range
-                            , (txMetaSlot <=) <$> W.inclusiveUpperBound range
+                            [ (txMetaSlot >=)
+                                <$> Range.inclusiveLowerBound range
+                            , (txMetaSlot <=)
+                                <$> Range.inclusiveUpperBound range
                             ]
                 reorder = case order of
                     Ascending -> sortOn ((,) <$> txMetaSlot <*> txMetaTxId)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -46,8 +46,10 @@ import Cardano.Wallet.DB.Store.Wallets.Store
     ( mkStoreTxWalletsHistory
     )
 import Cardano.Wallet.Primitive.Types
+    ( SortOrder
+    )
+import Cardano.Wallet.Primitive.Types.Range
     ( Range (..)
-    , SortOrder
     )
 import Data.Store
     ( Query (..)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
@@ -109,24 +109,6 @@ module Cardano.Wallet.Primitive.Types
     -- * Querying
     , SortOrder (..)
 
-    -- * Ranges
-    , Range (..)
-    , RangeBound (..)
-    , wholeRange
-    , isAfterRange
-    , isBeforeRange
-    , isSubrangeOf
-    , isWithinRange
-    , mapRangeLowerBound
-    , mapRangeUpperBound
-    , rangeIsFinite
-    , rangeIsSingleton
-    , rangeIsValid
-    , rangeHasLowerBound
-    , rangeHasUpperBound
-    , rangeLowerBound
-    , rangeUpperBound
-
     -- * Polymorphic
     , Signature (..)
 
@@ -206,24 +188,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     )
 import Cardano.Wallet.Primitive.Types.ProtocolParameters
     ( ProtocolParameters (..)
-    )
-import Cardano.Wallet.Primitive.Types.Range
-    ( Range (..)
-    , RangeBound (..)
-    , isAfterRange
-    , isBeforeRange
-    , isSubrangeOf
-    , isWithinRange
-    , mapRangeLowerBound
-    , mapRangeUpperBound
-    , rangeHasLowerBound
-    , rangeHasUpperBound
-    , rangeIsFinite
-    , rangeIsSingleton
-    , rangeIsValid
-    , rangeLowerBound
-    , rangeUpperBound
-    , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.SlottingParameters
     ( ActiveSlotCoefficient (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -162,8 +162,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     )
 import Cardano.Wallet.Primitive.Types.Range
     ( Range (..)
-    , rangeIsValid
-    , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..)
@@ -337,6 +335,7 @@ import qualified Cardano.Wallet.Address.Derivation.Shared as Shared
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.Address.Discovery.Sequential as Seq
 import qualified Cardano.Wallet.Address.Discovery.Shared as Shared
+import qualified Cardano.Wallet.Primitive.Types.Range as Range
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -394,7 +393,8 @@ instance Arbitrary GenTxHistory where
         -- tracked as part of the WalletState.
         filter (isInLedger . snd) <$> scale (min 25) arbitrary
       where
-        sortTxHistory = filterTxHistory Nothing Descending wholeRange Nothing
+        sortTxHistory =
+            filterTxHistory Nothing Descending Range.everything Nothing
 
 instance Arbitrary MockChain where
     shrink (MockChain chain) =
@@ -590,7 +590,7 @@ instance Arbitrary UTxO where
 instance (Ord a, Arbitrary a) => Arbitrary (Range a) where
     arbitrary = Range <$> arbitrary <*> arbitrary
 
-    shrink (Range from to) = filter rangeIsValid $
+    shrink (Range from to) = filter Range.isValid $
         [Range from' to | from' <- shrink from]
         ++ [Range from to' | to' <- shrink to]
 

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -137,7 +137,6 @@ import Cardano.Wallet.Primitive.Types
     , FeePolicy (..)
     , LinearFunction (LinearFunction)
     , ProtocolParameters (..)
-    , Range (..)
     , Slot
     , SlotInEpoch (..)
     , SlotNo (..)
@@ -148,9 +147,7 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , WithOrigin (..)
     , fromDecentralizationLevel
-    , rangeIsValid
     , unsafeEpochNo
-    , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
@@ -162,6 +159,11 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     , mockHash
+    )
+import Cardano.Wallet.Primitive.Types.Range
+    ( Range (..)
+    , rangeIsValid
+    , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -201,7 +201,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     )
 import Cardano.Wallet.Primitive.Types.Range
     ( Range
-    , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle
@@ -397,6 +396,7 @@ import qualified Cardano.Wallet.DB.Sqlite.Types as DB
 import qualified Cardano.Wallet.DB.Store.Info.Store as WalletInfo
 import qualified Cardano.Wallet.DB.WalletState as WalletState
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+import qualified Cardano.Wallet.Primitive.Types.Range as Range
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
@@ -660,7 +660,7 @@ fileModeSpec =  do
             testReopening
                 f
                 ( \db' ->
-                    readTransactions' db' Ascending wholeRange Nothing
+                    readTransactions' db' Ascending Range.everything Nothing
                 )
                 testTxs -- expected after opening db
 
@@ -670,7 +670,7 @@ fileModeSpec =  do
             testReopening
                 f
                 ( \db' ->
-                    readTransactions' db' Descending wholeRange Nothing
+                    readTransactions' db' Descending Range.everything Nothing
                 )
                 (reverse testTxs) -- expected after opening db
 
@@ -1369,7 +1369,7 @@ testMigrationTxMetaFee dbName expectedLength caseByCase = do
             @TestState dbName
         $ \DBLayer{..} -> atomically $ do
             readTransactions
-                Nothing Descending wholeRange Nothing Nothing Nothing
+                Nothing Descending Range.everything Nothing Nothing Nothing
 
     -- Check that we've indeed logged a needed migration for 'fee'
     length (filter isMsgManualMigration logs) `shouldBe` 1
@@ -1693,7 +1693,7 @@ getAvailableBalance :: DBLayer IO s -> IO Natural
 getAvailableBalance DBLayer{..} = do
     cp <- atomically readCheckpoint
     pend <- atomically $ fmap toTxHistory
-        <$> readTransactions Nothing Descending wholeRange
+        <$> readTransactions Nothing Descending Range.everything
                 (Just Pending) Nothing Nothing
     return $ fromIntegral $ unCoin $ TokenBundle.getCoin $
         availableBalance (Set.fromList $ map fst pend) cp
@@ -1701,6 +1701,6 @@ getAvailableBalance DBLayer{..} = do
 getTxsInLedger :: DBLayer IO s -> IO ([(Direction, Natural)])
 getTxsInLedger DBLayer {..} = do
     pend <- atomically $ fmap toTxHistory
-        <$> readTransactions Nothing Descending wholeRange
+        <$> readTransactions Nothing Descending Range.everything
                 (Just InLedger) Nothing Nothing
     pure $ map (\(_, m) -> (direction m, fromIntegral $ unCoin $ amount m)) pend

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -178,7 +178,6 @@ import Cardano.Wallet.Primitive.Types
     , Block (..)
     , BlockHeader (..)
     , GenesisParameters (..)
-    , Range
     , SlotNo (..)
     , SortOrder (..)
     , StartTime (..)
@@ -186,7 +185,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , WalletName (..)
     , WithOrigin (At)
-    , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
@@ -200,6 +198,10 @@ import Cardano.Wallet.Primitive.Types.Credentials
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     , mockHash
+    )
+import Cardano.Wallet.Primitive.Types.Range
+    ( Range
+    , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -47,10 +47,12 @@ import Cardano.Wallet.Primitive.Types
     , SortOrder (..)
     , WalletId (..)
     , WithOrigin (..)
-    , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
+    )
+import Cardano.Wallet.Primitive.Types.Range
+    ( wholeRange
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -51,9 +51,6 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
-import Cardano.Wallet.Primitive.Types.Range
-    ( wholeRange
-    )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..)
     )
@@ -128,6 +125,7 @@ import Test.QuickCheck.Monadic
     , run
     )
 
+import qualified Cardano.Wallet.Primitive.Types.Range as Range
 import qualified Data.List as L
 
 -- | How to boot a fresh database.
@@ -193,7 +191,11 @@ properties withBootDBLayer = describe "DB.Properties" $ do
                 (\db _ -> readTxHistory_ db)
                 ( let sort' =
                         GenTxHistory
-                            . filterTxHistory Nothing Descending wholeRange Nothing
+                            . filterTxHistory
+                                Nothing
+                                Descending
+                                Range.everything
+                                Nothing
                             . unGenTxHistory
                   in  Identity . sort' . fold
                 )
@@ -211,7 +213,14 @@ readTxHistory_
 readTxHistory_ DBLayer {..} =
     (Identity . GenTxHistory . fmap toTxHistory)
         <$> atomically
-            (readTransactions Nothing Descending wholeRange Nothing Nothing Nothing)
+            (readTransactions
+                Nothing
+                Descending
+                Range.everything
+                Nothing
+                Nothing
+                Nothing
+            )
 
 putTxHistory_
     :: DBLayer m s
@@ -392,7 +401,7 @@ prop_rollbackTxHistory test (InitialCheckpoint cp0) (GenTxHistory txs0) =
                             <$> readTransactions
                                 Nothing
                                 Descending
-                                wholeRange
+                                Range.everything
                                 Nothing
                                 Nothing
                                 Nothing

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -133,7 +133,6 @@ import Cardano.Wallet.Primitive.Types
     , FeePolicy
     , GenesisParameters (..)
     , LinearFunction
-    , Range (..)
     , Slot
     , SlotNo (..)
     , SortOrder (..)
@@ -152,6 +151,9 @@ import Cardano.Wallet.Primitive.Types.Coin
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
+    )
+import Cardano.Wallet.Primitive.Types.Range
+    ( Range (..)
     )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/StoreSpec.hs
@@ -49,9 +49,11 @@ import Cardano.Wallet.DB.Store.Meta.Store
     ( mkStoreMetaTransactions
     )
 import Cardano.Wallet.Primitive.Types
-    ( Range (..)
-    , SortOrder (Ascending, Descending)
+    ( SortOrder (Ascending, Descending)
     , WalletId
+    )
+import Cardano.Wallet.Primitive.Types.Range
+    ( Range (..)
     )
 import Control.Monad
     ( forM_

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -96,7 +96,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     )
 import Cardano.Wallet.Primitive.Types.Range
     ( Range (..)
-    , RangeBound (..)
     , isSubrangeOf
     )
 import Cardano.Wallet.Primitive.Types.RewardAccount
@@ -173,7 +172,6 @@ import Data.Maybe
     ( fromMaybe
     , isJust
     , isNothing
-    , mapMaybe
     )
 import Data.Proxy
     ( Proxy (..)
@@ -218,7 +216,6 @@ import Test.Hspec
     , describe
     , it
     , shouldBe
-    , shouldNotSatisfy
     , shouldSatisfy
     , shouldThrow
     )
@@ -238,7 +235,6 @@ import Test.QuickCheck
     , counterexample
     , cover
     , elements
-    , infiniteList
     , oneof
     , property
     , scale
@@ -442,150 +438,6 @@ spec = describe "Cardano.Wallet.Primitive.Types" $ do
                     result `shouldBe` n
                 else
                     evaluate result `shouldThrow` anyErrorCall
-
-    describe "Ranges" $ do
-
-        it "arbitrary ranges are valid" $
-            withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
-                checkCoverage $
-                cover 10 (Range.isFinite r) "finite range" $
-                Range.isValid r .&&.
-                    all Range.isValid (shrink r)
-
-        it "arbitrary non-singleton ranges are valid" $
-            withMaxSuccess 1000 $ property $ \(nsr :: NonSingletonRange Int) ->
-                let isValidNonSingleton (NonSingletonRange r) =
-                        Range.isValid r && not (Range.isSingleton r) in
-                checkCoverage $
-                cover 10 (Range.isFinite (getNonSingletonRange nsr))
-                    "finite range" $
-                isValidNonSingleton nsr .&&.
-                    all isValidNonSingleton (shrink nsr)
-
-        it "functions is{Before,Within,After}Range are mutually exclusive" $
-            withMaxSuccess 1000 $ property $ \(a :: Integer) r ->
-                let options =
-                        [ (Range.isBefore)
-                        , (Range.isWithin)
-                        , (Range.isAfter) ] in
-                checkCoverage $
-                cover 10 (a `Range.isBefore` r) "Range.isBefore" $
-                cover 10 (a `Range.isWithin` r) "Range.isWithin" $
-                cover 10 (a `Range.isAfter`  r) "Range.isAfter"  $
-                1 === length (filter (\f -> f a r) options)
-
-        it "pred (Range.inclusiveLowerBound r) `Range.isBefore` r" $
-            withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
-                checkCoverage $
-                cover 10 (Range.hasLowerBound r) "has lower bound" $
-                ((`Range.isBefore` r) . pred <$> Range.inclusiveLowerBound r)
-                    =/= Just False
-
-        it "Range.inclusiveLowerBound r `Range.isWithin` r" $
-            withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
-                checkCoverage $
-                cover 10 (Range.hasLowerBound r) "has lower bound" $
-                ((`Range.isWithin` r) <$> Range.inclusiveLowerBound r)
-                    =/= Just False
-
-        it "Range.inclusiveUpperBound r `Range.isWithin` r" $
-            withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
-                checkCoverage $
-                cover 10 (Range.hasUpperBound r) "has upper bound" $
-                ((`Range.isWithin` r) <$> Range.inclusiveUpperBound r)
-                    =/= Just False
-
-        it "succ (Range.inclusiveUpperBound r) `Range.isAfter` r" $
-            withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
-                checkCoverage $
-                cover 10 (Range.hasUpperBound r) "has upper bound" $
-                ((`Range.isAfter` r) . succ <$> Range.inclusiveUpperBound r)
-                    =/= Just False
-
-        it "a `Range.isWithin` Range.everything == True" $
-            property $ \(a :: Integer) ->
-                a `Range.isWithin` Range.everything === True
-
-        it "Range.isSingleton (Range a a)" $
-            property $ \(a :: Int) ->
-                Range (Just a) (Just a) `shouldSatisfy` Range.isSingleton
-
-        it "not (Range.isSingleton (Range (pred a) a))" $
-            property $ \(a :: Int) ->
-                Range (Just (pred a)) (Just a)
-                    `shouldNotSatisfy` Range.isSingleton
-
-        it "not (Range.isSingleton (Range a (succ a)))" $
-            property $ \(a :: Int) ->
-                Range (Just a) (Just (succ a))
-                    `shouldNotSatisfy` Range.isSingleton
-
-        it "Range.lowerBound r = Range.upperBound r <=> Range.isSingleton r" $
-            property $ \(r :: Range Bool) ->
-                checkCoverage $
-                cover 10 (Range.isFinite r) "is finite" $
-                (Range.lowerBound r == Range.upperBound r)
-                    === Range.isSingleton r
-
-        it "r `isSubrangeOf` r" $
-            property $ \(r :: Range Int) ->
-                r `isSubrangeOf` r
-
-        it "r `isSubrangeOf` Range.everything" $
-            property $ \(r :: Range Int) ->
-                checkCoverage $
-                cover 10 (Range.hasLowerBound r) "has lower bound" $
-                cover 10 (Range.hasUpperBound r) "has upper bound" $
-                cover 10 (Range.isFinite      r) "is finite" $
-                r `isSubrangeOf` Range.everything
-
-        it "Range (succ a) b `isSubrangeOf` Range a b" $
-            withMaxSuccess 1000 $ property $ \nsr ->
-                let r@(Range a b :: Range Int) = getNonSingletonRange nsr in
-                checkCoverage $
-                cover 10 (Range.hasLowerBound r) "has lower bound" $
-                cover 10 (Range.hasUpperBound r) "has upper bound" $
-                cover 10 (Range.isFinite      r) "is finite" $
-                Range (succ <$> a) b `isSubrangeOf` Range a b
-
-        it "Range a (pred b) `isSubrangeOf` Range a b" $
-            withMaxSuccess 1000 $ property $ \nsr ->
-                let r@(Range a b :: Range Int) = getNonSingletonRange nsr in
-                checkCoverage $
-                cover 10 (Range.hasLowerBound r) "has lower bound" $
-                cover 10 (Range.hasUpperBound r) "has upper bound" $
-                cover 10 (Range.isFinite      r) "is finite" $
-                Range a (pred <$> b) `isSubrangeOf` Range a b
-
-        it "Range a b `isSubrangeOf` Range (pred a) b" $
-            property $ \r@(Range a b :: Range Int) ->
-                checkCoverage $
-                cover 10 (Range.hasLowerBound r) "has lower bound" $
-                cover 10 (Range.hasUpperBound r) "has upper bound" $
-                cover 10 (Range.isFinite      r) "is finite" $
-                Range a b `isSubrangeOf` Range (pred <$> a) b
-
-        it "Range a b `isSubrangeOf` Range a (succ b)" $
-            property $ \r@(Range a b :: Range Int) ->
-                checkCoverage $
-                cover 10 (Range.hasLowerBound r) "has lower bound" $
-                cover 10 (Range.hasUpperBound r) "has upper bound" $
-                cover 10 (Range.isFinite      r) "is finite" $
-                Range a b `isSubrangeOf` Range a (succ <$> b)
-
-    describe "Range bounds" $ do
-
-        it "NegativeInfinity < InclusiveBound a" $
-            property $ \(a :: Int) ->
-                NegativeInfinity < InclusiveBound a
-
-        it "InclusiveBound a < PositiveInfinity" $
-            property $ \(a :: Int) ->
-                InclusiveBound a < PositiveInfinity
-
-        it "compare (InclusiveBound a) (InclusiveBound b) = compare a b" $
-            property $ \(a :: Int) (b :: Int) ->
-                compare (InclusiveBound a) (InclusiveBound b) === compare a b
 
     describe "Epoch arithmetic: arbitrary value generation" $ do
 
@@ -1177,27 +1029,6 @@ makeRangeValid :: Ord a => Range a -> Range a
 makeRangeValid = \case
     Range (Just p) (Just q) -> Range (Just $ min p q) (Just $ max p q)
     r -> r
-
--- A range that contains more than a single element.
-newtype NonSingletonRange a = NonSingletonRange
-    { getNonSingletonRange :: Range a
-    } deriving Show
-
-instance (Arbitrary a, Ord a) => Arbitrary (NonSingletonRange a) where
-    arbitrary = do
-        -- Iterate through the infinite list of arbitrary ranges and return
-        -- the first range that is not a singleton range:
-        head . mapMaybe (makeNonSingletonRangeValid . NonSingletonRange)
-            <$> infiniteList
-    shrink (NonSingletonRange r) = mapMaybe
-        (makeNonSingletonRangeValid . NonSingletonRange) (shrink r)
-
--- Ensures that a range is not a singleton range.
-makeNonSingletonRangeValid
-    :: Ord a => NonSingletonRange a -> Maybe (NonSingletonRange a)
-makeNonSingletonRangeValid (NonSingletonRange r)
-    | Range.isSingleton r = Nothing
-    | otherwise = Just $ NonSingletonRange $ makeRangeValid r
 
 instance Arbitrary TxOut where
     -- No Shrinking

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -70,8 +70,6 @@ import Cardano.Wallet.Primitive.Types
     , EpochNo (..)
     , FeePolicy (..)
     , LinearFunction (..)
-    , Range (..)
-    , RangeBound (..)
     , SlotId (..)
     , SlotInEpoch (..)
     , SlotLength (..)
@@ -79,23 +77,9 @@ import Cardano.Wallet.Primitive.Types
     , StartTime (..)
     , WalletId (..)
     , WalletName (..)
-    , isAfterRange
-    , isBeforeRange
-    , isSubrangeOf
-    , isWithinRange
-    , mapRangeLowerBound
-    , mapRangeUpperBound
-    , rangeHasLowerBound
-    , rangeHasUpperBound
-    , rangeIsFinite
-    , rangeIsSingleton
-    , rangeIsValid
-    , rangeLowerBound
-    , rangeUpperBound
     , unsafeEpochNo
     , walletNameMaxLength
     , walletNameMinLength
-    , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
@@ -109,6 +93,24 @@ import Cardano.Wallet.Primitive.Types.Coin.Gen
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
+    )
+import Cardano.Wallet.Primitive.Types.Range
+    ( Range (..)
+    , RangeBound (..)
+    , isAfterRange
+    , isBeforeRange
+    , isSubrangeOf
+    , isWithinRange
+    , mapRangeLowerBound
+    , mapRangeUpperBound
+    , rangeHasLowerBound
+    , rangeHasUpperBound
+    , rangeIsFinite
+    , rangeIsSingleton
+    , rangeIsValid
+    , rangeLowerBound
+    , rangeUpperBound
+    , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..)


### PR DESCRIPTION
## Issue

Follow-on from #4251.

## Description

PR #4251 moved the `Range` type and related functions to a dedicated `Range` module.

In this follow-on PR, we:

- Stop re-exporting the `Range` type and related functions from the monolithic `Primitive.Types` module.
- Adopt a qualified import style for functions defined by the `Range` module.
- Move tests for the `Range` type (and functions) to a new `RangeSpec` module, colocated within `cardano-wallet-primitive`.