### PR TITLE
Increate timeout to 120 mins for sanchonet and preprod sync

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -197,7 +197,7 @@ steps:
       depends_on:
         - cardano-wallet
         - linux-sanchonet-full-sync-block
-      timeout_in_minutes: 30
+      timeout_in_minutes: 120
       command: |
         rm -rf run/sanchonet/nix/logs
         mkdir -p run/sanchonet/nix/logs
@@ -222,7 +222,7 @@ steps:
       depends_on:
         - cardano-wallet
         - linux-preprod-full-sync-block
-      timeout_in_minutes: 30
+      timeout_in_minutes: 120
       command: |
         cd run/preprod/nix
         rm -rf logs


### PR DESCRIPTION
Sanchonet and  Preprod are not syncing reliably in 30 mins. Probably depending on the current network throughput.
We bump the timeout to 120 mins.