### PR TITLE
[ADP-3261] Separate concerns IO vs logic for stake pool join and quit 

### DIFF
--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -738,9 +738,6 @@ import Data.Function
 import Data.Functor
     ( (<&>)
     )
-import Data.Functor.Contravariant
-    ( (>$<)
-    )
 import Data.Functor.Identity
     ( Identity (..)
     )
@@ -2722,9 +2719,6 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
         let db = wrk ^. dbLayer
             netLayer = wrk ^. networkLayer
 
-            trWorker :: Tracer IO W.WalletLog
-            trWorker = MsgWallet >$< wrk ^. logger
-
         (Write.PParamsInAnyRecentEra era pp, _)
             <- liftIO $ W.readNodeTipStateForTxWrite netLayer
 
@@ -2749,7 +2743,8 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
 
         optionalVoteAction <- case (body ^. #vote) of
             Just (ApiT action) ->
-                liftIO $ Just <$> WD.voteAction trWorker db action
+                liftIO $ Just <$>
+                    Cardano.Wallet.IO.Delegation.voteAction wrk action
             Nothing ->
                 pure Nothing
 
@@ -3268,9 +3263,6 @@ constructSharedTransaction
         let db = wrk ^. dbLayer
             netLayer = wrk ^. networkLayer
 
-            trWorker :: Tracer IO W.WalletLog
-            trWorker = MsgWallet >$< wrk ^. logger
-
         currentEpochSlotting <- liftIO $ getCurrentEpochSlotting netLayer
         (Write.PParamsInAnyRecentEra era pp, _)
             <- liftIO $ W.readNodeTipStateForTxWrite netLayer
@@ -3299,7 +3291,8 @@ constructSharedTransaction
                     getPoolStatus NoWithdrawal
 
         optionalVoteAction <- case (body ^. #vote) of
-            Just (ApiT action) -> liftIO $ Just <$> WD.voteAction trWorker db action
+            Just (ApiT action) -> liftIO $ Just <$>
+                Cardano.Wallet.IO.Delegation.voteAction wrk action
             Nothing -> pure Nothing
 
         let txCtx = defaultTransactionCtx

--- a/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/wallet/api/http/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2740,11 +2740,11 @@ constructTransaction api argGenChange knownPools poolStatus apiWalletId body = d
             _ -> pure NoWithdrawal
 
         currentEpochSlotting <- liftIO $ getCurrentEpochSlotting netLayer
-        optionalDelegationAction <- liftHandler $
+        optionalDelegationAction <- liftIO $
             forM delegationRequest $
-                WD.handleDelegationRequest
-                    trWorker
-                    db currentEpochSlotting knownPools
+                Cardano.Wallet.IO.Delegation.handleDelegationRequest
+                    wrk
+                    currentEpochSlotting knownPools
                     poolStatus withdrawal
 
         optionalVoteAction <- case (body ^. #vote) of
@@ -3292,10 +3292,10 @@ constructSharedTransaction
         when (isNothing delegationTemplateM && isJust delegationRequest) $
             liftHandler $ throwE ErrConstructTxDelegationInvalid
 
-        optionalDelegationAction <- liftHandler $
+        optionalDelegationAction <- liftIO $
             forM delegationRequest $
-                WD.handleDelegationRequest
-                    trWorker db currentEpochSlotting knownPools
+                Cardano.Wallet.IO.Delegation.handleDelegationRequest
+                    wrk currentEpochSlotting knownPools
                     getPoolStatus NoWithdrawal
 
         optionalVoteAction <- case (body ^. #vote) of

--- a/lib/wallet/src/Cardano/Wallet/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
@@ -13,7 +12,6 @@ module Cardano.Wallet.Delegation
     , guardQuit
     , quitStakePoolDelegationAction
     , DelegationRequest(..)
-    , handleDelegationRequest
     , voteAction
     ) where
 
@@ -102,26 +100,6 @@ data DelegationRequest
     | Quit
     -- ^ Stop delegating if the wallet is delegating.
     deriving (Eq, Show)
-
-handleDelegationRequest
-    :: forall s
-     . Tracer IO WalletLog
-    -> DBLayer IO s
-    -> CurrentEpochSlotting
-    -> IO (Set PoolId)
-    -> (PoolId -> IO PoolLifeCycleStatus)
-    -> Withdrawal
-    -> DelegationRequest
-    -> ExceptT ErrStakePoolDelegation IO Tx.DelegationAction
-handleDelegationRequest
-    tr db currentEpochSlotting getKnownPools getPoolStatus withdrawal = \case
-    Join poolId -> liftIO $ do
-        poolStatus <- getPoolStatus poolId
-        pools <- getKnownPools
-        joinStakePoolDelegationAction
-            tr db currentEpochSlotting pools poolId poolStatus
-    Quit -> liftIO
-        $ quitStakePoolDelegationAction db currentEpochSlotting withdrawal
 
 voteAction
     :: Tracer IO WalletLog

--- a/lib/wallet/src/Cardano/Wallet/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation.hs
@@ -9,7 +9,6 @@
 
 module Cardano.Wallet.Delegation
     ( joinStakePoolDelegationAction
-    , joinStakePool
     , guardJoin
     , quitStakePool
     , guardQuit
@@ -205,32 +204,6 @@ joinStakePoolDelegationAction
         MonadIO m => (e -> ErrStakePoolDelegation) -> ExceptT e m a -> m a
     throwInIO f = runExceptT >=>
         either (liftIO . throwIO . ExceptionStakePoolDelegation . f) pure
-
-joinStakePool
-    :: Tracer IO WalletLog
-    -> TimeInterpreter (ExceptT PastHorizonException IO)
-    -> DBLayer IO s
-    -> CurrentEpochSlotting
-    -> Coin
-    -> Set PoolId
-    -> PoolId
-    -> PoolLifeCycleStatus
-    -> IO TransactionCtx
-joinStakePool tr ti db currentEpochSlotting deposit pools poolId poolStatus = do
-    action <- joinStakePoolDelegationAction
-        tr
-        db
-        currentEpochSlotting
-        pools
-        poolId
-        poolStatus
-    ttl <- transactionExpirySlot ti Nothing
-    pure defaultTransactionCtx
-        { txWithdrawal = NoWithdrawal
-        , txValidityInterval = (Nothing, ttl)
-        , txDelegationAction = Just action
-        , txDeposit = Just deposit
-        }
 
 guardJoin
     :: Set PoolId


### PR DESCRIPTION
This pull request separates concerns in the `Cardano.Wallet.Delegation` module for the functions

* `joinStakePoolDelegationAction`
* `quitStakePoolDeegationAction`

The following concerns are in scope for `Cardano.Wallet.IO.Delegation`:

* Read mutable data from `WalletLayer`

The following concerns are in scope for `Cardano.Wallet.Delegation`:

* Given a `WalletState` and additional data, compute the desired `DelegationAction`.

The end result is that the module `Cardano.Wallet.Delegation` now consists of pure functions only.

### Comments

* I have also moved the `voteAction` function into the `IO`-related module, but not performed the split into a "reading data with IO" and "pure computation acting on that data" yet.

### Issue Number

ADP-3261
