### PR TITLE
[ADP-3286] Remove `scrypt` build dependency and flag

### DIFF
--- a/docs/site/src/contributor/what/building.md
+++ b/docs/site/src/contributor/what/building.md
@@ -78,13 +78,6 @@
    > cabal install --install-method=copy --installdir=/usr/local/bin
    ```
 
-7. Build without `scrypt` (for compatibility with Apple M1 chip)
-
-   ```console
-   > cabal configure --disable-tests --disable-benchmarks -f-scrypt -O2
-   > cabal build cardano-wallet:exe:cardano-wallet
-   ```
-
 ## Nix
 
 Use the [Nix][] build if:

--- a/lib/secrets/cardano-wallet-secrets.cabal
+++ b/lib/secrets/cardano-wallet-secrets.cabal
@@ -33,17 +33,9 @@ flag release
   default:     False
   manual:      True
 
-flag scrypt
-  description: Enable compatibility support for legacy wallet passwords.
-  default:     True
-
 library
   import:          language, opts-lib
   hs-source-dirs:  src
-
-  if flag(scrypt)
-    cpp-options:   -DHAVE_SCRYPT
-    build-depends: scrypt
 
   build-depends:
     , base                    >= 4.14.3 && < 4.19

--- a/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase/Types.hs
+++ b/lib/secrets/src/Cardano/Wallet/Primitive/Passphrase/Types.hs
@@ -204,7 +204,6 @@ instance NFData WalletPassphraseInfo
 -- | Indicate a failure when checking for a given 'Passphrase' match
 data ErrWrongPassphrase
     = ErrWrongPassphrase
-    | ErrPassphraseSchemeUnsupported PassphraseScheme
     deriving stock (Generic, Show, Eq)
 
 instance NFData ErrWrongPassphrase

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -349,12 +349,6 @@ instance IsServerError ErrWithRootKey where
                 , ": "
                 , toText wid
                 ]
-        ErrWithRootKeyWrongPassphrase wid (ErrPassphraseSchemeUnsupported s) ->
-            apiError err501 WrongEncryptionPassphrase $ mconcat
-                [ "This build is not compiled with support for the "
-                , toText s <> " scheme used by the given wallet: "
-                , toText wid
-                ]
 
 instance IsServerError ErrSignPayment where
     toServerError = \case

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -387,10 +387,6 @@ hls: CHaP: haskell-nix: nixpkgs-recent: nodePkgs: haskell-nix.cabalProject' [
             packages.cardano-addresses-cli.cabal-generator = lib.mkForce null;
           }
 
-          # Disable scrypt support on ARM64
-          ({ pkgs, ... }: {
-            packages.cardano-wallet-secrets.flags.scrypt = !pkgs.stdenv.hostPlatform.isAarch64;
-          })
         ];
     })
 ]


### PR DESCRIPTION
This pull request finally removes the build dependency on the [scrypt][] package, which was last uploaded in 2014.

  [scrypt]: https://hackage.haskell.org/package/scrypt

### Comments

* Switching from `scrypt` to `cryptonite` with tests was done in https://github.com/cardano-foundation/cardano-wallet/pull/4449 .
* Unrelatedly, it appears that the source repository of the [cryptonite] package has been archived by Vincent. It appears [crypton] is a blessed fork.

  [cryptonite]: https://github.com/haskell-crypto/cryptonite
  [crypton]: https://github.com/kazu-yamamoto/crypton

### Issue number

ADP-3286