### PR TITLE
[AD_3288] Update windows unit test exe name in the github workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: cardano-wallet-tests-win64
-      - run: '.\\cardano-wallet-test-unit.exe --color --jobs 1 --skip /Cardano.Wallet.DB.Sqlite/ +RTS -M2G -N2'
+      - run: '.\\cardano-wallet-unit-test-unit.exe --color --jobs 1 --skip /Cardano.Wallet.DB.Sqlite/ +RTS -M2G -N2'
         env:
           LOCAL_CLUSTER_CONFIGS: test\data\cluster-configs
 


### PR DESCRIPTION
This PR fixes the name of the windows unit tests executable that was renamed as a side effect of moving the test suite out of the cardano-wallet.cabal into cardano-wallet-unit.cabal

ADP-3288