### PR TITLE
[ADP-3215] Add `getScriptValidity` to `read`

### DIFF
--- a/lib/read/cardano-wallet-read.cabal
+++ b/lib/read/cardano-wallet-read.cabal
@@ -100,6 +100,7 @@ library
     Cardano.Wallet.Read.Tx.Gen.Shelley
     Cardano.Wallet.Read.Tx.Gen.TxParameters
     Cardano.Wallet.Read.Tx.Inputs
+    Cardano.Wallet.Read.Tx.ScriptValidity
     Cardano.Wallet.Read.Tx.TxId
     Cardano.Wallet.Read.Tx.TxIn
     Cardano.Wallet.Read.Value

--- a/lib/read/lib/Cardano/Wallet/Read/Tx/ScriptValidity.hs
+++ b/lib/read/lib/Cardano/Wallet/Read/Tx/ScriptValidity.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- |
+Copyright: © 2024 IOHK
+License: Apache-2.0
+
+Script validity of a transaction.
+-}
+module Cardano.Wallet.Read.Tx.ScriptValidity
+    ( IsValid (IsValid)
+    , getScriptValidity
+    ) where
+
+import Prelude
+
+import Cardano.Ledger.Alonzo.Tx
+    ( IsValid (..)
+    )
+import Cardano.Read.Ledger.Tx.ScriptValidity
+    ( ScriptValidity (..)
+    , ScriptValidityType
+    , getEraScriptValidity
+    )
+import Cardano.Wallet.Read.Eras
+    ( Era (..)
+    , IsEra (..)
+    )
+import Cardano.Wallet.Read.Tx
+    ( Tx (..)
+    )
+
+{-# INLINABLE getScriptValidity #-}
+getScriptValidity :: forall era. IsEra era => Tx era -> IsValid
+getScriptValidity = case theEra :: Era era of
+    Byron -> onScriptValidity trueValid
+    Shelley -> onScriptValidity trueValid
+    Allegra -> onScriptValidity trueValid
+    Mary -> onScriptValidity trueValid
+    Alonzo -> onScriptValidity id
+    Babbage -> onScriptValidity id
+    Conway -> onScriptValidity id
+  where
+    trueValid = const (IsValid True)
+
+-- Helper function for type inference.
+onScriptValidity
+    :: IsEra era
+    => (ScriptValidityType era -> t)
+    -> Tx era -> t
+onScriptValidity f x =
+    case getEraScriptValidity x of
+        ScriptValidity v -> f v


### PR DESCRIPTION
This pull request adds a function `getScriptValidity` to the `Cardano.Wallet.Read` module hierarchy. We re-export the type `IsValid` from the Shelley ledger codebase, as it works well.

### Issue Number

ADP-3215