### PR TITLE
Add integration test for ADP-3359

### DIFF
--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -352,7 +352,7 @@ import qualified Cardano.Wallet.Api.Types.WalletAssets as ApiWalletAssets
 import qualified Cardano.Wallet.Primitive.Types.AssetName as AssetName
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Lazy as LB
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Percentage as Percentage
@@ -3001,10 +3001,10 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 \3e0a100818258201a6c21bc45c5d7089685610db372f2d2f87873aaa687af2\
                 \1b6bd62e7055d2402584029791f8f82d3413c93700ee63b86e3355880f4bda\
                 \b10893ad020358e04f78ef405bd031397dbbf311ab0297ed66196d6d57f662\
-                \aaab9e3610b2df03ccb38cc0df6\"}" :: LB.ByteString
+                \aaab9e3610b2df03ccb38cc0df6\"}" :: BL.ByteString
         let (Just submitMaryPayload) = decode @ApiSerialisedTransaction maryCBOR
         let submitMaryPayload' =
-                NonJson $ LB.fromStrict $ view #serialisedTx $ getApiT $
+                NonJson $ BL.fromStrict $ view #serialisedTx $ getApiT $
                 view #serialisedTxSealed submitMaryPayload
 
         --- $ cardano-cli transaction build-raw \
@@ -3025,10 +3025,10 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 \3e0a100818258201a6c21bc45c5d7089685610db372f2d2f87873aaa687af2\
                 \1b6bd62e7055d2402584029791f8f82d3413c93700ee63b86e3355880f4bda\
                 \b10893ad020358e04f78ef405bd031397dbbf311ab0297ed66196d6d57f662\
-                \aaab9e3610b2df03ccb38cc0df5f6\"}" :: LB.ByteString
+                \aaab9e3610b2df03ccb38cc0df5f6\"}" :: BL.ByteString
         let (Just submitBabbagePayload) = decode @ApiSerialisedTransaction babbageCBOR
         let submitBabbagePayload' =
-                NonJson $ LB.fromStrict $ view #serialisedTx $ getApiT $
+                NonJson $ BL.fromStrict $ view #serialisedTx $ getApiT $
                 view #serialisedTxSealed submitBabbagePayload
 
         submittedMaryTx <- submitTxWithWid ctx wa submitMaryPayload

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -362,7 +362,6 @@ import qualified Data.Text.Encoding as T
 import qualified Network.HTTP.Types.Status as HTTP
 import qualified Test.Integration.Plutus as PlutusScenario
 
-
 spec :: forall n. HasSNetworkId n => SpecWith Context
 spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
     it "TRANS_NEW_CREATE_01a - Empty payload is not allowed" $ \ctx -> runResourceT $ do


### PR DESCRIPTION
<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->


Showing that when foreign txs constructed in Mary and Babbage are  sent to `submitTxWithWid` then `ForeignTransaction` is emitted. 

When  foreign txs constructed in Babbage is sent through `postExternalTx` it can be accepted or rejected depending how it is formed (in the case added it ends up with 500 as expected).

But when foreign txs constructed in Mary is sent through `postExternalTx` it will emit `UnsupportedEras` error as expected

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number
adp-3359
<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
