### PR TITLE
[ADP-3305] Refactor local cluster code

### DIFF
--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -671,6 +671,7 @@ withShelleyServer tracers action = withFaucet $ \faucetClientEnv -> do
                             ]
                         , cfgTracer = stdoutTextTracer
                         , cfgNodeOutputFile = Nothing
+                        , cfgRelayNodePath = mkRelDirOf "relay"
                         }
             withCluster
                 clusterConfig

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -89,14 +89,14 @@ import Cardano.Wallet.Launch.Cluster
     , withCluster
     , withFaucet
     )
+import Cardano.Wallet.Launch.Cluster.CommandLine
+    ( clusterConfigsDirParser
+    )
 import Cardano.Wallet.Launch.Cluster.FileOf
     ( DirOf (..)
     , mkRelDirOf
     , newAbsolutizer
     , toFilePath
-    )
-import Cardano.Wallet.LocalCluster
-    ( clusterConfigsDirParser
     )
 import Cardano.Wallet.Network.Implementation.Ouroboros
     ( tunedForMainnetPipeliningStrategy

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -672,6 +672,7 @@ withShelleyServer tracers action = withFaucet $ \faucetClientEnv -> do
                         , cfgTracer = stdoutTextTracer
                         , cfgNodeOutputFile = Nothing
                         , cfgRelayNodePath = mkRelDirOf "relay"
+                        , cfgClusterLogFile = Nothing
                         }
             withCluster
                 clusterConfig

--- a/lib/integration/framework/Test/Integration/Framework/Setup.hs
+++ b/lib/integration/framework/Test/Integration/Framework/Setup.hs
@@ -83,6 +83,7 @@ import Cardano.Wallet.Launch.Cluster.Env
     )
 import Cardano.Wallet.Launch.Cluster.FileOf
     ( DirOf (..)
+    , FileOf (..)
     , mkRelDirOf
     , toFilePath
     )
@@ -479,6 +480,9 @@ withContext testingCtx@TestingCtx{..} action = do
                     , cfgTracer = contramap MsgCluster tr
                     , cfgNodeOutputFile = nodeOutputFile
                     , cfgRelayNodePath = mkRelDirOf "relay"
+                    , cfgClusterLogFile = Just
+                        $ FileOf @"cluster-logs"
+                        $ absDirOf testDir </> relFile "cluster.logs"
                     }
         let dbEventRecorder =
                 recordPoolGarbageCollectionEvents

--- a/lib/integration/framework/Test/Integration/Framework/Setup.hs
+++ b/lib/integration/framework/Test/Integration/Framework/Setup.hs
@@ -76,7 +76,7 @@ import Cardano.Wallet.Launch.Cluster.Env
     )
 import Cardano.Wallet.Launch.Cluster.FileOf
     ( DirOf (..)
-    , toFilePath
+    , toFilePath, mkRelDirOf
     )
 import Cardano.Wallet.Network.Implementation.Ouroboros
     ( tunedForMainnetPipeliningStrategy
@@ -350,6 +350,7 @@ withServer
                             , cfgShelleyGenesisMods = []
                             , cfgTracer = tr'
                             , cfgNodeOutputFile = nodeOutputFile
+                            , cfgRelayNodePath = mkRelDirOf "relay"
                             }
                 withCluster clusterConfig faucetFunds
                     $ onClusterStart
@@ -461,6 +462,7 @@ setupContext
                             , cfgShelleyGenesisMods = []
                             , cfgTracer = tr'
                             , cfgNodeOutputFile = nodeOutputFile
+                            , cfgRelayNodePath = mkRelDirOf "relay"
                             }
 
             putMVar

--- a/lib/integration/framework/Test/Integration/Framework/Setup.hs
+++ b/lib/integration/framework/Test/Integration/Framework/Setup.hs
@@ -71,7 +71,7 @@ import Cardano.Wallet.Launch.Cluster
     , withFaucet
     , withSMASH
     )
-import Cardano.Wallet.Launch.Cluster.ClusterEra
+import Cardano.Wallet.Launch.Cluster.Env
     ( nodeOutputFileFromEnv
     )
 import Cardano.Wallet.Launch.Cluster.FileOf

--- a/lib/integration/framework/Test/Integration/Framework/Setup.hs
+++ b/lib/integration/framework/Test/Integration/Framework/Setup.hs
@@ -60,23 +60,31 @@ import Cardano.Wallet.Faucet
     )
 import Cardano.Wallet.Launch.Cluster
     ( ClusterEra (..)
+    , Config
     , FaucetFunds (..)
-    , FileOf (..)
     , LogFileConfig (..)
     , RunningNode (..)
     , clusterEraFromEnv
+    , defaultPoolConfigs
     , runClusterM
     , sendFaucetAssetsTo
     , withCluster
     , withFaucet
     , withSMASH
     )
+import Cardano.Wallet.Launch.Cluster.Config
+    ( Config (..)
+    , TestnetMagic
+    , testnetMagicToNatural
+    )
 import Cardano.Wallet.Launch.Cluster.Env
-    ( nodeOutputFileFromEnv
+    ( localClusterConfigsFromEnv
+    , nodeOutputFileFromEnv
     )
 import Cardano.Wallet.Launch.Cluster.FileOf
     ( DirOf (..)
-    , toFilePath, mkRelDirOf
+    , mkRelDirOf
+    , toFilePath
     )
 import Cardano.Wallet.Network.Implementation.Ouroboros
     ( tunedForMainnetPipeliningStrategy
@@ -219,7 +227,6 @@ import qualified Cardano.Pool.DB as Pool
 import qualified Cardano.Pool.DB.Layer as Pool
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Faucet as Faucet
-import qualified Cardano.Wallet.Launch.Cluster as Cluster
 import qualified Data.Text as T
 
 -- | Do all the program setup required for integration tests, create a temporary
@@ -246,11 +253,10 @@ withTestsSetup action = do
             let clusterDir = DirOf $ absDir testDir
             withTracers clusterDir $ action clusterDir
 
-mkFaucetFunds :: Cluster.TestnetMagic -> FaucetM FaucetFunds
+mkFaucetFunds :: TestnetMagic -> FaucetM FaucetFunds
 mkFaucetFunds testnetMagic = do
     let networkTag =
-            NetworkTag . fromIntegral
-                $ Cluster.testnetMagicToNatural testnetMagic
+            NetworkTag . fromIntegral $ testnetMagicToNatural testnetMagic
     shelleyFunds <- Faucet.shelleyFunds shelleyTestnet
     byronFunds <- Faucet.byronFunds networkTag
     icarusFunds <- Faucet.icarusFunds networkTag
@@ -282,7 +288,7 @@ mkFaucetFunds testnetMagic = do
             }
 
 data TestingCtx = TestingCtx
-    { testnetMagic :: Cluster.TestnetMagic
+    { testnetMagic :: TestnetMagic
     , testDir :: DirOf "cluster"
     , tr :: Tracer IO TestsLog
     , tracers :: Tracers IO
@@ -317,10 +323,9 @@ recordPoolGarbageCollectionEvents TestingCtx{..} eventsRef =
 
 withServer
     :: TestingCtx
-    -> DirOf "cluster-configs"
+    -> Config
     -> FaucetFunds
     -> Pool.DBDecorator IO
-    -> Maybe (FileOf "node-output")
     -> ( T.Text
          -> CardanoNodeConn
          -> NetworkParameters
@@ -330,28 +335,13 @@ withServer
     -> IO ExitCode
 withServer
     ctx@TestingCtx{..}
-    clusterConfigs
+    clusterConfig
     faucetFunds
     dbDecorator
-    nodeOutputFile
     onReady =
         bracketTracer' tr "withServer" $ do
-            let tr' = contramap MsgCluster tr
-            era <- clusterEraFromEnv
+            let tr' = cfgTracer clusterConfig
             withSMASH tr' (toFilePath . absDirOf $ testDir) $ \smashUrl -> do
-                let clusterConfig =
-                        Cluster.Config
-                            { cfgStakePools = Cluster.defaultPoolConfigs
-                            , cfgLastHardFork = era
-                            , cfgNodeLogging = LogFileConfig Info Nothing Info
-                            , cfgClusterDir = testDir
-                            , cfgClusterConfigs = clusterConfigs
-                            , cfgTestnetMagic = testnetMagic
-                            , cfgShelleyGenesisMods = []
-                            , cfgTracer = tr'
-                            , cfgNodeOutputFile = nodeOutputFile
-                            , cfgRelayNodePath = mkRelDirOf "relay"
-                            }
                 withCluster clusterConfig faucetFunds
                     $ onClusterStart
                         ctx
@@ -415,10 +405,10 @@ httpManager = do
 
 setupContext
     :: TestingCtx
+    -> Config
     -> MVar Context
     -> ClientEnv
     -> IORef [PoolGarbageCollectionEvent]
-    -> Maybe (FileOf "node-output")
     -> T.Text
     -> CardanoNodeConn
     -> NetworkParameters
@@ -426,18 +416,16 @@ setupContext
     -> IO ()
 setupContext
     TestingCtx{..}
+    clusterConfig
     ctx
     faucetClientEnv
     poolGarbageCollectionEvents
-    nodeOutputFile
     smashUrl
     nodeConnection
     networkParameters
     baseUrl =
         bracketTracer' tr "setupContext" $ do
-            clusterConfigs <- Cluster.localClusterConfigsFromEnv
             faucet <- Faucet.initFaucet faucetClientEnv
-            let tr' = contramap MsgCluster tr
             prometheusUrl <-
                 let packPort (h, p) =
                         T.pack h <> ":" <> toText @(Port "Prometheus") p
@@ -449,22 +437,6 @@ setupContext
             traceWith tr $ MsgBaseUrl baseUrl ekgUrl prometheusUrl smashUrl
             manager <- httpManager
             mintSeaHorseAssetsLock <- newMVar ()
-
-            let withConfig =
-                    runClusterM
-                        $ Cluster.Config
-                            { cfgStakePools = error "cfgStakePools: unused"
-                            , cfgLastHardFork = localClusterEra
-                            , cfgNodeLogging = error "cfgNodeLogging: unused"
-                            , cfgClusterDir = testDir
-                            , cfgClusterConfigs = clusterConfigs
-                            , cfgTestnetMagic = testnetMagic
-                            , cfgShelleyGenesisMods = []
-                            , cfgTracer = tr'
-                            , cfgNodeOutputFile = nodeOutputFile
-                            , cfgRelayNodePath = mkRelDirOf "relay"
-                            }
-
             putMVar
                 ctx
                 Context
@@ -479,7 +451,7 @@ setupContext
                     , _smashUrl = smashUrl
                     , _mintSeaHorseAssets = \nPerAddr batchSize c addrs ->
                         withMVar mintSeaHorseAssetsLock $ \() ->
-                            withConfig
+                            runClusterM clusterConfig
                                 $ sendFaucetAssetsTo
                                     nodeConnection
                                     batchSize
@@ -491,10 +463,23 @@ withContext testingCtx@TestingCtx{..} action = do
     bracketTracer' tr "withContext" $ withFaucet $ \faucetClientEnv -> do
         ctx <- newEmptyMVar
         nodeOutputFile <- nodeOutputFileFromEnv
-        clusterConfigs <- Cluster.localClusterConfigsFromEnv
+        clusterConfigs <- localClusterConfigsFromEnv
         poolGarbageCollectionEvents <- newIORef []
         faucetFunds <- runFaucetM faucetClientEnv $ mkFaucetFunds testnetMagic
-
+        era <- clusterEraFromEnv
+        let clusterConfig =
+                Config
+                    { cfgStakePools = defaultPoolConfigs
+                    , cfgLastHardFork = era
+                    , cfgNodeLogging = LogFileConfig Info Nothing Info
+                    , cfgClusterDir = testDir
+                    , cfgClusterConfigs = clusterConfigs
+                    , cfgTestnetMagic = testnetMagic
+                    , cfgShelleyGenesisMods = []
+                    , cfgTracer = contramap MsgCluster tr
+                    , cfgNodeOutputFile = nodeOutputFile
+                    , cfgRelayNodePath = mkRelDirOf "relay"
+                    }
         let dbEventRecorder =
                 recordPoolGarbageCollectionEvents
                     testingCtx
@@ -502,25 +487,26 @@ withContext testingCtx@TestingCtx{..} action = do
             cluster =
                 setupContext
                     testingCtx
+                    clusterConfig
                     ctx
                     faucetClientEnv
                     poolGarbageCollectionEvents
-                    nodeOutputFile
         res <-
             race
                 ( withServer
                     testingCtx
-                    clusterConfigs
+                    clusterConfig
                     faucetFunds
                     dbEventRecorder
-                    nodeOutputFile
                     cluster
                 )
-                (takeMVar ctx >>= bracketTracer' tr "spec" .
-                    (\c -> setupDelegation faucetClientEnv c >> action c))
+                ( takeMVar ctx
+                    >>= bracketTracer' tr "spec"
+                        . (\c -> setupDelegation faucetClientEnv c >> action c)
+                )
         whenLeft res (throwIO . ProcessHasExited "integration")
   where
-    -- | Setup delegation for 'rewardWallet' / 'rewardWalletMnemonics'.
+    -- \| Setup delegation for 'rewardWallet' / 'rewardWalletMnemonics'.
     --
     -- Rewards take 4-5 epochs (here ~2 min) to accrue from delegating. By
     -- doing this up-front, the rewards are likely available by the time
@@ -539,11 +525,12 @@ withContext testingCtx@TestingCtx{..} action = do
         -- resources for unnecessary restoration.
         forM_ mnemonics $ \mw -> runResourceT $ do
             w <- walletFromMnemonic ctx mw
-            _ <- joinStakePool
-                @('Testnet 0) -- protocol magic doesn't matter
-                ctx
-                (SpecificPool pool)
-                (w, fixturePassphrase)
+            _ <-
+                joinStakePool
+                    @('Testnet 0) -- protocol magic doesn't matter
+                    ctx
+                    (SpecificPool pool)
+                    (w, fixturePassphrase)
             pure ()
 
 bracketTracer' :: Tracer IO TestsLog -> Text -> IO a -> IO a

--- a/lib/launcher/src/Cardano/Launcher/Node.hs
+++ b/lib/launcher/src/Cardano/Launcher/Node.hs
@@ -25,7 +25,6 @@ import Prelude
 
 import Cardano.Launcher
     ( LauncherLog
-    , ProcessHasExited
     , StdStream (..)
     , withBackendCreateProcess
     )
@@ -134,7 +133,7 @@ withCardanoNode
     -> CardanoNodeConfig
     -> (CardanoNodeConn -> IO a)
     -- ^ Callback function with a socket filename and genesis params
-    -> IO (Either ProcessHasExited a)
+    -> IO a
 withCardanoNode tr cfg action = do
     let socketPath = nodeSocketPath (nodeDir cfg)
     let run output = do

--- a/lib/launcher/src/Cardano/Launcher/Node.hs
+++ b/lib/launcher/src/Cardano/Launcher/Node.hs
@@ -140,7 +140,7 @@ withCardanoNode tr cfg action = do
     let run output = do
             cp <- cardanoNodeProcess cfg output socketPath
             withBackendCreateProcess tr cp
-                $ \_ _ -> action $ CardanoNodeConn socketPath
+                $ \_ -> action $ CardanoNodeConn socketPath
     case nodeOutputFile cfg of
         Nothing -> run Inherit
         Just file ->

--- a/lib/launcher/src/Cardano/Launcher/Wallet.hs
+++ b/lib/launcher/src/Cardano/Launcher/Wallet.hs
@@ -94,7 +94,7 @@ withCardanoWallet
     -> IO (Either ProcessHasExited a)
 withCardanoWallet tr node cfg@CardanoWalletConfig{..} action =
     withBackendCreateProcess tr (cardanoWallet cfg node)
-        $ \_ _ -> action $ CardanoWalletConn walletPort
+        $ \_ -> action $ CardanoWalletConn walletPort
 
 cardanoWallet :: CardanoWalletConfig -> CardanoNodeConn -> CreateProcess
 cardanoWallet CardanoWalletConfig{..} node =

--- a/lib/launcher/src/Cardano/Launcher/Wallet.hs
+++ b/lib/launcher/src/Cardano/Launcher/Wallet.hs
@@ -20,7 +20,6 @@ import Prelude
 
 import Cardano.Launcher
     ( LauncherLog
-    , ProcessHasExited
     , withBackendCreateProcess
     )
 import Cardano.Launcher.Node
@@ -91,7 +90,7 @@ withCardanoWallet
     -> CardanoWalletConfig
     -> (CardanoWalletConn -> IO a)
     -- ^ Callback function with a socket filename and genesis params
-    -> IO (Either ProcessHasExited a)
+    -> IO a
 withCardanoWallet tr node cfg@CardanoWalletConfig{..} action =
     withBackendCreateProcess tr (cardanoWallet cfg node)
         $ \_ -> action $ CardanoWalletConn walletPort

--- a/lib/launcher/test/unit/Cardano/LauncherSpec.hs
+++ b/lib/launcher/test/unit/Cardano/LauncherSpec.hs
@@ -105,6 +105,7 @@ import UnliftIO.Concurrent
     )
 import UnliftIO.Exception
     ( bracket
+    , try
     )
 import UnliftIO.MVar
     ( modifyMVar_
@@ -277,7 +278,7 @@ launch tr cmds = do
         waitForOthers (ProcessHandles _ _ _ ph) = do
             modifyMVar_ phsVar (pure . (ph:))
             forever $ threadDelay maxBound
-        start = async . flip (withBackendProcess tr) waitForOthers
+        start = async . try . flip (withBackendProcess tr) waitForOthers
 
     mapM start cmds >>= waitAnyCancel >>= \case
         (_, Left e) -> do

--- a/lib/launcher/test/unit/Cardano/LauncherSpec.hs
+++ b/lib/launcher/test/unit/Cardano/LauncherSpec.hs
@@ -38,6 +38,7 @@ import Cardano.BM.Trace
 import Cardano.Launcher
     ( Command (..)
     , LauncherLog
+    , ProcessHandles (..)
     , ProcessHasExited (..)
     , StdStream (..)
     , withBackendProcess
@@ -205,9 +206,10 @@ spec = beforeAll setupMockCommands $ do
     it "Backend process is terminated when Async thread is cancelled" $ \MockCommands{..} -> withTestLogging $ \tr -> do
         pendingOnWine "SYSTEM32 commands not available under wine"
         mvar <- newEmptyMVar
-        let backend = withBackendProcess tr foreverCommand $ \_ ph -> do
-                putMVar mvar ph
-                forever $ threadDelay maxBound
+        let backend = withBackendProcess tr foreverCommand
+                $ \(ProcessHandles _ _ _ ph) -> do
+                    putMVar mvar ph
+                    forever $ threadDelay maxBound
         before <- getCurrentTime
         race_ backend (threadDelay 1000000)
         after <- getCurrentTime
@@ -220,9 +222,10 @@ spec = beforeAll setupMockCommands $ do
     it "Misbehaving backend process is killed when Async thread is cancelled" $ \_ -> withTestLogging $ \tr -> do
         skipOnWindows "Not applicable"
         mvar <- newEmptyMVar
-        let backend = withBackendProcess tr unkillableCommand $ \_ ph -> do
-                putMVar mvar ph
-                forever $ threadDelay maxBound
+        let backend = withBackendProcess tr unkillableCommand
+                $ \(ProcessHandles _ _ _ ph) -> do
+                    putMVar mvar ph
+                    forever $ threadDelay maxBound
         before <- getCurrentTime
         race_ backend (threadDelay 1000000)
         after <- getCurrentTime
@@ -271,7 +274,7 @@ launch :: Tracer IO LauncherLog -> [Command] -> IO ([ProcessHandle], ProcessHasE
 launch tr cmds = do
     phsVar <- newMVar []
     let
-        waitForOthers _ ph = do
+        waitForOthers (ProcessHandles _ _ _ ph) = do
             modifyMVar_ phsVar (pure . (ph:))
             forever $ threadDelay maxBound
         start = async . flip (withBackendProcess tr) waitForOthers

--- a/lib/local-cluster/exe/Cluster.hs
+++ b/lib/local-cluster/exe/Cluster.hs
@@ -1,6 +1,0 @@
-import qualified Cardano.Wallet.LocalCluster as LocalCluster
-
-import Prelude
-
-main :: IO ()
-main = LocalCluster.main

--- a/lib/local-cluster/exe/local-cluster.hs
+++ b/lib/local-cluster/exe/local-cluster.hs
@@ -245,6 +245,7 @@ main = withUtf8 $ do
                     , cfgShelleyGenesisMods = [over #sgSlotLength \_ -> 0.2]
                     , cfgTracer = stdoutTextTracer
                     , cfgNodeOutputFile = Nothing
+                    , cfgRelayNodePath = mkRelDirOf "relay"
                     }
         node <-
             ContT

--- a/lib/local-cluster/exe/local-cluster.hs
+++ b/lib/local-cluster/exe/local-cluster.hs
@@ -218,7 +218,12 @@ main = withUtf8 $ do
             $ Just
             $ mkRelDirOf
             $ Cluster.clusterEraToString clusterEra
-    CommandLineOptions{clusterConfigsDir, clusterDir} <- parseCommandLineOptions
+    CommandLineOptions
+        { clusterConfigsDir
+        , clusterDir
+        , clusterLogs
+        } <-
+        parseCommandLineOptions
     evalContT $ do
         -- Create a temporary directory for the cluster
         clusterPath <-
@@ -246,6 +251,7 @@ main = withUtf8 $ do
                     , cfgTracer = stdoutTextTracer
                     , cfgNodeOutputFile = Nothing
                     , cfgRelayNodePath = mkRelDirOf "relay"
+                    , cfgClusterLogFile = clusterLogs
                     }
         node <-
             ContT

--- a/lib/local-cluster/exe/local-cluster.hs
+++ b/lib/local-cluster/exe/local-cluster.hs
@@ -43,6 +43,9 @@ import Cardano.Wallet.Launch.Cluster.FileOf
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
+import Control.Exception
+    ( bracket
+    )
 import Control.Lens
     ( over
     )
@@ -76,8 +79,6 @@ import System.Path
 import UnliftIO.Concurrent
     ( threadDelay
     )
-import Control.Exception (bracket)
-
 
 import qualified Cardano.Node.Cli.Launcher as NC
 import qualified Cardano.Wallet.Cli.Launcher as WC

--- a/lib/local-cluster/exe/local-cluster.hs
+++ b/lib/local-cluster/exe/local-cluster.hs
@@ -7,8 +7,6 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Cardano.Wallet.LocalCluster where
-
 import Prelude
 
 import Cardano.Address.Style.Shelley
@@ -32,19 +30,18 @@ import Cardano.Wallet.Launch.Cluster
     , FaucetFunds (..)
     , withFaucet
     )
+import Cardano.Wallet.Launch.Cluster.CommandLine
+    ( CommandLineOptions (..)
+    , parseCommandLineOptions
+    )
 import Cardano.Wallet.Launch.Cluster.FileOf
-    ( Absolutizer (..)
-    , DirOf (..)
+    ( DirOf (..)
     , FileOf (..)
     , mkRelDirOf
-    , newAbsolutizer
     , toFilePath
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
-    )
-import Control.Applicative
-    ( (<**>)
     )
 import Control.Lens
     ( over
@@ -71,7 +68,6 @@ import System.IO.Temp.Extra
     )
 import System.Path
     ( absDir
-    , absRel
     , parse
     , relDir
     , relFile
@@ -85,7 +81,6 @@ import qualified Cardano.Node.Cli.Launcher as NC
 import qualified Cardano.Wallet.Cli.Launcher as WC
 import qualified Cardano.Wallet.Faucet as Faucet
 import qualified Cardano.Wallet.Launch.Cluster as Cluster
-import qualified Options.Applicative as O
 
 -- |
 -- # OVERVIEW
@@ -279,26 +274,3 @@ main = withUtf8 $ do
                                 )
                                 (WC.stop . fst)
                         threadDelay maxBound -- wait for Ctrl+C
-
-newtype CommandLineOptions = CommandLineOptions
-    {clusterConfigsDir :: DirOf "cluster-configs"}
-    deriving stock (Show)
-
-parseCommandLineOptions :: IO CommandLineOptions
-parseCommandLineOptions = do
-    absolutizer <- newAbsolutizer
-    O.execParser
-        $ O.info
-            ( fmap CommandLineOptions (clusterConfigsDirParser absolutizer)
-                <**> O.helper
-            )
-            (O.progDesc "Local Cluster for testing")
-
-clusterConfigsDirParser :: Absolutizer -> O.Parser (DirOf "cluster-configs")
-clusterConfigsDirParser (Absolutizer absOf) =
-    DirOf . absOf . absRel
-        <$> O.strOption
-            ( O.long "cluster-configs"
-                <> O.metavar "LOCAL_CLUSTER_CONFIGS"
-                <> O.help "Path to the local cluster configuration directory"
-            )

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster.hs
@@ -56,9 +56,7 @@ import Cardano.Wallet.Launch.Cluster.Cluster
     )
 import Cardano.Wallet.Launch.Cluster.ClusterEra
     ( ClusterEra (..)
-    , clusterEraFromEnv
     , clusterEraToString
-    , localClusterConfigsFromEnv
     )
 import Cardano.Wallet.Launch.Cluster.ClusterM
     ( ClusterM
@@ -68,6 +66,10 @@ import Cardano.Wallet.Launch.Cluster.Config
     ( Config (..)
     , ShelleyGenesisModifier
     , TestnetMagic (..)
+    )
+import Cardano.Wallet.Launch.Cluster.Env
+    ( clusterEraFromEnv
+    , localClusterConfigsFromEnv
     )
 import Cardano.Wallet.Launch.Cluster.Faucet
     ( sendFaucetAssetsTo

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Cluster.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Cluster.hs
@@ -243,7 +243,8 @@ withCluster config@Config{..} faucetFunds onClusterStart = runClusterM config
                                 genesisFiles
                                 poolPorts
                                 runningPool0
-                    runningNode <- ContT $ withRelayNode relayNodeParams
+                    runningNode <-
+                        ContT $ withRelayNode relayNodeParams cfgRelayNodePath
                     liftIO $ onClusterStart runningNode
   where
     FaucetFunds pureAdaFunds maryAllegraFunds massiveWalletFunds =

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/ClusterEra.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/ClusterEra.hs
@@ -1,89 +1,20 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.Wallet.Launch.Cluster.ClusterEra
     ( ClusterEra (..)
-    , clusterEraFromEnv
-    , localClusterConfigsFromEnv
     , clusterEraToString
     , ignoreInConway
     , ignoreInBabbage
-    , nodeOutputFileFromEnv
     )
 where
 
 import Prelude
 
-import Cardano.Wallet.Launch.Cluster.FileOf
-    ( DirOf (..)
-    , FileOf (..)
-    , absolutize
-    )
-import Data.Char
-    ( toLower
-    )
-import System.Environment.Extended
-    ( lookupEnvNonEmpty
-    )
-import System.Exit
-    ( die
-    )
-import System.Path
-    ( absRel
-    , relDir
-    , (</>)
-    )
-
 data ClusterEra
     = BabbageHardFork
     | ConwayHardFork
     deriving stock (Show, Read, Eq, Ord, Enum, Bounded)
-
--- | Defaults to the latest era.
-clusterEraFromEnv :: IO ClusterEra
-clusterEraFromEnv = do
-    mera <- lookupEnvNonEmpty var
-    case mera of
-        Nothing -> pure BabbageHardFork
-        Just era -> getEra era
-  where
-    var = "LOCAL_CLUSTER_ERA"
-    err :: [Char] -> IO a
-    err era =
-        die
-            $ var
-                ++ ": "
-                ++ era
-                ++ " era is not supported in the local cluster"
-    getEra env = case map toLower env of
-        "byron" -> err "byron"
-        "shelley" -> err "shelley"
-        "allegra" -> err "allegra"
-        "mary" -> err "mary"
-        "alonzo" -> err "alonzo"
-        "babbage" -> pure BabbageHardFork
-        "conway" -> pure ConwayHardFork
-        _ -> die $ var ++ ": unknown era"
-
-localClusterConfigsFromEnv :: IO (DirOf "cluster-configs")
-localClusterConfigsFromEnv = do
-    mConfigsPath <- lookupEnvNonEmpty "LOCAL_CLUSTER_CONFIGS"
-    let configPath = case mConfigsPath of
-            Just path -> absRel path
-            Nothing ->
-                absRel ".."
-                    </> relDir "local-cluster"
-                    </> relDir "test"
-                    </> relDir "data"
-                    </> relDir "cluster-configs"
-    DirOf <$> absolutize configPath
-
-nodeOutputFileFromEnv :: IO (Maybe (FileOf "node-output"))
-nodeOutputFileFromEnv = do
-    mNodeOutput <- fmap absRel
-        <$> lookupEnvNonEmpty "LOCAL_CLUSTER_NODE_OUTPUT_FILE"
-    fmap FileOf <$> absolutize `traverse` mNodeOutput
 
 clusterEraToString :: ClusterEra -> String
 clusterEraToString = \case

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/ClusterM.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/ClusterM.hs
@@ -35,9 +35,6 @@ import Control.Monad.Reader
     , ReaderT (..)
     , asks
     )
-import Control.Monad.Trans.Resource
-    ( MonadUnliftIO
-    )
 import Control.Tracer
     ( contramap
     , traceWith
@@ -48,6 +45,9 @@ import Data.Text
 import System.Path
     ( RelDir
     , (</>)
+    )
+import UnliftIO
+    ( MonadUnliftIO
     )
 
 newtype ClusterM a = ClusterM

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/CommandLine.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/CommandLine.hs
@@ -23,6 +23,7 @@ import Options.Applicative
     , info
     , long
     , metavar
+    , optional
     , progDesc
     , strOption
     , (<**>)
@@ -31,8 +32,10 @@ import System.Path
     ( absRel
     )
 
-newtype CommandLineOptions = CommandLineOptions
-    {clusterConfigsDir :: DirOf "cluster-configs"}
+data CommandLineOptions = CommandLineOptions
+    { clusterConfigsDir :: DirOf "cluster-configs"
+    , clusterDir :: Maybe (DirOf "cluster")
+    }
     deriving stock (Show)
 
 parseCommandLineOptions :: IO CommandLineOptions
@@ -40,7 +43,9 @@ parseCommandLineOptions = do
     absolutizer <- newAbsolutizer
     execParser
         $ info
-            ( fmap CommandLineOptions (clusterConfigsDirParser absolutizer)
+            ( CommandLineOptions
+                <$> clusterConfigsDirParser absolutizer
+                <*> clusterDirParser absolutizer
                 <**> helper
             )
             (progDesc "Local Cluster for testing")
@@ -53,3 +58,13 @@ clusterConfigsDirParser (Absolutizer absOf) =
                 <> metavar "LOCAL_CLUSTER_CONFIGS"
                 <> help "Path to the local cluster configuration directory"
             )
+
+clusterDirParser :: Absolutizer -> Parser (Maybe (DirOf "cluster"))
+clusterDirParser (Absolutizer absOf) =
+    optional
+        $ DirOf . absOf . absRel
+            <$> strOption
+                ( long "cluster"
+                    <> metavar "LOCAL_CLUSTER"
+                    <> help "Path to the local cluster directory"
+                )

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/CommandLine.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/CommandLine.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module Cardano.Wallet.Launch.Cluster.CommandLine
+    ( CommandLineOptions (..)
+    , parseCommandLineOptions
+    , clusterConfigsDirParser
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.Launch.Cluster.FileOf
+    ( Absolutizer (..)
+    , DirOf (..)
+    , newAbsolutizer
+    )
+import Options.Applicative
+    ( Parser
+    , execParser
+    , help
+    , helper
+    , info
+    , long
+    , metavar
+    , progDesc
+    , strOption
+    , (<**>)
+    )
+import System.Path
+    ( absRel
+    )
+
+newtype CommandLineOptions = CommandLineOptions
+    {clusterConfigsDir :: DirOf "cluster-configs"}
+    deriving stock (Show)
+
+parseCommandLineOptions :: IO CommandLineOptions
+parseCommandLineOptions = do
+    absolutizer <- newAbsolutizer
+    execParser
+        $ info
+            ( fmap CommandLineOptions (clusterConfigsDirParser absolutizer)
+                <**> helper
+            )
+            (progDesc "Local Cluster for testing")
+
+clusterConfigsDirParser :: Absolutizer -> Parser (DirOf "cluster-configs")
+clusterConfigsDirParser (Absolutizer absOf) =
+    DirOf . absOf . absRel
+        <$> strOption
+            ( long "cluster-configs"
+                <> metavar "LOCAL_CLUSTER_CONFIGS"
+                <> help "Path to the local cluster configuration directory"
+            )

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/CommandLine.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/CommandLine.hs
@@ -13,6 +13,7 @@ import Prelude
 import Cardano.Wallet.Launch.Cluster.FileOf
     ( Absolutizer (..)
     , DirOf (..)
+    , FileOf (..)
     , newAbsolutizer
     )
 import Options.Applicative
@@ -35,6 +36,7 @@ import System.Path
 data CommandLineOptions = CommandLineOptions
     { clusterConfigsDir :: DirOf "cluster-configs"
     , clusterDir :: Maybe (DirOf "cluster")
+    , clusterLogs :: Maybe (FileOf "cluster-logs")
     }
     deriving stock (Show)
 
@@ -46,6 +48,7 @@ parseCommandLineOptions = do
             ( CommandLineOptions
                 <$> clusterConfigsDirParser absolutizer
                 <*> clusterDirParser absolutizer
+                <*> clusterLogsParser absolutizer
                 <**> helper
             )
             (progDesc "Local Cluster for testing")
@@ -67,4 +70,14 @@ clusterDirParser (Absolutizer absOf) =
                 ( long "cluster"
                     <> metavar "LOCAL_CLUSTER"
                     <> help "Path to the local cluster directory"
+                )
+
+clusterLogsParser :: Absolutizer -> Parser (Maybe (FileOf "cluster-logs"))
+clusterLogsParser (Absolutizer absOf) =
+    optional
+        $ FileOf . absOf . absRel
+            <$> strOption
+                ( long "cluster-logs"
+                    <> metavar "LOCAL_CLUSTER_LOGS"
+                    <> help "Path to the local cluster logs file"
                 )

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Config.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Config.hs
@@ -68,4 +68,7 @@ data Config = Config
     , cfgNodeOutputFile :: Maybe (FileOf "node-output")
     -- ^ File to write node output to.
     , cfgRelayNodePath :: RelDirOf "relay"
+    -- ^ Path segment for relay node.
+    , cfgClusterLogFile :: Maybe (FileOf "cluster-logs")
+    -- ^ File to write cluster logs to.
     }

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Config.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Config.hs
@@ -27,6 +27,7 @@ import Cardano.Wallet.Launch.Cluster.ClusterEra
 import Cardano.Wallet.Launch.Cluster.FileOf
     ( DirOf
     , FileOf
+    , RelDirOf
     )
 import Cardano.Wallet.Launch.Cluster.Logging
     ( ClusterLog (..)
@@ -65,4 +66,6 @@ data Config = Config
     -- ^ Shelley genesis modifications to apply.
     , cfgTracer :: Tracer IO ClusterLog
     , cfgNodeOutputFile :: Maybe (FileOf "node-output")
+    -- ^ File to write node output to.
+    , cfgRelayNodePath :: RelDirOf "relay"
     }

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/ConfiguredPool.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/ConfiguredPool.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-missing-local-signatures #-}
 
 module Cardano.Wallet.Launch.Cluster.ConfiguredPool
     ( ConfiguredPool (..)
@@ -177,8 +178,8 @@ data ConfiguredPool = ConfiguredPool
     { operatePool
         :: forall a
          . NodeParams
-        -> (RunningNode -> IO a)
-        -> IO a
+        -> (RunningNode -> ClusterM a)
+        -> ClusterM a
     -- ^ Precondition: the pool must first be registered.
     , metadataUrl
         :: Text
@@ -186,8 +187,9 @@ data ConfiguredPool = ConfiguredPool
         :: PoolRecipe
     -- ^ The 'PoolRecipe' used to create this 'ConfiguredPool'.
     , registerViaShelleyGenesis
-        :: IO (ShelleyGenesis StandardCrypto -> ShelleyGenesis StandardCrypto)
-    , finalizeShelleyGenesisSetup :: RunningNode -> IO ()
+        :: ClusterM
+            (ShelleyGenesis StandardCrypto -> ShelleyGenesis StandardCrypto)
+    , finalizeShelleyGenesisSetup :: RunningNode -> ClusterM ()
     -- ^ Submit any pool retirement certificate according to the 'recipe'
     -- on-chain.
     }
@@ -431,9 +433,10 @@ configurePool
     -> PoolRecipe
     -> ClusterM ConfiguredPool
 configurePool metadataServer recipe = do
-    let PoolRecipe pledgeAmt i mretirementEpoch metadata _ _ = recipe
-
     UnliftClusterM withConfig Config{..} <- askUnliftClusterM
+
+    let PoolRecipe pledgeAmt i mRetirementEpoch metadata _ _ = recipe
+    liftIO $ registerMetadataForPoolIndex metadataServer i metadata
     -- Use pool-specific dir
     let name = "pool-" <> show i
         nodeRelativePath :: RelDir
@@ -450,121 +453,112 @@ configurePool metadataServer recipe = do
     let ownerPrv = FileOf @"stake-prv" $ poolDir </> relFile "stake.prv"
     genStakeAddrKeyPair (ownerPrv, ownerPub)
 
-    let metadataURL = urlFromPoolIndex metadataServer i
-    liftIO $ registerMetadataForPoolIndex metadataServer i metadata
+    let metadataUrl = T.pack $ urlFromPoolIndex metadataServer i
     let metadataBytes = Aeson.encode metadata
-    pure
-        ConfiguredPool
-            { operatePool = \nodeParams action -> do
-                let NodeParams
-                        genesisFiles
-                        hardForks
-                        (port, peers)
-                        logCfg
-                        nodeOutput = nodeParams
-                let logCfg' = setLoggingName name logCfg
 
-                topology <- withConfig $ genTopology nodeRelativePath peers
-                withStaticServer (toFilePath poolDir) $ \url -> do
-                    traceWith cfgTracer $ MsgStartedStaticServer url poolDirPath
+        registerViaShelleyGenesis = do
+            poolId <- stakePoolIdFromOperatorVerKey opPub
+            vrf <- poolVrfFromFile vrfPub
+            stakePubHash <- stakingKeyHashFromFile ownerPub
+            pledgeAddr <- stakingAddrFromVkFile ownerPub
 
-                    (nodeConfig, genesisData, vd) <-
-                        withConfig
-                            $ genNodeConfig
-                                nodeRelativePath
-                                (Tagged @"node-name" mempty)
-                                genesisFiles
-                                hardForks
-                                logCfg'
+            let params =
+                    Ledger.PoolParams
+                        { ppId = poolId
+                        , ppVrf = vrf
+                        , ppPledge = Ledger.Coin $ intCast pledgeAmt
+                        , ppCost = Ledger.Coin 0
+                        , ppMargin = unsafeUnitInterval 0.1
+                        , ppRewardAcnt =
+                            Ledger.RewardAcnt Testnet
+                                $ Ledger.KeyHashObj stakePubHash
+                        , ppOwners = Set.fromList [stakePubHash]
+                        , ppRelays = mempty
+                        , ppMetadata =
+                            SJust
+                                $ Ledger.PoolMetadata
+                                    ( fromMaybe (error "invalid url (too long)")
+                                        $ textToUrl 128 metadataUrl
+                                    )
+                                    (blake2b256 (BL.toStrict metadataBytes))
+                        }
+            let updateStaking sgs =
+                    sgs
+                        { Ledger.sgsPools =
+                            ListMap.ListMap [(poolId, params)] <> sgsPools sgs
+                        , Ledger.sgsStake =
+                            ListMap.fromList [(stakePubHash, poolId)]
+                                <> Ledger.sgsStake sgs
+                        }
+            let poolSpecificFunds =
+                    ListMap.fromList
+                        [(pledgeAddr, Ledger.Coin $ intCast pledgeAmt)]
+            pure
+                $ over #sgInitialFunds (poolSpecificFunds <>)
+                    . over #sgStaking updateStaking
 
-                    let
-                        cfg =
-                            CardanoNodeConfig
-                                { nodeDir = toFilePath poolDir
-                                , nodeConfigFile = absFilePathOf nodeConfig
-                                , nodeTopologyFile = absFilePathOf topology
-                                , nodeDatabaseDir = toFilePath
-                                    $ poolDir </> relDir "db"
-                                , nodeDlgCertFile = Nothing
-                                , nodeSignKeyFile = Nothing
-                                , nodeOpCertFile = Just $ absFilePathOf opCert
-                                , nodeKesKeyFile = Just $ absFilePathOf kesPrv
-                                , nodeVrfKeyFile = Just $ absFilePathOf vrfPrv
-                                , nodePort = Just (NodePort port)
-                                , nodeLoggingHostname = Just name
-                                , nodeExecutable = Nothing
-                                , nodeOutputFile = absFilePathOf <$> nodeOutput
-                                }
+        finalizeShelleyGenesisSetup (RunningNode socket _ _) = do
+            -- Here is our chance to respect the 'retirementEpoch' of
+            -- the 'PoolRecipe'.
+            --
+            -- NOTE: We also submit the retirement cert in
+            -- @registerViaTx@, but this seems to work regardless. (We
+            -- do want to submit it here for the sake of babbage)
+            let retire e = do
+                    retCert <- issuePoolRetirementCert nodeRelativePath opPub e
+                    (rawTx, faucetPrv) <-
+                        preparePoolRetirement
+                            nodeRelativePath
+                            [retCert]
+                    signAndSubmitTx
+                        socket
+                        (changeFileOf @"retirement-tx" @"tx-body" rawTx)
+                        [ changeFileOf @"faucet-prv" @"signing-key" faucetPrv
+                        , changeFileOf @"stake-prv" @"signing-key" ownerPrv
+                        , changeFileOf @"op-prv" @"signing-key" opPrv
+                        ]
+                        "retirement cert"
+            traverse_ retire mRetirementEpoch
 
+        operatePool nodeParams action = do
+            let NodeParams
+                    genesisFiles
+                    hardForks
+                    (port, peers)
+                    logCfg
+                    nodeOutput = nodeParams
+            let logCfg' = setLoggingName name logCfg
+
+            topology <- genTopology nodeRelativePath peers
+            liftIO $ withStaticServer (toFilePath poolDir) $ \url -> do
+                traceWith cfgTracer $ MsgStartedStaticServer url poolDirPath
+
+                (nodeConfig, genesisData, vd) <-
                     withConfig
-                        $ withCardanoNodeProcess name cfg
-                        $ \socket -> action $ RunningNode socket genesisData vd
-            , registerViaShelleyGenesis = withConfig $ do
-                poolId <- stakePoolIdFromOperatorVerKey opPub
-                vrf <- poolVrfFromFile vrfPub
-                stakePubHash <- stakingKeyHashFromFile ownerPub
-                pledgeAddr <- stakingAddrFromVkFile ownerPub
+                        $ genNodeConfig
+                            nodeRelativePath
+                            (Tagged @"node-name" mempty)
+                            genesisFiles
+                            hardForks
+                            logCfg'
 
-                let params =
-                        Ledger.PoolParams
-                            { ppId = poolId
-                            , ppVrf = vrf
-                            , ppPledge = Ledger.Coin $ intCast pledgeAmt
-                            , ppCost = Ledger.Coin 0
-                            , ppMargin = unsafeUnitInterval 0.1
-                            , ppRewardAcnt =
-                                Ledger.RewardAcnt Testnet
-                                    $ Ledger.KeyHashObj stakePubHash
-                            , ppOwners = Set.fromList [stakePubHash]
-                            , ppRelays = mempty
-                            , ppMetadata =
-                                SJust
-                                    $ Ledger.PoolMetadata
-                                        ( fromMaybe (error "invalid url (too long)")
-                                            $ textToUrl 128
-                                            $ T.pack metadataURL
-                                        )
-                                        (blake2b256 (BL.toStrict metadataBytes))
-                            }
-
-                let updateStaking sgs =
-                        sgs
-                            { Ledger.sgsPools =
-                                ListMap.ListMap [(poolId, params)] <> sgsPools sgs
-                            , Ledger.sgsStake =
-                                ListMap.fromList [(stakePubHash, poolId)]
-                                    <> Ledger.sgsStake sgs
-                            }
-                let poolSpecificFunds =
-                        ListMap.fromList
-                            [(pledgeAddr, Ledger.Coin $ intCast pledgeAmt)]
-
-                pure
-                    $ over #sgInitialFunds (poolSpecificFunds <>)
-                        . over #sgStaking updateStaking
-            , finalizeShelleyGenesisSetup = \(RunningNode socket _ _) -> do
-                -- Here is our chance to respect the 'retirementEpoch' of
-                -- the 'PoolRecipe'.
-                --
-                -- NOTE: We also submit the retirement cert in
-                -- @registerViaTx@, but this seems to work regardless. (We
-                -- do want to submit it here for the sake of babbage)
-                let retire e = do
-                        retCert <- issuePoolRetirementCert nodeRelativePath opPub e
-                        (rawTx, faucetPrv) <-
-                            preparePoolRetirement
-                                nodeRelativePath
-                                [retCert]
-                        signAndSubmitTx
-                            socket
-                            (changeFileOf @"retirement-tx"  @"tx-body" rawTx)
-                            [ changeFileOf @"faucet-prv"  @"signing-key" faucetPrv
-                            , changeFileOf @"stake-prv"  @"signing-key" ownerPrv
-                            , changeFileOf @"op-prv"  @"signing-key" opPrv
-                            ]
-                            "retirement cert"
-
-                withConfig $ traverse_ retire mretirementEpoch
-            , metadataUrl = T.pack metadataURL
-            , recipe = recipe
-            }
+                let cfg = CardanoNodeConfig
+                        { nodeDir = toFilePath poolDir
+                        , nodeConfigFile = absFilePathOf nodeConfig
+                        , nodeTopologyFile = absFilePathOf topology
+                        , nodeDatabaseDir = toFilePath
+                            $ poolDir </> relDir "db"
+                        , nodeDlgCertFile = Nothing
+                        , nodeSignKeyFile = Nothing
+                        , nodeOpCertFile = Just $ absFilePathOf opCert
+                        , nodeKesKeyFile = Just $ absFilePathOf kesPrv
+                        , nodeVrfKeyFile = Just $ absFilePathOf vrfPrv
+                        , nodePort = Just (NodePort port)
+                        , nodeLoggingHostname = Just name
+                        , nodeExecutable = Nothing
+                        , nodeOutputFile = absFilePathOf <$> nodeOutput
+                        }
+                withConfig
+                    $ withCardanoNodeProcess name cfg
+                    $ \socket -> action $ RunningNode socket genesisData vd
+    pure ConfiguredPool{..}

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Env.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Env.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.Wallet.Launch.Cluster.Env where
+
+import Prelude
+
+import Cardano.Wallet.Launch.Cluster.ClusterEra
+    ( ClusterEra (..)
+    )
+import Cardano.Wallet.Launch.Cluster.FileOf
+    ( DirOf (..)
+    , FileOf (..)
+    , absolutize
+    )
+import Data.Char
+    ( toLower
+    )
+import System.Environment.Extended
+    ( lookupEnvNonEmpty
+    )
+import System.Exit
+    ( die
+    )
+import System.Path
+    ( absRel
+    , relDir
+    , (</>)
+    )
+
+-- | Defaults to the latest era.
+clusterEraFromEnv :: IO ClusterEra
+clusterEraFromEnv = do
+    mera <- lookupEnvNonEmpty var
+    case mera of
+        Nothing -> pure BabbageHardFork
+        Just era -> getEra era
+  where
+    var = "LOCAL_CLUSTER_ERA"
+    err :: [Char] -> IO a
+    err era =
+        die
+            $ var
+                ++ ": "
+                ++ era
+                ++ " era is not supported in the local cluster"
+    getEra env = case map toLower env of
+        "byron" -> err "byron"
+        "shelley" -> err "shelley"
+        "allegra" -> err "allegra"
+        "mary" -> err "mary"
+        "alonzo" -> err "alonzo"
+        "babbage" -> pure BabbageHardFork
+        "conway" -> pure ConwayHardFork
+        _ -> die $ var ++ ": unknown era"
+
+localClusterConfigsFromEnv :: IO (DirOf "cluster-configs")
+localClusterConfigsFromEnv = do
+    mConfigsPath <- lookupEnvNonEmpty "LOCAL_CLUSTER_CONFIGS"
+    let configPath = case mConfigsPath of
+            Just path -> absRel path
+            Nothing ->
+                absRel ".."
+                    </> relDir "local-cluster"
+                    </> relDir "test"
+                    </> relDir "data"
+                    </> relDir "cluster-configs"
+    DirOf <$> absolutize configPath
+
+nodeOutputFileFromEnv :: IO (Maybe (FileOf "node-output"))
+nodeOutputFileFromEnv = do
+    mNodeOutput <-
+        fmap absRel
+            <$> lookupEnvNonEmpty "LOCAL_CLUSTER_NODE_OUTPUT_FILE"
+    fmap FileOf <$> absolutize `traverse` mNodeOutput

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/Process.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/Process.hs
@@ -17,9 +17,6 @@ import Cardano.Wallet.Launch.Cluster.Config
 import Cardano.Wallet.Launch.Cluster.Logging
     ( ClusterLog (MsgLauncher)
     )
-import Control.Exception
-    ( throwIO
-    )
 import Control.Monad.Reader
     ( MonadIO (..)
     , MonadReader (..)
@@ -35,6 +32,4 @@ withCardanoNodeProcess
     -> ClusterM a
 withCardanoNodeProcess name cfg f = do
     Config{..} <- ask
-    liftIO $ do
-        r <- withCardanoNode (contramap (MsgLauncher name) cfgTracer) cfg f
-        either throwIO pure r
+    liftIO $ withCardanoNode (contramap (MsgLauncher name) cfgTracer) cfg f

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/Relay.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/Relay.hs
@@ -21,6 +21,7 @@ import Cardano.Wallet.Launch.Cluster.ClusterM
     )
 import Cardano.Wallet.Launch.Cluster.FileOf
     ( DirOf (..)
+    , RelDirOf (..)
     , absFilePathOf
     , toFilePath
     )
@@ -69,12 +70,13 @@ import System.Path.Directory
 withRelayNode
     :: NodeParams
     -- ^ Parameters used to generate config files.
+    -> RelDirOf "relay"
+    -- ^ Path segment for the node to add to the cluster directory.
     -> (RunningNode -> ClusterM a)
     -- ^ Callback function with socket path
     -> ClusterM a
-withRelayNode params onClusterStart = do
+withRelayNode params (RelDirOf nodeSegment) onClusterStart = do
     let name = "node"
-        nodeSegment = relDir name
     DirOf nodeDirPath <- askNodeDir nodeSegment
     let NodeParams genesisFiles hardForks (port, peers) logCfg _ = params
     bracketTracer' "withRelayNode" $ do

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/Relay.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/Relay.hs
@@ -69,7 +69,7 @@ import System.Path.Directory
 withRelayNode
     :: NodeParams
     -- ^ Parameters used to generate config files.
-    -> (RunningNode -> IO a)
+    -> (RunningNode -> ClusterM a)
     -- ^ Callback function with socket path
     -> ClusterM a
 withRelayNode params onClusterStart = do
@@ -107,5 +107,6 @@ withRelayNode params onClusterStart = do
                         <$> nodeParamsOutputFile params
                     }
 
-        let onClusterStart' socket = onClusterStart (RunningNode socket genesisData vd)
+        let onClusterStart' socket = onClusterStart
+                $ RunningNode socket genesisData vd
         withCardanoNodeProcess name cfg onClusterStart'

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -144,7 +144,6 @@ library
     , ouroboros-network-api
     , pathtype
     , profunctors
-    , resourcet
     , retry
     , servant
     , servant-client
@@ -179,8 +178,8 @@ executable local-cluster
     , iohk-monitoring-extra
     , lens
     , local-cluster
+    , mtl
     , pathtype
-    , resourcet
     , temporary-extra
     , unliftio
     , with-utf8

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -57,6 +57,7 @@ library
     Cardano.Wallet.Launch.Cluster.Cluster
     Cardano.Wallet.Launch.Cluster.ClusterEra
     Cardano.Wallet.Launch.Cluster.ClusterM
+    Cardano.Wallet.Launch.Cluster.CommandLine
     Cardano.Wallet.Launch.Cluster.Config
     Cardano.Wallet.Launch.Cluster.ConfiguredPool
     Cardano.Wallet.Launch.Cluster.Faucet
@@ -85,7 +86,6 @@ library
     Cardano.Wallet.Launch.Cluster.StakeCertificates
     Cardano.Wallet.Launch.Cluster.Tx
     Cardano.Wallet.Launch.Cluster.UnsafeInterval
-    Cardano.Wallet.LocalCluster
     Control.Monitoring.Concurrent
     Control.Monitoring.Monitor
     Control.Monitoring.Tracing
@@ -158,12 +158,11 @@ library
     , typed-process
     , unliftio
     , warp
-    , with-utf8
     , yaml
 
 executable local-cluster
   import:         language
-  main-is:        Cluster.hs
+  main-is:        local-cluster.hs
   hs-source-dirs: exe
   ghc-options: -threaded -rtsopts
 
@@ -172,7 +171,20 @@ executable local-cluster
 
   build-depends:
     , base
+    , cardano-addresses
+    , cardano-wallet-application-extras
+    , cardano-wallet-launcher
+    , cardano-wallet-primitive
+    , directory
+    , iohk-monitoring-extra
+    , lens
     , local-cluster
+    , pathtype
+    , resourcet
+    , temporary-extra
+    , unliftio
+    , with-utf8
+
 test-suite test
   import:         language
   type:           exitcode-stdio-1.0

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -60,6 +60,7 @@ library
     Cardano.Wallet.Launch.Cluster.CommandLine
     Cardano.Wallet.Launch.Cluster.Config
     Cardano.Wallet.Launch.Cluster.ConfiguredPool
+    Cardano.Wallet.Launch.Cluster.Env
     Cardano.Wallet.Launch.Cluster.Faucet
     Cardano.Wallet.Launch.Cluster.FileOf
     Cardano.Wallet.Launch.Cluster.GenesisFiles

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -355,7 +355,7 @@ withTestNode tr action = do
                         , cfgTracer = tr
                         , cfgNodeOutputFile = Nothing
                         , cfgRelayNodePath = mkRelDirOf "relay"
-
+                        , cfgClusterLogFile = Nothing
                         }
             withCluster clusterConfig (FaucetFunds [] [] [])
                 $ \(RunningNode sock genesisData vData) -> do

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -30,6 +30,7 @@ import Cardano.Wallet.Launch.Cluster
     )
 import Cardano.Wallet.Launch.Cluster.FileOf
     ( DirOf (..)
+    , mkRelDirOf
     )
 import Cardano.Wallet.Network
     ( NetworkLayer (..)
@@ -353,6 +354,8 @@ withTestNode tr action = do
                         , cfgShelleyGenesisMods = []
                         , cfgTracer = tr
                         , cfgNodeOutputFile = Nothing
+                        , cfgRelayNodePath = mkRelDirOf "relay"
+
                         }
             withCluster clusterConfig (FaucetFunds [] [] [])
                 $ \(RunningNode sock genesisData vData) -> do

--- a/lib/wallet-benchmarks/bench/memory-benchmark.hs
+++ b/lib/wallet-benchmarks/bench/memory-benchmark.hs
@@ -226,7 +226,7 @@ withCardanoWallet
     -> BenchmarkConfig
     -> C.CardanoNodeConn
     -> (C.CardanoWalletConn -> IO r)
-    -> IO (Either C.ProcessHasExited r)
+    -> IO r
 withCardanoWallet tr workingDir walletExe BenchmarkConfig{..} node action = do
     C.withCardanoWallet tr node
         C.CardanoWalletConfig
@@ -252,7 +252,7 @@ withCardanoNode
     -> FilePath
     -> BenchmarkConfig
     -> (C.CardanoNodeConn -> IO r)
-    -> IO (Either C.ProcessHasExited r)
+    -> IO r
 withCardanoNode tr nodeExe BenchmarkConfig{..} =
     C.withCardanoNode tr
         C.CardanoNodeConfig


### PR DESCRIPTION
- [x] Move the executable code into the executable stanza
- [x] Add CommandLine module
- [x] Use ContT when CPS syntax is hitting indentation
- [x]  Switch to record of handles to pass around process info
- [x] Use exceptions to signal `ProcessHasExited`
- [x] Use ClusterM over IO consistently 
- [x] Add --cluster option to set the cluster directory
- [x] Reduce config duplication (partially)
- [x] Add --cluster-logs option to set the the cluster logs file

ADP-3305
