### PR TITLE
[ADP-3173] Reinstate integration tests for `macOS`

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -3,24 +3,24 @@ env:
   NIX_PATH: "channel:nixos-21.11"
 
   # Per-host variables - shared across containers on host
-  macos: "x86_64-darwin"
+  macos: "aarch64-darwin"
 
 steps:
-  - label: 'Check auto-generated Nix on macos'
+  - label: 'Check auto-generated Nix on macOS'
     key: macos-nix
     commands:
       - './nix/regenerate.sh'
     agents:
       system: ${macos}
-    if: 0 == 1 # Suspended until we have a macos build agent
+      queue: "cardano-wallet"
 
-  # ADP-2522 - Fix integration tests on MacOS
-  - label: 'Run integration tests on macos'
+  - label: 'Run integration tests on macOS'
+    key: macos-tests-integration
     depends_on: macos-nix
-    command: 'GC_DONT_GC=1 nix build -L .#ci.${macos}.tests.run.integration'
+    command: nix shell 'nixpkgs#just' -c just babbage-integration-tests
     agents:
       system: ${macos}
-    if: 0 == 1 # Suspended until we have a macos build agent
+      queue: "cardano-wallet"
 
   - label: 'Restore benchmark - cardano mainnet'
     command: "./.buildkite/bench-restore.sh mainnet"

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -4,6 +4,7 @@ env:
 
   # Per-host variables - shared across containers on host
   macos: "aarch64-darwin"
+  linux: "x86_64-linux"
 
 steps:
   - label: 'Check auto-generated Nix on macOS'
@@ -26,7 +27,7 @@ steps:
     command: "./.buildkite/bench-restore.sh mainnet"
     timeout_in_minutes: 1200
     agents:
-      system: x86_64-linux
+      system: ${linux}
       queue: adrestia-bench
     if: 'build.env("step") == null || build.env("step") =~ /restore-mainnet/'
 
@@ -34,7 +35,7 @@ steps:
     command: "./.buildkite/bench-api.sh"
     timeout_in_minutes: 210
     agents:
-      system: x86_64-linux
+      system: ${linux}
       queue: adrestia-bench
     if: 'build.env("step") == null || build.env("step") =~ /bench-api/'
 
@@ -42,7 +43,7 @@ steps:
     command: "./.buildkite/bench-db.sh"
     timeout_in_minutes: 240
     agents:
-      system: x86_64-linux
+      system: ${linux}
       queue: adrestia-bench
     if: 'build.env("step") == null || build.env("step") =~ /bench-db/'
 
@@ -50,7 +51,7 @@ steps:
     command: "./.buildkite/bench-latency.sh"
     timeout_in_minutes: 120
     agents:
-      system: x86_64-linux
+      system: ${linux}
       queue: adrestia-bench
     if: 'build.env("step") == null || build.env("step") =~ /bench-latency/'
 
@@ -58,7 +59,7 @@ steps:
     command: "./.buildkite/bench-memory.sh"
     timeout_in_minutes: 30
     agents:
-      system: x86_64-linux
+      system: ${linux}
       queue: adrestia-bench
     if: 'build.env("step") == null || build.env("step") =~ /bench-memory/'
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -197,6 +197,14 @@ steps:
     agents:
       system: ${macos}
 
+  - label: 'Build integration tests (macOS, arm64)'
+    key: macos-tests-build-integration-arm64
+    depends_on: macos-nix
+    command: nix build -L .#packages.aarch64-darwin.integration-exe
+    agents:
+      system: ${macos}
+      queue: "cardano-wallet"
+
   - label: 'Build package (macOS, x86_64)'
     key: macos-package
     depends_on: macos-nix

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -184,21 +184,21 @@ steps:
       system: ${macos}
 
   - label: 'Run unit tests (macOS, x86_64)'
-    key: macos-tests-unit
+    key: macos-intel-tests-run-unit
     depends_on: macos-nix
     command: 'nix build -L .#ci.x86_64-darwin.tests.run.unit'
     agents:
       system: ${macos}
 
   - label: 'Run unit tests (macOS, arm64)'
+    key: macos-arm64-tests-run-unit
     depends_on: macos-nix
-    key: macos-build-tests-arm64
     command: 'nix build -L .#ci.aarch64-darwin.tests.run.unit'
     agents:
       system: ${macos}
 
   - label: 'Build integration tests (macOS, arm64)'
-    key: macos-tests-build-integration-arm64
+    key: macos-arm64-tests-build-integration
     depends_on: macos-nix
     command: nix build -L .#packages.aarch64-darwin.integration-exe
     agents:
@@ -206,7 +206,7 @@ steps:
       queue: "cardano-wallet"
 
   - label: 'Build package (macOS, x86_64)'
-    key: macos-package
+    key: macos-intel-package
     depends_on: macos-nix
     command: 'nix build -o result/macos-intel .#packages.x86_64-darwin.ci.artifacts.macos-intel.release'
     artifact_paths: [ "./result/macos-intel/**" ]
@@ -214,7 +214,7 @@ steps:
       system: ${macos}
 
   - label: 'Build package (macOS, arm64)'
-    key: macos-package-arm64
+    key: macos-arm64-package
     depends_on: macos-nix
     command: 'nix build -o result/macos-silicon .#packages.aarch64-darwin.ci.artifacts.macos-silicon.release'
     artifact_paths: [ "./result/macos-silicon/**" ]
@@ -293,6 +293,9 @@ steps:
       - linux-tests-unit
       - linux-tests-integration-babbage
       - linux-tests-integration-conway
+      - macos-arm64-tests-run-unit
+      - macos-arm64-tests-build-integration
+      - macos-intel-tests-run-unit
       - cabal-configure
       - code-format
       - hlint
@@ -300,8 +303,8 @@ steps:
       - lint-bash
       - hls
       - build-benchmarks
-      - macos-tests-unit
-      - macos-package
+      - macos-arm64-package
+      - macos-intel-package
       - linux-package
       - windows-package
       - windows-testing-bundle


### PR DESCRIPTION
This pull request reinstates the macOS integration tests at pre-release granularity.

### Comments

The integration tests on macOS are not free of flakiness (e.g. running out of file descriptors), but they can succeed:

<img width="543" alt="macos-integration-tests" src="https://github.com/cardano-foundation/cardano-wallet/assets/564592/f2710c1c-6eae-4e4f-ac44-c828b696af1c">

For this reason, I propose to run them at pre-release granularity, not at pre-merge granularity.

### Issue number

ADP-3173