### PR TITLE
Disable crypt in address-derivation-discovery.cabal on anything but x…

### DIFF
--- a/lib/address-derivation-discovery/address-derivation-discovery.cabal
+++ b/lib/address-derivation-discovery/address-derivation-discovery.cabal
@@ -43,7 +43,9 @@ library
   hs-source-dirs:  lib
   ghc-options:     -Wincomplete-uni-patterns -Wincomplete-record-updates
 
-  if flag(scrypt)
+  -- scrypt depends on sse2, which in turn is not reasonably available
+  -- on anything but x86_64.
+  if flag(scrypt) && arch(x86_64)
     cpp-options:   -DHAVE_SCRYPT
     build-depends: scrypt
 


### PR DESCRIPTION
…86_64

SSE2 is simply not available anywhere there.

This can probably also remove the custom hack to pass `-f-scrypt` in nix.
