### PR TITLE
[ADP-3266] Conway bump, todos

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -244,18 +244,6 @@ package cardano-node
 program-options
   ghc-options: -fwrite-ide-info
 
--- By default, we fail to build if there are any unused package dependencies.
-program-options
-  ghc-options: -Wunused-packages
-
--- NOTE: We make an exception for `cardano-wallet-primitive`, as for some
--- reason GHC panics when building this package if the above flag is enabled.
---
--- TODO: Investigate this problem further and/or file a GHC bug report.
---
-package cardano-wallet-primitive
-  ghc-options: -Wno-unused-packages
-
 --------------------------------------------------------------------------------
 -- Enable specific tests in this repo
 

--- a/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Random.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- |

--- a/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Sequential.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Sequential.hs
@@ -14,12 +14,12 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeInType #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
+{-# LANGUAGE DataKinds #-}
 
 -- We intentionally specify the constraint  (k == SharedKey) ~ 'False
 -- in some exports.

--- a/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/SequentialAny.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/SequentialAny.hs
@@ -11,12 +11,12 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeInType #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
+{-# LANGUAGE DataKinds #-}
 
 -- We intentionally specify the constraint  (k == SharedKey) ~ 'False
 -- in some exports.

--- a/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Shared.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery/Shared.hs
@@ -16,6 +16,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- |
 -- Copyright: © 2018-2021 IOHK

--- a/lib/application-extras/cardano-wallet-application-extras.cabal
+++ b/lib/application-extras/cardano-wallet-application-extras.cabal
@@ -40,4 +40,3 @@ library
     , text                   ^>=2.0.2
     , text-class             ^>=2023.12.18
     , unliftio               ^>=0.2.24
-    , unliftio-core          ^>=0.2.1

--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -150,6 +150,7 @@ test-suite test
     , ouroboros-network-api
     , QuickCheck
     , quickcheck-classes
+    , sop-extras
     , std-gen-seed
     , text
     , time

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -15,6 +15,14 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+{-# OPTIONS_GHC -Wno-unused-local-binds #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# HLINT ignore "Unused LANGUAGE pragma" #-}
 
 -- |
 -- Copyright: © 2022 IOHK
@@ -590,8 +598,9 @@ recentEraToBabbageTxOut (TxOutInRecentEra addr val datum mscript) =
     castScript = \case
         Alonzo.TimelockScript timelockEra ->
             Alonzo.TimelockScript (translateTimelock timelockEra)
-        Alonzo.PlutusScript l bs ->
-            Alonzo.PlutusScript l bs
+        _ -> error "TODO conway: castScript"
+        -- Alonzo.PlutusScript l bs ->
+        --     Alonzo.PlutusScript l bs
 
 --
 -- MinimumUTxO
@@ -678,9 +687,6 @@ fromCardanoApiTx
 fromCardanoApiTx = \case
     CardanoApi.ShelleyTx _era tx ->
         tx
-    CardanoApi.ByronTx {} ->
-        case (recentEra @era) of
-            {}
 
 toCardanoApiTx
     :: forall era. IsRecentEra era
@@ -853,7 +859,8 @@ evaluateTransactionBalance pp utxo =
         isRegPoolId :: Ledger.KeyHash 'Ledger.StakePool StandardCrypto -> Bool
         isRegPoolId _keyHash = True
 
-    in Ledger.evalBalanceTxBody pp lookupRefund isRegPoolId utxo
+    in  error "TODO conway: evaluateTransactionBalance"
+        -- Ledger.evalBalanceTxBody pp lookupRefund isRegPoolId utxo
 
 --------------------------------------------------------------------------------
 -- Policy and asset identifiers

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -18,6 +18,8 @@
 
 -- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
 {-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# HLINT ignore "Use max" #-}
 #if __GLASGOW_HASKELL__ >= 902
 {-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}
 #endif
@@ -1178,7 +1180,7 @@ splitSignedValue v = (bNegative, bPositive)
     filterPositive (MaryValue a (MultiAsset m)) =
         MaryValue aPositive (MultiAsset mPositive)
       where
-        aPositive = if a > 0 then a else 0
+        aPositive = if a > Coin 0 then a else Coin 0
         mPositive = Map.map (Map.filter (> 0)) m
 
 --------------------------------------------------------------------------------

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Redeemers.hs
@@ -7,6 +7,11 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-local-binds #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 {- HLINT ignore "Use <$>" -}
 
 -- |
@@ -158,24 +163,26 @@ assignScriptRedeemers pparams timeTranslation utxo redeemers tx = do
             fmap unzip $ forM redeemers parseRedeemer
         pure
             ( Map.fromList indexedRedeemers
-            , ledgerTx
-                & witsTxL . rdmrsTxWitsL
-                    .~ (Alonzo.Redeemers (Map.fromList nullRedeemers))
+            , error "TODO conway: assignNullRedeemers"
+            -- , ledgerTx
+            --     & witsTxL . rdmrsTxWitsL
+            --         .~ (Alonzo.Redeemers (Map.fromList nullRedeemers))
             )
       where
-        parseRedeemer rd = do
-            let mPtr = Alonzo.rdptr
-                    (view bodyTxL ledgerTx)
-                    (toScriptPurpose rd)
-            ptr <- case mPtr of
-                SNothing -> Left $ ErrAssignRedeemersTargetNotFound rd
-                SJust ptr -> pure ptr
-            let mDeserialisedData =
-                    deserialiseOrFail $ BL.fromStrict $ redeemerData rd
-            rData <- case mDeserialisedData of
-                Left e -> Left $ ErrAssignRedeemersInvalidData rd (show e)
-                Right d -> pure (Alonzo.Data d)
-            pure ((ptr, rd), (ptr, (rData, mempty)))
+        parseRedeemer = error "TODO conway: parseRedeemer"
+        -- parseRedeemer rd = do
+        --     let mPtr = Alonzo.rdptr
+        --             (view bodyTxL ledgerTx)
+        --             (toScriptPurpose rd)
+        --     ptr <- case mPtr of
+        --         SNothing -> Left $ ErrAssignRedeemersTargetNotFound rd
+        --         SJust ptr -> pure ptr
+        --     let mDeserialisedData =
+        --             deserialiseOrFail $ BL.fromStrict $ redeemerData rd
+        --     rData <- case mDeserialisedData of
+        --         Left e -> Left $ ErrAssignRedeemersInvalidData rd (show e)
+        --         Right d -> pure (Alonzo.Data d)
+        --     pure ((ptr, rd), (ptr, (rData, mempty)))
 
     -- | Evaluate execution units of each script/redeemer in the transaction.
     -- This may fail for each script.
@@ -185,11 +192,13 @@ assignScriptRedeemers pparams timeTranslation utxo redeemers tx = do
         -> Either ErrAssignRedeemers
             (Map Alonzo.RdmrPtr (Either ErrAssignRedeemers Alonzo.ExUnits))
     evaluateExecutionUnits indexedRedeemers ledgerTx =
-        Ledger.evalTxExUnits
-            pparams ledgerTx utxo epochInformation systemStart
+        error "TODO conway: evaluateExecutionUnits"
+        -- Ledger.evalTxExUnits
+        --     pparams ledgerTx utxo epochInformation systemStart
         & bimap
             ErrAssignRedeemersTranslationError
-            (hoistScriptFailure indexedRedeemers)
+            (error "TODO conway: evaluateExecutionUnits")
+            -- (hoistScriptFailure indexedRedeemers)
 
     hoistScriptFailure
         :: Show scriptFailure
@@ -273,11 +282,14 @@ redeemerData = \case
 toScriptPurpose :: Redeemer -> Alonzo.ScriptPurpose StandardCrypto
 toScriptPurpose = \case
     RedeemerSpending _ txin ->
-        Alonzo.Spending txin
+        error "TODO conway: toScriptPurpose"
+        -- Alonzo.Spending txin
     RedeemerMinting _ pid ->
-        Alonzo.Minting pid
+        error "TODO conway: toScriptPurpose"
+        -- Alonzo.Minting pid
     RedeemerRewarding _ acc ->
-        Alonzo.Rewarding acc
+        error "TODO conway: toScriptPurpose"
+        -- Alonzo.Rewarding acc
 
 --------------------------------------------------------------------------------
 -- Utils

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -274,20 +274,22 @@ estimateKeyWitnessCounts utxo tx timelockKeyWitCounts =
         scriptsAvailableInBody :: Map (ScriptHash StandardCrypto) (Script era)
         scriptsAvailableInBody = tx ^. witsTxL . scriptTxWitsL
 
-    estimateDelegSigningKeys :: CardanoApi.Certificate -> Integer
-    estimateDelegSigningKeys = \case
-        CardanoApi.StakeAddressRegistrationCertificate _ -> 0
-        CardanoApi.StakeAddressDeregistrationCertificate cred ->
-            estimateWitNumForCred cred
-        CardanoApi.StakeAddressPoolDelegationCertificate cred _ ->
-            estimateWitNumForCred cred
-        _ -> 1
-      where
-        -- Does not include the key witness needed for script credentials.
-        -- They are accounted for separately in @scriptVkWitsUpperBound@.
-        estimateWitNumForCred = \case
-            CardanoApi.StakeCredentialByKey _ -> 1
-            CardanoApi.StakeCredentialByScript _ -> 0
+    estimateDelegSigningKeys :: cert -> Integer
+    estimateDelegSigningKeys = error "TODO conway: estimateDelegSigningKeys"
+    -- estimateDelegSigningKeys :: CardanoApi.Certificate -> Integer
+    -- estimateDelegSigningKeys = \case
+    --     CardanoApi.StakeAddressRegistrationCertificate _ -> 0
+    --     CardanoApi.StakeAddressDeregistrationCertificate cred ->
+    --         estimateWitNumForCred cred
+    --     CardanoApi.StakeAddressPoolDelegationCertificate cred _ ->
+    --         estimateWitNumForCred cred
+    --     _ -> 1
+    --   where
+    --     -- Does not include the key witness needed for script credentials.
+    --     -- They are accounted for separately in @scriptVkWitsUpperBound@.
+    --     estimateWitNumForCred = \case
+    --         CardanoApi.StakeCredentialByKey _ -> 1
+    --         CardanoApi.StakeCredentialByScript _ -> 0
 
     toCAScript = Convert.toWalletScript (const dummyKeyRole)
       where
@@ -297,7 +299,8 @@ estimateKeyWitnessCounts utxo tx timelockKeyWitCounts =
         :: Ledger.Script era
         -> Maybe (Timelock era)
     toTimelockScript (Alonzo.TimelockScript timelock) = Just timelock
-    toTimelockScript (Alonzo.PlutusScript _ _)        = Nothing
+    toTimelockScript _ = error "TODO conway: toTimelockScript"
+    -- toTimelockScript (Alonzo.PlutusScript _ _)        = Nothing
 
     hasScriptCred
         :: UTxO era

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/CoinSelectionSpec.hs
@@ -83,6 +83,7 @@ spec = describe "Cardano.Wallet.CoinSelectionSpec" $ do
 
         it "prop_toInternalSelection_toExternalSelection" $
             prop_toInternalSelection_toExternalSelection & property
+                -- error "TODO conway: fix this test"
 
 --------------------------------------------------------------------------------
 -- Conversion between external (wallet) and internal UTxOs

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 module Internal.Cardano.Write.Tx.Balance.TokenBundleSizeSpec where
 
 import Prelude
@@ -273,34 +274,35 @@ data PParamsInRecentEra
     deriving (Show, Eq)
 
 instance Arbitrary PParamsInRecentEra where
-    arbitrary = oneof
-        [ PParamsInBabbage <$> genPParams RecentEraBabbage
-        , PParamsInConway <$> genPParams RecentEraConway
-        ]
+    arbitrary = error "TODO conway: Arbitrary PParamsInRecentEra"
+    -- arbitrary = oneof
+    --     [ PParamsInBabbage <$> genPParams RecentEraBabbage
+    --     , PParamsInConway <$> genPParams RecentEraConway
+    --     ]
 
-      where
-        genPParams
-            :: IsRecentEra era
-            => RecentEra era
-            -> Gen (PParams era)
-        genPParams _era = do
-            ver <- arbitrary
-            maxSize <- genMaxSizeBytes
-            return $ def
-                & ppProtocolVersionL .~ (ProtVer ver 0)
-                    -- minor version doesn't matter
-                & ppMaxValSizeL .~ maxSize
-          where
-            genMaxSizeBytes :: Gen Natural
-            genMaxSizeBytes =
-                oneof
-                -- Generate values close to the mainnet value of 4000 bytes
-                -- (and guard against underflow)
-                [ fromIntegral . max 0 . (4000 +) <$> arbitrary @Int
+    --   where
+    --     genPParams
+    --         :: IsRecentEra era
+    --         => RecentEra era
+    --         -> Gen (PParams era)
+    --     genPParams _era = do
+    --         ver <- arbitrary
+    --         maxSize <- genMaxSizeBytes
+    --         return $ def
+    --             & ppProtocolVersionL .~ (ProtVer ver 0)
+    --                 -- minor version doesn't matter
+    --             & ppMaxValSizeL .~ maxSize
+    --       where
+    --         genMaxSizeBytes :: Gen Natural
+    --         genMaxSizeBytes =
+    --             oneof
+    --             -- Generate values close to the mainnet value of 4000 bytes
+    --             -- (and guard against underflow)
+    --             [ fromIntegral . max 0 . (4000 +) <$> arbitrary @Int
 
-                -- Generate more extreme values (both small and large)
-                , fromIntegral <$> arbitrary @Word64
-                ]
+    --             -- Generate more extreme values (both small and large)
+    --             , fromIntegral <$> arbitrary @Word64
+    --             ]
 
 babbageTokenBundleSizeAssessor :: TokenBundleSizeAssessor
 babbageTokenBundleSizeAssessor = mkTokenBundleSizeAssessor

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -26,6 +26,12 @@
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 902
 {-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}
+{-# OPTIONS_GHC -Wno-unused-local-binds #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
 #endif
 
 module Internal.Cardano.Write.Tx.BalanceSpec
@@ -80,8 +86,6 @@ import Cardano.Ledger.Language
 import Cardano.Ledger.Shelley.API
     ( Credential (KeyHashObj)
     , Credential (..)
-    , DCert (DCertDeleg)
-    , DelegCert (..)
     , Delegation (..)
     , KeyHash (..)
     , StrictMaybe (SJust, SNothing)
@@ -943,14 +947,15 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
             mkBasicTxBody
                 & certsTxBodyL .~ StrictSeq.fromList certs
 
-        dummyStakeKey = KeyHashObj $ KeyHash
-            "00000000000000000000000000000000000000000000000000000000"
-        dummyPool = KeyHash
-            "00000000000000000000000000000000000000000000000000000001"
+        -- dummyStakeKey = KeyHashObj $ KeyHash
+        --     "00000000000000000000000000000000000000000000000000000000"
+        -- dummyPool = KeyHash
+        --     "00000000000000000000000000000000000000000000000000000001"
         certs =
-            [ DCertDeleg $ RegKey dummyStakeKey
-            , DCertDeleg $ Delegate $ Delegation dummyStakeKey dummyPool
-            ]
+            error "TODO conway: balanceTransactionGoldenSpec"
+            -- [ DCertDeleg $ RegKey dummyStakeKey
+            -- , DCertDeleg $ Delegate $ Delegation dummyStakeKey dummyPool
+            -- ]
 
     minFee
         :: IsRecentEra era
@@ -2547,9 +2552,9 @@ mockCardanoApiPParamsForBalancing = CardanoApi.ProtocolParameters
     , CardanoApi.protocolParamPoolPledgeInfluence = 0
     , CardanoApi.protocolParamMonetaryExpansion = 0
     , CardanoApi.protocolParamTreasuryCut  = 0
-    , CardanoApi.protocolParamUTxOCostPerWord =
-        Just $ CardanoApi.fromShelleyLovelace $
-            Alonzo.unCoinPerWord testParameter_coinsPerUTxOWord_Alonzo
+    -- , CardanoApi.protocolParamUTxOCostPerWord =
+    --     Just $ CardanoApi.fromShelleyLovelace $
+    --         Alonzo.unCoinPerWord testParameter_coinsPerUTxOWord_Alonzo
     , CardanoApi.protocolParamUTxOCostPerByte =
         Just $ CardanoApi.fromShelleyLovelace $
             Babbage.unCoinPerByte testParameter_coinsPerUTxOByte_Babbage
@@ -2685,32 +2690,33 @@ instance
     CardanoApi.IsCardanoEra era =>
     Arbitrary (CardanoApi.TxOutValue era)
   where
-    arbitrary = case CardanoApi.cardanoEra @era of
-       CardanoApi.AlonzoEra ->
-           CardanoApi.TxOutValue CardanoApi.MultiAssetInAlonzoEra
-               <$> CardanoApi.genValueForTxOut
-       CardanoApi.BabbageEra ->
-           CardanoApi.TxOutValue CardanoApi.MultiAssetInBabbageEra
-               <$>  CardanoApi.genValueForTxOut
-       e -> error $ mconcat
-           [ "Arbitrary (TxOutValue "
-           , show e
-           , ") not implemented)"
-           ]
+    arbitrary = error "TODO conway: Arbitrary (TxOutValue era)"
+    -- arbitrary = case CardanoApi.cardanoEra @era of
+    --    CardanoApi.AlonzoEra ->
+    --        CardanoApi.TxOutValue CardanoApi.MultiAssetInAlonzoEra
+    --            <$> CardanoApi.genValueForTxOut
+    --    CardanoApi.BabbageEra ->
+    --        CardanoApi.TxOutValue CardanoApi.MultiAssetInBabbageEra
+    --            <$>  CardanoApi.genValueForTxOut
+    --    e -> error $ mconcat
+    --        [ "Arbitrary (TxOutValue "
+    --        , show e
+    --        , ") not implemented)"
+    --        ]
 
-    shrink (CardanoApi.TxOutValue CardanoApi.MultiAssetInAlonzoEra val) =
-        map
-            (CardanoApi.TxOutValue CardanoApi.MultiAssetInAlonzoEra
-                . walletToCardanoValue)
-            (shrink $ cardanoToWalletValue val)
+    -- shrink (CardanoApi.TxOutValue CardanoApi.MultiAssetInAlonzoEra val) =
+    --     map
+    --         (CardanoApi.TxOutValue CardanoApi.MultiAssetInAlonzoEra
+    --             . walletToCardanoValue)
+    --         (shrink $ cardanoToWalletValue val)
 
-    shrink (CardanoApi.TxOutValue CardanoApi.MultiAssetInBabbageEra val) =
-        map
-            (CardanoApi.TxOutValue CardanoApi.MultiAssetInBabbageEra
-                . walletToCardanoValue)
-            (shrink $ cardanoToWalletValue val)
-    shrink _ =
-        error "Arbitrary (TxOutValue era) is not implemented for old eras"
+    -- shrink (CardanoApi.TxOutValue CardanoApi.MultiAssetInBabbageEra val) =
+    --     map
+    --         (CardanoApi.TxOutValue CardanoApi.MultiAssetInBabbageEra
+    --             . walletToCardanoValue)
+    --         (shrink $ cardanoToWalletValue val)
+    -- shrink _ =
+    --     error "Arbitrary (TxOutValue era) is not implemented for old eras"
 
 -- Coins (quantities of lovelace) must be strictly positive when included in
 -- transactions.
@@ -2847,11 +2853,12 @@ instance Arbitrary Wallet where
         ]
       where
         genShelleyVkAddr :: Gen (CardanoApi.AddressInEra CardanoApi.BabbageEra)
-        genShelleyVkAddr = CardanoApi.shelleyAddressInEra
-            <$> (CardanoApi.makeShelleyAddress
-                <$> CardanoApi.genNetworkId
-                <*> CardanoApi.genPaymentCredential -- only vk credentials
-                <*> CardanoApi.genStakeAddressReference)
+        genShelleyVkAddr = error "TODO conway: Arbitrary Wallet"
+        -- genShelleyVkAddr = CardanoApi.shelleyAddressInEra
+        --     <$> (CardanoApi.makeShelleyAddress
+        --         <$> CardanoApi.genNetworkId
+        --         <*> CardanoApi.genPaymentCredential -- only vk credentials
+        --         <*> CardanoApi.genStakeAddressReference)
 
         genByronVkAddr :: Gen (CardanoApi.AddressInEra CardanoApi.BabbageEra)
         genByronVkAddr = CardanoApi.byronAddressInEra
@@ -2969,13 +2976,14 @@ shrinkTxBodyBabbage
         , scriptData' <- prependOriginal shrinkScriptData scriptData
         , scripts' <- prependOriginal (shrinkList (const [])) scripts
         , val' <-
-            case CardanoApi.txScriptValiditySupportedInShelleyBasedEra e of
-                Nothing -> [val]
-                Just txsvsie -> val : filter (/= val)
-                    [ CardanoApi.TxScriptValidity
-                        txsvsie
-                        CardanoApi.ScriptValid
-                    ]
+            error "TODO conway: shrinkTxBodyBabbage"
+            -- case CardanoApi.txScriptValiditySupportedInShelleyBasedEra e of
+            --     Nothing -> [val]
+            --     Just txsvsie -> val : filter (/= val)
+            --         [ CardanoApi.TxScriptValidity
+            --             txsvsie
+            --             CardanoApi.ScriptValid
+            --         ]
         ]
   where
     shrinkLedgerTxBody

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOSelectionSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/UTxOSelectionSpec.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {- HLINT ignore "Use camelCase" -}
 

--- a/lib/faucet/lib/Cardano/Faucet/Mnemonics.hs
+++ b/lib/faucet/lib/Cardano/Faucet/Mnemonics.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Cardano.Faucet.Mnemonics
     ( random

--- a/lib/iohk-monitoring-extra/src/Cardano/BM/Extra.hs
+++ b/lib/iohk-monitoring-extra/src/Cardano/BM/Extra.hs
@@ -7,7 +7,9 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -81,7 +81,6 @@ test-suite unit
     , hspec-core
     , hspec-expectations
     , iohk-monitoring
-    , process
     , retry
     , text
     , text-class

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/ConfiguredPool.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/ConfiguredPool.hs
@@ -25,7 +25,7 @@ import Cardano.Api
 import Cardano.Binary
     ( FromCBOR (..)
     )
-import Cardano.CLI.Shelley.Key
+import Cardano.CLI.Types.Key
     ( VerificationKeyOrFile (..)
     , readVerificationKeyOrFile
     )

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -120,7 +120,6 @@ library
     , text
     , text-class
     , time
-    , transformers
     , typed-process
     , unliftio
     , warp

--- a/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
@@ -174,7 +174,7 @@ itSpec = describe "Extra.it" $ before_ (setEnv "TESTS_RETRY_FAILED" "y") $ do
     shouldMatchHSpecIt extraTest hspecTest = do
         extraRes <- runIt Extra.it extraTest
         hspecRes <- runIt it hspecTest
-        extraRes `shouldBe` hspecRes
+        lines extraRes `shouldBe` lines hspecRes
 
     runIt
         :: (String -> ActionWith () -> SpecWith ()) -- ^ it version
@@ -193,6 +193,7 @@ itSpec = describe "Extra.it" $ before_ (setEnv "TESTS_RETRY_FAILED" "y") $ do
                 . filter (not . ("Finished in" `isPrefixOf`))
                 . filter (not . ("Randomized" `isPrefixOf`))
                 . filter (not . ("retry:" `isPrefixOf`))
+                . filter (not . ("  To rerun use:" `isPrefixOf`))
                 . lines
 
     -- | Returns an IO action that is different every time you run it!,

--- a/lib/wai-middleware-logging/test/Network/Wai/Middleware/LoggingSpec.hs
+++ b/lib/wai-middleware-logging/test/Network/Wai/Middleware/LoggingSpec.hs
@@ -225,7 +225,7 @@ spec = describe "Logging Middleware" $ do
                 , (Info, "[POST] /post")
                 , (Debug, "Invalid payload: not JSON")
                 , (Info, "400 Bad Request")
-                , (Debug, "Failed reading: not a valid json value")
+                , (Debug, "Unexpected \"\\NUL\\NUL\\NUL\", expecting JSON value")
                 , (Debug, "LogRequestFinish")
                 ]
 

--- a/lib/wai-middleware-logging/wai-middleware-logging.cabal
+++ b/lib/wai-middleware-logging/wai-middleware-logging.cabal
@@ -81,6 +81,5 @@ test-suite unit
     , text
     , text-class
     , unliftio
-    , wai
     , warp
     , with-utf8

--- a/lib/wallet-e2e/cardano-wallet-e2e.cabal
+++ b/lib/wallet-e2e/cardano-wallet-e2e.cabal
@@ -58,31 +58,32 @@ library
   import:          options
   hs-source-dirs:  src
   build-depends:
-    , aeson                  ^>=2.1.2.1
-    , base                   >= 4.14.3.0 && < 4.19
-    , base58-bytestring      ^>=0.1
-    , cardano-addresses      ^>=3.12
-    , cardano-crypto         ^>=1.1.2
-    , cardano-wallet-client  ^>=0.1
+    , aeson                     ^>=2.1.2.1
+    , attoparsec-aeson
+    , base                      >=4.14.3.0  && <4.19
+    , base58-bytestring         ^>=0.1
+    , cardano-addresses         ^>=3.12
+    , cardano-crypto            ^>=1.1.2
+    , cardano-wallet-client     ^>=0.1
     , cardano-wallet-primitive
-    , effectful-core         ^>=2.2.2.0
-    , effectful-th           ^>=1.0.0.1
+    , effectful-core            ^>=2.2.2.0
+    , effectful-th              ^>=1.0.0.1
     , faucet
-    , http-client            ^>=0.7.13.1
-    , http-types             ^>=0.12.3
-    , local-cluster          ^>=0.1
-    , path                   ^>=0.9.2
-    , path-io                ^>=1.7.0
-    , random                 ^>=1.2.1.1
-    , relude                 ^>=1.2.0.0
-    , resourcet              ^>=1.3
-    , retry                  ^>=0.9.3.1
-    , sydtest                ^>=0.15
-    , tagged                 ^>=0.8.7
-    , text                   ^>=2.0.2
-    , time                   >= 1.9.3 && < 1.13
-    , timespan               ^>=0.4
-    , typed-process          ^>=0.2.11
+    , http-client               ^>=0.7.13.1
+    , http-types                ^>=0.12.3
+    , local-cluster             ^>=0.1
+    , path                      ^>=0.9.2
+    , path-io                   ^>=1.7.0
+    , random                    ^>=1.2.1.1
+    , relude                    ^>=1.2.0.0
+    , resourcet                 ^>=1.3
+    , retry                     ^>=0.9.3.1
+    , sydtest                   ^>=0.15
+    , tagged                    ^>=0.8.7
+    , text                      ^>=2.0.2
+    , time                      >=1.9.3     && <1.13
+    , timespan                  ^>=0.4
+    , typed-process             ^>=0.2.11
 
   exposed-modules:
     Cardano.Wallet.Spec
@@ -120,7 +121,7 @@ executable wallet-e2e
   hs-source-dirs: exe
   main-is:        Main.hs
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N
-  other-modules: Options
+  other-modules:  Options
   build-depends:
     , base
     , cardano-wallet-e2e

--- a/lib/wallet/api/http/Cardano/CLI.hs
+++ b/lib/wallet/api/http/Cardano/CLI.hs
@@ -18,6 +18,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
@@ -230,9 +230,6 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Shelley.BlockchainSource
     ( BlockchainSource (..)
     )
-import Control.Applicative
-    ( liftA2
-    )
 import Control.Monad
     ( when
     )

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -29,7 +29,7 @@ import Prelude
 import Cardano.Address.Script
     ( Cosigner (..)
     )
-import Cardano.Ledger.Alonzo.TxInfo
+import Cardano.Ledger.Alonzo.Plutus.TxInfo
     ( TranslationError (..)
     )
 import Cardano.Wallet
@@ -130,7 +130,6 @@ import Cardano.Write.Tx
     )
 import Control.Monad.Except
     ( ExceptT
-    , lift
     , withExceptT
     )
 import Control.Monad.Trans.Except
@@ -199,6 +198,7 @@ import Servant.Server
     , err501
     , err503
     )
+import Control.Monad.Trans (lift)
 
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -2566,7 +2566,7 @@ instance ToJSON ApiAddressData where
     toJSON (ApiAddressData (AddrBase payment' stake') validation') =
         object $ [ "payment" .= payment', "stake" .= stake'] ++ addOptionally validation'
 
-addOptionally :: (Aeson.KeyValue a, ToJSON v) => Maybe v -> [a]
+addOptionally :: (ToJSON v, Aeson.KeyValue e0 a) => Maybe v -> [a]
 addOptionally v = case v of
     Just v' -> ["validation" .= v']
     Nothing -> []

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/Primitive.hs
@@ -20,7 +20,6 @@ import Cardano.Address.Script
     )
 import Cardano.Api
     ( TxMetadataJsonSchema (..)
-    , displayError
     , metadataFromJson
     , metadataToJson
     )
@@ -378,6 +377,7 @@ instance FromJSON (ApiT TxMetadata) where
     parseJSON = fmap ApiT
         . either (fail . displayError) pure
         . metadataFromJson TxMetadataJsonDetailedSchema
+        where displayError = error "TODO conway: displayError"
 
 instance ToJSON (ApiT TxMetadata) where
     toJSON = metadataToJson TxMetadataJsonDetailedSchema . getApiT

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types/SchemaMetadata.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types/SchemaMetadata.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE StrictData #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 -- |
 -- Copyright: © 2018-2022 IOHK, 2023 Cardano Foundation
@@ -17,8 +18,7 @@
 module Cardano.Wallet.Api.Types.SchemaMetadata where
 
 import Cardano.Api
-    ( Error (displayError)
-    , TxMetadataJsonSchema (..)
+    ( TxMetadataJsonSchema (..)
     , metadataFromJson
     , metadataToJson
     )
@@ -98,3 +98,4 @@ instance FromJSON TxMetadataWithSchema where
             . either (fail . displayError) pure
             . metadataFromJson TxMetadataJsonNoSchema
         )
+      where displayError = error "TODO conway: displayError"

--- a/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Shelley.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- |
 -- Copyright: © 2020 IOHK

--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -7,6 +7,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
 {- |
 Copyright: © 2023–2023 IOHK
 

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -15,11 +15,14 @@
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE NoMonoLocalBinds #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -Wno-unused-local-binds #-}
 {-# OPTIONS_GHC -Wno-unused-do-bind #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+{-# LANGUAGE TypeFamilies #-}
 
 {- HLINT ignore "Redundant pure" -}
 
@@ -420,7 +423,10 @@ cardanoRestoreBench tr c socketFile = do
                     True -- Write progress to .timelog file
                     (unsafeMkPercentage 1)
                     benchmarksRnd
-        let benchRestoreSeqWithOwnership p pipelinings = do
+        let benchRestoreSeqWithOwnership :: forall p . KnownNat p => Proxy p
+                    -> PipeliningStrategy (CardanoBlock StandardCrypto)
+                    -> IO SomeBenchmarkResults
+            benchRestoreSeqWithOwnership p pipelinings = do
                 let benchname = showPercentFromPermyriad p <> "-percent-seq"
                 bench_restoration
                     pipelinings

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -656,6 +656,7 @@ test-suite unit
     , servant-server
     , si-timers
     , sop-core
+    , sop-extras
     , splitmix
     , string-interpolate
     , temporary

--- a/lib/wallet/src/Cardano/Pool/DB/Sqlite/TH.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Sqlite/TH.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- |

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/Shared.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/Shared.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/lib/wallet/src/Cardano/Wallet/Address/Keys/WitnessCount.hs
+++ b/lib/wallet/src/Cardano/Wallet/Address/Keys/WitnessCount.hs
@@ -7,6 +7,7 @@
 -- GHC 8.10.7 cannot figure out the constraint is necessary in
 -- toWitnessCount, so we disable the warning.
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Cardano.Wallet.Address.Keys.WitnessCount
     ( toWitnessCountCtx)

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 {- HLINT ignore "Use section" -}
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Pure/Implementation.hs
@@ -83,12 +83,11 @@ import Cardano.Wallet.Primitive.Slotting
     , slotToUTCTime
     )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (blockHeight, slotNo)
-    , ChainPoint
+    ( ChainPoint
     , DelegationCertificate (..)
     , GenesisParameters (..)
     , Slot
-    , SlotNo (..)
+    , SlotNo
     , SortOrder (..)
     , StakeKeyCertificate (..)
     , WalletMetadata (..)
@@ -165,6 +164,7 @@ import GHC.Generics
 
 import qualified Cardano.Wallet.Primitive.Types.Range as Range
 import qualified Data.Map.Strict as Map
+import qualified Cardano.Wallet.Primitive.Types.Block as W
 
 {-------------------------------------------------------------------------------
                             Model Database wid Types
@@ -431,7 +431,7 @@ mReadTxHistory ti minWithdrawal order range mstatus maddress db@(Database _ wall
              $ (blockHeight :: TxMeta -> Quantity "block" Word32)
              meta
         tipH = getQuantity
-             $ (blockHeight :: BlockHeader -> Quantity "block" Word32)
+             $ W.blockHeight
              $ currentTip cp
 
 mPutPrivateKey :: xprv -> ModelOp wid s xprv ()
@@ -574,4 +574,4 @@ filterTxHistory minWithdrawal order range address =
             checkCollInp addr txhistory || checkCollOut addr txhistory
 
 tip :: Wallet s -> SlotNo
-tip = (slotNo :: BlockHeader -> SlotNo) . currentTip
+tip = W.slotNo . currentTip

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- |
 -- Copyright: © 2018-2023 IOHK

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -31,7 +31,6 @@ import Cardano.Address.Script
     )
 import Cardano.Api
     ( TxMetadataJsonSchema (..)
-    , displayError
     , metadataFromJson
     , metadataToJson
     )
@@ -483,7 +482,8 @@ instance PersistFieldSql TxStatus where
 
 ----------------------------------------------------------------------------
 -- TxMetadata
-
+displayError :: a
+displayError = error "TODO conway: displayError"
 instance PersistField TxMetadata where
     toPersistValue =
         toPersistValue .

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migration/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migration/Schema.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- |

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Schema.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- |
 -- Copyright: © 2018-2023 IOHK

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Operations.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Operations.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 {- |

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Store.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 {- |
 Copyright: 2022 IOHK

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Store.hs
@@ -32,9 +32,6 @@ import Cardano.Wallet.DB.Store.Transactions.Model
 import Cardano.Wallet.DB.Store.Wallets.Model
     ( DeltaTxWalletsHistory (..)
     )
-import Control.Applicative
-    ( liftA2
-    )
 import Data.Store
     ( Store (..)
     , UpdateStore

--- a/lib/wallet/src/Cardano/Wallet/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Gen.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- | Shared QuickCheck generators for wallet types.
 --

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Delegation/State.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Delegation/State.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Module for `DelegationState`.

--- a/lib/wallet/src/Cardano/Wallet/Registry.hs
+++ b/lib/wallet/src/Cardano/Wallet/Registry.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Cardano.Wallet.Registry
     ( -- * Worker Registry

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -19,6 +19,10 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+{-# OPTIONS_GHC -Wno-unused-local-binds #-}
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Use camelCase" -}
 
@@ -267,6 +271,7 @@ import qualified Data.Text as T
 import qualified Internal.Cardano.Write.Tx as Write
 import qualified Internal.Cardano.Write.Tx.Sign as Write
 import qualified Internal.Cardano.Write.Tx.SizeEstimation as Write
+import qualified Cardano.Wallet.DB.Sqlite.Types as Cardano
 
 -- | Type encapsulating what we need to know to add things -- payloads,
 -- certificates -- to a transaction.
@@ -278,7 +283,7 @@ data TxPayload era = TxPayload
       -- ^ User or application-defined metadata to be included in the
       -- transaction.
 
-    , _certificates :: [Cardano.Certificate]
+    , _certificates :: [Cardano.Certificate (CardanoApiEra era)]
       -- ^ Certificates to be included in the transactions.
 
     , _extraWitnesses :: Cardano.TxBody era -> [Cardano.KeyWitness era]
@@ -293,7 +298,7 @@ constructUnsignedTx
      . IsRecentEra era
     => RecentEra era
     -> Cardano.NetworkId
-    -> (Maybe Cardano.TxMetadata, [Cardano.Certificate])
+    -> (Maybe Cardano.TxMetadata, [Cardano.Certificate (CardanoApiEra era)])
     -> (Maybe SlotNo, SlotNo)
     -- ^ Slot at which the transaction will optionally start and expire.
     -> Withdrawal
@@ -755,7 +760,7 @@ mkDelegationCertificates
         -- Pool Id to which we're planning to delegate
     -> Either XPub (Script KeyHash)
         --Staking credential
-    -> [Cardano.Certificate]
+    -> [Cardano.Certificate (CardanoApiEra era)]
 mkDelegationCertificates da cred =
     case da of
        Join poolId ->
@@ -782,7 +787,7 @@ mkUnsignedTx
     -> Either PreSelection (SelectionOf TxOut)
     -> Maybe Cardano.TxMetadata
     -> [(Cardano.StakeAddress, Cardano.Lovelace)]
-    -> [Cardano.Certificate]
+    -> [Cardano.Certificate (CardanoApiEra era)]
     -> Cardano.Lovelace
     -> TokenMap
     -> TokenMap
@@ -808,6 +813,7 @@ mkUnsignedTx
     left toErrMkTx
     $ fmap removeDummyInput
     $ Cardano.createAndValidateTransactionBody
+    (error "TODO conway: mkUnsignedTx")
     Cardano.TxBodyContent
     { Cardano.txIns = inputWits
 
@@ -896,18 +902,19 @@ mkUnsignedTx
             Cardano.TxCertificates certSupported certs ctx
 
     , Cardano.txFee = explicitFees shelleyEra fees
-
-    , Cardano.txValidityRange =
-        let toLowerBound from = case txValidityLowerBoundSupported of
-                Just lowerBoundSupported ->
-                    Cardano.TxValidityLowerBound lowerBoundSupported from
-                Nothing ->
-                    Cardano.TxValidityNoLowerBound
-        in
-        bimap
-            (maybe Cardano.TxValidityNoLowerBound toLowerBound)
-            (Cardano.TxValidityUpperBound txValidityUpperBoundSupported)
-            ttl
+    , Cardano.txValidityLowerBound = error "TODO conway: txValidityLowerBound"
+    , Cardano.txValidityUpperBound = error "TODO conway: txValidityUpperBound"
+    -- , Cardano.txValidityRange =
+    --     let toLowerBound from = case txValidityLowerBoundSupported of
+    --             Just lowerBoundSupported ->
+    --                 Cardano.TxValidityLowerBound lowerBoundSupported from
+    --             Nothing ->
+    --                 Cardano.TxValidityNoLowerBound
+    --     in
+    --     bimap
+    --         (maybe Cardano.TxValidityNoLowerBound toLowerBound)
+    --         (Cardano.TxValidityUpperBound txValidityUpperBoundSupported)
+    --         ttl
 
     , Cardano.txMetadata =
         maybe
@@ -944,11 +951,13 @@ mkUnsignedTx
                             mintingSource
                     ctx = Cardano.BuildTxWith witMap
                 in Cardano.TxMintValue mintedEra (mintValue <> burnValue) ctx
+    , Cardano.txProposalProcedures = error "TODO conway: txProposalProcedures"
+    , Cardano.txVotingProcedures = error "TODO conway: txVotingProcedures"
     }
   where
     toErrMkTx :: Cardano.TxBodyError -> ErrMkTransaction
-    toErrMkTx = ErrMkTransactionTxBodyError . T.pack . Cardano.displayError
-
+    toErrMkTx = ErrMkTransactionTxBodyError . T.pack . error "TODO conway: toErrMkTx"
+        -- Cardano.displayError
     -- Extra validation for HTTP API backward compatibility:
     --
     -- Previously validation of user-provided payment outputs was handled by
@@ -990,42 +999,50 @@ mkUnsignedTx
                         , quantityMaxBound = txOutMaxTokenQuantity
                         }
 
-    metadataSupported
-        :: Cardano.TxMetadataSupportedInEra (Write.CardanoApiEra era)
-    metadataSupported = case era of
-        RecentEraBabbage -> Cardano.TxMetadataInBabbageEra
-        RecentEraConway -> Cardano.TxMetadataInConwayEra
+    metadataSupported  :: a
+    metadataSupported = error "TODO conway: metadataSupported"
+    -- metadataSupported
+    --     :: Cardano.TxMetadataSupportedInEra (Write.CardanoApiEra era)
+    -- metadataSupported = case era of
+    --     RecentEraBabbage -> Cardano.TxMetadataInBabbagera
+    --     RecentEraConway -> Cardano.TxMetadataInConwayEra
 
-    certSupported
-        :: Cardano.CertificatesSupportedInEra (Write.CardanoApiEra era)
-    certSupported = case era of
-        RecentEraBabbage -> Cardano.CertificatesInBabbageEra
-        RecentEraConway -> Cardano.CertificatesInConwayEra
+    certSupported :: a
+    certSupported = error "TODO conway: certSupported"
+    -- certSupported
+    --     :: Cardano.CertificatesSupportedInEra (Write.CardanoApiEra era)
+    -- certSupported = case era of
+    --     RecentEraBabbage -> Cardano.CertificatesInBabbageEra
+    --     RecentEraConway -> Cardano.CertificatesInConwayEra
 
-    wdrlsSupported
-        :: Cardano.WithdrawalsSupportedInEra (Write.CardanoApiEra era)
-    wdrlsSupported = case era of
-        RecentEraBabbage -> Cardano.WithdrawalsInBabbageEra
-        RecentEraConway -> Cardano.WithdrawalsInConwayEra
+    wdrlsSupported :: a
+    wdrlsSupported = error "TODO conway: wdrlsSupported"
+    -- wdrlsSupported
+    --     :: Cardano.WithdrawalsSupportedInEra (Write.CardanoApiEra era)
+    -- wdrlsSupported = case era of
+    --     RecentEraBabbage -> Cardano.WithdrawalsInBabbageEra
+    --     RecentEraConway -> Cardano.WithdrawalsInConwayEra
 
-    txValidityUpperBoundSupported
-        :: Cardano.ValidityUpperBoundSupportedInEra (Write.CardanoApiEra era)
-    txValidityUpperBoundSupported = case era of
-        RecentEraBabbage -> Cardano.ValidityUpperBoundInBabbageEra
-        RecentEraConway -> Cardano.ValidityUpperBoundInConwayEra
+    -- txValidityUpperBoundSupported
+    --     :: Cardano.ValidityUpperBoundSupportedInEra (Write.CardanoApiEra era)
+    -- txValidityUpperBoundSupported = case era of
+    --     RecentEraBabbage -> Cardano.ValidityUpperBoundInBabbageEra
+    --     RecentEraConway -> Cardano.ValidityUpperBoundInConwayEra
 
-    txValidityLowerBoundSupported
-        :: Maybe
-            (Cardano.ValidityLowerBoundSupportedInEra (Write.CardanoApiEra era))
-    txValidityLowerBoundSupported = case era of
-        RecentEraBabbage -> Just Cardano.ValidityLowerBoundInBabbageEra
-        RecentEraConway -> Just Cardano.ValidityLowerBoundInConwayEra
+    -- txValidityLowerBoundSupported
+    --     :: Maybe
+    --         (Cardano.ValidityLowerBoundSupportedInEra (Write.CardanoApiEra era))
+    -- txValidityLowerBoundSupported = case era of
+    --     RecentEraBabbage -> Just Cardano.ValidityLowerBoundInBabbageEra
+    --     RecentEraConway -> Just Cardano.ValidityLowerBoundInConwayEra
 
-    txMintingSupported
-        :: Maybe (Cardano.MultiAssetSupportedInEra (Write.CardanoApiEra era))
-    txMintingSupported = case era of
-        RecentEraBabbage -> Just Cardano.MultiAssetInBabbageEra
-        RecentEraConway -> Just Cardano.MultiAssetInConwayEra
+    txMintingSupported :: a
+    txMintingSupported = error "TODO conway: txMintingSupported"
+    -- txMintingSupported
+    --     :: Maybe (Cardano.MultiAssetSupportedInEra (Write.CardanoApiEra era))
+    -- txMintingSupported = case era of
+    --     RecentEraBabbage -> Just Cardano.MultiAssetInBabbageEra
+    --     RecentEraConway -> Just Cardano.MultiAssetInConwayEra
 
     scriptWitsSupported
         :: Cardano.ScriptLanguageInEra
@@ -1035,16 +1052,18 @@ mkUnsignedTx
         RecentEraBabbage -> Cardano.SimpleScriptInBabbage
         RecentEraConway -> Cardano.SimpleScriptInConway
 
-    referenceInpsSupported
-        :: Maybe
-            (Cardano.ReferenceTxInsScriptsInlineDatumsSupportedInEra
-                (Write.CardanoApiEra era)
-            )
-    referenceInpsSupported = case era of
-        RecentEraBabbage ->
-            Just Cardano.ReferenceTxInsScriptsInlineDatumsInBabbageEra
-        RecentEraConway ->
-            Just Cardano.ReferenceTxInsScriptsInlineDatumsInConwayEra
+    referenceInpsSupported :: a
+    referenceInpsSupported = error "TODO conway: referenceInpsSupported"
+    -- referenceInpsSupported
+    --     :: Maybe
+    --         (Cardano.ReferenceTxInsScriptsInlineDatumsSupportedInEra
+    --             (Write.CardanoApiEra era)
+    --         )
+    -- referenceInpsSupported = case era of
+    --     RecentEraBabbage ->
+    --         Just Cardano.ReferenceTxInsScriptsInlineDatumsInBabbageEra
+    --     RecentEraConway ->
+    --         Just Cardano.ReferenceTxInsScriptsInlineDatumsInConwayEra
 
     toScriptWitness
         :: Script KeyHash
@@ -1091,7 +1110,6 @@ dummyInput = TxIn (Hash $ BS.replicate 32 0) 999
 
 removeDummyInput :: HasCallStack => Cardano.TxBody era -> Cardano.TxBody era
 removeDummyInput = \case
-    Byron.ByronTxBody{} -> bailOut
     Cardano.ShelleyTxBody era body scripts scriptData aux val -> case era of
         ShelleyBasedEraShelley -> bailOut
         ShelleyBasedEraAllegra -> bailOut
@@ -1146,7 +1164,8 @@ mkShelleyWitness
     -> (XPrv, Passphrase "encryption")
     -> Cardano.KeyWitness (CardanoApiEra era)
 mkShelleyWitness _era body key =
-    Cardano.makeShelleyKeyWitness body (unencrypt key)
+    error "TODO conway: mkShelleyWitness"
+    -- Cardano.makeShelleyKeyWitness body (unencrypt key)
   where
     unencrypt (xprv, pwd) = Cardano.WitnessPaymentExtendedKey
         $ Cardano.PaymentExtendedSigningKey
@@ -1160,8 +1179,8 @@ mkByronWitness
     -> Address
     -> (XPrv, Passphrase "encryption")
     -> Cardano.KeyWitness (CardanoApiEra era)
-mkByronWitness _ (Byron.ByronTxBody _ :: Cardano.TxBody byronEra) _ _ _ =
-    case Write.recentEra @(ShelleyLedgerEra byronEra) of {}
+-- mkByronWitness _ (Byron.ByronTxBody _ :: Cardano.TxBody byronEra) _ _ _ =
+--     case Write.recentEra @(ShelleyLedgerEra byronEra) of {}
 mkByronWitness
     era
     (Cardano.ShelleyTxBody
@@ -1189,19 +1208,20 @@ mkByronWitness
         (Byron.toByronNetworkMagic nw)
 
 explicitFees :: ShelleyBasedEra era -> Cardano.Lovelace -> Cardano.TxFee era
-explicitFees era = case era of
-    ShelleyBasedEraShelley ->
-        Cardano.TxFeeExplicit Cardano.TxFeesExplicitInShelleyEra
-    ShelleyBasedEraAllegra ->
-        Cardano.TxFeeExplicit Cardano.TxFeesExplicitInAllegraEra
-    ShelleyBasedEraMary ->
-        Cardano.TxFeeExplicit Cardano.TxFeesExplicitInMaryEra
-    ShelleyBasedEraAlonzo ->
-        Cardano.TxFeeExplicit Cardano.TxFeesExplicitInAlonzoEra
-    ShelleyBasedEraBabbage ->
-        Cardano.TxFeeExplicit Cardano.TxFeesExplicitInBabbageEra
-    ShelleyBasedEraConway ->
-        Cardano.TxFeeExplicit Cardano.TxFeesExplicitInConwayEra
+explicitFees = error "TODO conway: explicitFees"
+-- explicitFees era = case era of
+--     ShelleyBasedEraShelley ->
+--         Cardano.TxFeeExplicit Cardano.TxFeesExplicitInShelleyEra
+--     ShelleyBasedEraAllegra ->
+--         Cardano.TxFeeExplicit Cardano.TxFeesExplicitInAllegraEra
+--     ShelleyBasedEraMary ->
+--         Cardano.TxFeeExplicit Cardano.TxFeesExplicitInMaryEra
+--     ShelleyBasedEraAlonzo ->
+--         Cardano.TxFeeExplicit Cardano.TxFeesExplicitInAlonzoEra
+--     ShelleyBasedEraBabbage ->
+--         Cardano.TxFeeExplicit Cardano.TxFeesExplicitInBabbageEra
+--     ShelleyBasedEraConway ->
+--         Cardano.TxFeeExplicit Cardano.TxFeesExplicitInConwayEra
 
 txConstraints
     :: forall era. IsRecentEra era

--- a/lib/wallet/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/wallet/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -188,7 +188,7 @@ dummyNodeProtocolParameters = C.ProtocolParameters
     , C.protocolParamPoolPledgeInfluence = 0.3 -- a0
     , C.protocolParamMonetaryExpansion = 0.003 -- rho
     , C.protocolParamTreasuryCut = 0.20 -- tau
-    , C.protocolParamUTxOCostPerWord = Just $ C.Lovelace 34_482
+    -- , C.protocolParamUTxOCostPerWord = Just $ C.Lovelace 34_482
     , C.protocolParamUTxOCostPerByte = Just $ C.Lovelace 43_10
     , C.protocolParamCostModels = mempty
     , C.protocolParamPrices =
@@ -294,7 +294,7 @@ babbageMainnetProtocolParameters = C.ProtocolParameters
     , C.protocolParamPoolPledgeInfluence = 0.3 -- a0
     , C.protocolParamMonetaryExpansion = 0.003 -- rho
     , C.protocolParamTreasuryCut = 0.20 -- tau
-    , C.protocolParamUTxOCostPerWord = Just $ C.Lovelace 34_482
+    -- , C.protocolParamUTxOCostPerWord = Just $ C.Lovelace 34_482
     , C.protocolParamUTxOCostPerByte = Just $ C.Lovelace 4_310
     , C.protocolParamCostModels =
         mempty

--- a/lib/wallet/test/integration/integration-tests.hs
+++ b/lib/wallet/test/integration/integration-tests.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Main where
 

--- a/lib/wallet/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/wallet/test/unit/Cardano/Pool/DB/Properties.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/LayerSpec.hs
@@ -17,6 +17,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Cardano.Wallet.Shelley.CompatibilitySpec
     ( spec

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}


### PR DESCRIPTION
A branch to aid working in parallel on different sublibs for the conway compile time bump.
The commits contains real fixed, to be merged when there are no bogus fixes preceding, and bogus fixes that are fixes that satisfy the compiler but introduce errors with "TODO conway:" inside.
This branch is supposed to be rebased on branches that contain the single fixes.

- [x] Bogus fixes on `cardano-api-extra` lib to allow working on dependent libraries
- [x] Bogus fixes on `coin-selection` lib to allow working on dependent libraries
- [x] Bogus fixes on `balance-tx` lib to allow working on dependent libraries
- [x] Real fixes on `network-layer` lib to allow working on dependent libraries
- [x] Real fixes for `application-extras`
- [x] Real fixes for `address-derivation-discovery`
- [x] Real fixes for `faucet`
- [x] Real fixes for `launcher`
- [x] Real fixes for `local-cluster`
- [x] Real fixes for `wai-middleware-logging`
- [x] Real fixes for `wallet-e2e`
- [x] Real fixes for `iohk-monitoring-extra`
- [x] Bogus fixes for `cardano-wallet`
- [x] Partial fixes for `cardano-wallet-api`
- [x] Real fixes for `cardano-wallet` benchmarks
- [x] Bogus fixes for `cardano-wallet` tests
- [x] Disable unused-packages flag
