### PR TITLE
[ADP-3401] Expose the docker image as an artifact

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -615,7 +615,7 @@ steps:
 
   - group: Docker
     key: docker-artifacts
-    if: build.env("RELEASE_CANDIDATE") != null || build.tag =~ /^v20/
+    if: build.env("RELEASE_CANDIDATE") != null
     depends_on:
       - linux-artifacts
     steps:
@@ -629,7 +629,7 @@ steps:
         key: docker-build
         depends_on: docker-build-block
         commands:
-          ./scripts/buildkite/release/docker-build.sh
+          ./scripts/buildkite/main/docker-build.sh
         artifact_paths:
           - ./artifacts/*.tgz
         agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -630,6 +630,8 @@ steps:
         depends_on: docker-build-block
         commands:
           ./scripts/buildkite/release/docker-build.sh
+        artifact_paths:
+          - ./artifacts/*.tgz
         agents:
           system: x86_64-linux
 

--- a/scripts/buildkite/main/docker-build.sh
+++ b/scripts/buildkite/main/docker-build.sh
@@ -1,16 +1,20 @@
-#! /usr/bin/env -S nix shell --command bash
-# shellcheck shell=bash
+#! /bin/bash
 
 set -euox pipefail
 
 git fetch --all
 
 RELEASE_CANDIDATE_COMMIT=$(buildkite-agent meta-data get "release-candidate-commit")
+RELEASE_VERSION=$(buildkite-agent meta-data get "release-version")
 
 git checkout "$RELEASE_CANDIDATE_COMMIT"
 
 mkdir -p result
 
-nix build .#dockerImage -o result/docker-image
+mkdir -p artifacts
 
-docker load < result/docker-image
+TARGET="artifacts/cardano-wallet-$RELEASE_VERSION-docker-image.tgz"
+
+nix build .#dockerImage -o "$TARGET"
+
+docker load < "$TARGET"


### PR DESCRIPTION
- [x] Expose a version correct image in the docker build steps, to be copied to the release artifacts, https://buildkite.com/cardano-foundation/cardano-wallet/builds/6874#01915bab-9139-471f-b4a9-5c3267ef937e/161-168

ADP-3401
