### PR TITLE
[Experimental] Simplify the use of recent eras

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -671,7 +671,7 @@ serializeTx
     :: forall era. IsRecentEra era
     => Core.Tx era
     -> ByteString
-serializeTx tx = CardanoApi.serialiseToCBOR $ toCardanoApiTx @era tx
+serializeTx tx = CardanoApi.serialiseToCBOR $ toCardanoApiTx recentEra tx
 
 --------------------------------------------------------------------------------
 -- Compatibility
@@ -690,10 +690,11 @@ fromCardanoApiTx = \case
 
 toCardanoApiTx
     :: forall era. IsRecentEra era
-    => Core.Tx era
+    => RecentEra era
+    -> Core.Tx era
     -> CardanoApi.Tx (CardanoApiEra era)
-toCardanoApiTx =
-    CardanoApi.ShelleyTx (shelleyBasedEraFromRecentEra $ recentEra @era)
+toCardanoApiTx era =
+    CardanoApi.ShelleyTx (shelleyBasedEraFromRecentEra era)
 
 toCardanoApiUTxO
     :: forall era. IsRecentEra era

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -689,12 +689,11 @@ fromCardanoApiTx = \case
             {}
 
 toCardanoApiTx
-    :: forall era. IsRecentEra era
-    => RecentEra era
+    :: RecentEra era
     -> Core.Tx era
     -> CardanoApi.Tx (CardanoApiEra era)
 toCardanoApiTx era =
-    CardanoApi.ShelleyTx (shelleyBasedEraFromRecentEra era)
+    withRecentEra era $ CardanoApi.ShelleyTx (shelleyBasedEraFromRecentEra era)
 
 toCardanoApiUTxO
     :: forall era. IsRecentEra era

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -678,13 +678,12 @@ serializeTx tx = CardanoApi.serialiseToCBOR $ toCardanoApiTx recentEra tx
 --------------------------------------------------------------------------------
 
 fromCardanoApiTx
-    :: forall era. IsRecentEra era
-    => RecentEra era
+    :: RecentEra era
     -> CardanoApi.Tx (CardanoApiEra era)
     -> Core.Tx era
 fromCardanoApiTx era = \case
     CardanoApi.ShelleyTx _era tx ->
-        tx
+        withRecentEra era tx
     CardanoApi.ByronTx {} ->
         case era of
             {}

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -39,6 +39,7 @@ module Internal.Cardano.Write.Tx
     , CardanoApiEra
     , toRecentEra
     , fromRecentEra
+    , withRecentEra
     , MaybeInRecentEra (..)
     , toRecentEraGADT
     , LatestLedgerEra
@@ -372,6 +373,11 @@ fromRecentEra :: RecentEra era -> CardanoApi.CardanoEra (CardanoApiEra era)
 fromRecentEra = \case
     RecentEraConway -> CardanoApi.ConwayEra
     RecentEraBabbage -> CardanoApi.BabbageEra
+
+withRecentEra :: RecentEra era -> (IsRecentEra era => a) -> a
+withRecentEra era a = case era of
+    RecentEraBabbage -> a
+    RecentEraConway -> a
 
 instance IsRecentEra BabbageEra where
     recentEra = RecentEraBabbage

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -679,13 +679,14 @@ serializeTx tx = CardanoApi.serialiseToCBOR $ toCardanoApiTx recentEra tx
 
 fromCardanoApiTx
     :: forall era. IsRecentEra era
-    => CardanoApi.Tx (CardanoApiEra era)
+    => RecentEra era
+    -> CardanoApi.Tx (CardanoApiEra era)
     -> Core.Tx era
-fromCardanoApiTx = \case
+fromCardanoApiTx era = \case
     CardanoApi.ShelleyTx _era tx ->
         tx
     CardanoApi.ByronTx {} ->
-        case (recentEra @era) of
+        case era of
             {}
 
 toCardanoApiTx

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -656,11 +656,10 @@ isBelowMinimumCoinForTxOut pp out =
 -- Used to have a possibility for failure when we supported Alonzo and Babbage,
 -- and could possibly become failable again with future eras.
 utxoFromTxOutsInRecentEra
-    :: forall era. IsRecentEra era
-    => RecentEra era
+    :: RecentEra era
     -> [(TxIn, TxOutInRecentEra)]
     -> Shelley.UTxO era
-utxoFromTxOutsInRecentEra era =
+utxoFromTxOutsInRecentEra era = withRecentEra era $
     Shelley.UTxO . Map.fromList . map (second (unwrapTxOutInRecentEra era))
 
 --------------------------------------------------------------------------------

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -479,9 +479,10 @@ data UTxOIndex era = UTxOIndex
 
 constructUTxOIndex
     :: forall era. IsRecentEra era
-    => UTxO era
+    => RecentEra era
+    -> UTxO era
     -> UTxOIndex era
-constructUTxOIndex ledgerUTxO =
+constructUTxOIndex _era ledgerUTxO =
     UTxOIndex {walletUTxOIndex, ledgerUTxO}
   where
     walletUTxOIndex =

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -507,7 +507,8 @@ balanceTransaction
         ( MonadRandom m
         , IsRecentEra era
         )
-    => PParams era
+    => RecentEra era
+    -> PParams era
     -- Protocol parameters. Can be retrieved via Local State Query to a
     -- local node.
     --
@@ -532,6 +533,7 @@ balanceTransaction
     -> PartialTx era
     -> ExceptT (ErrBalanceTx era) m (Tx era, changeState)
 balanceTransaction
+    _era
     pp
     timeTranslation
     utxoAssumptions

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -478,14 +478,14 @@ data UTxOIndex era = UTxOIndex
     }
 
 constructUTxOIndex
-    :: forall era. IsRecentEra era
-    => RecentEra era
+    :: RecentEra era
     -> UTxO era
     -> UTxOIndex era
-constructUTxOIndex _era ledgerUTxO =
+constructUTxOIndex era ledgerUTxO =
     UTxOIndex {walletUTxOIndex, ledgerUTxO}
   where
     walletUTxOIndex =
+        withRecentEra era $
         UTxOIndex.fromMap $ toInternalUTxOMap $ toWalletUTxO ledgerUTxO
 
 fromWalletUTxO

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Sign.hs
@@ -235,7 +235,7 @@ estimateKeyWitnessCounts utxo tx timelockKeyWitCounts =
             nonInputWits <> inputWits
   where
     CardanoApi.Tx (CardanoApi.TxBody txbodycontent) _keyWits
-        = toCardanoApiTx tx
+        = toCardanoApiTx recentEra tx
 
     timelockTotalWitCount :: Natural
     timelockTotalWitCount = sum $ Map.elems $ Map.unionWith

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2226,6 +2226,7 @@ balanceTx
     (`evalRand` stdGenFromSeed seed) $ runExceptT $ do
         (transactionInEra, _nextChangeState) <-
             balanceTransaction
+                recentEra
                 protocolParameters
                 timeTranslation
                 utxoAssumptions
@@ -2250,6 +2251,7 @@ balanceTransactionWithDummyChangeState
 balanceTransactionWithDummyChangeState utxoAssumptions utxo seed partialTx =
     (`evalRand` stdGenFromSeed seed) $ runExceptT $
         balanceTransaction
+            recentEra
             mockPParamsForBalancing
             dummyTimeTranslation
             utxoAssumptions

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2323,7 +2323,7 @@ restrictResolution
 restrictResolution (PartialTx tx inputs redeemers timelockKeyWitnessCounts) =
     let
         CardanoApi.UTxO u = toCardanoApiUTxO @era inputs
-        u' = u `Map.restrictKeys` (inputsInTx (toCardanoApiTx @era tx))
+        u' = u `Map.restrictKeys` (inputsInTx (toCardanoApiTx recentEra tx))
         inputs' = fromCardanoApiUTxO @era (CardanoApi.UTxO u')
     in
         PartialTx tx inputs' redeemers timelockKeyWitnessCounts
@@ -2781,7 +2781,7 @@ instance Arbitrary (PartialTx Write.BabbageEra) where
                 inputUTxO
                 redeemers
                 timelockKeyWitnessCounts
-        | tx' <- shrinkTxBabbage (toCardanoApiTx tx)
+        | tx' <- shrinkTxBabbage (toCardanoApiTx recentEra tx)
         ]
 
 instance Arbitrary StdGenSeed  where

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2263,7 +2263,9 @@ balanceTransactionWithDummyChangeState utxoAssumptions utxo seed partialTx =
     utxoIndex = constructUTxOIndex recentEra $ fromWalletUTxO utxo
 
 deserializeBabbageTx :: ByteString -> Tx Write.BabbageEra
-deserializeBabbageTx = fromCardanoApiTx @BabbageEra . either (error . show) id
+deserializeBabbageTx
+    = fromCardanoApiTx RecentEraBabbage
+    . either (error . show) id
     . CardanoApi.deserialiseFromCBOR (CardanoApi.AsTx CardanoApi.AsBabbageEra)
 
 hasInsCollateral
@@ -2767,7 +2769,7 @@ instance Arbitrary (PartialTx Write.BabbageEra) where
                 return (fst i, o)
         let redeemers = []
         return $ PartialTx
-            (fromCardanoApiTx tx)
+            (fromCardanoApiTx recentEra tx)
             (fromCardanoApiUTxO inputUTxO)
             (redeemers)
             mempty
@@ -2777,7 +2779,7 @@ instance Arbitrary (PartialTx Write.BabbageEra) where
         ] <>
         [ restrictResolution $
             PartialTx
-                (fromCardanoApiTx tx')
+                (fromCardanoApiTx recentEra tx')
                 inputUTxO
                 redeemers
                 timelockKeyWitnessCounts

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2236,7 +2236,7 @@ balanceTx
                 partialTx
         pure transactionInEra
   where
-    utxoIndex = constructUTxOIndex @era $ fromWalletUTxO utxo
+    utxoIndex = constructUTxOIndex recentEra $ fromWalletUTxO utxo
 
 -- | Also returns the updated change state
 balanceTransactionWithDummyChangeState
@@ -2260,7 +2260,7 @@ balanceTransactionWithDummyChangeState utxoAssumptions utxo seed partialTx =
             (DummyChangeState 0)
             partialTx
   where
-    utxoIndex = constructUTxOIndex @era $ fromWalletUTxO utxo
+    utxoIndex = constructUTxOIndex recentEra $ fromWalletUTxO utxo
 
 deserializeBabbageTx :: ByteString -> Tx Write.BabbageEra
 deserializeBabbageTx = fromCardanoApiTx @BabbageEra . either (error . show) id

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3511,6 +3511,7 @@ balanceTransaction
                 . fst
                 )
             $ Write.balanceTransaction
+                era
                 pp
                 timeTranslation
                 utxoAssumptions

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2038,7 +2038,7 @@ selectCoins ctx@ApiLayer {..} argGenChange (ApiT walletId) body = do
     withWorkerCtx ctx walletId liftE liftE $ \workerCtx -> do
         let db = workerCtx ^. dbLayer
 
-        (Write.PParamsInAnyRecentEra _era pp, timeTranslation)
+        (Write.PParamsInAnyRecentEra era pp, timeTranslation)
             <- liftIO $ W.readNodeTipStateForTxWrite netLayer
 
         withdrawal <-
@@ -2057,7 +2057,7 @@ selectCoins ctx@ApiLayer {..} argGenChange (ApiT walletId) body = do
 
         (tx, walletState) <-
             liftIO $
-            W.buildTransaction @s
+            W.buildTransaction @s era
             db timeTranslation genChange pp txCtx paymentOuts
 
         let W.CoinSelection{..} =
@@ -2104,7 +2104,7 @@ selectCoinsForJoin ctx@ApiLayer{..}
     --
     poolStatus <- liftIO $ getPoolStatus poolId
     pools <- liftIO knownPools
-    (Write.PParamsInAnyRecentEra _era pp, timeTranslation)
+    (Write.PParamsInAnyRecentEra era pp, timeTranslation)
         <- liftIO @Handler $ W.readNodeTipStateForTxWrite netLayer
     withWorkerCtx ctx walletId liftE liftE $ \workerCtx -> liftIO $ do
         let db = workerCtx ^. typed @(DBLayer IO s)
@@ -2123,7 +2123,7 @@ selectCoinsForJoin ctx@ApiLayer{..}
         let paymentOuts = []
 
         (tx, walletState) <-
-            W.buildTransaction @s
+            W.buildTransaction @s era
             db timeTranslation changeAddrGen pp txCtx paymentOuts
 
         let W.CoinSelection{..} =
@@ -2160,7 +2160,7 @@ selectCoinsForQuit
     -> ApiT WalletId
     -> Handler (ApiCoinSelection n)
 selectCoinsForQuit ctx@ApiLayer{..} (ApiT walletId) = do
-    (Write.PParamsInAnyRecentEra _era pp, timeTranslation)
+    (Write.PParamsInAnyRecentEra era pp, timeTranslation)
         <- liftIO $ W.readNodeTipStateForTxWrite netLayer
     withWorkerCtx ctx walletId liftE liftE $ \workerCtx -> liftIO $ do
         let db = workerCtx ^. typed @(DBLayer IO s)
@@ -2180,7 +2180,7 @@ selectCoinsForQuit ctx@ApiLayer{..} (ApiT walletId) = do
         let paymentOuts = []
 
         (tx, walletState) <-
-            W.buildTransaction @s
+            W.buildTransaction @s era
             db timeTranslation changeAddrGen pp txCtx paymentOuts
 
         let W.CoinSelection{..} =

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3528,10 +3528,9 @@ balanceTransaction
                 (ApiT $ W.sealedTxFromCardano balancedTx) Base64Encoded
   where
     parsePartialTx
-        :: Write.IsRecentEra era
-        => Write.RecentEra era
+        :: Write.RecentEra era
         -> Handler (Write.PartialTx era)
-    parsePartialTx era = do
+    parsePartialTx era = Write.withRecentEra era $ do
         let externalUTxO
                 = Write.utxoFromTxOutsInRecentEra era
                 $ map fromExternalInput

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3507,7 +3507,7 @@ balanceTransaction
         balancedTx <- liftHandler
             . fmap
                 ( Cardano.InAnyCardanoEra Write.cardanoEra
-                . Write.toCardanoApiTx
+                . Write.toCardanoApiTx era
                 . fst
                 )
             $ Write.balanceTransaction

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3548,7 +3548,7 @@ balanceTransaction
             $ body ^. #transaction
 
         pure $ Write.PartialTx
-            (Write.fromCardanoApiTx tx)
+            (Write.fromCardanoApiTx era tx)
             externalUTxO
             (fromApiRedeemer <$> body ^. #redeemers)
             timelockKeyWitnessCounts

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3501,7 +3501,7 @@ balanceTransaction
     withWorkerCtx ctx wid liftE liftE $ \wrk -> do
         (utxo, wallet, _txs) <- handler $ W.readWalletUTxO wrk
         let utxoIndex =
-                Write.constructUTxOIndex $
+                Write.constructUTxOIndex era $
                 Write.fromWalletUTxO utxo
         partialTx <- parsePartialTx era
         balancedTx <- liftHandler

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2384,7 +2384,7 @@ buildTransactionPure
             changeAddrGen
             (getState wallet)
             PartialTx
-                { tx = Write.fromCardanoApiTx (Cardano.Tx unsignedTxBody [])
+                { tx = Write.fromCardanoApiTx era (Cardano.Tx unsignedTxBody [])
                 , inputs = Write.UTxO mempty
                 , redeemers = []
                 , timelockKeyWitnessCounts = mempty
@@ -3018,7 +3018,8 @@ transactionFee DBLayer{atomically, walletState} protocolParams
                 (Left preSelection)
 
         let ptx = PartialTx
-                { tx = Write.fromCardanoApiTx (Cardano.Tx unsignedTxBody [])
+                { tx = Write.fromCardanoApiTx recentEra
+                    (Cardano.Tx unsignedTxBody [])
                 , inputs = Write.UTxO mempty
                 , redeemers = []
                 , timelockKeyWitnessCounts = mempty

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2188,7 +2188,6 @@ buildAndSignTransactionPure
        , IsOurs s RewardAccount
        , IsOurs s Address
        , WalletFlavor s
-       , Write.IsRecentEra era
        , k ~ KeyOf s
        , CredFromOf s ~ 'CredFromKeyK
        , Excluding '[SharedKey] k
@@ -2243,7 +2242,10 @@ buildAndSignTransactionPure
             (RootCredentials rootKey passphrase)
             (wallet ^. #utxo)
             Nothing
-            (sealedTxFromCardano $ inAnyCardanoEra unsignedBalancedTx)
+            (Write.withRecentEra era
+                $ sealedTxFromCardano
+                $ inAnyCardanoEra unsignedBalancedTx
+            )
 
         ( tx
             , _tokenMapWithScripts1
@@ -2288,7 +2290,10 @@ buildAndSignTransactionPure
         }
   where
     wF = walletFlavor @s
-    anyCardanoEra = Cardano.AnyCardanoEra $ Write.cardanoEra @era
+    anyCardanoEra
+        = Write.withRecentEra era
+        $ Cardano.AnyCardanoEra
+        $ Write.cardanoEraFromRecentEra era
 
 buildTransaction
     :: forall s era.

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2482,10 +2482,7 @@ constructTransaction era db txCtx preSel = do
     netId = networkIdVal $ sNetworkId @n
 
 constructUnbalancedSharedTransaction
-    :: forall n era.
-        ( Write.IsRecentEra era
-        , HasSNetworkId n
-        )
+    :: forall n era. HasSNetworkId n
     => Write.RecentEra era
     -> DBLayer IO (SharedState n SharedKey)
     -> TransactionCtx

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2291,7 +2291,6 @@ buildAndSignTransactionPure
 buildTransaction
     :: forall s era.
         ( WalletFlavor s
-        , Write.IsRecentEra era
         , AddressBookIso s
         , HasSNetworkId (NetworkOf s)
         , Excluding '[SharedKey] (KeyOf s)
@@ -2306,7 +2305,7 @@ buildTransaction
     -- ^ payment outputs
     -> IO (Write.Tx era, Wallet s)
 buildTransaction era DBLayer{..} timeTranslation changeAddrGen
-    protocolParameters txCtx paymentOuts = do
+    protocolParameters txCtx paymentOuts = Write.withRecentEra era $ do
     stdGen <- initStdGen
     atomically $ do
         wallet <- readDBVar walletState <&> WalletState.getLatest

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2365,7 +2365,7 @@ buildTransactionPure
                 txCtx
                 (Left preSelection)
     let utxoIndex =
-            Write.constructUTxOIndex @era $
+            Write.constructUTxOIndex era $
             Write.fromWalletUTxO utxo
     withExceptT Left $
         balanceTransaction @_ @_ @s
@@ -3000,7 +3000,7 @@ transactionFee DBLayer{atomically, walletState} protocolParams
             -- strict, and each field is defined in terms of 'Data.Map.Strict'.
             --
             evaluate
-                $ Write.constructUTxOIndex @era
+                $ Write.constructUTxOIndex recentEra
                 $ Write.fromWalletUTxO
                 $ availableUTxO mempty wallet
         unsignedTxBody <- wrapErrMkTransaction $

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2468,8 +2468,7 @@ buildAndSignTransaction ctx wid mkRwdAcct pwd txCtx sel = db & \DBLayer{..} ->
 
 -- | Construct an unsigned transaction from a given selection.
 constructTransaction
-    :: forall n era
-     . (Write.IsRecentEra era, HasSNetworkId n)
+    :: forall n era. HasSNetworkId n
     => Write.RecentEra era
     -> DBLayer IO (SeqState n ShelleyKey)
     -> TransactionCtx

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2296,7 +2296,8 @@ buildTransaction
         , HasSNetworkId (NetworkOf s)
         , Excluding '[SharedKey] (KeyOf s)
         )
-    => DBLayer IO s
+    => Write.RecentEra era
+    -> DBLayer IO s
     -> TimeTranslation
     -> ChangeAddressGen s
     -> Write.PParams era
@@ -2304,7 +2305,7 @@ buildTransaction
     -> [TxOut]
     -- ^ payment outputs
     -> IO (Write.Tx era, Wallet s)
-buildTransaction DBLayer{..} timeTranslation changeAddrGen
+buildTransaction era DBLayer{..} timeTranslation changeAddrGen
     protocolParameters txCtx paymentOuts = do
     stdGen <- initStdGen
     atomically $ do
@@ -2323,7 +2324,7 @@ buildTransaction DBLayer{..} timeTranslation changeAddrGen
 
         fmap (\s' -> wallet { getState = s' }) <$>
             buildTransactionPure @s @era
-                recentEra
+                era
                 wallet
                 timeTranslation
                 utxo

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2367,6 +2367,7 @@ buildTransactionPure
             Write.fromWalletUTxO utxo
     withExceptT Left $
         balanceTransaction @_ @_ @s
+            recentEra
             pparams
             timeTranslation
             (utxoAssumptionsForWallet (walletFlavor @s))
@@ -3017,6 +3018,7 @@ transactionFee DBLayer{atomically, walletState} protocolParams
         wrapErrBalanceTx $ calculateFeePercentiles $ do
             res <- runExceptT $
                 balanceTransaction @_ @_ @s
+                    recentEra
                     protocolParams
                     timeTranslation
                     (utxoAssumptionsForWallet (walletFlavor @s))

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2338,8 +2338,7 @@ buildTransaction DBLayer{..} timeTranslation changeAddrGen
 
 buildTransactionPure
     :: forall s era.
-        ( Write.IsRecentEra era
-        , WalletFlavor s
+        ( WalletFlavor s
         , Excluding '[SharedKey] (KeyOf s)
         , HasSNetworkId (NetworkOf s)
         )
@@ -2357,10 +2356,10 @@ buildTransactionPure
         (Write.Tx era, s)
 buildTransactionPure
     era wallet timeTranslation utxo changeAddrGen pparams preSelection txCtx
-    = do
+    = Write.withRecentEra era $ do
     unsignedTxBody <-
         withExceptT (Right . ErrConstructTxBody) . except $
-            mkUnsignedTransaction (recentEra @era)
+            mkUnsignedTransaction era
                 (networkIdVal $ sNetworkId @(NetworkOf s))
                 (Left $ unsafeShelleyOnlyGetRewardXPub @s (getState wallet))
                 txCtx

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1936,7 +1936,7 @@ buildCoinSelectionForTransaction
   where
     Cardano.TxBody Cardano.TxBodyContent
         { txIns, txOuts, txInsCollateral, txWithdrawals } =
-            Cardano.getTxBody $ Write.toCardanoApiTx tx
+            Cardano.getTxBody $ Write.toCardanoApiTx recentEra tx
 
     resolveInput txIn = do
         (txOut, derivationPath) <- maybeToList (lookupTxIn wallet txIn)
@@ -2214,7 +2214,7 @@ buildAndSignTransactionPure
     pp txLayer changeAddrGen preSelection txCtx = do
     wallet <- get
     (unsignedBalancedTx, updatedWalletState) <- lift $
-        first Write.toCardanoApiTx <$>
+        first (Write.toCardanoApiTx era) <$>
         buildTransactionPure @s @era
             era
             wallet

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -320,7 +320,7 @@ constructUnsignedTx
     mintingScripts = Map.union (snd toMint) (snd toBurn)
 
 mkTransaction
-    :: forall era k. IsRecentEra era
+    :: forall era k. ()
     => RecentEra era
     -- ^ Era for which the transaction should be created.
     -> Cardano.NetworkId
@@ -364,7 +364,9 @@ mkTransaction era networkId keyF stakeCreds addrResolver ctx cs = do
             Nothing
             Nothing
     let signed :: Cardano.Tx (CardanoApiEra era)
-        signed = Write.toCardanoApiTx $
+        signed =
+            Write.withRecentEra era $
+            Write.toCardanoApiTx $
             signTransaction
                 era
                 keyF
@@ -381,7 +383,7 @@ mkTransaction era networkId keyF stakeCreds addrResolver ctx cs = do
             tx {resolvedInputs = second Just <$> F.toList (view #inputs cs)}
     Right
         ( withResolvedInputs (fromCardanoTx AnyWitnessCountCtx signed)
-        , sealedTxFromCardano' signed
+        , Write.withRecentEra era $ sealedTxFromCardano' signed
         )
   where
     inputResolver :: TxIn -> Maybe Address

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -287,8 +287,7 @@ data TxPayload era = TxPayload
     }
 
 constructUnsignedTx
-    :: forall era
-     . IsRecentEra era
+    :: forall era. ()
     => RecentEra era
     -> Cardano.NetworkId
     -> (Maybe Cardano.TxMetadata, [Cardano.Certificate])
@@ -664,8 +663,7 @@ withRecentEraLedgerTx (InAnyCardanoEra era tx) f = case era of
 -- in separate step.
 --
 mkUnsignedTransaction
-    :: forall era
-     . Write.IsRecentEra era
+    :: forall era. ()
     => Write.RecentEra era
     -> NetworkId
     -> Either XPub (Maybe (Script KeyHash))
@@ -774,7 +772,7 @@ mkDelegationCertificates da cred =
 --
 -- Which suggests that we may get away with Shelley-only transactions for now?
 mkUnsignedTx
-    :: forall era. Write.IsRecentEra era
+    :: forall era. ()
     => Write.RecentEra era
     -> (Maybe SlotNo, SlotNo)
     -> Either PreSelection (SelectionOf TxOut)
@@ -805,6 +803,7 @@ mkUnsignedTx
     refScriptM = extractValidatedOutputs cs >>= \outs ->
     left toErrMkTx
     $ fmap removeDummyInput
+    $ Write.withRecentEra era
     $ Cardano.createAndValidateTransactionBody
     Cardano.TxBodyContent
     { Cardano.txIns = inputWits

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1137,13 +1137,12 @@ mkWithdrawals networkId wdrl = case wdrl of
     stakeAddress = Cardano.makeStakeAddress networkId . toCardanoStakeCredential
 
 mkShelleyWitness
-    :: Write.IsRecentEra era
-    => RecentEra era
+    :: RecentEra era
     -> Cardano.TxBody (CardanoApiEra era)
     -> (XPrv, Passphrase "encryption")
     -> Cardano.KeyWitness (CardanoApiEra era)
-mkShelleyWitness _era body key =
-    Cardano.makeShelleyKeyWitness body (unencrypt key)
+mkShelleyWitness era body key =
+    Write.withRecentEra era $ Cardano.makeShelleyKeyWitness body (unencrypt key)
   where
     unencrypt (xprv, pwd) = Cardano.WitnessPaymentExtendedKey
         $ Cardano.PaymentExtendedSigningKey

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -366,7 +366,7 @@ mkTransaction era networkId keyF stakeCreds addrResolver ctx cs = do
     let signed :: Cardano.Tx (CardanoApiEra era)
         signed =
             Write.withRecentEra era $
-            Write.toCardanoApiTx $
+            Write.toCardanoApiTx era $
             signTransaction
                 era
                 keyF
@@ -442,8 +442,9 @@ signTransaction
     Write.withRecentEra era $
     Write.fromCardanoApiTx $ Cardano.makeSignedTransaction wits' body
  where
-    Cardano.Tx body wits = Write.withRecentEra era $
-        Write.toCardanoApiTx txToSign
+    Cardano.Tx body wits
+        = Write.withRecentEra era
+        $ Write.toCardanoApiTx era txToSign
 
     wits' = mconcat
         [ wits
@@ -636,13 +637,13 @@ withRecentEraLedgerTx
 withRecentEraLedgerTx (InAnyCardanoEra era tx) f = case era of
     Cardano.ConwayEra -> Just
         . InAnyCardanoEra era
-        . Write.toCardanoApiTx
+        . Write.toCardanoApiTx Write.RecentEraConway
         . f
         . Write.fromCardanoApiTx
         $ tx
     Cardano.BabbageEra -> Just
         . InAnyCardanoEra era
-        . Write.toCardanoApiTx
+        . Write.toCardanoApiTx Write.RecentEraBabbage
         . f
         . Write.fromCardanoApiTx
         $ tx

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -378,7 +378,7 @@ mkTransaction era networkId keyF stakeCreds addrResolver ctx cs = do
                 (const Nothing)
                 addrResolver
                 inputResolver
-                (Write.fromCardanoApiTx $ Cardano.Tx unsigned [])
+                (Write.fromCardanoApiTx era $ Cardano.Tx unsigned [])
     let withResolvedInputs (tx, _, _, _, _, _) =
             tx {resolvedInputs = second Just <$> F.toList (view #inputs cs)}
     Right
@@ -440,7 +440,7 @@ signTransaction
     txToSign
     =
     Write.withRecentEra era $
-    Write.fromCardanoApiTx $ Cardano.makeSignedTransaction wits' body
+    Write.fromCardanoApiTx era $ Cardano.makeSignedTransaction wits' body
  where
     Cardano.Tx body wits
         = Write.withRecentEra era
@@ -639,13 +639,13 @@ withRecentEraLedgerTx (InAnyCardanoEra era tx) f = case era of
         . InAnyCardanoEra era
         . Write.toCardanoApiTx Write.RecentEraConway
         . f
-        . Write.fromCardanoApiTx
+        . Write.fromCardanoApiTx Write.RecentEraConway
         $ tx
     Cardano.BabbageEra -> Just
         . InAnyCardanoEra era
         . Write.toCardanoApiTx Write.RecentEraBabbage
         . f
-        . Write.fromCardanoApiTx
+        . Write.fromCardanoApiTx Write.RecentEraBabbage
         $ tx
     Cardano.AlonzoEra
         -> Nothing

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -229,7 +229,6 @@ import Internal.Cardano.Write.Tx
     ( CardanoApiEra
     , IsRecentEra
     , RecentEra (..)
-    , ShelleyLedgerEra
     )
 import Internal.Cardano.Write.Tx.SizeEstimation
     ( TxSkeleton (..)
@@ -1149,15 +1148,15 @@ mkShelleyWitness era body key =
         $ Crypto.HD.xPrvChangePass pwd BS.empty xprv
 
 mkByronWitness
-    :: forall era. IsRecentEra era
+    :: forall era. ()
     => RecentEra era
     -> Cardano.TxBody (CardanoApiEra era)
     -> Cardano.NetworkId
     -> Address
     -> (XPrv, Passphrase "encryption")
     -> Cardano.KeyWitness (CardanoApiEra era)
-mkByronWitness _ (Byron.ByronTxBody _ :: Cardano.TxBody byronEra) _ _ _ =
-    case Write.recentEra @(ShelleyLedgerEra byronEra) of {}
+mkByronWitness era (Byron.ByronTxBody _ :: Cardano.TxBody byronEra) _ _ _ =
+    case era of {}
 mkByronWitness
     era
     (Cardano.ShelleyTxBody

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -403,8 +403,7 @@ mkTransaction era networkId keyF stakeCreds addrResolver ctx cs = do
 --
 -- If a key for a given input isn't found, the input is skipped.
 signTransaction
-    :: forall era k ktype
-     . Write.IsRecentEra era
+    :: forall era k ktype. ()
     => RecentEra era
     -> KeyFlavorS k
     -> Cardano.NetworkId
@@ -438,9 +437,11 @@ signTransaction
     resolveInput
     txToSign
     =
+    Write.withRecentEra era $
     Write.fromCardanoApiTx $ Cardano.makeSignedTransaction wits' body
  where
-    Cardano.Tx body wits = Write.toCardanoApiTx txToSign
+    Cardano.Tx body wits = Write.withRecentEra era $
+        Write.toCardanoApiTx txToSign
 
     wits' = mconcat
         [ wits

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -366,7 +366,7 @@ mkTransaction era networkId keyF stakeCreds addrResolver ctx cs = do
     let signed :: Cardano.Tx (CardanoApiEra era)
         signed = Write.toCardanoApiTx $
             signTransaction
-                @era
+                era
                 keyF
                 networkId
                 AnyWitnessCountCtx
@@ -405,7 +405,8 @@ mkTransaction era networkId keyF stakeCreds addrResolver ctx cs = do
 signTransaction
     :: forall era k ktype
      . Write.IsRecentEra era
-    => KeyFlavorS k
+    => RecentEra era
+    -> KeyFlavorS k
     -> Cardano.NetworkId
     -- ^ Network identifier (e.g. mainnet, testnet)
     -> WitnessCountCtx
@@ -425,6 +426,7 @@ signTransaction
     -- ^ The transaction to sign, possibly with already some existing witnesses
     -> Write.Tx era
 signTransaction
+    era
     keyF
     networkId
     witCountCtx
@@ -438,8 +440,6 @@ signTransaction
     =
     Write.fromCardanoApiTx $ Cardano.makeSignedTransaction wits' body
  where
-    era = Write.recentEra @era
-
     Cardano.Tx body wits = Write.toCardanoApiTx txToSign
 
     wits' = mconcat
@@ -615,6 +615,7 @@ newTransactionLayer keyF networkId = TransactionLayer
                     (cardanoTxIdeallyNoLaterThan era sealedTx)
                     $ \ledgerTx ->
                         signTransaction
+                            Write.recentEra
                             keyF networkId witCountCtx acctResolver
                             policyResolver policyKeyM stakingScriptResolver
                             addressResolver inputResolver

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1316,8 +1316,7 @@ prop_sealedTxRecentEraRoundtrip
     sealedTxB = sealedTxFromBytes' currentEra txBytes
 
 makeShelleyTx
-    :: IsRecentEra era
-    => RecentEra era
+    :: RecentEra era
     -> DecodeSetup
     -> Cardano.Tx (CardanoApiEra era)
 makeShelleyTx era testCase = Cardano.makeSignedTransaction addrWits unsigned


### PR DESCRIPTION
**⚠️  Caution: experimental PR!**

This PR converts several functions to accept just a `RecentEra era` parameter instead of both a parameter and an `IsRecentEra era` constraint.

In some ways, this PR is the mirror image of an older PR (below) that attempts to remove parameters instead of removing constraints:
- https://github.com/cardano-foundation/cardano-wallet/pull/4287