### PR TITLE
Clarify semantics of UTxO consistency check in `balanceTx`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -472,8 +472,7 @@ instance IsRecentEra era => Buildable (PartialTx era)
         txF tx' = pretty $ pShow tx'
 
 data UTxOIndex era = UTxOIndex
-    { walletUTxO :: !W.UTxO
-    , walletUTxOIndex :: !(UTxOIndex.UTxOIndex WalletUTxO)
+    { walletUTxOIndex :: !(UTxOIndex.UTxOIndex WalletUTxO)
     , ledgerUTxO :: !(UTxO era)
     }
 
@@ -482,7 +481,7 @@ constructUTxOIndex
     => UTxO era
     -> UTxOIndex era
 constructUTxOIndex ledgerUTxO =
-    UTxOIndex {walletUTxO, walletUTxOIndex, ledgerUTxO}
+    UTxOIndex {walletUTxOIndex, ledgerUTxO}
   where
     walletUTxO = toWalletUTxO ledgerUTxO
     walletUTxOIndex = UTxOIndex.fromMap $ toInternalUTxOMap walletUTxO
@@ -646,7 +645,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     pp
     timeTranslation
     utxoAssumptions
-    (UTxOIndex _walletUTxO internalUtxoAvailable walletLedgerUTxO)
+    (UTxOIndex internalUtxoAvailable walletLedgerUTxO)
     genChange
     s
     selectionStrategy

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -321,6 +321,7 @@ import qualified Cardano.Wallet.Primitive.Types.UTxO as W
     ( UTxO (..)
     )
 import qualified Data.Foldable as F
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
 import qualified Data.Map.Strict.Extra as Map
 import qualified Data.Sequence.Strict as StrictSeq
@@ -885,9 +886,9 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         :: UTxO era
         -> ExceptT (ErrBalanceTx era) m ()
     guardWalletUTxOConsistencyWith u =
-        case F.toList (conflicts u walletLedgerUTxO) of
-            (c : cs) -> throwE $ ErrBalanceTxInputResolutionConflicts (c :| cs)
-            [] -> return ()
+        case NE.nonEmpty (F.toList (conflicts u walletLedgerUTxO)) of
+            Just cs -> throwE $ ErrBalanceTxInputResolutionConflicts cs
+            Nothing -> return ()
       where
         conflicts :: UTxO era -> UTxO era -> Map TxIn (TxOut era, TxOut era)
         conflicts = Map.conflictsWith ((/=) `on` toWalletTxOut era) `on` unUTxO

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -876,16 +876,11 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             minfee' = Convert.toLedgerCoin minfee
         return (balance, minfee', witCount)
 
-    -- | Ensure the wallet UTxO is consistent with a provided @CardanoApi.UTxO@.
+    -- | Ensures the wallet UTxO set is consistent with the given UTxO set.
     --
     -- They are not consistent iff an input can be looked up in both UTxO sets
     -- with different @Address@, or @TokenBundle@ values.
     --
-    -- The @CardanoApi.UTxO era@ is allowed to contain additional information,
-    -- like datum hashes, which the wallet UTxO cannot represent.
-    --
-    -- NOTE: Representing the wallet utxo as a @CardanoApi.UTxO@ will not make
-    -- this check easier, even if it may be useful in other regards.
     guardWalletUTxOConsistencyWith
         :: UTxO era
         -> ExceptT (ErrBalanceTx era) m ()

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -483,8 +483,8 @@ constructUTxOIndex
 constructUTxOIndex ledgerUTxO =
     UTxOIndex {walletUTxOIndex, ledgerUTxO}
   where
-    walletUTxO = toWalletUTxO ledgerUTxO
-    walletUTxOIndex = UTxOIndex.fromMap $ toInternalUTxOMap walletUTxO
+    walletUTxOIndex =
+        UTxOIndex.fromMap $ toInternalUTxOMap $ toWalletUTxO ledgerUTxO
 
 fromWalletUTxO
     :: forall era. IsRecentEra era

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -212,6 +212,7 @@ library
     Cardano.Wallet.Util
     Control.Monad.Random.NonRandom
     Data.Aeson.Extra
+    Data.Map.Strict.Extra
     Data.Percentage
     Data.Quantity
 
@@ -256,6 +257,7 @@ test-suite test
     , quickcheck-classes
     , quickcheck-instances
     , quickcheck-monoid-subclasses
+    , quickcheck-quid
     , string-qq
     , text
     , text-class
@@ -283,6 +285,7 @@ test-suite test
     Cardano.Wallet.Primitive.Types.TokenQuantitySpec
     Cardano.Wallet.Primitive.Types.TxSpec
     Cardano.Wallet.Primitive.Types.UTxOSpec
+    Data.Map.Strict.ExtraSpec
     Data.PercentageSpec
     Data.QuantitySpec
     Spec

--- a/lib/primitive/lib/Data/Map/Strict/Extra.hs
+++ b/lib/primitive/lib/Data/Map/Strict/Extra.hs
@@ -1,0 +1,61 @@
+-- |
+-- Copyright: © 2023 Cardano Foundation
+--
+-- Extra functions for the strict 'Map' type.
+--
+module Data.Map.Strict.Extra
+    ( conflicts
+    , conflictsWith
+    ) where
+
+import Prelude
+
+import Data.Map.Merge.Strict
+    ( dropMissing
+    , merge
+    , zipWithMaybeMatched
+    )
+import Data.Map.Strict
+    ( Map
+    )
+
+-- | Generates the map of all conflicts between a pair of maps.
+--
+-- Equivalent to 'conflictsWith' '/='.
+--
+conflicts :: (Ord k, Eq v) => Map k v -> Map k v -> Map k (v, v)
+conflicts = conflictsWith (/=)
+
+-- | Generates the map of all conflicts between a pair of maps, for the given
+--   conflict indicator function.
+--
+-- For a given conflict indicator function 'f', a conflict between maps @m1@
+-- and @m2@ is a mapping from @k@ to @(v1, v2)@ such that:
+--
+-- @
+-- lookup k m1 == Just v1
+-- lookup k m2 == Just v2
+-- f v1 v2
+-- @
+--
+-- === Example
+--
+-- @
+-- >>> m1 = fromList [("A", 1), ("B", 1), ("C", 1), ("D", 1)          ]
+-- >>> m2 = fromList [          ("B", 1), ("C", 2), ("D", 1), ("E", 1)]
+-- >>> conflictsWith (/=) m1 m2
+-- fromList [("C", (1, 2))]
+-- @
+--
+conflictsWith
+    :: Ord k
+    => (v1 -> v2 -> Bool)
+    -> Map k v1
+    -> Map k v2
+    -> Map k (v1, v2)
+conflictsWith inConflictWith =
+    merge dropMissing dropMissing (zipWithMaybeMatched (const maybeConflict))
+  where
+    maybeConflict v1 v2
+        | v1 `inConflictWith` v2 = Just (v1, v2)
+        | otherwise = Nothing

--- a/lib/primitive/test/spec/Data/Map/Strict/ExtraSpec.hs
+++ b/lib/primitive/test/spec/Data/Map/Strict/ExtraSpec.hs
@@ -1,0 +1,138 @@
+{-# HLINT ignore "Use camelCase" #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+-- |
+-- Copyright: © 2023 Cardano Foundation
+--
+module Data.Map.Strict.ExtraSpec
+    ( spec
+    ) where
+
+import Prelude hiding
+    ( filter
+    )
+
+import Data.Function
+    ( (&)
+    )
+import Data.Map.Strict
+    ( Map
+    , filter
+    , fromList
+    , intersectionWith
+    )
+import Data.Map.Strict.Extra
+    ( conflictsWith
+    )
+import Data.String
+    ( IsString
+    )
+import Data.Tuple
+    ( swap
+    )
+import GHC.Generics
+    ( Generic
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    )
+import Test.QuickCheck
+    ( Arbitrary
+    , CoArbitrary
+    , pattern Fn2
+    , Fun
+    , Function (..)
+    , Property
+    , property
+    , (===)
+    )
+import Test.QuickCheck.Property
+    ( checkCoverage
+    , cover
+    )
+import Test.QuickCheck.Quid
+    ( Latin (..)
+    , Quid
+    , Size (..)
+    )
+
+import qualified Data.Map.Strict as Map
+
+spec :: Spec
+spec = do
+    describe "conflictsWith" $ do
+        it "example_conflictsWith" $
+            example_conflictsWith
+                & property
+        it "prop_conflictsWith_intersectionWith_filter" $
+            prop_conflictsWith_intersectionWith_filter
+                & property
+        it "prop_conflictsWith_flip_swap" $
+            prop_conflictsWith_flip_swap
+                & property
+
+--------------------------------------------------------------------------------
+-- Test key and value types
+--------------------------------------------------------------------------------
+
+newtype TestKey = TestKey Quid
+    deriving stock (Eq, Generic, Ord)
+    deriving (IsString, Show) via Latin Quid
+    deriving Arbitrary via Size 4 Quid
+    deriving CoArbitrary via Quid
+    deriving anyclass Function
+
+newtype TestValue = TestValue Int
+    deriving stock (Eq, Generic, Ord)
+    deriving newtype (Arbitrary, CoArbitrary, Show, Num)
+    deriving anyclass Function
+
+--------------------------------------------------------------------------------
+-- Examples
+--------------------------------------------------------------------------------
+
+example_conflictsWith :: Property
+example_conflictsWith =
+    conflictsWith @TestKey @TestValue (/=)
+        (fromList [("A", 1), ("B", 1), ("C", 1), ("D", 1)          ])
+        (fromList [          ("B", 1), ("C", 2), ("D", 1), ("E", 1)])
+    ===
+        (fromList [("C", (1, 2))])
+
+--------------------------------------------------------------------------------
+-- Properties
+--------------------------------------------------------------------------------
+
+prop_conflictsWith_intersectionWith_filter
+    :: Fun (TestValue, TestValue) Bool
+    -> Map TestKey TestValue
+    -> Map TestKey TestValue
+    -> Property
+prop_conflictsWith_intersectionWith_filter (Fn2 f) m1 m2 =
+    conflictsWith f m1 m2 === filter (uncurry f) (intersectionWith (,) m1 m2)
+    & cover 50
+        (Map.size (conflictsWith f m1 m2) > 1)
+        "Map.size (conflictsWith f m1 m2) > 1"
+    & checkCoverage
+
+prop_conflictsWith_flip_swap
+    :: Fun (TestValue, TestValue) Bool
+    -> Map TestKey TestValue
+    -> Map TestKey TestValue
+    -> Property
+prop_conflictsWith_flip_swap (Fn2 f) m1 m2 =
+    conflictsWith f m1 m2 === fmap swap (conflictsWith (flip f) m2 m1)
+    & cover 50
+        (Map.size (conflictsWith f m1 m2) > 1)
+        "Map.size (conflictsWith f m1 m2) > 1"
+    & checkCoverage


### PR DESCRIPTION
## Issue

ADP-3185

## Description

This PR clarifies the semantics of the `balanceTx` function's UTxO consistency check.

In particular, it:
- redefines `guardWalletUTxOConsistencyWith` in terms of `Map.conflictsWith` — a function with documented semantics and property test coverage.
- revises the comment for `guardWalletUTxOConsistencyWith` to remove outdated references to `cardano-api`.

This allows us to:
- simplify the definition of `UTxOIndex`, removing the now unused `walletUTxO` field.