### PR TITLE
[ADP-3272] Use `Data.Set.NonEmpty` for `UnresolvedInputs` error.

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -551,7 +551,7 @@ instance (Write.IsRecentEra era, IsServerError (ErrAssignRedeemers era))
             apiError err400 UnresolvedInputs $ T.unwords
                 [ "There are inputs in the transaction for which corresponding"
                 , "outputs could not be found:\n"
-                , pretty $ NE.toList $ show <$> ins
+                , pretty $ show <$> NE.toList ins
                 ]
         ErrBalanceTxInputResolutionConflicts conflicts -> do
             let conflictF (a, b) = build (show a) <> "\nvs\n" <> build (show b)

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -193,8 +193,8 @@ import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.Foldable as F
 import qualified Data.List as L
-import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Internal.Cardano.Write.Tx as Write
@@ -551,7 +551,7 @@ instance (Write.IsRecentEra era, IsServerError (ErrAssignRedeemers era))
             apiError err400 UnresolvedInputs $ T.unwords
                 [ "There are inputs in the transaction for which corresponding"
                 , "outputs could not be found:\n"
-                , pretty $ show <$> NE.toList ins
+                , pretty $ show <$> F.toList ins
                 ]
         ErrBalanceTxInputResolutionConflicts conflicts -> do
             let conflictF (a, b) = build (show a) <> "\nvs\n" <> build (show b)

--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -75,6 +75,7 @@ library internal
     , lens
     , MonadRandom
     , monoid-subclasses
+    , nonempty-containers
     , ouroboros-consensus
     , ouroboros-consensus-cardano
     , pretty-simple
@@ -147,6 +148,7 @@ test-suite test
     , lens
     , MonadRandom
     , monoid-subclasses
+    , nonempty-containers
     , ouroboros-consensus
     , ouroboros-consensus-cardano
     , ouroboros-network-api

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -566,9 +566,7 @@ balanceTx
         :: ExceptT (ErrBalanceTx era) m (UTxOIndex.UTxOIndex WalletUTxO)
     indexPreselectedUTxO
         | Just unresolvedTxIns <- maybeUnresolvedTxIns =
-            throwE
-                $ ErrBalanceTxUnresolvedInputs
-                $ NESet.fromList unresolvedTxIns
+            throwE (ErrBalanceTxUnresolvedInputs unresolvedTxIns)
         | otherwise = pure $
             UTxOIndex.fromSequence (convertUTxO <$> Map.toList selectedUTxO)
       where
@@ -576,9 +574,9 @@ balanceTx
         convertUTxO (i, o) = (WalletUTxO (Convert.toWallet i) addr, bundle)
           where
             W.TxOut addr bundle = toWalletTxOut era o
-        maybeUnresolvedTxIns :: Maybe (NonEmpty TxIn)
+        maybeUnresolvedTxIns :: Maybe (NESet TxIn)
         maybeUnresolvedTxIns =
-            NE.nonEmpty $ Set.toList $ txIns <\> Map.keysSet selectedUTxO
+            NESet.nonEmptySet $ txIns <\> Map.keysSet selectedUTxO
         selectedUTxO :: Map TxIn (TxOut era)
         selectedUTxO = Map.restrictKeys (unUTxO utxoReference) txIns
         txIns :: Set TxIn

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -206,9 +206,6 @@ import Data.List
     ( isSuffixOf
     , sortOn
     )
-import Data.List.NonEmpty
-    ( NonEmpty (..)
-    )
 import Data.Maybe
     ( catMaybes
     , fromJust
@@ -671,7 +668,10 @@ spec_balanceTx = describe "balanceTx" $ do
             balance partialTx
                 `shouldBe`
                 Left
-                    (ErrBalanceTxUnresolvedInputs (Convert.toLedger txin :| []))
+                    ( ErrBalanceTxUnresolvedInputs
+                    . NE.singleton
+                    $ Convert.toLedger txin
+                    )
 
         describe "with redeemers" $
             it "fails with ErrBalanceTxUnresolvedInputs" $ do
@@ -679,11 +679,12 @@ spec_balanceTx = describe "balanceTx" $ do
                     withNoUTxO ptx = ptx { extraUTxO = Write.UTxO mempty }
 
                 balance (withNoUTxO pingPong_2)
-                    `shouldBe` Left
-                        (ErrBalanceTxUnresolvedInputs $ NE.fromList
-                            [ Convert.toLedger $ W.TxIn
-                                (W.Hash "11111111111111111111111111111111") 0
-                            ]
+                    `shouldBe`
+                    Left
+                        ( ErrBalanceTxUnresolvedInputs
+                        . NE.singleton
+                        . Convert.toLedger
+                        $ W.TxIn (W.Hash "11111111111111111111111111111111") 0
                         )
 
     describe "when validity interval is too far in the future" $ do

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -458,10 +458,10 @@ import qualified Cardano.Wallet.Primitive.Types.UTxO as W
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Foldable as F
-import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
+import qualified Data.Set.NonEmpty as NESet
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Internal.Cardano.Write.Tx as Write
@@ -669,7 +669,7 @@ spec_balanceTx = describe "balanceTx" $ do
                 `shouldBe`
                 Left
                     ( ErrBalanceTxUnresolvedInputs
-                    . NE.singleton
+                    . NESet.singleton
                     $ Convert.toLedger txin
                     )
 
@@ -682,7 +682,7 @@ spec_balanceTx = describe "balanceTx" $ do
                     `shouldBe`
                     Left
                         ( ErrBalanceTxUnresolvedInputs
-                        . NE.singleton
+                        . NESet.singleton
                         . Convert.toLedger
                         $ W.TxIn (W.Hash "11111111111111111111111111111111") 0
                         )


### PR DESCRIPTION
This PR adjusts the `ErrBalanceTxUnresolvedInputs` error to use a non-empty **_set_** instead of a non-empty **_list_**:

```patch
- | ErrBalanceTxUnresolvedInputs (NonEmpty TxIn)
+ | ErrBalanceTxUnresolvedInputs (NESet    TxIn)
```

### Justification

- Transaction inputs are unique.
- The ability to represent duplicates is neither necessary nor helpful.
- The order of inputs is unimportant.

### Issue

ADP-3272