### PR TITLE
Factor out `localClusterConfigsFromEnv` helper

### DIFF
--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
@@ -39,6 +39,7 @@ module Cardano.Wallet.Launch.Cluster
       -- * Cluster node launcher
     , defaultPoolConfigs
     , clusterEraFromEnv
+    , localClusterConfigsFromEnv
     , clusterEraToString
     , withSMASH
 
@@ -1029,6 +1030,11 @@ clusterEraFromEnv =
         "babbage" -> pure BabbageHardFork
         _ -> die $ var ++ ": unknown era"
     withDefault = fromMaybe maxBound
+
+localClusterConfigsFromEnv :: IO (Tagged "cluster-configs" String)
+localClusterConfigsFromEnv = lookupEnvNonEmpty "LOCAL_CLUSTER_CONFIGS"
+    <&> Tagged @"cluster-configs"
+        . fromMaybe "../local-cluster/test/data/cluster-configs"
 
 clusterEraToString :: ClusterEra -> String
 clusterEraToString = \case

--- a/lib/wallet/test/integration/shelley-integration-test.hs
+++ b/lib/wallet/test/integration/shelley-integration-test.hs
@@ -131,9 +131,6 @@ import Control.Tracer
 import Data.Either.Combinators
     ( whenLeft
     )
-import Data.Functor
-    ( (<&>)
-    )
 import Data.IORef
     ( IORef
     , atomicModifyIORef'
@@ -178,7 +175,6 @@ import System.Environment
 import System.Environment.Extended
     ( envFromText
     , isEnvSet
-    , lookupEnvNonEmpty
     )
 import System.FilePath
     ( (</>)
@@ -357,9 +353,7 @@ specWithServer testnetMagic testDir (tr, tracers) = aroundAll withContext
     withContext action = bracketTracer' tr "withContext" $ do
         ctx <- newEmptyMVar
 
-        clusterConfigs <- lookupEnvNonEmpty "LOCAL_CLUSTER_CONFIGS"
-            <&> Tagged @"cluster-configs"
-                . fromMaybe "../local-cluster/test/data/cluster-configs"
+        clusterConfigs <- Cluster.localClusterConfigsFromEnv
 
         poolGarbageCollectionEvents <- newIORef []
         let dbEventRecorder =

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -24,6 +24,7 @@ import Cardano.Wallet.Launch.Cluster
     , LogFileConfig (..)
     , RunningNode (..)
     , defaultPoolConfigs
+    , localClusterConfigsFromEnv
     , withCluster
     )
 import Cardano.Wallet.Network
@@ -72,9 +73,6 @@ import Fmt
     )
 import Ouroboros.Network.NodeToClient
     ( NodeToClientVersionData
-    )
-import System.Environment
-    ( getEnv
     )
 import System.Environment.Extended
     ( isEnvSet
@@ -318,8 +316,7 @@ withTestNode tr action = do
     skipCleanup <- SkipCleanup <$> isEnvSet "NO_CLEANUP"
     withSystemTempDir (contramap MsgTempDir tr) "network-spec" skipCleanup $
         \dir -> do
-            cfgClusterConfigs <-
-                Tagged @"cluster-configs" <$> getEnv "LOCAL_CLUSTER_CONFIGS"
+            cfgClusterConfigs <- localClusterConfigsFromEnv
             let clusterConfig = Cluster.Config
                     { cfgStakePools = defaultPoolConfigs
                     , cfgLastHardFork = BabbageHardFork


### PR DESCRIPTION
Now we get a default value at both call sites. This should hopefully make the unit tests pass outside of nix shell.

### Comments


### Issue Number

Failing unit test on windows:

https://github.com/cardano-foundation/cardano-wallet/actions/runs/7036946906/job/19150937124#step:3:7560
