### PR TITLE
[ADP-3173] Enable `aarch64-darwin`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -205,6 +205,14 @@ steps:
     agents:
       system: ${macos}
 
+  - label: 'Build package (macOS, arm64)'
+    key: macos-package-arm64
+    depends_on: macos-nix
+    command: 'nix build -o result/macos-silicon .#packages.aarch64-darwin.ci.artifacts.macos-silicon.release'
+    artifact_paths: [ "./result/macos-silicon/**" ]
+    agents:
+      system: ${macos}
+
   - block: "Build package (linux)"
     if: |
       build.branch !~ /^gh-readonly-queue\/master/

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -186,14 +186,14 @@ steps:
   - label: 'Run unit tests (macOS, x86_64)'
     key: macos-tests-unit
     depends_on: macos-nix
-    command: 'GC_DONT_GC=1 nix build --max-silent-time 0 --max-jobs 1 -L .#ci.x86_64-darwin.tests.run.unit'
+    command: 'nix build -L .#ci.x86_64-darwin.tests.run.unit'
     agents:
       system: ${macos}
 
   - label: 'Build package (macOS, x86_64)'
     key: macos-package
     depends_on: macos-nix
-    command: nix build --max-silent-time 0 --max-jobs 1 -o result/macos-intel .#packages.x86_64-darwin.ci.artifacts.macos-intel.release
+    command: 'nix build -o result/macos-intel .#packages.x86_64-darwin.ci.artifacts.macos-intel.release'
     artifact_paths: [ "./result/macos-intel/**" ]
     agents:
       system: ${macos}

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -190,6 +190,13 @@ steps:
     agents:
       system: ${macos}
 
+  - label: 'Run unit tests (macOS, arm64)'
+    depends_on: macos-nix
+    key: macos-build-tests-arm64
+    command: 'nix build -L .#ci.aarch64-darwin.tests.run.unit'
+    agents:
+      system: ${macos}
+
   - label: 'Build package (macOS, x86_64)'
     key: macos-package
     depends_on: macos-nix

--- a/flake.nix
+++ b/flake.nix
@@ -205,6 +205,7 @@
             check;
 
           nodePkgs = cardano-node-runtime.legacyPackages.${system};
+          nodePackages = cardano-node-runtime.packages.${system};
           nodeProject = cardano-node-runtime.project.${system};
 
           walletProject = (import ./nix/haskell.nix
@@ -378,8 +379,8 @@
                     macOsPkgs.cardano-wallet
                     macOsPkgs.bech32
                     macOsPkgs.cardano-address
-                    nodePkgs.hydraJobs.native.cardano-cli
-                    nodePkgs.hydraJobs.native.cardano-node
+                    nodePackages.cardano-cli
+                    nodePackages.cardano-node
                   ];
                   platform = "macos-silicon";
                   format = "tar.gz";

--- a/nix/supported-systems.nix
+++ b/nix/supported-systems.nix
@@ -2,5 +2,5 @@
   "x86_64-linux"
   "x86_64-darwin"
   # TODO: Enable aarch64-darwin when there are Hydra builders for it
-  # "aarch64-darwin"
+  "aarch64-darwin"
 ]


### PR DESCRIPTION
This pull request builds `cardano-wallet` for the `aarch64-darwin` architecture.

* Enables unit tests for `aarch64-darwin`
* Builds a release package for `aarch64-darwin`

### Comments

`cardano-node-8.7.3` officially supports `aarch64-darwin`

### Changelog

**Removed** 
* The legacy `scrypt` passphrase scheme is no longer supported on `aarch64-darwin` builds.

### Issue Number

ADP-3173