### PR TITLE
[ADP-3215] Move definition of `TxT` to `Cardano.Read.Ledger`

### DIFF
--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -71,6 +71,7 @@ library
     Cardano.Read.Ledger.Tx.Validity
     Cardano.Read.Ledger.Tx.Withdrawals
     Cardano.Read.Ledger.Tx.Witnesses
+    Cardano.Read.Ledger.Tx.Tx
     Cardano.Read.Ledger.Value
     Cardano.Wallet.Read
     Cardano.Wallet.Read.Block

--- a/lib/read/lib/Cardano/Read/Ledger/Block/Txs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Block/Txs.hs
@@ -20,7 +20,7 @@ import Cardano.Read.Ledger.Eras
     , Era (..)
     , IsEra (..)
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     , TxT
     )

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/CBOR.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/CBOR.hs
@@ -32,7 +32,7 @@ import Cardano.Read.Ledger.Eras
     ( Era (..)
     , IsEra (..)
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     , TxT
     )

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Certificates.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Certificates.hs
@@ -48,7 +48,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/CollateralInputs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/CollateralInputs.hs
@@ -44,7 +44,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/CollateralOutputs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/CollateralOutputs.hs
@@ -53,7 +53,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Eras.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Eras.hs
@@ -10,7 +10,7 @@ module Cardano.Read.Ledger.Tx.Eras
     )
     where
 
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     , TxT
     )

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/ExtraSigs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/ExtraSigs.hs
@@ -45,7 +45,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Fee.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Fee.hs
@@ -44,7 +44,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Hash.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Hash.hs
@@ -43,7 +43,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Inputs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Inputs.hs
@@ -42,7 +42,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Integrity.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Integrity.hs
@@ -49,7 +49,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Metadata.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Metadata.hs
@@ -48,7 +48,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Mint.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Mint.hs
@@ -49,7 +49,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Outputs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Outputs.hs
@@ -48,7 +48,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/ReferenceInputs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/ReferenceInputs.hs
@@ -46,7 +46,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/ScriptValidity.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/ScriptValidity.hs
@@ -40,7 +40,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Tx.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Tx.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{- |
+Copyright: © 2022 IOHK, 2024 Cardano Foundation
+License: Apache-2.0
+
+The 'Tx' type represents transactions as they are read from the mainnet ledger.
+It is compatible with the era-specific index types from @cardano-ledger@.
+-}
+module Cardano.Read.Ledger.Tx.Tx
+    ( Tx (..)
+    , TxT
+    ) where
+
+import Prelude
+
+import Cardano.Ledger.Alonzo.Tx
+    ( AlonzoTx
+    )
+import Cardano.Ledger.Shelley.Tx
+    ( ShelleyTx
+    )
+import Cardano.Read.Ledger.Eras
+    ( Allegra
+    , Alonzo
+    , Babbage
+    , Byron
+    , Conway
+    , Mary
+    , Shelley
+    )
+
+import qualified Cardano.Chain.UTxO as Byron
+
+-- | Closed type family returning the ledger 'Tx' type for each known @era@.
+type family TxT era where
+    TxT Byron = Byron.ATxAux ()
+    TxT Shelley = ShelleyTx Shelley
+    TxT Allegra = ShelleyTx Allegra
+    TxT Mary = ShelleyTx Mary
+    TxT Alonzo = AlonzoTx Alonzo
+    TxT Babbage = AlonzoTx Babbage
+    TxT Conway = AlonzoTx Conway
+
+-- | A tx in any era
+newtype Tx era = Tx {unTx :: TxT era}
+
+deriving instance Show (TxT era) => Show (Tx era)
+deriving instance Eq (TxT era) => Eq (Tx era)

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/TxId.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/TxId.hs
@@ -41,7 +41,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Validity.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Validity.hs
@@ -52,7 +52,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Withdrawals.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Withdrawals.hs
@@ -52,7 +52,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Read/Ledger/Tx/Witnesses.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Tx/Witnesses.hs
@@ -45,7 +45,7 @@ import Cardano.Read.Ledger.Eras
 import Cardano.Read.Ledger.Tx.Eras
     ( onTx
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx (..)
     )
 import Control.Lens

--- a/lib/read/lib/Cardano/Wallet/Read/Block/Gen/BlockParameters.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Block/Gen/BlockParameters.hs
@@ -16,7 +16,7 @@ import Cardano.Read.Ledger.Block.BlockNo
 import Cardano.Read.Ledger.Block.SlotNo
     ( SlotNo (..)
     )
-import Cardano.Wallet.Read.Tx
+import Cardano.Read.Ledger.Tx.Tx
     ( Tx
     )
 import Control.Lens.TH

--- a/lib/read/lib/Cardano/Wallet/Read/Tx.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx.hs
@@ -1,60 +1,16 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
-
 {- |
-Copyright: © 2022 IOHK
+Copyright: © 2022 IOHK, 2024 Cardano Foundation
 License: Apache-2.0
 
 The 'Tx' type represents transactions as they are read from the mainnet ledger.
 It is compatible with the era-specific index types from @cardano-ledger@.
 -}
 module Cardano.Wallet.Read.Tx
-    ( -- * Transactions
-      Tx (..)
+    ( Tx (..)
     , TxT
     ) where
 
-import Prelude
-
-import Cardano.Ledger.Alonzo.Tx
-    ( AlonzoTx
+import Cardano.Read.Ledger.Tx.Tx
+    ( Tx (..)
+    , TxT
     )
-import Cardano.Ledger.Api
-    ( StandardCrypto
-    )
-import Cardano.Ledger.Shelley.Tx
-    ( ShelleyTx
-    )
-import Cardano.Wallet.Read.Eras
-    ( Allegra
-    , Alonzo
-    , Babbage
-    , Byron
-    , Conway
-    , Mary
-    , Shelley
-    )
-
-import qualified Cardano.Chain.UTxO as Byron
-import qualified Cardano.Ledger.Api as Ledger
-
--- | Closed type family returning the ledger 'Tx' type for each known @era@.
-type family TxT era where
-    TxT Byron = Byron.ATxAux ()
-    TxT Shelley = ShelleyTx (Ledger.ShelleyEra StandardCrypto)
-    TxT Allegra = ShelleyTx (Ledger.AllegraEra StandardCrypto)
-    TxT Mary = ShelleyTx (Ledger.MaryEra StandardCrypto)
-    TxT Alonzo = AlonzoTx (Ledger.AlonzoEra  StandardCrypto)
-    TxT Babbage = AlonzoTx (Ledger.BabbageEra StandardCrypto)
-    TxT Conway = AlonzoTx (Ledger.ConwayEra StandardCrypto)
-
--- | A tx in any era
-newtype Tx era = Tx {unTx :: TxT era}
-
-deriving instance Show (TxT era) => Show (Tx era)
-deriving instance Eq (TxT era) => Eq (Tx era)

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/CBOR.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/CBOR.hs
@@ -26,14 +26,14 @@ import Cardano.Read.Ledger.Tx.CBOR
     ( deserializeTx
     , serializeTx
     )
+import Cardano.Read.Ledger.Tx.Tx
+    ( Tx
+    )
 import Cardano.Wallet.Read.Eras
     ( EraValue (..)
     , K (..)
     , applyEraFunValue
     , extractEraValue
-    )
-import Cardano.Wallet.Read.Tx
-    ( Tx (..)
     )
 import Data.ByteArray.Encoding
     ( Base (Base16)


### PR DESCRIPTION
This pull request moves the type family `TxT era` and the newtype `Tx era` to the `Cardano.Read.Ledger` modules. This is a pure refactoring.

### Issue Number

ADP-3215