### PR TITLE
[ADP-3350] Change `watchNodeTip` to use `Read.ChainTip`

### DIFF
--- a/lib/benchmarks/exe/api-bench.hs
+++ b/lib/benchmarks/exe/api-bench.hs
@@ -144,9 +144,6 @@ import Data.Aeson
     , genericToJSON
     , (.=)
     )
-import Data.Maybe
-    ( fromJust
-    )
 import Data.Quantity
     ( Quantity (..)
     )
@@ -183,10 +180,8 @@ import qualified Cardano.Wallet.DB.Layer as DB
 import qualified Cardano.Wallet.DB.Layer as Sqlite
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Cardano.Wallet.Read as Read
-import qualified Cardano.Wallet.Read.Hash as Hash
 import qualified Cardano.Wallet.Transaction as Tx
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Char8 as B8
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Internal.Cardano.Write.Tx as Write
@@ -554,7 +549,7 @@ mockNetworkLayer = dummyNetworkLayer
     }
 
 mockHash :: Read.RawHeaderHash
-mockHash = fromJust $ Hash.hashFromBytes (B8.replicate 32 'a')
+mockHash = Read.mockRawHeaderHash 0
 
 mockTimeInterpreter :: TimeInterpreter IO
 mockTimeInterpreter = dummyTimeInterpreter

--- a/lib/network-layer/src/Cardano/Wallet/Network.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network.hs
@@ -145,7 +145,7 @@ data NetworkLayer m block = NetworkLayer
     -- ^ Get the last known slotting parameters. In principle, these can
     -- only change once per era.
     , watchNodeTip
-        :: (BlockHeader -> m ())
+        :: (Read.ChainTip -> m ())
         -> m ()
     -- ^ Register a callback for when the node tip changes.
     -- This function should never finish, unless the callback throws an

--- a/lib/read/lib/Cardano/Wallet/Read/Block.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block.hs
@@ -33,6 +33,7 @@ import Cardano.Wallet.Read.Block.HeaderHash
     , getEraHeaderHash
     , getEraPrevHeaderHash
     , getRawHeaderHash
+    , mockRawHeaderHash
     )
 import Cardano.Wallet.Read.Block.SlotNo
     ( SlotNo (..)

--- a/lib/read/lib/Cardano/Wallet/Read/Block/HeaderHash.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/HeaderHash.hs
@@ -16,6 +16,9 @@ module Cardano.Wallet.Read.Block.HeaderHash
     , PrevHeaderHash (..)
     , PrevHeaderHashT
     , getEraPrevHeaderHash
+
+    -- * Testing utilities
+    , mockRawHeaderHash
     )
 where
 
@@ -81,6 +84,8 @@ import Ouroboros.Consensus.Shelley.Protocol.TPraos
 import qualified Cardano.Crypto.Hashing as Byron
 import qualified Cardano.Ledger.Api as L
 import qualified Cardano.Ledger.Shelley.API as Shelley
+import qualified Cardano.Wallet.Read.Hash as Hash
+import qualified Data.ByteString.Char8 as B8
 import qualified Ouroboros.Consensus.Shelley.Ledger.Block as O
 import qualified Ouroboros.Consensus.Shelley.Protocol.Abstract as Shelley
 import qualified Ouroboros.Network.Block as O
@@ -130,6 +135,11 @@ data BHeader
 
 -- | Raw hash digest for a block header.
 type RawHeaderHash = Hash Blake2b_256 BHeader
+
+-- | Construct a 'RawHeaderHash' that is good enough for testing.
+mockRawHeaderHash :: Integer -> RawHeaderHash
+mockRawHeaderHash n =
+    Hash.hashWith (\_ -> B8.pack $ show n) (error "undefined :: BHeader")
 
 {-# INLINABLE getRawHeaderHash #-}
 getRawHeaderHash :: forall era. IsEra era => HeaderHash era -> RawHeaderHash

--- a/lib/unit/test/unit/Cardano/Wallet/Api/ServerSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/ServerSpec.hs
@@ -74,8 +74,7 @@ import Data.Either
     ( isLeft
     )
 import Data.Maybe
-    ( fromJust
-    , isJust
+    ( isJust
     , isNothing
     )
 import Data.SOP.Counting
@@ -143,7 +142,6 @@ import UnliftIO.Concurrent
 
 import qualified Cardano.Wallet.Primitive.SyncProgress as S
 import qualified Cardano.Wallet.Read as Read
-import qualified Cardano.Wallet.Read.Hash as Hash
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
 import qualified Ouroboros.Consensus.HardFork.History.EraParams as HF
@@ -278,7 +276,7 @@ networkInfoSpec = describe "getNetworkInformation" $ do
             }
       where
         mockHash :: Read.RawHeaderHash
-        mockHash = fromJust $ Hash.hashFromBytes $ B8.replicate 32 'a'
+        mockHash = Read.mockRawHeaderHash 0
 
     forkInterpreter startTime =
         let


### PR DESCRIPTION
This pull request changes the `watchNodeTip` function to use the data type `ChainTip` from the `Cardano.Wallet.Read` hierarchy.

In order to make creation of mock hashes for testing easier, I have added a function `mockRawHeaderHash`.

### Comments

* The goal is to eventually remove the legacy `primitive` types.

### Issue Number

ADP-3350