### PR TITLE
Update all E2E and windows testing to use ruby v@1 plugin

### DIFF
--- a/.github/workflows/docker_linux.yml
+++ b/.github/workflows/docker_linux.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || 'rc-latest'}}
 
-      - uses: ruby/setup-ruby@v1.127.0
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.1
       - name: Install cardano_wallet gem

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -53,7 +53,7 @@ jobs:
       id: cardano-node-tag
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1.127.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.1.2
         bundler-cache: true

--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -34,7 +34,7 @@ jobs:
         ref:  ${{ github.event.inputs.branch || 'rc-latest' }}
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1.127.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.1.2
         bundler-cache: true

--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -35,7 +35,7 @@ jobs:
         ref: ${{ github.event.inputs.branch || '' }}
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1.127.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.1.2
         bundler-cache: true

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -42,7 +42,7 @@ jobs:
         cd /c/cardano-wallet
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1.127.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7.1
         bundler-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: '📥 Checkout repository'
         uses: actions/checkout@v3.2.0
       - name: 'Set up Ruby'
-        uses: ruby/setup-ruby@v1.127.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - name: 'Install dependencies'

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v3.2.0
 
     - name: 💎 Set up Ruby
-      uses: ruby/setup-ruby@v1.127.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.1.2
         bundler-cache: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,7 +36,7 @@ jobs:
             ref: ${{ env.BRANCH }}
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1.127.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.1
           bundler-cache: true


### PR DESCRIPTION
- [x] selecting @v1 as setup-ruby@v1.127.0 is not working ATM
   https://github.com/cardano-foundation/cardano-wallet/actions/runs/7226507373/job/19692235962#step:3:58
