### PR TITLE
Use consistent naming for key witness counts.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -45,7 +45,7 @@ module Internal.Cardano.Write.Tx
     , RecentEraConstraints
 
     -- ** Key witness counts
-    , KeyWitnessCount (..)
+    , KeyWitnessCounts (..)
 
     -- ** Helpers for cardano-api compatibility
     , cardanoEra
@@ -479,7 +479,7 @@ fromAnyCardanoEra = \case
 -- Key witness counts
 --------------------------------------------------------------------------------
 
-data KeyWitnessCount = KeyWitnessCount
+data KeyWitnessCounts = KeyWitnessCounts
     { nKeyWits :: !Word
     -- ^ "Normal" verification key witnesses introduced with the Shelley era.
 
@@ -487,12 +487,12 @@ data KeyWitnessCount = KeyWitnessCount
     -- ^ Bootstrap key witnesses, a.k.a Byron witnesses.
     } deriving (Eq, Show)
 
-instance Semigroup KeyWitnessCount where
-    KeyWitnessCount s1 b1 <> KeyWitnessCount s2 b2
-        = KeyWitnessCount (s1 + s2) (b1 + b2)
+instance Semigroup KeyWitnessCounts where
+    KeyWitnessCounts s1 b1 <> KeyWitnessCounts s2 b2
+        = KeyWitnessCounts (s1 + s2) (b1 + b2)
 
-instance Monoid KeyWitnessCount where
-    mempty = KeyWitnessCount 0 0
+instance Monoid KeyWitnessCounts where
+    mempty = KeyWitnessCounts 0 0
 
 --------------------------------------------------------------------------------
 -- TxIn
@@ -790,12 +790,12 @@ evaluateMinimumFee
     :: IsRecentEra era
     => PParams era
     -> Core.Tx era
-    -> KeyWitnessCount
+    -> KeyWitnessCounts
     -> Coin
 evaluateMinimumFee pp tx kwc =
     mainFee <> bootWitnessFee
   where
-    KeyWitnessCount {nKeyWits, nBootstrapWits} = kwc
+    KeyWitnessCounts {nKeyWits, nBootstrapWits} = kwc
 
     mainFee :: Coin
     mainFee = Shelley.evaluateTransactionFee pp tx nKeyWits

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -488,7 +488,7 @@ data KeyWitnessCount = KeyWitnessCount
     } deriving (Eq, Show)
 
 instance Semigroup KeyWitnessCount where
-    (KeyWitnessCount s1 b1) <> (KeyWitnessCount s2 b2)
+    KeyWitnessCount s1 b1 <> KeyWitnessCount s2 b2
         = KeyWitnessCount (s1 + s2) (b1 + b2)
 
 instance Monoid KeyWitnessCount where

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -252,7 +252,7 @@ import Internal.Cardano.Write.Tx.Redeemers
     )
 import Internal.Cardano.Write.Tx.Sign
     ( TimelockKeyWitnessCounts (..)
-    , estimateKeyWitnessCount
+    , estimateKeyWitnessCounts
     , estimateSignedTxSize
     )
 import Internal.Cardano.Write.Tx.SizeEstimation
@@ -860,7 +860,10 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         -> ExceptT (ErrBalanceTx era) m (Value, Coin, KeyWitnessCounts)
     balanceAfterSettingMinFee tx = ExceptT . pure $ do
         let witCount =
-                estimateKeyWitnessCount combinedUTxO tx timelockKeyWitnessCounts
+                estimateKeyWitnessCounts
+                    combinedUTxO
+                    tx
+                    timelockKeyWitnessCounts
             minfee = Convert.toWalletCoin $ evaluateMinimumFee pp tx witCount
             update = TxUpdate [] [] [] [] (UseNewTxFee minfee)
         tx' <- left updateTxErrorToBalanceTxError $ updateTx tx update

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -207,7 +207,7 @@ import Internal.Cardano.Write.Tx
     , Coin (..)
     , FeePerByte (..)
     , IsRecentEra (..)
-    , KeyWitnessCount (..)
+    , KeyWitnessCounts (..)
     , PParams
     , PolicyId
     , RecentEra (..)
@@ -385,7 +385,7 @@ data ErrBalanceTxAssetsInsufficientError = ErrBalanceTxAssetsInsufficientError
     deriving (Eq, Generic, Show)
 
 data ErrBalanceTxInternalError era
-    = ErrUnderestimatedFee Coin (Tx era) KeyWitnessCount
+    = ErrUnderestimatedFee Coin (Tx era) KeyWitnessCounts
     | ErrFailedBalancing Value
 
 deriving instance IsRecentEra era => Eq (ErrBalanceTxInternalError era)
@@ -830,7 +830,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             Set.toList $ tx ^. (bodyTxL . inputsTxBodyL)
 
     guardTxSize
-        :: KeyWitnessCount
+        :: KeyWitnessCounts
         -> Tx era
         -> ExceptT (ErrBalanceTx era) m (Tx era)
     guardTxSize witCount tx = do
@@ -857,7 +857,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 
     balanceAfterSettingMinFee
         :: Tx era
-        -> ExceptT (ErrBalanceTx era) m (Value, Coin, KeyWitnessCount)
+        -> ExceptT (ErrBalanceTx era) m (Value, Coin, KeyWitnessCounts)
     balanceAfterSettingMinFee tx = ExceptT . pure $ do
         let witCount =
                 estimateKeyWitnessCount combinedUTxO tx timelockKeyWitnessCounts

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -19,7 +19,7 @@ module Internal.Cardano.Write.Tx.Sign
     -- * Signing-related utilities required for balancing
       estimateSignedTxSize
 
-    , KeyWitnessCount (..)
+    , KeyWitnessCounts (..)
     , TimelockKeyWitnessCounts (..)
     , estimateKeyWitnessCount
 
@@ -73,7 +73,7 @@ import Data.Set
     )
 import Internal.Cardano.Write.Tx
     ( IsRecentEra (..)
-    , KeyWitnessCount (..)
+    , KeyWitnessCounts (..)
     , PParams
     , Script
     , Tx
@@ -108,7 +108,7 @@ import qualified Internal.Cardano.Write.Tx as Write
 estimateSignedTxSize
     :: forall era. IsRecentEra era
     => PParams era
-    -> KeyWitnessCount
+    -> KeyWitnessCounts
     -> Tx era -- ^ existing wits in tx are ignored
     -> W.TxSize
 estimateSignedTxSize pparams nWits txWithWits =
@@ -150,7 +150,7 @@ estimateSignedTxSize pparams nWits txWithWits =
     coinQuotRem :: W.Coin -> W.Coin -> (Natural, Natural)
     coinQuotRem (W.Coin p) (W.Coin q) = quotRem p q
 
-    minfee :: KeyWitnessCount -> W.Coin
+    minfee :: KeyWitnessCounts -> W.Coin
     minfee witCount = Convert.toWalletCoin $ Write.evaluateMinimumFee
         pparams unsignedTx witCount
 
@@ -158,8 +158,8 @@ estimateSignedTxSize pparams nWits txWithWits =
     feePerByte = Convert.toWalletCoin $
         pparams ^. ppMinFeeAL
 
-numberOfShelleyWitnesses :: Word -> KeyWitnessCount
-numberOfShelleyWitnesses n = KeyWitnessCount n 0
+numberOfShelleyWitnesses :: Word -> KeyWitnessCounts
+numberOfShelleyWitnesses n = KeyWitnessCounts n 0
 
 -- | Estimates the required number of Shelley-era witnesses.
 --
@@ -187,7 +187,7 @@ estimateKeyWitnessCount
     --
     -- Timelock scripts without entries in this map will have their key witness
     -- counts estimated according to 'estimateMaxWitnessRequiredPerInput'.
-    -> KeyWitnessCount
+    -> KeyWitnessCounts
 estimateKeyWitnessCount utxo tx timelockKeyWitCounts =
     let txIns = map fst $ CardanoApi.txIns txbodycontent
         txInsCollateral =
@@ -223,7 +223,7 @@ estimateKeyWitnessCount utxo tx timelockKeyWitCounts =
             txUpdateProposal' +
             fromIntegral txCerts +
             fromIntegral timelockTotalWitCount
-        inputWits = KeyWitnessCount
+        inputWits = KeyWitnessCounts
             { nKeyWits = fromIntegral
                 . length
                 $ filter (not . hasBootstrapAddr utxo) vkInsUnique

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -21,7 +21,7 @@ module Internal.Cardano.Write.Tx.Sign
 
     , KeyWitnessCounts (..)
     , TimelockKeyWitnessCounts (..)
-    , estimateKeyWitnessCount
+    , estimateKeyWitnessCounts
 
     , estimateMaxWitnessRequiredPerInput
     , estimateMinWitnessRequiredPerInput
@@ -175,11 +175,11 @@ numberOfShelleyWitnesses n = KeyWitnessCounts n 0
 --
 -- NOTE: Similar to 'estimateTransactionKeyWitnessCount' from cardano-api, which
 -- we cannot use because it requires a 'TxBodyContent BuildTx era'.
-estimateKeyWitnessCount
+estimateKeyWitnessCounts
     :: forall era. IsRecentEra era
     => UTxO era
     -- ^ Must contain all inputs from the 'TxBody' or
-    -- 'estimateKeyWitnessCount will 'error'.
+    -- 'estimateKeyWitnessCounts will 'error'.
     -> Tx era
     -> TimelockKeyWitnessCounts
     -- ^ Specifying the intended number of timelock script key witnesses may
@@ -188,7 +188,7 @@ estimateKeyWitnessCount
     -- Timelock scripts without entries in this map will have their key witness
     -- counts estimated according to 'estimateMaxWitnessRequiredPerInput'.
     -> KeyWitnessCounts
-estimateKeyWitnessCount utxo tx timelockKeyWitCounts =
+estimateKeyWitnessCounts utxo tx timelockKeyWitCounts =
     let txIns = map fst $ CardanoApi.txIns txbodycontent
         txInsCollateral =
             case CardanoApi.txInsCollateral txbodycontent of

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -299,7 +299,7 @@ import Internal.Cardano.Write.Tx.Balance
     , updateTx
     )
 import Internal.Cardano.Write.Tx.Sign
-    ( KeyWitnessCount (..)
+    ( KeyWitnessCounts (..)
     , estimateKeyWitnessCount
     , estimateSignedTxSize
     )
@@ -525,7 +525,7 @@ spec_balanceTransaction = describe "balanceTransaction" $ do
                 $ Write.evaluateMinimumFee
                     pp
                     (withNoKeyWits tx)
-                    (KeyWitnessCount 0 (fromIntegral $ length wits))
+                    (KeyWitnessCounts 0 (fromIntegral $ length wits))
               where
                 wits = tx ^. witsTxL . bootAddrTxWitsL
 

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -300,7 +300,7 @@ import Internal.Cardano.Write.Tx.Balance
     )
 import Internal.Cardano.Write.Tx.Sign
     ( KeyWitnessCounts (..)
-    , estimateKeyWitnessCount
+    , estimateKeyWitnessCounts
     , estimateSignedTxSize
     )
 import Internal.Cardano.Write.Tx.SizeEstimation
@@ -943,7 +943,7 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
     minFee tx u =
         Write.evaluateMinimumFee mockPParamsForBalancing
             tx
-            (estimateKeyWitnessCount u tx mempty)
+            (estimateKeyWitnessCounts u tx mempty)
 
 spec_distributeSurplus :: Spec
 spec_distributeSurplus = describe "distributeSurplus" $ do
@@ -1109,7 +1109,7 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
         -> IO ()
     test _name bs tx = do
         let pparams = mockPParamsForBalancing @era
-            witCount dummyAddr = estimateKeyWitnessCount
+            witCount dummyAddr = estimateKeyWitnessCounts
                 (utxoPromisingInputsHaveAddress dummyAddr tx)
                 tx
                 mempty
@@ -1513,7 +1513,7 @@ prop_balanceTransactionValid
     prop_validSize tx utxo = do
         let (W.TxSize size) =
                 estimateSignedTxSize ledgerPParams
-                    (estimateKeyWitnessCount
+                    (estimateKeyWitnessCounts
                         utxo
                         tx
                         (timelockKeyWitnessCounts partialTx))
@@ -1567,7 +1567,7 @@ prop_balanceTransactionValid
     minFee tx utxo =
         Write.evaluateMinimumFee ledgerPParams
             tx
-            (estimateKeyWitnessCount utxo tx
+            (estimateKeyWitnessCounts utxo tx
                 (timelockKeyWitnessCounts partialTx))
 
     txBalance

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -167,7 +167,7 @@ import Fmt
     , pretty
     )
 import Internal.Cardano.Write.Tx.Sign
-    ( KeyWitnessCount (..)
+    ( KeyWitnessCounts (..)
     )
 import Network.HTTP.Media
     ( renderHeader
@@ -619,7 +619,7 @@ instance
                 , pretty (toWalletCoin coin), "and cannot finish balancing."
                 ]
           where
-            KeyWitnessCount nWits nBootWits = keyWitnessCounts
+            KeyWitnessCounts nWits nBootWits = keyWitnessCounts
             info = ApiErrorBalanceTxUnderestimatedFee
                 { underestimation = ApiAmount.fromCoin $ toWalletCoin coin
                 , candidateTxHex = hexText $ Write.serializeTx @era candidateTx

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -613,13 +613,13 @@ instance
     Write.IsRecentEra era => IsServerError (ErrBalanceTxInternalError era)
   where
     toServerError = \case
-        ErrUnderestimatedFee coin candidateTx (KeyWitnessCount nWits nBootWits) ->
+        ErrUnderestimatedFee coin candidateTx keyWitnessCounts ->
             apiError err500 (BalanceTxUnderestimatedFee info) $ T.unwords
                 [ "I have somehow underestimated the fee of the transaction by"
                 , pretty (toWalletCoin coin), "and cannot finish balancing."
                 ]
-
           where
+            KeyWitnessCount nWits nBootWits = keyWitnessCounts
             info = ApiErrorBalanceTxUnderestimatedFee
                 { underestimation = ApiAmount.fromCoin $ toWalletCoin coin
                 , candidateTxHex = hexText $ Write.serializeTx @era candidateTx


### PR DESCRIPTION
## Issue

Follow-up from #4337.

## Description

This PR performs the following renamings:
```patch
-         KeyWitnessCount  (data type)
- estimateKeyWitnessCount  (function name)
+         KeyWitnessCounts (data type)
+ estimateKeyWitnessCounts (function name)
```