### PR TITLE
[ADP-3350] Conversion to/from `Read.ChainPoint`

### DIFF
--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -47,6 +47,7 @@ library
     Cardano.Wallet.Network.Implementation
     Cardano.Wallet.Network.Implementation.Ouroboros
     Cardano.Wallet.Network.Implementation.UnliftIO
+    Cardano.Wallet.Network.Implementation.Types
     Cardano.Wallet.Network.Light
     Cardano.Wallet.Network.LocalStateQuery
     Cardano.Wallet.Network.LocalStateQuery.Extra

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation/Types.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation/Types.hs
@@ -1,0 +1,65 @@
+{-|
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+Conversions between types from @ouroboros-consensus@
+and "Cardano.Wallet.Read".
+-}
+module Cardano.Wallet.Network.Implementation.Types
+    ( fromOuroborosPoint
+    , toOuroborosPoint
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Read
+    ( BHeader
+    , ChainPoint (..)
+    , SlotNo (..)
+    )
+import Cardano.Wallet.Read.Hash
+    ( Blake2b_256
+    , Hash
+    , hashFromBytesShort
+    , hashToBytesShort
+    )
+import Data.Maybe
+    ( fromJust
+    )
+import Ouroboros.Consensus.Cardano.Block
+    ( CardanoBlock
+    , CardanoEras
+    )
+import Ouroboros.Consensus.HardFork.Combinator
+    ( OneEraHash (..)
+    )
+
+import qualified Ouroboros.Network.Block as O
+
+{-----------------------------------------------------------------------------
+    ChainPoint conversions
+------------------------------------------------------------------------------}
+
+toOuroborosPoint :: ChainPoint -> O.Point (CardanoBlock sc)
+toOuroborosPoint GenesisPoint =
+    O.GenesisPoint
+toOuroborosPoint (BlockPoint slot h) =
+    O.BlockPoint (toCardanoSlotNo slot) (toCardanoHash h)
+
+toCardanoSlotNo :: SlotNo -> O.SlotNo
+toCardanoSlotNo (SlotNo slot) = O.SlotNo (toEnum $ fromEnum slot)
+
+toCardanoHash :: Hash Blake2b_256 BHeader -> OneEraHash (CardanoEras sc)
+toCardanoHash = OneEraHash . hashToBytesShort
+
+fromOuroborosPoint :: O.Point (CardanoBlock sc) -> ChainPoint
+fromOuroborosPoint O.GenesisPoint =
+    GenesisPoint
+fromOuroborosPoint (O.BlockPoint slot h) =
+    BlockPoint (fromCardanoSlotNo slot) (fromCardanoHash h)
+
+fromCardanoSlotNo :: O.SlotNo -> SlotNo
+fromCardanoSlotNo (O.SlotNo slot) = SlotNo (fromIntegral slot)
+
+fromCardanoHash :: OneEraHash (CardanoEras sc) -> Hash Blake2b_256 BHeader
+fromCardanoHash = fromJust . hashFromBytesShort . getOneEraHash


### PR DESCRIPTION
This pull request adds conversion function to/from the data type `ChainPoint` that belongs to the `Cardano.Wallet.Read` hierarchy.

This includes
* Conversions to/from legacy types in `primitive`
* Conversions to/from types in `ouroboros-consensus` for the networking layer

### Comments

* The goal is to eventually remove the old `primitive` types. However, we add conversions `Read.ChainPoint ⟷ ChainPoint` here in order to have more control over the source code impact of future pull requests. Specifically, we can then change the types in `NetworkLayer` from `ChainPoint` to `Read.ChainPoint` while touching only a small portion of the code in `Cardano.Wallet` thanks to a cleverly inserted conversion.

### Issue Number

ADP-3350