### PR TITLE
[ADP-3272] Simplify creation of preselected UTxO index.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -560,6 +560,8 @@ balanceTransaction
             then balanceWith SelectionStrategyMinimal
             else throwE e
   where
+    era = recentEra @era
+
     -- Creates an index of all UTxOs that are already spent as inputs of the
     -- partial transaction.
     --
@@ -574,7 +576,6 @@ balanceTransaction
         | otherwise = pure $
             UTxOIndex.fromSequence (convertUTxO <$> Map.toList selectedUTxO)
       where
-        era = recentEra @era
         convertUTxO :: (TxIn, TxOut era) -> (WalletUTxO, W.TokenBundle)
         convertUTxO (i, o) = (WalletUTxO (Convert.toWallet i) addr, bundle)
           where
@@ -633,7 +634,6 @@ balanceTransaction
       where
         conflicts :: UTxO era -> UTxO era -> Map TxIn (TxOut era, TxOut era)
         conflicts = Map.conflictsWith ((/=) `on` toWalletTxOut era) `on` unUTxO
-        era = recentEra @era
 
     -- Determines whether or not the minimal selection strategy is worth trying.
     -- This depends upon the way in which the optimal selection strategy failed.

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -591,9 +591,8 @@ balanceTransaction
       where
         era = recentEra @era
         convertUTxO :: (TxIn, TxOut era) -> (WalletUTxO, W.TokenBundle)
-        convertUTxO (i, o) = (WalletUTxO i' addr, bundle)
+        convertUTxO (i, o) = (WalletUTxO (Convert.toWallet i) addr, bundle)
           where
-            i' = Convert.toWallet i
             W.TxOut addr bundle = toWalletTxOut era o
         maybeUnresolvedTxIns :: Maybe (NonEmpty TxIn)
         maybeUnresolvedTxIns

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -536,10 +536,10 @@ balanceTransaction
     guardExistingTotalCollateral
 
     guardUTxOConsistency
-    externallySelectedUtxo <- indexPreselectedUTxO
+    preselectedUTxOIndex <- indexPreselectedUTxO
     let utxoSelection =
             UTxOSelection.fromIndexPair
-                (availableUTxOIndex, externallySelectedUtxo)
+                (availableUTxOIndex, preselectedUTxOIndex)
     when (UTxOSelection.availableSize utxoSelection == 0) $
         throwE ErrBalanceTxUnableToCreateInput
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -592,8 +592,6 @@ balanceTransaction
             $ fmap convertUTxO
             $ Map.toList
             $ unUTxO selectedUTxO
-        txIns :: [TxIn]
-        txIns = Set.toList txInSet
         txInSet :: Set TxIn
         txInSet = tx ^. bodyTxL . inputsTxBodyL
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -580,10 +580,8 @@ balanceTransaction
                 case txinLookup i utxoReference of
                     Nothing ->
                        Left i
-                    Just o -> do
-                        let i' = Convert.toWallet i
-                        let W.TxOut addr bundle = toWalletTxOut era o
-                        pure (WalletUTxO i' addr, bundle)
+                    Just o ->
+                        pure (convertUTxO (i, o))
         case partitionEithers res of
             ([], resolved) -> pure $ UTxOIndex.fromSequence resolved
             (unresolvedInsHead : unresolvedInsTail, _) ->
@@ -592,6 +590,11 @@ balanceTransaction
                 $ (unresolvedInsHead :| unresolvedInsTail)
       where
         era = recentEra @era
+        convertUTxO :: (TxIn, TxOut era) -> (WalletUTxO, W.TokenBundle)
+        convertUTxO (i, o) = (WalletUTxO i' addr, bundle)
+          where
+            i' = Convert.toWallet i
+            W.TxOut addr bundle = toWalletTxOut era o
         maybeUnresolvedTxIns :: Maybe (NonEmpty TxIn)
         maybeUnresolvedTxIns
             = NE.nonEmpty

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -585,7 +585,8 @@ balanceTransaction
             $ Set.toList
             $ txIns <\> Map.keysSet (unUTxO selectedUTxO)
         selectedUTxO :: UTxO era
-        selectedUTxO = UTxO $ Map.restrictKeys (unUTxO utxoReference) txIns
+        selectedUTxO@(UTxO selectedUTxOMap) =
+            UTxO $ Map.restrictKeys (unUTxO utxoReference) txIns
         selectedUTxOIndex :: UTxOIndex.UTxOIndex WalletUTxO
         selectedUTxOIndex
             = UTxOIndex.fromSequence

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -592,6 +592,8 @@ balanceTransaction
                 $ (unresolvedInsHead :| unresolvedInsTail)
       where
         era = recentEra @era
+        selectedUTxO :: UTxO era
+        selectedUTxO = UTxO $ Map.restrictKeys (unUTxO utxoReference) txInSet
         txIns :: [TxIn]
         txIns = Set.toList txInSet
         txInSet :: Set TxIn

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -592,6 +592,11 @@ balanceTransaction
                 $ (unresolvedInsHead :| unresolvedInsTail)
       where
         era = recentEra @era
+        maybeUnresolvedTxIns :: Maybe (NonEmpty TxIn)
+        maybeUnresolvedTxIns
+            = NE.nonEmpty
+            $ Set.toList
+            $ txInSet <\> Map.keysSet (unUTxO selectedUTxO)
         selectedUTxO :: UTxO era
         selectedUTxO = UTxO $ Map.restrictKeys (unUTxO utxoReference) txInSet
         txIns :: [TxIn]

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -586,11 +586,8 @@ balanceTransaction
         selectedUTxO@(UTxO selectedUTxOMap) =
             UTxO $ Map.restrictKeys (unUTxO utxoReference) txIns
         selectedUTxOIndex :: UTxOIndex.UTxOIndex WalletUTxO
-        selectedUTxOIndex
-            = UTxOIndex.fromSequence
-            $ fmap convertUTxO
-            $ Map.toList
-            $ unUTxO selectedUTxO
+        selectedUTxOIndex =
+            UTxOIndex.fromSequence (convertUTxO <$> Map.toList selectedUTxOMap)
         txIns :: Set TxIn
         txIns = tx ^. bodyTxL . inputsTxBodyL
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -536,7 +536,7 @@ balanceTransaction
     guardExistingTotalCollateral
 
     guardUTxOConsistency
-    externallySelectedUtxo <- extractExternallySelectedUTxO
+    externallySelectedUtxo <- indexPreselectedUTxO
     let utxoSelection =
             UTxOSelection.fromIndexPair
                 (availableUTxOIndex, externallySelectedUtxo)
@@ -569,9 +569,9 @@ balanceTransaction
     -- This function will fail if any of the inputs refers to a UTxO that
     -- cannot be found in the UTxO reference set.
     --
-    extractExternallySelectedUTxO
+    indexPreselectedUTxO
         :: ExceptT (ErrBalanceTx era) m (UTxOIndex.UTxOIndex WalletUTxO)
-    extractExternallySelectedUTxO = do
+    indexPreselectedUTxO = do
         let res = flip map txIns $ \i ->
                 case txinLookup i utxoReference of
                     Nothing ->

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -601,6 +601,12 @@ balanceTransaction
             $ txInSet <\> Map.keysSet (unUTxO selectedUTxO)
         selectedUTxO :: UTxO era
         selectedUTxO = UTxO $ Map.restrictKeys (unUTxO utxoReference) txInSet
+        selectedUTxOIndex :: UTxOIndex.UTxOIndex WalletUTxO
+        selectedUTxOIndex
+            = UTxOIndex.fromSequence
+            $ fmap convertUTxO
+            $ Map.toList
+            $ unUTxO selectedUTxO
         txIns :: [TxIn]
         txIns = Set.toList txInSet
         txInSet :: Set TxIn

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -572,7 +572,8 @@ balanceTransaction
     indexPreselectedUTxO
         :: ExceptT (ErrBalanceTx era) m (UTxOIndex.UTxOIndex WalletUTxO)
     indexPreselectedUTxO = do
-        let res = flip map txIns $ \i ->
+        let res :: [Either TxIn (WalletUTxO, W.TokenBundle)]
+            res = flip map txIns $ \i ->
                 case txinLookup i utxoReference of
                     Nothing ->
                        Left i

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -581,12 +581,12 @@ balanceTransaction
             W.TxOut addr bundle = toWalletTxOut era o
         maybeUnresolvedTxIns :: Maybe (NonEmpty TxIn)
         maybeUnresolvedTxIns =
-            NE.nonEmpty $ Set.toList $ txIns <\> Map.keysSet selectedUTxOMap
-        selectedUTxOMap :: Map TxIn (TxOut era)
-        selectedUTxOMap = Map.restrictKeys (unUTxO utxoReference) txIns
+            NE.nonEmpty $ Set.toList $ txIns <\> Map.keysSet selectedUTxO
+        selectedUTxO :: Map TxIn (TxOut era)
+        selectedUTxO = Map.restrictKeys (unUTxO utxoReference) txIns
         selectedUTxOIndex :: UTxOIndex.UTxOIndex WalletUTxO
         selectedUTxOIndex =
-            UTxOIndex.fromSequence (convertUTxO <$> Map.toList selectedUTxOMap)
+            UTxOIndex.fromSequence (convertUTxO <$> Map.toList selectedUTxO)
         txIns :: Set TxIn
         txIns = tx ^. bodyTxL . inputsTxBodyL
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -571,8 +571,8 @@ balanceTransaction
     indexPreselectedUTxO
         | Just unresolvedTxIns <- maybeUnresolvedTxIns =
             throwE (ErrBalanceTxUnresolvedInputs unresolvedTxIns)
-        | otherwise =
-            pure selectedUTxOIndex
+        | otherwise = pure $
+            UTxOIndex.fromSequence (convertUTxO <$> Map.toList selectedUTxO)
       where
         era = recentEra @era
         convertUTxO :: (TxIn, TxOut era) -> (WalletUTxO, W.TokenBundle)
@@ -584,9 +584,6 @@ balanceTransaction
             NE.nonEmpty $ Set.toList $ txIns <\> Map.keysSet selectedUTxO
         selectedUTxO :: Map TxIn (TxOut era)
         selectedUTxO = Map.restrictKeys (unUTxO utxoReference) txIns
-        selectedUTxOIndex :: UTxOIndex.UTxOIndex WalletUTxO
-        selectedUTxOIndex =
-            UTxOIndex.fromSequence (convertUTxO <$> Map.toList selectedUTxO)
         txIns :: Set TxIn
         txIns = tx ^. bodyTxL . inputsTxBodyL
 

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -180,6 +180,9 @@ import Data.Monoid.Monus
 import Data.Semigroup.Cancellative
     ( Reductive ((</>))
     )
+import Data.Set
+    ( Set
+    )
 import Fmt
     ( Buildable
     , Builder
@@ -590,7 +593,9 @@ balanceTransaction
       where
         era = recentEra @era
         txIns :: [TxIn]
-        txIns = Set.toList $ tx ^. bodyTxL . inputsTxBodyL
+        txIns = Set.toList txInSet
+        txInSet :: Set TxIn
+        txInSet = tx ^. bodyTxL . inputsTxBodyL
 
     -- The set of all UTxOs that may be referenced by a balanced transaction.
     --

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -583,17 +583,17 @@ balanceTransaction
         maybeUnresolvedTxIns
             = NE.nonEmpty
             $ Set.toList
-            $ txInSet <\> Map.keysSet (unUTxO selectedUTxO)
+            $ txIns <\> Map.keysSet (unUTxO selectedUTxO)
         selectedUTxO :: UTxO era
-        selectedUTxO = UTxO $ Map.restrictKeys (unUTxO utxoReference) txInSet
+        selectedUTxO = UTxO $ Map.restrictKeys (unUTxO utxoReference) txIns
         selectedUTxOIndex :: UTxOIndex.UTxOIndex WalletUTxO
         selectedUTxOIndex
             = UTxOIndex.fromSequence
             $ fmap convertUTxO
             $ Map.toList
             $ unUTxO selectedUTxO
-        txInSet :: Set TxIn
-        txInSet = tx ^. bodyTxL . inputsTxBodyL
+        txIns :: Set TxIn
+        txIns = tx ^. bodyTxL . inputsTxBodyL
 
     -- The set of all UTxOs that may be referenced by a balanced transaction.
     --

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -580,10 +580,8 @@ balanceTransaction
           where
             W.TxOut addr bundle = toWalletTxOut era o
         maybeUnresolvedTxIns :: Maybe (NonEmpty TxIn)
-        maybeUnresolvedTxIns
-            = NE.nonEmpty
-            $ Set.toList
-            $ txIns <\> Map.keysSet (unUTxO selectedUTxO)
+        maybeUnresolvedTxIns =
+            NE.nonEmpty $ Set.toList $ txIns <\> Map.keysSet selectedUTxOMap
         selectedUTxO :: UTxO era
         selectedUTxO@(UTxO selectedUTxOMap) =
             UTxO $ Map.restrictKeys (unUTxO utxoReference) txIns

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -582,9 +582,8 @@ balanceTransaction
         maybeUnresolvedTxIns :: Maybe (NonEmpty TxIn)
         maybeUnresolvedTxIns =
             NE.nonEmpty $ Set.toList $ txIns <\> Map.keysSet selectedUTxOMap
-        selectedUTxO :: UTxO era
-        selectedUTxO@(UTxO selectedUTxOMap) =
-            UTxO $ Map.restrictKeys (unUTxO utxoReference) txIns
+        selectedUTxOMap :: Map TxIn (TxOut era)
+        selectedUTxOMap = Map.restrictKeys (unUTxO utxoReference) txIns
         selectedUTxOIndex :: UTxOIndex.UTxOIndex WalletUTxO
         selectedUTxOIndex =
             UTxOIndex.fromSequence (convertUTxO <$> Map.toList selectedUTxOMap)


### PR DESCRIPTION
This PR uses built-in `Set` and `Map` operations to simplify the creation of the "index of preselected UTxOs" (formerly known as the "externally selected UTxO index") within `balanceTx`.

## Context

The caller of `balanceTx` can provide a partial transaction that already has inputs. These inputs must resolve to UTxOs in the reference UTxO set. Provided that all inputs can be resolved, we then construct an index of preselected UTxOs. If one or more inputs cannot be resolved, we fail with `ErrBalanceTxUnresolvedInputs`.

## Issue

ADP-3272

## Performance

Mean and standard deviation of CPU time over 8 runs of `cabal test cardano-balance-tx`:

| Version | Mean | Standard Deviation |
|-|-|-|
| **Before** | `42.7 s` | `2.7 s` |
| **After** | `41.6 s` | `1.8 s` |

(no significant change)