### PR TITLE
Remove the use of `cardano-api` from module `Write.Tx.Balance`.

### DIFF
--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -70,6 +70,7 @@ library internal
     , deepseq
     , fmt
     , generic-lens
+    , groups
     , int-cast
     , lens
     , MonadRandom

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -1042,8 +1042,7 @@ selectAssets pp utxoAssumptions outs' redeemers
         , selectionStrategy = selectionStrategy
         }
       where
-        (balancePositive, balanceNegative) =
-            posAndNegFromCardanoApiValue (CardanoApi.fromMaryValue balance)
+        (balanceNegative, balancePositive) = splitSignedValue balance
         valueOfOutputs = F.foldMap' (view #tokens) outs
         valueOfInputs = UTxOSelection.selectedBalance utxoSelection
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -851,7 +851,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             update = TxUpdate [] [] [] [] (UseNewTxFee minfee)
         tx' <- left updateTxErrorToBalanceTxError $ updateTx tx update
         let balance = txBalance tx'
-            minfee' = Coin $ W.Coin.toInteger minfee
+            minfee' = Convert.toLedgerCoin minfee
         return (balance, minfee', witCount)
 
     -- | Ensure the wallet UTxO is consistent with a provided @CardanoApi.UTxO@.

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -15,6 +15,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 {- HLINT ignore "Use ||" -}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 -- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
 {-# LANGUAGE CPP #-}
@@ -54,7 +55,6 @@ module Internal.Cardano.Write.Tx.Balance
     , constructUTxOIndex
 
     -- * Utilities
-    , posAndNegFromCardanoApiValue
     , fromWalletUTxO
     , toWalletUTxO
     , splitSignedValue
@@ -145,10 +145,6 @@ import Control.Monad.Trans.Except
 import Control.Monad.Trans.State
     ( runState
     , state
-    )
-import Data.Bifunctor
-    ( bimap
-    , second
     )
 import Data.Bits
     ( Bits
@@ -328,7 +324,6 @@ import qualified Cardano.Wallet.Primitive.Types.UTxO as W
     ( UTxO (..)
     )
 import qualified Data.Foldable as F
-import qualified Data.List as L
 import qualified Data.Map as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
@@ -1140,19 +1135,6 @@ assignChangeAddresses (ChangeAddressGen genChange _) sel = runState $ do
         addr <- state genChange
         pure $ W.TxOut (Convert.toWalletAddress addr) bundle
     pure $ (sel :: SelectionOf W.TokenBundle) { change = changeOuts }
-
--- | Convert a 'CardanoApi.Value' into a positive and negative component. Useful
--- to convert the potentially negative balance of a partial tx into
--- TokenBundles.
-posAndNegFromCardanoApiValue
-    :: CardanoApi.Value
-    -> (W.TokenBundle, W.TokenBundle)
-posAndNegFromCardanoApiValue
-    = bimap
-        (fromCardanoApiValue . CardanoApi.valueFromList)
-        (fromCardanoApiValue . CardanoApi.valueFromList . L.map (second negate))
-    . L.partition ((>= 0) . snd)
-    . CardanoApi.valueToList
 
 unsafeIntCast
     :: (HasCallStack, Integral a, Integral b, Bits a, Bits b, Show a)

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -683,7 +683,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 redeemers
                 (UTxOSelection.fromIndexPair
                     (internalUtxoAvailable, externalSelectedUtxo))
-                (CardanoApi.fromMaryValue balance0)
+                balance0
                 (Convert.toWalletCoin minfee0)
                 randomSeed
                 genChange
@@ -947,7 +947,7 @@ selectAssets
     -> UTxOSelection WalletUTxO
     -- ^ Specifies which UTxOs are pre-selected, and which UTxOs can be used as
     -- inputs or collateral.
-    -> CardanoApi.Value
+    -> Value
     -- ^ Balance to cover.
     -> W.Coin
     -- ^ Current minimum fee (before selecting assets).
@@ -1034,7 +1034,7 @@ selectAssets pp utxoAssumptions outs' redeemers
         }
       where
         (balancePositive, balanceNegative) =
-            posAndNegFromCardanoApiValue balance
+            posAndNegFromCardanoApiValue (CardanoApi.fromMaryValue balance)
         valueOfOutputs = F.foldMap' (view #tokens) outs
         valueOfInputs = UTxOSelection.selectedBalance utxoSelection
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -15,7 +15,6 @@
 {-# LANGUAGE TypeApplications #-}
 
 {- HLINT ignore "Use ||" -}
-{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 -- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
 {-# LANGUAGE CPP #-}
@@ -280,8 +279,6 @@ import Text.Pretty.Simple
     )
 
 import qualified Cardano.Address.Script as CA
-import qualified Cardano.Api as CardanoApi
-import qualified Cardano.Api.Shelley as CardanoApi
 import qualified Cardano.CoinSelection.UTxOIndex as UTxOIndex
 import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
 import qualified Cardano.Ledger.Core as Core
@@ -1697,6 +1694,3 @@ validateTxOutputAdaQuantity constraints output@(address, bundle)
         (constraints ^. #computeMinimumAdaQuantity)
         (fst output)
         (snd output ^. #tokens)
-
-fromCardanoApiValue :: CardanoApi.Value -> W.TokenBundle
-fromCardanoApiValue = Convert.toWalletTokenBundle . CardanoApi.toMaryValue

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -948,8 +948,10 @@ selectAssets
     -> UTxOSelection WalletUTxO
     -- ^ Specifies which UTxOs are pre-selected, and which UTxOs can be used as
     -- inputs or collateral.
-    -> CardanoApi.Value -- Balance to cover
-    -> W.Coin -- Current minfee (before selecting assets)
+    -> CardanoApi.Value
+    -- ^ Balance to cover.
+    -> W.Coin
+    -- ^ Current minimum fee (before selecting assets).
     -> StdGenSeed
     -> ChangeAddressGen changeState
     -> SelectionStrategy

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -49,6 +49,7 @@ library
     , iohk-monitoring
     , int-cast
     , lattices
+    , monoid-subclasses
     , optparse-applicative
     , pretty-simple
     , QuickCheck
@@ -105,6 +106,7 @@ test-suite unit
     , generic-lens
     , generics-sop
     , lattices
+    , monoid-subclasses
     , safe
     , silently
     , QuickCheck

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -578,6 +578,7 @@ test-suite unit
     , cardano-ledger-api
     , cardano-ledger-babbage:{cardano-ledger-babbage}
     , cardano-ledger-core
+    , cardano-ledger-mary:testlib
     , cardano-ledger-shelley
     , cardano-numeric
     , cardano-sl-x509
@@ -612,6 +613,7 @@ test-suite unit
     , generic-arbitrary
     , generic-lens
     , generics-sop
+    , groups
     , hedgehog-corpus
     , hspec                                                     >=2.8.2
     , hspec-core                                                >=2.8.2

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -279,7 +279,6 @@ import Internal.Cardano.Write.Tx.Balance
     , maximumCostOfIncreasingCoin
     , mergeSignedValue
     , noTxUpdate
-    , posAndNegFromCardanoApiValue
     , sizeOfCoin
     , splitSignedValue
     , updateTx
@@ -546,10 +545,6 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
                     & tabulateOverestimation
 
     balanceTransactionGoldenSpec
-
-    describe "posAndNegFromCardanoApiValue" $
-        it "roundtrips with toCardanoApiValue" $
-            property prop_posAndNegFromCardanoApiValueRoundtrip
 
     describe "change address generation" $ do
         let balance' =
@@ -1905,16 +1900,6 @@ prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
     mres = distributeSurplusDelta
         feePolicy surplus (TxFeeAndChange fee0 change0)
     maxCoinCostIncrease = maximumCostOfIncreasingCoin feePolicy
-
-prop_posAndNegFromCardanoApiValueRoundtrip :: Property
-prop_posAndNegFromCardanoApiValueRoundtrip =
-    forAll CardanoApi.genSignedValue $ \v ->
-    let
-        (pos, neg) = posAndNegFromCardanoApiValue v
-    in
-        walletToCardanoValue pos <>
-        (CardanoApi.negateValue (walletToCardanoValue neg))
-        === v
 
 -- TODO [ADO-2997] Test this property in all recent eras.
 -- https://cardanofoundation.atlassian.net/browse/ADP-2997

--- a/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/wallet/test/unit/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -359,7 +359,10 @@ import Test.QuickCheck
     , (==>)
     )
 import Test.QuickCheck.Extra
-    ( report
+    ( DisjointPair
+    , genDisjointPair
+    , report
+    , shrinkDisjointPair
     , shrinkNatural
     , (.>=.)
     )
@@ -2510,6 +2513,10 @@ instance Arbitrary StdGenSeed  where
 instance Arbitrary W.TokenBundle where
     arbitrary = W.genTokenBundleSmallRange
     shrink = W.shrinkTokenBundleSmallRange
+
+instance Arbitrary (DisjointPair W.TokenBundle) where
+    arbitrary = genDisjointPair W.genTokenBundle
+    shrink = shrinkDisjointPair W.shrinkTokenBundle
 
 instance Arbitrary (TxBalanceSurplus W.Coin) where
     -- We want to test cases where the surplus is zero. So it's important that


### PR DESCRIPTION
## Issue

Tangentially related to ADP-3184.

## Description

This PR replaces `cardano-api` types with `cardano-ledger` types in module `Write.Tx.Balance`.