### PR TITLE
[ADP-3368] Add linux packaging step to release pipeline

### DIFF
--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -12,3 +12,13 @@ steps:
       ./scripts/buildkite/release/release-candidate.sh
     agents:
       system: x86_64-linux
+
+  - label: 'Build package (linux)'
+    key: linux-package
+    depends_on: add-release-commits
+    command:
+      - ./scripts/buildkite/release/linux-package.sh
+    artifact_paths: [ "./result/linux/**" ]
+    agents:
+      system: ${linux}
+

--- a/scripts/buildkite/release/linux-package.sh
+++ b/scripts/buildkite/release/linux-package.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/env -S nix shell --command bash
+# shellcheck shell=bash
+
+RELEASE_CANDIDATE_BRANCH=$(buildkite-agent meta-data get "release-candidate-branch")
+
+git checkout "$RELEASE_CANDIDATE_BRANCH"
+
+nix build -o result/linux .#ci.artifacts.linux64.release


### PR DESCRIPTION
This PR makes sure a linux package will be ready for the E2E testing phase package
https://buildkite.com/cardano-foundation/cardano-wallet-release/builds/115

- [x] Copy script and step from the main pipeline to package up the linux version of the wallet