### PR TITLE
[ADP-3305] Add --faucet-funds parameter to local cluster exe

### DIFF
--- a/lib/local-cluster/exe/local-cluster.hs
+++ b/lib/local-cluster/exe/local-cluster.hs
@@ -59,7 +59,8 @@ import Control.Monad.IO.Class
     ( MonadIO (..)
     )
 import Control.Tracer
-    ( traceWith
+    ( nullTracer
+    , traceWith
     )
 import Data.Text
     ( Text
@@ -233,11 +234,13 @@ main = withUtf8 $ do
         parseCommandLineOptions
     evalContT $ do
         -- Add a tracer for the cluster logs
-        ToTextTracer tracer <-
-            ContT
-                $ newToTextTracer
-                    (toFilePath . absFileOf <$> clusterLogs)
-                    minSeverity
+        ToTextTracer tracer <- case clusterLogs of
+            Nothing -> pure $ ToTextTracer nullTracer
+            Just path ->
+                ContT
+                    $ newToTextTracer
+                        (toFilePath . absFileOf $ path)
+                        minSeverity
 
         let debug :: MonadIO m => Text -> m ()
             debug = liftIO . traceWith tracer

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/CommandLine.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/CommandLine.hs
@@ -63,6 +63,7 @@ data CommandLineOptions = CommandLineOptions
     , minSeverity :: Maybe Severity
     , nodeToClientSocket :: Maybe (FileOf "node-to-client-socket")
     , httpService :: ServiceConfiguration
+    , faucetFunds :: FileOf "faucet-funds"
     }
     deriving stock (Show)
 
@@ -78,9 +79,19 @@ parseCommandLineOptions = do
                 <*> minSeverityParser
                 <*> nodeToClientSocketParser absolutizer
                 <*> monitoringParser
+                <*> faucetFundsParser absolutizer
                 <**> helper
             )
             (progDesc "Local Cluster for testing")
+
+faucetFundsParser :: Absolutizer -> Parser (FileOf "faucet-funds")
+faucetFundsParser (Absolutizer absOf) =
+    FileOf . absOf . absRel
+        <$> strOption
+            ( long "faucet-funds"
+                <> metavar "FAUCET_FUNDS"
+                <> help "Path to the faucet funds file"
+            )
 
 minSeverityParser :: Parser (Maybe Severity)
 minSeverityParser =

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Faucet/Gen.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Faucet/Gen.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Wno-missing-local-signatures #-}
+
+module Cardano.Wallet.Launch.Cluster.Faucet.Gen
+    ( genFaucetFunds
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Faucet.Gen.Address
+    ( NetworkTag
+    , genAddress
+    )
+import Cardano.Wallet.Launch.Cluster.Cluster
+    ( FaucetFunds (..)
+    )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..)
+    )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( fromFlatList
+    )
+import Cardano.Wallet.Primitive.Types.TokenPolicyId
+    ( TokenPolicyId (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenQuantity
+    ( TokenQuantity (..)
+    )
+import Cardano.Wallet.Unsafe
+    ( unsafeFromText
+    )
+import Control.Monad
+    ( replicateM
+    )
+import Data.ByteArray.Encoding
+    ( Base (..)
+    , convertToBase
+    )
+import Test.QuickCheck
+    ( Arbitrary (arbitrary)
+    , Gen
+    , choose
+    , vectorOf
+    )
+
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text.Encoding as T
+
+genFaucetFunds :: [NetworkTag] -> Gen FaucetFunds
+genFaucetFunds tags =
+    FaucetFunds
+        <$> generateAddrCoins
+        <*> generateMaryAllegraFunds
+        <*> generateAddrCoins
+  where
+    genCoin = Coin . fromIntegral <$> choose (1 :: Int, 1000000)
+    generateAddrCoins = do
+        n <- choose (1, 10)
+        replicateM n $ (,) <$> genAddress tags <*> genCoin
+    generateMaryAllegraFunds = do
+        n <- choose (1, 10)
+        replicateM n $ do
+            addr <- genAddress tags
+            coin <- genCoin
+            assets <- generateAssets
+            keys <- generateKeys
+            pure (addr, (fromFlatList coin assets, keys))
+    generateAssets = do
+        n <- choose (1, 10)
+        replicateM n $ do
+            policyId <-
+                UnsafeTokenPolicyId . Hash . B8.pack
+                    <$> vectorOf 28 arbitrary
+            assetNameLength <- choose (5, 16)
+            assetName <-
+                unsafeFromText
+                    . T.decodeUtf8
+                    . convertToBase Base16
+                    . B8.pack
+                    <$> vectorOf assetNameLength arbitrary
+            quantity <-
+                TokenQuantity . fromIntegral
+                    <$> choose (1 :: Int, 1000000)
+            pure (AssetId{..}, quantity)
+    generateKeys = do
+        n <- choose (1, 10)
+        replicateM n $ (,) <$> arbitrary <*> arbitrary

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Faucet/Serialize.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Faucet/Serialize.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Wallet.Launch.Cluster.Faucet.Serialize
+    ( retrieveFunds
+    , saveFunds
+    ) where
+
+import Prelude
+
+import Cardano.Address
+    ( bech32
+    , fromBech32
+    )
+import Cardano.Wallet.Launch.Cluster.Cluster
+    ( FaucetFunds (..)
+    )
+import Cardano.Wallet.Launch.Cluster.FileOf
+    ( FileOf
+    , absFilePathOf
+    )
+import Cardano.Wallet.Primitive.Types.AssetId
+    ( AssetId (..)
+    )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..)
+    )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle (..)
+    , fromFlatList
+    , toFlatList
+    )
+import Cardano.Wallet.Primitive.Types.TokenQuantity
+    ( TokenQuantity (..)
+    )
+import Data.Aeson
+    ( FromJSON (parseJSON)
+    , KeyValue ((.=))
+    , ToJSON (toJSON)
+    , Value (Number, Object, String)
+    , object
+    , withObject
+    , (.:)
+    )
+import Data.Aeson.Types
+    ( Parser
+    )
+import Data.Bifunctor
+    ( Bifunctor (..)
+    )
+import UnliftIO
+    ( SomeException
+    , catch
+    )
+
+import qualified Data.Text as T
+import qualified Data.Yaml as Y
+
+newtype FaucetFundsYaml = FaucetFundsYaml {getFaucetFunds :: FaucetFunds}
+
+instance Y.FromJSON FaucetFundsYaml where
+    parseJSON = fmap FaucetFundsYaml . faucetFundsFromValue
+
+instance Y.ToJSON FaucetFundsYaml where
+    toJSON (FaucetFundsYaml funds) = faucetFundsToValue funds
+
+faucetFundsToValue :: FaucetFunds -> Value
+faucetFundsToValue FaucetFunds{..} =
+    object
+        [ "pureAdaFunds" .= pureAdaFunds'
+        , "maryAllegraFunds" .= maryAllegraFunds'
+        , "massiveWalletFunds" .= massiveWalletFunds'
+        ]
+  where
+    pureAdaFunds' = encodeAddrCoins pureAdaFunds
+    maryAllegraFunds' =
+        map
+            (bimap bech32 encodeTokenBundle)
+            maryAllegraFunds
+    massiveWalletFunds' = encodeAddrCoins massiveWalletFunds
+    encodeAddrCoins = map (\(addr, Coin coin) -> (bech32 addr, coin))
+
+    -- encodeTokenBundle :: (TokenBundle, [(String, String)]) -> Value
+    -- encodeTokenBundle (bundle, keys) =
+    --     let (Coin c, assets) = toFlatList bundle
+    --     in  object
+    --             [ "coin" .= c
+    --             , "assets" .= (encodeAssets <$> assets)
+    --             , "keys" .= keys
+    --             ]
+    encodeTokenBundle :: (TokenBundle, [(String, String)]) -> Value
+    encodeTokenBundle (bundle, keys) =
+        let (Coin c, assets) = toFlatList bundle
+        in  object
+                [ "coin" .= c
+                , "assets" .= (encodeAssets <$> assets)
+                , "keys" .= toJSON (map encodeKeyPair keys)
+                ]
+    encodeKeyPair :: (String, String) -> Value
+    encodeKeyPair (x, y) =
+        object
+            [ "signingKey" .= x
+            , "verificationKeyHash" .= y
+            ]
+
+    encodeAssets :: (AssetId, TokenQuantity) -> Value
+    encodeAssets (AssetId policyId assetName, q) =
+        object
+            [ "policyId" .= policyId
+            , "assetName" .= assetName
+            , "quantity" .= q
+            ]
+
+retrieveFunds :: FileOf "faucet-funds" -> IO FaucetFunds
+retrieveFunds fp = catch
+    (getFaucetFunds <$> Y.decodeFileThrow (absFilePathOf fp))
+    $ \(e :: SomeException) ->
+        fail $ "Failed to read faucet funds from file: " <> show e
+
+saveFunds :: FileOf "faucet-funds" -> FaucetFunds -> IO ()
+saveFunds fp = Y.encodeFile (absFilePathOf fp) . FaucetFundsYaml
+
+faucetFundsFromValue :: Value -> Parser FaucetFunds
+faucetFundsFromValue = withObject "FaucetFunds" $ \o -> do
+    adaFunds <- o .: "pureAdaFunds" >>= decodeAddrCoins
+    allegraFunds <- o .: "maryAllegraFunds" >>= decodeMaryAllegraFunds
+    massiveFunds <- o .: "massiveWalletFunds" >>= decodeAddrCoins
+    pure $ FaucetFunds adaFunds allegraFunds massiveFunds
+  where
+    decodeAddr = \case
+        String addr -> case fromBech32 addr of
+            Nothing -> fail $ "Invalid address: " <> T.unpack addr
+            Just addr' -> pure addr'
+        _ -> fail "Invalid address"
+    decodeAddrCoins = traverse $ \case
+        (addr, Number c) -> do
+            addr' <- decodeAddr addr
+            pure (addr', Coin $ floor c)
+        _ -> fail "Invalid address/coin pair"
+    decodeMaryAllegraFunds = traverse decodeMaryAllegraFund
+    decodeMaryAllegraFund = \case
+        (addr, Object o) -> do
+            addr' <- decodeAddr addr
+            cain <- Coin <$> o .: "coin"
+            assets <- o .: "assets" >>= decodeAssets
+            keys <- o .: "keys" >>= decodeKeys
+            pure (addr', (fromFlatList cain assets, keys))
+        _ -> fail "Invalid address/bundle pair"
+    decodeAssets = traverse $ withObject "assets" $ \o -> do
+        policyId <- o .: "policyId"
+        assetName <- o .: "assetName"
+        quantity <- o .: "quantity"
+        pure (AssetId policyId assetName, quantity)
+    decodeKeys = traverse $ withObject "keys" $ \o -> do
+        signingKey <- o .: "signingKey"
+        verificationKeyHash <- o .: "verificationKeyHash"
+        pure (signingKey, verificationKeyHash)

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -173,7 +173,6 @@ executable local-cluster
 
   build-depends:
     , base
-    , cardano-addresses
     , cardano-wallet-application-extras
     , cardano-wallet-launcher
     , cardano-wallet-primitive
@@ -208,6 +207,7 @@ common test-common
     , foldl
     , hspec
     , hspec-golden
+    , iohk-monitoring-extra
     , local-cluster
     , mtl
     , openapi3

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -51,6 +51,8 @@ library
     Cardano.Wallet.Launch.Cluster.ConfiguredPool
     Cardano.Wallet.Launch.Cluster.Env
     Cardano.Wallet.Launch.Cluster.Faucet
+    Cardano.Wallet.Launch.Cluster.Faucet.Gen
+    Cardano.Wallet.Launch.Cluster.Faucet.Serialize
     Cardano.Wallet.Launch.Cluster.FileOf
     Cardano.Wallet.Launch.Cluster.GenesisFiles
     Cardano.Wallet.Launch.Cluster.Http.API
@@ -201,6 +203,7 @@ common test-common
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
     , contra-tracer
+    , extra
     , filepath
     , foldl
     , hspec
@@ -208,6 +211,7 @@ common test-common
     , local-cluster
     , mtl
     , openapi3
+    , pathtype
     , process
     , QuickCheck
     , time
@@ -219,6 +223,7 @@ common test-common
     , local-cluster:local-cluster
 
   other-modules:
+    Cardano.Wallet.Launch.Cluster.Faucet.SerializeSpec
     Cardano.Wallet.Launch.Cluster.Http.Faucet.APISpec
     Cardano.Wallet.Launch.Cluster.Http.Faucet.SendFaucetAssetsSpec
     Cardano.Wallet.Launch.Cluster.Http.Monitor.APISpec
@@ -229,6 +234,11 @@ common test-common
     Paths_local_cluster
     Spec
     SpecHook
+
+test-suite test-local-cluster
+  import:  test-common
+  main-is: test.hs
+  type:    exitcode-stdio-1.0
 
 executable test-local-cluster-exe
   import:  test-common

--- a/lib/local-cluster/test/unit/Cardano/Wallet/Launch/Cluster/Faucet/SerializeSpec.hs
+++ b/lib/local-cluster/test/unit/Cardano/Wallet/Launch/Cluster/Faucet/SerializeSpec.hs
@@ -1,0 +1,52 @@
+{-# OPTIONS_GHC -Wno-missing-local-signatures #-}
+module Cardano.Wallet.Launch.Cluster.Faucet.SerializeSpec
+    ( spec
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Faucet.Gen.Address
+    ( NetworkTag (..)
+    )
+import Cardano.Wallet.Launch.Cluster.Faucet.Gen
+    ( genFaucetFunds
+    )
+import Cardano.Wallet.Launch.Cluster.Faucet.Serialize
+    ( retrieveFunds
+    , saveFunds
+    )
+import Cardano.Wallet.Launch.Cluster.FileOf
+    ( FileOf (..)
+    )
+import System.IO.Extra
+    ( withTempFile
+    )
+import System.Path
+    ( absFile
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+import Test.QuickCheck
+    ( forAll
+    )
+
+spec :: Spec
+spec = do
+    describe "FaucetFunds serialization" $ do
+        let roundTripTest tag =
+                forAll (genFaucetFunds [tag])
+                    $ \funds ->
+                    withTempFile $ \fp -> do
+                        let file = FileOf . absFile $ fp
+                        saveFunds file funds
+                        funds' <- retrieveFunds file
+                        funds' `shouldBe` funds
+        it "should roundtrip for Testnet addresses"
+            $ roundTripTest TestnetTag
+        it "should roundtrip for Mainnet addresses"
+            $ roundTripTest MainnetTag

--- a/lib/wallet-e2e/src/Cardano/Wallet/Spec.hs
+++ b/lib/wallet-e2e/src/Cardano/Wallet/Spec.hs
@@ -75,7 +75,7 @@ configureTestNet testNetworkConfig withConfiguredNetwork = runResourceT $ do
         TestNetworkManual ->
             pure Manual.configuredNetwork
         TestNetworkLocal stateDir nodeConfigDir ->
-            Local.configuredNetwork stateDir nodeConfigDir
+            Local.configuredNetwork stateDir nodeConfigDir Nothing
         TestNetworkPreprod stateDir nodeConfigDir ->
             Preprod.configuredNetwork stateDir nodeConfigDir
     liftIO $ withConfiguredNetwork config


### PR DESCRIPTION
- [x] **Add `--faucet-funds` option to local-cluster exe** to pass the initial faucet funds to the application
- [x] **Add FaucetFunds serialization**
- [x] **Add FaucetFunds retrieval in the local-cluster exe**
- [x] **Add more logging reporting to the local-cluster tests**
- [x] **Add `--faucet-funds` to ServiceSpec**
- [x] **Add `--faucet-funds` support to wallet-e2e lib**

ADP-3305
