### PR TITLE
[ADP-3215] Add `maryTxLongOutput`

### DIFF
--- a/lib/read/test/Cardano/Wallet/Read/Tx/CBORSpec.hs
+++ b/lib/read/test/Cardano/Wallet/Read/Tx/CBORSpec.hs
@@ -40,20 +40,22 @@ import qualified Test.Unit.Cardano.Read.Ledger.Tx as Txs
 spec :: Spec
 spec = describe "Cardano.Read.Ledger.Tx.CBOR" $ do
     describe "TxCBOR roundtrips" $ do
-        it "byron tx" $ do
-            property $ prop_roundtrip Txs.byronTx
-        it "shelley tx" $ do
-            property $ prop_roundtrip Txs.shelleyTx
-        it "allegra tx" $ do
-            property $ prop_roundtrip Txs.allegraTx
-        it "mary tx" $ do
-            property $ prop_roundtrip Txs.maryTx
-        it "alonzo tx" $ do
-            property $ prop_roundtrip Txs.alonzoTx
-        it "babbage tx" $ do
-            property $ prop_roundtrip Txs.babbageTx
-        it "conway tx" $ do
-            property $ prop_roundtrip Txs.conwayTx
+        it "byron tx" $
+            prop_roundtrip Txs.byronTx
+        it "shelley tx" $
+            prop_roundtrip Txs.shelleyTx
+        it "allegra tx" $
+            prop_roundtrip Txs.allegraTx
+        it "mary tx" $
+            prop_roundtrip Txs.maryTx
+        it "mary tx, long output" $
+            prop_roundtrip Txs.maryTxLongOutput
+        it "property tx" $
+            prop_roundtrip Txs.alonzoTx
+        it "babbage tx" $
+            prop_roundtrip Txs.babbageTx
+        it "conway tx" $
+            prop_roundtrip Txs.conwayTx
 
     describe "TxCBOR depends on era" $ do
         it "may fail deserializing a Conway Tx binary as a Babbage Tx" $ do

--- a/lib/read/test/Cardano/Wallet/Read/Tx/TxIdSpec.hs
+++ b/lib/read/test/Cardano/Wallet/Read/Tx/TxIdSpec.hs
@@ -50,6 +50,8 @@ spec =
             prop_matches_TxId Txs.allegraTx allegraTxId
         it "mary tx" $
             prop_matches_TxId Txs.maryTx maryTxId
+        it "mary tx, long output" $
+            prop_matches_TxId Txs.maryTxLongOutput maryTxLongOutputId
         it "alonzo tx" $
             prop_matches_TxId Txs.alonzoTx alonzoTxId
         it "babbage tx" $
@@ -75,6 +77,10 @@ allegraTxId = unsafeTxIdFromHex
 maryTxId :: TxId
 maryTxId = unsafeTxIdFromHex
     "ca011f22d07b97ee17f6f2e2ef568b9521791608169425e92993c8c6e5541d79"
+
+maryTxLongOutputId :: TxId
+maryTxLongOutputId = unsafeTxIdFromHex
+    "369826b2f60b443d27966d222fa5bedc6b900326b77a09f15473d77f5ef2871c"
 
 alonzoTxId :: TxId
 alonzoTxId = unsafeTxIdFromHex

--- a/lib/read/test/Test/Unit/Cardano/Read/Ledger/Tx.hs
+++ b/lib/read/test/Test/Unit/Cardano/Read/Ledger/Tx.hs
@@ -12,6 +12,7 @@ module Test.Unit.Cardano.Read.Ledger.Tx
     , shelleyTx
     , allegraTx
     , maryTx
+    , maryTxLongOutput
     , alonzoTx
     , babbageTx
     , conwayTx
@@ -141,6 +142,42 @@ maryTx = unsafeParseEraTxFromHex
     \81be9b78955728bffa7efa54297c6a5d73337bd6280205b1759c13\
     \f79d4c93f29871fc51b78aeba80e58200000000000000000000000\
     \00000000000000000000000000000000000000000044a1024100f6"
+
+{- Interesting example of a transaction on Mainnet in the Mary era.
+
+The address of the first output of this transaction
+has more bytes than are parsed by the ledger
+— the ledger silently discards extra bytes at the end of the address.
+In other words, serializing the address after parsing
+will give a different result than the bytes recorded here.
+
+See also
+https://github.com/IntersectMBO/cardano-ledger/commit/ca351b80a7977a45cf4bcb9028b0a87436d2f448
+-}
+maryTxLongOutput :: Tx Mary
+maryTxLongOutput = unsafeParseEraTxFromHex
+    "83a40083825820bf4f8f6287993e17f785c949ef287416ba784198\
+    \bb0ee12b2c7720cbffecd26f0082582052cf971bee4ba1b4e3b32b\
+    \762e0bc3f7af83700bc8897eddbd77bd425dd28e8300825820bf4f\
+    \8f6287993e17f785c949ef287416ba784198bb0ee12b2c7720cbff\
+    \ecd26f01018282584e015bad085057ac10ecc7060f7ac41edd6f63\
+    \068d8963ef7d86ca58669e5ecf2d283418a60be5a848a2380eb721\
+    \000da1e0bbf39733134beca4cb57afb0b35fc89c63061c9914e055\
+    \001a518c75161a035377d082583901f4e9e89cc628b9204fd6e2f4\
+    \ae3e875aa0591fc2eb45b721520d2d22f4e9e89cc628b9204fd6e2\
+    \f4ae3e875aa0591fc2eb45b721520d2d221a2c651d70021a000315\
+    \70031a05f5e100a10083825820ec791e29bdb3157589872d3678db\
+    \93f661d72ac18204759fa5e8d630eee1e66a58408944366b1015ee\
+    \38809356ec48a59277701d40772a232c7cbb1e9510f2c632537d16\
+    \318ba30a06953401dc2bfd693a34dc73d482050e6ccdea5811d0e1\
+    \e32507825820ec791e29bdb3157589872d3678db93f661d72ac182\
+    \04759fa5e8d630eee1e66a58408944366b1015ee38809356ec48a5\
+    \9277701d40772a232c7cbb1e9510f2c632537d16318ba30a069534\
+    \01dc2bfd693a34dc73d482050e6ccdea5811d0e1e32507825820ec\
+    \791e29bdb3157589872d3678db93f661d72ac18204759fa5e8d630\
+    \eee1e66a58408944366b1015ee38809356ec48a59277701d40772a\
+    \232c7cbb1e9510f2c632537d16318ba30a06953401dc2bfd693a34\
+    \dc73d482050e6ccdea5811d0e1e32507f6"
 
 alonzoTx :: Tx Alonzo
 alonzoTx = unsafeParseEraTxFromHex


### PR DESCRIPTION
This pull request adds a test case to the `cardano-wallet-read` package.

Specifically, we add the CBOR of a transaction from the Mary era where one of the output addresses is overly long and cut off by the Cardano ledger implementation.

### Issue Number

ADP-3215