### PR TITLE
[ADP-3224] CI pipeline checks if cabal can build all.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,6 +30,14 @@ steps:
     env:
       TMPDIR: "/cache"
 
+  - label: 'Cabal Release Build works in the nix shell'
+    depends_on: linux-nix
+    command: 'nix develop -c cabal build all -frelease'
+    agents:
+      system: ${linux}
+    env:
+      TMPDIR: "/cache"
+
   - label: 'Run unit tests (linux)'
     depends_on: linux-nix
     command: 'nix build -L .#ci.${linux}.tests.run.unit'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,7 +32,9 @@ steps:
 
   - label: 'Cabal Release Build works in the nix shell'
     depends_on: linux-nix
-    command: 'nix develop -c cabal build all -frelease'
+    command: |
+      nix develop -c cabal update
+      nix develop -c cabal build all -frelease
     agents:
       system: ${linux}
     env:

--- a/cabal.project
+++ b/cabal.project
@@ -153,8 +153,8 @@ source-repository-package
     --sha256: 04q58c82wy6x9nkwqbvcxbv6s61fx08h5kf62sb511aqp08id4bb
     subdir: generated
 
--- -------------------------------------------------------------------------
--- Constraints tweaking
+--------------------------------------------------------------------------------
+-- BEGIN Constraints tweaking section
 
 -- cardano-addresses unit tests bring in some version constraint conflicts.
 --
@@ -204,8 +204,14 @@ constraints:
 if impl(ghc == 8.10.7)
   constraints: process == 1.6.13.2
 
--- ----------------------------------------------------------------
--- Flags for dependencies
+-- END Constraints tweaking section
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+-- Flags for dependencies without an S-R-P pragma should be kept in this section
+-- (conversely, flags for the S-R-P dependencies should be kept within the
+-- same section where an S-R-P pragma is located,
+-- for them to be managed together)
 
 -- Using RDRAND instead of /dev/urandom as an entropy source for key
 -- generation is dubious. Set the flag so we use /dev/urandom by default.

--- a/cabal.project
+++ b/cabal.project
@@ -104,6 +104,9 @@ source-repository-package
   tag: f22c31611c295637a3e72b341cd1c56d1d87b993
   --sha256: 10l7wlaz9rcr3fysi1vwg7qqa826bb7nidkpx9jy1q7ja7ddw47i
 
+--------------------------------------------------------------------------------
+-- BEGIN Cardano Addresses Dependency
+
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-addresses
@@ -112,8 +115,22 @@ source-repository-package
     subdir: command-line
             core
 
-package cardano-addresses
-  ghc-options: -Wno-incomplete-uni-patterns
+-- Normally cabal won't apply ghc-options which we specify to build packages
+-- to their "regular" dependencies.
+-- However, the dependencies declared using the `source-repository-package`
+-- pragma are an exception to this rule.
+-- This is why we need to manually control options that are applied to the
+-- `cardano-addresses` package by declaring them explicitly here.
+--
+-- Cardano Addresses CLI uses an outdated version of the `optparse-applicative`
+-- library. This causes a deprecation warning to be emitted when building.
+-- We don't want to promote this warning to an error level as it break the
+-- release build and cardano-addresses codebase is not under our control.
+package cardano-addresses-cli
+    ghc-options: -Wwarn=deprecations
+
+-- END Cardano Addresses Dependency
+--------------------------------------------------------------------------------
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -83,10 +83,8 @@ packages:
   , lib/wallet/
   , lib/wallet-e2e/
 
--- Using RDRAND instead of /dev/urandom as an entropy source for key
--- generation is dubious. Set the flag so we use /dev/urandom by default.
-package cryptonite
-  flags: -support_rdrand
+--------------------------------------------------------------------------------
+-- BEGIN OpenAPI
 
 -- Using a fork until our patches can be merged upstream
 
@@ -103,6 +101,9 @@ source-repository-package
   location: https://github.com/paolino/openapi3
   tag: f22c31611c295637a3e72b341cd1c56d1d87b993
   --sha256: 10l7wlaz9rcr3fysi1vwg7qqa826bb7nidkpx9jy1q7ja7ddw47i
+
+-- END OpenAPI
+--------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
 -- BEGIN Cardano Addresses Dependency
@@ -206,8 +207,14 @@ if impl(ghc == 8.10.7)
 -- ----------------------------------------------------------------
 -- Flags for dependencies
 
+-- Using RDRAND instead of /dev/urandom as an entropy source for key
+-- generation is dubious. Set the flag so we use /dev/urandom by default.
+package cryptonite
+  flags: -support_rdrand
+
 package cardano-config
   flags: -systemd
+
 package cardano-node
   flags: -systemd
 


### PR DESCRIPTION
- [x] Added CI step to check if `cabal build all -frelease` works inside the `nix shell`
- [x] Added a `-Wwarn=deprecations` to the cardano-addresses-cli SRP in the cabal.project


