### PR TITLE
[ADP-3358] Fix swagger to JSON transformation in `update-bump.sh`

### DIFF
--- a/scripts/gh/update-bump.sh
+++ b/scripts/gh/update-bump.sh
@@ -12,7 +12,7 @@ bump_swagger() {
   bump "$1" --doc "$BUMP_SH_DOC_ID" --token "$BUMP_SH_TOKEN" specifications/api/swagger.json
 }
 
-yq eval specifications/api/swagger.yaml -j > specifications/api/swagger.json
+yq eval specifications/api/swagger.yaml -o=json > specifications/api/swagger.json
 
 bump_swagger validate
 bump_swagger deploy


### PR DESCRIPTION
This PR fixes the transformation from swagger to JSON format in `update-bump.sh`.

When calling `jq`, we now use `-o=json` instead of `-j`.

The `-j` flag is shortform for `--tojson`, which has been **_deprecated_**:

```
Flag --tojson has been deprecated, please use -o=json instead
```

## Example
https://github.com/cardano-foundation/cardano-wallet/actions/runs/9026615038/job/24804201846#step:5:8

## Issue
ADP-3358