### PR TITLE
Rename `TokenName` to `AssetName`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -74,12 +74,12 @@ import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.AssetId as W
     ( AssetId (..)
     )
+import qualified Cardano.Wallet.Primitive.Types.AssetName as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
     ( Coin (..)
     )
 import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W.TokenBundle
-import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
     ( TxSize (..)
     )

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -314,8 +314,8 @@ estimateTxSize skeleton =
     -- We consider "native asset" to just be the "multiasset<uint>" part of the
     -- above, hence why we don't also include the size of the coin. Where this
     -- is used, the size of the coin and array are are added too.
-    sizeOf_NativeAsset W.AssetId {tokenName}
-        = sizeOf_MultiAsset sizeOf_LargeUInt tokenName
+    sizeOf_NativeAsset W.AssetId {assetName}
+        = sizeOf_MultiAsset sizeOf_LargeUInt assetName
 
     -- multiasset<a> = { * policy_id => { * asset_name => a } }
     -- policy_id = scripthash

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -329,7 +329,7 @@ estimateTxSize skeleton =
 
     -- asset_name = bytes .size (0..32)
     sizeOf_AssetName name
-        = 2 + fromIntegral (BS.length $ W.unTokenName name)
+        = 2 + fromIntegral (BS.length $ W.unAssetName name)
 
     -- Coins can really vary so it's very punishing to always assign them the
     -- upper bound. They will typically be between 3 and 9 bytes (only 6 bytes

--- a/lib/coin-selection/bench/UTxOIndexBench.hs
+++ b/lib/coin-selection/bench/UTxOIndexBench.hs
@@ -14,6 +14,9 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -26,9 +29,6 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)

--- a/lib/coin-selection/bench/UTxOIndexBench.hs
+++ b/lib/coin-selection/bench/UTxOIndexBench.hs
@@ -15,7 +15,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -241,13 +241,13 @@ testUTxOMapKeys = [0 ..]
 makeTestAssetId :: Natural -> AssetId
 makeTestAssetId n = AssetId
     (makeTestTokenPolicyId (n `div` 4))
-    (makeTestTokenName     (n `mod` 4))
+    (makeTestAssetName     (n `mod` 4))
 
 makeTestTokenPolicyId :: Natural -> TokenPolicyId
 makeTestTokenPolicyId = UnsafeTokenPolicyId . mockHash
 
-makeTestTokenName :: Natural -> TokenName
-makeTestTokenName = UnsafeTokenName . getHash . mockHash
+makeTestAssetName :: Natural -> AssetName
+makeTestAssetName = UnsafeAssetName . getHash . mockHash
 
 minimalCoin :: Coin
 minimalCoin = Coin 1

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -135,6 +135,12 @@ import Cardano.Wallet.Primitive.Types.AssetId.Gen
     , genAssetIdLargeRange
     , shrinkAssetId
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
+import Cardano.Wallet.Primitive.Types.AssetName.Gen
+    ( genTokenName
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -162,12 +168,6 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genTokenMapSmallRange
     , shrinkTokenMap
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenName.Gen
-    ( genTokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -136,10 +136,10 @@ import Cardano.Wallet.Primitive.Types.AssetId.Gen
     , shrinkAssetId
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName.Gen
-    ( genTokenName
+    ( genAssetName
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -530,13 +530,13 @@ spec = describe "Cardano.CoinSelection.BalanceSpec" $
         it "prop_runRoundRobin_identity" $
             property $ prop_runRoundRobin_identity @Int
         it "prop_runRoundRobin_iterationCount" $
-            property $ prop_runRoundRobin_iterationCount @TokenName @Word8
+            property $ prop_runRoundRobin_iterationCount @AssetName @Word8
         it "prop_runRoundRobin_iterationOrder" $
-            property $ prop_runRoundRobin_iterationOrder @TokenName @Word8
+            property $ prop_runRoundRobin_iterationOrder @AssetName @Word8
         it "prop_runRoundRobin_generationCount" $
-            property $ prop_runRoundRobin_generationCount @TokenName @Word8
+            property $ prop_runRoundRobin_generationCount @AssetName @Word8
         it "prop_runRoundRobin_generationOrder" $
-            property $ prop_runRoundRobin_generationOrder @TokenName @Word8
+            property $ prop_runRoundRobin_generationOrder @AssetName @Word8
 
     describe "Utility functions" $ do
 
@@ -3124,13 +3124,13 @@ unit_makeChange =
         . fmap (second TokenQuantity)
 
     assetA :: AssetId
-    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
+    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeAssetName "1")
 
     assetB :: AssetId
-    assetB = AssetId (UnsafeTokenPolicyId $ Hash "B") (UnsafeTokenName "")
+    assetB = AssetId (UnsafeTokenPolicyId $ Hash "B") (UnsafeAssetName "")
 
     assetC :: AssetId
-    assetC = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "2")
+    assetC = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeAssetName "2")
 
 --------------------------------------------------------------------------------
 -- Collating non-user-specified asset quantities.
@@ -3418,7 +3418,7 @@ unit_assignCoinsToChangeMaps =
         . fmap (second TokenQuantity)
 
     assetA :: AssetId
-    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
+    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeAssetName "1")
 
 --------------------------------------------------------------------------------
 -- Making change for coins
@@ -3523,7 +3523,7 @@ unit_makeChangeForNonUserSpecifiedAsset =
     m = TokenMap.fromFlatList
 
     assetA :: AssetId
-    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
+    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeAssetName "1")
 
 --------------------------------------------------------------------------------
 -- Making change for multiple non-user-specified assets
@@ -3827,13 +3827,13 @@ unit_makeChangeForUserSpecifiedAsset =
     m = TokenMap.fromFlatList
 
     assetA :: AssetId
-    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
+    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeAssetName "1")
 
     assetB :: AssetId
-    assetB = AssetId (UnsafeTokenPolicyId $ Hash "B") (UnsafeTokenName "")
+    assetB = AssetId (UnsafeTokenPolicyId $ Hash "B") (UnsafeAssetName "")
 
     assetC :: AssetId
-    assetC = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "2")
+    assetC = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeAssetName "2")
 
 --------------------------------------------------------------------------------
 -- Splitting bundles with excessive asset counts
@@ -4309,7 +4309,7 @@ matchSingletonList = \case
     _   -> Nothing
 
 mockAsset :: ByteString -> AssetId
-mockAsset a = AssetId (UnsafeTokenPolicyId $ Hash a) (UnsafeTokenName "1")
+mockAsset a = AssetId (UnsafeTokenPolicyId $ Hash a) (UnsafeAssetName "1")
 
 mockAssetQuantity :: ByteString -> Natural -> (AssetId, TokenQuantity)
 mockAssetQuantity a q = (mockAsset a, TokenQuantity q)
@@ -4375,8 +4375,8 @@ instance Arbitrary AssetId where
 instance Arbitrary MakeChangeData where
     arbitrary = genMakeChangeData
 
-instance Arbitrary (MockRoundRobinState TokenName Word8) where
-    arbitrary = genMockRoundRobinState genTokenName arbitrary
+instance Arbitrary (MockRoundRobinState AssetName Word8) where
+    arbitrary = genMockRoundRobinState genAssetName arbitrary
     shrink = shrinkMockRoundRobinState shrink
 
 instance Arbitrary TokenBundle where

--- a/lib/local-cluster/lib/Cardano/Wallet/Faucet.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Faucet.hs
@@ -15,7 +15,7 @@ module Cardano.Wallet.Faucet
     , nextWallet
 
       -- * Sea horses
-    , seaHorseTokenName
+    , seaHorseAssetName
     , seaHorsePolicyId
 
       -- * Integration test funds
@@ -52,7 +52,7 @@ import Cardano.Mnemonic
     , SomeMnemonic (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -102,7 +102,7 @@ import qualified Cardano.Address as CA
 import qualified Cardano.Address.Style.Icarus as Icarus
 import qualified Cardano.Wallet.Faucet.Addresses as Addresses
 import qualified Cardano.Wallet.Faucet.Mnemonics as Mnemonics
-import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
+import qualified Cardano.Wallet.Primitive.Types.AssetName as AssetName
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.List.NonEmpty as NE
@@ -311,13 +311,13 @@ maryIntegrationTestFunds tips =
 
     bundle p assets = TokenBundle.fromNestedList tips [(p, NE.fromList assets)]
 
-    simple p = bundle p [(TokenName.empty, TokenQuantity 1_000_000_000)]
+    simple p = bundle p [(AssetName.empty, TokenQuantity 1_000_000_000)]
     fruit p =
         bundle
             p
-            [ (UnsafeTokenName "apple", TokenQuantity 65_000_000)
-            , (UnsafeTokenName "banana", TokenQuantity 66_000_000)
-            , (UnsafeTokenName "cherry", TokenQuantity 67_000_000)
+            [ (UnsafeAssetName "apple", TokenQuantity 65_000_000)
+            , (UnsafeAssetName "banana", TokenQuantity 66_000_000)
+            , (UnsafeAssetName "cherry", TokenQuantity 67_000_000)
             ]
     combined p = simple p `TokenBundle.add` fruit p
 
@@ -340,7 +340,7 @@ seaHorseTestAssets nPerAddr c addrs =
     mint :: (t -> a) -> (t, b) -> (a, [b])
     mint mk (pid, info) = (mk pid, [info])
     seaHorse is p = bundle p $ flip map is $ \i ->
-        (seaHorseTokenName i, TokenQuantity 1)
+        (seaHorseAssetName i, TokenQuantity 1)
     bundle p assets = TokenBundle.fromNestedList c [(p, NE.fromList assets)]
 
 seaHorsePolicyId :: TokenPolicyId
@@ -359,9 +359,9 @@ seaHorseAssetScript =
             )
         )
 
-seaHorseTokenName :: Int -> TokenName
-seaHorseTokenName i =
-    UnsafeTokenName
+seaHorseAssetName :: Int -> AssetName
+seaHorseAssetName i =
+    UnsafeAssetName
         $ B8.pack
         $ "00000000000000000SeaHorse" <> show i
 

--- a/lib/local-cluster/lib/Cardano/Wallet/Faucet.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Faucet.hs
@@ -51,14 +51,14 @@ import Cardano.Mnemonic
     ( Mnemonic
     , SomeMnemonic (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
@@ -102,8 +102,8 @@ import qualified Cardano.Address as CA
 import qualified Cardano.Address.Style.Icarus as Icarus
 import qualified Cardano.Wallet.Faucet.Addresses as Addresses
 import qualified Cardano.Wallet.Faucet.Mnemonics as Mnemonics
+import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
-import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
@@ -161,14 +161,14 @@ import Cardano.Wallet.Network.Ports
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
@@ -162,7 +162,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -2271,7 +2271,7 @@ sendFaucet tr config conn what targets = do
                     ++ map (("+ " ++) . cliAsset) (TokenMap.toFlatList tokens)
             ]
         cliAsset (aid, (TokenQuantity q)) = unwords [show q, cliAssetId aid]
-        cliAssetId (AssetId pid (UnsafeTokenName name)) =
+        cliAssetId (AssetId pid (UnsafeAssetName name)) =
             mconcat
                 [ T.unpack (toText pid)
                 , if B8.null name then "" else "."

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -153,6 +153,8 @@ library
     Cardano.Wallet.Primitive.Types.AnyExplicitScripts
     Cardano.Wallet.Primitive.Types.AssetId
     Cardano.Wallet.Primitive.Types.AssetId.Gen
+    Cardano.Wallet.Primitive.Types.AssetName
+    Cardano.Wallet.Primitive.Types.AssetName.Gen
     Cardano.Wallet.Primitive.Types.Block
     Cardano.Wallet.Primitive.Types.Block.Gen
     Cardano.Wallet.Primitive.Types.BlockSummary
@@ -187,8 +189,6 @@ library
     Cardano.Wallet.Primitive.Types.TokenMap.Gen
     Cardano.Wallet.Primitive.Types.TokenMapWithScripts
     Cardano.Wallet.Primitive.Types.TokenMetadata
-    Cardano.Wallet.Primitive.Types.TokenName
-    Cardano.Wallet.Primitive.Types.TokenName.Gen
     Cardano.Wallet.Primitive.Types.TokenPolicyId
     Cardano.Wallet.Primitive.Types.TokenPolicyId.Gen
     Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
@@ -19,7 +19,7 @@ module Cardano.Wallet.Primitive.Ledger.Convert
     , toLedgerCoin
     , toLedgerTokenBundle
     , toLedgerTokenPolicyId
-    , toLedgerTokenName
+    , toLedgerAssetName
     , toLedgerTokenQuantity
     , toLedgerTimelockScript
 
@@ -28,7 +28,7 @@ module Cardano.Wallet.Primitive.Ledger.Convert
     , toWalletCoin
     , toWalletTokenBundle
     , toWalletTokenPolicyId
-    , toWalletTokenName
+    , toWalletAssetName
     , toWalletTokenQuantity
     , toWalletScript
     , toWalletScriptFromShelley
@@ -62,7 +62,7 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -198,7 +198,7 @@ toLedgerTokenBundle bundle =
         & Map.map mapInner
         & Ledger.MultiAsset
     mapInner inner = inner
-        & Map.mapKeys toLedgerTokenName
+        & Map.mapKeys toLedgerAssetName
         & Map.map toLedgerTokenQuantity
 
 toWalletTokenBundle :: Ledger.MaryValue StandardCrypto -> TokenBundle
@@ -211,24 +211,24 @@ toWalletTokenBundle
         & Map.mapKeys toWalletTokenPolicyId
         & Map.map mapInner
     mapInner inner = inner
-        & Map.mapKeys toWalletTokenName
+        & Map.mapKeys toWalletAssetName
         & Map.map toWalletTokenQuantity
 
 --------------------------------------------------------------------------------
--- Conversions for 'TokenName'
+-- Conversions for 'AssetName'
 --------------------------------------------------------------------------------
 
-instance Convert TokenName Ledger.AssetName where
-    toLedger = toLedgerTokenName
-    toWallet = toWalletTokenName
+instance Convert AssetName Ledger.AssetName where
+    toLedger = toLedgerAssetName
+    toWallet = toWalletAssetName
 
-toLedgerTokenName :: TokenName -> Ledger.AssetName
-toLedgerTokenName (UnsafeTokenName bytes) =
+toLedgerAssetName :: AssetName -> Ledger.AssetName
+toLedgerAssetName (UnsafeAssetName bytes) =
     Ledger.AssetName $ toShort bytes
 
-toWalletTokenName :: Ledger.AssetName -> TokenName
-toWalletTokenName (Ledger.AssetName bytes) =
-    UnsafeTokenName $ fromShort bytes
+toWalletAssetName :: Ledger.AssetName -> AssetName
+toWalletAssetName (Ledger.AssetName bytes) =
+    UnsafeAssetName $ fromShort bytes
 
 --------------------------------------------------------------------------------
 -- Conversions for 'TokenPolicyId'

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
@@ -61,6 +61,9 @@ import Cardano.Slotting.Slot
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -69,9 +72,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Mint.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Mint.hs
@@ -42,8 +42,8 @@ import Cardano.Ledger.Shelley.TxWits
     , scriptWits
     )
 import Cardano.Wallet.Primitive.Ledger.Convert
-    ( toWalletScript
-    , toWalletAssetName
+    ( toWalletAssetName
+    , toWalletScript
     , toWalletTokenPolicyId
     , toWalletTokenQuantity
     )

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Mint.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Mint.hs
@@ -43,7 +43,7 @@ import Cardano.Ledger.Shelley.TxWits
     )
 import Cardano.Wallet.Primitive.Ledger.Convert
     ( toWalletScript
-    , toWalletTokenName
+    , toWalletAssetName
     , toWalletTokenPolicyId
     , toWalletTokenQuantity
     )
@@ -222,7 +222,7 @@ fromLedgerMintValue (MultiAsset ledgerTokens) = (assetsToMint, assetsToBurn)
         & TokenMap.fromNestedMap
 
     mapInner inner = inner
-        & Map.mapKeys toWalletTokenName
+        & Map.mapKeys toWalletAssetName
         & Map.map toWalletTokenQuantity
 
 fromMaryScriptMap

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Outputs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Outputs.hs
@@ -69,11 +69,11 @@ import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Ledger
 import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.AssetId as W
+import qualified Cardano.Wallet.Primitive.Types.AssetName as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
-import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as W
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Outputs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Outputs.hs
@@ -157,12 +157,12 @@ fromCardanoValue = uncurry TokenBundle.fromFlatList . extract
           | otherwise = internalError "negative token quantity"
 
     mkBundle assets =
-        [ (W.AssetId (mkPolicyId p) (mkTokenName n), mkQuantity q)
+        [ (W.AssetId (mkPolicyId p) (mkAssetName n), mkQuantity q)
         | (Cardano.AssetId p n, Cardano.Quantity q) <- assets
         ]
 
     mkPolicyId = W.UnsafeTokenPolicyId . W.Hash . Cardano.serialiseToRawBytes
-    mkTokenName = W.UnsafeTokenName . Cardano.serialiseToRawBytes
+    mkAssetName = W.UnsafeAssetName . Cardano.serialiseToRawBytes
 
 fromByronTxOut :: Byron.TxOut -> W.TxOut
 fromByronTxOut (Byron.TxOut addr coin) = W.TxOut

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -1257,8 +1257,8 @@ toCardanoValue tb = Cardano.valueFromList $
     toCardanoAssetId (W.AssetId pid name) =
         Cardano.AssetId (toCardanoPolicyId pid) (toCardanoAssetName name)
 
-    toCardanoAssetName (W.UnsafeTokenName name) =
-        just "toCardanoValue" "TokenName"
+    toCardanoAssetName (W.UnsafeAssetName name) =
+        just "toCardanoValue" "AssetName"
         [ eitherToMaybe
             $ Cardano.deserialiseFromRawBytes Cardano.AsAssetName name
         ]

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -390,6 +390,7 @@ import qualified Cardano.Wallet.Primitive.Ledger.Convert as Ledger
 import qualified Cardano.Wallet.Primitive.Slotting as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.AssetId as W
+import qualified Cardano.Wallet.Primitive.Types.AssetName as W
 import qualified Cardano.Wallet.Primitive.Types.Block as W
 import qualified Cardano.Wallet.Primitive.Types.Certificates as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
@@ -407,7 +408,6 @@ import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
 import qualified Cardano.Wallet.Primitive.Types.SlottingParameters as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenBundleMaxSize as W
-import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as W
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId.hs
@@ -20,7 +20,7 @@ import GHC.Generics
     ( Generic
     )
 
--- | A combination of a token policy identifier and a token name that can be
+-- | A combination of a token policy identifier and an asset name that can be
 --   used as a compound identifier.
 --
 data AssetId = AssetId

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId.hs
@@ -7,7 +7,7 @@ module Cardano.Wallet.Primitive.Types.AssetId
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.TokenName
+import Cardano.Wallet.Primitive.Types.AssetName
     ( TokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId.hs
@@ -26,7 +26,7 @@ import GHC.Generics
 data AssetId = AssetId
     { tokenPolicyId
         :: !TokenPolicyId
-    , tokenName
+    , assetName
         :: !AssetName
     }
     deriving stock (Eq, Generic, Ord, Read, Show)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId.hs
@@ -8,7 +8,7 @@ module Cardano.Wallet.Primitive.Types.AssetId
 import Prelude
 
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName
+    ( AssetName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
@@ -27,7 +27,7 @@ data AssetId = AssetId
     { tokenPolicyId
         :: !TokenPolicyId
     , tokenName
-        :: !TokenName
+        :: !AssetName
     }
     deriving stock (Eq, Generic, Ord, Read, Show)
 

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId/Gen.hs
@@ -13,7 +13,7 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenName.Gen
+import Cardano.Wallet.Primitive.Types.AssetName.Gen
     ( genTokenName
     , genTokenNameLargeRange
     , shrinkTokenName

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId/Gen.hs
@@ -14,10 +14,10 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName.Gen
-    ( genTokenName
-    , genTokenNameLargeRange
-    , shrinkTokenName
-    , testTokenNames
+    ( genAssetName
+    , genAssetNameLargeRange
+    , shrinkAssetName
+    , testAssetNames
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId.Gen
     ( genTokenPolicyId
@@ -51,12 +51,12 @@ import Test.QuickCheck.Extra
 --------------------------------------------------------------------------------
 
 genAssetId :: Gen AssetId
-genAssetId = genSized2With AssetId genTokenPolicyId genTokenName
+genAssetId = genSized2With AssetId genTokenPolicyId genAssetName
 
 shrinkAssetId :: AssetId -> [AssetId]
 shrinkAssetId (AssetId p t) = uncurry AssetId <$> shrinkInterleaved
     (p, shrinkTokenPolicyId)
-    (t, shrinkTokenName)
+    (t, shrinkAssetName)
 
 --------------------------------------------------------------------------------
 -- Asset identifiers chosen from a large range (to minimize collisions)
@@ -65,7 +65,7 @@ shrinkAssetId (AssetId p t) = uncurry AssetId <$> shrinkInterleaved
 genAssetIdLargeRange :: Gen AssetId
 genAssetIdLargeRange = AssetId
     <$> genTokenPolicyIdLargeRange
-    <*> genTokenNameLargeRange
+    <*> genAssetNameLargeRange
 
 --------------------------------------------------------------------------------
 -- Filtering functions
@@ -79,6 +79,6 @@ instance Function AssetIdF where
 
 instance CoArbitrary AssetIdF where
     coarbitrary (AssetIdF AssetId {tokenName, tokenPolicyId}) genB = do
-        let n = fromMaybe 0 (elemIndex tokenName testTokenNames)
+        let n = fromMaybe 0 (elemIndex tokenName testAssetNames)
         let m = fromMaybe 0 (elemIndex tokenPolicyId testTokenPolicyIds)
         variant (n + m) genB

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId/Gen.hs
@@ -78,7 +78,7 @@ instance Function AssetIdF where
     function = functionMap show read
 
 instance CoArbitrary AssetIdF where
-    coarbitrary (AssetIdF AssetId {tokenName, tokenPolicyId}) genB = do
-        let n = fromMaybe 0 (elemIndex tokenName testAssetNames)
+    coarbitrary (AssetIdF AssetId {assetName, tokenPolicyId}) genB = do
+        let n = fromMaybe 0 (elemIndex assetName testAssetNames)
         let m = fromMaybe 0 (elemIndex tokenPolicyId testTokenPolicyIds)
         variant (n + m) genB

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetName.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetName.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 
 module Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     , empty
     , fromByteString
     , maxLength
@@ -56,20 +56,20 @@ import qualified Data.ByteString as BS
 import qualified Data.Text.Encoding as T
 
 -- | Token names, defined by the monetary policy script.
-newtype TokenName =
-    -- | Construct a 'TokenName' without any validation.
-    UnsafeTokenName { unTokenName :: ByteString }
+newtype AssetName =
+    -- | Construct a 'AssetName' without any validation.
+    UnsafeAssetName { unAssetName :: ByteString }
     deriving stock (Eq, Ord, Generic)
-    deriving (Read, Show) via (Quiet TokenName)
+    deriving (Read, Show) via (Quiet AssetName)
     deriving anyclass Hashable
 
--- | Construct a 'TokenName', validating that the length does not exceed
+-- | Construct a 'AssetName', validating that the length does not exceed
 --   'maxLength'.
 --
-fromByteString :: ByteString -> Either String TokenName
+fromByteString :: ByteString -> Either String AssetName
 fromByteString bs
-    | BS.length bs <= maxLength = Right $ UnsafeTokenName bs
-    | otherwise = Left $ "TokenName length " ++ show (BS.length bs)
+    | BS.length bs <= maxLength = Right $ UnsafeAssetName bs
+    | otherwise = Left $ "AssetName length " ++ show (BS.length bs)
         ++ " exceeds maximum of " ++ show maxLength
 
 -- | The empty asset name.
@@ -78,30 +78,30 @@ fromByteString bs
 -- asset, or where one asset should be considered as the "default" token for the
 -- policy.
 --
-empty :: TokenName
-empty = UnsafeTokenName ""
+empty :: AssetName
+empty = UnsafeAssetName ""
 
 -- | The maximum length of a valid token name.
 --
 maxLength :: Int
 maxLength = 32
 
-instance NFData TokenName
+instance NFData AssetName
 
-instance Buildable TokenName where
+instance Buildable AssetName where
     build = build . toText
 
-instance FromJSON TokenName where
+instance FromJSON AssetName where
     parseJSON = parseJSON >=> either (fail . show) pure . fromText
 
-instance ToJSON TokenName where
+instance ToJSON AssetName where
     toJSON = toJSON . toText
 
-instance ToText TokenName where
-    toText = T.decodeLatin1 . convertToBase Base16 . unTokenName
+instance ToText AssetName where
+    toText = T.decodeLatin1 . convertToBase Base16 . unAssetName
 
-instance FromText TokenName where
+instance FromText AssetName where
     fromText = first TextDecodingError
-        . either (Left . ("TokenName is not hex-encoded: " ++)) fromByteString
+        . either (Left . ("AssetName is not hex-encoded: " ++)) fromByteString
         . convertFromBase Base16
         . T.encodeUtf8

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetName.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetName.hs
@@ -55,15 +55,15 @@ import Quiet
 import qualified Data.ByteString as BS
 import qualified Data.Text.Encoding as T
 
--- | Token names, defined by the monetary policy script.
+-- | Asset names, defined by the monetary policy script.
 newtype AssetName =
-    -- | Construct a 'AssetName' without any validation.
+    -- | Construct an 'AssetName' without any validation.
     UnsafeAssetName { unAssetName :: ByteString }
     deriving stock (Eq, Ord, Generic)
     deriving (Read, Show) via (Quiet AssetName)
     deriving anyclass Hashable
 
--- | Construct a 'AssetName', validating that the length does not exceed
+-- | Construct an 'AssetName', validating that the length does not exceed
 --   'maxLength'.
 --
 fromByteString :: ByteString -> Either String AssetName
@@ -81,7 +81,7 @@ fromByteString bs
 empty :: AssetName
 empty = UnsafeAssetName ""
 
--- | The maximum length of a valid token name.
+-- | The maximum length of a valid asset name.
 --
 maxLength :: Int
 maxLength = 32

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetName.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetName.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 
-module Cardano.Wallet.Primitive.Types.TokenName
+module Cardano.Wallet.Primitive.Types.AssetName
     ( TokenName (..)
     , empty
     , fromByteString

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetName/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetName/Gen.hs
@@ -29,7 +29,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 
 --------------------------------------------------------------------------------
--- Token names chosen from a range that depends on the size parameter
+-- Asset names chosen from a range that depends on the size parameter
 --------------------------------------------------------------------------------
 
 genAssetName :: Gen AssetName
@@ -43,7 +43,7 @@ shrinkAssetName i
     simplest = head testAssetNames
 
 --------------------------------------------------------------------------------
--- Token names chosen from a large range (to minimize the risk of collisions)
+-- Asset names chosen from a large range (to minimize the risk of collisions)
 --------------------------------------------------------------------------------
 
 genAssetNameLargeRange :: Gen AssetName
@@ -57,4 +57,4 @@ testAssetNames :: [AssetName]
 testAssetNames = mkAssetName <$> ['A' .. 'Z']
 
 mkAssetName :: Char -> AssetName
-mkAssetName = UnsafeAssetName . B8.snoc "Token"
+mkAssetName = UnsafeAssetName . B8.snoc "Asset"

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetName/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetName/Gen.hs
@@ -1,22 +1,22 @@
 module Cardano.Wallet.Primitive.Types.AssetName.Gen
     (
     -- * Generators and shrinkers
-      genTokenName
-    , genTokenNameLargeRange
-    , shrinkTokenName
+      genAssetName
+    , genAssetNameLargeRange
+    , shrinkAssetName
 
     -- * Test values
-    , testTokenNames
+    , testAssetNames
 
     -- * Creation of test values
-    , mkTokenName
+    , mkAssetName
 
     ) where
 
 import Prelude
 
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Test.QuickCheck
     ( Gen
@@ -32,29 +32,29 @@ import qualified Data.ByteString.Char8 as B8
 -- Token names chosen from a range that depends on the size parameter
 --------------------------------------------------------------------------------
 
-genTokenName :: Gen TokenName
-genTokenName = sized $ \n -> elements $ take (max 1 n) testTokenNames
+genAssetName :: Gen AssetName
+genAssetName = sized $ \n -> elements $ take (max 1 n) testAssetNames
 
-shrinkTokenName :: TokenName -> [TokenName]
-shrinkTokenName i
+shrinkAssetName :: AssetName -> [AssetName]
+shrinkAssetName i
     | i == simplest = []
     | otherwise = [simplest]
   where
-    simplest = head testTokenNames
+    simplest = head testAssetNames
 
 --------------------------------------------------------------------------------
 -- Token names chosen from a large range (to minimize the risk of collisions)
 --------------------------------------------------------------------------------
 
-genTokenNameLargeRange :: Gen TokenName
-genTokenNameLargeRange = UnsafeTokenName . BS.pack <$> vector 32
+genAssetNameLargeRange :: Gen AssetName
+genAssetNameLargeRange = UnsafeAssetName . BS.pack <$> vector 32
 
 --------------------------------------------------------------------------------
 -- Internal utilities
 --------------------------------------------------------------------------------
 
-testTokenNames :: [TokenName]
-testTokenNames = mkTokenName <$> ['A' .. 'Z']
+testAssetNames :: [AssetName]
+testAssetNames = mkAssetName <$> ['A' .. 'Z']
 
-mkTokenName :: Char -> TokenName
-mkTokenName = UnsafeTokenName . B8.snoc "Token"
+mkAssetName :: Char -> AssetName
+mkAssetName = UnsafeAssetName . B8.snoc "Token"

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetName/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetName/Gen.hs
@@ -1,4 +1,4 @@
-module Cardano.Wallet.Primitive.Types.TokenName.Gen
+module Cardano.Wallet.Primitive.Types.AssetName.Gen
     (
     -- * Generators and shrinkers
       genTokenName
@@ -15,7 +15,7 @@ module Cardano.Wallet.Primitive.Types.TokenName.Gen
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.TokenName
+import Cardano.Wallet.Primitive.Types.AssetName
     ( TokenName (..)
     )
 import Test.QuickCheck

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -277,7 +277,7 @@ empty = mempty
 
 -- | Creates a token bundle from a coin and a flat list of token quantities.
 --
--- If a token name appears more than once in the list under the same policy,
+-- If an asset name appears more than once in the list under the same policy,
 -- its associated quantities will be added together in the resultant bundle.
 --
 fromFlatList
@@ -288,7 +288,7 @@ fromFlatList c = TokenBundle c . TokenMap.fromFlatList
 
 -- | Creates a token bundle from a coin and a nested list of token quantities.
 --
--- If a token name appears more than once in the list under the same policy,
+-- If an asset name appears more than once in the list under the same policy,
 -- its associated quantities will be added together in the resultant bundle.
 --
 fromNestedList

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -82,7 +82,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName
+    ( AssetName
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -293,12 +293,12 @@ fromFlatList c = TokenBundle c . TokenMap.fromFlatList
 --
 fromNestedList
     :: Coin
-    -> [(TokenPolicyId, NonEmpty (TokenName, TokenQuantity))]
+    -> [(TokenPolicyId, NonEmpty (AssetName, TokenQuantity))]
     -> TokenBundle
 fromNestedList c = TokenBundle c . TokenMap.fromNestedList
 
 fromNestedMap
-    :: (Coin, Map TokenPolicyId (Map TokenName TokenQuantity))
+    :: (Coin, Map TokenPolicyId (Map AssetName TokenQuantity))
     -> TokenBundle
 fromNestedMap (c, m) = TokenBundle c (TokenMap.fromNestedMap m)
 

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -81,6 +81,9 @@ import Algebra.PartialOrd
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -89,9 +92,6 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     , Lexicographic (..)
     , Nested (..)
     , TokenMap
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenFingerprint.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenFingerprint.hs
@@ -14,11 +14,11 @@ module Cardano.Wallet.Primitive.Types.TokenFingerprint
 
 import Prelude
 
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (UnsafeTokenPolicyId)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenFingerprint.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenFingerprint.hs
@@ -15,7 +15,7 @@ module Cardano.Wallet.Primitive.Types.TokenFingerprint
 import Prelude
 
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
@@ -70,11 +70,11 @@ newtype TokenFingerprint =
 
 instance NFData TokenFingerprint
 
--- | Construct a fingerprint from a 'TokenPolicyId' and 'TokenName'. The
+-- | Construct a fingerprint from a 'TokenPolicyId' and 'AssetName'. The
 -- fingerprint is not necessarily unique, but can be used in user-facing
 -- interfaces as a comparison mechanism.
-mkTokenFingerprint :: TokenPolicyId -> TokenName -> TokenFingerprint
-mkTokenFingerprint (UnsafeTokenPolicyId (Hash p)) (UnsafeTokenName n)
+mkTokenFingerprint :: TokenPolicyId -> AssetName -> TokenFingerprint
+mkTokenFingerprint (UnsafeTokenPolicyId (Hash p)) (UnsafeAssetName n)
     = (p <> n)
     & convert . hash @_ @Blake2b_160
     & Bech32.encodeLenient tokenFingerprintHrp . Bech32.dataPartFromBytes

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -497,7 +497,7 @@ singleton = setQuantity empty
 
 -- | Creates a token map from a flat list.
 --
--- If a token name appears more than once in the list under the same policy,
+-- If an asset name appears more than once in the list under the same policy,
 -- its associated quantities will be added together in the resultant map.
 --
 fromFlatList :: [(AssetId, TokenQuantity)] -> TokenMap
@@ -507,7 +507,7 @@ fromFlatList = F.foldl' acc empty
 
 -- | Creates a token map from a nested list.
 --
--- If a token name appears more than once in the list under the same policy,
+-- If an asset name appears more than once in the list under the same policy,
 -- its associated quantities will be added together in the resultant map.
 --
 fromNestedList

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -96,7 +96,7 @@ import Cardano.Numeric.Util
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (AssetId)
     )
-import Cardano.Wallet.Primitive.Types.TokenName
+import Cardano.Wallet.Primitive.Types.AssetName
     ( TokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
@@ -20,10 +20,10 @@ import Cardano.Wallet.Primitive.Ledger.Convert
     , toWalletScript
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName
+    ( AssetName
     )
 import Cardano.Wallet.Primitive.Types.AssetName.Gen
-    ( genTokenNameLargeRange
+    ( genAssetNameLargeRange
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -105,7 +105,7 @@ spec = describe "Cardano.Wallet.Primitive.Ledger.ConvertSpec" $
 
         ledgerRoundtrip $ Proxy @Coin
         ledgerRoundtrip $ Proxy @TokenBundle
-        ledgerRoundtrip $ Proxy @TokenName
+        ledgerRoundtrip $ Proxy @AssetName
         ledgerRoundtrip $ Proxy @TokenPolicyId
         ledgerRoundtrip $ Proxy @TokenQuantity
         ledgerRoundtrip $ Proxy @TxIn
@@ -152,8 +152,8 @@ instance Arbitrary TokenBundle where
     arbitrary = genTokenBundleSmallRange
     shrink = shrinkTokenBundleSmallRange
 
-instance Arbitrary TokenName where
-    arbitrary = genTokenNameLargeRange
+instance Arbitrary AssetName where
+    arbitrary = genAssetNameLargeRange
     -- No shrinking
 
 instance Arbitrary TokenPolicyId where

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ConvertSpec.hs
@@ -19,6 +19,12 @@ import Cardano.Wallet.Primitive.Ledger.Convert
     , toLedgerTimelockScript
     , toWalletScript
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName
+    )
+import Cardano.Wallet.Primitive.Types.AssetName.Gen
+    ( genTokenNameLargeRange
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -28,12 +34,6 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange
     , shrinkTokenBundleSmallRange
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName
-    )
-import Cardano.Wallet.Primitive.Types.TokenName.Gen
-    ( genTokenNameLargeRange
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenFingerprintSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenFingerprintSpec.hs
@@ -4,15 +4,15 @@ module Cardano.Wallet.Primitive.Types.TokenFingerprintSpec
 
 import Prelude
 
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenFingerprint
     ( TokenFingerprint (..)
     , mkTokenFingerprint
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenFingerprintSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenFingerprintSpec.hs
@@ -5,7 +5,7 @@ module Cardano.Wallet.Primitive.Types.TokenFingerprintSpec
 import Prelude
 
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
@@ -86,6 +86,6 @@ goldenTestCIP14
 goldenTestCIP14 rawPolicyId rawAssetName rawFingerprint =
     it ("golden test CIP-0014 - " <> T.unpack rawFingerprint) $ do
         let policyId = UnsafeTokenPolicyId $ Hash $ unsafeFromHex rawPolicyId
-        let assetName = UnsafeTokenName $ unsafeFromHex rawAssetName
+        let assetName = UnsafeAssetName $ unsafeFromHex rawAssetName
         let fingerprint = UnsafeTokenFingerprint rawFingerprint
         mkTokenFingerprint policyId assetName `shouldBe` fingerprint

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -32,11 +32,11 @@ import Cardano.Wallet.Primitive.Types.AssetId.Gen
     , shrinkAssetId
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName
+    ( AssetName
     )
 import Cardano.Wallet.Primitive.Types.AssetName.Gen
-    ( genTokenName
-    , shrinkTokenName
+    ( genAssetName
+    , shrinkAssetName
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
@@ -191,7 +191,7 @@ import Test.Utils.Paths
     ( getTestData
     )
 
-import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
+import qualified Cardano.Wallet.Primitive.Types.AssetName as AssetName
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
 import qualified Data.Aeson.Types as Aeson
@@ -370,7 +370,7 @@ prop_fromFlatList assetQuantities = checkCoverage $ property $
         Map.toList $ Map.fromListWith TokenQuantity.add assetQuantities
 
 prop_fromNestedList
-    :: [(TokenPolicyId, NonEmpty (TokenName, TokenQuantity))]
+    :: [(TokenPolicyId, NonEmpty (AssetName, TokenQuantity))]
     -> Property
 prop_fromNestedList assetQuantities = checkCoverage $ property $
     cover 2 (length flattenedAssetQuantities == length combinedAssetQuantities)
@@ -719,7 +719,7 @@ testZeroValuedTokenQuantityFlat =
         Left message
   where
     policy = dummyTokenPolicyId 'A'
-    token = dummyTokenName "DUMMY-TOKEN"
+    token = dummyAssetName "DUMMY-TOKEN"
     json =
         [aesonQQ|
           [ { "policy_id": #{policy}
@@ -742,7 +742,7 @@ testZeroValuedTokenQuantityNested =
         Left message
   where
     policy = dummyTokenPolicyId 'A'
-    token = dummyTokenName "DUMMY-TOKEN"
+    token = dummyAssetName "DUMMY-TOKEN"
     json =
         [aesonQQ|
           [ { "policy_id": #{policy}
@@ -799,7 +799,7 @@ testPrettyNested =
 testMap :: TokenMap
 testMap = testMapData
     & fmap (second TokenQuantity)
-    & fmap (first (bimap dummyTokenPolicyId dummyTokenName))
+    & fmap (first (bimap dummyTokenPolicyId dummyAssetName))
     & fmap (first (uncurry AssetId))
     & TokenMap.fromFlatList
 
@@ -847,8 +847,8 @@ testMapPrettyNested = [s|
 -- Utilities
 --------------------------------------------------------------------------------
 
-dummyTokenName :: ByteString -> TokenName
-dummyTokenName t = fromRight reportError $ TokenName.fromByteString t
+dummyAssetName :: ByteString -> AssetName
+dummyAssetName t = fromRight reportError $ AssetName.fromByteString t
   where
     reportError = error $
         "Unable to construct dummy token name from bytes: " <> show t
@@ -919,12 +919,12 @@ instance Arbitrary (Large TokenMap) where
             <*> genTokenQuantityPositive
     -- No shrinking
 
-instance Arbitrary TokenName where
-    arbitrary = genTokenName
-    shrink = shrinkTokenName
+instance Arbitrary AssetName where
+    arbitrary = genAssetName
+    shrink = shrinkAssetName
 
-deriving anyclass instance CoArbitrary TokenName
-deriving anyclass instance Function TokenName
+deriving anyclass instance CoArbitrary AssetName
+deriving anyclass instance Function AssetName
 
 instance Arbitrary TokenPolicyId where
     arbitrary = genTokenPolicyId

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -719,7 +719,7 @@ testZeroValuedTokenQuantityFlat =
         Left message
   where
     policy = dummyTokenPolicyId 'A'
-    token = dummyAssetName "DUMMY-TOKEN"
+    token = dummyAssetName "DUMMY-ASSET"
     json =
         [aesonQQ|
           [ { "policy_id": #{policy}
@@ -742,7 +742,7 @@ testZeroValuedTokenQuantityNested =
         Left message
   where
     policy = dummyTokenPolicyId 'A'
-    token = dummyAssetName "DUMMY-TOKEN"
+    token = dummyAssetName "DUMMY-ASSET"
     json =
         [aesonQQ|
           [ { "policy_id": #{policy}
@@ -851,7 +851,7 @@ dummyAssetName :: ByteString -> AssetName
 dummyAssetName t = fromRight reportError $ AssetName.fromByteString t
   where
     reportError = error $
-        "Unable to construct dummy token name from bytes: " <> show t
+        "Unable to construct dummy asset name from bytes: " <> show t
 
 -- The input must be a character in the range [0-9] or [A-Z].
 --

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -31,6 +31,13 @@ import Cardano.Wallet.Primitive.Types.AssetId.Gen
     , genAssetIdLargeRange
     , shrinkAssetId
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName
+    )
+import Cardano.Wallet.Primitive.Types.AssetName.Gen
+    ( genTokenName
+    , shrinkTokenName
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
@@ -44,13 +51,6 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genTokenMapPartition
     , genTokenMapSmallRange
     , shrinkTokenMap
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName
-    )
-import Cardano.Wallet.Primitive.Types.TokenName.Gen
-    ( genTokenName
-    , shrinkTokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
@@ -191,8 +191,8 @@ import Test.Utils.Paths
     ( getTestData
     )
 
+import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.Foldable as F

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TxSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TxSpec.hs
@@ -24,11 +24,11 @@ import Cardano.Wallet.Primitive.Types.AssetId.Gen
     ( genAssetId
     , shrinkAssetId
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TxSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TxSpec.hs
@@ -25,7 +25,7 @@ import Cardano.Wallet.Primitive.Types.AssetId.Gen
     , shrinkAssetId
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
@@ -235,8 +235,8 @@ instance Arbitrary TxOut where
     arbitrary = genTxOut
     shrink = shrinkTxOut
 
-deriving anyclass instance CoArbitrary TokenName
-deriving anyclass instance Function TokenName
+deriving anyclass instance CoArbitrary AssetName
+deriving anyclass instance Function AssetName
 
 deriving anyclass instance CoArbitrary TokenPolicyId
 deriving anyclass instance Function TokenPolicyId

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -29,12 +29,12 @@ import Cardano.Wallet.Primitive.Types.AssetId.Gen
     ( genAssetId
     , shrinkAssetId
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     , mockHash
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -30,7 +30,7 @@ import Cardano.Wallet.Primitive.Types.AssetId.Gen
     , shrinkAssetId
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
@@ -396,8 +396,8 @@ deriving newtype instance Arbitrary (Hash "Tx")
 deriving anyclass instance CoArbitrary (Hash "Tx")
 deriving anyclass instance Function (Hash "Tx")
 
-deriving anyclass instance CoArbitrary TokenName
-deriving anyclass instance Function TokenName
+deriving anyclass instance CoArbitrary AssetName
+deriving anyclass instance Function AssetName
 
 deriving anyclass instance CoArbitrary TokenPolicyId
 deriving anyclass instance Function TokenPolicyId

--- a/lib/wallet/api/http/Cardano/Wallet/Api.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api.hs
@@ -281,7 +281,7 @@ import Cardano.Wallet.Primitive.Types.Address
     ( AddressState
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName
+    ( AssetName
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -538,7 +538,7 @@ type GetAsset = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "assets"
     :> Capture "policyId" (ApiT TokenPolicyId)
-    :> Capture "assetName" (ApiT TokenName)
+    :> Capture "assetName" (ApiT AssetName)
     :> Get '[JSON] ApiAsset
 
 -- | https://cardano-foundation.github.io/cardano-wallet/api/#operation/getAssetDefault
@@ -867,7 +867,7 @@ type GetByronAsset = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "assets"
     :> Capture "policyId" (ApiT TokenPolicyId)
-    :> Capture "assetName" (ApiT TokenName)
+    :> Capture "assetName" (ApiT AssetName)
     :> Get '[JSON] ApiAsset
 
 -- | https://cardano-foundation.github.io/cardano-wallet/api/#operation/getByronAssetDefault

--- a/lib/wallet/api/http/Cardano/Wallet/Api.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api.hs
@@ -280,11 +280,11 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( AddressState
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -396,7 +396,7 @@ instance IsServerError ErrMkTransaction where
                 , ". Token policy identifier: "
                 , pretty (view (#asset . #tokenPolicyId) e)
                 , ". Asset name: "
-                , pretty (view (#asset . #tokenName) e)
+                , pretty (view (#asset . #assetName) e)
                 , ". Token quantity specified: "
                 , pretty (view #quantity e)
                 , ". Maximum allowable token quantity: "

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -586,7 +586,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -890,7 +890,7 @@ import qualified Cardano.Wallet.Delegation as WD
 import qualified Cardano.Wallet.Network as NW
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
 import qualified Cardano.Wallet.Primitive.Types as W
-import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
+import qualified Cardano.Wallet.Primitive.Types.AssetName as AssetName
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx.SealedTx as W
@@ -2235,7 +2235,7 @@ getAsset
     => ctx
     -> ApiT WalletId
     -> ApiT TokenPolicyId
-    -> ApiT TokenName
+    -> ApiT AssetName
     -> Handler ApiAsset
 getAsset ctx wid (ApiT policyId) (ApiT assetName) = do
     assetId <- liftHandler . findAsset =<< listAssetsBase ctx wid
@@ -2245,7 +2245,7 @@ getAsset ctx wid (ApiT policyId) (ApiT assetName) = do
         . F.find (== (AssetId policyId assetName))
     client = ctx ^. tokenMetadataClient
 
--- | The handler for 'getAsset' when 'TokenName' is empty.
+-- | The handler for 'getAsset' when 'AssetName' is empty.
 getAssetDefault
     :: forall ctx s .
         ( ctx ~ ApiLayer s
@@ -2256,7 +2256,7 @@ getAssetDefault
     -> ApiT WalletId
     -> ApiT TokenPolicyId
     -> Handler ApiAsset
-getAssetDefault ctx wid pid = getAsset ctx wid pid (ApiT TokenName.empty)
+getAssetDefault ctx wid pid = getAsset ctx wid pid (ApiT AssetName.empty)
 
 {-------------------------------------------------------------------------------
                                     Addresses
@@ -2943,11 +2943,11 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
           where
             updateFromScript :: ApiMintBurnDataFromScript n -> ApiMintBurnDataFromScript n
             updateFromScript mbd = case mbd ^. #assetName of
-                Nothing -> mbd {assetName = Just (ApiT TokenName.empty)}
+                Nothing -> mbd {assetName = Just (ApiT AssetName.empty)}
                 Just _ -> mbd
             updateFromInp :: ApiMintBurnDataFromInput n -> ApiMintBurnDataFromInput n
             updateFromInp mbd = case mbd ^. #assetName of
-                Nothing -> mbd {assetName = Just (ApiT TokenName.empty)}
+                Nothing -> mbd {assetName = Just (ApiT AssetName.empty)}
                 Just _ -> mbd
 
         guardWrongMintingTemplate
@@ -2972,10 +2972,10 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
             when (any assetNameTooLong mbs)$ Left ErrConstructTxAssetNameTooLong
           where
             assetNameTooLong mb = case mb ^. #mintBurnData of
-                Left (ApiMintBurnDataFromScript _ (Just (ApiT (UnsafeTokenName bs))) _) ->
-                    BS.length bs > TokenName.maxLength
-                Right (ApiMintBurnDataFromInput _ _ (Just (ApiT (UnsafeTokenName bs))) _) ->
-                    BS.length bs > TokenName.maxLength
+                Left (ApiMintBurnDataFromScript _ (Just (ApiT (UnsafeAssetName bs))) _) ->
+                    BS.length bs > AssetName.maxLength
+                Right (ApiMintBurnDataFromInput _ _ (Just (ApiT (UnsafeAssetName bs))) _) ->
+                    BS.length bs > AssetName.maxLength
                 _ -> error "at this moment there should be asset name attributed"
 
         guardAssetQuantityOutOfBounds

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -585,6 +585,9 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -601,9 +604,6 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap
     , fromFlatList
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
@@ -890,9 +890,9 @@ import qualified Cardano.Wallet.Delegation as WD
 import qualified Cardano.Wallet.Network as NW
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
-import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
 import qualified Cardano.Wallet.Primitive.Types.Tx.SealedTx as W
     ( SealedTx
     , sealedTxFromCardano

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Link.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Link.hs
@@ -161,7 +161,7 @@ import Cardano.Wallet.Primitive.Types.Address
     , AddressState
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName
+    ( AssetName
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -221,7 +221,7 @@ import Web.HttpApiData
     )
 
 import qualified Cardano.Wallet.Api as Api
-import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
+import qualified Cardano.Wallet.Primitive.Types.AssetName as AssetName
 
 --
 -- Wallets
@@ -582,10 +582,10 @@ getAsset
         )
     => w
     -> TokenPolicyId
-    -> TokenName
+    -> AssetName
     -> (Method, Text)
 getAsset w pid n
-    | n == TokenName.empty = endpoint @Api.GetAssetDefault mkURLDefault
+    | n == AssetName.empty = endpoint @Api.GetAssetDefault mkURLDefault
     | otherwise = endpoint @Api.GetAsset mkURL
   where
     wid = w ^. typed @(ApiT WalletId)
@@ -609,10 +609,10 @@ getByronAsset
         )
     => w
     -> TokenPolicyId
-    -> TokenName
+    -> AssetName
     -> (Method, Text)
 getByronAsset w pid n
-    | n == TokenName.empty = endpoint @Api.GetByronAssetDefault mkURLDefault
+    | n == AssetName.empty = endpoint @Api.GetByronAssetDefault mkURLDefault
     | otherwise = endpoint @Api.GetByronAsset mkURL
   where
     wid = w ^. typed @(ApiT WalletId)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Link.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Link.hs
@@ -160,14 +160,14 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address
     , AddressState
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
@@ -221,7 +221,7 @@ import Web.HttpApiData
     )
 
 import qualified Cardano.Wallet.Api as Api
-import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
+import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
 
 --
 -- Wallets

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -648,9 +648,9 @@ import qualified Cardano.Address.Script as CA
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet.Address.Derivation as AD
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.AssetName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenFingerprint as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMetadata as W
-import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as W
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -773,7 +773,7 @@ newtype ApiPostPolicyIdData = ApiPostPolicyIdData
 
 data ApiAsset = ApiAsset
     { policyId :: ApiT W.TokenPolicyId
-    , assetName :: ApiT W.TokenName
+    , assetName :: ApiT W.AssetName
     , fingerprint :: ApiT W.TokenFingerprint
     , metadata :: Maybe ApiAssetMetadata
     , metadataError :: Maybe ApiMetadataError
@@ -3404,7 +3404,7 @@ data ApiMintBurnDataFromScript (n :: NetworkDiscriminant) = ApiMintBurnDataFromS
         -- ^ A script regulating minting/burning policy. 'self' is expected
         -- in place of verification key.
     , assetName
-        :: !(Maybe (ApiT W.TokenName))
+        :: !(Maybe (ApiT W.AssetName))
         -- ^ The name of the asset to mint/burn.
     , operation
         :: !(ApiMintBurnOperation n)
@@ -3422,7 +3422,7 @@ data ApiMintBurnDataFromInput (n :: NetworkDiscriminant) = ApiMintBurnDataFromIn
         :: !(ApiT W.TokenPolicyId)
         -- ^ A policy id of the script regulating minting/burning policy.
     , assetName
-        :: !(Maybe (ApiT W.TokenName))
+        :: !(Maybe (ApiT W.AssetName))
         -- ^ The name of the asset to mint/burn.
     , operation
         :: !(ApiMintBurnOperation n)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/MintBurn.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/MintBurn.hs
@@ -40,7 +40,7 @@ import Cardano.Wallet.Api.Types.Key
 import Cardano.Wallet.Api.Types.Primitive
     ()
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName
+    ( AssetName
     )
 import Cardano.Wallet.Primitive.Types.TokenFingerprint
     ( mkTokenFingerprint
@@ -86,7 +86,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 
 data ApiTokenAmountFingerprint = ApiTokenAmountFingerprint
-    { assetName :: ApiT W.TokenName
+    { assetName :: ApiT W.AssetName
     , quantity :: Natural
     , fingerprint :: ApiT W.TokenFingerprint
     }
@@ -128,7 +128,7 @@ includePolicyKeyInfo (TokenMapWithScripts tokenMap _) xpubM =
         xpubM
 
 fromIdScriptAssets
-    :: ( TokenPolicyId , AnyScript, NE.NonEmpty (TokenName, TokenQuantity) )
+    :: ( TokenPolicyId , AnyScript, NE.NonEmpty (AssetName, TokenQuantity) )
     -> ApiTokens
 fromIdScriptAssets (policy, script, tokens') = ApiTokens
     { policyId = ApiT policy
@@ -138,7 +138,7 @@ fromIdScriptAssets (policy, script, tokens') = ApiTokens
 
 toTokenAmountFingerprint
     :: TokenPolicyId
-    -> (TokenName, TokenQuantity)
+    -> (AssetName, TokenQuantity)
     -> ApiTokenAmountFingerprint
 toTokenAmountFingerprint policy (name, tokenquantity) =
     ApiTokenAmountFingerprint
@@ -150,7 +150,7 @@ toTokenAmountFingerprint policy (name, tokenquantity) =
 toIdScriptAssets
     :: Map TokenPolicyId b
     -> TokenMap.TokenMap
-    -> [(TokenPolicyId, b, NE.NonEmpty (TokenName, TokenQuantity))]
+    -> [(TokenPolicyId, b, NE.NonEmpty (AssetName, TokenQuantity))]
 toIdScriptAssets scriptmap tokenmap =
     [ (policy, askForScript policy scriptmap, tokenQuantities)
     | (policy, tokenQuantities) <- toNestedList tokenmap

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/MintBurn.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/MintBurn.hs
@@ -39,14 +39,14 @@ import Cardano.Wallet.Api.Types.Key
     )
 import Cardano.Wallet.Api.Types.Primitive
     ()
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName
+    )
 import Cardano.Wallet.Primitive.Types.TokenFingerprint
     ( mkTokenFingerprint
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( toNestedList
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
@@ -78,9 +78,9 @@ import Numeric.Natural
     ( Natural
     )
 
+import qualified Cardano.Wallet.Primitive.Types.AssetName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenFingerprint as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as W
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
@@ -314,11 +314,11 @@ instance ToJSON (ApiT AnyExplicitScript) where
                 , "reference" .= toJSON refInput
                 ]
 
-instance FromJSON (ApiT W.TokenName) where
+instance FromJSON (ApiT W.AssetName) where
     parseJSON = withText "AssetName"
-        (fmap (ApiT . W.UnsafeTokenName) . eitherToParser . fromHexText)
-instance ToJSON (ApiT W.TokenName) where
-    toJSON = toJSON . hexText . W.unTokenName . getApiT
+        (fmap (ApiT . W.UnsafeAssetName) . eitherToParser . fromHexText)
+instance ToJSON (ApiT W.AssetName) where
+    toJSON = toJSON . hexText . W.unAssetName . getApiT
 
 instance FromJSON (ApiT W.TokenFingerprint) where
     parseJSON = fromTextApiT "TokenFingerprint"

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
@@ -145,11 +145,11 @@ import Numeric.Natural
     )
 
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.AssetName as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
 import qualified Cardano.Wallet.Primitive.Types.TokenFingerprint as W
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as W
-import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as W
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Data.Aeson.Types as Aeson

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -184,6 +184,9 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -195,9 +198,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     )
 import Cardano.Wallet.Primitive.Types.Range
     ( Range (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..)

--- a/lib/wallet/bench/db-bench.hs
+++ b/lib/wallet/bench/db-bench.hs
@@ -185,7 +185,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -719,13 +719,13 @@ mkOutputs prefix nOuts nAssets =
         (mkAddress prefix i)
         (TokenBundle.TokenBundle (Coin 1) (TokenMap.fromFlatList tokens))
     tokens =
-        [ ( AssetId (mkTokenPolicyId (ac `mod` 10)) (mkTokenName ac)
+        [ ( AssetId (mkTokenPolicyId (ac `mod` 10)) (mkAssetName ac)
           , TokenQuantity 42
           )
         | !ac <- [1 .. nAssets]
         ]
-    mkTokenName =
-        UnsafeTokenName . B8.singleton . Char.chr
+    mkAssetName =
+        UnsafeAssetName . B8.singleton . Char.chr
     mkTokenPolicyId = fromRight (error "Couldn't decode tokenPolicyId")
         . fromText
         . T.pack

--- a/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
@@ -121,7 +121,7 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName
+    ( AssetName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
@@ -565,7 +565,7 @@ errMsg403OutputTokenBundleSizeExceedsLimit
 errMsg403OutputTokenQuantityExceedsLimit
     :: Address
     -> TokenPolicyId
-    -> TokenName
+    -> AssetName
     -> TokenQuantity
     -- ^ Specified token quantity
     -> TokenQuantity

--- a/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/TestData.hs
@@ -120,7 +120,7 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address
     )
-import Cardano.Wallet.Primitive.Types.TokenName
+import Cardano.Wallet.Primitive.Types.AssetName
     ( TokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -131,8 +131,8 @@ import Test.Integration.Framework.TestData
     )
 
 import qualified Cardano.Wallet.Api.Link as Link
+import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as TokenPolicy
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -131,7 +131,7 @@ import Test.Integration.Framework.TestData
     )
 
 import qualified Cardano.Wallet.Api.Link as Link
-import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
+import qualified Cardano.Wallet.Primitive.Types.AssetName as AssetName
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as TokenPolicy
 import qualified Data.ByteString as BS
@@ -303,7 +303,7 @@ spec = describe "BYRON_TRANSACTIONS" $ do
 
         wal <- srcFixture ctx
         let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
-        let assName = TokenName.UnsafeTokenName $ B8.replicate 4 'x'
+        let assName = AssetName.UnsafeAssetName $ B8.replicate 4 'x'
         let ep = Link.getByronAsset wal polId assName
         r <- request @(ApiAsset) ctx ep Default Empty
         expectResponseCode HTTP.status404 r
@@ -316,7 +316,7 @@ spec = describe "BYRON_TRANSACTIONS" $ do
 
         wal <- srcFixture ctx
         let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
-        let ep = Link.getByronAsset wal polId TokenName.empty
+        let ep = Link.getByronAsset wal polId AssetName.empty
         r <- request @(ApiAsset) ctx ep Default Empty
         expectResponseCode HTTP.status404 r
         expectErrorMessage errMsg404NoAsset r

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
@@ -364,9 +364,9 @@ spec = describe "SHELLEY_COIN_SELECTION" $ do
             let assetCount = 1_280
             let policyId = UnsafeTokenPolicyId $
                     Hash "1234567890123456789012345678"
-            let tokenNames = UnsafeAssetName . T.encodeUtf8 . T.singleton <$>
+            let assetNames = UnsafeAssetName . T.encodeUtf8 . T.singleton <$>
                     ['a' ..]
-            let assetIds = AssetId policyId <$> take assetCount tokenNames
+            let assetIds = AssetId policyId <$> take assetCount assetNames
             let nonAdaQuantities = TokenMap.fromFlatList $
                     (, TokenQuantity 1) <$> assetIds
             sourceWallet <- fixtureWallet ctx

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
@@ -42,7 +42,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
@@ -329,7 +329,7 @@ spec = describe "SHELLEY_COIN_SELECTION" $ do
     it "WALLETS_COIN_SELECTION_07 - \
         \Single output with excessively high token quantity." $
         \ctx -> runResourceT $ do
-            let assetName = UnsafeTokenName "1"
+            let assetName = UnsafeAssetName "1"
             let policyId = UnsafeTokenPolicyId $
                     Hash "1234567890123456789012345678"
             let adaQuantity = Quantity . minUTxOValue $ _mainEra ctx
@@ -364,7 +364,7 @@ spec = describe "SHELLEY_COIN_SELECTION" $ do
             let assetCount = 1_280
             let policyId = UnsafeTokenPolicyId $
                     Hash "1234567890123456789012345678"
-            let tokenNames = UnsafeTokenName . T.encodeUtf8 . T.singleton <$>
+            let tokenNames = UnsafeAssetName . T.encodeUtf8 . T.singleton <$>
                     ['a' ..]
             let assetIds = AssetId policyId <$> take assetCount tokenNames
             let nonAdaQuantities = TokenMap.fromFlatList $

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
@@ -41,11 +41,11 @@ import Cardano.Wallet.Primitive.NetworkId
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -56,7 +56,7 @@ import Cardano.Wallet.Api.Types.SchemaMetadata
     )
 import Cardano.Wallet.Faucet
     ( seaHorsePolicyId
-    , seaHorseTokenName
+    , seaHorseAssetName
     )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId (..)
@@ -234,7 +234,7 @@ import Web.HttpApiData
 
 import qualified Cardano.Address as CA
 import qualified Cardano.Wallet.Api.Link as Link
-import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
+import qualified Cardano.Wallet.Primitive.Types.AssetName as AssetName
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as TokenPolicy
 import qualified Data.Aeson as Aeson
@@ -901,7 +901,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             responses <- forM sourceWallets $ \(wSrc, nPerAddr) -> do
                 let seaHorses = map $ \ix ->
                         (( toText seaHorsePolicyId
-                        , toText $ seaHorseTokenName ix)
+                        , toText $ seaHorseAssetName ix)
                         , 1)
                 payload <- mkTxPayloadMA @n
                     destAddr
@@ -1063,7 +1063,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         wal <- fixtureMultiAssetWallet ctx
         let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
-        let assName = TokenName.UnsafeTokenName $ B8.replicate 4 'x'
+        let assName = AssetName.UnsafeAssetName $ B8.replicate 4 'x'
         let ep = Link.getAsset wal polId assName
         r <- request @(ApiAsset) ctx ep Default Empty
         expectResponseCode HTTP.status404 r
@@ -1074,7 +1074,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         wal <- fixtureMultiAssetWallet ctx
         let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
-        let ep = Link.getAsset wal polId TokenName.empty
+        let ep = Link.getAsset wal polId AssetName.empty
         r <- request @(ApiAsset) ctx ep Default Empty
         expectResponseCode HTTP.status404 r
         expectErrorMessage errMsg404NoAsset r

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -55,8 +55,8 @@ import Cardano.Wallet.Api.Types.SchemaMetadata
     ( detailedMetadata
     )
 import Cardano.Wallet.Faucet
-    ( seaHorsePolicyId
-    , seaHorseAssetName
+    ( seaHorseAssetName
+    , seaHorsePolicyId
     )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId (..)

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -234,8 +234,8 @@ import Web.HttpApiData
 
 import qualified Cardano.Address as CA
 import qualified Cardano.Wallet.Api.Link as Link
+import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as TokenPolicy
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -1328,12 +1328,12 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
         addrsMint <- listAddresses @n ctx wa
         let addrMint = (addrsMint !! 1) ^. #id
-        let Right tokenName' = AssetName.fromByteString "ab12"
+        let Right assetName' = AssetName.fromByteString "ab12"
         let payloadMint = Json [json|{
                 "mint_burn": [{
                     "policy_id": #{toText policyId'},
                     "reference_input": #{toJSON refInp},
-                    "asset_name": #{toText tokenName'},
+                    "asset_name": #{toText assetName'},
                     "operation":
                         { "mint" :
                               { "receiving_address": #{addrMint},
@@ -1361,7 +1361,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 unScriptHash $
                 toScriptHash scriptUsed
         let tokens' = TokenMap.singleton
-                (AssetId tokenPolicyId' tokenName')
+                (AssetId tokenPolicyId' assetName')
                 (TokenQuantity 1_000)
 
         eventually "wallet holds minted assets" $ do
@@ -1379,7 +1379,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 "mint_burn": [{
                     "policy_id": #{toText policyId'},
                     "reference_input": #{toJSON refInp},
-                    "asset_name": #{toText tokenName'},
+                    "asset_name": #{toText assetName'},
                     "operation":
                         { "burn" :
                               { "quantity": 1000
@@ -1608,7 +1608,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         let tokenPolicyId' =
                 UnsafeTokenPolicyId $ Hash
                 "\145\158\138\EM\"\170\167d\177\214d\a\198\246\"D\231p\129!_8[`\166 \145I"
-        let tokenName' = UnsafeAssetName "HappyCoin"
+        let assetName' = UnsafeAssetName "HappyCoin"
         let policyWithHash = Link.getPolicyKey @'Shelley wa (Just True)
         (_, policyKeyHashPayload) <-
             unsafeRequest @ApiPolicyKey ctx policyWithHash Empty
@@ -1619,10 +1619,10 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         let scriptUsed = RequireAllOf [RequireSignatureOf externalPolicyKeyHash]
 
         let apiTokenAmountFingerprint = ApiTokenAmountFingerprint
-                { assetName = ApiT tokenName'
+                { assetName = ApiT assetName'
                 , quantity = 50_000
                 , fingerprint =
-                    ApiT $ mkTokenFingerprint tokenPolicyId' tokenName'
+                    ApiT $ mkTokenFingerprint tokenPolicyId' assetName'
                 }
         let apiTokens = ApiTokens
                 { policyId = ApiT tokenPolicyId'
@@ -1860,13 +1860,13 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         (_, policyKeyHashPayload) <-
             unsafeRequest @ApiPolicyKey ctx policyWithHash Empty
 
-        let tokenName' = UnsafeAssetName "ReferencePlutusScriptAsset"
+        let assetName' = UnsafeAssetName "ReferencePlutusScriptAsset"
         let tokenPolicyId' = UnsafeTokenPolicyId $ Hash plutusScriptHash
         let apiTokenAmountFingerprint = ApiTokenAmountFingerprint
-                { assetName = ApiT tokenName'
+                { assetName = ApiT assetName'
                 , quantity = 1
                 , fingerprint =
-                    ApiT $ mkTokenFingerprint tokenPolicyId' tokenName'
+                    ApiT $ mkTokenFingerprint tokenPolicyId' assetName'
                 }
         let refScript = AnyScriptReference (ScriptHash plutusScriptHash) [refInp]
         let apiTokens = ApiTokens
@@ -2006,14 +2006,14 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         (_, policyKeyHashPayload) <-
             unsafeRequest @ApiPolicyKey ctx policyWithHash Empty
 
-        let tokenName' = UnsafeAssetName "ReferenceSimpleScriptAsset"
+        let assetName' = UnsafeAssetName "ReferenceSimpleScriptAsset"
         let (ScriptHash nativeScriptHash) = toScriptHash nativeScript
         let tokenPolicyId' = UnsafeTokenPolicyId $ Hash nativeScriptHash
         let apiTokenAmountFingerprint = ApiTokenAmountFingerprint
-                { assetName = ApiT tokenName'
+                { assetName = ApiT assetName'
                 , quantity = 1
                 , fingerprint =
-                    ApiT $ mkTokenFingerprint tokenPolicyId' tokenName'
+                    ApiT $ mkTokenFingerprint tokenPolicyId' assetName'
                 }
         let refScript = AnyScriptReference (ScriptHash nativeScriptHash) [refInp]
         let apiTokens = ApiTokens
@@ -3800,7 +3800,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wa
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = AssetName.fromByteString "ab12"
+        let (Right assetName') = AssetName.fromByteString "ab12"
 
         let payload = Json [json|{
                 "mint_burn": [{
@@ -3809,7 +3809,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                            [ "cosigner#0"
                            ]
                         },
-                    "asset_name": #{toText tokenName'},
+                    "asset_name": #{toText assetName'},
                     "operation":
                         { "mint" :
                               { "receiving_address": #{destination},
@@ -3823,7 +3823,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 [ RequireSignatureOf policyKeyHash
                 ]
 
-        mintAssetsCheck ctx wa tokenName' payload scriptUsed
+        mintAssetsCheck ctx wa assetName' payload scriptUsed
 
     it "TRANS_NEW_CREATE_10e - Minting assets with timelocks \
        \successful as validity interval is inside time interval \
@@ -3840,7 +3840,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wa
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = AssetName.fromByteString "ab12"
+        let (Right assetName') = AssetName.fromByteString "ab12"
 
         rSlot <- request @ApiNetworkInformation ctx
             Link.getNetworkInfo Default Empty
@@ -3862,7 +3862,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                              { "active_until": #{sl + 11} }
                            ]
                         },
-                    "asset_name": #{toText tokenName'},
+                    "asset_name": #{toText assetName'},
                     "operation":
                         { "mint" :
                               { "receiving_address": #{destination},
@@ -3877,7 +3877,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 , ActiveUntilSlot (fromIntegral $ sl + 11)
                 ]
 
-        mintAssetsCheck ctx wa tokenName' payload scriptUsed
+        mintAssetsCheck ctx wa assetName' payload scriptUsed
 
     it "TRANS_NEW_CREATE_10e - \
         \Minting assets with timelocks not successful as validity interval \
@@ -3894,7 +3894,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wa
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = AssetName.fromByteString "ab12"
+        let (Right assetName') = AssetName.fromByteString "ab12"
 
         rSlot <- request @ApiNetworkInformation ctx
             Link.getNetworkInfo Default Empty
@@ -3917,7 +3917,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                                 , { "active_from": 5 }
                                 ]
                             }
-                        , "asset_name": #{toText tokenName'}
+                        , "asset_name": #{toText assetName'}
                         , "operation":
                             { "mint":
                                 { "receiving_address": #{destination}
@@ -3943,7 +3943,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wa
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = AssetName.fromByteString "ab12"
+        let (Right assetName') = AssetName.fromByteString "ab12"
         let payloadMint = Json [json|{
                 "mint_burn": [{
                     "policy_script_template":
@@ -3951,7 +3951,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                             [ "cosigner#0"
                             ]
                         },
-                    "asset_name": #{toText tokenName'},
+                    "asset_name": #{toText assetName'},
                     "operation":
                         { "mint" :
                             { "receiving_address": #{destination},
@@ -3965,7 +3965,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 [ RequireSignatureOf policyKeyHash
                 ]
 
-        mintAssetsCheck ctx wa tokenName' payloadMint scriptUsed
+        mintAssetsCheck ctx wa assetName' payloadMint scriptUsed
 
         let payloadBurn = Json [json|{
                 "mint_burn": [{
@@ -3974,7 +3974,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                             [ "cosigner#0"
                             ]
                         },
-                    "asset_name": #{toText tokenName'},
+                    "asset_name": #{toText assetName'},
                     "operation":
                         { "burn" :
                             { "quantity": 50000
@@ -3983,7 +3983,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 }]
             }|]
 
-        burnAssetsCheck ctx wa tokenName' payloadBurn scriptUsed
+        burnAssetsCheck ctx wa assetName' payloadBurn scriptUsed
 
     it "TRANS_NEW_CREATE_10g - Burning assets without timelock and token name" $
         \ctx -> runResourceT $ do
@@ -3992,7 +3992,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wa
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = AssetName.fromByteString ""
+        let (Right assetName') = AssetName.fromByteString ""
         let payloadMint = Json [json|{
                 "mint_burn": [
                     { "policy_script_template":
@@ -4014,7 +4014,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 [ RequireSignatureOf policyKeyHash
                 ]
 
-        mintAssetsCheck ctx wa tokenName' payloadMint scriptUsed
+        mintAssetsCheck ctx wa assetName' payloadMint scriptUsed
 
         let payloadBurn = Json [json|{
                 "mint_burn": [{
@@ -4031,7 +4031,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 }]
             }|]
 
-        burnAssetsCheck ctx wa tokenName' payloadBurn scriptUsed
+        burnAssetsCheck ctx wa assetName' payloadBurn scriptUsed
 
     it "TRANS_NEW_CREATE_10h - \
         \Minting assets without timelock to foreign address" $
@@ -4041,7 +4041,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wForeign
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = AssetName.fromByteString "ab12"
+        let (Right assetName') = AssetName.fromByteString "ab12"
 
         let payload = Json [json|{
                 "mint_burn": [
@@ -4050,7 +4050,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                            [ "cosigner#0"
                            ]
                         }
-                    , "asset_name": #{toText tokenName'}
+                    , "asset_name": #{toText assetName'}
                     , "operation":
                         { "mint":
                             { "receiving_address": #{destination}
@@ -4067,7 +4067,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
         (initialBalance, expectedFee, tokens') <-
             mintAssetsCheckWithoutBalanceCheck
-                ctx wa tokenName' payload scriptUsed
+                ctx wa assetName' payload scriptUsed
 
         let minutxo = (minUTxOValue (_mainEra ctx) :: Natural)
         -- we are sending to external address and it must be more than minimum
@@ -5005,7 +5005,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         -> (KeyHash -> Script KeyHash)
         -> m (Natural, Natural, TokenMap.TokenMap)
     mintAssetsCheckWithoutBalanceCheck
-        ctx wa tokenName' payload scriptUsedF = do
+        ctx wa assetName' payload scriptUsedF = do
 
         rTx <- request @(ApiConstructTransaction n) ctx
             (Link.createUnsignedTransaction @'Shelley wa) Default payload
@@ -5038,14 +5038,14 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 unScriptHash $
                 toScriptHash scriptUsed
         let tokens' = TokenMap.singleton
-                (AssetId tokenPolicyId' tokenName')
+                (AssetId tokenPolicyId' assetName')
                 (TokenQuantity 50_000)
 
         let apiTokenAmountFingerprint = ApiTokenAmountFingerprint
-                { assetName = ApiT tokenName'
+                { assetName = ApiT assetName'
                 , quantity = 50_000
                 , fingerprint =
-                    ApiT $ mkTokenFingerprint tokenPolicyId' tokenName'
+                    ApiT $ mkTokenFingerprint tokenPolicyId' assetName'
                 }
         let apiTokens = ApiTokens
                 { policyId = ApiT tokenPolicyId'
@@ -5103,11 +5103,11 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         -> Payload
         -> (KeyHash -> Script KeyHash)
         -> m ()
-    mintAssetsCheck ctx wa tokenName' payload scriptUsedF = do
+    mintAssetsCheck ctx wa assetName' payload scriptUsedF = do
 
         (initialBalance, expectedFee, tokens') <-
             mintAssetsCheckWithoutBalanceCheck
-                ctx wa tokenName' payload scriptUsedF
+                ctx wa assetName' payload scriptUsedF
 
         eventually
             "Wallet balance is decreased by fee and holds minted assets" $ do
@@ -5132,7 +5132,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         -> Payload
         -> (KeyHash -> Script KeyHash)
         -> m ()
-    burnAssetsCheck ctx wa tokenName' payload scriptUsedF = do
+    burnAssetsCheck ctx wa assetName' payload scriptUsedF = do
 
         rTx <- request @(ApiConstructTransaction n) ctx
             (Link.createUnsignedTransaction @'Shelley wa) Default payload
@@ -5154,10 +5154,10 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 UnsafeTokenPolicyId . Hash $
                 unScriptHash $ toScriptHash scriptUsed
         let apiTokenAmountFingerprint = ApiTokenAmountFingerprint
-                { assetName = ApiT tokenName'
+                { assetName = ApiT assetName'
                 , quantity = 50_000
                 , fingerprint =
-                    ApiT $ mkTokenFingerprint tokenPolicyId' tokenName'
+                    ApiT $ mkTokenFingerprint tokenPolicyId' assetName'
                 }
         let apiTokens = ApiTokens
                 { policyId = ApiT tokenPolicyId'

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -128,6 +128,9 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -139,9 +142,6 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
     )
 import Cardano.Wallet.Primitive.Types.TokenFingerprint
     ( mkTokenFingerprint
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
@@ -324,8 +324,8 @@ import qualified Cardano.Api as Cardano
 import qualified Cardano.Ledger.Keys as Ledger
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.Api.Link as Link
+import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
 import qualified Data.Aeson as Aeson
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -129,7 +129,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -324,7 +324,7 @@ import qualified Cardano.Api as Cardano
 import qualified Cardano.Ledger.Keys as Ledger
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.Api.Link as Link
-import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
+import qualified Cardano.Wallet.Primitive.Types.AssetName as AssetName
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.Aeson as Aeson
 import qualified Data.List.NonEmpty as NE
@@ -1328,7 +1328,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
         addrsMint <- listAddresses @n ctx wa
         let addrMint = (addrsMint !! 1) ^. #id
-        let Right tokenName' = TokenName.fromByteString "ab12"
+        let Right tokenName' = AssetName.fromByteString "ab12"
         let payloadMint = Json [json|{
                 "mint_burn": [{
                     "policy_id": #{toText policyId'},
@@ -1608,7 +1608,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         let tokenPolicyId' =
                 UnsafeTokenPolicyId $ Hash
                 "\145\158\138\EM\"\170\167d\177\214d\a\198\246\"D\231p\129!_8[`\166 \145I"
-        let tokenName' = UnsafeTokenName "HappyCoin"
+        let tokenName' = UnsafeAssetName "HappyCoin"
         let policyWithHash = Link.getPolicyKey @'Shelley wa (Just True)
         (_, policyKeyHashPayload) <-
             unsafeRequest @ApiPolicyKey ctx policyWithHash Empty
@@ -1860,7 +1860,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         (_, policyKeyHashPayload) <-
             unsafeRequest @ApiPolicyKey ctx policyWithHash Empty
 
-        let tokenName' = UnsafeTokenName "ReferencePlutusScriptAsset"
+        let tokenName' = UnsafeAssetName "ReferencePlutusScriptAsset"
         let tokenPolicyId' = UnsafeTokenPolicyId $ Hash plutusScriptHash
         let apiTokenAmountFingerprint = ApiTokenAmountFingerprint
                 { assetName = ApiT tokenName'
@@ -2006,7 +2006,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         (_, policyKeyHashPayload) <-
             unsafeRequest @ApiPolicyKey ctx policyWithHash Empty
 
-        let tokenName' = UnsafeTokenName "ReferenceSimpleScriptAsset"
+        let tokenName' = UnsafeAssetName "ReferenceSimpleScriptAsset"
         let (ScriptHash nativeScriptHash) = toScriptHash nativeScript
         let tokenPolicyId' = UnsafeTokenPolicyId $ Hash nativeScriptHash
         let apiTokenAmountFingerprint = ApiTokenAmountFingerprint
@@ -3800,7 +3800,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wa
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = TokenName.fromByteString "ab12"
+        let (Right tokenName') = AssetName.fromByteString "ab12"
 
         let payload = Json [json|{
                 "mint_burn": [{
@@ -3840,7 +3840,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wa
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = TokenName.fromByteString "ab12"
+        let (Right tokenName') = AssetName.fromByteString "ab12"
 
         rSlot <- request @ApiNetworkInformation ctx
             Link.getNetworkInfo Default Empty
@@ -3894,7 +3894,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wa
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = TokenName.fromByteString "ab12"
+        let (Right tokenName') = AssetName.fromByteString "ab12"
 
         rSlot <- request @ApiNetworkInformation ctx
             Link.getNetworkInfo Default Empty
@@ -3943,7 +3943,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wa
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = TokenName.fromByteString "ab12"
+        let (Right tokenName') = AssetName.fromByteString "ab12"
         let payloadMint = Json [json|{
                 "mint_burn": [{
                     "policy_script_template":
@@ -3992,7 +3992,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wa
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = TokenName.fromByteString ""
+        let (Right tokenName') = AssetName.fromByteString ""
         let payloadMint = Json [json|{
                 "mint_burn": [
                     { "policy_script_template":
@@ -4041,7 +4041,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         addrs <- listAddresses @n ctx wForeign
         let destination = (addrs !! 1) ^. #id
 
-        let (Right tokenName') = TokenName.fromByteString "ab12"
+        let (Right tokenName') = AssetName.fromByteString "ab12"
 
         let payload = Json [json|{
                 "mint_burn": [
@@ -5000,7 +5000,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         :: MonadUnliftIO m
         => Context
         -> ApiWallet
-        -> TokenName
+        -> AssetName
         -> Payload
         -> (KeyHash -> Script KeyHash)
         -> m (Natural, Natural, TokenMap.TokenMap)
@@ -5099,7 +5099,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         :: MonadUnliftIO m
         => Context
         -> ApiWallet
-        -> TokenName
+        -> AssetName
         -> Payload
         -> (KeyHash -> Script KeyHash)
         -> m ()
@@ -5128,7 +5128,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         :: MonadUnliftIO m
         => Context
         -> ApiWallet
-        -> TokenName
+        -> AssetName
         -> Payload
         -> (KeyHash -> Script KeyHash)
         -> m ()

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -3985,7 +3985,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
         burnAssetsCheck ctx wa assetName' payloadBurn scriptUsed
 
-    it "TRANS_NEW_CREATE_10g - Burning assets without timelock and token name" $
+    it "TRANS_NEW_CREATE_10g - Burning assets without timelock and asset name" $
         \ctx -> runResourceT $ do
 
         wa <- fixtureWallet ctx

--- a/lib/wallet/mock-token-metadata/src/Cardano/Wallet/TokenMetadata/MockServer.hs
+++ b/lib/wallet/mock-token-metadata/src/Cardano/Wallet/TokenMetadata/MockServer.hs
@@ -34,6 +34,9 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
@@ -41,9 +44,6 @@ import Cardano.Wallet.Primitive.Types.TokenMetadata
     ( AssetDecimals (..)
     , AssetLogo (..)
     , AssetURL (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)

--- a/lib/wallet/mock-token-metadata/src/Cardano/Wallet/TokenMetadata/MockServer.hs
+++ b/lib/wallet/mock-token-metadata/src/Cardano/Wallet/TokenMetadata/MockServer.hs
@@ -35,7 +35,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
@@ -223,7 +223,7 @@ assetIdFromSubject :: Subject -> AssetId
 assetIdFromSubject =
     mk . BS.splitAt 32 . unsafeFromHex . T.encodeUtf8 . unSubject
   where
-    mk (p, n) = AssetId (UnsafeTokenPolicyId (Hash p)) (UnsafeTokenName n)
+    mk (p, n) = AssetId (UnsafeTokenPolicyId (Hash p)) (UnsafeAssetName n)
 
 {-------------------------------------------------------------------------------
                               JSON orphans

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/MintBurn.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/MintBurn.hs
@@ -47,11 +47,11 @@ import Cardano.Wallet.Primitive.Passphrase
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/MintBurn.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/MintBurn.hs
@@ -48,7 +48,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName
+    ( AssetName
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
@@ -92,7 +92,7 @@ toTokenMapAndScript
     => KeyFlavorS key
     -> Script Cosigner
     -> Map Cosigner XPub
-    -> TokenName
+    -> AssetName
     -> Natural
     -> (AssetId, TokenQuantity, Script KeyHash)
 toTokenMapAndScript kf scriptTempl cosignerMap tName val =

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
@@ -87,8 +87,8 @@ import qualified Cardano.Wallet.Address.Discovery.Sequential as W
 import qualified Cardano.Wallet.Primitive.Passphrase.Types as W
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
+import qualified Cardano.Wallet.Primitive.Types.AssetName as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
-import qualified Cardano.Wallet.Primitive.Types.TokenName as W
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as W
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
@@ -202,7 +202,7 @@ TxOutToken
     txOutTokenTxId      TxId              sql=tx_id
     txOutTokenTxIndex   Word32            sql=tx_index
     txOutTokenPolicyId  W.TokenPolicyId   sql=token_policy_id
-    txOutTokenName      W.TokenName       sql=token_name
+    txOutTokenName      W.AssetName       sql=token_name
     txOutTokenQuantity  W.TokenQuantity   sql=token_quantity
 
     Primary txOutTokenTxId txOutTokenTxIndex txOutTokenPolicyId txOutTokenName
@@ -239,7 +239,7 @@ TxCollateralOut
 TxCollateralOutToken
     txCollateralOutTokenTxId     TxId            sql=tx_id
     txCollateralOutTokenPolicyId W.TokenPolicyId sql=token_policy_id
-    txCollateralOutTokenName     W.TokenName     sql=token_name
+    txCollateralOutTokenName     W.AssetName     sql=token_name
     txCollateralOutTokenQuantity W.TokenQuantity sql=token_quantity
 
     Primary txCollateralOutTokenTxId txCollateralOutTokenPolicyId txCollateralOutTokenName
@@ -327,7 +327,7 @@ UTxOToken                               sql=utxo_token
     utxoTokenTxId      TxId             sql=tx_id
     utxoTokenTxIndex   Word32           sql=tx_index
     utxoTokenPolicyId  W.TokenPolicyId  sql=token_policy_id
-    utxoTokenName      W.TokenName      sql=token_name
+    utxoTokenName      W.AssetName      sql=token_name
     utxoTokenQuantity  W.TokenQuantity  sql=token_quantity
 
     Primary

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -80,7 +80,7 @@ import Cardano.Wallet.Primitive.Types.Address
     , AddressState (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName
+    ( AssetName
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -345,11 +345,11 @@ instance PathPiece TxId where
 -- Tokens
 --------------------------------------------------------------------------------
 
-instance PersistField TokenName where
+instance PersistField AssetName where
     toPersistValue = toPersistValue . toText
     fromPersistValue = fromPersistValueFromText
 
-instance PersistFieldSql TokenName where
+instance PersistFieldSql AssetName where
     sqlType _ = sqlType (Proxy @Text)
 
 instance PersistField TokenPolicyId where

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -79,6 +79,9 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     , AddressState (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -87,9 +90,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -53,11 +53,11 @@ import Cardano.Wallet.DB.Sqlite.Types
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (AssetId)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName
+    )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -54,7 +54,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (AssetId)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName
+    ( AssetName
     )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount
@@ -221,11 +221,11 @@ mkTxCollateral tid (ix, (txCollateral, txOut)) =
     }
 
 -- The key to sort TxCollateralOutToken
-tokenCollateralOrd :: TxCollateralOutToken -> (TokenPolicyId, TokenName)
+tokenCollateralOrd :: TxCollateralOutToken -> (TokenPolicyId, AssetName)
 tokenCollateralOrd = txCollateralOutTokenPolicyId &&& txCollateralOutTokenName
 
 -- The key to sort TxOutToken
-tokenOutOrd :: TxOutToken -> (TokenPolicyId, TokenName)
+tokenOutOrd :: TxOutToken -> (TokenPolicyId, AssetName)
 tokenOutOrd = txOutTokenPolicyId &&& txOutTokenName
 
 mkTxOut

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/TxOutCBOR.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/TxOutCBOR.hs
@@ -12,6 +12,9 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (AssetId)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (UnsafeTokenName)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -24,9 +27,6 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( fromFlatList
     , toFlatList
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (UnsafeTokenName)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (UnsafeTokenPolicyId)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/TxOutCBOR.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/TxOutCBOR.hs
@@ -13,7 +13,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (AssetId)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (UnsafeTokenName)
+    ( AssetName (UnsafeAssetName)
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -86,7 +86,7 @@ encodeTxOut (TxOut (Address addr) (TokenBundle (Coin c) m)) =
                 <> foldMap
                     ( \( AssetId
                             (UnsafeTokenPolicyId (Hash policy))
-                            (UnsafeTokenName name)
+                            (UnsafeAssetName name)
                         , TokenQuantity quant
                         ) ->
                             encodeListLen 3
@@ -114,7 +114,7 @@ decodeTxOut = do
                         return
                             ( AssetId
                                 (UnsafeTokenPolicyId (Hash policy))
-                                (UnsafeTokenName name)
+                                (UnsafeAssetName name)
                             , TokenQuantity $
                                 fromIntegral quant
                             )

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
@@ -117,7 +117,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -543,7 +543,7 @@ shrinkTxIds s = mapTxIds toSimpleTxId s
 simpleAssetIds :: [AssetId]
 simpleAssetIds
     = AssetId (UnsafeTokenPolicyId $ Hash mempty)
-    . UnsafeTokenName
+    . UnsafeAssetName
     . T.encodeUtf8
     . T.pack
     . show <$> [0 :: Integer ..]

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxSeq.hs
@@ -116,6 +116,9 @@ import Cardano.Wallet.Primitive.Model
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -124,9 +127,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     )
 import Cardano.Wallet.Primitive.Types.StateDeltaSeq
     ( StateDeltaSeq
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)

--- a/lib/wallet/src/Cardano/Wallet/TokenMetadata.hs
+++ b/lib/wallet/src/Cardano/Wallet/TokenMetadata.hs
@@ -94,7 +94,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
@@ -542,7 +542,7 @@ getTokenMetadata (TokenMetadataClient client) as =
 -- | Creates a metadata server subject from an AssetId. The subject is the
 -- policy id and asset name hex-encoded.
 assetIdToSubject :: AssetId -> Subject
-assetIdToSubject (AssetId (UnsafeTokenPolicyId (Hash p)) (UnsafeTokenName n)) =
+assetIdToSubject (AssetId (UnsafeTokenPolicyId (Hash p)) (UnsafeAssetName n)) =
     Subject $ T.decodeLatin1 $ convertToBase Base16 (p <> n)
 
 -- | Convert metadata server properties response into an 'AssetMetadata' record.

--- a/lib/wallet/src/Cardano/Wallet/TokenMetadata.hs
+++ b/lib/wallet/src/Cardano/Wallet/TokenMetadata.hs
@@ -93,6 +93,9 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     )
@@ -107,9 +110,6 @@ import Cardano.Wallet.Primitive.Types.TokenMetadata
     , validateMetadataName
     , validateMetadataTicker
     , validateMetadataURL
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -101,7 +101,7 @@ import Cardano.Wallet.Primitive.Types
     ( WalletId
     , walletNameMaxLength
     )
-import Cardano.Wallet.Primitive.Types.TokenName
+import Cardano.Wallet.Primitive.Types.AssetName
     ( TokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -102,7 +102,7 @@ import Cardano.Wallet.Primitive.Types
     , walletNameMaxLength
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName
+    ( AssetName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId
@@ -283,7 +283,7 @@ instance Malformed (PathParam (ApiT TokenPolicyId)) where
         msgMalformed = "Invalid tokenPolicy hash: expecting a hex-encoded value that is 28 bytes in length."
         msgWrongLength = msgMalformed
 
-instance Wellformed (PathParam (ApiT TokenName)) where
+instance Wellformed (PathParam (ApiT AssetName)) where
     wellformed = PathParam <$>
         [ T.replicate 64 "0"
         , ""
@@ -292,15 +292,15 @@ instance Wellformed (PathParam (ApiT TokenName)) where
         , "e29883"
         ]
 
-instance Malformed (PathParam (ApiT TokenName)) where
+instance Malformed (PathParam (ApiT AssetName)) where
     malformed = first PathParam <$>
         [ ( T.replicate 65 "0", msgWrongLength )
         , ( "f", msgWrongLength )
         , ( "patate", msgMalformed )
         ]
       where
-        msgWrongLength = "TokenName is not hex-encoded: base16: input: invalid length"
-        msgMalformed = "TokenName is not hex-encoded: base16: input: invalid encoding at offset: 0"
+        msgWrongLength = "AssetName is not hex-encoded: base16: input: invalid length"
+        msgMalformed = "AssetName is not hex-encoded: base16: input: invalid encoding at offset: 0"
 
 --
 -- Class instances (BodyParam)

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -353,6 +353,12 @@ import Cardano.Wallet.Primitive.Types.AssetId
 import Cardano.Wallet.Primitive.Types.AssetId.Gen
     ( genAssetId
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
+import Cardano.Wallet.Primitive.Types.AssetName.Gen
+    ( genTokenName
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -388,12 +394,6 @@ import Cardano.Wallet.Primitive.Types.TokenMetadata
     , AssetLogo (..)
     , AssetMetadata (..)
     , AssetURL (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenName.Gen
-    ( genTokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -354,10 +354,10 @@ import Cardano.Wallet.Primitive.Types.AssetId.Gen
     ( genAssetId
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName.Gen
-    ( genTokenName
+    ( genAssetName
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -2170,7 +2170,7 @@ instance HasSNetworkId n => Arbitrary (ApiConstructTransaction n) where
 
 instance Arbitrary ApiTokenAmountFingerprint where
     arbitrary = do
-        name <- genTokenName
+        name <- genAssetName
         policyid <- arbitrary
         let fingerprint = ApiT $ mkTokenFingerprint policyid name
         ApiTokenAmountFingerprint (ApiT name)
@@ -2253,7 +2253,7 @@ instance HasSNetworkId n => Arbitrary (ApiMintBurnDataFromScript n) where
                 ]
             ]
         <*> oneof
-            [ Just . ApiT <$> genTokenName
+            [ Just . ApiT <$> genAssetName
             , pure Nothing
             ]
         <*> arbitrary
@@ -2263,7 +2263,7 @@ instance HasSNetworkId n => Arbitrary (ApiMintBurnDataFromInput n) where
         <$> (ReferenceInput <$> arbitrary)
         <*> arbitrary
         <*> oneof
-            [ Just . ApiT <$> genTokenName
+            [ Just . ApiT <$> genAssetName
             , pure Nothing
             ]
         <*> arbitrary
@@ -2308,8 +2308,8 @@ instance Arbitrary ApiMintBurnInfo where
 instance Arbitrary TokenPolicyId where
     arbitrary = UnsafeTokenPolicyId . Hash . BS.pack <$> vector 28
 
-instance Arbitrary TokenName where
-    arbitrary = UnsafeTokenName . BS.pack <$> vector 32
+instance Arbitrary AssetName where
+    arbitrary = UnsafeAssetName . BS.pack <$> vector 32
 
 instance Arbitrary ApiWithdrawalPostData where
     arbitrary = genericArbitrary

--- a/lib/wallet/test/unit/Cardano/Wallet/Balance/Migration/SelectionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Balance/Migration/SelectionSpec.hs
@@ -33,7 +33,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -1063,7 +1063,7 @@ mockAssetIds :: [AssetId]
 mockAssetIds =
     [ AssetId i n
     | i <- UnsafeTokenPolicyId . Hash . B8.singleton <$> ['0' .. '3']
-    , n <- UnsafeTokenName . B8.singleton <$> ['0' .. '3']
+    , n <- UnsafeAssetName . B8.singleton <$> ['0' .. '3']
     ]
 
 --------------------------------------------------------------------------------

--- a/lib/wallet/test/unit/Cardano/Wallet/Balance/Migration/SelectionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Balance/Migration/SelectionSpec.hs
@@ -32,6 +32,9 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -47,9 +50,6 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -147,6 +147,9 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address
     , AddressState
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -164,9 +167,6 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -148,7 +148,7 @@ import Cardano.Wallet.Primitive.Types.Address
     , AddressState
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName
+    ( AssetName
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -863,7 +863,7 @@ instance ToExpr TokenBundle where
 instance ToExpr TokenMap where
     toExpr = genericToExpr . TokenMap.toNestedList
 
-instance ToExpr TokenName where
+instance ToExpr AssetName where
     toExpr = genericToExpr
 
 instance ToExpr TokenPolicyId where

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
@@ -25,7 +25,7 @@ import Cardano.Wallet.Primitive.Types.AssetId.Gen
     , shrinkAssetId
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (..)
+    ( AssetName (..)
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
@@ -548,11 +548,11 @@ instance Arbitrary ShrinkableTxSeq where
 deriving anyclass instance CoArbitrary (Hash "TokenPolicy")
 deriving anyclass instance CoArbitrary (Hash "Tx")
 deriving anyclass instance CoArbitrary AssetId
-deriving anyclass instance CoArbitrary TokenName
+deriving anyclass instance CoArbitrary AssetName
 deriving anyclass instance CoArbitrary TokenPolicyId
 
 deriving anyclass instance Function (Hash "TokenPolicy")
 deriving anyclass instance Function (Hash "Tx")
 deriving anyclass instance Function AssetId
-deriving anyclass instance Function TokenName
+deriving anyclass instance Function AssetName
 deriving anyclass instance Function TokenPolicyId

--- a/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Primitive/Types/Tx/TxSeqSpec.hs
@@ -24,11 +24,11 @@ import Cardano.Wallet.Primitive.Types.AssetId.Gen
     ( genAssetId
     , shrinkAssetId
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (..)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -107,6 +107,9 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( TokenName (UnsafeTokenName)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -127,9 +130,6 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange
     , shrinkTokenBundleSmallRange
-    )
-import Cardano.Wallet.Primitive.Types.TokenName
-    ( TokenName (UnsafeTokenName)
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -108,7 +108,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetName
-    ( TokenName (UnsafeTokenName)
+    ( AssetName (UnsafeAssetName)
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -1629,7 +1629,7 @@ instance Arbitrary AssetId where
         -- asset, whereas the size of an asset name has a maximum of 32 bytes).
         -- So we create a generator here that forces the variable factor to
         -- dominate so we can test the sanity of the estimation algorithm.
-        <*> (UnsafeTokenName . BS.pack <$> vector 128)
+        <*> (UnsafeAssetName . BS.pack <$> vector 128)
 
 instance Arbitrary Coin where
     arbitrary = genCoinPositive

--- a/lib/wallet/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -76,7 +76,7 @@ import Test.Utils.Trace
     ( traceSpec
     )
 
-import qualified Cardano.Wallet.Primitive.Types.TokenName as TokenName
+import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
 
 spec :: Spec
 spec = do

--- a/lib/wallet/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -76,7 +76,7 @@ import Test.Utils.Trace
     ( traceSpec
     )
 
-import qualified Cardano.Wallet.Primitive.Types.AssetName as TokenName
+import qualified Cardano.Wallet.Primitive.Types.AssetName as AssetName
 
 spec :: Spec
 spec = do
@@ -141,7 +141,7 @@ spec = do
                 let subj = "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c27"
                 let aid = AssetId
                         (UnsafeTokenPolicyId (unsafeFromText subj))
-                        TokenName.empty
+                        AssetName.empty
                 getTokenMetadata client [assetIdFromSubject (Subject subj)]
                     `shouldReturn` Right [(aid, golden1Metadata0)]
 
@@ -150,7 +150,7 @@ spec = do
                 client <- newMetadataClient tr (Just srv)
                 let aid subj = AssetId
                         (UnsafeTokenPolicyId (unsafeFromText subj))
-                        TokenName.empty
+                        AssetName.empty
                 let aid1 = aid "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c27"
                 let aid2 = aid "bad00000000000000000000000000000000000000000000000000000"
                 getTokenMetadata client [aid1, aid2]
@@ -161,7 +161,7 @@ spec = do
                 client <- newMetadataClient tr (Just srv)
                 let aid = AssetId
                         (UnsafeTokenPolicyId (Hash "a"))
-                        TokenName.empty
+                        AssetName.empty
                 res <- getTokenMetadata client [aid]
                 res `shouldBe` Right []
 


### PR DESCRIPTION
## Summary

This PR renames the `TokenName` type to `AssetName`, correcting a terminological inconsistency between `cardano-wallet` and the [Cardano Multi-Asset Ledger Specification](https://github.com/input-output-hk/cardano-ledger/releases/latest/download/mary-ledger.pdf).

## Details

The [Cardano Multi-Asset Ledger Specification](https://github.com/input-output-hk/cardano-ledger/releases/latest/download/mary-ledger.pdf) uses the term `AssetName`:

> ![mary-ledger-asset-name](https://github.com/cardano-foundation/cardano-wallet/assets/206319/988c61bc-dbb0-4f45-97e4-14fab3f6f839)

The `cardano-wallet` HTTP REST API also uses the derived terms `assetName` and `asset_name`:
> https://github.com/cardano-foundation/cardano-wallet/blob/85b7a721778ba0034b8eab3533de3b513cd9a937/specifications/api/swagger.yaml#L7165

> https://github.com/cardano-foundation/cardano-wallet/blob/85b7a721778ba0034b8eab3533de3b513cd9a937/specifications/api/swagger.yaml#L1028

However, the equivalent `cardano-wallet` Haskell type was called `TokenName`.

This PR corrects this discrepancy, and:
- renames `TokenName` to `AssetName`;
- renames related functions, strings, and comments;
- **avoids** making any change to database schemas;
- **avoids** making any change to the HTTP REST API.