### PR TITLE
[ADP-3350] Add `Read.ChainPoint`

### DIFF
--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -60,6 +60,7 @@ library
     Cardano.Wallet.Read.Eras.EraFun
     Cardano.Wallet.Read.Eras.EraValue
     Cardano.Wallet.Read.Eras.KnownEras
+    Cardano.Wallet.Read.Hash
     Cardano.Wallet.Read.Tx
     Cardano.Wallet.Read.Tx.Cardano
     Cardano.Wallet.Read.Tx.CBOR

--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -56,6 +56,7 @@ library
     Cardano.Wallet.Read.Block.HeaderHash
     Cardano.Wallet.Read.Block.SlotNo
     Cardano.Wallet.Read.Block.Txs
+    Cardano.Wallet.Read.Chain
     Cardano.Wallet.Read.Eras
     Cardano.Wallet.Read.Eras.EraFun
     Cardano.Wallet.Read.Eras.EraValue

--- a/lib/read/lib/Cardano/Wallet/Read.hs
+++ b/lib/read/lib/Cardano/Wallet/Read.hs
@@ -14,10 +14,12 @@ import qualified Cardano.Wallet.Read as Read
 -}
 module Cardano.Wallet.Read
     ( module Cardano.Wallet.Read.Block
+    , module Cardano.Wallet.Read.Chain
     , module Cardano.Wallet.Read.Eras
     , module Cardano.Wallet.Read.Tx
     ) where
 
 import Cardano.Wallet.Read.Block
+import Cardano.Wallet.Read.Chain
 import Cardano.Wallet.Read.Eras
 import Cardano.Wallet.Read.Tx

--- a/lib/read/lib/Cardano/Wallet/Read/Block.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block.hs
@@ -24,12 +24,15 @@ import Cardano.Wallet.Read.Block.BlockNo
     , getEraBlockNo
     )
 import Cardano.Wallet.Read.Block.HeaderHash
-    ( HeaderHash (..)
+    ( BHeader
+    , HeaderHash (..)
     , HeaderHashT
     , PrevHeaderHash (..)
     , PrevHeaderHashT
+    , RawHeaderHash
     , getEraHeaderHash
     , getEraPrevHeaderHash
+    , getRawHeaderHash
     )
 import Cardano.Wallet.Read.Block.SlotNo
     ( SlotNo (..)

--- a/lib/read/lib/Cardano/Wallet/Read/Chain.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Chain.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE DeriveGeneric #-}
+{- |
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+Data types relating to the consensus about the blockchain.
+-}
+module Cardano.Wallet.Read.Chain
+    ( ChainPoint (GenesisPoint, BlockPoint)
+    , getChainPoint
+    , prettyChainPoint
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Read.Block
+    ( Block
+    , RawHeaderHash
+    , SlotNo (..)
+    , getEraHeaderHash
+    , getEraSlotNo
+    , getRawHeaderHash
+    )
+import Cardano.Wallet.Read.Eras
+    ( IsEra
+    )
+import GHC.Generics
+    ( Generic
+    )
+import NoThunks.Class
+    ( NoThunks (..)
+    )
+
+import qualified Cardano.Wallet.Read.Hash as Hash
+import qualified Data.Text as T
+
+{-----------------------------------------------------------------------------
+    ChainPoint
+------------------------------------------------------------------------------}
+
+-- | A point (block) on the Cardano blockchain.
+data ChainPoint
+    = GenesisPoint
+    | BlockPoint !SlotNo !RawHeaderHash
+    deriving (Eq, Ord, Show, Generic)
+
+instance NoThunks ChainPoint
+
+{-# INLINABLE getChainPoint #-}
+getChainPoint :: IsEra era => Block era -> ChainPoint
+getChainPoint block =
+    BlockPoint
+        (getEraSlotNo block)
+        (getRawHeaderHash $ getEraHeaderHash block)
+
+-- | Short printed representation of a 'ChainPoint'.
+prettyChainPoint :: ChainPoint -> T.Text
+prettyChainPoint GenesisPoint =
+    "[point genesis]"
+prettyChainPoint (BlockPoint slot hash) =
+    "[point " <> hashF hash <> " at slot " <> slotF slot <> "]"
+  where
+    hashF = T.take 8 . Hash.hashToTextAsHex
+    slotF (SlotNo n) = T.pack (show n)

--- a/lib/read/lib/Cardano/Wallet/Read/Hash.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Hash.hs
@@ -1,0 +1,38 @@
+{- |
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+Abstract and specific Hash functionality.
+-}
+module Cardano.Wallet.Read.Hash
+    ( -- * Core operations
+      H.Hash
+    , H.HashAlgorithm (H.digest, H.hashAlgorithmName)
+    , H.sizeHash
+    , H.hashWith
+
+    -- * Conversions
+    , H.castHash
+    , H.hashToBytes
+    , H.hashFromBytes
+    , H.hashToBytesShort
+    , H.hashFromBytesShort
+
+    -- * Rendering and parsing
+    , H.hashToBytesAsHex
+    , H.hashFromBytesAsHex
+    , H.hashToTextAsHex
+    , H.hashFromTextAsHex
+    , H.hashToStringAsHex
+    , H.hashFromStringAsHex
+
+    -- * Specific Hash algorithms
+    , Blake2b_224
+    , Blake2b_256
+    ) where
+
+import Cardano.Crypto.Hash.Blake2b
+    ( Blake2b_224
+    , Blake2b_256
+    )
+import qualified Cardano.Crypto.Hash.Class as H


### PR DESCRIPTION
This pull request adds a data type `ChainPoint` to the `Cardano.Wallet.Read` hierarchy.

In order to add this type, we also need to

* Add functions related to hashing. The `Cardano.Crypto.Hash.Class` provides a very thoughtful API, we re-export it.
* Add a type `RawHeaderHash` that is an era-independent string of bytes representing a `HeaderHash`.

### Comments

* This `ChainPoint` type is meant to be consistent with the other types in the `Cardano.Wallet.Read` hierarchy, which are in turn meant to be consistent with the ledger specification.
* The ledger specification stipulates that `SlotNo ~ Natural`. We stick to this type.
* The goal is to eventually remove the old `primitive` types.

### Issue Number

ADP-3350
