### PR TITLE
[ADP-3306] Use `expectErrorInfo` for `UtxoTooSmall` errors in integration tests.

### DIFF
--- a/lib/integration/framework/Test/Integration/Framework/TestData.hs
+++ b/lib/integration/framework/Test/Integration/Framework/TestData.hs
@@ -79,7 +79,6 @@ module Test.Integration.Framework.TestData
     , errMsgNotInDictionary
     , errMsg400MinWithdrawalWrong
     , errMsg403WithdrawalNotBeneficial
-    , errMsg403MinUTxOValue
     , errMsg403CouldntIdentifyAddrAsMine
     , errMsg503PastHorizon
     , errMsg403WrongIndex
@@ -334,15 +333,6 @@ errMsg403InvalidConstructTx =
     "It looks like I've created an empty transaction that does not have \
      \any payments, withdrawals, delegations, metadata nor minting. \
      \Include at least one of them."
-
-errMsg403MinUTxOValue :: String
-errMsg403MinUTxOValue = unwords
-    [ "One of the outputs you've specified has an ada quantity that is"
-    , "below the minimum required. Either increase the ada quantity to"
-    , "at least the minimum, or specify an ada quantity of zero, in"
-    , "which case the wallet will automatically assign the correct"
-    , "minimum ada quantity to the output."
-    ]
 
 errMsg409WalletExists :: String -> String
 errMsg409WalletExists walId = "This operation would yield a wallet with the following\

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -30,6 +31,10 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Api.Types.Amount
     ( ApiAmount (ApiAmount)
+    )
+import Cardano.Wallet.Api.Types.Error
+    ( ApiErrorInfo (UtxoTooSmall)
+    , ApiErrorTxOutputLovelaceInsufficient (ApiErrorTxOutputLovelaceInsufficient)
     )
 import Cardano.Wallet.Api.Types.Transaction
     ( ApiLimit (..)
@@ -78,6 +83,7 @@ import Test.Hspec
 import Test.Hspec.Expectations.Lifted
     ( shouldBe
     , shouldNotBe
+    , shouldSatisfy
     )
 import Test.Hspec.Extra
     ( it
@@ -91,6 +97,7 @@ import Test.Integration.Framework.DSL
     , emptyRandomWallet
     , emptyWallet
     , eventually
+    , expectErrorInfo
     , expectErrorMessage
     , expectField
     , expectListField
@@ -124,7 +131,6 @@ import Test.Integration.Framework.Request
     )
 import Test.Integration.Framework.TestData
     ( errMsg400StartTimeLaterThanEndTime
-    , errMsg403MinUTxOValue
     , errMsg404NoAsset
     , errMsg404NoWallet
     , steveToken
@@ -201,8 +207,14 @@ spec = describe "BYRON_TRANSACTIONS" $ do
 
         rtx <- request @(ApiTransaction n) ctx
             (Link.createTransactionOld @'Byron wSrc) Default payload
-        expectResponseCode HTTP.status403 rtx
-        expectErrorMessage errMsg403MinUTxOValue rtx
+        verify rtx
+            [ expectResponseCode HTTP.status403
+            , expectErrorInfo $ flip shouldSatisfy $ \case
+                UtxoTooSmall ApiErrorTxOutputLovelaceInsufficient {} ->
+                    True
+                _anythingElse ->
+                    False
+            ]
 
     describe "BYRON_TRANS_ASSETS_CREATE_02a - Multi-asset transaction with no ADA" $
         forM_ [ (fixtureMultiAssetRandomWallet @n, "Byron wallet")

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -54,6 +54,7 @@ import Cardano.Wallet.Api.Types.Amount
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)
+    , ApiErrorTxOutputLovelaceInsufficient (ApiErrorTxOutputLovelaceInsufficient)
     )
 import Cardano.Wallet.Api.Types.SchemaMetadata
     ( detailedMetadata
@@ -219,7 +220,6 @@ import Test.Integration.Framework.TestData
     , errMsg400TxMetadataStringTooLong
     , errMsg403AlreadyInLedger
     , errMsg403Fee
-    , errMsg403MinUTxOValue
     , errMsg403WithdrawalNotBeneficial
     , errMsg403WrongPass
     , errMsg404CannotFindTx
@@ -994,9 +994,14 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                     (Link.createTransactionOld @'Shelley wSrc)
                     Default
                     payload
-            -- It should fail with InsufficientMinCoinValueError
-            expectResponseCode HTTP.status403 rtx
-            expectErrorMessage errMsg403MinUTxOValue rtx
+            verify rtx
+                [ expectResponseCode HTTP.status403
+                , expectErrorInfo $ flip shouldSatisfy $ \case
+                    UtxoTooSmall ApiErrorTxOutputLovelaceInsufficient {} ->
+                        True
+                    _anythingElse ->
+                        False
+                ]
 
     it "TRANS_ASSETS_CREATE_02a - Multi-asset transaction without Ada"
         $ \ctx -> runResourceT $ do

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -111,6 +111,7 @@ import Cardano.Wallet.Api.Types.Certificate
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)
+    , ApiErrorTxOutputLovelaceInsufficient (ApiErrorTxOutputLovelaceInsufficient)
     )
 import Cardano.Wallet.Api.Types.Transaction
     ( ApiAddress (..)
@@ -326,7 +327,6 @@ import Test.Integration.Framework.TestData
     , errMsg403ForeignTransaction
     , errMsg403InvalidConstructTx
     , errMsg403InvalidValidityBounds
-    , errMsg403MinUTxOValue
     , errMsg403MintOrBurnAssetQuantityOutOfBounds
     , errMsg403MissingWitsInTransaction
     , errMsg403MultiaccountTransaction
@@ -895,7 +895,11 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             (Link.createUnsignedTransaction @'Shelley wa) Default payload
         verify rTx
             [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403MinUTxOValue
+            , expectErrorInfo $ flip shouldSatisfy $ \case
+                UtxoTooSmall ApiErrorTxOutputLovelaceInsufficient {} ->
+                    True
+                _anythingElse ->
+                    False
             ]
 
     it "TRANS_NEW_CREATE_04c - Can't cover fee" $ \ctx -> runResourceT $ do
@@ -1160,7 +1164,11 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             (Link.createUnsignedTransaction @'Shelley wa) Default payload
         verify rTx
             [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403MinUTxOValue
+            , expectErrorInfo $ flip shouldSatisfy $ \case
+                UtxoTooSmall ApiErrorTxOutputLovelaceInsufficient {} ->
+                    True
+                _anythingElse ->
+                    False
             ]
 
     it "TRANS_NEW_ASSETS_CREATE_01c - Multi-asset tx without Ada" $ \ctx -> runResourceT $ do


### PR DESCRIPTION
## Issue

ADP-3306

## Notes

This PR contains a small number of commits from https://github.com/cardano-foundation/cardano-wallet/pull/3767.

## Description

This PR uses `expectErrorInfo` to test expectations about `UtxoTooSmall` errors within integration tests, instead of testing the human-readable error message.