### PR TITLE
Co-locate UTxO-related arguments of `balanceTransaction`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -516,8 +516,7 @@ balanceTransaction
         ( MonadRandom m
         , IsRecentEra era
         )
-    => UTxOAssumptions
-    -> PParams era
+    => PParams era
     -- Protocol parameters. Can be retrieved via Local State Query to a
     -- local node.
     --
@@ -535,15 +534,16 @@ balanceTransaction
     -- forfeited. We should ideally investigate and clarify as part of ADP-1544
     -- or similar ticket. Relevant ledger code:
     -- https://github.com/input-output-hk/cardano-ledger/blob/fdec04e8c071060a003263cdcb37e7319fb4dbf3/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs#L428-L440
+    -> UTxOAssumptions
     -> UTxOIndex era
     -> ChangeAddressGen changeState
     -> changeState
     -> PartialTx era
     -> ExceptT (ErrBalanceTx era) m (Tx era, changeState)
 balanceTransaction
-    utxoAssumptions
     pp
     timeTranslation
+    utxoAssumptions
     utxo
     genChange
     s

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -554,9 +554,9 @@ balanceTransaction
         balanceWith strategy =
             balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 @era @m @changeState
-                utxoAssumptions
                 pp
                 timeTranslation
+                utxoAssumptions
                 utxo
                 genChange
                 s
@@ -641,9 +641,9 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         ( MonadRandom m
         , IsRecentEra era
         )
-    => UTxOAssumptions
-    -> PParams era
+    => PParams era
     -> TimeTranslation
+    -> UTxOAssumptions
     -> UTxOIndex era
     -> ChangeAddressGen changeState
     -> changeState
@@ -651,9 +651,9 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     -> PartialTx era
     -> ExceptT (ErrBalanceTx era) m (Tx era, changeState)
 balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
-    utxoAssumptions
     pp
     timeTranslation
+    utxoAssumptions
     (UTxOIndex walletUTxO internalUtxoAvailable walletLedgerUTxO)
     genChange
     s

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3464,9 +3464,9 @@ balanceTransaction
                 . fst
                 )
             $ Write.balanceTransaction
-                utxoAssumptions
                 pp
                 timeTranslation
+                utxoAssumptions
                 utxoIndex
                 (W.defaultChangeAddressGen argGenChange)
                 (getState wallet)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2353,9 +2353,9 @@ buildTransactionPure
     withExceptT Left $
         first Write.toCardanoApiTx <$>
         balanceTransaction @_ @_ @s
-            (utxoAssumptionsForWallet (walletFlavor @s))
             pparams
             timeTranslation
+            (utxoAssumptionsForWallet (walletFlavor @s))
             utxoIndex
             changeAddrGen
             (getState wallet)
@@ -3006,9 +3006,9 @@ transactionFee DBLayer{atomically, walletState} protocolParams
             res <- runExceptT $
                 first (Write.toCardanoApiTx @era) <$>
                     balanceTransaction @_ @_ @s
-                        (utxoAssumptionsForWallet (walletFlavor @s))
                         protocolParams
                         timeTranslation
+                        (utxoAssumptionsForWallet (walletFlavor @s))
                         utxoIndex
                         changeAddressGen
                         (getState wallet)

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1981,9 +1981,9 @@ balanceTx
     = (`evalRand` stdGenFromSeed seed) $ runExceptT $ do
         (transactionInEra, _nextChangeState) <-
             balanceTransaction
-                utxoAssumptions
                 protocolParameters
                 timeTranslation
+                utxoAssumptions
                 utxoIndex
                 genChange
                 s
@@ -2005,9 +2005,9 @@ balanceTransactionWithDummyChangeState
 balanceTransactionWithDummyChangeState utxoAssumptions utxo seed partialTx =
     (`evalRand` stdGenFromSeed seed) $ runExceptT $
         balanceTransaction
-            utxoAssumptions
             mockPParamsForBalancing
             dummyTimeTranslation
+            utxoAssumptions
             utxoIndex
             dummyChangeAddrGen
             (DummyChangeState 0)


### PR DESCRIPTION
## Issue

None, noticed while reviewing code.

## Description

This PR adjusts the type signature of `balanceTransaction` so that the following UTxO-related arguments occur together:
- `UTxOAssumptions`
- `UTxOIndex`