### PR TITLE
[ADP-3426] Push docker image to docker hub in release pipeline steps

### DIFF
--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -122,3 +122,13 @@ steps:
           system: x86_64-linux
         env:
           RELEASE: true
+
+      - label: Push Docker Image
+        depends_on:
+          - create-release
+        command:
+          - "mkdir -p config && echo '{ outputs = _: { dockerHubRepoName = \"cardanofoundation/cardano-wallet\"; }; }'  > config/flake.nix"
+          - "nix build .#pushDockerImage --override-input hostNixpkgs \"path:$(nix eval --impure -I $NIX_PATH --expr '(import <nixpkgs> {}).path')\" --override-input customConfig path:./config -o docker-build-push"
+          - "./docker-build-push"
+        agents:
+          system: x86_64-linux


### PR DESCRIPTION
This PR tries to solve the fact that during last release process no image was pushed dockerhub. The dockerhub stuff is messy so I cannot guarantee it's going to work. OTOH , testing it is not great as we do not have delete rights on dockerhub and we have to open a ticket to do it.

- Copy over push to dockerhub step in the release pipeline


ADP-3426