### PR TITLE
Wrap long lines in module `Primitive.Ledger.Convert`.

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
@@ -479,11 +479,17 @@ toLedgerDRep = \case
     Abstain -> Ledger.DRepAlwaysAbstain
     NoConfidence -> Ledger.DRepAlwaysNoConfidence
     FromDRepID (DRepFromKeyHash (DRepKeyHash keyhash)) ->
-        Ledger.DRepCredential . Ledger.KeyHashObj . Ledger.KeyHash . Crypto.UnsafeHash $
-        toShort keyhash
+        Ledger.DRepCredential
+            . Ledger.KeyHashObj
+            . Ledger.KeyHash
+            . Crypto.UnsafeHash
+            $ toShort keyhash
     FromDRepID (DRepFromScriptHash (DRepScriptHash scripthash)) ->
-        Ledger.DRepCredential . Ledger.ScriptHashObj . Ledger.ScriptHash . Crypto.UnsafeHash $
-        toShort scripthash
+        Ledger.DRepCredential
+            . Ledger.ScriptHashObj
+            . Ledger.ScriptHash
+            . Crypto.UnsafeHash
+            $ toShort scripthash
 
 toPlutusScriptInfo
     :: forall era. Alonzo.AlonzoEraScript era

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Convert.hs
@@ -469,7 +469,11 @@ toLedgerDelegatee poolM vaM = case (poolM, vaM) of
     (Just poolId, Just vote) ->
         Conway.DelegStakeVote (toKeyHash poolId) (toLedgerDRep vote)
     _ ->
-        error "toLedgerDelegatee: wrong use, at least pool or vote action must be present"
+        error $ unwords
+            [ "toLedgerDelegatee:"
+            , "wrong use:"
+            , "at least pool or vote action must be present"
+            ]
   where
     toKeyHash (PoolId pid) = Ledger.KeyHash . Crypto.UnsafeHash $ toShort pid
 


### PR DESCRIPTION
## Issue

None. Noticed while browsing code.

## Description

This PR wraps long lines in module `Primitive.Ledger.Convert` so that they fit within the [line length limit](https://github.com/cardano-foundation/cardano-wallet/blob/master/docs/site/src/contributor/what/coding-standards.md#limit-line-length-to-80-characters) (80 characters).