### PR TITLE
Rely more on `bodyTxL` and `outputsTxBodyL`

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -83,8 +83,6 @@ module Internal.Cardano.Write.Tx
     -- * Tx
     , Core.Tx
     , Core.TxBody
-    , txBody
-    , outputs
     , emptyTx
     , serializeTx
 
@@ -173,9 +171,7 @@ import Cardano.Ledger.Alonzo.UTxO
     ( AlonzoScriptsNeeded
     )
 import Cardano.Ledger.Api
-    ( bodyTxL
-    , coinTxOutL
-    , outputsTxBodyL
+    ( coinTxOutL
     )
 import Cardano.Ledger.Api.UTxO
     ( EraUTxO (ScriptsNeeded)
@@ -222,9 +218,6 @@ import Data.ByteString.Short
     )
 import Data.Coerce
     ( coerce
-    )
-import Data.Foldable
-    ( toList
     )
 import Data.Generics.Internal.VL.Lens
     ( over
@@ -680,19 +673,6 @@ serializeTx
     => Core.Tx era
     -> ByteString
 serializeTx tx = CardanoApi.serialiseToCBOR $ toCardanoApiTx @era tx
-
-txBody
-    :: IsRecentEra era
-    => Core.Tx era
-    -> Core.TxBody era
-txBody = (^. bodyTxL)
-
--- Until we have convenient lenses to use
-outputs
-    :: IsRecentEra era
-    => Core.TxBody era
-    -> [TxOut era]
-outputs body = toList $ body ^. outputsTxBodyL
 
 emptyTx
     :: IsRecentEra era

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
@@ -226,9 +225,7 @@ import Internal.Cardano.Write.Tx
     , getFeePerByte
     , isBelowMinimumCoinForTxOut
     , maxScriptExecutionCost
-    , outputs
     , toCardanoApiTx
-    , txBody
     )
 import Internal.Cardano.Write.Tx.Balance.CoinSelection
     ( Selection
@@ -868,7 +865,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     txBalance :: Tx era -> Value
     txBalance
         = evaluateTransactionBalance pp combinedUTxO
-        . txBody
+        . view bodyTxL
 
     balanceAfterSettingMinFee
         :: Tx era

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
@@ -93,7 +93,6 @@ import Internal.Cardano.Write.Tx
     , StandardCrypto
     , TxIn
     , UTxO
-    , txBody
     )
 import Internal.Cardano.Write.Tx.TimeTranslation
     ( TimeTranslation
@@ -166,7 +165,7 @@ assignScriptRedeemers pparams timeTranslation utxo redeemers tx = do
       where
         parseRedeemer rd = do
             let mPtr = Alonzo.rdptr
-                    (txBody ledgerTx)
+                    (view bodyTxL ledgerTx)
                     (toScriptPurpose rd)
             ptr <- case mPtr of
                 SNothing -> Left $ ErrAssignRedeemersTargetNotFound rd

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -612,7 +612,7 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
         let CardanoApi.ShelleyTx _ tx = either (error . show) id
                 $ balance
                 $ paymentPartialTx [ out ]
-        let outs = Write.outputs $ Write.txBody tx
+        let outs = F.toList $ tx ^. bodyTxL . outputsTxBodyL
 
         let pp = def
                 & ppCoinsPerUTxOByteL .~ testParameter_coinsPerUTxOByte_Babbage
@@ -747,7 +747,7 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
         :: CardanoApi.Tx CardanoApi.BabbageEra
         -> [Babbage.BabbageTxOut StandardBabbage]
     outputs (CardanoApi.Tx (CardanoApi.ShelleyTxBody _ body _ _ _ _ ) _) =
-        Write.outputs body
+        F.toList $ body ^. outputsTxBodyL
 
     mapFirst f (x:xs) = f x : xs
     mapFirst _ [] = error "mapFirst: empty list"
@@ -1517,7 +1517,7 @@ prop_balanceTransactionValid
         :: CardanoApi.Tx (CardanoApiEra era)
         -> Property
     _prop_outputsSatisfyMinAdaRequirement (CardanoApi.ShelleyTx _ tx) = do
-        let outputs = Write.outputs $ Write.txBody tx
+        let outputs = F.toList $ tx ^. bodyTxL . outputsTxBodyL
         conjoin $ map valid outputs
       where
         valid :: TxOut era -> Property
@@ -1573,7 +1573,7 @@ prop_balanceTransactionValid
         Write.evaluateTransactionBalance
             ledgerPParams
             u
-            (Write.txBody $ fromCardanoApiTx tx)
+            ((fromCardanoApiTx tx) ^. bodyTxL)
 
     ledgerPParams = mockPParamsForBalancing @era
 


### PR DESCRIPTION
- Remove need for `extractOutputsFromTx` in `Write.Tx.Balance`
- Remove `Write.outputs` and `Write.txBody` helpers

### Issue Number

Minor follow-up to ADP-2353 
