### PR TITLE
Add new `Balance.Size.{Coin,TokenBundle,Selection}` module hierarchy

### DIFF
--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -88,7 +88,7 @@ library internal
     Internal.Cardano.Write.Tx.Balance
     Internal.Cardano.Write.Tx.Balance.CoinSelection
     Internal.Cardano.Write.Tx.Balance.Size.Coin
-    Internal.Cardano.Write.Tx.Balance.TokenBundleSize
+    Internal.Cardano.Write.Tx.Balance.Size.TokenBundle
     Internal.Cardano.Write.Tx.Gen
     Internal.Cardano.Write.Tx.Redeemers
     Internal.Cardano.Write.Tx.Sign
@@ -161,8 +161,8 @@ test-suite test
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:
     Internal.Cardano.Write.Tx.Balance.CoinSelectionSpec
-    Internal.Cardano.Write.Tx.Balance.TokenBundleSizeSpec
     Internal.Cardano.Write.Tx.BalanceSpec
     Internal.Cardano.Write.Tx.Balance.Size.CoinSpec
+    Internal.Cardano.Write.Tx.Balance.Size.TokenBundleSpec
     Internal.Cardano.Write.TxSpec
     Spec

--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -89,10 +89,10 @@ library internal
     Internal.Cardano.Write.Tx.Balance.CoinSelection
     Internal.Cardano.Write.Tx.Balance.Size.Coin
     Internal.Cardano.Write.Tx.Balance.Size.TokenBundle
+    Internal.Cardano.Write.Tx.Balance.Size.Selection
     Internal.Cardano.Write.Tx.Gen
     Internal.Cardano.Write.Tx.Redeemers
     Internal.Cardano.Write.Tx.Sign
-    Internal.Cardano.Write.Tx.SizeEstimation
     Internal.Cardano.Write.Tx.TimeTranslation
     Internal.Cardano.Write.UTxOAssumptions
 

--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -87,6 +87,7 @@ library internal
     Internal.Cardano.Write.Tx
     Internal.Cardano.Write.Tx.Balance
     Internal.Cardano.Write.Tx.Balance.CoinSelection
+    Internal.Cardano.Write.Tx.Balance.Size.Coin
     Internal.Cardano.Write.Tx.Balance.TokenBundleSize
     Internal.Cardano.Write.Tx.Gen
     Internal.Cardano.Write.Tx.Redeemers
@@ -162,5 +163,6 @@ test-suite test
     Internal.Cardano.Write.Tx.Balance.CoinSelectionSpec
     Internal.Cardano.Write.Tx.Balance.TokenBundleSizeSpec
     Internal.Cardano.Write.Tx.BalanceSpec
+    Internal.Cardano.Write.Tx.Balance.Size.CoinSpec
     Internal.Cardano.Write.TxSpec
     Spec

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -227,6 +227,11 @@ import Internal.Cardano.Write.Tx.Balance.Size.Coin
     , TxFeeAndChange (..)
     , distributeSurplus
     )
+import Internal.Cardano.Write.Tx.Balance.Size.Selection
+    ( TxSkeleton (..)
+    , assumedTxWitnessTag
+    , estimateTxCost
+    )
 import Internal.Cardano.Write.Tx.Balance.Size.TokenBundle
     ( mkTokenBundleSizeAssessor
     )
@@ -239,11 +244,6 @@ import Internal.Cardano.Write.Tx.Sign
     ( TimelockKeyWitnessCounts (..)
     , estimateKeyWitnessCounts
     , estimateSignedTxSize
-    )
-import Internal.Cardano.Write.Tx.SizeEstimation
-    ( TxSkeleton (..)
-    , assumedTxWitnessTag
-    , estimateTxCost
     )
 import Internal.Cardano.Write.Tx.TimeTranslation
     ( TimeTranslation

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NoFieldSelectors #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE Rank2Types #-}
@@ -59,14 +58,6 @@ module Internal.Cardano.Write.Tx.Balance
     , TxFeeUpdate (..)
     , ErrUpdateTx (..)
 
-    -- ** distributeSurplus
-    , distributeSurplus
-    , distributeSurplusDelta
-    , sizeOfCoin
-    , maximumCostOfIncreasingCoin
-    , costOfIncreasingCoin
-    , TxFeeAndChange (..)
-    , ErrMoreSurplusNeeded (..)
     )
     where
 
@@ -177,9 +168,6 @@ import Data.Maybe
 import Data.Monoid.Monus
     ( Monus ((<\>))
     )
-import Data.Semigroup.Cancellative
-    ( Reductive ((</>))
-    )
 import Fmt
     ( Buildable
     , Builder
@@ -198,7 +186,6 @@ import Internal.Cardano.Write.Tx
     ( Address
     , AssetName
     , Coin (..)
-    , FeePerByte (..)
     , IsRecentEra (..)
     , KeyWitnessCounts (..)
     , PParams
@@ -235,6 +222,11 @@ import Internal.Cardano.Write.Tx.Balance.CoinSelection
     , toExternalUTxOMap
     , toInternalUTxOMap
     )
+import Internal.Cardano.Write.Tx.Balance.Size.Coin
+    ( ErrMoreSurplusNeeded (..)
+    , TxFeeAndChange (..)
+    , distributeSurplus
+    )
 import Internal.Cardano.Write.Tx.Balance.TokenBundleSize
     ( mkTokenBundleSizeAssessor
     )
@@ -260,6 +252,7 @@ import Internal.Cardano.Write.UTxOAssumptions
     ( UTxOAssumptions (..)
     , assumedInputScriptTemplate
     )
+
 import Numeric.Natural
     ( Natural
     )
@@ -304,7 +297,6 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (..)
     )
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
     ( UTxO (..)
     )
@@ -314,7 +306,6 @@ import qualified Data.Map as Map
 import qualified Data.Map.Strict.Extra as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
-
 -- | Indicates a failure to select a sufficient amount of collateral.
 --
 data ErrBalanceTxInsufficientCollateralError era =
@@ -1262,223 +1253,6 @@ modifyShelleyTxBody txUpdate =
     modifyFee old = case feeUpdate of
         UseNewTxFee c -> Convert.toLedger c
         UseOldTxFee -> old
-
---------------------------------------------------------------------------------
--- distributeSurplus
---------------------------------------------------------------------------------
-
--- | Indicates that it's impossible for 'distributeSurplus' to distribute a
--- surplus. As long as the surplus is larger than 'costOfIncreasingCoin', this
--- should never happen.
-newtype ErrMoreSurplusNeeded = ErrMoreSurplusNeeded W.Coin
-    deriving (Generic, Eq, Show)
-
--- | Small helper record to disambiguate between a fee and change Coin values.
--- Used by 'distributeSurplus'.
-data TxFeeAndChange change = TxFeeAndChange
-    { fee :: W.Coin
-    , change :: change
-    }
-    deriving (Eq, Show)
-
--- | Manipulates a 'TxFeeAndChange' value.
---
-mapTxFeeAndChange
-    :: (W.Coin -> W.Coin)
-    -- ^ A function to transform the fee
-    -> (change1 -> change2)
-    -- ^ A function to transform the change
-    -> TxFeeAndChange change1
-    -- ^ The original fee and change
-    -> TxFeeAndChange change2
-    -- ^ The transformed fee and change
-mapTxFeeAndChange mapFee mapChange TxFeeAndChange {fee, change} =
-    TxFeeAndChange (mapFee fee) (mapChange change)
-
--- | Calculate the cost of increasing a CBOR-encoded Coin-value by another Coin
--- with the lovelace/byte cost given by the 'FeePolicy'.
---
--- Outputs values in the range of [0, 8 * perByteFee]
---
--- >>> let p = FeePolicy (Quantity 0) (Quantity 44)
---
--- >>> costOfIncreasingCoin p 4294967295 1
--- Coin 176 -- (9 bytes - 5 bytes) * 44 lovelace/byte
---
--- >>> costOfIncreasingCoin p 0 4294967296
--- Coin 352 -- 8 bytes * 44 lovelace/byte
-costOfIncreasingCoin
-    :: FeePerByte
-    -> W.Coin -- ^ Original coin
-    -> W.Coin -- ^ Increment
-    -> W.Coin
-costOfIncreasingCoin (FeePerByte perByte) from delta =
-    costOfCoin (from <> delta) <\> costOfCoin from
-  where
-    costOfCoin = W.Coin . (perByte *) . W.unTxSize . sizeOfCoin
-
--- The maximum cost increase 'costOfIncreasingCoin' can return, which is the
--- cost of 8 bytes.
-maximumCostOfIncreasingCoin :: FeePerByte -> W.Coin
-maximumCostOfIncreasingCoin (FeePerByte perByte) = W.Coin $ 8 * perByte
-
--- | Calculate the size of a coin when encoded as CBOR.
-sizeOfCoin :: W.Coin -> W.TxSize
-sizeOfCoin (W.Coin c)
-    | c >= 4_294_967_296 = W.TxSize 9 -- c >= 2^32
-    | c >=        65_536 = W.TxSize 5 -- c >= 2^16
-    | c >=           256 = W.TxSize 3 -- c >= 2^ 8
-    | c >=            24 = W.TxSize 2
-    | otherwise          = W.TxSize 1
-
--- | Distributes a surplus transaction balance between the given change
--- outputs and the given fee. This function is aware of the fact that
--- any increase in a 'Coin' value could increase the size and fee
--- requirement of a transaction.
---
--- When comparing the original fee and change outputs to the adjusted
--- fee and change outputs, this function guarantees that:
---
---    - The number of the change outputs remains constant;
---
---    - The fee quantity either remains the same or increases.
---
---    - For each change output:
---        - the ada quantity either remains constant or increases.
---        - non-ada quantities remain the same.
---
---    - The surplus is conserved:
---        The total increase in the fee and change ada quantities is
---        exactly equal to the surplus.
---
---    - Any increase in cost is covered:
---        If the total cost has increased by 𝛿c, then the fee value
---        will have increased by at least 𝛿c.
---
--- If the cost of distributing the provided surplus is greater than the
--- surplus itself, the function will return 'ErrMoreSurplusNeeded'. If
--- the provided surplus is greater or equal to
--- @maximumCostOfIncreasingCoin feePolicy@, the function will always
--- return 'Right'.
-distributeSurplus
-    :: FeePerByte
-    -> W.Coin
-    -- ^ Surplus transaction balance to distribute.
-    -> TxFeeAndChange [W.TxOut]
-    -- ^ Original fee and change outputs.
-    -> Either ErrMoreSurplusNeeded (TxFeeAndChange [W.TxOut])
-    -- ^ Adjusted fee and change outputs.
-distributeSurplus feePolicy surplus fc@(TxFeeAndChange fee change) =
-    distributeSurplusDelta feePolicy surplus
-        (mapTxFeeAndChange id (fmap W.TxOut.coin) fc)
-    <&> mapTxFeeAndChange
-        (fee <>)
-        (zipWith (flip W.TxOut.addCoin) change)
-
-distributeSurplusDelta
-    :: FeePerByte
-    -> W.Coin
-    -- ^ Surplus to distribute
-    -> TxFeeAndChange [W.Coin]
-    -> Either ErrMoreSurplusNeeded (TxFeeAndChange [W.Coin])
-distributeSurplusDelta feePolicy surplus (TxFeeAndChange fee change) =
-    case change of
-        changeHead : changeTail ->
-            distributeSurplusDeltaWithOneChangeCoin feePolicy surplus
-                (TxFeeAndChange fee changeHead)
-            <&> mapTxFeeAndChange id
-                (: (W.Coin 0 <$ changeTail))
-        [] ->
-            burnSurplusAsFees feePolicy surplus
-                (TxFeeAndChange fee ())
-            <&> mapTxFeeAndChange id
-                (\() -> [])
-
-distributeSurplusDeltaWithOneChangeCoin
-    :: FeePerByte
-    -> W.Coin -- ^ Surplus to distribute
-    -> TxFeeAndChange W.Coin
-    -> Either ErrMoreSurplusNeeded (TxFeeAndChange W.Coin)
-distributeSurplusDeltaWithOneChangeCoin
-    feePolicy surplus fc@(TxFeeAndChange fee0 change0) =
-    let
-        -- We calculate the maximum possible fee increase, by assuming the
-        -- **entire** surplus is added to the change.
-        extraFee = findFixpointIncreasingFeeBy $
-            costOfIncreasingCoin feePolicy change0 surplus
-    in
-        case surplus </> extraFee of
-            Just extraChange ->
-                Right $ TxFeeAndChange
-                    { fee = extraFee
-                    , change = extraChange
-                    }
-            Nothing ->
-                -- The fee increase from adding the surplus to the change was
-                -- greater than the surplus itself. This could happen if the
-                -- surplus is small.
-                burnSurplusAsFees feePolicy surplus
-                    (mapTxFeeAndChange id (const ()) fc)
-                        <&> mapTxFeeAndChange id (\() -> W.Coin 0)
-  where
-    -- Increasing the fee may itself increase the fee. If that is the case, this
-    -- function will increase the fee further. The process repeats until the fee
-    -- doesn't need to be increased.
-    --
-    -- The function will always converge because the result of
-    -- 'costOfIncreasingCoin' is bounded to @8 * feePerByte@.
-    --
-    -- On mainnet it seems unlikely that the function would recurse more than
-    -- one time, and certainly not more than twice. If the protocol parameters
-    -- are updated to allow for slightly more expensive txs, it might be
-    -- possible to hit the boundary at ≈4 ada where the fee would need 9 bytes
-    -- rather than 5. This is already the largest boundary.
-    --
-    -- Note that both the argument and the result of this function are increases
-    -- relative to 'fee0'.
-    --
-    -- == Example ==
-    --
-    -- In this more extreme example the fee is increased from increasing the fee
-    -- itself:
-    --
-    -- @@
-    --     let fee0 = 23
-    --     let feePolicy = -- 300 lovelace / byte
-    --
-    --     findFixpointIncreasingFeeBy 1 = go 0 1
-    --     -- Recurse:
-    --     = go (0 + 1) (costOfIncreasingCoin feePolicy (23 + 0) 1)
-    --     = go (0 + 1) 300
-    --     -- Recurse:
-    --     = go (1 + 300) (costOfIncreasingCoin feePolicy (23 + 1) 300)
-    --     = go 301 300
-    --     = go (301 + 300) (costOfIncreasingCoin feePolicy (23 + 301) 300)
-    --     = go (301 + 300) 0
-    --     = go 601 0
-    --     = 601
-    -- @@
-    findFixpointIncreasingFeeBy = go mempty
-      where
-        go :: W.Coin -> W.Coin -> W.Coin
-        go c (W.Coin 0) = c
-        go c increase = go
-            (c <> increase)
-            (costOfIncreasingCoin feePolicy (c <> fee0) increase)
-
-burnSurplusAsFees
-    :: FeePerByte
-    -> W.Coin -- Surplus
-    -> TxFeeAndChange ()
-    -> Either ErrMoreSurplusNeeded (TxFeeAndChange ())
-burnSurplusAsFees feePolicy surplus (TxFeeAndChange fee0 ())
-    | shortfall > W.Coin 0 =
-        Left $ ErrMoreSurplusNeeded shortfall
-    | otherwise =
-        Right $ TxFeeAndChange surplus ()
-  where
-    costOfBurningSurplus = costOfIncreasingCoin feePolicy fee0 surplus
-    shortfall = costOfBurningSurplus <\> surplus
 
 toLedgerTxOut
     :: HasCallStack

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -227,7 +227,7 @@ import Internal.Cardano.Write.Tx.Balance.Size.Coin
     , TxFeeAndChange (..)
     , distributeSurplus
     )
-import Internal.Cardano.Write.Tx.Balance.TokenBundleSize
+import Internal.Cardano.Write.Tx.Balance.Size.TokenBundle
     ( mkTokenBundleSizeAssessor
     )
 import Internal.Cardano.Write.Tx.Redeemers

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/Size/Coin.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/Size/Coin.hs
@@ -1,0 +1,255 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+module Internal.Cardano.Write.Tx.Balance.Size.Coin
+    ( sizeOfCoin
+    , costOfIncreasingCoin
+    , maximumCostOfIncreasingCoin
+
+    -- * distributeSurplus
+    , distributeSurplus
+    , TxFeeAndChange (..)
+    , ErrMoreSurplusNeeded (..)
+
+    -- ** Internals
+    , distributeSurplusDelta
+    )
+    where
+
+import Prelude
+
+import Data.Functor
+    ( (<&>)
+    )
+import Data.Monoid.Cancellative
+    ( (</>)
+    )
+import Data.Monoid.Monus
+    ( (<\>)
+    )
+import GHC.Generics
+    ( Generic
+    )
+import Internal.Cardano.Write.Tx
+    ( FeePerByte (..)
+    )
+
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
+
+-- | Indicates that it's impossible for 'distributeSurplus' to distribute a
+-- surplus. As long as the surplus is larger than 'costOfIncreasingCoin', this
+-- should never happen.
+newtype ErrMoreSurplusNeeded = ErrMoreSurplusNeeded W.Coin
+    deriving (Generic, Eq, Show)
+
+-- | Small helper record to disambiguate between a fee and change Coin values.
+-- Used by 'distributeSurplus'.
+data TxFeeAndChange change = TxFeeAndChange
+    { fee :: W.Coin
+    , change :: change
+    }
+    deriving (Eq, Show)
+
+-- | Manipulates a 'TxFeeAndChange' value.
+--
+mapTxFeeAndChange
+    :: (W.Coin -> W.Coin)
+    -- ^ A function to transform the fee
+    -> (change1 -> change2)
+    -- ^ A function to transform the change
+    -> TxFeeAndChange change1
+    -- ^ The original fee and change
+    -> TxFeeAndChange change2
+    -- ^ The transformed fee and change
+mapTxFeeAndChange mapFee mapChange TxFeeAndChange{fee, change} =
+    TxFeeAndChange (mapFee fee) (mapChange change)
+
+-- | Calculate the cost of increasing a CBOR-encoded Coin-value by another Coin
+-- with the lovelace/byte cost given by the 'FeePolicy'.
+--
+-- Outputs values in the range of [0, 8 * perByteFee]
+--
+-- >>> let p = FeePolicy (Quantity 0) (Quantity 44)
+--
+-- >>> costOfIncreasingCoin p 4294967295 1
+-- Coin 176 -- (9 bytes - 5 bytes) * 44 lovelace/byte
+--
+-- >>> costOfIncreasingCoin p 0 4294967296
+-- Coin 352 -- 8 bytes * 44 lovelace/byte
+costOfIncreasingCoin
+    :: FeePerByte
+    -> W.Coin -- ^ Original coin
+    -> W.Coin -- ^ Increment
+    -> W.Coin
+costOfIncreasingCoin (FeePerByte perByte) from delta =
+    costOfCoin (from <> delta) <\> costOfCoin from
+  where
+    costOfCoin = W.Coin . (perByte *) . W.unTxSize . sizeOfCoin
+
+-- The maximum cost increase 'costOfIncreasingCoin' can return, which is the
+-- cost of 8 bytes.
+maximumCostOfIncreasingCoin :: FeePerByte -> W.Coin
+maximumCostOfIncreasingCoin (FeePerByte perByte) = W.Coin $ 8 * perByte
+
+-- | Calculate the size of a coin when encoded as CBOR.
+sizeOfCoin :: W.Coin -> W.TxSize
+sizeOfCoin (W.Coin c)
+    | c >= 4_294_967_296 = W.TxSize 9 -- c >= 2^32
+    | c >=        65_536 = W.TxSize 5 -- c >= 2^16
+    | c >=           256 = W.TxSize 3 -- c >= 2^ 8
+    | c >=            24 = W.TxSize 2
+    | otherwise          = W.TxSize 1
+
+-- | Distributes a surplus transaction balance between the given change
+-- outputs and the given fee. This function is aware of the fact that
+-- any increase in a 'Coin' value could increase the size and fee
+-- requirement of a transaction.
+--
+-- When comparing the original fee and change outputs to the adjusted
+-- fee and change outputs, this function guarantees that:
+--
+--    - The number of the change outputs remains constant;
+--
+--    - The fee quantity either remains the same or increases.
+--
+--    - For each change output:
+--        - the ada quantity either remains constant or increases.
+--        - non-ada quantities remain the same.
+--
+--    - The surplus is conserved:
+--        The total increase in the fee and change ada quantities is
+--        exactly equal to the surplus.
+--
+--    - Any increase in cost is covered:
+--        If the total cost has increased by ??c, then the fee value
+--        will have increased by at least ??c.
+--
+-- If the cost of distributing the provided surplus is greater than the
+-- surplus itself, the function will return 'ErrMoreSurplusNeeded'. If
+-- the provided surplus is greater or equal to
+-- @maximumCostOfIncreasingCoin feePolicy@, the function will always
+-- return 'Right'.
+distributeSurplus
+    :: FeePerByte
+    -> W.Coin
+    -- ^ Surplus transaction balance to distribute.
+    -> TxFeeAndChange [W.TxOut]
+    -- ^ Original fee and change outputs.
+    -> Either ErrMoreSurplusNeeded (TxFeeAndChange [W.TxOut])
+    -- ^ Adjusted fee and change outputs.
+distributeSurplus feePolicy surplus fc@(TxFeeAndChange fee change) =
+    distributeSurplusDelta feePolicy surplus
+        (mapTxFeeAndChange id (fmap W.TxOut.coin) fc)
+    <&> mapTxFeeAndChange
+        (fee <>)
+        (zipWith (flip W.TxOut.addCoin) change)
+
+distributeSurplusDelta
+    :: FeePerByte
+    -> W.Coin
+    -- ^ Surplus to distribute
+    -> TxFeeAndChange [W.Coin]
+    -> Either ErrMoreSurplusNeeded (TxFeeAndChange [W.Coin])
+distributeSurplusDelta feePolicy surplus (TxFeeAndChange fee change) =
+    case change of
+        changeHead : changeTail ->
+            distributeSurplusDeltaWithOneChangeCoin feePolicy surplus
+                (TxFeeAndChange fee changeHead)
+            <&> mapTxFeeAndChange id
+                (: (W.Coin 0 <$ changeTail))
+        [] ->
+            burnSurplusAsFees feePolicy surplus
+                (TxFeeAndChange fee ())
+            <&> mapTxFeeAndChange id
+                (\() -> [])
+
+distributeSurplusDeltaWithOneChangeCoin
+    :: FeePerByte
+    -> W.Coin -- ^ Surplus to distribute
+    -> TxFeeAndChange W.Coin
+    -> Either ErrMoreSurplusNeeded (TxFeeAndChange W.Coin)
+distributeSurplusDeltaWithOneChangeCoin
+    feePolicy surplus fc@(TxFeeAndChange fee0 change0) =
+    let
+        -- We calculate the maximum possible fee increase, by assuming the
+        -- **entire** surplus is added to the change.
+        extraFee = findFixpointIncreasingFeeBy $
+            costOfIncreasingCoin feePolicy change0 surplus
+    in
+        case surplus </> extraFee of
+            Just extraChange ->
+                Right $ TxFeeAndChange
+                    { fee = extraFee
+                    , change = extraChange
+                    }
+            Nothing ->
+                -- The fee increase from adding the surplus to the change was
+                -- greater than the surplus itself. This could happen if the
+                -- surplus is small.
+                burnSurplusAsFees feePolicy surplus
+                    (mapTxFeeAndChange id (const ()) fc)
+                        <&> mapTxFeeAndChange id (\() -> W.Coin 0)
+  where
+    -- Increasing the fee may itself increase the fee. If that is the case, this
+    -- function will increase the fee further. The process repeats until the fee
+    -- doesn't need to be increased.
+    --
+    -- The function will always converge because the result of
+    -- 'costOfIncreasingCoin' is bounded to @8 * feePerByte@.
+    --
+    -- On mainnet it seems unlikely that the function would recurse more than
+    -- one time, and certainly not more than twice. If the protocol parameters
+    -- are updated to allow for slightly more expensive txs, it might be
+    -- possible to hit the boundary at Å4 ada where the fee would need 9 bytes
+    -- rather than 5. This is already the largest boundary.
+    --
+    -- Note that both the argument and the result of this function are increases
+    -- relative to 'fee0'.
+    --
+    -- == Example ==
+    --
+    -- In this more extreme example the fee is increased from increasing the fee
+    -- itself:
+    --
+    -- @@
+    --     let fee0 = 23
+    --     let feePolicy = -- 300 lovelace / byte
+    --
+    --     findFixpointIncreasingFeeBy 1 = go 0 1
+    --     -- Recurse:
+    --     = go (0 + 1) (costOfIncreasingCoin feePolicy (23 + 0) 1)
+    --     = go (0 + 1) 300
+    --     -- Recurse:
+    --     = go (1 + 300) (costOfIncreasingCoin feePolicy (23 + 1) 300)
+    --     = go 301 300
+    --     = go (301 + 300) (costOfIncreasingCoin feePolicy (23 + 301) 300)
+    --     = go (301 + 300) 0
+    --     = go 601 0
+    --     = 601
+    -- @@
+    findFixpointIncreasingFeeBy = go mempty
+      where
+        go :: W.Coin -> W.Coin -> W.Coin
+        go c (W.Coin 0) = c
+        go c increase = go
+            (c <> increase)
+            (costOfIncreasingCoin feePolicy (c <> fee0) increase)
+
+burnSurplusAsFees
+    :: FeePerByte
+    -> W.Coin -- Surplus
+    -> TxFeeAndChange ()
+    -> Either ErrMoreSurplusNeeded (TxFeeAndChange ())
+burnSurplusAsFees feePolicy surplus (TxFeeAndChange fee0 ())
+    | shortfall > W.Coin 0 =
+        Left $ ErrMoreSurplusNeeded shortfall
+    | otherwise =
+        Right $ TxFeeAndChange surplus ()
+  where
+    costOfBurningSurplus = costOfIncreasingCoin feePolicy fee0 surplus
+    shortfall = costOfBurningSurplus <\> surplus
+

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/Size/Coin.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/Size/Coin.hs
@@ -258,4 +258,3 @@ burnSurplusAsFees feePolicy surplus (TxFeeAndChange fee0 ())
   where
     costOfBurningSurplus = costOfIncreasingCoin feePolicy fee0 surplus
     shortfall = costOfBurningSurplus <\> surplus
-

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/Size/Coin.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/Size/Coin.hs
@@ -2,6 +2,12 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+-- The main purpose of this module is containing 'distributeSurplus', which is
+-- needed by 'balanceTransaction'.
 module Internal.Cardano.Write.Tx.Balance.Size.Coin
     ( sizeOfCoin
     , costOfIncreasingCoin

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/Size/Selection.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/Size/Selection.hs
@@ -22,7 +22,7 @@
 --
 -- Module containing logic relating to size estimation as needed, mainly for
 -- the purpose of coin selection.
-module Internal.Cardano.Write.Tx.SizeEstimation
+module Internal.Cardano.Write.Tx.Balance.Size.Selection
     ( -- * Needed for normal coin selection for balanceTx
       estimateTxSize
     , estimateTxCost

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/Size/TokenBundle.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/Size/TokenBundle.hs
@@ -1,5 +1,5 @@
 -- | Assessing sizes of token bundles
-module Internal.Cardano.Write.Tx.Balance.TokenBundleSize
+module Internal.Cardano.Write.Tx.Balance.Size.TokenBundle
     ( TokenBundleSizeAssessor (..)
     , mkTokenBundleSizeAssessor
     , computeTokenBundleSerializedLengthBytes

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/Size/CoinSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/Size/CoinSpec.hs
@@ -548,7 +548,6 @@ instance Arbitrary (TxBalanceSurplus W.Coin) where
         ]
     shrink = shrinkMapBy TxBalanceSurplus unTxBalanceSurplus W.shrinkCoin
 
-
 instance Arbitrary (TxFeeAndChange [W.TxOut]) where
     arbitrary = do
         fee <- W.genCoin
@@ -575,4 +574,3 @@ instance Arbitrary FeePerByte where
         ]
     shrink (FeePerByte x) =
         FeePerByte <$> shrinkNatural x
-

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/Size/CoinSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/Size/CoinSpec.hs
@@ -1,0 +1,578 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NoNumericUnderscores #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+{- HLINT ignore "Use null" -}
+
+module Internal.Cardano.Write.Tx.Balance.Size.CoinSpec where
+
+import Prelude
+
+import Cardano.Numeric.Util
+    ( power
+    )
+import Data.Either
+    ( isLeft
+    , isRight
+    )
+import Data.Function
+    ( (&)
+    )
+import Data.Generics.Internal.VL.Lens
+    ( view
+    )
+import Data.Maybe
+    ( fromMaybe
+    )
+import Data.Monoid.Monus
+    ( Monus ((<\>))
+    )
+import Internal.Cardano.Write.Tx
+    ( FeePerByte (..)
+    )
+import Internal.Cardano.Write.Tx.Balance.Size.Coin
+    ( ErrMoreSurplusNeeded (..)
+    , TxFeeAndChange (..)
+    , costOfIncreasingCoin
+    , distributeSurplus
+    , distributeSurplusDelta
+    , maximumCostOfIncreasingCoin
+    , sizeOfCoin
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Property
+    , Testable
+    , arbitrarySizedNatural
+    , checkCoverage
+    , conjoin
+    , counterexample
+    , cover
+    , forAll
+    , frequency
+    , liftShrink2
+    , listOf
+    , property
+    , scale
+    , shrinkList
+    , shrinkMapBy
+    , withMaxSuccess
+    , (===)
+    )
+import Test.QuickCheck.Extra
+    ( report
+    , shrinkNatural
+    )
+
+import qualified Cardano.Api as CardanoApi
+import qualified Cardano.Api.Gen as CardanoApi
+import qualified Cardano.Api.Shelley as CardanoApi
+import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+    ( Coin (..)
+    )
+import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
+import qualified Cardano.Wallet.Primitive.Types.Coin.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as W
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Write as CBOR
+import qualified Data.ByteString as BS
+import qualified Data.Foldable as F
+
+spec :: Spec
+spec = do
+    describe "sizeOfCoin" $ do
+        let coinToWord64Clamped = fromMaybe maxBound . W.Coin.toWord64Maybe
+        let cborSizeOfCoin =
+                W.TxSize
+                . fromIntegral
+                . BS.length
+                . CBOR.toStrictByteString
+                . CBOR.encodeWord64 . coinToWord64Clamped
+
+        let isBoundary c =
+                sizeOfCoin c /= sizeOfCoin (c <\> W.Coin 1)
+                || sizeOfCoin c /= sizeOfCoin (c <> W.Coin 1)
+
+        it "matches the size of the Word64 CBOR encoding" $
+            property $ checkCoverage $
+                forAll CardanoApi.genEncodingBoundaryLovelace $ \l -> do
+                    let c = cardanoToWalletCoin l
+                    let expected = cborSizeOfCoin c
+
+                    -- Use a low coverage requirement of 0.01% just to
+                    -- ensure we see /some/ amount of every size.
+                    let coverSize s = cover 0.01 (s == expected) (show s)
+                    sizeOfCoin c === expected
+                        & coverSize (W.TxSize 1)
+                        & coverSize (W.TxSize 2)
+                        & coverSize (W.TxSize 3)
+                        & coverSize (W.TxSize 5)
+                        & coverSize (W.TxSize 9)
+                        & cover 0.5 (isBoundary c) "boundary case"
+
+        describe "boundary case goldens" $ do
+            it "1 byte to 2 byte boundary" $ do
+                sizeOfCoin (W.Coin 23) `shouldBe` W.TxSize 1
+                sizeOfCoin (W.Coin 24) `shouldBe` W.TxSize 2
+            it "2 byte to 3 byte boundary" $ do
+                sizeOfCoin (W.Coin $ 2 `power` 8 - 1) `shouldBe` W.TxSize 2
+                sizeOfCoin (W.Coin $ 2 `power` 8    ) `shouldBe` W.TxSize 3
+            it "3 byte to 5 byte boundary" $ do
+                sizeOfCoin (W.Coin $ 2 `power` 16 - 1) `shouldBe` W.TxSize 3
+                sizeOfCoin (W.Coin $ 2 `power` 16    ) `shouldBe` W.TxSize 5
+            it "5 byte to 9 byte boundary" $ do
+                sizeOfCoin (W.Coin $ 2 `power` 32 - 1) `shouldBe` W.TxSize 5
+                sizeOfCoin (W.Coin $ 2 `power` 32    ) `shouldBe` W.TxSize 9
+
+    describe "costOfIncreasingCoin" $ do
+        it "costs 176 lovelace to increase 4294.967295 ada (2^32 - 1 lovelace) \
+           \by 1 lovelace on mainnet" $ do
+
+            let expectedCostIncrease = W.Coin 176
+            let mainnet = mainnetFeePerByte
+            costOfIncreasingCoin mainnet (W.Coin $ 2 `power` 32 - 1) (W.Coin 1)
+                `shouldBe` expectedCostIncrease
+
+        it "produces results in the range [0, 8 * feePerByte]" $
+            property $ \c increase -> do
+                let res = costOfIncreasingCoin (FeePerByte 1) c increase
+                counterexample (show res <> "out of bounds") $
+                    res >= W.Coin 0 && res <= W.Coin 8
+
+    describe "distributeSurplus" $ do
+
+        it "prop_distributeSurplus_onSuccess_conservesSurplus" $
+            prop_distributeSurplus_onSuccess_conservesSurplus
+                & property
+        it "prop_distributeSurplus_onSuccess_coversCostIncrease" $
+            prop_distributeSurplus_onSuccess_coversCostIncrease
+                & property
+        it "prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues" $
+            prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues
+                & property
+        it "prop_distributeSurplus_onSuccess_doesNotReduceFeeValue" $
+            prop_distributeSurplus_onSuccess_doesNotReduceFeeValue
+                & property
+        it "prop_distributeSurplus_onSuccess_preservesChangeLength" $
+            prop_distributeSurplus_onSuccess_preservesChangeLength
+                & property
+        it "prop_distributeSurplus_onSuccess_preservesChangeAddresses" $
+            prop_distributeSurplus_onSuccess_preservesChangeAddresses
+                & property
+        it "prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets" $
+            prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets
+                & property
+        it "prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue" $
+            prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue
+                & property
+        it "prop_distributeSurplus_onSuccess_increasesValuesByDelta" $
+            prop_distributeSurplus_onSuccess_increasesValuesByDelta
+                & property
+
+    describe "distributeSurplusDelta" $ do
+
+        -- NOTE: The test values below make use of 255 being encoded as 2 bytes,
+        -- and 256 as 3 bytes.
+
+        describe "when increasing change increases fee" $
+            it "will increase fee (99 lovelace for change, 1 for fee)" $
+                distributeSurplusDelta
+                    (FeePerByte 1)
+                    (W.Coin 100)
+                    (TxFeeAndChange (W.Coin 200) [W.Coin 200])
+                    `shouldBe`
+                    Right (TxFeeAndChange (W.Coin 1) [W.Coin 99])
+
+        describe "when increasing fee increases fee" $
+            it "will increase fee (98 lovelace for change, 2 for fee)" $ do
+                distributeSurplusDelta
+                    (FeePerByte 1)
+                    (W.Coin 100)
+                    (TxFeeAndChange (W.Coin 255) [W.Coin 200])
+                    `shouldBe`
+                    Right (TxFeeAndChange (W.Coin 2) [W.Coin 98])
+
+        describe
+            (unwords
+                [ "when increasing the change costs more in fees than the"
+                , "increase itself"
+                ]) $ do
+            it "will try burning the surplus as fees" $ do
+                distributeSurplusDelta
+                    mainnetFeePerByte
+                    (W.Coin 10)
+                    (TxFeeAndChange (W.Coin 200) [W.Coin 255])
+                    `shouldBe`
+                    Right (TxFeeAndChange (W.Coin 10) [W.Coin 0])
+
+            it "will fail if neither the fee can be increased" $ do
+                distributeSurplusDelta
+                    mainnetFeePerByte
+                    (W.Coin 10)
+                    (TxFeeAndChange (W.Coin 255) [W.Coin 255])
+                    `shouldBe`
+                    Left (ErrMoreSurplusNeeded $ W.Coin 34)
+
+        describe "when no change output is present" $ do
+            it "will burn surplus as excess fees" $
+                property $ \surplus fee0 -> do
+                    distributeSurplusDelta
+                        (FeePerByte 1)
+                        surplus
+                        (TxFeeAndChange fee0 [])
+                        `shouldBe`
+                        Right (TxFeeAndChange surplus [])
+
+        it "prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus" $
+            prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
+                & withMaxSuccess 10_000
+                & property
+
+-- A helper function to generate properties for 'distributeSurplus' on
+-- success.
+--
+prop_distributeSurplus_onSuccess
+    :: Testable prop
+    => (FeePerByte
+        -> W.Coin
+        -> TxFeeAndChange [W.TxOut]
+        -> TxFeeAndChange [W.TxOut]
+        -> prop)
+    -> FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess propertyToTest policy txSurplus fc =
+    checkCoverage $
+    cover 50
+        (isRight mResult)
+        "isRight mResult" $
+    cover 10
+        (length changeOriginal == 0)
+        "length changeOriginal == 0" $
+    cover 10
+        (length changeOriginal == 1)
+        "length changeOriginal == 1" $
+    cover 50
+        (length changeOriginal >= 2)
+        "length changeOriginal >= 2" $
+    cover 2
+        (feeOriginal == W.Coin 0)
+        "feeOriginal == W.Coin 0" $
+    cover 2
+        (feeOriginal == W.Coin 1)
+        "feeOriginal == W.Coin 1" $
+    cover 50
+        (feeOriginal >= W.Coin 2)
+        "feeOriginal >= W.Coin 2" $
+    cover 1
+        (surplus == W.Coin 0)
+        "surplus == W.Coin 0" $
+    cover 1
+        (surplus == W.Coin 1)
+        "surplus == W.Coin 1" $
+    cover 50
+        (surplus >= W.Coin 2)
+        "surplus >= W.Coin 2" $
+    either
+        (const $ property True)
+        (property . propertyToTest policy surplus fc)
+        mResult
+  where
+    TxBalanceSurplus surplus = txSurplus
+    TxFeeAndChange feeOriginal changeOriginal = fc
+
+    mResult :: Either ErrMoreSurplusNeeded (TxFeeAndChange [W.TxOut])
+    mResult = distributeSurplus policy surplus fc
+
+-- Verifies that the 'distributeSurplus' function conserves the surplus: the
+-- total increase in the fee and change ada quantities should be exactly equal
+-- to the given surplus.
+--
+prop_distributeSurplus_onSuccess_conservesSurplus
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_conservesSurplus =
+    prop_distributeSurplus_onSuccess $ \_policy surplus
+        (TxFeeAndChange feeOriginal changeOriginal)
+        (TxFeeAndChange feeModified changeModified) ->
+        surplus ===
+            (feeModified <> F.foldMap W.TxOut.coin changeModified)
+            <\>
+            (feeOriginal <> F.foldMap W.TxOut.coin changeOriginal)
+
+-- The 'distributeSurplus' function should cover the cost of any increases in
+-- 'Coin' values.
+--
+-- If the total cost of encoding ada quantities has increased by 𝛿c, then the
+-- fee value should have increased by at least 𝛿c.
+--
+prop_distributeSurplus_onSuccess_coversCostIncrease
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_coversCostIncrease =
+    prop_distributeSurplus_onSuccess $ \policy _surplus
+        (TxFeeAndChange feeOriginal changeOriginal)
+        (TxFeeAndChange feeModified changeModified) -> do
+        let coinsOriginal = feeOriginal : (W.TxOut.coin <$> changeOriginal)
+        let coinsModified = feeModified : (W.TxOut.coin <$> changeModified)
+        let coinDeltas = zipWith (<\>) coinsModified coinsOriginal
+        let costIncrease = F.foldMap
+                (uncurry $ costOfIncreasingCoin policy)
+                (coinsOriginal `zip` coinDeltas)
+        feeModified <\> feeOriginal >= costIncrease
+            & report feeModified "feeModified"
+            & report feeOriginal "feeOriginal"
+            & report costIncrease "costIncrease"
+
+-- Since the 'distributeSurplus' function is not aware of the minimum ada
+-- quantity or how to calculate it, it should never allow change ada values to
+-- decrease.
+--
+prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues =
+    prop_distributeSurplus_onSuccess $ \_policy _surplus
+        (TxFeeAndChange _feeOriginal changeOriginal)
+        (TxFeeAndChange _feeModified changeModified) ->
+            all (uncurry (<=)) $ zip
+                (W.TxOut.coin <$> changeOriginal)
+                (W.TxOut.coin <$> changeModified)
+
+-- The 'distributeSurplus' function should never return a 'fee' value that is
+-- less than the original value.
+--
+prop_distributeSurplus_onSuccess_doesNotReduceFeeValue
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_doesNotReduceFeeValue =
+    prop_distributeSurplus_onSuccess $ \_policy _surplus
+        (TxFeeAndChange feeOriginal _changeOriginal)
+        (TxFeeAndChange feeModified _changeModified) ->
+            feeOriginal <= feeModified
+
+-- The 'distributeSurplus' function should increase values by the exact amounts
+-- indicated in 'distributeSurplusDelta'.
+--
+-- This is actually an implementation detail of 'distributeSurplus'.
+--
+-- However, it's useful to verify that this is true by subtracting the delta
+-- values from the result of 'distributeSurplus', which should produce the
+-- original fee and change values.
+--
+prop_distributeSurplus_onSuccess_increasesValuesByDelta
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_increasesValuesByDelta =
+    prop_distributeSurplus_onSuccess $ \policy surplus
+        (TxFeeAndChange feeOriginal changeOriginal)
+        (TxFeeAndChange feeModified changeModified) ->
+            let (TxFeeAndChange feeDelta changeDeltas) =
+                    either (error . show) id
+                    $ distributeSurplusDelta policy surplus
+                    $ TxFeeAndChange
+                        (feeOriginal)
+                        (W.TxOut.coin <$> changeOriginal)
+            in
+            (TxFeeAndChange
+                (feeModified <\> feeDelta)
+                (zipWith W.TxOut.subtractCoin changeDeltas changeModified)
+            )
+            ===
+            TxFeeAndChange feeOriginal changeOriginal
+
+-- The 'distributeSurplus' function should only adjust the very first change
+-- value.  All other change values should be left untouched.
+--
+-- This is actually an implementation detail of 'distributeSurplus'.
+--
+-- In principle, 'distributeSurplus' could allow itself to adjust any of the
+-- change values in order to find a (marginally) more optimal solution.
+-- However, for reasons of simplicity, we only adjust the first change value.
+--
+-- Here we verify that the implementation indeed only adjusts the first change
+-- value, as expected.
+--
+prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue =
+    prop_distributeSurplus_onSuccess $ \_policy _surplus
+        (TxFeeAndChange _feeOriginal changeOriginal)
+        (TxFeeAndChange _feeModified changeModified) ->
+            (drop 1 changeOriginal) ===
+            (drop 1 changeModified)
+
+-- The 'distributeSurplus' function should never adjust addresses of change
+-- outputs.
+--
+prop_distributeSurplus_onSuccess_preservesChangeAddresses
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_preservesChangeAddresses =
+    prop_distributeSurplus_onSuccess $ \_policy _surplus
+        (TxFeeAndChange _feeOriginal changeOriginal)
+        (TxFeeAndChange _feeModified changeModified) ->
+            (view #address <$> changeOriginal) ===
+            (view #address <$> changeModified)
+
+-- The 'distributeSurplus' function should always return exactly the same
+-- number of change outputs that it was given. It should never create or
+-- destroy change outputs.
+--
+prop_distributeSurplus_onSuccess_preservesChangeLength
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_preservesChangeLength =
+    prop_distributeSurplus_onSuccess $ \_policy _surplus
+        (TxFeeAndChange _feeOriginal changeOriginal)
+        (TxFeeAndChange _feeModified changeModified) ->
+            length changeOriginal === length changeModified
+
+-- The 'distributeSurplus' function should never adjust the values of non-ada
+-- assets.
+--
+prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets =
+    prop_distributeSurplus_onSuccess $ \_policy _surplus
+        (TxFeeAndChange _feeOriginal changeOriginal)
+        (TxFeeAndChange _feeModified changeModified) ->
+            (view (#tokens . #tokens) <$> changeOriginal) ===
+            (view (#tokens . #tokens) <$> changeModified)
+
+-- Verify that 'distributeSurplusDelta':
+--
+--    - covers the increase to the fee requirement incurred as a result of
+--      increasing the fee value and change values.
+--
+--    - conserves the surplus:
+--        - feeDelta + sum changeDeltas == surplus
+--
+prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
+    :: FeePerByte -> W.Coin -> W.Coin -> [W.Coin] -> Property
+prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
+    feePolicy surplus fee0 change0 =
+    checkCoverage $
+    cover 2  (isLeft  mres) "Failure" $
+    cover 50 (isRight mres) "Success" $
+    report mres "Result" $
+    counterexample (show mres) $ case mres of
+        Left (ErrMoreSurplusNeeded shortfall) ->
+            conjoin
+                [ property $ surplus < maxCoinCostIncrease
+                , property $ shortfall > W.Coin 0
+                , costOfIncreasingCoin feePolicy fee0 surplus
+                    === surplus <> shortfall
+                ]
+        Right (TxFeeAndChange feeDelta changeDeltas) -> do
+            let feeRequirementIncrease = mconcat
+                    [ costOfIncreasingCoin feePolicy fee0 feeDelta
+                    , F.fold $ zipWith (costOfIncreasingCoin feePolicy)
+                        change0
+                        changeDeltas
+                    ]
+            conjoin
+                [ property $ feeDelta >= feeRequirementIncrease
+                    & counterexample ("fee requirement increased by "
+                        <> show feeRequirementIncrease
+                        <> " but the fee delta was just "
+                        <> show feeDelta
+                        )
+                , F.fold changeDeltas <> feeDelta
+                    === surplus
+                ]
+  where
+    mres = distributeSurplusDelta
+        feePolicy surplus (TxFeeAndChange fee0 change0)
+    maxCoinCostIncrease = maximumCostOfIncreasingCoin feePolicy
+
+--------------------------------------------------------------------------------
+-- Utils
+--------------------------------------------------------------------------------
+
+cardanoToWalletCoin :: CardanoApi.Lovelace -> W.Coin
+cardanoToWalletCoin = Convert.toWallet . CardanoApi.toShelleyLovelace
+
+mainnetFeePerByte :: FeePerByte
+mainnetFeePerByte = FeePerByte 44
+
+--------------------------------------------------------------------------------
+-- Generators
+--------------------------------------------------------------------------------
+
+newtype TxBalanceSurplus a = TxBalanceSurplus {unTxBalanceSurplus :: a}
+    deriving (Eq, Show)
+
+instance Arbitrary (TxBalanceSurplus W.Coin) where
+    -- We want to test cases where the surplus is zero. So it's important that
+    -- we do not restrict ourselves to positive coins here.
+    arbitrary = TxBalanceSurplus <$> frequency
+        [ (8, W.genCoin)
+        , (4, W.genCoin & scale (* (2 `power`  4)))
+        , (2, W.genCoin & scale (* (2 `power`  8)))
+        , (1, W.genCoin & scale (* (2 `power` 16)))
+        ]
+    shrink = shrinkMapBy TxBalanceSurplus unTxBalanceSurplus W.shrinkCoin
+
+
+instance Arbitrary (TxFeeAndChange [W.TxOut]) where
+    arbitrary = do
+        fee <- W.genCoin
+        change <- frequency
+            [ (1, pure [])
+            , (1, (: []) <$> W.genTxOut)
+            , (6, listOf W.genTxOut)
+            ]
+        pure $ TxFeeAndChange{fee, change}
+    shrink (TxFeeAndChange fee change) =
+        uncurry TxFeeAndChange <$> liftShrink2
+            (W.shrinkCoin)
+            (shrinkList W.shrinkTxOut)
+            (fee, change)
+
+instance Arbitrary W.Coin where
+    arbitrary = W.genCoinPositive
+    shrink = W.shrinkCoinPositive
+
+instance Arbitrary FeePerByte where
+    arbitrary = frequency
+        [ (1, pure mainnetFeePerByte)
+        , (7, FeePerByte <$> arbitrarySizedNatural)
+        ]
+    shrink (FeePerByte x) =
+        FeePerByte <$> shrinkNatural x
+

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/Size/TokenBundleSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/Size/TokenBundleSpec.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Internal.Cardano.Write.Tx.Balance.TokenBundleSizeSpec where
+module Internal.Cardano.Write.Tx.Balance.Size.TokenBundleSpec where
 
 import Prelude
 
@@ -38,7 +38,7 @@ import Internal.Cardano.Write.Tx
     , StandardConway
     , Version
     )
-import Internal.Cardano.Write.Tx.Balance.TokenBundleSize
+import Internal.Cardano.Write.Tx.Balance.Size.TokenBundle
     ( TokenBundleSizeAssessor
     , assessTokenBundleSize
     , computeTokenBundleSerializedLengthBytes

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1527,7 +1527,6 @@ prop_bootstrapWitnesses
             (toHDPayloadAddress addr)
             (CardanoApi.toByronNetworkMagic network)
 
-
 -- TODO [ADO-2997] Test this property in all recent eras.
 -- https://cardanofoundation.atlassian.net/browse/ADP-2997
 prop_updateTx

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -298,13 +298,13 @@ import Internal.Cardano.Write.Tx.Balance
     , splitSignedValue
     , updateTx
     )
+import Internal.Cardano.Write.Tx.Balance.Size.Selection
+    ( sizeOf_BootstrapWitnesses
+    )
 import Internal.Cardano.Write.Tx.Sign
     ( KeyWitnessCounts (..)
     , estimateKeyWitnessCounts
     , estimateSignedTxSize
-    )
-import Internal.Cardano.Write.Tx.SizeEstimation
-    ( sizeOf_BootstrapWitnesses
     )
 import Internal.Cardano.Write.Tx.TimeTranslation
     ( TimeTranslation

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -103,9 +103,6 @@ import Cardano.Mnemonic
     , entropyToMnemonic
     , mkEntropy
     )
-import Cardano.Numeric.Util
-    ( power
-    )
 import Cardano.Wallet.Address.Constants
     ( maxLengthAddressForByron
     )
@@ -184,8 +181,7 @@ import Data.Default
     ( Default (..)
     )
 import Data.Either
-    ( isLeft
-    , isRight
+    ( isRight
     )
 import Data.Function
     ( (&)
@@ -216,10 +212,6 @@ import Data.List.NonEmpty
 import Data.Maybe
     ( catMaybes
     , fromJust
-    , fromMaybe
-    )
-import Data.Monoid.Monus
-    ( Monus ((<\>))
     )
 import Data.Ratio
     ( (%)
@@ -292,24 +284,17 @@ import Internal.Cardano.Write.Tx.Balance
     , ErrBalanceTxInternalError (..)
     , ErrBalanceTxOutputError (..)
     , ErrBalanceTxOutputErrorInfo (..)
-    , ErrMoreSurplusNeeded (..)
     , ErrUpdateTx (..)
     , PartialTx (..)
     , Redeemer (..)
-    , TxFeeAndChange (..)
     , TxFeeUpdate (UseNewTxFee)
     , TxUpdate (TxUpdate)
     , UTxOAssumptions (..)
     , balanceTransaction
     , constructUTxOIndex
-    , costOfIncreasingCoin
-    , distributeSurplus
-    , distributeSurplusDelta
     , fromWalletUTxO
-    , maximumCostOfIncreasingCoin
     , mergeSignedValue
     , noTxUpdate
-    , sizeOfCoin
     , splitSignedValue
     , updateTx
     )
@@ -374,9 +359,7 @@ import Test.Hspec.QuickCheck
     )
 import Test.QuickCheck
     ( Arbitrary (..)
-    , Arbitrary2 (liftShrink2)
     , Property
-    , Testable
     , arbitraryBoundedEnum
     , arbitrarySizedNatural
     , checkCoverage
@@ -385,7 +368,6 @@ import Test.QuickCheck
     , counterexample
     , cover
     , elements
-    , forAll
     , frequency
     , label
     , listOf
@@ -407,7 +389,6 @@ import Test.QuickCheck.Extra
     , genDisjointPair
     , genericRoundRobinShrink
     , getDisjointPair
-    , report
     , shrinkDisjointPair
     , shrinkNatural
     , (.>=.)
@@ -475,11 +456,7 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (..)
     )
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
-import qualified Codec.CBOR.Encoding as CBOR
-import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Foldable as F
@@ -500,7 +477,6 @@ import qualified Test.Hspec.Extra as Hspec
 spec :: Spec
 spec = do
     spec_balanceTransaction
-    spec_distributeSurplus
     spec_estimateSignedTxSize
     spec_updateTx
 
@@ -969,156 +945,6 @@ balanceTransactionGoldenSpec = describe "balance goldens" $ do
         Write.evaluateMinimumFee mockPParamsForBalancing
             tx
             (estimateKeyWitnessCounts u tx mempty)
-
-spec_distributeSurplus :: Spec
-spec_distributeSurplus = describe "distributeSurplus" $ do
-    describe "sizeOfCoin" $ do
-        let coinToWord64Clamped = fromMaybe maxBound . W.Coin.toWord64Maybe
-        let cborSizeOfCoin =
-                W.TxSize
-                . fromIntegral
-                . BS.length
-                . CBOR.toStrictByteString
-                . CBOR.encodeWord64 . coinToWord64Clamped
-
-        let isBoundary c =
-                sizeOfCoin c /= sizeOfCoin (c <\> W.Coin 1)
-                || sizeOfCoin c /= sizeOfCoin (c <> W.Coin 1)
-
-        it "matches the size of the Word64 CBOR encoding" $
-            property $ checkCoverage $
-                forAll CardanoApi.genEncodingBoundaryLovelace $ \l -> do
-                    let c = cardanoToWalletCoin l
-                    let expected = cborSizeOfCoin c
-
-                    -- Use a low coverage requirement of 0.01% just to
-                    -- ensure we see /some/ amount of every size.
-                    let coverSize s = cover 0.01 (s == expected) (show s)
-                    sizeOfCoin c === expected
-                        & coverSize (W.TxSize 1)
-                        & coverSize (W.TxSize 2)
-                        & coverSize (W.TxSize 3)
-                        & coverSize (W.TxSize 5)
-                        & coverSize (W.TxSize 9)
-                        & cover 0.5 (isBoundary c) "boundary case"
-
-        describe "boundary case goldens" $ do
-            it "1 byte to 2 byte boundary" $ do
-                sizeOfCoin (W.Coin 23) `shouldBe` W.TxSize 1
-                sizeOfCoin (W.Coin 24) `shouldBe` W.TxSize 2
-            it "2 byte to 3 byte boundary" $ do
-                sizeOfCoin (W.Coin $ 2 `power` 8 - 1) `shouldBe` W.TxSize 2
-                sizeOfCoin (W.Coin $ 2 `power` 8    ) `shouldBe` W.TxSize 3
-            it "3 byte to 5 byte boundary" $ do
-                sizeOfCoin (W.Coin $ 2 `power` 16 - 1) `shouldBe` W.TxSize 3
-                sizeOfCoin (W.Coin $ 2 `power` 16    ) `shouldBe` W.TxSize 5
-            it "5 byte to 9 byte boundary" $ do
-                sizeOfCoin (W.Coin $ 2 `power` 32 - 1) `shouldBe` W.TxSize 5
-                sizeOfCoin (W.Coin $ 2 `power` 32    ) `shouldBe` W.TxSize 9
-
-    describe "costOfIncreasingCoin" $ do
-        it "costs 176 lovelace to increase 4294.967295 ada (2^32 - 1 lovelace) \
-           \by 1 lovelace on mainnet" $ do
-
-            let expectedCostIncrease = W.Coin 176
-            let mainnet = mainnetFeePerByte
-            costOfIncreasingCoin mainnet (W.Coin $ 2 `power` 32 - 1) (W.Coin 1)
-                `shouldBe` expectedCostIncrease
-
-        it "produces results in the range [0, 8 * feePerByte]" $
-            property $ \c increase -> do
-                let res = costOfIncreasingCoin (FeePerByte 1) c increase
-                counterexample (show res <> "out of bounds") $
-                    res >= W.Coin 0 && res <= W.Coin 8
-
-    describe "distributeSurplus" $ do
-
-        it "prop_distributeSurplus_onSuccess_conservesSurplus" $
-            prop_distributeSurplus_onSuccess_conservesSurplus
-                & property
-        it "prop_distributeSurplus_onSuccess_coversCostIncrease" $
-            prop_distributeSurplus_onSuccess_coversCostIncrease
-                & property
-        it "prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues" $
-            prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues
-                & property
-        it "prop_distributeSurplus_onSuccess_doesNotReduceFeeValue" $
-            prop_distributeSurplus_onSuccess_doesNotReduceFeeValue
-                & property
-        it "prop_distributeSurplus_onSuccess_preservesChangeLength" $
-            prop_distributeSurplus_onSuccess_preservesChangeLength
-                & property
-        it "prop_distributeSurplus_onSuccess_preservesChangeAddresses" $
-            prop_distributeSurplus_onSuccess_preservesChangeAddresses
-                & property
-        it "prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets" $
-            prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets
-                & property
-        it "prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue" $
-            prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue
-                & property
-        it "prop_distributeSurplus_onSuccess_increasesValuesByDelta" $
-            prop_distributeSurplus_onSuccess_increasesValuesByDelta
-                & property
-
-    describe "distributeSurplusDelta" $ do
-
-        -- NOTE: The test values below make use of 255 being encoded as 2 bytes,
-        -- and 256 as 3 bytes.
-
-        describe "when increasing change increases fee" $
-            it "will increase fee (99 lovelace for change, 1 for fee)" $
-                distributeSurplusDelta
-                    (FeePerByte 1)
-                    (W.Coin 100)
-                    (TxFeeAndChange (W.Coin 200) [W.Coin 200])
-                    `shouldBe`
-                    Right (TxFeeAndChange (W.Coin 1) [W.Coin 99])
-
-        describe "when increasing fee increases fee" $
-            it "will increase fee (98 lovelace for change, 2 for fee)" $ do
-                distributeSurplusDelta
-                    (FeePerByte 1)
-                    (W.Coin 100)
-                    (TxFeeAndChange (W.Coin 255) [W.Coin 200])
-                    `shouldBe`
-                    Right (TxFeeAndChange (W.Coin 2) [W.Coin 98])
-
-        describe
-            (unwords
-                [ "when increasing the change costs more in fees than the"
-                , "increase itself"
-                ]) $ do
-            it "will try burning the surplus as fees" $ do
-                distributeSurplusDelta
-                    mainnetFeePerByte
-                    (W.Coin 10)
-                    (TxFeeAndChange (W.Coin 200) [W.Coin 255])
-                    `shouldBe`
-                    Right (TxFeeAndChange (W.Coin 10) [W.Coin 0])
-
-            it "will fail if neither the fee can be increased" $ do
-                distributeSurplusDelta
-                    mainnetFeePerByte
-                    (W.Coin 10)
-                    (TxFeeAndChange (W.Coin 255) [W.Coin 255])
-                    `shouldBe`
-                    Left (ErrMoreSurplusNeeded $ W.Coin 34)
-
-        describe "when no change output is present" $ do
-            it "will burn surplus as excess fees" $
-                property $ \surplus fee0 -> do
-                    distributeSurplusDelta
-                        (FeePerByte 1)
-                        surplus
-                        (TxFeeAndChange fee0 [])
-                        `shouldBe`
-                        Right (TxFeeAndChange surplus [])
-
-        it "prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus" $
-            prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
-                & withMaxSuccess 10_000
-                & property
 
 spec_estimateSignedTxSize :: Spec
 spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
@@ -1701,284 +1527,6 @@ prop_bootstrapWitnesses
             (toHDPayloadAddress addr)
             (CardanoApi.toByronNetworkMagic network)
 
--- A helper function to generate properties for 'distributeSurplus' on
--- success.
---
-prop_distributeSurplus_onSuccess
-    :: Testable prop
-    => (FeePerByte
-        -> W.Coin
-        -> TxFeeAndChange [W.TxOut]
-        -> TxFeeAndChange [W.TxOut]
-        -> prop)
-    -> FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess propertyToTest policy txSurplus fc =
-    checkCoverage $
-    cover 50
-        (isRight mResult)
-        "isRight mResult" $
-    cover 10
-        (length changeOriginal == 0)
-        "length changeOriginal == 0" $
-    cover 10
-        (length changeOriginal == 1)
-        "length changeOriginal == 1" $
-    cover 50
-        (length changeOriginal >= 2)
-        "length changeOriginal >= 2" $
-    cover 2
-        (feeOriginal == W.Coin 0)
-        "feeOriginal == W.Coin 0" $
-    cover 2
-        (feeOriginal == W.Coin 1)
-        "feeOriginal == W.Coin 1" $
-    cover 50
-        (feeOriginal >= W.Coin 2)
-        "feeOriginal >= W.Coin 2" $
-    cover 1
-        (surplus == W.Coin 0)
-        "surplus == W.Coin 0" $
-    cover 1
-        (surplus == W.Coin 1)
-        "surplus == W.Coin 1" $
-    cover 50
-        (surplus >= W.Coin 2)
-        "surplus >= W.Coin 2" $
-    either
-        (const $ property True)
-        (property . propertyToTest policy surplus fc)
-        mResult
-  where
-    TxBalanceSurplus surplus = txSurplus
-    TxFeeAndChange feeOriginal changeOriginal = fc
-
-    mResult :: Either ErrMoreSurplusNeeded (TxFeeAndChange [W.TxOut])
-    mResult = distributeSurplus policy surplus fc
-
--- Verifies that the 'distributeSurplus' function conserves the surplus: the
--- total increase in the fee and change ada quantities should be exactly equal
--- to the given surplus.
---
-prop_distributeSurplus_onSuccess_conservesSurplus
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_conservesSurplus =
-    prop_distributeSurplus_onSuccess $ \_policy surplus
-        (TxFeeAndChange feeOriginal changeOriginal)
-        (TxFeeAndChange feeModified changeModified) ->
-        surplus ===
-            (feeModified <> F.foldMap W.TxOut.coin changeModified)
-            <\>
-            (feeOriginal <> F.foldMap W.TxOut.coin changeOriginal)
-
--- The 'distributeSurplus' function should cover the cost of any increases in
--- 'Coin' values.
---
--- If the total cost of encoding ada quantities has increased by 𝛿c, then the
--- fee value should have increased by at least 𝛿c.
---
-prop_distributeSurplus_onSuccess_coversCostIncrease
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_coversCostIncrease =
-    prop_distributeSurplus_onSuccess $ \policy _surplus
-        (TxFeeAndChange feeOriginal changeOriginal)
-        (TxFeeAndChange feeModified changeModified) -> do
-        let coinsOriginal = feeOriginal : (W.TxOut.coin <$> changeOriginal)
-        let coinsModified = feeModified : (W.TxOut.coin <$> changeModified)
-        let coinDeltas = zipWith (<\>) coinsModified coinsOriginal
-        let costIncrease = F.foldMap
-                (uncurry $ costOfIncreasingCoin policy)
-                (coinsOriginal `zip` coinDeltas)
-        feeModified <\> feeOriginal >= costIncrease
-            & report feeModified "feeModified"
-            & report feeOriginal "feeOriginal"
-            & report costIncrease "costIncrease"
-
--- Since the 'distributeSurplus' function is not aware of the minimum ada
--- quantity or how to calculate it, it should never allow change ada values to
--- decrease.
---
-prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues =
-    prop_distributeSurplus_onSuccess $ \_policy _surplus
-        (TxFeeAndChange _feeOriginal changeOriginal)
-        (TxFeeAndChange _feeModified changeModified) ->
-            all (uncurry (<=)) $ zip
-                (W.TxOut.coin <$> changeOriginal)
-                (W.TxOut.coin <$> changeModified)
-
--- The 'distributeSurplus' function should never return a 'fee' value that is
--- less than the original value.
---
-prop_distributeSurplus_onSuccess_doesNotReduceFeeValue
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_doesNotReduceFeeValue =
-    prop_distributeSurplus_onSuccess $ \_policy _surplus
-        (TxFeeAndChange feeOriginal _changeOriginal)
-        (TxFeeAndChange feeModified _changeModified) ->
-            feeOriginal <= feeModified
-
--- The 'distributeSurplus' function should increase values by the exact amounts
--- indicated in 'distributeSurplusDelta'.
---
--- This is actually an implementation detail of 'distributeSurplus'.
---
--- However, it's useful to verify that this is true by subtracting the delta
--- values from the result of 'distributeSurplus', which should produce the
--- original fee and change values.
---
-prop_distributeSurplus_onSuccess_increasesValuesByDelta
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_increasesValuesByDelta =
-    prop_distributeSurplus_onSuccess $ \policy surplus
-        (TxFeeAndChange feeOriginal changeOriginal)
-        (TxFeeAndChange feeModified changeModified) ->
-            let (TxFeeAndChange feeDelta changeDeltas) =
-                    either (error . show) id
-                    $ distributeSurplusDelta policy surplus
-                    $ TxFeeAndChange
-                        (feeOriginal)
-                        (W.TxOut.coin <$> changeOriginal)
-            in
-            (TxFeeAndChange
-                (feeModified <\> feeDelta)
-                (zipWith W.TxOut.subtractCoin changeDeltas changeModified)
-            )
-            ===
-            TxFeeAndChange feeOriginal changeOriginal
-
--- The 'distributeSurplus' function should only adjust the very first change
--- value.  All other change values should be left untouched.
---
--- This is actually an implementation detail of 'distributeSurplus'.
---
--- In principle, 'distributeSurplus' could allow itself to adjust any of the
--- change values in order to find a (marginally) more optimal solution.
--- However, for reasons of simplicity, we only adjust the first change value.
---
--- Here we verify that the implementation indeed only adjusts the first change
--- value, as expected.
---
-prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue =
-    prop_distributeSurplus_onSuccess $ \_policy _surplus
-        (TxFeeAndChange _feeOriginal changeOriginal)
-        (TxFeeAndChange _feeModified changeModified) ->
-            (drop 1 changeOriginal) ===
-            (drop 1 changeModified)
-
--- The 'distributeSurplus' function should never adjust addresses of change
--- outputs.
---
-prop_distributeSurplus_onSuccess_preservesChangeAddresses
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_preservesChangeAddresses =
-    prop_distributeSurplus_onSuccess $ \_policy _surplus
-        (TxFeeAndChange _feeOriginal changeOriginal)
-        (TxFeeAndChange _feeModified changeModified) ->
-            (view #address <$> changeOriginal) ===
-            (view #address <$> changeModified)
-
--- The 'distributeSurplus' function should always return exactly the same
--- number of change outputs that it was given. It should never create or
--- destroy change outputs.
---
-prop_distributeSurplus_onSuccess_preservesChangeLength
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_preservesChangeLength =
-    prop_distributeSurplus_onSuccess $ \_policy _surplus
-        (TxFeeAndChange _feeOriginal changeOriginal)
-        (TxFeeAndChange _feeModified changeModified) ->
-            length changeOriginal === length changeModified
-
--- The 'distributeSurplus' function should never adjust the values of non-ada
--- assets.
---
-prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets =
-    prop_distributeSurplus_onSuccess $ \_policy _surplus
-        (TxFeeAndChange _feeOriginal changeOriginal)
-        (TxFeeAndChange _feeModified changeModified) ->
-            (view (#tokens . #tokens) <$> changeOriginal) ===
-            (view (#tokens . #tokens) <$> changeModified)
-
--- Verify that 'distributeSurplusDelta':
---
---    - covers the increase to the fee requirement incurred as a result of
---      increasing the fee value and change values.
---
---    - conserves the surplus:
---        - feeDelta + sum changeDeltas == surplus
---
-prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
-    :: FeePerByte -> W.Coin -> W.Coin -> [W.Coin] -> Property
-prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
-    feePolicy surplus fee0 change0 =
-    checkCoverage $
-    cover 2  (isLeft  mres) "Failure" $
-    cover 50 (isRight mres) "Success" $
-    report mres "Result" $
-    counterexample (show mres) $ case mres of
-        Left (ErrMoreSurplusNeeded shortfall) ->
-            conjoin
-                [ property $ surplus < maxCoinCostIncrease
-                , property $ shortfall > W.Coin 0
-                , costOfIncreasingCoin feePolicy fee0 surplus
-                    === surplus <> shortfall
-                ]
-        Right (TxFeeAndChange feeDelta changeDeltas) -> do
-            let feeRequirementIncrease = mconcat
-                    [ costOfIncreasingCoin feePolicy fee0 feeDelta
-                    , F.fold $ zipWith (costOfIncreasingCoin feePolicy)
-                        change0
-                        changeDeltas
-                    ]
-            conjoin
-                [ property $ feeDelta >= feeRequirementIncrease
-                    & counterexample ("fee requirement increased by "
-                        <> show feeRequirementIncrease
-                        <> " but the fee delta was just "
-                        <> show feeDelta
-                        )
-                , F.fold changeDeltas <> feeDelta
-                    === surplus
-                ]
-  where
-    mres = distributeSurplusDelta
-        feePolicy surplus (TxFeeAndChange fee0 change0)
-    maxCoinCostIncrease = maximumCostOfIncreasingCoin feePolicy
 
 -- TODO [ADO-2997] Test this property in all recent eras.
 -- https://cardanofoundation.atlassian.net/browse/ADP-2997
@@ -2165,9 +1713,6 @@ newtype DummyChangeState = DummyChangeState { nextUnusedIndex :: Int }
 newtype MixedSign a = MixedSign a
     deriving (Eq, Show)
 
-newtype TxBalanceSurplus a = TxBalanceSurplus {unTxBalanceSurplus :: a}
-    deriving (Eq, Show)
-
 data Wallet = Wallet UTxOAssumptions W.UTxO AnyChangeAddressGenWithState
     deriving Show via (ShowBuildable Wallet)
 
@@ -2344,9 +1889,6 @@ withValidityInterval
     -> PartialTx BabbageEra
     -> PartialTx BabbageEra
 withValidityInterval vi = #tx . bodyTxL %~ vldtTxBodyL .~ vi
-
-cardanoToWalletCoin :: CardanoApi.Lovelace -> W.Coin
-cardanoToWalletCoin = Convert.toWallet . CardanoApi.toShelleyLovelace
 
 cardanoToWalletTxOut
     :: forall era. IsRecentEra era
@@ -2715,32 +2257,6 @@ instance Arbitrary W.TokenBundle where
 instance Arbitrary (DisjointPair W.TokenBundle) where
     arbitrary = genDisjointPair W.genTokenBundle
     shrink = shrinkDisjointPair W.shrinkTokenBundle
-
-instance Arbitrary (TxBalanceSurplus W.Coin) where
-    -- We want to test cases where the surplus is zero. So it's important that
-    -- we do not restrict ourselves to positive coins here.
-    arbitrary = TxBalanceSurplus <$> frequency
-        [ (8, W.genCoin)
-        , (4, W.genCoin & scale (* (2 `power`  4)))
-        , (2, W.genCoin & scale (* (2 `power`  8)))
-        , (1, W.genCoin & scale (* (2 `power` 16)))
-        ]
-    shrink = shrinkMapBy TxBalanceSurplus unTxBalanceSurplus W.shrinkCoin
-
-instance Arbitrary (TxFeeAndChange [W.TxOut]) where
-    arbitrary = do
-        fee <- W.genCoin
-        change <- frequency
-            [ (1, pure [])
-            , (1, (: []) <$> W.genTxOut)
-            , (6, listOf W.genTxOut)
-            ]
-        pure $ TxFeeAndChange fee change
-    shrink (TxFeeAndChange fee change) =
-        uncurry TxFeeAndChange <$> liftShrink2
-            (W.shrinkCoin)
-            (shrinkList W.shrinkTxOut)
-            (fee, change)
 
 instance Arbitrary W.TxIn where
     arbitrary = do

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -276,7 +276,7 @@ import Internal.Cardano.Write.Tx
     , ShelleyLedgerEra
     , cardanoEraFromRecentEra
     )
-import Internal.Cardano.Write.Tx.SizeEstimation
+import Internal.Cardano.Write.Tx.Balance.Size.Selection
     ( TxSkeleton (..)
     , estimateTxSize
     )

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -328,7 +328,7 @@ import Data.Word
 import GHC.Generics
     ( Generic
     )
-import Internal.Cardano.Write.Tx.SizeEstimation
+import Internal.Cardano.Write.Tx.Balance.Size.Selection
     ( TxWitnessTag (..)
     )
 import System.Random

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -795,7 +795,7 @@ import Internal.Cardano.Write.Tx.Balance
     , PartialTx (..)
     , UTxOAssumptions (..)
     )
-import Internal.Cardano.Write.Tx.SizeEstimation
+import Internal.Cardano.Write.Tx.Balance.Size.Selection
     ( TxWitnessTag (..)
     )
 import Internal.Cardano.Write.Tx.TimeTranslation

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -241,7 +241,7 @@ import Internal.Cardano.Write.Tx
     ( CardanoApiEra
     , RecentEra (..)
     )
-import Internal.Cardano.Write.Tx.SizeEstimation
+import Internal.Cardano.Write.Tx.Balance.Size.Selection
     ( TxSkeleton (..)
     , TxWitnessTag (..)
     , estimateTxCost
@@ -290,13 +290,13 @@ import qualified Internal.Cardano.Write.Tx as Write
     , shelleyBasedEraFromRecentEra
     , toCardanoApiTx
     )
-import qualified Internal.Cardano.Write.Tx.Sign as Write
-    ( estimateMaxWitnessRequiredPerInput
-    )
-import qualified Internal.Cardano.Write.Tx.SizeEstimation as Write
+import qualified Internal.Cardano.Write.Tx.Balance.Size.Selection as Write
     ( sizeOf_BootstrapWitnesses
     , sizeOf_VKeyWitnesses
     , sizeOf_Withdrawals
+    )
+import qualified Internal.Cardano.Write.Tx.Sign as Write
+    ( estimateMaxWitnessRequiredPerInput
     )
 
 -- | Type encapsulating what we need to know to add things -- payloads,

--- a/lib/wallet/src/Cardano/Wallet/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Transaction.hs
@@ -166,7 +166,7 @@ import Fmt
 import GHC.Generics
     ( Generic
     )
-import Internal.Cardano.Write.Tx.SizeEstimation
+import Internal.Cardano.Write.Tx.Balance.Size.Selection
     ( TxWitnessTag
     )
 


### PR DESCRIPTION
<img width="228" alt="Skärmavbild 2024-04-15 kl  19 24 47" src="https://github.com/cardano-foundation/cardano-wallet/assets/304423/83306615-4744-4e84-900d-bcfb4202273d">

- Move `distributeSurplus` to new `Balance.Size.Coin` module
- `Balance.TokenBundleSize` -> `Balance.Size.TokenBundle`
- `SizeEstimation` -> `Balance.Size.Selection`

### Comments

Even if this is not the module structure we ultimate want, I thought this would be a step in the right direction

### Issue Number

None / preparation for ADP-3347 in particular by making the `Balance` module smaller
