### PR TITLE
Invert dependency between `Quantity` and `Coin`.

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -3,8 +3,6 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK
@@ -23,7 +21,6 @@ module Cardano.Wallet.Primitive.Types.Coin
     , fromWord64
     , toInteger
     , toNatural
-    , toQuantity
     , toWord64Maybe
 
       -- * Conversions (Unsafe)
@@ -63,8 +60,7 @@ import Data.Hashable
     ( Hashable
     )
 import Data.IntCast
-    ( IsIntSubType
-    , intCast
+    ( intCast
     , intCastMaybe
     )
 import Data.List.NonEmpty
@@ -92,9 +88,6 @@ import Data.Monoid.Monus
     )
 import Data.Monoid.Null
     ( MonoidNull
-    )
-import Data.Quantity
-    ( Quantity (..)
     )
 import Data.Semigroup.Commutative
     ( Commutative
@@ -185,14 +178,6 @@ toInteger = intCast . unCoin
 --
 toNatural :: Coin -> Natural
 toNatural = unCoin
-
--- | Converts a 'Coin' to a 'Quantity'.
---
-toQuantity
-    :: (Integral i, IsIntSubType Natural i ~ 'True)
-    => Coin
-    -> Quantity "lovelace" i
-toQuantity (Coin c) = Quantity (intCast c)
 
 -- | Converts a 'Coin' to a 'Word64' value.
 --

--- a/lib/primitive/lib/Data/Quantity.hs
+++ b/lib/primitive/lib/Data/Quantity.hs
@@ -4,10 +4,11 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK
@@ -18,12 +19,16 @@
 -- bases depending on the context.
 
 module Data.Quantity
-    ( Quantity(..)
+    ( Quantity (..)
+    , fromCoin
     )
     where
 
 import Prelude
 
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (Coin)
+    )
 import Control.DeepSeq
     ( NFData
     )
@@ -44,6 +49,10 @@ import Data.Data
     )
 import Data.Hashable
     ( Hashable
+    )
+import Data.IntCast
+    ( IsIntSubType
+    , intCast
     )
 import Data.Proxy
     ( Proxy (..)
@@ -66,6 +75,9 @@ import GHC.TypeLits
     )
 import NoThunks.Class
     ( NoThunks (..)
+    )
+import Numeric.Natural
+    ( Natural
     )
 import Quiet
     ( Quiet (..)
@@ -140,3 +152,11 @@ instance (KnownSymbol unit, Buildable a) => Buildable (Quantity unit a) where
     build (Quantity a) = build a <> fmt " " <> build u
       where
         u = symbolVal (Proxy :: Proxy unit)
+
+-- | Constructs a 'Quantity` from a 'Coin'.
+--
+fromCoin
+    :: (Integral i, IsIntSubType Natural i ~ 'True)
+    => Coin
+    -> Quantity "lovelace" i
+fromCoin (Coin c) = Quantity (intCast c)

--- a/lib/wallet/src/Cardano/Wallet/Pools.hs
+++ b/lib/wallet/src/Cardano/Wallet/Pools.hs
@@ -294,12 +294,12 @@ import UnliftIO.STM
 import qualified Cardano.Pool.DB as PoolDb
 import qualified Cardano.Pool.DB.Layer as Pool
 import qualified Cardano.Wallet.Primitive.Types.Checkpoints.Policy as CP
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Merge.Strict as Map
 import qualified Data.Map.Strict as Map
 import qualified Data.Percentage as Percentage
+import qualified Data.Quantity as Quantity
 import qualified Data.Set as Set
 import qualified UnliftIO.STM as STM
 
@@ -551,14 +551,16 @@ combineDbAndLsqData ti nOpt lsqData =
                 { id = pid
                 , metrics =
                     StakePoolMetrics
-                        { nonMyopicMemberRewards = Coin.toQuantity prew
+                        { nonMyopicMemberRewards = Quantity.fromCoin prew
                         , relativeStake = Quantity pstk
                         , saturation = psat
                         , producedBlocks = (fmap fromIntegral . nProducedBlocks) dbData
                         }
                 , metadata = poolDbMetadata dbData
-                , cost = Coin.toQuantity $ poolCost $ registrationCert dbData
-                , pledge = Coin.toQuantity $ poolPledge $ registrationCert dbData
+                , cost = Quantity.fromCoin $
+                    poolCost $ registrationCert dbData
+                , pledge = Quantity.fromCoin $
+                    poolPledge $ registrationCert dbData
                 , margin = Quantity $ poolMargin $ registrationCert dbData
                 , retirement = retirementEpochInfo
                 , flags = [Delisted | delisted dbData]


### PR DESCRIPTION
## Description

This PR inverts the dependency between the `Quantity` and `Coin` modules, by moving a single function from the `Coin` module to the `Quantity` module:

```patch
- Coin.toQuantity
+ Quantity.fromCoin
```

This eliminates one obstacle to moving the `Quantity` module to a more suitable location.

## Motivation

We use the `Quantity` type mainly to specify the types of values allowable through FFI boundaries (such as the HTTP API and the CLI), and how to serialise such values. It provides a convenient way to specify a "maximum width". For example:

```hs
-- Specifies a quantity of lovelace that fits within a 64-bit word
Quantity "lovelace" Word64
```

Conceptually, the `Coin` module is not concerned with FFI boundaries or serialisation logic, and ought not to depend on modules that do.