### PR TITLE
[ADP-3215] Split `TxCBOR` serialization

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Handlers/TxCBOR.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Handlers/TxCBOR.hs
@@ -19,8 +19,7 @@ import Cardano.Binary
     ( DecoderError
     )
 import Cardano.Read.Ledger.Tx.CBOR
-    ( TxCBOR
-    , deserializeTx
+    ( deserializeTx
     )
 import Cardano.Read.Ledger.Tx.Certificates
     ( getEraCertificates
@@ -67,6 +66,9 @@ import Cardano.Wallet.Read.Eras
     ( K (..)
     , applyEraFun
     , (:*:) (..)
+    )
+import Cardano.Wallet.Read.Tx.CBOR
+    ( TxCBOR
     )
 import Cardano.Wallet.Transaction
     ( TokenMapWithScripts

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -168,9 +168,6 @@ import Cardano.Mnemonic
 import Cardano.Pool.Types
     ( PoolId
     )
-import Cardano.Read.Ledger.Tx.CBOR
-    ( TxCBOR
-    )
 import Cardano.Wallet
     ( BuiltTx (..)
     , DelegationFee (feePercentiles)
@@ -648,6 +645,9 @@ import Cardano.Wallet.Primitive.Types.Tx.TxMeta
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
+    )
+import Cardano.Wallet.Read.Tx.CBOR
+    ( TxCBOR
     )
 import Cardano.Wallet.Registry
     ( HasWorkerCtx (..)

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/Tx.hs
@@ -13,9 +13,6 @@ where
 
 import Prelude
 
-import Cardano.Read.Ledger.Tx.CBOR
-    ( renderTxToCBOR
-    )
 import Cardano.Read.Ledger.Tx.CollateralInputs
     ( getEraCollateralInputs
     )
@@ -73,6 +70,9 @@ import Cardano.Wallet.Read
     )
 import Cardano.Wallet.Read.Eras
     ( eraValue
+    )
+import Cardano.Wallet.Read.Tx.CBOR
+    ( renderTxToCBOR
     )
 import Data.Foldable
     ( fold

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Types/Tx/Tx.hs
@@ -47,9 +47,6 @@ import Cardano.Api
     , TxMetadata (..)
     , TxMetadataValue (..)
     )
-import Cardano.Read.Ledger.Tx.CBOR
-    ( TxCBOR
-    )
 import Cardano.Wallet.Orphans
     ()
 import Cardano.Wallet.Primitive.Types.AssetId
@@ -67,6 +64,9 @@ import Cardano.Wallet.Primitive.Types.Tx.TxIn
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
+    )
+import Cardano.Wallet.Read.Tx.CBOR
+    ( TxCBOR
     )
 import Control.DeepSeq
     ( NFData (..)

--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -87,6 +87,7 @@ library
     Cardano.Wallet.Read.Eras.EraValue
     Cardano.Wallet.Read.Hash
     Cardano.Wallet.Read.Tx
+    Cardano.Wallet.Read.Tx.CBOR
     Cardano.Wallet.Read.Tx.Gen
     Cardano.Wallet.Read.Tx.Gen.Address
     Cardano.Wallet.Read.Tx.Gen.Allegra

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/CBOR.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/CBOR.hs
@@ -1,27 +1,17 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
 
-{-# OPTIONS_GHC -Wno-orphans #-}
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{- |
+Copyright: © 2020-2022 IOHK, 2024 Cardano Foundation
+License: Apache-2.0
 
--- |
--- Copyright: © 2020-2022 IOHK
--- License: Apache-2.0
---
--- CBOR operations for era dependent transactions.
---
-
+Binary serialization of transactions.
+-}
 module Cardano.Read.Ledger.Tx.CBOR
-    ( TxCBOR
-    , renderTxToCBOR
-    , parseTxFromCBOR
-    , serializeTx
+    ( serializeTx
     , deserializeTx
-    , roundTripTxCBor
     )
     where
 
@@ -46,33 +36,13 @@ import Cardano.Read.Ledger.Eras
     , IsEra (..)
     )
 import Cardano.Wallet.Read.Eras
-    ( EraValue
-    , K (..)
-    , applyEraFunValue
-    , extractEraValue
-    , sequenceEraValue
+    ( K (..)
     , unK
     , (:.:) (..)
     )
 import Cardano.Wallet.Read.Tx
     ( Tx (..)
     , TxT
-    )
-import Data.ByteArray.Encoding
-    ( Base (Base16)
-    , convertToBase
-    )
-import Data.ByteString.Lazy
-    ( toStrict
-    )
-import Data.Text.Class
-    ( ToText
-    )
-import Data.Text.Encoding
-    ( decodeUtf8
-    )
-import Fmt
-    ( Buildable (..)
     )
 import Ouroboros.Consensus.Shelley.Eras
     ( StandardAllegra
@@ -86,20 +56,6 @@ import Ouroboros.Consensus.Shelley.Eras
 import qualified Cardano.Ledger.Binary.Encoding as Ledger
 import qualified Data.ByteString.Lazy as BL
 
--- | Serialized version of a transaction. Deserializing should at least expose
--- enough information to compute the `TxId`.
-type TxCBOR = EraValue (K BL.ByteString)
-
-instance Buildable TxCBOR where
-    build
-        = build . decodeUtf8 . convertToBase Base16 . toStrict . extractEraValue
-
-instance ToText TxCBOR
-
--- | Render a tx into its cbor, it just applies 'serializeTx'.
-renderTxToCBOR :: EraValue Tx -> EraValue (K BL.ByteString)
-renderTxToCBOR = applyEraFunValue serializeTx
-
 {-# INLINABLE serializeTx #-}
 -- | CBOR serialization of a tx in any era.
 serializeTx :: forall era . IsEra era => Tx era -> K BL.ByteString era
@@ -111,20 +67,15 @@ serializeTx = case theEra @era of
     Alonzo -> f (eraProtVerLow @StandardAlonzo)
     Babbage -> f (eraProtVerLow @StandardBabbage)
     Conway -> f (eraProtVerLow @StandardConway)
-
   where
     f :: EncCBOR (TxT era) => Ledger.Version -> Tx era -> K BL.ByteString era
     f protVer = K . Ledger.serialize protVer . unTx
 
--- | Parse CBOR into a transaction in any eras
--- , smart application  of `deserializeTx`.
-parseTxFromCBOR :: TxCBOR -> Either DecoderError (EraValue Tx)
-parseTxFromCBOR = sequenceEraValue
-    . applyEraFunValue deserializeTx
-
 {-# INLINABLE deserializeTx #-}
 -- | CBOR deserialization of a tx in any era.
-deserializeTx :: forall era . IsEra era => K BL.ByteString era -> (Either DecoderError :.: Tx) era
+deserializeTx
+    :: forall era . IsEra era
+    => K BL.ByteString era -> (Either DecoderError :.: Tx) era
 deserializeTx = case theEra @era of
     Byron -> \txCBOR ->
         Comp $ Tx <$> decodeFull byronProtVer (unK txCBOR)
@@ -134,9 +85,6 @@ deserializeTx = case theEra @era of
     Alonzo -> decodeTx (eraProtVerLow @StandardAlonzo) "AlonzoTx"
     Babbage -> decodeTx (eraProtVerLow @StandardBabbage) "BabbageTx"
     Conway -> decodeTx (eraProtVerLow @StandardConway) "ConwayTx"
-    where
+  where
     decodeTx protVer label (K txCBOR) =
         Comp $ Tx <$> decodeFullAnnotator protVer label decCBOR txCBOR
-
-roundTripTxCBor :: TxCBOR -> Either DecoderError TxCBOR
-roundTripTxCBor = fmap renderTxToCBOR . parseTxFromCBOR

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/CBOR.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/CBOR.hs
@@ -13,7 +13,7 @@ module Cardano.Wallet.Read.Tx.CBOR
     ( TxCBOR
     , renderTxToCBOR
     , parseTxFromCBOR
-    , roundTripTxCBor
+    , roundTripTxCBOR
     )
     where
 
@@ -74,5 +74,5 @@ parseTxFromCBOR :: TxCBOR -> Either DecoderError (EraValue Tx)
 parseTxFromCBOR (EraValue (K bytes :: K BL.ByteString era)) =
     EraValue <$> (deserializeTx bytes :: Either DecoderError (Tx era))
 
-roundTripTxCBor :: TxCBOR -> Either DecoderError TxCBOR
-roundTripTxCBor = fmap renderTxToCBOR . parseTxFromCBOR
+roundTripTxCBOR :: TxCBOR -> Either DecoderError TxCBOR
+roundTripTxCBOR = fmap renderTxToCBOR . parseTxFromCBOR

--- a/lib/read/test/Cardano/Wallet/Read/Tx/CBORSpec.hs
+++ b/lib/read/test/Cardano/Wallet/Read/Tx/CBORSpec.hs
@@ -7,16 +7,16 @@ module Cardano.Wallet.Read.Tx.CBORSpec
 
 import Prelude
 
-import Cardano.Read.Ledger.Tx.CBOR
-    ( TxCBOR
-    , parseTxFromCBOR
-    , renderTxToCBOR
-    )
 import Cardano.Wallet.Read.Eras
     ( Era (..)
     , EraValue (..)
     , IsEra
     , K (..)
+    )
+import Cardano.Wallet.Read.Tx.CBOR
+    ( TxCBOR
+    , parseTxFromCBOR
+    , renderTxToCBOR
     )
 import Data.ByteArray.Encoding
     ( Base (..)

--- a/lib/read/test/Cardano/Wallet/Read/Tx/TxIdSpec.hs
+++ b/lib/read/test/Cardano/Wallet/Read/Tx/TxIdSpec.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Cardano.Wallet.Read.Tx.TxIdSpec
     ( spec
@@ -13,8 +12,6 @@ import Cardano.Read.Ledger.Tx.CBOR
     )
 import Cardano.Wallet.Read.Eras
     ( IsEra
-    , K (..)
-    , (:.:) (Comp)
     )
 import Cardano.Wallet.Read.Hash
     ( hashFromBytesAsHex
@@ -234,12 +231,7 @@ unsafeParseEraTxFromHex
     -> Tx era
 unsafeParseEraTxFromHex bytes =
     either (error . show) id
-    . unComp
-    $ deserializeTx
-        (K (unsafeReadBase16 bytes) :: K BL.ByteString era)
-  where
-    unComp :: (f :.: g) era -> f (g era)
-    unComp (Comp fg) = fg
+    $ deserializeTx (unsafeReadBase16 bytes :: BL.ByteString)
 
 unsafeTxIdFromHex :: ByteString -> TxId
 unsafeTxIdFromHex =

--- a/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -23,9 +23,6 @@ module Cardano.Wallet.DummyTarget.Primitive.Types
 
 import Prelude
 
-import Cardano.Read.Ledger.Tx.CBOR
-    ( TxCBOR
-    )
 import Cardano.Wallet.Network
     ( NetworkLayer (..)
     )
@@ -71,6 +68,9 @@ import Cardano.Wallet.Primitive.Types.Tx.TxIn
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut (..)
+    )
+import Cardano.Wallet.Read.Tx.CBOR
+    ( TxCBOR
     )
 import Data.Functor.Identity
     ( Identity (..)

--- a/lib/unit/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -49,9 +49,6 @@ import Cardano.Mnemonic
 import Cardano.Pool.Types
     ( PoolId (..)
     )
-import Cardano.Read.Ledger.Tx.CBOR
-    ( TxCBOR
-    )
 import Cardano.Wallet.Address.Book
     ( AddressBookIso (..)
     )
@@ -220,6 +217,9 @@ import Cardano.Wallet.Primitive.Types.UTxO
 import Cardano.Wallet.Read.Eras
     ( eraValueSerialize
     , knownEraIndices
+    )
+import Cardano.Wallet.Read.Tx.CBOR
+    ( TxCBOR
     )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic

--- a/lib/unit/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -58,9 +58,6 @@ import Cardano.Address.Script
 import Cardano.Pool.Types
     ( PoolId (..)
     )
-import Cardano.Read.Ledger.Tx.CBOR
-    ( TxCBOR
-    )
 import Cardano.Wallet.Address.Book
     ( AddressBookIso
     )
@@ -224,6 +221,9 @@ import Cardano.Wallet.Primitive.Types.UTxO
     )
 import Cardano.Wallet.Read.Eras.EraValue
     ( eraValueSerialize
+    )
+import Cardano.Wallet.Read.Tx.CBOR
+    ( TxCBOR
     )
 import Control.DeepSeq
     ( NFData

--- a/lib/unit/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -61,7 +61,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..)
     )
 import Cardano.Wallet.Read.Tx.CBOR
-    ( roundTripTxCBor
+    ( roundTripTxCBOR
     )
 import Control.Monad
     ( forM_
@@ -168,7 +168,7 @@ spec = do
                         runQuery db $ loadS mkStoreTransactions
                     let cbors =
                             mapMaybe (cbor >=> mkTxCBOR) $ toList txSet
-                        Right cbors' = mapM roundTripTxCBor cbors
+                        Right cbors' = mapM roundTripTxCBOR cbors
                     cbors `shouldBe` cbors'
 
 withinCopiedFile

--- a/lib/unit/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/Store/Transactions/StoreSpec.hs
@@ -21,9 +21,6 @@ import Cardano.DB.Sqlite
     ( ForeignKeysSetting (..)
     , runQuery
     )
-import Cardano.Read.Ledger.Tx.CBOR
-    ( roundTripTxCBor
-    )
 import Cardano.Wallet.DB.Arbitrary
     ()
 import Cardano.Wallet.DB.Fixtures
@@ -62,6 +59,9 @@ import Cardano.Wallet.DB.Store.Transactions.TransactionInfo
     )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..)
+    )
+import Cardano.Wallet.Read.Tx.CBOR
+    ( roundTripTxCBor
     )
 import Control.Monad
     ( forM_

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -280,9 +280,6 @@ import Cardano.Ledger.Api
 import Cardano.Mnemonic
     ( SomeMnemonic
     )
-import Cardano.Read.Ledger.Tx.CBOR
-    ( TxCBOR
-    )
 import Cardano.Slotting.Slot
     ( SlotNo (..)
     )
@@ -597,6 +594,9 @@ import Cardano.Wallet.Primitive.Types.UTxO
     )
 import Cardano.Wallet.Primitive.Types.UTxOStatistics
     ( UTxOStatistics
+    )
+import Cardano.Wallet.Read.Tx.CBOR
+    ( TxCBOR
     )
 import Cardano.Wallet.Shelley.Transaction
     ( _txRewardWithdrawalCost

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -76,9 +76,6 @@ import Cardano.DB.Sqlite.Migration.Old
     ( ManualMigration (..)
     , MigrationError
     )
-import Cardano.Read.Ledger.Tx.CBOR
-    ( parseTxFromCBOR
-    )
 import Cardano.Slotting.Slot
     ( WithOrigin (..)
     )
@@ -189,6 +186,9 @@ import Cardano.Wallet.Primitive.Types.Coin
     )
 import Cardano.Wallet.Read.Eras.EraValue
     ( EraValue
+    )
+import Cardano.Wallet.Read.Tx.CBOR
+    ( parseTxFromCBOR
     )
 import Control.DeepSeq
     ( force

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -37,9 +37,6 @@ module Cardano.Wallet.DB.Store.Transactions.Model
 
 import Prelude
 
-import Cardano.Read.Ledger.Tx.CBOR
-    ( TxCBOR
-    )
 import Cardano.Wallet.DB.Sqlite.Schema
     ( CBOR (..)
     , TxCollateral (..)
@@ -73,6 +70,9 @@ import Cardano.Wallet.Primitive.Types.Tx.Tx
     )
 import Cardano.Wallet.Read.Eras.EraValue
     ( eraValueSerialize
+    )
+import Cardano.Wallet.Read.Tx.CBOR
+    ( TxCBOR
     )
 import Control.Arrow
     ( (&&&)

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/TransactionInfo.hs
@@ -12,10 +12,6 @@ module Cardano.Wallet.DB.Store.Transactions.TransactionInfo
 
 import Prelude
 
-import Cardano.Read.Ledger.Tx.CBOR
-    ( TxCBOR
-    , renderTxToCBOR
-    )
 import Cardano.Read.Ledger.Tx.CollateralInputs
     ( getEraCollateralInputs
     )
@@ -116,6 +112,10 @@ import Cardano.Wallet.Read.Eras
     ( EraValue
     , IsEra
     , applyEraFun
+    )
+import Cardano.Wallet.Read.Tx.CBOR
+    ( TxCBOR
+    , renderTxToCBOR
     )
 import Cardano.Wallet.Transaction
     ( ValidityIntervalExplicit (invalidHereafter)

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TransactionInfo.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Types/Tx/TransactionInfo.hs
@@ -24,9 +24,6 @@ module Cardano.Wallet.Primitive.Types.Tx.TransactionInfo
 
 import Prelude
 
-import Cardano.Read.Ledger.Tx.CBOR
-    ( TxCBOR
-    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
@@ -51,6 +48,9 @@ import Cardano.Wallet.Primitive.Types.Tx.TxMeta
     )
 import Cardano.Wallet.Primitive.Types.Tx.TxOut
     ( TxOut
+    )
+import Cardano.Wallet.Read.Tx.CBOR
+    ( TxCBOR
     )
 import Control.DeepSeq
     ( NFData (..)


### PR DESCRIPTION
This pull request splits the binary serialization of transactions through `TxCBOR` into two modules:

* `Cardano.Read.Ledger.Tx.CBOR` — contains the era-indexed functions `serializeTx` and `deserializeTx` that are responsible for serialization.
* `Cardano.Wallet.Read.Tx.CBOR` — contains the `TxCBOR` type (synonym) which is a disjoint union of transactions in different eras.

### Comments

* In general, I envision the separation between the modules like this
    * `Cardano.Read.Ledger` — contains functions that are *era-indexed*.
    * `Cardano.Wallet.Read` — contains functions that work *across eras*, which may or may not include an `era` index, and may even convert or unify between eras.
    * This separation of concerns should be sufficient to ensure that `Cardano.Read.Ledger` will not depend on modules from `Cardano.Wallet.Read`.

### Issue Number

ADP-3215