### PR TITLE
[ADP-3335] Add "Use case: Centralized Exchanges" to Deposit Wallet

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -299,6 +299,9 @@ package cardano-wallet-integration
 package cardano-wallet-test-utils
   tests: True
 
+package customer-deposit-wallet
+  tests: True
+
 package std-gen-seed
   tests: True
 

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -57,6 +57,7 @@ library
     , contra-tracer
     , delta-store
     , delta-types
+    , io-classes
     , iohk-monitoring-extra              ^>=0.1
     , persistent                         >= 2.13 && < 2.15
     , sqlite-simple                      >= 0.4.19.0 && < 0.5
@@ -66,6 +67,7 @@ library
   exposed-modules:
     Cardano.Wallet.Deposit.IO
     Cardano.Wallet.Deposit.IO.DB
+    Cardano.Wallet.Deposit.IO.Network.Mock
     Cardano.Wallet.Deposit.IO.Network.Type
     Cardano.Wallet.Deposit.Pure
     Cardano.Wallet.Deposit.Pure.Balance

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -14,6 +14,7 @@ category:           Web
 
 extra-source-files:
   spec/**/*.lagda.md
+  spec/**/*.lhs.md
   spec/**/*.openapi.yaml
 
 common language
@@ -95,6 +96,29 @@ test-suite unit
   other-modules:
     Cardano.Wallet.Deposit.PureSpec
     Spec
+
+test-suite scenario
+  import:             language, opts-exe
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     test/scenario
+  main-is:            test-suite-scenario.hs
+  build-tool-depends:
+    markdown-unlit:markdown-unlit
+  ghc-options:
+    -pgmL markdown-unlit 
+  build-depends:
+    , base
+    , cardano-crypto
+    , cardano-wallet-test-utils
+    , containers
+    , contra-tracer
+    , customer-deposit-wallet
+    , delta-store
+    , hspec >=2.8.2
+  other-modules:
+    Test.Scenario.Blockchain
+    Test.Scenario.Wallet.Deposit.Exchanges
+    Test.Scenario.Wallet.Deposit.Run
 
 library customer-deposit-wallet-http
   import:          language, opts-lib

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
@@ -1,0 +1,114 @@
+{-|
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+Mock implementation of a 'NetworkEnv'.
+-}
+module Cardano.Wallet.Deposit.IO.Network.Mock
+    ( newNetworkEnvMock
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Deposit.IO.Network.Type
+    ( NetworkEnv (..)
+    )
+import Cardano.Wallet.Network
+    ( ChainFollower (..)
+    )
+import Control.Concurrent.Class.MonadSTM
+    ( MonadSTM
+    , atomically
+    , modifyTVar
+    , newTVarIO
+    , readTVar
+    , readTVarIO
+    , writeTVar
+    )
+import Control.Monad
+    ( forever
+    )
+import Control.Monad.Class.MonadTimer
+    ( MonadDelay
+    , threadDelay
+    )
+import Data.Foldable
+    ( for_
+    )
+import Data.List.NonEmpty
+    ( NonEmpty ((:|))
+    )
+
+import qualified Cardano.Wallet.Deposit.Read as Read
+import qualified Cardano.Wallet.Deposit.Write as Write
+
+{-----------------------------------------------------------------------------
+    Mock implementation of 'NetworkEnv'
+------------------------------------------------------------------------------}
+newNetworkEnvMock
+    :: (MonadDelay m, MonadSTM m)
+    => m (NetworkEnv m Read.Block)
+newNetworkEnvMock = do
+    mchain <- newTVarIO []
+    mtip <- newTVarIO genesis
+    mfollowers <- newTVarIO []
+
+    let registerAndUpdate follower = do
+            _ <- rollBackward follower genesis
+            (chain, tip) <- atomically $ do
+                modifyTVar mfollowers (follower:)
+                (,) <$> readTVar mchain <*> readTVar mtip
+            case reverse chain of
+                [] -> pure ()
+                (b:bs) -> rollForward follower (b :| bs) tip
+
+    let forgeBlock tx = atomically $ do
+            tipOld <- readTVar mtip
+            let txRead = Write.toReadTx (Write.mockTxId tipOld) tx
+                blockNew = mkNextBlock tipOld [txRead]
+                tipNew = getBlockPoint blockNew
+            writeTVar mtip tipNew
+            modifyTVar mchain (blockNew:)
+            pure (blockNew, tipNew)
+
+    let broadcast block tip = do
+            followers <- readTVarIO mfollowers
+            for_ followers $ \follower ->
+                rollForward follower (block :| []) tip
+
+    pure NetworkEnv
+        { chainSync = \_ follower -> do
+            registerAndUpdate follower
+            forever $ threadDelay 1000000
+        , postTx = \tx -> do
+            (block, tip) <- forgeBlock tx
+            broadcast block tip
+            -- brief delay to account for asynchronous chain followers
+            threadDelay 10
+            pure $ Right ()
+        }
+
+genesis :: Read.ChainPoint
+genesis = Read.Origin
+
+getBlockPoint :: Read.Block -> Read.ChainPoint
+getBlockPoint = Read.At . Read.slot . Read.blockHeaderBody . Read.blockHeader
+
+mkNextBlock :: Read.ChainPoint -> [Read.Tx] -> Read.Block
+mkNextBlock tipOld txs =
+    Read.Block
+        { Read.blockHeader = Read.BHeader
+            { Read.blockHeaderBody = Read.BHBody
+                { Read.prev = Nothing
+                , Read.blockno = toEnum $ fromEnum slotNext
+                , Read.slot = slotNext
+                , Read.bhash = ()
+                }
+            , Read.blockHeaderSignature = ()
+            }
+        , Read.transactions = txs
+        }
+ where
+    slotNext = case tipOld of
+        Read.Origin -> 1
+        Read.At n -> succ n

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Type.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Type.hs
@@ -26,6 +26,7 @@ import GHC.Generics
     )
 
 import qualified Cardano.Wallet.Deposit.Read as Read
+import qualified Cardano.Wallet.Deposit.Write as Write
 
 {-----------------------------------------------------------------------------
     Type
@@ -39,7 +40,7 @@ data NetworkEnv m block = NetworkEnv
         -- ^ Run the chain-sync mini-protocol (forever).
 
     , postTx
-        :: Read.Tx -> m (Either ErrPostTx ())
+        :: Write.Tx -> m (Either ErrPostTx ())
         -- ^ Post a transaction to the Cardano network.
 
     }

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -187,15 +187,19 @@ data TxSummary = TxSummary
     , blockHeaderBody :: Read.BHBody
     , transfer :: ValueTransfer
     }
+    deriving (Eq, Ord, Show)
 
 data ValueTransfer = ValueTransfer
     { spent :: Read.Value
     , received :: Read.Value
     }
+    deriving (Eq, Ord, Show)
 
 getCustomerHistory :: Customer -> WalletState -> [TxSummary]
 getCustomerHistory = undefined
 
+-- TODO: Return an error if any of the `ChainPoint` are no longer
+-- part of the consensus chain?
 getCustomerHistories
     :: (Read.ChainPoint, Read.ChainPoint)
     -> WalletState

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -72,7 +72,10 @@ data Network = Testnet | Mainnet
 -- Spec: type Slot = Natural
 type Slot = W.SlotNo
 
-data ChainPoint = Origin | At Slot
+data ChainPoint
+    = Origin
+    | At Slot
+    deriving (Eq, Ord, Show)
 
 -- newtype Addr = Addr { getAddressBytes :: ByteString }
 --    deriving (Eq, Show)

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
+
 -- | Indirection module that re-exports types
 -- used for writing transactions to the blockchain,
 -- in the most recent and the next future eras.
@@ -11,11 +14,27 @@ module Cardano.Wallet.Deposit.Write
     , TxId
     , Tx (..)
     , TxBody (..)
+    , TxIn
+    , TxOut
     , TxWitness
+
+    -- * Helper functions
+    , mkAda
+    , mkTxOut
+    , mockTxId
+    , toReadTx
     ) where
 
 import Prelude
 
+import Cardano.Wallet.Deposit.Read
+    ( Address
+    , TxId
+    , TxIn
+    , TxOut
+    , TxWitness
+    , Value
+    )
 import Data.Map
     ( Map
     )
@@ -23,10 +42,15 @@ import Data.Set
     ( Set
     )
 
-import Cardano.Wallet.Deposit.Read hiding
-    ( Tx
-    , TxBody
-    )
+import qualified Cardano.Wallet.Deposit.Read as Read
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+import qualified Cardano.Wallet.Primitive.Types.Hash as W
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
+import qualified Cardano.Wallet.Primitive.Types.Tx as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 {-----------------------------------------------------------------------------
     Type definitions
@@ -41,7 +65,41 @@ data Tx = Tx
 data TxBody = TxBody
     { spendInputs :: Set TxIn
     , collInputs :: Set TxIn
-    , txouts :: Map Ix TxOut
+    , txouts :: Map Read.Ix TxOut
     , collRet :: Maybe TxOut
     }
     deriving (Eq, Ord, Show)
+
+mkAda :: Integer -> Value
+mkAda = W.fromCoin . W.unsafeFromIntegral
+
+mkTxOut :: Address -> Value -> TxOut
+mkTxOut = W.TxOut
+
+toReadTx :: TxId -> Tx -> Read.Tx
+toReadTx txid Tx{txbody=TxBody{..}} =
+    W.Tx
+        { W.txId =
+            W.Hash txid
+        , W.txCBOR =
+            Nothing
+        , W.fee =
+            Nothing
+        , W.resolvedInputs =
+            map (,Nothing) $ Set.toList spendInputs
+        , W.resolvedCollateralInputs =
+            map (,Nothing) $ Set.toList collInputs
+        , W.outputs =
+            map snd $ Map.toAscList txouts
+        , W.collateralOutput =
+            collRet
+        , W.withdrawals =
+            mempty
+        , W.metadata =
+            Nothing
+        , W.scriptValidity =
+            Nothing
+        }
+
+mockTxId :: Show a => a -> TxId
+mockTxId = B8.pack . show

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+
+{-|
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+Mock implementation of a blockchain for the purpose of testing.
+
+TODO:
+* Make the blockchain more real.
+-}
+module Test.Scenario.Blockchain
+    ( assert
+
+    , ScenarioEnv
+    , withScenarioEnvMock
+    , withWalletEnvMock
+
+    , Faucet
+    , ada
+    , payFromFaucet
+
+    , signTx
+    , submitTx
+    ) where
+
+import Prelude
+
+import Cardano.Crypto.Wallet
+    ( XPrv
+    )
+import Cardano.Wallet.Deposit.IO.DB
+    ( SqlContext (..)
+    , withSqlContextInMemory
+    )
+import Cardano.Wallet.Deposit.IO.Network.Mock
+    ( newNetworkEnvMock
+    )
+import Cardano.Wallet.Deposit.IO.Network.Type
+    ( NetworkEnv (..)
+    )
+import Control.Tracer
+    ( nullTracer
+    )
+import Data.Store
+    ( newStore
+    )
+import GHC.Stack
+    ( HasCallStack
+    )
+
+import qualified Cardano.Wallet.Deposit.IO as Wallet
+import qualified Cardano.Wallet.Deposit.Read as Read
+import qualified Cardano.Wallet.Deposit.Write as Write
+import qualified Data.Map.Strict as Map
+
+{-----------------------------------------------------------------------------
+    Logic
+------------------------------------------------------------------------------}
+
+assert :: HasCallStack => Bool -> IO ()
+assert True = pure ()
+assert False = error "Assertion failed!"
+
+{-----------------------------------------------------------------------------
+    Environment
+------------------------------------------------------------------------------}
+-- | Environment for scenarios.
+data ScenarioEnv = ScenarioEnv
+    { genesisData :: Read.GenesisData
+    , networkEnv :: NetworkEnv IO Read.Block
+    , faucet :: Faucet
+    }
+
+-- | Acquire and release a mock environment for a blockchain
+withScenarioEnvMock :: (ScenarioEnv -> IO a) -> IO a
+withScenarioEnvMock action = do
+    networkEnv <- newNetworkEnvMock
+    action
+        $ ScenarioEnv
+            { genesisData = error "TODO: Mock Genesis Data"
+            , networkEnv
+            , faucet = Faucet{xprv = error "TODO: Faucet xprv"}
+            }
+
+-- | Acquire and release a mock environment for a wallet.
+withWalletEnvMock
+    :: ScenarioEnv
+    -> (Wallet.WalletEnv IO -> IO a)
+    -> IO a
+withWalletEnvMock ScenarioEnv{..} action =
+    withSqlContextInMemory nullTracer
+        $ \SqlContext{runSqlM} -> do
+            database <- runSqlM newStore
+            let walletEnv = Wallet.WalletEnv
+                    { Wallet.logger = nullTracer
+                    , Wallet.genesisData = genesisData
+                    , Wallet.networkEnv = networkEnv
+                    , Wallet.database = database
+                    , Wallet.atomically = runSqlM
+                    }
+            action walletEnv
+
+{-----------------------------------------------------------------------------
+    Faucet
+------------------------------------------------------------------------------}
+newtype Faucet = Faucet
+    { xprv :: XPrv
+    }
+
+ada :: Integer -> Write.Value
+ada = Write.mkAda
+
+payFromFaucet :: ScenarioEnv -> [(Write.Address, Write.Value)] -> IO ()
+payFromFaucet env destinations =
+    submitTx env tx
+  where
+    toTxOut (addr, value) = Write.mkTxOut addr value
+    txBody = Write.TxBody
+        { Write.spendInputs = mempty
+        , Write.collInputs = mempty
+        , Write.txouts = Map.fromList $ zip [0..] $ map toTxOut destinations
+        , Write.collRet = Nothing
+        }
+    tx = signTx (xprv (faucet env)) [] txBody
+
+{-----------------------------------------------------------------------------
+    Transaction submission
+------------------------------------------------------------------------------}
+type Path = ()
+
+signTx :: XPrv -> [Path] -> Write.TxBody -> Write.Tx
+signTx _ _ txbody =
+    Write.Tx
+        { Write.txbody = txbody
+        , Write.txwits = ()
+        }
+
+submitTx :: ScenarioEnv -> Write.Tx -> IO ()
+submitTx env tx = do
+    _ <- postTx (networkEnv env) tx
+    pure ()

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Exchanges.lhs
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Exchanges.lhs
@@ -1,0 +1,1 @@
+Exchanges.lhs.md

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Exchanges.lhs.md
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Exchanges.lhs.md
@@ -1,5 +1,218 @@
+# Use case: Centralized Exchange
+
+This document describes how a centralized exchange (CEX) can use the Deposit Wallet to
+
+1. Assign an address to a customer ID.
+2. Track deposits at this address.
+3. Track deposits at all addresses.
+4. Create payments to a different wallet.
+
+# Scenarios, Haskell
+
+In this section, we describe the scenarios using Haskell.
+
 ```haskell
 module Test.Scenario.Wallet.Deposit.Exchanges
-    (
+    ( scenarioRestore
+    , scenarioStart
+    , scenarioCreateAddressList
+    , scenarioTrackDepositOne
+    , scenarioTrackDepositAll
+    , scenarioCreatePayment
     ) where
+
+import Prelude
+
+import Cardano.Crypto.Wallet
+    ( XPrv
+    , XPub
+    )
+import Cardano.Wallet.Deposit.IO
+    ( WalletEnv
+    , WalletInstance
+    )
+import Cardano.Wallet.Deposit.Pure
+    ( Customer
+    , TxSummary (..)
+    , ValueTransfer (..)
+    )
+import Cardano.Wallet.Deposit.Read
+    ( Address
+    , Value
+    )
+import Test.Scenario.Blockchain
+    ( ScenarioEnv
+    , ada
+    , assert
+    , payFromFaucet
+    , signTx
+    , submitTx
+    )
+
+import qualified Cardano.Wallet.Deposit.IO as Wallet
+import qualified Data.Map as Map
+```
+
+We use a function `depositFundsAt` to make a deposit at a given address.
+
+```haskell
+depositFundsAt :: ScenarioEnv -> Address -> Value -> IO ()
+depositFundsAt env address value = payFromFaucet env [(address, value)]
+```
+
+## 0. Start a Wallet
+
+A `WalletInstance` denotes a mutable wallet that is actively synchronizing to the blockchain, continuously writes its state to a database file, and responds to queries.
+
+In order to create a fresh wallet, or in order to restore a wallet from its public key all the way from genesis, use the function `withWalletInit`. In addition to the public key, this function expects a number which equals the numerically largest customer ID previously handled with this wallet.
+
+```haskell
+scenarioRestore
+    :: XPub -> WalletEnv IO -> IO ()
+scenarioRestore xpub env = do
+    let knownCustomerCount = 127
+    Wallet.withWalletInit env xpub knownCustomerCount $ \w -> do
+        value <- Wallet.availableBalance w
+        assert $ value == ada 0
+```
+
+In order to load the wallet state from a database file and resume operation from that state use the function `withWalletLoad`.
+
+```haskell
+scenarioStart
+    :: WalletEnv IO -> IO ()
+scenarioStart env =
+    Wallet.withWalletLoad env $ \w -> do
+        value <- Wallet.availableBalance w
+        assert $ value == ada 0
+```
+
+## 1. Assign an address to a customer ID
+
+A `Customer` is represented by a numeric customer ID.
+Given such a customer ID, the function `createAddress` will create an address and add the association between the customer and this address to the wallet state.
+
+(The mapping from customer ID to address is deterministic and based on the [BIP-32][] address derivation scheme.)
+
+  [bip-32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+
+
+The function `listCustomers` returns the associations between customers and addresses recorded in the current wallet state.
+
+```haskell
+scenarioCreateAddressList
+    :: WalletInstance -> IO ()
+scenarioCreateAddressList w = do
+    let customer = 31
+    address <- Wallet.createAddress customer w
+    customers <- Wallet.listCustomers w
+    assert $ (customer, address) `elem` customers
+```
+
+## 2. Track deposits at this address
+
+As soon as an association between customer and address has been added to the wallet state using `createAddress`, the wallet will track deposits sent to this address.
+
+The function `getCustomerHistory` returns a `TxSummary` for each transaction that is related to this customer. For every `TxSummary`, the `received` field records the total deposit made by the customer at this address in this transaction.
+
+(The `spent` field has informative purpose only, and records whether the wallet has moved any funds out of this address.)
+
+The following scenario illustrates how `getCustomerHistory` records deposits:
+
+```haskell
+scenarioTrackDepositOne
+    :: ScenarioEnv -> WalletInstance -> IO ()
+scenarioTrackDepositOne env w = do
+    address <- Wallet.createAddress customer w
+
+    -- no deposits
+    txsummaries0<- Wallet.getCustomerHistory customer w
+    assert $ txsummaries0 == []
+
+    -- first deposit
+    depositFundsAt env address coin
+    txsummaries1 <- Wallet.getCustomerHistory customer w
+    assert $ map (received . transfer) txsummaries1 == [coin]
+
+    -- second deposit
+    depositFundsAt env address coin
+    txsummaries2 <- Wallet.getCustomerHistory customer w
+    assert $ map (received . transfer) txsummaries2 == [coin, coin]
+  where
+    customer = 7 :: Customer
+    coin = ada 12
+```
+
+## 3. Track deposits at all addresses
+
+A centralized exchange typically wants to monitor all transactions in a recent time window for activity in order to synchronize customer deposits on the blockchain ledger with the exchange ledger recording customer balances.
+
+This is a task for the `getCustomerHistories` function — it returns a mapping from customers to `TxSummaries` that record the entire activity within the given time interval.
+
+The time interval is specified by a `from` and a `to` point on the blockchain. We note that the `from` argument is exclusive while the `to` argument is inclusive.
+We use the type `ChainPoint` to specify points on the blockchain — this type uses both a slot number and a block header to uniquely identify a block. We do this in order to allow atomic operations — in the event that the `to` or `from` point are no longer part of the consensus chain, the `getCustomerHistories` functions throws an exception.
+
+The wallet is synchronized to a particular point on the blockchain — use `getWalletTip` to query it.
+
+```haskell
+scenarioTrackDepositAll
+    :: ScenarioEnv -> WalletInstance -> IO ()
+scenarioTrackDepositAll env w = do
+    address1 <- Wallet.createAddress customer1 w
+    address2 <- Wallet.createAddress customer2 w
+
+    from <- Wallet.getWalletTip w
+    depositFundsAt env address1 coin
+    depositFundsAt env address2 coin
+    depositFundsAt env address1 (coin <> coin)
+    to <- Wallet.getWalletTip w
+
+    history <- Wallet.getCustomerHistories (from,to) w
+    assert $
+        Map.map received history
+      ==
+        Map.fromList
+            [ (customer1, coin <> coin <> coin)
+            , (customer2, coin)
+            ]
+  where
+    customer1, customer2 :: Customer
+    customer1 = 1
+    customer2 = 2
+    coin = ada 3
+```
+
+## 4. Create payments to a different wallet
+
+The `createPayment` function allows you to move funds from one wallet to other addresses, e.g. in order to process customer withdrawals. If the wallet has sufficient funds, this function creates a transaction body which sends the given values to the given addresses.
+
+The transaction body needs to be signed. Given a transaction body, the function `getBIP32PathsForOwnedInputs` will provide you with all [BIP-32][] address derivation paths of all inputs that are owned by the wallet, and which therefore require a signature.
+
+```haskell
+scenarioCreatePayment
+    :: XPrv -> ScenarioEnv -> Address -> WalletInstance -> IO ()
+scenarioCreatePayment xprv env destination w = do
+    -- deposit some funds at customer address
+    address1 <- Wallet.createAddress customer w
+    depositFundsAt env address1 (coin <> coin)
+    value1 <- Wallet.availableBalance w
+    assert $ value1 == (coin <> coin)
+
+    -- createPayment
+    Just txBody <- Wallet.createPayment [(destination, coin)] w
+    paths <- Wallet.getBIP32PathsForOwnedInputs txBody w
+    let tx = signTx xprv paths txBody
+    submitTx env tx
+
+    -- funds have been moved out of the wallet
+    value2 <- Wallet.availableBalance w
+    assert $ value2 <> coin == value1
+
+    -- but the original deposit amount is still recorded
+    txsummaries <- Wallet.getCustomerHistory customer w
+    assert $ value1 `elem` map (received . transfer) txsummaries
+  where
+    customer :: Customer
+    customer = 17
+    coin = ada 5
 ```

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Exchanges.lhs.md
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Exchanges.lhs.md
@@ -1,0 +1,5 @@
+```haskell
+module Test.Scenario.Wallet.Deposit.Exchanges
+    (
+    ) where
+```

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Run.hs
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Run.hs
@@ -1,0 +1,61 @@
+{-|
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+Execute usage scenarios for the deposit wallet.
+-}
+module Test.Scenario.Wallet.Deposit.Run
+    ( main
+    ) where
+
+import Prelude
+
+import Cardano.Crypto.Wallet
+    ( XPub
+    )
+import Test.Hspec
+    ( SpecWith
+    , describe
+    , it
+    )
+import Test.Hspec.Extra
+    ( aroundAll
+    , hspecMain
+    )
+import Test.Scenario.Blockchain
+    ( ScenarioEnv
+    , ada
+    , assert
+    , payFromFaucet
+    , withScenarioEnvMock
+    , withWalletEnvMock
+    )
+
+import qualified Cardano.Wallet.Deposit.IO as Wallet
+
+main :: IO ()
+main =
+    hspecMain
+    $ aroundAll withScenarioEnvMock scenarios
+
+scenarios :: SpecWith ScenarioEnv
+scenarios = do
+    describe "Temporary tests" $ do
+        it "Wallet receives funds that are sent to customer address" $ \env -> do
+            withWalletEnvMock env $ \walletEnv ->
+                Wallet.withWalletInit xpub 1 walletEnv $
+                    testBalance env
+
+xpub :: XPub
+xpub = error "todo: xpub"
+
+testBalance
+    :: ScenarioEnv -> Wallet.WalletInstance -> IO ()
+testBalance env w = do
+    address <- Wallet.createAddress customer w
+    payFromFaucet env [(address, coin)]
+    value <- Wallet.availableBalance w
+    assert $ coin == value
+  where
+    customer = 7
+    coin = ada 12

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Run.hs
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Run.hs
@@ -32,6 +32,7 @@ import Test.Scenario.Blockchain
     )
 
 import qualified Cardano.Wallet.Deposit.IO as Wallet
+import qualified Test.Scenario.Wallet.Deposit.Exchanges as Exchanges
 
 main :: IO ()
 main =
@@ -40,10 +41,25 @@ main =
 
 scenarios :: SpecWith ScenarioEnv
 scenarios = do
+    describe "Scenarios for centralized exchanges" $ do
+        it "Restore a wallet" $ \env ->
+            withWalletEnvMock env $
+                Exchanges.scenarioRestore xpub
+
+        it "Start a wallet" $ \env ->
+            withWalletEnvMock env $ \w -> do
+                Exchanges.scenarioRestore xpub w
+                Exchanges.scenarioStart w
+
+        it "Assign an address to a customer ID" $ \env -> do
+            withWalletEnvMock env $ \walletEnv ->
+                Wallet.withWalletInit walletEnv xpub 1
+                    Exchanges.scenarioCreateAddressList
+
     describe "Temporary tests" $ do
         it "Wallet receives funds that are sent to customer address" $ \env -> do
             withWalletEnvMock env $ \walletEnv ->
-                Wallet.withWalletInit xpub 1 walletEnv $
+                Wallet.withWalletInit walletEnv xpub 1 $
                     testBalance env
 
 xpub :: XPub

--- a/lib/customer-deposit-wallet/test/scenario/test-suite-scenario.hs
+++ b/lib/customer-deposit-wallet/test/scenario/test-suite-scenario.hs
@@ -1,0 +1,10 @@
+module Main where
+
+import Prelude
+
+import qualified Test.Scenario.Wallet.Deposit.Run
+    ( main
+    )
+
+main :: IO ()
+main = Test.Scenario.Wallet.Deposit.Run.main

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -147,6 +147,7 @@ hls: CHaP: haskell-nix: nixpkgs-recent: nodePkgs: haskell-nix.cabalProject' [
           haskellPackages.hlint
           haskellPackages.hp2pretty
           haskellPackages.lentil
+          haskellPackages.markdown-unlit
           haskellPackages.pretty-simple
           haskellPackages.weeder
           haskellPackages.stylish-haskell

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -50,7 +50,7 @@ rec {
   */
   keepUnitChecks =
     setEmptyAttrsWithCondition
-      (path: !lib.any (name: name == "unit" || name == "test") path);
+      (path: !lib.any (name: name == "unit" || name == "test" || name == "scenario") path);
 
   /* Recursively remove all attributes named `recurseForDerivations`.
   */


### PR DESCRIPTION
This pull request adds usage scenarios that are relevant for centralized exchanges.

These usage scenarios
* … use the stateful Haskell API presented in `Cardano.Wallet.Deposit.IO`.
* … are described in literate Haskell — the module `Test.Scenario.Wallet.Deposit.Exchanges` is a markdown document.
* … are executable. We can already execute some of them using a mock blockchain implementation. These scenarios are part of our unit test suite.

### Comments

* The future HTTP API is intended to mirror the Haskell API. The source of truth for that API is the stateful Haskell API in `Cardano.Wallet.Deposit.IO`.
* These scenarios document usage patterns. They do not attempt to exhaustively test failure modes or corner cases — a full understanding of the program semantics can only be gained from the specification. The source of truth for the specification is the specification of the pure Haskell API `Cardano.Wallet.Deposit.Pure`, as stateful APIs currently elude specification in many aspects (state, exceptions, concurrency, networking, …).
* For technical reasons, the file `Exchanges.lhs` is a symbolic link to `Exchanges.lhs.md`.

### Issue Number

ADP-3335