### PR TITLE
[ADP-3389] Collect history of benchmark results in the CI of the release candidate

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -297,6 +297,7 @@ steps:
       artifact_paths: [ "./bench-results.csv" ]
       concurrency: 4
       concurrency_group: 'concurrent-benchmarks'
+      key: api-benchmark
 
     - label: Latency Benchmark (linux)
       command: |
@@ -310,6 +311,7 @@ steps:
       artifact_paths: [ "./bench-results.csv" ]
       concurrency: 4
       concurrency_group: 'concurrent-benchmarks'
+      key: latency-benchmark
 
     - label: DB Benchmark (linux)
       command: |
@@ -323,6 +325,7 @@ steps:
       artifact_paths: [ "./bench-results.csv" ]
       concurrency: 4
       concurrency_group: 'concurrent-benchmarks'
+      key: db-benchmark
 
     - label: Read-blocks Benchmark (linux)
       command: |
@@ -336,7 +339,7 @@ steps:
       artifact_paths: [ "./bench-results.csv" ]
       concurrency: 4
       concurrency_group: 'concurrent-benchmarks'
-
+      key: read-blocks-benchmark
 
     - label: Memory Benchmark (linux)
       command: |
@@ -351,6 +354,23 @@ steps:
       artifact_paths: [ "./bench-results.csv" ]
       concurrency: 4
       concurrency_group: 'concurrent-benchmarks'
+      key: memory-benchmark
+
+    - label: Benchmarks history
+      if: build.env("RELEASE_CANDIDATE") != null
+      depends_on:
+        - api-benchmark
+        - latency-benchmark
+        - db-benchmark
+        - read-blocks-benchmark
+        - memory-benchmark
+        - trigger-benchmarks
+      artifact_paths:
+        - ./benchmark-history*.tgz
+      command: |
+        ./scripts/buildkite/main/benchmark-history.sh
+      agents:
+        system: x86_64-linux
 
     - input: "Restoration Benchmark Parameters"
       if: build.env("RELEASE_CANDIDATE") == null

--- a/cabal.project
+++ b/cabal.project
@@ -62,6 +62,7 @@ packages:
   lib/application-extras
   lib/balance-tx/
   lib/benchmarks/
+  lib/buildkite/
   lib/cardano-api-extra/
   lib/crypto-primitives/
   lib/coin-selection/
@@ -231,6 +232,9 @@ cabal-lib-version: 3.6
 -- Enable specific tests in this repo
 
 test-show-details: direct
+
+package cardano-wallet-buildkite
+  tests: True
 
 package delta-chain
   tests: True

--- a/flake.nix
+++ b/flake.nix
@@ -236,6 +236,7 @@
                 };
                 # Local test cluster and mock metadata server
                 inherit (project.hsPkgs.cardano-wallet.components.exes) mock-token-metadata-server;
+                inherit (project.hsPkgs.cardano-wallet-benchmarks.components.exes) benchmark-history;
                 inherit (project.hsPkgs.local-cluster.components.exes) local-cluster;
                 inherit (project.hsPkgs.cardano-wallet-integration.components.exes) integration-exe;
                 inherit (project.hsPkgs.local-cluster.components.exes) test-local-cluster-exe;

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -41,23 +41,23 @@ library
     , aeson
     , base
     , bytestring
-    , cardano-addresses
     , cardano-wallet
     , cardano-wallet-api
     , cardano-wallet-application-extras
     , cardano-wallet-integration:framework
     , cardano-wallet-launcher
-    , cardano-wallet-network-layer
-    , cardano-wallet-primitive
     , cardano-wallet-test-utils
     , cassava
     , comonad
     , containers
+    , diagrams-lib
+    , diagrams-rasterific
+    , Chart-diagrams
+    , Chart
     , criterion-measurement
     , deepseq
     , directory
     , extra
-    , faucet
     , filepath
     , fmt
     , foldl
@@ -67,7 +67,9 @@ library
     , http-types
     , iohk-monitoring
     , iohk-monitoring-extra
+    , JuicyPixels
     , local-cluster
+    , monoidal-containers
     , mtl
     , optparse-applicative
     , pathtype
@@ -88,6 +90,7 @@ library
   exposed-modules:
     Cardano.Wallet.Benchmarks.Collect
     Cardano.Wallet.Benchmarks.History
+    Cardano.Wallet.Benchmarks.Charting
     Cardano.Wallet.Benchmarks.Latency.BenchM
     Cardano.Wallet.Benchmarks.Latency.Measure
     Cardano.Wallet.BenchShared

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -86,10 +86,11 @@ library
     , with-utf8
 
   exposed-modules:
-    Cardano.Wallet.BenchShared
     Cardano.Wallet.Benchmarks.Collect
-    Cardano.Wallet.Benchmarks.Latency.Measure
+    Cardano.Wallet.Benchmarks.History
     Cardano.Wallet.Benchmarks.Latency.BenchM
+    Cardano.Wallet.Benchmarks.Latency.Measure
+    Cardano.Wallet.BenchShared
 
 benchmark restore
   import:         language, opts-exe

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -261,3 +261,32 @@ benchmark read-blocks
     , time
 
   default-language: Haskell2010
+
+executable benchmark-history
+  import:         language, opts-exe
+  hs-source-dirs: exe
+  main-is:        benchmark-history.hs
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , cardano-wallet-benchmarks
+    , cardano-wallet-buildkite
+    , cassava
+    , containers
+    , directory
+    , filepath
+    , exceptions
+    , foldl
+    , http-client
+    , http-client-tls
+    , http-media
+    , monoidal-containers
+    , optparse-applicative
+    , pretty-simple
+    , servant
+    , servant-client
+    , streaming
+    , text
+    , time
+    , vector

--- a/lib/benchmarks/exe/api-bench.hs
+++ b/lib/benchmarks/exe/api-bench.hs
@@ -84,7 +84,7 @@ import Cardano.Wallet.Benchmarks.Collect
     , Reporter (addSemantic, report)
     , Result (Result)
     , Semantic
-    , Units (Seconds)
+    , Unit (Seconds)
     , mkSemantic
     , newReporterFromEnv
     )

--- a/lib/benchmarks/exe/benchmark-history.hs
+++ b/lib/benchmarks/exe/benchmark-history.hs
@@ -1,0 +1,290 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+import Prelude
+
+import Buildkite.API
+    ( Artifact (filename, job_id)
+    , Build (branch, jobs, number)
+    , GetArtifact
+    , Job (finished_at)
+    , Time (Time)
+    , WithAuthPipeline
+    )
+import Buildkite.Client
+    ( BuildAPI
+    , BuildJobsMap
+    , Query (..)
+    , getArtifacts
+    , getArtifactsContent
+    , getBuildsOfBranch
+    )
+import Cardano.Wallet.Benchmarks.Charting
+    ( renderHarmonizedHistoryChartSVG
+    )
+import Cardano.Wallet.Benchmarks.Collect
+    ( Benchmark (..)
+    , Result (..)
+    )
+import Cardano.Wallet.Benchmarks.History
+    ( History
+    , IndexedSemantic (IndexedSemantic)
+    , harmonizeHistory
+    , pastDays
+    , renderHarmonizedHistoryCsv
+    )
+import Control.Monad
+    ( when
+    )
+import Data.Csv
+    ( decodeByName
+    , encodeByName
+    )
+import Data.Data
+    ( Proxy (..)
+    )
+import Data.Foldable
+    ( Foldable (..)
+    )
+import Data.Semigroup
+    ( First (..)
+    )
+import Data.Text
+    ( Text
+    , isSuffixOf
+    )
+import Data.Time
+    ( Day
+    , UTCTime (utctDay)
+    )
+import Network.HTTP.Client
+    ( Manager
+    , ManagerSettings (managerModifyRequest)
+    , Request (shouldStripHeaderOnRedirect)
+    , newManager
+    )
+import Network.HTTP.Client.TLS
+    ( tlsManagerSettings
+    )
+import Network.HTTP.Media
+    ( (//)
+    )
+import Options.Applicative
+    ( Parser
+    , ParserInfo
+    , auto
+    , execParser
+    , fullDesc
+    , header
+    , help
+    , info
+    , long
+    , metavar
+    , option
+    , progDesc
+    , strOption
+    )
+import Servant.API
+    ( Accept (..)
+    , MimeUnrender
+    )
+import Servant.API.ContentTypes
+    ( MimeRender (..)
+    , MimeUnrender (..)
+    )
+import Servant.Client
+    ( BaseUrl (..)
+    , ClientEnv
+    , ClientError
+    , ClientM
+    , Scheme (..)
+    , client
+    , mkClientEnv
+    , runClientM
+    )
+import System.Environment
+    ( getEnv
+    )
+import System.FilePath
+    ( (<.>)
+    , (</>)
+    )
+
+import qualified Data.ByteString.Lazy.Char8 as BL8
+import qualified Data.Map as Map
+import qualified Data.Map.Monoidal.Strict as MMap
+import qualified Data.Text as T
+import qualified Streaming as S
+import qualified Streaming.Prelude as S
+
+data CSV
+
+instance Accept CSV where
+    contentType _ = "text" // "csv"
+
+instance Show a => MimeRender CSV a where
+    mimeRender _ val = BL8.pack $ show val
+
+instance MimeUnrender CSV BL8.ByteString where
+    mimeUnrender _ = Right
+
+organizationSlug :: Text
+organizationSlug = "cardano-foundation"
+
+pipelineSlug :: Text
+pipelineSlug = "cardano-wallet"
+
+buildkiteDomain :: String
+buildkiteDomain = "api.buildkite.com"
+
+buildkitePort :: Int
+buildkitePort = 443
+
+withAuthWallet :: String -> WithAuthPipeline a -> a
+withAuthWallet apiToken f =
+    f (Just $ T.pack apiToken) organizationSlug pipelineSlug
+
+fetchArtifactContent
+    :: WithAuthPipeline (Int -> Text -> Text -> ClientM BL8.ByteString)
+fetchArtifactContent = client (Proxy :: Proxy (GetArtifact CSV BL8.ByteString))
+
+queryBuildkite :: Query -> Day -> IO History
+queryBuildkite q d0 =
+    S.foldMap_ Prelude.id
+        $ flip
+            S.for
+            ( \case
+                Right h -> S.yield h
+                Left _e -> pure ()
+            )
+        $ S.map historyPoints
+        $ flip S.for (\(a, j) -> getArtifactsContent q fetchArtifactContent j a)
+        $ S.chain
+            ( \(_, b) ->
+                putStrLn
+                    $ "Build number: "
+                        <> show (number b)
+                        <> ", branch: "
+                        <> T.unpack (branch b)
+            )
+        $ S.filter (\(a, _) -> "bench-results.csv" `isSuffixOf` filename a)
+        $ S.map (\(b, a) -> (a, b))
+        $ flip S.for (getArtifacts q)
+        $ getReleaseCandidateBuilds q d0
+
+mkReleaseCandidateName :: Day -> String
+mkReleaseCandidateName d = "release-candidate/v" ++ show d
+
+getReleaseCandidateBuilds :: Query -> Day -> S.Stream (S.Of BuildAPI) IO ()
+getReleaseCandidateBuilds q d = S.effect $ do
+    ds <- pastDays d
+    pure
+        $ flip S.for (getBuildsOfBranch q . mkReleaseCandidateName)
+        $ S.each ds
+
+getToken :: IO String
+getToken = do
+    token <- getEnv "BUILDKITE_API_TOKEN"
+    pure $ "Bearer " ++ token
+
+data Options = Options
+    { _optSinceDate :: Day
+    , _outputDir :: FilePath
+    }
+
+parseOptDate :: Parser Day
+parseOptDate =
+    option auto
+        $ long "since"
+            <> metavar "YYYY-MM-DD"
+            <> help "The date to start collecting data from"
+
+parseOptChartsDir :: Parser FilePath
+parseOptChartsDir =
+    strOption
+        $ long "charts-dir"
+            <> metavar "DIR"
+            <> help "The directory to save the charts to"
+
+optionsParser :: ParserInfo Options
+optionsParser =
+    info
+        (Options <$> parseOptDate <*> parseOptChartsDir)
+        ( fullDesc
+            <> progDesc "Collect and process benchmark history data."
+            <> header "benchmark-history - a tool for benchmark data analysis"
+        )
+
+main :: IO ()
+main = do
+    bkToken <- getToken
+    Options sinceDay outputDir <- execParser optionsParser
+    manager <- newManager $ specialSettings False
+    let env = buildkiteEnv manager
+        runQuery action = bailout $ runClientM action env
+        query = Query runQuery $ withAuthWallet bkToken
+    result <- queryBuildkite query sinceDay
+    let eHarmonized = harmonizeHistory result
+    case eHarmonized of
+        Left rs -> error $ "Failed to harmonize history: " ++ show rs
+        Right harmonized -> do
+            let csv = uncurry encodeByName $ renderHarmonizedHistoryCsv harmonized
+            BL8.writeFile (outputDir </> "benchmark_history" <.> "csv") csv
+            renderHarmonizedHistoryChartSVG outputDir harmonized
+
+bailout :: IO (Either ClientError a) -> IO a
+bailout f = do
+    res <- f
+    case res of
+        Left e -> error $ show e
+        Right a -> pure a
+
+buildkiteEnv :: Manager -> ClientEnv
+buildkiteEnv manager =
+    mkClientEnv manager
+        $ BaseUrl Https buildkiteDomain buildkitePort ""
+
+specialSettings :: Bool -> ManagerSettings
+specialSettings logs =
+    tlsManagerSettings
+        { managerModifyRequest = \req -> do
+            let req' =
+                    req
+                        { shouldStripHeaderOnRedirect =
+                            \case
+                                "Authorization" -> True
+                                _ -> False
+                        }
+            when logs
+                $ putStrLn
+                $ "Querying: " ++ show req'
+            pure req'
+        }
+
+parseResults :: BL8.ByteString -> Either String ([(IndexedSemantic, Result)])
+parseResults = fmap (fmap f . zip [0 ..] . toList . snd) . decodeByName
+  where
+    f (i, (Benchmark s r)) = (IndexedSemantic s i, r)
+
+historyPoints
+    :: (BuildJobsMap, Artifact, BL8.ByteString)
+    -> Either String History
+historyPoints (b, a, r) =
+    let
+        rs = parseResults r
+        t = finished_at =<< Map.lookup (job_id a) (jobs b)
+    in
+        case rs of
+            Left e -> Left e
+            Right rs' -> case t of
+                Nothing -> Left "No time"
+                Just (Time t') -> Right $ fold $ do
+                    (i, r') <- rs'
+                    pure
+                        $ MMap.singleton i
+                        $ MMap.singleton (utctDay t')
+                        $ First r'

--- a/lib/benchmarks/exe/benchmark-history.hs
+++ b/lib/benchmarks/exe/benchmark-history.hs
@@ -171,6 +171,7 @@ queryBuildkite q d0 =
                         <> ", branch: "
                         <> T.unpack (branch b)
             )
+
         $ S.filter (\(a, _) -> "bench-results.csv" `isSuffixOf` filename a)
         $ S.map (\(b, a) -> (a, b))
         $ flip S.for (getArtifacts q)
@@ -232,6 +233,7 @@ main = do
     case eHarmonized of
         Left rs -> error $ "Failed to harmonize history: " ++ show rs
         Right harmonized -> do
+            putStrLn $ "Harmonized history: " <> show harmonized
             let csv = uncurry encodeByName $ renderHarmonizedHistoryCsv harmonized
             BL8.writeFile (outputDir </> "benchmark_history" <.> "csv") csv
             renderHarmonizedHistoryChartSVG outputDir harmonized

--- a/lib/benchmarks/exe/db-bench.hs
+++ b/lib/benchmarks/exe/db-bench.hs
@@ -116,7 +116,7 @@ import Cardano.Wallet.Address.Keys.WalletKey
 import Cardano.Wallet.Benchmarks.Collect
     ( Reporter
     , Result (..)
-    , Units (Bytes)
+    , Unit (Bytes)
     , addSemantic
     , mkSemantic
     , newReporterFromEnv

--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -70,7 +70,7 @@ import Cardano.Wallet.Benchmarks.Collect
     ( Benchmark (..)
     , Reporter (..)
     , Result (..)
-    , Units (Milliseconds)
+    , Unit (Milliseconds)
     , mkSemantic
     , newReporterResourceTFromEnv
     , report

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Charting.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Charting.hs
@@ -1,0 +1,178 @@
+module Cardano.Wallet.Benchmarks.Charting
+    ( renderHarmonizedHistoryChartPng
+    , renderHarmonizedHistoryChartSVG
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.Benchmarks.Collect
+    ( Units
+    )
+import Cardano.Wallet.Benchmarks.History
+    ( HarmonizedHistory (..)
+    , HarmonizedRow (..)
+    , IndexedSemantic (IndexedSemantic)
+    )
+import Codec.Picture
+    ( Image
+    , PixelRGBA8
+    , writePng
+    )
+import Control.Monad
+    ( forM_
+    , void
+    )
+import Data.Csv
+    ( toField
+    )
+import Data.Map
+    ( Map
+    )
+import Data.Set
+    ( Set
+    )
+import Data.Time
+    ( Day
+    )
+import Diagrams.Backend.Rasterific
+    ( Options (RasterificOptions)
+    , Rasterific (..)
+    )
+import Diagrams.Prelude
+    ( V2 (..)
+    , dims
+    , renderDia
+    )
+import Graphics.Rendering.Chart
+    ( FontStyle (_font_size)
+    , HTextAnchor (HTA_Centre)
+    , Layout
+    , LayoutPick
+    , Renderable
+    , VTextAnchor (VTA_Centre)
+    , area_spots_fillcolour
+    , area_spots_max_radius
+    , area_spots_title
+    , area_spots_values
+    , fillBackground
+    , label
+    , laxis_generate
+    , layoutToGrid
+    , layout_y_axis
+    , nullPickFn
+    , render
+    , scaledAxis
+    , setPickFn
+    , vectorAlignmentFns
+    )
+import Graphics.Rendering.Chart.Backend.Diagrams
+    ( FileOptions (..)
+    , defaultEnv
+    , renderableToFile
+    , runBackend
+    )
+import Graphics.Rendering.Chart.Easy
+    ( Default (def)
+    , blue
+    , execEC
+    , liftEC
+    , line
+    , plot
+    , (.=)
+    )
+import Graphics.Rendering.Chart.Grid
+    ( Grid
+    , gridToRenderable
+    , wideAbove
+    )
+import System.FilePath
+    ( (<.>)
+    , (</>)
+    )
+
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Map as Map
+import qualified Data.Map.Monoidal.Strict as MMap
+
+bsChart :: Set Day -> Map Day Double -> Layout Day Double
+bsChart ds vs = execEC $ do
+    layout_y_axis . laxis_generate .= scaledAxis def (0, maximum vs)
+    let successes = Map.restrictKeys vs ds
+    plot $ line "benchmark" $ pure $ Map.assocs successes
+    plot $ liftEC $ do
+        area_spots_title .= "value present"
+        area_spots_fillcolour .= blue
+        area_spots_max_radius .= 7
+        area_spots_values
+            .= fmap (\(d, v) -> (d, v, 1 :: Int)) (Map.assocs successes)
+
+renderIndexedSemantic :: IndexedSemantic -> String
+renderIndexedSemantic (IndexedSemantic s i) =
+    B8.unpack (toField s) <> ", " <> show i
+
+grid
+    :: Set Day
+    -> IndexedSemantic
+    -> HarmonizedRow
+    -> Grid (Renderable (LayoutPick Day Double Double))
+grid ds is mr =
+    let title :: Maybe Units -> Renderable b
+        title mu =
+            setPickFn nullPickFn
+                $ label font HTA_Centre VTA_Centre
+                $ renderIndexedSemantic is
+                    <> case mu of
+                        Nothing -> ""
+                        Just u ->
+                            "( "
+                                <> B8.unpack (toField (u :: Units))
+                                <> " )"
+    in  case mr of
+            Harmonized m u ->
+                title (Just u) `wideAbove` layoutToGrid (bsChart ds m)
+  where
+    font = def{_font_size = 12}
+
+renderHarmonizedHistoryChartSVG :: FilePath -> HarmonizedHistory -> IO ()
+renderHarmonizedHistoryChartSVG dir (HarmonizedHistory h' ds) = do
+    let mkSVGPath :: Int -> FilePath
+        mkSVGPath n = dir </> "benchmarks-history-" <> show n <.> ".svg"
+    forM_ (zip [1 :: Int ..] $ MMap.assocs h') $ \(n, (is, hr)) -> do
+        let filePath = mkSVGPath n
+        void
+            $ renderableToFile
+                def{_fo_size = (1500, 500)}
+                (mkSVGPath n)
+            $ fillBackground def
+            $ gridToRenderable
+            $ grid ds is hr
+        putStrLn
+            $ "Wrote: "
+                <> filePath
+                <> " with history of : "
+                <> renderIndexedSemantic is
+
+renderHarmonizedHistoryChartPng :: FilePath -> HarmonizedHistory -> IO ()
+renderHarmonizedHistoryChartPng dir (HarmonizedHistory h' ds) = do
+    let height = 500
+        width = 1500
+    d <- defaultEnv vectorAlignmentFns width height
+    let imageOf :: Grid (Renderable a) -> (Image PixelRGBA8)
+        imageOf grid' =
+            renderDia Rasterific (RasterificOptions (dims (V2 width height)))
+                $ fst
+                $ runBackend d
+                $ render
+                    (fillBackground def $ gridToRenderable grid')
+                    (width, height)
+    let mkPNGPath :: Int -> FilePath
+        mkPNGPath n = dir </> "benchmarks-history-" <> show n <.> ".png"
+    forM_ (zip [1 :: Int ..] $ MMap.assocs h') $ \(n, (is, hr)) -> do
+        let filePath = mkPNGPath n
+        writePng filePath $ imageOf $ grid ds is hr
+        putStrLn
+            $ "Wrote: "
+                <> filePath
+                <> " with history of : "
+                <> renderIndexedSemantic is

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Charting.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Charting.hs
@@ -7,7 +7,7 @@ where
 import Prelude
 
 import Cardano.Wallet.Benchmarks.Collect
-    ( Units
+    ( Unit
     )
 import Cardano.Wallet.Benchmarks.History
     ( HarmonizedHistory (..)
@@ -117,7 +117,7 @@ grid
     -> HarmonizedRow
     -> Grid (Renderable (LayoutPick Day Double Double))
 grid ds is mr =
-    let title :: Maybe Units -> Renderable b
+    let title :: Maybe Unit -> Renderable b
         title mu =
             setPickFn nullPickFn
                 $ label font HTA_Centre VTA_Centre
@@ -126,7 +126,7 @@ grid ds is mr =
                         Nothing -> ""
                         Just u ->
                             "( "
-                                <> B8.unpack (toField (u :: Units))
+                                <> B8.unpack (toField (u :: Unit))
                                 <> " )"
     in  case mr of
             Harmonized m u ->

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Collect.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/Collect.hs
@@ -15,7 +15,7 @@ module Cardano.Wallet.Benchmarks.Collect
 
       -- * Result
     , Result (..)
-    , Units (..)
+    , Unit (..)
 
       -- * Semantic
     , Semantic
@@ -34,7 +34,7 @@ module Cardano.Wallet.Benchmarks.Collect
 
       -- * Collecting results from criterion benchmarks
     , runCriterionBenchmark
-    , convertUnits
+    , convertUnit
 
     ) where
 
@@ -142,8 +142,8 @@ mkSemantic = Semantic . filter (not . T.null) . fmap (T.replace " " "-")
 unMkSemantic :: Semantic -> [Text]
 unMkSemantic (Semantic xs) = toList xs
 
--- | Units for a result.
-data Units
+-- | Unit for a result.
+data Unit
     = Seconds
     | Milliseconds
     | Microseconds
@@ -154,10 +154,10 @@ data Units
     | GigaBytes
     | Count
 
-instance Show Units where
-    show = showUnits
+instance Show Unit where
+    show = showUnit
 
-instance FromField Units where
+instance FromField Unit where
     parseField "s" = pure Seconds
     parseField "ms" = pure Milliseconds
     parseField "us" = pure Microseconds
@@ -167,24 +167,24 @@ instance FromField Units where
     parseField "MB" = pure MegaBytes
     parseField "GB" = pure GigaBytes
     parseField "count" = pure Count
-    parseField _ = fail "Invalid units"
+    parseField _ = fail "Invalid unit"
 
-instance ToField Units where
-    toField = B8.pack . showUnits
+instance ToField Unit where
+    toField = B8.pack . showUnit
 
-showUnits :: Units -> String
-showUnits Seconds = "s"
-showUnits Milliseconds = "ms"
-showUnits Microseconds = "us"
-showUnits Nanoseconds = "ns"
-showUnits Bytes = "B"
-showUnits KiloBytes = "KB"
-showUnits MegaBytes = "MB"
-showUnits GigaBytes = "GB"
-showUnits Count = "count"
+showUnit :: Unit -> String
+showUnit Seconds = "s"
+showUnit Milliseconds = "ms"
+showUnit Microseconds = "us"
+showUnit Nanoseconds = "ns"
+showUnit Bytes = "B"
+showUnit KiloBytes = "KB"
+showUnit MegaBytes = "MB"
+showUnit GigaBytes = "GB"
+showUnit Count = "count"
 
-convertUnits :: Units -> Units -> Double -> Double
-convertUnits from to = case (from, to) of
+convertUnit :: Unit -> Unit -> Double -> Double
+convertUnit from to = case (from, to) of
     (Seconds, Seconds) -> id
     (Seconds, Milliseconds) -> (* 1_000)
     (Seconds, Microseconds) -> (* 1_000_000)
@@ -218,20 +218,20 @@ convertUnits from to = case (from, to) of
     (GigaBytes, MegaBytes) -> (* 1_024)
     (GigaBytes, GigaBytes) -> id
     (Count, Count) -> id
-    _ -> error "Invalid units"
+    _ -> error "Invalid unit"
 
--- | A result with a value and units.
+-- | A result with a value and unit.
 data Result = Result
     { resultValue :: Double
-    , resultUnits :: Units
+    , resultUnit :: Unit
     , resultIterations :: Int
     }
 
 instance Show Result where
-    show (Result value units iterations) =
+    show (Result value unit iterations) =
         show value
             ++ " "
-            ++ show units
+            ++ show unit
             ++ " ("
             ++ show iterations
             ++ " iterations)"
@@ -254,11 +254,11 @@ instance ToText Benchmark where
             ]
 
 instance ToNamedRecord Benchmark where
-    toNamedRecord (Benchmark semantic (Result value units iterations)) =
+    toNamedRecord (Benchmark semantic (Result value unit iterations)) =
         namedRecord
             [ "semantic" .= toField semantic
             , "value" .= toField value
-            , "units" .= toField units
+            , "units" .= toField unit
             , "iterations" .= toField iterations
             ]
 
@@ -295,7 +295,7 @@ mkNullReport :: Applicative m => Reporter m
 mkNullReport = Reporter (const mkNullReport) noSemantic (const $ pure ())
 
 benchmarksHeader :: Header
-benchmarksHeader = header ["semantic", "value", "units", "iterations"]
+benchmarksHeader = header ["semantic", "value", "unit", "iterations"]
 
 -- | Create a new reporter from a file path in a 'ContT' context.
 newReporter

--- a/lib/benchmarks/src/Cardano/Wallet/Benchmarks/History.hs
+++ b/lib/benchmarks/src/Cardano/Wallet/Benchmarks/History.hs
@@ -1,0 +1,209 @@
+{-# LANGUAGE DerivingStrategies #-}
+
+module Cardano.Wallet.Benchmarks.History
+    ( HarmonizedHistory (..)
+    , History
+    , IndexedSemantic (..)
+    , HarmonizedRow (..)
+    , harmonizeHistory
+    , pastDays
+    , renderHarmonizedHistoryCsv
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.Benchmarks.Collect
+    ( Result (Result, resultUnits)
+    , Semantic
+    , Units (..)
+    , convertUnits
+    )
+import Data.Bifunctor
+    ( second
+    )
+import Data.Csv
+    ( Header
+    , ToNamedRecord (..)
+    , namedRecord
+    , (.=)
+    )
+import Data.Foldable
+    ( Foldable (..)
+    )
+import Data.Functor
+    ( (<&>)
+    )
+import Data.Map
+    ( Map
+    )
+import Data.Map.Monoidal.Strict
+    ( MonoidalMap (..)
+    , assocs
+    )
+import Data.Semigroup
+    ( First (..)
+    )
+import Data.Set
+    ( Set
+    )
+import Data.Time
+    ( Day
+    , UTCTime (..)
+    , addDays
+    , getCurrentTime
+    )
+
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Map as Map
+import qualified Data.Map.Monoidal.Strict as MMap
+import qualified Data.Text as T
+import qualified Data.Vector as V
+
+-- | A semantic, indexed by an integer which is the row number in the input CSV
+-- file. The row number is a hack for same-semantics metrics.
+data IndexedSemantic = IndexedSemantic
+    { semantic :: Semantic
+    , index :: Int
+    }
+    deriving stock (Eq, Ord, Show)
+
+-- | A history of results, indexed by semantic and day.
+type History = MonoidalMap IndexedSemantic (MonoidalMap Day (First Result))
+
+-- | A row of unit-harmonized data, indexed by day.
+data HarmonizedRow
+    = Harmonized (Map Day Double) Units
+    deriving stock (Show)
+
+-- | Unit-harmonize a list of results, returning the harmonized row if all results
+-- have the same units. Otherwise it fails with Nothing.
+harmonizeUnits :: [(Day, Result)] -> Maybe HarmonizedRow
+harmonizeUnits rs =
+    let
+        u = biggestUnit $ fmap (resultUnits . snd) rs
+    in
+        u <&> \u' ->
+            Harmonized
+                (Map.fromList $ second (harmonizeResult u') <$> rs)
+                u'
+
+-- dropping the iteration count ... for now
+harmonizeResult :: Units -> Result -> Double
+harmonizeResult u (Result v u' _i) = convertUnits u' u v
+
+-- | Find the biggest unit in a list of units.
+biggestUnit :: [Units] -> Maybe Units
+biggestUnit = foldr go Nothing
+  where
+    go :: Units -> Maybe Units -> Maybe Units
+    go u Nothing = Just u
+    go u (Just u') = compareUnits u u'
+
+-- | Compare two units and return the biggest one if they are compatible.
+compareUnits :: Units -> Units -> Maybe Units
+compareUnits u u' = case (u, u') of
+    (Seconds, Seconds) -> Just Seconds
+    (Seconds, Milliseconds) -> Just Seconds
+    (Seconds, Microseconds) -> Just Seconds
+    (Seconds, Nanoseconds) -> Just Seconds
+    (Milliseconds, Seconds) -> Just Seconds
+    (Milliseconds, Milliseconds) -> Just Milliseconds
+    (Milliseconds, Microseconds) -> Just Milliseconds
+    (Milliseconds, Nanoseconds) -> Just Milliseconds
+    (Microseconds, Seconds) -> Just Seconds
+    (Microseconds, Milliseconds) -> Just Milliseconds
+    (Microseconds, Microseconds) -> Just Microseconds
+    (Microseconds, Nanoseconds) -> Just Microseconds
+    (Nanoseconds, Seconds) -> Just Seconds
+    (Nanoseconds, Milliseconds) -> Just Milliseconds
+    (Nanoseconds, Microseconds) -> Just Microseconds
+    (Nanoseconds, Nanoseconds) -> Just Nanoseconds
+    (Bytes, Bytes) -> Just Bytes
+    (Bytes, KiloBytes) -> Just KiloBytes
+    (Bytes, MegaBytes) -> Just MegaBytes
+    (Bytes, GigaBytes) -> Just GigaBytes
+    (KiloBytes, Bytes) -> Just KiloBytes
+    (KiloBytes, KiloBytes) -> Just KiloBytes
+    (KiloBytes, MegaBytes) -> Just MegaBytes
+    (KiloBytes, GigaBytes) -> Just GigaBytes
+    (MegaBytes, Bytes) -> Just MegaBytes
+    (MegaBytes, KiloBytes) -> Just MegaBytes
+    (MegaBytes, MegaBytes) -> Just MegaBytes
+    (MegaBytes, GigaBytes) -> Just GigaBytes
+    (GigaBytes, Bytes) -> Just GigaBytes
+    (GigaBytes, KiloBytes) -> Just GigaBytes
+    (GigaBytes, MegaBytes) -> Just GigaBytes
+    (GigaBytes, GigaBytes) -> Just GigaBytes
+    (Count, Count) -> Just Count
+    _ -> Nothing
+
+-- | A history of unit-harmonized data, indexed by semantic and day.
+-- The union of all days in the history is stored in the 'days' field.
+data HarmonizedHistory = HarmonizedHistory
+    { harmonizedHistory :: MonoidalMap IndexedSemantic HarmonizedRow
+    , days :: Set Day
+    }
+    deriving stock (Show)
+
+-- | Harmonize a row of results, returning the unit-harmonized row if all results
+-- are harmonizable. Otherwise it fails with the list of unharmonizable results.
+harmonizeDay
+    :: MonoidalMap Day (First Result)
+    -> Either [(Day, Result)] HarmonizedRow
+harmonizeDay = f . fmap (second getFirst) . assocs
+  where
+    f rs = maybe (Left rs) Right $ harmonizeUnits rs
+
+-- | Harmonize a history of results, returning the unit-harmonized history if all
+-- rows are harmonizable. Otherwise it fails with the first unharmonizable row.
+harmonizeHistory
+    :: History
+    -> Either [(Day, Result)] HarmonizedHistory
+harmonizeHistory h =
+    case traverse harmonizeDay h of
+        Right h' ->
+            Right
+                $ HarmonizedHistory
+                    { harmonizedHistory = h'
+                    , days = foldMap (Map.keysSet . getMonoidalMap) h
+                    }
+        Left rs -> Left rs
+
+-- | Generate a list of days from a given day up to today in reverse order.
+pastDays :: Day -> IO [Day]
+pastDays d = do
+    today <- utctDay <$> getCurrentTime
+    return $ reverse $ takeWhile (<= today) $ iterate (addDays 1) d
+
+-- | A CSV row of data with semantic and units
+data Row = Row
+    { rowSemantic :: Semantic
+    , rowIndex :: Int
+    , units :: Units
+    , values :: [(Day, Maybe Double)]
+    }
+    deriving stock (Show)
+
+instance ToNamedRecord Row where
+    toNamedRecord (Row s i u vs) =
+        namedRecord
+            $ ("Semantic" .= s)
+                : ("Index" .= T.pack (show i))
+                : ("Units" .= u)
+                : fmap (\(d, v) -> (B8.pack . show $ d) .= v) vs
+
+-- | Render a harmonized history as a CSV file.
+renderHarmonizedHistoryCsv :: HarmonizedHistory -> (Header, [Row])
+renderHarmonizedHistoryCsv (HarmonizedHistory h ds) = (header', rows)
+  where
+    header' =
+        V.fromList
+            $ "Semantic"
+                : "Index"
+                : "Units"
+                : fmap (B8.pack . show) (toList ds)
+    rows = do
+        (IndexedSemantic s i, Harmonized m' u) <- MMap.assocs h
+        pure $ Row s i u $ do
+            toList ds <&> \d -> (d, Map.lookup d m')

--- a/lib/buildkite/LICENSE
+++ b/lib/buildkite/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/lib/buildkite/cardano-wallet-buildkite.cabal
+++ b/lib/buildkite/cardano-wallet-buildkite.cabal
@@ -1,0 +1,59 @@
+cabal-version: 3.0
+name:          cardano-wallet-buildkite
+version:       0.2024.7.7
+description:   CI tools to query Buildkite API
+license:       Apache-2.0
+license-file:  LICENSE
+author:        Cardano Foundation (High Assurance Lab)
+maintainer:    hal@cardanofoundation.org
+synopsis:      Query Buildkite API using Servant
+copyright:     2024 Cardano Foundation
+build-type:    Simple
+
+common language
+  default-language:   Haskell2010
+  default-extensions:
+    NoImplicitPrelude
+    OverloadedStrings
+
+flag release
+  description: Enable optimization and `-Werror`
+  default:     False
+  manual:      True
+
+common opts-lib
+  ghc-options:
+    -O2 -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns
+    -Wunused-foralls -Wunused-foralls -fprint-explicit-foralls
+    -fprint-explicit-kinds -Wcompat -Widentities
+    -Werror=incomplete-patterns -Wredundant-constraints
+    -Wpartial-fields -Wtabs -fhelpful-errors -fprint-expanded-synonyms
+    -fwarn-unused-do-bind -fwarn-incomplete-uni-patterns
+    -freverse-errors
+
+
+library
+  import:           language, opts-lib
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , containers
+    , exceptions
+    , http-client
+    , http-client-tls
+    , http-media
+    , pretty-simple
+    , servant
+    , servant-client
+    , streaming
+    , text
+    , time
+
+  if flag(release)
+    ghc-options: -O2 -Werror
+  hs-source-dirs:   src
+
+  exposed-modules:
+    Buildkite.API
+    Buildkite.Client

--- a/lib/buildkite/src/Buildkite/API.hs
+++ b/lib/buildkite/src/Buildkite/API.hs
@@ -1,0 +1,193 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Buildkite.API
+    ( Artifact (..)
+    , ArtifactURL (..)
+    , Build (..)
+    , Job (..)
+    , Time (..)
+    , fetchBuilds
+    , fetchBuildsOfBranch
+    , fetchArtifacts
+    , jobId
+    , artifactId
+    , WithAuthPipeline
+    , overJobs
+    , GetArtifact
+    )
+where
+
+import Prelude
+
+import Control.Monad
+    ( mzero
+    , (>=>)
+    )
+import Data.Aeson
+    ( FromJSON (..)
+    )
+import Data.Aeson.Types
+    ( Parser
+    )
+import Data.Data
+    ( Proxy (..)
+    )
+import Data.Text
+    ( Text
+    )
+import Data.Time
+    ( UTCTime
+    , defaultTimeLocale
+    , parseTimeM
+    )
+import GHC.Generics
+    ( Generic
+    )
+import Servant.API
+    ( Capture
+    , Get
+    , Header
+    , JSON
+    , QueryParam
+    , (:>)
+    )
+import Servant.Client
+    ( ClientM
+    , client
+    )
+
+newtype Time = Time
+    { time :: UTCTime
+    }
+    deriving (Show)
+
+parseDate :: String -> Parser UTCTime
+parseDate dateString =
+    maybe mzero pure
+        $ parseTimeM True defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" dateString
+
+instance FromJSON Time where
+    parseJSON = parseJSON >=> parseDate >=> pure . Time
+
+data Job = Job
+    { id :: Text
+    , name :: Maybe Text
+    , step_key :: Maybe Text
+    , finished_at :: Maybe Time
+    }
+    deriving (Show, Generic)
+
+instance FromJSON Job
+
+jobId :: Job -> Text
+jobId (Job i _ _ _) = i
+
+data Build l = Build
+    { number :: Int
+    , branch :: Text
+    , jobs :: l Job
+    }
+    deriving (Generic)
+
+deriving instance (Show (l Job)) => Show (Build l)
+
+overJobs :: Build l -> (l Job -> l' Job) -> Build l'
+overJobs (Build n b j) f = Build n b (f j)
+
+data Artifact = Artifact
+    { filename :: Text
+    , id :: Text
+    , job_id :: Text
+    , state :: Text
+    }
+    deriving (Show, Generic)
+
+artifactId :: Artifact -> Text
+artifactId (Artifact _ i _ _) = i
+
+newtype ArtifactURL = ArtifactURL
+    { url :: Text
+    }
+    deriving (Show, Generic)
+
+instance FromJSON (Build [])
+instance FromJSON Artifact
+instance FromJSON ArtifactURL
+
+type PreamblePipeline a =
+    "v2"
+        :> Header "Authorization" Text
+        :> "organizations"
+        :> Capture "org_slug" Text
+        :> "pipelines"
+        :> Capture "pipeline_slug" Text
+        :> a
+
+type GetBuilds =
+    PreamblePipeline
+        ( "builds"
+            :> QueryParam "page" Int
+            :> Get '[JSON] [Build []]
+        )
+
+type GetBuildsOfBranch =
+    PreamblePipeline
+        ( "builds"
+            :> QueryParam "branch" String
+            :> QueryParam "page" Int
+            :> Get '[JSON] [Build []]
+        )
+
+type PreambleBuilds a =
+    PreamblePipeline
+        ( "builds"
+            :> Capture "build_number" Int
+            :> a
+        )
+
+type GetArtifacts =
+    PreambleBuilds
+        ( QueryParam "page" Int
+            :> "artifacts"
+            :> Get '[JSON] [Artifact]
+        )
+
+type PreambleJobs a =
+    PreambleBuilds
+        ( "jobs"
+            :> Capture "jobs" Text
+            :> a
+        )
+
+type GetArtifact mime content =
+    PreambleJobs
+        ( "artifacts"
+            :> Capture "artifact" Text
+            :> "download"
+            :> Get '[mime] content
+        )
+
+type WithAuthPipeline a = Maybe Text -> Text -> Text -> a
+
+fetchBuilds
+    :: WithAuthPipeline
+        (Maybe Int -> ClientM [Build []])
+fetchBuilds = client $ Proxy @GetBuilds
+
+fetchBuildsOfBranch
+    :: WithAuthPipeline
+        (Maybe String -> Maybe Int -> ClientM [Build []])
+fetchBuildsOfBranch = client $ Proxy @GetBuildsOfBranch
+
+fetchArtifacts
+    :: WithAuthPipeline
+        (Int -> Maybe Int -> ClientM [Artifact])
+fetchArtifacts = client $ Proxy @GetArtifacts

--- a/lib/buildkite/src/Buildkite/Client.hs
+++ b/lib/buildkite/src/Buildkite/Client.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TupleSections #-}
+
+module Buildkite.Client
+    ( Query (..)
+    , JobMap
+    , BuildJobsMap
+    , BuildAPI
+    , paging
+    , getBuilds
+    , getBuildsOfBranch
+    , getArtifacts
+    , getArtifactsContent
+    , downloadArtifact
+    )
+where
+
+import Prelude
+
+import Buildkite.API
+    ( Artifact (..)
+    , ArtifactURL (..)
+    , Job
+    , WithAuthPipeline
+    , fetchArtifacts
+    , fetchBuilds
+    , fetchBuildsOfBranch
+    , jobId
+    , number
+    , overJobs
+    )
+import Control.Monad.IO.Class
+    ( liftIO
+    )
+import Data.Map
+    ( Map
+    )
+import Data.Text
+    ( Text
+    )
+import Network.HTTP.Client
+    ( Response (responseBody)
+    , httpLbs
+    , parseRequest
+    )
+import Network.HTTP.Client.TLS
+    ( newTlsManager
+    )
+import Servant.Client
+    ( ClientM
+    )
+import Streaming
+    ( MonadTrans (lift)
+    , Of
+    , Stream
+    )
+
+import qualified Buildkite.API as BKAPI
+import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.Map as Map
+import qualified Streaming.Prelude as S
+
+data Query
+    = Query
+        (forall a. ClientM a -> IO a)
+        (forall a. WithAuthPipeline a -> a)
+
+type JobMap = Map Text Job
+
+type BuildJobsMap = BKAPI.Build (Map Text)
+
+type BuildAPI = BKAPI.Build []
+
+paging :: Monad m => (Maybe Int -> m [a]) -> Stream (Of a) m ()
+paging f = go 1
+  where
+    go page = do
+        bs <- lift $ f $ Just page
+        S.each bs
+        case bs of
+            [] -> pure ()
+            _ -> go $ page + 1
+
+getBuilds :: Query -> Stream (Of BuildAPI) IO ()
+getBuilds (Query q w) = paging $ q . w fetchBuilds
+
+getBuildsOfBranch :: Query -> String -> Stream (Of BuildAPI) IO ()
+getBuildsOfBranch (Query q w) branch =
+    paging $ q . w fetchBuildsOfBranch (Just branch)
+
+getArtifacts :: Query -> BuildAPI -> Stream (Of (BuildJobsMap, Artifact)) IO ()
+getArtifacts (Query q w) build =
+    S.map (build',) $ paging $ q . w fetchArtifacts (number build)
+  where
+    build' = overJobs build $ \job' -> Map.fromList $ do
+        jobV <- job'
+        pure (jobId jobV, jobV)
+
+getArtifactsContent
+    :: Query
+    -> WithAuthPipeline
+        ( Int
+          -> Text
+          -> Text
+          -> ClientM r
+        )
+    -> BuildJobsMap
+    -> Artifact
+    -> Stream (Of (BuildJobsMap, Artifact, r)) IO ()
+getArtifactsContent (Query q w) getArtifact build artifact = do
+    benchResults <-
+        lift
+            $ q
+            $ w
+                getArtifact
+                (number build)
+                (job_id artifact)
+                (BKAPI.artifactId artifact)
+    S.yield (build, artifact, benchResults)
+
+downloadArtifact :: ArtifactURL -> Stream (Of BL.ByteString) IO ()
+downloadArtifact (ArtifactURL url') = do
+    response <- liftIO $ do
+        manager <- newTlsManager
+        request <- parseRequest $ show url'
+        httpLbs request manager
+    S.yield $ responseBody response

--- a/lib/wallet-benchmarks/bench/memory-benchmark.hs
+++ b/lib/wallet-benchmarks/bench/memory-benchmark.hs
@@ -37,7 +37,7 @@ import Cardano.Wallet.Benchmark.Memory.Pmap
 import Cardano.Wallet.Benchmarks.Collect
     ( Benchmark (..)
     , Result (..)
-    , Units (..)
+    , Unit (..)
     , mkSemantic
     , newReporterFromEnv
     , noSemantic

--- a/scripts/buildkite/main/benchmark-history.sh
+++ b/scripts/buildkite/main/benchmark-history.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env -S nix shell .#benchmark-history nixpkgs#gnutar -c bash
+# shellcheck shell=bash
+
+set -euox pipefail
+
+mkdir -p ./benchmark-history
+
+benchmark-history \
+    --since 2024-06-24 \
+    --charts-dir benchmark-history
+
+# shellcheck disable=SC2295
+branch="${BUILDKITE_BRANCH#release-candidate/}"
+
+# Sanitize the branch variable to replace '/' with '-'. Useful when not running
+# against a release candidate branch.
+branch_sanitized="${branch//\//-}"
+
+# shellcheck disable=SC2086
+tar -czf ./benchmark-history.${branch_sanitized}.tgz benchmark-history


### PR DESCRIPTION
- [x] Add buildkite client library that support retrieving builds by branch and artifacts
- [x] Collect benchmark CSV from buildkite
- [x] Produce a csv file containing the historical data
- [x] Produce a chart for every metrics 
- [x] Add a step in the pipeline of the release-candidate build that produce an artifact with the historical data and the 289 charts

ADP-3389 
