### PR TITLE
Remove constraints from `ErrBalanceTx` data type definition.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -403,12 +403,11 @@ data ErrBalanceTxAssetsInsufficientError = ErrBalanceTxAssetsInsufficientError
     deriving (Eq, Generic, Show)
 
 data ErrBalanceTxInternalError era
-    = IsRecentEra era
-        => ErrUnderestimatedFee Coin (Tx era) KeyWitnessCount
+    = ErrUnderestimatedFee Coin (Tx era) KeyWitnessCount
     | ErrFailedBalancing Value
 
-deriving instance Eq (ErrBalanceTxInternalError era)
-deriving instance Show (ErrBalanceTxInternalError era)
+deriving instance IsRecentEra era => Eq (ErrBalanceTxInternalError era)
+deriving instance IsRecentEra era => Show (ErrBalanceTxInternalError era)
 
 -- | Errors that can occur when balancing transactions.
 data ErrBalanceTx era

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -417,15 +417,12 @@ data ErrBalanceTx era
     | ErrBalanceTxExistingCollateral
     | ErrBalanceTxExistingTotalCollateral
     | ErrBalanceTxExistingReturnCollateral
-    | IsRecentEra era
-        => ErrBalanceTxInsufficientCollateral
+    | ErrBalanceTxInsufficientCollateral
         (ErrBalanceTxInsufficientCollateralError era)
     | ErrBalanceTxConflictingNetworks
     | ErrBalanceTxAssignRedeemers ErrAssignRedeemers
-    | IsRecentEra era
-        => ErrBalanceTxInternalError (ErrBalanceTxInternalError era)
-    | IsRecentEra era
-        => ErrBalanceTxInputResolutionConflicts
+    | ErrBalanceTxInternalError (ErrBalanceTxInternalError era)
+    | ErrBalanceTxInputResolutionConflicts
         (NonEmpty (TxOut era, TxOut era))
     | ErrBalanceTxUnresolvedInputs (NonEmpty TxIn)
     | ErrBalanceTxOutputError ErrBalanceTxOutputError
@@ -436,8 +433,8 @@ data ErrBalanceTx era
     --   - the given UTxO index is empty.
     -- A transaction must have at least one input in order to be valid.
 
-deriving instance Eq (ErrBalanceTx era)
-deriving instance Show (ErrBalanceTx era)
+deriving instance IsRecentEra era => Eq (ErrBalanceTx era)
+deriving instance IsRecentEra era => Show (ErrBalanceTx era)
 
 -- | A 'PartialTx' is an an unbalanced 'SealedTx' along with the necessary
 -- information to balance it.

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -609,7 +609,9 @@ instance Write.IsRecentEra era => IsServerError (ErrBalanceTx era) where
                 , "or sending a smaller amount."
                 ]
 
-instance forall era. IsServerError (ErrBalanceTxInternalError era) where
+instance
+    Write.IsRecentEra era => IsServerError (ErrBalanceTxInternalError era)
+  where
     toServerError = \case
         ErrUnderestimatedFee coin candidateTx (KeyWitnessCount nWits nBootWits) ->
             apiError err500 (BalanceTxUnderestimatedFee info) $ T.unwords


### PR DESCRIPTION
## Issue

ADP-3185

## Description

This PR removes all type class constraints from the `ErrBalanceTx` data type hierarchy, and adds constraints back in only where necessary — at the definitions of type class instances.

In practice, this only affects the `IsRecentEra` type class constraint.