### PR TITLE
Simplify `Arbitrary` instances in `Api.TypesSpec`.

### DIFF
--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -388,12 +388,8 @@ import Cardano.Wallet.Primitive.Types.TokenFingerprint
     ( TokenFingerprint
     , mkTokenFingerprint
     )
-import Cardano.Wallet.Primitive.Types.TokenMap
-    ( TokenMap
-    )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genTokenMapSmallRange
-    , shrinkTokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenMetadata
     ( AssetDecimals (..)
@@ -2528,10 +2524,6 @@ instance Arbitrary UTxO where
 instance Arbitrary TokenBundle where
     shrink = shrinkTokenBundleSmallRange
     arbitrary = genTokenBundleSmallRange
-
-instance Arbitrary TokenMap where
-    shrink = shrinkTokenMap
-    arbitrary = genTokenMapSmallRange
 
 instance Arbitrary TxOut where
     -- Shrink token bundle but not address

--- a/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -377,9 +377,6 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..)
     )
-import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( TokenBundle
-    )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange
     , shrinkTokenBundleSmallRange
@@ -2521,14 +2518,10 @@ instance Arbitrary UTxO where
             <*> vector n
         return $ UTxO $ Map.fromList utxo
 
-instance Arbitrary TokenBundle where
-    shrink = shrinkTokenBundleSmallRange
-    arbitrary = genTokenBundleSmallRange
-
 instance Arbitrary TxOut where
     -- Shrink token bundle but not address
-    shrink (TxOut a t) = TxOut a <$> shrink t
-    arbitrary = TxOut <$> arbitrary <*> arbitrary
+    shrink (TxOut a t) = TxOut a <$> shrinkTokenBundleSmallRange t
+    arbitrary = TxOut <$> arbitrary <*> genTokenBundleSmallRange
 
 instance Arbitrary TxIn where
     -- No Shrinking


### PR DESCRIPTION
## Description

This PR simplifies a pair of `Arbitrary` instances in `Api.TypesSpec`:

- The `Arbitrary` instance for `TokenMap` is unused, so it can be removed.
- The `Arbitrary` instance for `TokenBundle` is trivial and only used once, so it can be inlined.

## Issue

Follow-on from #4359.

