### PR TITLE
[ADP-3224] Use skip instead of pending in join/leave SP flaky E2E tests

### DIFF
--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -1312,7 +1312,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
     end
 
     it 'Delegation (join and quit)' do
-      pending 'ADP-3243'
+      skip 'ADP-3243'
       balance = get_shelley_balances(@target_id)
       expected_deposit = CARDANO_CLI.protocol_params['stakeAddressDeposit']
       puts "Expected deposit #{expected_deposit}"
@@ -2901,7 +2901,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
       end
 
       it 'Can join and quit Stake Pool' do
-        pending 'ADP-3243'
+        skip 'ADP-3243'
         # Get funds on the wallet
         address = SHELLEY.addresses.list(@target_id)[0]['id']
         amt = 10_000_000


### PR DESCRIPTION
- [x] Use skip instead of pending when tests are flaky (E2E join/quit). Pending will fail if the test succeed.

ADP-3224