### PR TITLE
Hide `updateTx` abstraction from public interface of `balanceTx`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -1208,7 +1208,7 @@ data TxFeeUpdate
     deriving (Eq, Show)
 
 newtype ErrUpdateTx
-    = ErrExistingKeyWitnesses Int
+    = ErrUpdateTxExistingKeyWitnesses Int
     -- ^ The transaction could not be updated because the *n* existing
     -- key-witnesses would be rendered invalid.
     deriving (Generic, Eq, Show)
@@ -1237,7 +1237,7 @@ updateTx tx extraContent = do
 
     case numberOfExistingKeyWits of
         0 -> Right tx'
-        n -> Left $ ErrExistingKeyWitnesses n
+        n -> Left $ ErrUpdateTxExistingKeyWitnesses n
   where
     numberOfExistingKeyWits :: Int
     numberOfExistingKeyWits = sum

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -414,6 +414,8 @@ data ErrBalanceTx era
     = ErrBalanceTxAssetsInsufficient ErrBalanceTxAssetsInsufficientError
     | ErrBalanceTxMaxSizeLimitExceeded
     | ErrBalanceTxExistingKeyWitnesses Int
+    -- ^ Indicates that a transaction could not be balanced because a given
+    -- number of existing key witnesses would be rendered invalid.
     | ErrBalanceTxExistingCollateral
     | ErrBalanceTxExistingTotalCollateral
     | ErrBalanceTxExistingReturnCollateral

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -36,7 +36,6 @@ module Internal.Cardano.Write.Tx.Balance
     , ErrBalanceTxOutputSizeExceedsLimitError (..)
     , ErrBalanceTxOutputTokenQuantityExceedsLimitError (..)
     , ErrBalanceTxUnableToCreateChangeError (..)
-    , ErrUpdateTx (..)
     , ErrAssignRedeemers (..)
 
     -- * Change addresses
@@ -64,6 +63,7 @@ module Internal.Cardano.Write.Tx.Balance
     , noTxUpdate
     , updateTx
     , TxFeeUpdate (..)
+    , ErrUpdateTx (..)
 
     -- ** distributeSurplus
     , distributeSurplus

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -36,7 +36,7 @@ module Internal.Cardano.Write.Tx.Balance
     , ErrBalanceTxOutputSizeExceedsLimitError (..)
     , ErrBalanceTxOutputTokenQuantityExceedsLimitError (..)
     , ErrBalanceTxUnableToCreateChangeError (..)
-    , ErrUpdateSealedTx (..)
+    , ErrUpdateTx (..)
     , ErrAssignRedeemers (..)
 
     -- * Change addresses
@@ -411,7 +411,7 @@ deriving instance IsRecentEra era => Show (ErrBalanceTxInternalError era)
 
 -- | Errors that can occur when balancing transactions.
 data ErrBalanceTx era
-    = ErrBalanceTxUpdateError ErrUpdateSealedTx
+    = ErrBalanceTxUpdateError ErrUpdateTx
     | ErrBalanceTxAssetsInsufficient ErrBalanceTxAssetsInsufficientError
     | ErrBalanceTxMaxSizeLimitExceeded
     | ErrBalanceTxExistingCollateral
@@ -1207,7 +1207,7 @@ data TxFeeUpdate
         -- ^ Specify a new fee to use instead.
     deriving (Eq, Show)
 
-newtype ErrUpdateSealedTx
+newtype ErrUpdateTx
     = ErrExistingKeyWitnesses Int
     -- ^ The transaction could not be updated because the *n* existing
     -- key-witnesses would be rendered invalid.
@@ -1229,7 +1229,7 @@ updateTx
     :: forall era. IsRecentEra era
     => Tx era
     -> TxUpdate
-    -> Either ErrUpdateSealedTx (Tx era)
+    -> Either ErrUpdateTx (Tx era)
 updateTx tx extraContent = do
     let tx' = tx
             & over bodyTxL (modifyShelleyTxBody extraContent)

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -436,7 +436,7 @@ data ErrBalanceTx era
 deriving instance IsRecentEra era => Eq (ErrBalanceTx era)
 deriving instance IsRecentEra era => Show (ErrBalanceTx era)
 
--- | A 'PartialTx' is an an unbalanced 'SealedTx' along with the necessary
+-- | A 'PartialTx' is an an unbalanced transaction along with the necessary
 -- information to balance it.
 --
 -- The 'TxIn's of the 'inputs' must exactly match the inputs contained in the
@@ -1209,7 +1209,7 @@ data TxFeeUpdate
 
 newtype ErrUpdateSealedTx
     = ErrExistingKeyWitnesses Int
-    -- ^ The `SealedTx` could not be updated because the *n* existing
+    -- ^ The transaction could not be updated because the *n* existing
     -- key-witnesses would be rendered invalid.
     deriving (Generic, Eq, Show)
 

--- a/lib/balance-tx/lib/main/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/main/Cardano/Write/Tx.hs
@@ -17,7 +17,6 @@ module Cardano.Write.Tx
     , ErrBalanceTxOutputSizeExceedsLimitError (..)
     , ErrBalanceTxOutputTokenQuantityExceedsLimitError (..)
     , ErrBalanceTxUnableToCreateChangeError (..)
-    , ErrUpdateTx (..)
 
     -- * UTxO-related types and functions
     , UTxO
@@ -41,7 +40,6 @@ import Internal.Cardano.Write.Tx.Balance
     , ErrBalanceTxOutputSizeExceedsLimitError (..)
     , ErrBalanceTxOutputTokenQuantityExceedsLimitError (..)
     , ErrBalanceTxUnableToCreateChangeError (..)
-    , ErrUpdateTx (..)
     , UTxOAssumptions
     , UTxOIndex
     , balanceTransaction

--- a/lib/balance-tx/lib/main/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/main/Cardano/Write/Tx.hs
@@ -17,7 +17,7 @@ module Cardano.Write.Tx
     , ErrBalanceTxOutputSizeExceedsLimitError (..)
     , ErrBalanceTxOutputTokenQuantityExceedsLimitError (..)
     , ErrBalanceTxUnableToCreateChangeError (..)
-    , ErrUpdateSealedTx (..)
+    , ErrUpdateTx (..)
 
     -- * UTxO-related types and functions
     , UTxO
@@ -41,7 +41,7 @@ import Internal.Cardano.Write.Tx.Balance
     , ErrBalanceTxOutputSizeExceedsLimitError (..)
     , ErrBalanceTxOutputTokenQuantityExceedsLimitError (..)
     , ErrBalanceTxUnableToCreateChangeError (..)
-    , ErrUpdateSealedTx (..)
+    , ErrUpdateTx (..)
     , UTxOAssumptions
     , UTxOIndex
     , balanceTransaction

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -125,7 +125,7 @@ import Cardano.Write.Tx
     , ErrBalanceTxOutputErrorInfo (..)
     , ErrBalanceTxOutputSizeExceedsLimitError (..)
     , ErrBalanceTxOutputTokenQuantityExceedsLimitError (..)
-    , ErrUpdateSealedTx (..)
+    , ErrUpdateTx (..)
     )
 import Control.Monad.Except
     ( ExceptT

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -531,7 +531,7 @@ instance IsServerError ErrWriteTxEra where
 
 instance Write.IsRecentEra era => IsServerError (ErrBalanceTx era) where
     toServerError = \case
-        ErrBalanceTxUpdateError (ErrExistingKeyWitnesses n) ->
+        ErrBalanceTxUpdateError (ErrUpdateTxExistingKeyWitnesses n) ->
             apiError err403 BalanceTxExistingKeyWitnesses $ mconcat
                 [ "The transaction could not be balanced, because it contains "
                 , T.pack (show n), " "

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -125,7 +125,6 @@ import Cardano.Write.Tx
     , ErrBalanceTxOutputErrorInfo (..)
     , ErrBalanceTxOutputSizeExceedsLimitError (..)
     , ErrBalanceTxOutputTokenQuantityExceedsLimitError (..)
-    , ErrUpdateTx (..)
     )
 import Control.Monad.Except
     ( ExceptT
@@ -531,7 +530,7 @@ instance IsServerError ErrWriteTxEra where
 
 instance Write.IsRecentEra era => IsServerError (ErrBalanceTx era) where
     toServerError = \case
-        ErrBalanceTxUpdateError (ErrUpdateTxExistingKeyWitnesses n) ->
+        ErrBalanceTxExistingKeyWitnesses n ->
             apiError err403 BalanceTxExistingKeyWitnesses $ mconcat
                 [ "The transaction could not be balanced, because it contains "
                 , T.pack (show n), " "

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1369,7 +1369,7 @@ prop_balanceTransactionValid
                         (True, True) ->
                             label "shortfall of both ada and non-ada assets"
                                 $ property True
-            Left (ErrBalanceTxUpdateError (ErrUpdateTxExistingKeyWitnesses _)) ->
+            Left (ErrBalanceTxExistingKeyWitnesses _) ->
                 label "existing key wits" $ property True
             Left
                 (ErrBalanceTxOutputError

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -253,7 +253,7 @@ import Internal.Cardano.Write.Tx.Balance
     , ErrBalanceTxOutputError (..)
     , ErrBalanceTxOutputErrorInfo (..)
     , ErrMoreSurplusNeeded (..)
-    , ErrUpdateSealedTx (..)
+    , ErrUpdateTx (..)
     , PartialTx (..)
     , Redeemer (..)
     , TxFeeAndChange (..)

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1214,7 +1214,7 @@ spec_updateTx = describe "updateTx" $ do
                     tx
                     noTxUpdate
 
-            res `shouldBe` Left (ErrExistingKeyWitnesses 1)
+            res `shouldBe` Left (ErrUpdateTxExistingKeyWitnesses 1)
 
         it "returns `Left err` when extra body content is non-empty" $ do
             pendingWith "todo: add test data"
@@ -1369,7 +1369,7 @@ prop_balanceTransactionValid
                         (True, True) ->
                             label "shortfall of both ada and non-ada assets"
                                 $ property True
-            Left (ErrBalanceTxUpdateError (ErrExistingKeyWitnesses _)) ->
+            Left (ErrBalanceTxUpdateError (ErrUpdateTxExistingKeyWitnesses _)) ->
                 label "existing key wits" $ property True
             Left
                 (ErrBalanceTxOutputError


### PR DESCRIPTION
## Issue

ADP-3185

## Description

Internally, the `balanceTx` function relies on the `updateTx` abstraction in order to update various parts of a transaction. While this is relevant to the internals of `balanceTx`, it's really an implementation detail, and not necessary for users to understand in order to use `balanceTx`.

However, this implementation detail leaks into the public interface of the `balanceTx` function via the error type `ErrUpdateSealedTx`.

This PR:
- Renames `ErrUpdateSealedTx` to `ErrUpdateTx` to match the name of the `updateTx` function (and to reflect the fact that the `SealedTx` type is no longer involved in transaction updates).
- Provides an embedding of the `ErrUpdateTx.ExistingKeyWitnesses` error into the `ErrBalanceTx` type, thus removing the need for users to know about `updateTx` in order to work with `balanceTx`.