### PR TITLE
[ADP-3224] Change docker-hub image publication logic

### DIFF
--- a/.buildkite/docker-build-push.nix
+++ b/.buildkite/docker-build-push.nix
@@ -77,10 +77,10 @@ in
     if [[ "$git_tag" =~ ^v20 ]]; then
       tags+=( "${image.imageTag}" )
       tags+=( "latest" )
-    elif [[ "$git_branch" = master ]]; then
-      tags+=( "$(echo ${image.imageTag} | sed -e s/${image.version}/dev-$git_branch/)" )
+    elif [[ "$git_tag" = "rc-latest" ]]; then
+      tags+=( "$git_tag" )
     else
-      echo 'Not pushing docker image because this is not a master branch or v20* tag build.'
+      echo 'Not pushing docker image because this is neither a rc-latest nor a v20* tag build.'
     fi
 
     echo

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -169,7 +169,7 @@ steps:
     agents:
       system: ${macos}
 
-  - block: "Build package and docker image (linux)"
+  - block: "Build package (linux)"
     depends_on: linux-nix
     if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master")'
     key: trigger-build-linux-package
@@ -179,18 +179,6 @@ steps:
     key: build-linux
     command: nix build -o result/linux .#ci.artifacts.linux64.release
     artifact_paths: [ "./result/linux/**" ]
-    agents:
-      system: ${linux}
-    env:
-      TMPDIR: "/cache"
-
-  - label: 'Build Docker Image (linux)'
-    depends_on: [linux-nix, trigger-build-linux-package]
-    key: build-docker
-    command:
-      - "mkdir -p config && echo '{ outputs = _: { dockerHubRepoName = \"cardanofoundation/cardano-wallet\"; }; }'  > config/flake.nix"
-      - "nix build .#pushDockerImage --override-input hostNixpkgs \"path:$(nix eval --impure -I $NIX_PATH --expr '(import <nixpkgs> {}).path')\" --override-input customConfig path:./config -o docker-build-push"
-      - "./docker-build-push"
     agents:
       system: ${linux}
     env:

--- a/.buildkite/tagly.yml
+++ b/.buildkite/tagly.yml
@@ -1,0 +1,17 @@
+agents:
+  queue: "cardano-wallet"
+
+env:
+  LC_ALL: "C.UTF-8"
+  NIX_PATH: "channel:nixos-21.11"
+  TMPDIR: "/cache"
+
+steps:
+  - label: 'Build Docker Image (linux)'
+    key: build-docker
+    command:
+      - "mkdir -p config && echo '{ outputs = _: { dockerHubRepoName = \"cardanofoundation/cardano-wallet\"; }; }'  > config/flake.nix"
+      - "nix build .#pushDockerImage --override-input hostNixpkgs \"path:$(nix eval --impure -I $NIX_PATH --expr '(import <nixpkgs> {}).path')\" --override-input customConfig path:./config -o docker-build-push"
+      - "./docker-build-push"
+    agents:
+      system: x86_64-linux


### PR DESCRIPTION
- [x] Create a pipeline `cardano-wallet/tagly` in buildkite to publish docker images
        [new pipeline](https://buildkite.com/cardano-foundation/cardano-wallet-tagly)
- [x] Move the docker step from `cardano-wallet` pipeline to the new one
- [x] Publish `rc-latest` tag in place of `dev-master`

[new pipeline](https://buildkite.com/cardano-foundation/cardano-wallet-tagly)

ADP-3224