### PR TITLE
Add soft-fail to hls buildkite step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -104,6 +104,7 @@ steps:
       TMPDIR: "/cache"
 
   - label: 'Check HLS works'
+    soft_fail: true
     depends_on: linux-nix
     command: |
         nix develop --command bash -c "haskell-language-server lib/wallet/src/Cardano/Wallet.hs"


### PR DESCRIPTION
Hls check is not reliable any more.

I.e checking out a commit like `6a7bfdf40d`

> git checkout 6a7bfdf40d

and 

>  nix develop --command bash -c "haskell-language-server lib/wallet/src/Cardano/Wallet.hs"

it passes on my machine and @Unisay 's one but not on buildkite agent
I tried removing `hie-bios` cache and `ghcide` on the agents home and removing all clones

> rm -rf ~/.cache/ghcide/
>  rm -rf ~/.cache/hie-bios/
> find . -name cardano-wallet | xargs rm -rf

The problem persists

- [x] Let HLS test soft-fail until after the release
- [x] Added a high priority ticket https://cardanofoundation.atlassian.net/browse/ADP-3236 
