### PR TITLE
[ADP-3350] Change `fetchNextBlock` to use `Read.ChainPoint`

### DIFF
--- a/lib/api/src/Cardano/CLI.hs
+++ b/lib/api/src/Cardano/CLI.hs
@@ -439,6 +439,7 @@ import UnliftIO.Exception
 import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.BM.Data.BackendKind as CM
 import qualified Cardano.BM.Data.Observable as Obs
+import qualified Cardano.Wallet.Read as Read
 import qualified Command.Key as Key
 import qualified Command.RecoveryPhrase as RecoveryPhrase
 import qualified Data.Aeson as Aeson
@@ -709,11 +710,11 @@ restorationModeOption f =
                     <> metavar "BLOCKHEADERHASH"
                     <> help "The block hash to restore from."
         slotNo <-
-            option auto
+            option (Read.SlotNo <$> auto)
                 $ long "slot-no"
                     <> metavar "SLOTNO"
                     <> help "The slot number to restore from."
-        pure $ RestoreFromBlock blockHash slotNo
+        pure $ RestoreFromBlock slotNo blockHash
 
 -- | Arguments for 'wallet create from-public-key' command
 data WalletCreateFromPublicKeyArgs = WalletCreateFromPublicKeyArgs

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -579,7 +579,6 @@ import Cardano.Wallet.Primitive.SyncProgress
 import Cardano.Wallet.Primitive.Types
     ( Block
     , BlockHeader (..)
-    , ChainPoint (..)
     , NetworkParameters (..)
     , PoolLifeCycleStatus
     , Signature (..)
@@ -929,6 +928,7 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.TxMeta as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Read as Read
+import qualified Cardano.Wallet.Read.Hash as Hash
 import qualified Cardano.Wallet.Registry as Registry
 import qualified Control.Concurrent.Concierge as Concierge
 import qualified Data.ByteString as BS
@@ -5340,21 +5340,21 @@ instance IsServerError ErrCreateWallet where
                 , "permissions or available space?"
                 ]
         ErrCreateWalletRestorationFromABlockFailed
-            (ErrNoBlockAt (ChainPoint slot block ))
+            (ErrNoBlockAt (Read.BlockPoint (Read.SlotNo slot) block))
             -> apiError err404 UnexpectedError $ mconcat
             [
-            "Restoration from a given block failed."
-            , "The block at slot "
+            "Restoration from a given block failed. "
+            , "The block at slot number "
                 <> T.pack (show slot)
                 <> " and hash "
-                <> toText block
+                <> Hash.hashToTextAsHex block
                 <> " does not exist."
             ]
         ErrCreateWalletRestorationFromABlockFailed
-            (ErrNoBlockAt (ChainPointAtGenesis))
+            (ErrNoBlockAt (Read.GenesisPoint))
             -> apiError err404 UnexpectedError $ mconcat
             [
-            "Restoration from a given block failed."
+            "Restoration from a given block failed. "
             , "The block at genesis does not exist."
             ]
 

--- a/lib/api/src/Cardano/Wallet/Api/Types/Primitive.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Primitive.hs
@@ -412,6 +412,7 @@ instance FromJSON (ApiT (Hash "ExtraSignature")) where
             (BS.length bytes /= 28)
             $ fail "expected a bech32 req_signer_vkh hash of 28 bytes"
         pure $ ApiT $ Hash bytes
+
 instance ToJSON (ApiT (Hash "ExtraSignature")) where
     toJSON (ApiT (Hash hashed')) =
         toJSON $ Bech32.encodeLenient

--- a/lib/integration/cardano-wallet-integration.cabal
+++ b/lib/integration/cardano-wallet-integration.cabal
@@ -138,6 +138,7 @@ library scenarios
     , cardano-wallet-integration:framework
     , cardano-wallet-network-layer
     , cardano-wallet-primitive
+    , cardano-wallet-read
     , cardano-wallet-secrets
     , cardano-wallet-test-utils
     , command

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Restoration.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Restoration.hs
@@ -22,8 +22,8 @@ import Cardano.Wallet.Api.Types.BlockHeader
 import Cardano.Wallet.Network.RestorationMode
     ( RestorationMode (..)
     )
-import Cardano.Wallet.Primitive.Slotting
-    ( SlotNo (..)
+import Cardano.Wallet.Primitive.Types.Hash
+    ( toRawHeaderHash
     )
 import Cardano.Wallet.Unsafe
     ( unsafeFromText
@@ -66,6 +66,7 @@ import Test.Integration.Framework.DSL.Wallet
     )
 
 import qualified Cardano.Wallet.Api.Clients.Network as C
+import qualified Cardano.Wallet.Read as Read
 
 spec :: SpecWith Context
 spec = describe "restoration of wallets" $ do
@@ -188,8 +189,8 @@ spec = describe "restoration of wallets" $ do
                 errStatusIs 404
                 errResponseBody
                     $ "message"
-                        `fieldIs` "Restoration from a given block failed.\
-                                  \The block at slot SlotNo 0 \
+                        `fieldIs` "Restoration from a given block failed. \
+                                  \The block at slot number 0 \
                                   \and hash 39d89a1e837e968ba35370be47cdfcbfd193cd992fdeed557b77c49b77ee59cf \
                                   \does not exist."
 
@@ -208,5 +209,5 @@ restoringFromCheckpoint
 restoringFromCheckpoint cp =
     setRestorationMode
         $ RestoreFromBlock
-            (headerHash cp)
-            (SlotNo $ getQuantity $ slotNo cp)
+            (Read.SlotNo $ fromIntegral $ getQuantity $ slotNo cp)
+            (toRawHeaderHash $ headerHash cp)

--- a/lib/network-layer/src/Cardano/Wallet/Network.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network.hs
@@ -96,9 +96,6 @@ import Data.Text
 import Data.Text.Class
     ( ToText (..)
     )
-import Fmt
-    ( pretty
-    )
 import GHC.Generics
     ( Generic
     )
@@ -106,6 +103,8 @@ import Internal.Cardano.Write.Tx
     ( MaybeInRecentEra
     )
 
+import qualified Cardano.Wallet.Read as Read
+import qualified Data.Text as T
 import qualified Internal.Cardano.Write.Tx as Write
 
 {-----------------------------------------------------------------------------
@@ -122,7 +121,7 @@ data NetworkLayer m block = NetworkLayer
     -- are used to handle intersection finding,
     -- the arrival of new blocks, and rollbacks.
     , fetchNextBlock
-        :: ChainPoint
+        :: Read.ChainPoint
         -> m (Either ErrFetchBlock block)
     -- ^ Connect to the node,
     -- try to retrieve the block at a given 'ChainPoint',
@@ -290,10 +289,10 @@ instance ToText ErrPostTx where
             "mempool was full and refused posted transaction"
 
 -- | Error while trying to retrieve a block
-newtype ErrFetchBlock = ErrNoBlockAt ChainPoint
+newtype ErrFetchBlock = ErrNoBlockAt Read.ChainPoint
     deriving (Generic, Show, Eq)
 
 instance ToText ErrFetchBlock where
     toText = \case
         ErrNoBlockAt pt ->
-            "no block found at ChainPoint " <> pretty pt
+            "no block found at ChainPoint " <> T.pack (show pt)

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -84,6 +84,9 @@ import Cardano.Wallet.Network.Implementation.Ouroboros
     , localTxSubmission
     , send
     )
+import Cardano.Wallet.Network.Implementation.Types
+    ( toOuroborosPoint
+    )
 import Cardano.Wallet.Network.Implementation.UnliftIO
     ( coerceHandlers
     )
@@ -590,7 +593,7 @@ withNodeNetworkLayerBase
             connectClient nullTracer retryHandlers ouroborosApp versionData conn
 
         _fetchNextBlock retryHandlers pt = do
-            let pt' = toPoint pt
+            let pt' = toOuroborosPoint pt
             blockQ <- newTQueueIO
             let runNodeToClient =
                     runFetchBlockClient retryHandlers blockQ

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Block.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Block.hs
@@ -33,6 +33,7 @@ import Cardano.Wallet.Primitive.Types.Certificates
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
+    , toRawHeaderHash
     )
 import Cardano.Wallet.Primitive.Types.Tx.Tx
     ( Tx
@@ -48,8 +49,7 @@ import Data.ByteArray.Encoding
     , convertToBase
     )
 import Data.Maybe
-    ( fromJust
-    , isNothing
+    ( isNothing
     )
 import Data.Quantity
     ( Quantity (getQuantity)
@@ -167,7 +167,7 @@ fromWalletChainPoint ChainPointAtGenesis = Read.GenesisPoint
 fromWalletChainPoint (ChainPoint slot hash) =
     Read.BlockPoint
         (toReadSlotNo slot)
-        (fromJust $ Hash.hashFromBytes $ getHash hash)
+        (toRawHeaderHash hash)
 
 toReadSlotNo :: SlotNo -> Read.SlotNo
 toReadSlotNo (SlotNo n) = Read.SlotNo (fromIntegral n)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Hash.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Hash.hs
@@ -20,6 +20,7 @@ module Cardano.Wallet.Primitive.Types.Hash
     , hashFromText
     , mockHash
     , mockHashRewardAccount
+    , toRawHeaderHash
     ) where
 
 import Prelude
@@ -54,6 +55,9 @@ import Data.Data
 import Data.Hashable
     ( Hashable
     )
+import Data.Maybe
+    ( fromMaybe
+    )
 import Data.Proxy
     ( Proxy (..)
     )
@@ -84,6 +88,8 @@ import Quiet
     ( Quiet (..)
     )
 
+import qualified Cardano.Wallet.Read as Read
+import qualified Cardano.Wallet.Read.Hash as Hash
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -145,6 +151,15 @@ mockHash = Hash . blake2b256 . B8.pack . show
 
 blake2b256 :: ByteString -> ByteString
 blake2b256 = BA.convert . hash @_ @Blake2b_256
+
+toRawHeaderHash :: Hash "BlockHeader" -> Read.RawHeaderHash
+toRawHeaderHash h =
+    fromMaybe err . Hash.hashFromBytes $ getHash h
+  where
+    err = error
+        $ "toRawHeaderHash:"
+        <> "invalid value of type Hash \"BlockHeader\":"
+        <> show h
 
 -- | Construct a hash that is good enough for testing (28 byte length).
 mockHashRewardAccount :: Show a => a -> Hash "RewardAccount"

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -698,6 +698,7 @@ import qualified Cardano.Wallet.Api.Types as Api
 import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
 import qualified Cardano.Wallet.Api.Types.WalletAssets as ApiWalletAssets
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
+import qualified Cardano.Wallet.Read as Read
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
 import qualified Data.Aeson.KeyMap as Aeson
@@ -2725,6 +2726,9 @@ instance Arbitrary (Hash "BlockHeader") where
 instance Arbitrary ApiBlockHeader where
     arbitrary = genericArbitrary
     shrink = genericShrink
+
+instance Arbitrary Read.SlotNo where
+    arbitrary = Read.SlotNo <$> arbitrary
 
 instance Arbitrary RestorationMode where
     arbitrary = genericArbitrary


### PR DESCRIPTION
This pull request changes the `fetchNextBlock` function to use the data type `ChainPoint` to the `Cardano.Wallet.Read` hierarchy.

### Comments

* The goal is to eventually remove the legacy `primitive` types.

### Issue number

ADP-3350