### PR TITLE
Make it easier for the UTxO selection algorithm to split up unrelated assets.

### DIFF
--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -973,7 +973,7 @@ performSelectionNonEmpty constraints params
             -- change outputs is fewer than optimal, because the supply of ada
             -- was insufficient. Try again with more ada to see if it leads to
             -- an improvement:
-            selectMinimalQuantityOfLovelace s >>= \case
+            selectQuantityOfLovelace s >>= \case
                 Just s' ->
                     makeChangeRepeatedly s'
                 Nothing ->
@@ -984,7 +984,7 @@ performSelectionNonEmpty constraints params
         Left changeErr ->
             -- We've failed to make any change outputs, because the supply of
             -- ada was insufficient. Try again with more ada.
-            selectMinimalQuantityOfLovelace s >>= \case
+            selectQuantityOfLovelace s >>= \case
                 Just s' ->
                     makeChangeRepeatedly s'
                 Nothing ->
@@ -1061,7 +1061,7 @@ runSelectionNonEmpty
     => RunSelectionParams u
     -> m (Maybe (UTxOSelectionNonEmpty u))
 runSelectionNonEmpty =
-    runSelectionNonEmptyWith selectMinimalQuantityOfLovelace
+    runSelectionNonEmptyWith selectQuantityOfLovelace
     <=<
     runSelection
 
@@ -1148,12 +1148,12 @@ selectQuantityOf a = selectMatchingQuantity . \case
     SelectionStrategyOptimal ->
         [ SelectAnyWith a ]
 
-selectMinimalQuantityOfLovelace
+selectQuantityOfLovelace
     :: (MonadRandom m, Ord u)
     => IsUTxOSelection utxoSelection u
     => utxoSelection u
     -> m (Maybe (UTxOSelectionNonEmpty u))
-selectMinimalQuantityOfLovelace =
+selectQuantityOfLovelace =
     selectQuantityOf AssetLovelace SelectionStrategyMinimal
 
 -- | Selects a UTxO entry that matches one of the specified filters.

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -1128,7 +1128,7 @@ coinSelectionLens strategy minimumCoinQuantity = SelectionLens
     { currentQuantity = selectedCoinQuantity
     , updatedQuantity = selectedCoinQuantity
     , minimumQuantity = intCast $ unCoin minimumCoinQuantity
-    , selectQuantity  = selectQuantityOf AssetLovelace strategy
+    , selectQuantity  = selectQuantityOfLovelace
     , selectionStrategy = strategy
     }
 

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -1061,8 +1061,7 @@ runSelectionNonEmpty
     => RunSelectionParams u
     -> m (Maybe (UTxOSelectionNonEmpty u))
 runSelectionNonEmpty =
-    runSelectionNonEmptyWith
-        (selectQuantityOf AssetLovelace SelectionStrategyMinimal)
+    runSelectionNonEmptyWith selectMinimalQuantityOfLovelace
     <=<
     runSelection
 

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -1018,7 +1018,7 @@ performSelectionNonEmpty constraints params
             , assetsToBurn
             }
 
-        selectOneEntry = selectQuantityOf AssetLovelace
+        selectOneEntry = selectQuantityOf AssetLovelace SelectionStrategyMinimal
 
         requiredCost = computeMinimumCost SelectionSkeleton
             { skeletonInputCount = UTxOSelection.selectedSize s
@@ -1063,7 +1063,8 @@ runSelectionNonEmpty
     => RunSelectionParams u
     -> m (Maybe (UTxOSelectionNonEmpty u))
 runSelectionNonEmpty =
-    runSelectionNonEmptyWith (selectQuantityOf AssetLovelace)
+    runSelectionNonEmptyWith
+        (selectQuantityOf AssetLovelace SelectionStrategyMinimal)
     <=<
     runSelection
 
@@ -1116,7 +1117,7 @@ assetSelectionLens strategy (asset, minimumAssetQuantity) = SelectionLens
     { currentQuantity = selectedAssetQuantity asset
     , updatedQuantity = selectedAssetQuantity asset
     , minimumQuantity = unTokenQuantity minimumAssetQuantity
-    , selectQuantity = selectQuantityOf (Asset asset)
+    , selectQuantity = selectQuantityOf (Asset asset) strategy
     , selectionStrategy = strategy
     }
 
@@ -1130,7 +1131,7 @@ coinSelectionLens strategy minimumCoinQuantity = SelectionLens
     { currentQuantity = selectedCoinQuantity
     , updatedQuantity = selectedCoinQuantity
     , minimumQuantity = intCast $ unCoin minimumCoinQuantity
-    , selectQuantity  = selectQuantityOf AssetLovelace
+    , selectQuantity  = selectQuantityOf AssetLovelace strategy
     , selectionStrategy = strategy
     }
 
@@ -1138,9 +1139,10 @@ selectQuantityOf
     :: (MonadRandom m, Ord u)
     => IsUTxOSelection utxoSelection u
     => Asset
+    -> SelectionStrategy
     -> utxoSelection u
     -> m (Maybe (UTxOSelectionNonEmpty u))
-selectQuantityOf a = selectMatchingQuantity
+selectQuantityOf a _strategy = selectMatchingQuantity
     [ SelectSingleton a
     , SelectPairWith a
     , SelectAnyWith a

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -1018,9 +1018,6 @@ performSelectionNonEmpty constraints params
             , assetsToBurn
             }
 
-        selectMinimalQuantityOfLovelace =
-            selectQuantityOf AssetLovelace SelectionStrategyMinimal
-
         requiredCost = computeMinimumCost SelectionSkeleton
             { skeletonInputCount = UTxOSelection.selectedSize s
             , skeletonOutputs = NE.toList outputsToCover
@@ -1151,6 +1148,14 @@ selectQuantityOf a = selectMatchingQuantity . \case
         ]
     SelectionStrategyOptimal ->
         [ SelectAnyWith a ]
+
+selectMinimalQuantityOfLovelace
+    :: (MonadRandom m, Ord u)
+    => IsUTxOSelection utxoSelection u
+    => utxoSelection u
+    -> m (Maybe (UTxOSelectionNonEmpty u))
+selectMinimalQuantityOfLovelace =
+    selectQuantityOf AssetLovelace SelectionStrategyMinimal
 
 -- | Selects a UTxO entry that matches one of the specified filters.
 --

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -973,7 +973,7 @@ performSelectionNonEmpty constraints params
             -- change outputs is fewer than optimal, because the supply of ada
             -- was insufficient. Try again with more ada to see if it leads to
             -- an improvement:
-            selectOneEntry s >>= \case
+            selectMinimalQuantityOfLovelace s >>= \case
                 Just s' ->
                     makeChangeRepeatedly s'
                 Nothing ->
@@ -984,7 +984,7 @@ performSelectionNonEmpty constraints params
         Left changeErr ->
             -- We've failed to make any change outputs, because the supply of
             -- ada was insufficient. Try again with more ada.
-            selectOneEntry s >>= \case
+            selectMinimalQuantityOfLovelace s >>= \case
                 Just s' ->
                     makeChangeRepeatedly s'
                 Nothing ->
@@ -1018,7 +1018,8 @@ performSelectionNonEmpty constraints params
             , assetsToBurn
             }
 
-        selectOneEntry = selectQuantityOf AssetLovelace SelectionStrategyMinimal
+        selectMinimalQuantityOfLovelace =
+            selectQuantityOf AssetLovelace SelectionStrategyMinimal
 
         requiredCost = computeMinimumCost SelectionSkeleton
             { skeletonInputCount = UTxOSelection.selectedSize s

--- a/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs
@@ -1142,11 +1142,14 @@ selectQuantityOf
     -> SelectionStrategy
     -> utxoSelection u
     -> m (Maybe (UTxOSelectionNonEmpty u))
-selectQuantityOf a _strategy = selectMatchingQuantity
-    [ SelectSingleton a
-    , SelectPairWith a
-    , SelectAnyWith a
-    ]
+selectQuantityOf a = selectMatchingQuantity . \case
+    SelectionStrategyMinimal ->
+        [ SelectSingleton a
+        , SelectPairWith a
+        , SelectAnyWith a
+        ]
+    SelectionStrategyOptimal ->
+        [ SelectAnyWith a ]
 
 -- | Selects a UTxO entry that matches one of the specified filters.
 --

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -1762,10 +1762,15 @@ prop_assetSelectionLens_givesPriorityToSingletonAssets (Blind (Small u)) =
         SelectionStrategyMinimal (nonAdaAsset, minimumAssetQuantity)
     minimumAssetQuantity = TokenQuantity 1
 
+-- Regardless of which selection strategy is chosen, the coin selection lens
+-- should always give priority to singleton lovelace quantities (quantities
+-- of lovelace that are not bundled with other assets).
+--
 prop_coinSelectionLens_givesPriorityToCoins
     :: Blind (Small (UTxOIndex TestUTxO))
+    -> SelectionStrategy
     -> Property
-prop_coinSelectionLens_givesPriorityToCoins (Blind (Small u)) =
+prop_coinSelectionLens_givesPriorityToCoins (Blind (Small u)) strategy =
     entryCount > 0 ==> monadicIO $ do
         hasCoin <- isJust <$>
             run (UTxOIndex.selectRandom u (SelectSingleton AssetLovelace))
@@ -1790,8 +1795,7 @@ prop_coinSelectionLens_givesPriorityToCoins (Blind (Small u)) =
   where
     entryCount = UTxOIndex.size u
     initialState = UTxOSelection.fromIndex u
-    lens = coinSelectionLens
-        SelectionStrategyOptimal minimumCoinQuantity
+    lens = coinSelectionLens strategy minimumCoinQuantity
     minimumCoinQuantity = Coin 1
 
 --------------------------------------------------------------------------------

--- a/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
+++ b/lib/coin-selection/test/spec/Cardano/CoinSelection/BalanceSpec.hs
@@ -1702,6 +1702,10 @@ prop_runSelectionStep_exceedsOptimalTargetAndGetsFurtherAway
 -- Behaviour of selection lenses
 --------------------------------------------------------------------------------
 
+-- When the minimal selection strategy is chosen, the asset selection lens
+-- should give priority to singleton asset quantities over quantities that
+-- are bundled together with other assets.
+--
 prop_assetSelectionLens_givesPriorityToSingletonAssets
     :: Blind (Small (UTxOIndex TestUTxO))
     -> Property
@@ -1755,7 +1759,7 @@ prop_assetSelectionLens_givesPriorityToSingletonAssets (Blind (Small u)) =
     nonAdaAssetCount = Set.size (utxoIndexNonAdaAssets u)
     initialState = UTxOSelection.fromIndex u
     lens = assetSelectionLens
-        SelectionStrategyOptimal (nonAdaAsset, minimumAssetQuantity)
+        SelectionStrategyMinimal (nonAdaAsset, minimumAssetQuantity)
     minimumAssetQuantity = TokenQuantity 1
 
 prop_coinSelectionLens_givesPriorityToCoins


### PR DESCRIPTION
## Summary

This PR adjusts the UTxO selection algorithm so that when selecting for a given **_non-ada asset_** under the [**optimal selection strategy**](https://github.com/cardano-foundation/cardano-wallet/blob/15ca1dac2d9c40330db9a7cdaf1b7f1e403576ec/lib/coin-selection/lib/Cardano/CoinSelection/Balance.hs#L353), we no longer prioritise the selection of UTxOs with fewer numbers of unique assets.

(In contrast, when selecting for ada, we **_preserve_** the existing behaviour of always prioritising the selection of pure-ada UTxOs over UTxOs with other assets.)

## Motivation

This PR assumes the desirability of the following properties:
- assets that are frequently spent **_together_** should, over time, become bundled **_together_** within the UTxO set.
- assets that are frequently spent **_separately_** should, over time, become located **_separately_** within the UTxO set.

One intuitive reason for this is that if a user commonly attempts to create transactions that spend some asset `a`, then we would like to reduce the (amortised) probability that the user is also forced to spend assets that are unrelated to the transaction, assets that can only be returned as change (which increases the amortised size and cost of transactions).

Furthermore, for a given pair of assets `a` and `b`, if the user shifts their spending pattern from one where `a` and `b` are typically spent **_together_** to a pattern where `a` and `b` are typically spent **_separately_**, then we ideally want the UTxO selection algorithm, when repeatedly applied over time, to cause the UTxO set to evolve **_away_** from a distribution where `a` and `b` are typically bundled together **_toward_** a distribution where `a` and `b` are usually separate.

By removing the bias toward selecting smaller UTxOs over larger UTxOs, we make the following evolutionary changes **_equally easy_**:
- **_Evolution type 1: separation of assets_**
  Evolving from a distribution where assets `a`  and `b` are typically bundled together to a distribution where `a` and `b` are usually separate.
- **_Evolution type 2: colocation of assets_**
  Evolving from a distribution where assets `a`  and `b` are usually separate to a distribution where `a` and `b` are typically bundled together.

Without this PR, the former type of evolution is more difficult than the latter, for no good reason.

## Context

When the multi-asset UTxO selection algorithm was first written, there was no explicit choice of selection strategy. In order to maximise the chance that a given selection would not exceed transaction size and cost limits, the algorithm used the following fixed strategy when selecting for a given asset `a`:
1. First, attempt to find a UTxO that contain `a` and **_no_** other assets.
2. Then attempt to find a UTxO that contains `a` and **_just one_** another asset.
3. Finally, attempt to find a UTxO that contains `a` and **_any number_** of additional assets.

However, since then:
1. the UTxO selection algorithm was upgraded to accept a `SelectionStrategy` parameter, with two possibilities:
    - `SelectionStrategyOptimal`: attempt to select around twice the minimum possible amount of each asset from the UTxO set, making it possible to generate change outputs that are  roughly the same sizes and shapes as the user-specified outputs.
    - `SelectionStrategyMinimal`: attempt to only select just enough of each asset from the available UTxO set to meet the minimum amount, terminating selection as soon as the minimum amount of each asset has been covered.  
2. the `balanceTx` function was upgraded to use `SelectionStrategyOptimal` by default, and then fall back to `SelectionStrategyMinimal` in the event that the optimal strategy fails.

Given that we always have the safe option of falling back to the minimal strategy, it's no longer necessary to artificially constrain the optimal strategy so that it prioritises the selection of UTxOs with fewer assets.