### PR TITLE
[ADP-3309] Fix latency benchmark

### DIFF
--- a/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery.hs
+++ b/lib/address-derivation-discovery/lib/Cardano/Wallet/Address/Discovery.hs
@@ -60,7 +60,7 @@ import Data.Kind
     ( Type
     )
 import Data.List.NonEmpty
-    ( NonEmpty
+    ( NonEmpty (..)
     )
 import Data.String
     ( fromString
@@ -224,7 +224,7 @@ nextChangeIndex pool (PendingIxs pendingIndexes) =
                 [] -> (firstUnused, PendingIxs [firstUnused])
                 firstIndex : restIndexes ->
                     if length pendingIndexes < AddressPool.gap pool
-                        then let next = succ firstIndex
+                        then let next = succ $ maximum (firstIndex :| restIndexes)
                              in (next, PendingIxs (next : pendingIndexes))
                         else ( firstIndex
                              , PendingIxs (restIndexes <> [firstIndex])


### PR DESCRIPTION
This PR fixes a bug in the pending addresses logic where the rotation is breaking the assumption of order inside the list of them.

- [x] Use the next of the maximum in the pending address indices as the new address
 
ADP-3309