### PR TITLE
[ADP-3226] Fix address pool gap for `SHELLEY_MIGRATE_02`

### DIFF
--- a/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/wallet/integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -774,6 +774,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
         $ \ctx -> runResourceT @IO $ do
             bigDustWallet <- liftIO $ bigDustWalletMnemonic (_faucet ctx)
 
+            let bigDustUTxOSize = 200 :: Int
             -- Create a large source wallet from which funds will be migrated:
             sourceWallet <-
                 unsafeResponse
@@ -783,7 +784,8 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                             [json|{
                 "name": "Big Shelley Wallet",
                 "mnemonic_sentence": #{someMnemonicToWords bigDustWallet},
-                "passphrase": #{fixturePassphrase}
+                "passphrase": #{fixturePassphrase},
+                "address_pool_gap": #{bigDustUTxOSize}
             }|]
                         )
 


### PR DESCRIPTION
This pull request fixes an issue where the integration test `SHELLEY_MIGRATE_02` would fail because the wallet would not discover its own funds at genesis.

### Issue number

ADP-3226