### PR TITLE
[ADP-3224] Change defaults in docker compose linux

### DIFF
--- a/.github/workflows/docker_linux.yml
+++ b/.github/workflows/docker_linux.yml
@@ -1,8 +1,21 @@
-name: Docker-compose Linux
+name: Docker-compose smoke test
 on:
   schedule:
   - cron:  "0 23 * * *"
   workflow_dispatch:
+    inputs:
+      nodeTag:
+        description: 'Node docker image tag'
+        required: true
+        default: '8.1.2'
+      walletTag:
+        description: 'Wallet docker image tag'
+        required: true
+        default: 'rc-latest'
+      branch:
+        description: 'Branch to checkout'
+        required: true
+        default: 'rc-latest'
 
 
 jobs:
@@ -12,7 +25,10 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v4.1.1
+        with:
+          ref: ${{ github.event.inputs.branch || 'rc-latest'}}
+
       - uses: ruby/setup-ruby@v1.127.0
         with:
           ruby-version: 2.7.1
@@ -23,7 +39,12 @@ jobs:
           docker-compose up -d
           ./scripts/connect_wallet.rb
         env:
-          NETWORK: preprod
+            NODE_TAG: ${{ github.event.inputs.nodeTag || '8.1.2'}}
+            WALLET_TAG: ${{ github.event.inputs.walletTag || 'rc-latest'}}
+            NETWORK: preprod
+            WALLET_DB: /tmp/wallet-db
+            NODE_DB: /tmp/node-db
+            WALLET_PORT: 8090
   report:
     needs: [build]
     if: always()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,12 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:8.1.2
+    image: inputoutput/cardano-node:${NODE_TAG}
     environment:
       NETWORK:
       CARDANO_NODE_SOCKET_PATH: /ipc/node.socket
     volumes:
-      - node-${NETWORK}-db:/data
+      - ${NODE_DB}:/data
       - node-ipc:/ipc
     restart: on-failure
     logging:
@@ -18,12 +18,12 @@ services:
         max-size: "50m"
 
   cardano-wallet:
-    image: cardanofoundation/cardano-wallet:2023.7.18
+    image: cardanofoundation/cardano-wallet:${WALLET_TAG}
     volumes:
-      - wallet-${NETWORK}-db:/wallet-db
+      - ${WALLET_DB}:/wallet-db
       - node-ipc:/ipc
     ports:
-      - 8090:8090
+      - ${WALLET_PORT}:8090
     entrypoint: []
     command: bash -c "
         ([[ $$NETWORK == \"mainnet\" ]] && $$CMD --mainnet) ||
@@ -41,11 +41,4 @@ services:
         max-size: "50m"
 
 volumes:
-  node-mainnet-db:
-  wallet-mainnet-db:
-  node-preprod-db:
-  wallet-preprod-db:
-  node-preview-db:
-  wallet-preview-db:
   node-ipc:
-  node-config:

--- a/scripts/connect_wallet.rb
+++ b/scripts/connect_wallet.rb
@@ -5,6 +5,8 @@ require 'cardano_wallet'
 timeout = 100
 threshold = Time.now + timeout
 
+$stdout.sync = true
+
 def is_connected?
   begin
     CardanoWallet.new.misc.network.information


### PR DESCRIPTION
- [x] Let linux docker-compose workflow use `rc-latest` tag as default
- [x] Parameterize the workflow on node and wallet image tags and branch to checkout
- [x] Update docker-compose.yaml to accept parameters

ADP-3224
