### PR TITLE
[ADP-3305] Add node --socket-path option to the local-cluster

### DIFF
--- a/justfile
+++ b/justfile
@@ -29,9 +29,12 @@ bench target:
 
 # run a local test cluster
 local-cluster:
-  nix shell '.#local-cluster' '.#cardano-node' '.#cardano-wallet' \
+  nix shell '.#local-cluster' '.#cardano-node' \
     -c "local-cluster" \
-    --cluster-configs lib/local-cluster/test/data/cluster-configs
+    control \
+    --cluster-configs lib/local-cluster/test/data/cluster-configs \
+    --cluster-logs ignore-me/cluster.logs \
+    --socket-path ignore-me/cluster.socket
 
 # run unit tests on a match
 unit-tests-cabal-match match:

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -52,6 +52,7 @@ library
     , criterion-measurement
     , deepseq
     , directory
+    , extra
     , faucet
     , filepath
     , fmt
@@ -64,6 +65,7 @@ library
     , local-cluster
     , mtl
     , optparse-applicative
+    , pathtype
     , resourcet
     , say
     , servant-client
@@ -133,6 +135,7 @@ benchmark latency
     , cardano-wallet-primitive
     , directory
     , exceptions
+    , extra
     , faucet
     , filepath
     , fmt

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -46,10 +46,11 @@ library
   hs-source-dirs:
       src
   exposed-modules:
-      Cardano.Launcher
-    , Cardano.Launcher.Node
-      Cardano.Launcher.Wallet
-    , Cardano.Startup
+    Cardano.Launcher
+    Cardano.Launcher.Node
+    Cardano.Launcher.Wallet
+    Cardano.Startup
+    Data.MaybeK
   if os(windows)
     build-depends: Win32
     other-modules: Cardano.Startup.Windows

--- a/lib/launcher/src/Data/MaybeK.hs
+++ b/lib/launcher/src/Data/MaybeK.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE DeriveFunctor #-}
 
 module Data.MaybeK
     ( MaybeK (..)

--- a/lib/launcher/src/Data/MaybeK.hs
+++ b/lib/launcher/src/Data/MaybeK.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveFunctor #-}
+
+module Data.MaybeK
+    ( MaybeK (..)
+    , IsMaybe (..)
+    , maybeFromMaybeK
+    )
+where
+
+import Prelude
+
+-- | A type level tag to indicate whether a value is present or not.
+data IsMaybe = IsJust | IsNothing
+
+-- | A Maybe carring the type level tag.
+data MaybeK k a where
+    NothingK :: MaybeK IsNothing a
+    JustK :: a -> MaybeK IsJust a
+
+deriving instance Show a => Show (MaybeK k a)
+deriving instance Eq a => Eq (MaybeK k a)
+deriving instance Functor (MaybeK k)
+
+-- | Convert a MaybeK to a Maybe, dropping the type level tag.
+maybeFromMaybeK :: MaybeK k a -> Maybe a
+maybeFromMaybeK NothingK = Nothing
+maybeFromMaybeK (JustK x) = Just x

--- a/lib/local-cluster/exe/local-cluster.hs
+++ b/lib/local-cluster/exe/local-cluster.hs
@@ -222,6 +222,7 @@ main = withUtf8 $ do
         { clusterConfigsDir
         , clusterDir
         , clusterLogs
+        , nodeToClientSocket
         } <-
         parseCommandLineOptions
     evalContT $ do
@@ -252,6 +253,7 @@ main = withUtf8 $ do
                     , cfgNodeOutputFile = Nothing
                     , cfgRelayNodePath = mkRelDirOf "relay"
                     , cfgClusterLogFile = clusterLogs
+                    , cfgNodeToClientSocket = nodeToClientSocket
                     }
         node <-
             ContT

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/CommandLine.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/CommandLine.hs
@@ -37,6 +37,7 @@ data CommandLineOptions = CommandLineOptions
     { clusterConfigsDir :: DirOf "cluster-configs"
     , clusterDir :: Maybe (DirOf "cluster")
     , clusterLogs :: Maybe (FileOf "cluster-logs")
+    , nodeToClientSocket :: FileOf "node-to-client-socket"
     }
     deriving stock (Show)
 
@@ -49,9 +50,19 @@ parseCommandLineOptions = do
                 <$> clusterConfigsDirParser absolutizer
                 <*> clusterDirParser absolutizer
                 <*> clusterLogsParser absolutizer
+                <*> nodeToClientSocketParser absolutizer
                 <**> helper
             )
             (progDesc "Local Cluster for testing")
+
+nodeToClientSocketParser :: Absolutizer -> Parser (FileOf "node-to-client-socket")
+nodeToClientSocketParser (Absolutizer absOf) =
+    FileOf . absOf . absRel
+        <$> strOption
+            ( long "socket-path"
+                <> metavar "NODE_TO_CLIENT_SOCKET"
+                <> help "Path to the node-to-client socket"
+            )
 
 clusterConfigsDirParser :: Absolutizer -> Parser (DirOf "cluster-configs")
 clusterConfigsDirParser (Absolutizer absOf) =

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Config.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Config.hs
@@ -71,4 +71,5 @@ data Config = Config
     -- ^ Path segment for relay node.
     , cfgClusterLogFile :: Maybe (FileOf "cluster-logs")
     -- ^ File to write cluster logs to.
+    , cfgNodeToClientSocket :: FileOf "node-to-client-socket"
     }

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/NodeParams.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/NodeParams.hs
@@ -12,6 +12,9 @@ import Prelude
 import Cardano.BM.Tracing
     ( Severity
     )
+import Cardano.Launcher.Node
+    ( MaybeK
+    )
 import Cardano.Wallet.Launch.Cluster.ClusterEra
     ( ClusterEra (BabbageHardFork)
     )
@@ -27,7 +30,7 @@ import Cardano.Wallet.Launch.Cluster.Logging
     )
 
 -- | Configuration parameters which update the @node.config@ test data file.
-data NodeParams = NodeParams
+data NodeParams d = NodeParams
     { nodeGenesisFiles :: GenesisFiles
     -- ^ Genesis block start time
     , nodeHardForks :: ClusterEra
@@ -39,6 +42,7 @@ data NodeParams = NodeParams
     -- config. This option can set the minimum severity and add another output
     -- file.
     , nodeParamsOutputFile :: Maybe (FileOf "node-output")
+    , nodeSocket :: MaybeK d (FileOf "node-to-client-socket")
     }
     deriving stock (Show)
 
@@ -47,7 +51,8 @@ singleNodeParams
     -> Severity
     -> Maybe (DirOf "node-logs", Severity)
     -> Maybe (FileOf "node-output")
-    -> NodeParams
+    -> MaybeK d (FileOf "node-to-client-socket")
+    -> NodeParams d
 singleNodeParams genesisFiles severity extraLogFile =
     NodeParams genesisFiles BabbageHardFork (0, []) LogFileConfig
         { minSeverityTerminal = severity

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/Process.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/Process.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Cardano.Wallet.Launch.Cluster.Node.Process where
@@ -7,6 +9,7 @@ import Prelude
 import Cardano.Launcher.Node
     ( CardanoNodeConfig
     , CardanoNodeConn
+    , MaybeK
     , withCardanoNode
     )
 import Cardano.Wallet.Launch.Cluster.ClusterM
@@ -30,8 +33,8 @@ import Control.Tracer
 
 withCardanoNodeProcess
     :: String
-    -> CardanoNodeConfig
-    -> (CardanoNodeConn -> ClusterM a)
+    -> CardanoNodeConfig d
+    -> (MaybeK d CardanoNodeConn -> ClusterM a)
     -> ClusterM a
 withCardanoNodeProcess name cfg f = do
     Config{..} <- ask

--- a/lib/wallet-benchmarks/bench/memory-benchmark.hs
+++ b/lib/wallet-benchmarks/bench/memory-benchmark.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -7,6 +8,9 @@ import Prelude
 import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..)
     , HasSeverityAnnotation (..)
+    )
+import Cardano.Launcher.Node
+    ( MaybeK (..)
     )
 import Cardano.Startup
     ( installSignalHandlers
@@ -253,7 +257,7 @@ withCardanoNode
     -> BenchmarkConfig
     -> (C.CardanoNodeConn -> IO r)
     -> IO r
-withCardanoNode tr nodeExe BenchmarkConfig{..} =
+withCardanoNode tr nodeExe BenchmarkConfig{..} action =
     C.withCardanoNode tr
         C.CardanoNodeConfig
             { C.nodeDir = nodeDatabaseDir
@@ -269,7 +273,9 @@ withCardanoNode tr nodeExe BenchmarkConfig{..} =
             , C.nodeLoggingHostname = Nothing
             , C.nodeExecutable = Just nodeExe
             , C.nodeOutputFile = Nothing
+            , C.nodeSocketPathFile = JustK $ nodeDatabaseDir </> "node.socket"
             }
+        $ \(JustK c) -> action c
 
 {-----------------------------------------------------------------------------
     Utilities


### PR DESCRIPTION
- [x] Add --socket-path option to set the node-to-client socket path
- [x] Remove the socket-path from pool nodes
- [x] Use the relay node socket path instead of pool0 to execute the secondary funding  

ADP-3305
