### PR TITLE
[ADP-2565] Implement SQL expressions for `WHERE` clauses

### DIFF
--- a/lib/delta-table/delta-table.cabal
+++ b/lib/delta-table/delta-table.cabal
@@ -65,6 +65,7 @@ library
       Database.Table.SQL.Column
       Database.Table.SQL.Stmt
       Database.Table.SQL.Table
+      Database.Table.SQL.Var
       Database.Table.SQLite.Simple.Exec
 
 test-suite unit

--- a/lib/delta-table/delta-table.cabal
+++ b/lib/delta-table/delta-table.cabal
@@ -63,6 +63,7 @@ library
   other-modules:
       Database.Table.Schema
       Database.Table.SQL.Column
+      Database.Table.SQL.Expr
       Database.Table.SQL.Stmt
       Database.Table.SQL.Table
       Database.Table.SQL.Var

--- a/lib/delta-table/src/Database/Table/SQL/Expr.hs
+++ b/lib/delta-table/src/Database/Table/SQL/Expr.hs
@@ -1,0 +1,211 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
+{- |
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+SQL expressions (for use in WHERE clauses)
+-}
+module Database.Table.SQL.Expr
+    (
+    -- * SQL expressions
+    -- ** Expressions
+    Expr
+    , true
+    , false
+    , not_
+    , (&&.)
+    , and_
+    , (||.)
+    , or_
+    , (==.)
+    , (/=.)
+    , (<.)
+    , (<=.)
+    , (>.)
+    , (>=.)
+
+    -- ** Internal
+    , renderExpr
+    , parens
+    , text
+    , var
+    ) where
+
+import Prelude
+
+import Data.Text
+    ( Text
+    )
+import Database.Table.Schema
+    ( Col
+    , IsColumnName
+    , getColumnName
+    )
+
+import qualified Database.SQLite.Simple as Sqlite
+import qualified Database.SQLite.Simple.ToField as Sqlite
+import qualified Database.Table.SQL.Var as Var
+
+{-------------------------------------------------------------------------------
+    Expressions
+    Type
+-------------------------------------------------------------------------------}
+type Identifier = Text
+
+-- | SQL expressions corresponding to the Haskell type @a@.
+data Expr a where
+    Value :: Sqlite.SQLData -> Expr Identifier
+    Zero :: Expr0 a -> Expr a
+    One  :: Op1 a b -> Expr a -> Expr b
+    Two  :: Op2 a b c -> Expr a -> Expr b -> Expr c
+
+data Expr0 a where
+    TrueE :: Expr0 Bool
+    FalseE :: Expr0 Bool
+    ColumnName :: Text -> Expr0 Identifier
+
+data Op1 a b where
+    Not :: Op1 Bool Bool
+
+data Op2 a b c where
+    And :: Op2 Bool Bool Bool
+    Or :: Op2 Bool Bool Bool
+    Eq :: Op2 a a Bool
+    Lt :: Op2 a a Bool
+    Leq :: Op2 a a Bool
+    Gt :: Op2 a a Bool
+    Geq :: Op2 a a Bool
+
+infix  4  ==., /=., <., <=., >=., >.
+infixr 3  &&.
+infixr 2  ||.
+
+-- | SQL @true@ literal.
+true :: Expr Bool
+true = Zero TrueE
+
+-- | SQL @false@ literal.
+false :: Expr Bool
+false = Zero FalseE
+
+-- | SQL @NOT@, negation.
+not_ :: Expr Bool -> Expr Bool
+not_ = One Not
+
+-- | SQL @AND@, conjunction.
+(&&.) :: Expr Bool -> Expr Bool -> Expr Bool
+(&&.) = Two And
+
+-- | Combine multiple 'Expr' with '(&&.)'.
+and_ :: [Expr Bool] -> Expr Bool
+and_ [] = true
+and_ (x:xs) = foldr (&&.) x xs
+
+-- | SQL @OR@, disjunction.
+(||.) :: Expr Bool -> Expr Bool -> Expr Bool
+(||.) = Two Or
+
+-- | Combine multiple 'Expr' with '(||.)'.
+or_ :: [Expr Bool] -> Expr Bool
+or_ [] = false
+or_ (x:xs) = foldr (||.) x xs
+
+-- | Comparing a column against a given value.
+columnOpValue
+    :: forall n a c. (IsColumnName n, Sqlite.ToField a)
+    => Op2 Identifier Identifier c -> Col n a -> a -> Expr c
+columnOpValue op2 col a =
+    Two op2
+        (Zero . ColumnName $ getColumnName col)
+        (Value $ Sqlite.toField a)
+
+-- | Test whether the value in a given column equals a given value.
+(==.)
+    :: forall n a. (IsColumnName n, Sqlite.ToField a)
+    => Col n a -> a -> Expr Bool
+(==.) = columnOpValue Eq
+
+(/=.)
+    :: forall n a. (IsColumnName n, Sqlite.ToField a)
+    => Col n a -> a -> Expr Bool
+(/=.) col a = not_ (col ==. a)
+
+(<.)
+    :: forall n a. (IsColumnName n, Sqlite.ToField a, Ord a)
+    => Col n a -> a -> Expr Bool
+(<.) = columnOpValue Lt
+
+(<=.)
+    :: forall n a. (IsColumnName n, Sqlite.ToField a, Ord a)
+    => Col n a -> a -> Expr Bool
+(<=.) = columnOpValue Leq
+
+(>.)
+    :: forall n a. (IsColumnName n, Sqlite.ToField a, Ord a)
+    => Col n a -> a -> Expr Bool
+(>.) = columnOpValue Gt
+
+(>=.)
+    :: forall n a. (IsColumnName n, Sqlite.ToField a, Ord a)
+    => Col n a -> a -> Expr Bool
+(>=.) = columnOpValue Geq
+
+{-------------------------------------------------------------------------------
+    Expressions
+    Rendering
+-------------------------------------------------------------------------------}
+-- | Render an expression as SQL source code.
+renderExpr :: Expr a -> Var.Lets Text
+renderExpr (Value value) =
+    Var.bindValue value >>= var
+renderExpr (Zero e) =
+    text (render0 e)
+renderExpr (One op1 ea) =
+    text (renderOp1 op1)
+        <> sp <> parens (renderExpr ea)
+renderExpr (Two op2 ea eb) =
+    parens (renderExpr ea)
+        <> sp <> text (renderOp2 op2)
+        <> sp <> parens (renderExpr eb)
+
+-- | A single whitespace character.
+sp :: Var.Lets Text
+sp = text " "
+
+mkIdentifier :: Text -> Text
+mkIdentifier name = "\"" <> name <> "\""
+
+render0 :: Expr0 a -> Text
+render0 TrueE = "true"
+render0 FalseE = "false"
+render0 (ColumnName name) = mkIdentifier name
+
+renderOp1 :: Op1 a b -> Text
+renderOp1 Not = "NOT"
+
+renderOp2 :: Op2 a b c -> Text
+renderOp2 And = "AND"
+renderOp2 Or = "OR"
+renderOp2 Eq = "="
+renderOp2 Lt = "<"
+renderOp2 Leq = "<="
+renderOp2 Gt = ">"
+renderOp2 Geq = ">="
+
+-- | Render a fixed text.
+text :: Text -> Var.Lets Text
+text = pure
+
+-- | Render a variable name
+var :: Var.VarName -> Var.Lets Text
+var = pure . Var.renderVarName
+
+-- | Wrap a rendering in parentheses
+parens :: Var.Lets Text -> Var.Lets Text
+parens = fmap $ \x -> "(" <> x <> ")"

--- a/lib/delta-table/src/Database/Table/SQL/Stmt.hs
+++ b/lib/delta-table/src/Database/Table/SQL/Stmt.hs
@@ -41,6 +41,8 @@ import Database.Table.SQL.Table
     )
 
 import qualified Data.Text as T
+import qualified Database.Table.SQL.Expr as Expr
+import qualified Database.Table.SQL.Var as Var
 
 {-------------------------------------------------------------------------------
     SQL Statements
@@ -63,26 +65,26 @@ data Where where
     Rendering
 -------------------------------------------------------------------------------}
 -- | Render an statement as SQL source code.
-renderStmt :: Stmt -> Text
-renderStmt (CreateTable table cols) =
-    "CREATE TABLE IF NOT EXISTS "
+renderStmt :: Stmt -> Var.Lets Text
+renderStmt (CreateTable table cols) = Expr.text
+    $ "CREATE TABLE IF NOT EXISTS "
         <> renderName table
         <> " " <> renderTuple (map renderCol cols)
         <> ";"
   where
     renderCol (col, typ)= renderName col <> " " <> escapeSqlType typ
-renderStmt (Insert table cols) =
-    "INSERT INTO "
+renderStmt (Insert table cols) = Expr.text
+    $ "INSERT INTO "
         <> renderName table
         <> " " <> renderTuple (map renderName cols)
         <> " VALUES " <> renderTuple ("?" <$ cols)
         <> ";"
-renderStmt (Select cols table All) =
-    "SELECT " <> T.intercalate "," (map renderName cols)
+renderStmt (Select cols table All) = Expr.text
+    $ "SELECT " <> T.intercalate "," (map renderName cols)
         <> " FROM " <> renderName table
         <> ";"
-renderStmt (Delete table All) =
-    "DELETE FROM " <> renderName table
+renderStmt (Delete table All) = Expr.text
+    $ "DELETE FROM " <> renderName table
 
 -- | Escape a column or table name.
 renderName :: Text -> Text

--- a/lib/delta-table/src/Database/Table/SQL/Stmt.hs
+++ b/lib/delta-table/src/Database/Table/SQL/Stmt.hs
@@ -20,6 +20,7 @@ module Database.Table.SQL.Stmt
     , selectWhere
     , insertOne
     , deleteAll
+    , deleteWhere
     ) where
 
 import Prelude
@@ -92,8 +93,10 @@ renderStmt (Select cols table (Where expr)) =
         <> Expr.text ";"
 renderStmt (Delete table All) = Expr.text
     $ "DELETE FROM " <> renderName table
-renderStmt (Delete _ (Where _)) =
-    error "DELERE FROM … WHERE not implemented yet."
+renderStmt (Delete table (Where expr)) =
+    Expr.text ("DELETE FROM " <> renderName table)
+        <> Expr.text " WHERE " <> Expr.renderExpr expr
+        <> Expr.text ";"
 
 -- | Escape a column or table name.
 renderName :: Text -> Text
@@ -135,3 +138,10 @@ insertOne proxy =
 deleteAll :: IsTableSql t => proxy t -> Stmt
 deleteAll proxy =
     Delete (getTableName proxy) All
+
+-- | Delete those rows from a database table that satisfy a condition.
+deleteWhere
+    :: IsTableSql t
+    => Expr.Expr Bool -> proxy t -> Stmt
+deleteWhere expr proxy =
+    Delete (getTableName proxy) (Where expr)

--- a/lib/delta-table/src/Database/Table/SQL/Var.hs
+++ b/lib/delta-table/src/Database/Table/SQL/Var.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE TupleSections #-}
+
+{- |
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+Variables and bindings.
+-}
+module Database.Table.SQL.Var
+    (
+    -- * Variables and Bindings
+    -- ** Variable names
+    VarName
+    , renderVarName
+    , Fresh
+    , newVarName
+
+    -- ** Bindings
+    , Value
+    , Bindings
+    , Lets
+    , freshVarName
+    , bindValue
+
+    -- ** Rendering
+    , Rendering (..)
+    , render
+    ) where
+
+import Prelude
+
+import Control.Monad
+    ( ap
+    )
+import Control.Monad.Trans.State.Strict
+    ( State
+    , evalState
+    , get
+    , put
+    )
+import Data.Bifunctor
+    ( first
+    )
+import Data.Text
+    ( Text
+    )
+import Numeric.Natural
+    ( Natural
+    )
+
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
+
+import qualified Database.SQLite.Simple as Sqlite
+
+{-------------------------------------------------------------------------------
+    Name allocation
+-------------------------------------------------------------------------------}
+-- | Name for a variable.
+newtype VarName = Var Text
+    deriving (Eq, Ord)
+
+-- | Render a variable name in a format that SQLite recognizes as variable.
+renderVarName :: VarName -> Text
+renderVarName (Var v) = v
+
+type VarCounter = Natural
+
+-- | Monad for allocating fresh variable names.
+type Fresh = State VarCounter
+
+-- | Create a variable name from the current counter.
+mkVarName :: VarCounter -> VarName
+mkVarName = Var . T.pack . (":var" <>) . show
+
+-- | Allocate a fresh variable name.
+newVarName :: Fresh VarName
+newVarName = do
+    c <- get
+    put $! (c+1)
+    pure $ mkVarName c
+
+{-------------------------------------------------------------------------------
+    Bindings
+-------------------------------------------------------------------------------}
+-- | Value that can be bound to a variable.
+type Value = Sqlite.SQLData
+
+-- | Bindings of variables to names.
+type Bindings = Map.Map VarName Value
+
+-- | Monad for creating values that also contain variables and bindings.
+newtype Lets a = Lets {runLets :: Fresh (a, Bindings)}
+
+instance Functor Lets where
+    fmap f (Lets x) = Lets (first f <$> x)
+
+instance Applicative Lets where
+    pure a = Lets $ pure (a, mempty)
+    (<*>) = ap
+
+instance Monad Lets where
+    Lets mx >>= g = Lets $ do
+        (x, xs) <- mx
+        (y, ys) <- runLets (g x)
+        pure (y, xs <> ys)
+
+instance Semigroup a => Semigroup (Lets a) where
+    a <> b = (<>) <$> a <*> b
+
+instance Monoid a => Monoid (Lets a) where
+    mempty = pure mempty
+
+-- | Allocate a new variable name, but without binding to it.
+freshVarName :: Lets VarName
+freshVarName = Lets $ (,mempty) <$> newVarName
+
+-- | Bind a given value to a variable name.
+bindValue :: Value -> Lets VarName
+bindValue value =
+    Lets $ (\name -> (name, Map.singleton name value)) <$> newVarName
+
+{-------------------------------------------------------------------------------
+    Rendering
+-------------------------------------------------------------------------------}
+-- | A value together with variable bindings.
+data Rendering a = Rendering
+    { val :: a
+    , bindings :: Bindings
+    }
+
+-- | Instantiate all variable names.
+render :: Lets a -> Rendering a
+render (Lets mf) = uncurry Rendering $ evalState mf 0

--- a/lib/delta-table/src/Database/Table/SQLite/Simple.hs
+++ b/lib/delta-table/src/Database/Table/SQLite/Simple.hs
@@ -13,10 +13,12 @@ import qualified Database.Table.SQLite.Simple as Sqlite
 module Database.Table.SQLite.Simple
     (
       module Database.Table.SQL.Table
+    , module Database.Table.SQL.Expr
     , module Database.Table.SQLite.Simple.Exec
     , module Database.Table.SQL.Column
     ) where
 
 import Database.Table.SQL.Column
+import Database.Table.SQL.Expr
 import Database.Table.SQL.Table
 import Database.Table.SQLite.Simple.Exec

--- a/lib/delta-table/src/Database/Table/SQLite/Simple/Exec.hs
+++ b/lib/delta-table/src/Database/Table/SQLite/Simple/Exec.hs
@@ -21,6 +21,7 @@ module Database.Table.SQLite.Simple.Exec
     , insertOne
     , insertMany
     , deleteAll
+    , deleteWhere
     ) where
 
 import Prelude
@@ -131,3 +132,6 @@ insertMany rows proxy = for_ rows (`insertOne` proxy)
 
 deleteAll :: IsTableSql t => proxy t -> SqlM ()
 deleteAll = execute_ . Stmt.deleteAll
+
+deleteWhere :: IsTableSql t => Expr.Expr Bool -> proxy t -> SqlM ()
+deleteWhere expr = executeNamed . Stmt.deleteWhere expr

--- a/lib/delta-table/src/Database/Table/SQLite/Simple/Exec.hs
+++ b/lib/delta-table/src/Database/Table/SQLite/Simple/Exec.hs
@@ -17,6 +17,7 @@ module Database.Table.SQLite.Simple.Exec
     -- * SQL statements
     , createTable
     , selectAll
+    , selectWhere
     , insertOne
     , insertMany
     , deleteAll
@@ -39,6 +40,7 @@ import Database.Table.SQL.Table
 
 import qualified Data.Map.Strict as Map
 import qualified Database.SQLite.Simple as Sqlite
+import qualified Database.Table.SQL.Expr as Expr
 import qualified Database.Table.SQL.Stmt as Stmt
 import qualified Database.Table.SQL.Var as Var
 
@@ -117,6 +119,9 @@ createTable = execute_ . Stmt.createTable
 
 selectAll :: IsTableSql t => proxy t -> SqlM [Row t]
 selectAll = query_ . Stmt.selectAll
+
+selectWhere :: IsTableSql t => Expr.Expr Bool -> proxy t -> SqlM [Row t]
+selectWhere expr = queryNamed . Stmt.selectWhere expr
 
 insertOne :: IsTableSql t => Row t -> proxy t -> SqlM ()
 insertOne row proxy = executeOne (Stmt.insertOne proxy) row

--- a/lib/delta-table/src/Database/Table/Schema.hs
+++ b/lib/delta-table/src/Database/Table/Schema.hs
@@ -1,9 +1,9 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 {- |
 Copyright: © 2024 Cardano Foundation
@@ -21,6 +21,9 @@ module Database.Table.Schema
     , Table (..)
     , Col (..)
     , (:.) (..)
+
+    , IsColumnName
+    , getColumnName
 
     -- * Rows
     , Row
@@ -80,6 +83,13 @@ infixl 3 :.
 -- | Named database column.
 data Col (name :: Symbol) a = Col
     deriving (Eq,Ord,Show)
+
+-- | Constraint synonym for 'getColName'.
+type IsColumnName (name :: Symbol) = KnownSymbol name
+
+-- | Get the name of a column from its type.
+getColumnName :: forall name a. IsColumnName name => Col name a -> Text
+getColumnName _ = T.pack $ symbolVal (Proxy :: Proxy name)
 
 -- | Named database table.
 data Table (name :: Symbol) = Table

--- a/lib/delta-table/src/Demo/Database.hs
+++ b/lib/delta-table/src/Demo/Database.hs
@@ -52,7 +52,7 @@ action :: Sql.SqlM [Row TablePerson]
 action = do
     Sql.createTable tablePerson
     Sql.insertOne ("Neko", 1603) tablePerson
-    Sql.deleteAll tablePerson
+    Sql.deleteWhere (colName Sql.==. "Neko") tablePerson
     Sql.insertOne ("Babbage", 1791) tablePerson
     Sql.insertOne ("William", 1805) tablePerson
     Sql.insertOne ("Ada", 1815) tablePerson

--- a/lib/delta-table/src/Demo/Database.hs
+++ b/lib/delta-table/src/Demo/Database.hs
@@ -22,7 +22,7 @@ import Data.Text
     ( Text
     )
 import Database.Table
-    ( Col
+    ( Col (..)
     , Row
     , Table
     , (:.)
@@ -42,14 +42,23 @@ type TablePerson =
 tablePerson :: Proxy TablePerson
 tablePerson = Proxy
 
+colName :: Col "name" Text
+colName = Col
+
+colBirthYear :: Col "birthyear" Int
+colBirthYear = Col
+
 action :: Sql.SqlM [Row TablePerson]
 action = do
     Sql.createTable tablePerson
     Sql.insertOne ("Neko", 1603) tablePerson
     Sql.deleteAll tablePerson
+    Sql.insertOne ("Babbage", 1791) tablePerson
     Sql.insertOne ("William", 1805) tablePerson
     Sql.insertOne ("Ada", 1815) tablePerson
-    Sql.selectAll tablePerson
+    Sql.selectWhere
+        (colName Sql./=. "William" Sql.&&. colBirthYear Sql.<. 1800)
+        tablePerson
 
 main :: IO ()
 main = do


### PR DESCRIPTION
This pull request

* Implements facilities for working with variables: a type `VarName`, a type `Bindings`, and a `Lets` monad.
* Implements a type `Expr a` that represents expression in the SQL language. Specifically, `Expr Bool` can be used in a `WHERE` clause.
* Implements a function `selectWhere` that works with the `Table` type and computes a `SELECT … WHERE` clause.
* Implements a function `deleteWhere` that works with the `Table` type



### Comments

* I have skipped extensive property testing for now, as I want to stabilize the API first. The module `Demo.Database` provides a basic functionality check.

### Issue Number

ADP-2565