### PR TITLE
[ADP-3258] Enable integration tests in Conway era

### DIFF
--- a/justfile
+++ b/justfile
@@ -64,8 +64,16 @@ integration-tests-cabal-match match:
   echo "Running integration tests with cardano-wallet exe compiled"
   LOCAL_CLUSTER_CONFIGS=../../lib/local-cluster/test/data/cluster-configs \
   CARDANO_WALLET_TEST_DATA=test/data \
-  TESTS_RETRY_FAILED=1 \
-  cabal test integration -O0 -v0 --test-options '--match="{{match}}"'
+  cabal test integration -O0 -v0 \
+    --test-options '--match="{{match}}"'
+
+# run any integration test matching the given pattern via cabal
+integration-tests-cabal-options options:
+  echo "Running integration tests with cardano-wallet exe compiled"
+  LOCAL_CLUSTER_CONFIGS=../../lib/local-cluster/test/data/cluster-configs \
+  CARDANO_WALLET_TEST_DATA=test/data \
+  cabal test integration -O0 -v0 \
+    --test-options 'options'
 
 # run babbage integration tests matching the given pattern via cabal
 babbage-integration-tests-cabal-match match:

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+LC_ALL := 'C.UTF-8'
+
 default:
   @just --list
 
@@ -5,9 +7,17 @@ default:
 syntax:
   ./.buildkite/check-code-format.sh
 
-# build wallet-e2e suite with cabal
+hlint:
+  nix develop --command bash -c 'hlint lib'
+
+# build wallet
 build:
-  cabal build all
+  cabal build all -Werror -O0 -v0
+
+# build after clean
+clean-build:
+  cabal clean
+  cabal build all -Werror -O0 -v0
 
 # run a nix shell with `cardano-wallet` in scope
 wallet:
@@ -27,19 +37,6 @@ local-cluster:
 unit:
   cabal run cardano-wallet:test:unit \
     --test-options '--cluster-configs lib/local-cluster/test/data/cluster-configs'
-
-# run integration tests
-integration:
-  LOCAL_CLUSTER_CONFIGS=lib/local-cluster/test/data/cluster-configs \
-  nix shell '.#cardano-wallet' -c cabal test integration
-
-babbage-integration-tests-cabal-no-wallet-match match:
-  echo "Running integration tests without cardano-wallet exe compiled"
-  LOCAL_CLUSTER_CONFIGS=../../lib/local-cluster/test/data/cluster-configs \
-  CARDANO_WALLET_TEST_DATA=test/data \
-  LOCAL_CLUSTER_ERA=babbage \
-  TESTS_RETRY_FAILED=1 \
-  cabal test integration -O0 -v0 --test-options '--match="{{match}}"'
 
 # run wallet-e2e suite against the preprod network
 e2e-preprod:
@@ -62,32 +59,59 @@ e2e-local:
 e2e-manual:
   nix run '.#cardano-wallet-e2e' -- manual
 
-#run integration tests locally via babbage-integration-exe
-babbage-integration-tests:
-  LOCAL_CLUSTER_CONFIGS=lib/local-cluster/test/data/cluster-configs \
-  CARDANO_WALLET_TEST_DATA=./lib/wallet/test/data \
+# run any integration test matching the given pattern via cabal
+integration-tests-cabal-match match:
+  echo "Running integration tests with cardano-wallet exe compiled"
+  LOCAL_CLUSTER_CONFIGS=../../lib/local-cluster/test/data/cluster-configs \
+  CARDANO_WALLET_TEST_DATA=test/data \
+  TESTS_RETRY_FAILED=1 \
+  cabal test integration -O0 -v0 --test-options '--match="{{match}}"'
+
+# run babbage integration tests matching the given pattern via cabal
+babbage-integration-tests-cabal-match match:
   LOCAL_CLUSTER_ERA=babbage \
-  TESTS_RETRY_FAILED=1 \
-  nix shell \
-    '.#cardano-node' \
-    '.#cardano-cli' \
-    '.#cardano-wallet' \
-    '.#integration-exe' \
-    -c integration-exe -j 3
+  just integration-tests-cabal-match "{{match}}"
 
-# run integration tests locally via conway-integration-exe
-conway-integration-tests:
+# run conway integration tests matching the given pattern via cabal
+conway-integration-tests-cabal-match match:
+  LOCAL_CLUSTER_ERA=conway \
+  just integration-tests-cabal-match "{{match}}"
+
+# run babbage integration tests via cabal
+babbage-integration-tests-cabal:
+  just babbage-integration-tests-cabal-match ""
+
+# run conway integration tests via cabal
+conway-integration-tests-cabal:
+  just conway-integration-tests-cabal-match ""
+
+
+# run any integration test matching the given pattern via nix
+integration-tests match:
   LOCAL_CLUSTER_CONFIGS=lib/local-cluster/test/data/cluster-configs \
   CARDANO_WALLET_TEST_DATA=./lib/wallet/test/data \
-  LOCAL_CLUSTER_ERA=conway \
   TESTS_RETRY_FAILED=1 \
   nix shell \
-    '.#local-cluster' \
     '.#cardano-node' \
     '.#cardano-cli' \
     '.#cardano-wallet' \
     '.#integration-exe' \
-    -c integration-exe -j 3
+    -c integration-exe -j 3 --match="{{match}}"
 
-hlint:
-  nix develop --command bash -c 'hlint lib'
+# run babbage integration tests matching the given pattern via nix
+babbage-integration-tests-match match:
+  LOCAL_CLUSTER_ERA=babbage \
+  just integration-tests "{{match}}"
+
+# run conway integration tests matching the given pattern via nix
+conway-integration-tests-match match:
+  LOCAL_CLUSTER_ERA=conway \
+  just integration-tests "{{match}}"
+
+# run babbage integration tests via nix
+babbage-integration-tests:
+  just babbage-integration-tests-match ""
+
+# run conway integration tests via nix
+conway-integration-tests:
+  just conway-integration-tests-match ""

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -416,7 +416,7 @@ emptyGenesis gp = W.Block
 
 -- | The protocol client version. Distinct from the codecs version.
 nodeToClientVersions :: [NodeToClientVersion]
-nodeToClientVersions = [NodeToClientV_13]
+nodeToClientVersions = [NodeToClientV_16]
 
 --------------------------------------------------------------------------------
 --

--- a/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/wallet/integration/src/Test/Integration/Framework/DSL.hs
@@ -228,6 +228,7 @@ module Test.Integration.Framework.DSL
     , runResourceT
     , ResourceT
     , listLimitedTransactions
+    , noConway
     ) where
 
 import Prelude
@@ -428,6 +429,7 @@ import Control.Monad
     , replicateM
     , unless
     , void
+    , when
     , (>=>)
     )
 import Control.Monad.IO.Unlift
@@ -585,6 +587,7 @@ import System.IO
 import Test.Hspec
     ( Expectation
     , HasCallStack
+    , pendingWith
     )
 import Test.Hspec.Expectations.Lifted
     ( expectationFailure
@@ -3554,3 +3557,8 @@ replaceStakeKey addr1 addr2 =
             addr = either (error . show) id $
                 decodeAddress (sNetworkId @n) $ Bech32.encodeLenient hrp dp
         in ApiAddress addr
+
+noConway :: MonadIO m => Context -> String -> m ()
+noConway ctx reason = liftIO $ do
+    when (_mainEra ctx == ApiConway) $
+        pendingWith $ "CONWAY is not supported: " <> reason

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shared/Transactions.hs
@@ -185,6 +185,7 @@ import Test.Integration.Framework.DSL
     , json
     , listAddresses
     , minUTxOValue
+    , noConway
     , notDelegating
     , notRetiringPools
     , patchSharedWallet
@@ -1811,7 +1812,7 @@ spec = describe "SHARED_TRANSACTIONS" $ do
 
     it "SHARED_TRANSACTIONS_DELEGATION_01a - \
        \Can join stakepool, rejoin another and quit" $ \ctx -> runResourceT $ do
-
+        noConway ctx "delegation"
         (party1,party2) <- fixtureSharedWalletDelegating @n ctx
         let depositAmt = ApiAmount 1_000_000
 

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -112,6 +112,7 @@ import Test.Integration.Framework.DSL
     , icarusAddresses
     , json
     , listAddresses
+    , noConway
     , postWallet
     , randomAddresses
     , request
@@ -143,83 +144,113 @@ import qualified Test.Hspec as Hspec
 
 spec :: forall n. HasSNetworkId n => SpecWith Context
 spec = describe "SHELLEY_MIGRATIONS" $ do
-
-    it "SHELLEY_CREATE_MIGRATION_PLAN_01 - \
+    it
+        "SHELLEY_CREATE_MIGRATION_PLAN_01 - \
         \Can create a migration plan."
         $ \ctx -> runResourceT $ do
             sourceWallet <- fixtureWallet ctx
             targetWallet <- emptyWallet ctx
             targetAddresses <- listAddresses @n ctx targetWallet
-            let targetAddressIds = targetAddresses <&>
-                    (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+            let targetAddressIds =
+                    targetAddresses
+                        <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
             let ep = Link.createMigrationPlan @'Shelley sourceWallet
-            response <- request @(ApiWalletMigrationPlan n) ctx ep Default
-                (Json [json|{addresses: #{targetAddressIds}}|])
-            verify response
+            response <-
+                request @(ApiWalletMigrationPlan n)
+                    ctx
+                    ep
+                    Default
+                    (Json [json|{addresses: #{targetAddressIds}}|])
+            verify
+                response
                 [ expectResponseCode HTTP.status202
-                , expectField (#totalFee . #toNatural)
-                    (`shouldBe`
+                , expectField
+                    (#totalFee . #toNatural)
+                    ( `shouldBe`
                         if _mainEra ctx >= ApiBabbage
-                        then 255_100
-                        else 254_900)
-                , expectField (#selections)
+                            then 255_100
+                            else 254_900
+                    )
+                , expectField
+                    (#selections)
                     ((`shouldBe` 1) . length)
-                , expectField (#balanceSelected . #ada . #toNatural)
+                , expectField
+                    (#balanceSelected . #ada . #toNatural)
                     (`shouldBe` 1_000_000_000_000)
-                , expectField (#balanceLeftover . #ada . #toNatural)
+                , expectField
+                    (#balanceLeftover . #ada . #toNatural)
                     (`shouldBe` 0)
                 ]
 
-    it "SHELLEY_CREATE_MIGRATION_PLAN_02 - \
+    it
+        "SHELLEY_CREATE_MIGRATION_PLAN_02 - \
         \Cannot create plan for empty wallet."
         $ \ctx -> runResourceT $ do
             sourceWallet <- emptyWallet ctx
             targetWallet <- emptyWallet ctx
             targetAddresses <- listAddresses @n ctx targetWallet
-            let targetAddressIds = targetAddresses <&>
-                    (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+            let targetAddressIds =
+                    targetAddresses
+                        <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
             let ep = Link.createMigrationPlan @'Shelley sourceWallet
-            response <- request @(ApiWalletMigrationPlan n) ctx ep Default
-                (Json [json|{addresses: #{targetAddressIds}}|])
-            verify response
+            response <-
+                request @(ApiWalletMigrationPlan n)
+                    ctx
+                    ep
+                    Default
+                    (Json [json|{addresses: #{targetAddressIds}}|])
+            verify
+                response
                 [ expectResponseCode HTTP.status403
                 , expectErrorMessage
                     (errMsg403NothingToMigrate $ sourceWallet ^. walletId)
                 ]
 
-    describe "SHELLEY_CREATE_MIGRATION_PLAN_03 - \
-        \Cannot create plan for Byron wallet using Shelley endpoint." $ do
-        let sourceWallets =
-              [ ("Random", emptyRandomWallet)
-              , ("Icarus", emptyIcarusWallet)
-              ]
-        forM_ sourceWallets $ \(walletType, byronWallet) -> do
-            let title = mconcat
-                    [ "Cannot calculate Shelley migration using wallet: "
-                    , walletType
+    describe
+        "SHELLEY_CREATE_MIGRATION_PLAN_03 - \
+        \Cannot create plan for Byron wallet using Shelley endpoint."
+        $ do
+            let sourceWallets =
+                    [ ("Random", emptyRandomWallet)
+                    , ("Icarus", emptyIcarusWallet)
                     ]
-            it title $ \ctx -> runResourceT $ do
-                sourceWallet <- byronWallet ctx
-                targetWallet <- emptyWallet ctx
-                targetAddresses <- listAddresses @n ctx targetWallet
-                let targetAddressIds = targetAddresses <&>
-                        (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
-                let ep = Link.createMigrationPlan @'Shelley sourceWallet
-                result <- request
-                    @(ApiWalletMigrationPlan n) ctx ep Default
-                    (Json [json|{addresses: #{targetAddressIds}}|])
-                verify result
-                    [ expectResponseCode HTTP.status404
-                    , expectErrorMessage
-                        (errMsg404NoWallet $ sourceWallet ^. walletId)
-                    ]
+            forM_ sourceWallets $ \(walletType, byronWallet) -> do
+                let title =
+                        mconcat
+                            [ "Cannot calculate Shelley migration using wallet: "
+                            , walletType
+                            ]
+                it title $ \ctx -> runResourceT $ do
+                    sourceWallet <- byronWallet ctx
+                    targetWallet <- emptyWallet ctx
+                    targetAddresses <- listAddresses @n ctx targetWallet
+                    let targetAddressIds =
+                            targetAddresses
+                                <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+                    let ep = Link.createMigrationPlan @'Shelley sourceWallet
+                    result <-
+                        request
+                            @(ApiWalletMigrationPlan n)
+                            ctx
+                            ep
+                            Default
+                            (Json [json|{addresses: #{targetAddressIds}}|])
+                    verify
+                        result
+                        [ expectResponseCode HTTP.status404
+                        , expectErrorMessage
+                            (errMsg404NoWallet $ sourceWallet ^. walletId)
+                        ]
 
-    Hspec.it "SHELLEY_CREATE_MIGRATION_PLAN_04 - \
+    Hspec.it
+        "SHELLEY_CREATE_MIGRATION_PLAN_04 - \
         \Cannot create a plan for a wallet that only contains freeriders."
         $ \ctx -> runResourceT @IO $ do
+            noConway ctx "migration accepted"
             sourceWallet <- emptyWallet ctx
-            srcAddrs <- map (CA.unsafeMkAddress . unAddress . apiAddress . view #id)
-                <$> listAddresses @n ctx sourceWallet
+            srcAddrs <-
+                map (CA.unsafeMkAddress . unAddress . apiAddress . view #id)
+                    <$> listAddresses @n ctx sourceWallet
 
             -- Add a relatively small number of freerider UTxO entries to the
             -- source wallet. (Few enough to not require more than one
@@ -241,56 +272,81 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             -- entry as a freerider.
 
             let perEntryAdaQuantity = Coin $ case _mainEra ctx of
-                    e | e == ApiAlonzo  -> 3_100_000
-                      | e == ApiBabbage -> 2_500_000
-                      | otherwise       -> 3_300_000
+                    e
+                        | e == ApiAlonzo -> 3_100_000
+                        | e == ApiBabbage -> 2_500_000
+                        | otherwise -> 3_300_000
 
             let perEntryAssetCount = 10
             let batchSize = 20
-            liftIO $ _mintSeaHorseAssets ctx
-                perEntryAssetCount
-                batchSize
-                perEntryAdaQuantity
-                srcAddrs
+            liftIO
+                $ _mintSeaHorseAssets
+                    ctx
+                    perEntryAssetCount
+                    batchSize
+                    perEntryAdaQuantity
+                    srcAddrs
             waitForTxImmutability ctx
 
             -- Check that the minting indeed worked, and that the wallet isn't
             -- empty:
-            request @ApiWallet ctx
-                (Link.getWallet @'Shelley sourceWallet) Default Empty
-                >>= flip verify
-                [ expectField (#balance . #available . #toNatural)
-                    (.> 0)
-                , expectField (#assets . #available)
-                    ((.> 0) . length . toList)
-                ]
+            request @ApiWallet
+                ctx
+                (Link.getWallet @'Shelley sourceWallet)
+                Default
+                Empty
+                >>= flip
+                    verify
+                    [ expectField
+                        (#balance . #available . #toNatural)
+                        (.> 0)
+                    , expectField
+                        (#assets . #available)
+                        ((.> 0) . length . toList)
+                    ]
 
             targetWallet <- emptyWallet ctx
             targetAddresses <- listAddresses @n ctx targetWallet
-            let targetAddressIds = targetAddresses <&>
-                    (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+            let targetAddressIds =
+                    targetAddresses
+                        <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
             let ep = Link.createMigrationPlan @'Shelley sourceWallet
-            response <- request @(ApiWalletMigrationPlan n) ctx ep Default
-                (Json [json|{addresses: #{targetAddressIds}}|])
-            verify response
+            response <-
+                request @(ApiWalletMigrationPlan n)
+                    ctx
+                    ep
+                    Default
+                    (Json [json|{addresses: #{targetAddressIds}}|])
+            verify
+                response
                 [ expectResponseCode HTTP.status403
                 , expectErrorMessage
                     (errMsg403NothingToMigrate $ sourceWallet ^. walletId)
                 ]
 
-    it "SHELLEY_CREATE_MIGRATION_PLAN_05 - \
+    it
+        "SHELLEY_CREATE_MIGRATION_PLAN_05 - \
         \Creating a plan is deterministic."
         $ \ctx -> runResourceT $ do
             sourceWallet <- fixtureWallet ctx
             targetWallet <- emptyWallet ctx
             targetAddresses <- listAddresses @n ctx targetWallet
-            let targetAddressIds = targetAddresses <&>
-                    (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+            let targetAddressIds =
+                    targetAddresses
+                        <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
             let ep = Link.createMigrationPlan @'Shelley sourceWallet
-            response1 <- request @(ApiWalletMigrationPlan n) ctx ep Default
-                (Json [json|{addresses: #{targetAddressIds}}|])
-            response2 <- request @(ApiWalletMigrationPlan n) ctx ep Default
-                (Json [json|{addresses: #{targetAddressIds}}|])
+            response1 <-
+                request @(ApiWalletMigrationPlan n)
+                    ctx
+                    ep
+                    Default
+                    (Json [json|{addresses: #{targetAddressIds}}|])
+            response2 <-
+                request @(ApiWalletMigrationPlan n)
+                    ctx
+                    ep
+                    Default
+                    (Json [json|{addresses: #{targetAddressIds}}|])
             expectResponseCode HTTP.status202 response1
             expectResponseCode HTTP.status202 response2
             expectField (#selections) ((.> 0) . length) response1
@@ -301,88 +357,125 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 _ ->
                     error "Unable to compare plans."
 
-    it "SHELLEY_CREATE_MIGRATION_PLAN_06 - \
+    it
+        "SHELLEY_CREATE_MIGRATION_PLAN_06 - \
         \Can create a migration plan for a wallet that has rewards."
         $ \ctx -> runResourceT $ do
+            noConway ctx "MIR"
             (sourceWallet, _sourceWalletMnemonic) <- rewardWallet ctx
             -- Check that the source wallet has the expected balance.
-            request @ApiWallet ctx
-                (Link.getWallet @'Shelley sourceWallet) Default Empty
-                >>= flip verify
-                [ expectField (#balance . #reward . #toNatural)
-                    (`shouldBe` 1_000_000_000_000)
-                , expectField (#balance . #available . #toNatural)
-                    (`shouldBe`   100_000_000_000)
-                , expectField (#balance . #total . #toNatural)
-                    (`shouldBe` 1_100_000_000_000)
-                ]
+            request @ApiWallet
+                ctx
+                (Link.getWallet @'Shelley sourceWallet)
+                Default
+                Empty
+                >>= flip
+                    verify
+                    [ expectField
+                        (#balance . #reward . #toNatural)
+                        (`shouldBe` 1_000_000_000_000)
+                    , expectField
+                        (#balance . #available . #toNatural)
+                        (`shouldBe` 100_000_000_000)
+                    , expectField
+                        (#balance . #total . #toNatural)
+                        (`shouldBe` 1_100_000_000_000)
+                    ]
             targetWallet <- emptyWallet ctx
             targetAddresses <- listAddresses @n ctx targetWallet
-            let targetAddressIds = targetAddresses <&>
-                    (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+            let targetAddressIds =
+                    targetAddresses
+                        <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
             let ep = Link.createMigrationPlan @'Shelley sourceWallet
-            response <- request @(ApiWalletMigrationPlan n) ctx ep Default
-                (Json [json|{addresses: #{targetAddressIds}}|])
-            verify response
+            response <-
+                request @(ApiWalletMigrationPlan n)
+                    ctx
+                    ep
+                    Default
+                    (Json [json|{addresses: #{targetAddressIds}}|])
+            verify
+                response
                 [ expectResponseCode HTTP.status202
-                , expectField (#totalFee . #toNatural)
-                    (`shouldBe`
+                , expectField
+                    (#totalFee . #toNatural)
+                    ( `shouldBe`
                         if _mainEra ctx >= ApiBabbage
-                        then 139_200
-                        else 139_000)
-                , expectField (#selections)
+                            then 139_200
+                            else 139_000
+                    )
+                , expectField
+                    (#selections)
                     ((`shouldBe` 1) . length)
-                , expectField (#selections)
+                , expectField
+                    (#selections)
                     ((`shouldBe` 1) . length . view #withdrawals . NE.head)
-                , expectField (#selections)
-                    ((`shouldBe` 1_000_000_000_000)
+                , expectField
+                    (#selections)
+                    ( (`shouldBe` 1_000_000_000_000)
                         . view #toNatural
                         . view #amount
                         . head
                         . view #withdrawals
-                        . NE.head)
-                , expectField (#balanceSelected . #ada . #toNatural)
+                        . NE.head
+                    )
+                , expectField
+                    (#balanceSelected . #ada . #toNatural)
                     (`shouldBe` 1_100_000_000_000)
-                , expectField (#balanceLeftover . #ada . #toNatural)
+                , expectField
+                    (#balanceLeftover . #ada . #toNatural)
                     (`shouldBe` 0)
                 ]
 
-    Hspec.it "SHELLEY_CREATE_MIGRATION_PLAN_07 - \
+    Hspec.it
+        "SHELLEY_CREATE_MIGRATION_PLAN_07 - \
         \Can create a complete migration plan for a wallet with a large number \
         \of freerider UTxO entries, but with just enough non-freerider entries \
         \to enable the entire UTxO set to be migrated."
         $ \ctx -> runResourceT @IO $ do
-
             -- Create a source wallet with some pure ada entries, where each
             -- ada entry is large enough to create a singleton transaction:
-            sourceWallet <- fixtureWalletWith @n ctx
-                [ 100_000_000
-                , 100_000_000
-                ]
+            sourceWallet <-
+                fixtureWalletWith @n
+                    ctx
+                    [ 100_000_000
+                    , 100_000_000
+                    ]
 
             -- Check that the source wallet has the expected balance and UTxO
             -- distribution:
-            request @ApiWallet ctx
-                (Link.getWallet @'Shelley sourceWallet) Default Empty
-                >>= flip verify
-                [ expectField (#balance . #reward . #toNatural)
-                    (`shouldBe` 0)
-                , expectField (#balance . #available . #toNatural)
-                    (`shouldBe` 200_000_000)
-                , expectField (#balance . #total . #toNatural)
-                    (`shouldBe` 200_000_000)
-                ]
+            request @ApiWallet
+                ctx
+                (Link.getWallet @'Shelley sourceWallet)
+                Default
+                Empty
+                >>= flip
+                    verify
+                    [ expectField
+                        (#balance . #reward . #toNatural)
+                        (`shouldBe` 0)
+                    , expectField
+                        (#balance . #available . #toNatural)
+                        (`shouldBe` 200_000_000)
+                    , expectField
+                        (#balance . #total . #toNatural)
+                        (`shouldBe` 200_000_000)
+                    ]
             let expectedSourceDistribution =
                     [(100_000_000, 2)]
-            request @ApiUtxoStatistics ctx
-                (Link.getUTxOsStatistics @'Shelley sourceWallet) Default Empty
-                >>= flip verify
-                [ expectField #distribution
-                    ((`shouldBe` expectedSourceDistribution)
-                    . Map.toList
-                    . Map.filter (> 0)
-                    )
-                ]
+            request @ApiUtxoStatistics
+                ctx
+                (Link.getUTxOsStatistics @'Shelley sourceWallet)
+                Default
+                Empty
+                >>= flip
+                    verify
+                    [ expectField
+                        #distribution
+                        ( (`shouldBe` expectedSourceDistribution)
+                            . Map.toList
+                            . Map.filter (> 0)
+                        )
+                    ]
 
             -- Add a relatively large number of freerider UTxO entries to the
             -- source wallet.
@@ -408,102 +501,141 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             sourceAddresses <-
                 take 20 . map (CA.unsafeMkAddress . unAddress . apiAddress . view #id)
                     <$> listAddresses @n ctx sourceWallet
-            replicateM_ 6 $ liftIO $ _mintSeaHorseAssets ctx
-                perEntryAssetCount
-                batchSize
-                perEntryAdaQuantity
-                sourceAddresses
+            replicateM_ 6
+                $ liftIO
+                $ _mintSeaHorseAssets
+                    ctx
+                    perEntryAssetCount
+                    batchSize
+                    perEntryAdaQuantity
+                    sourceAddresses
             waitForTxImmutability ctx
 
             -- Check that minting was successful, and that the balance and UTxO
             -- distribution have both changed accordingly:
             let expectedBalanceAda = 387_500_000
             let expectedAssetCount = 20
-            request @ApiWallet ctx
-                (Link.getWallet @'Shelley sourceWallet) Default Empty
-                >>= flip verify
-                [ expectField (#balance . #available . #toNatural)
-                    (`shouldBe` expectedBalanceAda)
-                , expectField (#balance . #total . #toNatural)
-                    (`shouldBe` expectedBalanceAda)
-                , expectField (#assets . #available)
-                    ((`shouldBe` expectedAssetCount) . length . toList)
-                ]
-            let expectedSourceDistributionAfterMinting =
-                    [ ( 10_000_000, 120)
-                    , (100_000_000,   2)
+            request @ApiWallet
+                ctx
+                (Link.getWallet @'Shelley sourceWallet)
+                Default
+                Empty
+                >>= flip
+                    verify
+                    [ expectField
+                        (#balance . #available . #toNatural)
+                        (`shouldBe` expectedBalanceAda)
+                    , expectField
+                        (#balance . #total . #toNatural)
+                        (`shouldBe` expectedBalanceAda)
+                    , expectField
+                        (#assets . #available)
+                        ((`shouldBe` expectedAssetCount) . length . toList)
                     ]
-            request @ApiUtxoStatistics ctx
-                (Link.getUTxOsStatistics @'Shelley sourceWallet) Default Empty
-                >>= flip verify
-                [ expectField #distribution
-                    ((`shouldBe` expectedSourceDistributionAfterMinting)
-                        . Map.toList
-                        . Map.filter (> 0)
-                    )
-                ]
+            let expectedSourceDistributionAfterMinting =
+                    [ (10_000_000, 120)
+                    , (100_000_000, 2)
+                    ]
+            request @ApiUtxoStatistics
+                ctx
+                (Link.getUTxOsStatistics @'Shelley sourceWallet)
+                Default
+                Empty
+                >>= flip
+                    verify
+                    [ expectField
+                        #distribution
+                        ( (`shouldBe` expectedSourceDistributionAfterMinting)
+                            . Map.toList
+                            . Map.filter (> 0)
+                        )
+                    ]
 
             -- Create an empty target wallet:
             targetWallet <- emptyWallet ctx
             targetAddresses <- listAddresses @n ctx targetWallet
-            let targetAddressIds = targetAddresses <&>
-                    (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+            let targetAddressIds =
+                    targetAddresses
+                        <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
 
             -- Create a migration plan, and check that the plan is complete:
             let ep = Link.createMigrationPlan @'Shelley sourceWallet
-            request @(ApiWalletMigrationPlan n) ctx ep Default
+            request @(ApiWalletMigrationPlan n)
+                ctx
+                ep
+                Default
                 (Json [json|{addresses: #{targetAddressIds}}|])
-                >>= flip verify
-                [ expectResponseCode HTTP.status202
-                , expectField (#selections)
-                    ((`shouldBe` 2) . length)
-                , expectField id
-                    ((`shouldBe` 122) . apiPlanTotalInputCount)
-                , expectField id
-                    ((`shouldBe` 2) . apiPlanTotalOutputCount)
-                , expectField (#balanceSelected . #ada . #toNatural)
-                    (`shouldBe` expectedBalanceAda)
-                , expectField (#balanceSelected . #assets)
-                    ((`shouldBe` expectedAssetCount) . length . toList)
-                , expectField (#balanceLeftover . #ada . #toNatural)
-                    (`shouldBe` 0)
-                , expectField (#balanceLeftover . #assets)
-                    ((`shouldBe` 0) . length . toList)
-                ]
+                >>= flip
+                    verify
+                    [ expectResponseCode HTTP.status202
+                    , expectField
+                        (#selections)
+                        ((`shouldBe` 2) . length)
+                    , expectField
+                        id
+                        ((`shouldBe` 122) . apiPlanTotalInputCount)
+                    , expectField
+                        id
+                        ((`shouldBe` 2) . apiPlanTotalOutputCount)
+                    , expectField
+                        (#balanceSelected . #ada . #toNatural)
+                        (`shouldBe` expectedBalanceAda)
+                    , expectField
+                        (#balanceSelected . #assets)
+                        ((`shouldBe` expectedAssetCount) . length . toList)
+                    , expectField
+                        (#balanceLeftover . #ada . #toNatural)
+                        (`shouldBe` 0)
+                    , expectField
+                        (#balanceLeftover . #assets)
+                        ((`shouldBe` 0) . length . toList)
+                    ]
 
-    Hspec.it "SHELLEY_CREATE_MIGRATION_PLAN_08 - \
+    Hspec.it
+        "SHELLEY_CREATE_MIGRATION_PLAN_08 - \
         \Can create a partial migration plan for a wallet with a large number \
         \of freerider UTxO entries, but with not quite enough non-freerider \
         \entries to enable the entire UTxO set to be migrated."
         $ \ctx -> runResourceT @IO $ do
-
             -- Create a source wallet with just one pure ada entry that is
             -- large enough to create a singleton transaction:
-            sourceWallet <- fixtureWalletWith @n ctx [ 100_000_000 ]
+            sourceWallet <- fixtureWalletWith @n ctx [100_000_000]
 
             -- Check that the source wallet has the expected balance and UTxO
             -- distribution:
-            request @ApiWallet ctx
-                (Link.getWallet @'Shelley sourceWallet) Default Empty
-                >>= flip verify
-                [ expectField (#balance . #reward . #toNatural)
-                    (`shouldBe` 0)
-                , expectField (#balance . #available . #toNatural)
-                    (`shouldBe` 100_000_000)
-                , expectField (#balance . #total . #toNatural)
-                    (`shouldBe` 100_000_000)
-                ]
+            request @ApiWallet
+                ctx
+                (Link.getWallet @'Shelley sourceWallet)
+                Default
+                Empty
+                >>= flip
+                    verify
+                    [ expectField
+                        (#balance . #reward . #toNatural)
+                        (`shouldBe` 0)
+                    , expectField
+                        (#balance . #available . #toNatural)
+                        (`shouldBe` 100_000_000)
+                    , expectField
+                        (#balance . #total . #toNatural)
+                        (`shouldBe` 100_000_000)
+                    ]
             let expectedSourceDistribution =
                     [(100_000_000, 1)]
-            request @ApiUtxoStatistics ctx
-                (Link.getUTxOsStatistics @'Shelley sourceWallet) Default Empty
-                >>= flip verify
-                [ expectField #distribution
-                    ((`shouldBe` expectedSourceDistribution)
-                    . Map.toList
-                    . Map.filter (> 0)
-                    )
-                ]
+            request @ApiUtxoStatistics
+                ctx
+                (Link.getUTxOsStatistics @'Shelley sourceWallet)
+                Default
+                Empty
+                >>= flip
+                    verify
+                    [ expectField
+                        #distribution
+                        ( (`shouldBe` expectedSourceDistribution)
+                            . Map.toList
+                            . Map.filter (> 0)
+                        )
+                    ]
 
             -- Add a relatively large number of freerider UTxO entries to the
             -- source wallet.
@@ -526,215 +658,289 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             let perEntryAdaQuantity = Coin 1_462_500
             let perEntryAssetCount = 1
             let batchSize = 20
-            sourceAddresses <- take 20 . map (apiAddress . view #id)
-                <$> listAddresses @n ctx sourceWallet
-            replicateM_ 6 $ liftIO $ _mintSeaHorseAssets ctx
-                perEntryAssetCount
-                batchSize
-                perEntryAdaQuantity
-                (CA.unsafeMkAddress . unAddress <$> sourceAddresses)
+            sourceAddresses <-
+                take 20 . map (apiAddress . view #id)
+                    <$> listAddresses @n ctx sourceWallet
+            replicateM_ 6
+                $ liftIO
+                $ _mintSeaHorseAssets
+                    ctx
+                    perEntryAssetCount
+                    batchSize
+                    perEntryAdaQuantity
+                    (CA.unsafeMkAddress . unAddress <$> sourceAddresses)
             waitForTxImmutability ctx
 
             -- Check that minting was successful, and that the balance and UTxO
             -- distribution have both changed accordingly:
             let expectedBalanceAda = 275_500_000
             let expectedAssetCount = 20
-            request @ApiWallet ctx
-                (Link.getWallet @'Shelley sourceWallet) Default Empty
-                >>= flip verify
-                [ expectField (#balance . #available . #toNatural)
-                    (`shouldBe` expectedBalanceAda)
-                , expectField (#balance . #total . #toNatural)
-                    (`shouldBe` expectedBalanceAda)
-                , expectField (#assets . #available)
-                    ((`shouldBe` expectedAssetCount) . length . toList)
-                ]
-            let expectedSourceDistributionAfterMinting =
-                    [ ( 10_000_000, 120)
-                    , (100_000_000,   1)
+            request @ApiWallet
+                ctx
+                (Link.getWallet @'Shelley sourceWallet)
+                Default
+                Empty
+                >>= flip
+                    verify
+                    [ expectField
+                        (#balance . #available . #toNatural)
+                        (`shouldBe` expectedBalanceAda)
+                    , expectField
+                        (#balance . #total . #toNatural)
+                        (`shouldBe` expectedBalanceAda)
+                    , expectField
+                        (#assets . #available)
+                        ((`shouldBe` expectedAssetCount) . length . toList)
                     ]
-            request @ApiUtxoStatistics ctx
-                (Link.getUTxOsStatistics @'Shelley sourceWallet) Default Empty
-                >>= flip verify
-                [ expectField #distribution
-                    ((`shouldBe` expectedSourceDistributionAfterMinting)
-                    . Map.toList
-                    . Map.filter (> 0)
-                    )
-                ]
+            let expectedSourceDistributionAfterMinting =
+                    [ (10_000_000, 120)
+                    , (100_000_000, 1)
+                    ]
+            request @ApiUtxoStatistics
+                ctx
+                (Link.getUTxOsStatistics @'Shelley sourceWallet)
+                Default
+                Empty
+                >>= flip
+                    verify
+                    [ expectField
+                        #distribution
+                        ( (`shouldBe` expectedSourceDistributionAfterMinting)
+                            . Map.toList
+                            . Map.filter (> 0)
+                        )
+                    ]
 
             -- Create an empty target wallet:
             targetWallet <- emptyWallet ctx
             targetAddresses <- listAddresses @n ctx targetWallet
-            let targetAddressIds = targetAddresses <&>
-                    (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+            let targetAddressIds =
+                    targetAddresses
+                        <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
 
             -- Create a migration plan, and check that the plan is only
             -- partially complete:
             let ep = Link.createMigrationPlan @'Shelley sourceWallet
-            request @(ApiWalletMigrationPlan n) ctx ep Default
+            request @(ApiWalletMigrationPlan n)
+                ctx
+                ep
+                Default
                 (Json [json|{addresses: #{targetAddressIds}}|])
-                >>= flip verify
-                [ expectResponseCode HTTP.status202
-                , expectField (#selections)
-                    ((`shouldBe` 1) . length)
-                , expectField id
-                    ((`shouldBe` 102) . apiPlanTotalInputCount)
-                , expectField id
-                    ((`shouldBe` 1) . apiPlanTotalOutputCount)
-                , expectField (#balanceSelected . #ada . #toNatural)
-                    (`shouldBe` 247_712_500)
-                , expectField (#balanceLeftover . #ada . #toNatural)
-                    (`shouldBe` 27_787_500)
-                , expectField (#balanceSelected . #assets)
-                    ((.> 0) . length . toList)
-                , expectField (#balanceLeftover . #assets)
-                    ((.> 0) . length . toList)
-                ]
+                >>= flip
+                    verify
+                    [ expectResponseCode HTTP.status202
+                    , expectField
+                        (#selections)
+                        ((`shouldBe` 1) . length)
+                    , expectField
+                        id
+                        ((`shouldBe` 102) . apiPlanTotalInputCount)
+                    , expectField
+                        id
+                        ((`shouldBe` 1) . apiPlanTotalOutputCount)
+                    , expectField
+                        (#balanceSelected . #ada . #toNatural)
+                        (`shouldBe` 247_712_500)
+                    , expectField
+                        (#balanceLeftover . #ada . #toNatural)
+                        (`shouldBe` 27_787_500)
+                    , expectField
+                        (#balanceSelected . #assets)
+                        ((.> 0) . length . toList)
+                    , expectField
+                        (#balanceLeftover . #assets)
+                        ((.> 0) . length . toList)
+                    ]
 
-    describe "SHELLEY_MIGRATE_01 - \
+    describe
+        "SHELLEY_MIGRATE_01 - \
         \After a migration operation successfully completes, the correct \
         \amounts eventually become available in the target wallet for an \
         \arbitrary number of specified addresses, and the balance of the \
         \source wallet is completely depleted."
         $ do
-            testAddressCycling  1
-            testAddressCycling  3
+            testAddressCycling 1
+            testAddressCycling 3
             testAddressCycling 10
 
-    it "SHELLEY_MIGRATE_02 - \
+    it
+        "SHELLEY_MIGRATE_02 - \
         \Can migrate a large wallet requiring more than one transaction."
         $ \ctx -> runResourceT @IO $ do
+            bigDustWallet <- liftIO $ bigDustWalletMnemonic (_faucet ctx)
 
-        bigDustWallet <- liftIO $ bigDustWalletMnemonic (_faucet ctx)
-
-        -- Create a large source wallet from which funds will be migrated:
-        sourceWallet <- unsafeResponse <$> postWallet ctx
-            (Json [json|{
+            -- Create a large source wallet from which funds will be migrated:
+            sourceWallet <-
+                unsafeResponse
+                    <$> postWallet
+                        ctx
+                        ( Json
+                            [json|{
                 "name": "Big Shelley Wallet",
                 "mnemonic_sentence": #{someMnemonicToWords bigDustWallet},
                 "passphrase": #{fixturePassphrase}
-            }|])
-        sourceBalance <- eventually "Source wallet balance is correct." $ do
-            response <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley sourceWallet) Default Empty
-            verify response
-                [ expectField (#balance . #available . #toNatural)
+            }|]
+                        )
+            sourceBalance <- eventually "Source wallet balance is correct." $ do
+                response <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley sourceWallet)
+                        Default
+                        Empty
+                verify
+                    response
+                    [ expectField
+                        (#balance . #available . #toNatural)
+                        (`shouldBe` 10_000_100_000_000)
+                    ]
+                return
+                    $ getFromResponse
+                        (#balance . #available . #toNatural)
+                        response
+
+            -- Create an empty target wallet:
+            targetWallet <- emptyWallet ctx
+            targetAddresses <- listAddresses @n ctx targetWallet
+            let targetAddressIds =
+                    targetAddresses
+                        <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+
+            -- Compute the expected migration plan:
+            responsePlan <-
+                request @(ApiWalletMigrationPlan n)
+                    ctx
+                    (Link.createMigrationPlan @'Shelley sourceWallet)
+                    Default
+                    (Json [json|{addresses: #{targetAddressIds}}|])
+            verify
+                responsePlan
+                [ expectResponseCode HTTP.status202
+                , expectField
+                    (#totalFee . #toNatural)
+                    ( `shouldBe`
+                        if _mainEra ctx >= ApiBabbage
+                            then 3_120_200
+                            else 3_119_800
+                    )
+                , expectField
+                    (#selections)
+                    ((`shouldBe` 2) . length)
+                , expectField
+                    (#balanceLeftover . #ada . #toNatural)
+                    (`shouldBe` 0)
+                , expectField
+                    (#balanceSelected . #ada . #toNatural)
                     (`shouldBe` 10_000_100_000_000)
                 ]
-            return $ getFromResponse
-                (#balance . #available . #toNatural) response
+            let expectedFee =
+                    getFromResponse
+                        (#totalFee . #toNatural)
+                        responsePlan
+            let balanceLeftover =
+                    getFromResponse
+                        (#balanceLeftover . #ada . #toNatural)
+                        responsePlan
 
-        -- Create an empty target wallet:
-        targetWallet <- emptyWallet ctx
-        targetAddresses <- listAddresses @n ctx targetWallet
-        let targetAddressIds = targetAddresses <&>
-                (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+            -- Perform a migration from the source wallet to the target wallet.
+            --
+            -- This migration will involve more than one transaction, where each
+            -- transaction is sent one by one. It may happen that one of these
+            -- transactions is rolled back or simply discarded entirely. The wallet
+            -- doesn't currently have any retry mechanism, which means that
+            -- transactions must be manually retried by clients.
+            --
+            -- The 'migrateWallet' function tries do exactly that: to make sure
+            -- that rolled-back transactions are cancelled and retried until the
+            -- migration is complete.
+            --
+            liftIO $ migrateWallet ctx sourceWallet targetAddressIds
+            waitForTxImmutability ctx
 
-        -- Compute the expected migration plan:
-        responsePlan <- request @(ApiWalletMigrationPlan n) ctx
-            (Link.createMigrationPlan @'Shelley sourceWallet) Default
-            (Json [json|{addresses: #{targetAddressIds}}|])
-        verify responsePlan
-            [ expectResponseCode HTTP.status202
-            , expectField
-                (#totalFee . #toNatural)
-                (`shouldBe`
-                    if _mainEra ctx >= ApiBabbage
-                    then 3_120_200
-                    else 3_119_800)
-            , expectField
-                (#selections)
-                ((`shouldBe` 2) . length)
-            , expectField
-                (#balanceLeftover . #ada . #toNatural)
-                (`shouldBe` 0)
-            , expectField
-                (#balanceSelected . #ada . #toNatural)
-                (`shouldBe` 10_000_100_000_000)
-            ]
-        let expectedFee = getFromResponse
-                (#totalFee . #toNatural) responsePlan
-        let balanceLeftover = getFromResponse
-                (#balanceLeftover . #ada . #toNatural) responsePlan
+            -- Check that funds become available in the target wallet:
+            let expectedTargetBalance =
+                    sourceBalance - balanceLeftover - expectedFee
+            response <-
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley targetWallet)
+                    Default
+                    Empty
+            verify
+                response
+                [ expectField
+                    (#balance . #available . #toNatural)
+                    (`shouldBe` expectedTargetBalance)
+                , expectField
+                    (#balance . #total . #toNatural)
+                    (`shouldBe` expectedTargetBalance)
+                ]
 
-        -- Perform a migration from the source wallet to the target wallet.
-        --
-        -- This migration will involve more than one transaction, where each
-        -- transaction is sent one by one. It may happen that one of these
-        -- transactions is rolled back or simply discarded entirely. The wallet
-        -- doesn't currently have any retry mechanism, which means that
-        -- transactions must be manually retried by clients.
-        --
-        -- The 'migrateWallet' function tries do exactly that: to make sure
-        -- that rolled-back transactions are cancelled and retried until the
-        -- migration is complete.
-        --
-        liftIO $ migrateWallet ctx sourceWallet targetAddressIds
-        waitForTxImmutability ctx
+            -- Analyse the target wallet's UTxO distribution:
+            responseStats <-
+                request @ApiUtxoStatistics
+                    ctx
+                    (Link.getUTxOsStatistics @'Shelley targetWallet)
+                    Default
+                    Empty
+            verify
+                responseStats
+                [ expectField
+                    (#distribution)
+                    ((`shouldBe` (Just 2)) . Map.lookup 10_000_000_000_000)
+                ]
 
-        -- Check that funds become available in the target wallet:
-        let expectedTargetBalance =
-                sourceBalance - balanceLeftover - expectedFee
-        response <- request @ApiWallet ctx
-            (Link.getWallet @'Shelley targetWallet) Default Empty
-        verify response
-            [ expectField
-                (#balance . #available . #toNatural)
-                (`shouldBe` expectedTargetBalance)
-            , expectField
-                (#balance . #total . #toNatural)
-                (`shouldBe` expectedTargetBalance)
-            ]
+            -- Check that the source wallet has the expected leftover balance:
+            responseFinalSourceBalance <-
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley sourceWallet)
+                    Default
+                    Empty
+            verify
+                responseFinalSourceBalance
+                [ expectResponseCode HTTP.status200
+                , expectField
+                    (#balance . #available)
+                    (`shouldBe` ApiAmount 0)
+                , expectField
+                    (#balance . #total)
+                    (`shouldBe` ApiAmount 0)
+                ]
 
-        -- Analyse the target wallet's UTxO distribution:
-        responseStats <- request @ApiUtxoStatistics ctx
-            (Link.getUTxOsStatistics @'Shelley targetWallet) Default Empty
-        verify responseStats
-            [ expectField
-                (#distribution)
-                ((`shouldBe` (Just 2)) . Map.lookup 10_000_000_000_000)
-            ]
-
-        -- Check that the source wallet has the expected leftover balance:
-        responseFinalSourceBalance <- request @ApiWallet ctx
-            (Link.getWallet @'Shelley sourceWallet) Default Empty
-        verify responseFinalSourceBalance
-            [ expectResponseCode HTTP.status200
-            , expectField (#balance . #available)
-                (`shouldBe` ApiAmount 0)
-            , expectField (#balance . #total)
-                (`shouldBe` ApiAmount 0)
-            ]
-
-    it "SHELLEY_MIGRATE_03 - \
+    it
+        "SHELLEY_MIGRATE_03 - \
         \Migrating an empty wallet should fail."
         $ \ctx -> runResourceT $ do
             sourceWallet <- emptyWallet ctx
             let sourceWalletId = sourceWallet ^. walletId
             targetWallet <- emptyWallet ctx
             targetAddresses <- listAddresses @n ctx targetWallet
-            let targetAddressIds = targetAddresses <&>
-                    (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+            let targetAddressIds =
+                    targetAddresses
+                        <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
             let ep = Link.migrateWallet @'Shelley sourceWallet
-            response <- request @[ApiTransaction n] ctx ep Default $
-                    Json [json|
+            response <-
+                request @[ApiTransaction n] ctx ep Default
+                    $ Json
+                        [json|
                         { passphrase: #{fixturePassphrase}
                         , addresses: #{targetAddressIds}
                         }|]
-            verify response
+            verify
+                response
                 [ expectResponseCode HTTP.status403
                 , expectErrorMessage (errMsg403NothingToMigrate sourceWalletId)
                 ]
 
-    Hspec.it "SHELLEY_MIGRATE_04 - \
+    Hspec.it
+        "SHELLEY_MIGRATE_04 - \
         \Actual fee for migration is identical to predicted fee."
         $ \ctx -> runResourceT @IO $ do
-
             let feeExpected =
                     if _mainEra ctx >= ApiBabbage
-                    then 255_100
-                    else 254_900
+                        then 255_100
+                        else 254_900
 
             -- Restore a source wallet with funds:
             sourceWallet <- fixtureWallet ctx
@@ -742,16 +948,21 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             -- Create an empty target wallet:
             targetWallet <- emptyWallet ctx
             targetAddresses <- listAddresses @n ctx targetWallet
-            let targetAddressIds = targetAddresses <&>
-                    (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+            let targetAddressIds =
+                    targetAddresses
+                        <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
 
             -- Create a migration plan:
             let endpointPlan = (Link.createMigrationPlan @'Shelley sourceWallet)
-            responsePlan <- request @(ApiWalletMigrationPlan n)
-                ctx endpointPlan Default $
-                Json [json|{addresses: #{targetAddressIds}}|]
+            responsePlan <-
+                request @(ApiWalletMigrationPlan n)
+                    ctx
+                    endpointPlan
+                    Default
+                    $ Json [json|{addresses: #{targetAddressIds}}|]
             -- Verify the fee is as expected:
-            verify responsePlan
+            verify
+                responsePlan
                 [ expectResponseCode HTTP.status202
                 , expectField #totalFee (`shouldBe` ApiAmount feeExpected)
                 , expectField #selections ((`shouldBe` 1) . length)
@@ -760,52 +971,60 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             -- Perform a migration:
             let endpointMigrate = Link.migrateWallet @'Shelley sourceWallet
             responseMigrate <-
-                request @[ApiTransaction n] ctx endpointMigrate Default $
-                Json [json|
+                request @[ApiTransaction n] ctx endpointMigrate Default
+                    $ Json
+                        [json|
                     { passphrase: #{fixturePassphrase}
                     , addresses: #{targetAddressIds}
                     }|]
             -- Verify the fee is as expected:
-            verify responseMigrate
+            verify
+                responseMigrate
                 [ expectResponseCode HTTP.status202
                 , expectField id ((`shouldBe` 1) . length)
                 , expectField id
                     $ (`shouldBe` feeExpected)
-                    . fromIntegral
-                    . sum
-                    . fmap apiTransactionFee
+                        . fromIntegral
+                        . sum
+                        . fmap apiTransactionFee
                 ]
 
-    it "SHELLEY_MIGRATE_05 - \
+    it
+        "SHELLEY_MIGRATE_05 - \
         \Migration fails if the wrong passphrase is supplied."
         $ \ctx -> runResourceT $ do
-
             -- Restore a Shelley wallet with funds, to act as a source wallet:
             sourceWallet <- fixtureWallet ctx
 
             -- Create an empty target wallet:
             targetWallet <- emptyWallet ctx
             targetAddresses <- listAddresses @n ctx targetWallet
-            let targetAddressIds = targetAddresses <&>
-                    (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+            let targetAddressIds =
+                    targetAddresses
+                        <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
 
             -- Attempt to perform a migration:
-            response <- request @[ApiTransaction n] ctx
-                (Link.migrateWallet @'Shelley sourceWallet)
-                Default
-                (Json [json|
+            response <-
+                request @[ApiTransaction n]
+                    ctx
+                    (Link.migrateWallet @'Shelley sourceWallet)
+                    Default
+                    ( Json
+                        [json|
                     { passphrase: "not-the-right-passphrase"
                     , addresses: #{targetAddressIds}
-                    }|])
-            verify response
+                    }|]
+                    )
+            verify
+                response
                 [ expectResponseCode HTTP.status403
                 , expectErrorMessage errMsg403WrongPass
                 ]
 
-    it "SHELLEY_MIGRATE_06 - \
+    it
+        "SHELLEY_MIGRATE_06 - \
         \It's possible to migrate to any valid address."
         $ \ctx -> runResourceT $ do
-
             -- Create a Shelley address:
             wShelley <- emptyWallet ctx
             addrs <- listAddresses @n ctx wShelley
@@ -825,90 +1044,126 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             sourceWallet <- emptyWallet ctx
 
             -- Initiate a migration to all address types:
-            response <- request @[ApiTransaction n] ctx
-                (Link.migrateWallet @'Shelley sourceWallet) Default
-                (Json [json|
+            response <-
+                request @[ApiTransaction n]
+                    ctx
+                    (Link.migrateWallet @'Shelley sourceWallet)
+                    Default
+                    ( Json
+                        [json|
                     { passphrase: #{fixturePassphrase}
                     , addresses: [#{addrShelley}, #{addrIcarus}, #{addrByron}]
-                    }|])
-            verify response
+                    }|]
+                    )
+            verify
+                response
                 [ expectResponseCode HTTP.status403
                 , expectErrorMessage
                     (errMsg403NothingToMigrate (sourceWallet ^. walletId))
                 ]
 
-    it "SHELLEY_MIGRATE_07 - \
+    it
+        "SHELLEY_MIGRATE_07 - \
         \Including an invalidly-formatted passphrase results in a parser error."
         $ \ctx -> runResourceT $ do
             sourceWallet <- emptyWallet ctx
-            response <- request @[ApiTransaction n] ctx
-                (Link.migrateWallet @'Shelley sourceWallet) Default
-                (NonJson "{passphrase:,}")
-            verify response
+            response <-
+                request @[ApiTransaction n]
+                    ctx
+                    (Link.migrateWallet @'Shelley sourceWallet)
+                    Default
+                    (NonJson "{passphrase:,}")
+            verify
+                response
                 [ expectResponseCode HTTP.status400
                 , expectErrorMessage
                     "Unexpected 'passphrase:,}', \
                     \expecting record key literal or }"
                 ]
 
-    Hspec.it "SHELLEY_MIGRATE_08 - \
+    Hspec.it
+        "SHELLEY_MIGRATE_08 - \
         \It's possible to migrate a wallet with many small ada quantities, \
         \provided that the total balance is significantly greater than the \
         \minimum ada quantity for an output."
         $ \ctx -> runResourceT @IO $ do
-
             onlyDustWallet <- liftIO $ onlyDustWalletMnemonic (_faucet ctx)
 
             -- Create a source wallet with many small ada quantities:
-            sourceWallet <- unsafeResponse <$> postWallet ctx
-                (Json [json|{
+            sourceWallet <-
+                unsafeResponse
+                    <$> postWallet
+                        ctx
+                        ( Json
+                            [json|{
                     "name": "Shelley Wallet",
                     "mnemonic_sentence": #{someMnemonicToWords onlyDustWallet},
                     "passphrase": #{fixturePassphrase}
-                }|])
+                }|]
+                        )
             sourceBalance <- eventually "Source wallet balance is correct." $ do
-                response <- request @ApiWallet ctx
-                    (Link.getWallet @'Shelley sourceWallet) Default Empty
-                verify response
-                    [ expectField (#balance . #available . #toNatural)
+                response <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley sourceWallet)
+                        Default
+                        Empty
+                verify
+                    response
+                    [ expectField
+                        (#balance . #available . #toNatural)
                         (`shouldBe` 43_000_000)
-                    , expectField (#balance . #total . #toNatural)
+                    , expectField
+                        (#balance . #total . #toNatural)
                         (`shouldBe` 43_000_000)
                     ]
-                pure $ getFromResponse (#balance. #available . #toNatural)
-                    response
+                pure
+                    $ getFromResponse
+                        (#balance . #available . #toNatural)
+                        response
 
             -- Analyse the source wallet's UTxO distribution:
             let expectedSourceDistribution =
-                    [ (  1_000_000, 3)
-                    , ( 10_000_000, 6)
+                    [ (1_000_000, 3)
+                    , (10_000_000, 6)
                     , (100_000_000, 1)
                     ]
-            responseSourceDistribution <- request @ApiUtxoStatistics ctx
-                (Link.getUTxOsStatistics @'Shelley sourceWallet) Default Empty
-            verify responseSourceDistribution
-                [ expectField #distribution
-                    ((`shouldBe` expectedSourceDistribution)
-                    . Map.toList
-                    . Map.filter (> 0)
+            responseSourceDistribution <-
+                request @ApiUtxoStatistics
+                    ctx
+                    (Link.getUTxOsStatistics @'Shelley sourceWallet)
+                    Default
+                    Empty
+            verify
+                responseSourceDistribution
+                [ expectField
+                    #distribution
+                    ( (`shouldBe` expectedSourceDistribution)
+                        . Map.toList
+                        . Map.filter (> 0)
                     )
                 ]
 
             -- Create an empty target wallet:
             targetWallet <- emptyWallet ctx
             targetAddresses <- listAddresses @n ctx targetWallet
-            let targetAddressIds = targetAddresses <&>
-                    (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+            let targetAddressIds =
+                    targetAddresses
+                        <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
 
             -- Compute the expected migration plan:
             let feeExpected =
                     if _mainEra ctx >= ApiBabbage
-                    then 254_700
-                    else 254_500
-            responsePlan <- request @(ApiWalletMigrationPlan n) ctx
-                (Link.createMigrationPlan @'Shelley sourceWallet) Default
-                (Json [json|{addresses: #{targetAddressIds}}|])
-            verify responsePlan
+                        then 254_700
+                        else 254_500
+            responsePlan <-
+                request @(ApiWalletMigrationPlan n)
+                    ctx
+                    (Link.createMigrationPlan @'Shelley sourceWallet)
+                    Default
+                    (Json [json|{addresses: #{targetAddressIds}}|])
+            verify
+                responsePlan
                 [ expectResponseCode HTTP.status202
                 , expectField #totalFee (`shouldBe` ApiAmount feeExpected)
                 , expectField #selections ((`shouldBe` 1) . length)
@@ -916,83 +1171,107 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
 
             -- Perform the migration:
             let ep = Link.migrateWallet @'Shelley sourceWallet
-            responseMigrate <- request @[ApiTransaction n] ctx ep Default $
-                Json [json|
+            responseMigrate <-
+                request @[ApiTransaction n] ctx ep Default
+                    $ Json
+                        [json|
                     { passphrase: #{fixturePassphrase}
                     , addresses: #{targetAddressIds}
                     }|]
 
             -- Verify the fee is as expected:
-            verify responseMigrate
+            verify
+                responseMigrate
                 [ expectResponseCode HTTP.status202
                 , expectField id ((`shouldBe` 1) . length)
                 , expectField id
                     $ (`shouldBe` feeExpected)
-                    . fromIntegral
-                    . sum
-                    . fmap apiTransactionFee
+                        . fromIntegral
+                        . sum
+                        . fmap apiTransactionFee
                 ]
 
             waitForTxImmutability ctx
 
             -- Check that funds become available in the target wallet:
             let expectedBalance = sourceBalance - feeExpected
-            request @ApiWallet ctx
+            request @ApiWallet
+                ctx
                 (Link.getWallet @'Shelley targetWallet)
                 Default
-                Empty >>= flip verify
-                [ expectField
-                    (#balance . #available)
-                    ( `shouldBe` ApiAmount expectedBalance)
-                , expectField
-                    (#balance . #total)
-                    ( `shouldBe` ApiAmount expectedBalance)
-                ]
+                Empty
+                >>= flip
+                    verify
+                    [ expectField
+                        (#balance . #available)
+                        (`shouldBe` ApiAmount expectedBalance)
+                    , expectField
+                        (#balance . #total)
+                        (`shouldBe` ApiAmount expectedBalance)
+                    ]
 
             -- Analyse the target wallet's UTxO distribution:
             let expectedTargetDistribution = [(100_000_000, 1)]
-            responseTargetDistribution <- request @ApiUtxoStatistics ctx
-                (Link.getUTxOsStatistics @'Shelley targetWallet) Default Empty
-            verify responseTargetDistribution
-                [ expectField #distribution
-                    ((`shouldBe` expectedTargetDistribution)
-                    . Map.toList
-                    . Map.filter (> 0)
+            responseTargetDistribution <-
+                request @ApiUtxoStatistics
+                    ctx
+                    (Link.getUTxOsStatistics @'Shelley targetWallet)
+                    Default
+                    Empty
+            verify
+                responseTargetDistribution
+                [ expectField
+                    #distribution
+                    ( (`shouldBe` expectedTargetDistribution)
+                        . Map.toList
+                        . Map.filter (> 0)
                     )
                 ]
 
-    Hspec.it "SHELLEY_MIGRATE_09 - \
+    Hspec.it
+        "SHELLEY_MIGRATE_09 - \
         \Can migrate a wallet that has rewards."
         $ \ctx -> runResourceT @IO $ do
+            noConway ctx "MIR"
 
             -- Create a source wallet with rewards:
             (sourceWallet, _sourceWalletMnemonic) <- rewardWallet ctx
 
             -- Check that the source wallet has the expected balance:
-            let expectedAdaBalanceAvailable =   100_000_000_000
-            let expectedAdaBalanceReward    = 1_000_000_000_000
-            let expectedAdaBalanceTotal     = 1_100_000_000_000
-            request @ApiWallet ctx
-                (Link.getWallet @'Shelley sourceWallet) Default Empty
-                >>= flip verify
-                [ expectField (#balance . #available . #toNatural)
-                    (`shouldBe` expectedAdaBalanceAvailable)
-                , expectField (#balance . #reward . #toNatural)
-                    (`shouldBe` expectedAdaBalanceReward)
-                , expectField (#balance . #total . #toNatural)
-                    (`shouldBe` expectedAdaBalanceTotal)
-                ]
+            let expectedAdaBalanceAvailable = 100_000_000_000
+            let expectedAdaBalanceReward = 1_000_000_000_000
+            let expectedAdaBalanceTotal = 1_100_000_000_000
+            request @ApiWallet
+                ctx
+                (Link.getWallet @'Shelley sourceWallet)
+                Default
+                Empty
+                >>= flip
+                    verify
+                    [ expectField
+                        (#balance . #available . #toNatural)
+                        (`shouldBe` expectedAdaBalanceAvailable)
+                    , expectField
+                        (#balance . #reward . #toNatural)
+                        (`shouldBe` expectedAdaBalanceReward)
+                    , expectField
+                        (#balance . #total . #toNatural)
+                        (`shouldBe` expectedAdaBalanceTotal)
+                    ]
 
             -- Create an empty target wallet:
             targetWallet <- emptyWallet ctx
             targetAddresses <- listAddresses @n ctx targetWallet
-            let targetAddressIds = targetAddresses <&>
-                    (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+            let targetAddressIds =
+                    targetAddresses
+                        <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
 
             -- Perform a migration:
             let ep = Link.migrateWallet @'Shelley sourceWallet
-            responseMigrate <- request @[ApiTransaction n] ctx ep Default $
-                Json [json|
+            responseMigrate <-
+                request @[ApiTransaction n] ctx ep Default
+                    $ Json
+                        [json|
                     { passphrase: #{fixturePassphrase}
                     , addresses: #{targetAddressIds}
                     }|]
@@ -1000,163 +1279,208 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             -- Verify the fee is as expected:
             let expectedFee =
                     if _mainEra ctx >= ApiBabbage
-                    then 139_200
-                    else 139_000
-            verify responseMigrate
+                        then 139_200
+                        else 139_000
+            verify
+                responseMigrate
                 [ expectResponseCode HTTP.status202
                 , expectField id ((`shouldBe` 1) . length)
                 , expectField id
                     $ (`shouldBe` expectedFee)
-                    . sum
-                    . fmap apiTransactionFee
+                        . sum
+                        . fmap apiTransactionFee
                 ]
 
             waitForTxImmutability ctx
 
             -- Check that funds become available in the target wallet:
             let expectedTargetBalance = expectedAdaBalanceTotal - expectedFee
-            request @ApiWallet ctx
-                (Link.getWallet @'Shelley targetWallet) Default Empty
-                >>= flip verify
-                [ expectField
-                    (#balance . #available)
-                    (`shouldBe` ApiAmount expectedTargetBalance)
-                , expectField
-                    (#balance . #total)
-                    (`shouldBe` ApiAmount expectedTargetBalance)
-                ]
+            request @ApiWallet
+                ctx
+                (Link.getWallet @'Shelley targetWallet)
+                Default
+                Empty
+                >>= flip
+                    verify
+                    [ expectField
+                        (#balance . #available)
+                        (`shouldBe` ApiAmount expectedTargetBalance)
+                    , expectField
+                        (#balance . #total)
+                        (`shouldBe` ApiAmount expectedTargetBalance)
+                    ]
 
             -- Check that the source wallet has been depleted:
-            request @ApiWallet ctx
-                (Link.getWallet @'Shelley sourceWallet) Default Empty
-                >>= flip verify
-                [ expectResponseCode HTTP.status200
-                , expectField
-                    (#balance . #available)
-                    (`shouldBe` ApiAmount 0)
-                , expectField
-                    (#balance . #total)
-                    (`shouldBe` ApiAmount 0)
-                ]
+            request @ApiWallet
+                ctx
+                (Link.getWallet @'Shelley sourceWallet)
+                Default
+                Empty
+                >>= flip
+                    verify
+                    [ expectResponseCode HTTP.status200
+                    , expectField
+                        (#balance . #available)
+                        (`shouldBe` ApiAmount 0)
+                    , expectField
+                        (#balance . #total)
+                        (`shouldBe` ApiAmount 0)
+                    ]
 
-    Hspec.it "SHELLEY_MIGRATE_MULTI_ASSET_01 - \
+    Hspec.it
+        "SHELLEY_MIGRATE_MULTI_ASSET_01 - \
         \Can migrate a multi-asset wallet."
         $ \ctx -> runResourceT @IO $ do
-
             -- Restore a source wallet with funds:
             sourceWallet <- fixtureMultiAssetWallet ctx
 
             -- Wait for the source wallet balance to be correct:
             let expectedAdaBalance = 40_000_000
             sourceBalance <- eventually "Source wallet balance is correct." $ do
-                response <- request @ApiWallet ctx
-                    (Link.getWallet @'Shelley sourceWallet) Default Empty
-                verify response
-                    [ expectField (#balance . #available . #toNatural)
+                response <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley sourceWallet)
+                        Default
+                        Empty
+                verify
+                    response
+                    [ expectField
+                        (#balance . #available . #toNatural)
                         (`shouldBe` expectedAdaBalance)
-                    , expectField (#balance . #total . #toNatural)
+                    , expectField
+                        (#balance . #total . #toNatural)
                         (`shouldBe` expectedAdaBalance)
-                    , expectField (#assets . #available)
+                    , expectField
+                        (#assets . #available)
                         ((`shouldBe` 8) . length . toList)
-                    , expectField (#assets . #total)
+                    , expectField
+                        (#assets . #total)
                         ((`shouldBe` 8) . length . toList)
                     ]
-                let balanceAda = response
-                        & getFromResponse (#balance . #available . #toNatural)
-                        & fromIntegral
-                        & Coin
-                let balanceAssets = response
-                        & getFromResponse (#assets . #available)
-                        & ApiWalletAssets.toTokenMap
+                let balanceAda =
+                        response
+                            & getFromResponse (#balance . #available . #toNatural)
+                            & fromIntegral
+                            & Coin
+                let balanceAssets =
+                        response
+                            & getFromResponse (#assets . #available)
+                            & ApiWalletAssets.toTokenMap
                 pure $ TokenBundle balanceAda balanceAssets
 
             -- Create an empty target wallet:
             targetWallet <- emptyWallet ctx
             targetAddresses <- listAddresses @n ctx targetWallet
-            let targetAddressIds = targetAddresses <&>
-                    (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+            let targetAddressIds =
+                    targetAddresses
+                        <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
 
             -- Create a migration plan:
             let endpointPlan = (Link.createMigrationPlan @'Shelley sourceWallet)
-            responsePlan <- request @(ApiWalletMigrationPlan n)
-                ctx endpointPlan Default $
-                Json [json|{addresses: #{targetAddressIds}}|]
+            responsePlan <-
+                request @(ApiWalletMigrationPlan n)
+                    ctx
+                    endpointPlan
+                    Default
+                    $ Json [json|{addresses: #{targetAddressIds}}|]
 
             -- Verify the plan is as expected:
             let expectedFee =
                     if _mainEra ctx >= ApiBabbage
-                    then 191_000
-                    else 190_800
-            verify responsePlan
+                        then 191_000
+                        else 190_800
+            verify
+                responsePlan
                 [ expectResponseCode HTTP.status202
-                , expectField (#totalFee . #toNatural)
+                , expectField
+                    (#totalFee . #toNatural)
                     (`shouldBe` expectedFee)
-                , expectField (#selections)
+                , expectField
+                    (#selections)
                     ((`shouldBe` 1) . length)
-                , expectField id
+                , expectField
+                    id
                     ((`shouldBe` 3) . apiPlanTotalInputCount)
-                , expectField id
+                , expectField
+                    id
                     ((`shouldBe` 1) . apiPlanTotalOutputCount)
-                , expectField (#balanceSelected . #ada)
+                , expectField
+                    (#balanceSelected . #ada)
                     (`shouldBe` ApiAmount.fromCoin (view #coin sourceBalance))
-                , expectField (#balanceLeftover . #ada . #toNatural)
+                , expectField
+                    (#balanceLeftover . #ada . #toNatural)
                     (`shouldBe` 0)
-                , expectField (#balanceSelected . #assets)
-                    (`shouldBe`
+                , expectField
+                    (#balanceSelected . #assets)
+                    ( `shouldBe`
                         ApiWalletAssets.fromTokenMap
                             (view #tokens sourceBalance)
                     )
-                , expectField (#balanceLeftover . #assets)
+                , expectField
+                    (#balanceLeftover . #assets)
                     (`shouldBe` mempty)
                 ]
 
             -- Perform a migration:
             let endpointMigrate = Link.migrateWallet @'Shelley sourceWallet
             responseMigrate <-
-                request @[ApiTransaction n] ctx endpointMigrate Default $
-                Json [json|
+                request @[ApiTransaction n] ctx endpointMigrate Default
+                    $ Json
+                        [json|
                     { passphrase: #{fixturePassphrase}
                     , addresses: #{targetAddressIds}
                     }|]
 
             -- Verify the fee is as expected:
-            verify responseMigrate
+            verify
+                responseMigrate
                 [ expectResponseCode HTTP.status202
                 , expectField id ((`shouldBe` 1) . length)
                 , expectField id
                     $ (`shouldBe` expectedFee)
-                    . fromIntegral
-                    . sum
-                    . fmap apiTransactionFee
+                        . fromIntegral
+                        . sum
+                        . fmap apiTransactionFee
                 ]
 
             waitForTxImmutability ctx
 
             -- Check that funds become available in the target wallet:
             let expectedTargetBalance = expectedAdaBalance - expectedFee
-            let expectedSourceBalance = ApiWalletAssets.fromTokenMap
-                    (view #tokens sourceBalance)
-            request @ApiWallet ctx
-                (Link.getWallet @'Shelley targetWallet) Default Empty
-                >>= flip verify
-                [ expectField
-                    (#balance . #available)
-                    (`shouldBe` ApiAmount expectedTargetBalance)
-                , expectField
-                    (#balance . #total)
-                    (`shouldBe` ApiAmount expectedTargetBalance)
-                , expectField
-                    (#assets . #available)
-                    (`shouldBe` expectedSourceBalance)
-                , expectField
-                    (#assets . #total)
-                    (`shouldBe` expectedSourceBalance)
-                ]
+            let expectedSourceBalance =
+                    ApiWalletAssets.fromTokenMap
+                        (view #tokens sourceBalance)
+            request @ApiWallet
+                ctx
+                (Link.getWallet @'Shelley targetWallet)
+                Default
+                Empty
+                >>= flip
+                    verify
+                    [ expectField
+                        (#balance . #available)
+                        (`shouldBe` ApiAmount expectedTargetBalance)
+                    , expectField
+                        (#balance . #total)
+                        (`shouldBe` ApiAmount expectedTargetBalance)
+                    , expectField
+                        (#assets . #available)
+                        (`shouldBe` expectedSourceBalance)
+                    , expectField
+                        (#assets . #total)
+                        (`shouldBe` expectedSourceBalance)
+                    ]
 
             -- Check that the source wallet has been depleted:
-            responseFinalSourceBalance <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley sourceWallet) Default Empty
-            verify responseFinalSourceBalance
+            responseFinalSourceBalance <-
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley sourceWallet)
+                    Default
+                    Empty
+            verify
+                responseFinalSourceBalance
                 [ expectResponseCode HTTP.status200
                 , expectField
                     (#balance . #available)
@@ -1182,19 +1506,31 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
         -> [ApiAddress n]
         -> IO ()
     migrateWallet ctx src targets = do
-        (status, _) <- request @(ApiWalletMigrationPlan n) ctx
-            endpointCreateMigrationPlan Default payloadCreateMigrationPlan
+        (status, _) <-
+            request @(ApiWalletMigrationPlan n)
+                ctx
+                endpointCreateMigrationPlan
+                Default
+                payloadCreateMigrationPlan
         when (status == HTTP.status202) $ do
             -- The above request returns '403 Nothing to Migrate' when done.
 
             -- 1. Forget all pending transactions to unlock any locked UTxO:
-            (_, txs) <- unsafeRequest
-                @[ApiTransaction n] ctx endpointListTxs Empty
+            (_, txs) <-
+                unsafeRequest
+                    @[ApiTransaction n]
+                    ctx
+                    endpointListTxs
+                    Empty
             forM_ txs $ forgetTxIf ((== ApiT Pending) . view #status)
 
             -- 2. Attempt to migrate:
-            _ <- request @[ApiTransaction n] ctx endpointMigrateWallet Default
-                payloadMigrateWallet
+            _ <-
+                request @[ApiTransaction n]
+                    ctx
+                    endpointMigrateWallet
+                    Default
+                    payloadMigrateWallet
 
             -- 3. Wait long enough for transactions to have been inserted:
             waitForTxImmutability ctx
@@ -1213,7 +1549,9 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             Link.deleteTransaction @'Shelley src
 
         payloadCreateMigrationPlan = Json [json|{"addresses": #{targets}}|]
-        payloadMigrateWallet = Json [json|
+        payloadMigrateWallet =
+            Json
+                [json|
             { "passphrase": #{fixturePassphrase}
             , "addresses": #{targets}
             }|]
@@ -1225,28 +1563,34 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 pure ()
 
     testAddressCycling targetAddressCount = do
-        let title = mconcat
-                [ "Migration from Shelley wallet to target address count: "
-                , show targetAddressCount
-                , "."
-                ]
+        let title =
+                mconcat
+                    [ "Migration from Shelley wallet to target address count: "
+                    , show targetAddressCount
+                    , "."
+                    ]
         it title $ \ctx -> runResourceT $ do
             -- Restore a Shelley wallet with funds, to act as a source wallet:
             sourceWallet <- fixtureWallet ctx
             let sourceBalance =
-                    view (#balance. #available . #toNatural) sourceWallet
+                    view (#balance . #available . #toNatural) sourceWallet
 
             -- Create an empty target wallet:
             targetWallet <- emptyWallet ctx
             targetAddresses <- listAddresses @n ctx targetWallet
-            let targetAddressIds = take targetAddressCount targetAddresses <&>
-                    (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
+            let targetAddressIds =
+                    take targetAddressCount targetAddresses
+                        <&> (\(ApiTypes.ApiAddressWithPath addrId _ _) -> addrId)
 
             -- Create a migration plan:
-            response0 <- request @(ApiWalletMigrationPlan n) ctx
-                (Link.createMigrationPlan @'Shelley sourceWallet) Default
-                (Json [json|{addresses: #{targetAddressIds}}|])
-            verify response0
+            response0 <-
+                request @(ApiWalletMigrationPlan n)
+                    ctx
+                    (Link.createMigrationPlan @'Shelley sourceWallet)
+                    Default
+                    (Json [json|{addresses: #{targetAddressIds}}|])
+            verify
+                response0
                 [ expectResponseCode HTTP.status202
                 , expectField #totalFee (.> ApiAmount 0)
                 ]
@@ -1254,14 +1598,19 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                     getFromResponse (#totalFee . #toNatural) response0
 
             -- Perform a migration from the source wallet to the target wallet:
-            response1 <- request @[ApiTransaction n] ctx
-                (Link.migrateWallet @'Shelley sourceWallet)
-                Default
-                (Json [json|
+            response1 <-
+                request @[ApiTransaction n]
+                    ctx
+                    (Link.migrateWallet @'Shelley sourceWallet)
+                    Default
+                    ( Json
+                        [json|
                     { passphrase: #{fixturePassphrase}
                     , addresses: #{targetAddressIds}
-                    }|])
-            verify response1
+                    }|]
+                    )
+            verify
+                response1
                 [ expectResponseCode HTTP.status202
                 , expectField id (`shouldSatisfy` (not . null))
                 ]
@@ -1270,9 +1619,14 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
 
             -- Check that funds have become available in the target wallet:
             let expectedTargetBalance = sourceBalance - expectedFee
-            response2 <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley targetWallet) Default Empty
-            verify response2
+            response2 <-
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley targetWallet)
+                    Default
+                    Empty
+            verify
+                response2
                 [ expectField
                     (#balance . #available)
                     (`shouldBe` ApiAmount expectedTargetBalance)
@@ -1282,9 +1636,14 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 ]
 
             -- Check that the source wallet has a balance of zero:
-            responseFinalSourceBalance <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley sourceWallet) Default Empty
-            verify responseFinalSourceBalance
+            responseFinalSourceBalance <-
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley sourceWallet)
+                    Default
+                    Empty
+            verify
+                responseFinalSourceBalance
                 [ expectField
                     (#balance . #available)
                     (`shouldBe` ApiAmount 0)

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -177,6 +177,7 @@ import Test.Integration.Framework.DSL
     , json
     , listAddresses
     , minUTxOValue
+    , noConway
     , notDelegating
     , notRetiringPools
     , postWallet
@@ -224,31 +225,39 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             request @[ApiT StakePool] ctx (Link.listStakePools stake) Default Empty
                 & (fmap . fmap . fmap . fmap) getApiT
 
-    it "STAKE_POOLS_MAINTENANCE_01 - \
-        \trigger GC action when metadata source = direct" $ \ctx -> runResourceT $ bracketSettings ctx $ do
-        updateMetadataSource ctx "direct"
-        verifyMetadataSource ctx FetchDirect
-        triggerMaintenanceAction ctx "gc_stake_pools"
-        let delay = 500 * 1_000
-            timeout = 10
-        eventuallyUsingDelay delay timeout "GC Status shows as NotApplicable" $ do
-          verifyMaintenanceAction ctx NotApplicable
+    it
+        "STAKE_POOLS_MAINTENANCE_01 - \
+        \trigger GC action when metadata source = direct"
+        $ \ctx -> runResourceT $ bracketSettings ctx $ do
+            updateMetadataSource ctx "direct"
+            verifyMetadataSource ctx FetchDirect
+            triggerMaintenanceAction ctx "gc_stake_pools"
+            let delay = 500 * 1_000
+                timeout = 10
+            eventuallyUsingDelay delay timeout "GC Status shows as NotApplicable" $ do
+                verifyMaintenanceAction ctx NotApplicable
 
-    it "STAKE_POOLS_MAINTENANCE_02 - \
-        \trigger GC action when metadata source = none" $ \ctx -> runResourceT $ bracketSettings ctx $ do
-        updateMetadataSource ctx "none"
-        verifyMetadataSource ctx FetchNone
-        triggerMaintenanceAction ctx "gc_stake_pools"
-        let delay = 500 * 1_000
-            timeout = 10
-        eventuallyUsingDelay delay timeout "GC Status shows as NotApplicable" $ do
-          verifyMaintenanceAction ctx NotApplicable
+    it
+        "STAKE_POOLS_MAINTENANCE_02 - \
+        \trigger GC action when metadata source = none"
+        $ \ctx -> runResourceT $ bracketSettings ctx $ do
+            updateMetadataSource ctx "none"
+            verifyMetadataSource ctx FetchNone
+            triggerMaintenanceAction ctx "gc_stake_pools"
+            let delay = 500 * 1_000
+                timeout = 10
+            eventuallyUsingDelay delay timeout "GC Status shows as NotApplicable" $ do
+                verifyMaintenanceAction ctx NotApplicable
 
     it "STAKE_POOLS_JOIN_01 - Cannot join non-existent wallet" $ \ctx -> runResourceT $ do
         w <- emptyWallet ctx
         let wid = w ^. walletId
-        _ <- request @ApiWallet ctx
-            (Link.deleteWallet @'Shelley w) Default Empty
+        _ <-
+            request @ApiWallet
+                ctx
+                (Link.deleteWallet @'Shelley w)
+                Default
+                Empty
         let poolIdAbsent = PoolId $ BS.pack $ replicate 32 1
         r <- joinStakePool @n ctx (SpecificPool poolIdAbsent) (w, fixturePassphrase)
         expectResponseCode HTTP.status404 r
@@ -257,87 +266,100 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
     it "STAKE_POOLS_JOIN_01 - Cannot join non-existent stakepool" $ \ctx -> runResourceT $ do
         w <- fixtureWallet ctx
         let poolIdAbsent = PoolId $ BS.pack $ replicate 32 1
-        r <- joinStakePool @n ctx (SpecificPool  poolIdAbsent) (w, fixturePassphrase)
+        r <- joinStakePool @n ctx (SpecificPool poolIdAbsent) (w, fixturePassphrase)
         expectResponseCode HTTP.status404 r
         expectErrorMessage (errMsg404NoSuchPool (toText poolIdAbsent)) r
 
-    it "STAKE_POOLS_JOIN_01 - \
-        \Cannot join existent stakepool with wrong password" $ \ctx -> runResourceT $ do
-        w <- fixtureWallet ctx
-        pool : _ <- map (view #id . getApiT) . snd <$>
-            unsafeRequest @[ApiT StakePool]
-            ctx (Link.listStakePools arbitraryStake) Empty
-        joinStakePool @n ctx (SpecificPool  pool) (w, "Wrong Passphrase")
-            >>= flip verify
-            [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403WrongPass
-            ]
+    it
+        "STAKE_POOLS_JOIN_01 - \
+        \Cannot join existent stakepool with wrong password"
+        $ \ctx -> runResourceT $ do
+            w <- fixtureWallet ctx
+            pool : _ <-
+                map (view #id . getApiT) . snd
+                    <$> unsafeRequest @[ApiT StakePool]
+                        ctx
+                        (Link.listStakePools arbitraryStake)
+                        Empty
+            joinStakePool @n ctx (SpecificPool pool) (w, "Wrong Passphrase")
+                >>= flip
+                    verify
+                    [ expectResponseCode HTTP.status403
+                    , expectErrorMessage errMsg403WrongPass
+                    ]
 
-    it "STAKE_POOLS_JOIN_01rewards - \
-        \Can join a pool, earn rewards and collect them" $ \ctx -> runResourceT $ do
-        src <- fixtureWallet ctx
-        dest <- emptyWallet ctx
-        let deposit = depositAmt ctx
-        pool : _  <- map (view #id) <$> notRetiringPools ctx
+    it
+        "STAKE_POOLS_JOIN_01rewards - \
+        \Can join a pool, earn rewards and collect them"
+        $ \ctx -> runResourceT $ do
+            noConway ctx "certificate"
+            src <- fixtureWallet ctx
+            dest <- emptyWallet ctx
+            let deposit = depositAmt ctx
+            pool : _ <- map (view #id) <$> notRetiringPools ctx
 
-        -- Join Pool
-        rJoin <- joinStakePool @n ctx (SpecificPool pool) (src, fixturePassphrase)
-        verify rJoin
-            [ expectResponseCode HTTP.status202
-            , expectField (#status . #getApiT) (`shouldBe` Pending)
-            , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-            , expectField #depositTaken (`shouldBe` ApiAmount deposit)
-            , expectField #inputs $ \inputs' -> do
-                inputs' `shouldSatisfy` all (isJust . source)
-            ]
-        eventually "Wallet has joined pool and deposit info persists" $ do
-            let endpoint = Link.getTransaction @'Shelley src (getResponse rJoin)
-            request @(ApiTransaction n) ctx endpoint Default Empty
-                >>= flip verify
-                [ expectResponseCode HTTP.status200
-                , expectField (#status . #getApiT) (`shouldBe` InLedger)
+            -- Join Pool
+            rJoin <- joinStakePool @n ctx (SpecificPool pool) (src, fixturePassphrase)
+            verify
+                rJoin
+                [ expectResponseCode HTTP.status202
+                , expectField (#status . #getApiT) (`shouldBe` Pending)
                 , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
                 , expectField #depositTaken (`shouldBe` ApiAmount deposit)
-                , expectField #depositReturned (`shouldBe` ApiAmount 0)
-                ]
-
-        let txId = getFromResponse #id rJoin
-        let link = Link.getTransaction @'Shelley src (ApiTxId txId)
-        eventually "delegation transaction is in ledger" $ do
-            rSrc <- request @(ApiTransaction n) ctx link Default Empty
-            verify rSrc
-                [ expectResponseCode HTTP.status200
-                , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-                , expectField (#status . #getApiT) (`shouldBe` InLedger)
-                , expectField #metadata (`shouldBe` Nothing)
-                , expectField #depositTaken (`shouldBe` ApiAmount deposit)
-                , expectField #depositReturned (`shouldBe` ApiAmount 0)
-                , expectField (#fee . #toNatural) (`shouldSatisfy` (> 0))
-                , expectField #inputs $ \inputs' ->
+                , expectField #inputs $ \inputs' -> do
                     inputs' `shouldSatisfy` all (isJust . source)
                 ]
+            eventually "Wallet has joined pool and deposit info persists" $ do
+                let endpoint = Link.getTransaction @'Shelley src (getResponse rJoin)
+                request @(ApiTransaction n) ctx endpoint Default Empty
+                    >>= flip
+                        verify
+                        [ expectResponseCode HTTP.status200
+                        , expectField (#status . #getApiT) (`shouldBe` InLedger)
+                        , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+                        , expectField #depositTaken (`shouldBe` ApiAmount deposit)
+                        , expectField #depositReturned (`shouldBe` ApiAmount 0)
+                        ]
 
-        -- Epoch A: delegation tx is in the ledger.
-        -- Epoch A+1: stake is registered to a chosen pool.
-        -- Epoch A+2: stake is active, rewards start accumulating.
-        -- Epoch A+3: rewards from epoch A+2 are calculated.
-        -- Epoch A+4: rewards from epoch A+2 are paid out.
-        waitNumberOfEpochBoundaries 4 ctx
+            let txId = getFromResponse #id rJoin
+            let link = Link.getTransaction @'Shelley src (ApiTxId txId)
+            eventually "delegation transaction is in ledger" $ do
+                rSrc <- request @(ApiTransaction n) ctx link Default Empty
+                verify
+                    rSrc
+                    [ expectResponseCode HTTP.status200
+                    , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+                    , expectField (#status . #getApiT) (`shouldBe` InLedger)
+                    , expectField #metadata (`shouldBe` Nothing)
+                    , expectField #depositTaken (`shouldBe` ApiAmount deposit)
+                    , expectField #depositReturned (`shouldBe` ApiAmount 0)
+                    , expectField (#fee . #toNatural) (`shouldSatisfy` (> 0))
+                    , expectField #inputs $ \inputs' ->
+                        inputs' `shouldSatisfy` all (isJust . source)
+                    ]
 
-        (previousBalance, walletRewards) <- eventually "Wallet gets rewards" $ do
-            let endpoint = Link.getWallet @'Shelley src
-            r <- request @ApiWallet ctx endpoint Default Empty
-            verify r [ expectField (#balance . #reward) (.> ApiAmount 0) ]
-            pure
-                ( getFromResponse (#balance . #available) r
-                , getFromResponse (#balance . #reward) r
-                )
+            -- Epoch A: delegation tx is in the ledger.
+            -- Epoch A+1: stake is registered to a chosen pool.
+            -- Epoch A+2: stake is active, rewards start accumulating.
+            -- Epoch A+3: rewards from epoch A+2 are calculated.
+            -- Epoch A+4: rewards from epoch A+2 are paid out.
+            waitNumberOfEpochBoundaries 4 ctx
 
-        -- Try to use rewards
-        addrs <- listAddresses @n ctx dest
-        let coin = minUTxOValue (_mainEra ctx) :: Natural
-        let addr = (addrs !! 1) ^. #id
-        let payload = [json|
+            (previousBalance, walletRewards) <- eventually "Wallet gets rewards" $ do
+                let endpoint = Link.getWallet @'Shelley src
+                r <- request @ApiWallet ctx endpoint Default Empty
+                verify r [expectField (#balance . #reward) (.> ApiAmount 0)]
+                pure
+                    ( getFromResponse (#balance . #available) r
+                    , getFromResponse (#balance . #reward) r
+                    )
+
+            -- Try to use rewards
+            addrs <- listAddresses @n ctx dest
+            let coin = minUTxOValue (_mainEra ctx) :: Natural
+            let addr = (addrs !! 1) ^. #id
+            let payload =
+                    [json|
                 { "payments":
                     [ { "address": #{addr}
                       , "amount":
@@ -349,50 +371,75 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                 , "passphrase": #{fixturePassphrase}
                 }|]
 
-        -- cannot use rewards by default
-        r1 <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley src)
-            Default (Json payload)
-        expectResponseCode HTTP.status202 r1
-        eventually "Wallet has not consumed rewards" $ do
-          let linkSrc = Link.getTransaction @'Shelley
-                  src (getFromResponse Prelude.id r1)
-          request @(ApiTransaction n) ctx linkSrc Default Empty
-              >>= flip verify
-                  [ expectField
-                      (#status . #getApiT) (`shouldBe` InLedger)
-                  ]
-          request @ApiWallet ctx (Link.getWallet @'Shelley src) Default Empty
-              >>= flip verify
-                  [ expectField
-                      (#balance . #reward) (`shouldBe` walletRewards)
-                  ]
+            -- cannot use rewards by default
+            r1 <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley src)
+                    Default
+                    (Json payload)
+            expectResponseCode HTTP.status202 r1
+            eventually "Wallet has not consumed rewards" $ do
+                let linkSrc =
+                        Link.getTransaction @'Shelley
+                            src
+                            (getFromResponse Prelude.id r1)
+                request @(ApiTransaction n) ctx linkSrc Default Empty
+                    >>= flip
+                        verify
+                        [ expectField
+                            (#status . #getApiT)
+                            (`shouldBe` InLedger)
+                        ]
+                request @ApiWallet ctx (Link.getWallet @'Shelley src) Default Empty
+                    >>= flip
+                        verify
+                        [ expectField
+                            (#balance . #reward)
+                            (`shouldBe` walletRewards)
+                        ]
 
-        -- Listing stake keys shows
-        request @(ApiStakeKeys n) ctx (Link.listStakeKeys src) Default Empty
-            >>= flip verify
-            [ expectField (#_foreign) (`shouldBe` [])
-            , expectField (#_ours) (\case
-                [acc] -> do
-                    (acc ^. #_stake) .> ApiAmount 0
-                    acc ^. (#_delegation . #active . #status)
-                        `shouldBe` Delegating
-                    acc ^. (#_delegation . #active . #target)
-                        `shouldBe` (Just (ApiT pool))
-                _ -> expectationFailure "wrong number of accounts in \"ours\""
-                )
-            , expectField (#_none . #_stake) (.> ApiAmount 0)
-            ]
+            -- Listing stake keys shows
+            request @(ApiStakeKeys n) ctx (Link.listStakeKeys src) Default Empty
+                >>= flip
+                    verify
+                    [ expectField (#_foreign) (`shouldBe` [])
+                    , expectField
+                        (#_ours)
+                        ( \case
+                            [acc] -> do
+                                (acc ^. #_stake) .> ApiAmount 0
+                                acc
+                                    ^. (#_delegation . #active . #status)
+                                        `shouldBe` Delegating
+                                acc
+                                    ^. (#_delegation . #active . #target)
+                                        `shouldBe` (Just (ApiT pool))
+                            _ -> expectationFailure "wrong number of accounts in \"ours\""
+                        )
+                    , expectField (#_none . #_stake) (.> ApiAmount 0)
+                    ]
 
-        -- there's currently no withdrawals in the wallet
-        rw1 <- request @[ApiTransaction n] ctx
-            (Link.listTransactions' @'Shelley src (Just 1)
-                Nothing Nothing Nothing Nothing Nothing)
-            Default Empty
-        verify rw1 [ expectListSize 0 ]
+            -- there's currently no withdrawals in the wallet
+            rw1 <-
+                request @[ApiTransaction n]
+                    ctx
+                    ( Link.listTransactions' @'Shelley
+                        src
+                        (Just 1)
+                        Nothing
+                        Nothing
+                        Nothing
+                        Nothing
+                        Nothing
+                    )
+                    Default
+                    Empty
+            verify rw1 [expectListSize 0]
 
-        -- can use rewards with an explicit withdrawal request to self.
-        let payloadWithdrawal = [json|
+            -- can use rewards with an explicit withdrawal request to self.
+            let payloadWithdrawal =
+                    [json|
                 { "payments":
                     [ { "address": #{addr}
                       , "amount":
@@ -405,127 +452,179 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                   "withdrawal": "self"
                 }|]
 
-        waitForNextEpoch ctx
-        rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley src)
-            Default (Json payloadWithdrawal)
-        verify rTx
-            [ expectField #amount (.> (ApiAmount coin))
-            , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-            ]
-        let txAmount = getFromResponse #amount rTx
+            waitForNextEpoch ctx
+            rTx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley src)
+                    Default
+                    (Json payloadWithdrawal)
+            verify
+                rTx
+                [ expectField #amount (.> (ApiAmount coin))
+                , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+                ]
+            let txAmount = getFromResponse #amount rTx
 
-        -- Rewards are have been consumed.
-        eventually "Wallet has consumed rewards" $ do
-            request @ApiWallet ctx (Link.getWallet @'Shelley src) Default Empty
-                >>= flip verify
-                    [ expectField
-                        (#balance . #reward)
-                        (`shouldBe` (ApiAmount 0))
-                    , expectField
-                        (#balance . #available)
-                        (.> previousBalance)
+            -- Rewards are have been consumed.
+            eventually "Wallet has consumed rewards" $ do
+                request @ApiWallet ctx (Link.getWallet @'Shelley src) Default Empty
+                    >>= flip
+                        verify
+                        [ expectField
+                            (#balance . #reward)
+                            (`shouldBe` (ApiAmount 0))
+                        , expectField
+                            (#balance . #available)
+                            (.> previousBalance)
+                        ]
+
+            eventually "There's at least one outgoing transaction with a withdrawal" $ do
+                rWithdrawal <-
+                    request @(ApiTransaction n)
+                        ctx
+                        ( Link.getTransaction @'Shelley
+                            src
+                            (getFromResponse Prelude.id rTx)
+                        )
+                        Default
+                        Empty
+                verify
+                    rWithdrawal
+                    [ expectResponseCode HTTP.status200
+                    , expectField #withdrawals (`shouldSatisfy` (not . null))
+                    , expectField #amount (`shouldBe` txAmount)
                     ]
+                rw2 <-
+                    request @[ApiTransaction n]
+                        ctx
+                        ( Link.listTransactions' @'Shelley
+                            src
+                            (Just 1)
+                            Nothing
+                            Nothing
+                            Nothing
+                            Nothing
+                            Nothing
+                        )
+                        Default
+                        Empty
+                verify rw2 [expectListSize 1]
 
-        eventually "There's at least one outgoing transaction with a withdrawal" $ do
-            rWithdrawal <- request @(ApiTransaction n) ctx
-                (Link.getTransaction @'Shelley src
-                    (getFromResponse Prelude.id rTx))
-                Default Empty
-            verify rWithdrawal
-                [ expectResponseCode HTTP.status200
-                , expectField #withdrawals (`shouldSatisfy` (not . null))
-                , expectField #amount (`shouldBe` txAmount)
-                ]
-            rw2 <- request @[ApiTransaction n] ctx
-                (Link.listTransactions' @'Shelley src (Just 1)
-                    Nothing Nothing Nothing Nothing Nothing)
-                Default Empty
-            verify rw2 [ expectListSize 1 ]
+            eventually "There's one incoming transaction with correct amount" $ do
+                request @[ApiTransaction n]
+                    ctx
+                    (Link.listTransactions @'Shelley dest)
+                    Default
+                    Empty
+                    >>= flip
+                        verify
+                        [ expectListSize 2
+                        , expectListField 0 (#amount . #toNatural) (`shouldBe` coin)
+                        , expectListField 1 (#amount . #toNatural) (`shouldBe` coin)
+                        ]
 
-        eventually "There's one incoming transaction with correct amount" $ do
-            request @[ApiTransaction n] ctx (Link.listTransactions @'Shelley dest)
-                Default Empty >>= flip verify
-                [ expectListSize 2
-                , expectListField 0 (#amount . #toNatural) (`shouldBe` coin)
-                , expectListField 1 (#amount . #toNatural) (`shouldBe` coin)
-                ]
-
-        -- Quit delegation altogether.
-        rq <- quitStakePool @n ctx (src, fixturePassphrase)
-        verify rq
-            -- pending tx for quitting pool is initially outgoing
-            -- because there is a fee for this tx
-            [ expectResponseCode HTTP.status202
-            , expectField (#status . #getApiT) (`shouldBe` Pending)
-            , expectField (#direction . #getApiT) (`shouldBe` Incoming)
-            , expectField #depositTaken (`shouldBe` ApiAmount 0)
-            , expectField #depositReturned (`shouldBe` ApiAmount deposit)
-            , expectField (#fee . #toNatural) (`shouldSatisfy` (> 0))
-            ]
-        let txid = getFromResponse Prelude.id rq
-        let quitFeeAmt = getFromResponse #amount rq
-
-        eventually "Certificates are inserted after quitting a pool" $ do
-            let epg = Link.getTransaction @'Shelley src txid
-            rlg <- request @(ApiTransaction n) ctx epg Default Empty
-            verify rlg
-                [ expectField
-                    (#direction . #getApiT) (`shouldBe` Incoming)
-                , expectField
-                    #amount (`shouldBe` quitFeeAmt)
-                , expectField
-                    (#status . #getApiT) (`shouldBe` InLedger)
+            -- Quit delegation altogether.
+            rq <- quitStakePool @n ctx (src, fixturePassphrase)
+            verify
+                rq
+                -- pending tx for quitting pool is initially outgoing
+                -- because there is a fee for this tx
+                [ expectResponseCode HTTP.status202
+                , expectField (#status . #getApiT) (`shouldBe` Pending)
+                , expectField (#direction . #getApiT) (`shouldBe` Incoming)
                 , expectField #depositTaken (`shouldBe` ApiAmount 0)
                 , expectField #depositReturned (`shouldBe` ApiAmount deposit)
                 , expectField (#fee . #toNatural) (`shouldSatisfy` (> 0))
                 ]
+            let txid = getFromResponse Prelude.id rq
+            let quitFeeAmt = getFromResponse #amount rq
 
-            let epl = Link.listTransactions @'Shelley src
-            rlq <- request @[ApiTransaction n] ctx epl Default Empty
-            verify rlq
-                [ expectListField 0
-                    (#direction . #getApiT) (`shouldBe` Incoming)
-                , expectListField 0
-                    #amount (`shouldBe` quitFeeAmt)
-                , expectListField 0
-                    (#status . #getApiT) (`shouldBe` InLedger)
-                , expectListField 1
-                    (#direction . #getApiT) (`shouldBe` Outgoing)
-                , expectListField 1
-                    (#status . #getApiT) (`shouldBe` InLedger)
-                , expectListField 2
-                    (#direction . #getApiT) (`shouldBe` Outgoing)
-                , expectListField 2
-                    (#status . #getApiT) (`shouldBe` InLedger)
-                ]
+            eventually "Certificates are inserted after quitting a pool" $ do
+                let epg = Link.getTransaction @'Shelley src txid
+                rlg <- request @(ApiTransaction n) ctx epg Default Empty
+                verify
+                    rlg
+                    [ expectField
+                        (#direction . #getApiT)
+                        (`shouldBe` Incoming)
+                    , expectField
+                        #amount
+                        (`shouldBe` quitFeeAmt)
+                    , expectField
+                        (#status . #getApiT)
+                        (`shouldBe` InLedger)
+                    , expectField #depositTaken (`shouldBe` ApiAmount 0)
+                    , expectField #depositReturned (`shouldBe` ApiAmount deposit)
+                    , expectField (#fee . #toNatural) (`shouldSatisfy` (> 0))
+                    ]
 
-    it "STAKE_POOLS_JOIN_02 - \
-        \Cannot join already joined stake pool" $ \ctx -> runResourceT $ do
-        w <- fixtureWallet ctx
-        pool : _  <- map (view #id) <$> notRetiringPools ctx
+                let epl = Link.listTransactions @'Shelley src
+                rlq <- request @[ApiTransaction n] ctx epl Default Empty
+                verify
+                    rlq
+                    [ expectListField
+                        0
+                        (#direction . #getApiT)
+                        (`shouldBe` Incoming)
+                    , expectListField
+                        0
+                        #amount
+                        (`shouldBe` quitFeeAmt)
+                    , expectListField
+                        0
+                        (#status . #getApiT)
+                        (`shouldBe` InLedger)
+                    , expectListField
+                        1
+                        (#direction . #getApiT)
+                        (`shouldBe` Outgoing)
+                    , expectListField
+                        1
+                        (#status . #getApiT)
+                        (`shouldBe` InLedger)
+                    , expectListField
+                        2
+                        (#direction . #getApiT)
+                        (`shouldBe` Outgoing)
+                    , expectListField
+                        2
+                        (#status . #getApiT)
+                        (`shouldBe` InLedger)
+                    ]
 
-        waitForTxStatus ctx w InLedger . getResponse =<<
+    it
+        "STAKE_POOLS_JOIN_02 - \
+        \Cannot join already joined stake pool"
+        $ \ctx -> runResourceT $ do
+            noConway ctx "certificate"
+            w <- fixtureWallet ctx
+            pool : _ <- map (view #id) <$> notRetiringPools ctx
+
+            waitForTxStatus ctx w InLedger . getResponse
+                =<< joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)
+
             joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)
-
-        joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)
-            >>= flip verify
-            [ expectResponseCode HTTP.status403
-            , expectErrorMessage (errMsg403PoolAlreadyJoined $ toText pool)
-            ]
+                >>= flip
+                    verify
+                    [ expectResponseCode HTTP.status403
+                    , expectErrorMessage (errMsg403PoolAlreadyJoined $ toText pool)
+                    ]
 
     it "STAKE_POOLS_JOIN_03 - Cannot join a pool that has retired" $ \ctx -> runResourceT $ do
         waitForEpoch 3 ctx -- One pool retires at epoch 3
         response <- listPools ctx arbitraryStake
-        verify response [ expectListSize 3 ]
+        verify response [expectListSize 3]
         let nonRetiredPoolIds = Set.fromList (view #id <$> getResponse response)
-        let reportError = error $ unlines
-                [ "Unable to find a retired pool ID."
-                , "Test cluster pools:"
-                , unlines (showT <$> Set.toList testClusterPoolIds)
-                , "Non-retired pools:"
-                , unlines (showT <$> Set.toList nonRetiredPoolIds)
-                ]
+        let reportError =
+                error
+                    $ unlines
+                        [ "Unable to find a retired pool ID."
+                        , "Test cluster pools:"
+                        , unlines (showT <$> Set.toList testClusterPoolIds)
+                        , "Non-retired pools:"
+                        , unlines (showT <$> Set.toList nonRetiredPoolIds)
+                        ]
         let retiredPoolIds =
                 testClusterPoolIds `Set.difference` nonRetiredPoolIds
         let retiredPoolId =
@@ -537,86 +636,105 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
     it "STAKE_POOLS_JOIN_EMPTY - Empty wallet cannot join a pool" $ \ctx ->
         runResourceT $ do
+            noConway ctx "certificate"
             w <- emptyWallet ctx
-            pool : _  <- map (view #id) <$> notRetiringPools ctx
+            pool : _ <- map (view #id) <$> notRetiringPools ctx
             r <- joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)
-            verify r
+            verify
+                r
                 [ expectResponseCode HTTP.status403
                 , expectErrorInfo (`shouldBe` NoUtxosAvailable)
                 ]
 
     it "STAKE_POOLS_QUIT_02 - Passphrase must be correct to quit" $ \ctx -> runResourceT $ do
+        noConway ctx "certificate"
         w <- fixtureWallet ctx
-        pool : _  <- map (view #id) <$> notRetiringPools ctx
+        pool : _ <- map (view #id) <$> notRetiringPools ctx
 
-        waitForTxStatus ctx w InLedger . getResponse =<<
-            joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)
+        waitForTxStatus ctx w InLedger . getResponse
+            =<< joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)
 
         let wrongPassphrase = "Incorrect Passphrase"
-        quitStakePool @n ctx (w, wrongPassphrase) >>= flip verify
-            [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403WrongPass
-            ]
+        quitStakePool @n ctx (w, wrongPassphrase)
+            >>= flip
+                verify
+                [ expectResponseCode HTTP.status403
+                , expectErrorMessage errMsg403WrongPass
+                ]
 
-    it "STAKE_POOL_NEXT_02/STAKE_POOLS_QUIT_01 - \
+    it
+        "STAKE_POOL_NEXT_02/STAKE_POOLS_QUIT_01 - \
         \Cannot quit when active: not_delegating"
         $ \ctx -> runResourceT $ do
-        w <- fixtureWallet ctx
-        quitStakePool @n ctx (w, fixturePassphrase) >>= flip verify
-            [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403NotDelegating
-            ]
+            w <- fixtureWallet ctx
+            quitStakePool @n ctx (w, fixturePassphrase)
+                >>= flip
+                    verify
+                    [ expectResponseCode HTTP.status403
+                    , expectErrorMessage errMsg403NotDelegating
+                    ]
 
     it "STAKE_POOLS_QUIT_03 - Can quit with rewards"
         $ \ctx -> runResourceT $ do
-        (w, _) <- rewardWallet ctx
+            noConway ctx "MIR"
+            (w, _) <- rewardWallet ctx
 
-        pool:_:_ <- map (view #id . getApiT) . snd
-            <$> unsafeRequest @[ApiT StakePool]
-                ctx (Link.listStakePools arbitraryStake) Empty
-        joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase) >>= flip verify
-            [ expectResponseCode HTTP.status202
-            , expectField #depositTaken (`shouldBe` ApiAmount 0)
-            , expectField #depositReturned (`shouldBe` ApiAmount 0)
-            ]
-        waitForTxImmutability ctx
-        quitStakePool @n ctx (w, fixturePassphrase) >>= flip verify
-            [ expectResponseCode HTTP.status202
-            , expectField #depositTaken (`shouldBe` ApiAmount 0)
-            , expectField #depositReturned (`shouldBe` ApiAmount 1_000_000)
-            ]
+            pool : _ : _ <-
+                map (view #id . getApiT) . snd
+                    <$> unsafeRequest @[ApiT StakePool]
+                        ctx
+                        (Link.listStakePools arbitraryStake)
+                        Empty
+            joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)
+                >>= flip
+                    verify
+                    [ expectResponseCode HTTP.status202
+                    , expectField #depositTaken (`shouldBe` ApiAmount 0)
+                    , expectField #depositReturned (`shouldBe` ApiAmount 0)
+                    ]
+            waitForTxImmutability ctx
+            quitStakePool @n ctx (w, fixturePassphrase)
+                >>= flip
+                    verify
+                    [ expectResponseCode HTTP.status202
+                    , expectField #depositTaken (`shouldBe` ApiAmount 0)
+                    , expectField #depositReturned (`shouldBe` ApiAmount 1_000_000)
+                    ]
 
     it "STAKE_POOLS_JOIN_01 - Can rejoin another stakepool" $ \ctx -> runResourceT $ do
+        noConway ctx "certificate"
         w <- fixtureWallet ctx
 
         -- make sure we are at the beginning of new epoch
         waitForNextEpoch ctx
         (currentEpoch, _) <- getSlotParams ctx
 
-        pool1 : pool2 : _  <- map (view #id) <$> notRetiringPools ctx
+        pool1 : pool2 : _ <- map (view #id) <$> notRetiringPools ctx
 
-        waitForTxStatus ctx w InLedger . getResponse =<<
-            joinStakePool @n ctx (SpecificPool pool1) (w, fixturePassphrase)
+        waitForTxStatus ctx w InLedger . getResponse
+            =<< joinStakePool @n ctx (SpecificPool pool1) (w, fixturePassphrase)
 
         request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty
-            >>= flip verify
-            [ expectField (#delegation . #next) $ \case
-                [dlg] -> do
-                    (dlg ^. #status) `shouldBe` Delegating
-                    (dlg ^. #target) `shouldBe` Just (ApiT pool1)
-                    (view #epochNumber <$> dlg ^. #changesAt) `shouldSatisfy`
-                        (\x -> x == Just (currentEpoch + 2)
-                            || x == Just (currentEpoch + 3)
-                            -- _^^^^ This is to reduce flakiness of the test.
-                            -- The reason why we can't be sure which epoch
-                            -- exactly the delegation change will happen is
-                            -- because the transaction might be submitted
-                            -- just before the epoch boundary, and the
-                            -- transaction might be included in the next
-                            -- epoch.
-                        )
-                _ -> fail "next delegation should contain exactly one element"
-            ]
+            >>= flip
+                verify
+                [ expectField (#delegation . #next) $ \case
+                    [dlg] -> do
+                        (dlg ^. #status) `shouldBe` Delegating
+                        (dlg ^. #target) `shouldBe` Just (ApiT pool1)
+                        (view #epochNumber <$> dlg ^. #changesAt)
+                            `shouldSatisfy` ( \x ->
+                                                x == Just (currentEpoch + 2)
+                                                    || x == Just (currentEpoch + 3)
+                                                    -- _^^^^ This is to reduce flakiness of the test.
+                                                    -- The reason why we can't be sure which epoch
+                                                    -- exactly the delegation change will happen is
+                                                    -- because the transaction might be submitted
+                                                    -- just before the epoch boundary, and the
+                                                    -- transaction might be included in the next
+                                                    -- epoch.
+                                            )
+                    _ -> fail "next delegation should contain exactly one element"
+                ]
 
         -- Epoch A: delegation tx happened.
         -- Epoch A+1: stake is registered to a chosen pool.
@@ -624,26 +742,29 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
         waitNumberOfEpochBoundaries 2 ctx
 
         request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty
-            >>= flip verify
+            >>= flip
+                verify
                 [expectField #delegation (`shouldBe` delegating (ApiT pool1) [])]
 
         -- join another stake pool
-        waitForTxStatus ctx w InLedger . getResponse =<<
-            joinStakePool @n ctx (SpecificPool pool2) (w, fixturePassphrase)
+        waitForTxStatus ctx w InLedger . getResponse
+            =<< joinStakePool @n ctx (SpecificPool pool2) (w, fixturePassphrase)
 
         waitNumberOfEpochBoundaries 2 ctx
 
         eventually "Wallet is now delegating to pool2" $ do
             request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty
-                >>= flip verify
-                [expectField #delegation (`shouldBe` delegating (ApiT pool2) [])]
+                >>= flip
+                    verify
+                    [expectField #delegation (`shouldBe` delegating (ApiT pool2) [])]
 
     it "STAKE_POOLS_JOIN_04 - Rewards accumulate" $ \ctx -> runResourceT $ do
+        noConway ctx "certificate"
         w <- fixtureWallet ctx
-        pool : _  <- map (view #id) <$> notRetiringPools ctx
+        pool : _ <- map (view #id) <$> notRetiringPools ctx
 
-        waitForTxStatus ctx w InLedger . getResponse =<<
-            joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)
+        waitForTxStatus ctx w InLedger . getResponse
+            =<< joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)
 
         -- Epoch A: delegation tx happened.
         -- Epoch A+1: stake is registered to a chosen pool.
@@ -654,392 +775,533 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
         eventually "Rewards are visible" $ do
             request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty
-                >>= flip verify
-                    [ expectField (#balance . #reward) (.> ApiAmount 0) ]
+                >>= flip
+                    verify
+                    [expectField (#balance . #reward) (.> ApiAmount 0)]
 
         -- Can quit with rewards
-        quitStakePool @n ctx (w, fixturePassphrase) >>= flip verify
-            [ expectResponseCode HTTP.status202
-            , expectField #depositReturned (`shouldBe` ApiAmount 1_000_000)
-            , expectField #withdrawals
-                (\[ApiWithdrawal _ c] -> c .> ApiAmount 0)
-            ]
+        quitStakePool @n ctx (w, fixturePassphrase)
+            >>= flip
+                verify
+                [ expectResponseCode HTTP.status202
+                , expectField #depositReturned (`shouldBe` ApiAmount 1_000_000)
+                , expectField
+                    #withdrawals
+                    (\[ApiWithdrawal _ c] -> c .> ApiAmount 0)
+                ]
 
-    it "STAKE_POOLS_JOIN_05 - \
-        \Can join when stake key already exists" $ \ctx -> runResourceT $ do
-        preregKeyWallet <- liftIO $ preregKeyWalletMnemonic (_faucet ctx)
+    it
+        "STAKE_POOLS_JOIN_05 - \
+        \Can join when stake key already exists"
+        $ \ctx -> runResourceT $ do
+            noConway ctx "certificate"
+            preregKeyWallet <- liftIO $ preregKeyWalletMnemonic (_faucet ctx)
 
-        let payload = Json [json| {
+            let payload =
+                    Json
+                        [json| {
                 "name": "Wallet with pre-registered stake key",
                 "mnemonic_sentence": #{someMnemonicToWords preregKeyWallet},
                 "passphrase": #{fixturePassphrase}
                 } |]
 
-        w <- unsafeResponse <$> postWallet ctx payload
-        pool:_ <- map (view #id . getApiT) . snd <$>
-            unsafeRequest @[ApiT StakePool]
-                ctx (Link.listStakePools arbitraryStake) Empty
+            w <- unsafeResponse <$> postWallet ctx payload
+            pool : _ <-
+                map (view #id . getApiT) . snd
+                    <$> unsafeRequest @[ApiT StakePool]
+                        ctx
+                        (Link.listStakePools arbitraryStake)
+                        Empty
 
-        eventually "wallet join a pool" $ do
-            joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)
-                >>= flip verify
-                    [ expectResponseCode HTTP.status202
-                    , expectField (#status . #getApiT) (`shouldBe` Pending)
-                    , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-                    ]
+            eventually "wallet join a pool" $ do
+                joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)
+                    >>= flip
+                        verify
+                        [ expectResponseCode HTTP.status202
+                        , expectField (#status . #getApiT) (`shouldBe` Pending)
+                        , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+                        ]
 
     describe "STAKE_POOLS_JOIN_UNSIGNED_01" $ do
         it "Can join a pool that's not retiring" $ \ctx -> runResourceT $ do
+            noConway ctx "certificate"
             nonRetiredPools <- eventually "One of the pools should retire." $ do
                 response <- listPools ctx arbitraryStake
 
-                verify response [ expectListSize 3 ]
+                verify response [expectListSize 3]
 
                 pure $ getFromResponse Prelude.id response
 
-            let reportError = error $ unlines
-                    [ "Unable to find a non-retiring pool ID."
-                    , "Test cluster pools:"
-                    , unlines (showT <$> Set.toList testClusterPoolIds)
-                    , "Non-retired pools:"
-                    , unlines (show <$> nonRetiredPools)
-                    ]
+            let reportError =
+                    error
+                        $ unlines
+                            [ "Unable to find a non-retiring pool ID."
+                            , "Test cluster pools:"
+                            , unlines (showT <$> Set.toList testClusterPoolIds)
+                            , "Non-retired pools:"
+                            , unlines (show <$> nonRetiredPools)
+                            ]
 
-            let nonRetiringPoolId = (view #id) . fromMaybe reportError
-                    $ find (isNothing . getRetirementEpoch) nonRetiredPools
+            let nonRetiringPoolId =
+                    (view #id) . fromMaybe reportError
+                        $ find (isNothing . getRetirementEpoch) nonRetiredPools
 
-            let isValidCerts (Just (RegisterRewardAccount{}:|[JoinPool{}])) =
+            let isValidCerts (Just (RegisterRewardAccount{} :| [JoinPool{}])) =
                     True
                 isValidCerts _ =
                     False
 
             -- Join Pool
             w <- fixtureWallet ctx
-            liftIO $ joinStakePoolUnsigned
-                @n @'Shelley ctx w (ApiT nonRetiringPoolId) >>= \o -> do
-                verify o
-                    [ expectResponseCode HTTP.status200
-                    , expectField #inputs
-                        (`shouldSatisfy` (not . null))
-                    , expectField #outputs
-                        (`shouldSatisfy` null)
-                    , expectField #change
-                        (`shouldSatisfy` (not . null))
-                    , expectField #certificates
-                        (`shouldSatisfy` isValidCerts)
-                    ]
+            liftIO
+                $ joinStakePoolUnsigned
+                    @n
+                    @'Shelley
+                    ctx
+                    w
+                    (ApiT nonRetiringPoolId)
+                    >>= \o -> do
+                        verify
+                            o
+                            [ expectResponseCode HTTP.status200
+                            , expectField
+                                #inputs
+                                (`shouldSatisfy` (not . null))
+                            , expectField
+                                #outputs
+                                (`shouldSatisfy` null)
+                            , expectField
+                                #change
+                                (`shouldSatisfy` (not . null))
+                            , expectField
+                                #certificates
+                                (`shouldSatisfy` isValidCerts)
+                            ]
 
     describe "STAKE_POOLS_JOIN_UNSIGNED_02"
-        $ it "Can join a pool that's retiring" $ \ctx -> runResourceT $ do
+        $ it "Can join a pool that's retiring"
+        $ \ctx -> runResourceT $ do
+            noConway ctx "certificate"
             nonRetiredPools <- eventually "One of the pools should retire." $ do
                 response <- listPools ctx arbitraryStake
 
-                verify response [ expectListSize 3 ]
+                verify response [expectListSize 3]
 
                 pure $ getFromResponse Prelude.id response
-            let reportError = error $ unlines
-                    [ "Unable to find a retiring pool ID."
-                    , "Test cluster pools:"
-                    , unlines (showT <$> Set.toList testClusterPoolIds)
-                    , "Non-retired pools:"
-                    , unlines (show <$> nonRetiredPools)
-                    ]
+            let reportError =
+                    error
+                        $ unlines
+                            [ "Unable to find a retiring pool ID."
+                            , "Test cluster pools:"
+                            , unlines (showT <$> Set.toList testClusterPoolIds)
+                            , "Non-retired pools:"
+                            , unlines (show <$> nonRetiredPools)
+                            ]
 
-            let retiringPoolId = (view #id) . fromMaybe reportError
-                    . find (isJust . getRetirementEpoch)
-                    $ nonRetiredPools
+            let retiringPoolId =
+                    (view #id)
+                        . fromMaybe reportError
+                        . find (isJust . getRetirementEpoch)
+                        $ nonRetiredPools
             -- Join Pool
             w <- fixtureWallet ctx
-            liftIO $ joinStakePoolUnsigned @n @'Shelley ctx w (ApiT retiringPoolId)
-                >>= \o -> do
-                    verify o
-                        [ expectResponseCode HTTP.status200
-                        , expectField #inputs
-                            (`shouldSatisfy` (not . null))
-                        , expectField #outputs
-                            (`shouldSatisfy` null)
-                        , expectField #change
-                            (`shouldSatisfy` (not . null))
-                        , expectField #certificates
-                            (`shouldSatisfy` (not . null))
-                        ]
+            liftIO
+                $ joinStakePoolUnsigned @n @'Shelley ctx w (ApiT retiringPoolId)
+                    >>= \o -> do
+                        verify
+                            o
+                            [ expectResponseCode HTTP.status200
+                            , expectField
+                                #inputs
+                                (`shouldSatisfy` (not . null))
+                            , expectField
+                                #outputs
+                                (`shouldSatisfy` null)
+                            , expectField
+                                #change
+                                (`shouldSatisfy` (not . null))
+                            , expectField
+                                #certificates
+                                (`shouldSatisfy` (not . null))
+                            ]
 
     describe "STAKE_POOLS_JOIN_UNSIGNED_03"
-        $ it "Cannot join a pool that's retired" $ \ctx -> runResourceT $ do
+        $ it "Cannot join a pool that's retired"
+        $ \ctx -> runResourceT $ do
             nonRetiredPoolIds <-
                 eventually "One of the pools should retire." $ do
                     response <- listPools ctx arbitraryStake
-                    verify response [ expectListSize 3 ]
+                    verify response [expectListSize 3]
                     getFromResponse Prelude.id response
                         & fmap (view #id)
                         & Set.fromList
                         & pure
-            let reportError = error $ unlines
-                    [ "Unable to find a retired pool ID."
-                    , "Test cluster pools:"
-                    , unlines (showT <$> Set.toList testClusterPoolIds)
-                    , "Non-retired pools:"
-                    , unlines (showT <$> Set.toList nonRetiredPoolIds)
-                    ]
+            let reportError =
+                    error
+                        $ unlines
+                            [ "Unable to find a retired pool ID."
+                            , "Test cluster pools:"
+                            , unlines (showT <$> Set.toList testClusterPoolIds)
+                            , "Non-retired pools:"
+                            , unlines (showT <$> Set.toList nonRetiredPoolIds)
+                            ]
             let retiredPoolIds =
                     testClusterPoolIds `Set.difference` nonRetiredPoolIds
             let retiredPoolId =
-                    fromMaybe reportError $ listToMaybe $
-                        Set.toList retiredPoolIds
+                    fromMaybe reportError
+                        $ listToMaybe
+                        $ Set.toList retiredPoolIds
             w <- fixtureWallet ctx
             r <- liftIO $ joinStakePoolUnsigned @n @'Shelley ctx w (ApiT retiredPoolId)
             expectResponseCode HTTP.status404 r
             expectErrorMessage (errMsg404NoSuchPool (toText retiredPoolId)) r
 
     describe "STAKE_POOLS_JOIN_UNSIGNED_04"
-        $ it "Cannot join a pool that's never existed" $ \ctx -> runResourceT $ do
-            (Right non_existing_pool_id) <- pure $ decodePoolIdBech32
-                "pool1y25deq9kldy9y9gfvrpw8zt05zsrfx84zjhugaxrx9ftvwdpua2"
+        $ it "Cannot join a pool that's never existed"
+        $ \ctx -> runResourceT $ do
+            (Right non_existing_pool_id) <-
+                pure
+                    $ decodePoolIdBech32
+                        "pool1y25deq9kldy9y9gfvrpw8zt05zsrfx84zjhugaxrx9ftvwdpua2"
             w <- fixtureWallet ctx
-            r <- liftIO $ joinStakePoolUnsigned
-                @n @'Shelley ctx w (ApiT non_existing_pool_id)
+            r <-
+                liftIO
+                    $ joinStakePoolUnsigned
+                        @n
+                        @'Shelley
+                        ctx
+                        w
+                        (ApiT non_existing_pool_id)
             expectResponseCode HTTP.status404 r
             expectErrorMessage
-                (errMsg404NoSuchPool (toText non_existing_pool_id)) r
+                (errMsg404NoSuchPool (toText non_existing_pool_id))
+                r
 
-    it "STAKE_POOLS_QUIT_UNSIGNED_01 - \
-        \Join/quit when already joined a pool" $ \ctx -> runResourceT $ do
-        w <- fixtureWallet ctx
+    it
+        "STAKE_POOLS_QUIT_UNSIGNED_01 - \
+        \Join/quit when already joined a pool"
+        $ \ctx -> runResourceT $ do
+            noConway ctx "certificate"
+            w <- fixtureWallet ctx
 
-        pool1 : pool2 : _  <- map (view #id) <$> notRetiringPools ctx
+            pool1 : pool2 : _ <- map (view #id) <$> notRetiringPools ctx
 
-        joinStakePool @n ctx (SpecificPool pool1) (w, fixturePassphrase)
-            >>= flip verify
-            [ expectResponseCode HTTP.status202
-            , expectField (#status . #getApiT) (`shouldBe` Pending)
-            , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-            ]
+            joinStakePool @n ctx (SpecificPool pool1) (w, fixturePassphrase)
+                >>= flip
+                    verify
+                    [ expectResponseCode HTTP.status202
+                    , expectField (#status . #getApiT) (`shouldBe` Pending)
+                    , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+                    ]
 
-        waitNumberOfEpochBoundaries 2 ctx
+            waitNumberOfEpochBoundaries 2 ctx
 
-        request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty
-            >>= flip verify
-            [ expectField #delegation (`shouldBe` delegating (ApiT pool1) []) ]
+            request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty
+                >>= flip
+                    verify
+                    [expectField #delegation (`shouldBe` delegating (ApiT pool1) [])]
 
-        -- Cannot join the same pool
-        liftIO $ joinStakePoolUnsigned @n @'Shelley ctx w (ApiT pool1)
-            >>= flip verify
-            [ expectResponseCode HTTP.status403
-            , expectErrorMessage (errMsg403PoolAlreadyJoined (toText pool1))
-            ]
+            -- Cannot join the same pool
+            liftIO
+                $ joinStakePoolUnsigned @n @'Shelley ctx w (ApiT pool1)
+                    >>= flip
+                        verify
+                        [ expectResponseCode HTTP.status403
+                        , expectErrorMessage (errMsg403PoolAlreadyJoined (toText pool1))
+                        ]
 
-        -- Can join another pool
-        liftIO $ joinStakePoolUnsigned @n @'Shelley ctx w (ApiT pool2)
-            >>= flip verify
-            [ expectResponseCode HTTP.status200
-            , expectField #inputs (`shouldSatisfy` not . null)
-            , expectField #certificates (`shouldSatisfy` \case
-                Just (JoinPool{} :| []) -> True
-                _ -> False
-              )
-            ]
+            -- Can join another pool
+            liftIO
+                $ joinStakePoolUnsigned @n @'Shelley ctx w (ApiT pool2)
+                    >>= flip
+                        verify
+                        [ expectResponseCode HTTP.status200
+                        , expectField #inputs (`shouldSatisfy` not . null)
+                        , expectField
+                            #certificates
+                            ( `shouldSatisfy`
+                                \case
+                                    Just (JoinPool{} :| []) -> True
+                                    _ -> False
+                            )
+                        ]
 
-        quitStakePoolUnsigned @n @'Shelley ctx w
-            >>= flip verify
-            [ expectResponseCode HTTP.status200
-            , expectField #inputs (`shouldSatisfy` not . null)
-            , expectField #outputs (`shouldSatisfy` null)
-            , expectField #change (`shouldSatisfy` not . null)
-            , expectField #certificates (`shouldSatisfy` \case
-                Just (QuitPool{} :| []) -> True
-                _ -> False
-              )
-            ]
+            quitStakePoolUnsigned @n @'Shelley ctx w
+                >>= flip
+                    verify
+                    [ expectResponseCode HTTP.status200
+                    , expectField #inputs (`shouldSatisfy` not . null)
+                    , expectField #outputs (`shouldSatisfy` null)
+                    , expectField #change (`shouldSatisfy` not . null)
+                    , expectField
+                        #certificates
+                        ( `shouldSatisfy`
+                            \case
+                                Just (QuitPool{} :| []) -> True
+                                _ -> False
+                        )
+                    ]
 
     describe "STAKE_POOLS_QUIT_UNSIGNED_02"
-        $ it "Cannot quit if not delegating" $ \ctx -> runResourceT $ do
+        $ it "Cannot quit if not delegating"
+        $ \ctx -> runResourceT $ do
             w <- fixtureWallet ctx
 
             quitStakePoolUnsigned @n @'Shelley ctx w >>= \r -> do
                 expectResponseCode HTTP.status403 r
-                flip expectErrorMessage r $ mconcat
-                    [ "It seems that you're trying to retire from delegation "
-                    , "although you're not even delegating, "
-                    , "nor won't be in an immediate future"
-                    ]
+                flip expectErrorMessage r
+                    $ mconcat
+                        [ "It seems that you're trying to retire from delegation "
+                        , "although you're not even delegating, "
+                        , "nor won't be in an immediate future"
+                        ]
 
     describe "STAKE_POOLS_JOIN_01x - Fee boundary values" $ do
-        it "STAKE_POOLS_JOIN_01x - \
-            \I can join if I have just the right amount" $ \ctx -> runResourceT $ do
-            w <- fixtureWalletWith @n ctx [costOfJoining ctx + depositAmt ctx]
-            pool:_ <- map (view #id . getApiT) . snd <$>
-                unsafeRequest @[ApiT StakePool]
-                    ctx (Link.listStakePools arbitraryStake) Empty
-            joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)>>= flip verify
-                [ expectResponseCode HTTP.status202
-                , expectField (#status . #getApiT) (`shouldBe` Pending)
-                , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-                ]
+        it
+            "STAKE_POOLS_JOIN_01x - \
+            \I can join if I have just the right amount"
+            $ \ctx -> runResourceT $ do
+                noConway ctx "certificate"
+                w <- fixtureWalletWith @n ctx [costOfJoining ctx + depositAmt ctx]
+                pool : _ <-
+                    map (view #id . getApiT) . snd
+                        <$> unsafeRequest @[ApiT StakePool]
+                            ctx
+                            (Link.listStakePools arbitraryStake)
+                            Empty
+                joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)
+                    >>= flip
+                        verify
+                        [ expectResponseCode HTTP.status202
+                        , expectField (#status . #getApiT) (`shouldBe` Pending)
+                        , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+                        ]
 
-        it "STAKE_POOLS_JOIN_01x - \
-           \I cannot join if I have not enough fee to cover" $ \ctx -> runResourceT $ do
-            w <- fixtureWalletWith @n ctx [costOfJoining ctx + depositAmt ctx - 1]
-            pool:_ <- map (view #id . getApiT) . snd <$>
-                unsafeRequest @[ApiT StakePool]
-                    ctx (Link.listStakePools arbitraryStake) Empty
-            joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase) >>= flip verify
-                [ expectResponseCode HTTP.status403
-                , expectErrorMessage errMsg403Fee
-                ]
+        it
+            "STAKE_POOLS_JOIN_01x - \
+            \I cannot join if I have not enough fee to cover"
+            $ \ctx -> runResourceT $ do
+                noConway ctx "certificate"
+                w <- fixtureWalletWith @n ctx [costOfJoining ctx + depositAmt ctx - 1]
+                pool : _ <-
+                    map (view #id . getApiT) . snd
+                        <$> unsafeRequest @[ApiT StakePool]
+                            ctx
+                            (Link.listStakePools arbitraryStake)
+                            Empty
+                joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)
+                    >>= flip
+                        verify
+                        [ expectResponseCode HTTP.status403
+                        , expectErrorMessage errMsg403Fee
+                        ]
 
     describe "STAKE_POOLS_QUIT_01x - Fee boundary values" $ do
+        it
+            "STAKE_POOLS_QUIT_01xx - \
+            \I can quit if I have enough to cover fee"
+            $ \ctx -> runResourceT $ do
+                noConway ctx "certificate"
+                -- change needed to satisfy minUTxOValue
+                let initBalance =
+                        [ costOfJoining ctx
+                            + depositAmt ctx
+                            + minUTxOValue (_mainEra ctx)
+                            + costOfQuitting ctx
+                            + minUTxOValue (_mainEra ctx)
+                        ]
+                w <- fixtureWalletWith @n ctx initBalance
 
-        it "STAKE_POOLS_QUIT_01xx - \
-            \I can quit if I have enough to cover fee" $ \ctx -> runResourceT $ do
-            -- change needed to satisfy minUTxOValue
-            let initBalance =
-                    [ costOfJoining ctx
-                    + depositAmt ctx
-                    + minUTxOValue (_mainEra ctx)
-                    + costOfQuitting ctx
-                    + minUTxOValue (_mainEra ctx)
+                pool : _ <-
+                    map (view #id . getApiT) . snd
+                        <$> unsafeRequest @[ApiT StakePool]
+                            ctx
+                            (Link.listStakePools arbitraryStake)
+                            Empty
+
+                rJoin <-
+                    joinStakePool @n
+                        ctx
+                        (SpecificPool pool)
+                        (w, fixturePassphrase)
+                verify
+                    rJoin
+                    [ expectResponseCode HTTP.status202
+                    , expectField (#status . #getApiT) (`shouldBe` Pending)
+                    , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
                     ]
-            w <- fixtureWalletWith @n ctx initBalance
+                eventually "join transaction is in ledger"
+                    $ do
+                        let txId = ApiTxId (getFromResponse #id rJoin)
+                        request @(ApiTransaction n)
+                            ctx
+                            (Link.getTransaction @'Shelley w txId)
+                            Default
+                            Empty
+                        >>= flip
+                            verify
+                            [expectField (#status . #getApiT) (`shouldBe` InLedger)]
 
-            pool:_ <- map (view #id . getApiT) . snd
-                <$> unsafeRequest @[ApiT StakePool]
-                    ctx (Link.listStakePools arbitraryStake) Empty
+                -- Epoch A: delegation tx happened.
+                -- Epoch A+1: stake is live, registered to a chosen pool.
+                -- Epoch A+2: stake is active, rewards start accumulating.
+                waitNumberOfEpochBoundaries 2 ctx
 
-            rJoin <- joinStakePool @n
-                ctx (SpecificPool pool) (w, fixturePassphrase)
-            verify rJoin
-                [ expectResponseCode HTTP.status202
-                , expectField (#status . #getApiT) (`shouldBe` Pending)
-                , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-                ]
-            eventually "join transaction is in ledger" $ do
-                let txId = ApiTxId (getFromResponse #id rJoin)
-                request @(ApiTransaction n)
-                    ctx (Link.getTransaction @'Shelley w txId) Default Empty
-                >>= flip verify
-                    [ expectField (#status . #getApiT) (`shouldBe` InLedger) ]
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley w)
+                    Default
+                    Empty
+                    >>= flip
+                        verify
+                        [ expectField #delegation (`shouldBe` delegating (ApiT pool) [])
+                        ]
 
-            -- Epoch A: delegation tx happened.
-            -- Epoch A+1: stake is live, registered to a chosen pool.
-            -- Epoch A+2: stake is active, rewards start accumulating.
-            waitNumberOfEpochBoundaries 2 ctx
-
-            request @ApiWallet ctx (Link.getWallet @'Shelley w)
-                Default Empty >>= flip verify
-                [ expectField #delegation (`shouldBe` delegating (ApiT pool) [])
-                ]
-
-            rQuit <- quitStakePool @n ctx (w, fixturePassphrase)
-            verify rQuit
-                [ expectResponseCode HTTP.status202
-                , expectField (#status . #getApiT) (`shouldBe` Pending)
-                , expectField (#direction . #getApiT) (`shouldBe` Incoming)
-                , expectField #inputs $ \inputs' -> do
-                    inputs' `shouldSatisfy` all (isJust . source)
-                ]
-
-            eventually "quit transaction is in ledger" $ do
-                let txId = ApiTxId (getFromResponse #id rQuit)
-                request @(ApiTransaction n)
-                    ctx (Link.getTransaction @'Shelley w txId) Default Empty
-                >>= flip verify
-                    [ expectResponseCode HTTP.status200
+                rQuit <- quitStakePool @n ctx (w, fixturePassphrase)
+                verify
+                    rQuit
+                    [ expectResponseCode HTTP.status202
+                    , expectField (#status . #getApiT) (`shouldBe` Pending)
                     , expectField (#direction . #getApiT) (`shouldBe` Incoming)
-                    , expectField (#status . #getApiT) (`shouldBe` InLedger)
-                    , expectField #metadata  (`shouldBe` Nothing)
-                    , expectField #inputs (`shouldSatisfy` all (isJust . source))
+                    , expectField #inputs $ \inputs' -> do
+                        inputs' `shouldSatisfy` all (isJust . source)
                     ]
 
-            -- Epoch A: un-delegation tx happened.
-            -- Epoch A+1: un-delegation has been registered.
-            -- Epoch A+2: wallet is not delegating;
-            waitNumberOfEpochBoundaries 2 ctx
+                eventually "quit transaction is in ledger"
+                    $ do
+                        let txId = ApiTxId (getFromResponse #id rQuit)
+                        request @(ApiTransaction n)
+                            ctx
+                            (Link.getTransaction @'Shelley w txId)
+                            Default
+                            Empty
+                        >>= flip
+                            verify
+                            [ expectResponseCode HTTP.status200
+                            , expectField (#direction . #getApiT) (`shouldBe` Incoming)
+                            , expectField (#status . #getApiT) (`shouldBe` InLedger)
+                            , expectField #metadata (`shouldBe` Nothing)
+                            , expectField #inputs (`shouldSatisfy` all (isJust . source))
+                            ]
 
-            request @ApiWallet ctx (Link.getWallet @'Shelley w)
-                Default Empty >>= flip verify
-                [ expectField #delegation
-                    (`shouldBe` notDelegating [])
-                , expectField (#balance . #total)
-                    (.>= ApiAmount (depositAmt ctx))
-                , expectField (#balance . #available)
-                    (.>= ApiAmount (depositAmt ctx))
-                ]
+                -- Epoch A: un-delegation tx happened.
+                -- Epoch A+1: un-delegation has been registered.
+                -- Epoch A+2: wallet is not delegating;
+                waitNumberOfEpochBoundaries 2 ctx
 
-        it "STAKE_POOLS_QUIT_01x - \
-            \I cannot quit if I have not enough to cover fees" $ \ctx -> runResourceT $ do
-            let initBalance = [costOfJoining ctx + depositAmt ctx]
-            w <- fixtureWalletWith @n ctx initBalance
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley w)
+                    Default
+                    Empty
+                    >>= flip
+                        verify
+                        [ expectField
+                            #delegation
+                            (`shouldBe` notDelegating [])
+                        , expectField
+                            (#balance . #total)
+                            (.>= ApiAmount (depositAmt ctx))
+                        , expectField
+                            (#balance . #available)
+                            (.>= ApiAmount (depositAmt ctx))
+                        ]
 
-            pool:_ <- map (view #id . getApiT) . snd
-                <$> unsafeRequest @[ApiT StakePool]
-                    ctx (Link.listStakePools arbitraryStake) Empty
+        it
+            "STAKE_POOLS_QUIT_01x - \
+            \I cannot quit if I have not enough to cover fees"
+            $ \ctx -> runResourceT $ do
+                noConway ctx "certificate"
+                let initBalance = [costOfJoining ctx + depositAmt ctx]
+                w <- fixtureWalletWith @n ctx initBalance
 
-            joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase) >>= flip verify
-                [ expectResponseCode HTTP.status202
-                , expectField (#status . #getApiT) (`shouldBe` Pending)
-                , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-                ]
+                pool : _ <-
+                    map (view #id . getApiT) . snd
+                        <$> unsafeRequest @[ApiT StakePool]
+                            ctx
+                            (Link.listStakePools arbitraryStake)
+                            Empty
 
-            -- Epoch A: delegation tx happened.
-            -- Epoch A+1: stake is live, registered to a chosen pool.
-            -- Epoch A+2: stake is active, rewards start accumulating.
-            waitNumberOfEpochBoundaries 2 ctx
+                joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)
+                    >>= flip
+                        verify
+                        [ expectResponseCode HTTP.status202
+                        , expectField (#status . #getApiT) (`shouldBe` Pending)
+                        , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+                        ]
 
-            request @ApiWallet ctx (Link.getWallet @'Shelley w)
-                Default Empty >>= flip verify
-                [ expectField #delegation (`shouldBe` delegating (ApiT pool) [])
-                ]
+                -- Epoch A: delegation tx happened.
+                -- Epoch A+1: stake is live, registered to a chosen pool.
+                -- Epoch A+2: stake is active, rewards start accumulating.
+                waitNumberOfEpochBoundaries 2 ctx
 
-            response <- quitStakePool @n ctx (w, fixturePassphrase)
-            verify response [expectResponseCode HTTP.status403]
-            decodeErrorInfo response `shouldBe` NoUtxosAvailable
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley w)
+                    Default
+                    Empty
+                    >>= flip
+                        verify
+                        [ expectField #delegation (`shouldBe` delegating (ApiT pool) [])
+                        ]
+
+                response <- quitStakePool @n ctx (w, fixturePassphrase)
+                verify response [expectResponseCode HTTP.status403]
+                decodeErrorInfo response `shouldBe` NoUtxosAvailable
 
     it "STAKE_POOLS_ESTIMATE_FEE_01 - can estimate fees" $ \ctx -> runResourceT $ do
         w <- fixtureWallet ctx
-        delegationFee ctx w >>= flip verify
-            [ expectResponseCode HTTP.status200
-            , expectField (#deposit . #toNatural) (`shouldBe` depositAmt ctx)
-            , expectField (#estimatedMin . #toNatural) (.< costOfJoining ctx)
-            , expectField (#estimatedMax . #toNatural) (.< costOfJoining ctx)
-            , expectField #minimumCoins (`shouldBe` [])
-            ]
+        delegationFee ctx w
+            >>= flip
+                verify
+                [ expectResponseCode HTTP.status200
+                , expectField (#deposit . #toNatural) (`shouldBe` depositAmt ctx)
+                , expectField (#estimatedMin . #toNatural) (.< costOfJoining ctx)
+                , expectField (#estimatedMax . #toNatural) (.< costOfJoining ctx)
+                , expectField #minimumCoins (`shouldBe` [])
+                ]
 
-    it "STAKE_POOLS_ESTIMATE_FEE_02 - \
-        \empty wallet cannot estimate fee" $ \ctx -> runResourceT $ do
-        w <- emptyWallet ctx
-        response <- delegationFee ctx w
-        verify response [expectResponseCode HTTP.status403]
-        decodeErrorInfo response `shouldBe` NoUtxosAvailable
+    it
+        "STAKE_POOLS_ESTIMATE_FEE_02 - \
+        \empty wallet cannot estimate fee"
+        $ \ctx -> runResourceT $ do
+            w <- emptyWallet ctx
+            response <- delegationFee ctx w
+            verify response [expectResponseCode HTTP.status403]
+            decodeErrorInfo response `shouldBe` NoUtxosAvailable
 
     describe "STAKE_POOLS_LIST_01 - List stake pools" $ do
-
         it "has non-zero saturation & stake" $ \ctx -> runResourceT $ do
             eventually "list pools returns non-empty list" $ do
                 r <- listPools ctx arbitraryStake
                 expectResponseCode HTTP.status200 r
-                verify r
+                verify
+                    r
                     [ expectListSize 3
-                    -- At the time of setup, the pools have 1/3 stake each, but
-                    -- this could potentially be changed by other tests. Hence,
-                    -- we try to be forgiving here.
-                    , expectListField 0
+                    , -- At the time of setup, the pools have 1/3 stake each, but
+                      -- this could potentially be changed by other tests. Hence,
+                      -- we try to be forgiving here.
+                      expectListField
+                        0
                         (#metrics . #relativeStake)
-                            (.> Quantity (unsafeMkPercentage 0))
-                    , expectListField 1
+                        (.> Quantity (unsafeMkPercentage 0))
+                    , expectListField
+                        1
                         (#metrics . #relativeStake)
-                            (.> Quantity (unsafeMkPercentage 0))
-                    , expectListField 2
+                        (.> Quantity (unsafeMkPercentage 0))
+                    , expectListField
+                        2
                         (#metrics . #relativeStake)
-                            (.> Quantity (unsafeMkPercentage 0))
+                        (.> Quantity (unsafeMkPercentage 0))
                     ]
 
         it "pools have the correct retirement information" $ \ctx -> runResourceT $ do
-
-            let expectedRetirementEpochs = Set.fromList
-                    [ Nothing
-                    , Just 100_000
-                    , Just 1_000_000
-                    ]
+            let expectedRetirementEpochs =
+                    Set.fromList
+                        [ Nothing
+                        , Just 100_000
+                        , Just 1_000_000
+                        ]
 
             eventually "pools have the correct retirement information" $ do
                 response <- listPools ctx arbitraryStake
@@ -1047,8 +1309,8 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
                 let actualRetirementEpochs =
                         getFromResponse Prelude.id response
-                        & fmap getRetirementEpoch
-                        & Set.fromList
+                            & fmap getRetirementEpoch
+                            & Set.fromList
                 actualRetirementEpochs `shouldBe` expectedRetirementEpochs
 
         it "eventually has correct margin, cost and pledge" $ \ctx -> runResourceT $ do
@@ -1074,8 +1336,9 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
         it "at least one pool eventually produces block" $ \ctx -> runResourceT $ do
             eventually "eventually produces block" $ do
                 (_, Right r) <- listPools ctx arbitraryStake
-                let production = sum $
-                        getQuantity . view (#metrics . #producedBlocks) <$> r
+                let production =
+                        sum
+                            $ getQuantity . view (#metrics . #producedBlocks) <$> r
                 let saturation =
                         view (#metrics . #saturation) <$> r
 
@@ -1086,11 +1349,13 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             updateMetadataSource ctx "direct"
             eventually "metadata is fetched" $ do
                 r <- listPools ctx arbitraryStake
-                verify r
+                verify
+                    r
                     [ expectListSize 3
                     , expectField Prelude.id $ \pools' -> do
-                        let metadataActual = Set.fromList $
-                                mapMaybe (view #metadata) pools'
+                        let metadataActual =
+                                Set.fromList
+                                    $ mapMaybe (view #metadata) pools'
                         metadataActual
                             `shouldSatisfy` (`Set.isSubsetOf` metadataPossible)
                         metadataActual
@@ -1099,12 +1364,12 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
         it "contains and is sorted by non-myopic-rewards" $ \ctx -> runResourceT $ do
             eventually "eventually shows non-zero rewards" $ do
-                Right pools'@[pool1,_pool2,pool3] <-
+                Right pools'@[pool1, _pool2, pool3] <-
                     snd <$> listPools ctx arbitraryStake
                 let rewards = view (#metrics . #nonMyopicMemberRewards)
 
-                (rewards <$> pools') `shouldBe`
-                    (rewards <$> sortOn (Down . rewards) pools')
+                (rewards <$> pools')
+                    `shouldBe` (rewards <$> sortOn (Down . rewards) pools')
                 -- Make sure the rewards are not all equal:
                 rewards pool1 .> rewards pool3
 
@@ -1122,31 +1387,45 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                 rewardsStakeBig .> rewardsStakeSmall
 
     it "STAKE_POOLS_LIST_05 - Fails without query parameter" $ \ctx -> runResourceT $ do
-        r <- request @[ApiT StakePool] ctx
-            (Link.listStakePools Nothing) Default Empty
+        r <-
+            request @[ApiT StakePool]
+                ctx
+                (Link.listStakePools Nothing)
+                Default
+                Empty
         expectResponseCode HTTP.status400 r
 
-    it "STAKE_POOLS_LIST_06 - \
-        \NonMyopicMemberRewards are 0 when stake is 0" $ \ctx -> runResourceT $ do
-        liftIO $ pendingWith "This assumption seems false, for some reasons..."
-        let stake = Just $ Coin 0
-        r <- request @[ApiT StakePool] ctx (Link.listStakePools stake) Default Empty
-            & (fmap . fmap . fmap . fmap) getApiT
-        expectResponseCode HTTP.status200 r
-        verify r
-            [ expectListSize 3
-            , expectListField 0
-                (#metrics . #nonMyopicMemberRewards) (`shouldBe` Quantity 0)
-            , expectListField 1
-                (#metrics . #nonMyopicMemberRewards) (`shouldBe` Quantity 0)
-            , expectListField 2
-                (#metrics . #nonMyopicMemberRewards) (`shouldBe` Quantity 0)
-            ]
+    it
+        "STAKE_POOLS_LIST_06 - \
+        \NonMyopicMemberRewards are 0 when stake is 0"
+        $ \ctx -> runResourceT $ do
+            liftIO $ pendingWith "This assumption seems false, for some reasons..."
+            let stake = Just $ Coin 0
+            r <-
+                request @[ApiT StakePool] ctx (Link.listStakePools stake) Default Empty
+                    & (fmap . fmap . fmap . fmap) getApiT
+            expectResponseCode HTTP.status200 r
+            verify
+                r
+                [ expectListSize 3
+                , expectListField
+                    0
+                    (#metrics . #nonMyopicMemberRewards)
+                    (`shouldBe` Quantity 0)
+                , expectListField
+                    1
+                    (#metrics . #nonMyopicMemberRewards)
+                    (`shouldBe` Quantity 0)
+                , expectListField
+                    2
+                    (#metrics . #nonMyopicMemberRewards)
+                    (`shouldBe` Quantity 0)
+                ]
 
-    it "STAKE_POOLS_GARBAGE_COLLECTION_01 - \
-        \retired pools are garbage collected on schedule and not before" $
-        \ctx -> runResourceT $ do
-
+    it
+        "STAKE_POOLS_GARBAGE_COLLECTION_01 - \
+        \retired pools are garbage collected on schedule and not before"
+        $ \ctx -> runResourceT $ do
             -- The retirement epoch of the only test pool that is configured
             -- to retire within the lifetime of an integration test run.
             -- See 'testPoolConfigs' for the source of this value.
@@ -1178,11 +1457,12 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             -- require a few minutes to complete.
             --
             liftIO $ forM_ [1 .. lastGarbageCollectionEpoch] $ \epochNo -> do
-                let stateDescription = mconcat
-                        [ "Garbage has been collected for epoch "
-                        , show epochNo
-                        , "."
-                        ]
+                let stateDescription =
+                        mconcat
+                            [ "Garbage has been collected for epoch "
+                            , show epochNo
+                            , "."
+                            ]
                 -- It's important that we wait incrementally, as an individual
                 -- call to 'eventually' must complete within a fairly short
                 -- period of time.
@@ -1195,8 +1475,9 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             let certificates = poolGarbageCollectionCertificates =<< events
             liftIO $ certificates `shouldSatisfy` ((== 1) . length)
             let [certificate] = certificates
-            let [event] = events &
-                    filter (not . null . poolGarbageCollectionCertificates)
+            let [event] =
+                    events
+                        & filter (not . null . poolGarbageCollectionCertificates)
 
             -- Check that the removed pool was removed at the correct epoch:
             view #retirementEpoch certificate
@@ -1212,40 +1493,49 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             let epochs = poolGarbageCollectionEpochNo <$> events
             (reverse epochs `zip` [1 ..]) `shouldSatisfy` all (uncurry (==))
 
-    it "STAKE_POOLS_SMASH_01 - fetching metadata from SMASH works with delisted pools" $
-        \ctx -> runResourceT $ bracketSettings ctx $ do
+    it "STAKE_POOLS_SMASH_01 - fetching metadata from SMASH works with delisted pools"
+        $ \ctx -> runResourceT $ bracketSettings ctx $ do
             updateMetadataSource ctx (_smashUrl ctx)
             -- This can be slow; let's retry less frequently and with a longer
             -- timeout.
             let s = 1_000_000
             eventuallyUsingDelay (10 * s) 300 "metadata is fetched" $ do
                 r <- listPools ctx arbitraryStake
-                verify r
+                verify
+                    r
                     [ expectListSize 3
                     , expectField Prelude.id $ \pools' -> do
-                        let metadataActual = Set.fromList $
-                                mapMaybe (view #metadata) pools'
-                            delistedPools = filter (\pool -> Delisted `elem` flags pool)
-                                pools'
+                        let metadataActual =
+                                Set.fromList
+                                    $ mapMaybe (view #metadata) pools'
+                            delistedPools =
+                                filter
+                                    (\pool -> Delisted `elem` flags pool)
+                                    pools'
                         metadataActual
                             `shouldSatisfy` (`Set.isSubsetOf` metadataPossible)
                         metadataActual
                             `shouldSatisfy` (not . Set.null)
                         (fmap (view #id) delistedPools)
-                            `shouldBe` [PoolId . unsafeFromHex $
-                                "b45768c1a2da4bd13ebcaa1ea51408eda31dcc21765ccbd407cda9f2"]
+                            `shouldBe` [ PoolId . unsafeFromHex
+                                            $ "b45768c1a2da4bd13ebcaa1ea51408eda31dcc21765ccbd407cda9f2"
+                                       ]
                     ]
 
             updateMetadataSource ctx "direct"
             eventually "pools are not delisted anymore" $ do
                 r <- listPools ctx arbitraryStake
-                verify r
+                verify
+                    r
                     [ expectListSize 3
                     , expectField Prelude.id $ \pools' -> do
-                        let metadataActual = Set.fromList $
-                                mapMaybe (view #metadata) pools'
-                            delistedPools = filter (\pool -> Delisted `elem` flags pool)
-                                pools'
+                        let metadataActual =
+                                Set.fromList
+                                    $ mapMaybe (view #metadata) pools'
+                            delistedPools =
+                                filter
+                                    (\pool -> Delisted `elem` flags pool)
+                                    pools'
                         metadataActual
                             `shouldSatisfy` (`Set.isSubsetOf` metadataPossible)
                         metadataActual
@@ -1254,27 +1544,34 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                             `shouldBe` []
                     ]
 
-    it "STAKE_POOLS_SMASH_HEALTH_01 - Can check SMASH health when configured" $
-        \ctx -> runResourceT $ bracketSettings ctx $ do
+    it "STAKE_POOLS_SMASH_HEALTH_01 - Can check SMASH health when configured"
+        $ \ctx -> runResourceT $ bracketSettings ctx $ do
             updateMetadataSource ctx (_smashUrl ctx)
-            r <- request @ApiHealthCheck
-                ctx Link.getCurrentSMASHHealth
-                Default Empty
+            r <-
+                request @ApiHealthCheck
+                    ctx
+                    Link.getCurrentSMASHHealth
+                    Default
+                    Empty
             expectResponseCode HTTP.status200 r
             expectField #health (`shouldBe` Available) r
 
-    describe "STAKE_POOLS_SMASH_HEALTH_02 - Cannot check SMASH health when not configured" $
-        forM_ ["direct", "none"] $ \fetching -> it fetching $
-            \ctx -> runResourceT $ bracketSettings ctx $ do
+    describe "STAKE_POOLS_SMASH_HEALTH_02 - Cannot check SMASH health when not configured"
+        $ forM_ ["direct", "none"]
+        $ \fetching -> it fetching
+            $ \ctx -> runResourceT $ bracketSettings ctx $ do
                 updateMetadataSource ctx (T.pack fetching)
-                r <- request @ApiHealthCheck
-                    ctx Link.getCurrentSMASHHealth
-                    Default Empty
+                r <-
+                    request @ApiHealthCheck
+                        ctx
+                        Link.getCurrentSMASHHealth
+                        Default
+                        Empty
                 expectResponseCode HTTP.status200 r
                 expectField #health (`shouldBe` NoSmashConfigured) r
 
-    it "STAKE_POOLS_SMASH_HEALTH_03 - Can check SMASH health via url" $
-        \ctx -> runResourceT $ do
+    it "STAKE_POOLS_SMASH_HEALTH_03 - Can check SMASH health via url"
+        $ \ctx -> runResourceT $ do
             let withUrl f (method, link) = (method, link <> "?url=" <> f)
             let link = withUrl (_smashUrl ctx) Link.getCurrentSMASHHealth
 
@@ -1283,7 +1580,8 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             expectField #health (`shouldBe` Available) r
 
     describe "STAKE_POOLS_SMASH_HEALTH_04 - SMASH url needs to be valid" $ do
-        let m = [ ("ftp://localhost", "only http/https is supported")
+        let m =
+                [ ("ftp://localhost", "only http/https is supported")
                 , ("thats_not_link", "Not a valid absolute URI")
                 ]
         forM_ m $ \(url, message) -> it url $ \ctx -> runResourceT $ do
@@ -1291,7 +1589,8 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             let link = withUrl url Link.getCurrentSMASHHealth
 
             r <- request @ApiHealthCheck ctx link Default Empty
-            verify r
+            verify
+                r
                 [ expectResponseCode HTTP.status400
                 , expectErrorMessage message
                 ]
@@ -1303,24 +1602,29 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
         -- fixtureWallets have funds on payment addresses, so their entire ada
         -- balance is not associated with their first stake key.
         request @(ApiStakeKeys n) ctx (Link.listStakeKeys w) Default Empty
-            >>= flip verify
-            [ expectField (#_foreign) (`shouldBe` [])
-            , expectField (#_ours) (\case
-                [acc] -> do
-                    (acc ^. #_index) `shouldBe` 0
-                    (acc ^. #_stake) `shouldBe` ApiAmount 0
-                    acc ^. (#_delegation . #active . #status)
-                        `shouldBe` NotDelegating
-                _ -> expectationFailure "wrong number of accounts in \"ours\""
-                )
-            , expectField (#_none . #_stake) (`shouldBe` balance)
-            ]
+            >>= flip
+                verify
+                [ expectField (#_foreign) (`shouldBe` [])
+                , expectField
+                    (#_ours)
+                    ( \case
+                        [acc] -> do
+                            (acc ^. #_index) `shouldBe` 0
+                            (acc ^. #_stake) `shouldBe` ApiAmount 0
+                            acc
+                                ^. (#_delegation . #active . #status)
+                                    `shouldBe` NotDelegating
+                        _ -> expectationFailure "wrong number of accounts in \"ours\""
+                    )
+                , expectField (#_none . #_stake) (`shouldBe` balance)
+                ]
 
         -- By sending funds to ourselves, we associate funds with our stake key.
         -- Both from the payment output itself and the change.
         addrs <- listAddresses @n ctx w
         let addr = (addrs !! 1) ^. #id
-        let payload = [json|
+        let payload =
+                [json|
                 { "payments":
                     [ { "address": #{addr}
                       , "amount":
@@ -1332,26 +1636,33 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                 , "passphrase": #{fixturePassphrase}
                 }|]
 
-        request @(ApiTransaction n) ctx
+        request @(ApiTransaction n)
+            ctx
             (Link.createTransactionOld @'Shelley w)
-            Default (Json payload)
-            >>= flip verify
-                [ expectResponseCode HTTP.status202 ]
+            Default
+            (Json payload)
+            >>= flip
+                verify
+                [expectResponseCode HTTP.status202]
 
         waitForTxImmutability ctx
 
         request @(ApiStakeKeys n) ctx (Link.listStakeKeys w) Default Empty
-            >>= flip verify
-            [ expectField (#_foreign) (`shouldBe` [])
-            , expectField (#_ours) (\case
-                [acc] -> do
-                    (acc ^. #_stake) .> ApiAmount 0
-                    acc ^. (#_delegation . #active . #status)
-                        `shouldBe` NotDelegating
-                _ -> expectationFailure "wrong number of accounts in \"ours\""
-                )
-            , expectField (#_none . #_stake) (.< balance)
-            ]
+            >>= flip
+                verify
+                [ expectField (#_foreign) (`shouldBe` [])
+                , expectField
+                    (#_ours)
+                    ( \case
+                        [acc] -> do
+                            (acc ^. #_stake) .> ApiAmount 0
+                            acc
+                                ^. (#_delegation . #active . #status)
+                                    `shouldBe` NotDelegating
+                        _ -> expectationFailure "wrong number of accounts in \"ours\""
+                    )
+                , expectField (#_none . #_stake) (.< balance)
+                ]
 
     it "STAKE_KEY_LIST_02 - Can list foreign stake key from UTxO" $ \ctx -> runResourceT $ do
         w <- fixtureWallet ctx
@@ -1362,7 +1673,8 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
         foreignAddr <- head . map (view #id) <$> listAddresses @n ctx otherWallet
         ourAddr <- head . map (view #id) <$> listAddresses @n ctx w
         let ourAddr' = replaceStakeKey ourAddr foreignAddr
-        let payload = [json|
+        let payload =
+                [json|
                 { "payments":
                     [ { "address": #{ourAddr'}
                       , "amount":
@@ -1373,58 +1685,68 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                     ]
                 , "passphrase": #{fixturePassphrase}
                 }|]
-        request @(ApiTransaction n) ctx
+        request @(ApiTransaction n)
+            ctx
             (Link.createTransactionOld @'Shelley w)
-            Default (Json payload)
-            >>= flip verify
-                [ expectResponseCode HTTP.status202 ]
+            Default
+            (Json payload)
+            >>= flip
+                verify
+                [expectResponseCode HTTP.status202]
         waitForTxImmutability ctx
 
         request @(ApiStakeKeys n) ctx (Link.listStakeKeys w) Default Empty
-            >>= flip verify
-            [ expectField (#_foreign) (\case
-                [acc] -> do
-                    (acc ^. #_stake) .> ApiAmount 0
-                _ -> expectationFailure "wrong number of accounts in \"foreign\""
-                )
-            , expectField (#_ours) (\case
-                [acc] -> do
-                    -- NOTE: because of the change from the transaction, this
-                    -- is no longer 0:
-                    (acc ^. #_stake) .> ApiAmount 0
-                    acc ^. (#_delegation . #active . #status)
-                        `shouldBe` NotDelegating
-                _ -> expectationFailure "wrong number of accounts in \"ours\""
-                )
-            , expectField (#_none . #_stake) (.< balance)
-            ]
+            >>= flip
+                verify
+                [ expectField
+                    (#_foreign)
+                    ( \case
+                        [acc] -> do
+                            (acc ^. #_stake) .> ApiAmount 0
+                        _ -> expectationFailure "wrong number of accounts in \"foreign\""
+                    )
+                , expectField
+                    (#_ours)
+                    ( \case
+                        [acc] -> do
+                            -- NOTE: because of the change from the transaction, this
+                            -- is no longer 0:
+                            (acc ^. #_stake) .> ApiAmount 0
+                            acc
+                                ^. (#_delegation . #active . #status)
+                                    `shouldBe` NotDelegating
+                        _ -> expectationFailure "wrong number of accounts in \"ours\""
+                    )
+                , expectField (#_none . #_stake) (.< balance)
+                ]
   where
-    metadataPossible = Set.fromList
-        [ StakePoolMetadata
-            { ticker = (StakePoolTicker "GPA")
-            , name = "Genesis Pool A"
-            , description = Nothing
-            , homepage = "https://iohk.io"
-            }
-        , StakePoolMetadata
-            { ticker = (StakePoolTicker "GPB")
-            , name = "Genesis Pool B"
-            , description = Nothing
-            , homepage = "https://iohk.io"
-            }
-        , StakePoolMetadata
-            { ticker = (StakePoolTicker "GPC")
-            , name = "Genesis Pool C"
-            , description = Just "Lorem Ipsum Dolor Sit Amet."
-            , homepage = "https://iohk.io"
-            }
-        , StakePoolMetadata
-            { ticker = (StakePoolTicker "GPD")
-            , name = "Genesis Pool D"
-            , description = Just "Lorem Ipsum Dolor Sit Amet."
-            , homepage = "https://iohk.io"
-            }
-        ]
+    metadataPossible =
+        Set.fromList
+            [ StakePoolMetadata
+                { ticker = (StakePoolTicker "GPA")
+                , name = "Genesis Pool A"
+                , description = Nothing
+                , homepage = "https://iohk.io"
+                }
+            , StakePoolMetadata
+                { ticker = (StakePoolTicker "GPB")
+                , name = "Genesis Pool B"
+                , description = Nothing
+                , homepage = "https://iohk.io"
+                }
+            , StakePoolMetadata
+                { ticker = (StakePoolTicker "GPC")
+                , name = "Genesis Pool C"
+                , description = Just "Lorem Ipsum Dolor Sit Amet."
+                , homepage = "https://iohk.io"
+                }
+            , StakePoolMetadata
+                { ticker = (StakePoolTicker "GPD")
+                , name = "Genesis Pool D"
+                , description = Just "Lorem Ipsum Dolor Sit Amet."
+                , homepage = "https://iohk.io"
+                }
+            ]
 
     setOf :: Ord b => [a] -> (a -> b) -> Set b
     setOf xs f = Set.fromList $ map f xs
@@ -1439,21 +1761,21 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
     costOfJoining :: Context -> Natural
     costOfJoining ctx =
         if _mainEra ctx >= ApiBabbage
-        then costOf (TxSize 485) ctx
-        else costOf (TxSize 479) ctx
+            then costOf (TxSize 485) ctx
+            else costOf (TxSize 479) ctx
 
     costOfQuitting :: Context -> Natural
     costOfQuitting ctx =
         if _mainEra ctx >= ApiBabbage
-        then costOf (TxSize 334) ctx
-        else costOf (TxSize 332) ctx
+            then costOf (TxSize 334) ctx
+            else costOf (TxSize 332) ctx
 
     costOf :: TxSize -> Context -> Natural
     costOf (TxSize txSizeInBytes) ctx =
         txSizeInBytes * round slope + round intercept
       where
         pp = ctx ^. #_networkParameters . #protocolParameters
-        LinearFee LinearFunction {..} = pp ^. #txParameters . #getFeePolicy
+        LinearFee LinearFunction{..} = pp ^. #txParameters . #getFeePolicy
 
 -- The complete set of pool identifiers in the static test pool cluster.
 --
@@ -1463,9 +1785,11 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 -- TODO: Remove this duplication.
 --
 testClusterPoolIds :: Set PoolId
-testClusterPoolIds = Set.fromList $ PoolId . unsafeFromHex <$>
-    [ "1b3dc19c6ab89eaffc8501f375bb03c11bf8ed5d183736b1d80413d6"
-    , "b45768c1a2da4bd13ebcaa1ea51408eda31dcc21765ccbd407cda9f2"
-    , "bb114cb37d75fa05260328c235a3dae295a33d0ba674a5eb1e3e568e"
-    , "ec28f33dcbe6d6400a1e5e339bd0647c0973ca6c0cf9c2bbe6838dc6"
-    ]
+testClusterPoolIds =
+    Set.fromList
+        $ PoolId . unsafeFromHex
+            <$> [ "1b3dc19c6ab89eaffc8501f375bb03c11bf8ed5d183736b1d80413d6"
+                , "b45768c1a2da4bd13ebcaa1ea51408eda31dcc21765ccbd407cda9f2"
+                , "bb114cb37d75fa05260328c235a3dae295a33d0ba674a5eb1e3e568e"
+                , "ec28f33dcbe6d6400a1e5e339bd0647c0973ca6c0cf9c2bbe6838dc6"
+                ]

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -12,7 +12,6 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 {- HLINT ignore "Use head" -}
@@ -193,6 +192,7 @@ import Test.Integration.Framework.DSL
     , listTransactions
     , minUTxOValue
     , mkTxPayloadMA
+    , noConway
     , pickAnAsset
     , postTx
     , request
@@ -257,24 +257,22 @@ spec
      . HasSNetworkId n
     => SpecWith Context
 spec = describe "SHELLEY_TRANSACTIONS" $ do
-
-    it "TRANS_MIN_UTXO_01: \
-
+    it
+        "TRANS_MIN_UTXO_01: \
         \Specifying a non-zero quantity of lovelace that is below the minimum \
         \required by the ledger results in an error, but specifying a quantity \
-        \that is equal to the required minimum results in success." $
-
-        \ctx -> runResourceT $ do
-
-        sourceWallet <- fixtureWallet ctx
-        targetWallet <- emptyWallet ctx
-        targetAddresses <- listAddresses @n ctx targetWallet
-        let targetAddress = (targetAddresses !! 1) ^. #id
-        let endpoint = Link.createTransactionOld @'Shelley sourceWallet
-        let mkRequest = request @(ApiTransaction n) ctx endpoint Default
-        let mkPayload :: ApiAmount -> Payload
-            mkPayload lovelaceRequested = Json
-                [json|
+        \that is equal to the required minimum results in success."
+        $ \ctx -> runResourceT $ do
+            sourceWallet <- fixtureWallet ctx
+            targetWallet <- emptyWallet ctx
+            targetAddresses <- listAddresses @n ctx targetWallet
+            let targetAddress = (targetAddresses !! 1) ^. #id
+            let endpoint = Link.createTransactionOld @'Shelley sourceWallet
+            let mkRequest = request @(ApiTransaction n) ctx endpoint Default
+            let mkPayload :: ApiAmount -> Payload
+                mkPayload lovelaceRequested =
+                    Json
+                        [json|
                     { "payments":
                         [
                             { "address": #{targetAddress}
@@ -285,39 +283,42 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                     }
                 |]
 
-        -- Attempt #1:
-        --
-        -- Attempt to create a transaction with a non-zero quantity of lovelace
-        -- that is significantly below the minimum required by the ledger.
-        --
-        -- This attempt should fail with an error that states the minimum
-        -- required amount.
-        --
-        e <- counterexample "Attempt #1" $ do
-            let lovelaceRequested = ApiAmount 1
-            response <- mkRequest (mkPayload lovelaceRequested)
-            expectResponseCode HTTP.status403 response
-            let UtxoTooSmall e = decodeErrorInfo response
-            e ^. #txOutputIndex
-                `shouldBe` 0
-            e ^. #txOutputLovelaceSpecified
-                `shouldBe` lovelaceRequested
-            e ^. #txOutputLovelaceRequiredMinimum `shouldSatisfy`
-                (> lovelaceRequested)
-            pure e
+            -- Attempt #1:
+            --
+            -- Attempt to create a transaction with a non-zero quantity of lovelace
+            -- that is significantly below the minimum required by the ledger.
+            --
+            -- This attempt should fail with an error that states the minimum
+            -- required amount.
+            --
+            e <- counterexample "Attempt #1" $ do
+                let lovelaceRequested = ApiAmount 1
+                response <- mkRequest (mkPayload lovelaceRequested)
+                expectResponseCode HTTP.status403 response
+                let UtxoTooSmall e = decodeErrorInfo response
+                e
+                    ^. #txOutputIndex
+                        `shouldBe` 0
+                e
+                    ^. #txOutputLovelaceSpecified
+                        `shouldBe` lovelaceRequested
+                e
+                    ^. #txOutputLovelaceRequiredMinimum
+                        `shouldSatisfy` (> lovelaceRequested)
+                pure e
 
-        -- Attempt #2:
-        --
-        -- Attempt to create a transaction with a quantity of lovelace equal to
-        -- the minimum required amount, as specified by the error returned in
-        -- the previous attempt.
-        --
-        -- This attempt should succeed.
-        --
-        counterexample "Attempt #2" $ do
-            let lovelaceRequested = e ^. #txOutputLovelaceRequiredMinimum
-            response <- mkRequest (mkPayload lovelaceRequested)
-            expectResponseCode HTTP.status202 response
+            -- Attempt #2:
+            --
+            -- Attempt to create a transaction with a quantity of lovelace equal to
+            -- the minimum required amount, as specified by the error returned in
+            -- the previous attempt.
+            --
+            -- This attempt should succeed.
+            --
+            counterexample "Attempt #2" $ do
+                let lovelaceRequested = e ^. #txOutputLovelaceRequiredMinimum
+                response <- mkRequest (mkPayload lovelaceRequested)
+                expectResponseCode HTTP.status202 response
 
     it "Regression ADP-626 - Filtering transactions between eras" $ do
         \ctx -> runResourceT $ do
@@ -325,213 +326,264 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             let startTimeBeforeShelley = T.pack "2009-09-09T09:09:09Z"
             currTime <- liftIO getCurrentTime
             let endTimeAfterShelley = utcIso8601ToText currTime
-            let link = Link.listTransactions' @'Shelley w
-                    Nothing
-                    (either (const Nothing) Just
-                        $ fromText startTimeBeforeShelley)
-                    (either (const Nothing) Just
-                        $ fromText endTimeAfterShelley)
-                    Nothing
-                    Nothing
-                    Nothing
+            let link =
+                    Link.listTransactions' @'Shelley
+                        w
+                        Nothing
+                        ( either (const Nothing) Just
+                            $ fromText startTimeBeforeShelley
+                        )
+                        ( either (const Nothing) Just
+                            $ fromText endTimeAfterShelley
+                        )
+                        Nothing
+                        Nothing
+                        Nothing
             r <- request @([ApiTransaction n]) ctx link Default Empty
             expectResponseCode HTTP.status200 r
             expectListSize 10 r
 
-    it "Regression #1004 -\
+    it
+        "Regression #1004 -\
         \ Transaction to self shows only fees as a tx amount\
-        \ while both, pending and in_ledger" $
-        \ctx -> runResourceT $ do
+        \ while both, pending and in_ledger"
+        $ \ctx -> runResourceT $ do
+            wSrc <- fixtureWallet ctx
 
-        wSrc <- fixtureWallet ctx
+            payload <-
+                liftIO
+                    $ mkTxPayload ctx wSrc (minUTxOValue (_mainEra ctx)) fixturePassphrase
 
-        payload <- liftIO $
-            mkTxPayload ctx wSrc (minUTxOValue (_mainEra ctx)) fixturePassphrase
+            (_, ApiFee (ApiAmount feeMin) (ApiAmount feeMax) _ _) <-
+                unsafeRequest
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley wSrc)
+                    payload
 
-        (_, ApiFee (ApiAmount feeMin) (ApiAmount feeMax) _ _) <-
-            unsafeRequest ctx
-                (Link.getTransactionFeeOld @'Shelley wSrc) payload
+            r <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSrc)
+                    Default
+                    payload
 
-        r <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSrc) Default payload
-
-        verify r
-            [ expectSuccess
-            , expectResponseCode HTTP.status202
-            -- tx amount includes only fees because it is tx to self address
-            -- when tx is pending
-            , expectField (#amount . #toNatural) $ between (feeMin, feeMax)
-            , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-            , expectField (#status . #getApiT) (`shouldBe` Pending)
-            ]
-
-        eventually "Tx is in ledger" $ do
-            rt <- request @([ApiTransaction n]) ctx
-                (Link.listTransactions @'Shelley wSrc) Default Empty
-            verify rt
+            verify
+                r
                 [ expectSuccess
-                , expectResponseCode HTTP.status200
-                -- tx amount includes only fees because it is tx to self address
-                -- also when tx is already in ledger
-                , expectListField 0 (#amount . #toNatural) $
-                    between (feeMin, feeMax)
-                , expectListField 0 (#direction . #getApiT)
-                    (`shouldBe` Outgoing)
-                , expectListField 0 (#status . #getApiT)
-                    (`shouldBe` InLedger)
+                , expectResponseCode HTTP.status202
+                , -- tx amount includes only fees because it is tx to self address
+                  -- when tx is pending
+                  expectField (#amount . #toNatural) $ between (feeMin, feeMax)
+                , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+                , expectField (#status . #getApiT) (`shouldBe` Pending)
                 ]
 
-    it "Regression #935 -\
-        \ Pending tx should have pendingSince in the list tx response" $
-        \ctx -> runResourceT $ do
+            eventually "Tx is in ledger" $ do
+                rt <-
+                    request @([ApiTransaction n])
+                        ctx
+                        (Link.listTransactions @'Shelley wSrc)
+                        Default
+                        Empty
+                verify
+                    rt
+                    [ expectSuccess
+                    , expectResponseCode HTTP.status200
+                    , -- tx amount includes only fees because it is tx to self address
+                      -- also when tx is already in ledger
+                      expectListField 0 (#amount . #toNatural)
+                        $ between (feeMin, feeMax)
+                    , expectListField
+                        0
+                        (#direction . #getApiT)
+                        (`shouldBe` Outgoing)
+                    , expectListField
+                        0
+                        (#status . #getApiT)
+                        (`shouldBe` InLedger)
+                    ]
 
-        wSrc <- fixtureWallet ctx
-        wDest <- emptyWallet ctx
+    it
+        "Regression #935 -\
+        \ Pending tx should have pendingSince in the list tx response"
+        $ \ctx -> runResourceT $ do
+            wSrc <- fixtureWallet ctx
+            wDest <- emptyWallet ctx
 
-        eventually "Pending tx has pendingSince field" $ do
-            -- Post Tx
-            let amt = (minUTxOValue (_mainEra ctx) :: Natural)
-            r <- postTx @n ctx
-                (wSrc, Link.createTransactionOld @'Shelley,fixturePassphrase)
-                wDest
-                amt
-            let tx = getFromResponse Prelude.id r
-            tx ^. (#status . #getApiT) `shouldBe` Pending
-            insertedAt tx `shouldBe` Nothing
-            pendingSince tx `shouldSatisfy` isJust
+            eventually "Pending tx has pendingSince field" $ do
+                -- Post Tx
+                let amt = (minUTxOValue (_mainEra ctx) :: Natural)
+                r <-
+                    postTx @n
+                        ctx
+                        (wSrc, Link.createTransactionOld @'Shelley, fixturePassphrase)
+                        wDest
+                        amt
+                let tx = getFromResponse Prelude.id r
+                tx ^. (#status . #getApiT) `shouldBe` Pending
+                insertedAt tx `shouldBe` Nothing
+                pendingSince tx `shouldSatisfy` isJust
 
-            -- Verify Tx
-            let link = Link.listTransactions' @'Shelley wSrc
-                    Nothing
-                    Nothing
-                    Nothing
-                    (Just Descending)
-                    Nothing
-                    Nothing
-            (_, txs) <- unsafeRequest @([ApiTransaction n]) ctx link Empty
-            case filter ((== Pending) . view (#status . #getApiT)) txs of
-                [] ->
-                    fail "Tx no longer pending, need to retry scenario."
-                tx':_ -> do
-                    tx' ^. (#direction . #getApiT) `shouldBe` Outgoing
-                    tx' ^. (#status . #getApiT) `shouldBe` Pending
-                    insertedAt tx' `shouldBe` Nothing
-                    pendingSince tx' `shouldBe` pendingSince tx
+                -- Verify Tx
+                let link =
+                        Link.listTransactions' @'Shelley
+                            wSrc
+                            Nothing
+                            Nothing
+                            Nothing
+                            (Just Descending)
+                            Nothing
+                            Nothing
+                (_, txs) <- unsafeRequest @([ApiTransaction n]) ctx link Empty
+                case filter ((== Pending) . view (#status . #getApiT)) txs of
+                    [] ->
+                        fail "Tx no longer pending, need to retry scenario."
+                    tx' : _ -> do
+                        tx' ^. (#direction . #getApiT) `shouldBe` Outgoing
+                        tx' ^. (#status . #getApiT) `shouldBe` Pending
+                        insertedAt tx' `shouldBe` Nothing
+                        pendingSince tx' `shouldBe` pendingSince tx
 
-    it "TRANS_CREATE_01x - Single Output Transaction" $
-        \ctx -> runResourceT $ do
+    it "TRANS_CREATE_01x - Single Output Transaction"
+        $ \ctx -> runResourceT $ do
+            let initialAmt = 3 * minUTxOValue (_mainEra ctx)
+            wa <- fixtureWalletWith @n ctx [initialAmt]
+            wb <- fixtureWalletWith @n ctx [initialAmt]
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
 
-        let initialAmt = 3 * minUTxOValue (_mainEra ctx)
-        wa <- fixtureWalletWith @n ctx [initialAmt]
-        wb <- fixtureWalletWith @n ctx [initialAmt]
-        let amt = minUTxOValue (_mainEra ctx) :: Natural
+            payload <- liftIO $ mkTxPayload ctx wb amt fixturePassphrase
 
-        payload <- liftIO $ mkTxPayload ctx wb amt fixturePassphrase
+            (_, ApiFee (ApiAmount feeMin) (ApiAmount feeMax) minCoins _) <-
+                unsafeRequest
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley wa)
+                    payload
+            rTx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wa)
+                    Default
+                    payload
+            ra <-
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley wa)
+                    Default
+                    Empty
 
-        (_, ApiFee (ApiAmount feeMin) (ApiAmount feeMax) minCoins _) <-
-            unsafeRequest ctx
-                (Link.getTransactionFeeOld @'Shelley wa) payload
-        rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wa) Default payload
-        ra <- request @ApiWallet ctx
-            (Link.getWallet @'Shelley wa) Default Empty
-
-        verify rTx
-            [ expectSuccess
-            , expectResponseCode HTTP.status202
-            , expectField (#amount . #toNatural) $
-                between (feeMin + amt, feeMax + amt)
-            , const $
-                -- The minimum ada quantities returned within an 'ApiFee'
-                -- object are computed using the 'computeMinimumCoinForUTxO'
-                -- function. This function produces quantities that are very
-                -- slightly higher than the Cardano API function on which it is
-                -- based, so as to guarantee that ada quantities can always be
-                -- safely increased while still retaining their validity.
-                --
-                -- To avoid making the test suite more brittle than necessary,
-                -- here we simply assert that the minimum values returned are
-                -- greater than or equal to the 'minUTxOValue' test suite
-                -- constant:
-                --
-                minCoins `shouldSatisfy` all
-                    (>= (ApiAmount $ minUTxOValue (_mainEra ctx)))
-            , expectField #inputs $ \inputs' -> do
-                inputs' `shouldSatisfy` all (isJust . source)
-            , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-            , expectField (#status . #getApiT) (`shouldBe` Pending)
-            , expectField #metadata (`shouldBe` Nothing)
-            ]
-
-        verify ra
-            [ expectSuccess
-            , expectField (#balance . #total) $
-                between
-                    ( ApiAmount (initialAmt - feeMax - amt)
-                    , ApiAmount (initialAmt - feeMin - amt)
-                    )
-            , expectField
-                    (#balance . #available)
-                    (`shouldBe` ApiAmount 0)
-            ]
-
-        let txid = getFromResponse #id rTx
-        let linkSrc = Link.getTransaction @'Shelley wa (ApiTxId txid)
-        let ApiAmount fee = getFromResponse #fee rTx
-        eventually "transaction is no longer pending on source wallet" $ do
-            rSrc <- request @(ApiTransaction n) ctx linkSrc Default Empty
-            verify rSrc
-                [ expectResponseCode HTTP.status200
-                , expectField (#amount . #toNatural) $
-                    between (feeMin + amt, feeMax + amt)
+            verify
+                rTx
+                [ expectSuccess
+                , expectResponseCode HTTP.status202
+                , expectField (#amount . #toNatural)
+                    $ between (feeMin + amt, feeMax + amt)
+                , const
+                    $
+                    -- The minimum ada quantities returned within an 'ApiFee'
+                    -- object are computed using the 'computeMinimumCoinForUTxO'
+                    -- function. This function produces quantities that are very
+                    -- slightly higher than the Cardano API function on which it is
+                    -- based, so as to guarantee that ada quantities can always be
+                    -- safely increased while still retaining their validity.
+                    --
+                    -- To avoid making the test suite more brittle than necessary,
+                    -- here we simply assert that the minimum values returned are
+                    -- greater than or equal to the 'minUTxOValue' test suite
+                    -- constant:
+                    --
+                    minCoins
+                        `shouldSatisfy` all
+                            (>= (ApiAmount $ minUTxOValue (_mainEra ctx)))
                 , expectField #inputs $ \inputs' -> do
                     inputs' `shouldSatisfy` all (isJust . source)
                 , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-                , expectField (#status . #getApiT) (`shouldBe` InLedger)
-                , expectField (#metadata) (`shouldBe` Nothing)
-                , expectField (#fee . #toNatural) $
-                    between (feeMin, feeMax)
+                , expectField (#status . #getApiT) (`shouldBe` Pending)
+                , expectField #metadata (`shouldBe` Nothing)
                 ]
 
-        let linkDest = Link.getTransaction @'Shelley wb (ApiTxId txid)
-        eventually "transaction is discovered by destination wallet" $ do
-            rDst <- request @(ApiTransaction n) ctx linkDest Default Empty
-            verify rDst
-                [ expectResponseCode HTTP.status200
-                , expectField (#amount . #toNatural) (`shouldBe` amt)
-                , expectField #inputs $ \inputs' -> do
-                    inputs' `shouldSatisfy` all (isNothing . source)
-                , expectField (#direction . #getApiT) (`shouldBe` Incoming)
-                , expectField (#status . #getApiT) (`shouldBe` InLedger)
-                , expectField (#metadata) (`shouldBe` Nothing)
-                , expectField (#fee . #toNatural) $
-                    between (feeMin, feeMax)
+            verify
+                ra
+                [ expectSuccess
+                , expectField (#balance . #total)
+                    $ between
+                        ( ApiAmount (initialAmt - feeMax - amt)
+                        , ApiAmount (initialAmt - feeMin - amt)
+                        )
+                , expectField
+                    (#balance . #available)
+                    (`shouldBe` ApiAmount 0)
                 ]
 
-        eventually "wa and wb balances are as expected" $ do
-            rb <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wb) Default Empty
-            expectField
-                (#balance . #available)
-                (`shouldBe` ApiAmount (initialAmt + amt)) rb
+            let txid = getFromResponse #id rTx
+            let linkSrc = Link.getTransaction @'Shelley wa (ApiTxId txid)
+            let ApiAmount fee = getFromResponse #fee rTx
+            eventually "transaction is no longer pending on source wallet" $ do
+                rSrc <- request @(ApiTransaction n) ctx linkSrc Default Empty
+                verify
+                    rSrc
+                    [ expectResponseCode HTTP.status200
+                    , expectField (#amount . #toNatural)
+                        $ between (feeMin + amt, feeMax + amt)
+                    , expectField #inputs $ \inputs' -> do
+                        inputs' `shouldSatisfy` all (isJust . source)
+                    , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+                    , expectField (#status . #getApiT) (`shouldBe` InLedger)
+                    , expectField (#metadata) (`shouldBe` Nothing)
+                    , expectField (#fee . #toNatural)
+                        $ between (feeMin, feeMax)
+                    ]
 
-            ra2 <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wa) Default Empty
-            expectField
-                (#balance . #available)
-                (`shouldBe` ApiAmount (initialAmt - fee - amt)) ra2
+            let linkDest = Link.getTransaction @'Shelley wb (ApiTxId txid)
+            eventually "transaction is discovered by destination wallet" $ do
+                rDst <- request @(ApiTransaction n) ctx linkDest Default Empty
+                verify
+                    rDst
+                    [ expectResponseCode HTTP.status200
+                    , expectField (#amount . #toNatural) (`shouldBe` amt)
+                    , expectField #inputs $ \inputs' -> do
+                        inputs' `shouldSatisfy` all (isNothing . source)
+                    , expectField (#direction . #getApiT) (`shouldBe` Incoming)
+                    , expectField (#status . #getApiT) (`shouldBe` InLedger)
+                    , expectField (#metadata) (`shouldBe` Nothing)
+                    , expectField (#fee . #toNatural)
+                        $ between (feeMin, feeMax)
+                    ]
 
-    it "TRANS_CREATE_02x - Multiple Output Tx to single wallet" $
-        \ctx -> runResourceT $ do
+            eventually "wa and wb balances are as expected" $ do
+                rb <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley wb)
+                        Default
+                        Empty
+                expectField
+                    (#balance . #available)
+                    (`shouldBe` ApiAmount (initialAmt + amt))
+                    rb
 
-        wSrc <- fixtureWallet ctx
-        wDest <- emptyWallet ctx
-        addrs <- listAddresses @n ctx wDest
+                ra2 <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley wa)
+                        Default
+                        Empty
+                expectField
+                    (#balance . #available)
+                    (`shouldBe` ApiAmount (initialAmt - fee - amt))
+                    ra2
 
-        let amt = minUTxOValue (_mainEra ctx) :: Natural
-        let destination1 = (addrs !! 1) ^. #id
-        let destination2 = (addrs !! 2) ^. #id
-        let payload = Json [json|{
+    it "TRANS_CREATE_02x - Multiple Output Tx to single wallet"
+        $ \ctx -> runResourceT $ do
+            wSrc <- fixtureWallet ctx
+            wDest <- emptyWallet ctx
+            addrs <- listAddresses @n ctx wDest
+
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
+            let destination1 = (addrs !! 1) ^. #id
+            let destination2 = (addrs !! 2) ^. #id
+            let payload =
+                    Json
+                        [json|{
                 "payments": [{
                     "address": #{destination1},
                     "amount": {
@@ -549,125 +601,174 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 "passphrase": "cardano-wallet"
             }|]
 
-        (_, ApiFee (ApiAmount feeMin) (ApiAmount feeMax) _ _) <-
-            unsafeRequest ctx
-                (Link.getTransactionFeeOld @'Shelley wSrc) payload
+            (_, ApiFee (ApiAmount feeMin) (ApiAmount feeMax) _ _) <-
+                unsafeRequest
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley wSrc)
+                    payload
 
-        r <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSrc) Default payload
+            r <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSrc)
+                    Default
+                    payload
 
-        ra <- request @ApiWallet ctx
-            (Link.getWallet @'Shelley wSrc) Default Empty
+            ra <-
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley wSrc)
+                    Default
+                    Empty
 
-        verify r
-            [ expectResponseCode HTTP.status202
-            , expectField (#amount . #toNatural) $
-                between (feeMin + (2*amt), feeMax + (2*amt))
-            , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-            , expectField (#status . #getApiT) (`shouldBe` Pending)
-            , expectField #inputs $ \inputs' -> do
-                inputs' `shouldSatisfy` all (isJust . source)
-            ]
+            verify
+                r
+                [ expectResponseCode HTTP.status202
+                , expectField (#amount . #toNatural)
+                    $ between (feeMin + (2 * amt), feeMax + (2 * amt))
+                , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+                , expectField (#status . #getApiT) (`shouldBe` Pending)
+                , expectField #inputs $ \inputs' -> do
+                    inputs' `shouldSatisfy` all (isJust . source)
+                ]
 
-        verify ra
-            [ expectField (#balance . #total) $
-                between
-                    ( ApiAmount (faucetAmt - feeMax - (2*amt))
-                    , ApiAmount (faucetAmt - feeMin - (2*amt))
-                    )
-            , expectField
+            verify
+                ra
+                [ expectField (#balance . #total)
+                    $ between
+                        ( ApiAmount (faucetAmt - feeMax - (2 * amt))
+                        , ApiAmount (faucetAmt - feeMin - (2 * amt))
+                        )
+                , expectField
                     (#balance . #available)
                     (.>= ApiAmount (faucetAmt - 2 * faucetUtxoAmt))
-            ]
-        eventually "wDest balance is as expected" $ do
-            rd <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wDest) Default Empty
-            verify rd
-                [ expectField
+                ]
+            eventually "wDest balance is as expected" $ do
+                rd <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley wDest)
+                        Default
+                        Empty
+                verify
+                    rd
+                    [ expectField
                         (#balance . #available)
-                        (`shouldBe` ApiAmount (2*amt))
-                , expectField
+                        (`shouldBe` ApiAmount (2 * amt))
+                    , expectField
                         (#balance . #total)
-                        (`shouldBe` ApiAmount (2*amt))
+                        (`shouldBe` ApiAmount (2 * amt))
+                    ]
+
+    it "TRANS_CREATE_03 - 0 balance after transaction"
+        $ \ctx -> runResourceT $ do
+            liftIO
+                $ pendingWith
+                    "This test relies on knowing exactly how the underlying selection \
+                    \implementation works. We may want to revise this test completely \
+                    \otherwise we'll have to update it for every single change in \
+                    \the fee calculation or selection algorithm."
+            let amt = minUTxOValue (_mainEra ctx)
+
+            wDest <- fixtureWalletWith @n ctx [amt]
+            payload <- liftIO $ mkTxPayload ctx wDest amt fixturePassphrase
+
+            (_, ApiFee (ApiAmount feeMin) _ _ _) <-
+                unsafeRequest
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley wDest)
+                    payload
+
+            -- NOTE It's a little tricky to estimate the fee needed for a
+            -- transaction with no change output, because in order to know the right
+            -- amount of fees, we need to create a transaction spends precisely this
+            -- amount.
+            --
+            -- Said differently, in order to know what amount we need, we need to
+            -- know what the amount is... ¯\_(ツ)_/¯ ... So, we use a little
+            -- hard-wired margin, which works with the current fee settings. If we
+            -- ever change that, this test will fail.
+            let margin = 400
+            wSrc <- fixtureWalletWith @n ctx [feeMin + amt + margin]
+
+            r <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSrc)
+                    Default
+                    payload
+            verify
+                r
+                [ expectResponseCode HTTP.status202
+                , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+                , expectField (#status . #getApiT) (`shouldBe` Pending)
                 ]
 
-    it "TRANS_CREATE_03 - 0 balance after transaction" $
-        \ctx -> runResourceT $ do
-
-        liftIO $ pendingWith
-            "This test relies on knowing exactly how the underlying selection \
-            \implementation works. We may want to revise this test completely \
-            \otherwise we'll have to update it for every single change in \
-            \the fee calculation or selection algorithm."
-        let amt = minUTxOValue (_mainEra ctx)
-
-        wDest <- fixtureWalletWith @n ctx [amt]
-        payload <- liftIO $ mkTxPayload ctx wDest amt fixturePassphrase
-
-        (_, ApiFee (ApiAmount feeMin) _ _ _) <- unsafeRequest ctx
-            (Link.getTransactionFeeOld @'Shelley wDest) payload
-
-        -- NOTE It's a little tricky to estimate the fee needed for a
-        -- transaction with no change output, because in order to know the right
-        -- amount of fees, we need to create a transaction spends precisely this
-        -- amount.
-        --
-        -- Said differently, in order to know what amount we need, we need to
-        -- know what the amount is... ¯\_(ツ)_/¯ ... So, we use a little
-        -- hard-wired margin, which works with the current fee settings. If we
-        -- ever change that, this test will fail.
-        let margin = 400
-        wSrc <- fixtureWalletWith @n ctx [feeMin+amt+margin]
-
-        r <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSrc) Default payload
-        verify r
-            [ expectResponseCode HTTP.status202
-            , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-            , expectField (#status . #getApiT) (`shouldBe` Pending)
-            ]
-
-        ra <- request @ApiWallet ctx
-            (Link.getWallet @'Shelley wSrc) Default Empty
-        verify ra
-            [ expectField (#balance . #total) (`shouldBe` ApiAmount 0)
-            , expectField (#balance . #available) (`shouldBe` ApiAmount 0)
-            ]
-
-        eventually "Wallet balance is as expected" $ do
-            rd <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wDest) Default Empty
-            verify rd
-                [ expectField
-                        (#balance . #available)
-                        (`shouldBe` ApiAmount (2*amt))
-                , expectField
-                        (#balance . #total)
-                        (`shouldBe` ApiAmount (2*amt))
+            ra <-
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley wSrc)
+                    Default
+                    Empty
+            verify
+                ra
+                [ expectField (#balance . #total) (`shouldBe` ApiAmount 0)
+                , expectField (#balance . #available) (`shouldBe` ApiAmount 0)
                 ]
 
-        ra2 <- request @ApiWallet ctx
-            (Link.getWallet @'Shelley wSrc) Default Empty
-        verify ra2
-            [ expectField (#balance . #total) (`shouldBe` ApiAmount 0)
-            , expectField (#balance . #available) (`shouldBe` ApiAmount 0)
-            ]
+            eventually "Wallet balance is as expected" $ do
+                rd <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley wDest)
+                        Default
+                        Empty
+                verify
+                    rd
+                    [ expectField
+                        (#balance . #available)
+                        (`shouldBe` ApiAmount (2 * amt))
+                    , expectField
+                        (#balance . #total)
+                        (`shouldBe` ApiAmount (2 * amt))
+                    ]
+
+            ra2 <-
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley wSrc)
+                    Default
+                    Empty
+            verify
+                ra2
+                [ expectField (#balance . #total) (`shouldBe` ApiAmount 0)
+                , expectField (#balance . #available) (`shouldBe` ApiAmount 0)
+                ]
 
     it "TRANS_CREATE_04 - Can't cover fee" $ \ctx -> runResourceT $ do
         wDest <- fixtureWallet ctx
 
         let minUTxOValue' = minUTxOValue (_mainEra ctx)
 
-        payload <- liftIO $
-            mkTxPayload ctx wDest minUTxOValue' fixturePassphrase
-        (_, ApiFee (ApiAmount feeMin) _ _ _) <- unsafeRequest ctx
-            (Link.getTransactionFeeOld @'Shelley wDest) payload
+        payload <-
+            liftIO
+                $ mkTxPayload ctx wDest minUTxOValue' fixturePassphrase
+        (_, ApiFee (ApiAmount feeMin) _ _ _) <-
+            unsafeRequest
+                ctx
+                (Link.getTransactionFeeOld @'Shelley wDest)
+                payload
 
         wSrc <- fixtureWalletWith @n ctx [minUTxOValue' + (feeMin `div` 2)]
 
-        r <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSrc) Default payload
-        verify r
+        r <-
+            request @(ApiTransaction n)
+                ctx
+                (Link.createTransactionOld @'Shelley wSrc)
+                Default
+                payload
+        verify
+            r
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403Fee
             ]
@@ -678,20 +779,26 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         wSrc <- fixtureWalletWith @n ctx [srcAmt]
         wDest <- emptyWallet ctx
         payload <- mkTxPayload ctx wDest reqAmt fixturePassphrase
-        r <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSrc) Default payload
+        r <-
+            request @(ApiTransaction n)
+                ctx
+                (Link.createTransactionOld @'Shelley wSrc)
+                Default
+                payload
         verify r [expectResponseCode HTTP.status403]
         decodeErrorInfo r `shouldSatisfy` \case
-            NotEnoughMoney {} -> True
+            NotEnoughMoney{} -> True
             _someOtherError -> False
 
     it "TRANS_CREATE_04 - Wrong password" $ \ctx -> runResourceT $ do
         wSrc <- fixtureWallet ctx
         wDest <- emptyWallet ctx
-        addr:_ <- listAddresses @n ctx wDest
+        addr : _ <- listAddresses @n ctx wDest
 
         let destination = addr ^. #id
-        let payload = Json [json|{
+        let payload =
+                Json
+                    [json|{
                 "payments": [{
                     "address": #{destination},
                     "amount": {
@@ -701,21 +808,32 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 }],
                 "passphrase": "This password is wrong"
             }|]
-        r <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSrc) Default payload
-        verify r
+        r <-
+            request @(ApiTransaction n)
+                ctx
+                (Link.createTransactionOld @'Shelley wSrc)
+                Default
+                payload
+        verify
+            r
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403WrongPass
             ]
 
     it "TRANS_CREATE_07 - Deleted wallet" $ \ctx -> runResourceT $ do
         w <- emptyWallet ctx
-        _ <- request @ApiWallet ctx
-            (Link.deleteWallet @'Shelley w) Default Empty
+        _ <-
+            request @ApiWallet
+                ctx
+                (Link.deleteWallet @'Shelley w)
+                Default
+                Empty
         wDest <- emptyWallet ctx
-        addr:_ <- listAddresses @n ctx wDest
+        addr : _ <- listAddresses @n ctx wDest
         let destination = addr ^. #id
-        let payload = Json [json|{
+        let payload =
+                Json
+                    [json|{
                 "payments": [{
                     "address": #{destination},
                     "amount": {
@@ -725,156 +843,209 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 }],
                 "passphrase": "cardano-wallet"
             }|]
-        r <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley w) Default payload
+        r <-
+            request @(ApiTransaction n)
+                ctx
+                (Link.createTransactionOld @'Shelley w)
+                Default
+                payload
         expectResponseCode HTTP.status404 r
         expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r
 
     describe "TRANS_CREATE_08 - Bad payload" $ do
         let matrix =
-                [ ( "empty payload", NonJson "" )
-                , ( "{} payload", NonJson "{}" )
-                , ( "non-json valid payload"
-                  , NonJson
+                [ ("empty payload", NonJson "")
+                , ("{} payload", NonJson "{}")
+                ,
+                    ( "non-json valid payload"
+                    , NonJson
                         "{ payments: [{\
-                         \\"address\": 12312323,\
-                         \\"amount: {\
-                         \\"quantity\": 1,\
-                         \\"unit\": \"lovelace\"} }],\
-                         \\"passphrase\": \"cardano-wallet\" }"
-                  )
+                        \\"address\": 12312323,\
+                        \\"amount: {\
+                        \\"quantity\": 1,\
+                        \\"unit\": \"lovelace\"} }],\
+                        \\"passphrase\": \"cardano-wallet\" }"
+                    )
                 ]
 
         forM_ matrix $ \(title, nonJson) -> it title $ \ctx -> runResourceT $ do
             w <- emptyWallet ctx
             let payload = nonJson
-            r <- request @(ApiTransaction n) ctx
-                (Link.createTransactionOld @'Shelley w) Default payload
+            r <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley w)
+                    Default
+                    payload
             expectResponseCode HTTP.status400 r
 
-    it "TRANS_ASSETS_CREATE_01 - Multi-asset balance" $
-        \ctx -> runResourceT $ do
-
-        w <- fixtureMultiAssetWallet ctx
-        r <- request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty
-        verify r
-            [ expectField (#assets . #available)
-                (`shouldNotBe` mempty)
-            , expectField (#assets . #total)
-                (`shouldNotBe` mempty)
-            ]
-
-        r2 <- request @[ApiAsset] ctx (Link.listAssets w) Default Empty
-        verify r2
-            [ expectListField 0 #metadata (`shouldBe` Just steveToken)
-            , expectListField 0 #metadataError (`shouldBe` Nothing)
-            ]
-
-    it "TRANS_ASSETS_CREATE_01a - Multi-asset transaction with Ada" $
-        \ctx -> runResourceT $ do
-
-        wSrc <- fixtureMultiAssetWallet ctx
-        wDest <- emptyWallet ctx
-        ra <- request @ApiWallet ctx
-            (Link.getWallet @'Shelley wSrc) Default Empty
-        let (_, Right wal) = ra
-
-        -- pick out an asset to send
-        let assetsSrc = wal ^. #assets . #total
-        assetsSrc `shouldNotBe` mempty
-        let val = minUTxOValue (_mainEra ctx) <$ pickAnAsset assetsSrc
-
-        addrs <- listAddresses @n ctx wDest
-        let destination = (addrs !! 1) ^. #id
-
-        -- use minimum coin value provided by the server
-        payloadFee <- mkTxPayloadMA @n destination 0 [val] fixturePassphrase
-        rFee <- request @ApiFee ctx
-            (Link.getTransactionFeeOld @'Shelley wSrc) Default payloadFee
-        let [ApiAmount minCoin] = getFromResponse #minimumCoins rFee
-
-        payload <- mkTxPayloadMA @n destination minCoin [val] fixturePassphrase
-        rtx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSrc) Default payload
-        expectResponseCode HTTP.status202 rtx
-
-        eventually "Payee wallet balance is as expected" $ do
-            rb <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wDest) Default Empty
-            verify rb
-                [ expectField (#assets . #available)
+    it "TRANS_ASSETS_CREATE_01 - Multi-asset balance"
+        $ \ctx -> runResourceT $ do
+            w <- fixtureMultiAssetWallet ctx
+            r <- request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty
+            verify
+                r
+                [ expectField
+                    (#assets . #available)
                     (`shouldNotBe` mempty)
-                , expectField (#assets . #total)
-                    (`shouldNotBe` mempty)
-                , expectField (#balance . #total . #toNatural)
-                    (`shouldBe` minCoin)
-                ]
-        -- todo: asset balance values more exactly
-        -- todo: assert payer wallet balance
-
-    it "TRANS_ASSETS_CREATE_02 - \
-        \Multi-asset transaction with small Ada amount" $
-        \ctx -> runResourceT $ do
-
-        wSrc <- fixtureMultiAssetWallet ctx
-        wDest <- emptyWallet ctx
-        ra <- request @ApiWallet ctx
-            (Link.getWallet @'Shelley wSrc) Default Empty
-        let (_, Right wal) = ra
-
-        -- pick out an asset to send
-        let assetsSrc = wal ^. #assets . #total
-        assetsSrc `shouldNotBe` mempty
-        let val = minUTxOValue (_mainEra ctx) <$ pickAnAsset assetsSrc
-
-        -- This is a non-zero ada amount, but less than the actual minimum utxo
-        -- due to assets in the transaction.
-        let coin = minUTxOValue (_mainEra ctx)
-
-        addrs <- listAddresses @n ctx wDest
-        let destination = (addrs !! 1) ^. #id
-        payload <- mkTxPayloadMA @n destination coin [val] fixturePassphrase
-
-        rtx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSrc) Default payload
-        -- It should fail with InsufficientMinCoinValueError
-        expectResponseCode HTTP.status403 rtx
-        expectErrorMessage errMsg403MinUTxOValue rtx
-
-    it "TRANS_ASSETS_CREATE_02a - Multi-asset transaction without Ada" $
-        \ctx -> runResourceT $ do
-
-        wSrc <- fixtureMultiAssetWallet ctx
-        wDest <- emptyWallet ctx
-        ra <- request @ApiWallet ctx
-            (Link.getWallet @'Shelley wSrc) Default Empty
-        let (_, Right wal) = ra
-
-        -- pick out an asset to send
-        let assetsSrc = wal ^. #assets . #total
-        assetsSrc `shouldNotBe` mempty
-        let val = minUTxOValue (_mainEra ctx) <$ pickAnAsset assetsSrc
-
-        addrs <- listAddresses @n ctx wDest
-        let destination = (addrs !! 1) ^. #id
-        payload <- mkTxPayloadMA @n destination 0 [val] fixturePassphrase
-
-        rtx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSrc) Default payload
-        expectResponseCode HTTP.status202 rtx
-
-        eventually "Payee wallet balance is as expected" $ do
-            rb <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wDest) Default Empty
-            verify rb
-                [ expectField (#assets . #available)
-                    (`shouldNotBe` mempty)
-                , expectField (#assets . #total)
+                , expectField
+                    (#assets . #total)
                     (`shouldNotBe` mempty)
                 ]
 
-    it "TRANS_ASSETS_CREATE_02c - Send SeaHorses" $
-        \ctx -> runResourceT $ do
+            r2 <- request @[ApiAsset] ctx (Link.listAssets w) Default Empty
+            verify
+                r2
+                [ expectListField 0 #metadata (`shouldBe` Just steveToken)
+                , expectListField 0 #metadataError (`shouldBe` Nothing)
+                ]
+
+    it "TRANS_ASSETS_CREATE_01a - Multi-asset transaction with Ada"
+        $ \ctx -> runResourceT $ do
+            wSrc <- fixtureMultiAssetWallet ctx
+            wDest <- emptyWallet ctx
+            ra <-
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley wSrc)
+                    Default
+                    Empty
+            let (_, Right wal) = ra
+
+            -- pick out an asset to send
+            let assetsSrc = wal ^. #assets . #total
+            assetsSrc `shouldNotBe` mempty
+            let val = minUTxOValue (_mainEra ctx) <$ pickAnAsset assetsSrc
+
+            addrs <- listAddresses @n ctx wDest
+            let destination = (addrs !! 1) ^. #id
+
+            -- use minimum coin value provided by the server
+            payloadFee <- mkTxPayloadMA @n destination 0 [val] fixturePassphrase
+            rFee <-
+                request @ApiFee
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley wSrc)
+                    Default
+                    payloadFee
+            let [ApiAmount minCoin] = getFromResponse #minimumCoins rFee
+
+            payload <- mkTxPayloadMA @n destination minCoin [val] fixturePassphrase
+            rtx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSrc)
+                    Default
+                    payload
+            expectResponseCode HTTP.status202 rtx
+
+            eventually "Payee wallet balance is as expected" $ do
+                rb <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley wDest)
+                        Default
+                        Empty
+                verify
+                    rb
+                    [ expectField
+                        (#assets . #available)
+                        (`shouldNotBe` mempty)
+                    , expectField
+                        (#assets . #total)
+                        (`shouldNotBe` mempty)
+                    , expectField
+                        (#balance . #total . #toNatural)
+                        (`shouldBe` minCoin)
+                    ]
+    -- todo: asset balance values more exactly
+    -- todo: assert payer wallet balance
+
+    it
+        "TRANS_ASSETS_CREATE_02 - \
+        \Multi-asset transaction with small Ada amount"
+        $ \ctx -> runResourceT $ do
+            wSrc <- fixtureMultiAssetWallet ctx
+            wDest <- emptyWallet ctx
+            ra <-
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley wSrc)
+                    Default
+                    Empty
+            let (_, Right wal) = ra
+
+            -- pick out an asset to send
+            let assetsSrc = wal ^. #assets . #total
+            assetsSrc `shouldNotBe` mempty
+            let val = minUTxOValue (_mainEra ctx) <$ pickAnAsset assetsSrc
+
+            -- This is a non-zero ada amount, but less than the actual minimum utxo
+            -- due to assets in the transaction.
+            let coin = minUTxOValue (_mainEra ctx)
+
+            addrs <- listAddresses @n ctx wDest
+            let destination = (addrs !! 1) ^. #id
+            payload <- mkTxPayloadMA @n destination coin [val] fixturePassphrase
+
+            rtx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSrc)
+                    Default
+                    payload
+            -- It should fail with InsufficientMinCoinValueError
+            expectResponseCode HTTP.status403 rtx
+            expectErrorMessage errMsg403MinUTxOValue rtx
+
+    it "TRANS_ASSETS_CREATE_02a - Multi-asset transaction without Ada"
+        $ \ctx -> runResourceT $ do
+            wSrc <- fixtureMultiAssetWallet ctx
+            wDest <- emptyWallet ctx
+            ra <-
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley wSrc)
+                    Default
+                    Empty
+            let (_, Right wal) = ra
+
+            -- pick out an asset to send
+            let assetsSrc = wal ^. #assets . #total
+            assetsSrc `shouldNotBe` mempty
+            let val = minUTxOValue (_mainEra ctx) <$ pickAnAsset assetsSrc
+
+            addrs <- listAddresses @n ctx wDest
+            let destination = (addrs !! 1) ^. #id
+            payload <- mkTxPayloadMA @n destination 0 [val] fixturePassphrase
+
+            rtx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSrc)
+                    Default
+                    payload
+            expectResponseCode HTTP.status202 rtx
+
+            eventually "Payee wallet balance is as expected" $ do
+                rb <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley wDest)
+                        Default
+                        Empty
+                verify
+                    rb
+                    [ expectField
+                        (#assets . #available)
+                        (`shouldNotBe` mempty)
+                    , expectField
+                        (#assets . #total)
+                        (`shouldNotBe` mempty)
+                    ]
+
+    it "TRANS_ASSETS_CREATE_02c - Send SeaHorses"
+        $ \ctx -> runResourceT $ do
             -- Notes on the style of this test:
             -- - By doing the minting here it is easier to control, and tweak
             -- the values.
@@ -891,8 +1062,13 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                         <$> listAddresses @n ctx wSrc
                 let batchSize = 1
                 let coinPerAddr = Coin 1000_000_000
-                liftIO $ _mintSeaHorseAssets ctx
-                    nAssetsPerAddr batchSize  coinPerAddr (take 2 srcAddrs)
+                liftIO
+                    $ _mintSeaHorseAssets
+                        ctx
+                        nAssetsPerAddr
+                        batchSize
+                        coinPerAddr
+                        (take 2 srcAddrs)
                 return (wSrc, nAssetsPerAddr)
             wDest <- emptyWallet ctx
             destAddr <- head . map (view #id) <$> listAddresses @n ctx wDest
@@ -901,208 +1077,245 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             -- 2. Try spending from each wallet, and record the response.
             responses <- forM sourceWallets $ \(wSrc, nPerAddr) -> do
                 let seaHorses = map $ \ix ->
-                        (( toText seaHorsePolicyId
-                        , toText $ seaHorseAssetName ix)
-                        , 1)
-                payload <- mkTxPayloadMA @n
-                    destAddr
-                    0
-                    (seaHorses [1, nPerAddr * 2])
-                    -- Send one token from our first bundle, and one token from
-                    -- our second bundle, to ensure the change output is large.
-                    fixturePassphrase
+                        (
+                            ( toText seaHorsePolicyId
+                            , toText $ seaHorseAssetName ix
+                            )
+                        , 1
+                        )
+                payload <-
+                    mkTxPayloadMA @n
+                        destAddr
+                        0
+                        (seaHorses [1, nPerAddr * 2])
+                        -- Send one token from our first bundle, and one token from
+                        -- our second bundle, to ensure the change output is large.
+                        fixturePassphrase
 
                 let verifyRes r = case r of
                         (s, Right _)
                             | s == HTTP.status202 -> Right ()
-                            | otherwise           -> Left $ mconcat
-                                [ "impossible: request succeeded, but got "
-                                , "status code "
-                                , show s
-                                ]
+                            | otherwise ->
+                                Left
+                                    $ mconcat
+                                        [ "impossible: request succeeded, but got "
+                                        , "status code "
+                                        , show s
+                                        ]
                         (_, Left e) -> Left $ show e
 
-                (nPerAddr,) . verifyRes <$> request @(ApiTransaction n) ctx
-                    (Link.createTransactionOld @'Shelley wSrc) Default payload
+                (nPerAddr,) . verifyRes
+                    <$> request @(ApiTransaction n)
+                        ctx
+                        (Link.createTransactionOld @'Shelley wSrc)
+                        Default
+                        payload
 
             -- 3. They should all succeed
-            responses `shouldBe` (map (, Right ()) assetsPerAddrScenarios)
+            responses `shouldBe` (map (,Right ()) assetsPerAddrScenarios)
 
     let hasAssetOutputs :: [AddressAmount (ApiAddress n)] -> Bool
         hasAssetOutputs = any ((/= mempty) . view #assets)
 
-    it "TRANS_ASSETS_CREATE_02b - Multi-asset tx history" $
-        \ctx -> runResourceT $ do
+    it "TRANS_ASSETS_CREATE_02b - Multi-asset tx history"
+        $ \ctx -> runResourceT $ do
+            wSrc <- fixtureMultiAssetWallet ctx
+            wDest <- emptyWallet ctx
+            wal <- getWallet ctx wSrc
 
-        wSrc <- fixtureMultiAssetWallet ctx
-        wDest <- emptyWallet ctx
-        wal <- getWallet ctx wSrc
+            -- pick out an asset to send
+            let assetsSrc = wal ^. #assets . #total
+            assetsSrc `shouldNotBe` mempty
+            let val = minUTxOValue (_mainEra ctx) <$ pickAnAsset assetsSrc
 
-        -- pick out an asset to send
-        let assetsSrc = wal ^. #assets . #total
-        assetsSrc `shouldNotBe` mempty
-        let val = minUTxOValue (_mainEra ctx) <$ pickAnAsset assetsSrc
+            addrs <- listAddresses @n ctx wDest
+            let destination = (addrs !! 1) ^. #id
+            payload <- mkTxPayloadMA @n destination 0 [val] fixturePassphrase
 
-        addrs <- listAddresses @n ctx wDest
-        let destination = (addrs !! 1) ^. #id
-        payload <- mkTxPayloadMA @n destination 0 [val] fixturePassphrase
+            rtx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSrc)
+                    Default
+                    payload
 
-        rtx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSrc) Default payload
-
-        verify rtx
-            [ expectSuccess
-            , expectField (#status . #getApiT) (`shouldBe` Pending)
-            -- , expectField #assets (`shouldNotBe` mempty) -- TODO: ADP-683
-            , expectField #outputs (`shouldSatisfy` hasAssetOutputs)
-            ]
-
-        eventually "asset transfer is confirmed in transaction list" $ do
-            -- on src wallet
-            let linkSrcList = Link.listTransactions @'Shelley wSrc
-            rla <- request @([ApiTransaction n]) ctx linkSrcList Default Empty
-            verify rla
+            verify
+                rtx
                 [ expectSuccess
-                , expectListField 0 (#status . #getApiT) (`shouldBe` InLedger)
-                , expectListField 0
-                    (#direction . #getApiT) (`shouldBe` Outgoing)
-                -- TODO: ADP-683
-                --, expectListField 0 #assets (`shouldBe` "fewer than before")
-                , expectListField 0 #outputs (`shouldSatisfy` hasAssetOutputs)
+                , expectField (#status . #getApiT) (`shouldBe` Pending)
+                , -- , expectField #assets (`shouldNotBe` mempty) -- TODO: ADP-683
+                  expectField #outputs (`shouldSatisfy` hasAssetOutputs)
                 ]
-            -- on dst wallet
-            let linkDestList = Link.listTransactions @'Shelley wDest
-            rlb <- request @([ApiTransaction n]) ctx linkDestList Default Empty
-            verify rlb
+
+            eventually "asset transfer is confirmed in transaction list" $ do
+                -- on src wallet
+                let linkSrcList = Link.listTransactions @'Shelley wSrc
+                rla <- request @([ApiTransaction n]) ctx linkSrcList Default Empty
+                verify
+                    rla
+                    [ expectSuccess
+                    , expectListField 0 (#status . #getApiT) (`shouldBe` InLedger)
+                    , expectListField
+                        0
+                        (#direction . #getApiT)
+                        (`shouldBe` Outgoing)
+                    , -- TODO: ADP-683
+                      -- , expectListField 0 #assets (`shouldBe` "fewer than before")
+                      expectListField 0 #outputs (`shouldSatisfy` hasAssetOutputs)
+                    ]
+                -- on dst wallet
+                let linkDestList = Link.listTransactions @'Shelley wDest
+                rlb <- request @([ApiTransaction n]) ctx linkDestList Default Empty
+                verify
+                    rlb
+                    [ expectSuccess
+                    , expectListField 0 (#status . #getApiT) (`shouldBe` InLedger)
+                    , expectListField
+                        0
+                        (#direction . #getApiT)
+                        (`shouldBe` Incoming)
+                    , -- TODO: ADP-683
+                      -- , expectListField 0 #assets (`shouldNotBe` mempty)
+                      expectListField 0 #outputs (`shouldSatisfy` hasAssetOutputs)
+                    ]
+
+            eventually "Payee wallet balance is as expected" $ do
+                rb <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley wDest)
+                        Default
+                        Empty
+                verify
+                    rb
+                    [ expectField
+                        (#assets . #available)
+                        (`shouldNotBe` mempty)
+                    , expectField
+                        (#assets . #total)
+                        (`shouldNotBe` mempty)
+                    ]
+
+    it "TRANS_ASSETS_LIST_01 - Asset list present"
+        $ \ctx -> runResourceT $ do
+            wal <- fixtureMultiAssetWallet ctx
+
+            let assetsSrc = wal ^. (#assets . #total)
+            assetsSrc `shouldNotBe` mempty
+            let (polId, assName) =
+                    bimap unsafeFromText unsafeFromText
+                        $ fst
+                        $ pickAnAsset assetsSrc
+            let tokenFingerprint = mkTokenFingerprint polId assName
+
+            r <- request @([ApiAsset]) ctx (Link.listAssets wal) Default Empty
+            verify
+                r
                 [ expectSuccess
-                , expectListField 0 (#status . #getApiT) (`shouldBe` InLedger)
-                , expectListField 0
-                    (#direction . #getApiT) (`shouldBe` Incoming)
-                -- TODO: ADP-683
-                -- , expectListField 0 #assets (`shouldNotBe` mempty)
-                , expectListField 0 #outputs (`shouldSatisfy` hasAssetOutputs)
+                , expectListSizeSatisfy (> 0)
+                , expectListField 0 #policyId (`shouldBe` ApiT polId)
+                , expectListField 0 #assetName (`shouldBe` ApiT assName)
+                , expectListField
+                    0
+                    (#fingerprint . #getApiT)
+                    (`shouldBe` tokenFingerprint)
+                , expectListField 0 #metadata (`shouldBe` Just steveToken)
+                , expectListField 0 #metadataError (`shouldBe` Nothing)
                 ]
 
-        eventually "Payee wallet balance is as expected" $ do
-            rb <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wDest) Default Empty
-            verify rb
-                [ expectField (#assets . #available)
-                    (`shouldNotBe` mempty)
-                , expectField (#assets . #total)
-                    (`shouldNotBe` mempty)
+    it "TRANS_ASSETS_LIST_02 - Asset list present when not used"
+        $ \ctx -> runResourceT $ do
+            wal <- fixtureWallet ctx
+            r <- request @([ApiAsset]) ctx (Link.listAssets wal) Default Empty
+            verify
+                r
+                [ expectSuccess
+                , expectListSize 0
                 ]
 
-    it "TRANS_ASSETS_LIST_01 - Asset list present" $
-        \ctx -> runResourceT $ do
+    it "TRANS_ASSETS_LIST_02a - Asset list present when not used"
+        $ \ctx -> runResourceT $ do
+            wal <- emptyWallet ctx
+            r <- request @([ApiAsset]) ctx (Link.listAssets wal) Default Empty
+            verify
+                r
+                [ expectSuccess
+                , expectListSize 0
+                ]
 
-        wal <- fixtureMultiAssetWallet ctx
+    it "TRANS_ASSETS_GET_01 - Asset list present"
+        $ \ctx -> runResourceT $ do
+            wal <- fixtureMultiAssetWallet ctx
 
-        let assetsSrc = wal ^. (#assets . #total)
-        assetsSrc `shouldNotBe` mempty
-        let (polId, assName) = bimap unsafeFromText unsafeFromText $ fst $
-                pickAnAsset assetsSrc
-        let tokenFingerprint = mkTokenFingerprint polId assName
+            -- pick an asset from the fixture wallet
+            assetsSrc <- view (#assets . #total) <$> getWallet ctx wal
+            assetsSrc `shouldNotBe` mempty
+            let (polId, assName) =
+                    bimap unsafeFromText unsafeFromText
+                        $ fst
+                        $ pickAnAsset assetsSrc
+            let tokenFingerprint = mkTokenFingerprint polId assName
+            let ep = Link.getAsset wal polId assName
+            r <- request @(ApiAsset) ctx ep Default Empty
+            verify
+                r
+                [ expectSuccess
+                , expectField #policyId (`shouldBe` ApiT polId)
+                , expectField #assetName (`shouldBe` ApiT assName)
+                , expectField
+                    (#fingerprint . #getApiT)
+                    (`shouldBe` tokenFingerprint)
+                , expectField #metadata (`shouldBe` Just steveToken)
+                , expectField #metadataError (`shouldBe` Nothing)
+                ]
 
-        r <- request @([ApiAsset]) ctx (Link.listAssets wal) Default Empty
-        verify r
-            [ expectSuccess
-            , expectListSizeSatisfy ( > 0)
-            , expectListField 0 #policyId (`shouldBe` ApiT polId)
-            , expectListField 0 #assetName (`shouldBe` ApiT assName)
-            , expectListField 0 (#fingerprint . #getApiT)
-                (`shouldBe` tokenFingerprint)
-            , expectListField 0 #metadata (`shouldBe` Just steveToken)
-            , expectListField 0 #metadataError (`shouldBe` Nothing)
-            ]
+    it "TRANS_ASSETS_GET_02 - Asset not present when isn't associated"
+        $ \ctx -> runResourceT $ do
+            wal <- fixtureMultiAssetWallet ctx
+            let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
+            let assName = AssetName.UnsafeAssetName $ B8.replicate 4 'x'
+            let ep = Link.getAsset wal polId assName
+            r <- request @(ApiAsset) ctx ep Default Empty
+            expectResponseCode HTTP.status404 r
+            expectErrorMessage errMsg404NoAsset r
 
-    it "TRANS_ASSETS_LIST_02 - Asset list present when not used" $
-        \ctx -> runResourceT $ do
+    it "TRANS_ASSETS_GET_02a - Asset not present when isn't associated"
+        $ \ctx -> runResourceT $ do
+            wal <- fixtureMultiAssetWallet ctx
+            let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
+            let ep = Link.getAsset wal polId AssetName.empty
+            r <- request @(ApiAsset) ctx ep Default Empty
+            expectResponseCode HTTP.status404 r
+            expectErrorMessage errMsg404NoAsset r
 
-        wal <- fixtureWallet ctx
-        r <- request @([ApiAsset]) ctx (Link.listAssets wal) Default Empty
-        verify r
-            [ expectSuccess
-            , expectListSize 0
-            ]
+    it "TRANS_TTL_04 - Large TTL"
+        $ \ctx -> runResourceT $ do
+            (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
+            let hugeTTL = 1e9 :: NominalDiffTime
 
-    it "TRANS_ASSETS_LIST_02a - Asset list present when not used" $
-        \ctx -> runResourceT $ do
+            basePayload <- mkTxPayload ctx wb amt fixturePassphrase
+            let payload = addTxTTL (realToFrac hugeTTL) basePayload
 
-        wal <- emptyWallet ctx
-        r <- request @([ApiAsset]) ctx (Link.listAssets wal) Default Empty
-        verify r
-            [ expectSuccess
-            , expectListSize 0
-            ]
+            r <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wa)
+                    Default
+                    payload
 
-    it "TRANS_ASSETS_GET_01 - Asset list present" $
-        \ctx -> runResourceT $ do
+            -- If another HFC Era is added, then this payment request will fail
+            -- because the expiry would be past the slotting horizon.
+            verify
+                r
+                [ expectSuccess
+                , expectField (#status . #getApiT) (`shouldBe` Pending)
+                , expectField #expiresAt (`shouldSatisfy` isJust)
+                ]
 
-        wal <- fixtureMultiAssetWallet ctx
-
-        -- pick an asset from the fixture wallet
-        assetsSrc <- view (#assets . #total) <$> getWallet ctx wal
-        assetsSrc `shouldNotBe` mempty
-        let (polId, assName) = bimap unsafeFromText unsafeFromText $ fst $
-                pickAnAsset assetsSrc
-        let tokenFingerprint = mkTokenFingerprint polId assName
-        let ep = Link.getAsset wal polId assName
-        r <- request @(ApiAsset) ctx ep Default Empty
-        verify r
-            [ expectSuccess
-            , expectField #policyId (`shouldBe` ApiT polId)
-            , expectField #assetName (`shouldBe` ApiT assName)
-            , expectField (#fingerprint . #getApiT)
-                (`shouldBe` tokenFingerprint)
-            , expectField #metadata (`shouldBe` Just steveToken)
-            , expectField #metadataError (`shouldBe` Nothing)
-            ]
-
-    it "TRANS_ASSETS_GET_02 - Asset not present when isn't associated" $
-        \ctx -> runResourceT $ do
-
-        wal <- fixtureMultiAssetWallet ctx
-        let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
-        let assName = AssetName.UnsafeAssetName $ B8.replicate 4 'x'
-        let ep = Link.getAsset wal polId assName
-        r <- request @(ApiAsset) ctx ep Default Empty
-        expectResponseCode HTTP.status404 r
-        expectErrorMessage errMsg404NoAsset r
-
-    it "TRANS_ASSETS_GET_02a - Asset not present when isn't associated" $
-        \ctx -> runResourceT $ do
-
-        wal <- fixtureMultiAssetWallet ctx
-        let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
-        let ep = Link.getAsset wal polId AssetName.empty
-        r <- request @(ApiAsset) ctx ep Default Empty
-        expectResponseCode HTTP.status404 r
-        expectErrorMessage errMsg404NoAsset r
-
-    it "TRANS_TTL_04 - Large TTL" $
-        \ctx -> runResourceT $ do
-
-        (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
-        let amt = minUTxOValue (_mainEra ctx) :: Natural
-        let hugeTTL = 1e9 :: NominalDiffTime
-
-        basePayload <- mkTxPayload ctx wb amt fixturePassphrase
-        let payload = addTxTTL (realToFrac hugeTTL) basePayload
-
-        r <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wa) Default payload
-
-        -- If another HFC Era is added, then this payment request will fail
-        -- because the expiry would be past the slotting horizon.
-        verify r
-            [ expectSuccess
-            , expectField (#status . #getApiT) (`shouldBe` Pending)
-            , expectField #expiresAt (`shouldSatisfy` isJust)
-            ]
-
-    describe "TRANSMETA_CREATE_01 - Including metadata within transactions" $
-        mapM_ spec_createTransactionWithMetadata
+    describe "TRANSMETA_CREATE_01 - Including metadata within transactions"
+        $ mapM_
+            spec_createTransactionWithMetadata
             [ CreateTransactionWithMetadataTest
                 { testName =
                     "transaction without any metadata (1 output)"
@@ -1129,7 +1342,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 , txOutputAdaQuantities = \minUTxOVal ->
                     [minUTxOVal]
                 , txMetadata =
-                      Just txMetadata_ADP_1005
+                    Just txMetadata_ADP_1005
                 , expectedFee =
                     ApiAmount 151_800
                 }
@@ -1140,264 +1353,307 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                     -- An ada quantity that is greater than or equal to the
                     -- minimum ada quantity for all known eras:
                     [ 1_107_670
-                    -- The exact ada quantity recorded in ADP-1005:
-                    , 498_283_127
+                    , -- The exact ada quantity recorded in ADP-1005:
+                      498_283_127
                     ]
                 , txMetadata =
-                      Just txMetadata_ADP_1005
+                    Just txMetadata_ADP_1005
                 , expectedFee =
                     ApiAmount 165_200
                 }
             ]
 
-    it "TRANSMETA_CREATE_02a - \
-        \Transaction with invalid metadata" $
-        \ctx -> runResourceT $ do
+    it
+        "TRANSMETA_CREATE_02a - \
+        \Transaction with invalid metadata"
+        $ \ctx -> runResourceT $ do
+            (wa, wb) <- (,) <$> fixtureWallet ctx <*> fixtureWallet ctx
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
 
-        (wa, wb) <- (,) <$> fixtureWallet ctx <*> fixtureWallet ctx
-        let amt = minUTxOValue (_mainEra ctx) :: Natural
+            basePayload <- mkTxPayload ctx wb amt fixturePassphrase
 
-        basePayload <- mkTxPayload ctx wb amt fixturePassphrase
+            let txMeta = [json|{ "1": { "string": #{T.replicate 65 "a"} } }|]
+            let payload = addTxMetadata txMeta basePayload
 
-        let txMeta = [json|{ "1": { "string": #{T.replicate 65 "a"} } }|]
-        let payload = addTxMetadata txMeta basePayload
+            r <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wa)
+                    Default
+                    payload
 
-        r <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wa) Default payload
+            expectResponseCode HTTP.status400 r
+            expectErrorMessage errMsg400TxMetadataStringTooLong r
 
-        expectResponseCode HTTP.status400 r
-        expectErrorMessage errMsg400TxMetadataStringTooLong r
+    it
+        "TRANSMETA_CREATE_02b - \
+        \Transaction with invalid no-schema metadata"
+        $ \ctx -> runResourceT $ do
+            (wa, wb) <- (,) <$> fixtureWallet ctx <*> fixtureWallet ctx
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
 
-    it "TRANSMETA_CREATE_02b - \
-        \Transaction with invalid no-schema metadata" $
-        \ctx -> runResourceT $ do
+            basePayload <- mkTxPayload ctx wb amt fixturePassphrase
 
-        (wa, wb) <- (,) <$> fixtureWallet ctx <*> fixtureWallet ctx
-        let amt = minUTxOValue (_mainEra ctx) :: Natural
+            let txMeta = [json|{ "1": #{T.replicate 65 "a"} }|]
+            let payload = addTxMetadata txMeta basePayload
 
-        basePayload <- mkTxPayload ctx wb amt fixturePassphrase
+            r <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wa)
+                    Default
+                    payload
 
-        let txMeta = [json|{ "1": #{T.replicate 65 "a"} }|]
-        let payload = addTxMetadata txMeta basePayload
+            expectResponseCode HTTP.status400 r
+            expectErrorMessage errMsg400TxMetadataStringTooLong r
 
-        r <-
-            request @(ApiTransaction n)
-                ctx
-                (Link.createTransactionOld @'Shelley wa)
-                Default
-                payload
+    it "TRANSMETA_CREATE_03 - Transaction with too much metadata"
+        $ \ctx -> runResourceT $ do
+            (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
 
-        expectResponseCode HTTP.status400 r
-        expectErrorMessage errMsg400TxMetadataStringTooLong r
+            basePayload <- mkTxPayload ctx wb amt fixturePassphrase
 
-    it "TRANSMETA_CREATE_03 - Transaction with too much metadata" $
-        \ctx -> runResourceT $ do
+            -- This will encode to at least 32k of CBOR. The max tx size for the
+            -- integration tests cluster is 16k.
+            let txMeta =
+                    Aeson.object
+                        [ (Aeson.fromText $ toText @Int i, bytes)
+                        | i <- [0 .. 511]
+                        ]
+                bytes = [json|{ "bytes": #{T.replicate 64 "a"} }|]
+            let payload = addTxMetadata txMeta basePayload
 
-        (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
-        let amt = minUTxOValue (_mainEra ctx) :: Natural
+            r <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wa)
+                    Default
+                    payload
 
-        basePayload <- mkTxPayload ctx wb amt fixturePassphrase
+            expectResponseCode HTTP.status403 r
+            expectErrorInfo (`shouldBe` TransactionIsTooBig) r
 
-        -- This will encode to at least 32k of CBOR. The max tx size for the
-        -- integration tests cluster is 16k.
-        let txMeta = Aeson.object
-                [ (Aeson.fromText $ toText @Int i, bytes)
-                | i <- [0..511] ]
-            bytes = [json|{ "bytes": #{T.replicate 64 "a"} }|]
-        let payload = addTxMetadata txMeta basePayload
+    it
+        "TRANSMETA_ESTIMATE_01a - \
+        \fee estimation includes metadata"
+        $ \ctx -> runResourceT $ do
+            (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
 
-        r <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wa) Default payload
+            payload <- mkTxPayload ctx wb amt fixturePassphrase
 
-        expectResponseCode HTTP.status403 r
-        expectErrorInfo (`shouldBe` TransactionIsTooBig) r
+            let txMeta = [json|{ "1": { "string": "hello" } }|]
+            let payloadWithMetadata = addTxMetadata txMeta payload
 
-    it "TRANSMETA_ESTIMATE_01a - \
-        \fee estimation includes metadata" $
-        \ctx -> runResourceT $ do
+            ra <-
+                request @ApiFee
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley wa)
+                    Default
+                    payloadWithMetadata
+            verify
+                ra
+                [ expectSuccess
+                , expectResponseCode HTTP.status202
+                ]
+            let (ApiAmount feeEstMin) = getFromResponse #estimatedMin ra
+            let (ApiAmount feeEstMax) = getFromResponse #estimatedMax ra
 
-        (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
-        let amt = minUTxOValue (_mainEra ctx) :: Natural
+            -- check that it's estimated to have less fees for transactions without
+            -- metadata.
+            rb <-
+                request @ApiFee
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley wa)
+                    Default
+                    payload
+            verify
+                rb
+                [ expectResponseCode HTTP.status202
+                , expectField (#estimatedMin . #toNatural) (.< feeEstMin)
+                , expectField (#estimatedMax . #toNatural) (.< feeEstMax)
+                ]
 
-        payload <- mkTxPayload ctx wb amt fixturePassphrase
+    it
+        "TRANSMETA_ESTIMATE_01b - \
+        \fee estimation includes no-schema metadata"
+        $ \ctx -> runResourceT $ do
+            (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
 
-        let txMeta = [json|{ "1": { "string": "hello" } }|]
-        let payloadWithMetadata = addTxMetadata txMeta payload
+            payload <- mkTxPayload ctx wb amt fixturePassphrase
 
-        ra <- request @ApiFee ctx
-            (Link.getTransactionFeeOld @'Shelley wa) Default payloadWithMetadata
-        verify ra
-            [ expectSuccess
-            , expectResponseCode HTTP.status202
-            ]
-        let (ApiAmount feeEstMin) = getFromResponse #estimatedMin ra
-        let (ApiAmount feeEstMax) = getFromResponse #estimatedMax ra
+            let txMeta = [json|{ "1": "hello" }|]
+            let payloadWithMetadata = addTxMetadata txMeta payload
 
-        -- check that it's estimated to have less fees for transactions without
-        -- metadata.
-        rb <- request @ApiFee ctx
-            (Link.getTransactionFeeOld @'Shelley wa) Default payload
-        verify rb
-            [ expectResponseCode HTTP.status202
-            , expectField (#estimatedMin . #toNatural) (.< feeEstMin)
-            , expectField (#estimatedMax . #toNatural) (.< feeEstMax)
-            ]
+            ra <-
+                request @ApiFee
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley wa)
+                    Default
+                    payloadWithMetadata
+            verify
+                ra
+                [ expectSuccess
+                , expectResponseCode HTTP.status202
+                ]
+            let (ApiAmount feeEstMin) = getFromResponse #estimatedMin ra
+            let (ApiAmount feeEstMax) = getFromResponse #estimatedMax ra
 
-    it "TRANSMETA_ESTIMATE_01b - \
-        \fee estimation includes no-schema metadata" $
-        \ctx -> runResourceT $ do
+            -- check that it's estimated to have less fees for transactions without
+            -- metadata.
+            rb <-
+                request @ApiFee
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley wa)
+                    Default
+                    payload
+            verify
+                rb
+                [ expectResponseCode HTTP.status202
+                , expectField (#estimatedMin . #toNatural) (.< feeEstMin)
+                , expectField (#estimatedMax . #toNatural) (.< feeEstMax)
+                ]
 
-        (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
-        let amt = minUTxOValue (_mainEra ctx) :: Natural
+    it
+        "TRANSMETA_ESTIMATE_02a - \
+        \fee estimation with invalid metadata"
+        $ \ctx -> runResourceT $ do
+            (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
 
-        payload <- mkTxPayload ctx wb amt fixturePassphrase
+            basePayload <- mkTxPayload ctx wb amt fixturePassphrase
 
-        let txMeta = [json|{ "1": "hello" }|]
-        let payloadWithMetadata = addTxMetadata txMeta payload
+            let txMeta = [json|{ "1": { "string": #{T.replicate 65 "a"} } }|]
+            let payload = addTxMetadata txMeta basePayload
 
-        ra <-
-            request @ApiFee
-                ctx
-                (Link.getTransactionFeeOld @'Shelley wa)
-                Default
-                payloadWithMetadata
-        verify
-            ra
-            [ expectSuccess
-            , expectResponseCode HTTP.status202
-            ]
-        let (ApiAmount feeEstMin) = getFromResponse #estimatedMin ra
-        let (ApiAmount feeEstMax) = getFromResponse #estimatedMax ra
+            r <-
+                request @ApiFee
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley wa)
+                    Default
+                    payload
 
-        -- check that it's estimated to have less fees for transactions without
-        -- metadata.
-        rb <-
-            request @ApiFee
-                ctx
-                (Link.getTransactionFeeOld @'Shelley wa)
-                Default
-                payload
-        verify
-            rb
-            [ expectResponseCode HTTP.status202
-            , expectField (#estimatedMin . #toNatural) (.< feeEstMin)
-            , expectField (#estimatedMax . #toNatural) (.< feeEstMax)
-            ]
+            expectResponseCode HTTP.status400 r
+            expectErrorMessage errMsg400TxMetadataStringTooLong r
 
-    it "TRANSMETA_ESTIMATE_02a - \
-        \fee estimation with invalid metadata" $
-        \ctx -> runResourceT $ do
+    it
+        "TRANSMETA_ESTIMATE_02b - \
+        \fee estimation with invalid no-schema metadata"
+        $ \ctx -> runResourceT $ do
+            (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
 
-        (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
-        let amt = minUTxOValue (_mainEra ctx) :: Natural
+            basePayload <- mkTxPayload ctx wb amt fixturePassphrase
 
-        basePayload <- mkTxPayload ctx wb amt fixturePassphrase
+            let txMeta = [json|{ "1": #{T.replicate 65 "a" } }|]
+            let payload = addTxMetadata txMeta basePayload
 
-        let txMeta = [json|{ "1": { "string": #{T.replicate 65 "a"} } }|]
-        let payload = addTxMetadata txMeta basePayload
+            r <-
+                request @ApiFee
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley wa)
+                    Default
+                    payload
 
-        r <- request @ApiFee ctx
-            (Link.getTransactionFeeOld @'Shelley wa) Default payload
+            expectResponseCode HTTP.status400 r
+            expectErrorMessage errMsg400TxMetadataStringTooLong r
 
-        expectResponseCode HTTP.status400 r
-        expectErrorMessage errMsg400TxMetadataStringTooLong r
+    it "TRANSMETA_ESTIMATE_03 - fee estimation with too much metadata"
+        $ \ctx -> runResourceT $ do
+            (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
 
-    it "TRANSMETA_ESTIMATE_02b - \
-        \fee estimation with invalid no-schema metadata" $
-        \ctx -> runResourceT $ do
+            basePayload <- mkTxPayload ctx wb amt fixturePassphrase
 
-        (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
-        let amt = minUTxOValue (_mainEra ctx) :: Natural
+            -- This will encode to at least 32k of CBOR. The max tx size for the
+            -- integration tests cluster is 16k.
+            let txMeta =
+                    Aeson.object
+                        [ (Aeson.fromText $ toText @Int i, bytes)
+                        | i <- [0 .. 511]
+                        ]
+                bytes = [json|{ "bytes": #{T.replicate 64 "a"} }|]
+            let payload = addTxMetadata txMeta basePayload
+            r <-
+                request @ApiFee
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley wa)
+                    Default
+                    payload
 
-        basePayload <- mkTxPayload ctx wb amt fixturePassphrase
-
-        let txMeta = [json|{ "1": #{T.replicate 65 "a" } }|]
-        let payload = addTxMetadata txMeta basePayload
-
-        r <-
-            request @ApiFee
-                ctx
-                (Link.getTransactionFeeOld @'Shelley wa)
-                Default
-                payload
-
-        expectResponseCode HTTP.status400 r
-        expectErrorMessage errMsg400TxMetadataStringTooLong r
-
-    it "TRANSMETA_ESTIMATE_03 - fee estimation with too much metadata" $
-        \ctx -> runResourceT $ do
-
-        (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
-        let amt = minUTxOValue (_mainEra ctx) :: Natural
-
-        basePayload <- mkTxPayload ctx wb amt fixturePassphrase
-
-        -- This will encode to at least 32k of CBOR. The max tx size for the
-        -- integration tests cluster is 16k.
-        let txMeta = Aeson.object
-                [ (Aeson.fromText $ toText @Int i, bytes)
-                | i <- [0..511] ]
-            bytes = [json|{ "bytes": #{T.replicate 64 "a"} }|]
-        let payload = addTxMetadata txMeta basePayload
-        r <- request @ApiFee ctx
-            (Link.getTransactionFeeOld @'Shelley wa) Default payload
-
-        verify r
-            [ expectResponseCode HTTP.status403
-            , expectErrorInfo (`shouldBe` TransactionIsTooBig)
-            ]
+            verify
+                r
+                [ expectResponseCode HTTP.status403
+                , expectErrorInfo (`shouldBe` TransactionIsTooBig)
+                ]
 
     describe "TRANS_ESTIMATE_08 - Bad payload" $ do
         let matrix =
-                [ ( "empty payload", NonJson "" )
-                , ( "{} payload", NonJson "{}" )
-                , ( "non-json valid payload"
-                  , NonJson
+                [ ("empty payload", NonJson "")
+                , ("{} payload", NonJson "{}")
+                ,
+                    ( "non-json valid payload"
+                    , NonJson
                         "{ payments: [{\
-                         \\"address\": 12312323,\
-                         \\"amount: {\
-                         \\"quantity\": 1,\
-                         \\"unit\": \"lovelace\"} }]\
-                         \ }"
-                  )
+                        \\"address\": 12312323,\
+                        \\"amount: {\
+                        \\"quantity\": 1,\
+                        \\"unit\": \"lovelace\"} }]\
+                        \ }"
+                    )
                 ]
 
         forM_ matrix $ \(title, nonJson) -> it title $ \ctx -> runResourceT $ do
             w <- emptyWallet ctx
             let payload = nonJson
-            r <- request @ApiFee ctx
-                (Link.getTransactionFeeOld @'Shelley w) Default payload
+            r <-
+                request @ApiFee
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley w)
+                    Default
+                    payload
             expectResponseCode HTTP.status400 r
 
-    it "TRANS_ESTIMATE_03a - we see result when we can't cover fee" $
-        \ctx -> runResourceT $ do
+    it "TRANS_ESTIMATE_03a - we see result when we can't cover fee"
+        $ \ctx -> runResourceT $ do
+            wSrc <- fixtureWallet ctx
+            payload <- mkTxPayload ctx wSrc faucetAmt fixturePassphrase
+            r <-
+                request @ApiFee
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley wSrc)
+                    Default
+                    payload
+            verify
+                r
+                [ expectResponseCode HTTP.status202
+                , expectField (#estimatedMin . #toNatural) (.>= 0)
+                , expectField (#estimatedMax . #toNatural) (.<= oneAda)
+                ]
 
-        wSrc <- fixtureWallet ctx
-        payload <- mkTxPayload ctx wSrc faucetAmt fixturePassphrase
-        r <- request @ApiFee ctx
-            (Link.getTransactionFeeOld @'Shelley wSrc) Default payload
-        verify r
-            [ expectResponseCode HTTP.status202
-            , expectField (#estimatedMin . #toNatural) (.>= 0)
-            , expectField (#estimatedMax . #toNatural) (.<= oneAda)
-            ]
+    it
+        "TRANS_ESTIMATE_03b - \
+        \we see result when we can't cover fee (with withdrawal)"
+        $ \ctx -> runResourceT $ do
+            noConway ctx "MIR"
 
-    it "TRANS_ESTIMATE_03b - \
-        \we see result when we can't cover fee (with withdrawal)" $
-        \ctx -> runResourceT $ do
+            liftIO
+                $ pendingWith
+                    "This now triggers a new error on the backend side which is harder \
+                    \to catch without much logic changes. Since we are about to do a \
+                    \complete revision of the way transaction are constructed, which \
+                    \will result in the removal of the fee estimation altogether, I \
+                    \won't bother fixing this particular test case which is pretty \
+                    \minor / edge-case."
 
-        liftIO $ pendingWith
-            "This now triggers a new error on the backend side which is harder \
-            \to catch without much logic changes. Since we are about to do a \
-            \complete revision of the way transaction are constructed, which \
-            \will result in the removal of the fee estimation altogether, I \
-            \won't bother fixing this particular test case which is pretty \
-            \minor / edge-case."
-
-        (wSrc, _) <- rewardWallet ctx
-        addr:_ <- fmap (view #id) <$> listAddresses @n ctx wSrc
-        let totalBalance = wSrc ^. #balance . #total
-        let payload = Json [json|{
+            (wSrc, _) <- rewardWallet ctx
+            addr : _ <- fmap (view #id) <$> listAddresses @n ctx wSrc
+            let totalBalance = wSrc ^. #balance . #total
+            let payload =
+                    Json
+                        [json|{
                 "withdrawal": "self",
                 "payments": [{
                     "address": #{addr},
@@ -1405,13 +1661,18 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 }],
                 "passphrase": #{fixturePassphrase}
             }|]
-        r <- request @ApiFee ctx
-            (Link.getTransactionFeeOld @'Shelley wSrc) Default payload
-        verify r
-            [ expectResponseCode HTTP.status202
-            , expectField (#estimatedMin . #toNatural) (.>= 0)
-            , expectField (#estimatedMax . #toNatural) (.<= oneAda)
-            ]
+            r <-
+                request @ApiFee
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley wSrc)
+                    Default
+                    payload
+            verify
+                r
+                [ expectResponseCode HTTP.status202
+                , expectField (#estimatedMin . #toNatural) (.>= 0)
+                , expectField (#estimatedMax . #toNatural) (.<= oneAda)
+                ]
 
     it "TRANS_ESTIMATE_04 - Not enough money" $ \ctx -> runResourceT $ do
         let minUTxOValue' = minUTxOValue (_mainEra ctx)
@@ -1419,35 +1680,48 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         wSrc <- fixtureWalletWith @n ctx [srcAmt]
         wDest <- emptyWallet ctx
         payload <- mkTxPayload ctx wDest reqAmt fixturePassphrase
-        r <- request @ApiFee ctx
-            (Link.getTransactionFeeOld @'Shelley wSrc) Default payload
+        r <-
+            request @ApiFee
+                ctx
+                (Link.getTransactionFeeOld @'Shelley wSrc)
+                Default
+                payload
         verify r [expectResponseCode HTTP.status403]
         decodeErrorInfo r `shouldSatisfy` \case
-            NotEnoughMoney {} -> True
+            NotEnoughMoney{} -> True
             _someOtherError -> False
 
     it "TRANS_ESTIMATE_07 - Deleted wallet" $ \ctx -> runResourceT $ do
         w <- emptyWallet ctx
-        _ <- request @ApiWallet ctx
-            (Link.deleteWallet @'Shelley w) Default Empty
+        _ <-
+            request @ApiWallet
+                ctx
+                (Link.deleteWallet @'Shelley w)
+                Default
+                Empty
         wDest <- emptyWallet ctx
         let minUTxOValue' = minUTxOValue (_mainEra ctx)
         payload <- mkTxPayload ctx wDest minUTxOValue' fixturePassphrase
-        r <- request @ApiFee ctx
-            (Link.getTransactionFeeOld @'Shelley w) Default payload
+        r <-
+            request @ApiFee
+                ctx
+                (Link.getTransactionFeeOld @'Shelley w)
+                Default
+                payload
         expectResponseCode HTTP.status404 r
         expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r
 
-    it "TRANS_LIST_01 - Can list Incoming and Outgoing transactions" $
-        \ctx -> runResourceT $ do
+    it "TRANS_LIST_01 - Can list Incoming and Outgoing transactions"
+        $ \ctx -> runResourceT $ do
+            -- Make tx from fixtureWallet
+            (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
+            addrs <- listAddresses @n ctx wDest
 
-        -- Make tx from fixtureWallet
-        (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
-        addrs <- listAddresses @n ctx wDest
-
-        let amt = minUTxOValue (_mainEra ctx) :: Natural
-        let destination = (addrs !! 1) ^. #id
-        let payload = Json [json|{
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
+            let destination = (addrs !! 1) ^. #id
+            let payload =
+                    Json
+                        [json|{
                 "payments": [{
                     "address": #{destination},
                     "amount": {
@@ -1458,28 +1732,40 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 "passphrase": "cardano-wallet"
             }|]
 
-        tx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSrc) Default payload
-        expectResponseCode HTTP.status202 tx
-        eventually "Wallet balance is as expected" $ do
-            rGet <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wDest) Default Empty
-            verify rGet
-                [ expectField
-                    (#balance . #total) (`shouldBe` ApiAmount amt)
-                , expectField
-                    (#balance . #available) (`shouldBe` ApiAmount amt)
+            tx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSrc)
+                    Default
+                    payload
+            expectResponseCode HTTP.status202 tx
+            eventually "Wallet balance is as expected" $ do
+                rGet <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley wDest)
+                        Default
+                        Empty
+                verify
+                    rGet
+                    [ expectField
+                        (#balance . #total)
+                        (`shouldBe` ApiAmount amt)
+                    , expectField
+                        (#balance . #available)
+                        (`shouldBe` ApiAmount amt)
+                    ]
+
+            -- Verify Tx list contains Incoming and Outgoing
+            let link = Link.listTransactions @'Shelley wSrc
+            r <- request @([ApiTransaction n]) ctx link Default Empty
+            expectResponseCode HTTP.status200 r
+
+            verify
+                r
+                [ expectListField 0 (#direction . #getApiT) (`shouldBe` Outgoing)
+                , expectListField 1 (#direction . #getApiT) (`shouldBe` Incoming)
                 ]
-
-        -- Verify Tx list contains Incoming and Outgoing
-        let link = Link.listTransactions @'Shelley wSrc
-        r <- request @([ApiTransaction n]) ctx link Default Empty
-        expectResponseCode HTTP.status200 r
-
-        verify r
-            [ expectListField 0 (#direction . #getApiT) (`shouldBe` Outgoing)
-            , expectListField 1 (#direction . #getApiT) (`shouldBe` Incoming)
-            ]
 
     -- This scenario covers the following matrix of cases. Cases were generated
     -- using one of pairwise test cases generation tools available online.
@@ -1509,363 +1795,393 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
     -- +---+----------+----------+------------+-----------+---------------+
     it "TRANS_LIST_02,03x - Can limit/order results with start, end and order"
         $ \ctx -> runResourceT $ do
-        let minUTxOValue' = minUTxOValue (_mainEra ctx)
-        let a1 = ApiAmount minUTxOValue'
-        let a2 = ApiAmount (2 * minUTxOValue')
-        (wSrc, w) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
-        -- post txs
-        let linkTx =
-                (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
-        _ <- postTx @n ctx linkTx w minUTxOValue'
-        verifyWalletBalance ctx w (ApiAmount minUTxOValue')
+            let minUTxOValue' = minUTxOValue (_mainEra ctx)
+            let a1 = ApiAmount minUTxOValue'
+            let a2 = ApiAmount (2 * minUTxOValue')
+            (wSrc, w) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
+            -- post txs
+            let linkTx =
+                    (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
+            _ <- postTx @n ctx linkTx w minUTxOValue'
+            verifyWalletBalance ctx w (ApiAmount minUTxOValue')
 
-        _ <- postTx @n ctx linkTx w (2 * minUTxOValue')
-        verifyWalletBalance ctx w (ApiAmount (3 * minUTxOValue'))
+            _ <- postTx @n ctx linkTx w (2 * minUTxOValue')
+            verifyWalletBalance ctx w (ApiAmount (3 * minUTxOValue'))
 
-        txs <- eventually "I make sure there are exactly 2 transactions" $ do
-            let linkList = Link.listTransactions' @'Shelley w
-                    Nothing
-                    Nothing
-                    Nothing
-                    Nothing
-                    Nothing
-                    Nothing
-            rl <- request @([ApiTransaction n]) ctx linkList Default Empty
-            verify rl [expectListSize 2]
-            pure (getFromResponse Prelude.id rl)
+            txs <- eventually "I make sure there are exactly 2 transactions" $ do
+                let linkList =
+                        Link.listTransactions' @'Shelley
+                            w
+                            Nothing
+                            Nothing
+                            Nothing
+                            Nothing
+                            Nothing
+                            Nothing
+                rl <- request @([ApiTransaction n]) ctx linkList Default Empty
+                verify rl [expectListSize 2]
+                pure (getFromResponse Prelude.id rl)
 
-        let [Just t2, Just t1] = fmap (fmap (view #time) . insertedAt) txs
-        let matrix :: [TestCase [ApiTransaction n]] =
-                [ TestCase -- 1
-                    { query = toQueryString
-                        [ ("start", utcIso8601ToText t1)
-                        , ("end", utcIso8601ToText t2)
-                        , ("order", "ascending")
-                        ]
-                    , assertions =
-                        [ expectListSize 2
-                        , expectListField 0 #amount (`shouldBe` a1)
-                        , expectListField 1 #amount (`shouldBe` a2)
-                        ]
-                    }
-                , TestCase -- 2
-                    { query = toQueryString
-                        [ ("start", utcIso8601ToText t1)
-                        , ("end", utcIso8601ToText $ plusDelta t2)
-                        , ("order", "descending")
-                        ]
-                    , assertions =
-                        [ expectListSize 2
-                        , expectListField 0 #amount (`shouldBe` a2)
-                        , expectListField 1 #amount (`shouldBe` a1)
-                        ]
-                    }
-                , TestCase -- 3
-                    { query = toQueryString
-                        [ ("start", utcIso8601ToText t1)
-                        , ("end", utcIso8601ToText $ minusDelta t2)
-                        ]
-                    , assertions =
-                        [ expectListSize 1
-                        , expectListField 0 #amount (`shouldBe` a1)
-                        ]
-                    }
-                , TestCase -- 4
-                    { query = toQueryString
-                        [ ("start", utcIso8601ToText t1) ]
-                    , assertions =
-                        [ expectListSize 2
-                        , expectListField 0 #amount (`shouldBe` a2)
-                        , expectListField 1 #amount (`shouldBe` a1)
-                        ]
-                    }
-                , TestCase --5
-                    { query = toQueryString
-                        [ ("start", utcIso8601ToText $ plusDelta t1)
-                        , ("end", utcIso8601ToText $ plusDelta t2)
-                        ]
-                    , assertions =
-                        [ expectListSize 1
-                        , expectListField 0 #amount (`shouldBe` a2)
-                        ]
-                    }
-                , TestCase -- 6
-                    { query = toQueryString
-                        [ ("start", utcIso8601ToText $ plusDelta t1)
-                        , ("end", utcIso8601ToText $ minusDelta t2)
-                        ]
-                    , assertions =
-                        [ expectListSize 0 ]
-                    }
-                , TestCase -- 7
-                    { query = toQueryString
-                        [ ("start", utcIso8601ToText $ plusDelta t1)
-                        , ("order", "ascending")
-                        ]
-                    , assertions =
-                        [ expectListSize 1
-                        , expectListField 0 #amount (`shouldBe` a2)
-                        ]
-                    }
-                , TestCase -- 8
-                    { query = toQueryString
-                        [ ("order", "descending")
-                        , ("start", utcIso8601ToText $ plusDelta t1)
-                        , ("end", utcIso8601ToText t2)
-                        ]
-                    , assertions =
-                        [ expectListSize 1
-                        , expectListField 0 #amount (`shouldBe` a2)
-                        ]
-                    }
-                , TestCase -- 9
-                    { query = toQueryString
-                        [ ("order", "ascending")
-                        , ("start", utcIso8601ToText $ minusDelta t1)
-                        , ("end", utcIso8601ToText $ minusDelta t2)
-                        ]
-                    , assertions =
-                        [ expectListSize 1
-                        , expectListField 0 #amount (`shouldBe` a1)
-                        ]
-                    }
-                , TestCase -- 10
-                    { query = toQueryString
-                        [ ("order", "descending")
-                        , ("start", utcIso8601ToText $ minusDelta t1)
-                        ]
-                    , assertions =
-                        [ expectListSize 2
-                        , expectListField 0 #amount (`shouldBe` a2)
-                        , expectListField 1 #amount (`shouldBe` a1)
-                        ]
-                    }
-                , TestCase -- 11
-                    { query = toQueryString
-                        [ ("start", utcIso8601ToText $ minusDelta t1)
-                        , ("end", utcIso8601ToText t2)
-                        ]
-                    , assertions =
-                        [ expectListSize 2
-                        , expectListField 0 #amount (`shouldBe` a2)
-                        , expectListField 1 #amount (`shouldBe` a1)
-                        ]
-                    }
-                , TestCase -- 12
-                    { query = toQueryString
-                        [ ("start", utcIso8601ToText $ minusDelta t1)
-                        , ("end", utcIso8601ToText $ plusDelta t2)
-                        ]
-                    , assertions =
-                        [ expectListSize 2
-                        , expectListField 0 #amount (`shouldBe` a2)
-                        , expectListField 1 #amount (`shouldBe` a1)
-                        ]
-                    }
-                , TestCase -- 13
-                    { query = mempty
-                    , assertions =
-                        [ expectListSize 2
-                        , expectListField 0 #amount (`shouldBe` a2)
-                        , expectListField 1 #amount (`shouldBe` a1)
-                        ]
-                    }
-                , TestCase -- 14
-                    { query = toQueryString
-                        [ ("end", utcIso8601ToText t2) ]
-                    , assertions =
-                        [ expectListSize 2
-                        , expectListField 0 #amount (`shouldBe` a2)
-                        , expectListField 1 #amount (`shouldBe` a1)
-                        ]
-                    }
-                , TestCase -- 15
-                    { query = toQueryString
-                        [ ("end", utcIso8601ToText $ plusDelta t2) ]
-                    , assertions =
-                        [ expectListSize 2
-                        , expectListField 0 #amount (`shouldBe` a2)
-                        , expectListField 1 #amount (`shouldBe` a1)
-                        ]
-                    }
-                , TestCase -- 16
-                    { query = toQueryString
-                        [ ("end", utcIso8601ToText $ minusDelta t2) ]
-                    , assertions =
-                        [ expectListSize 1
-                        , expectListField 0 #amount (`shouldBe` a1)
-                        ]
-                    }
-                , TestCase -- 17
-                    { query = toQueryString
-                        [ ("start", utcIso8601ToText t1)
-                        , ("end", utcIso8601ToText t1)
-                        ]
-                    , assertions =
-                        [ expectListSize 1
-                        , expectListField 0 #amount (`shouldBe` a1)
-                        ]
-                    }
-                , TestCase -- 18
-                    { query = toQueryString
-                        [ ("start", utcIso8601ToText t2)
-                        , ("end", utcIso8601ToText t2)
-                        ]
-                    , assertions =
-                        [ expectListSize 1
-                        , expectListField 0 #amount (`shouldBe` a2)
-                        ]
-                    }
-                , TestCase -- 19
-                    { query = toQueryString
-                        [ ("max_count", "1")
-                        ]
-                    , assertions =
-                        [ expectListSize 1
-                        , expectListField 0 #amount (`shouldBe` a2)
-                        ]
-                    }
-                , TestCase -- 20
-                    { query = toQueryString
-                        [ ("max_count", "1")
-                        , ("order", "ascending")
-                        ]
-                    , assertions =
-                        [ expectListSize 1
-                        , expectListField 0 #amount (`shouldBe` a1)
-                        ]
-                    }
-                ]
+            let [Just t2, Just t1] = fmap (fmap (view #time) . insertedAt) txs
+            let matrix :: [TestCase [ApiTransaction n]] =
+                    [ TestCase -- 1
+                        { query =
+                            toQueryString
+                                [ ("start", utcIso8601ToText t1)
+                                , ("end", utcIso8601ToText t2)
+                                , ("order", "ascending")
+                                ]
+                        , assertions =
+                            [ expectListSize 2
+                            , expectListField 0 #amount (`shouldBe` a1)
+                            , expectListField 1 #amount (`shouldBe` a2)
+                            ]
+                        }
+                    , TestCase -- 2
+                        { query =
+                            toQueryString
+                                [ ("start", utcIso8601ToText t1)
+                                , ("end", utcIso8601ToText $ plusDelta t2)
+                                , ("order", "descending")
+                                ]
+                        , assertions =
+                            [ expectListSize 2
+                            , expectListField 0 #amount (`shouldBe` a2)
+                            , expectListField 1 #amount (`shouldBe` a1)
+                            ]
+                        }
+                    , TestCase -- 3
+                        { query =
+                            toQueryString
+                                [ ("start", utcIso8601ToText t1)
+                                , ("end", utcIso8601ToText $ minusDelta t2)
+                                ]
+                        , assertions =
+                            [ expectListSize 1
+                            , expectListField 0 #amount (`shouldBe` a1)
+                            ]
+                        }
+                    , TestCase -- 4
+                        { query =
+                            toQueryString
+                                [("start", utcIso8601ToText t1)]
+                        , assertions =
+                            [ expectListSize 2
+                            , expectListField 0 #amount (`shouldBe` a2)
+                            , expectListField 1 #amount (`shouldBe` a1)
+                            ]
+                        }
+                    , TestCase -- 5
+                        { query =
+                            toQueryString
+                                [ ("start", utcIso8601ToText $ plusDelta t1)
+                                , ("end", utcIso8601ToText $ plusDelta t2)
+                                ]
+                        , assertions =
+                            [ expectListSize 1
+                            , expectListField 0 #amount (`shouldBe` a2)
+                            ]
+                        }
+                    , TestCase -- 6
+                        { query =
+                            toQueryString
+                                [ ("start", utcIso8601ToText $ plusDelta t1)
+                                , ("end", utcIso8601ToText $ minusDelta t2)
+                                ]
+                        , assertions =
+                            [expectListSize 0]
+                        }
+                    , TestCase -- 7
+                        { query =
+                            toQueryString
+                                [ ("start", utcIso8601ToText $ plusDelta t1)
+                                , ("order", "ascending")
+                                ]
+                        , assertions =
+                            [ expectListSize 1
+                            , expectListField 0 #amount (`shouldBe` a2)
+                            ]
+                        }
+                    , TestCase -- 8
+                        { query =
+                            toQueryString
+                                [ ("order", "descending")
+                                , ("start", utcIso8601ToText $ plusDelta t1)
+                                , ("end", utcIso8601ToText t2)
+                                ]
+                        , assertions =
+                            [ expectListSize 1
+                            , expectListField 0 #amount (`shouldBe` a2)
+                            ]
+                        }
+                    , TestCase -- 9
+                        { query =
+                            toQueryString
+                                [ ("order", "ascending")
+                                , ("start", utcIso8601ToText $ minusDelta t1)
+                                , ("end", utcIso8601ToText $ minusDelta t2)
+                                ]
+                        , assertions =
+                            [ expectListSize 1
+                            , expectListField 0 #amount (`shouldBe` a1)
+                            ]
+                        }
+                    , TestCase -- 10
+                        { query =
+                            toQueryString
+                                [ ("order", "descending")
+                                , ("start", utcIso8601ToText $ minusDelta t1)
+                                ]
+                        , assertions =
+                            [ expectListSize 2
+                            , expectListField 0 #amount (`shouldBe` a2)
+                            , expectListField 1 #amount (`shouldBe` a1)
+                            ]
+                        }
+                    , TestCase -- 11
+                        { query =
+                            toQueryString
+                                [ ("start", utcIso8601ToText $ minusDelta t1)
+                                , ("end", utcIso8601ToText t2)
+                                ]
+                        , assertions =
+                            [ expectListSize 2
+                            , expectListField 0 #amount (`shouldBe` a2)
+                            , expectListField 1 #amount (`shouldBe` a1)
+                            ]
+                        }
+                    , TestCase -- 12
+                        { query =
+                            toQueryString
+                                [ ("start", utcIso8601ToText $ minusDelta t1)
+                                , ("end", utcIso8601ToText $ plusDelta t2)
+                                ]
+                        , assertions =
+                            [ expectListSize 2
+                            , expectListField 0 #amount (`shouldBe` a2)
+                            , expectListField 1 #amount (`shouldBe` a1)
+                            ]
+                        }
+                    , TestCase -- 13
+                        { query = mempty
+                        , assertions =
+                            [ expectListSize 2
+                            , expectListField 0 #amount (`shouldBe` a2)
+                            , expectListField 1 #amount (`shouldBe` a1)
+                            ]
+                        }
+                    , TestCase -- 14
+                        { query =
+                            toQueryString
+                                [("end", utcIso8601ToText t2)]
+                        , assertions =
+                            [ expectListSize 2
+                            , expectListField 0 #amount (`shouldBe` a2)
+                            , expectListField 1 #amount (`shouldBe` a1)
+                            ]
+                        }
+                    , TestCase -- 15
+                        { query =
+                            toQueryString
+                                [("end", utcIso8601ToText $ plusDelta t2)]
+                        , assertions =
+                            [ expectListSize 2
+                            , expectListField 0 #amount (`shouldBe` a2)
+                            , expectListField 1 #amount (`shouldBe` a1)
+                            ]
+                        }
+                    , TestCase -- 16
+                        { query =
+                            toQueryString
+                                [("end", utcIso8601ToText $ minusDelta t2)]
+                        , assertions =
+                            [ expectListSize 1
+                            , expectListField 0 #amount (`shouldBe` a1)
+                            ]
+                        }
+                    , TestCase -- 17
+                        { query =
+                            toQueryString
+                                [ ("start", utcIso8601ToText t1)
+                                , ("end", utcIso8601ToText t1)
+                                ]
+                        , assertions =
+                            [ expectListSize 1
+                            , expectListField 0 #amount (`shouldBe` a1)
+                            ]
+                        }
+                    , TestCase -- 18
+                        { query =
+                            toQueryString
+                                [ ("start", utcIso8601ToText t2)
+                                , ("end", utcIso8601ToText t2)
+                                ]
+                        , assertions =
+                            [ expectListSize 1
+                            , expectListField 0 #amount (`shouldBe` a2)
+                            ]
+                        }
+                    , TestCase -- 19
+                        { query =
+                            toQueryString
+                                [ ("max_count", "1")
+                                ]
+                        , assertions =
+                            [ expectListSize 1
+                            , expectListField 0 #amount (`shouldBe` a2)
+                            ]
+                        }
+                    , TestCase -- 20
+                        { query =
+                            toQueryString
+                                [ ("max_count", "1")
+                                , ("order", "ascending")
+                                ]
+                        , assertions =
+                            [ expectListSize 1
+                            , expectListField 0 #amount (`shouldBe` a1)
+                            ]
+                        }
+                    ]
 
-        let withQuery q (method, link) = (method, link <> q)
+            let withQuery q (method, link) = (method, link <> q)
 
-        liftIO $ forM_ matrix $ \tc -> do
-            let link = withQuery (query tc) $ Link.listTransactions @'Shelley w
-            rf <- request @([ApiTransaction n]) ctx link Default Empty
-            verify rf (assertions tc)
+            liftIO $ forM_ matrix $ \tc -> do
+                let link = withQuery (query tc) $ Link.listTransactions @'Shelley w
+                rf <- request @([ApiTransaction n]) ctx link Default Empty
+                verify rf (assertions tc)
 
     describe "TRANS_LIST_02,03 - Faulty start, end, order values" $ do
-        let orderErr = "Please specify one of the following values:\
-            \ ascending, descending."
-        let startEndErr = "Expecting ISO 8601 date-and-time format\
-            \ (basic or extended), e.g. 2012-09-25T10:15:00Z."
+        let orderErr =
+                "Please specify one of the following values:\
+                \ ascending, descending."
+        let startEndErr =
+                "Expecting ISO 8601 date-and-time format\
+                \ (basic or extended), e.g. 2012-09-25T10:15:00Z."
         let queries :: [TestCase [ApiTransaction n]] =
-                [
-                  TestCase
-                    { query = toQueryString [ ("start", "2009") ]
+                [ TestCase
+                    { query = toQueryString [("start", "2009")]
                     , assertions =
-                             [ expectResponseCode HTTP.status400
-                             , expectErrorMessage startEndErr
-                             ]
-
+                        [ expectResponseCode HTTP.status400
+                        , expectErrorMessage startEndErr
+                        ]
                     }
-                 , TestCase
-                     { query = toQueryString
-                             [ ("start", "2012-09-25T10:15:00Z")
-                             , ("end", "2016-11-21")
-                             ]
-                     , assertions =
-                             [ expectResponseCode HTTP.status400
-                             , expectErrorMessage startEndErr
-                             ]
-
-                     }
-                 , TestCase
-                     { query = toQueryString
-                             [ ("start", "2012-09-25")
-                             , ("end", "2016-11-21T10:15:00Z")
-                             ]
-                     , assertions =
-                             [ expectResponseCode HTTP.status400
-                             , expectErrorMessage startEndErr
-                             ]
-
-                     }
-                 , TestCase
-                     { query = toQueryString
-                             [ ("end", "2012-09-25T10:15:00Z")
-                             , ("start", "2016-11-21")
-                             ]
-                     , assertions =
-                             [ expectResponseCode HTTP.status400
-                             , expectErrorMessage startEndErr
-                             ]
-
-                     }
-                 , TestCase
-                     { query = toQueryString [ ("order", "scending") ]
-                     , assertions =
-                            [ expectResponseCode HTTP.status400
-                            , expectErrorMessage orderErr
+                , TestCase
+                    { query =
+                        toQueryString
+                            [ ("start", "2012-09-25T10:15:00Z")
+                            , ("end", "2016-11-21")
                             ]
-
-                     }
-                 , TestCase
-                     { query = toQueryString
-                             [ ("start", "2012-09-25T10:15:00Z")
-                             , ("order", "asc")
-                             ]
-                     , assertions =
-                             [ expectResponseCode HTTP.status400
-                             , expectErrorMessage orderErr
-                             ]
-                     }
+                    , assertions =
+                        [ expectResponseCode HTTP.status400
+                        , expectErrorMessage startEndErr
+                        ]
+                    }
+                , TestCase
+                    { query =
+                        toQueryString
+                            [ ("start", "2012-09-25")
+                            , ("end", "2016-11-21T10:15:00Z")
+                            ]
+                    , assertions =
+                        [ expectResponseCode HTTP.status400
+                        , expectErrorMessage startEndErr
+                        ]
+                    }
+                , TestCase
+                    { query =
+                        toQueryString
+                            [ ("end", "2012-09-25T10:15:00Z")
+                            , ("start", "2016-11-21")
+                            ]
+                    , assertions =
+                        [ expectResponseCode HTTP.status400
+                        , expectErrorMessage startEndErr
+                        ]
+                    }
+                , TestCase
+                    { query = toQueryString [("order", "scending")]
+                    , assertions =
+                        [ expectResponseCode HTTP.status400
+                        , expectErrorMessage orderErr
+                        ]
+                    }
+                , TestCase
+                    { query =
+                        toQueryString
+                            [ ("start", "2012-09-25T10:15:00Z")
+                            , ("order", "asc")
+                            ]
+                    , assertions =
+                        [ expectResponseCode HTTP.status400
+                        , expectErrorMessage orderErr
+                        ]
+                    }
                 ]
 
         let withQuery q (method, link) = (method, link <> q)
 
-        forM_ queries $ \tc -> it (T.unpack $ query tc) $
-            \ctx -> runResourceT $ do
+        forM_ queries $ \tc -> it (T.unpack $ query tc)
+            $ \ctx -> runResourceT $ do
                 w <- emptyWallet ctx
-                let link = withQuery (query tc) $
-                        Link.listTransactions @'Shelley w
+                let link =
+                        withQuery (query tc)
+                            $ Link.listTransactions @'Shelley w
                 r <- request @([ApiTransaction n]) ctx link Default Empty
                 liftIO $ verify r (assertions tc)
 
-    it "TRANS_LIST_02 - Start time shouldn't be later than end time" $
-        \ctx -> runResourceT $ do
+    it "TRANS_LIST_02 - Start time shouldn't be later than end time"
+        $ \ctx -> runResourceT $ do
             w <- emptyWallet ctx
             let startTime = "2009-09-09T09:09:09Z"
             let endTime = "2001-01-01T01:01:01Z"
-            let link = Link.listTransactions' @'Shelley w
-                    Nothing
-                    (either (const Nothing) Just $ fromText $ T.pack startTime)
-                    (either (const Nothing) Just $ fromText $ T.pack endTime)
-                    Nothing
-                    Nothing
-                    Nothing
+            let link =
+                    Link.listTransactions' @'Shelley
+                        w
+                        Nothing
+                        (either (const Nothing) Just $ fromText $ T.pack startTime)
+                        (either (const Nothing) Just $ fromText $ T.pack endTime)
+                        Nothing
+                        Nothing
+                        Nothing
             r <- request @([ApiTransaction n]) ctx link Default Empty
             expectResponseCode HTTP.status400 r
             expectErrorMessage
-                (errMsg400StartTimeLaterThanEndTime startTime endTime) r
+                (errMsg400StartTimeLaterThanEndTime startTime endTime)
+                r
             pure ()
 
-    it "TRANS_LIST_03 - Minimum withdrawal shouldn't be 0" $
-        \ctx -> runResourceT $ do
+    it "TRANS_LIST_03 - Minimum withdrawal shouldn't be 0"
+        $ \ctx -> runResourceT $ do
             w <- emptyWallet ctx
-            let link = Link.listTransactions' @'Shelley w
-                    (Just 0)
-                    Nothing
-                    Nothing
-                    Nothing
-                    Nothing
-                    Nothing
+            let link =
+                    Link.listTransactions' @'Shelley
+                        w
+                        (Just 0)
+                        Nothing
+                        Nothing
+                        Nothing
+                        Nothing
+                        Nothing
             r <- request @([ApiTransaction n]) ctx link Default Empty
             expectResponseCode HTTP.status400 r
             expectErrorMessage errMsg400MinWithdrawalWrong r
             pure ()
 
-    it "TRANS_LIST_03 - \
-        \Minimum withdrawal can be 1, shows empty when no withdrawals" $
-        \ctx -> runResourceT $ do
+    it
+        "TRANS_LIST_03 - \
+        \Minimum withdrawal can be 1, shows empty when no withdrawals"
+        $ \ctx -> runResourceT $ do
             w <- emptyWallet ctx
-            let link = Link.listTransactions' @'Shelley w
-                    (Just 1)
-                    Nothing
-                    Nothing
-                    Nothing
-                    Nothing
-                    Nothing
+            let link =
+                    Link.listTransactions' @'Shelley
+                        w
+                        (Just 1)
+                        Nothing
+                        Nothing
+                        Nothing
+                        Nothing
+                        Nothing
             r <- request @([ApiTransaction n]) ctx link Default Empty
             expectResponseCode HTTP.status200 r
             let txs = getFromResponse Prelude.id r
@@ -1873,114 +2189,193 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
     it "TRANS_LIST_04 - Deleted wallet" $ \ctx -> runResourceT $ do
         w <- emptyWallet ctx
-        _ <- request @ApiWallet ctx
-            (Link.deleteWallet @'Shelley w) Default Empty
-        r <- request @([ApiTransaction n]) ctx
-            (Link.listTransactions @'Shelley w)
-            Default Empty
+        _ <-
+            request @ApiWallet
+                ctx
+                (Link.deleteWallet @'Shelley w)
+                Default
+                Empty
+        r <-
+            request @([ApiTransaction n])
+                ctx
+                (Link.listTransactions @'Shelley w)
+                Default
+                Empty
         expectResponseCode HTTP.status404 r
         expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r
 
-    it "TRANS_LIST_RANGE_01 - \
-       \Transaction at time t is SELECTED by small ranges that cover it" $
-          \ctx -> runResourceT $ do
-              w <- fixtureWalletWith @n ctx [minUTxOValue (_mainEra ctx) ]
-              t <- unsafeGetTransactionTime =<< listAllTransactions @n ctx w
-              let (te, tl) = (utcTimePred t, utcTimeSucc t)
-              txs1 <- listTransactions @n ctx w (Just t ) (Just t ) Nothing
-                Nothing
-              txs2 <- listTransactions @n ctx w (Just te) (Just t ) Nothing
-                Nothing
-              txs3 <- listTransactions @n ctx w (Just t ) (Just tl) Nothing
-                Nothing
-              txs4 <- listTransactions @n ctx w (Just te) (Just tl) Nothing
-                Nothing
-              length <$> [txs1, txs2, txs3, txs4] `shouldSatisfy` all (== 1)
+    it
+        "TRANS_LIST_RANGE_01 - \
+        \Transaction at time t is SELECTED by small ranges that cover it"
+        $ \ctx -> runResourceT $ do
+            w <- fixtureWalletWith @n ctx [minUTxOValue (_mainEra ctx)]
+            t <- unsafeGetTransactionTime =<< listAllTransactions @n ctx w
+            let (te, tl) = (utcTimePred t, utcTimeSucc t)
+            txs1 <-
+                listTransactions @n
+                    ctx
+                    w
+                    (Just t)
+                    (Just t)
+                    Nothing
+                    Nothing
+            txs2 <-
+                listTransactions @n
+                    ctx
+                    w
+                    (Just te)
+                    (Just t)
+                    Nothing
+                    Nothing
+            txs3 <-
+                listTransactions @n
+                    ctx
+                    w
+                    (Just t)
+                    (Just tl)
+                    Nothing
+                    Nothing
+            txs4 <-
+                listTransactions @n
+                    ctx
+                    w
+                    (Just te)
+                    (Just tl)
+                    Nothing
+                    Nothing
+            length <$> [txs1, txs2, txs3, txs4] `shouldSatisfy` all (== 1)
 
-    it "TRANS_LIST_RANGE_02 - \
-       \Transaction at time t is NOT selected by range (t + 𝛿t, ...)" $
-          \ctx -> runResourceT $ do
-              w <- fixtureWalletWith @n ctx [minUTxOValue (_mainEra ctx)]
-              t <- unsafeGetTransactionTime =<< listAllTransactions @n ctx w
-              let tl = utcTimeSucc t
-              txs1 <- listTransactions @n ctx w (Just tl) (Nothing) Nothing
-                Nothing
-              txs2 <- listTransactions @n ctx w (Just tl) (Just tl) Nothing
-                Nothing
-              length <$> [txs1, txs2] `shouldSatisfy` all (== 0)
+    it
+        "TRANS_LIST_RANGE_02 - \
+        \Transaction at time t is NOT selected by range (t + 𝛿t, ...)"
+        $ \ctx -> runResourceT $ do
+            w <- fixtureWalletWith @n ctx [minUTxOValue (_mainEra ctx)]
+            t <- unsafeGetTransactionTime =<< listAllTransactions @n ctx w
+            let tl = utcTimeSucc t
+            txs1 <-
+                listTransactions @n
+                    ctx
+                    w
+                    (Just tl)
+                    (Nothing)
+                    Nothing
+                    Nothing
+            txs2 <-
+                listTransactions @n
+                    ctx
+                    w
+                    (Just tl)
+                    (Just tl)
+                    Nothing
+                    Nothing
+            length <$> [txs1, txs2] `shouldSatisfy` all (== 0)
 
-    it "TRANS_LIST_RANGE_03 - \
-       \Transaction at time t is NOT selected by range (..., t - 𝛿t)" $
-          \ctx -> runResourceT $ do
-              w <- fixtureWalletWith @n ctx [minUTxOValue (_mainEra ctx) ]
-              t <- unsafeGetTransactionTime =<< listAllTransactions @n ctx w
-              let te = utcTimePred t
-              txs1 <- listTransactions @n ctx w (Nothing) (Just te) Nothing
-                Nothing
-              txs2 <- listTransactions @n ctx w (Just te) (Just te) Nothing
-                Nothing
-              length <$> [txs1, txs2] `shouldSatisfy` all (== 0)
+    it
+        "TRANS_LIST_RANGE_03 - \
+        \Transaction at time t is NOT selected by range (..., t - 𝛿t)"
+        $ \ctx -> runResourceT $ do
+            w <- fixtureWalletWith @n ctx [minUTxOValue (_mainEra ctx)]
+            t <- unsafeGetTransactionTime =<< listAllTransactions @n ctx w
+            let te = utcTimePred t
+            txs1 <-
+                listTransactions @n
+                    ctx
+                    w
+                    (Nothing)
+                    (Just te)
+                    Nothing
+                    Nothing
+            txs2 <-
+                listTransactions @n
+                    ctx
+                    w
+                    (Just te)
+                    (Just te)
+                    Nothing
+                    Nothing
+            length <$> [txs1, txs2] `shouldSatisfy` all (== 0)
 
-    it "TRANS_LIST_LIMIT_01 - \
-       \Transactions can be limited" $
-          \ctx -> runResourceT $ do
-              w <- fixtureWallet ctx
-              txs <- listLimitedTransactions @n ctx w 9
-              length txs `shouldBe` 9
+    it
+        "TRANS_LIST_LIMIT_01 - \
+        \Transactions can be limited"
+        $ \ctx -> runResourceT $ do
+            w <- fixtureWallet ctx
+            txs <- listLimitedTransactions @n ctx w 9
+            length txs `shouldBe` 9
 
-    it "TRANS_GET_01 - Can get Incoming and Outgoing transaction" $
-        \ctx -> runResourceT $ do
-
-        (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
-        -- post tx
-        let amt = minUTxOValue (_mainEra ctx) :: Natural
-        rMkTx <- postTx @n ctx
-            (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
-            wDest
-            amt
-        let txid = getFromResponse #id rMkTx
-        verify rMkTx
-            [ expectSuccess
-            , expectResponseCode HTTP.status202
-            , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-            , expectField (#status . #getApiT) (`shouldBe` Pending)
-            ]
-
-        eventually "Wallet balance is as expected" $ do
-            rGet <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wDest) Default Empty
-            verify rGet
-                [ expectField
-                        (#balance . #total) (`shouldBe` ApiAmount amt)
-                , expectField
-                        (#balance . #available) (`shouldBe` ApiAmount amt)
-                ]
-
-        eventually "Transactions are available and in ledger" $ do
-            -- Verify Tx in source wallet is Outgoing and InLedger
-            let linkSrc = Link.getTransaction @'Shelley
-                    wSrc (ApiTxId txid)
-            r1 <- request @(ApiTransaction n) ctx linkSrc Default Empty
-            verify r1
-                [ expectResponseCode HTTP.status200
+    it "TRANS_GET_01 - Can get Incoming and Outgoing transaction"
+        $ \ctx -> runResourceT $ do
+            (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
+            -- post tx
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
+            rMkTx <-
+                postTx @n
+                    ctx
+                    (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
+                    wDest
+                    amt
+            let txid = getFromResponse #id rMkTx
+            verify
+                rMkTx
+                [ expectSuccess
+                , expectResponseCode HTTP.status202
                 , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-                , expectField (#status . #getApiT) (`shouldBe` InLedger)
+                , expectField (#status . #getApiT) (`shouldBe` Pending)
                 ]
 
-            -- Verify Tx in destination wallet is Incoming and InLedger
-            let linkDest = Link.getTransaction
-                    @'Shelley wDest (ApiTxId txid)
-            r2 <- request @(ApiTransaction n) ctx linkDest Default Empty
-            verify r2
-                [ expectResponseCode HTTP.status200
-                , expectField (#direction . #getApiT) (`shouldBe` Incoming)
-                , expectField (#status . #getApiT) (`shouldBe` InLedger)
-                ]
+            eventually "Wallet balance is as expected" $ do
+                rGet <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley wDest)
+                        Default
+                        Empty
+                verify
+                    rGet
+                    [ expectField
+                        (#balance . #total)
+                        (`shouldBe` ApiAmount amt)
+                    , expectField
+                        (#balance . #available)
+                        (`shouldBe` ApiAmount amt)
+                    ]
+
+            eventually "Transactions are available and in ledger" $ do
+                -- Verify Tx in source wallet is Outgoing and InLedger
+                let linkSrc =
+                        Link.getTransaction @'Shelley
+                            wSrc
+                            (ApiTxId txid)
+                r1 <- request @(ApiTransaction n) ctx linkSrc Default Empty
+                verify
+                    r1
+                    [ expectResponseCode HTTP.status200
+                    , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+                    , expectField (#status . #getApiT) (`shouldBe` InLedger)
+                    ]
+
+                -- Verify Tx in destination wallet is Incoming and InLedger
+                let linkDest =
+                        Link.getTransaction
+                            @'Shelley
+                            wDest
+                            (ApiTxId txid)
+                r2 <- request @(ApiTransaction n) ctx linkDest Default Empty
+                verify
+                    r2
+                    [ expectResponseCode HTTP.status200
+                    , expectField (#direction . #getApiT) (`shouldBe` Incoming)
+                    , expectField (#status . #getApiT) (`shouldBe` InLedger)
+                    ]
 
     it "TRANS_GET_02 - Deleted wallet" $ \ctx -> runResourceT $ do
         w <- emptyWallet ctx
-        _ <- request @ApiWallet
-            ctx (Link.deleteWallet @'Shelley w) Default Empty
+        _ <-
+            request @ApiWallet
+                ctx
+                (Link.deleteWallet @'Shelley w)
+                Default
+                Empty
         let txid = ApiT $ Hash $ BS.pack $ replicate 32 1
         let link = Link.getTransaction @'Shelley w (ApiTxId txid)
         r <- request @(ApiTransaction n) ctx link Default Empty
@@ -1991,149 +2386,195 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
         -- post tx
         let amt = minUTxOValue (_mainEra ctx) :: Natural
-        rMkTx <- postTx @n ctx
-            (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
-            wDest
-            amt
-        verify rMkTx
+        rMkTx <-
+            postTx @n
+                ctx
+                (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
+                wDest
+                amt
+        verify
+            rMkTx
             [ expectSuccess
             , expectResponseCode HTTP.status202
             , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
             , expectField (#status . #getApiT) (`shouldBe` Pending)
             ]
 
-        let txid =  Hash $ BS.pack $ replicate 32 1
-        let link = Link.getTransaction @'Shelley
-                wSrc (ApiTxId $ ApiT txid)
+        let txid = Hash $ BS.pack $ replicate 32 1
+        let link =
+                Link.getTransaction @'Shelley
+                    wSrc
+                    (ApiTxId $ ApiT txid)
         r <- request @(ApiTransaction n) ctx link Default Empty
         expectResponseCode HTTP.status404 r
         expectErrorMessage (errMsg404CannotFindTx $ toText txid) r
 
-    it "TRANS_GET_04 - Sumbitted transactions result in pending state" $
-        \ctx -> runResourceT $ do
+    it "TRANS_GET_04 - Sumbitted transactions result in pending state"
+        $ \ctx -> runResourceT $ do
+            (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
+            -- post tx
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
+            rMkTx <-
+                postTx @n
+                    ctx
+                    (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
+                    wDest
+                    amt
+            verify
+                rMkTx
+                [ expectSuccess
+                , expectResponseCode HTTP.status202
+                , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+                , expectField (#status . #getApiT) (`shouldBe` Pending)
+                ]
 
-        (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
-        -- post tx
-        let amt = minUTxOValue (_mainEra ctx) :: Natural
-        rMkTx <- postTx @n ctx
-            (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
-            wDest
-            amt
-        verify rMkTx
-            [ expectSuccess
-            , expectResponseCode HTTP.status202
-            , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-            , expectField (#status . #getApiT) (`shouldBe` Pending)
-            ]
+    it
+        "TRANS_DELETE_01 -\
+        \ Shelley: Can forget pending transaction"
+        $ \ctx -> runResourceT $ do
+            (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
+            -- post tx
+            let amt = minUTxOValue (_mainEra ctx) :: Natural
+            rMkTx <-
+                postTx @n
+                    ctx
+                    (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
+                    wDest
+                    amt
+            let txid = getFromResponse #id rMkTx
+            verify
+                rMkTx
+                [ expectSuccess
+                , expectResponseCode HTTP.status202
+                , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+                , expectField (#status . #getApiT) (`shouldBe` Pending)
+                ]
 
-    it "TRANS_DELETE_01 -\
-        \ Shelley: Can forget pending transaction" $ \ctx -> runResourceT $ do
-        (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
-        -- post tx
-        let amt = minUTxOValue (_mainEra ctx) :: Natural
-        rMkTx <- postTx @n ctx
-            (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
-            wDest
-            amt
-        let txid = getFromResponse #id rMkTx
-        verify rMkTx
-            [ expectSuccess
-            , expectResponseCode HTTP.status202
-            , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-            , expectField (#status . #getApiT) (`shouldBe` Pending)
-            ]
+            -- forget transaction
+            (statusDelete, _) <-
+                request @ApiTxId
+                    ctx
+                    (Link.deleteTransaction @'Shelley wSrc (ApiTxId txid))
+                    Default
+                    Empty
+            rBalance <-
+                getFromResponse (#balance . #total)
+                    <$> request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley wSrc)
+                        Default
+                        Empty
 
-        -- forget transaction
-        (statusDelete, _) <- request @ApiTxId ctx
-            (Link.deleteTransaction @'Shelley wSrc (ApiTxId txid)) Default Empty
-        rBalance <- getFromResponse (#balance . #total)
-            <$> request @ApiWallet
-                ctx (Link.getWallet @'Shelley wSrc) Default Empty
+            let assertSourceTx = do
+                    let ep = Link.listTransactions @'Shelley wSrc
+                    request @[ApiTransaction n] ctx ep Default Empty
+                        >>= flip
+                            verify
+                            [ expectListField
+                                0
+                                (#direction . #getApiT)
+                                (`shouldBe` Outgoing)
+                            , expectListField
+                                0
+                                (#status . #getApiT)
+                                (`shouldBe` InLedger)
+                            ]
 
-        let assertSourceTx = do
-                let ep = Link.listTransactions @'Shelley wSrc
-                request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
-                    [ expectListField 0
-                        (#direction . #getApiT) (`shouldBe` Outgoing)
-                    , expectListField 0
-                        (#status . #getApiT) (`shouldBe` InLedger)
-                    ]
-
-        -- We cannot guarantee that we're able to forget the tx before it is
-        -- accepted. The slot length is really fast in the integration tests.
-        --
-        -- As a workaround we also pass if the tx is already accepted.
-        case (statusDelete, rBalance) of
-            (s, balance)
-                | s == HTTP.status204 && balance == ApiAmount faucetAmt ->
-                    eventually "transaction eventually is in source wallet"
+            -- We cannot guarantee that we're able to forget the tx before it is
+            -- accepted. The slot length is really fast in the integration tests.
+            --
+            -- As a workaround we also pass if the tx is already accepted.
+            case (statusDelete, rBalance) of
+                (s, balance)
+                    | s == HTTP.status204 && balance == ApiAmount faucetAmt ->
+                        eventually
+                            "transaction eventually is in source wallet"
+                            assertSourceTx
+                    | s == HTTP.status204 && balance < ApiAmount faucetAmt ->
+                        liftIO assertSourceTx
+                    | s == HTTP.status403 -> liftIO $ do
                         assertSourceTx
-                | s == HTTP.status204 && balance < ApiAmount faucetAmt ->
-                    liftIO assertSourceTx
-                | s == HTTP.status403 -> liftIO $ do
-                    assertSourceTx
-                    balance .< ApiAmount faucetAmt
-            _ ->
-                expectationFailure $ "invalid combination of results: "
-                    <> show statusDelete
-                    <> ", wallet balance="
-                    <> show rBalance
+                        balance .< ApiAmount faucetAmt
+                _ ->
+                    expectationFailure
+                        $ "invalid combination of results: "
+                            <> show statusDelete
+                            <> ", wallet balance="
+                            <> show rBalance
 
-        eventually "transaction eventually is in target wallet" $ do
-            let ep = Link.listTransactions @'Shelley wDest
-            request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
-                [ expectListField 0
-                    (#direction . #getApiT) (`shouldBe` Incoming)
-                , expectListField 0
-                    (#status . #getApiT) (`shouldBe` InLedger)
-                ]
+            eventually "transaction eventually is in target wallet" $ do
+                let ep = Link.listTransactions @'Shelley wDest
+                request @[ApiTransaction n] ctx ep Default Empty
+                    >>= flip
+                        verify
+                        [ expectListField
+                            0
+                            (#direction . #getApiT)
+                            (`shouldBe` Incoming)
+                        , expectListField
+                            0
+                            (#status . #getApiT)
+                            (`shouldBe` InLedger)
+                        ]
 
-    it "TRANS_DELETE_02 -\
-        \ Shelley: Cannot forget tx that is already in ledger" $
-        \ctx -> runResourceT $ do
+    it
+        "TRANS_DELETE_02 -\
+        \ Shelley: Cannot forget tx that is already in ledger"
+        $ \ctx -> runResourceT $ do
+            (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
 
-        (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
+            -- post transaction
+            rTx <-
+                postTx @n
+                    ctx
+                    (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
+                    wDest
+                    (minUTxOValue (_mainEra ctx) :: Natural)
+            let txid = getFromResponse #id rTx
 
-        -- post transaction
-        rTx <-
-            postTx @n ctx
-            (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
-            wDest
-            (minUTxOValue (_mainEra ctx) :: Natural)
-        let txid = getFromResponse #id rTx
+            eventually "Transaction is accepted" $ do
+                let ep = Link.listTransactions @'Shelley wSrc
+                request @([ApiTransaction n]) ctx ep Default Empty
+                    >>= flip
+                        verify
+                        [ expectListField
+                            0
+                            (#direction . #getApiT)
+                            (`shouldBe` Outgoing)
+                        , expectListField
+                            0
+                            (#status . #getApiT)
+                            (`shouldBe` InLedger)
+                        ]
 
-        eventually "Transaction is accepted" $ do
-            let ep = Link.listTransactions @'Shelley wSrc
-            request @([ApiTransaction n]) ctx ep Default Empty >>= flip verify
-                [ expectListField 0
-                    (#direction . #getApiT) (`shouldBe` Outgoing)
-                , expectListField 0
-                    (#status . #getApiT) (`shouldBe` InLedger)
-                ]
-
-        -- Try Forget transaction once it's no longer pending
-        let ep = Link.deleteTransaction @'Shelley wSrc (ApiTxId txid)
-        rDel <- request @ApiTxId ctx ep Default Empty
-        expectResponseCode HTTP.status403 rDel
-        let err = errMsg403AlreadyInLedger (toUrlPiece (ApiTxId txid))
-        expectErrorMessage err rDel
+            -- Try Forget transaction once it's no longer pending
+            let ep = Link.deleteTransaction @'Shelley wSrc (ApiTxId txid)
+            rDel <- request @ApiTxId ctx ep Default Empty
+            expectResponseCode HTTP.status403 rDel
+            let err = errMsg403AlreadyInLedger (toUrlPiece (ApiTxId txid))
+            expectErrorMessage err rDel
 
     describe "TRANS_DELETE_03 - checking no transaction id error for " $ do
         txDeleteNotExistsingTxIdTest emptyWallet "wallets"
         txDeleteNotExistsingTxIdTest emptyRandomWallet "byron-wallets"
 
-    describe "TRANS_DELETE_06 -\
-        \ Cannot forget tx that is performed from different wallet" $ do
-        txDeleteFromDifferentWalletTest emptyWallet "wallets"
-        txDeleteFromDifferentWalletTest emptyRandomWallet "byron-wallets"
+    describe
+        "TRANS_DELETE_06 -\
+        \ Cannot forget tx that is performed from different wallet"
+        $ do
+            txDeleteFromDifferentWalletTest emptyWallet "wallets"
+            txDeleteFromDifferentWalletTest emptyRandomWallet "byron-wallets"
 
-    it "SHELLEY_TX_REDEEM_01 - Can redeem rewards from self" $
-        \ctx -> runResourceT $ do
+    it "SHELLEY_TX_REDEEM_01 - Can redeem rewards from self"
+        $ \ctx -> runResourceT $ do
+            noConway ctx "MIR"
 
-        (wSrc,_) <- rewardWallet ctx
-        addr:_ <- fmap (view #id) <$> listAddresses @n ctx wSrc
+            (wSrc, _) <- rewardWallet ctx
+            addr : _ <- fmap (view #id) <$> listAddresses @n ctx wSrc
 
-        let payload = Json [json|{
+            let payload =
+                    Json
+                        [json|{
                 "withdrawal": "self",
                 "payments": [{
                     "address": #{addr},
@@ -2144,31 +2585,47 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 }],
                 "passphrase": #{fixturePassphrase}
             }|]
-        rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSrc) Default payload
-        verify rTx
-            [ expectResponseCode HTTP.status202
-            , expectField #withdrawals
-                (`shouldSatisfy` (not . null))
-            ]
-
-        eventually "rewards are transferred from self to self" $ do
-            rW <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wSrc) Default payload
-            verify rW
-                [ expectField (#balance . #available)
-                    (.> (wSrc ^. #balance . #available))
-                , expectField (#balance . #reward)
-                    (`shouldBe` ApiAmount 0)
+            rTx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSrc)
+                    Default
+                    payload
+            verify
+                rTx
+                [ expectResponseCode HTTP.status202
+                , expectField
+                    #withdrawals
+                    (`shouldSatisfy` (not . null))
                 ]
 
-    it "SHELLEY_TX_REDEEM_02 - Can redeem rewards from other" $
-        \ctx -> runResourceT $ do
-        (wOther, SomeMnemonic mw) <- rewardWallet ctx
-        wSelf  <- fixtureWallet ctx
-        addr:_ <- fmap (view #id) <$> listAddresses @n ctx wSelf
+            eventually "rewards are transferred from self to self" $ do
+                rW <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley wSrc)
+                        Default
+                        payload
+                verify
+                    rW
+                    [ expectField
+                        (#balance . #available)
+                        (.> (wSrc ^. #balance . #available))
+                    , expectField
+                        (#balance . #reward)
+                        (`shouldBe` ApiAmount 0)
+                    ]
 
-        let payload = Json [json|{
+    it "SHELLEY_TX_REDEEM_02 - Can redeem rewards from other"
+        $ \ctx -> runResourceT $ do
+            noConway ctx "MIR"
+            (wOther, SomeMnemonic mw) <- rewardWallet ctx
+            wSelf <- fixtureWallet ctx
+            addr : _ <- fmap (view #id) <$> listAddresses @n ctx wSelf
+
+            let payload =
+                    Json
+                        [json|{
                 "withdrawal": #{mnemonicToText mw},
                 "payments": [{
                     "address": #{addr},
@@ -2179,82 +2636,124 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 }],
                 "passphrase": #{fixturePassphrase}
             }|]
-        (_, ApiFee (ApiAmount estimatedFeeMin) (ApiAmount estimatedFeeMax) _ _)
-            <- unsafeRequest ctx
-                (Link.getTransactionFeeOld @'Shelley wSelf) payload
+            (_, ApiFee (ApiAmount estimatedFeeMin) (ApiAmount estimatedFeeMax) _ _) <-
+                unsafeRequest
+                    ctx
+                    (Link.getTransactionFeeOld @'Shelley wSelf)
+                    payload
 
-        rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSelf) Default payload
-        let ApiAmount fee = getFromResponse #fee rTx
-        verify rTx
-            [ expectResponseCode HTTP.status202
-            , expectField #withdrawals
-                (`shouldSatisfy` (not . null))
-            , expectField (#direction . #getApiT)
-                (`shouldBe` Incoming)
-            , expectField (#amount . #toNatural)
-                (`shouldBe` (oneMillionAda - fee))
-
-            -- TODO: Drop https://cardanofoundation.atlassian.net/browse/ADP-2935
-            , expectField (#fee . #toNatural)
-                (between (estimatedFeeMin, estimatedFeeMax))
-            ]
-        let tid = getFromResponse Prelude.id rTx
-
-        eventually "rewards disappear from other" $ do
-            rWOther <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wOther) Default payload
-            verify rWOther
-                [ expectField (#balance . #reward)
-                    (`shouldBe` ApiAmount 0)
-                ]
-
-        eventually "withdrawal transaction is listed on other" $ do
-            rTxOther <- request @(ApiTransaction n) ctx
-                (Link.getTransaction @'Shelley wOther tid) Default payload
-            verify rTxOther
-                [ expectResponseCode
-                    HTTP.status200
-                , expectField #withdrawals
+            rTx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSelf)
+                    Default
+                    payload
+            let ApiAmount fee = getFromResponse #fee rTx
+            verify
+                rTx
+                [ expectResponseCode HTTP.status202
+                , expectField
+                    #withdrawals
                     (`shouldSatisfy` (not . null))
-                , expectField (#direction . #getApiT)
-                    (`shouldBe` Outgoing)
-                , expectField (#amount . #toNatural)
-                    (`shouldBe` oneMillionAda)
-                ]
-
-        eventually "rewards appear on self" $ do
-            rWSelf <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wSelf) Default payload
-            verify rWSelf
-                [ expectField (#balance . #available)
-                    (.> (wSelf ^. #balance . #available))
-                ]
-
-        eventually "withdrawal transaction is listed on self" $ do
-            rTxSelf <- request @(ApiTransaction n) ctx
-                (Link.getTransaction  @'Shelley wSelf tid) Default payload
-            verify rTxSelf
-                [ expectResponseCode
-                    HTTP.status200
-                , expectField #withdrawals
-                    (`shouldSatisfy` (not . null))
-                , expectField (#direction . #getApiT)
+                , expectField
+                    (#direction . #getApiT)
                     (`shouldBe` Incoming)
-                , expectField (#amount . #toNatural)
+                , expectField
+                    (#amount . #toNatural)
                     (`shouldBe` (oneMillionAda - fee))
-                , expectField (#status . #getApiT)
-                    (`shouldBe` InLedger)
+                , -- TODO: Drop https://cardanofoundation.atlassian.net/browse/ADP-2935
+                  expectField
+                    (#fee . #toNatural)
+                    (between (estimatedFeeMin, estimatedFeeMax))
                 ]
+            let tid = getFromResponse Prelude.id rTx
 
-    it "SHELLEY_TX_REDEEM_03 - Can't redeem rewards from other if none left" $
-        \ctx -> runResourceT $ do
+            eventually "rewards disappear from other" $ do
+                rWOther <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley wOther)
+                        Default
+                        payload
+                verify
+                    rWOther
+                    [ expectField
+                        (#balance . #reward)
+                        (`shouldBe` ApiAmount 0)
+                    ]
 
-        (wOther, SomeMnemonic mw) <- rewardWallet ctx
-        wSelf  <- fixtureWallet ctx
-        addr:_ <- fmap (view #id) <$> listAddresses @n ctx wSelf
+            eventually "withdrawal transaction is listed on other" $ do
+                rTxOther <-
+                    request @(ApiTransaction n)
+                        ctx
+                        (Link.getTransaction @'Shelley wOther tid)
+                        Default
+                        payload
+                verify
+                    rTxOther
+                    [ expectResponseCode
+                        HTTP.status200
+                    , expectField
+                        #withdrawals
+                        (`shouldSatisfy` (not . null))
+                    , expectField
+                        (#direction . #getApiT)
+                        (`shouldBe` Outgoing)
+                    , expectField
+                        (#amount . #toNatural)
+                        (`shouldBe` oneMillionAda)
+                    ]
 
-        let payload = Json [json|{
+            eventually "rewards appear on self" $ do
+                rWSelf <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley wSelf)
+                        Default
+                        payload
+                verify
+                    rWSelf
+                    [ expectField
+                        (#balance . #available)
+                        (.> (wSelf ^. #balance . #available))
+                    ]
+
+            eventually "withdrawal transaction is listed on self" $ do
+                rTxSelf <-
+                    request @(ApiTransaction n)
+                        ctx
+                        (Link.getTransaction @'Shelley wSelf tid)
+                        Default
+                        payload
+                verify
+                    rTxSelf
+                    [ expectResponseCode
+                        HTTP.status200
+                    , expectField
+                        #withdrawals
+                        (`shouldSatisfy` (not . null))
+                    , expectField
+                        (#direction . #getApiT)
+                        (`shouldBe` Incoming)
+                    , expectField
+                        (#amount . #toNatural)
+                        (`shouldBe` (oneMillionAda - fee))
+                    , expectField
+                        (#status . #getApiT)
+                        (`shouldBe` InLedger)
+                    ]
+
+    it "SHELLEY_TX_REDEEM_03 - Can't redeem rewards from other if none left"
+        $ \ctx -> runResourceT $ do
+            noConway ctx "MIR"
+
+            (wOther, SomeMnemonic mw) <- rewardWallet ctx
+            wSelf <- fixtureWallet ctx
+            addr : _ <- fmap (view #id) <$> listAddresses @n ctx wSelf
+
+            let payload =
+                    Json
+                        [json|{
                 "withdrawal": #{mnemonicToText mw},
                 "payments": [{
                     "address": #{addr},
@@ -2266,32 +2765,48 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 "passphrase": #{fixturePassphrase}
             }|]
 
-        -- Withdraw rewards from the other wallet.
-        _ <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSelf) Default payload
-        eventually "rewards disappear from other" $ do
-            rWOther <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wOther) Default payload
-            verify rWOther
-                [ expectField (#balance . #reward)
-                    (`shouldBe` ApiAmount 0)
+            -- Withdraw rewards from the other wallet.
+            _ <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSelf)
+                    Default
+                    payload
+            eventually "rewards disappear from other" $ do
+                rWOther <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley wOther)
+                        Default
+                        payload
+                verify
+                    rWOther
+                    [ expectField
+                        (#balance . #reward)
+                        (`shouldBe` ApiAmount 0)
+                    ]
+
+            -- Try withdrawing AGAIN, rewards that aren't there anymore.
+            rTx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSelf)
+                    Default
+                    payload
+            verify
+                rTx
+                [ expectResponseCode HTTP.status403
+                , expectErrorMessage errMsg403WithdrawalNotBeneficial
                 ]
 
-        -- Try withdrawing AGAIN, rewards that aren't there anymore.
-        rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSelf) Default payload
-        verify rTx
-            [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403WithdrawalNotBeneficial
-            ]
+    it "SHELLEY_TX_REDEEM_04 - Can always ask for self redemption"
+        $ \ctx -> runResourceT $ do
+            wSelf <- fixtureWallet ctx
+            addr : _ <- fmap (view #id) <$> listAddresses @n ctx wSelf
 
-    it "SHELLEY_TX_REDEEM_04 - Can always ask for self redemption" $
-        \ctx -> runResourceT $ do
-
-        wSelf <- fixtureWallet ctx
-        addr:_ <- fmap (view #id) <$> listAddresses @n ctx wSelf
-
-        let payload = Json [json|{
+            let payload =
+                    Json
+                        [json|{
                 "withdrawal": "self",
                 "payments": [{
                     "address": #{addr},
@@ -2303,21 +2818,27 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 "passphrase": #{fixturePassphrase}
             }|]
 
-        rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSelf) Default payload
-        verify rTx
-            [ expectResponseCode HTTP.status202
-            , expectField #withdrawals (`shouldSatisfy` null)
-            ]
+            rTx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSelf)
+                    Default
+                    payload
+            verify
+                rTx
+                [ expectResponseCode HTTP.status202
+                , expectField #withdrawals (`shouldSatisfy` null)
+                ]
 
-    it "SHELLEY_TX_REDEEM_05 - Can't redeem rewards from unknown key" $
-        \ctx -> runResourceT $ do
+    it "SHELLEY_TX_REDEEM_05 - Can't redeem rewards from unknown key"
+        $ \ctx -> runResourceT $ do
+            wSelf <- fixtureWallet ctx
+            addr : _ <- fmap (view #id) <$> listAddresses @n ctx wSelf
 
-        wSelf  <- fixtureWallet ctx
-        addr:_ <- fmap (view #id) <$> listAddresses @n ctx wSelf
-
-        mw <- liftIO $ entropyToMnemonic <$> genEntropy @160
-        let payload = Json [json|{
+            mw <- liftIO $ entropyToMnemonic <$> genEntropy @160
+            let payload =
+                    Json
+                        [json|{
                 "withdrawal": #{mnemonicToText mw},
                 "payments": [{
                     "address": #{addr},
@@ -2329,20 +2850,26 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 "passphrase": #{fixturePassphrase}
             }|]
 
-        rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSelf) Default payload
-        verify rTx
-            [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403WithdrawalNotBeneficial
-            ]
+            rTx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSelf)
+                    Default
+                    payload
+            verify
+                rTx
+                [ expectResponseCode HTTP.status403
+                , expectErrorMessage errMsg403WithdrawalNotBeneficial
+                ]
 
-    it "SHELLEY_TX_REDEEM_06 - Can't redeem rewards using byron wallet" $
-        \ctx -> runResourceT $ do
+    it "SHELLEY_TX_REDEEM_06 - Can't redeem rewards using byron wallet"
+        $ \ctx -> runResourceT $ do
+            (wSelf, addrs) <- fixtureIcarusWalletAddrs @n ctx
+            let addr = encodeAddress (sNetworkId @n) (head addrs)
 
-        (wSelf, addrs) <- fixtureIcarusWalletAddrs @n ctx
-        let addr = encodeAddress (sNetworkId @n) (head addrs)
-
-        let payload = Json [json|{
+            let payload =
+                    Json
+                        [json|{
                 "withdrawal": "self",
                 "payments": [{
                     "address": #{addr},
@@ -2354,21 +2881,29 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 "passphrase": #{fixturePassphrase}
             }|]
 
-        rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Byron wSelf) Default payload
-        verify rTx
-            [ expectResponseCode HTTP.status403
-            ]
-        decodeErrorInfo rTx `shouldBe` InvalidWalletType
+            rTx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Byron wSelf)
+                    Default
+                    payload
+            verify
+                rTx
+                [ expectResponseCode HTTP.status403
+                ]
+            decodeErrorInfo rTx `shouldBe` InvalidWalletType
 
-    it "SHELLEY_TX_REDEEM_06a - Can't redeem rewards if utxo = 0 from other" $
-        \ctx -> runResourceT $ do
+    it "SHELLEY_TX_REDEEM_06a - Can't redeem rewards if utxo = 0 from other"
+        $ \ctx -> runResourceT $ do
+            noConway ctx "MIR"
 
-        (_, SomeMnemonic mw) <- rewardWallet ctx
-        wSelf  <- emptyWallet ctx
-        addr:_ <- fmap (view #id) <$> listAddresses @n ctx wSelf
+            (_, SomeMnemonic mw) <- rewardWallet ctx
+            wSelf <- emptyWallet ctx
+            addr : _ <- fmap (view #id) <$> listAddresses @n ctx wSelf
 
-        let payload = Json [json|{
+            let payload =
+                    Json
+                        [json|{
                 "withdrawal": #{mnemonicToText mw},
                 "payments": [{
                     "address": #{addr},
@@ -2380,40 +2915,55 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 "passphrase": #{fixturePassphrase}
             }|]
 
-        -- Try withdrawing when no UTxO on a wallet
-        rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSelf) Default payload
-        verify rTx [expectResponseCode HTTP.status403]
-        decodeErrorInfo rTx `shouldBe` NoUtxosAvailable
+            -- Try withdrawing when no UTxO on a wallet
+            rTx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSelf)
+                    Default
+                    payload
+            verify rTx [expectResponseCode HTTP.status403]
+            decodeErrorInfo rTx `shouldBe` NoUtxosAvailable
 
-    it "SHELLEY_TX_REDEEM_06b - Can't redeem rewards if utxo = 0 from self" $
-        \ctx -> runResourceT $ do
+    it "SHELLEY_TX_REDEEM_06b - Can't redeem rewards if utxo = 0 from self"
+        $ \ctx -> runResourceT $ do
+            noConway ctx "MIR"
 
-        liftIO $ pendingWith "Migration endpoints temporarily disabled"
-        (wRewards, SomeMnemonic mw) <- rewardWallet ctx
-        wOther  <- emptyWallet ctx
+            liftIO $ pendingWith "Migration endpoints temporarily disabled"
+            (wRewards, SomeMnemonic mw) <- rewardWallet ctx
+            wOther <- emptyWallet ctx
 
-        -- migrate all utxo from rewards wallet
-        addr:_ <- fmap (view #id) <$> listAddresses @n ctx wOther
-        let payloadMigr = Json [json|{
+            -- migrate all utxo from rewards wallet
+            addr : _ <- fmap (view #id) <$> listAddresses @n ctx wOther
+            let payloadMigr =
+                    Json
+                        [json|{
                 "passphrase": #{fixturePassphrase},
                 "addresses": [#{addr}]
             }|]
 
-        let ep = Link.migrateWallet @'Shelley wRewards
-        rM <- request @[ApiTransaction n] ctx ep Default payloadMigr
-        expectResponseCode HTTP.status202 rM
+            let ep = Link.migrateWallet @'Shelley wRewards
+            rM <- request @[ApiTransaction n] ctx ep Default payloadMigr
+            expectResponseCode HTTP.status202 rM
 
-        eventually "No UTxO is on rewards wallet" $ do
-            rWOther <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wRewards) Default Empty
-            verify rWOther
-                [ expectField (#balance . #available)
-                    (`shouldBe` ApiAmount 0)
-                ]
+            eventually "No UTxO is on rewards wallet" $ do
+                rWOther <-
+                    request @ApiWallet
+                        ctx
+                        (Link.getWallet @'Shelley wRewards)
+                        Default
+                        Empty
+                verify
+                    rWOther
+                    [ expectField
+                        (#balance . #available)
+                        (`shouldBe` ApiAmount 0)
+                    ]
 
-        -- Try withdrawing when no UTxO on a wallet
-        let payload = Json [json|{
+            -- Try withdrawing when no UTxO on a wallet
+            let payload =
+                    Json
+                        [json|{
                 "withdrawal": #{mnemonicToText mw},
                 "payments": [{
                     "address": #{addr},
@@ -2421,22 +2971,29 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 }],
                 "passphrase": #{fixturePassphrase}
             }|]
-        rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wRewards) Default payload
-        verify rTx [expectResponseCode HTTP.status403]
-        decodeErrorInfo rTx `shouldSatisfy` \case
-            NotEnoughMoney {} -> True
-            _someOtherError -> False
+            rTx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wRewards)
+                    Default
+                    payload
+            verify rTx [expectResponseCode HTTP.status403]
+            decodeErrorInfo rTx `shouldSatisfy` \case
+                NotEnoughMoney{} -> True
+                _someOtherError -> False
 
-    it "SHELLEY_TX_REDEEM_07a - Can't redeem rewards if cannot cover fee" $
-        \ctx -> runResourceT $ do
+    it "SHELLEY_TX_REDEEM_07a - Can't redeem rewards if cannot cover fee"
+        $ \ctx -> runResourceT $ do
+            noConway ctx "MIR"
 
-        (_, SomeMnemonic mw) <- rewardWallet ctx
-        wSelf  <- fixtureWalletWith @n ctx [oneThousandAda]
-        addr:_ <- fmap (view #id) <$> listAddresses @n ctx wSelf
-        let amt = oneThousandAda + oneMillionAda
+            (_, SomeMnemonic mw) <- rewardWallet ctx
+            wSelf <- fixtureWalletWith @n ctx [oneThousandAda]
+            addr : _ <- fmap (view #id) <$> listAddresses @n ctx wSelf
+            let amt = oneThousandAda + oneMillionAda
 
-        let payload = Json [json|{
+            let payload =
+                    Json
+                        [json|{
                 "withdrawal": #{mnemonicToText mw},
                 "payments": [{
                     "address": #{addr},
@@ -2445,23 +3002,30 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 "passphrase": #{fixturePassphrase}
             }|]
 
-        -- Try withdrawing when cannot cover fee
-        rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSelf) Default payload
-        verify rTx
-            [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403Fee
-            ]
+            -- Try withdrawing when cannot cover fee
+            rTx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSelf)
+                    Default
+                    payload
+            verify
+                rTx
+                [ expectResponseCode HTTP.status403
+                , expectErrorMessage errMsg403Fee
+                ]
 
-    it "SHELLEY_TX_REDEEM_07b - Can't redeem rewards if not enough money" $
-        \ctx -> runResourceT $ do
+    it "SHELLEY_TX_REDEEM_07b - Can't redeem rewards if not enough money"
+        $ \ctx -> runResourceT $ do
+            noConway ctx "redeem rewards"
+            (_, SomeMnemonic mw) <- rewardWallet ctx
+            wSelf <- fixtureWalletWith @n ctx [oneThousandAda]
+            addr : _ <- fmap (view #id) <$> listAddresses @n ctx wSelf
+            let amt = oneThousandAda + oneMillionAda + oneAda
 
-        (_, SomeMnemonic mw) <- rewardWallet ctx
-        wSelf  <- fixtureWalletWith @n ctx [oneThousandAda]
-        addr:_ <- fmap (view #id) <$> listAddresses @n ctx wSelf
-        let amt = oneThousandAda + oneMillionAda + oneAda
-
-        let payload = Json [json|{
+            let payload =
+                    Json
+                        [json|{
                 "withdrawal": #{mnemonicToText mw},
                 "payments": [{
                     "address": #{addr},
@@ -2470,13 +3034,17 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 "passphrase": #{fixturePassphrase}
             }|]
 
-        -- Try withdrawing when no not enough money
-        rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wSelf) Default payload
-        verify rTx [expectResponseCode HTTP.status403]
-        decodeErrorInfo rTx `shouldSatisfy` \case
-            NotEnoughMoney {} -> True
-            _someOtherError -> False
+            -- Try withdrawing when no not enough money
+            rTx <-
+                request @(ApiTransaction n)
+                    ctx
+                    (Link.createTransactionOld @'Shelley wSelf)
+                    Default
+                    payload
+            verify rTx [expectResponseCode HTTP.status403]
+            decodeErrorInfo rTx `shouldSatisfy` \case
+                NotEnoughMoney{} -> True
+                _someOtherError -> False
   where
     spec_createTransactionWithMetadata
         :: CreateTransactionWithMetadataTest
@@ -2488,169 +3056,207 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 , txMetadata
                 , expectedFee
                 } = testData
-        in it testName $ \ctx -> runResourceT $ do
+        in  it testName $ \ctx -> runResourceT $ do
+                when (_mainEra ctx < ApiBabbage)
+                    $ liftIO
+                    $ pendingWith
+                        "expected fees have been updated to Babbage and these \
+                        \tests marked pending on earlier eras."
 
-        when (_mainEra ctx < ApiBabbage) $
-            liftIO $ pendingWith
-                "expected fees have been updated to Babbage and these \
-                \tests marked pending on earlier eras."
+                let maybeAddTxMetadata =
+                        maybe
+                            (Prelude.id)
+                            (addTxMetadata . Aeson.toJSON . ApiT)
+                            (txMetadata)
 
-        let maybeAddTxMetadata = maybe
-                (Prelude.id)
-                (addTxMetadata . Aeson.toJSON . ApiT)
-                (txMetadata)
+                (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
 
-        (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
+                let minUTxOValue' = minUTxOValue (_mainEra ctx)
+                let outputQuantities = txOutputAdaQuantities minUTxOValue'
+                let paymentCount = length outputQuantities
+                targetAddresses <-
+                    take paymentCount
+                        . fmap (view #id)
+                        <$> listAddresses @n ctx wb
+                let targetAssets = repeat mempty
+                let payments =
+                        NE.fromList
+                            $ map ($ mempty)
+                            $ zipWith
+                                (AddressAmount)
+                                (targetAddresses)
+                                (ApiAmount <$> outputQuantities)
+                let outputs =
+                        zipWith3
+                            ApiCoinSelectionOutput
+                            (targetAddresses)
+                            (ApiAmount <$> outputQuantities)
+                            (targetAssets)
 
-        let minUTxOValue' = minUTxOValue (_mainEra ctx)
-        let outputQuantities = txOutputAdaQuantities minUTxOValue'
-        let paymentCount = length outputQuantities
-        targetAddresses <- take paymentCount .
-            fmap (view #id) <$> listAddresses @n ctx wb
-        let targetAssets = repeat mempty
-        let payments = NE.fromList $ map ($ mempty) $ zipWith
-                (AddressAmount)
-                (targetAddresses)
-                (ApiAmount <$> outputQuantities)
-        let outputs = zipWith3
-                ApiCoinSelectionOutput
-                (targetAddresses)
-                (ApiAmount <$> outputQuantities)
-                (targetAssets)
+                -- First, perform a dry-run selection using the 'selectCoins' endpoint.
+                -- This will allow us to confirm that the 'selectCoins' endpoint
+                -- produces a selection whose fee is similar to the selection
+                -- produced by the 'postTransaction' endpoint.
+                coinSelectionResponse <-
+                    selectCoinsWith @n @'Shelley ctx wa payments maybeAddTxMetadata
+                verify
+                    coinSelectionResponse
+                    [ expectResponseCode HTTP.status200
+                    , expectField
+                        #inputs
+                        (`shouldSatisfy` (not . null))
+                    , expectField
+                        #outputs
+                        (`shouldSatisfy` ((Set.fromList outputs ==) . Set.fromList))
+                    , expectField
+                        #change
+                        (`shouldSatisfy` (not . null))
+                    ]
 
-        -- First, perform a dry-run selection using the 'selectCoins' endpoint.
-        -- This will allow us to confirm that the 'selectCoins' endpoint
-        -- produces a selection whose fee is similar to the selection
-        -- produced by the 'postTransaction' endpoint.
-        coinSelectionResponse <-
-            selectCoinsWith @n @'Shelley ctx wa payments maybeAddTxMetadata
-        verify coinSelectionResponse
-            [ expectResponseCode HTTP.status200
-            , expectField #inputs
-                (`shouldSatisfy` (not . null))
-            , expectField #outputs
-                (`shouldSatisfy` ((Set.fromList outputs ==) . Set.fromList))
-            , expectField #change
-                (`shouldSatisfy` (not . null))
-            ]
+                let apiCoinSelection = getFromResponse Prelude.id coinSelectionResponse
+                let fee = computeApiCoinSelectionFee apiCoinSelection
+                let withinToleranceTo (ApiAmount expected) tol =
+                        between (ApiAmount $ expected - tol, ApiAmount $ expected + tol)
 
-        let apiCoinSelection = getFromResponse Prelude.id coinSelectionResponse
-        let fee = computeApiCoinSelectionFee apiCoinSelection
-        let withinToleranceTo (ApiAmount expected) tol =
-                between (ApiAmount $ expected - tol, ApiAmount $ expected + tol)
-
-        -- Some tolerance is needed as 'selectCoins' doesn't make room for a
-        -- validity interval / TTL, whereas 'postTransaction' does. We seem to
-        -- need 6 bytes / 600 lovelace, but using a bit more to rule out
-        -- flakiness from variable size encoding of slot numbers.
-        --
-        --
-        -- TODO Consider replacing with golden tests on the unit level
-        -- for fee values.
-        --
-        -- Related to https://cardanofoundation.atlassian.net/browse/ADP-2935
-        liftIO $ withinToleranceTo
-            expectedFee
-            1_000
-            (ApiAmount.fromCoin fee)
-
-        -- Next, actually create a transaction and submit it to the network.
-        -- This transaction should have a fee that is identical to the fee
-        -- of the dry-run coin selection produced in the previous step.
-        let payload = Json [json|
-                { "payments": #{payments}
-                , "passphrase": #{fixturePassphrase}
-                , "metadata": #{ApiT <$> txMetadata}
-                }|]
-        ra <- request @(ApiTransaction n) ctx
-            (Link.createTransactionOld @'Shelley wa) Default payload
-
-        verify ra
-            [ expectSuccess
-            , expectResponseCode HTTP.status202
-            , expectField (#status . #getApiT) (`shouldBe` Pending)
-            , expectField
-                #metadata
-                (`shouldBe` detailedMetadata <$> txMetadata)
-            , expectField
-                #fee
-                (withinToleranceTo expectedFee 1_000)
-                -- Rule out flakiness from variable size of slot numbers.
+                -- Some tolerance is needed as 'selectCoins' doesn't make room for a
+                -- validity interval / TTL, whereas 'postTransaction' does. We seem to
+                -- need 6 bytes / 600 lovelace, but using a bit more to rule out
+                -- flakiness from variable size encoding of slot numbers.
+                --
                 --
                 -- TODO Consider replacing with golden tests on the unit level
                 -- for fee values.
                 --
                 -- Related to https://cardanofoundation.atlassian.net/browse/ADP-2935
-            ]
+                liftIO
+                    $ withinToleranceTo
+                        expectedFee
+                        1_000
+                        (ApiAmount.fromCoin fee)
 
-        eventually "metadata is confirmed in transaction list" $ do
-            -- on src wallet
-            let linkSrcList = Link.listTransactions @'Shelley wa
-            rla <- request @([ApiTransaction n]) ctx linkSrcList Default Empty
-            verify rla
-                [ expectResponseCode HTTP.status200
-                , expectListField 0
-                    (#status . #getApiT) (`shouldBe` InLedger)
-                , expectListField 0
-                    (#direction . #getApiT) (`shouldBe` Outgoing)
-                , expectListField 0
-                    (#metadata )
-                    (`shouldBe` detailedMetadata <$> txMetadata)
-                ]
-            -- on dst wallet
-            let linkDstList = Link.listTransactions @'Shelley wb
-            rlb <- request @([ApiTransaction n]) ctx linkDstList Default Empty
-            verify rlb
-                [ expectResponseCode HTTP.status200
-                , expectListField 0
-                    (#status . #getApiT) (`shouldBe` InLedger)
-                , expectListField 0
-                    (#direction . #getApiT) (`shouldBe` Incoming)
-                , expectListField 0
-                    (#metadata )
-                    (`shouldBe` detailedMetadata <$> txMetadata)
-                ]
+                -- Next, actually create a transaction and submit it to the network.
+                -- This transaction should have a fee that is identical to the fee
+                -- of the dry-run coin selection produced in the previous step.
+                let payload =
+                        Json
+                            [json|
+                { "payments": #{payments}
+                , "passphrase": #{fixturePassphrase}
+                , "metadata": #{ApiT <$> txMetadata}
+                }|]
+                ra <-
+                    request @(ApiTransaction n)
+                        ctx
+                        (Link.createTransactionOld @'Shelley wa)
+                        Default
+                        payload
 
-        let txid = getFromResponse #id ra
-        eventually "metadata is confirmed in transaction get" $ do
-          -- on src wallet
-            let linkSrc = Link.getTransaction @'Shelley wa (ApiTxId txid)
-            rg1 <- request @(ApiTransaction n) ctx linkSrc Default Empty
-            verify rg1
-                [ expectResponseCode HTTP.status200
-                , expectField
-                    (#direction . #getApiT) (`shouldBe` Outgoing)
-                , expectField
-                    (#status . #getApiT) (`shouldBe` InLedger)
-                , expectField
-                    #metadata
-                    (`shouldBe` detailedMetadata <$> txMetadata)
-                ]
-          -- on dst wallet
-            let linkDst = Link.getTransaction @'Shelley wb (ApiTxId txid)
-            rg2 <- request @(ApiTransaction n) ctx linkDst Default Empty
-            verify rg2
-                [ expectResponseCode HTTP.status200
-                , expectField
-                    (#direction . #getApiT) (`shouldBe` Incoming)
-                , expectField
-                    (#status . #getApiT) (`shouldBe` InLedger)
-                , expectField
-                    #metadata
-                    (`shouldBe` detailedMetadata <$> txMetadata)
-                ]
+                verify
+                    ra
+                    [ expectSuccess
+                    , expectResponseCode HTTP.status202
+                    , expectField (#status . #getApiT) (`shouldBe` Pending)
+                    , expectField
+                        #metadata
+                        (`shouldBe` detailedMetadata <$> txMetadata)
+                    , expectField
+                        #fee
+                        (withinToleranceTo expectedFee 1_000)
+                        -- Rule out flakiness from variable size of slot numbers.
+                        --
+                        -- TODO Consider replacing with golden tests on the unit level
+                        -- for fee values.
+                        --
+                        -- Related to https://cardanofoundation.atlassian.net/browse/ADP-2935
+                    ]
+
+                eventually "metadata is confirmed in transaction list" $ do
+                    -- on src wallet
+                    let linkSrcList = Link.listTransactions @'Shelley wa
+                    rla <- request @([ApiTransaction n]) ctx linkSrcList Default Empty
+                    verify
+                        rla
+                        [ expectResponseCode HTTP.status200
+                        , expectListField
+                            0
+                            (#status . #getApiT)
+                            (`shouldBe` InLedger)
+                        , expectListField
+                            0
+                            (#direction . #getApiT)
+                            (`shouldBe` Outgoing)
+                        , expectListField
+                            0
+                            (#metadata)
+                            (`shouldBe` detailedMetadata <$> txMetadata)
+                        ]
+                    -- on dst wallet
+                    let linkDstList = Link.listTransactions @'Shelley wb
+                    rlb <- request @([ApiTransaction n]) ctx linkDstList Default Empty
+                    verify
+                        rlb
+                        [ expectResponseCode HTTP.status200
+                        , expectListField
+                            0
+                            (#status . #getApiT)
+                            (`shouldBe` InLedger)
+                        , expectListField
+                            0
+                            (#direction . #getApiT)
+                            (`shouldBe` Incoming)
+                        , expectListField
+                            0
+                            (#metadata)
+                            (`shouldBe` detailedMetadata <$> txMetadata)
+                        ]
+
+                let txid = getFromResponse #id ra
+                eventually "metadata is confirmed in transaction get" $ do
+                    -- on src wallet
+                    let linkSrc = Link.getTransaction @'Shelley wa (ApiTxId txid)
+                    rg1 <- request @(ApiTransaction n) ctx linkSrc Default Empty
+                    verify
+                        rg1
+                        [ expectResponseCode HTTP.status200
+                        , expectField
+                            (#direction . #getApiT)
+                            (`shouldBe` Outgoing)
+                        , expectField
+                            (#status . #getApiT)
+                            (`shouldBe` InLedger)
+                        , expectField
+                            #metadata
+                            (`shouldBe` detailedMetadata <$> txMetadata)
+                        ]
+                    -- on dst wallet
+                    let linkDst = Link.getTransaction @'Shelley wb (ApiTxId txid)
+                    rg2 <- request @(ApiTransaction n) ctx linkDst Default Empty
+                    verify
+                        rg2
+                        [ expectResponseCode HTTP.status200
+                        , expectField
+                            (#direction . #getApiT)
+                            (`shouldBe` Incoming)
+                        , expectField
+                            (#status . #getApiT)
+                            (`shouldBe` InLedger)
+                        , expectField
+                            #metadata
+                            (`shouldBe` detailedMetadata <$> txMetadata)
+                        ]
 
     txDeleteNotExistsingTxIdTest eWallet resource =
         it resource $ \ctx -> runResourceT $ do
             w <- eWallet ctx
             let walId = w ^. walletId
             let txid = "3e6ec12da4414aa0781ff8afa9717ae53ee8cb4aa55d622f65bc62619a4f7b12"
-            let endpoint = "v2/"
-                    <> T.pack resource
-                    <> "/"
-                    <> walId
-                    <> "/transactions/"
-                    <> txid
+            let endpoint =
+                    "v2/"
+                        <> T.pack resource
+                        <> "/"
+                        <> walId
+                        <> "/transactions/"
+                        <> txid
             ra <- request @ApiTxId ctx ("DELETE", endpoint) Default Empty
             expectResponseCode HTTP.status404 ra
             expectErrorMessage (errMsg404CannotFindTx txid) ra
@@ -2664,18 +3270,24 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         it resource $ \ctx -> runResourceT $ do
             -- post tx
             (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
-            rMkTx <- postTx @n ctx
-                (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
-                wDest
-                (minUTxOValue (_mainEra ctx) :: Natural)
+            rMkTx <-
+                postTx @n
+                    ctx
+                    (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
+                    wDest
+                    (minUTxOValue (_mainEra ctx) :: Natural)
 
             -- try to forget from different wallet
             wDifferent <- eWallet ctx
             let txid = toText $ getApiT $ getFromResponse #id rMkTx
-            let endpoint = "v2/" <> T.pack resource <> "/"
-                     <> wDifferent ^. walletId
-                     <> "/transactions/"
-                     <> txid
+            let endpoint =
+                    "v2/"
+                        <> T.pack resource
+                        <> "/"
+                        <> wDifferent
+                        ^. walletId
+                        <> "/transactions/"
+                        <> txid
             ra <- request @ApiTxId ctx ("DELETE", endpoint) Default Empty
             expectResponseCode HTTP.status404 ra
             expectErrorMessage (errMsg404CannotFindTx txid) ra
@@ -2688,17 +3300,26 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         -> m ()
     verifyWalletBalance ctx wallet amt = do
         eventually "Wallet Ada balance is as expected" $ do
-            rGet <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wallet) Default Empty
-            verify rGet
+            rGet <-
+                request @ApiWallet
+                    ctx
+                    (Link.getWallet @'Shelley wallet)
+                    Default
+                    Empty
+            verify
+                rGet
                 [ expectField
-                    (#balance . #total) (`shouldBe` amt)
+                    (#balance . #total)
+                    (`shouldBe` amt)
                 , expectField
-                    (#balance . #available) (`shouldBe` amt)
+                    (#balance . #available)
+                    (`shouldBe` amt)
                 , expectField
-                    (#assets . #total) (`shouldBe` mempty)
+                    (#assets . #total)
+                    (`shouldBe` mempty)
                 , expectField
-                    (#assets . #available) (`shouldBe` mempty)
+                    (#assets . #available)
+                    (`shouldBe` mempty)
                 ]
 
     -- Construct a JSON payment request for the given quantity of lovelace.
@@ -2712,7 +3333,9 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
     mkTxPayload ctx wDest amt passphrase = do
         addrs <- listAddresses @n ctx wDest
         let destination = (addrs !! 1) ^. #id
-        return $ Json [json|{
+        return
+            $ Json
+                [json|{
                 "payments": [{
                     "address": #{destination},
                     "amount": {
@@ -2751,8 +3374,9 @@ data CreateTransactionWithMetadataTest = CreateTransactionWithMetadataTest
     { testName
         :: String
     , txOutputAdaQuantities
-        :: Natural -> [Natural]
-        -- ^ Takes `minUTxOValue` as argument.
+        :: Natural
+        -> [Natural]
+    -- ^ Takes `minUTxOValue` as argument.
     , txMetadata
         :: Maybe TxMetadata
     , expectedFee

--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -298,6 +298,7 @@ import Test.Integration.Framework.DSL
     , json
     , listAddresses
     , minUTxOValue
+    , noConway
     , notDelegating
     , notRetiringPools
     , pickAnAsset
@@ -577,6 +578,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 ]
 
     it "TRANS_NEW_CREATE_03a - Withdrawal from self" $ \ctx -> runResourceT $ do
+        noConway ctx "MIR"
         (wa, _) <- rewardWallet ctx
         let withdrawal = Json [json|{ "withdrawal": "self" }|]
         let withdrawalAmt = 1_000_000_000_000
@@ -647,7 +649,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             ]
 
     it "TRANS_NEW_CREATE_04a - Single Output Transaction with decode transaction" $ \ctx -> runResourceT $ do
-
+        noConway ctx "MIR"
         let initialAmt = 3 * minUTxOValue (_mainEra ctx)
         wa <- fixtureWalletWith @n ctx [initialAmt]
         wb <- emptyWallet ctx
@@ -2371,6 +2373,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
     it "TRANS_NEW_BALANCE_02a - Cannot balance on empty wallet" $
         \ctx -> runResourceT $ do
+        noConway ctx "wrong era"
         wa <- emptyWallet ctx
         let balancePayload = Json PlutusScenario.pingPong_1
         request @ApiSerialisedTransaction
@@ -2382,6 +2385,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
     it "TRANS_NEW_BALANCE_02b - Cannot balance when I cannot afford fee" $
         \ctx -> runResourceT $ do
+        noConway ctx "wrong era"
         wa <- fixtureWalletWith @n ctx [2 * 1_000_000]
         let balancePayload = Json PlutusScenario.pingPong_1
         rTx <- request @ApiSerialisedTransaction ctx
@@ -2579,6 +2583,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
     it "TRANS_NEW_BALANCE_05/ADP-1286 - \
         \I can balance correctly in case I need to spend my remaining ADA for fee" $
         \ctx -> runResourceT $ do
+        noConway ctx "wrong era"
         wa <- fixtureWalletWith @n ctx [3_000_000]
         -- PlutusScenario.pingPong_1 is sending out 2₳ therefore tx fee
         -- needs to be 1₳ to comply with minUTxOValue constraint
@@ -2652,8 +2657,9 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             ]
 
     it "TRANS_NEW_SIGN_03 - Sign withdrawals" $ \ctx -> runResourceT $ do
+        noConway ctx "MIR"
         (w, _) <- rewardWallet ctx
-
+        noConway ctx "wrong era"
         -- Construct tx
         let payload = Json [json|{"withdrawal": "self"}|]
         let constructEndpoint = Link.createUnsignedTransaction @'Shelley w
@@ -2956,7 +2962,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             foldM_ runStep txid steps
 
     it "TRANS_NEW_JOIN_01a - Can join stakepool, rejoin another and quit" $ \ctx -> runResourceT $ do
-
+        noConway ctx "certificate"
         let initialAmt = 10 * minUTxOValue (_mainEra ctx)
         src <- fixtureWalletWith @n ctx [initialAmt]
         dest <- emptyWallet ctx
@@ -3303,6 +3309,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             ]
 
     it "TRANS_NEW_JOIN_01e - Can re-join and withdraw at once"  $ \ctx -> runResourceT $ do
+        noConway ctx "MIR"
         (src, _) <- rewardWallet ctx
         pool1:_ <- map (view #id . getApiT) . snd <$> unsafeRequest
             @[ApiT StakePool]
@@ -3366,6 +3373,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
     it "TRANS_NEW_JOIN_02 - Can join stakepool in case I have many UTxOs on 1 address"
         $ \ctx -> runResourceT $ do
+        noConway ctx "certificate"
         let amt = minUTxOValue (_mainEra ctx)
         src <- emptyWallet ctx
         wa <- fixtureWallet ctx
@@ -3490,6 +3498,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
     it "TRANS_NEW_QUIT_02a - Cannot quit with rewards without explicit withdrawal"
         $ \ctx -> runResourceT $ do
+        noConway ctx "MIR"
         (w, _) <- rewardWallet ctx
 
         pool1:_:_ <- map (view #id . getApiT) . snd
@@ -3531,6 +3540,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
     it "TRANS_NEW_QUIT_02b - Can quit with rewards with explicit withdrawal"
         $ \ctx -> runResourceT $ do
+        noConway ctx "MIR"
         (w, _) <- rewardWallet ctx
 
         pool1:_:_ <- map (view #id . getApiT) . snd
@@ -3586,6 +3596,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
     it "TRANS_NEW_CREATE_MULTI_TX - Tx including \
         \payments, delegation, metadata, withdrawals, validity_interval" $
         \ctx -> runResourceT $ do
+        noConway ctx "certificate"
 
         wa <- fixtureWallet ctx
         wb <- emptyWallet ctx

--- a/lib/wallet/test/integration/Cardano/Wallet/Test/Integration/Logging.hs
+++ b/lib/wallet/test/integration/Cardano/Wallet/Test/Integration/Logging.hs
@@ -71,7 +71,7 @@ import Test.Integration.Framework.Context
     ( PoolGarbageCollectionEvent (..)
     )
 import UnliftIO.Exception
-    ( SomeException
+    ( SomeException (..)
     , isAsyncException
     )
 
@@ -113,7 +113,8 @@ instance ToText TestsLog where
                             ]
                 ]
         MsgServerError e
-            | isAsyncException e -> "Server thread cancelled"
+            | isAsyncException (SomeException e)
+                -> "Server thread cancelled: " <> T.pack (show e)
             | otherwise -> T.pack (show e)
 
 instance HasPrivacyAnnotation TestsLog
@@ -125,7 +126,7 @@ instance HasSeverityAnnotation TestsLog where
         MsgCluster msg -> getSeverityAnnotation msg
         MsgPoolGarbageCollectionEvent _ -> Info
         MsgServerError e
-            | isAsyncException e -> Info
+            | isAsyncException e -> Critical
             | otherwise -> Critical
 
 withTracers

--- a/lib/wallet/test/integration/integration-tests.hs
+++ b/lib/wallet/test/integration/integration-tests.hs
@@ -37,14 +37,14 @@ import System.Environment
     ( lookupEnv
     )
 import Test.Hspec.Core.Spec
-    ( describe
+    ( SpecM
+    , describe
     , parallel
     , sequential
     )
 import Test.Hspec.Extra
     ( aroundAll
     , hspecMain
-    , it
     )
 
 import qualified Cardano.Wallet.Launch.Cluster as Cluster
@@ -80,8 +80,9 @@ import qualified Test.Integration.Scenario.CLI.Shelley.Wallets as WalletsCLI
 main :: forall netId n. (netId ~ 42, n ~ 'Testnet netId) => IO ()
 main = withTestsSetup $ \testDir (tr, tracers) -> do
     localClusterEra <- Cluster.clusterEraFromEnv
-    let noConway = ignoreInConway localClusterEra
-        noBabbage = ignoreInBabbage localClusterEra
+    let _noConway, _noBabbage :: SpecM a () -> SpecM a ()
+        _noConway = ignoreInConway localClusterEra
+        _noBabbage = ignoreInBabbage localClusterEra
         testnetMagic = Cluster.TestnetMagic (natVal (Proxy @netId))
     testDataDir <-
         FileOf . fromMaybe "."
@@ -92,13 +93,7 @@ main = withTestsSetup $ \testDir (tr, tracers) -> do
             $ parallel
             $ describe "Miscellaneous CLI tests" MiscellaneousCLI.spec
 
-        noBabbage
-            $ aroundAll (withContext testingCtx)
-            $ describe "We can start the conway cluster"
-            $ it "doing nothing"
-            $ \_ctx -> pure ()
-
-        noConway $ aroundAll (withContext testingCtx) $ do
+        aroundAll (withContext testingCtx) $ do
             describe "API Specifications" $ do
                 parallel $ do
                     Addresses.spec @n

--- a/lib/wallet/test/integration/integration-tests.hs
+++ b/lib/wallet/test/integration/integration-tests.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 module Main where
 


### PR DESCRIPTION
- [x] Enable all integration tests in Conway
- [x] Mark tests that are failing for Conway WIP as pending (grep for `noConway`)
- [x] Set `AsyncExceptions`  logging to critical 
- [x] Bump NodeToClient protocol version to from V_13 to V_16

ADP-3258
