### PR TITLE
Expect `no_utxos_available` instead of `not_enough_money`.

### DIFF
--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -2877,7 +2877,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
         pools = SHELLEY.stake_pools
         fees = pools.delegation_fees(id)
         expect(fees).to be_correct_and_respond 403
-        expect(fees.to_s).to include 'not_enough_money'
+        expect(fees.to_s).to include 'no_utxos_available'
       end
 
       it 'I could join Stake Pool - if I had enough to cover fee' do
@@ -2887,7 +2887,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
 
         join = pools.join(pool_id, id, PASS)
         expect(join).to be_correct_and_respond 403
-        expect(join.to_s).to include 'not_enough_money'
+        expect(join.to_s).to include 'no_utxos_available'
       end
 
       it 'Can list stake pools only when stake is provided' do


### PR DESCRIPTION
## Summary

This PR attempts to fix the end-to-end tests.

## Details

If the wallet is asked to create a transaction in a situation where there are no UTxOs available, then the wallet will return a `no_utxos_available` error instead of a `not_enough_money` error.

See:
- #4366 
- https://github.com/cardano-foundation/cardano-wallet/actions/runs/7294574003/job/19879662240#step:12:906

## Issue

ADP-3248
