### PR TITLE
[ADP-3255] Change `submitExternalTx` to return `TxId`

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -18,6 +18,7 @@ module Cardano.Wallet.Primitive.Types.Tx
     (
     -- * Types
       Tx (..)
+    , TxId
     , TxChange (..)
     , TxMetadata (..)
     , TxMetadataValue (..)
@@ -77,9 +78,6 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash
-    )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap
     )
@@ -120,6 +118,9 @@ import Cardano.Wallet.Primitive.Types.Tx.Tx
     , txMetadataIsNull
     , txRemoveAssetId
     , txScriptInvalid
+    )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxId
     )
 import Data.Word
     ( Word64
@@ -173,7 +174,7 @@ data UnsignedTx input output change withdrawal = UnsignedTx
 -- | Information about when a transaction was submitted to the local node.
 -- This is used for scheduling resubmissions.
 data LocalTxSubmissionStatus tx = LocalTxSubmissionStatus
-    { txId :: Hash "Tx"
+    { txId :: TxId
     , submittedTx :: tx
     , latestSubmission :: SlotNo
     -- ^ Time of most recent resubmission attempt.

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
@@ -55,14 +55,12 @@ import Cardano.Wallet.Primitive.Types.AssetId
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..)
-    )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
-    ( TxIn (..)
+    ( TxId
+    , TxIn (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
@@ -113,12 +111,9 @@ import qualified Data.Set as Set
 -- node.
 data Tx = Tx
     { txId
-        :: Hash "Tx"
-        -- ^ Jörmungandr computes transaction id by hashing the full content of
-        -- the transaction, which includes witnesses. Therefore, we need either
-        -- to keep track of the witnesses to be able to re-compute the tx id
+        :: TxId
+        -- ^ Hash of the transaction body (i.e. without witnesses).
 
-        -- every time, or, simply keep track of the id itself.
     , txCBOR
         :: Maybe TxCBOR
         -- ^ Serialized version of the transaction as received from the Node.
@@ -260,7 +255,7 @@ txMapAssetIds f tx = tx
     & over #collateralOutput
         (fmap (TxOut.mapAssetIds f))
 
-txMapTxIds :: (Hash "Tx" -> Hash "Tx") -> Tx -> Tx
+txMapTxIds :: (TxId -> TxId) -> Tx -> Tx
 txMapTxIds f tx = tx
     & over #txId
         f

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxIn.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/TxIn.hs
@@ -9,6 +9,7 @@
 --
 module Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn (..)
+    , TxId
     ) where
 
 import Prelude
@@ -30,9 +31,13 @@ import GHC.Generics
     ( Generic
     )
 
+-- | Unique reference to a transaction.
+-- In practice, this is the hash of the transaction body.
+type TxId = Hash "Tx"
+
 data TxIn = TxIn
     { inputId
-        :: !(Hash "Tx")
+        :: !TxId
     , inputIx
         :: !Word32
     }

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -69,14 +69,12 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId
     )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash
-    )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
-    ( TxIn
+    ( TxId
+    , TxIn
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
@@ -296,7 +294,7 @@ receiveD a b = (da, a <> new)
 assetIds :: UTxO -> Set AssetId
 assetIds (UTxO u) = foldMap TxOut.assetIds u
 
-txIds :: UTxO -> Set (Hash "Tx")
+txIds :: UTxO -> Set TxId
 txIds (UTxO u) = Set.map (view #inputId) (Map.keysSet u)
 
 --------------------------------------------------------------------------------
@@ -312,7 +310,7 @@ mapAssetIds f (UTxO u) = UTxO $ Map.map (TxOut.mapAssetIds f) u
 -- then only the smallest 'TxOut' is retained, according to the 'Ord' instance
 -- for 'TxOut'.
 --
-mapTxIds :: (Hash "Tx" -> Hash "Tx") -> UTxO -> UTxO
+mapTxIds :: (TxId -> TxId) -> UTxO -> UTxO
 mapTxIds f (UTxO u) = UTxO $ Map.mapKeysWith min (over #inputId f) u
 
 removeAssetId :: UTxO -> AssetId -> UTxO

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TxSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/TxSpec.hs
@@ -47,6 +47,9 @@ import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTx
     , shrinkTx
     )
+import Cardano.Wallet.Primitive.Types.Tx.TxIn
+    ( TxId
+    )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
     )
@@ -166,8 +169,8 @@ prop_txMapTxIds_identity m =
 
 prop_txMapTxIds_composition
     :: Tx
-    -> Fun (Hash "Tx") (Hash "Tx")
-    -> Fun (Hash "Tx") (Hash "Tx")
+    -> Fun TxId TxId
+    -> Fun TxId TxId
     -> Property
 prop_txMapTxIds_composition m (applyFun -> f) (applyFun -> g) =
     txMapTxIds f (txMapTxIds g m) ===
@@ -220,12 +223,12 @@ instance Arbitrary AssetId where
 deriving anyclass instance CoArbitrary AssetId
 deriving anyclass instance Function AssetId
 
-deriving newtype instance Arbitrary (Hash "Tx")
+deriving newtype instance Arbitrary TxId
 deriving anyclass instance CoArbitrary (Hash "TokenPolicy")
 deriving anyclass instance Function (Hash "TokenPolicy")
 
-deriving anyclass instance CoArbitrary (Hash "Tx")
-deriving anyclass instance Function (Hash "Tx")
+deriving anyclass instance CoArbitrary TxId
+deriving anyclass instance Function TxId
 
 instance Arbitrary Tx where
     arbitrary = genTx

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -40,7 +40,8 @@ import Cardano.Wallet.Primitive.Types.TokenPolicyId
     ( TokenPolicyId (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
-    ( TxIn (..)
+    ( TxId
+    , TxIn (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
@@ -352,8 +353,8 @@ prop_mapTxIds_identity m =
 
 prop_mapTxIds_composition
     :: UTxO
-    -> Fun (Hash "Tx") (Hash "Tx")
-    -> Fun (Hash "Tx") (Hash "Tx")
+    -> Fun TxId TxId
+    -> Fun TxId TxId
     -> Property
 prop_mapTxIds_composition m (applyFun -> f) (applyFun -> g) =
     UTxO.mapTxIds f (UTxO.mapTxIds g m) ===
@@ -389,9 +390,9 @@ deriving anyclass instance Function AssetId
 deriving anyclass instance CoArbitrary (Hash "TokenPolicy")
 deriving anyclass instance Function (Hash "TokenPolicy")
 
-deriving newtype instance Arbitrary (Hash "Tx")
-deriving anyclass instance CoArbitrary (Hash "Tx")
-deriving anyclass instance Function (Hash "Tx")
+deriving newtype instance Arbitrary TxId
+deriving anyclass instance CoArbitrary TxId
+deriving anyclass instance Function TxId
 
 deriving anyclass instance CoArbitrary AssetName
 deriving anyclass instance Function AssetName

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -4440,9 +4440,9 @@ postExternalTransaction
     -> ApiT W.SealedTx
     -> Handler ApiTxId
 postExternalTransaction ctx (ApiT sealed) = do
-    tx <- liftHandler $ W.submitExternalTx
+    txid <- liftHandler $ W.submitExternalTx
             (tracerTxSubmit ctx) (ctx ^. #netLayer) (ctx ^. #txLayer) sealed
-    return $ ApiTxId (ApiT (tx ^. #txId))
+    return $ ApiTxId (ApiT txid)
 
 signMetadata
     :: forall ctx s k n.

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -543,6 +543,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , SealedTx
     , Tx (..)
     , TxChange (..)
+    , TxId
     , TxMetadata (..)
     , UnsignedTx (..)
     , sealedTxFromCardano
@@ -2623,7 +2624,7 @@ submitExternalTx tr nw tl sealedTx = do
 -- be added back to the transaction history.
 forgetTx
     :: WalletLayer m s
-    -> Hash "Tx"
+    -> TxId
     -> ExceptT ErrRemoveTx m ()
 forgetTx ctx txid =
     ExceptT
@@ -2803,7 +2804,7 @@ listAssets ctx = db & \DBLayer{..} -> do
 -- | Get transaction and metadata from history for a given wallet.
 getTransaction
     :: WalletLayer IO s
-    -> Hash "Tx"
+    -> TxId
     -> ExceptT ErrGetTransaction IO TransactionInfo
 getTransaction ctx tid =
     db & \DBLayer {..} -> do
@@ -3845,8 +3846,8 @@ instance HasSeverityAnnotation WalletLog where
 
 data TxSubmitLog
     = MsgSubmitTx BuiltTx (BracketLog' (Either ErrSubmitTx ()))
-    | MsgSubmitExternalTx (Hash "Tx") (BracketLog' (Either ErrPostTx Tx))
-    | MsgRetryPostTx (Hash "Tx") (BracketLog' (Either ErrPostTx ()))
+    | MsgSubmitExternalTx TxId (BracketLog' (Either ErrPostTx Tx))
+    | MsgRetryPostTx TxId (BracketLog' (Either ErrPostTx ()))
     | MsgProcessPendingPool BracketLog
     deriving (Show, Eq)
 

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2606,15 +2606,17 @@ submitExternalTx
     -> NetworkLayer IO block
     -> TransactionLayer k ktype SealedTx
     -> SealedTx
-    -> ExceptT ErrPostTx IO Tx
+    -> ExceptT ErrPostTx IO TxId
 submitExternalTx tr nw tl sealedTx = do
     -- FIXME: We read the current era to constrain the @sealedTx@ **twice**:
     -- once here for decodeTx, and once in postTx before submitting.
     era <- liftIO $ currentNodeEra nw
     let (tx, _, _, _, _, _) = decodeTx tl era AnyWitnessCountCtx sealedTx
-    traceResult (MsgSubmitExternalTx (tx ^. #txId) >$< tr) $ do
+        txid = tx ^. #txId
+    _ <- traceResult (MsgSubmitExternalTx txid >$< tr) $ do
         postTx nw sealedTx
-        pure tx
+        pure sealedTx
+    pure txid
 
 -- | Remove a pending or expired transaction from the transaction history. This
 -- happens at the request of the user. If the transaction is already on chain,
@@ -3846,7 +3848,7 @@ instance HasSeverityAnnotation WalletLog where
 
 data TxSubmitLog
     = MsgSubmitTx BuiltTx (BracketLog' (Either ErrSubmitTx ()))
-    | MsgSubmitExternalTx TxId (BracketLog' (Either ErrPostTx Tx))
+    | MsgSubmitExternalTx TxId (BracketLog' (Either ErrPostTx SealedTx))
     | MsgRetryPostTx TxId (BracketLog' (Either ErrPostTx ()))
     | MsgProcessPendingPool BracketLog
     deriving (Show, Eq)


### PR DESCRIPTION
This pull request changes the `submitExternalTx` to return a `TxId` as opposed to a full `Tx`. It turns out that downstream code only used the `TxId` of the result anyway.

### Issue Number

Noticed during ADP-3255.
