### PR TITLE
Use terminology consistent with ledger specification in `TokenMap`.

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/AssetId.hs
@@ -24,7 +24,7 @@ import GHC.Generics
 --   used as a compound identifier.
 --
 data AssetId = AssetId
-    { tokenPolicyId
+    { policyId
         :: !TokenPolicyId
     , assetName
         :: !AssetName

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -399,18 +399,18 @@ jsonFailWithZeroValueTokenQuantity policyId assetName = jsonFailWith $ unwords
 instance ToJSON (Flat TokenMap) where
     toJSON = toJSON . fmap fromTuple . toFlatList . getFlat
       where
-        fromTuple (AssetId policyId assetName, q) =
-            FlatAssetQuantity policyId assetName q
+        fromTuple (AssetId policyId assetName, quantity) =
+            FlatAssetQuantity policyId assetName quantity
 
 instance FromJSON (Flat TokenMap) where
     parseJSON =
         fmap (Flat . fromFlatList) . mapM parseTuple <=< parseJSON
       where
         parseTuple :: FlatAssetQuantity -> Parser (AssetId, TokenQuantity)
-        parseTuple (FlatAssetQuantity policyId assetName q) = do
-            when (TokenQuantity.isZero q) $
+        parseTuple (FlatAssetQuantity policyId assetName quantity) = do
+            when (TokenQuantity.isZero quantity) $
                 jsonFailWithZeroValueTokenQuantity policyId assetName
-            pure (AssetId policyId assetName, q)
+            pure (AssetId policyId assetName, quantity)
 
 -- Used for JSON serialization only: not exported.
 data FlatAssetQuantity = FlatAssetQuantity

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -394,7 +394,7 @@ instance IsServerError ErrMkTransaction where
                 , "Destination address: "
                 , pretty (view #address e)
                 , ". Token policy identifier: "
-                , pretty (view (#asset . #tokenPolicyId) e)
+                , pretty (view (#asset . #policyId) e)
                 , ". Asset name: "
                 , pretty (view (#asset . #assetName) e)
                 , ". Token quantity specified: "

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -938,7 +938,7 @@ mkUnsignedTx
                     witMap =
                             Map.map toScriptWitnessGeneral $
                             Map.mapKeys
-                                (toCardanoPolicyId . AssetId.tokenPolicyId)
+                                (toCardanoPolicyId . AssetId.policyId)
                             mintingSource
                     ctx = Cardano.BuildTxWith witMap
                 in Cardano.TxMintValue mintedEra (mintValue <> burnValue) ctx


### PR DESCRIPTION
## Issue

None. Noticed while reviewing code.

## Description

This PR adjusts the `TokenMap` module to use variable names that are more consistent with the ledger specification, as presented below:

| Type | Name |
|--|--|
| `TokenPolicyId` | `policyId` |
| `AssetName` | `assetName` |