### PR TITLE
[ADP-3286] Support verification `EncryptWithScrypt` using `cryptonite`

### DIFF
--- a/lib/secrets/cardano-wallet-secrets.cabal
+++ b/lib/secrets/cardano-wallet-secrets.cabal
@@ -53,7 +53,6 @@ library
     , cryptonite              ^>=0.30
     , crypto-hash-extra
     , deepseq
-    , extra
     , generic-arbitrary
     , memory                  ^>=0.18
     , text

--- a/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase.hs
+++ b/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase.hs
@@ -74,10 +74,10 @@ checkPassphrase
     -> Either ErrWrongPassphrase ()
 checkPassphrase scheme received stored = case scheme of
     EncryptWithPBKDF2 -> PBKDF2.checkPassphrase prepared stored
-    EncryptWithScrypt -> case Scrypt.checkPassphrase prepared stored of
-        Just True -> Right ()
-        Just False -> Left ErrWrongPassphrase
-        Nothing -> Left (ErrPassphraseSchemeUnsupported scheme)
+    EncryptWithScrypt ->
+        if Scrypt.checkPassphrase prepared stored
+        then Right ()
+        else Left ErrWrongPassphrase
   where
     prepared = preparePassphrase scheme received
 

--- a/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase/Legacy.hs
+++ b/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase/Legacy.hs
@@ -94,13 +94,13 @@ In order to ensure that the new package produces the same result as the
 old one, we proceed as follows:
 
     * in production:
-        * use `scrypt` package if available
-        * use `cryptonite` on `aarch64-darwin`
+        * use `cryptonite`
     * in testing:
         * generate random passphrases,
-            encrypted with `scrypt` package if available.
+            encrypted with `scrypt` package if available
         * check that these encrypted passphrases
-            are verified correctly with the `cryptonite` package
+            * are verified correctly with the `cryptonite` package
+            * are verified correctly with the `scrypt` package
 
 These tests ensure that the code using `cryptonite` can verify
 hashed passphrases that were created with `scrypt`.
@@ -112,13 +112,8 @@ hashed passphrases that were created with `scrypt`.
 ------------------------------------------------------------------------------}
 -- | Verify a wallet spending password using the legacy Byron scrypt encryption
 -- scheme.
-checkPassphrase :: Passphrase "encryption" -> PassphraseHash -> Maybe Bool
-#if HAVE_SCRYPT
-checkPassphrase pwd stored = Just $ checkPassphraseScrypt pwd stored
-#else
--- Stub function for when compiled without @scrypt@.
-checkPassphrase _ _ = Nothing
-#endif
+checkPassphrase :: Passphrase "encryption" -> PassphraseHash -> Bool
+checkPassphrase = checkPassphraseCryptonite
 
 -- | Encrypt a wallet spending password using
 -- the legacy Byron scrypt encryption scheme.

--- a/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase/Legacy.hs
+++ b/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase/Legacy.hs
@@ -22,14 +22,14 @@ module Cardano.Wallet.Primitive.Passphrase.Legacy
       checkPassphrase
     , preparePassphrase
 
-      -- * Testing-only scrypt password implementation
-    , checkPassphraseTestingOnly
-    , encryptPassphraseTestingOnly
-
       -- * Testing-only helper
     , haveScrypt
 
-      -- * Internal functions
+      -- * Internal functions, exposed for testing
+    , PassphraseHashLength
+    , encryptPassphraseTestingOnly
+    , checkPassphraseCryptonite
+    , checkPassphraseScrypt
     , getSalt
     , genSalt
     ) where
@@ -63,34 +63,97 @@ import qualified Codec.CBOR.Write as CBOR
 import qualified Crypto.KDF.Scrypt as Scrypt
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString.Char8 as B8
-import Data.Either.Extra
-    ( eitherToMaybe
-    )
 
 #if HAVE_SCRYPT
 import Crypto.Scrypt
     ( EncryptedPass (..)
     , Pass (..)
+    , Salt (Salt)
+    , encryptPass
+    , scryptParamsLen
     , verifyPass'
     )
 
--- | Verify a wallet spending password using the legacy Byron scrypt encryption
--- scheme.
-checkPassphrase :: Passphrase "encryption" -> PassphraseHash -> Maybe Bool
-checkPassphrase pwd stored = Just $
-    verifyPass' (Pass (BA.convert (cborify pwd))) encryptedPass
-  where
-    encryptedPass = EncryptedPass (BA.convert stored)
-
 haveScrypt :: Bool
 haveScrypt = True
+
 #else
--- | Stub function for when compiled without @scrypt@.
-checkPassphrase :: Passphrase "encryption" -> PassphraseHash -> Maybe Bool
-checkPassphrase _ _ = Nothing
 
 haveScrypt :: Bool
 haveScrypt = False
+
+#endif
+
+{- NOTE [LegacyScrypt]
+
+We need to transition away from the unmaintained `scrypt` package.
+Specifically, the `scrypt` package is not supported on `aarch64-darwin`.
+
+We can use the `cryptonite` package instead.
+In order to ensure that the new package produces the same result as the
+old one, we proceed as follows:
+
+    * in production:
+        * use `scrypt` package if available
+        * use `cryptonite` on `aarch64-darwin`
+    * in testing:
+        * generate random passphrases,
+            encrypted with `scrypt` package if available.
+        * check that these encrypted passphrases
+            are verified correctly with the `cryptonite` package
+
+These tests ensure that the code using `cryptonite` can verify
+hashed passphrases that were created with `scrypt`.
+
+-}
+
+{-----------------------------------------------------------------------------
+    Passphrase hashing and verification using the Scrypt algorithm
+------------------------------------------------------------------------------}
+-- | Verify a wallet spending password using the legacy Byron scrypt encryption
+-- scheme.
+checkPassphrase :: Passphrase "encryption" -> PassphraseHash -> Maybe Bool
+#if HAVE_SCRYPT
+checkPassphrase pwd stored = Just $ checkPassphraseScrypt pwd stored
+#else
+-- Stub function for when compiled without @scrypt@.
+checkPassphrase _ _ = Nothing
+#endif
+
+-- | Encrypt a wallet spending password using
+-- the legacy Byron scrypt encryption scheme.
+--
+-- Do not use this function in production, only in unit tests!
+encryptPassphraseTestingOnly
+    :: MonadRandom m
+    => PassphraseHashLength
+    -> Passphrase "encryption"
+    -> m PassphraseHash
+#if HAVE_SCRYPT
+encryptPassphraseTestingOnly len pwd = mkPassphraseHash <$> genSalt
+  where
+    mkPassphraseHash :: Passphrase "salt" -> PassphraseHash
+    mkPassphraseHash (Passphrase salt) =
+        PassphraseHash
+        . BA.convert
+        . getEncryptedPass
+        $ encryptPass
+            params
+            (Salt $ BA.convert salt)
+            (Pass . BA.convert . unPassphrase $ cborify pwd)
+
+    params =
+        case scryptParamsLen
+                (fromIntegral logN)
+                (fromIntegral r)
+                (fromIntegral p)
+                (fromIntegral len)
+          of
+            Just x -> x
+            Nothing -> error "scryptParamsLen: unreachable code path"
+#else
+encryptPassphraseTestingOnly len pwd =
+    encryptPassphraseCryptoniteWithLength len <$> genSalt <*> pure pwd
 #endif
 
 preparePassphrase :: Passphrase "user" -> Passphrase "encryption"
@@ -100,45 +163,81 @@ preparePassphrase = Passphrase . hashMaybe . unPassphrase
         | pw == mempty = mempty
         | otherwise = BA.convert $ blake2b256 pw
 
--- | This is for use by test cases only. Use only the implementation from the
--- @scrypt@ package for application code.
-checkPassphraseTestingOnly :: Passphrase "encryption" -> PassphraseHash -> Bool
-checkPassphraseTestingOnly pwd stored = case getSalt stored of
-    Just salt -> encryptPassphraseTestingOnly pwd salt == stored
-    Nothing -> False
+{-----------------------------------------------------------------------------
+    Passphrase verification
+------------------------------------------------------------------------------}
 
-cborify :: Passphrase "encryption" -> Passphrase "encryption"
-cborify = Passphrase . BA.convert . CBOR.toStrictByteString
-    . CBOR.encodeBytes . BA.convert . unPassphrase
+checkPassphraseScrypt :: Passphrase "encryption" -> PassphraseHash -> Bool
+#if HAVE_SCRYPT
+checkPassphraseScrypt pwd stored =
+    verifyPass' (Pass (BA.convert (cborify pwd))) encryptedPass
+  where
+    encryptedPass = EncryptedPass (BA.convert stored)
+#else
+checkPassphraseScrypt _ _ = error "checkPassphraseScrypt not available"
+#endif
+
+checkPassphraseCryptonite
+    :: Passphrase "encryption" -> PassphraseHash -> Bool
+checkPassphraseCryptonite pwd stored =
+    case parsePassphraseHash stored of
+        Just (salt, len) ->
+            encryptPassphraseCryptoniteWithLength len salt pwd == stored
+        Nothing -> False
 
 -- | Extract salt field from pipe-delimited password hash.
 -- This will fail unless there are exactly 5 fields
 getSalt :: PassphraseHash -> Maybe (Passphrase "salt")
-getSalt (PassphraseHash stored) = case B8.split '|' (BA.convert stored) of
-    [_logN, _r, _p, salt, _passHash] -> eitherToMaybe $
-        Passphrase <$> convertFromBase Base64 salt
-    _ -> Nothing
+getSalt = fmap fst . parsePassphraseHash
 
--- | This is for use by test cases only.
-encryptPassphraseTestingOnly
-    :: MonadRandom m
-    => Passphrase "encryption"
-    -> m PassphraseHash
-encryptPassphraseTestingOnly pwd = mkPassphraseHash <$> genSalt
+parsePassphraseHash
+    :: PassphraseHash
+    -> Maybe (Passphrase "salt", PassphraseHashLength)
+parsePassphraseHash (PassphraseHash stored) =
+    case B8.split '|' (BA.convert stored) of
+        [_logN, _r, _p, salt64, hash64]
+            | Right salt <- convertFromBase Base64 salt64
+            , Right hash <- convertFromBase Base64 hash64
+            -> Just (Passphrase salt, B8.length hash)
+        _ -> Nothing
+
+{-----------------------------------------------------------------------------
+    Passphrase hashing
+------------------------------------------------------------------------------}
+type PassphraseHashLength = Int
+
+encryptPassphraseCryptoniteWithLength
+    :: PassphraseHashLength
+    -> Passphrase "salt"
+    -> Passphrase "encryption"
+    -> PassphraseHash
+encryptPassphraseCryptoniteWithLength len (Passphrase salt) pwd =
+    PassphraseHash $ BA.convert combined
   where
-    mkPassphraseHash salt = PassphraseHash $ BA.convert $ B8.intercalate "|"
-        [ showBS logN, showBS r, showBS p
-        , convertToBase Base64 salt, convertToBase Base64 (passHash salt)]
+    combined = B8.intercalate "|"
+        [ showBS logN
+        , showBS r
+        , showBS p
+        , convertToBase Base64 salt
+        , convertToBase Base64 passphraseHash
+        ]
 
-    passHash :: Passphrase "salt" -> ByteString
-    passHash (Passphrase salt) = Scrypt.generate params (cborify pwd) salt
+    passphraseHash :: ByteString
+    passphraseHash = Scrypt.generate params (cborify pwd) salt
 
-    params = Scrypt.Parameters ((2 :: Word64) ^ logN) r p 64
-    logN = 14
-    r = 8
-    p = 1
+    params = Scrypt.Parameters ((2 :: Word64) ^ logN) r p len
 
     showBS = B8.pack . show
+
+-- Scrypt parameters
+logN, r, p :: Int
+logN = 14
+r = 8
+p = 1
+
+cborify :: Passphrase "encryption" -> Passphrase "encryption"
+cborify = Passphrase . BA.convert . CBOR.toStrictByteString
+    . CBOR.encodeBytes . BA.convert . unPassphrase
 
 genSalt :: MonadRandom m => m (Passphrase "salt")
 genSalt = Passphrase <$> getRandomBytes 32

--- a/lib/wallet/integration/framework/Test/Integration/Framework/DSL.hs
+++ b/lib/wallet/integration/framework/Test/Integration/Framework/DSL.hs
@@ -1622,7 +1622,7 @@ emptyRandomWalletWithPasswd ctx rawPwd = do
             $ hex
             $ Byron.getKey
             $ Byron.generateKeyFromSeed seed pwd
-    pwdH <- liftIO $ toText <$> encryptPassphraseTestingOnly pwd
+    pwdH <- liftIO $ toText <$> encryptPassphraseTestingOnly 64 pwd
     emptyByronWalletFromXPrvWith ctx "random" ("Random Wallet", key, pwdH)
 
 postWallet'


### PR DESCRIPTION
This pull request changes the `checkPassphrase` function to support `EncryptWithScrypt` on all platforms by switching the implementation to `cryptonite`.

To do that with sufficient testing in place, we

* add an implementation of `encryptPassphraseTestingOnly` using the `scrypt` package,
* add tests of `checkPassphraseCryptonite` against this implementation, and
* use `checkPassphraseCryptonite` for checking passphrases always.

### Issue number

ADP-3286