### PR TITLE
[ADP-3284] Investigate flaky SHELLEY_MIGRATION_02

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,12 +12,12 @@ hlint:
 
 # build wallet
 build:
-  cabal build all -Werror -O0 -v0
+  cabal build all  --enable-benchmarks --enable-tests -O0 -v0 --ghc-options="-Werror"
 
 # build after clean
 clean-build:
   cabal clean
-  cabal build all -Werror -O0 -v0
+  just build
 
 # run a nix shell with `cardano-wallet` in scope
 wallet:

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -423,6 +423,7 @@ library cardano-wallet-integration
     , microstache
     , monad-loops
     , network-uri
+    , pretty-simple
     , process
     , resourcet
     , retry


### PR DESCRIPTION
- [x] Change description argument from `String` to  `IO String` in `eventually`
- [x] Add txs reporting to SHELLEY_MIGRATION_02 when failing like in https://buildkite.com/cardano-foundation/cardano-wallet/builds/3199#018d560c-db5c-4680-abd3-0aeb6aa7b47b/6-1903

ADP-3284