### PR TITLE
[ADP-3410] Remove bump.sh instructions from github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,27 +26,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  bump_sh:
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-20.04
-    steps:
-      - name: '📥 Checkout repository'
-        uses: actions/checkout@v3.2.0
-      - name: 'Set up Ruby'
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-      - name: 'Install dependencies'
-        run: |
-          gem install bump-cli
-          sudo snap install yq
-      - name: 'Update Release in Bump.sh'
-        run: './scripts/gh/update-bump.sh'
-        env:
-          BUMP_SH_DOC_ID: ${{ secrets.BUMP_SH_DOC_ID }}
-          BUMP_SH_TOKEN: ${{ secrets.BUMP_SH_TOKEN }}
-      - uses: cachix/install-nix-action@v13
-        with:
-          nix_path: nixpkgs=channel:nixpkgs-21.11-darwin
-      - name: 'Show latest changes from Bump.sh'
-        run: './scripts/gh/show-bump.sh'


### PR DESCRIPTION
This PR completes the move from github to buildkite of the bump.sh swagger push

- [x] Remove bump.sh job in the github release workflow

ADP-3410