### PR TITLE
[ADP-3335] Change `Cardano.Wallet.Deposit.IO.DB` to depend on `sqlite-simple`

### DIFF
--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -58,7 +58,9 @@ library
     , delta-types
     , iohk-monitoring-extra              ^>=0.1
     , persistent                         >= 2.13 && < 2.15
+    , sqlite-simple                      >= 0.4.19.0 && < 0.5
     , text
+    , transformers
     , time
   exposed-modules:
     Cardano.Wallet.Deposit.IO

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -83,6 +83,7 @@ onWalletState
     -> IO r
 onWalletState WalletInstance{env,walletState} update' =
     atomically env $ Delta.onDBVar walletState update'
+    -- FIXME: Propagation of exceptions from Pure to IO.
 
 -- | Convenience to read the 'WalletState'.
 --


### PR DESCRIPTION
This pull request changes `Cardano.Wallet.Deposit.IO.DB` to use `sqlite-simple` instead of `persistent`.

The reason for this change is that `withDBHandleInMemory` throws an exception when called *twice* in some circumstances.

It appears that this bug is located in a dependency. Rumor has it that there might be a bug in `persistent` where SQL statements are not finalized. It seems likely that the SQL statement which is not finalized is the `BEGIN TRANSACTION` statement that `persistent` reuses in each call to `runSqlConn`. I did not investigate this further, as I want to move away from `persistent` anyway, and using `sqlite-simple` fixes the issue.

### Comment

This pull request prepares the implementation of a mock environment for
the Deposit Wallet. In turn, this enables execution of user scenarios.

### Issue Number

ADP-3335