### PR TITLE
[ADP-3224] Fix docker e2e failures

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -30,7 +30,7 @@ jobs:
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}
       BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_TOKEN_READ_BUILDS_ARTIFACTS }}
       WALLET: ${{ github.event.inputs.walletTag || 'dev-master' }}
-      TESTS_E2E_TOKEN_METADATA: https://metadata.cardano-testnet.iohkdev.io/
+      TESTS_E2E_TOKEN_METADATA: https://metadata.world.dev.cardano.org/
       TAGS: ${{ github.event.inputs.tags || 'all' }}
       E2E_DOCKER_RUN: 1
 
@@ -95,7 +95,7 @@ jobs:
       run: |
         echo "Wallet: $WALLET"
         echo "Node: ${{steps.cardano-node-tag.outputs.NODE_TAG}}"
-
+        echo $TESTS_E2E_TOKEN_METADATA
         NODE=${{steps.cardano-node-tag.outputs.NODE_TAG}} \
         NODE_CONFIG_PATH=`pwd`/state/configs/preprod \
         DATA=`pwd`/state/node_db/preprod \

--- a/docs/site/src/user/common-use-cases/assets.md
+++ b/docs/site/src/user/common-use-cases/assets.md
@@ -83,7 +83,7 @@ For example on `preview` or `preprod` that would be:
   --node-socket /path/to/node.socket \
   --testnet byron-genesis.json \
   --database ./wallet-db \
-  --token-metadata-server https://metadata.cardano-testnet.iohkdev.io/
+  --token-metadata-server https://metadata.world.dev.cardano.org/
 ```
 
 Then, if you list assets associated with your wallet you will get their available metadata.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -33,8 +33,8 @@ If there is a need to update the mnemonics to new ones, it is certainly possible
 
 Please note that the wallets used in tests must have ADA and specific assets on their balance. Test ADA can be obtained from the [Faucet](https://docs.cardano.org/cardano-testnet/tools/faucet/). The assets required on the wallet's balance are:
 
--   SadCoin (with [metadata](https://metadata.cardano-testnet.iohkdev.io/metadata/ee1ce9d7560f48a4ba3867037dbec2d8fed776d94dd6b00a35309073))
--   HappyCoin (with [metadata](https://metadata.cardano-testnet.iohkdev.io/metadata/919e8a1922aaa764b1d66407c6f62244e77081215f385b60a62091494861707079436f696e))
+-   SadCoin (with [metadata](https://metadata.world.dev.cardano.org/metadata/ee1ce9d7560f48a4ba3867037dbec2d8fed776d94dd6b00a35309073))
+-   HappyCoin (with [metadata](https://metadata.world.dev.cardano.org/metadata/919e8a1922aaa764b1d66407c6f62244e77081215f385b60a62091494861707079436f696e))
 
 Both assets have metadata in the [Testnet Metadata Registry](https://github.com/input-output-hk/metadata-registry-testnet), and there are tests in place to ensure that the wallet reads data from there correctly. Both assets can be minted outside of the wallet using tools such as `cardano-cli` or [token-minter](https://github.com/piotr-iohk/token_minter), and then sent to the balances of the fixture wallets. Policy scripts and keys required for minting are availeble in [tests/e2e/fixtuers/wallet_assets](https://github.com/cardano-foundation/cardano-wallet/tree/master/test/e2e/fixtures/wallet_assets).
 
@@ -71,7 +71,7 @@ cardano-node and cardano-wallet are started as separate Windows services using [
 One can also start tests against cardano-wallet docker. There is docker-compose-test.yml provided that includes cardano-node and cardano-wallet. To start it several env variables need to be set to feed docker-compose:
 >```bash
 >NETWORK=preprod \
->TESTS_E2E_TOKEN_METADATA=https://metadata.cardano-testnet.iohkdev.io/ \
+>TESTS_E2E_TOKEN_METADATA=https://metadata.world.dev.cardano.org/ \
 >WALLET=dev-master \
 >NODE=8.1.1 \
 >NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK \

--- a/test/e2e/docker_compose.sh
+++ b/test/e2e/docker_compose.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-NETWORK=testnet \
-TESTS_E2E_TOKEN_METADATA=https://metadata.cardano-testnet.iohkdev.io/ \
+NETWORK=preprod \
+TESTS_E2E_TOKEN_METADATA=https://metadata.world.dev.cardano.org/ \
 WALLET=dev-master \
-NODE=1.34.1 \
+NODE=8.1.1 \
 NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK \
 DATA=`pwd`/state/node_db/$NETWORK \
 WALLET_DATA=`pwd`/state/wallet_db/$NETWORK \

--- a/test/e2e/env.rb
+++ b/test/e2e/env.rb
@@ -24,7 +24,7 @@ ENV['TESTS_WALLET_DB'] ||= File.join(ENV.fetch('TESTS_E2E_STATEDIR', nil), 'wall
 # NOTE: Running `rake run_on[testnet,local]' overrides this and assumes node and wallet on $PATH
 ENV['TESTS_E2E_BINDIR'] ||= './bins'
 
-ENV['TESTS_E2E_TOKEN_METADATA'] ||= 'http://metadata.world.dev.cardano.org'
+ENV['TESTS_E2E_TOKEN_METADATA'] ||= 'https://metadata.world.dev.cardano.org'
 ENV['TESTS_E2E_SMASH'] ||= 'https://smash.shelley-qa.dev.cardano.org/'
 ENV['WALLET_PORT'] ||= '8090'
 ENV['NETWORK'] ||= 'preprod'

--- a/test/e2e/helpers/matchers.rb
+++ b/test/e2e/helpers/matchers.rb
@@ -7,7 +7,7 @@ RSpec::Matchers.define :be_correct_and_respond do |code|
     if code == 204
       response.code == code
     else
-      ((response.code == code) && (response.headers >= { 'content-type' => ['application/json;charset=utf-8'] }))
+      response.code == code && response.headers >= { 'content-type' => ['application/json;charset=utf-8'] }
     end
   end
   failure_message do |response|

--- a/test/e2e/run_all_tests.sh
+++ b/test/e2e/run_all_tests.sh
@@ -2,5 +2,5 @@
 
 TESTS_E2E_STATEDIR=./state \
 TESTS_E2E_BINDIR=./bins \
-TESTS_E2E_TOKEN_METADATA=https://metadata.cardano-testnet.iohkdev.io/ \
+TESTS_E2E_TOKEN_METADATA=https://metadata.world.dev.cardano.org/ \
 rake run_on[testnet]

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -2395,13 +2395,13 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
                                                           nil, # validity_interval
                                                           o_enc) # encoding
           expect(tx_constructed).to be_correct_and_respond 202
-          expect(method("#{o_enc}?".to_sym).call(tx_constructed['transaction'])).to be true
+          expect(method("#{o_enc}?").call(tx_constructed['transaction'])).to be true
 
           tx_signed = SHELLEY.transactions.sign(@wid, PASS,
                                                 tx_constructed['transaction'],
                                                 o_enc)
           expect(tx_signed).to be_correct_and_respond 202
-          expect(method("#{o_enc}?".to_sym).call(tx_signed['transaction'])).to be true
+          expect(method("#{o_enc}?").call(tx_signed['transaction'])).to be true
         end
       end
     end

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -76,7 +76,7 @@ METADATA = { '0' => { 'string' => 'cardano' },
              '4' => { 'map' => [{ 'k' => { 'string' => 'key' }, 'v' => { 'string' => 'value' } },
                                 { 'k' => { 'int' => 14 }, 'v' => { 'int' => 42 } }] } }.freeze
 
-# Testnet assets with metadata from mock server https://metadata.cardano-testnet.iohkdev.io/
+# Testnet assets with metadata from mock server https://metadata.world.dev.cardano.org/
 ASSETS = [{ 'policy_id' => 'ee1ce9d7560f48a4ba3867037dbec2d8fed776d94dd6b00a35309073',
             'asset_name' => '',
             'fingerprint' => 'asset1s3yhz885gnyu2wcpz5h275u37hw3axz3c9sfqu',


### PR DESCRIPTION
- [x]  Fixed the links to the metadata server, [passed tests](https://github.com/cardano-foundation/cardano-wallet/actions/runs/7063750920/job/19230374682#step:14:167)
- [x]  Applied rubocop hints

ADP-3224
