### PR TITLE
[ADP-3432] Add a UI deposit wallet page to initialize the wallet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ package.json
 
 # buildkite artifacts testing
 artifacts
+deposit-*

--- a/configs/cardano/preprod/config.json
+++ b/configs/cardano/preprod/config.json
@@ -68,11 +68,6 @@
       "stdout"
     ]
   ],
-  "hasEKG": 12788,
-  "hasPrometheus": [
-    "127.0.0.1",
-    12798
-  ],
   "minSeverity": "Info",
   "options": {
     "mapBackends": {

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -157,6 +157,7 @@ test-suite unit
     , bytestring
     , cardano-crypto
     , cardano-wallet-test-utils
+    , contra-tracer
     , customer-deposit-wallet
     , customer-deposit-wallet:customer-deposit-wallet-http
     , directory

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -35,13 +35,25 @@ common opts-exe
   import:      opts-lib
   ghc-options: -threaded -rtsopts
 
+
+common no-delta-table-on-windows
+  if !os(windows)
+    build-depends:
+        , delta-table
+        , sqlite-simple
+    other-modules:
+        Cardano.Wallet.Deposit.IO.DB.Real
+  else
+    other-modules:
+        Cardano.Wallet.Deposit.IO.DB.Stub
+
 flag release
   description: Enable optimization and `-Werror`
   default:     False
   manual:      True
 
 library
-  import:          language, opts-lib
+  import:          language, opts-lib, no-delta-table-on-windows
   hs-source-dirs:  src
   build-depends:
     , async
@@ -62,7 +74,6 @@ library
     , crypto-primitives
     , customer-deposit-wallet-pure
     , delta-store
-    , delta-table
     , delta-types
     , directory
     , filepath
@@ -71,7 +82,6 @@ library
     , memory
     , microlens
     , OddWord
-    , sqlite-simple
     , serialise
     , text
     , time

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -6,6 +6,7 @@ module Cardano.Wallet.Deposit.IO
     -- * Types
       WalletEnv (..)
     , WalletBootEnv (..)
+    , WalletPublicIdentity (..)
     , WalletInstance
 
     -- * Operations
@@ -29,6 +30,7 @@ module Cardano.Wallet.Deposit.IO
     , getBIP32PathsForOwnedInputs
     , signTxBody
     , WalletStore
+    , walletPublicIdentity
     ) where
 
 import Prelude
@@ -193,6 +195,18 @@ createAddress c w =
             let (r,s1) = Wallet.createAddress c s0
             in  (Delta.Replace s1, r)
 
+data WalletPublicIdentity = WalletPublicIdentity
+    { pubXpub :: XPub
+    , pubNextUser :: Word31
+    }
+
+walletPublicIdentity :: WalletInstance -> IO WalletPublicIdentity
+walletPublicIdentity w = do
+    state <- readWalletState w
+    pure $ WalletPublicIdentity
+        { pubXpub = Wallet.walletXPub state
+        , pubNextUser = Wallet.nextCustomer state
+        }
 {-----------------------------------------------------------------------------
     Operations
     Reading from the blockchain

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -43,6 +43,7 @@ import Cardano.Wallet.Address.BIP32
     )
 import Cardano.Wallet.Deposit.Pure
     ( Customer
+    , WalletPublicIdentity (..)
     , WalletState
     , Word31
     )
@@ -194,11 +195,6 @@ createAddress c w =
         $ \s0 ->
             let (r,s1) = Wallet.createAddress c s0
             in  (Delta.Replace s1, r)
-
-data WalletPublicIdentity = WalletPublicIdentity
-    { pubXpub :: XPub
-    , pubNextUser :: Word31
-    }
 
 walletPublicIdentity :: WalletInstance -> IO WalletPublicIdentity
 walletPublicIdentity w = do

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/DB.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/DB.hs
@@ -1,61 +1,17 @@
-{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE CPP #-}
+
 module Cardano.Wallet.Deposit.IO.DB
-    ( Connection
-    , withSqliteFile
-    , withSqliteInMemory
-
-    , SqlM
-    , runSqlM
-
-    , DBLog (..)
-    ) where
-
-import Prelude
-
-import Control.Tracer
-    ( Tracer
-    , traceWith
-    )
-import Database.Table.SQLite.Simple
-    ( Connection
-    , SqlM
-    , runSqlM
-    , withConnection
+    (
+#ifndef mingw32_HOST_OS
+    module Cardano.Wallet.Deposit.IO.DB.Real
+#endif
     )
 
-{-----------------------------------------------------------------------------
-    SqlContext
-------------------------------------------------------------------------------}
--- | Acquire and release an SQLite 'Connection' in memory.
-withSqliteInMemory
-    :: Tracer IO DBLog
-    -- ^ Logging
-    -> (Connection -> IO a)
-    -- ^ Action to run
-    -> IO a
-withSqliteInMemory tr = withSqliteFile tr ":memory:"
+where
 
--- | Acquire and release an SQLite 'Connection' from a file.
-withSqliteFile
-    :: Tracer IO DBLog
-    -- ^ Logging
-    -> FilePath
-    -- ^ Database file
-    -> (Connection -> IO a)
-    -- ^ Action to run
-    -> IO a
-withSqliteFile tr filepath action =
-    withConnection filepath $ \conn -> do
-        traceWith tr $ MsgStartConnection filepath
-        result <- action conn
-        traceWith tr $ MsgDoneConnection filepath
-        pure result
-
-{-------------------------------------------------------------------------------
-    Logging
--------------------------------------------------------------------------------}
-
-data DBLog
-    = MsgStartConnection FilePath
-    | MsgDoneConnection FilePath
-    deriving (Show, Eq)
+#ifdef mingw32_HOST_OS
+import Cardano.Wallet.Deposit.IO.DB.Stub
+    ()
+#else
+import Cardano.Wallet.Deposit.IO.DB.Real
+#endif

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/DB/Real.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/DB/Real.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE Rank2Types #-}
+
+module Cardano.Wallet.Deposit.IO.DB.Real
+    ( Connection
+    , withSqliteFile
+    , withSqliteInMemory
+    , SqlM
+    , runSqlM
+    , DBLog (..)
+    ) where
+
+import Prelude
+
+import Control.Tracer
+    ( Tracer
+    , traceWith
+    )
+import Database.Table.SQLite.Simple
+    ( Connection
+    , SqlM
+    , runSqlM
+    , withConnection
+    )
+
+{-----------------------------------------------------------------------------
+    SqlContext
+------------------------------------------------------------------------------}
+
+-- | Acquire and release an SQLite 'Connection' in memory.
+withSqliteInMemory
+    :: Tracer IO DBLog
+    -- ^ Logging
+    -> (Connection -> IO a)
+    -- ^ Action to run
+    -> IO a
+withSqliteInMemory tr = withSqliteFile tr ":memory:"
+
+-- | Acquire and release an SQLite 'Connection' from a file.
+withSqliteFile
+    :: Tracer IO DBLog
+    -- ^ Logging
+    -> FilePath
+    -- ^ Database file
+    -> (Connection -> IO a)
+    -- ^ Action to run
+    -> IO a
+withSqliteFile tr filepath action =
+    withConnection filepath $ \conn -> do
+        traceWith tr $ MsgStartConnection filepath
+        result <- action conn
+        traceWith tr $ MsgDoneConnection filepath
+        pure result
+
+{-------------------------------------------------------------------------------
+    Logging
+-------------------------------------------------------------------------------}
+
+data DBLog
+    = MsgStartConnection FilePath
+    | MsgDoneConnection FilePath
+    deriving (Show, Eq)

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/DB/Stub.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/DB/Stub.hs
@@ -1,0 +1,2 @@
+module Cardano.Wallet.Deposit.IO.DB.Stub ()
+where

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -38,6 +38,8 @@ module Cardano.Wallet.Deposit.Pure
 
     , addTxSubmission
     , listTxsInSubmission
+    , nextCustomer
+    , walletXPub
     ) where
 
 import Prelude
@@ -136,6 +138,12 @@ isCustomerAddress address =
 
 fromRawCustomer :: Word31 -> Customer
 fromRawCustomer = id
+
+nextCustomer :: WalletState -> Customer
+nextCustomer = fromIntegral . length . Address.addresses . addresses
+
+walletXPub :: WalletState -> XPub
+walletXPub  = Address.getXPub . addresses
 
 {-----------------------------------------------------------------------------
     Operations

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -3,6 +3,7 @@ module Cardano.Wallet.Deposit.Pure
     -- * Types
       WalletState
     , DeltaWalletState
+    , WalletPublicIdentity (..)
 
     -- * Operations
     -- ** Mapping between customers and addresses
@@ -102,6 +103,12 @@ data WalletState = WalletState
     }
 
 type DeltaWalletState = Delta.Replace WalletState
+
+data WalletPublicIdentity = WalletPublicIdentity
+    { pubXpub :: XPub
+    , pubNextUser :: Word31
+    }
+    deriving Show
 
 {-----------------------------------------------------------------------------
     Operations

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/REST.hs
@@ -43,6 +43,7 @@ module Cardano.Wallet.Deposit.REST
     , getBIP32PathsForOwnedInputs
     , signTxBody
     , walletExists
+    , walletPublicIdentity
     ) where
 
 import Prelude
@@ -56,6 +57,9 @@ import Cardano.Crypto.Wallet
     )
 import Cardano.Wallet.Address.BIP32
     ( BIP32Path
+    )
+import Cardano.Wallet.Deposit.IO
+    ( WalletPublicIdentity
     )
 import Cardano.Wallet.Deposit.IO.Resource
     ( ErrResourceExists (..)
@@ -314,6 +318,9 @@ walletExists :: FilePath -> WalletResourceM Bool
 walletExists fp = liftIO $ findTheDepositWalletOnDisk fp $ \case
     Right _ -> pure True
     Left _ -> pure False
+
+walletPublicIdentity :: WalletResourceM WalletPublicIdentity
+walletPublicIdentity = onWalletInstance  WalletIO.walletPublicIdentity
 
 {-----------------------------------------------------------------------------
     Operations

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/RESTSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/RESTSpec.hs
@@ -77,7 +77,7 @@ withInitializedWallet
     -> WalletResourceM a
     -> IO (Either ErrWalletResource a)
 withInitializedWallet dir f = withWallet $ do
-    initXPubWallet fakeBootEnv dir nullTracer xpub 0
+    initXPubWallet nullTracer fakeBootEnv dir nullTracer xpub 0
     letItInitialize
     f
 

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/RESTSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/RESTSpec.hs
@@ -35,6 +35,9 @@ import Control.Concurrent
 import Control.Monad.IO.Class
     ( MonadIO (..)
     )
+import Control.Tracer
+    ( nullTracer
+    )
 import System.IO.Temp
     ( withSystemTempDirectory
     )
@@ -74,7 +77,7 @@ withInitializedWallet
     -> WalletResourceM a
     -> IO (Either ErrWalletResource a)
 withInitializedWallet dir f = withWallet $ do
-    initXPubWallet fakeBootEnv dir xpub 0
+    initXPubWallet fakeBootEnv dir nullTracer xpub 0
     letItInitialize
     f
 
@@ -83,7 +86,7 @@ withLoadedWallet
     -> WalletResourceM a
     -> IO (Either ErrWalletResource a)
 withLoadedWallet dir f = withWallet $ do
-    loadWallet fakeBootEnv dir
+    loadWallet fakeBootEnv dir nullTracer
     letItInitialize
     f
 

--- a/lib/exe/cardano-wallet-exe.cabal
+++ b/lib/exe/cardano-wallet-exe.cabal
@@ -88,6 +88,7 @@ library
     , cardano-wallet-secrets
     , cardano-wallet-ui
     , contra-tracer
+    , customer-deposit-wallet
     , data-default
     , directory
     , extra

--- a/lib/exe/lib/Cardano/Wallet/Application.hs
+++ b/lib/exe/lib/Cardano/Wallet/Application.hs
@@ -95,6 +95,9 @@ import Cardano.Wallet.DB.Layer
 import Cardano.Wallet.DB.Sqlite.Migration.Old
     ( DefaultFieldValues (..)
     )
+import Cardano.Wallet.Deposit.IO
+    ( WalletBootEnv (..)
+    )
 import Cardano.Wallet.Deposit.IO.Resource
     ( withResource
     )
@@ -200,6 +203,9 @@ import Control.Tracer
     )
 import Data.Function
     ( (&)
+    )
+import Data.Functor.Contravariant
+    ( (>$<)
     )
 import Data.Generics.Internal.VL
     ( view
@@ -551,7 +557,13 @@ serveWallet
                     application =
                         Server.serve api
                             $ DepositUi.serveUI
+                                (UIApplicationLog >$< applicationTracer)
                                 ui
+                                ( WalletBootEnv
+                                    (error "Not defined")
+                                    (error "Not defined")
+                                    (error "Not defined")
+                                )
                                 databaseDir'
                                 (PageConfig "" "Deposit Cardano Wallet")
                                 _proxy

--- a/lib/exe/lib/Cardano/Wallet/Application.hs
+++ b/lib/exe/lib/Cardano/Wallet/Application.hs
@@ -95,6 +95,12 @@ import Cardano.Wallet.DB.Layer
 import Cardano.Wallet.DB.Sqlite.Migration.Old
     ( DefaultFieldValues (..)
     )
+import Cardano.Wallet.Deposit.IO.Resource
+    ( withResource
+    )
+import Cardano.Wallet.Deposit.REST
+    ( WalletResource
+    )
 import Cardano.Wallet.Flavor
     ( CredFromOf
     , KeyFlavorS (..)
@@ -384,7 +390,8 @@ serveWallet
                     case ms of
                         Nothing -> pure ()
                         Just (_port, socket) -> do
-                            ui <- Ui.withUILayer 1 ()
+                            r <- ContT withResource
+                            ui <- Ui.withUILayer 1 r
                             sourceOfNewTip netLayer ui
                             let uiService =
                                     startDepositUiServer
@@ -519,7 +526,7 @@ serveWallet
             :: forall n
              . ( HasSNetworkId n
                )
-            => UILayer ()
+            => UILayer WalletResource
             -> Socket
             -> SNetworkId n
             -> NetworkLayer IO (CardanoBlock StandardCrypto)

--- a/lib/exe/lib/Cardano/Wallet/Application/Logging.hs
+++ b/lib/exe/lib/Cardano/Wallet/Application/Logging.hs
@@ -7,9 +7,12 @@ module Cardano.Wallet.Application.Logging
 
 import Prelude
 
+import Cardano.BM.Data.Severity
+    ( Severity (..)
+    )
 import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation
-    , HasSeverityAnnotation
+    , HasSeverityAnnotation (..)
     )
 import Cardano.Wallet.Api.Http.Logging
     ( ApiApplicationLog
@@ -27,13 +30,19 @@ import GHC.Generics
 data ApplicationLog
     = ApiApplicationLog ApiApplicationLog
     | MsgServerStartupError ListenError
+    | UIApplicationLog String
     deriving (Generic, Show, Eq)
 
 instance ToText ApplicationLog where
     toText = \case
         ApiApplicationLog msg -> toText msg
         MsgServerStartupError err -> toText err
+        UIApplicationLog msg -> toText msg
 
 instance HasPrivacyAnnotation ApplicationLog
 
-instance HasSeverityAnnotation ApplicationLog
+instance HasSeverityAnnotation ApplicationLog where
+    getSeverityAnnotation = \case
+        ApiApplicationLog msg -> getSeverityAnnotation msg
+        MsgServerStartupError _ -> Error
+        UIApplicationLog _ -> Warning

--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -55,8 +55,10 @@ library
     Cardano.Wallet.UI.Common.Layer
     Cardano.Wallet.UI.Cookies
     Cardano.Wallet.UI.Deposit.API
+    Cardano.Wallet.UI.Deposit.Handlers.Wallet
     Cardano.Wallet.UI.Deposit.Html.Pages.About
     Cardano.Wallet.UI.Deposit.Html.Pages.Page
+    Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
     Cardano.Wallet.UI.Deposit.Server
     Cardano.Wallet.UI.Lib.ListOf
     Cardano.Wallet.UI.Shelley.API
@@ -89,6 +91,7 @@ library
     , containers
     , contra-tracer
     , cookie
+    , customer-deposit-wallet
     , exceptions
     , generic-lens
     , http-media

--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -75,6 +75,7 @@ library
     Cardano.Wallet.UI.Shelley.Html.Pages.Wallets.NewWallet
     Cardano.Wallet.UI.Shelley.Server
     Cardano.Wallet.UI.Signal
+    Cardano.Wallet.UI.Type
 
   other-modules:    Paths_cardano_wallet_ui
   build-depends:
@@ -99,6 +100,7 @@ library
     , http-media
     , lens
     , lucid
+    , mmorph
     , mtl
     , ntp-client
     , operational

--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -21,6 +21,7 @@ common language
 
 common opts-lib
   ghc-options: -Wall -Wcompat -Wredundant-constraints -Wunused-packages
+   -Wunused-imports -Wincomplete-uni-patterns -Wincomplete-record-updates
 
   if flag(release)
     ghc-options: -O2 -Werror
@@ -36,8 +37,10 @@ library
     Cardano.Wallet.UI.Common.API
     Cardano.Wallet.UI.Common.Handlers.Lib
     Cardano.Wallet.UI.Common.Handlers.Settings
+    Cardano.Wallet.UI.Common.Handlers.Session
     Cardano.Wallet.UI.Common.Handlers.SSE
     Cardano.Wallet.UI.Common.Handlers.State
+    Cardano.Wallet.UI.Common.Handlers.Wallet
     Cardano.Wallet.UI.Common.Html.Html
     Cardano.Wallet.UI.Common.Html.Htmx
     Cardano.Wallet.UI.Common.Html.Lib
@@ -48,6 +51,7 @@ library
     Cardano.Wallet.UI.Common.Html.Pages.Template.Footer
     Cardano.Wallet.UI.Common.Html.Pages.Template.Head
     Cardano.Wallet.UI.Common.Html.Pages.Template.Navigation
+    Cardano.Wallet.UI.Common.Html.Pages.Wallet
     Cardano.Wallet.UI.Common.Layer
     Cardano.Wallet.UI.Cookies
     Cardano.Wallet.UI.Deposit.API

--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -97,6 +97,7 @@ library
     , customer-deposit-wallet
     , exceptions
     , generic-lens
+    , http-api-data
     , http-media
     , lens
     , lucid

--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -55,6 +55,8 @@ library
     Cardano.Wallet.UI.Common.Layer
     Cardano.Wallet.UI.Cookies
     Cardano.Wallet.UI.Deposit.API
+    Cardano.Wallet.UI.Deposit.Handlers.Lib
+    Cardano.Wallet.UI.Deposit.Handlers.Page
     Cardano.Wallet.UI.Deposit.Handlers.Wallet
     Cardano.Wallet.UI.Deposit.Html.Pages.About
     Cardano.Wallet.UI.Deposit.Html.Pages.Page
@@ -107,6 +109,7 @@ library
     , text
     , text-class
     , time
+    , transformers
     , unliftio
 
   hs-source-dirs:   src

--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -100,6 +100,7 @@ library
     , http-media
     , lens
     , lucid
+    , memory
     , mmorph
     , mtl
     , ntp-client

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Handlers/Session.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Handlers/Session.hs
@@ -1,0 +1,38 @@
+module Cardano.Wallet.UI.Common.Handlers.Session where
+
+import Prelude
+
+import Cardano.Wallet.UI.Common.Layer
+    ( SessionLayer (..)
+    , UILayer (..)
+    )
+import Cardano.Wallet.UI.Cookies
+    ( CookieResponse
+    , RequestCookies
+    , withSession
+    , withSessionRead
+    )
+import Control.Monad.Trans
+    ( MonadIO (..)
+    )
+import Servant
+    ( Handler
+    )
+
+withSessionLayerRead
+    :: UILayer s
+    -> (SessionLayer s -> Handler a)
+    -> Maybe RequestCookies
+    -> Handler a
+withSessionLayerRead ul f = withSessionRead $ \k -> do
+    s <- liftIO $ sessions ul k
+    f s
+
+withSessionLayer
+    :: UILayer s
+    -> (SessionLayer s -> Handler a)
+    -> Maybe RequestCookies
+    -> Handler (CookieResponse a)
+withSessionLayer ulayer f = withSession $ \k -> do
+    s <- liftIO $ sessions ulayer k
+    f s

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Handlers/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Handlers/Wallet.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Wallet.UI.Common.Handlers.Wallet where
+
+import Prelude hiding
+    ( lookup
+    )
+
+import Cardano.Mnemonic
+    ( MkSomeMnemonic (mkSomeMnemonic)
+    )
+import Cardano.Wallet.Api.Types
+    ( AllowedMnemonics
+    , WalletStyle (..)
+    )
+import Control.Monad
+    ( replicateM
+    )
+import Data.Text
+    ( Text
+    )
+import Paths_cardano_wallet_ui
+    ( getDataFileName
+    )
+import System.Random.Stateful
+    ( randomRIO
+    )
+
+import qualified Data.Text as T
+
+pickMnemonic :: Int -> Maybe Bool -> IO (Maybe [Text])
+pickMnemonic _n (Just True) = pure Nothing
+pickMnemonic n _ = do
+    wordsFile <- getDataFileName "data/english.txt"
+    dict <- fmap T.pack . words <$> readFile wordsFile
+
+    let loop = do
+            xs <- replicateM n $ do
+                i <- randomRIO (0, length dict - 1)
+                pure $ dict !! i
+            case mkSomeMnemonic @(AllowedMnemonics 'Shelley) xs of
+                Left _ -> loop
+                Right _ -> pure xs
+    Just <$> loop

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Lib.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Lib.hs
@@ -8,6 +8,8 @@ module Cardano.Wallet.UI.Common.Html.Lib
     , ShowTime
     , justifyRight
     , linkText
+    , showHtml
+    , toTextHtml
     )
 where
 
@@ -18,6 +20,9 @@ import Data.Generics.Product
 import Data.Text
     ( Text
     )
+import Data.Text.Class
+    ( ToText (..)
+    )
 import Data.Time
     ( UTCTime
     , defaultTimeLocale
@@ -27,6 +32,7 @@ import Data.Time
     )
 import Lucid
     ( Html
+    , HtmlT
     , ToHtml (..)
     , class_
     , div_
@@ -60,3 +66,9 @@ justifyRight = div_ [class_ "d-flex justify-content-end"] . toHtml
 
 linkText :: Link -> Text
 linkText = T.pack . ('/' :) . show . linkURI
+
+showHtml :: (Show a, Monad m) => a -> HtmlT m ()
+showHtml = toHtml . show
+
+toTextHtml :: (Monad m, ToText a) => a -> HtmlT m ()
+toTextHtml = toHtml . toText

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Lib.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Lib.hs
@@ -31,7 +31,6 @@ import Prelude
 import Cardano.Wallet.UI.Common.Html.Htmx
     ( hxExt_
     , hxGet_
-    , hxSse_
     , hxSwap_
     , hxTarget_
     , hxTrigger_
@@ -140,17 +139,11 @@ fieldHtml as = field as . toHtml
 fieldShow :: (Show a, Monad m) => [Attribute] -> Text -> a -> ListOf (AssocRow m)
 fieldShow attrs key val = field attrs (toHtml key) (toHtml $ show val)
 
--- | A value attribute to use to connect to an SSE endpoint.
-sseConnectFromLink :: Link -> Text
-sseConnectFromLink sse = "connect:" <> linkText sse
-
 -- | A tag that can self populate with data that is fetched as GET from a link
 -- whenever some specific events are received from an SSE endpoint.
 -- It also self populate on load.
 sseH
     :: Link
-    -- ^ SSE link
-    -> Link
     -- ^ Link to fetch data from
     -> Text
     -- ^ Target element
@@ -158,8 +151,8 @@ sseH
     -- ^ Events to trigger onto
     -> Monad m
     => HtmlT m ()
-sseH sseLink link target events = do
-    div_ [hxSse_ $ sseConnectFromLink sseLink] $ do
+sseH link target events = do
+     do
         div_
             [ hxTrigger_ triggered
             , hxGet_ $ linkText link
@@ -176,11 +169,10 @@ sseH sseLink link target events = do
     triggered = T.intercalate "," $ ("sse:" <>) <$> events
 
 -- | A tag that can self populate with data directly received in the SSE event.
-sseInH :: Link -> Text -> [Text] -> Html ()
-sseInH sseLink target events =
+sseInH :: Text -> [Text] -> Html ()
+sseInH target events =
     div_
-        [ hxSse_ $ sseConnectFromLink sseLink
-        , hxExt_ "sse"
+        [hxExt_ "sse"
         ]
         $ div_
             [ hxTarget_ $ "#" <> target

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Lib.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Lib.hs
@@ -83,7 +83,7 @@ import Servant
 import qualified Data.Text as T
 
 -- | A simple alert message around any html content.
-alertH :: ToHtml a => a -> Html ()
+alertH :: (ToHtml a, Monad m) => a -> HtmlT m ()
 alertH =
     div_
         [ id_ "result"

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Lib.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Lib.hs
@@ -104,8 +104,7 @@ rogerH =
 
 -- | A simple table row with two columns.
 data AssocRow m
-    =
-    AssocRow
+    = AssocRow
     { rowAttributes :: [Attribute]
     , key :: HtmlT m ()
     , val :: HtmlT m ()
@@ -157,7 +156,8 @@ sseH
     -- ^ Target element
     -> [Text]
     -- ^ Events to trigger onto
-    -> Monad m => HtmlT m ()
+    -> Monad m
+    => HtmlT m ()
 sseH sseLink link target events = do
     div_ [hxSse_ $ sseConnectFromLink sseLink] $ do
         div_
@@ -228,16 +228,21 @@ showThousandDots = reverse . showThousandDots' . reverse . show
 
 -- | A button that copies the content of a field to the clipboard.
 copyButton
-    :: Text -- ^ Field id
-    -> Html ()
+    :: Monad m
+    => Text
+    -- ^ Field id
+    -> HtmlT m ()
 copyButton field' = do
-    script_
-        [i|
-            document.getElementById('#{button}').addEventListener('click', function() {
-                var mnemonic = document.getElementById('#{field'}').innerText;
-                navigator.clipboard.writeText(mnemonic);
-            });
-        |]
     button_ [class_ "btn btn-outline-secondary", id_ button] "Copy"
+    script_ $ copyButtonScript button field'
   where
     button = field' <> "-copy-button"
+
+copyButtonScript :: Text -> Text -> Text
+copyButtonScript button field' =
+    [i|
+    document.getElementById('#{button}').addEventListener('click', function() {
+        var mnemonic = document.getElementById('#{field'}').innerText;
+        navigator.clipboard.writeText(mnemonic);
+    });
+    |]

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Lib.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Lib.hs
@@ -56,6 +56,7 @@ import Data.Text
 import Lucid
     ( Attribute
     , Html
+    , HtmlT
     , ToHtml (..)
     , b_
     , button_
@@ -112,14 +113,14 @@ data AssocRow
     }
 
 -- | Render an 'AssocRow' as a table row.
-assocRowH :: AssocRow -> Html ()
+assocRowH :: AssocRow -> Monad m => HtmlT m ()
 assocRowH AssocRow{..} = tr_ ([scope_ "row"] <> rowAttributes) $ do
     td_ [scope_ "col"] $ b_ $ toHtml key
     td_ [scope_ "col"] $ toHtml val
 
 -- | Render a list of 'AssocRow' as a table. We use 'listOf' to allow 'do' notation
 -- in the definition of the rows
-record :: ListOf AssocRow -> Html ()
+record :: ListOf AssocRow -> Monad m => HtmlT m ()
 record xs =
     table_ [class_ "table table-hover table-striped"]
         $ mapM_ assocRowH
@@ -157,7 +158,7 @@ sseH
     -- ^ Target element
     -> [Text]
     -- ^ Events to trigger onto
-    -> Html ()
+    -> Monad m => HtmlT m ()
 sseH sseLink link target events = do
     div_ [hxSse_ $ sseConnectFromLink sseLink] $ do
         div_

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Network.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Network.hs
@@ -42,6 +42,7 @@ import Data.Quantity
     )
 import Lucid
     ( Html
+    , HtmlT
     , ToHtml (..)
     , p_
     )
@@ -53,18 +54,21 @@ import qualified Data.Percentage as Percentage
 
 -- | Network information tag
 networkH
-    :: Link
+    :: Monad m
+    => Link
     -- ^ Link to the SSE endpoint
     -> Link
     -- ^ Link to the network information endpoint
-    -> Html ()
+    -> HtmlT m ()
 networkH sseLink networkInfoLink =
     sseH sseLink networkInfoLink "content" ["tip"]
 
 -- | Render the network information as a record
 networkInfoH
-    :: ShowTime -- ^ how to show time
-    -> ApiNetworkInformation -- ^ network information
+    :: ShowTime
+    -- ^ how to show time
+    -> ApiNetworkInformation
+    -- ^ network information
     -> Html ()
 networkInfoH showTime ApiNetworkInformation{..} = record $ do
     simpleField "Sync progress" $ syncProgressH progress

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Network.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Network.hs
@@ -57,12 +57,10 @@ import qualified Data.Percentage as Percentage
 networkH
     :: Monad m
     => Link
-    -- ^ Link to the SSE endpoint
-    -> Link
     -- ^ Link to the network information endpoint
     -> HtmlT m ()
-networkH sseLink networkInfoLink =
-    sseH sseLink networkInfoLink "content" ["tip"]
+networkH networkInfoLink =
+    sseH networkInfoLink "content" ["tip"]
 
 -- | Render the network information as a record
 networkInfoH

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Network.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Network.hs
@@ -28,6 +28,7 @@ import Cardano.Wallet.Primitive.Types.EpochNo
     )
 import Cardano.Wallet.UI.Common.Html.Lib
     ( ShowTime
+    , showHtml
     , showPercentage
     )
 import Cardano.Wallet.UI.Common.Html.Pages.Lib
@@ -85,8 +86,8 @@ nextEpochH :: Maybe EpochInfo -> Html ()
 nextEpochH Nothing = p_ "Unknown"
 nextEpochH (Just EpochInfo{..}) = do
     record $ do
-        simpleField "Epoch start" $ show epochStartTime
-        simpleField "Epoch number" $ showThousandDots epochNumber'
+        simpleField "Epoch start" $ showHtml epochStartTime
+        simpleField "Epoch number" $ toHtml $ showThousandDots epochNumber'
   where
     EpochNo epochNumber' = epochNumber
 
@@ -101,8 +102,8 @@ syncProgressH (NotResponding) = "Not Responding"
 blockReferenceH :: ShowTime -> ApiBlockReference -> Html ()
 blockReferenceH showTime ApiBlockReference{..} =
     record $ do
-        simpleField "Slot" $ showThousandDots slot
-        simpleField "Time" $ showTime time
+        simpleField "Slot" $ toHtml $ showThousandDots slot
+        simpleField "Time" $ toHtml $ showTime time
         simpleField "Block" $ blockInfoH block
   where
     ApiT (SlotNo slot) = absoluteSlotNumber
@@ -116,8 +117,8 @@ networkTipH :: ShowTime -> Maybe ApiSlotReference -> Html ()
 networkTipH _ Nothing = "Unknown"
 networkTipH showTime (Just ApiSlotReference{..}) = do
     record $ do
-        simpleField "Slot" $ showThousandDots slot
-        simpleField "Time" $ showTime time
+        simpleField "Slot" $ toHtml $ showThousandDots slot
+        simpleField "Time" $ toHtml $ showTime time
   where
     ApiT (SlotNo slot) = absoluteSlotNumber
 
@@ -135,5 +136,5 @@ nodeEraH ApiConway = "Conway"
 networkIdH :: ApiNetworkInfo -> Html ()
 networkIdH ApiNetworkInfo{..} = do
     record $ do
-        simpleField "Network ID" networkId
+        simpleField "Network ID" $ toHtml networkId
         fieldShow [] "Protocol Magic" protocolMagic

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Settings.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Settings.hs
@@ -38,9 +38,9 @@ import Servant.Links
     )
 
 -- | Settings page
-settingsPageH :: Monad m => Link -> Link -> HtmlT m ()
-settingsPageH sseLink settingsGetLink =
-    sseH sseLink settingsGetLink "content" ["settings"]
+settingsPageH :: Monad m => Link -> HtmlT m ()
+settingsPageH settingsGetLink =
+    sseH settingsGetLink "content" ["settings"]
 
 -- | Settings state
 settingsStateH :: Link -> State s -> Html ()

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Settings.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Settings.hs
@@ -11,6 +11,7 @@ import Cardano.Wallet.UI.Common.Html.Htmx
     )
 import Lucid
     ( Html
+    , HtmlT
     , checked_
     , class_
     , input_
@@ -37,7 +38,7 @@ import Servant.Links
     )
 
 -- | Settings page
-settingsPageH :: Link -> Link -> Html ()
+settingsPageH :: Monad m => Link -> Link -> HtmlT m ()
 settingsPageH sseLink settingsGetLink =
     sseH sseLink settingsGetLink "content" ["settings"]
 

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Body.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Body.hs
@@ -7,27 +7,44 @@ where
 
 import Prelude
 
+import Cardano.Wallet.UI.Common.Html.Htmx
+    ( hxSse_
+    )
+import Cardano.Wallet.UI.Common.Html.Lib
+    ( linkText
+    )
 import Cardano.Wallet.UI.Common.Html.Pages.Template.Footer
     ( footerH
+    )
+import Data.Text
+    ( Text
     )
 import Lucid
     ( HtmlT
     , class_
     , div_
     )
+import Servant
+    ( Link
+    )
+-- | A value attribute to use to connect to an SSE endpoint.
+sseConnectFromLink :: Link -> Text
+sseConnectFromLink sse = "connect:" <> linkText sse
 
 -- | The body of a page.
 bodyH
     :: Monad m
-    => HtmlT m ()
+    => Link
+    -> HtmlT m ()
     -- ^ Header
     -> HtmlT m ()
     -- ^ Body content
     -> HtmlT m ()
-bodyH header body = do
+bodyH sseLink header body = do
     header
-    div_ [class_ "container-fluid"] $ do
-        div_ [class_ "main"] body
-        div_
-            [class_ "footer"]
-            footerH
+    div_ [hxSse_ $ sseConnectFromLink sseLink] $
+        div_ [class_ "container-fluid"] $ do
+            div_ [class_ "main"] body
+            div_
+                [class_ "footer"]
+                footerH

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Body.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Body.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RankNTypes #-}
+
 module Cardano.Wallet.UI.Common.Html.Pages.Template.Body
     ( bodyH
     )
@@ -9,18 +11,19 @@ import Cardano.Wallet.UI.Common.Html.Pages.Template.Footer
     ( footerH
     )
 import Lucid
-    ( Html
+    ( HtmlT
     , class_
     , div_
     )
 
 -- | The body of a page.
 bodyH
-    :: Html ()
+    :: Monad m
+    => HtmlT m ()
     -- ^ Header
-    -> Html ()
+    -> HtmlT m ()
     -- ^ Body content
-    -> Html ()
+    -> HtmlT m ()
 bodyH header body = do
     header
     div_ [class_ "container-fluid"] $ do

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Footer.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Footer.hs
@@ -6,7 +6,7 @@ where
 import Prelude
 
 import Lucid
-    ( Html
+    ( HtmlT
     , a_
     , class_
     , div_
@@ -18,14 +18,14 @@ import Lucid
     )
 
 -- | A link to the GitHub repository of the project.
-githubLinkH :: Html ()
+githubLinkH :: Monad m => HtmlT m ()
 githubLinkH =
     a_
         [href_ "https://github.com/cardano-foundation/cardano-wallet"]
         "GitHub"
 
 -- | The footer of a page.
-footerH :: Html ()
+footerH :: Monad m => HtmlT m ()
 footerH =
     term
         "footer_"

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Head.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Head.hs
@@ -10,7 +10,8 @@ where
 import Prelude
 
 import Cardano.Wallet.UI.Common.Html.Htmx
-    ( useHtmxVersion, useHtmxExtension
+    ( useHtmxExtension
+    , useHtmxVersion
     )
 import Cardano.Wallet.UI.Common.Html.Lib
     ( linkText

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Head.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Head.hs
@@ -10,7 +10,7 @@ where
 import Prelude
 
 import Cardano.Wallet.UI.Common.Html.Htmx
-    ( useHtmxVersion
+    ( useHtmxVersion, useHtmxExtension
     )
 import Cardano.Wallet.UI.Common.Html.Lib
     ( linkText
@@ -107,6 +107,7 @@ pageFromBodyH faviconLink PageConfig{..} body =
                 popperScript
                 favicon faviconLink
                 useHtmxVersion (1, 9, 12)
+                useHtmxExtension "json-enc"
             body_ body
 
 data PageConfig = PageConfig

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Head.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Head.hs
@@ -46,9 +46,9 @@ bootstrapLink :: Monad m => HtmlT m ()
 bootstrapLink =
     link_
         [ rel_ "stylesheet"
-        , href_ "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+        , href_ "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
         , integrity_
-            "sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM"
+            "sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
         , crossorigin_ "anonymous"
         ]
 
@@ -57,9 +57,9 @@ bootstrapScript =
     term
         "script"
         [ src_
-            "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
+            "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
         , integrity_
-            "sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"
+            "sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
         , crossorigin_ "anonymous"
         ]
         $ pure ()
@@ -79,9 +79,9 @@ popperScript =
     term
         "script"
         [ src_
-            "https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"
+            "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js"
         , integrity_
-            "sha384-UOdGjl+2WYrdV0fJ9xJJ4TLEkH4WcJs1SXmeaZ7uwy/ZPwmYupt0VyrKjqqhd8q8"
+            "sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r"
         , crossorigin_ "anonymous"
         ]
         $ pure ()
@@ -102,10 +102,10 @@ pageFromBodyH faviconLink PageConfig{..} body =
                 title_ $ toHtml title
                 meta_ [charset_ "utf-8"]
                 meta_ [name_ "viewport", content_ "width=device-width, initial-scale=1.0"]
+                popperScript
                 bootstrapLink
                 bootstrapScript
                 bootstrapIcons
-                popperScript
                 favicon faviconLink
                 useHtmxVersion (1, 9, 12)
                 useHtmxExtension "json-enc"

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Head.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Head.hs
@@ -1,8 +1,9 @@
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Cardano.Wallet.UI.Common.Html.Pages.Template.Head
     ( pageFromBodyH
-    , PageConfig(..)
+    , PageConfig (..)
     )
 where
 
@@ -18,7 +19,7 @@ import Data.Text
     ( Text
     )
 import Lucid
-    ( Html
+    ( HtmlT
     , ToHtml (..)
     , body_
     , charset_
@@ -40,7 +41,7 @@ import Servant
     ( Link
     )
 
-bootstrapLink :: Html ()
+bootstrapLink :: Monad m => HtmlT m ()
 bootstrapLink =
     link_
         [ rel_ "stylesheet"
@@ -50,7 +51,7 @@ bootstrapLink =
         , crossorigin_ "anonymous"
         ]
 
-bootstrapScript :: Html ()
+bootstrapScript :: Monad m => HtmlT m ()
 bootstrapScript =
     term
         "script"
@@ -62,7 +63,7 @@ bootstrapScript =
         ]
         $ pure ()
 
-bootstrapIcons :: Html ()
+bootstrapIcons :: Monad m => HtmlT m ()
 bootstrapIcons =
     link_
         [ rel_ "stylesheet"
@@ -72,7 +73,7 @@ bootstrapIcons =
         , crossorigin_ "anonymous"
         ]
 
-popperScript :: Html ()
+popperScript :: Monad m => HtmlT m ()
 popperScript =
     term
         "script"
@@ -85,28 +86,28 @@ popperScript =
         $ pure ()
 
 -- | Render a favicon link.
-favicon :: Link -> Html ()
+favicon :: Link -> Monad m => HtmlT m ()
 favicon path =
     link_
         [ rel_ "icon"
         , href_ $ linkText path
         ]
 
-pageFromBodyH :: Link -> PageConfig -> Html () -> Html ()
-pageFromBodyH faviconLink PageConfig{..} body
-    = html_ [term "data-bs-theme" "dark"]
-    $ do
-        head_ $ do
-            title_ $ toHtml title
-            meta_ [charset_ "utf-8"]
-            meta_ [name_ "viewport", content_ "width=device-width, initial-scale=1.0"]
-            bootstrapLink
-            bootstrapScript
-            bootstrapIcons
-            popperScript
-            favicon faviconLink
-            useHtmxVersion (1,9,12)
-        body_ body
+pageFromBodyH :: Monad m => Link -> PageConfig ->  HtmlT m () -> HtmlT m ()
+pageFromBodyH faviconLink PageConfig{..} body =
+    html_ [term "data-bs-theme" "dark"]
+        $ do
+            head_ $ do
+                title_ $ toHtml title
+                meta_ [charset_ "utf-8"]
+                meta_ [name_ "viewport", content_ "width=device-width, initial-scale=1.0"]
+                bootstrapLink
+                bootstrapScript
+                bootstrapIcons
+                popperScript
+                favicon faviconLink
+                useHtmxVersion (1, 9, 12)
+            body_ body
 
 data PageConfig = PageConfig
     { prefix :: Text

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Navigation.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Navigation.hs
@@ -16,7 +16,7 @@ import Data.Text
     )
 import Lucid
     ( Attribute
-    , Html
+    , HtmlT
     , a_
     , class_
     , header_
@@ -38,28 +38,31 @@ activePageH c =
 
 -- | Wrap a content as link tab.
 tabOf
-    :: Text
+    :: Monad m
+    => Text
     -- ^ Link prefix
     -> Bool
     -- ^ Is current page
     -> Link
     -- ^ Page link
-    -> Html ()
+    -> HtmlT m ()
     -- ^ Tab content
-    -> Html ()
+    -> HtmlT m ()
     -- ^ Tab
 tabOf prefix c p t =
     li_ [class_ "nav-item"]
         $ a_ (activePageH c [href_ $ prefix <> linkText p]) t
 
 -- | Navigation bar definition.
-type PageLinks = [(Bool, Link, Html ())]
 
 -- | Navigation bar rendered.
 navigationH
-    :: Text -- ^ Link prefix
-    -> PageLinks -- ^ Page links
-    -> Html ()
+    :: Monad m
+    => Text
+    -- ^ Link prefix
+    -> [(Bool, Link, HtmlT m ())]
+    -- ^ Pages
+    -> HtmlT m ()
 navigationH prefix pages = do
     header_ [class_ "d-flex justify-content-center py-3"] $ do
         ul_ [class_ "nav nav-pills"] $ do

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Wallet.hs
@@ -21,8 +21,9 @@ import Cardano.Wallet.UI.Common.Html.Lib
 import Cardano.Wallet.UI.Common.Html.Pages.Lib
     ( copyButton
     )
-import Control.Monad
-    ( when
+import Cardano.Wallet.UI.Type
+    ( WHtml
+    , onShelley
     )
 import Data.Text
     ( Text
@@ -60,7 +61,7 @@ mnemonicH (Just mnemonic) = do
             $ T.intercalate " " mnemonic
         copyButton "copy-mnemonic"
 
-newWalletH :: (Maybe Bool -> Link) -> PostWalletConfig -> Html ()
+newWalletH :: (Maybe Bool -> Link) -> PostWalletConfig -> WHtml ()
 newWalletH walletMnemonicLink config = do
     useHtmxExtension "json-enc"
     div_ [class_ "btn-group mb-3", role_ "group"] $ do
@@ -88,11 +89,10 @@ newWalletH walletMnemonicLink config = do
 
 data PostWalletConfig = PostWalletConfig
     { passwordVisibility :: Maybe Visible
-    , namePresence :: Bool
     , walletDataLink :: Link
     }
 
-postWalletForm :: PostWalletConfig -> Html ()
+postWalletForm :: PostWalletConfig -> WHtml ()
 postWalletForm PostWalletConfig{..} = form_
     [ hxPost_ $ linkText walletDataLink
     , hxExt_ "json-enc"
@@ -106,19 +106,20 @@ postWalletForm PostWalletConfig{..} = form_
             , name_ "mnemonicSentence"
             , placeholder_ "Mnemonic Sentence"
             ]
-        when namePresence $
-            input_
+        onShelley
+            $ input_
                 [ class_ "form-control form-control-lg mb-3"
                 , type_ "text"
                 , name_ "name"
                 , placeholder_ "Wallet Name"
                 ]
-        input_
-            [ class_ "form-control form-control-lg mb-3"
-            , visibility
-            , name_ "passphrase"
-            , placeholder_ "Passphrase"
-            ]
+        onShelley
+            $ input_
+                [ class_ "form-control form-control-lg mb-3"
+                , visibility
+                , name_ "passphrase"
+                , placeholder_ "Passphrase"
+                ]
         button_
             [ class_ "btn btn-primary btn-block mb-3"
             , type_ "submit"

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Wallet.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Cardano.Wallet.UI.Common.Html.Pages.Wallet
+where
+
+import Prelude
+
+import Cardano.Wallet.UI.Common.API
+    ( Visible (..)
+    )
+import Cardano.Wallet.UI.Common.Html.Htmx
+    ( hxExt_
+    , hxGet_
+    , hxPost_
+    , hxTarget_
+    , useHtmxExtension
+    )
+import Cardano.Wallet.UI.Common.Html.Lib
+    ( linkText
+    )
+import Cardano.Wallet.UI.Common.Html.Pages.Lib
+    ( copyButton
+    )
+import Control.Monad
+    ( when
+    )
+import Data.Text
+    ( Text
+    )
+import Lucid
+    ( Html
+    , ToHtml (..)
+    , autocomplete_
+    , button_
+    , class_
+    , div_
+    , form_
+    , id_
+    , input_
+    , name_
+    , placeholder_
+    , role_
+    , type_
+    )
+import Servant
+    ( Link
+    )
+
+import qualified Data.Text as T
+
+mnemonicH :: Maybe [Text] -> Html ()
+mnemonicH Nothing = ""
+mnemonicH (Just mnemonic) = do
+    div_ [class_ "card"] $ do
+        div_
+            [ class_ "card-body text-muted small"
+            , id_ "copy-mnemonic"
+            ]
+            $ toHtml
+            $ T.intercalate " " mnemonic
+        copyButton "copy-mnemonic"
+
+newWalletH :: (Maybe Bool -> Link) -> PostWalletConfig -> Html ()
+newWalletH walletMnemonicLink config = do
+    useHtmxExtension "json-enc"
+    div_ [class_ "btn-group mb-3", role_ "group"] $ do
+        button_
+            [ class_ "btn btn-outline-secondary"
+            , hxGet_ $ linkText $ walletMnemonicLink Nothing
+            , hxTarget_ "#menmonic"
+            ]
+            "Hint a mnemonic"
+        button_
+            [ class_ "btn btn-outline-secondary"
+            , hxGet_ $ linkText $ walletMnemonicLink $ Just True
+            , hxTarget_ "#menmonic"
+            ]
+            "Clean hinted mnemonic"
+
+    div_ [id_ "menmonic", class_ "mb-3"] ""
+
+    postWalletForm config
+
+    div_
+        [ id_ "new_wallet"
+        ]
+        mempty
+
+data PostWalletConfig = PostWalletConfig
+    { passwordVisibility :: Maybe Visible
+    , namePresence :: Bool
+    , walletDataLink :: Link
+    }
+
+postWalletForm :: PostWalletConfig -> Html ()
+postWalletForm PostWalletConfig{..} = form_
+    [ hxPost_ $ linkText walletDataLink
+    , hxExt_ "json-enc"
+    , hxTarget_ "#new_wallet"
+    , autocomplete_ "off"
+    ]
+    $ do
+        input_
+            [ class_ "form-control form-control-lg mb-3"
+            , visibility
+            , name_ "mnemonicSentence"
+            , placeholder_ "Mnemonic Sentence"
+            ]
+        when namePresence $
+            input_
+                [ class_ "form-control form-control-lg mb-3"
+                , type_ "text"
+                , name_ "name"
+                , placeholder_ "Wallet Name"
+                ]
+        input_
+            [ class_ "form-control form-control-lg mb-3"
+            , visibility
+            , name_ "passphrase"
+            , placeholder_ "Passphrase"
+            ]
+        button_
+            [ class_ "btn btn-primary btn-block mb-3"
+            , type_ "submit"
+            ]
+            "Restore wallet"
+  where
+    visibility = type_ $ case passwordVisibility of
+        Just Visible -> "text"
+        Just Hidden -> "password"
+        Nothing -> "password"

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Wallet.hs
@@ -13,7 +13,6 @@ import Cardano.Wallet.UI.Common.Html.Htmx
     , hxGet_
     , hxPost_
     , hxTarget_
-    
     )
 import Cardano.Wallet.UI.Common.Html.Lib
     ( linkText

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Wallet.hs
@@ -9,8 +9,7 @@ import Cardano.Wallet.UI.Common.API
     ( Visible (..)
     )
 import Cardano.Wallet.UI.Common.Html.Htmx
-    ( hxExt_
-    , hxGet_
+    ( hxGet_
     , hxPost_
     , hxTarget_
     )
@@ -22,6 +21,7 @@ import Cardano.Wallet.UI.Common.Html.Pages.Lib
     )
 import Cardano.Wallet.UI.Type
     ( WHtml
+    , onDeposit
     , onShelley
     )
 import Data.Text
@@ -70,7 +70,6 @@ postWalletFormTagH :: PostWalletConfig -> WHtml () -> WHtml ()
 postWalletFormTagH PostWalletConfig{..} =
     form_
         [ hxPost_ $ linkText walletDataLink
-        , hxExt_ "json-enc"
         , hxTarget_ responseTarget
         , autocomplete_ "off"
         ]
@@ -119,9 +118,16 @@ mnemonicSetupFieldsH PostWalletConfig{..} = do
     input_
         [ class_ "form-control form-control-lg mb-3"
         , visibility
-        , name_ "mnemonicSentence"
+        , name_ "mnemonics"
         , placeholder_ "Mnemonic Sentence"
         ]
+    onDeposit
+        $ input_
+            [ class_ "form-control form-control-lg mb-3"
+            , type_ "number"
+            , name_ "users"
+            , placeholder_ "Customer Discovery"
+            ]
     onShelley
         $ input_
             [ class_ "form-control form-control-lg mb-3"
@@ -160,6 +166,13 @@ newWalletFromXPubH config = do
             , name_ "xpub"
             , placeholder_ "Extended Public Key"
             ]
+        onDeposit
+            $ input_
+                [ class_ "form-control form-control-lg mb-3"
+                , type_ "number"
+                , name_ "users"
+                , placeholder_ "Customer Discovery"
+                ]
         button_
             [ class_ "btn btn-primary btn-block mb-3"
             , type_ "submit"

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Layer.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Layer.hs
@@ -178,8 +178,6 @@ mkUILayer throttling sessions' s0 = UILayer{..}
             sessions'' <- readTVarIO sessions'
             forM_ (Map.elems sessions'') $ \s -> do
                 sendSSE s $ Push "tip"
-                sendSSE s $ Push "wallets"
-                sendSSE s $ Push "wallet"
 
 -- | Run an action with a UI layer.
 withUILayer :: Int -> s -> ContT r IO (UILayer s)

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
@@ -13,6 +13,8 @@
 
 module Cardano.Wallet.UI.Deposit.API where
 
+import Prelude
+
 import Cardano.Wallet.UI.Common.API
     ( Image
     , SessionedHtml
@@ -30,6 +32,7 @@ import Servant
     , Link
     , Post
     , Proxy (..)
+    , QueryParam
     , allLinks
     , (:<|>) (..)
     , (:>)
@@ -42,6 +45,8 @@ type Pages =
     "about" :> SessionedHtml Get
         :<|> "network" :> SessionedHtml Get
         :<|> "settings" :> SessionedHtml Get
+        :<|> "wallet" :> SessionedHtml Get
+
 -- | Data endpoints
 type Data =
     "network" :> "info" :> SessionedHtml Get
@@ -49,6 +54,11 @@ type Data =
         :<|> "settings" :> "sse" :> "toggle" :> SessionedHtml Post
         :<|> "sse" :> (CookieRequest :> SSE)
         :<|> "favicon.ico" :> Get '[Image] BL.ByteString
+        :<|> "wallet"
+            :> "mnemonic"
+            :> QueryParam "clean" Bool
+            :> SessionedHtml Get
+        :<|> "wallet" :> SessionedHtml Get
 
 type Home = SessionedHtml Get
 
@@ -69,14 +79,19 @@ settingsGetLink :: Link
 settingsSseToggleLink :: Link
 sseLink :: Link
 faviconLink :: Link
-
+walletMnemonicLink :: Maybe Bool -> Link
+walletPageLink :: Link
+walletLink :: Link
 homePageLink
     :<|> aboutPageLink
     :<|> networkPageLink
     :<|> settingsPageLink
+    :<|> walletPageLink
     :<|> networkInfoLink
     :<|> settingsGetLink
     :<|> settingsSseToggleLink
     :<|> sseLink
-    :<|> faviconLink =
+    :<|> faviconLink
+    :<|> walletMnemonicLink
+    :<|> walletLink =
         allLinks (Proxy @UI)

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
@@ -27,12 +27,17 @@ import Cardano.Wallet.UI.Common.Handlers.SSE
 import Cardano.Wallet.UI.Cookies
     ( CookieRequest
     )
+import Data.Aeson
+    ( Value
+    )
 import Servant
     ( Get
+    , JSON
     , Link
     , Post
     , Proxy (..)
     , QueryParam
+    , ReqBody
     , allLinks
     , (:<|>) (..)
     , (:>)
@@ -59,6 +64,14 @@ type Data =
             :> QueryParam "clean" Bool
             :> SessionedHtml Get
         :<|> "wallet" :> SessionedHtml Get
+        :<|> "wallet"
+            :> "mnemonic"
+            :> ReqBody '[JSON] Value
+            :> SessionedHtml Post
+        :<|> "wallet"
+            :> "xpub"
+            :> ReqBody '[JSON] Value
+            :> SessionedHtml Post
 
 type Home = SessionedHtml Get
 
@@ -82,6 +95,8 @@ faviconLink :: Link
 walletMnemonicLink :: Maybe Bool -> Link
 walletPageLink :: Link
 walletLink :: Link
+walletPostMnemonicLink :: Link
+walletPostXPubLink :: Link
 homePageLink
     :<|> aboutPageLink
     :<|> networkPageLink
@@ -93,5 +108,7 @@ homePageLink
     :<|> sseLink
     :<|> faviconLink
     :<|> walletMnemonicLink
-    :<|> walletLink =
+    :<|> walletLink
+    :<|> walletPostMnemonicLink
+    :<|> walletPostXPubLink =
         allLinks (Proxy @UI)

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
@@ -27,12 +29,15 @@ import Cardano.Wallet.UI.Common.Handlers.SSE
 import Cardano.Wallet.UI.Cookies
     ( CookieRequest
     )
-import Data.Aeson
-    ( Value
+import Data.Text
+    ( Text
+    )
+import GHC.Generics
+    ( Generic
     )
 import Servant
-    ( Get
-    , JSON
+    ( FormUrlEncoded
+    , Get
     , Link
     , Post
     , Proxy (..)
@@ -42,8 +47,27 @@ import Servant
     , (:<|>) (..)
     , (:>)
     )
+import Web.FormUrlEncoded
+    ( FromForm
+    )
 
 import qualified Data.ByteString.Lazy as BL
+
+data PostWalletViaMenmonic = PostWalletViaMenmonic
+    { mnemonics :: Text
+    , users :: Int
+    }
+    deriving (Generic)
+
+instance FromForm PostWalletViaMenmonic
+
+data PostWalletViaXPub = PostWalletViaXPub
+    { xpub :: Text
+    , users :: Int
+    }
+    deriving (Generic)
+
+instance FromForm PostWalletViaXPub
 
 -- | Pages endpoints
 type Pages =
@@ -66,11 +90,11 @@ type Data =
         :<|> "wallet" :> SessionedHtml Get
         :<|> "wallet"
             :> "mnemonic"
-            :> ReqBody '[JSON] Value
+            :> ReqBody '[FormUrlEncoded] PostWalletViaMenmonic
             :> SessionedHtml Post
         :<|> "wallet"
             :> "xpub"
-            :> ReqBody '[JSON] Value
+            :> ReqBody '[FormUrlEncoded] PostWalletViaXPub
             :> SessionedHtml Post
 
 type Home = SessionedHtml Get
@@ -110,6 +134,5 @@ homePageLink
     :<|> walletMnemonicLink
     :<|> walletLink
     :<|> walletPostMnemonicLink
-    :<|> walletPostXPubLink
-    =
+    :<|> walletPostXPubLink =
         allLinks (Proxy @UI)

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
@@ -110,5 +110,6 @@ homePageLink
     :<|> walletMnemonicLink
     :<|> walletLink
     :<|> walletPostMnemonicLink
-    :<|> walletPostXPubLink =
+    :<|> walletPostXPubLink
+    =
         allLinks (Proxy @UI)

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Page.hs
@@ -24,7 +24,9 @@ import Cardano.Wallet.UI.Common.Html.Pages.Template.Head
     ( PageConfig
     )
 import Cardano.Wallet.UI.Common.Layer
-    ( UILayer (..)
+    ( Push (..)
+    , UILayer (..)
+    , sendSSE
     )
 import Cardano.Wallet.UI.Cookies
     ( CookieResponse
@@ -45,7 +47,7 @@ import Control.Monad.IO.Class
     ( MonadIO (..)
     )
 import Control.Tracer
-    ( Tracer
+    ( Tracer (..)
     , traceWith
     )
 import Servant
@@ -80,6 +82,8 @@ pageHandler tr layer env dir config x =
                         then do
                             lg tr "Loading wallet from" dir
                             loadWallet env dir
+                                $ Tracer
+                                $ \_ -> sendSSE session $ Push "wallet-present"
                             lg tr "Wallet loaded from" dir
                             WalletPresent <$> walletPublicIdentity
                         else

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Page.hs
@@ -1,0 +1,61 @@
+module Cardano.Wallet.UI.Deposit.Handlers.Page
+where
+
+import Prelude
+
+import Cardano.Wallet.Deposit.REST
+    ( WalletResource
+    , walletExists
+    , walletPublicIdentity
+    )
+import Cardano.Wallet.UI.Common.Handlers.Session
+    ( withSessionLayer
+    )
+import Cardano.Wallet.UI.Common.Html.Html
+    ( RawHtml (..)
+    )
+import Cardano.Wallet.UI.Common.Html.Pages.Template.Head
+    ( PageConfig
+    )
+import Cardano.Wallet.UI.Common.Layer
+    ( UILayer (..)
+    )
+import Cardano.Wallet.UI.Cookies
+    ( CookieResponse
+    , RequestCookies
+    )
+import Cardano.Wallet.UI.Deposit.Handlers.Lib
+    ( catchRunWalletResourceM
+    )
+import Cardano.Wallet.UI.Deposit.Html.Pages.Page
+    ( Page (..)
+    , page
+    )
+import Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
+    ( WalletPresent (..)
+    )
+import Servant
+    ( Handler
+    )
+
+pageHandler
+    :: UILayer WalletResource
+    -- ^ The deposit UI layer
+    -> FilePath
+    -- ^ The directory where the wallet data is stored
+    -> PageConfig
+    -- ^ The page configuration
+    -> Page
+    -- ^ The page to render
+    -> Maybe RequestCookies
+    -- ^ The request cookies
+    -> Handler (CookieResponse RawHtml)
+pageHandler layer dir config x =
+    withSessionLayer layer $ \session -> do
+        w <- catchRunWalletResourceM session $ do
+            test <- walletExists dir
+            if test
+                then do
+                    WalletPresent <$> walletPublicIdentity
+                else pure WalletAbsent
+        pure $ page config x w

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Page.hs
@@ -1,10 +1,20 @@
+{-# OPTIONS_GHC -Wno-type-defaults #-}
+
 module Cardano.Wallet.UI.Deposit.Handlers.Page
 where
 
 import Prelude
 
+import Cardano.Wallet.Deposit.IO
+    ( WalletBootEnv
+    )
+import Cardano.Wallet.Deposit.IO.Resource
+    ( ResourceStatus (..)
+    , readStatus
+    )
 import Cardano.Wallet.Deposit.REST
     ( WalletResource
+    , loadWallet
     , walletExists
     , walletPublicIdentity
     )
@@ -34,12 +44,32 @@ import Cardano.Wallet.UI.Deposit.Html.Pages.Page
 import Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
     ( WalletPresent (..)
     )
+import Cardano.Wallet.UI.Type
+    ( WHtml
+    )
+import Control.Monad.IO.Class
+    ( MonadIO (..)
+    )
+import Control.Monad.Reader.Class
+    ( ask
+    )
+import Control.Tracer
+    ( Tracer
+    , traceWith
+    )
 import Servant
     ( Handler
     )
 
+import qualified Data.ByteString.Lazy.Char8 as BL
+
+lg :: (MonadIO m, Show a) => Tracer IO String -> String -> a -> m ()
+lg tr p x = liftIO $ traceWith tr $ p <> ": " <> show x
+
 pageHandler
-    :: UILayer WalletResource
+    :: Tracer IO String
+    -> UILayer WalletResource
+    -> WalletBootEnv IO
     -- ^ The deposit UI layer
     -> FilePath
     -- ^ The directory where the wallet data is stored
@@ -47,15 +77,28 @@ pageHandler
     -- ^ The page configuration
     -> Page
     -- ^ The page to render
+    -> (BL.ByteString -> WHtml ())
     -> Maybe RequestCookies
     -- ^ The request cookies
     -> Handler (CookieResponse RawHtml)
-pageHandler layer dir config x =
+pageHandler tr layer env dir config x alert =
     withSessionLayer layer $ \session -> do
         w <- catchRunWalletResourceM session $ do
-            test <- walletExists dir
-            if test
-                then do
-                    WalletPresent <$> walletPublicIdentity
-                else pure WalletAbsent
-        pure $ page config x w
+            s <- ask >>= liftIO . readStatus
+            case s of
+                NotInitialized -> do
+                    test <- walletExists dir
+                    if test
+                        then do
+                            lg tr "Loading wallet from" dir
+                            loadWallet env dir
+                            lg tr "Wallet loaded from" dir
+                            WalletPresent <$> walletPublicIdentity
+                        else
+                            pure WalletAbsent
+                Initialized _ -> WalletPresent <$> walletPublicIdentity
+                Vanished e -> pure $ WalletVanished e
+                FailedToInitialize e -> pure $ WalletFailedToInitialize e
+                Initializing -> pure WalletInitializing
+        lg tr "Rendering page" w
+        pure $ page config x alert w

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Wallet.hs
@@ -95,6 +95,7 @@ initWalletWithXPub
     -> XPub
     -> Handler html
 initWalletWithXPub l@SessionLayer{sendSSE} alert render initWallet xpub = do
+    liftIO $ sendSSE $ Push "wallet"
     r <- liftIO $ catchRunWalletResourceM l (initWallet xpub)
     case r of
         Left e -> pure $ alert $ BL.pack $ show e
@@ -153,15 +154,8 @@ parsePostXPubRequest = parseEither
     . withObject "create wallet from xpub request"
     $ \o -> o .: "xpub"
 
--- deleteWalletHandler
---     :: SessionLayer WalletResource
---     -> (BL.ByteString -> html)
---     -> (() -> html)
---     -> Handler html
--- deleteWalletHandler layer alert render = do
---     r <- liftIO $ catchRunWalletResourceM layer deleteWallet
---     case r of
---         Left e -> pure $ alert $ BL.pack $ show e
---         Right _ -> do
---             liftIO $ sendSSE layer $ Push "wallet"
---             pure $ render ()
+walletIsLoading
+    :: SessionLayer WalletResource
+    -> (WalletPresent -> html)
+    -> Handler html
+walletIsLoading layer render = render <$> walletPresent layer

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Wallet.hs
@@ -3,6 +3,9 @@ where
 
 import Prelude
 
+import Cardano.Address.Derivation
+    ( XPub
+    )
 import Cardano.Wallet.Deposit.IO
     ( WalletPublicIdentity
     )
@@ -12,6 +15,9 @@ import Cardano.Wallet.Deposit.REST
     , WalletResourceM
     , runWalletResourceM
     , walletPublicIdentity
+    )
+import Cardano.Wallet.UI.Common.Handlers.Lib
+    ( handleParseRequestError
     )
 import Cardano.Wallet.UI.Common.Layer
     ( SessionLayer (..)
@@ -23,11 +29,31 @@ import Control.Lens
 import Control.Monad.Trans
     ( MonadIO (..)
     )
+import Data.Aeson
+    ( Value
+    , withObject
+    , (.:)
+    )
+import Data.Aeson.Types
+    ( parseEither
+    )
+import Data.ByteArray.Encoding
+    ( Base (..)
+    , convertFromBase
+    )
+import Data.ByteString
+    ( ByteString
+    )
+import Data.Text
+    ( Text
+    )
 import Servant
     ( Handler
     )
 
+import qualified Cardano.Address.Derivation as Addresses
 import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.Text.Encoding as T
 
 catchRunWalletResourceM
     :: SessionLayer WalletResource
@@ -57,3 +83,67 @@ getWallet
     -> Handler html
 getWallet layer alert render =
     catchRunWalletResourceHtml layer alert render walletPublicIdentity
+
+initWalletWithXPub
+    :: SessionLayer WalletResource
+    -> (BL.ByteString -> html)
+    -> (() -> html)
+    -> (XPub -> WalletResourceM a)
+    -> XPub
+    -> Handler html
+initWalletWithXPub l alert render initWallet xpub = do
+    r <- liftIO $ catchRunWalletResourceM l (initWallet xpub)
+    pure $ case r of
+        Left e -> alert $ BL.pack $ show e
+        Right _ -> render ()
+
+postMnemonicWallet
+    :: SessionLayer WalletResource
+    -> (XPub -> WalletResourceM a)
+    -> (BL.ByteString -> html)
+    -> (() -> html)
+    -> Value
+    -> Handler html
+postMnemonicWallet l initWallet alert render v = do
+    mnemonic <-
+        handleParseRequestError
+            $ parsePostWalletRequest v
+    let xpub =
+            Addresses.toXPub
+                $ Addresses.generate (T.encodeUtf8 mnemonic)
+    initWalletWithXPub l alert render initWallet xpub
+
+parsePostWalletRequest :: Value -> Either String Text
+parsePostWalletRequest = parseEither
+    . withObject "create wallet request"
+    $ \o -> o .: "mnemonicSentence"
+
+unBase64 :: ByteString -> Either String ByteString
+unBase64 = convertFromBase Base64
+
+postXPubWallet
+    :: SessionLayer WalletResource
+    -> (XPub -> WalletResourceM a)
+    -> (BL.ByteString -> html)
+    -> (() -> html)
+    -> Value
+    -> Handler html
+postXPubWallet l initWallet alert render v = do
+    xpubText <-
+        handleParseRequestError
+            $ parsePostXPubRequest v
+    case T.encodeUtf8 xpubText of
+        xpubByteString -> case unBase64 xpubByteString of
+            Left e -> pure $ alert $ BL.pack $ "Invalid base64: " <> e
+            Right xpubBytes -> case Addresses.xpubFromBytes xpubBytes of
+                Nothing ->
+                    pure
+                        $ alert
+                        $ BL.pack
+                        $ "Invalid xpub: " <> show xpubText
+                Just xpub -> initWalletWithXPub l alert render initWallet xpub
+
+parsePostXPubRequest :: Value -> Either String Text
+parsePostXPubRequest = parseEither
+    . withObject "create wallet from xpub request"
+    $ \o -> o .: "xpub"

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Wallet.hs
@@ -1,0 +1,50 @@
+module Cardano.Wallet.UI.Deposit.Handlers.Wallet
+where
+
+import Prelude
+
+import Cardano.Wallet.Deposit.IO
+    ( WalletPublicIdentity
+    )
+import Cardano.Wallet.Deposit.REST
+    ( WalletResource
+    , WalletResourceM
+    , runWalletResourceM
+    , walletPublicIdentity
+    )
+import Cardano.Wallet.UI.Common.Layer
+    ( SessionLayer (..)
+    , stateL
+    )
+import Control.Lens
+    ( view
+    )
+import Control.Monad.Trans
+    ( MonadIO (..)
+    )
+import Servant
+    ( Handler
+    )
+
+import qualified Data.ByteString.Lazy.Char8 as BL
+
+catchRunWalletResourceM
+    :: SessionLayer WalletResource
+    -> (BL.ByteString -> html)
+    -> (a -> html)
+    -> WalletResourceM a
+    -> Handler html
+catchRunWalletResourceM layer alert render f = liftIO $ do
+    s <- view stateL <$> state layer
+    r <- runWalletResourceM f s
+    pure $ case r of
+        Left e -> alert $ BL.pack $ show e
+        Right a -> render a
+
+getWallet
+    :: SessionLayer WalletResource
+    -> (BL.ByteString -> html) -- problem report
+    -> (WalletPublicIdentity -> html) -- success report
+    -> Handler html
+getWallet layer alert render =
+    catchRunWalletResourceM layer alert render walletPublicIdentity

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/About.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/About.hs
@@ -1,11 +1,13 @@
 module Cardano.Wallet.UI.Deposit.Html.Pages.About where
 
+import Prelude
+
 import Lucid
-    ( Html
+    ( HtmlT
     , p_
     )
 
-aboutH :: Html ()
+aboutH :: Monad m => HtmlT m ()
 aboutH = do
     p_
         "This is the new builtin Cardano Deposit Wallet web UI, pre-alpha version"

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
@@ -49,7 +49,8 @@ import Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
     , walletH
     )
 import Cardano.Wallet.UI.Type
-    ( WalletType (..)
+    ( WHtml
+    , WalletType (..)
     , runWHtml
     )
 import Control.Lens.Extras
@@ -66,6 +67,8 @@ import Lucid
     , renderBS
     )
 
+import qualified Data.ByteString.Lazy.Char8 as BL
+
 data Page
     = About
     | Network
@@ -79,10 +82,11 @@ page
     -- ^ Page configuration
     -> Page
     -- ^ Current page
+    -> (BL.ByteString -> WHtml ())
     -> WalletPresent
     -- ^ If a wallet is present
     -> RawHtml
-page c@PageConfig{..} p wp = RawHtml
+page c@PageConfig{..} p alert wp = RawHtml
     $ renderBS
     $ runWHtml Deposit
     $ pageFromBodyH faviconLink c
@@ -91,7 +95,7 @@ page c@PageConfig{..} p wp = RawHtml
         About -> aboutH
         Network -> networkH sseLink networkInfoLink
         Settings -> settingsPageH sseLink settingsGetLink
-        Wallet -> walletH wp
+        Wallet -> walletH alert wp
 
 headerH :: Text -> Page -> Monad m => HtmlT m ()
 headerH prefix p =

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
@@ -38,9 +38,13 @@ import Cardano.Wallet.UI.Deposit.API
     , settingsGetLink
     , settingsPageLink
     , sseLink
+    , walletPageLink
     )
 import Cardano.Wallet.UI.Deposit.Html.Pages.About
     ( aboutH
+    )
+import Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
+    ( walletH
     )
 import Control.Lens.Extras
     ( is
@@ -60,6 +64,7 @@ data Page
     = About
     | Network
     | Settings
+    | Wallet
 
 makePrisms ''Page
 
@@ -69,7 +74,7 @@ page
     -> Page
     -- ^ If a wallet was selected
     -> RawHtml
-page c@PageConfig{..} p  = RawHtml
+page c@PageConfig{..} p = RawHtml
     $ renderBS
     $ pageFromBodyH faviconLink c
     $ bodyH (headerH prefix p)
@@ -77,6 +82,7 @@ page c@PageConfig{..} p  = RawHtml
         About -> aboutH
         Network -> networkH sseLink networkInfoLink
         Settings -> settingsPageH sseLink settingsGetLink
+        Wallet -> walletH
 
 headerH :: Text -> Page -> Html ()
 headerH prefix p =
@@ -85,4 +91,5 @@ headerH prefix p =
         [ (is _About p, aboutPageLink, "About")
         , (is _Network p, networkPageLink, "Network")
         , (is _Settings p, settingsPageLink, "Settings")
+        , (is _Wallet p, walletPageLink, "Wallet")
         ]

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
@@ -45,12 +45,10 @@ import Cardano.Wallet.UI.Deposit.Html.Pages.About
     ( aboutH
     )
 import Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
-    ( WalletPresent
-    , walletH
+    ( walletH
     )
 import Cardano.Wallet.UI.Type
-    ( WHtml
-    , WalletType (..)
+    ( WalletType (..)
     , runWHtml
     )
 import Control.Lens.Extras
@@ -67,8 +65,6 @@ import Lucid
     , renderBS
     )
 
-import qualified Data.ByteString.Lazy.Char8 as BL
-
 data Page
     = About
     | Network
@@ -82,11 +78,8 @@ page
     -- ^ Page configuration
     -> Page
     -- ^ Current page
-    -> (BL.ByteString -> WHtml ())
-    -> WalletPresent
-    -- ^ If a wallet is present
     -> RawHtml
-page c@PageConfig{..} p alert wp = RawHtml
+page c@PageConfig{..} p = RawHtml
     $ renderBS
     $ runWHtml Deposit
     $ pageFromBodyH faviconLink c
@@ -95,7 +88,7 @@ page c@PageConfig{..} p alert wp = RawHtml
         About -> aboutH
         Network -> networkH sseLink networkInfoLink
         Settings -> settingsPageH sseLink settingsGetLink
-        Wallet -> walletH alert wp
+        Wallet -> walletH
 
 headerH :: Text -> Page -> Monad m => HtmlT m ()
 headerH prefix p =

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
@@ -83,12 +83,13 @@ page c@PageConfig{..} p = RawHtml
     $ renderBS
     $ runWHtml Deposit
     $ pageFromBodyH faviconLink c
-    $ bodyH (headerH prefix p)
-    $ case p of
-        About -> aboutH
-        Network -> networkH sseLink networkInfoLink
-        Settings -> settingsPageH sseLink settingsGetLink
-        Wallet -> walletH
+    $ bodyH sseLink (headerH prefix p)
+    $ do
+        case p of
+            About -> aboutH
+            Network -> networkH networkInfoLink
+            Settings -> settingsPageH settingsGetLink
+            Wallet -> walletH
 
 headerH :: Text -> Page -> Monad m => HtmlT m ()
 headerH prefix p =

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -47,6 +48,10 @@ import Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
     ( WalletPresent
     , walletH
     )
+import Cardano.Wallet.UI.Type
+    ( WalletType (..)
+    , runWHtml
+    )
 import Control.Lens.Extras
     ( is
     )
@@ -79,6 +84,7 @@ page
     -> RawHtml
 page c@PageConfig{..} p wp = RawHtml
     $ renderBS
+    $ runWHtml Deposit
     $ pageFromBodyH faviconLink c
     $ bodyH (headerH prefix p)
     $ case p of

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
@@ -57,7 +57,7 @@ import Data.Text
     ( Text
     )
 import Lucid
-    ( Html
+    ( HtmlT
     , renderBS
     )
 
@@ -87,7 +87,7 @@ page c@PageConfig{..} p wp = RawHtml
         Settings -> settingsPageH sseLink settingsGetLink
         Wallet -> walletH wp
 
-headerH :: Text -> Page -> Html ()
+headerH :: Text -> Page -> Monad m => HtmlT m ()
 headerH prefix p =
     navigationH
         prefix

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
@@ -44,7 +44,8 @@ import Cardano.Wallet.UI.Deposit.Html.Pages.About
     ( aboutH
     )
 import Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
-    ( walletH
+    ( WalletPresent
+    , walletH
     )
 import Control.Lens.Extras
     ( is
@@ -72,9 +73,11 @@ page
     :: PageConfig
     -- ^ Page configuration
     -> Page
-    -- ^ If a wallet was selected
+    -- ^ Current page
+    -> WalletPresent
+    -- ^ If a wallet is present
     -> RawHtml
-page c@PageConfig{..} p = RawHtml
+page c@PageConfig{..} p wp = RawHtml
     $ renderBS
     $ pageFromBodyH faviconLink c
     $ bodyH (headerH prefix p)
@@ -82,7 +85,7 @@ page c@PageConfig{..} p = RawHtml
         About -> aboutH
         Network -> networkH sseLink networkInfoLink
         Settings -> settingsPageH sseLink settingsGetLink
-        Wallet -> walletH
+        Wallet -> walletH wp
 
 headerH :: Text -> Page -> Html ()
 headerH prefix p =

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
 where
@@ -22,6 +23,7 @@ import Cardano.Wallet.UI.Common.Html.Pages.Lib
     ( copyButton
     , record
     , simpleField
+    , sseH
     )
 import Cardano.Wallet.UI.Common.Html.Pages.Wallet
     ( PostWalletConfig (..)
@@ -29,12 +31,15 @@ import Cardano.Wallet.UI.Common.Html.Pages.Wallet
     , newWalletFromXPubH
     )
 import Cardano.Wallet.UI.Deposit.API
-    ( walletMnemonicLink
+    ( walletLink
+    , walletMnemonicLink
     , walletPostMnemonicLink
     , walletPostXPubLink
     )
 import Cardano.Wallet.UI.Type
     ( WHtml
+    , WalletType (..)
+    , runWHtml
     )
 import Control.Exception
     ( SomeException
@@ -50,7 +55,8 @@ import Data.Text.Class
     ( ToText (..)
     )
 import Lucid
-    ( HtmlT
+    ( Html
+    , HtmlT
     , ToHtml (..)
     , class_
     , div_
@@ -58,6 +64,9 @@ import Lucid
     , id_
     )
 
+import Cardano.Wallet.UI.Shelley.API
+    ( sseLink
+    )
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy.Char8 as BL
 
@@ -75,49 +84,55 @@ instance Show WalletPresent where
     show (WalletVanished _) = "WalletVanished"
     show WalletInitializing = "WalletInitializing"
 
-walletH :: (BL.ByteString -> WHtml ()) -> WalletPresent -> WHtml ()
-walletH alert walletPresent = do
-    -- sseH sseLink walletLink "wallet" ["wallet"]
-    case walletPresent of
-        WalletPresent wallet -> walletElementH wallet
-        WalletAbsent -> do
-            newWalletFromMnemonicH walletMnemonicLink
-                $ PostWalletConfig
-                    { walletDataLink = walletPostMnemonicLink
-                    , passwordVisibility = Just Hidden
-                    , responseTarget = "#post-response"
-                    }
-            newWalletFromXPubH
-                $ PostWalletConfig
-                    { walletDataLink = walletPostXPubLink
-                    , passwordVisibility = Just Hidden
-                    , responseTarget = "#post-response"
-                    }
-            div_ [id_ "post-response"] mempty
-        WalletFailedToInitialize err ->
-            alert
-                $ "Failed to initialize wallet"
-                    <> BL.pack (show err)
-        WalletVanished e -> alert $ "Wallet vanished " <> BL.pack (show e)
-        WalletInitializing -> alert "Wallet is initializing"
+walletH :: WHtml ()
+walletH = sseH sseLink walletLink "wallet" ["wallet"]
 
 base64 :: ByteString -> ByteString
 base64 = convertToBase Base64
 
 pubKeyH :: Monad m => XPub -> HtmlT m ()
-pubKeyH xpub = div_ [class_ "row"]   $ do
+pubKeyH xpub = div_ [class_ "row"] $ do
     div_ [id_ "public_key", hidden_ "false"] $ toHtml xpubByteString
     div_ [class_ "col-6"] $ toHtml $ headAndTail 4 $ B8.dropEnd 2 xpubByteString
     div_ [class_ "col-6"]
         $ copyButton "public_key"
-
-    where xpubByteString = base64 $ xpubToBytes xpub
+  where
+    xpubByteString = base64 $ xpubToBytes xpub
 
 headAndTail :: Int -> ByteString -> ByteString
 headAndTail n t = B8.take n t <> ".." <> B8.takeEnd n t
 
-walletElementH :: Monad m => WalletPublicIdentity -> HtmlT m ()
-walletElementH (WalletPublicIdentity xpub customers) = do
-    record $ do
-        simpleField "Public Key" $ pubKeyH xpub
-        simpleField "Customer Discovery" $ toHtml $ toText customers
+walletElementH :: (BL.ByteString -> Html ()) -> WalletPresent -> Html ()
+walletElementH alert = \case
+    (WalletPresent (WalletPublicIdentity xpub customers)) -> do
+        record $ do
+            simpleField "Public Key" $ pubKeyH xpub
+            simpleField "Customer Discovery" $ toHtml $ toText customers
+        -- div_ [class_ "row"] $ do
+            -- button_
+            --     [ class_ "btn btn-danger"
+            --     , hxDelete_ $ linkText walletDeleteLink
+            --     , hxTarget_ "#delete-result"
+            --     ]
+            --     "Delete Wallet"
+            -- div_ [id_ "delete-result"] mempty
+    WalletAbsent -> runWHtml Deposit $ do
+        newWalletFromMnemonicH walletMnemonicLink
+            $ PostWalletConfig
+                { walletDataLink = walletPostMnemonicLink
+                , passwordVisibility = Just Hidden
+                , responseTarget = "#post-response"
+                }
+        newWalletFromXPubH
+            $ PostWalletConfig
+                { walletDataLink = walletPostXPubLink
+                , passwordVisibility = Just Hidden
+                , responseTarget = "#post-response"
+                }
+        div_ [id_ "post-response"] mempty
+    WalletFailedToInitialize err ->
+        alert
+            $ "Failed to initialize wallet"
+                <> BL.pack (show err)
+    WalletVanished e -> alert $ "Wallet vanished " <> BL.pack (show e)
+    WalletInitializing -> alert "Wallet is initializing"

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -1,0 +1,68 @@
+module Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
+where
+
+import Prelude
+
+import Cardano.Address.Derivation
+    ( xpubChainCode
+    , xpubPublicKey
+    )
+import Cardano.Wallet.Deposit.IO
+    ( WalletPublicIdentity (..)
+    )
+import Cardano.Wallet.UI.Common.API
+    ( Visible (..)
+    )
+import Cardano.Wallet.UI.Common.Html.Pages.Lib
+    ( record
+    , simpleField
+    )
+import Cardano.Wallet.UI.Common.Html.Pages.Wallet
+    ( PostWalletConfig (..)
+    , newWalletH
+    )
+import Cardano.Wallet.UI.Deposit.API
+    ( walletLink
+    , walletMnemonicLink
+    )
+import Codec.Binary.Encoding
+    ( AbstractEncoding (..)
+    , encode
+    )
+import Data.ByteString
+    ( ByteString
+    )
+import Data.Text
+    ( Text
+    )
+import Data.Text.Class
+    ( ToText (..)
+    )
+import Lucid
+    ( Html
+    , p_
+    )
+
+import qualified Data.Text.Encoding as T
+
+walletH :: Html ()
+walletH = do
+    -- sseH sseLink walletLink "wallet" ["wallet"]
+    p_
+        "You have no wallet. Pls initialize it"
+    newWalletH walletMnemonicLink $ PostWalletConfig
+        { walletDataLink = walletLink
+        , passwordVisibility = Just Hidden
+        , namePresence = False
+        }
+
+base16 :: ByteString -> Text
+base16 = T.decodeUtf8 . encode EBase16
+
+walletElementH :: WalletPublicIdentity -> Html ()
+walletElementH (WalletPublicIdentity xpub customers) = do
+    record $ do
+        simpleField "XPub" $ record $ do
+            simpleField "public key" $ base16 $ xpubPublicKey xpub
+            simpleField "other" $ base16 $ xpubChainCode xpub
+        simpleField "Known customers" $ toText customers

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -39,7 +39,7 @@ import Data.Text.Class
     ( ToText (..)
     )
 import Lucid
-    ( Html
+    ( HtmlT
     )
 
 import qualified Data.Text.Encoding as T
@@ -61,7 +61,7 @@ walletH walletPresent = do
 base16 :: ByteString -> Text
 base16 = T.decodeUtf8 . encode EBase16
 
-walletElementH :: WalletPublicIdentity -> Html ()
+walletElementH :: WalletPublicIdentity -> Monad m => HtmlT m ()
 walletElementH (WalletPublicIdentity xpub customers) = do
     record $ do
         simpleField "XPub" $ record $ do

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -40,21 +40,23 @@ import Data.Text.Class
     )
 import Lucid
     ( Html
-    , p_
     )
 
 import qualified Data.Text.Encoding as T
 
-walletH :: Html ()
-walletH = do
+data WalletPresent = WalletPresent WalletPublicIdentity | WalletAbsent
+
+walletH :: WalletPresent -> Html ()
+walletH walletPresent = do
     -- sseH sseLink walletLink "wallet" ["wallet"]
-    p_
-        "You have no wallet. Pls initialize it"
-    newWalletH walletMnemonicLink $ PostWalletConfig
-        { walletDataLink = walletLink
-        , passwordVisibility = Just Hidden
-        , namePresence = False
-        }
+    case walletPresent of
+        WalletPresent wallet -> walletElementH wallet
+        WalletAbsent ->
+            newWalletH walletMnemonicLink $ PostWalletConfig
+                { walletDataLink = walletLink
+                , passwordVisibility = Just Hidden
+                , namePresence = False
+                }
 
 base16 :: ByteString -> Text
 base16 = T.decodeUtf8 . encode EBase16

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -6,7 +6,8 @@ where
 import Prelude
 
 import Cardano.Address.Derivation
-    ( xpubToBytes
+    ( XPub
+    , xpubToBytes
     )
 import Cardano.Wallet.Deposit.IO
     ( WalletPublicIdentity (..)
@@ -18,7 +19,8 @@ import Cardano.Wallet.UI.Common.API
     ( Visible (..)
     )
 import Cardano.Wallet.UI.Common.Html.Pages.Lib
-    ( record
+    ( copyButton
+    , record
     , simpleField
     )
 import Cardano.Wallet.UI.Common.Html.Pages.Wallet
@@ -50,10 +52,13 @@ import Data.Text.Class
 import Lucid
     ( HtmlT
     , ToHtml (..)
+    , class_
     , div_
+    , hidden_
     , id_
     )
 
+import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy.Char8 as BL
 
 data WalletPresent
@@ -99,8 +104,20 @@ walletH alert walletPresent = do
 base64 :: ByteString -> ByteString
 base64 = convertToBase Base64
 
+pubKeyH :: Monad m => XPub -> HtmlT m ()
+pubKeyH xpub = div_ [class_ "row"]   $ do
+    div_ [id_ "public_key", hidden_ "false"] $ toHtml xpubByteString
+    div_ [class_ "col-6"] $ toHtml $ headAndTail 4 $ B8.dropEnd 2 xpubByteString
+    div_ [class_ "col-6"]
+        $ copyButton "public_key"
+
+    where xpubByteString = base64 $ xpubToBytes xpub
+
+headAndTail :: Int -> ByteString -> ByteString
+headAndTail n t = B8.take n t <> ".." <> B8.takeEnd n t
+
 walletElementH :: Monad m => WalletPublicIdentity -> HtmlT m ()
 walletElementH (WalletPublicIdentity xpub customers) = do
     record $ do
-        simpleField "Public Key" $ toHtml $ base64 $ xpubToBytes xpub
+        simpleField "Public Key" $ pubKeyH xpub
         simpleField "Customer Discovery" $ toHtml $ toText customers

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -65,7 +65,9 @@ import Lucid
     , class_
     , div_
     , hidden_
+    , hr_
     , id_
+    , section_
     )
 
 import qualified Data.ByteString.Char8 as B8
@@ -110,13 +112,16 @@ walletElementH alert = \case
             simpleField "Public Key" $ pubKeyH xpub
             simpleField "Customer Discovery" $ toHtml $ toText customers
     WalletAbsent -> runWHtml Deposit $ do
-        newWalletFromMnemonicH walletMnemonicLink
+        section_
+            $ newWalletFromMnemonicH walletMnemonicLink
             $ PostWalletConfig
                 { walletDataLink = walletPostMnemonicLink
                 , passwordVisibility = Just Hidden
                 , responseTarget = "#post-response"
                 }
-        newWalletFromXPubH
+        hr_ mempty
+        section_
+            $ newWalletFromXPubH
             $ PostWalletConfig
                 { walletDataLink = walletPostXPubLink
                 , passwordVisibility = Just Hidden

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RankNTypes #-}
 module Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
 where
 
@@ -25,6 +26,9 @@ import Cardano.Wallet.UI.Deposit.API
     ( walletLink
     , walletMnemonicLink
     )
+import Cardano.Wallet.UI.Type
+    ( WHtml
+    )
 import Codec.Binary.Encoding
     ( AbstractEncoding (..)
     , encode
@@ -46,7 +50,7 @@ import qualified Data.Text.Encoding as T
 
 data WalletPresent = WalletPresent WalletPublicIdentity | WalletAbsent
 
-walletH :: WalletPresent -> Html ()
+walletH :: WalletPresent -> WHtml ()
 walletH walletPresent = do
     -- sseH sseLink walletLink "wallet" ["wallet"]
     case walletPresent of
@@ -55,7 +59,6 @@ walletH walletPresent = do
             newWalletH walletMnemonicLink $ PostWalletConfig
                 { walletDataLink = walletLink
                 , passwordVisibility = Just Hidden
-                , namePresence = False
                 }
 
 base16 :: ByteString -> Text

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -1,15 +1,18 @@
 {-# LANGUAGE RankNTypes #-}
+
 module Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
 where
 
 import Prelude
 
 import Cardano.Address.Derivation
-    ( xpubChainCode
-    , xpubPublicKey
+    ( xpubToBytes
     )
 import Cardano.Wallet.Deposit.IO
     ( WalletPublicIdentity (..)
+    )
+import Cardano.Wallet.Deposit.REST
+    ( ErrDatabase
     )
 import Cardano.Wallet.UI.Common.API
     ( Visible (..)
@@ -17,57 +20,87 @@ import Cardano.Wallet.UI.Common.API
 import Cardano.Wallet.UI.Common.Html.Pages.Lib
     ( record
     , simpleField
+    
     )
 import Cardano.Wallet.UI.Common.Html.Pages.Wallet
     ( PostWalletConfig (..)
-    , newWalletH
+    , newWalletFromMnemonicH
+    , newWalletFromXPubH
     )
 import Cardano.Wallet.UI.Deposit.API
-    ( walletLink
-    , walletMnemonicLink
+    ( walletMnemonicLink
+    , walletPostMnemonicLink
+    , walletPostXPubLink
     )
 import Cardano.Wallet.UI.Type
     ( WHtml
     )
-import Codec.Binary.Encoding
-    ( AbstractEncoding (..)
-    , encode
+import Control.Exception
+    ( SomeException
+    )
+import Data.ByteArray.Encoding
+    ( Base (..)
+    , convertToBase
     )
 import Data.ByteString
     ( ByteString
-    )
-import Data.Text
-    ( Text
     )
 import Data.Text.Class
     ( ToText (..)
     )
 import Lucid
     ( HtmlT
+    , div_
+    , id_
     )
 
-import qualified Data.Text.Encoding as T
+import qualified Data.ByteString.Lazy.Char8 as BL
 
-data WalletPresent = WalletPresent WalletPublicIdentity | WalletAbsent
+data WalletPresent
+    = WalletPresent WalletPublicIdentity
+    | WalletAbsent
+    | WalletFailedToInitialize ErrDatabase
+    | WalletVanished SomeException
+    | WalletInitializing
 
-walletH :: WalletPresent -> WHtml ()
-walletH walletPresent = do
+instance Show WalletPresent where
+    show (WalletPresent x) = "WalletPresent: " <> show x
+    show WalletAbsent = "WalletAbsent"
+    show (WalletFailedToInitialize _) = "WalletFailedToInitialize"
+    show (WalletVanished _) = "WalletVanished"
+    show WalletInitializing = "WalletInitializing"
+
+walletH :: (BL.ByteString -> WHtml ()) -> WalletPresent -> WHtml ()
+walletH alert walletPresent = do
     -- sseH sseLink walletLink "wallet" ["wallet"]
     case walletPresent of
         WalletPresent wallet -> walletElementH wallet
-        WalletAbsent ->
-            newWalletH walletMnemonicLink $ PostWalletConfig
-                { walletDataLink = walletLink
-                , passwordVisibility = Just Hidden
-                }
+        WalletAbsent -> do
+            newWalletFromMnemonicH walletMnemonicLink
+                $ PostWalletConfig
+                    { walletDataLink = walletPostMnemonicLink
+                    , passwordVisibility = Just Hidden
+                    , responseTarget = "#post-response"
+                    }
+            newWalletFromXPubH
+                $ PostWalletConfig
+                    { walletDataLink = walletPostXPubLink
+                    , passwordVisibility = Just Hidden
+                    , responseTarget = "#post-response"
+                    }
+            div_ [id_ "post-response"] mempty
+        WalletFailedToInitialize err ->
+            alert
+                $ "Failed to initialize wallet"
+                    <> BL.pack (show err)
+        WalletVanished e -> alert $ "Wallet vanished " <> BL.pack (show e)
+        WalletInitializing -> alert "Wallet is initializing"
 
-base16 :: ByteString -> Text
-base16 = T.decodeUtf8 . encode EBase16
+base64 :: ByteString -> ByteString
+base64 = convertToBase Base64
 
 walletElementH :: WalletPublicIdentity -> Monad m => HtmlT m ()
 walletElementH (WalletPublicIdentity xpub customers) = do
     record $ do
-        simpleField "XPub" $ record $ do
-            simpleField "public key" $ base16 $ xpubPublicKey xpub
-            simpleField "other" $ base16 $ xpubChainCode xpub
-        simpleField "Known customers" $ toText customers
+        simpleField "Public Key" $ base64 $ xpubToBytes xpub
+        simpleField "Customer Discovery" $ toText customers

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
 where
@@ -20,7 +20,6 @@ import Cardano.Wallet.UI.Common.API
 import Cardano.Wallet.UI.Common.Html.Pages.Lib
     ( record
     , simpleField
-    
     )
 import Cardano.Wallet.UI.Common.Html.Pages.Wallet
     ( PostWalletConfig (..)
@@ -50,6 +49,7 @@ import Data.Text.Class
     )
 import Lucid
     ( HtmlT
+    , ToHtml (..)
     , div_
     , id_
     )
@@ -99,8 +99,8 @@ walletH alert walletPresent = do
 base64 :: ByteString -> ByteString
 base64 = convertToBase Base64
 
-walletElementH :: WalletPublicIdentity -> Monad m => HtmlT m ()
+walletElementH :: Monad m => WalletPublicIdentity -> HtmlT m ()
 walletElementH (WalletPublicIdentity xpub customers) = do
     record $ do
-        simpleField "Public Key" $ base64 $ xpubToBytes xpub
-        simpleField "Customer Discovery" $ toText customers
+        simpleField "Public Key" $ toHtml $ base64 $ xpubToBytes xpub
+        simpleField "Customer Discovery" $ toHtml $ toText customers

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
 where
@@ -51,6 +52,9 @@ import Data.ByteArray.Encoding
 import Data.ByteString
     ( ByteString
     )
+import Data.Text
+    ( Text
+    )
 import Data.Text.Class
     ( ToText (..)
     )
@@ -64,9 +68,6 @@ import Lucid
     , id_
     )
 
-import Cardano.Wallet.UI.Shelley.API
-    ( sseLink
-    )
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy.Char8 as BL
 
@@ -85,7 +86,7 @@ instance Show WalletPresent where
     show WalletInitializing = "WalletInitializing"
 
 walletH :: WHtml ()
-walletH = sseH sseLink walletLink "wallet" ["wallet"]
+walletH = sseH walletLink "wallet" ["wallet"]
 
 base64 :: ByteString -> ByteString
 base64 = convertToBase Base64
@@ -108,14 +109,6 @@ walletElementH alert = \case
         record $ do
             simpleField "Public Key" $ pubKeyH xpub
             simpleField "Customer Discovery" $ toHtml $ toText customers
-        -- div_ [class_ "row"] $ do
-            -- button_
-            --     [ class_ "btn btn-danger"
-            --     , hxDelete_ $ linkText walletDeleteLink
-            --     , hxTarget_ "#delete-result"
-            --     ]
-            --     "Delete Wallet"
-            -- div_ [id_ "delete-result"] mempty
     WalletAbsent -> runWHtml Deposit $ do
         newWalletFromMnemonicH walletMnemonicLink
             $ PostWalletConfig
@@ -136,3 +129,24 @@ walletElementH alert = \case
                 <> BL.pack (show err)
     WalletVanished e -> alert $ "Wallet vanished " <> BL.pack (show e)
     WalletInitializing -> alert "Wallet is initializing"
+
+data BadgeStyle
+    = Primary
+    | Secondary
+    | Success
+    | Danger
+    | Warning
+    | Info
+    | Light
+    | Dark
+
+renderBadgeStyle :: BadgeStyle -> Text
+renderBadgeStyle = \case
+    Primary -> "primary"
+    Secondary -> "secondary"
+    Success -> "success"
+    Danger -> "danger"
+    Warning -> "warning"
+    Info -> "info"
+    Light -> "light"
+    Dark -> "dark"

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Server.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Server.hs
@@ -153,11 +153,11 @@ serveUI tr ul env dbDir config _ nl bs =
         :<|> withSessionLayerRead ul (sse . sseConfig)
         :<|> serveFavicon
         :<|> (\c -> sessioning $ renderHtml . mnemonicH <$> liftIO (pickMnemonic 15 c))
-        :<|> wsl (\l -> getWallet l alert (renderHtml . walletElementH))
+        :<|> wsl (\l -> getWallet l (renderHtml . walletElementH alertH))
         :<|> (\v -> wsl (\l -> postMnemonicWallet l initWallet alert ok v))
         :<|> (\v -> wsl (\l -> postXPubWallet l initWallet alert ok v))
   where
-    ph p = pageHandler tr ul env dbDir config p alertH
+    ph = pageHandler tr ul env dbDir config
     ok _ = renderHtml . rogerH @Text $ "ok"
     alert = renderHtml . alertH
     nid = networkIdVal (sNetworkId @n)

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Server.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Server.hs
@@ -172,7 +172,7 @@ serveUI tr ul env dbDir config _ nl bs =
         NodeSource{} -> Node
     _ = networkInfoH
     wsl f = withSessionLayer ul $ \l -> f l
-    initWallet l xpub = initXPubWallet env dbDir trs xpub 500000
+    initWallet l = initXPubWallet tr env dbDir trs
       where
         trs :: Tracer IO (ResourceStatus ErrDatabase WalletInstance)
         trs = Tracer $ \_e -> do

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/API.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/API.hs
@@ -21,7 +21,6 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.UI.Common.API
     ( Image
     , SessionedHtml
-    , Visible
     , type (|>)
     , type (|>>)
     )
@@ -66,11 +65,6 @@ type Data =
             :> "mnemonic"
             :> QueryParam "clean" Bool
             :> SessionedHtml Get
-        :<|> "wallet"
-            :> "post"
-            :> "form"
-            :> QueryParam "visible" Visible
-            :> SessionedHtml Get
         :<|> "wallets" :> "list" :> SessionedHtml Get
         :<|> "wallet" :> SessionedHtml Get
         :<|> "wallet" :> "addresses" :> SessionedHtml Get
@@ -104,7 +98,6 @@ settingsPageLink :: Link
 networkInfoLink :: Link
 walletPostLink :: Link
 walletMnemonicLink :: Maybe Bool -> Link
-walletPostFormLink :: Maybe Visible -> Link
 walletsListLink :: Link
 walletLink :: Link
 walletAddressesLink :: Link
@@ -125,7 +118,6 @@ homePageLink
     :<|> networkInfoLink
     :<|> walletPostLink
     :<|> walletMnemonicLink
-    :<|> walletPostFormLink
     :<|> walletsListLink
     :<|> walletLink
     :<|> walletAddressesLink

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/About.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/About.hs
@@ -1,11 +1,13 @@
 module Cardano.Wallet.UI.Shelley.Html.Pages.About where
 
+import Prelude
+
 import Lucid
-    ( Html
+    ( HtmlT
     , p_
     )
 
-aboutH :: Html ()
+aboutH :: Monad m => HtmlT m ()
 aboutH = do
     p_
         "This is the new builtin Cardano Wallet web UI, pre-alpha version"

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Addresses.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Addresses.hs
@@ -48,7 +48,7 @@ import Data.Text.Class
     ( ToText (..)
     )
 import Lucid
-    ( Html
+    ( HtmlT
     , ToHtml (toHtml)
     , class_
     , div_
@@ -57,11 +57,15 @@ import Lucid
     , ul_
     )
 
-addressesPageH :: Html ()
+addressesPageH :: Monad m => HtmlT m ()
 addressesPageH =
     sseH sseLink walletAddressesLink "addresses" ["wallet"]
 
-addressesH :: forall n. HasSNetworkId n => [ApiAddressWithPath n] -> Html ()
+addressesH
+    :: forall n m
+     . (HasSNetworkId n, Monad m)
+    => [ApiAddressWithPath n]
+    -> HtmlT m ()
 addressesH addresses = record $ do
     forM_ (zip [0 :: Int ..] addresses) $ \(j, ApiAddressWithPath{..}) -> do
         fieldHtml [] "id" $ do
@@ -80,5 +84,10 @@ addressesH addresses = record $ do
                 . toText
                 . getApiT
 
-addressH :: forall n. HasSNetworkId n => Proxy n -> Address -> Html ()
+addressH
+    :: forall n m
+     . (HasSNetworkId n, Monad m)
+    => Proxy n
+    -> Address
+    -> HtmlT m ()
 addressH _ a = toHtml $ encodeAddress (sNetworkId @n) a

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Addresses.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Addresses.hs
@@ -35,8 +35,7 @@ import Cardano.Wallet.UI.Common.Html.Pages.Lib
     , sseH
     )
 import Cardano.Wallet.UI.Shelley.API
-    ( sseLink
-    , walletAddressesLink
+    ( walletAddressesLink
     )
 import Control.Monad
     ( forM_
@@ -59,7 +58,7 @@ import Lucid
 
 addressesPageH :: Monad m => HtmlT m ()
 addressesPageH =
-    sseH sseLink walletAddressesLink "addresses" ["wallet"]
+    sseH walletAddressesLink "addresses" ["wallet"]
 
 addressesH
     :: forall n m

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Addresses.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Addresses.hs
@@ -72,10 +72,11 @@ addressesH addresses = record $ do
             let identifier = "address-" <> toText j
             div_ [class_ "row"] $ do
                 div_ [class_ "text-break col-sm-10", id_ identifier]
+                    $ toHtml
                     $ addressH (Proxy @n)
                     $ apiAddress id
-                div_ [class_ "col-sm-2"] $ copyButton identifier
-        simpleField "state" $ toText $ getApiT state
+                div_ [class_ "col-sm-2"] $ toHtml $ copyButton identifier
+        simpleField "state" $ toHtml $ toText $ getApiT state
         fieldHtml [] "derivation path"
             $ ul_ [class_ "list-inline"]
             $ forM_ derivationPath

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Page.hs
@@ -95,14 +95,14 @@ page c@PageConfig{..} p wp = RawHtml
     $ renderBS
     $ runWHtml Shelley
     $ pageFromBodyH faviconLink c
-    $ bodyH (headerH prefix p)
+    $ bodyH sseLink (headerH prefix p)
     $ case p of
         About -> aboutH
-        Network -> networkH sseLink networkInfoLink
+        Network -> networkH networkInfoLink
         Wallets -> walletsH
         Wallet -> walletH wp
         Addresses -> addressesPageH
-        Settings -> settingsPageH sseLink settingsGetLink
+        Settings -> settingsPageH settingsGetLink
 
 headerH :: Monad m => Text -> Page -> HtmlT m ()
 headerH prefix p =

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Page.hs
@@ -65,7 +65,7 @@ import Data.Text
     ( Text
     )
 import Lucid
-    ( Html
+    ( HtmlT
     , renderBS
     )
 
@@ -99,7 +99,7 @@ page c@PageConfig{..} p wp = RawHtml
         Addresses -> addressesPageH
         Settings -> settingsPageH sseLink settingsGetLink
 
-headerH :: Text -> Page -> Html ()
+headerH :: Monad m => Text -> Page -> HtmlT m ()
 headerH prefix p =
     navigationH
         prefix

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Page.hs
@@ -55,6 +55,10 @@ import Cardano.Wallet.UI.Shelley.Html.Pages.Wallet
 import Cardano.Wallet.UI.Shelley.Html.Pages.Wallets
     ( walletsH
     )
+import Cardano.Wallet.UI.Type
+    ( WalletType (..)
+    , runWHtml
+    )
 import Control.Lens.Extras
     ( is
     )
@@ -89,6 +93,7 @@ page
     -> RawHtml
 page c@PageConfig{..} p wp = RawHtml
     $ renderBS
+    $ runWHtml Shelley
     $ pageFromBodyH faviconLink c
     $ bodyH (headerH prefix p)
     $ case p of

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Wallet.hs
@@ -38,7 +38,9 @@ import Cardano.Wallet.UI.Common.Html.Htmx
 import Cardano.Wallet.UI.Common.Html.Lib
     ( ShowTime
     , linkText
+    , showHtml
     , showPercentage
+    , toTextHtml
     )
 import Cardano.Wallet.UI.Common.Html.Pages.Lib
     ( fieldHtml
@@ -61,9 +63,6 @@ import Control.Monad
 import Data.Quantity
     ( Quantity (..)
     )
-import Data.Text
-    ( Text
-    )
 import Data.Text.Class
     ( ToText (..)
     )
@@ -82,74 +81,83 @@ import qualified Data.Percentage as Percentage
 
 data WalletPresent = WalletPresent | WalletAbsent
 
-walletH :: Monad m => WalletPresent -> HtmlT m  ()
+walletH :: Monad m => WalletPresent -> HtmlT m ()
 walletH wp = do
     sseH sseLink walletLink "wallet" ["wallet"]
     case wp of
         WalletPresent -> walletActionsH
         WalletAbsent -> mempty
 
-walletActionsH :: Monad m => HtmlT m  ()
+walletActionsH :: Monad m => HtmlT m ()
 walletActionsH = do
     div_ [class_ "mt-3"] $ do
         button_
-                [ class_ "btn btn-danger"
-                , hxPost_ (linkText walletDeleteLink)
-                , hxTarget_ "#actions"
-                ]
-                "Forget this wallet"
+            [ class_ "btn btn-danger"
+            , hxPost_ (linkText walletDeleteLink)
+            , hxTarget_ "#actions"
+            ]
+            "Forget this wallet"
         div_
             [ id_ "actions"
             ]
             mempty
         mempty
 
-walletElementH :: Monad m => ShowTime -> ApiWallet -> HtmlT m  ()
+walletElementH :: Monad m => ShowTime -> ApiWallet -> HtmlT m ()
 walletElementH showTime ApiWallet{..} = do
     record $ do
-        simpleField "name" $ toText $ getApiT name
-        simpleField "id" $ toText $ getApiT id
-        simpleField "state" $ renderState state
-        simpleField "tip" $ blockReferenceH showTime tip
+        simpleField "name" $ toHtml $ toText $ getApiT name
+        simpleField "id" $ toHtml $ toText $ getApiT id
+        simpleField "state" $ toHtml $ renderState state
+        simpleField "tip" $ toHtml $ blockReferenceH showTime tip
         simpleField "pool gap" $ renderPoolGap addressPoolGap
         simpleField "balance" $ renderBalance balance
         simpleField "assets" $ renderAssets assets
         simpleField "delegation" $ renderDelegation delegation
         simpleField "passphrase" $ renderPassphrase showTime passphrase
 
-renderPassphrase :: Monad m => ShowTime
-    -> Maybe ApiWalletPassphraseInfo -> HtmlT m  ()
+renderPassphrase
+    :: Monad m
+    => ShowTime
+    -> Maybe ApiWalletPassphraseInfo
+    -> HtmlT m ()
 renderPassphrase _ Nothing = ""
 renderPassphrase showTime (Just ApiWalletPassphraseInfo{..}) =
     toHtml $ showTime lastUpdatedAt
 
-renderPoolGap :: Monad m => ApiT AddressPoolGap -> HtmlT m  ()
+renderPoolGap :: Monad m => ApiT AddressPoolGap -> HtmlT m ()
 renderPoolGap = toHtml . show . getAddressPoolGap . getApiT
 
-renderDelegation :: Monad m => ApiWalletDelegation -> HtmlT m  ()
+renderDelegation :: Monad m => ApiWalletDelegation -> HtmlT m ()
 renderDelegation ApiWalletDelegation{..} = record
     $ do
         simpleField "active" $ renderActive active
         fieldHtml [] "next" $ ul_ $ forM_ next $ li_ . renderActive
 
-renderActive :: Monad m => ApiWalletDelegationNext -> HtmlT m  ()
+renderActive :: Monad m => ApiWalletDelegationNext -> HtmlT m ()
 renderActive (ApiWalletDelegationNext status target voting _changesAt) =
     record $ do
         case status of
-            NotDelegating -> simpleField "not delegating" (mempty :: Text)
-            Delegating -> simpleField "delegating to" $ foldMap (show . getApiT) target
-            Voting -> simpleField "voting through" $ foldMap (show . getApiT) voting
+            NotDelegating -> simpleField "not delegating" mempty
+            Delegating ->
+                simpleField "delegating to"
+                    $ foldMap (showHtml . getApiT) target
+            Voting ->
+                simpleField "voting through"
+                    $ foldMap (showHtml . getApiT) voting
             VotingAndDelegating -> do
-                simpleField "delegating to" $ foldMap (show . getApiT) target
-                simpleField "voting through" $ foldMap (show . getApiT) voting
+                simpleField "delegating to"
+                    $ foldMap (showHtml . getApiT) target
+                simpleField "voting through"
+                    $ foldMap (showHtml . getApiT) voting
 
-renderAsset :: Monad m => ApiWalletAsset -> HtmlT m  ()
+renderAsset :: Monad m => ApiWalletAsset -> HtmlT m ()
 renderAsset ApiWalletAsset{..} = record $ do
-    simpleField "policy id" $ toText $ getApiT policyId
-    simpleField "asset name" $ toText $ getApiT assetName
+    simpleField "policy id" $ toTextHtml $ getApiT policyId
+    simpleField "asset name" $ toTextHtml $ getApiT assetName
     simpleField "quantity" $ toHtml $ showThousandDots quantity
 
-renderAssets :: Monad m => ApiWalletAssetsBalance -> HtmlT m  ()
+renderAssets :: Monad m => ApiWalletAssetsBalance -> HtmlT m ()
 renderAssets ApiWalletAssetsBalance{..} =
     record $ do
         fieldHtml [] "available"
@@ -162,7 +170,7 @@ renderAssets ApiWalletAssetsBalance{..} =
             $ forM_ (getApiWalletAssets total)
             $ li_ . renderAsset
 
-renderBalance :: Monad m => ApiWalletBalance -> HtmlT m  ()
+renderBalance :: Monad m => ApiWalletBalance -> HtmlT m ()
 renderBalance ApiWalletBalance{..} =
     record $ do
         simpleField "available" $ toHtml $ showAmount available

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Wallet.hs
@@ -68,7 +68,7 @@ import Data.Text.Class
     ( ToText (..)
     )
 import Lucid
-    ( Html
+    ( HtmlT
     , ToHtml (toHtml)
     , button_
     , class_
@@ -82,14 +82,14 @@ import qualified Data.Percentage as Percentage
 
 data WalletPresent = WalletPresent | WalletAbsent
 
-walletH :: WalletPresent -> Html ()
+walletH :: Monad m => WalletPresent -> HtmlT m  ()
 walletH wp = do
     sseH sseLink walletLink "wallet" ["wallet"]
     case wp of
         WalletPresent -> walletActionsH
         WalletAbsent -> mempty
 
-walletActionsH :: Html ()
+walletActionsH :: Monad m => HtmlT m  ()
 walletActionsH = do
     div_ [class_ "mt-3"] $ do
         button_
@@ -104,7 +104,7 @@ walletActionsH = do
             mempty
         mempty
 
-walletElementH :: ShowTime -> ApiWallet -> Html ()
+walletElementH :: Monad m => ShowTime -> ApiWallet -> HtmlT m  ()
 walletElementH showTime ApiWallet{..} = do
     record $ do
         simpleField "name" $ toText $ getApiT name
@@ -117,21 +117,22 @@ walletElementH showTime ApiWallet{..} = do
         simpleField "delegation" $ renderDelegation delegation
         simpleField "passphrase" $ renderPassphrase showTime passphrase
 
-renderPassphrase :: ShowTime -> Maybe ApiWalletPassphraseInfo -> Html ()
+renderPassphrase :: Monad m => ShowTime
+    -> Maybe ApiWalletPassphraseInfo -> HtmlT m  ()
 renderPassphrase _ Nothing = ""
 renderPassphrase showTime (Just ApiWalletPassphraseInfo{..}) =
     toHtml $ showTime lastUpdatedAt
 
-renderPoolGap :: ApiT AddressPoolGap -> Html ()
+renderPoolGap :: Monad m => ApiT AddressPoolGap -> HtmlT m  ()
 renderPoolGap = toHtml . show . getAddressPoolGap . getApiT
 
-renderDelegation :: ApiWalletDelegation -> Html ()
+renderDelegation :: Monad m => ApiWalletDelegation -> HtmlT m  ()
 renderDelegation ApiWalletDelegation{..} = record
     $ do
         simpleField "active" $ renderActive active
         fieldHtml [] "next" $ ul_ $ forM_ next $ li_ . renderActive
 
-renderActive :: ApiWalletDelegationNext -> Html ()
+renderActive :: Monad m => ApiWalletDelegationNext -> HtmlT m  ()
 renderActive (ApiWalletDelegationNext status target voting _changesAt) =
     record $ do
         case status of
@@ -142,13 +143,13 @@ renderActive (ApiWalletDelegationNext status target voting _changesAt) =
                 simpleField "delegating to" $ foldMap (show . getApiT) target
                 simpleField "voting through" $ foldMap (show . getApiT) voting
 
-renderAsset :: ApiWalletAsset -> Html ()
+renderAsset :: Monad m => ApiWalletAsset -> HtmlT m  ()
 renderAsset ApiWalletAsset{..} = record $ do
     simpleField "policy id" $ toText $ getApiT policyId
     simpleField "asset name" $ toText $ getApiT assetName
     simpleField "quantity" $ toHtml $ showThousandDots quantity
 
-renderAssets :: ApiWalletAssetsBalance -> Html ()
+renderAssets :: Monad m => ApiWalletAssetsBalance -> HtmlT m  ()
 renderAssets ApiWalletAssetsBalance{..} =
     record $ do
         fieldHtml [] "available"
@@ -161,7 +162,7 @@ renderAssets ApiWalletAssetsBalance{..} =
             $ forM_ (getApiWalletAssets total)
             $ li_ . renderAsset
 
-renderBalance :: ApiWalletBalance -> Html ()
+renderBalance :: Monad m => ApiWalletBalance -> HtmlT m  ()
 renderBalance ApiWalletBalance{..} =
     record $ do
         simpleField "available" $ toHtml $ showAmount available

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Wallet.hs
@@ -53,8 +53,7 @@ import Cardano.Wallet.UI.Common.Html.Pages.Network
     ( blockReferenceH
     )
 import Cardano.Wallet.UI.Shelley.API
-    ( sseLink
-    , walletDeleteLink
+    ( walletDeleteLink
     , walletLink
     )
 import Control.Monad
@@ -83,7 +82,7 @@ data WalletPresent = WalletPresent | WalletAbsent
 
 walletH :: Monad m => WalletPresent -> HtmlT m ()
 walletH wp = do
-    sseH sseLink walletLink "wallet" ["wallet"]
+    sseH walletLink "wallet" ["wallet"]
     case wp of
         WalletPresent -> walletActionsH
         WalletAbsent -> mempty

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Wallets.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Wallets.hs
@@ -14,6 +14,9 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.Types
     ( WalletId
     )
+import Cardano.Wallet.UI.Common.API
+    ( Visible (..)
+    )
 import Cardano.Wallet.UI.Common.Html.Htmx
     ( hxPost_
     , hxSwap_
@@ -29,19 +32,22 @@ import Cardano.Wallet.UI.Common.Html.Pages.Lib
     , simpleField
     , sseH
     )
+import Cardano.Wallet.UI.Common.Html.Pages.Wallet
+    ( PostWalletConfig (..)
+    , newWalletH
+    )
 import Cardano.Wallet.UI.Lib.ListOf
     ( ListOf
     )
 import Cardano.Wallet.UI.Shelley.API
     ( settingsWalletSelectLink
     , sseLink
+    , walletLink
+    , walletMnemonicLink
     , walletsListLink
     )
 import Cardano.Wallet.UI.Shelley.Html.Pages.Wallet
     ( renderState
-    )
-import Cardano.Wallet.UI.Shelley.Html.Pages.Wallets.NewWallet
-    ( newWalletH
     )
 import Control.Monad
     ( forM_
@@ -69,7 +75,11 @@ data Selected = Selected | NotSelected
 walletsH :: Html ()
 walletsH = do
     sseH sseLink walletsListLink "content" ["wallets"]
-    newWalletH
+    newWalletH walletMnemonicLink $ PostWalletConfig
+        { walletDataLink = walletLink
+        , passwordVisibility = Just Hidden
+        , namePresence = True
+        }
 
 walletListH :: Maybe WalletId -> [(ApiWallet, UTCTime)] -> Html ()
 walletListH mwid wallets = record

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Wallets.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Wallets.hs
@@ -34,7 +34,7 @@ import Cardano.Wallet.UI.Common.Html.Pages.Lib
     )
 import Cardano.Wallet.UI.Common.Html.Pages.Wallet
     ( PostWalletConfig (..)
-    , newWalletH
+    , newWalletFromMnemonicH
     )
 import Cardano.Wallet.UI.Lib.ListOf
     ( ListOf
@@ -69,7 +69,9 @@ import Lucid
     , Html
     , ToHtml (..)
     , class_
+    , div_
     , i_
+    , id_
     , scope_
     )
 
@@ -77,11 +79,13 @@ data Selected = Selected | NotSelected
 
 walletsH :: WHtml ()
 walletsH = do
-    sseH sseLink walletsListLink "content" ["wallets"]
-    newWalletH walletMnemonicLink $ PostWalletConfig
+    -- sseH sseLink walletsListLink "content" ["wallets"]
+    newWalletFromMnemonicH walletMnemonicLink $ PostWalletConfig
         { walletDataLink = walletLink
         , passwordVisibility = Just Hidden
+        , responseTarget = "#post-response"
         }
+    div_ [ id_ "#post-response" ] mempty
 
 walletListH :: Maybe WalletId -> [(ApiWallet, UTCTime)] -> Html ()
 walletListH mwid wallets = record

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Wallets.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Wallets.hs
@@ -49,6 +49,9 @@ import Cardano.Wallet.UI.Shelley.API
 import Cardano.Wallet.UI.Shelley.Html.Pages.Wallet
     ( renderState
     )
+import Cardano.Wallet.UI.Type
+    ( WHtml
+    )
 import Control.Monad
     ( forM_
     )
@@ -72,13 +75,12 @@ import Lucid
 
 data Selected = Selected | NotSelected
 
-walletsH :: Html ()
+walletsH :: WHtml ()
 walletsH = do
     sseH sseLink walletsListLink "content" ["wallets"]
     newWalletH walletMnemonicLink $ PostWalletConfig
         { walletDataLink = walletLink
         , passwordVisibility = Just Hidden
-        , namePresence = True
         }
 
 walletListH :: Maybe WalletId -> [(ApiWallet, UTCTime)] -> Html ()

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Server.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Server.hs
@@ -94,8 +94,6 @@ import Cardano.Wallet.UI.Cookies
     ( CookieResponse
     , RequestCookies
     , sessioning
-    , withSession
-    , withSessionRead
     )
 import Cardano.Wallet.UI.Shelley.API
     ( UI

--- a/lib/ui/src/Cardano/Wallet/UI/Type.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Type.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Cardano.Wallet.UI.Type
+where
+
+import Prelude
+
+import Control.Monad.Morph
+    ( MFunctor (..)
+    )
+import Control.Monad.Reader
+    ( MonadReader (..)
+    , Reader
+    , runReader
+    )
+import Data.Functor.Identity
+    ( Identity (..)
+    )
+import Lucid
+    ( Html
+    , HtmlT
+    )
+
+data WalletType = Deposit | Shelley
+
+type WHtml a = HtmlT (Reader WalletType) a
+
+runWHtml :: WalletType -> WHtml a -> Html a
+runWHtml t = hoist (Identity . (`runReader` t))
+
+onDeposit :: WHtml () -> WHtml ()
+onDeposit h = do
+    t <- ask
+    case t of
+        Deposit -> h
+        Shelley -> pure ()
+
+onShelley :: WHtml () -> WHtml ()
+onShelley h = do
+    t <- ask
+    case t of
+        Deposit -> pure ()
+        Shelley -> h

--- a/run/common/nix/run-node.sh
+++ b/run/common/nix/run-node.sh
@@ -1,0 +1,49 @@
+#! /usr/bin/env -S nix shell '.#cardano-node' --command bash
+# shellcheck shell=bash
+
+# set -euox pipefail
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source .env
+
+mkdir -p ./databases
+
+# Define a local db if NODE_DB is not set
+if [[ -z "${NODE_DB-}" ]]; then
+    LOCAL_NODE_DB=./databases/node-db
+    mkdir -p $LOCAL_NODE_DB
+    NODE_DB=$LOCAL_NODE_DB
+    export NODE_DB
+fi
+
+NETWORK=${NETWORK:=testnet}
+
+# Define and export the node socket name
+NODE_SOCKET_NAME=node.socket
+
+# Define and export the local and actual directory for the node socket
+LOCAL_NODE_SOCKET_DIR=./databases
+NODE_SOCKET_DIR=${NODE_SOCKET_DIR:=$LOCAL_NODE_SOCKET_DIR}
+
+NODE_SOCKET_PATH=${NODE_SOCKET_DIR}/${NODE_SOCKET_NAME}
+
+# Define and export the local and actual configs directory for the node
+LOCAL_NODE_CONFIGS=./configs
+NODE_CONFIGS=${NODE_CONFIGS:=$LOCAL_NODE_CONFIGS}
+
+
+# Define the node logs file
+LOCAL_NODE_LOGS_FILE=./node.log
+NODE_LOGS_FILE="${NODE_LOGS_FILE:=$LOCAL_NODE_LOGS_FILE}"
+
+echo "Node socket path: $NODE_SOCKET_PATH"
+
+# Start the node with logs redirected to a file if NODE_LOGS_FILE is set
+# shellcheck disable=SC2086
+cardano-node run \
+    --topology "${NODE_CONFIGS}"/topology.json \
+    --database-path "${NODE_DB}"\
+    --socket-path "${NODE_SOCKET_PATH}" \
+    --config "${NODE_CONFIGS}"/config.json \
+    +RTS -N -A16m -qg -qb -RTS

--- a/run/common/nix/run-wallet.sh
+++ b/run/common/nix/run-wallet.sh
@@ -1,0 +1,68 @@
+#! /usr/bin/env bash
+# set -euox pipefail
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source .env
+
+mkdir -p ./databases
+
+# Define a local db if WALLET_DB is not set
+if [[ -z "${WALLET_DB-}" ]]; then
+    LOCAL_WALLET_DB=./databases/wallet-db
+    mkdir -p $LOCAL_WALLET_DB
+    WALLET_DB=$LOCAL_WALLET_DB
+    export WALLET_DB
+fi
+
+if [[ -n "${CLEANUP_DB-}" ]]; then
+    rm -rf "${WALLET_DB:?}"/*
+fi
+
+NETWORK=${NETWORK:=testnet}
+
+# Define and export the node socket name
+NODE_SOCKET_NAME=node.socket
+
+# Define and export the local and actual directory for the node socket
+LOCAL_NODE_SOCKET_DIR=./databases
+NODE_SOCKET_DIR=${NODE_SOCKET_DIR:=$LOCAL_NODE_SOCKET_DIR}
+
+NODE_SOCKET_PATH=${NODE_SOCKET_DIR}/${NODE_SOCKET_NAME}
+
+# Define and export the local and actual configs directory for the node
+LOCAL_NODE_CONFIGS=./configs
+NODE_CONFIGS=${NODE_CONFIGS:=$LOCAL_NODE_CONFIGS}
+
+
+# Generate a random port for the wallet service and export it
+RANDOM_PORT=$(shuf -i 2000-65000 -n 1)
+WALLET_PORT=${WALLET_PORT:=$RANDOM_PORT}
+
+RANDOM_PORT=$(shuf -i 2000-65000 -n 1)
+WALLET_UI_PORT=${WALLET_UI_PORT:=$RANDOM_PORT}
+
+RANDOM_PORT=$(shuf -i 2000-65000 -n 1)
+DEPOSIT_WALLET_UI_PORT=${DEPOSIT_WALLET_UI_PORT:=$RANDOM_PORT}
+# Define the wallet logs file
+LOCAL_WALLET_LOGS_FILE=./wallet.log
+WALLET_LOGS_FILE="${WALLET_LOGS_FILE:=$LOCAL_WALLET_LOGS_FILE}"
+
+echo "Wallet service port: $WALLET_PORT"
+echo "Wallet UI port: $WALLET_UI_PORT"
+echo "Deposit wallet UI port: $DEPOSIT_WALLET_UI_PORT"
+
+# shellcheck disable=SC2086
+cabal run --project-dir ../../.. -O0 cardano-wallet-exe:exe:cardano-wallet -- \
+    serve \
+    --log-level DEBUG \
+    --trace-application DEBUG \
+    --port "${WALLET_PORT}" \
+    --ui-port "${WALLET_UI_PORT}" \
+    --ui-deposit-port "${DEPOSIT_WALLET_UI_PORT}" \
+    --database "${WALLET_DB}" \
+    --node-socket "${NODE_SOCKET_PATH}" \
+    --testnet "${NODE_CONFIGS}"/byron-genesis.json \
+    --listen-address 0.0.0.0 \
+    +RTS -N -A16m -qg -qb -RTS
+    

--- a/run/common/nix/run.sh
+++ b/run/common/nix/run.sh
@@ -3,7 +3,7 @@
 
 # set -euox pipefail
 set -euo pipefail
-
+cardano-wallet serve --help-tracing
 usage() {
     echo "Usage: $0 [sync]"
     echo "  sync: Sync the service and wait for it to be ready"
@@ -72,6 +72,7 @@ cleanup() {
         rm -rf "${NODE_DB:?}"/* || echo "Failed to clean node db"
         rm -rf "${WALLET_DB:?}"/* || echo "Failed to clean wallet db"
     fi
+    trap - ERR INT EXIT
 }
 
 # Trap the cleanup function on exit

--- a/run/preprod/nix/run-node.sh
+++ b/run/preprod/nix/run-node.sh
@@ -1,0 +1,1 @@
+../../common/nix/run-node.sh

--- a/run/preprod/nix/run-wallet.sh
+++ b/run/preprod/nix/run-wallet.sh
@@ -1,0 +1,1 @@
+../../common/nix/run-wallet.sh


### PR DESCRIPTION
- Collect wallet page common code from the shelley wallet UI
- Add a wallet page that based on wallet presence on disk alternatively shows 
   - The public key of the wallet and the customer discovery limit , if the wallet is on disk
   - 2 forms to create a wallet , if the wallet is not present on disk
      - Both forms are creating a non-signing wallet ATM, so the mnemonics based one is not production ready 
- A simplified runner for the nix env that runs the node and the wallet separately (useful for fast starting the wallet)
- Workaround an issue during linking in cross-compiling windows executable. ATM , for the windows platform, database persistence is not implementable using sqlite-simple as it conflicts during linking with persistent-sqlite

Notes:

This is the cross compilation error before the sqlite-simple in the last commit:
```
Listening on port 8315
GHCruntimelinker:fatalerror:Ifoundaduplicatedefinitionforsymbol
sqlite3_mutex_free
whilstprocessingobjectfile
/nix/store/2iaahkxqa564k36zsbvvjrl1d1v7xia3-direct-sqlite-lib-direct-sqlite-x
86_64-w64-mingw32-2.3.29/lib/x86_64-windows-ghc-9.6.6/direct-sqlite-2.3.29-4sYgk
dKULbzEbITAE5vtqr/HSdirect-sqlite-2.3.29-4sYgkdKULbzEbITAE5vtqr.o
Thesymbolwaspreviouslydefinedin
/nix/store/g208baq5d45dpdcg8zldj964wpi2ddh8-persistent-sqlite-lib-persistent-
sqlite-x86_64-w64-mingw32-2.13.3.0/lib/x86_64-windows-ghc-9.6.6/persistent-sqlit
e-2.13.3.0-2cYeK5mKue8gWmhy84urS/HSpersistent-sqlite-2.13.3.0-2cYeK5mKue8gWmhy84
urS.o
Thiscouldbecausedby:
*Loadingtwodifferentobjectfileswhichexportthesamesymbol
*SpecifyingthesameobjectfiletwiceontheGHCicommandline
*Anincorrect`package.conf'entry,causingsomeobjecttobe
loadedtwice.
iserv-proxy-interpreter.exe:munmapForLinker:m32_release_page:Failedtounmap 
503808bytesat0000000059448000:Invalidaddress.
iserv-proxy-interpreter.exe:munmapForLinker:m32_release_page:Failedtounmap 
4096bytesat00000000546f1000:Invalidaddress.
iserv-proxy-interpreter.exe:munmapForLinker:m32_release_page:Failedtounmap 
4096bytesat00000000546f2000:Invalidaddress.
iserv-proxy-interpreter.exe:loadObj"/nix/store/2iaahkxqa564k36zsbvvjrl1d1v7xia
3-direct-sqlite-lib-direct-sqlite-x86_64-w64-mingw32-2.3.29/lib/x86_64-windows-g
hc-9.6.6/direct-sqlite-2.3.29-4sYgkdKULbzEbITAE5vtqr/HSdirect-sqlite-2.3.29-4sYg
kdKULbzEbITAE5vtqr.o":failed
iserv-proxy: <socket: 10>: hGetBufSome: resource vanished (Connection reset by peer)
```

ADP-3432