### PR TITLE
Use `method` for encryption method in `ApiEncryptMetadata`.

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types.hs
@@ -1245,7 +1245,7 @@ data ApiEncryptMetadataMethod = Basic
 
 data ApiEncryptMetadata = ApiEncryptMetadata
     { passphrase :: ApiT (Passphrase "lenient")
-    , enc :: Maybe ApiEncryptMetadataMethod
+    , method :: Maybe ApiEncryptMetadataMethod
     }
     deriving (Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via DefaultRecord ApiEncryptMetadata

--- a/lib/unit/test/data/Cardano/Wallet/Api/ApiEncryptMetadata.json
+++ b/lib/unit/test/data/Cardano/Wallet/Api/ApiEncryptMetadata.json
@@ -1,41 +1,41 @@
 {
     "samples": [
         {
-            "enc": "basic",
+            "method": "basic",
             "passphrase": "䬲&6~X#𱸴q𢮆r`⸅𫖨Pb.`G+ib!эHeC&w󠄐𩭚b)k|Q.𦽌J5\\:_~bx𲌬$W!𱫥hk}3?SyT^sSb*I6X렇H녔nO?}l_ T𣅞kOFCbdJ2%,jh=t嗺?nN(HE𢭰POⒹw҇CWk%𣵚]> j໘m\"_jWf#S𣀩𡯁[a𛲝𭟴"
         },
         {
             "passphrase": "五>q芠N^1;䐰*𱓞/纋;"
         },
         {
-            "enc": "basic",
+            "method": "basic",
             "passphrase": "WyLhQ4)Q2𩚬`V)cly$,+𠀖s{+qW12𠻉Xc㳬𢅮V*,m𬓄bw{4𨗍-S𬥈P(bGKRpqba&U3b鵄𦅫iu𰓦W#wMwA|)7L@쀇C괨v8𣨧D萀𦳶O쑀/Zў-忆JdF~;`;\"$𱯯8𬱽Ai~]nmk/䟷𱹗.CE迢'h5'K(𰓙"
         },
         {
-            "enc": "basic",
+            "method": "basic",
             "passphrase": ")24vcAoFr?~=^UZ뿳[!Km&1\\\"e𡣫A~#wiRria.gN𮷉ak0d`gCI]t\\wXe@u64pp𡸨繴W#{j+-8/BeXB/0꼲"
         },
         {
-            "enc": "basic",
+            "method": "basic",
             "passphrase": "m𭠬d𭦞$:䤠a]n;D2엦\"|3lUTurl]i?LX,sb3G烽fvC)1~D64𬼹$乔>h圹$V+9U|F𰰓Y🃫^/<𔑍SJ^#X_呅=^ap\"ZA+vgyD/^mc<6`𩆺𭑗⪮?Q')]5gh隡I\"XZ#p𐚮C^+𝙻\\F?鋌alen9X;𡸵DLYxTQYnd𞢗cU}]6\"𗒼7y3\"5#㚏=C4?X6r4i-&_乮𮜣剶>𢢉)R@+C뮲䗘_{䔒qT~<Y=*YX5M5{cOQ4Qa6&'Q𬣑Y%9貼kW每X}z𨅔(S鬘mz"
         },
         {
-            "enc": "basic",
+            "method": "basic",
             "passphrase": "=l痿b:*\\wS贯R"
         },
         {
-            "enc": "basic",
+            "method": "basic",
             "passphrase": "[kGmv"
         },
         {
-            "enc": "basic",
+            "method": "basic",
             "passphrase": "!DOq3𐢐v𗳨_녿1𭍁L*𦗖vr19⃝;qkoy𫇑慮ݔ5#Ⲧ?-錏e𨎏l9dE𑅗𣕗j88Qv1 𦒢j)**,/O@GQ𗶱땼𗓹䣔)R\\}&^OhF%h}𑠺3w𪩃=`kPpɉ,Pl@n2`&:(>_𮢈𐦆&穐𣯸jLe{&X?𣣌~7G~d,S𦚈9zmwhYLP.NWip2p\"RG💔[Q쵎"
         },
         {
             "passphrase": "5G+Y+qg17]j쎄𨲳D8aul𨞁HRk\"I𢈤xVi𲊔<𞄢;^l𘩲6PXlN#7𱗪c/?a1t]u𰤫𫓠&N\"𱑠}xnD튏𪱚𘄨!>𭪵'6]yP쁹𘧻D𠗹TQS𢦁sf a~>Au*tSNA𡄹F_﹈<)=T}pY5p'\\md`*dxv𗇁*d&Y䲗nsbn}/LX^f칳n]8tjYMjv_b킋f^H>XN^r𤴸z𡎓-q\"*B𭕛-jgl疋oC뇭_|v2R𮭴𢱤|]CGl祌?.[𗚝:𫢄핕F1J𰸾\\𭛝~,됟j\\𫮹W$ebWW!𦦯kA"
         },
         {
-            "enc": "basic",
+            "method": "basic",
             "passphrase": "b@$+},&m6💑y𧼭f_fGHk+z xqISX𬋼<l{M8검%nQ𞲙#Y𦁌4𝡕𥺷J1))hY-`#!^Ns𝐧(]𓈳Fa罻"
         }
     ],

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1199,7 +1199,7 @@ spec = do
         it "short msg - no salt" $ do
             let apiEncrypt = ApiEncryptMetadata
                     { passphrase = ApiT $ Passphrase "cardano"
-                    , enc = Nothing
+                    , method = Nothing
                     }
                 schemaBefore =
                     TxMetadataWithSchema TxMetadataNoSchema $
@@ -1243,7 +1243,7 @@ spec = do
         it "long msg - no salt" $ do
             let apiEncrypt = ApiEncryptMetadata
                     { passphrase = ApiT $ Passphrase "cardano"
-                    , enc = Nothing
+                    , method = Nothing
                     }
                 schemaBefore =
                     TxMetadataWithSchema TxMetadataNoSchema $
@@ -1291,7 +1291,7 @@ spec = do
         it "cip msg - no salt" $ do
             let apiEncrypt = ApiEncryptMetadata
                     { passphrase = ApiT $ Passphrase "cardano"
-                    , enc = Nothing
+                    , method = Nothing
                     }
                 schemaBefore =
                     TxMetadataWithSchema TxMetadataNoSchema $
@@ -1340,7 +1340,7 @@ spec = do
         it "short msg - salted" $ do
             let apiEncrypt = ApiEncryptMetadata
                     { passphrase = ApiT $ Passphrase "cardano"
-                    , enc = Nothing
+                    , method = Nothing
                     }
                 schemaBefore =
                     TxMetadataWithSchema TxMetadataNoSchema $
@@ -1385,7 +1385,7 @@ spec = do
         it "long msg - salted" $ do
             let apiEncrypt = ApiEncryptMetadata
                     { passphrase = ApiT $ Passphrase "cardano"
-                    , enc = Nothing
+                    , method = Nothing
                     }
                 schemaBefore =
                     TxMetadataWithSchema TxMetadataNoSchema $
@@ -1431,7 +1431,7 @@ spec = do
         it "cip msg - salted" $ do
             let apiEncrypt = ApiEncryptMetadata
                     { passphrase = ApiT $ Passphrase "cardano"
-                    , enc = Nothing
+                    , method = Nothing
                     }
                 schemaBefore =
                     TxMetadataWithSchema TxMetadataNoSchema $
@@ -1479,7 +1479,7 @@ spec = do
         it "msg wrong label - no salt" $ do
             let apiEncrypt = ApiEncryptMetadata
                     { passphrase = ApiT $ Passphrase "cardano"
-                    , enc = Nothing
+                    , method = Nothing
                     }
                 schemaBefore =
                     TxMetadataWithSchema TxMetadataNoSchema $
@@ -1505,7 +1505,7 @@ spec = do
         it "msg without 'msg field' - no salt" $ do
             let apiEncrypt = ApiEncryptMetadata
                     { passphrase = ApiT $ Passphrase "cardano"
-                    , enc = Nothing
+                    , method = Nothing
                     }
                 schemaBefore =
                     TxMetadataWithSchema TxMetadataNoSchema $

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -3555,10 +3555,10 @@ class GetPath api where
     getPath :: Proxy api -> (StdMethod, String)
 
 instance (Method m) => GetPath (Verb m s ct a) where
-    getPath _ = (method (Proxy @m), "")
+    getPath _ = (stdMethod (Proxy @m), "")
 
 instance (Method m) => GetPath (NoContentVerb m) where
-    getPath _ = (method (Proxy @m), "")
+    getPath _ = (stdMethod (Proxy @m), "")
 
 instance (KnownSymbol path, GetPath sub) => GetPath (path :> sub) where
     getPath _ =
@@ -3591,13 +3591,13 @@ instance GetPath sub => GetPath (Header' opts name ty :> sub) where
 -- A way to demote 'StdMethod' back to the world of values. Servant provides a
 -- 'reflectMethod' that does just that, but demote types to raw 'ByteString' for
 -- an unknown reason :/
-instance Method 'GET where method _ = GET
-instance Method 'POST where method _ = POST
-instance Method 'PUT where method _ = PUT
-instance Method 'DELETE where method _ = DELETE
-instance Method 'PATCH where method _ = PATCH
+instance Method 'GET where stdMethod _ = GET
+instance Method 'POST where stdMethod _ = POST
+instance Method 'PUT where stdMethod _ = PUT
+instance Method 'DELETE where stdMethod _ = DELETE
+instance Method 'PATCH where stdMethod _ = PATCH
 class Method (m :: StdMethod) where
-    method :: Proxy m -> StdMethod
+    stdMethod :: Proxy m -> StdMethod
 
 {-------------------------------------------------------------------------------
             Generating Golden Test Vectors For Address Encoding

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1810,7 +1810,7 @@ x-encryptMetadata: &encryptMetadata
   required:
     - passphrase
   properties:
-    enc: *encryptionMethod
+    method: *encryptionMethod
     passphrase: *lenientPassphrase
 
 x-transactionTTL: &transactionTTL


### PR DESCRIPTION
This PR changes the name for the encryption method field for `ApiEncryptMetadata` from `enc` to `method`.

## Justification

- In the context of the `cardano-wallet` HTTP API, it's idiomatic to use complete words instead of shortenings such as `enc`.
- The name `method` is consistent with the field type `ApiEncryptMetadataMethod`.
- The name `method` is (arguably) more self-documenting than `enc`.

## Issue

ADP-322