### PR TITLE
[ADP-3288] Fix latency benchmarks

### DIFF
--- a/justfile
+++ b/justfile
@@ -127,3 +127,7 @@ babbage-integration-tests:
 # run conway integration tests via nix
 conway-integration-tests:
   just conway-integration-tests-match ""
+
+latency-bench:
+   cabal run -O2 -v0 cardano-wallet-benchmarks:latency -- \
+   --cluster-configs lib/local-cluster/test/data/cluster-configs

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -133,6 +133,7 @@ benchmark latency
     , iohk-monitoring-extra
     , local-cluster
     , optparse-applicative
+    , resourcet
     , servant-client
     , temporary-extra
     , text

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -73,7 +73,7 @@ library
 
   exposed-modules:
     Cardano.Wallet.BenchShared
-    Cardano.Wallet.LatencyBenchShared
+    Cardano.Wallet.Benchmarks.Latency.Measure
 
 benchmark restore
   import:         language, opts-exe

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -133,6 +133,7 @@ benchmark latency
     , iohk-monitoring-extra
     , local-cluster
     , optparse-applicative
+    , servant-client
     , temporary-extra
     , text
     , time

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -61,19 +61,24 @@ library
     , iohk-monitoring
     , iohk-monitoring-extra
     , local-cluster
+    , mtl
     , optparse-applicative
+    , resourcet
     , say
+    , servant-client
     , temporary-extra
     , text
     , text-class
     , time
     , unliftio
+    , unliftio-core
     , wai-middleware-logging
     , with-utf8
 
   exposed-modules:
     Cardano.Wallet.BenchShared
     Cardano.Wallet.Benchmarks.Latency.Measure
+    Cardano.Wallet.Benchmarks.Latency.BenchM
 
 benchmark restore
   import:         language, opts-exe

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -127,6 +127,7 @@ benchmark latency
     , cardano-wallet:{cardano-wallet, cardano-wallet-api-http}
     , cardano-wallet-integration:framework
     , directory
+    , exceptions
     , faucet
     , filepath
     , fmt
@@ -137,6 +138,7 @@ benchmark latency
     , iohk-monitoring
     , iohk-monitoring-extra
     , local-cluster
+    , mtl
     , optparse-applicative
     , resourcet
     , servant-client
@@ -144,6 +146,7 @@ benchmark latency
     , text
     , time
     , unliftio
+    , unliftio-core
     , wai-middleware-logging
     , with-utf8
 

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -109,9 +109,6 @@ import Cardano.Wallet.Network.Implementation.Ouroboros
 import Cardano.Wallet.Network.Ports
     ( portFromURL
     )
-import Cardano.Wallet.Pools
-    ( StakePool
-    )
 import Cardano.Wallet.Primitive.Ledger.Shelley
     ( fromGenesisData
     )
@@ -532,13 +529,7 @@ runScenario scenario = lift . runResourceT $ do
     --             payloadMA
     -- fmtResult "postTransactionMA  " t7b
 
-    t8 <-
-        measureApiLogs
-            $ request @[ApiT StakePool]
-                (Link.listStakePools arbitraryStake)
-                Default
-                Empty
-    fmtResult "listStakePools     " t8
+    sceneOfClientM "listStakePools" $ C.listPools $ ApiT <$> arbitraryStake
 
     t9 <-
         measureApiLogs

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -334,9 +334,9 @@ walletApiBench capture ctx = do
     requestWithError :: MonadIO m => ClientM a -> m (Either ClientError a)
     requestWithError x = liftIO $ runClientM x cenv
     requestC :: MonadIO m => ClientM a -> m a
-    requestC x = bombLeft <$> requestWithError x
-    bombLeft :: Show l => Either l r -> r
-    bombLeft = either (error . show) Prelude.id
+    requestC x = partialFromRight <$> requestWithError x
+    partialFromRight :: Show l => Either l r -> r
+    partialFromRight = either (error . show) Prelude.id
     freeWallet w =
         void
             $ allocate (pure ())

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -55,7 +55,6 @@ import Cardano.Wallet.Api.Http.Shelley.Server
     )
 import Cardano.Wallet.Api.Types
     ( AddressAmount (..)
-    , ApiAsset (..)
     , ApiEra
     , ApiMnemonicT (..)
     , ApiT (..)
@@ -461,6 +460,7 @@ runScenario scenario = lift . runResourceT $ do
     (wal1, wal2, walMA, maWalletToMigrate) <- scenario
     let wal1Id = wal1 ^. #id
         wal2Id = wal2 ^. #id
+        walMAId = walMA ^. #id
         amt = minUTxOValue era
     sceneOfClientM "listWallets" C.listWallets
     sceneOfClientM "getWallet" $ C.getWallet wal1Id
@@ -532,13 +532,7 @@ runScenario scenario = lift . runResourceT $ do
 
     sceneOfClientM "getNetworkInfo" CN.networkInformation
 
-    t10 <-
-        measureApiLogs
-            $ request @([ApiAsset])
-                (Link.listAssets walMA)
-                Default
-                Empty
-    fmtResult "listMultiAssets    " t10
+    sceneOfClientM "listAssets" $ C.getAssets walMAId
 
     let assetsSrc = walMA ^. #assets . #total
     let (polId, assName) =

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -77,7 +77,7 @@ import Cardano.Wallet.Api.Types.Amount
 import Cardano.Wallet.Api.Types.WalletAssets
     ( ApiWalletAssets (..)
     )
-import Cardano.Wallet.LatencyBenchShared
+import Cardano.Wallet.Benchmarks.Latency.Measure
     ( LogCaptureFunc
     , fmtResult
     , fmtTitle

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -228,7 +228,6 @@ import Test.Integration.Framework.DSL
     , fixturePassphrase
     , json
     , minUTxOValue
-    , mkTxPayloadMA
     , pickAnAsset
     , runResourceT
     , shouldBe
@@ -582,16 +581,16 @@ runScenario scenario = lift . runResourceT $ do
                 payloadTxTo5Addr
     fmtResult "postTransTo5Addrs  " t7a
 
-    let assetsToSend = walMA ^. #assets . #total
-    let val = minUTxOValue era <$ pickAnAsset assetsToSend
-    payloadMA <- mkTxPayloadMA @A destination (2 * minUTxOValue era) [val] fixturePassphrase
-    t7b <-
-        measureApiLogs
-            $ request @(ApiTransaction A)
-                (Link.createTransactionOld @'Shelley walMA)
-                Default
-                payloadMA
-    fmtResult "postTransactionMA  " t7b
+    -- let assetsToSend = walMA ^. #assets . #total
+    -- let val = minUTxOValue era <$ pickAnAsset assetsToSend
+    -- payloadMA <- mkTxPayloadMA @A destination (2 * minUTxOValue era) [val] fixturePassphrase
+    -- t7b <-
+    --     measureApiLogs
+    --         $ request @(ApiTransaction A)
+    --             (Link.createTransactionOld @'Shelley walMA)
+    --             Default
+    --             payloadMA
+    -- fmtResult "postTransactionMA  " t7b
 
     t8 <-
         measureApiLogs
@@ -638,19 +637,19 @@ runScenario scenario = lift . runResourceT $ do
             $ Json [json|{addresses: #{addresses}}|]
     fmtResult "postMigrationPlan  " t12a
 
-    -- Perform a migration:
-    let endpointMigrate = Link.migrateWallet @'Shelley maWalletToMigrate
-    t12b <-
-        measureApiLogs
-            $ request @[ApiTransaction A]
-                endpointMigrate
-                Default
-            $ Json
-                [json|
-            { passphrase: #{fixturePassphrase}
-            , addresses: #{addresses}
-            }|]
-    fmtResult "postMigration      " t12b
+-- -- Perform a migration:
+-- let endpointMigrate = Link.migrateWallet @'Shelley maWalletToMigrate
+-- t12b <-
+--     measureApiLogs
+--         $ request @[ApiTransaction A]
+--             endpointMigrate
+--             Default
+--         $ Json
+--             [json|
+--         { passphrase: #{fixturePassphrase}
+--         , addresses: #{addresses}
+--         }|]
+-- fmtResult "postMigration      " t12b
 
 fmtResult :: String -> [NominalDiffTime] -> BenchM ()
 fmtResult title ts = liftIO $ Measure.fmtResult title ts

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -535,15 +535,11 @@ runScenario scenario = lift . runResourceT $ do
     sceneOfClientM "listAssets" $ C.getAssets walMAId
 
     let assetsSrc = walMA ^. #assets . #total
-    let (polId, assName) =
+        (polId, assName) =
             bimap unsafeFromText unsafeFromText
                 $ fst
                 $ pickAnAsset assetsSrc
-    t11 <-
-        measureApiLogs
-            $ requestWithError
-            $ C.getAsset (walMA ^. #id) (ApiT polId) (ApiT assName)
-    fmtResult "getMultiAsset      " t11
+    sceneOfClientM "getAsset" $ C.getAsset walMAId (ApiT polId) (ApiT assName)
 
     -- Create a migration plan:
     let endpointPlan = (Link.createMigrationPlan @'Shelley maWalletToMigrate)

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -58,7 +58,6 @@ import Cardano.Wallet.Api.Types
     , ApiAsset (..)
     , ApiEra
     , ApiMnemonicT (..)
-    , ApiNetworkInformation
     , ApiT (..)
     , ApiTransaction
     , ApiTxId (..)
@@ -531,13 +530,7 @@ runScenario scenario = lift . runResourceT $ do
 
     sceneOfClientM "listStakePools" $ C.listPools $ ApiT <$> arbitraryStake
 
-    t9 <-
-        measureApiLogs
-            $ request @ApiNetworkInformation
-                Link.getNetworkInfo
-                Default
-                Empty
-    fmtResult "getNetworkInfo     " t9
+    sceneOfClientM "getNetworkInfo" CN.networkInformation
 
     t10 <-
         measureApiLogs

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/BenchM.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/BenchM.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Wallet.Benchmarks.Latency.BenchM
+    ( BenchM
+    , BenchCtx (..)
+    , partialFromRight
+    , clientEnv
+    , fixtureMultiAssetWallet
+    , fixtureWallet
+    , fixtureWalletWith
+    , finallyDeleteWallet
+    , request
+    , requestC
+    , requestWithError
+    , runDSL
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.Api.Clients.Testnet.Shelley
+    ( A
+    )
+import Cardano.Wallet.Api.Types
+    ( ApiWallet
+    )
+import Cardano.Wallet.Benchmarks.Latency.Measure
+    ( LogCaptureFunc
+    )
+import Control.Monad
+    ( void
+    )
+import Control.Monad.Reader
+    ( MonadIO (..)
+    , MonadReader (..)
+    , ReaderT (..)
+    , ask
+    )
+import Control.Monad.Trans.Resource
+    ( MonadResource (..)
+    , ResourceT
+    , allocate
+    , runResourceT
+    )
+import Data.Aeson
+    ( FromJSON
+    )
+import Data.Generics.Internal.VL
+    ( (^.)
+    )
+import Network.HTTP.Types
+    ( Method
+    )
+import Network.Wai.Middleware.Logging
+    ( ApiLog
+    )
+import Numeric.Natural
+    ( Natural
+    )
+import Servant.Client
+    ( ClientEnv
+    , ClientError
+    , ClientM
+    , mkClientEnv
+    , parseBaseUrl
+    , runClientM
+    )
+import Test.Integration.Framework.DSL
+    ( Context
+    )
+
+import qualified Cardano.Wallet.Api.Clients.Testnet.Shelley as C
+import qualified Data.Text as T
+import qualified Test.Integration.Framework.DSL as DSL
+
+data BenchCtx = BenchCtx
+    { dslContext :: Context
+    , logFun :: LogCaptureFunc ApiLog ()
+    }
+
+-- one day we will export the manager from the context
+clientEnv :: Context -> ClientEnv
+clientEnv ctx = case parseBaseUrl $ show (fst $ ctx ^. #_manager) of
+    Left _ -> error "Invalid base URL"
+    Right bu -> mkClientEnv (snd $ ctx ^. #_manager) bu
+
+partialFromRight :: Show l => Either l r -> r
+partialFromRight = either (error . show) Prelude.id
+
+type BenchM = ResourceT (ReaderT BenchCtx IO)
+
+requestWithError :: ClientM a -> BenchM (Either ClientError a)
+requestWithError x = do
+    BenchCtx ctx _ <- ask
+    liftIO $ runClientM x $ clientEnv ctx
+
+requestC :: ClientM a -> BenchM a
+requestC x = partialFromRight <$> requestWithError x
+
+finallyDeleteWallet :: ApiWallet -> BenchM ()
+finallyDeleteWallet w = do
+    env <- ask
+    void
+        $ allocate (pure ())
+        $ const
+        $ void
+        $ runReaderT (runResourceT (requestC $ C.deleteWallet (w ^. #id))) env
+
+-- compatibility with DSL functions
+runDSL :: (Context -> ResourceT IO a) -> BenchM a
+runDSL action = do
+    BenchCtx ctx _ <- ask
+    liftResourceT $ action ctx
+
+fixtureMultiAssetWallet :: BenchM ApiWallet
+fixtureMultiAssetWallet = runDSL DSL.fixtureMultiAssetWallet
+
+fixtureWallet :: BenchM ApiWallet
+fixtureWallet = runDSL DSL.fixtureWallet
+
+fixtureWalletWith :: [Natural] -> BenchM ApiWallet
+fixtureWalletWith w = runDSL $ \ctx -> DSL.fixtureWalletWith @A ctx w
+
+-- to be removed  in this PR
+request
+    :: (FromJSON a)
+    => (Method, T.Text)
+    -> DSL.Headers
+    -> DSL.Payload
+    -> BenchM (Either DSL.RequestException a)
+request link headers payload = runDSL
+    $ \ctx -> snd <$> DSL.request ctx link headers payload

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/Measure.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/Measure.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Cardano.Wallet.LatencyBenchShared
+module Cardano.Wallet.Benchmarks.Latency.Measure
   ( -- * Measuring traces
     withLatencyLogging
   , measureApiLogs

--- a/lib/integration/framework/Test/Integration/Framework/DSL.hs
+++ b/lib/integration/framework/Test/Integration/Framework/DSL.hs
@@ -58,6 +58,7 @@ module Test.Integration.Framework.DSL
 
     -- * Lens
     , walletId
+    , utxoStatisticsFromCoins
 
     -- * Constants
     , minUTxOValue
@@ -805,18 +806,19 @@ expectWalletUTxO
     -> m ()
 expectWalletUTxO coins = \case
     Left e  -> wantedSuccessButError e
-    Right stats -> do
-        let addr = Address "ARBITRARY"
-        let constructUtxoEntry idx c =
-                ( TxIn (Hash "ARBITRARY") idx
-                , TxOut addr (TokenBundle.fromCoin $ Coin c)
-                )
-        let utxo = UTxO $ Map.fromList $ zipWith constructUtxoEntry [0..] coins
-        let (UTxOStatistics hist stakes bType) = UTxOStatistics.compute utxo
-        let distr = Map.fromList $ map (\(HistogramBar k v)-> (k,v)) hist
-        (ApiUtxoStatistics (ApiAmount.fromWord64 stakes) (ApiT bType) distr)
-            `shouldBe` stats
+    Right stats -> utxoStatisticsFromCoins coins `shouldBe` stats
 
+utxoStatisticsFromCoins :: [Natural] -> ApiUtxoStatistics
+utxoStatisticsFromCoins coins =
+    let addr = Address "ARBITRARY"
+        constructUtxoEntry idx c =
+            ( TxIn (Hash "ARBITRARY") idx
+            , TxOut addr (TokenBundle.fromCoin $ Coin c)
+            )
+        utxo = UTxO $ Map.fromList $ zipWith constructUtxoEntry [0..] coins
+        (UTxOStatistics hist stakes bType) = UTxOStatistics.compute utxo
+        distr = Map.fromList $ map (\(HistogramBar k v)-> (k,v)) hist
+    in ApiUtxoStatistics (ApiAmount.fromWord64 stakes) (ApiT bType) distr
 --
 -- CLI output expectations
 --

--- a/lib/integration/framework/Test/Integration/Framework/Setup.hs
+++ b/lib/integration/framework/Test/Integration/Framework/Setup.hs
@@ -231,6 +231,7 @@ mkFaucetFunds testnetMagic = do
     bigDustWallet <- Faucet.bigDustWallet shelleyTestnet
     preregKeyWallet <- Faucet.preregKeyWallet shelleyTestnet
     instantaneousRewardFunds <- Faucet.mirFunds shelleyTestnet
+    massiveWallet <- Faucet.massiveWalletFunds (Coin 0) 0 shelleyTestnet
     maryAllegraFunds <-
         Faucet.maryAllegraFunds
             (Coin 10__000_000)
@@ -260,6 +261,7 @@ mkFaucetFunds testnetMagic = do
                     ]
             , maryAllegraFunds
             , mirCredentials
+            , massiveWalletFunds = massiveWallet
             }
 
 data TestingCtx = TestingCtx

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Cluster.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Cluster.hs
@@ -153,6 +153,7 @@ data FaucetFunds = FaucetFunds
     -- the faucet.
     , mirCredentials :: [(Credential, Coin)]
     -- ^ "Move instantaneous rewards" - for easily funding reward accounts.
+    , massiveWalletFunds :: [(Address, Coin)]
     }
     deriving stock (Eq, Show)
 
@@ -200,7 +201,7 @@ withCluster config@Config{..} faucetFunds onClusterStart = runClusterM config
 
             genesisFiles <-
                 generateGenesis
-                    (pureAdaFunds <> faucetAddresses)
+                    (pureAdaFunds <> faucetAddresses <> massiveWalletFunds)
                     (addGenesisPools : cfgShelleyGenesisMods)
 
             extraPort : poolsTcpPorts <-
@@ -244,7 +245,8 @@ withCluster config@Config{..} faucetFunds onClusterStart = runClusterM config
                                         relayNodeParams
                                         onClusterStart
   where
-    FaucetFunds pureAdaFunds maryAllegraFunds mirCredentials = faucetFunds
+    FaucetFunds pureAdaFunds maryAllegraFunds mirCredentials massiveWalletFunds
+        = faucetFunds
 
     -- Important cluster setup to run without rollbacks
     extraClusterSetupUsingNode

--- a/lib/local-cluster/lib/Cardano/Wallet/LocalCluster.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/LocalCluster.hs
@@ -239,6 +239,7 @@ main = withUtf8 $ do
                         | m <- Mnemonics.mir
                         , let (xPub, _xPrv) = Addresses.shelleyRewardAccount m
                         ]
+                    , massiveWalletFunds = []
                     }
                 $ \node -> do
                     clusterDir <- Path.parseAbsDir clusterPath

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -326,7 +326,7 @@ withTestNode tr action = do
                     , cfgShelleyGenesisMods = []
                     , cfgTracer = tr
                     }
-            withCluster clusterConfig (FaucetFunds [] [] []) $
+            withCluster clusterConfig (FaucetFunds [] [] [] []) $
                 \(RunningNode sock genesisData vData) -> do
                     let (np, _, _ ) = fromGenesisData genesisData
                     action np sock vData

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Clients/Testnet/Byron.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Clients/Testnet/Byron.hs
@@ -1,0 +1,195 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Wallet.Api.Clients.Testnet.Byron
+    ( A
+    , deleteWallet
+    , deleteTransaction
+    , getTransaction
+    , getWallet
+    , getWalletUtxoSnapshot
+    , getWalletUtxoStatistics
+    , inspectAddress
+    , listAddresses
+    , listTransactions
+    , listWallets
+    , postExternalTransaction
+    , postRandomAddress
+    , postScriptAddress
+    , postTransaction
+    , postTransactionFee
+    , postWallet
+    , putRandomAddress
+    , putRandomAddresses
+    , putWalletByron
+    , putWalletPassphrase
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.Api
+    ( Addresses
+    , ByronAddresses
+    , ByronTransactions
+    , ByronWallets
+    , Proxy_
+    )
+import Cardano.Wallet.Api.Types
+    ( AnyAddress
+    , ApiAddressData
+    , ApiAddressIdT
+    , ApiAddressInspect (..)
+    , ApiAddressInspectData (..)
+    , ApiAddressT
+    , ApiByronWallet
+    , ApiFee
+    , ApiPostRandomAddressData
+    , ApiPutAddressesDataT
+    , ApiT (..)
+    , ApiTransactionT
+    , ApiTxId (..)
+    , ApiUtxoStatistics
+    , ApiWalletPutData (..)
+    , ApiWalletUtxoSnapshot (..)
+    , ByronWalletPutPassphraseData (..)
+    , Iso8601Time (..)
+    , PostTransactionFeeOldDataT
+    , PostTransactionOldDataT
+    , SomeByronWalletPostData
+    )
+import Cardano.Wallet.Api.Types.Transaction
+    ( ApiLimit
+    )
+import Cardano.Wallet.Primitive.NetworkId
+    ( NetworkDiscriminant (..)
+    )
+import Cardano.Wallet.Primitive.Types
+    ( SortOrder
+    , WalletId
+    )
+import Cardano.Wallet.Primitive.Types.Address
+    ( AddressState
+    )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( SealedTx
+    )
+import Data.Generics.Labels
+    ()
+import Data.Proxy
+    ( Proxy (..)
+    )
+import Servant
+    ( NoContent
+    , (:<|>) (..)
+    , (:>)
+    )
+import Servant.Client
+    ( ClientM
+    , client
+    )
+
+type A = Testnet 42
+
+postWallet
+    :: SomeByronWalletPostData
+    -> ClientM ApiByronWallet
+deleteWallet
+    :: ApiT WalletId
+    -> ClientM NoContent
+getWallet
+    :: ApiT WalletId
+    -> ClientM ApiByronWallet
+listWallets
+    :: ClientM [ApiByronWallet]
+putWalletByron
+    :: ApiT WalletId
+    -> ApiWalletPutData
+    -> ClientM ApiByronWallet
+getWalletUtxoSnapshot
+    :: ApiT WalletId
+    -> ClientM ApiWalletUtxoSnapshot
+getWalletUtxoStatistics
+    :: ApiT WalletId
+    -> ClientM ApiUtxoStatistics
+putWalletPassphrase
+    :: ApiT WalletId
+    -> ByronWalletPutPassphraseData
+    -> ClientM NoContent
+postWallet
+    :<|> deleteWallet
+    :<|> getWallet
+    :<|> listWallets
+    :<|> putWalletByron
+    :<|> getWalletUtxoSnapshot
+    :<|> getWalletUtxoStatistics
+    :<|> putWalletPassphrase =
+        client (Proxy @("v2" :> ByronWallets))
+
+listTransactions
+    :: ApiT WalletId
+    -> Maybe Iso8601Time
+    -> Maybe Iso8601Time
+    -> Maybe (ApiT SortOrder)
+    -> Maybe ApiLimit
+    -> Maybe (ApiAddressIdT A)
+    -> ClientM [ApiTransactionT A]
+getTransaction
+    :: ApiT WalletId
+    -> ApiTxId
+    -> ClientM (ApiTransactionT A)
+deleteTransaction
+    :: ApiT WalletId
+    -> ApiTxId
+    -> ClientM NoContent
+postTransaction
+    :: ApiT WalletId
+    -> PostTransactionOldDataT A
+    -> ClientM (ApiTransactionT A)
+postTransactionFee
+    :: ApiT WalletId
+    -> PostTransactionFeeOldDataT A
+    -> ClientM ApiFee
+listTransactions
+    :<|> getTransaction
+    :<|> deleteTransaction
+    :<|> postTransaction
+    :<|> postTransactionFee =
+        client (Proxy @("v2" :> (ByronTransactions A)))
+
+postExternalTransaction :: ApiT SealedTx -> ClientM ApiTxId
+postExternalTransaction =
+    client (Proxy @("v2" :> Proxy_))
+
+inspectAddress
+    :: ApiAddressInspectData
+    -> ClientM ApiAddressInspect
+postScriptAddress
+    :: ApiAddressData
+    -> ClientM AnyAddress
+_ :<|> inspectAddress
+    :<|> postScriptAddress =
+        client (Proxy @("v2" :> Addresses A))
+
+postRandomAddress
+    :: ApiT WalletId
+    -> ApiPostRandomAddressData
+    -> ClientM (ApiAddressT A)
+putRandomAddress
+    :: ApiT WalletId
+    -> ApiAddressIdT A
+    -> ClientM NoContent
+putRandomAddresses
+    :: ApiT WalletId
+    -> ApiPutAddressesDataT A
+    -> ClientM NoContent
+listAddresses
+    :: ApiT WalletId
+    -> Maybe (ApiT AddressState)
+    -> ClientM [ApiAddressT A]
+postRandomAddress
+    :<|> putRandomAddress
+    :<|> putRandomAddresses
+    :<|> listAddresses =
+        client (Proxy @("v2" :> ByronAddresses A))

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Clients/Testnet/Network.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Clients/Testnet/Network.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Wallet.Api.Clients.Testnet.Network
+    ( networkInformation
+    , networkParameters
+    , networkClock
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.Api
+    ( Network
+    )
+import Cardano.Wallet.Api.Types
+    ( ApiNetworkClock
+    , ApiNetworkInformation
+    , ApiNetworkParameters
+    )
+import Data.Proxy
+    ( Proxy (..)
+    )
+import Servant.API
+    ( type (:<|>) ((:<|>))
+    , type (:>)
+    )
+import Servant.Client
+    ( ClientM
+    , client
+    )
+
+networkInformation
+    :: ClientM ApiNetworkInformation
+networkParameters
+    :: ClientM ApiNetworkParameters
+networkClock
+    :: Bool -> ClientM ApiNetworkClock
+networkInformation :<|> networkParameters :<|> networkClock =
+    client (Proxy @("v2" :> Network))

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Clients/Testnet/Shelley.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Clients/Testnet/Shelley.hs
@@ -42,11 +42,12 @@ import Prelude
 
 import Cardano.Wallet.Api
     ( Addresses
+    , Assets
     , Network
     , Proxy_
     , ShelleyTransactions
     , StakePools
-    , Wallets, Assets
+    , Wallets
     )
 import Cardano.Wallet.Api.Types
     ( AnyAddress
@@ -54,6 +55,7 @@ import Cardano.Wallet.Api.Types
     , ApiAddressInspect
     , ApiAddressInspectData
     , ApiAddressWithPath
+    , ApiAsset
     , ApiBalanceTransactionPostData
     , ApiConstructTransaction
     , ApiConstructTransactionData
@@ -78,7 +80,7 @@ import Cardano.Wallet.Api.Types
     , PostTransactionFeeOldData
     , PostTransactionOldData
     , WalletOrAccountPostData
-    , WalletPutPassphraseData, ApiAsset
+    , WalletPutPassphraseData
     )
 import Cardano.Wallet.Api.Types.Transaction
     ( ApiAddress
@@ -98,8 +100,14 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( AddressState
     )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( AssetName
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
+    ( TokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx
@@ -118,8 +126,6 @@ import Servant.Client
     ( ClientM
     , client
     )
-import Cardano.Wallet.Primitive.Types.TokenPolicyId (TokenPolicyId)
-import Cardano.Wallet.Primitive.Types.AssetName (AssetName)
 
 type A = Testnet 42
 

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Clients/Testnet/Shelley.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Clients/Testnet/Shelley.hs
@@ -1,0 +1,251 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Wallet.Api.Clients.Testnet.Shelley
+    ( A
+    , deleteWallet
+    , getWallet
+    , listWallets
+    , postWallet
+    , putWallet
+    , putWalletPassphrase
+    , getWalletUtxoSnapshot
+    , getWalletUtxoStatistics
+    , constructTransaction
+    , signTransaction
+    , listTransactions
+    , getTransaction
+    , deleteTransaction
+    , postTransaction
+    , postTransactionFee
+    , balanceTransaction
+    , decodeTransaction
+    , submitTransaction
+    , postExternalTransaction
+    , listAddresses
+    , inspectAddress
+    , postScriptAddress
+    , listPools
+    , joinStakePool
+    , quitStakePool
+    , networkInformation
+    , networkParameters
+    , networkClock
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.Api
+    ( Addresses
+    , Network
+    , Proxy_
+    , ShelleyTransactions
+    , StakePools
+    , Wallets
+    )
+import Cardano.Wallet.Api.Types
+    ( AnyAddress
+    , ApiAddressData
+    , ApiAddressInspect
+    , ApiAddressInspectData
+    , ApiAddressWithPath
+    , ApiBalanceTransactionPostData
+    , ApiConstructTransaction
+    , ApiConstructTransactionData
+    , ApiDecodeTransactionPostData
+    , ApiFee
+    , ApiNetworkClock
+    , ApiNetworkInformation
+    , ApiNetworkParameters
+    , ApiPoolSpecifier
+    , ApiSerialisedTransaction
+    , ApiSignTransactionPostData
+    , ApiT
+    , ApiTransaction
+    , ApiTxId
+    , ApiUtxoStatistics
+    , ApiWallet
+    , ApiWalletPassphrase
+    , ApiWalletPutDataExtended
+    , ApiWalletUtxoSnapshot
+    , Iso8601Time
+    , MinWithdrawal
+    , PostTransactionFeeOldData
+    , PostTransactionOldData
+    , WalletOrAccountPostData
+    , WalletPutPassphraseData
+    )
+import Cardano.Wallet.Api.Types.Transaction
+    ( ApiAddress
+    , ApiDecodedTransaction
+    , ApiLimit
+    )
+import Cardano.Wallet.Pools
+    ( StakePool
+    )
+import Cardano.Wallet.Primitive.NetworkId
+    ( NetworkDiscriminant (Testnet)
+    )
+import Cardano.Wallet.Primitive.Types
+    ( SortOrder
+    , WalletId
+    )
+import Cardano.Wallet.Primitive.Types.Address
+    ( AddressState
+    )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin
+    )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( SealedTx
+    )
+import Data.Generics.Labels
+    ()
+import Data.Proxy
+    ( Proxy (..)
+    )
+import Servant.API
+    ( NoContent
+    , type (:<|>) ((:<|>))
+    , type (:>)
+    )
+import Servant.Client
+    ( ClientM
+    , client
+    )
+
+type A = Testnet 42
+
+deleteWallet
+    :: ApiT WalletId -> ClientM NoContent
+getWallet
+    :: ApiT WalletId -> ClientM ApiWallet
+listWallets
+    :: ClientM [ApiWallet]
+postWallet
+    :: WalletOrAccountPostData -> ClientM ApiWallet
+putWallet
+    :: ApiT WalletId -> ApiWalletPutDataExtended -> ClientM ApiWallet
+putWalletPassphrase
+    :: ApiT WalletId
+    -> WalletPutPassphraseData
+    -> ClientM NoContent
+getWalletUtxoSnapshot
+    :: ApiT WalletId -> ClientM ApiWalletUtxoSnapshot
+getWalletUtxoStatistics
+    :: ApiT WalletId -> ClientM ApiUtxoStatistics
+deleteWallet
+    :<|> getWallet
+    :<|> listWallets
+    :<|> postWallet
+    :<|> putWallet
+    :<|> putWalletPassphrase
+    :<|> getWalletUtxoSnapshot
+    :<|> getWalletUtxoStatistics =
+        client (Proxy @("v2" :> Wallets))
+
+constructTransaction
+    :: ApiT WalletId
+    -> ApiConstructTransactionData A
+    -> ClientM (ApiConstructTransaction A)
+signTransaction
+    :: ApiT WalletId
+    -> ApiSignTransactionPostData
+    -> ClientM ApiSerialisedTransaction
+listTransactions
+    :: ApiT WalletId
+    -> Maybe MinWithdrawal
+    -> Maybe Iso8601Time
+    -> Maybe Iso8601Time
+    -> Maybe (ApiT SortOrder)
+    -> Maybe ApiLimit
+    -> Maybe (ApiAddress A)
+    -> Bool
+    -> ClientM [ApiTransaction A]
+getTransaction
+    :: ApiT WalletId
+    -> ApiTxId
+    -> Bool
+    -> ClientM (ApiTransaction A)
+deleteTransaction
+    :: ApiT WalletId
+    -> ApiTxId
+    -> ClientM NoContent
+postTransaction
+    :: ApiT WalletId
+    -> PostTransactionOldData A
+    -> ClientM (ApiTransaction A)
+postTransactionFee
+    :: ApiT WalletId
+    -> PostTransactionFeeOldData A
+    -> ClientM ApiFee
+balanceTransaction
+    :: ApiT WalletId
+    -> ApiBalanceTransactionPostData A
+    -> ClientM ApiSerialisedTransaction
+decodeTransaction
+    :: ApiT WalletId
+    -> ApiDecodeTransactionPostData
+    -> ClientM (ApiDecodedTransaction A)
+submitTransaction
+    :: ApiT WalletId
+    -> ApiSerialisedTransaction
+    -> ClientM ApiTxId
+constructTransaction
+    :<|> signTransaction
+    :<|> listTransactions
+    :<|> getTransaction
+    :<|> deleteTransaction
+    :<|> postTransaction
+    :<|> postTransactionFee
+    :<|> balanceTransaction
+    :<|> decodeTransaction
+    :<|> submitTransaction =
+        client (Proxy @("v2" :> (ShelleyTransactions A)))
+
+postExternalTransaction
+    :: ApiT SealedTx -> ClientM ApiTxId
+postExternalTransaction =
+    client (Proxy @("v2" :> Proxy_))
+
+listAddresses
+    :: ApiT WalletId
+    -> Maybe (ApiT AddressState)
+    -> ClientM [ApiAddressWithPath A]
+inspectAddress
+    :: ApiAddressInspectData -> ClientM ApiAddressInspect
+postScriptAddress
+    :: ApiAddressData -> ClientM AnyAddress
+listAddresses
+    :<|> inspectAddress
+    :<|> postScriptAddress =
+        client (Proxy @("v2" :> Addresses A))
+
+listPools
+    :: Maybe (ApiT Coin) -> ClientM [ApiT StakePool]
+joinStakePool
+    :: ApiPoolSpecifier
+    -> ApiT WalletId
+    -> ApiWalletPassphrase
+    -> ClientM (ApiTransaction A)
+quitStakePool
+    :: ApiT WalletId
+    -> ApiWalletPassphrase
+    -> ClientM (ApiTransaction A)
+listPools
+    :<|> joinStakePool
+    :<|> quitStakePool
+    :<|> _
+    :<|> _
+    :<|> _ =
+        client (Proxy @("v2" :> StakePools A))
+networkInformation
+    :: ClientM ApiNetworkInformation
+networkParameters
+    :: ClientM ApiNetworkParameters
+networkClock
+    :: Bool -> ClientM ApiNetworkClock
+networkInformation :<|> networkParameters :<|> networkClock =
+    client (Proxy @("v2" :> Network))

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Clients/Testnet/Shelley.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Clients/Testnet/Shelley.hs
@@ -35,6 +35,8 @@ module Cardano.Wallet.Api.Clients.Testnet.Shelley
     , getAssets
     , getAsset
     , getAsset'
+    , planMigration
+    , migrate
     )
 where
 
@@ -45,6 +47,7 @@ import Cardano.Wallet.Api
     , Assets
     , Network
     , Proxy_
+    , ShelleyMigrations
     , ShelleyTransactions
     , StakePools
     , Wallets
@@ -72,6 +75,9 @@ import Cardano.Wallet.Api.Types
     , ApiTxId
     , ApiUtxoStatistics
     , ApiWallet
+    , ApiWalletMigrationPlan
+    , ApiWalletMigrationPlanPostData
+    , ApiWalletMigrationPostData
     , ApiWalletPassphrase
     , ApiWalletPutDataExtended
     , ApiWalletUtxoSnapshot
@@ -114,6 +120,9 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Data.Generics.Labels
     ()
+import Data.List.NonEmpty
+    ( NonEmpty
+    )
 import Data.Proxy
     ( Proxy (..)
     )
@@ -261,8 +270,21 @@ networkClock
 networkInformation :<|> networkParameters :<|> networkClock =
     client (Proxy @("v2" :> Network))
 
-getAssets :: ApiT WalletId -> ClientM [ApiAsset]
-getAsset :: ApiT WalletId -> ApiT TokenPolicyId -> ApiT AssetName -> ClientM ApiAsset
-getAsset' :: ApiT WalletId -> ApiT TokenPolicyId -> ClientM ApiAsset
-getAssets  :<|> getAsset :<|> getAsset'
-    = client (Proxy @("v2" :> Assets))
+getAssets
+    :: ApiT WalletId -> ClientM [ApiAsset]
+getAsset
+    :: ApiT WalletId -> ApiT TokenPolicyId -> ApiT AssetName -> ClientM ApiAsset
+getAsset'
+    :: ApiT WalletId -> ApiT TokenPolicyId -> ClientM ApiAsset
+getAssets :<|> getAsset :<|> getAsset' =
+    client (Proxy @("v2" :> Assets))
+
+planMigration
+    :: ApiT WalletId
+    -> ApiWalletMigrationPlanPostData (Testnet 42)
+    -> ClientM (ApiWalletMigrationPlan A)
+migrate
+    :: ApiT WalletId
+    -> ApiWalletMigrationPostData (Testnet 42) "user"
+    -> ClientM (NonEmpty (ApiTransaction (Testnet 42)))
+planMigration :<|> migrate = client (Proxy @("v2" :> ShelleyMigrations A))

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Clients/Testnet/Shelley.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Clients/Testnet/Shelley.hs
@@ -32,6 +32,9 @@ module Cardano.Wallet.Api.Clients.Testnet.Shelley
     , networkInformation
     , networkParameters
     , networkClock
+    , getAssets
+    , getAsset
+    , getAsset'
     )
 where
 
@@ -43,7 +46,7 @@ import Cardano.Wallet.Api
     , Proxy_
     , ShelleyTransactions
     , StakePools
-    , Wallets
+    , Wallets, Assets
     )
 import Cardano.Wallet.Api.Types
     ( AnyAddress
@@ -75,7 +78,7 @@ import Cardano.Wallet.Api.Types
     , PostTransactionFeeOldData
     , PostTransactionOldData
     , WalletOrAccountPostData
-    , WalletPutPassphraseData
+    , WalletPutPassphraseData, ApiAsset
     )
 import Cardano.Wallet.Api.Types.Transaction
     ( ApiAddress
@@ -115,6 +118,8 @@ import Servant.Client
     ( ClientM
     , client
     )
+import Cardano.Wallet.Primitive.Types.TokenPolicyId (TokenPolicyId)
+import Cardano.Wallet.Primitive.Types.AssetName (AssetName)
 
 type A = Testnet 42
 
@@ -249,3 +254,9 @@ networkClock
     :: Bool -> ClientM ApiNetworkClock
 networkInformation :<|> networkParameters :<|> networkClock =
     client (Proxy @("v2" :> Network))
+
+getAssets :: ApiT WalletId -> ClientM [ApiAsset]
+getAsset :: ApiT WalletId -> ApiT TokenPolicyId -> ApiT AssetName -> ClientM ApiAsset
+getAsset' :: ApiT WalletId -> ApiT TokenPolicyId -> ClientM ApiAsset
+getAssets  :<|> getAsset :<|> getAsset'
+    = client (Proxy @("v2" :> Assets))

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -352,6 +352,9 @@ library cardano-wallet-api-http
     Cardano.Wallet.Api.Aeson
     Cardano.Wallet.Api.Aeson.Variant
     Cardano.Wallet.Api.Client
+    Cardano.Wallet.Api.Clients.Testnet.Byron
+    Cardano.Wallet.Api.Clients.Testnet.Network
+    Cardano.Wallet.Api.Clients.Testnet.Shelley
     Cardano.Wallet.Api.Hex
     Cardano.Wallet.Api.Http.Logging
     Cardano.Wallet.Api.Http.Server


### PR DESCRIPTION
This is an epic going to 

- [x] Restructure the benchmark to be inspectable via HLS (with a lot of care , due to multi home issues)
- [x] Eliminate the use of Link as a mean to perform client calls
- [x] Creation of bare bone servant client calls
- [x] Creation of minimal support over straight servant client calls
- [x] Fix for the massive wallet benchmarks
- [x] Add more cunning exception catching and got benchmarks benchmarking exceptions :shrug: ADP-3239 to fix them

ADP-3288