### PR TITLE
Clarify API docs for `transactions-balance`  fields `inputs` & `redeemers`

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -4061,11 +4061,9 @@ components:
         transaction: *serialisedTransactionEncoded
         inputs:
             description: |
-                No longer required, except if the supplied `transaction` contains inputs not in the `cardano-node` UTxO.
+                Mapping from inputs (`id`, `ix`) in the supplied `transaction` binary to outputs (`amount`, `assets`, ...). It is not required to include inputs present in the `cardano-node` UTxO, as `cardano-wallet` will automatically query for them.
 
-                Balancing a transaction requires knowing the full outputs (`amount`, `assets`, ...) of the inputs (`id`, `ix`) in the `transaction` binary.
-                The wallet will now automatically try to resolve inputs using the `cardano-node` UTxO. This `inputs` field is kept for backwards compatibility
-                and for cases where the inputs don't yet exist in the `cardano-node` UTxO.
+                In other words, this field can be left empty unless the supplied `transaction` contains inputs referring to pending transactions.
             type: array
             items:
               type: object

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -4060,7 +4060,12 @@ components:
       properties:
         transaction: *serialisedTransactionEncoded
         inputs:
-            description: A list of additional transaction inputs foreign to the wallet.
+            description: |
+                No longer required, except if the supplied `transaction` contains inputs not in the `cardano-node` UTxO.
+
+                Balancing a transaction requires knowing the full outputs (`amount`, `assets`, ...) of the inputs (`id`, `ix`) in the `transaction` binary.
+                The wallet will now automatically try to resolve inputs using the `cardano-node` UTxO. This `inputs` field is kept for backwards compatibility
+                and for cases where the inputs don't yet exist in the `cardano-node` UTxO.
             type: array
             items:
               type: object

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -4085,7 +4085,7 @@ components:
                 datum: *datum
                 assets: *walletAssets
         redeemers:
-            description: A list of redeemers data with their purpose.
+            description: A list of redeemers data with their purpose. The redeemers in the `transaction` binary will be overwritten by this value.
             type: array
             items: *ApiRedeemer
         encoding:


### PR DESCRIPTION
- Document recent changes to the `transactions-balance` `inputs` field (#4630 )
- Clarify semantics of the `transactions-balance` `redeemers` field

### Rendered

<img width="739" alt="Skärmavbild 2024-07-16 kl  16 55 27" src="https://github.com/user-attachments/assets/9b92879b-e11e-4d80-9c04-7f2e4f7cdae2">

