### PR TITLE
[ADP-3224] Reschedule e2e to avoid race conditions

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -2,7 +2,7 @@ name: E2E Docker
 
 on:
   schedule:
-  - cron:  "0 0 * * *"
+  - cron:  "0 6 * * *"
   workflow_dispatch:
     inputs:
       nodeTag:
@@ -35,7 +35,10 @@ jobs:
       E2E_DOCKER_RUN: 1
 
     steps:
-    - uses: actions/checkout@v3.2.0
+    - name: Checkout the rc-latest tag
+      uses: actions/checkout@v4.1.1
+      with:
+        ref: rc-latest
 
     - name: Get supported node tag
       run: |

--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -2,7 +2,7 @@ name: E2E Linux
 
 on:
   schedule:
-  - cron:  "0 20 * * *"
+  - cron:  "0 0 * * *"
   workflow_dispatch:
     inputs:
 
@@ -28,7 +28,10 @@ jobs:
       TAGS: ${{ github.event.inputs.tags || 'all' }}
 
     steps:
-    - uses: actions/checkout@v3.2.0
+    - name: Checkout the rc-latest tag
+      uses: actions/checkout@v4.1.1
+      with:
+        ref: rc-latest
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1.127.0

--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -2,7 +2,7 @@ name: E2E MacOS
 
 on:
   schedule:
-  - cron:  "0 20 * * *"
+  - cron:  "0 3 * * *"
   workflow_dispatch:
     inputs:
 
@@ -28,7 +28,11 @@ jobs:
       TAGS: ${{ github.event.inputs.tags || 'all' }}
 
     steps:
-    - uses: actions/checkout@v3
+
+    - name: Checkout the rc-latest tag
+      uses: actions/checkout@v4.1.1
+      with:
+        ref: rc-latest
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1.127.0

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -2,7 +2,7 @@ name: E2E Windows
 
 on:
   schedule:
-  - cron:  "0 20 * * *"
+  - cron:  "0 21 * * *"
   workflow_dispatch:
     inputs:
       branch:
@@ -38,9 +38,8 @@ jobs:
     - name: Checkout
       shell: bash
       run: |
-        git clone https://github.com/cardano-foundation/cardano-wallet.git C:/cardano-wallet --depth 1 --no-single-branch
+        git clone -b rc-latest https://github.com/cardano-foundation/cardano-wallet.git C:/cardano-wallet --depth 1 --no-single-branch
         cd /c/cardano-wallet
-        git checkout ${GITHUB_REF#refs/heads/}
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1.127.0

--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -131,7 +131,7 @@ task :wait_until_node_synced do
       sleep 5
     end
   rescue StandardError => e
-    if current_time <= timeout_treshold then
+    if current_time <= timeout_treshold
       log "Retrying after error #{e}"
       sleep 5
       retry


### PR DESCRIPTION
- [x] schedule E2E tests every 3 hours to rule out race conditions on the shared wallets
- [x] retarget checkouts to tag `rc-latest` for E2E tests

ADP-3224