### PR TITLE
[ADP-3272] Revise `UTxOIndex` field names.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -633,7 +633,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     pp
     timeTranslation
     utxoAssumptions
-    (UTxOIndex internalUtxoAvailable walletLedgerUTxO)
+    (UTxOIndex internalUtxoAvailable availableUTxO)
     genChange
     s
     selectionStrategy
@@ -868,7 +868,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     --
     guardUTxOConsistency :: ExceptT (ErrBalanceTx era) m ()
     guardUTxOConsistency =
-        case NE.nonEmpty (F.toList (conflicts extraUTxO walletLedgerUTxO)) of
+        case NE.nonEmpty (F.toList (conflicts extraUTxO availableUTxO)) of
             Just cs -> throwE $ ErrBalanceTxInputResolutionConflicts cs
             Nothing -> return ()
       where
@@ -884,7 +884,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
          -- UTxO set. (Whether or not this is a sane thing for the user to do,
          -- is another question.)
          [ extraUTxO
-         , walletLedgerUTxO
+         , availableUTxO
          ]
 
     assembleTransaction

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -635,7 +635,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     pp
     timeTranslation
     utxoAssumptions
-    (UTxOIndex availableUTxO availableUTxOIndex)
+    UTxOIndex {availableUTxO, availableUTxOIndex}
     genChange
     s
     selectionStrategy

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -462,7 +462,9 @@ instance IsRecentEra era => Buildable (PartialTx era)
 
 data UTxOIndex era = UTxOIndex
     { availableUTxO :: !(UTxO era)
+    -- ^ The set of UTxOs that are available to spend.
     , availableUTxOIndex :: !(UTxOIndex.UTxOIndex WalletUTxO)
+    -- ^ The set of UTxOs that are available to spend, in indexed form.
     }
 
 constructUTxOIndex

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -461,8 +461,8 @@ instance IsRecentEra era => Buildable (PartialTx era)
         txF tx' = pretty $ pShow tx'
 
 data UTxOIndex era = UTxOIndex
-    { availableUTxOIndex :: !(UTxOIndex.UTxOIndex WalletUTxO)
-    , availableUTxO :: !(UTxO era)
+    { availableUTxO :: !(UTxO era)
+    , availableUTxOIndex :: !(UTxOIndex.UTxOIndex WalletUTxO)
     }
 
 constructUTxOIndex
@@ -470,7 +470,7 @@ constructUTxOIndex
     => UTxO era
     -> UTxOIndex era
 constructUTxOIndex availableUTxO =
-    UTxOIndex {availableUTxOIndex, availableUTxO}
+    UTxOIndex {availableUTxO, availableUTxOIndex}
   where
     availableUTxOIndex =
         UTxOIndex.fromMap $ toInternalUTxOMap $ toWalletUTxO availableUTxO
@@ -633,7 +633,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     pp
     timeTranslation
     utxoAssumptions
-    (UTxOIndex availableUTxOIndex availableUTxO)
+    (UTxOIndex availableUTxO availableUTxOIndex)
     genChange
     s
     selectionStrategy

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -633,7 +633,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     pp
     timeTranslation
     utxoAssumptions
-    (UTxOIndex internalUtxoAvailable availableUTxO)
+    (UTxOIndex availableUTxOIndex availableUTxO)
     genChange
     s
     selectionStrategy
@@ -677,7 +677,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         externalSelectedUtxo <- extractExternallySelectedUTxO
         let utxoSelection =
                 UTxOSelection.fromIndexPair
-                    (internalUtxoAvailable, externalSelectedUtxo)
+                    (availableUTxOIndex, externalSelectedUtxo)
 
         when (UTxOSelection.availableSize utxoSelection == 0) $
             throwE ErrBalanceTxUnableToCreateInput

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -461,7 +461,7 @@ instance IsRecentEra era => Buildable (PartialTx era)
         txF tx' = pretty $ pShow tx'
 
 data UTxOIndex era = UTxOIndex
-    { walletUTxOIndex :: !(UTxOIndex.UTxOIndex WalletUTxO)
+    { availableUTxOIndex :: !(UTxOIndex.UTxOIndex WalletUTxO)
     , availableUTxO :: !(UTxO era)
     }
 
@@ -470,9 +470,9 @@ constructUTxOIndex
     => UTxO era
     -> UTxOIndex era
 constructUTxOIndex availableUTxO =
-    UTxOIndex {walletUTxOIndex, availableUTxO}
+    UTxOIndex {availableUTxOIndex, availableUTxO}
   where
-    walletUTxOIndex =
+    availableUTxOIndex =
         UTxOIndex.fromMap $ toInternalUTxOMap $ toWalletUTxO availableUTxO
 
 fromWalletUTxO

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -462,18 +462,18 @@ instance IsRecentEra era => Buildable (PartialTx era)
 
 data UTxOIndex era = UTxOIndex
     { walletUTxOIndex :: !(UTxOIndex.UTxOIndex WalletUTxO)
-    , ledgerUTxO :: !(UTxO era)
+    , availableUTxO :: !(UTxO era)
     }
 
 constructUTxOIndex
     :: IsRecentEra era
     => UTxO era
     -> UTxOIndex era
-constructUTxOIndex ledgerUTxO =
-    UTxOIndex {walletUTxOIndex, ledgerUTxO}
+constructUTxOIndex availableUTxO =
+    UTxOIndex {walletUTxOIndex, availableUTxO}
   where
     walletUTxOIndex =
-        UTxOIndex.fromMap $ toInternalUTxOMap $ toWalletUTxO ledgerUTxO
+        UTxOIndex.fromMap $ toInternalUTxOMap $ toWalletUTxO availableUTxO
 
 fromWalletUTxO
     :: forall era. IsRecentEra era


### PR DESCRIPTION
## Issue

ADP-3272

## Description

This PR:
- revises the `UTxOIndex` record type to use field names that more closely match their intended **_purpose_**:
    - `availableUTxO`: the set of UTxOs that are available to spend.
    - `availableUTxOIndex`: an indexed version of the above set.
- uses these new names consistently within the `Write.Tx.Balance` module.
- uses [named field puns](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/record_puns.html) to match on values of type `UTxOIndex` instead of positional pattern matching.
