### PR TITLE
[ADP-3215] Add `TxOut` type to `Cardano.Wallet.Read.Tx`

### DIFF
--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -67,6 +67,7 @@ library
     Cardano.Read.Ledger.Tx.Integrity
     Cardano.Read.Ledger.Tx.Metadata
     Cardano.Read.Ledger.Tx.Mint
+    Cardano.Read.Ledger.Tx.Output
     Cardano.Read.Ledger.Tx.ReferenceInputs
     Cardano.Read.Ledger.Tx.ScriptValidity
     Cardano.Read.Ledger.Tx.Validity
@@ -155,6 +156,7 @@ test-suite test
   ghc-options:        -with-rtsopts=-M2G -with-rtsopts=-N4
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:
+    Cardano.Read.Ledger.OutputSpec
     Cardano.Wallet.Read.EraValueSpec
     Cardano.Wallet.Read.Tx.CBORSpec
     Cardano.Wallet.Read.Tx.TxIdSpec
@@ -168,6 +170,9 @@ test-suite test
   build-depends:
     , base
     , bytestring
+    , cardano-ledger-api
+    , cardano-ledger-core
+    , cardano-ledger-mary
     , cardano-wallet-read
     , cardano-wallet-test-utils
     , hspec

--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -104,6 +104,7 @@ library
     Cardano.Wallet.Read.Tx.ScriptValidity
     Cardano.Wallet.Read.Tx.TxId
     Cardano.Wallet.Read.Tx.TxIn
+    Cardano.Wallet.Read.Tx.TxOut
     Cardano.Wallet.Read.Value
 
   build-depends:
@@ -160,6 +161,7 @@ test-suite test
     Cardano.Wallet.Read.EraValueSpec
     Cardano.Wallet.Read.Tx.CBORSpec
     Cardano.Wallet.Read.Tx.TxIdSpec
+    Cardano.Wallet.Read.Tx.TxOutSpec
     Test.Unit.Cardano.Read.Ledger.Tx
     Spec
     SpecHook

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Output.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Output.hs
@@ -1,0 +1,243 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{- |
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+Era-indexed transaction output.
+-}
+module Cardano.Read.Ledger.Tx.Output
+    ( OutputType
+    , Output (..)
+    , getEraCompactAddr
+    , getEraValue
+    , upgradeToOutputBabbage
+    , upgradeToOutputConway
+    , deserializeOutput
+    , serializeOutput
+    )
+    where
+
+import Prelude
+
+import Cardano.Ledger.Alonzo.TxOut
+    ( AlonzoTxOut
+    )
+import Cardano.Ledger.Api
+    ( Addr (AddrBootstrap)
+    , BootstrapAddress (..)
+    , eraProtVerLow
+    , mkBasicTxOut
+    , upgradeTxOut
+    )
+import Cardano.Ledger.Babbage.TxOut
+    ( BabbageTxOut
+    )
+import Cardano.Ledger.Binary
+    ( DecCBOR (decCBOR)
+    , DecoderError
+    , EncCBOR
+    , byronProtVer
+    , decodeFull
+    , decodeFullDecoder
+    , shelleyProtVer
+    )
+import Cardano.Ledger.Core
+    ( compactAddrTxOutL
+    , valueTxOutL
+    )
+import Cardano.Ledger.Shelley.TxOut
+    ( ShelleyTxOut
+    )
+import Cardano.Read.Ledger.Address
+    ( CompactAddr (..)
+    , CompactAddrType
+    )
+import Cardano.Read.Ledger.Value
+    ( Value (..)
+    , ValueType
+    , maryValueFromByronValue
+    )
+import Cardano.Wallet.Read.Eras
+    ( Allegra
+    , Alonzo
+    , Babbage
+    , Byron
+    , Conway
+    , Era (..)
+    , IsEra (..)
+    , Mary
+    , Shelley
+    )
+import Control.Lens
+    ( view
+    )
+import Data.Text
+    ( Text
+    )
+
+import qualified Cardano.Chain.UTxO as BY
+import qualified Cardano.Ledger.Binary.Encoding as Ledger
+import qualified Data.ByteString.Lazy as BL
+
+{-----------------------------------------------------------------------------
+    Output
+------------------------------------------------------------------------------}
+
+type family OutputType era where
+    OutputType Byron = BY.TxOut
+    OutputType Shelley = ShelleyTxOut Shelley
+    OutputType Allegra = ShelleyTxOut Allegra
+    OutputType Mary = ShelleyTxOut Mary
+    OutputType Alonzo = AlonzoTxOut Alonzo
+    OutputType Babbage = BabbageTxOut Babbage
+    OutputType Conway = BabbageTxOut Conway
+
+newtype Output era = Output (OutputType era)
+
+deriving instance Show (OutputType era) => Show (Output era)
+deriving instance Eq (OutputType era) => Eq (Output era)
+
+{-----------------------------------------------------------------------------
+    Eliminators
+------------------------------------------------------------------------------}
+
+{-# INLINEABLE getEraCompactAddr #-}
+getEraCompactAddr :: forall era. IsEra era => Output era -> CompactAddr era
+getEraCompactAddr = case theEra :: Era era of
+    Byron -> address $ (\(BY.CompactTxOut a _) -> a) . BY.toCompactTxOut
+    Shelley -> address (view compactAddrTxOutL)
+    Allegra -> address (view compactAddrTxOutL)
+    Mary -> address (view compactAddrTxOutL)
+    Alonzo -> address (view compactAddrTxOutL)
+    Babbage -> address (view compactAddrTxOutL)
+    Conway -> address (view compactAddrTxOutL)
+
+-- Helper function for type inference
+address
+    :: (OutputType era -> CompactAddrType era)
+    -> Output era -> CompactAddr era
+address f (Output x) = CompactAddr (f x)
+
+{-# INLINEABLE getEraValue #-}
+getEraValue :: forall era. IsEra era => Output era -> Value era
+getEraValue = case theEra :: Era era of
+    Byron -> value BY.txOutValue
+    Shelley -> value (view valueTxOutL)
+    Allegra -> value (view valueTxOutL)
+    Mary -> value (view valueTxOutL)
+    Alonzo -> value (view valueTxOutL)
+    Babbage -> value (view valueTxOutL)
+    Conway -> value (view valueTxOutL)
+
+-- Helper function for type inference
+value :: (OutputType era -> ValueType era) -> Output era -> Value era
+value f (Output x) = Value (f x)
+
+{-----------------------------------------------------------------------------
+    Operations
+------------------------------------------------------------------------------}
+
+{-# INLINEABLE upgradeToOutputBabbage #-}
+-- | Upgrade an 'Output' to the 'Babbage' era if possibile.
+--
+-- Hardfork: Update this function to the new era.
+upgradeToOutputBabbage
+    :: forall era. IsEra era
+    => Output era -> Maybe (Output Babbage)
+upgradeToOutputBabbage = case theEra :: Era era of
+    Byron -> Just . onOutput
+        (\(BY.TxOut addr lovelace) ->
+            mkBasicTxOut
+                (AddrBootstrap (BootstrapAddress addr))
+                (maryValueFromByronValue lovelace)
+        )
+    Shelley -> Just . onOutput
+        (upgradeTxOut . upgradeTxOut . upgradeTxOut . upgradeTxOut)
+    Allegra -> Just . onOutput
+        (upgradeTxOut . upgradeTxOut . upgradeTxOut)
+    Mary -> Just . onOutput
+        (upgradeTxOut . upgradeTxOut)
+    Alonzo -> Just . onOutput upgradeTxOut
+    Babbage -> Just . id
+    Conway -> const Nothing
+
+{-# INLINEABLE upgradeToOutputConway #-}
+-- | Upgrade an 'Output' to the 'Conway' era.
+--
+-- Hardfork: Update this function to the next era.
+upgradeToOutputConway :: forall era. IsEra era => Output era -> Output Conway
+upgradeToOutputConway = case theEra :: Era era of
+    Byron -> onOutput
+        $ \(BY.TxOut addr lovelace) ->
+            mkBasicTxOut
+                (AddrBootstrap (BootstrapAddress addr))
+                (maryValueFromByronValue lovelace)
+    Shelley -> onOutput
+        $ upgradeTxOut . upgradeTxOut . upgradeTxOut . upgradeTxOut
+        . upgradeTxOut
+    Allegra -> onOutput
+        $ upgradeTxOut . upgradeTxOut . upgradeTxOut . upgradeTxOut
+    Mary -> onOutput
+        $ upgradeTxOut . upgradeTxOut . upgradeTxOut
+    Alonzo -> onOutput
+        $ upgradeTxOut . upgradeTxOut
+    Babbage -> onOutput upgradeTxOut
+    Conway -> id
+
+-- Helper function for type inference
+onOutput
+    :: (OutputType era1 -> OutputType era2)
+    -> Output era1 -> Output era2
+onOutput f (Output x) = Output (f x)
+
+{-----------------------------------------------------------------------------
+    Serialization
+------------------------------------------------------------------------------}
+
+{-# INLINABLE serializeOutput #-}
+-- | Serialize an 'Output' in binary format, e.g. for storing in a database.
+serializeOutput :: forall era. IsEra era => Output era -> BL.ByteString
+serializeOutput = case theEra :: Era era of
+    Byron -> encode byronProtVer
+    Shelley -> encode (eraProtVerLow @Shelley)
+    Allegra -> encode (eraProtVerLow @Allegra)
+    Mary -> encode (eraProtVerLow @Mary)
+    Alonzo -> encode (eraProtVerLow @Alonzo)
+    Babbage -> encode (eraProtVerLow @Babbage)
+    Conway -> encode (eraProtVerLow @Conway)
+  where
+    encode
+        :: EncCBOR (OutputType era)
+        => Ledger.Version -> Output era -> BL.ByteString
+    encode protVer (Output out) = Ledger.serialize protVer out
+
+{-# INLINABLE deserializeOutput #-}
+-- | Deserialize an 'Output' from the binary format.
+--
+-- prop> ∀ o.  deserializeOutput (serializeOutput o) == Just o
+deserializeOutput
+    :: forall era . IsEra era
+    => BL.ByteString -> Either DecoderError (Output era)
+deserializeOutput = case theEra :: Era era of
+    Byron -> fmap Output . decodeFull byronProtVer
+    Shelley -> decode shelleyProtVer "ShelleyTxOut"
+    Allegra -> decode (eraProtVerLow @Allegra) "AllegraTxOut"
+    Mary -> decode (eraProtVerLow @Mary) "MaryTxOut"
+    Alonzo -> decode (eraProtVerLow @Alonzo) "AlonzoTxOut"
+    Babbage -> decode (eraProtVerLow @Babbage) "BabbageTxOut"
+    Conway -> decode (eraProtVerLow @Conway) "ConwayTxOut"
+  where
+    decode
+        :: DecCBOR (OutputType era)
+        => Ledger.Version
+        -> Text
+        -> BL.ByteString
+        -> Either DecoderError (Output era)
+    decode protVer label =
+        fmap Output . decodeFullDecoder protVer label decCBOR

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/TxOut.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/TxOut.hs
@@ -1,0 +1,304 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- |
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+'TxOut' — transaction output.
+-}
+module Cardano.Wallet.Read.Tx.TxOut
+    ( -- * TxOut
+      TxOut
+    , mkBasicTxOut
+    , getCompactAddr
+    , getValue
+    , utxoFromEraTx
+    , upgradeTxOutToBabbageOrLater
+
+    -- * Conversions
+    , toBabbageOutput
+    , toConwayOutput
+
+    -- * Serialization
+    , deserializeTxOut
+    , serializeTxOut
+
+    -- * Internal
+    , mkEraTxOut
+    )
+    where
+
+import Prelude
+
+import Cardano.Ledger.Binary
+    ( DecoderError (DecoderErrorCustom)
+    )
+import Cardano.Ledger.Compactible
+    ( toCompact
+    )
+import Cardano.Read.Ledger.Tx.CollateralOutputs
+    ( CollateralOutputs (..)
+    , getEraCollateralOutputs
+    )
+import Cardano.Read.Ledger.Tx.Output
+    ( Output (..)
+    , OutputType
+    , deserializeOutput
+    , getEraCompactAddr
+    , getEraValue
+    , serializeOutput
+    , upgradeToOutputBabbage
+    , upgradeToOutputConway
+    )
+import Cardano.Read.Ledger.Tx.Outputs
+    ( Outputs (..)
+    , getEraOutputs
+    )
+import Cardano.Wallet.Read.Address
+    ( CompactAddr
+    , fromEraCompactAddr
+    )
+import Cardano.Wallet.Read.Eras
+    ( Babbage
+    , Conway
+    , Era (..)
+    , EraValue (..)
+    , IsEra (theEra)
+    , indexOfEra
+    , parseEraIndex
+    )
+import Cardano.Wallet.Read.Tx
+    ( Tx (..)
+    )
+import Cardano.Wallet.Read.Tx.TxIn
+    ( TxIn
+    , pattern TxIn
+    , pattern TxIx
+    )
+import Cardano.Wallet.Read.Value
+    ( Value
+    , fromEraValue
+    , toMaryValue
+    )
+import Data.Foldable
+    ( toList
+    )
+import Data.Maybe
+    ( fromMaybe
+    )
+import Data.Maybe.Strict
+    ( StrictMaybe (SNothing)
+    )
+import Data.Word
+    ( Word16
+    )
+
+import qualified Cardano.Ledger.Babbage.TxBody as Babbage
+import qualified Cardano.Wallet.Read.Tx.ScriptValidity as Read
+import qualified Cardano.Wallet.Read.Tx.TxId as Read
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
+
+{-----------------------------------------------------------------------------
+    Type
+------------------------------------------------------------------------------}
+-- | A 'TxOut' is a transaction output from any era — past, present
+-- or next one.
+newtype TxOut = TxOutC (EraValue Output)
+
+instance Show TxOut where
+    show (TxOutC v) = show v
+
+-- | For testing — make a 'TxOut' from an era-indexed transaction output.
+mkEraTxOut :: IsEra era => Output era -> TxOut
+mkEraTxOut = TxOutC . EraValue
+
+-- | Make a basic 'TxOut' from an address and a value.
+mkBasicTxOut :: CompactAddr -> Value -> TxOut
+mkBasicTxOut addr value =
+    TxOutC (EraValue (Output txout :: Output Conway))
+  where
+    val = toMaryValue value
+    -- The function 'toCompact' returns 'Nothing' when the input
+    -- contains quantities that are outside the bounds of a Word64,
+    -- x < 0 or x > (2^64 - 1)
+    -- Such quantities are valid 'Integer's, but they cannot be
+    -- encoded in a 'TxOut', hence the 'Nothing' result.
+    -- Cardano.Ledger uses the same error message when converting.
+    cVal = fromMaybe (error ("Illegal Value in TxOut: " ++ show val))
+        $ toCompact val
+    txout = Babbage.TxOutCompact addr cVal
+
+{-# INLINEABLE getCompactAddr #-}
+-- | Get the address which controls who can spend the transaction output.
+getCompactAddr :: TxOut -> CompactAddr
+getCompactAddr (TxOutC (EraValue txout)) =
+    fromEraCompactAddr $ getEraCompactAddr txout
+
+{-# INLINEABLE getValue #-}
+-- | Get the monetary 'Value' in this transaction output.
+getValue :: TxOut -> Value
+getValue (TxOutC (EraValue txout)) =
+    fromEraValue $ getEraValue txout
+
+-- | Upgrade the internal representation of a 'TxOut'
+-- to at least the 'Babbage' era.
+--
+-- Hardfork: Upgrade this function to a new era.
+upgradeTxOutToBabbageOrLater :: TxOut -> TxOut
+upgradeTxOutToBabbageOrLater x@(TxOutC (EraValue (txout :: Output era))) =
+    case theEra :: Era era of
+        Conway -> x
+        Babbage -> x
+        _ -> case upgradeToOutputBabbage txout of
+            Just output -> TxOutC (EraValue output)
+            _ -> error "upgradeTxOutToBabbageOrLater: impossible"
+
+-- | Convert to an output in the 'Babbage' output, if possible.
+--
+-- Hardfork: Update this function to the current era.
+toBabbageOutput :: TxOut -> Maybe (Output Babbage)
+toBabbageOutput (TxOutC (EraValue txout)) = upgradeToOutputBabbage txout
+
+-- | Convert to an output in the 'Conway' output
+--
+-- Hardfork: Update this function to the next era.
+toConwayOutput :: TxOut -> Output Conway
+toConwayOutput (TxOutC (EraValue txout)) = upgradeToOutputConway txout
+
+{-----------------------------------------------------------------------------
+    Serialization
+------------------------------------------------------------------------------}
+
+-- | Serialize a 'TxOut' in binary format, e.g. for storing in a database.
+serializeTxOut :: TxOut -> BL.ByteString
+serializeTxOut (TxOutC (EraValue (txout :: Output era))) =
+    BL.cons tag (serializeOutput txout)
+  where
+    tag = toEnum (indexOfEra (theEra :: Era era))
+
+type Dec era = Either DecoderError (Output era)
+
+-- | Deserialize a 'TxOut' from the binary format.
+--
+-- prop> ∀ o.  deserializeTxOut (serializeTxOut o) == Just o
+deserializeTxOut :: BL.ByteString -> Either DecoderError TxOut
+deserializeTxOut bytes
+    | Just (x,xs) <- BL.uncons bytes = do
+        eera <- maybe (Left $ errUnknownEraIndex x) Right
+            $ parseEraIndex (fromEnum x)
+        case eera of
+            EraValue (_ :: Era era) ->
+                TxOutC . EraValue <$> (deserializeOutput xs :: Dec era)
+    | otherwise =
+        Left $ DecoderErrorCustom "Empty input" ""
+  where
+    errUnknownEraIndex =
+        DecoderErrorCustom "Unknown era index" . T.pack . show
+
+{-----------------------------------------------------------------------------
+    Transactions
+------------------------------------------------------------------------------}
+
+{-# INLINEABLE utxoFromEraTx #-}
+-- | Unspent transaction outputs (UTxO) created by the transaction.
+utxoFromEraTx :: forall era. IsEra era => Tx era -> Map.Map TxIn TxOut
+utxoFromEraTx tx =
+    case Read.getScriptValidity tx of
+        Read.IsValid True -> utxoFromEraTxCollateralOutputs tx
+        Read.IsValid False -> utxoFromEraTxOutputs tx
+
+{-# INLINEABLE utxoFromEraTxOutputs #-}
+-- | UTxO corresponding to the ordinary outputs of a transaction.
+--
+-- This function ignores the transaction's script validity.
+--
+utxoFromEraTxOutputs
+    :: forall era. IsEra era => Tx era -> Map.Map TxIn TxOut
+utxoFromEraTxOutputs tx =
+    withFoldableOutputs toMap (getEraOutputs tx)
+  where
+    txid = Read.getTxId tx
+    mkOutputInEra out = Output out :: Output era
+
+    toMap
+        :: forall t. Foldable t
+        => t (OutputType era) -> Map.Map TxIn TxOut
+    toMap =
+        Map.fromList
+        . zipWith (\ix -> mkTxInTxOutPair txid ix . mkOutputInEra) [0..]
+        . toList
+
+{-# INLINEABLE utxoFromEraTxCollateralOutputs #-}
+-- | UTxO corresponding to the collateral outputs of a transaction.
+--
+-- This function ignores the transaction's script validity.
+--
+utxoFromEraTxCollateralOutputs
+    :: forall era. IsEra era => Tx era -> Map.Map TxIn TxOut
+utxoFromEraTxCollateralOutputs tx =
+    withMaybeCollateralOutputs singleton (getEraCollateralOutputs tx)
+  where
+    txid = Read.getTxId tx
+    mkOutputInEra out = Output out :: Output era
+
+    singleton :: StrictMaybe (OutputType era) -> Map.Map TxIn TxOut
+    singleton =
+        Map.fromList
+        . map (mkTxInTxOutPair txid index . mkOutputInEra)
+        . toList
+
+    -- To reference a collateral output within transaction t, we specify an
+    -- output index that is equal to the number of ordinary outputs within t.
+    --
+    -- See definition of function "collOuts" within "Formal Specification of
+    -- the Cardano Ledger for the Babbage era".
+    --
+    -- https://github.com/IntersectMBO/cardano-ledger?tab=readme-ov-file
+    --
+    index :: Word16
+    index = fromIntegral $
+        withFoldableOutputs length (getEraOutputs tx)
+
+-- Helper function: Create a pair @(TxIn, TxOut)@.
+mkTxInTxOutPair
+    :: forall era. IsEra era
+    => Read.TxId -> Word16 -> Output era -> (TxIn, TxOut)
+mkTxInTxOutPair txid ix out =
+    ( TxIn txid (TxIx ix)
+    , TxOutC (EraValue out)
+    )
+
+-- Helper function: Treat the 'Outputs' as a 'Foldable' container.
+withFoldableOutputs
+    :: forall era a. IsEra era
+    => (forall t. Foldable t => t (OutputType era) -> a)
+    -> Outputs era
+    -> a
+withFoldableOutputs f = case theEra :: Era era of
+    Byron -> \(Outputs x) -> f x
+    Shelley -> \(Outputs x) -> f x
+    Allegra -> \(Outputs x) -> f x
+    Mary -> \(Outputs x) -> f x
+    Alonzo -> \(Outputs x) -> f x
+    Babbage -> \(Outputs x) -> f x
+    Conway -> \(Outputs x) -> f x
+
+-- Helper function: Treat the 'CollateralOutputs' as a 'StrictMaybe'.
+withMaybeCollateralOutputs
+    :: forall era a. IsEra era
+    => (StrictMaybe (OutputType era) -> a)
+    -> CollateralOutputs era
+    -> a
+withMaybeCollateralOutputs f = case theEra :: Era era of
+    Byron -> \(CollateralOutputs _) -> f SNothing
+    Shelley -> \(CollateralOutputs _) -> f SNothing
+    Allegra -> \(CollateralOutputs _) -> f SNothing
+    Mary -> \(CollateralOutputs _) -> f SNothing
+    Alonzo -> \(CollateralOutputs _) -> f SNothing
+    Babbage -> \(CollateralOutputs x) -> f x
+    Conway -> \(CollateralOutputs x) -> f x

--- a/lib/read/lib/Cardano/Wallet/Read/Value.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Value.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
 {- |
@@ -29,7 +31,7 @@ module Cardano.Wallet.Read.Value
     , lessOrEqual
 
     -- * Internal
-    , fromMaryValue
+    , fromEraValue
     , toMaryValue
     ) where
 
@@ -47,10 +49,15 @@ import Cardano.Ledger.Val
     ( pointwise
     , (<->)
     )
+import Cardano.Read.Ledger.Eras
+    ( Era (..)
+    , IsEra (..)
+    )
 
 import qualified Cardano.Ledger.BaseTypes as SH
 import qualified Cardano.Ledger.Coin as L
 import qualified Cardano.Ledger.Mary.Value as MA
+import qualified Cardano.Read.Ledger.Value as L
 
 {-----------------------------------------------------------------------------
     Coin
@@ -84,14 +91,6 @@ type MultiAsset = MA.MultiAsset StandardCrypto
 ------------------------------------------------------------------------------}
 -- | Monetary values, representing both ADA and native assets/tokens.
 newtype Value = Value (MA.MaryValue StandardCrypto)
-
--- | Internal: Convert from ledger 'MaryValue'.
-fromMaryValue :: MA.MaryValue StandardCrypto -> Value
-fromMaryValue = Value
-
--- | Internal: Convert to ledger 'MaryValue'.
-toMaryValue :: Value -> MA.MaryValue StandardCrypto
-toMaryValue (Value v) = v
 
 instance Eq Value where
     (Value x) == (Value y) = x == y
@@ -145,3 +144,29 @@ subtract (Value x) (Value y) = Value (x <-> y)
 lessOrEqual :: Value -> Value -> Bool
 lessOrEqual (Value value1) (Value value2) =
     pointwise (<=) value1 value2
+
+{-----------------------------------------------------------------------------
+    Conversions from Eras
+------------------------------------------------------------------------------}
+-- | Internal: Convert from ledger 'MaryValue'.
+fromMaryValue :: MA.MaryValue StandardCrypto -> Value
+fromMaryValue = Value
+
+-- | Internal: Convert to ledger 'MaryValue'.
+toMaryValue :: Value -> MA.MaryValue StandardCrypto
+toMaryValue (Value v) = v
+
+-- | Internal: Convert from era-indexed 'L.Value'.
+fromEraValue :: forall era. IsEra era => L.Value era -> Value
+fromEraValue = fromMaryValue . case theEra :: Era era of
+    Byron -> onValue L.maryValueFromByronValue
+    Shelley -> onValue L.maryValueFromShelleyValue
+    Allegra -> onValue L.maryValueFromShelleyValue
+    Mary -> onValue id
+    Alonzo -> onValue id
+    Babbage -> onValue id
+    Conway -> onValue id
+
+-- Helper function for type inference.
+onValue :: (L.ValueType era -> t) -> L.Value era -> t
+onValue f (L.Value x) = f x

--- a/lib/read/lib/Cardano/Wallet/Read/Value.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Value.hs
@@ -10,7 +10,7 @@ License: Apache-2.0
 -}
 module Cardano.Wallet.Read.Value
     ( -- * Coin
-      Coin (unCoin)
+      Coin (CoinC, unCoin)
 
     -- * MultiAsset
     , MultiAsset
@@ -41,7 +41,7 @@ import Cardano.Ledger.Api
     ( StandardCrypto
     )
 import Cardano.Ledger.Coin
-    ( Coin (unCoin)
+    ( Coin
     )
 import Cardano.Ledger.Val
     ( pointwise
@@ -49,7 +49,15 @@ import Cardano.Ledger.Val
     )
 
 import qualified Cardano.Ledger.BaseTypes as SH
+import qualified Cardano.Ledger.Coin as L
 import qualified Cardano.Ledger.Mary.Value as MA
+
+{-----------------------------------------------------------------------------
+    Coin
+------------------------------------------------------------------------------}
+{-# COMPLETE CoinC #-}
+pattern CoinC :: Integer -> Coin
+pattern CoinC{unCoin} = L.Coin unCoin
 
 {-----------------------------------------------------------------------------
     MultiAssets

--- a/lib/read/test/Cardano/Read/Ledger/OutputSpec.hs
+++ b/lib/read/test/Cardano/Read/Ledger/OutputSpec.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Read.Ledger.OutputSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Ledger.Address
+    ( Addr (Addr)
+    )
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    , mkBasicTxOut
+    )
+import Cardano.Ledger.BaseTypes
+    ( Network (Mainnet)
+    )
+import Cardano.Ledger.Coin
+    ( Coin (Coin)
+    )
+import Cardano.Ledger.Credential
+    ( Credential (KeyHashObj)
+    , PaymentCredential
+    , Ptr (Ptr)
+    , StakeReference (StakeRefPtr)
+    )
+import Cardano.Ledger.Keys
+    ( KeyHash (KeyHash)
+    )
+import Cardano.Ledger.Val
+    ( inject
+    )
+import Cardano.Read.Ledger.Tx.Output
+    ( Output (..)
+    , upgradeToOutputConway
+    )
+import Cardano.Wallet.Read.Eras
+    ( Babbage
+    )
+import Cardano.Wallet.Read.Hash
+    ( hashFromBytesAsHex
+    )
+import Data.ByteString
+    ( ByteString
+    )
+import Data.Maybe
+    ( fromMaybe
+    )
+import Data.Word
+    ( Word16
+    )
+import Test.Hspec
+    ( Spec
+    , it
+    )
+import Test.QuickCheck
+    ( (.&&.)
+    , (=/=)
+    , (===)
+    )
+
+spec :: Spec
+spec =
+    it "Conway equalizes TxOut with invalid pointer addresses" $
+        (outputPtr1 =/= outputPtr2)
+        .&&.
+        (upgradeToOutputConway outputPtr1
+            === upgradeToOutputConway outputPtr2
+        )
+
+{-----------------------------------------------------------------------------
+    Pointer addresses
+------------------------------------------------------------------------------}
+outputPtr1 :: Output Babbage
+outputPtr1 = Output $ mkBasicTxOut addrInvalidPtr $ inject (Coin 13)
+
+outputPtr2 :: Output Babbage
+outputPtr2 = Output $ mkBasicTxOut addrNullPtr $ inject (Coin 13)
+
+addrInvalidPtr :: Addr StandardCrypto
+addrInvalidPtr =
+    Addr
+        Mainnet
+        paymentCred
+        (StakeRefPtr invalidPtr)
+  where
+    invalidPtr = Ptr (toEnum 0) (toEnum 0) (toEnum maxWord16plus3)
+    maxWord16plus3 :: Int
+    maxWord16plus3 = fromIntegral (maxBound :: Word16) + 3
+
+addrNullPtr :: Addr StandardCrypto
+addrNullPtr =
+    Addr
+        Mainnet
+        paymentCred
+        (StakeRefPtr nullPtr)
+  where
+    nullPtr = Ptr (toEnum 0) (toEnum 0) (toEnum 0)
+
+paymentCred :: PaymentCredential StandardCrypto
+paymentCred =
+    mkPaymentCred
+        "6505f8fa4e47723170d3e60bbc30d6ec406f368b1c84e1f75b0a8cba"
+
+mkPaymentCred :: ByteString -> PaymentCredential StandardCrypto
+mkPaymentCred =
+    KeyHashObj
+    . KeyHash
+    . fromMaybe (error "paymentCred: invalid hex length")
+    . hashFromBytesAsHex

--- a/lib/read/test/Cardano/Wallet/Read/Tx/TxOutSpec.hs
+++ b/lib/read/test/Cardano/Wallet/Read/Tx/TxOutSpec.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Wallet.Read.Tx.TxOutSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Ledger.Address
+    ( Addr (Addr)
+    )
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    , mkBasicTxOut
+    )
+import Cardano.Ledger.BaseTypes
+    ( Network (Mainnet)
+    )
+import Cardano.Ledger.Credential
+    ( Credential (KeyHashObj)
+    , PaymentCredential
+    , StakeReference (StakeRefNull)
+    )
+import Cardano.Ledger.Keys
+    ( KeyHash (KeyHash)
+    )
+import Cardano.Read.Ledger.Tx.Output
+    ( Output (..)
+    )
+import Cardano.Wallet.Read.Eras
+    ( Era (..)
+    , EraValue (..)
+    , IsEra (theEra)
+    , knownEras
+    )
+import Cardano.Wallet.Read.Hash
+    ( hashFromBytesAsHex
+    )
+import Cardano.Wallet.Read.Tx.TxOut
+    ( TxOut
+    , getValue
+    , mkEraTxOut
+    , upgradeTxOutToBabbageOrLater
+    )
+import Cardano.Wallet.Read.Value
+    ( Coin (CoinC)
+    , Value (getCoin)
+    , injectCoin
+    , toMaryValue
+    )
+import Data.ByteString
+    ( ByteString
+    )
+import Data.Maybe
+    ( fromMaybe
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    )
+import Test.QuickCheck
+    ( Gen
+    , arbitrary
+    , elements
+    , forAll
+    , getPositive
+    , vectorOf
+    , (===)
+    )
+
+import qualified Data.ByteString.Char8 as B8
+
+spec :: Spec
+spec =
+    describe "upgradeTxOutToBabbageOrLater" $
+        it "preserves getEraValue" $
+            forAll genTxOut $ \txout ->
+                getValue txout
+                === getValue (upgradeTxOutToBabbageOrLater txout)
+
+{-----------------------------------------------------------------------------
+    Generators
+------------------------------------------------------------------------------}
+
+genAddr :: Gen (Addr StandardCrypto)
+genAddr = mkAddr . mkPaymentCred . B8.pack
+    <$> vectorOf (2*28) (elements $ ['0'..'9'] <> ['a'..'f'])
+
+genValue :: Gen Value
+genValue = injectCoin . CoinC . getPositive <$> arbitrary
+
+genNonByronEra :: Gen (EraValue Era)
+genNonByronEra = elements (tail knownEras)
+
+genTxOut :: Gen TxOut
+genTxOut = do
+    EraValue (_ :: Era era) <- genNonByronEra
+    (output :: Output era) <- mkBasicOutput <$> genAddr <*> genValue
+    pure $ mkEraTxOut output
+
+{-----------------------------------------------------------------------------
+    Constructors
+------------------------------------------------------------------------------}
+mkBasicOutput
+    :: forall era. IsEra era
+    => Addr StandardCrypto -> Value -> Output era
+mkBasicOutput addr value = case theEra :: Era era of
+    Byron -> error "not implemented"
+    Shelley -> Output $ mkBasicTxOut addr (getCoin value)
+    Allegra -> Output $ mkBasicTxOut addr (getCoin value)
+    Mary -> Output $ mkBasicTxOut addr (toMaryValue value)
+    Alonzo -> Output $ mkBasicTxOut addr (toMaryValue value)
+    Babbage -> Output $ mkBasicTxOut addr (toMaryValue value)
+    Conway -> Output $ mkBasicTxOut addr (toMaryValue value)
+
+mkPaymentCred :: ByteString -> PaymentCredential StandardCrypto
+mkPaymentCred =
+    KeyHashObj
+    . KeyHash
+    . fromMaybe (error "paymentCred: invalid hex length")
+    . hashFromBytesAsHex
+
+mkAddr :: PaymentCredential StandardCrypto -> Addr StandardCrypto
+mkAddr x = Addr Mainnet x StakeRefNull


### PR DESCRIPTION
This pull request adds a type `TxOut` to `Cardano.Wallet.Read.Tx.TxOut`.

The type `TxOut` occupies the following point in the design space:

* `TxOut` is era-*independent* — a value of this type can be any transaction output from a past era.
* `TxOut` can — in principle — be deconstructed using functions from the latest or next era. This is possible because transaction outputs are upwards-compatible.
* `TxOut` can be serialized and deserialized to a format that is close to the ledger CBOR. However, we allow `serialize . deserialize ≠ id` in order to allow internal era upgrades.

The above design choices can be realized with different internal representations. We choose the following:

*  `TxOut` is represented as a disjoint sum of `Output era`.
* `TxOut` supports explicit an upgrade to `Output era` where `era` is the latest or next era — but this conversion is not zero-cost.

### Comments

* In addition to deconstruction, we also provide a constructor `mkBasicTxOut` for convenience and testing.

### Issue Number

ADP-3215