### PR TITLE
[ADP-3368] Add admin.yml pipeline with a step to update a preprod snapshot

### DIFF
--- a/.buildkite/admin.yml
+++ b/.buildkite/admin.yml
@@ -1,0 +1,21 @@
+agents:
+  queue: "cardano-wallet"
+
+env:
+  LC_ALL: "C.UTF-8"
+  NIX_PATH: "channel:nixos-21.11"
+  STATE_DIR: "/var/lib/buildkite-agent/cache"
+
+
+
+steps:
+  - block: "Refresh preprod node state"
+    key: refresh-preprod-node-state-block
+  - label: 'Refresh preprod node state'
+    depends_on: refresh-preprod-node-state-block
+    command:
+      - ./scripts/buildkite/release/fetch-preprod-snapshot.sh
+    env:
+      NODE_STATE_DIR: "${STATE_DIR?}/node/preprod"
+    agents:
+      system: x86_64-linux

--- a/scripts/buildkite/release/fetch-preprod-snapshot.sh
+++ b/scripts/buildkite/release/fetch-preprod-snapshot.sh
@@ -1,0 +1,43 @@
+#! /usr/bin/env -S nix shell 'nixpkgs#curl' 'nixpkgs#lz4' --command bash
+# shellcheck shell=bash
+
+set -euox pipefail
+
+mkdir -p "$NODE_STATE_DIR"
+
+cd "$NODE_STATE_DIR"
+
+curl -s https://downloads.csnapshots.io/testnet/testnet-db-snapshot.json \
+    | jq -r .[].file_name > filename_new
+
+
+if [ -f filename ]; then
+    if [ "$(cat filename)" == "$(cat filename_new)" ]; then
+        echo "Preprod snapshot is up to date with the latest snapshot available."
+        exit 0
+    fi
+fi
+
+dir_new="$(sed -e 's/\.tar\.lz4//' filename_new)"
+
+rm -rf "$dir_new" && mkdir -p "$dir_new"
+
+cd "$dir_new"
+
+curl -o snapshot.tar.lz4 \
+    "https://downloads.csnapshots.io/testnet/$(cat ../filename_new)"
+lz4 -c -d snapshot.tar.lz4 > snapshot.tar
+tar -x -f snapshot.tar
+
+cd ..
+
+if [ -f filename ]; then
+    dir_old="$(sed -e 's/\.tar\.lz4//' filename)"
+    rm -rf "$dir_old"
+fi
+
+# Set the `db` directory to a symlink in a way that is supposed to be atomic.
+#     See also: https://unix.stackexchange.com/a/6786
+ln -s "$dir_new"/db db-new && mv -T db-new db
+
+mv filename_new filename


### PR DESCRIPTION
This PR is feeding a new pipeline with 1 command. The new pipeline is active at https://buildkite.com/cardano-foundation/cardano-wallet-buildkite-admin

- [x] Add a new pipeline to manage/control buildkite agent state
- [x] Add a blocked command that refresh the common preprod node state via `csnapshot` service

