### PR TITLE
[ADP-3272] Remove `cardano-api` conversions from `restrictResolution`.

### DIFF
--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2301,16 +2301,9 @@ paymentPartialTx txouts =
 -- shrinking the CBOR.
 --
 -- NOTE: Perhaps ideally 'PartialTx' would handle this automatically.
-restrictResolution
-    :: forall era. IsRecentEra era
-    => PartialTx era
-    -> PartialTx era
-restrictResolution partialTx@PartialTx {tx, extraUTxO} =
-    partialTx
-        { extraUTxO
-            = UTxO
-            $ unUTxO extraUTxO `Map.restrictKeys` txIns
-        }
+restrictResolution :: IsRecentEra era => PartialTx era -> PartialTx era
+restrictResolution partialTx@PartialTx {tx, extraUTxO} = partialTx
+    {extraUTxO = UTxO $ unUTxO extraUTxO `Map.restrictKeys` txIns}
   where
     txIns = tx ^. bodyTxL . inputsTxBodyL
 

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -282,7 +282,6 @@ import Internal.Cardano.Write.Tx
     , recentEra
     , serializeTx
     , toCardanoApiTx
-    , toCardanoApiUTxO
     , unsafeUtxoFromTxOutsInRecentEra
     )
 import Internal.Cardano.Write.Tx.Balance
@@ -2309,14 +2308,12 @@ restrictResolution
 restrictResolution partialTx@PartialTx {tx, extraUTxO} =
     partialTx
         { extraUTxO
-            = fromCardanoApiUTxO
-            $ CardanoApi.UTxO
-            $ extraUTxOMap `Map.restrictKeys` inputsInTx (toCardanoApiTx tx)
+            = UTxO
+            $ extraUTxOMap `Map.restrictKeys` inputsInTx tx
         }
   where
-    CardanoApi.UTxO extraUTxOMap = toCardanoApiUTxO extraUTxO
-    inputsInTx (CardanoApi.Tx (CardanoApi.TxBody bod) _) =
-        Set.fromList $ map fst $ CardanoApi.txIns bod
+    UTxO extraUTxOMap = extraUTxO
+    inputsInTx tx' = tx' ^. bodyTxL . inputsTxBodyL
 
 serializedSize
     :: forall era. IsRecentEra era

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2309,10 +2309,10 @@ restrictResolution partialTx@PartialTx {tx, extraUTxO} =
     partialTx
         { extraUTxO
             = UTxO
-            $ unUTxO extraUTxO `Map.restrictKeys` inputsInTx tx
+            $ unUTxO extraUTxO `Map.restrictKeys` inputsInTx
         }
   where
-    inputsInTx tx' = tx' ^. bodyTxL . inputsTxBodyL
+    inputsInTx = tx ^. bodyTxL . inputsTxBodyL
 
 serializedSize
     :: forall era. IsRecentEra era

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2309,10 +2309,9 @@ restrictResolution partialTx@PartialTx {tx, extraUTxO} =
     partialTx
         { extraUTxO
             = UTxO
-            $ extraUTxOMap `Map.restrictKeys` inputsInTx tx
+            $ unUTxO extraUTxO `Map.restrictKeys` inputsInTx tx
         }
   where
-    UTxO extraUTxOMap = extraUTxO
     inputsInTx tx' = tx' ^. bodyTxL . inputsTxBodyL
 
 serializedSize

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2309,10 +2309,10 @@ restrictResolution partialTx@PartialTx {tx, extraUTxO} =
     partialTx
         { extraUTxO
             = UTxO
-            $ unUTxO extraUTxO `Map.restrictKeys` inputsInTx
+            $ unUTxO extraUTxO `Map.restrictKeys` txIns
         }
   where
-    inputsInTx = tx ^. bodyTxL . inputsTxBodyL
+    txIns = tx ^. bodyTxL . inputsTxBodyL
 
 serializedSize
     :: forall era. IsRecentEra era


### PR DESCRIPTION
This PR removes conversions to and from `cardano-api` types from the `restrictResolution` function.

## Issue

ADP-3272