### PR TITLE
[ADP-3272] Consolidate generators and shrinkers for `Map` data type.

### DIFF
--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2216,15 +2216,15 @@ instance Arbitrary (MixedSign Value) where
 instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
     arbitrary = do
         tx <- genTxForBalancing
-        extraUTxO <- genExtraUTxO tx
+        extraUTxO <- genExtraUTxO (txInputs tx)
         let redeemers = []
         let timelockKeyWitnessCounts = mempty
         pure PartialTx {tx, extraUTxO, redeemers, timelockKeyWitnessCounts}
       where
-        genExtraUTxO :: Tx era -> Gen (UTxO era)
-        genExtraUTxO tx =
+        genExtraUTxO :: Set TxIn -> Gen (UTxO era)
+        genExtraUTxO txIns =
             UTxO . Map.fromList <$>
-            mapM (\i -> (i,) <$> genTxOut) (Set.toList $ txInputs tx)
+            mapM (\i -> (i,) <$> genTxOut) (Set.toList txIns)
         txInputs :: Tx era -> Set TxIn
         txInputs tx = tx ^. bodyTxL . inputsTxBodyL
     shrink partialTx@PartialTx {tx, extraUTxO} =

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -389,6 +389,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Extra
     ( DisjointPair
     , genDisjointPair
+    , genMapFromKeysWith
     , genericRoundRobinShrink
     , getDisjointPair
     , shrinkDisjointPair
@@ -2223,9 +2224,6 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
       where
         genExtraUTxO :: Set TxIn -> Gen (UTxO era)
         genExtraUTxO = fmap UTxO . genMapFromKeysWith genTxOut
-        genMapFromKeysWith :: Ord k => Gen v -> Set k -> Gen (Map k v)
-        genMapFromKeysWith genValue =
-            fmap Map.fromList . mapM (\k -> (k,) <$> genValue) . Set.toList
         txInputs :: Tx era -> Set TxIn
         txInputs tx = tx ^. bodyTxL . inputsTxBodyL
     shrink partialTx@PartialTx {tx, extraUTxO} =

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2222,9 +2222,10 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         pure PartialTx {tx, extraUTxO, redeemers, timelockKeyWitnessCounts}
       where
         genExtraUTxO :: Set TxIn -> Gen (UTxO era)
-        genExtraUTxO txIns =
-            UTxO . Map.fromList <$>
-            mapM (\i -> (i,) <$> genTxOut) (Set.toList txIns)
+        genExtraUTxO = fmap UTxO . genMapFromKeysWith genTxOut
+        genMapFromKeysWith :: Ord k => Gen v -> Set k -> Gen (Map k v)
+        genMapFromKeysWith genValue =
+            fmap Map.fromList . mapM (\k -> (k,) <$> genValue) . Set.toList
         txInputs :: Tx era -> Set TxIn
         txInputs tx = tx ^. bodyTxL . inputsTxBodyL
     shrink partialTx@PartialTx {tx, extraUTxO} =

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2349,14 +2349,15 @@ shrinkFee _ = [Ledger.Coin 0]
 -- TODO: ADP-3272
 -- Fix this function so that it returns something other than the empty list.
 shrinkInputResolution :: IsRecentEra era => Write.UTxO era -> [Write.UTxO era]
-shrinkInputResolution = shrinkMapBy UTxO unUTxO (shrinkMapValues shrinkOutput)
+shrinkInputResolution =
+    shrinkMapBy UTxO unUTxO (shrinkMapValuesWith shrinkOutput)
   where
     shrinkOutput _ = []
 
 -- | Shrinks just the values of a map, keeping the set of keys constant.
 --
-shrinkMapValues :: forall k v. Ord k => (v -> [v]) -> Map k v -> [Map k v]
-shrinkMapValues shrinkValue =
+shrinkMapValuesWith :: forall k v. Ord k => (v -> [v]) -> Map k v -> [Map k v]
+shrinkMapValuesWith shrinkValue =
     shrinkMapBy Map.fromList Map.toList shrinkKeyValuePairs
   where
     shrinkKeyValuePairs :: [(k, v)] -> [[(k, v)]]

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2224,10 +2224,9 @@ instance forall era. IsRecentEra era => Arbitrary (PartialTx era) where
         genExtraUTxO :: Tx era -> Gen (UTxO era)
         genExtraUTxO tx =
             UTxO . Map.fromList <$>
-            mapM (\i -> (i,) <$> genTxOut) (Set.toList txInputs)
-          where
-            txInputs :: Set TxIn
-            txInputs = tx ^. bodyTxL . inputsTxBodyL
+            mapM (\i -> (i,) <$> genTxOut) (Set.toList $ txInputs tx)
+        txInputs :: Tx era -> Set TxIn
+        txInputs tx = tx ^. bodyTxL . inputsTxBodyL
     shrink partialTx@PartialTx {tx, extraUTxO} =
         [ partialTx {extraUTxO = extraUTxO'}
         | extraUTxO' <- shrinkInputResolution extraUTxO

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -209,9 +209,6 @@ import Data.List
 import Data.List.NonEmpty
     ( NonEmpty (..)
     )
-import Data.Map.Strict
-    ( Map
-    )
 import Data.Maybe
     ( catMaybes
     , fromJust
@@ -393,6 +390,7 @@ import Test.QuickCheck.Extra
     , genericRoundRobinShrink
     , getDisjointPair
     , shrinkDisjointPair
+    , shrinkMapValuesWith
     , shrinkNatural
     , (.>=.)
     , (<:>)
@@ -2353,22 +2351,6 @@ shrinkInputResolution =
     shrinkMapBy UTxO unUTxO (shrinkMapValuesWith shrinkOutput)
   where
     shrinkOutput _ = []
-
--- | Shrinks just the values of a map, keeping the set of keys constant.
---
-shrinkMapValuesWith :: forall k v. Ord k => (v -> [v]) -> Map k v -> [Map k v]
-shrinkMapValuesWith shrinkValue =
-    shrinkMapBy Map.fromList Map.toList shrinkKeyValuePairs
-  where
-    shrinkKeyValuePairs :: [(k, v)] -> [[(k, v)]]
-    shrinkKeyValuePairs = \case
-        ((k, v) : rest) -> mconcat
-            -- First shrink the first element
-            [ map (\v' -> (k, v') : rest) (shrinkValue v)
-            -- Recurse to shrink subsequent elements on their own
-            , map ((k, v) :) (shrinkKeyValuePairs rest)
-            ]
-        [] -> []
 
 shrinkScriptData
     :: Era (CardanoApi.ShelleyLedgerEra era)

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -623,7 +623,7 @@ shrinkMapWith shrinkKey shrinkValue
     $ shrinkList
     $ liftShrink2 shrinkKey shrinkValue
 
--- | Shrinks just the values of a map, keeping the set of keys constant.
+-- | Shrinks just the values of a 'Map', keeping the set of keys constant.
 --
 shrinkMapValuesWith :: forall k v. Ord k => (v -> [v]) -> Map k v -> [Map k v]
 shrinkMapValuesWith shrinkValue =

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -52,6 +53,7 @@ module Test.QuickCheck.Extra
 
       -- * Generating and shrinking maps
     , genMapWith
+    , genMapFromKeysWith
     , shrinkMapWith
 
       -- * Selecting entries from maps
@@ -600,6 +602,12 @@ genFunction coarbitraryFn gen = promote (`coarbitraryFn` gen)
 genMapWith :: Ord k => Gen k -> Gen v -> Gen (Map k v)
 genMapWith genKey genValue =
     Map.fromList <$> listOf (liftArbitrary2 genKey genValue)
+
+-- | Generates a 'Map' from a set of keys and a value generation function.
+--
+genMapFromKeysWith :: Ord k => Gen v -> Set k -> Gen (Map k v)
+genMapFromKeysWith genValue =
+    fmap Map.fromList . mapM (\k -> (k,) <$> genValue) . Set.toList
 
 -- | Shrinks a 'Map' with the given key and value shrinking functions.
 --

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -21,7 +21,6 @@ module Test.QuickCheck.Extra
     (
       -- * Generation
       genFunction
-    , genMapWith
     , genSized2
     , genSized2With
     , reasonablySized
@@ -35,7 +34,6 @@ module Test.QuickCheck.Extra
       -- * Shrinking
     , liftShrinker
     , shrinkInterleaved
-    , shrinkMapWith
     , groundRobinShrink
     , groundRobinShrink'
     , genericRoundRobinShrink
@@ -51,6 +49,10 @@ module Test.QuickCheck.Extra
 
       -- * Partitioning lists
     , partitionList
+
+      -- * Generating and shrinking maps
+    , genMapWith
+    , shrinkMapWith
 
       -- * Selecting entries from maps
     , selectMapEntry


### PR DESCRIPTION
This PR creates a common home for generators and shrinkers of the `Map` data type.

## Issue

ADP-3272