### PR TITLE
Fix local-cluster (invalid config name)

### DIFF
--- a/lib/local-cluster/lib/Cardano/Wallet/LocalCluster.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/LocalCluster.hs
@@ -239,7 +239,7 @@ main = withUtf8 $ do
                         , WC.walletListenPort =
                             Nothing
                         , WC.walletByronGenesisForTestnet = Just $
-                            clusterDir Path.</> [Path.relfile|genesis.byron.json|]
+                            clusterDir Path.</> [Path.relfile|genesis-byron.json|]
                         }
                     )
                     (WC.stop . fst)


### PR DESCRIPTION
 I have fixed the config file name so the local-cluster starts without problems as a part of the `e2e` test run.
