### PR TITLE
[ADP-3272] Simplify handling of UTxOs in inner helper function of `balanceTx`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -561,14 +561,14 @@ balanceTransaction
             timelockKeyWitnessCounts
             adjustedPartialTx
 
+    -- The set of all UTxOs that may be referenced by a balanced transaction.
+    --
+    -- Note that when constructing this set, we give precedence to UTxOs
+    -- provided as part of the 'PartialTx' object. This relies on the
+    -- left-biased nature of the 'Semigroup' 'mappend' operation on UTxO sets.
+    --
     utxoReference :: UTxO era
     utxoReference = mconcat
-         -- The @CardanoApi.UTxO@ can contain strictly more information than
-         -- @W.UTxO@. Therefore we make the user-specified @inputUTxO@ to take
-         -- precedence. This matters if a user is trying to balance a tx making
-         -- use of a datum hash in a UTxO which is also present in the wallet
-         -- UTxO set. (Whether or not this is a sane thing for the user to do,
-         -- is another question.)
          [ extraUTxO
          , availableUTxO
          ]

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -529,7 +529,7 @@ balanceTransaction
     utxo@UTxOIndex {availableUTxO}
     genChange
     s
-    partialTx@PartialTx {extraUTxO, tx, redeemers, timelockKeyWitnessCounts}
+    PartialTx {extraUTxO, tx, redeemers, timelockKeyWitnessCounts}
     = do
     guardExistingCollateral
     guardExistingReturnCollateral
@@ -567,20 +567,20 @@ balanceTransaction
         -- consensus was that we /could/ allow for it with just a day's work or
         -- so, but that the need for it was unclear enough that it was not in
         -- any way a priority.
-        let collIns = partialTx ^. #tx . bodyTxL . collateralInputsTxBodyL
+        let collIns = tx ^. bodyTxL . collateralInputsTxBodyL
         unless (null collIns) $
             throwE ErrBalanceTxExistingCollateral
 
     guardExistingReturnCollateral :: ExceptT (ErrBalanceTx era) m ()
     guardExistingReturnCollateral = do
-        let collRet = partialTx ^. #tx . bodyTxL . collateralReturnTxBodyL
+        let collRet = tx ^. bodyTxL . collateralReturnTxBodyL
         case collRet of
             SNothing -> return ()
             SJust _ -> throwE ErrBalanceTxExistingReturnCollateral
 
     guardExistingTotalCollateral :: ExceptT (ErrBalanceTx era) m ()
     guardExistingTotalCollateral = do
-        let totColl = partialTx ^. #tx . bodyTxL . totalCollateralTxBodyL
+        let totColl = tx ^. bodyTxL . totalCollateralTxBodyL
         case totColl of
             SNothing -> return ()
             SJust _ -> throwE ErrBalanceTxExistingTotalCollateral

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -552,7 +552,7 @@ balanceTransaction
             pp
             timeTranslation
             utxoAssumptions
-            combinedUTxO
+            utxoReference
             availableUTxOIndex
             genChange
             s
@@ -561,8 +561,8 @@ balanceTransaction
             timelockKeyWitnessCounts
             adjustedPartialTx
 
-    combinedUTxO :: UTxO era
-    combinedUTxO = mconcat
+    utxoReference :: UTxO era
+    utxoReference = mconcat
          -- The @CardanoApi.UTxO@ can contain strictly more information than
          -- @W.UTxO@. Therefore we make the user-specified @inputUTxO@ to take
          -- precedence. This matters if a user is trying to balance a tx making
@@ -703,7 +703,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     pp
     timeTranslation
     utxoAssumptions
-    combinedUTxO
+    utxoReference
     availableUTxOIndex
     genChange
     s
@@ -848,7 +848,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     era = recentEra @era
 
     -- | Extract the inputs from the raw 'tx' of the 'Partialtx', with the
-    -- corresponding 'TxOut' according to @combinedUTxO@.
+    -- corresponding 'TxOut' according to @utxoReference@.
     --
     -- === Examples using pseudo-code
     --
@@ -867,7 +867,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         :: ExceptT (ErrBalanceTx era) m (UTxOIndex.UTxOIndex WalletUTxO)
     extractExternallySelectedUTxO = do
         let res = flip map txIns $ \i-> do
-                case txinLookup i combinedUTxO of
+                case txinLookup i utxoReference of
                     Nothing ->
                        Left i
                     Just o -> do
@@ -910,7 +910,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
 
     txBalance :: Tx era -> Value
     txBalance
-        = evaluateTransactionBalance pp combinedUTxO
+        = evaluateTransactionBalance pp utxoReference
         . view bodyTxL
 
     balanceAfterSettingMinFee
@@ -919,7 +919,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     balanceAfterSettingMinFee tx = ExceptT . pure $ do
         let witCount =
                 estimateKeyWitnessCounts
-                    combinedUTxO
+                    utxoReference
                     tx
                     timelockKeyWitnessCounts
             minfee = Convert.toWalletCoin $ evaluateMinimumFee pp tx witCount
@@ -936,7 +936,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
         tx' <- left updateTxErrorToBalanceTxError
             $ updateTx partialTx update
         left ErrBalanceTxAssignRedeemers $
-            assignScriptRedeemers pp timeTranslation combinedUTxO redeemers tx'
+            assignScriptRedeemers pp timeTranslation utxoReference redeemers tx'
 
 -- | Select assets to cover the specified balance and fee.
 --

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -568,10 +568,7 @@ balanceTransaction
     -- left-biased nature of the 'Semigroup' 'mappend' operation on UTxO sets.
     --
     utxoReference :: UTxO era
-    utxoReference = mconcat
-         [ extraUTxO
-         , availableUTxO
-         ]
+    utxoReference = mconcat [extraUTxO, availableUTxO]
 
     guardExistingCollateral :: ExceptT (ErrBalanceTx era) m ()
     guardExistingCollateral = do

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -531,9 +531,7 @@ balanceTransaction
     s
     partialTx
     = do
-    let adjustedPartialTx = flip (over #tx) partialTx $
-            assignMinimalAdaQuantitiesToOutputsWithoutAda pp
-        balanceWith strategy =
+    let balanceWith strategy =
             balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
                 pp
                 timeTranslation
@@ -549,6 +547,10 @@ balanceTransaction
             then balanceWith SelectionStrategyMinimal
             else throwE e
   where
+    adjustedPartialTx :: PartialTx era
+    adjustedPartialTx = flip (over #tx) partialTx $
+        assignMinimalAdaQuantitiesToOutputsWithoutAda pp
+
     -- Determines whether or not the minimal selection strategy is worth trying.
     -- This depends upon the way in which the optimal selection strategy failed.
     minimalStrategyIsWorthTrying :: ErrBalanceTx era -> Bool

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -531,16 +531,6 @@ balanceTransaction
     s
     partialTx
     = do
-    let balanceWith strategy =
-            balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
-                pp
-                timeTranslation
-                utxoAssumptions
-                utxo
-                genChange
-                s
-                strategy
-                adjustedPartialTx
     balanceWith SelectionStrategyOptimal
         `catchE` \e ->
             if minimalStrategyIsWorthTrying e
@@ -550,6 +540,20 @@ balanceTransaction
     adjustedPartialTx :: PartialTx era
     adjustedPartialTx = flip (over #tx) partialTx $
         assignMinimalAdaQuantitiesToOutputsWithoutAda pp
+
+    balanceWith
+        :: SelectionStrategy
+        -> ExceptT (ErrBalanceTx era) m (Tx era, changeState)
+    balanceWith strategy =
+        balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
+            pp
+            timeTranslation
+            utxoAssumptions
+            utxo
+            genChange
+            s
+            strategy
+            adjustedPartialTx
 
     -- Determines whether or not the minimal selection strategy is worth trying.
     -- This depends upon the way in which the optimal selection strategy failed.

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -543,33 +543,26 @@ balanceTransaction
     when (UTxOSelection.availableSize utxoSelection == 0) $
         throwE ErrBalanceTxUnableToCreateInput
 
-    balanceWith utxoSelection SelectionStrategyOptimal
+    let adjustedPartialTx = assignMinimalAdaQuantitiesToOutputsWithoutAda pp tx
+        balanceWith strategy =
+            balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
+                pp
+                timeTranslation
+                utxoAssumptions
+                utxoReference
+                utxoSelection
+                genChange
+                s
+                strategy
+                redeemers
+                timelockKeyWitnessCounts
+                adjustedPartialTx
+    balanceWith SelectionStrategyOptimal
         `catchE` \e ->
             if minimalStrategyIsWorthTrying e
-            then balanceWith utxoSelection SelectionStrategyMinimal
+            then balanceWith SelectionStrategyMinimal
             else throwE e
   where
-    adjustedPartialTx :: Tx era
-    adjustedPartialTx = assignMinimalAdaQuantitiesToOutputsWithoutAda pp tx
-
-    balanceWith
-        :: UTxOSelection WalletUTxO
-        -> SelectionStrategy
-        -> ExceptT (ErrBalanceTx era) m (Tx era, changeState)
-    balanceWith utxoSelection strategy =
-        balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
-            pp
-            timeTranslation
-            utxoAssumptions
-            utxoReference
-            utxoSelection
-            genChange
-            s
-            strategy
-            redeemers
-            timelockKeyWitnessCounts
-            adjustedPartialTx
-
     -- Creates an index of all UTxOs that are already spent as inputs of the
     -- partial transaction.
     --

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -529,7 +529,7 @@ balanceTransaction
     utxo@UTxOIndex {availableUTxO}
     genChange
     s
-    partialTx@PartialTx {extraUTxO, redeemers, timelockKeyWitnessCounts}
+    partialTx@PartialTx {extraUTxO, tx, redeemers, timelockKeyWitnessCounts}
     = do
     guardExistingCollateral
     guardExistingReturnCollateral
@@ -541,9 +541,8 @@ balanceTransaction
             then balanceWith SelectionStrategyMinimal
             else throwE e
   where
-    adjustedPartialTx :: PartialTx era
-    adjustedPartialTx = flip (over #tx) partialTx $
-        assignMinimalAdaQuantitiesToOutputsWithoutAda pp
+    adjustedPartialTx :: Tx era
+    adjustedPartialTx = assignMinimalAdaQuantitiesToOutputsWithoutAda pp tx
 
     balanceWith
         :: SelectionStrategy
@@ -560,7 +559,7 @@ balanceTransaction
             strategy
             redeemers
             timelockKeyWitnessCounts
-            (view #tx adjustedPartialTx)
+            adjustedPartialTx
 
     guardExistingCollateral :: ExceptT (ErrBalanceTx era) m ()
     guardExistingCollateral = do

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -545,7 +545,7 @@ balanceTransaction
 
     let adjustedPartialTx = assignMinimalAdaQuantitiesToOutputsWithoutAda pp tx
         balanceWith strategy =
-            balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
+            balanceTransactionInner
                 pp
                 timeTranslation
                 utxoAssumptions
@@ -707,7 +707,7 @@ assignMinimalAdaQuantitiesToOutputsWithoutAda pp =
         if c == mempty then computeMinimumCoinForTxOut pp out else c
 
 -- | Internal helper to 'balanceTransaction'
-balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
+balanceTransactionInner
     :: forall era m changeState.
         ( MonadRandom m
         , IsRecentEra era
@@ -727,7 +727,7 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     -> TimelockKeyWitnessCounts
     -> Tx era
     -> ExceptT (ErrBalanceTx era) m (Tx era, changeState)
-balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
+balanceTransactionInner
     pp
     timeTranslation
     utxoAssumptions

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -526,7 +526,7 @@ balanceTransaction
     pp
     timeTranslation
     utxoAssumptions
-    utxo@UTxOIndex {availableUTxO}
+    UTxOIndex {availableUTxO, availableUTxOIndex}
     genChange
     s
     PartialTx {extraUTxO, tx, redeemers, timelockKeyWitnessCounts}
@@ -552,8 +552,9 @@ balanceTransaction
             pp
             timeTranslation
             utxoAssumptions
-            utxo
             extraUTxO
+            availableUTxO
+            availableUTxOIndex
             genChange
             s
             strategy
@@ -676,9 +677,12 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     => PParams era
     -> TimeTranslation
     -> UTxOAssumptions
-    -> UTxOIndex era
     -> UTxO era
     -- ^ The set of UTxOs that were provided by the `PartialTx`.
+    -> UTxO era
+    -- ^ The set of UTxOs that are available to spend.
+    -> UTxOIndex.UTxOIndex WalletUTxO
+    -- ^ The set of UTxOs that are available to spend, in indexed form.
     -> ChangeAddressGen changeState
     -> changeState
     -> SelectionStrategy
@@ -690,8 +694,9 @@ balanceTransactionWithSelectionStrategyAndNoZeroAdaAdjustment
     pp
     timeTranslation
     utxoAssumptions
-    UTxOIndex {availableUTxO, availableUTxOIndex}
     extraUTxO
+    availableUTxO
+    availableUTxOIndex
     genChange
     s
     selectionStrategy

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -570,22 +570,12 @@ balanceTransaction
             timelockKeyWitnessCounts
             adjustedPartialTx
 
-    -- | Extract the inputs from the raw 'tx' of the 'Partialtx', with the
-    -- corresponding 'TxOut' according to @utxoReference@.
+    -- Creates an index of all UTxOs that are already spent as inputs of the
+    -- partial transaction.
     --
-    -- === Examples using pseudo-code
+    -- This function will fail if any of the inputs refers to a UTxO that
+    -- cannot be found in the UTxO reference set.
     --
-    -- >>> let extraUTxO = {inA -> outA, inB -> outB }
-    -- >>> let tx = addInputs [inA] emptyTx
-    -- >>> let ptx = PartialTx tx extraUTxO []
-    -- >>> extractExternallySelectedUTxO ptx
-    -- Right (UTxOIndex.fromMap {inA -> outA})
-    --
-    -- >>> let extraUTxO = {inB -> outB }
-    -- >>> let tx = addInputs [inA, inC] emptyTx
-    -- >>> let ptx = PartialTx tx extraUTxO []
-    -- >>> extractExternallySelectedUTxO ptx
-    -- Left (ErrBalanceTxUnresolvedInputs [inA, inC])
     extractExternallySelectedUTxO
         :: ExceptT (ErrBalanceTx era) m (UTxOIndex.UTxOIndex WalletUTxO)
     extractExternallySelectedUTxO = do


### PR DESCRIPTION
## Issue

ADP-3272

## Description

This PR simplifies the handling of UTxOs within the inner helper function of `balanceTransaction`, so that it only has to handle two UTxO-related data structures, both supplied by the outer function:

- `utxoReference`: the set of all UTxOs (formerly known as `combinedUTxO`).
- `utxoSelection`: the set of all UTxOs that the transaction is allowed to spend, along with a pre-selected subset.

As a bonus, because this PR moves the computation of UTxO-related data structures from the inner helper function to the outer function, the above data structures should now be evaluated **_at most once_**, instead of multiple times (once per strategy).

## Notes

The `balanceTransaction` function delegates the main portion of its work to an inner helper function that is parameterised by `SelectionStrategy`. It initially calls the inner helper function with `SelectionStrategyOptimal`, but if that strategy fails, then it (potentially) calls the inner helper function a **_second time_** with `SelectionStrategyMinimal`.

In the event that the inner helper function is evaluated more than once (with two different strategies), we ideally want to avoid recomputing potentially expensive data structures that should be constant across both evaluations.