### PR TITLE
[ADP-3184] Remove use of `StdGenSeed` from `balanceTransaction`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -124,13 +124,11 @@ import Control.Monad
     )
 import Control.Monad.Random
     ( MonadRandom
-    , evalRand
     )
 import Control.Monad.Trans.Except
     ( ExceptT (ExceptT)
     , catchE
     , except
-    , runExceptT
     , throwE
     , withExceptT
     )
@@ -263,10 +261,6 @@ import Internal.Cardano.Write.UTxOAssumptions
     )
 import Numeric.Natural
     ( Natural
-    )
-import System.Random.StdGenSeed
-    ( stdGenFromSeed
-    , stdGenSeed
     )
 import Text.Pretty.Simple
     ( pShow
@@ -982,12 +976,9 @@ selectAssets pp utxoAssumptions outs' redeemers
 
     performSelection'
         :: ExceptT (ErrBalanceTx era) m Selection
-    performSelection' = do
-        seed <- stdGenSeed
-        except
-            $ left coinSelectionErrorToBalanceTxError
-            $ (`evalRand` stdGenFromSeed seed) . runExceptT
-            $ performSelection selectionConstraints selectionParams
+    performSelection'
+        = withExceptT coinSelectionErrorToBalanceTxError
+        $ performSelection selectionConstraints selectionParams
 
     selectionConstraints = SelectionConstraints
         { tokenBundleSizeAssessor =

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -663,7 +663,6 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         -- adjust the change and ExUnits of each redeemer to something more
         -- sensible than the max execution cost.
 
-        randomSeed <- stdGenSeed
         let
             transform
                 :: Selection
@@ -697,7 +696,6 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 utxoSelection
                 balance0
                 (Convert.toWalletCoin minfee0)
-                randomSeed
                 genChange
                 selectionStrategy
 
@@ -958,13 +956,12 @@ selectAssets
     -- ^ Balance to cover.
     -> W.Coin
     -- ^ Current minimum fee (before selecting assets).
-    -> StdGenSeed
     -> ChangeAddressGen changeState
     -> SelectionStrategy
     -- ^ A function to assess the size of a token bundle.
     -> ExceptT (ErrBalanceTx era) m Selection
 selectAssets pp utxoAssumptions outs' redeemers
-    utxoSelection balance fee0 _seed changeGen selectionStrategy = do
+    utxoSelection balance fee0 changeGen selectionStrategy = do
         seed <- stdGenSeed
         except validateTxOutputs'
         except (performSelection' seed)

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -964,9 +964,10 @@ selectAssets
     -- ^ A function to assess the size of a token bundle.
     -> ExceptT (ErrBalanceTx era) m Selection
 selectAssets pp utxoAssumptions outs' redeemers
-    utxoSelection balance fee0 seed changeGen selectionStrategy = do
+    utxoSelection balance fee0 _seed changeGen selectionStrategy = do
+        seed <- stdGenSeed
         except validateTxOutputs'
-        except performSelection'
+        except (performSelection' seed)
   where
     era = recentEra @era
 
@@ -985,8 +986,8 @@ selectAssets pp utxoAssumptions outs' redeemers
             (outs <&> \out -> (view #address out, view #tokens out))
 
     performSelection'
-        :: Either (ErrBalanceTx era) Selection
-    performSelection'
+        :: StdGenSeed -> Either (ErrBalanceTx era) Selection
+    performSelection' seed
         = left coinSelectionErrorToBalanceTxError
         $ (`evalRand` stdGenFromSeed seed) . runExceptT
         $ performSelection selectionConstraints selectionParams

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -701,7 +701,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 genChange
                 selectionStrategy
 
-        except $ transform <$> mSel
+        transform <$> mSel
 
     -- NOTE:
     -- Once the coin selection is done, we need to
@@ -943,8 +943,10 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 -- transaction. For this, and other reasons, the selection may include too
 -- much ada.
 selectAssets
-    :: forall era changeState
-     . IsRecentEra era
+    :: forall era m changeState.
+        ( MonadRandom m
+        , IsRecentEra era
+        )
     => PParams era
     -> UTxOAssumptions
     -> [TxOut era]
@@ -960,11 +962,11 @@ selectAssets
     -> ChangeAddressGen changeState
     -> SelectionStrategy
     -- ^ A function to assess the size of a token bundle.
-    -> Either (ErrBalanceTx era) Selection
+    -> ExceptT (ErrBalanceTx era) m Selection
 selectAssets pp utxoAssumptions outs' redeemers
     utxoSelection balance fee0 seed changeGen selectionStrategy = do
-        validateTxOutputs'
-        performSelection'
+        except validateTxOutputs'
+        except performSelection'
   where
     era = recentEra @era
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -984,11 +984,12 @@ selectAssets pp utxoAssumptions outs' redeemers
 
     performSelection'
         :: StdGenSeed -> ExceptT (ErrBalanceTx era) m Selection
-    performSelection' seed
-        = except
-        $ left coinSelectionErrorToBalanceTxError
-        $ (`evalRand` stdGenFromSeed seed) . runExceptT
-        $ performSelection selectionConstraints selectionParams
+    performSelection' _seed = do
+        seed <- stdGenSeed
+        except
+            $ left coinSelectionErrorToBalanceTxError
+            $ (`evalRand` stdGenFromSeed seed) . runExceptT
+            $ performSelection selectionConstraints selectionParams
 
     selectionConstraints = SelectionConstraints
         { tokenBundleSizeAssessor =

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -964,7 +964,7 @@ selectAssets pp utxoAssumptions outs' redeemers
     utxoSelection balance fee0 changeGen selectionStrategy = do
         seed <- stdGenSeed
         except validateTxOutputs'
-        except (performSelection' seed)
+        performSelection' seed
   where
     era = recentEra @era
 
@@ -983,9 +983,10 @@ selectAssets pp utxoAssumptions outs' redeemers
             (outs <&> \out -> (view #address out, view #tokens out))
 
     performSelection'
-        :: StdGenSeed -> Either (ErrBalanceTx era) Selection
+        :: StdGenSeed -> ExceptT (ErrBalanceTx era) m Selection
     performSelection' seed
-        = left coinSelectionErrorToBalanceTxError
+        = except
+        $ left coinSelectionErrorToBalanceTxError
         $ (`evalRand` stdGenFromSeed seed) . runExceptT
         $ performSelection selectionConstraints selectionParams
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -265,8 +265,7 @@ import Numeric.Natural
     ( Natural
     )
 import System.Random.StdGenSeed
-    ( StdGenSeed (..)
-    , stdGenFromSeed
+    ( stdGenFromSeed
     , stdGenSeed
     )
 import Text.Pretty.Simple
@@ -962,9 +961,8 @@ selectAssets
     -> ExceptT (ErrBalanceTx era) m Selection
 selectAssets pp utxoAssumptions outs' redeemers
     utxoSelection balance fee0 changeGen selectionStrategy = do
-        seed <- stdGenSeed
         except validateTxOutputs'
-        performSelection' seed
+        performSelection'
   where
     era = recentEra @era
 
@@ -983,8 +981,8 @@ selectAssets pp utxoAssumptions outs' redeemers
             (outs <&> \out -> (view #address out, view #tokens out))
 
     performSelection'
-        :: StdGenSeed -> ExceptT (ErrBalanceTx era) m Selection
-    performSelection' _seed = do
+        :: ExceptT (ErrBalanceTx era) m Selection
+    performSelection' = do
         seed <- stdGenSeed
         except
             $ left coinSelectionErrorToBalanceTxError


### PR DESCRIPTION
## Description

This PR adjusts the definition of `balanceTransaction` to remove the use of `StdGenSeed`.

The `balanceTransaction` function needs a source of randomness in order to call `performSelection`. However, since both `balanceTransaction` and `performSelection` already have a `MonadRandom` constraint, it's not necessary to produce or consume values of `StdGenSeed`.

## Related tickets

ADP-3184
ADP-3185
