### PR TITLE
Test that an empty wallet can't join a stake pool (no_utxos_available)

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -688,14 +688,19 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                     )
 
         externalSelectedUtxo <- extractExternallySelectedUTxO ptx
+        let utxoSelection =
+                UTxOSelection.fromIndexPair
+                    (internalUtxoAvailable, externalSelectedUtxo)
+
+        when (UTxOSelection.availableSize utxoSelection == 0) $
+            throwE ErrBalanceTxUnableToCreateInput
 
         let mSel = selectAssets
                 pp
                 utxoAssumptions
                 (F.toList $ partialTx ^. bodyTxL . outputsTxBodyL)
                 redeemers
-                (UTxOSelection.fromIndexPair
-                    (internalUtxoAvailable, externalSelectedUtxo))
+                utxoSelection
                 balance0
                 (Convert.toWalletCoin minfee0)
                 randomSeed

--- a/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
@@ -693,7 +693,7 @@ expectErrorMessage
     -> m ()
 expectErrorMessage want = either expectation wantedErrorButSuccess . snd
   where
-    expectation msg = fmt msg `shouldContain` want
+    expectation exception = fmt exception `shouldContain` want
     fmt = \case
         DecodeFailure res msg -> msg ++ "\n" ++ BL8.unpack res
         ClientError val       -> BL8.unpack $ Aeson.encode val

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -138,6 +138,7 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: haskell-nix.cabalProject' [
           pkgconfig
           nixpkgs-recent.python3Packages.openapi-spec-validator
           (ruby_3_1.withPackages (ps: [ ps.rake ps.thor ]))
+          rubyPackages_3_1.rubocop
           sqlite-interactive
           curlFull
           jq

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -125,7 +125,7 @@ One can run specific tests using by providing `SPEC` or `SPEC_OPTS` arguments to
  ```
   - run only `non-e2e` tests on downloaded binaries and don't wait for node to be synced
  ```ruby
- $ rake run_on[preprod,bins,no-sync] SPEC_OPTS="-t ~e2e"
+ $ rake run_on[preprod,no-sync] SPEC_OPTS="-t ~e2e"
  ```
   - run only tests matching specific string
  ```ruby

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -131,7 +131,7 @@ One can run specific tests using by providing `SPEC` or `SPEC_OPTS` arguments to
  ```ruby
  $ rake run_on[preprod] SPEC_OPTS="-e 'CardanoWallet::Shelley::Wallets'"
  ```
-  - run only specific test identified by line of test code against node and wallet from the `$PATH` (skips downloading from Hydra)
+  - run only specific test identified by line of test code against node and wallet from the `$PATH` (skips downloading from CI)
  ```ruby
  $ TESTS_E2E_BINDIR="" rake run_on[preprod] SPEC=spec/shelley_spec.rb:9
  ```

--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -367,30 +367,34 @@ end
 ##
 # Setup utility task getting node and wallet binaries, configs and decoding fixtures
 # so it is ready to start
-task :setup, [:env, :branch, :skip_configs] do |_task, args|
+task :setup, [:env, :branch, :skip_bins, :skip_configs] do |_task, args|
   log '>> Getting latest binaries and configs and decoding fixtures...'
   env = args[:env]
   branch = args[:branch] || 'master'
-  skip_configs = args[:skip_configs] || nil
 
-  if BINS == ''
+  if args[:skip_bins]
     log '>> Skipping getting latest binaries. Will test wallet and node from $PATH.'
   else
     Rake::Task[:get_latest_bins].invoke(branch)
   end
-  Rake::Task[:get_latest_configs].invoke(env) unless skip_configs
+
+  if args[:skip_configs]
+    log '>> Skipping getting latest configs.'
+  else
+    Rake::Task[:get_latest_configs].invoke(env)
+  end
+
   Rake::Task[:secrets_decode].invoke
 end
 
-task :run_on, [:env, :sync_strategy, :skip_configs, :branch] do |_task, args|
+task :run_on, [:env, :sync_strategy, :skip_bins, :skip_configs, :branch] do |_task, args|
   log '>> Setting up env and running tests...'
   log "TESTS_E2E_STATEDIR=#{STATE}"
   env = args[:env]
-  skip_configs = args[:skip_configs]
   sync_strategy = args[:sync_strategy] || :sync
   branch = args[:branch] || nil
 
-  Rake::Task[:setup].invoke(env, branch, skip_configs)
+  Rake::Task[:setup].invoke(env, branch, args[:skip_bins], args[:skip_configs])
   Rake::Task[:display_versions].invoke
   Rake::Task[:start_node_and_wallet].invoke(env)
 

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -2880,16 +2880,6 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
         expect(fees.to_s).to include 'no_utxos_available'
       end
 
-      it 'I could join Stake Pool - if I had enough to cover fee' do
-        id = create_shelley_wallet
-        pools = SHELLEY.stake_pools
-        pool_id = pools.list({ stake: 1000 })[0]['id']
-
-        join = pools.join(pool_id, id, PASS)
-        expect(join).to be_correct_and_respond 403
-        expect(join.to_s).to include 'no_utxos_available'
-      end
-
       it 'Can list stake pools only when stake is provided' do
         pools = SHELLEY.stake_pools
         l = pools.list({ stake: 1000 })


### PR DESCRIPTION
- [x] Opportunistically improved some code and docs (`chore:` commits)
- [x] Replicated E2E test which verifies that an empty wallet can't join a stake pool (no_utxos_available) at the level of local cluster integration.
- [x] Removed original E2E integration test that was running against the preprod in favour of the test created for the local cluster integration.
- [x] Fixed the original problem by 1) requiring a non-empty UTxO selection for balancing; 2) Failing explicitly with the `no_utxos_available` before trying to balance tx;

### Issue Number

ADP-3250