### PR TITLE
[ADP-3224] Remove unacceptable e2e tests

### DIFF
--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -1482,7 +1482,6 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
       expect(stake_keys['ours'].first['stake']['quantity']).to eq expected_quit_balance
       expect(stake_keys['none']['stake']['quantity']).to eq 0
       expect(stake_keys['ours'].first['delegation']['active']['status']).to eq 'not_delegating'
-      expect(stake_keys['ours'].first['delegation']['next'].first['status']).to eq 'not_delegating'
       expect(stake_keys['ours'].first['delegation']['next'].last['status']).to eq 'not_delegating'
     end
 
@@ -3002,7 +3001,6 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
         expect(stake_keys['ours'].first['stake']['quantity']).to eq total_balance_after
         expect(stake_keys['none']['stake']['quantity']).to eq 0
         expect(stake_keys['ours'].first['delegation']['active']['status']).to eq 'not_delegating'
-        expect(stake_keys['ours'].first['delegation']['next'].first['status']).to eq 'not_delegating'
         expect(stake_keys['ours'].first['delegation']['next'].last['status']).to eq 'not_delegating'
 
         # examine the tx in history


### PR DESCRIPTION
- [x] Relax expectations used in the E2E tests that are too strict (and therefore fragile): they fail to take into account a possibility of an epoch boundary happening between registering a stake key delegation and un-registering it. 