### PR TITLE
Fix broken assumptions about transaction ordering in integration tests.

### DIFF
--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -2101,11 +2101,11 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         let txid = getFromResponse #id rTx
 
         eventually "Transaction is accepted" $ do
-            let ep = Link.listTransactions @'Shelley wSrc
-            request @([ApiTransaction n]) ctx ep Default Empty >>= flip verify
-                [ expectListField 0
+            let ep = Link.getTransaction @'Shelley wSrc txid
+            request @(ApiTransaction n) ctx ep Default Empty >>= flip verify
+                [ expectField
                     (#direction . #getApiT) (`shouldBe` Outgoing)
-                , expectListField 0
+                , expectField
                     (#status . #getApiT) (`shouldBe` InLedger)
                 ]
 


### PR DESCRIPTION
The `listTransactions` endpoint makes no promises about the ordering of transactions.

Therefore, our integration test suite should not assume a particular ordering.

In particular, we probably shouldn't assume that the transaction we've just created is at the head of the list.