### PR TITLE
[ADP-3266] Add node-to-client-version 15 support

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -416,7 +416,7 @@ emptyGenesis gp = W.Block
 
 -- | The protocol client version. Distinct from the codecs version.
 nodeToClientVersions :: [NodeToClientVersion]
-nodeToClientVersions = [NodeToClientV_16]
+nodeToClientVersions = [NodeToClientV_15, NodeToClientV_16]
 
 --------------------------------------------------------------------------------
 --


### PR DESCRIPTION
- [x] Add  node-to-client-version to 15 to support pre-prod network in E2E tests

ADP-3266
