### PR TITLE
[ADP-3224] Change 'token' to 'assetName' in E2E expectations

### DIFF
--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -382,7 +382,7 @@ task :setup, [:env, :branch, :skip_configs] do |_task, args|
   Rake::Task[:secrets_decode].invoke
 end
 
-task :run_on, [:env, :sync_strategy, :skip_configs, :branch] do |_task, args|
+task :run_on, [:env, :branch, :sync_strategy, :skip_configs] do |_task, args|
   log '>> Setting up env and running tests...'
   log "TESTS_E2E_STATEDIR=#{STATE}"
   env = args[:env]

--- a/test/e2e/shell.nix
+++ b/test/e2e/shell.nix
@@ -23,6 +23,7 @@ in pkgs.mkShell {
   ] ++ pkgs.lib.optionals bins [
     cardanoWallet.cardano-wallet
     cardanoWallet.cardano-node
+    cardanoWallet.cardano-cli
   ];
   CARDANO_NODE_CONFIGS = pkgs.cardano-node-deployments;
 }

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -2077,7 +2077,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
                                                         burn)
         expect(tx_constructed).to be_correct_and_respond 403
         expect(tx_constructed['code'].to_s).to eq 'not_enough_money'
-        expect(tx_constructed['message'].to_s).to include "token: #{asset_name('AmazingNFTIdontHave')}"
+        expect(tx_constructed['message'].to_s).to include "assetName: #{asset_name('AmazingNFTIdontHave')}"
         expect(tx_constructed['message'].to_s).to include 'quantity: 1'
       end
 
@@ -2115,7 +2115,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
 
         expect(tx_constructed).to be_correct_and_respond 403
         expect(tx_constructed['code'].to_s).to eq 'not_enough_money'
-        expect(tx_constructed['message'].to_s).to include "token: #{asset_name('MintIt')}"
+        expect(tx_constructed['message'].to_s).to include "assetName: #{asset_name('MintIt')}"
         expect(tx_constructed['message'].to_s).to include 'quantity: 1000'
 
         #  - correct policy_script but too much
@@ -2129,7 +2129,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
 
         expect(tx_constructed).to be_correct_and_respond 403
         expect(tx_constructed['code'].to_s).to eq 'not_enough_money'
-        expect(tx_constructed['message'].to_s).to include "token: #{asset_name('MintIt')}"
+        expect(tx_constructed['message'].to_s).to include "assetName: #{asset_name('MintIt')}"
         expect(tx_constructed['message'].to_s).to include 'quantity: 22'
 
         # Burn it:
@@ -2200,7 +2200,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
                                                         burn)
         expect(tx_constructed).to be_correct_and_respond 403
         expect(tx_constructed['code'].to_s).to eq 'not_enough_money'
-        expect(tx_constructed['message'].to_s).to include "token: #{assets_name}"
+        expect(tx_constructed['message'].to_s).to include "assetName: #{assets_name}"
         expect(tx_constructed['message'].to_s).to include "quantity: #{assets_quantity}"
 
         # Send them back to src wallet:
@@ -2274,7 +2274,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
                                                             mint)
             expect(tx_constructed).to be_correct_and_respond code
             expect(tx_constructed['code'].to_s).to eq message
-            # expect(tx_constructed['message'].to_s).to include "token: #{asset_name('AmazingNFTIdontHave')}"
+            # expect(tx_constructed['message'].to_s).to include "assetName: #{asset_name('AmazingNFTIdontHave')}"
             # expect(tx_constructed['message'].to_s).to include "quantity: 1"
           end
 


### PR DESCRIPTION
- [x] changed `token` into `assetName` in the E2E expectations in some error messages
- [x] add `cardano-cli` to the E2E nix shell to allow running tests locally

Fixes https://github.com/cardano-foundation/cardano-wallet/actions/runs/7208803096/job/19638494587#step:12:926

ADP-3224
