### PR TITLE
Try making GH workflow update commit status

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,6 +31,13 @@ jobs:
     runs-on: windows-2022
     name: Download testing bundle
     steps:
+      - name: Set commit status as pending
+        uses: myrotvorets/set-commit-status-action@v2.0.0
+        with:
+          sha: ${{ github.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: pending
+
       - uses: actions/checkout@v3.2.0
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1.127.0
@@ -123,6 +130,28 @@ jobs:
           SLACK_MESSAGE: |
               *Job Link:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SLACK_COLOR: '#00FF00'
+
+    - name: Set final commit status on success
+      uses: myrotvorets/set-commit-status-action@v2.0.0
+      if: |
+           needs.cardano-wallet-launcher-test-unit.result == 'success' &&
+           needs.cardano-wallet-test-unit.result == 'success' &&
+           needs.text-class-test-unit.result == 'success'
+      with:
+        sha: ${{ github.sha }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        status: 'success'
+
+    - name: Set final commit status on non-success
+      uses: myrotvorets/set-commit-status-action@v2.0.0
+      if: |
+           needs.cardano-wallet-launcher-test-unit.result != 'success' ||
+           needs.cardano-wallet-test-unit.result != 'success' ||
+           needs.text-class-test-unit.result != 'success'
+      with:
+        sha: ${{ github.sha }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        status: 'failure'
 
   # ADP-2517 - Fix integration tests on Windows
   # cardano-wallet-test-integration:


### PR DESCRIPTION
- At the cost of some boilerplate, we can make GH workflows triggered by schedule and manually update the status of the commit they're testing

## Demo

https://github.com/cardano-foundation/cardano-wallet/actions/runs/7117768576

<img width="610" alt="Skärmavbild 2023-12-06 kl  18 12 07" src="https://github.com/cardano-foundation/cardano-wallet/assets/304423/f3b59d1e-c9cd-4e9c-b381-17cfd265aa07">
<img width="548" alt="Skärmavbild 2023-12-06 kl  18 35 20" src="https://github.com/cardano-foundation/cardano-wallet/assets/304423/0c92e118-957d-4fcd-938e-4cbd2ac7d3bb">

