### PR TITLE
[ADP-2565] Make `runSqlM` atomic

### DIFF
--- a/lib/delta-table/delta-table.cabal
+++ b/lib/delta-table/delta-table.cabal
@@ -48,7 +48,7 @@ library
     , containers
     , delta-store
     , delta-types
-    , exceptions
+    , io-classes
     , Only == 0.1
     , sqlite-simple
     , text

--- a/lib/delta-table/delta-table.cabal
+++ b/lib/delta-table/delta-table.cabal
@@ -68,6 +68,7 @@ library
       Database.Table.SQL.Table
       Database.Table.SQL.Var
       Database.Table.SQLite.Simple.Exec
+      Database.Table.SQLite.Simple.Monad
 
 test-suite unit
   import:             language, opts-exe

--- a/lib/delta-table/src/Database/Table/SQLite/Simple.hs
+++ b/lib/delta-table/src/Database/Table/SQLite/Simple.hs
@@ -14,6 +14,7 @@ module Database.Table.SQLite.Simple
     (
       module Database.Table.SQL.Table
     , module Database.Table.SQL.Expr
+    , module Database.Table.SQLite.Simple.Monad
     , module Database.Table.SQLite.Simple.Exec
     , module Database.Table.SQL.Column
     ) where
@@ -22,3 +23,4 @@ import Database.Table.SQL.Column
 import Database.Table.SQL.Expr
 import Database.Table.SQL.Table
 import Database.Table.SQLite.Simple.Exec
+import Database.Table.SQLite.Simple.Monad

--- a/lib/delta-table/src/Database/Table/SQLite/Simple/Monad.hs
+++ b/lib/delta-table/src/Database/Table/SQLite/Simple/Monad.hs
@@ -89,6 +89,7 @@ withConnection s = bracket (open s) close
 -}
 newtype SqlM a = SqlM (ReaderT Sqlite.Connection IO a)
     deriving newtype (Functor, Applicative, Monad)
+    deriving newtype (MonadThrow, MonadCatch)
 
 {- | Atomically run a computation from the 'SqlM' monad.
 

--- a/lib/delta-table/src/Database/Table/SQLite/Simple/Monad.hs
+++ b/lib/delta-table/src/Database/Table/SQLite/Simple/Monad.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+{- |
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+Monad for atomic SQLite operations.
+-}
+module Database.Table.SQLite.Simple.Monad
+    ( -- * SQL Connection
+      Connection
+    , open
+    , close
+    , withConnection
+
+    -- * SQL monad
+    , SqlM
+    , runSqlM
+    , rawSqlite
+    ) where
+
+import Prelude
+
+import Control.Concurrent.MVar
+    ( MVar
+    , newMVar
+    , withMVar
+    )
+import Control.Monad.Class.MonadThrow
+    ( MonadCatch (..)
+    , MonadThrow (..)
+    )
+import Control.Monad.Trans.Reader
+    ( ReaderT (..)
+    )
+
+import qualified Database.SQLite.Simple as Sqlite
+
+{-------------------------------------------------------------------------------
+    SQL Connection
+-------------------------------------------------------------------------------}
+-- | A connection to an SQLite
+data Connection = Connection
+    { filepath :: FilePath
+    , connection :: Sqlite.Connection
+    , lock :: MVar ()
+    }
+
+{-| Equivalent of 'Sqlite.open'.
+
+Open a database connection to a given file.
+Will throw an exception if it cannot connect.
+
+Every 'open' must be closed with a call to 'close'.
+
+If you specify ":memory:" or an empty string as the input filename,
+then a private, temporary in-memory database is created for the connection.
+This database will vanish when you close the connection.
+-}
+open :: FilePath -> IO Connection
+open filepath = do
+    connection <- Sqlite.open filepath
+    lock <- newMVar ()
+    pure $ Connection{filepath, connection, lock}
+
+-- | Equivalent of 'Sqlite.close'.
+-- Close a database connection.
+close :: Connection -> IO ()
+close Connection{connection} = Sqlite.close connection
+
+-- | Equivalent of 'Sqlite.withConnection'.
+--
+-- Opens a database connection, executes an action using this connection,
+-- and closes the connection, even in the presence of exceptions.
+withConnection :: FilePath -> (Connection -> IO a) -> IO a
+withConnection s = bracket (open s) close
+
+{-------------------------------------------------------------------------------
+    SQL monad
+-------------------------------------------------------------------------------}
+{- | Monad for database operations.
+--
+-- This monad includes the following effects:
+--
+-- * mutable state (of the database)
+-- * exceptions
+-}
+newtype SqlM a = SqlM (ReaderT Sqlite.Connection IO a)
+    deriving newtype (Functor, Applicative, Monad)
+
+{- | Atomically run a computation from the 'SqlM' monad.
+
+* exceptions — The change to the database state performed by 'SqlM'
+  completes either fully or not at all.
+  If the computation throws an exception, then any intermediate
+  state change is rolled back.
+  (Essentially, the computation is wrapped in 'Sqlite.withTransaction'.)
+* concurrency — A lock ensures that multiple calls to 'runSqlM'
+  are run in sequence.
+-}
+runSqlM :: SqlM a -> Connection -> IO a
+runSqlM (SqlM action) Connection{lock,connection} =
+    withMVar lock $ \_ ->
+        Sqlite.withTransaction connection $
+            runReaderT action connection
+
+-- | Wrap a function from "Database.SQLite.Simple" in 'SqlM'.
+rawSqlite :: (Sqlite.Connection -> IO a) -> SqlM a
+rawSqlite = SqlM . ReaderT


### PR DESCRIPTION
This pull request changes the semantics of `runSqlM` to become

* atomic in the presence of exceptions
* atomic in the presence of concurrency

This makes the `SqlM` monad less error-prone and more convenient to use, but disallows some performance techniques, such as SQL savepoints or concurrent access to the SQLite database. However, we need to wrap the monad in a less error-prone interface anyway, and we can always attempt to reintroduce these techniques later, so the gain in convenience is worth the trade now.

This pull request also exposes the exception effect in the `SqlM` monad explicitly by exposing standard functions such as `throw` and `catch`.

### Comments

* I have skipped extensive property testing for now, as I want to stabilize the API first. The module `Demo.Database` provides a basic functionality check.

### Issue Number

ADP-2565
