### PR TITLE
Attempt to prevent GHC panic when building from scratch on GHC `8.10.7`.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -195,7 +195,7 @@ package cardano-node
   flags: -systemd
 
 -- Fail to build if there are any unused package dependencies:
-package *
+program-options
   ghc-options: -Wunused-packages
 
 -- -------------------------------------------------------------------------

--- a/cabal.project
+++ b/cabal.project
@@ -194,11 +194,23 @@ package cardano-config
 package cardano-node
   flags: -systemd
 
--- Fail to build if there are any unused package dependencies:
+--------------------------------------------------------------------------------
+-- Detection of unused package dependencies
+--------------------------------------------------------------------------------
+
+-- By default, we fail to build if there are any unused package dependencies.
 program-options
   ghc-options: -Wunused-packages
 
--- -------------------------------------------------------------------------
+-- NOTE: We make an exception for `cardano-wallet-primitive`, as for some
+-- reason GHC panics when building this package if the above flag is enabled.
+--
+-- TODO: Investigate this problem further and/or file a GHC bug report.
+--
+package cardano-wallet-primitive
+  ghc-options: -Wno-unused-packages
+
+--------------------------------------------------------------------------------
 -- Enable specific tests in this repo
 
 test-show-details: direct


### PR DESCRIPTION
This PR attempts to prevent a GHC panic when building `cardano-wallet-primitive` from scratch on GHC `8.10.7`.

Without this PR, `cabal clean && cabal build all` can fail with the following error:
```hs
Linking /home/jsk/projects/input-output-hk/cardano-wallet-0/dist-newstyle/build/x86_64-linux/ghc-8.10.7/cardano-api-extra-2023.7.18/t/test/build/test/test ...
ghc: panic! (the 'impossible' happened)
  (GHC version 8.10.7:
        getPackageDetails: couldn't find package
  cardano-wallet-primitive-2023.7.18-inplace
  Call stack:
      CallStack (from HasCallStack):
        callStackDoc, called at compiler/utils/Outputable.hs:1179:37 in ghc:Outputable
        pprPanic, called at compiler/main/Packages.hs:434:14 in ghc:Packages
```

This particular panic seems to emanate from the following location:
https://github.com/ghc/ghc/blob/1f02b7430b2fbab403d7ffdde9cfd006e884678e/compiler/main/Packages.hs#L431-L434