### PR TITLE
[ADP-3212] DB migration of delegation store to support voting state

### DIFF
--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -183,8 +183,8 @@ library
     Cardano.Wallet.DB.Store.Checkpoints.Migration
     Cardano.Wallet.DB.Store.Checkpoints.Store
     Cardano.Wallet.DB.Store.Delegations.Layer
-    Cardano.Wallet.DB.Store.Delegations.Migration
-    Cardano.Wallet.DB.Store.Delegations.Migration.Schema
+    Cardano.Wallet.DB.Store.Delegations.Migrations.V2.Schema
+    Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Migration
     Cardano.Wallet.DB.Store.Delegations.Model
     Cardano.Wallet.DB.Store.Delegations.Schema
     Cardano.Wallet.DB.Store.Delegations.Store

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -190,6 +190,7 @@ library
     Cardano.Wallet.DB.Store.Delegations.Model
     Cardano.Wallet.DB.Store.Delegations.Schema
     Cardano.Wallet.DB.Store.Delegations.Store
+    Cardano.Wallet.DB.Store.Delegations.Types
     Cardano.Wallet.DB.Store.Info.Store
     Cardano.Wallet.DB.Store.Meta.Layer
     Cardano.Wallet.DB.Store.Meta.Model

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -561,7 +561,7 @@ executable mock-token-metadata-server
 
 test-suite unit
   import:             language, opts-exe
-  ghc-options:        -with-rtsopts=-M2G -with-rtsopts=-N4
+  ghc-options:        -with-rtsopts=-M2G -with-rtsopts=-N4 -fprint-potential-instances
   type:               exitcode-stdio-1.0
   hs-source-dirs:     test-common test/unit test/data
   main-is:            core-unit-test.hs
@@ -635,6 +635,7 @@ test-suite unit
     , memory
     , mock-token-metadata
     , MonadRandom
+    , monad-logger
     , monoid-subclasses
     , mtl
     , network
@@ -655,6 +656,7 @@ test-suite unit
     , quickcheck-state-machine                           >=0.6.0
     , random
     , regex-pcre-builtin
+    , resourcet
     , retry
     , safe
     , servant
@@ -723,7 +725,8 @@ test-suite unit
     Cardano.Wallet.DB.StateMachine
     Cardano.Wallet.DB.Store.Checkpoints.MigrationSpec
     Cardano.Wallet.DB.Store.Checkpoints.StoreSpec
-    Cardano.Wallet.DB.Store.Delegations.MigrationSpec
+    Cardano.Wallet.DB.Store.Delegations.Migrations.V3Spec
+    Cardano.Wallet.DB.Store.Delegations.Migrations.V5Spec
     Cardano.Wallet.DB.Store.Delegations.StoreSpec
     Cardano.Wallet.DB.Store.Info.StoreSpec
     Cardano.Wallet.DB.Store.Meta.ModelSpec

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -187,6 +187,7 @@ library
     Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Migration
     Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Schema
     Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Model
+    Cardano.Wallet.DB.Store.Delegations.Migrations.V5.Migration
     Cardano.Wallet.DB.Store.Delegations.Model
     Cardano.Wallet.DB.Store.Delegations.Schema
     Cardano.Wallet.DB.Store.Delegations.Store

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -185,6 +185,8 @@ library
     Cardano.Wallet.DB.Store.Delegations.Layer
     Cardano.Wallet.DB.Store.Delegations.Migrations.V2.Schema
     Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Migration
+    Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Schema
+    Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Model
     Cardano.Wallet.DB.Store.Delegations.Model
     Cardano.Wallet.DB.Store.Delegations.Schema
     Cardano.Wallet.DB.Store.Delegations.Store

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/New.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/New.hs
@@ -56,15 +56,18 @@ import System.Directory
     )
 
 import qualified Cardano.Wallet.DB.Sqlite.Migration.Old as Old
-import qualified Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Migration as DelegationsV3
+import qualified Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Migration as V3
+import qualified Cardano.Wallet.DB.Store.Delegations.Migrations.V5.Migration as V5
 
 {-----------------------------------------------------------------------------
     Specific migrations
 ------------------------------------------------------------------------------}
 
-newStyleMigrations :: Migration (ReadDBHandle IO) 2 4
+newStyleMigrations :: Migration (ReadDBHandle IO) 2 5
 newStyleMigrations =
-    migratePrologue . DelegationsV3.migrateDelegations
+    V5.migrateDelegations
+        . migratePrologue
+        . V3.migrateDelegations
 
 latestVersion :: Version
 latestVersion = getTargetVersion newStyleMigrations

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/New.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Migration/New.hs
@@ -6,7 +6,7 @@ module Cardano.Wallet.DB.Sqlite.Migration.New
     , latestVersion
     , runNewStyleMigrations
 
-    -- * Operating on database
+      -- * Operating on database
     , newMigrationInterface
     ) where
 
@@ -36,9 +36,6 @@ import Cardano.Wallet.DB.Sqlite.Migration.Old
 import Cardano.Wallet.DB.Store.Checkpoints.Migration
     ( migratePrologue
     )
-import Cardano.Wallet.DB.Store.Delegations.Migration
-    ( migrateDelegations
-    )
 import Control.Category
     ( (.)
     )
@@ -59,6 +56,7 @@ import System.Directory
     )
 
 import qualified Cardano.Wallet.DB.Sqlite.Migration.Old as Old
+import qualified Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Migration as DelegationsV3
 
 {-----------------------------------------------------------------------------
     Specific migrations
@@ -66,7 +64,7 @@ import qualified Cardano.Wallet.DB.Sqlite.Migration.Old as Old
 
 newStyleMigrations :: Migration (ReadDBHandle IO) 2 4
 newStyleMigrations =
-    migratePrologue . migrateDelegations
+    migratePrologue . DelegationsV3.migrateDelegations
 
 latestVersion :: Version
 latestVersion = getTargetVersion newStyleMigrations

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -861,30 +861,6 @@ iso8601DateFormatHMS :: String
 -- The function `iso8601DateFormatHMS` has been deprecated from the `time` library.
 iso8601DateFormatHMS = "%Y-%m-%dT%H:%M:%S"
 
-data DelegationStatusEnum =
-    InactiveE | RegisteredE | ActiveE | ActiveAndVotedE | VotedE
-    deriving (Eq, Show, Enum, Generic)
-
-instance PersistField DelegationStatusEnum where
-    toPersistValue = toPersistValue . \case
-        InactiveE -> "inactive" :: Text
-        RegisteredE -> "registered"
-        ActiveE -> "active"
-        ActiveAndVotedE -> "active_and_voted"
-        VotedE -> "voted"
-    fromPersistValue = fromPersistValue >=> readDelegationStatus
-
-readDelegationStatus :: Text -> Either Text DelegationStatusEnum
-readDelegationStatus "inactive" = Right InactiveE
-readDelegationStatus "registered" = Right RegisteredE
-readDelegationStatus "active" = Right ActiveE
-readDelegationStatus "active_and_voted" = Right ActiveAndVotedE
-readDelegationStatus "voted" = Right VotedE
-readDelegationStatus other = Left $ "Invalid delegation status: " <> other
-
-instance PersistFieldSql DelegationStatusEnum where
-    sqlType _ = sqlType (Proxy @Text)
-
 instance PersistField Slot where
     toPersistValue Origin = toPersistValue ((-1) :: Int64)
     toPersistValue (At s) = toPersistValue (fromIntegral $ unSlotNo s :: Int64)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V2/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V2/Schema.hs
@@ -25,8 +25,7 @@
 -- More than 6K lines end-up being generated from the instructions below! As a
 -- result, we're going to ignore code-coverage on the following module and, no
 -- hand-written functions should be written in this module!
-
-module Cardano.Wallet.DB.Store.Delegations.Migration.Schema where
+module Cardano.Wallet.DB.Store.Delegations.Migrations.V2.Schema where
 
 import Prelude
 
@@ -92,14 +91,15 @@ import GHC.Generics
 
 import qualified Data.Text.Encoding as T
 
-newtype WalletId = WalletId { getWalletId :: Digest Blake2b_160 }
+newtype WalletId = WalletId {getWalletId :: Digest Blake2b_160}
     deriving (Generic, Eq, Ord, Show)
 
 instance FromText WalletId where
-    fromText txt = maybe
-        (Left $ TextDecodingError msg)
-        (Right . WalletId)
-        (decodeHex txt >>= digestFromByteString @_ @ByteString)
+    fromText txt =
+        maybe
+            (Left $ TextDecodingError msg)
+            (Right . WalletId)
+            (decodeHex txt >>= digestFromByteString @_ @ByteString)
       where
         msg = "wallet id should be a hex-encoded string of 40 characters"
         decodeHex =

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V3/Migration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V3/Migration.hs
@@ -38,6 +38,11 @@ import Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Model
     , Operation (Delegate, Deregister, Register)
     , Status (..)
     )
+import Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Schema
+    ( DelegationStatusEnum (..)
+    , Delegations (..)
+    , resetDelegationTable
+    )
 import Cardano.Wallet.Primitive.Types
     ( SlotNo (..)
     )
@@ -62,12 +67,7 @@ import Database.Persist.Sql
     , rawExecute
     , selectList
     )
-import Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Schema
-    ( DelegationStatusEnum (..)
-    , Delegations (..)
-    , resetDelegationTable
-    )
-    
+
 import qualified Data.Map as Map
 import qualified Data.Map.Merge.Strict as Map
 

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V3/Migration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V3/Migration.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Cardano.Wallet.DB.Store.Delegations.Migration
+module Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Migration
     ( migrateDelegations
     ) where
 
@@ -27,7 +27,7 @@ import Cardano.Wallet.DB.Sqlite.Migration.Old
     ( SqlColumnStatus (..)
     , isFieldPresent
     )
-import Cardano.Wallet.DB.Store.Delegations.Migration.Schema
+import Cardano.Wallet.DB.Store.Delegations.Migrations.V2.Schema
     ( DelegationCertificate (..)
     , EntityField (..)
     , StakeKeyCertificate (..)
@@ -125,21 +125,25 @@ migration store = do
     conn <- asks dbConn
     r <- liftIO $ isFieldPresent conn $ DBField StakeKeyCertSlot
     case r of
-        TableMissing -> fail $ unwords
-            [ "Database migration from version 2 to version 3 failed:"
-            , "Expected TABLE stake_key_certificate"
-            , "to exist in database_schema_version 2"
-            ]
-        ColumnMissing -> fail $ unwords
-            [ "Database migration from version 2 to version 3 failed:"
-            , "Expected COLUMN slot of TABLE stake_key_certificate"
-            , "to exist in database_schema_version 2"
-            ]
+        TableMissing ->
+            fail
+                $ unwords
+                    [ "Database migration from version 2 to version 3 failed:"
+                    , "Expected TABLE stake_key_certificate"
+                    , "to exist in database_schema_version 2"
+                    ]
+        ColumnMissing ->
+            fail
+                $ unwords
+                    [ "Database migration from version 2 to version 3 failed:"
+                    , "Expected COLUMN slot of TABLE stake_key_certificate"
+                    , "to exist in database_schema_version 2"
+                    ]
         ColumnPresent -> withReaderT dbBackend $ do
             old <- readOldEncoding
             writeS store old
-            rawExecute "DROP TABLE stake_key_certificate"  []
-            rawExecute "DROP TABLE delegation_certificate"  []
+            rawExecute "DROP TABLE stake_key_certificate" []
+            rawExecute "DROP TABLE delegation_certificate" []
 
 migrateDelegations :: Migration (ReadDBHandle IO) 2 3
 migrateDelegations = mkMigration $ migration mkStoreDelegations

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V3/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V3/Model.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+-- Copyright: © 2023 IOHK
+-- License: Apache-2.0
+--
+-- Data types that represents a history of delegations and its changes.
+module Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Model
+    ( Operation (..)
+    , slotOf
+    , Status (..)
+    , History
+    , status
+    ) where
+
+import Prelude
+
+import Data.Delta
+    ( Delta (..)
+    )
+import Data.Function
+    ( (&)
+    )
+import Data.Map.Strict
+    ( Map
+    )
+
+import qualified Data.Map.Strict as Map
+
+-- | Delta type for the delegation 'History'.
+data Operation slot pool
+    = Register slot
+    | Deregister slot
+    | Delegate pool slot
+    | Rollback slot
+    deriving (Show)
+
+-- | Target slot of each 'Operation'.
+slotOf :: Operation slot pool -> slot
+slotOf (Register x) = x
+slotOf (Deregister x) = x
+slotOf (Delegate _ x) = x
+slotOf (Rollback x) = x
+
+-- | Valid state for the delegations, independent of time.
+data Status pool = Inactive | Registered | Active pool
+    deriving (Show, Eq)
+
+-- | Delegation history implementation.
+type History slot pool = Map slot (Status pool)
+
+instance (Ord slot, Eq pool) => Delta (Operation slot pool) where
+    type Base (Operation slot pool) = History slot pool
+    apply r hist = hist' & if miss == wanted then id else Map.insert slot wanted
+      where
+        slot = slotOf r
+        hist' = cut (< slot) hist
+        miss = status slot hist'
+        wanted = transition r $ status slot hist
+
+transition :: Operation slot pool -> Status pool -> Status pool
+transition (Register _) Inactive = Registered
+transition (Delegate p _) Registered = Active p
+transition (Delegate p _) (Active _) = Active p
+transition (Deregister _) _ = Inactive
+transition _ s = s
+
+type Change slot pool = History slot pool -> History slot pool
+
+cut :: (slot -> Bool) -> Change slot pool
+cut op = fst . Map.spanAntitone op
+
+-- | Status of the delegation at a given slot.
+status :: Ord slot => slot -> History slot pool -> Status pool
+status x = maybe Inactive snd . Map.lookupMax . cut (<= x)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V3/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V3/Schema.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Schema
+    ( Delegations (..)
+    , EntityField (DelegationSlot)
+    , Key (DelegationsKey)
+    , resetDelegationTable
+    , DelegationStatusEnum (..)
+    )
+where
+
+import Prelude
+
+import Cardano.Pool.Types
+    ( PoolId
+    )
+import Cardano.Slotting.Slot
+    ( SlotNo (..)
+    )
+import Control.Monad
+    ( void
+    , (>=>)
+    )
+import Control.Monad.IO.Class
+    ( MonadIO
+    )
+import Data.Proxy
+    ( Proxy (..)
+    )
+import Data.Text
+    ( Text
+    )
+import Data.Text.Class
+    ( ToText (..)
+    )
+import Data.Word
+    ( Word64
+    )
+import Database.Persist
+    ( PersistEntity (EntityField, Key, entityDef)
+    , PersistField (..)
+    , PersistValue
+    )
+import Database.Persist.PersistValue.Extended
+    ( fromPersistValueFromText
+    )
+import Database.Persist.Sql
+    ( Migration
+    , PersistFieldSql (..)
+    , SqlPersistT
+    , rawExecute
+    , runMigrationUnsafeQuiet
+    )
+import Database.Persist.TH
+    ( MkPersistSettings (mpsPrefixFields)
+    , migrateModels
+    , mkPersist
+    , persistLowerCase
+    , sqlSettings
+    )
+import GHC.Generics
+    ( Generic (..)
+    )
+import Web.HttpApiData
+    ( FromHttpApiData (..)
+    , ToHttpApiData (..)
+    )
+import Web.PathPieces
+    ( PathPiece (..)
+    )
+
+instance PersistField PoolId where
+    toPersistValue :: PoolId -> PersistValue
+    toPersistValue = toPersistValue . toText
+    fromPersistValue = fromPersistValueFromText
+
+instance PersistFieldSql PoolId where
+    sqlType _ = sqlType (Proxy @Text)
+
+persistSlotNo :: SlotNo -> PersistValue
+persistSlotNo = toPersistValue . unSlotNo
+
+unPersistSlotNo :: PersistValue -> Either Text SlotNo
+unPersistSlotNo = fmap SlotNo . fromPersistValue
+
+instance PersistField SlotNo where
+    toPersistValue = persistSlotNo
+    fromPersistValue = unPersistSlotNo
+
+instance PersistFieldSql SlotNo where
+    sqlType _ = sqlType (Proxy @Word64)
+
+instance Read SlotNo where
+    readsPrec _ = error "readsPrec stub needed for persistent"
+
+instance ToHttpApiData SlotNo where
+    toUrlPiece = error "toUrlPiece stub needed for persistent"
+instance FromHttpApiData SlotNo where
+    parseUrlPiece = error "parseUrlPiece stub needed for persistent"
+instance PathPiece SlotNo where
+    toPathPiece = error "toPathPiece stub needed for persistent"
+    fromPathPiece = error "fromPathPiece stub needed for persistent"
+
+mkPersist (sqlSettings { mpsPrefixFields = False })
+    [persistLowerCase|
+        Delegations                                     sql=delegations
+            delegationSlot      SlotNo                  sql=slot
+            delegationStatus    DelegationStatusEnum    sql=status
+            delegationPool      PoolId Maybe            sql=pool
+
+            Primary delegationSlot
+            deriving Show Generic Eq
+
+    |]
+
+data DelegationStatusEnum = InactiveE | RegisteredE | ActiveE
+    deriving (Eq, Show, Enum, Generic)
+
+instance PersistField DelegationStatusEnum where
+    toPersistValue = toPersistValue . \case
+        InactiveE -> "inactive" :: Text
+        RegisteredE -> "registered"
+        ActiveE -> "active"
+    fromPersistValue = fromPersistValue >=> readDelegationStatus
+
+readDelegationStatus :: Text -> Either Text DelegationStatusEnum
+readDelegationStatus "inactive" = Right InactiveE
+readDelegationStatus "registered" = Right RegisteredE
+readDelegationStatus "active" = Right ActiveE
+readDelegationStatus other = Left $ "Invalid delegation status: " <> other
+
+instance PersistFieldSql DelegationStatusEnum where
+    sqlType _ = sqlType (Proxy @Text)
+
+delegationMigration :: Migration
+delegationMigration = migrateModels [entityDef (Proxy :: Proxy Delegations)]
+
+migrateDelegations :: MonadIO m => SqlPersistT m ()
+migrateDelegations = void $ runMigrationUnsafeQuiet delegationMigration
+
+dropDelegationTable :: MonadIO m => SqlPersistT m ()
+dropDelegationTable = rawExecute "DROP TABLE IF EXISTS \"delegations\";" []
+
+resetDelegationTable :: MonadIO m => SqlPersistT m ()
+resetDelegationTable = do
+    dropDelegationTable
+    migrateDelegations

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V5/Migration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V5/Migration.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Wallet.DB.Store.Delegations.Migrations.V5.Migration
+    ( migrateDelegations
+    ) where
+
+import Prelude
+
+import Cardano.DB.Sqlite
+    ( ReadDBHandle
+    , dbConn
+    )
+import Cardano.DB.Sqlite.Migration.Old
+    ( DBField (..)
+    , fieldName
+    , fieldType
+    , tableName
+    )
+import Cardano.Wallet.DB.Migration
+    ( Migration
+    , mkMigration
+    )
+import Cardano.Wallet.DB.Sqlite.Migration.Old
+    ( SqlColumnStatus (..)
+    , isFieldPresent
+    )
+import Cardano.Wallet.DB.Store.Delegations.Schema
+    ( EntityField (..)
+    )
+import Control.Monad
+    ( void
+    )
+import Control.Monad.Reader
+    ( ReaderT (..)
+    )
+import Data.Text
+    ( Text
+    )
+
+import qualified Data.Text as T
+import qualified Database.Sqlite as Sqlite
+
+migrateDelegations :: Migration (ReadDBHandle IO) 4 5
+migrateDelegations = mkMigration $ ReaderT $ \db -> void $ do
+    let conn = dbConn db
+    addColumnIfMissing conn (DBField DelegationVote)
+
+headerFail :: Text
+headerFail = "Database migration from version 4 to version 5 failed:"
+
+addColumnIfMissing
+    :: Sqlite.Connection
+    -> DBField
+    -> IO ()
+addColumnIfMissing conn field = do
+    isFieldPresent conn field >>= \case
+        TableMissing -> fail $ T.unpack $ T.unwords
+            [ headerFail
+            , "Expected TABLE", tableName field
+            , "to exist."
+            ]
+        ColumnMissing -> do
+            query <- Sqlite.prepare conn $ T.unwords
+                [ "ALTER TABLE", tableName field
+                , "ADD COLUMN", fieldName field
+                , fieldType field , "NULL"
+                , ";"
+                ]
+            _ <- Sqlite.step query
+            Sqlite.finalize query
+        ColumnPresent -> fail $ T.unpack $ T.unwords
+            [ headerFail
+            , "Expected COLUMN", fieldName field
+            , "in TABLE", tableName field
+            , "to not exist."
+            ]

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Schema.hs
@@ -26,7 +26,7 @@
 
 module Cardano.Wallet.DB.Store.Delegations.Schema
     ( Delegations (..)
-    , EntityField (DelegationSlot)
+    , EntityField (..)
     , Key (DelegationsKey)
     , resetDelegationTable
     )

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Schema.hs
@@ -41,8 +41,10 @@ import Cardano.Slotting.Slot
     ( SlotNo
     )
 import Cardano.Wallet.DB.Sqlite.Types
-    ( DelegationStatusEnum (..)
-    , sqlSettings'
+    ( sqlSettings'
+    )
+import Cardano.Wallet.DB.Store.Delegations.Types
+    ( DelegationStatusEnum
     )
 import Cardano.Wallet.Primitive.Types.DRep
     ( DRep

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Schema.hs
@@ -44,6 +44,9 @@ import Cardano.Wallet.DB.Sqlite.Types
     ( DelegationStatusEnum (..)
     , sqlSettings'
     )
+import Cardano.Wallet.Primitive.Types.DRep
+    ( DRep
+    )
 import Control.Monad
     ( void
     )
@@ -79,6 +82,7 @@ mkPersist sqlSettings'
             delegationSlot      SlotNo                  sql=slot
             delegationStatus    DelegationStatusEnum    sql=status
             delegationPool      PoolId Maybe            sql=pool
+            delegationVote      DRep Maybe              sql=vote
 
             Primary delegationSlot
             deriving Show Generic Eq

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Store.hs
@@ -23,14 +23,14 @@ import Cardano.Pool.Types
 import Cardano.Slotting.Slot
     ( SlotNo
     )
-import Cardano.Wallet.DB.Sqlite.Types
-    ( DelegationStatusEnum (..)
-    )
 import Cardano.Wallet.DB.Store.Delegations.Schema
     ( Delegations (..)
     , EntityField (DelegationSlot)
     , Key (DelegationsKey)
     , resetDelegationTable
+    )
+import Cardano.Wallet.DB.Store.Delegations.Types
+    ( DelegationStatusEnum (..)
     )
 import Cardano.Wallet.Delegation.Model
     ( History

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Types.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Wallet.DB.Store.Delegations.Types
+    ( DelegationStatusEnum (..)
+    )
+where
+
+import Prelude
+
+import Control.Monad ((>=>))
+import Data.Proxy (Proxy (..))
+import Data.Text (Text)
+import Database.Persist.Sql (PersistField (..), PersistFieldSql (..))
+import GHC.Generics (Generic)
+
+data DelegationStatusEnum
+    = InactiveE
+    | RegisteredE
+    | ActiveE
+    | ActiveAndVotedE
+    | VotedE
+    deriving (Eq, Show, Enum, Generic)
+
+instance PersistField DelegationStatusEnum where
+    toPersistValue =
+        toPersistValue . \case
+            InactiveE -> "inactive" :: Text
+            RegisteredE -> "registered"
+            ActiveE -> "active"
+            ActiveAndVotedE -> "active_and_voted"
+            VotedE -> "voted"
+    fromPersistValue = fromPersistValue >=> readDelegationStatus
+
+readDelegationStatus :: Text -> Either Text DelegationStatusEnum
+readDelegationStatus "inactive" = Right InactiveE
+readDelegationStatus "registered" = Right RegisteredE
+readDelegationStatus "active" = Right ActiveE
+readDelegationStatus "active_and_voted" = Right ActiveAndVotedE
+readDelegationStatus "voted" = Right VotedE
+readDelegationStatus other = Left $ "Invalid delegation status: " <> other
+
+instance PersistFieldSql DelegationStatusEnum where
+    sqlType _ = sqlType (Proxy @Text)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Types.hs
@@ -32,7 +32,7 @@ data DelegationStatusEnum
     | ActiveE
     | ActiveAndVotedE
     | VotedE
-    deriving (Eq, Show, Enum, Generic)
+    deriving (Eq, Show, Enum, Generic, Ord)
 
 instance PersistField DelegationStatusEnum where
     toPersistValue =

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Types.hs
@@ -9,11 +9,22 @@ where
 
 import Prelude
 
-import Control.Monad ((>=>))
-import Data.Proxy (Proxy (..))
-import Data.Text (Text)
-import Database.Persist.Sql (PersistField (..), PersistFieldSql (..))
-import GHC.Generics (Generic)
+import Control.Monad
+    ( (>=>)
+    )
+import Data.Proxy
+    ( Proxy (..)
+    )
+import Data.Text
+    ( Text
+    )
+import Database.Persist.Sql
+    ( PersistField (..)
+    , PersistFieldSql (..)
+    )
+import GHC.Generics
+    ( Generic
+    )
 
 data DelegationStatusEnum
     = InactiveE

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Delegations/MigrationSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Delegations/MigrationSpec.hs
@@ -14,7 +14,7 @@ import Cardano.Wallet.DB.Migration
 import Cardano.Wallet.DB.Sqlite.Migration.New
     ( newMigrationInterface
     )
-import Cardano.Wallet.DB.Store.Delegations.Migration
+import Cardano.Wallet.DB.Store.Delegations.Migrations.V3.Migration
     ( migrateDelegations
     )
 import Control.Tracer

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Delegations/Migrations/V3Spec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Delegations/Migrations/V3Spec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Cardano.Wallet.DB.Store.Delegations.MigrationSpec where
+module Cardano.Wallet.DB.Store.Delegations.Migrations.V3Spec where
 
 import Prelude
 

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Delegations/Migrations/V5Spec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Delegations/Migrations/V5Spec.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Wallet.DB.Store.Delegations.Migrations.V5Spec where
+
+import Prelude
+
+import Cardano.Wallet.DB.LayerSpec
+    ( withinCopiedFile
+    )
+import Cardano.Wallet.DB.Migration
+    ( runMigrations
+    )
+import Cardano.Wallet.DB.Sqlite.Migration.New
+    ( newMigrationInterface
+    , newStyleMigrations
+    )
+import Cardano.Wallet.DB.Store.Delegations.Schema
+    ( Delegations (..)
+    )
+import Cardano.Wallet.DB.Store.Delegations.Types
+    ( DelegationStatusEnum (..)
+    )
+import Cardano.Wallet.Primitive.Types.DRep
+    ( DRep (..)
+    , DRepID (..)
+    , DRepKeyHash (..)
+    , DRepScriptHash (..)
+    )
+import Control.Monad.IO.Class
+    ( MonadIO (..)
+    )
+import Control.Monad.Logger
+    ( NoLoggingT (..)
+    )
+import Control.Monad.Reader
+    ( ReaderT (..)
+    )
+import Control.Tracer
+    ( nullTracer
+    )
+import Database.Persist.Sql
+    ( Entity (..)
+    , PersistStoreWrite (..)
+    , insertMany_
+    , selectList
+    )
+import Database.Persist.Sqlite
+    ( withSqliteConn
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    , shouldNotBe
+    )
+import Test.QuickCheck
+    ( Gen
+    , InfiniteList (..)
+    , Positive (..)
+    , arbitrary
+    , elements
+    , generate
+    , oneof
+    )
+import UnliftIO.Resource
+    ( runResourceT
+    )
+
+import Cardano.Api
+    ( SlotNo
+    )
+import Cardano.Wallet.Primitive.Types.Pool
+    ( PoolId
+    )
+import Data.List
+    ( maximumBy
+    , sortOn
+    )
+import Data.Ord
+    ( Down (..)
+    , comparing
+    )
+
+import qualified Data.ByteString as BS
+import qualified Data.Text as T
+
+spec :: Spec
+spec =
+    describe "Delegations table migration"
+        $ it "'migrate' db new delegation table"
+        $ testMigrationDelegationsTable
+            "before_new_delegation.sqlite"
+
+testMigrationDelegationsTable :: FilePath -> IO ()
+testMigrationDelegationsTable dbName = do
+    let performMigrations path =
+            runMigrations
+                (newMigrationInterface nullTracer)
+                path
+                newStyleMigrations
+        testOnCopiedAndMigrated test = fmap snd
+            $ withinCopiedFile dbName
+            $ \path _ -> do
+                performMigrations path
+                test path
+    testOnCopiedAndMigrated persistentTableIsCompatible
+  where
+    persistentTableIsCompatible :: FilePath -> IO ()
+    persistentTableIsCompatible path = do
+        runResourceT . runNoLoggingT
+            $ withSqliteConn (T.pack path)
+            $ runReaderT
+            $ do
+                -- delegations from the migration
+                oldDelegations <-
+                    fmap entityVal
+                        <$> selectList [] []
+                liftIO $ length oldDelegations `shouldNotBe` 0
+                -- last used slot
+                let latest = maximumBy (comparing delegationSlot) oldDelegations
+                -- 10 delegations to insert
+                delegations <-
+                    sortOn delegationOrd
+                        <$> liftIO (someDelegations 10 $ delegationSlot latest)
+                insertMany_ delegations
+                -- last 10 delegations
+                delegations' <-
+                    reverse
+                        . take 10
+                        . sortOn (Down . delegationOrd)
+                        . fmap entityVal
+                        <$> selectList [] []
+                liftIO $ delegations' `shouldBe` delegations
+
+-- generate n delegations with a slot number greater than the given slot and
+-- all different slots
+generateDelegations :: Int -> SlotNo -> Gen [Delegations]
+generateDelegations 0 _ = pure []
+generateDelegations n lslot = do
+    status <-
+        elements
+            [InactiveE, RegisteredE, ActiveE, ActiveAndVotedE, VotedE]
+    drep <- oneof [pure Nothing, Just <$> arbitrary]
+    pool <- oneof [pure Nothing, Just <$> arbitraryDRep]
+    Positive dslot <- arbitrary
+    let slot = lslot + dslot
+    (Delegations slot status drep pool :) <$> generateDelegations (n - 1) lslot
+
+someDelegations :: Int -> SlotNo -> IO [Delegations]
+someDelegations n lslot = generate $ generateDelegations n lslot
+
+arbitraryDRepID :: Gen DRepID
+arbitraryDRepID = do
+    InfiniteList bytes _ <- arbitrary
+    oneof
+        [ pure $ DRepFromKeyHash $ DRepKeyHash $ BS.pack $ take 28 bytes
+        , pure $ DRepFromScriptHash $ DRepScriptHash $ BS.pack $ take 28 bytes
+        ]
+
+arbitraryDRep :: Gen DRep
+arbitraryDRep =
+    oneof [pure Abstain, pure NoConfidence, FromDRepID <$> arbitraryDRepID]
+
+delegationOrd
+    :: Delegations
+    -> (SlotNo, DelegationStatusEnum, Maybe PoolId, Maybe DRep)
+delegationOrd (Delegations slot status drep pool) = (slot, status, drep, pool)


### PR DESCRIPTION
- [x] Refactor the Delegations migrations modules to better track history in a Migrations namespace
        - V2: only contain the historical schema
        - V3: contains the migration from V2 to V3 schema and the V3 schema itself (Lean introduction)
        - V5: contains the migration from V3 to V5 (Conway changes)
        - V5 schema takes place of V3 schema at top level
 - [x] Update the schema by updating the types of delegation state and adding a nullable column to store a DRep
 - [x] Archive V3 (Lean) delegation schema so that migrations from and to it will be using the old code forever (almost)
 - [x] Move database delegation types inside the Store.Delegations namespace

ADP-3212
