### PR TITLE
[ADP-3224] Increase timeout for setting up docker in docker_macos.yml

### DIFF
--- a/.github/workflows/docker_macos.yml
+++ b/.github/workflows/docker_macos.yml
@@ -13,7 +13,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.2.0
-      - uses: docker-practice/actions-setup-docker@master
+      - run: |
+            brew install docker
+            brew install docker-compose
+
+            mkdir -p ~/.docker/cli-plugins \
+                ln -sfn $HOMEBREW_PREFIX/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
+
       - uses: ruby/setup-ruby@v1.127.0
         with:
           ruby-version: 2.7.1
@@ -21,7 +27,7 @@ jobs:
         run: gem install cardano_wallet
       - name: Check docker-compose
         run: |
-          docker-compose up -d
+          docker compose up -d
           ./scripts/connect_wallet.rb
         env:
           NETWORK: preprod


### PR DESCRIPTION
The docker-compose macos workflow is failing, this is a try to fix it based on https://github.com/docker-practice/actions-setup-docker

ADP-3224