### PR TITLE
[ADP-3215] Add `TxIn` type to `Cardano.Wallet.Read.Tx`

### DIFF
--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx.hs
@@ -13,6 +13,9 @@ where
 
 import Prelude
 
+import Cardano.Read.Ledger.Tx.Inputs
+    ( getEraInputs
+    )
 import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.CollateralInputs
     ( getCollateralInputs
     )
@@ -58,9 +61,6 @@ import Cardano.Wallet.Read.Tx.Fee
     )
 import Cardano.Wallet.Read.Tx.Hash
     ( getEraTxHash
-    )
-import Cardano.Wallet.Read.Tx.Inputs
-    ( getEraInputs
     )
 import Cardano.Wallet.Read.Tx.Metadata
     ( getEraMetadata

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Inputs.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Inputs.hs
@@ -13,6 +13,10 @@ module Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Inputs
 
 import Prelude
 
+import Cardano.Read.Ledger.Tx.Inputs
+    ( Inputs (..)
+    , InputsType
+    )
 import Cardano.Wallet.Primitive.Types.Tx.TxIn
     ( TxIn (..)
     )
@@ -22,10 +26,6 @@ import Cardano.Wallet.Read.Eras
     )
 import Cardano.Wallet.Read.Tx.Hash
     ( fromShelleyTxId
-    )
-import Cardano.Wallet.Read.Tx.Inputs
-    ( Inputs (..)
-    , InputsType
     )
 import Data.Foldable
     ( toList

--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -44,6 +44,7 @@ library
   import:           opts-lib, language
   exposed-modules:
     Cardano.Read.Ledger
+    Cardano.Read.Ledger.Tx.Inputs
     Cardano.Read.Ledger.Tx.TxId
     Cardano.Wallet.Read
     Cardano.Wallet.Read.Block
@@ -85,7 +86,6 @@ library
     Cardano.Wallet.Read.Tx.Gen.Shelley
     Cardano.Wallet.Read.Tx.Gen.TxParameters
     Cardano.Wallet.Read.Tx.Hash
-    Cardano.Wallet.Read.Tx.Inputs
     Cardano.Wallet.Read.Tx.Integrity
     Cardano.Wallet.Read.Tx.Metadata
     Cardano.Wallet.Read.Tx.Mint

--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -86,6 +86,7 @@ library
     Cardano.Wallet.Read.Tx.Gen.Shelley
     Cardano.Wallet.Read.Tx.Gen.TxParameters
     Cardano.Wallet.Read.Tx.Hash
+    Cardano.Wallet.Read.Tx.Inputs
     Cardano.Wallet.Read.Tx.Integrity
     Cardano.Wallet.Read.Tx.Metadata
     Cardano.Wallet.Read.Tx.Mint

--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -93,6 +93,7 @@ library
     Cardano.Wallet.Read.Tx.ReferenceInputs
     Cardano.Wallet.Read.Tx.ScriptValidity
     Cardano.Wallet.Read.Tx.TxId
+    Cardano.Wallet.Read.Tx.TxIn
     Cardano.Wallet.Read.Tx.Validity
     Cardano.Wallet.Read.Tx.Withdrawals
     Cardano.Wallet.Read.Tx.Witnesses

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Inputs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Inputs.hs
@@ -8,13 +8,11 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 -- |
--- Copyright: © 2020-2022 IOHK
+-- Copyright: © 2020-2024 IOHK
 -- License: Apache-2.0
 --
--- Raw inputs data extraction from 'Tx'
---
 
-module Cardano.Wallet.Read.Tx.Inputs
+module Cardano.Read.Ledger.Tx.Inputs
     ( InputsType
     , Inputs (..)
     , getEraInputs
@@ -75,7 +73,6 @@ deriving instance Show (InputsType era) => Show (Inputs era)
 deriving instance Eq (InputsType era) => Eq (Inputs era)
 
 {-# INLINABLE getEraInputs #-}
--- | Extract the inputs from a transaction in any era.
 getEraInputs :: forall era . IsEra era => Tx era -> Inputs era
 getEraInputs = case theEra @era of
     Byron -> onTx $ \tx -> Inputs $ BY.txInputs $ BY.taTx tx

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Inputs.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Inputs.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Copyright: © 2020-2024 IOHK
+-- License: Apache-2.0
+--
+
+module Cardano.Wallet.Read.Tx.Inputs
+    ( getInputs
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Read.Eras
+    ( Byron
+    , Era (..)
+    , IsEra (..)
+    )
+import Cardano.Wallet.Read.Tx
+    ( Tx
+    )
+import Cardano.Wallet.Read.Tx.TxId
+    ( TxId
+    , fromLedgerTxId
+    )
+import Cardano.Wallet.Read.Tx.TxIn
+    ( TxIn
+    , pattern TxIn
+    , pattern TxIx
+    )
+import Data.List.NonEmpty
+    ( toList
+    )
+import Data.Set
+    ( Set
+    )
+
+import qualified Cardano.Chain.UTxO as BY
+import qualified Cardano.Read.Ledger.Tx.Inputs as L
+import qualified Cardano.Read.Ledger.Tx.TxId as L
+import qualified Data.Set as Set
+
+{-# INLINABLE getInputs #-}
+-- | Extract the inputs from a transaction in any era.
+getInputs :: forall era . IsEra era => Tx era -> Set TxIn
+getInputs = case theEra :: Era era of
+    Byron -> byronInputs . L.getEraInputs
+    Shelley -> unInputs . L.getEraInputs
+    Allegra -> unInputs . L.getEraInputs
+    Mary -> unInputs . L.getEraInputs
+    Alonzo -> unInputs . L.getEraInputs
+    Babbage -> unInputs . L.getEraInputs
+    Conway -> unInputs . L.getEraInputs
+
+{-# INLINE byronInputs #-}
+byronInputs :: L.Inputs Byron -> Set TxIn
+byronInputs (L.Inputs x)= Set.fromList . map fromByronTxIn $ toList x
+
+unInputs :: L.Inputs era -> L.InputsType era
+unInputs (L.Inputs x) = x
+
+fromByronTxIn :: BY.TxIn -> TxIn
+fromByronTxIn (BY.TxInUtxo txid ix) =
+    TxIn (fromByronTxId $ L.TxId txid) (TxIx ix)
+
+fromByronTxId :: L.TxId Byron -> TxId
+fromByronTxId = fromLedgerTxId

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/TxIn.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/TxIn.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+-- 'TxIn' — transaction input.
+--
+
+module Cardano.Wallet.Read.Tx.TxIn
+    ( TxIn
+    , pattern TxIn
+    , inputId
+    , inputIx
+    , TxIx
+    , pattern TxIx
+    , word16FromTxIx
+    )
+    where
+
+import Prelude
+
+import Cardano.Ledger.Crypto
+    ( StandardCrypto
+    )
+import Cardano.Wallet.Read.Tx.TxId
+    ( TxId
+    )
+import Data.Word
+    ( Word16
+    )
+
+import qualified Cardano.Ledger.BaseTypes as SH
+import qualified Cardano.Ledger.TxIn as SH
+
+{-----------------------------------------------------------------------------
+    Types
+------------------------------------------------------------------------------}
+
+-- | A 'TxIn' is a unique reference to a transaction output.
+-- It references the 'TxId' and an output index.
+--
+-- Note: We use a type synonym here because we want zero-cost
+-- coercion between @Set TxIn@ and @Set SH.TxIn StandardCrypto@.
+-- Unfortunately, 'Set' expects a nominal role.
+-- (See the design literature on 'Data.Coercible'.)
+type TxIn = SH.TxIn StandardCrypto
+
+{-# COMPLETE TxIn #-}
+pattern TxIn :: TxId -> TxIx -> TxIn
+pattern TxIn{inputId,inputIx} = SH.TxIn inputId inputIx
+
+-- | Index of a transaction output.
+-- Equivalent to 'Word16'.
+type TxIx = SH.TxIx
+
+{-# COMPLETE TxIx #-}
+pattern TxIx :: Word16 -> TxIx
+pattern TxIx{word16FromTxIx} <- (fromTxIx -> word16FromTxIx) where
+    TxIx w16 = SH.mkTxIx w16
+
+fromTxIx :: TxIx -> Word16
+fromTxIx (SH.TxIx w16) = fromIntegral w16

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
@@ -33,6 +33,9 @@ import Prelude hiding
     ( (.)
     )
 
+import Cardano.Read.Ledger.Tx.Inputs
+    ( getEraInputs
+    )
 import Cardano.Wallet.DB.Sqlite.Schema
     ( TxCollateral (..)
     , TxIn (..)
@@ -60,9 +63,6 @@ import Cardano.Wallet.Read.Eras.EraFun
     )
 import Cardano.Wallet.Read.Tx.CollateralInputs
     ( getEraCollateralInputs
-    )
-import Cardano.Wallet.Read.Tx.Inputs
-    ( getEraInputs
     )
 import Control.Applicative
     ( (<|>)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -14,6 +14,9 @@ import Prelude hiding
     ( (.)
     )
 
+import Cardano.Read.Ledger.Tx.Inputs
+    ( getEraInputs
+    )
 import Cardano.Slotting.Slot
     ( SlotNo (..)
     )
@@ -100,9 +103,6 @@ import Cardano.Wallet.Read.Tx.Fee
     )
 import Cardano.Wallet.Read.Tx.Hash
     ( getEraTxHash
-    )
-import Cardano.Wallet.Read.Tx.Inputs
-    ( getEraInputs
     )
 import Cardano.Wallet.Read.Tx.Metadata
     ( getEraMetadata


### PR DESCRIPTION
This pull request adds a type `TxIn` to `Cardano.Wallet.Read.Tx.TxIn`.

The `TxIn` type is era-_independent_ and has zero-cost conversion to the `TxIn` type from the Shelley ledgers.

### Comments

* We provide convenient pattern synonyms for `TxIn` and `TxIx`. (Unfortunately, we can't export them as bundled patterns, because GHC will not allow that for type synonyms.)

### Issue Number

ADP-3215