### PR TITLE
[ADP-3350] Change `chainSync` to use `Read.ChainPoint`

### DIFF
--- a/lib/benchmarks/exe/restore-bench.hs
+++ b/lib/benchmarks/exe/restore-bench.hs
@@ -204,10 +204,12 @@ import Cardano.Wallet.Primitive.Types
     , SortOrder (..)
     , WalletId (..)
     , WalletName (..)
-    , chainPointFromBlockHeader
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
+    )
+import Cardano.Wallet.Primitive.Types.Block
+    ( chainPointFromBlockHeader'
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -788,7 +790,7 @@ bench_baseline_restoration
             , readChainPoints  = readTVarIO chainPointT
             , rollForward = \blocks ntip -> do
                 atomically $ writeTVar chainPointT
-                    [chainPointFromBlockHeader ntip]
+                    [chainPointFromBlockHeader' ntip]
                 let (ntxs, hss) = NE.unzip $
                         numberOfTransactionsInBlock <$> blocks
                     (heights, slots) = NE.unzip hss

--- a/lib/network-layer/src/Cardano/Wallet/Network.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network.hs
@@ -52,7 +52,6 @@ import Cardano.Wallet.Primitive.SyncProgress
     )
 import Cardano.Wallet.Primitive.Types.Block
     ( BlockHeader
-    , ChainPoint (..)
     )
 import Cardano.Wallet.Primitive.Types.Checkpoints.Policy
     ( CheckpointPolicy
@@ -114,7 +113,7 @@ import qualified Internal.Cardano.Write.Tx as Write
 data NetworkLayer m block = NetworkLayer
     { chainSync
         :: Tracer IO ChainFollowLog
-        -> ChainFollower m ChainPoint BlockHeader (NonEmpty block)
+        -> ChainFollower m Read.ChainPoint BlockHeader (NonEmpty block)
         -> m ()
     -- ^ Connect to the node and run the ChainSync protocol.
     -- The callbacks provided in the 'ChainFollower' argument

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -99,8 +99,7 @@ import Cardano.Wallet.Primitive.Ledger.Read.Block.Header
     ( getBlockHeader
     )
 import Cardano.Wallet.Primitive.Ledger.Shelley
-    ( fromPoint
-    , fromTip'
+    ( fromTip'
     , nodeToClientVersions
     , toCardanoEra
     , unsealShelleyTx

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -85,7 +85,8 @@ import Cardano.Wallet.Network.Implementation.Ouroboros
     , send
     )
 import Cardano.Wallet.Network.Implementation.Types
-    ( fromOuroborosTip
+    ( fromOuroborosPoint
+    , fromOuroborosTip
     , toOuroborosPoint
     )
 import Cardano.Wallet.Network.Implementation.UnliftIO
@@ -102,7 +103,6 @@ import Cardano.Wallet.Primitive.Ledger.Shelley
     , fromTip'
     , nodeToClientVersions
     , toCardanoEra
-    , toPoint
     , unsealShelleyTx
     )
 import Cardano.Wallet.Primitive.Slotting
@@ -481,13 +481,19 @@ withNodeNetworkLayerBase
                                 (_syncProgress interpreterVar)
                     withStats $ \trChainSyncLog -> do
                         let mapB = getBlockHeader getGenesisBlockHash
-                            mapP = fromPoint
+                            mapP = fromOuroborosPoint
                         let blockHeader = fromTip' gp
                         let client =
                                 mkWalletClient
                                     (mapChainSyncLog mapB mapP >$< trChainSyncLog)
                                     pipeliningStrategy
-                                    (mapChainFollower toPoint mapP blockHeader id follower)
+                                    (mapChainFollower
+                                        toOuroborosPoint
+                                        mapP
+                                        blockHeader
+                                        id
+                                        follower
+                                    )
                                     cfg
                         traceWith trFollowLog MsgStartFollowing
                         let trChainSync = MsgConnectionStatus ClientChainSync >$< tr

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -44,8 +44,6 @@ module Cardano.Wallet.Primitive.Ledger.Shelley
       -- * Conversions
     , toCardanoHash
     , unsealShelleyTx
-    , toPoint
-    , fromPoint
     , toCardanoTxId
     , toCardanoTxIn
     , fromCardanoTxIn
@@ -184,9 +182,6 @@ import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Outputs
     ( fromCardanoValue
     , fromShelleyAddress
     , fromShelleyTxOut
-    )
-import Cardano.Wallet.Primitive.Types.Block
-    ( ChainPoint (..)
     )
 import Cardano.Wallet.Primitive.Types.Certificates
     ( PoolCertificate
@@ -426,14 +421,6 @@ nodeToClientVersions = [NodeToClientV_15, NodeToClientV_16]
 toCardanoHash :: W.Hash "BlockHeader" -> OneEraHash (CardanoEras sc)
 toCardanoHash (W.Hash bytes) =
     OneEraHash $ toShort bytes
-
-toPoint :: W.ChainPoint -> O.Point (CardanoBlock sc)
-toPoint ChainPointAtGenesis = O.GenesisPoint
-toPoint (ChainPoint slot h) = O.BlockPoint slot (toCardanoHash h)
-
-fromPoint :: O.Point (CardanoBlock sc) -> W.ChainPoint
-fromPoint O.GenesisPoint = ChainPointAtGenesis
-fromPoint (O.BlockPoint slot h) = ChainPoint slot (fromCardanoHash h)
 
 getProducer
     :: (Era era, EncCBORGroup (TxSeq era))

--- a/lib/unit/test/unit/Cardano/Wallet/NetworkSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/NetworkSpec.hs
@@ -21,7 +21,6 @@ import Cardano.Wallet.Network
     )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
-    , ChainPoint (..)
     )
 import Data.Time.Clock
     ( getCurrentTime
@@ -42,6 +41,7 @@ import Test.QuickCheck
     , property
     )
 
+import qualified Cardano.Wallet.Read as Read
 import qualified Data.List.NonEmpty as NE
 
 spec :: Spec
@@ -51,7 +51,7 @@ spec = do
 
     describe "updateStats" $ do
         it "results in no unexpected thunks" $ property $
-          \(msg :: ChainSyncLog () ChainPoint) -> do
+          \(msg :: ChainSyncLog () Read.ChainPoint) -> do
             -- This test is not /fully/ fool-proof. Adding lots of nested types to
             -- LogState and logic in updateStats not covered by the generator
             -- might cause us to miss a thunk.
@@ -64,7 +64,7 @@ spec = do
                 Nothing -> return ()
                 Just x -> expectationFailure $ show x
 
-instance Arbitrary block => Arbitrary (ChainSyncLog block ChainPoint) where
+instance Arbitrary block => Arbitrary (ChainSyncLog block Read.ChainPoint) where
     arbitrary = oneof
         [ MsgChainRollForward <$> genNonEmpty <*> genChainPoint
         , MsgChainRollBackward <$> genChainPoint <*> arbitrary

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -431,6 +431,7 @@ import Cardano.Wallet.Network
     , ChainFollower (..)
     , ErrPostTx (..)
     , NetworkLayer (..)
+    , mapChainFollower
     )
 import Cardano.Wallet.Network.RestorationMode
     ( RestorationPoint (..)
@@ -521,6 +522,10 @@ import Cardano.Wallet.Primitive.Types.Address
     )
 import Cardano.Wallet.Primitive.Types.AssetId
     ( AssetId
+    )
+import Cardano.Wallet.Primitive.Types.Block
+    ( fromWalletChainPoint
+    , toWalletChainPoint
     )
 import Cardano.Wallet.Primitive.Types.BlockSummary
     ( ChainEvents
@@ -1264,8 +1269,14 @@ restoreWallet ctx = db & \DBLayer{..} ->
         rollBackward = rollbackBlocks ctx . toSlot
         rollForward' = restoreBlocks ctx (contramap MsgWalletFollow tr)
     in
-      catchFromIO $
-            chainSync nw (contramap MsgChainFollow tr) $ ChainFollower
+      catchFromIO
+        $ chainSync nw (contramap MsgChainFollow tr)
+        $ mapChainFollower
+            fromWalletChainPoint
+            toWalletChainPoint
+            id
+            id
+            ChainFollower
                 { checkpointPolicy
                 , readChainPoints
                 , rollForward = \blocks tip ->

--- a/lib/wallet/src/Cardano/Wallet/Gen.hs
+++ b/lib/wallet/src/Cardano/Wallet/Gen.hs
@@ -47,9 +47,7 @@ import Cardano.Wallet.Address.Discovery.Shared
     ( retrieveAllCosigners
     )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..)
-    , ChainPoint (..)
-    , Slot
+    ( Slot
     , SlotNo (..)
     , WalletId (..)
     , WithOrigin (..)
@@ -114,6 +112,7 @@ import Test.QuickCheck
     )
 
 import qualified Cardano.Byron.Codec.Cbor as CBOR
+import qualified Cardano.Wallet.Read as Read
 import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteString as BS
 import qualified Data.Map as Map
@@ -170,13 +169,17 @@ genSlotNo = SlotNo . fromIntegral <$> arbitrary @Word32
 shrinkSlotNo :: SlotNo -> [SlotNo]
 shrinkSlotNo (SlotNo x) = map SlotNo $ shrink x
 
-genChainPoint :: Gen ChainPoint
+genChainPoint :: Gen Read.ChainPoint
 genChainPoint = frequency
-    [ ( 1, pure ChainPointAtGenesis)  -- "common" but not "very common"
-    , (40, toChainPoint <$> (genBlockHeader =<< genSlotNo))
+    [ ( 1, pure Read.GenesisPoint)  -- "common" but not "very common"
+    , (40, Read.BlockPoint <$> genReadSlotNo <*> genHeaderHash)
     ]
   where
-    toChainPoint (BlockHeader slot _ h _) = ChainPoint slot h
+    genReadSlotNo = Read.SlotNo . fromIntegral <$> arbitrary @Word32
+    genHeaderHash = elements mockHashes
+
+mockHashes :: [Read.RawHeaderHash]
+mockHashes = map Read.mockRawHeaderHash [0..2]
 
 genSlot :: Gen Slot
 genSlot = frequency


### PR DESCRIPTION
This pull request changes the `chainSync` function to use the data type `ChainPoint` from the `Cardano.Wallet.Read` hierarchy.

In order to keep the scope of this change limited, we add conversion functions `fromWalletChainPoint` and `toWalletChainPoint` — otherwise, we might have to propagate the change all the way to the database, which I don't want to do here. This pull request focuses on changing the `NetworkLayer`, not on changing the `Cardano.Wallet`.

### Comments

* The goal is to eventually remove the legacy `primitive` types.

### Issue Number

ADP-3350