### PR TITLE
Disambiguate record field updates in `cardano-{balance-tx,coin-selection}`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -16,12 +16,6 @@
 
 {- HLINT ignore "Use ||" -}
 
--- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
-{-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 902
-{-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}
-#endif
-
 module Internal.Cardano.Write.Tx.Balance
     (
     -- * Balancing transactions

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -160,6 +160,7 @@ import Data.Functor
     )
 import Data.Generics.Internal.VL.Lens
     ( over
+    , set
     , view
     , (^.)
     )
@@ -232,7 +233,7 @@ import Internal.Cardano.Write.Tx.Balance.CoinSelection
     , SelectionCollateralRequirement (..)
     , SelectionConstraints (..)
     , SelectionError (..)
-    , SelectionOf (change)
+    , SelectionOf (..)
     , SelectionParams (..)
     , SelectionStrategy (..)
     , UnableToConstructChangeError (..)
@@ -1141,7 +1142,7 @@ assignChangeAddresses (ChangeAddressGen genChange _) sel = runState $ do
     changeOuts <- forM (view #change sel) $ \bundle -> do
         addr <- state genChange
         pure $ W.TxOut (Convert.toWalletAddress addr) bundle
-    pure $ (sel :: SelectionOf W.TokenBundle) { change = changeOuts }
+    pure $ set #change changeOuts sel
 
 unsafeIntCast
     :: (HasCallStack, Integral a, Integral b, Bits a, Bits b, Show a)

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -16,6 +16,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
 {- HLINT ignore "Use null" -}
 {- HLINT ignore "Use camelCase" -}
@@ -26,7 +27,6 @@
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 902
 {-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}
-{-# LANGUAGE TypeOperators #-}
 #endif
 
 module Internal.Cardano.Write.Tx.BalanceSpec

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -23,12 +23,6 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
--- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
-{-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 902
-{-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}
-#endif
-
 module Internal.Cardano.Write.Tx.BalanceSpec
     ( spec
     ) where

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -16,12 +16,6 @@
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 {- HLINT ignore "Use camelCase" -}
 
--- TODO: https://cardanofoundation.atlassian.net/browse/ADP-2841
-{-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 902
-{-# OPTIONS_GHC -fno-warn-ambiguous-fields #-}
-#endif
-
 module Cardano.CoinSelection.BalanceSpec
     ( spec
     , MockAssessTokenBundleSize

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -324,6 +324,9 @@ import Test.Utils.Pretty
     ( Pretty (..)
     )
 
+import qualified Cardano.CoinSelection.Balance as SelectionParams
+    ( SelectionParamsOf (..)
+    )
 import qualified Cardano.CoinSelection.Context as SC
 import qualified Cardano.CoinSelection.UTxOIndex as UTxOIndex
 import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
@@ -919,7 +922,9 @@ prop_performSelection_huge_inner utxoAvailable mockConstraints (Large params) =
   where
     params' :: SelectionParams TestSelectionContext
     params' = params
-        { utxoAvailable = UTxOSelection.fromIndex utxoAvailable }
+        { SelectionParams.utxoAvailable =
+            UTxOSelection.fromIndex utxoAvailable
+        }
 
 prop_performSelection
     :: MockSelectionConstraints


### PR DESCRIPTION
## Issue

ADP-2481

## Description

This PR:
- revises record field updates so that GHC no longer labels them as ambiguous.
- removes the suppression of the `ambiguous-fields` warning.

## Scope

This PR affects the following packages:
- `cardano-balance-tx`
- `cardano-coin-selection`
