### PR TITLE
[ADP-3173] Clean up `flake.nix`

### DIFF
--- a/nix/supported-systems.nix
+++ b/nix/supported-systems.nix
@@ -1,6 +1,5 @@
 [
   "x86_64-linux"
   "x86_64-darwin"
-  # TODO: Enable aarch64-darwin when there are Hydra builders for it
   "aarch64-darwin"
 ]


### PR DESCRIPTION
This pull request performs a small cleanup of our `flake.nix` after merging support for `aarch64-darwin`.

### Issue number

ADP-3173