### PR TITLE
[ADP-3344] Use `Read.ChainPoint` in `Cardano.Wallet.Deposit.Read`

### DIFF
--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -156,6 +156,7 @@ test-suite unit
     , base
     , bytestring
     , cardano-crypto
+    , cardano-wallet-read
     , cardano-wallet-test-utils
     , customer-deposit-wallet
     , customer-deposit-wallet:customer-deposit-wallet-http

--- a/lib/customer-deposit-wallet/data/swagger.json
+++ b/lib/customer-deposit-wallet/data/swagger.json
@@ -15,6 +15,13 @@
                     },
                     {
                         "properties": {
+                            "header_hash": {
+                                "description": "Hash (Blake2b_256) of a block header.",
+                                "format": "hex",
+                                "maxLength": 64,
+                                "minLength": 64,
+                                "type": "string"
+                            },
                             "slot_no": {
                                 "maximum": 1.8446744073709551615e19,
                                 "minimum": 0,

--- a/lib/customer-deposit-wallet/http/Cardano/Wallet/Deposit/HTTP/Types/OpenAPI.hs
+++ b/lib/customer-deposit-wallet/http/Cardano/Wallet/Deposit/HTTP/Types/OpenAPI.hs
@@ -39,7 +39,9 @@ import Data.OpenApi
     , HasInfo (..)
     , HasItems (..)
     , HasLicense (license)
+    , HasMaxLength (..)
     , HasMaximum (..)
+    , HasMinLength (..)
     , HasMinimum (..)
     , HasName (..)
     , HasOneOf (..)
@@ -217,8 +219,9 @@ chainPointAtSlotSchema =
     mempty
         & type_ ?~ OpenApiObject
         & properties
-            .~ [ ("slot_no", Inline slotSchema)
-               ]
+            .~  [ ("slot_no", Inline slotSchema)
+                , ("header_hash", Inline headerHashSchema)
+                ]
 
 slotSchema :: Schema
 slotSchema =
@@ -226,3 +229,19 @@ slotSchema =
         & type_ ?~ OpenApiInteger
         & minimum_ ?~ 0
         & maximum_ ?~ fromIntegral (maxBound :: Word64)
+
+headerHashSchema :: Schema
+headerHashSchema =
+    blake2b_256Schema
+        & description ?~ "Hash (Blake2b_256) of a block header."
+
+blake2b_256Schema :: Schema
+blake2b_256Schema =
+    mempty
+        & type_ ?~ OpenApiString
+        & format ?~ "hex"
+        & minLength ?~ (32 * hexCharactersPerByte)
+        & maxLength ?~ (32 * hexCharactersPerByte)
+
+hexCharactersPerByte :: Integer
+hexCharactersPerByte = 2

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
@@ -96,7 +96,7 @@ genesis :: Read.ChainPoint
 genesis = Read.Origin
 
 getBlockPoint :: Read.Block -> Read.ChainPoint
-getBlockPoint = Read.At . Read.slot . Read.blockHeaderBody . Read.blockHeader
+getBlockPoint = Read.At . Read.slotNo . Read.blockHeaderBody . Read.blockHeader
 
 mkNextBlock :: Read.ChainPoint -> [Tx Conway] -> Read.Block
 mkNextBlock tipOld txs =
@@ -105,7 +105,7 @@ mkNextBlock tipOld txs =
             { Read.blockHeaderBody = Read.BHBody
                 { Read.prev = Nothing
                 , Read.blockno = toEnum $ fromEnum slotNext
-                , Read.slot = slotNext
+                , Read.slotNo = slotNext
                 , Read.bhash = ()
                 }
             , Read.blockHeaderSignature = ()

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 {-|
 Copyright: © 2024 Cardano Foundation
 License: Apache-2.0
@@ -93,10 +94,19 @@ newNetworkEnvMock = do
         }
 
 genesis :: Read.ChainPoint
-genesis = Read.Origin
+genesis = Read.GenesisPoint
 
 getBlockPoint :: Read.Block -> Read.ChainPoint
-getBlockPoint = Read.At . Read.slotNo . Read.blockHeaderBody . Read.blockHeader
+getBlockPoint block =
+    Read.BlockPoint
+        { Read.slotNo = slot
+        , Read.headerHash =
+            Read.mockRawHeaderHash
+            $ fromIntegral $ fromEnum slot
+        }
+  where
+    bhBody = Read.blockHeaderBody $ Read.blockHeader block
+    slot = Read.slotNo bhBody
 
 mkNextBlock :: Read.ChainPoint -> [Tx Conway] -> Read.Block
 mkNextBlock tipOld txs =
@@ -114,5 +124,5 @@ mkNextBlock tipOld txs =
         }
  where
     slotNext = case tipOld of
-        Read.Origin -> 1
-        Read.At n -> succ n
+        Read.GenesisPoint -> 1
+        Read.BlockPoint{slotNo = n} -> succ n

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -176,7 +176,7 @@ rollForwardUTxO isOurs block u =
     UTxOHistory.appendBlock slot deltaUTxO u
   where
     (deltaUTxO,_) = Balance.applyBlock isOurs block (UTxOHistory.getUTxO u)
-    slot = Read.slot . Read.blockHeaderBody $ Read.blockHeader block
+    slot = Read.slotNo . Read.blockHeaderBody $ Read.blockHeader block
 
 rollBackward
     :: Read.ChainPoint

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Submissions.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Submissions.hs
@@ -31,11 +31,11 @@ import qualified Data.Delta as Delta
     Types
 ------------------------------------------------------------------------------}
 type TxSubmissions
-    = Sbm.Submissions () Read.Slot (Read.TxId, Read.Tx)
+    = Sbm.Submissions () Read.SlotNo (Read.TxId, Read.Tx)
 type TxSubmissionsStatus
-    = Sbm.TxStatusMeta () Read.Slot (Read.TxId, Read.Tx)
+    = Sbm.TxStatusMeta () Read.SlotNo (Read.TxId, Read.Tx)
 type DeltaTxSubmissions1
-    = Sbm.Operation () Read.Slot (Read.TxId, Read.Tx)
+    = Sbm.Operation () Read.SlotNo (Read.TxId, Read.Tx)
 type DeltaTxSubmissions
     = [DeltaTxSubmissions1]
 
@@ -56,7 +56,7 @@ empty = Sbm.mkEmpty 0
 
 -- | Add a /new/ transaction to the local submission pool
 -- with the most recent submission slot.
-add :: Read.Tx -> Read.Slot -> DeltaTxSubmissions
+add :: Read.Tx -> Read.SlotNo -> DeltaTxSubmissions
 add = undefined
 
 listInSubmission :: TxSubmissions -> Set Read.Tx
@@ -69,5 +69,5 @@ rollForward block = [ Sbm.RollForward tip txs ]
     txids = undefined block
     txs = map (tip,) txids
 
-rollBackward :: Read.Slot -> DeltaTxSubmissions
+rollBackward :: Read.SlotNo -> DeltaTxSubmissions
 rollBackward = undefined

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/UTxOHistory.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/UTxOHistory.hs
@@ -7,25 +7,10 @@ module Cardano.Wallet.Deposit.Pure.UTxOHistory
     , getUTxO
     ) where
 
-import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
-    ( DeltaUTxO
-    )
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory
-    ( UTxOHistory
+    ( DeltaUTxOHistory (..)
+    , UTxOHistory
     , appendBlock
     , empty
     , getUTxO
     )
-import Cardano.Wallet.Deposit.Read
-    ( Slot
-    , SlotNo
-    )
-
--- | Changes to the UTxO history.
-data DeltaUTxOHistory
-    = -- | New slot tip, changes within that block.
-      AppendBlock SlotNo DeltaUTxO
-    | -- | Rollback tip.
-      Rollback Slot
-    | -- | Move finality forward.
-      Prune SlotNo

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -7,7 +7,6 @@
 -- TODO: Match this up with the @Read@ hierarchy.
 module Cardano.Wallet.Deposit.Read
     ( Network (..)
-    , Slot
     , Read.SlotNo
     , toSlot
     , fromSlot
@@ -79,18 +78,9 @@ import qualified Data.ByteString.Short as SBS
 ------------------------------------------------------------------------------}
 data Network = Testnet | Mainnet
 
--- Spec: type Slot = Natural
-type Slot = Read.SlotNo
-
-toSlot :: Natural -> Slot
-toSlot = Read.SlotNo
-
-fromSlot :: Slot -> Natural
-fromSlot (Read.SlotNo sl) = sl
-
 data ChainPoint
     = Origin
-    | At Slot
+    | At Read.SlotNo
     deriving (Eq, Ord, Show)
 
 -- | Synonym for readability.
@@ -154,7 +144,7 @@ type Sig = ()
 data BHBody = BHBody
     { prev :: Maybe HashHeader
     , blockno :: BlockNo
-    , slot :: Slot
+    , slotNo :: Read.SlotNo
     , bhash :: HashBBody
     }
     deriving (Eq, Ord, Show)
@@ -166,7 +156,7 @@ dummyBHBody :: BHBody
 dummyBHBody = BHBody
     { prev = Nothing
     , blockno = 128
-    , slot = Read.SlotNo 42
+    , slotNo = Read.SlotNo 42
     , bhash = ()
     }
 

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -8,9 +8,7 @@
 module Cardano.Wallet.Deposit.Read
     ( Network (..)
     , Read.SlotNo
-    , toSlot
-    , fromSlot
-    , ChainPoint (..)
+    , Read.ChainPoint (..)
 
     , Address
     , KeyHash
@@ -34,6 +32,7 @@ module Cardano.Wallet.Deposit.Read
     , BlockNo
     , Block (..)
     , BHeader (..)
+    , Read.mockRawHeaderHash
     , BHBody (..)
 
     , GenesisData
@@ -77,11 +76,6 @@ import qualified Data.ByteString.Short as SBS
     with dummies
 ------------------------------------------------------------------------------}
 data Network = Testnet | Mainnet
-
-data ChainPoint
-    = Origin
-    | At Read.SlotNo
-    deriving (Eq, Ord, Show)
 
 -- | Synonym for readability.
 -- The ledger specifications define @Addr@.


### PR DESCRIPTION
This pull request changes `Cardano.Wallet.Deposit.Read` to use the `ChainPoint` type from `Cardano.Wallet.Read`.

### Comment

* This pull request moves us closer to a point where the temporary module `Cardano.Wallet.Deposit.Read` is subsumed by the official `Cardano.Wallet.Read`.

### Issue Number

ADP-3344