### PR TITLE
Enable `"certificate"` tests in Conway

### DIFF
--- a/justfile
+++ b/justfile
@@ -108,7 +108,7 @@ integration-tests match:
     '.#cardano-cli' \
     '.#cardano-wallet' \
     '.#integration-exe' \
-    -c integration-exe -j 3 --match="{{match}}"
+    -c integration-exe -j 2 --match="{{match}}"
 
 # run babbage integration tests matching the given pattern via nix
 babbage-integration-tests-match match:

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -1049,9 +1049,11 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
     describe "STAKE_POOLS_JOIN_01x - Fee boundary values" $ do
         it
             "STAKE_POOLS_JOIN_01x - \
-            \I can join if I have just the right amount"
+            \I can join if I have barely enough fees"
             $ \ctx -> runResourceT $ do
-                w <- fixtureWalletWith @n ctx [costOfJoining ctx + depositAmt ctx]
+                let fuzz = costOf 50 ctx -- exact CBOR size can change
+                let enoughFees = costOfJoining ctx + depositAmt ctx + fuzz
+                w <- fixtureWalletWith @n ctx [enoughFees]
                 pool : _ <-
                     map (view #id . getApiT) . snd
                         <$> unsafeRequest @[ApiT StakePool]
@@ -1070,7 +1072,9 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             "STAKE_POOLS_JOIN_01x - \
             \I cannot join if I have not enough fee to cover"
             $ \ctx -> runResourceT $ do
-                w <- fixtureWalletWith @n ctx [costOfJoining ctx + depositAmt ctx - 1]
+                let fuzz = costOf 50 ctx -- exact CBOR size can change
+                let notEnoughFees = costOfJoining ctx + depositAmt ctx - fuzz
+                w <- fixtureWalletWith @n ctx [notEnoughFees]
                 pool : _ <-
                     map (view #id . getApiT) . snd
                         <$> unsafeRequest @[ApiT StakePool]

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -1315,7 +1315,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
                 setOf pools' (view #pledge)
                     `shouldBe` Set.fromList
-                        [ Quantity $ 100 * oneMillionAda
+                        [ Quantity $ 150 * oneMillionAda
                         , Quantity $ 100 * oneMillionAda
                         ]
 

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -292,7 +292,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
         "STAKE_POOLS_JOIN_01rewards - \
         \Can join a pool, earn rewards and collect them"
         $ \ctx -> runResourceT $ do
-            noConway ctx "certificate"
             src <- fixtureWallet ctx
             dest <- emptyWallet ctx
             let deposit = depositAmt ctx
@@ -597,7 +596,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
         "STAKE_POOLS_JOIN_02 - \
         \Cannot join already joined stake pool"
         $ \ctx -> runResourceT $ do
-            noConway ctx "certificate"
             w <- fixtureWallet ctx
             pool : _ <- map (view #id) <$> notRetiringPools ctx
 
@@ -636,7 +634,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
     it "STAKE_POOLS_JOIN_EMPTY - Empty wallet cannot join a pool" $ \ctx ->
         runResourceT $ do
-            noConway ctx "certificate"
             w <- emptyWallet ctx
             pool : _ <- map (view #id) <$> notRetiringPools ctx
             r <- joinStakePool @n ctx (SpecificPool pool) (w, fixturePassphrase)
@@ -647,7 +644,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                 ]
 
     it "STAKE_POOLS_QUIT_02 - Passphrase must be correct to quit" $ \ctx -> runResourceT $ do
-        noConway ctx "certificate"
         w <- fixtureWallet ctx
         pool : _ <- map (view #id) <$> notRetiringPools ctx
 
@@ -702,7 +698,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                     ]
 
     it "STAKE_POOLS_JOIN_01 - Can rejoin another stakepool" $ \ctx -> runResourceT $ do
-        noConway ctx "certificate"
         w <- fixtureWallet ctx
 
         -- make sure we are at the beginning of new epoch
@@ -759,7 +754,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                     [expectField #delegation (`shouldBe` delegating (ApiT pool2) [])]
 
     it "STAKE_POOLS_JOIN_04 - Rewards accumulate" $ \ctx -> runResourceT $ do
-        noConway ctx "certificate"
         w <- fixtureWallet ctx
         pool : _ <- map (view #id) <$> notRetiringPools ctx
 
@@ -794,7 +788,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
         "STAKE_POOLS_JOIN_05 - \
         \Can join when stake key already exists"
         $ \ctx -> runResourceT $ do
-            noConway ctx "certificate"
             preregKeyWallet <- liftIO $ preregKeyWalletMnemonic (_faucet ctx)
 
             let payload =
@@ -824,7 +817,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
     describe "STAKE_POOLS_JOIN_UNSIGNED_01" $ do
         it "Can join a pool that's not retiring" $ \ctx -> runResourceT $ do
-            noConway ctx "certificate"
             nonRetiredPools <- eventually "One of the pools should retire." $ do
                 response <- listPools ctx arbitraryStake
 
@@ -881,7 +873,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
     describe "STAKE_POOLS_JOIN_UNSIGNED_02"
         $ it "Can join a pool that's retiring"
         $ \ctx -> runResourceT $ do
-            noConway ctx "certificate"
             nonRetiredPools <- eventually "One of the pools should retire." $ do
                 response <- listPools ctx arbitraryStake
 
@@ -981,7 +972,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
         "STAKE_POOLS_QUIT_UNSIGNED_01 - \
         \Join/quit when already joined a pool"
         $ \ctx -> runResourceT $ do
-            noConway ctx "certificate"
             w <- fixtureWallet ctx
 
             pool1 : pool2 : _ <- map (view #id) <$> notRetiringPools ctx
@@ -1061,7 +1051,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             "STAKE_POOLS_JOIN_01x - \
             \I can join if I have just the right amount"
             $ \ctx -> runResourceT $ do
-                noConway ctx "certificate"
                 w <- fixtureWalletWith @n ctx [costOfJoining ctx + depositAmt ctx]
                 pool : _ <-
                     map (view #id . getApiT) . snd
@@ -1081,7 +1070,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             "STAKE_POOLS_JOIN_01x - \
             \I cannot join if I have not enough fee to cover"
             $ \ctx -> runResourceT $ do
-                noConway ctx "certificate"
                 w <- fixtureWalletWith @n ctx [costOfJoining ctx + depositAmt ctx - 1]
                 pool : _ <-
                     map (view #id . getApiT) . snd
@@ -1101,7 +1089,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             "STAKE_POOLS_QUIT_01xx - \
             \I can quit if I have enough to cover fee"
             $ \ctx -> runResourceT $ do
-                noConway ctx "certificate"
                 -- change needed to satisfy minUTxOValue
                 let initBalance =
                         [ costOfJoining ctx
@@ -1211,7 +1198,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             "STAKE_POOLS_QUIT_01x - \
             \I cannot quit if I have not enough to cover fees"
             $ \ctx -> runResourceT $ do
-                noConway ctx "certificate"
                 let initBalance = [costOfJoining ctx + depositAmt ctx]
                 w <- fixtureWalletWith @n ctx initBalance
 
@@ -1759,16 +1745,12 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             fromIntegral (unCoin c)
 
     costOfJoining :: Context -> Natural
-    costOfJoining ctx =
-        if _mainEra ctx >= ApiBabbage
-            then costOf (TxSize 485) ctx
-            else costOf (TxSize 479) ctx
+    costOfJoining ctx = if _mainEra ctx >= ApiConway
+            then costOf (TxSize 491) ctx
+            else costOf (TxSize 485) ctx
 
     costOfQuitting :: Context -> Natural
-    costOfQuitting ctx =
-        if _mainEra ctx >= ApiBabbage
-            then costOf (TxSize 334) ctx
-            else costOf (TxSize 332) ctx
+    costOfQuitting = costOf (TxSize 334)
 
     costOf :: TxSize -> Context -> Natural
     costOf (TxSize txSizeInBytes) ctx =

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -314,6 +314,7 @@ import Test.Integration.Framework.DSL
     , waitForTxImmutability
     , waitNumberOfEpochBoundaries
     , walletId
+    , (.<)
     , (.>)
     )
 import Test.Integration.Framework.TestData
@@ -3167,8 +3168,10 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
         eventually "Rewards have been consumed" $ do
             getSrcWallet >>= flip verify
-                [ expectField (#balance . #reward) (`shouldBe` ApiAmount 0)
-                  -- this assumes that we have received no new rewards
+                [ expectField (#balance . #reward . #toNatural)
+                    (.< withdrawalAmount)
+                    -- should be 0, but in case new rewards acrue, let's just
+                    -- require the reward balance to have decreased.
                 , expectField (#balance . #available)
                     (.>  (walletBeforeWithdrawal ^. #balance . #available))
                 ] & counterexample ("Wdrl: " <> show withdrawalAmount)

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -2962,7 +2962,6 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             foldM_ runStep txid steps
 
     it "TRANS_NEW_JOIN_01a - Can join stakepool, rejoin another and quit" $ \ctx -> runResourceT $ do
-        noConway ctx "certificate"
         let initialAmt = 10 * minUTxOValue (_mainEra ctx)
         src <- fixtureWalletWith @n ctx [initialAmt]
         dest <- emptyWallet ctx
@@ -3373,7 +3372,6 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
 
     it "TRANS_NEW_JOIN_02 - Can join stakepool in case I have many UTxOs on 1 address"
         $ \ctx -> runResourceT $ do
-        noConway ctx "certificate"
         let amt = minUTxOValue (_mainEra ctx)
         src <- emptyWallet ctx
         wa <- fixtureWallet ctx

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -273,6 +273,7 @@ import Test.Integration.Framework.DSL
     , Headers (..)
     , Payload (..)
     , arbitraryStake
+    , counterexample
     , decodeErrorInfo
     , delegating
     , emptyIcarusWallet
@@ -3170,7 +3171,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                   -- this assumes that we have received no new rewards
                 , expectField (#balance . #available)
                     (.>  (walletBeforeWithdrawal ^. #balance . #available))
-                ]
+                ] & counterexample ("Wdrl: " <> show withdrawalAmount)
 
         -- now we can quit
         let delegationQuit = Json [json|{

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/GenesisFiles.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/GenesisFiles.hs
@@ -176,7 +176,7 @@ generateGenesis initialFunds genesisMods = do
                     & ppNOptL
                         .~ 3
                     & ppRhoL
-                        .~ unsafeUnitInterval 0.178_650_067
+                        .~ unsafeUnitInterval 0.02
                     & ppTauL
                         .~ unsafeUnitInterval 0.1
                     & ppA0L

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/GenesisFiles.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/GenesisFiles.hs
@@ -197,7 +197,7 @@ generateGenesis initialFunds genesisMods = do
                         , sgActiveSlotsCoeff = unsafePositiveUnitInterval 0.5
                         , sgSecurityParam = 10
                         , sgEpochLength = 120
-                        , sgSlotLength = 0.12
+                        , sgSlotLength = 0.25
                         , sgUpdateQuorum = 1
                         , sgNetworkMagic =
                             fromIntegral (testnetMagicToNatural cfgTestnetMagic)

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/PoolRecipe.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/PoolRecipe.hs
@@ -55,7 +55,7 @@ defaultPoolConfigs =
         $
         -- This pool should never retire:
         PoolRecipe
-            { pledgeAmt = 100 * millionAda
+            { pledgeAmt = 150 * millionAda
             , retirementEpoch = Nothing
             , poolMetadata =
                 Aeson.object

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -3047,6 +3047,8 @@ delegationFee db@DBLayer{..} netLayer changeAddressGen = do
     feePercentiles <- transactionFee
         db protocolParams timeTranslation changeAddressGen
         defaultTransactionCtx
+            { txDeposit = Just $ toWallet $ Write.stakeKeyDeposit protocolParams
+            }
         -- It would seem that we should add a delegation action
         -- to the partial tx we construct, this was not done
         -- previously, and the difference should be negligible.

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -374,7 +374,7 @@ mkTransaction era networkId keyF stakeCreds addrResolver ctx cs = do
                 Just action ->
                     let stakeXPub = toXPub $ fst stakeCreds
                     in certificateFromDelegationAction era (Left stakeXPub)
-                       Nothing action
+                       (view #txDeposit ctx) action
     let wdrls = mkWithdrawals networkId wdrl
     unsigned <-
         mkUnsignedTx


### PR DESCRIPTION
- [x] Enable delegation tests for Conway
- [x] Ensure Conway delegation works by adding missing txDeposit-related glue

### Comments

```
LOCAL_CLUSTER_CONFIGS=../local-cluster/test/data/cluster-configs CARDANO_WALLET_TEST_DATA=test/data LOCAL_CLUSTER_ERA=conway cabal test cardano-wallet:integration --test-options '--match JOIN_01 -j 4'
```

### Issue Number

Related to ADP-3212, #4438 

