### PR TITLE
Remove unused `scrypt` flag from `cardano-wallet` library.

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -37,19 +37,10 @@ flag release
   default:     False
   manual:      True
 
-flag scrypt
-  description: Enable compatibility support for legacy wallet passwords.
-  default:     True
-
 library
   import:          language, opts-lib
   hs-source-dirs:  src
   ghc-options:     -Wincomplete-uni-patterns -Wincomplete-record-updates
-
-  if flag(scrypt)
-    cpp-options:   -DHAVE_SCRYPT
-    build-depends: scrypt
-
   build-depends:
     , address-derivation-discovery
     , aeson
@@ -697,11 +688,6 @@ test-suite unit
     , x509
     , x509-store
     , yaml
-
-  if flag(scrypt)
-    cpp-options:   -DHAVE_SCRYPT
-    build-depends: scrypt
-
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:
     Cardano.Byron.Codec.CborSpec

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -391,7 +391,7 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: haskell-nix.cabalProject' [
 
           # Disable scrypt support on ARM64
           ({ pkgs, ... }: {
-            packages.cardano-wallet.flags.scrypt = !pkgs.stdenv.hostPlatform.isAarch64;
+            packages.address-derivation-discovery.flags.scrypt = !pkgs.stdenv.hostPlatform.isAarch64;
           })
         ];
     })


### PR DESCRIPTION
## Issue

Follow-on from:
- #4148 
- #4270 

## Description

This PR removes the unused `scrypt` flag from the `cardano-wallet` library, and updates the way this flag is handled within our `nix` configuration.

## Context

As a result of PR #4148, the `scrypt` and `HAVE_SCRYPT` flags are now only used by the `address-derivation-discovery` package, and are no longer used by the `cardano-wallet` library.

See [this relevant section of code](https://github.com/cardano-foundation/cardano-wallet/blob/94be4cdf6588231bcb5b8229c5cd908138943e71/lib/address-derivation-discovery/lib/Cardano/Wallet/Primitive/Passphrase/Legacy.hs#L70-L94) within `address-derivation-discovery`.