### PR TITLE
[ADP-3359] Report unaccepted-era transactions as HTTP 403 errors

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Types/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Error.hs
@@ -31,6 +31,7 @@ module Cardano.Wallet.Api.Types.Error
     , ApiErrorNotEnoughMoneyShortfall (..)
     , ApiErrorMissingWitnessesInTransaction (..)
     , ApiErrorNoSuchPool (..)
+    , ApiErrorUnsupportedEra (..)
     )
     where
 
@@ -75,6 +76,9 @@ import Data.Data
     )
 import Data.Maybe
     ( fromMaybe
+    )
+import Data.Set
+    ( Set
     )
 import Data.Text
     ( Text
@@ -217,6 +221,7 @@ data ApiErrorInfo
     | BlockHeaderNotFound
     | TranslationByronTxOutInContext
     | BalanceTxInlinePlutusV3ScriptNotSupportedInBabbage
+    | UnsupportedEra !ApiErrorUnsupportedEra
 
     deriving (Eq, Generic, Show, Data, Typeable)
     deriving anyclass NFData
@@ -234,6 +239,16 @@ apiErrorInfoOptions = defaultSumTypeOptions
         , contentsFieldName = "info"
         }
     }
+
+data ApiErrorUnsupportedEra = ApiErrorUnsupportedEra
+    { unsupportedEra :: !ApiEra
+    -- ^ The unsupported era (as specified by the caller).
+    , supportedEras :: !(Set ApiEra)
+    -- ^ The set of eras that we currently support.
+    }
+    deriving (Data, Eq, Generic, Show, Typeable)
+    deriving (FromJSON, ToJSON) via DefaultRecord ApiErrorUnsupportedEra
+    deriving anyclass NFData
 
 data ApiErrorSharedWalletNoSuchCosigner = ApiErrorSharedWalletNoSuchCosigner
     { cosignerIndex

--- a/lib/network-layer/src/Cardano/Wallet/Network.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network.hs
@@ -106,6 +106,7 @@ import qualified Internal.Cardano.Write.Tx as Write
 {-----------------------------------------------------------------------------
     NetworkLayer
 ------------------------------------------------------------------------------}
+
 -- | Interface for network capabilities.
 data NetworkLayer m block = NetworkLayer
     { chainSync
@@ -134,8 +135,7 @@ data NetworkLayer m block = NetworkLayer
     -- only change once per epoch.
     , currentProtocolParametersInRecentEras
         :: m (MaybeInRecentEra Write.PParams)
-        -- ^ Get the last known protocol parameters for recent eras.
-
+    -- ^ Get the last known protocol parameters for recent eras.
     , currentSlottingParameters
         :: m SlottingParameters
     -- ^ Get the last known slotting parameters. In principle, these can
@@ -193,6 +193,7 @@ instance Functor m => Functor (NetworkLayer m) where
 {-----------------------------------------------------------------------------
     ChainFollower
 ------------------------------------------------------------------------------}
+
 -- | A collection of callbacks to use with the 'chainSync' function.
 data ChainFollower m point tip blocks = ChainFollower
     { checkpointPolicy :: Integer -> CheckpointPolicy
@@ -275,7 +276,10 @@ mapChainFollower fpoint12 fpoint21 ftip fblocks cf =
 -------------------------------------------------------------------------------}
 
 -- | Error while trying to send a transaction
-data ErrPostTx = ErrPostTxValidationError Text | ErrPostTxMempoolFull
+data ErrPostTx
+    = ErrPostTxValidationError Text
+    | ErrPostTxMempoolFull
+    | ErrPostTxEraUnsupported AnyCardanoEra
     deriving (Generic, Show, Eq)
 
 instance ToText ErrPostTx where
@@ -283,6 +287,10 @@ instance ToText ErrPostTx where
         ErrPostTxValidationError msg -> msg
         ErrPostTxMempoolFull ->
             "mempool was full and refused posted transaction"
+        ErrPostTxEraUnsupported unsupported ->
+            "Submitted transaction was in "
+                <> T.pack (show unsupported)
+                <> " era, which is not supported"
 
 -- | Error while trying to retrieve a block
 newtype ErrFetchBlock = ErrNoBlockAt Read.ChainPoint

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -631,7 +631,7 @@ withNodeNetworkLayerBase
             liftIO $ traceWith tr $ MsgPostTx tx
             preferredEra <- liftIO readCurrentEra
             let cmd =
-                    CmdSubmitTx . toConsensusGenTx
+                    CmdSubmitTx . toConsensusGenTx . fromRight (error "SealedTx")
                         $ unsealShelleyTx preferredEra tx
             liftIO (send txSubmissionQueue cmd) >>= \case
                 SubmitSuccess -> pure ()

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Shelley.hs
@@ -94,7 +94,7 @@ module Cardano.Wallet.Primitive.Ledger.Shelley
     , numberOfTransactionsInBlock
 
     -- * Errors
-    , UnsealedTxException (..)
+    , UnsealException (..)
     ) where
 
 import Prelude
@@ -1021,7 +1021,7 @@ rewardAccountFromAddress (W.Address bytes) = refToAccount . ref =<< parseAddr by
     refToAccount (SL.StakeRefPtr _) = Nothing
     refToAccount SL.StakeRefNull = Nothing
 
-newtype UnsealedTxException = UnsealedTxInUnsupportedEra AnyCardanoEra
+newtype UnsealException = UnsealedTxInUnsupportedEra AnyCardanoEra
 
 -- | Converts 'SealedTx' to something that can be submitted with the
 -- 'Cardano.Api' local tx submission client.
@@ -1029,7 +1029,7 @@ unsealShelleyTx
     :: AnyCardanoEra
     -- ^ Preferred latest era (see 'ideallyNoLaterThan')
     -> W.SealedTx
-    -> Either UnsealedTxException TxInMode
+    -> Either UnsealException TxInMode
 unsealShelleyTx era wtx = case W.cardanoTxIdeallyNoLaterThan era wtx of
     Cardano.InAnyCardanoEra BabbageEra tx ->
         Right $ TxInMode ShelleyBasedEraBabbage tx

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -283,6 +283,7 @@ import Cardano.Wallet.Api.Types.Error
     , ApiErrorNotEnoughMoneyShortfall (..)
     , ApiErrorSharedWalletNoSuchCosigner (..)
     , ApiErrorTxOutputLovelaceInsufficient (..)
+    , ApiErrorUnsupportedEra (..)
     )
 import Cardano.Wallet.Api.Types.RestorationMode
     ( ApiRestorationMode
@@ -2467,6 +2468,10 @@ instance Arbitrary ApiErrorNoSuchPool where
     shrink = genericShrink
 
 instance Arbitrary ApiErrorMissingWitnessesInTransaction where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary ApiErrorUnsupportedEra where
     arbitrary = genericArbitrary
     shrink = genericShrink
 

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -5557,6 +5557,26 @@ x-errBlockHeaderNotFound: &errBlockHeaderNotFound
       type: string
       enum: ['block_header_not_found']
 
+x-errUnsupportedEra: &errUnsupportedEra
+   <<: *responsesErr
+   title: unsupported_era
+   properties:
+    message:
+      type: string
+    code:
+      type: string
+      enum: ['unsupported_era']
+    info:
+      type: object
+      required:
+        - unsupported_era
+        - supported_eras
+      properties:
+          unsupported_era: *ApiEra
+          supported_eras:
+            type: array
+            items: *ApiEra
+
 x-responsesErr400: &responsesErr400
   400:
     description: Bad Request
@@ -6015,6 +6035,7 @@ x-responsesPostTransaction: &responsesPostTransaction
             - <<: *errTransactionIsTooBig
             - <<: *errNoRootKey
             - <<: *errWrongEncryptionPassphrase
+            - <<: *errUnsupportedEra
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
   <<: *responsesErr415UnsupportedMediaType


### PR DESCRIPTION
- [x] Remove an `error` call when not-in-a-recent-era  tx is posted
- [x] Add a 403 HTTP error in case the exception above is triggered

ADP-3359