### PR TITLE
Drop incorrect FIXME in `Cardano.Wallet.balanceTx`

### DIFF
--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2179,7 +2179,6 @@ balanceTx
     -> IO (Write.Tx era)
 balanceTx wrk pp timeTranslation partialTx = do
     (utxo, wallet, _txs) <- liftIO $ readWalletUTxO wrk
-    -- FIXME: Why are we not using the availableUTxO here?
     let utxoIndex =
             Write.constructUTxOIndex $
             Write.fromWalletUTxO utxo


### PR DESCRIPTION
`readWalletUTxO` /is/ returning the availible UTxO, that is, UTxOs used as
inputs for pending txs are excluded.
