### PR TITLE
[ADP-3359] Simplify construction of API errors relating to recent eras.

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -649,14 +649,11 @@ instance IsServerError ErrPostTx where
                     , "node because its mempool was full."
                     ]
         e@(ErrPostTxEraUnsupported unsupported) ->
-            apiError err403 error' $ toText e
-          where
-            error' =
-                UnsupportedEra
-                    ApiErrorUnsupportedEra
-                        { unsupportedEra = toApiEra unsupported
-                        , supportedEras = Api.supportedRecentEras
-                        }
+            flip (apiError err403) (toText e) $ UnsupportedEra
+                ApiErrorUnsupportedEra
+                    { unsupportedEra = toApiEra unsupported
+                    , supportedEras = Api.supportedRecentEras
+                    }
 
 instance IsServerError ErrSubmitTransaction where
     toServerError = \case

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -653,7 +653,7 @@ instance IsServerError ErrPostTx where
           where
             error' =
                 UnsupportedEra
-                    $ ApiErrorUnsupportedEra
+                    ApiErrorUnsupportedEra
                         { unsupportedEra = toApiEra unsupported
                         , supportedEras = Api.supportedRecentEras
                         }

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -484,6 +484,7 @@ instance IsServerError ErrWriteTxEra where
             info = ApiErrorNodeNotYetInRecentEra
                 { nodeEra = toApiEra $ Cardano.AnyCardanoEra era
                 , supportedRecentEras =
+                    Set.fromList $
                     map (toApiEra . Write.toAnyCardanoEra) [minBound .. maxBound]
                 }
         ErrPartialTxNotInNodeEra nodeEra ->

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -204,13 +204,11 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Foldable as F
 import qualified Data.List as L
-import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Internal.Cardano.Write.Tx as Write
     ( IsRecentEra
     , serializeTx
-    , toAnyCardanoEra
     )
 import qualified Internal.Cardano.Write.Tx as WriteTx
 import qualified Internal.Cardano.Write.Tx.Balance as Write
@@ -657,12 +655,7 @@ instance IsServerError ErrPostTx where
                 UnsupportedEra
                     $ ApiErrorUnsupportedEra
                         { unsupportedEra = toApiEra unsupported
-                        , supportedEras =
-                            Set.fromList
-                                ( toApiEra
-                                    . Write.toAnyCardanoEra
-                                    <$> [minBound .. maxBound]
-                                )
+                        , supportedEras = Api.supportedRecentEras
                         }
 
 instance IsServerError ErrSubmitTransaction where

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -191,6 +191,9 @@ import Servant.Server
     )
 
 import qualified Cardano.Api as Cardano
+import qualified Cardano.Wallet.Api.Types as Api
+    ( supportedRecentEras
+    )
 import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
 import qualified Cardano.Wallet.Api.Types.WalletAssets as ApiWalletAssets
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
@@ -485,9 +488,7 @@ instance IsServerError ErrWriteTxEra where
           where
             info = ApiErrorNodeNotYetInRecentEra
                 { nodeEra = toApiEra $ Cardano.AnyCardanoEra era
-                , supportedRecentEras =
-                    Set.fromList $
-                    map (toApiEra . Write.toAnyCardanoEra) [minBound .. maxBound]
+                , supportedRecentEras = Api.supportedRecentEras
                 }
         ErrPartialTxNotInNodeEra nodeEra ->
             apiError err403 TxNotInNodeEra $ T.unwords

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -171,6 +171,8 @@ import Fmt
     , pretty
     )
 import Internal.Cardano.Write.Tx
+    ( KeyWitnessCounts (..)
+    )
 import Network.Wai
     ( Request (pathInfo)
     )

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -192,7 +192,7 @@ import Servant.Server
 
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Api.Types as Api
-    ( supportedRecentEras
+    ( allRecentEras
     )
 import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
 import qualified Cardano.Wallet.Api.Types.WalletAssets as ApiWalletAssets
@@ -486,7 +486,7 @@ instance IsServerError ErrWriteTxEra where
           where
             info = ApiErrorNodeNotYetInRecentEra
                 { nodeEra = toApiEra $ Cardano.AnyCardanoEra era
-                , supportedRecentEras = Api.supportedRecentEras
+                , supportedRecentEras = Api.allRecentEras
                 }
         ErrPartialTxNotInNodeEra nodeEra ->
             apiError err403 TxNotInNodeEra $ T.unwords
@@ -652,7 +652,7 @@ instance IsServerError ErrPostTx where
             flip (apiError err403) (toText e) $ UnsupportedEra
                 ApiErrorUnsupportedEra
                     { unsupportedEra = toApiEra unsupported
-                    , supportedEras = Api.supportedRecentEras
+                    , supportedEras = Api.allRecentEras
                     }
 
 instance IsServerError ErrSubmitTransaction where

--- a/lib/api/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types.hs
@@ -168,6 +168,7 @@ module Cardano.Wallet.Api.Types
     , ApiWithdrawalPostData (..)
     , ApiRewardAccount (..)
     , fromApiEra
+    , supportedRecentEras
     , Iso8601Time (..)
     , KeyFormat (..)
     , MaintenanceAction (..)
@@ -576,6 +577,9 @@ import Data.Proxy
 import Data.Quantity
     ( Quantity (..)
     )
+import Data.Set
+    ( Set
+    )
 import Data.String
     ( IsString
     )
@@ -671,6 +675,7 @@ import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.List as L
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Read as T
@@ -678,6 +683,8 @@ import qualified Internal.Cardano.Write.Tx as Write
     ( DatumHash
     , datumHashFromBytes
     , datumHashToBytes
+    , supportedRecentEras
+    , toAnyCardanoEra
     )
 
 {-------------------------------------------------------------------------------
@@ -1640,6 +1647,12 @@ fromApiEra ApiMary = AnyCardanoEra MaryEra
 fromApiEra ApiAlonzo = AnyCardanoEra AlonzoEra
 fromApiEra ApiBabbage = AnyCardanoEra BabbageEra
 fromApiEra ApiConway = AnyCardanoEra ConwayEra
+
+-- | The complete set of supported recent eras.
+--
+supportedRecentEras :: Set ApiEra
+supportedRecentEras =
+    Set.map (toApiEra . Write.toAnyCardanoEra) Write.supportedRecentEras
 
 instance FromJSON ApiEra where
     parseJSON = genericParseJSON $ Aeson.defaultOptions

--- a/lib/api/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types.hs
@@ -168,7 +168,7 @@ module Cardano.Wallet.Api.Types
     , ApiWithdrawalPostData (..)
     , ApiRewardAccount (..)
     , fromApiEra
-    , supportedRecentEras
+    , allRecentEras
     , Iso8601Time (..)
     , KeyFormat (..)
     , MaintenanceAction (..)
@@ -681,9 +681,9 @@ import qualified Data.Text.Encoding as T
 import qualified Data.Text.Read as T
 import qualified Internal.Cardano.Write.Tx as Write
     ( DatumHash
+    , allRecentEras
     , datumHashFromBytes
     , datumHashToBytes
-    , supportedRecentEras
     , toAnyCardanoEra
     )
 
@@ -1648,11 +1648,10 @@ fromApiEra ApiAlonzo = AnyCardanoEra AlonzoEra
 fromApiEra ApiBabbage = AnyCardanoEra BabbageEra
 fromApiEra ApiConway = AnyCardanoEra ConwayEra
 
--- | The complete set of supported recent eras.
+-- | The complete set of recent eras.
 --
-supportedRecentEras :: Set ApiEra
-supportedRecentEras =
-    Set.map (toApiEra . Write.toAnyCardanoEra) Write.supportedRecentEras
+allRecentEras :: Set ApiEra
+allRecentEras = Set.map (toApiEra . Write.toAnyCardanoEra) Write.allRecentEras
 
 instance FromJSON ApiEra where
     parseJSON = genericParseJSON $ Aeson.defaultOptions

--- a/lib/api/src/Cardano/Wallet/Api/Types/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Error.hs
@@ -288,7 +288,7 @@ data ApiErrorBalanceTxUnderestimatedFee = ApiErrorBalanceTxUnderestimatedFee
 
 data ApiErrorNodeNotYetInRecentEra = ApiErrorNodeNotYetInRecentEra
     { nodeEra :: ApiEra
-    , supportedRecentEras :: [ApiEra]
+    , supportedRecentEras :: Set ApiEra
     }
     deriving (Data, Eq, Generic, Show, Typeable)
     deriving (FromJSON, ToJSON)

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -47,6 +47,7 @@ module Internal.Cardano.Write.Tx
     , toRecentEraGADT
     , LatestLedgerEra
     , RecentEraConstraints
+    , supportedRecentEras
 
     -- ** Key witness counts
     , KeyWitnessCounts (..)
@@ -251,6 +252,9 @@ import Data.Maybe
     ( fromMaybe
     , isJust
     )
+import Data.Set
+    ( Set
+    )
 import Data.Type.Equality
     ( TestEquality (testEquality)
     , (:~:) (Refl)
@@ -292,6 +296,7 @@ import qualified Cardano.Wallet.Primitive.Types.Tx.Constraints as W
     ( txOutMaxCoin
     )
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 
 --------------------------------------------------------------------------------
 -- Eras
@@ -475,6 +480,11 @@ instance Show AnyRecentEra where
 instance Eq AnyRecentEra where
     AnyRecentEra e1 == AnyRecentEra e2 =
         isJust $ testEquality e1 e2
+
+-- | The complete set of supported recent eras.
+--
+supportedRecentEras :: Set AnyRecentEra
+supportedRecentEras = Set.fromList [minBound .. maxBound]
 
 toAnyCardanoEra :: AnyRecentEra -> CardanoApi.AnyCardanoEra
 toAnyCardanoEra (AnyRecentEra era) =

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -47,7 +47,7 @@ module Internal.Cardano.Write.Tx
     , toRecentEraGADT
     , LatestLedgerEra
     , RecentEraConstraints
-    , supportedRecentEras
+    , allRecentEras
 
     -- ** Key witness counts
     , KeyWitnessCounts (..)
@@ -481,10 +481,10 @@ instance Eq AnyRecentEra where
     AnyRecentEra e1 == AnyRecentEra e2 =
         isJust $ testEquality e1 e2
 
--- | The complete set of supported recent eras.
+-- | The complete set of recent eras.
 --
-supportedRecentEras :: Set AnyRecentEra
-supportedRecentEras = Set.fromList [minBound .. maxBound]
+allRecentEras :: Set AnyRecentEra
+allRecentEras = Set.fromList [minBound .. maxBound]
 
 toAnyCardanoEra :: AnyRecentEra -> CardanoApi.AnyCardanoEra
 toAnyCardanoEra (AnyRecentEra era) =

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -231,6 +231,9 @@ import Data.ByteString.Short
 import Data.Coerce
     ( coerce
     )
+import Data.Function
+    ( on
+    )
 import Data.Generics.Internal.VL.Lens
     ( over
     , (^.)
@@ -462,6 +465,9 @@ instance Enum AnyRecentEra where
 instance Bounded AnyRecentEra where
     minBound = AnyRecentEra RecentEraBabbage
     maxBound = AnyRecentEra RecentEraConway
+
+instance Ord AnyRecentEra where
+    compare = compare `on` fromEnum
 
 instance Show AnyRecentEra where
     show (AnyRecentEra era) = "AnyRecentEra " <> show era

--- a/lib/unit/test/data/Cardano/Wallet/Api/ApiError.json
+++ b/lib/unit/test/data/Cardano/Wallet/Api/ApiError.json
@@ -174,8 +174,8 @@
             "info": {
                 "node_era": "byron",
                 "supported_recent_eras": [
-                    "babbage",
-                    "alonzo"
+                    "alonzo",
+                    "babbage"
                 ]
             },
             "message": "𧰏@qs𬤻DL\u0017􆊛'"
@@ -231,7 +231,6 @@
                 "supported_recent_eras": [
                     "byron",
                     "alonzo",
-                    "byron",
                     "babbage"
                 ]
             },
@@ -294,10 +293,8 @@
             "info": {
                 "node_era": "byron",
                 "supported_recent_eras": [
+                    "byron",
                     "mary",
-                    "babbage",
-                    "byron",
-                    "byron",
                     "babbage"
                 ]
             },
@@ -372,11 +369,8 @@
             "info": {
                 "node_era": "babbage",
                 "supported_recent_eras": [
-                    "allegra",
-                    "babbage",
-                    "allegra",
-                    "allegra",
                     "shelley",
+                    "allegra",
                     "babbage"
                 ]
             },
@@ -774,7 +768,6 @@
                 "node_era": "allegra",
                 "supported_recent_eras": [
                     "allegra",
-                    "mary",
                     "mary"
                 ]
             },


### PR DESCRIPTION
This PR:
- adds a new constant `recentEras :: Set AnyRecentEra`
    - this constant defines the complete set of **_recent eras_** that are supported for transaction construction.
- uses this constant to simplify the construction of the following API errors:
    - `ApiErrorNodeNotYetInRecentEra`
    - `ApiErrorUnsupportedEra`

## Issue

ADP-3359

Follow-on from #4595.