### PR TITLE
[ADP-3350] Remove `BlockHeader` from `Cardano.Wallet.Network.Logging`

### DIFF
--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -95,9 +95,6 @@ import Cardano.Wallet.Network.Implementation.UnliftIO
 import Cardano.Wallet.Primitive.Ledger.Byron
     ( byronCodecConfig
     )
-import Cardano.Wallet.Primitive.Ledger.Read.Block.Header
-    ( getBlockHeader
-    )
 import Cardano.Wallet.Primitive.Ledger.Shelley
     ( nodeToClientVersions
     , toCardanoEra
@@ -478,7 +475,9 @@ withNodeNetworkLayerBase
                                 trFollowLog
                                 (_syncProgress interpreterVar)
                     withStats $ \trChainSyncLog -> do
-                        let mapB = getBlockHeader getGenesisBlockHash
+                        let mapB =
+                                Read.applyEraFunValue Read.getEraBHeader
+                                . Read.fromConsensusBlock
                             mapP = fromOuroborosPoint
                         let client =
                                 mkWalletClient
@@ -527,8 +526,7 @@ withNodeNetworkLayerBase
                 }
       where
         GenesisParameters
-            { getGenesisBlockHash
-            , getGenesisBlockDate
+            { getGenesisBlockDate
             } = genesisParameters np
         sp = slottingParameters np
         cfg = codecConfig sp

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation/Types.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation/Types.hs
@@ -17,10 +17,10 @@ module Cardano.Wallet.Network.Implementation.Types
 import Prelude
 
 import Cardano.Wallet.Read
-    ( BHeader
-    , BlockNo (..)
+    ( BlockNo (..)
     , ChainPoint (..)
     , ChainTip (..)
+    , EraIndependentBlockHeader
     , SlotNo (..)
     )
 import Cardano.Wallet.Read.Hash
@@ -89,10 +89,14 @@ toCardanoSlotNo (SlotNo slot) = O.SlotNo (toEnum $ fromEnum slot)
 fromCardanoSlotNo :: O.SlotNo -> SlotNo
 fromCardanoSlotNo (O.SlotNo slot) = SlotNo (fromIntegral slot)
 
-toCardanoHash :: Hash Blake2b_256 BHeader -> OneEraHash (CardanoEras sc)
+toCardanoHash
+    :: Hash Blake2b_256 EraIndependentBlockHeader
+    -> OneEraHash (CardanoEras sc)
 toCardanoHash = OneEraHash . hashToBytesShort
 
-fromCardanoHash :: OneEraHash (CardanoEras sc) -> Hash Blake2b_256 BHeader
+fromCardanoHash
+    :: OneEraHash (CardanoEras sc)
+    -> Hash Blake2b_256 EraIndependentBlockHeader
 fromCardanoHash = fromJust . hashFromBytesShort . getOneEraHash
 
 toCardanoBlockNo :: BlockNo -> O.BlockNo

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Block.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Block.hs
@@ -26,7 +26,6 @@ import Cardano.Wallet.Read
     , ConsensusBlock
     , IsEra
     , fromConsensusBlock
-    , (:.:) (Comp)
     )
 import Cardano.Wallet.Read.Block.Txs
     ( getEraTransactions
@@ -66,7 +65,7 @@ primitiveBlock hg = do
 
 getTxsAndCertificates :: IsEra era => Block era -> [(W.Tx, [W.Certificate])]
 getTxsAndCertificates block =
-    let Comp txs = getEraTransactions block
+    let txs = getEraTransactions block
         ptxs = primitiveTx <$> txs
         pcts = getCertificates . getEraCertificates <$> txs
     in  zip ptxs pcts

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Block/Header.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Block/Header.hs
@@ -30,6 +30,9 @@ import Cardano.Wallet.Read
     , fromConsensusBlock
     , theEra
     )
+import Cardano.Wallet.Read.Block.BHeader
+    ( getEraBHeader
+    )
 import Cardano.Wallet.Read.Block.BlockNo
     ( BlockNo (..)
     , getEraBlockNo
@@ -88,7 +91,7 @@ primitiveBlockHeader
     -> Block era
     -> W.BlockHeader
 primitiveBlockHeader gp = do
-    slotNo <- fromSlotNo <$> getEraSlotNo
+    slotNo <- fromSlotNo <$> getEraSlotNo . getEraBHeader
     blockNo <- fromBlockNo <$> getEraBlockNo
     headerHash <- primitiveHash . getEraHeaderHash
     prevHeaderHash <- primitivePrevHash gp . getEraPrevHeaderHash

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Block/Header.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Block/Header.hs
@@ -92,7 +92,7 @@ primitiveBlockHeader
     -> W.BlockHeader
 primitiveBlockHeader gp = do
     slotNo <- fromSlotNo <$> getEraSlotNo . getEraBHeader
-    blockNo <- fromBlockNo <$> getEraBlockNo
+    blockNo <- fromBlockNo <$> getEraBlockNo . getEraBHeader
     headerHash <- primitiveHash . getEraHeaderHash
     prevHeaderHash <- primitivePrevHash gp . getEraPrevHeaderHash
     pure $ W.BlockHeader slotNo blockNo headerHash (Just prevHeaderHash)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -117,13 +116,6 @@ import Cardano.Api.Shelley
     ( ShelleyBasedEra (..)
     , ShelleyGenesis (..)
     )
-import Cardano.Chain.Block
-    ( ABlockOrBoundary (ABOBBlock, ABOBBoundary)
-    , blockTxPayload
-    )
-import Cardano.Chain.UTxO
-    ( unTxPayload
-    )
 import Cardano.Crypto.Hash.Class
     ( Hash (UnsafeHash)
     , hashToBytes
@@ -166,9 +158,6 @@ import Cardano.Slotting.Slot
 import Cardano.Wallet.Primitive.Ledger.Byron
     ( maryTokenBundleMaxSize
     )
-import Cardano.Wallet.Primitive.Ledger.Read.Tx
-    ( primitiveTx
-    )
 import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Certificates
     ( fromStakeCredential
     )
@@ -191,9 +180,6 @@ import Cardano.Wallet.Primitive.Types.Pool
 import Cardano.Wallet.Primitive.Types.StakePoolMetadata
     ( StakePoolMetadataHash (..)
     , StakePoolMetadataUrl (..)
-    )
-import Cardano.Wallet.Read
-    ( Byron
     )
 import Cardano.Wallet.Read.Tx.Hash
     ( fromShelleyTxId
@@ -261,9 +247,6 @@ import Fmt
 import GHC.Stack
     ( HasCallStack
     )
-import Ouroboros.Consensus.Byron.Ledger
-    ( byronBlockRaw
-    )
 import Ouroboros.Consensus.Cardano.Block
     ( CardanoBlock
     , CardanoEras
@@ -302,17 +285,13 @@ import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Ledger.Address as SL
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
-import qualified Cardano.Ledger.Alonzo.TxSeq as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
-import qualified Cardano.Ledger.Babbage as Babbage
 import qualified Cardano.Ledger.BaseTypes as SL
 import qualified Cardano.Ledger.Coin as Ledger
-import qualified Cardano.Ledger.Conway as Conway
 import qualified Cardano.Ledger.Credential as SL
 import qualified Cardano.Ledger.Crypto as SL
 import qualified Cardano.Ledger.Shelley.API as SL
 import qualified Cardano.Ledger.Shelley.API as SLAPI
-import qualified Cardano.Ledger.Shelley.BlockChain as SL
 import qualified Cardano.Protocol.TPraos.BHeader as SL
 import qualified Cardano.Slotting.Slot as Slotting
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Ledger
@@ -430,69 +409,20 @@ getConwayProducer (ShelleyBlock (SL.Block (Consensus.Header header _) _) _) =
     fromPoolKeyHash $ SL.hashKey (Consensus.hbVk header)
 
 numberOfTransactionsInBlock
-    :: CardanoBlock StandardCrypto -> (Int, (Quantity "block" Word32, O.SlotNo))
-numberOfTransactionsInBlock = \case
-    BlockByron byb -> transactionsByron byb
-    BlockShelley shb -> transactions shb
-    BlockAllegra shb -> transactions shb
-    BlockMary shb -> transactions shb
-    BlockAlonzo shb -> transactionsAlonzo shb
-    BlockBabbage shb -> transactionsBabbage shb
-    BlockConway shb -> transactionsConway shb
+    :: CardanoBlock StandardCrypto -> (Int, (Read.BlockNo, O.SlotNo))
+numberOfTransactionsInBlock =
+    Read.applyEraFun get . Read.fromConsensusBlock
   where
-    transactions
-        (ShelleyBlock
-            (SL.Block (SL.BHeader header _) (SL.ShelleyTxSeq txs'))
-            _
-        ) =
-            ( length txs'
-            , (fromBlockNo $ SL.bheaderBlockNo header, SL.bheaderSlotNo header)
-            )
-    transactionsAlonzo
-        (ShelleyBlock
-            (SL.Block (SL.BHeader header _) (Alonzo.AlonzoTxSeq txs'))
-            _
-        ) =
-            ( length txs'
-            , (fromBlockNo $ SL.bheaderBlockNo header, SL.bheaderSlotNo header)
-            )
-    transactionsBabbage
-        :: ShelleyBlock
-            (Consensus.Praos StandardCrypto)
-            (Babbage.BabbageEra StandardCrypto)
-        -> (Int, (Quantity "block" Word32, O.SlotNo))
-    transactionsBabbage
-        (ShelleyBlock
-            (SL.Block (Consensus.Header header _)
-            (Alonzo.AlonzoTxSeq txs')) _) =
-                ( length txs'
-                , ( fromBlockNo $ Consensus.hbBlockNo header
-                  , Consensus.hbSlotNo header
-                  )
-                )
-    transactionsByron blk =
-        (, (fromBlockNo $ O.blockNo blk, O.blockSlot blk)) $
-            case byronBlockRaw blk of
-            ABOBBlock blk' ->
-                length $ primitiveTx @Byron . Read.Tx
-                    <$> unTxPayload (blockTxPayload blk')
-            ABOBBoundary _ ->
-                0
-
-    transactionsConway
-        :: ShelleyBlock
-            (Consensus.Praos StandardCrypto)
-            (Conway.ConwayEra StandardCrypto)
-        -> (Int, (Quantity "block" Word32, O.SlotNo))
-    transactionsConway
-        (ShelleyBlock
-            (SL.Block (Consensus.Header header _)
-            (Alonzo.AlonzoTxSeq txs')) _) =
-                ( length txs'
-                , ( fromBlockNo $ Consensus.hbBlockNo header
-                  , Consensus.hbSlotNo header
-                  )
-                )
+    get :: Read.IsEra era => Read.Block era -> (Int, (Read.BlockNo, O.SlotNo))
+    get block =
+        ( length (Read.getEraTransactions block)
+        , (blockNo, O.SlotNo slotNo)
+        )
+      where
+        header = Read.getEraBHeader block
+        blockNo = Read.getEraBlockNo header
+        slotNo =
+            toEnum $ fromIntegral $ Read.unSlotNo $ Read.getEraSlotNo header
 
 toCardanoEra :: CardanoBlock c -> AnyCardanoEra
 toCardanoEra = \case

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -77,7 +77,6 @@ module Cardano.Wallet.Primitive.Ledger.Shelley
     , fromNonMyopicMemberRewards
     , optimumNumberOfPools
     , getProducer
-    , fromBlockNo
     , toCardanoEra
     , fromShelleyTxOut
     , fromGenesisData
@@ -270,9 +269,6 @@ import Ouroboros.Consensus.Shelley.Eras
 import Ouroboros.Consensus.Shelley.Ledger.Block
     ( ShelleyBlock (..)
     )
-import Ouroboros.Network.Block
-    ( BlockNo (..)
-    )
 import Ouroboros.Network.NodeToClient
     ( ConnectionId (..)
     , LocalAddress (..)
@@ -433,10 +429,6 @@ toCardanoEra = \case
     BlockAlonzo{}  -> AnyCardanoEra AlonzoEra
     BlockBabbage{} -> AnyCardanoEra BabbageEra
     BlockConway{}  -> AnyCardanoEra ConwayEra
-
--- FIXME unsafe conversion (Word64 -> Word32)
-fromBlockNo :: BlockNo -> Quantity "block" Word32
-fromBlockNo (BlockNo h) = Quantity (fromIntegral h)
 
 -- NOTE: Unsafe conversion from Natural -> Word16
 fromMaxSize :: Word32 -> Quantity "byte" Word16

--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -45,6 +45,7 @@ library
   exposed-modules:
     Cardano.Wallet.Read
     Cardano.Wallet.Read.Block
+    Cardano.Wallet.Read.Block.BHeader
     Cardano.Wallet.Read.Block.Block
     Cardano.Wallet.Read.Block.BlockNo
     Cardano.Wallet.Read.Block.Gen

--- a/lib/read/lib/Cardano/Wallet/Read/Block.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block.hs
@@ -6,13 +6,18 @@ The 'Block' type represents a block indexed by one of the known eras.
 It is compatible with the types from @cardano-ledger@.
 -}
 module Cardano.Wallet.Read.Block
-    ( module Cardano.Wallet.Read.Block.Block
+    ( module Cardano.Wallet.Read.Block.BHeader
+    , module Cardano.Wallet.Read.Block.Block
     , module Cardano.Wallet.Read.Block.BlockNo
     , module Cardano.Wallet.Read.Block.HeaderHash
     , module Cardano.Wallet.Read.Block.SlotNo
     , module Cardano.Wallet.Read.Block.Txs
     ) where
 
+import Cardano.Wallet.Read.Block.BHeader
+    ( BHeader (..)
+    , getEraBHeader
+    )
 import Cardano.Wallet.Read.Block.Block
     ( Block (..)
     , ConsensusBlock
@@ -24,7 +29,7 @@ import Cardano.Wallet.Read.Block.BlockNo
     , getEraBlockNo
     )
 import Cardano.Wallet.Read.Block.HeaderHash
-    ( BHeader
+    ( EraIndependentBlockHeader
     , HeaderHash (..)
     , HeaderHashT
     , PrevHeaderHash (..)

--- a/lib/read/lib/Cardano/Wallet/Read/Block.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block.hs
@@ -43,6 +43,7 @@ import Cardano.Wallet.Read.Block.HeaderHash
 import Cardano.Wallet.Read.Block.SlotNo
     ( SlotNo (..)
     , getEraSlotNo
+    , prettySlotNo
     )
 import Cardano.Wallet.Read.Block.Txs
     ( getEraTransactions

--- a/lib/read/lib/Cardano/Wallet/Read/Block.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block.hs
@@ -27,6 +27,7 @@ import Cardano.Wallet.Read.Block.Block
 import Cardano.Wallet.Read.Block.BlockNo
     ( BlockNo (..)
     , getEraBlockNo
+    , prettyBlockNo
     )
 import Cardano.Wallet.Read.Block.HeaderHash
     ( EraIndependentBlockHeader

--- a/lib/read/lib/Cardano/Wallet/Read/Block/BlockNo.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/BlockNo.hs
@@ -8,6 +8,7 @@
 module Cardano.Wallet.Read.Block.BlockNo
     ( getEraBlockNo
     , BlockNo (..)
+    , prettyBlockNo
     ) where
 
 import Prelude
@@ -36,6 +37,7 @@ import Ouroboros.Consensus.Shelley.Protocol.Praos
 import Ouroboros.Consensus.Shelley.Protocol.TPraos
     ()
 
+import qualified Data.Text as T
 import qualified Ouroboros.Network.Block as O
 
 {-# INLINABLE getEraBlockNo #-}
@@ -55,3 +57,7 @@ newtype BlockNo = BlockNo {unBlockNo :: Natural}
     deriving (Eq, Ord, Show, Generic, Enum)
 
 instance NoThunks BlockNo
+
+-- | Short printed representation of a 'BlockNo'.
+prettyBlockNo :: BlockNo -> T.Text
+prettyBlockNo (BlockNo n) = T.pack (show n)

--- a/lib/read/lib/Cardano/Wallet/Read/Block/HeaderHash.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/HeaderHash.hs
@@ -9,7 +9,7 @@ module Cardano.Wallet.Read.Block.HeaderHash
     , HeaderHashT
     , getEraHeaderHash
 
-    , BHeader
+    , EraIndependentBlockHeader
     , RawHeaderHash
     , getRawHeaderHash
 
@@ -33,6 +33,9 @@ import Cardano.Ledger.Crypto
     )
 import Cardano.Ledger.Era
     ( EraSegWits (..)
+    )
+import Cardano.Ledger.Hashes
+    ( EraIndependentBlockHeader
     )
 import Cardano.Protocol.TPraos.BHeader
     ( PrevHash
@@ -130,16 +133,15 @@ getHeaderHashShelley
 getHeaderHashShelley
     (O.ShelleyBlock (Shelley.Block header _) _) = Shelley.pHeaderHash header
 
--- | Tag representing a block header.
-data BHeader
-
 -- | Raw hash digest for a block header.
-type RawHeaderHash = Hash Blake2b_256 BHeader
+type RawHeaderHash = Hash Blake2b_256 EraIndependentBlockHeader
 
 -- | Construct a 'RawHeaderHash' that is good enough for testing.
 mockRawHeaderHash :: Integer -> RawHeaderHash
 mockRawHeaderHash n =
-    Hash.hashWith (\_ -> B8.pack $ show n) (error "undefined :: BHeader")
+    Hash.hashWith
+        (\_ -> B8.pack $ show n)
+        (error "undefined :: EraIndependentBlockHeader")
 
 {-# INLINABLE getRawHeaderHash #-}
 getRawHeaderHash :: forall era. IsEra era => HeaderHash era -> RawHeaderHash
@@ -152,7 +154,7 @@ getRawHeaderHash = case theEra @era of
     Babbage -> \(HeaderHash h) -> castHash $ unShelleyHash h
     Conway -> \(HeaderHash h) -> castHash $ unShelleyHash h
   where
-    fromByron :: ByronHash -> Hash Blake2b_256 BHeader
+    fromByron :: ByronHash -> Hash Blake2b_256 EraIndependentBlockHeader
     fromByron =
         fromJust
         . hashFromBytesShort

--- a/lib/read/lib/Cardano/Wallet/Read/Block/SlotNo.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/SlotNo.hs
@@ -7,6 +7,7 @@
 module Cardano.Wallet.Read.Block.SlotNo
     ( getEraSlotNo
     , SlotNo (..)
+    , prettySlotNo
     ) where
 
 import Prelude
@@ -35,6 +36,7 @@ import Ouroboros.Consensus.Shelley.Protocol.Praos
 import Ouroboros.Consensus.Shelley.Protocol.TPraos
     ()
 
+import qualified Data.Text as T
 import qualified Ouroboros.Network.Block as O
 
 {-# INLINABLE getEraSlotNo #-}
@@ -55,3 +57,6 @@ newtype SlotNo = SlotNo {unSlotNo :: Natural}
 
 instance NoThunks SlotNo
 
+-- | Short printed representation of a 'ChainPoint'.
+prettySlotNo :: SlotNo -> T.Text
+prettySlotNo (SlotNo n) = T.pack (show n)

--- a/lib/read/lib/Cardano/Wallet/Read/Block/SlotNo.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/SlotNo.hs
@@ -11,14 +11,8 @@ module Cardano.Wallet.Read.Block.SlotNo
 
 import Prelude
 
-import Cardano.Ledger.Block
-    ( bheader
-    )
-import Cardano.Ledger.Crypto
-    ( StandardCrypto
-    )
-import Cardano.Wallet.Read.Block.Block
-    ( Block (..)
+import Cardano.Wallet.Read.Block.BHeader
+    ( BHeader (..)
     )
 import Cardano.Wallet.Read.Eras.KnownEras
     ( Era (..)
@@ -33,12 +27,6 @@ import NoThunks.Class
 import Numeric.Natural
     ( Natural
     )
-import Ouroboros.Consensus.Protocol.Praos
-    ( Praos
-    )
-import Ouroboros.Consensus.Protocol.TPraos
-    ( TPraos
-    )
 import Ouroboros.Consensus.Shelley.Protocol.Abstract
     ( pHeaderSlot
     )
@@ -47,20 +35,18 @@ import Ouroboros.Consensus.Shelley.Protocol.Praos
 import Ouroboros.Consensus.Shelley.Protocol.TPraos
     ()
 
-import qualified Ouroboros.Consensus.Shelley.Ledger.Block as O
 import qualified Ouroboros.Network.Block as O
 
 {-# INLINABLE getEraSlotNo #-}
-getEraSlotNo :: forall era. IsEra era => Block era -> SlotNo
+getEraSlotNo :: forall era. IsEra era => BHeader era -> SlotNo
 getEraSlotNo = case theEra @era of
-    Byron -> \(Block block) -> k $ O.blockSlot block
-    Shelley -> \(Block block) -> k $ getSlotNoShelley block
-    Allegra -> \(Block block) -> k $ getSlotNoShelley block
-    Mary -> \(Block block) -> k $ getSlotNoShelley block
-    Alonzo -> \(Block block) -> k $ getSlotNoShelley block
-    Babbage -> \(Block block) -> k $ getSlotNoBabbage block
-    Conway -> \(Block block) -> k $ getSlotNoBabbage block
-
+    Byron -> \(BHeader h) -> k $ O.blockSlot h
+    Shelley -> \(BHeader h) -> k $ pHeaderSlot h
+    Allegra -> \(BHeader h) -> k $ pHeaderSlot h
+    Mary -> \(BHeader h) -> k $ pHeaderSlot h
+    Alonzo -> \(BHeader h) -> k $ pHeaderSlot h
+    Babbage -> \(BHeader h) -> k $ pHeaderSlot h
+    Conway -> \(BHeader h) -> k $ pHeaderSlot h
   where
     k = SlotNo . fromIntegral . O.unSlotNo
 
@@ -69,14 +55,3 @@ newtype SlotNo = SlotNo {unSlotNo :: Natural}
 
 instance NoThunks SlotNo
 
-getSlotNoShelley
-    :: O.ShelleyBlock (TPraos StandardCrypto) era
-    -> O.SlotNo
-getSlotNoShelley (O.ShelleyBlock block _) =
-    pHeaderSlot $ bheader block
-
-getSlotNoBabbage
-    :: O.ShelleyBlock (Praos StandardCrypto) era
-    -> O.SlotNo
-getSlotNoBabbage (O.ShelleyBlock block _) =
-    pHeaderSlot $ bheader block

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Txs.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Txs.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Cardano.Wallet.Read.Block.Txs
     ( getEraTransactions
@@ -18,7 +17,6 @@ import Cardano.Wallet.Read.Block.Block
     )
 import Cardano.Wallet.Read.Eras
     ( Byron
-    , (:.:) (..)
     )
 import Cardano.Wallet.Read.Eras.KnownEras
     ( Era (..)
@@ -48,7 +46,7 @@ import qualified Ouroboros.Consensus.Shelley.Ledger as O
 
 {-# INLINABLE getEraTransactions #-}
 -- | Get the list of transactions in the block.
-getEraTransactions :: forall era. IsEra era => Block era -> ([] :.: Tx) era
+getEraTransactions :: forall era. IsEra era => Block era -> [Tx era]
 getEraTransactions = case theEra @era of
     Byron -> getTxs' getTxsFromBlockByron
     Shelley -> getTxs' getTxsFromBlockShelleyAndOn
@@ -58,7 +56,7 @@ getEraTransactions = case theEra @era of
     Babbage -> getTxs' getTxsFromBlockShelleyAndOn
     Conway -> getTxs' getTxsFromBlockShelleyAndOn
   where
-    getTxs' f (Block block) = Comp $ Tx <$> f block
+    getTxs' f (Block block) = Tx <$> f block
 
 getTxsFromBlockByron :: O.ByronBlock -> [TxT Byron]
 getTxsFromBlockByron block =

--- a/lib/read/lib/Cardano/Wallet/Read/Chain.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Chain.hs
@@ -107,7 +107,7 @@ getChainTip block =
     BlockTip
         { slotNo = getEraSlotNo $ getEraBHeader block
         , headerHash = getRawHeaderHash $ getEraHeaderHash block
-        , blockNo = getEraBlockNo block
+        , blockNo = getEraBlockNo $ getEraBHeader block
         }
 
 -- | Short printed representation of a 'ChainPoint'.

--- a/lib/read/lib/Cardano/Wallet/Read/Chain.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Chain.hs
@@ -28,6 +28,7 @@ import Cardano.Wallet.Read.Block
     , BlockNo (..)
     , RawHeaderHash
     , SlotNo (..)
+    , getEraBHeader
     , getEraBlockNo
     , getEraHeaderHash
     , getEraSlotNo
@@ -65,7 +66,7 @@ instance NoThunks ChainPoint
 getChainPoint :: IsEra era => Block era -> ChainPoint
 getChainPoint block =
     BlockPoint
-        { slotNo = getEraSlotNo block
+        { slotNo = getEraSlotNo $ getEraBHeader block
         , headerHash = getRawHeaderHash $ getEraHeaderHash block
         }
 
@@ -104,7 +105,7 @@ instance NoThunks ChainTip
 getChainTip :: IsEra era => Block era -> ChainTip
 getChainTip block =
     BlockTip
-        { slotNo = getEraSlotNo block
+        { slotNo = getEraSlotNo $ getEraBHeader block
         , headerHash = getRawHeaderHash $ getEraHeaderHash block
         , blockNo = getEraBlockNo block
         }


### PR DESCRIPTION
This pull request removes the use of the `BlockHeader` type from the module `Cardano.Wallet.Network.Logging`. Instead, we use the `Read.BHeader` type from `Cardano.Wallet.Read`.

In order to do so, the pull request also 

* Fixes the implementation of `BHeader`
* Changes `getEraSlotNo` and `getEraBlockNo`
* Simplifies `numberOfTransactionsInBlock`

### Comments

* The goal is to eventually remove the legacy `primitive` types.

### Issue Number

ADP-3350