### PR TITLE
Replace `input-output-hk` with `IntersectMBO`.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,7 +30,7 @@ body:
 
         1. You have reason to believe that this is caused by cardano-wallet and not
         [Daedalus](https://github.com/input-output-hk/daedalus) or
-        [cardano-node](https://github.com/input-output-hk/cardano-node).
+        [cardano-node](https://github.com/IntersectMBO/cardano-node).
 
         2. You are using the latest
         [`cardano-wallet` release](https://github.com/cardano-foundation/cardano-wallet/releases).

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Short optional summary -->
 
-Compatible with [`cardano-node@{{CARDANO_NODE_TAG}}`](https://github.com/input-output-hk/cardano-node/releases/tag/{{CARDANO_NODE_TAG}}).
+Compatible with [`cardano-node@{{CARDANO_NODE_TAG}}`](https://github.com/IntersectMBO/cardano-node/releases/tag/{{CARDANO_NODE_TAG}}).
 
 
 ## API Changes
@@ -42,7 +42,7 @@ Compatible with [`cardano-node@{{CARDANO_NODE_TAG}}`](https://github.com/input-o
 basically captures whatever is currently available on the repository at
 the moment of releasing. -->
 
-1. Install [`cardano-node@{{CARDANO_NODE_TAG}}`](https://github.com/input-output-hk/cardano-node/releases/tag/{{CARDANO_NODE_TAG}}).
+1. Install [`cardano-node@{{CARDANO_NODE_TAG}}`](https://github.com/IntersectMBO/cardano-node/releases/tag/{{CARDANO_NODE_TAG}}).
 
 2. Download the provided `cardano-wallet` for your platform, and uncompress it in a directory that is on your `$PATH`, e.g. `/usr/local/bin`. Or `%PATH%` on Windows.
 

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ We provide executables as part of our [releases](https://github.com/cardano-foun
 >
 > | cardano-wallet | cardano-node (compatible versions) |
 > | --- | --- |
-> | `master` branch | [8.1.1](https://github.com/input-output-hk/cardano-node/releases/tag/8.1.1) |
-> | [v2023-07-18](https://github.com/cardano-foundation/cardano-wallet/releases/tag/v2023-07-18) | [8.1.1](https://github.com/input-output-hk/cardano-node/releases/tag/8.1.1) |
-> | [v2023-04-14](https://github.com/cardano-foundation/cardano-wallet/releases/tag/v2023-04-14) | [1.35.4](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.4) |
-> | [v2022-12-14](https://github.com/cardano-foundation/cardano-wallet/releases/tag/v2022-12-14) | [1.35.4](https://github.com/input-output-hk/cardano-node/releases/tag/1.35.4) |
+> | `master` branch | [8.1.1](https://github.com/IntersectMBO/cardano-node/releases/tag/8.1.1) |
+> | [v2023-07-18](https://github.com/cardano-foundation/cardano-wallet/releases/tag/v2023-07-18) | [8.1.1](https://github.com/IntersectMBO/cardano-node/releases/tag/8.1.1) |
+> | [v2023-04-14](https://github.com/cardano-foundation/cardano-wallet/releases/tag/v2023-04-14) | [1.35.4](https://github.com/IntersectMBO/cardano-node/releases/tag/1.35.4) |
+> | [v2022-12-14](https://github.com/cardano-foundation/cardano-wallet/releases/tag/v2022-12-14) | [1.35.4](https://github.com/IntersectMBO/cardano-node/releases/tag/1.35.4) |
 
 ### Building from source
 

--- a/cabal.project
+++ b/cabal.project
@@ -110,7 +110,7 @@ source-repository-package
 
 source-repository-package
     type: git
-    location: https://github.com/input-output-hk/cardano-addresses
+    location: https://github.com/IntersectMBO/cardano-addresses
     tag: 44d5a9eb3505b6bfbf281d40fa88531c3253b771
     --sha256: 16rja48ryfjw3531kf15w0h3cdmscqgs8l1z1i2mvahq1vlhr2y6
     subdir: command-line
@@ -141,7 +141,7 @@ source-repository-package
 
 source-repository-package
     type: git
-    location: https://github.com/input-output-hk/bech32.git
+    location: https://github.com/IntersectMBO/bech32.git
     tag: e341e7f83d7b73f10baa87e946818b2c493cc5f5
     --sha256: 1d891bpc1q1m1gqj02b4iv3kr4g9w7knlkq43hwbl9dn5k78aydc
     subdir: bech32

--- a/docs/site/src/contributor/what/nix.md
+++ b/docs/site/src/contributor/what/nix.md
@@ -19,7 +19,7 @@ The minimum required version of Nix is 2.5.
 
 To improve build speed, it is **highly recommended** (but not mandatory) to configure the **binary cache maintained by IOG**.
 
-See [iohk-nix/docs/nix.md](https://github.com/input-output-hk/iohk-nix/blob/8b1d65ba294708b12d7b15103ac35431d9b60819/docs/nix.md) or [cardano-node/doc/getting-started/building-the-node-using-nix.md](https://github.com/input-output-hk/cardano-node/blob/468f52e5a6a2f18a2a89218a849d702481819f0b/doc/getting-started/building-the-node-using-nix.md#building-under-nix)
+See [iohk-nix/docs/nix.md](https://github.com/input-output-hk/iohk-nix/blob/8b1d65ba294708b12d7b15103ac35431d9b60819/docs/nix.md) or [cardano-node/doc/getting-started/building-the-node-using-nix.md](https://github.com/IntersectMBO/cardano-node/blob/468f52e5a6a2f18a2a89218a849d702481819f0b/doc/getting-started/building-the-node-using-nix.md#building-under-nix)
 for instructions on how to configure the IOG binary cache on your system.
 
 ## Building with Nix

--- a/docs/site/src/design/adrestia-architecture.md
+++ b/docs/site/src/design/adrestia-architecture.md
@@ -20,8 +20,8 @@ Service applications for integrating with Cardano.
 - [cardano-transactions]: Utilities for constructing and signing transactions.
 - [bech32][bech32]: Haskell implementation of the Bech32 address format (BIP 0173).
 
-[cardano‑addresses]: https://github.com/input-output-hk/cardano-addresses
-[bech32]: https://github.com/input-output-hk/bech32
+[cardano‑addresses]: https://github.com/IntersectMBO/cardano-addresses
+[bech32]: https://github.com/IntersectMBO/bech32
 
 
 ## High-Level Dependency Diagram
@@ -70,8 +70,8 @@ The core [cardano-node][], which participates in the Cardano network, and mainta
 
 An implementation of the protocol is [here][ouroboros-network], deployed as stake pool nodes and relay nodes to form the Cardano network.
 
-[ouroboros-network]: https://github.com/input-output-hk/ouroboros-network
-[cardano-node]: https://github.com/input-output-hk/cardano-node
+[ouroboros-network]: https://github.com/IntersectMBO/ouroboros-network
+[cardano-node]: https://github.com/IntersectMBO/cardano-node
 
 ### [cardano-wallet]
 
@@ -205,7 +205,7 @@ flowchart TB
 | [cardano‑launcher]  | Typescript library for starting and stopping [cardano-wallet] and [cardano-node] |       | ❌    | ✔       | ✔    | ✔      |
 | [cardano‑addresses] | Address validation and inspection                                                | ✔     | ✔    | ✔       | ✔    | ✔      |
 
-[cardano‑launcher]: https://github.com/input-output-hk/cardano-launcher
+[cardano‑launcher]: https://github.com/IntersectMBO/cardano-launcher
 
 ### Formal Specifications
 
@@ -230,15 +230,15 @@ does not benefit from the same care in documentation than other tools above.
 
 
 [cardano-cli]: https://docs.cardano.org/projects/cardano-node/en/latest/reference/cardano-node-cli-reference.html
-[cardano-coin-selection]: https://github.com/input-output-hk/cardano-coin-selection
-[cardano-db-sync]: https://github.com/input-output-hk/cardano-db-sync
-[cardano-graphql]: https://github.com/input-output-hk/cardano-graphql
-[cardano-node]: https://github.com/input-output-hk/cardano-node
+[cardano-coin-selection]: https://github.com/IntersectMBO/cardano-coin-selection
+[cardano-db-sync]: https://github.com/IntersectMBO/cardano-db-sync
+[cardano-graphql]: https://github.com/cardano-foundation/cardano-graphql
+[cardano-node]: https://github.com/IntersectMBO/cardano-node
 [cardano-rest]: https://github.com/input-output-hk/cardano-rest
 [cardano-serialization-lib]: https://github.com/Emurgo/cardano-serialization-lib
 [cardano-sl-explorer]: https://cardanodocs.com/technical/explorer/api/
-[cardano-submit-api]: https://github.com/input-output-hk/cardano-node/tree/master/cardano-submit-api
-[cardano-transactions]: https://github.com/input-output-hk/cardano-transactions
+[cardano-submit-api]: https://github.com/IntersectMBO/cardano-node/tree/master/cardano-submit-api
+[cardano-transactions]: https://github.com/IntersectMBO/cardano-transactions
 [cardano-wallet]: https://github.com/cardano-foundation/cardano-wallet
 [ouroboros]: https://iohk.io/en/research/library/papers/ouroboros-praosan-adaptively-securesemi-synchronous-proof-of-stake-protocol/
 [react-native-haskell-shelley]: https://github.com/Emurgo/react-native-haskell-shelley

--- a/docs/site/src/design/architecture.md
+++ b/docs/site/src/design/architecture.md
@@ -59,8 +59,8 @@ The core [cardano-node], which participates in the Cardano network, and maintain
 
 [SMASH] is a proxy for stake pool metadata.
 
-[cardano-node]: https://github.com/input-output-hk/cardano-node
+[cardano-node]: https://github.com/IntersectMBO/cardano-node
 [cardano-wallet]: https://github.com/cardano-foundation/cardano-wallet
-[cardano-launcher]: https://github.com/input-output-hk/cardano-launcher
+[cardano-launcher]: https://github.com/IntersectMBO/cardano-launcher
 [daedalus]: https://github.com/input-output-hk/daedalus
 [SMASH]: https://github.com/input-output-hk/smash

--- a/docs/site/src/design/concepts/eras.md
+++ b/docs/site/src/design/concepts/eras.md
@@ -66,7 +66,7 @@ Cardano Mode is the default. I'm not aware of too many people using single-era m
 
 ## Specifications
 
-Formal specifications (and the actual implementations!) for each Cardano era exist in the [input-output-hk/cardano-ledger](https://github.com/input-output-hk/cardano-ledger) repo. These documents are surprisingly readable, and are our go-to source for answers about how the node operates. See the [`README.md`](https://github.com/input-output-hk/cardano-ledger/blob/master/README.md) for links to PDFs and/or build instructions.
+Formal specifications (and the actual implementations!) for each Cardano era exist in the [IntersectMBO/cardano-ledger](https://github.com/IntersectMBO/cardano-ledger) repo. These documents are surprisingly readable, and are our go-to source for answers about how the node operates. See the [`README.md`](https://github.com/IntersectMBO/cardano-ledger/blob/master/README.md) for links to PDFs and/or build instructions.
 
 ### Decentralized Update Proposals
 

--- a/docs/site/src/design/links.md
+++ b/docs/site/src/design/links.md
@@ -6,12 +6,12 @@
 - [Engineering Design Specification for Delegation and Incentives](https://hydra.iohk.io/build/902246/download/1/delegation_design_spec.pdf)
 - [A Formal Specification of the Cardano Ledger](https://hydra.iohk.io/build/1224753/download/1/ledger-spec.pdf)
 - Networking Protocol(s)
-  - Repository: [input-output-hk/ouroboros-network](https://github.com/input-output-hk/ouroboros-network), includes specifications
+  - Repository: [IntersectMBO/ouroboros-network](https://github.com/IntersectMBO/ouroboros-network), includes specifications
   - Specification: [The Shelley Networking Protocol](https://hydra.iohk.io/build/6955704/download/2/network-spec.pdf) (Version 1.3.0, 16th July 2021)
 - Low-Level Specifications
   - [ [Byron] On-Chain Binary Formats](https://github.com/input-output-hk/cardano-sl/blob/master/docs/on-the-wire/current-spec.cddl)
-  - [  [Shelley] Network Binary Formats - Draft](https://github.com/input-output-hk/ouroboros-network/blob/master/ouroboros-network/test/messages.cddl)
-  - [ [Shelley] On chain Binary formats - Draft](https://github.com/input-output-hk/cardano-ledger/blob/master/shelley/chain-and-ledger/cddl-spec/shelley.cddl#L32)
+  - [  [Shelley] Network Binary Formats - Draft](https://github.com/IntersectMBO/ouroboros-network/blob/master/ouroboros-network/test/messages.cddl)
+  - [ [Shelley] On chain Binary formats - Draft](https://github.com/IntersectMBO/cardano-ledger/blob/master/shelley/chain-and-ledger/cddl-spec/shelley.cddl#L32)
 
 ## Plutus
 

--- a/docs/site/src/design/prototypes/light-mode.md
+++ b/docs/site/src/design/prototypes/light-mode.md
@@ -189,7 +189,7 @@ See also the `light-mode-test` prototype!
 * [Cardano-launcher][] will have to be modified to not launch the `cardano-node` process when the cardano-wallet is launched in light-mode.
 * Provision of the data source and of the transaction submission service is outside the scope of light-mode; we assume these services will be operated and paid for by someone. (Any light wallet assumes this.) In the MVP, we use [Blockfrost][] for demonstration purposes.
 
-  [cardano-launcher]: https://github.com/input-output-hk/cardano-launcher
+  [cardano-launcher]: https://github.com/IntersectMBO/cardano-launcher
 
 # Design alternatives
 

--- a/docs/site/src/user/cli.md
+++ b/docs/site/src/user/cli.md
@@ -46,7 +46,7 @@ The CLI commands for `wallet`, `transaction` and `address` only output valid JSO
 
 ### serve
 
-Serve API that listens for commands/actions. Before launching user should start [`cardano-node`](https://github.com/input-output-hk/cardano-node).
+Serve API that listens for commands/actions. Before launching user should start [`cardano-node`](https://github.com/IntersectMBO/cardano-node).
 
 ```console
 Usage: cardano-wallet serve [--listen-address HOST]

--- a/docs/site/src/user/common-use-cases/shared-wallets.md
+++ b/docs/site/src/user/common-use-cases/shared-wallets.md
@@ -15,7 +15,7 @@ This guide shows you how to create a shared wallet and make a shared transaction
 ```
 
 ```admonish note
-The script templates use Cardano [simple scripts](https://github.com/input-output-hk/cardano-node/blob/master/doc/reference/simple-scripts.md) therefore one can build more sophisticated templates to guard their shared wallet spending or delegation operations. Below are some examples of possible templates. You can also explore [`POST /shared-wallets`](https://cardano-foundation.github.io/cardano-wallet/api/edge/#operation/postSharedWallet) swagger specification for more details.
+The script templates use Cardano [simple scripts](https://github.com/IntersectMBO/cardano-node/blob/master/doc/reference/simple-scripts.md) therefore one can build more sophisticated templates to guard their shared wallet spending or delegation operations. Below are some examples of possible templates. You can also explore [`POST /shared-wallets`](https://cardano-foundation.github.io/cardano-wallet/api/edge/#operation/postSharedWallet) swagger specification for more details.
 ```
 
 ### Template examples

--- a/docs/site/src/user/hardware-recommendations.md
+++ b/docs/site/src/user/hardware-recommendations.md
@@ -1,6 +1,6 @@
 ## Hardware recommendations
 
-As cardano-wallet runs side by side with cardano-node, the hardware requirements for cardano-wallet would largely depend on the hardware requirements for cardano-node. Current hardware requirements for cardano-node are published on cardano-node's [release page](https://github.com/input-output-hk/cardano-node/releases). For most cases cardano-node's hardware requirements are good enough to cover requirements of running cardano-wallet as well.
+As cardano-wallet runs side by side with cardano-node, the hardware requirements for cardano-wallet would largely depend on the hardware requirements for cardano-node. Current hardware requirements for cardano-node are published on cardano-node's [release page](https://github.com/IntersectMBO/cardano-node/releases). For most cases cardano-node's hardware requirements are good enough to cover requirements of running cardano-wallet as well.
 
 Here are some general hardware recommendations for running cardano-wallet:
 

--- a/docs/site/src/user/installation.md
+++ b/docs/site/src/user/installation.md
@@ -50,24 +50,24 @@ As a pre-requisite, you may want to install and configure [Nix](https://nixos.or
 | [cardano-rosetta][cardano-rosetta]       | [releases][release-cardano-rosetta] | ✔️     | ✔️     | ❌       |
 | [cardano-wallet][cardano-wallet]         | [releases][release-cardano-wallet]  | ✔️     | ✔️     | ✔️       |
 
-[cardano-node]: https://github.com/input-output-hk/cardano-node
-[cardano-db-sync]: https://github.com/input-output-hk/cardano-db-sync
-[cardano-submit-api]: https://github.com/input-output-hk/cardano-node/tree/master/cardano-submit-api
+[cardano-node]: https://github.com/IntersectMBO/cardano-node
+[cardano-db-sync]: https://github.com/IntersectMBO/cardano-db-sync
+[cardano-submit-api]: https://github.com/IntersectMBO/cardano-node/tree/master/cardano-submit-api
 [cardano-rosetta]: https://github.com/input-output-hk/cardano-rosetta
-[cardano-graphql]: https://github.com/input-output-hk/cardano-graphql
+[cardano-graphql]: https://github.com/cardano-foundation/cardano-graphql
 [cardano-wallet]: https://github.com/cardano-foundation/cardano-wallet
 
-[release-cardano-node]: https://github.com/input-output-hk/cardano-node/releases
-[release-cardano-db-sync]: https://github.com/input-output-hk/cardano-db-sync/releases
-[release-cardano-graphql]: https://github.com/input-output-hk/cardano-graphql/releases
+[release-cardano-node]: https://github.com/IntersectMBO/cardano-node/releases
+[release-cardano-db-sync]: https://github.com/IntersectMBO/cardano-db-sync/releases
+[release-cardano-graphql]: https://github.com/cardano-foundation/cardano-graphql/releases
 [release-cardano-rosetta]: https://github.com/input-output-hk/cardano-rosetta/releases
 [release-cardano-wallet]: https://github.com/cardano-foundation/cardano-wallet/releases
 
-[cardano-node]: https://github.com/input-output-hk/cardano-node
-[cardano-db-sync]: https://github.com/input-output-hk/cardano-db-sync
+[cardano-node]: https://github.com/IntersectMBO/cardano-node
+[cardano-db-sync]: https://github.com/IntersectMBO/cardano-db-sync
 [cardano-submit-api]: https://github.com/input-output-hk/cardano-rest
 
-[doc-cardano-db-sync]: https://github.com/input-output-hk/cardano-db-sync/blob/master/nix/docker.nix#L1-L35
+[doc-cardano-db-sync]: https://github.com/IntersectMBO/cardano-db-sync/blob/master/nix/docker.nix#L1-L35
 [doc-cardano-rest]: https://github.com/input-output-hk/cardano-rest/wiki/Docker
-[doc-cardano-graphql]: https://github.com/input-output-hk/cardano-graphql/wiki/Docker
+[doc-cardano-graphql]: https://github.com/cardano-foundation/cardano-graphql/wiki/Docker
 [doc-cardano-rosetta]: https://github.com/input-output-hk/cardano-rosetta

--- a/docs/site/src/user/installation/use-docker.md
+++ b/docs/site/src/user/installation/use-docker.md
@@ -91,7 +91,7 @@ wget https://raw.githubusercontent.com/cardano-foundation/cardano-wallet/master/
 NETWORK=mainnet docker-compose up
 ```
 
-There is also an example configuration for [cardano-graphql](https://github.com/input-output-hk/cardano-graphql/blob/master/docker-compose.yml).
+There is also an example configuration for [cardano-graphql](https://github.com/cardano-foundation/cardano-graphql/blob/master/docker-compose.yml).
 
 [inputoutput-cardano-node]: https://hub.docker.com/r/inputoutput/cardano-node
 [inputoutput-cardano-db-sync]: https://hub.docker.com/r/inputoutput/cardano-db-sync
@@ -99,4 +99,4 @@ There is also an example configuration for [cardano-graphql](https://github.com/
 [inputoutput-cardano-wallet]: https://hub.docker.com/r/cardanofoundation/cardano-wallet
 [inputoutput-cardano-rosetta]: https://hub.docker.com/r/inputoutput/cardano-rosetta
 
-[doc-cardano-node]: https://github.com/input-output-hk/cardano-node/blob/master/nix/docker.nix#L1-L25
+[doc-cardano-node]: https://github.com/IntersectMBO/cardano-node/blob/master/nix/docker.nix#L1-L25

--- a/docs/site/src/user/integrations.md
+++ b/docs/site/src/user/integrations.md
@@ -25,7 +25,7 @@ A non-exhaustive list of applications and libraries which use the `cardano-walle
 ## TypeScript/JavaScript
 
  * [`input-output-hk/daedalus`](https://github.com/input-output-hk/daedalus) - a graphical Cardano Wallet user interface using Electron and the [React Polymorph](https://github.com/input-output-hk/react-polymorph) framework.
- * [`input-output-hk/cardano-launcher`](https://github.com/input-output-hk/cardano-launcher) - a library for configuring, starting and stopping `cardano-wallet` and `cardano-node`.
+ * [`IntersectMBO/cardano-launcher`](https://github.com/IntersectMBO/cardano-launcher) - a library for configuring, starting and stopping `cardano-wallet` and `cardano-node`.
  * [`tango-crypto/cardano-wallet-js`](https://github.com/tango-crypto/cardano-wallet-js) - a Typescript/Javascript module for accessing the `cardano-wallet` REST [API][].
 
 ## Unknown

--- a/flake.lock
+++ b/flake.lock
@@ -300,13 +300,13 @@
       "locked": {
         "lastModified": 1690209950,
         "narHash": "sha256-d0V8N+y/OarYv6GQycGXnbPly7GeJRBEeE1017qj9eI=",
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "repo": "cardano-node",
         "rev": "d2d90b48c5577b4412d5c9c9968b55f8ab4b9767",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "ref": "8.1.2",
         "repo": "cardano-node",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -142,14 +142,14 @@
       flake = false;
     };
     customConfig.url = "github:input-output-hk/empty-flake";
-    cardano-node-runtime.url = "github:input-output-hk/cardano-node?ref=8.1.2";
+    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=8.1.2";
   };
 
   outputs = { self, nixpkgs, nixpkgs-unstable, hostNixpkgs, flake-utils,
               haskellNix, iohkNix, CHaP, customConfig, cardano-node-runtime,
               ... }:
     let
-      # Import libraries      
+      # Import libraries
       lib = import ./nix/lib.nix nixpkgs.lib;
       config = import ./nix/config.nix nixpkgs.lib customConfig;
       inherit (flake-utils.lib) eachSystem mkApp flattenTree;

--- a/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Derivation.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Derivation.hs
@@ -529,7 +529,7 @@ class HardDerivation (key :: Depth -> Type -> Type) where
     type AddressCredential key :: Depth
 
     -- | Derives account private key from the given root private key, using
-    -- derivation scheme 2 (see <https://github.com/input-output-hk/cardano-crypto/ cardano-crypto>
+    -- derivation scheme 2 (see <https://github.com/IntersectMBO/cardano-crypto/ cardano-crypto>
     -- package for more details).
     --
     -- NOTE: The caller is expected to provide the corresponding passphrase (and
@@ -543,7 +543,7 @@ class HardDerivation (key :: Depth -> Type -> Type) where
         -> key 'AccountK XPrv
 
     -- | Derives address private key from the given account private key, using
-    -- derivation scheme 2 (see <https://github.com/input-output-hk/cardano-crypto/ cardano-crypto>
+    -- derivation scheme 2 (see <https://github.com/IntersectMBO/cardano-crypto/ cardano-crypto>
     -- package for more details).
     --
     -- It is preferred to use 'deriveAddressPublicKey' whenever possible to avoid
@@ -563,7 +563,7 @@ class HardDerivation (key :: Depth -> Type -> Type) where
 -- | An interface for doing soft derivations from an account public key
 class HardDerivation key => SoftDerivation (key :: Depth -> Type -> Type) where
     -- | Derives address public key from the given account public key, using
-    -- derivation scheme 2 (see <https://github.com/input-output-hk/cardano-crypto/ cardano-crypto>
+    -- derivation scheme 2 (see <https://github.com/IntersectMBO/cardano-crypto/ cardano-crypto>
     -- package for more details).
     --
     -- This is the preferred way of deriving new sequential address public keys.

--- a/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Derivation/Byron.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Derivation/Byron.hs
@@ -22,7 +22,7 @@
 --
 -- For full documentation of the key derivation schemes,
 -- see the "Cardano.Crypto.Wallet" module, and the implementation in
--- <https://github.com/input-output-hk/cardano-crypto/blob/4590efa638397e952a51a8994b5543e4ea3c1ecd/cbits/encrypted_sign.c cardano-crypto>.
+-- <https://github.com/IntersectMBO/cardano-crypto/blob/4590efa638397e952a51a8994b5543e4ea3c1ecd/cbits/encrypted_sign.c cardano-crypto>.
 
 module Cardano.Wallet.Address.Derivation.Byron
     ( -- * Types

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -512,7 +512,7 @@ balanceTransaction
     -- It is unclear whether an incorrect value could cause collateral to be
     -- forfeited. We should ideally investigate and clarify as part of ADP-1544
     -- or similar ticket. Relevant ledger code:
-    -- https://github.com/input-output-hk/cardano-ledger/blob/fdec04e8c071060a003263cdcb37e7319fb4dbf3/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs#L428-L440
+    -- https://github.com/IntersectMBO/cardano-ledger/blob/fdec04e8c071060a003263cdcb37e7319fb4dbf3/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxInfo.hs#L428-L440
     -> UTxOAssumptions
     -> UTxOIndex era
     -> ChangeAddressGen changeState

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/SizeEstimation.hs
@@ -126,9 +126,9 @@ estimateTxCost (FeePerByte feePerByte) skeleton =
 -- This function uses the upper bounds of CBOR serialized objects as the basis
 -- for many of its calculations. The following document is used as a reference:
 --
--- https://github.com/input-output-hk/cardano-ledger/blob/master/eras/shelley/test-suite/cddl-files/shelley.cddl
--- https://github.com/input-output-hk/cardano-ledger/blob/master/eras/shelley-ma/test-suite/cddl-files/shelley-ma.cddl
--- https://github.com/input-output-hk/cardano-ledger/blob/master/eras/alonzo/test-suite/cddl-files/alonzo.cddl
+-- https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/shelley/test-suite/cddl-files/shelley.cddl
+-- https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/shelley-ma/test-suite/cddl-files/shelley-ma.cddl
+-- https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/alonzo/test-suite/cddl-files/alonzo.cddl
 --
 estimateTxSize
     :: TxSkeleton

--- a/lib/cardano-api-extra/lib/Cardano/Api/Gen.hs
+++ b/lib/cardano-api-extra/lib/Cardano/Api/Gen.hs
@@ -733,7 +733,7 @@ genScriptData =
 
         -- NOTE: Negative values would trigger "Impossible" errors to be
         -- thrown. This seems expected and fine:
-        -- https://github.com/input-output-hk/cardano-ledger/pull/2333#issuecomment-864159342
+        -- https://github.com/IntersectMBO/cardano-ledger/pull/2333#issuecomment-864159342
         genConstructorIx :: Gen Integer
         genConstructorIx = frequency
             [ (45, arbitrarySizedNatural)
@@ -1060,7 +1060,7 @@ genRational =
     ratioToRational = toRational
 
 -- TODO: consolidate this back to just genRational once this is merged:
--- https://github.com/input-output-hk/cardano-ledger/pull/2330
+-- https://github.com/IntersectMBO/cardano-ledger/pull/2330
 genRationalInt64 :: Gen Rational
 genRationalInt64 =
     (\d -> ratioToRational (1 % d)) <$> genDenominator
@@ -1291,7 +1291,7 @@ genStakePoolRelay = do
     castPort :: Ledger.Port -> PortNumber
     castPort = fromInteger . toInteger . Ledger.portToWord16
 
-    -- See https://github.com/input-output-hk/cardano-ledger-1-tech-writing-tweaks/blob/2de173e8574ab079c9e18013d7906c20a70a7251/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/Generators/Genesis.hs#L113
+    -- See https://github.com/IntersectMBO/cardano-ledger-1-tech-writing-tweaks/blob/2de173e8574ab079c9e18013d7906c20a70a7251/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/Generators/Genesis.hs#L113
     genLedgerStakePoolRelay :: Gen Ledger.StakePoolRelay
     genLedgerStakePoolRelay = oneof
         [ Ledger.SingleHostAddr

--- a/lib/launcher/src/Cardano/Startup.hs
+++ b/lib/launcher/src/Cardano/Startup.hs
@@ -85,7 +85,7 @@ import qualified Data.Text as T
 --
 -- This is necessary when running cardano-wallet as a subprocess of Daedalus.
 -- For more details, see
--- <https://github.com/input-output-hk/cardano-launcher/blob/master/docs/windows-clean-shutdown.md>
+-- <https://github.com/IntersectMBO/cardano-launcher/blob/master/docs/windows-clean-shutdown.md>
 --
 -- It works simply by reading from 'stdin', which is otherwise unused by the API
 -- server. Once end-of-file is reached, it cancels the action, causing the

--- a/lib/launcher/test/unit/Cardano/StartupSpec.hs
+++ b/lib/launcher/test/unit/Cardano/StartupSpec.hs
@@ -199,7 +199,7 @@ captureLogging' = fmap fst . captureLogging
 -- | Run an IO action allowing interruptions on windows.
 -- Any 'IOException's are rethrown.
 -- The action should not throw any exception other than 'IOException'.
--- Example: https://github.com/input-output-hk/ouroboros-network/blob/69d62063e59f966dc90bda5b4d0ac0a11efd3657/Win32-network/src/System/Win32/Async/Socket.hs#L46-L59
+-- Example: https://github.com/IntersectMBO/ouroboros-network/blob/69d62063e59f966dc90bda5b4d0ac0a11efd3657/Win32-network/src/System/Win32/Async/Socket.hs#L46-L59
 wrapIO :: IO a -> IO a
 #if defined(WINDOWS)
 wrapIO action = do

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -1721,7 +1721,7 @@ currentEra = eraIndexToAnyCardanoEra <$> LSQry (QueryHardFork GetCurrentEra)
 -- This mapping replaces a conversion between enumerations.
 --
 -- The following is used as a reference for the index mapping:
--- https://github.com/input-output-hk/cardano-node/blob/3531289c9f79eab7ac5d3272ce6e6821504fec4c/cardano-api/src/Cardano/Api/Eras.hs#L188
+-- https://github.com/IntersectMBO/cardano-node/blob/3531289c9f79eab7ac5d3272ce6e6821504fec4c/cardano-api/src/Cardano/Api/Eras.hs#L188
 eraIndexToAnyCardanoEra :: EraIndex xs -> AnyCardanoEra
 eraIndexToAnyCardanoEra index =
     case eraIndexToInt index of

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Inputs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Inputs.hs
@@ -75,7 +75,7 @@ fromShelleyTxIn (SL.TxIn txid (SL.TxIx ix)) =
     -- During the Vasil hard-fork the cardano-ledger team moved from
     -- representing transaction indices with Word16s, to using Word64s (see
     -- commit
-    -- https://github.com/input-output-hk/cardano-ledger/commit/4097a9055e6ea57161755e6a8cbfcf719b65e9ab).
+    -- https://github.com/IntersectMBO/cardano-ledger/commit/4097a9055e6ea57161755e6a8cbfcf719b65e9ab).
     -- However, the valid range is still 0 <= x <= (maxBound :: Word16), so we
     -- reflect that here.
     unsafeCast :: Word64 -> Word32

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Shelley.hs
@@ -120,7 +120,7 @@ fromShelleyTxIn (SL.TxIn txid (SL.TxIx ix)) =
     -- During the Vasil hard-fork the cardano-ledger team moved from
     -- representing transaction indices with Word16s, to using Word64s (see
     -- commit
-    -- https://github.com/input-output-hk/cardano-ledger/commit/4097a9055e6ea57161755e6a8cbfcf719b65e9ab).
+    -- https://github.com/IntersectMBO/cardano-ledger/commit/4097a9055e6ea57161755e6a8cbfcf719b65e9ab).
     -- However, the valid range is still 0 <= x <= (maxBound :: Word16), so we
     -- reflect that here.
     unsafeCast :: Word64 -> Word32

--- a/lib/wallet/api/http/Cardano/CLI.hs
+++ b/lib/wallet/api/http/Cardano/CLI.hs
@@ -1846,7 +1846,7 @@ initTracer loggerName outputs = do
     ekgEnabled >>= flip when (startCapturingMetrics tr)
     pure (sb, (cfg, tr))
   where
-    -- https://github.com/input-output-hk/cardano-node/blob/f7d57e30c47028ba2aeb306a4f21b47bb41dec01/cardano-node/src/Cardano/Node/Configuration/Logging.hs#L224
+    -- https://github.com/IntersectMBO/cardano-node/blob/f7d57e30c47028ba2aeb306a4f21b47bb41dec01/cardano-node/src/Cardano/Node/Configuration/Logging.hs#L224
     startCapturingMetrics :: Trace IO Text -> IO ()
     startCapturingMetrics trace0 = do
       let trace = appendName "metrics" trace0

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/SchemaMetadata.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/SchemaMetadata.hs
@@ -13,7 +13,7 @@
 -- License: Apache-2.0
 --
 -- A wrapper around TxMetadata to allow different JSON codecs. (ADP-1596)
--- see https://github.com/input-output-hk/cardano-node/blob/master/cardano-api/src/Cardano/Api/TxMetadata.hs
+-- see https://github.com/IntersectMBO/cardano-node/blob/master/cardano-api/src/Cardano/Api/TxMetadata.hs
 module Cardano.Wallet.Api.Types.SchemaMetadata where
 
 import Cardano.Api

--- a/prototypes/light-mode-test/README.md
+++ b/prototypes/light-mode-test/README.md
@@ -31,7 +31,7 @@ This prototype explores whether we can implement a "light mode" for cardano-wall
 * Projects like [cardano-graphql][] also allow us to query the *ledger state*, albeit with a lower level of trust than Proof-of-Stake.
 * In cardano-wallet, the data type `NetworkLayer` collects all functions necessary to gather blockchain data. Chances are that changes to the code are confined to providing a second implementation of this type.
 
-  [cardano-graphql]: https://github.com/input-output-hk/cardano-graphql/
+  [cardano-graphql]: https://github.com/cardano-foundation/cardano-graphql/
 
 ## In-Scope
 

--- a/specifications/Cardano/Wallet/delegation.md
+++ b/specifications/Cardano/Wallet/delegation.md
@@ -13,7 +13,7 @@ Here, the `Delegations` type only keeps track of the final change to the delegat
 
 See the [Shelley ledger specification, Section 9 "Delegation"][ledger-spec] for more details.
 
-  [ledger-spec]: https://github.com/input-output-hk/cardano-ledger/releases/latest/download/shelley-ledger.pdf
+  [ledger-spec]: https://github.com/IntersectMBO/cardano-ledger/releases/latest/download/shelley-ledger.pdf
 
 # Data type
 

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2202,7 +2202,7 @@ components:
             description: |
               The raw type field of the address.
 
-              Details about possible address types are following (refer also to [cddl](https://github.com/input-output-hk/cardano-ledger/blob/master/eras/alonzo/test-suite/cddl-files/alonzo.cddl)).
+              Details about possible address types are following (refer also to [cddl](https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/alonzo/test-suite/cddl-files/alonzo.cddl)).
 
               | address_type | binary prefix  |   Meaning                                                |
               | ------------ |:--------------:|:--------------------------------------------------------:|
@@ -3772,7 +3772,7 @@ components:
 
     ScriptTemplateValue: *ScriptTemplateValue
 
-    # https://github.com/input-output-hk/cardano-ledger/blob/8d836e61bb88bda4a6a5c00694735928390067a1/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MetaData.hs#L48-L65
+    # https://github.com/IntersectMBO/cardano-ledger/blob/8d836e61bb88bda4a6a5c00694735928390067a1/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MetaData.hs#L48-L65
     TransactionMetadataValue: &TransactionMetadataValue
       oneOf:
         - title: String

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
       ##
       # This test is trying to spend utxo from a script address
       # that will always fail.
-      # Script: https://github.com/input-output-hk/cardano-node/blob/master/scripts/plutus/scripts/v2/always-fails.plutus
+      # Script: https://github.com/IntersectMBO/cardano-node/blob/master/scripts/plutus/scripts/v2/always-fails.plutus
       #
       # The spending transaction sets:
       # - collateral return output to be sent to wallet address

--- a/test/manual/make-env.sh
+++ b/test/manual/make-env.sh
@@ -20,7 +20,7 @@ pushd $(mktemp -d)
 curl -L -o cardano-wallet.tar.gz "https://github.com/cardano-foundation/cardano-wallet/archive/refs/tags/v${WALLET_VERSION}.tar.gz"
 tar -xzf cardano-wallet.tar.gz
 
-curl -L -o cardano-node.tar.gz "https://github.com/input-output-hk/cardano-node/archive/refs/tags/${NODE_VERSION}.tar.gz"
+curl -L -o cardano-node.tar.gz "https://github.com/IntersectMBO/cardano-node/archive/refs/tags/${NODE_VERSION}.tar.gz"
 tar -xzf cardano-node.tar.gz
 
 WALLET_DIR=cardano-wallet-${WALLET_VERSION}


### PR DESCRIPTION
Today IOG migrated their repositories to the Intersect MBO.

I have changed `input-output-hk` to `IntersectMBO` in repo names where appropriate.