### PR TITLE
[ADP-3232] Re-enable macOS tests and builds on `x86_64-darwin`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ env:
   NIX_PATH: "channel:nixos-21.11"
 
   # Per-host variables - shared across containers on host
-  macos: "x86_64-darwin"
+  macos: "aarch64-darwin"
   linux: "x86_64-linux"
 
 
@@ -139,27 +139,24 @@ steps:
     depends_on: trigger-macos
     key: macos-nix
     commands:
-      - './nix/regenerate.sh'
+      - 'nix flake info'
     agents:
       system: ${macos}
-    if: 0 == 1 # Disabled for now until a macos mini is available
 
-  - label: 'Run unit tests (macOS)'
+  - label: 'Run unit tests (macOS, x86_64)'
     depends_on: macos-nix
     key: macos-build-tests
-    command: 'GC_DONT_GC=1 nix build --max-silent-time 0 --max-jobs 1 -L .#ci.${macos}.tests.run.unit'
+    command: 'GC_DONT_GC=1 nix build --max-silent-time 0 --max-jobs 1 -L .#ci.x86_64-darwin.tests.run.unit'
     agents:
       system: ${macos}
-    if: 0 == 1 # Disabled for now until a macos mini is available
 
-  - label: 'Build package (macOS)'
+  - label: 'Build package (macOS, x86_64)'
     depends_on: macos-nix
     key: build-macos
-    command: nix build --max-silent-time 0 --max-jobs 1 -o result/macos-intel .#ci.artifacts.macos-intel.release
+    command: nix build --max-silent-time 0 --max-jobs 1 -o result/macos-intel .#packages.x86_64-darwin.ci.artifacts.macos-intel.release
     artifact_paths: [ "./result/macos-intel/**" ]
     agents:
       system: ${macos}
-    if: 0 == 1 # Disabled for now until a macos mini is available
 
   - block: "Build package and docker image (linux)"
     depends_on: linux-nix


### PR DESCRIPTION
After further configuration of our macOS CI machine, this pull request re-enables building and testing on macOS post-merge.

Builds and tests are done for the `x86_64-darwin` architecture.

Our CI machine has architecture `aarch64-darwin`. Hence, we would be able to build and test `cardano-wallet` on this architecture as well, but at the moment, there is no officially tested build of `cardano-node` for this architecture that is also ready for mainnet.

### Issue number

ADP-3232
