### PR TITLE
[ADP-3350] Change `lightSync` to use `Read.ChainPoint`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -259,6 +259,9 @@ package cardano-wallet-cli
 package cardano-wallet-launcher
   tests: True
 
+package cardano-wallet-network-layer
+  tests: True
+
 package cardano-wallet-primitive
   tests: True
 

--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -123,6 +123,7 @@ test-suite unit
     , bytestring
     , cardano-wallet-network-layer
     , cardano-wallet-primitive
+    , cardano-wallet-read
     , contra-tracer
     , hspec
     , io-classes


### PR DESCRIPTION
This pull request changes the `lightSync` function to use the data type `ChainPoint` from the `Cardano.Wallet.Read` hierarchy.

### Comments

* `lightSync` still uses the legacy `BlockHeader` type from `primitive` for now.
* The goal is to eventually remove the legacy `primitive` types.

### Issue Number

ADP-3350