### PR TITLE
Rename `s` to `changeState` within `Write.Tx.{Balance,BalanceSpec}`.

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -918,7 +918,7 @@ selectAssets
     -> changeState
     -> ExceptT (ErrBalanceTx era) m (SelectAssetsResult, changeState)
 selectAssets pp utxoAssumptions outs' redeemers
-    utxoSelection balance fee0 changeGen selectionStrategy s = do
+    utxoSelection balance fee0 changeGen selectionStrategy changeState = do
         except validateTxOutputs'
         transformSelection <$> performSelection'
   where
@@ -1057,7 +1057,8 @@ selectAssets pp utxoAssumptions outs' redeemers
         -> (SelectAssetsResult, changeState)
     transformSelection sel =
         let
-            (sel', s') = assignChangeAddresses changeGen sel s
+            (sel', changeState') =
+                assignChangeAddresses changeGen sel changeState
             inputs = F.toList (sel' ^. #inputs)
             collateral = sel' ^. #collateral
             change = sel' ^. #change
@@ -1083,7 +1084,7 @@ selectAssets pp utxoAssumptions outs' redeemers
                 , extraInputScripts = inputScripts
                 }
         in
-        (selectAssetsResult, s')
+        (selectAssetsResult, changeState')
 
 data ChangeAddressGen s = ChangeAddressGen
     {

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -515,7 +515,7 @@ balanceTx
     utxoAssumptions
     UTxOIndex {availableUTxO, availableUTxOIndex}
     genChange
-    s
+    changeState
     PartialTx {extraUTxO, tx, redeemers, timelockKeyWitnessCounts}
     = do
     guardExistingCollateral
@@ -539,7 +539,7 @@ balanceTx
                 utxoReference
                 utxoSelection
                 genChange
-                s
+                changeState
                 strategy
                 redeemers
                 timelockKeyWitnessCounts

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -720,7 +720,7 @@ balanceTxInner
     utxoReference
     utxoSelection
     genChange
-    s
+    changeState
     selectionStrategy
     redeemers
     timelockKeyWitnessCounts
@@ -736,7 +736,7 @@ balanceTxInner
     -- transaction considering only the maximum cost, and only after, try to
     -- adjust the change and ExUnits of each redeemer to something more
     -- sensible than the max execution cost.
-    (selectAssetsResult, s')
+    (selectAssetsResult, changeState')
         <- selectAssets
             pp
             utxoAssumptions
@@ -747,7 +747,7 @@ balanceTxInner
             (Convert.toWalletCoin minfee0)
             genChange
             selectionStrategy
-            s
+            changeState
     let SelectAssetsResult
             { extraInputs
             , extraCollateral
@@ -816,7 +816,7 @@ balanceTxInner
         (ExceptT . pure $
             distributeSurplus feePerByte surplus feeAndChange)
 
-    fmap ((, s')) . guardTxSize witCount
+    fmap ((, changeState')) . guardTxSize witCount
         =<< guardTxBalanced
         =<< assembleTransaction
         TxUpdate

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -589,16 +589,16 @@ spec_balanceTx = describe "balanceTx" $ do
         -- True for values of nPayments small enough not to cause
         -- 'ErrBalanceTxMaxSizeLimitExceeded' or ErrMakeChange
         let nChange = max nPayments 1
-        let s0 = DummyChangeState 0
+        let changeState0 = DummyChangeState 0
         let expectedChange = fmap Convert.toWalletAddress <$>
-                flip evalState s0
+                flip evalState changeState0
                 $ replicateM nChange
                 $ state @Identity dummyChangeAddrGen.genChangeAddress
 
         let address :: Babbage.BabbageTxOut StandardBabbage -> W.Address
             address (Babbage.BabbageTxOut addr _ _ _) = Convert.toWallet addr
 
-        let (tx, s') =
+        let (tx, changeState') =
                 either (error . show) id $ balance' ptx
 
         it "assigns change addresses as expected" $
@@ -607,7 +607,7 @@ spec_balanceTx = describe "balanceTx" $ do
                 (map (view #address) paymentOuts ++ expectedChange)
 
         it "returns s' corresponding to which addresses were used" $ do
-            s' `shouldBe` DummyChangeState { nextUnusedIndex = nChange }
+            changeState' `shouldBe` DummyChangeState {nextUnusedIndex = nChange}
 
     it "assigns minimal ada quantities to outputs without ada" $ do
         let out = W.TxOut dummyAddr (W.TokenBundle.fromCoin (W.Coin 0))

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -606,7 +606,7 @@ spec_balanceTx = describe "balanceTx" $ do
                 `shouldBe`
                 (map (view #address) paymentOuts ++ expectedChange)
 
-        it "returns s' corresponding to which addresses were used" $ do
+        it "returns a change state that corresponds to the addresses used" $ do
             changeState' `shouldBe` DummyChangeState {nextUnusedIndex = nChange}
 
     it "assigns minimal ada quantities to outputs without ada" $ do


### PR DESCRIPTION
This PR renames variables called `s`  to `changeState` in modules `Write.Tx.{Balance,BalanceSpec}`.

### Justification

Readability and ease-of-understanding.

The `balanceTx` function and its cousins are quite long and have multiple concepts vying for the reader's attention. A more descriptive name is arguably helpful here.

### Issue

None. Noticed while reviewing code.