### PR TITLE
[ADP-3272] Remove `cardano-api` conversions from `Arbitrary` instance for `PartialTx era`.

### DIFF
--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2681,18 +2681,6 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         genTxForBalancing :: Gen (Tx era)
         genTxForBalancing =
             fromCardanoApiTx <$> CardanoApi.genTxForBalancing (cardanoEra @era)
-        genTxOut :: Gen (TxOut era)
-        genTxOut =
-            CardanoApi.toShelleyTxOut (Write.shelleyBasedEra @era)
-                <$> genCardanoApiTxOut
-          where
-            genCardanoApiTxOut :: Gen (CardanoApi.TxOut ctx (CardanoApiEra era))
-            genCardanoApiTxOut =
-                -- NOTE: genTxOut does not generate quantities larger than
-                -- `maxBound :: Word64`, however users could supply these. We
-                -- should ideally test what happens, and make it clear what
-                -- code, if any, should validate.
-                CardanoApi.genTxOut (cardanoEra @era)
         txInputs :: Tx era -> Set TxIn
         txInputs tx = tx ^. bodyTxL . inputsTxBodyL
     shrink partialTx@PartialTx {tx, extraUTxO} =
@@ -2819,6 +2807,19 @@ instance forall era. IsRecentEra era => Arbitrary (Wallet era) where
             utxoToMap (UTxO m) = m
 
         shrinkEntry _ = []
+
+genTxOut :: forall era. IsRecentEra era => Gen (TxOut era)
+genTxOut =
+    CardanoApi.toShelleyTxOut (Write.shelleyBasedEra @era)
+        <$> genCardanoApiTxOut
+  where
+    genCardanoApiTxOut :: Gen (CardanoApi.TxOut ctx (CardanoApiEra era))
+    genCardanoApiTxOut =
+        -- NOTE: genTxOut does not generate quantities larger than
+        -- `maxBound :: Word64`, however users could supply these. We
+        -- should ideally test what happens, and make it clear what
+        -- code, if any, should validate.
+        CardanoApi.genTxOut (cardanoEra @era)
 
 -- | For writing shrinkers in the style of https://stackoverflow.com/a/14006575
 prependOriginal :: (t -> [t]) -> t -> [t]

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2685,6 +2685,10 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
             -- should ideally test what happens, and make it clear what
             -- code, if any, should validate.
             CardanoApi.genTxOut (cardanoEra @era)
+        genTxOutLedger :: Gen (TxOut era)
+        genTxOutLedger =
+            CardanoApi.toShelleyTxOut (Write.shelleyBasedEra @era)
+                <$> genTxOut
         txInputs tx = fst <$> CardanoApi.txIns content
           where
             CardanoApi.Tx (CardanoApi.TxBody content) _ = tx

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2665,7 +2665,7 @@ instance Arbitrary (MixedSign Value) where
 
 instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
     arbitrary = do
-        tx <- CardanoApi.genTxForBalancing $ cardanoEra @era
+        tx <- genTxForBalancing
         extraUTxO <- genExtraUTxO (fromCardanoApiTx tx)
         return PartialTx
             { tx = fromCardanoApiTx tx
@@ -2682,6 +2682,9 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
             mapM
                 (\i -> (i,) <$> genTxOutLedger)
                 (Set.toList $ txInputsLedger tx)
+        genTxForBalancing :: Gen (CardanoApi.Tx (CardanoApiEra era))
+        genTxForBalancing =
+            CardanoApi.genTxForBalancing $ cardanoEra @era
         genTxOut :: Gen (CardanoApi.TxOut ctx (CardanoApiEra era))
         genTxOut =
             -- NOTE: genTxOut does not generate quantities larger than

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2694,14 +2694,6 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         [ restrictResolution (partialTx {tx = tx'})
         | tx' <- shrinkTx tx
         ]
-      where
-        shrinkTx :: Tx era -> [Tx era]
-        shrinkTx =
-            shrinkMapBy fromCardanoApiTx toCardanoApiTx shrinkCardanoApiTx
-          where
-            shrinkCardanoApiTx = case recentEra @era of
-                RecentEraBabbage -> shrinkTxBabbage
-                RecentEraConway -> \_ -> [] -- no shrinker implemented yet
 
 instance Arbitrary StdGenSeed  where
     arbitrary = StdGenSeed . fromIntegral @Int <$> arbitrary
@@ -2878,6 +2870,14 @@ shrinkStrictMaybe :: StrictMaybe a -> [StrictMaybe a]
 shrinkStrictMaybe = \case
     SNothing -> []
     SJust _ -> [SNothing]
+
+shrinkTx :: forall era. IsRecentEra era => Tx era -> [Tx era]
+shrinkTx =
+    shrinkMapBy fromCardanoApiTx toCardanoApiTx shrinkCardanoApiTx
+  where
+    shrinkCardanoApiTx = case recentEra @era of
+        RecentEraBabbage -> shrinkTxBabbage
+        RecentEraConway -> \_ -> [] -- no shrinker implemented yet
 
 shrinkTxBabbage
     :: CardanoApi.Tx CardanoApi.BabbageEra

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2678,6 +2678,7 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         genExtraUTxO tx =
             CardanoApi.UTxO . Map.fromList <$>
             mapM (\i -> (i,) <$> genTxOut) (txInputs tx)
+        genTxOut :: Gen (CardanoApi.TxOut ctx (CardanoApiEra era))
         genTxOut =
             -- NOTE: genTxOut does not generate quantities larger than
             -- `maxBound :: Word64`, however users could supply these. We

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2698,6 +2698,9 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         shrinkCardanoApiTx = case recentEra @era of
             RecentEraBabbage -> shrinkTxBabbage
             RecentEraConway -> \_ -> [] -- no shrinker implemented yet
+        shrinkTx :: Tx era -> [Tx era]
+        shrinkTx =
+            shrinkMapBy fromCardanoApiTx toCardanoApiTx shrinkCardanoApiTx
 
 instance Arbitrary StdGenSeed  where
     arbitrary = StdGenSeed . fromIntegral @Int <$> arbitrary

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2810,16 +2810,12 @@ instance forall era. IsRecentEra era => Arbitrary (Wallet era) where
 
 genTxOut :: forall era. IsRecentEra era => Gen (TxOut era)
 genTxOut =
+    -- NOTE: genTxOut does not generate quantities larger than
+    -- `maxBound :: Word64`, however users could supply these. We
+    -- should ideally test what happens, and make it clear what
+    -- code, if any, should validate.
     CardanoApi.toShelleyTxOut (Write.shelleyBasedEra @era)
-        <$> genCardanoApiTxOut
-  where
-    genCardanoApiTxOut :: Gen (CardanoApi.TxOut ctx (CardanoApiEra era))
-    genCardanoApiTxOut =
-        -- NOTE: genTxOut does not generate quantities larger than
-        -- `maxBound :: Word64`, however users could supply these. We
-        -- should ideally test what happens, and make it clear what
-        -- code, if any, should validate.
-        CardanoApi.genTxOut (cardanoEra @era)
+        <$> CardanoApi.genTxOut (cardanoEra @era)
 
 -- | For writing shrinkers in the style of https://stackoverflow.com/a/14006575
 prependOriginal :: (t -> [t]) -> t -> [t]

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2695,12 +2695,13 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         | tx' <- shrinkTx tx
         ]
       where
-        shrinkCardanoApiTx = case recentEra @era of
-            RecentEraBabbage -> shrinkTxBabbage
-            RecentEraConway -> \_ -> [] -- no shrinker implemented yet
         shrinkTx :: Tx era -> [Tx era]
         shrinkTx =
             shrinkMapBy fromCardanoApiTx toCardanoApiTx shrinkCardanoApiTx
+          where
+            shrinkCardanoApiTx = case recentEra @era of
+                RecentEraBabbage -> shrinkTxBabbage
+                RecentEraConway -> \_ -> [] -- no shrinker implemented yet
 
 instance Arbitrary StdGenSeed  where
     arbitrary = StdGenSeed . fromIntegral @Int <$> arbitrary

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2693,9 +2693,6 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         genTxOutLedger =
             CardanoApi.toShelleyTxOut (Write.shelleyBasedEra @era)
                 <$> genTxOut
-        txInputs tx = fst <$> CardanoApi.txIns content
-          where
-            CardanoApi.Tx (CardanoApi.TxBody content) _ = tx
         txInputsLedger tx = tx ^. bodyTxL . inputsTxBodyL
     shrink partialTx@PartialTx {tx, extraUTxO} =
         [ partialTx {extraUTxO = extraUTxO'}

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2681,7 +2681,7 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
             UTxO . Map.fromList <$>
             mapM
                 (\i -> (i,) <$> genTxOut)
-                (Set.toList $ txInputsLedger tx)
+                (Set.toList $ txInputs tx)
         genTxForBalancing :: Gen (Tx era)
         genTxForBalancing =
             fromCardanoApiTx <$> CardanoApi.genTxForBalancing (cardanoEra @era)
@@ -2697,7 +2697,8 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
                 -- should ideally test what happens, and make it clear what
                 -- code, if any, should validate.
                 CardanoApi.genTxOut (cardanoEra @era)
-        txInputsLedger tx = tx ^. bodyTxL . inputsTxBodyL
+        txInputs :: Tx era -> Set TxIn
+        txInputs tx = tx ^. bodyTxL . inputsTxBodyL
     shrink partialTx@PartialTx {tx, extraUTxO} =
         [ partialTx {extraUTxO = extraUTxO'}
         | extraUTxO' <- shrinkInputResolution extraUTxO

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2674,14 +2674,10 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
             , timelockKeyWitnessCounts = mempty
             }
       where
-        genExtraUTxO
-            :: Tx era
-            -> Gen (UTxO era)
+        genExtraUTxO :: Tx era -> Gen (UTxO era)
         genExtraUTxO tx =
             UTxO . Map.fromList <$>
-            mapM
-                (\i -> (i,) <$> genTxOut)
-                (Set.toList $ txInputs tx)
+            mapM (\i -> (i,) <$> genTxOut) (Set.toList $ txInputs tx)
         genTxForBalancing :: Gen (Tx era)
         genTxForBalancing =
             fromCardanoApiTx <$> CardanoApi.genTxForBalancing (cardanoEra @era)

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2667,12 +2667,9 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
     arbitrary = do
         tx <- genTxForBalancing
         extraUTxO <- genExtraUTxO tx
-        return PartialTx
-            { tx
-            , extraUTxO
-            , redeemers = []
-            , timelockKeyWitnessCounts = mempty
-            }
+        let redeemers = []
+        let timelockKeyWitnessCounts = mempty
+        pure PartialTx {tx, extraUTxO, redeemers, timelockKeyWitnessCounts}
       where
         genExtraUTxO :: Tx era -> Gen (UTxO era)
         genExtraUTxO tx =

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2670,15 +2670,16 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         extraUTxO <- genExtraUTxO tx
         return PartialTx
             { tx = fromCardanoApiTx tx
-            , extraUTxO = fromCardanoApiUTxO extraUTxO
+            , extraUTxO
             , redeemers = []
             , timelockKeyWitnessCounts = mempty
             }
       where
         genExtraUTxO
             :: CardanoApi.Tx (CardanoApiEra era)
-            -> Gen (CardanoApi.UTxO (CardanoApiEra era))
+            -> Gen (UTxO era)
         genExtraUTxO tx =
+            fromCardanoApiUTxO .
             CardanoApi.UTxO . Map.fromList <$>
             mapM (\i -> (i,) <$> genTxOut) (txInputs tx)
         genTxOut :: Gen (CardanoApi.TxOut ctx (CardanoApiEra era))

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2695,6 +2695,7 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         txInputs tx = fst <$> CardanoApi.txIns content
           where
             CardanoApi.Tx (CardanoApi.TxBody content) _ = tx
+        txInputsLedger tx = tx ^. bodyTxL . inputsTxBodyL
     shrink partialTx@PartialTx {tx, extraUTxO} =
         [ partialTx {extraUTxO = extraUTxO'}
         | extraUTxO' <- shrinkInputResolution extraUTxO

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2678,9 +2678,6 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         genExtraUTxO tx =
             UTxO . Map.fromList <$>
             mapM (\i -> (i,) <$> genTxOut) (Set.toList $ txInputs tx)
-        genTxForBalancing :: Gen (Tx era)
-        genTxForBalancing =
-            fromCardanoApiTx <$> CardanoApi.genTxForBalancing (cardanoEra @era)
         txInputs :: Tx era -> Set TxIn
         txInputs tx = tx ^. bodyTxL . inputsTxBodyL
     shrink partialTx@PartialTx {tx, extraUTxO} =
@@ -2807,6 +2804,10 @@ instance forall era. IsRecentEra era => Arbitrary (Wallet era) where
             utxoToMap (UTxO m) = m
 
         shrinkEntry _ = []
+
+genTxForBalancing :: forall era. IsRecentEra era => Gen (Tx era)
+genTxForBalancing =
+    fromCardanoApiTx <$> CardanoApi.genTxForBalancing (cardanoEra @era)
 
 genTxOut :: forall era. IsRecentEra era => Gen (TxOut era)
 genTxOut =

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2675,6 +2675,9 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
             , timelockKeyWitnessCounts = mempty
             }
       where
+        genExtraUTxO
+            :: CardanoApi.Tx (CardanoApiEra era)
+            -> Gen (CardanoApi.UTxO (CardanoApiEra era))
         genExtraUTxO tx =
             CardanoApi.UTxO . Map.fromList <$>
             mapM (\i -> (i,) <$> genTxOut) (txInputs tx)

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2680,13 +2680,13 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         genExtraUTxO tx =
             UTxO . Map.fromList <$>
             mapM
-                (\i -> (i,) <$> genTxOutLedger)
+                (\i -> (i,) <$> genTxOut)
                 (Set.toList $ txInputsLedger tx)
         genTxForBalancing :: Gen (Tx era)
         genTxForBalancing =
             fromCardanoApiTx <$> CardanoApi.genTxForBalancing (cardanoEra @era)
-        genTxOutLedger :: Gen (TxOut era)
-        genTxOutLedger =
+        genTxOut :: Gen (TxOut era)
+        genTxOut =
             CardanoApi.toShelleyTxOut (Write.shelleyBasedEra @era)
                 <$> genCardanoApiTxOut
           where

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2677,9 +2677,10 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         genExtraUTxO :: Tx era -> Gen (UTxO era)
         genExtraUTxO tx =
             UTxO . Map.fromList <$>
-            mapM (\i -> (i,) <$> genTxOut) (Set.toList $ txInputs tx)
-        txInputs :: Tx era -> Set TxIn
-        txInputs tx = tx ^. bodyTxL . inputsTxBodyL
+            mapM (\i -> (i,) <$> genTxOut) (Set.toList txInputs)
+          where
+            txInputs :: Set TxIn
+            txInputs = tx ^. bodyTxL . inputsTxBodyL
     shrink partialTx@PartialTx {tx, extraUTxO} =
         [ partialTx {extraUTxO = extraUTxO'}
         | extraUTxO' <- shrinkInputResolution extraUTxO

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2685,17 +2685,18 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         genTxForBalancing :: Gen (Tx era)
         genTxForBalancing =
             fromCardanoApiTx <$> CardanoApi.genTxForBalancing (cardanoEra @era)
-        genTxOut :: Gen (CardanoApi.TxOut ctx (CardanoApiEra era))
-        genTxOut =
-            -- NOTE: genTxOut does not generate quantities larger than
-            -- `maxBound :: Word64`, however users could supply these. We
-            -- should ideally test what happens, and make it clear what
-            -- code, if any, should validate.
-            CardanoApi.genTxOut (cardanoEra @era)
         genTxOutLedger :: Gen (TxOut era)
         genTxOutLedger =
             CardanoApi.toShelleyTxOut (Write.shelleyBasedEra @era)
-                <$> genTxOut
+                <$> genCardanoApiTxOut
+          where
+            genCardanoApiTxOut :: Gen (CardanoApi.TxOut ctx (CardanoApiEra era))
+            genCardanoApiTxOut =
+                -- NOTE: genTxOut does not generate quantities larger than
+                -- `maxBound :: Word64`, however users could supply these. We
+                -- should ideally test what happens, and make it clear what
+                -- code, if any, should validate.
+                CardanoApi.genTxOut (cardanoEra @era)
         txInputsLedger tx = tx ^. bodyTxL . inputsTxBodyL
     shrink partialTx@PartialTx {tx, extraUTxO} =
         [ partialTx {extraUTxO = extraUTxO'}

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2691,8 +2691,8 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         [ partialTx {extraUTxO = extraUTxO'}
         | extraUTxO' <- shrinkInputResolution extraUTxO
         ] <>
-        [ restrictResolution (partialTx {tx = fromCardanoApiTx tx'})
-        | tx' <- shrinkCardanoApiTx (toCardanoApiTx tx)
+        [ restrictResolution (partialTx {tx = tx'})
+        | tx' <- shrinkTx tx
         ]
       where
         shrinkCardanoApiTx = case recentEra @era of

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2666,9 +2666,9 @@ instance Arbitrary (MixedSign Value) where
 instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
     arbitrary = do
         tx <- genTxForBalancing
-        extraUTxO <- genExtraUTxO (fromCardanoApiTx tx)
+        extraUTxO <- genExtraUTxO tx
         return PartialTx
-            { tx = fromCardanoApiTx tx
+            { tx
             , extraUTxO
             , redeemers = []
             , timelockKeyWitnessCounts = mempty
@@ -2682,9 +2682,9 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
             mapM
                 (\i -> (i,) <$> genTxOutLedger)
                 (Set.toList $ txInputsLedger tx)
-        genTxForBalancing :: Gen (CardanoApi.Tx (CardanoApiEra era))
+        genTxForBalancing :: Gen (Tx era)
         genTxForBalancing =
-            CardanoApi.genTxForBalancing $ cardanoEra @era
+            fromCardanoApiTx <$> CardanoApi.genTxForBalancing (cardanoEra @era)
         genTxOut :: Gen (CardanoApi.TxOut ctx (CardanoApiEra era))
         genTxOut =
             -- NOTE: genTxOut does not generate quantities larger than


### PR DESCRIPTION
This PR redefines the `Arbitrary` instance for `PartialTx era` in terms of the following generators and shrinkers that use ledger types:

```hs
genTxForBalancing :: IsRecentEra era => Gen (Tx era)
genTxOut          :: IsRecentEra era => Gen (TxOut era)
shrinkTx          :: IsRecentEra era => Tx era -> [Tx era]
```

Internally, these generators and shrinkers may still use conversions to and from `cardano-api` types, but those conversions no longer leak out into code that calls them.
 
Importantly, this allows the definition of `Arbitrary` for `PartialTx era` to be completely free of conversions, which makes the flow of data clearer.

## Issue

ADP-3272