### PR TITLE
[ADP-3286] Remove `encryptPassphrase'`

### DIFF
--- a/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase.hs
+++ b/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase.hs
@@ -24,7 +24,6 @@ module Cardano.Wallet.Primitive.Passphrase
 
       -- * Operations
     , encryptPassphrase
-    , encryptPassphrase'
     , checkPassphrase
     , preparePassphrase
     , changePassphraseXPrv
@@ -56,18 +55,7 @@ encryptPassphrase
     => Passphrase "user"
     -> m (PassphraseScheme, PassphraseHash)
 encryptPassphrase = fmap (currentPassphraseScheme,)
-    . encryptPassphrase' currentPassphraseScheme
-
-encryptPassphrase'
-    :: MonadRandom m
-    => PassphraseScheme
-    -> Passphrase "user"
-    -> m PassphraseHash
-encryptPassphrase' scheme = encrypt . preparePassphrase scheme
-  where
-    encrypt = case scheme of
-        EncryptWithPBKDF2 -> PBKDF2.encryptPassphrase
-        EncryptWithScrypt -> Scrypt.encryptPassphraseTestingOnly
+    . PBKDF2.encryptPassphrase . preparePassphrase currentPassphraseScheme
 
 -- | Manipulation done on legacy passphrases before used for encryption.
 preparePassphrase

--- a/lib/secrets/test/Cardano/Wallet/Primitive/Passphrase/LegacySpec.hs
+++ b/lib/secrets/test/Cardano/Wallet/Primitive/Passphrase/LegacySpec.hs
@@ -16,7 +16,6 @@ import Cardano.Wallet.Primitive.Passphrase
     ( ErrWrongPassphrase (ErrWrongPassphrase)
     , PassphraseScheme (EncryptWithScrypt)
     , checkPassphrase
-    , encryptPassphrase'
     )
 import Cardano.Wallet.Primitive.Passphrase.Gen
     ( genEncryptionPassphrase
@@ -227,7 +226,8 @@ prop_passphraseFromScryptRoundtripFail p p' =
 encryptPasswordWithScrypt
     :: Passphrase "user"
     -> IO PassphraseHash
-encryptPasswordWithScrypt = encryptPassphrase' EncryptWithScrypt
+encryptPasswordWithScrypt =
+    encryptPassphraseTestingOnly . preparePassphrase
 
 instance Arbitrary (Passphrase "user") where
     arbitrary = genUserPassphrase


### PR DESCRIPTION
This pull request removes the function `encryptPassphrase'`. This makes it more clear that passphrases are always hashed with the `currentPassphraseScheme`.

### Issue number

ADP-3286