### PR TITLE
[ADP-3272] Simplify guard name to `guardUTxOConsistency`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -642,7 +642,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     guardExistingCollateral
     guardExistingTotalCollateral
     guardExistingReturnCollateral
-    guardWalletUTxOConsistencyWith
+    guardUTxOConsistency
 
     (balance0, minfee0, _) <- balanceAfterSettingMinFee (partialTx ^. #tx)
 
@@ -866,8 +866,8 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     -- They are not consistent iff an input can be looked up in both UTxO sets
     -- with different @Address@, or @TokenBundle@ values.
     --
-    guardWalletUTxOConsistencyWith :: ExceptT (ErrBalanceTx era) m ()
-    guardWalletUTxOConsistencyWith =
+    guardUTxOConsistency :: ExceptT (ErrBalanceTx era) m ()
+    guardUTxOConsistency =
         case NE.nonEmpty (F.toList (conflicts extraUTxO walletLedgerUTxO)) of
             Just cs -> throwE $ ErrBalanceTxInputResolutionConflicts cs
             Nothing -> return ()

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -861,7 +861,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
             minfee' = Convert.toLedgerCoin minfee
         return (balance, minfee', witCount)
 
-    -- | Ensures the wallet UTxO set is consistent with the given UTxO set.
+    -- | Ensures that the given UTxO sets are consistent with one another.
     --
     -- They are not consistent iff an input can be looked up in both UTxO sets
     -- with different @Address@, or @TokenBundle@ values.


### PR DESCRIPTION
## Issue

ADP-3272
Follow-on from https://github.com/cardano-foundation/cardano-wallet/pull/4531

## Description

This PR revises the name of a guard to better reflect its type.