### PR TITLE
[ADP-3368] Add nix flake to E2E tests

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -110,17 +110,7 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: haskell-nix.cabalProject' [
         filter = haskell-nix.haskellSourceFilter;
       };
 
-      shell =
-        let
-          # To update gemset.nix, run:
-          #   nix-shell --arg bins false --run bundix
-          gems = pkgs.bundlerEnv {
-            name = "gems-cardano-wallet-e2e";
-            gemdir = ../test/e2e;
-            ruby = pkgs.ruby_3_1;
-          };
-        in
-      {
+      shell = {
         name = "cardano-wallet-shell${lib.optionalString config.profiling "-profiled"}";
         packages = ps: builtins.attrValues (haskellLib.selectProjectPackages ps);
         tools = {
@@ -140,11 +130,6 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: haskell-nix.cabalProject' [
           nodePkgs.cardano-node
           cardano-addresses-cli.components.exes.cardano-address
           bech32.components.exes.bech32
-          # for e2e tests
-          gems
-          gems.wrappedRuby
-          pkgs.bundix
-          pkgs.screen
         ]) ++ (with pkgs.buildPackages.buildPackages; [
           just
           pkg-config

--- a/test/e2e/flake.lock
+++ b/test/e2e/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681378341,
+        "narHash": "sha256-2qUN04W6X9cHHytEsJTM41CmusifPTC0bgTtYsHSNY8=",
+        "owner": "hamishmack",
+        "repo": "flake-utils",
+        "rev": "2767bafdb189cd623354620c2dacbeca8fd58b17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hamishmack",
+        "ref": "hkm/nested-hydraJobs",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1719486507,
+        "narHash": "sha256-5rD75idBP4BrhcLMtkosrpLnOS5i1ebzN5az2JtmgMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "febf0c45943643f076d39bce6cd6f90ce20b2eaa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/test/e2e/flake.nix
+++ b/test/e2e/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = ''
+    Shell for the Ruby E2E tests.
+    This shell does *not* include `cardano-wallet` and `cardano-node`,
+    only the Ruby environment.
+  '';
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
+  };
+
+  outputs = inputs:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        # The `blake2b` Ruby gem does not compile on aarch64-*
+        # "aarch64-linux"
+        # "aarch64-darwin"
+       ]; in
+    inputs.flake-utils.lib.eachSystem supportedSystems (system:
+      let
+        # Imports
+        pkgs = inputs.nixpkgs.legacyPackages.${system};
+
+        # To update gemset.nix, run:
+        #   nix develop -c bundix
+        gems = pkgs.bundlerEnv {
+          name = "gems-cardano-wallet-e2e";
+          gemdir = ./.;
+          ruby = pkgs.ruby_3_1;
+        };
+      in {
+        packages = { };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.curl
+            pkgs.jq
+            gems
+            gems.wrappedRuby
+            pkgs.bundix
+            pkgs.screen
+          ];
+          shellHook = ''
+            # use this hook to set up additional environment variables
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
This pull request adds a `flake.nix` file to the E2E tests. This nix flake only provisions the Ruby environment, but neither `cardano-wallet` nor `cardano-node`, as these executables are the ones that are subject to testing.

### Issue Number

ADP-3368