### PR TITLE
[ADP-3350] Fix `Cardano.Wallet.Read.Block.SlotNo`

### DIFF
--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -122,6 +122,7 @@ library
     , generics-sop
     , lens
     , memory
+    , nothunks
     , operational
     , ouroboros-consensus
     , ouroboros-consensus-cardano

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Block.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Block.hs
@@ -56,6 +56,8 @@ import qualified Ouroboros.Consensus.Shelley.Ledger as O
 type ConsensusBlock = O.CardanoBlock O.StandardCrypto
 
 -- Family of era-specific block types
+-- TODO: ADP-3351 The results of this type family should be ledger types,
+-- not ouroboros-consensus types.
 type family BlockT era where
     BlockT Byron =
         O.ByronBlock


### PR DESCRIPTION
This pull request fixes the `Cardano.Wallet.Read.Block.SlotNo` module which encountered some difficulties with type class resolution and orphan instances, to the point where I suspected a compiler bug.

I have also added `NoThunks` and `Generic` instances for the `Cardano.Wallet.Read.SlotNo` type in preparation for future pull requests.

### Issue Number

Discovered during ADP-3350