### PR TITLE
[ADP-3252] Add logs directory option to wallet e2e executable

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,8 +2,8 @@ default:
   @just --list
 
 # check that the code is formatted with stylish-haskell
-check target="stylish":
-  ./.buildkite/check-{{target}}.sh
+check:
+  ./.buildkite/check-code-format.sh
 
 # build wallet-e2e suite with cabal
 build:
@@ -36,15 +36,16 @@ integration:
 # run wallet-e2e suite against the preprod network
 e2e-preprod:
   nix run '.#cardano-wallet-e2e' -- preprod \
-    -s lib/wallet-e2e/test-state \
+    -s lib/wallet-e2e/test-state/preprod \
     -c lib/wallet-e2e/config/cardano-node/preprod
 
 # run wallet-e2e suite against the local test cluster
 e2e-local:
   nix shell \
-    '.#local-cluster' '.#cardano-node' '.#cardano-wallet' '.#cardano-wallet-e2e' '.#local-cluster' \
-    -c wallet-e2e local -s lib/wallet-e2e/test-state -c lib/local-cluster/test/data/cluster-configs
-
+    '.#local-cluster' '.#cardano-node' '.#cardano-wallet' '.#cardano-wallet-e2e' \
+    -c wallet-e2e local \
+    -s lib/wallet-e2e/test-state/local \
+    -c lib/local-cluster/test/data/cluster-configs
 # run wallet-e2e suite against the manually started node/wallet
 e2e-manual:
   nix run '.#cardano-wallet-e2e' -- manual

--- a/justfile
+++ b/justfile
@@ -37,7 +37,9 @@ integration:
 e2e-preprod:
   nix run '.#cardano-wallet-e2e' -- preprod \
     -s lib/wallet-e2e/test-state/preprod \
-    -c lib/wallet-e2e/config/cardano-node/preprod
+    -c lib/wallet-e2e/config/cardano-node/preprod \
+    -t lib/wallet-e2e/test-output/preprod
+
 
 # run wallet-e2e suite against the local test cluster
 e2e-local:
@@ -45,7 +47,9 @@ e2e-local:
     '.#local-cluster' '.#cardano-node' '.#cardano-wallet' '.#cardano-wallet-e2e' \
     -c wallet-e2e local \
     -s lib/wallet-e2e/test-state/local \
-    -c lib/local-cluster/test/data/cluster-configs
+    -c lib/local-cluster/test/data/cluster-configs \
+    -t lib/wallet-e2e/test-output/local
+
 # run wallet-e2e suite against the manually started node/wallet
 e2e-manual:
   nix run '.#cardano-wallet-e2e' -- manual

--- a/lib/wallet-e2e/cardano-wallet-e2e.cabal
+++ b/lib/wallet-e2e/cardano-wallet-e2e.cabal
@@ -118,6 +118,7 @@ executable wallet-e2e
   hs-source-dirs: exe
   main-is:        Main.hs
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
+  other-modules: Options
   build-depends:
     , base                         ^>=4.14.3.0
     , cardano-wallet-e2e

--- a/lib/wallet-e2e/cardano-wallet-e2e.cabal
+++ b/lib/wallet-e2e/cardano-wallet-e2e.cabal
@@ -101,6 +101,7 @@ library
     Cardano.Wallet.Spec.Interpreters.Config
     Cardano.Wallet.Spec.Interpreters.Effectfully
     Cardano.Wallet.Spec.Interpreters.Pure
+    Cardano.Wallet.Spec.Lib.Paths
     Cardano.Wallet.Spec.Network.Configured
     Cardano.Wallet.Spec.Network.Local
     Cardano.Wallet.Spec.Network.Manual

--- a/lib/wallet-e2e/cardano-wallet-e2e.cabal
+++ b/lib/wallet-e2e/cardano-wallet-e2e.cabal
@@ -98,6 +98,7 @@ library
     Cardano.Wallet.Spec.Effect.Random
     Cardano.Wallet.Spec.Effect.Timeout
     Cardano.Wallet.Spec.Effect.Trace
+    Cardano.Wallet.Spec.Interpreters.Config
     Cardano.Wallet.Spec.Interpreters.Effectfully
     Cardano.Wallet.Spec.Interpreters.Pure
     Cardano.Wallet.Spec.Network.Configured

--- a/lib/wallet-e2e/exe/Main.hs
+++ b/lib/wallet-e2e/exe/Main.hs
@@ -1,161 +1,23 @@
 module Main where
 
-import qualified Options.Applicative as OptParse
 import qualified Test.Syd.OptParse as SydTest
 
 import Cardano.Wallet.Spec
-    ( TestNetworkConfig (..)
-    , effectsSpec
+    ( effectsSpec
     , walletSpec
-    )
-import Cardano.Wallet.Spec.Interpreters.Config
-    ( TraceConfiguration (..)
-    )
-import Cardano.Wallet.Spec.Lib.Paths
-    ( SomeDirOf
-    , makeDirAbsolute
-    )
-import Data.Tagged
-    ( Tagged (..)
     )
 import Main.Utf8
     ( withUtf8
     )
-import Options.Applicative
-    ( Parser
-    , eitherReader
-    , execParser
-    , fullDesc
-    , help
-    , helper
-    , info
-    , long
-    , metavar
-    , option
-    , progDesc
-    , short
-    )
-import Path
-    ( parseSomeDir
+import Options
+    ( withTestOptions
     )
 import Test.Syd
     ( sydTestWith
     )
 
 main :: IO ()
-main = withUtf8 do
-    TestOptions{..} :: TestOptions <-
-        execParser
-            $ info
-                (parserTestOptions <**> helper)
-                (fullDesc <> progDesc "E2E Wallet test suite")
-    testNetwork <- testNetworkOptionsToConfig testNetworkOptions
-    traceConfiguration <- do
-        absTraceDir <-
-            makeDirAbsolute
-                $ testGlobalOptionsTraceOutput testGlobalOptions
-        pure $ TraceConfiguration absTraceDir
+main = withUtf8 $ withTestOptions $ \testNetwork traceConfiguration ->
     sydTestWith SydTest.defaultSettings{SydTest.settingRetries = 1} do
         effectsSpec
         walletSpec traceConfiguration testNetwork
-
-parserTestOptions :: Parser TestOptions
-parserTestOptions = TestOptions <$> parserNetworkOptions <*> parserGlobalOptions
-
---------------------------------------------------------------------------------
--- Command line options --------------------------------------------------------
-
-data TestOptions = TestOptions
-    { testNetworkOptions :: TestNetworkOptions
-    , testGlobalOptions :: TestGlobalOptions
-    }
-
-newtype TestGlobalOptions = TestGlobalOptions
-    { testGlobalOptionsTraceOutput :: SomeDirOf "tracing-dir"
-    }
-
-parserGlobalOptions :: Parser TestGlobalOptions
-parserGlobalOptions = TestGlobalOptions <$> traceOutputOption
-  where
-    traceOutputOption :: Parser (SomeDirOf "tracing-dir") =
-        option
-            (eitherReader (bimap show Tagged . parseSomeDir))
-            ( long "tracing-dir"
-                <> short 't'
-                <> metavar "TRACE_OUTPUT_DIR"
-                <> help
-                    "Absolute or relative directory path to save trace output"
-            )
-
-data TestNetworkOptions
-    = TestNetworkOptionManual
-    | TestNetworkOptionLocal (SomeDirOf "state") (SomeDirOf "config")
-    | TestNetworkOptionPreprod (SomeDirOf "state") (SomeDirOf "config")
-
-testNetworkOptionsToConfig :: TestNetworkOptions -> IO TestNetworkConfig
-testNetworkOptionsToConfig = \case
-    TestNetworkOptionManual ->
-        pure TestNetworkManual
-    TestNetworkOptionLocal stateDir nodeConfigsDir -> do
-        absStateDir <- makeDirAbsolute stateDir
-        absNodeConfigsDir <- makeDirAbsolute nodeConfigsDir
-        pure (TestNetworkLocal absStateDir absNodeConfigsDir)
-    TestNetworkOptionPreprod stateDir nodeConfigsDir -> do
-        absStateDir <- makeDirAbsolute stateDir
-        absNodeConfigsDir <- makeDirAbsolute nodeConfigsDir
-        pure (TestNetworkPreprod absStateDir absNodeConfigsDir)
-
-parserNetworkOptions :: Parser TestNetworkOptions
-parserNetworkOptions = OptParse.subparser $ cmdManual <> cmdLocal <> cmdPreprod
-  where
-    cmdManual =
-        OptParse.command
-            "manual"
-            ( OptParse.info
-                (pure TestNetworkOptionManual)
-                ( OptParse.progDesc
-                    "Relies on a node and wallet started manually."
-                )
-            )
-    cmdLocal =
-        OptParse.command
-            "local"
-            ( OptParse.info
-                ( TestNetworkOptionLocal
-                    <$> stateDirOption
-                    <*> nodeConfigsDirOption
-                )
-                (OptParse.progDesc "Automatically starts a local test cluster.")
-            )
-    cmdPreprod =
-        OptParse.command
-            "preprod"
-            ( OptParse.info
-                ( TestNetworkOptionPreprod
-                    <$> stateDirOption
-                    <*> nodeConfigsDirOption
-                )
-                ( OptParse.progDesc
-                    "Automatically starts a preprod node and wallet."
-                )
-            )
-    stateDirOption :: Parser (SomeDirOf "state") =
-        option
-            (eitherReader (bimap show Tagged . parseSomeDir))
-            ( long "state-dir"
-                <> short 's'
-                <> metavar "STATE_DIR"
-                <> help
-                    "Absolute or relative directory path \
-                    \ to save node and wallet state"
-            )
-    nodeConfigsDirOption :: Parser (SomeDirOf "config") =
-        option
-            (eitherReader (bimap show Tagged . parseSomeDir))
-            ( long "node-configs-dir"
-                <> short 'c'
-                <> metavar "NODE_CONFIGS_DIR"
-                <> help
-                    "Absolute or relative directory path \
-                    \ to a directory with node configs"
-            )

--- a/lib/wallet-e2e/exe/Options.hs
+++ b/lib/wallet-e2e/exe/Options.hs
@@ -1,0 +1,142 @@
+module Options where
+
+import qualified Options.Applicative as OptParse
+
+import Cardano.Wallet.Spec
+    ( TestNetworkConfig (..)
+    )
+import Cardano.Wallet.Spec.Interpreters.Config
+    ( TraceConfiguration (..)
+    )
+import Cardano.Wallet.Spec.Lib.Paths
+    ( SomeDirOf
+    , makeDirAbsolute
+    )
+import Data.Tagged
+    ( Tagged (..)
+    )
+import Options.Applicative
+    ( Parser
+    , eitherReader
+    , help
+    , long
+    , metavar
+    , option
+    , short
+    )
+import Path
+    ( parseSomeDir
+    )
+
+withTestOptions :: (TestNetworkConfig -> TraceConfiguration -> IO b) -> IO b
+withTestOptions action = do
+    TestOptions{..} :: TestOptions <-
+        OptParse.execParser
+            $ OptParse.info
+                (parserTestOptions OptParse.<**> OptParse.helper)
+                (OptParse.fullDesc <> OptParse.progDesc "E2E Wallet test suite")
+    testNetwork <- testNetworkOptionsToConfig testNetworkOptions
+    traceConfiguration <- do
+        absTraceDir <-
+            makeDirAbsolute
+                $ testGlobalOptionsTraceOutput testGlobalOptions
+        pure $ TraceConfiguration absTraceDir
+    action testNetwork traceConfiguration
+
+parserTestOptions :: Parser TestOptions
+parserTestOptions = TestOptions <$> parserNetworkOptions <*> parserGlobalOptions
+
+data TestOptions = TestOptions
+    { testNetworkOptions :: TestNetworkOptions
+    , testGlobalOptions :: TestGlobalOptions
+    }
+
+newtype TestGlobalOptions = TestGlobalOptions
+    { testGlobalOptionsTraceOutput :: SomeDirOf "tracing-dir"
+    }
+
+parserGlobalOptions :: Parser TestGlobalOptions
+parserGlobalOptions = TestGlobalOptions <$> traceOutputOption
+  where
+    traceOutputOption :: Parser (SomeDirOf "tracing-dir") =
+        option
+            (eitherReader (bimap show Tagged . parseSomeDir))
+            ( long "tracing-dir"
+                <> short 't'
+                <> metavar "TRACE_OUTPUT_DIR"
+                <> help
+                    "Absolute or relative directory path to save trace output"
+            )
+
+data TestNetworkOptions
+    = TestNetworkOptionManual
+    | TestNetworkOptionLocal (SomeDirOf "state") (SomeDirOf "config")
+    | TestNetworkOptionPreprod (SomeDirOf "state") (SomeDirOf "config")
+
+testNetworkOptionsToConfig :: TestNetworkOptions -> IO TestNetworkConfig
+testNetworkOptionsToConfig = \case
+    TestNetworkOptionManual ->
+        pure TestNetworkManual
+    TestNetworkOptionLocal stateDir nodeConfigsDir -> do
+        absStateDir <- makeDirAbsolute stateDir
+        absNodeConfigsDir <- makeDirAbsolute nodeConfigsDir
+        pure (TestNetworkLocal absStateDir absNodeConfigsDir)
+    TestNetworkOptionPreprod stateDir nodeConfigsDir -> do
+        absStateDir <- makeDirAbsolute stateDir
+        absNodeConfigsDir <- makeDirAbsolute nodeConfigsDir
+        pure (TestNetworkPreprod absStateDir absNodeConfigsDir)
+
+parserNetworkOptions :: Parser TestNetworkOptions
+parserNetworkOptions = OptParse.subparser $ cmdManual <> cmdLocal <> cmdPreprod
+  where
+    cmdManual =
+        OptParse.command
+            "manual"
+            ( OptParse.info
+                (pure TestNetworkOptionManual)
+                ( OptParse.progDesc
+                    "Relies on a node and wallet started manually."
+                )
+            )
+    cmdLocal =
+        OptParse.command
+            "local"
+            ( OptParse.info
+                ( TestNetworkOptionLocal
+                    <$> stateDirOption
+                    <*> nodeConfigsDirOption
+                )
+                (OptParse.progDesc "Automatically starts a local test cluster.")
+            )
+    cmdPreprod =
+        OptParse.command
+            "preprod"
+            ( OptParse.info
+                ( TestNetworkOptionPreprod
+                    <$> stateDirOption
+                    <*> nodeConfigsDirOption
+                )
+                ( OptParse.progDesc
+                    "Automatically starts a preprod node and wallet."
+                )
+            )
+    stateDirOption :: Parser (SomeDirOf "state") =
+        option
+            (eitherReader (bimap show Tagged . parseSomeDir))
+            ( long "state-dir"
+                <> short 's'
+                <> metavar "STATE_DIR"
+                <> help
+                    "Absolute or relative directory path \
+                    \ to save node and wallet state"
+            )
+    nodeConfigsDirOption :: Parser (SomeDirOf "config") =
+        option
+            (eitherReader (bimap show Tagged . parseSomeDir))
+            ( long "node-configs-dir"
+                <> short 'c'
+                <> metavar "NODE_CONFIGS_DIR"
+                <> help
+                    "Absolute or relative directory path \
+                    \ to a directory with node configs"
+            )

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec.hs
@@ -8,6 +8,9 @@ import qualified Cardano.Wallet.Spec.Network.Local as Local
 import qualified Cardano.Wallet.Spec.Network.Manual as Manual
 import qualified Cardano.Wallet.Spec.Network.Preprod as Preprod
 
+import Cardano.Wallet.Spec.Interpreters.Config
+    ( TraceConfiguration
+    )
 import Cardano.Wallet.Spec.Interpreters.Effectfully
     ( story
     )
@@ -40,12 +43,24 @@ import Test.Syd
     , sequential
     )
 
-walletSpec :: TestNetworkConfig -> Spec
-walletSpec config = aroundAll (configureTestNet config) do
-    describe "Wallet Backend API" $ sequential do
-        story "Created wallet is listed" createdWalletListed
-        story "Created wallet can be retrieved by id" createdWalletRetrievable
-        story "Created wallet has zero ADA balance" createdWalletHasZeroAda
+walletSpec :: TraceConfiguration -> TestNetworkConfig -> Spec
+walletSpec tracingConfig config =
+    aroundAll (configureTracing tracingConfig)
+        $ aroundAll (configureTestNet config)
+        $ do
+            describe "Wallet Backend API" $ sequential do
+                story
+                    "Created wallet is listed"
+                    createdWalletListed
+                story
+                    "Created wallet can be retrieved by id"
+                    createdWalletRetrievable
+                story
+                    "Created wallet has zero ADA balance"
+                    createdWalletHasZeroAda
+
+configureTracing :: TraceConfiguration -> (TraceConfiguration -> IO ()) -> IO ()
+configureTracing config f = f config
 
 effectsSpec :: Spec
 effectsSpec = describe "Effect interpreters" do

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec.hs
@@ -14,6 +14,9 @@ import Cardano.Wallet.Spec.Interpreters.Config
 import Cardano.Wallet.Spec.Interpreters.Effectfully
     ( story
     )
+import Cardano.Wallet.Spec.Lib.Paths
+    ( DirOf
+    )
 import Cardano.Wallet.Spec.Network.Configured
     ( ConfiguredNetwork
     )
@@ -27,14 +30,6 @@ import Cardano.Wallet.Spec.TimeoutSpec
     )
 import Control.Monad.Trans.Resource
     ( runResourceT
-    )
-import Data.Tagged
-    ( Tagged
-    )
-import Path
-    ( Abs
-    , Dir
-    , Path
     )
 import Test.Syd
     ( Spec
@@ -71,12 +66,8 @@ effectsSpec = describe "Effect interpreters" do
 
 data TestNetworkConfig
     = TestNetworkManual
-    | TestNetworkLocal
-        (Tagged "state" (Path Abs Dir))
-        (Tagged "config" (Path Abs Dir))
-    | TestNetworkPreprod
-        (Tagged "state" (Path Abs Dir))
-        (Tagged "config" (Path Abs Dir))
+    | TestNetworkLocal (DirOf "state") (DirOf "config")
+    | TestNetworkPreprod (DirOf "state") (DirOf "config")
 
 configureTestNet :: TestNetworkConfig -> (ConfiguredNetwork -> IO ()) -> IO ()
 configureTestNet testNetworkConfig withConfiguredNetwork = runResourceT $ do

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Trace.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec/Effect/Trace.hs
@@ -5,8 +5,14 @@ module Cardano.Wallet.Spec.Effect.Trace where
 
 import qualified Data.Sequence as Seq
 
+import Cardano.Wallet.Spec.Interpreters.Config
+    ( TraceConfiguration (..)
+    )
 import Data.Sequence
     ( (|>)
+    )
+import Data.Tagged
+    ( Tagged (..)
     )
 import Effectful
     ( Eff
@@ -24,13 +30,11 @@ import Effectful.TH
     )
 import Path
     ( parseRelFile
-    , reldir
     , toFilePath
     , (</>)
     )
 import Path.IO
     ( ensureDir
-    , getCurrentDir
     )
 import Prelude hiding
     ( modify
@@ -47,13 +51,11 @@ runTracePure :: Eff (FxTrace : es) a -> Eff es (a, Seq Text)
 runTracePure = reinterpret (runState Seq.empty) \_ (Trace msg) ->
     modify (|> msg)
 
-recordTraceLog :: String -> Seq Text -> IO ()
-recordTraceLog storyLabel log = do
-    cwd <- getCurrentDir
-    let outDir = cwd </> [reldir|test-output|]
+recordTraceLog :: TraceConfiguration -> String -> Seq Text -> IO ()
+recordTraceLog (TraceConfiguration (Tagged outDir)) storyLabel log = do
     ensureDir outDir
     fileName <-
         parseRelFile
-            ([if c == ' ' then '_' else c | c <- storyLabel] <> ".log")
+            $ [if c == ' ' then '_' else c | c <- storyLabel] <> ".log"
     let outFile = outDir </> fileName
     writeFile (toFilePath outFile) $ toString $ unlines $ toList log

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec/Interpreters/Config.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec/Interpreters/Config.hs
@@ -1,0 +1,14 @@
+module Cardano.Wallet.Spec.Interpreters.Config where
+
+import Data.Tagged
+    ( Tagged
+    )
+import Path
+    ( Abs
+    , Dir
+    , Path
+    )
+
+newtype TraceConfiguration = TraceConfiguration
+    { traceConfigurationDir :: Tagged "tracing-dir" (Path Abs Dir)
+    }

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec/Interpreters/Config.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec/Interpreters/Config.hs
@@ -1,14 +1,9 @@
 module Cardano.Wallet.Spec.Interpreters.Config where
 
-import Data.Tagged
-    ( Tagged
-    )
-import Path
-    ( Abs
-    , Dir
-    , Path
+import Cardano.Wallet.Spec.Lib.Paths
+    ( DirOf
     )
 
 newtype TraceConfiguration = TraceConfiguration
-    { traceConfigurationDir :: Tagged "tracing-dir" (Path Abs Dir)
+    { traceConfigurationDir :: DirOf "tracing-dir"
     }

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec/Lib/Paths.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec/Lib/Paths.hs
@@ -1,0 +1,26 @@
+module Cardano.Wallet.Spec.Lib.Paths where
+
+import Data.Tagged
+    ( Tagged (..)
+    , untag
+    )
+import Path
+    ( Abs
+    , Dir
+    , Path
+    , SomeBase (..)
+    )
+import Path.IO
+    ( AnyPath (..)
+    )
+
+type DirOf x = Tagged x (Path Abs Dir)
+type SomeDirOf x = Tagged x (SomeBase Dir)
+
+makeDirAbsolute :: SomeDirOf x -> IO (DirOf x)
+makeDirAbsolute = fmap Tagged . makeAbsolute' . untag
+
+makeAbsolute' :: SomeBase Dir -> IO (Path Abs Dir)
+makeAbsolute' = \case
+    Abs absDir -> pure absDir
+    Rel relDir -> makeAbsolute relDir

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec/Network/Config.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec/Network/Config.hs
@@ -1,7 +1,0 @@
-module Cardano.Wallet.Spec.Network.Config where
-
-import Cardano.Wallet.Cli.Launcher
-    ( WalletApi
-    )
-
-newtype NetworkConfig = NetworkConfig {networkConfigWallet :: WalletApi}

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec/Network/Local.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec/Network/Local.hs
@@ -9,6 +9,9 @@ import qualified Cardano.Wallet.Spec.Network.Wait as Wait
 import Cardano.Wallet.Cli.Launcher
     ( WalletApi (..)
     )
+import Cardano.Wallet.Spec.Lib.Paths
+    ( DirOf
+    )
 import Cardano.Wallet.Spec.Network.Configured
     ( ConfiguredNetwork (..)
     )
@@ -17,14 +20,10 @@ import Control.Monad.Trans.Resource
     , allocate
     )
 import Data.Tagged
-    ( Tagged
-    , untag
+    ( untag
     )
 import Path
-    ( Abs
-    , Dir
-    , Path
-    , relfile
+    ( relfile
     , toFilePath
     , (</>)
     )
@@ -42,8 +41,8 @@ import System.Process.Typed
     )
 
 configuredNetwork
-    :: Tagged "state" (Path Abs Dir)
-    -> Tagged "config" (Path Abs Dir)
+    :: DirOf "state"
+    -> DirOf "config"
     -> ResourceT IO ConfiguredNetwork
 configuredNetwork stateDir clusterConfigsDir = do
     walletApi <- startCluster

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec/Network/Preprod.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec/Network/Preprod.hs
@@ -14,6 +14,9 @@ import Cardano.Node.Cli.Launcher
 import Cardano.Wallet.Cli.Launcher
     ( WalletProcessConfig (..)
     )
+import Cardano.Wallet.Spec.Lib.Paths
+    ( DirOf
+    )
 import Cardano.Wallet.Spec.Network.Configured
     ( ConfiguredNetwork (..)
     )
@@ -22,21 +25,17 @@ import Control.Monad.Trans.Resource
     , allocate
     )
 import Data.Tagged
-    ( Tagged
-    , untag
+    ( untag
     )
 import Path
-    ( Abs
-    , Dir
-    , Path
-    , reldir
+    ( reldir
     , relfile
     , (</>)
     )
 
 configuredNetwork
-    :: Tagged "state" (Path Abs Dir)
-    -> Tagged "config" (Path Abs Dir)
+    :: DirOf "state"
+    -> DirOf "config"
     -> ResourceT IO ConfiguredNetwork
 configuredNetwork stateDir nodeConfigDir = do
     nodeApi <- startNode

--- a/lib/wallet-e2e/test-state/.gitignore
+++ b/lib/wallet-e2e/test-state/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/lib/wallet-e2e/test-state/local/.gitignore
+++ b/lib/wallet-e2e/test-state/local/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/lib/wallet-e2e/test-state/preprod/.gitignore
+++ b/lib/wallet-e2e/test-state/preprod/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
- [x] add an option to control where test trace logs are written
- [x] update justfile to use the new option 
- [x] refactor code for less duplication 

ADP-3252