### PR TITLE
[ADP-3356] Use `Set TxIn` instead of `[TxIn]` for transaction inputs.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -1261,7 +1261,7 @@ modifyShelleyTxBody txUpdate =
         (<> extraCollateral')
   where
     era = recentEra @era
-    TxUpdate extraInputs extraCollateral extraOutputs _ feeUpdate = txUpdate
+    TxUpdate {extraInputs, extraCollateral, extraOutputs, feeUpdate} = txUpdate
     extraOutputs' = StrictSeq.fromList $ map (toLedgerTxOut era) extraOutputs
     extraInputs' = Set.fromList (Convert.toLedger <$> extraInputs)
     extraCollateral' = Set.fromList $ Convert.toLedger <$> extraCollateral

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -862,7 +862,13 @@ balanceTxInner
                     tx
                     timelockKeyWitnessCounts
             minfee = Convert.toWalletCoin $ evaluateMinimumFee pp tx witCount
-            update = TxUpdate [] [] [] [] (UseNewTxFee minfee)
+            update = TxUpdate
+                { extraInputs = []
+                , extraCollateral = []
+                , extraOutputs = []
+                , extraInputScripts = []
+                , feeUpdate = UseNewTxFee minfee
+                }
         tx' <- left updateTxErrorToBalanceTxError $ updateTx tx update
         let balance = txBalance tx'
             minfee' = Convert.toLedgerCoin minfee
@@ -1167,7 +1173,13 @@ data TxUpdate = TxUpdate
 --      == Right tx or Left
 -- @
 noTxUpdate :: TxUpdate
-noTxUpdate = TxUpdate [] [] [] [] UseOldTxFee
+noTxUpdate = TxUpdate
+    { extraInputs = []
+    , extraCollateral = []
+    , extraOutputs = []
+    , extraInputScripts = []
+    , feeUpdate = UseOldTxFee
+    }
 
 -- | Method to use when updating the fee of a transaction.
 data TxFeeUpdate

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1537,7 +1537,7 @@ prop_updateTx
     :: forall era. era ~ Write.BabbageEra
     => Tx era
     -> Set W.TxIn
-    -> [W.TxIn]
+    -> Set W.TxIn
     -> [W.TxOut]
     -> W.Coin
     -> Property
@@ -1558,7 +1558,7 @@ prop_updateTx tx extraInputs extraCollateral extraOutputs newFee = do
             <> StrictSeq.fromList (fromWalletTxOut <$> extraOutputs)
         , fee tx' === Convert.toLedger newFee
         , collateralIns tx' === collateralIns tx
-            <> Set.fromList (fromWalletTxIn <$> extraCollateral)
+            <> Set.map fromWalletTxIn extraCollateral
         ]
   where
     inputs = view (bodyTxL . inputsTxBodyL)

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1541,9 +1541,9 @@ prop_updateTx
     -> [W.TxOut]
     -> W.Coin
     -> Property
-prop_updateTx tx extraIns extraCol extraOuts newFee = do
+prop_updateTx tx extraInputs extraCol extraOuts newFee = do
     let extra = TxUpdate
-            { extraInputs = extraIns
+            { extraInputs
             , extraCollateral = extraCol
             , extraOutputs = extraOuts
             , extraInputScripts = []
@@ -1553,7 +1553,7 @@ prop_updateTx tx extraIns extraCol extraOuts newFee = do
             $ updateTx tx extra
     conjoin
         [ inputs tx' === inputs tx
-            <> Set.fromList (fromWalletTxIn <$> extraIns)
+            <> Set.fromList (fromWalletTxIn <$> extraInputs)
         , outputs tx' === (outputs tx)
             <> StrictSeq.fromList (fromWalletTxOut <$> extraOuts)
         , fee tx' === Convert.toLedger newFee

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -289,7 +289,7 @@ import Internal.Cardano.Write.Tx.Balance
     , PartialTx (..)
     , Redeemer (..)
     , TxFeeUpdate (UseNewTxFee)
-    , TxUpdate (TxUpdate)
+    , TxUpdate (..)
     , UTxOAssumptions (..)
     , balanceTx
     , constructUTxOIndex
@@ -1542,7 +1542,13 @@ prop_updateTx
     -> W.Coin
     -> Property
 prop_updateTx tx extraIns extraCol extraOuts newFee = do
-    let extra = TxUpdate extraIns extraCol extraOuts [] (UseNewTxFee newFee)
+    let extra = TxUpdate
+            { extraInputs = extraIns
+            , extraCollateral = extraCol
+            , extraOutputs = extraOuts
+            , extraInputScripts = []
+            , feeUpdate = UseNewTxFee newFee
+            }
     let tx' = either (error . show) id
             $ updateTx tx extra
     conjoin

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1541,11 +1541,11 @@ prop_updateTx
     -> [W.TxOut]
     -> W.Coin
     -> Property
-prop_updateTx tx extraInputs extraCollateral extraOuts newFee = do
+prop_updateTx tx extraInputs extraCollateral extraOutputs newFee = do
     let extra = TxUpdate
             { extraInputs
             , extraCollateral
-            , extraOutputs = extraOuts
+            , extraOutputs
             , extraInputScripts = []
             , feeUpdate = UseNewTxFee newFee
             }
@@ -1555,7 +1555,7 @@ prop_updateTx tx extraInputs extraCollateral extraOuts newFee = do
         [ inputs tx' === inputs tx
             <> Set.fromList (fromWalletTxIn <$> extraInputs)
         , outputs tx' === (outputs tx)
-            <> StrictSeq.fromList (fromWalletTxOut <$> extraOuts)
+            <> StrictSeq.fromList (fromWalletTxOut <$> extraOutputs)
         , fee tx' === Convert.toLedger newFee
         , collateralIns tx' === collateralIns tx
             <> Set.fromList (fromWalletTxIn <$> extraCollateral)

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1541,10 +1541,10 @@ prop_updateTx
     -> [W.TxOut]
     -> W.Coin
     -> Property
-prop_updateTx tx extraInputs extraCol extraOuts newFee = do
+prop_updateTx tx extraInputs extraCollateral extraOuts newFee = do
     let extra = TxUpdate
             { extraInputs
-            , extraCollateral = extraCol
+            , extraCollateral
             , extraOutputs = extraOuts
             , extraInputScripts = []
             , feeUpdate = UseNewTxFee newFee
@@ -1558,7 +1558,7 @@ prop_updateTx tx extraInputs extraCol extraOuts newFee = do
             <> StrictSeq.fromList (fromWalletTxOut <$> extraOuts)
         , fee tx' === Convert.toLedger newFee
         , collateralIns tx' === collateralIns tx
-            <> Set.fromList (fromWalletTxIn <$> extraCol)
+            <> Set.fromList (fromWalletTxIn <$> extraCollateral)
         ]
   where
     inputs = view (bodyTxL . inputsTxBodyL)

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1536,7 +1536,7 @@ prop_bootstrapWitnesses
 prop_updateTx
     :: forall era. era ~ Write.BabbageEra
     => Tx era
-    -> [W.TxIn]
+    -> Set W.TxIn
     -> [W.TxIn]
     -> [W.TxOut]
     -> W.Coin
@@ -1553,7 +1553,7 @@ prop_updateTx tx extraInputs extraCollateral extraOutputs newFee = do
             $ updateTx tx extra
     conjoin
         [ inputs tx' === inputs tx
-            <> Set.fromList (fromWalletTxIn <$> extraInputs)
+            <> Set.map fromWalletTxIn extraInputs
         , outputs tx' === (outputs tx)
             <> StrictSeq.fromList (fromWalletTxOut <$> extraOutputs)
         , fee tx' === Convert.toLedger newFee


### PR DESCRIPTION
This PR:

- Adjusts the `SelectAssetsResult` and `TxUpdate` record types to use `Set TxIn` instead of `[TxIn]`. Every transaction input must be unique, so we don't need to make it possible to represent duplicates.
- Adjusts constructors and pattern matches of `TxUpdate` to use explicit record field names. This arguably makes it easier for readers to tell which field is which.

## Issue

ADP-3356