### PR TITLE
[ADP-3359] Move `ApiEra` type and related functions to separate module.

### DIFF
--- a/lib/api/cardano-wallet-api.cabal
+++ b/lib/api/cardano-wallet-api.cabal
@@ -148,6 +148,7 @@ library
     Cardano.Wallet.Api.Types.Amount
     Cardano.Wallet.Api.Types.BlockHeader
     Cardano.Wallet.Api.Types.Certificate
+    Cardano.Wallet.Api.Types.Era
     Cardano.Wallet.Api.Types.Error
     Cardano.Wallet.Api.Types.Key
     Cardano.Wallet.Api.Types.MintBurn

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -106,7 +106,7 @@ import Cardano.Wallet.Api.Types
     , Iso8601Time (..)
     )
 import Cardano.Wallet.Api.Types.Era
-    ( toApiEra
+    ( fromAnyCardanoEra
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorBalanceTxUnderestimatedFee (..)
@@ -487,7 +487,7 @@ instance IsServerError ErrWriteTxEra where
                 ]
           where
             info = ApiErrorNodeNotYetInRecentEra
-                { nodeEra = toApiEra $ Cardano.AnyCardanoEra era
+                { nodeEra = fromAnyCardanoEra $ Cardano.AnyCardanoEra era
                 , supportedRecentEras = Api.allRecentEras
                 }
         ErrPartialTxNotInNodeEra nodeEra ->
@@ -653,7 +653,7 @@ instance IsServerError ErrPostTx where
         e@(ErrPostTxEraUnsupported unsupported) ->
             flip (apiError err403) (toText e) $ UnsupportedEra
                 ApiErrorUnsupportedEra
-                    { unsupportedEra = toApiEra unsupported
+                    { unsupportedEra = fromAnyCardanoEra unsupported
                     , supportedEras = Api.allRecentEras
                     }
 

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -104,7 +104,9 @@ import Cardano.Wallet.Api.Types
     ( ApiCosignerIndex (..)
     , ApiCredentialType (..)
     , Iso8601Time (..)
-    , toApiEra
+    )
+import Cardano.Wallet.Api.Types.Era
+    ( toApiEra
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorBalanceTxUnderestimatedFee (..)
@@ -191,10 +193,10 @@ import Servant.Server
     )
 
 import qualified Cardano.Api as Cardano
-import qualified Cardano.Wallet.Api.Types as Api
+import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
+import qualified Cardano.Wallet.Api.Types.Era as Api
     ( allRecentEras
     )
-import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
 import qualified Cardano.Wallet.Api.Types.WalletAssets as ApiWalletAssets
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -105,9 +105,6 @@ import Cardano.Wallet.Api.Types
     , ApiCredentialType (..)
     , Iso8601Time (..)
     )
-import Cardano.Wallet.Api.Types.Era
-    ( fromAnyCardanoEra
-    )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorBalanceTxUnderestimatedFee (..)
     , ApiErrorInfo (..)
@@ -194,8 +191,9 @@ import Servant.Server
 
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
-import qualified Cardano.Wallet.Api.Types.Era as Api
+import qualified Cardano.Wallet.Api.Types.Era as ApiEra
     ( allRecentEras
+    , fromAnyCardanoEra
     )
 import qualified Cardano.Wallet.Api.Types.WalletAssets as ApiWalletAssets
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
@@ -487,8 +485,8 @@ instance IsServerError ErrWriteTxEra where
                 ]
           where
             info = ApiErrorNodeNotYetInRecentEra
-                { nodeEra = fromAnyCardanoEra $ Cardano.AnyCardanoEra era
-                , supportedRecentEras = Api.allRecentEras
+                { nodeEra = ApiEra.fromAnyCardanoEra $ Cardano.AnyCardanoEra era
+                , supportedRecentEras = ApiEra.allRecentEras
                 }
         ErrPartialTxNotInNodeEra nodeEra ->
             apiError err403 TxNotInNodeEra $ T.unwords
@@ -653,8 +651,8 @@ instance IsServerError ErrPostTx where
         e@(ErrPostTxEraUnsupported unsupported) ->
             flip (apiError err403) (toText e) $ UnsupportedEra
                 ApiErrorUnsupportedEra
-                    { unsupportedEra = fromAnyCardanoEra unsupported
-                    , supportedEras = Api.allRecentEras
+                    { unsupportedEra = ApiEra.fromAnyCardanoEra unsupported
+                    , supportedEras = ApiEra.allRecentEras
                     }
 
 instance IsServerError ErrSubmitTransaction where

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -474,9 +474,6 @@ import Cardano.Wallet.Api.Types.Certificate
     ( ApiRewardAccount (..)
     , mkApiAnyCertificate
     )
-import Cardano.Wallet.Api.Types.Era
-    ( fromAnyCardanoEra
-    )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)
     )
@@ -913,6 +910,9 @@ import qualified Cardano.Wallet.Address.Discovery.Sequential as Seq
 import qualified Cardano.Wallet.Address.Discovery.Shared as Shared
 import qualified Cardano.Wallet.Api.Types as Api
 import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
+import qualified Cardano.Wallet.Api.Types.Era as ApiEra
+    ( fromAnyCardanoEra
+    )
 import qualified Cardano.Wallet.Api.Types.WalletAssets as ApiWalletAssets
 import qualified Cardano.Wallet.DB as W
 import qualified Cardano.Wallet.Delegation as WD
@@ -4408,7 +4408,7 @@ getNetworkInformation nid
             , Api.nextEpoch = snd <$> nowInfo
             , Api.nodeTip = apiNodeTip
             , Api.networkTip = fst <$> nowInfo
-            , Api.nodeEra = fromAnyCardanoEra nodeEra
+            , Api.nodeEra = ApiEra.fromAnyCardanoEra nodeEra
             , Api.networkInfo =
                 Api.ApiNetworkInfo
                     ( case nid of

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -475,7 +475,7 @@ import Cardano.Wallet.Api.Types.Certificate
     , mkApiAnyCertificate
     )
 import Cardano.Wallet.Api.Types.Era
-    ( toApiEra
+    ( fromAnyCardanoEra
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)
@@ -4408,7 +4408,7 @@ getNetworkInformation nid
             , Api.nextEpoch = snd <$> nowInfo
             , Api.nodeTip = apiNodeTip
             , Api.networkTip = fst <$> nowInfo
-            , Api.nodeEra = toApiEra nodeEra
+            , Api.nodeEra = fromAnyCardanoEra nodeEra
             , Api.networkInfo =
                 Api.ApiNetworkInfo
                     ( case nid of

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -460,7 +460,6 @@ import Cardano.Wallet.Api.Types
     , getApiMnemonicT
     , toApiAsset
     , toApiDecodeTransactionPostData
-    , toApiEra
     , toApiNetworkParameters
     , toApiUtxoStatistics
     )
@@ -474,6 +473,9 @@ import Cardano.Wallet.Api.Types.BlockHeader
 import Cardano.Wallet.Api.Types.Certificate
     ( ApiRewardAccount (..)
     , mkApiAnyCertificate
+    )
+import Cardano.Wallet.Api.Types.Era
+    ( toApiEra
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)

--- a/lib/api/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types.hs
@@ -272,9 +272,7 @@ import Cardano.Address.Script
     , ValidationLevel (..)
     )
 import Cardano.Api
-    ( AnyCardanoEra (..)
-    , CardanoEra (..)
-    , StakeAddress
+    ( StakeAddress
     , deserialiseFromBech32
     , proxyToAsType
     , serialiseToBech32
@@ -362,6 +360,7 @@ import Cardano.Wallet.Api.Types.Certificate
     )
 import Cardano.Wallet.Api.Types.Era
     ( ApiEra (..)
+    , fromApiEra
     , toApiEra
     )
 import Cardano.Wallet.Api.Types.Key
@@ -1622,15 +1621,6 @@ newtype ApiBlockInfo = ApiBlockInfo
     deriving (FromJSON, ToJSON) via DefaultRecord ApiBlockInfo
     deriving anyclass NFData
     deriving Show via (Quiet ApiBlockInfo)
-
-fromApiEra :: ApiEra -> AnyCardanoEra
-fromApiEra ApiByron = AnyCardanoEra ByronEra
-fromApiEra ApiShelley = AnyCardanoEra ShelleyEra
-fromApiEra ApiAllegra = AnyCardanoEra AllegraEra
-fromApiEra ApiMary = AnyCardanoEra MaryEra
-fromApiEra ApiAlonzo = AnyCardanoEra AlonzoEra
-fromApiEra ApiBabbage = AnyCardanoEra BabbageEra
-fromApiEra ApiConway = AnyCardanoEra ConwayEra
 
 -- | The complete set of recent eras.
 --

--- a/lib/api/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types.hs
@@ -362,6 +362,7 @@ import Cardano.Wallet.Api.Types.Certificate
     )
 import Cardano.Wallet.Api.Types.Era
     ( ApiEra (..)
+    , toApiEra
     )
 import Cardano.Wallet.Api.Types.Key
     ( ApiAccountKey (..)
@@ -1621,15 +1622,6 @@ newtype ApiBlockInfo = ApiBlockInfo
     deriving (FromJSON, ToJSON) via DefaultRecord ApiBlockInfo
     deriving anyclass NFData
     deriving Show via (Quiet ApiBlockInfo)
-
-toApiEra :: AnyCardanoEra -> ApiEra
-toApiEra (AnyCardanoEra ByronEra) = ApiByron
-toApiEra (AnyCardanoEra ShelleyEra) = ApiShelley
-toApiEra (AnyCardanoEra AllegraEra) = ApiAllegra
-toApiEra (AnyCardanoEra MaryEra) = ApiMary
-toApiEra (AnyCardanoEra AlonzoEra) = ApiAlonzo
-toApiEra (AnyCardanoEra BabbageEra) = ApiBabbage
-toApiEra (AnyCardanoEra ConwayEra) = ApiConway
 
 fromApiEra :: ApiEra -> AnyCardanoEra
 fromApiEra ApiByron = AnyCardanoEra ByronEra

--- a/lib/api/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types.hs
@@ -360,6 +360,7 @@ import Cardano.Wallet.Api.Types.Certificate
     )
 import Cardano.Wallet.Api.Types.Era
     ( ApiEra (..)
+    , allRecentEras
     , fromApiEra
     , toApiEra
     )
@@ -580,9 +581,6 @@ import Data.Proxy
 import Data.Quantity
     ( Quantity (..)
     )
-import Data.Set
-    ( Set
-    )
 import Data.String
     ( IsString
     )
@@ -678,16 +676,13 @@ import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.List as L
 import qualified Data.Map as Map
-import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Read as T
 import qualified Internal.Cardano.Write.Tx as Write
     ( DatumHash
-    , allRecentEras
     , datumHashFromBytes
     , datumHashToBytes
-    , toAnyCardanoEra
     )
 
 {-------------------------------------------------------------------------------
@@ -1621,11 +1616,6 @@ newtype ApiBlockInfo = ApiBlockInfo
     deriving (FromJSON, ToJSON) via DefaultRecord ApiBlockInfo
     deriving anyclass NFData
     deriving Show via (Quiet ApiBlockInfo)
-
--- | The complete set of recent eras.
---
-allRecentEras :: Set ApiEra
-allRecentEras = Set.map (toApiEra . Write.toAnyCardanoEra) Write.allRecentEras
 
 data ApiNetworkInfo = ApiNetworkInfo
     { networkId :: !Text

--- a/lib/api/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types.hs
@@ -88,7 +88,6 @@ module Cardano.Wallet.Api.Types
     , ApiDecodedTransaction (..)
     , ApiDelegationAction (..)
     , ApiDeregisterPool (..)
-    , ApiEra (..)
     , ApiEraInfo (..)
     , ApiExternalCertificate (..)
     , ApiExternalInput (..)
@@ -167,8 +166,6 @@ module Cardano.Wallet.Api.Types
     , ApiWithdrawalGeneral (..)
     , ApiWithdrawalPostData (..)
     , ApiRewardAccount (..)
-    , fromApiEra
-    , allRecentEras
     , Iso8601Time (..)
     , KeyFormat (..)
     , MaintenanceAction (..)
@@ -180,7 +177,6 @@ module Cardano.Wallet.Api.Types
     , SettingsPutData (..)
     , toApiAsset
     , toApiAssetMetadata
-    , toApiEra
     , toApiNetworkParameters
     , toApiUtxoStatistics
     , VerificationKeyHashing (..)
@@ -360,9 +356,6 @@ import Cardano.Wallet.Api.Types.Certificate
     )
 import Cardano.Wallet.Api.Types.Era
     ( ApiEra (..)
-    , allRecentEras
-    , fromApiEra
-    , toApiEra
     )
 import Cardano.Wallet.Api.Types.Key
     ( ApiAccountKey (..)

--- a/lib/api/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types.hs
@@ -360,6 +360,9 @@ import Cardano.Wallet.Api.Types.Certificate
     , ApiRegisterPool (..)
     , ApiRewardAccount (..)
     )
+import Cardano.Wallet.Api.Types.Era
+    ( ApiEra (..)
+    )
 import Cardano.Wallet.Api.Types.Key
     ( ApiAccountKey (..)
     , ApiAccountKeyShared (..)
@@ -1619,17 +1622,6 @@ newtype ApiBlockInfo = ApiBlockInfo
     deriving anyclass NFData
     deriving Show via (Quiet ApiBlockInfo)
 
-data ApiEra
-    = ApiByron
-    | ApiShelley
-    | ApiAllegra
-    | ApiMary
-    | ApiAlonzo
-    | ApiBabbage
-    | ApiConway
-    deriving (Data, Show, Eq, Generic, Enum, Ord, Bounded)
-    deriving anyclass NFData
-
 toApiEra :: AnyCardanoEra -> ApiEra
 toApiEra (AnyCardanoEra ByronEra) = ApiByron
 toApiEra (AnyCardanoEra ShelleyEra) = ApiShelley
@@ -1652,13 +1644,6 @@ fromApiEra ApiConway = AnyCardanoEra ConwayEra
 --
 allRecentEras :: Set ApiEra
 allRecentEras = Set.map (toApiEra . Write.toAnyCardanoEra) Write.allRecentEras
-
-instance FromJSON ApiEra where
-    parseJSON = genericParseJSON $ Aeson.defaultOptions
-        { constructorTagModifier = drop 4 . camelTo2 '_' }
-instance ToJSON ApiEra where
-    toJSON = genericToJSON $ Aeson.defaultOptions
-        { constructorTagModifier = drop 4 . camelTo2 '_' }
 
 data ApiNetworkInfo = ApiNetworkInfo
     { networkId :: !Text

--- a/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+
 -- |
 -- Copyright:
 --    © 2018-2023 IOHK
@@ -8,5 +13,65 @@
 -- This module provides API types and functions relating to eras.
 --
 module Cardano.Wallet.Api.Types.Era
-    ()
+    ( ApiEra (..)
+    )
     where
+
+import Control.DeepSeq
+    ( NFData
+    )
+import Data.Aeson
+    ( FromJSON (parseJSON)
+    , Options (constructorTagModifier)
+    , ToJSON (toJSON)
+    , camelTo2
+    , genericParseJSON
+    , genericToJSON
+    )
+import Data.Data
+    ( Data
+    )
+import Data.Eq
+    ( Eq
+    )
+import Data.Function
+    ( ($)
+    , (.)
+    )
+import Data.List
+    ( drop
+    )
+import Data.Ord
+    ( Ord
+    )
+import GHC.Generics
+    ( Generic
+    )
+import Prelude
+    ( Bounded
+    , Enum
+    )
+import Text.Show
+    ( Show
+    )
+
+import qualified Data.Aeson as Aeson
+
+data ApiEra
+    = ApiByron
+    | ApiShelley
+    | ApiAllegra
+    | ApiMary
+    | ApiAlonzo
+    | ApiBabbage
+    | ApiConway
+    deriving (Data, Show, Eq, Generic, Enum, Ord, Bounded)
+    deriving anyclass NFData
+
+instance FromJSON ApiEra where
+    parseJSON = genericParseJSON $ Aeson.defaultOptions
+        { constructorTagModifier = drop 4 . camelTo2 '_' }
+
+instance ToJSON ApiEra where
+    toJSON = genericToJSON $ Aeson.defaultOptions
+        { constructorTagModifier = drop 4 . camelTo2 '_' }

--- a/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
@@ -18,6 +18,7 @@ module Cardano.Wallet.Api.Types.Era
     ( ApiEra (..)
     , toApiEra
     , fromApiEra
+    , allRecentEras
     )
     where
 
@@ -52,6 +53,9 @@ import Data.List
 import Data.Ord
     ( Ord
     )
+import Data.Set
+    ( Set
+    )
 import GHC.Generics
     ( Generic
     )
@@ -64,6 +68,11 @@ import Text.Show
     )
 
 import qualified Data.Aeson as Aeson
+import qualified Data.Set as Set
+import qualified Internal.Cardano.Write.Tx as Write
+    ( allRecentEras
+    , toAnyCardanoEra
+    )
 
 data ApiEra
     = ApiByron
@@ -103,3 +112,8 @@ fromApiEra = \case
     ApiAlonzo -> AnyCardanoEra AlonzoEra
     ApiBabbage -> AnyCardanoEra BabbageEra
     ApiConway -> AnyCardanoEra ConwayEra
+
+-- | The complete set of recent eras.
+--
+allRecentEras :: Set ApiEra
+allRecentEras = Set.map (toApiEra . Write.toAnyCardanoEra) Write.allRecentEras

--- a/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
@@ -17,6 +17,7 @@
 module Cardano.Wallet.Api.Types.Era
     ( ApiEra (..)
     , toApiEra
+    , fromApiEra
     )
     where
 
@@ -92,3 +93,12 @@ toApiEra = \case
     AnyCardanoEra AlonzoEra -> ApiAlonzo
     AnyCardanoEra BabbageEra -> ApiBabbage
     AnyCardanoEra ConwayEra -> ApiConway
+
+fromApiEra :: ApiEra -> AnyCardanoEra
+fromApiEra ApiByron = AnyCardanoEra ByronEra
+fromApiEra ApiShelley = AnyCardanoEra ShelleyEra
+fromApiEra ApiAllegra = AnyCardanoEra AllegraEra
+fromApiEra ApiMary = AnyCardanoEra MaryEra
+fromApiEra ApiAlonzo = AnyCardanoEra AlonzoEra
+fromApiEra ApiBabbage = AnyCardanoEra BabbageEra
+fromApiEra ApiConway = AnyCardanoEra ConwayEra

--- a/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GADTs #-}
 
 -- |
 -- Copyright:
@@ -14,9 +15,14 @@
 --
 module Cardano.Wallet.Api.Types.Era
     ( ApiEra (..)
+    , toApiEra
     )
     where
 
+import Cardano.Api
+    ( AnyCardanoEra (AnyCardanoEra)
+    , CardanoEra (..)
+    )
 import Control.DeepSeq
     ( NFData
     )
@@ -75,3 +81,12 @@ instance FromJSON ApiEra where
 instance ToJSON ApiEra where
     toJSON = genericToJSON $ Aeson.defaultOptions
         { constructorTagModifier = drop 4 . camelTo2 '_' }
+
+toApiEra :: AnyCardanoEra -> ApiEra
+toApiEra (AnyCardanoEra ByronEra) = ApiByron
+toApiEra (AnyCardanoEra ShelleyEra) = ApiShelley
+toApiEra (AnyCardanoEra AllegraEra) = ApiAllegra
+toApiEra (AnyCardanoEra MaryEra) = ApiMary
+toApiEra (AnyCardanoEra AlonzoEra) = ApiAlonzo
+toApiEra (AnyCardanoEra BabbageEra) = ApiBabbage
+toApiEra (AnyCardanoEra ConwayEra) = ApiConway

--- a/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
@@ -17,7 +17,7 @@
 module Cardano.Wallet.Api.Types.Era
     ( ApiEra (..)
     , fromAnyCardanoEra
-    , fromApiEra
+    , toAnyCardanoEra
     , allRecentEras
     )
     where
@@ -103,8 +103,8 @@ fromAnyCardanoEra = \case
     AnyCardanoEra BabbageEra -> ApiBabbage
     AnyCardanoEra ConwayEra -> ApiConway
 
-fromApiEra :: ApiEra -> AnyCardanoEra
-fromApiEra = \case
+toAnyCardanoEra :: ApiEra -> AnyCardanoEra
+toAnyCardanoEra = \case
     ApiByron -> AnyCardanoEra ByronEra
     ApiShelley -> AnyCardanoEra ShelleyEra
     ApiAllegra -> AnyCardanoEra AllegraEra

--- a/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
@@ -1,0 +1,12 @@
+-- |
+-- Copyright:
+--    © 2018-2023 IOHK
+--    © 2023-2024 Cardano Foundation
+-- License:
+--    Apache-2.0
+--
+-- This module provides API types and functions relating to eras.
+--
+module Cardano.Wallet.Api.Types.Era
+    ()
+    where

--- a/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
@@ -95,10 +95,11 @@ toApiEra = \case
     AnyCardanoEra ConwayEra -> ApiConway
 
 fromApiEra :: ApiEra -> AnyCardanoEra
-fromApiEra ApiByron = AnyCardanoEra ByronEra
-fromApiEra ApiShelley = AnyCardanoEra ShelleyEra
-fromApiEra ApiAllegra = AnyCardanoEra AllegraEra
-fromApiEra ApiMary = AnyCardanoEra MaryEra
-fromApiEra ApiAlonzo = AnyCardanoEra AlonzoEra
-fromApiEra ApiBabbage = AnyCardanoEra BabbageEra
-fromApiEra ApiConway = AnyCardanoEra ConwayEra
+fromApiEra = \case
+    ApiByron -> AnyCardanoEra ByronEra
+    ApiShelley -> AnyCardanoEra ShelleyEra
+    ApiAllegra -> AnyCardanoEra AllegraEra
+    ApiMary -> AnyCardanoEra MaryEra
+    ApiAlonzo -> AnyCardanoEra AlonzoEra
+    ApiBabbage -> AnyCardanoEra BabbageEra
+    ApiConway -> AnyCardanoEra ConwayEra

--- a/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
@@ -16,7 +16,7 @@
 --
 module Cardano.Wallet.Api.Types.Era
     ( ApiEra (..)
-    , toApiEra
+    , fromAnyCardanoEra
     , fromApiEra
     , allRecentEras
     )
@@ -93,8 +93,8 @@ instance ToJSON ApiEra where
     toJSON = genericToJSON $ Aeson.defaultOptions
         { constructorTagModifier = drop 4 . camelTo2 '_' }
 
-toApiEra :: AnyCardanoEra -> ApiEra
-toApiEra = \case
+fromAnyCardanoEra :: AnyCardanoEra -> ApiEra
+fromAnyCardanoEra = \case
     AnyCardanoEra ByronEra -> ApiByron
     AnyCardanoEra ShelleyEra -> ApiShelley
     AnyCardanoEra AllegraEra -> ApiAllegra
@@ -116,4 +116,5 @@ fromApiEra = \case
 -- | The complete set of recent eras.
 --
 allRecentEras :: Set ApiEra
-allRecentEras = Set.map (toApiEra . Write.toAnyCardanoEra) Write.allRecentEras
+allRecentEras =
+    Set.map (fromAnyCardanoEra . Write.toAnyCardanoEra) Write.allRecentEras

--- a/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 
 -- |
 -- Copyright:
@@ -83,10 +84,11 @@ instance ToJSON ApiEra where
         { constructorTagModifier = drop 4 . camelTo2 '_' }
 
 toApiEra :: AnyCardanoEra -> ApiEra
-toApiEra (AnyCardanoEra ByronEra) = ApiByron
-toApiEra (AnyCardanoEra ShelleyEra) = ApiShelley
-toApiEra (AnyCardanoEra AllegraEra) = ApiAllegra
-toApiEra (AnyCardanoEra MaryEra) = ApiMary
-toApiEra (AnyCardanoEra AlonzoEra) = ApiAlonzo
-toApiEra (AnyCardanoEra BabbageEra) = ApiBabbage
-toApiEra (AnyCardanoEra ConwayEra) = ApiConway
+toApiEra = \case
+    AnyCardanoEra ByronEra -> ApiByron
+    AnyCardanoEra ShelleyEra -> ApiShelley
+    AnyCardanoEra AllegraEra -> ApiAllegra
+    AnyCardanoEra MaryEra -> ApiMary
+    AnyCardanoEra AlonzoEra -> ApiAlonzo
+    AnyCardanoEra BabbageEra -> ApiBabbage
+    AnyCardanoEra ConwayEra -> ApiConway

--- a/lib/api/src/Cardano/Wallet/Api/Types/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Error.hs
@@ -44,10 +44,12 @@ import Cardano.Wallet.Api.Lib.Options
 import Cardano.Wallet.Api.Types
     ( ApiCosignerIndex (..)
     , ApiCredentialType (..)
-    , ApiEra
     )
 import Cardano.Wallet.Api.Types.Amount
     ( ApiAmount
+    )
+import Cardano.Wallet.Api.Types.Era
+    ( ApiEra
     )
 import Cardano.Wallet.Api.Types.WalletAssets
     ( ApiWalletAssets

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -45,7 +45,6 @@ import Cardano.Wallet.Api.Http.Shelley.Server
     )
 import Cardano.Wallet.Api.Types
     ( AddressAmount (..)
-    , ApiEra
     , ApiMnemonicT (..)
     , ApiT (..)
     , ApiTransaction
@@ -60,6 +59,9 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Api.Types.Amount
     ( ApiAmount (..)
+    )
+import Cardano.Wallet.Api.Types.Era
+    ( ApiEra
     )
 import Cardano.Wallet.Api.Types.WalletAssets
     ( ApiWalletAssets (..)

--- a/lib/integration/framework/Test/Integration/Framework/Context.hs
+++ b/lib/integration/framework/Test/Integration/Framework/Context.hs
@@ -18,7 +18,7 @@ import Cardano.Address
 import Cardano.CLI
     ( Port (..)
     )
-import Cardano.Wallet.Api.Types
+import Cardano.Wallet.Api.Types.Era
     ( ApiEra
     )
 import Cardano.Wallet.Faucet

--- a/lib/integration/framework/Test/Integration/Framework/DSL.hs
+++ b/lib/integration/framework/Test/Integration/Framework/DSL.hs
@@ -307,7 +307,6 @@ import Cardano.Wallet.Api.Types
     , ApiByronWallet
     , ApiCoinSelection
     , ApiConstructTransaction
-    , ApiEra (..)
     , ApiFee (..)
     , ApiMaintenanceAction (..)
     , ApiNetworkInformation
@@ -333,6 +332,9 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Api.Types.Amount
     ( ApiAmount (ApiAmount)
+    )
+import Cardano.Wallet.Api.Types.Era
+    ( ApiEra (..)
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)

--- a/lib/integration/framework/Test/Integration/Framework/PendingInEra.hs
+++ b/lib/integration/framework/Test/Integration/Framework/PendingInEra.hs
@@ -6,7 +6,7 @@ where
 
 import Prelude
 
-import Cardano.Wallet.Api.Types
+import Cardano.Wallet.Api.Types.Era
     ( ApiEra (..)
     )
 import Test.Hspec.Core.Spec

--- a/lib/integration/framework/Test/Integration/Framework/Setup.hs
+++ b/lib/integration/framework/Test/Integration/Framework/Setup.hs
@@ -50,9 +50,11 @@ import Cardano.Wallet.Api.Http.Shelley.Server
     ( walletListenFromEnv
     )
 import Cardano.Wallet.Api.Types
-    ( ApiEra (..)
-    , ApiPoolSpecifier (..)
+    ( ApiPoolSpecifier (..)
     , ApiT (..)
+    )
+import Cardano.Wallet.Api.Types.Era
+    ( ApiEra (..)
     )
 import Cardano.Wallet.Faucet
     ( FaucetM

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -22,7 +22,6 @@ import Cardano.Wallet.Address.Encoding
 import Cardano.Wallet.Api.Types
     ( ApiAddress
     , ApiByronWallet
-    , ApiEra (..)
     , ApiT (..)
     , ApiTransaction
     , ApiTxInput (source)
@@ -33,6 +32,9 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Api.Types.Amount
     ( ApiAmount (ApiAmount)
+    )
+import Cardano.Wallet.Api.Types.Era
+    ( ApiEra (..)
     )
 import Cardano.Wallet.Primitive.NetworkId
     ( HasSNetworkId (..)

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shared/Transactions.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shared/Transactions.hs
@@ -55,11 +55,13 @@ import Cardano.Wallet.Api.Types
     , ApiWalletOutput (..)
     , Iso8601Time (..)
     , WalletStyle (..)
-    , fromApiEra
     , insertedAt
     )
 import Cardano.Wallet.Api.Types.Amount
     ( ApiAmount (ApiAmount)
+    )
+import Cardano.Wallet.Api.Types.Era
+    ( fromApiEra
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shared/Transactions.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shared/Transactions.hs
@@ -61,7 +61,7 @@ import Cardano.Wallet.Api.Types.Amount
     ( ApiAmount (ApiAmount)
     )
 import Cardano.Wallet.Api.Types.Era
-    ( fromApiEra
+    ( toAnyCardanoEra
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)
@@ -478,7 +478,7 @@ spec = describe "SHARED_TRANSACTIONS" $ do
                         Cardano.TxMetadataInEra _ (Cardano.TxMetadata m) ->
                             Just m
 
-        let era = fromApiEra $ _mainEra ctx
+        let era = toAnyCardanoEra $ _mainEra ctx
         let txbinary1 = cardanoTxIdeallyNoLaterThan era $
                 getApiT (txCbor1 ^. #serialisedTxSealed)
         case getMetadata txbinary1 of

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shared/Transactions.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shared/Transactions.hs
@@ -60,9 +60,6 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Api.Types.Amount
     ( ApiAmount (ApiAmount)
     )
-import Cardano.Wallet.Api.Types.Era
-    ( toAnyCardanoEra
-    )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)
     , ApiErrorMissingWitnessesInTransaction (..)
@@ -224,6 +221,9 @@ import qualified Cardano.Address.Style.Shelley as CA
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Faucet.Mnemonics as Mnemonics
 import qualified Cardano.Wallet.Api.Link as Link
+import qualified Cardano.Wallet.Api.Types.Era as ApiEra
+    ( toAnyCardanoEra
+    )
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.List.NonEmpty as NE
@@ -478,7 +478,7 @@ spec = describe "SHARED_TRANSACTIONS" $ do
                         Cardano.TxMetadataInEra _ (Cardano.TxMetadata m) ->
                             Just m
 
-        let era = toAnyCardanoEra $ _mainEra ctx
+        let era = ApiEra.toAnyCardanoEra $ _mainEra ctx
         let txbinary1 = cardanoTxIdeallyNoLaterThan era $
                 getApiT (txCbor1 ^. #serialisedTxSealed)
         case getMetadata txbinary1 of

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -24,7 +24,6 @@ import Cardano.Wallet.Address.Encoding
     )
 import Cardano.Wallet.Api.Types
     ( ApiAddress
-    , ApiEra (..)
     , ApiT (..)
     , ApiTransaction
     , ApiUtxoStatistics
@@ -35,6 +34,9 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Api.Types.Amount
     ( ApiAmount (ApiAmount)
+    )
+import Cardano.Wallet.Api.Types.Era
+    ( ApiEra (..)
     )
 import Cardano.Wallet.Faucet
     ( Faucet (..)

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -13,8 +13,10 @@ module Test.Integration.Scenario.API.Shelley.Network
 import Prelude
 
 import Cardano.Wallet.Api.Types
+    ( ApiNetworkParameters (..)
+    )
+import Cardano.Wallet.Api.Types.Era
     ( ApiEra (..)
-    , ApiNetworkParameters (..)
     )
 import Cardano.Wallet.Pools
     ( EpochInfo (..)

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -35,7 +35,6 @@ import Cardano.Pool.Types
 import Cardano.Wallet.Api.Types
     ( ApiCertificate (JoinPool, QuitPool, RegisterRewardAccount)
     , ApiConstructTransaction
-    , ApiEra (..)
     , ApiHealthCheck
     , ApiPoolSpecifier (..)
     , ApiSerialisedTransaction (..)
@@ -51,6 +50,9 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Api.Types.Amount
     ( ApiAmount (ApiAmount)
+    )
+import Cardano.Wallet.Api.Types.Era
+    ( ApiEra (..)
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -37,7 +37,6 @@ import Cardano.Wallet.Api.Types
     , ApiAddress
     , ApiAsset (..)
     , ApiCoinSelectionOutput (..)
-    , ApiEra (..)
     , ApiFee (..)
     , ApiT (..)
     , ApiTransaction
@@ -51,6 +50,9 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Api.Types.Amount
     ( ApiAmount (ApiAmount)
+    )
+import Cardano.Wallet.Api.Types.Era
+    ( ApiEra (..)
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -110,7 +110,7 @@ import Cardano.Wallet.Api.Types.Certificate
     )
 import Cardano.Wallet.Api.Types.Era
     ( ApiEra (..)
-    , fromApiEra
+    , toAnyCardanoEra
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)
@@ -428,7 +428,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                         Cardano.TxMetadataInEra _ (Cardano.TxMetadata m) ->
                             Just m
 
-        let era = fromApiEra $ _mainEra ctx
+        let era = toAnyCardanoEra $ _mainEra ctx
         let tx = cardanoTxIdeallyNoLaterThan era $ getApiT (signedTx ^. #serialisedTxSealed)
         case getMetadata tx of
             Nothing -> error "Tx doesn't include metadata"
@@ -493,7 +493,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                         Cardano.TxMetadataInEra _ (Cardano.TxMetadata m) ->
                             Just m
 
-        let era = fromApiEra $ _mainEra ctx
+        let era = toAnyCardanoEra $ _mainEra ctx
         let tx = cardanoTxIdeallyNoLaterThan era $ getApiT (signedTx ^. #serialisedTxSealed)
         case getMetadata tx of
             Nothing -> error "Tx doesn't include metadata"

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -80,7 +80,6 @@ import Cardano.Wallet.Api.Types
     , ApiConstructTransaction (..)
     , ApiDecodedTransaction
     , ApiDeregisterPool (..)
-    , ApiEra (..)
     , ApiExternalCertificate (..)
     , ApiNetworkInformation
     , ApiPolicyId (..)
@@ -102,13 +101,16 @@ import Cardano.Wallet.Api.Types
     , ApiWalletOutput (..)
     , ResourceContext (..)
     , WalletStyle (..)
-    , fromApiEra
     )
 import Cardano.Wallet.Api.Types.Amount
     ( ApiAmount (ApiAmount)
     )
 import Cardano.Wallet.Api.Types.Certificate
     ( ApiRewardAccount (..)
+    )
+import Cardano.Wallet.Api.Types.Era
+    ( ApiEra (..)
+    , fromApiEra
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -110,7 +110,6 @@ import Cardano.Wallet.Api.Types.Certificate
     )
 import Cardano.Wallet.Api.Types.Era
     ( ApiEra (..)
-    , toAnyCardanoEra
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiErrorInfo (..)
@@ -344,6 +343,9 @@ import qualified Cardano.Ledger.Keys as Ledger
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
+import qualified Cardano.Wallet.Api.Types.Era as ApiEra
+    ( toAnyCardanoEra
+    )
 import qualified Cardano.Wallet.Api.Types.WalletAssets as ApiWalletAssets
 import qualified Cardano.Wallet.Primitive.Types.AssetName as AssetName
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
@@ -428,7 +430,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                         Cardano.TxMetadataInEra _ (Cardano.TxMetadata m) ->
                             Just m
 
-        let era = toAnyCardanoEra $ _mainEra ctx
+        let era = ApiEra.toAnyCardanoEra $ _mainEra ctx
         let tx = cardanoTxIdeallyNoLaterThan era $ getApiT (signedTx ^. #serialisedTxSealed)
         case getMetadata tx of
             Nothing -> error "Tx doesn't include metadata"
@@ -493,7 +495,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                         Cardano.TxMetadataInEra _ (Cardano.TxMetadata m) ->
                             Just m
 
-        let era = toAnyCardanoEra $ _mainEra ctx
+        let era = ApiEra.toAnyCardanoEra $ _mainEra ctx
         let tx = cardanoTxIdeallyNoLaterThan era $ getApiT (signedTx ^. #serialisedTxSealed)
         case getMetadata tx of
             Nothing -> error "Tx doesn't include metadata"

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -702,8 +702,8 @@ import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Api.Types as Api
 import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
 import qualified Cardano.Wallet.Api.Types.Era as Api
-    ( fromApiEra
-    , toApiEra
+    ( fromAnyCardanoEra
+    , fromApiEra
     )
 import qualified Cardano.Wallet.Api.Types.WalletAssets as ApiWalletAssets
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
@@ -873,8 +873,8 @@ spec = do
         jsonTest @ApiRestorationMode
 
     describe "ApiEra roundtrip" $
-        it "toApiEra . fromApiEra == id" $ property $ \era -> do
-            Api.toApiEra (Api.fromApiEra era) === era
+        it "fromAnyCardanoEra . fromApiEra == id" $ property $ \era -> do
+            Api.fromAnyCardanoEra (Api.fromApiEra era) === era
 
     describe "ToText-FromText Roundtrip" $ do
             textRoundtrip $ Proxy @Iso8601Time

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -703,7 +703,7 @@ import qualified Cardano.Wallet.Api.Types as Api
 import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
 import qualified Cardano.Wallet.Api.Types.Era as Api
     ( fromAnyCardanoEra
-    , fromApiEra
+    , toAnyCardanoEra
     )
 import qualified Cardano.Wallet.Api.Types.WalletAssets as ApiWalletAssets
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
@@ -873,8 +873,8 @@ spec = do
         jsonTest @ApiRestorationMode
 
     describe "ApiEra roundtrip" $
-        it "fromAnyCardanoEra . fromApiEra == id" $ property $ \era -> do
-            Api.fromAnyCardanoEra (Api.fromApiEra era) === era
+        it "fromAnyCardanoEra . toAnyCardanoEra == id" $ property $ \era -> do
+            Api.fromAnyCardanoEra (Api.toAnyCardanoEra era) === era
 
     describe "ToText-FromText Roundtrip" $ do
             textRoundtrip $ Proxy @Iso8601Time

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -701,7 +701,7 @@ import Web.HttpApiData
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Api.Types as Api
 import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
-import qualified Cardano.Wallet.Api.Types.Era as Api
+import qualified Cardano.Wallet.Api.Types.Era as ApiEra
     ( fromAnyCardanoEra
     , toAnyCardanoEra
     )
@@ -874,7 +874,7 @@ spec = do
 
     describe "ApiEra roundtrip" $
         it "fromAnyCardanoEra . toAnyCardanoEra == id" $ property $ \era -> do
-            Api.fromAnyCardanoEra (Api.toAnyCardanoEra era) === era
+            ApiEra.fromAnyCardanoEra (ApiEra.toAnyCardanoEra era) === era
 
     describe "ToText-FromText Roundtrip" $ do
             textRoundtrip $ Proxy @Iso8601Time

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -152,7 +152,6 @@ import Cardano.Wallet.Api.Types
     , ApiDelegationAction (..)
     , ApiDeregisterPool (..)
     , ApiEncryptMetadata (..)
-    , ApiEra (..)
     , ApiEraInfo (..)
     , ApiExternalCertificate (..)
     , ApiExternalInput (..)
@@ -270,6 +269,9 @@ import Cardano.Wallet.Api.Types.BlockHeader
     )
 import Cardano.Wallet.Api.Types.Certificate
     ( ApiRewardAccount (..)
+    )
+import Cardano.Wallet.Api.Types.Era
+    ( ApiEra (..)
     )
 import Cardano.Wallet.Api.Types.Error
     ( ApiError (..)
@@ -699,6 +701,10 @@ import Web.HttpApiData
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Api.Types as Api
 import qualified Cardano.Wallet.Api.Types.Amount as ApiAmount
+import qualified Cardano.Wallet.Api.Types.Era as Api
+    ( fromApiEra
+    , toApiEra
+    )
 import qualified Cardano.Wallet.Api.Types.WalletAssets as ApiWalletAssets
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Cardano.Wallet.Read as Read

--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -872,9 +872,9 @@ spec = do
         jsonTest @(ApiT DRep)
         jsonTest @ApiRestorationMode
 
-    describe "ApiEra roundtrip" $
-        it "fromAnyCardanoEra . toAnyCardanoEra == id" $ property $ \era -> do
-            ApiEra.fromAnyCardanoEra (ApiEra.toAnyCardanoEra era) === era
+    it "Round trip between types `ApiEra` and `AnyCardanoEra`"
+        $ property
+        $ \era -> ApiEra.fromAnyCardanoEra (ApiEra.toAnyCardanoEra era) === era
 
     describe "ToText-FromText Roundtrip" $ do
             textRoundtrip $ Proxy @Iso8601Time


### PR DESCRIPTION
This PR moves the `ApiEra` type and related functions to a separate module `Api.Types.Era`.

As a result:
- the `ApiEra` type is co-located only with its related functions;
- the `Api.Types` [megamodule](https://www.parsonsmatt.org/2019/11/27/keeping_compilation_fast.html) is now ever-so-slightly smaller.

Additionally:
- functions relating to `ApiEra` are now imported via the `ApiEra` qualifier;
- the `Api.Types` module does **_not_** re-export symbols from `Api.Types.Era`.

## Issue

ADP-3359

Follow-on from #4595.