### PR TITLE
Fix remaining E2E tests (s/not_enough_money/no_utxos_available/)

### DIFF
--- a/test/e2e/spec/byron_spec.rb
+++ b/test/e2e/spec/byron_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe CardanoWallet::Byron, :all, :byron do
       rnd = BYRON.coin_selections.random wid, addr_amount
 
       expect(rnd).to be_correct_and_respond 403
-      expect(rnd.to_s).to include 'not_enough_money'
+      expect(rnd.to_s).to include 'no_utxos_available'
     end
   end
 
@@ -288,7 +288,7 @@ RSpec.describe CardanoWallet::Byron, :all, :byron do
 
         tx_sent = BYRON.transactions.create(id, PASS, [{ target_addr => 1_000_000 }])
         expect(tx_sent).to be_correct_and_respond 403
-        expect(tx_sent.to_s).to include 'not_enough_money'
+        expect(tx_sent.to_s).to include 'no_utxos_available'
       end
 
       it "I could estimate fees if I had money - #{style}" do
@@ -298,7 +298,7 @@ RSpec.describe CardanoWallet::Byron, :all, :byron do
 
         fees = BYRON.transactions.payment_fees(id, [{ target_addr => 1_000_000 }])
         expect(fees).to be_correct_and_respond 403
-        expect(fees.to_s).to include 'not_enough_money'
+        expect(fees.to_s).to include 'no_utxos_available'
       end
 
       it "I could forget transaction - #{style}" do

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -371,7 +371,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
       payload = get_plutus_tx 'ping-pong_1.json'
       tx_balanced = SHELLEY.transactions.balance(wid, payload)
       expect(tx_balanced).to be_correct_and_respond 403
-      expect(tx_balanced.to_s).to include 'not_enough_money'
+      expect(tx_balanced.to_s).to include 'no_utxos_available'
     end
 
     it 'ping-pong' do
@@ -3067,7 +3067,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
 
         rnd = SHELLEY.coin_selections.random_deleg wid, action_join
         expect(rnd).to be_correct_and_respond 403
-        expect(rnd.to_s).to include 'not_enough_money'
+        expect(rnd.to_s).to include 'no_utxos_available'
       end
 
       it 'I could trigger random coin selection delegation action - if I known pool id' do

--- a/test/e2e/spec/shelley_spec.rb
+++ b/test/e2e/spec/shelley_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe CardanoWallet::Shelley, :all, :shelley do
 
       rnd = SHELLEY.coin_selections.random wid, addr_amount
       expect(rnd).to be_correct_and_respond 403
-      expect(rnd.to_s).to include 'not_enough_money'
+      expect(rnd.to_s).to include 'no_utxos_available'
     end
   end
 
@@ -335,7 +335,7 @@ RSpec.describe CardanoWallet::Shelley, :all, :shelley do
 
       tx_sent = txs.create(id, PASS, amt)
       expect(tx_sent).to be_correct_and_respond 403
-      expect(tx_sent.to_s).to include 'not_enough_money'
+      expect(tx_sent.to_s).to include 'no_utxos_available'
     end
 
     it 'I could create transaction using rewards - if I had money' do
@@ -347,7 +347,7 @@ RSpec.describe CardanoWallet::Shelley, :all, :shelley do
 
       tx_sent = txs.create(id, PASS, amt, 'self')
       expect(tx_sent).to be_correct_and_respond 403
-      expect(tx_sent.to_s).to include 'not_enough_money'
+      expect(tx_sent.to_s).to include 'no_utxos_available'
     end
 
     it 'I could estimate transaction fee - if I had money' do
@@ -360,11 +360,11 @@ RSpec.describe CardanoWallet::Shelley, :all, :shelley do
 
       fees = txs.payment_fees(id, amt)
       expect(fees).to be_correct_and_respond 403
-      expect(fees.to_s).to include 'not_enough_money'
+      expect(fees.to_s).to include 'no_utxos_available'
 
       fees = txs.payment_fees(id, amt, 'self')
       expect(fees).to be_correct_and_respond 403
-      expect(fees.to_s).to include 'not_enough_money'
+      expect(fees.to_s).to include 'no_utxos_available'
 
       metadata = { '0' => { 'string' => 'cardano' },
                    '1' => { 'int' => 14 },
@@ -375,7 +375,7 @@ RSpec.describe CardanoWallet::Shelley, :all, :shelley do
 
       fees = txs.payment_fees(id, amt, 'self', metadata)
       expect(fees).to be_correct_and_respond 403
-      expect(fees.to_s).to include 'not_enough_money'
+      expect(fees.to_s).to include 'no_utxos_available'
     end
 
     it 'I could forget transaction' do


### PR DESCRIPTION
I have updated E2E to expect `no_utxos_available` error code instead of the `not_enough_money` where it makes sense.

### Issue Number

ADP-3249
