### PR TITLE
Add property test for `ErrBalanceTxUnableToCreateInput`.

### DIFF
--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2102,11 +2102,11 @@ newtype SuccessOrFailure a = SuccessOrFailure a
 
 instance Arbitrary (Success (BalanceTxArgs Write.BabbageEra)) where
     arbitrary = coerce genBalanceTxArgsForSuccess
-    shrink = coerce shrinkBalanceTxArgs
+    shrink = coerce shrinkBalanceTxArgsForSuccessOrFailure
 
 instance Arbitrary (SuccessOrFailure (BalanceTxArgs Write.BabbageEra)) where
     arbitrary = coerce genBalanceTxArgsForSuccessOrFailure
-    shrink = coerce shrinkBalanceTxArgs
+    shrink = coerce shrinkBalanceTxArgsForSuccessOrFailure
 
 genBalanceTxArgsForSuccess
     :: forall era. era ~ Write.BabbageEra
@@ -2132,11 +2132,11 @@ genBalanceTxArgsForSuccessOrFailure =
     genProtocolParams = pure mockPParamsForBalancing
     genTimeTranslation = pure dummyTimeTranslation
 
-shrinkBalanceTxArgs
+shrinkBalanceTxArgsForSuccessOrFailure
     :: forall era. era ~ Write.BabbageEra
     => BalanceTxArgs era
     -> [BalanceTxArgs era]
-shrinkBalanceTxArgs =
+shrinkBalanceTxArgsForSuccessOrFailure =
     genericRoundRobinShrink
         <@> shrinkProtocolParams
         <:> shrinkTimeTranslation

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1307,12 +1307,11 @@ spec_updateTx = describe "updateTx" $ do
 
 prop_balanceTransactionExistingReturnCollateral
     :: forall era. (era ~ BabbageEra)
-    => Wallet
-    -> ShowBuildable (PartialTx era)
-    -> StdGenSeed
+    => SuccessOrFailure (BalanceTxArgs era)
     -> Property
 prop_balanceTransactionExistingReturnCollateral
-    wallet (ShowBuildable partialTx@PartialTx{tx}) seed = withMaxSuccess 10 $
+    (SuccessOrFailure (BalanceTxArgs {wallet, partialTx, seed})) =
+        withMaxSuccess 10 $
         hasReturnCollateral @era tx
             && not (hasInsCollateral @era tx)
             && not (hasTotalCollateral @era tx) ==>
@@ -1321,6 +1320,7 @@ prop_balanceTransactionExistingReturnCollateral
             e -> counterexample (show e) False
   where
     pp = mockPParamsForBalancing
+    PartialTx {tx} = partialTx
 
 prop_balanceTransactionExistingTotalCollateral
     :: forall era. (era ~ BabbageEra)

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE EmptyCase #-}
@@ -241,6 +242,9 @@ import Fmt
     , fmt
     , nameF
     , pretty
+    )
+import GHC.Generics
+    ( Generic
     )
 import GHC.Stack
     ( HasCallStack
@@ -2051,6 +2055,19 @@ prop_splitSignedValue_mergeSignedValue (MixedSign v) =
     & cover 10
         (valueHasNegativeAndPositiveParts v)
         "valueHasNegativeAndPositiveParts v"
+
+--------------------------------------------------------------------------------
+-- Arguments for balanceTx
+--------------------------------------------------------------------------------
+
+-- | A set of arguments for the 'balanceTx' function.
+--
+data BalanceTxArgs era = BalanceTxArgs
+    { wallet :: !Wallet
+    , partialTx :: !(PartialTx era)
+    , seed :: !StdGenSeed
+    }
+    deriving stock Generic
 
 --------------------------------------------------------------------------------
 -- Utility types

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2080,6 +2080,16 @@ data BalanceTxArgs era = BalanceTxArgs
     }
     deriving stock (Generic, Show)
 
+-- | Applies the 'balanceTx' function to the given arguments.
+--
+applyBalanceTxArgs
+    :: IsRecentEra era
+    => BalanceTxArgs era
+    -> Either (ErrBalanceTx era) (Tx era)
+applyBalanceTxArgs
+    BalanceTxArgs {protocolParams, timeTranslation, wallet, partialTx, seed} =
+        balanceTx wallet protocolParams timeTranslation seed partialTx
+
 -- | A set of arguments that will always lead to success.
 --
 newtype Success a = Success a

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2118,6 +2118,14 @@ genBalanceTxArgsForSuccess =
     `suchThat`
     (isRight . applyBalanceTxArgs)
 
+shrinkBalanceTxArgsForSuccess
+    :: forall era. era ~ Write.BabbageEra
+    => BalanceTxArgs era
+    -> [BalanceTxArgs era]
+shrinkBalanceTxArgsForSuccess
+    = filter (isRight . applyBalanceTxArgs)
+    . shrinkBalanceTxArgsForSuccessOrFailure
+
 genBalanceTxArgsForSuccessOrFailure
     :: forall era. era ~ Write.BabbageEra
     => Gen (BalanceTxArgs era)

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2114,18 +2114,9 @@ genBalanceTxArgsForSuccess
 genBalanceTxArgsForSuccess =
     -- For the moment, we use the brute force tactic of repeatedly generating
     -- arguments until we have a set of arguments that leads to success:
-    genBalanceTxArgsForSuccessOrFailure `suchThat` producesSuccess
-  where
-    producesSuccess :: BalanceTxArgs era -> Bool
-    producesSuccess
-        BalanceTxArgs
-            {protocolParams, timeTranslation, wallet, partialTx, seed} =
-        isRight $ balanceTx
-            wallet
-            protocolParams
-            timeTranslation
-            seed
-            partialTx
+    genBalanceTxArgsForSuccessOrFailure
+    `suchThat`
+    (isRight . applyBalanceTxArgs)
 
 genBalanceTxArgsForSuccessOrFailure
     :: forall era. era ~ Write.BabbageEra

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1390,13 +1390,12 @@ prop_balanceTransactionValid
     :: forall era. era ~ Write.BabbageEra
     -- TODO [ADP-2997] Test with all RecentEras
     -- https://cardanofoundation.atlassian.net/browse/ADP-2997
-    => Wallet
-    -> ShowBuildable (PartialTx Write.BabbageEra)
-    -> StdGenSeed
+    => SuccessOrFailure (BalanceTxArgs era)
     -> Property
 prop_balanceTransactionValid
-    wallet@(Wallet _ walletUTxO _) (ShowBuildable partialTx) seed =
+    (SuccessOrFailure (BalanceTxArgs {wallet, partialTx, seed})) =
         withMaxSuccess 1_000 $ do
+        let Wallet _ walletUTxO _ = wallet
         let combinedUTxO =
                 view #inputs partialTx
                 <> fromWalletUTxO walletUTxO

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1316,14 +1316,12 @@ prop_balanceTransactionExistingReturnCollateral
         hasReturnCollateral @era tx
             && not (hasInsCollateral @era tx)
             && not (hasTotalCollateral @era tx) ==>
-        let result = balanceTx
-                wallet protocolParams dummyTimeTranslation seed partialTx
-        in
-        case result of
+        case balanceTx wallet protocolParams timeTranslation seed partialTx of
             Left err -> ErrBalanceTxExistingReturnCollateral === err
             e -> counterexample (show e) False
   where
-    BalanceTxArgs {protocolParams, wallet, partialTx, seed} = balanceTxArgs
+    BalanceTxArgs {protocolParams, timeTranslation, wallet, partialTx, seed} =
+        balanceTxArgs
     PartialTx {tx} = partialTx
 
 prop_balanceTransactionExistingTotalCollateral
@@ -1336,14 +1334,12 @@ prop_balanceTransactionExistingTotalCollateral
         hasTotalCollateral @era tx
             && not (hasInsCollateral @era tx)
             && not (hasReturnCollateral @era tx) ==>
-        let result = balanceTx
-                wallet protocolParams dummyTimeTranslation seed partialTx
-        in
-        case result of
+        case balanceTx wallet protocolParams timeTranslation seed partialTx of
             Left err -> ErrBalanceTxExistingTotalCollateral === err
             e -> counterexample (show e) False
   where
-    BalanceTxArgs {protocolParams, wallet, partialTx, seed} = balanceTxArgs
+    BalanceTxArgs {protocolParams, timeTranslation, wallet, partialTx, seed} =
+        balanceTxArgs
     PartialTx {tx} = partialTx
 
 -- If 'balanceTx' is able to balance a transaction, then repeating the attempt
@@ -1369,13 +1365,14 @@ prop_balanceTransactionUnableToCreateInput
         balanceTx
             (eraseWalletUTxOSet wallet)
             protocolParams
-            dummyTimeTranslation
+            timeTranslation
             seed
             (erasePartialTxInputList partialTx)
         ===
         Left ErrBalanceTxUnableToCreateInput
   where
-    BalanceTxArgs {protocolParams, wallet, partialTx, seed} = balanceTxArgs
+    BalanceTxArgs {protocolParams, timeTranslation, wallet, partialTx, seed} =
+        balanceTxArgs
 
     erasePartialTxInputList :: PartialTx era -> PartialTx era
     erasePartialTxInputList = over #tx (set (bodyTxL . inputsTxBodyL) mempty)
@@ -1424,7 +1421,7 @@ prop_balanceTransactionValid
                 balanceTx
                     wallet
                     protocolParams
-                    dummyTimeTranslation
+                    timeTranslation
                     seed
                     partialTx
         classifications $ case res of
@@ -1528,7 +1525,7 @@ prop_balanceTransactionValid
             Left err -> label "other error" $
                 counterexample ("balanceTransaction failed: " <> show err) False
   where
-    BalanceTxArgs {protocolParams, wallet, partialTx, seed} =
+    BalanceTxArgs {protocolParams, timeTranslation, wallet, partialTx, seed} =
         balanceTxArgs
     Wallet _ walletUTxO _ = wallet
 

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2102,7 +2102,7 @@ newtype SuccessOrFailure a = SuccessOrFailure a
 
 instance Arbitrary (Success (BalanceTxArgs Write.BabbageEra)) where
     arbitrary = coerce genBalanceTxArgsForSuccess
-    shrink = coerce shrinkBalanceTxArgsForSuccessOrFailure
+    shrink = coerce shrinkBalanceTxArgsForSuccess
 
 instance Arbitrary (SuccessOrFailure (BalanceTxArgs Write.BabbageEra)) where
     arbitrary = coerce genBalanceTxArgsForSuccessOrFailure

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1575,13 +1575,13 @@ prop_balanceTransactionValid
         -> Property
     prop_validSize tx utxo = do
         let (W.TxSize size) =
-                estimateSignedTxSize ledgerPParams
+                estimateSignedTxSize protocolParams
                     (estimateKeyWitnessCounts
                         utxo
                         tx
                         (timelockKeyWitnessCounts partialTx))
                     tx
-        let limit = ledgerPParams ^. ppMaxTxSizeL
+        let limit = protocolParams ^. ppMaxTxSizeL
         let msg = unwords
                 [ "The tx size "
                 , show size
@@ -1600,7 +1600,7 @@ prop_balanceTransactionValid
       where
         valid :: TxOut era -> Property
         valid out = counterexample msg $ property $
-            not $ Write.isBelowMinimumCoinForTxOut ledgerPParams out
+            not $ Write.isBelowMinimumCoinForTxOut protocolParams out
           where
             msg = unwords
                 [ "ada quantity is"
@@ -1610,11 +1610,9 @@ prop_balanceTransactionValid
                 , "\n"
                 , "Suggested ada quantity (may overestimate requirement):"
                 , show $ Write.computeMinimumCoinForTxOut
-                    ledgerPParams
+                    protocolParams
                     out
                 ]
-
-    ledgerPParams = protocolParams
 
     hasZeroAdaOutputs :: Tx era -> Bool
     hasZeroAdaOutputs tx =
@@ -1628,7 +1626,7 @@ prop_balanceTransactionValid
         -> UTxO era
         -> Coin
     minFee tx utxo =
-        Write.evaluateMinimumFee ledgerPParams
+        Write.evaluateMinimumFee protocolParams
             tx
             (estimateKeyWitnessCounts utxo tx
                 (timelockKeyWitnessCounts partialTx))
@@ -1639,7 +1637,7 @@ prop_balanceTransactionValid
         -> Value
     txBalance tx u =
         Write.evaluateTransactionBalance
-            ledgerPParams
+            protocolParams
             u
             (tx ^. bodyTxL)
 


### PR DESCRIPTION
## Issue

Follow-on from #4379

## Description

This PR adds a test for the `ErrBalanceTxUnableToCreateInput` failure condition.

In addition, this PR also:
- adds a `BalanceTxArgs` record type to hold arguments for the `balanceTx` function.
- adds a pair of combinators for `BalanceTxArgs`:
    - `Success`
      for arguments that will always produce a balanced transaction.
    - `SuccessOrFailure`
      for arguments that will sometimes produce a balanced transaction but sometimes result in failure.
- uses these combinators to simplify the arguments for `balanceTx` properties.