### PR TITLE
[ADP-3224] Minimal bump to node 8.1.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     "CHaP_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1686070892,
-        "narHash": "sha256-0yAYqvCg2/aby4AmW0QQK9RKnU1siQczfbUC6hOU02w=",
+        "lastModified": 1689937110,
+        "narHash": "sha256-qbd7y3zJucW8GtRYVROg0HPzaXI3hAz/1vT46DE/8uI=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "596cf203a0a1ba252a083a79d384325000faeb49",
+        "rev": "4e27319575bc0f0516d72d9fb4403b1f16e50833",
         "type": "github"
       },
       "original": {
@@ -298,16 +298,16 @@
         "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1687190129,
-        "narHash": "sha256-JCa9+QhZ2RVSIKkhz2WCZqTKCgdUSuezWS2YsQ5vhM4=",
+        "lastModified": 1690209950,
+        "narHash": "sha256-d0V8N+y/OarYv6GQycGXnbPly7GeJRBEeE1017qj9eI=",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "6f79e5c3ea109a70cd01910368e011635767305a",
+        "rev": "d2d90b48c5577b4412d5c9c9968b55f8ab4b9767",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "8.1.1",
+        "ref": "8.1.2",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -142,7 +142,7 @@
       flake = false;
     };
     customConfig.url = "github:input-output-hk/empty-flake";
-    cardano-node-runtime.url = "github:input-output-hk/cardano-node?ref=8.1.1";
+    cardano-node-runtime.url = "github:input-output-hk/cardano-node?ref=8.1.2";
   };
 
   outputs = { self, nixpkgs, nixpkgs-unstable, hostNixpkgs, flake-utils,


### PR DESCRIPTION
This pull request does the minimum thing to bump the run-time dependency on `cardano-node` to version 8.1.2.

### Issue number

ADP-3224