### PR TITLE
[ADP-3292] Separate `lightSync` in `cardano-wallet-network-layer`

### DIFF
--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -1,4 +1,4 @@
-cabal-version:   3.4
+cabal-version:   3.6
 name:            cardano-wallet-network-layer
 version:         0.1.0.0
 synopsis:        Node communication layer functionality.
@@ -14,19 +14,39 @@ maintainer:      hal@cardanofoundation.org
 category:        Network
 build-type:      Simple
 extra-doc-files: CHANGELOG.md
-
 -- extra-source-files:
 
-common warnings
-  ghc-options: -Wall
+common language
+  default-language:
+    Haskell2010
+  default-extensions:
+    NoImplicitPrelude
+    OverloadedStrings
+
+common opts-lib
+  ghc-options: -Wall -Wcompat -Wredundant-constraints
+
+  if flag(release)
+    ghc-options: -O2 -Werror
+
+common opts-exe
+  import:      opts-lib
+  ghc-options: -threaded -rtsopts
+
+flag release
+  description: Enable optimization and `-Werror`
+  default:     False
+  manual:      True
 
 library
-  import:           warnings
+  import:          language, opts-lib
+  hs-source-dirs:  src
   exposed-modules:
     Cardano.Wallet.Network
     Cardano.Wallet.Network.Implementation
     Cardano.Wallet.Network.Implementation.Ouroboros
     Cardano.Wallet.Network.Implementation.UnliftIO
+    Cardano.Wallet.Network.Light
     Cardano.Wallet.Network.Logging
     Cardano.Wallet.Network.Logging.Aggregation
 
@@ -73,5 +93,24 @@ library
     , unliftio
     , unliftio-core
 
-  hs-source-dirs:   src
-  default-language: Haskell2010
+test-suite unit
+  import:          language, opts-exe
+  type:            exitcode-stdio-1.0
+  hs-source-dirs:  test
+  build-depends:
+      base
+    , bytestring
+    , cardano-wallet-network-layer
+    , cardano-wallet-primitive
+    , contra-tracer
+    , io-classes
+    , text
+    , transformers
+    , hspec
+    , QuickCheck
+  build-tool-depends:
+      hspec-discover:hspec-discover
+  main-is:
+      Main.hs
+  other-modules:
+      Cardano.Wallet.Network.LightSpec

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -538,7 +538,6 @@ withNodeNetworkLayerBase
                         let trChainSync = MsgConnectionStatus ClientChainSync >$< tr
                             retryHandlers = handlers ClientChainSync
                         connectClient trChainSync retryHandlers client versionData conn
-                , lightSync = Nothing
                 , currentNodeTip =
                     fromTip getGenesisBlockHash <$> atomically readNodeTip
                 , currentNodeEra =

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation/UnliftIO.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation/UnliftIO.hs
@@ -4,6 +4,8 @@ module Cardano.Wallet.Network.Implementation.UnliftIO
     )
 where
 
+import Prelude
+
 import qualified Control.Monad.Catch as Exceptions
 import qualified UnliftIO
 

--- a/lib/network-layer/src/Cardano/Wallet/Network/Light.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Light.hs
@@ -29,7 +29,7 @@ import Cardano.BM.Data.Tracer
 import Cardano.Wallet.Network
     ( ChainFollower (..)
     )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Block
     ( BlockHeader (..)
     , ChainPoint (..)
     , chainPointFromBlockHeader

--- a/lib/network-layer/test/Cardano/Wallet/Network/LightSpec.hs
+++ b/lib/network-layer/test/Cardano/Wallet/Network/LightSpec.hs
@@ -22,7 +22,7 @@ import Cardano.Wallet.Network.Light
     , hoistLightSyncSource
     , lightSync
     )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Block
     ( BlockHeader (..)
     , ChainPoint (..)
     , chainPointFromBlockHeader

--- a/lib/network-layer/test/Main.hs
+++ b/lib/network-layer/test/Main.hs
@@ -1,4 +1,1 @@
-module Main (main) where
-
-main :: IO ()
-main = putStrLn "Test suite not yet implemented."
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/lib/unit/cardano-wallet-unit.cabal
+++ b/lib/unit/cardano-wallet-unit.cabal
@@ -240,7 +240,6 @@ test-suite unit
     Cardano.Wallet.DB.Store.WalletState.StoreSpec
     Cardano.Wallet.Delegation.ModelSpec
     Cardano.Wallet.DelegationSpec
-    Cardano.Wallet.Network.LightSpec
     Cardano.Wallet.Network.PortsSpec
     Cardano.Wallet.NetworkSpec
     Cardano.Wallet.Primitive.Delegation.StateSpec

--- a/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -213,7 +213,6 @@ dummyNodeProtocolParameters = C.ProtocolParameters
 dummyNetworkLayer :: HasCallStack => NetworkLayer m a
 dummyNetworkLayer = NetworkLayer
     { chainSync = err "chainSync"
-    , lightSync = Nothing
     , currentNodeEra = err "currentNodeEra"
     , currentNodeTip = err "currentNodeTip"
     , watchNodeTip = err "watchNodeTip"

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -220,7 +220,6 @@ library
     Cardano.Wallet.Flavor
     Cardano.Wallet.Gen
     Cardano.Wallet.Network.Config
-    Cardano.Wallet.Network.Light
     Cardano.Wallet.Pools
     Cardano.Wallet.Primitive.Delegation.State
     Cardano.Wallet.Primitive.Delegation.UTxO

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -364,7 +364,7 @@ import Cardano.Wallet.Address.Keys.WalletKey
     , liftRawKey
     )
 import Cardano.Wallet.Address.MaybeLight
-    ( MaybeLight (maybeDiscover)
+    ( MaybeLight
     )
 import Cardano.Wallet.Address.States.IsOwned
     ( isOwned
@@ -1241,15 +1241,7 @@ restoreWallet ctx = db & \DBLayer{..} ->
         rollBackward = rollbackBlocks ctx . toSlot
         rollForward' = restoreBlocks ctx (contramap MsgWalletFollow tr)
     in
-      catchFromIO $ case (maybeDiscover, lightSync nw) of
-        (Just discover, Just sync) ->
-            sync $ ChainFollower
-                { checkpointPolicy
-                , readChainPoints
-                , rollForward = rollForward' . either List (Summary discover)
-                , rollBackward
-                }
-        (_,_) -> -- light-mode not available
+      catchFromIO $
             chainSync nw (contramap MsgChainFollow tr) $ ChainFollower
                 { checkpointPolicy
                 , readChainPoints


### PR DESCRIPTION
This pull request separates out the remaining `lightSync` code:

* We move the `lightSync` out of the `NetworkLayer` record into a separate `LightLayer` record
* The implementation in `Cardano.Wallet.Network.Light` and tests are moved into the `cardano-wallet-network-layer` package.

### Issue number

ADP-3292
