### PR TITLE
[ADP-3350] Change `currentNodeTip` to use `Read.ChainTip`

### DIFF
--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -99,6 +99,7 @@ benchmark restore
     , cardano-wallet-launcher
     , cardano-wallet-network-layer
     , cardano-wallet-primitive
+    , cardano-wallet-read
     , containers
     , contra-tracer
     , crypto-primitives

--- a/lib/benchmarks/exe/api-bench.hs
+++ b/lib/benchmarks/exe/api-bench.hs
@@ -116,17 +116,12 @@ import Cardano.Wallet.Primitive.Slotting
     , hoistTimeInterpreter
     )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..)
-    , SlotNo (..)
-    , SortOrder (..)
+    ( SortOrder (..)
     , WalletId
     , WalletMetadata (..)
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
-    )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..)
     )
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
     ( HistogramBar (..)
@@ -148,6 +143,9 @@ import Data.Aeson
     ( ToJSON (..)
     , genericToJSON
     , (.=)
+    )
+import Data.Maybe
+    ( fromJust
     )
 import Data.Quantity
     ( Quantity (..)
@@ -185,6 +183,7 @@ import qualified Cardano.Wallet.DB.Layer as DB
 import qualified Cardano.Wallet.DB.Layer as Sqlite
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Cardano.Wallet.Read as Read
+import qualified Cardano.Wallet.Read.Hash as Hash
 import qualified Cardano.Wallet.Transaction as Tx
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Char8 as B8
@@ -547,13 +546,15 @@ mockNetworkLayer = dummyNetworkLayer
                     C.ShelleyBasedEraBabbage
                     dummyNodeProtocolParameters
     , currentNodeEra = pure $ Cardano.anyCardanoEra Cardano.BabbageEra
-    , currentNodeTip = pure BlockHeader
-        { slotNo = SlotNo 123456789
-        , blockHeight = Quantity 12345
-        , headerHash = Hash (B8.replicate 32 'a')
-        , parentHeaderHash = Just (Hash (B8.replicate 32 'b'))
+    , currentNodeTip = pure Read.BlockTip
+        { Read.slotNo = Read.SlotNo 123456789
+        , Read.blockNo = Read.BlockNo 12345
+        , Read.headerHash = mockHash
         }
     }
+
+mockHash :: Read.RawHeaderHash
+mockHash = fromJust $ Hash.hashFromBytes (B8.replicate 32 'a')
 
 mockTimeInterpreter :: TimeInterpreter IO
 mockTimeInterpreter = dummyTimeInterpreter

--- a/lib/network-layer/src/Cardano/Wallet/Network.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network.hs
@@ -127,7 +127,7 @@ data NetworkLayer m block = NetworkLayer
     -- try to retrieve the block at a given 'ChainPoint',
     -- and close the connection again.
     , currentNodeTip
-        :: m BlockHeader
+        :: m Read.ChainTip
     -- ^ Get the current tip from the chain producer
     , currentNodeEra
         :: m AnyCardanoEra

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -85,7 +85,8 @@ import Cardano.Wallet.Network.Implementation.Ouroboros
     , send
     )
 import Cardano.Wallet.Network.Implementation.Types
-    ( toOuroborosPoint
+    ( fromOuroborosTip
+    , toOuroborosPoint
     )
 import Cardano.Wallet.Network.Implementation.UnliftIO
     ( coerceHandlers
@@ -495,7 +496,7 @@ withNodeNetworkLayerBase
                 , fetchNextBlock =
                     _fetchNextBlock (handlers ClientFetchBlock)
                 , currentNodeTip =
-                    fromTip getGenesisBlockHash <$> atomically readNodeTip
+                    fromOuroborosTip <$> atomically readNodeTip
                 , currentNodeEra =
                     -- NOTE: Is not guaranteed to be consistent with @currentNodeTip@
                     readCurrentNodeEra

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation/Types.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-|
 Copyright: © 2024 Cardano Foundation
 License: Apache-2.0
@@ -63,8 +65,11 @@ fromOuroborosPoint (O.BlockPoint slot h) =
 toOuroborosTip :: ChainTip -> O.Tip (CardanoBlock sc)
 toOuroborosTip GenesisTip =
     O.TipGenesis
-toOuroborosTip (BlockTip slot h blockNo) =
-    O.Tip (toCardanoSlotNo slot) (toCardanoHash h) (toCardanoBlockNo blockNo)
+toOuroborosTip BlockTip{slotNo,headerHash,blockNo} =
+    O.Tip
+        (toCardanoSlotNo slotNo)
+        (toCardanoHash headerHash)
+        (toCardanoBlockNo blockNo)
 
 fromOuroborosTip :: O.Tip (CardanoBlock sc) -> ChainTip
 fromOuroborosTip O.TipGenesis =

--- a/lib/network-layer/src/Cardano/Wallet/Network/RestorationMode.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/RestorationMode.hs
@@ -19,7 +19,6 @@ import Cardano.Wallet.Primitive.Ledger.Read.Block.Header
     )
 import Cardano.Wallet.Primitive.Types.Block
     ( BlockHeader (..)
-    , chainPointFromBlockHeader'
     )
 import Cardano.Wallet.Primitive.Types.GenesisParameters
     ( GenesisParameters (..)
@@ -51,8 +50,8 @@ getRestorationPoint genesisParams mode netLayer = do
     case mode of
         RestoreFromGenesis -> pure $ Right RestorationPointAtGenesis
         RestoreFromTip -> do
-            bh <- currentNodeTip netLayer
-            case chainPointFromBlockHeader' bh of
+            nodeTip <- currentNodeTip netLayer
+            case Read.chainPointFromChainTip nodeTip of
                 Read.GenesisPoint -> pure $ Right RestorationPointAtGenesis
                 Read.BlockPoint slot blockhash -> do
                     getRestorationPoint

--- a/lib/unit/test/unit/Cardano/WalletSpec.hs
+++ b/lib/unit/test/unit/Cardano/WalletSpec.hs
@@ -301,6 +301,7 @@ import Data.Map
     )
 import Data.Maybe
     ( catMaybes
+    , fromJust
     , fromMaybe
     , isJust
     , isNothing
@@ -409,6 +410,7 @@ import qualified Cardano.Wallet.DB.Store.Checkpoints.Store as Sqlite
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Read as Read
+import qualified Cardano.Wallet.Read.Hash as Hash
 import qualified Cardano.Wallet.Submissions.Submissions as Smbs
 import qualified Cardano.Wallet.Submissions.TxStatus as Sbms
 import qualified Data.ByteArray as BA
@@ -1422,8 +1424,8 @@ mockNetworkLayer = dummyNetworkLayer
         error "dummyNetworkLayer: syncProgress not implemented"
     }
   where
-    dummyTip = BlockHeader (SlotNo 0) (Quantity 0) dummyHash (Just dummyHash)
-    dummyHash = Hash "dummy hash"
+    dummyTip = Read.BlockTip (Read.SlotNo 0) dummyHash (Read.BlockNo 0)
+    dummyHash = fromJust $ Hash.hashFromBytes $ B8.replicate 32 'a'
 
 type DummyState =
     TestState

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -1126,7 +1126,10 @@ getCurrentEpochSlotting
     :: HasCallStack => NetworkLayer IO block -> IO CurrentEpochSlotting
 getCurrentEpochSlotting nl@NetworkLayer{timeInterpreter} = do
     tip <- currentNodeTip nl
-    let epochQuery = Slotting.epochOf (tip ^. #slotNo)
+    let pseudoSlot Read.GenesisTip = 0
+        pseudoSlot Read.BlockTip{slotNo} =
+            SlotNo $ fromIntegral $ Read.unSlotNo slotNo
+        epochQuery = Slotting.epochOf (pseudoSlot tip)
         throwingInterpreter = Slotting.expectAndThrowFailures timeInterpreter
     epoch <- interpretQuery throwingInterpreter epochQuery
     mkCurrentEpochSlotting throwingInterpreter epoch


### PR DESCRIPTION
This pull request changes the `currentNodeTip` function to use the data type `ChainPoint` to the `Cardano.Wallet.Read` hierarchy.

In order to make the types `ChainPoint` and `ChainTip` more convenient to use, I have also added record fields.

### Comments

* The combination of `NoFieldSelectors`, `DuplicateRecordFields`, and `NamedFieldPuns` enables short field names such as `slotNo`. Specifically
    * `NoFieldSelectors` — enables the use of `slotNo` as a variable outside of a record context (very common).
    * `DuplicateRecordFields` — enables the use of `slotNo` in both `ChainPoint` and `ChainTip`.
    * `NamedFieldPuns` — enables pattern matching of the form `BlockPoint{slotNo}`.
* The goal is to eventually remove the legacy `primitive` types.

### Issue Number

ADP-3350