### PR TITLE
[ADP-3270] Support key deposit refund lookup in `Write.balanceTx` & new tx workflow

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -636,6 +636,12 @@ instance (Write.IsRecentEra era, IsServerError (ErrAssignRedeemers era))
                 , "outputs could not be found:\n"
                 , pretty $ show <$> F.toList ins
                 ]
+        ErrBalanceTxUnresolvedRefunds creds ->
+            apiError err500 UnresolvedRefunds $ T.unwords
+                [ "There are refunds in the transaction whose amounts for some"
+                , "reason weren't determined:\n"
+                , pretty $ show <$> F.toList creds
+                ]
         ErrBalanceTxInputResolutionConflicts conflicts -> do
             let conflictF (a, b) = build (show a) <> "\nvs\n" <> build (show b)
             apiError err400 InputResolutionConflicts $ mconcat

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -928,8 +928,6 @@ import qualified Internal.Cardano.Write.Tx as Write
     , utxoFromTxOutsInRecentEra
     )
 import qualified Internal.Cardano.Write.Tx.Balance as Write
-    ( PartialTx (PartialTx)
-    )
 import qualified Internal.Cardano.Write.Tx.Sign as Write
     ( TimelockKeyWitnessCounts (..)
     , estimateMinWitnessRequiredPerInput
@@ -2784,6 +2782,8 @@ constructTransaction api knownPools poolStatus apiWalletId body = do
                     { tx = Write.fromCardanoApiTx $ Cardano.Tx unbalancedTx []
                     , extraUTxO = mempty
                     , redeemers = mempty
+                    , stakeKeyDeposits = Write.StakeKeyDepositMap mempty
+                    -- Stake key deposits will be queried by W.balanceTx
                     , timelockKeyWitnessCounts = mintBurnTimelockKeyWitCounts
                     }
 
@@ -3208,6 +3208,8 @@ constructSharedTransaction
                              $ Cardano.Tx unbalancedTx []
                         , extraUTxO = mempty
                         , redeemers = mempty
+                        , stakeKeyDeposits = Write.StakeKeyDepositMap mempty
+                        -- Stake key deposits will be queried by W.balanceTx
                         , timelockKeyWitnessCounts = mempty
                         }
 
@@ -3416,6 +3418,8 @@ balanceTransaction ctx (ApiT wid) body = do
                 (Write.fromCardanoApiTx tx)
                 externalUTxO
                 (fromApiRedeemer <$> body ^. #redeemers)
+                (Write.StakeKeyDepositMap mempty)
+                -- Stake key deposits will be queried by W.balanceTx
                 (mempty :: TimelockKeyWitnessCounts)
             Left e -> liftHandler $ throwE e
 

--- a/lib/api/src/Cardano/Wallet/Api/Types/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Error.hs
@@ -243,6 +243,7 @@ data ApiErrorInfo
     | UnableToDetermineCurrentEpoch
     | UnexpectedError
     | UnresolvedInputs
+    | UnresolvedRefunds
     | UnsupportedMediaType
     | UtxoTooSmall
         !ApiErrorTxOutputLovelaceInsufficient

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -890,9 +890,9 @@ evaluateTransactionBalance pp depositLookup =
   where
     -- Deposit lookup for `UnRegDRep` certificates in the TxBody
     --
-    -- TODO [ADP-3270] Query actual value of deposit
+    -- TODO [ADP-3404] Query actual value of deposit
     --
-    -- https://cardanofoundation.atlassian.net/browse/ADP-3270
+    -- https://cardanofoundation.atlassian.net/browse/ADP-3404
     dRepDepositAssumeCurrent
         :: Core.Credential 'Ledger.DRepRole StandardCrypto
         -> Maybe Coin

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -359,12 +359,10 @@ type RecentEraConstraints era =
     , Core.Tx era ~ Babbage.AlonzoTx era
     , Core.Value era ~ Value
     , Core.TxWits era ~ AlonzoTxWits era
-    -- , ExtendedUTxO era
     , Alonzo.AlonzoEraPParams era
     , Ledger.AlonzoEraTx era
     , ScriptsNeeded era ~ AlonzoScriptsNeeded era
     , AlonzoEraScript era
-    -- , EraPlutusContext 'PlutusV1 era
     , Eq (TxOut era)
     , Ledger.Crypto (Core.EraCrypto era)
     , Show (TxOut era)

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -122,6 +122,7 @@ module Internal.Cardano.Write.Tx
 
     -- ** Rewards
     , RewardAccount
+    , StakeCredential
 
     -- ** Script
     , Script
@@ -173,7 +174,6 @@ import Cardano.Ledger.Alonzo.UTxO
     )
 import Cardano.Ledger.Api
     ( coinTxOutL
-    , ppKeyDepositL
     , upgradeTxOut
     )
 import Cardano.Ledger.Api.UTxO
@@ -357,6 +357,7 @@ type RecentEraConstraints era =
     , Core.EraCrypto era ~ StandardCrypto
     , Core.Script era ~ AlonzoScript era
     , Core.Tx era ~ Babbage.AlonzoTx era
+    , Core.EraTxCert era
     , Core.Value era ~ Value
     , Core.TxWits era ~ AlonzoTxWits era
     , Alonzo.AlonzoEraPParams era
@@ -876,25 +877,17 @@ stakeKeyDeposit pp = pp ^. Core.ppKeyDepositL
 evaluateTransactionBalance
     :: forall era. IsRecentEra era
     => PParams era
+    -> (StakeCredential -> Maybe Coin)
     -> Shelley.UTxO era
     -> Core.TxBody era
     -> Core.Value era
-evaluateTransactionBalance pp =
+evaluateTransactionBalance pp depositLookup =
     Ledger.evalBalanceTxBody
         pp
-        keyDepositAssumeCurrent
+        depositLookup
         dRepDepositAssumeCurrent
         assumePoolIsReg
   where
-    -- Deposit lookup for 'DeRegKey' delegation certificates in the TxBody
-    --
-    -- TODO [ADP-3270] Query actual value of deposit
-    --
-    -- https://cardanofoundation.atlassian.net/browse/ADP-3270
-    keyDepositAssumeCurrent
-        :: Core.StakeCredential StandardCrypto -> Maybe Coin
-    keyDepositAssumeCurrent _stakeCred = Just $ pp ^. ppKeyDepositL
-
     -- Deposit lookup for `UnRegDRep` certificates in the TxBody
     --
     -- TODO [ADP-3270] Query actual value of deposit
@@ -932,3 +925,9 @@ pattern PolicyId
     :: Core.ScriptHash StandardCrypto
     -> Value.PolicyID StandardCrypto
 pattern PolicyId h = Value.PolicyID h
+
+--------------------------------------------------------------------------------
+-- Stake Credential
+--------------------------------------------------------------------------------
+
+type StakeCredential = Core.StakeCredential StandardCrypto

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -690,12 +690,12 @@ balanceTx
 
     guardRefundsResolvable :: ExceptT (ErrBalanceTx era) m ()
     guardRefundsResolvable = case stakeKeyDeposits of
-        StakeKeyDepositAssumeCurrent -> return ()
+        StakeKeyDepositAssumeCurrent -> pure ()
         StakeKeyDepositMap deposits -> do
             let refunds = stakeCredentialsWithRefunds tx
             let unresolvedRefunds = refunds <\> Set.fromList (Map.keys deposits)
             maybe
-                (return ())
+                (pure ())
                 (throwE . ErrBalanceTxUnresolvedRefunds)
                 (NESet.nonEmptySet unresolvedRefunds)
 

--- a/lib/network-layer/src/Cardano/Wallet/Network.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network.hs
@@ -156,6 +156,9 @@ data NetworkLayer m block = NetworkLayer
     , getUTxOByTxIn
         :: Set Write.TxIn
         -> m (MaybeInRecentEra Write.UTxO)
+    , getStakeDelegDeposits
+        :: Set Write.StakeCredential
+        -> m (Map Write.StakeCredential Write.Coin)
     , getCachedRewardAccountBalance
         :: RewardAccount
         -- Either reward account from key hash or script hash

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -520,6 +520,8 @@ withNodeNetworkLayerBase
                     _stakeDistribution queryRewardQ
                 , getUTxOByTxIn =
                     _getUTxOByTxIn queryRewardQ readCurrentNodeEra
+                , getStakeDelegDeposits =
+                    _getStakeDelegDeposits queryRewardQ
                 , getCachedRewardAccountBalance =
                     _getCachedRewardAccountBalance rewardsObserver
                 , fetchRewardAccountBalances =
@@ -674,6 +676,11 @@ withNodeNetworkLayerBase
             | otherwise
                 = bracketQuery "getUTxOByTxIn" tr
                 $ queue `send` SomeLSQ (LSQ.getUTxOByTxIn ins)
+        _getStakeDelegDeposits queue creds
+            | creds == mempty = mempty
+            | otherwise
+                = bracketQuery "getStakeDelegDeposits" tr
+                $ queue `send` SomeLSQ (LSQ.getStakeDelegDeposits creds)
 
         _watchNodeTip readTip callback = do
             observeForever readTip $ \tip -> do

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery.hs
@@ -22,6 +22,7 @@ import Cardano.Wallet.Network.LocalStateQuery.PParams
     )
 import Cardano.Wallet.Network.LocalStateQuery.RewardAccount
     ( fetchRewardAccounts
+    , getStakeDelegDeposits
     )
 import Cardano.Wallet.Network.LocalStateQuery.StakeDistribution
     ( stakeDistribution

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/RewardAccount.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/RewardAccount.hs
@@ -11,10 +11,14 @@
 --
 module Cardano.Wallet.Network.LocalStateQuery.RewardAccount
     ( fetchRewardAccounts
+    , getStakeDelegDeposits
     ) where
 
 import Prelude
 
+import Cardano.Ledger.Credential
+    ( StakeCredential
+    )
 import Cardano.Wallet.Network.Implementation.Ouroboros
     ( LSQ (..)
     )
@@ -42,6 +46,7 @@ import Ouroboros.Consensus.Shelley.Eras
     )
 
 import qualified Cardano.Crypto.Hash as Crypto
+import qualified Cardano.Ledger.Coin as Ledger
 import qualified Cardano.Ledger.Credential as SL
 import qualified Cardano.Ledger.Crypto as SL
 import qualified Cardano.Ledger.Shelley.API as SL
@@ -96,3 +101,19 @@ fetchRewardAccounts accounts =
         ( Map.mapKeys fromStakeCredential
             $ Map.map Ledger.toWalletCoin rewardAccounts
         )
+
+getStakeDelegDeposits
+    :: Set (StakeCredential StandardCrypto)
+    -> LSQ' (Map (StakeCredential StandardCrypto) Ledger.Coin)
+getStakeDelegDeposits credentials =
+    onAnyEra
+        (pure byronValue)
+        (LSQry $ Shelley.GetStakeDelegDeposits credentials)
+        (LSQry $ Shelley.GetStakeDelegDeposits credentials)
+        (LSQry $ Shelley.GetStakeDelegDeposits credentials)
+        (LSQry $ Shelley.GetStakeDelegDeposits credentials)
+        (LSQry $ Shelley.GetStakeDelegDeposits credentials)
+        (LSQry $ Shelley.GetStakeDelegDeposits credentials)
+  where
+    byronValue :: Map (StakeCredential StandardCrypto) Ledger.Coin
+    byronValue = Map.fromList . map (,Ledger.Coin 0) $ Set.toList credentials

--- a/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -159,6 +159,7 @@ dummyNetworkLayer = NetworkLayer
         = err "currentProtocolParametersInRecentEras"
     , currentSlottingParameters = err "currentSlottingParameters"
     , getUTxOByTxIn = err "getUTxOByTxIn"
+    , getStakeDelegDeposits = error "getStakeDelegDeposits"
     , postTx = err "postTx"
     , stakeDistribution = err "stakeDistribution"
     , getCachedRewardAccountBalance = err "getRewardCachedAccountBalance"

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2193,14 +2193,12 @@ balanceTx wrk pp timeTranslation partialTx = do
     -- the user when calling transactions-construct, or in transactions-balance.
     let netLayer = wrk ^. networkLayer
     let inputsToLookup = partialTx ^. #tx . bodyTxL . allInputsTxBodyF
-    lookedUpUTxO <- liftIO $
-        forceUTxOToEra =<< getUTxOByTxIn netLayer inputsToLookup
+    lookedUpUTxO <- forceUTxOToEra =<< getUTxOByTxIn netLayer inputsToLookup
 
     -- Look up key deposits of refunds
     let deregCreds = stakeCredentialsWithRefunds $ view #tx partialTx
-    lookedUpDeposits <-
-        fmap Write.StakeKeyDepositMap
-        . liftIO $ getStakeDelegDeposits netLayer deregCreds
+    lookedUpDeposits <- Write.StakeKeyDepositMap
+        <$> getStakeDelegDeposits netLayer deregCreds
 
     let utxoAssumptions = case walletFlavor @s of
             ShelleyWallet -> AllKeyPaymentCredentials

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -893,6 +893,7 @@ import qualified Internal.Cardano.Write.Tx as Write
     )
 import qualified Internal.Cardano.Write.Tx.Balance as Write
     ( PartialTx
+    , StakeKeyDepositLookup (StakeKeyDepositAssumeCurrent, StakeKeyDepositMap)
     , UTxOIndex
     , balanceTx
     , constructUTxOIndex
@@ -2545,6 +2546,7 @@ buildTransactionPure
                 , extraUTxO = Write.UTxO mempty
                 , redeemers = []
                 , timelockKeyWitnessCounts = mempty
+                , stakeKeyDeposits = Write.StakeKeyDepositAssumeCurrent
                 }
 
 -- HACK: 'mkUnsignedTransaction' takes a reward account 'XPub' even when the
@@ -3239,6 +3241,7 @@ transactionFee DBLayer{atomically, walletState} protocolParams
                 , extraUTxO = Write.UTxO mempty
                 , redeemers = []
                 , timelockKeyWitnessCounts = mempty
+                , stakeKeyDeposits = Write.StakeKeyDepositAssumeCurrent
                 }
 
         wrapErrBalanceTx $ calculateFeePercentiles $ do

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -5609,6 +5609,19 @@ x-errUnresolvedInputs: &errUnresolvedInputs
       type: string
       enum: ['unknown_inputs']
 
+x-errUnresolvedRefunds: &errUnresolvedRefunds
+  <<: *responsesErr
+  title: unresolved_refunds
+  properties:
+    message:
+      type: string
+      description: |
+        There are stake key deregistration certificates in the transaction for which corresponding
+        deposit amounts could not be found.
+    code:
+      type: string
+      enum: ['unresolved_refunds']
+
 x-errRedeemerInvalidData: &errRedeemerInvalidData
   <<: *responsesErr
   title: redeemer_invalid_data


### PR DESCRIPTION
- [x] Add new `PartialTx` field `keyDeposits` for looking up stake key UnReg refunds 
    - This allows us to stop assuming the deposited amount equals the `ppKeyDeposit` value of
      the current protocol parameters.
- [x] Test that `Write.balanceTx` takes it into account
- [x] Query deposit amounts with LSQ for the new tx workflow (construct, construct-shared, balance) 

### For later

- Query deposit amounts for the old tx workflow

- Improve the internals of `Write.balanceTx`. This PR muddies the point of `TxWithUTxO` and the distinction between `balanceTx` and `balanceTxInner`. We could imagine a new type

```haskell
-- | Tx with enough additional context to evaluate it's balance etc (may or may not include PParams)
data TxWithContext 

evaluateBalanceAfterSettingMinFee :: TxWithContext -> (Value, Coin, KeyWitnessCounts)

balance :: TxWithContext -> Value

-- | Will also modify the UTxO
applySelection :: TxWithContext -> SelectAssetsResult -> TxWithContext
```
where we'd let `balanceTxInner` take `TxWithContext` instead of `Tx` + related args.

However, we'd either need to include the entire `referenceUTxO` (`extraUTxO <> walletUTxO`) in
the `utxo` of the `TxWithContext` and later trust that the inputs from the 
`SelectAssetsResult` can be resolved, or we'd need to do something else...

The relationship of `PartialTx` with a new `TxWithContext` may also be awkward, as they would be almost — but not quite — the same. E.g. `PartialTx` contains a `redeemers` field.

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-3270

