### PR TITLE
[ADP-3350] Change `chainSync` to use `Read.ChainTip`

### DIFF
--- a/lib/benchmarks/exe/restore-bench.hs
+++ b/lib/benchmarks/exe/restore-bench.hs
@@ -208,9 +208,6 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..)
     )
-import Cardano.Wallet.Primitive.Types.Block
-    ( chainPointFromBlockHeader'
-    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -788,9 +785,9 @@ bench_baseline_restoration
             $ ChainFollower
             { checkpointPolicy = const CP.atTip
             , readChainPoints  = readTVarIO chainPointT
-            , rollForward = \blocks ntip -> do
+            , rollForward = \blocks nodeTip -> do
                 atomically $ writeTVar chainPointT
-                    [chainPointFromBlockHeader' ntip]
+                    [Read.chainPointFromChainTip nodeTip]
                 let (ntxs, hss) = NE.unzip $
                         numberOfTransactionsInBlock <$> blocks
                     (heights, slots) = NE.unzip hss

--- a/lib/network-layer/src/Cardano/Wallet/Network.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network.hs
@@ -50,9 +50,6 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..)
     )
-import Cardano.Wallet.Primitive.Types.Block
-    ( BlockHeader
-    )
 import Cardano.Wallet.Primitive.Types.Checkpoints.Policy
     ( CheckpointPolicy
     )
@@ -113,7 +110,7 @@ import qualified Internal.Cardano.Write.Tx as Write
 data NetworkLayer m block = NetworkLayer
     { chainSync
         :: Tracer IO ChainFollowLog
-        -> ChainFollower m Read.ChainPoint BlockHeader (NonEmpty block)
+        -> ChainFollower m Read.ChainPoint Read.ChainTip (NonEmpty block)
         -> m ()
     -- ^ Connect to the node and run the ChainSync protocol.
     -- The callbacks provided in the 'ChainFollower' argument

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -99,8 +99,7 @@ import Cardano.Wallet.Primitive.Ledger.Read.Block.Header
     ( getBlockHeader
     )
 import Cardano.Wallet.Primitive.Ledger.Shelley
-    ( fromTip'
-    , nodeToClientVersions
+    ( nodeToClientVersions
     , toCardanoEra
     , unsealShelleyTx
     )
@@ -481,7 +480,6 @@ withNodeNetworkLayerBase
                     withStats $ \trChainSyncLog -> do
                         let mapB = getBlockHeader getGenesisBlockHash
                             mapP = fromOuroborosPoint
-                        let blockHeader = fromTip' gp
                         let client =
                                 mkWalletClient
                                     (mapChainSyncLog mapB mapP >$< trChainSyncLog)
@@ -489,7 +487,7 @@ withNodeNetworkLayerBase
                                     (mapChainFollower
                                         toOuroborosPoint
                                         mapP
-                                        blockHeader
+                                        fromOuroborosTip
                                         id
                                         follower
                                     )
@@ -528,7 +526,7 @@ withNodeNetworkLayerBase
                 , syncProgress = _syncProgress interpreterVar
                 }
       where
-        gp@GenesisParameters
+        GenesisParameters
             { getGenesisBlockHash
             , getGenesisBlockDate
             } = genesisParameters np

--- a/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ShelleySpec.hs
+++ b/lib/primitive/test/spec/Cardano/Wallet/Primitive/Ledger/ShelleySpec.hs
@@ -49,13 +49,11 @@ import Cardano.Wallet.Primitive.Ledger.Shelley
     , StandardCrypto
     , decentralizationLevelFromPParams
     , fromCardanoValue
-    , fromTip
     , interval0
     , interval1
     , invertUnitInterval
     , toCardanoHash
     , toCardanoValue
-    , toTip
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
@@ -168,7 +166,6 @@ import qualified Cardano.Api as Cardano
 import qualified Cardano.Ledger.BaseTypes as SL
 import qualified Cardano.Ledger.Shelley as SL
 import qualified Cardano.Ledger.Shelley.PParams as SL
-import qualified Cardano.Wallet.Primitive.Types.Block as W
 import qualified Cardano.Wallet.Primitive.Types.EpochNo as W
 import qualified Cardano.Wallet.Primitive.Types.SlotId as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
@@ -178,10 +175,6 @@ import qualified Data.Text.Encoding as T
 spec :: Spec
 spec = do
     describe "Conversions" $ do
-        it "toTip' . fromTip' == id" $ property $ \gh tip -> do
-            let fromTip' = fromTip gh
-            let toTip' = toTip gh :: W.BlockHeader -> Tip (CardanoBlock StandardCrypto)
-            toTip' (fromTip' tip) === tip
 
         it "unsafeIntToWord" $
             property prop_unsafeIntToWord

--- a/lib/wallet/src/Cardano/Wallet/Pools.hs
+++ b/lib/wallet/src/Cardano/Wallet/Pools.hs
@@ -744,7 +744,7 @@ monitorStakePools tr (NetworkParameters gp sp _pp) genesisPools nl DBLayer{..} =
     forward
         :: IORef EpochNo
         -> NonEmpty (CardanoBlock StandardCrypto)
-        -> BlockHeader
+        -> Read.ChainTip
         -> IO ()
     forward latestGarbageCollectionEpochRef blocks _ =
         atomically $ forAllAndLastM blocks forAllBlocks forLastBlock


### PR DESCRIPTION
This pull request changes the `chainSync` function to use the data type `ChainTip` from the `Cardano.Wallet.Read` hierarchy. The other pull request #4550 has changed the type of the chain point, here we change the type of the **tip**.

### Comments

* The goal is to eventually remove the legacy `primitive` types.

### Issue Number

ADP-3350