### PR TITLE
[ADP-3409] Expect ready status in nix mithril tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -211,7 +211,7 @@ steps:
       agents:
         system: x86_64-linux
       env:
-        SUCCESS_STATUS: syncing
+        SUCCESS_STATUS: ready
         NODE_LOGS_FILE: ./logs/node.log
         WALLET_LOGS_FILE: ./logs/wallet.log
         CLEANUP_DB: true


### PR DESCRIPTION
- [x] Expect `ready` status  when booting the node via mithril as `syncing` seems more rare, https://buildkite.com/cardano-foundation/cardano-wallet/builds/6923#01917035-6188-46bc-adda-60101ce0293a/6-23
