### PR TITLE
[ADP-3266] Bump Hackage index-state

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -50,10 +50,10 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 -- repeating the index-state for hackage to work around hackage.nix parsing limitation
-index-state: 2023-06-06T00:00:00Z
+index-state: 2024-01-12T11:04:55Z
 
 index-state:
-  , hackage.haskell.org 2023-06-06T00:00:00Z
+  , hackage.haskell.org 2024-01-12T11:04:55Z
   , cardano-haskell-packages 2023-12-18T12:30:16Z
 
 packages:
@@ -199,6 +199,10 @@ constraints:
 
   -- TH Name shadowing warnings need to be addressed when bumping to 2.13.3.5
   , persistent == 2.13.3.3
+
+  -- warp-tls specifies incorrect upper bound on tls
+  , any.warp-tls ==3.3.6
+  , any.tls ==1.6.0
 
   -- Haddock is broken in this release. Waiting for the next release
 


### PR DESCRIPTION
This pull request bumps the index-state of `hackage.haskell.org`.

### Issue Number

ADP-3266