### PR TITLE
Remove redundant use of `AllowAmbiguousTypes` in `BalanceSpec`.

### DIFF
--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}


### PR DESCRIPTION
## Issue

None. Noticed while reviewing code.

## Description

This PR removes a redundant use of `AllowAmbiguousTypes` from `BalanceSpec`. 

## Motivation

Make it so that we notice if we ever have to re-enable this extension.