### PR TITLE
Increase `prop_balanceTxValid` coverage of success from 3% to 11%

### DIFF
--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1216,7 +1216,13 @@ prop_balanceTxValid
                     ">20 payment outputs"
                 . classify (length originalOuts > 100)
                     ">100 payment outputs"
-
+        let coverage res =
+                cover 10 (isRight res) "success"
+                -- We're not using 'checkCoverage', as we like to keep direct
+                -- control over the number of tests we run. We are also
+                -- intentionally keeping the "success" /label/ below for the
+                -- sake of preserving the pattern of (at least) one label per
+                -- case branch.
         let res =
                 testBalanceTx
                     wallet
@@ -1224,7 +1230,7 @@ prop_balanceTxValid
                     timeTranslation
                     seed
                     partialTx
-        classifications $ case res of
+        coverage res $ classifications $ case res of
             Right tx -> counterexample ("\nResult: " <> show (Pretty tx)) $ do
                 label "success"
                     $ classify (originalBalance == mempty)

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1217,12 +1217,7 @@ prop_balanceTxValid
                 . classify (length originalOuts > 100)
                     ">100 payment outputs"
         let coverage res =
-                cover 10 (isRight res) "success"
-                -- We're not using 'checkCoverage', as we like to keep direct
-                -- control over the number of tests we run. We are also
-                -- intentionally keeping the "success" /label/ below for the
-                -- sake of preserving the pattern of (at least) one label per
-                -- case branch.
+                checkCoverage . cover 8 (isRight res) "success"
         let res =
                 testBalanceTx
                     wallet

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -360,6 +360,7 @@ import Test.Hspec.QuickCheck
     )
 import Test.QuickCheck
     ( Arbitrary (..)
+    , Args (..)
     , Property
     , arbitraryBoundedEnum
     , arbitrarySizedNatural
@@ -374,10 +375,12 @@ import Test.QuickCheck
     , listOf
     , oneof
     , property
+    , quickCheckWith
     , scale
     , shrinkBoundedEnum
     , shrinkList
     , shrinkMapBy
+    , stdArgs
     , suchThat
     , tabulate
     , vectorOf
@@ -486,11 +489,14 @@ spec = do
 
 spec_balanceTx :: Spec
 spec_balanceTx = describe "balanceTx" $ do
+    let moreDiscardsAllowed = stdArgs { maxDiscardRatio = 100 }
     it "doesn't balance transactions with existing 'totalCollateral'"
-        $ property prop_balanceTxExistingTotalCollateral
+        $ quickCheckWith moreDiscardsAllowed
+            prop_balanceTxExistingTotalCollateral
 
     it "doesn't balance transactions with existing 'returnCollateral'"
-        $ property prop_balanceTxExistingReturnCollateral
+        $ quickCheckWith moreDiscardsAllowed
+            prop_balanceTxExistingReturnCollateral
 
     it "does not balance transactions if no inputs can be created"
         $ property prop_balanceTxUnableToCreateInput

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -486,8 +486,6 @@ spec = do
 
 spec_balanceTx :: Spec
 spec_balanceTx = describe "balanceTx" $ do
-    -- TODO: Create a test to show that datums are passed through...
-
     it "doesn't balance transactions with existing 'totalCollateral'"
         $ property prop_balanceTxExistingTotalCollateral
 

--- a/lib/cardano-api-extra/lib/Cardano/Api/Gen.hs
+++ b/lib/cardano-api-extra/lib/Cardano/Api/Gen.hs
@@ -509,8 +509,14 @@ genSlotNo32 = do
 genLovelace :: Gen Lovelace
 genLovelace =
     frequency
-        [ (10, Lovelace . intCast . getNonNegative @Int <$> arbitrary)
-        , (50, choose (1_000_000, 1_000_000_000))
+        [ (60, genLovelaceForTxOutAdaValue)
+        , (40, choose (1_000_000, 1_000_000_000))
+        ]
+
+genLovelaceForTxOutAdaValue :: Gen Lovelace
+genLovelaceForTxOutAdaValue =
+    frequency
+        [ (60, choose (1_000_000, 1_000_000_000))
         , (10, choose (txOutMinLovelace, txOutMaxLovelace))
         , (30, genEncodingBoundaryLovelace)
         ]
@@ -762,7 +768,7 @@ genValueForTxOut = do
             , pure []
             ]
     assetQuantities <- infiniteListOf genUnsignedQuantity
-    ada <- fromInteger . unLovelace <$> genLovelace
+    ada <- fromInteger . unLovelace <$> genLovelaceForTxOutAdaValue
     return $ valueFromList $ (AdaAssetId, ada) : zip assetIds assetQuantities
   where
     unLovelace (Lovelace l) = l

--- a/lib/cardano-api-extra/lib/Cardano/Api/Gen.hs
+++ b/lib/cardano-api-extra/lib/Cardano/Api/Gen.hs
@@ -615,16 +615,16 @@ genExtraKeyWitnesses era =
 
 genTxTotalCollateral :: CardanoEra era -> Gen (TxTotalCollateral era)
 genTxTotalCollateral era = withEraWitness era $ \supported ->
-    oneof
-        [ pure TxTotalCollateralNone
-        , TxTotalCollateral supported <$> genLovelace
+    frequency
+        [ (95, pure TxTotalCollateralNone)
+        , (5, TxTotalCollateral supported <$> genLovelace)
         ]
 
 genTxReturnCollateral :: CardanoEra era -> Gen (TxReturnCollateral ctx era)
 genTxReturnCollateral era = withEraWitness era $ \supported ->
-    oneof
-        [ pure TxReturnCollateralNone
-        , TxReturnCollateral supported <$> genTxOut era
+    frequency
+        [ (95, pure TxReturnCollateralNone)
+        , (5, TxReturnCollateral supported <$> genTxOut era)
         ]
 
 genPlutusScript :: PlutusScriptVersion lang -> Gen (PlutusScript lang)


### PR DESCRIPTION
- [x] Increase `prop_balanceTxValid` coverage of sucess from 3% to 11%
    - Generate fewer total- and return-collateral values (using `maxDiscardRatio` workaround 🎉 )
    - Generate fewer outputs with ada values below the minAda requirement
- [x] Add success `coverage` check along with `checkCoverage`

### Comments

Previously

```
          51.1% existing collateral return outputs
          24.1% existing total collateral
          11.7% output below minCoinValue
           5.2% shortfall of non-ada assets
           3.2% success
           1.9% input resolution conflicts
           1.0% shortfall of ada
           0.6% existing collateral
           0.6% maxTxSize limit exceeded
           0.5% shortfall of both ada and non-ada assets
           0.1% failed with ByronTxOutInContext
```

Now:

```
          43.2% shortfall of non-ada assets
          14.3% output below minCoinValue
          11.6% success
           7.3% maxTxSize limit exceeded
           5.3% input resolution conflicts
           5.2% shortfall of both ada and non-ada assets
           4.5% existing total collateral
           4.3% existing collateral return outputs
           2.5% shortfall of ada
           1.0% failed with ByronTxOutInContext
           0.4% ReferenceScriptsNotSupported
           0.4% existing collateral
```

### Issue Number

None. General maintenance.
