### PR TITLE
[ADP-3300] Make `Cardano.Wallet.Read.Block` a hierarchy root

### DIFF
--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -45,6 +45,7 @@ library
   exposed-modules:
     Cardano.Wallet.Read
     Cardano.Wallet.Read.Block
+    Cardano.Wallet.Read.Block.Block
     Cardano.Wallet.Read.Block.BlockNo
     Cardano.Wallet.Read.Block.Gen
     Cardano.Wallet.Read.Block.Gen.Babbage

--- a/lib/read/lib/Cardano/Wallet/Read/Block.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block.hs
@@ -1,103 +1,40 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
+{- |
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
 
--- |
--- Copyright: © 2022 IOHK
--- License: Apache-2.0
---
--- The 'Block' type represents blocks as they are read from the mainnet ledger.
--- It is compatible with the era-specific types from @cardano-ledger@.
+The 'Block' type represents a block indexed by one of the known eras.
+It is compatible with the types from @cardano-ledger@.
+-}
 module Cardano.Wallet.Read.Block
-    ( ConsensusBlock
-    , Block (..)
-    , fromConsensusBlock
-    , toConsensusBlock
+    ( module Cardano.Wallet.Read.Block.Block
+    , module Cardano.Wallet.Read.Block.BlockNo
+    , module Cardano.Wallet.Read.Block.HeaderHash
+    , module Cardano.Wallet.Read.Block.SlotNo
+    , module Cardano.Wallet.Read.Block.Txs
     ) where
 
-import Prelude
-
-import Cardano.Ledger.Api
-    ( StandardCrypto
+import Cardano.Wallet.Read.Block.Block
+    ( Block (..)
+    , ConsensusBlock
+    , fromConsensusBlock
+    , toConsensusBlock
     )
-import Cardano.Wallet.Read.Eras
-    ( Allegra
-    , Alonzo
-    , Babbage
-    , Byron
-    , Conway
-    , EraFun (..)
-    , EraValue
-    , K (..)
-    , Mary
-    , Shelley
-    , allegra
-    , alonzo
-    , babbage
-    , byron
-    , conway
-    , inject
-    , mary
-    , shelley
+import Cardano.Wallet.Read.Block.BlockNo
+    ( BlockNo (..)
+    , getEraBlockNo
     )
-import Ouroboros.Consensus.Protocol.Praos
-    ( Praos
+import Cardano.Wallet.Read.Block.HeaderHash
+    ( HeaderHash (..)
+    , HeaderHashT
+    , PrevHeaderHash (..)
+    , PrevHeaderHashT
+    , getEraHeaderHash
+    , getEraPrevHeaderHash
     )
-import Ouroboros.Consensus.Protocol.TPraos
-    ( TPraos
+import Cardano.Wallet.Read.Block.SlotNo
+    ( SlotNo (..)
+    , getEraSlotNo
     )
-
-import qualified Ouroboros.Consensus.Byron.Ledger as O
-import qualified Ouroboros.Consensus.Cardano.Block as O
-import qualified Ouroboros.Consensus.Shelley.Ledger as O
-
--- | Type synonym for 'CardanoBlock' with cryptography as used on mainnet.
-type ConsensusBlock = O.CardanoBlock O.StandardCrypto
-
--- Family of era-specific block types
-type family BlockT era where
-    BlockT Byron =
-        O.ByronBlock
-    BlockT Shelley =
-        O.ShelleyBlock (TPraos StandardCrypto) (O.ShelleyEra StandardCrypto)
-    BlockT Allegra =
-        O.ShelleyBlock (TPraos StandardCrypto) (O.AllegraEra StandardCrypto)
-    BlockT Mary =
-        O.ShelleyBlock (TPraos StandardCrypto) (O.MaryEra StandardCrypto)
-    BlockT Alonzo =
-        O.ShelleyBlock (TPraos StandardCrypto) (O.AlonzoEra StandardCrypto)
-    BlockT Babbage =
-        O.ShelleyBlock (Praos StandardCrypto) (O.BabbageEra StandardCrypto)
-    BlockT Conway =
-        O.ShelleyBlock (Praos StandardCrypto) (O.ConwayEra StandardCrypto)
-
-newtype Block era = Block {unBlock :: BlockT era}
-
-deriving instance Show (BlockT era) => Show (Block era)
-deriving instance Eq (BlockT era) => Eq (Block era)
-
--- | Convert block as received from cardano-node
--- via Haskell library of mini-protocol.
-fromConsensusBlock :: ConsensusBlock -> EraValue Block
-fromConsensusBlock = \case
-    O.BlockByron b -> inject byron $ Block b
-    O.BlockShelley block -> inject shelley $ Block block
-    O.BlockAllegra block -> inject allegra $ Block block
-    O.BlockMary block -> inject mary $ Block block
-    O.BlockAlonzo block -> inject alonzo $ Block block
-    O.BlockBabbage block -> inject babbage $ Block block
-    O.BlockConway block -> inject conway $ Block block
-
-toConsensusBlock :: EraFun Block (K ConsensusBlock)
-toConsensusBlock =
-    EraFun
-        { byronFun = K . O.BlockByron . unBlock
-        , shelleyFun = K . O.BlockShelley . unBlock
-        , allegraFun = K . O.BlockAllegra . unBlock
-        , maryFun = K . O.BlockMary . unBlock
-        , alonzoFun = K . O.BlockAlonzo . unBlock
-        , babbageFun = K . O.BlockBabbage . unBlock
-        , conwayFun = K . O.BlockConway . unBlock
-        }
+import Cardano.Wallet.Read.Block.Txs
+    ( getEraTransactions
+    )

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Block.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Block.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Copyright: © 2022 IOHK
+-- License: Apache-2.0
+--
+-- The 'Block' type.
+--
+module Cardano.Wallet.Read.Block.Block
+    ( ConsensusBlock
+    , Block (..)
+    , fromConsensusBlock
+    , toConsensusBlock
+    ) where
+
+import Prelude
+
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
+import Cardano.Wallet.Read.Eras
+    ( Allegra
+    , Alonzo
+    , Babbage
+    , Byron
+    , Conway
+    , EraFun (..)
+    , EraValue
+    , K (..)
+    , Mary
+    , Shelley
+    , allegra
+    , alonzo
+    , babbage
+    , byron
+    , conway
+    , inject
+    , mary
+    , shelley
+    )
+import Ouroboros.Consensus.Protocol.Praos
+    ( Praos
+    )
+import Ouroboros.Consensus.Protocol.TPraos
+    ( TPraos
+    )
+
+import qualified Ouroboros.Consensus.Byron.Ledger as O
+import qualified Ouroboros.Consensus.Cardano.Block as O
+import qualified Ouroboros.Consensus.Shelley.Ledger as O
+
+-- | Type synonym for 'CardanoBlock',
+-- using the same cryptographic functionalities as Mainnet.
+type ConsensusBlock = O.CardanoBlock O.StandardCrypto
+
+-- Family of era-specific block types
+type family BlockT era where
+    BlockT Byron =
+        O.ByronBlock
+    BlockT Shelley =
+        O.ShelleyBlock (TPraos StandardCrypto) (O.ShelleyEra StandardCrypto)
+    BlockT Allegra =
+        O.ShelleyBlock (TPraos StandardCrypto) (O.AllegraEra StandardCrypto)
+    BlockT Mary =
+        O.ShelleyBlock (TPraos StandardCrypto) (O.MaryEra StandardCrypto)
+    BlockT Alonzo =
+        O.ShelleyBlock (TPraos StandardCrypto) (O.AlonzoEra StandardCrypto)
+    BlockT Babbage =
+        O.ShelleyBlock (Praos StandardCrypto) (O.BabbageEra StandardCrypto)
+    BlockT Conway =
+        O.ShelleyBlock (Praos StandardCrypto) (O.ConwayEra StandardCrypto)
+
+newtype Block era = Block {unBlock :: BlockT era}
+
+deriving instance Show (BlockT era) => Show (Block era)
+deriving instance Eq (BlockT era) => Eq (Block era)
+
+-- | Convert block as received from cardano-node
+-- via Haskell library of mini-protocol.
+fromConsensusBlock :: ConsensusBlock -> EraValue Block
+fromConsensusBlock = \case
+    O.BlockByron b -> inject byron $ Block b
+    O.BlockShelley block -> inject shelley $ Block block
+    O.BlockAllegra block -> inject allegra $ Block block
+    O.BlockMary block -> inject mary $ Block block
+    O.BlockAlonzo block -> inject alonzo $ Block block
+    O.BlockBabbage block -> inject babbage $ Block block
+    O.BlockConway block -> inject conway $ Block block
+
+toConsensusBlock :: EraFun Block (K ConsensusBlock)
+toConsensusBlock =
+    EraFun
+        { byronFun = K . O.BlockByron . unBlock
+        , shelleyFun = K . O.BlockShelley . unBlock
+        , allegraFun = K . O.BlockAllegra . unBlock
+        , maryFun = K . O.BlockMary . unBlock
+        , alonzoFun = K . O.BlockAlonzo . unBlock
+        , babbageFun = K . O.BlockBabbage . unBlock
+        , conwayFun = K . O.BlockConway . unBlock
+        }

--- a/lib/read/lib/Cardano/Wallet/Read/Block/BlockNo.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/BlockNo.hs
@@ -18,7 +18,7 @@ import Cardano.Ledger.Era
     ( Era
     , EraSegWits (..)
     )
-import Cardano.Wallet.Read
+import Cardano.Wallet.Read.Block.Block
     ( Block (..)
     )
 import Cardano.Wallet.Read.Eras.EraFun

--- a/lib/read/lib/Cardano/Wallet/Read/Block/HeaderHash.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/HeaderHash.hs
@@ -28,7 +28,7 @@ import Cardano.Ledger.Era
 import Cardano.Protocol.TPraos.BHeader
     ( PrevHash
     )
-import Cardano.Wallet.Read
+import Cardano.Wallet.Read.Block.Block
     ( Block (..)
     )
 import Cardano.Wallet.Read.Eras

--- a/lib/read/lib/Cardano/Wallet/Read/Block/SlotNo.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/SlotNo.hs
@@ -17,9 +17,13 @@ import Cardano.Ledger.Era
     ( Era
     , EraSegWits (..)
     )
-import Cardano.Wallet.Read
+import Cardano.Wallet.Read.Block.Block
     ( Block (..)
     )
+import Cardano.Wallet.Read.Block.BlockNo
+    ()
+    -- ?! GHC 9.6.4: This import looks redundant, but the compilation
+    -- of getSlotNoShelley will fail if we don't that. No idea why.
 import Cardano.Wallet.Read.Eras.EraFun
     ( EraFun (..)
     )
@@ -37,7 +41,6 @@ import Ouroboros.Consensus.Protocol.TPraos
     )
 
 import qualified Cardano.Ledger.Shelley.API as Shelley
-import qualified Cardano.Ledger.Slot as L
 import qualified Cardano.Protocol.TPraos.BHeader as Shelley
 import qualified Ouroboros.Consensus.Protocol.Praos.Header as O
 import qualified Ouroboros.Consensus.Shelley.Ledger.Block as O
@@ -55,7 +58,7 @@ getEraSlotNo =
         , conwayFun = \(Block block) -> k $ getSlotNoBabbage block
         }
   where
-    k = K . SlotNo . fromIntegral . L.unSlotNo
+    k = K . SlotNo . fromIntegral . O.unSlotNo
 
 newtype SlotNo = SlotNo {unSlotNo :: Natural}
     deriving (Eq, Show)
@@ -67,6 +70,7 @@ getSlotNoShelley
 getSlotNoShelley
     (O.ShelleyBlock (Shelley.Block (Shelley.BHeader header _) _) _) =
         Shelley.bheaderSlotNo header
+
 getSlotNoBabbage
     :: (Era era, EncCBORGroup (TxSeq era), Crypto crypto)
     => O.ShelleyBlock (Praos crypto) era

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Txs.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Txs.hs
@@ -11,7 +11,7 @@ import Prelude
 import Cardano.Ledger.Binary
     ( EncCBOR
     )
-import Cardano.Wallet.Read.Block
+import Cardano.Wallet.Read.Block.Block
     ( Block (..)
     )
 import Cardano.Wallet.Read.Eras


### PR DESCRIPTION
This pull request rearranges the modules `Cardano.Wallet.Read.Block.*` to make `Cardano.Wallet.Read.Block` a hierarchy root that reexports lower levels.

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-3300