### PR TITLE
[ADP-3368] Set all internal packages version to 2024.5.5 or 0.2024.5.5

### DIFF
--- a/lib/address-derivation-discovery/address-derivation-discovery.cabal
+++ b/lib/address-derivation-discovery/address-derivation-discovery.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               address-derivation-discovery
-version:            2024.5.5
+version:            0.2024.5.5
 synopsis:           Address derivation and discovery.
 description:        Please see README.md.
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/application-extras/cardano-wallet-application-extras.cabal
+++ b/lib/application-extras/cardano-wallet-application-extras.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            cardano-wallet-application-extras
-version:         0.1.0.0
+version:         0.2024.5.5
 synopsis:        modules to support applications for the cardano wallet
 license:         Apache-2.0
 license-file:    LICENSE

--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-balance-tx
-version:            2024.5.5
+version:            0.2024.5.5
 synopsis:           Balancing transactions for the Cardano blockchain.
 description:        Please see README.md.
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/cardano-api-extra/cardano-api-extra.cabal
+++ b/lib/cardano-api-extra/cardano-api-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.4
 name:               cardano-api-extra
-version:            2024.5.5
+version:            0.2024.5.5
 synopsis:           Useful extensions to the Cardano API.
 description:        Please see README.md.
 homepage:           https://github.com/cardano-foundation/cardano-wallet
@@ -67,4 +67,3 @@ library
   exposed-modules:
     Cardano.Api.Gen
     Cardano.Ledger.Credential.Safe
-

--- a/lib/coin-selection/cardano-coin-selection.cabal
+++ b/lib/coin-selection/cardano-coin-selection.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               cardano-coin-selection
-version:            2024.5.5
+version:            0.2024.5.5
 synopsis:           Coin selection algorithms for the Cardano blockchain.
 description:        Please see README.md.
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/crypto-primitives/crypto-primitives.cabal
+++ b/lib/crypto-primitives/crypto-primitives.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          crypto-primitives
-version:       0.1.0.0
+version:       0.2024.5.5
 synopsis:      Cryptographic primitives
 license:       Apache-2.0
 author:        Cardano Foundation (High Assurance Lab)

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -1,7 +1,7 @@
 cabal-version:      3.6
 build-type:         Simple
 name:               customer-deposit-wallet
-version:            0.1.0.0
+version:            0.2024.5.5
 synopsis:           A wallet for the Cardano blockchain.
 description:        Please see README.md
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/delta-store/delta-store.cabal
+++ b/lib/delta-store/delta-store.cabal
@@ -1,5 +1,5 @@
 name:                delta-store
-version:             0.1.0.0
+version:             0.2024.5.5
 synopsis:            Facility for storing a Haskell value, using delta types.
 homepage:            https://github.com/cardano-foundation/cardano-wallet
 author:              Cardano Foundation (High Assurance Lab)

--- a/lib/delta-table/delta-table.cabal
+++ b/lib/delta-table/delta-table.cabal
@@ -1,5 +1,5 @@
 name:                delta-table
-version:             0.1.0.0
+version:             0.2024.5.5
 synopsis:            Work with database tables using delta encodings.
 homepage:            https://github.com/cardano-foundation/cardano-wallet
 author:              Cardano Foundation (High Assurance Lab)

--- a/lib/delta-types/delta-types.cabal
+++ b/lib/delta-types/delta-types.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                delta-types
-version:             0.1.0.0
+version:             0.2024.5.5
 synopsis:            Delta types, also known as change actions.
 description:
     A __delta type__ @da@ for a __base type__ @a@ is a collection

--- a/lib/faucet/faucet.cabal
+++ b/lib/faucet/faucet.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          faucet
-version:       0.1.0.0
+version:       2024.5.5
 synopsis:      Faucet for the local Cardano cluster.
 homepage:      https://github.com/cardano-foundation/cardano-wallet
 license:       Apache-2.0

--- a/lib/iohk-monitoring-extra/iohk-monitoring-extra.cabal
+++ b/lib/iohk-monitoring-extra/iohk-monitoring-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          iohk-monitoring-extra
-version:       0.1.0.0
+version:       0.2024.5.5
 synopsis:      Extra functionality extending the iohk-monitoring package
 license:       Apache-2.0
 license-file:  LICENSE

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-launcher
-version:             2024.5.5
+version:             0.2024.5.5
 synopsis:            Utilities for a building commands launcher
 homepage:            https://github.com/cardano-foundation/cardano-wallet
 author:              Cardano Foundation (High Assurance Lab)

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.6
 name:          local-cluster
-version:       0.1.0.0
+version:       2024.5.5
 synopsis:      Local cluster of cardano nodes
 homepage:      https://github.com/cardano-foundation/cardano-wallet
 license:       Apache-2.0

--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.6
 name:            cardano-wallet-network-layer
-version:         0.1.0.0
+version:         0.2024.5.5
 synopsis:        Node communication layer functionality.
 
 -- description:

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.6
 name:          cardano-wallet-primitive
-version:       2024.5.5
+version:       0.2024.5.5
 synopsis:      Selected primitive types for Cardano Wallet.
 description:   Please see README.md.
 homepage:      https://github.com/cardano-foundation/cardano-wallet

--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.6
 name:            cardano-wallet-read
-version:         2023.8.1
+version:         0.2024.5.5
 synopsis:
   Primitive era-dependent operations to read the cardano blocks and transactions
 

--- a/lib/secrets/cardano-wallet-secrets.cabal
+++ b/lib/secrets/cardano-wallet-secrets.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-wallet-secrets
-version:            0.1.0.0
+version:            0.2024.5.5
 synopsis:           Utilities for storing private keys and passphrases
 license:            Apache-2.0
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/lib/std-gen-seed/std-gen-seed.cabal
+++ b/lib/std-gen-seed/std-gen-seed.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            std-gen-seed
-version:         0.0.0.0
+version:         0.2024.5.5
 synopsis:        Support for standard random number generator seeds
 license:         Apache-2.0
 author:          Cardano Foundation (High Assurance Lab)

--- a/lib/temporary-extra/temporary-extra.cabal
+++ b/lib/temporary-extra/temporary-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          temporary-extra
-version:       0.1.0.0
+version:       0.2024.5.5
 synopsis:      Extra functionality extending the temporary package
 license:       Apache-2.0
 license-file:  LICENSE

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-test-utils
-version:             2024.5.5
+version:             0.2024.5.5
 synopsis:            Shared utilities for writing unit and property tests.
 description:         Shared utilities for writing unit and property tests.
 homepage:            https://github.com/cardano-foundation/cardano-wallet

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -1,5 +1,5 @@
 name:                text-class
-version:             2024.5.5
+version:             0.2024.5.5
 synopsis:            Extra helpers to convert data-types to and from Text
 homepage:            https://github.com/cardano-foundation/cardano-wallet
 author:              Cardano Foundation (High Assurance Lab)

--- a/lib/wai-middleware-logging/wai-middleware-logging.cabal
+++ b/lib/wai-middleware-logging/wai-middleware-logging.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          wai-middleware-logging
-version:       1.0
+version:       0.2024.5.5
 synopsis:      WAI Middleware for Logging
 homepage:      https://github.com/cardano-foundation/cardano-wallet
 author:        Cardano Foundation (High Assurance Lab)

--- a/lib/wallet-e2e/cardano-wallet-e2e.cabal
+++ b/lib/wallet-e2e/cardano-wallet-e2e.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-wallet-e2e
-version:       0.1.0.0
+version:       2024.5.5
 synopsis:      End-to-end test suite for the cardano-wallet.
 description:   Please see README.md
 homepage:      https://github.com/input-output-hk/cardano-wallet

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.6
 name:               cardano-wallet
-version:            2024.5.5
+version:            0.2024.5.5
 synopsis:           The Wallet Backend for a Cardano node.
 description:        Please see README.md
 homepage:           https://github.com/cardano-foundation/cardano-wallet

--- a/prototypes/light-mode-test/light-mode-test.cabal
+++ b/prototypes/light-mode-test/light-mode-test.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               light-mode-test
-version:            0.1.0.0
+version:            0.2024.5.5
 synopsis:           Explore feasability of light mode
 description:
     This prototype explores whether we can implement a "light mode"


### PR DESCRIPTION
This PR normalizes internal package version to the wallet version, so they will be bumped automatically on the new release.

- [x] Set all executables package version to 2024.5.5
- [x] Set all library package version to 0.2024.5.5 

This is a re-take of https://github.com/cardano-foundation/cardano-wallet/pull/4625 that was merged unintentionally in another PR