### PR TITLE
Remove unused `Buildable` instances.

### DIFF
--- a/lib/unit/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -382,7 +382,7 @@ newtype MockChain = MockChain
 -- | Generate arbitrary checkpoints, but that always have their tip at 0 0.
 newtype InitialCheckpoint s =
     InitialCheckpoint { getInitialCheckpoint :: Wallet s }
-    deriving newtype (Show, Eq, Buildable, NFData)
+    deriving newtype (Show, Eq, NFData)
 
 instance (Arbitrary k, Ord k, Arbitrary v) => Arbitrary (KeyValPairs k v) where
     shrink = genericShrink

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Model.hs
@@ -171,10 +171,6 @@ import Data.Set
 import Data.Word
     ( Word32
     )
-import Fmt
-    ( Buildable (..)
-    , indentF
-    )
 import GHC.Generics
     ( Generic
     )
@@ -240,12 +236,6 @@ instance NFData s => NFData (Wallet s) where
         deepseq (rnf sl) $
         deepseq (rnf s)
         ()
-
-instance Buildable s => Buildable (Wallet s) where
-    build (Wallet u tip s) = "Wallet s\n"
-        <> indentF 4 ("Tip: " <> build tip)
-        <> indentF 4 ("UTxO:\n" <> indentF 4 (build u))
-        <> indentF 4 (build s)
 
 -- | Delta encoding for 'Wallet'.
 data DeltaWallet s = DeltaWallet


### PR DESCRIPTION
This PR removes `Buildable` instances for the following types:
- `Wallet`
- `InitialCheckpoint`

## Issue

None. Spotted while reviewing code.