### PR TITLE
[ADP-3244] Use `AddressState` from `customer-deposit-wallet-pure`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -156,6 +156,17 @@ source-repository-package
     --sha256: 04q58c82wy6x9nkwqbvcxbv6s61fx08h5kf62sb511aqp08id4bb
     subdir: generated
 
+source-repository-package
+    type: git
+    location: https://github.com/cardano-foundation/cardano-wallet-agda
+    tag: 33702851de8b846cc0bb9c48ee24c987e6d02c01
+    --sha256: 0qiffp4dgz2c8wjjs4qk8g307a8li2lcczbdzinfcyxn0q01pcvy
+    subdir: lib/customer-deposit-wallet-pure
+
+-- With (semi-circular) dependency on cardano-wallet-read:
+-- tag: 1b2b22f68b7535d055b91753b68c92a2b2596038
+-- --sha256: 0yqga8hv66xxmd724pwyr4jdd98s5w3mc35sfzkpaywivi8g3kxx
+
 --------------------------------------------------------------------------------
 -- BEGIN Constraints tweaking section
 

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -61,6 +61,7 @@ library
     , delta-types
     , io-classes
     , iohk-monitoring-extra
+    , OddWord
     , persistent
     , sqlite-simple
     , text
@@ -86,6 +87,8 @@ test-suite unit
   main-is:            test-suite-unit.hs
   build-depends:
     , base
+    , bytestring
+    , cardano-crypto
     , cardano-wallet:cardano-wallet
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
@@ -109,6 +112,7 @@ test-suite scenario
     -pgmL markdown-unlit
   build-depends:
     , base
+    , bytestring
     , cardano-crypto
     , cardano-wallet-test-utils
     , containers

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -56,6 +56,7 @@ library
     , cardano-ledger-byron
     , containers
     , contra-tracer
+    , customer-deposit-wallet-pure
     , delta-store
     , delta-types
     , io-classes

--- a/lib/customer-deposit-wallet/http/Cardano/Wallet/Deposit/HTTP/Types/JSON.hs
+++ b/lib/customer-deposit-wallet/http/Cardano/Wallet/Deposit/HTTP/Types/JSON.hs
@@ -76,13 +76,13 @@ deriving via ViaText Address instance ToJSON (ApiT Address)
 
 -- Customer
 instance FromHttpApiData (ApiT Customer) where
-    parseUrlPiece = fmap ApiT . fromText'
+    parseUrlPiece = fmap (ApiT . toEnum) . fromText'
 
 instance FromJSON (ApiT Customer) where
-    parseJSON = fmap ApiT . parseJSON
+    parseJSON = fmap (ApiT . toEnum) . parseJSON
 
 instance ToJSON (ApiT Customer) where
-    toJSON = toJSON . unApiT
+    toJSON = toJSON . fromEnum . unApiT
 
 -- | 'fromText' but with a simpler error type.
 fromText' :: FromText a => Text -> Either Text a

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -33,6 +33,9 @@ import Prelude
 import Cardano.Crypto.Wallet
     ( XPub
     )
+import Cardano.Wallet.Address.BIP32
+    ( BIP32Path
+    )
 import Cardano.Wallet.Deposit.Pure
     ( Customer
     , WalletState
@@ -207,7 +210,7 @@ createPayment a w =
     Wallet.createPayment a <$> readWalletState w
 
 getBIP32PathsForOwnedInputs
-    :: Write.TxBody -> WalletInstance -> IO [()]
+    :: Write.TxBody -> WalletInstance -> IO [BIP32Path]
 getBIP32PathsForOwnedInputs a w =
     Wallet.getBIP32PathsForOwnedInputs a <$> readWalletState w
 

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -10,6 +10,7 @@ module Cardano.Wallet.Deposit.IO
     -- * Operations
     -- ** Initialization
     , withWalletInit
+    , Word31
     , withWalletLoad
 
     -- ** Mapping between customers and addresses
@@ -35,6 +36,7 @@ import Cardano.Crypto.Wallet
 import Cardano.Wallet.Deposit.Pure
     ( Customer
     , WalletState
+    , Word31
     )
 import Cardano.Wallet.Deposit.Read
     ( Address
@@ -108,7 +110,7 @@ readWalletState WalletInstance{env,walletState} =
 withWalletInit
     :: WalletEnv IO
     -> XPub
-    -> Integer
+    -> Word31
     -> (WalletInstance -> IO a)
     -> IO a
 withWalletInit env@WalletEnv{..} xpub knownCustomerCount action = do

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/UTxO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/UTxO.hs
@@ -2,7 +2,9 @@ module Cardano.Wallet.Deposit.Pure.UTxO
     ( UTxO
     , balance
     , excluding
+    , restrictedBy
     , filterByAddress
+    , toList
 
     , DeltaUTxO
     , excludingD

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -17,6 +17,7 @@ module Cardano.Wallet.Deposit.Read
     , Ix
     , TxIn
     , TxOut
+    , address
     , Value
     , UTxO
 
@@ -59,6 +60,7 @@ import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
+import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
 import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
 import qualified Data.ByteString as BS
@@ -107,6 +109,9 @@ type TxIn = W.TxIn
 
 -- type TxOut = (Addr, Value)
 type TxOut = W.TxOut
+
+address :: TxOut -> Address
+address = TxOut.address
 
 type Value = W.TokenBundle
 

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -10,6 +10,8 @@ module Cardano.Wallet.Deposit.Read
 
     , Addr
     , Address
+    , fromRawAddress
+    , toRawAddress
     , mockAddress
 
     , Ix
@@ -85,6 +87,12 @@ type Addr = W.Address
 -- The ledger specifications define @Addr@.
 -- Byron addresses are represented by @Addr_bootstrap@.
 type Address = Addr
+
+fromRawAddress :: BS.ByteString -> Address
+fromRawAddress = W.Address
+
+toRawAddress :: Address -> BS.ByteString
+toRawAddress (W.Address a) = a
 
 mockAddress :: Show a => a -> Address
 mockAddress = W.Address . B8.pack . show

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
@@ -40,6 +40,9 @@ import Cardano.Wallet.Deposit.IO.Network.Mock
 import Cardano.Wallet.Deposit.IO.Network.Type
     ( NetworkEnv (..)
     )
+import Cardano.Wallet.Deposit.Pure
+    ( BIP32Path
+    )
 import Control.Tracer
     ( nullTracer
     )
@@ -128,9 +131,8 @@ payFromFaucet env destinations =
 {-----------------------------------------------------------------------------
     Transaction submission
 ------------------------------------------------------------------------------}
-type Path = ()
 
-signTx :: XPrv -> [Path] -> Write.TxBody -> Write.Tx
+signTx :: XPrv -> [BIP32Path] -> Write.TxBody -> Write.Tx
 signTx _ _ txbody =
     Write.Tx
         { Write.txbody = txbody

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Run.hs
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Run.hs
@@ -12,6 +12,8 @@ import Prelude
 
 import Cardano.Crypto.Wallet
     ( XPub
+    , generate
+    , toXPub
     )
 import Test.Hspec
     ( SpecWith
@@ -32,6 +34,7 @@ import Test.Scenario.Blockchain
     )
 
 import qualified Cardano.Wallet.Deposit.IO as Wallet
+import qualified Data.ByteString.Char8 as B8
 import qualified Test.Scenario.Wallet.Deposit.Exchanges as Exchanges
 
 main :: IO ()
@@ -63,7 +66,9 @@ scenarios = do
                     testBalance env
 
 xpub :: XPub
-xpub = error "todo: xpub"
+xpub =
+    toXPub
+    $ generate (B8.pack "random seed for a testing xpub lala") B8.empty
 
 testBalance
     :: ScenarioEnv -> Wallet.WalletInstance -> IO ()


### PR DESCRIPTION
This pull request changes the deposit wallet implementation in `Cardano.Wallet.Deposit.Pure` to use the `AddressState` type from the [customer-deposit-wallet-pure](https://github.com/cardano-foundation/cardano-wallet-agda). This type was generated from Agda code using `agda2hs`.

### Comments

* The `AddressState` type uses `ByteString` to represent addresses. We currently cannot depend on `cardano-wallet-read` in the other repository, because this would cause a circular dependency between the two repositories. This is not an issue for very basic types like `Address`, but will be more complicated for more complex types such as `UTxO` or `TxBody`. That said, in order to prove something about functions involving those types, the `cardano-wallet-agda` repository will need to have access to them. The interim solution will be to move `cardano-wallet-read` to the `cardano-wallet-agda` repository.

### Issue Number

ADP-3244
