### PR TITLE
Enable salt in aes cipher

### DIFF
--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -106,7 +106,7 @@ encrypt
     -> ByteString
     -- ^ Initialisation vector (IV): must be 16 bytes.
     -> Maybe ByteString
-    -- ^ Optional salt, if specified must be 8 bytes
+    -- ^ Optional salt. If specified, must be 8 bytes.
     -> ByteString
     -- ^ Payload: must be a multiple of a block size, ie., 16 bytes.
     -> Either CipherError ByteString
@@ -144,12 +144,12 @@ decrypt
     -> ByteString
     -- ^ Payload: must be a multiple of a block size, ie., 16 bytes.
     -> Either CipherError (ByteString, Maybe ByteString)
-    -- ^ Decrypted payload and optionally salt that was used upon encryption of the payment
+    -- ^ Decrypted payload and optionally salt that was used for encryption.
 decrypt mode key iv msg = do
    when (mode == WithoutPadding && BS.length msg `mod` 16 /= 0) $
        Left WrongPayloadSize
    initedIV <- mapLeft FromCryptonite (createIV iv)
-   let (prefix,rest)= BS.splitAt 8 msg
+   let (prefix,rest) = BS.splitAt 8 msg
    let saltDetected = prefix == saltPrefix
    let unpadding p = case mode of
            WithoutPadding -> Right p

--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -114,10 +114,10 @@ encrypt
     -- ^ Payload: must be a multiple of a block size, ie., 16 bytes.
     -> Either CipherError ByteString
 encrypt mode key iv saltM msg = do
-   when (mode == WithoutPadding && BS.length msg `mod` 16 /= 0) $
-       Left WrongPayloadSize
    when (isJust saltM && BS.length (fromJust saltM) /= 8) $
        Left WrongSaltSize
+   when (mode == WithoutPadding && BS.length msg `mod` 16 /= 0) $
+       Left WrongPayloadSize
    initedIV <- mapLeft FromCryptonite (createIV iv)
    let msgM = case mode of
            WithoutPadding -> Just msg

--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -72,10 +72,6 @@ import Data.Either.Combinators
 import Data.Either.Extra
     ( maybeToEither
     )
-import Data.Maybe
-    ( fromJust
-    , isJust
-    )
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -115,7 +111,7 @@ encrypt
     -- ^ Payload: must be a multiple of a block size, ie., 16 bytes.
     -> Either CipherError ByteString
 encrypt mode key iv saltM msg = do
-   when (isJust saltM && BS.length (fromJust saltM) /= 8) $
+   when (any ((/= 8) . BS.length) saltM) $
        Left WrongSaltSize
    when (mode == WithoutPadding && BS.length msg `mod` 16 /= 0) $
        Left WrongPayloadSize

--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TupleSections #-}
 
 -- | Provides support for AES 256.
 --
@@ -158,12 +159,12 @@ decrypt mode key iv msg = do
            WithoutPadding -> Right p
            WithPadding -> maybeToRight EmptyPayload (unpadPKCS7 p)
    if saltDetected then
-       mapRight (\c -> (c, Just $ BS.take 8 rest)) $
+       mapRight (, Just $ BS.take 8 rest) $
        mapBoth FromCryptonite
        (\c -> cbcDecrypt c initedIV (BS.drop 8 rest)) (initCipher key) >>=
        unpadding
    else
-       mapRight (\c -> (c, Nothing)) $
+       mapRight (, Nothing) $
        mapBoth FromCryptonite
        (\c -> cbcDecrypt c initedIV msg) (initCipher key) >>=
        unpadding

--- a/lib/crypto-primitives/test/Cryptography/Cipher/AES256CBCSpec.hs
+++ b/lib/crypto-primitives/test/Cryptography/Cipher/AES256CBCSpec.hs
@@ -92,6 +92,12 @@ spec = do
             encrypt WithoutPadding key' iv' Nothing payload' ===
                 Left WrongPayloadSize
 
+    describe "encrypt with incorrect salt" $
+        it "encrypt payload == error" $ property $
+        \(CipherWrongSetup payload' key' iv' salt') -> do
+            encrypt WithoutPadding key' iv' salt' payload' ===
+                Left WrongSaltSize
+
     describe "decrypt with incorrect block size" $
         it "decrypt payload == error" $ property $
         \(CipherWrongSetup payload' key' iv' _salt') -> do
@@ -328,8 +334,5 @@ instance Arbitrary CipherWrongSetup where
         key' <- BS.pack <$> vectorOf 32 arbitrary
         iv' <- BS.pack <$> vectorOf 16 arbitrary
         saltLen <- chooseInt (1,32) `suchThat` (\p -> p /= 8)
-        salt' <- oneof
-            [ Just . BS.pack <$> vectorOf saltLen arbitrary
-            , pure Nothing
-            ]
+        salt' <- Just . BS.pack <$> vectorOf saltLen arbitrary
         pure $ CipherWrongSetup payload' key' iv' salt'

--- a/lib/crypto-primitives/test/Cryptography/Cipher/AES256CBCSpec.hs
+++ b/lib/crypto-primitives/test/Cryptography/Cipher/AES256CBCSpec.hs
@@ -452,6 +452,6 @@ instance Arbitrary CipherWrongSetup where
         payload' <- BS.pack <$> vectorOf len arbitrary
         key' <- BS.pack <$> vectorOf 32 arbitrary
         iv' <- BS.pack <$> vectorOf 16 arbitrary
-        saltLen <- chooseInt (1,32) `suchThat` (\p -> p /= 8)
+        saltLen <- chooseInt (1,32) `suchThat` (/= 8)
         salt' <- Just . BS.pack <$> vectorOf saltLen arbitrary
         pure $ CipherWrongSetup payload' key' iv' salt'

--- a/lib/crypto-primitives/test/Cryptography/Cipher/AES256CBCSpec.hs
+++ b/lib/crypto-primitives/test/Cryptography/Cipher/AES256CBCSpec.hs
@@ -121,7 +121,7 @@ spec = do
          -- ZMGELuBkqtHVw5pUA353vQ==
          -- bytes read   :        1
          -- bytes written:       25
-        it "golden 1-byte payload" $
+        it "golden 1-byte payload no salt" $
             checkEncryption GoldenCase
             { input = "0"
             , key = noSaltKey
@@ -134,7 +134,7 @@ spec = do
         -- KBO1WMy3NpqMmm+fEL2kbg==
         -- bytes read   :        2
         -- bytes written:       25
-        it "golden 2-byte payload" $
+        it "golden 2-byte payload no salt" $
             checkEncryption GoldenCase
             { input = "00"
             , key = noSaltKey
@@ -147,7 +147,7 @@ spec = do
         -- 49TERtYsEVKVgpJkUzqmJw==
         -- bytes read   :        5
         -- bytes written:       25
-        it "golden 5-byte payload" $
+        it "golden 5-byte payload no salt" $
             checkEncryption GoldenCase
             { input = "00000"
             , key = noSaltKey
@@ -160,7 +160,7 @@ spec = do
         -- XaYfTkqDajiW6hRc+SlJ8A==
         -- bytes read   :       10
         -- bytes written:       25
-        it "golden 10-byte payload" $
+        it "golden 10-byte payload no salt" $
             checkEncryption GoldenCase
             { input = "0000000000"
             , key = noSaltKey
@@ -173,7 +173,7 @@ spec = do
         -- CXH8t8dSqroR4r4IiNAsfA==
         -- bytes read   :       15
         -- bytes written:       25
-        it "golden 15-byte payload" $
+        it "golden 15-byte payload no salt" $
             checkEncryption GoldenCase
             { input = "000000000000000"
             , key = noSaltKey
@@ -186,7 +186,7 @@ spec = do
         -- hLArzI8DbqOXiEi6HqGQh8iZSRCztrdYpMEE1aj8ES8=
         -- bytes read   :       16
         -- bytes written:       45
-        it "golden 16-byte payload" $
+        it "golden 16-byte payload no salt" $
             checkEncryption GoldenCase
             { input = "0000000000000000"
             , key = noSaltKey
@@ -199,7 +199,7 @@ spec = do
         -- hLArzI8DbqOXiEi6HqGQh96Z6cWqsqTJlbxfcWg/Nvo=
         -- bytes read   :       20
         -- bytes written:       45
-        it "golden 20-byte payload" $
+        it "golden 20-byte payload no salt" $
             checkEncryption GoldenCase
             { input = "00000000000000000000"
             , key = noSaltKey
@@ -212,7 +212,7 @@ spec = do
         -- hLArzI8DbqOXiEi6HqGQh9VxdtWlCXnKS1n/vvCOwL0=
         -- bytes read   :       31
         -- bytes written:       45
-        it "golden 31-byte payload" $
+        it "golden 31-byte payload no salt" $
             checkEncryption GoldenCase
             { input = "0000000000000000000000000000000"
             , key = noSaltKey
@@ -225,7 +225,7 @@ spec = do
         -- hLArzI8DbqOXiEi6HqGQh/VxwHicJoMlVJqa8H2yg5xUYf9zCre088MTCb8jjIN1
         -- bytes read   :       32
         -- bytes written:       65
-        it "golden 32-byte payload" $
+        it "golden 32-byte payload no salt" $
             checkEncryption GoldenCase
             { input = "00000000000000000000000000000000"
             , key = noSaltKey
@@ -234,6 +234,71 @@ spec = do
             } `shouldBe`
             Right
             "hLArzI8DbqOXiEi6HqGQh/VxwHicJoMlVJqa8H2yg5xUYf9zCre088MTCb8jjIN1"
+
+        -- echo -n 0 | openssl enc -e -aes-256-cbc -pbkdf2 -iter 10000 -a -k "password" -S 3030303030303030 -v
+        -- U2FsdGVkX18wMDAwMDAwMJCtI/MMCZ7dqZI6TrtlLyg=
+        -- bytes read   :        1
+        -- bytes written:       45
+        it "golden 1-byte payload salted" $
+            checkEncryption GoldenCase
+            { input = "0"
+            , key = saltKey
+            , iv = saltIv
+            , salt = fromHex "3030303030303030"
+            } `shouldBe`
+            Right "U2FsdGVkX18wMDAwMDAwMJCtI/MMCZ7dqZI6TrtlLyg="
+
+        -- echo -n 00 | openssl enc -e -aes-256-cbc -pbkdf2 -iter 10000 -a -k "password" -S 3030303030303030 -v
+        -- U2FsdGVkX18wMDAwMDAwMKZlzmc8ZsSxwTwDKJY4J+I=
+        -- bytes read   :        2
+        -- bytes written:       45
+        it "golden 2-byte payload salted" $
+            checkEncryption GoldenCase
+            { input = "00"
+            , key = saltKey
+            , iv = saltIv
+            , salt = fromHex "3030303030303030"
+            } `shouldBe`
+            Right "U2FsdGVkX18wMDAwMDAwMKZlzmc8ZsSxwTwDKJY4J+I="
+
+        -- echo -n 00000 | openssl enc -e -aes-256-cbc -pbkdf2 -iter 10000 -a -k "password" -S 3030303030303030 -v
+        -- U2FsdGVkX18wMDAwMDAwMCP7dvgIZ/E+vzQN+2JuGF0=
+        -- bytes read   :        5
+        -- bytes written:       45
+        it "golden 5-byte payload salted" $
+            checkEncryption GoldenCase
+            { input = "00000"
+            , key = saltKey
+            , iv = saltIv
+            , salt = fromHex "3030303030303030"
+            } `shouldBe`
+            Right "U2FsdGVkX18wMDAwMDAwMCP7dvgIZ/E+vzQN+2JuGF0="
+
+        -- echo -n 0000000000 | openssl enc -e -aes-256-cbc -pbkdf2 -iter 10000 -a -k "password" -S 3030303030303030 -v
+        -- U2FsdGVkX18wMDAwMDAwMDXxr84l/PtjzWRCPGb8oSY=
+        -- bytes read   :       10
+        -- bytes written:       45
+        it "golden 10-byte payload salted" $
+            checkEncryption GoldenCase
+            { input = "0000000000"
+            , key = saltKey
+            , iv = saltIv
+            , salt = fromHex "3030303030303030"
+            } `shouldBe`
+            Right "U2FsdGVkX18wMDAwMDAwMDXxr84l/PtjzWRCPGb8oSY="
+
+        -- echo -n 000000000000000 | openssl enc -e -aes-256-cbc -pbkdf2 -iter 10000 -a -k "password" -S 3030303030303030 -v
+        -- U2FsdGVkX18wMDAwMDAwMPCoW2E+adl2BLopcz8iftA=
+        -- bytes read   :       15
+        -- bytes written:       45
+        it "golden 15-byte payload salted" $
+            checkEncryption GoldenCase
+            { input = "000000000000000"
+            , key = saltKey
+            , iv = saltIv
+            , salt = fromHex "3030303030303030"
+            } `shouldBe`
+            Right "U2FsdGVkX18wMDAwMDAwMPCoW2E+adl2BLopcz8iftA="
   where
     --  We are using the following key and iv for goldens
     -- $ openssl enc -aes-256-cbc -pbkdf2 -pass stdin -P -S 3030303030303030 -k "password" -iter 10000 -P

--- a/lib/crypto-primitives/test/Cryptography/Cipher/AES256CBCSpec.hs
+++ b/lib/crypto-primitives/test/Cryptography/Cipher/AES256CBCSpec.hs
@@ -299,6 +299,60 @@ spec = do
             , salt = fromHex "3030303030303030"
             } `shouldBe`
             Right "U2FsdGVkX18wMDAwMDAwMPCoW2E+adl2BLopcz8iftA="
+
+        -- echo -n 0000000000000000 | openssl enc -e -aes-256-cbc -pbkdf2 -iter 10000 -a -k "password" -S 3030303030303030 -v
+        -- U2FsdGVkX18wMDAwMDAwMEmgP1lu1tbBnNx984qKn/KQzjySUk4bPGtysOLjtex2
+        -- bytes read   :       16
+        -- bytes written:       6
+        it "golden 16-byte payload salted" $
+            checkEncryption GoldenCase
+            { input = "0000000000000000"
+            , key = saltKey
+            , iv = saltIv
+            , salt = fromHex "3030303030303030"
+            } `shouldBe`
+            Right "U2FsdGVkX18wMDAwMDAwMEmgP1lu1tbBnNx984qKn/KQzjySUk4bPGtysOLjtex2"
+
+        -- echo -n 00000000000000000000 | openssl enc -e -aes-256-cbc -pbkdf2 -iter 10000 -a -k "password" -S 3030303030303030 -v
+        -- U2FsdGVkX18wMDAwMDAwMEmgP1lu1tbBnNx984qKn/LR9tAdmXupg7jaO09x75x+
+        -- bytes read   :       20
+        -- bytes written:       65
+        it "golden 20-byte payload salted" $
+            checkEncryption GoldenCase
+            { input = "00000000000000000000"
+            , key = saltKey
+            , iv = saltIv
+            , salt = fromHex "3030303030303030"
+            } `shouldBe`
+            Right "U2FsdGVkX18wMDAwMDAwMEmgP1lu1tbBnNx984qKn/LR9tAdmXupg7jaO09x75x+"
+
+        -- echo -n 0000000000000000000000000000000 | openssl enc -e -aes-256-cbc -pbkdf2 -iter 10000 -a -k "password" -S 3030303030303030 -v
+        -- U2FsdGVkX18wMDAwMDAwMEmgP1lu1tbBnNx984qKn/I6rOQXQsrifJ04fr1+IKEk
+        -- bytes read   :       31
+        -- bytes written:       65
+        it "golden 31-byte payload salted" $
+            checkEncryption GoldenCase
+            { input = "0000000000000000000000000000000"
+            , key = saltKey
+            , iv = saltIv
+            , salt = fromHex "3030303030303030"
+            } `shouldBe`
+            Right "U2FsdGVkX18wMDAwMDAwMEmgP1lu1tbBnNx984qKn/I6rOQXQsrifJ04fr1+IKEk"
+
+        -- echo -n 00000000000000000000000000000000 | openssl enc -e -aes-256-cbc -pbkdf2 -iter 10000 -a -k "password" -S 3030303030303030 -v
+        -- U2FsdGVkX18wMDAwMDAwMEmgP1lu1tbBnNx984qKn/K9sJJpdKMH4wS0xz8+OUa3
+        -- 8Hj/N4XOSY5x6a+7PCWwtg==
+        -- bytes read   :       32
+        -- bytes written:       90
+        it "golden 32-byte payload salted" $
+            checkEncryption GoldenCase
+            { input = "00000000000000000000000000000000"
+            , key = saltKey
+            , iv = saltIv
+            , salt = fromHex "3030303030303030"
+            } `shouldBe`
+            Right
+            "U2FsdGVkX18wMDAwMDAwMEmgP1lu1tbBnNx984qKn/K9sJJpdKMH4wS0xz8+OUa38Hj/N4XOSY5x6a+7PCWwtg=="
   where
     --  We are using the following key and iv for goldens
     -- $ openssl enc -aes-256-cbc -pbkdf2 -pass stdin -P -S 3030303030303030 -k "password" -iter 10000 -P

--- a/lib/crypto-primitives/test/Cryptography/Cipher/AES256CBCSpec.hs
+++ b/lib/crypto-primitives/test/Cryptography/Cipher/AES256CBCSpec.hs
@@ -72,19 +72,19 @@ spec = do
                 === 0
     describe "encrypt/decrypt roundtrip with padding" $
         it "decrypt . encrypt $ payload == payload" $ property $
-        \(CipherPaddingSetup payload' key' iv' _salt') -> do
-            let toPayload (Left EmptyPayload) = Right BS.empty
+        \(CipherPaddingSetup payload' key' iv' salt') -> do
+            let toPayload (Left EmptyPayload) = Right (BS.empty, salt')
                 toPayload res = res
-            toPayload (encrypt WithPadding key' iv' Nothing payload' >>=
-                decrypt WithPadding key' iv') === Right payload'
+            toPayload (encrypt WithPadding key' iv' salt' payload' >>=
+                decrypt WithPadding key' iv') === Right (payload', salt')
 
     describe "encrypt/decrypt roundtrip without padding" $
         it "decrypt . encrypt $ payload == payload" $ property $
-        \(CipherRawSetup payload' key' iv' _salt') -> do
-            let toPayload (Left EmptyPayload) = Right BS.empty
+        \(CipherRawSetup payload' key' iv' salt') -> do
+            let toPayload (Left EmptyPayload) = Right (BS.empty, salt')
                 toPayload res = res
-            toPayload (encrypt WithoutPadding key' iv' Nothing payload' >>=
-                decrypt WithoutPadding key' iv') === Right payload'
+            toPayload (encrypt WithoutPadding key' iv' salt' payload' >>=
+                decrypt WithoutPadding key' iv') === Right (payload', salt')
 
     describe "encrypt with incorrect block size" $
         it "encrypt payload == error" $ property $


### PR DESCRIPTION
<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->


- [x] `encrypt` salt support
- [x] `decrypt` salt support
- [x] update unit tests
- [x] add goldens with openssl correspondence    


### Comments
It is important to note that when we use salt encrypted message is appended with salt prefix and salt.
Here is demonstration:
```
$ echo CXH8t8dSqro-n 000000000000000 | openssl enc -e -aes-256-cbc -pbkdf2 -iter 10000 -a -k "password" -S 3030303030303030 -v
bufsize=8192
U2FsdGVkX18wMDAwMDAwMPCoW2E+adl2BLopcz8iftA=
bytes read   :       15
bytes written:       45

$ echo U2FsdGVkX18wMDAwMDAwMPCoW2E+adl2BLopcz8iftA= | base64 -d | xxd
00000000: 5361 6c74 6564 5f5f 3030 3030 3030 3030  Salted__00000000
00000010: f0a8 5b61 3e69 d976 04ba 2973 3f22 7ed0  ..[a>i.v..)s?"~.

$ echo -n 000000000000000 | openssl enc -e -aes-256-cbc -pbkdf2 -iter 10000 -a -k "password" -S 3232323230303030 -v
bufsize=8192
U2FsdGVkX18yMjIyMDAwMNMkzD3e6bZFrwKXyj5GWi8=
bytes read   :       15
bytes written:       45

$ echo U2FsdGVkX18yMjIyMDAwMNMkzD3e6bZFrwKXyj5GWi8= | base64 -d | xxd
00000000: 5361 6c74 6564 5f5f 3232 3232 3030 3030  Salted__22220000
00000010: d324 cc3d dee9 b645 af02 97ca 3e46 5a2f  .$.=...E....>FZ/
```

Conclusions:
1.  16 bytes are prepended when salt is used.
2. First 8 bytes are always constant, ie. irrespective of salt value, and is `Salted__`, the next 8 bytes is salt
3. Salt MUST be 8 bytes.

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number
adp-3327
<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
