### PR TITLE
[ADP-3224] Set join and leave stake pool tests to pending in E2E suite

### DIFF
--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -1312,6 +1312,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
     end
 
     it 'Delegation (join and quit)' do
+      pending 'ADP-3243'
       balance = get_shelley_balances(@target_id)
       expected_deposit = CARDANO_CLI.protocol_params['stakeAddressDeposit']
       puts "Expected deposit #{expected_deposit}"
@@ -2900,6 +2901,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
       end
 
       it 'Can join and quit Stake Pool' do
+        pending 'ADP-3243'
         # Get funds on the wallet
         address = SHELLEY.addresses.list(@target_id)[0]['id']
         amt = 10_000_000


### PR DESCRIPTION
Joining a stakepool in an epoch and quitting in the next one is leaving the wallet delegating for 5 days. This condition is unacceptable for join + leave tests to start with.

- [x] make 2 E2E flaky tests, actually failing, pending
- [x] create ticket ADP-3243 to address the removal of those tests

ADP-3224