### PR TITLE
[APD-3185] Import only explicitly from `Internal.Cardano.Write`.

### DIFF
--- a/lib/network-layer/src/Cardano/Wallet/Network.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network.hs
@@ -107,6 +107,8 @@ import Internal.Cardano.Write.Tx
     )
 
 import qualified Internal.Cardano.Write.Tx as Write
+    ( PParams
+    )
 
 -- | Interface for network capabilities.
 data NetworkLayer m block = NetworkLayer

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -431,6 +431,8 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Internal.Cardano.Write.Tx as Write
+    ( PParams
+    )
 import qualified Ouroboros.Consensus.Byron.Ledger as Byron
 import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -219,6 +219,8 @@ import qualified Internal.Cardano.Write.Tx as Write
     , toAnyCardanoEra
     )
 import qualified Internal.Cardano.Write.Tx.Balance as Write
+    ( toWalletUTxO
+    )
 
 -- | Maps types to servant error responses.
 class IsServerError e where

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -214,6 +214,10 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Internal.Cardano.Write.Tx as Write
+    ( IsRecentEra
+    , serializeTx
+    , toAnyCardanoEra
+    )
 import qualified Internal.Cardano.Write.Tx.Balance as Write
 
 -- | Maps types to servant error responses.

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -945,6 +945,9 @@ import qualified Internal.Cardano.Write.Tx.Balance as Write
     , fromWalletUTxO
     )
 import qualified Internal.Cardano.Write.Tx.Sign as Write
+    ( TimelockKeyWitnessCounts (TimelockKeyWitnessCounts)
+    , estimateMinWitnessRequiredPerInput
+    )
 import qualified Network.Ntp as Ntp
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Handler.WarpTLS as Warp

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -939,6 +939,11 @@ import qualified Internal.Cardano.Write.Tx as Write
     , utxoFromTxOutsInRecentEra
     )
 import qualified Internal.Cardano.Write.Tx.Balance as Write
+    ( PartialTx (PartialTx)
+    , balanceTransaction
+    , constructUTxOIndex
+    , fromWalletUTxO
+    )
 import qualified Internal.Cardano.Write.Tx.Sign as Write
 import qualified Network.Ntp as Ntp
 import qualified Network.Wai.Handler.Warp as Warp

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -924,6 +925,19 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Internal.Cardano.Write.Tx as Write
+    ( Datum (DatumHash, NoDatum)
+    , IsRecentEra
+    , PParamsInAnyRecentEra (PParamsInAnyRecentEra)
+    , RecentEra
+    , TxIn
+    , TxOutInRecentEra (TxOutInRecentEra)
+    , cardanoEraFromRecentEra
+    , fromCardanoApiTx
+    , getFeePerByte
+    , pattern PolicyId
+    , toCardanoApiTx
+    , utxoFromTxOutsInRecentEra
+    )
 import qualified Internal.Cardano.Write.Tx.Balance as Write
 import qualified Internal.Cardano.Write.Tx.Sign as Write
 import qualified Network.Ntp as Ntp

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Types.hs
@@ -672,6 +672,10 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Read as T
 import qualified Internal.Cardano.Write.Tx as Write
+    ( DatumHash
+    , datumHashFromBytes
+    , datumHashToBytes
+    )
 
 {-------------------------------------------------------------------------------
                                Styles of Wallets

--- a/lib/wallet/bench/api-bench.hs
+++ b/lib/wallet/bench/api-bench.hs
@@ -191,6 +191,8 @@ import qualified Data.ByteString.Char8 as B8
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Internal.Cardano.Write.Tx as Write
+    ( MaybeInRecentEra (InRecentEraBabbage)
+    )
 import qualified System.Environment as Sys
 import qualified System.Exit as Sys
 

--- a/lib/wallet/bench/restore-bench.hs
+++ b/lib/wallet/bench/restore-bench.hs
@@ -374,6 +374,8 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Internal.Cardano.Write.Tx as Write
+    ( PParamsInAnyRecentEra (PParamsInAnyRecentEra)
+    )
 
 main :: IO ()
 main = execBenchWithNode argsNetworkConfig cardanoRestoreBench >>= exitWith

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -840,6 +840,22 @@ import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import qualified Internal.Cardano.Write.Tx as Write
+    ( AnyRecentEra
+    , CardanoApiEra
+    , FeePerByte
+    , IsRecentEra
+    , PParams
+    , PParamsInAnyRecentEra (PParamsInAnyRecentEra)
+    , RecentEra
+    , Tx
+    , UTxO (UTxO)
+    , cardanoEraFromRecentEra
+    , feeOfBytes
+    , fromCardanoApiTx
+    , getFeePerByte
+    , stakeKeyDeposit
+    , toCardanoApiTx
+    )
 import qualified Internal.Cardano.Write.Tx.Balance as Write
 
 -- $Development

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -857,6 +857,11 @@ import qualified Internal.Cardano.Write.Tx as Write
     , toCardanoApiTx
     )
 import qualified Internal.Cardano.Write.Tx.Balance as Write
+    ( PartialTx
+    , UTxOIndex
+    , constructUTxOIndex
+    , fromWalletUTxO
+    )
 
 -- $Development
 -- __Naming Conventions__

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -285,6 +285,10 @@ import qualified Internal.Cardano.Write.Tx.Sign as Write
     ( estimateMaxWitnessRequiredPerInput
     )
 import qualified Internal.Cardano.Write.Tx.SizeEstimation as Write
+    ( sizeOf_BootstrapWitnesses
+    , sizeOf_VKeyWitnesses
+    , sizeOf_Withdrawals
+    )
 
 -- | Type encapsulating what we need to know to add things -- payloads,
 -- certificates -- to a transaction.

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -265,6 +265,22 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Internal.Cardano.Write.Tx as Write
+    ( CardanoApiEra
+    , FeePerByte
+    , IsRecentEra (recentEra)
+    , PParams
+    , RecentEra (RecentEraBabbage, RecentEraConway)
+    , Tx
+    , TxOut
+    , computeMinimumCoinForTxOut
+    , feeOfBytes
+    , fromCardanoApiTx
+    , getFeePerByte
+    , isBelowMinimumCoinForTxOut
+    , shelleyBasedEra
+    , shelleyBasedEraFromRecentEra
+    , toCardanoApiTx
+    )
 import qualified Internal.Cardano.Write.Tx.Sign as Write
 import qualified Internal.Cardano.Write.Tx.SizeEstimation as Write
 

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -282,6 +282,8 @@ import qualified Internal.Cardano.Write.Tx as Write
     , toCardanoApiTx
     )
 import qualified Internal.Cardano.Write.Tx.Sign as Write
+    ( estimateMaxWitnessRequiredPerInput
+    )
 import qualified Internal.Cardano.Write.Tx.SizeEstimation as Write
 
 -- | Type encapsulating what we need to know to add things -- payloads,

--- a/lib/wallet/src/Cardano/Wallet/Transaction/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction/Delegation.hs
@@ -44,6 +44,9 @@ import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Ledger.Keys as Ledger
 import qualified Internal.Cardano.Write.Tx as Write
+    ( CardanoApiEra
+    , RecentEra (RecentEraBabbage, RecentEraConway)
+    )
 
 {-----------------------------------------------------------------------------
     Cardano.Certificate

--- a/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/wallet/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -361,6 +361,15 @@ import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Internal.Cardano.Write.Tx as Write
+    ( BabbageEra
+    , CardanoApiEra
+    , IsRecentEra
+    , PParams
+    , RecentEra (RecentEraBabbage, RecentEraConway)
+    , cardanoEraFromRecentEra
+    , shelleyBasedEra
+    , shelleyBasedEraFromRecentEra
+    )
 
 spec :: Spec
 spec = describe "TransactionSpec" $ do

--- a/lib/wallet/test/unit/Cardano/WalletSpec.hs
+++ b/lib/wallet/test/unit/Cardano/WalletSpec.hs
@@ -413,6 +413,9 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Internal.Cardano.Write.Tx as Write
+    ( AnyRecentEra (AnyRecentEra)
+    , RecentEra (RecentEraBabbage, RecentEraConway)
+    )
 
 spec :: Spec
 spec = describe "Cardano.WalletSpec" $ do


### PR DESCRIPTION
## Issue

ADP-3185

## Summary

This PR adjusts the way we import symbols from the `Internal.Cardano.Write` hierarchy so that we only import symbols **_explicitly_**.

This serves two purposes:

1. We frequently import from **_more than one_** module into a common `Write` namespace. Using explicit imports makes it easier for the reader to determine from **_which_** of these modules a particular symbol is imported.

2. We eventually want to stop importing from the `Internal.Cardano.Write` hierarchy entirely, and instead import from the public `Cardano.Write` hierarchy.  Using explicit imports makes it easy to enumerate **_which_** symbols have yet to be exported from the public API, and for each symbol:
    - decide from **_where_** in the public API it should be exported (if at all);
    - update downstream consumers of that symbol to import it from the public API.