### PR TITLE
Fix compilation error on GHC 9.2

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -11,6 +11,8 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
+{- HLINT ignore "Use section" -}
+
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
@@ -868,7 +870,7 @@ withTestLoadDBLayerFromFile tr ti dbFile action = do
             dbFile
             noManualMigration
             noMigration
-            (`runQuery` readWalletId)
+            (flip runQuery readWalletId)
     case mwid of
         Nothing -> fail "No wallet id found in database"
         Just wid -> do


### PR DESCRIPTION
```
src/Cardano/Wallet/DB/Layer.hs:872:14: error:
    * Couldn't match type: forall a1. SqlPersistT IO a1 -> IO a1
                     with: SqlPersistT IO (Maybe W.WalletId) -> IO (Maybe W.WalletId)
      Expected: SqliteContext
                -> SqlPersistT IO (Maybe W.WalletId) -> IO (Maybe W.WalletId)
        Actual: SqliteContext -> forall a. SqlPersistT IO a -> IO a
    * In the expression: runQuery
      In the fifth argument of `withSqliteContextFile', namely
        `(`runQuery` readWalletId)'
      In the second argument of `(<$>)', namely
        `withSqliteContextFile
           (contramap MsgDB tr) dbFile noManualMigration noMigration
           (`runQuery` readWalletId)'
    |
872 |             (`runQuery` readWalletId)
```
And for some reason this helps.