### PR TITLE
[ADP-3300] Add query for single block to `NetworkLayer`

### DIFF
--- a/lib/network-layer/src/Cardano/Wallet/Network.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network.hs
@@ -8,6 +8,7 @@ module Cardano.Wallet.Network
 
       -- * Errors
     , ErrPostTx (..)
+    , ErrFetchBlock (..)
 
       -- * Chain following
     , ChainFollower (..)
@@ -103,6 +104,9 @@ import Data.Text
 import Data.Text.Class
     ( ToText (..)
     )
+import Fmt
+    ( pretty
+    )
 import GHC.Generics
     ( Generic
     )
@@ -111,8 +115,6 @@ import Internal.Cardano.Write.Tx
     )
 
 import qualified Internal.Cardano.Write.Tx as Write
-    ( PParams
-    )
 
 {-----------------------------------------------------------------------------
     NetworkLayer
@@ -127,6 +129,12 @@ data NetworkLayer m block = NetworkLayer
     -- The callbacks provided in the 'ChainFollower' argument
     -- are used to handle intersection finding,
     -- the arrival of new blocks, and rollbacks.
+    , fetchNextBlock
+        :: ChainPoint
+        -> m (Either ErrFetchBlock block)
+    -- ^ Connect to the node,
+    -- try to retrieve the block at a given 'ChainPoint',
+    -- and close the connection again.
     , currentNodeTip
         :: m BlockHeader
     -- ^ Get the current tip from the chain producer
@@ -191,6 +199,8 @@ instance Functor m => Functor (NetworkLayer m) where
         nl
             { chainSync = \tr follower ->
                 chainSync nl tr $ mapChainFollower id id id (fmap f) follower
+            , fetchNextBlock =
+                fmap (fmap f) . fetchNextBlock nl
             }
 
 {-----------------------------------------------------------------------------
@@ -304,3 +314,12 @@ instance ToText ErrPostTx where
         ErrPostTxValidationError msg -> msg
         ErrPostTxMempoolFull ->
             "mempool was full and refused posted transaction"
+
+-- | Error while trying to retrieve a block
+newtype ErrFetchBlock = ErrNoBlockAt ChainPoint
+    deriving (Generic, Show, Eq)
+
+instance ToText ErrFetchBlock where
+    toText = \case
+        ErrNoBlockAt pt ->
+            "no block found at ChainPoint " <> pretty pt

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -64,6 +64,7 @@ import Cardano.Wallet.Network
     ( ChainFollowLog (..)
     , ChainFollower
     , ChainSyncLog (..)
+    , ErrFetchBlock (..)
     , ErrPostTx (..)
     , NetworkLayer (..)
     , mapChainFollower
@@ -484,6 +485,8 @@ withNodeNetworkLayerBase
                         let trChainSync = MsgConnectionStatus ClientChainSync >$< tr
                             retryHandlers = handlers ClientChainSync
                         connectClient trChainSync retryHandlers client versionData conn
+                , fetchNextBlock =
+                    pure . Left . ErrNoBlockAt
                 , currentNodeTip =
                     fromTip getGenesisBlockHash <$> atomically readNodeTip
                 , currentNodeEra =

--- a/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -213,6 +213,7 @@ dummyNodeProtocolParameters = C.ProtocolParameters
 dummyNetworkLayer :: HasCallStack => NetworkLayer m a
 dummyNetworkLayer = NetworkLayer
     { chainSync = err "chainSync"
+    , fetchNextBlock = err "fetchNextBlock"
     , currentNodeEra = err "currentNodeEra"
     , currentNodeTip = err "currentNodeTip"
     , watchNodeTip = err "watchNodeTip"


### PR DESCRIPTION
This pull request implements a query  in `NetworkLayer`:

```hs
    , fetchNextBlock
        :: ChainPoint
        -> m (Either ErrFetchBlock block)
    -- ^ Connect to the node and try to retrieve
    -- the block at a given 'ChainPoint'.
```

This is useful for starting a wallet from a recent `ChainPoint` as opposed to from genesis.

### Comments

The present implementation uses the node-to-client protocol. The main drawback of this approach is that the block **after** the given `ChainPoint` is retrieved. In contrast, an implementation using the node-to-node protocol could retrieve the block at the given `ChainPoint`. However, the wallet implementation only uses the node-to-client protocol for now.

### Issue number

ADP-3300