### PR TITLE
[ADP-3239] Remove `/cache` from nightly benchmark

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -24,8 +24,6 @@ steps:
 
   - label: 'Restore benchmark - cardano mainnet'
     command: "./.buildkite/bench-restore.sh mainnet"
-    env:
-      HOME: "/cache/cardano-wallet.home"
     timeout_in_minutes: 1200
     agents:
       system: x86_64-linux


### PR DESCRIPTION
This pull requests removes any mention of the `/cache` directory from the nightly benchmark pipeline.

The `/cache` directory was symlinked to `/tmp`, which got cleaned up during a system update. This may not have been the right solution in the first place.

### Issue number

None. Found after system update.
