### PR TITLE
[ADP-3224] Refine buildkite cardano-wallet pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -157,7 +157,11 @@ steps:
       TMPDIR: "/cache"
 
   - block: "macOS steps"
-    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/) && (build.branch != "rc-latest")'
+    if: |
+      build.branch !~ /^gh-readonly-queue\/master/
+        && build.branch != "master"
+        && build.branch !~ /^release-candidate/
+        && build.branch != "rc-latest"
     depends_on: linux-nix
     key: trigger-macos
 
@@ -185,8 +189,12 @@ steps:
       system: ${macos}
 
   - block: "Build package (linux)"
+    if: |
+      build.branch !~ /^gh-readonly-queue\/master/
+        && build.branch != "master"
+        && build.branch !~ /^release-candidate/
+        && build.branch != "rc-latest"
     depends_on: linux-nix
-    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/) && (build.branch != "rc-latest")'
     key: trigger-build-linux-package
 
   - label: 'Build package (linux)'
@@ -200,8 +208,12 @@ steps:
       TMPDIR: "/cache"
 
   - block: "Build windows artifacts"
+    if: |
+      build.branch !~ /^gh-readonly-queue\/master/
+        && build.branch != "master"
+        && build.branch !~ /^release-candidate/
+        && build.branch != "rc-latest"
     depends_on: linux-nix
-    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/) && (build.branch != "rc-latest")'
     key: trigger-build-windows-artifacts
 
   - label: 'Build package (windows)'
@@ -225,7 +237,11 @@ steps:
       TMPDIR: "/cache"
 
   - block: "Run E2E tests"
-    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/) && (build.branch != "rc-latest")'
+    if: |
+      build.branch !~ /^gh-readonly-queue\/master/
+        && build.branch != "master"
+        && build.branch !~ /^release-candidate/
+        && build.branch != "rc-latest"
     depends_on: linux-nix
     key: trigger-e2e-tests
 
@@ -256,7 +272,7 @@ steps:
       - windows-package
       - windows-testing-bundle
       - e2e
-    if: '(build.branch =~ /^release-candidate/)' #build.branch =~ /\/feature$$/
+    if: build.branch =~ /^release-candidate/
     command: .buildkite/retag-rc-latest.sh
     agents:
       system: ${linux}

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,9 +30,14 @@ steps:
     env:
       TMPDIR: "/cache"
 
-  - label: 'Cabal Release Build works in the nix shell'
-    key: cabal-release
+  - block: "Run cabal release"
+    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/)'
     depends_on: linux-nix
+    key: cabal-release-block
+
+  - label: 'Cabal build all -frelease'
+    key: cabal-release
+    depends_on: cabal-release-block
     command: |
       nix develop -c cabal update
       nix develop -c cabal build all -frelease

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -138,6 +138,7 @@ steps:
       TMPDIR: "/cache"
 
   - block: 'Run benchmark (api)'
+    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/)'
     depends_on: linux-nix
     key: trigger-benchmark-api
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -138,7 +138,7 @@ steps:
       TMPDIR: "/cache"
 
   - block: 'Run benchmark (api)'
-    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/)'
+    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/) && (build.branch != "rc-latest")'
     depends_on: linux-nix
     key: trigger-benchmark-api
 
@@ -157,7 +157,7 @@ steps:
       TMPDIR: "/cache"
 
   - block: "macOS steps"
-    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/)'
+    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/) && (build.branch != "rc-latest")'
     depends_on: linux-nix
     key: trigger-macos
 
@@ -186,7 +186,7 @@ steps:
 
   - block: "Build package (linux)"
     depends_on: linux-nix
-    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/)'
+    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/) && (build.branch != "rc-latest")'
     key: trigger-build-linux-package
 
   - label: 'Build package (linux)'
@@ -201,7 +201,7 @@ steps:
 
   - block: "Build windows artifacts"
     depends_on: linux-nix
-    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/)'
+    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/) && (build.branch != "rc-latest")'
     key: trigger-build-windows-artifacts
 
   - label: 'Build package (windows)'
@@ -225,7 +225,7 @@ steps:
       TMPDIR: "/cache"
 
   - block: "Run E2E tests"
-    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/)'
+    if: '(build.branch !~ /^gh-readonly-queue\/master/) && (build.branch != "master") && (build.branch !~ /^release-candidate/) && (build.branch != "rc-latest")'
     depends_on: linux-nix
     key: trigger-e2e-tests
 


### PR DESCRIPTION
Context: the cabal build all -frelease takes approx 24 mins. If we evaluate it only after merge, with other secondary checks, it should be fine.

- [x] Add a block to control `cabal build all -frelease` step
- [x] Add the benchmark step to the "required after merge list"
- [x] Add rc-latest to the branches that run all the tests (necessary for the artifacts to be found from E2E)
 
ADP-3224