### PR TITLE
[ADP-3368] Fix back windows E2E github action to use rc-latest

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -398,6 +398,7 @@ steps:
         build.branch !~ /^gh-readonly-queue\/master/
           && build.branch != "master"
           && build.env("RELEASE_CANDIDATE") == null
+          && build.branch != "rc-latest"
       depends_on: linux-nix
       key: trigger-build-windows-artifacts
 

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -3,7 +3,7 @@ name: E2E Windows
 on:
   push:
     tags:
-      - release-candidate-tag/*
+      - rc-latest
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -117,7 +117,7 @@ jobs:
       if: always()
       uses: actions/cache/save@v3
       with:
-        path: test/e2e/state/node_db/preprod
+        path: C:/cardano-wallet/test/e2e/state/node_db/preprod
         key: node-db-e2e-windows-preprod
 
     - name: 📎 Upload state

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@ name: Windows Unit Tests
 on:
   push:
     tags:
-      - release-candidate-tag/*
+      - rc-latest
 
   workflow_dispatch:
     inputs:

--- a/scripts/buildkite/main/tag-release-candidate.sh
+++ b/scripts/buildkite/main/tag-release-candidate.sh
@@ -8,9 +8,18 @@ git remote set-url origin "git@github.com:cardano-foundation/cardano-wallet.git"
 
 TAG="release-candidate-tag"
 date=$(git show -s --format=%ci | awk '{print $1}')
+
 DTAG="$TAG/$date"
+LATEST="rc-latest"
 
 git tag --delete "$DTAG" || true
+git tag --delete "$LATEST" || true
+
 git push origin --delete "$DTAG" || true
+git push origin --delete "$LATEST" || true
+
 git tag "$DTAG" "$BUILDKITE_COMMIT"
+git tag "$LATEST" "$BUILDKITE_COMMIT"
+
 git push origin "$DTAG"
+git push origin "$LATEST"

--- a/scripts/buildkite/main/tag-release-candidate.sh
+++ b/scripts/buildkite/main/tag-release-candidate.sh
@@ -23,3 +23,8 @@ git tag "$LATEST" "$BUILDKITE_COMMIT"
 
 git push origin "$DTAG"
 git push origin "$LATEST"
+
+# we wait 2 minutes to let buildite build the windows artifacts for the rc-latest tag
+# it will be fast as they are already built for the same commit, do cached by nix
+
+sleep 120


### PR DESCRIPTION
- [x] Add `rc-latest` management in the main pipeline
- [x] Fix the trigger for the E2E windows action to be `rc-latest`

ADP-3368