### PR TITLE
[ADP-3368] Add benchmark format and write lib, add csv reporting to benchmarks

### DIFF
--- a/.buildkite/bench-db.sh
+++ b/.buildkite/bench-db.sh
@@ -15,8 +15,9 @@ nix build .#ci.benchmarks.db -o $bench_name
 
 echo "+++ Run benchmark"
 
-
-./$bench_name/bin/db --json $bench_name.json -o $bench_name.html | tee $bench_name.txt
+./$bench_name/bin/db --json $bench_name.json \
+    -o $bench_name.html \
+    | tee $bench_name.txt
 
 printf 'Link to \033]1339;url=artifact://'$bench_name.html';content='"Benchmark Report"'\a\n'
 

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -84,7 +84,9 @@ steps:
     key: latency-block
 
   - label: 'Latency benchmark'
-    command: "./.buildkite/bench-latency.sh"
+    command: |
+      export BENCHMARK_CSV_FILE="bench-results.csv"
+      ./.buildkite/bench-latency.sh
     timeout_in_minutes: 120
     agents:
       system: ${linux}

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -55,8 +55,11 @@ steps:
     key: api-block
 
   - label: 'API benchmark'
-    command: "./.buildkite/bench-api.sh"
+    command: |
+      export BENCHMARK_CSV_FILE="bench-results.csv"
+      ./.buildkite/bench-api.sh
     timeout_in_minutes: 210
+    artifact_paths: [ "./bench-results.csv" ]
     agents:
       system: ${linux}
       queue: adrestia-bench

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -187,6 +187,19 @@ steps:
     env:
       TMPDIR: "/cache"
 
+  - label: 'Latency benchmark'
+    command: |
+      export BENCHMARK_CSV_FILE="`pwd`/bench-results.csv"
+      ./.buildkite/bench-latency.sh
+    depends_on: trigger-benchmarks
+    timeout_in_minutes: 20
+    agents:
+      system: x86_64-linux
+    artifact_paths: [ "./bench-results.csv" ]
+    env:
+      TMPDIR: "/cache"
+
+
   - label: 'Read-blocks benchmark'
     command: "./.buildkite/bench-read-blocks.sh"
     depends_on: trigger-benchmarks

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -199,6 +199,17 @@ steps:
     env:
       TMPDIR: "/cache"
 
+  - label: 'DB benchmark'
+    command: |
+      export BENCHMARK_CSV_FILE="`pwd`/bench-results.csv"
+      ./.buildkite/bench-db.sh
+    depends_on: trigger-benchmarks
+    timeout_in_minutes: 50
+    agents:
+      system: x86_64-linux
+    artifact_paths: [ "./bench-results.csv" ]
+    env:
+      TMPDIR: "/cache"
 
   - label: 'Read-blocks benchmark'
     command: "./.buildkite/bench-read-blocks.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -212,16 +212,14 @@ steps:
       TMPDIR: "/cache"
 
   - label: 'Read-blocks benchmark'
-    command: "./.buildkite/bench-read-blocks.sh"
+    command: |
+      export BENCHMARK_CSV_FILE="`pwd`/bench-results.csv"
+      ./.buildkite/bench-read-blocks.sh
     depends_on: trigger-benchmarks
     timeout_in_minutes: 20
     agents:
       system: x86_64-linux
-    # We do not use the  benchmark  queue here, as we don't want
-    # to use system resources that are intended for long-running processes
-    # to perform quick-and-dirty benchmark runs.
-    # queue: benchmark
-    if: 'build.env("step") == null || build.env("step") =~ /bench-api/'
+    artifact_paths: [ "./bench-results.csv" ]
     env:
       TMPDIR: "/cache"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -223,6 +223,18 @@ steps:
     env:
       TMPDIR: "/cache"
 
+  - label: 'memory benchmark'
+    command: |
+      export BENCHMARK_CSV_FILE="`pwd`/bench-results.csv"
+      ./.buildkite/bench-memory.sh
+    depends_on: trigger-benchmarks
+    timeout_in_minutes: 20
+    agents:
+      system: x86_64-linux
+    artifact_paths: [ "./bench-results.csv" ]
+    env:
+      TMPDIR: "/cache"
+
   - block: "macOS steps"
     if: |
       build.branch !~ /^gh-readonly-queue\/master/

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -176,16 +176,14 @@ steps:
     key: trigger-benchmarks
 
   - label: 'API benchmark'
-    command: "./.buildkite/bench-api.sh"
+    command: |
+      export BENCHMARK_CSV_FILE="`pwd`/bench-results.csv"
+      "./.buildkite/bench-api.sh"
     depends_on: trigger-benchmarks
     timeout_in_minutes: 20
     agents:
       system: x86_64-linux
-    # We do not use the  benchmark  queue here, as we don't want
-    # to use system resources that are intended for long-running processes
-    # to perform quick-and-dirty benchmark runs.
-    # queue: benchmark
-    if: 'build.env("step") == null || build.env("step") =~ /bench-api/'
+    artifact_paths: [ "./bench-results.csv" ]
     env:
       TMPDIR: "/cache"
 

--- a/justfile
+++ b/justfile
@@ -172,3 +172,9 @@ test-local-cluster:
         '.#cardano-node' \
         '.#cardano-wallet' \
         -c test-local-cluster-exe
+
+api-bench:
+    BENCHMARK_CSV_FILE=ignore-me/api-bench.csv \
+    cabal run -O0 -v0 \
+            cardano-wallet-benchmarks:api \
+            -- lib/benchmarks/data/api-bench

--- a/justfile
+++ b/justfile
@@ -184,3 +184,8 @@ db-bench:
     BENCHMARK_CSV_FILE=ignore-me/db-bench.csv \
     cabal run -O0 -v0 \
             cardano-wallet-benchmarks:db \
+
+read-blocks-bench:
+    BENCHMARK_CSV_FILE=ignore-me/read-blocks-bench.csv \
+    cabal run -O0 -v0 \
+            cardano-wallet-benchmarks:read-blocks

--- a/justfile
+++ b/justfile
@@ -179,3 +179,8 @@ api-bench:
     cabal run -O0 -v0 \
             cardano-wallet-benchmarks:api \
             -- lib/benchmarks/data/api-bench
+
+db-bench:
+    BENCHMARK_CSV_FILE=ignore-me/db-bench.csv \
+    cabal run -O0 -v0 \
+            cardano-wallet-benchmarks:db \

--- a/justfile
+++ b/justfile
@@ -190,3 +190,19 @@ read-blocks-bench:
     BENCHMARK_CSV_FILE=ignore-me/read-blocks-bench.csv \
     cabal run -O0 -v0 \
             cardano-wallet-benchmarks:read-blocks
+
+memory-bench:
+    mkdir -p ignore-me/memory-bench
+    BENCHMARK_CSV_FILE=ignore-me/memory-bench.csv \
+        nix shell \
+            '.#cardano-node' \
+            '.#cardano-wallet' \
+            'nixpkgs#jq' \
+            'nixpkgs#curl' \
+            'nixpkgs#procps' \
+            -c cabal run -O0 -v0 \
+                cardano-wallet-blackbox-benchmarks:memory -- \
+                    --snapshot lib/wallet-benchmarks/data/membench-snapshot.tgz \
+                    --wallet cardano-wallet \
+                    --node cardano-node \
+                    --work-dir ignore-me/memory-bench

--- a/justfile
+++ b/justfile
@@ -160,7 +160,8 @@ conway-integration-tests:
   just conway-integration-tests-match ""
 
 latency-bench:
-   cabal run -O2 -v0 cardano-wallet-benchmarks:latency -- \
+   BENCHMARK_CSV_FILE=ignore-me/latency-bench.csv \
+   cabal run -O0 -v0 cardano-wallet-benchmarks:latency -- \
    --cluster-configs lib/local-cluster/test/data/cluster-configs
 
 test-local-cluster:

--- a/justfile
+++ b/justfile
@@ -42,6 +42,7 @@ unit-tests-cabal-match match:
   cabal test \
     cardano-balance-tx:test \
     cardano-numeric:unit \
+    cardano-wallet-blackbox-benchmarks:unit \
     cardano-wallet-launcher:unit \
     cardano-wallet-network-layer:unit \
     cardano-wallet-primitive:test \

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -40,6 +40,7 @@ library
   build-depends:
     , aeson
     , base
+    , bytestring
     , cardano-addresses
     , cardano-wallet
     , cardano-wallet-api
@@ -49,6 +50,9 @@ library
     , cardano-wallet-network-layer
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
+    , cassava
+    , comonad
+    , containers
     , criterion-measurement
     , deepseq
     , directory
@@ -56,6 +60,7 @@ library
     , faucet
     , filepath
     , fmt
+    , foldl
     , generic-lens
     , hspec
     , http-client
@@ -69,17 +74,20 @@ library
     , resourcet
     , say
     , servant-client
+    , stm
     , temporary-extra
     , text
     , text-class
     , time
     , unliftio
     , unliftio-core
+    , vector
     , wai-middleware-logging
     , with-utf8
 
   exposed-modules:
     Cardano.Wallet.BenchShared
+    Cardano.Wallet.Benchmarks.Collect
     Cardano.Wallet.Benchmarks.Latency.Measure
     Cardano.Wallet.Benchmarks.Latency.BenchM
 
@@ -182,14 +190,18 @@ benchmark db
     , containers
     , contra-tracer
     , criterion
+    , criterion-measurement
     , crypto-primitives
     , deepseq
     , directory
+    , extra
     , filepath
     , fmt
+    , foldl
     , iohk-monitoring
     , iohk-monitoring-extra
     , memory
+    , mtl
     , random
     , text
     , text-class
@@ -216,9 +228,11 @@ benchmark api
     , cardano-wallet-read
     , cardano-wallet-unit:test-common
     , containers
+    , filepath
     , fmt
     , iohk-monitoring
     , iohk-monitoring-extra
+    , mtl
     , say
     , text
     , time

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -247,9 +247,12 @@ benchmark read-blocks
     , base
     , bytestring
     , cardano-wallet
+    , cardano-wallet-benchmarks
     , cardano-wallet-primitive
     , cardano-wallet-read
     , criterion
+    , iohk-monitoring-extra
+    , mtl
     , time
 
   default-language: Haskell2010

--- a/lib/benchmarks/exe/db-bench.hs
+++ b/lib/benchmarks/exe/db-bench.hs
@@ -17,9 +17,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
-#if __GLASGOW_HASKELL__ >= 902
 {-# OPTIONS_GHC -Wno-ambiguous-fields #-}
-#endif
 
 -- |
 -- Copyright: © 2018-2020 IOHK
@@ -56,25 +54,16 @@ import Cardano.Address.Derivation
     ( XPub
     , xpubFromBytes
     )
-import Cardano.BM.Configuration.Static
-    ( defaultConfigStdout
-    )
 import Cardano.BM.Data.Severity
     ( Severity (..)
-    )
-import Cardano.BM.Data.Trace
-    ( Trace
     )
 import Cardano.BM.Data.Tracer
     ( Tracer
     , filterSeverity
     )
-import Cardano.BM.Extra
-    ( trMessageText
-    )
-import Cardano.BM.Setup
-    ( setupTrace_
-    , shutdown
+import Cardano.BM.ToTextTracer
+    ( ToTextTracer (..)
+    , withToTextTracer
     )
 import Cardano.DB.Sqlite
     ( SqliteContext (..)
@@ -123,6 +112,17 @@ import Cardano.Wallet.Address.Keys.SequentialAny
     )
 import Cardano.Wallet.Address.Keys.WalletKey
     ( publicKey
+    )
+import Cardano.Wallet.Benchmarks.Collect
+    ( Reporter
+    , Result (..)
+    , Units (Bytes)
+    , addSemantic
+    , mkSemantic
+    , newReporterFromEnv
+    , noSemantic
+    , report
+    , runCriterionBenchmark
     )
 import Cardano.Wallet.BenchShared
     ( withTempSqliteFile
@@ -233,14 +233,20 @@ import Control.DeepSeq
     , force
     )
 import Control.Monad
-    ( join
+    ( forM_
+    , join
+    )
+import Control.Monad.Cont
+    ( evalContT
+    )
+import Control.Monad.IO.Class
+    ( liftIO
     )
 import Criterion.Main
     ( Benchmark
     , Benchmarkable
     , bench
     , bgroup
-    , defaultMain
     , perRunEnvWithCleanup
     )
 import Cryptography.Hash.Core
@@ -269,9 +275,6 @@ import Data.Proxy
     )
 import Data.Quantity
     ( Quantity (..)
-    )
-import Data.Text
-    ( Text
     )
 import Data.Text.Class
     ( fromText
@@ -317,14 +320,16 @@ import System.Random
 import Test.Utils.Resource
     ( unBracket
     )
+import UnliftIO
+    ( stdout
+    )
 import UnliftIO.Exception
     ( bracket
     )
 
-import qualified Cardano.BM.Configuration.Model as CM
-import qualified Cardano.BM.Data.BackendKind as CM
 import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
 import qualified Cardano.Wallet.Address.Pool as AddressPool
+import qualified Cardano.Wallet.Benchmarks.Collect as Collect
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
@@ -335,20 +340,32 @@ import qualified Data.Char as Char
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 
+timeBenchmarks :: Tracer IO WalletDBLog -> [Benchmark]
+timeBenchmarks tr =
+    [ bgroupWriteUTxO tr
+    , bgroupReadUTxO tr
+    , bgroupWriteSeqState tr
+    , bgroupWriteRndState tr
+    , bgroupWriteTxHistory tr
+    , bgroupReadTxHistory tr
+    ]
+
 main :: IO ()
-main = withUtf8 $ withLogging $ \trace -> do
-    let tr = filterSeverity (pure . const Error) $ trMessageText trace
-    defaultMain
-        [ bgroupWriteUTxO tr
-        , bgroupReadUTxO tr
-        , bgroupWriteSeqState tr
-        , bgroupWriteRndState tr
-        , bgroupWriteTxHistory tr
-        , bgroupReadTxHistory tr
-        ]
-    putStrLn "\n--"
-    utxoDiskSpaceTests tr
-    txHistoryDiskSpaceTests tr
+
+main = withUtf8 $ evalContT $ do
+    ToTextTracer tr <- withToTextTracer (Left stdout) Nothing
+    let onlyErrors = filterSeverity (const $ pure Error) tr
+    let sem = mkSemantic ["db"]
+    reporter <- newReporterFromEnv tr sem
+    forM_ (timeBenchmarks onlyErrors)
+        $ liftIO . runCriterionBenchmark 10 tr reporter
+    liftIO $ do
+        let utxoSizeSem = mkSemantic ["size", "utxo"]
+        utxoDiskSpaceTests (addSemantic reporter utxoSizeSem) onlyErrors
+        let txHistorySizeSem = mkSemantic ["size", "txhistory"]
+        txHistoryDiskSpaceTests
+            (addSemantic reporter txHistorySizeSem)
+            onlyErrors
 
 ----------------------------------------------------------------------------
 -- UTxO Benchmarks
@@ -779,58 +796,80 @@ walletFixtureByron =
 -- These are not proper criterion benchmarks but use the benchmark test data to
 -- measure size on disk of the database and its temporary files.
 
-utxoDiskSpaceTests :: Tracer IO WalletDBLog -> IO ()
-utxoDiskSpaceTests tr = do
+utxoDiskSpaceTests :: Reporter IO -> Tracer IO WalletDBLog -> IO ()
+utxoDiskSpaceTests reporter tr = do
     putStrLn "Database disk space usage tests for UTxO\n"
     sequence_
         --      #Checkpoints   UTxO Size
-        [ bUTxO            1          10
-        , bUTxO           10          10
-        , bUTxO            1         100
-        , bUTxO           10         100
-        , bUTxO            1        1000
-        , bUTxO           10        1000
-        , bUTxO            1       10000
-        , bUTxO           10       10000
-        , bUTxO            1      100000
-        , bUTxO           10      100000
+        [ bUTxO 1 10
+        , bUTxO 10 10
+        , bUTxO 1 100
+        , bUTxO 10 100
+        , bUTxO 1 1000
+        , bUTxO 10 1000
+        , bUTxO 1 10000
+        , bUTxO 10 10000
+        , bUTxO 1 100000
+        , bUTxO 10 100000
         ]
   where
-    bUTxO n s = benchDiskSize tr walletFixture $ \db -> do
-        putStrLn ("File size /"+|n|+" CP x "+|s|+" UTxO")
-        benchPutUTxO n s 0 db
+    bUTxO n s = do
+        let sem = mkSemantic
+                [ T.pack $ show n <> "-cp"
+                , T.pack $ show s <> "-utxo"
+                ]
+        benchDiskSize (addSemantic reporter sem) tr walletFixture $ \db -> do
+            putStrLn ("File size /" +| n |+ " CP x " +| s |+ " UTxO")
+            benchPutUTxO n s 0 db
 
-txHistoryDiskSpaceTests :: Tracer IO WalletDBLog -> IO ()
-txHistoryDiskSpaceTests tr = do
+txHistoryDiskSpaceTests
+    :: Reporter IO
+    -> Tracer IO WalletDBLog
+    -> IO ()
+txHistoryDiskSpaceTests reporter tr = do
     putStrLn "Database disk space usage tests for TxHistory\n"
     sequence_
         --       #NTransactions  #NInputs  #NOutputs
-        [ bTxs             100         20         20
-        , bTxs            1000         20         20
-        , bTxs           10000         20         20
-        , bTxs          100000         20         20
+        [ bTxs 100 20 20
+        , bTxs 1000 20 20
+        , bTxs 10000 20 20
+        , bTxs 100000 20 20
         ]
   where
-    bTxs n i o = benchDiskSize tr walletFixture $ \db -> do
-        putStrLn ("File size /"+|n|+" w/ "+|i|+"i + "+|o|+"o")
-        benchPutTxHistory n i o 0 [1..100] db
+    bTxs n i o = do
+        let sem = mkSemantic
+                [ T.pack $ show n <> "-txs"
+                , T.pack $ show i <> "-inputs"
+                , T.pack $ show o <> "-outputs"
+                ]
+        benchDiskSize (addSemantic reporter sem) tr walletFixture $ \db -> do
+            putStrLn ("File size /" +| n |+ " w/ " +| i |+ "i + " +| o |+ "o")
+            benchPutTxHistory n i o 0 [1 .. 100] db
 
 benchDiskSize
-    :: Tracer IO WalletDBLog
+    :: Reporter IO
+    -> Tracer IO WalletDBLog
     -> WalletFixture StateBench
     -> (DBLayerBench -> IO ()) -> IO ()
-benchDiskSize tr fixture action = bracket (setupDB tr fixture) dbDown
+benchDiskSize reporter tr fixture action = bracket (setupDB tr fixture) dbDown
     $ \(BenchEnv destroyPool f db) -> do
         action db
+        mWalSize <- safeGetFileSize $ f <> "-wal"
+        forM_ mWalSize $ \size ->
+            report reporter
+                $ pure
+                $ Collect.Benchmark noSemantic
+                $ Result (fromIntegral size) Bytes 1
         mapM_ (printFileSize "") [f, f <> "-shm", f <> "-wal"]
         destroyPool
         printFileSize " (closed)" f
         putStrLn ""
   where
+    safeGetFileSize f = doesFileExist f >>= \case
+        True -> Just <$> getFileSize f
+        False -> pure Nothing
     printFileSize sfx f = do
-        size <- doesFileExist f >>= \case
-            True -> Just <$> getFileSize f
-            False -> pure Nothing
+        size <- safeGetFileSize f
         putStrLn $ "  " +|
             padRightF 28 ' ' (takeFileName f ++ sfx) <>
             padLeftF 20 ' ' (maybe "-" sizeF size)
@@ -1031,26 +1070,3 @@ mkByronAddress i j =
     g = mkStdGen $ 1459*i + 1153*j
     unsafeXPub = fromMaybe (error "xpubFromBytes error") . xpubFromBytes
     [acctIx, addrIx] = take 2 $ randoms g
-
--- | Run an action with logging available and configured. When the action is
--- finished (normally or otherwise), log messages are flushed.
-withLogging
-    :: (Trace IO Text -> IO a)
-    -- ^ The action to run with logging configured.
-    -> IO a
-withLogging action = bracket before after between
-  where
-    before = do
-        cfg <- do
-            c <- defaultConfigStdout
-            CM.setMinSeverity c Debug
-            CM.setSetupBackends c [CM.KatipBK, CM.AggregationBK]
-            pure c
-        (tr, sb) <- setupTrace_ cfg "bench-db"
-        pure (sb, tr)
-
-    after =
-        shutdown . fst
-
-    between =
-        action . snd

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -280,6 +280,7 @@ main = withUtf8
 
 walletApiBench :: SomeMnemonic -> BenchM ()
 walletApiBench massiveMnemonic = do
+
     fmtTitle "Non-cached run"
     runWarmUpScenario
 

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -16,20 +16,20 @@ import Prelude
 import Cardano.Address.Style.Shelley
     ( shelleyTestnet
     )
-import Cardano.BM.Data.LogItem
-    ( LogObject
-    )
 import Cardano.BM.Data.Severity
     ( Severity (Error)
     )
 import Cardano.BM.Data.Tracer
-    ( HasSeverityAnnotation
-    , Tracer (..)
-    , filterSeverity
+    ( filterSeverity
     )
 import Cardano.BM.Extra
     ( stdoutTextTracer
     , trMessage
+    )
+import Cardano.BM.ToTextTracer
+    ( ToTextTracer (..)
+    , overToTextTracer
+    , withToTextTracer
     )
 import Cardano.BM.Trace
     ( traceInTVarIO
@@ -66,6 +66,15 @@ import Cardano.Wallet.Api.Types.Era
 import Cardano.Wallet.Api.Types.WalletAssets
     ( ApiWalletAssets (..)
     )
+import Cardano.Wallet.Benchmarks.Collect
+    ( Benchmark (..)
+    , Reporter (..)
+    , Result (..)
+    , Units (Milliseconds)
+    , mkSemantic
+    , newReporterResourceTFromEnv
+    , report
+    )
 import Cardano.Wallet.Benchmarks.Latency.BenchM
     ( BenchCtx (..)
     , BenchM
@@ -77,7 +86,8 @@ import Cardano.Wallet.Benchmarks.Latency.BenchM
     , requestWithError
     )
 import Cardano.Wallet.Benchmarks.Latency.Measure
-    ( withLatencyLogging
+    ( meanAvg
+    , withLatencyLogging
     )
 import Cardano.Wallet.Faucet
     ( Faucet (massiveWalletMnemonic)
@@ -145,6 +155,9 @@ import Control.Monad.Catch
     ( Exception
     , MonadThrow (..)
     )
+import Control.Monad.Cont
+    ( evalContT
+    )
 import Control.Monad.IO.Class
     ( liftIO
     )
@@ -173,7 +186,6 @@ import Data.Generics.Labels
 import Data.Generics.Wrapped
     ( _Unwrapped
     )
-import Data.Text.Class.Extended
 import Data.Time
     ( NominalDiffTime
     )
@@ -190,9 +202,6 @@ import Network.HTTP.Client
     , newManager
     , responseTimeoutMicro
     )
-import Network.Wai.Middleware.Logging
-    ( ApiLog (..)
-    )
 import Numeric.Natural
     ( Natural
     )
@@ -205,6 +214,9 @@ import System.Directory
     )
 import System.Environment.Extended
     ( isEnvSet
+    )
+import System.IO
+    ( stdout
     )
 import System.IO.Extra
     ( withTempFile
@@ -238,9 +250,6 @@ import UnliftIO.MVar
     , putMVar
     , takeMVar
     )
-import UnliftIO.STM
-    ( TVar
-    )
 
 import qualified Cardano.Wallet.Api.Clients.Network as CN
 import qualified Cardano.Wallet.Api.Clients.Testnet.Id as C
@@ -249,85 +258,93 @@ import qualified Cardano.Wallet.Benchmarks.Latency.Measure as Measure
 import qualified Cardano.Wallet.Faucet as Faucet
 import qualified Cardano.Wallet.Launch.Cluster as Cluster
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Text as T
 import qualified Options.Applicative as O
 
 main :: IO ()
-main = withUtf8
-    $ withLatencyLogging setupTracers
-    $ \tracers capture ->
-        withShelleyServer tracers $ \massiveWalletMnemonic' ctx ->
-            runReaderT (runResourceT $ walletApiBench massiveWalletMnemonic')
+main = withUtf8 $ evalContT $ do
+    tr <- withToTextTracer (Left stdout) Nothing
+    let ToTextTracer onlyErrors =
+            overToTextTracer (filterSeverity (const $ pure Error)) tr
+        setupTracers tvar =
+            Tracers
+                { apiServerTracer = trMessage $ snd >$< traceInTVarIO tvar
+                , applicationTracer = onlyErrors
+                , tokenMetadataTracer = onlyErrors
+                , walletEngineTracer = onlyErrors
+                , walletDbTracer = onlyErrors
+                , poolsEngineTracer = onlyErrors
+                , poolsDbTracer = onlyErrors
+                , ntpClientTracer = onlyErrors
+                , networkTracer = onlyErrors
+                }
+    (tracers, capture) <- withLatencyLogging setupTracers
+    liftIO
+        $ withShelleyServer tracers
+        $ \massiveWalletMnemonic' ctx ->
+            runReaderT (runResourceT $ walletApiBench tr massiveWalletMnemonic')
                 $ BenchCtx ctx capture
-  where
-    onlyErrors :: (HasSeverityAnnotation a, ToText a) => Tracer IO a
-    onlyErrors = filterSeverity (const $ pure Error) stdoutTextTracer
-
-    setupTracers :: TVar [LogObject ApiLog] -> Tracers IO
-    setupTracers tvar =
-        Tracers
-            { apiServerTracer = trMessage $ snd >$< traceInTVarIO tvar
-            , applicationTracer = onlyErrors
-            , tokenMetadataTracer = onlyErrors
-            , walletEngineTracer = onlyErrors
-            , walletDbTracer = onlyErrors
-            , poolsEngineTracer = onlyErrors
-            , poolsDbTracer = onlyErrors
-            , ntpClientTracer = onlyErrors
-            , networkTracer = onlyErrors
-            }
 
 -- Creates n fixture wallets and return 3 of them
 
-walletApiBench :: SomeMnemonic -> BenchM ()
-walletApiBench massiveMnemonic = do
+walletApiBench :: ToTextTracer -> SomeMnemonic -> BenchM ()
+walletApiBench (ToTextTracer tr) massiveMnemonic = do
+
+    let semantic = mkSemantic ["latency"]
+    reporter <- newReporterResourceTFromEnv tr semantic
+
+    let runScenarioR semSeg scen = do
+            let sem = mkSemantic [T.pack semSeg]
+            runScenario (addSemantic reporter sem) scen
 
     fmtTitle "Non-cached run"
     runWarmUpScenario
 
-    fmtTitle "Latencies for 2 fixture wallets scenario"
-    runScenario (nFixtureWallet 2)
+    fmtTitle "Latencies for 2 fixture wallets scenarioR"
+    runScenarioR "2-fixture" (nFixtureWallet 2)
 
-    fmtTitle "Latencies for 10 fixture wallets scenario"
-    runScenario (nFixtureWallet 10)
+    fmtTitle "Latencies for 10 fixture wallets scenarioR"
+    runScenarioR "10-fixture" (nFixtureWallet 10)
 
     fmtTitle "Latencies for 100 fixture wallets"
-    runScenario (nFixtureWallet 100)
+    runScenarioR "100-fixture" (nFixtureWallet 100)
 
-    fmtTitle "Latencies for 2 fixture wallets with 10 txs scenario"
-    runScenario (nFixtureWalletWithTxs 2 10)
+    fmtTitle "Latencies for 2 fixture wallets with 10 txs scenarioR"
+    runScenarioR "2-fixture-10-txs" (nFixtureWalletWithTxs 2 10)
 
-    fmtTitle "Latencies for 2 fixture wallets with 20 txs scenario"
-    runScenario (nFixtureWalletWithTxs 2 20)
+    fmtTitle "Latencies for 2 fixture wallets with 20 txs scenarioR"
+    runScenarioR "2-fixture-20-txs" (nFixtureWalletWithTxs 2 20)
 
-    fmtTitle "Latencies for 2 fixture wallets with 100 txs scenario"
-    runScenario (nFixtureWalletWithTxs 2 100)
+    fmtTitle "Latencies for 2 fixture wallets with 100 txs scenarioR"
+    runScenarioR "2-fixture-100-txs" (nFixtureWalletWithTxs 2 100)
 
-    fmtTitle "Latencies for 10 fixture wallets with 10 txs scenario"
-    runScenario (nFixtureWalletWithTxs 10 10)
+    fmtTitle "Latencies for 10 fixture wallets with 10 txs scenarioR"
+    runScenarioR "10-fixture-10-txs" (nFixtureWalletWithTxs 10 10)
 
-    fmtTitle "Latencies for 10 fixture wallets with 20 txs scenario"
-    runScenario (nFixtureWalletWithTxs 10 20)
+    fmtTitle "Latencies for 10 fixture wallets with 20 txs scenarioR"
+    runScenarioR "10-fixture-20-txs" (nFixtureWalletWithTxs 10 20)
 
-    fmtTitle "Latencies for 10 fixture wallets with 100 txs scenario"
-    runScenario (nFixtureWalletWithTxs 10 100)
+    fmtTitle "Latencies for 10 fixture wallets with 100 txs scenarioR"
+    runScenarioR "10-fixture-100-txs" (nFixtureWalletWithTxs 10 100)
 
-    fmtTitle "Latencies for 2 fixture wallets with 100 utxos scenario"
-    runScenario (nFixtureWalletWithUTxOs 2 100)
+    fmtTitle "Latencies for 2 fixture wallets with 100 utxos scenarioR"
+    runScenarioR "2-fixture-100-utxos" (nFixtureWalletWithUTxOs 2 100)
 
-    fmtTitle "Latencies for 2 fixture wallets with 200 utxos scenario"
-    runScenario (nFixtureWalletWithUTxOs 2 200)
+    fmtTitle "Latencies for 2 fixture wallets with 200 utxos scenarioR"
+    runScenarioR "2-fixture-200-utxos" (nFixtureWalletWithUTxOs 2 200)
 
-    fmtTitle "Latencies for 2 fixture wallets with 500 utxos scenario"
-    runScenario (nFixtureWalletWithUTxOs 2 500)
+    fmtTitle "Latencies for 2 fixture wallets with 500 utxos scenarioR"
+    runScenarioR "2-fixture-500-utxos" (nFixtureWalletWithUTxOs 2 500)
 
-    fmtTitle "Latencies for 2 fixture wallets with 1000 utxos scenario"
-    runScenario (nFixtureWalletWithUTxOs 2 1_000)
+    fmtTitle "Latencies for 2 fixture wallets with 1000 utxos scenarioR"
+    runScenarioR "2-fixture-1000-utxos" (nFixtureWalletWithUTxOs 2 1_000)
 
     fmtTitle
         $ "Latencies for 2 fixture wallets with "
             <> build massiveWalletUTxOSize
             <> " utxos scenario"
-    runScenario $ massiveFixtureWallet massiveMnemonic
+    runScenarioR "2-fixture-massive-utxos"
+        $ massiveFixtureWallet massiveMnemonic
 
 nFixtureWallet
     :: Int
@@ -437,11 +454,17 @@ repeatPostTx wDest amtToSend batchSize amtExp = do
 
     void $ request $ C.deleteWallet wSrcId
 
-scene :: String -> BenchM (Either ClientError a) -> BenchM ()
-scene title scenario = measureApiLogs scenario >>= fmtResult title
+scene :: Reporter IO -> String -> BenchM (Either ClientError a) -> BenchM ()
+scene reporter title scenario = do
+    ts <- measureApiLogs scenario
+    let avg = meanAvg ts
+        semantic = mkSemantic [T.pack title]
+    liftIO $ report reporter [Benchmark semantic $ Result avg Milliseconds 1]
+    fmtResult title ts
 
-sceneOfClientM :: String -> ClientM a -> BenchM ()
-sceneOfClientM title action = scene title $ requestWithError action
+sceneOfClientM :: Reporter IO -> String -> ClientM a -> BenchM ()
+sceneOfClientM reporter title action =
+    scene reporter title $ requestWithError action
 
 listAllTransactions :: ApiT WalletId -> ClientM [ApiTransaction C.Testnet42]
 listAllTransactions walId =
@@ -458,22 +481,27 @@ listAllTransactions walId =
 pend :: Applicative m => m () -> m ()
 pend = const $ pure ()
 
-runScenario :: BenchM (ApiWallet, ApiWallet, ApiWallet, ApiWallet) -> BenchM ()
-runScenario scenario = lift . runResourceT $ do
+runScenario
+    :: Reporter IO
+    -> BenchM (ApiWallet, ApiWallet, ApiWallet, ApiWallet)
+    -> BenchM ()
+runScenario reporter scenario = lift . runResourceT $ do
+    let sceneOfClientMR :: String -> ClientM a -> BenchM ()
+        sceneOfClientMR = sceneOfClientM reporter
     (wal1, wal2, walMA, maWalletToMigrate) <- scenario
     let wal1Id = wal1 ^. #id
         wal2Id = wal2 ^. #id
         walMAId = walMA ^. #id
         maWalletToMigrateId = maWalletToMigrate ^. #id
         amt = minUTxOValue era
-    sceneOfClientM "listWallets" C.listWallets
-    sceneOfClientM "getWallet" $ C.getWallet wal1Id
-    sceneOfClientM "getUTxOsStatistics" $ C.getWalletUtxoStatistics wal1Id
-    sceneOfClientM "listAddresses" $ C.listAddresses wal1Id Nothing
-    sceneOfClientM "listTransactions" $ listAllTransactions wal1Id
+    sceneOfClientMR "listWallets" C.listWallets
+    sceneOfClientMR "getWallet" $ C.getWallet wal1Id
+    sceneOfClientMR "getUTxOsStatistics" $ C.getWalletUtxoStatistics wal1Id
+    sceneOfClientMR "listAddresses" $ C.listAddresses wal1Id Nothing
+    sceneOfClientMR "listTransactions" $ listAllTransactions wal1Id
 
     txs <- request $ listAllTransactions wal1Id
-    sceneOfClientM "getTransaction"
+    sceneOfClientMR "getTransaction"
         $ C.getTransaction wal1Id (ApiTxId $ txs !! 1 ^. #id) False
 
     addrs <- request $ C.listAddresses wal2Id Nothing
@@ -491,7 +519,7 @@ runScenario scenario = lift . runResourceT $ do
                 , metadata = Nothing
                 , timeToLive = Nothing
                 }
-    sceneOfClientM "postTransactionFee" $ C.postTransactionFee wal1Id payload
+    sceneOfClientMR "postTransactionFee" $ C.postTransactionFee wal1Id payload
 
     let payloadTx =
             PostTransactionOldData
@@ -501,7 +529,7 @@ runScenario scenario = lift . runResourceT $ do
                 , metadata = Nothing
                 , timeToLive = Nothing
                 }
-    sceneOfClientM "postTransaction" $ C.postTransaction wal1Id payloadTx
+    sceneOfClientMR "postTransaction" $ C.postTransaction wal1Id payloadTx
 
     let payments =
             replicate 5
@@ -518,7 +546,7 @@ runScenario scenario = lift . runResourceT $ do
                 , metadata = Nothing
                 , timeToLive = Nothing
                 }
-    sceneOfClientM "postTransactionTo5Addrs"
+    sceneOfClientMR "postTransactionTo5Addrs"
         $ C.postTransaction wal1Id payloadTxTo5Addr
 
     let
@@ -541,27 +569,27 @@ runScenario scenario = lift . runResourceT $ do
                 }
     -- Todo ADP-3293
     pend
-        $ sceneOfClientM "postTransactionMA"
+        $ sceneOfClientMR "postTransactionMA"
         $ C.postTransaction walMAId payloadMA
 
-    sceneOfClientM "listStakePools" $ C.listPools $ ApiT <$> arbitraryStake
+    sceneOfClientMR "listStakePools" $ C.listPools $ ApiT <$> arbitraryStake
 
-    sceneOfClientM "getNetworkInfo" CN.networkInformation
+    sceneOfClientMR "getNetworkInfo" CN.networkInformation
 
-    sceneOfClientM "listAssets" $ C.getAssets walMAId
+    sceneOfClientMR "listAssets" $ C.getAssets walMAId
 
     let assetsSrc = walMA ^. #assets . #total
         (polId, assName) =
             bimap unsafeFromText unsafeFromText
                 $ fst
                 $ pickAnAsset assetsSrc
-    sceneOfClientM "getAsset" $ C.getAsset walMAId (ApiT polId) (ApiT assName)
+    sceneOfClientMR "getAsset" $ C.getAsset walMAId (ApiT polId) (ApiT assName)
 
     let addresses = replicate 5 destination
         migrationPlanPayload =
             ApiWalletMigrationPlanPostData $ NE.fromList addresses
 
-    sceneOfClientM "postMigrationPlan"
+    sceneOfClientMR "postMRigrationPlan"
         $ C.planMigration maWalletToMigrateId migrationPlanPayload
 
     let migrationPayload =
@@ -571,7 +599,7 @@ runScenario scenario = lift . runResourceT $ do
                 }
     -- Todo ADP-3293
     pend
-        $ sceneOfClientM "postMigration"
+        $ sceneOfClientMR "postMRigration"
         $ C.migrate maWalletToMigrateId migrationPayload
 
 fmtResult :: String -> [NominalDiffTime] -> BenchM ()

--- a/lib/benchmarks/exe/read-blocks.hs
+++ b/lib/benchmarks/exe/read-blocks.hs
@@ -2,6 +2,15 @@
 
 import Prelude
 
+import Cardano.BM.ToTextTracer
+    ( ToTextTracer (..)
+    , withToTextTracer
+    )
+import Cardano.Wallet.Benchmarks.Collect
+    ( newReporterFromEnv
+    , noSemantic
+    , runCriterionBenchmark
+    )
 import Cardano.Wallet.Primitive.Types
     ( GenesisParameters (..)
     , StartTime (..)
@@ -16,25 +25,35 @@ import Cardano.Wallet.Read.Block
 import Cardano.Wallet.Read.Block.Gen.Build
     ( exampleBlocks
     )
+import Control.Monad.Cont
+    ( evalContT
+    )
+import Control.Monad.IO.Class
+    ( MonadIO (..)
+    )
 import Criterion.Main
     ( bench
     , bgroup
-    , defaultMain
     , nf
     )
 import Data.Time.Clock.POSIX
     ( posixSecondsToUTCTime
+    )
+import System.IO
+    ( stdout
     )
 
 import qualified Cardano.Wallet.Primitive.Ledger.Read.Block as New
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.ByteString.Char8 as B8
 
--- Our benchmark harness.
 main :: IO ()
-main =
-    defaultMain
-        [ bgroup
+main = evalContT $ do
+    ToTextTracer tr <- withToTextTracer (Left stdout) Nothing
+    reporter <- newReporterFromEnv tr noSemantic
+    liftIO
+        $ runCriterionBenchmark 60 tr reporter
+        $ bgroup
             "read blocks"
             [ bench "1 block" $ nf (run new) 1
             , bench "10 blocks" $ nf (run new) 10
@@ -42,7 +61,6 @@ main =
             , bench "1000 blocks" $ nf (run new) 1000
             , bench "10000 blocks" $ nf (run new) 10000
             ]
-        ]
 
 new :: GenesisParameters -> ConsensusBlock -> W.Block
 new gp = fst . New.fromCardanoBlock (getGenesisBlockHash gp)

--- a/lib/benchmarks/src/Cardano/Wallet/BenchShared.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/BenchShared.hs
@@ -24,7 +24,7 @@ module Cardano.Wallet.BenchShared
       -- * Benchmark runner
     , runBenchmarks
     , bench
-    , Time
+    , Time (..)
     , withTempSqliteFile
     ) where
 

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Collect.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Collect.hs
@@ -1,0 +1,449 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Functor law" #-}
+
+module Cardano.Wallet.Benchmarks.Collect
+    ( -- * Benchmark
+      Benchmark (..)
+
+      -- * Result
+    , Result (..)
+    , Units (..)
+
+      -- * Semantic
+    , Semantic
+    , mkSemantic
+    , noSemantic
+
+      -- * Collecting results
+    , Reporter
+    , addSemantic
+    , readSemantic
+    , report
+    , newReporter
+    , newReporterFromEnv
+    , newReporterResourceT
+    , newReporterResourceTFromEnv
+
+      -- * Collecting results from criterion benchmarks
+    , runCriterionBenchmark
+    ) where
+
+import Prelude
+
+import Cardano.BM.Tracing
+    ( HasSeverityAnnotation (..)
+    , Severity (..)
+    , Tracer
+    , traceWith
+    )
+import Control.Comonad
+    ( Comonad (..)
+    )
+import Control.Foldl
+    ( Fold (..)
+    , fold
+    )
+import Control.Monad
+    ( void
+    )
+import Control.Monad.Cont
+    ( ContT (..)
+    )
+import Control.Monad.Fix
+    ( fix
+    )
+import Control.Monad.Trans.Resource
+    ( ResourceT
+    , register
+    )
+import Criterion.Measurement
+    ( getTime
+    , measure
+    )
+import Criterion.Measurement.Types
+    ( Measured (..)
+    )
+import Data.Csv
+    ( FromField (..)
+    , FromNamedRecord (..)
+    , Header
+    , ToField (..)
+    , ToNamedRecord (..)
+    , header
+    , namedRecord
+    , (.:)
+    , (.=)
+    )
+import Data.Csv.Incremental
+    ( encodeByName
+    , encodeNamedRecord
+    )
+import Data.Foldable
+    ( toList
+    )
+import Data.Int
+    ( Int64
+    )
+import Data.Text
+    ( Text
+    )
+import System.Environment
+    ( lookupEnv
+    )
+import UnliftIO
+    ( MonadIO (..)
+    , atomically
+    , modifyTVar'
+    , newTVarIO
+    , readTVarIO
+    )
+
+import qualified Criterion.Measurement.Types as Cr
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.Text as T
+import Data.Text.Class
+    ( ToText
+    )
+import Data.Text.Class.Extended
+    ( ToText (..)
+    )
+
+-- | A semantic for a benchmark.
+newtype Semantic = Semantic [Text]
+    deriving newtype (Show, Semigroup)
+
+-- | An empty semantic.
+noSemantic :: Semantic
+noSemantic = Semantic []
+
+instance FromField Semantic where
+    parseField = fmap (mkSemantic . reverse . T.words) . parseField
+
+instance ToField Semantic where
+    toField = toField . T.unwords . reverse . unMkSemantic
+
+-- | Create a new semantic from a list of words.
+-- It will frop empty words.
+-- It will replace spaces with dashes.
+mkSemantic :: [Text] -> Semantic
+mkSemantic = Semantic . filter (not . T.null) . fmap (T.replace " " "-")
+
+unMkSemantic :: Semantic -> [Text]
+unMkSemantic (Semantic xs) = toList xs
+
+-- | Units for a result.
+data Units
+    = Seconds
+    | Milliseconds
+    | Microseconds
+    | Nanoseconds
+    | Bytes
+    | MegaBytes
+    | GigaBytes
+    | Count
+
+instance Show Units where
+    show = showUnits
+
+instance FromField Units where
+    parseField "s" = pure Seconds
+    parseField "ms" = pure Milliseconds
+    parseField "us" = pure Microseconds
+    parseField "ns" = pure Nanoseconds
+    parseField "B" = pure Bytes
+    parseField "MB" = pure MegaBytes
+    parseField "GB" = pure GigaBytes
+    parseField "count" = pure Count
+    parseField _ = fail "Invalid units"
+
+instance ToField Units where
+    toField = B8.pack . showUnits
+
+showUnits :: Units -> String
+showUnits Seconds = "s"
+showUnits Milliseconds = "ms"
+showUnits Microseconds = "us"
+showUnits Nanoseconds = "ns"
+showUnits Bytes = "B"
+showUnits MegaBytes = "MB"
+showUnits GigaBytes = "GB"
+showUnits Count = "count"
+
+-- | A result with a value and units.
+data Result = Result
+    { resultValue :: Double
+    , resultUnits :: Units
+    , resultIterations :: Int
+    }
+
+instance Show Result where
+    show (Result value units iterations) =
+        show value
+            ++ " "
+            ++ show units
+            ++ " ("
+            ++ show iterations
+            ++ " iterations)"
+
+-- | A benchmark result with a semantic and a value.
+data Benchmark = Benchmark
+    { benchmarkSemantic :: Semantic
+    , benchmarkResult :: Result
+    }
+    deriving (Show)
+
+instance HasSeverityAnnotation Benchmark where
+    getSeverityAnnotation _ = Notice
+
+instance ToText Benchmark where
+    toText (Benchmark sem res) =
+        T.unwords
+            [ T.unwords $ reverse $ unMkSemantic sem
+            , T.pack $ show res
+            ]
+
+instance ToNamedRecord Benchmark where
+    toNamedRecord (Benchmark semantic (Result value units iterations)) =
+        namedRecord
+            [ "semantic" .= toField semantic
+            , "value" .= toField value
+            , "units" .= toField units
+            , "iterations" .= toField iterations
+            ]
+
+addSemanticToBenchmark :: Semantic -> Benchmark -> Benchmark
+addSemanticToBenchmark sem' (Benchmark sem res) = Benchmark (sem <> sem') res
+
+instance FromNamedRecord Benchmark where
+    parseNamedRecord v
+        | length v == 4 =
+            (\s r u i -> Benchmark s (Result r u i))
+                <$> v .: "semantic"
+                <*> v .: "value"
+                <*> v .: "units"
+                <*> v .: "iterations"
+        | otherwise = fail "Expected 3 fields"
+
+-- | An object to track results with an updatable Semantic
+data Reporter m
+    = Reporter
+    { addSemantic :: Semantic -> Reporter m
+    , readSemantic :: Semantic
+    , report :: [Benchmark] -> m ()
+    }
+
+mkReport :: (Benchmark -> IO ()) -> Semantic -> Reporter IO
+mkReport out sem =
+    Reporter
+        (\sem' -> mkReport out $ sem' <> sem)
+        sem
+        $ mapM_
+        $ out . addSemanticToBenchmark sem
+
+mkNullReport :: Applicative m => Reporter m
+mkNullReport = Reporter (const mkNullReport) noSemantic (const $ pure ())
+
+benchmarksHeader :: Header
+benchmarksHeader = header ["semantic", "value", "units", "iterations"]
+
+-- | Create a new reporter from a file path in a 'ContT' context.
+newReporter
+    :: FilePath
+    -- ^ File path to write the results to
+    -> Tracer IO Benchmark
+    -- ^ Tracer for benchmark results
+    -> Semantic
+    -- ^ Root semantic for all benchmarks
+    -> ContT r IO (Reporter IO)
+newReporter fp tr sem0 = do
+    outputVar <- newTVarIO mempty
+    let update bench = do
+            atomically
+                $ modifyTVar' outputVar
+                $ \bs -> bs <> encodeNamedRecord bench
+            traceWith tr bench
+    ContT $ \k -> do
+        r <- k $ mkReport update sem0
+        output <- readTVarIO outputVar
+        BL.writeFile fp $ encodeByName benchmarksHeader output
+        pure r
+
+-- | Create a new reporter from the environment variable 'BENCHMARK_CSV_FILE'
+-- in a 'ContT' context.
+newReporterFromEnv
+    :: Tracer IO Benchmark
+    -- ^ Tracer for benchmark results
+    -> Semantic
+    -- ^ Root semantic for all benchmarks
+    -> ContT r IO (Reporter IO)
+newReporterFromEnv tr rootSem = do
+    csvFile <- liftIO $ lookupEnv "BENCHMARK_CSV_FILE"
+    case csvFile of
+        Just fp -> newReporter fp tr rootSem
+        Nothing -> pure mkNullReport
+
+-- | Create a new reporter from a file path in a 'ResourceT' context.
+newReporterResourceT
+    :: MonadIO m
+    => FilePath
+    -- ^ File path to write the results to
+    -> Tracer IO Benchmark
+    -- ^ Tracer for benchmark results
+    -> Semantic
+    -- ^ Root semantic for all benchmarks
+    -> ResourceT m (Reporter IO)
+newReporterResourceT fp tr sem0 = do
+    outputVar <- newTVarIO mempty
+    let update bench = do
+            atomically
+                $ modifyTVar' outputVar
+                $ \bs -> bs <> encodeNamedRecord bench
+            traceWith tr bench
+    void $ register $ do
+        output <- readTVarIO outputVar
+        BL.writeFile fp $ encodeByName benchmarksHeader output
+    pure $ mkReport update sem0
+
+-- | Create a new reporter from the environment variable 'BENCHMARK_CSV_FILE' in
+-- a 'ResourceT' context.
+newReporterResourceTFromEnv
+    :: MonadIO m
+    => Tracer IO Benchmark
+    -- ^ Tracer for benchmark results
+    -> Semantic
+    -- ^ Root semantic for all benchmarks
+    -> ResourceT m (Reporter IO)
+newReporterResourceTFromEnv tr rootSem = do
+    csvFile <- liftIO $ lookupEnv "BENCHMARK_CSV_FILE"
+    case csvFile of
+        Just fp -> newReporterResourceT fp tr rootSem
+        Nothing -> pure mkNullReport
+
+--------------------------------------------------------------------------------
+--- Collecting results from criterion benchmarks -------------------------------
+--------------------------------------------------------------------------------
+data CountAndAppend a = CountAndAppend
+    { cIterations :: !Int64
+    , total :: !a
+    }
+    deriving stock (Show, Functor)
+
+instance Monoid a => Monoid (CountAndAppend a) where
+    mempty = CountAndAppend 0 mempty
+
+instance Semigroup a => Semigroup (CountAndAppend a) where
+    CountAndAppend n1 t1 <> CountAndAppend n2 t2 =
+        CountAndAppend (n1 + n2) (t1 <> t2)
+
+newtype Time = Time Double
+    deriving newtype (Show, Num, Fractional, Ord, Eq, RealFrac, Real)
+
+data MeasureAndTotal = MeasureAndTotal
+    { measureTime :: !Time
+    , measureTotalTime :: !Time
+    }
+    deriving (Show)
+
+instance Semigroup MeasureAndTotal where
+    MeasureAndTotal t1 tt1 <> MeasureAndTotal t2 tt2 =
+        MeasureAndTotal (t1 + t2) (tt1 + tt2)
+
+instance Monoid MeasureAndTotal where
+    mempty = MeasureAndTotal 0 0
+
+stateFromMeasured :: (Measured, Time) -> CountAndAppend MeasureAndTotal
+stateFromMeasured (m, t) =
+    CountAndAppend
+        (measIters m)
+        (MeasureAndTotal (Time $ measTime m) t)
+
+-- | A special frontend for running criterion benchmarks with a given timeout.
+-- It is designed to use 'Reporter IO' to collect the results and it is not
+-- guaranteed that there is a statistical significance in the results.
+-- In fact if the first iteration is already over the timeout, the result will
+-- be the time of the first iteration.
+runCriterionBenchmark
+    :: Time
+    -- ^ Timeout in seconds. At least 1 iteration will be run.
+    -> Tracer IO Benchmark
+    -- ^ Tracer for benchmark results
+    -> Reporter IO
+    -- ^ Reporter for benchmark results
+    -> Cr.Benchmark
+    -- ^ Criterion benchmark to run
+    -> IO ()
+runCriterionBenchmark timeout tr = go
+  where
+    go r (Cr.Benchmark s b) = do
+        v <- runCriterion timeout (\n -> fst <$> measure b (fromIntegral n))
+        let r' = addSemantic r $ mkSemantic [T.pack s]
+            Time average = total v / fromIntegral (cIterations v)
+            benchmark =
+                Benchmark (readSemantic r')
+                    $ Result average Seconds
+                    $ fromIntegral
+                    $ cIterations v
+        traceWith tr benchmark
+        report r' [benchmark]
+    go r (Cr.BenchGroup s bs) = do
+        let sem = mkSemantic [T.pack s]
+        mapM_ (go $ addSemantic r sem) bs
+    go r (Cr.Environment s c f) = do
+        e <- s
+        go r $ f e
+        void $ c e
+
+-- | Update a fold with a new value.
+updateFold :: Fold input output -> input -> Fold input output
+updateFold f x = fold (duplicate f) [x]
+
+-- | A fold over a stream of (Measured, Time) where the time is the
+-- real time of the full measurement.
+-- It will output the total iterations, and the total measured time as from
+-- the Measured values from criterion.
+collectFold
+    :: Time
+    -- ^ Timeout in seconds. At least 1 iteration will be run.
+    -> Fold (Measured, Time) (CountAndAppend Time, Int)
+collectFold timeout = Fold add create value
+  where
+    add (state, _) v =
+        let
+            state'@(CountAndAppend n (MeasureAndTotal _ ut)) =
+                state <> stateFromMeasured v
+            timeLeft = max 0 $ timeout - ut
+            estimate = ut / fromIntegral n
+        in
+            (state', floor $ timeLeft / estimate)
+    create = (mempty, 1)
+    value (state, j) = (fmap measureTime state, j)
+
+withElapsedTime :: MonadIO m => m a -> m (a, Time)
+withElapsedTime action = do
+    start <- liftIO getTime
+    result <- action
+    end <- liftIO getTime
+    pure (result, Time $ end - start)
+
+runCriterion
+    :: MonadIO m
+    => Time
+    -- ^ Timeout in seconds. At least 1 iteration will be run.
+    -> (Int -> m Measured)
+    -- ^ Action to run for each iteration
+    -> m (CountAndAppend Time)
+runCriterion t f = ($ (collectFold t)) $ fix $ \loop state -> do
+    let (result, next) = extract state
+    if next <= 0
+        then pure result
+        else do
+            v <- withElapsedTime $ f next
+            loop $ updateFold state v

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Collect.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Collect.hs
@@ -146,6 +146,7 @@ data Units
     | Microseconds
     | Nanoseconds
     | Bytes
+    | KiloBytes
     | MegaBytes
     | GigaBytes
     | Count
@@ -159,6 +160,7 @@ instance FromField Units where
     parseField "us" = pure Microseconds
     parseField "ns" = pure Nanoseconds
     parseField "B" = pure Bytes
+    parseField "KB" = pure KiloBytes
     parseField "MB" = pure MegaBytes
     parseField "GB" = pure GigaBytes
     parseField "count" = pure Count
@@ -173,6 +175,7 @@ showUnits Milliseconds = "ms"
 showUnits Microseconds = "us"
 showUnits Nanoseconds = "ns"
 showUnits Bytes = "B"
+showUnits KiloBytes = "KB"
 showUnits MegaBytes = "MB"
 showUnits GigaBytes = "GB"
 showUnits Count = "count"

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/Measure.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/Measure.hs
@@ -110,24 +110,21 @@ isLogRequestFinish = \case
     ApiLog _ LogRequestFinish -> True
     _ -> False
 
-measureApiLogs :: LogCaptureFunc ApiLog () -> IO a -> IO [NominalDiffTime]
-measureApiLogs = measureLatency isLogRequestStart isLogRequestFinish
-
--- | Run tests for at least this long to get accurate timings.
-sampleNTimes :: Int
-sampleNTimes = 10
+measureApiLogs :: Int -> LogCaptureFunc ApiLog () -> IO a -> IO [NominalDiffTime]
+measureApiLogs count = measureLatency count isLogRequestStart isLogRequestFinish
 
 -- | Measure how long an action takes based on trace points and taking an
 -- average of results over a short time period.
 measureLatency
     :: Show msg
-    => (msg -> Bool) -- ^ Predicate for start message
+    => Int
+    -> (msg -> Bool) -- ^ Predicate for start message
     -> (msg -> Bool) -- ^ Predicate for end message
     -> LogCaptureFunc msg () -- ^ Log capture function.
     -> IO a -- ^ Action to run
     -> IO [NominalDiffTime]
-measureLatency start finish capture action = do
-    (logs, ()) <- capture $ replicateM_ sampleNTimes action
+measureLatency count start finish capture action = do
+    (logs, ()) <- capture $ replicateM_ count action
     pure $ extractTimings start finish logs
 
 -- | Scan through iohk-monitoring logs and extract time differences between

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/Measure.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Latency/Measure.hs
@@ -13,6 +13,7 @@ module Cardano.Wallet.Benchmarks.Latency.Measure
     -- * Formatting results
   , fmtResult
   , fmtTitle
+  , meanAvg
   ) where
 
 import Prelude

--- a/lib/iohk-monitoring-extra/src/Cardano/BM/ToTextTracer.hs
+++ b/lib/iohk-monitoring-extra/src/Cardano/BM/ToTextTracer.hs
@@ -3,8 +3,8 @@
 module Cardano.BM.ToTextTracer
     ( ToTextTracer (..)
     , logHandleFromFilePath
-    , newToTextTracer
     , withFile
+    , withToTextTracer
     )
 where
 
@@ -80,13 +80,13 @@ logHandleFromFilePath clusterLogsFile = do
     pure h
 
 -- | Create a new `ToTextTracer`
-newToTextTracer
+withToTextTracer
     :: Either Handle FilePath
     -- ^ If provided, logs will be written to this file, otherwise to stdout
     -> Maybe Severity
     -- ^ Minimum severity level to log
     -> ContT r IO ToTextTracer
-newToTextTracer mClusterLogsFile minSeverity = do
+withToTextTracer mClusterLogsFile minSeverity = do
     ch <- newTChanIO
     h <- case mClusterLogsFile of
         Left h -> pure h

--- a/lib/iohk-monitoring-extra/src/Cardano/BM/ToTextTracer.hs
+++ b/lib/iohk-monitoring-extra/src/Cardano/BM/ToTextTracer.hs
@@ -5,6 +5,7 @@ module Cardano.BM.ToTextTracer
     , logHandleFromFilePath
     , withFile
     , withToTextTracer
+    , overToTextTracer
     )
 where
 
@@ -133,3 +134,14 @@ withFile path mode action = do
             hClose h
             throwIO e
     catch action' handler
+
+-- | Modify the tracer of a `ToTextTracer`
+overToTextTracer
+    :: ( forall a
+          . (HasSeverityAnnotation a, ToText a)
+         => Tracer IO a
+         -> Tracer IO a
+       )
+    -> ToTextTracer
+    -> ToTextTracer
+overToTextTracer f (ToTextTracer tr) = ToTextTracer (f tr)

--- a/lib/local-cluster/exe/local-cluster.hs
+++ b/lib/local-cluster/exe/local-cluster.hs
@@ -6,7 +6,7 @@ import Prelude
 
 import Cardano.BM.ToTextTracer
     ( ToTextTracer (..)
-    , newToTextTracer
+    , withToTextTracer
     )
 import Cardano.Launcher.Node
     ( nodeSocketFile
@@ -252,10 +252,9 @@ main = withUtf8 $ do
         -- Add a tracer for the cluster logs
         ToTextTracer tracer <- case clusterLogs of
             Nothing -> pure $ ToTextTracer nullTracer
-            Just path ->
-                newToTextTracer
-                    (Right . toFilePath . absFileOf $ path)
-                    minSeverity
+            Just path -> withToTextTracer
+                (Right . toFilePath . absFileOf $ path)
+                minSeverity
 
         let debug :: MonadIO m => Text -> m ()
             debug = liftIO . traceWith tracer

--- a/lib/local-cluster/exe/local-cluster.hs
+++ b/lib/local-cluster/exe/local-cluster.hs
@@ -6,8 +6,7 @@ import Prelude
 
 import Cardano.BM.ToTextTracer
     ( ToTextTracer (..)
-    , logHandleFromFilePath
-    , newToTextTracerFromHandle
+    , newToTextTracer
     )
 import Cardano.Launcher.Node
     ( nodeSocketFile
@@ -253,9 +252,10 @@ main = withUtf8 $ do
         -- Add a tracer for the cluster logs
         ToTextTracer tracer <- case clusterLogs of
             Nothing -> pure $ ToTextTracer nullTracer
-            Just path -> do
-                h <- logHandleFromFilePath $ toFilePath . absFileOf $ path
-                newToTextTracerFromHandle h minSeverity
+            Just path ->
+                newToTextTracer
+                    (Right . toFilePath . absFileOf $ path)
+                    minSeverity
 
         let debug :: MonadIO m => Text -> m ()
             debug = liftIO . traceWith tracer

--- a/lib/local-cluster/process/Cardano/Wallet/Launch/Cluster/Process.hs
+++ b/lib/local-cluster/process/Cardano/Wallet/Launch/Cluster/Process.hs
@@ -22,7 +22,7 @@ import Prelude
 import Cardano.BM.ToTextTracer
     ( ToTextTracer (..)
     , logHandleFromFilePath
-    , newToTextTracerFromHandle
+    , newToTextTracer
     )
 import Cardano.Launcher
     ( Command (..)
@@ -145,9 +145,8 @@ withLocalCluster name walletOption envs faucetFundsValue = do
         localClusterCommand name walletOption envs port faucetFundsPath
     ToTextTracer processLogs <- case logsPathName of
         Nothing -> pure $ ToTextTracer nullTracer
-        Just path -> do
-            handle <- logHandleFromFilePath $ path <> "-process" <.> "log"
-            newToTextTracerFromHandle handle Nothing
+        Just path ->
+            newToTextTracer (Right $ path <> "-process" <.> "log") Nothing
     _ <-
         ContT
             $ withBackendProcess

--- a/lib/local-cluster/process/Cardano/Wallet/Launch/Cluster/Process.hs
+++ b/lib/local-cluster/process/Cardano/Wallet/Launch/Cluster/Process.hs
@@ -22,7 +22,7 @@ import Prelude
 import Cardano.BM.ToTextTracer
     ( ToTextTracer (..)
     , logHandleFromFilePath
-    , newToTextTracer
+    , withToTextTracer
     )
 import Cardano.Launcher
     ( Command (..)
@@ -146,7 +146,7 @@ withLocalCluster name walletOption envs faucetFundsValue = do
     ToTextTracer processLogs <- case logsPathName of
         Nothing -> pure $ ToTextTracer nullTracer
         Just path ->
-            newToTextTracer (Right $ path <> "-process" <.> "log") Nothing
+            withToTextTracer (Right $ path <> "-process" <.> "log") Nothing
     _ <-
         ContT
             $ withBackendProcess

--- a/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
+++ b/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
@@ -32,6 +32,7 @@ benchmark memory
   build-depends:
     , base
     , cardano-wallet-launcher
+    , cardano-wallet-benchmarks
     , contra-tracer
     , filepath
     , iohk-monitoring

--- a/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
+++ b/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
@@ -60,10 +60,14 @@ benchmark memory
     Paths_cardano_wallet_blackbox_benchmarks
   build-depends:
     , base
+    , cardano-wallet-blackbox-benchmarks
+    , cardano-wallet-benchmarks
     , cardano-wallet-launcher
     , contra-tracer
     , filepath
     , iohk-monitoring
+    , iohk-monitoring-extra
+    , mtl
     , process
     , temporary
     , text

--- a/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
+++ b/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
@@ -1,4 +1,4 @@
-cabal-version:       3.0
+cabal-version:       3.6
 name:                cardano-wallet-blackbox-benchmarks
 version:             2024.5.5
 synopsis:            Benchmarks for the `cardano-wallet` exectuable.
@@ -12,15 +12,44 @@ copyright:           2023 Cardano Foundation
 license:             Apache-2.0
 category:            Web
 build-type:          Simple
-data-files:          data/membench-snapshot.tgz
+data-files:
+    data/membench-snapshot.tgz
+    data/hoogle-pmap.txt
 
 common language
-  ghc-options:        -threaded -Wall
+  ghc-options:        -threaded -Wall -Wunused-packages
   default-language:   Haskell2010
   default-extensions:
     NamedFieldPuns
     NoImplicitPrelude
     OverloadedStrings
+
+flag release
+  description: Enable optimization and `-Werror`
+  default:     False
+  manual:      True
+
+common opts-lib
+  ghc-options: -Wall -Wcompat -Wredundant-constraints
+
+  if flag(release)
+    ghc-options: -O2 -Werror
+
+common opts-exe
+  import:      opts-lib
+  ghc-options: -threaded -rtsopts
+
+library
+  import:          language, opts-lib
+  hs-source-dirs:  lib
+  build-depends:
+    , attoparsec
+    , base
+    , bytestring
+    , process
+    , unliftio
+  exposed-modules:
+    Cardano.Wallet.Benchmark.Memory.Pmap
 
 benchmark memory
   import:         language
@@ -32,7 +61,6 @@ benchmark memory
   build-depends:
     , base
     , cardano-wallet-launcher
-    , cardano-wallet-benchmarks
     , contra-tracer
     , filepath
     , iohk-monitoring
@@ -42,3 +70,19 @@ benchmark memory
     , text-class
     , optparse-applicative
     , with-utf8
+
+test-suite unit
+  import:           language, opts-exe
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  main-is:          Main.hs
+  build-depends:
+    , attoparsec
+    , base
+    , bytestring
+    , hspec
+    , cardano-wallet-blackbox-benchmarks
+  build-tool-depends: hspec-discover:hspec-discover
+  other-modules:
+    Cardano.Wallet.Benchmark.Memory.PmapSpec
+    Paths_cardano_wallet_blackbox_benchmarks

--- a/lib/wallet-benchmarks/data/hoogle-pmap.txt
+++ b/lib/wallet-benchmarks/data/hoogle-pmap.txt
@@ -1,0 +1,94 @@
+2316565:   /nix/store/2a2sbgbjg11g40awcizfbcrhsqa580wx-hoogle-exe-hoogle-5.0.18.4/bin/hoogle serve --database /nix/store/vk9yi9ww5bslmy49jv1g4ahifj527kjy-hoogle-with-packages/share/doc/hoogle/default.hoo --local
+0000000000400000  17376K r-x-- hoogle
+00000000014f9000      8K r---- hoogle
+00000000014fb000   2628K rw--- hoogle
+000000000178c000     12K rw---   [ anon ]
+00000000018d4000    276K rw---   [ anon ]
+0000004200000000  15360K rw---   [ anon ]
+0000004200f00000 1073727488K -----   [ anon ]
+00007f1204000000    132K rw---   [ anon ]
+00007f1204021000  65404K -----   [ anon ]
+00007f1208feb000 114772K r---- default.hoo
+00007f1210000000   1360K rw---   [ anon ]
+00007f1210154000  64176K -----   [ anon ]
+00007f1216ffe000      4K -----   [ anon ]
+00007f1216fff000   8192K rw---   [ anon ]
+00007f12177ff000      4K -----   [ anon ]
+00007f1217800000   9388K rw---   [ anon ]
+00007f121812b000  64340K -----   [ anon ]
+00007f121c000000    132K rw---   [ anon ]
+00007f121c021000  65404K -----   [ anon ]
+00007f1220000000    132K rw---   [ anon ]
+00007f1220021000  65404K -----   [ anon ]
+00007f12246d3000      4K -----   [ anon ]
+00007f12246d4000   8192K rw---   [ anon ]
+00007f1224ed4000      4K -----   [ anon ]
+00007f1224ed5000   8192K rw---   [ anon ]
+00007f12256d5000      4K -----   [ anon ]
+00007f12256d6000  12296K rw---   [ anon ]
+00007f12262d8000    460K r---- locale-archive
+00007f122634b000     16K rw---   [ anon ]
+00007f122634f000     16K r---- libgcc_s.so.1
+00007f1226353000     92K r-x-- libgcc_s.so.1
+00007f122636a000     16K r---- libgcc_s.so.1
+00007f122636e000      4K r---- libgcc_s.so.1
+00007f122636f000      4K rw--- libgcc_s.so.1
+00007f1226370000      8K rw---   [ anon ]
+00007f1226372000     16K r---- libnuma.so.1.0.0
+00007f1226376000     24K r-x-- libnuma.so.1.0.0
+00007f122637c000      8K r---- libnuma.so.1.0.0
+00007f122637e000      4K r---- libnuma.so.1.0.0
+00007f122637f000      4K rw--- libnuma.so.1.0.0
+00007f1226380000      8K r---- libffi.so.8.1.2
+00007f1226382000     28K r-x-- libffi.so.8.1.2
+00007f1226389000      8K r---- libffi.so.8.1.2
+00007f122638b000      4K r---- libffi.so.8.1.2
+00007f122638c000      4K rw--- libffi.so.8.1.2
+00007f122638d000      4K r---- libdl.so.2
+00007f122638e000      4K r-x-- libdl.so.2
+00007f122638f000      4K r---- libdl.so.2
+00007f1226390000      4K r---- libdl.so.2
+00007f1226391000      4K rw--- libdl.so.2
+00007f1226392000      4K r---- librt.so.1
+00007f1226393000      4K r-x-- librt.so.1
+00007f1226394000      4K r---- librt.so.1
+00007f1226395000      4K r---- librt.so.1
+00007f1226396000      4K rw--- librt.so.1
+00007f1226397000    136K r---- libc.so.6
+00007f12263b9000   1380K r-x-- libc.so.6
+00007f1226512000    352K r---- libc.so.6
+00007f122656a000     16K r---- libc.so.6
+00007f122656e000      8K rw--- libc.so.6
+00007f1226570000     60K rw---   [ anon ]
+00007f122657f000     72K r---- libgmp.so.10.5.0
+00007f1226591000    476K r-x-- libgmp.so.10.5.0
+00007f1226608000     92K r---- libgmp.so.10.5.0
+00007f122661f000      8K r---- libgmp.so.10.5.0
+00007f1226621000      4K rw--- libgmp.so.10.5.0
+00007f1226622000    644K r---- libstdc++.so.6.0.30
+00007f12266c3000   1052K r-x-- libstdc++.so.6.0.30
+00007f12267ca000    444K r---- libstdc++.so.6.0.30
+00007f1226839000     52K r---- libstdc++.so.6.0.30
+00007f1226846000      4K rw--- libstdc++.so.6.0.30
+00007f1226847000     12K rw---   [ anon ]
+00007f122684a000     12K r---- libz.so.1.3
+00007f122684d000     72K r-x-- libz.so.1.3
+00007f122685f000     28K r---- libz.so.1.3
+00007f1226866000      4K r---- libz.so.1.3
+00007f1226867000      4K rw--- libz.so.1.3
+00007f1226868000     56K r---- libm.so.6
+00007f1226876000    464K r-x-- libm.so.6
+00007f12268ea000    368K r---- libm.so.6
+00007f1226946000      4K r---- libm.so.6
+00007f1226947000      4K rw--- libm.so.6
+00007f1226948000      8K rw---   [ anon ]
+00007f122694a000      4K r---- ld-linux-x86-64.so.2
+00007f122694b000    152K r-x-- ld-linux-x86-64.so.2
+00007f1226971000     40K r---- ld-linux-x86-64.so.2
+00007f122697b000      8K r---- ld-linux-x86-64.so.2
+00007f122697d000      8K rw--- ld-linux-x86-64.so.2
+00007ffc25363000    196K rw---   [ stack ]
+00007ffc253c2000     16K r----   [ anon ]
+00007ffc253c6000      8K r-x--   [ anon ]
+ffffffffff600000      4K --x--   [ anon ]
+ total       1074257720K

--- a/lib/wallet-benchmarks/lib/Cardano/Wallet/Benchmark/Memory/Pmap.hs
+++ b/lib/wallet-benchmarks/lib/Cardano/Wallet/Benchmark/Memory/Pmap.hs
@@ -1,0 +1,117 @@
+module Cardano.Wallet.Benchmark.Memory.Pmap
+    ( pmapParser
+    , lineParser
+    , topLineParser
+    , bottomLineParser
+    , pmap
+    , Pmap (..)
+    , Line (..)
+    , Header (..)
+    ) where
+
+import Prelude
+
+import Control.Monad
+    ( void
+    )
+import Data.Attoparsec.ByteString.Char8
+    ( Parser
+    , char
+    , decimal
+    , endOfLine
+    , hexadecimal
+    , inClass
+    , many1
+    , parseOnly
+    , skipSpace
+    , string
+    , takeTill
+    )
+import System.Process
+    ( getPid
+    )
+import UnliftIO
+    ( liftIO
+    )
+import UnliftIO.Process
+    ( ProcessHandle
+    , readProcess
+    )
+
+import qualified Data.Attoparsec.ByteString.Char8 as A
+import qualified Data.ByteString.Char8 as B8
+
+-- | Represents a line of the pmap command
+data Line = Line
+    { address :: Int
+    , memory :: Int
+    , permissions :: String
+    , command :: String
+    }
+    deriving (Show, Eq)
+
+-- | Represents the header of the pmap command
+data Header = Header
+    { pid :: Int
+    , commandCall :: String
+    }
+    deriving (Show, Eq)
+
+-- | Represents the footer of the pmap command
+newtype Footer = Footer
+    { total :: Int
+    }
+    deriving (Show, Eq)
+
+-- | Represents the output of the pmap command
+data Pmap = Pmap
+    { header :: Header
+    , pmapLines :: [Line]
+    , footer :: Footer
+    }
+    deriving (Show, Eq)
+
+pmapParser :: Parser Pmap
+pmapParser = do
+    t <- topLineParser
+    ls <- many1 lineParser
+    Pmap t ls <$> bottomLineParser
+
+topLineParser :: Parser Header
+topLineParser = do
+    pid <- decimal
+    void $ char ':'
+    skipSpace
+    Header pid . B8.unpack <$> lastPart
+
+lineParser :: Parser Line
+lineParser = do
+    addr <- hexadecimal
+    skipSpace
+    mem <- decimal <* char 'K'
+    skipSpace
+    perms <- A.takeWhile (inClass "rwxp-")
+    skipSpace
+    Line addr mem (B8.unpack perms) . B8.unpack <$> lastPart
+
+bottomLineParser :: Parser Footer
+bottomLineParser = do
+    skipSpace
+    void $ string "total"
+    skipSpace
+    tot <- decimal
+    void $ char 'K'
+    void lastPart
+    pure $ Footer tot
+
+lastPart :: Parser B8.ByteString
+lastPart = takeTill (== '\n') <* endOfLine
+
+-- | Get the pmap output for a given process
+pmap :: ProcessHandle -> IO Pmap
+pmap p = do
+    Just pid <- liftIO $ getPid p
+    output <- liftIO $ readProcess "pmap" [show pid] ""
+    case parseOnly pmapParser $ B8.pack output of
+        Right x -> pure x
+        Left _ -> error "Failed to parse pmap output"

--- a/lib/wallet-benchmarks/test/Cardano/Wallet/Benchmark/Memory/PmapSpec.hs
+++ b/lib/wallet-benchmarks/test/Cardano/Wallet/Benchmark/Memory/PmapSpec.hs
@@ -1,0 +1,55 @@
+module Cardano.Wallet.Benchmark.Memory.PmapSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Benchmark.Memory.Pmap
+    ( Line (..)
+    , lineParser
+    , pmapParser
+    )
+import Control.Monad
+    ( replicateM
+    )
+import Data.Attoparsec.ByteString.Char8
+    ( parseOnly
+    )
+import Paths_cardano_wallet_blackbox_benchmarks
+    ( getDataFileName
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+
+import qualified Data.ByteString.Char8 as B8
+
+spec :: Spec
+spec = do
+    describe "pmap parser" $ do
+        it "can parse a line"
+            $ parseOnly
+                lineParser
+                "0000000000400000  50668K r-x-- cardano-wallet\n"
+            `shouldBe` Right (Line 0x400000 50668 "r-x--" "cardano-wallet")
+        it "can parse 2 lines" $ do
+            let input =
+                    "0000000000400000  50668K r-x-- cardano-wallet\n\
+                    \000000f000600000  50669K -wxp- cardano-wallet2\n"
+            parseOnly (replicateM 2 lineParser) input
+                `shouldBe` Right
+                    [ Line 0x400000 50668 "r-x--" "cardano-wallet"
+                    , Line 0xf000600000 50669 "-wxp-" "cardano-wallet2"
+                    ]
+        it "can parse a topline and lines of pmap output" $ do
+            input <-
+                getDataFileName "data/hoogle-pmap.txt"
+                    >>= B8.readFile
+            case parseOnly pmapParser input of
+                Left e -> fail e
+                Right _ -> pure ()
+
+-- 0000000000400000  50668K r-x-- cardano-wallet

--- a/lib/wallet-benchmarks/test/Main.hs
+++ b/lib/wallet-benchmarks/test/Main.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
In this PR we improve the benchmarks reports to have them machine readable. The restoration benchmark is left out from this work as it's not going to appear in the CI-1 (gate-to-master) pipeline anyway as it takes 16 hours. 
The involved benchmarks are

1. api
2. latency
3. memory
4. db

Each of them now creates a csv artifact during its new CI-1 step.

- [x] Add a library to write csv reports of the benchmarks
- [x] Use the lib in all benchmarks to get new csv artifacts in buildkite
- [x] Add justfile runners for all benchmarks (-O0 is just for testing them)
- [x] Add steps in the pipeline for all of them 
- [x] Add a library to parse `pmap` utility output
- [x] Small rework of `ToTextTracer` and use it in place of heavier logging machine

ADP-3368

(this is a retake of https://github.com/cardano-foundation/cardano-wallet/pull/4621 that was closed automatically by github because of an operation on the base branch or smth)