### PR TITLE
[ADP-3368] Fix Github Action for E2E Windows tests

### DIFF
--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -23,7 +23,6 @@ jobs:
       BRANCH: ${{ github.event.inputs.branch || 'rc-latest' }}
       TAGS: ${{ github.event.inputs.tags || 'all' }}
 
-
     steps:
     - name: Check space
       run: Get-PSDrive
@@ -46,6 +45,7 @@ jobs:
       with:
         ruby-version: 2.7.1
         bundler-cache: true
+        working-directory: C:/cardano-wallet/test/e2e
 
     - name: Install dependencies
       working-directory: C:/cardano-wallet/test/e2e
@@ -58,13 +58,9 @@ jobs:
         choco install nssm
         choco install archiver
 
-
     - name: 🕒 Get Date/Time
       working-directory: C:/cardano-wallet/test/e2e
-      id: date-time
-      shell: bash
-      run: |
-        echo "value=$(rake datetime)" >> $GITHUB_OUTPUT
+      run: bundle exec rake datetime
 
     - name: 💾 GH Cache node db
       id: cache-node
@@ -90,27 +86,27 @@ jobs:
 
     - name: ⚙️ Setup (get latest bins and configs and decode fixtures)
       working-directory: C:/cardano-wallet/test/e2e
-      run: rake setup[preprod,%BRANCH%]
+      run: bundle exec rake setup[preprod,%BRANCH%]
 
     - name: 🔍 Display versions
       working-directory: C:/cardano-wallet/test/e2e
-      run: rake display_versions
+      run: bundle exec rake display_versions
 
     - name: 🚀 Start node and wallet
       working-directory: C:/cardano-wallet/test/e2e
-      run: rake start_node_and_wallet[preprod]
+      run: bundle exec rake start_node_and_wallet[preprod]
 
     - name: ⏳ Wait until node is synced
       working-directory: C:/cardano-wallet/test/e2e
-      run: rake wait_until_node_synced
+      run: bundle exec rake wait_until_node_synced
 
     - name: 🧪 Run all tests
       working-directory: C:/cardano-wallet/test/e2e
-      run: rake spec SPEC_OPTS="-t %TAGS%"
+      run: bundle exec rake spec SPEC_OPTS="-t %TAGS%"
 
     - name: 🏁 Stop node and wallet
       working-directory: C:/cardano-wallet/test/e2e
-      run: rake stop_node_and_wallet[preprod]
+      run: bundle exec rake stop_node_and_wallet[preprod]
 
     - name: 💾 GH Save Cache of node db
       if: always()

--- a/test/e2e/Gemfile.lock
+++ b/test/e2e/Gemfile.lock
@@ -55,4 +55,4 @@ DEPENDENCIES
   rspec (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.4.22

--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -117,7 +117,7 @@ task :wait_until_node_synced do
 
   network = CardanoWallet.new.misc.network
   # allow 180 mins for connecting to the node in case it needs to replay ledger
-  timeout = 300
+  timeout = 180*60
   current_time = Time.now
   timeout_treshold = current_time + timeout
   log "Timeout: #{timeout}s"


### PR DESCRIPTION
This pull request fixes the Github Action for the E2E Windows tests. In particular, we

- [x] Use Ruby setup based on `Gemfile` 
- [x] Increate timeout of `wait_until_node_synced`

### Issue number

ADP-3368