### PR TITLE
Fix inconsistency with HTTP API `amount` type.

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -24,7 +24,6 @@ module Cardano.Wallet.Primitive.Types.Coin
     , toInteger
     , toNatural
     , toQuantity
-    , toQuantityMaybe
     , toWord64Maybe
 
       -- * Conversions (Unsafe)
@@ -194,17 +193,6 @@ toQuantity
     => Coin
     -> Quantity "lovelace" i
 toQuantity (Coin c) = Quantity (intCast c)
-
--- | Converts a 'Coin' to a 'Quantity'.
---
--- Returns 'Nothing' if the given value does not fit within the bounds of
--- the target type.
---
-toQuantityMaybe
-    :: (Bits i, Integral i)
-    => Coin
-    -> Maybe (Quantity "lovelace" i)
-toQuantityMaybe (Coin c) = Quantity <$> intCastMaybe c
 
 -- | Converts a 'Coin' to a 'Word64' value.
 --

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -29,7 +29,6 @@ module Cardano.Wallet.Primitive.Types.Coin
 
       -- * Conversions (Unsafe)
     , unsafeFromIntegral
-    , unsafeToQuantity
     , unsafeToWord64
 
       -- * Arithmetic operations
@@ -237,26 +236,6 @@ unsafeFromIntegral i = fromMaybe onError (fromIntegralMaybe i)
         [ "Coin.unsafeFromIntegral:"
         , show i
         , "is not a natural number."
-        ]
-
--- | Converts a 'Coin' to a 'Quantity'.
---
--- Callers of this function must take responsibility for checking that the
--- given value will fit within the bounds of the target type.
---
--- Produces a run-time error if the given value is out of bounds.
---
-unsafeToQuantity
-    :: HasCallStack
-    => (Bits i, Integral i)
-    => Coin
-    -> Quantity "lovelace" i
-unsafeToQuantity c = fromMaybe onError (toQuantityMaybe c)
-  where
-    onError = error $ unwords
-        [ "Coin.unsafeToQuantity:"
-        , show c
-        , "does not fit within the bounds of the target type."
         ]
 
 -- | Converts a 'Coin' to a 'Word64' value.

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -20,7 +20,6 @@ module Cardano.Wallet.Primitive.Types.Coin
       -- * Conversions (Safe)
     , fromIntegralMaybe
     , fromNatural
-    , fromQuantity
     , fromWord64
     , toInteger
     , toNatural
@@ -173,14 +172,6 @@ fromIntegralMaybe i = Coin <$> intCastMaybe i
 --
 fromNatural :: Natural -> Coin
 fromNatural = Coin
-
--- | Constructs a 'Coin' from a 'Quantity'.
---
-fromQuantity
-    :: (Integral i, IsIntSubType i Natural ~ 'True)
-    => Quantity "lovelace" i
-    -> Coin
-fromQuantity (Quantity c) = Coin (intCast c)
 
 -- | Constructs a 'Coin' from a 'Word64' value.
 --

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -199,7 +199,7 @@ import Servant.Server
     )
 
 import qualified Cardano.Api as Cardano
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
+import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
@@ -620,7 +620,7 @@ instance
 
           where
             info = ApiErrorBalanceTxUnderestimatedFee
-                { underestimation = Coin.toQuantity $ toWalletCoin coin
+                { underestimation = ApiAmount.fromCoin $ toWalletCoin coin
                 , candidateTxHex = hexText $ Write.serializeTx @era candidateTx
                 , candidateTxReadable = T.pack (show candidateTx)
                 , estimatedNumberOfKeyWits = intCast nWits
@@ -966,13 +966,14 @@ instance IsServerError ErrBalanceTxOutputError where
                             , show index
                             ]
                 , txOutputLovelaceSpecified =
-                    Coin.toQuantity
+                    ApiAmount.fromCoin
                         $ TokenBundle.getCoin
                         $ toWallet
                         $ snd
                         $ view #output e
                 , txOutputLovelaceRequiredMinimum =
-                    Coin.toQuantity $ toWalletCoin $ view #minimumExpectedCoin e
+                    ApiAmount.fromCoin $
+                    toWalletCoin $ view #minimumExpectedCoin e
                 }
         ErrBalanceTxOutputSizeExceedsLimit e ->
             toServerError e

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Amount.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Amount.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+
+-- |
+-- Copyright: © 2023 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Haskell implementation of the API `amount` type, which represents a natural
+-- quantity of lovelace.
+--
+module Cardano.Wallet.Api.Types.Amount
+    ( ApiAmount (..)
+    , fromCoin
+    , fromNatural
+    , fromWord64
+    , toCoin
+    , toInteger
+    )
+    where
+
+import Prelude hiding
+    ( toInteger
+    )
+
+import Control.DeepSeq
+    ( NFData
+    )
+import Data.Aeson.Types
+    ( FromJSON
+    , ToJSON
+    )
+import Data.Data
+    ( Data
+    )
+import Data.Hashable
+    ( Hashable
+    )
+import Data.IntCast
+    ( intCast
+    )
+import Data.Monoid
+    ( Sum (Sum)
+    )
+import Data.Quantity
+    ( Quantity (..)
+    )
+import Data.Text.Class
+    ( FromText
+    , ToText
+    )
+import Data.Word
+    ( Word64
+    )
+import GHC.Generics
+    ( Generic
+    )
+import Numeric.Natural
+    ( Natural
+    )
+
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+import qualified Data.Quantity as W
+
+newtype ApiAmount = ApiAmount {toNatural :: Natural}
+    deriving stock (Data, Eq, Generic, Ord, Show)
+    deriving (FromJSON, ToJSON) via W.Quantity "lovelace" Natural
+    deriving (FromText, ToText) via W.Quantity "lovelace" Natural
+    deriving (Semigroup, Monoid) via Sum Natural
+    deriving anyclass (Hashable, NFData)
+
+fromCoin :: W.Coin -> ApiAmount
+fromCoin (W.Coin n) = ApiAmount n
+
+fromNatural :: Natural -> ApiAmount
+fromNatural = ApiAmount
+
+fromWord64 :: Word64 -> ApiAmount
+fromWord64 = ApiAmount . intCast
+
+toCoin :: ApiAmount -> W.Coin
+toCoin (ApiAmount n) = W.Coin n
+
+toInteger :: ApiAmount -> Integer
+toInteger (ApiAmount n) = intCast n

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Certificate.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Certificate.hs
@@ -53,6 +53,9 @@ import Cardano.Wallet.Api.Lib.ExtendedObject
     ( extendAesonObject
     , parseExtendedAesonObject
     )
+import Cardano.Wallet.Api.Types.Amount
+    ( ApiAmount
+    )
 import Cardano.Wallet.Api.Types.Primitive
     ()
 import Cardano.Wallet.Primitive.NetworkId
@@ -61,9 +64,6 @@ import Cardano.Wallet.Primitive.NetworkId
     )
 import Cardano.Wallet.Primitive.Types
     ( NonWalletCertificate
-    )
-import Cardano.Wallet.Primitive.Types.Coin
-    ( unCoin
     )
 import Cardano.Wallet.Util
     ( ShowFmt (..)
@@ -98,10 +98,8 @@ import Data.Quantity
 import GHC.Generics
     ( Generic
     )
-import Numeric.Natural
-    ( Natural
-    )
 
+import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.RewardAccount as W
 import qualified Data.Aeson.Types as Aeson
@@ -147,8 +145,8 @@ data ApiRegisterPool = ApiRegisterPool
     { poolId :: ApiT PoolId
     , poolOwners :: [ApiT PoolOwner]
     , poolMargin :: Quantity "percent" Percentage
-    , poolCost :: Quantity "lovelace" Natural
-    , poolPledge :: Quantity "lovelace" Natural
+    , poolCost :: ApiAmount
+    , poolPledge :: ApiAmount
     , poolMetadata :: Maybe (ApiT StakePoolMetadataUrl, ApiT StakePoolMetadataHash)
     }
     deriving (Eq, Generic, Show)
@@ -257,8 +255,8 @@ mkApiAnyCertificate acct' acctPath' = \case
            (ApiT poolId')
            (map ApiT poolOwners')
            (Quantity poolMargin')
-           (Quantity $ unCoin poolCost')
-           (Quantity $ unCoin poolPledge')
+           (ApiAmount.fromCoin poolCost')
+           (ApiAmount.fromCoin poolPledge')
            (enrich <$> poolMetadata')
     toApiPoolCert
         (W.Retirement (W.PoolRetirementCertificate poolId' retirementEpoch')) =

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Error.hs
@@ -39,6 +39,9 @@ import Cardano.Wallet.Api.Types
     , ApiCredentialType (..)
     , ApiEra
     )
+import Cardano.Wallet.Api.Types.Amount
+    ( ApiAmount
+    )
 import Control.DeepSeq
     ( NFData (..)
     )
@@ -60,9 +63,6 @@ import Data.Data
     )
 import Data.Maybe
     ( fromMaybe
-    )
-import Data.Quantity
-    ( Quantity
     )
 import Data.Text
     ( Text
@@ -226,9 +226,9 @@ data ApiErrorTxOutputLovelaceInsufficient = ApiErrorTxOutputLovelaceInsufficient
     { txOutputIndex
         :: !Word32
     , txOutputLovelaceSpecified
-        :: !(Quantity "lovelace" Natural)
+        :: !ApiAmount
     , txOutputLovelaceRequiredMinimum
-        :: !(Quantity "lovelace" Natural)
+        :: !ApiAmount
     }
     deriving (Data, Eq, Generic, Show, Typeable)
     deriving (FromJSON, ToJSON)
@@ -236,7 +236,7 @@ data ApiErrorTxOutputLovelaceInsufficient = ApiErrorTxOutputLovelaceInsufficient
     deriving anyclass NFData
 
 data ApiErrorBalanceTxUnderestimatedFee = ApiErrorBalanceTxUnderestimatedFee
-    { underestimation :: !(Quantity "lovelace" Natural)
+    { underestimation :: !ApiAmount
     , estimatedNumberOfKeyWits :: Natural
     , estimatedNumberOfBootstrapKeyWits :: Natural
     , candidateTxHex :: Text

--- a/lib/wallet/bench/latency-bench.hs
+++ b/lib/wallet/bench/latency-bench.hs
@@ -357,8 +357,10 @@ walletApiBench capture ctx = do
             verify rWal1
                 [ expectSuccess
                 , expectField
-                        (#balance . #available . #getQuantity)
-                        (`shouldBe` ((minUTxOValue era) * (fromIntegral utxoNumber)))
+                    (#balance . #available . #toNatural)
+                    (`shouldBe`
+                        ((minUTxOValue era) * (fromIntegral utxoNumber))
+                    )
                 ]
 
         rStat <- request @ApiUtxoStatistics ctx
@@ -382,8 +384,12 @@ walletApiBench capture ctx = do
         verify rWal
             [ expectSuccess
             , expectField
-                    (#balance . #available . #getQuantity)
-                    (`shouldBe` (fromIntegral massiveWalletUTxOSize * unCoin massiveWalletAmt))
+                (#balance . #available . #toNatural)
+                (`shouldBe`
+                    ( fromIntegral massiveWalletUTxOSize
+                    * unCoin massiveWalletAmt
+                    )
+                )
             ]
         let wal1 = getFromResponse Prelude.id rWal
         pure (wal1, wal2, walMA, maWalletToMigrate)
@@ -397,7 +403,7 @@ walletApiBench capture ctx = do
             verify rWal1
                 [ expectSuccess
                 , expectField
-                    (#balance . #available . #getQuantity)
+                    (#balance . #available . #toNatural)
                     (`shouldBe` amtExp)
                 ]
         rDel <- request @ApiWallet  ctx (Link.deleteWallet @'Shelley wSrc) Default Empty

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -362,6 +362,7 @@ library cardano-wallet-api-http
     Cardano.Wallet.Api.Lib.Options
     Cardano.Wallet.Api.Link
     Cardano.Wallet.Api.Types
+    Cardano.Wallet.Api.Types.Amount
     Cardano.Wallet.Api.Types.BlockHeader
     Cardano.Wallet.Api.Types.Certificate
     Cardano.Wallet.Api.Types.Error

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/CoinSelections.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/CoinSelections.hs
@@ -22,6 +22,9 @@ import Cardano.Wallet.Api.Types
     , ApiCoinSelectionOutput (..)
     , WalletStyle (..)
     )
+import Cardano.Wallet.Api.Types.Amount
+    ( ApiAmount (ApiAmount)
+    )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId
     )
@@ -31,9 +34,6 @@ import Data.Generics.Internal.VL.Lens
     )
 import Data.List.NonEmpty
     ( NonEmpty ((:|))
-    )
-import Data.Quantity
-    ( Quantity (..)
     )
 import Test.Hspec
     ( SpecWith
@@ -87,7 +87,7 @@ spec = describe "BYRON_COIN_SELECTION" $ do
         rnW <- emptyRandomWallet ctx
         shW <- emptyWallet ctx
         (addr:_) <- fmap (view #id) <$> listAddresses @n ctx shW
-        let amt = Quantity . minUTxOValue . _mainEra $ ctx
+        let amt = ApiAmount . minUTxOValue . _mainEra $ ctx
         let payments = pure (AddressAmount addr amt mempty)
         selectCoins @_ @'Byron ctx rnW payments >>= flip verify
             [ expectResponseCode HTTP.status403
@@ -100,7 +100,7 @@ spec = describe "BYRON_COIN_SELECTION" $ do
             source <- fixtureIcarusWallet ctx
             target <- emptyWallet ctx
             targetAddress : _ <- fmap (view #id) <$> listAddresses @n ctx target
-            let amt = Quantity . minUTxOValue $ _mainEra ctx
+            let amt = ApiAmount . minUTxOValue $ _mainEra ctx
             let payment = AddressAmount targetAddress amt mempty
             let output = ApiCoinSelectionOutput targetAddress amt mempty
             selectCoins @_ @'Byron ctx source (payment :| []) >>= flip verify
@@ -126,7 +126,7 @@ spec = describe "BYRON_COIN_SELECTION" $ do
             source <- fixtureIcarusWallet ctx
             target <- emptyWallet ctx
             targetAddresses <- fmap (view #id) <$> listAddresses @n ctx target
-            let amounts = Quantity <$> [minUTxOValue (_mainEra ctx) ..]
+            let amounts = ApiAmount <$> [minUTxOValue (_mainEra ctx) ..]
             let targetAssets = repeat mempty
             let payments = NE.fromList
                     $ take paymentCount
@@ -147,7 +147,7 @@ spec = describe "BYRON_COIN_SELECTION" $ do
         icW <- emptyIcarusWallet ctx
         shW <- emptyWallet ctx
         (addr:_) <- fmap (view #id) <$> listAddresses @n ctx shW
-        let minUTxOValue' = Quantity . minUTxOValue $ _mainEra ctx
+        let minUTxOValue' = ApiAmount . minUTxOValue $ _mainEra ctx
         let payments = pure (AddressAmount addr minUTxOValue' mempty)
         _ <- request @ApiByronWallet ctx (Link.deleteWallet @'Byron icW) Default Empty
         selectCoins @_ @'Byron ctx icW payments >>= flip verify

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
@@ -48,6 +48,9 @@ import Cardano.Wallet.Api.Types
     , ApiUtxoStatistics
     , WalletStyle (..)
     )
+import Cardano.Wallet.Api.Types.Amount
+    ( ApiAmount (ApiAmount)
+    )
 import Cardano.Wallet.Flavor
     ( KeyFlavorS (IcarusKeyS)
     )
@@ -68,9 +71,6 @@ import Control.Monad.Trans.Resource
     )
 import Data.Generics.Internal.VL.Lens
     ( (^.)
-    )
-import Data.Quantity
-    ( Quantity (..)
     )
 import Data.Text
     ( Text
@@ -143,8 +143,8 @@ spec = describe "BYRON_HW_WALLETS" $ do
         rInit <- postByronWallet ctx payldCrt
         verify rInit
             [ expectResponseCode HTTP.status201
-            , expectField (#balance . #available) (`shouldBe` Quantity 0)
-            , expectField (#balance . #total) (`shouldBe` Quantity 0)
+            , expectField (#balance . #available) (`shouldBe` ApiAmount 0)
+            , expectField (#balance . #total) (`shouldBe` ApiAmount 0)
             ]
         let wDest = getFromResponse id rInit
 
@@ -171,9 +171,9 @@ spec = describe "BYRON_HW_WALLETS" $ do
                 (Link.getWallet @'Byron wDest) Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #total) (`shouldBe` Quantity minUTxOValue')
+                    (#balance . #total) (`shouldBe` ApiAmount minUTxOValue')
                 , expectField
-                        (#balance . #available) (`shouldBe` Quantity minUTxOValue')
+                    (#balance . #available) (`shouldBe` ApiAmount minUTxOValue')
                 ]
 
         -- delete wallet
@@ -190,9 +190,9 @@ spec = describe "BYRON_HW_WALLETS" $ do
                 (Link.getWallet @'Byron wDest') Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #total) (`shouldBe` Quantity minUTxOValue')
+                    (#balance . #total) (`shouldBe` ApiAmount minUTxOValue')
                 , expectField
-                        (#balance . #available) (`shouldBe` Quantity minUTxOValue')
+                    (#balance . #available) (`shouldBe` ApiAmount minUTxOValue')
                 ]
 
     describe "HW_WALLETS_03 - Cannot do operations requiring private key" $ do
@@ -354,7 +354,7 @@ spec = describe "BYRON_HW_WALLETS" $ do
                     icarusAddresses @n mnemonics
             let minUTxOValue' = minUTxOValue (_mainEra ctx)
             let targetAmounts = take paymentCount $
-                    Quantity <$> [minUTxOValue' ..]
+                    ApiAmount <$> [minUTxOValue' ..]
             let targetAssets = repeat mempty
             let payments = NE.fromList $ map ($ mempty) $
                     zipWith AddressAmount targetAddresses targetAmounts

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
@@ -22,6 +22,9 @@ import Cardano.Wallet.Api.Types
     , ApiWalletUtxoSnapshot
     , WalletStyle (..)
     )
+import Cardano.Wallet.Api.Types.Amount
+    ( ApiAmount (ApiAmount)
+    )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId
     )
@@ -51,9 +54,6 @@ import Data.Maybe
     )
 import Data.Proxy
     ( Proxy (..)
-    )
-import Data.Quantity
-    ( Quantity (..)
     )
 import Test.Hspec
     ( SpecWith
@@ -185,12 +185,17 @@ spec = describe "BYRON_WALLETS" $ do
                         then DiscoveryRandom
                         else DiscoverySequential
                 let expectations =
-                            [ expectField (#name . #getApiT . #getWalletName) (`shouldBe` name)
-                            , expectField (#balance . #available) (`shouldBe` Quantity 0)
-                            , expectField (#balance . #total) (`shouldBe` Quantity 0)
-                            , expectField #passphrase (`shouldNotBe` Nothing)
-                            , expectField #discovery (`shouldBe` discovery)
-                            ]
+                        [ expectField (#name . #getApiT . #getWalletName)
+                            (`shouldBe` name)
+                        , expectField (#balance . #available)
+                            (`shouldBe` ApiAmount 0)
+                        , expectField (#balance . #total)
+                            (`shouldBe` ApiAmount 0)
+                        , expectField #passphrase
+                            (`shouldNotBe` Nothing)
+                        , expectField #discovery
+                            (`shouldBe` discovery)
+                        ]
                 -- create
                 r <- postByronWallet ctx payload
                 liftIO $ verify r expectations
@@ -209,13 +214,13 @@ spec = describe "BYRON_WALLETS" $ do
                         [ expectResponseCode HTTP.status200
                         , expectListSize 1
                         , expectListField 0
-                                (#name . #getApiT . #getWalletName) (`shouldBe` name)
+                            (#name . #getApiT . #getWalletName) (`shouldBe` name)
                         , expectListField 0
-                                (#balance . #available) (`shouldBe` Quantity 0)
+                            (#balance . #available) (`shouldBe` ApiAmount 0)
                         , expectListField 0
-                                (#state . #getApiT) (`shouldBe` Ready)
+                            (#state . #getApiT) (`shouldBe` Ready)
                         , expectListField 0
-                                (#balance . #total) (`shouldBe` Quantity 0)
+                            (#balance . #total) (`shouldBe` ApiAmount 0)
                         ]
 
         let scenarioFailure style mnemonic ctx = runResourceT $ do

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
@@ -35,6 +35,9 @@ import Cardano.Wallet.Api.Types
     , ApiWallet
     , WalletStyle (..)
     )
+import Cardano.Wallet.Api.Types.Amount
+    ( ApiAmount (ApiAmount)
+    )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId
     )
@@ -62,9 +65,6 @@ import Data.Aeson
 import Data.Generics.Internal.VL.Lens
     ( view
     , (^.)
-    )
-import Data.Quantity
-    ( Quantity (..)
     )
 import Data.Text
     ( Text
@@ -263,7 +263,7 @@ spec = describe "SHELLEY_ADDRESSES" $ do
                 (Link.getWallet @'Shelley wDest) Default Empty
             expectField
                 (#balance . #available)
-                (`shouldBe` Quantity (10 * amt))
+                (`shouldBe` ApiAmount (10 * amt))
                 rb
 
         -- verify new address_pool_gap has been created

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
@@ -31,6 +31,9 @@ import Cardano.Wallet.Api.Types
     , ApiWallet
     , WalletStyle (..)
     )
+import Cardano.Wallet.Api.Types.Amount
+    ( ApiAmount (ApiAmount)
+    )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId
     )
@@ -52,9 +55,6 @@ import Data.Generics.Internal.VL.Lens
     )
 import Data.Proxy
     ( Proxy (..)
-    )
-import Data.Quantity
-    ( Quantity (..)
     )
 import Data.Text
     ( Text
@@ -121,8 +121,8 @@ spec = describe "SHELLEY_HW_WALLETS" $ do
         rInit <- postWallet ctx payldCrt
         verify rInit
             [ expectResponseCode HTTP.status201
-            , expectField (#balance . #available) (`shouldBe` Quantity 0)
-            , expectField (#balance . #total) (`shouldBe` Quantity 0)
+            , expectField (#balance . #available) (`shouldBe` ApiAmount 0)
+            , expectField (#balance . #total) (`shouldBe` ApiAmount 0)
             ]
 
         --send funds
@@ -149,9 +149,9 @@ spec = describe "SHELLEY_HW_WALLETS" $ do
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #total) (`shouldBe` Quantity minUTxOValue')
+                    (#balance . #total) (`shouldBe` ApiAmount minUTxOValue')
                 , expectField
-                        (#balance . #available) (`shouldBe` Quantity minUTxOValue')
+                    (#balance . #available) (`shouldBe` ApiAmount minUTxOValue')
                 ]
 
         -- delete wallet
@@ -168,9 +168,9 @@ spec = describe "SHELLEY_HW_WALLETS" $ do
                 (Link.getWallet @'Shelley wDest') Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #total) (`shouldBe` Quantity minUTxOValue')
+                    (#balance . #total) (`shouldBe` ApiAmount minUTxOValue')
                 , expectField
-                        (#balance . #available) (`shouldBe` Quantity minUTxOValue')
+                    (#balance . #available) (`shouldBe` ApiAmount minUTxOValue')
                 ]
 
     describe "HW_WALLETS_03 - Cannot do operations requiring private key" $ do

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -41,6 +41,9 @@ import Cardano.Wallet.Api.Types
     , ApiWalletUtxoSnapshot
     , WalletStyle (..)
     )
+import Cardano.Wallet.Api.Types.Amount
+    ( ApiAmount (ApiAmount)
+    )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId
     )
@@ -91,9 +94,6 @@ import Data.Generics.Internal.VL.Lens
     )
 import Data.Proxy
     ( Proxy (..)
-    )
-import Data.Quantity
-    ( Quantity (..)
     )
 import Data.Text
     ( Text
@@ -210,9 +210,9 @@ spec = describe "SHELLEY_WALLETS" $ do
                     (#name . #getApiT . #getWalletName) (`shouldBe` "1st Wallet")
             , expectField
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) (`shouldBe` 30)
-            , expectField (#balance . #available) (`shouldBe` Quantity 0)
-            , expectField (#balance . #total) (`shouldBe` Quantity 0)
-            , expectField (#balance . #reward) (`shouldBe` Quantity 0)
+            , expectField (#balance . #available) (`shouldBe` ApiAmount 0)
+            , expectField (#balance . #total) (`shouldBe` ApiAmount 0)
+            , expectField (#balance . #reward) (`shouldBe` ApiAmount 0)
             , expectField (#assets . #total) (`shouldBe` mempty)
             , expectField (#assets . #available) (`shouldBe` mempty)
             , expectField #delegation (`shouldBe` notDelegating [])
@@ -250,11 +250,11 @@ spec = describe "SHELLEY_WALLETS" $ do
                 , expectField
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) (`shouldBe` 20)
                 , expectField
-                    (#balance . #available) (`shouldBe` Quantity 0)
+                    (#balance . #available) (`shouldBe` ApiAmount 0)
                 , expectField
-                    (#balance . #total) (`shouldBe` Quantity 0)
+                    (#balance . #total) (`shouldBe` ApiAmount 0)
                 , expectField
-                    (#balance . #reward) (`shouldBe` Quantity 0)
+                    (#balance . #reward) (`shouldBe` ApiAmount 0)
                 , expectField #delegation (`shouldBe` notDelegating [])
                 , expectField #passphrase (`shouldNotBe` Nothing)
                 ]
@@ -274,8 +274,8 @@ spec = describe "SHELLEY_WALLETS" $ do
         rInit <- postWallet ctx payldCrt
         verify rInit
             [ expectResponseCode HTTP.status201
-            , expectField (#balance . #available) (`shouldBe` Quantity 0)
-            , expectField (#balance . #total) (`shouldBe` Quantity 0)
+            , expectField (#balance . #available) (`shouldBe` ApiAmount 0)
+            , expectField (#balance . #total) (`shouldBe` ApiAmount 0)
             , expectField (#assets . #available) (`shouldBe` mempty)
             , expectField (#assets . #total) (`shouldBe` mempty)
             ]
@@ -303,9 +303,9 @@ spec = describe "SHELLEY_WALLETS" $ do
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rGet
                 [ expectField (#balance . #total)
-                    (`shouldBe` Quantity minUTxOValue')
+                    (`shouldBe` ApiAmount minUTxOValue')
                 , expectField (#balance . #available)
-                    (`shouldBe` Quantity minUTxOValue')
+                    (`shouldBe` ApiAmount minUTxOValue')
                 , expectField (#assets . #available)
                     (`shouldBe` mempty)
                 , expectField (#assets . #total)
@@ -324,9 +324,9 @@ spec = describe "SHELLEY_WALLETS" $ do
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #total) (`shouldBe` Quantity minUTxOValue')
+                        (#balance . #total) (`shouldBe` ApiAmount minUTxOValue')
                 , expectField
-                        (#balance . #available) (`shouldBe` Quantity minUTxOValue')
+                        (#balance . #available) (`shouldBe` ApiAmount minUTxOValue')
                 ]
 
     it "WALLETS_CREATE_03,09 - Cannot create wallet that exists" $ \ctx -> runResourceT $ do
@@ -677,11 +677,11 @@ spec = describe "SHELLEY_WALLETS" $ do
                 , expectField
                         (#addressPoolGap . #getApiT . #getAddressPoolGap) (`shouldBe` 20)
                 , expectField
-                        (#balance . #available) (`shouldBe` Quantity 0)
+                        (#balance . #available) (`shouldBe` ApiAmount 0)
                 , expectField
-                        (#balance . #total) (`shouldBe` Quantity 0)
+                        (#balance . #total) (`shouldBe` ApiAmount 0)
                 , expectField
-                        (#balance . #reward) (`shouldBe` Quantity 0)
+                        (#balance . #reward) (`shouldBe` ApiAmount 0)
                 , expectField (#state . #getApiT) (`shouldBe` Ready)
                 , expectField #delegation (`shouldBe` notDelegating [])
                 , expectField walletId (`shouldBe` w ^. walletId)
@@ -720,11 +720,11 @@ spec = describe "SHELLEY_WALLETS" $ do
             , expectListField 0
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) (`shouldBe` 20)
             , expectListField 0
-                    (#balance . #available) (`shouldBe` Quantity 0)
+                    (#balance . #available) (`shouldBe` ApiAmount 0)
             , expectListField 0
-                    (#balance . #total) (`shouldBe` Quantity 0)
+                    (#balance . #total) (`shouldBe` ApiAmount 0)
             , expectListField 0
-                    (#balance . #reward) (`shouldBe` Quantity 0)
+                    (#balance . #reward) (`shouldBe` ApiAmount 0)
             , expectListField 0 #delegation (`shouldBe` notDelegating [])
             ]
 
@@ -774,9 +774,9 @@ spec = describe "SHELLEY_WALLETS" $ do
                             (#addressPoolGap . #getApiT . #getAddressPoolGap)
                             (`shouldBe` 20)
                     , expectField
-                            (#balance . #available) (`shouldBe` Quantity 0)
+                            (#balance . #available) (`shouldBe` ApiAmount 0)
                     , expectField
-                            (#balance . #total) (`shouldBe` Quantity 0)
+                            (#balance . #total) (`shouldBe` ApiAmount 0)
                     , expectField #delegation (`shouldBe` notDelegating [])
                     , expectField walletId (`shouldBe` walId)
                     , expectField #passphrase (`shouldBe` passLastUpdateValue)
@@ -1222,11 +1222,11 @@ spec = describe "SHELLEY_WALLETS" $ do
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #total)
-                        (`shouldBe` Quantity (fromIntegral $ sum coins))
+                    (#balance . #total)
+                    (`shouldBe` ApiAmount (sum coins))
                 , expectField
-                        (#balance . #available)
-                        (`shouldBe` Quantity (fromIntegral $ sum coins))
+                    (#balance . #available)
+                    (`shouldBe` ApiAmount (sum coins))
                 ]
 
         --verify utxo

--- a/lib/wallet/integration/src/Test/Integration/Scenario/CLI/Byron/Wallets.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/CLI/Byron/Wallets.hs
@@ -17,6 +17,9 @@ import Cardano.Wallet.Api.Types
     ( ApiByronWallet
     , ApiUtxoStatistics
     )
+import Cardano.Wallet.Api.Types.Amount
+    ( ApiAmount (ApiAmount)
+    )
 import Cardano.Wallet.Primitive.Passphrase
     ( PassphraseMaxLength (..)
     , PassphraseMinLength (..)
@@ -42,9 +45,6 @@ import Data.Maybe
     )
 import Data.Proxy
     ( Proxy (..)
-    )
-import Data.Quantity
-    ( Quantity (..)
     )
 import System.Command
     ( Exit (..)
@@ -161,9 +161,9 @@ spec = describe "BYRON_CLI_WALLETS" $ do
                         [ expectCliField (#name . #getApiT . #getWalletName)
                             (`shouldBe` (T.pack name))
                         , expectCliField (#balance .  #available)
-                            (`shouldBe` Quantity 0)
+                            (`shouldBe` ApiAmount 0)
                         , expectCliField (#balance .  #total)
-                            (`shouldBe` Quantity 0)
+                            (`shouldBe` ApiAmount 0)
                         , expectCliField #passphrase (`shouldNotBe` Nothing)
                         ]
                 -- create

--- a/lib/wallet/integration/src/Test/Integration/Scenario/CLI/Shelley/Addresses.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/CLI/Shelley/Addresses.hs
@@ -43,9 +43,6 @@ import Data.Generics.Internal.VL.Lens
 import Data.Proxy
     ( Proxy (..)
     )
-import Data.Quantity
-    ( Quantity (..)
-    )
 import Data.Text
     ( Text
     )
@@ -90,6 +87,9 @@ import Test.Integration.Framework.TestData
     , falseWalletIds
     )
 
+import Cardano.Wallet.Api.Types.Amount
+    ( ApiAmount (ApiAmount)
+    )
 import qualified Data.Text as T
 
 spec
@@ -219,7 +219,7 @@ spec = describe "SHELLEY_CLI_ADDRESSES" $ do
             w <- expectValidJSON (Proxy @ApiWallet) o2
             expectCliField
                 (#balance . #available)
-                (`shouldBe` Quantity (10 * amt)) w
+                (`shouldBe` ApiAmount (10 * amt)) w
 
         -- verify new address_pool_gap has been created
         (Exit c1, Stdout o1, Stderr e1) <- listAddressesViaCLI ctx [widDest]

--- a/lib/wallet/integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
@@ -49,9 +49,6 @@ import Data.Generics.Internal.VL.Lens
 import Data.Proxy
     ( Proxy (..)
     )
-import Data.Quantity
-    ( Quantity (..)
-    )
 import Data.Text.Class
     ( ToText (..)
     )
@@ -115,6 +112,9 @@ import Test.Integration.Scenario.CLI.Shelley.Wallets
     , walletNamesInvalid
     )
 
+import Cardano.Wallet.Api.Types.Amount
+    ( ApiAmount (ApiAmount)
+    )
 import qualified Data.Text as T
 
 spec
@@ -133,12 +133,12 @@ spec = describe "SHELLEY_CLI_HW_WALLETS" $ do
         T.unpack e1 `shouldContain` cmdOk
         wDest <- expectValidJSON (Proxy @ApiWallet) o1
         verifyMsg "Wallet balance is as expected" wDest
-            [ expectCliField (#balance . #available) (`shouldBe` Quantity 0)
-            , expectCliField (#balance . #total) (`shouldBe` Quantity 0)
+            [ expectCliField (#balance . #available) (`shouldBe` ApiAmount 0)
+            , expectCliField (#balance . #total) (`shouldBe` ApiAmount 0)
             ]
 
         --send transaction to the wallet
-        let amount = Quantity . minUTxOValue . _mainEra $ ctx
+        let amount = ApiAmount . minUTxOValue . _mainEra $ ctx
         addrs:_ <- listAddresses @n ctx wDest
         let addr = encodeAddress (sNetworkId @n) (apiAddress $ addrs ^. #id)
         let args = T.unpack <$>
@@ -199,7 +199,7 @@ spec = describe "SHELLEY_CLI_HW_WALLETS" $ do
                 justRestored <- expectValidJSON (Proxy @ApiWallet) o3
                 verify justRestored
                     [ expectCliField (#balance . #available)
-                        (.> Quantity 0)
+                        (.> ApiAmount 0)
                     ]
 
             -- make sure you cannot send tx from wallet
@@ -263,7 +263,7 @@ spec = describe "SHELLEY_CLI_HW_WALLETS" $ do
                 Stdout og <- getWalletViaCLI ctx $ T.unpack (wRestored ^. walletId)
                 expectValidJSON (Proxy @ApiWallet) og >>= flip verify
                     [ expectCliField (#balance . #available)
-                        (.> Quantity 0)
+                        (.> ApiAmount 0)
                     ]
 
             -- get fee
@@ -279,8 +279,8 @@ spec = describe "SHELLEY_CLI_HW_WALLETS" $ do
             err `shouldBe` cmdOk
             txJson <- expectValidJSON (Proxy @ApiFee) out
             verify txJson
-                [ expectCliField (#estimatedMin . #getQuantity) (.> 0)
-                , expectCliField (#estimatedMax . #getQuantity) (.> 0)
+                [ expectCliField (#estimatedMin) (.> ApiAmount 0)
+                , expectCliField (#estimatedMax) (.> ApiAmount 0)
                 ]
             code `shouldBe` ExitSuccess
 

--- a/lib/wallet/integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -31,6 +31,9 @@ import Cardano.Wallet.Api.Types
     , apiAddress
     , getApiT
     )
+import Cardano.Wallet.Api.Types.Amount
+    ( ApiAmount (ApiAmount)
+    )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId (..)
     )
@@ -65,9 +68,6 @@ import Data.Generics.Product.Typed
     )
 import Data.Proxy
     ( Proxy (..)
-    )
-import Data.Quantity
-    ( Quantity (..)
     )
 import Data.Text
     ( Text
@@ -214,9 +214,9 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
             [ expectCliField (#name . #getApiT . #getWalletName) (`shouldBe` "n")
             , expectCliField
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) (`shouldBe` 20)
-            , expectCliField (#balance . #available) (`shouldBe` Quantity 0)
-            , expectCliField (#balance . #total) (`shouldBe` Quantity 0)
-            , expectCliField (#balance . #reward) (`shouldBe` Quantity 0)
+            , expectCliField (#balance . #available) (`shouldBe` ApiAmount 0)
+            , expectCliField (#balance . #total) (`shouldBe` ApiAmount 0)
+            , expectCliField (#balance . #reward) (`shouldBe` ApiAmount 0)
             , expectCliField #delegation (`shouldBe` notDelegating [])
             , expectCliField #passphrase (`shouldNotBe` Nothing)
             ]
@@ -237,9 +237,9 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
         wDest <- expectValidJSON (Proxy @ApiWallet) o1
         verify wDest
             [ expectCliField
-                    (#balance . #available) (`shouldBe` Quantity 0)
+                    (#balance . #available) (`shouldBe` ApiAmount 0)
             , expectCliField
-                    (#balance . #total) (`shouldBe` Quantity 0)
+                    (#balance . #total) (`shouldBe` ApiAmount 0)
             ]
 
         --send transaction to the wallet
@@ -260,9 +260,9 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
             Stdout og <- getWalletViaCLI ctx $ T.unpack (wDest ^. walletId)
             jg <- expectValidJSON (Proxy @ApiWallet) og
             expectCliField (#balance . #available)
-                (`shouldBe` Quantity amount) jg
+                (`shouldBe` ApiAmount amount) jg
             expectCliField (#balance . #total)
-                (`shouldBe` Quantity amount) jg
+                (`shouldBe` ApiAmount amount) jg
 
         -- delete wallet
         Exit cd <- deleteWalletViaCLI ctx $ T.unpack (wDest ^. walletId)
@@ -284,9 +284,9 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
         justRestored <- expectValidJSON (Proxy @ApiWallet) o3
         verify justRestored
             [ expectCliField
-                    (#balance . #available) (`shouldBe` Quantity amount)
+                    (#balance . #available) (`shouldBe` ApiAmount amount)
             , expectCliField
-                    (#balance . #total) (`shouldBe` Quantity amount)
+                    (#balance . #total) (`shouldBe` ApiAmount amount)
             , expectCliField walletId (`shouldBe` wDest ^. walletId)
             ]
 
@@ -469,11 +469,11 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
             , expectCliField
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) (`shouldBe` 20)
             , expectCliField
-                    (#balance . #available) (`shouldBe` Quantity 0)
+                    (#balance . #available) (`shouldBe` ApiAmount 0)
             , expectCliField
-                    (#balance . #total) (`shouldBe` Quantity 0)
+                    (#balance . #total) (`shouldBe` ApiAmount 0)
             , expectCliField
-                    (#balance . #reward) (`shouldBe` Quantity 0)
+                    (#balance . #reward) (`shouldBe` ApiAmount 0)
             , expectCliField #delegation (`shouldBe` notDelegating [])
             , expectCliField #passphrase (`shouldNotBe` Nothing)
             ]
@@ -512,11 +512,11 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
             , expectCliListField 0
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) (`shouldBe` 21)
             , expectCliListField 0
-                    (#balance . #available) (`shouldBe` Quantity 0)
+                    (#balance . #available) (`shouldBe` ApiAmount 0)
             , expectCliListField 0
-                    (#balance . #total) (`shouldBe` Quantity 0)
+                    (#balance . #total) (`shouldBe` ApiAmount 0)
             , expectCliListField 0
-                    (#balance . #reward) (`shouldBe` Quantity 0)
+                    (#balance . #reward) (`shouldBe` ApiAmount 0)
             , expectCliListField 0 #delegation (`shouldBe` notDelegating [])
             , expectCliListField 0 walletId (`shouldBe` T.pack w1)
             ]
@@ -813,9 +813,9 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
             Stdout og <- getWalletViaCLI ctx $ T.unpack (wDest ^. walletId)
             jg <- expectValidJSON (Proxy @ApiWallet) og
             expectCliField (#balance . #available)
-                (`shouldBe` Quantity (fromIntegral $ sum coins)) jg
+                (`shouldBe` ApiAmount (sum coins)) jg
             expectCliField (#balance . #total)
-                (`shouldBe` Quantity (fromIntegral $ sum coins)) jg
+                (`shouldBe` ApiAmount (sum coins)) jg
 
         --verify utxo
         (Exit c, Stdout o, Stderr e) <-

--- a/lib/wallet/test/data/Cardano/Wallet/Api/ApiAmount.json
+++ b/lib/wallet/test/data/Cardano/Wallet/Api/ApiAmount.json
@@ -1,0 +1,45 @@
+{
+    "samples": [
+        {
+            "quantity": 23039438828441838,
+            "unit": "lovelace"
+        },
+        {
+            "quantity": 12970704496057804,
+            "unit": "lovelace"
+        },
+        {
+            "quantity": 41742315535650458,
+            "unit": "lovelace"
+        },
+        {
+            "quantity": 0,
+            "unit": "lovelace"
+        },
+        {
+            "quantity": 16084087917178796,
+            "unit": "lovelace"
+        },
+        {
+            "quantity": 34927768908128345,
+            "unit": "lovelace"
+        },
+        {
+            "quantity": 4004955618617285,
+            "unit": "lovelace"
+        },
+        {
+            "quantity": 505584857499610,
+            "unit": "lovelace"
+        },
+        {
+            "quantity": 37496733906414564,
+            "unit": "lovelace"
+        },
+        {
+            "quantity": 45000000000000000,
+            "unit": "lovelace"
+        }
+    ],
+    "seed": -429923947
+}

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -266,6 +266,9 @@ import Cardano.Wallet.Api.Types
     , XPubOrSelf (..)
     , toApiAsset
     )
+import Cardano.Wallet.Api.Types.Amount
+    ( ApiAmount
+    )
 import Cardano.Wallet.Api.Types.BlockHeader
     ( ApiBlockHeader
     )
@@ -636,6 +639,7 @@ import Test.QuickCheck
     , scale
     , shrinkBoundedEnum
     , shrinkIntegral
+    , shrinkMap
     , shrinkMapBy
     , sized
     , suchThat
@@ -682,6 +686,7 @@ import Web.HttpApiData
 
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Api.Types as Api
+import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
 import qualified Cardano.Wallet.Api.Types.WalletAssets as ApiWalletAssets
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
@@ -770,6 +775,7 @@ spec = do
         jsonTest @ApiAddressData
         jsonTest @ApiAsset
         jsonTest @ApiAssetMintBurn
+        jsonTest @ApiAmount
         jsonTest @ApiBase64
         jsonTest @ApiBlockReference
         jsonTest @ApiByronWallet
@@ -1180,6 +1186,10 @@ instance FromJSON SchemaApiErrorInfo where
 {-------------------------------------------------------------------------------
                               Arbitrary Instances
 -------------------------------------------------------------------------------}
+
+instance Arbitrary ApiAmount where
+    arbitrary = ApiAmount.fromCoin <$> arbitrary
+    shrink = shrinkMap ApiAmount.fromCoin ApiAmount.toCoin
 
 instance Arbitrary (ApiRewardAccount n)
     where

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -688,7 +688,6 @@ import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Api.Types as Api
 import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
 import qualified Cardano.Wallet.Api.Types.WalletAssets as ApiWalletAssets
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
@@ -2567,7 +2566,7 @@ instance Arbitrary ApiWalletUtxoSnapshot where
             adaValue2 <- genCoinPositive
             -- The actual ada quantity of an output's token bundle must be
             -- greater than or equal to the minimum permissible ada quantity:
-            let ada = Coin.toQuantity $ max adaValue1 adaValue2
+            let ada = ApiAmount.fromCoin $ max adaValue1 adaValue2
             assets <- ApiWalletAssets.fromTokenMap <$> genTokenMapSmallRange
             pure ApiWalletUtxoSnapshotEntry
                 { ada
@@ -2582,7 +2581,7 @@ instance Arbitrary ApiUtxoStatistics where
         let boundCountMap =
                 Map.fromList $ map (\(HistogramBar k v)-> (k,v)) histoBars
         return $ ApiUtxoStatistics
-            (Quantity $ fromIntegral stakes)
+            (ApiAmount.fromWord64 stakes)
             (ApiT bType)
             boundCountMap
 


### PR DESCRIPTION
## Motivation

This PR brings us one step closer to a world where:
- every type defined in the HTTP API specification (`swagger.yaml`) has an equivalent Haskell type within the `Api.Types` hierarchy.
- every type defined in the `Api.Types` hierarchy has `{To,FromJSON}` instances that are auto-generated using standard combinators.

## Description

This PR fixes an inconsistency with the HTTP API `amount` type:
- the HTTP API specification defines an [`amount`](https://github.com/cardano-foundation/cardano-wallet/blob/e8d8f6cc11ce843e29a4b9e3e01b71b121b520cf/specifications/api/swagger.yaml#L246) type, but the `Api.Types` hierarchy does not define its own equivalent Haskell type.
- the JSON encoding for the `amount` type is not defined (or directly tested) within the HTTP API layer itself.

To solve the above inconsistency, this PR:
- Creates a new Haskell type `ApiAmount` that:
    - corresponds directly to the [`amount`](https://github.com/cardano-foundation/cardano-wallet/blob/e8d8f6cc11ce843e29a4b9e3e01b71b121b520cf/specifications/api/swagger.yaml#L246) type in our OpenAPI specification.
    - has a golden test of its own.
    - has conversions to and from `Primitive.Types.Coin`.
- Uses `ApiAmount` to replace `Quantity "lovelace" Natural` in the API layer.

As a bonus, we can delete several functions within the `Primitive.Types.Coin` module that convert between `Coin` and `Quantity`.

## Future work

Ideally, the `Primitive.Types.Coin` module should not depend on the `Quantity` module in any way — the `Quantity` type essentially only exists for the purposes of the HTTP API, and should arguably be retired or absorbed into the `cardano-wallet-api-http` package.

## Issue

Follow-on from https://github.com/cardano-foundation/cardano-wallet/pull/4359.