### PR TITLE
[ADP-3366] Refactor node config generation code

### DIFF
--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Aeson.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Aeson.hs
@@ -1,10 +1,6 @@
-{-# LANGUAGE LambdaCase #-}
-
 module Cardano.Wallet.Launch.Cluster.Aeson
-    ( withAddedKey
-    , withObject
+    ( decodeFileThrow
     , ChangeValue
-    , decodeFileThrow
     )
 where
 
@@ -12,35 +8,9 @@ import Prelude
 
 import Data.Aeson
     ( FromJSON
-    , ToJSON (toJSON)
     , Value
     , eitherDecodeFileStrict
     )
-
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.KeyMap as Aeson
-
-withAddedKey
-    :: (MonadFail m, Aeson.ToJSON a)
-    => Aeson.Key
-    -> a
-    -> Aeson.Value
-    -> m Aeson.Value
-withAddedKey k v = withObject (pure . Aeson.insert k (toJSON v))
-
--- | Do something with an a JSON object. Fails if the given JSON value isn't an
--- object.
-withObject
-    :: MonadFail m
-    => (Aeson.Object -> m Aeson.Object)
-    -> Aeson.Value
-    -> m Aeson.Value
-withObject action = \case
-    Aeson.Object m -> Aeson.Object <$> action m
-    _ ->
-        fail
-            "withObject: was given an invalid JSON. Expected an Object but got \
-            \something else."
 
 type ChangeValue = Value -> Value
 

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/FileOf.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/FileOf.hs
@@ -46,8 +46,10 @@ import qualified System.Path.PartClass as C
 
 -- | An absolute path with a type-level tag
 newtype FileOf (s :: Symbol) = FileOf {absFileOf :: AbsFile}
-    deriving stock (Show)
     deriving newtype (Eq, Ord)
+
+instance Show (FileOf s) where
+    show (FileOf x) = toFilePath x
 
 -- | Shortcut to get string filepath from a FileOf
 absFilePathOf :: FileOf a -> FilePath
@@ -55,8 +57,10 @@ absFilePathOf (FileOf fp) = toFilePath fp
 
 -- | An absolute directory with a type-level tag
 newtype DirOf (s :: Symbol) = DirOf {absDirOf :: AbsDir}
-    deriving stock (Show)
     deriving newtype (Eq, Ord)
+
+instance Show (DirOf s) where
+    show (DirOf x) = toFilePath x
 
 -- | A relative directory with a type-level tag
 newtype RelDirOf (s :: Symbol) = RelDirOf {relDirOf :: RelDir}

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/GenNodeConfig.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/GenNodeConfig.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.Wallet.Launch.Cluster.Node.GenNodeConfig
+    ( genNodeConfig
+    )
 where
 
 import Prelude
@@ -24,8 +26,7 @@ import Cardano.Ledger.Shelley.API
     ( ShelleyGenesis (..)
     )
 import Cardano.Wallet.Launch.Cluster.Aeson
-    ( withAddedKey
-    , withObject
+    ( ChangeValue
     )
 import Cardano.Wallet.Launch.Cluster.ClusterEra
     ( ClusterEra (..)
@@ -50,15 +51,31 @@ import Cardano.Wallet.Launch.Cluster.Node.GenesisFiles
     ( GenesisFiles
     , GenesisRecord (..)
     )
-import Control.Monad
-    ( (>=>)
+import Control.Lens
+    ( (%~)
+    , (&)
+    , (.~)
+    , (<&>)
+    , (?~)
+    , (^?)
     )
 import Control.Monad.Reader
     ( MonadIO (..)
     , MonadReader (..)
     )
 import Data.Aeson
-    ( toJSON
+    ( Key
+    , Value (..)
+    , toJSON
+    )
+import Data.Aeson.Key
+    ( fromText
+    )
+import Data.Aeson.Lens
+    ( _Array
+    , _String
+    , atKey
+    , key
     )
 import Data.Generics.Labels
     ()
@@ -76,23 +93,20 @@ import Ouroboros.Network.NodeToClient
     ( NodeToClientVersionData (..)
     )
 import System.Path
-    ( AbsFile
-    , RelDir
+    ( RelDir
     , relFile
     , (<.>)
     , (</>)
     )
 
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Key as Aeson
-import qualified Data.Aeson.KeyMap as Aeson
 import qualified Data.Text as T
 import qualified Data.Yaml as Yaml
 
 genNodeConfig
     :: RelDir
     -- ^ A top-level directory where to put the configuration.
-    -> Tagged "node-name" String -- Node name
+    -> Tagged "node-name" String
+    -- ^ Node name
     -> GenesisFiles
     -- ^ Genesis block start time
     -> ClusterEra
@@ -106,97 +120,97 @@ genNodeConfig
         )
 genNodeConfig nodeSegment name genesisFiles clusterEra logCfg = do
     Config{..} <- ask
+
     DirOf poolDir <- askNodeDir nodeSegment
+
     let LogFileConfig severity mExtraLogFile extraSev = logCfg
-    let GenesisRecord byronFile shelleyFile alonzoFile conwayFile = genesisFiles
-    let fileScribe (path, sev) =
-            ScribeDefinition
-                { scName = path
-                , scFormat = ScText
-                , scKind = FileSK
-                , scMinSev = sev
-                , scMaxSev = Critical
-                , scPrivacy = ScPublic
-                , scRotation = Nothing
-                }
 
-    let scribes =
-            map fileScribe
-                $ catMaybes
-                    [ Just ("cardano-node.log", severity)
-                    , case mExtraLogFile of
-                        Just (FileOf file) ->
-                            Just
-                                (T.pack $ toFilePath file, extraSev)
-                        Nothing -> Nothing
-                    ]
+        GenesisRecord byronFile shelleyFile alonzoFile conwayFile = genesisFiles
 
-    let poolNodeConfig =
+        scribes =
+            let
+                fileScribe (path, sev) =
+                    ScribeDefinition
+                        { scName = path
+                        , scFormat = ScText
+                        , scKind = FileSK
+                        , scMinSev = sev
+                        , scMaxSev = Critical
+                        , scPrivacy = ScPublic
+                        , scRotation = Nothing
+                        }
+            in
+                fileScribe
+                    <$> catMaybes
+                        [ Just ("cardano-node.log", severity)
+                        , mExtraLogFile <&> \(FileOf file) ->
+                            (T.pack $ toFilePath file, extraSev)
+                        ]
+
+        patchConfig value =
+            value
+                & setFilePath "ByronGenesisFile" byronFile
+                & setFilePath "ShelleyGenesisFile" shelleyFile
+                & setFilePath "AlonzoGenesisFile" alonzoFile
+                & setFilePath "ConwayGenesisFile" conwayFile
+                & setHardFork "ShelleyHardFork"
+                & setHardFork "AllegraHardFork"
+                & setHardFork "MaryHardFork"
+                & setHardFork "AlonzoHardFork"
+                & setHardForksForLatestEras clusterEra
+                & key "TestMinSeverity" .~ toJSON Debug
+                & key "setupScribes" .~ toJSON scribes
+                & key "defaultScribes" .~ toJSON (scribeToJSON <$> scribes)
+                & addMinSeverityStdout severity
+
+        poolNodeConfig =
             poolDir </> relFile ("node" <> untag name <> "-config") <.> "yaml"
-        nodeConfigPath :: AbsFile
-        nodeConfigPath = absDirOf cfgClusterConfigs
-            </> relFile "node-config.json"
+
+        nodeConfigPath =
+            absDirOf cfgClusterConfigs </> relFile "node-config.json"
+
     liftIO
         $ Yaml.decodeFileThrow (toFilePath nodeConfigPath)
-            >>= withAddedKey "ShelleyGenesisFile" (absFilePathOf shelleyFile)
-            >>= withAddedKey "ByronGenesisFile" (absFilePathOf byronFile)
-            >>= withAddedKey "AlonzoGenesisFile" (absFilePathOf alonzoFile)
-            >>= withAddedKey "ConwayGenesisFile" (absFilePathOf conwayFile)
-            >>= withHardForks clusterEra
-            >>= withAddedKey "minSeverity" Debug
-            >>= withScribes scribes
-            >>= withObject (addMinSeverityStdout severity)
-            >>= Yaml.encodeFile (toFilePath poolNodeConfig)
+            >>= Yaml.encodeFile (toFilePath poolNodeConfig) . patchConfig
 
-    -- Parameters
     genesisData <- Yaml.decodeFileThrow $ absFilePathOf shelleyFile
-    let networkMagic = NetworkMagic $ sgNetworkMagic genesisData
+
     pure
         ( FileOf @"node-config" poolNodeConfig
         , genesisData
-        , NodeToClientVersionData{networkMagic, query = False}
+        , NodeToClientVersionData
+            { networkMagic = NetworkMagic $ sgNetworkMagic genesisData
+            , query = False
+            }
         )
-  where
-    withScribes :: [ScribeDefinition] -> Yaml.Value -> IO Yaml.Value
-    withScribes scribes =
-        withAddedKey "setupScribes" scribes
-            >=> withAddedKey
-                "defaultScribes"
-                (map (\s -> [toJSON $ scKind s, toJSON $ scName s]) scribes)
 
-    withHardForks :: ClusterEra -> Yaml.Value -> IO Yaml.Value
-    withHardForks era =
-        withObject (pure . Aeson.union (Aeson.fromList hardForks))
-      where
-        hardForks =
-            [ ( Aeson.fromText $ "Test" <> hardFork <> "AtEpoch"
-              , Yaml.Number 0
-              )
-            | hardFork <-
-                [ "ShelleyHardFork"
-                , "AllegraHardFork"
-                , "MaryHardFork"
-                , "AlonzoHardFork"
-                ]
-                    <> (T.pack . show <$> [minBound .. era])
-            ]
+setHardForksForLatestEras :: ClusterEra -> ChangeValue
+setHardForksForLatestEras clusterEra =
+    case clusterEra of
+        BabbageHardFork -> setHardFork (T.pack $ show BabbageHardFork)
+        ConwayHardFork ->
+            setHardFork (T.pack $ show ConwayHardFork)
+                . setHardFork (T.pack $ show BabbageHardFork)
 
--- | Add a @setupScribes[1].scMinSev@ field in a given config object.
--- The full lens library would be quite helpful here.
-addMinSeverityStdout
-    :: MonadFail m
-    => Severity
-    -> Aeson.Object
-    -> m Aeson.Object
-addMinSeverityStdout severity ob = case Aeson.lookup "setupScribes" ob of
-    Just (Aeson.Array scribes) -> do
-        let scribes' = Aeson.Array $ fmap setMinSev scribes
-        pure $ Aeson.insert "setupScribes" scribes' ob
-    _ -> fail "setupScribes logging config is missing or the wrong type"
+scribeToJSON :: ScribeDefinition -> [Value]
+scribeToJSON ScribeDefinition{..} =
+    [ toJSON scKind
+    , toJSON scName
+    ]
+
+setFilePath :: Key -> FileOf x -> ChangeValue
+setFilePath keyName path =
+    atKey keyName ?~ toJSON (absFilePathOf path)
+
+setHardFork :: T.Text -> ChangeValue
+setHardFork hardFork =
+    atKey ("Test" <> fromText hardFork <> "AtEpoch") ?~ Number 0
+
+addMinSeverityStdout :: Severity -> ChangeValue
+addMinSeverityStdout severity =
+    key "setupScribes" . _Array . traverse %~ setMinSev
   where
-    sev = toJSON $ show severity
-    setMinSev (Aeson.Object scribe)
-        | Aeson.lookup "scKind" scribe == Just (Aeson.String "StdoutSK") =
-            Aeson.Object (Aeson.insert "scMinSev" sev scribe)
-        | otherwise = Aeson.Object scribe
-    setMinSev a = a
+    setMinSev :: ChangeValue
+    setMinSev scribe = case scribe ^? key "scKind" . _String of
+        Just "StdoutSK" -> scribe & atKey "scMinSev" ?~ toJSON (show severity)
+        _ -> scribe

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -188,6 +188,7 @@ executable local-cluster
     , local-cluster
     , mtl
     , pathtype
+    , pretty-simple
     , temporary-extra
     , text
     , unliftio


### PR DESCRIPTION
- [x] Refactor `GenNodeConfig` module to simplify direct JSON data corrections
- [x] Add readability to `Show` instances of `FileOf` and `DirOf`
- [x] Remove use of async `link` 

ADP-3366
