### PR TITLE
[ADP-3224] Fix wallet cache key typo in macos E2E

### DIFF
--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -54,7 +54,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: test/e2e/state/wallet_db/preprod
-        key: wallet-db-e2-macos-preprod
+        key: wallet-db-e2e-macos-preprod
 
     - name: Fetch preprod snapshot
       if: steps.cache-node.outputs.cache-hit != 'true'


### PR DESCRIPTION
- [x] Fix a typo in the E2E GH action

ADP-3224