### PR TITLE
[ADP-3415] Fix ruby e2e to work in any build

### DIFF
--- a/scripts/buildkite/main/linux-e2e.sh
+++ b/scripts/buildkite/main/linux-e2e.sh
@@ -11,7 +11,10 @@ export TESTS_LOGDIR
 CARDANO_NODE_CONFIGS="$(pwd)/configs/cardano"
 export CARDANO_NODE_CONFIGS
 
-VERSION=$(buildkite-agent meta-data get "release-version" --default "v2024-07-27")
+CURRENT_VERSION=v2024-08-11
+
+VERSION=$(buildkite-agent meta-data get "release-version" --default "$CURRENT_VERSION")
+
 echo "VERSION=$VERSION"
 
 buildkite-agent artifact \

--- a/scripts/buildkite/release/release-candidate.sh
+++ b/scripts/buildkite/release/release-candidate.sh
@@ -57,6 +57,9 @@ sed -i "s|WALLET_TAG=.*|WALLET_TAG=$NEW_CABAL_VERSION|g" README.md
 sed -i "s|WALLET_VERSION=.*|WALLET_VERSION=$NEW_GIT_TAG|g" README.md
 git commit -am "Update cardano-wallet version in README.md"
 
+sed -i "s|$OLD_GIT_TAG|$NEW_GIT_TAG|g" scripts/buildkite/main/linux-e2e.sh
+git commit -am "Update cardano-wallet version in linux-e2e.sh"
+
 RELEASE_COMMIT=$(git rev-parse HEAD)
 
 git remote set-url origin "git@github.com:cardano-foundation/cardano-wallet.git"


### PR DESCRIPTION
fixed: https://buildkite.com/cardano-foundation/cardano-wallet/builds/7147#01918f83-093a-47d4-bac6-82727a4c9aa1/149-169
release will bump it: https://github.com/cardano-foundation/cardano-wallet/commit/9ab655d8c1d2ce12e77e4d8f59ed824e83ab2c04

ADP-3415
