### PR TITLE
Factor out `TimelockKeyWitnessCounts`

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -133,8 +135,8 @@ module Internal.Cardano.Write.Tx
     , utxoFromTxOutsInRecentEra
 
     -- * Policy and asset identifiers
-    , Value.PolicyID (..)
-    , PolicyId
+    , type PolicyId
+    , pattern PolicyId
     , AssetName
 
     -- * Balancing
@@ -858,3 +860,9 @@ evaluateTransactionBalance pp utxo =
 --------------------------------------------------------------------------------
 
 type PolicyId = Value.PolicyID StandardCrypto
+
+{-# COMPLETE PolicyId #-}
+pattern PolicyId
+    :: Core.ScriptHash StandardCrypto
+    -> Value.PolicyID StandardCrypto
+pattern PolicyId h = Value.PolicyID h

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -122,6 +122,7 @@ module Internal.Cardano.Write.Tx
     -- ** Script
     , Script
     , Alonzo.isPlutusScript
+    , ScriptHash
 
     -- * TxIn
     , TxIn
@@ -132,6 +133,7 @@ module Internal.Cardano.Write.Tx
     , utxoFromTxOutsInRecentEra
 
     -- * Policy and asset identifiers
+    , Value.PolicyID (..)
     , PolicyId
     , AssetName
 
@@ -190,7 +192,6 @@ import Cardano.Ledger.Mary
     )
 import Cardano.Ledger.Mary.Value
     ( AssetName
-    , PolicyID
     )
 import Cardano.Ledger.SafeHash
     ( SafeHash
@@ -264,6 +265,7 @@ import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Credential as Core
 import qualified Cardano.Ledger.Keys as Ledger
+import qualified Cardano.Ledger.Mary.Value as Value
 import qualified Cardano.Ledger.Shelley.API.Wallet as Shelley
 import qualified Cardano.Ledger.Shelley.UTxO as Shelley
 import qualified Cardano.Ledger.TxIn as Ledger
@@ -518,6 +520,7 @@ type Address = Ledger.Addr StandardCrypto
 
 type RewardAccount = Ledger.RewardAcnt StandardCrypto
 type Script = AlonzoScript
+type ScriptHash = Core.ScriptHash StandardCrypto
 type Value = MaryValue StandardCrypto
 
 unsafeAddressFromBytes :: ByteString -> Address
@@ -854,4 +857,4 @@ evaluateTransactionBalance pp utxo =
 -- Policy and asset identifiers
 --------------------------------------------------------------------------------
 
-type PolicyId = PolicyID StandardCrypto
+type PolicyId = Value.PolicyID StandardCrypto

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -455,8 +455,8 @@ instance IsRecentEra era => Buildable (PartialTx era)
             , nameF "tx" (txF tx)
             , nameF "intended number of timelock signers"
                 $ blockListF' "-" (build . show)
-                    $ Map.toList
-                    $ getSpecifiedTimelockScriptVkCounts timelockVkCounts
+                $ Map.toList
+                $ getSpecifiedTimelockScriptVkCounts timelockVkCounts
             ]
       where
         inF = build . show

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -251,7 +251,8 @@ import Internal.Cardano.Write.Tx.Redeemers
     , assignScriptRedeemers
     )
 import Internal.Cardano.Write.Tx.Sign
-    ( estimateKeyWitnessCount
+    ( IntendedNumberOfTimelockSigners (..)
+    , estimateKeyWitnessCount
     , estimateSignedTxSize
     )
 import Internal.Cardano.Write.Tx.SizeEstimation
@@ -438,6 +439,7 @@ data PartialTx era = PartialTx
     , inputs :: UTxO era
       -- ^ NOTE: Can we rename this to something better? Perhaps 'extraUTxO'?
     , redeemers :: [Redeemer]
+    , intendedNumberOfTimelockSigners :: IntendedNumberOfTimelockSigners
     }
     deriving Generic
 
@@ -446,11 +448,15 @@ deriving instance IsRecentEra era => Show (PartialTx era)
 
 instance IsRecentEra era => Buildable (PartialTx era)
   where
-    build (PartialTx tx (UTxO ins) redeemers)
+    build (PartialTx tx (UTxO ins) redeemers nTimelockWits)
         = nameF "PartialTx" $ mconcat
             [ nameF "inputs" (blockListF' "-" inF (Map.toList ins))
             , nameF "redeemers" (pretty redeemers)
             , nameF "tx" (txF tx)
+            , nameF "intended number of timelock signers"
+                $ blockListF' "-" (build . show)
+                    $ Map.toList
+                    $ getIntendedNumberOfTimelockSigners nTimelockWits
             ]
       where
         inF = build . show
@@ -637,7 +643,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     genChange
     s
     selectionStrategy
-    ptx@(PartialTx partialTx inputUTxO redeemers)
+    ptx@(PartialTx partialTx inputUTxO redeemers nTimelockWits)
     = do
     guardExistingCollateral partialTx
     guardExistingTotalCollateral partialTx
@@ -795,7 +801,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     extractExternallySelectedUTxO
         :: PartialTx era
         -> ExceptT (ErrBalanceTx era) m (UTxOIndex.UTxOIndex WalletUTxO)
-    extractExternallySelectedUTxO (PartialTx tx _ _rdms) = do
+    extractExternallySelectedUTxO (PartialTx tx _ _rdms _) = do
         let res = flip map txIns $ \i-> do
                 case txinLookup i combinedUTxO of
                     Nothing ->
@@ -847,7 +853,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         :: Tx era
         -> ExceptT (ErrBalanceTx era) m (Value, Coin, KeyWitnessCount)
     balanceAfterSettingMinFee tx = ExceptT . pure $ do
-        let witCount = estimateKeyWitnessCount combinedUTxO tx
+        let witCount = estimateKeyWitnessCount combinedUTxO tx nTimelockWits
             minfee = Convert.toWalletCoin $ evaluateMinimumFee pp tx witCount
             update = TxUpdate [] [] [] [] (UseNewTxFee minfee)
         tx' <- left updateTxErrorToBalanceTxError $ updateTx tx update

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -251,7 +251,7 @@ import Internal.Cardano.Write.Tx.Redeemers
     , assignScriptRedeemers
     )
 import Internal.Cardano.Write.Tx.Sign
-    ( IntendedNumberOfTimelockSigners (..)
+    ( SpecifiedTimelockScriptVkCounts (..)
     , estimateKeyWitnessCount
     , estimateSignedTxSize
     )
@@ -439,7 +439,7 @@ data PartialTx era = PartialTx
     , inputs :: UTxO era
       -- ^ NOTE: Can we rename this to something better? Perhaps 'extraUTxO'?
     , redeemers :: [Redeemer]
-    , intendedNumberOfTimelockSigners :: IntendedNumberOfTimelockSigners
+    , timelockVkCounts :: SpecifiedTimelockScriptVkCounts
     }
     deriving Generic
 
@@ -448,7 +448,7 @@ deriving instance IsRecentEra era => Show (PartialTx era)
 
 instance IsRecentEra era => Buildable (PartialTx era)
   where
-    build (PartialTx tx (UTxO ins) redeemers nTimelockWits)
+    build (PartialTx tx (UTxO ins) redeemers timelockVkCounts)
         = nameF "PartialTx" $ mconcat
             [ nameF "inputs" (blockListF' "-" inF (Map.toList ins))
             , nameF "redeemers" (pretty redeemers)
@@ -456,7 +456,7 @@ instance IsRecentEra era => Buildable (PartialTx era)
             , nameF "intended number of timelock signers"
                 $ blockListF' "-" (build . show)
                     $ Map.toList
-                    $ getIntendedNumberOfTimelockSigners nTimelockWits
+                    $ getSpecifiedTimelockScriptVkCounts timelockVkCounts
             ]
       where
         inF = build . show

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -20,7 +20,7 @@ module Internal.Cardano.Write.Tx.Sign
       estimateSignedTxSize
 
     , KeyWitnessCount (..)
-    , SpecifiedTimelockScriptVkCounts (..)
+    , TimelockScriptVkCounts (..)
     , estimateKeyWitnessCount
 
     , estimateMaxWitnessRequiredPerInput
@@ -181,7 +181,7 @@ estimateKeyWitnessCount
     -- ^ Must contain all inputs from the 'TxBody' or
     -- 'estimateKeyWitnessCount will 'error'.
     -> Tx era
-    -> SpecifiedTimelockScriptVkCounts
+    -> TimelockScriptVkCounts
     -- ^ Specifying the intended number of timelock script signers may
     -- save space and fees when constructing a transaction.
     --
@@ -251,7 +251,7 @@ estimateKeyWitnessCount utxo tx timelockVkCounts =
                 :: (ScriptHash StandardCrypto)
                 -> Maybe (ScriptHash StandardCrypto, Natural)
             resolve h = (h,) <$> Map.lookup h
-                (getSpecifiedTimelockScriptVkCounts timelockVkCounts)
+                (getTimelockScriptVkCounts timelockVkCounts)
 
         upperBoundEstimatedTimelockVkCounts
             :: Map (ScriptHash StandardCrypto) Natural
@@ -330,8 +330,8 @@ estimateKeyWitnessCount utxo tx timelockVkCounts =
 -- | Used to specify the intended number of timelock script vk witnesses.
 --
 -- Like for the underlying 'Map', '<>' is left-biased.
-newtype SpecifiedTimelockScriptVkCounts = SpecifiedTimelockScriptVkCounts
-    { getSpecifiedTimelockScriptVkCounts
+newtype TimelockScriptVkCounts = TimelockScriptVkCounts
+    { getTimelockScriptVkCounts
         :: Map (ScriptHash StandardCrypto) Natural
     }
     deriving (Show, Eq)

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -240,11 +240,12 @@ estimateKeyWitnessCount utxo tx timelockKeyWitCounts =
     timelockTotalWitCount :: Natural
     timelockTotalWitCount = sum $ Map.elems $ Map.unionWith
         (\_est spec -> spec) -- Allow specified values to override
-        upperBoundEstimatedTimelockVkCounts
-        specifiedTimelockVkCounts
+        upperBoundEstimatedTimelockKeyWitnessCounts
+        specifiedTimelockKeyWitnessCounts
       where
-        specifiedTimelockVkCounts :: Map (ScriptHash StandardCrypto) Natural
-        specifiedTimelockVkCounts = Map.fromList $ mapMaybe resolve
+        specifiedTimelockKeyWitnessCounts
+            :: Map (ScriptHash StandardCrypto) Natural
+        specifiedTimelockKeyWitnessCounts = Map.fromList $ mapMaybe resolve
             $ F.toList scriptsNeeded
           where
             resolve
@@ -253,9 +254,9 @@ estimateKeyWitnessCount utxo tx timelockKeyWitCounts =
             resolve h = (h,) <$> Map.lookup h
                 (getTimelockKeyWitnessCounts timelockKeyWitCounts)
 
-        upperBoundEstimatedTimelockVkCounts
+        upperBoundEstimatedTimelockKeyWitnessCounts
             :: Map (ScriptHash StandardCrypto) Natural
-        upperBoundEstimatedTimelockVkCounts = Map.mapMaybe
+        upperBoundEstimatedTimelockKeyWitnessCounts = Map.mapMaybe
             (fmap (estimateMaxWitnessRequiredPerInput . toCAScript)
                 . toTimelockScript)
             -- TODO [ADP-2675] https://cardanofoundation.atlassian.net/browse/ADP-2675
@@ -327,7 +328,7 @@ estimateKeyWitnessCount utxo tx timelockKeyWitCounts =
                     , "Caller is expected to ensure this does not happen."
                     ]
 
--- | Used to specify the intended number of timelock script vk witnesses.
+-- | Used to specify the intended number of timelock script key witnesses.
 --
 -- The 'Semigroup' instance resolves conflicts using 'max'.
 newtype TimelockKeyWitnessCounts = TimelockKeyWitnessCounts

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -327,6 +327,9 @@ estimateKeyWitnessCount utxo tx timelockVkCounts =
                     , "Caller is expected to ensure this does not happen."
                     ]
 
+-- | Used to specify the intended number of timelock script vk witnesses.
+--
+-- Like for the underlying 'Map', '<>' is left-biased.
 newtype SpecifiedTimelockScriptVkCounts = SpecifiedTimelockScriptVkCounts
     { getSpecifiedTimelockScriptVkCounts
         :: Map (ScriptHash StandardCrypto) Natural

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -183,9 +183,9 @@ estimateKeyWitnessCount
     -> Tx era
     -> SpecifiedTimelockScriptVkCounts
     -- ^ Specifying the intended number of timelock script signers may
-    -- save space and fees when constructing a tx.
+    -- save space and fees when constructing a transaction.
     --
-    -- Timelock scripts without entries in this map will have their vk witness
+    -- Timelock scripts without entries in this map will have their VK witness
     -- counts estimated according to 'estimateMaxWitnessRequiredPerInput'.
     -> KeyWitnessCount
 estimateKeyWitnessCount utxo tx timelockVkCounts =
@@ -270,8 +270,7 @@ estimateKeyWitnessCount utxo tx timelockVkCounts =
             $ getScriptsNeeded utxo
             $ view bodyTxL tx
 
-        scriptsAvailableInBody
-            :: Map (ScriptHash StandardCrypto) (Script era)
+        scriptsAvailableInBody :: Map (ScriptHash StandardCrypto) (Script era)
         scriptsAvailableInBody = tx ^. witsTxL . scriptTxWitsL
 
     estimateDelegSigningKeys :: CardanoApi.Certificate -> Integer
@@ -330,7 +329,7 @@ estimateKeyWitnessCount utxo tx timelockVkCounts =
 
 newtype SpecifiedTimelockScriptVkCounts = SpecifiedTimelockScriptVkCounts
     { getSpecifiedTimelockScriptVkCounts
-        :: (Map (ScriptHash StandardCrypto) Natural)
+        :: Map (ScriptHash StandardCrypto) Natural
     }
     deriving (Show, Eq)
     deriving newtype (Monoid, Semigroup)

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -329,13 +329,17 @@ estimateKeyWitnessCount utxo tx timelockKeyWitCounts =
 
 -- | Used to specify the intended number of timelock script vk witnesses.
 --
--- Like for the underlying 'Map', '<>' is left-biased.
+-- The 'Semigroup' instance resolves conflicts using 'max'.
 newtype TimelockKeyWitnessCounts = TimelockKeyWitnessCounts
     { getTimelockKeyWitnessCounts
         :: Map (ScriptHash StandardCrypto) Natural
     }
     deriving (Show, Eq)
-    deriving newtype (Monoid, Semigroup)
+    deriving newtype (Monoid)
+
+instance Semigroup TimelockKeyWitnessCounts where
+    (TimelockKeyWitnessCounts a) <> (TimelockKeyWitnessCounts b)
+        = TimelockKeyWitnessCounts (Map.unionWith max a b)
 
 --------------------------------------------------------------------------------
 -- Helpers

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1516,7 +1516,7 @@ prop_balanceTransactionValid
                     (estimateKeyWitnessCount
                         utxo
                         tx
-                        (timelockVkCounts partialTx))
+                        (timelockKeyWitnessCounts partialTx))
                     tx
         let limit = ledgerPParams ^. ppMaxTxSizeL
         let msg = unwords
@@ -1568,7 +1568,7 @@ prop_balanceTransactionValid
         Write.evaluateMinimumFee ledgerPParams
             tx
             (estimateKeyWitnessCount utxo tx
-                (timelockVkCounts partialTx))
+                (timelockKeyWitnessCounts partialTx))
 
     txBalance
         :: Tx era
@@ -2169,13 +2169,13 @@ restrictResolution
     :: forall era. IsRecentEra era
     => PartialTx era
     -> PartialTx era
-restrictResolution (PartialTx tx inputs redeemers timelockVkCounts) =
+restrictResolution (PartialTx tx inputs redeemers timelockKeyWitnessCounts) =
     let
         CardanoApi.UTxO u = toCardanoApiUTxO @era inputs
         u' = u `Map.restrictKeys` (inputsInTx (toCardanoApiTx @era tx))
         inputs' = fromCardanoApiUTxO @era (CardanoApi.UTxO u')
     in
-        PartialTx tx inputs' redeemers timelockVkCounts
+        PartialTx tx inputs' redeemers timelockKeyWitnessCounts
   where
     inputsInTx (CardanoApi.Tx (CardanoApi.TxBody bod) _) =
         Set.fromList $ map fst $ CardanoApi.txIns bod
@@ -2456,7 +2456,7 @@ pingPong_2 = PartialTx
             (unsafeFromHex "D87A80")
             (Convert.toLedger (W.TxIn (W.Hash tid) 0))
         ]
-    , timelockVkCounts = mempty
+    , timelockKeyWitnessCounts = mempty
     }
   where
     tid = B8.replicate 32 '1'
@@ -2620,8 +2620,8 @@ instance Arbitrary (PartialTx Write.BabbageEra) where
             (fromCardanoApiUTxO inputUTxO)
             (redeemers)
             mempty
-    shrink (PartialTx tx inputUTxO redeemers timelockVkCounts) =
-        [ PartialTx tx inputUTxO' redeemers timelockVkCounts
+    shrink (PartialTx tx inputUTxO redeemers timelockKeyWitnessCounts) =
+        [ PartialTx tx inputUTxO' redeemers timelockKeyWitnessCounts
         | inputUTxO' <- shrinkInputResolution @Write.BabbageEra inputUTxO
         ] <>
         [ restrictResolution $
@@ -2629,7 +2629,7 @@ instance Arbitrary (PartialTx Write.BabbageEra) where
                 (fromCardanoApiTx tx')
                 inputUTxO
                 redeemers
-                timelockVkCounts
+                timelockKeyWitnessCounts
         | tx' <- shrinkTxBabbage (toCardanoApiTx tx)
         ]
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
@@ -398,7 +398,10 @@ server byron icarus shelley multisig spl ntp blockchainSource =
         :<|> postTransactionOld shelley (delegationAddressS @n)
         :<|> postTransactionFeeOld shelley
         :<|> balanceTransaction
-            shelley (delegationAddressS @n) (utxoAssumptionsForWallet ShelleyWallet)
+            shelley
+            (delegationAddressS @n)
+            (utxoAssumptionsForWallet ShelleyWallet)
+            mempty
         :<|> decodeTransaction shelley
         :<|> submitTransaction @_ @_ @_ @n shelley
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -811,8 +811,7 @@ import Internal.Cardano.Write.Tx
     ( AnyRecentEra (..)
     )
 import Internal.Cardano.Write.Tx.Balance
-    ( PartialTx (timelockVkCounts)
-    , Redeemer (..)
+    ( Redeemer (..)
     , UTxOAssumptions (..)
     )
 import Internal.Cardano.Write.Tx.Sign

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2876,7 +2876,7 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
                 Left ApiMintBurnDataFromScript{} -> mempty
                 Right (ApiMintBurnDataFromInput _ (ApiT policyId) _ _) ->
                     let
-                        Write.PolicyID policyId' =
+                        Write.PolicyId policyId' =
                             Convert.toLedgerTokenPolicyId policyId
                     in
                         Write.SpecifiedTimelockScriptVkCounts

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2868,20 +2868,20 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
                     PreSelection { outputs = outs <> mintingOuts }
 
         -- We need to assume that mint/burn scripts in reference inputs require
-        -- 1 vk witness each, and we need to tell 'balanceTransaction' about
+        -- 1 key witness each, and we need to tell 'balanceTransaction' about
         -- this assumption.
-        let intendedSignersForMintBurn
-                :: ApiMintBurnData n -> Write.TimelockScriptVkCounts
-            intendedSignersForMintBurn mb = case mb ^. #mintBurnData of
+        let timelockKeyWitCountsForMintBurn
+                :: ApiMintBurnData n -> Write.TimelockKeyWitnessCounts
+            timelockKeyWitCountsForMintBurn mb = case mb ^. #mintBurnData of
                 Left ApiMintBurnDataFromScript{} -> mempty
                 Right (ApiMintBurnDataFromInput _ (ApiT policyId) _ _) ->
                     let
                         Write.PolicyId policyId' =
                             Convert.toLedgerTokenPolicyId policyId
                     in
-                        Write.TimelockScriptVkCounts
+                        Write.TimelockKeyWitnessCounts
                             $ Map.singleton policyId' 1
-        let intendedMintBurnVkCount =
+        let mintBurnTimelockKeyWitCounts =
                 foldMap intendedSignersForMintBurn
                 $ maybe [] NE.toList mintBurnDatum
 
@@ -2890,7 +2890,7 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
                 api
                 argGenChange
                 (utxoAssumptionsForWallet (walletFlavor @s))
-                intendedMintBurnVkCount
+                mintBurnTimelockKeyWitCounts
                 apiWalletId
                 ApiBalanceTransactionPostData
                     { transaction = ApiT (sealedTxFromCardanoBody unbalancedTx)

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -811,7 +811,8 @@ import Internal.Cardano.Write.Tx
     ( AnyRecentEra (..)
     )
 import Internal.Cardano.Write.Tx.Balance
-    ( Redeemer (..)
+    ( PartialTx (timelockVkCounts)
+    , Redeemer (..)
     , UTxOAssumptions (..)
     )
 import Internal.Cardano.Write.Tx.Sign
@@ -3486,7 +3487,13 @@ balanceTransaction
     -> ApiBalanceTransactionPostData (NetworkOf s)
     -> Handler ApiSerialisedTransaction
 balanceTransaction
-    ctx@ApiLayer{..} argGenChange utxoAssumptions timelockSigners (ApiT wid) body = do
+    ctx@ApiLayer{..}
+    argGenChange
+    utxoAssumptions
+    timelockVkCounts
+    (ApiT wid)
+    body
+    = do
     (Write.PParamsInAnyRecentEra era pp, timeTranslation)
         <- liftIO $ W.readNodeTipStateForTxWrite netLayer
     withWorkerCtx ctx wid liftE liftE $ \wrk -> do
@@ -3541,7 +3548,7 @@ balanceTransaction
             (Write.fromCardanoApiTx tx)
             externalUTxO
             (fromApiRedeemer <$> body ^. #redeemers)
-            timelockSigners
+            timelockVkCounts
 
 decodeTransaction
     :: forall s n

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -815,7 +815,7 @@ import Internal.Cardano.Write.Tx.Balance
     , UTxOAssumptions (..)
     )
 import Internal.Cardano.Write.Tx.Sign
-    ( TimelockScriptVkCounts
+    ( TimelockKeyWitnessCounts
     )
 import Network.Ntp
     ( NtpClient
@@ -2882,7 +2882,7 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
                         Write.TimelockKeyWitnessCounts
                             $ Map.singleton policyId' 1
         let mintBurnTimelockKeyWitCounts =
-                foldMap intendedSignersForMintBurn
+                foldMap timelockKeyWitCountsForMintBurn
                 $ maybe [] NE.toList mintBurnDatum
 
         balancedTx <-
@@ -3481,7 +3481,7 @@ balanceTransaction
     => ApiLayer s
     -> ArgGenChange s
     -> UTxOAssumptions
-    -> TimelockScriptVkCounts
+    -> TimelockKeyWitnessCounts
     -> ApiT WalletId
     -> ApiBalanceTransactionPostData (NetworkOf s)
     -> Handler ApiSerialisedTransaction
@@ -3489,7 +3489,7 @@ balanceTransaction
     ctx@ApiLayer{..}
     argGenChange
     utxoAssumptions
-    timelockVkCounts
+    timelockKeyWitnessCounts
     (ApiT wid)
     body
     = do
@@ -3547,7 +3547,7 @@ balanceTransaction
             (Write.fromCardanoApiTx tx)
             externalUTxO
             (fromApiRedeemer <$> body ^. #redeemers)
-            timelockVkCounts
+            timelockKeyWitnessCounts
 
 decodeTransaction
     :: forall s n

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -815,7 +815,7 @@ import Internal.Cardano.Write.Tx.Balance
     , UTxOAssumptions (..)
     )
 import Internal.Cardano.Write.Tx.Sign
-    ( SpecifiedTimelockScriptVkCounts
+    ( TimelockScriptVkCounts
     )
 import Network.Ntp
     ( NtpClient
@@ -2871,7 +2871,7 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
         -- 1 vk witness each, and we need to tell 'balanceTransaction' about
         -- this assumption.
         let intendedSignersForMintBurn
-                :: ApiMintBurnData n -> Write.SpecifiedTimelockScriptVkCounts
+                :: ApiMintBurnData n -> Write.TimelockScriptVkCounts
             intendedSignersForMintBurn mb = case mb ^. #mintBurnData of
                 Left ApiMintBurnDataFromScript{} -> mempty
                 Right (ApiMintBurnDataFromInput _ (ApiT policyId) _ _) ->
@@ -2879,7 +2879,7 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
                         Write.PolicyId policyId' =
                             Convert.toLedgerTokenPolicyId policyId
                     in
-                        Write.SpecifiedTimelockScriptVkCounts
+                        Write.TimelockScriptVkCounts
                             $ Map.singleton policyId' 1
         let intendedMintBurnVkCount =
                 foldMap intendedSignersForMintBurn
@@ -3481,7 +3481,7 @@ balanceTransaction
     => ApiLayer s
     -> ArgGenChange s
     -> UTxOAssumptions
-    -> SpecifiedTimelockScriptVkCounts
+    -> TimelockScriptVkCounts
     -> ApiT WalletId
     -> ApiBalanceTransactionPostData (NetworkOf s)
     -> Handler ApiSerialisedTransaction

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2377,6 +2377,7 @@ buildTransactionPure
                 { tx = Write.fromCardanoApiTx (Cardano.Tx unsignedTxBody [])
                 , inputs = Write.UTxO mempty
                 , redeemers = []
+                , intendedNumberOfTimelockSigners = mempty
                 }
 
 -- HACK: 'mkUnsignedTransaction' takes a reward account 'XPub' even when the
@@ -3014,6 +3015,7 @@ transactionFee DBLayer{atomically, walletState} protocolParams
                 { tx = Write.fromCardanoApiTx (Cardano.Tx unsignedTxBody [])
                 , inputs = Write.UTxO mempty
                 , redeemers = []
+                , intendedNumberOfTimelockSigners = mempty
                 }
 
         wrapErrBalanceTx $ calculateFeePercentiles $ do

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2377,7 +2377,7 @@ buildTransactionPure
                 { tx = Write.fromCardanoApiTx (Cardano.Tx unsignedTxBody [])
                 , inputs = Write.UTxO mempty
                 , redeemers = []
-                , intendedNumberOfTimelockSigners = mempty
+                , timelockVkCounts = mempty
                 }
 
 -- HACK: 'mkUnsignedTransaction' takes a reward account 'XPub' even when the
@@ -3015,7 +3015,7 @@ transactionFee DBLayer{atomically, walletState} protocolParams
                 { tx = Write.fromCardanoApiTx (Cardano.Tx unsignedTxBody [])
                 , inputs = Write.UTxO mempty
                 , redeemers = []
-                , intendedNumberOfTimelockSigners = mempty
+                , timelockVkCounts = mempty
                 }
 
         wrapErrBalanceTx $ calculateFeePercentiles $ do

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2377,7 +2377,7 @@ buildTransactionPure
                 { tx = Write.fromCardanoApiTx (Cardano.Tx unsignedTxBody [])
                 , inputs = Write.UTxO mempty
                 , redeemers = []
-                , timelockVkCounts = mempty
+                , timelockKeyWitnessCounts = mempty
                 }
 
 -- HACK: 'mkUnsignedTransaction' takes a reward account 'XPub' even when the
@@ -3015,7 +3015,7 @@ transactionFee DBLayer{atomically, walletState} protocolParams
                 { tx = Write.fromCardanoApiTx (Cardano.Tx unsignedTxBody [])
                 , inputs = Write.UTxO mempty
                 , redeemers = []
-                , timelockVkCounts = mempty
+                , timelockKeyWitnessCounts = mempty
                 }
 
         wrapErrBalanceTx $ calculateFeePercentiles $ do


### PR DESCRIPTION
Add the following as argument to `balanceTransaction`:
```haskell
newtype TimelockKeyWitnessCounts = TimelockKeyWitnessCounts
    { getTimelockKeyWitnessCounts
        :: Map (ScriptHash StandardCrypto) Natural
    }
    deriving (Show, Eq)
    deriving newtype (Monoid)
```

This serves two purposes:
1. Allow callers of `balanceTransaction` to optionally specify exactly how many witnesses they intend to provide for a given `Timelock` script. (Recall that `Timelock` scripts are the only source of uncertainty in how many witnesses are needed for a tx)
2. Allow callers, specifically the wallet, to promise `{mintPolicyScriptHash -> 1 }` without providing the exact `Timelock` script as part of the `UTxO` lookup.
    - Simply providing a mock script as part of the `UTxO` lookup would not work. We'd need the hash of the mock script to correspond to the policy id in the mint field... so we'd need to know it exactly.


### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-3197
