### PR TITLE
[ADP-3226] Use even more `IsRecentEra`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -995,9 +995,9 @@ selectAssets pp utxoAssumptions outs' redeemers
         , computeMinimumAdaQuantity = \addr tokens -> Convert.toWallet $
             computeMinimumCoinForTxOut
                 pp
-                (mkLedgerTxOut era addr (W.TokenBundle W.txOutMaxCoin tokens))
+                (mkLedgerTxOut addr (W.TokenBundle W.txOutMaxCoin tokens))
         , isBelowMinimumAdaQuantity = \addr bundle ->
-            isBelowMinimumCoinForTxOut pp (mkLedgerTxOut era addr bundle)
+            isBelowMinimumCoinForTxOut pp (mkLedgerTxOut addr bundle)
         , computeMinimumCost = \skeleton -> mconcat
             [ feePadding
             , fee0
@@ -1044,12 +1044,11 @@ selectAssets pp utxoAssumptions outs' redeemers
 
     mkLedgerTxOut
         :: HasCallStack
-        => RecentEra era
-        -> W.Address
+        => W.Address
         -> W.TokenBundle
         -> TxOut era
-    mkLedgerTxOut txOutEra address bundle =
-        case txOutEra of
+    mkLedgerTxOut address bundle =
+        case era of
             RecentEraBabbage -> Convert.toBabbageTxOut txOut
             RecentEraConway -> Convert.toConwayTxOut txOut
           where

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -1242,13 +1242,10 @@ updateTx tx extraContent = do
         Map.fromList $ map (pairWithHash . convert) extraInputScripts
       where
         pairWithHash s = (hashScript s, s)
-        convert = flip toLedgerScript (recentEra @era)
+        convert = toLedgerScript
 
-    toLedgerScript
-        :: CA.Script CA.KeyHash
-        -> RecentEra era
-        -> Core.Script era
-    toLedgerScript s = \case
+    toLedgerScript :: CA.Script CA.KeyHash -> Core.Script era
+    toLedgerScript s = case recentEra @era of
         RecentEraBabbage -> TimelockScript $ Convert.toLedgerTimelockScript s
         RecentEraConway -> TimelockScript $ Convert.toLedgerTimelockScript s
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -487,7 +487,7 @@ fromWalletUTxO
     -> UTxO era
 fromWalletUTxO (W.UTxO m) = UTxO
     $ Map.mapKeys Convert.toLedger
-    $ Map.map (toLedgerTxOut (recentEra @era)) m
+    $ Map.map toLedgerTxOut m
 
 toWalletUTxO
     :: forall era. IsRecentEra era
@@ -1262,9 +1262,8 @@ modifyShelleyTxBody txUpdate =
     . over collateralInputsTxBodyL
         (<> extraCollateral')
   where
-    era = recentEra @era
     TxUpdate extraInputs extraCollateral extraOutputs _ feeUpdate = txUpdate
-    extraOutputs' = StrictSeq.fromList $ map (toLedgerTxOut era) extraOutputs
+    extraOutputs' = StrictSeq.fromList $ map toLedgerTxOut extraOutputs
     extraInputs' = Set.fromList (Convert.toLedger . fst <$> extraInputs)
     extraCollateral' = Set.fromList $ Convert.toLedger <$> extraCollateral
 
@@ -1490,12 +1489,11 @@ burnSurplusAsFees feePolicy surplus (TxFeeAndChange fee0 ())
     shortfall = costOfBurningSurplus <\> surplus
 
 toLedgerTxOut
-    :: HasCallStack
-    => RecentEra era
-    -> W.TxOut
+    :: forall era. (HasCallStack, IsRecentEra era)
+    => W.TxOut
     -> TxOut era
-toLedgerTxOut txOutEra txOut =
-    case txOutEra of
+toLedgerTxOut txOut =
+    case recentEra @era of
         RecentEraBabbage -> Convert.toBabbageTxOut txOut
         RecentEraConway -> Convert.toConwayTxOut txOut
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -1239,10 +1239,9 @@ updateTx tx extraContent = do
     extraInputScripts'
         :: Map (ScriptHash StandardCrypto) (Script era)
     extraInputScripts' =
-        Map.fromList $ map (pairWithHash . convert) extraInputScripts
+        Map.fromList $ map (pairWithHash . toLedgerScript) extraInputScripts
       where
         pairWithHash s = (hashScript s, s)
-        convert = toLedgerScript
 
     toLedgerScript :: CA.Script CA.KeyHash -> Core.Script era
     toLedgerScript s = case recentEra @era of

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -33,7 +33,6 @@ import Data.Word
 import Internal.Cardano.Write.Tx
     ( IsRecentEra (..)
     , ProtVer (..)
-    , RecentEra (..)
     , StandardBabbage
     , StandardConway
     , Version
@@ -274,16 +273,12 @@ data PParamsInRecentEra
 
 instance Arbitrary PParamsInRecentEra where
     arbitrary = oneof
-        [ PParamsInBabbage <$> genPParams RecentEraBabbage
-        , PParamsInConway <$> genPParams RecentEraConway
+        [ PParamsInBabbage <$> genPParams
+        , PParamsInConway <$> genPParams
         ]
-
       where
-        genPParams
-            :: IsRecentEra era
-            => RecentEra era
-            -> Gen (PParams era)
-        genPParams _era = do
+        genPParams :: IsRecentEra era => Gen (PParams era)
+        genPParams = do
             ver <- arbitrary
             maxSize <- genMaxSizeBytes
             return $ def

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2772,7 +2772,7 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
             trWorker :: Tracer IO W.WalletLog
             trWorker = MsgWallet >$< wrk ^. logger
 
-        (Write.PParamsInAnyRecentEra era pp, _)
+        (Write.PParamsInAnyRecentEra (_era :: Write.RecentEra era) pp, _)
             <- liftIO $ W.readNodeTipStateForTxWrite netLayer
 
         withdrawal <- case body ^. #withdrawal of
@@ -2904,7 +2904,7 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
                 Nothing -> []
 
         unbalancedTx <- liftHandler $
-            W.constructTransaction @n era
+            W.constructTransaction @n @era
                 db transactionCtx3
                     PreSelection { outputs = outs <> mintingOuts }
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3305,7 +3305,7 @@ constructSharedTransaction
             trWorker = MsgWallet >$< wrk ^. logger
 
         currentEpochSlotting <- liftIO $ getCurrentEpochSlotting netLayer
-        (Write.PParamsInAnyRecentEra era pp, _)
+        (Write.PParamsInAnyRecentEra (_era :: Write.RecentEra era) pp, _)
             <- liftIO $ W.readNodeTipStateForTxWrite netLayer
         (cp, _, _) <- handler $ W.readWallet wrk
 
@@ -3347,7 +3347,7 @@ constructSharedTransaction
                         Just (ApiPaymentAddresses content) ->
                             F.toList (addressAmountToTxOut <$> content)
                 (unbalancedTx, scriptLookup) <- liftHandler $
-                    W.constructUnbalancedSharedTransaction @n era
+                    W.constructUnbalancedSharedTransaction @n @era
                     db txCtx PreSelection {outputs = outs}
 
                 balancedTx <-

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2076,7 +2076,7 @@ selectCoins ctx@ApiLayer {..} argGenChange (ApiT walletId) body = do
     withWorkerCtx ctx walletId liftE liftE $ \workerCtx -> do
         let db = workerCtx ^. dbLayer
 
-        (Write.PParamsInAnyRecentEra era pp, timeTranslation)
+        (Write.PParamsInAnyRecentEra _era pp, timeTranslation)
             <- liftIO $ W.readNodeTipStateForTxWrite netLayer
 
         withdrawal <-
@@ -2095,7 +2095,7 @@ selectCoins ctx@ApiLayer {..} argGenChange (ApiT walletId) body = do
 
         (tx, walletState) <-
             liftIO $
-            W.buildTransaction @s era
+            W.buildTransaction @s
             db timeTranslation genChange pp txCtx paymentOuts
 
         let W.CoinSelection{..} =
@@ -2142,7 +2142,7 @@ selectCoinsForJoin ctx@ApiLayer{..}
     --
     poolStatus <- liftIO $ getPoolStatus poolId
     pools <- liftIO knownPools
-    (Write.PParamsInAnyRecentEra era pp, timeTranslation)
+    (Write.PParamsInAnyRecentEra _era pp, timeTranslation)
         <- liftIO @Handler $ W.readNodeTipStateForTxWrite netLayer
     withWorkerCtx ctx walletId liftE liftE $ \workerCtx -> liftIO $ do
         let db = workerCtx ^. typed @(DBLayer IO s)
@@ -2161,7 +2161,7 @@ selectCoinsForJoin ctx@ApiLayer{..}
         let paymentOuts = []
 
         (tx, walletState) <-
-            W.buildTransaction @s era
+            W.buildTransaction @s
             db timeTranslation changeAddrGen pp txCtx paymentOuts
 
         let W.CoinSelection{..} =
@@ -2198,7 +2198,7 @@ selectCoinsForQuit
     -> ApiT WalletId
     -> Handler (ApiCoinSelection n)
 selectCoinsForQuit ctx@ApiLayer{..} (ApiT walletId) = do
-    (Write.PParamsInAnyRecentEra era pp, timeTranslation)
+    (Write.PParamsInAnyRecentEra _era pp, timeTranslation)
         <- liftIO $ W.readNodeTipStateForTxWrite netLayer
     withWorkerCtx ctx walletId liftE liftE $ \workerCtx -> liftIO $ do
         let db = workerCtx ^. typed @(DBLayer IO s)
@@ -2218,7 +2218,7 @@ selectCoinsForQuit ctx@ApiLayer{..} (ApiT walletId) = do
         let paymentOuts = []
 
         (tx, walletState) <-
-            W.buildTransaction @s era
+            W.buildTransaction @s
             db timeTranslation changeAddrGen pp txCtx paymentOuts
 
         let W.CoinSelection{..} =

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2496,12 +2496,11 @@ constructTransaction
         ( HasSNetworkId n
         , Write.IsRecentEra era
         )
-    => Write.RecentEra era
-    -> DBLayer IO (SeqState n ShelleyKey)
+    => DBLayer IO (SeqState n ShelleyKey)
     -> TransactionCtx
     -> PreSelection
     -> ExceptT ErrConstructTx IO (Cardano.TxBody (Write.CardanoApiEra era))
-constructTransaction _era db txCtx preSel = do
+constructTransaction db txCtx preSel = do
     (_, xpub, _) <- lift $ readRewardAccount db
     mkUnsignedTransaction netId (Left $ fromJust xpub) txCtx (Left preSel)
         & withExceptT ErrConstructTxBody . except

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -846,7 +846,6 @@ import qualified Internal.Cardano.Write.Tx as Write
     , IsRecentEra
     , PParams
     , PParamsInAnyRecentEra (PParamsInAnyRecentEra)
-    , RecentEra
     , Tx
     , UTxO (UTxO)
     , cardanoEraFromRecentEra
@@ -2512,15 +2511,14 @@ constructUnbalancedSharedTransaction
         ( HasSNetworkId n
         , Write.IsRecentEra era
         )
-    => Write.RecentEra era
-    -> DBLayer IO (SharedState n SharedKey)
+    => DBLayer IO (SharedState n SharedKey)
     -> TransactionCtx
     -> PreSelection
     -> ExceptT ErrConstructTx IO
         ( Cardano.TxBody (Write.CardanoApiEra era)
         , (Address -> CA.Script KeyHash)
         )
-constructUnbalancedSharedTransaction _era db txCtx sel = db & \DBLayer{..} -> do
+constructUnbalancedSharedTransaction db txCtx sel = db & \DBLayer{..} -> do
     cp <- lift $ atomically readCheckpoint
     let s = getState cp
         scriptM =

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2318,8 +2318,7 @@ buildTransaction
         , HasSNetworkId (NetworkOf s)
         , Excluding '[SharedKey] (KeyOf s)
         )
-    => Write.RecentEra era
-    -> DBLayer IO s
+    => DBLayer IO s
     -> TimeTranslation
     -> ChangeAddressGen s
     -> Write.PParams era
@@ -2327,7 +2326,7 @@ buildTransaction
     -> [TxOut]
     -- ^ payment outputs
     -> IO (Write.Tx era, Wallet s)
-buildTransaction _era DBLayer{..} timeTranslation changeAddrGen
+buildTransaction DBLayer{..} timeTranslation changeAddrGen
     protocolParameters txCtx paymentOuts = do
     stdGen <- initStdGen
     atomically $ do

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -358,7 +358,7 @@ mkTransaction
     -- ^ A balanced coin selection where all change addresses have been
     -- assigned.
     -> Either ErrMkTransaction (Tx, SealedTx)
-mkTransaction era networkId keyF stakeCreds addrResolver ctx cs = do
+mkTransaction _era networkId keyF stakeCreds addrResolver ctx cs = do
     let ttl = txValidityInterval ctx
     let wdrl = view #txWithdrawal ctx
     let delta = selectionDelta cs
@@ -369,7 +369,7 @@ mkTransaction era networkId keyF stakeCreds addrResolver ctx cs = do
                     mempty
                 Just action ->
                     let stakeXPub = toXPub $ fst stakeCreds
-                    in certificateFromDelegationAction era (Left stakeXPub) action
+                    in certificateFromDelegationAction (Left stakeXPub) action
     let wdrls = mkWithdrawals networkId wdrl
     unsigned <-
         mkUnsignedTx
@@ -734,9 +734,9 @@ mkUnsignedTransaction networkId stakeCred ctx selection = do
         Just action -> do
             let certs = case stakeCred of
                     Left xpub ->
-                        certificateFromDelegationAction era (Left xpub) action
+                        certificateFromDelegationAction (Left xpub) action
                     Right (Just script) ->
-                        certificateFromDelegationAction era (Right script) action
+                        certificateFromDelegationAction (Right script) action
                     Right Nothing ->
                         error $ unwords
                             [ "stakeCred in mkUnsignedTransaction must be"

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -230,7 +230,6 @@ import Data.Word
     )
 import Internal.Cardano.Write.Tx
     ( CardanoApiEra
-    , RecentEra (..)
     )
 import Internal.Cardano.Write.Tx.SizeEstimation
     ( TxSkeleton (..)
@@ -345,7 +344,7 @@ constructUnsignedTx
 
 mkTransaction
     :: forall era k. Write.IsRecentEra era
-    => RecentEra era
+    => Write.RecentEra era
     -- ^ Era for which the transaction should be created.
     -> Cardano.NetworkId
     -> KeyFlavorS k
@@ -993,8 +992,8 @@ mkUnsignedTx
             Cardano.SimpleScript'
             (Write.CardanoApiEra era)
     scriptWitsSupported = case era of
-        RecentEraBabbage -> Cardano.SimpleScriptInBabbage
-        RecentEraConway -> Cardano.SimpleScriptInConway
+        Write.RecentEraBabbage -> Cardano.SimpleScriptInBabbage
+        Write.RecentEraConway -> Cardano.SimpleScriptInConway
 
     toScriptWitness
         :: Script KeyHash
@@ -1036,18 +1035,18 @@ mkUnsignedTx
 
     allegraOnwards :: Cardano.AllegraEraOnwards (CardanoApiEra era)
     allegraOnwards = case era of
-        RecentEraBabbage -> Cardano.AllegraEraOnwardsBabbage
-        RecentEraConway  -> Cardano.AllegraEraOnwardsConway
+        Write.RecentEraBabbage -> Cardano.AllegraEraOnwardsBabbage
+        Write.RecentEraConway -> Cardano.AllegraEraOnwardsConway
 
     maryOnwards :: Cardano.MaryEraOnwards (CardanoApiEra era)
     maryOnwards = case era of
-        RecentEraBabbage -> Cardano.MaryEraOnwardsBabbage
-        RecentEraConway  -> Cardano.MaryEraOnwardsConway
+        Write.RecentEraBabbage -> Cardano.MaryEraOnwardsBabbage
+        Write.RecentEraConway -> Cardano.MaryEraOnwardsConway
 
     babbageOnwards :: Cardano.BabbageEraOnwards (CardanoApiEra era)
     babbageOnwards = case era of
-        RecentEraBabbage -> Cardano.BabbageEraOnwardsBabbage
-        RecentEraConway  -> Cardano.BabbageEraOnwardsConway
+        Write.RecentEraBabbage -> Cardano.BabbageEraOnwardsBabbage
+        Write.RecentEraConway -> Cardano.BabbageEraOnwardsConway
 
 -- TODO: ADP-2257
 -- cardano-node does not allow to construct tx without inputs at this moment.
@@ -1119,8 +1118,10 @@ mkByronWitness
   where
     era = Write.recentEra @era
     txHash = case era of
-        RecentEraBabbage -> Crypto.castHash $ Crypto.hashWith serialize' body
-        RecentEraConway  -> Crypto.castHash $ Crypto.hashWith serialize' body
+        Write.RecentEraBabbage ->
+            Crypto.castHash $ Crypto.hashWith serialize' body
+        Write.RecentEraConway ->
+            Crypto.castHash $ Crypto.hashWith serialize' body
 
     unencrypt (xprv, pwd) = CC.SigningKey
         $ Crypto.HD.xPrvChangePass pwd BS.empty xprv

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -1116,12 +1116,7 @@ mkByronWitness
     Cardano.ShelleyBootstrapWitness cardanoEra $
         SL.makeBootstrapWitness txHash (unencrypt encryptedKey) addrAttr
   where
-    era = Write.recentEra @era
-    txHash = case era of
-        Write.RecentEraBabbage ->
-            Crypto.castHash $ Crypto.hashWith serialize' body
-        Write.RecentEraConway ->
-            Crypto.castHash $ Crypto.hashWith serialize' body
+    txHash = Crypto.castHash $ Crypto.hashWith serialize' body
 
     unencrypt (xprv, pwd) = CC.SigningKey
         $ Crypto.HD.xPrvChangePass pwd BS.empty xprv

--- a/lib/wallet/src/Cardano/Wallet/Transaction/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction/Delegation.hs
@@ -57,15 +57,14 @@ import qualified Internal.Cardano.Write.Tx as Write
 
 certificateFromDelegationAction
     :: forall era. Write.IsRecentEra era
-    => Write.RecentEra era
         -- ^ Era in which we create the certificate
-    -> Either XPub (Script KeyHash)
+    => Either XPub (Script KeyHash)
         -- ^ Our staking credential
     -> DelegationAction
         -- ^ Delegation action that we plan to take
     -> [Cardano.Certificate (Write.CardanoApiEra era)]
         -- ^ Certificates representing the action
-certificateFromDelegationAction _era = case Write.recentEra @era of
+certificateFromDelegationAction = case Write.recentEra @era of
     Write.RecentEraBabbage -> \cred -> \case
         Join poolId ->
             [ Cardano.makeStakeAddressDelegationCertificate

--- a/lib/wallet/src/Cardano/Wallet/Transaction/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction/Delegation.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Copyright: © 2024 Cardano Foundation
@@ -45,6 +47,7 @@ import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Ledger.Keys as Ledger
 import qualified Internal.Cardano.Write.Tx as Write
     ( CardanoApiEra
+    , IsRecentEra (recentEra)
     , RecentEra (RecentEraBabbage, RecentEraConway)
     )
 
@@ -53,7 +56,8 @@ import qualified Internal.Cardano.Write.Tx as Write
 ------------------------------------------------------------------------------}
 
 certificateFromDelegationAction
-    :: Write.RecentEra era
+    :: forall era. Write.IsRecentEra era
+    => Write.RecentEra era
         -- ^ Era in which we create the certificate
     -> Either XPub (Script KeyHash)
         -- ^ Our staking credential
@@ -61,7 +65,7 @@ certificateFromDelegationAction
         -- ^ Delegation action that we plan to take
     -> [Cardano.Certificate (Write.CardanoApiEra era)]
         -- ^ Certificates representing the action
-certificateFromDelegationAction era = case era of
+certificateFromDelegationAction _era = case Write.recentEra @era of
     Write.RecentEraBabbage -> \cred -> \case
         Join poolId ->
             [ Cardano.makeStakeAddressDelegationCertificate

--- a/lib/wallet/src/Cardano/Wallet/Transaction/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction/Delegation.hs
@@ -51,6 +51,7 @@ import qualified Internal.Cardano.Write.Tx as Write
 {-----------------------------------------------------------------------------
     Cardano.Certificate
 ------------------------------------------------------------------------------}
+
 certificateFromDelegationAction
     :: Write.RecentEra era
         -- ^ Era in which we create the certificate
@@ -60,37 +61,38 @@ certificateFromDelegationAction
         -- ^ Delegation action that we plan to take
     -> [Cardano.Certificate (Write.CardanoApiEra era)]
         -- ^ Certificates representing the action
-certificateFromDelegationAction Write.RecentEraBabbage cred = \case
-    Join poolId ->
-        [ Cardano.makeStakeAddressDelegationCertificate
-            $ Cardano.StakeDelegationRequirementsPreConway
-                babbageWitness
-                (toCardanoStakeCredential cred)
-                (toCardanoPoolId poolId)
-        ]
-    JoinRegisteringKey poolId ->
-        [ Cardano.makeStakeAddressRegistrationCertificate
-            $ Cardano.StakeAddrRegistrationPreConway
-                babbageWitness
-                (toCardanoStakeCredential cred)
-        , Cardano.makeStakeAddressDelegationCertificate
-            $ Cardano.StakeDelegationRequirementsPreConway
-                babbageWitness
-                (toCardanoStakeCredential cred)
-                (toCardanoPoolId poolId)
-        ]
-    Quit ->
-        [ Cardano.makeStakeAddressUnregistrationCertificate
-            $ Cardano.StakeAddrRegistrationPreConway
-                babbageWitness
-                (toCardanoStakeCredential cred)
-        ]
-  where
-    babbageWitness = Cardano.ShelleyToBabbageEraBabbage
-certificateFromDelegationAction Write.RecentEraConway _cred =
-    error "certificateFromDelegationAction: not supported in Conway yet"
-  where
-    _conwayWitness = Cardano.ConwayEraOnwardsConway
+certificateFromDelegationAction era = case era of
+    Write.RecentEraBabbage -> \cred -> \case
+        Join poolId ->
+            [ Cardano.makeStakeAddressDelegationCertificate
+                $ Cardano.StakeDelegationRequirementsPreConway
+                    babbageWitness
+                    (toCardanoStakeCredential cred)
+                    (toCardanoPoolId poolId)
+            ]
+        JoinRegisteringKey poolId ->
+            [ Cardano.makeStakeAddressRegistrationCertificate
+                $ Cardano.StakeAddrRegistrationPreConway
+                    babbageWitness
+                    (toCardanoStakeCredential cred)
+            , Cardano.makeStakeAddressDelegationCertificate
+                $ Cardano.StakeDelegationRequirementsPreConway
+                    babbageWitness
+                    (toCardanoStakeCredential cred)
+                    (toCardanoPoolId poolId)
+            ]
+        Quit ->
+            [ Cardano.makeStakeAddressUnregistrationCertificate
+                $ Cardano.StakeAddrRegistrationPreConway
+                    babbageWitness
+                    (toCardanoStakeCredential cred)
+            ]
+      where
+        babbageWitness = Cardano.ShelleyToBabbageEraBabbage
+    Write.RecentEraConway -> \_cred ->
+        error "certificateFromDelegationAction: not supported in Conway yet"
+      where
+        _conwayWitness = Cardano.ConwayEraOnwardsConway
 
 {-----------------------------------------------------------------------------
     Cardano.StakeCredential


### PR DESCRIPTION
## Issues

ADP-3226 (Follow-on from #4422)

## Description

This PR adjusts even more functions to use an `IsRecentEra era` constraint instead of a `RecentEra era` parameter.