### PR TITLE
[ADP-3215] Add `CompactAddr` to `read`

### DIFF
--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -44,6 +44,7 @@ library
   import:           opts-lib, language
   exposed-modules:
     Cardano.Read.Ledger
+    Cardano.Read.Ledger.Address
     Cardano.Read.Ledger.Block.Block
     Cardano.Read.Ledger.Block.BHeader
     Cardano.Read.Ledger.Block.BlockNo

--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -75,6 +75,7 @@ library
     Cardano.Read.Ledger.Tx.Tx
     Cardano.Read.Ledger.Value
     Cardano.Wallet.Read
+    Cardano.Wallet.Read.Address
     Cardano.Wallet.Read.Block
     Cardano.Wallet.Read.Block.Gen
     Cardano.Wallet.Read.Block.Gen.Babbage

--- a/lib/read/lib/Cardano/Read/Ledger/Address.hs
+++ b/lib/read/lib/Cardano/Read/Ledger/Address.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{- |
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+Era-indexed address types.
+-}
+module Cardano.Read.Ledger.Address
+    ( CompactAddrType
+    , CompactAddr (..)
+    , translateCompactAddrShelleyFromByron
+    )
+    where
+
+import Prelude
+
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
+import Cardano.Wallet.Read.Eras
+    ( Allegra
+    , Alonzo
+    , Babbage
+    , Byron
+    , Conway
+    , Mary
+    , Shelley
+    )
+
+import qualified Cardano.Chain.Common as BY
+import qualified Cardano.Ledger.Address as SH
+
+{-----------------------------------------------------------------------------
+    Output
+------------------------------------------------------------------------------}
+
+type family CompactAddrType era where
+    CompactAddrType Byron = BY.CompactAddress
+    CompactAddrType Shelley = SH.CompactAddr StandardCrypto
+    CompactAddrType Allegra = SH.CompactAddr StandardCrypto
+    CompactAddrType Mary = SH.CompactAddr StandardCrypto
+    CompactAddrType Alonzo = SH.CompactAddr StandardCrypto
+    CompactAddrType Babbage = SH.CompactAddr StandardCrypto
+    CompactAddrType Conway = SH.CompactAddr StandardCrypto
+
+newtype CompactAddr era = CompactAddr (CompactAddrType era)
+
+deriving instance Show (CompactAddrType era) => Show (CompactAddr era)
+deriving instance Eq (CompactAddrType era) => Eq (CompactAddr era)
+
+translateCompactAddrShelleyFromByron
+    :: CompactAddrType Byron -> CompactAddrType Shelley
+translateCompactAddrShelleyFromByron = SH.fromBoostrapCompactAddress

--- a/lib/read/lib/Cardano/Wallet/Read/Address.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Address.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- |
+Copyright: © 2024 Cardano Foundation
+License: Apache-2.0
+
+'Addr' — Addresses on the Cardano Blockchain
+-}
+module Cardano.Wallet.Read.Address
+    ( -- * Compact Addr
+      CompactAddr
+    , toShortByteString
+    , fromShortByteString
+    , isBootstrapCompactAddr
+
+    -- * Internal
+    , fromEraCompactAddr
+    ) where
+
+import Prelude
+
+import Cardano.Ledger.Api
+    ( StandardCrypto
+    )
+import Cardano.Read.Ledger.Address
+    ( translateCompactAddrShelleyFromByron
+    )
+import Cardano.Read.Ledger.Eras
+    ( Era (..)
+    , IsEra (..)
+    )
+import Control.Monad.Trans.State.Strict
+    ( evalStateT
+    )
+
+import qualified Cardano.Ledger.Address as SH
+import qualified Cardano.Read.Ledger.Address as L
+import qualified Data.ByteString.Short as SBS
+
+{-----------------------------------------------------------------------------
+    CompactAddr
+------------------------------------------------------------------------------}
+type CompactAddr = SH.CompactAddr StandardCrypto
+
+toShortByteString :: CompactAddr -> SBS.ShortByteString
+toShortByteString = SH.unCompactAddr
+
+fromShortByteString :: SBS.ShortByteString -> Maybe CompactAddr
+fromShortByteString sbs =
+    SH.compactAddr
+        <$> evalStateT (SH.decodeAddrStateLenientT True True sbs) 0
+
+-- | Efficient check whether this is a Bootstrap address
+-- (i.e. an address that was valid in the Byron era).
+isBootstrapCompactAddr :: CompactAddr -> Bool
+isBootstrapCompactAddr = SH.isBootstrapCompactAddr
+
+{-# INLINEABLE fromEraCompactAddr #-}
+fromEraCompactAddr
+    :: forall era. IsEra era
+    => L.CompactAddr era -> CompactAddr
+fromEraCompactAddr = case theEra :: Era era of
+    Byron -> onAddress translateCompactAddrShelleyFromByron
+    Shelley -> onAddress id
+    Allegra -> onAddress id
+    Mary -> onAddress id
+    Alonzo -> onAddress id
+    Babbage -> onAddress id
+    Conway -> onAddress id
+
+-- Helper function for type inference.
+onAddress :: (L.CompactAddrType era -> t) -> L.CompactAddr era -> t
+onAddress f (L.CompactAddr x) = f x


### PR DESCRIPTION
This pull request adds a type `CompactAddr` to the `Cardano.Wallet.Read` module hierarchy. This type is internally represented as a `ShortByteString`.

The module `Cardano.Read.Ledger.Address` adds a type family which records the compact address types for the different eras. We use the Shelley-era ledger implementations for our `CompactAddr` type.

### Issue Number

ADP-3215
