### PR TITLE
[ADP-3272] Add shrinker function `shrinkMapToSubmaps`.

### DIFF
--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -54,6 +54,7 @@ module Test.QuickCheck.Extra
       -- * Generating and shrinking maps
     , genMapWith
     , genMapFromKeysWith
+    , shrinkMapToSubmaps
     , shrinkMapWith
     , shrinkMapValuesWith
 
@@ -609,6 +610,21 @@ genMapWith genKey genValue =
 genMapFromKeysWith :: Ord k => Gen v -> Set k -> Gen (Map k v)
 genMapFromKeysWith genValue =
     fmap Map.fromList . mapM (\k -> (k,) <$> genValue) . Set.toList
+
+-- | Shrinks a 'Map' to list of proper submaps.
+--
+-- Satisfies the following property:
+--
+-- @
+-- all (`Map.isProperSubmapOf` m) (shrinkMapToSubmaps m)
+-- @
+--
+shrinkMapToSubmaps :: Ord k => Map k v -> [Map k v]
+shrinkMapToSubmaps =
+    shrinkMapBy Map.fromList Map.toList shrinkListToSublist
+  where
+    shrinkListToSublist :: [a] -> [[a]]
+    shrinkListToSublist = shrinkList (const [])
 
 -- | Shrinks a 'Map' with the given key and value shrinking functions.
 --

--- a/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
@@ -100,6 +100,7 @@ import Test.QuickCheck.Extra
     , selectMapEntries
     , selectMapEntry
     , shrinkDisjointPair
+    , shrinkMapToSubmaps
     , shrinkSpace
     , shrinkWhile
     , shrinkWhileSteps
@@ -188,6 +189,17 @@ spec = describe "Test.QuickCheck.ExtraSpec" $ do
                     @Int @Int & property
             it "prop_selectMapEntries_union" $
                 prop_selectMapEntries_union
+                    @Int @Int & property
+
+    describe "Generating and shrinking associative maps" $ do
+
+        describe "Shrinking" $ do
+
+            it "prop_shrinkMapToSubmaps_all_isProperSubmapOf" $
+                prop_shrinkMapToSubmaps_all_isProperSubmapOf
+                    @Int @Int & property
+            it "prop_shrinkMapToSubmaps_unique" $
+                prop_shrinkMapToSubmaps_unique
                     @Int @Int & property
 
     describe "Evaluating shrinkers" $ do
@@ -697,6 +709,36 @@ prop_selectMapEntries_union m0 (Positive (Small i)) =
         cover 1 (length kvs == 0)
             "number of selected entries = 0" $
         Map.fromList kvs `Map.union` m1 === m0
+
+--------------------------------------------------------------------------------
+-- Shrinking associative maps
+--------------------------------------------------------------------------------
+
+prop_shrinkMapToSubmaps_all_isProperSubmapOf
+    :: (Ord k, Eq v)
+    => Map k v
+    -> Property
+prop_shrinkMapToSubmaps_all_isProperSubmapOf m =
+    all (`Map.isProperSubmapOf` m) (shrinkMapToSubmaps m)
+        ===
+        True
+    & cover 10
+        (length (shrinkMapToSubmaps m) >= 10)
+        "length (shrinkMapToSubmaps m) >= 10"
+    & checkCoverage
+
+prop_shrinkMapToSubmaps_unique
+    :: (Ord k, Ord v)
+    => Map k v
+    -> Property
+prop_shrinkMapToSubmaps_unique m =
+    length (shrinkMapToSubmaps m)
+        ===
+        length (Set.fromList (shrinkMapToSubmaps m))
+    & cover 10
+        (length (shrinkMapToSubmaps m) >= 10)
+        "length (shrinkMapToSubmaps m) >= 10"
+    & checkCoverage
 
 --------------------------------------------------------------------------------
 -- Generating sequences of shrunken values


### PR DESCRIPTION
This PR adds a shrinker function `shrinkMapToSubmaps` to `Test.QuickCheck.Extra`:

```hs
-- | Shrinks a 'Map' to list of proper submaps.
--
-- Satisfies the following property:
--
-- @
-- all (`Map.isProperSubmapOf` m) (shrinkMapToSubmaps m)
-- @
--
shrinkMapToSubmaps :: Ord k => Map k v -> [Map k v]
```

### Issue

ADP-3272