### PR TITLE
[ADP-3300] Move `Cardano.Wallet.Network.Config` to `network-layer`

### DIFF
--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -43,6 +43,7 @@ library
   hs-source-dirs:  src
   exposed-modules:
     Cardano.Wallet.Network
+    Cardano.Wallet.Network.Config
     Cardano.Wallet.Network.Implementation
     Cardano.Wallet.Network.Implementation.Ouroboros
     Cardano.Wallet.Network.Implementation.UnliftIO
@@ -63,6 +64,7 @@ library
     , cardano-api
     , cardano-balance-tx:internal
     , cardano-crypto-class
+    , cardano-ledger-byron
     , cardano-ledger-core
     , cardano-ledger-shelley
     , cardano-slotting

--- a/lib/network-layer/src/Cardano/Wallet/Network/Config.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Config.hs
@@ -11,7 +11,7 @@
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
 --
--- Command-line option passing for cardano-wallet shelley.
+-- Convert abbreviated NetworkConfiguration into extended configuration data.
 --
 
 module Cardano.Wallet.Network.Config
@@ -29,9 +29,11 @@ import Cardano.Chain.Genesis
 import Cardano.Wallet.Primitive.NetworkId
     ( NetworkId (..)
     )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Block
     ( Block (..)
-    , NetworkParameters (..)
+    )
+import Cardano.Wallet.Primitive.Types.NetworkParameters
+    ( NetworkParameters (..)
     )
 import Control.Monad.Trans.Except
     ( ExceptT (..)

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -220,7 +220,6 @@ library
     Cardano.Wallet.Flavor
     Cardano.Wallet.Gen
     Cardano.Wallet.IO.Delegation
-    Cardano.Wallet.Network.Config
     Cardano.Wallet.Pools
     Cardano.Wallet.Primitive.Delegation.State
     Cardano.Wallet.Primitive.Delegation.UTxO


### PR DESCRIPTION
This pull request moves the module `Cardano.Wallet.Network.Config` to the package `cardano-wallet-network-layer`.

The concern of the module `Cardano.Wallet.Network.Config` is to convert an abbreviated description of a network, such as "Mainnet", into more extended configuration data. I think that this is on-topic for the `cardano-wallet-network-layer` package; for example, it helps with creating integration tests for this package.

### Issue number

ADP-3300