### PR TITLE
Resolve `PartialTx` inputs over LSQ

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -263,6 +263,7 @@ instance IsServerError WalletException where
         ExceptionSoftDerivationIndex e -> toServerError e
         ExceptionHardenedDerivationIndex e -> toServerError e
         ExceptionVoting e -> toServerError e
+        ExceptionInvalidTxOutInEra e -> toServerError e
 
 instance IsServerError ErrNoSuchWallet where
     toServerError = \case

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -1000,7 +1000,7 @@ import qualified Internal.Cardano.Write.Tx.Balance as Write
     ( PartialTx (PartialTx)
     )
 import qualified Internal.Cardano.Write.Tx.Sign as Write
-    ( TimelockKeyWitnessCounts (TimelockKeyWitnessCounts)
+    ( TimelockKeyWitnessCounts (..)
     , estimateMinWitnessRequiredPerInput
     )
 import qualified Network.Ntp as Ntp

--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -54,6 +54,7 @@ library
     Cardano.Wallet.Network.LocalStateQuery.PParams
     Cardano.Wallet.Network.LocalStateQuery.RewardAccount
     Cardano.Wallet.Network.LocalStateQuery.StakeDistribution
+    Cardano.Wallet.Network.LocalStateQuery.UTxO
     Cardano.Wallet.Network.Logging
     Cardano.Wallet.Network.Logging.Aggregation
     Cardano.Wallet.Network.RestorationMode

--- a/lib/network-layer/src/Cardano/Wallet/Network.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network.hs
@@ -153,6 +153,9 @@ data NetworkLayer m block = NetworkLayer
     , stakeDistribution
         :: Coin -- Stake to consider for rewards
         -> m StakePoolsSummary
+    , getUTxOByTxIn
+        :: Set Write.TxIn
+        -> m (MaybeInRecentEra Write.UTxO)
     , getCachedRewardAccountBalance
         :: RewardAccount
         -- Either reward account from key hash or script hash

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -517,6 +517,8 @@ withNodeNetworkLayerBase
                     _postTx txSubmissionQ readCurrentNodeEra
                 , stakeDistribution =
                     _stakeDistribution queryRewardQ
+                , getUTxOByTxIn =
+                    _getUTxOByTxIn queryRewardQ
                 , getCachedRewardAccountBalance =
                     _getCachedRewardAccountBalance rewardsObserver
                 , fetchRewardAccountBalances =
@@ -658,6 +660,10 @@ withNodeNetworkLayerBase
                             (Map.size rewards)
                     return res
                 Nothing -> pure $ StakePoolsSummary 0 mempty mempty
+
+        _getUTxOByTxIn queue ins =
+            bracketQuery "getUTxOByTxIn" tr
+                $ queue `send` SomeLSQ (LSQ.getUTxOByTxIn ins)
 
         _watchNodeTip readTip callback = do
             observeForever readTip $ \tip -> do

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery.hs
@@ -9,6 +9,7 @@ module Cardano.Wallet.Network.LocalStateQuery
     , module Cardano.Wallet.Network.LocalStateQuery.PParams
     , module Cardano.Wallet.Network.LocalStateQuery.RewardAccount
     , module Cardano.Wallet.Network.LocalStateQuery.StakeDistribution
+    , module Cardano.Wallet.Network.LocalStateQuery.UTxO
     ) where
 
 import Cardano.Wallet.Network.LocalStateQuery.Extra
@@ -24,4 +25,7 @@ import Cardano.Wallet.Network.LocalStateQuery.RewardAccount
     )
 import Cardano.Wallet.Network.LocalStateQuery.StakeDistribution
     ( stakeDistribution
+    )
+import Cardano.Wallet.Network.LocalStateQuery.UTxO
+    ( getUTxOByTxIn
     )

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/UTxO.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/UTxO.hs
@@ -11,11 +11,20 @@ module Cardano.Wallet.Network.LocalStateQuery.UTxO
 
 import Prelude
 
+import Cardano.Ledger.TxIn
+    ( TxIn
+    )
+import Cardano.Ledger.UTxO
+    ( UTxO
+    )
 import Cardano.Wallet.Network.Implementation.Ouroboros
     ( LSQ (..)
     )
 import Cardano.Wallet.Network.LocalStateQuery.Extra
     ( onAnyEra
+    )
+import Data.Set
+    ( Set
     )
 import Internal.Cardano.Write.Tx
     ( MaybeInRecentEra (..)
@@ -25,15 +34,6 @@ import Ouroboros.Consensus.Cardano
     )
 import Ouroboros.Consensus.Shelley.Eras
     ( StandardCrypto
-    )
-import Cardano.Ledger.TxIn
-    ( TxIn
-    )
-import Cardano.Ledger.UTxO
-    ( UTxO
-    )
-import Data.Set
-    ( Set
     )
 
 import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/UTxO.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/UTxO.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE GADTs #-}
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+-- A local state query that looks up UTxOs based on TxIns.
+--
+module Cardano.Wallet.Network.LocalStateQuery.UTxO
+    ( getUTxOByTxIn
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Network.Implementation.Ouroboros
+    ( LSQ (..)
+    )
+import Cardano.Wallet.Network.LocalStateQuery.Extra
+    ( onAnyEra
+    )
+import Internal.Cardano.Write.Tx
+    ( MaybeInRecentEra (..)
+    )
+import Ouroboros.Consensus.Cardano
+    ( CardanoBlock
+    )
+import Ouroboros.Consensus.Shelley.Eras
+    ( StandardCrypto
+    )
+import Cardano.Ledger.TxIn
+    ( TxIn
+    )
+import Cardano.Ledger.UTxO
+    ( UTxO
+    )
+import Data.Set
+    ( Set
+    )
+
+import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley
+
+{-----------------------------------------------------------------------------
+    Local State Query for GetUTxOByTxIn
+------------------------------------------------------------------------------}
+--
+type LSQ' m = LSQ (CardanoBlock StandardCrypto) m
+
+getUTxOByTxIn
+    :: Set (TxIn StandardCrypto) -> LSQ' m (MaybeInRecentEra UTxO)
+getUTxOByTxIn ins =
+    onAnyEra
+        (pure InNonRecentEraByron)
+        (pure InNonRecentEraShelley)
+        (pure InNonRecentEraAllegra)
+        (pure InNonRecentEraMary)
+        (pure InNonRecentEraAlonzo)
+        (InRecentEraBabbage <$> LSQry (Shelley.GetUTxOByTxIn ins))
+        (InRecentEraConway <$> LSQry (Shelley.GetUTxOByTxIn ins))

--- a/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -222,6 +222,7 @@ dummyNetworkLayer = NetworkLayer
     , currentProtocolParametersInRecentEras
         = err "currentProtocolParametersInRecentEras"
     , currentSlottingParameters = err "currentSlottingParameters"
+    , getUTxOByTxIn = err "getUTxOByTxIn"
     , postTx = err "postTx"
     , stakeDistribution = err "stakeDistribution"
     , getCachedRewardAccountBalance = err "getRewardCachedAccountBalance"

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2206,7 +2206,8 @@ balanceTx wrk pp timeTranslation partialTx = do
         utxoIndex
         (defaultChangeAddressGen argGenChange)
         changeState
-        (over #extraUTxO (<> lookedUpUTxO) partialTx)
+        -- In case of conflicts, the UTxO looked up from the node will win.
+        (over #extraUTxO (lookedUpUTxO <>) partialTx)
 
     return tx
   where


### PR DESCRIPTION
- Add `getUTxOByTxIn` local state query
- Resolve `PartialTx` inputs over LSQ in `Cardano.Wallet.balanceTx`

### Comments

This is part of the fix for the [integration test in the 8.11 branch](https://buildkite.com/cardano-foundation/cardano-wallet/builds/5254#018fee3c-01ad-441e-bb7e-25acd78cb7f3); if we have the UTxO of the reference input containing the script used for minting in constructTx, then `Ledger.getMinFeeTxUtxo pp tx utxo` will correctly account for minFeeRefScriptCoinsPerByte * totalRefScriptSize.

Previous step: #4629
Next step: #4631

### Issue Number

ADP-3373
