### PR TITLE
[ADP-3306] Fix call to `dataTypeConstrs` in `FromJSON` instance for `SchemaApiErrorInfo`.

### DIFF
--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1197,7 +1197,8 @@ data SchemaApiErrorInfo = SchemaApiErrorInfo
 instance FromJSON SchemaApiErrorInfo where
     parseJSON = withObject "SchemaApiErrorInfo" $ \o -> do
         let constructors :: [String] =
-                showConstr <$> dataTypeConstrs (dataTypeOf NoSuchWallet)
+                showConstr <$>
+                dataTypeConstrs (dataTypeOf (undefined :: ApiErrorInfo))
         vals :: [Either String Yaml.Value] <-
             forM constructors $ \c ->
                 maybe (Left c) Right <$> o .:? Aeson.fromString (toSchemaName c)


### PR DESCRIPTION
This PR makes a small fix for #4597.

## Issue

ADP-3306