### PR TITLE
Remove usages of `AllowAmbiguousTypes` in `cardano-balance-tx`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -55,7 +55,6 @@ module Internal.Cardano.Write.Tx
     , fromCardanoApiTx
     , toCardanoApiUTxO
     , fromCardanoApiUTxO
-    , toCardanoApiValue
     , toCardanoApiLovelace
     , toCardanoApiTx
 
@@ -724,12 +723,6 @@ fromCardanoApiUTxO =
     . Map.map
         (CardanoApi.toShelleyTxOut (shelleyBasedEra @era))
     . CardanoApi.unUTxO
-
-toCardanoApiValue
-    :: forall era. IsRecentEra era
-    => Core.Value era
-    -> CardanoApi.Value
-toCardanoApiValue = CardanoApi.fromMaryValue
 
 toCardanoApiLovelace :: Coin -> CardanoApi.Lovelace
 toCardanoApiLovelace = CardanoApi.fromShelleyLovelace

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE EmptyCase #-}

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -40,7 +39,6 @@ module Internal.Cardano.Write.Tx.SizeEstimation
     , sizeOf_VKeyWitnesses
     , sizeOf_Withdrawals
     )
-
     where
 
 import Prelude


### PR DESCRIPTION
## Issue

None. Spotted while reviewing code.

## Description

This PR removes a usage of the `AllowAmbiguousTypes` extension. This extension was only required by the `toCardanoApiValue` function, which is no longer used.