### PR TITLE
[ADP-3368] Add basic release pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,14 +11,6 @@ env:
 
 
 steps:
-  - label: 'Merge from staging only'
-    if: 'build.branch == "staging"'
-    command: './.buildkite/check-bors.sh'
-    agents:
-      system: ${linux}
-
-  - wait: ~
-    if: 'build.branch == "staging"'
 
   - label: 'Check nix (linux)'
     # Check whether regenerate.sh was applied when it had to be applied.

--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -1,0 +1,15 @@
+agents:
+  queue: "cardano-wallet"
+
+env:
+  LC_ALL: "C.UTF-8"
+  NIX_PATH: "channel:nixos-21.11"
+  TMPDIR: "/cache"
+
+steps:
+  - label: 'Hello'
+    key: build-docker
+    command: |
+      nix shell .#cardano-wallet -c cardano-wallet version
+    agents:
+      system: x86_64-linux

--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -4,12 +4,11 @@ agents:
 env:
   LC_ALL: "C.UTF-8"
   NIX_PATH: "channel:nixos-21.11"
-  TMPDIR: "/cache"
 
 steps:
-  - label: 'Hello'
-    key: build-docker
-    command: |
-      nix shell .#cardano-wallet -c cardano-wallet version
+  - label: Add release commits
+    key: add-release-commits
+    commands: |
+      ./scripts/buildkite/release/release-candidate.sh
     agents:
       system: x86_64-linux

--- a/scripts/buildkite/release/release-candidate.sh
+++ b/scripts/buildkite/release/release-candidate.sh
@@ -1,0 +1,63 @@
+#! /usr/bin/env -S nix shell '.#cardano-node' 'nixpkgs#gnused' --command bash
+# shellcheck shell=bash
+
+set -euox pipefail
+
+# date from git tag
+# example v2023-04-04 -> 2023-04-04
+tag_date() {
+  echo "${1##v}"
+}
+# cabal version from git tag
+# example v2023-04-04 -> 2023.4.4
+tag_cabal_ver() {
+  tag_date "$1" | sed -e s/-0/-/g -e s/-/./g
+}
+
+git fetch --all
+
+BASE_COMMIT=$(git rev-parse HEAD)
+
+git checkout "$BASE_COMMIT"
+
+today=$(date +%Y-%m-%d)
+
+NEW_GIT_TAG=v$today
+
+NEW_CABAL_VERSION=$(tag_cabal_ver "$NEW_GIT_TAG")
+
+OLD_GIT_TAG=$( git tag -l "v2*-*-*" | sort | tail -n1)
+
+OLD_CABAL_VERSION=$(tag_cabal_ver "$OLD_GIT_TAG")
+
+CARDANO_NODE_TAG=$(cardano-node version | head -n1 | awk '{print $2}')
+
+RELEASE_CANDIDATE_BRANCH="release-candidate-new/$NEW_GIT_TAG"
+
+git config --global user.email "gha@cardanofoundation.org"
+git config --global user.name "Github Action"
+
+git branch -D "$RELEASE_CANDIDATE_BRANCH" || true
+git checkout -b "$RELEASE_CANDIDATE_BRANCH" || true
+
+sed -i "s|version: .*|version: $NEW_GIT_TAG|g" specifications/api/swagger.yaml
+git commit -m "Update wallet version in swagger.yaml" specifications/api/swagger.yaml
+
+git ls-files  '*.cabal' | xargs sed -i "s|$OLD_CABAL_VERSION|$NEW_CABAL_VERSION|g"
+git commit -am "Update cardano-wallet version in *.cabal files"
+
+sed -i "s|NODE_TAG=.*|NODE_TAG=$CARDANO_NODE_TAG|g" README.md
+sed -i "s|WALLET_TAG=.*|WALLET_TAG=$NEW_CABAL_VERSION|g" README.md
+sed -i "s|WALLET_VERSION=.*|WALLET_VERSION=$NEW_GIT_TAG|g" README.md
+git commit -am "Update cardano-wallet version in README.md"
+
+RELEASE_COMMIT=$(git rev-parse HEAD)
+
+git remote set-url origin "git@github.com:cardano-foundation/cardano-wallet.git"
+git remote get-url origin
+
+git push -f origin "$RELEASE_CANDIDATE_BRANCH"
+
+buildkite-agent meta-data set "release-version" "$NEW_GIT_TAG"
+buildkite-agent meta-data set "release-commit" "$RELEASE_COMMIT"
+buildkite-agent meta-data set "release-candidate-branch" "$RELEASE_CANDIDATE_BRANCH"


### PR DESCRIPTION
This PR provide basic instructions for the new [release pipeline](https://buildkite.com/cardano-foundation/cardano-wallet-release) so that it will produce a release candidate  branch with the administrative commits bumping the versions. More steps will run based on the effect of this step. (They will run tests and build artifacts over the last commit created by this step)

Until we do not decommission the old mechanism we are using the template `release-candidate-new/YYYY-MM-DD` . 
Once the old one will be decommissioned we will drop the `new` from the name.

- [x] Add instructions for the release pipeline `release.yml`  
- [x] Add a step to it to create a new branch for the current day and push 3 administrative commits that bumps the version numbers

This PR also remove unused code from the main pipeline  