### PR TITLE
[ADP-3409] Expect ready with mithril and docker

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -674,7 +674,6 @@ steps:
         agents:
           system: x86_64-linux
 
-
   - group: Docker Checks
     depends_on:
       - docker-artifacts
@@ -700,12 +699,12 @@ steps:
           cd run/mainnet/docker
           export WALLET_TAG=$(buildkite-agent meta-data get "release-cabal-version")
           rm -rf databases
-          ./run.sh node-db-with-mithril
           ./run.sh sync
         agents:
           system: x86_64-linux
         env:
-          SUCCESS_STATUS: syncing
+          SUCCESS_STATUS: ready
+          USE_MITHRIL: true
           USE_LOCAL_IMAGE: true
 
       - label: Private Network Full Sync

--- a/run/common/docker/run.sh
+++ b/run/common/docker/run.sh
@@ -83,7 +83,7 @@ export NODE_CONFIGS
 
 startup() {
     # Pull the latest images
-    if [ -z "${USE_LOCAL_IMAGE}" ]; then
+    if [ -z "${USE_LOCAL_IMAGE-}" ]; then
         docker compose pull -q
     fi
     # Start the service in detached mode
@@ -112,6 +112,9 @@ node-db-with-mithril() {
 # Case statement to handle different command-line arguments
 case "$1" in
     sync)
+        if [[ -n "${USE_MITHRIL-}" ]]; then
+            node-db-with-mithril
+        fi
         echo "Wallet service port: $WALLET_PORT"
         echo "Wallet service tag: $WALLET_TAG"
         echo "Syncing the service..."


### PR DESCRIPTION
- [x] User `ready` state when testing nix mithril node boot 

ADP-3409