### PR TITLE
[ADP-3358] Remove underscores from integer literals in `swagger.yaml`.

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -4111,7 +4111,7 @@ x-parametersIntendedStakeAmount: &parametersIntendedStakeAmount
   schema:
     type: integer
     minimum: 0
-    maximum: 45_000_000_000_000_000 # 45 B ada (in Lovelace)
+    maximum: 45000000000000000 # 45 B ada (in Lovelace)
   description: |
     The stake the user intends to delegate in Lovelace. Required.
 


### PR DESCRIPTION
This PR removes underscores from integer literals in `swagger.yaml`:
```patch
-   maximum: 45_000_000_000_000_000
+   maximum: 45000000000000000
```

## Justification

As part of the release process for `cardano-wallet`, we transform the API specification (`swagger.yaml`) to JSON format with the following script:

https://github.com/cardano-foundation/cardano-wallet/blob/6dc7c0389eb2866485fd0e57a33f04f9c9cd1cce/scripts/gh/update-bump.sh#L15

The above script uses the `yq` tool to perform this transformation.

Recent versions of the `yq` tool fail with a `ParseInt` error if there are underscores within integer literals:
```
$ yq --version
yq (https://github.com/mikefarah/yq/) version v4.40.5
```
```
$ yq eval specifications/api/swagger.yaml -o=json
Error: json: error calling MarshalJSON for type *yqlib.CandidateNode:
json: error calling MarshalJSON for type *yqlib.CandidateNode: json:
error calling MarshalJSON for type *yqlib.CandidateNode:
strconv.ParseInt: parsing "45_000_000_000_000_000": invalid syntax
```

Removing underscores prevents these errors.

## Example failure

https://github.com/cardano-foundation/cardano-wallet/actions/runs/9026615038/job/24804201846#step:5:9

## Issue

ADP-3358