### PR TITLE
[ADP-3407] Fix compiler error in `Cardano.Read.Ledger.Block.Txs`

### DIFF
--- a/lib/read/lib/Cardano/Read/Ledger/Block/Txs.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Block/Txs.hs
@@ -32,6 +32,8 @@ import Ouroboros.Consensus.Shelley.Protocol.Abstract
     )
 import Ouroboros.Consensus.Shelley.Protocol.Praos
     ()
+import Ouroboros.Consensus.Shelley.Protocol.TPraos
+    ()
 
 import qualified Cardano.Chain.Block as Byron
 import qualified Cardano.Chain.UTxO as Byron


### PR DESCRIPTION
This pull request fixes a compiler error in `Cardano.Read.Ledger.Block.Txs` by explicitly importing orphan instances.

Curiously, this compiler error is flaky — without this fix, sometimes the module compiles, and sometimes it does not.

### Issue Number

ADP-3407