### PR TITLE
Move `distributeSurplus` to new `Balance.Surplus` module

### DIFF
--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -87,6 +87,7 @@ library internal
     Internal.Cardano.Write.Tx
     Internal.Cardano.Write.Tx.Balance
     Internal.Cardano.Write.Tx.Balance.CoinSelection
+    Internal.Cardano.Write.Tx.Balance.Distribute
     Internal.Cardano.Write.Tx.Balance.TokenBundleSize
     Internal.Cardano.Write.Tx.Gen
     Internal.Cardano.Write.Tx.Redeemers
@@ -160,6 +161,7 @@ test-suite test
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:
     Internal.Cardano.Write.Tx.Balance.CoinSelectionSpec
+    Internal.Cardano.Write.Tx.Balance.DistributeSpec
     Internal.Cardano.Write.Tx.Balance.TokenBundleSizeSpec
     Internal.Cardano.Write.Tx.BalanceSpec
     Internal.Cardano.Write.TxSpec

--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -87,7 +87,7 @@ library internal
     Internal.Cardano.Write.Tx
     Internal.Cardano.Write.Tx.Balance
     Internal.Cardano.Write.Tx.Balance.CoinSelection
-    Internal.Cardano.Write.Tx.Balance.Distribute
+    Internal.Cardano.Write.Tx.Balance.Surplus
     Internal.Cardano.Write.Tx.Balance.TokenBundleSize
     Internal.Cardano.Write.Tx.Gen
     Internal.Cardano.Write.Tx.Redeemers
@@ -161,7 +161,7 @@ test-suite test
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:
     Internal.Cardano.Write.Tx.Balance.CoinSelectionSpec
-    Internal.Cardano.Write.Tx.Balance.DistributeSpec
+    Internal.Cardano.Write.Tx.Balance.SurplusSpec
     Internal.Cardano.Write.Tx.Balance.TokenBundleSizeSpec
     Internal.Cardano.Write.Tx.BalanceSpec
     Internal.Cardano.Write.TxSpec

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -219,7 +219,7 @@ import Internal.Cardano.Write.Tx.Balance.CoinSelection
     , toExternalUTxOMap
     , toInternalUTxOMap
     )
-import Internal.Cardano.Write.Tx.Balance.Distribute
+import Internal.Cardano.Write.Tx.Balance.Surplus
     ( ErrMoreSurplusNeeded (..)
     , TxFeeAndChange (..)
     , distributeSurplus

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NoFieldSelectors #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE Rank2Types #-}
@@ -59,14 +58,6 @@ module Internal.Cardano.Write.Tx.Balance
     , TxFeeUpdate (..)
     , ErrUpdateTx (..)
 
-    -- ** distributeSurplus
-    , distributeSurplus
-    , distributeSurplusDelta
-    , sizeOfCoin
-    , maximumCostOfIncreasingCoin
-    , costOfIncreasingCoin
-    , TxFeeAndChange (..)
-    , ErrMoreSurplusNeeded (..)
     )
     where
 
@@ -171,9 +162,6 @@ import Data.Maybe
 import Data.Monoid.Monus
     ( Monus ((<\>))
     )
-import Data.Semigroup.Cancellative
-    ( Reductive ((</>))
-    )
 import Data.Set
     ( Set
     )
@@ -195,7 +183,6 @@ import Internal.Cardano.Write.Tx
     ( Address
     , AssetName
     , Coin (..)
-    , FeePerByte (..)
     , IsRecentEra (..)
     , KeyWitnessCounts (..)
     , PParams
@@ -231,6 +218,11 @@ import Internal.Cardano.Write.Tx.Balance.CoinSelection
     , performSelection
     , toExternalUTxOMap
     , toInternalUTxOMap
+    )
+import Internal.Cardano.Write.Tx.Balance.Distribute
+    ( ErrMoreSurplusNeeded (..)
+    , TxFeeAndChange (..)
+    , distributeSurplus
     )
 import Internal.Cardano.Write.Tx.Balance.TokenBundleSize
     ( mkTokenBundleSizeAssessor
@@ -301,7 +293,6 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (..)
     )
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
     ( UTxO (..)
     )
@@ -1252,223 +1243,6 @@ modifyShelleyTxBody txUpdate =
     modifyFee old = case feeUpdate of
         UseNewTxFee c -> Convert.toLedger c
         UseOldTxFee -> old
-
---------------------------------------------------------------------------------
--- distributeSurplus
---------------------------------------------------------------------------------
-
--- | Indicates that it's impossible for 'distributeSurplus' to distribute a
--- surplus. As long as the surplus is larger than 'costOfIncreasingCoin', this
--- should never happen.
-newtype ErrMoreSurplusNeeded = ErrMoreSurplusNeeded W.Coin
-    deriving (Generic, Eq, Show)
-
--- | Small helper record to disambiguate between a fee and change Coin values.
--- Used by 'distributeSurplus'.
-data TxFeeAndChange change = TxFeeAndChange
-    { fee :: W.Coin
-    , change :: change
-    }
-    deriving (Eq, Show)
-
--- | Manipulates a 'TxFeeAndChange' value.
---
-mapTxFeeAndChange
-    :: (W.Coin -> W.Coin)
-    -- ^ A function to transform the fee
-    -> (change1 -> change2)
-    -- ^ A function to transform the change
-    -> TxFeeAndChange change1
-    -- ^ The original fee and change
-    -> TxFeeAndChange change2
-    -- ^ The transformed fee and change
-mapTxFeeAndChange mapFee mapChange TxFeeAndChange {fee, change} =
-    TxFeeAndChange (mapFee fee) (mapChange change)
-
--- | Calculate the cost of increasing a CBOR-encoded Coin-value by another Coin
--- with the lovelace/byte cost given by the 'FeePolicy'.
---
--- Outputs values in the range of [0, 8 * perByteFee]
---
--- >>> let p = FeePolicy (Quantity 0) (Quantity 44)
---
--- >>> costOfIncreasingCoin p 4294967295 1
--- Coin 176 -- (9 bytes - 5 bytes) * 44 lovelace/byte
---
--- >>> costOfIncreasingCoin p 0 4294967296
--- Coin 352 -- 8 bytes * 44 lovelace/byte
-costOfIncreasingCoin
-    :: FeePerByte
-    -> W.Coin -- ^ Original coin
-    -> W.Coin -- ^ Increment
-    -> W.Coin
-costOfIncreasingCoin (FeePerByte perByte) from delta =
-    costOfCoin (from <> delta) <\> costOfCoin from
-  where
-    costOfCoin = W.Coin . (perByte *) . W.unTxSize . sizeOfCoin
-
--- The maximum cost increase 'costOfIncreasingCoin' can return, which is the
--- cost of 8 bytes.
-maximumCostOfIncreasingCoin :: FeePerByte -> W.Coin
-maximumCostOfIncreasingCoin (FeePerByte perByte) = W.Coin $ 8 * perByte
-
--- | Calculate the size of a coin when encoded as CBOR.
-sizeOfCoin :: W.Coin -> W.TxSize
-sizeOfCoin (W.Coin c)
-    | c >= 4_294_967_296 = W.TxSize 9 -- c >= 2^32
-    | c >=        65_536 = W.TxSize 5 -- c >= 2^16
-    | c >=           256 = W.TxSize 3 -- c >= 2^ 8
-    | c >=            24 = W.TxSize 2
-    | otherwise          = W.TxSize 1
-
--- | Distributes a surplus transaction balance between the given change
--- outputs and the given fee. This function is aware of the fact that
--- any increase in a 'Coin' value could increase the size and fee
--- requirement of a transaction.
---
--- When comparing the original fee and change outputs to the adjusted
--- fee and change outputs, this function guarantees that:
---
---    - The number of the change outputs remains constant;
---
---    - The fee quantity either remains the same or increases.
---
---    - For each change output:
---        - the ada quantity either remains constant or increases.
---        - non-ada quantities remain the same.
---
---    - The surplus is conserved:
---        The total increase in the fee and change ada quantities is
---        exactly equal to the surplus.
---
---    - Any increase in cost is covered:
---        If the total cost has increased by 𝛿c, then the fee value
---        will have increased by at least 𝛿c.
---
--- If the cost of distributing the provided surplus is greater than the
--- surplus itself, the function will return 'ErrMoreSurplusNeeded'. If
--- the provided surplus is greater or equal to
--- @maximumCostOfIncreasingCoin feePolicy@, the function will always
--- return 'Right'.
-distributeSurplus
-    :: FeePerByte
-    -> W.Coin
-    -- ^ Surplus transaction balance to distribute.
-    -> TxFeeAndChange [W.TxOut]
-    -- ^ Original fee and change outputs.
-    -> Either ErrMoreSurplusNeeded (TxFeeAndChange [W.TxOut])
-    -- ^ Adjusted fee and change outputs.
-distributeSurplus feePolicy surplus fc@(TxFeeAndChange fee change) =
-    distributeSurplusDelta feePolicy surplus
-        (mapTxFeeAndChange id (fmap W.TxOut.coin) fc)
-    <&> mapTxFeeAndChange
-        (fee <>)
-        (zipWith (flip W.TxOut.addCoin) change)
-
-distributeSurplusDelta
-    :: FeePerByte
-    -> W.Coin
-    -- ^ Surplus to distribute
-    -> TxFeeAndChange [W.Coin]
-    -> Either ErrMoreSurplusNeeded (TxFeeAndChange [W.Coin])
-distributeSurplusDelta feePolicy surplus (TxFeeAndChange fee change) =
-    case change of
-        changeHead : changeTail ->
-            distributeSurplusDeltaWithOneChangeCoin feePolicy surplus
-                (TxFeeAndChange fee changeHead)
-            <&> mapTxFeeAndChange id
-                (: (W.Coin 0 <$ changeTail))
-        [] ->
-            burnSurplusAsFees feePolicy surplus
-                (TxFeeAndChange fee ())
-            <&> mapTxFeeAndChange id
-                (\() -> [])
-
-distributeSurplusDeltaWithOneChangeCoin
-    :: FeePerByte
-    -> W.Coin -- ^ Surplus to distribute
-    -> TxFeeAndChange W.Coin
-    -> Either ErrMoreSurplusNeeded (TxFeeAndChange W.Coin)
-distributeSurplusDeltaWithOneChangeCoin
-    feePolicy surplus fc@(TxFeeAndChange fee0 change0) =
-    let
-        -- We calculate the maximum possible fee increase, by assuming the
-        -- **entire** surplus is added to the change.
-        extraFee = findFixpointIncreasingFeeBy $
-            costOfIncreasingCoin feePolicy change0 surplus
-    in
-        case surplus </> extraFee of
-            Just extraChange ->
-                Right $ TxFeeAndChange
-                    { fee = extraFee
-                    , change = extraChange
-                    }
-            Nothing ->
-                -- The fee increase from adding the surplus to the change was
-                -- greater than the surplus itself. This could happen if the
-                -- surplus is small.
-                burnSurplusAsFees feePolicy surplus
-                    (mapTxFeeAndChange id (const ()) fc)
-                        <&> mapTxFeeAndChange id (\() -> W.Coin 0)
-  where
-    -- Increasing the fee may itself increase the fee. If that is the case, this
-    -- function will increase the fee further. The process repeats until the fee
-    -- doesn't need to be increased.
-    --
-    -- The function will always converge because the result of
-    -- 'costOfIncreasingCoin' is bounded to @8 * feePerByte@.
-    --
-    -- On mainnet it seems unlikely that the function would recurse more than
-    -- one time, and certainly not more than twice. If the protocol parameters
-    -- are updated to allow for slightly more expensive txs, it might be
-    -- possible to hit the boundary at ≈4 ada where the fee would need 9 bytes
-    -- rather than 5. This is already the largest boundary.
-    --
-    -- Note that both the argument and the result of this function are increases
-    -- relative to 'fee0'.
-    --
-    -- == Example ==
-    --
-    -- In this more extreme example the fee is increased from increasing the fee
-    -- itself:
-    --
-    -- @@
-    --     let fee0 = 23
-    --     let feePolicy = -- 300 lovelace / byte
-    --
-    --     findFixpointIncreasingFeeBy 1 = go 0 1
-    --     -- Recurse:
-    --     = go (0 + 1) (costOfIncreasingCoin feePolicy (23 + 0) 1)
-    --     = go (0 + 1) 300
-    --     -- Recurse:
-    --     = go (1 + 300) (costOfIncreasingCoin feePolicy (23 + 1) 300)
-    --     = go 301 300
-    --     = go (301 + 300) (costOfIncreasingCoin feePolicy (23 + 301) 300)
-    --     = go (301 + 300) 0
-    --     = go 601 0
-    --     = 601
-    -- @@
-    findFixpointIncreasingFeeBy = go mempty
-      where
-        go :: W.Coin -> W.Coin -> W.Coin
-        go c (W.Coin 0) = c
-        go c increase = go
-            (c <> increase)
-            (costOfIncreasingCoin feePolicy (c <> fee0) increase)
-
-burnSurplusAsFees
-    :: FeePerByte
-    -> W.Coin -- Surplus
-    -> TxFeeAndChange ()
-    -> Either ErrMoreSurplusNeeded (TxFeeAndChange ())
-burnSurplusAsFees feePolicy surplus (TxFeeAndChange fee0 ())
-    | shortfall > W.Coin 0 =
-        Left $ ErrMoreSurplusNeeded shortfall
-    | otherwise =
-        Right $ TxFeeAndChange surplus ()
-  where
-    costOfBurningSurplus = costOfIncreasingCoin feePolicy fee0 surplus
-    shortfall = costOfBurningSurplus <\> surplus
 
 toLedgerTxOut
     :: HasCallStack

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/Distribute.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/Distribute.hs
@@ -1,0 +1,256 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+module Internal.Cardano.Write.Tx.Balance.Distribute
+    ( distributeSurplus
+    , TxFeeAndChange (..)
+    , ErrMoreSurplusNeeded (..)
+
+    -- ** Internals
+    , distributeSurplusDelta
+    , sizeOfCoin
+    , costOfIncreasingCoin
+    , maximumCostOfIncreasingCoin
+    )
+    where
+
+import Prelude
+
+import Data.Functor
+    ( (<&>)
+    )
+import Data.Monoid.Cancellative
+    ( (</>)
+    )
+import Data.Monoid.Monus
+    ( (<\>)
+    )
+import GHC.Generics
+    ( Generic
+    )
+import Internal.Cardano.Write.Tx
+    ( FeePerByte (..)
+    )
+
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
+
+-- | Indicates that it's impossible for 'distributeSurplus' to distribute a
+-- surplus. As long as the surplus is larger than 'costOfIncreasingCoin', this
+-- should never happen.
+newtype ErrMoreSurplusNeeded = ErrMoreSurplusNeeded W.Coin
+    deriving (Generic, Eq, Show)
+
+-- | Small helper record to disambiguate between a fee and change Coin values.
+-- Used by 'distributeSurplus'.
+data TxFeeAndChange change = TxFeeAndChange
+    { fee :: W.Coin
+    , change :: change
+    }
+    deriving (Eq, Show)
+
+-- | Manipulates a 'TxFeeAndChange' value.
+--
+mapTxFeeAndChange
+    :: (W.Coin -> W.Coin)
+    -- ^ A function to transform the fee
+    -> (change1 -> change2)
+    -- ^ A function to transform the change
+    -> TxFeeAndChange change1
+    -- ^ The original fee and change
+    -> TxFeeAndChange change2
+    -- ^ The transformed fee and change
+mapTxFeeAndChange mapFee mapChange TxFeeAndChange{fee, change} =
+    TxFeeAndChange (mapFee fee) (mapChange change)
+
+-- | Calculate the cost of increasing a CBOR-encoded Coin-value by another Coin
+-- with the lovelace/byte cost given by the 'FeePolicy'.
+--
+-- Outputs values in the range of [0, 8 * perByteFee]
+--
+-- >>> let p = FeePolicy (Quantity 0) (Quantity 44)
+--
+-- >>> costOfIncreasingCoin p 4294967295 1
+-- Coin 176 -- (9 bytes - 5 bytes) * 44 lovelace/byte
+--
+-- >>> costOfIncreasingCoin p 0 4294967296
+-- Coin 352 -- 8 bytes * 44 lovelace/byte
+costOfIncreasingCoin
+    :: FeePerByte
+    -> W.Coin -- ^ Original coin
+    -> W.Coin -- ^ Increment
+    -> W.Coin
+costOfIncreasingCoin (FeePerByte perByte) from delta =
+    costOfCoin (from <> delta) <\> costOfCoin from
+  where
+    costOfCoin = W.Coin . (perByte *) . W.unTxSize . sizeOfCoin
+
+-- The maximum cost increase 'costOfIncreasingCoin' can return, which is the
+-- cost of 8 bytes.
+maximumCostOfIncreasingCoin :: FeePerByte -> W.Coin
+maximumCostOfIncreasingCoin (FeePerByte perByte) = W.Coin $ 8 * perByte
+
+-- | Calculate the size of a coin when encoded as CBOR.
+sizeOfCoin :: W.Coin -> W.TxSize
+sizeOfCoin (W.Coin c)
+    | c >= 4_294_967_296 = W.TxSize 9 -- c >= 2^32
+    | c >=        65_536 = W.TxSize 5 -- c >= 2^16
+    | c >=           256 = W.TxSize 3 -- c >= 2^ 8
+    | c >=            24 = W.TxSize 2
+    | otherwise          = W.TxSize 1
+
+-- | Distributes a surplus transaction balance between the given change
+-- outputs and the given fee. This function is aware of the fact that
+-- any increase in a 'Coin' value could increase the size and fee
+-- requirement of a transaction.
+--
+-- When comparing the original fee and change outputs to the adjusted
+-- fee and change outputs, this function guarantees that:
+--
+--    - The number of the change outputs remains constant;
+--
+--    - The fee quantity either remains the same or increases.
+--
+--    - For each change output:
+--        - the ada quantity either remains constant or increases.
+--        - non-ada quantities remain the same.
+--
+--    - The surplus is conserved:
+--        The total increase in the fee and change ada quantities is
+--        exactly equal to the surplus.
+--
+--    - Any increase in cost is covered:
+--        If the total cost has increased by ??c, then the fee value
+--        will have increased by at least ??c.
+--
+-- If the cost of distributing the provided surplus is greater than the
+-- surplus itself, the function will return 'ErrMoreSurplusNeeded'. If
+-- the provided surplus is greater or equal to
+-- @maximumCostOfIncreasingCoin feePolicy@, the function will always
+-- return 'Right'.
+distributeSurplus
+    :: FeePerByte
+    -> W.Coin
+    -- ^ Surplus transaction balance to distribute.
+    -> TxFeeAndChange [W.TxOut]
+    -- ^ Original fee and change outputs.
+    -> Either ErrMoreSurplusNeeded (TxFeeAndChange [W.TxOut])
+    -- ^ Adjusted fee and change outputs.
+distributeSurplus feePolicy surplus fc@(TxFeeAndChange fee change) =
+    distributeSurplusDelta feePolicy surplus
+        (mapTxFeeAndChange id (fmap W.TxOut.coin) fc)
+    <&> mapTxFeeAndChange
+        (fee <>)
+        (zipWith (flip W.TxOut.addCoin) change)
+
+distributeSurplusDelta
+    :: FeePerByte
+    -> W.Coin
+    -- ^ Surplus to distribute
+    -> TxFeeAndChange [W.Coin]
+    -> Either ErrMoreSurplusNeeded (TxFeeAndChange [W.Coin])
+distributeSurplusDelta feePolicy surplus (TxFeeAndChange fee change) =
+    case change of
+        changeHead : changeTail ->
+            distributeSurplusDeltaWithOneChangeCoin feePolicy surplus
+                (TxFeeAndChange fee changeHead)
+            <&> mapTxFeeAndChange id
+                (: (W.Coin 0 <$ changeTail))
+        [] ->
+            burnSurplusAsFees feePolicy surplus
+                (TxFeeAndChange fee ())
+            <&> mapTxFeeAndChange id
+                (\() -> [])
+
+distributeSurplusDeltaWithOneChangeCoin
+    :: FeePerByte
+    -> W.Coin -- ^ Surplus to distribute
+    -> TxFeeAndChange W.Coin
+    -> Either ErrMoreSurplusNeeded (TxFeeAndChange W.Coin)
+distributeSurplusDeltaWithOneChangeCoin
+    feePolicy surplus fc@(TxFeeAndChange fee0 change0) =
+    let
+        -- We calculate the maximum possible fee increase, by assuming the
+        -- **entire** surplus is added to the change.
+        extraFee = findFixpointIncreasingFeeBy $
+            costOfIncreasingCoin feePolicy change0 surplus
+    in
+        case surplus </> extraFee of
+            Just extraChange ->
+                Right $ TxFeeAndChange
+                    { fee = extraFee
+                    , change = extraChange
+                    }
+            Nothing ->
+                -- The fee increase from adding the surplus to the change was
+                -- greater than the surplus itself. This could happen if the
+                -- surplus is small.
+                burnSurplusAsFees feePolicy surplus
+                    (mapTxFeeAndChange id (const ()) fc)
+                        <&> mapTxFeeAndChange id (\() -> W.Coin 0)
+  where
+    -- Increasing the fee may itself increase the fee. If that is the case, this
+    -- function will increase the fee further. The process repeats until the fee
+    -- doesn't need to be increased.
+    --
+    -- The function will always converge because the result of
+    -- 'costOfIncreasingCoin' is bounded to @8 * feePerByte@.
+    --
+    -- On mainnet it seems unlikely that the function would recurse more than
+    -- one time, and certainly not more than twice. If the protocol parameters
+    -- are updated to allow for slightly more expensive txs, it might be
+    -- possible to hit the boundary at Å4 ada where the fee would need 9 bytes
+    -- rather than 5. This is already the largest boundary.
+    --
+    -- Note that both the argument and the result of this function are increases
+    -- relative to 'fee0'.
+    --
+    -- == Example ==
+    --
+    -- In this more extreme example the fee is increased from increasing the fee
+    -- itself:
+    --
+    -- @@
+    --     let fee0 = 23
+    --     let feePolicy = -- 300 lovelace / byte
+    --
+    --     findFixpointIncreasingFeeBy 1 = go 0 1
+    --     -- Recurse:
+    --     = go (0 + 1) (costOfIncreasingCoin feePolicy (23 + 0) 1)
+    --     = go (0 + 1) 300
+    --     -- Recurse:
+    --     = go (1 + 300) (costOfIncreasingCoin feePolicy (23 + 1) 300)
+    --     = go 301 300
+    --     = go (301 + 300) (costOfIncreasingCoin feePolicy (23 + 301) 300)
+    --     = go (301 + 300) 0
+    --     = go 601 0
+    --     = 601
+    -- @@
+    findFixpointIncreasingFeeBy = go mempty
+      where
+        go :: W.Coin -> W.Coin -> W.Coin
+        go c (W.Coin 0) = c
+        go c increase = go
+            (c <> increase)
+            (costOfIncreasingCoin feePolicy (c <> fee0) increase)
+
+burnSurplusAsFees
+    :: FeePerByte
+    -> W.Coin -- Surplus
+    -> TxFeeAndChange ()
+    -> Either ErrMoreSurplusNeeded (TxFeeAndChange ())
+burnSurplusAsFees feePolicy surplus (TxFeeAndChange fee0 ())
+    | shortfall > W.Coin 0 =
+        Left $ ErrMoreSurplusNeeded shortfall
+    | otherwise =
+        Right $ TxFeeAndChange surplus ()
+  where
+    costOfBurningSurplus = costOfIncreasingCoin feePolicy fee0 surplus
+    shortfall = costOfBurningSurplus <\> surplus

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/Surplus.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance/Surplus.hs
@@ -6,7 +6,7 @@
 -- Copyright: © 2024 Cardano Foundation
 -- License: Apache-2.0
 --
-module Internal.Cardano.Write.Tx.Balance.Distribute
+module Internal.Cardano.Write.Tx.Balance.Surplus
     ( distributeSurplus
     , TxFeeAndChange (..)
     , ErrMoreSurplusNeeded (..)

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/DistributeSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/DistributeSpec.hs
@@ -1,0 +1,576 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NoNumericUnderscores #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+{- HLINT ignore "Use null" -}
+
+module Internal.Cardano.Write.Tx.Balance.DistributeSpec where
+
+import Prelude
+
+import Cardano.Numeric.Util
+    ( power
+    )
+import Data.Either
+    ( isLeft
+    , isRight
+    )
+import Data.Function
+    ( (&)
+    )
+import Data.Generics.Internal.VL.Lens
+    ( view
+    )
+import Data.Maybe
+    ( fromMaybe
+    )
+import Data.Monoid.Monus
+    ( Monus ((<\>))
+    )
+import Internal.Cardano.Write.Tx
+    ( FeePerByte (..)
+    )
+import Internal.Cardano.Write.Tx.Balance.Distribute
+    ( ErrMoreSurplusNeeded (..)
+    , TxFeeAndChange (..)
+    , costOfIncreasingCoin
+    , distributeSurplus
+    , distributeSurplusDelta
+    , maximumCostOfIncreasingCoin
+    , sizeOfCoin
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Property
+    , Testable
+    , arbitrarySizedNatural
+    , checkCoverage
+    , conjoin
+    , counterexample
+    , cover
+    , forAll
+    , frequency
+    , liftShrink2
+    , listOf
+    , property
+    , scale
+    , shrinkList
+    , shrinkMapBy
+    , withMaxSuccess
+    , (===)
+    )
+import Test.QuickCheck.Extra
+    ( report
+    , shrinkNatural
+    )
+
+import qualified Cardano.Api as CardanoApi
+import qualified Cardano.Api.Gen as CardanoApi
+import qualified Cardano.Api.Shelley as CardanoApi
+import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
+    ( Coin (..)
+    )
+import qualified Cardano.Wallet.Primitive.Types.Coin as W.Coin
+import qualified Cardano.Wallet.Primitive.Types.Coin.Gen as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as W
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Write as CBOR
+import qualified Data.ByteString as BS
+import qualified Data.Foldable as F
+
+spec :: Spec
+spec = do
+    describe "sizeOfCoin" $ do
+        let coinToWord64Clamped = fromMaybe maxBound . W.Coin.toWord64Maybe
+        let cborSizeOfCoin =
+                W.TxSize
+                . fromIntegral
+                . BS.length
+                . CBOR.toStrictByteString
+                . CBOR.encodeWord64 . coinToWord64Clamped
+
+        let isBoundary c =
+                sizeOfCoin c /= sizeOfCoin (c <\> W.Coin 1)
+                || sizeOfCoin c /= sizeOfCoin (c <> W.Coin 1)
+
+        it "matches the size of the Word64 CBOR encoding" $
+            property $ checkCoverage $
+                forAll CardanoApi.genEncodingBoundaryLovelace $ \l -> do
+                    let c = cardanoToWalletCoin l
+                    let expected = cborSizeOfCoin c
+
+                    -- Use a low coverage requirement of 0.01% just to
+                    -- ensure we see /some/ amount of every size.
+                    let coverSize s = cover 0.01 (s == expected) (show s)
+                    sizeOfCoin c === expected
+                        & coverSize (W.TxSize 1)
+                        & coverSize (W.TxSize 2)
+                        & coverSize (W.TxSize 3)
+                        & coverSize (W.TxSize 5)
+                        & coverSize (W.TxSize 9)
+                        & cover 0.5 (isBoundary c) "boundary case"
+
+        describe "boundary case goldens" $ do
+            it "1 byte to 2 byte boundary" $ do
+                sizeOfCoin (W.Coin 23) `shouldBe` W.TxSize 1
+                sizeOfCoin (W.Coin 24) `shouldBe` W.TxSize 2
+            it "2 byte to 3 byte boundary" $ do
+                sizeOfCoin (W.Coin $ 2 `power` 8 - 1) `shouldBe` W.TxSize 2
+                sizeOfCoin (W.Coin $ 2 `power` 8    ) `shouldBe` W.TxSize 3
+            it "3 byte to 5 byte boundary" $ do
+                sizeOfCoin (W.Coin $ 2 `power` 16 - 1) `shouldBe` W.TxSize 3
+                sizeOfCoin (W.Coin $ 2 `power` 16    ) `shouldBe` W.TxSize 5
+            it "5 byte to 9 byte boundary" $ do
+                sizeOfCoin (W.Coin $ 2 `power` 32 - 1) `shouldBe` W.TxSize 5
+                sizeOfCoin (W.Coin $ 2 `power` 32    ) `shouldBe` W.TxSize 9
+
+    describe "costOfIncreasingCoin" $ do
+        it "costs 176 lovelace to increase 4294.967295 ada (2^32 - 1 lovelace) \
+           \by 1 lovelace on mainnet" $ do
+
+            let expectedCostIncrease = W.Coin 176
+            let mainnet = mainnetFeePerByte
+            costOfIncreasingCoin mainnet (W.Coin $ 2 `power` 32 - 1) (W.Coin 1)
+                `shouldBe` expectedCostIncrease
+
+        it "produces results in the range [0, 8 * feePerByte]" $
+            property $ \c increase -> do
+                let res = costOfIncreasingCoin (FeePerByte 1) c increase
+                counterexample (show res <> "out of bounds") $
+                    res >= W.Coin 0 && res <= W.Coin 8
+
+    describe "distributeSurplus" $ do
+
+        it "prop_distributeSurplus_onSuccess_conservesSurplus" $
+            prop_distributeSurplus_onSuccess_conservesSurplus
+                & property
+        it "prop_distributeSurplus_onSuccess_coversCostIncrease" $
+            prop_distributeSurplus_onSuccess_coversCostIncrease
+                & property
+        it "prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues" $
+            prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues
+                & property
+        it "prop_distributeSurplus_onSuccess_doesNotReduceFeeValue" $
+            prop_distributeSurplus_onSuccess_doesNotReduceFeeValue
+                & property
+        it "prop_distributeSurplus_onSuccess_preservesChangeLength" $
+            prop_distributeSurplus_onSuccess_preservesChangeLength
+                & property
+        it "prop_distributeSurplus_onSuccess_preservesChangeAddresses" $
+            prop_distributeSurplus_onSuccess_preservesChangeAddresses
+                & property
+        it "prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets" $
+            prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets
+                & property
+        it "prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue" $
+            prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue
+                & property
+        it "prop_distributeSurplus_onSuccess_increasesValuesByDelta" $
+            prop_distributeSurplus_onSuccess_increasesValuesByDelta
+                & property
+
+    describe "distributeSurplusDelta" $ do
+
+        -- NOTE: The test values below make use of 255 being encoded as 2 bytes,
+        -- and 256 as 3 bytes.
+
+        describe "when increasing change increases fee" $
+            it "will increase fee (99 lovelace for change, 1 for fee)" $
+                distributeSurplusDelta
+                    (FeePerByte 1)
+                    (W.Coin 100)
+                    (TxFeeAndChange (W.Coin 200) [W.Coin 200])
+                    `shouldBe`
+                    Right (TxFeeAndChange (W.Coin 1) [W.Coin 99])
+
+        describe "when increasing fee increases fee" $
+            it "will increase fee (98 lovelace for change, 2 for fee)" $ do
+                distributeSurplusDelta
+                    (FeePerByte 1)
+                    (W.Coin 100)
+                    (TxFeeAndChange (W.Coin 255) [W.Coin 200])
+                    `shouldBe`
+                    Right (TxFeeAndChange (W.Coin 2) [W.Coin 98])
+
+        describe
+            (unwords
+                [ "when increasing the change costs more in fees than the"
+                , "increase itself"
+                ]) $ do
+            it "will try burning the surplus as fees" $ do
+                distributeSurplusDelta
+                    mainnetFeePerByte
+                    (W.Coin 10)
+                    (TxFeeAndChange (W.Coin 200) [W.Coin 255])
+                    `shouldBe`
+                    Right (TxFeeAndChange (W.Coin 10) [W.Coin 0])
+
+            it "will fail if neither the fee can be increased" $ do
+                distributeSurplusDelta
+                    mainnetFeePerByte
+                    (W.Coin 10)
+                    (TxFeeAndChange (W.Coin 255) [W.Coin 255])
+                    `shouldBe`
+                    Left (ErrMoreSurplusNeeded $ W.Coin 34)
+
+        describe "when no change output is present" $ do
+            it "will burn surplus as excess fees" $
+                property $ \surplus fee0 -> do
+                    distributeSurplusDelta
+                        (FeePerByte 1)
+                        surplus
+                        (TxFeeAndChange fee0 [])
+                        `shouldBe`
+                        Right (TxFeeAndChange surplus [])
+
+        it "prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus" $
+            prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
+                & withMaxSuccess 10_000
+                & property
+
+-- A helper function to generate properties for 'distributeSurplus' on
+-- success.
+--
+prop_distributeSurplus_onSuccess
+    :: Testable prop
+    => (FeePerByte
+        -> W.Coin
+        -> TxFeeAndChange [W.TxOut]
+        -> TxFeeAndChange [W.TxOut]
+        -> prop)
+    -> FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess propertyToTest policy txSurplus fc =
+    checkCoverage $
+    cover 50
+        (isRight mResult)
+        "isRight mResult" $
+    cover 10
+        (length changeOriginal == 0)
+        "length changeOriginal == 0" $
+    cover 10
+        (length changeOriginal == 1)
+        "length changeOriginal == 1" $
+    cover 50
+        (length changeOriginal >= 2)
+        "length changeOriginal >= 2" $
+    cover 2
+        (feeOriginal == W.Coin 0)
+        "feeOriginal == W.Coin 0" $
+    cover 2
+        (feeOriginal == W.Coin 1)
+        "feeOriginal == W.Coin 1" $
+    cover 50
+        (feeOriginal >= W.Coin 2)
+        "feeOriginal >= W.Coin 2" $
+    cover 1
+        (surplus == W.Coin 0)
+        "surplus == W.Coin 0" $
+    cover 1
+        (surplus == W.Coin 1)
+        "surplus == W.Coin 1" $
+    cover 50
+        (surplus >= W.Coin 2)
+        "surplus >= W.Coin 2" $
+    either
+        (const $ property True)
+        (property . propertyToTest policy surplus fc)
+        mResult
+  where
+    TxBalanceSurplus surplus = txSurplus
+    TxFeeAndChange feeOriginal changeOriginal = fc
+
+    mResult :: Either ErrMoreSurplusNeeded (TxFeeAndChange [W.TxOut])
+    mResult = distributeSurplus policy surplus fc
+
+-- Verifies that the 'distributeSurplus' function conserves the surplus: the
+-- total increase in the fee and change ada quantities should be exactly equal
+-- to the given surplus.
+--
+prop_distributeSurplus_onSuccess_conservesSurplus
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_conservesSurplus =
+    prop_distributeSurplus_onSuccess $ \_policy surplus
+        (TxFeeAndChange feeOriginal changeOriginal)
+        (TxFeeAndChange feeModified changeModified) ->
+        surplus ===
+            (feeModified <> F.foldMap W.TxOut.coin changeModified)
+            <\>
+            (feeOriginal <> F.foldMap W.TxOut.coin changeOriginal)
+
+-- The 'distributeSurplus' function should cover the cost of any increases in
+-- 'Coin' values.
+--
+-- If the total cost of encoding ada quantities has increased by 𝛿c, then the
+-- fee value should have increased by at least 𝛿c.
+--
+prop_distributeSurplus_onSuccess_coversCostIncrease
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_coversCostIncrease =
+    prop_distributeSurplus_onSuccess $ \policy _surplus
+        (TxFeeAndChange feeOriginal changeOriginal)
+        (TxFeeAndChange feeModified changeModified) -> do
+        let coinsOriginal = feeOriginal : (W.TxOut.coin <$> changeOriginal)
+        let coinsModified = feeModified : (W.TxOut.coin <$> changeModified)
+        let coinDeltas = zipWith (<\>) coinsModified coinsOriginal
+        let costIncrease = F.foldMap
+                (uncurry $ costOfIncreasingCoin policy)
+                (coinsOriginal `zip` coinDeltas)
+        feeModified <\> feeOriginal >= costIncrease
+            & report feeModified "feeModified"
+            & report feeOriginal "feeOriginal"
+            & report costIncrease "costIncrease"
+
+-- Since the 'distributeSurplus' function is not aware of the minimum ada
+-- quantity or how to calculate it, it should never allow change ada values to
+-- decrease.
+--
+prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues =
+    prop_distributeSurplus_onSuccess $ \_policy _surplus
+        (TxFeeAndChange _feeOriginal changeOriginal)
+        (TxFeeAndChange _feeModified changeModified) ->
+            all (uncurry (<=)) $ zip
+                (W.TxOut.coin <$> changeOriginal)
+                (W.TxOut.coin <$> changeModified)
+
+-- The 'distributeSurplus' function should never return a 'fee' value that is
+-- less than the original value.
+--
+prop_distributeSurplus_onSuccess_doesNotReduceFeeValue
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_doesNotReduceFeeValue =
+    prop_distributeSurplus_onSuccess $ \_policy _surplus
+        (TxFeeAndChange feeOriginal _changeOriginal)
+        (TxFeeAndChange feeModified _changeModified) ->
+            feeOriginal <= feeModified
+
+-- The 'distributeSurplus' function should increase values by the exact amounts
+-- indicated in 'distributeSurplusDelta'.
+--
+-- This is actually an implementation detail of 'distributeSurplus'.
+--
+-- However, it's useful to verify that this is true by subtracting the delta
+-- values from the result of 'distributeSurplus', which should produce the
+-- original fee and change values.
+--
+prop_distributeSurplus_onSuccess_increasesValuesByDelta
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_increasesValuesByDelta =
+    prop_distributeSurplus_onSuccess $ \policy surplus
+        (TxFeeAndChange feeOriginal changeOriginal)
+        (TxFeeAndChange feeModified changeModified) ->
+            let (TxFeeAndChange feeDelta changeDeltas) =
+                    either (error . show) id
+                    $ distributeSurplusDelta policy surplus
+                    $ TxFeeAndChange
+                        (feeOriginal)
+                        (W.TxOut.coin <$> changeOriginal)
+            in
+            (TxFeeAndChange
+                (feeModified <\> feeDelta)
+                (zipWith W.TxOut.subtractCoin changeDeltas changeModified)
+            )
+            ===
+            TxFeeAndChange feeOriginal changeOriginal
+
+-- The 'distributeSurplus' function should only adjust the very first change
+-- value.  All other change values should be left untouched.
+--
+-- This is actually an implementation detail of 'distributeSurplus'.
+--
+-- In principle, 'distributeSurplus' could allow itself to adjust any of the
+-- change values in order to find a (marginally) more optimal solution.
+-- However, for reasons of simplicity, we only adjust the first change value.
+--
+-- Here we verify that the implementation indeed only adjusts the first change
+-- value, as expected.
+--
+prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue =
+    prop_distributeSurplus_onSuccess $ \_policy _surplus
+        (TxFeeAndChange _feeOriginal changeOriginal)
+        (TxFeeAndChange _feeModified changeModified) ->
+            (drop 1 changeOriginal) ===
+            (drop 1 changeModified)
+
+-- The 'distributeSurplus' function should never adjust addresses of change
+-- outputs.
+--
+prop_distributeSurplus_onSuccess_preservesChangeAddresses
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_preservesChangeAddresses =
+    prop_distributeSurplus_onSuccess $ \_policy _surplus
+        (TxFeeAndChange _feeOriginal changeOriginal)
+        (TxFeeAndChange _feeModified changeModified) ->
+            (view #address <$> changeOriginal) ===
+            (view #address <$> changeModified)
+
+-- The 'distributeSurplus' function should always return exactly the same
+-- number of change outputs that it was given. It should never create or
+-- destroy change outputs.
+--
+prop_distributeSurplus_onSuccess_preservesChangeLength
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_preservesChangeLength =
+    prop_distributeSurplus_onSuccess $ \_policy _surplus
+        (TxFeeAndChange _feeOriginal changeOriginal)
+        (TxFeeAndChange _feeModified changeModified) ->
+            length changeOriginal === length changeModified
+
+-- The 'distributeSurplus' function should never adjust the values of non-ada
+-- assets.
+--
+prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets
+    :: FeePerByte
+    -> TxBalanceSurplus W.Coin
+    -> TxFeeAndChange [W.TxOut]
+    -> Property
+prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets =
+    prop_distributeSurplus_onSuccess $ \_policy _surplus
+        (TxFeeAndChange _feeOriginal changeOriginal)
+        (TxFeeAndChange _feeModified changeModified) ->
+            (view (#tokens . #tokens) <$> changeOriginal) ===
+            (view (#tokens . #tokens) <$> changeModified)
+
+-- Verify that 'distributeSurplusDelta':
+--
+--    - covers the increase to the fee requirement incurred as a result of
+--      increasing the fee value and change values.
+--
+--    - conserves the surplus:
+--        - feeDelta + sum changeDeltas == surplus
+--
+prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
+    :: FeePerByte -> W.Coin -> W.Coin -> [W.Coin] -> Property
+prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
+    feePolicy surplus fee0 change0 =
+    checkCoverage $
+    cover 2  (isLeft  mres) "Failure" $
+    cover 50 (isRight mres) "Success" $
+    report mres "Result" $
+    counterexample (show mres) $ case mres of
+        Left (ErrMoreSurplusNeeded shortfall) ->
+            conjoin
+                [ property $ surplus < maxCoinCostIncrease
+                , property $ shortfall > W.Coin 0
+                , costOfIncreasingCoin feePolicy fee0 surplus
+                    === surplus <> shortfall
+                ]
+        Right (TxFeeAndChange feeDelta changeDeltas) -> do
+            let feeRequirementIncrease = mconcat
+                    [ costOfIncreasingCoin feePolicy fee0 feeDelta
+                    , F.fold $ zipWith (costOfIncreasingCoin feePolicy)
+                        change0
+                        changeDeltas
+                    ]
+            conjoin
+                [ property $ feeDelta >= feeRequirementIncrease
+                    & counterexample ("fee requirement increased by "
+                        <> show feeRequirementIncrease
+                        <> " but the fee delta was just "
+                        <> show feeDelta
+                        )
+                , F.fold changeDeltas <> feeDelta
+                    === surplus
+                ]
+  where
+    mres = distributeSurplusDelta
+        feePolicy surplus (TxFeeAndChange fee0 change0)
+    maxCoinCostIncrease = maximumCostOfIncreasingCoin feePolicy
+
+--------------------------------------------------------------------------------
+-- Utils
+--------------------------------------------------------------------------------
+
+cardanoToWalletCoin :: CardanoApi.Lovelace -> W.Coin
+cardanoToWalletCoin = Convert.toWallet . CardanoApi.toShelleyLovelace
+
+mainnetFeePerByte :: FeePerByte
+mainnetFeePerByte = FeePerByte 44
+
+--------------------------------------------------------------------------------
+-- Generators
+--------------------------------------------------------------------------------
+
+newtype TxBalanceSurplus a = TxBalanceSurplus {unTxBalanceSurplus :: a}
+    deriving (Eq, Show)
+
+instance Arbitrary (TxBalanceSurplus W.Coin) where
+    -- We want to test cases where the surplus is zero. So it's important that
+    -- we do not restrict ourselves to positive coins here.
+    arbitrary = TxBalanceSurplus <$> frequency
+        [ (8, W.genCoin)
+        , (4, W.genCoin & scale (* (2 `power`  4)))
+        , (2, W.genCoin & scale (* (2 `power`  8)))
+        , (1, W.genCoin & scale (* (2 `power` 16)))
+        ]
+    shrink = shrinkMapBy TxBalanceSurplus unTxBalanceSurplus W.shrinkCoin
+
+instance Arbitrary (TxFeeAndChange [W.TxOut]) where
+    arbitrary = do
+        fee <- W.genCoin
+        change <- frequency
+            [ (1, pure [])
+            , (1, (: []) <$> W.genTxOut)
+            , (6, listOf W.genTxOut)
+            ]
+        pure $ TxFeeAndChange{fee, change}
+    shrink (TxFeeAndChange fee change) =
+        uncurry TxFeeAndChange <$> liftShrink2
+            (W.shrinkCoin)
+            (shrinkList W.shrinkTxOut)
+            (fee, change)
+
+instance Arbitrary W.Coin where
+    arbitrary = W.genCoinPositive
+    shrink = W.shrinkCoinPositive
+
+instance Arbitrary FeePerByte where
+    arbitrary = frequency
+        [ (1, pure mainnetFeePerByte)
+        , (7, FeePerByte <$> arbitrarySizedNatural)
+        ]
+    shrink (FeePerByte x) =
+        FeePerByte <$> shrinkNatural x

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/SurplusSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/SurplusSpec.hs
@@ -7,7 +7,7 @@
 
 {- HLINT ignore "Use null" -}
 
-module Internal.Cardano.Write.Tx.Balance.DistributeSpec where
+module Internal.Cardano.Write.Tx.Balance.SurplusSpec where
 
 import Prelude
 
@@ -33,7 +33,7 @@ import Data.Monoid.Monus
 import Internal.Cardano.Write.Tx
     ( FeePerByte (..)
     )
-import Internal.Cardano.Write.Tx.Balance.Distribute
+import Internal.Cardano.Write.Tx.Balance.Surplus
     ( ErrMoreSurplusNeeded (..)
     , TxFeeAndChange (..)
     , costOfIncreasingCoin

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -103,9 +103,6 @@ import Cardano.Mnemonic
     , entropyToMnemonic
     , mkEntropy
     )
-import Cardano.Numeric.Util
-    ( power
-    )
 import Cardano.Wallet.Address.Constants
     ( maxLengthAddressForByron
     )
@@ -184,8 +181,7 @@ import Data.Default
     ( Default (..)
     )
 import Data.Either
-    ( isLeft
-    , isRight
+    ( isRight
     )
 import Data.Function
     ( (&)
@@ -219,10 +215,6 @@ import Data.Map.Strict
 import Data.Maybe
     ( catMaybes
     , fromJust
-    , fromMaybe
-    )
-import Data.Monoid.Monus
-    ( Monus ((<\>))
     )
 import Data.Ratio
     ( (%)
@@ -293,24 +285,17 @@ import Internal.Cardano.Write.Tx.Balance
     , ErrBalanceTxInternalError (..)
     , ErrBalanceTxOutputError (..)
     , ErrBalanceTxOutputErrorInfo (..)
-    , ErrMoreSurplusNeeded (..)
     , ErrUpdateTx (..)
     , PartialTx (..)
     , Redeemer (..)
-    , TxFeeAndChange (..)
     , TxFeeUpdate (UseNewTxFee)
     , TxUpdate (TxUpdate)
     , UTxOAssumptions (..)
     , balanceTx
     , constructUTxOIndex
-    , costOfIncreasingCoin
-    , distributeSurplus
-    , distributeSurplusDelta
     , fromWalletUTxO
-    , maximumCostOfIncreasingCoin
     , mergeSignedValue
     , noTxUpdate
-    , sizeOfCoin
     , splitSignedValue
     , toWalletUTxO
     , updateTx
@@ -376,9 +361,7 @@ import Test.Hspec.QuickCheck
     )
 import Test.QuickCheck
     ( Arbitrary (..)
-    , Arbitrary2 (liftShrink2)
     , Property
-    , Testable
     , arbitraryBoundedEnum
     , arbitrarySizedNatural
     , checkCoverage
@@ -387,7 +370,6 @@ import Test.QuickCheck
     , counterexample
     , cover
     , elements
-    , forAll
     , frequency
     , label
     , listOf
@@ -409,7 +391,6 @@ import Test.QuickCheck.Extra
     , genDisjointPair
     , genericRoundRobinShrink
     , getDisjointPair
-    , report
     , shrinkDisjointPair
     , shrinkNatural
     , (.>=.)
@@ -477,11 +458,7 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
     ( TxOut (..)
     )
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W.TxOut
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen as W
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
-import qualified Codec.CBOR.Encoding as CBOR
-import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Foldable as F
@@ -502,7 +479,6 @@ import qualified Test.Hspec.Extra as Hspec
 spec :: Spec
 spec = do
     spec_balanceTx
-    spec_distributeSurplus
     spec_estimateSignedTxSize
     spec_updateTx
 
@@ -971,156 +947,6 @@ balanceTxGoldenSpec = describe "balance goldens" $ do
         Write.evaluateMinimumFee mockPParamsForBalancing
             tx
             (estimateKeyWitnessCounts u tx mempty)
-
-spec_distributeSurplus :: Spec
-spec_distributeSurplus = describe "distributeSurplus" $ do
-    describe "sizeOfCoin" $ do
-        let coinToWord64Clamped = fromMaybe maxBound . W.Coin.toWord64Maybe
-        let cborSizeOfCoin =
-                W.TxSize
-                . fromIntegral
-                . BS.length
-                . CBOR.toStrictByteString
-                . CBOR.encodeWord64 . coinToWord64Clamped
-
-        let isBoundary c =
-                sizeOfCoin c /= sizeOfCoin (c <\> W.Coin 1)
-                || sizeOfCoin c /= sizeOfCoin (c <> W.Coin 1)
-
-        it "matches the size of the Word64 CBOR encoding" $
-            property $ checkCoverage $
-                forAll CardanoApi.genEncodingBoundaryLovelace $ \l -> do
-                    let c = cardanoToWalletCoin l
-                    let expected = cborSizeOfCoin c
-
-                    -- Use a low coverage requirement of 0.01% just to
-                    -- ensure we see /some/ amount of every size.
-                    let coverSize s = cover 0.01 (s == expected) (show s)
-                    sizeOfCoin c === expected
-                        & coverSize (W.TxSize 1)
-                        & coverSize (W.TxSize 2)
-                        & coverSize (W.TxSize 3)
-                        & coverSize (W.TxSize 5)
-                        & coverSize (W.TxSize 9)
-                        & cover 0.5 (isBoundary c) "boundary case"
-
-        describe "boundary case goldens" $ do
-            it "1 byte to 2 byte boundary" $ do
-                sizeOfCoin (W.Coin 23) `shouldBe` W.TxSize 1
-                sizeOfCoin (W.Coin 24) `shouldBe` W.TxSize 2
-            it "2 byte to 3 byte boundary" $ do
-                sizeOfCoin (W.Coin $ 2 `power` 8 - 1) `shouldBe` W.TxSize 2
-                sizeOfCoin (W.Coin $ 2 `power` 8    ) `shouldBe` W.TxSize 3
-            it "3 byte to 5 byte boundary" $ do
-                sizeOfCoin (W.Coin $ 2 `power` 16 - 1) `shouldBe` W.TxSize 3
-                sizeOfCoin (W.Coin $ 2 `power` 16    ) `shouldBe` W.TxSize 5
-            it "5 byte to 9 byte boundary" $ do
-                sizeOfCoin (W.Coin $ 2 `power` 32 - 1) `shouldBe` W.TxSize 5
-                sizeOfCoin (W.Coin $ 2 `power` 32    ) `shouldBe` W.TxSize 9
-
-    describe "costOfIncreasingCoin" $ do
-        it "costs 176 lovelace to increase 4294.967295 ada (2^32 - 1 lovelace) \
-           \by 1 lovelace on mainnet" $ do
-
-            let expectedCostIncrease = W.Coin 176
-            let mainnet = mainnetFeePerByte
-            costOfIncreasingCoin mainnet (W.Coin $ 2 `power` 32 - 1) (W.Coin 1)
-                `shouldBe` expectedCostIncrease
-
-        it "produces results in the range [0, 8 * feePerByte]" $
-            property $ \c increase -> do
-                let res = costOfIncreasingCoin (FeePerByte 1) c increase
-                counterexample (show res <> "out of bounds") $
-                    res >= W.Coin 0 && res <= W.Coin 8
-
-    describe "distributeSurplus" $ do
-
-        it "prop_distributeSurplus_onSuccess_conservesSurplus" $
-            prop_distributeSurplus_onSuccess_conservesSurplus
-                & property
-        it "prop_distributeSurplus_onSuccess_coversCostIncrease" $
-            prop_distributeSurplus_onSuccess_coversCostIncrease
-                & property
-        it "prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues" $
-            prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues
-                & property
-        it "prop_distributeSurplus_onSuccess_doesNotReduceFeeValue" $
-            prop_distributeSurplus_onSuccess_doesNotReduceFeeValue
-                & property
-        it "prop_distributeSurplus_onSuccess_preservesChangeLength" $
-            prop_distributeSurplus_onSuccess_preservesChangeLength
-                & property
-        it "prop_distributeSurplus_onSuccess_preservesChangeAddresses" $
-            prop_distributeSurplus_onSuccess_preservesChangeAddresses
-                & property
-        it "prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets" $
-            prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets
-                & property
-        it "prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue" $
-            prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue
-                & property
-        it "prop_distributeSurplus_onSuccess_increasesValuesByDelta" $
-            prop_distributeSurplus_onSuccess_increasesValuesByDelta
-                & property
-
-    describe "distributeSurplusDelta" $ do
-
-        -- NOTE: The test values below make use of 255 being encoded as 2 bytes,
-        -- and 256 as 3 bytes.
-
-        describe "when increasing change increases fee" $
-            it "will increase fee (99 lovelace for change, 1 for fee)" $
-                distributeSurplusDelta
-                    (FeePerByte 1)
-                    (W.Coin 100)
-                    (TxFeeAndChange (W.Coin 200) [W.Coin 200])
-                    `shouldBe`
-                    Right (TxFeeAndChange (W.Coin 1) [W.Coin 99])
-
-        describe "when increasing fee increases fee" $
-            it "will increase fee (98 lovelace for change, 2 for fee)" $ do
-                distributeSurplusDelta
-                    (FeePerByte 1)
-                    (W.Coin 100)
-                    (TxFeeAndChange (W.Coin 255) [W.Coin 200])
-                    `shouldBe`
-                    Right (TxFeeAndChange (W.Coin 2) [W.Coin 98])
-
-        describe
-            (unwords
-                [ "when increasing the change costs more in fees than the"
-                , "increase itself"
-                ]) $ do
-            it "will try burning the surplus as fees" $ do
-                distributeSurplusDelta
-                    mainnetFeePerByte
-                    (W.Coin 10)
-                    (TxFeeAndChange (W.Coin 200) [W.Coin 255])
-                    `shouldBe`
-                    Right (TxFeeAndChange (W.Coin 10) [W.Coin 0])
-
-            it "will fail if neither the fee can be increased" $ do
-                distributeSurplusDelta
-                    mainnetFeePerByte
-                    (W.Coin 10)
-                    (TxFeeAndChange (W.Coin 255) [W.Coin 255])
-                    `shouldBe`
-                    Left (ErrMoreSurplusNeeded $ W.Coin 34)
-
-        describe "when no change output is present" $ do
-            it "will burn surplus as excess fees" $
-                property $ \surplus fee0 -> do
-                    distributeSurplusDelta
-                        (FeePerByte 1)
-                        surplus
-                        (TxFeeAndChange fee0 [])
-                        `shouldBe`
-                        Right (TxFeeAndChange surplus [])
-
-        it "prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus" $
-            prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
-                & withMaxSuccess 10_000
-                & property
 
 spec_estimateSignedTxSize :: Spec
 spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
@@ -1705,285 +1531,6 @@ prop_bootstrapWitnesses
             (toHDPayloadAddress addr)
             (CardanoApi.toByronNetworkMagic network)
 
--- A helper function to generate properties for 'distributeSurplus' on
--- success.
---
-prop_distributeSurplus_onSuccess
-    :: Testable prop
-    => (FeePerByte
-        -> W.Coin
-        -> TxFeeAndChange [W.TxOut]
-        -> TxFeeAndChange [W.TxOut]
-        -> prop)
-    -> FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess propertyToTest policy txSurplus fc =
-    checkCoverage $
-    cover 50
-        (isRight mResult)
-        "isRight mResult" $
-    cover 10
-        (length changeOriginal == 0)
-        "length changeOriginal == 0" $
-    cover 10
-        (length changeOriginal == 1)
-        "length changeOriginal == 1" $
-    cover 50
-        (length changeOriginal >= 2)
-        "length changeOriginal >= 2" $
-    cover 2
-        (feeOriginal == W.Coin 0)
-        "feeOriginal == W.Coin 0" $
-    cover 2
-        (feeOriginal == W.Coin 1)
-        "feeOriginal == W.Coin 1" $
-    cover 50
-        (feeOriginal >= W.Coin 2)
-        "feeOriginal >= W.Coin 2" $
-    cover 1
-        (surplus == W.Coin 0)
-        "surplus == W.Coin 0" $
-    cover 1
-        (surplus == W.Coin 1)
-        "surplus == W.Coin 1" $
-    cover 50
-        (surplus >= W.Coin 2)
-        "surplus >= W.Coin 2" $
-    either
-        (const $ property True)
-        (property . propertyToTest policy surplus fc)
-        mResult
-  where
-    TxBalanceSurplus surplus = txSurplus
-    TxFeeAndChange feeOriginal changeOriginal = fc
-
-    mResult :: Either ErrMoreSurplusNeeded (TxFeeAndChange [W.TxOut])
-    mResult = distributeSurplus policy surplus fc
-
--- Verifies that the 'distributeSurplus' function conserves the surplus: the
--- total increase in the fee and change ada quantities should be exactly equal
--- to the given surplus.
---
-prop_distributeSurplus_onSuccess_conservesSurplus
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_conservesSurplus =
-    prop_distributeSurplus_onSuccess $ \_policy surplus
-        (TxFeeAndChange feeOriginal changeOriginal)
-        (TxFeeAndChange feeModified changeModified) ->
-        surplus ===
-            (feeModified <> F.foldMap W.TxOut.coin changeModified)
-            <\>
-            (feeOriginal <> F.foldMap W.TxOut.coin changeOriginal)
-
--- The 'distributeSurplus' function should cover the cost of any increases in
--- 'Coin' values.
---
--- If the total cost of encoding ada quantities has increased by 𝛿c, then the
--- fee value should have increased by at least 𝛿c.
---
-prop_distributeSurplus_onSuccess_coversCostIncrease
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_coversCostIncrease =
-    prop_distributeSurplus_onSuccess $ \policy _surplus
-        (TxFeeAndChange feeOriginal changeOriginal)
-        (TxFeeAndChange feeModified changeModified) -> do
-        let coinsOriginal = feeOriginal : (W.TxOut.coin <$> changeOriginal)
-        let coinsModified = feeModified : (W.TxOut.coin <$> changeModified)
-        let coinDeltas = zipWith (<\>) coinsModified coinsOriginal
-        let costIncrease = F.foldMap
-                (uncurry $ costOfIncreasingCoin policy)
-                (coinsOriginal `zip` coinDeltas)
-        feeModified <\> feeOriginal >= costIncrease
-            & report feeModified "feeModified"
-            & report feeOriginal "feeOriginal"
-            & report costIncrease "costIncrease"
-
--- Since the 'distributeSurplus' function is not aware of the minimum ada
--- quantity or how to calculate it, it should never allow change ada values to
--- decrease.
---
-prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_doesNotReduceChangeCoinValues =
-    prop_distributeSurplus_onSuccess $ \_policy _surplus
-        (TxFeeAndChange _feeOriginal changeOriginal)
-        (TxFeeAndChange _feeModified changeModified) ->
-            all (uncurry (<=)) $ zip
-                (W.TxOut.coin <$> changeOriginal)
-                (W.TxOut.coin <$> changeModified)
-
--- The 'distributeSurplus' function should never return a 'fee' value that is
--- less than the original value.
---
-prop_distributeSurplus_onSuccess_doesNotReduceFeeValue
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_doesNotReduceFeeValue =
-    prop_distributeSurplus_onSuccess $ \_policy _surplus
-        (TxFeeAndChange feeOriginal _changeOriginal)
-        (TxFeeAndChange feeModified _changeModified) ->
-            feeOriginal <= feeModified
-
--- The 'distributeSurplus' function should increase values by the exact amounts
--- indicated in 'distributeSurplusDelta'.
---
--- This is actually an implementation detail of 'distributeSurplus'.
---
--- However, it's useful to verify that this is true by subtracting the delta
--- values from the result of 'distributeSurplus', which should produce the
--- original fee and change values.
---
-prop_distributeSurplus_onSuccess_increasesValuesByDelta
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_increasesValuesByDelta =
-    prop_distributeSurplus_onSuccess $ \policy surplus
-        (TxFeeAndChange feeOriginal changeOriginal)
-        (TxFeeAndChange feeModified changeModified) ->
-            let (TxFeeAndChange feeDelta changeDeltas) =
-                    either (error . show) id
-                    $ distributeSurplusDelta policy surplus
-                    $ TxFeeAndChange
-                        (feeOriginal)
-                        (W.TxOut.coin <$> changeOriginal)
-            in
-            (TxFeeAndChange
-                (feeModified <\> feeDelta)
-                (zipWith W.TxOut.subtractCoin changeDeltas changeModified)
-            )
-            ===
-            TxFeeAndChange feeOriginal changeOriginal
-
--- The 'distributeSurplus' function should only adjust the very first change
--- value.  All other change values should be left untouched.
---
--- This is actually an implementation detail of 'distributeSurplus'.
---
--- In principle, 'distributeSurplus' could allow itself to adjust any of the
--- change values in order to find a (marginally) more optimal solution.
--- However, for reasons of simplicity, we only adjust the first change value.
---
--- Here we verify that the implementation indeed only adjusts the first change
--- value, as expected.
---
-prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_onlyAdjustsFirstChangeValue =
-    prop_distributeSurplus_onSuccess $ \_policy _surplus
-        (TxFeeAndChange _feeOriginal changeOriginal)
-        (TxFeeAndChange _feeModified changeModified) ->
-            (drop 1 changeOriginal) ===
-            (drop 1 changeModified)
-
--- The 'distributeSurplus' function should never adjust addresses of change
--- outputs.
---
-prop_distributeSurplus_onSuccess_preservesChangeAddresses
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_preservesChangeAddresses =
-    prop_distributeSurplus_onSuccess $ \_policy _surplus
-        (TxFeeAndChange _feeOriginal changeOriginal)
-        (TxFeeAndChange _feeModified changeModified) ->
-            (view #address <$> changeOriginal) ===
-            (view #address <$> changeModified)
-
--- The 'distributeSurplus' function should always return exactly the same
--- number of change outputs that it was given. It should never create or
--- destroy change outputs.
---
-prop_distributeSurplus_onSuccess_preservesChangeLength
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_preservesChangeLength =
-    prop_distributeSurplus_onSuccess $ \_policy _surplus
-        (TxFeeAndChange _feeOriginal changeOriginal)
-        (TxFeeAndChange _feeModified changeModified) ->
-            length changeOriginal === length changeModified
-
--- The 'distributeSurplus' function should never adjust the values of non-ada
--- assets.
---
-prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets
-    :: FeePerByte
-    -> TxBalanceSurplus W.Coin
-    -> TxFeeAndChange [W.TxOut]
-    -> Property
-prop_distributeSurplus_onSuccess_preservesChangeNonAdaAssets =
-    prop_distributeSurplus_onSuccess $ \_policy _surplus
-        (TxFeeAndChange _feeOriginal changeOriginal)
-        (TxFeeAndChange _feeModified changeModified) ->
-            (view (#tokens . #tokens) <$> changeOriginal) ===
-            (view (#tokens . #tokens) <$> changeModified)
-
--- Verify that 'distributeSurplusDelta':
---
---    - covers the increase to the fee requirement incurred as a result of
---      increasing the fee value and change values.
---
---    - conserves the surplus:
---        - feeDelta + sum changeDeltas == surplus
---
-prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
-    :: FeePerByte -> W.Coin -> W.Coin -> [W.Coin] -> Property
-prop_distributeSurplusDelta_coversCostIncreaseAndConservesSurplus
-    feePolicy surplus fee0 change0 =
-    checkCoverage $
-    cover 2  (isLeft  mres) "Failure" $
-    cover 50 (isRight mres) "Success" $
-    report mres "Result" $
-    counterexample (show mres) $ case mres of
-        Left (ErrMoreSurplusNeeded shortfall) ->
-            conjoin
-                [ property $ surplus < maxCoinCostIncrease
-                , property $ shortfall > W.Coin 0
-                , costOfIncreasingCoin feePolicy fee0 surplus
-                    === surplus <> shortfall
-                ]
-        Right (TxFeeAndChange feeDelta changeDeltas) -> do
-            let feeRequirementIncrease = mconcat
-                    [ costOfIncreasingCoin feePolicy fee0 feeDelta
-                    , F.fold $ zipWith (costOfIncreasingCoin feePolicy)
-                        change0
-                        changeDeltas
-                    ]
-            conjoin
-                [ property $ feeDelta >= feeRequirementIncrease
-                    & counterexample ("fee requirement increased by "
-                        <> show feeRequirementIncrease
-                        <> " but the fee delta was just "
-                        <> show feeDelta
-                        )
-                , F.fold changeDeltas <> feeDelta
-                    === surplus
-                ]
-  where
-    mres = distributeSurplusDelta
-        feePolicy surplus (TxFeeAndChange fee0 change0)
-    maxCoinCostIncrease = maximumCostOfIncreasingCoin feePolicy
-
 -- TODO [ADO-2997] Test this property in all recent eras.
 -- https://cardanofoundation.atlassian.net/browse/ADP-2997
 prop_updateTx
@@ -2159,9 +1706,6 @@ newtype DummyChangeState = DummyChangeState { nextUnusedIndex :: Int }
 
 -- | Encapsulates a value that may be negative or positive or a mixture of both.
 newtype MixedSign a = MixedSign a
-    deriving (Eq, Show)
-
-newtype TxBalanceSurplus a = TxBalanceSurplus {unTxBalanceSurplus :: a}
     deriving (Eq, Show)
 
 data Wallet era = Wallet UTxOAssumptions (UTxO era) AnyChangeAddressGenWithState
@@ -2340,9 +1884,6 @@ withValidityInterval
     -> PartialTx BabbageEra
     -> PartialTx BabbageEra
 withValidityInterval vi = #tx . bodyTxL %~ vldtTxBodyL .~ vi
-
-cardanoToWalletCoin :: CardanoApi.Lovelace -> W.Coin
-cardanoToWalletCoin = Convert.toWallet . CardanoApi.toShelleyLovelace
 
 cardanoToWalletTxOut
     :: forall era. IsRecentEra era
@@ -2699,32 +2240,6 @@ instance Arbitrary W.TokenBundle where
 instance Arbitrary (DisjointPair W.TokenBundle) where
     arbitrary = genDisjointPair W.genTokenBundle
     shrink = shrinkDisjointPair W.shrinkTokenBundle
-
-instance Arbitrary (TxBalanceSurplus W.Coin) where
-    -- We want to test cases where the surplus is zero. So it's important that
-    -- we do not restrict ourselves to positive coins here.
-    arbitrary = TxBalanceSurplus <$> frequency
-        [ (8, W.genCoin)
-        , (4, W.genCoin & scale (* (2 `power`  4)))
-        , (2, W.genCoin & scale (* (2 `power`  8)))
-        , (1, W.genCoin & scale (* (2 `power` 16)))
-        ]
-    shrink = shrinkMapBy TxBalanceSurplus unTxBalanceSurplus W.shrinkCoin
-
-instance Arbitrary (TxFeeAndChange [W.TxOut]) where
-    arbitrary = do
-        fee <- W.genCoin
-        change <- frequency
-            [ (1, pure [])
-            , (1, (: []) <$> W.genTxOut)
-            , (6, listOf W.genTxOut)
-            ]
-        pure $ TxFeeAndChange fee change
-    shrink (TxFeeAndChange fee change) =
-        uncurry TxFeeAndChange <$> liftShrink2
-            (W.shrinkCoin)
-            (shrinkList W.shrinkTxOut)
-            (fee, change)
 
 instance Arbitrary W.TxIn where
     arbitrary = do


### PR DESCRIPTION
- [x] Move `distributeSurplus` to new `Balance.Distribute` module.

### Comments

Smaller alternative to #4537, now without the `Size` hierarchy idea.

### Issue Number

None directly.