### PR TITLE
[ADP-3389] Skip deleted artifacts when collecting benchmark history

### DIFF
--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -281,6 +281,7 @@ executable benchmark-history
     , http-client
     , http-client-tls
     , http-media
+    , http-types
     , monoidal-containers
     , optparse-applicative
     , pretty-simple


### PR DESCRIPTION
This PR is about not blowing up during benchmark result collections when the result artifacts were deleted.

- [x] Accept a 410 status when getting an artifact and interpret it as a skip the result action

ADP-3389 