### PR TITLE
[ADP-3238] Add `lib.nix` library

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -415,7 +415,7 @@
               inherit dockerImage;
               inherit (config) dockerHubRepoName;
             };
-            inherit (pkgs) checkCabalProject cabalProjectRegenerate;
+            inherit (pkgs) checkCabalProject;
           } // (lib.optionalAttrs buildPlatform.isLinux {
             nixosTests = import ./nix/nixos/tests {
               inherit pkgs project;

--- a/flake.nix
+++ b/flake.nix
@@ -334,6 +334,7 @@
               linux64.release =
                 import ./nix/release-package.nix {
                   inherit pkgs;
+                  walletLib = lib;
                   exes = linuxReleaseExes;
                   platform = "linux64";
                   format = "tar.gz";
@@ -345,6 +346,7 @@
                 in {
                   release = import ./nix/release-package.nix {
                     inherit pkgs;
+                    walletLib = lib;
                     exes = [
                       windowsPackages.cardano-wallet
                       windowsPackages.bech32
@@ -371,6 +373,7 @@
               macos-intel = lib.optionalAttrs buildPlatform.isx86_64 {
                 release = import ./nix/release-package.nix {
                   inherit pkgs;
+                  walletLib = lib;
                   exes = let macOsPkgs = mkPackages project; in [
                     macOsPkgs.cardano-wallet
                     macOsPkgs.bech32
@@ -385,6 +388,7 @@
               macos-silicon = lib.optionalAttrs buildPlatform.isAarch64 {
                 release = import ./nix/release-package.nix {
                   inherit pkgs;
+                  walletLib = lib;
                   exes = let macOsPkgs = mkPackages project; in [
                     macOsPkgs.cardano-wallet
                     macOsPkgs.bech32

--- a/flake.nix
+++ b/flake.nix
@@ -149,13 +149,17 @@
               haskellNix, iohkNix, CHaP, customConfig, cardano-node-runtime,
               ... }:
     let
-      inherit (nixpkgs) lib;
-      config = import ./nix/config.nix lib customConfig;
+      # Import libraries      
+      lib = import ./nix/lib.nix nixpkgs.lib;
+      config = import ./nix/config.nix nixpkgs.lib customConfig;
       inherit (flake-utils.lib) eachSystem mkApp flattenTree;
       removeRecurse = lib.filterAttrsRecursive (n: _: n != "recurseForDerivations");
       inherit (iohkNix.lib) evalService;
+
+      # Definitions
       supportedSystems = import ./nix/supported-systems.nix;
       defaultSystem = lib.head supportedSystems;
+
       overlay = final: prev: {
         cardanoWalletHaskellProject = self.legacyPackages.${final.system};
         inherit (final.cardanoWalletHaskellProject.hsPkgs.cardano-wallet.components.exes) cardano-wallet;

--- a/flake.nix
+++ b/flake.nix
@@ -170,18 +170,6 @@
       };
       nixosModules.cardano-wallet = nixosModule;
 
-      # Helper functions for separating unit and integration tests
-      setEmptyAttrsWithCondition = cond:
-        lib.mapAttrsRecursiveCond
-          (value: !(lib.isDerivation value)) # do not modify attributes of derivations
-          (path: value: if cond path then {} else value);
-      keepIntegrationChecks =
-        setEmptyAttrsWithCondition
-          (path: !lib.any (lib.hasPrefix "integration") path);
-      keepUnitChecks =
-        setEmptyAttrsWithCondition
-          (path: !lib.any (name: name == "unit" || name == "test") path);
-
       # Define flake outputs for a particular system.
       mkOutputs = system:
         let
@@ -474,7 +462,7 @@
               meta.description = "Run unit tests";
               constituents =
                 lib.collect lib.isDerivation
-                  (keepUnitChecks packages.checks);
+                  (lib.keepUnitChecks packages.checks);
             };
           ci.tests.run.integration = pkgs.releaseTools.aggregate
             {
@@ -482,7 +470,7 @@
               meta.description = "Run integration tests";
               constituents =
                 lib.collect lib.isDerivation
-                  (keepIntegrationChecks packages.checks);
+                  (lib.keepIntegrationChecks packages.checks);
             };
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -153,7 +153,6 @@
       lib = import ./nix/lib.nix nixpkgs.lib;
       config = import ./nix/config.nix nixpkgs.lib customConfig;
       inherit (flake-utils.lib) eachSystem mkApp flattenTree;
-      removeRecurse = lib.filterAttrsRecursive (n: _: n != "recurseForDerivations");
       inherit (iohkNix.lib) evalService;
 
       # Definitions
@@ -246,9 +245,10 @@
                 # Combined project coverage report
                 testCoverageReport = coveredProject.projectCoverageReport;
                 # `tests` are the test suites which have been built.
-                tests = removeRecurse (collectComponents "tests" isProjectPackage coveredProject.hsPkgs);
+                tests =
+                  lib.removeRecurse (collectComponents "tests" isProjectPackage coveredProject.hsPkgs);
                 # `checks` are the result of executing the tests.
-                checks = removeRecurse (
+                checks = lib.removeRecurse (
                   lib.recursiveUpdate
                     (collectChecks isProjectPackage coveredProject.hsPkgs)
                     # Run the integration tests in the previous era too:
@@ -274,7 +274,8 @@
                     )
                 );
                 # `benchmarks` are only built, not run.
-                benchmarks = removeRecurse (collectComponents "benchmarks" isProjectPackage project.hsPkgs);
+                benchmarks =
+                  lib.removeRecurse (collectComponents "benchmarks" isProjectPackage project.hsPkgs);
               };
             in
             self;

--- a/flake.nix
+++ b/flake.nix
@@ -158,7 +158,6 @@
 
       # Definitions
       supportedSystems = import ./nix/supported-systems.nix;
-      defaultSystem = lib.head supportedSystems;
 
       overlay = final: prev: {
         cardanoWalletHaskellProject = self.legacyPackages.${final.system};

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -5,6 +5,9 @@ lib
 :
 
 {
+  # Imports from nixpkgs.lib
+  inherit (lib) filterAttrsRecursive recursiveUpdate collect 
+                optionalAttrs mapAttrs isDerivation;
 
   /* Recursively traces an attrset as it's evaluated.
      This is helpful for debugging large attribute sets.

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,0 +1,22 @@
+# Library of Nix functions used for cardano-wallet
+
+# nixpkgs.lib  library to import from.
+lib
+:
+
+{
+
+  /* Recursively traces an attrset as it's evaluated.
+     This is helpful for debugging large attribute sets.
+  */
+  traceNames =
+    let
+      go = prefix: builtins.mapAttrs (n: v:
+        if builtins.isAttrs v
+          then if v ? type && v.type == "derivation"
+            then __trace (prefix + n) v
+            else go (prefix + n + ".") v
+          else v);
+    in
+      go;
+}

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -32,6 +32,11 @@ rec {
     setEmptyAttrsWithCondition
       (path: !lib.any (name: name == "unit" || name == "test") path);
 
+  /* Recursively remove all attributes named `recurseForDerivations`.
+  */
+  removeRecurse =
+    lib.filterAttrsRecursive (n: _: n != "recurseForDerivations");
+
   /* Recursively traces an attrset as it's evaluated.
      This is helpful for debugging large attribute sets.
   */

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -4,10 +4,33 @@
 lib
 :
 
-{
+rec {
   # Imports from nixpkgs.lib
   inherit (lib) filterAttrsRecursive recursiveUpdate collect 
                 optionalAttrs mapAttrs isDerivation;
+
+  /* Recursively set all attributes whose path satisfies
+     a given condition to the empty set {}.
+  */
+  setEmptyAttrsWithCondition =
+    # cond :: [string] -> bool
+    cond:
+    lib.mapAttrsRecursiveCond
+      (value: !(lib.isDerivation value)) # do not modify attributes of derivations
+      (path: value: if cond path then {} else value);
+
+  /* Keep all attributes whose path contains a name starting
+     with "integration".
+  */
+  keepIntegrationChecks =
+    setEmptyAttrsWithCondition
+      (path: !lib.any (lib.hasPrefix "integration") path);
+
+  /* Keep all attributes whose path contain a name that is "unit" or "test".
+  */
+  keepUnitChecks =
+    setEmptyAttrsWithCondition
+      (path: !lib.any (name: name == "unit" || name == "test") path);
 
   /* Recursively traces an attrset as it's evaluated.
      This is helpful for debugging large attribute sets.

--- a/nix/overlays/common-lib.nix
+++ b/nix/overlays/common-lib.nix
@@ -4,12 +4,6 @@ self: super: let
 in {
   cardanoWalletLib = {
 
-    # lib.cleanSourceWith filter function which removes socket files
-    # from a source tree. This files can be created by cardano-node and
-    # cause errors when nix attempts to copy them into the store.
-    removeSocketFilesFilter = _path: type:
-      lib.elem type ["regular" "directory" "symlink" ];
-
     # Convert version strings from Cabal format (YYYY.M.D)
     # to git tag format (vYYYY-MM-DD).
     versionTag = cabalName: let

--- a/nix/overlays/common-lib.nix
+++ b/nix/overlays/common-lib.nix
@@ -59,19 +59,5 @@ in {
           && p.package.homepage == "https://github.com/cardano-foundation/cardano-wallet")
         cardanoWalletHaskellProject.pkg-set.config.packages);
 
-    ############################################################################
-    # Debugging tools
-
-    # Recursively traces an attrset as it's evaluated.
-    # This is helpful for debugging large attribute sets.
-    traceNames = let
-      go = prefix: builtins.mapAttrs (n: v:
-        if builtins.isAttrs v
-          then if v ? type && v.type == "derivation"
-            then __trace (prefix + n) v
-            else go (prefix + n + ".") v
-          else v);
-    in
-      go;
   };
 }

--- a/nix/overlays/common-lib.nix
+++ b/nix/overlays/common-lib.nix
@@ -4,21 +4,6 @@ self: super: let
 in {
   cardanoWalletLib = {
 
-    # Convert version strings from Cabal format (YYYY.M.D)
-    # to git tag format (vYYYY-MM-DD).
-    versionTag = cabalName: let
-        versionRegExp = "(^.*)([[:digit:]]{4})\.([[:digit:]]{1,2})\.([[:digit:]]{1,2})(.*$)";
-        parts = builtins.match versionRegExp cabalName;
-        name = lib.head parts;
-        cabalVer = lib.take 3 (lib.drop 1 parts);
-        rest = lib.drop 4 parts;
-        leading0 = str: if lib.stringLength str == 1 then "0" + str else str;
-        tag = "v" + lib.concatMapStringsSep "-" leading0 cabalVer;
-      in
-        assert lib.assertMsg (parts != null)
-          "versionTag: \"${cabalName}\" does not have a version in YYYY.M.D format";
-        (name + tag + lib.concatStrings rest);
-
     # Retrieve the list of local project packages by
     # filtering the set of *all* packages by their homepage.
     projectPackageList = lib.attrNames (lib.filterAttrs

--- a/nix/release-package.nix
+++ b/nix/release-package.nix
@@ -1,23 +1,25 @@
-############################################################################
+###############################################################################
 # Release package
 #
 # This bundles up the build of the given exes, with their
 # dependencies, and sets up the Hydra build artifact.
 #
-############################################################################
+###############################################################################
 
 { pkgs
+, walletLib
 , platform
 , exes
 , format
 }:
 
 let
-  inherit (pkgs) lib cardanoWalletLib;
+  inherit (pkgs) lib;
 
   exe = assert lib.assertMsg (lib.length exes > 0) "empty list of exes";
     lib.head exes;
-  name = "${cardanoWalletLib.versionTag exe.meta.name}-${platform}";
+  name =
+    "${walletLib.gitTagFromCabalVersion exe.meta.name}-${platform}";
 
   makeTarball = format == "tar.gz";
   makeZip = format == "zip";


### PR DESCRIPTION
Nix combines several aspects:

* A functional programming language, focusing on functions.
* A package description language, focusing on attribute sets and their contents.

This pull request is about changing `flake.nix` to better separate these aspects.

Specifically, we introduce a file `./nix/lib.nix` which represents a library of functions that are later used to specify packages. These are imported in the flake file and bound to the `lib` variable.

### Issue number

ADP-3238