### PR TITLE
[ADP-3171] Shorten various definitions in `Write.Tx.BalanceSpec`.

### DIFF
--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -2425,10 +2425,10 @@ shrinkTxBodyBabbage
         , scriptData' <- prependOriginal shrinkScriptData scriptData
         , scripts' <- prependOriginal (shrinkList (const [])) scripts
         , val' <- val : filter (/= val)
-                    [ CardanoApi.TxScriptValidity
-                        CardanoApi.AlonzoEraOnwardsBabbage
-                        CardanoApi.ScriptValid
-                    ]
+            [ CardanoApi.TxScriptValidity
+                CardanoApi.AlonzoEraOnwardsBabbage
+                CardanoApi.ScriptValid
+            ]
         ]
   where
     shrinkLedgerTxBody

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1035,12 +1035,8 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
             | i <- allInputs tx
             ]
       where
-        allInputs
-            :: Tx era
-            -> [TxIn]
-        allInputs body =
-            Set.toList
-            $ body ^. (bodyTxL . allInputsTxBodyF)
+        allInputs :: Tx era -> [TxIn]
+        allInputs body = Set.toList $ body ^. (bodyTxL . allInputsTxBodyF)
 
     -- An address with a vk payment credential. For the test above, this is the
     -- only aspect which matters.

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1030,11 +1030,7 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
         allInputs body = Set.toList $ body ^. (bodyTxL . allInputsTxBodyF)
 
         txOut :: TxOutInRecentEra
-        txOut = TxOutInRecentEra
-            (Convert.toLedger addr)
-            (Convert.toLedgerTokenBundle mempty)
-            NoDatum
-            Nothing
+        txOut = TxOutInRecentEra (Convert.toLedger addr) mempty NoDatum Nothing
 
     -- An address with a vk payment credential. For the test above, this is the
     -- only aspect which matters.

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1024,19 +1024,17 @@ spec_estimateSignedTxSize = describe "estimateSignedTxSize" $ do
         -> Tx era
         -> UTxO era
     utxoPromisingInputsHaveAddress addr tx =
-        unsafeUtxoFromTxOutsInRecentEra
-            [ (i
-              , TxOutInRecentEra
-                    (Convert.toLedger addr)
-                    (Convert.toLedgerTokenBundle mempty)
-                    NoDatum
-                    Nothing
-              )
-            | i <- allInputs tx
-            ]
+        unsafeUtxoFromTxOutsInRecentEra [(i, txOut) | i <- allInputs tx]
       where
         allInputs :: Tx era -> [TxIn]
         allInputs body = Set.toList $ body ^. (bodyTxL . allInputsTxBodyF)
+
+        txOut :: TxOutInRecentEra
+        txOut = TxOutInRecentEra
+            (Convert.toLedger addr)
+            (Convert.toLedgerTokenBundle mempty)
+            NoDatum
+            Nothing
 
     -- An address with a vk payment credential. For the test above, this is the
     -- only aspect which matters.


### PR DESCRIPTION
This PR makes a few definitions more concise within `Write.Tx.BalanceSpec`.

## Issue

Follow-on from ADP-3171.