### PR TITLE
[ADP-3300] Add query for single block to `NetworkLayer`

### DIFF
--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -64,6 +64,7 @@ import Cardano.Wallet.Network
     ( ChainFollowLog (..)
     , ChainFollower
     , ChainSyncLog (..)
+    , ErrFetchBlock (..)
     , ErrPostTx (..)
     , NetworkLayer (..)
     , mapChainFollower
@@ -484,6 +485,8 @@ withNodeNetworkLayerBase
                         let trChainSync = MsgConnectionStatus ClientChainSync >$< tr
                             retryHandlers = handlers ClientChainSync
                         connectClient trChainSync retryHandlers client versionData conn
+                , fetchBlock =
+                    pure . Left . ErrNoBlockAt
                 , currentNodeTip =
                     fromTip getGenesisBlockHash <$> atomically readNodeTip
                 , currentNodeEra =

--- a/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -213,6 +213,7 @@ dummyNodeProtocolParameters = C.ProtocolParameters
 dummyNetworkLayer :: HasCallStack => NetworkLayer m a
 dummyNetworkLayer = NetworkLayer
     { chainSync = err "chainSync"
+    , fetchBlock = err "fetchBlock"
     , currentNodeEra = err "currentNodeEra"
     , currentNodeTip = err "currentNodeTip"
     , watchNodeTip = err "watchNodeTip"


### PR DESCRIPTION
This pull request implements a query  in `NetworkLayer`:

```hs
    , fetchNextBlock
        :: ChainPoint
        -> m (Either ErrFetchBlock block)
    -- ^ Connect to the node and try to retrieve
    -- the block at a given 'ChainPoint'.
```

This is useful for starting a wallet from a recent `ChainPoint` as opposed to from genesis.

### Issue number

ADP-3300