### PR TITLE
Remove the redundant `AssetIdF` type.

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId/Gen.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId/Gen.hs
@@ -1,11 +1,7 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE NamedFieldPuns #-}
-
 module Cardano.Wallet.Primitive.Types.AssetId.Gen
     ( genAssetId
     , genAssetIdLargeRange
     , shrinkAssetId
-    , AssetIdF (..)
     ) where
 
 import Prelude
@@ -17,29 +13,14 @@ import Cardano.Wallet.Primitive.Types.AssetName.Gen
     ( genAssetName
     , genAssetNameLargeRange
     , shrinkAssetName
-    , testAssetNames
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicyId.Gen
     ( genTokenPolicyId
     , genTokenPolicyIdLargeRange
     , shrinkTokenPolicyId
-    , testTokenPolicyIds
-    )
-import Data.List
-    ( elemIndex
-    )
-import Data.Maybe
-    ( fromMaybe
-    )
-import GHC.Generics
-    ( Generic
     )
 import Test.QuickCheck
-    ( CoArbitrary (..)
-    , Function (..)
-    , Gen
-    , functionMap
-    , variant
+    ( Gen
     )
 import Test.QuickCheck.Extra
     ( genSized2With
@@ -66,19 +47,3 @@ genAssetIdLargeRange :: Gen AssetId
 genAssetIdLargeRange = AssetId
     <$> genTokenPolicyIdLargeRange
     <*> genAssetNameLargeRange
-
---------------------------------------------------------------------------------
--- Filtering functions
---------------------------------------------------------------------------------
-
-newtype AssetIdF = AssetIdF AssetId
-    deriving (Generic, Eq, Show, Read)
-
-instance Function AssetIdF where
-    function = functionMap show read
-
-instance CoArbitrary AssetIdF where
-    coarbitrary (AssetIdF AssetId {assetName, tokenPolicyId}) genB = do
-        let n = fromMaybe 0 (elemIndex assetName testAssetNames)
-        let m = fromMaybe 0 (elemIndex tokenPolicyId testTokenPolicyIds)
-        variant (n + m) genB

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -26,8 +26,7 @@ import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId (..)
     )
 import Cardano.Wallet.Primitive.Types.AssetId.Gen
-    ( AssetIdF (..)
-    , genAssetId
+    ( genAssetId
     , genAssetIdLargeRange
     , shrinkAssetId
     )
@@ -416,29 +415,29 @@ prop_toNestedList_fromNestedList b =
 --------------------------------------------------------------------------------
 
 -- | Verify that all assets in the resulting filtered map satisfy the predicate.
-prop_filter_conjoin :: Fun AssetIdF Bool -> TokenMap -> Property
+prop_filter_conjoin :: Fun AssetId Bool -> TokenMap -> Property
 prop_filter_conjoin f b =
     let
-        as = TokenMap.getAssets $ TokenMap.filter (applyFun f . AssetIdF) b
+        as = TokenMap.getAssets $ TokenMap.filter (applyFun f) b
     in
-        Set.foldr ((&&) . applyFun f . AssetIdF) True as === True
+        Set.foldr ((&&) . applyFun f) True as === True
 
 -- | Verify that we can partition the token map using the predicate, and recover
 -- the original map by computing the union of both partitions.
-prop_filter_partition :: Fun AssetIdF Bool -> TokenMap -> Property
+prop_filter_partition :: Fun AssetId Bool -> TokenMap -> Property
 prop_filter_partition f b =
     let
-        l = TokenMap.filter (applyFun f . AssetIdF) b
-        r = TokenMap.filter (not . applyFun f . AssetIdF) b
+        l = TokenMap.filter (applyFun f) b
+        r = TokenMap.filter (not . applyFun f) b
     in
         (l <> r) === b
 
 -- | Verify that filtering twice has the same effect as filtering once.
-prop_filter_twice :: Fun AssetIdF Bool -> TokenMap -> Property
+prop_filter_twice :: Fun AssetId Bool -> TokenMap -> Property
 prop_filter_twice f b =
     let
-        once  = TokenMap.filter (applyFun f . AssetIdF) b
-        twice = TokenMap.filter (applyFun f . AssetIdF) once
+        once  = TokenMap.filter (applyFun f) b
+        twice = TokenMap.filter (applyFun f) once
     in
         once === twice
 


### PR DESCRIPTION
## Issue

None. Noticed while reviewing code.

## Summary

This PR removes the `AssetIdF` type, which is redundant.

## Details

The `AssetIdF` newtype wrapper for `AssetId` was originally introduced so that we could define reusable `CoArbitrary` and `Function` instances without having to write orphan instances.
 
However, both the `CoArbitrary` and `Function` classes provide default implementations for types that are instances of `Generic`.
    
Since `AssetId` is indeed an instance of `Generic`, we can derive instances for these classes automatically:
    
```hs
deriving anyclass instance CoArbitrary AssetId
deriving anyclass instance Function AssetId
```

And given that we _already have_ the above definitions, we can remove all usages of the `AssetIdF` type.