### PR TITLE
[ADP-3261] Separate concerns HTTP vs IO for stake pool join and quit

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
@@ -411,6 +411,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     stakePools =
              listStakePools_
         :<|> joinStakePool shelley (knownPools spl) (getPoolLifeCycleStatus spl)
+        :<|> quitStakePool shelley
         :<|> (postPoolMaintenance :<|> getPoolMaintenance)
         :<|> delegationFee shelley
         :<|> listStakeKeys rewardAccountFromAddress shelley

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Server.hs
@@ -410,9 +410,7 @@ server byron icarus shelley multisig spl ntp blockchainSource =
     stakePools :: Server (StakePools n)
     stakePools =
              listStakePools_
-        :<|> joinStakePool shelley
-            (delegationAddressS @n) (knownPools spl) (getPoolLifeCycleStatus spl)
-        :<|> quitStakePool shelley (delegationAddressS @n)
+        :<|> joinStakePool shelley (knownPools spl) (getPoolLifeCycleStatus spl)
         :<|> (postPoolMaintenance :<|> getPoolMaintenance)
         :<|> delegationFee shelley
         :<|> listStakeKeys rewardAccountFromAddress shelley

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -219,6 +219,7 @@ library
     Cardano.Wallet.Delegation.Properties
     Cardano.Wallet.Flavor
     Cardano.Wallet.Gen
+    Cardano.Wallet.IO.Delegation
     Cardano.Wallet.Network.Config
     Cardano.Wallet.Pools
     Cardano.Wallet.Primitive.Delegation.State

--- a/lib/wallet/src/Cardano/Wallet/IO/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/IO/Delegation.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Delegation functionality used by Daedalus.
+--
+module Cardano.Wallet.IO.Delegation
+    where
+
+import Prelude
+
+import Cardano.Pool.Types
+    ( PoolId
+    )
+import Cardano.Wallet
+    ( WalletLayer
+    , dbLayer
+    , logger
+    , networkLayer
+    , transactionLayer
+    )
+import Cardano.Wallet.Address.Book
+    ( AddressBookIso
+    )
+import Cardano.Wallet.Address.Derivation
+    ( DelegationAddress (..)
+    , Depth (..)
+    , DerivationType (..)
+    , HardDerivation (..)
+    , delegationAddressS
+    )
+import Cardano.Wallet.Address.Derivation.SharedKey
+    ( SharedKey
+    )
+import Cardano.Wallet.Address.Derivation.Shelley
+    ( ShelleyKey
+    )
+import Cardano.Wallet.Address.Discovery
+    ( GenChange (..)
+    , IsOurs
+    )
+import Cardano.Wallet.Address.Discovery.Sequential
+    ( SeqState (..)
+    )
+import Cardano.Wallet.Flavor
+    ( Excluding
+    , WalletFlavor (..)
+    , keyOfWallet
+    )
+import Cardano.Wallet.Network
+    ( NetworkLayer (..)
+    )
+import Cardano.Wallet.Primitive.NetworkId
+    ( HasSNetworkId
+    )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase
+    )
+import Cardano.Wallet.Primitive.Types
+    ( PoolLifeCycleStatus
+    , ProtocolParameters (..)
+    , WalletId
+    )
+import Cardano.Wallet.Primitive.Types.RewardAccount
+    ( RewardAccount
+    )
+import Cardano.Wallet.Transaction
+    ( PreSelection (..)
+    , TransactionCtx (..)
+    , defaultTransactionCtx
+    )
+import Data.Functor.Contravariant
+    ( (>$<)
+    )
+import Data.Generics.Internal.VL.Lens
+    ( (^.)
+    )
+import Data.Set
+    ( Set
+    )
+import Data.Time.Clock
+    ( UTCTime
+    )
+
+import qualified Cardano.Wallet as W
+import qualified Cardano.Wallet.Address.Discovery.Sequential as Seq
+import qualified Cardano.Wallet.Delegation as WD
+import qualified Internal.Cardano.Write.Tx as Write


### PR DESCRIPTION
This pull request separates concerns in the `Cardano.Wallet.Api.Http.Shelley.Server` module for the functions

* `selectCoinsForJoin`
* `selectCoinsForQuit`
* `joinStakePool`
* `quitStakePool`

The following concerns are in scope for `Cardano.Wallet.Api.Http.Shelley.Server`:

* Converting to and from `Api*` types
* Working with data only provided by `ApiLayer`:
    * Operating on a single `WalletId`
    * Retrieving the list of stake pools

The other concerns are moved to `Cardano.Wallet.IO.Delegation`.

### Issue Number

ADP-3261