### PR TITLE
[ADP-3391] Use special name for windows namedpipe in the unit tests

### DIFF
--- a/lib/benchmarks/exe/latency-bench.hs
+++ b/lib/benchmarks/exe/latency-bench.hs
@@ -104,6 +104,9 @@ import Cardano.Wallet.Launch.Cluster
 import Cardano.Wallet.Launch.Cluster.CommandLine
     ( clusterConfigsDirParser
     )
+import Cardano.Wallet.Launch.Cluster.Config
+    ( OsNamedPipe (..)
+    )
 import Cardano.Wallet.Launch.Cluster.FileOf
     ( DirOf (..)
     , FileOf (..)
@@ -717,7 +720,8 @@ withShelleyServer tracers action = withFaucet $ \faucetClientEnv -> do
                             , cfgNodeOutputFile = Nothing
                             , cfgRelayNodePath = mkRelDirOf "relay"
                             , cfgClusterLogFile = Nothing
-                            , cfgNodeToClientSocket = FileOf $ absFile socket
+                            , cfgNodeToClientSocket = UnixPipe
+                                $ FileOf $ absFile socket
                             }
                 withCluster
                     clusterConfig

--- a/lib/launcher/src/Cardano/Launcher/Node.hs
+++ b/lib/launcher/src/Cardano/Launcher/Node.hs
@@ -24,6 +24,7 @@ module Cardano.Launcher.Node
 
       -- * Helpers
     , nodeSocketPath
+    , mkWindowsPipeName
     ) where
 
 import Prelude

--- a/lib/local-cluster/exe/local-cluster.hs
+++ b/lib/local-cluster/exe/local-cluster.hs
@@ -24,6 +24,9 @@ import Cardano.Wallet.Launch.Cluster.CommandLine
     , WalletPresence (..)
     , parseCommandLineOptions
     )
+import Cardano.Wallet.Launch.Cluster.Config
+    ( OsNamedPipe (..)
+    )
 import Cardano.Wallet.Launch.Cluster.Faucet.Serialize
     ( retrieveFunds
     )
@@ -271,9 +274,11 @@ main = withUtf8 $ do
 
         debug "Creating cluster configuration"
         clusterCfg <- do
-            socketPath <- case nodeToClientSocket of
+            -- ATM, only unix is supported
+            socketPath <- fmap UnixPipe $ case nodeToClientSocket of
                 Just path -> pure path
-                Nothing -> FileOf . absFile <$> ContT withTempFile
+                Nothing ->
+                    FileOf . absFile <$> ContT withTempFile
             clusterEra <- liftIO Cluster.clusterEraFromEnv
             cfgNodeLogging <-
                 liftIO

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Config.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Config.hs
@@ -6,7 +6,8 @@ module Cardano.Wallet.Launch.Cluster.Config
     ( Config (..)
     , ShelleyGenesisModifier
     , TestnetMagic (..)
-
+    , OsNamedPipe (..)
+    , filePathOfOsNamedPipe
     )
 where
 
@@ -28,6 +29,8 @@ import Cardano.Wallet.Launch.Cluster.FileOf
     ( DirOf
     , FileOf
     , RelDirOf
+    , absFileOf
+    , toFilePath
     )
 import Cardano.Wallet.Launch.Cluster.Logging
     ( ClusterLog (..)
@@ -48,6 +51,15 @@ newtype TestnetMagic = TestnetMagic {testnetMagicToNatural :: Natural}
 
 type ShelleyGenesisModifier =
     ShelleyGenesis StandardCrypto -> ShelleyGenesis StandardCrypto
+
+data OsNamedPipe
+    = UnixPipe (FileOf "node-to-client-socket")
+    | WindowsPipe FilePath
+    deriving stock (Show)
+
+filePathOfOsNamedPipe :: OsNamedPipe -> FilePath
+filePathOfOsNamedPipe (UnixPipe f) = toFilePath $ absFileOf f
+filePathOfOsNamedPipe (WindowsPipe f) = f
 
 data Config = Config
     { cfgStakePools :: NonEmpty PoolRecipe
@@ -71,5 +83,5 @@ data Config = Config
     -- ^ Path segment for relay node.
     , cfgClusterLogFile :: Maybe (FileOf "cluster-logs")
     -- ^ File to write cluster logs to.
-    , cfgNodeToClientSocket :: FileOf "node-to-client-socket"
+    , cfgNodeToClientSocket :: OsNamedPipe
     }

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/NodeParams.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/NodeParams.hs
@@ -18,6 +18,9 @@ import Cardano.Launcher.Node
 import Cardano.Wallet.Launch.Cluster.ClusterEra
     ( ClusterEra (BabbageHardFork)
     )
+import Cardano.Wallet.Launch.Cluster.Config
+    ( OsNamedPipe
+    )
 import Cardano.Wallet.Launch.Cluster.FileOf
     ( DirOf (..)
     , FileOf (..)
@@ -42,7 +45,7 @@ data NodeParams d = NodeParams
     -- config. This option can set the minimum severity and add another output
     -- file.
     , nodeParamsOutputFile :: Maybe (FileOf "node-output")
-    , nodeSocket :: MaybeK d (FileOf "node-to-client-socket")
+    , nodeSocket :: MaybeK d OsNamedPipe
     }
     deriving stock (Show)
 
@@ -51,7 +54,7 @@ singleNodeParams
     -> Severity
     -> Maybe (DirOf "node-logs", Severity)
     -> Maybe (FileOf "node-output")
-    -> MaybeK d (FileOf "node-to-client-socket")
+    -> MaybeK d OsNamedPipe
     -> NodeParams d
 singleNodeParams genesisFiles severity extraLogFile =
     NodeParams genesisFiles BabbageHardFork (0, []) LogFileConfig

--- a/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/Relay.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Launch/Cluster/Node/Relay.hs
@@ -20,9 +20,11 @@ import Cardano.Wallet.Launch.Cluster.ClusterM
     , askNodeDir
     , bracketTracer'
     )
+import Cardano.Wallet.Launch.Cluster.Config
+    ( filePathOfOsNamedPipe
+    )
 import Cardano.Wallet.Launch.Cluster.FileOf
     ( DirOf (..)
-    , FileOf (..)
     , RelDirOf (..)
     , absFilePathOf
     , toFilePath
@@ -116,7 +118,7 @@ withRelayNode params (RelDirOf nodeSegment) onClusterStart = do
                     , nodeExecutable = Nothing
                     , nodeOutputFile = absFilePathOf
                         <$> nodeParamsOutputFile params
-                    , nodeSocketPathFile = fmap (toFilePath . absFileOf) socket
+                    , nodeSocketPathFile = fmap filePathOfOsNamedPipe socket
                     }
 
         let onClusterStart' (JustK (socketPath)) = onClusterStart


### PR DESCRIPTION
- [x] Add discrimination between windows and unix named pipe paths in the local-cluster config
- [x] Fix named pipe name in tests in case of windows OS

fixed test: https://github.com/cardano-foundation/cardano-wallet/actions/runs/10091399690/job/27903177938#step:3:6581

ADP-3391 