### PR TITLE
[ADP-3406] Scaffold `signTxBody` for deposit wallet

### DIFF
--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -26,6 +26,7 @@ module Cardano.Wallet.Deposit.IO
     -- ** Writing to the blockchain
     , createPayment
     , getBIP32PathsForOwnedInputs
+    , signTxBody
     ) where
 
 import Prelude
@@ -210,6 +211,9 @@ getBIP32PathsForOwnedInputs
     :: Write.TxBody -> WalletInstance -> IO [BIP32Path]
 getBIP32PathsForOwnedInputs a w =
     Wallet.getBIP32PathsForOwnedInputs a <$> readWalletState w
+
+signTxBody :: Write.TxBody -> WalletInstance -> IO (Maybe Write.Tx)
+signTxBody txbody w = Wallet.signTxBody txbody <$> readWalletState w
 
 {-----------------------------------------------------------------------------
     Logging

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -34,6 +34,7 @@ module Cardano.Wallet.Deposit.Pure
     , BIP32Path (..)
     , DerivationType (..)
     , getBIP32PathsForOwnedInputs
+    , signTxBody
 
     , addTxSubmission
     , listTxsInSubmission
@@ -244,6 +245,9 @@ getBIP32PathsForOwnedInputs txbody w =
 getBIP32Paths :: WalletState -> [Read.Address] -> [BIP32Path]
 getBIP32Paths w =
     mapMaybe $ Address.getBIP32Path (addresses w) . Read.toRawAddress
+
+signTxBody :: Write.TxBody -> WalletState -> Maybe Write.Tx
+signTxBody _txbody _w = undefined
 
 addTxSubmission :: Write.Tx -> WalletState -> WalletState
 addTxSubmission _tx _w = undefined

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -43,7 +43,8 @@ module Cardano.Wallet.Deposit.Pure
 import Prelude
 
 import Cardano.Crypto.Wallet
-    ( XPub
+    ( XPrv
+    , XPub
     )
 import Cardano.Wallet.Address.BIP32
     ( BIP32Path (..)
@@ -96,7 +97,7 @@ data WalletState = WalletState
     , utxoHistory :: !UTxOHistory.UTxOHistory
     -- , txHistory :: [Read.Tx]
     , submissions :: Sbm.TxSubmissions
-    -- , credentials :: Maybe (HashedCredentials (KeyOf s))
+    , rootXSignKey :: Maybe XPrv
     -- , info :: !WalletInfo
     }
 
@@ -152,6 +153,7 @@ fromXPubAndGenesis xpub knownCustomerCount _ =
             Address.fromXPubAndCount xpub knownCustomerCount
         , utxoHistory = UTxOHistory.empty initialUTxO
         , submissions = Sbm.empty
+        , rootXSignKey = Nothing
         }
   where
     initialUTxO = mempty


### PR DESCRIPTION
- Scaffold `signTxBody` function
- Add `rootXSignKey` field to `WalletState`

### Issue Number

ADP-3406
