### PR TITLE
[ADP-322] Simplify functions within  `AES256CBC`.

### DIFF
--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -172,9 +172,4 @@ decrypt mode key iv msg = do
 getSaltFromEncrypted :: ByteString -> Maybe ByteString
 getSaltFromEncrypted msg = do
     when (BS.length msg < 32) Nothing
-    let (prefix,rest) = BS.splitAt 8 msg
-    let saltDetected = prefix == saltPrefix
-    if saltDetected then
-        Just $ BS.take saltLengthBytes rest
-    else
-        Nothing
+    BS.take saltLengthBytes <$> BS.stripPrefix saltPrefix msg

--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -129,12 +129,6 @@ encrypt mode keyBytes ivBytes saltM msg
             WithoutPadding -> id
             WithPadding -> PKCS7.pad
 
-saltLengthBytes :: Int
-saltLengthBytes = 8
-
-saltPrefix :: ByteString
-saltPrefix = "Salted__"
-
 -- | Decrypt using AES256 using CBC mode.
 decrypt
     :: CipherMode
@@ -168,6 +162,12 @@ decrypt mode key iv msg = do
     unpad p = case mode of
         WithoutPadding -> Right p
         WithPadding -> maybeToEither EmptyPayload (PKCS7.unpad p)
+
+saltLengthBytes :: Int
+saltLengthBytes = 8
+
+saltPrefix :: ByteString
+saltPrefix = "Salted__"
 
 getSaltFromEncrypted :: ByteString -> Maybe ByteString
 getSaltFromEncrypted msg

--- a/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
+++ b/lib/crypto-primitives/src/Cryptography/Cipher/AES256CBC.hs
@@ -170,6 +170,6 @@ decrypt mode key iv msg = do
         WithPadding -> maybeToEither EmptyPayload (PKCS7.unpad p)
 
 getSaltFromEncrypted :: ByteString -> Maybe ByteString
-getSaltFromEncrypted msg = do
-    when (BS.length msg < 32) Nothing
-    BS.take saltLengthBytes <$> BS.stripPrefix saltPrefix msg
+getSaltFromEncrypted msg
+    | BS.length msg < 32 = Nothing
+    | otherwise = BS.take saltLengthBytes <$> BS.stripPrefix saltPrefix msg


### PR DESCRIPTION
This PR:
- uses function [`stripPrefix`](https://hackage.haskell.org/package/bytestring-0.12.1.0/docs/Data-ByteString.html#v:stripPrefix) to replace usages of [`splitAt`](https://hackage.haskell.org/package/bytestring-0.12.1.0/docs/Data-ByteString.html#v:splitAt) that require further equality checks.
- defines a named constant `saltLengthBytes = 8` to avoid repetition of the magic constant `8`.

## Issue

ADP-322
