### PR TITLE
Demonstrate that the HTTP API returns "Internal Server Error" when attempting to encrypt multiple transaction metadata messages.

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3195,14 +3195,13 @@ toMetadataEncrypted apiEncrypt payload saltM =
     secretKey, iv :: ByteString
     (secretKey, iv) = PBKDF2.generateKey metadataPBKDF2Config pwd saltM
 
-    -- `msg` is not embedded beyond the first level
-    parseMessage :: TxMetadataValue -> Maybe TxMetadataValue
+    -- `msg` is embedded at the first level
+    parseMessage :: TxMetadataValue -> Maybe [TxMetadataValue]
     parseMessage = \case
         TxMetaMap kvs ->
             case mapMaybe getValue kvs of
                 [ ] -> Nothing
-                [v] -> Just v
-                _vs -> error "only one 'msg' field expected"
+                vs -> Just vs
         _ ->
             Nothing
       where

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -3225,7 +3225,8 @@ toMetadataEncrypted apiEncrypt payload saltM =
     encryptMessage :: TxMetadataValue -> Either ErrConstructTx TxMetadataValue
     encryptMessage = \case
         TxMetaMap pairs ->
-            TxMetaMap . concat <$> mapM encryptPairIfQualifies pairs
+            TxMetaMap . reverse . L.nub . reverse . concat <$>
+            mapM encryptPairIfQualifies pairs
         _ ->
             error "encryptMessage should have TxMetaMap value"
       where

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -600,7 +600,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             checkMetadataEncryption ctx toBeEncrypted metadataRaw
 
     it "TRANS_NEW_CREATE_02d - \
-        \Attempt to encrypt multiple metadata messages" $
+        \Encrypt multiple metadata messages" $
         \ctx -> runResourceT $ do
             wa <- fixtureWallet ctx
             let toBeEncrypted1 =

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -599,6 +599,36 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                     ]
             checkMetadataEncryption ctx toBeEncrypted metadataRaw
 
+    it "TRANS_NEW_CREATE_02d - \
+        \Attempt to encrypt multiple metadata messages" $
+        \ctx -> runResourceT $ do
+            wa <- fixtureWallet ctx
+            let toBeEncrypted1 =
+                    TxMetaList [TxMetaText "Extremely secret message #1."]
+            let toBeEncrypted2 =
+                    TxMetaList [TxMetaText "Extremely secret message #2."]
+            let metadataToBeEncrypted =
+                    TxMetadataWithSchema TxMetadataDetailedSchema $
+                    TxMetadata $
+                    Map.fromList
+                        [ (674, TxMetaMap
+                            [ (TxMetaText "msg", toBeEncrypted1)
+                            , (TxMetaText "msg", toBeEncrypted2)
+                            ]
+                          )
+                        ]
+            let pwdApiT = ApiT $ Passphrase "metadata-secret"
+            let encryptMetadata = ApiEncryptMetadata pwdApiT Nothing
+            let payload = Json [json|{
+                    "encrypt_metadata": #{toJSON encryptMetadata},
+                    "metadata": #{toJSON metadataToBeEncrypted}
+                }|]
+            rTx <- request @(ApiConstructTransaction n) ctx
+                (Link.createUnsignedTransaction @'Shelley wa) Default payload
+            verify rTx
+                [ expectResponseCode HTTP.status202
+                ]
+
     it "TRANS_NEW_CREATE_03a - Withdrawal from self, 0 rewards" $ \ctx -> runResourceT $ do
         wa <- fixtureWallet ctx
         let initialBalance = wa ^. #balance . #available . #toNatural


### PR DESCRIPTION
## Related issue

- https://github.com/cardano-foundation/cardano-wallet/issues/4652

## Description

This PR demonstrates that if:
- the user calls the `constructTransaction` HTTP API endpoint
- the `metadata` field is populated with metadata to be encrypted according to [CIP-83](https://cips.cardano.org/cip/CIP-83)

And if:
- the included metadata map includes **_more than one_** message with a `msg` key
- the **_detailed_** JSON schema option `TxMetadataDetailedSchema` is used.

Then the HTTP API will return "Internal Server Error".

## How to reproduce the failure

With a fresh checkout of the branch in this PR, run:

```sh
$ nix develop
$ just conway-integration-tests-match "encrypt multiple metadata messages"
```

## Example failure links

- https://buildkite.com/cardano-foundation/cardano-wallet/builds/5570#01905814-2e6e-460b-83aa-7cfed4ede245/139-753
- https://buildkite.com/cardano-foundation/cardano-wallet/builds/5570#01905814-2e70-4cc3-b3f8-8f8f3d9eb0f8/139-758

## Example failure log extract
```hs
only one 'msg' field expected
CallStack (from HasCallStack):
  error, called at src/Cardano/Wallet/Api/Http/Shelley/Server.hs:3207:24 in cardano-wallet-api-2024.5.5-AKdt1G4fjDDEhVlTTGjQVf:Cardano.Wallet.Api.Http.Shelley.Server
From the following response: Left
    ( DecodeFailure "Something went wrong" "Unexpected "Something went wrong", expecting JSON value" )
While verifying value:
  ( Status
      { statusCode = 500
      , statusMessage = "Internal Server Error"
      }
  , Left
      ( DecodeFailure "Something went wrong" "Unexpected "Something went wrong", expecting JSON value" )
  )
expected: Status {statusCode = 202, statusMessage = "Accepted"}
 but got: Status {statusCode = 500, statusMessage = "Internal Server Error"}
```