### PR TITLE
Use qualified style for `TokenName` functions.

### DIFF
--- a/lib/local-cluster/lib/Cardano/Wallet/Faucet.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Faucet.hs
@@ -59,7 +59,6 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , nullTokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
@@ -104,6 +103,7 @@ import qualified Cardano.Address.Style.Icarus as Icarus
 import qualified Cardano.Wallet.Faucet.Addresses as Addresses
 import qualified Cardano.Wallet.Faucet.Mnemonics as Mnemonics
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
@@ -311,7 +311,7 @@ maryIntegrationTestFunds tips =
 
     bundle p assets = TokenBundle.fromNestedList tips [(p, NE.fromList assets)]
 
-    simple p = bundle p [(nullTokenName, TokenQuantity 1_000_000_000)]
+    simple p = bundle p [(TokenName.empty, TokenQuantity 1_000_000_000)]
     fruit p =
         bundle
             p

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenName.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenName.hs
@@ -8,7 +8,7 @@ module Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
     , empty
     , fromByteString
-    , tokenNameMaxLength
+    , maxLength
     ) where
 
 import Prelude
@@ -64,13 +64,13 @@ newtype TokenName =
     deriving anyclass Hashable
 
 -- | Construct a 'TokenName', validating that the length does not exceed
---   'tokenNameMaxLength'.
+--   'maxLength'.
 --
 fromByteString :: ByteString -> Either String TokenName
 fromByteString bs
-    | BS.length bs <= tokenNameMaxLength = Right $ UnsafeTokenName bs
+    | BS.length bs <= maxLength = Right $ UnsafeTokenName bs
     | otherwise = Left $ "TokenName length " ++ show (BS.length bs)
-        ++ " exceeds maximum of " ++ show tokenNameMaxLength
+        ++ " exceeds maximum of " ++ show maxLength
 
 -- | The empty asset name.
 --
@@ -83,8 +83,8 @@ empty = UnsafeTokenName ""
 
 -- | The maximum length of a valid token name.
 --
-tokenNameMaxLength :: Int
-tokenNameMaxLength = 32
+maxLength :: Int
+maxLength = 32
 
 instance NFData TokenName
 

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenName.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenName.hs
@@ -6,7 +6,7 @@
 
 module Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , mkTokenName
+    , fromByteString
     , nullTokenName
     , tokenNameMaxLength
     ) where
@@ -66,8 +66,8 @@ newtype TokenName =
 -- | Construct a 'TokenName', validating that the length does not exceed
 --   'tokenNameMaxLength'.
 --
-mkTokenName :: ByteString -> Either String TokenName
-mkTokenName bs
+fromByteString :: ByteString -> Either String TokenName
+fromByteString bs
     | BS.length bs <= tokenNameMaxLength = Right $ UnsafeTokenName bs
     | otherwise = Left $ "TokenName length " ++ show (BS.length bs)
         ++ " exceeds maximum of " ++ show tokenNameMaxLength
@@ -102,6 +102,6 @@ instance ToText TokenName where
 
 instance FromText TokenName where
     fromText = first TextDecodingError
-        . either (Left . ("TokenName is not hex-encoded: " ++)) mkTokenName
+        . either (Left . ("TokenName is not hex-encoded: " ++)) fromByteString
         . convertFromBase Base16
         . T.encodeUtf8

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenName.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenName.hs
@@ -6,8 +6,8 @@
 
 module Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
+    , empty
     , fromByteString
-    , nullTokenName
     , tokenNameMaxLength
     ) where
 
@@ -78,8 +78,8 @@ fromByteString bs
 -- asset, or where one asset should be considered as the "default" token for the
 -- policy.
 --
-nullTokenName :: TokenName
-nullTokenName = UnsafeTokenName ""
+empty :: TokenName
+empty = UnsafeTokenName ""
 
 -- | The maximum length of a valid token name.
 --

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -47,7 +47,6 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
-    , mkTokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenName.Gen
     ( genTokenName
@@ -193,6 +192,7 @@ import Test.Utils.Paths
     )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.Foldable as F
@@ -848,7 +848,7 @@ testMapPrettyNested = [s|
 --------------------------------------------------------------------------------
 
 dummyTokenName :: ByteString -> TokenName
-dummyTokenName t = fromRight reportError $ mkTokenName t
+dummyTokenName t = fromRight reportError $ TokenName.fromByteString t
   where
     reportError = error $
         "Unable to construct dummy token name from bytes: " <> show t

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -604,7 +604,6 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , tokenNameMaxLength
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
@@ -2974,9 +2973,9 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
           where
             assetNameTooLong mb = case mb ^. #mintBurnData of
                 Left (ApiMintBurnDataFromScript _ (Just (ApiT (UnsafeTokenName bs))) _) ->
-                    BS.length bs > tokenNameMaxLength
+                    BS.length bs > TokenName.maxLength
                 Right (ApiMintBurnDataFromInput _ _ (Just (ApiT (UnsafeTokenName bs))) _) ->
-                    BS.length bs > tokenNameMaxLength
+                    BS.length bs > TokenName.maxLength
                 _ -> error "at this moment there should be asset name attributed"
 
         guardAssetQuantityOutOfBounds

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -604,7 +604,6 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , nullTokenName
     , tokenNameMaxLength
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
@@ -894,6 +893,7 @@ import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
 import qualified Cardano.Wallet.Primitive.Types.Tx.SealedTx as W
     ( SealedTx
     , sealedTxFromCardano
@@ -2257,7 +2257,7 @@ getAssetDefault
     -> ApiT WalletId
     -> ApiT TokenPolicyId
     -> Handler ApiAsset
-getAssetDefault ctx wid pid = getAsset ctx wid pid (ApiT nullTokenName)
+getAssetDefault ctx wid pid = getAsset ctx wid pid (ApiT TokenName.empty)
 
 {-------------------------------------------------------------------------------
                                     Addresses
@@ -2944,11 +2944,11 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
           where
             updateFromScript :: ApiMintBurnDataFromScript n -> ApiMintBurnDataFromScript n
             updateFromScript mbd = case mbd ^. #assetName of
-                Nothing -> mbd {assetName = Just (ApiT nullTokenName)}
+                Nothing -> mbd {assetName = Just (ApiT TokenName.empty)}
                 Just _ -> mbd
             updateFromInp :: ApiMintBurnDataFromInput n -> ApiMintBurnDataFromInput n
             updateFromInp mbd = case mbd ^. #assetName of
-                Nothing -> mbd {assetName = Just (ApiT nullTokenName)}
+                Nothing -> mbd {assetName = Just (ApiT TokenName.empty)}
                 Just _ -> mbd
 
         guardWrongMintingTemplate

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Link.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Link.hs
@@ -168,7 +168,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName
-    , nullTokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
@@ -222,6 +221,7 @@ import Web.HttpApiData
     )
 
 import qualified Cardano.Wallet.Api as Api
+import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
 
 --
 -- Wallets
@@ -585,7 +585,7 @@ getAsset
     -> TokenName
     -> (Method, Text)
 getAsset w pid n
-    | n == nullTokenName = endpoint @Api.GetAssetDefault mkURLDefault
+    | n == TokenName.empty = endpoint @Api.GetAssetDefault mkURLDefault
     | otherwise = endpoint @Api.GetAsset mkURL
   where
     wid = w ^. typed @(ApiT WalletId)
@@ -612,7 +612,7 @@ getByronAsset
     -> TokenName
     -> (Method, Text)
 getByronAsset w pid n
-    | n == nullTokenName = endpoint @Api.GetByronAssetDefault mkURLDefault
+    | n == TokenName.empty = endpoint @Api.GetByronAssetDefault mkURLDefault
     | otherwise = endpoint @Api.GetByronAsset mkURL
   where
     wid = w ^. typed @(ApiT WalletId)

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -316,7 +316,7 @@ spec = describe "BYRON_TRANSACTIONS" $ do
 
         wal <- srcFixture ctx
         let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
-        let ep = Link.getByronAsset wal polId TokenName.nullTokenName
+        let ep = Link.getByronAsset wal polId TokenName.empty
         r <- request @(ApiAsset) ctx ep Default Empty
         expectResponseCode HTTP.status404 r
         expectErrorMessage errMsg404NoAsset r

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -1074,7 +1074,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         wal <- fixtureMultiAssetWallet ctx
         let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
-        let ep = Link.getAsset wal polId TokenName.nullTokenName
+        let ep = Link.getAsset wal polId TokenName.empty
         r <- request @(ApiAsset) ctx ep Default Empty
         expectResponseCode HTTP.status404 r
         expectErrorMessage errMsg404NoAsset r

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -142,7 +142,6 @@ import Cardano.Wallet.Primitive.Types.TokenFingerprint
     )
 import Cardano.Wallet.Primitive.Types.TokenName
     ( TokenName (..)
-    , mkTokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
@@ -326,6 +325,7 @@ import qualified Cardano.Ledger.Keys as Ledger
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
 import qualified Data.Aeson as Aeson
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
@@ -1328,7 +1328,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
         addrsMint <- listAddresses @n ctx wa
         let addrMint = (addrsMint !! 1) ^. #id
-        let Right tokenName' = mkTokenName "ab12"
+        let Right tokenName' = TokenName.fromByteString "ab12"
         let payloadMint = Json [json|{
                 "mint_burn": [{
                     "policy_id": #{toText policyId'},
@@ -3800,7 +3800,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wa
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = mkTokenName "ab12"
+        let (Right tokenName') = TokenName.fromByteString "ab12"
 
         let payload = Json [json|{
                 "mint_burn": [{
@@ -3840,7 +3840,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wa
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = mkTokenName "ab12"
+        let (Right tokenName') = TokenName.fromByteString "ab12"
 
         rSlot <- request @ApiNetworkInformation ctx
             Link.getNetworkInfo Default Empty
@@ -3894,7 +3894,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wa
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = mkTokenName "ab12"
+        let (Right tokenName') = TokenName.fromByteString "ab12"
 
         rSlot <- request @ApiNetworkInformation ctx
             Link.getNetworkInfo Default Empty
@@ -3943,7 +3943,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wa
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = mkTokenName "ab12"
+        let (Right tokenName') = TokenName.fromByteString "ab12"
         let payloadMint = Json [json|{
                 "mint_burn": [{
                     "policy_script_template":
@@ -3992,7 +3992,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wa
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = mkTokenName ""
+        let (Right tokenName') = TokenName.fromByteString ""
         let payloadMint = Json [json|{
                 "mint_burn": [
                     { "policy_script_template":
@@ -4041,7 +4041,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wForeign
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = mkTokenName "ab12"
+        let (Right tokenName') = TokenName.fromByteString "ab12"
 
         let payload = Json [json|{
                 "mint_burn": [

--- a/lib/wallet/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -21,9 +21,6 @@ import Cardano.Wallet.Primitive.Types.TokenMetadata
     , AssetMetadata (..)
     , AssetURL (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( nullTokenName
-    )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
@@ -78,6 +75,8 @@ import Test.Utils.Paths
 import Test.Utils.Trace
     ( traceSpec
     )
+
+import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
 
 spec :: Spec
 spec = do
@@ -140,14 +139,18 @@ spec = do
             withMetadataServer (queryServerStatic golden1File) $ \srv -> do
                 client <- newMetadataClient tr (Just srv)
                 let subj = "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c27"
-                let aid = AssetId (UnsafeTokenPolicyId (unsafeFromText subj)) nullTokenName
+                let aid = AssetId
+                        (UnsafeTokenPolicyId (unsafeFromText subj))
+                        TokenName.empty
                 getTokenMetadata client [assetIdFromSubject (Subject subj)]
                     `shouldReturn` Right [(aid, golden1Metadata0)]
 
         it "ill-formatted entry doesn't make the entire response fail to parse" $ \tr -> do
             withMetadataServer (queryServerStatic golden2File) $ \srv -> do
                 client <- newMetadataClient tr (Just srv)
-                let aid subj = AssetId (UnsafeTokenPolicyId (unsafeFromText subj)) nullTokenName
+                let aid subj = AssetId
+                        (UnsafeTokenPolicyId (unsafeFromText subj))
+                        TokenName.empty
                 let aid1 = aid "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c27"
                 let aid2 = aid "bad00000000000000000000000000000000000000000000000000000"
                 getTokenMetadata client [aid1, aid2]
@@ -156,7 +159,9 @@ spec = do
         it "missing subject" $ \tr ->
             withMetadataServer (queryServerStatic golden1File) $ \srv -> do
                 client <- newMetadataClient tr (Just srv)
-                let aid = AssetId (UnsafeTokenPolicyId (Hash "a")) nullTokenName
+                let aid = AssetId
+                        (UnsafeTokenPolicyId (Hash "a"))
+                        TokenName.empty
                 res <- getTokenMetadata client [aid]
                 res `shouldBe` Right []
 


### PR DESCRIPTION
## Issue

None. (Noticed while reviewing.)

## Description

This PR adjusts the names of functions exported by the `TokenName` module so that the names of functions do not repeat the name `TokenName`.

As a result, it's more natural to import from `TokenName` in a qualified style.