### PR TITLE
[ADP-3293] Remove superfluous argument from `resubmitTx`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2796,7 +2796,7 @@ runLocalTxSubmissionPool cfg ctx = db & \DBLayer{..} -> do
         forM_ (filter (isScheduled sp sl) pendingOldStyle) $ \st -> do
             _ <- runExceptT $ traceResult (trRetry (st ^. #txId)) $
                 postTx nw (st ^. #submittedTx )
-            atomically $ resubmitTx (st ^. #txId) (st ^. #submittedTx) sl
+            atomically $ resubmitTx (st ^. #txId) sl
     watchNodeTip nw submitPending
   where
     nw = networkLayer_ ctx

--- a/lib/wallet/src/Cardano/Wallet/DB.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB.hs
@@ -98,8 +98,7 @@ import Cardano.Wallet.Primitive.Types.Range
     ( Range (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( SealedTx
-    , Tx (..)
+    ( Tx (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx.TransactionInfo
     ( TransactionInfo (..)
@@ -258,7 +257,6 @@ data DBLayer m s = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
 
     , resubmitTx
         :: Hash "Tx"
-        -> SealedTx -- TODO: ADP-2596 really not needed
         -> SlotNo
         -> stm ()
         -- ^ Resubmit a transaction.
@@ -427,7 +425,7 @@ mkDBLayerFromParts ti wid_ DBLayerCollection{..} = DBLayer
                     (hoistTimeInterpreter liftIO ti)
                     (mkDecorator_ dbTxHistory) tip
                         . fmap snd
-    , resubmitTx = \hash _ slotNo ->
+    , resubmitTx = \hash slotNo ->
             updateSubmissionsNoError dbCheckpoints
                 $ Sbms.resubmitTx hash slotNo
     , rollForwardTxSubmissions = \tip txs ->


### PR DESCRIPTION
This pull request removes a superfluous argument from `resubmitTx`.

### Issue number

ADP-3293