### PR TITLE
[ADP-3414] Optimize benchmark history tracking

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -464,6 +464,7 @@ steps:
         - trigger-benchmarks
       artifact_paths:
         - ./benchmark-history*.tgz
+        - ./benchmark-history.csv
       command: |
         ./scripts/buildkite/main/benchmark-history.sh
       agents:

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ test/e2e/.direnv/flake-profile*
 node_modules
 package-lock.json
 package.json
+
+# buildkite artifacts testing
+artifacts

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -275,6 +275,7 @@ executable benchmark-history
     , cardano-wallet-buildkite
     , cassava
     , containers
+    , contra-tracer
     , directory
     , filepath
     , exceptions

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -39,6 +39,7 @@ library
   hs-source-dirs:  src
   build-depends:
     , aeson
+    , attoparsec
     , base
     , bytestring
     , cardano-wallet
@@ -83,6 +84,7 @@ library
     , time
     , unliftio
     , unliftio-core
+    , unordered-containers
     , vector
     , wai-middleware-logging
     , with-utf8

--- a/lib/buildkite/cardano-wallet-buildkite.cabal
+++ b/lib/buildkite/cardano-wallet-buildkite.cabal
@@ -44,6 +44,7 @@ library
     , http-client
     , http-client-tls
     , http-media
+    , http-types
     , pretty-simple
     , servant
     , servant-client
@@ -58,5 +59,7 @@ library
 
   exposed-modules:
     Buildkite.API
+    Buildkite.Artifacts.CSV
     Buildkite.Client
+    Buildkite.Connection
     Buildkite.LimitsLock

--- a/lib/buildkite/cardano-wallet-buildkite.cabal
+++ b/lib/buildkite/cardano-wallet-buildkite.cabal
@@ -39,6 +39,7 @@ library
     , base
     , bytestring
     , containers
+    , contra-tracer
     , exceptions
     , http-client
     , http-client-tls
@@ -48,6 +49,7 @@ library
     , servant-client
     , streaming
     , text
+    , stm
     , time
 
   if flag(release)
@@ -57,3 +59,4 @@ library
   exposed-modules:
     Buildkite.API
     Buildkite.Client
+    Buildkite.LimitsLock

--- a/lib/buildkite/src/Buildkite/API.hs
+++ b/lib/buildkite/src/Buildkite/API.hs
@@ -22,14 +22,23 @@ module Buildkite.API
     , WithAuthPipeline
     , overJobs
     , GetArtifact
+    , newLimitsLock
+    , LimitsLock
+    , withLimitsLock
     )
 where
 
 import Prelude
 
+import Buildkite.LimitsLock
+    ( LimitsLock (..)
+    , newLimitsLock
+    )
 import Control.Monad
-    ( mzero
-    , (>=>)
+    ( (>=>)
+    )
+import Control.Monad.IO.Class
+    ( MonadIO (..)
     )
 import Data.Aeson
     ( FromJSON (..)
@@ -55,8 +64,11 @@ import Servant.API
     ( Capture
     , Get
     , Header
+    , Headers (getResponse)
     , JSON
     , QueryParam
+    , ResponseHeader (..)
+    , lookupResponseHeader
     , (:>)
     )
 import Servant.Client
@@ -135,7 +147,7 @@ type GetBuilds =
     PreamblePipeline
         ( "builds"
             :> QueryParam "page" Int
-            :> Get '[JSON] [Build []]
+            :> Get '[JSON] (BuildKiteHeaders [Build []])
         )
 
 type GetBuildsOfBranch =
@@ -143,7 +155,7 @@ type GetBuildsOfBranch =
         ( "builds"
             :> QueryParam "branch" String
             :> QueryParam "page" Int
-            :> Get '[JSON] [Build []]
+            :> Get '[JSON] (BuildKiteHeaders [Build []])
         )
 
 type PreambleBuilds a =
@@ -157,7 +169,7 @@ type GetArtifacts =
     PreambleBuilds
         ( QueryParam "page" Int
             :> "artifacts"
-            :> Get '[JSON] [Artifact]
+            :> Get '[JSON] (BuildKiteHeaders [Artifact])
         )
 
 type PreambleJobs a =
@@ -172,22 +184,48 @@ type GetArtifact mime content =
         ( "artifacts"
             :> Capture "artifact" Text
             :> "download"
-            :> Get '[mime] content
+            :> Get '[mime] (BuildKiteHeaders content)
         )
 
-type WithAuthPipeline a = Maybe Text -> Text -> Text -> a
+type WithAuthPipeline a = LimitsLock -> Maybe Text -> Text -> Text -> a
+
+respectLimits :: LimitsLock -> BuildKiteHeaders o -> ClientM o
+respectLimits l r = do
+    let remaining = case lookupResponseHeader r
+                            :: ResponseHeader "RateLimit-Remaining" Int of
+            Header remaining' -> remaining'
+            _ -> error "RateLimit-Remaining header not found"
+    let reset = case lookupResponseHeader r
+                        :: ResponseHeader "RateLimit-Reset" Int of
+            Header reset' -> reset'
+            _ -> error "RateLimit-Reset header not found"
+    liftIO $ setLimit l remaining reset
+    pure $ getResponse r
+
+withLimitsLock :: LimitsLock -> ClientM (BuildKiteHeaders b) -> ClientM b
+withLimitsLock l f = do
+    liftIO $ checkLimit l
+    r <- f
+    respectLimits l r
 
 fetchBuilds
     :: WithAuthPipeline
         (Maybe Int -> ClientM [Build []])
-fetchBuilds = client $ Proxy @GetBuilds
+fetchBuilds l ma o r mc =
+    withLimitsLock l $ client (Proxy @GetBuilds) ma o r mc
 
 fetchBuildsOfBranch
     :: WithAuthPipeline
         (Maybe String -> Maybe Int -> ClientM [Build []])
-fetchBuildsOfBranch = client $ Proxy @GetBuildsOfBranch
+fetchBuildsOfBranch l ma o r mb mc =
+    withLimitsLock l $ client (Proxy @GetBuildsOfBranch) ma o r mb mc
 
 fetchArtifacts
     :: WithAuthPipeline
         (Int -> Maybe Int -> ClientM [Artifact])
-fetchArtifacts = client $ Proxy @GetArtifacts
+fetchArtifacts l ma o r bn mp = do
+    withLimitsLock l $ client (Proxy @GetArtifacts) ma o r bn mp
+
+type RateLimitRemaining = Header "RateLimit-Remaining" Int
+type RateLimitReset = Header "RateLimit-Reset" Int
+type BuildKiteHeaders = Headers '[RateLimitRemaining, RateLimitReset]

--- a/lib/buildkite/src/Buildkite/Artifacts/CSV.hs
+++ b/lib/buildkite/src/Buildkite/Artifacts/CSV.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Buildkite.Artifacts.CSV
+    ( fetchCSVArtifactContent
+    )
+where
+
+import Prelude
+
+import Buildkite.API
+    ( GetArtifact
+    , WithAuthPipeline
+    )
+import Data.Proxy
+    ( Proxy (..)
+    )
+import Data.Text
+    ( Text
+    )
+import Network.HTTP.Media
+    ( (//)
+    )
+import Servant.API.ContentTypes
+    ( Accept (contentType)
+    , MimeRender (..)
+    , MimeUnrender (mimeUnrender)
+    )
+import Servant.Client
+    ( ClientM
+    , client
+    )
+
+import qualified Data.ByteString.Lazy.Char8 as BL8
+
+data CSV
+
+instance Accept CSV where
+    contentType _ = "text" // "csv"
+
+instance Show a => MimeRender CSV a where
+    mimeRender _ val = BL8.pack $ show val
+
+instance MimeUnrender CSV BL8.ByteString where
+    mimeUnrender _ = Right
+
+fetchCSVArtifactContent
+    :: WithAuthPipeline (Int -> Text -> Text -> ClientM BL8.ByteString)
+fetchCSVArtifactContent =
+    client (Proxy :: Proxy (GetArtifact CSV BL8.ByteString))

--- a/lib/buildkite/src/Buildkite/Client.hs
+++ b/lib/buildkite/src/Buildkite/Client.hs
@@ -8,7 +8,6 @@ module Buildkite.Client
     , JobMap
     , BuildJobsMap
     , BuildAPI
-    , paging
     , getBuilds
     , getBuildsOfBranch
     , getArtifacts
@@ -24,6 +23,7 @@ import Buildkite.API
     , ArtifactURL (..)
     , Job
     , WithAuthPipeline
+    , WithLockingAuthPipeline
     , fetchArtifacts
     , fetchBuilds
     , fetchBuildsOfBranch
@@ -62,11 +62,13 @@ import qualified Data.ByteString.Lazy.Char8 as BL
 import qualified Data.Map as Map
 import qualified Streaming.Prelude as S
 
+-- | An opaque containg a handle to the Buildkite API
 data Query
     = Query
-        { query :: forall a. ClientM a -> IO (Maybe a)
-        , withAuth :: forall a. WithAuthPipeline a -> a
-        }
+    { _query :: forall a. ClientM a -> IO (Maybe a)
+    , _withLockAuth :: forall a. WithLockingAuthPipeline a -> a
+    , _withAuth :: forall a. WithAuthPipeline a -> a
+    }
 
 type JobMap = Map Text Job
 
@@ -74,7 +76,9 @@ type BuildJobsMap = BKAPI.Build (Map Text)
 
 type BuildAPI = BKAPI.Build []
 
-paging :: Monad m => (Maybe Int -> m (Maybe [a]))
+paging
+    :: Monad m
+    => (Maybe Int -> m (Maybe [a]))
     -> Stream (Of a) m ()
 paging f = go 1
   where
@@ -90,14 +94,14 @@ paging f = go 1
                     _ -> go $ page + 1
 
 getBuilds :: Query -> Stream (Of BuildAPI) IO ()
-getBuilds (Query q w) = paging $ q . w fetchBuilds
+getBuilds (Query q w _) = paging $ q . w fetchBuilds
 
 getBuildsOfBranch :: Query -> String -> Stream (Of BuildAPI) IO ()
-getBuildsOfBranch (Query q w) branch =
+getBuildsOfBranch (Query q w _) branch =
     paging $ q . w fetchBuildsOfBranch (Just branch)
 
 getArtifacts :: Query -> BuildAPI -> Stream (Of (BuildJobsMap, Artifact)) IO ()
-getArtifacts (Query q w) build =
+getArtifacts (Query q w _) build =
     S.map (build',) $ paging $ q . w fetchArtifacts (number build)
   where
     build' = overJobs build $ \job' -> Map.fromList $ do
@@ -115,7 +119,7 @@ getArtifactsContent
     -> BuildJobsMap
     -> Artifact
     -> Stream (Of (BuildJobsMap, Artifact, r)) IO ()
-getArtifactsContent (Query q w) getArtifact build artifact = do
+getArtifactsContent (Query q _ w) getArtifact build artifact = do
     mBenchResults <- do
         lift
             $ q

--- a/lib/buildkite/src/Buildkite/Connection.hs
+++ b/lib/buildkite/src/Buildkite/Connection.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Buildkite.Connection
+    ( PipelineName (..)
+    , OrganizationName (..)
+
+      -- * Connector
+    , Connector
+    , newConnector
+
+      -- * Error handling
+    , HandleClientError (..)
+    , bailout
+    , skip410
+    , handleClientError
+    )
+where
+
+import Prelude
+
+import Buildkite.Client
+    ( Query (..)
+    )
+import Buildkite.LimitsLock
+    ( LimitsLockLog
+    , newLimitsLock
+    )
+import Control.Tracer
+    ( Tracer
+    )
+import Data.Functor
+    ( (<&>)
+    )
+import Data.Text
+    ( Text
+    )
+import Network.HTTP.Client
+    ( Manager
+    , ManagerSettings (..)
+    , Request (..)
+    , newManager
+    )
+import Network.HTTP.Client.TLS
+    ( tlsManagerSettings
+    )
+import Network.HTTP.Types
+    ( status410
+    )
+import Servant.Client
+    ( BaseUrl (..)
+    , ClientEnv
+    , ClientError (..)
+    , ClientM
+    , ResponseF (..)
+    , Scheme (..)
+    , mkClientEnv
+    , runClientM
+    )
+import System.Environment
+    ( getEnv
+    )
+
+import qualified Data.Text as T
+
+buildkiteDomain :: String
+buildkiteDomain = "api.buildkite.com"
+
+buildkitePort :: Int
+buildkitePort = 443
+
+-- | The name of the pipeline
+newtype PipelineName = PipelineName Text
+
+-- | The name of the organization
+newtype OrganizationName = OrganizationName Text
+
+-- | How to handle http client errors
+newtype HandleClientError
+    = HandleClientError (forall a. IO (Either ClientError a) -> IO (Maybe a))
+
+-- | The way to create a query type
+type Connector = OrganizationName -> PipelineName -> HandleClientError -> Query
+
+-- | Create a new connect computer
+newConnector
+    :: String
+    -- ^ Environment variable for the API token
+    -> Int
+    -- ^ The maximum remaining request per minute, before locking (< 200)
+    -> Tracer IO LimitsLockLog
+    -- ^ The tracer for the limits lock events
+    -> IO Connector
+newConnector tokenEnvVar lockLimit lockTracer = do
+    apiToken <- getEnv tokenEnvVar <&> \t -> "Bearer " ++ t
+    manager <- newManager $ stripAuthOnRedirect tlsManagerSettings
+    let env = buildkiteEnv manager
+        runQuery :: HandleClientError -> ClientM a -> IO (Maybe a)
+        runQuery (HandleClientError f) action = f $ runClientM action env
+    limitsLock <- newLimitsLock lockTracer lockLimit
+    pure $ \(OrganizationName organizationSlug) (PipelineName slug) h ->
+        let withLockingAuthPipeline action =
+                action limitsLock (Just $ T.pack apiToken) organizationSlug slug
+            withAuthPipeline action =
+                action (Just $ T.pack apiToken) organizationSlug slug
+        in  Query (runQuery h) withLockingAuthPipeline withAuthPipeline
+
+-- the environment for the buildkite API
+buildkiteEnv :: Manager -> ClientEnv
+buildkiteEnv manager =
+    mkClientEnv manager
+        $ BaseUrl Https buildkiteDomain buildkitePort ""
+
+-- necessary for the buildkite API on getting artifacts content (redirect to AWS)
+stripAuthOnRedirect :: ManagerSettings -> ManagerSettings
+stripAuthOnRedirect settings =
+    settings
+        { managerModifyRequest = \req -> do
+            pure
+                $ req
+                    { shouldStripHeaderOnRedirect =
+                        \case
+                            "Authorization" -> True
+                            _ -> False
+                    }
+        }
+
+data SkipOrAbort = Skip | Abort
+
+bailout :: HandleClientError
+bailout = handleClientError $ const Abort
+
+handleClientError :: (ClientError -> SkipOrAbort) -> HandleClientError
+handleClientError g = HandleClientError $ \f -> do
+    res <- f
+    case res of
+        Left e -> case g e of
+            Abort -> error $ show e
+            Skip -> pure Nothing
+        Right a -> pure $ Just a
+
+skip410 :: HandleClientError
+skip410 = handleClientError $ \case
+    FailureResponse _ (Response s _ _ _)
+        | s == status410 -> Skip
+    _ -> Abort

--- a/lib/buildkite/src/Buildkite/LimitsLock.hs
+++ b/lib/buildkite/src/Buildkite/LimitsLock.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Buildkite.LimitsLock
+    ( LimitsLock (..)
+    , SetLimit
+    , LimitsLockLog (..)
+    , newLimitsLock
+    ) where
+
+import Prelude
+
+import Control.Concurrent
+    ( threadDelay
+    )
+import Control.Concurrent.STM
+    ( atomically
+    , newTVarIO
+    , readTVar
+    , retry
+    , writeTVar
+    )
+import Control.Monad
+    ( join
+    , when
+    )
+import Control.Tracer
+    ( Tracer
+    , traceWith
+    )
+import Data.Functor
+    ( ($>)
+    )
+
+-- | Set the limit of requests to a resource. This specific interface is dictated
+-- by buildkite's API, but it could be generalized to any rate limiting system.
+type SetLimit =
+    Int
+    -- ^ Remaining requests.
+    -> Int
+    -- ^ Seconds to wait before the allowed limit is reset.
+    -> IO ()
+
+-- | A lock to limit the number of requests to a resource.
+data LimitsLock = LimitsLock
+    { setLimit :: SetLimit
+    -- ^ Try to lock the resource.
+    , checkLimit :: IO ()
+    -- ^ Check if the resource is locked and wait until it is available.
+    }
+
+-- | Log messages for 'LimitsLock'.
+newtype LimitsLockLog = RateLimitReached Int
+    deriving (Show)
+
+-- | Create a new 'LimitsLock'. To simplify the implementation, the setLimit is
+-- implemented as blocking. A more sophisticated implementation could use
+-- a thread to reset the lock after the time has passed.
+newLimitsLock
+    :: Tracer IO LimitsLockLog
+    -- ^ Tracer for logging messages.
+    -> Int
+    -- ^ Number of remaining requests to consider as the limit to block the resource.
+    -> IO LimitsLock
+newLimitsLock tracer safeRemaining = do
+    lock <- newTVarIO False
+    let
+        pass = pure ()
+        block secs = do
+            traceWith tracer $ RateLimitReached secs
+            threadDelay $ secs * 1000000
+            atomically $ writeTVar lock False
+        setLimit remaining secs = join $ atomically $ do
+            locked <- readTVar lock
+            if locked
+                then pure pass
+                else
+                    if remaining < safeRemaining
+                        then writeTVar lock True $> block secs
+                        else pure pass
+        checkLimit = do
+            atomically $ do
+                locked <- readTVar lock
+                when locked retry
+    pure $ LimitsLock{..}

--- a/scripts/buildkite/main/benchmark-history.sh
+++ b/scripts/buildkite/main/benchmark-history.sh
@@ -6,7 +6,7 @@ set -euox pipefail
 mkdir -p ./benchmark-history
 
 benchmark-history \
-    --since 2024-06-24 \
+    --since 2024-08-25 \
     --charts-dir benchmark-history
 
 # shellcheck disable=SC2295
@@ -15,6 +15,10 @@ branch="${BUILDKITE_BRANCH#release-candidate/}"
 # Sanitize the branch variable to replace '/' with '-'. Useful when not running
 # against a release candidate branch.
 branch_sanitized="${branch//\//-}"
+
+mkdir -p artifacts
+
+mv benchmark-history/benchmark-history.csv .
 
 # shellcheck disable=SC2086
 tar -czf ./benchmark-history.${branch_sanitized}.tgz benchmark-history


### PR DESCRIPTION
This  PR refactors and improve buildkite lib.

- Introduces a LimitsLock object to avoid `429` when the 200 API calls per minute are surpassed.
- Factor out code from the benchmark-history exe into the buildkite lib

I also compute the benchmark history incrementally, by adding new data points to the last checkpoint

- Exposes the csv database of benchmarks for further reuse
- Catch that csv while collecting new benchmark results, stopping the collection there and simply amending it 