### PR TITLE
[ADP-3272] Add generator functions `genNonEmptyDisjoint{Set,Map}`.

### DIFF
--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -57,6 +57,7 @@ module Test.QuickCheck.Extra
       -- * Generating and shrinking maps
     , genMapWith
     , genMapFromKeysWith
+    , genNonEmptyDisjointMap
     , shrinkMapToSubmaps
     , shrinkMapWith
     , shrinkMapValuesWith
@@ -633,6 +634,18 @@ genMapWith genKey genValue =
 genMapFromKeysWith :: Ord k => Gen v -> Set k -> Gen (Map k v)
 genMapFromKeysWith genValue =
     fmap Map.fromList . mapM (\k -> (k,) <$> genValue) . Set.toList
+
+-- | Generates a non-empty 'Map' that is disjoint to an existing 'Map'.
+--
+-- The size of the resultant map depends on the implicit size parameter.
+--
+-- Caution: if the given key generator is incapable of generating keys that are
+-- outside the existing map's domain, then this function will not terminate.
+--
+genNonEmptyDisjointMap :: Ord k => Gen k -> Gen v -> Map k v -> Gen (Map k v)
+genNonEmptyDisjointMap genKey genValue existingMap =
+    genMapFromKeysWith genValue =<<
+    genNonEmptyDisjointSet genKey (Map.keysSet existingMap)
 
 -- | Shrinks a 'Map' to list of proper submaps.
 --

--- a/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/QuickCheck/ExtraSpec.hs
@@ -92,6 +92,7 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Extra
     ( Pretty (..)
+    , genNonEmptyDisjointMap
     , genNonEmptyDisjointSet
     , genShrinkSequence
     , genericRoundRobinShrink
@@ -205,6 +206,15 @@ spec = describe "Test.QuickCheck.ExtraSpec" $ do
                     @Int & property
 
     describe "Generating and shrinking associative maps" $ do
+
+        describe "Generation" $ do
+
+            it "prop_genNonEmptyDisjointMap_disjoint" $
+                prop_genNonEmptyDisjointMap_disjoint
+                    @Int @Int & property
+            it "prop_genNonEmptyDisjointMap_nonEmpty" $
+                prop_genNonEmptyDisjointMap_nonEmpty
+                    @Int @Int & property
 
         describe "Shrinking" $ do
 
@@ -614,6 +624,36 @@ prop_genNonEmptyDisjointSet_nonEmpty set1 =
         & cover 10
             (Set.size set1 >= 10 && Set.size set2 >= 10)
             "Set.size set1 >= 10 && Set.size set2 >= 10"
+        & checkCoverage
+
+--------------------------------------------------------------------------------
+-- Generating maps
+--------------------------------------------------------------------------------
+
+prop_genNonEmptyDisjointMap_disjoint
+    :: (Arbitrary k, Show k, Ord k)
+    => (Arbitrary v, Show v, Eq v)
+    => Map k v
+    -> Property
+prop_genNonEmptyDisjointMap_disjoint map1 =
+    forAll (genNonEmptyDisjointMap arbitrary arbitrary map1) $ \map2 ->
+        Map.intersectionWith (,) map1 map2 === Map.empty
+        & cover 10
+            (Map.size map1 >= 10 && Map.size map2 >= 10)
+            "Map.size map1 >= 10 && Map.size map2 >= 10"
+        & checkCoverage
+
+prop_genNonEmptyDisjointMap_nonEmpty
+    :: (Arbitrary k, Show k, Ord k)
+    => (Arbitrary v, Show v, Eq v)
+    => Map k v
+    -> Property
+prop_genNonEmptyDisjointMap_nonEmpty map1 =
+    forAll (genNonEmptyDisjointMap arbitrary arbitrary map1) $ \map2 ->
+        Map.size map2 =/= 0
+        & cover 10
+            (Map.size map1 >= 10 && Map.size map2 >= 10)
+            "Map.size map1 >= 10 && Map.size map2 >= 10"
         & checkCoverage
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds the following generators to `Test.QuickCheck.Extra`:

```hs
genNonEmptyDisjointSet :: Ord a =>          Gen a -> Set   a -> Gen (Set   a)
genNonEmptyDisjointMap :: Ord k => Gen k -> Gen v -> Map k v -> Gen (Map k v)
```

These functions are useful in situations where you have a pre-existing `Set` (or `Map`), and you want to generate another `Set` (or `Map`) that is guaranteed to be non-empty and disjoint to the original.

## Issue

ADP-3272