### PR TITLE
Make `selectAssets` responsible for change addr assignment and extraInputScripts

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -736,18 +736,18 @@ balanceTxInner
     -- transaction considering only the maximum cost, and only after, try to
     -- adjust the change and ExUnits of each redeemer to something more
     -- sensible than the max execution cost.
-    (Selection extraInputs extraCollateral extraOutputs extraInputScripts, s')
+    (Selection{extraInputs,extraCollateral,extraOutputs,extraInputScripts}, s')
         <- selectAssets
-               pp
-               utxoAssumptions
-               (F.toList $ partialTx ^. bodyTxL . outputsTxBodyL)
-               redeemers
-               utxoSelection
-               balance0
-               (Convert.toWalletCoin minfee0)
-               genChange
-               selectionStrategy
-               s
+            pp
+            utxoAssumptions
+            (F.toList $ partialTx ^. bodyTxL . outputsTxBodyL)
+            redeemers
+            utxoSelection
+            balance0
+            (Convert.toWalletCoin minfee0)
+            genChange
+            selectionStrategy
+            s
 
     -- NOTE:
     -- Once the coin selection is done, we need to
@@ -1060,6 +1060,11 @@ selectAssets pp utxoAssumptions outs' redeemers
                         ) <$> inputs <> collateral
         in  ( Selection
                 { extraInputs = map fst inputs
+                -- TODO [ADP-3355] Filter out pre-selected inputs here
+                --
+                -- The correctness of balanceTx is currently not affected, but
+                -- it is misleading.
+                -- https://cardanofoundation.atlassian.net/browse/ADP-3355
                 , extraCollateral = map fst collateral
                 , extraOutputs = change
                 , extraInputScripts = inputScripts

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -736,7 +736,13 @@ balanceTxInner
     -- transaction considering only the maximum cost, and only after, try to
     -- adjust the change and ExUnits of each redeemer to something more
     -- sensible than the max execution cost.
-    (Selection{extraInputs,extraCollateral,extraOutputs,extraInputScripts}, s')
+    ( SelectAssetsResult
+        { extraInputs
+        , extraCollateral
+        , extraOutputs
+        , extraInputScripts
+        }
+        , s')
         <- selectAssets
             pp
             utxoAssumptions
@@ -871,7 +877,7 @@ balanceTxInner
         left ErrBalanceTxAssignRedeemers $
             assignScriptRedeemers pp timeTranslation utxoReference redeemers tx'
 
-data Selection = Selection
+data SelectAssetsResult = SelectAssetsResult
     { extraInputs :: [W.TxIn]
     , extraCollateral :: [W.TxIn]
     , extraOutputs :: [W.TxOut]
@@ -903,7 +909,7 @@ selectAssets
     -> ChangeAddressGen changeState
     -> SelectionStrategy
     -> changeState
-    -> ExceptT (ErrBalanceTx era) m (Selection, changeState)
+    -> ExceptT (ErrBalanceTx era) m (SelectAssetsResult, changeState)
 selectAssets pp utxoAssumptions outs' redeemers
     utxoSelection balance fee0 changeGen selectionStrategy s = do
         except validateTxOutputs'
@@ -1041,7 +1047,7 @@ selectAssets pp utxoAssumptions outs' redeemers
 
     transformSelection
         :: CoinSelection.Selection
-        -> (Selection, changeState)
+        -> (SelectAssetsResult, changeState)
     transformSelection sel =
         let
             (sel', s') = assignChangeAddresses changeGen sel s
@@ -1058,7 +1064,7 @@ selectAssets pp utxoAssumptions outs' redeemers
                         . view #address
                         . snd
                         ) <$> inputs <> collateral
-        in  ( Selection
+        in  ( SelectAssetsResult
                 { extraInputs = map fst inputs
                 -- TODO [ADP-3355] Filter out pre-selected inputs here
                 --

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1536,7 +1536,7 @@ prop_bootstrapWitnesses
 prop_updateTx
     :: forall era. era ~ Write.BabbageEra
     => Tx era
-    -> [(W.TxIn, W.TxOut)]
+    -> [W.TxIn]
     -> [W.TxIn]
     -> [W.TxOut]
     -> W.Coin
@@ -1547,7 +1547,7 @@ prop_updateTx tx extraIns extraCol extraOuts newFee = do
             $ updateTx tx extra
     conjoin
         [ inputs tx' === inputs tx
-            <> Set.fromList (fromWalletTxIn . fst <$> extraIns)
+            <> Set.fromList (fromWalletTxIn <$> extraIns)
         , outputs tx' === (outputs tx)
             <> StrictSeq.fromList (fromWalletTxOut <$> extraOuts)
         , fee tx' === Convert.toLedger newFee


### PR DESCRIPTION
- [x] Embed the assignment of change address directly into `selectAssets`
- [x] Embed the lookup of `extraInputScripts` directly into `selectAssets` 

### Comments

- This enables us to remove the `TxOut`s corresponding to the `TxIns` in `Selection` 
- This will in the future allow us to make `TxUpdate` take a `Selection` instead of the component `extra{Inputs, ...}`

### Issue Number

ADP-3356