### PR TITLE
[ADP-3224] Remove wallet db caching in E2E tests

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -84,13 +84,6 @@ jobs:
             | lz4 -c -d - | tar -x -C .
         mv db/* .
 
-    - name: 💾 Cache wallet db
-      id: cache-wallet
-      uses: actions/cache@v3
-      with:
-        path: test/e2e/state/wallet_db/preprod
-        key: wallet-db-docker-linux-preprod
-
     - name: 🚀 Start node and wallet
       run: |
         echo "Wallet: $WALLET"
@@ -133,13 +126,6 @@ jobs:
       with:
         path: test/e2e/state/node_db/preprod
         key: node-db-docker-linux-preprod
-
-    - name: 💾 GH Save Cache of wallet db
-      if: always()
-      uses: actions/cache/save@v3
-      with:
-        path: test/e2e/state/wallet_db/preprod
-        key: wallet-db-docker-linux-preprod
 
     - name: Slack Notification on failure
       if: failure()

--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -46,13 +46,6 @@ jobs:
         path: test/e2e/state/node_db/preprod
         key: node-db-e2e-linux-preprod
 
-    - name: 💾 Cache wallet db
-      id: cache-wallet
-      uses: actions/cache@v3
-      with:
-        path: test/e2e/state/wallet_db/preprod
-        key: wallet-db-e2e-linux-preprod
-
     - name: Fetch preprod snapshot
       if: steps.cache-node.outputs.cache-hit != 'true'
       run: |
@@ -93,13 +86,6 @@ jobs:
       with:
         path: test/e2e/state/node_db/preprod
         key: node-db-e2e-linux-preprod
-
-    - name: 💾 GH Save Cache of wallet db
-      if: always()
-      uses: actions/cache/save@v3
-      with:
-        path: test/e2e/state/wallet_db/preprod
-        key: wallet-db-e2e-linux-preprod
 
     - name: 📎 Upload state
       uses: actions/upload-artifact@v3

--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -49,13 +49,6 @@ jobs:
         path: test/e2e/state/node_db/preprod
         key: node-db-e2e-macos-preprod
 
-    - name: 💾 Cache wallet db
-      id: cache-wallet
-      uses: actions/cache@v3
-      with:
-        path: test/e2e/state/wallet_db/preprod
-        key: wallet-db-e2e-macos-preprod
-
     - name: Fetch preprod snapshot
       if: steps.cache-node.outputs.cache-hit != 'true'
       run: |
@@ -97,13 +90,6 @@ jobs:
       with:
         path: test/e2e/state/node_db/preprod
         key: node-db-e2e-macos-preprod
-
-    - name: 💾 GH Save Cache of wallet db
-      if: always()
-      uses: actions/cache/save@v3
-      with:
-        path: test/e2e/state/wallet_db/preprod
-        key: wallet-db-e2e-macos-preprod
 
     - name: 📎 Upload state
       uses: actions/upload-artifact@v3

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -74,13 +74,6 @@ jobs:
         path: C:/cardano-wallet/test/e2e/state/node_db/preprod
         key: node-db-e2e-windows-preprod
 
-    - name: 💾 Cache wallet db
-      id: cache-wallet
-      uses: actions/cache@v3
-      with:
-        path: C:/cardano-wallet/test/e2e/state/wallet_db/preprod
-        key: wallet-db-e2e-windows-preprod
-
     - name: Fetch preprod snapshot
       if: steps.cache-node.outputs.cache-hit != 'true'
       working-directory: C:/cardano-wallet/test/e2e
@@ -127,13 +120,6 @@ jobs:
         path: test/e2e/state/node_db/preprod
         key: node-db-e2e-windows-preprod
 
-    - name: 💾 GH Save Cache of wallet db
-      if: always()
-      uses: actions/cache/save@v3
-      with:
-        path: test/e2e/state/wallet_db/preprod
-        key: wallet-db-e2e-windows-preprod
-
     - name: 📎 Upload state
       uses: actions/upload-artifact@v3
       if: always()
@@ -143,8 +129,6 @@ jobs:
           C:/cardano-wallet/test/e2e/state/logs
           C:/cardano-wallet/test/e2e/state/configs
           C:/cardano-wallet/test/e2e/state/wallet_db
-
-
 
   report:
     needs: [test]

--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -127,11 +127,16 @@ task :wait_until_node_synced do
     current_time = Time.now
     while network.information['sync_progress']['status'] == 'syncing'
       log "Syncing node... #{network.information['sync_progress']['progress']['quantity']}%"
+
       sleep 5
     end
-  rescue StandardError
-    retry if current_time <= timeout_treshold
-    raise("[#{Time.now}] Could not connect to wallet within #{timeout} seconds...")
+  rescue StandardError => e
+    if current_time <= timeout_treshold then
+      log "Retrying after error #{e}"
+      sleep 5
+      retry
+    end
+    raise("[#{Time.now}] Could not connect to wallet within #{timeout} seconds, last error: #{e}")
   end
 
   log '>> Cardano-node and cardano-wallet are synced! <<'


### PR DESCRIPTION

We remove this feature because the tests can leave a cache which is corrupted and make the next runs fail forever.

- [x] Add better log reporting to sync phase in E2E
- [x] Remove caching for the wallet db in all suites