### PR TITLE
[ADP-3344] Implement REST-like `IO` interface for Deposit Wallet

### DIFF
--- a/lib/crypto-primitives/src/Cryptography/Hash/Blake.hs
+++ b/lib/crypto-primitives/src/Cryptography/Hash/Blake.hs
@@ -6,6 +6,7 @@ module Cryptography.Hash.Blake
     , Blake2b_224
     , Blake2b_256
 
+    , blake2b160
     , blake2b256
     , blake2b224
     , hashSizeBlake2b224
@@ -40,6 +41,9 @@ blake2b256 = BA.convert . hash @_ @Blake2b_256
 -- | Hash a byte string using Blake2b with a 224-bit (28-byte) digest.
 blake2b224 :: ByteArrayAccess a => a -> ByteString
 blake2b224 = BA.convert . hash @_ @Blake2b_224
+
+blake2b160 :: ByteArrayAccess a => a -> ByteString
+blake2b160 = BA.convert . hash @_ @Blake2b_160
 
 hashSizeBlake2b224 :: Int
 hashSizeBlake2b224 = hashDigestSize Blake2b_224

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -76,6 +76,7 @@ library
     Cardano.Wallet.Deposit.IO.DB
     Cardano.Wallet.Deposit.IO.Network.Mock
     Cardano.Wallet.Deposit.IO.Network.Type
+    Cardano.Wallet.Deposit.IO.Resource
     Cardano.Wallet.Deposit.Pure
     Cardano.Wallet.Deposit.Pure.Balance
     Cardano.Wallet.Deposit.Pure.UTxO

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -12,24 +12,21 @@ maintainer:         hal@cardanofoundation.org
 copyright:          2023 Cardano Foundation
 category:           Web
 data-files:         data/swagger.json
-
 extra-source-files:
   spec/**/*.lagda.md
   spec/**/*.lhs.md
   spec/**/*.openapi.yaml
 
 common language
-  default-language:
-    Haskell2010
+  default-language:   Haskell2010
   default-extensions:
     NoImplicitPrelude
     OverloadedStrings
 
 common opts-lib
   ghc-options:
-    -Wall -Wcompat
-    -Wredundant-constraints
-    -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wall -Wcompat -Wredundant-constraints -Wincomplete-uni-patterns
+    -Wincomplete-record-updates
 
   if flag(release)
     ghc-options: -O2 -Werror
@@ -50,27 +47,36 @@ library
     , async
     , base
     , bytestring
+    , cardano-addresses
+    , cardano-binary
     , cardano-crypto
-    , cardano-wallet:cardano-wallet
-    , cardano-wallet-network-layer
-    , cardano-wallet-read == 0.2024.8.27
+    , cardano-ledger-api
+    , cardano-ledger-binary
     , cardano-ledger-byron
+    , cardano-strict-containers
+    , cardano-wallet
+    , cardano-wallet-network-layer
+    , cardano-wallet-read           ==0.2024.8.27
     , containers
     , contra-tracer
+    , crypto-primitives
     , customer-deposit-wallet-pure
     , delta-store
     , delta-table
     , delta-types
+    , directory
+    , filepath
     , io-classes
     , iohk-monitoring-extra
+    , memory
+    , microlens
     , OddWord
     , sqlite-simple
+    , serialise
     , text
-    , transformers
     , time
-    , cardano-ledger-api
-    , cardano-strict-containers
-    , microlens
+    , transformers
+
   exposed-modules:
     Cardano.Wallet.Deposit.IO
     Cardano.Wallet.Deposit.IO.DB
@@ -79,10 +85,11 @@ library
     Cardano.Wallet.Deposit.IO.Resource
     Cardano.Wallet.Deposit.Pure
     Cardano.Wallet.Deposit.Pure.Balance
+    Cardano.Wallet.Deposit.Pure.Submissions
     Cardano.Wallet.Deposit.Pure.UTxO
     Cardano.Wallet.Deposit.Pure.UTxOHistory
-    Cardano.Wallet.Deposit.Pure.Submissions
     Cardano.Wallet.Deposit.Read
+    Cardano.Wallet.Deposit.REST
     Cardano.Wallet.Deposit.Write
 
 test-suite scenario
@@ -90,10 +97,8 @@ test-suite scenario
   type:               exitcode-stdio-1.0
   hs-source-dirs:     test/scenario
   main-is:            test-suite-scenario.hs
-  build-tool-depends:
-    markdown-unlit:markdown-unlit
-  ghc-options:
-    -pgmL markdown-unlit
+  build-tool-depends: markdown-unlit:markdown-unlit
+  ghc-options:        -pgmL markdown-unlit
   build-depends:
     , base
     , bytestring
@@ -103,7 +108,8 @@ test-suite scenario
     , contra-tracer
     , customer-deposit-wallet
     , delta-store
-    , hspec >=2.8.2
+    , hspec                      >=2.8.2
+
   other-modules:
     Test.Scenario.Blockchain
     Test.Scenario.Wallet.Deposit.Exchanges
@@ -129,6 +135,7 @@ library customer-deposit-wallet-http
     , text
     , text-class
     , warp
+
   exposed-modules:
     Cardano.Wallet.Deposit.HTTP
     Cardano.Wallet.Deposit.HTTP.Endpoints
@@ -150,13 +157,16 @@ test-suite unit
     , bytestring
     , cardano-crypto
     , cardano-wallet-test-utils
-    , customer-deposit-wallet:{customer-deposit-wallet, customer-deposit-wallet-http}
+    , customer-deposit-wallet
+    , customer-deposit-wallet:customer-deposit-wallet-http
     , directory
-    , hspec >=2.8.2
+    , hspec
     , hspec-golden
     , openapi3
     , QuickCheck
+    , temporary
     , with-utf8
+
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:
     Cardano.Wallet.Deposit.HTTP.JSON.JSONSpec
@@ -167,7 +177,5 @@ test-suite unit
 executable customer-deposit-wallet
   import:         language, opts-exe
   hs-source-dirs: exe
-  build-depends:
-    , base
-  main-is:
-    customer-deposit-wallet.hs
+  build-depends:  base
+  main-is:        customer-deposit-wallet.hs

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -171,6 +171,7 @@ test-suite unit
   other-modules:
     Cardano.Wallet.Deposit.HTTP.JSON.JSONSpec
     Cardano.Wallet.Deposit.HTTP.OpenAPISpec
+    Cardano.Wallet.Deposit.RESTSpec
     Paths_customer_deposit_wallet
     Spec
 

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Resource.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Resource.hs
@@ -1,0 +1,181 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use void" #-}
+
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Implementation of a 'Resource' (think REST) which can be initialized.
+module Cardano.Wallet.Deposit.IO.Resource
+    ( Resource
+    , withResource
+    , ErrResourceMissing (..)
+    , onResource
+    , ErrResourceExists (..)
+    , putResource
+    , ResourceStatus (..)
+    , readStatus
+    ) where
+
+import Prelude
+
+import Control.Concurrent
+    ( forkFinally
+    )
+import Control.Concurrent.Class.MonadMVar
+    ( MonadMVar (..)
+    , putMVar
+    , takeMVar
+    )
+import Control.Concurrent.Class.MonadSTM
+    ( MonadSTM (..)
+    , TVar
+    , atomically
+    , readTVar
+    , writeTVar
+    )
+import Control.Monad
+    ( void
+    )
+import Control.Monad.Class.MonadThrow
+    ( MonadThrow (..)
+    , SomeException
+    )
+
+{-----------------------------------------------------------------------------
+    Resource
+------------------------------------------------------------------------------}
+
+-- | Mutable resource (think REST) that holds a reference of type @a@
+-- that has to be initialized with a 'with…' function.
+data Resource e a = Resource
+    { content :: TVar IO (ResourceStatus e a)
+    , waitForEndOfLife :: IO ()
+    -- ^ Wait until the 'Resource' is out of scope.
+    }
+
+-- | Possible status of the content of a 'Resource'.
+data ResourceStatus e a
+    = NotInitialized
+    | Initializing
+    | Initialized a
+    | FailedToInitialize e
+    | Vanished SomeException
+    deriving (Show)
+
+instance Functor (ResourceStatus e) where
+    fmap _ NotInitialized = NotInitialized
+    fmap _ Initializing = Initializing
+    fmap f (Initialized a) = Initialized (f a)
+    fmap _ (Vanished e) = Vanished e
+    fmap _ (FailedToInitialize e) = FailedToInitialize e
+
+-- | Read the status of a 'Resource'.
+readStatus :: Resource e a -> IO (ResourceStatus e ())
+readStatus resource = void <$> readTVarIO (content resource)
+
+-- | Make a 'Resource' that can be initialized later.
+--
+-- Once the 'Resource' has been initialized,
+-- it will also be cleaned up once the 'withResource' function has finished.
+--
+-- If the 'Resource' vanishes because of an exception,
+-- the 'withResource' will /not/ be interrupted.
+-- You can use 'getStatus' to poll the current status.
+withResource
+    :: (Resource e a -> IO b)
+    -- ^ Action to perform on the 'Resource'.
+    -> IO b
+    -- ^ Result of the action.
+withResource action = do
+    content <- newTVarIO NotInitialized
+    finished <- newEmptyMVar
+    let waitForEndOfLife = takeMVar finished
+        resource = Resource{content, waitForEndOfLife}
+    action resource `finally` putMVar finished ()
+
+-- | Error condition for 'onResource'.
+data ErrResourceMissing e
+    = -- | The 'Resource' has not been initialized yet.
+      ErrNotInitialized
+    | -- | The 'Resource' is currently being initialized.
+      ErrStillInitializing
+    | -- | The 'Resource' has not been initialized yet.
+      ErrVanished SomeException
+    | -- ErrFailedToInitialize
+      ErrFailedToInitialize e
+    deriving (Show)
+
+-- | Perform an action on a 'Resource' if it is initialized.
+onResource
+    :: (a -> IO b)
+    -- ^ Action to perform on the initialized 'Resource'.
+    -> Resource e a
+    -- ^ The 'Resource' to act on.
+    -> IO (Either (ErrResourceMissing e) b)
+onResource action resource = do
+    eContent <- readTVarIO $ content resource
+    case eContent of
+        NotInitialized -> pure $ Left ErrNotInitialized
+        Initializing -> pure $ Left ErrStillInitializing
+        Initialized a -> Right <$> action a
+        Vanished e -> pure $ Left $ ErrVanished e
+        FailedToInitialize e -> pure $ Left $ ErrFailedToInitialize e
+
+-- | Error condition for 'putResource'.
+data ErrResourceExists e a
+    = -- | The resource 'a' is currently being initialized.
+      ErrAlreadyInitializing
+    | -- | The resource 'a' has already been initialized.
+      ErrAlreadyInitialized a
+    | -- | The resource 'a' has vanished.
+      ErrAlreadyVanished SomeException
+    | -- | The resource 'a' has failed to initialize.
+      ErrAlreadyFailedToInitialize e
+    deriving (Show)
+
+-- | Initialize a 'Resource' using a @with…@ function.
+-- This @with…@ function will be called with an argument that does
+-- not terminate until 'withResource' terminates.
+-- The function can logically fail returning a 'Left' value.
+-- Exceptions will be caught and stored in the 'Resource' as well
+putResource
+    :: (forall b. (a -> IO b) -> IO (Either e b))
+    -- ^ Function to initialize the resource 'a'
+    -> Resource e a
+    -- ^ The 'Resource' to initialize.
+    -> IO (Either (ErrResourceExists e a) ())
+putResource start resource = do
+    forking <- atomically $ do
+        ca :: ResourceStatus e a <- readTVar (content resource)
+        case ca of
+            FailedToInitialize e -> pure $ Left $ ErrAlreadyFailedToInitialize e
+            Vanished e -> pure $ Left $ ErrAlreadyVanished e
+            Initializing -> pure $ Left ErrAlreadyInitializing
+            Initialized a -> pure $ Left $ ErrAlreadyInitialized a
+            NotInitialized -> do
+                writeTVar (content resource) Initializing
+                pure $ Right forkInitialization
+    case forking of
+        Left e -> pure $ Left e
+        Right action -> Right <$> action
+  where
+    controlInitialization = do
+        r <- start run
+        atomically $ case r of
+            Left e -> writeTVar (content resource) (FailedToInitialize e)
+            Right () -> pure ()
+    forkInitialization = void $ forkFinally controlInitialization vanish
+
+    run a = do
+        atomically $ writeTVar (content resource) (Initialized a)
+        waitForEndOfLife resource
+
+    vanish (Left e) =
+        atomically $ writeTVar (content resource) (Vanished e)
+    vanish (Right _) =
+        pure () -- waitForEndOfLife has succeeded

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/REST.hs
@@ -1,0 +1,369 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+-- 'IO'-based interface to the Deposit Wallet
+-- where the wallet is treated as a mutable resource (~ REST).
+-- This interface can be mapped one-to-one to a HTTP interface.
+module Cardano.Wallet.Deposit.REST
+    ( -- * Types
+      WalletResource
+    , WalletResourceM
+    , ErrDatabase (..)
+    , ErrLoadingDatabase (..)
+    , ErrCreatingDatabase (..)
+    , ErrWalletResource (..)
+
+      -- * Running
+    , runWalletResourceM
+
+      -- * Operations
+
+      -- ** Initialization
+    , initXPubWallet
+    , loadWallet
+
+      -- ** Mapping between customers and addresses
+    , listCustomers
+    , createAddress
+
+      -- ** Reading from the blockchain
+    , getWalletTip
+    , availableBalance
+    , getCustomerHistory
+    , getCustomerHistories
+
+      -- ** Writing to the blockchain
+    , createPayment
+    , getBIP32PathsForOwnedInputs
+    , signTxBody
+    , walletExists
+    ) where
+
+import Prelude
+
+import Cardano.Address.Derivation
+    ( xpubFromBytes
+    , xpubToBytes
+    )
+import Cardano.Crypto.Wallet
+    ( XPub (..)
+    )
+import Cardano.Wallet.Address.BIP32
+    ( BIP32Path
+    )
+import Cardano.Wallet.Deposit.IO.Resource
+    ( ErrResourceExists (..)
+    , ErrResourceMissing (..)
+    )
+import Cardano.Wallet.Deposit.Pure
+    ( Customer
+    , Word31
+    , fromXPubAndGenesis
+    )
+import Cardano.Wallet.Deposit.Read
+    ( Address
+    )
+import Codec.Serialise
+    ( deserialise
+    , serialise
+    )
+import Control.Monad.IO.Class
+    ( MonadIO (..)
+    )
+import Control.Monad.Trans.Class
+    ( lift
+    )
+import Control.Monad.Trans.Except
+    ( ExceptT (..)
+    , runExceptT
+    )
+import Control.Monad.Trans.Reader
+    ( ReaderT (..)
+    , ask
+    )
+import Cryptography.Hash.Blake
+    ( blake2b160
+    )
+import Data.Bifunctor
+    ( first
+    )
+import Data.ByteArray.Encoding
+    ( Base (..)
+    , convertToBase
+    )
+import Data.List
+    ( isPrefixOf
+    )
+import Data.Store
+    ( Store (..)
+    , newStore
+    )
+import System.Directory
+    ( listDirectory
+    )
+import System.FilePath
+    ( (</>)
+    )
+
+import qualified Cardano.Wallet.Deposit.IO as WalletIO
+import qualified Cardano.Wallet.Deposit.IO.Resource as Resource
+import qualified Cardano.Wallet.Deposit.Pure as Wallet
+import qualified Cardano.Wallet.Deposit.Read as Read
+import qualified Cardano.Wallet.Deposit.Write as Write
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Map as Map
+
+{-----------------------------------------------------------------------------
+    Types
+------------------------------------------------------------------------------}
+
+-- | Error indicating that the database could not be loaded.
+data ErrLoadingDatabase
+    = ErrDatabaseNotFound FilePath
+    | ErrDatabaseCorrupted FilePath
+    | ErrMultipleDatabases [FilePath]
+    deriving (Show, Eq)
+
+-- | Error indicating that the database could not be created.
+newtype ErrCreatingDatabase
+    = ErrDatabaseAlreadyExists FilePath
+    deriving (Show, Eq)
+
+-- | Error indicating that the database could not be loaded or created.
+data ErrDatabase
+    = ErrLoadingDatabase ErrLoadingDatabase
+    | ErrCreatingDatabase ErrCreatingDatabase
+    deriving (Show, Eq)
+
+-- | Mutable resource that may hold a 'WalletInstance'.
+type WalletResource = Resource.Resource ErrDatabase WalletIO.WalletInstance
+
+-- | Error indicating that the 'WalletResource' does not hold a wallet.
+data ErrWalletResource
+    = ErrNoWallet (Resource.ErrResourceMissing ErrDatabase)
+    | ErrWalletPresent
+        (Resource.ErrResourceExists ErrDatabase WalletIO.WalletInstance)
+
+instance Show ErrWalletResource where
+    show = \case
+        ErrNoWallet e -> case e of
+            ErrNotInitialized -> "Wallet is not initialized"
+            ErrStillInitializing -> "Wallet is still initializing"
+            ErrVanished e' -> "Wallet absent and vanished: " <> show e'
+            ErrFailedToInitialize e' ->
+                "Wallet failed to initialize (no wallet): "
+                    <> show e'
+        ErrWalletPresent e -> case e of
+            ErrAlreadyInitializing -> "Wallet is already initializing"
+            ErrAlreadyInitialized _ -> "Wallet is already initialized"
+            ErrAlreadyVanished e' -> "Wallet vanished: " <> show e'
+            ErrAlreadyFailedToInitialize e' ->
+                "Wallet failed to initialize (wallet present): "
+                    <> show e'
+
+-- | Monad for acting on a 'WalletResource'.
+type WalletResourceM = ReaderT WalletResource (ExceptT ErrWalletResource IO)
+
+-- | Run a 'WalletResourceM' action on a 'WalletResource'.
+runWalletResourceM
+    :: WalletResourceM a
+    -> WalletResource
+    -> IO (Either ErrWalletResource a)
+runWalletResourceM action resource =
+    runExceptT (runReaderT action resource)
+
+-- | Run an 'IO' function on the 'WalletInstance'.
+onWalletInstance
+    :: (WalletIO.WalletInstance -> IO a)
+    -> WalletResourceM a
+onWalletInstance action = ReaderT $ \resource ->
+    ExceptT
+        $ first ErrNoWallet <$> Resource.onResource action resource
+
+{-----------------------------------------------------------------------------
+    Initialization
+------------------------------------------------------------------------------}
+
+-- | Prefix for deposit wallets on disk.
+depositPrefix :: String
+depositPrefix = "deposit-"
+
+-- | Scan a directory for deposit wallets.
+scanDirectoryForDepositPrefix :: FilePath -> IO [FilePath]
+scanDirectoryForDepositPrefix fp = do
+    files <- listDirectory fp
+    pure $ filter (depositPrefix `isPrefixOf`) files
+
+-- | Try to open an existing wallet
+findTheDepositWalletOnDisk
+    :: FilePath
+    -- ^ Path to the wallet database directory
+    -> (Either ErrLoadingDatabase WalletIO.WalletStore -> IO a)
+    -- ^ Action to run if the wallet is found
+    -> IO a
+findTheDepositWalletOnDisk fp action = do
+    ds <- scanDirectoryForDepositPrefix fp
+    case ds of
+        [d] -> do
+            (xpub, users) <- deserialise <$> BL.readFile (fp </> d)
+            case xpubFromBytes xpub of
+                Nothing -> action $ Left $ ErrDatabaseCorrupted (fp </> d)
+                Just identity -> do
+                    let state =
+                            fromXPubAndGenesis
+                                identity
+                                (fromIntegral @Int users)
+                                (error "FIXME")
+                    store <- newStore
+                    writeS store state
+                    action $ Right store
+        [] -> action $ Left $ ErrDatabaseNotFound fp
+        ds' -> action $ Left $ ErrMultipleDatabases ((fp </>) <$> ds')
+
+-- | Try to create a new wallet
+createTheDepositWalletOnDisk
+    :: FilePath
+    -- ^ Path to the wallet database directory
+    -> XPub
+    -- ^ Id of the wallet
+    -> Word31
+    -- ^ Max number of users ?
+    -> (Maybe WalletIO.WalletStore -> IO a)
+    -- ^ Action to run if the wallet is created
+    -> IO a
+createTheDepositWalletOnDisk fp identity users action = do
+    ds <- scanDirectoryForDepositPrefix fp
+    case ds of
+        [] -> do
+            BL.writeFile (fp </> depositPrefix <> hashWalletId identity)
+                $ serialise (xpubToBytes identity, fromIntegral users :: Int)
+            store <- newStore
+            action $ Just store
+        _ -> do
+            action Nothing
+  where
+    hashWalletId :: XPub -> String
+    hashWalletId =
+        B8.unpack
+            . convertToBase Base64
+            . blake2b160
+            . xpubPublicKey
+
+-- | Load an existing wallet from disk.
+loadWallet
+    :: WalletIO.WalletBootEnv IO
+    -- ^ Environment for the wallet
+    -> FilePath
+    -- ^ Path to the wallet database directory
+    -> WalletResourceM ()
+loadWallet bootEnv fp = do
+    let action :: (WalletIO.WalletInstance -> IO b) -> IO (Either ErrDatabase b)
+        action f = findTheDepositWalletOnDisk fp $ \case
+            Right wallet ->
+                Right <$> do
+                    WalletIO.withWalletLoad
+                        (WalletIO.WalletEnv bootEnv wallet)
+                        f
+            Left e -> pure $ Left $ ErrLoadingDatabase e
+    resource <- ask
+    lift
+        $ ExceptT
+        $ first ErrWalletPresent
+            <$> Resource.putResource action resource
+
+-- | Initialize a new wallet from an 'XPub'.
+initXPubWallet
+    :: WalletIO.WalletBootEnv IO
+    -- ^ Environment for the wallet
+    -> FilePath
+    -- ^ Path to the wallet database directory
+    -> XPub
+    -- ^ Id of the wallet
+    -> Word31
+    -- ^ Max number of users ?
+    -> WalletResourceM ()
+initXPubWallet bootEnv fp xpub users = do
+    let action :: (WalletIO.WalletInstance -> IO b) -> IO (Either ErrDatabase b)
+        action f = createTheDepositWalletOnDisk fp xpub users $ \case
+            Just wallet ->
+                Right
+                    <$> WalletIO.withWalletInit
+                        (WalletIO.WalletEnv bootEnv wallet)
+                        xpub
+                        users
+                        f
+            Nothing ->
+                pure
+                    $ Left
+                    $ ErrCreatingDatabase
+                    $ ErrDatabaseAlreadyExists fp
+    resource <- ask
+    lift
+        $ ExceptT
+        $ first ErrWalletPresent
+            <$> Resource.putResource action resource
+
+walletExists :: FilePath -> WalletResourceM Bool
+walletExists fp = liftIO $ findTheDepositWalletOnDisk fp $ \case
+    Right _ -> pure True
+    Left _ -> pure False
+
+{-----------------------------------------------------------------------------
+    Operations
+------------------------------------------------------------------------------}
+listCustomers
+    :: WalletResourceM [(Customer, Address)]
+listCustomers = onWalletInstance WalletIO.listCustomers
+
+createAddress
+    :: Customer
+    -> WalletResourceM Address
+createAddress = onWalletInstance . WalletIO.createAddress
+
+{-----------------------------------------------------------------------------
+    Operations
+    Reading from the blockchain
+------------------------------------------------------------------------------}
+getWalletTip :: WalletResourceM Read.ChainPoint
+getWalletTip = onWalletInstance WalletIO.getWalletTip
+
+availableBalance :: WalletResourceM Read.Value
+availableBalance = onWalletInstance WalletIO.availableBalance
+
+getCustomerHistory
+    :: Customer
+    -> WalletResourceM [Wallet.TxSummary]
+getCustomerHistory = onWalletInstance . WalletIO.getCustomerHistory
+
+getCustomerHistories
+    :: (Read.ChainPoint, Read.ChainPoint)
+    -> WalletResourceM (Map.Map Customer Wallet.ValueTransfer)
+getCustomerHistories = onWalletInstance . WalletIO.getCustomerHistories
+
+{-----------------------------------------------------------------------------
+    Operations
+    Writing to blockchain
+------------------------------------------------------------------------------}
+
+createPayment
+    :: [(Address, Read.Value)]
+    -> WalletResourceM (Maybe Write.TxBody)
+createPayment = onWalletInstance . WalletIO.createPayment
+
+getBIP32PathsForOwnedInputs
+    :: Write.TxBody
+    -> WalletResourceM [BIP32Path]
+getBIP32PathsForOwnedInputs =
+    onWalletInstance . WalletIO.getBIP32PathsForOwnedInputs
+
+signTxBody
+    :: Write.TxBody
+    -> WalletResourceM (Maybe Write.Tx)
+signTxBody = onWalletInstance . WalletIO.signTxBody

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
@@ -91,11 +91,12 @@ withWalletEnvMock
 withWalletEnvMock ScenarioEnv{..} action = do
     database <- newStore
     let walletEnv = Wallet.WalletEnv
-            { Wallet.logger = nullTracer
-            , Wallet.genesisData = genesisData
-            , Wallet.networkEnv = networkEnv
-            , Wallet.database = database
-            }
+            Wallet.WalletBootEnv
+                { Wallet.logger = nullTracer
+                , Wallet.genesisData = genesisData
+                , Wallet.networkEnv = networkEnv
+                }
+            database
     action walletEnv
 
 {-----------------------------------------------------------------------------

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/RESTSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/RESTSpec.hs
@@ -1,0 +1,151 @@
+module Cardano.Wallet.Deposit.RESTSpec
+    ( spec
+    )
+where
+
+import Prelude
+
+import Cardano.Crypto.Wallet
+    ( XPub
+    , generate
+    , toXPub
+    )
+import Cardano.Wallet.Deposit.IO
+    ( WalletBootEnv (WalletBootEnv)
+    )
+import Cardano.Wallet.Deposit.IO.Resource
+    ( ErrResourceMissing (..)
+    , withResource
+    )
+import Cardano.Wallet.Deposit.REST
+    ( ErrCreatingDatabase (..)
+    , ErrDatabase (..)
+    , ErrLoadingDatabase (..)
+    , ErrWalletResource (..)
+    , WalletResourceM
+    , availableBalance
+    , initXPubWallet
+    , loadWallet
+    , runWalletResourceM
+    , walletExists
+    )
+import Control.Concurrent
+    ( threadDelay
+    )
+import Control.Monad.IO.Class
+    ( MonadIO (..)
+    )
+import System.IO.Temp
+    ( withSystemTempDirectory
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+
+import qualified Cardano.Wallet.Deposit.Read as Read
+import qualified Data.ByteString.Char8 as B8
+
+fakeBootEnv :: WalletBootEnv IO
+fakeBootEnv = WalletBootEnv undefined undefined undefined
+
+xpub :: XPub
+xpub =
+    toXPub
+        $ generate (B8.pack "random seed for a testing xpub lala") B8.empty
+
+letItInitialize :: WalletResourceM ()
+letItInitialize = liftIO $ threadDelay 100000
+
+onSuccess :: (Show e, MonadFail m) => Either e a -> (a -> m b) -> m b
+onSuccess (Left e) _ = fail $ show e
+onSuccess (Right a) f = f a
+
+matchEmptyValue :: Show e => Either e Read.Value -> IO ()
+matchEmptyValue x = onSuccess x $ \v -> v `shouldBe` mempty
+
+withWallet :: WalletResourceM a -> IO (Either ErrWalletResource a)
+withWallet f = withResource $ runWalletResourceM f
+
+withInitializedWallet
+    :: FilePath
+    -> WalletResourceM a
+    -> IO (Either ErrWalletResource a)
+withInitializedWallet dir f = withWallet $ do
+    initXPubWallet fakeBootEnv dir xpub 0
+    letItInitialize
+    f
+
+withLoadedWallet
+    :: FilePath
+    -> WalletResourceM a
+    -> IO (Either ErrWalletResource a)
+withLoadedWallet dir f = withWallet $ do
+    loadWallet fakeBootEnv dir
+    letItInitialize
+    f
+
+doNothing :: WalletResourceM ()
+doNothing = pure ()
+
+inADirectory :: (FilePath -> IO a) -> IO a
+inADirectory = withSystemTempDirectory "deposit-rest"
+
+spec :: Spec
+spec = do
+    describe "REST Deposit interface" $ do
+        it "can initialize a wallet"
+            $ inADirectory
+            $ \dir -> do
+                val <- withInitializedWallet dir availableBalance
+                matchEmptyValue val
+        it "can load an existing wallet"
+            $ inADirectory
+            $ \dir -> do
+                val <- withInitializedWallet dir availableBalance
+                onSuccess val $ \_ -> do
+                    val' <- withLoadedWallet dir availableBalance
+                    matchEmptyValue val'
+        it "cannot re-initialize a wallet"
+            $ inADirectory
+            $ \dir -> do
+                val <- withInitializedWallet dir doNothing
+                onSuccess val $ \_ -> do
+                    val' <- withInitializedWallet dir availableBalance
+                    case val' of
+                        Left
+                            ( ErrNoWallet
+                                    ( ErrFailedToInitialize
+                                            ( ErrCreatingDatabase
+                                                    (ErrDatabaseAlreadyExists fp)
+                                                )
+                                        )
+                                )
+                                | dir == fp -> pure ()
+                        Left e -> fail $ show e
+                        Right _ -> fail "Should have failed the query on re-init"
+        it "cannot load a non-existing wallet"
+            $ inADirectory
+            $ \dir -> do
+                val <- withLoadedWallet dir availableBalance
+                case val of
+                    Left
+                        ( ErrNoWallet
+                                ( ErrFailedToInitialize
+                                        ( ErrLoadingDatabase
+                                                (ErrDatabaseNotFound fp)
+                                            )
+                                    )
+                            )
+                            | dir == fp -> pure ()
+                    Left e -> fail $ show e
+                    Right _ -> fail "Should have failed the query on load"
+        it "can check if a wallet is present"
+            $ inADirectory
+            $ \dir -> do
+                r <- withInitializedWallet dir doNothing
+                onSuccess r $ \_ -> do
+                    presence <- withWallet $ walletExists dir
+                    onSuccess presence $ \p -> p `shouldBe` True


### PR DESCRIPTION
This pull requests implements a REST-like `IO` interface for the Deposit Wallet. This interface corresponds more closely to an HTTP interface.

Essentially, the main difference between `Cardano.Wallet.Deposit.IO` and `Cardano.Wallet.Deposit.REST` is that the latter postpones the need to initialize the wallet. Instead of working with a `WalletInstance`, the latter module now works with a `WalletResource`, which is roughly a `TVar (Maybe WalletInstance)`. This mutable variable starts with `Nothing` and the function `putWallet` can be used to initialize the wallet, putting a `Just` in the mutable variable.

In turn, a module `Cardano.Wallet.Deposit.IO.Resource` implements a data type `Resource` that encapsulate the idea of `TVar (Maybe WalletInstance)` and is (reasonably) safe to use in a concurrent environment.

### Comments

* Not implemented yet: `withWalletResource` inspects the database directory and loads a wallet if necessary.

### Issue Number

ADP-3344