### PR TITLE
Demonstrate that JSON roundtrip property is not always satisfied for `TxMetadataWithSchema`.

### DIFF
--- a/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -889,6 +889,21 @@ spec = do
         jsonTest @(ApiT DRep)
         jsonTest @ApiRestorationMode
 
+    it "Broken round trip for TxMetadataWithSchema" $ do
+
+        let testValue =
+                TxMetadataWithSchema TxMetadataNoSchema $
+                Cardano.TxMetadata $
+                Map.fromList
+                [ ( 1
+                  , Cardano.TxMetaMap
+                    [ (Cardano.TxMetaText "k", Cardano.TxMetaText "v1")
+                    , (Cardano.TxMetaText "k", Cardano.TxMetaText "v2")
+                    ]
+                  )
+                ]
+        Aeson.decode (Aeson.encode testValue) `shouldBe` Just testValue
+
     it "Round trip between types `ApiEra` and `AnyCardanoEra`"
         $ property
         $ \era -> ApiEra.fromAnyCardanoEra (ApiEra.toAnyCardanoEra era) === era


### PR DESCRIPTION
## Related Issue

- #4647 

## Description

This PR demonstrates that the JSON roundtrip property does not always hold for values of the `TxMetadataWithSchema` type, and provides a single counterexample:

```hs
TxMetadataWithSchema TxMetadataNoSchema $
Cardano.TxMetadata $
Map.fromList
  [ ( 1
    , Cardano.TxMetaMap
      [ (Cardano.TxMetaText "k", Cardano.TxMetaText "v1")
      , (Cardano.TxMetaText "k", Cardano.TxMetaText "v2")
      ]
    )
  ]
```

With the following command:
```
cabal test cardano-wallet-unit --test-options '--match "Broken round trip for TxMetadataWithSchema"'
```

We see the following failure ([link to failure on Buildkite](https://buildkite.com/cardano-foundation/cardano-wallet/builds/5531#019053f2-4134-48f8-8f5c-81b0baff8700/6-5069)):
```hs
Cardano.Wallet.Api.Types
  Broken round trip for TxMetadataWithSchema [x]

Failures:

  test/unit/Cardano/Wallet/Api/TypesSpec.hs:905:47:
  1) Cardano.Wallet.Api.Types Broken round trip for TxMetadataWithSchema
       expected: Just (TxMetadataWithSchema {txMetadataWithSchema_schema = TxMetadataNoSchema, txMetadataWithSchema_metadata = TxMetadata (fromList [(1,TxMetaMap [(TxMetaText "k",TxMetaText "v1"),(TxMetaText "k",TxMetaText "v2")])])})
        but got: Just (TxMetadataWithSchema {txMetadataWithSchema_schema = TxMetadataNoSchema, txMetadataWithSchema_metadata = TxMetadata (fromList [(1,TxMetaMap [(TxMetaText "k",TxMetaText "v2")])])})

  To rerun use: --match "/Cardano.Wallet.Api.Types/Broken round trip for TxMetadataWithSchema/" --seed 321733787

Randomized with seed 321733787
```