### PR TITLE
Replace `CardanoApi.Tx` with `Write.Tx` in `Cardano.Wallet`.

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2044,7 +2044,6 @@ selectCoins ctx@ApiLayer {..} argGenChange (ApiT walletId) body = do
 
         (cardanoTx, walletState) <-
             liftIO $
-            first Write.toCardanoApiTx <$>
             W.buildTransaction @s
             db timeTranslation genChange pp txCtx paymentOuts
 
@@ -2111,7 +2110,6 @@ selectCoinsForJoin ctx@ApiLayer{..}
         let paymentOuts = []
 
         (cardanoTx, walletState) <-
-            first Write.toCardanoApiTx <$>
             W.buildTransaction @s
             db timeTranslation changeAddrGen pp txCtx paymentOuts
 
@@ -2169,7 +2167,6 @@ selectCoinsForQuit ctx@ApiLayer{..} (ApiT walletId) = do
         let paymentOuts = []
 
         (cardanoTx, walletState) <-
-            first Write.toCardanoApiTx <$>
             W.buildTransaction @s
             db timeTranslation changeAddrGen pp txCtx paymentOuts
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2042,7 +2042,7 @@ selectCoins ctx@ApiLayer {..} argGenChange (ApiT walletId) body = do
                 , txMetadata = getApiT <$> body ^. #metadata
                 }
 
-        (cardanoTx, walletState) <-
+        (tx, walletState) <-
             liftIO $
             W.buildTransaction @s
             db timeTranslation genChange pp txCtx paymentOuts
@@ -2053,7 +2053,7 @@ selectCoins ctx@ApiLayer {..} argGenChange (ApiT walletId) body = do
                     paymentOuts
                     (W.getStakeKeyDeposit pp)
                     Nothing -- delegation action
-                    cardanoTx
+                    tx
 
         pure ApiCoinSelection
             { inputs = mkApiCoinSelectionInput <$> inputs
@@ -2109,7 +2109,7 @@ selectCoinsForJoin ctx@ApiLayer{..}
 
         let paymentOuts = []
 
-        (cardanoTx, walletState) <-
+        (tx, walletState) <-
             W.buildTransaction @s
             db timeTranslation changeAddrGen pp txCtx paymentOuts
 
@@ -2119,7 +2119,7 @@ selectCoinsForJoin ctx@ApiLayer{..}
                     paymentOuts
                     (W.getStakeKeyDeposit pp)
                     (Just action)
-                    cardanoTx
+                    tx
 
         pure ApiCoinSelection
             { inputs = mkApiCoinSelectionInput <$> inputs
@@ -2166,7 +2166,7 @@ selectCoinsForQuit ctx@ApiLayer{..} (ApiT walletId) = do
 
         let paymentOuts = []
 
-        (cardanoTx, walletState) <-
+        (tx, walletState) <-
             W.buildTransaction @s
             db timeTranslation changeAddrGen pp txCtx paymentOuts
 
@@ -2176,7 +2176,7 @@ selectCoinsForQuit ctx@ApiLayer{..} (ApiT walletId) = do
                     paymentOuts
                     (W.getStakeKeyDeposit pp)
                     (Just action)
-                    cardanoTx
+                    tx
 
         pure ApiCoinSelection
             { inputs = mkApiCoinSelectionInput <$> inputs

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2042,7 +2042,10 @@ selectCoins ctx@ApiLayer {..} argGenChange (ApiT walletId) body = do
                 , txMetadata = getApiT <$> body ^. #metadata
                 }
 
-        (cardanoTx, walletState) <- liftIO $ W.buildTransaction @s
+        (cardanoTx, walletState) <-
+            liftIO $
+            first Write.toCardanoApiTx <$>
+            W.buildTransaction @s
             db timeTranslation genChange pp txCtx paymentOuts
 
         let W.CoinSelection{..} =
@@ -2107,9 +2110,10 @@ selectCoinsForJoin ctx@ApiLayer{..}
 
         let paymentOuts = []
 
-        (cardanoTx, walletState) <- W.buildTransaction @s
-            db timeTranslation changeAddrGen pp txCtx
-            paymentOuts
+        (cardanoTx, walletState) <-
+            first Write.toCardanoApiTx <$>
+            W.buildTransaction @s
+            db timeTranslation changeAddrGen pp txCtx paymentOuts
 
         let W.CoinSelection{..} =
                 W.buildCoinSelectionForTransaction @s @n
@@ -2164,7 +2168,9 @@ selectCoinsForQuit ctx@ApiLayer{..} (ApiT walletId) = do
 
         let paymentOuts = []
 
-        (cardanoTx, walletState) <- W.buildTransaction @s
+        (cardanoTx, walletState) <-
+            first Write.toCardanoApiTx <$>
+            W.buildTransaction @s
             db timeTranslation changeAddrGen pp txCtx paymentOuts
 
         let W.CoinSelection{..} =

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1891,7 +1891,7 @@ buildCoinSelectionForTransaction
     -> Coin
     -- ^ protocol parameter deposit amount
     -> Maybe DelegationAction
-    -> Cardano.Tx (Write.CardanoApiEra era)
+    -> Write.Tx era
     -> CoinSelection
 buildCoinSelectionForTransaction
     wallet paymentOutputs depositRefund delegationAction cardanoTx =
@@ -1933,7 +1933,7 @@ buildCoinSelectionForTransaction
   where
     Cardano.TxBody Cardano.TxBodyContent
         { txIns, txOuts, txInsCollateral, txWithdrawals } =
-            Cardano.getTxBody cardanoTx
+            Cardano.getTxBody $ Write.toCardanoApiTx cardanoTx
 
     resolveInput txIn = do
         (txOut, derivationPath) <- maybeToList (lookupTxIn wallet txIn)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -3024,8 +3024,8 @@ transactionFee DBLayer{atomically, walletState} protocolParams
                         changeAddressGen
                         (getState wallet)
                         ptx
-            case res of
-                Right (Cardano.Tx (Cardano.TxBody bodyContent) _, _updatedWallet)
+            case fst <$> res of
+                Right (Cardano.Tx (Cardano.TxBody bodyContent) _)
                     -> pure $ case Cardano.txFee bodyContent of
                         Cardano.TxFeeExplicit _ coin
                             -> Fee (fromCardanoLovelace coin)

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2299,7 +2299,7 @@ buildTransaction
     -> TransactionCtx
     -> [TxOut]
     -- ^ payment outputs
-    -> IO (Cardano.Tx (Write.CardanoApiEra era), Wallet s)
+    -> IO (Write.Tx era, Wallet s)
 buildTransaction DBLayer{..} timeTranslation changeAddrGen
     protocolParameters txCtx paymentOuts = do
     stdGen <- initStdGen
@@ -2317,8 +2317,7 @@ buildTransaction DBLayer{..} timeTranslation changeAddrGen
 
         let utxo = availableUTxO @s pendingTxs wallet
 
-        fmap (\s' -> wallet { getState = s' }) .
-            first Write.toCardanoApiTx <$>
+        fmap (\s' -> wallet { getState = s' }) <$>
             buildTransactionPure @s @era
                 wallet
                 timeTranslation

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1886,8 +1886,10 @@ buildCoinSelectionForTransaction
        , s ~ SeqState n k
        )
     => Wallet s
-    -> [TxOut] -- ^ payment outputs to exclude from change outputs
-    -> Coin -- ^ protocol parameter deposit amount
+    -> [TxOut]
+    -- ^ payment outputs to exclude from change outputs
+    -> Coin
+    -- ^ protocol parameter deposit amount
     -> Maybe DelegationAction
     -> Cardano.Tx (Write.CardanoApiEra era)
     -> CoinSelection
@@ -2294,7 +2296,8 @@ buildTransaction
     -> ChangeAddressGen s
     -> Write.PParams era
     -> TransactionCtx
-    -> [TxOut] -- ^ payment outputs
+    -> [TxOut]
+    -- ^ payment outputs
     -> IO (Cardano.Tx (Write.CardanoApiEra era), Wallet s)
 buildTransaction DBLayer{..} timeTranslation changeAddrGen
     protocolParameters txCtx paymentOuts = do
@@ -2304,7 +2307,12 @@ buildTransaction DBLayer{..} timeTranslation changeAddrGen
 
         pendingTxs <- Set.fromList . fmap fromTransactionInfo <$>
             readTransactions
-                Nothing Descending Range.everything (Just Pending) Nothing Nothing
+                Nothing
+                Descending
+                Range.everything
+                (Just Pending)
+                Nothing
+                Nothing
 
         let utxo = availableUTxO @s pendingTxs wallet
 

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1894,7 +1894,7 @@ buildCoinSelectionForTransaction
     -> Write.Tx era
     -> CoinSelection
 buildCoinSelectionForTransaction
-    wallet paymentOutputs depositRefund delegationAction cardanoTx =
+    wallet paymentOutputs depositRefund delegationAction tx =
     CoinSelection
     { inputs = resolveInput . fromCardanoTxIn . fst =<< txIns
     , outputs = paymentOutputs
@@ -1933,7 +1933,7 @@ buildCoinSelectionForTransaction
   where
     Cardano.TxBody Cardano.TxBodyContent
         { txIns, txOuts, txInsCollateral, txWithdrawals } =
-            Cardano.getTxBody $ Write.toCardanoApiTx cardanoTx
+            Cardano.getTxBody $ Write.toCardanoApiTx tx
 
     resolveInput txIn = do
         (txOut, derivationPath) <- maybeToList (lookupTxIn wallet txIn)


### PR DESCRIPTION
## Issue

Follow-up from previous PRs.

## Description

This PR adjusts the type signatures of several functions in `Cardano.Wallet`, applying the following transformation:
```patch
- CardanoApi.Tx (Write.CardanoApiEra era)
+ Write     .Tx                      era
```