### PR TITLE
[ADP-3344] Use `applyTx` from the `cardano-wallet-agda` repository

### DIFF
--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Balance.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Balance.hs
@@ -3,14 +3,21 @@
 module Cardano.Wallet.Deposit.Pure.Balance
     ( balance
     , availableUTxO
+    , IsOurs
     , applyBlock
     ) where
 
 import Prelude
 
-import Cardano.Wallet.Deposit.Pure.UTxO
+import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
     ( DeltaUTxO
-    , UTxO
+    )
+import Cardano.Wallet.Deposit.Pure.UTxO.Tx
+    ( IsOurs
+    , applyTx
+    )
+import Cardano.Wallet.Deposit.Pure.UTxO.UTxO
+    ( UTxO
     , balance
     , excluding
     )
@@ -21,11 +28,8 @@ import Data.Set
     ( Set
     )
 
-import qualified Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO as DeltaUTxO
-import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxO as UTxO
 import qualified Cardano.Wallet.Deposit.Read as Read
 import qualified Cardano.Wallet.Deposit.Write as Write
-import qualified Cardano.Wallet.Read.Tx as Tx
 
 {-----------------------------------------------------------------------------
     Wallet Balance
@@ -48,8 +52,6 @@ availableUTxO u pending =
 {-----------------------------------------------------------------------------
     Applying Blocks
 ------------------------------------------------------------------------------}
-type IsOurs addr = addr -> Bool
-
 -- | Apply a 'Block' to the 'UTxO'.
 --
 -- Returns both a delta and the new value.
@@ -57,49 +59,10 @@ applyBlock
     :: IsOurs Read.Address -> Read.Block -> UTxO -> (DeltaUTxO, UTxO)
 applyBlock isOurs block u0 =
     (mconcat $ reverse dus, u1)
- where
+  where
     (dus, u1) =
         mapAccumL' (applyTx isOurs) u0
             $ Read.transactions block
-
--- | Apply a transactions to the 'UTxO'.
---
--- Returns both a delta and the new value.
-applyTx
-    :: IsOurs Read.Address -> Read.Tx -> UTxO -> (DeltaUTxO, UTxO)
-applyTx isOurs tx u0 =
-    if isUnchangedUTxO
-        then (mempty, u0)
-        else (du, u)
-  where
-    (du, u) = (du21 <> du10, u2)
-
-    (du10, u1)   = spendTxD tx u0
-    receivedUTxO = UTxO.filterByAddress isOurs (Read.utxoFromEraTx tx)
-    (du21, u2)   = DeltaUTxO.receiveD u1 receivedUTxO
-
-    -- NOTE: Performance.
-    -- 'applyTx' is part of a tight loop that inspects all transactions
-    -- (> 30M Txs as of Feb 2022).
-    -- Thus, we make a small performance optimization here.
-    -- Specifically, we want to reject a transaction as soon as possible
-    -- if it does not change the 'UTxO' set. The test
-    isUnchangedUTxO = UTxO.null receivedUTxO && DeltaUTxO.null du10
-    -- allocates slightly fewer new Set/Map than the definition
-    --   isUnchangedUTxO =  mempty == du
-
-{-----------------------------------------------------------------------------
-    UTxO utilities
-------------------------------------------------------------------------------}
--- | Remove unspent outputs that are consumed by the given transaction.
-spendTxD :: Read.Tx -> UTxO -> (DeltaUTxO, UTxO)
-spendTxD tx !u =
-    u `DeltaUTxO.excludingD` inputsToExclude
-  where
-    inputsToExclude =
-        case Tx.getScriptValidity tx of
-            Tx.IsValidC True -> Tx.getInputs tx
-            Tx.IsValidC False -> Tx.getCollateralInputs tx
 
 {-----------------------------------------------------------------------------
     Helpers


### PR DESCRIPTION
This pull request changes `Cardano.Wallet.Deposit.Pure.Balance` to use the `applyTx` from the `cardano-wallet-agda` repository.

In the other repository, we may eventually verify the correctness of the `applyTx` function.

### Issue number

ADP-3344