### PR TITLE
[ADP-3344] Change Deposit Wallet to use `Cardano.Wallet.Read`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -157,8 +157,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/cardano-foundation/cardano-wallet-agda
-    tag: 1feea08e8c387cf23deee780e0de52b24edc004c
-    --sha256: 1zsx0191pwaw30017jrxll1ldfvp4pk9jkw0fb9pd4235kpmslkm
+    tag: 525eb93be15a8c1ea6198e472f401ea0f9a985cd
+    --sha256: 1mw98kdqhafdq89ry3yxwd1xwjd7g69fs5pd1p2np8sdrpxh3n8g
     subdir:
       lib/customer-deposit-wallet-pure
       lib/cardano-wallet-read

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -53,7 +53,6 @@ library
     , cardano-crypto
     , cardano-wallet:cardano-wallet
     , cardano-wallet-network-layer
-    , cardano-wallet-primitive
     , cardano-wallet-read == 0.2024.8.27
     , cardano-ledger-byron
     , containers
@@ -117,6 +116,7 @@ library customer-deposit-wallet-http
     , aeson-pretty
     , base
     , bytestring
+    , cardano-wallet-read
     , customer-deposit-wallet
     , http-media
     , insert-ordered-containers
@@ -148,8 +148,6 @@ test-suite unit
     , base
     , bytestring
     , cardano-crypto
-    , cardano-wallet:cardano-wallet
-    , cardano-wallet-primitive
     , cardano-wallet-test-utils
     , customer-deposit-wallet:{customer-deposit-wallet, customer-deposit-wallet-http}
     , directory

--- a/lib/customer-deposit-wallet/http/Cardano/Wallet/Deposit/HTTP/Types/JSON/Encoding.hs
+++ b/lib/customer-deposit-wallet/http/Cardano/Wallet/Deposit/HTTP/Types/JSON/Encoding.hs
@@ -10,8 +10,8 @@
 --
 module Cardano.Wallet.Deposit.HTTP.Types.JSON.Encoding
     ( Custom (..)
-    , ViaText (..)
     , customOptions
+    , ViaText (..)
     ) where
 
 import Prelude

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Balance.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Balance.hs
@@ -59,7 +59,7 @@ type IsOurs addr = addr -> Bool
 --
 -- Returns both a delta and the new value.
 applyBlock
-    :: IsOurs Read.Addr -> Read.Block -> UTxO -> (DeltaUTxO, UTxO)
+    :: IsOurs Read.Address -> Read.Block -> UTxO -> (DeltaUTxO, UTxO)
 applyBlock isOurs block u0 =
     (mconcat $ reverse dus, u1)
  where
@@ -72,7 +72,7 @@ applyBlock isOurs block u0 =
 --
 -- Returns both a delta and the new value.
 applyTx
-    :: IsOurs Read.Addr -> Read.Tx -> UTxO -> (DeltaUTxO, UTxO)
+    :: IsOurs Read.Address -> Read.Tx -> UTxO -> (DeltaUTxO, UTxO)
 applyTx isOurs tx u0 =
     if isUnchangedUTxO
         then (mempty, u0)

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/UTxO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/UTxO.hs
@@ -12,4 +12,19 @@ module Cardano.Wallet.Deposit.Pure.UTxO
     , null
     ) where
 
-import Cardano.Wallet.Primitive.Types.UTxO
+import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
+    ( DeltaUTxO
+    , excludingD
+    , null
+    , receiveD
+    )
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxO
+    ( UTxO
+    , balance
+    , excluding
+    , filterByAddress
+    , restrictedBy
+    )
+import Data.Map.Strict
+    ( toList
+    )

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/UTxOHistory.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/UTxOHistory.hs
@@ -1,9 +1,31 @@
 module Cardano.Wallet.Deposit.Pure.UTxOHistory
     ( UTxOHistory
     , empty
+    , appendBlock
 
     , DeltaUTxOHistory (..)
     , getUTxO
     ) where
 
-import Cardano.Wallet.DB.Store.UTxOHistory.Model
+import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
+    ( DeltaUTxO
+    )
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory
+    ( UTxOHistory
+    , appendBlock
+    , empty
+    , getUTxO
+    )
+import Cardano.Wallet.Deposit.Read
+    ( Slot
+    , SlotNo
+    )
+
+-- | Changes to the UTxO history.
+data DeltaUTxOHistory
+    = -- | New slot tip, changes within that block.
+      AppendBlock SlotNo DeltaUTxO
+    | -- | Rollback tip.
+      Rollback Slot
+    | -- | Move finality forward.
+      Prune SlotNo

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -10,7 +10,6 @@ module Cardano.Wallet.Deposit.Read
     , Slot
     , ChainPoint (..)
 
-    , Addr
     , Address
     , fromRawAddress
     , toRawAddress
@@ -93,14 +92,10 @@ data ChainPoint
     | At Slot
     deriving (Eq, Ord, Show)
 
--- newtype Addr = Addr { getAddressBytes :: ByteString }
---    deriving (Eq, Show)
-type Addr = W.Address
-
 -- | Synonym for readability.
 -- The ledger specifications define @Addr@.
 -- Byron addresses are represented by @Addr_bootstrap@.
-type Address = Addr
+type Address = W.Address
 
 fromRawAddress :: Read.CompactAddr -> Address
 fromRawAddress = W.Address . SBS.fromShort . Read.toShortByteString

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -8,29 +8,24 @@
 module Cardano.Wallet.Deposit.Read
     ( Network (..)
     , Slot
+    , Read.SlotNo
     , ChainPoint (..)
 
     , Address
-    , fromRawAddress
-    , toRawAddress
     , KeyHash
     , mkEnterpriseAddress
     , mockAddress
 
     , Ix
-    , TxIn
-    , TxOut
+    , Read.TxIn
+    , Read.TxOut
     , address
-    , Value
+    , Read.Value
     , UTxO
 
-    , TxId
+    , Read.TxId
     , Tx
-    , W.txScriptInvalid
-    , W.collateralInputs
-    , W.inputs
-    , W.outputs
-    , W.collateralOutput
+    , Read.utxoFromEraTx
 
     , TxBody
     , TxWitness
@@ -50,8 +45,14 @@ module Cardano.Wallet.Deposit.Read
 
 import Prelude
 
+import Cardano.Wallet.Read.Tx
+    ( TxIx
+    )
 import Data.ByteString
     ( ByteString
+    )
+import Data.Map
+    ( Map
     )
 import Data.Maybe
     ( fromJust
@@ -64,14 +65,6 @@ import Numeric.Natural
     )
 
 import qualified Cardano.Chain.Genesis as Byron
-import qualified Cardano.Wallet.Primitive.Types as W
-import qualified Cardano.Wallet.Primitive.Types.Address as W
-import qualified Cardano.Wallet.Primitive.Types.TokenBundle as W
-import qualified Cardano.Wallet.Primitive.Types.Tx as W
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxIn as W
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as TxOut
-import qualified Cardano.Wallet.Primitive.Types.Tx.TxOut as W
-import qualified Cardano.Wallet.Primitive.Types.UTxO as W
 import qualified Cardano.Wallet.Read as Read
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -85,7 +78,7 @@ import qualified Data.ByteString.Short as SBS
 data Network = Testnet | Mainnet
 
 -- Spec: type Slot = Natural
-type Slot = W.SlotNo
+type Slot = Read.SlotNo
 
 data ChainPoint
     = Origin
@@ -95,14 +88,7 @@ data ChainPoint
 -- | Synonym for readability.
 -- The ledger specifications define @Addr@.
 -- Byron addresses are represented by @Addr_bootstrap@.
-type Address = W.Address
-
-fromRawAddress :: Read.CompactAddr -> Address
-fromRawAddress = W.Address . SBS.fromShort . Read.toShortByteString
-
-toRawAddress :: Address -> Read.CompactAddr
-toRawAddress (W.Address a) =
-    fromJust . Read.fromShortByteString $ SBS.toShort a
+type Address = Read.CompactAddr
 
 mockAddress :: Show a => a -> Address
 mockAddress = mkEnterpriseAddress . B8.pack . show
@@ -112,7 +98,7 @@ type KeyHash = ByteString
 
 mkEnterpriseAddress :: KeyHash -> Address
 mkEnterpriseAddress keyHash =
-    W.Address . BS.pack
+    fromJust . Read.fromShortByteString . SBS.pack
         $ [tagEnterprise] <> take 28 (BS.unpack keyHash <> repeat 0)
 
 tagEnterprise :: Word8
@@ -121,25 +107,14 @@ tagEnterprise = 0b01100001
 dummyAddress :: Address
 dummyAddress = mockAddress (0 :: Int)
 
-type Ix = Natural
+type Ix = TxIx
 
--- type TxIn = (TxId, Ix)
-type TxIn = W.TxIn
+address :: Read.TxOut -> Address
+address = Read.getCompactAddr
 
--- type TxOut = (Addr, Value)
-type TxOut = W.TxOut
+type UTxO = Map Read.TxIn Read.TxOut
 
-address :: TxOut -> Address
-address = TxOut.address
-
-type Value = W.TokenBundle
-
--- type UTxO = Map TxIn TxOut
-type UTxO = W.UTxO
-
-type TxId = ByteString
-
-type Tx = W.Tx
+type Tx = Read.Tx Read.Conway
 
 type TxBody = ()
 
@@ -183,7 +158,7 @@ dummyBHBody :: BHBody
 dummyBHBody = BHBody
     { prev = Nothing
     , blockno = 128
-    , slot = 42
+    , slot = Read.SlotNo 42
     , bhash = ()
     }
 

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
@@ -116,7 +116,8 @@ payFromFaucet env destinations =
     txBody = Write.TxBody
         { Write.spendInputs = mempty
         , Write.collInputs = mempty
-        , Write.txouts = Map.fromList $ zip [0..] $ map toTxOut destinations
+        , Write.txouts =
+            Map.fromList $ zip [toEnum 0..] $ map toTxOut destinations
         , Write.collRet = Nothing
         }
     tx = signTx (xprv (faucet env)) [] txBody

--- a/lib/unit/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -219,7 +219,7 @@ import Cardano.Wallet.Primitive.Types.Tx.TxOut
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..)
     )
-import Cardano.Wallet.Read.Eras.EraValue
+import Cardano.Wallet.Read.Eras
     ( eraValueSerialize
     )
 import Cardano.Wallet.Read.Tx.CBOR

--- a/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Layer.hs
@@ -184,7 +184,7 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..)
     )
-import Cardano.Wallet.Read.Eras.EraValue
+import Cardano.Wallet.Read.Eras
     ( EraValue
     )
 import Cardano.Wallet.Read.Tx.CBOR

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Transactions/Model.hs
@@ -68,7 +68,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.Tx.Tx
     ( Tx (txCBOR)
     )
-import Cardano.Wallet.Read.Eras.EraValue
+import Cardano.Wallet.Read.Eras
     ( eraValueSerialize
     )
 import Cardano.Wallet.Read.Tx.CBOR


### PR DESCRIPTION
This pull request changes the module `Cardano.Wallet.Deposit.Read` to use the types from `Cardano.Wallet.Read` and implements a minimal set of necessary follow-up adjustments.

This pull request manages to remove the dependency of the `customer-deposit-wallet` on the `cardano-wallet-primitive` package.

### Issue Number

ADP-3344