### PR TITLE
[ADP-3327] Small revisions to `AES256CBC`.

### DIFF
--- a/lib/crypto-primitives/crypto-primitives.cabal
+++ b/lib/crypto-primitives/crypto-primitives.cabal
@@ -51,7 +51,6 @@ library
     , base                    >= 4.14.3 && < 4.19
     , bytestring              >= 0.10.12 && < 0.13
     , cryptonite              ^>=0.30
-    , either
     , extra
     , memory                  ^>=0.18
     , monoid-subclasses

--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -114,10 +114,8 @@ encrypt mode key iv saltM msg
         Left EmptyPayload
     | otherwise = do
         initedIV <- first FromCryptonite (createIV iv)
-        bimap
-            FromCryptonite
-            (maybeAddSalt . (\c -> cbcEncrypt c initedIV (maybePad msg)))
-            (initCipher key)
+        cypher <- first FromCryptonite (initCipher key)
+        pure $ maybeAddSalt $ cbcEncrypt cypher initedIV $ maybePad msg
   where
     maybeAddSalt :: ByteString -> ByteString
     maybeAddSalt =

--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -113,7 +113,7 @@ encrypt mode key iv saltM msg = do
     initedIV <- first FromCryptonite (createIV iv)
     let msgM = case mode of
             WithoutPadding -> Just msg
-            WithPadding -> padPKCS7 msg
+            WithPadding -> pad msg
     msg' <- maybeToEither EmptyPayload msgM
     case saltM of
         Nothing ->
@@ -125,7 +125,7 @@ encrypt mode key iv saltM msg = do
             (\c -> cbcEncrypt c initedIV msg') (initCipher key)
   where
     addSalt salt = saltPrefix <> salt
-    padPKCS7 payload
+    pad payload
         | BS.null payload = Nothing
         | otherwise = Just (PKCS7.pad payload)
 

--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -124,8 +124,7 @@ encrypt mode key iv saltM msg = do
     maybeAddSalt =
         case saltM of
             Nothing -> id
-            Just salt -> \c -> addSalt salt <> c
-    addSalt salt = saltPrefix <> salt
+            Just salt -> \c -> saltPrefix <> salt <> c
     pad payload
         | BS.null payload = Nothing
         | otherwise = Just (PKCS7.pad payload)

--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -149,16 +149,16 @@ decrypt mode key iv msg = do
     initedIV <- first FromCryptonite (createIV iv)
     let (prefix,rest) = BS.splitAt 8 msg
     let saltDetected = prefix == saltPrefix
-    let unpadding p = case mode of
+    let unpad p = case mode of
             WithoutPadding -> Right p
             WithPadding -> maybeToEither EmptyPayload (PKCS7.unpad p)
     if saltDetected then
         second (, Just $ BS.take 8 rest) $
         bimap FromCryptonite
         (\c -> cbcDecrypt c initedIV (BS.drop 8 rest)) (initCipher key) >>=
-        unpadding
+        unpad
     else
         second (, Nothing) $
         bimap FromCryptonite
         (\c -> cbcDecrypt c initedIV msg) (initCipher key) >>=
-        unpadding
+        unpad

--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -105,7 +105,7 @@ encrypt
     -> ByteString
     -- ^ Payload: must be a multiple of a block size, ie., 16 bytes.
     -> Either CipherError ByteString
-encrypt mode key iv saltM msg
+encrypt mode keyBytes ivBytes saltM msg
     | any ((/= 8) . BS.length) saltM =
         Left WrongSaltSize
     | mode == WithoutPadding && BS.length msg `mod` 16 /= 0 =
@@ -113,9 +113,9 @@ encrypt mode key iv saltM msg
     | BS.null msg =
         Left EmptyPayload
     | otherwise = do
-        initedIV <- first FromCryptonite (createIV iv)
-        cypher <- first FromCryptonite (initCipher key)
-        pure $ maybeAddSalt $ cbcEncrypt cypher initedIV $ maybePad msg
+        iv <- first FromCryptonite (createIV ivBytes)
+        cypher <- first FromCryptonite (initCipher keyBytes)
+        pure $ maybeAddSalt $ cbcEncrypt cypher iv $ maybePad msg
   where
     maybeAddSalt :: ByteString -> ByteString
     maybeAddSalt =

--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -59,14 +59,13 @@ import Cryptography.Core
     , CryptoFailable (CryptoFailed, CryptoPassed)
     )
 import Data.Bifunctor
-    ( Bifunctor (bimap)
+    ( Bifunctor (bimap, first)
     )
 import Data.ByteString
     ( ByteString
     )
 import Data.Either.Combinators
-    ( mapLeft
-    , mapRight
+    ( mapRight
     , maybeToRight
     )
 import Data.Either.Extra
@@ -115,7 +114,7 @@ encrypt mode key iv saltM msg = do
         Left WrongSaltSize
     when (mode == WithoutPadding && BS.length msg `mod` 16 /= 0) $
         Left WrongPayloadSize
-    initedIV <- mapLeft FromCryptonite (createIV iv)
+    initedIV <- first FromCryptonite (createIV iv)
     let msgM = case mode of
             WithoutPadding -> Just msg
             WithPadding -> padPKCS7 msg
@@ -151,7 +150,7 @@ decrypt
 decrypt mode key iv msg = do
     when (mode == WithoutPadding && BS.length msg `mod` 16 /= 0) $
         Left WrongPayloadSize
-    initedIV <- mapLeft FromCryptonite (createIV iv)
+    initedIV <- first FromCryptonite (createIV iv)
     let (prefix,rest) = BS.splitAt 8 msg
     let saltDetected = prefix == saltPrefix
     let unpadding p = case mode of

--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -115,11 +115,10 @@ encrypt mode key iv saltM msg = do
             WithoutPadding -> Just msg
             WithPadding -> pad msg
     msg' <- maybeToEither EmptyPayload msgM
-    second maybeAddSalt $
-        bimap
-            FromCryptonite
-            (\c -> cbcEncrypt c initedIV msg')
-            (initCipher key)
+    bimap
+        FromCryptonite
+        (maybeAddSalt . (\c -> cbcEncrypt c initedIV msg'))
+        (initCipher key)
   where
     maybeAddSalt :: ByteString -> ByteString
     maybeAddSalt =

--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -59,14 +59,13 @@ import Cryptography.Core
     , CryptoFailable (CryptoFailed, CryptoPassed)
     )
 import Data.Bifunctor
-    ( Bifunctor (bimap, first)
+    ( Bifunctor (bimap, first, second)
     )
 import Data.ByteString
     ( ByteString
     )
 import Data.Either.Combinators
-    ( mapRight
-    , maybeToRight
+    ( maybeToRight
     )
 import Data.Either.Extra
     ( maybeToEither
@@ -124,7 +123,7 @@ encrypt mode key iv saltM msg = do
             bimap FromCryptonite
             (\c -> cbcEncrypt c initedIV msg') (initCipher key)
         Just salt ->
-            mapRight (\c -> addSalt salt <> c) $
+            second (\c -> addSalt salt <> c) $
             bimap FromCryptonite
             (\c -> cbcEncrypt c initedIV msg') (initCipher key)
   where
@@ -157,12 +156,12 @@ decrypt mode key iv msg = do
             WithoutPadding -> Right p
             WithPadding -> maybeToRight EmptyPayload (PKCS7.unpad p)
     if saltDetected then
-        mapRight (, Just $ BS.take 8 rest) $
+        second (, Just $ BS.take 8 rest) $
         bimap FromCryptonite
         (\c -> cbcDecrypt c initedIV (BS.drop 8 rest)) (initCipher key) >>=
         unpadding
     else
-        mapRight (, Nothing) $
+        second (, Nothing) $
         bimap FromCryptonite
         (\c -> cbcDecrypt c initedIV msg) (initCipher key) >>=
         unpadding

--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -64,9 +64,6 @@ import Data.Bifunctor
 import Data.ByteString
     ( ByteString
     )
-import Data.Either.Combinators
-    ( maybeToRight
-    )
 import Data.Either.Extra
     ( maybeToEither
     )
@@ -117,7 +114,7 @@ encrypt mode key iv saltM msg = do
     let msgM = case mode of
             WithoutPadding -> Just msg
             WithPadding -> padPKCS7 msg
-    msg' <- maybeToRight EmptyPayload msgM
+    msg' <- maybeToEither EmptyPayload msgM
     case saltM of
         Nothing ->
             bimap FromCryptonite
@@ -154,7 +151,7 @@ decrypt mode key iv msg = do
     let saltDetected = prefix == saltPrefix
     let unpadding p = case mode of
             WithoutPadding -> Right p
-            WithPadding -> maybeToRight EmptyPayload (PKCS7.unpad p)
+            WithPadding -> maybeToEither EmptyPayload (PKCS7.unpad p)
     if saltDetected then
         second (, Just $ BS.take 8 rest) $
         bimap FromCryptonite


### PR DESCRIPTION
## Issue

ADP-3327

## Description

This PR makes a number of small revisions to the `AES256CBC` module:
- Use pattern guards instead of `when`.
- Use general functions from `Data.Bifunctor` (in `base`) instead of the `Either`-specific combinators from`Data.Either.Combinators` (from the `either` library).