### PR TITLE
[ADP-2565] Implement `updateWhere`

### DIFF
--- a/lib/delta-table/src/Database/Table/SQLite/Simple/Exec.hs
+++ b/lib/delta-table/src/Database/Table/SQLite/Simple/Exec.hs
@@ -22,6 +22,9 @@ module Database.Table.SQLite.Simple.Exec
     , insertMany
     , deleteAll
     , deleteWhere
+    , updateWhere
+    , Update
+    , (=.)
     ) where
 
 import Prelude
@@ -34,6 +37,10 @@ import Data.Foldable
     )
 import Database.Table
     ( Row
+    )
+import Database.Table.SQL.Stmt
+    ( Update
+    , (=.)
     )
 import Database.Table.SQL.Table
     ( IsTableSql
@@ -129,6 +136,11 @@ insertOne row proxy = executeOne (Stmt.insertOne proxy) row
 
 insertMany :: IsTableSql t => [Row t] -> proxy t -> SqlM ()
 insertMany rows proxy = for_ rows (`insertOne` proxy)
+
+updateWhere
+    :: IsTableSql t
+    => Expr.Expr Bool -> [Stmt.Update] -> proxy t -> SqlM ()
+updateWhere expr updates = executeNamed . Stmt.updateWhere expr updates
 
 deleteAll :: IsTableSql t => proxy t -> SqlM ()
 deleteAll = execute_ . Stmt.deleteAll

--- a/lib/delta-table/src/Demo/Database.hs
+++ b/lib/delta-table/src/Demo/Database.hs
@@ -55,9 +55,13 @@ action = do
     Sql.deleteWhere (colName Sql.==. "Neko") tablePerson
     Sql.insertOne ("Babbage", 1791) tablePerson
     Sql.insertOne ("William", 1805) tablePerson
-    Sql.insertOne ("Ada", 1815) tablePerson
+    Sql.insertOne ("Bada", 1815) tablePerson
+    Sql.updateWhere
+        (colName Sql.==. "Bada")
+        [colName Sql.=. "Ada"]
+        tablePerson
     Sql.selectWhere
-        (colName Sql./=. "William" Sql.&&. colBirthYear Sql.<. 1800)
+        (colName Sql./=. "William" Sql.&&. colBirthYear Sql.>. 1800)
         tablePerson
 
 main :: IO ()


### PR DESCRIPTION
This pull request

* Implements a function `updateWhere` that works with the `Table` type.

### Comments

* The collection of functions `selectWhere`, `insertMany`, `updateWhere`, and `deleteWhere` are sufficient to express all database table manipulations of interest, I don't expect to add more functions to `Database.Table.SQLite.Simple.Exec`.
* I have skipped extensive property testing for now, as I want to stabilize the API first. The module `Demo.Database` provides a basic functionality check.

### Issue Number

ADP-2565
