### PR TITLE
[ADP-3368] Add macOS E2E step to release pipeline

### DIFF
--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -5,6 +5,7 @@ env:
   LC_ALL: "C.UTF-8"
   NIX_PATH: "channel:nixos-21.11"
   STATE_DIR: "/var/lib/buildkite-agent/cache"
+  STATE_DIR_MACOS: "/var/lib/buildkite-agent-hal-mac/cache"
 
   linux: "x86_64-linux"
   macos: "aarch64-darwin"
@@ -27,6 +28,7 @@ steps:
       system: ${linux}
 
   - label: 'Run linux e2e tests'
+    key: linux-e2e
     depends_on:
       - add-release-commits
       - linux-package
@@ -59,5 +61,19 @@ steps:
       - ./scripts/buildkite/release/macos-silicon-package.sh
     artifact_paths:
       - "./result/macos-silicon/**"
+    agents:
+      system: ${macos}
+
+  - label: 'Run E2E tests (macOS, arm64)'
+    key: macos-silicon-e2e
+    depends_on:
+      - add-release-commits
+      - macos-silicon-package
+    command:
+      - nix develop path:./scripts/buildkite/release -c ./scripts/buildkite/release/macos-silicon-e2e.sh
+    artifact_paths:
+      - "./logs/**/*"
+    env:
+      NODE_STATE_DIR: "${STATE_DIR_MACOS?}/node/preprod"
     agents:
       system: ${macos}

--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -6,6 +6,9 @@ env:
   NIX_PATH: "channel:nixos-21.11"
   STATE_DIR: "/var/lib/buildkite-agent/cache"
 
+  linux: "x86_64-linux"
+  macos: "aarch64-darwin"
+
 steps:
   - label: Add release commits
     key: add-release-commits
@@ -36,3 +39,25 @@ steps:
       NODE_STATE_DIR: "${STATE_DIR?}/node/preprod"
     agents:
       system: x86_64-linux
+
+  - label: 'Build package (macOS, x86_64)'
+    key: macos-intel-package
+    depends_on:
+      - add-release-commits
+    command:
+      - ./scripts/buildkite/release/macos-intel-package.sh
+    artifact_paths:
+      - "./result/macos-intel/**"
+    agents:
+      system: ${macos}
+
+  - label: 'Build package (macOS, arm64)'
+    key: macos-silicon-package
+    depends_on:
+      - add-release-commits
+    command:
+      - ./scripts/buildkite/release/macos-silicon-package.sh
+    artifact_paths:
+      - "./result/macos-silicon/**"
+    agents:
+      system: ${macos}

--- a/scripts/buildkite/release/flake.lock
+++ b/scripts/buildkite/release/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681378341,
+        "narHash": "sha256-2qUN04W6X9cHHytEsJTM41CmusifPTC0bgTtYsHSNY8=",
+        "owner": "hamishmack",
+        "repo": "flake-utils",
+        "rev": "2767bafdb189cd623354620c2dacbeca8fd58b17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hamishmack",
+        "ref": "hkm/nested-hydraJobs",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1719571325,
+        "narHash": "sha256-cyNYj2MtFvZJfNI3zdtGTIFxezT44QQ3y3NryOLzMyk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c8201d6eef0554bec529465300e600be6ddcf79d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/scripts/buildkite/release/flake.nix
+++ b/scripts/buildkite/release/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = ''
+    Shell for the release pipeline
+    that builds release artifacts and runs E2E tests.
+  '';
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
+  };
+
+  outputs = inputs:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+       ]; in
+    inputs.flake-utils.lib.eachSystem supportedSystems (system:
+      let
+        # Imports
+        pkgs = inputs.nixpkgs.legacyPackages.${system};
+      in {
+        packages = { };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.curl
+            pkgs.jq
+            pkgs.rsync
+            pkgs.gnutar
+            pkgs.gnupg
+          ];
+          shellHook = ''
+            # use this hook to set up additional environment variables
+          '';
+        };
+      }
+    );
+}

--- a/scripts/buildkite/release/linux-package.sh
+++ b/scripts/buildkite/release/linux-package.sh
@@ -1,8 +1,12 @@
 #! /usr/bin/env -S nix shell --command bash
 # shellcheck shell=bash
 
+set -euox pipefail
+
 RELEASE_CANDIDATE_BRANCH=$(buildkite-agent meta-data get "release-candidate-branch")
 
+git fetch --all
 git checkout "$RELEASE_CANDIDATE_BRANCH"
 
+rm -rf ./result/*
 nix build -o result/linux .#ci.artifacts.linux64.release

--- a/scripts/buildkite/release/macos-intel-package.sh
+++ b/scripts/buildkite/release/macos-intel-package.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+# shellcheck shell=bash
+
+set -euox pipefail
+
+RELEASE_CANDIDATE_BRANCH=$(buildkite-agent meta-data get "release-candidate-branch")
+
+git fetch --all
+git checkout "$RELEASE_CANDIDATE_BRANCH"
+
+rm -rf ./result/*
+nix build -o result/macos-intel .#packages.x86_64-darwin.ci.artifacts.macos-intel.release

--- a/scripts/buildkite/release/macos-silicon-e2e.sh
+++ b/scripts/buildkite/release/macos-silicon-e2e.sh
@@ -1,0 +1,52 @@
+#! /usr/bin/env bash
+# shellcheck shell=bash
+
+set -euox pipefail
+
+mkdir -p "$(pwd)/logs"
+
+TESTS_LOGDIR="$(pwd)/logs"
+export TESTS_LOGDIR
+
+CARDANO_NODE_CONFIGS="$(pwd)/configs/cardano"
+export CARDANO_NODE_CONFIGS
+
+VERSION=$(buildkite-agent meta-data get "release-version")
+echo "VERSION=$VERSION"
+
+buildkite-agent artifact \
+    download "result/macos-silicon/cardano-wallet-$VERSION-macos-silicon.tar.gz" "."
+
+tar xvzf "result/macos-silicon/cardano-wallet-$VERSION-macos-silicon.tar.gz"
+
+TESTS_E2E_BINDIR="$(pwd)/cardano-wallet-$VERSION-macos-silicon"
+export TESTS_E2E_BINDIR
+
+cd test/e2e
+
+TESTS_NODE_DB="$(pwd)/state/node_db"
+export TESTS_NODE_DB
+
+mkdir -p "$TESTS_NODE_DB"/preprod
+rsync -a --delete "$NODE_STATE_DIR/db/" "$TESTS_NODE_DB/preprod"
+
+tmpdir=$(mktemp -d /tmp/node-preprod.XXXXXX)
+
+CARDANO_NODE_SOCKET_PATH="$tmpdir/node.socket"
+export CARDANO_NODE_SOCKET_PATH
+
+TESTS_E2E_STATEDIR=$(pwd)/state
+export TESTS_E2E_STATEDIR
+
+TESTS_E2E_TOKEN_METADATA=https://metadata.world.dev.cardano.org/
+export TESTS_E2E_TOKEN_METADATA
+
+TESTS_E2E_FIXTURES="$FIXTURE_DECRYPTION_KEY"
+
+export TESTS_E2E_FIXTURES
+
+# We have to use the `nix develop` shell defined for x86_64-darwin
+# But we can still *test* the aarch64-darwin cardano-wallet executable
+nix develop --system x86_64-darwin -c rake "run_on[preprod,sync,true]"
+
+rm -Rv "$tmpdir"

--- a/scripts/buildkite/release/macos-silicon-package.sh
+++ b/scripts/buildkite/release/macos-silicon-package.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+# shellcheck shell=bash
+
+set -euox pipefail
+
+RELEASE_CANDIDATE_BRANCH=$(buildkite-agent meta-data get "release-candidate-branch")
+
+git fetch --all
+git checkout "$RELEASE_CANDIDATE_BRANCH"
+
+rm -rf ./result/*
+nix build -o result/macos-silicon .#packages.aarch64-darwin.ci.artifacts.macos-silicon.release

--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -197,6 +197,9 @@ task :start_node_and_wallet, [:env] do |_task, args|
         --socket-path #{NODE_SOCKET_PATH}
     CMD
     log ">> Starting cardano-node with command: #{start_node}"
+    # wait a couple of seconds for the node to provide a socket file, at least
+    sleep 5.0
+
     start_wallet = <<~CMD
       #{bin_dir}cardano-wallet serve #{network} \
         --port #{WALLET_PORT} \


### PR DESCRIPTION
This pull request adds E2E tests for macOS to the `release.yml` pipeline.

### Comments

* This pull request uses the nix flake from the `./test/e2e` directory, but also introduces a flake used to provision executables that are used for the release pipeline, such as `rsync` or `gnutar`.
* CI run here: https://buildkite.com/cardano-foundation/cardano-wallet-release/builds/236

### Issue Number

ADP-3368