### PR TITLE
[ADP-3306] Improve witness count validation in `submitTransaction`.

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -649,15 +649,11 @@ instance IsServerError ErrSubmitTransaction where
                 ]
         ErrSubmitTransactionMissingWitnesses
             ErrSubmitTransactionMissingWitnessCounts
-                { expectedNumberOfKeyWits
-                , detectedNumberOfKeyWits
-                } ->
+            {expectedNumberOfKeyWits, detectedNumberOfKeyWits} ->
                 flip (apiError err403) message $
                 MissingWitnessesInTransaction
                     ApiErrorMissingWitnessesInTransaction
-                    { expectedNumberOfKeyWits
-                    , detectedNumberOfKeyWits
-                    }
+                    {expectedNumberOfKeyWits, detectedNumberOfKeyWits}
           where
             message = mconcat
                 [ "The transaction expects "

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -655,8 +655,8 @@ instance IsServerError ErrSubmitTransaction where
                 flip (apiError err403) message $
                 MissingWitnessesInTransaction
                     ApiErrorMissingWitnessesInTransaction
-                    { expectedNumberOfKeyWits = fromIntegral expectedWitsNo
-                    , detectedNumberOfKeyWits = fromIntegral foundWitsNo
+                    { expectedNumberOfKeyWits = expectedWitsNo
+                    , detectedNumberOfKeyWits = foundWitsNo
                     }
           where
             message = mconcat

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -64,6 +64,7 @@ import Cardano.Wallet
     , ErrStakePoolDelegation (..)
     , ErrStartTimeLaterThanEndTime (..)
     , ErrSubmitTransaction (..)
+    , ErrSubmitTransactionMissingWitnessCounts (..)
     , ErrSubmitTx (..)
     , ErrUpdatePassphrase (..)
     , ErrWalletAlreadyExists (..)
@@ -647,7 +648,10 @@ instance IsServerError ErrSubmitTransaction where
                 , "either an input or a withdrawal belonging to the wallet."
                 ]
         ErrSubmitTransactionMissingWitnesses
-            expectedWitsNo foundWitsNo ->
+            ErrSubmitTransactionMissingWitnessCounts
+                { expectedNumberOfKeyWits = expectedWitsNo
+                , detectedNumberOfKeyWits = foundWitsNo
+                } ->
                 flip (apiError err403) message $
                 MissingWitnessesInTransaction
                     ApiErrorMissingWitnessesInTransaction

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -646,7 +646,7 @@ instance IsServerError ErrSubmitTransaction where
                 , "wallet and cannot be sent. Submit a transaction that has "
                 , "either an input or a withdrawal belonging to the wallet."
                 ]
-        ErrSubmitTransactionPartiallySignedOrNoSignedTx
+        ErrSubmitTransactionMissingWitnesses
             expectedWitsNo foundWitsNo ->
                 flip (apiError err403) message $
                 MissingWitnessesInTransaction

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -649,21 +649,21 @@ instance IsServerError ErrSubmitTransaction where
                 ]
         ErrSubmitTransactionMissingWitnesses
             ErrSubmitTransactionMissingWitnessCounts
-                { expectedNumberOfKeyWits = expectedWitsNo
-                , detectedNumberOfKeyWits = foundWitsNo
+                { expectedNumberOfKeyWits
+                , detectedNumberOfKeyWits
                 } ->
                 flip (apiError err403) message $
                 MissingWitnessesInTransaction
                     ApiErrorMissingWitnessesInTransaction
-                    { expectedNumberOfKeyWits = expectedWitsNo
-                    , detectedNumberOfKeyWits = foundWitsNo
+                    { expectedNumberOfKeyWits
+                    , detectedNumberOfKeyWits
                     }
           where
             message = mconcat
                 [ "The transaction expects "
-                , toText expectedWitsNo
+                , toText expectedNumberOfKeyWits
                 , " witness(es) to be fully-signed but "
-                , toText foundWitsNo
+                , toText detectedNumberOfKeyWits
                 , " was provided."
                 , " Please submit a fully-signed transaction."
                 ]

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3715,14 +3715,13 @@ validateWitnessCounts
     -> Int
     -- ^ detected number of key witnesses
     -> ExceptT ErrSubmitTransaction m ()
-validateWitnessCounts expected detected
-    | expected > detected = throwE $
+validateWitnessCounts expected detected =
+    when (expected > detected) $ throwE $
         ErrSubmitTransactionMissingWitnesses $
         ErrSubmitTransactionMissingWitnessCounts
             { expectedNumberOfKeyWits = toNatural expected
             , detectedNumberOfKeyWits = toNatural detected
             }
-    | otherwise = pure ()
   where
     toNatural :: Int -> Natural
     toNatural = fromJustNote "validateWitnessCounts.toNatural" . intCastMaybe

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -189,6 +189,7 @@ import Cardano.Wallet
     , ErrReadRewardAccount (..)
     , ErrSignPayment (..)
     , ErrSubmitTransaction (..)
+    , ErrSubmitTransactionMissingWitnessCounts (..)
     , ErrUpdatePassphrase (..)
     , ErrWalletAlreadyExists (..)
     , ErrWalletNotResponding (..)
@@ -3750,6 +3751,7 @@ submitTransaction ctx apiw@(ApiT wid) apitx = do
     when (witsRequiredForInputs > totalNumberOfWits)
         $ liftHandler . throwE
         $ ErrSubmitTransactionMissingWitnesses
+        $ ErrSubmitTransactionMissingWitnessCounts
             witsRequiredForInputs totalNumberOfWits
 
     void $ withWorkerCtx ctx wid liftE liftE $ \wrk -> do
@@ -3899,7 +3901,8 @@ submitSharedTransaction ctx apiw@(ApiT wid) apitx = do
                 paymentWitsRequired + fromIntegral delegationWitsRequired
         when (allWitsRequired > totalNumberOfWits) $
             liftHandler $ throwE $
-            ErrSubmitTransactionMissingWitnesses
+            ErrSubmitTransactionMissingWitnesses $
+            ErrSubmitTransactionMissingWitnessCounts
             allWitsRequired totalNumberOfWits
 
         let txCtx = defaultTransactionCtx

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3752,7 +3752,8 @@ submitTransaction ctx apiw@(ApiT wid) apitx = do
         $ liftHandler . throwE
         $ ErrSubmitTransactionMissingWitnesses
         $ ErrSubmitTransactionMissingWitnessCounts
-            witsRequiredForInputs totalNumberOfWits
+            (fromIntegral witsRequiredForInputs)
+            (fromIntegral totalNumberOfWits)
 
     void $ withWorkerCtx ctx wid liftE liftE $ \wrk -> do
         let tx = walletTx $ decodeTx tl era sealedTx
@@ -3903,7 +3904,8 @@ submitSharedTransaction ctx apiw@(ApiT wid) apitx = do
             liftHandler $ throwE $
             ErrSubmitTransactionMissingWitnesses $
             ErrSubmitTransactionMissingWitnessCounts
-            allWitsRequired totalNumberOfWits
+                (fromIntegral allWitsRequired)
+                (fromIntegral totalNumberOfWits)
 
         let txCtx = defaultTransactionCtx
                 { txValidityInterval = (Nothing, ttl)

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3749,7 +3749,7 @@ submitTransaction ctx apiw@(ApiT wid) apitx = do
 
     when (witsRequiredForInputs > totalNumberOfWits)
         $ liftHandler . throwE
-        $ ErrSubmitTransactionPartiallySignedOrNoSignedTx
+        $ ErrSubmitTransactionMissingWitnesses
             witsRequiredForInputs totalNumberOfWits
 
     void $ withWorkerCtx ctx wid liftE liftE $ \wrk -> do
@@ -3899,7 +3899,7 @@ submitSharedTransaction ctx apiw@(ApiT wid) apitx = do
                 paymentWitsRequired + fromIntegral delegationWitsRequired
         when (allWitsRequired > totalNumberOfWits) $
             liftHandler $ throwE $
-            ErrSubmitTransactionPartiallySignedOrNoSignedTx
+            ErrSubmitTransactionMissingWitnesses
             allWitsRequired totalNumberOfWits
 
         let txCtx = defaultTransactionCtx

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -3659,8 +3659,8 @@ data ErrSubmitTransaction
 
 data ErrSubmitTransactionMissingWitnessCounts =
     ErrSubmitTransactionMissingWitnessCounts
-        { expectedNumberOfKeyWits :: !Int
-        , detectedNumberOfKeyWits :: !Int
+        { expectedNumberOfKeyWits :: !Natural
+        , detectedNumberOfKeyWits :: !Natural
         }
     deriving (Show, Eq)
 

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -161,6 +161,7 @@ module Cardano.Wallet
     , ErrCannotQuit (..)
     , ErrCannotVote (..)
     , ErrSubmitTransaction (..)
+    , ErrSubmitTransactionMissingWitnessCounts (..)
 
     -- ** Migration
     , createMigrationPlan
@@ -3651,8 +3652,16 @@ data ErrSignPayment
 -- | Errors that can occur when submitting a transaction.
 data ErrSubmitTransaction
     = ErrSubmitTransactionForeignWallet
-    | ErrSubmitTransactionMissingWitnesses Int Int
+    | ErrSubmitTransactionMissingWitnesses
+        !ErrSubmitTransactionMissingWitnessCounts
     | ErrSubmitTransactionMultidelegationNotSupported
+    deriving (Show, Eq)
+
+data ErrSubmitTransactionMissingWitnessCounts =
+    ErrSubmitTransactionMissingWitnessCounts
+        { expectedNumberOfKeyWits :: !Int
+        , detectedNumberOfKeyWits :: !Int
+        }
     deriving (Show, Eq)
 
 -- | Errors that can occur when constructing an unsigned transaction.

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -3651,7 +3651,7 @@ data ErrSignPayment
 -- | Errors that can occur when submitting a transaction.
 data ErrSubmitTransaction
     = ErrSubmitTransactionForeignWallet
-    | ErrSubmitTransactionPartiallySignedOrNoSignedTx Int Int
+    | ErrSubmitTransactionMissingWitnesses Int Int
     | ErrSubmitTransactionMultidelegationNotSupported
     deriving (Show, Eq)
 


### PR DESCRIPTION
This PR follows on from #4590, and:
- Extracts out witness count validation into a common function `validateWitnessCounts`.
- Replaces `fromIntegral` with `intCastMaybe` and `fromJustNote` with a unique and identifiable error message.
- Changes the types of fields `{expected,detected}NumberOfKeyWits` to `Natural`.
- Changes the name of `ErrSubmitTransactionPartiallySignedOrNoSignedTx` to `ErrSubmitTransactionMissingWitnesses`.

## Issue

ADP-3306