### PR TITLE
[ADP-3224] Bump 8.1.1 to 8.1.2 node version mentions

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -8,7 +8,7 @@ on:
       nodeTag:
         description: 'Node tag (docker)'
         required: true
-        default: '8.1.1'
+        default: '8.1.2'
       walletTag:
         description: 'Wallet tag (docker)'
         required: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:8.1.1
+    image: inputoutput/cardano-node:8.1.2
     environment:
       NETWORK:
       CARDANO_NODE_SOCKET_PATH: /ipc/node.socket

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -73,7 +73,7 @@ One can also start tests against cardano-wallet docker. There is docker-compose-
 >NETWORK=preprod \
 >TESTS_E2E_TOKEN_METADATA=https://metadata.world.dev.cardano.org/ \
 >WALLET=dev-master \
->NODE=8.1.1 \
+>NODE=8.1.2 \
 >NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK \
 >DATA=`pwd`/state/node_db/$NETWORK
 >docker-compose -f docker-compose-test.yml up

--- a/test/e2e/docker_compose.sh
+++ b/test/e2e/docker_compose.sh
@@ -3,7 +3,7 @@
 NETWORK=preprod \
 TESTS_E2E_TOKEN_METADATA=https://metadata.world.dev.cardano.org/ \
 WALLET=dev-master \
-NODE=8.1.1 \
+NODE=8.1.2 \
 NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK \
 DATA=`pwd`/state/node_db/$NETWORK \
 WALLET_DATA=`pwd`/state/wallet_db/$NETWORK \


### PR DESCRIPTION
These were left overs from the node bump that are not reflected E2E scheduled tests

ADP-3224