### PR TITLE
[ADP-3335] Add `withDBHandleInMemory`

### DIFF
--- a/lib/wallet/src/Cardano/DB/Sqlite.hs
+++ b/lib/wallet/src/Cardano/DB/Sqlite.hs
@@ -32,6 +32,7 @@ module Cardano.DB.Sqlite
       -- * DB Connections
     , DBHandle
     , withDBHandle
+    , withDBHandleInMemory
     , dbConn
     , dbFile
     , dbBackend
@@ -301,6 +302,14 @@ withDBHandle
     -> IO a
 withDBHandle tr fp =
     bracket (newDBHandle tr fp) (closeDBHandleRetrying tr)
+
+-- | Acquire and release a 'DBHandle' in memory.
+withDBHandleInMemory
+    :: Tracer IO DBLog
+    -> (DBHandle -> IO a)
+    -> IO a
+withDBHandleInMemory tr =
+    bracket (newDBHandleInMemory tr) (closeDBHandle tr)
 
 -- | Create a new 'DBHandle' from a file.
 -- Needs to be closed explicitly.


### PR DESCRIPTION
This pull request adds a function `withDBHandleInMemory` and uses it in `Cardano.Wallet.Deposit.IO.DB`.

### Comment

This pull request prepares the implementation of a mock environment for the Deposit Wallet. In turn, this enables execution of user scenarios.

### Issue Number

ADP-3335
