### PR TITLE
[ADP-3322] Optimize `EraFun` calls

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Block/Header.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Block/Header.hs
@@ -100,6 +100,7 @@ fromBlockNo (BlockNo h) = Quantity (fromIntegral h)
 fromSlotNo :: SlotNo -> O.SlotNo
 fromSlotNo (SlotNo s) = O.SlotNo $ fromIntegral s
 
+{-# INLINEABLE primitiveHash #-}
 primitiveHash :: forall era. IsEra era => HeaderHash era -> W.Hash "BlockHeader"
 primitiveHash = case theEra @era of
     Byron -> \(HeaderHash h) -> fromByronHash h
@@ -116,6 +117,7 @@ primitiveHash = case theEra @era of
         -> W.Hash "BlockHeader"
     mkHashShelley (HeaderHash (ShelleyHash h)) = W.Hash . hashToBytes $ h
 
+{-# INLINABLE primitivePrevHash #-}
 primitivePrevHash
     :: forall era
     . IsEra era

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Certificates.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Certificates.hs
@@ -110,6 +110,7 @@ import qualified Data.Set as Set
 anyEraCerts :: forall era . IsEra era => Tx era -> [Certificate]
 anyEraCerts = primitiveCertificates . getEraCertificates
 
+{-# INLINABLE primitiveCertificates #-}
 -- | Compute wallet primitive certificates from ledger certificates
 primitiveCertificates
     :: forall era . IsEra era => Certificates era -> [W.Certificate]

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/CollateralInputs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/CollateralInputs.hs
@@ -25,6 +25,7 @@ import Cardano.Wallet.Read.Tx.CollateralInputs
 import qualified Cardano.Ledger.Shelley.API as SH
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 
+{-# INLINABLE getCollateralInputs #-}
 getCollateralInputs :: forall era. IsEra era => CollateralInputs era -> [W.TxIn]
 getCollateralInputs = case theEra @era of
     Byron -> \_ -> []

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/CollateralOutputs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/CollateralOutputs.hs
@@ -34,6 +34,7 @@ import qualified Cardano.Ledger.Babbage as Babbage
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 
+{-# INLINABLE getCollateralOutputs #-}
 getCollateralOutputs
     :: forall era
      . IsEra era

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/ExtraSigs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/ExtraSigs.hs
@@ -49,6 +49,7 @@ import Data.Set
 
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 
+{-# INLINABLE extraSigs #-}
 extraSigs :: forall era. IsEra era => ExtraSigs era -> [W.Hash "ExtraSignature"]
 extraSigs = case theEra @era of
     Byron -> noExtraSigs

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Fee.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Fee.hs
@@ -27,6 +27,7 @@ import Cardano.Wallet.Read.Tx.Fee
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Ledger
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 
+{-# INLINABLE getFee #-}
 getFee :: forall era . IsEra era => Fee era -> Maybe W.Coin
 getFee = case theEra @era of
     Byron -> \_ -> Nothing

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Inputs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Inputs.hs
@@ -44,6 +44,7 @@ import qualified Cardano.Ledger.TxIn as SL
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 
+{-# INLINABLE getInputs #-}
 getInputs :: forall era. IsEra era => Inputs era -> [W.TxIn]
 getInputs = case theEra @era of
     Byron -> \(Inputs ins) -> fromByronTxIn <$> toList ins

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Integrity.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Integrity.hs
@@ -52,6 +52,7 @@ import Data.Maybe.Strict
 
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 
+{-# INLINABLE integrity #-}
 integrity :: forall era . IsEra era
     => Integrity era -> Maybe (W.Hash "ScriptIntegrity")
 integrity = case theEra @era of

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Metadata.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Metadata.hs
@@ -62,6 +62,7 @@ import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Api.Shelley as CardanoAPI
 import qualified Cardano.Wallet.Primitive.Types.Tx.Tx as W
 
+{-# INLINABLE getMetadata #-}
 getMetadata :: forall era . IsEra era => Metadata era -> Maybe W.TxMetadata
 getMetadata = case theEra @era of
     Byron -> noMetadatas

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Mint.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Mint.hs
@@ -118,6 +118,7 @@ import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.Map.Strict as Map
 
+{-# INLINABLE mint #-}
 mint
     :: forall era
      . IsEra era

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Outputs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Outputs.hs
@@ -83,6 +83,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenPolicyId as W
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 
+{-# INLINABLE getOutputs #-}
 getOutputs :: forall era . IsEra era => Outputs era -> [W.TxOut]
 getOutputs = case theEra @era of
     Byron -> \(Outputs os) -> fromByronTxOut <$> toList os

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Validity.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Validity.hs
@@ -41,6 +41,7 @@ import Data.Quantity
 
 import qualified Ouroboros.Network.Block as O
 
+{-# INLINABLE getValidity #-}
 getValidity :: forall era. IsEra era => Validity era -> Maybe ValidityIntervalExplicit
 getValidity = case theEra @era of
     Byron -> \_validity -> Nothing

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Withdrawals.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Withdrawals.hs
@@ -41,6 +41,7 @@ import qualified Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Certificates a
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Data.Map as Map
 
+{-# INLINABLE getWithdrawals #-}
 getWithdrawals :: forall era. IsEra era => Withdrawals era -> Maybe (Map RewardAccount Coin)
 getWithdrawals = case theEra @era of
     Byron -> \_withdrawals -> Nothing

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Block.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Block.hs
@@ -89,6 +89,7 @@ fromConsensusBlock = \case
     O.BlockBabbage block -> eraValue @Babbage $ Block block
     O.BlockConway block -> eraValue @Conway $ Block block
 
+{-# INLINABLE toConsensusBlock #-}
 toConsensusBlock :: forall era . IsEra era => Block era -> ConsensusBlock
 toConsensusBlock = case theEra @era of
     Byron -> O.BlockByron . unBlock

--- a/lib/read/lib/Cardano/Wallet/Read/Block/BlockNo.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/BlockNo.hs
@@ -44,6 +44,7 @@ import qualified Ouroboros.Consensus.Protocol.Praos.Header as O
 import qualified Ouroboros.Consensus.Shelley.Ledger.Block as O
 import qualified Ouroboros.Network.Block as O
 
+{-# INLINABLE getEraBlockNo #-}
 getEraBlockNo :: forall era. IsEra era => Block era -> BlockNo
 getEraBlockNo = case theEra @era of
     Byron -> \(Block block) -> k $ O.blockNo block

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Gen.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Gen.hs
@@ -36,6 +36,7 @@ import Control.Category
     ( (.)
     )
 
+{-# INLINABLE mkBlockEra #-}
 mkBlockEra :: forall era . IsEra era => BlockParameters era -> Block era
 mkBlockEra = case theEra @era of
     Byron -> g mkByronBlock

--- a/lib/read/lib/Cardano/Wallet/Read/Block/HeaderHash.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/HeaderHash.hs
@@ -83,6 +83,7 @@ type family HeaderHashT era where
 -- | Era-specific header hash type from the ledger
 newtype HeaderHash era = HeaderHash (HeaderHashT era)
 
+{-# INLINABLE getEraHeaderHash #-}
 getEraHeaderHash :: forall era . IsEra era => Block era -> HeaderHash era
 getEraHeaderHash = case theEra @era of
     Byron -> \(Block block) -> HeaderHash $ O.blockHash block
@@ -129,6 +130,7 @@ getPrevHeaderHashShelley
 getPrevHeaderHashShelley (O.ShelleyBlock (Shelley.Block header _) _) =
     Shelley.pHeaderPrevHash header
 
+{-# INLINABLE getEraPrevHeaderHash #-}
 getEraPrevHeaderHash :: forall era . IsEra era => Block era -> PrevHeaderHash era
 getEraPrevHeaderHash = case theEra @era of
     Byron -> \(Block block) -> PrevHeaderHash $ headerPrevHash $ O.getHeader block

--- a/lib/read/lib/Cardano/Wallet/Read/Block/SlotNo.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/SlotNo.hs
@@ -47,6 +47,7 @@ import qualified Ouroboros.Consensus.Protocol.Praos.Header as O
 import qualified Ouroboros.Consensus.Shelley.Ledger.Block as O
 import qualified Ouroboros.Network.Block as O
 
+{-# INLINABLE getEraSlotNo #-}
 getEraSlotNo :: forall era. IsEra era => Block era -> SlotNo
 getEraSlotNo = case theEra @era of
     Byron -> \(Block block) -> k $ O.blockSlot block

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Txs.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Txs.hs
@@ -46,6 +46,7 @@ import qualified Ouroboros.Consensus.Byron.Ledger as Byron
 import qualified Ouroboros.Consensus.Byron.Ledger as O
 import qualified Ouroboros.Consensus.Shelley.Ledger as O
 
+{-# INLINABLE getEraTransactions #-}
 -- | Get the list of transactions in the block.
 getEraTransactions :: forall era. IsEra era => Block era -> ([] :.: Tx) era
 getEraTransactions = case theEra @era of

--- a/lib/read/lib/Cardano/Wallet/Read/Eras/EraValue.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Eras/EraValue.hs
@@ -68,6 +68,7 @@ instance (All (Compose Show f) KnownEras) => Show (EraValue f) where
         Conway -> "InConway " ++ show x
 
 instance (All (Compose Eq f) KnownEras) => Eq (EraValue f) where
+    {-# INLINABLE (==) #-}
     (==) (EraValue (v :: f erax)) (EraValue (w :: f eray)) =
         case (theEra @erax, theEra @eray) of
             (Byron, Byron) -> v == w
@@ -80,6 +81,7 @@ instance (All (Compose Eq f) KnownEras) => Eq (EraValue f) where
             (_, _) -> False
 
 instance (All (Compose Ord f) KnownEras) => Ord (EraValue f) where
+    {-# INLINABLE compare #-}
     compare ex@(EraValue (x :: f erax)) ey@(EraValue (y :: f eray)) =
         case (theEra @erax, theEra @eray) of
             (Byron, Byron) -> compare x y
@@ -92,6 +94,7 @@ instance (All (Compose Ord f) KnownEras) => Ord (EraValue f) where
             (_, _) -> compare (indexEraValue ex) (indexEraValue ey)
 
 instance (All (Compose NFData f) KnownEras) => NFData (EraValue f) where
+    {-# INLINABLE rnf #-}
     rnf (EraValue (x :: f era)) = case theEra @era of
         Byron -> rnf x
         Shelley -> rnf x
@@ -105,6 +108,7 @@ instance (All (Compose NFData f) KnownEras) => NFData (EraValue f) where
 extractEraValue :: EraValue (K a) -> a
 extractEraValue (EraValue (K x)) = x
 
+{-# INLINABLE indexEraValue #-}
 indexEraValue :: EraValue f -> Int
 indexEraValue (EraValue (_ :: f era)) = case theEra @era of
     Byron -> 0

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/CBOR.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/CBOR.hs
@@ -101,6 +101,7 @@ instance ToText TxCBOR
 renderTxToCBOR :: EraValue Tx -> EraValue (K BL.ByteString)
 renderTxToCBOR = applyEraFunValue serializeTx
 
+{-# INLINABLE serializeTx #-}
 -- | CBOR serialization of a tx in any era.
 serializeTx :: forall era . IsEra era => Tx era -> K BL.ByteString era
 serializeTx = case theEra @era of
@@ -122,6 +123,7 @@ parseTxFromCBOR :: TxCBOR -> Either DecoderError (EraValue Tx)
 parseTxFromCBOR = sequenceEraValue
     . applyEraFunValue deserializeTx
 
+{-# INLINABLE deserializeTx #-}
 -- | CBOR deserialization of a tx in any era.
 deserializeTx :: forall era . IsEra era => K BL.ByteString era -> (Either DecoderError :.: Tx) era
 deserializeTx = case theEra @era of

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Certificates.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Certificates.hs
@@ -83,6 +83,7 @@ newtype Certificates era = Certificates (CertificatesType era)
 deriving instance Show (CertificatesType era) => Show (Certificates era)
 deriving instance Eq (CertificatesType era) => Eq (Certificates era)
 
+{-# INLINABLE getEraCertificates #-}
 -- | Extract certificates from a 'Tx' in any era.
 getEraCertificates :: forall era . IsEra era => Tx era -> Certificates era
 getEraCertificates = case theEra @era of

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/CollateralInputs.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/CollateralInputs.hs
@@ -72,6 +72,7 @@ newtype CollateralInputs era = CollateralInputs (CollateralInputsType era)
 deriving instance Show (CollateralInputsType era) => Show (CollateralInputs era)
 deriving instance Eq (CollateralInputsType era) => Eq (CollateralInputs era)
 
+{-# INLINABLE getEraCollateralInputs #-}
 -- | Extract the collateral inputs from a 'Tx' in any era.
 getEraCollateralInputs :: forall era. IsEra era => Tx era -> CollateralInputs era
 getEraCollateralInputs = case theEra @era of

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/CollateralOutputs.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/CollateralOutputs.hs
@@ -83,6 +83,7 @@ deriving instance Show (CollateralOutputsType era)
     => Show (CollateralOutputs era)
 deriving instance Eq (CollateralOutputsType era) => Eq (CollateralOutputs era)
 
+{-# INLINABLE getEraCollateralOutputs #-}
 -- | Get the 'CollateralOutputs' for a given 'Tx' in any era.
 getEraCollateralOutputs
     :: forall era. IsEra era => Tx era -> CollateralOutputs era

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/ExtraSigs.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/ExtraSigs.hs
@@ -69,6 +69,7 @@ newtype ExtraSigs era = ExtraSigs (ExtraSigsType era)
 deriving instance Show (ExtraSigsType era) => Show (ExtraSigs era)
 deriving instance Eq (ExtraSigsType era) => Eq (ExtraSigs era)
 
+{-# INLINABLE getEraExtraSigs #-}
 -- | Get extra signatures required for a transaction in any era.
 getEraExtraSigs :: forall era. IsEra era => Tx era -> ExtraSigs era
 getEraExtraSigs = case theEra @era of

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Fee.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Fee.hs
@@ -65,6 +65,7 @@ newtype Fee era = Fee (FeeType era)
 deriving instance Show (FeeType era) => Show (Fee era)
 deriving instance Eq (FeeType era) => Eq (Fee era)
 
+{-# INLINABLE getEraFee #-}
 -- | Extract fee from 'Tx' in all available eras.
 getEraFee :: forall era. IsEra era => Tx era -> Fee era
 getEraFee = case theEra @era of

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Gen.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Gen.hs
@@ -38,6 +38,7 @@ import Cardano.Wallet.Read.Tx.Gen.TxParameters
     ( TxParameters
     )
 
+{-# INLINABLE mkTxEra #-}
 mkTxEra :: forall era. IsEra era => TxParameters -> Tx era
 mkTxEra = case theEra @era of
     Byron -> g mkByronTx

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Hash.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Hash.hs
@@ -57,6 +57,7 @@ import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Ledger.Core as SL.Core
 import qualified Cardano.Ledger.SafeHash as SafeHash
 
+{-# INLINE getEraTxHash #-}
 -- | Extract the hash of a transaction in any era.
 getEraTxHash :: forall era. IsEra era => Tx era -> Crypto.ByteString
 getEraTxHash = case theEra @era of

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Inputs.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Inputs.hs
@@ -74,6 +74,7 @@ newtype Inputs era = Inputs (InputsType era)
 deriving instance Show (InputsType era) => Show (Inputs era)
 deriving instance Eq (InputsType era) => Eq (Inputs era)
 
+{-# INLINABLE getEraInputs #-}
 -- | Extract the inputs from a transaction in any era.
 getEraInputs :: forall era . IsEra era => Tx era -> Inputs era
 getEraInputs = case theEra @era of

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Integrity.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Integrity.hs
@@ -73,6 +73,7 @@ newtype Integrity era = Integrity (IntegrityType era)
 deriving instance Show (IntegrityType era) => Show (Integrity era)
 deriving instance Eq (IntegrityType era) => Eq (Integrity era)
 
+{-# INLINABLE getEraIntegrity #-}
 -- | Extract the script integrity data from a transaction in any available era.
 getEraIntegrity :: forall era. IsEra era => Tx era -> Integrity era
 getEraIntegrity = case theEra @era of

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Metadata.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Metadata.hs
@@ -72,6 +72,7 @@ newtype Metadata era = Metadata (MetadataType era)
 deriving instance Show (MetadataType era) => Show (Metadata era)
 deriving instance Eq (MetadataType era) => Eq (Metadata era)
 
+{-# INLINABLE getEraMetadata #-}
 getEraMetadata :: forall era . IsEra era => Tx era -> Metadata era
 getEraMetadata = case theEra @era of
     Byron -> \_ -> Metadata ()

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Mint.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Mint.hs
@@ -70,6 +70,7 @@ newtype Mint era = Mint (MintType era)
 deriving instance Show (MintType era) => Show (Mint era)
 deriving instance Eq (MintType era) => Eq (Mint era)
 
+{-# INLINABLE getEraMint #-}
 getEraMint :: forall era. IsEra era => Tx era -> Mint era
 getEraMint = case theEra @era of
     Byron -> \_ -> Mint ()

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Outputs.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Outputs.hs
@@ -87,6 +87,7 @@ newtype Outputs era = Outputs (OutputsType era)
 deriving instance Show (OutputsType era) => Show (Outputs era)
 deriving instance Eq (OutputsType era) => Eq (Outputs era)
 
+{-# INLINE getEraOutputs #-}
 getEraOutputs :: forall era . IsEra era => Tx era -> Outputs era
 getEraOutputs = case theEra @era of
     Byron -> onTx $ Outputs . BY.txOutputs . BY.taTx

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/ReferenceInputs.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/ReferenceInputs.hs
@@ -72,6 +72,7 @@ newtype ReferenceInputs era = ReferenceInputs (ReferenceInputsType era)
 deriving instance Show (ReferenceInputsType era) => Show (ReferenceInputs era)
 deriving instance Eq (ReferenceInputsType era) => Eq (ReferenceInputs era)
 
+{-# INLINABLE getEraReferenceInputs #-}
 getEraReferenceInputs :: forall era. IsEra era => Tx era -> ReferenceInputs era
 getEraReferenceInputs = case theEra @era of
     Byron -> \_ -> ReferenceInputs ()

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/ScriptValidity.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/ScriptValidity.hs
@@ -61,6 +61,7 @@ newtype ScriptValidity era = ScriptValidity (ScriptValidityType era)
 deriving instance Show (ScriptValidityType era) => Show (ScriptValidity era)
 deriving instance Eq (ScriptValidityType era) => Eq (ScriptValidity era)
 
+{-# INLINABLE getEraScriptValidity #-}
 getEraScriptValidity :: forall era. IsEra era => Tx era -> ScriptValidity era
 getEraScriptValidity = case theEra @era of
     Byron -> \_ -> ScriptValidity ()

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Validity.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Validity.hs
@@ -73,6 +73,7 @@ newtype Validity era = Validity (ValidityType era)
 deriving instance Show (ValidityType era) => Show (Validity era)
 deriving instance Eq (ValidityType era) => Eq (Validity era)
 
+{-# INLINABLE getEraValidity #-}
 -- | Extract validity data from tx for any available era.
 getEraValidity :: forall era . IsEra era => Tx era -> Validity era
 getEraValidity = case theEra @era of

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Withdrawals.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Withdrawals.hs
@@ -82,6 +82,7 @@ newtype Withdrawals era
 deriving instance Show (WithdrawalsType era) => Show (Withdrawals era)
 deriving instance Eq (WithdrawalsType era) => Eq (Withdrawals era)
 
+{-# INLINABLE getEraWithdrawals #-}
 -- | Extract withdrawals from tx for any available era.
 getEraWithdrawals :: forall era . IsEra era => Tx era -> Withdrawals era
 getEraWithdrawals = case theEra @era of

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Witnesses.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Witnesses.hs
@@ -68,6 +68,7 @@ newtype Witnesses era = Witnesses (WitnessesType era)
 deriving instance Show (WitnessesType era) => Show (Witnesses era)
 deriving instance Eq (WitnessesType era) => Eq (Witnesses era)
 
+{-# INLINABLE getEraWitnesses #-}
 getEraWitnesses :: forall era .  IsEra era => Tx era ->  Witnesses era
 getEraWitnesses = case theEra @era of
         Byron -> const $ Witnesses ()


### PR DESCRIPTION
- [x] Annotate every function calling `theEra` as INLINEABLE so that the compiler can specialize the code for specific eras

ADP-3322
