### PR TITLE
Remove redundant usage of `TemplateHaskell` extension.

### DIFF
--- a/lib/local-cluster/lib/Cardano/Wallet/LocalCluster.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/LocalCluster.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Cardano.Wallet.LocalCluster where
 


### PR DESCRIPTION
Discovered while using the most recent version of [`hlint`](https://github.com/ndmitchell/hlint) ([`3.6.1`](https://github.com/ndmitchell/hlint/releases/tag/v3.6.1)).

Note that version 3.6.1 of `hlint`:
  - is not available in our current `nix` shell.
  - does not appear to support versions of GHC before 9.2 ([source](https://github.com/ndmitchell/hlint/blob/ed1259a7da88420e8d05d6241d6bdd4493a9997f/hlint.cabal#L39
)).

See also: #4171