### PR TITLE
[ADP-3224] Use default values when calling `get_latest_windows_tests`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,6 +3,7 @@ name: Windows Unit Tests
 on:
   schedule:
   - cron:  "0 20 * * *"
+
   workflow_dispatch:
     inputs:
       branch:
@@ -43,7 +44,7 @@ jobs:
           bundle install
           echo "STATUS = ${{ github.event.inputs.status }}"
           echo "BUILD = ${{ github.event.inputs.build }}"
-          rake get_latest_windows_tests[%BRANCH%,cardano-wallet-tests-win64,${{ github.event.inputs.status }},${{ github.event.inputs.build }}]
+          rake get_latest_windows_tests[%BRANCH%,cardano-wallet-tests-win64,${{ github.event.inputs.status || 'any' }},${{ github.event.inputs.build || 'latest' }}]
 
       - name: Report version
         working-directory: ${{ env.WORK_DIR }}


### PR DESCRIPTION
The scheduled builds won't pick up the default values from the
`workflow_dispatch` `inputs` definition, so we need additional fallback.
This was how it was failing before:
https://github.com/cardano-foundation/cardano-wallet/actions/runs/7091896429/job/19302041024

Temporary on-`pull_request` run running fine:

![Skärmavbild 2023-12-05 kl  10 29 15](https://github.com/cardano-foundation/cardano-wallet/assets/304423/73de4e83-3e44-45ed-85d3-1676a912fa4c)

### Issue Number

ADP-3224
