### PR TITLE
[ADP-2565] Use `Database.Table.SQLite.Simple` in Deposit Wallet

### DIFF
--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -58,11 +58,11 @@ library
     , contra-tracer
     , customer-deposit-wallet-pure
     , delta-store
+    , delta-table
     , delta-types
     , io-classes
     , iohk-monitoring-extra
     , OddWord
-    , persistent
     , sqlite-simple
     , text
     , transformers

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/DB.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/DB.hs
@@ -1,76 +1,61 @@
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE Rank2Types #-}
 module Cardano.Wallet.Deposit.IO.DB
-    ( SqlM
-    , SqlContext (..)
+    ( Connection
     , withSqliteFile
-    , withSqlContextInMemory
+    , withSqliteInMemory
+
+    , SqlM
+    , runSqlM
 
     , DBLog (..)
     ) where
 
 import Prelude
 
-import Cardano.BM.Extra
-    ( bracketTracer
-    )
-import Cardano.DB.Sqlite
-    ( DBLog (..)
-    )
-import Control.Concurrent.MVar
-    ( newMVar
-    , withMVar
-    )
-import Control.Monad.Trans.Reader
-    ( ReaderT (..)
-    )
 import Control.Tracer
     ( Tracer
-    , contramap
     , traceWith
     )
-
-import qualified Database.SQLite.Simple as Sqlite
+import Database.Table.SQLite.Simple
+    ( Connection
+    , SqlM
+    , runSqlM
+    , withConnection
+    )
 
 {-----------------------------------------------------------------------------
     SqlContext
 ------------------------------------------------------------------------------}
--- | Monad to run SQL queries in.
-type SqlM = ReaderT Sqlite.Connection IO
-
--- | A facility to run 'SqlM' computations.
--- Importantly, computations are not run in parallel, but sequenced.
-newtype SqlContext = SqlContext
-    { runSqlM :: forall a. SqlM a -> IO a
-    }
-
--- | Acquire and release an 'SqlContext' in memory.
-withSqlContextInMemory
+-- | Acquire and release an SQLite 'Connection' in memory.
+withSqliteInMemory
     :: Tracer IO DBLog
     -- ^ Logging
-    -> (SqlContext -> IO a)
+    -> (Connection -> IO a)
     -- ^ Action to run
     -> IO a
-withSqlContextInMemory tr = withSqliteFile tr ":memory:"
+withSqliteInMemory tr = withSqliteFile tr ":memory:"
 
--- | Use sqlite to open a database file
--- and provide an 'SqlContext' for running 'SqlM' actions.
+-- | Acquire and release an SQLite 'Connection' from a file.
 withSqliteFile
     :: Tracer IO DBLog
     -- ^ Logging
     -> FilePath
     -- ^ Database file
-    -> (SqlContext -> IO a)
+    -> (Connection -> IO a)
     -- ^ Action to run
     -> IO a
 withSqliteFile tr filepath action =
-    Sqlite.withConnection filepath $ \connection0 -> do
-        traceWith tr $ MsgOpenSingleConnection filepath
-        -- The lock ensures that database operations are sequenced.
-        lock <- newMVar connection0
-        let runSqlM :: SqlM a -> IO a
-            runSqlM cmd = withMVar lock (observe . runReaderT cmd)
-        action SqlContext{runSqlM}
-  where
-    observe :: IO a -> IO a
-    observe = bracketTracer (contramap MsgRun tr)
+    withConnection filepath $ \conn -> do
+        traceWith tr $ MsgStartConnection filepath
+        result <- action conn
+        traceWith tr $ MsgDoneConnection filepath
+        pure result
+
+{-------------------------------------------------------------------------------
+    Logging
+-------------------------------------------------------------------------------}
+
+data DBLog
+    = MsgStartConnection FilePath
+    | MsgDoneConnection FilePath
+    deriving (Show, Eq)

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
@@ -84,7 +84,7 @@ newNetworkEnvMock = do
             (block, tip) <- forgeBlock tx
             broadcast block tip
             -- brief delay to account for asynchronous chain followers
-            threadDelay 10
+            threadDelay 100
             pure $ Right ()
         }
 

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
@@ -30,10 +30,6 @@ import Prelude
 import Cardano.Crypto.Wallet
     ( XPrv
     )
-import Cardano.Wallet.Deposit.IO.DB
-    ( SqlContext (..)
-    , withSqlContextInMemory
-    )
 import Cardano.Wallet.Deposit.IO.Network.Mock
     ( newNetworkEnvMock
     )
@@ -92,18 +88,15 @@ withWalletEnvMock
     :: ScenarioEnv
     -> (Wallet.WalletEnv IO -> IO a)
     -> IO a
-withWalletEnvMock ScenarioEnv{..} action =
-    withSqlContextInMemory nullTracer
-        $ \SqlContext{runSqlM} -> do
-            database <- runSqlM newStore
-            let walletEnv = Wallet.WalletEnv
-                    { Wallet.logger = nullTracer
-                    , Wallet.genesisData = genesisData
-                    , Wallet.networkEnv = networkEnv
-                    , Wallet.database = database
-                    , Wallet.atomically = runSqlM
-                    }
-            action walletEnv
+withWalletEnvMock ScenarioEnv{..} action = do
+    database <- newStore
+    let walletEnv = Wallet.WalletEnv
+            { Wallet.logger = nullTracer
+            , Wallet.genesisData = genesisData
+            , Wallet.networkEnv = networkEnv
+            , Wallet.database = database
+            }
+    action walletEnv
 
 {-----------------------------------------------------------------------------
     Faucet


### PR DESCRIPTION
This pull request changes the Deposit Wallet to use the database functionality from `Database.Table.SQLite.Simple`.

At the moment, this actually means removing all database usage from the Deposit Wallet — the mock environment does not need it, and also cannot use it, as the `SqlM` monad is not an instance of `MonadSTM`. (For good reason: The `SqlM` monad meant to represent atomic database operations and is **not** an instance of `MonadIO`).

However, I want to keep the module `Cardano.Wallet.Deposit.IO.DB` around as a small indirection over `Database.Table.SQLite.Simple`.

### Issue Number

ADP-2565