### PR TITLE
[ADP-3272] Clarify `Arbitrary` instance for `PartialTx`.

### DIFF
--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2681,12 +2681,13 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
             , timelockKeyWitnessCounts = mempty
             }
       where
-        genExtraUTxO tx = do
-            let CardanoApi.Tx (CardanoApi.TxBody content) _ = tx
-            let inputs :: [CardanoApi.TxIn]
-                inputs = fst <$> CardanoApi.txIns content
+        genExtraUTxO tx =
             fmap (CardanoApi.UTxO . Map.fromList) . forM inputs $ \i ->
                 (i,) <$> genTxOut
+          where
+            CardanoApi.Tx (CardanoApi.TxBody content) _ = tx
+            inputs :: [CardanoApi.TxIn]
+            inputs = fst <$> CardanoApi.txIns content
         genTxOut =
             -- NOTE: genTxOut does not generate quantities larger than
             -- `maxBound :: Word64`, however users could supply these. We

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2676,7 +2676,7 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         let (CardanoApi.Tx (CardanoApi.TxBody content) _) = tx
         let inputs :: [CardanoApi.TxIn]
             inputs = fst <$> CardanoApi.txIns content
-        inputUTxO <- fmap (CardanoApi.UTxO . Map.fromList) . forM inputs $ \i ->
+        extraUTxO <- fmap (CardanoApi.UTxO . Map.fromList) . forM inputs $ \i ->
             do
                 -- NOTE: genTxOut does not generate quantities larger than
                 -- `maxBound :: Word64`, however users could supply these. We
@@ -2686,7 +2686,7 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
                 return (i, o)
         return PartialTx
             { tx = fromCardanoApiTx tx
-            , extraUTxO = fromCardanoApiUTxO inputUTxO
+            , extraUTxO = fromCardanoApiUTxO extraUTxO
             , redeemers = []
             , timelockKeyWitnessCounts = mempty
             }

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2683,11 +2683,10 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
                 -- code, if any, should validate.
                 o <- CardanoApi.genTxOut (cardanoEra @era)
                 return (fst i, o)
-        let redeemers = []
         return PartialTx
             { tx = fromCardanoApiTx tx
             , extraUTxO = fromCardanoApiUTxO inputUTxO
-            , redeemers
+            , redeemers = []
             , timelockKeyWitnessCounts = mempty
             }
     shrink partialTx@PartialTx {tx, extraUTxO} =

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2677,9 +2677,7 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         let inputs :: [CardanoApi.TxIn]
             inputs = fst <$> CardanoApi.txIns content
         extraUTxO <- fmap (CardanoApi.UTxO . Map.fromList) . forM inputs $ \i ->
-            do
-                o <- genTxOut
-                return (i, o)
+            (i,) <$> genTxOut
         return PartialTx
             { tx = fromCardanoApiTx tx
             , extraUTxO = fromCardanoApiUTxO extraUTxO

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2684,11 +2684,12 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
                 o <- CardanoApi.genTxOut (cardanoEra @era)
                 return (fst i, o)
         let redeemers = []
-        return $ PartialTx
-            (fromCardanoApiTx tx)
-            (fromCardanoApiUTxO inputUTxO)
-            (redeemers)
-            mempty
+        return PartialTx
+            { tx = fromCardanoApiTx tx
+            , extraUTxO = fromCardanoApiUTxO inputUTxO
+            , redeemers
+            , timelockKeyWitnessCounts = mempty
+            }
     shrink partialTx@PartialTx {tx, extraUTxO} =
         [ partialTx {extraUTxO = extraUTxO'}
         | extraUTxO' <- shrinkInputResolution extraUTxO

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2681,9 +2681,9 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
             , timelockKeyWitnessCounts = mempty
             }
       where
-        genExtraUTxO tx
-            = fmap (CardanoApi.UTxO . Map.fromList)
-            $ mapM (\i -> (i,) <$> genTxOut) inputs
+        genExtraUTxO tx =
+            CardanoApi.UTxO . Map.fromList <$>
+            mapM (\i -> (i,) <$> genTxOut) inputs
           where
             CardanoApi.Tx (CardanoApi.TxBody content) _ = tx
             inputs :: [CardanoApi.TxIn]

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2678,11 +2678,7 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
             inputs = fst <$> CardanoApi.txIns content
         extraUTxO <- fmap (CardanoApi.UTxO . Map.fromList) . forM inputs $ \i ->
             do
-                -- NOTE: genTxOut does not generate quantities larger than
-                -- `maxBound :: Word64`, however users could supply these. We
-                -- should ideally test what happens, and make it clear what
-                -- code, if any, should validate.
-                o <- CardanoApi.genTxOut (cardanoEra @era)
+                o <- genTxOut
                 return (i, o)
         return PartialTx
             { tx = fromCardanoApiTx tx
@@ -2690,6 +2686,13 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
             , redeemers = []
             , timelockKeyWitnessCounts = mempty
             }
+      where
+        genTxOut =
+            -- NOTE: genTxOut does not generate quantities larger than
+            -- `maxBound :: Word64`, however users could supply these. We
+            -- should ideally test what happens, and make it clear what
+            -- code, if any, should validate.
+            CardanoApi.genTxOut (cardanoEra @era)
     shrink partialTx@PartialTx {tx, extraUTxO} =
         [ partialTx {extraUTxO = extraUTxO'}
         | extraUTxO' <- shrinkInputResolution extraUTxO

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2673,7 +2673,7 @@ instance Arbitrary (MixedSign Value) where
 instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
     arbitrary = do
         tx <- CardanoApi.genTxForBalancing $ cardanoEra @era
-        let (CardanoApi.Tx (CardanoApi.TxBody content) _) = tx
+        let CardanoApi.Tx (CardanoApi.TxBody content) _ = tx
         let inputs :: [CardanoApi.TxIn]
             inputs = fst <$> CardanoApi.txIns content
         extraUTxO <- fmap (CardanoApi.UTxO . Map.fromList) . forM inputs $ \i ->

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2674,7 +2674,8 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
     arbitrary = do
         tx <- CardanoApi.genTxForBalancing $ cardanoEra @era
         let (CardanoApi.Tx (CardanoApi.TxBody content) _) = tx
-        let inputs = CardanoApi.txIns content
+        let inputs :: [CardanoApi.TxIn]
+            inputs = fst <$> CardanoApi.txIns content
         inputUTxO <- fmap (CardanoApi.UTxO . Map.fromList) . forM inputs $ \i ->
             do
                 -- NOTE: genTxOut does not generate quantities larger than
@@ -2682,7 +2683,7 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
                 -- should ideally test what happens, and make it clear what
                 -- code, if any, should validate.
                 o <- CardanoApi.genTxOut (cardanoEra @era)
-                return (fst i, o)
+                return (i, o)
         return PartialTx
             { tx = fromCardanoApiTx tx
             , extraUTxO = fromCardanoApiUTxO inputUTxO

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2683,17 +2683,16 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
       where
         genExtraUTxO tx =
             CardanoApi.UTxO . Map.fromList <$>
-            mapM
-                (\i -> (i,) <$> genTxOut)
-                (fst <$> CardanoApi.txIns content)
-          where
-            CardanoApi.Tx (CardanoApi.TxBody content) _ = tx
+            mapM (\i -> (i,) <$> genTxOut) (txInputs tx)
         genTxOut =
             -- NOTE: genTxOut does not generate quantities larger than
             -- `maxBound :: Word64`, however users could supply these. We
             -- should ideally test what happens, and make it clear what
             -- code, if any, should validate.
             CardanoApi.genTxOut (cardanoEra @era)
+        txInputs tx = fst <$> CardanoApi.txIns content
+          where
+            CardanoApi.Tx (CardanoApi.TxBody content) _ = tx
     shrink partialTx@PartialTx {tx, extraUTxO} =
         [ partialTx {extraUTxO = extraUTxO'}
         | extraUTxO' <- shrinkInputResolution extraUTxO

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2683,11 +2683,11 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
       where
         genExtraUTxO tx =
             CardanoApi.UTxO . Map.fromList <$>
-            mapM (\i -> (i,) <$> genTxOut) inputs
+            mapM
+                (\i -> (i,) <$> genTxOut)
+                (fst <$> CardanoApi.txIns content)
           where
             CardanoApi.Tx (CardanoApi.TxBody content) _ = tx
-            inputs :: [CardanoApi.TxIn]
-            inputs = fst <$> CardanoApi.txIns content
         genTxOut =
             -- NOTE: genTxOut does not generate quantities larger than
             -- `maxBound :: Word64`, however users could supply these. We

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2681,9 +2681,9 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
             , timelockKeyWitnessCounts = mempty
             }
       where
-        genExtraUTxO tx =
-            fmap (CardanoApi.UTxO . Map.fromList) . forM inputs $ \i ->
-                (i,) <$> genTxOut
+        genExtraUTxO tx
+            = fmap (CardanoApi.UTxO . Map.fromList)
+            $ mapM (\i -> (i,) <$> genTxOut) inputs
           where
             CardanoApi.Tx (CardanoApi.TxBody content) _ = tx
             inputs :: [CardanoApi.TxIn]


### PR DESCRIPTION
## Issue

ADP-3272

## Description

This PR clarifies the `Arbitrary` instance for `PartialTx`, making the following small improvements:
- Use of explicit field names when constructing a `PartialTx`:
    - `timelockKeyWitnessCounts = mempty` is (arguably) more self-documenting than `mempty` as a positional argument.
- Use of consistent terminology:
    - `extraUTxO` matches the field name used in `PartialTx`.
- Clearer data flow:
    - It's (arguably) clearer that the `extraUTxO` is generated exclusively from the result of generating a `tx`.