### PR TITLE
[ADP-3254] Generalize the http client to work on all networks

### DIFF
--- a/lib/api/cardano-wallet-api.cabal
+++ b/lib/api/cardano-wallet-api.cabal
@@ -122,8 +122,10 @@ library
     Cardano.Wallet.Api.Aeson
     Cardano.Wallet.Api.Aeson.Variant
     Cardano.Wallet.Api.Client
+    Cardano.Wallet.Api.Clients.Byron
     Cardano.Wallet.Api.Clients.Shelley
     Cardano.Wallet.Api.Clients.Testnet.Byron
+    Cardano.Wallet.Api.Clients.Testnet.Id
     Cardano.Wallet.Api.Clients.Testnet.Network
     Cardano.Wallet.Api.Clients.Testnet.Shelley
     Cardano.Wallet.Api.Hex

--- a/lib/api/cardano-wallet-api.cabal
+++ b/lib/api/cardano-wallet-api.cabal
@@ -122,6 +122,7 @@ library
     Cardano.Wallet.Api.Aeson
     Cardano.Wallet.Api.Aeson.Variant
     Cardano.Wallet.Api.Client
+    Cardano.Wallet.Api.Clients.Shelley
     Cardano.Wallet.Api.Clients.Testnet.Byron
     Cardano.Wallet.Api.Clients.Testnet.Network
     Cardano.Wallet.Api.Clients.Testnet.Shelley

--- a/lib/api/cardano-wallet-api.cabal
+++ b/lib/api/cardano-wallet-api.cabal
@@ -123,10 +123,10 @@ library
     Cardano.Wallet.Api.Aeson.Variant
     Cardano.Wallet.Api.Client
     Cardano.Wallet.Api.Clients.Byron
+    Cardano.Wallet.Api.Clients.Network
     Cardano.Wallet.Api.Clients.Shelley
     Cardano.Wallet.Api.Clients.Testnet.Byron
     Cardano.Wallet.Api.Clients.Testnet.Id
-    Cardano.Wallet.Api.Clients.Testnet.Network
     Cardano.Wallet.Api.Clients.Testnet.Shelley
     Cardano.Wallet.Api.Hex
     Cardano.Wallet.Api.Http.Logging

--- a/lib/api/src/Cardano/Wallet/Api/Clients/Byron.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Clients/Byron.hs
@@ -1,0 +1,204 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Wallet.Api.Clients.Byron
+    ( deleteWallet
+    , deleteTransaction
+    , getTransaction
+    , getWallet
+    , getWalletUtxoSnapshot
+    , getWalletUtxoStatistics
+    , listAddresses
+    , listTransactions
+    , listWallets
+    , postExternalTransaction
+    , postRandomAddress
+    , postTransaction
+    , postTransactionFee
+    , postWallet
+    , putRandomAddress
+    , putRandomAddresses
+    , putWalletByron
+    , putWalletPassphrase
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.Api
+    ( ByronWallets
+    , CreateByronTransactionOld
+    , DeleteByronTransaction
+    , GetByronTransaction
+    , ListByronAddresses
+    , ListByronTransactions
+    , PostByronAddress
+    , PostByronTransactionFeeOld
+    , Proxy_
+    , PutByronAddress
+    , PutByronAddresses
+    )
+import Cardano.Wallet.Api.Types
+    ( ApiAddressIdT
+    , ApiAddressT
+    , ApiByronWallet
+    , ApiFee
+    , ApiPostRandomAddressData
+    , ApiPutAddressesDataT
+    , ApiT (..)
+    , ApiTransactionT
+    , ApiTxId (..)
+    , ApiUtxoStatistics
+    , ApiWalletPutData (..)
+    , ApiWalletUtxoSnapshot (..)
+    , ByronWalletPutPassphraseData (..)
+    , Iso8601Time (..)
+    , PostTransactionFeeOldDataT
+    , PostTransactionOldDataT
+    , SomeByronWalletPostData
+    )
+import Cardano.Wallet.Api.Types.Transaction
+    ( ApiLimit
+    )
+import Cardano.Wallet.Primitive.NetworkId
+    ( HasSNetworkId
+    )
+import Cardano.Wallet.Primitive.Types
+    ( SortOrder
+    , WalletId
+    )
+import Cardano.Wallet.Primitive.Types.Address
+    ( AddressState
+    )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( SealedTx
+    )
+import Data.Generics.Labels
+    ()
+import Data.Proxy
+    ( Proxy (..)
+    )
+import Servant
+    ( NoContent
+    , (:<|>) (..)
+    , (:>)
+    )
+import Servant.Client
+    ( ClientM
+    , client
+    )
+
+postWallet
+    :: SomeByronWalletPostData
+    -> ClientM ApiByronWallet
+deleteWallet
+    :: ApiT WalletId
+    -> ClientM NoContent
+getWallet
+    :: ApiT WalletId
+    -> ClientM ApiByronWallet
+listWallets
+    :: ClientM [ApiByronWallet]
+putWalletByron
+    :: ApiT WalletId
+    -> ApiWalletPutData
+    -> ClientM ApiByronWallet
+getWalletUtxoSnapshot
+    :: ApiT WalletId
+    -> ClientM ApiWalletUtxoSnapshot
+getWalletUtxoStatistics
+    :: ApiT WalletId
+    -> ClientM ApiUtxoStatistics
+putWalletPassphrase
+    :: ApiT WalletId
+    -> ByronWalletPutPassphraseData
+    -> ClientM NoContent
+postWallet
+    :<|> deleteWallet
+    :<|> getWallet
+    :<|> listWallets
+    :<|> putWalletByron
+    :<|> getWalletUtxoSnapshot
+    :<|> getWalletUtxoStatistics
+    :<|> putWalletPassphrase =
+        client (Proxy @("v2" :> ByronWallets))
+
+listTransactions
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> Maybe Iso8601Time
+    -> Maybe Iso8601Time
+    -> Maybe (ApiT SortOrder)
+    -> Maybe ApiLimit
+    -> Maybe (ApiAddressIdT network)
+    -> ClientM [ApiTransactionT network]
+listTransactions = client (Proxy @("v2" :> ListByronTransactions network))
+
+getTransaction
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> ApiTxId
+    -> ClientM (ApiTransactionT network)
+getTransaction = client (Proxy @("v2" :> GetByronTransaction network))
+
+deleteTransaction
+    :: ApiT WalletId
+    -> ApiTxId
+    -> ClientM NoContent
+deleteTransaction = client (Proxy @("v2" :> DeleteByronTransaction))
+
+postTransaction
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> PostTransactionOldDataT network
+    -> ClientM (ApiTransactionT network)
+postTransaction = client (Proxy @("v2" :> CreateByronTransactionOld network))
+
+postTransactionFee
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> PostTransactionFeeOldDataT network
+    -> ClientM ApiFee
+postTransactionFee = client (Proxy @("v2" :> PostByronTransactionFeeOld network))
+
+postExternalTransaction :: ApiT SealedTx -> ClientM ApiTxId
+postExternalTransaction =
+    client (Proxy @("v2" :> Proxy_))
+
+postRandomAddress
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> ApiPostRandomAddressData
+    -> ClientM (ApiAddressT network)
+postRandomAddress = client (Proxy @("v2" :> PostByronAddress network))
+
+putRandomAddress
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> ApiAddressIdT network
+    -> ClientM NoContent
+putRandomAddress = client (Proxy @("v2" :> PutByronAddress network))
+
+putRandomAddresses
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> ApiPutAddressesDataT network
+    -> ClientM NoContent
+putRandomAddresses = client (Proxy @("v2" :> PutByronAddresses network))
+
+listAddresses
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> Maybe (ApiT AddressState)
+    -> ClientM [ApiAddressT network]
+listAddresses = client (Proxy @("v2" :> ListByronAddresses network))

--- a/lib/api/src/Cardano/Wallet/Api/Clients/Network.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Clients/Network.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Cardano.Wallet.Api.Clients.Testnet.Network
+module Cardano.Wallet.Api.Clients.Network
     ( networkInformation
     , networkParameters
     , networkClock

--- a/lib/api/src/Cardano/Wallet/Api/Clients/Shelley.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Clients/Shelley.hs
@@ -1,0 +1,319 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Wallet.Api.Clients.Shelley
+where
+
+import Prelude
+
+import Cardano.Wallet.Api
+    ( Assets
+    , BalanceTransaction
+    , ConstructTransaction
+    , CreateShelleyWalletMigrationPlan
+    , CreateTransactionOld
+    , DecodeTransaction
+    , DeleteTransaction
+    , GetTransaction
+    , InspectAddress
+    , JoinStakePool
+    , ListAddresses
+    , ListStakePools
+    , ListTransactions
+    , MigrateShelleyWallet
+    , Network
+    , PostAnyAddress
+    , PostTransactionFeeOld
+    , Proxy_
+    , QuitStakePool
+    , SignTransaction
+    , SubmitTransaction
+    , Wallets
+    )
+
+import Cardano.Wallet.Api.Types
+    ( AnyAddress
+    , ApiAddressData
+    , ApiAddressInspect
+    , ApiAddressInspectData
+    , ApiAddressWithPath
+    , ApiAsset
+    , ApiBalanceTransactionPostData
+    , ApiConstructTransaction
+    , ApiConstructTransactionData
+    , ApiDecodeTransactionPostData
+    , ApiFee
+    , ApiNetworkClock
+    , ApiNetworkInformation
+    , ApiNetworkParameters
+    , ApiPoolSpecifier
+    , ApiSerialisedTransaction
+    , ApiSignTransactionPostData
+    , ApiT
+    , ApiTransaction
+    , ApiTxId
+    , ApiUtxoStatistics
+    , ApiWallet
+    , ApiWalletMigrationPlan
+    , ApiWalletMigrationPlanPostData
+    , ApiWalletMigrationPostData
+    , ApiWalletPassphrase
+    , ApiWalletPutDataExtended
+    , ApiWalletUtxoSnapshot
+    , Iso8601Time
+    , MinWithdrawal
+    , PostTransactionFeeOldData
+    , PostTransactionOldData
+    , WalletOrAccountPostData
+    , WalletPutPassphraseData
+    )
+import Cardano.Wallet.Api.Types.Transaction
+    ( ApiAddress
+    , ApiDecodedTransaction
+    , ApiLimit
+    )
+import Cardano.Wallet.Pools
+    ( StakePool
+    )
+import Cardano.Wallet.Primitive.NetworkId
+    ( HasSNetworkId
+    , NetworkDiscriminant
+    )
+import Cardano.Wallet.Primitive.Types
+    ( SortOrder
+    , WalletId
+    )
+import Cardano.Wallet.Primitive.Types.Address
+    ( AddressState
+    )
+import Cardano.Wallet.Primitive.Types.AssetName
+    ( AssetName
+    )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
+    ( TokenPolicyId
+    )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( SealedTx
+    )
+import Data.Generics.Labels
+    ()
+import Data.List.NonEmpty
+    ( NonEmpty
+    )
+import Data.Proxy
+    ( Proxy (..)
+    )
+import Servant.API
+    ( NoContent
+    , type (:<|>) ((:<|>))
+    , type (:>)
+    )
+import Servant.Client
+    ( ClientM
+    , client
+    )
+
+deleteWallet
+    :: ApiT WalletId -> ClientM NoContent
+getWallet
+    :: ApiT WalletId -> ClientM ApiWallet
+listWallets
+    :: ClientM [ApiWallet]
+postWallet
+    :: WalletOrAccountPostData -> ClientM ApiWallet
+putWallet
+    :: ApiT WalletId -> ApiWalletPutDataExtended -> ClientM ApiWallet
+putWalletPassphrase
+    :: ApiT WalletId
+    -> WalletPutPassphraseData
+    -> ClientM NoContent
+getWalletUtxoSnapshot
+    :: ApiT WalletId -> ClientM ApiWalletUtxoSnapshot
+getWalletUtxoStatistics
+    :: ApiT WalletId -> ClientM ApiUtxoStatistics
+deleteWallet
+    :<|> getWallet
+    :<|> listWallets
+    :<|> postWallet
+    :<|> putWallet
+    :<|> putWalletPassphrase
+    :<|> getWalletUtxoSnapshot
+    :<|> getWalletUtxoStatistics =
+        client (Proxy @("v2" :> Wallets))
+
+constructTransaction
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> ApiConstructTransactionData network
+    -> ClientM (ApiConstructTransaction network)
+constructTransaction =
+    client (Proxy @("v2" :> ConstructTransaction network))
+
+signTransaction
+    :: forall network
+     . Proxy (network :: NetworkDiscriminant)
+    -> ApiT WalletId
+    -> ApiSignTransactionPostData
+    -> ClientM ApiSerialisedTransaction
+signTransaction _ =
+    client (Proxy @("v2" :> SignTransaction network))
+
+listTransactions
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> Maybe MinWithdrawal
+    -> Maybe Iso8601Time
+    -> Maybe Iso8601Time
+    -> Maybe (ApiT SortOrder)
+    -> Maybe ApiLimit
+    -> Maybe (ApiAddress network)
+    -> Bool
+    -> ClientM [ApiTransaction network]
+listTransactions =
+    client (Proxy @("v2" :> ListTransactions network))
+
+getTransaction
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> ApiTxId
+    -> Bool
+    -> ClientM (ApiTransaction network)
+getTransaction =
+    client (Proxy @("v2" :> GetTransaction network))
+
+deleteTransaction
+    :: ApiT WalletId
+    -> ApiTxId
+    -> ClientM NoContent
+deleteTransaction =
+    client (Proxy @("v2" :> DeleteTransaction))
+
+postTransaction
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> PostTransactionOldData network
+    -> ClientM (ApiTransaction network)
+postTransaction =
+    client (Proxy @("v2" :> CreateTransactionOld network))
+
+postTransactionFee
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> PostTransactionFeeOldData network
+    -> ClientM ApiFee
+postTransactionFee =
+    client (Proxy @("v2" :> PostTransactionFeeOld network))
+
+balanceTransaction
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> ApiBalanceTransactionPostData network
+    -> ClientM ApiSerialisedTransaction
+balanceTransaction =
+    client (Proxy @("v2" :> BalanceTransaction network))
+
+decodeTransaction
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> ApiDecodeTransactionPostData
+    -> ClientM (ApiDecodedTransaction network)
+decodeTransaction =
+    client (Proxy @("v2" :> DecodeTransaction network))
+
+submitTransaction
+    :: ApiT WalletId
+    -> ApiSerialisedTransaction
+    -> ClientM ApiTxId
+submitTransaction =
+    client (Proxy @("v2" :> SubmitTransaction))
+
+postExternalTransaction
+    :: ApiT SealedTx -> ClientM ApiTxId
+postExternalTransaction =
+    client (Proxy @("v2" :> Proxy_))
+
+listAddresses
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> Maybe (ApiT AddressState)
+    -> ClientM [ApiAddressWithPath network]
+listAddresses = client (Proxy @("v2" :> ListAddresses network))
+
+inspectAddress
+    :: ApiAddressInspectData -> ClientM ApiAddressInspect
+inspectAddress = client (Proxy @("v2" :> InspectAddress))
+
+postScriptAddress
+    :: forall (network :: NetworkDiscriminant)
+    . Proxy network
+    -> ApiAddressData -> ClientM AnyAddress
+postScriptAddress _ = client (Proxy @("v2" :> PostAnyAddress network))
+
+listPools
+    :: Maybe (ApiT Coin) -> ClientM [ApiT StakePool]
+listPools = client (Proxy @("v2" :> ListStakePools))
+
+joinStakePool
+    :: forall network
+     . HasSNetworkId network
+    => ApiPoolSpecifier
+    -> ApiT WalletId
+    -> ApiWalletPassphrase
+    -> ClientM (ApiTransaction network)
+joinStakePool = client (Proxy @("v2" :> JoinStakePool network))
+
+quitStakePool
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> ApiWalletPassphrase
+    -> ClientM (ApiTransaction network)
+quitStakePool = client (Proxy @("v2" :> QuitStakePool network))
+
+networkInformation
+    :: ClientM ApiNetworkInformation
+networkParameters
+    :: ClientM ApiNetworkParameters
+networkClock
+    :: Bool -> ClientM ApiNetworkClock
+networkInformation :<|> networkParameters :<|> networkClock =
+    client (Proxy @("v2" :> Network))
+
+getAssets
+    :: ApiT WalletId -> ClientM [ApiAsset]
+getAsset
+    :: ApiT WalletId -> ApiT TokenPolicyId -> ApiT AssetName -> ClientM ApiAsset
+getAsset'
+    :: ApiT WalletId -> ApiT TokenPolicyId -> ClientM ApiAsset
+getAssets :<|> getAsset :<|> getAsset' =
+    client (Proxy @("v2" :> Assets))
+
+planMigration
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> ApiWalletMigrationPlanPostData network
+    -> ClientM (ApiWalletMigrationPlan network)
+planMigration = client (Proxy @("v2" :> CreateShelleyWalletMigrationPlan network))
+
+migrate
+    :: forall network
+     . HasSNetworkId network
+    => ApiT WalletId
+    -> ApiWalletMigrationPostData network "user"
+    -> ClientM (NonEmpty (ApiTransaction network))
+migrate = client (Proxy @("v2" :> MigrateShelleyWallet network))

--- a/lib/api/src/Cardano/Wallet/Api/Clients/Shelley.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Clients/Shelley.hs
@@ -24,7 +24,6 @@ import Cardano.Wallet.Api
     , ListStakePools
     , ListTransactions
     , MigrateShelleyWallet
-    , Network
     , PostAnyAddress
     , PostTransactionFeeOld
     , Proxy_
@@ -46,9 +45,6 @@ import Cardano.Wallet.Api.Types
     , ApiConstructTransactionData
     , ApiDecodeTransactionPostData
     , ApiFee
-    , ApiNetworkClock
-    , ApiNetworkInformation
-    , ApiNetworkParameters
     , ApiPoolSpecifier
     , ApiSerialisedTransaction
     , ApiSignTransactionPostData
@@ -259,8 +255,9 @@ inspectAddress = client (Proxy @("v2" :> InspectAddress))
 
 postScriptAddress
     :: forall (network :: NetworkDiscriminant)
-    . Proxy network
-    -> ApiAddressData -> ClientM AnyAddress
+     . Proxy network
+    -> ApiAddressData
+    -> ClientM AnyAddress
 postScriptAddress _ = client (Proxy @("v2" :> PostAnyAddress network))
 
 listPools
@@ -283,15 +280,6 @@ quitStakePool
     -> ApiWalletPassphrase
     -> ClientM (ApiTransaction network)
 quitStakePool = client (Proxy @("v2" :> QuitStakePool network))
-
-networkInformation
-    :: ClientM ApiNetworkInformation
-networkParameters
-    :: ClientM ApiNetworkParameters
-networkClock
-    :: Bool -> ClientM ApiNetworkClock
-networkInformation :<|> networkParameters :<|> networkClock =
-    client (Proxy @("v2" :> Network))
 
 getAssets
     :: ApiT WalletId -> ClientM [ApiAsset]

--- a/lib/api/src/Cardano/Wallet/Api/Clients/Testnet/Byron.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Clients/Testnet/Byron.hs
@@ -1,22 +1,19 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Wallet.Api.Clients.Testnet.Byron
-    ( A
+    ( Testnet42
     , deleteWallet
     , deleteTransaction
     , getTransaction
     , getWallet
     , getWalletUtxoSnapshot
     , getWalletUtxoStatistics
-    , inspectAddress
     , listAddresses
     , listTransactions
     , listWallets
     , postExternalTransaction
     , postRandomAddress
-    , postScriptAddress
     , postTransaction
     , postTransactionFee
     , postWallet
@@ -29,19 +26,11 @@ where
 
 import Prelude
 
-import Cardano.Wallet.Api
-    ( Addresses
-    , ByronAddresses
-    , ByronTransactions
-    , ByronWallets
-    , Proxy_
+import Cardano.Wallet.Api.Clients.Testnet.Id
+    ( Testnet42
     )
 import Cardano.Wallet.Api.Types
-    ( AnyAddress
-    , ApiAddressData
-    , ApiAddressIdT
-    , ApiAddressInspect (..)
-    , ApiAddressInspectData (..)
+    ( ApiAddressIdT
     , ApiAddressT
     , ApiByronWallet
     , ApiFee
@@ -62,9 +51,6 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Api.Types.Transaction
     ( ApiLimit
     )
-import Cardano.Wallet.Primitive.NetworkId
-    ( NetworkDiscriminant (..)
-    )
 import Cardano.Wallet.Primitive.Types
     ( SortOrder
     , WalletId
@@ -77,55 +63,54 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Data.Generics.Labels
     ()
-import Data.Proxy
-    ( Proxy (..)
-    )
 import Servant
     ( NoContent
-    , (:<|>) (..)
-    , (:>)
     )
 import Servant.Client
     ( ClientM
-    , client
     )
 
-type A = Testnet 42
+import qualified Cardano.Wallet.Api.Clients.Byron as Byron
 
 postWallet
     :: SomeByronWalletPostData
     -> ClientM ApiByronWallet
+postWallet = Byron.postWallet
+
 deleteWallet
     :: ApiT WalletId
     -> ClientM NoContent
+deleteWallet = Byron.deleteWallet
+
 getWallet
     :: ApiT WalletId
     -> ClientM ApiByronWallet
-listWallets
-    :: ClientM [ApiByronWallet]
+getWallet = Byron.getWallet
+
+listWallets :: ClientM [ApiByronWallet]
+listWallets = Byron.listWallets
+
 putWalletByron
     :: ApiT WalletId
     -> ApiWalletPutData
     -> ClientM ApiByronWallet
+putWalletByron = Byron.putWalletByron
+
 getWalletUtxoSnapshot
     :: ApiT WalletId
     -> ClientM ApiWalletUtxoSnapshot
+getWalletUtxoSnapshot = Byron.getWalletUtxoSnapshot
+
 getWalletUtxoStatistics
     :: ApiT WalletId
     -> ClientM ApiUtxoStatistics
+getWalletUtxoStatistics = Byron.getWalletUtxoStatistics
+
 putWalletPassphrase
     :: ApiT WalletId
     -> ByronWalletPutPassphraseData
     -> ClientM NoContent
-postWallet
-    :<|> deleteWallet
-    :<|> getWallet
-    :<|> listWallets
-    :<|> putWalletByron
-    :<|> getWalletUtxoSnapshot
-    :<|> getWalletUtxoStatistics
-    :<|> putWalletPassphrase =
-        client (Proxy @("v2" :> ByronWallets))
+putWalletPassphrase = Byron.putWalletPassphrase
 
 listTransactions
     :: ApiT WalletId
@@ -133,63 +118,57 @@ listTransactions
     -> Maybe Iso8601Time
     -> Maybe (ApiT SortOrder)
     -> Maybe ApiLimit
-    -> Maybe (ApiAddressIdT A)
-    -> ClientM [ApiTransactionT A]
+    -> Maybe (ApiAddressIdT Testnet42)
+    -> ClientM [ApiTransactionT Testnet42]
+listTransactions = Byron.listTransactions
+
 getTransaction
     :: ApiT WalletId
     -> ApiTxId
-    -> ClientM (ApiTransactionT A)
+    -> ClientM (ApiTransactionT Testnet42)
+getTransaction = Byron.getTransaction
+
 deleteTransaction
     :: ApiT WalletId
     -> ApiTxId
     -> ClientM NoContent
+deleteTransaction = Byron.deleteTransaction
+
 postTransaction
     :: ApiT WalletId
-    -> PostTransactionOldDataT A
-    -> ClientM (ApiTransactionT A)
+    -> PostTransactionOldDataT Testnet42
+    -> ClientM (ApiTransactionT Testnet42)
+postTransaction = Byron.postTransaction
+
 postTransactionFee
     :: ApiT WalletId
-    -> PostTransactionFeeOldDataT A
+    -> PostTransactionFeeOldDataT Testnet42
     -> ClientM ApiFee
-listTransactions
-    :<|> getTransaction
-    :<|> deleteTransaction
-    :<|> postTransaction
-    :<|> postTransactionFee =
-        client (Proxy @("v2" :> (ByronTransactions A)))
+postTransactionFee = Byron.postTransactionFee
 
 postExternalTransaction :: ApiT SealedTx -> ClientM ApiTxId
-postExternalTransaction =
-    client (Proxy @("v2" :> Proxy_))
-
-inspectAddress
-    :: ApiAddressInspectData
-    -> ClientM ApiAddressInspect
-postScriptAddress
-    :: ApiAddressData
-    -> ClientM AnyAddress
-_ :<|> inspectAddress
-    :<|> postScriptAddress =
-        client (Proxy @("v2" :> Addresses A))
+postExternalTransaction = Byron.postExternalTransaction
 
 postRandomAddress
     :: ApiT WalletId
     -> ApiPostRandomAddressData
-    -> ClientM (ApiAddressT A)
+    -> ClientM (ApiAddressT Testnet42)
+postRandomAddress = Byron.postRandomAddress
+
 putRandomAddress
     :: ApiT WalletId
-    -> ApiAddressIdT A
+    -> ApiAddressIdT Testnet42
     -> ClientM NoContent
+putRandomAddress = Byron.putRandomAddress
+
 putRandomAddresses
     :: ApiT WalletId
-    -> ApiPutAddressesDataT A
+    -> ApiPutAddressesDataT Testnet42
     -> ClientM NoContent
+putRandomAddresses = Byron.putRandomAddresses
+
 listAddresses
     :: ApiT WalletId
     -> Maybe (ApiT AddressState)
-    -> ClientM [ApiAddressT A]
-postRandomAddress
-    :<|> putRandomAddress
-    :<|> putRandomAddresses
-    :<|> listAddresses =
-        client (Proxy @("v2" :> ByronAddresses A))
+    -> ClientM [ApiAddressT Testnet42]
+listAddresses = Byron.listAddresses

--- a/lib/api/src/Cardano/Wallet/Api/Clients/Testnet/Id.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Clients/Testnet/Id.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.Wallet.Api.Clients.Testnet.Id
+    ( Testnet42
+    )
+where
+
+import Cardano.Wallet.Primitive.NetworkId
+    ( NetworkDiscriminant (..)
+    )
+
+type Testnet42 = 'Testnet 42

--- a/lib/api/src/Cardano/Wallet/Api/Clients/Testnet/Shelley.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Clients/Testnet/Shelley.hs
@@ -8,6 +8,9 @@ where
 
 import Prelude
 
+import Cardano.Wallet.Api.Clients.Testnet.Id
+    ( Testnet42
+    )
 import Cardano.Wallet.Api.Types
     ( AnyAddress
     , ApiAddressData
@@ -49,9 +52,6 @@ import Cardano.Wallet.Api.Types.Transaction
 import Cardano.Wallet.Pools
     ( StakePool
     )
-import Cardano.Wallet.Primitive.NetworkId
-    ( NetworkDiscriminant (..)
-    )
 import Cardano.Wallet.Primitive.Types
     ( SortOrder
     , WalletId
@@ -87,8 +87,6 @@ import Servant.Client
     )
 
 import qualified Cardano.Wallet.Api.Clients.Shelley as Shelley
-
-type Testnet42 = 'Testnet 42
 
 deleteWallet
     :: ApiT WalletId -> ClientM NoContent

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -104,8 +104,7 @@ import Cardano.Wallet.Primitive.Ledger.Shelley
     ( fromGenesisData
     )
 import Cardano.Wallet.Primitive.NetworkId
-    ( NetworkDiscriminant (..)
-    , NetworkId (..)
+    ( NetworkId (..)
     )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..)
@@ -237,9 +236,6 @@ import qualified Cardano.Wallet.Faucet as Faucet
 import qualified Cardano.Wallet.Launch.Cluster as Cluster
 import qualified Data.List.NonEmpty as NE
 import qualified Options.Applicative as O
-
--- will go away once we have all implemented in terms of servant-client code
-type A = 'Testnet 42
 
 main :: IO ()
 main = withUtf8
@@ -402,7 +398,7 @@ repeatPostTx wDest amtToSend batchSize amtExp = do
     wSrcId <- view #id <$> fixtureWallet
     replicateM_ batchSize
         $ do
-            addrs <- request $ C.listAddresses @A (wDest ^. #id) Nothing
+            addrs <- request $ C.listAddresses (wDest ^. #id) Nothing
             let destination = addrs !! 1 ^. #id
                 amount =
                     AddressAmount
@@ -432,7 +428,7 @@ scene title scenario = measureApiLogs scenario >>= fmtResult title
 sceneOfClientM :: String -> ClientM a -> BenchM ()
 sceneOfClientM title action = scene title $ requestWithError action
 
-listAllTransactions :: ApiT WalletId -> ClientM [ApiTransaction (Testnet 42)]
+listAllTransactions :: ApiT WalletId -> ClientM [ApiTransaction C.Testnet42]
 listAllTransactions walId =
     C.listTransactions
         walId
@@ -458,14 +454,14 @@ runScenario scenario = lift . runResourceT $ do
     sceneOfClientM "listWallets" C.listWallets
     sceneOfClientM "getWallet" $ C.getWallet wal1Id
     sceneOfClientM "getUTxOsStatistics" $ C.getWalletUtxoStatistics wal1Id
-    sceneOfClientM "listAddresses" $ C.listAddresses @A wal1Id Nothing
+    sceneOfClientM "listAddresses" $ C.listAddresses wal1Id Nothing
     sceneOfClientM "listTransactions" $ listAllTransactions wal1Id
 
     txs <- request $ listAllTransactions wal1Id
     sceneOfClientM "getTransaction"
-        $ C.getTransaction @A wal1Id (ApiTxId $ txs !! 1 ^. #id) False
+        $ C.getTransaction wal1Id (ApiTxId $ txs !! 1 ^. #id) False
 
-    addrs <- request $ C.listAddresses @A wal2Id Nothing
+    addrs <- request $ C.listAddresses wal2Id Nothing
     let destination = addrs !! 1 ^. #id
         amount =
             AddressAmount

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -402,7 +402,7 @@ repeatPostTx wDest amtToSend batchSize amtExp = do
     wSrcId <- view #id <$> fixtureWallet
     replicateM_ batchSize
         $ do
-            addrs <- request $ C.listAddresses (wDest ^. #id) Nothing
+            addrs <- request $ C.listAddresses @A (wDest ^. #id) Nothing
             let destination = addrs !! 1 ^. #id
                 amount =
                     AddressAmount
@@ -432,7 +432,7 @@ scene title scenario = measureApiLogs scenario >>= fmtResult title
 sceneOfClientM :: String -> ClientM a -> BenchM ()
 sceneOfClientM title action = scene title $ requestWithError action
 
-listAllTransactions :: ApiT WalletId -> ClientM [ApiTransaction C.A]
+listAllTransactions :: ApiT WalletId -> ClientM [ApiTransaction (Testnet 42)]
 listAllTransactions walId =
     C.listTransactions
         walId
@@ -458,14 +458,14 @@ runScenario scenario = lift . runResourceT $ do
     sceneOfClientM "listWallets" C.listWallets
     sceneOfClientM "getWallet" $ C.getWallet wal1Id
     sceneOfClientM "getUTxOsStatistics" $ C.getWalletUtxoStatistics wal1Id
-    sceneOfClientM "listAddresses" $ C.listAddresses wal1Id Nothing
+    sceneOfClientM "listAddresses" $ C.listAddresses @A wal1Id Nothing
     sceneOfClientM "listTransactions" $ listAllTransactions wal1Id
 
     txs <- request $ listAllTransactions wal1Id
     sceneOfClientM "getTransaction"
-        $ C.getTransaction wal1Id (ApiTxId $ txs !! 1 ^. #id) False
+        $ C.getTransaction @A wal1Id (ApiTxId $ txs !! 1 ^. #id) False
 
-    addrs <- request $ C.listAddresses wal2Id Nothing
+    addrs <- request $ C.listAddresses @A wal2Id Nothing
     let destination = addrs !! 1 ^. #id
         amount =
             AddressAmount

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -229,8 +229,8 @@ import UnliftIO.STM
     ( TVar
     )
 
+import qualified Cardano.Wallet.Api.Clients.Network as CN
 import qualified Cardano.Wallet.Api.Clients.Testnet.Id as C
-import qualified Cardano.Wallet.Api.Clients.Testnet.Network as CN
 import qualified Cardano.Wallet.Api.Clients.Testnet.Shelley as C
 import qualified Cardano.Wallet.Benchmarks.Latency.Measure as Measure
 import qualified Cardano.Wallet.Faucet as Faucet

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -229,6 +229,7 @@ import UnliftIO.STM
     ( TVar
     )
 
+import qualified Cardano.Wallet.Api.Clients.Testnet.Id as C
 import qualified Cardano.Wallet.Api.Clients.Testnet.Network as CN
 import qualified Cardano.Wallet.Api.Clients.Testnet.Shelley as C
 import qualified Cardano.Wallet.Benchmarks.Latency.Measure as Measure

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/BenchM.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/BenchM.hs
@@ -59,6 +59,7 @@ import Test.Integration.Framework.DSL
     , clientEnv
     )
 
+import qualified Cardano.Wallet.Api.Clients.Testnet.Id as C
 import qualified Cardano.Wallet.Api.Clients.Testnet.Shelley as C
 import qualified Test.Integration.Framework.DSL as DSL
 

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/BenchM.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/BenchM.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE TypeApplications #-}
@@ -18,9 +19,6 @@ where
 
 import Prelude
 
-import Cardano.Wallet.Api.Clients.Testnet.Shelley
-    ( A
-    )
 import Cardano.Wallet.Api.Types
     ( ApiWallet
     )
@@ -59,6 +57,9 @@ import Servant.Client
 import Test.Integration.Framework.DSL
     ( Context
     , clientEnv
+    )
+import Cardano.Wallet.Primitive.NetworkId
+    ( NetworkDiscriminant (..)
     )
 
 import qualified Cardano.Wallet.Api.Clients.Testnet.Shelley as C
@@ -104,4 +105,5 @@ fixtureWallet :: BenchM ApiWallet
 fixtureWallet = runDSL DSL.fixtureWallet
 
 fixtureWalletWith :: [Natural] -> BenchM ApiWallet
-fixtureWalletWith w = runDSL $ \ctx -> DSL.fixtureWalletWith @A ctx w
+fixtureWalletWith w = runDSL $
+    \ctx -> DSL.fixtureWalletWith @('Testnet 42) ctx w

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/BenchM.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/BenchM.hs
@@ -58,9 +58,6 @@ import Test.Integration.Framework.DSL
     ( Context
     , clientEnv
     )
-import Cardano.Wallet.Primitive.NetworkId
-    ( NetworkDiscriminant (..)
-    )
 
 import qualified Cardano.Wallet.Api.Clients.Testnet.Shelley as C
 import qualified Test.Integration.Framework.DSL as DSL
@@ -106,4 +103,4 @@ fixtureWallet = runDSL DSL.fixtureWallet
 
 fixtureWalletWith :: [Natural] -> BenchM ApiWallet
 fixtureWalletWith w = runDSL $
-    \ctx -> DSL.fixtureWalletWith @('Testnet 42) ctx w
+    \ctx -> DSL.fixtureWalletWith @C.Testnet42 ctx w

--- a/lib/integration/framework/Test/Integration/Framework/DSL/Network.hs
+++ b/lib/integration/framework/Test/Integration/Framework/DSL/Network.hs
@@ -27,7 +27,7 @@ import Test.Integration.Framework.DSL.TestM
     , request
     )
 
-import qualified Cardano.Wallet.Api.Clients.Testnet.Network as C
+import qualified Cardano.Wallet.Api.Clients.Network as C
 
 tipInfo :: TestM EpochNo
 tipInfo = do

--- a/lib/integration/framework/Test/Integration/Framework/DSL/Wallet.hs
+++ b/lib/integration/framework/Test/Integration/Framework/DSL/Wallet.hs
@@ -24,7 +24,7 @@ import Prelude
 import Cardano.Mnemonic
     ( SomeMnemonic
     )
-import Cardano.Wallet.Api.Clients.Testnet.Shelley
+import Cardano.Wallet.Api.Clients.Testnet.Id
     ( Testnet42
     )
 import Cardano.Wallet.Api.Types

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Restoration.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Restoration.hs
@@ -65,7 +65,7 @@ import Test.Integration.Framework.DSL.Wallet
     , withApiWallet
     )
 
-import qualified Cardano.Wallet.Api.Clients.Testnet.Network as C
+import qualified Cardano.Wallet.Api.Clients.Network as C
 
 spec :: SpecWith Context
 spec = describe "restoration of wallets" $ do


### PR DESCRIPTION
This PR extract a polymorphic (in the network) version of the (covered) http client functions for testing and release purposes

- [x] Add a polymorphic version of the Shelley and Byron clients function
- [x] Create a monomorphic (Testnet 42) version of the clients to support test only DSLs
- [x] Move the polymorphic code and the network client code to their separate namespace