### PR TITLE
[ADP-3272] Extract out function `shrinkMapValues` from `shrinkInputResolution`

### DIFF
--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2951,8 +2951,8 @@ shrinkTxBodyBabbage
         , b' <- prependOriginal shrinkStrictMaybe b
         ]
 
-shrinkValue :: (Eq a, Monoid a) => a -> [a]
-shrinkValue v = filter (/= v) [mempty]
+    shrinkValue :: (Eq a, Monoid a) => a -> [a]
+    shrinkValue v = filter (/= v) [mempty]
 
 shrinkWdrl :: Withdrawals era -> [Withdrawals era]
 shrinkWdrl (Withdrawals m) = map (Withdrawals . Map.fromList) $

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2839,13 +2839,14 @@ shrinkInputResolution =
     -- NOTE: We only want to shrink the outputs, keeping the inputs and length
     -- of the list the same.
     shrinkUTxOEntries :: [(TxIn, TxOut era)] -> [[(TxIn, TxOut era)]]
-    shrinkUTxOEntries ((i, o) : rest) = mconcat
-        -- First shrink the first element
-        [ map (\o' -> (i, o') : rest) (shrinkOutput o)
-        -- Recurse to shrink subsequent elements on their own
-        , map ((i, o) :) (shrinkUTxOEntries rest)
-        ]
-    shrinkUTxOEntries [] = []
+    shrinkUTxOEntries = \case
+        ((i, o) : rest) -> mconcat
+            -- First shrink the first element
+            [ map (\o' -> (i, o') : rest) (shrinkOutput o)
+            -- Recurse to shrink subsequent elements on their own
+            , map ((i, o) :) (shrinkUTxOEntries rest)
+            ]
+        [] -> []
 
 shrinkScriptData
     :: Era (CardanoApi.ShelleyLedgerEra era)

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2829,7 +2829,7 @@ shrinkInputResolution
     => Write.UTxO era
     -> [Write.UTxO era]
 shrinkInputResolution =
-    shrinkMapBy utxoFromList utxoToList shrinkKeyValuePairs
+    shrinkMapBy utxoFromList utxoToList (shrinkKeyValuePairs shrinkOutput)
   where
     utxoToList = Map.toList . unUTxO
     utxoFromList = UTxO . Map.fromList
@@ -2838,13 +2838,13 @@ shrinkInputResolution =
 
     -- NOTE: We only want to shrink the values, keeping the keys and length
     -- of the list the same.
-    shrinkKeyValuePairs :: [(k, v)] -> [[(k, v)]]
-    shrinkKeyValuePairs = \case
+    shrinkKeyValuePairs :: (v -> [v]) -> [(k, v)] -> [[(k, v)]]
+    shrinkKeyValuePairs shrinkValue = \case
         ((k, v) : rest) -> mconcat
             -- First shrink the first element
-            [ map (\v' -> (k, v') : rest) (shrinkOutput v)
+            [ map (\v' -> (k, v') : rest) (shrinkValue v)
             -- Recurse to shrink subsequent elements on their own
-            , map ((k, v) :) (shrinkKeyValuePairs rest)
+            , map ((k, v) :) (shrinkKeyValuePairs shrinkValue rest)
             ]
         [] -> []
 

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2832,11 +2832,8 @@ shrinkInputResolution
     => Write.UTxO era
     -> [Write.UTxO era]
 shrinkInputResolution =
-    shrinkMapBy utxoFromList utxoToList (shrinkKeyValuePairs shrinkOutput)
+    shrinkMapBy UTxO unUTxO (shrinkMapValues shrinkOutput)
   where
-    utxoToList = Map.toList . unUTxO
-    utxoFromList = UTxO . Map.fromList
-
     shrinkOutput _ = []
 
     shrinkMapValues :: Ord k => (v -> [v]) -> Map k v -> [Map k v]

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2836,15 +2836,15 @@ shrinkInputResolution =
 
     shrinkOutput _ = []
 
-    -- NOTE: We only want to shrink the outputs, keeping the inputs and length
+    -- NOTE: We only want to shrink the values, keeping the keys and length
     -- of the list the same.
-    shrinkUTxOEntries :: [(TxIn, TxOut era)] -> [[(TxIn, TxOut era)]]
+    shrinkUTxOEntries :: [(k, v)] -> [[(k, v)]]
     shrinkUTxOEntries = \case
-        ((i, o) : rest) -> mconcat
+        ((k, v) : rest) -> mconcat
             -- First shrink the first element
-            [ map (\o' -> (i, o') : rest) (shrinkOutput o)
+            [ map (\v' -> (k, v') : rest) (shrinkOutput v)
             -- Recurse to shrink subsequent elements on their own
-            , map ((i, o) :) (shrinkUTxOEntries rest)
+            , map ((k, v) :) (shrinkUTxOEntries rest)
             ]
         [] -> []
 

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -213,6 +213,9 @@ import Data.List
 import Data.List.NonEmpty
     ( NonEmpty (..)
     )
+import Data.Map.Strict
+    ( Map
+    )
 import Data.Maybe
     ( catMaybes
     , fromJust
@@ -2835,6 +2838,9 @@ shrinkInputResolution =
     utxoFromList = UTxO . Map.fromList
 
     shrinkOutput _ = []
+
+    shrinkMapValues :: Ord k => (v -> [v]) -> Map k v -> [Map k v]
+    shrinkMapValues = shrinkMapBy Map.fromList Map.toList . shrinkKeyValuePairs
 
     -- NOTE: We only want to shrink the values, keeping the keys and length
     -- of the list the same.

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2827,12 +2827,8 @@ shrinkFee :: Ledger.Coin -> [Ledger.Coin]
 shrinkFee (Ledger.Coin 0) = []
 shrinkFee _ = [Ledger.Coin 0]
 
-shrinkInputResolution
-    :: forall era. IsRecentEra era
-    => Write.UTxO era
-    -> [Write.UTxO era]
-shrinkInputResolution =
-    shrinkMapBy UTxO unUTxO (shrinkMapValues shrinkOutput)
+shrinkInputResolution :: IsRecentEra era => Write.UTxO era -> [Write.UTxO era]
+shrinkInputResolution = shrinkMapBy UTxO unUTxO (shrinkMapValues shrinkOutput)
   where
     shrinkOutput _ = []
 

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2830,22 +2830,22 @@ shrinkInputResolution
     -> [Write.UTxO era]
 shrinkInputResolution =
     shrinkMapBy utxoFromList utxoToList shrinkUTxOEntries
-   where
-     utxoToList = Map.toList . unUTxO
-     utxoFromList = UTxO . Map.fromList
+  where
+    utxoToList = Map.toList . unUTxO
+    utxoFromList = UTxO . Map.fromList
 
-     shrinkOutput _ = []
+    shrinkOutput _ = []
 
-     -- NOTE: We only want to shrink the outputs, keeping the inputs and length
-     -- of the list the same.
-     shrinkUTxOEntries :: [(TxIn, TxOut era)] -> [[(TxIn, TxOut era)]]
-     shrinkUTxOEntries ((i,o) : rest) = mconcat
-         -- First shrink the first element
-         [ map (\o' -> (i, o') : rest ) (shrinkOutput o)
-         -- Recurse to shrink subsequent elements on their own
-         , map ((i,o):) (shrinkUTxOEntries rest)
-         ]
-     shrinkUTxOEntries [] = []
+    -- NOTE: We only want to shrink the outputs, keeping the inputs and length
+    -- of the list the same.
+    shrinkUTxOEntries :: [(TxIn, TxOut era)] -> [[(TxIn, TxOut era)]]
+    shrinkUTxOEntries ((i, o) : rest) = mconcat
+        -- First shrink the first element
+        [ map (\o' -> (i, o') : rest) (shrinkOutput o)
+        -- Recurse to shrink subsequent elements on their own
+        , map ((i, o) :) (shrinkUTxOEntries rest)
+        ]
+    shrinkUTxOEntries [] = []
 
 shrinkScriptData
     :: Era (CardanoApi.ShelleyLedgerEra era)

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2836,9 +2836,9 @@ shrinkInputResolution =
   where
     shrinkOutput _ = []
 
-    shrinkMapValues :: Ord k => (v -> [v]) -> Map k v -> [Map k v]
-    shrinkMapValues = shrinkMapBy Map.fromList Map.toList . shrinkKeyValuePairs
-
+shrinkMapValues :: Ord k => (v -> [v]) -> Map k v -> [Map k v]
+shrinkMapValues = shrinkMapBy Map.fromList Map.toList . shrinkKeyValuePairs
+  where
     -- NOTE: We only want to shrink the values, keeping the keys and length
     -- of the list the same.
     shrinkKeyValuePairs :: (v -> [v]) -> [(k, v)] -> [[(k, v)]]

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2827,6 +2827,8 @@ shrinkFee :: Ledger.Coin -> [Ledger.Coin]
 shrinkFee (Ledger.Coin 0) = []
 shrinkFee _ = [Ledger.Coin 0]
 
+-- TODO: ADP-3272
+-- Fix this function so that it returns something other than the empty list.
 shrinkInputResolution :: IsRecentEra era => Write.UTxO era -> [Write.UTxO era]
 shrinkInputResolution = shrinkMapBy UTxO unUTxO (shrinkMapValues shrinkOutput)
   where

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2836,11 +2836,11 @@ shrinkInputResolution =
   where
     shrinkOutput _ = []
 
+-- | Shrinks just the values of a map, keeping the set of keys constant.
+--
 shrinkMapValues :: Ord k => (v -> [v]) -> Map k v -> [Map k v]
 shrinkMapValues = shrinkMapBy Map.fromList Map.toList . shrinkKeyValuePairs
   where
-    -- NOTE: We only want to shrink the values, keeping the keys and length
-    -- of the list the same.
     shrinkKeyValuePairs :: (v -> [v]) -> [(k, v)] -> [[(k, v)]]
     shrinkKeyValuePairs shrinkValue = \case
         ((k, v) : rest) -> mconcat

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2838,16 +2838,17 @@ shrinkInputResolution =
 
 -- | Shrinks just the values of a map, keeping the set of keys constant.
 --
-shrinkMapValues :: Ord k => (v -> [v]) -> Map k v -> [Map k v]
-shrinkMapValues = shrinkMapBy Map.fromList Map.toList . shrinkKeyValuePairs
+shrinkMapValues :: forall k v. Ord k => (v -> [v]) -> Map k v -> [Map k v]
+shrinkMapValues shrinkValue =
+    shrinkMapBy Map.fromList Map.toList shrinkKeyValuePairs
   where
-    shrinkKeyValuePairs :: (v -> [v]) -> [(k, v)] -> [[(k, v)]]
-    shrinkKeyValuePairs shrinkValue = \case
+    shrinkKeyValuePairs :: [(k, v)] -> [[(k, v)]]
+    shrinkKeyValuePairs = \case
         ((k, v) : rest) -> mconcat
             -- First shrink the first element
             [ map (\v' -> (k, v') : rest) (shrinkValue v)
             -- Recurse to shrink subsequent elements on their own
-            , map ((k, v) :) (shrinkKeyValuePairs shrinkValue rest)
+            , map ((k, v) :) (shrinkKeyValuePairs rest)
             ]
         [] -> []
 

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2829,7 +2829,7 @@ shrinkInputResolution
     => Write.UTxO era
     -> [Write.UTxO era]
 shrinkInputResolution =
-    shrinkMapBy utxoFromList utxoToList shrinkUTxOEntries
+    shrinkMapBy utxoFromList utxoToList shrinkKeyValuePairs
   where
     utxoToList = Map.toList . unUTxO
     utxoFromList = UTxO . Map.fromList
@@ -2838,13 +2838,13 @@ shrinkInputResolution =
 
     -- NOTE: We only want to shrink the values, keeping the keys and length
     -- of the list the same.
-    shrinkUTxOEntries :: [(k, v)] -> [[(k, v)]]
-    shrinkUTxOEntries = \case
+    shrinkKeyValuePairs :: [(k, v)] -> [[(k, v)]]
+    shrinkKeyValuePairs = \case
         ((k, v) : rest) -> mconcat
             -- First shrink the first element
             [ map (\v' -> (k, v') : rest) (shrinkOutput v)
             -- Recurse to shrink subsequent elements on their own
-            , map ((k, v) :) (shrinkUTxOEntries rest)
+            , map ((k, v) :) (shrinkKeyValuePairs rest)
             ]
         [] -> []
 


### PR DESCRIPTION
This PR extracts out function `shrinkMapValues` from function `shrinkInputResolution`.

The function `shrinkMapValues` is more general, and can be tested with any `Map k v` that is convenient to construct.

## Issue

ADP-3272