### PR TITLE
Fix e2e `"currency"` test

### DIFF
--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -473,6 +473,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
       payload_cs = [{ address: address,
                       amount: { quantity: 1_000_000_000, unit: 'lovelace' } }]
       coin_selection = SHELLEY.coin_selections.random(@wid, payload_cs)
+      print coin_selection if coin_selection['inputs'].nil?
       input = coin_selection['inputs'].select { |i| i['assets'] == [] }.first
       tx_id = input['id']
       tx_idx = input['index'].to_i

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -471,7 +471,7 @@ RSpec.describe 'Cardano Wallet E2E tests', :all, :e2e do
       # Perform coin selection to select input to be used in minting contract
       address = SHELLEY.addresses.list(@wid)[0]['id']
       payload_cs = [{ address: address,
-                      amount: { quantity: 1_000_000_000, unit: 'lovelace' } }]
+                      amount: { quantity: 10_000_000, unit: 'lovelace' } }]
       coin_selection = SHELLEY.coin_selections.random(@wid, payload_cs)
       print coin_selection if coin_selection['inputs'].nil?
       input = coin_selection['inputs'].select { |i| i['assets'] == [] }.first


### PR DESCRIPTION
- [x] Alleviate the following failure in the e2e tests

```
1) Cardano Wallet E2E tests E2E Balance -> Sign -> Submit currency
     Failure/Error: input = coin_selection['inputs'].select { |i| i['assets'] == [] }.first

     NoMethodError:
       private method `select' called for nil:NilClass

             input = coin_selection['inputs'].select { |i| i['assets'] == [] }.first
                                             ^^^^^^^
     # ./spec/e2e_spec.rb:476:in `block (3 levels) in <top (required)>'
```

by making it easier to find an UTxO from the wallet.

New (about to be) passing run: https://github.com/cardano-foundation/cardano-wallet/actions/runs/8943585972


### Debug details

- [Failure on master](https://github.com/cardano-foundation/cardano-wallet/actions/runs/8903361781/job/24450976372)
- [Run with extra logs](https://github.com/cardano-foundation/cardano-wallet/actions/runs/8941664115/job/24562523942)

<details>
    <summary>UTxO ada amounts of wallet associated with test failure</summary>

https://preprod.cexplorer.io/address/addr_test1qp9juu544jrkel0hp6pvrjud70h9ev3ajw2fuvezyv8ug3eg3292mxuf3kq7nysjumlxjrlsfn9tp85r0l54l29x3qcsytvx58/utxo#data

```
[
  24.08152,
  24.08152,
  24.08152,
  24.08152,
  24.08152,
  24.08152,
  24.08152,
  24.08152,
  24.08152,
  24.08152,
  24.08152,
  24.08152,
  24.08152,
  10,
  10,
  24.08152,
  24.08152,
  10,
  24.08152,
  24.08152,
  10,
  10,
  10,
  24.08152,
  10,
  24.08152,
  10,
  24.08152,
  24.08152,
  10,
  24.08152,
  24.08152,
  10,
  10,
  24.08152,
  24.08152,
  10,
  10,
  10,
  24.08152,
  10,
  24.08152,
  10,
  24.08152,
  10,
  10,
  24.08152,
  10,
  10,
  10,
  24.08152,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  24.08152,
  10,
  10,
  10,
  10,
  24.08152,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  24.08152,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  24.08152,
  10,
  10,
  10,
  10,
  10,
  10,
  24.08152,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  10,
  10
]
```

</details>

### Issue Number

ADP-3358
