### PR TITLE
[ADP-3421] Ruby E2E tests: Skip test with two cosigners

### DIFF
--- a/test/e2e/spec/e2e_shared_spec.rb
+++ b/test/e2e/spec/e2e_shared_spec.rb
@@ -337,7 +337,7 @@ RSpec.describe 'Cardano Wallet E2E tests - Shared wallets', :all, :e2e, :shared 
 
       it 'Multi-assets transaction - two cosigners, all' do
         # TODO: [ADP-3419] https://cardanofoundation.atlassian.net/browse/ADP-3419
-        pending 'wallet has run out of HappyCoin and SadCoin'
+        skip 'wallet has run out of HappyCoin and SadCoin'
         amt = 1
         amt_ada = 1_600_000
         src_wid = @wid_sha_cos0_all


### PR DESCRIPTION
This pull requests makes happy coins sad again. Well, actually this pull request uses `skip` instead of `pending` for the E2E test on shared wallets. It turns out that `pending` expects failure, while `skip` ignores the test entirely.

### Issue Number

ADP-3421