### PR TITLE
[ADP-3229] Move wallet network implementation to network lib

### DIFF
--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -24,6 +24,7 @@ library
   import:           warnings
   exposed-modules:
     Cardano.Wallet.Network
+    Cardano.Wallet.Network.Implementation.Ouroboros
     Cardano.Wallet.Network.Implementation.UnliftIO
     Cardano.Wallet.Network.Logging
     Cardano.Wallet.Network.Logging.Aggregation

--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -23,9 +23,10 @@ common warnings
 library
   import:           warnings
   exposed-modules:
-    Cardano.Wallet.Network.Logging.Aggregation
-    Cardano.Wallet.Network.Logging
     Cardano.Wallet.Network
+    Cardano.Wallet.Network.Implementation.UnliftIO
+    Cardano.Wallet.Network.Logging
+    Cardano.Wallet.Network.Logging.Aggregation
 
   -- other-modules:
   -- other-extensions:
@@ -42,6 +43,7 @@ library
     , cborg
     , containers
     , contra-tracer
+    , exceptions
     , fmt
     , generics-sop
     , io-classes

--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -24,6 +24,7 @@ library
   import:           warnings
   exposed-modules:
     Cardano.Wallet.Network
+    Cardano.Wallet.Network.Implementation
     Cardano.Wallet.Network.Implementation.Ouroboros
     Cardano.Wallet.Network.Implementation.UnliftIO
     Cardano.Wallet.Network.Logging
@@ -32,11 +33,13 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:
-    , base                         ^>=4.14.3.0
+    , base                           ^>=4.14.3.0
     , bytestring
     , cardano-api
     , cardano-balance-tx:internal
+    , cardano-crypto-class
     , cardano-ledger-core
+    , cardano-ledger-shelley
     , cardano-slotting
     , cardano-wallet-launcher
     , cardano-wallet-primitive
@@ -51,13 +54,18 @@ library
     , iohk-monitoring
     , iohk-monitoring-extra
     , memory
+    , mtl
     , network-mux
     , nothunks
     , ouroboros-consensus
     , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion
+    , ouroboros-consensus-protocol
+    , ouroboros-network
     , ouroboros-network-api
     , ouroboros-network-framework
     , ouroboros-network-protocols
+    , retry
     , safe
     , strict-stm
     , text
@@ -66,6 +74,7 @@ library
     , transformers
     , typed-protocols
     , unliftio
+    , unliftio-core
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation/Ouroboros.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation/Ouroboros.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -21,7 +22,7 @@
 -- clients implement the logic and lift away concerns related to concrete
 -- data-type representation so that the code can be re-used / shared between
 -- Byron and Shelley.
-module Ouroboros.Network.Client.Wallet
+module Cardano.Wallet.Network.Implementation.Ouroboros
     (
       -- * ChainSyncFollowTip
       chainSyncFollowTip

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation/UnliftIO.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation/UnliftIO.hs
@@ -1,0 +1,20 @@
+module Cardano.Wallet.Network.Implementation.UnliftIO
+    ( coerceHandler
+    , coerceHandlers
+    )
+where
+
+import qualified Control.Monad.Catch as Exceptions
+import qualified UnliftIO
+
+-- | Convert the generalized handler from 'UnliftIO.Exception' type to 'Control.Monad.Catch' type
+coerceHandler :: UnliftIO.Handler IO b -> Exceptions.Handler IO b
+coerceHandler (UnliftIO.Handler h) = Exceptions.Handler h
+
+-- | Convert a list of handler factories from the 'UnliftIO.Exception' type to
+-- 'Control.Monad.Catch' type. Such handlers are used in
+-- 'Control.Retry.Recovering' for example.
+coerceHandlers
+    :: [a -> UnliftIO.Handler IO b]
+    -> [a -> Exceptions.Handler IO b]
+coerceHandlers = map (coerceHandler .)

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -143,6 +143,7 @@ library
     Cardano.Wallet.Primitive.Ledger.Read.Tx.Mary
     Cardano.Wallet.Primitive.Ledger.Read.Tx.Sealed
     Cardano.Wallet.Primitive.Ledger.Read.Tx.Shelley
+    Cardano.Wallet.Primitive.Ledger.Shelley
     Cardano.Wallet.Primitive.NetworkId
     Cardano.Wallet.Primitive.Slotting
     Cardano.Wallet.Primitive.Slotting.Legacy

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -39,6 +39,7 @@ library
   hs-source-dirs:  lib
   build-depends:
     , aeson
+    , array
     , base
     , bech32
     , bech32-th
@@ -50,10 +51,12 @@ library
     , cardano-crypto
     , cardano-crypto-class
     , cardano-crypto-wrapper
+    , cardano-data
     , cardano-ledger-allegra
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-babbage
+    , cardano-ledger-binary
     , cardano-ledger-byron
     , cardano-ledger-conway
     , cardano-ledger-core
@@ -63,12 +66,14 @@ library
     , cardano-protocol-tpraos
     , cardano-slotting
     , cardano-strict-containers
+    , cardano-wallet-launcher
     , cardano-wallet-read
     , cardano-wallet-test-utils
     , cborg
     , commutative-semigroups
     , containers
     , contra-tracer
+    , crypto-hash-extra
     , cryptonite
     , deepseq
     , delta-types
@@ -92,6 +97,8 @@ library
     , OddWord
     , ouroboros-consensus
     , ouroboros-consensus-cardano
+    , ouroboros-consensus-protocol
+    , ouroboros-network
     , ouroboros-network-api
     , pretty-simple
     , QuickCheck
@@ -110,6 +117,7 @@ library
   exposed-modules:
     Cardano.Wallet.Orphans
     Cardano.Wallet.Primitive.Collateral
+    Cardano.Wallet.Primitive.Ledger.Byron
     Cardano.Wallet.Primitive.Ledger.Convert
     Cardano.Wallet.Primitive.Ledger.Read.Block
     Cardano.Wallet.Primitive.Ledger.Read.Block.Header

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -156,6 +156,7 @@ library
     Cardano.Wallet.Primitive.Types.FeePolicy
     Cardano.Wallet.Primitive.Types.GenesisParameters
     Cardano.Wallet.Primitive.Types.Hash
+    Cardano.Wallet.Primitive.Types.NetworkParameters
     Cardano.Wallet.Primitive.Types.Pool
     Cardano.Wallet.Primitive.Types.ProtocolMagic
     Cardano.Wallet.Primitive.Types.ProtocolParameters

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -222,9 +222,12 @@ test-suite test
     , binary
     , bytestring
     , cardano-addresses
+    , cardano-api
+    , cardano-crypto-class
     , cardano-ledger-allegra:{cardano-ledger-allegra, testlib}
     , cardano-ledger-byron-test
     , cardano-ledger-core:{cardano-ledger-core, testlib}
+    , cardano-ledger-shelley
     , cardano-ledger-shelley-test
     , cardano-numeric
     , cardano-slotting
@@ -243,9 +246,12 @@ test-suite test
     , hspec-core
     , iohk-monitoring
     , lattices
+    , lens
     , MonadRandom
     , ouroboros-consensus
     , ouroboros-consensus-cardano
+    , ouroboros-network
+    , ouroboros-network-api
     , QuickCheck
     , quickcheck-classes
     , quickcheck-instances
@@ -264,6 +270,7 @@ test-suite test
   other-modules:
     Cardano.Wallet.Primitive.CollateralSpec
     Cardano.Wallet.Primitive.Ledger.ConvertSpec
+    Cardano.Wallet.Primitive.Ledger.ShelleySpec
     Cardano.Wallet.Primitive.SlottingSpec
     Cardano.Wallet.Primitive.SyncProgressSpec
     Cardano.Wallet.Primitive.Types.AddressSpec

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -111,6 +111,30 @@ library
     Cardano.Wallet.Orphans
     Cardano.Wallet.Primitive.Collateral
     Cardano.Wallet.Primitive.Ledger.Convert
+    Cardano.Wallet.Primitive.Ledger.Read.Block
+    Cardano.Wallet.Primitive.Ledger.Read.Block.Header
+    Cardano.Wallet.Primitive.Ledger.Read.Tx
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Allegra
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Alonzo
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Babbage
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Byron
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Conway
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Certificates
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.CollateralInputs
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.CollateralOutputs
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.ExtraSigs
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Fee
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Inputs
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Integrity
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Metadata
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Mint
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Outputs
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.ScriptValidity
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Validity
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Withdrawals
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Mary
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Sealed
+    Cardano.Wallet.Primitive.Ledger.Read.Tx.Shelley
     Cardano.Wallet.Primitive.NetworkId
     Cardano.Wallet.Primitive.Slotting
     Cardano.Wallet.Primitive.Slotting.Legacy
@@ -130,6 +154,7 @@ library
     Cardano.Wallet.Primitive.Types.EraInfo
     Cardano.Wallet.Primitive.Types.ExecutionUnitPrices
     Cardano.Wallet.Primitive.Types.FeePolicy
+    Cardano.Wallet.Primitive.Types.GenesisParameters
     Cardano.Wallet.Primitive.Types.Hash
     Cardano.Wallet.Primitive.Types.Pool
     Cardano.Wallet.Primitive.Types.ProtocolMagic
@@ -167,30 +192,6 @@ library
     Cardano.Wallet.Primitive.Types.UTxO.Gen
     Cardano.Wallet.Primitive.Types.ValidityIntervalExplicit
     Cardano.Wallet.Primitive.Types.WitnessCount
-    Cardano.Wallet.Primitive.Ledger.Read.Block
-    Cardano.Wallet.Primitive.Ledger.Read.Block.Header
-    Cardano.Wallet.Primitive.Ledger.Read.Tx
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Allegra
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Alonzo
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Babbage
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Byron
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Conway
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Certificates
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.CollateralInputs
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.CollateralOutputs
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.ExtraSigs
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Fee
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Inputs
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Integrity
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Metadata
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Mint
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Outputs
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.ScriptValidity
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Validity
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Withdrawals
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Mary
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Sealed
-    Cardano.Wallet.Primitive.Ledger.Read.Tx.Shelley
     Cardano.Wallet.Unsafe
     Cardano.Wallet.Util
     Control.Monad.Random.NonRandom

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Byron.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Byron.hs
@@ -186,7 +186,7 @@ mainnetNetworkParameters =
 -- it became an updateable protocol parameter.
 --
 -- NOTE: A bit weird to define in "Cardano.Wallet.Primitive.Ledger.Byron", but we
--- need it both here and in "Cardano.Wallet.Shelley.Compatibility".
+-- need it both here and in "Cardano.Wallet.Primitive.Ledger.Shelley".
 maryTokenBundleMaxSize :: W.TokenBundleMaxSize
 maryTokenBundleMaxSize = W.TokenBundleMaxSize $ W.TxSize 4_000
 

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Byron.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Byron.hs
@@ -13,7 +13,7 @@
 -- License: Apache-2.0
 --
 -- Conversion functions and static chain settings for Byron.
-module Cardano.Wallet.Byron.Compatibility
+module Cardano.Wallet.Primitive.Ledger.Byron
     ( -- * Chain Parameters
       mainnetNetworkParameters
     , maryTokenBundleMaxSize
@@ -105,16 +105,27 @@ import Ouroboros.Network.Block
 import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.Update.Validation.Interface as Update
 import qualified Cardano.Crypto.Hashing as CC
-import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Slotting.Slot as Slotting
+import qualified Cardano.Wallet.Primitive.Slotting as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
+import qualified Cardano.Wallet.Primitive.Types.Block as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
+import qualified Cardano.Wallet.Primitive.Types.EpochNo as W
+import qualified Cardano.Wallet.Primitive.Types.EraInfo as W
+import qualified Cardano.Wallet.Primitive.Types.FeePolicy as W
+import qualified Cardano.Wallet.Primitive.Types.GenesisParameters as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
+import qualified Cardano.Wallet.Primitive.Types.NetworkParameters as W
 import qualified Cardano.Wallet.Primitive.Types.ProtocolMagic as W
+import qualified Cardano.Wallet.Primitive.Types.ProtocolParameters as W
+import qualified Cardano.Wallet.Primitive.Types.SlottingParameters as W
+import qualified Cardano.Wallet.Primitive.Types.TokenBundleMaxSize as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (TxOut)
     )
+import qualified Cardano.Wallet.Primitive.Types.TxParameters as W
 import qualified Data.Map.Strict as Map
 import qualified Ouroboros.Consensus.Block as O
 
@@ -174,7 +185,7 @@ mainnetNetworkParameters =
 -- The concept was introduced in Mary, and hard-coded to this value. In Alonzo
 -- it became an updateable protocol parameter.
 --
--- NOTE: A bit weird to define in "Cardano.Wallet.Byron.Compatibility", but we
+-- NOTE: A bit weird to define in "Cardano.Wallet.Primitive.Ledger.Byron", but we
 -- need it both here and in "Cardano.Wallet.Shelley.Compatibility".
 maryTokenBundleMaxSize :: W.TokenBundleMaxSize
 maryTokenBundleMaxSize = W.TokenBundleMaxSize $ W.TxSize 4_000
@@ -195,7 +206,7 @@ emptyGenesis gp =
         , header =
             W.BlockHeader
                 { slotNo =
-                    W.SlotNo 0
+                    Slotting.SlotNo 0
                 , blockHeight =
                     Quantity 0
                 , headerHash =

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -23,7 +23,7 @@
 -- License: Apache-2.0
 --
 -- Conversion functions and static chain settings for Shelley.
-module Cardano.Wallet.Shelley.Compatibility
+module Cardano.Wallet.Primitive.Ledger.Shelley
     ( CardanoBlock
     , StandardCrypto
     , StandardShelley
@@ -206,14 +206,6 @@ import Cardano.Ledger.PoolParams
 import Cardano.Ledger.Shelley.Genesis
     ( fromNominalDiffTimeMicro
     )
-import Cardano.Pool.Metadata.Types
-    ( StakePoolMetadataHash (..)
-    , StakePoolMetadataUrl (..)
-    )
-import Cardano.Pool.Types
-    ( PoolId (..)
-    , PoolOwner (..)
-    )
 import Cardano.Slotting.Slot
     ( EpochNo (..)
     , EpochSize (..)
@@ -221,12 +213,14 @@ import Cardano.Slotting.Slot
 import Cardano.Slotting.Time
     ( SystemStart (..)
     )
-import Cardano.Wallet.Address.Encoding
-    ( fromStakeCredential
-    )
 import Cardano.Wallet.Primitive.Ledger.Byron
+    ( maryTokenBundleMaxSize
+    )
+import Cardano.Wallet.Primitive.Ledger.Read.Tx.Byron
     ( fromTxAux
-    , maryTokenBundleMaxSize
+    )
+import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Certificates
+    ( fromStakeCredential
     )
 import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Inputs
     ( fromShelleyTxIn
@@ -236,12 +230,20 @@ import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Outputs
     , fromShelleyAddress
     , fromShelleyTxOut
     )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Block
     ( ChainPoint (..)
-    , PoolCertificate
+    )
+import Cardano.Wallet.Primitive.Types.Certificates
+    ( PoolCertificate
     , PoolRegistrationCertificate (..)
-    , ProtocolParameters (txParameters)
-    , TxParameters (getTokenBundleMaxSize)
+    )
+import Cardano.Wallet.Primitive.Types.Pool
+    ( PoolId (..)
+    , PoolOwner (..)
+    )
+import Cardano.Wallet.Primitive.Types.StakePoolMetadata
+    ( StakePoolMetadataHash (..)
+    , StakePoolMetadataUrl (..)
     )
 import Cardano.Wallet.Read.Tx.Hash
     ( fromShelleyTxId
@@ -383,14 +385,27 @@ import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Ledger.Shelley.API as SLAPI
 import qualified Cardano.Ledger.Shelley.BlockChain as SL
 import qualified Cardano.Protocol.TPraos.BHeader as SL
+import qualified Cardano.Slotting.Slot as Slotting
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Ledger
-import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Slotting as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
+import qualified Cardano.Wallet.Primitive.Types.Block as W
+import qualified Cardano.Wallet.Primitive.Types.Certificates as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
+import qualified Cardano.Wallet.Primitive.Types.DecentralizationLevel as W
+import qualified Cardano.Wallet.Primitive.Types.EpochNo as W
+import qualified Cardano.Wallet.Primitive.Types.EraInfo as W
+import qualified Cardano.Wallet.Primitive.Types.ExecutionUnitPrices as W
+import qualified Cardano.Wallet.Primitive.Types.FeePolicy as W
+import qualified Cardano.Wallet.Primitive.Types.GenesisParameters as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
+import qualified Cardano.Wallet.Primitive.Types.NetworkParameters as W
+import qualified Cardano.Wallet.Primitive.Types.ProtocolParameters as W
 import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
+import qualified Cardano.Wallet.Primitive.Types.SlottingParameters as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenBundleMaxSize as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
@@ -407,6 +422,7 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (TxOut)
     )
+import qualified Cardano.Wallet.Primitive.Types.TxParameters as W
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
 import qualified Data.Array as Array
 import qualified Data.ByteString as BS
@@ -439,7 +455,7 @@ emptyGenesis gp = W.Block
     , delegations  = []
     , header = W.BlockHeader
         { slotNo =
-            W.SlotNo 0
+            Slotting.SlotNo 0
         , blockHeight =
             Quantity 0
         , headerHash =
@@ -581,7 +597,7 @@ fromTip
     -> W.BlockHeader
 fromTip genesisHash tip = case getPoint (getTipPoint tip) of
     Origin -> W.BlockHeader
-        { slotNo = W.SlotNo 0
+        { slotNo = Slotting.SlotNo 0
         , blockHeight = Quantity 0
         , headerHash = coerce genesisHash
         , parentHeaderHash = Nothing
@@ -898,7 +914,7 @@ fromGenesisData g =
     genesisBlockFromTxOuts outs = W.Block
         { delegations  = []
         , header = W.BlockHeader
-            { slotNo = W.SlotNo 0
+            { slotNo = Slotting.SlotNo 0
             , blockHeight = Quantity 0
             , headerHash = dummyGenesisHash
             , parentHeaderHash = Nothing

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/GenesisParameters.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/GenesisParameters.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Cardano.Wallet.Primitive.Types.GenesisParameters
+    ( GenesisParameters (..)
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Slotting (StartTime (StartTime))
+import Cardano.Wallet.Primitive.Types.Hash (Hash (getHash))
+import Control.DeepSeq (NFData)
+import Data.ByteArray.Encoding (Base (Base16), convertToBase)
+import Fmt (Buildable (..), blockListF')
+import GHC.Generics (Generic)
+
+import qualified Data.Text.Encoding as T
+
+-- | Parameters defined by the __genesis block__.
+--
+-- At present, these values cannot be changed through the update system.
+--
+-- They can only be changed through a soft or hard fork.
+data GenesisParameters = GenesisParameters
+    { getGenesisBlockHash :: Hash "Genesis"
+    -- ^ Hash of the very first block
+    , getGenesisBlockDate :: StartTime
+    -- ^ Start time of the chain.
+    }
+    deriving (Generic, Show, Eq)
+
+instance NFData GenesisParameters
+
+instance Buildable GenesisParameters where
+    build gp =
+        blockListF'
+            ""
+            id
+            [ "Genesis block hash: " <> genesisF (getGenesisBlockHash gp)
+            , "Genesis block date: "
+                <> startTimeF
+                    ( getGenesisBlockDate
+                        (gp :: GenesisParameters)
+                    )
+            ]
+      where
+        genesisF = build . T.decodeUtf8 . convertToBase Base16 . getHash
+        startTimeF (StartTime s) = build s

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/GenesisParameters.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/GenesisParameters.hs
@@ -8,12 +8,26 @@ where
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Slotting (StartTime (StartTime))
-import Cardano.Wallet.Primitive.Types.Hash (Hash (getHash))
-import Control.DeepSeq (NFData)
-import Data.ByteArray.Encoding (Base (Base16), convertToBase)
-import Fmt (Buildable (..), blockListF')
-import GHC.Generics (Generic)
+import Cardano.Wallet.Primitive.Slotting
+    ( StartTime (StartTime)
+    )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (getHash)
+    )
+import Control.DeepSeq
+    ( NFData
+    )
+import Data.ByteArray.Encoding
+    ( Base (Base16)
+    , convertToBase
+    )
+import Fmt
+    ( Buildable (..)
+    , blockListF'
+    )
+import GHC.Generics
+    ( Generic
+    )
 
 import qualified Data.Text.Encoding as T
 

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/NetworkParameters.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/NetworkParameters.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Cardano.Wallet.Primitive.Types.NetworkParameters
+    ( NetworkParameters (..)
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.GenesisParameters
+    ( GenesisParameters
+    )
+import Cardano.Wallet.Primitive.Types.ProtocolParameters
+    ( ProtocolParameters
+    )
+import Cardano.Wallet.Primitive.Types.SlottingParameters
+    ( SlottingParameters
+    )
+import Control.DeepSeq
+    ( NFData
+    )
+import Fmt
+    ( Buildable (..)
+    )
+import GHC.Generics
+    ( Generic
+    )
+
+-- | Records the complete set of parameters currently in use by the network
+--   that are relevant to the wallet.
+data NetworkParameters = NetworkParameters
+    { genesisParameters :: GenesisParameters
+    -- ^ See 'GenesisParameters'.
+    , slottingParameters :: SlottingParameters
+    -- ^ See 'SlottingParameters'.
+    , protocolParameters :: ProtocolParameters
+    -- ^ See 'ProtocolParameters'.
+    }
+    deriving (Generic, Show, Eq)
+
+instance NFData NetworkParameters
+
+instance Buildable NetworkParameters where
+    build (NetworkParameters gp sp pp) = build gp <> build sp <> build pp

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ShelleySpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ShelleySpec.hs
@@ -1,0 +1,571 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.Primitive.Ledger.ShelleySpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Address.Derivation
+    ( XPrv
+    )
+import Cardano.Address.Script
+    ( KeyHash
+    , KeyRole (..)
+    , Script (..)
+    , ScriptHash (..)
+    , keyHashFromBytes
+    , serializeScript
+    , toScriptHash
+    )
+import Cardano.Crypto.Hash.Class
+    ( digest
+    )
+import Cardano.Ledger.Core
+    ( PParams
+    , ppDL
+    )
+import Cardano.Ledger.Crypto
+    ( Crypto (..)
+    )
+import Cardano.Mnemonic
+    ( ConsistentEntropy
+    , EntropySize
+    , Mnemonic
+    , SomeMnemonic (..)
+    , entropyToMnemonic
+    )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( CardanoBlock
+    , StandardCrypto
+    , decentralizationLevelFromPParams
+    , fromCardanoValue
+    , fromTip
+    , interval0
+    , interval1
+    , invertUnitInterval
+    , toCardanoHash
+    , toCardanoValue
+    , toTip
+    )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..)
+    )
+import Cardano.Wallet.Primitive.Types.DecentralizationLevel
+    ( DecentralizationLevel (getDecentralizationLevel)
+    )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..)
+    )
+import Cardano.Wallet.Primitive.Types.RewardAccount
+    ( RewardAccount (..)
+    )
+import Cardano.Wallet.Primitive.Types.SlotId
+    ( SlotId (SlotId)
+    )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle
+    )
+import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
+    ( genTokenBundle
+    , genTokenBundleSmallRange
+    , shrinkTokenBundleSmallRange
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
+    ( genTxOutTokenBundle
+    )
+import Cardano.Wallet.Unsafe
+    ( unsafeIntToWord
+    , unsafeMkEntropy
+    )
+import Cardano.Wallet.Util
+    ( tryInternalError
+    )
+import Codec.Binary.Encoding
+    ( fromBase16
+    )
+import Control.Lens
+    ( (.~)
+    )
+import Control.Monad
+    ( forM_
+    )
+import Data.Function
+    ( (&)
+    )
+import Data.Maybe
+    ( fromMaybe
+    )
+import Data.Proxy
+    ( Proxy (..)
+    )
+import Data.Ratio
+    ( Ratio
+    , (%)
+    )
+import Data.Text
+    ( Text
+    )
+import Data.Text.Class
+    ( toText
+    )
+import Data.Word
+    ( Word16
+    , Word32
+    , Word64
+    )
+import GHC.TypeLits
+    ( natVal
+    )
+import Ouroboros.Network.Block
+    ( BlockNo (..)
+    , SlotNo (..)
+    , Tip (..)
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+import Test.Hspec.Core.Spec
+    ( SpecWith
+    )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Gen
+    , NonNegative (..)
+    , Property
+    , Small (..)
+    , checkCoverage
+    , choose
+    , counterexample
+    , cover
+    , frequency
+    , oneof
+    , property
+    , resize
+    , vector
+    , (===)
+    )
+import Test.QuickCheck.Monadic
+    ( assert
+    , monadicIO
+    , monitor
+    , run
+    )
+
+import qualified Cardano.Api as Cardano
+import qualified Cardano.Ledger.BaseTypes as SL
+import qualified Cardano.Ledger.Shelley as SL
+import qualified Cardano.Ledger.Shelley.PParams as SL
+import qualified Cardano.Wallet.Primitive.Types.Block as W
+import qualified Cardano.Wallet.Primitive.Types.EpochNo as W
+import qualified Cardano.Wallet.Primitive.Types.SlotId as W
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Data.ByteString as BS
+import qualified Data.Text.Encoding as T
+
+spec :: Spec
+spec = do
+    describe "Conversions" $ do
+        it "toTip' . fromTip' == id" $ property $ \gh tip -> do
+            let fromTip' = fromTip gh
+            let toTip' = toTip gh :: W.BlockHeader -> Tip (CardanoBlock StandardCrypto)
+            toTip' (fromTip' tip) === tip
+
+        it "unsafeIntToWord" $
+            property prop_unsafeIntToWord
+
+    describe "decentralizationLevelFromPParams" $ do
+
+        let mkDecentralizationParam
+                :: SL.UnitInterval
+                -> PParams (SL.ShelleyEra StandardCrypto)
+            mkDecentralizationParam i = SL.emptyPParams & ppDL .~ i
+
+        let testCases :: [(Ratio Word64, Text)]
+            testCases =
+                [ (10 % 10,   "0.00%")
+                , ( 9 % 10,  "10.00%")
+                , ( 5 % 10,  "50.00%")
+                , ( 1 % 10,  "90.00%")
+                , ( 0 % 10, "100.00%")
+                ]
+
+        forM_ testCases $ \(input, expectedOutput) -> do
+            let title = show input <> " -> " <> show expectedOutput
+            let output = input
+                    & toRational
+                    & unsafeBoundRational
+                    & mkDecentralizationParam
+                    & decentralizationLevelFromPParams
+                    & getDecentralizationLevel
+                    & toText
+            it title $ output `shouldBe` expectedOutput
+
+    describe "Cardano.Api.Value-TokenBundle conversion" $ do
+        it "roundtrips" $ checkCoverage $ property $ \tb ->
+            cover 20 (TokenBundle.getCoin tb /= Coin 0) "has ada" $
+            cover 2 (TokenBundle.getCoin tb == Coin 0) "has no ada" $
+            cover 10 (length (snd $ TokenBundle.toFlatList tb) > 3)
+                "has some assets" $
+            fromCardanoValue (toCardanoValue tb) === tb
+
+    describe "Utilities" $ do
+
+        describe "UnitInterval" $ do
+
+            it "coverage adequate" $
+                checkCoverage $ property $ \i ->
+                    let half = unsafeBoundRational (1 % 2) in
+                    cover 10 (i == half) "i = 0.5" $
+                    cover 10 (i == interval0) "i = 0" $
+                    cover 10 (i == interval1) "i = 1" $
+                    cover 10 (i > interval0 && i < half) "0 < i < 0.5" $
+                    cover 10 (half < i && i < interval1) "0.5 < i < 1"
+                    True
+
+            it "invertUnitInterval . invertUnitInterval == id" $
+                property $ \i ->
+                    invertUnitInterval (invertUnitInterval i) `shouldBe` i
+
+            it "intervalValue i + intervalValue (invertUnitInterval i) == 1" $
+                property $ \i ->
+                    SL.unboundRational i + SL.unboundRational (invertUnitInterval i)
+                        `shouldBe` 1
+
+            it "invertUnitInterval interval0 == interval1" $
+                invertUnitInterval interval0 `shouldBe` interval1
+
+            it "invertUnitInterval interval1 == interval0" $
+                invertUnitInterval interval1 `shouldBe` interval0
+
+            it "invertUnitInterval half == half" $
+                let half = unsafeBoundRational (1 % 2) in
+                invertUnitInterval half `shouldBe` half
+
+    describe "golden tests for script hashes" $ do
+        testScriptsAllLangs
+        testScriptsTimelockLang
+
+    describe "golden tests for script preimages" $ do
+        testScriptPreimages
+        testTimelockScriptImagesLang
+
+--------------------------------------------------------------------------------
+-- Conversions
+--------------------------------------------------------------------------------
+
+prop_unsafeIntToWord :: TrickyInt Integer Word16 -> Property
+prop_unsafeIntToWord (TrickyInt n wrong) = monadicIO $ do
+    res <- run $ tryInternalError $ unsafeIntToWord @Integer @Word16 n
+    monitor (counterexample ("res = " ++ show res))
+    assert $ case res of
+        Right correct -> fromIntegral correct == n
+        Left _ -> fromIntegral wrong /= n
+
+data TrickyInt n w = TrickyInt n w deriving (Show, Eq)
+
+instance (Arbitrary n, Integral n, Num w) => Arbitrary (TrickyInt n w) where
+    arbitrary = do
+        d <- arbitrary
+        x <- getSmall . getNonNegative <$> arbitrary :: Gen Int
+        s <- frequency [(20, pure 1), (5, pure (-1)), (1, pure 0)]
+        let n = s * ((2 ^ x) + d)
+        pure $ TrickyInt n (fromIntegral n)
+
+toKeyHash :: Text -> Script KeyHash
+toKeyHash txt = case fromBase16 (T.encodeUtf8 txt) of
+    Right bs -> case keyHashFromBytes (Payment, bs) of
+        Just kh -> RequireSignatureOf kh
+        Nothing -> error "Hash key not valid"
+    Left _ -> error "Hash key not valid"
+
+toPaymentHash :: Text -> Cardano.SimpleScript
+toPaymentHash txt =
+    case Cardano.deserialiseFromRawBytesHex (Cardano.AsHash Cardano.AsPaymentKey) (T.encodeUtf8 txt) of
+        Right payKeyHash -> Cardano.RequireSignature payKeyHash
+        Left err -> error $ "toPaymentHash: " <> show err
+
+checkScriptHashes
+    :: String
+    -> Script KeyHash
+    -> Cardano.Script lang
+    -> SpecWith ()
+checkScriptHashes title adrestiaScript nodeScript = it title $
+    unScriptHash (toScriptHash adrestiaScript) `shouldBe`
+    Cardano.serialiseToRawBytes (Cardano.hashScript nodeScript)
+
+checkScriptPreimage
+    :: Cardano.SerialiseAsCBOR (Cardano.Script lang)
+    => String
+    -> Script KeyHash
+    -> Cardano.Script lang
+    -> SpecWith ()
+checkScriptPreimage title adrestiaScript nodeScript = it title $
+    (serializeScript adrestiaScript) `shouldBe`
+    BS.append "\00" (Cardano.serialiseToCBOR nodeScript)
+
+scriptMatrix
+    :: [(String, Script KeyHash, Cardano.Script Cardano.SimpleScript')]
+scriptMatrix =
+    [ ( "RequireSignatureOf"
+      , toKeyHash hashKeyTxt1
+      , toSimpleScript $ toPaymentHash hashKeyTxt1
+      )
+    , ( "RequireSignatureOf"
+      , toKeyHash hashKeyTxt2
+      , toSimpleScript $ toPaymentHash hashKeyTxt2
+      )
+    , ( "RequireSignatureOf"
+      , toKeyHash hashKeyTxt3
+      , toSimpleScript $ toPaymentHash hashKeyTxt3
+      )
+    , ( "RequireSignatureOf"
+      , toKeyHash hashKeyTxt4
+      , toSimpleScript $ toPaymentHash hashKeyTxt4
+      )
+    , ( "RequireAllOf"
+      , RequireAllOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2]
+      , toSimpleScript $
+          Cardano.RequireAllOf [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2]
+      )
+    , ( "RequireAllOf"
+      , RequireAllOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2, toKeyHash hashKeyTxt3]
+      , toSimpleScript $
+          Cardano.RequireAllOf [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2, toPaymentHash hashKeyTxt3]
+      )
+    , ( "RequireAnyOf"
+      , RequireAnyOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2]
+      , toSimpleScript $
+          Cardano.RequireAnyOf [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2]
+      )
+    , ( "RequireAnyOf"
+      , RequireAnyOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2, toKeyHash hashKeyTxt3]
+      , toSimpleScript $
+          Cardano.RequireAnyOf [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2, toPaymentHash hashKeyTxt3]
+      )
+    , ( "RequireSomeOf"
+      , RequireSomeOf 2 [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2, toKeyHash hashKeyTxt3]
+      , toSimpleScript $
+          Cardano.RequireMOf 2 [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2, toPaymentHash hashKeyTxt3]
+      )
+    , ( "RequireSomeOf"
+      , RequireSomeOf 2 [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2, toKeyHash hashKeyTxt3, toKeyHash hashKeyTxt4]
+      , toSimpleScript $
+          Cardano.RequireMOf 2 [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2, toPaymentHash hashKeyTxt3, toPaymentHash hashKeyTxt4]
+      )
+    , ( "nested 1"
+      , RequireSomeOf 2 [ toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2
+                        , RequireAllOf [toKeyHash hashKeyTxt3, toKeyHash hashKeyTxt4]
+                        ]
+      , toSimpleScript $
+          Cardano.RequireMOf 2 [ toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2
+                               , Cardano.RequireAllOf [toPaymentHash hashKeyTxt3, toPaymentHash hashKeyTxt4]
+                                       ]
+      )
+    , ( "nested 2"
+      , RequireAllOf [ toKeyHash hashKeyTxt1
+                     , RequireAnyOf [toKeyHash hashKeyTxt2, toKeyHash hashKeyTxt3, toKeyHash hashKeyTxt4]
+                     ]
+      , toSimpleScript $
+          Cardano.RequireAllOf [ toPaymentHash hashKeyTxt1
+                               , Cardano.RequireAnyOf [toPaymentHash hashKeyTxt2, toPaymentHash hashKeyTxt3, toPaymentHash hashKeyTxt4]
+                               ]
+      )
+    , ( "nested 3"
+      , RequireSomeOf 1 [ toKeyHash hashKeyTxt1
+                        , RequireAllOf [ toKeyHash hashKeyTxt2
+                                       , RequireAnyOf [toKeyHash hashKeyTxt3, toKeyHash hashKeyTxt4 ]
+                                       ]
+                        ]
+      , toSimpleScript $
+          Cardano.RequireMOf 1 [ toPaymentHash hashKeyTxt1
+                               , Cardano.RequireAllOf [ toPaymentHash hashKeyTxt2
+                                                      , Cardano.RequireAnyOf [toPaymentHash hashKeyTxt3, toPaymentHash hashKeyTxt4]
+                                                      ]
+                               ]
+      )
+    ]
+  where
+    toSimpleScript = Cardano.SimpleScript
+    hashKeyTxt1 = "deeae4e895d8d57378125ed4fd540f9bf245d59f7936a504379cfc1e"
+    hashKeyTxt2 = "60a3bf69aa748f9934b64357d9f1ca202f1a768aaf57263aedca8d5f"
+    hashKeyTxt3 = "ffcbb72393215007d9a0aa02b7430080409cd8c053fd4f5b4d905053"
+    hashKeyTxt4 = "96834025cdca063ce9c32dfae6bc6a3e47f8da07ee4fb8e1a3901559"
+
+testScriptsAllLangs
+    :: Spec
+testScriptsAllLangs = do
+    forM_ scriptMatrix $ \(title, adrestiaScript, nodeScript) ->
+        checkScriptHashes title adrestiaScript nodeScript
+
+testScriptPreimages
+    :: Spec
+testScriptPreimages = do
+    forM_ scriptMatrix $ \(title, adrestiaScript, nodeScript) ->
+        checkScriptPreimage title adrestiaScript nodeScript
+
+timelockScriptMatrix
+    :: [(String, Script KeyHash, Cardano.Script Cardano.SimpleScript')]
+timelockScriptMatrix =
+    [ ( "SimpleScript ActiveFromSlot"
+      , RequireAllOf [toKeyHash hashKeyTxt1, ActiveFromSlot 120]
+      , toSimpleScript $
+          Cardano.RequireAllOf
+              [toPaymentHash hashKeyTxt1, Cardano.RequireTimeAfter (SlotNo 120)]
+      )
+    , ( "SimpleScript ActiveUntilSlot"
+      , RequireAllOf [toKeyHash hashKeyTxt1, ActiveUntilSlot 120]
+      , toSimpleScript $
+          Cardano.RequireAllOf
+              [toPaymentHash hashKeyTxt1, Cardano.RequireTimeBefore (SlotNo 120)]
+      )
+    , ( "SimpleScript ActiveFromSlot and ActiveUntilSlot"
+      , RequireAllOf
+          [ ActiveFromSlot 120
+          , ActiveUntilSlot 150
+          , RequireAnyOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2]
+          ]
+      , toSimpleScript $
+          Cardano.RequireAllOf
+          [ Cardano.RequireTimeAfter (SlotNo 120)
+          , Cardano.RequireTimeBefore (SlotNo 150)
+          , Cardano.RequireAnyOf
+              [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2 ]
+          ]
+      )
+    ]
+  where
+    hashKeyTxt1 = "deeae4e895d8d57378125ed4fd540f9bf245d59f7936a504379cfc1e"
+    hashKeyTxt2 = "60a3bf69aa748f9934b64357d9f1ca202f1a768aaf57263aedca8d5f"
+    toSimpleScript = Cardano.SimpleScript
+
+testScriptsTimelockLang :: Spec
+testScriptsTimelockLang =
+    forM_ timelockScriptMatrix $ \(title, adrestiaScript, nodeScript) ->
+        checkScriptHashes title adrestiaScript nodeScript
+
+testTimelockScriptImagesLang :: Spec
+testTimelockScriptImagesLang =
+    forM_ timelockScriptMatrix $ \(title, adrestiaScript, nodeScript) ->
+        checkScriptPreimage title adrestiaScript nodeScript
+
+instance Arbitrary (Hash "Genesis") where
+    arbitrary = Hash . BS.pack <$> vector 32
+
+instance Arbitrary (Hash "BlockHeader") where
+    arbitrary = Hash . BS.pack <$> vector 32
+
+instance Arbitrary RewardAccount where
+    arbitrary = FromKeyHash . BS.pack <$> vector 28
+
+instance Arbitrary (Tip (CardanoBlock StandardCrypto)) where
+    arbitrary = frequency
+        [ (10, return TipGenesis)
+        , (90, arbitraryTip)
+        ]
+      where
+        arbitraryTip = do
+            n <- choose (0, 100)
+            hash <- toCardanoHash
+                . Hash
+                . digest (Proxy @(HASH StandardCrypto))
+                . BS.pack <$> vector 5
+            return $ Tip (SlotNo n) hash (BlockNo n)
+
+instance Arbitrary SL.UnitInterval where
+    arbitrary = oneof
+        [ pure interval0
+        , pure interval1
+        , pure $ unsafeBoundRational (1 % 2)
+        , unsafeBoundRational . (% 1000) <$> choose (0, 1000)
+        ]
+    shrink = map unsafeBoundRational . shrink . SL.unboundRational
+
+instance Arbitrary SlotId where
+    arbitrary = SlotId
+        <$> (W.EpochNo . fromIntegral <$> choose (0, 10 :: Word32))
+        <*> (W.SlotInEpoch <$> choose (0, 10))
+
+instance Arbitrary SomeMnemonic where
+    arbitrary = SomeMnemonic <$> genMnemonic @12
+
+genMnemonic
+    :: forall mw ent csz.
+     ( ConsistentEntropy ent mw csz
+     , EntropySize mw ~ ent
+     )
+    => Gen (Mnemonic mw)
+genMnemonic = do
+        let n = fromIntegral (natVal $ Proxy @(EntropySize mw)) `div` 8
+        bytes <- BS.pack <$> vector n
+        let ent = unsafeMkEntropy @(EntropySize mw) bytes
+        return $ entropyToMnemonic ent
+
+instance Show XPrv where
+    show _ = "<xprv>"
+
+instance Arbitrary TokenBundle.TokenBundle where
+    arbitrary = genTokenBundleSmallRange
+    shrink = shrinkTokenBundleSmallRange
+
+newtype FixedSize32 a = FixedSize32 { unFixedSize32 :: a }
+    deriving (Eq, Show)
+
+newtype FixedSize48 a = FixedSize48 { unFixedSize48 :: a }
+    deriving (Eq, Show)
+
+newtype FixedSize64 a = FixedSize64 { unFixedSize64 :: a }
+    deriving (Eq, Show)
+
+newtype FixedSize128 a = FixedSize128 { unFixedSize128 :: a }
+    deriving (Eq, Show)
+
+newtype VariableSize16 a = VariableSize16 { unVariableSize16 :: a}
+    deriving (Eq, Show)
+
+newtype VariableSize1024 a = VariableSize1024 { unVariableSize1024 :: a}
+    deriving (Eq, Show)
+
+instance Arbitrary (FixedSize32 TokenBundle) where
+    arbitrary = FixedSize32 <$> genTxOutTokenBundle 32
+    -- No shrinking
+
+instance Arbitrary (FixedSize48 TokenBundle) where
+    arbitrary = FixedSize48 <$> genTxOutTokenBundle 48
+    -- No shrinking
+
+instance Arbitrary (FixedSize64 TokenBundle) where
+    arbitrary = FixedSize64 <$> genTxOutTokenBundle 64
+    -- No shrinking
+
+instance Arbitrary (FixedSize128 TokenBundle) where
+    arbitrary = FixedSize128 <$> genTxOutTokenBundle 128
+    -- No shrinking
+
+instance Arbitrary (VariableSize16 TokenBundle) where
+    arbitrary = VariableSize16 <$> resize 16 genTokenBundle
+    -- No shrinking
+
+instance Arbitrary (VariableSize1024 TokenBundle) where
+    arbitrary = VariableSize1024 <$> resize 1024 genTokenBundle
+    -- No shrinking
+
+--
+-- Helpers
+--
+
+unsafeBoundRational :: Rational -> SL.UnitInterval
+unsafeBoundRational =
+    fromMaybe (error "unsafeBoundRational: the impossible happened")
+    . SL.boundRational

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
@@ -215,6 +215,9 @@ import Cardano.Wallet.Flavor
 import Cardano.Wallet.Pools
     ( StakePoolLayer (..)
     )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( rewardAccountFromAddress
+    )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId (..)
     , networkIdVal
@@ -226,9 +229,6 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Shelley.BlockchainSource
     ( BlockchainSource (..)
-    )
-import Cardano.Wallet.Shelley.Compatibility
-    ( rewardAccountFromAddress
     )
 import Control.Applicative
     ( liftA2

--- a/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
@@ -91,6 +91,10 @@ import Cardano.Wallet.Pools
     , withNodeStakePoolLayer
     , withStakePoolDbLayer
     )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( CardanoBlock
+    , StandardCrypto
+    )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId
     , NetworkId
@@ -129,10 +133,6 @@ import Cardano.Wallet.Registry
     )
 import Cardano.Wallet.Shelley.BlockchainSource
     ( BlockchainSource (..)
-    )
-import Cardano.Wallet.Shelley.Compatibility
-    ( CardanoBlock
-    , StandardCrypto
     )
 import Cardano.Wallet.Shelley.Network
     ( withNetworkLayer
@@ -255,7 +255,7 @@ serveWallet
     -> Maybe TokenMetadataServer
     -> Block
     -- ^ The genesis block, or some starting point.
-    -- See also: 'Cardano.Wallet.Shelley.Compatibility#KnownNetwork'.
+    -- See also: 'Cardano.Wallet.Primitive.Ledger.Shelley#KnownNetwork'.
     -> (URI -> IO ())
     -- ^ Callback to run before the main loop
     -> IO ExitCode

--- a/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
@@ -86,6 +86,9 @@ import Cardano.Wallet.Flavor
 import Cardano.Wallet.Network
     ( NetworkLayer (..)
     )
+import Cardano.Wallet.Network.Implementation.Ouroboros
+    ( PipeliningStrategy
+    )
 import Cardano.Wallet.Pools
     ( StakePoolLayer (..)
     , withNodeStakePoolLayer
@@ -206,9 +209,6 @@ import Network.URI
     )
 import Network.Wai.Handler.Warp
     ( setBeforeMainLoop
-    )
-import Ouroboros.Network.Client.Wallet
-    ( PipeliningStrategy
     )
 import System.Exit
     ( ExitCode (..)

--- a/lib/wallet/bench/latency-bench.hs
+++ b/lib/wallet/bench/latency-bench.hs
@@ -95,6 +95,9 @@ import Cardano.Wallet.Network.Ports
 import Cardano.Wallet.Pools
     ( StakePool
     )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( fromGenesisData
+    )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId
     , NetworkDiscriminant (..)
@@ -113,9 +116,6 @@ import Cardano.Wallet.Shelley
     )
 import Cardano.Wallet.Shelley.BlockchainSource
     ( BlockchainSource (..)
-    )
-import Cardano.Wallet.Shelley.Compatibility
-    ( fromGenesisData
     )
 import Cardano.Wallet.Unsafe
     ( unsafeFromText

--- a/lib/wallet/bench/latency-bench.hs
+++ b/lib/wallet/bench/latency-bench.hs
@@ -89,6 +89,9 @@ import Cardano.Wallet.Launch.Cluster
 import Cardano.Wallet.LocalCluster
     ( clusterConfigsDirParser
     )
+import Cardano.Wallet.Network.Implementation.Ouroboros
+    ( tunedForMainnetPipeliningStrategy
+    )
 import Cardano.Wallet.Network.Ports
     ( portFromURL
     )
@@ -167,9 +170,6 @@ import Network.Wai.Middleware.Logging
     )
 import Numeric.Natural
     ( Natural
-    )
-import Ouroboros.Network.Client.Wallet
-    ( tunedForMainnetPipeliningStrategy
     )
 import System.Directory
     ( createDirectory

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -150,6 +150,10 @@ import Cardano.Wallet.Network.Config
     ( NetworkConfiguration (..)
     , parseGenesisData
     )
+import Cardano.Wallet.Network.Implementation.Ouroboros
+    ( PipeliningStrategy
+    , tunedForMainnetPipeliningStrategy
+    )
 import Cardano.Wallet.Primitive.Ledger.Read.Block
     ( fromCardanoBlock
     )
@@ -325,10 +329,6 @@ import Internal.Cardano.Write.Tx
 import Numeric
     ( fromRat
     , showFFloat
-    )
-import Ouroboros.Network.Client.Wallet
-    ( PipeliningStrategy
-    , tunedForMainnetPipeliningStrategy
     )
 import Say
     ( sayErr

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -153,6 +153,14 @@ import Cardano.Wallet.Network.Config
 import Cardano.Wallet.Primitive.Ledger.Read.Block
     ( fromCardanoBlock
     )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( AnyCardanoEra (..)
+    , CardanoBlock
+    , NodeToClientVersionData
+    , StandardCrypto
+    , emptyGenesis
+    , numberOfTransactionsInBlock
+    )
 import Cardano.Wallet.Primitive.Model
     ( Wallet
     , availableUTxO
@@ -209,14 +217,6 @@ import Cardano.Wallet.Primitive.Types.Tx.TxOut
     )
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
     ( UTxOStatistics (..)
-    )
-import Cardano.Wallet.Shelley.Compatibility
-    ( AnyCardanoEra (..)
-    , CardanoBlock
-    , NodeToClientVersionData
-    , StandardCrypto
-    , emptyGenesis
-    , numberOfTransactionsInBlock
     )
 import Cardano.Wallet.Shelley.Network.Node
     ( withNetworkLayer
@@ -367,12 +367,12 @@ import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.DB.Sqlite.Migration.Old as Sqlite
+import qualified Cardano.Wallet.Primitive.Ledger.Shelley as Cardano
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Checkpoints.Policy as CP
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
-import qualified Cardano.Wallet.Shelley.Compatibility as Cardano
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -150,6 +150,9 @@ import Cardano.Wallet.Network.Config
     ( NetworkConfiguration (..)
     , parseGenesisData
     )
+import Cardano.Wallet.Network.Implementation
+    ( withNetworkLayer
+    )
 import Cardano.Wallet.Network.Implementation.Ouroboros
     ( PipeliningStrategy
     , tunedForMainnetPipeliningStrategy
@@ -221,9 +224,6 @@ import Cardano.Wallet.Primitive.Types.Tx.TxOut
     )
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
     ( UTxOStatistics (..)
-    )
-import Cardano.Wallet.Shelley.Network.Node
-    ( withNetworkLayer
     )
 import Cardano.Wallet.Shelley.Transaction
     ( newTransactionLayer

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -311,7 +311,6 @@ library
     Cardano.Wallet.Primitive.Types.UTxOStatistics
     Cardano.Wallet.Registry
     Cardano.Wallet.Shelley.BlockchainSource
-    Cardano.Wallet.Shelley.Compatibility
     Cardano.Wallet.Shelley.Network
     Cardano.Wallet.Shelley.Network.Node
     Cardano.Wallet.Shelley.Transaction

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -312,7 +312,6 @@ library
     Cardano.Wallet.Registry
     Cardano.Wallet.Shelley.BlockchainSource
     Cardano.Wallet.Shelley.Network
-    Cardano.Wallet.Shelley.Network.Node
     Cardano.Wallet.Shelley.Transaction
     Cardano.Wallet.Submissions.Operations
     Cardano.Wallet.Submissions.Primitives

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -338,7 +338,6 @@ library
     Data.Vector.Shuffle
     Database.Persist.PersistValue.Extended
     Network.Ntp
-    Ouroboros.Network.Client.Wallet
     UnliftIO.Compat
 
   other-modules:   Paths_cardano_wallet
@@ -639,6 +638,7 @@ executable cardano-wallet
     , cardano-wallet-api-http
     , cardano-wallet-application-extras
     , cardano-wallet-launcher
+    , cardano-wallet-network-layer
     , contra-tracer
     , iohk-monitoring
     , iohk-monitoring-extra
@@ -923,6 +923,7 @@ test-suite integration
     , cardano-wallet-application-extras
     , cardano-wallet-integration
     , cardano-wallet-launcher
+    , cardano-wallet-network-layer
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
     , contra-tracer
@@ -1000,6 +1001,7 @@ benchmark latency
     , cardano-wallet-application-extras
     , cardano-wallet-integration
     , cardano-wallet-launcher
+    , cardano-wallet-network-layer
     , cardano-wallet-primitive
     , directory
     , filepath

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -244,7 +244,6 @@ library
     Cardano.Wallet.Balance.Migration
     Cardano.Wallet.Balance.Migration.Planning
     Cardano.Wallet.Balance.Migration.Selection
-    Cardano.Wallet.Byron.Compatibility
     Cardano.Wallet.Checkpoints
     Cardano.Wallet.CLI
     Cardano.Wallet.Compat

--- a/lib/wallet/exe/cardano-wallet.hs
+++ b/lib/wallet/exe/cardano-wallet.hs
@@ -104,6 +104,9 @@ import Cardano.Wallet.Network.Config
     ( NetworkConfiguration (..)
     , parseGenesisData
     )
+import Cardano.Wallet.Network.Implementation.Ouroboros
+    ( tunedForMainnetPipeliningStrategy
+    )
 import Cardano.Wallet.Primitive.Types
     ( PoolMetadataSource (..)
     , Settings (..)
@@ -174,9 +177,6 @@ import "optparse-applicative" Options.Applicative
     , option
     , progDesc
     , value
-    )
-import Ouroboros.Network.Client.Wallet
-    ( tunedForMainnetPipeliningStrategy
     )
 import System.Environment
     ( getArgs

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -435,6 +435,12 @@ import Cardano.Wallet.Primitive.Ledger.Convert
 import Cardano.Wallet.Primitive.Ledger.Read.Block
     ( fromCardanoBlock
     )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( fromCardanoLovelace
+    , fromCardanoTxIn
+    , fromCardanoTxOut
+    , fromCardanoWdrls
+    )
 import Cardano.Wallet.Primitive.Model
     ( BlockData (..)
     , Wallet
@@ -559,12 +565,6 @@ import Cardano.Wallet.Primitive.Types.UTxOStatistics
     )
 import Cardano.Wallet.Read.Tx.CBOR
     ( TxCBOR
-    )
-import Cardano.Wallet.Shelley.Compatibility
-    ( fromCardanoLovelace
-    , fromCardanoTxIn
-    , fromCardanoTxOut
-    , fromCardanoWdrls
     )
 import Cardano.Wallet.Shelley.Transaction
     ( mkTransaction

--- a/lib/wallet/src/Cardano/Wallet/Network/Config.hs
+++ b/lib/wallet/src/Cardano/Wallet/Network/Config.hs
@@ -44,7 +44,7 @@ import Ouroboros.Network.NodeToClient
     ( NodeToClientVersionData (..)
     )
 
-import qualified Cardano.Wallet.Byron.Compatibility as Byron
+import qualified Cardano.Wallet.Primitive.Ledger.Byron as Byron
 import qualified Cardano.Wallet.Primitive.Types.ProtocolMagic as W
 
 -- | Shelley hard fork network configuration has two genesis data.

--- a/lib/wallet/src/Cardano/Wallet/Pools.hs
+++ b/lib/wallet/src/Cardano/Wallet/Pools.hs
@@ -88,6 +88,12 @@ import Cardano.Wallet.Primitive.Ledger.Read.Block
 import Cardano.Wallet.Primitive.Ledger.Read.Block.Header
     ( getBlockHeader
     )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( StandardCrypto
+    , getBabbageProducer
+    , getConwayProducer
+    , getProducer
+    )
 import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException (..)
     , Qry
@@ -125,12 +131,6 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Registry
     ( AfterThreadLog
     , traceAfterThread
-    )
-import Cardano.Wallet.Shelley.Compatibility
-    ( StandardCrypto
-    , getBabbageProducer
-    , getConwayProducer
-    , getProducer
     )
 import Cardano.Wallet.Unsafe
     ( unsafeMkPercentage

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
@@ -193,6 +193,9 @@ import Cardano.Wallet.Primitive.Types.FeePolicy
 import Cardano.Wallet.Primitive.Types.GenesisParameters
     ( GenesisParameters (..)
     )
+import Cardano.Wallet.Primitive.Types.NetworkParameters
+    ( NetworkParameters (..)
+    )
 import Cardano.Wallet.Primitive.Types.Pool
     ( PoolId
     )
@@ -502,23 +505,6 @@ instance ToText DerivationIndex where
 {-------------------------------------------------------------------------------
                               Network Parameters
 -------------------------------------------------------------------------------}
-
--- | Records the complete set of parameters currently in use by the network
---   that are relevant to the wallet.
---
-data NetworkParameters = NetworkParameters
-    { genesisParameters :: GenesisParameters
-       -- ^ See 'GenesisParameters'.
-    , slottingParameters :: SlottingParameters
-       -- ^ See 'SlottingParameters'.
-    , protocolParameters :: ProtocolParameters
-       -- ^ See 'ProtocolParameters'.
-    } deriving (Generic, Show, Eq)
-
-instance NFData NetworkParameters
-
-instance Buildable NetworkParameters where
-    build (NetworkParameters gp sp pp) = build gp <> build sp <> build pp
 
 instance PersistField StakeKeyCertificate where
     toPersistValue = toPersistValue . show

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
@@ -190,8 +190,8 @@ import Cardano.Wallet.Primitive.Types.FeePolicy
     ( FeePolicy (..)
     , LinearFunction (..)
     )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..)
+import Cardano.Wallet.Primitive.Types.GenesisParameters
+    ( GenesisParameters (..)
     )
 import Cardano.Wallet.Primitive.Types.Pool
     ( PoolId
@@ -295,7 +295,6 @@ import Database.Persist.Sql
     )
 import Fmt
     ( Buildable (..)
-    , blockListF'
     , prefixF
     , pretty
     , suffixF
@@ -520,31 +519,6 @@ instance NFData NetworkParameters
 
 instance Buildable NetworkParameters where
     build (NetworkParameters gp sp pp) = build gp <> build sp <> build pp
-
--- | Parameters defined by the __genesis block__.
---
--- At present, these values cannot be changed through the update system.
---
--- They can only be changed through a soft or hard fork.
---
-data GenesisParameters = GenesisParameters
-    { getGenesisBlockHash :: Hash "Genesis"
-        -- ^ Hash of the very first block
-    , getGenesisBlockDate :: StartTime
-        -- ^ Start time of the chain.
-    } deriving (Generic, Show, Eq)
-
-instance NFData GenesisParameters
-
-instance Buildable GenesisParameters where
-    build gp = blockListF' "" id
-        [ "Genesis block hash: " <> genesisF (getGenesisBlockHash gp)
-        , "Genesis block date: " <> startTimeF (getGenesisBlockDate
-            (gp :: GenesisParameters))
-        ]
-      where
-        genesisF = build . T.decodeUtf8 . convertToBase Base16 . getHash
-        startTimeF (StartTime s) = build s
 
 instance PersistField StakeKeyCertificate where
     toPersistValue = toPersistValue . show

--- a/lib/wallet/src/Cardano/Wallet/Shelley/BlockchainSource.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/BlockchainSource.hs
@@ -11,11 +11,11 @@ module Cardano.Wallet.Shelley.BlockchainSource
 import Cardano.Launcher.Node
     ( CardanoNodeConn
     )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( NodeToClientVersionData
+    )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance
-    )
-import Cardano.Wallet.Shelley.Compatibility
-    ( NodeToClientVersionData
     )
 
 data BlockchainSource

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -224,7 +224,7 @@ import Cardano.Slotting.Time
 import Cardano.Wallet.Address.Encoding
     ( fromStakeCredential
     )
-import Cardano.Wallet.Byron.Compatibility
+import Cardano.Wallet.Primitive.Ledger.Byron
     ( fromTxAux
     , maryTokenBundleMaxSize
     )

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Network.hs
@@ -24,6 +24,10 @@ import Cardano.BM.Tracing
 import Cardano.Wallet.Network
     ( NetworkLayer
     )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( CardanoBlock
+    , StandardCrypto
+    )
 import Cardano.Wallet.Primitive.NetworkId
     ( NetworkId
     )
@@ -32,10 +36,6 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Shelley.BlockchainSource
     ( BlockchainSource (..)
-    )
-import Cardano.Wallet.Shelley.Compatibility
-    ( CardanoBlock
-    , StandardCrypto
     )
 import Control.Monad.Trans.Cont
     ( ContT (ContT)

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Network.hs
@@ -24,6 +24,9 @@ import Cardano.BM.Tracing
 import Cardano.Wallet.Network
     ( NetworkLayer
     )
+import Cardano.Wallet.Network.Implementation.Ouroboros
+    ( PipeliningStrategy
+    )
 import Cardano.Wallet.Primitive.Ledger.Shelley
     ( CardanoBlock
     , StandardCrypto
@@ -48,9 +51,6 @@ import Data.Text.Class
     )
 import GHC.Stack
     ( HasCallStack
-    )
-import Ouroboros.Network.Client.Wallet
-    ( PipeliningStrategy
     )
 
 newtype NetworkLayerLog = NodeNetworkLog Node.Log

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Network.hs
@@ -14,7 +14,7 @@ module Cardano.Wallet.Shelley.Network
 
 import Prelude
 
-import qualified Cardano.Wallet.Shelley.Network.Node as Node
+import qualified Cardano.Wallet.Network.Implementation as Node
 
 import Cardano.BM.Tracing
     ( HasPrivacyAnnotation

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Network/Node.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Network/Node.hs
@@ -63,10 +63,6 @@ import Cardano.Pool.Types
     ( PoolId
     , StakePoolsSummary (..)
     )
-import Cardano.Wallet.Byron.Compatibility
-    ( byronCodecConfig
-    , protocolParametersFromUpdateState
-    )
 import Cardano.Wallet.Network
     ( ChainFollowLog (..)
     , ChainFollower
@@ -76,6 +72,10 @@ import Cardano.Wallet.Network
     , mapChainFollower
     , mapChainSyncLog
     , withFollowStatsMonitoring
+    )
+import Cardano.Wallet.Primitive.Ledger.Byron
+    ( byronCodecConfig
+    , protocolParametersFromUpdateState
     )
 import Cardano.Wallet.Primitive.Ledger.Read.Block.Header
     ( getBlockHeader

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Network/Node.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Network/Node.hs
@@ -80,23 +80,7 @@ import Cardano.Wallet.Primitive.Ledger.Byron
 import Cardano.Wallet.Primitive.Ledger.Read.Block.Header
     ( getBlockHeader
     )
-import Cardano.Wallet.Primitive.Slotting
-    ( TimeInterpreter
-    , TimeInterpreterLog
-    , currentRelativeTime
-    , mkTimeInterpreter
-    )
-import Cardano.Wallet.Primitive.SyncProgress
-    ( SyncProgress (..)
-    , SyncTolerance
-    )
-import Cardano.Wallet.Primitive.Types
-    ( GenesisParameters (..)
-    )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( SealedTx (..)
-    )
-import Cardano.Wallet.Shelley.Compatibility
+import Cardano.Wallet.Primitive.Ledger.Shelley
     ( StandardCrypto
     , fromAllegraPParams
     , fromAlonzoPParams
@@ -118,6 +102,22 @@ import Cardano.Wallet.Shelley.Compatibility
     , toPoint
     , toShelleyCoin
     , unsealShelleyTx
+    )
+import Cardano.Wallet.Primitive.Slotting
+    ( TimeInterpreter
+    , TimeInterpreterLog
+    , currentRelativeTime
+    , mkTimeInterpreter
+    )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncProgress (..)
+    , SyncTolerance
+    )
+import Cardano.Wallet.Primitive.Types
+    ( GenesisParameters (..)
+    )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( SealedTx (..)
     )
 import Control.Applicative
     ( liftA3

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Network/Node.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Network/Node.hs
@@ -73,6 +73,17 @@ import Cardano.Wallet.Network
     , mapChainSyncLog
     , withFollowStatsMonitoring
     )
+import Cardano.Wallet.Network.Implementation.Ouroboros
+    ( LSQ (..)
+    , LocalStateQueryCmd (..)
+    , LocalTxSubmissionCmd (..)
+    , PipeliningStrategy
+    , chainSyncFollowTip
+    , chainSyncWithBlocks
+    , localStateQuery
+    , localTxSubmission
+    , send
+    )
 import Cardano.Wallet.Primitive.Ledger.Byron
     ( byronCodecConfig
     , protocolParametersFromUpdateState
@@ -318,17 +329,6 @@ import Ouroboros.Consensus.Shelley.Ledger.Config
 import Ouroboros.Network.Block
     ( Point
     , Tip (..)
-    )
-import Ouroboros.Network.Client.Wallet
-    ( LSQ (..)
-    , LocalStateQueryCmd (..)
-    , LocalTxSubmissionCmd (..)
-    , PipeliningStrategy
-    , chainSyncFollowTip
-    , chainSyncWithBlocks
-    , localStateQuery
-    , localTxSubmission
-    , send
     )
 import Ouroboros.Network.Driver.Simple
     ( TraceSendRecv

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -104,6 +104,21 @@ import Cardano.Wallet.Primitive.Ledger.Convert
 import Cardano.Wallet.Primitive.Ledger.Read.Tx
     ( fromCardanoTx
     )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( cardanoCertKeysForWitnesses
+    , fromCardanoAddress
+    , fromCardanoWdrls
+    , toCardanoLovelace
+    , toCardanoPolicyId
+    , toCardanoSimpleScript
+    , toCardanoStakeCredential
+    , toCardanoTxIn
+    , toCardanoTxOut
+    , toCardanoValue
+    , toStakeKeyDeregCert
+    , toStakeKeyRegCert
+    , toStakePoolDlgCert
+    )
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase (..)
     )
@@ -147,21 +162,6 @@ import Cardano.Wallet.Primitive.Types.Tx.TxIn
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
-    )
-import Cardano.Wallet.Shelley.Compatibility
-    ( cardanoCertKeysForWitnesses
-    , fromCardanoAddress
-    , fromCardanoWdrls
-    , toCardanoLovelace
-    , toCardanoPolicyId
-    , toCardanoSimpleScript
-    , toCardanoStakeCredential
-    , toCardanoTxIn
-    , toCardanoTxOut
-    , toCardanoValue
-    , toStakeKeyDeregCert
-    , toStakeKeyRegCert
-    , toStakePoolDlgCert
     )
 import Cardano.Wallet.Transaction
     ( AnyExplicitScript (..)
@@ -251,8 +251,8 @@ import qualified Cardano.Crypto.Wallet as Crypto.HD
 import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Ledger.Keys.Bootstrap as SL
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
+import qualified Cardano.Wallet.Primitive.Ledger.Shelley as Compatibility
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
 import qualified Data.ByteString as BS
 import qualified Data.Foldable as F
 import qualified Data.List as L

--- a/lib/wallet/src/UnliftIO/Compat.hs
+++ b/lib/wallet/src/UnliftIO/Compat.hs
@@ -22,6 +22,10 @@ module UnliftIO.Compat
 
 import Prelude
 
+import Cardano.Wallet.Network.Implementation.UnliftIO
+    ( coerceHandler
+    , coerceHandlers
+    )
 import Control.Concurrent.Async
     ( AsyncCancelled (..)
     )
@@ -34,18 +38,6 @@ import Control.Monad.IO.Unlift
 
 import qualified Control.Monad.Catch as Exceptions
 import qualified UnliftIO.Exception as UnliftIO
-
--- | Convert the generalized handler from 'UnliftIO.Exception' type to 'Control.Monad.Catch' type
-coerceHandler :: UnliftIO.Handler IO b -> Exceptions.Handler IO b
-coerceHandler (UnliftIO.Handler h) = Exceptions.Handler h
-
--- | Convert a list of handler factories from the 'UnliftIO.Exception' type to
--- 'Control.Monad.Catch' type. Such handlers are used in
--- 'Control.Retry.Recovering' for example.
-coerceHandlers
-    :: [a -> UnliftIO.Handler IO b]
-    -> [a -> Exceptions.Handler IO b]
-coerceHandlers = map (coerceHandler .)
 
 -- | Shortcut for creating a single 'Control.Retry' handler, which doesn't use
 -- the 'Control.Retry.RetryStatus' info.

--- a/lib/wallet/test/integration/shelley-integration-test.hs
+++ b/lib/wallet/test/integration/shelley-integration-test.hs
@@ -85,6 +85,9 @@ import Cardano.Wallet.Launch.Cluster
     , withCluster
     , withSMASH
     )
+import Cardano.Wallet.Network.Implementation.Ouroboros
+    ( tunedForMainnetPipeliningStrategy
+    )
 import Cardano.Wallet.Network.Ports
     ( portFromURL
     )
@@ -165,9 +168,6 @@ import Network.HTTP.Client
     )
 import Network.URI
     ( URI
-    )
-import Ouroboros.Network.Client.Wallet
-    ( tunedForMainnetPipeliningStrategy
     )
 import System.Directory
     ( createDirectory

--- a/lib/wallet/test/integration/shelley-integration-test.hs
+++ b/lib/wallet/test/integration/shelley-integration-test.hs
@@ -88,6 +88,9 @@ import Cardano.Wallet.Launch.Cluster
 import Cardano.Wallet.Network.Ports
     ( portFromURL
     )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( fromGenesisData
+    )
 import Cardano.Wallet.Primitive.NetworkId
     ( NetworkDiscriminant (..)
     , NetworkId (..)
@@ -106,9 +109,6 @@ import Cardano.Wallet.Shelley
     )
 import Cardano.Wallet.Shelley.BlockchainSource
     ( BlockchainSource (..)
-    )
-import Cardano.Wallet.Shelley.Compatibility
-    ( fromGenesisData
     )
 import Cardano.Wallet.TokenMetadata.MockServer
     ( queryServerStatic

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -70,6 +70,19 @@ import Cardano.Wallet.Flavor
     ( KeyFlavor
     , keyFlavor
     )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( CardanoBlock
+    , StandardCrypto
+    , decentralizationLevelFromPParams
+    , fromCardanoValue
+    , fromTip
+    , interval0
+    , interval1
+    , invertUnitInterval
+    , toCardanoHash
+    , toCardanoValue
+    , toTip
+    )
 import Cardano.Wallet.Primitive.NetworkId
     ( NetworkId (..)
     , SNetworkId (..)
@@ -101,19 +114,6 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
     ( genTxOutTokenBundle
-    )
-import Cardano.Wallet.Shelley.Compatibility
-    ( CardanoBlock
-    , StandardCrypto
-    , decentralizationLevelFromPParams
-    , fromCardanoValue
-    , fromTip
-    , interval0
-    , interval1
-    , invertUnitInterval
-    , toCardanoHash
-    , toCardanoValue
-    , toTip
     )
 import Cardano.Wallet.Unsafe
     ( unsafeIntToWord

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -19,25 +19,6 @@ import Cardano.Address.Derivation
     ( XPrv
     , XPub
     )
-import Cardano.Address.Script
-    ( KeyHash
-    , KeyRole (..)
-    , Script (..)
-    , ScriptHash (..)
-    , keyHashFromBytes
-    , serializeScript
-    , toScriptHash
-    )
-import Cardano.Crypto.Hash.Class
-    ( digest
-    )
-import Cardano.Ledger.Core
-    ( PParams
-    , ppDL
-    )
-import Cardano.Ledger.Crypto
-    ( Crypto (..)
-    )
 import Cardano.Mnemonic
     ( ConsistentEntropy
     , EntropySize
@@ -71,65 +52,24 @@ import Cardano.Wallet.Flavor
     , keyFlavor
     )
 import Cardano.Wallet.Primitive.Ledger.Shelley
-    ( CardanoBlock
-    , StandardCrypto
-    , decentralizationLevelFromPParams
-    , fromCardanoValue
-    , fromTip
-    , interval0
-    , interval1
-    , invertUnitInterval
-    , toCardanoHash
-    , toCardanoValue
-    , toTip
+    ( StandardCrypto
     )
 import Cardano.Wallet.Primitive.NetworkId
     ( NetworkId (..)
     , SNetworkId (..)
     , withSNetworkId
     )
-import Cardano.Wallet.Primitive.Types
-    ( SlotId (..)
-    , getDecentralizationLevel
-    )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
-    )
-import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..)
-    )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..)
     )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( TokenBundle
-    )
-import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
-    ( genTokenBundle
-    , genTokenBundleSmallRange
-    , shrinkTokenBundleSmallRange
-    )
-import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
-    ( genTxOutTokenBundle
-    )
 import Cardano.Wallet.Unsafe
-    ( unsafeIntToWord
-    , unsafeMkEntropy
-    )
-import Cardano.Wallet.Util
-    ( tryInternalError
+    ( unsafeMkEntropy
     )
 import Codec.Binary.Bech32.TH
     ( humanReadablePart
-    )
-import Codec.Binary.Encoding
-    ( fromBase16
-    )
-import Control.Lens
-    ( (.~)
     )
 import Control.Monad
     ( forM_
@@ -148,44 +88,20 @@ import Data.Either
 import Data.Function
     ( (&)
     )
-import Data.Maybe
-    ( fromMaybe
-    )
 import Data.Proxy
     ( Proxy (..)
-    )
-import Data.Ratio
-    ( Ratio
-    , (%)
     )
 import Data.Text
     ( Text
     )
-import Data.Text.Class
-    ( toText
-    )
-import Data.Word
-    ( Word16
-    , Word32
-    , Word64
-    )
 import GHC.TypeLits
     ( natVal
-    )
-import Ouroboros.Network.Block
-    ( BlockNo (..)
-    , SlotNo (..)
-    , Tip (..)
     )
 import Test.Hspec
     ( Spec
     , describe
     , it
-    , shouldBe
     , shouldSatisfy
-    )
-import Test.Hspec.Core.Spec
-    ( SpecWith
     )
 import Test.Hspec.QuickCheck
     ( prop
@@ -193,52 +109,23 @@ import Test.Hspec.QuickCheck
 import Test.QuickCheck
     ( Arbitrary (..)
     , Gen
-    , NonNegative (..)
-    , Property
-    , Small (..)
-    , checkCoverage
-    , choose
     , chooseInt
     , counterexample
-    , cover
-    , frequency
-    , oneof
     , property
-    , resize
     , vector
     , (===)
     )
-import Test.QuickCheck.Monadic
-    ( assert
-    , monadicIO
-    , monitor
-    , run
-    )
 
-import qualified Cardano.Api as Cardano
 import qualified Cardano.Ledger.Address as SL
-import qualified Cardano.Ledger.BaseTypes as SL
-import qualified Cardano.Ledger.Shelley as SL
-import qualified Cardano.Ledger.Shelley.PParams as SL
 import qualified Cardano.Wallet.Address.Derivation as Address.Derivation
 import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
-import qualified Cardano.Wallet.Primitive.Types as W
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Data.ByteString as BS
 import qualified Data.Text.Encoding as T
 
 spec :: Spec
 spec = do
-    describe "Conversions" $ do
-        it "toTip' . fromTip' == id" $ property $ \gh tip -> do
-            let fromTip' = fromTip gh
-            let toTip' = toTip gh :: W.BlockHeader -> Tip (CardanoBlock StandardCrypto)
-            toTip' (fromTip' tip) === tip
-
-        it "unsafeIntToWord" $
-            property prop_unsafeIntToWord
 
     describe "Shelley StakeAddress" $ do
         prop "roundtrip / Mainnet" $ \x ->
@@ -284,74 +171,6 @@ spec = do
                     = paymentAddress @ByronKey @'CredFromKeyK SMainnet k
             in  decodeAddress SMainnet (base58 bytes) === Right addr
                     & counterexample (show $ base58 bytes)
-
-    describe "decentralizationLevelFromPParams" $ do
-
-        let mkDecentralizationParam
-                :: SL.UnitInterval
-                -> PParams (SL.ShelleyEra StandardCrypto)
-            mkDecentralizationParam i = SL.emptyPParams & ppDL .~ i
-
-        let testCases :: [(Ratio Word64, Text)]
-            testCases =
-                [ (10 % 10,   "0.00%")
-                , ( 9 % 10,  "10.00%")
-                , ( 5 % 10,  "50.00%")
-                , ( 1 % 10,  "90.00%")
-                , ( 0 % 10, "100.00%")
-                ]
-
-        forM_ testCases $ \(input, expectedOutput) -> do
-            let title = show input <> " -> " <> show expectedOutput
-            let output = input
-                    & toRational
-                    & unsafeBoundRational
-                    & mkDecentralizationParam
-                    & decentralizationLevelFromPParams
-                    & getDecentralizationLevel
-                    & toText
-            it title $ output `shouldBe` expectedOutput
-
-    describe "Cardano.Api.Value-TokenBundle conversion" $ do
-        it "roundtrips" $ checkCoverage $ property $ \tb ->
-            cover 20 (TokenBundle.getCoin tb /= Coin 0) "has ada" $
-            cover 2 (TokenBundle.getCoin tb == Coin 0) "has no ada" $
-            cover 10 (length (snd $ TokenBundle.toFlatList tb) > 3)
-                "has some assets" $
-            fromCardanoValue (toCardanoValue tb) === tb
-
-    describe "Utilities" $ do
-
-        describe "UnitInterval" $ do
-
-            it "coverage adequate" $
-                checkCoverage $ property $ \i ->
-                    let half = unsafeBoundRational (1 % 2) in
-                    cover 10 (i == half) "i = 0.5" $
-                    cover 10 (i == interval0) "i = 0" $
-                    cover 10 (i == interval1) "i = 1" $
-                    cover 10 (i > interval0 && i < half) "0 < i < 0.5" $
-                    cover 10 (half < i && i < interval1) "0.5 < i < 1"
-                    True
-
-            it "invertUnitInterval . invertUnitInterval == id" $
-                property $ \i ->
-                    invertUnitInterval (invertUnitInterval i) `shouldBe` i
-
-            it "intervalValue i + intervalValue (invertUnitInterval i) == 1" $
-                property $ \i ->
-                    SL.unboundRational i + SL.unboundRational (invertUnitInterval i)
-                        `shouldBe` 1
-
-            it "invertUnitInterval interval0 == interval1" $
-                invertUnitInterval interval0 `shouldBe` interval1
-
-            it "invertUnitInterval interval1 == interval0" $
-                invertUnitInterval interval1 `shouldBe` interval0
-
-            it "invertUnitInterval half == half" $
-                let half = unsafeBoundRational (1 % 2) in
-                invertUnitInterval half `shouldBe` half
 
     describe "InspectAddr" $ do
         -- Cases below are taken straight from cardano-addresses. We don't go in
@@ -415,249 +234,12 @@ spec = do
         forM_ matrix $ \(title, addr, predicate) ->
             it title $ inspectAddress addr `shouldSatisfy` predicate
 
-    describe "golden tests for script hashes" $ do
-        testScriptsAllLangs
-        testScriptsTimelockLang
-
-    describe "golden tests for script preimages" $ do
-        testScriptPreimages
-        testTimelockScriptImagesLang
-
 --------------------------------------------------------------------------------
 -- Conversions
 --------------------------------------------------------------------------------
 
-prop_unsafeIntToWord :: TrickyInt Integer Word16 -> Property
-prop_unsafeIntToWord (TrickyInt n wrong) = monadicIO $ do
-    res <- run $ tryInternalError $ unsafeIntToWord @Integer @Word16 n
-    monitor (counterexample ("res = " ++ show res))
-    assert $ case res of
-        Right correct -> fromIntegral correct == n
-        Left _ -> fromIntegral wrong /= n
-
-data TrickyInt n w = TrickyInt n w deriving (Show, Eq)
-
-instance (Arbitrary n, Integral n, Num w) => Arbitrary (TrickyInt n w) where
-    arbitrary = do
-        d <- arbitrary
-        x <- getSmall . getNonNegative <$> arbitrary :: Gen Int
-        s <- frequency [(20, pure 1), (5, pure (-1)), (1, pure 0)]
-        let n = s * ((2 ^ x) + d)
-        pure $ TrickyInt n (fromIntegral n)
-
-toKeyHash :: Text -> Script KeyHash
-toKeyHash txt = case fromBase16 (T.encodeUtf8 txt) of
-    Right bs -> case keyHashFromBytes (Payment, bs) of
-        Just kh -> RequireSignatureOf kh
-        Nothing -> error "Hash key not valid"
-    Left _ -> error "Hash key not valid"
-
-toPaymentHash :: Text -> Cardano.SimpleScript
-toPaymentHash txt =
-    case Cardano.deserialiseFromRawBytesHex (Cardano.AsHash Cardano.AsPaymentKey) (T.encodeUtf8 txt) of
-        Right payKeyHash -> Cardano.RequireSignature payKeyHash
-        Left err -> error $ "toPaymentHash: " <> show err
-
-checkScriptHashes
-    :: String
-    -> Script KeyHash
-    -> Cardano.Script lang
-    -> SpecWith ()
-checkScriptHashes title adrestiaScript nodeScript = it title $
-    unScriptHash (toScriptHash adrestiaScript) `shouldBe`
-    Cardano.serialiseToRawBytes (Cardano.hashScript nodeScript)
-
-checkScriptPreimage
-    :: Cardano.SerialiseAsCBOR (Cardano.Script lang)
-    => String
-    -> Script KeyHash
-    -> Cardano.Script lang
-    -> SpecWith ()
-checkScriptPreimage title adrestiaScript nodeScript = it title $
-    (serializeScript adrestiaScript) `shouldBe`
-    BS.append "\00" (Cardano.serialiseToCBOR nodeScript)
-
-scriptMatrix
-    :: [(String, Script KeyHash, Cardano.Script Cardano.SimpleScript')]
-scriptMatrix =
-    [ ( "RequireSignatureOf"
-      , toKeyHash hashKeyTxt1
-      , toSimpleScript $ toPaymentHash hashKeyTxt1
-      )
-    , ( "RequireSignatureOf"
-      , toKeyHash hashKeyTxt2
-      , toSimpleScript $ toPaymentHash hashKeyTxt2
-      )
-    , ( "RequireSignatureOf"
-      , toKeyHash hashKeyTxt3
-      , toSimpleScript $ toPaymentHash hashKeyTxt3
-      )
-    , ( "RequireSignatureOf"
-      , toKeyHash hashKeyTxt4
-      , toSimpleScript $ toPaymentHash hashKeyTxt4
-      )
-    , ( "RequireAllOf"
-      , RequireAllOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2]
-      , toSimpleScript $
-          Cardano.RequireAllOf [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2]
-      )
-    , ( "RequireAllOf"
-      , RequireAllOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2, toKeyHash hashKeyTxt3]
-      , toSimpleScript $
-          Cardano.RequireAllOf [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2, toPaymentHash hashKeyTxt3]
-      )
-    , ( "RequireAnyOf"
-      , RequireAnyOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2]
-      , toSimpleScript $
-          Cardano.RequireAnyOf [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2]
-      )
-    , ( "RequireAnyOf"
-      , RequireAnyOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2, toKeyHash hashKeyTxt3]
-      , toSimpleScript $
-          Cardano.RequireAnyOf [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2, toPaymentHash hashKeyTxt3]
-      )
-    , ( "RequireSomeOf"
-      , RequireSomeOf 2 [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2, toKeyHash hashKeyTxt3]
-      , toSimpleScript $
-          Cardano.RequireMOf 2 [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2, toPaymentHash hashKeyTxt3]
-      )
-    , ( "RequireSomeOf"
-      , RequireSomeOf 2 [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2, toKeyHash hashKeyTxt3, toKeyHash hashKeyTxt4]
-      , toSimpleScript $
-          Cardano.RequireMOf 2 [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2, toPaymentHash hashKeyTxt3, toPaymentHash hashKeyTxt4]
-      )
-    , ( "nested 1"
-      , RequireSomeOf 2 [ toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2
-                        , RequireAllOf [toKeyHash hashKeyTxt3, toKeyHash hashKeyTxt4]
-                        ]
-      , toSimpleScript $
-          Cardano.RequireMOf 2 [ toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2
-                               , Cardano.RequireAllOf [toPaymentHash hashKeyTxt3, toPaymentHash hashKeyTxt4]
-                                       ]
-      )
-    , ( "nested 2"
-      , RequireAllOf [ toKeyHash hashKeyTxt1
-                     , RequireAnyOf [toKeyHash hashKeyTxt2, toKeyHash hashKeyTxt3, toKeyHash hashKeyTxt4]
-                     ]
-      , toSimpleScript $
-          Cardano.RequireAllOf [ toPaymentHash hashKeyTxt1
-                               , Cardano.RequireAnyOf [toPaymentHash hashKeyTxt2, toPaymentHash hashKeyTxt3, toPaymentHash hashKeyTxt4]
-                               ]
-      )
-    , ( "nested 3"
-      , RequireSomeOf 1 [ toKeyHash hashKeyTxt1
-                        , RequireAllOf [ toKeyHash hashKeyTxt2
-                                       , RequireAnyOf [toKeyHash hashKeyTxt3, toKeyHash hashKeyTxt4 ]
-                                       ]
-                        ]
-      , toSimpleScript $
-          Cardano.RequireMOf 1 [ toPaymentHash hashKeyTxt1
-                               , Cardano.RequireAllOf [ toPaymentHash hashKeyTxt2
-                                                      , Cardano.RequireAnyOf [toPaymentHash hashKeyTxt3, toPaymentHash hashKeyTxt4]
-                                                      ]
-                               ]
-      )
-    ]
-  where
-    toSimpleScript = Cardano.SimpleScript
-    hashKeyTxt1 = "deeae4e895d8d57378125ed4fd540f9bf245d59f7936a504379cfc1e"
-    hashKeyTxt2 = "60a3bf69aa748f9934b64357d9f1ca202f1a768aaf57263aedca8d5f"
-    hashKeyTxt3 = "ffcbb72393215007d9a0aa02b7430080409cd8c053fd4f5b4d905053"
-    hashKeyTxt4 = "96834025cdca063ce9c32dfae6bc6a3e47f8da07ee4fb8e1a3901559"
-
-testScriptsAllLangs
-    :: Spec
-testScriptsAllLangs = do
-    forM_ scriptMatrix $ \(title, adrestiaScript, nodeScript) ->
-        checkScriptHashes title adrestiaScript nodeScript
-
-testScriptPreimages
-    :: Spec
-testScriptPreimages = do
-    forM_ scriptMatrix $ \(title, adrestiaScript, nodeScript) ->
-        checkScriptPreimage title adrestiaScript nodeScript
-
-timelockScriptMatrix
-    :: [(String, Script KeyHash, Cardano.Script Cardano.SimpleScript')]
-timelockScriptMatrix =
-    [ ( "SimpleScript ActiveFromSlot"
-      , RequireAllOf [toKeyHash hashKeyTxt1, ActiveFromSlot 120]
-      , toSimpleScript $
-          Cardano.RequireAllOf
-              [toPaymentHash hashKeyTxt1, Cardano.RequireTimeAfter (SlotNo 120)]
-      )
-    , ( "SimpleScript ActiveUntilSlot"
-      , RequireAllOf [toKeyHash hashKeyTxt1, ActiveUntilSlot 120]
-      , toSimpleScript $
-          Cardano.RequireAllOf
-              [toPaymentHash hashKeyTxt1, Cardano.RequireTimeBefore (SlotNo 120)]
-      )
-    , ( "SimpleScript ActiveFromSlot and ActiveUntilSlot"
-      , RequireAllOf
-          [ ActiveFromSlot 120
-          , ActiveUntilSlot 150
-          , RequireAnyOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2]
-          ]
-      , toSimpleScript $
-          Cardano.RequireAllOf
-          [ Cardano.RequireTimeAfter (SlotNo 120)
-          , Cardano.RequireTimeBefore (SlotNo 150)
-          , Cardano.RequireAnyOf
-              [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2 ]
-          ]
-      )
-    ]
-  where
-    hashKeyTxt1 = "deeae4e895d8d57378125ed4fd540f9bf245d59f7936a504379cfc1e"
-    hashKeyTxt2 = "60a3bf69aa748f9934b64357d9f1ca202f1a768aaf57263aedca8d5f"
-    toSimpleScript = Cardano.SimpleScript
-
-testScriptsTimelockLang :: Spec
-testScriptsTimelockLang =
-    forM_ timelockScriptMatrix $ \(title, adrestiaScript, nodeScript) ->
-        checkScriptHashes title adrestiaScript nodeScript
-
-testTimelockScriptImagesLang :: Spec
-testTimelockScriptImagesLang =
-    forM_ timelockScriptMatrix $ \(title, adrestiaScript, nodeScript) ->
-        checkScriptPreimage title adrestiaScript nodeScript
-
-instance Arbitrary (Hash "Genesis") where
-    arbitrary = Hash . BS.pack <$> vector 32
-
-instance Arbitrary (Hash "BlockHeader") where
-    arbitrary = Hash . BS.pack <$> vector 32
-
 instance Arbitrary RewardAccount where
     arbitrary = FromKeyHash . BS.pack <$> vector 28
-
-instance Arbitrary (Tip (CardanoBlock StandardCrypto)) where
-    arbitrary = frequency
-        [ (10, return TipGenesis)
-        , (90, arbitraryTip)
-        ]
-      where
-        arbitraryTip = do
-            n <- choose (0, 100)
-            hash <- toCardanoHash
-                . Hash
-                . digest (Proxy @(HASH StandardCrypto))
-                . BS.pack <$> vector 5
-            return $ Tip (SlotNo n) hash (BlockNo n)
-
-instance Arbitrary SL.UnitInterval where
-    arbitrary = oneof
-        [ pure interval0
-        , pure interval1
-        , pure $ unsafeBoundRational (1 % 2)
-        , unsafeBoundRational . (% 1000) <$> choose (0, 1000)
-        ]
-    shrink = map unsafeBoundRational . shrink . SL.unboundRational
-
-instance Arbitrary SlotId where
-    arbitrary = SlotId
-        <$> (W.EpochNo . fromIntegral <$> choose (0, 10 :: Word32))
-        <*> (W.SlotInEpoch <$> choose (0, 10))
 
 instance Arbitrary (ShelleyKey 'CredFromKeyK XPrv) where
     shrink _ = []
@@ -707,52 +289,6 @@ genMnemonic = do
 instance Show XPrv where
     show _ = "<xprv>"
 
-instance Arbitrary TokenBundle.TokenBundle where
-    arbitrary = genTokenBundleSmallRange
-    shrink = shrinkTokenBundleSmallRange
-
-newtype FixedSize32 a = FixedSize32 { unFixedSize32 :: a }
-    deriving (Eq, Show)
-
-newtype FixedSize48 a = FixedSize48 { unFixedSize48 :: a }
-    deriving (Eq, Show)
-
-newtype FixedSize64 a = FixedSize64 { unFixedSize64 :: a }
-    deriving (Eq, Show)
-
-newtype FixedSize128 a = FixedSize128 { unFixedSize128 :: a }
-    deriving (Eq, Show)
-
-newtype VariableSize16 a = VariableSize16 { unVariableSize16 :: a}
-    deriving (Eq, Show)
-
-newtype VariableSize1024 a = VariableSize1024 { unVariableSize1024 :: a}
-    deriving (Eq, Show)
-
-instance Arbitrary (FixedSize32 TokenBundle) where
-    arbitrary = FixedSize32 <$> genTxOutTokenBundle 32
-    -- No shrinking
-
-instance Arbitrary (FixedSize48 TokenBundle) where
-    arbitrary = FixedSize48 <$> genTxOutTokenBundle 48
-    -- No shrinking
-
-instance Arbitrary (FixedSize64 TokenBundle) where
-    arbitrary = FixedSize64 <$> genTxOutTokenBundle 64
-    -- No shrinking
-
-instance Arbitrary (FixedSize128 TokenBundle) where
-    arbitrary = FixedSize128 <$> genTxOutTokenBundle 128
-    -- No shrinking
-
-instance Arbitrary (VariableSize16 TokenBundle) where
-    arbitrary = VariableSize16 <$> resize 16 genTokenBundle
-    -- No shrinking
-
-instance Arbitrary (VariableSize1024 TokenBundle) where
-    arbitrary = VariableSize1024 <$> resize 1024 genTokenBundle
-    -- No shrinking
-
 --
 -- Helpers
 --
@@ -770,8 +306,3 @@ bech32testnet = Bech32.encodeLenient hrp . Bech32.dataPartFromBytes
 
 base58 :: ByteString -> Text
 base58 = T.decodeUtf8 . encodeBase58 bitcoinAlphabet
-
-unsafeBoundRational :: Rational -> SL.UnitInterval
-unsafeBoundRational =
-    fromMaybe (error "unsafeBoundRational: the impossible happened")
-    . SL.boundRational

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -29,6 +29,9 @@ import Cardano.Wallet.Launch.Cluster
 import Cardano.Wallet.Network
     ( NetworkLayer (..)
     )
+import Cardano.Wallet.Network.Implementation.Ouroboros
+    ( tunedForMainnetPipeliningStrategy
+    )
 import Cardano.Wallet.Primitive.Ledger.Shelley
     ( fromGenesisData
     )
@@ -66,9 +69,6 @@ import Fmt
     ( build
     , fmt
     , indentF
-    )
-import Ouroboros.Network.Client.Wallet
-    ( tunedForMainnetPipeliningStrategy
     )
 import Ouroboros.Network.NodeToClient
     ( NodeToClientVersionData

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -29,6 +29,12 @@ import Cardano.Wallet.Launch.Cluster
 import Cardano.Wallet.Network
     ( NetworkLayer (..)
     )
+import Cardano.Wallet.Network.Implementation
+    ( Observer (..)
+    , ObserverLog (..)
+    , newObserver
+    , withNetworkLayer
+    )
 import Cardano.Wallet.Network.Implementation.Ouroboros
     ( tunedForMainnetPipeliningStrategy
     )
@@ -40,12 +46,6 @@ import Cardano.Wallet.Primitive.SyncProgress
     )
 import Cardano.Wallet.Primitive.Types
     ( NetworkParameters (..)
-    )
-import Cardano.Wallet.Shelley.Network.Node
-    ( Observer (..)
-    , ObserverLog (..)
-    , newObserver
-    , withNetworkLayer
     )
 import Control.Monad
     ( replicateM

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -29,14 +29,14 @@ import Cardano.Wallet.Launch.Cluster
 import Cardano.Wallet.Network
     ( NetworkLayer (..)
     )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( fromGenesisData
+    )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..)
     )
 import Cardano.Wallet.Primitive.Types
     ( NetworkParameters (..)
-    )
-import Cardano.Wallet.Shelley.Compatibility
-    ( fromGenesisData
     )
 import Cardano.Wallet.Shelley.Network.Node
     ( Observer (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -87,6 +87,10 @@ import Cardano.Wallet.Gen
 import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Integrity
     ( txIntegrity
     )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( toCardanoLovelace
+    , toCardanoTxIn
+    )
 import Cardano.Wallet.Primitive.NetworkId
     ( SNetworkId (..)
     )
@@ -163,10 +167,6 @@ import Cardano.Wallet.Primitive.Types.UTxO
     )
 import Cardano.Wallet.Read.Tx.Cardano
     ( fromCardanoApiTx
-    )
-import Cardano.Wallet.Shelley.Compatibility
-    ( toCardanoLovelace
-    , toCardanoTxIn
     )
 import Cardano.Wallet.Shelley.Transaction
     ( TxWitnessTag (..)


### PR DESCRIPTION
- [x] Move `GenesisParameters` to primitive lib
- [x] Move `NetworkParameters` to primitive lib
- [x] Move `Byron` compatibility modules to primitive lib, rename to` Primitive.Ledger.Byron`
- [x] Move `Shelley` compatibility module to primitive lib , rename to` Primitive.Ledger.Shelley` 
- [x] Split `CompatibilitySpec` (because it's containing stuff that has nothing to do with `Compatibility` module, ehm)
- [x] Move the `CompatibilitySpec` part that pertains to Compatibility to primitive lib 
- [x] Split `UnliftIO.Compat` and move `coerceHandlers` to network-layer lib
- [x] Move `Ouroboros.Network.Client.Wallet` to network-layer lib , rename to `Network.Implementation.Ouroboros`
- [x] Move network implementation to network-layer lib and rename as  `Network.Implementation`

ADP-3229