### PR TITLE
[ADP-3212] Restructure delegation datatypes to match Conway specs

### DIFF
--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -797,7 +797,7 @@ mkDBLayerCollection ti wid atomically_ walletState =
                         , UpdateSubmissions
                             $ rollBackSubmissions nearestSlotNo
                         , UpdateDelegations
-                            [Dlgs.Rollback nearestSlotNo]
+                            $ Dlgs.Rollback nearestSlotNo
                         ]
                     ,   case Map.lookup nearestPoint
                                 (wal ^. #checkpoints . #checkpoints) of

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Model.hs
@@ -19,25 +19,24 @@ import Cardano.Wallet.Delegation.Model
 import Cardano.Wallet.Primitive.Types
     ( SlotNo
     )
+import Cardano.Wallet.Primitive.Types.DRep
+    ( DRep
+    )
 import Fmt
     ( Buildable (..)
-    , listF'
     )
 
 -- | Wallet delegation history
-type Delegations = History SlotNo PoolId
+type Delegations = History SlotNo DRep PoolId
 
 -- | Delta of wallet delegation history. As always with deltas, the
 -- order of the operations matters and it's reversed! (ask the architects)
-type DeltaDelegations = [Operation SlotNo PoolId]
+type DeltaDelegations = Operation SlotNo DRep PoolId
 
 instance Buildable DeltaDelegations where
-    build = listF' build1
-      where
-        build1 = \case
-            Register slot -> "Register " <> build slot
+    build = \case
             Deregister slot -> "Deregister " <> build slot
-            Delegate pool slot -> "Delegate " <> build pool <> " " <> build slot
-            DelegateAndVote pool vote slot -> "Delegate " <> build pool <> " and vote "<> build vote <> " " <> build slot
-            Vote vote slot -> "Vote " <> build vote <> " " <> build slot
+            VoteAndDelegate vote pool slot ->
+                    "Delegate " <> build pool
+                        <> " and vote "<> build vote <> " " <> build slot
             Rollback slot -> "Rollback " <> build slot

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/WalletState/Store.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/WalletState/Store.hs
@@ -124,9 +124,6 @@ mkStoreWallet wF wid = mkUpdateStore load write update
         update1 _ (UpdateInfo delta) = updateS infoStore Nothing delta
         update1 _ (UpdateCredentials delta) = do
             updateS pkStore Nothing delta
-        update1 s (UpdateDelegations deltas) = do
-            updateSequence
-                (updateS delegationsStore . Just)
-                (delegations s)
-                deltas
+        update1 s (UpdateDelegations delta) = do
+            updateS delegationsStore (Just $ delegations s) delta
         update1 _ (UpdateRewards delta) = updateS rewardsStore Nothing delta

--- a/lib/wallet/src/Cardano/Wallet/Delegation/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation/Model.hs
@@ -15,9 +15,6 @@ module Cardano.Wallet.Delegation.Model
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.DRep
-    ( DRep
-    )
 import Data.Delta
     ( Delta (..)
     )
@@ -31,38 +28,29 @@ import Data.Map.Strict
 import qualified Data.Map.Strict as Map
 
 -- | Delta type for the delegation 'History'.
-data Operation slot pool
-    = Register slot
+data Operation slot drep pool
+    = VoteAndDelegate (Maybe drep) (Maybe pool) slot
     | Deregister slot
-    | Delegate pool slot
-    | DelegateAndVote pool DRep slot
-    | Vote DRep slot
     | Rollback slot
     deriving (Show)
 
 -- | Target slot of each 'Operation'.
-slotOf :: Operation slot pool -> slot
-slotOf (Register x) = x
+slotOf :: Operation slot drep pool -> slot
 slotOf (Deregister x) = x
-slotOf (Delegate _ x) = x
-slotOf (DelegateAndVote _ _ x) = x
-slotOf (Vote _ x) = x
 slotOf (Rollback x) = x
+slotOf (VoteAndDelegate _ _ x) = x
 
 -- | Valid state for the delegations, independent of time.
-data Status pool
+data Status drep pool
     = Inactive
-    | Registered
-    | Active pool
-    | ActiveAndVoted pool DRep
-    | Voted DRep
+    | Active (Maybe drep) (Maybe pool)
     deriving (Show, Eq)
 
 -- | Delegation history implementation.
-type History slot pool = Map slot (Status pool)
+type History slot drep pool = Map slot (Status drep pool)
 
-instance (Ord slot, Eq pool) => Delta (Operation slot pool) where
-    type Base (Operation slot pool) = History slot pool
+instance (Ord slot, Eq pool, Eq drep) => Delta (Operation slot drep pool) where
+    type Base (Operation slot drep pool) = History slot drep pool
     apply r hist = hist' & if miss == wanted then id else Map.insert slot wanted
       where
         slot = slotOf r
@@ -70,28 +58,24 @@ instance (Ord slot, Eq pool) => Delta (Operation slot pool) where
         miss = status slot hist'
         wanted = transition r $ status slot hist
 
-transition :: Operation slot pool -> Status pool -> Status pool
-transition (Register _) Inactive = Registered
-transition (Delegate p _) Registered = Active p
-transition (Delegate p _) (Active _) = Active p
-transition (Vote v _) Registered = Voted v
-transition (DelegateAndVote p v _) Registered = ActiveAndVoted p v
-transition (Vote v _) (Voted _) = Voted v
-transition (Delegate p _) (Voted v) = ActiveAndVoted p v
-transition (DelegateAndVote p v _) (Voted _) = ActiveAndVoted p v
-transition (Vote v _) (Active p) = ActiveAndVoted p v
-transition (DelegateAndVote p v _) (Active _) = ActiveAndVoted p v
-transition (DelegateAndVote p v _) (ActiveAndVoted _ _) = ActiveAndVoted p v
-transition (Delegate p _) (ActiveAndVoted _ v) = ActiveAndVoted p v
-transition (Vote v _) (ActiveAndVoted p _) = ActiveAndVoted p v
+transition :: Operation slot drep pool -> Status drep pool -> Status drep pool
 transition (Deregister _) _ = Inactive
+transition (VoteAndDelegate d p _) (Active d' p') = Active d'' p''
+    where
+        d'' = insertIfJust d d'
+        p'' = insertIfJust p p'
+transition (VoteAndDelegate d p _) _ = Active d p
 transition _ s = s
 
-type Change slot pool = History slot pool -> History slot pool
+insertIfJust :: Maybe a -> Maybe a -> Maybe a
+insertIfJust (Just y) _ = Just y
+insertIfJust Nothing x = x
 
-cut :: (slot -> Bool) -> Change slot pool
+type Change slot drep pool = History slot drep pool -> History slot drep pool
+
+cut :: (slot -> Bool) -> Change slot drep pool
 cut op = fst . Map.spanAntitone op
 
 -- | Status of the delegation at a given slot.
-status :: Ord slot => slot -> History slot pool -> Status pool
+status :: Ord slot => slot -> Map slot (Status drep pool) -> Status drep pool
 status x = maybe Inactive snd . Map.lookupMax . cut (<= x)

--- a/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Delegations/StoreSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/DB/Store/Delegations/StoreSpec.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- |
@@ -46,14 +48,14 @@ import Cardano.Wallet.Delegation.ModelSpec
     ( Config (..)
     , genDelta
     )
+import Cardano.Wallet.Primitive.Types.DRep
+    ( DRep
+    )
 import Control.Monad.IO.Class
     ( liftIO
     )
 import Data.List
     ( nub
-    )
-import Fmt
-    ( Buildable (..)
     )
 import Test.Hspec
     ( Spec
@@ -98,7 +100,7 @@ prop_StoreDelegationsLaws db _ =
         (pure mempty)
         (logScale . genDelta conf)
 
-conf :: Config SlotNo PoolId
+conf :: Config SlotNo DRep PoolId
 conf =
     Config
         { genSlotBefore = \t -> toEnum <$> choose (0, fromEnum t)
@@ -106,18 +108,40 @@ conf =
             toEnum <$> choose (fromEnum t + 1, fromEnum t + 10)
         , genSlotNew = toEnum <$> choose (0, 9)
         , genNewPool = \xs -> arbitrary `suchThat` (not . (`elem` xs))
+        , genNewDRep = \xs -> arbitrary `suchThat` (not . (`elem` xs))
         }
 
-instance Buildable (Operation SlotNo PoolId) where
-    build = build . show
+pattern Register :: slot -> Operation slot drep pool
+pattern Register i = VoteAndDelegate Nothing Nothing i
+
+pattern Delegate :: pool -> slot -> Operation slot drep pool
+pattern Delegate p i = VoteAndDelegate Nothing (Just p) i
+
+pattern Vote :: drep -> slot -> Operation slot drep pool
+pattern Vote v i = VoteAndDelegate (Just v) Nothing i
+
+pattern DelegateAndVote :: pool -> drep -> slot -> Operation slot drep pool
+pattern DelegateAndVote p v i = VoteAndDelegate (Just v) (Just p) i
+
+pattern Registered :: Status drep pool
+pattern Registered = Active Nothing Nothing
+
+pattern Delegating :: pool -> Status drep pool
+pattern Delegating p = Active Nothing (Just p)
+
+pattern Voting :: drep -> Status drep pool
+pattern Voting v = Active (Just v) Nothing
+
+pattern DelegatingAndVoting :: pool -> drep -> Status drep pool
+pattern DelegatingAndVoting p v = Active (Just v) (Just p)
 
 units :: WalletProperty
 units = withInitializedWalletProp $ \_ runQ -> do
-    [p0, p1, _p2] <-
+    [p0 :: PoolId, p1, _p2] <-
         liftIO
             $ generate
             $ vectorOf 3 arbitrary `suchThat` (\xs -> xs == nub xs)
-    [v0, v1, _v2] <-
+    [v0 :: DRep , v1, _v2] <-
         liftIO
             $ generate
             $ vectorOf 3 arbitrary `suchThat` (\xs -> xs == nub xs)
@@ -146,17 +170,17 @@ units = withInitializedWalletProp $ \_ runQ -> do
         unit "reg-deleg" $ do
             applyS $ Register 0
             applyS $ Delegate p0 0
-            observeStatus 0 $ Active p0
+            observeStatus 0 $ Delegating p0
         unit "reg-deleg 2" $ do
             applyS $ Register 0
             applyS $ Delegate p0 0
             applyS $ Delegate p1 0
-            observeStatus 0 $ Active p1
+            observeStatus 0 $ Delegating p1
         unit "reg-deleg different time" $ do
             applyS $ Register 0
             applyS $ Delegate p0 1
             applyS $ Delegate p1 2
-            observeStatus 2 $ Active p1
+            observeStatus 2 $ Delegating p1
         unit "reg-deleg-dereg" $ do
             applyS $ Register 0
             applyS $ Delegate p0 0
@@ -165,17 +189,17 @@ units = withInitializedWalletProp $ \_ runQ -> do
         unit "reg-vote" $ do
             applyS $ Register 0
             applyS $ Vote v0 0
-            observeStatus 0 $ Voted v0
+            observeStatus 0 $ Voting v0
         unit "reg-vote 2" $ do
             applyS $ Register 0
             applyS $ Vote v0 0
             applyS $ Vote v1 0
-            observeStatus 0 $ Voted v1
+            observeStatus 0 $ Voting v1
         unit "reg-vote different time" $ do
             applyS $ Register 0
             applyS $ Vote v0 1
             applyS $ Vote v1 2
-            observeStatus 2 $ Voted v1
+            observeStatus 2 $ Voting v1
         unit "reg-vote-dereg" $ do
             applyS $ Register 0
             applyS $ Vote v0 0
@@ -184,17 +208,17 @@ units = withInitializedWalletProp $ \_ runQ -> do
         unit "reg-deleg-and-vote" $ do
             applyS $ Register 0
             applyS $ DelegateAndVote p0 v0 0
-            observeStatus 0 $ ActiveAndVoted p0 v0
+            observeStatus 0 $ DelegatingAndVoting p0 v0
         unit "reg-deleg-and-vote 2" $ do
             applyS $ Register 0
             applyS $ DelegateAndVote p0 v0 0
             applyS $ DelegateAndVote p1 v1 0
-            observeStatus 0 $ ActiveAndVoted p1 v1
+            observeStatus 0 $ DelegatingAndVoting p1 v1
         unit "reg-deleg-and-vote different time" $ do
             applyS $ Register 0
             applyS $ DelegateAndVote p0 v0 1
             applyS $ DelegateAndVote p1 v1 2
-            observeStatus 2 $ ActiveAndVoted p1 v1
+            observeStatus 2 $ DelegatingAndVoting p1 v1
         unit "reg-deleg-and-vote-dereg" $ do
             applyS $ Register 0
             applyS $ DelegateAndVote p0 v0 0
@@ -204,42 +228,42 @@ units = withInitializedWalletProp $ \_ runQ -> do
             applyS $ Register 0
             applyS $ Delegate p0 0
             applyS $ Vote v0 0
-            observeStatus 0 $ ActiveAndVoted p0 v0
+            observeStatus 0 $ DelegatingAndVoting p0 v0
         unit "reg-deleg-then-vote different time" $ do
             applyS $ Register 0
             applyS $ Delegate p0 1
             applyS $ Vote v1 2
-            observeStatus 2 $ ActiveAndVoted p0 v1
+            observeStatus 2 $ DelegatingAndVoting p0 v1
         unit "reg-vote-then-deleg" $ do
             applyS $ Register 0
             applyS $ Vote v0 0
             applyS $ Delegate p0 0
-            observeStatus 0 $ ActiveAndVoted p0 v0
+            observeStatus 0 $ DelegatingAndVoting p0 v0
         unit "reg-vote-then-deleg different time" $ do
             applyS $ Register 0
             applyS $ Vote v0 1
             applyS $ Delegate p0 2
-            observeStatus 2 $ ActiveAndVoted p0 v0
+            observeStatus 2 $ DelegatingAndVoting p0 v0
         unit "reg-deleg-then-deleg-and-vote" $ do
             applyS $ Register 0
             applyS $ Delegate p0 0
             applyS $ DelegateAndVote p1 v0 0
-            observeStatus 0 $ ActiveAndVoted p1 v0
+            observeStatus 0 $ DelegatingAndVoting p1 v0
         unit "reg-deleg-then-deleg-and-vote different time" $ do
             applyS $ Register 0
             applyS $ Delegate p0 1
             applyS $ DelegateAndVote p1 v1 2
-            observeStatus 2 $ ActiveAndVoted p1 v1
+            observeStatus 2 $ DelegatingAndVoting p1 v1
         unit "reg-vote-then-deleg-and-vote" $ do
             applyS $ Register 0
             applyS $ Vote v0 0
             applyS $ DelegateAndVote p0 v1 0
-            observeStatus 0 $ ActiveAndVoted p0 v1
+            observeStatus 0 $ DelegatingAndVoting p0 v1
         unit "reg-vote-then-deleg-and-vote different time" $ do
             applyS $ Register 0
             applyS $ Vote v0 1
             applyS $ DelegateAndVote p0 v1 2
-            observeStatus 2 $ ActiveAndVoted p0 v1
+            observeStatus 2 $ DelegatingAndVoting p0 v1
         ignore
             $ unit "xxxx"
             $ observeStatus 2 Registered


### PR DESCRIPTION
Follow up on #4433. As ledger Conway specs regarding Certificates has changed we try to follow their data model in our Store

- [x] Update delegations Operations
- [x] Update delegations Status 

A follow up to this PR will update the lean specifications

ADP-3212
