### PR TITLE
[ADP-3212] Prefer to import `SlotNo` and `WithOrigin` from primitive lib re-exports in the wallet code

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Slotting.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Slotting.hs
@@ -70,6 +70,7 @@ module Cardano.Wallet.Primitive.Slotting
 
     -- ** Re-exports
     , SlotNo (..)
+    , WithOrigin(..)
     ) where
 
 import Prelude
@@ -85,6 +86,7 @@ import Cardano.Slotting.EpochInfo.API
     )
 import Cardano.Slotting.Slot
     ( SlotNo
+    , WithOrigin (..)
     )
 import Cardano.Wallet.Orphans
     ()

--- a/lib/wallet/src/Cardano/Pool/DB/Sqlite/TH.hs
+++ b/lib/wallet/src/Cardano/Pool/DB/Sqlite/TH.hs
@@ -33,11 +33,11 @@ import Cardano.Pool.Types
     ( PoolId (..)
     , StakePoolTicker
     )
-import Cardano.Slotting.Slot
-    ( SlotNo
-    )
 import Cardano.Wallet.DB.Sqlite.Types
     ( sqlSettings'
+    )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotNo
     )
 import Cardano.Wallet.Primitive.Types
     ()

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -274,9 +274,6 @@ import Cardano.Ledger.Api
 import Cardano.Mnemonic
     ( SomeMnemonic
     )
-import Cardano.Slotting.Slot
-    ( SlotNo (..)
-    )
 import Cardano.Wallet.Address.Book
     ( AddressBookIso
     , Prologue (..)
@@ -471,6 +468,7 @@ import Cardano.Wallet.Primitive.Passphrase
     )
 import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException (..)
+    , SlotNo (..)
     , TimeInterpreter
     , addRelTime
     , ceilingSlotAt

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -76,9 +76,6 @@ import Cardano.DB.Sqlite.Migration.Old
     ( ManualMigration (..)
     , MigrationError
     )
-import Cardano.Slotting.Slot
-    ( WithOrigin (..)
-    )
 import Cardano.Wallet.Address.Keys.WalletKey
     ( keyTypeDescriptor
     )
@@ -179,6 +176,7 @@ import Cardano.Wallet.Flavor
     )
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter
+    , WithOrigin (..)
     , hoistTimeInterpreter
     )
 import Cardano.Wallet.Primitive.Types.Coin

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Schema.hs
@@ -33,9 +33,6 @@ import Cardano.Address.Script
     ( Cosigner
     , Script
     )
-import Cardano.Slotting.Slot
-    ( SlotNo
-    )
 import Cardano.Wallet.Address.Discovery.Shared
     ( CredentialType
     )
@@ -50,6 +47,9 @@ import Cardano.Wallet.DB.Sqlite.Types
 import Cardano.Wallet.DB.Store.UTxOHistory.Model
     ( Pruned
     , Spent
+    )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotNo
     )
 import Cardano.Wallet.Primitive.Types
     ( Slot

--- a/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -37,9 +37,6 @@ import Cardano.Api
 import Cardano.Pool.Types
     ( PoolId
     )
-import Cardano.Slotting.Slot
-    ( SlotNo (..)
-    )
 import Cardano.Wallet.Address.Derivation
     ( Role (..)
     )
@@ -62,6 +59,9 @@ import Cardano.Wallet.DB.Store.UTxOHistory.Model
 import Cardano.Wallet.Primitive.Passphrase.Types
     ( Passphrase (..)
     , PassphraseScheme (..)
+    )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotNo (..)
     )
 import Cardano.Wallet.Primitive.Types
     ( EpochNo (..)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V2/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V2/Schema.hs
@@ -32,11 +32,11 @@ import Prelude
 import Cardano.Pool.Types
     ( PoolId
     )
-import Cardano.Slotting.Slot
-    ( SlotNo
-    )
 import Cardano.Wallet.DB.Sqlite.Types
     ( sqlSettings'
+    )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotNo
     )
 import Crypto.Hash
     ( Blake2b_160

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V3/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Migrations/V3/Schema.hs
@@ -30,7 +30,7 @@ import Prelude
 import Cardano.Pool.Types
     ( PoolId
     )
-import Cardano.Slotting.Slot
+import Cardano.Wallet.Primitive.Slotting
     ( SlotNo (..)
     )
 import Control.Monad

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Schema.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Schema.hs
@@ -37,14 +37,14 @@ import Prelude
 import Cardano.Pool.Types
     ( PoolId
     )
-import Cardano.Slotting.Slot
-    ( SlotNo
-    )
 import Cardano.Wallet.DB.Sqlite.Types
     ( sqlSettings'
     )
 import Cardano.Wallet.DB.Store.Delegations.Types
     ( DelegationStatusEnum
+    )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotNo
     )
 import Cardano.Wallet.Primitive.Types.DRep
     ( DRep

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Store.hs
@@ -20,9 +20,6 @@ import Prelude
 import Cardano.Pool.Types
     ( PoolId
     )
-import Cardano.Slotting.Slot
-    ( SlotNo
-    )
 import Cardano.Wallet.DB.Store.Delegations.Schema
     ( Delegations (..)
     , EntityField (DelegationSlot)
@@ -37,6 +34,9 @@ import Cardano.Wallet.Delegation.Model
     , Operation (..)
     , Status (..)
     , slotOf
+    )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotNo
     )
 import Control.Exception
     ( Exception

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Meta/Layer.hs
@@ -13,9 +13,6 @@ module Cardano.Wallet.DB.Store.Meta.Layer
 
 import Prelude
 
-import Cardano.Slotting.Slot
-    ( SlotNo
-    )
 import Cardano.Wallet.DB.Sqlite.Schema
     ( EntityField (..)
     , TxMeta (..)
@@ -29,6 +26,9 @@ import Cardano.Wallet.DB.Store.Meta.Model
     )
 import Cardano.Wallet.DB.Store.Meta.Store
     ( mkStoreMetaTransactions
+    )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotNo
     )
 import Cardano.Wallet.Primitive.Types
     ( SortOrder (..)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -12,9 +12,6 @@ import Prelude hiding
     ( (.)
     )
 
-import Cardano.Slotting.Slot
-    ( SlotNo (..)
-    )
 import Cardano.Wallet.DB.Sqlite.Schema
     ( TxCollateral (..)
     , TxIn (..)
@@ -71,7 +68,8 @@ import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Withdrawals
     ( getWithdrawals
     )
 import Cardano.Wallet.Primitive.Slotting
-    ( TimeInterpreter
+    ( SlotNo (..)
+    , TimeInterpreter
     , interpretQuery
     , slotToUTCTime
     )

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/UTxOHistory/Model.hs
@@ -37,13 +37,13 @@ where
 
 import Prelude
 
-import Cardano.Slotting.Slot
-    ( SlotNo
-    , WithOrigin (..)
-    )
 import Cardano.Wallet.DB.Store.UTxOHistory.Model.Internal
     ( Pruned (..)
     , UTxOHistory (..)
+    )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotNo
+    , WithOrigin (..)
     )
 import Cardano.Wallet.Primitive.Types
     ( Slot

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Wallets/Layer.hs
@@ -18,9 +18,6 @@ module Cardano.Wallet.DB.Store.Wallets.Layer
 
 import Prelude
 
-import Cardano.Slotting.Slot
-    ( SlotNo
-    )
 import Cardano.Wallet.DB.Sqlite.Schema
     ( CBOR
     , TxMeta (..)
@@ -44,6 +41,9 @@ import Cardano.Wallet.DB.Store.Wallets.Model
     )
 import Cardano.Wallet.DB.Store.Wallets.Store
     ( mkStoreTxWalletsHistory
+    )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotNo
     )
 import Cardano.Wallet.Primitive.Types
     ( SortOrder

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types.hs
@@ -130,17 +130,15 @@ module Cardano.Wallet.Primitive.Types
 
 import Prelude
 
-import Cardano.Slotting.Slot
-    ( SlotNo (..)
-    , WithOrigin (..)
-    )
 import Cardano.Wallet.Orphans
     ()
 import Cardano.Wallet.Primitive.Passphrase.Types
     ( WalletPassphraseInfo (..)
     )
 import Cardano.Wallet.Primitive.Slotting
-    ( StartTime (..)
+    ( SlotNo (..)
+    , StartTime (..)
+    , WithOrigin (..)
     )
 import Cardano.Wallet.Primitive.Types.Block
     ( Block (..)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxMeta.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TxMeta.hs
@@ -24,11 +24,11 @@ module Cardano.Wallet.Primitive.Types.Tx.TxMeta
 
 import Prelude
 
-import Cardano.Slotting.Slot
-    ( SlotNo (..)
-    )
 import Cardano.Wallet.Orphans
     ()
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotNo (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Delegations/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Delegations/StoreSpec.hs
@@ -23,9 +23,6 @@ import Cardano.DB.Sqlite
 import Cardano.Pool.Types
     ( PoolId (..)
     )
-import Cardano.Slotting.Slot
-    ( SlotNo (..)
-    )
 import Cardano.Wallet.DB.Arbitrary
     ()
 import Cardano.Wallet.DB.Fixtures
@@ -45,6 +42,9 @@ import Cardano.Wallet.Delegation.Model
 import Cardano.Wallet.Delegation.ModelSpec
     ( Config (..)
     , genDelta
+    )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotNo (..)
     )
 import Control.Monad.IO.Class
     ( liftIO

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Meta/StoreSpec.hs
@@ -13,9 +13,6 @@ import Cardano.DB.Sqlite
     ( ForeignKeysSetting (..)
     , runQuery
     )
-import Cardano.Slotting.Slot
-    ( SlotNo
-    )
 import Cardano.Wallet.DB.Arbitrary
     ()
 import Cardano.Wallet.DB.Fixtures
@@ -47,6 +44,9 @@ import Cardano.Wallet.DB.Store.Meta.ModelSpec
     )
 import Cardano.Wallet.DB.Store.Meta.Store
     ( mkStoreMetaTransactions
+    )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotNo
     )
 import Cardano.Wallet.Primitive.Types
     ( SortOrder (Ascending, Descending)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/UTxOHistory/ModelSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/UTxOHistory/ModelSpec.hs
@@ -11,10 +11,6 @@ module Cardano.Wallet.DB.Store.UTxOHistory.ModelSpec
 
 import Prelude
 
-import Cardano.Slotting.Slot
-    ( SlotNo (..)
-    , WithOrigin (..)
-    )
 import Cardano.Wallet.DB.Store.UTxOHistory.Model
     ( DeltaUTxOHistory (..)
     , Pruned (..)
@@ -24,6 +20,10 @@ import Cardano.Wallet.DB.Store.UTxOHistory.Model
     , getSpent
     , getTip
     , getUTxO
+    )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotNo (..)
+    , WithOrigin (..)
     )
 import Cardano.Wallet.Primitive.Types
     ( Slot


### PR DESCRIPTION
Following up a suggestion in https://github.com/cardano-foundation/cardano-wallet/pull/4434 we try to import as much as possible from internal libraries in the wallet code

- [x] Change imports of SlotNo and WithOrigin from Cardano.Slotting.SlotNo to Cardano.Wallet.Primitive.Slotting in the wallet code

ADP-3212