### PR TITLE
[ADP-3272] Use `Write.UTxO era` type in `Wallet` test type.

### DIFF
--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1999,17 +1999,13 @@ prop_updateTx tx extraIns extraCol extraOuts newFee = do
         [ inputs tx' === inputs tx
             <> Set.fromList (fromWalletTxIn . fst <$> extraIns)
         , outputs tx' === (outputs tx)
-            <> StrictSeq.fromList (fromWalletTxOut <$> extraOuts)
+            <> StrictSeq.fromList (fromWalletTxOut era <$> extraOuts)
         , fee tx' === Convert.toLedger newFee
         , collateralIns tx' === collateralIns tx
             <> Set.fromList (fromWalletTxIn <$> extraCol)
         ]
   where
     era = Write.recentEra @era
-
-    fromWalletTxOut :: W.TxOut -> TxOut era
-    fromWalletTxOut = case era of
-        RecentEraBabbage -> Convert.toBabbageTxOut
 
     fromWalletTxIn = Convert.toLedger
 
@@ -2247,6 +2243,11 @@ deserializeBabbageTx
     = fromCardanoApiTx
     . either (error . show) id
     . CardanoApi.deserialiseFromCBOR (CardanoApi.AsTx CardanoApi.AsBabbageEra)
+
+fromWalletTxOut :: RecentEra era -> W.TxOut -> TxOut era
+fromWalletTxOut era = case era of
+    RecentEraBabbage -> Convert.toBabbageTxOut
+    RecentEraConway -> Convert.toConwayTxOut
 
 hasInsCollateral
     :: forall era. IsRecentEra era

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1999,14 +1999,12 @@ prop_updateTx tx extraIns extraCol extraOuts newFee = do
         [ inputs tx' === inputs tx
             <> Set.fromList (fromWalletTxIn . fst <$> extraIns)
         , outputs tx' === (outputs tx)
-            <> StrictSeq.fromList (fromWalletTxOut era <$> extraOuts)
+            <> StrictSeq.fromList (fromWalletTxOut <$> extraOuts)
         , fee tx' === Convert.toLedger newFee
         , collateralIns tx' === collateralIns tx
             <> Set.fromList (fromWalletTxIn <$> extraCol)
         ]
   where
-    era = Write.recentEra @era
-
     fromWalletTxIn = Convert.toLedger
 
     inputs = view (bodyTxL . inputsTxBodyL)
@@ -2244,8 +2242,8 @@ deserializeBabbageTx
     . either (error . show) id
     . CardanoApi.deserialiseFromCBOR (CardanoApi.AsTx CardanoApi.AsBabbageEra)
 
-fromWalletTxOut :: RecentEra era -> W.TxOut -> TxOut era
-fromWalletTxOut era = case era of
+fromWalletTxOut :: forall era. IsRecentEra era => W.TxOut -> TxOut era
+fromWalletTxOut = case recentEra @era of
     RecentEraBabbage -> Convert.toBabbageTxOut
     RecentEraConway -> Convert.toConwayTxOut
 

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2770,12 +2770,14 @@ instance Arbitrary Wallet where
         ]
       where
         genShelleyVkAddr :: Gen (CardanoApi.AddressInEra CardanoApi.BabbageEra)
-        genShelleyVkAddr = CardanoApi.shelleyAddressInEra
-            CardanoApi.ShelleyBasedEraBabbage
-            <$> (CardanoApi.makeShelleyAddress
+        genShelleyVkAddr
+            = fmap (CardanoApi.shelleyAddressInEra era)
+            $ CardanoApi.makeShelleyAddress
                 <$> CardanoApi.genNetworkId
                 <*> CardanoApi.genPaymentCredential -- only vk credentials
-                <*> CardanoApi.genStakeAddressReference)
+                <*> CardanoApi.genStakeAddressReference
+          where
+            era = CardanoApi.ShelleyBasedEraBabbage
 
         genByronVkAddr :: Gen (CardanoApi.AddressInEra CardanoApi.BabbageEra)
         genByronVkAddr = CardanoApi.byronAddressInEra
@@ -2790,12 +2792,13 @@ instance Arbitrary Wallet where
                 genIn = W.genTxIn
 
                 genOut :: Gen W.TxOut
-                genOut = cardanoToWalletTxOut <$>
-                    (CardanoApi.TxOut
+                genOut
+                    = fmap cardanoToWalletTxOut
+                    $ CardanoApi.TxOut
                         <$> genAddr
                         <*> scale (* 2) (CardanoApi.genTxOutValue era)
                         <*> pure CardanoApi.TxOutDatumNone
-                        <*> pure CardanoApi.ReferenceScriptNone)
+                        <*> pure CardanoApi.ReferenceScriptNone
                   where
                     era = CardanoApi.BabbageEra
 

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2005,8 +2005,6 @@ prop_updateTx tx extraIns extraCol extraOuts newFee = do
             <> Set.fromList (fromWalletTxIn <$> extraCol)
         ]
   where
-    fromWalletTxIn = Convert.toLedger
-
     inputs = view (bodyTxL . inputsTxBodyL)
     outputs = view (bodyTxL . outputsTxBodyL)
     collateralIns = view (bodyTxL . collateralInputsTxBodyL)
@@ -2241,6 +2239,9 @@ deserializeBabbageTx
     = fromCardanoApiTx
     . either (error . show) id
     . CardanoApi.deserialiseFromCBOR (CardanoApi.AsTx CardanoApi.AsBabbageEra)
+
+fromWalletTxIn :: W.TxIn -> TxIn
+fromWalletTxIn = Convert.toLedger
 
 fromWalletTxOut :: forall era. IsRecentEra era => W.TxOut -> TxOut era
 fromWalletTxOut = case recentEra @era of

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2791,7 +2791,7 @@ instance Arbitrary Wallet where
 
                 genOut :: Gen W.TxOut
                 genOut = cardanoToWalletTxOut <$>
-                  (CardanoApi.TxOut
+                    (CardanoApi.TxOut
                         <$> genAddr
                         <*> (scale (* 2) (CardanoApi.genTxOutValue era))
                         <*> (pure CardanoApi.TxOutDatumNone)

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2764,11 +2764,11 @@ instance Arbitrary W.TxOut where
 instance IsRecentEra era => Arbitrary (Wallet era) where
     arbitrary = oneof
         [ Wallet AllKeyPaymentCredentials
-            <$> (fromWalletUTxO <$> genWalletUTxO genShelleyVkAddr)
+            <$> genWalletUTxO genShelleyVkAddr
             <*> pure dummyShelleyChangeAddressGen
 
         , Wallet AllByronKeyPaymentCredentials
-            <$> (fromWalletUTxO <$> genWalletUTxO genByronVkAddr)
+            <$> genWalletUTxO genByronVkAddr
             <*> pure dummyByronChangeAddressGen
         ]
       where
@@ -2788,9 +2788,11 @@ instance IsRecentEra era => Arbitrary (Wallet era) where
 
         genWalletUTxO
             :: Gen (CardanoApi.AddressInEra CardanoApi.BabbageEra)
-            -> Gen W.UTxO
-        genWalletUTxO genAddr = scale (* 2) $
-            W.UTxO . Map.fromList <$> listOf genEntry
+            -> Gen (UTxO era)
+        genWalletUTxO genAddr
+            = fmap fromWalletUTxO
+            . scale (* 2)
+            $ W.UTxO . Map.fromList <$> listOf genEntry
           where
             genEntry = (,) <$> genIn <*> genOut
               where

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2790,18 +2790,17 @@ instance forall era. IsRecentEra era => Arbitrary (Wallet era) where
             :: Gen (CardanoApi.AddressInEra (CardanoApiEra era))
             -> Gen (UTxO era)
         genWalletUTxO genAddr
-            = fmap fromWalletUTxO
-            . scale (* 2)
-            $ W.UTxO . Map.fromList <$> listOf genEntry
+            = scale (* 2)
+            $ UTxO . Map.fromList <$> listOf genEntry
           where
             genEntry = (,) <$> genIn <*> genOut
               where
-                genIn :: Gen W.TxIn
-                genIn = W.genTxIn
+                genIn :: Gen TxIn
+                genIn = fromWalletTxIn <$> W.genTxIn
 
-                genOut :: Gen W.TxOut
+                genOut :: Gen (TxOut era)
                 genOut
-                    = fmap cardanoToWalletTxOut
+                    = fmap (fromWalletTxOut . cardanoToWalletTxOut)
                     $ CardanoApi.TxOut
                         <$> genAddr
                         <*> scale (* 2) (CardanoApi.genTxOutValue era)

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2169,7 +2169,7 @@ newtype TxBalanceSurplus a = TxBalanceSurplus {unTxBalanceSurplus :: a}
     deriving (Eq, Show)
 
 data Wallet = Wallet UTxOAssumptions W.UTxO AnyChangeAddressGenWithState
-    deriving Show via (ShowBuildable Wallet)
+    deriving Show via ShowBuildable Wallet
 
 --------------------------------------------------------------------------------
 -- Utility functions
@@ -2793,9 +2793,9 @@ instance Arbitrary Wallet where
                 genOut = cardanoToWalletTxOut <$>
                     (CardanoApi.TxOut
                         <$> genAddr
-                        <*> (scale (* 2) (CardanoApi.genTxOutValue era))
-                        <*> (pure CardanoApi.TxOutDatumNone)
-                        <*> (pure CardanoApi.ReferenceScriptNone))
+                        <*> scale (* 2) (CardanoApi.genTxOutValue era)
+                        <*> pure CardanoApi.TxOutDatumNone
+                        <*> pure CardanoApi.ReferenceScriptNone)
                   where
                     era = CardanoApi.BabbageEra
 

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2807,12 +2807,10 @@ instance IsRecentEra era => Arbitrary (Wallet era) where
 
     shrink (Wallet utxoAssumptions utxo changeAddressGen) =
         [ Wallet utxoAssumptions utxo' changeAddressGen
-        | utxo' <- shrinkUTxO utxo
+        | utxo' <- shrinkToUTxOSubset utxo
         ]
       where
-        -- We cannot use 'Cardano.Wallet.Primitive.Types.UTxO.Gen.shrinkUTxO'
-        -- because it will shrink to invalid addresses.
-        shrinkUTxO
+        shrinkToUTxOSubset
             = take 16
             . fmap (UTxO . Map.fromList)
             . shrinkList shrinkEntry

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2807,17 +2807,19 @@ instance IsRecentEra era => Arbitrary (Wallet era) where
 
     shrink (Wallet utxoAssumptions utxo changeAddressGen) =
         [ Wallet utxoAssumptions utxo' changeAddressGen
-        | utxo' <- fmap fromWalletUTxO $ shrinkUTxO $ toWalletUTxO utxo
+        | utxo' <- shrinkUTxO utxo
         ]
       where
         -- We cannot use 'Cardano.Wallet.Primitive.Types.UTxO.Gen.shrinkUTxO'
         -- because it will shrink to invalid addresses.
         shrinkUTxO
             = take 16
-            . fmap (W.UTxO . Map.fromList)
+            . fmap (UTxO . Map.fromList)
             . shrinkList shrinkEntry
             . Map.toList
-            . W.unUTxO
+            . utxoToMap
+          where
+            utxoToMap (UTxO m) = m
 
         shrinkEntry _ = []
 

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2786,6 +2786,9 @@ instance IsRecentEra era => Arbitrary (Wallet era) where
         genByronVkAddr = CardanoApi.byronAddressInEra
             <$> CardanoApi.genAddressByron
 
+        genWalletUTxO
+            :: Gen (CardanoApi.AddressInEra CardanoApi.BabbageEra)
+            -> Gen W.UTxO
         genWalletUTxO genAddr = scale (* 2) $
             W.UTxO . Map.fromList <$> listOf genEntry
           where


### PR DESCRIPTION
## Issue

ADP-3272

## Description

This PR redefines the test `Wallet` type in terms of the `Write.UTxO era` type instead of the primitive `UTxO` type:
```patch
- data Wallet     =
+ data Wallet era =
-      Wallet UTxOAssumptions  UTxO      AnyChangeAddressGenWithState
+      Wallet UTxOAssumptions (UTxO era) AnyChangeAddressGenWithState
```

## Motivation

The `balanceTransaction` function accepts a UTxO set of type `Write.UTxO era`, which (in principal) is capable of encoding more information than a primitive `UTxO` object.