### PR TITLE
[ADP-3305] Expose RunningNode in local cluster api

### DIFF
--- a/lib/local-cluster/data/swagger.json
+++ b/lib/local-cluster/data/swagger.json
@@ -21,7 +21,7 @@
                                             "properties": {
                                                 "tag": {
                                                     "enum": [
-                                                        "RetrievingFunds"
+                                                        "retrieving-funds"
                                                     ],
                                                     "type": "string"
                                                 }
@@ -32,7 +32,7 @@
                                             "properties": {
                                                 "tag": {
                                                     "enum": [
-                                                        "Metadata"
+                                                        "metadata"
                                                     ],
                                                     "type": "string"
                                                 }
@@ -43,7 +43,7 @@
                                             "properties": {
                                                 "tag": {
                                                     "enum": [
-                                                        "Genesis"
+                                                        "genesis"
                                                     ],
                                                     "type": "string"
                                                 }
@@ -54,7 +54,7 @@
                                             "properties": {
                                                 "tag": {
                                                     "enum": [
-                                                        "Pool0"
+                                                        "pool0"
                                                     ],
                                                     "type": "string"
                                                 }
@@ -65,7 +65,7 @@
                                             "properties": {
                                                 "tag": {
                                                     "enum": [
-                                                        "Funding"
+                                                        "funding"
                                                     ],
                                                     "type": "string"
                                                 }
@@ -76,7 +76,7 @@
                                             "properties": {
                                                 "tag": {
                                                     "enum": [
-                                                        "Pools"
+                                                        "pools"
                                                     ],
                                                     "type": "string"
                                                 }
@@ -87,7 +87,7 @@
                                             "properties": {
                                                 "tag": {
                                                     "enum": [
-                                                        "Relay"
+                                                        "relay"
                                                     ],
                                                     "type": "string"
                                                 }
@@ -96,13 +96,33 @@
                                         },
                                         {
                                             "properties": {
-                                                "contents": {
-                                                    "description": "The socket file or pipe of a relay node",
-                                                    "type": "string"
+                                                "content": {
+                                                    "description": "A running node",
+                                                    "properties": {
+                                                        "genesis": {
+                                                            "additionalProperties": true,
+                                                            "type": "object"
+                                                        },
+                                                        "socket": {
+                                                            "type": "string"
+                                                        },
+                                                        "version": {
+                                                            "properties": {
+                                                                "magic": {
+                                                                    "type": "number"
+                                                                },
+                                                                "query": {
+                                                                    "type": "boolean"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "type": "object"
                                                 },
                                                 "tag": {
                                                     "enum": [
-                                                        "Cluster"
+                                                        "cluster"
                                                     ],
                                                     "type": "string"
                                                 }

--- a/lib/local-cluster/exe/local-cluster.hs
+++ b/lib/local-cluster/exe/local-cluster.hs
@@ -39,7 +39,6 @@ import Cardano.Wallet.Launch.Cluster.Http.Service
     )
 import Cardano.Wallet.Launch.Cluster.Monitoring.Phase
     ( Phase (..)
-    , RelayNode (..)
     )
 import Cardano.Wallet.Primitive.NetworkId
     ( NetworkId (..)
@@ -333,9 +332,7 @@ main = withUtf8 $ do
         liftIO
             $ traceWith phaseTracer
             $ Cluster
-            $ Just
-            $ RelayNode
-            $ toFilePath nodeSocket
+            $ Just node
 
         debug "Wait forever or ctrl-c"
         threadDelay maxBound

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Faucet/Serialize.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Faucet/Serialize.hs
@@ -83,14 +83,6 @@ faucetFundsToValue FaucetFunds{..} =
     massiveWalletFunds' = encodeAddrCoins massiveWalletFunds
     encodeAddrCoins = map (\(addr, Coin coin) -> (bech32 addr, coin))
 
-    -- encodeTokenBundle :: (TokenBundle, [(String, String)]) -> Value
-    -- encodeTokenBundle (bundle, keys) =
-    --     let (Coin c, assets) = toFlatList bundle
-    --     in  object
-    --             [ "coin" .= c
-    --             , "assets" .= (encodeAssets <$> assets)
-    --             , "keys" .= keys
-    --             ]
     encodeTokenBundle :: (TokenBundle, [(String, String)]) -> Value
     encodeTokenBundle (bundle, keys) =
         let (Coin c, assets) = toFlatList bundle

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Http/Client.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Http/Client.hs
@@ -89,7 +89,7 @@ withHttpClient
     -- ^ how to trace the http client operations
     -> PortNumber
     -- ^ Monitoring port to attach to (http://localhost is hardcoded)
-    -> ContT () m (RunMonitorQ m, RunFaucetQ m)
+    -> ContT r m (RunMonitorQ m, RunFaucetQ m)
 withHttpClient networkId tracer httpPort = ContT $ \continue -> do
     let tr = traceWith tracer
     tr MsgClientStart
@@ -111,6 +111,6 @@ withHttpClient networkId tracer httpPort = ContT $ \continue -> do
             query
             (MsgFaucetClient >$< tracer)
             $ mkFaucet networkId
-    continue (runQuery, runFaucet)
-
+    r <- continue (runQuery, runFaucet)
     tr MsgClientDone
+    pure r

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Http/Monitor/API.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Http/Monitor/API.hs
@@ -21,12 +21,23 @@ where
 
 import Prelude
 
+import Cardano.Launcher.Node
+    ( cardanoNodeConn
+    , nodeSocketFile
+    )
 import Cardano.Wallet.Launch.Cluster.Http.Monitor.OpenApi
     ( monitorStateSchema
     , observationSchema
     )
 import Cardano.Wallet.Launch.Cluster.Monitoring.Phase
     ( History (..)
+    , Phase (..)
+    )
+import Cardano.Wallet.Launch.Cluster.Node.RunningNode
+    ( RunningNode (..)
+    )
+import Control.Applicative
+    ( asum
     )
 import Control.Monitoring.Tracing
     ( MonitorState (..)
@@ -49,8 +60,17 @@ import Data.OpenApi
     ( NamedSchema (..)
     , ToSchema (..)
     )
+import Data.Text
+    ( Text
+    )
 import GHC.Generics
     ( Generic (..)
+    )
+import Ouroboros.Network.Magic
+    ( NetworkMagic (..)
+    )
+import Ouroboros.Network.NodeToClient
+    ( NodeToClientVersionData (..)
     )
 import Servant
     ( Post
@@ -62,6 +82,8 @@ import Servant.API
     , (:<|>)
     , (:>)
     )
+
+import qualified Data.Map as Map
 
 type ReadyAPI = "ready" :> Get '[JSON] Bool
 type StepAPI = "control" :> "step" :> PostNoContent
@@ -81,7 +103,52 @@ renderHistory History{history} = toJSON $ do
     pure
         $ object
             [ "time" .= time
-            , "phase" .= phase
+            , "phase" .= renderPhase phase
+            ]
+
+renderTagged :: Text -> Value
+renderTagged tagName =
+    object
+        [ "tag" .= tagName
+        ]
+
+renderTaggedWithContent :: Text -> (Maybe Value) -> Value
+renderTaggedWithContent tagName mContent =
+    object
+        $ [ "tag" .= tagName
+          ]
+            <> ["content" .= content | Just content <- [mContent]]
+
+renderPhase :: Phase -> Value
+renderPhase = \case
+    RetrievingFunds -> renderTagged "retrieving-funds"
+    Metadata -> renderTagged "metadata"
+    Genesis -> renderTagged "genesis"
+    Pool0 -> renderTagged "pool0"
+    Funding -> renderTagged "funding"
+    Pools -> renderTagged "pools"
+    Relay -> renderTagged "relay"
+    Cluster mNode -> renderTaggedWithContent "cluster" $ fmap renderNode mNode
+
+renderNode :: RunningNode -> Value
+renderNode
+    RunningNode
+        { runningNodeSocketPath
+        , runningNodeShelleyGenesis
+        , runningNodeVersionData =
+            NodeToClientVersionData
+                { networkMagic = NetworkMagic nm
+                , query
+                }
+        } =
+        object
+            [ "socket" .= nodeSocketFile runningNodeSocketPath
+            , "genesis" .= runningNodeShelleyGenesis
+            , "version"
+                .= object
+                    [ "magic" .= nm
+                    , "query" .= query
+                    ]
             ]
 
 parseHistory :: Value -> Parser History
@@ -91,8 +158,68 @@ parseHistory = withArray "History" $ \arr -> do
   where
     parsePhase = withObject "Phase" $ \o -> do
         time <- o .: "time"
-        phase <- o .: "phase"
+        phase <- o .: "phase" >>= parsePhase'
         pure (time, phase)
+
+type Tags a = [(Text, [Either a (Value -> Parser a)])]
+
+tag :: a -> b -> (a, [b])
+tag a b = (a, [b])
+
+tags :: a -> [b] -> (a, [b])
+tags a bs = (a, bs)
+
+parseTaggeds :: Tags a -> Value -> Parser a
+parseTaggeds ts = withObject "Tagged" $ \o -> do
+    t <- o .: "tag"
+    case Map.lookup t $ Map.fromList ts of
+        Just fs ->
+            let g :: Either a (Value -> Parser a) -> Parser a
+                g = \case
+                    Left a -> pure a
+                    Right f -> o .: "content" >>= f
+            in  asum $ g <$> fs
+        Nothing -> fail "Invalid tag"
+
+parsePhase' :: Value -> Parser Phase
+parsePhase' =
+    parseTaggeds
+        [ tag "retrieving-funds" $ Left RetrievingFunds
+        , tag "metadata" $ Left Metadata
+        , tag "genesis" $ Left Genesis
+        , tag "pool0" $ Left Pool0
+        , tag "funding" $ Left Funding
+        , tag "pools" $ Left Pools
+        , tag "relay" $ Left Relay
+        , tags "cluster" [Right parseNode, Left $ Cluster Nothing]
+        ]
+
+parseNode :: Value -> Parser Phase
+parseNode = withObject "RunningNode" $ \o -> do
+    socket <- o .: "socket"
+    genesis <- o .: "genesis"
+    version <- o .: "version" >>= parseVersionData
+    case cardanoNodeConn socket of
+        Left e -> fail e
+        Right nodeConn ->
+            pure
+                $ Cluster
+                $ Just
+                    RunningNode
+                        { runningNodeSocketPath = nodeConn
+                        , runningNodeShelleyGenesis = genesis
+                        , runningNodeVersionData = version
+                        }
+
+parseVersionData :: Value -> Parser NodeToClientVersionData
+parseVersionData = withObject "NodeToClientVersionData" $ \o -> do
+    nm <- o .: "magic"
+    query <- o .: "query"
+    pure
+        NodeToClientVersionData
+            { networkMagic = NetworkMagic nm
+            , query
+            }
 
 instance ToJSON (ApiT MonitorState) where
     toJSON = \case

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Http/Monitor/API.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Http/Monitor/API.hs
@@ -16,6 +16,7 @@ module Cardano.Wallet.Launch.Cluster.Http.Monitor.API
     , SwitchAPI
     , ObserveAPI
     , ControlAPI
+    , renderPhase
     )
 where
 

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Monitoring/Phase.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Monitoring/Phase.hs
@@ -1,27 +1,16 @@
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 
 module Cardano.Wallet.Launch.Cluster.Monitoring.Phase
     ( Phase (..)
-    , RelayNode (..)
     , History (..)
     )
 where
 
 import Prelude
 
-import Cardano.Launcher.Node
-    ( cardanoNodeConn
-    , nodeSocketFile
-    )
-import Data.Aeson
-    ( FromJSON
-    , ToJSON
-    )
-import Data.Aeson.Types
-    ( FromJSON (..)
-    , ToJSON (..)
+import Cardano.Wallet.Launch.Cluster.Node.RunningNode
+    ( RunningNode
     )
 import Data.Time
     ( UTCTime
@@ -29,20 +18,6 @@ import Data.Time
 import GHC.Generics
     ( Generic
     )
-
--- | A relay node as a reference to its socket file or pipe
-newtype RelayNode = RelayNode FilePath
-    deriving stock (Eq, Show, Generic)
-
-instance ToJSON RelayNode where
-    toJSON (RelayNode f) = toJSON f
-
-instance FromJSON RelayNode where
-    parseJSON x = do
-        f <- parseJSON x
-        case cardanoNodeConn f of
-            Right conn -> pure $ RelayNode $ nodeSocketFile conn
-            Left e -> fail e
 
 -- | The different phases the cluster can be in. We use the convention to report
 -- the start of a phase.
@@ -54,9 +29,9 @@ data Phase
     | Funding
     | Pools
     | Relay
-    | Cluster (Maybe RelayNode)
+    | Cluster (Maybe RunningNode)
     deriving stock (Eq, Show, Generic)
-    deriving anyclass (ToJSON, FromJSON)
+    -- deriving anyclass (ToJSON, FromJSON)
 
 -- | The history of the cluster phases
 newtype History = History

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -195,6 +195,7 @@ common test-common
   hs-source-dirs:     test/unit
   build-depends:
     , aeson
+    , aeson-pretty
     , aeson-qq
     , base
     , bytestring

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -195,8 +195,10 @@ common test-common
   hs-source-dirs:     test/unit
   build-depends:
     , aeson
+    , aeson-qq
     , base
     , bytestring
+    , cardano-ledger-shelley
     , cardano-wallet-application-extras
     , cardano-wallet-launcher
     , cardano-wallet-primitive
@@ -211,12 +213,14 @@ common test-common
     , local-cluster
     , mtl
     , openapi3
+    , ouroboros-network
     , pathtype
     , process
     , QuickCheck
     , time
     , unliftio
     , with-utf8
+
 
   build-tool-depends:
     , hspec-discover:hspec-discover

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -10,7 +10,9 @@ maintainer:    hal@cardanofoundation.org
 copyright:     2023 Cardano Foundation
 category:      Web
 build-type:    Simple
-data-files:    data/swagger.json
+
+data-files:
+    data/swagger.json
 
 common language
   default-language:   Haskell2010
@@ -26,6 +28,7 @@ common language
     -Wmissing-deriving-strategies -Wmissing-local-signatures
     -Wpartial-fields -Wredundant-constraints -Wtabs -Wunused-foralls
     -Wunused-packages
+    -Wno-missing-home-modules
 
 flag release
   description: Enable optimization and `-Werror`
@@ -202,6 +205,7 @@ common test-common
     , cardano-ledger-shelley
     , cardano-wallet-application-extras
     , cardano-wallet-launcher
+    , cardano-wallet-network-layer
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
     , contra-tracer
@@ -227,6 +231,12 @@ common test-common
     , hspec-discover:hspec-discover
     , local-cluster:local-cluster
 
+-- until cabal has no support for multi home, hls requires to have only one home
+-- for the other modules , so we cannot use the common test-common for those
+test-suite test-local-cluster
+  import:  test-common
+  main-is: test.hs
+  type:    exitcode-stdio-1.0
   other-modules:
     Cardano.Wallet.Launch.Cluster.Faucet.SerializeSpec
     Cardano.Wallet.Launch.Cluster.Http.Faucet.APISpec
@@ -239,11 +249,6 @@ common test-common
     Paths_local_cluster
     Spec
     SpecHook
-
-test-suite test-local-cluster
-  import:  test-common
-  main-is: test.hs
-  type:    exitcode-stdio-1.0
 
 executable test-local-cluster-exe
   import:  test-common

--- a/lib/local-cluster/test/unit/Cardano/Wallet/Launch/Cluster/Http/Monitor/APISpec.hs
+++ b/lib/local-cluster/test/unit/Cardano/Wallet/Launch/Cluster/Http/Monitor/APISpec.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 module Cardano.Wallet.Launch.Cluster.Http.Monitor.APISpec
     ( spec
@@ -9,13 +12,25 @@ where
 
 import Prelude
 
+import Cardano.Launcher.Node
+    ( CardanoNodeConn
+    , cardanoNodeConn
+    )
+import Cardano.Ledger.Shelley.Genesis
+    ( ShelleyGenesis
+    )
+import Cardano.Wallet.Launch.Cluster
+    ( RunningNode (..)
+    )
 import Cardano.Wallet.Launch.Cluster.Http.Monitor.API
     ( ApiT (..)
     )
 import Cardano.Wallet.Launch.Cluster.Monitoring.Phase
     ( History (..)
     , Phase (..)
-    , RelayNode (..)
+    )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( StandardCrypto
     )
 import Control.Monitoring.Tracing
     ( MonitorState (..)
@@ -24,7 +39,11 @@ import Data.Aeson
     ( FromJSON (..)
     , Result (..)
     , ToJSON (..)
+    , Value
     , fromJSON
+    )
+import Data.Aeson.QQ
+    ( aesonQQ
     )
 import Data.OpenApi
     ( ToSchema
@@ -34,6 +53,12 @@ import Data.Time
     ( Day (ModifiedJulianDay)
     , UTCTime (UTCTime)
     , secondsToDiffTime
+    )
+import Ouroboros.Network.Magic
+    ( NetworkMagic (..)
+    )
+import Ouroboros.Network.NodeToClient
+    ( NodeToClientVersionData (..)
     )
 import Test.Hspec
     ( Expectation
@@ -99,12 +124,92 @@ genPhase =
         , pure Funding
         , pure Pools
         , pure Relay
-        , Cluster
-            <$> oneof
-                [pure Nothing, Just <$> genRelayNodePath]
+        , Cluster <$> oneof [pure Nothing, Just <$> genRunningNode]
         ]
 
-genRelayNodePath :: Gen RelayNode
-genRelayNodePath =
-    RelayNode <$> do
-        oneof [pure "path1", pure "path1/path2", pure "/path3"]
+genCardanoNodeConn :: Gen CardanoNodeConn
+genCardanoNodeConn = do
+    mConn <-
+        cardanoNodeConn <$> do
+            oneof [pure "path1", pure "path1/path2", pure "/path3"]
+    case mConn of
+        Left e -> error $ "genCardanoNodeConn: " <> e
+        Right conn -> pure conn
+
+genRunningNode :: Gen RunningNode
+genRunningNode = do
+    socket <- genCardanoNodeConn
+    genesis <- genShelleyGenesis
+    version <- genNodeToClientVersionData
+    pure
+        $ RunningNode
+            { runningNodeSocketPath = socket
+            , runningNodeShelleyGenesis = genesis
+            , runningNodeVersionData = version
+            }
+
+genNodeToClientVersionData :: Gen NodeToClientVersionData
+genNodeToClientVersionData =
+    pure
+        $ NodeToClientVersionData
+            { networkMagic = NetworkMagic 42
+            , query = True
+            }
+
+genShelleyGenesis :: Gen (ShelleyGenesis StandardCrypto)
+genShelleyGenesis = pure $ case fromJSON shelleyGenesis of
+    Success genesis -> genesis
+    Error e -> error e
+
+shelleyGenesis :: Value
+shelleyGenesis =
+    [aesonQQ|
+{
+    "activeSlotsCoeff": 5.0e-2,
+    "epochLength": 21600,
+    "genDelegs": {
+        "8a1cebc0df78b69ef71099de3867a78d85b93b57513fc0508b27bee6": {
+            "delegate": "2103d8279e759d7163d1422467cfb88c19e584adc9506d4b8484a397",
+            "vrf": "8d8f6e4c0685ca835d7dbe4ec4c240f4d71d0ceb2e4fe1d7bd97b7b3d30f435d"
+        }
+    },
+    "initialFunds": {},
+    "maxKESEvolutions": 62,
+    "maxLovelaceSupply": 45000000000000000,
+    "networkId": "Testnet",
+    "networkMagic": 42,
+    "protocolParams": {
+        "a0": 0.3,
+        "decentralisationParam": 1.0,
+        "eMax": 18,
+        "extraEntropy": {
+            "tag": "NeutralNonce"
+        },
+        "keyDeposit": 2000000,
+        "maxBlockBodySize": 65536,
+        "maxBlockHeaderSize": 1100,
+        "maxTxSize": 16384,
+        "minFeeA": 44,
+        "minFeeB": 155381,
+        "minPoolCost": 340000000,
+        "minUTxOValue": 1000000,
+        "nOpt": 150,
+        "poolDeposit": 500000000,
+        "protocolVersion": {
+            "major": 6,
+            "minor": 0
+        },
+        "rho": 3.0e-3,
+        "tau": 0.2
+    },
+    "securityParam": 108,
+    "slotLength": 1,
+    "slotsPerKESPeriod": 129600,
+    "staking": {
+        "pools": {},
+        "stake": {}
+    },
+    "systemStart": "2024-03-25T10:34:26.544957596Z",
+    "updateQuorum": 1
+}
+|]


### PR DESCRIPTION
- [x] Change the `observe` end-point to serve a full `RunningNode` value in place of just the socket path 
- [x] Test the new `RunningNode` via cardano-wallet-network

ADP-3305
