### PR TITLE
[ADP-3224] Revert wallet version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ We provide executables as part of our [releases](https://github.com/cardano-foun
 >
 > | cardano-wallet | cardano-node (compatible versions) |
 > | --- | --- |
-> | [v2023-12-07](https://github.com/cardano-foundation/cardano-wallet/releases/tag/v2023-12-07) | [8.1.2](https://github.com/input-output-hk/cardano-node/releases/tag/8.1.2) |
+> | `master` branch | [8.1.1](https://github.com/input-output-hk/cardano-node/releases/tag/8.1.1) |
 > | [v2023-07-18](https://github.com/cardano-foundation/cardano-wallet/releases/tag/v2023-07-18) | [8.1.1](https://github.com/input-output-hk/cardano-node/releases/tag/8.1.1) |
 > | [v2023-04-14](https://github.com/cardano-foundation/cardano-wallet/releases/tag/v2023-04-14) | [1.35.4](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.4) |
 > | [v2022-12-14](https://github.com/cardano-foundation/cardano-wallet/releases/tag/v2022-12-14) | [1.35.4](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.4) |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
         max-size: "50m"
 
   cardano-wallet:
-    image: cardanofoundation/cardano-wallet:2023.12.7
+    image: cardanofoundation/cardano-wallet:2023.7.18
     volumes:
       - wallet-${NETWORK}-db:/wallet-db
       - node-ipc:/ipc

--- a/lib/address-derivation-discovery/address-derivation-discovery.cabal
+++ b/lib/address-derivation-discovery/address-derivation-discovery.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               address-derivation-discovery
-version:            2023.12.7
+version:            2023.7.18
 synopsis:           Address derivation and discovery.
 description:        Please see README.md.
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/application-extras/cardano-wallet-application-extras.cabal
+++ b/lib/application-extras/cardano-wallet-application-extras.cabal
@@ -38,6 +38,6 @@ library
     , safe                   ^>=0.3.19
     , streaming-commons      ^>=0.2.2.6
     , text                   ^>=1.2.4.1
-    , text-class             ^>=2023.12.7
+    , text-class             ^>=2023.7.18
     , unliftio               ^>=0.2.24
     , unliftio-core          ^>=0.2.1

--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-balance-tx
-version:            2023.12.7
+version:            2023.7.18
 synopsis:           Balancing transactions for the Cardano blockchain.
 description:        Please see README.md.
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/cardano-api-extra/cardano-api-extra.cabal
+++ b/lib/cardano-api-extra/cardano-api-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               cardano-api-extra
-version:            2023.12.7
+version:            2023.7.18
 synopsis:           Useful extensions to the Cardano API.
 description:        Please see README.md.
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/coin-selection/cardano-coin-selection.cabal
+++ b/lib/coin-selection/cardano-coin-selection.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               cardano-coin-selection
-version:            2023.12.7
+version:            2023.7.18
 synopsis:           Coin selection algorithms for the Cardano blockchain.
 description:        Please see README.md.
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/iohk-monitoring-extra/iohk-monitoring-extra.cabal
+++ b/lib/iohk-monitoring-extra/iohk-monitoring-extra.cabal
@@ -36,7 +36,7 @@ library
     , fmt                  ^>=0.6.3
     , iohk-monitoring      ^>=0.1.11.3
     , text                 ^>=1.2.4.1
-    , text-class           ^>=2023.12.7
+    , text-class           ^>=2023.7.18
     , time                 ^>=1.9.3
     , tracer-transformers  ^>=0.1.0.4
     , transformers         ^>=0.5.6.2

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-launcher
-version:             2023.12.7
+version:             2023.7.18
 synopsis:            Utilities for a building commands launcher
 homepage:            https://github.com/cardano-foundation/cardano-wallet
 author:              Cardano Foundation (High Assurance Lab)

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-wallet-primitive
-version:       2023.12.7
+version:       2023.7.18
 synopsis:      Selected primitive types for Cardano Wallet.
 description:   Please see README.md.
 homepage:      https://github.com/cardano-foundation/cardano-wallet

--- a/lib/temporary-extra/temporary-extra.cabal
+++ b/lib/temporary-extra/temporary-extra.cabal
@@ -32,5 +32,5 @@ library
     , iohk-monitoring-extra  ^>=0.1
     , temporary              ^>=1.3
     , text                   ^>=1.2.4.1
-    , text-class             ^>=2023.12.7
+    , text-class             ^>=2023.7.18
     , unliftio               ^>=0.2.24

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-test-utils
-version:             2023.12.7
+version:             2023.7.18
 synopsis:            Shared utilities for writing unit and property tests.
 description:         Shared utilities for writing unit and property tests.
 homepage:            https://github.com/cardano-foundation/cardano-wallet

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -1,5 +1,5 @@
 name:                text-class
-version:             2023.12.7
+version:             2023.7.18
 synopsis:            Extra helpers to convert data-types to and from Text
 homepage:            https://github.com/cardano-foundation/cardano-wallet
 author:              Cardano Foundation (High Assurance Lab)

--- a/lib/wallet-benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/wallet-benchmarks/cardano-wallet-benchmarks.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                cardano-wallet-benchmarks
-version:             2023.12.7
+version:             2023.7.18
 synopsis:            Benchmarks for the `cardano-wallet` exectuable.
 description:         This package is a collection of benchmarks
                      for the `cardano-wallet` exectuable.

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-wallet
-version:            2023.12.7
+version:            2023.7.18
 synopsis:           The Wallet Backend for a Cardano node.
 description:        Please see README.md
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Cardano Wallet Backend API
-  version: v2023-12-07
+  version: v2023-07-18
   license:
     name: Apache-2.0
     url: https://raw.githubusercontent.com/cardano-foundation/cardano-wallet/master/LICENSE


### PR DESCRIPTION
This changes were premature as we couldn't replicate the green state in the release branch. We are fixing instructions so that merging to master happens only after releasing from the release branch.

We revert them as
  - date is now wrong
  - the docker image is not in dockerhub so docker E2E are now broken on master

ADP-3224
