### PR TITLE
[ADP-3215] Clean up imports in `read`

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Handlers/TxCBOR.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Handlers/TxCBOR.hs
@@ -65,10 +65,8 @@ import Cardano.Wallet.Read
     )
 import Cardano.Wallet.Read.Eras
     ( K (..)
+    , applyEraFun
     , (:*:) (..)
-    )
-import Cardano.Wallet.Read.Eras.EraFun
-    ( applyEraFun
     )
 import Cardano.Wallet.Transaction
     ( TokenMapWithScripts

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Block/Header.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Block/Header.hs
@@ -12,9 +12,7 @@ module Cardano.Wallet.Primitive.Ledger.Read.Block.Header
     )
 where
 
-import Prelude hiding
-    ( (.)
-    )
+import Prelude
 
 import Cardano.Crypto.Hash.Class
     ( hashToBytes
@@ -51,9 +49,6 @@ import Cardano.Wallet.Read
     )
 import Cardano.Wallet.Read.Eras.EraFun
     ( applyEraFun
-    )
-import Control.Category
-    ( (.)
     )
 import Data.Coerce
     ( coerce

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Certificates.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Certificates.hs
@@ -16,9 +16,7 @@ module Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Certificates
     )
 where
 
-import Prelude hiding
-    ( (.)
-    )
+import Prelude
 
 import Cardano.Crypto.Hash.Class
     ( hashToBytes
@@ -70,9 +68,6 @@ import Cardano.Wallet.Read.Eras
     )
 import Cardano.Wallet.Util
     ( internalError
-    )
-import Control.Category
-    ( (.)
     )
 import Data.Foldable
     ( toList

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Integrity.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Features/Integrity.hs
@@ -16,9 +16,7 @@ module Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Integrity
 
  where
 
-import Prelude hiding
-    ( (.)
-    )
+import Prelude
 
 import Cardano.Ledger.Alonzo.Tx
     ( ScriptIntegrityHash
@@ -41,9 +39,6 @@ import Cardano.Wallet.Read.Eras
     )
 import Cardano.Wallet.Read.Tx
     ( Tx
-    )
-import Control.Category
-    ( (.)
     )
 import Data.Maybe.Strict
     ( StrictMaybe

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Sealed.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx/Sealed.hs
@@ -22,12 +22,10 @@ import Cardano.Read.Ledger.Tx.Cardano
 import Cardano.Wallet.Primitive.Types.Tx.SealedTx
     ( SealedTx (unsafeCardanoTx)
     )
-import Cardano.Wallet.Read.Eras
+import Cardano.Wallet.Read
     ( EraValue
+    , Tx
     , applyEraFun
-    )
-import Cardano.Wallet.Read.Tx
-    ( Tx (..)
     )
 
 import qualified Cardano.Wallet.Primitive.Types.Tx.SealedTx as W

--- a/lib/read/lib/Cardano/Read/Ledger/Block/BHeader.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Block/BHeader.hs
@@ -34,12 +34,10 @@ import Cardano.Wallet.Read.Eras
     , Babbage
     , Byron
     , Conway
+    , Era (..)
+    , IsEra (..)
     , Mary
     , Shelley
-    )
-import Cardano.Wallet.Read.Eras.KnownEras
-    ( Era (..)
-    , IsEra (..)
     )
 import GHC.Generics
     ( Generic

--- a/lib/read/lib/Cardano/Read/Ledger/Block/Block.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Block/Block.hs
@@ -30,15 +30,12 @@ import Cardano.Wallet.Read.Eras
     , Babbage
     , Byron
     , Conway
+    , Era (..)
     , EraValue (..)
-    , IsEra
+    , IsEra (..)
     , Mary
     , Shelley
     , eraValue
-    )
-import Cardano.Wallet.Read.Eras.KnownEras
-    ( Era (..)
-    , IsEra (..)
     )
 import Ouroboros.Consensus.Protocol.Praos
     ( Praos

--- a/lib/read/lib/Cardano/Read/Ledger/Block/HeaderHash.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Block/HeaderHash.hs
@@ -24,12 +24,12 @@ where
 
 import Prelude
 
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
 import Cardano.Ledger.Binary
     ( EncCBOR
     , EncCBORGroup
-    )
-import Cardano.Ledger.Crypto
-    ( StandardCrypto
     )
 import Cardano.Ledger.Era
     ( EraSegWits (..)

--- a/lib/read/lib/Cardano/Read/Ledger/Block/HeaderHash.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Block/HeaderHash.hs
@@ -49,13 +49,10 @@ import Cardano.Wallet.Read.Eras
     , Babbage
     , Byron
     , Conway
-    , IsEra
+    , Era (..)
+    , IsEra (..)
     , Mary
     , Shelley
-    )
-import Cardano.Wallet.Read.Eras.KnownEras
-    ( Era (..)
-    , IsEra (..)
     )
 import Cardano.Wallet.Read.Hash
     ( Blake2b_256

--- a/lib/read/lib/Cardano/Read/Ledger/Block/SlotNo.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Block/SlotNo.hs
@@ -15,7 +15,7 @@ import Prelude
 import Cardano.Read.Ledger.Block.BHeader
     ( BHeader (..)
     )
-import Cardano.Wallet.Read.Eras.KnownEras
+import Cardano.Wallet.Read.Eras
     ( Era (..)
     , IsEra (..)
     )

--- a/lib/read/lib/Cardano/Read/Ledger/Block/Txs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Block/Txs.hs
@@ -17,9 +17,7 @@ import Cardano.Read.Ledger.Block.Block
     )
 import Cardano.Wallet.Read.Eras
     ( Byron
-    )
-import Cardano.Wallet.Read.Eras.KnownEras
-    ( Era (..)
+    , Era (..)
     , IsEra (..)
     )
 import Cardano.Wallet.Read.Tx

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/CBOR.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/CBOR.hs
@@ -42,18 +42,15 @@ import Cardano.Ledger.Binary.Decoding
     , shelleyProtVer
     )
 import Cardano.Wallet.Read.Eras
-    ( EraValue
-    , IsEra
+    ( Era (..)
+    , EraValue
+    , IsEra (..)
     , K (..)
     , applyEraFunValue
     , extractEraValue
     , sequenceEraValue
     , unK
     , (:.:) (..)
-    )
-import Cardano.Wallet.Read.Eras.KnownEras
-    ( Era (..)
-    , IsEra (..)
     )
 import Cardano.Wallet.Read.Tx
     ( Tx (..)

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Cardano.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Cardano.hs
@@ -15,16 +15,14 @@ module Cardano.Read.Ledger.Tx.Cardano
 import Prelude
 
 import Cardano.Wallet.Read.Eras
-    ( EraValue
-    , eraValue
-    )
-import Cardano.Wallet.Read.Eras.KnownEras
     ( Allegra
     , Alonzo
     , Babbage
     , Conway
+    , EraValue
     , Mary
     , Shelley
+    , eraValue
     )
 import Cardano.Wallet.Read.Tx
     ( Tx (..)

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Certificates.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Certificates.hs
@@ -24,14 +24,12 @@ module Cardano.Read.Ledger.Tx.Certificates
 import Prelude
 
 import Cardano.Ledger.Api
-    ( bodyTxL
+    ( StandardCrypto
+    , bodyTxL
     , certsTxBodyL
     )
 import Cardano.Ledger.Conway.TxCert
     ( ConwayTxCert
-    )
-import Cardano.Ledger.Crypto
-    ( StandardCrypto
     )
 import Cardano.Ledger.Shelley.TxCert
     ( ShelleyTxCert

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/CollateralInputs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/CollateralInputs.hs
@@ -24,13 +24,11 @@ module Cardano.Read.Ledger.Tx.CollateralInputs
 import Prelude
 
 import Cardano.Ledger.Api
-    ( collateralInputsTxBodyL
+    ( StandardCrypto
+    , collateralInputsTxBodyL
     )
 import Cardano.Ledger.Core
     ( bodyTxL
-    )
-import Cardano.Ledger.Crypto
-    ( StandardCrypto
     )
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/CollateralOutputs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/CollateralOutputs.hs
@@ -23,6 +23,9 @@ module Cardano.Read.Ledger.Tx.CollateralOutputs
 
 import Prelude
 
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
 import Cardano.Ledger.Babbage.Collateral
     ()
 import Cardano.Ledger.Babbage.Rules
@@ -35,9 +38,6 @@ import Cardano.Ledger.Babbage.TxBody
     )
 import Cardano.Ledger.Core
     ( bodyTxL
-    )
-import Cardano.Ledger.Crypto
-    ( StandardCrypto
     )
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/ExtraSigs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/ExtraSigs.hs
@@ -21,11 +21,11 @@ import Prelude
 import Cardano.Ledger.Alonzo.TxBody
     ( reqSignerHashesTxBodyL
     )
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
 import Cardano.Ledger.Core
     ( bodyTxL
-    )
-import Cardano.Ledger.Crypto
-    ( StandardCrypto
     )
 import Cardano.Ledger.Keys
     ( KeyHash

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Inputs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Inputs.hs
@@ -21,12 +21,12 @@ module Cardano.Read.Ledger.Tx.Inputs
 
 import Prelude
 
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
 import Cardano.Ledger.Core
     ( bodyTxL
     , inputsTxBodyL
-    )
-import Cardano.Ledger.Crypto
-    ( StandardCrypto
     )
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Integrity.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Integrity.hs
@@ -29,11 +29,11 @@ import Cardano.Ledger.Alonzo.Tx
 import Cardano.Ledger.Alonzo.TxBody
     ( scriptIntegrityHashTxBodyL
     )
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
 import Cardano.Ledger.Core
     ( bodyTxL
-    )
-import Cardano.Ledger.Crypto
-    ( StandardCrypto
     )
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Mint.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Mint.hs
@@ -23,11 +23,11 @@ module Cardano.Read.Ledger.Tx.Mint
 
 import Prelude
 
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
 import Cardano.Ledger.Core
     ( bodyTxL
-    )
-import Cardano.Ledger.Crypto
-    ( StandardCrypto
     )
 import Cardano.Ledger.Mary.Core
     ( mintTxBodyL

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/ReferenceInputs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/ReferenceInputs.hs
@@ -23,14 +23,14 @@ module Cardano.Read.Ledger.Tx.ReferenceInputs
 
 import Prelude
 
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
 import Cardano.Ledger.Babbage.TxBody
     ( referenceInputsTxBodyL
     )
 import Cardano.Ledger.Core
     ( bodyTxL
-    )
-import Cardano.Ledger.Crypto
-    ( StandardCrypto
     )
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/TxId.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/TxId.hs
@@ -20,12 +20,12 @@ import Cardano.Chain.UTxO
 import Cardano.Crypto.Hashing
     ( serializeCborHash
     )
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
 import Cardano.Ledger.Core
     ( bodyTxL
     , txIdTxBody
-    )
-import Cardano.Ledger.Crypto
-    ( StandardCrypto
     )
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Withdrawals.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Withdrawals.hs
@@ -28,15 +28,15 @@ import Cardano.Ledger.Address
     ( RewardAccount
     , unWithdrawals
     )
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
 import Cardano.Ledger.Coin
     ( Coin
     )
 import Cardano.Ledger.Core
     ( bodyTxL
     , withdrawalsTxBodyL
-    )
-import Cardano.Ledger.Crypto
-    ( StandardCrypto
     )
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Witnesses.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Witnesses.hs
@@ -40,12 +40,10 @@ import Cardano.Wallet.Read.Eras
     , Babbage
     , Byron
     , Conway
+    , Era (..)
+    , IsEra (..)
     , Mary
     , Shelley
-    )
-import Cardano.Wallet.Read.Eras.KnownEras
-    ( Era (..)
-    , IsEra (..)
     )
 import Cardano.Wallet.Read.Tx
     ( Tx (..)

--- a/lib/read/lib/Cardano/Read/Ledger/Value.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Value.hs
@@ -20,7 +20,7 @@ module Cardano.Read.Ledger.Value
 
 import Prelude
 
-import Cardano.Ledger.Crypto
+import Cardano.Ledger.Api
     ( StandardCrypto
     )
 import Cardano.Wallet.Read.Eras

--- a/lib/read/lib/Cardano/Wallet/Read/Block.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block.hs
@@ -15,11 +15,11 @@ module Cardano.Wallet.Read.Block
     ) where
 
 import Cardano.Read.Ledger.Block.BHeader
-    ( BHeader (..)
+    ( BHeader
     , getEraBHeader
     )
 import Cardano.Read.Ledger.Block.Block
-    ( Block (..)
+    ( Block
     , ConsensusBlock
     , fromConsensusBlock
     , toConsensusBlock
@@ -31,10 +31,8 @@ import Cardano.Read.Ledger.Block.BlockNo
     )
 import Cardano.Read.Ledger.Block.HeaderHash
     ( EraIndependentBlockHeader
-    , HeaderHash (..)
-    , HeaderHashT
-    , PrevHeaderHash (..)
-    , PrevHeaderHashT
+    , HeaderHash
+    , PrevHeaderHash
     , RawHeaderHash
     , getEraHeaderHash
     , getEraPrevHeaderHash

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Gen.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Gen.hs
@@ -5,9 +5,7 @@
 
 module Cardano.Wallet.Read.Block.Gen where
 
-import Prelude hiding
-    ( (.)
-    )
+import Prelude
 
 import Cardano.Ledger.BaseTypes
     ( natVersion
@@ -30,9 +28,6 @@ import Cardano.Wallet.Read.Block.Gen.Shelley
 import Cardano.Wallet.Read.Eras
     ( Era (..)
     , IsEra (..)
-    )
-import Control.Category
-    ( (.)
     )
 
 {-# INLINABLE mkBlockEra #-}

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Gen.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Gen.hs
@@ -3,8 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Cardano.Wallet.Read.Block.Gen
-where
+module Cardano.Wallet.Read.Block.Gen where
 
 import Prelude hiding
     ( (.)
@@ -13,7 +12,7 @@ import Prelude hiding
 import Cardano.Ledger.BaseTypes
     ( natVersion
     )
-import Cardano.Wallet.Read.Block
+import Cardano.Read.Ledger.Block.Block
     ( Block (..)
     )
 import Cardano.Wallet.Read.Block.Gen.Babbage

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Gen/Babbage.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Gen/Babbage.hs
@@ -21,6 +21,9 @@ import Cardano.Crypto.VRF
     ( CertifiedVRF (CertifiedVRF)
     , VRFAlgorithm (..)
     )
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
 import Cardano.Ledger.BaseTypes
     ( ProtVer (..)
     )
@@ -62,9 +65,6 @@ import Ouroboros.Consensus.Protocol.Praos
 import Ouroboros.Consensus.Protocol.Praos.Header
     ( Header (..)
     , HeaderBody (..)
-    )
-import Ouroboros.Consensus.Protocol.TPraos
-    ( StandardCrypto
     )
 
 import qualified Cardano.Ledger.Core as L

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Gen/Build.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Gen/Build.hs
@@ -25,9 +25,7 @@ module Cardano.Wallet.Read.Block.Gen.Build
     )
 where
 
-import Prelude hiding
-    ( (.)
-    )
+import Prelude
 
 import Cardano.Ledger.Address
     ( serialiseAddr
@@ -79,9 +77,6 @@ import Cardano.Wallet.Read.Tx.TxId
     ( TxId
     , getTxId
     , txIdFromHash
-    )
-import Control.Category
-    ( (.)
     )
 import Control.Lens
     ( over

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Gen/Shelley.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Gen/Shelley.hs
@@ -46,6 +46,9 @@ import Cardano.Crypto.VRF
 import Cardano.Crypto.VRF.Praos
     ( PraosVRF
     )
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
 import Cardano.Ledger.BaseTypes
     ( ProtVer (..)
     , Version
@@ -94,8 +97,7 @@ import Ouroboros.Consensus.Protocol.Praos.Header
     ( Header (..)
     )
 import Ouroboros.Consensus.Protocol.TPraos
-    ( StandardCrypto
-    , TPraos
+    ( TPraos
     )
 
 import qualified Cardano.Crypto.DSIGN as Crypto

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Gen/Allegra.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Gen/Allegra.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.Allegra.TxBody
     , StrictMaybe (..)
     , ValidityInterval (..)
     )
-import Cardano.Ledger.Api.Era
+import Cardano.Ledger.Api
     ( AllegraEra
     , StandardCrypto
     )

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Gen/Alonzo.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Gen/Alonzo.hs
@@ -25,7 +25,7 @@ import Cardano.Ledger.Alonzo.TxBody
 import Cardano.Ledger.Alonzo.TxWits
     ( AlonzoTxWits
     )
-import Cardano.Ledger.Api.Era
+import Cardano.Ledger.Api
     ( AlonzoEra
     , StandardCrypto
     )

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Gen/Babbage.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Gen/Babbage.hs
@@ -20,10 +20,10 @@ import Cardano.Ledger.Alonzo.TxAuxData
     )
 import Cardano.Ledger.Api
     ( Datum (NoDatum)
+    , StandardCrypto
     )
 import Cardano.Ledger.Api.Era
     ( BabbageEra
-    , StandardCrypto
     )
 import Cardano.Ledger.Babbage.Tx
     ( AlonzoTx (AlonzoTx)

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Gen/Conway.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Gen/Conway.hs
@@ -21,10 +21,8 @@ import Cardano.Ledger.Alonzo.TxAuxData
     ( AuxiliaryDataHash
     )
 import Cardano.Ledger.Api
-    ( Datum (NoDatum)
-    )
-import Cardano.Ledger.Api.Era
     ( ConwayEra
+    , Datum (NoDatum)
     , StandardCrypto
     )
 import Cardano.Ledger.Api.Tx.In

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Gen/Mary.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Gen/Mary.hs
@@ -15,7 +15,7 @@ import Cardano.Ledger.Allegra.Core
 import Cardano.Ledger.Allegra.TxAuxData
     ( AllegraTxAuxData
     )
-import Cardano.Ledger.Api.Era
+import Cardano.Ledger.Api
     ( MaryEra
     , StandardCrypto
     )

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/Gen/Shelley.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/Gen/Shelley.hs
@@ -25,7 +25,7 @@ import Cardano.Crypto.Hash
 import Cardano.Ledger.Address
     ( Addr (..)
     )
-import Cardano.Ledger.Api.Era
+import Cardano.Ledger.Api
     ( Era
     , ShelleyEra
     , StandardCrypto

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/TxIn.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/TxIn.hs
@@ -21,7 +21,7 @@ module Cardano.Wallet.Read.Tx.TxIn
 
 import Prelude
 
-import Cardano.Ledger.Crypto
+import Cardano.Ledger.Api
     ( StandardCrypto
     )
 import Cardano.Wallet.Read.Tx.TxId

--- a/lib/read/lib/Cardano/Wallet/Read/Value.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Value.hs
@@ -37,11 +37,11 @@ import Prelude hiding
     ( subtract
     )
 
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
 import Cardano.Ledger.Coin
     ( Coin (unCoin)
-    )
-import Cardano.Ledger.Crypto
-    ( StandardCrypto
     )
 import Cardano.Ledger.Val
     ( pointwise

--- a/lib/unit/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -217,11 +217,9 @@ import Cardano.Wallet.Primitive.Types.Tx.TxOut.Gen
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..)
     )
-import Cardano.Wallet.Read.Eras.EraValue
+import Cardano.Wallet.Read.Eras
     ( eraValueSerialize
-    )
-import Cardano.Wallet.Read.Eras.KnownEras
-    ( knownEraIndices
+    , knownEraIndices
     )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Submissions/Layer.hs
@@ -28,9 +28,7 @@ module Cardano.Wallet.DB.Store.Submissions.Layer
     )
     where
 
-import Prelude hiding
-    ( (.)
-    )
+import Prelude
 
 import Cardano.Wallet.DB.Errors
     ( ErrNoSuchTransaction (..)
@@ -75,9 +73,6 @@ import Cardano.Wallet.Submissions.TxStatus
     )
 import Cardano.Wallet.Transaction.Built
     ( BuiltTx (..)
-    )
-import Control.Category
-    ( (.)
     )
 import Control.Lens
     ( has

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
@@ -29,9 +29,7 @@ module Cardano.Wallet.DB.Store.Transactions.Decoration
    , decorateTxInsForReadTxFromLookupTxOut
    ) where
 
-import Prelude hiding
-    ( (.)
-    )
+import Prelude
 
 import Cardano.Read.Ledger.Tx.CollateralInputs
     ( getEraCollateralInputs
@@ -66,9 +64,6 @@ import Cardano.Wallet.Read.Eras.EraFun
     )
 import Control.Applicative
     ( (<|>)
-    )
-import Control.Category
-    ( (.)
     )
 import Control.Monad
     ( guard

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Decoration.hs
@@ -58,9 +58,7 @@ import Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Inputs
     )
 import Cardano.Wallet.Read.Eras
     ( EraValue
-    )
-import Cardano.Wallet.Read.Eras.EraFun
-    ( applyEraFun
+    , applyEraFun
     )
 import Control.Applicative
     ( (<|>)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -10,9 +10,7 @@ module Cardano.Wallet.DB.Store.Transactions.TransactionInfo
     , mkTxCBOR
     ) where
 
-import Prelude hiding
-    ( (.)
-    )
+import Prelude
 
 import Cardano.Read.Ledger.Tx.CBOR
     ( TxCBOR
@@ -121,9 +119,6 @@ import Cardano.Wallet.Read.Eras
     )
 import Cardano.Wallet.Transaction
     ( ValidityIntervalExplicit (invalidHereafter)
-    )
-import Control.Category
-    ( (.)
     )
 import Data.Foldable
     ( fold


### PR DESCRIPTION
This pull request cleans up a few imports involving the `read` package. This is a pure refactoring — in fact, it's a pure rearranging of imports.

### Comment

* Despite being a no-op on the functionality, this pull request is important for internal structure. The idea is that we import an identifier, such as `IsEra`, from the highest level of abstraction that exports it. For instance, instead of importing `IsEra` from `Cardano.Wallet.Read.Eras.KnownEras`, we import it from the higher module `Cardano.Wallet.Read.Eras`. Following this scheme ensures that the highest module `Cardano.Wallet.Read.Eras` can act as an abstraction boundary, as we can now rearrange children of this module without affecting independent modules. In turn, a single qualified import of `Cardano.Wallet.Read.Eras` can now bring the entire abstraction into scope.

### Issue Number

ADP-3215