### PR TITLE
Use the GHC specializer to remove pattern matches on `era` dictionary

### DIFF
--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -60,6 +60,7 @@ library
     Cardano.Wallet.Read.Eras.EraFun
     Cardano.Wallet.Read.Eras.EraValue
     Cardano.Wallet.Read.Eras.KnownEras
+    Cardano.Wallet.Read.Test
     Cardano.Wallet.Read.Tx
     Cardano.Wallet.Read.Tx.Cardano
     Cardano.Wallet.Read.Tx.CBOR

--- a/lib/read/lib/Cardano/Wallet/Read/Test.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Test.hs
@@ -1,0 +1,109 @@
+{-# OPTIONS_GHC -ddump-simpl -ddump-to-file -O #-}
+
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Wallet.Read.Test where
+
+import Prelude
+
+newtype K a era = K {unK :: a}
+
+{-----------------------------------------------------------------------------
+    EraFun
+------------------------------------------------------------------------------}
+data Byron
+data Shelley
+
+data Era era where
+    Byron :: Era Byron
+    Shelley :: Era Shelley
+
+class IsEra era where
+    theEra :: Era era
+
+instance IsEra Byron where theEra = Byron
+instance IsEra Shelley where theEra = Shelley
+
+data EraFun f g = EraFun
+    { byronFun :: f Byron -> g Byron
+    , shelleyFun :: f Shelley -> g Shelley
+    }
+
+{-# INLINEABLE applyOnEra #-}
+applyOnEra
+    :: forall era f g. IsEra era
+    => EraFun f g -> f era -> g era
+applyOnEra f = case theEra :: Era era of
+    Byron -> byronFun f
+    Shelley -> shelleyFun f
+
+{-----------------------------------------------------------------------------
+    Block
+------------------------------------------------------------------------------}
+type SlotNo = Integer
+
+data BlockByron = BlockByron
+    { slotNo :: Integer
+    , isEpochBoundaryBlock :: Bool
+    }
+
+data BlockShelley = BlockShelley
+    { slotNo :: Integer
+    , headerHash :: String
+    }
+
+type family BlockT era where
+    BlockT Byron = BlockByron
+    BlockT Shelley = BlockShelley
+
+newtype Block era = Block {unBlock :: BlockT era}
+
+{-----------------------------------------------------------------------------
+    Block features
+------------------------------------------------------------------------------}
+getEraSlotNo :: EraFun Block (K SlotNo)
+getEraSlotNo = EraFun
+    { byronFun = \(Block BlockByron{slotNo}) -> K slotNo
+    , shelleyFun = \(Block BlockShelley{slotNo}) -> K slotNo
+    }
+
+type family HeaderHashT era where
+    HeaderHashT Byron = ()
+    HeaderHashT Shelley = String
+
+newtype HeaderHash era = HeaderHash {unHeaderHash :: HeaderHashT era}
+
+getEraHeaderHash :: EraFun Block HeaderHash
+getEraHeaderHash = EraFun
+    { byronFun = \(Block{}) -> HeaderHash ()
+    , shelleyFun = \(Block BlockShelley{headerHash}) -> HeaderHash headerHash
+    }
+
+{-----------------------------------------------------------------------------
+    Block
+------------------------------------------------------------------------------}
+
+{-# INLINEABLE getSlotNo #-}
+getSlotNo :: IsEra era => Block era -> SlotNo
+getSlotNo = unK . applyOnEra getEraSlotNo
+
+{-# INLINEABLE getHeaderHash #-}
+getHeaderHash :: IsEra era => Block era -> HeaderHash era
+getHeaderHash = applyOnEra getEraHeaderHash
+
+{-# INLINEABLE getLength #-}
+getLength :: forall era. IsEra era => HeaderHash era -> Int
+getLength (HeaderHash hash) = case theEra :: Era era of
+    Byron -> 0
+    Shelley -> length hash
+
+{-# INLINEABLE getHeaderHashLength #-}
+getHeaderHashLength :: forall era. IsEra era => Block era -> Int
+getHeaderHashLength = getLength . getHeaderHash
+
+specializeShelley :: Block Shelley -> (SlotNo, Int)
+specializeShelley block = (getSlotNo block, getHeaderHashLength block)


### PR DESCRIPTION
This pull request experiments with a simplification of the `Cardano.Wallet.Read.*` hierarchy where the `EraFun f g` is removed in favor of a plain type

```hs
foo :: forall era. IsEra era => f era → g era
```

Here, `foo` pattern matches on the `theEra :: Era era` dictionary to select the appropriate era. Applying multiple functions of this kind might lead to repeated, redundant pattern matches. However, since `era` is a type-level argument, we can use the [GHC specializer][1] to apply this argument at compile-time — this pull request demonstrates how.

  [1]: https://downloads.haskell.org/ghc/latest/docs/users_guide/exts/pragmas.html#specialize-pragma

After compiling this module, there is a file `dist-newstyle/**/Test.dump-simpl` which contains the compile Core of the module. Noteworthy outcomes are:

* The function `Cardano.Wallet.Read.Test.$wgetHeaderHashLength` does a pattern match on the era `$dIsEra_s65W :: IsEra era_s65V`, but the compiler was able to remove the intermediate match associated with `getLength`.

* The function `specializeShelley` is completely specialized — the dictionary and any pattern matches on it have been removed.