### PR TITLE
[ADP-3224] Update default branch to be rc-latest in E2E tests

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -12,7 +12,7 @@ on:
       walletTag:
         description: 'Wallet tag (docker)'
         required: true
-        default: 'dev-master'
+        default: 'rc-latest'
       tags:
         description: 'Test tags (all, light, offchain...)'
         default: 'all'
@@ -29,7 +29,7 @@ jobs:
     env:
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}
       BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_TOKEN_READ_BUILDS_ARTIFACTS }}
-      WALLET: ${{ github.event.inputs.walletTag || 'dev-master' }}
+      WALLET: ${{ github.event.inputs.walletTag || 'rc-latest' }}
       TESTS_E2E_TOKEN_METADATA: https://metadata.world.dev.cardano.org/
       TAGS: ${{ github.event.inputs.tags || 'all' }}
       E2E_DOCKER_RUN: 1
@@ -38,7 +38,7 @@ jobs:
     - name: Checkout the rc-latest tag
       uses: actions/checkout@v4.1.1
       with:
-        ref: rc-latest
+        ref: ${{ github.event.inputs.walletTag || 'rc-latest' }}
 
     - name: Get supported node tag
       run: |
@@ -62,7 +62,7 @@ jobs:
       run: bundle install
 
     - name: ⚙️ Setup (get latest bins and configs and decode fixtures)
-      run: rake setup[preprod]
+      run: rake setup[preprod,${{ env.WALLET}}]
 
 
     - name: 💾 Cache node db

--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -8,7 +8,7 @@ on:
 
       branch:
         description: 'Run tests against branch'
-        default: 'master'
+        default: 'rc-latest'
       tags:
         description: 'Test tags (all, light, offchain...)'
         default: 'all'
@@ -24,14 +24,14 @@ jobs:
     env:
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}
       BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_TOKEN_READ_BUILDS_ARTIFACTS }}
-      BRANCH: ${{ github.event.inputs.branch || '' }}
+      BRANCH: ${{ github.event.inputs.branch || 'rc-latest' }}
       TAGS: ${{ github.event.inputs.tags || 'all' }}
 
     steps:
     - name: Checkout the rc-latest tag
       uses: actions/checkout@v4.1.1
       with:
-        ref: rc-latest
+        ref:  ${{ github.event.inputs.branch || 'rc-latest' }}
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1.127.0

--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -8,7 +8,7 @@ on:
 
       branch:
         description: 'Run tests against branch'
-        default: 'master'
+        default: 'rc-latest'
       tags:
         description: 'Test tags (all, light, offchain...)'
         default: 'all'
@@ -24,7 +24,7 @@ jobs:
     env:
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}
       BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_TOKEN_READ_BUILDS_ARTIFACTS }}
-      BRANCH: ${{ github.event.inputs.branch || '' }}
+      BRANCH: ${{ github.event.inputs.branch || 'rc-latest' }}
       TAGS: ${{ github.event.inputs.tags || 'all' }}
 
     steps:
@@ -32,7 +32,7 @@ jobs:
     - name: Checkout the rc-latest tag
       uses: actions/checkout@v4.1.1
       with:
-        ref: rc-latest
+        ref: ${{ github.event.inputs.branch || '' }}
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1.127.0

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       branch:
         description: 'Run tests against branch'
-        default: 'master'
+        default: 'rc-latest'
       tags:
         description: 'Test tags (all, light, offchain...)'
         default: 'all'
@@ -20,7 +20,7 @@ jobs:
       NETWORK: preprod
       BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_TOKEN_READ_BUILDS_ARTIFACTS }}
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}
-      BRANCH: ${{ github.event.inputs.branch || 'master' }}
+      BRANCH: ${{ github.event.inputs.branch || 'rc-latest' }}
       TAGS: ${{ github.event.inputs.tags || 'all' }}
 
 
@@ -38,7 +38,7 @@ jobs:
     - name: Checkout
       shell: bash
       run: |
-        git clone -b rc-latest https://github.com/cardano-foundation/cardano-wallet.git C:/cardano-wallet --depth 1 --no-single-branch
+        git clone -b $BRANCH https://github.com/cardano-foundation/cardano-wallet.git C:/cardano-wallet --depth 1 --no-single-branch
         cd /c/cardano-wallet
 
     - name: Set up Ruby

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       branch:
         description: 'Run tests against branch'
-        default: 'master'
+        default: 'rc-latest'
       status:
         description: 'Run tests against status (use `any` as wildcard)'
         default: 'passed'
@@ -27,11 +27,14 @@ jobs:
     env:
       BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_TOKEN_READ_BUILDS_ARTIFACTS }}
       WORK_DIR: ./test/e2e
-      BRANCH: ${{ github.event.inputs.branch || 'master' }}
+      BRANCH: ${{ github.event.inputs.branch || 'rc-latest' }}
     runs-on: windows-2022
     name: Download testing bundle
     steps:
       - uses: actions/checkout@v3.2.0
+        with:
+            ref: ${{ env.BRANCH }}
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1.127.0
         with:


### PR DESCRIPTION
- [x] Changed E2E tests to default to `rc-latest` instead of `master` when selecting branches for artifacts/docker images

ADP-3224 
