### PR TITLE
Improve structure of token-related modules in `cardano-wallet-primitive`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -284,6 +284,9 @@ import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
 import qualified Cardano.Wallet.Primitive.Types.Address as W
     ( Address
     )
+import qualified Cardano.Wallet.Primitive.Types.AssetId as W
+    ( AssetId (..)
+    )
 import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..)
@@ -293,9 +296,6 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle (..)
     )
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W.TokenMap
-import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
-    ( AssetId (..)
-    )
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
     ( TokenQuantity (..)
     )

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/CoinSelection.hs
@@ -125,6 +125,9 @@ import qualified Cardano.CoinSelection.Context as SC
 import qualified Cardano.Wallet.Primitive.Types.Address as W
     ( Address (..)
     )
+import qualified Cardano.Wallet.Primitive.Types.AssetId as W
+    ( AssetId
+    )
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin
     )
@@ -133,8 +136,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle (..)
     )
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
-    ( AssetId
-    , TokenMap
+    ( TokenMap
     )
 import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
     ( txOutMaxCoin

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -81,7 +81,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
     ( AssetId (..)
     )
-import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
+import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
     ( TxSize (..)
     )

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -73,14 +73,14 @@ import qualified Cardano.Address.Script as CA
 import qualified Cardano.Wallet.Primitive.Types.Address as W
     ( Address (..)
     )
+import qualified Cardano.Wallet.Primitive.Types.AssetId as W
+    ( AssetId (..)
+    )
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..)
     )
 import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
-import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
-    ( AssetId (..)
-    )
 import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
     ( TxSize (..)

--- a/lib/coin-selection/bench/UTxOIndexBench.hs
+++ b/lib/coin-selection/bench/UTxOIndexBench.hs
@@ -28,7 +28,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/coin-selection/bench/UTxOIndexBench.hs
+++ b/lib/coin-selection/bench/UTxOIndexBench.hs
@@ -11,6 +11,9 @@ module Main where
 
 import Prelude
 
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -22,8 +25,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
-    , TokenMap
+    ( TokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)

--- a/lib/coin-selection/bench/UTxOIndexBench.hs
+++ b/lib/coin-selection/bench/UTxOIndexBench.hs
@@ -25,9 +25,11 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..)
     , TokenMap
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , TokenPolicyId (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/coin-selection/lib/Cardano/CoinSelection.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection.hs
@@ -75,6 +75,9 @@ import Cardano.CoinSelection.Size
 import Cardano.CoinSelection.UTxOSelection
     ( UTxOSelection
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -82,8 +85,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId
-    , TokenMap
+    ( TokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -139,6 +139,9 @@ import Cardano.CoinSelection.UTxOSelection
 import Cardano.Numeric.Util
     ( padCoalesce
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -146,8 +149,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId
-    , Lexicographic (..)
+    ( Lexicographic (..)
     , TokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance/Gen.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance/Gen.hs
@@ -18,6 +18,10 @@ import Cardano.CoinSelection.Balance
 import Cardano.CoinSelection.Context
     ( SelectionContext (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId.Gen
+    ( genAssetId
+    , shrinkAssetId
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -27,10 +31,6 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange
     , shrinkTokenBundleSmallRange
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetId
-    , shrinkAssetId
     )
 import Generics.SOP
     ( NP (..)

--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
@@ -145,14 +145,14 @@ import GHC.Generics
     ( Generic
     )
 
+import qualified Cardano.Wallet.Primitive.Types.AssetId as W
+    ( AssetId
+    )
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
     ( TokenBundle
     )
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W.TokenMap
-import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
-    ( AssetId
-    )
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -130,6 +130,11 @@ import Cardano.Numeric.Util
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId.Gen
+    ( genAssetId
+    , genAssetIdLargeRange
+    , shrinkAssetId
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -155,10 +160,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetId
-    , genAssetIdLargeRange
-    , genTokenMapSmallRange
-    , shrinkAssetId
+    ( genTokenMapSmallRange
     , shrinkTokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenName

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -159,9 +159,11 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     , shrinkAssetId
     , shrinkTokenMap
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , TokenPolicyId (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     ( genTokenName

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -162,11 +162,11 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
+import Cardano.Wallet.Primitive.Types.TokenName.Gen
+    ( genTokenName
+    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenPolicyId (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
-    ( genTokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -165,7 +165,7 @@ import Cardano.Wallet.Primitive.Types.TokenName
 import Cardano.Wallet.Primitive.Types.TokenName.Gen
     ( genTokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -127,6 +127,9 @@ import Cardano.CoinSelection.UTxOSelection.Gen
 import Cardano.Numeric.Util
     ( inAscendingPartialOrder
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -149,8 +152,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     , shrinkTokenBundleSmallRangePositive
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
-    , TokenMap
+    ( TokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genAssetId

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOIndexSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOIndexSpec.hs
@@ -33,16 +33,16 @@ import Cardano.CoinSelection.UTxOIndex.Internal
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId
     )
+import Cardano.Wallet.Primitive.Types.AssetId.Gen
+    ( genAssetId
+    , shrinkAssetId
+    )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRangePositive
     , shrinkTokenBundleSmallRangePositive
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetId
-    , shrinkAssetId
     )
 import Control.Monad
     ( void

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOIndexSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOIndexSpec.hs
@@ -30,15 +30,15 @@ import Cardano.CoinSelection.UTxOIndex.Internal
     , categorizeTokenBundle
     , checkInvariant
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId
+    )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRangePositive
     , shrinkTokenBundleSmallRangePositive
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId
     )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genAssetId

--- a/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelectionSpec.hs
@@ -67,6 +67,9 @@ import Cardano.CoinSelection.UTxOSelection.Gen
     ( genUTxOSelection
     , shrinkUTxOSelection
     )
+import Cardano.Wallet.Primitive.Types.AssetId.Gen
+    ( genAssetId
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -87,8 +90,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetId
-    , genTokenMap
+    ( genTokenMap
     , shrinkTokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/local-cluster/lib/Cardano/Wallet/Faucet.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Faucet.hs
@@ -61,7 +61,7 @@ import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     , nullTokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/local-cluster/lib/Cardano/Wallet/Faucet.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Faucet.hs
@@ -57,10 +57,12 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , TokenPolicyId
     , nullTokenName
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
@@ -158,12 +158,14 @@ import Cardano.Startup
 import Cardano.Wallet.Network.Ports
     ( randomUnusedTCPPorts
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( AssetId (..)
-    , TokenBundle (..)
+    ( TokenBundle (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
@@ -165,7 +165,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( AssetId (..)
     , TokenBundle (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -152,6 +152,7 @@ library
     Cardano.Wallet.Primitive.Types.Address.Gen
     Cardano.Wallet.Primitive.Types.AnyExplicitScripts
     Cardano.Wallet.Primitive.Types.AssetId
+    Cardano.Wallet.Primitive.Types.AssetId.Gen
     Cardano.Wallet.Primitive.Types.Block
     Cardano.Wallet.Primitive.Types.Block.Gen
     Cardano.Wallet.Primitive.Types.BlockSummary

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -184,6 +184,7 @@ library
     Cardano.Wallet.Primitive.Types.TokenMap
     Cardano.Wallet.Primitive.Types.TokenMap.Gen
     Cardano.Wallet.Primitive.Types.TokenMapWithScripts
+    Cardano.Wallet.Primitive.Types.TokenMetadata
     Cardano.Wallet.Primitive.Types.TokenName
     Cardano.Wallet.Primitive.Types.TokenName.Gen
     Cardano.Wallet.Primitive.Types.TokenPolicy

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -274,8 +274,8 @@ test-suite test
     Cardano.Wallet.Primitive.Types.PoolSpec
     Cardano.Wallet.Primitive.Types.RangeSpec
     Cardano.Wallet.Primitive.Types.TokenBundleSpec
+    Cardano.Wallet.Primitive.Types.TokenFingerprintSpec
     Cardano.Wallet.Primitive.Types.TokenMapSpec
-    Cardano.Wallet.Primitive.Types.TokenPolicySpec
     Cardano.Wallet.Primitive.Types.TokenQuantitySpec
     Cardano.Wallet.Primitive.Types.TxSpec
     Cardano.Wallet.Primitive.Types.UTxOSpec

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -183,6 +183,7 @@ library
     Cardano.Wallet.Primitive.Types.TokenMap
     Cardano.Wallet.Primitive.Types.TokenMap.Gen
     Cardano.Wallet.Primitive.Types.TokenMapWithScripts
+    Cardano.Wallet.Primitive.Types.TokenName
     Cardano.Wallet.Primitive.Types.TokenPolicy
     Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -188,7 +188,7 @@ library
     Cardano.Wallet.Primitive.Types.TokenName
     Cardano.Wallet.Primitive.Types.TokenName.Gen
     Cardano.Wallet.Primitive.Types.TokenPolicyId
-    Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
+    Cardano.Wallet.Primitive.Types.TokenPolicyId.Gen
     Cardano.Wallet.Primitive.Types.TokenQuantity
     Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     Cardano.Wallet.Primitive.Types.Tx

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -151,6 +151,7 @@ library
     Cardano.Wallet.Primitive.Types.Address
     Cardano.Wallet.Primitive.Types.Address.Gen
     Cardano.Wallet.Primitive.Types.AnyExplicitScripts
+    Cardano.Wallet.Primitive.Types.AssetId
     Cardano.Wallet.Primitive.Types.Block
     Cardano.Wallet.Primitive.Types.Block.Gen
     Cardano.Wallet.Primitive.Types.BlockSummary

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -180,6 +180,7 @@ library
     Cardano.Wallet.Primitive.Types.TokenBundle
     Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     Cardano.Wallet.Primitive.Types.TokenBundleMaxSize
+    Cardano.Wallet.Primitive.Types.TokenFingerprint
     Cardano.Wallet.Primitive.Types.TokenMap
     Cardano.Wallet.Primitive.Types.TokenMap.Gen
     Cardano.Wallet.Primitive.Types.TokenMapWithScripts

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -184,6 +184,7 @@ library
     Cardano.Wallet.Primitive.Types.TokenMap.Gen
     Cardano.Wallet.Primitive.Types.TokenMapWithScripts
     Cardano.Wallet.Primitive.Types.TokenName
+    Cardano.Wallet.Primitive.Types.TokenName.Gen
     Cardano.Wallet.Primitive.Types.TokenPolicy
     Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -187,7 +187,7 @@ library
     Cardano.Wallet.Primitive.Types.TokenMetadata
     Cardano.Wallet.Primitive.Types.TokenName
     Cardano.Wallet.Primitive.Types.TokenName.Gen
-    Cardano.Wallet.Primitive.Types.TokenPolicy
+    Cardano.Wallet.Primitive.Types.TokenPolicyId
     Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     Cardano.Wallet.Primitive.Types.TokenQuantity
     Cardano.Wallet.Primitive.Types.TokenQuantity.Gen

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
@@ -73,7 +73,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
@@ -70,9 +70,11 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , TokenPolicyId (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Babbage.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Babbage.hs
@@ -67,7 +67,7 @@ import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Validity
 import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Withdrawals
     ( fromLedgerWithdrawals
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.Tx

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Conway.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Conway.hs
@@ -82,7 +82,7 @@ import Cardano.Wallet.Primitive.Types.TokenMapWithScripts
     , ScriptReference (..)
     , TokenMapWithScripts
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Mint.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Mint.hs
@@ -67,7 +67,7 @@ import Cardano.Wallet.Primitive.Types.TokenMapWithScripts
     , TokenMapWithScripts (TokenMapWithScripts)
     , emptyTokenMapWithScripts
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Read.Eras

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Outputs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Outputs.hs
@@ -72,6 +72,7 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Outputs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Outputs.hs
@@ -73,7 +73,7 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenName as W
-import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
+import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as W
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Outputs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Outputs.hs
@@ -68,6 +68,7 @@ import qualified Cardano.Ledger.Crypto as SL
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Ledger
 import qualified Cardano.Wallet.Primitive.Types.Address as W
+import qualified Cardano.Wallet.Primitive.Types.AssetId as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
@@ -156,7 +157,7 @@ fromCardanoValue = uncurry TokenBundle.fromFlatList . extract
           | otherwise = internalError "negative token quantity"
 
     mkBundle assets =
-        [ (TokenBundle.AssetId (mkPolicyId p) (mkTokenName n) , mkQuantity q)
+        [ (W.AssetId (mkPolicyId p) (mkTokenName n), mkQuantity q)
         | (Cardano.AssetId p n, Cardano.Quantity q) <- assets
         ]
 

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -406,6 +406,7 @@ import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
 import qualified Cardano.Wallet.Primitive.Types.SlottingParameters as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundleMaxSize as W
+import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -389,6 +389,7 @@ import qualified Cardano.Slotting.Slot as Slotting
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Ledger
 import qualified Cardano.Wallet.Primitive.Slotting as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
+import qualified Cardano.Wallet.Primitive.Types.AssetId as W
 import qualified Cardano.Wallet.Primitive.Types.Block as W
 import qualified Cardano.Wallet.Primitive.Types.Certificates as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
@@ -1253,7 +1254,7 @@ toCardanoValue tb = Cardano.valueFromList $
     map (bimap toCardanoAssetId toQuantity) bundle
   where
     (coin, bundle) = TokenBundle.toFlatList tb
-    toCardanoAssetId (TokenBundle.AssetId pid name) =
+    toCardanoAssetId (W.AssetId pid name) =
         Cardano.AssetId (toCardanoPolicyId pid) (toCardanoAssetName name)
 
     toCardanoAssetName (W.UnsafeTokenName name) =

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -407,7 +407,7 @@ import qualified Cardano.Wallet.Primitive.Types.SlottingParameters as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundleMaxSize as W
 import qualified Cardano.Wallet.Primitive.Types.TokenName as W
-import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
+import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as W
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.SealedTx as W

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.TokenName
+    ( TokenName
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
+    ( TokenPolicyId
+    )
+import Control.DeepSeq
+    ( NFData
+    )
+import GHC.Generics
+    ( Generic
+    )
+
+-- | A combination of a token policy identifier and a token name that can be
+--   used as a compound identifier.
+--
+data AssetId = AssetId
+    { tokenPolicyId
+        :: !TokenPolicyId
+    , tokenName
+        :: !TokenName
+    }
+    deriving stock (Eq, Generic, Ord, Read, Show)
+
+instance NFData AssetId

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId/Gen.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Cardano.Wallet.Primitive.Types.AssetId.Gen
+    ( genAssetId
+    , genAssetIdLargeRange
+    , shrinkAssetId
+    , AssetIdF (..)
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenName.Gen
+    ( genTokenName
+    , genTokenNameLargeRange
+    , shrinkTokenName
+    , testTokenNames
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicyId.Gen
+    ( genTokenPolicyId
+    , genTokenPolicyIdLargeRange
+    , shrinkTokenPolicyId
+    , testTokenPolicyIds
+    )
+import Data.List
+    ( elemIndex
+    )
+import Data.Maybe
+    ( fromMaybe
+    )
+import GHC.Generics
+    ( Generic
+    )
+import Test.QuickCheck
+    ( CoArbitrary (..)
+    , Function (..)
+    , Gen
+    , functionMap
+    , variant
+    )
+import Test.QuickCheck.Extra
+    ( genSized2With
+    , shrinkInterleaved
+    )
+
+--------------------------------------------------------------------------------
+-- Asset identifiers chosen from a range that depends on the size parameter
+--------------------------------------------------------------------------------
+
+genAssetId :: Gen AssetId
+genAssetId = genSized2With AssetId genTokenPolicyId genTokenName
+
+shrinkAssetId :: AssetId -> [AssetId]
+shrinkAssetId (AssetId p t) = uncurry AssetId <$> shrinkInterleaved
+    (p, shrinkTokenPolicyId)
+    (t, shrinkTokenName)
+
+--------------------------------------------------------------------------------
+-- Asset identifiers chosen from a large range (to minimize collisions)
+--------------------------------------------------------------------------------
+
+genAssetIdLargeRange :: Gen AssetId
+genAssetIdLargeRange = AssetId
+    <$> genTokenPolicyIdLargeRange
+    <*> genTokenNameLargeRange
+
+--------------------------------------------------------------------------------
+-- Filtering functions
+--------------------------------------------------------------------------------
+
+newtype AssetIdF = AssetIdF AssetId
+    deriving (Generic, Eq, Show, Read)
+
+instance Function AssetIdF where
+    function = functionMap show read
+
+instance CoArbitrary AssetIdF where
+    coarbitrary (AssetIdF AssetId {tokenName, tokenPolicyId}) genB = do
+        let n = fromMaybe 0 (elemIndex tokenName testTokenNames)
+        let m = fromMaybe 0 (elemIndex tokenPolicyId testTokenPolicyIds)
+        variant (n + m) genB

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -89,9 +89,11 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     , Nested (..)
     , TokenMap
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
-    , TokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -17,9 +17,8 @@
 --
 module Cardano.Wallet.Primitive.Types.TokenBundle
     (
-    -- * Types
+    -- * Type
       TokenBundle (..)
-    , AssetId (..)
 
     -- * Construction
     , empty
@@ -79,12 +78,14 @@ import Prelude hiding
 import Algebra.PartialOrd
     ( PartialOrd (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
-    , Flat (..)
+    ( Flat (..)
     , Lexicographic (..)
     , Nested (..)
     , TokenMap

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -92,7 +92,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenFingerprint.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenFingerprint.hs
@@ -20,7 +20,7 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (UnsafeTokenPolicyId)
     )
 import Codec.Binary.Bech32.TH

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenFingerprint.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenFingerprint.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Wallet.Primitive.Types.TokenFingerprint
+    ( TokenFingerprint (..)
+    , mkTokenFingerprint
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenName
+    ( TokenName (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (UnsafeTokenPolicyId)
+    )
+import Codec.Binary.Bech32.TH
+    ( humanReadablePart
+    )
+import Control.DeepSeq
+    ( NFData
+    )
+import Crypto.Hash
+    ( hash
+    )
+import Crypto.Hash.Algorithms
+    ( Blake2b_160
+    )
+import Data.ByteArray
+    ( convert
+    )
+import Data.Function
+    ( (&)
+    )
+import Data.Hashable
+    ( Hashable
+    )
+import Data.Text
+    ( Text
+    )
+import Data.Text.Class
+    ( FromText (..)
+    , TextDecodingError (..)
+    , ToText (..)
+    )
+import GHC.Generics
+    ( Generic
+    )
+import Quiet
+    ( Quiet (..)
+    )
+
+import qualified Codec.Binary.Bech32 as Bech32
+import qualified Data.ByteString as BS
+
+newtype TokenFingerprint =
+    UnsafeTokenFingerprint { unTokenFingerprint :: Text }
+    deriving stock (Eq, Ord, Generic)
+    deriving (Read, Show) via (Quiet TokenFingerprint)
+    deriving anyclass Hashable
+
+instance NFData TokenFingerprint
+
+-- | Construct a fingerprint from a 'TokenPolicyId' and 'TokenName'. The
+-- fingerprint is not necessarily unique, but can be used in user-facing
+-- interfaces as a comparison mechanism.
+mkTokenFingerprint :: TokenPolicyId -> TokenName -> TokenFingerprint
+mkTokenFingerprint (UnsafeTokenPolicyId (Hash p)) (UnsafeTokenName n)
+    = (p <> n)
+    & convert . hash @_ @Blake2b_160
+    & Bech32.encodeLenient tokenFingerprintHrp . Bech32.dataPartFromBytes
+    & UnsafeTokenFingerprint
+
+tokenFingerprintHrp :: Bech32.HumanReadablePart
+tokenFingerprintHrp = [humanReadablePart|asset|]
+
+instance ToText TokenFingerprint where
+    toText = unTokenFingerprint
+
+instance FromText TokenFingerprint where
+    fromText = tokenFingerprintFromText
+
+tokenFingerprintFromText :: Text -> Either TextDecodingError TokenFingerprint
+tokenFingerprintFromText txt = case Bech32.decodeLenient txt of
+    Left{} -> Left invalidBech32String
+    Right (hrp, dp)
+        | hrp /= tokenFingerprintHrp -> Left unrecognizedHrp
+        | otherwise -> case BS.length <$> Bech32.dataPartToBytes dp of
+            Just 20 -> Right (UnsafeTokenFingerprint txt)
+            _ -> Left invalidDatapart
+  where
+    invalidBech32String = TextDecodingError
+        "A 'TokenFingerprint' must be a valid bech32-encoded string."
+    unrecognizedHrp = TextDecodingError
+        "Expected 'asset' as a human-readable part, but got something else."
+    invalidDatapart = TextDecodingError
+        "Expected a Blake2b-160 digest as data payload, but got something else."

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -97,7 +97,7 @@ import Cardano.Numeric.Util
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -20,9 +20,8 @@
 --
 module Cardano.Wallet.Primitive.Types.TokenMap
     (
-    -- * Types
+    -- * Type
       TokenMap
-    , AssetId (..)
 
     -- * Construction
     , empty
@@ -93,6 +92,9 @@ import Algebra.PartialOrd
     )
 import Cardano.Numeric.Util
     ( equipartitionNatural
+    )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (AssetId)
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
@@ -243,19 +245,6 @@ newtype TokenMap = TokenMap
 instance NFData TokenMap
 instance Hashable TokenMap where
     hashWithSalt = hashUsing toNestedList
-
--- | A combination of a token policy identifier and a token name that can be
---   used as a compound identifier.
---
-data AssetId = AssetId
-    { tokenPolicyId
-        :: !TokenPolicyId
-    , tokenName
-        :: !TokenName
-    }
-    deriving stock (Eq, Generic, Ord, Read, Show)
-
-instance NFData AssetId
 
 --------------------------------------------------------------------------------
 -- Ordering

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -94,9 +94,11 @@ import Algebra.PartialOrd
 import Cardano.Numeric.Util
     ( equipartitionNatural
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
-    , TokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
@@ -19,14 +19,16 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..)
     , TokenMap
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
+import Cardano.Wallet.Primitive.Types.TokenName.Gen
     ( genTokenName
     , genTokenNameLargeRange
-    , genTokenPolicyId
-    , genTokenPolicyIdLargeRange
     , shrinkTokenName
-    , shrinkTokenPolicyId
     , testTokenNames
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
+    ( genTokenPolicyId
+    , genTokenPolicyIdLargeRange
+    , shrinkTokenPolicyId
     , testTokenPolicyIds
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
@@ -15,9 +15,11 @@ module Cardano.Wallet.Primitive.Types.TokenMap.Gen
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.TokenMap
+import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
-    , TokenMap
+    )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( TokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenName.Gen
     ( genTokenName

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
@@ -1,37 +1,19 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE NamedFieldPuns #-}
-
 module Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetId
-    , genAssetIdLargeRange
-    , genTokenMap
+    ( genTokenMap
     , genTokenMapSmallRange
-    , shrinkAssetId
     , shrinkTokenMap
-    , AssetIdF (..)
     , genTokenMapPartition
     , genTokenMapPartitionNonNull
     ) where
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.AssetId
-    ( AssetId (..)
+import Cardano.Wallet.Primitive.Types.AssetId.Gen
+    ( genAssetId
+    , shrinkAssetId
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap
-    )
-import Cardano.Wallet.Primitive.Types.TokenName.Gen
-    ( genTokenName
-    , genTokenNameLargeRange
-    , shrinkTokenName
-    , testTokenNames
-    )
-import Cardano.Wallet.Primitive.Types.TokenPolicyId.Gen
-    ( genTokenPolicyId
-    , genTokenPolicyIdLargeRange
-    , shrinkTokenPolicyId
-    , testTokenPolicyIds
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)
@@ -45,61 +27,28 @@ import Control.Monad
     ( replicateM
     )
 import Data.List
-    ( elemIndex
-    , transpose
+    ( transpose
     )
 import Data.List.NonEmpty
     ( NonEmpty
-    )
-import Data.Maybe
-    ( fromMaybe
-    )
-import GHC.Generics
-    ( Generic
     )
 import Safe
     ( fromJustNote
     )
 import Test.QuickCheck
-    ( CoArbitrary (..)
-    , Function (..)
-    , Gen
+    ( Gen
     , choose
-    , functionMap
     , oneof
     , shrinkList
     , sized
-    , variant
     )
 import Test.QuickCheck.Extra
-    ( genSized2With
-    , shrinkInterleaved
+    ( shrinkInterleaved
     )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
-
---------------------------------------------------------------------------------
--- Asset identifiers chosen from a range that depends on the size parameter
---------------------------------------------------------------------------------
-
-genAssetId :: Gen AssetId
-genAssetId = genSized2With AssetId genTokenPolicyId genTokenName
-
-shrinkAssetId :: AssetId -> [AssetId]
-shrinkAssetId (AssetId p t) = uncurry AssetId <$> shrinkInterleaved
-    (p, shrinkTokenPolicyId)
-    (t, shrinkTokenName)
-
---------------------------------------------------------------------------------
--- Asset identifiers chosen from a large range (to minimize collisions)
---------------------------------------------------------------------------------
-
-genAssetIdLargeRange :: Gen AssetId
-genAssetIdLargeRange = AssetId
-    <$> genTokenPolicyIdLargeRange
-    <*> genTokenNameLargeRange
 
 --------------------------------------------------------------------------------
 -- Token maps with assets and quantities chosen from ranges that depend on the
@@ -141,22 +90,6 @@ shrinkTokenMap
     shrinkAssetQuantity (a, q) = shrinkInterleaved
         (a, shrinkAssetId)
         (q, shrinkTokenQuantity)
-
---------------------------------------------------------------------------------
--- Filtering functions
---------------------------------------------------------------------------------
-
-newtype AssetIdF = AssetIdF AssetId
-    deriving (Generic, Eq, Show, Read)
-
-instance Function AssetIdF where
-    function = functionMap show read
-
-instance CoArbitrary AssetIdF where
-    coarbitrary (AssetIdF AssetId{tokenName, tokenPolicyId}) genB = do
-        let n = fromMaybe 0 (elemIndex tokenName testTokenNames)
-        let m = fromMaybe 0 (elemIndex tokenPolicyId testTokenPolicyIds)
-        variant (n+m) genB
 
 --------------------------------------------------------------------------------
 -- Partitioning token maps

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
@@ -25,7 +25,7 @@ import Cardano.Wallet.Primitive.Types.TokenName.Gen
     , shrinkTokenName
     , testTokenNames
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
+import Cardano.Wallet.Primitive.Types.TokenPolicyId.Gen
     ( genTokenPolicyId
     , genTokenPolicyIdLargeRange
     , shrinkTokenPolicyId

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMapWithScripts.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMapWithScripts.hs
@@ -23,7 +23,7 @@ import Cardano.Address.Script
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMetadata.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMetadata.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module Cardano.Wallet.Primitive.Types.TokenMetadata
+    ( AssetMetadata (..)
+    , AssetURL (..)
+    , AssetLogo (..)
+    , AssetDecimals (..)
+    , validateMetadataDecimals
+    , validateMetadataName
+    , validateMetadataTicker
+    , validateMetadataDescription
+    , validateMetadataURL
+    , validateMetadataLogo
+    ) where
+
+import Prelude
+
+import Control.DeepSeq
+    ( NFData
+    )
+import Control.Monad
+    ( (>=>)
+    )
+import Data.Bifunctor
+    ( first
+    )
+import Data.ByteString
+    ( ByteString
+    )
+import Data.Text
+    ( Text
+    )
+import Data.Text.Class
+    ( FromText (..)
+    , TextDecodingError (..)
+    , ToText (..)
+    )
+import GHC.Generics
+    ( Generic
+    )
+import Network.URI
+    ( URI
+    , parseAbsoluteURI
+    , uriScheme
+    )
+import Quiet
+    ( Quiet (..)
+    )
+
+import qualified Data.ByteString as BS
+import qualified Data.Text as T
+
+-- | Information about an asset, from a source external to the chain.
+data AssetMetadata = AssetMetadata
+    { name :: Text
+    , description :: Text
+    , ticker :: Maybe Text
+    , url :: Maybe AssetURL
+    , logo :: Maybe AssetLogo
+    , decimals :: Maybe AssetDecimals
+    } deriving stock (Eq, Ord, Generic)
+    deriving (Show) via (Quiet AssetMetadata)
+
+instance NFData AssetMetadata
+
+-- | Specify an asset logo as an image data payload
+newtype AssetLogo = AssetLogo
+    { unAssetLogo :: ByteString
+    } deriving (Eq, Ord, Generic)
+    deriving (Show) via (Quiet AssetLogo)
+
+instance NFData AssetLogo
+
+-- | The validated URL for the asset.
+newtype AssetURL = AssetURL
+    { unAssetURL :: URI
+    } deriving (Eq, Ord, Generic)
+    deriving (Show) via (Quiet AssetURL)
+
+instance NFData AssetURL
+
+instance ToText AssetURL where
+    toText = T.pack . show . unAssetURL
+
+instance FromText AssetURL where
+    fromText = first TextDecodingError . validateMetadataURL
+
+newtype AssetDecimals = AssetDecimals
+    { unAssetDecimals :: Int
+    } deriving (Eq, Ord, Generic)
+    deriving (Show) via (Quiet AssetDecimals)
+
+instance NFData AssetDecimals
+
+instance ToText AssetDecimals where
+    toText = T.pack . show . unAssetDecimals
+
+instance FromText AssetDecimals where
+    fromText t = do
+        unvalidated <- AssetDecimals <$> fromText t
+        first TextDecodingError $ validateMetadataDecimals unvalidated
+
+validateMinLength :: Int -> Text -> Either String Text
+validateMinLength n text
+    | len >= n = Right text
+    | otherwise = Left $ mconcat
+        [ "Length must be at least "
+        , show n
+        , " characters, got "
+        , show len
+        ]
+  where
+    len = T.length text
+
+validateMaxLength :: Int -> Text -> Either String Text
+validateMaxLength n text
+    | len <= n = Right text
+    | otherwise = Left $ mconcat
+        [ "Length must be no more than "
+        , show n
+        , " characters, got "
+        , show len
+        ]
+  where
+    len = T.length text
+
+validateMetadataName :: Text -> Either String Text
+validateMetadataName = validateMinLength 1 >=> validateMaxLength 50
+
+validateMetadataTicker :: Text -> Either String Text
+validateMetadataTicker = validateMinLength 2 >=> validateMaxLength 6
+
+validateMetadataDescription :: Text -> Either String Text
+validateMetadataDescription = validateMaxLength 500
+
+validateMetadataURL :: Text -> Either String AssetURL
+validateMetadataURL = fmap AssetURL .
+    (validateMaxLength 250 >=> validateURI >=> validateHttps)
+  where
+    validateURI = maybe (Left "Not an absolute URI") Right
+        . parseAbsoluteURI
+        . T.unpack
+    validateHttps u@(uriScheme -> scheme)
+        | scheme == "https:" = Right u
+        | otherwise = Left $ "Scheme must be https: but got " ++ scheme
+
+validateMetadataLogo :: AssetLogo -> Either String AssetLogo
+validateMetadataLogo logo
+    | len <= maxLen = Right logo
+    | otherwise = Left $ mconcat
+        [ "Length must be no more than "
+        , show maxLen
+        , " bytes, got "
+        , show len
+        ]
+  where
+    len = BS.length $ unAssetLogo logo
+    maxLen = 65536
+
+validateMetadataDecimals :: AssetDecimals -> Either String AssetDecimals
+validateMetadataDecimals (AssetDecimals n)
+    | n >= 0 && n <= 255 =
+        Right $ AssetDecimals n
+    | otherwise =
+        Left "Decimal value must be between [0, 255] inclusive."

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenName.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenName.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module Cardano.Wallet.Primitive.Types.TokenName
+    ( TokenName (..)
+    , mkTokenName
+    , nullTokenName
+    , tokenNameMaxLength
+    ) where
+
+import Prelude
+
+import Control.DeepSeq
+    ( NFData
+    )
+import Control.Monad
+    ( (>=>)
+    )
+import Data.Aeson
+    ( FromJSON (..)
+    , ToJSON (..)
+    )
+import Data.Bifunctor
+    ( first
+    )
+import Data.ByteArray.Encoding
+    ( Base (Base16)
+    , convertFromBase
+    , convertToBase
+    )
+import Data.ByteString
+    ( ByteString
+    )
+import Data.Hashable
+    ( Hashable
+    )
+import Data.Text.Class
+    ( FromText (..)
+    , TextDecodingError (..)
+    , ToText (..)
+    )
+import Fmt
+    ( Buildable (..)
+    )
+import GHC.Generics
+    ( Generic
+    )
+import Quiet
+    ( Quiet (..)
+    )
+
+import qualified Data.ByteString as BS
+import qualified Data.Text.Encoding as T
+
+-- | Token names, defined by the monetary policy script.
+newtype TokenName =
+    -- | Construct a 'TokenName' without any validation.
+    UnsafeTokenName { unTokenName :: ByteString }
+    deriving stock (Eq, Ord, Generic)
+    deriving (Read, Show) via (Quiet TokenName)
+    deriving anyclass Hashable
+
+-- | Construct a 'TokenName', validating that the length does not exceed
+--   'tokenNameMaxLength'.
+--
+mkTokenName :: ByteString -> Either String TokenName
+mkTokenName bs
+    | BS.length bs <= tokenNameMaxLength = Right $ UnsafeTokenName bs
+    | otherwise = Left $ "TokenName length " ++ show (BS.length bs)
+        ++ " exceeds maximum of " ++ show tokenNameMaxLength
+
+-- | The empty asset name.
+--
+-- Asset names may be empty, where a monetary policy script only mints a single
+-- asset, or where one asset should be considered as the "default" token for the
+-- policy.
+--
+nullTokenName :: TokenName
+nullTokenName = UnsafeTokenName ""
+
+-- | The maximum length of a valid token name.
+--
+tokenNameMaxLength :: Int
+tokenNameMaxLength = 32
+
+instance NFData TokenName
+
+instance Buildable TokenName where
+    build = build . toText
+
+instance FromJSON TokenName where
+    parseJSON = parseJSON >=> either (fail . show) pure . fromText
+
+instance ToJSON TokenName where
+    toJSON = toJSON . toText
+
+instance ToText TokenName where
+    toText = T.decodeLatin1 . convertToBase Base16 . unTokenName
+
+instance FromText TokenName where
+    fromText = first TextDecodingError
+        . either (Left . ("TokenName is not hex-encoded: " ++)) mkTokenName
+        . convertFromBase Base16
+        . T.encodeUtf8

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenName/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenName/Gen.hs
@@ -1,0 +1,60 @@
+module Cardano.Wallet.Primitive.Types.TokenName.Gen
+    (
+    -- * Generators and shrinkers
+      genTokenName
+    , genTokenNameLargeRange
+    , shrinkTokenName
+
+    -- * Test values
+    , testTokenNames
+
+    -- * Creation of test values
+    , mkTokenName
+
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.TokenName
+    ( TokenName (..)
+    )
+import Test.QuickCheck
+    ( Gen
+    , elements
+    , sized
+    , vector
+    )
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B8
+
+--------------------------------------------------------------------------------
+-- Token names chosen from a range that depends on the size parameter
+--------------------------------------------------------------------------------
+
+genTokenName :: Gen TokenName
+genTokenName = sized $ \n -> elements $ take (max 1 n) testTokenNames
+
+shrinkTokenName :: TokenName -> [TokenName]
+shrinkTokenName i
+    | i == simplest = []
+    | otherwise = [simplest]
+  where
+    simplest = head testTokenNames
+
+--------------------------------------------------------------------------------
+-- Token names chosen from a large range (to minimize the risk of collisions)
+--------------------------------------------------------------------------------
+
+genTokenNameLargeRange :: Gen TokenName
+genTokenNameLargeRange = UnsafeTokenName . BS.pack <$> vector 32
+
+--------------------------------------------------------------------------------
+-- Internal utilities
+--------------------------------------------------------------------------------
+
+testTokenNames :: [TokenName]
+testTokenNames = mkTokenName <$> ['A' .. 'Z']
+
+mkTokenName :: Char -> TokenName
+mkTokenName = UnsafeTokenName . B8.snoc "Token"

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
@@ -2,26 +2,9 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Cardano.Wallet.Primitive.Types.TokenPolicy
-    (
-      -- * Token Policies
-      TokenPolicyId (..)
-
-      -- * Token Metadata
-    , AssetMetadata (..)
-    , AssetURL (..)
-    , AssetLogo (..)
-    , AssetDecimals (..)
-    , validateMetadataDecimals
-    , validateMetadataName
-    , validateMetadataTicker
-    , validateMetadataDescription
-    , validateMetadataURL
-    , validateMetadataLogo
+    ( TokenPolicyId (..)
     ) where
 
 import Prelude
@@ -39,21 +22,11 @@ import Data.Aeson
     ( FromJSON (..)
     , ToJSON (..)
     )
-import Data.Bifunctor
-    ( first
-    )
-import Data.ByteString
-    ( ByteString
-    )
 import Data.Hashable
     ( Hashable
     )
-import Data.Text
-    ( Text
-    )
 import Data.Text.Class
     ( FromText (..)
-    , TextDecodingError (..)
     , ToText (..)
     )
 import Fmt
@@ -62,17 +35,9 @@ import Fmt
 import GHC.Generics
     ( Generic
     )
-import Network.URI
-    ( URI
-    , parseAbsoluteURI
-    , uriScheme
-    )
 import Quiet
     ( Quiet (..)
     )
-
-import qualified Data.ByteString as BS
-import qualified Data.Text as T
 
 -- | Token policy identifiers, represented by the hash of the monetary policy
 -- script.
@@ -99,117 +64,3 @@ instance ToText TokenPolicyId where
 
 instance FromText TokenPolicyId where
     fromText = fmap UnsafeTokenPolicyId . fromText
-
--- | Information about an asset, from a source external to the chain.
-data AssetMetadata = AssetMetadata
-    { name :: Text
-    , description :: Text
-    , ticker :: Maybe Text
-    , url :: Maybe AssetURL
-    , logo :: Maybe AssetLogo
-    , decimals :: Maybe AssetDecimals
-    } deriving stock (Eq, Ord, Generic)
-    deriving (Show) via (Quiet AssetMetadata)
-
-instance NFData AssetMetadata
-
--- | Specify an asset logo as an image data payload
-newtype AssetLogo = AssetLogo
-    { unAssetLogo :: ByteString
-    } deriving (Eq, Ord, Generic)
-    deriving (Show) via (Quiet AssetLogo)
-
-instance NFData AssetLogo
-
--- | The validated URL for the asset.
-newtype AssetURL = AssetURL
-    { unAssetURL :: URI
-    } deriving (Eq, Ord, Generic)
-    deriving (Show) via (Quiet AssetURL)
-
-instance NFData AssetURL
-
-instance ToText AssetURL where
-    toText = T.pack . show . unAssetURL
-
-instance FromText AssetURL where
-    fromText = first TextDecodingError . validateMetadataURL
-
-newtype AssetDecimals = AssetDecimals
-    { unAssetDecimals :: Int
-    } deriving (Eq, Ord, Generic)
-    deriving (Show) via (Quiet AssetDecimals)
-
-instance NFData AssetDecimals
-
-instance ToText AssetDecimals where
-    toText = T.pack . show . unAssetDecimals
-
-instance FromText AssetDecimals where
-    fromText t = do
-        unvalidated <- AssetDecimals <$> fromText t
-        first TextDecodingError $ validateMetadataDecimals unvalidated
-
-validateMinLength :: Int -> Text -> Either String Text
-validateMinLength n text
-    | len >= n = Right text
-    | otherwise = Left $ mconcat
-        [ "Length must be at least "
-        , show n
-        , " characters, got "
-        , show len
-        ]
-  where
-    len = T.length text
-
-validateMaxLength :: Int -> Text -> Either String Text
-validateMaxLength n text
-    | len <= n = Right text
-    | otherwise = Left $ mconcat
-        [ "Length must be no more than "
-        , show n
-        , " characters, got "
-        , show len
-        ]
-  where
-    len = T.length text
-
-validateMetadataName :: Text -> Either String Text
-validateMetadataName = validateMinLength 1 >=> validateMaxLength 50
-
-validateMetadataTicker :: Text -> Either String Text
-validateMetadataTicker = validateMinLength 2 >=> validateMaxLength 6
-
-validateMetadataDescription :: Text -> Either String Text
-validateMetadataDescription = validateMaxLength 500
-
-validateMetadataURL :: Text -> Either String AssetURL
-validateMetadataURL = fmap AssetURL .
-    (validateMaxLength 250 >=> validateURI >=> validateHttps)
-  where
-    validateURI = maybe (Left "Not an absolute URI") Right
-        . parseAbsoluteURI
-        . T.unpack
-    validateHttps u@(uriScheme -> scheme)
-        | scheme == "https:" = Right u
-        | otherwise = Left $ "Scheme must be https: but got " ++ scheme
-
-validateMetadataLogo :: AssetLogo -> Either String AssetLogo
-validateMetadataLogo logo
-    | len <= maxLen = Right logo
-    | otherwise = Left $ mconcat
-        [ "Length must be no more than "
-        , show maxLen
-        , " bytes, got "
-        , show len
-        ]
-  where
-    len = BS.length $ unAssetLogo logo
-    maxLen = 65536
-
-validateMetadataDecimals :: AssetDecimals -> Either String AssetDecimals
-validateMetadataDecimals (AssetDecimals n)
-    | n >= 0 && n <= 255 =
-        Right $ AssetDecimals n
-    | otherwise =
-        Left "Decimal value must be between [0, 255] inclusive."

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
@@ -4,18 +4,12 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Cardano.Wallet.Primitive.Types.TokenPolicy
     (
       -- * Token Policies
       TokenPolicyId (..)
-
-      -- * Token Fingerprints
-    , TokenFingerprint (..)
-    , mkTokenFingerprint
 
       -- * Token Metadata
     , AssetMetadata (..)
@@ -35,23 +29,11 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
-    )
-import Codec.Binary.Bech32.TH
-    ( humanReadablePart
-    )
 import Control.DeepSeq
     ( NFData
     )
 import Control.Monad
     ( (>=>)
-    )
-import Crypto.Hash
-    ( hash
-    )
-import Crypto.Hash.Algorithms
-    ( Blake2b_160
     )
 import Data.Aeson
     ( FromJSON (..)
@@ -60,14 +42,8 @@ import Data.Aeson
 import Data.Bifunctor
     ( first
     )
-import Data.ByteArray
-    ( convert
-    )
 import Data.ByteString
     ( ByteString
-    )
-import Data.Function
-    ( (&)
     )
 import Data.Hashable
     ( Hashable
@@ -95,7 +71,6 @@ import Quiet
     ( Quiet (..)
     )
 
-import qualified Codec.Binary.Bech32 as Bech32
 import qualified Data.ByteString as BS
 import qualified Data.Text as T
 
@@ -124,49 +99,6 @@ instance ToText TokenPolicyId where
 
 instance FromText TokenPolicyId where
     fromText = fmap UnsafeTokenPolicyId . fromText
-
-newtype TokenFingerprint =
-    UnsafeTokenFingerprint { unTokenFingerprint :: Text }
-    deriving stock (Eq, Ord, Generic)
-    deriving (Read, Show) via (Quiet TokenFingerprint)
-    deriving anyclass Hashable
-
-instance NFData TokenFingerprint
-
--- | Construct a fingerprint from a 'TokenPolicyId' and 'TokenName'. The
--- fingerprint is not necessarily unique, but can be used in user-facing
--- interfaces as a comparison mechanism.
-mkTokenFingerprint :: TokenPolicyId -> TokenName -> TokenFingerprint
-mkTokenFingerprint (UnsafeTokenPolicyId (Hash p)) (UnsafeTokenName n)
-    = (p <> n)
-    & convert . hash @_ @Blake2b_160
-    & Bech32.encodeLenient tokenFingerprintHrp . Bech32.dataPartFromBytes
-    & UnsafeTokenFingerprint
-
-tokenFingerprintHrp :: Bech32.HumanReadablePart
-tokenFingerprintHrp = [humanReadablePart|asset|]
-
-instance ToText TokenFingerprint where
-    toText = unTokenFingerprint
-
-instance FromText TokenFingerprint where
-    fromText = tokenFingerprintFromText
-
-tokenFingerprintFromText :: Text -> Either TextDecodingError TokenFingerprint
-tokenFingerprintFromText txt = case Bech32.decodeLenient txt of
-    Left{} -> Left invalidBech32String
-    Right (hrp, dp)
-        | hrp /= tokenFingerprintHrp -> Left unrecognizedHrp
-        | otherwise -> case BS.length <$> Bech32.dataPartToBytes dp of
-            Just 20 -> Right (UnsafeTokenFingerprint txt)
-            _ -> Left invalidDatapart
-  where
-    invalidBech32String = TextDecodingError
-        "A 'TokenFingerprint' must be a valid bech32-encoded string."
-    unrecognizedHrp = TextDecodingError
-        "Expected 'asset' as a human-readable part, but got something else."
-    invalidDatapart = TextDecodingError
-        "Expected a Blake2b-160 digest as data payload, but got something else."
 
 -- | Information about an asset, from a source external to the chain.
 data AssetMetadata = AssetMetadata

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
@@ -18,7 +18,7 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Data.Either

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
@@ -23,9 +23,11 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , TokenPolicyId (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..)
     )
 import Data.Either
     ( fromRight

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
@@ -1,19 +1,14 @@
 module Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     (
     -- * Generators and shrinkers
-      genTokenName
-    , genTokenNameLargeRange
-    , genTokenPolicyId
+      genTokenPolicyId
     , genTokenPolicyIdLargeRange
-    , shrinkTokenName
     , shrinkTokenPolicyId
 
     -- * Test values
-    , testTokenNames
     , testTokenPolicyIds
 
     -- * Creation of test values
-    , mkTokenName
     , mkTokenPolicyId
 
     ) where
@@ -22,9 +17,6 @@ import Prelude
 
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenPolicyId (..)
@@ -43,29 +35,7 @@ import Test.QuickCheck
     )
 
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
-
---------------------------------------------------------------------------------
--- Token names chosen from a range that depends on the size parameter
---------------------------------------------------------------------------------
-
-genTokenName :: Gen TokenName
-genTokenName = sized $ \n -> elements $ take (max 1 n) testTokenNames
-
-shrinkTokenName :: TokenName -> [TokenName]
-shrinkTokenName i
-    | i == simplest = []
-    | otherwise = [simplest]
-  where
-    simplest = head testTokenNames
-
---------------------------------------------------------------------------------
--- Token names chosen from a large range (to minimize the risk of collisions)
---------------------------------------------------------------------------------
-
-genTokenNameLargeRange :: Gen TokenName
-genTokenNameLargeRange = UnsafeTokenName . BS.pack <$> vector 32
 
 --------------------------------------------------------------------------------
 -- Token policy identifiers chosen from a range that depends on the size
@@ -94,14 +64,8 @@ genTokenPolicyIdLargeRange = UnsafeTokenPolicyId . Hash . BS.pack <$> vector 28
 -- Internal utilities
 --------------------------------------------------------------------------------
 
-testTokenNames :: [TokenName]
-testTokenNames = mkTokenName <$> ['A' .. 'Z']
-
 testTokenPolicyIds :: [TokenPolicyId]
 testTokenPolicyIds = mkTokenPolicyId <$> mkTokenPolicyIdValidChars
-
-mkTokenName :: Char -> TokenName
-mkTokenName = UnsafeTokenName . B8.snoc "Token"
 
 -- The set of characters that can be passed to the 'mkTokenPolicyId' function.
 --

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicyId.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicyId.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 
-module Cardano.Wallet.Primitive.Types.TokenPolicy
+module Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     ) where
 

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicyId/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenPolicyId/Gen.hs
@@ -1,4 +1,4 @@
-module Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
+module Cardano.Wallet.Primitive.Types.TokenPolicyId.Gen
     (
     -- * Generators and shrinkers
       genTokenPolicyId

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
@@ -49,6 +49,9 @@ import Cardano.Api
     )
 import Cardano.Wallet.Orphans
     ()
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -57,9 +60,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn (..)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxOut.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxOut.hs
@@ -32,6 +32,9 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -39,8 +42,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId
-    , Lexicographic (..)
+    ( Lexicographic (..)
     )
 import Control.DeepSeq
     ( NFData (..)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxOut/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxOut/Gen.hs
@@ -18,6 +18,9 @@ import Cardano.Wallet.Primitive.Types.Address.Gen
     ( genAddress
     , shrinkAddress
     )
+import Cardano.Wallet.Primitive.Types.AssetId.Gen
+    ( genAssetIdLargeRange
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -27,9 +30,6 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange
     , shrinkTokenBundleSmallRange
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetIdLargeRange
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -66,14 +66,14 @@ import Prelude hiding
 import Cardano.Wallet.Primitive.Types.Address
     ( Address
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
@@ -35,11 +35,11 @@ import Cardano.Wallet.Primitive.Types.TokenName
 import Cardano.Wallet.Primitive.Types.TokenName.Gen
     ( genTokenNameLargeRange
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
-    ( genTokenPolicyIdLargeRange
-    )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicyId.Gen
+    ( genTokenPolicyIdLargeRange
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
@@ -32,12 +32,14 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
     )
+import Cardano.Wallet.Primitive.Types.TokenName.Gen
+    ( genTokenNameLargeRange
+    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
-    ( genTokenNameLargeRange
-    , genTokenPolicyIdLargeRange
+    ( genTokenPolicyIdLargeRange
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
@@ -29,9 +29,11 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange
     , shrinkTokenBundleSmallRange
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
-    , TokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     ( genTokenNameLargeRange

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
@@ -35,11 +35,11 @@ import Cardano.Wallet.Primitive.Types.TokenName
 import Cardano.Wallet.Primitive.Types.TokenName.Gen
     ( genTokenNameLargeRange
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( TokenPolicyId
-    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     ( genTokenPolicyIdLargeRange
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenFingerprintSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenFingerprintSpec.hs
@@ -14,7 +14,7 @@ import Cardano.Wallet.Primitive.Types.TokenFingerprint
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Unsafe

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenFingerprintSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenFingerprintSpec.hs
@@ -1,4 +1,4 @@
-module Cardano.Wallet.Primitive.Types.TokenPolicySpec
+module Cardano.Wallet.Primitive.Types.TokenFingerprintSpec
     ( spec
     ) where
 

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -25,6 +25,12 @@ import Cardano.Numeric.Util
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId.Gen
+    ( AssetIdF (..)
+    , genAssetId
+    , genAssetIdLargeRange
+    , shrinkAssetId
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
@@ -35,12 +41,8 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     , TokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( AssetIdF (..)
-    , genAssetId
-    , genAssetIdLargeRange
-    , genTokenMapPartition
+    ( genTokenMapPartition
     , genTokenMapSmallRange
-    , shrinkAssetId
     , shrinkTokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenName

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -41,10 +41,12 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     , shrinkAssetId
     , shrinkTokenMap
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
-    , TokenPolicyId
     , mkTokenName
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     ( genTokenName

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -49,12 +49,12 @@ import Cardano.Wallet.Primitive.Types.TokenName.Gen
     ( genTokenName
     , shrinkTokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
-    ( genTokenPolicyId
-    , shrinkTokenPolicyId
-    )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicyId.Gen
+    ( genTokenPolicyId
+    , shrinkTokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -49,12 +49,12 @@ import Cardano.Wallet.Primitive.Types.TokenName.Gen
     ( genTokenName
     , shrinkTokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( TokenPolicyId
-    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     ( genTokenPolicyId
     , shrinkTokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -45,13 +45,15 @@ import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
     , mkTokenName
     )
+import Cardano.Wallet.Primitive.Types.TokenName.Gen
+    ( genTokenName
+    , shrinkTokenName
+    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
-    ( genTokenName
-    , genTokenPolicyId
-    , shrinkTokenName
+    ( genTokenPolicyId
     , shrinkTokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -22,12 +22,14 @@ import Prelude
 import Cardano.Numeric.Util
     ( inAscendingPartialOrder
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
-    , Flat (..)
+    ( Flat (..)
     , Lexicographic (..)
     , Nested (..)
     , TokenMap

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenPolicySpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenPolicySpec.hs
@@ -7,9 +7,11 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
+import Cardano.Wallet.Primitive.Types.TokenName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenFingerprint (..)
-    , TokenName (..)
     , TokenPolicyId (..)
     , mkTokenFingerprint
     )

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenPolicySpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenPolicySpec.hs
@@ -7,13 +7,15 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
+import Cardano.Wallet.Primitive.Types.TokenFingerprint
+    ( TokenFingerprint (..)
+    , mkTokenFingerprint
+    )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( TokenFingerprint (..)
-    , TokenPolicyId (..)
-    , mkTokenFingerprint
+    ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TxSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TxSpec.hs
@@ -17,11 +17,11 @@ module Cardano.Wallet.Primitive.Types.TxSpec
 
 import Prelude
 
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genAssetId

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TxSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TxSpec.hs
@@ -30,7 +30,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TxSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TxSpec.hs
@@ -27,9 +27,11 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genAssetId
     , shrinkAssetId
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , TokenPolicyId (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TxSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TxSpec.hs
@@ -20,12 +20,12 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap.Gen
+import Cardano.Wallet.Primitive.Types.AssetId.Gen
     ( genAssetId
     , shrinkAssetId
+    )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -22,12 +22,12 @@ import Cardano.Wallet.Primitive.Types.Address.Gen
     ( Parity (..)
     , addressParity
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     , mockHash
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genAssetId

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -25,13 +25,13 @@ import Cardano.Wallet.Primitive.Types.Address.Gen
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId.Gen
+    ( genAssetId
+    , shrinkAssetId
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     , mockHash
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetId
-    , shrinkAssetId
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -33,9 +33,11 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genAssetId
     , shrinkAssetId
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , TokenPolicyId (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn (..)

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -36,7 +36,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn

--- a/lib/wallet/api/http/Cardano/Wallet/Api.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api.hs
@@ -286,7 +286,7 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.Tx

--- a/lib/wallet/api/http/Cardano/Wallet/Api.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api.hs
@@ -283,9 +283,11 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
-    , TokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -600,11 +600,13 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     , TokenMap
     , fromFlatList
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , TokenPolicyId (..)
     , nullTokenName
     , tokenNameMaxLength
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -605,7 +605,7 @@ import Cardano.Wallet.Primitive.Types.TokenName
     , nullTokenName
     , tokenNameMaxLength
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -582,6 +582,9 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     , AddressState (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -596,8 +599,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
-    , TokenMap
+    ( TokenMap
     , fromFlatList
     )
 import Cardano.Wallet.Primitive.Types.TokenName

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Link.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Link.hs
@@ -166,10 +166,12 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
-    , TokenPolicyId
     , nullTokenName
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId
     )
 import Data.Function
     ( (&)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Link.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Link.hs
@@ -170,7 +170,7 @@ import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
     , nullTokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
     )
 import Data.Function

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -646,6 +646,7 @@ import qualified Cardano.Address.Script as CA
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet.Address.Derivation as AD
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -432,12 +432,14 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     , AddressState (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
-    , TokenMap
+    ( TokenMap
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -647,6 +647,7 @@ import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet.Address.Derivation as AD
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.TokenFingerprint as W
+import qualified Cardano.Wallet.Primitive.Types.TokenMetadata as W
 import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
 import qualified Codec.Binary.Bech32 as Bech32

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -646,6 +646,7 @@ import qualified Cardano.Address.Script as CA
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet.Address.Derivation as AD
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.TokenFingerprint as W
 import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
 import qualified Codec.Binary.Bech32 as Bech32

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -649,7 +649,7 @@ import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.TokenFingerprint as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMetadata as W
 import qualified Cardano.Wallet.Primitive.Types.TokenName as W
-import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
+import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as W
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32
 import qualified Data.Aeson as Aeson

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/MintBurn.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/MintBurn.hs
@@ -39,6 +39,9 @@ import Cardano.Wallet.Api.Types.Key
     )
 import Cardano.Wallet.Api.Types.Primitive
     ()
+import Cardano.Wallet.Primitive.Types.TokenFingerprint
+    ( mkTokenFingerprint
+    )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( toNestedList
     )
@@ -47,7 +50,6 @@ import Cardano.Wallet.Primitive.Types.TokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenPolicyId
-    , mkTokenFingerprint
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (unTokenQuantity)
@@ -76,6 +78,7 @@ import Numeric.Natural
     ( Natural
     )
 
+import qualified Cardano.Wallet.Primitive.Types.TokenFingerprint as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/MintBurn.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/MintBurn.hs
@@ -48,7 +48,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
@@ -81,7 +81,7 @@ import Numeric.Natural
 import qualified Cardano.Wallet.Primitive.Types.TokenFingerprint as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenName as W
-import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
+import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as W
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/MintBurn.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/MintBurn.hs
@@ -42,9 +42,11 @@ import Cardano.Wallet.Api.Types.Primitive
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( toNestedList
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
-    , TokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId
     , mkTokenFingerprint
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
@@ -75,6 +77,7 @@ import Numeric.Natural
     )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
@@ -148,6 +148,7 @@ import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
+import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Data.Aeson.Types as Aeson

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
@@ -147,6 +147,7 @@ import Numeric.Natural
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
+import qualified Cardano.Wallet.Primitive.Types.TokenFingerprint as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
 import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
@@ -150,7 +150,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
 import qualified Cardano.Wallet.Primitive.Types.TokenFingerprint as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
 import qualified Cardano.Wallet.Primitive.Types.TokenName as W
-import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
+import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as W
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString as BS

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -193,7 +193,7 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.Range
     ( Range (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -181,6 +181,9 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     , AddressState (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -716,7 +719,7 @@ mkOutputs prefix nOuts nAssets =
         (mkAddress prefix i)
         (TokenBundle.TokenBundle (Coin 1) (TokenMap.fromFlatList tokens))
     tokens =
-        [ ( TokenMap.AssetId (mkTokenPolicyId (ac `mod` 10)) (mkTokenName ac)
+        [ ( AssetId (mkTokenPolicyId (ac `mod` 10)) (mkTokenName ac)
           , TokenQuantity 42
           )
         | !ac <- [1 .. nAssets]

--- a/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
@@ -378,6 +378,9 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -1039,7 +1042,7 @@ isValidRandomDerivationPath path =
 
 pickAnAsset :: TokenMap.TokenMap -> ((Text, Text), Natural)
 pickAnAsset tm = case TokenMap.toFlatList tm of
-    (TokenBundle.AssetId pid an, TokenQuantity.TokenQuantity q):_ ->
+    (AssetId pid an, TokenQuantity.TokenQuantity q):_ ->
         ((toText pid, toText an), q)
     _ -> error "pickAnAsset: empty TokenMap"
 

--- a/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
@@ -123,7 +123,7 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
@@ -158,7 +158,7 @@ import Test.Integration.Framework.DSL
     , json
     )
 
-import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
+import qualified Cardano.Wallet.Primitive.Types.TokenMetadata as W
 import qualified Data.Map as Map
 
 falseWalletIds :: [(String, String)]

--- a/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
@@ -120,9 +120,11 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
-    , TokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -133,7 +133,7 @@ import Test.Integration.Framework.TestData
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
-import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as TokenPolicy
+import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as TokenPolicy
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -132,6 +132,7 @@ import Test.Integration.Framework.TestData
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as TokenPolicy
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -302,7 +303,7 @@ spec = describe "BYRON_TRANSACTIONS" $ do
 
         wal <- srcFixture ctx
         let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
-        let assName = TokenPolicy.UnsafeTokenName $ B8.replicate 4 'x'
+        let assName = TokenName.UnsafeTokenName $ B8.replicate 4 'x'
         let ep = Link.getByronAsset wal polId assName
         r <- request @(ApiAsset) ctx ep Default Empty
         expectResponseCode HTTP.status404 r
@@ -315,7 +316,7 @@ spec = describe "BYRON_TRANSACTIONS" $ do
 
         wal <- srcFixture ctx
         let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
-        let ep = Link.getByronAsset wal polId TokenPolicy.nullTokenName
+        let ep = Link.getByronAsset wal polId TokenName.nullTokenName
         r <- request @(ApiAsset) ctx ep Default Empty
         expectResponseCode HTTP.status404 r
         expectErrorMessage errMsg404NoAsset r

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -37,7 +37,7 @@ import Cardano.Wallet.Primitive.NetworkId
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenFingerprint
     ( mkTokenFingerprint
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxMeta

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
@@ -47,7 +47,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
@@ -38,11 +38,11 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
@@ -44,9 +44,11 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , TokenPolicyId (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -74,7 +74,7 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenFingerprint
     ( mkTokenFingerprint
     )
 import Cardano.Wallet.Primitive.Types.Tx

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -235,6 +235,7 @@ import Web.HttpApiData
 import qualified Cardano.Address as CA
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as TokenPolicy
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
@@ -1062,7 +1063,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         wal <- fixtureMultiAssetWallet ctx
         let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
-        let assName = TokenPolicy.UnsafeTokenName $ B8.replicate 4 'x'
+        let assName = TokenName.UnsafeTokenName $ B8.replicate 4 'x'
         let ep = Link.getAsset wal polId assName
         r <- request @(ApiAsset) ctx ep Default Empty
         expectResponseCode HTTP.status404 r
@@ -1073,7 +1074,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         wal <- fixtureMultiAssetWallet ctx
         let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
-        let ep = Link.getAsset wal polId TokenPolicy.nullTokenName
+        let ep = Link.getAsset wal polId TokenName.nullTokenName
         r <- request @(ApiAsset) ctx ep Default Empty
         expectResponseCode HTTP.status404 r
         expectErrorMessage errMsg404NoAsset r

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -236,7 +236,7 @@ import qualified Cardano.Address as CA
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
-import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as TokenPolicy
+import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as TokenPolicy
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
 import qualified Data.ByteString as BS

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -125,6 +125,9 @@ import Cardano.Wallet.Primitive.Types
     , NonWalletCertificate (..)
     , SlotNo (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -133,9 +136,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenFingerprint
     ( mkTokenFingerprint

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -137,13 +137,15 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.TokenFingerprint
+    ( mkTokenFingerprint
+    )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     , mkTokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenPolicyId (..)
-    , mkTokenFingerprint
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -137,11 +137,13 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( AssetId (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , TokenPolicyId (..)
-    , mkTokenFingerprint
     , mkTokenName
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..)
+    , mkTokenFingerprint
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -144,7 +144,7 @@ import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     , mkTokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/wallet/mock-token-metadata/src/Cardano/Wallet/TokenMetadata/MockServer.hs
+++ b/lib/wallet/mock-token-metadata/src/Cardano/Wallet/TokenMetadata/MockServer.hs
@@ -37,11 +37,13 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.TokenName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( AssetDecimals (..)
     , AssetLogo (..)
     , AssetURL (..)
-    , TokenName (..)
     , TokenPolicyId (..)
     )
 import Cardano.Wallet.TokenMetadata

--- a/lib/wallet/mock-token-metadata/src/Cardano/Wallet/TokenMetadata/MockServer.hs
+++ b/lib/wallet/mock-token-metadata/src/Cardano/Wallet/TokenMetadata/MockServer.hs
@@ -45,7 +45,7 @@ import Cardano.Wallet.Primitive.Types.TokenMetadata
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.TokenMetadata

--- a/lib/wallet/mock-token-metadata/src/Cardano/Wallet/TokenMetadata/MockServer.hs
+++ b/lib/wallet/mock-token-metadata/src/Cardano/Wallet/TokenMetadata/MockServer.hs
@@ -31,11 +31,11 @@ import Prelude
 import Cardano.Wallet.Primitive.Types
     ( TokenMetadataServer (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenMetadata
     ( AssetDecimals (..)

--- a/lib/wallet/mock-token-metadata/src/Cardano/Wallet/TokenMetadata/MockServer.hs
+++ b/lib/wallet/mock-token-metadata/src/Cardano/Wallet/TokenMetadata/MockServer.hs
@@ -37,14 +37,16 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.TokenMetadata
+    ( AssetDecimals (..)
+    , AssetLogo (..)
+    , AssetURL (..)
+    )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( AssetDecimals (..)
-    , AssetLogo (..)
-    , AssetURL (..)
-    , TokenPolicyId (..)
+    ( TokenPolicyId (..)
     )
 import Cardano.Wallet.TokenMetadata
     ( BatchRequest (..)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -511,6 +511,9 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     , AddressState (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId
+    )
 import Cardano.Wallet.Primitive.Types.BlockSummary
     ( ChainEvents
     )
@@ -2766,7 +2769,7 @@ listTransactions ctx mMinWithdrawal mStart mEnd order mLimit mAddress
 listAssets
     :: IsOurs s Address
     => WalletLayer IO s
-    -> IO (Set TokenMap.AssetId)
+    -> IO (Set AssetId)
 listAssets ctx = db & \DBLayer{..} -> do
     cp <- atomically readCheckpoint
     txs <- atomically $
@@ -2774,7 +2777,7 @@ listAssets ctx = db & \DBLayer{..} -> do
             allTxStatuses = Nothing
         in readTransactions noMinWithdrawal Ascending Range.everything
             allTxStatuses Nothing Nothing
-    let txAssets :: TransactionInfo -> Set TokenMap.AssetId
+    let txAssets :: TransactionInfo -> Set AssetId
         txAssets = Set.unions
             . map (TokenBundle.getAssets . view #tokens)
             . filter ourOut

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/MintBurn.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/MintBurn.hs
@@ -50,9 +50,11 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
-    , TokenPolicyId (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/MintBurn.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/MintBurn.hs
@@ -44,11 +44,11 @@ import Cardano.Wallet.Flavor
 import Cardano.Wallet.Primitive.Passphrase
     ( Passphrase (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/MintBurn.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/MintBurn.hs
@@ -53,7 +53,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
@@ -88,6 +88,7 @@ import qualified Cardano.Wallet.Primitive.Passphrase.Types as W
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
+import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
@@ -89,7 +89,7 @@ import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.TokenName as W
-import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
+import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as W
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxMeta as W

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -91,7 +91,7 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -88,9 +88,11 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
-    , TokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Checkpoints/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Checkpoints/Store.hs
@@ -122,11 +122,11 @@ import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId (..)
     , NetworkDiscriminantCheck
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
     )
 import Control.Monad
     ( forM

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -59,7 +59,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -56,9 +56,11 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (AssetId)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
-    , TokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -50,11 +50,11 @@ import Cardano.Wallet.DB.Sqlite.Schema
 import Cardano.Wallet.DB.Sqlite.Types
     ( TxId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (AssetId)
+    )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (AssetId)
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/TxOutCBOR.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/TxOutCBOR.hs
@@ -9,6 +9,9 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (AssetId)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -19,8 +22,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (TokenBundle)
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (AssetId)
-    , fromFlatList
+    ( fromFlatList
     , toFlatList
     )
 import Cardano.Wallet.Primitive.Types.TokenName

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/TxOutCBOR.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/TxOutCBOR.hs
@@ -26,7 +26,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (UnsafeTokenName)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (UnsafeTokenPolicyId)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/TxOutCBOR.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/TxOutCBOR.hs
@@ -23,9 +23,11 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     , fromFlatList
     , toFlatList
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (UnsafeTokenName)
-    , TokenPolicyId (UnsafeTokenPolicyId)
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (UnsafeTokenPolicyId)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (TokenQuantity)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
@@ -113,6 +113,9 @@ import Prelude hiding
 import Cardano.Wallet.Primitive.Model
     ( applyTxToUTxO
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -121,9 +124,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     )
 import Cardano.Wallet.Primitive.Types.StateDeltaSeq
     ( StateDeltaSeq
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
@@ -128,7 +128,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
@@ -125,9 +125,11 @@ import Cardano.Wallet.Primitive.Types.StateDeltaSeq
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , TokenPolicyId (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq/Gen.hs
@@ -37,6 +37,9 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Address
     ( Address
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -49,9 +52,6 @@ import Cardano.Wallet.Primitive.Types.RewardAccount.Gen
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundlePartitionNonNull
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..)

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -128,6 +128,9 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -138,8 +141,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
-    , TokenMap
+    ( TokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (TokenQuantity)
@@ -252,6 +254,7 @@ import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Ledger.Keys.Bootstrap as SL
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
 import qualified Cardano.Wallet.Primitive.Ledger.Shelley as Compatibility
+import qualified Cardano.Wallet.Primitive.Types.AssetId as AssetId
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.ByteString as BS
 import qualified Data.Foldable as F
@@ -935,7 +938,7 @@ mkUnsignedTx
                     witMap =
                             Map.map toScriptWitnessGeneral $
                             Map.mapKeys
-                                (toCardanoPolicyId . TokenMap.tokenPolicyId)
+                                (toCardanoPolicyId . AssetId.tokenPolicyId)
                             mintingSource
                     ctx = Cardano.BuildTxWith witMap
                 in Cardano.TxMintValue mintedEra (mintValue <> burnValue) ctx

--- a/lib/wallet/src/Cardano/Wallet/TokenMetadata.hs
+++ b/lib/wallet/src/Cardano/Wallet/TokenMetadata.hs
@@ -96,21 +96,23 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenMetadata
     ( AssetDecimals (..)
     , AssetLogo (..)
     , AssetMetadata (..)
     , AssetURL (..)
-    , TokenPolicyId (..)
     , validateMetadataDecimals
     , validateMetadataDescription
     , validateMetadataLogo
     , validateMetadataName
     , validateMetadataTicker
     , validateMetadataURL
+    )
+import Cardano.Wallet.Primitive.Types.TokenName
+    ( TokenName (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..)
     )
 import Control.Applicative
     ( (<|>)

--- a/lib/wallet/src/Cardano/Wallet/TokenMetadata.hs
+++ b/lib/wallet/src/Cardano/Wallet/TokenMetadata.hs
@@ -96,12 +96,14 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.TokenName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( AssetDecimals (..)
     , AssetLogo (..)
     , AssetMetadata (..)
     , AssetURL (..)
-    , TokenName (..)
     , TokenPolicyId (..)
     , validateMetadataDecimals
     , validateMetadataDescription

--- a/lib/wallet/src/Cardano/Wallet/TokenMetadata.hs
+++ b/lib/wallet/src/Cardano/Wallet/TokenMetadata.hs
@@ -111,7 +111,7 @@ import Cardano.Wallet.Primitive.Types.TokenMetadata
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Control.Applicative

--- a/lib/wallet/src/Cardano/Wallet/TokenMetadata.hs
+++ b/lib/wallet/src/Cardano/Wallet/TokenMetadata.hs
@@ -90,11 +90,11 @@ import Cardano.BM.Extra
 import Cardano.Wallet.Primitive.Types
     ( TokenMetadataServer (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenMetadata
     ( AssetDecimals (..)

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -92,6 +92,9 @@ import Cardano.Wallet.Primitive.Types.AnyExplicitScripts
     ( AnyExplicitScript (..)
     , changeRoleInAnyExplicitScript
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -102,8 +105,7 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId
-    , TokenMap
+    ( TokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenMapWithScripts
     ( AnyScript (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -104,7 +104,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.Tx

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -101,9 +101,11 @@ import Cardano.Wallet.Primitive.Types
     ( WalletId
     , walletNameMaxLength
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
-    , TokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -378,6 +378,9 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
+import Cardano.Wallet.Primitive.Types.TokenName.Gen
+    ( genTokenName
+    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( AssetDecimals (..)
     , AssetLogo (..)
@@ -386,9 +389,6 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
     , TokenFingerprint
     , TokenPolicyId (..)
     , mkTokenFingerprint
-    )
-import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
-    ( genTokenName
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -391,7 +391,7 @@ import Cardano.Wallet.Primitive.Types.TokenName
 import Cardano.Wallet.Primitive.Types.TokenName.Gen
     ( genTokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -350,6 +350,9 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId.Gen
+    ( genAssetId
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -377,8 +380,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetId
-    , genTokenMapSmallRange
+    ( genTokenMapSmallRange
     , shrinkTokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenMetadata

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -367,6 +367,10 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange
     , shrinkTokenBundleSmallRange
     )
+import Cardano.Wallet.Primitive.Types.TokenFingerprint
+    ( TokenFingerprint
+    , mkTokenFingerprint
+    )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap
     )
@@ -386,9 +390,7 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
     , AssetLogo (..)
     , AssetMetadata (..)
     , AssetURL (..)
-    , TokenFingerprint
     , TokenPolicyId (..)
-    , mkTokenFingerprint
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -379,6 +379,12 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     , genTokenMapSmallRange
     , shrinkTokenMap
     )
+import Cardano.Wallet.Primitive.Types.TokenMetadata
+    ( AssetDecimals (..)
+    , AssetLogo (..)
+    , AssetMetadata (..)
+    , AssetURL (..)
+    )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
@@ -386,11 +392,7 @@ import Cardano.Wallet.Primitive.Types.TokenName.Gen
     ( genTokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( AssetDecimals (..)
-    , AssetLogo (..)
-    , AssetMetadata (..)
-    , AssetURL (..)
-    , TokenPolicyId (..)
+    ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -375,13 +375,15 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     , genTokenMapSmallRange
     , shrinkTokenMap
     )
+import Cardano.Wallet.Primitive.Types.TokenName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( AssetDecimals (..)
     , AssetLogo (..)
     , AssetMetadata (..)
     , AssetURL (..)
     , TokenFingerprint
-    , TokenName (..)
     , TokenPolicyId (..)
     , mkTokenFingerprint
     )

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -347,6 +347,9 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     , AddressState (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -360,8 +363,7 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( AssetId (..)
-    , TokenBundle
+    ( TokenBundle
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange

--- a/lib/wallet/test/unit/Cardano/Wallet/Balance/Migration/SelectionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Balance/Migration/SelectionSpec.hs
@@ -29,6 +29,9 @@ import Cardano.Wallet.Balance.Migration.Selection
 import Cardano.Wallet.Primitive.Types.Address
     ( Address
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -43,8 +46,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     , TokenBundle (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
-    , TokenMap
+    ( TokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Balance/Migration/SelectionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Balance/Migration/SelectionSpec.hs
@@ -46,9 +46,11 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..)
     , TokenMap
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , TokenPolicyId (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Balance/Migration/SelectionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Balance/Migration/SelectionSpec.hs
@@ -49,7 +49,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -165,9 +165,11 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
-    , TokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -168,7 +168,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
@@ -30,7 +30,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxSeq.Gen

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
@@ -27,9 +27,11 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genAssetId
     , shrinkAssetId
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , TokenPolicyId (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxSeq.Gen
     ( ShrinkableTxSeq

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
@@ -20,12 +20,12 @@ import Cardano.Wallet.Primitive.Types.Address.Gen
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId
     )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap.Gen
+import Cardano.Wallet.Primitive.Types.AssetId.Gen
     ( genAssetId
     , shrinkAssetId
+    )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
@@ -17,11 +17,11 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Address.Gen
     ( genAddress
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId
     )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genAssetId

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -104,6 +104,9 @@ import Cardano.Wallet.Primitive.Passphrase
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -119,8 +122,7 @@ import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( AssetId
-    , TokenBundle
+    ( TokenBundle
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange
@@ -1618,7 +1620,7 @@ instance Arbitrary AnyRecentEra where
 
 instance Arbitrary AssetId where
     arbitrary =
-        TokenBundle.AssetId
+        AssetId
         <$> arbitrary
         -- In the calculation of the size of the Tx, the minting of assets
         -- increases the size of the Tx by both a constant factor per asset

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -126,9 +126,11 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange
     , shrinkTokenBundleSmallRange
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (UnsafeTokenName)
-    , TokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     ( genTokenPolicyId

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -129,12 +129,12 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (UnsafeTokenName)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( TokenPolicyId
-    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     ( genTokenPolicyId
     , shrinkTokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -129,12 +129,12 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (UnsafeTokenName)
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
-    ( genTokenPolicyId
-    , shrinkTokenPolicyId
-    )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicyId.Gen
+    ( genTokenPolicyId
+    , shrinkTokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -24,7 +24,7 @@ import Cardano.Wallet.Primitive.Types.TokenMetadata
 import Cardano.Wallet.Primitive.Types.TokenName
     ( nullTokenName
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.TokenMetadata

--- a/lib/wallet/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -15,13 +15,15 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.TokenName
+    ( nullTokenName
+    )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( AssetDecimals (..)
     , AssetLogo (..)
     , AssetMetadata (..)
     , AssetURL (..)
     , TokenPolicyId (..)
-    , nullTokenName
     )
 import Cardano.Wallet.TokenMetadata
     ( BatchResponse (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -15,15 +15,17 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( nullTokenName
-    )
-import Cardano.Wallet.Primitive.Types.TokenPolicy
+import Cardano.Wallet.Primitive.Types.TokenMetadata
     ( AssetDecimals (..)
     , AssetLogo (..)
     , AssetMetadata (..)
     , AssetURL (..)
-    , TokenPolicyId (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenName
+    ( nullTokenName
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..)
     )
 import Cardano.Wallet.TokenMetadata
     ( BatchResponse (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -9,11 +9,11 @@ module Cardano.Wallet.TokenMetadataSpec
 
 import Prelude
 
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenMetadata
     ( AssetDecimals (..)

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -135,6 +135,9 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Address.Gen
     ( genAddress
     )
+import Cardano.Wallet.Primitive.Types.AssetId.Gen
+    ( genAssetIdLargeRange
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -150,9 +153,6 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (TokenBundle)
     , getAssets
-    )
-import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetIdLargeRange
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantityPositive


### PR DESCRIPTION
## Issue

None. Spotted while reviewing.

## Description

This PR:
- breaks up large token-related modules in `cardano-wallet-primitive`
- extracts out the following new modules:
    - `Primitive.Types.AssetId`
    - `Primitive.Types.AssetId.Gen`
    - `Primitive.Types.TokenFingerprint`
    - `Primitive.Types.TokenFingerprintSpec`
    - `Primitive.Types.TokenMetadata`
    - `Primitive.Types.TokenName`
    - `Primitive.Types.TokenName.Gen`
    - `Primitive.Types.TokenPolicyId`
    - `Primitive.Types.TokenPolicyId.Gen`

In general, this PR arranges that:
- each distinct type `X` with its own language of related functions is located in its own module:
    - `Primitive.X`
- generators and shrinkers for type `X` are located in:
    - `Primitive.X.Gen`

In particular, this PR retires the old `TokenPolicy` module, which had become a menagerie of miscellaneous token-related types and functions. ☢️