### PR TITLE
[ADP-3368] Add benchmark format and write lib, add csv reporting to benchmarks

### DIFF
--- a/.buildkite/bench-db.sh
+++ b/.buildkite/bench-db.sh
@@ -15,8 +15,9 @@ nix build .#ci.benchmarks.db -o $bench_name
 
 echo "+++ Run benchmark"
 
-
-./$bench_name/bin/db --json $bench_name.json -o $bench_name.html | tee $bench_name.txt
+./$bench_name/bin/db --json $bench_name.json \
+    -o $bench_name.html \
+    | tee $bench_name.txt
 
 printf 'Link to \033]1339;url=artifact://'$bench_name.html';content='"Benchmark Report"'\a\n'
 

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -84,7 +84,9 @@ steps:
     key: latency-block
 
   - label: 'Latency benchmark'
-    command: "./.buildkite/bench-latency.sh"
+    command: |
+      export BENCHMARK_CSV_FILE="bench-results.csv"
+      ./.buildkite/bench-latency.sh
     timeout_in_minutes: 120
     agents:
       system: ${linux}

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -55,8 +55,11 @@ steps:
     key: api-block
 
   - label: 'API benchmark'
-    command: "./.buildkite/bench-api.sh"
+    command: |
+      export BENCHMARK_CSV_FILE="bench-results.csv"
+      ./.buildkite/bench-api.sh
     timeout_in_minutes: 210
+    artifact_paths: [ "./bench-results.csv" ]
     agents:
       system: ${linux}
       queue: adrestia-bench

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -187,6 +187,19 @@ steps:
     env:
       TMPDIR: "/cache"
 
+  - label: 'Latency benchmark'
+    command: |
+      export BENCHMARK_CSV_FILE="`pwd`/bench-results.csv"
+      ./.buildkite/bench-latency.sh
+    depends_on: trigger-benchmarks
+    timeout_in_minutes: 20
+    agents:
+      system: x86_64-linux
+    artifact_paths: [ "./bench-results.csv" ]
+    env:
+      TMPDIR: "/cache"
+
+
   - label: 'Read-blocks benchmark'
     command: "./.buildkite/bench-read-blocks.sh"
     depends_on: trigger-benchmarks

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -199,6 +199,17 @@ steps:
     env:
       TMPDIR: "/cache"
 
+  - label: 'DB benchmark'
+    command: |
+      export BENCHMARK_CSV_FILE="`pwd`/bench-results.csv"
+      ./.buildkite/bench-db.sh
+    depends_on: trigger-benchmarks
+    timeout_in_minutes: 50
+    agents:
+      system: x86_64-linux
+    artifact_paths: [ "./bench-results.csv" ]
+    env:
+      TMPDIR: "/cache"
 
   - label: 'Read-blocks benchmark'
     command: "./.buildkite/bench-read-blocks.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -212,16 +212,14 @@ steps:
       TMPDIR: "/cache"
 
   - label: 'Read-blocks benchmark'
-    command: "./.buildkite/bench-read-blocks.sh"
+    command: |
+      export BENCHMARK_CSV_FILE="`pwd`/bench-results.csv"
+      ./.buildkite/bench-read-blocks.sh
     depends_on: trigger-benchmarks
     timeout_in_minutes: 20
     agents:
       system: x86_64-linux
-    # We do not use the  benchmark  queue here, as we don't want
-    # to use system resources that are intended for long-running processes
-    # to perform quick-and-dirty benchmark runs.
-    # queue: benchmark
-    if: 'build.env("step") == null || build.env("step") =~ /bench-api/'
+    artifact_paths: [ "./bench-results.csv" ]
     env:
       TMPDIR: "/cache"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -223,6 +223,18 @@ steps:
     env:
       TMPDIR: "/cache"
 
+  - label: 'memory benchmark'
+    command: |
+      export BENCHMARK_CSV_FILE="`pwd`/bench-results.csv"
+      ./.buildkite/bench-memory.sh
+    depends_on: trigger-benchmarks
+    timeout_in_minutes: 20
+    agents:
+      system: x86_64-linux
+    artifact_paths: [ "./bench-results.csv" ]
+    env:
+      TMPDIR: "/cache"
+
   - block: "macOS steps"
     if: |
       build.branch !~ /^gh-readonly-queue\/master/

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -176,16 +176,14 @@ steps:
     key: trigger-benchmarks
 
   - label: 'API benchmark'
-    command: "./.buildkite/bench-api.sh"
+    command: |
+      export BENCHMARK_CSV_FILE="`pwd`/bench-results.csv"
+      "./.buildkite/bench-api.sh"
     depends_on: trigger-benchmarks
     timeout_in_minutes: 20
     agents:
       system: x86_64-linux
-    # We do not use the  benchmark  queue here, as we don't want
-    # to use system resources that are intended for long-running processes
-    # to perform quick-and-dirty benchmark runs.
-    # queue: benchmark
-    if: 'build.env("step") == null || build.env("step") =~ /bench-api/'
+    artifact_paths: [ "./bench-results.csv" ]
     env:
       TMPDIR: "/cache"
 

--- a/justfile
+++ b/justfile
@@ -172,3 +172,9 @@ test-local-cluster:
         '.#cardano-node' \
         '.#cardano-wallet' \
         -c test-local-cluster-exe
+
+api-bench:
+    BENCHMARK_CSV_FILE=ignore-me/api-bench.csv \
+    cabal run -O0 -v0 \
+            cardano-wallet-benchmarks:api \
+            -- lib/benchmarks/data/api-bench

--- a/justfile
+++ b/justfile
@@ -184,3 +184,8 @@ db-bench:
     BENCHMARK_CSV_FILE=ignore-me/db-bench.csv \
     cabal run -O0 -v0 \
             cardano-wallet-benchmarks:db \
+
+read-blocks-bench:
+    BENCHMARK_CSV_FILE=ignore-me/read-blocks-bench.csv \
+    cabal run -O0 -v0 \
+            cardano-wallet-benchmarks:read-blocks

--- a/justfile
+++ b/justfile
@@ -179,3 +179,8 @@ api-bench:
     cabal run -O0 -v0 \
             cardano-wallet-benchmarks:api \
             -- lib/benchmarks/data/api-bench
+
+db-bench:
+    BENCHMARK_CSV_FILE=ignore-me/db-bench.csv \
+    cabal run -O0 -v0 \
+            cardano-wallet-benchmarks:db \

--- a/justfile
+++ b/justfile
@@ -190,3 +190,19 @@ read-blocks-bench:
     BENCHMARK_CSV_FILE=ignore-me/read-blocks-bench.csv \
     cabal run -O0 -v0 \
             cardano-wallet-benchmarks:read-blocks
+
+memory-bench:
+    mkdir -p ignore-me/memory-bench
+    BENCHMARK_CSV_FILE=ignore-me/memory-bench.csv \
+        nix shell \
+            '.#cardano-node' \
+            '.#cardano-wallet' \
+            'nixpkgs#jq' \
+            'nixpkgs#curl' \
+            'nixpkgs#procps' \
+            -c cabal run -O0 -v0 \
+                cardano-wallet-blackbox-benchmarks:memory -- \
+                    --snapshot lib/wallet-benchmarks/data/membench-snapshot.tgz \
+                    --wallet cardano-wallet \
+                    --node cardano-node \
+                    --work-dir ignore-me/memory-bench

--- a/justfile
+++ b/justfile
@@ -160,7 +160,8 @@ conway-integration-tests:
   just conway-integration-tests-match ""
 
 latency-bench:
-   cabal run -O2 -v0 cardano-wallet-benchmarks:latency -- \
+   BENCHMARK_CSV_FILE=ignore-me/latency-bench.csv \
+   cabal run -O0 -v0 cardano-wallet-benchmarks:latency -- \
    --cluster-configs lib/local-cluster/test/data/cluster-configs
 
 test-local-cluster:

--- a/justfile
+++ b/justfile
@@ -42,6 +42,7 @@ unit-tests-cabal-match match:
   cabal test \
     cardano-balance-tx:test \
     cardano-numeric:unit \
+    cardano-wallet-blackbox-benchmarks:unit \
     cardano-wallet-launcher:unit \
     cardano-wallet-network-layer:unit \
     cardano-wallet-primitive:test \

--- a/lib/address-derivation-discovery/address-derivation-discovery.cabal
+++ b/lib/address-derivation-discovery/address-derivation-discovery.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               address-derivation-discovery
-version:            2024.5.5
+version:            0.2024.5.5
 synopsis:           Address derivation and discovery.
 description:        Please see README.md.
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/application-extras/cardano-wallet-application-extras.cabal
+++ b/lib/application-extras/cardano-wallet-application-extras.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            cardano-wallet-application-extras
-version:         0.1.0.0
+version:         0.2024.5.5
 synopsis:        modules to support applications for the cardano wallet
 license:         Apache-2.0
 license-file:    LICENSE

--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-balance-tx
-version:            2024.5.5
+version:            0.2024.5.5
 synopsis:           Balancing transactions for the Cardano blockchain.
 description:        Please see README.md.
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -40,6 +40,7 @@ library
   build-depends:
     , aeson
     , base
+    , bytestring
     , cardano-addresses
     , cardano-wallet
     , cardano-wallet-api
@@ -49,6 +50,9 @@ library
     , cardano-wallet-network-layer
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
+    , cassava
+    , comonad
+    , containers
     , criterion-measurement
     , deepseq
     , directory
@@ -56,6 +60,7 @@ library
     , faucet
     , filepath
     , fmt
+    , foldl
     , generic-lens
     , hspec
     , http-client
@@ -69,17 +74,20 @@ library
     , resourcet
     , say
     , servant-client
+    , stm
     , temporary-extra
     , text
     , text-class
     , time
     , unliftio
     , unliftio-core
+    , vector
     , wai-middleware-logging
     , with-utf8
 
   exposed-modules:
     Cardano.Wallet.BenchShared
+    Cardano.Wallet.Benchmarks.Collect
     Cardano.Wallet.Benchmarks.Latency.Measure
     Cardano.Wallet.Benchmarks.Latency.BenchM
 
@@ -182,14 +190,18 @@ benchmark db
     , containers
     , contra-tracer
     , criterion
+    , criterion-measurement
     , crypto-primitives
     , deepseq
     , directory
+    , extra
     , filepath
     , fmt
+    , foldl
     , iohk-monitoring
     , iohk-monitoring-extra
     , memory
+    , mtl
     , random
     , text
     , text-class
@@ -216,9 +228,11 @@ benchmark api
     , cardano-wallet-read
     , cardano-wallet-unit:test-common
     , containers
+    , filepath
     , fmt
     , iohk-monitoring
     , iohk-monitoring-extra
+    , mtl
     , say
     , text
     , time

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -247,9 +247,12 @@ benchmark read-blocks
     , base
     , bytestring
     , cardano-wallet
+    , cardano-wallet-benchmarks
     , cardano-wallet-primitive
     , cardano-wallet-read
     , criterion
+    , iohk-monitoring-extra
+    , mtl
     , time
 
   default-language: Haskell2010

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -280,6 +280,7 @@ main = withUtf8
 
 walletApiBench :: SomeMnemonic -> BenchM ()
 walletApiBench massiveMnemonic = do
+
     fmtTitle "Non-cached run"
     runWarmUpScenario
 

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -454,12 +454,18 @@ repeatPostTx wDest amtToSend batchSize amtExp = do
 
     void $ request $ C.deleteWallet wSrcId
 
+iterations :: Int
+iterations = 10
+
 scene :: Reporter IO -> String -> BenchM (Either ClientError a) -> BenchM ()
 scene reporter title scenario = do
-    ts <- measureApiLogs scenario
+    ts <- measureApiLogs iterations scenario
     let avg = meanAvg ts
         semantic = mkSemantic [T.pack title]
-    liftIO $ report reporter $ Benchmark semantic $ Result avg Milliseconds 1
+    liftIO
+        $ report reporter
+        $ Benchmark semantic
+        $ Result avg Milliseconds iterations
     fmtResult title ts
 
 sceneOfClientM :: Reporter IO -> String -> ClientM a -> BenchM ()
@@ -613,21 +619,21 @@ arbitraryStake = Just $ ada 10_000
   where
     ada = Coin . (1_000_000 *)
 
-measureApiLogs :: Exception e => BenchM (Either e a) -> BenchM [NominalDiffTime]
-measureApiLogs action = do
+measureApiLogs :: Exception e => Int -> BenchM (Either e a) -> BenchM [NominalDiffTime]
+measureApiLogs count action = do
     BenchCtx _ctx capture <- ask
     run <- toIO $ do
         r <- action
         case r of
             Left e -> throwM e
             Right q -> pure q
-    liftIO $ Measure.measureApiLogs capture run
+    liftIO $ Measure.measureApiLogs count capture run
 
 runWarmUpScenario :: BenchM ()
 runWarmUpScenario = do
     -- this one is to have comparable results from first to last measurement
     -- in runScenario
-    t <- measureApiLogs $ requestWithError CN.networkInformation
+    t <- measureApiLogs iterations $ requestWithError CN.networkInformation
     fmtResult "getNetworkInfo     " t
 
 withShelleyServer :: Tracers IO -> (SomeMnemonic -> Context -> IO ()) -> IO ()

--- a/lib/benchmarks/exe/read-blocks.hs
+++ b/lib/benchmarks/exe/read-blocks.hs
@@ -2,6 +2,15 @@
 
 import Prelude
 
+import Cardano.BM.ToTextTracer
+    ( ToTextTracer (..)
+    , withToTextTracer
+    )
+import Cardano.Wallet.Benchmarks.Collect
+    ( newReporterFromEnv
+    , noSemantic
+    , runCriterionBenchmark
+    )
 import Cardano.Wallet.Primitive.Types
     ( GenesisParameters (..)
     , StartTime (..)
@@ -16,25 +25,35 @@ import Cardano.Wallet.Read.Block
 import Cardano.Wallet.Read.Block.Gen.Build
     ( exampleBlocks
     )
+import Control.Monad.Cont
+    ( evalContT
+    )
+import Control.Monad.IO.Class
+    ( MonadIO (..)
+    )
 import Criterion.Main
     ( bench
     , bgroup
-    , defaultMain
     , nf
     )
 import Data.Time.Clock.POSIX
     ( posixSecondsToUTCTime
+    )
+import System.IO
+    ( stdout
     )
 
 import qualified Cardano.Wallet.Primitive.Ledger.Read.Block as New
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.ByteString.Char8 as B8
 
--- Our benchmark harness.
 main :: IO ()
-main =
-    defaultMain
-        [ bgroup
+main = evalContT $ do
+    ToTextTracer tr <- withToTextTracer (Left stdout) Nothing
+    reporter <- newReporterFromEnv tr noSemantic
+    liftIO
+        $ runCriterionBenchmark 60 tr reporter
+        $ bgroup
             "read blocks"
             [ bench "1 block" $ nf (run new) 1
             , bench "10 blocks" $ nf (run new) 10
@@ -42,7 +61,6 @@ main =
             , bench "1000 blocks" $ nf (run new) 1000
             , bench "10000 blocks" $ nf (run new) 10000
             ]
-        ]
 
 new :: GenesisParameters -> ConsensusBlock -> W.Block
 new gp = fst . New.fromCardanoBlock (getGenesisBlockHash gp)

--- a/lib/benchmarks/src/Cardano/Wallet/BenchShared.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/BenchShared.hs
@@ -24,7 +24,7 @@ module Cardano.Wallet.BenchShared
       -- * Benchmark runner
     , runBenchmarks
     , bench
-    , Time
+    , Time (..)
     , withTempSqliteFile
     ) where
 

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Collect.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Collect.hs
@@ -1,0 +1,458 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Functor law" #-}
+
+module Cardano.Wallet.Benchmarks.Collect
+    ( -- * Benchmark
+      Benchmark (..)
+
+      -- * Result
+    , Result (..)
+    , Units (..)
+    , HasResults (..)
+
+      -- * Semantic
+    , Semantic
+    , mkSemantic
+    , noSemantic
+
+      -- * Collecting results
+    , Reporter
+    , addSemantic
+    , readSemantic
+    , report
+    , newReporter
+    , newReporterFromEnv
+    , newReporterResourceT
+    , newReporterResourceTFromEnv
+
+      -- * Collecting results from criterion benchmarks
+    , runCriterionBenchmark
+    ) where
+
+import Prelude
+
+import Cardano.BM.Tracing
+    ( HasSeverityAnnotation (..)
+    , Severity (..)
+    , Tracer
+    , traceWith
+    )
+import Control.Comonad
+    ( Comonad (..)
+    )
+import Control.Foldl
+    ( Fold (..)
+    , fold
+    )
+import Control.Monad
+    ( forM_
+    , void
+    )
+import Control.Monad.Cont
+    ( ContT (..)
+    )
+import Control.Monad.Fix
+    ( fix
+    )
+import Control.Monad.Trans.Resource
+    ( ResourceT
+    , register
+    )
+import Criterion.Measurement
+    ( getTime
+    , measure
+    )
+import Criterion.Measurement.Types
+    ( Measured (..)
+    )
+import Data.Csv
+    ( FromField (..)
+    , FromNamedRecord (..)
+    , Header
+    , ToField (..)
+    , ToNamedRecord (..)
+    , header
+    , namedRecord
+    , (.:)
+    , (.=)
+    )
+import Data.Csv.Incremental
+    ( encodeByName
+    , encodeNamedRecord
+    )
+import Data.Foldable
+    ( toList
+    )
+import Data.Int
+    ( Int64
+    )
+import Data.Text
+    ( Text
+    )
+import System.Environment
+    ( lookupEnv
+    )
+import UnliftIO
+    ( MonadIO (..)
+    , atomically
+    , modifyTVar'
+    , newTVarIO
+    , readTVarIO
+    )
+
+import qualified Criterion.Measurement.Types as Cr
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.Text as T
+import Data.Text.Class
+    ( ToText
+    )
+import Data.Text.Class.Extended
+    ( ToText (..)
+    )
+
+-- | A semantic for a benchmark.
+newtype Semantic = Semantic [Text]
+    deriving newtype (Show, Semigroup)
+
+-- | An empty semantic.
+noSemantic :: Semantic
+noSemantic = Semantic []
+
+instance FromField Semantic where
+    parseField = fmap (mkSemantic . reverse . T.words) . parseField
+
+instance ToField Semantic where
+    toField = toField . T.unwords . reverse . unMkSemantic
+
+-- | Create a new semantic from a list of words.
+-- It will frop empty words.
+-- It will replace spaces with dashes.
+mkSemantic :: [Text] -> Semantic
+mkSemantic = Semantic . filter (not . T.null) . fmap (T.replace " " "-")
+
+unMkSemantic :: Semantic -> [Text]
+unMkSemantic (Semantic xs) = toList xs
+
+-- | Units for a result.
+data Units
+    = Seconds
+    | Milliseconds
+    | Microseconds
+    | Nanoseconds
+    | Bytes
+    | MegaBytes
+    | GigaBytes
+    | Count
+
+instance Show Units where
+    show = showUnits
+
+instance FromField Units where
+    parseField "s" = pure Seconds
+    parseField "ms" = pure Milliseconds
+    parseField "us" = pure Microseconds
+    parseField "ns" = pure Nanoseconds
+    parseField "B" = pure Bytes
+    parseField "MB" = pure MegaBytes
+    parseField "GB" = pure GigaBytes
+    parseField "count" = pure Count
+    parseField _ = fail "Invalid units"
+
+instance ToField Units where
+    toField = B8.pack . showUnits
+
+showUnits :: Units -> String
+showUnits Seconds = "s"
+showUnits Milliseconds = "ms"
+showUnits Microseconds = "us"
+showUnits Nanoseconds = "ns"
+showUnits Bytes = "B"
+showUnits MegaBytes = "MB"
+showUnits GigaBytes = "GB"
+showUnits Count = "count"
+
+-- | A result with a value and units.
+data Result = Result
+    { resultValue :: Double
+    , resultUnits :: Units
+    , resultIterations :: Int
+    }
+
+instance Show Result where
+    show (Result value units iterations) =
+        show value
+            ++ " "
+            ++ show units
+            ++ " ("
+            ++ show iterations
+            ++ " iterations)"
+
+-- | A benchmark result with a semantic and a value.
+data Benchmark = Benchmark
+    { benchmarkSemantic :: Semantic
+    , benchmarkResult :: Result
+    }
+    deriving (Show)
+
+-- | A class to collect 'Benchmark' from values of any type.
+class HasResults m r where
+    resultsOf :: r -> m [Benchmark]
+
+instance Monad m => HasResults m Benchmark where
+    resultsOf = pure . pure
+
+instance HasSeverityAnnotation Benchmark where
+    getSeverityAnnotation _ = Notice
+
+instance ToText Benchmark where
+    toText (Benchmark sem res) =
+        T.unwords
+            [ T.unwords $ reverse $ unMkSemantic sem
+            , T.pack $ show res
+            ]
+
+instance ToNamedRecord Benchmark where
+    toNamedRecord (Benchmark semantic (Result value units iterations)) =
+        namedRecord
+            [ "semantic" .= toField semantic
+            , "value" .= toField value
+            , "units" .= toField units
+            , "iterations" .= toField iterations
+            ]
+
+changeBenchmarkSemantic :: (Semantic -> Semantic) -> Benchmark -> Benchmark
+changeBenchmarkSemantic f (Benchmark sem res) = Benchmark (f sem) res
+
+instance FromNamedRecord Benchmark where
+    parseNamedRecord v
+        | length v == 4 =
+            (\s r u i -> Benchmark s (Result r u i))
+                <$> v .: "semantic"
+                <*> v .: "value"
+                <*> v .: "units"
+                <*> v .: "iterations"
+        | otherwise = fail "Expected 3 fields"
+
+-- | An object to track results with an updatable Semantic
+data Reporter m
+    = Reporter
+    { addSemantic :: Semantic -> Reporter m
+    , readSemantic :: Semantic
+    , report :: forall results. HasResults m results => results -> m ()
+    }
+
+mkReport :: (Benchmark -> IO ()) -> Semantic -> Reporter IO
+mkReport out sem = Reporter
+    (\sem' -> mkReport out $ sem' <> sem)
+    sem
+    $ \rs -> do
+        results <- resultsOf rs
+        forM_ results $ out . changeBenchmarkSemantic (<> sem)
+
+mkNullReport :: Applicative m => Reporter m
+mkNullReport = Reporter (const mkNullReport) noSemantic (const $ pure ())
+
+benchmarksHeader :: Header
+benchmarksHeader = header ["semantic", "value", "units", "iterations"]
+
+-- | Create a new reporter from a file path in a 'ContT' context.
+newReporter
+    :: FilePath
+    -- ^ File path to write the results to
+    -> Tracer IO Benchmark
+    -- ^ Tracer for benchmark results
+    -> Semantic
+    -- ^ Root semantic for all benchmarks
+    -> ContT r IO (Reporter IO)
+newReporter fp tr sem0 = do
+    outputVar <- newTVarIO mempty
+    let update bench = do
+            atomically
+                $ modifyTVar' outputVar
+                $ \bs -> bs <> encodeNamedRecord bench
+            traceWith tr bench
+    ContT $ \k -> do
+        r <- k $ mkReport update sem0
+        output <- readTVarIO outputVar
+        BL.writeFile fp $ encodeByName benchmarksHeader output
+        pure r
+
+-- | Create a new reporter from the environment variable 'BENCHMARK_CSV_FILE'
+-- in a 'ContT' context.
+newReporterFromEnv
+    :: Tracer IO Benchmark
+    -- ^ Tracer for benchmark results
+    -> Semantic
+    -- ^ Root semantic for all benchmarks
+    -> ContT r IO (Reporter IO)
+newReporterFromEnv tr rootSem = do
+    csvFile <- liftIO $ lookupEnv "BENCHMARK_CSV_FILE"
+    case csvFile of
+        Just fp -> newReporter fp tr rootSem
+        Nothing -> pure mkNullReport
+
+-- | Create a new reporter from a file path in a 'ResourceT' context.
+newReporterResourceT
+    :: MonadIO m
+    => FilePath
+    -- ^ File path to write the results to
+    -> Tracer IO Benchmark
+    -- ^ Tracer for benchmark results
+    -> Semantic
+    -- ^ Root semantic for all benchmarks
+    -> ResourceT m (Reporter IO)
+newReporterResourceT fp tr sem0 = do
+    outputVar <- newTVarIO mempty
+    let update bench = do
+            atomically
+                $ modifyTVar' outputVar
+                $ \bs -> bs <> encodeNamedRecord bench
+            traceWith tr bench
+    void $ register $ do
+        output <- readTVarIO outputVar
+        BL.writeFile fp $ encodeByName benchmarksHeader output
+    pure $ mkReport update sem0
+
+-- | Create a new reporter from the environment variable 'BENCHMARK_CSV_FILE' in
+-- a 'ResourceT' context.
+newReporterResourceTFromEnv
+    :: MonadIO m
+    => Tracer IO Benchmark
+    -- ^ Tracer for benchmark results
+    -> Semantic
+    -- ^ Root semantic for all benchmarks
+    -> ResourceT m (Reporter IO)
+newReporterResourceTFromEnv tr rootSem = do
+    csvFile <- liftIO $ lookupEnv "BENCHMARK_CSV_FILE"
+    case csvFile of
+        Just fp -> newReporterResourceT fp tr rootSem
+        Nothing -> pure mkNullReport
+
+--------------------------------------------------------------------------------
+--- Collecting results from criterion benchmarks -------------------------------
+--------------------------------------------------------------------------------
+data CountAndAppend a = CountAndAppend
+    { cIterations :: !Int64
+    , total :: !a
+    }
+    deriving stock (Show, Functor)
+
+instance Monoid a => Monoid (CountAndAppend a) where
+    mempty = CountAndAppend 0 mempty
+
+instance Semigroup a => Semigroup (CountAndAppend a) where
+    CountAndAppend n1 t1 <> CountAndAppend n2 t2 =
+        CountAndAppend (n1 + n2) (t1 <> t2)
+
+newtype Time = Time Double
+    deriving newtype (Show, Num, Fractional, Ord, Eq, RealFrac, Real)
+
+data MeasureAndTotal = MeasureAndTotal
+    { measureTime :: !Time
+    , measureTotalTime :: !Time
+    }
+    deriving (Show)
+
+instance Semigroup MeasureAndTotal where
+    MeasureAndTotal t1 tt1 <> MeasureAndTotal t2 tt2 =
+        MeasureAndTotal (t1 + t2) (tt1 + tt2)
+
+instance Monoid MeasureAndTotal where
+    mempty = MeasureAndTotal 0 0
+
+stateFromMeasured :: (Measured, Time) -> CountAndAppend MeasureAndTotal
+stateFromMeasured (m, t) =
+    CountAndAppend
+        (measIters m)
+        (MeasureAndTotal (Time $ measTime m) t)
+
+-- | A special frontend for running criterion benchmarks with a given timeout.
+-- It is designed to use 'Reporter IO' to collect the results and it is not
+-- guaranteed that there is a statistical significance in the results.
+-- In fact if the first iteration is already over the timeout, the result will
+-- be the time of the first iteration.
+runCriterionBenchmark
+    :: Time
+    -- ^ Timeout in seconds. At least 1 iteration will be run.
+    -> Tracer IO Benchmark
+    -- ^ Tracer for benchmark results
+    -> Reporter IO
+    -- ^ Reporter for benchmark results
+    -> Cr.Benchmark
+    -- ^ Criterion benchmark to run
+    -> IO ()
+runCriterionBenchmark timeout tr = go
+  where
+    go r (Cr.Benchmark s b) = do
+        v <- runCriterion timeout (\n -> fst <$> measure b (fromIntegral n))
+        let r' = addSemantic r $ mkSemantic [T.pack s]
+            Time average = total v / fromIntegral (cIterations v)
+            benchmark =
+                Benchmark (readSemantic r')
+                    $ Result average Seconds
+                    $ fromIntegral
+                    $ cIterations v
+        traceWith tr benchmark
+        report r' benchmark
+    go r (Cr.BenchGroup s bs) = do
+        let sem = mkSemantic [T.pack s]
+        mapM_ (go $ addSemantic r sem) bs
+    go r (Cr.Environment s c f) = do
+        e <- s
+        go r $ f e
+        void $ c e
+
+-- | Update a fold with a new value.
+updateFold :: Fold input output -> input -> Fold input output
+updateFold f x = fold (duplicate f) [x]
+
+-- | A fold over a stream of (Measured, Time) where the time is the
+-- real time of the full measurement.
+-- It will output the total iterations, and the total measured time as from
+-- the Measured values from criterion.
+collectFold
+    :: Time
+    -- ^ Timeout in seconds. At least 1 iteration will be run.
+    -> Fold (Measured, Time) (CountAndAppend Time, Int)
+collectFold timeout = Fold add create value
+  where
+    add (state, _) v =
+        let
+            state'@(CountAndAppend n (MeasureAndTotal _ ut)) =
+                state <> stateFromMeasured v
+            timeLeft = max 0 $ timeout - ut
+            estimate = ut / fromIntegral n
+        in
+            (state', floor $ timeLeft / estimate)
+    create = (mempty, 1)
+    value (state, j) = (fmap measureTime state, j)
+
+withElapsedTime :: MonadIO m => m a -> m (a, Time)
+withElapsedTime action = do
+    start <- liftIO getTime
+    result <- action
+    end <- liftIO getTime
+    pure (result, Time $ end - start)
+
+runCriterion
+    :: MonadIO m
+    => Time
+    -- ^ Timeout in seconds. At least 1 iteration will be run.
+    -> (Int -> m Measured)
+    -- ^ Action to run for each iteration
+    -> m (CountAndAppend Time)
+runCriterion t f = ($ (collectFold t)) $ fix $ \loop state -> do
+    let (result, next) = extract state
+    if next <= 0
+        then pure result
+        else do
+            v <- withElapsedTime $ f next
+            loop $ updateFold state v

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Collect.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Collect.hs
@@ -148,6 +148,7 @@ data Units
     | Microseconds
     | Nanoseconds
     | Bytes
+    | KiloBytes
     | MegaBytes
     | GigaBytes
     | Count
@@ -161,6 +162,7 @@ instance FromField Units where
     parseField "us" = pure Microseconds
     parseField "ns" = pure Nanoseconds
     parseField "B" = pure Bytes
+    parseField "KB" = pure KiloBytes
     parseField "MB" = pure MegaBytes
     parseField "GB" = pure GigaBytes
     parseField "count" = pure Count
@@ -175,6 +177,7 @@ showUnits Milliseconds = "ms"
 showUnits Microseconds = "us"
 showUnits Nanoseconds = "ns"
 showUnits Bytes = "B"
+showUnits KiloBytes = "KB"
 showUnits MegaBytes = "MB"
 showUnits GigaBytes = "GB"
 showUnits Count = "count"

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/Measure.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/Measure.hs
@@ -110,24 +110,21 @@ isLogRequestFinish = \case
     ApiLog _ LogRequestFinish -> True
     _ -> False
 
-measureApiLogs :: LogCaptureFunc ApiLog () -> IO a -> IO [NominalDiffTime]
-measureApiLogs = measureLatency isLogRequestStart isLogRequestFinish
-
--- | Run tests for at least this long to get accurate timings.
-sampleNTimes :: Int
-sampleNTimes = 10
+measureApiLogs :: Int -> LogCaptureFunc ApiLog () -> IO a -> IO [NominalDiffTime]
+measureApiLogs count = measureLatency count isLogRequestStart isLogRequestFinish
 
 -- | Measure how long an action takes based on trace points and taking an
 -- average of results over a short time period.
 measureLatency
     :: Show msg
-    => (msg -> Bool) -- ^ Predicate for start message
+    => Int
+    -> (msg -> Bool) -- ^ Predicate for start message
     -> (msg -> Bool) -- ^ Predicate for end message
     -> LogCaptureFunc msg () -- ^ Log capture function.
     -> IO a -- ^ Action to run
     -> IO [NominalDiffTime]
-measureLatency start finish capture action = do
-    (logs, ()) <- capture $ replicateM_ sampleNTimes action
+measureLatency count start finish capture action = do
+    (logs, ()) <- capture $ replicateM_ count action
     pure $ extractTimings start finish logs
 
 -- | Scan through iohk-monitoring logs and extract time differences between

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/Measure.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/Measure.hs
@@ -13,6 +13,7 @@ module Cardano.Wallet.Benchmarks.Latency.Measure
     -- * Formatting results
   , fmtResult
   , fmtTitle
+  , meanAvg
   ) where
 
 import Prelude

--- a/lib/cardano-api-extra/cardano-api-extra.cabal
+++ b/lib/cardano-api-extra/cardano-api-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.4
 name:               cardano-api-extra
-version:            2024.5.5
+version:            0.2024.5.5
 synopsis:           Useful extensions to the Cardano API.
 description:        Please see README.md.
 homepage:           https://github.com/cardano-foundation/cardano-wallet
@@ -67,4 +67,3 @@ library
   exposed-modules:
     Cardano.Api.Gen
     Cardano.Ledger.Credential.Safe
-

--- a/lib/coin-selection/cardano-coin-selection.cabal
+++ b/lib/coin-selection/cardano-coin-selection.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               cardano-coin-selection
-version:            2024.5.5
+version:            0.2024.5.5
 synopsis:           Coin selection algorithms for the Cardano blockchain.
 description:        Please see README.md.
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/crypto-primitives/crypto-primitives.cabal
+++ b/lib/crypto-primitives/crypto-primitives.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          crypto-primitives
-version:       0.1.0.0
+version:       0.2024.5.5
 synopsis:      Cryptographic primitives
 license:       Apache-2.0
 author:        Cardano Foundation (High Assurance Lab)

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.6
 build-type:         Simple
 name:               customer-deposit-wallet
-version:            0.1.0.0
+version:            0.2024.5.5
 synopsis:           A wallet for the Cardano blockchain.
 description:        Please see README.md
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/delta-store/delta-store.cabal
+++ b/lib/delta-store/delta-store.cabal
@@ -1,5 +1,5 @@
 name:                delta-store
-version:             0.1.0.0
+version:             0.2024.5.5
 synopsis:            Facility for storing a Haskell value, using delta types.
 homepage:            https://github.com/cardano-foundation/cardano-wallet
 author:              Cardano Foundation (High Assurance Lab)

--- a/lib/delta-table/delta-table.cabal
+++ b/lib/delta-table/delta-table.cabal
@@ -1,5 +1,5 @@
 name:                delta-table
-version:             0.1.0.0
+version:             0.2024.5.5
 synopsis:            Work with database tables using delta encodings.
 homepage:            https://github.com/cardano-foundation/cardano-wallet
 author:              Cardano Foundation (High Assurance Lab)

--- a/lib/delta-types/delta-types.cabal
+++ b/lib/delta-types/delta-types.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                delta-types
-version:             0.1.0.0
+version:             0.2024.5.5
 synopsis:            Delta types, also known as change actions.
 description:
     A __delta type__ @da@ for a __base type__ @a@ is a collection

--- a/lib/faucet/faucet.cabal
+++ b/lib/faucet/faucet.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          faucet
-version:       0.1.0.0
+version:       2024.5.5
 synopsis:      Faucet for the local Cardano cluster.
 homepage:      https://github.com/cardano-foundation/cardano-wallet
 license:       Apache-2.0

--- a/lib/iohk-monitoring-extra/iohk-monitoring-extra.cabal
+++ b/lib/iohk-monitoring-extra/iohk-monitoring-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          iohk-monitoring-extra
-version:       0.1.0.0
+version:       0.2024.5.5
 synopsis:      Extra functionality extending the iohk-monitoring package
 license:       Apache-2.0
 license-file:  LICENSE

--- a/lib/iohk-monitoring-extra/src/Cardano/BM/ToTextTracer.hs
+++ b/lib/iohk-monitoring-extra/src/Cardano/BM/ToTextTracer.hs
@@ -3,8 +3,8 @@
 module Cardano.BM.ToTextTracer
     ( ToTextTracer (..)
     , logHandleFromFilePath
-    , newToTextTracer
     , withFile
+    , withToTextTracer
     )
 where
 
@@ -80,13 +80,13 @@ logHandleFromFilePath clusterLogsFile = do
     pure h
 
 -- | Create a new `ToTextTracer`
-newToTextTracer
+withToTextTracer
     :: Either Handle FilePath
     -- ^ If provided, logs will be written to this file, otherwise to stdout
     -> Maybe Severity
     -- ^ Minimum severity level to log
     -> ContT r IO ToTextTracer
-newToTextTracer mClusterLogsFile minSeverity = do
+withToTextTracer mClusterLogsFile minSeverity = do
     ch <- newTChanIO
     h <- case mClusterLogsFile of
         Left h -> pure h

--- a/lib/iohk-monitoring-extra/src/Cardano/BM/ToTextTracer.hs
+++ b/lib/iohk-monitoring-extra/src/Cardano/BM/ToTextTracer.hs
@@ -5,6 +5,7 @@ module Cardano.BM.ToTextTracer
     , logHandleFromFilePath
     , withFile
     , withToTextTracer
+    , overToTextTracer
     )
 where
 
@@ -133,3 +134,14 @@ withFile path mode action = do
             hClose h
             throwIO e
     catch action' handler
+
+-- | Modify the tracer of a `ToTextTracer`
+overToTextTracer
+    :: ( forall a
+          . (HasSeverityAnnotation a, ToText a)
+         => Tracer IO a
+         -> Tracer IO a
+       )
+    -> ToTextTracer
+    -> ToTextTracer
+overToTextTracer f (ToTextTracer tr) = ToTextTracer (f tr)

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-launcher
-version:             2024.5.5
+version:             0.2024.5.5
 synopsis:            Utilities for a building commands launcher
 homepage:            https://github.com/cardano-foundation/cardano-wallet
 author:              Cardano Foundation (High Assurance Lab)

--- a/lib/local-cluster/exe/local-cluster.hs
+++ b/lib/local-cluster/exe/local-cluster.hs
@@ -6,7 +6,7 @@ import Prelude
 
 import Cardano.BM.ToTextTracer
     ( ToTextTracer (..)
-    , newToTextTracer
+    , withToTextTracer
     )
 import Cardano.Launcher.Node
     ( nodeSocketFile
@@ -252,10 +252,9 @@ main = withUtf8 $ do
         -- Add a tracer for the cluster logs
         ToTextTracer tracer <- case clusterLogs of
             Nothing -> pure $ ToTextTracer nullTracer
-            Just path ->
-                newToTextTracer
-                    (Right . toFilePath . absFileOf $ path)
-                    minSeverity
+            Just path -> withToTextTracer
+                (Right . toFilePath . absFileOf $ path)
+                minSeverity
 
         let debug :: MonadIO m => Text -> m ()
             debug = liftIO . traceWith tracer

--- a/lib/local-cluster/exe/local-cluster.hs
+++ b/lib/local-cluster/exe/local-cluster.hs
@@ -6,8 +6,7 @@ import Prelude
 
 import Cardano.BM.ToTextTracer
     ( ToTextTracer (..)
-    , logHandleFromFilePath
-    , newToTextTracerFromHandle
+    , newToTextTracer
     )
 import Cardano.Launcher.Node
     ( nodeSocketFile
@@ -253,9 +252,10 @@ main = withUtf8 $ do
         -- Add a tracer for the cluster logs
         ToTextTracer tracer <- case clusterLogs of
             Nothing -> pure $ ToTextTracer nullTracer
-            Just path -> do
-                h <- logHandleFromFilePath $ toFilePath . absFileOf $ path
-                newToTextTracerFromHandle h minSeverity
+            Just path ->
+                newToTextTracer
+                    (Right . toFilePath . absFileOf $ path)
+                    minSeverity
 
         let debug :: MonadIO m => Text -> m ()
             debug = liftIO . traceWith tracer

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.6
 name:          local-cluster
-version:       0.1.0.0
+version:       2024.5.5
 synopsis:      Local cluster of cardano nodes
 homepage:      https://github.com/cardano-foundation/cardano-wallet
 license:       Apache-2.0

--- a/lib/local-cluster/process/Cardano/Wallet/Launch/Cluster/Process.hs
+++ b/lib/local-cluster/process/Cardano/Wallet/Launch/Cluster/Process.hs
@@ -22,7 +22,7 @@ import Prelude
 import Cardano.BM.ToTextTracer
     ( ToTextTracer (..)
     , logHandleFromFilePath
-    , newToTextTracerFromHandle
+    , newToTextTracer
     )
 import Cardano.Launcher
     ( Command (..)
@@ -145,9 +145,8 @@ withLocalCluster name walletOption envs faucetFundsValue = do
         localClusterCommand name walletOption envs port faucetFundsPath
     ToTextTracer processLogs <- case logsPathName of
         Nothing -> pure $ ToTextTracer nullTracer
-        Just path -> do
-            handle <- logHandleFromFilePath $ path <> "-process" <.> "log"
-            newToTextTracerFromHandle handle Nothing
+        Just path ->
+            newToTextTracer (Right $ path <> "-process" <.> "log") Nothing
     _ <-
         ContT
             $ withBackendProcess

--- a/lib/local-cluster/process/Cardano/Wallet/Launch/Cluster/Process.hs
+++ b/lib/local-cluster/process/Cardano/Wallet/Launch/Cluster/Process.hs
@@ -22,7 +22,7 @@ import Prelude
 import Cardano.BM.ToTextTracer
     ( ToTextTracer (..)
     , logHandleFromFilePath
-    , newToTextTracer
+    , withToTextTracer
     )
 import Cardano.Launcher
     ( Command (..)
@@ -146,7 +146,7 @@ withLocalCluster name walletOption envs faucetFundsValue = do
     ToTextTracer processLogs <- case logsPathName of
         Nothing -> pure $ ToTextTracer nullTracer
         Just path ->
-            newToTextTracer (Right $ path <> "-process" <.> "log") Nothing
+            withToTextTracer (Right $ path <> "-process" <.> "log") Nothing
     _ <-
         ContT
             $ withBackendProcess

--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.6
 name:            cardano-wallet-network-layer
-version:         0.1.0.0
+version:         0.2024.5.5
 synopsis:        Node communication layer functionality.
 
 -- description:

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.6
 name:          cardano-wallet-primitive
-version:       2024.5.5
+version:       0.2024.5.5
 synopsis:      Selected primitive types for Cardano Wallet.
 description:   Please see README.md.
 homepage:      https://github.com/cardano-foundation/cardano-wallet

--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.6
 name:            cardano-wallet-read
-version:         2023.8.1
+version:         0.2024.5.5
 synopsis:
   Primitive era-dependent operations to read the cardano blocks and transactions
 

--- a/lib/secrets/cardano-wallet-secrets.cabal
+++ b/lib/secrets/cardano-wallet-secrets.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-wallet-secrets
-version:            0.1.0.0
+version:            0.2024.5.5
 synopsis:           Utilities for storing private keys and passphrases
 license:            Apache-2.0
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/std-gen-seed/std-gen-seed.cabal
+++ b/lib/std-gen-seed/std-gen-seed.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            std-gen-seed
-version:         0.0.0.0
+version:         0.2024.5.5
 synopsis:        Support for standard random number generator seeds
 license:         Apache-2.0
 author:          Cardano Foundation (High Assurance Lab)

--- a/lib/temporary-extra/temporary-extra.cabal
+++ b/lib/temporary-extra/temporary-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          temporary-extra
-version:       0.1.0.0
+version:       0.2024.5.5
 synopsis:      Extra functionality extending the temporary package
 license:       Apache-2.0
 license-file:  LICENSE

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-test-utils
-version:             2024.5.5
+version:             0.2024.5.5
 synopsis:            Shared utilities for writing unit and property tests.
 description:         Shared utilities for writing unit and property tests.
 homepage:            https://github.com/cardano-foundation/cardano-wallet

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -1,5 +1,5 @@
 name:                text-class
-version:             2024.5.5
+version:             0.2024.5.5
 synopsis:            Extra helpers to convert data-types to and from Text
 homepage:            https://github.com/cardano-foundation/cardano-wallet
 author:              Cardano Foundation (High Assurance Lab)

--- a/lib/wai-middleware-logging/wai-middleware-logging.cabal
+++ b/lib/wai-middleware-logging/wai-middleware-logging.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          wai-middleware-logging
-version:       1.0
+version:       0.2024.5.5
 synopsis:      WAI Middleware for Logging
 homepage:      https://github.com/cardano-foundation/cardano-wallet
 author:        Cardano Foundation (High Assurance Lab)

--- a/lib/wallet-benchmarks/bench/memory-benchmark.hs
+++ b/lib/wallet-benchmarks/bench/memory-benchmark.hs
@@ -1,31 +1,63 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
-import Prelude
+import Prelude hiding
+    ( takeWhile
+    )
 
-import Cardano.BM.Data.Tracer
-    ( HasPrivacyAnnotation (..)
-    , HasSeverityAnnotation (..)
+import Cardano.BM.ToTextTracer
+    ( ToTextTracer (ToTextTracer)
+    , withToTextTracer
+    )
+import Cardano.BM.Tracing
+    ( HasSeverityAnnotation (..)
+    , Severity (..)
+    )
+import Cardano.Launcher
+    ( ProcessHandles (..)
     )
 import Cardano.Launcher.Node
     ( MaybeK (..)
     )
+import Cardano.Launcher.Wallet
+    ( CardanoWalletConn (CardanoWalletConn)
+    )
 import Cardano.Startup
     ( installSignalHandlers
+    )
+import Cardano.Wallet.Benchmark.Memory.Pmap
+    ( Line
+    , Pmap (..)
+    , command
+    , memory
+    , pmap
+    )
+import Cardano.Wallet.Benchmarks.Collect
+    ( Benchmark (..)
+    , Result (..)
+    , Units (..)
+    , mkSemantic
+    , newReporterFromEnv
+    , noSemantic
+    , report
     )
 import Control.Concurrent
     ( threadDelay
     )
 import Control.Monad
-    ( unless
-    , void
-    , when
+    ( when
+    )
+import Control.Monad.Cont
+    ( ContT (..)
+    , evalContT
+    )
+import Control.Monad.IO.Class
+    ( MonadIO (..)
     )
 import Control.Tracer
     ( Tracer (..)
-    , contramap
     , traceWith
     )
 import Data.List
@@ -47,6 +79,9 @@ import System.FilePath
     ( takeBaseName
     , (</>)
     )
+import System.IO
+    ( stdout
+    )
 import System.IO.Temp
     ( withSystemTempDirectory
     )
@@ -54,19 +89,12 @@ import Text.Read
     ( readMaybe
     )
 
-import qualified Cardano.BM.Configuration.Model as Log
-import qualified Cardano.BM.Configuration.Static as Log
-import qualified Cardano.BM.Data.BackendKind as Log
-import qualified Cardano.BM.Data.LogItem as Log
-import qualified Cardano.BM.Data.Severity as Log
-import qualified Cardano.BM.Setup as Log
 import qualified Cardano.Launcher as C
 import qualified Cardano.Launcher.Node as C
 import qualified Cardano.Launcher.Wallet as C
-import qualified "optparse-applicative" Options.Applicative as O
+import qualified Data.Text as T
+import qualified Options.Applicative as O
 import qualified System.Process as S
-
--- See ADP-1910 for Options.Applicative usage
 
 {-----------------------------------------------------------------------------
     Configuration
@@ -126,6 +154,14 @@ configInfo = O.info (configParser O.<**> O.helper) $ mconcat
     , O.header "memory-benchmark - a benchmark for cardano-wallet memory usage"
     ]
 
+newtype MemoryBenchLog = MemoryBenchLog Text
+
+instance HasSeverityAnnotation MemoryBenchLog where
+    getSeverityAnnotation _ = Notice
+
+instance ToText MemoryBenchLog where
+    toText (MemoryBenchLog t) = t
+
 main :: IO ()
 main = withUtf8 $ do
     Config{..} <- O.execParser configInfo
@@ -136,20 +172,41 @@ main = withUtf8 $ do
 
     installSignalHandlers (pure ())
 
-    trText <- initLogging "memory-benchmark" Log.Debug
-    let tr0 = trText
-        tr = contramap toText tr0
+    evalContT $ do
+        ToTextTracer tr <- withToTextTracer (Left stdout) (Just Notice)
+        let trace = liftIO . traceWith tr . MemoryBenchLog
+        trace "Starting memory benchmark"
+        tmp <- ContT $ withSystemTempDirectory "wallet"
+        trace $ "Copying snapshot to " <> T.pack tmp
+        cfg <- liftIO $ copyNodeSnapshot snapshot tmp
+        trace "Starting the node"
+        node <- ContT $ withCardanoNode tr nodeExe cfg
+        sleep 5
+        trace "Starting the wallet"
+        wallet@(CardanoWalletConn _c p) <-
+            ContT $ withCardanoWallet tr workingDir walletExe cfg node
+        sleep 1
+        trace "Creating a wallet"
+        liftIO $ createWallet wallet testMnemonic
+        sleep 1
+        trace "Waiting for synchronization"
+        liftIO $ waitUntilSynchronized tr wallet
+        reporter <- newReporterFromEnv tr $ mkSemantic ["memory"]
+        trace "Running pmap on the wallet process"
+        Pmap {pmapLines} <- liftIO $ pmap $ processHandle p
+        let usage = highestMemoryUsageFor "cardano-wallet" pmapLines
+        trace "Reporting the result"
+        liftIO
+            $ report reporter
+            $ Benchmark noSemantic
+            $ Result (fromIntegral usage) KiloBytes 1
+        trace "End of the benchmark"
 
-    withSystemTempDirectory "wallet" $ \tmp -> do
-        cfg <- copyNodeSnapshot snapshot tmp
-        void $ withCardanoNode tr nodeExe cfg $ \node -> do
-            sleep 5
-            withCardanoWallet tr workingDir walletExe cfg node
-                $ \wallet -> void $ do
-                    sleep 1
-                    createWallet wallet testMnemonic
-                    sleep 1
-                    waitUntilSynchronized tr0 wallet
+highestMemoryUsageFor :: String -> [Line] -> Int
+highestMemoryUsageFor cmd =
+    maximum
+        . map memory
+        . filter (\l -> command l == cmd)
 
 waitUntilSynchronized :: Tracer IO Text  -> C.CardanoWalletConn -> IO ()
 waitUntilSynchronized tr wallet = do
@@ -280,8 +337,8 @@ withCardanoNode tr nodeExe BenchmarkConfig{..} action =
 {-----------------------------------------------------------------------------
     Utilities
 ------------------------------------------------------------------------------}
-sleep :: Int -> IO ()
-sleep seconds = threadDelay (seconds * 1000 * 1000)
+sleep :: MonadIO m => Int -> m ()
+sleep seconds = liftIO $ threadDelay (seconds * 1000 * 1000)
 
 -- | Throw an exception if the executable is not in the `$PATH`.
 requireExecutable :: FilePath -> String -> IO ()
@@ -293,29 +350,3 @@ copyFile source destination = S.callProcess "cp" [source,destination]
 decompress :: FilePath -> FilePath -> IO ()
 decompress source destination =
     S.callProcess "tar" ["-xzvf", source, "-C", destination]
-
-{-----------------------------------------------------------------------------
-    Logging
-------------------------------------------------------------------------------}
-initLogging :: Text -> Log.Severity -> IO (Tracer IO Text)
-initLogging name minSeverity = do
-    c <- Log.defaultConfigStdout
-    Log.setMinSeverity c minSeverity
-    Log.setSetupBackends c [Log.KatipBK, Log.AggregationBK]
-    (tr, _sb) <- Log.setupTrace_ c name
-    pure (trMessageText tr)
-
--- | Tracer transformer which transforms traced items to their 'ToText'
--- representation and further traces them as a 'Log.LogObject'.
--- If the 'ToText' representation is empty, then no tracing happens.
-trMessageText
-    :: (ToText a, HasPrivacyAnnotation a, HasSeverityAnnotation a)
-    => Tracer IO (Log.LoggerName, Log.LogObject Text)
-    -> Tracer IO a
-trMessageText tr = Tracer $ \arg -> do
-    let msg = toText arg
-    unless (msg == mempty) $ do
-        meta <- Log.mkLOMeta
-            (getSeverityAnnotation arg)
-            (getPrivacyAnnotation arg)
-        traceWith tr (mempty, Log.LogObject mempty meta (Log.LogMessage msg))

--- a/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
+++ b/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
@@ -32,6 +32,7 @@ benchmark memory
   build-depends:
     , base
     , cardano-wallet-launcher
+    , cardano-wallet-benchmarks
     , contra-tracer
     , filepath
     , iohk-monitoring

--- a/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
+++ b/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
@@ -60,10 +60,14 @@ benchmark memory
     Paths_cardano_wallet_blackbox_benchmarks
   build-depends:
     , base
+    , cardano-wallet-blackbox-benchmarks
+    , cardano-wallet-benchmarks
     , cardano-wallet-launcher
     , contra-tracer
     , filepath
     , iohk-monitoring
+    , iohk-monitoring-extra
+    , mtl
     , process
     , temporary
     , text

--- a/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
+++ b/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
@@ -1,4 +1,4 @@
-cabal-version:       3.0
+cabal-version:       3.6
 name:                cardano-wallet-blackbox-benchmarks
 version:             2024.5.5
 synopsis:            Benchmarks for the `cardano-wallet` exectuable.
@@ -12,15 +12,44 @@ copyright:           2023 Cardano Foundation
 license:             Apache-2.0
 category:            Web
 build-type:          Simple
-data-files:          data/membench-snapshot.tgz
+data-files:
+    data/membench-snapshot.tgz
+    data/hoogle-pmap.txt
 
 common language
-  ghc-options:        -threaded -Wall
+  ghc-options:        -threaded -Wall -Wunused-packages
   default-language:   Haskell2010
   default-extensions:
     NamedFieldPuns
     NoImplicitPrelude
     OverloadedStrings
+
+flag release
+  description: Enable optimization and `-Werror`
+  default:     False
+  manual:      True
+
+common opts-lib
+  ghc-options: -Wall -Wcompat -Wredundant-constraints
+
+  if flag(release)
+    ghc-options: -O2 -Werror
+
+common opts-exe
+  import:      opts-lib
+  ghc-options: -threaded -rtsopts
+
+library
+  import:          language, opts-lib
+  hs-source-dirs:  lib
+  build-depends:
+    , attoparsec
+    , base
+    , bytestring
+    , process
+    , unliftio
+  exposed-modules:
+    Cardano.Wallet.Benchmark.Memory.Pmap
 
 benchmark memory
   import:         language
@@ -32,7 +61,6 @@ benchmark memory
   build-depends:
     , base
     , cardano-wallet-launcher
-    , cardano-wallet-benchmarks
     , contra-tracer
     , filepath
     , iohk-monitoring
@@ -42,3 +70,19 @@ benchmark memory
     , text-class
     , optparse-applicative
     , with-utf8
+
+test-suite unit
+  import:           language, opts-exe
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  main-is:          Main.hs
+  build-depends:
+    , attoparsec
+    , base
+    , bytestring
+    , hspec
+    , cardano-wallet-blackbox-benchmarks
+  build-tool-depends: hspec-discover:hspec-discover
+  other-modules:
+    Cardano.Wallet.Benchmark.Memory.PmapSpec
+    Paths_cardano_wallet_blackbox_benchmarks

--- a/lib/wallet-benchmarks/data/hoogle-pmap.txt
+++ b/lib/wallet-benchmarks/data/hoogle-pmap.txt
@@ -1,0 +1,94 @@
+2316565:   /nix/store/2a2sbgbjg11g40awcizfbcrhsqa580wx-hoogle-exe-hoogle-5.0.18.4/bin/hoogle serve --database /nix/store/vk9yi9ww5bslmy49jv1g4ahifj527kjy-hoogle-with-packages/share/doc/hoogle/default.hoo --local
+0000000000400000  17376K r-x-- hoogle
+00000000014f9000      8K r---- hoogle
+00000000014fb000   2628K rw--- hoogle
+000000000178c000     12K rw---   [ anon ]
+00000000018d4000    276K rw---   [ anon ]
+0000004200000000  15360K rw---   [ anon ]
+0000004200f00000 1073727488K -----   [ anon ]
+00007f1204000000    132K rw---   [ anon ]
+00007f1204021000  65404K -----   [ anon ]
+00007f1208feb000 114772K r---- default.hoo
+00007f1210000000   1360K rw---   [ anon ]
+00007f1210154000  64176K -----   [ anon ]
+00007f1216ffe000      4K -----   [ anon ]
+00007f1216fff000   8192K rw---   [ anon ]
+00007f12177ff000      4K -----   [ anon ]
+00007f1217800000   9388K rw---   [ anon ]
+00007f121812b000  64340K -----   [ anon ]
+00007f121c000000    132K rw---   [ anon ]
+00007f121c021000  65404K -----   [ anon ]
+00007f1220000000    132K rw---   [ anon ]
+00007f1220021000  65404K -----   [ anon ]
+00007f12246d3000      4K -----   [ anon ]
+00007f12246d4000   8192K rw---   [ anon ]
+00007f1224ed4000      4K -----   [ anon ]
+00007f1224ed5000   8192K rw---   [ anon ]
+00007f12256d5000      4K -----   [ anon ]
+00007f12256d6000  12296K rw---   [ anon ]
+00007f12262d8000    460K r---- locale-archive
+00007f122634b000     16K rw---   [ anon ]
+00007f122634f000     16K r---- libgcc_s.so.1
+00007f1226353000     92K r-x-- libgcc_s.so.1
+00007f122636a000     16K r---- libgcc_s.so.1
+00007f122636e000      4K r---- libgcc_s.so.1
+00007f122636f000      4K rw--- libgcc_s.so.1
+00007f1226370000      8K rw---   [ anon ]
+00007f1226372000     16K r---- libnuma.so.1.0.0
+00007f1226376000     24K r-x-- libnuma.so.1.0.0
+00007f122637c000      8K r---- libnuma.so.1.0.0
+00007f122637e000      4K r---- libnuma.so.1.0.0
+00007f122637f000      4K rw--- libnuma.so.1.0.0
+00007f1226380000      8K r---- libffi.so.8.1.2
+00007f1226382000     28K r-x-- libffi.so.8.1.2
+00007f1226389000      8K r---- libffi.so.8.1.2
+00007f122638b000      4K r---- libffi.so.8.1.2
+00007f122638c000      4K rw--- libffi.so.8.1.2
+00007f122638d000      4K r---- libdl.so.2
+00007f122638e000      4K r-x-- libdl.so.2
+00007f122638f000      4K r---- libdl.so.2
+00007f1226390000      4K r---- libdl.so.2
+00007f1226391000      4K rw--- libdl.so.2
+00007f1226392000      4K r---- librt.so.1
+00007f1226393000      4K r-x-- librt.so.1
+00007f1226394000      4K r---- librt.so.1
+00007f1226395000      4K r---- librt.so.1
+00007f1226396000      4K rw--- librt.so.1
+00007f1226397000    136K r---- libc.so.6
+00007f12263b9000   1380K r-x-- libc.so.6
+00007f1226512000    352K r---- libc.so.6
+00007f122656a000     16K r---- libc.so.6
+00007f122656e000      8K rw--- libc.so.6
+00007f1226570000     60K rw---   [ anon ]
+00007f122657f000     72K r---- libgmp.so.10.5.0
+00007f1226591000    476K r-x-- libgmp.so.10.5.0
+00007f1226608000     92K r---- libgmp.so.10.5.0
+00007f122661f000      8K r---- libgmp.so.10.5.0
+00007f1226621000      4K rw--- libgmp.so.10.5.0
+00007f1226622000    644K r---- libstdc++.so.6.0.30
+00007f12266c3000   1052K r-x-- libstdc++.so.6.0.30
+00007f12267ca000    444K r---- libstdc++.so.6.0.30
+00007f1226839000     52K r---- libstdc++.so.6.0.30
+00007f1226846000      4K rw--- libstdc++.so.6.0.30
+00007f1226847000     12K rw---   [ anon ]
+00007f122684a000     12K r---- libz.so.1.3
+00007f122684d000     72K r-x-- libz.so.1.3
+00007f122685f000     28K r---- libz.so.1.3
+00007f1226866000      4K r---- libz.so.1.3
+00007f1226867000      4K rw--- libz.so.1.3
+00007f1226868000     56K r---- libm.so.6
+00007f1226876000    464K r-x-- libm.so.6
+00007f12268ea000    368K r---- libm.so.6
+00007f1226946000      4K r---- libm.so.6
+00007f1226947000      4K rw--- libm.so.6
+00007f1226948000      8K rw---   [ anon ]
+00007f122694a000      4K r---- ld-linux-x86-64.so.2
+00007f122694b000    152K r-x-- ld-linux-x86-64.so.2
+00007f1226971000     40K r---- ld-linux-x86-64.so.2
+00007f122697b000      8K r---- ld-linux-x86-64.so.2
+00007f122697d000      8K rw--- ld-linux-x86-64.so.2
+00007ffc25363000    196K rw---   [ stack ]
+00007ffc253c2000     16K r----   [ anon ]
+00007ffc253c6000      8K r-x--   [ anon ]
+ffffffffff600000      4K --x--   [ anon ]
+ total       1074257720K

--- a/lib/wallet-benchmarks/lib/Cardano/Wallet/Benchmark/Memory/Pmap.hs
+++ b/lib/wallet-benchmarks/lib/Cardano/Wallet/Benchmark/Memory/Pmap.hs
@@ -1,0 +1,117 @@
+module Cardano.Wallet.Benchmark.Memory.Pmap
+    ( pmapParser
+    , lineParser
+    , topLineParser
+    , bottomLineParser
+    , pmap
+    , Pmap (..)
+    , Line (..)
+    , Header (..)
+    ) where
+
+import Prelude
+
+import Control.Monad
+    ( void
+    )
+import Data.Attoparsec.ByteString.Char8
+    ( Parser
+    , char
+    , decimal
+    , endOfLine
+    , hexadecimal
+    , inClass
+    , many1
+    , parseOnly
+    , skipSpace
+    , string
+    , takeTill
+    )
+import System.Process
+    ( getPid
+    )
+import UnliftIO
+    ( liftIO
+    )
+import UnliftIO.Process
+    ( ProcessHandle
+    , readProcess
+    )
+
+import qualified Data.Attoparsec.ByteString.Char8 as A
+import qualified Data.ByteString.Char8 as B8
+
+-- | Represents a line of the pmap command
+data Line = Line
+    { address :: Int
+    , memory :: Int
+    , permissions :: String
+    , command :: String
+    }
+    deriving (Show, Eq)
+
+-- | Represents the header of the pmap command
+data Header = Header
+    { pid :: Int
+    , commandCall :: String
+    }
+    deriving (Show, Eq)
+
+-- | Represents the footer of the pmap command
+newtype Footer = Footer
+    { total :: Int
+    }
+    deriving (Show, Eq)
+
+-- | Represents the output of the pmap command
+data Pmap = Pmap
+    { header :: Header
+    , pmapLines :: [Line]
+    , footer :: Footer
+    }
+    deriving (Show, Eq)
+
+pmapParser :: Parser Pmap
+pmapParser = do
+    t <- topLineParser
+    ls <- many1 lineParser
+    Pmap t ls <$> bottomLineParser
+
+topLineParser :: Parser Header
+topLineParser = do
+    pid <- decimal
+    void $ char ':'
+    skipSpace
+    Header pid . B8.unpack <$> lastPart
+
+lineParser :: Parser Line
+lineParser = do
+    addr <- hexadecimal
+    skipSpace
+    mem <- decimal <* char 'K'
+    skipSpace
+    perms <- A.takeWhile (inClass "rwxp-")
+    skipSpace
+    Line addr mem (B8.unpack perms) . B8.unpack <$> lastPart
+
+bottomLineParser :: Parser Footer
+bottomLineParser = do
+    skipSpace
+    void $ string "total"
+    skipSpace
+    tot <- decimal
+    void $ char 'K'
+    void lastPart
+    pure $ Footer tot
+
+lastPart :: Parser B8.ByteString
+lastPart = takeTill (== '\n') <* endOfLine
+
+-- | Get the pmap output for a given process
+pmap :: ProcessHandle -> IO Pmap
+pmap p = do
+    Just pid <- liftIO $ getPid p
+    output <- liftIO $ readProcess "pmap" [show pid] ""
+    case parseOnly pmapParser $ B8.pack output of
+        Right x -> pure x
+        Left _ -> error "Failed to parse pmap output"

--- a/lib/wallet-benchmarks/test/Cardano/Wallet/Benchmark/Memory/PmapSpec.hs
+++ b/lib/wallet-benchmarks/test/Cardano/Wallet/Benchmark/Memory/PmapSpec.hs
@@ -1,0 +1,55 @@
+module Cardano.Wallet.Benchmark.Memory.PmapSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Benchmark.Memory.Pmap
+    ( Line (..)
+    , lineParser
+    , pmapParser
+    )
+import Control.Monad
+    ( replicateM
+    )
+import Data.Attoparsec.ByteString.Char8
+    ( parseOnly
+    )
+import Paths_cardano_wallet_blackbox_benchmarks
+    ( getDataFileName
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+
+import qualified Data.ByteString.Char8 as B8
+
+spec :: Spec
+spec = do
+    describe "pmap parser" $ do
+        it "can parse a line"
+            $ parseOnly
+                lineParser
+                "0000000000400000  50668K r-x-- cardano-wallet\n"
+            `shouldBe` Right (Line 0x400000 50668 "r-x--" "cardano-wallet")
+        it "can parse 2 lines" $ do
+            let input =
+                    "0000000000400000  50668K r-x-- cardano-wallet\n\
+                    \000000f000600000  50669K -wxp- cardano-wallet2\n"
+            parseOnly (replicateM 2 lineParser) input
+                `shouldBe` Right
+                    [ Line 0x400000 50668 "r-x--" "cardano-wallet"
+                    , Line 0xf000600000 50669 "-wxp-" "cardano-wallet2"
+                    ]
+        it "can parse a topline and lines of pmap output" $ do
+            input <-
+                getDataFileName "data/hoogle-pmap.txt"
+                    >>= B8.readFile
+            case parseOnly pmapParser input of
+                Left e -> fail e
+                Right _ -> pure ()
+
+-- 0000000000400000  50668K r-x-- cardano-wallet

--- a/lib/wallet-benchmarks/test/Main.hs
+++ b/lib/wallet-benchmarks/test/Main.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/lib/wallet-e2e/cardano-wallet-e2e.cabal
+++ b/lib/wallet-e2e/cardano-wallet-e2e.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-wallet-e2e
-version:       0.1.0.0
+version:       2024.5.5
 synopsis:      End-to-end test suite for the cardano-wallet.
 description:   Please see README.md
 homepage:      https://github.com/input-output-hk/cardano-wallet

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.6
 name:               cardano-wallet
-version:            2024.5.5
+version:            0.2024.5.5
 synopsis:           The Wallet Backend for a Cardano node.
 description:        Please see README.md
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/prototypes/light-mode-test/light-mode-test.cabal
+++ b/prototypes/light-mode-test/light-mode-test.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               light-mode-test
-version:            0.1.0.0
+version:            0.2024.5.5
 synopsis:           Explore feasability of light mode
 description:
     This prototype explores whether we can implement a "light mode"


### PR DESCRIPTION
In this PR we improve the benchmarks reports to have them machine readable. The restoration benchmark is left out from this work as it's not going to appear in the CI-1 (gate-to-master) pipeline anyway as it takes 16 hours. 
The involved benchmarks are

1. api
2. latency
3. memory
4. db

Each of them now creates a csv artifact during its new CI-1 step.

- [x] Add a library to write csv reports of the benchmarks
- [x] Use the lib in all benchmarks to get new csv artifacts in buildkite
- [x] Add justfile runners for all benchmarks (-O0 is just for testing them)
- [x] Add steps in the pipeline for all of them 
- [x] Add a library to parse `pmap` utility output
- [x] Small rework of `ToTextTracer` and use it in place of heavier logging machine

ADP-3368