### PR TITLE
[ADP-3368] Add node refresh on macOS platform to `admin.yml`

### DIFF
--- a/.buildkite/admin.yml
+++ b/.buildkite/admin.yml
@@ -5,6 +5,7 @@ env:
   LC_ALL: "C.UTF-8"
   NIX_PATH: "channel:nixos-21.11"
   STATE_DIR: "/var/lib/buildkite-agent/cache"
+  STATE_DIR_MACOS: "/var/lib/buildkite-agent-hal-mac/cache"
 
 steps:
 
@@ -19,3 +20,16 @@ steps:
       NODE_STATE_DIR: "${STATE_DIR?}/node/preprod"
     agents:
       system: x86_64-linux
+
+  - block: "Refresh preprod node state (macOS)"
+    depends_on: []
+    key: refresh-preprod-node-state-macos-block
+
+  - label: 'Refresh preprod node state (macOS)'
+    depends_on: refresh-preprod-node-state-macos-block
+    command: |
+        cd ./scripts/buildkite/admin/ && nix develop -c ./refresh-preprod-snapshot.sh
+    env:
+      NODE_STATE_DIR: "${STATE_DIR_MACOS?}/node/preprod"
+    agents:
+      system: aarch64-darwin

--- a/.buildkite/admin.yml
+++ b/.buildkite/admin.yml
@@ -6,15 +6,15 @@ env:
   NIX_PATH: "channel:nixos-21.11"
   STATE_DIR: "/var/lib/buildkite-agent/cache"
 
-
-
 steps:
-  - block: "Refresh preprod node state"
-    key: refresh-preprod-node-state-block
-  - label: 'Refresh preprod node state'
-    depends_on: refresh-preprod-node-state-block
-    command:
-      - ./scripts/buildkite/release/fetch-preprod-snapshot.sh
+
+  - block: "Refresh preprod node state (linux)"
+    key: refresh-preprod-node-state-linux-block
+
+  - label: 'Refresh preprod node state (linux)'
+    depends_on: refresh-preprod-node-state-linux-block
+    command: |
+        cd ./scripts/buildkite/admin/ && nix develop -c ./refresh-preprod-snapshot.sh
     env:
       NODE_STATE_DIR: "${STATE_DIR?}/node/preprod"
     agents:

--- a/scripts/buildkite/admin/flake.lock
+++ b/scripts/buildkite/admin/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681378341,
+        "narHash": "sha256-2qUN04W6X9cHHytEsJTM41CmusifPTC0bgTtYsHSNY8=",
+        "owner": "hamishmack",
+        "repo": "flake-utils",
+        "rev": "2767bafdb189cd623354620c2dacbeca8fd58b17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hamishmack",
+        "ref": "hkm/nested-hydraJobs",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1719418842,
+        "narHash": "sha256-kIixn/287o4bs0e35Bed3uUjQ0zrrvLfdiGxr6DhghY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a34b46771ff90d279762b0ab5abdae8ff46a5d67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/scripts/buildkite/admin/flake.nix
+++ b/scripts/buildkite/admin/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = ''
+    Shell for the admin.yml Buildkite pipeline
+  '';
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
+  };
+
+  outputs = inputs:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+       ]; in
+    inputs.flake-utils.lib.eachSystem supportedSystems (system:
+      let
+        # Imports
+        pkgs = inputs.nixpkgs.legacyPackages.${system};
+      in {
+        packages = { };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.curl
+            pkgs.jq
+            pkgs.lz4
+          ];
+          shellHook = ''
+            # use this hook to set up additional environment variables
+          '';
+        };
+      }
+    );
+}

--- a/scripts/buildkite/admin/refresh-preprod-snapshot.sh
+++ b/scripts/buildkite/admin/refresh-preprod-snapshot.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env -S nix shell 'nixpkgs#curl' 'nixpkgs#lz4' --command bash
+#! /usr/bin/env bash
 # shellcheck shell=bash
 
 set -euox pipefail


### PR DESCRIPTION
This pull requests does two things:

* It groups the scripts related to the `admin.yml` pipeline and adds a `flake.nix` file that provisions the require exectuables.
* It adds a blocked command that refreshes the common preprod node state via `csnapshot` service on the macOS builder machine.

### Issue number

ADP-3368