### PR TITLE
[ADP-3407] Fix and quarantine flaky compiler error

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -80,6 +80,7 @@ packages:
   lib/network-layer/
   lib/numeric/
   lib/primitive/
+  lib/quarantine/
   lib/read
   lib/secrets
   lib/std-gen-seed/

--- a/lib/quarantine/cardano-wallet-quarantine.cabal
+++ b/lib/quarantine/cardano-wallet-quarantine.cabal
@@ -1,0 +1,78 @@
+cabal-version:   3.6
+name:            cardano-wallet-quarantine
+version:         0.2024.7.27
+synopsis:
+  Package for isolating a compiler bug in GHC 9.6.4 to 9.6.6
+
+-- description:
+homepage:        https://github.com/cardano-foundation/cardano-wallet
+license:         Apache-2.0
+license-file:    LICENSE
+author:          Cardano Foundation (High Assurance Lab)
+maintainer:      hal@cardanofoundation.org
+copyright:       2024 Cardano Foundation
+category:        Cardano
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
+common language
+  default-language:   Haskell2010
+  default-extensions:
+    NoImplicitPrelude
+    OverloadedStrings
+
+common opts-lib
+  ghc-options:
+    -Wall -Wcompat -Wredundant-constraints -Wincomplete-uni-patterns
+    -Wincomplete-record-updates
+    -Werror
+
+library
+  import:           opts-lib, language
+  exposed-modules:
+    Quarantine.Cardano.Block
+    Quarantine.Cardano.Eras
+    Quarantine.Cardano.Tx
+    Quarantine.Cardano.Txs
+
+  build-depends:
+    , base
+    , bytestring
+    , cardano-crypto
+    , cardano-crypto-class
+    , cardano-crypto-praos
+    , cardano-crypto-test
+    , cardano-crypto-wrapper
+    , cardano-data
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo
+    , cardano-ledger-alonzo-test
+    , cardano-ledger-api
+    , cardano-ledger-babbage
+    , cardano-ledger-binary
+    , cardano-ledger-byron
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-ledger-mary
+    , cardano-ledger-shelley
+    , cardano-protocol-tpraos
+    , cardano-strict-containers
+    , containers
+    , deepseq
+    , extra
+    , fmt
+    , generic-lens
+    , generics-sop
+    , lens
+    , memory
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-protocol
+    , ouroboros-network-api
+    , QuickCheck
+    , text
+    , transformers
+
+  hs-source-dirs:   lib
+  default-language: Haskell2010

--- a/lib/quarantine/lib/Quarantine/Cardano/Block.hs
+++ b/lib/quarantine/lib/Quarantine/Cardano/Block.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Copyright: © 2022 IOHK
+-- License: Apache-2.0
+--
+-- The 'Block' type.
+--
+module Quarantine.Cardano.Block
+    ( ConsensusBlock
+    , Block (..)
+    -- , fromConsensusBlock
+    , toConsensusBlock
+    ) where
+
+import Prelude
+
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
+import Quarantine.Cardano.Eras
+    ( Allegra
+    , Alonzo
+    , Babbage
+    , Byron
+    , Conway
+    , Era (..)
+    , IsEra (..)
+    , Mary
+    , Shelley
+    )
+{-
+import Cardano.Wallet.Read.Eras
+    ( EraValue (..)
+    , eraValue
+    )
+-}
+import Ouroboros.Consensus.Protocol.Praos
+    ( Praos
+    )
+import Ouroboros.Consensus.Protocol.TPraos
+    ( TPraos
+    )
+
+import qualified Ouroboros.Consensus.Byron.Ledger as O
+import qualified Ouroboros.Consensus.Cardano.Block as O
+import qualified Ouroboros.Consensus.Shelley.Ledger as O
+
+-- | Type synonym for 'CardanoBlock',
+-- using the same cryptographic functionalities as Mainnet.
+type ConsensusBlock = O.CardanoBlock O.StandardCrypto
+
+-- Family of era-specific block types
+-- TODO: ADP-3351 The results of this type family should be ledger types,
+-- not ouroboros-consensus types.
+type family BlockT era where
+    BlockT Byron =
+        O.ByronBlock
+    BlockT Shelley =
+        O.ShelleyBlock (TPraos StandardCrypto) (O.ShelleyEra StandardCrypto)
+    BlockT Allegra =
+        O.ShelleyBlock (TPraos StandardCrypto) (O.AllegraEra StandardCrypto)
+    BlockT Mary =
+        O.ShelleyBlock (TPraos StandardCrypto) (O.MaryEra StandardCrypto)
+    BlockT Alonzo =
+        O.ShelleyBlock (TPraos StandardCrypto) (O.AlonzoEra StandardCrypto)
+    BlockT Babbage =
+        O.ShelleyBlock (Praos StandardCrypto) (O.BabbageEra StandardCrypto)
+    BlockT Conway =
+        O.ShelleyBlock (Praos StandardCrypto) (O.ConwayEra StandardCrypto)
+
+newtype Block era = Block {unBlock :: BlockT era}
+
+deriving instance Show (BlockT era) => Show (Block era)
+deriving instance Eq (BlockT era) => Eq (Block era)
+
+{-
+-- | Convert block as received from cardano-node
+-- via Haskell library of mini-protocol.
+fromConsensusBlock :: ConsensusBlock -> EraValue Block
+fromConsensusBlock = \case
+    O.BlockByron b -> eraValue @Byron $ Block b
+    O.BlockShelley block -> eraValue @Shelley $ Block block
+    O.BlockAllegra block -> eraValue @Allegra $ Block block
+    O.BlockMary block -> eraValue @Mary $ Block block
+    O.BlockAlonzo block -> eraValue @Alonzo $ Block block
+    O.BlockBabbage block -> eraValue @Babbage $ Block block
+    O.BlockConway block -> eraValue @Conway $ Block block
+-}
+
+{-# INLINABLE toConsensusBlock #-}
+toConsensusBlock :: forall era . IsEra era => Block era -> ConsensusBlock
+toConsensusBlock = case theEra @era of
+    Byron -> O.BlockByron . unBlock
+    Shelley -> O.BlockShelley . unBlock
+    Allegra -> O.BlockAllegra . unBlock
+    Mary -> O.BlockMary . unBlock
+    Alonzo -> O.BlockAlonzo . unBlock
+    Babbage -> O.BlockBabbage . unBlock
+    Conway -> O.BlockConway . unBlock

--- a/lib/quarantine/lib/Quarantine/Cardano/Eras.hs
+++ b/lib/quarantine/lib/Quarantine/Cardano/Eras.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{- |
+Copyright: © 2020-2022 IOHK, 2024 Cardano Foundation
+License: Apache-2.0
+
+A type list of known eras, useful for indexing types by era.
+-}
+module Quarantine.Cardano.Eras
+    ( Era (..)
+    , IsEra (..)
+
+    , KnownEras
+    , knownEraIndices
+    , indexOfEra
+
+    , Allegra
+    , Alonzo
+    , Babbage
+    , Byron
+    , Conway
+    , Mary
+    , Shelley
+    ) where
+
+import Prelude
+
+import Cardano.Ledger.Api
+    ( Allegra
+    , Alonzo
+    , Babbage
+    , ByronEra
+    , Conway
+    , Mary
+    , Shelley
+    , StandardCrypto
+    )
+import Generics.SOP
+    ( Proxy (..)
+    , lengthSList
+    )
+
+type Byron = ByronEra StandardCrypto
+
+-- | Singleton type for eras.
+--
+-- This GADT provides a value-level representation of eras.
+data Era era where
+    Byron :: Era Byron
+    Shelley :: Era Shelley
+    Allegra :: Era Allegra
+    Mary :: Era Mary
+    Alonzo :: Era Alonzo
+    Babbage :: Era Babbage
+    Conway :: Era Conway
+
+deriving instance Show (Era era)
+
+-- | Singleton class for eras.
+class IsEra era where
+    theEra :: Era era
+
+instance IsEra Byron where theEra = Byron
+instance IsEra Shelley where theEra = Shelley
+instance IsEra Allegra where theEra = Allegra
+instance IsEra Mary where theEra = Mary
+instance IsEra Alonzo where theEra = Alonzo
+instance IsEra Babbage where theEra = Babbage
+instance IsEra Conway where theEra = Conway
+
+-- | Type-level list of known eras, in chronological order.
+type KnownEras =
+    '[Byron, Shelley, Allegra, Mary, Alonzo, Babbage, Conway]
+
+-- | Official numbering of the 'KnownEras'.
+knownEraIndices :: [Int]
+knownEraIndices = [0 .. lengthSList (Proxy :: Proxy KnownEras) - 1]
+
+-- | Official number of the member of 'KnownEras'.
+indexOfEra :: Era era -> Int
+indexOfEra e = case e of
+    Byron -> 0
+    Shelley -> 1
+    Allegra -> 2
+    Mary -> 3
+    Alonzo -> 4
+    Babbage -> 5
+    Conway -> 6

--- a/lib/quarantine/lib/Quarantine/Cardano/Tx.hs
+++ b/lib/quarantine/lib/Quarantine/Cardano/Tx.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{- |
+Copyright: © 2022 IOHK
+License: Apache-2.0
+
+The 'Tx' type represents transactions as they are read from the mainnet ledger.
+It is compatible with the era-specific index types from @cardano-ledger@.
+-}
+module Quarantine.Cardano.Tx
+    ( -- * Transactions
+      Tx (..)
+    , TxT
+    ) where
+
+import Prelude
+
+import Cardano.Ledger.Alonzo.Tx
+    ( AlonzoTx
+    )
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
+import Cardano.Ledger.Shelley.Tx
+    ( ShelleyTx
+    )
+import Quarantine.Cardano.Eras
+    ( Allegra
+    , Alonzo
+    , Babbage
+    , Byron
+    , Conway
+    , Mary
+    , Shelley
+    )
+
+import qualified Cardano.Chain.UTxO as Byron
+import qualified Cardano.Ledger.Api as Ledger
+
+-- | Closed type family returning the ledger 'Tx' type for each known @era@.
+type family TxT era where
+    TxT Byron = Byron.ATxAux ()
+    TxT Shelley = ShelleyTx (Ledger.ShelleyEra StandardCrypto)
+    TxT Allegra = ShelleyTx (Ledger.AllegraEra StandardCrypto)
+    TxT Mary = ShelleyTx (Ledger.MaryEra StandardCrypto)
+    TxT Alonzo = AlonzoTx (Ledger.AlonzoEra  StandardCrypto)
+    TxT Babbage = AlonzoTx (Ledger.BabbageEra StandardCrypto)
+    TxT Conway = AlonzoTx (Ledger.ConwayEra StandardCrypto)
+
+-- | A tx in any era
+newtype Tx era = Tx {unTx :: TxT era}
+
+deriving instance Show (TxT era) => Show (Tx era)
+deriving instance Eq (TxT era) => Eq (Tx era)

--- a/lib/quarantine/lib/Quarantine/Cardano/Txs.hs
+++ b/lib/quarantine/lib/Quarantine/Cardano/Txs.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Quarantine.Cardano.Txs
+    ( getEraTransactions
+    ) where
+
+import Prelude
+
+import Cardano.Ledger.Binary
+    ( EncCBOR
+    )
+import Data.Foldable
+    ( toList
+    )
+import Ouroboros.Consensus.Shelley.Protocol.Abstract
+    ( ShelleyProtocolHeader
+    )
+import Ouroboros.Consensus.Shelley.Protocol.Praos
+    ()
+import Quarantine.Cardano.Block
+    ( Block (..)
+    )
+import Quarantine.Cardano.Eras
+    ( Byron
+    , Era (..)
+    , IsEra (..)
+    )
+import Quarantine.Cardano.Tx
+    ( Tx (..)
+    , TxT
+    )
+
+import qualified Cardano.Chain.Block as Byron
+import qualified Cardano.Chain.UTxO as Byron
+import qualified Cardano.Ledger.Api as Ledger
+import qualified Cardano.Ledger.Era as Shelley
+import qualified Cardano.Ledger.Shelley.API as Shelley
+import qualified Ouroboros.Consensus.Byron.Ledger as Byron
+import qualified Ouroboros.Consensus.Byron.Ledger as O
+import qualified Ouroboros.Consensus.Shelley.Ledger as O
+
+{-# INLINABLE getEraTransactions #-}
+-- | Get the list of transactions in the block.
+getEraTransactions :: forall era. IsEra era => Block era -> [Tx era]
+getEraTransactions = case theEra @era of
+    Byron -> getTxs' getTxsFromBlockByron
+    Shelley -> getTxs' getTxsFromBlockShelleyAndOn
+    Allegra -> getTxs' getTxsFromBlockShelleyAndOn
+    Mary -> getTxs' getTxsFromBlockShelleyAndOn
+    Alonzo -> getTxs' getTxsFromBlockShelleyAndOn
+    Babbage -> getTxs' getTxsFromBlockShelleyAndOn
+    Conway -> getTxs' getTxsFromBlockShelleyAndOn
+  where
+    getTxs' f (Block block) = Tx <$> f block
+
+getTxsFromBlockByron :: O.ByronBlock -> [TxT Byron]
+getTxsFromBlockByron block =
+    case Byron.byronBlockRaw block of
+        Byron.ABOBBlock b -> Byron.unTxPayload . Byron.blockTxPayload $ b
+        Byron.ABOBBoundary _ -> []
+
+getTxsFromBlockShelleyAndOn
+    :: (Shelley.EraSegWits era, EncCBOR (ShelleyProtocolHeader proto))
+    => O.ShelleyBlock proto era
+    -> [Ledger.Tx era]
+getTxsFromBlockShelleyAndOn (O.ShelleyBlock (Shelley.Block _ txs) _) =
+    toList (Shelley.fromTxSeq txs)

--- a/lib/read/lib/Cardano/Read/Ledger/Block/Txs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Block/Txs.hs
@@ -32,6 +32,8 @@ import Ouroboros.Consensus.Shelley.Protocol.Abstract
     )
 import Ouroboros.Consensus.Shelley.Protocol.Praos
     ()
+import Ouroboros.Consensus.Shelley.Protocol.TPraos
+    ()
 
 import qualified Cardano.Chain.Block as Byron
 import qualified Cardano.Chain.UTxO as Byron


### PR DESCRIPTION
This pull request quarantines a compiler error in `Cardano.Read.Ledger.Block.Txs`.

**Error**
The error message starts with

```
lib/Quarantine/Cardano/Txs.hs:50:24: error: [GHC-39999]
    • Could not deduce ‘EncCBOR
                          (ShelleyProtocolHeader
                             (Ouroboros.Consensus.Protocol.TPraos.TPraos
                                Ledger.StandardCrypto))’
        arising from a use of ‘getTxsFromBlockShelleyAndOn’
      from the context: IsEra era
        bound by the type signature for:
                   getEraTransactions :: forall era.
                                         IsEra era =>
                                         Block era -> [Tx era]
        at lib/Quarantine/Cardano/Txs.hs:47:1-68
      or from: era ~ Ledger.ShelleyEra Ledger.StandardCrypto
        bound by a pattern with constructor:
                   Shelley :: Era (Ledger.ShelleyEra Ledger.StandardCrypto),
                 in a case alternative
        at lib/Quarantine/Cardano/Txs.hs:50:5-11
    • In the first argument of ‘getTxs'’, namely
        ‘getTxsFromBlockShelleyAndOn’
      In the expression: getTxs' getTxsFromBlockShelleyAndOn
      In a case alternative:
          Shelley -> getTxs' getTxsFromBlockShelleyAndOn
   |
50 |     Shelley -> getTxs' getTxsFromBlockShelleyAndOn
   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[…]
```

**Solution**
Importing orphan instances

```hs
import Ouroboros.Consensus.Shelley.Protocol.TPraos
    ()
```

solves the issue, but the curious thing is that compilation sometimes succeeds.


### Issue Number

ADP-3407
