### PR TITLE
[ADP-3368] Add linux E2E step to release pipeline

### DIFF
--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -4,6 +4,7 @@ agents:
 env:
   LC_ALL: "C.UTF-8"
   NIX_PATH: "channel:nixos-21.11"
+  STATE_DIR: "/var/lib/buildkite-agent/cache"
 
 steps:
   - label: Add release commits
@@ -22,3 +23,16 @@ steps:
     agents:
       system: ${linux}
 
+  - label: 'Run linux e2e tests'
+    depends_on:
+      - add-release-commits
+      - linux-package
+    commands: |
+      ./scripts/buildkite/release/linux-e2e.sh
+    artifact_paths:
+      - "./result/linux/**"
+      - "./logs/**/*"
+    env:
+      NODE_STATE_DIR: "${STATE_DIR?}/node/preprod"
+    agents:
+      system: x86_64-linux

--- a/scripts/buildkite/release/linux-e2e.sh
+++ b/scripts/buildkite/release/linux-e2e.sh
@@ -1,0 +1,50 @@
+#! /usr/bin/env -S nix shell 'nixpkgs#rsync' 'nixpkgs#gnutar' 'nixpkgs#gnupg' --command bash
+# shellcheck shell=bash
+
+set -euox pipefail
+
+mkdir -p "$(pwd)/logs"
+
+TESTS_LOGDIR="$(pwd)/logs"
+export TESTS_LOGDIR
+
+CARDANO_NODE_CONFIGS="$(pwd)/configs/cardano"
+export CARDANO_NODE_CONFIGS
+
+VERSION=$(buildkite-agent meta-data get "release-version")
+echo "VERSION=$VERSION"
+
+buildkite-agent artifact \
+    download "result/linux/cardano-wallet-$VERSION-linux64.tar.gz" "."
+
+tar xvzf "result/linux/cardano-wallet-$VERSION-linux64.tar.gz"
+
+TESTS_E2E_BINDIR="$(pwd)/cardano-wallet-$VERSION-linux64"
+export TESTS_E2E_BINDIR
+
+cd test/e2e
+
+TESTS_NODE_DB="$(pwd)/state/node_db"
+export TESTS_NODE_DB
+
+mkdir -p "$TESTS_NODE_DB"/preprod
+rsync -a --delete "$NODE_STATE_DIR/db/" "$TESTS_NODE_DB/preprod"
+
+tmpfile=$(mktemp /tmp/node-preprod.XXXXXX)
+
+CARDANO_NODE_SOCKET_PATH="$tmpfile"
+export CARDANO_NODE_SOCKET_PATH
+
+TESTS_E2E_STATEDIR=$(pwd)/state
+export TESTS_E2E_STATEDIR
+
+TESTS_E2E_TOKEN_METADATA=https://metadata.world.dev.cardano.org/
+export TESTS_E2E_TOKEN_METADATA
+
+TESTS_E2E_FIXTURES="$FIXTURE_DECRYPTION_KEY"
+
+export TESTS_E2E_FIXTURES
+
+nix develop -c rake "run_on[preprod,sync,true]" # SPEC_OPTS="-e '<match>'"
+
+rm "$tmpfile"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -21,7 +21,7 @@ export TESTS_E2E_FIXTURES=*******
 rake secrets_decode
 ```
 > :information_source:  **_TESTS_E2E_FIXTURES_** secret  is defined on https://github.com/cardano-foundation/cardano-wallet/settings/secrets and also used by GH actions. Note that this step is also executed on very first test run.
-> :information_source:  **_TESTS_E2E_FIXTURES_** is also kept in the team's Vaultwarden.
+> :information_source:  **_TESTS_E2E_FIXTURES_** is also kept in the team's 1Password.
 
 #### Fixture wallets
 The command `rake secrets_decode` can be used to decode the file [fixture_wallets.json.gpg](https://github.com/cardano-foundation/cardano-wallet/blob/master/test/e2e/fixtures/fixture_wallets.json.gpg) into a plain JSON file named `fixture_wallets.json`. This file contains mnemonic sentences of the wallets that are utilized in tests. The test framework will retrieve these wallets from the file. It is important to note that there are separate sets of wallets for different operating systems, namely Linux, MacOS, and Windows. This allows tests to be run in parallel on different operating systems.

--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -16,6 +16,7 @@ CONFIGS = absolute_path ENV.fetch('CARDANO_NODE_CONFIGS', nil)
 LOGS = absolute_path ENV.fetch('TESTS_LOGDIR', nil)
 NODE_DB = absolute_path ENV.fetch('TESTS_NODE_DB', nil)
 WALLET_DB = absolute_path ENV.fetch('TESTS_WALLET_DB', nil)
+NODE_SOCKET_PATH = ENV.fetch('CARDANO_NODE_SOCKET_PATH', nil)
 
 BINS = absolute_path ENV.fetch('TESTS_E2E_BINDIR', nil)
 
@@ -116,7 +117,7 @@ task :wait_until_node_synced do
 
   network = CardanoWallet.new.misc.network
   # allow 180 mins for connecting to the node in case it needs to replay ledger
-  timeout = 10_800
+  timeout = 300
   current_time = Time.now
   timeout_treshold = current_time + timeout
   log "Timeout: #{timeout}s"
@@ -149,9 +150,13 @@ task :start_node_and_wallet, [:env] do |_task, args|
 
   bin_dir = BINS == '' ? BINS : "#{BINS}/"
   config_dir = File.join(CONFIGS, args[:env])
+  log ">> Using config directory '#{config_dir}'"
   log_dir = File.join(LOGS, args[:env])
+  log ">> Using log directory '#{log_dir}'"
   wallet_db_dir = File.join(WALLET_DB, args[:env])
+  log ">> Using wallet_db directory '#{wallet_db_dir}'"
   node_db_dir = File.join(NODE_DB, args[:env])
+  log ">> Using node_db directory '#{node_db_dir}'"
   cd = Dir.pwd
   mk_dir(STATE)
   mk_dir(log_dir)
@@ -189,15 +194,17 @@ task :start_node_and_wallet, [:env] do |_task, args|
         --config #{config_dir}/config.json \
         --topology #{config_dir}/topology.json \
         --database-path #{node_db_dir} \
-        --socket-path #{node_db_dir}/node.socket
+        --socket-path #{NODE_SOCKET_PATH}
     CMD
+    log ">> Starting cardano-node with command: #{start_node}"
     start_wallet = <<~CMD
       #{bin_dir}cardano-wallet serve #{network} \
         --port #{WALLET_PORT} \
-        --node-socket #{node_db_dir}/node.socket \
+        --node-socket #{NODE_SOCKET_PATH} \
         --database #{wallet_db_dir} \
         --token-metadata-server #{TOKEN_METADATA}
     CMD
+    log ">> Starting cardano-wallet with command: #{start_wallet}"
     cmd <<~CMD
       screen -dmS NODE_#{args[:env]} -L \
         -Logfile #{log_dir}/node.log \
@@ -396,6 +403,8 @@ task :run_on, [:env, :sync_strategy, :skip_bins, :skip_configs, :branch] do |_ta
 
   Rake::Task[:setup].invoke(env, branch, args[:skip_bins], args[:skip_configs])
   Rake::Task[:display_versions].invoke
+
+  Rake::Task[:stop_node_and_wallet].invoke(env)
   Rake::Task[:start_node_and_wallet].invoke(env)
 
   if sync_strategy == 'no-sync'

--- a/test/e2e/helpers/cardano_cli.rb
+++ b/test/e2e/helpers/cardano_cli.rb
@@ -13,7 +13,7 @@ class CardanoCli
     if win?
       @socket_path = '\\\\.\\pipe\\cardano-node-testnet'
     else
-      @socket_path = File.join(@node_state, 'node.socket')
+      @socket_path = ENV.fetch('CARDANO_NODE_SOCKET_PATH')
       # Add additional permissions to node.socket if we're in e2e docker test suite,
       # so cardano-cli can work with cardano-node from the docker container
       cmd(%(sudo chmod a+rwx #{@socket_path})) if ENV['E2E_DOCKER_RUN'] == '1'

--- a/test/e2e/run_all_tests.sh
+++ b/test/e2e/run_all_tests.sh
@@ -3,4 +3,6 @@
 TESTS_E2E_STATEDIR=./state \
 TESTS_E2E_BINDIR=./bins \
 TESTS_E2E_TOKEN_METADATA=https://metadata.world.dev.cardano.org/ \
-rake run_on[testnet]
+CARDANO_NODE_SOCKET_PATH=./state/node.socket \
+rake stop_node_and_wallet
+rake run_on[preprod,sync,skip]


### PR DESCRIPTION
This PR enables linux E2E tests in the release pipeline, https://buildkite.com/cardano-foundation/cardano-wallet-release/builds/150

- [x] Add node socket arguments to work around socket name length limitation
- [x] Add a shell script that captures the GHA steps of the linux E2E
- [x] Add a bit of logs to the Rakefile
- [x] Add a step to the release pipeline 
