### PR TITLE
[ADP-3435] Add deposit wallet deletion UI element

### DIFF
--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/REST.hs
@@ -169,6 +169,7 @@ instance Show ErrWalletResource where
             ErrFailedToInitialize e' ->
                 "Wallet failed to initialize (no wallet): "
                     <> show e'
+            ErrClosing -> "Wallet is closing"
         ErrWalletPresent e -> case e of
             ErrAlreadyInitializing -> "Wallet is already initializing"
             ErrAlreadyInitialized _ -> "Wallet is already initialized"
@@ -176,6 +177,7 @@ instance Show ErrWalletResource where
             ErrAlreadyFailedToInitialize e' ->
                 "Wallet failed to initialize (wallet present): "
                     <> show e'
+            ErrAlreadyClosing -> "Wallet is already closing"
 
 -- | Monad for acting on a 'WalletResource'.
 type WalletResourceM = ReaderT WalletResource (ExceptT ErrWalletResource IO)

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/REST.hs
@@ -45,6 +45,8 @@ module Cardano.Wallet.Deposit.REST
     , signTxBody
     , walletExists
     , walletPublicIdentity
+    , deleteWallet
+    , deleteTheDepositWalletOnDisk
     ) where
 
 import Prelude
@@ -115,6 +117,7 @@ import Data.Store
     )
 import System.Directory
     ( listDirectory
+    , removeFile
     )
 import System.FilePath
     ( (</>)
@@ -208,9 +211,16 @@ depositPrefix = "deposit-"
 
 -- | Scan a directory for deposit wallets.
 scanDirectoryForDepositPrefix :: FilePath -> IO [FilePath]
-scanDirectoryForDepositPrefix fp = do
-    files <- listDirectory fp
+scanDirectoryForDepositPrefix dir = do
+    files <- listDirectory dir
     pure $ filter (depositPrefix `isPrefixOf`) files
+
+deleteTheDepositWalletOnDisk :: FilePath -> IO ()
+deleteTheDepositWalletOnDisk dir = do
+    ds <- scanDirectoryForDepositPrefix dir
+    case ds of
+        [d] -> removeFile (dir </> d)
+        _ -> pure ()
 
 -- | Try to open an existing wallet
 findTheDepositWalletOnDisk
@@ -219,13 +229,13 @@ findTheDepositWalletOnDisk
     -> (Either ErrLoadingDatabase WalletIO.WalletStore -> IO a)
     -- ^ Action to run if the wallet is found
     -> IO a
-findTheDepositWalletOnDisk fp action = do
-    ds <- scanDirectoryForDepositPrefix fp
+findTheDepositWalletOnDisk dir action = do
+    ds <- scanDirectoryForDepositPrefix dir
     case ds of
         [d] -> do
-            (xpub, users) <- deserialise <$> BL.readFile (fp </> d)
+            (xpub, users) <- deserialise <$> BL.readFile (dir </> d)
             case xpubFromBytes xpub of
-                Nothing -> action $ Left $ ErrDatabaseCorrupted (fp </> d)
+                Nothing -> action $ Left $ ErrDatabaseCorrupted (dir </> d)
                 Just identity -> do
                     let state =
                             fromXPubAndGenesis
@@ -235,8 +245,8 @@ findTheDepositWalletOnDisk fp action = do
                     store <- newStore
                     writeS store state
                     action $ Right store
-        [] -> action $ Left $ ErrDatabaseNotFound fp
-        ds' -> action $ Left $ ErrMultipleDatabases ((fp </>) <$> ds')
+        [] -> action $ Left $ ErrDatabaseNotFound dir
+        ds' -> action $ Left $ ErrMultipleDatabases ((dir </>) <$> ds')
 
 -- | Try to create a new wallet
 createTheDepositWalletOnDisk
@@ -251,11 +261,12 @@ createTheDepositWalletOnDisk
     -> (Maybe WalletIO.WalletStore -> IO a)
     -- ^ Action to run if the wallet is created
     -> IO a
-createTheDepositWalletOnDisk _tr fp identity users action = do
-    ds <- scanDirectoryForDepositPrefix fp
+createTheDepositWalletOnDisk _tr dir identity users action = do
+    ds <- scanDirectoryForDepositPrefix dir
     case ds of
         [] -> do
-            BL.writeFile (fp </> depositPrefix <> hashWalletId identity)
+            let fp = dir </> depositPrefix <> hashWalletId identity
+            BL.writeFile fp
                 $ serialise (xpubToBytes identity, fromIntegral users :: Int)
             store <- newStore
             action $ Just store
@@ -277,14 +288,14 @@ loadWallet
     -- ^ Path to the wallet database directory
     -> Tracer IO (ResourceStatus ErrDatabase WalletIO.WalletInstance)
     -> WalletResourceM ()
-loadWallet bootEnv fp trs = do
+loadWallet bootEnv dir trs = do
     let action :: (WalletIO.WalletInstance -> IO b) -> IO (Either ErrDatabase b)
-        action f = findTheDepositWalletOnDisk fp $ \case
+        action f = findTheDepositWalletOnDisk dir $ \case
             Right wallet ->
-                Right <$> do
+                Right <$>
                     WalletIO.withWalletLoad
                         (WalletIO.WalletEnv bootEnv wallet)
-                        f
+                     f
             Left e -> pure $ Left $ ErrLoadingDatabase e
     resource <- ask
     lift
@@ -306,9 +317,9 @@ initXPubWallet
     -> Word31
     -- ^ Max number of users ?
     -> WalletResourceM ()
-initXPubWallet tr bootEnv fp trs xpub users = do
+initXPubWallet tr bootEnv dir trs xpub users = do
     let action :: (WalletIO.WalletInstance -> IO b) -> IO (Either ErrDatabase b)
-        action f = createTheDepositWalletOnDisk tr fp xpub users $ \case
+        action f = createTheDepositWalletOnDisk tr dir xpub users $ \case
             Just wallet -> do
                 fmap Right
                     $ WalletIO.withWalletInit
@@ -322,15 +333,24 @@ initXPubWallet tr bootEnv fp trs xpub users = do
                 pure
                     $ Left
                     $ ErrCreatingDatabase
-                    $ ErrDatabaseAlreadyExists fp
+                    $ ErrDatabaseAlreadyExists dir
     resource <- ask
     lift
         $ ExceptT
         $ first ErrWalletPresent
             <$> Resource.putResource action trs resource
 
+deleteWallet :: FilePath -> WalletResourceM ()
+deleteWallet dir = do
+    resource <- ask
+    lift
+        $ ExceptT
+        $ first ErrNoWallet
+            <$> Resource.closeResource resource
+    liftIO $ deleteTheDepositWalletOnDisk dir
+
 walletExists :: FilePath -> WalletResourceM Bool
-walletExists fp = liftIO $ findTheDepositWalletOnDisk fp $ \case
+walletExists dir = liftIO $ findTheDepositWalletOnDisk dir $ \case
     Right _ -> pure True
     Left _ -> pure False
 

--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -44,6 +44,7 @@ library
     Cardano.Wallet.UI.Common.Html.Html
     Cardano.Wallet.UI.Common.Html.Htmx
     Cardano.Wallet.UI.Common.Html.Lib
+    Cardano.Wallet.UI.Common.Html.Modal
     Cardano.Wallet.UI.Common.Html.Pages.Lib
     Cardano.Wallet.UI.Common.Html.Pages.Network
     Cardano.Wallet.UI.Common.Html.Pages.Settings

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Lib.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Lib.hs
@@ -10,6 +10,11 @@ module Cardano.Wallet.UI.Common.Html.Lib
     , linkText
     , showHtml
     , toTextHtml
+    , dataBsToggle_
+    , dataBsTarget_
+    , dataBsDismiss_
+    , ariaHidden_
+    , ariaLabel_
     )
 where
 
@@ -31,11 +36,15 @@ import Data.Time
     , utcToLocalTime
     )
 import Lucid
-    ( Html
+    ( Attribute
+    , Html
     , HtmlT
     , ToHtml (..)
     , class_
     , div_
+    )
+import Lucid.Base
+    ( makeAttribute
     )
 import Servant.Links
     ( Link
@@ -72,3 +81,18 @@ showHtml = toHtml . show
 
 toTextHtml :: (Monad m, ToText a) => a -> HtmlT m ()
 toTextHtml = toHtml . toText
+
+dataBsToggle_ :: Text -> Attribute
+dataBsToggle_ = makeAttribute "data-bs-toggle"
+
+dataBsTarget_ :: Text -> Attribute
+dataBsTarget_ = makeAttribute "data-bs-target"
+
+dataBsDismiss_ :: Text -> Attribute
+dataBsDismiss_ = makeAttribute "data-bs-dismiss"
+
+ariaHidden_ :: Text -> Attribute
+ariaHidden_ = makeAttribute "aria-hidden"
+
+ariaLabel_ :: Text -> Attribute
+ariaLabel_ = makeAttribute "aria-label"

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Modal.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Modal.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Cardano.Wallet.UI.Common.Html.Modal
+    ( modalsH
+    , ModalData (..)
+    , mkModal
+    , mkModalButton
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.UI.Common.Html.Htmx
+    ( hxGet_
+    , hxTarget_
+    )
+import Cardano.Wallet.UI.Common.Html.Lib
+    ( ariaHidden_
+    , dataBsTarget_
+    , dataBsToggle_
+    , linkText
+    )
+import Lucid
+    ( Attribute
+    , HtmlT
+    , button_
+    , class_
+    , div_
+    , id_
+    , role_
+    , tabindex_
+    )
+import Servant
+    ( Link
+    )
+
+-- | the unique node of the modal support, pls add it to the end of the body
+modalsH :: Applicative m => HtmlT m ()
+modalsH = do
+    div_
+        [ class_ "modal"
+        , role_ "dialog"
+        , ariaHidden_ "false"
+        , tabindex_ "-1"
+        , id_ "modals"
+        ]
+        $ do
+            div_
+                [ class_ "modal-dialog"
+                , role_ "document"
+                ]
+                $ do
+                    div_ [class_ "modal-content", id_ "modal-content"] mempty
+
+data ModalData m = ModalData
+    { modalTitle :: HtmlT m ()
+    , modalBody :: HtmlT m ()
+    , modalFooter :: HtmlT m ()
+    }
+
+mkModal :: Monad m => ModalData m -> HtmlT m ()
+mkModal ModalData{..} = do
+    div_ [class_ "modal-header"] $ do
+        modalTitle
+    div_ [class_ "modal-body"] modalBody
+    div_ [class_ "modal-footer"] modalFooter
+
+mkModalButton :: Monad m => Link -> [Attribute] -> HtmlT m () -> HtmlT m ()
+mkModalButton getLink buttonAttrs =
+    button_
+        $ [ hxGet_ $ linkText getLink
+          , hxTarget_ "#modal-content"
+          , dataBsToggle_ "modal"
+          , dataBsTarget_ "#modals"
+          ]
+            <> buttonAttrs

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Head.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Head.hs
@@ -70,7 +70,7 @@ bootstrapIcons =
         [ rel_ "stylesheet"
         , href_ "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
         , integrity_
-            "sha384-XI+Zz5ooq0QtjZVWisDbzKhZHpDvojmuW5fxM3Z1NY3VHU2hlI7c1o4TmYH72yK"
+            "sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+"
         , crossorigin_ "anonymous"
         ]
 

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
@@ -36,7 +36,8 @@ import GHC.Generics
     ( Generic
     )
 import Servant
-    ( FormUrlEncoded
+    ( Delete
+    , FormUrlEncoded
     , Get
     , Link
     , Post
@@ -96,6 +97,7 @@ type Data =
             :> "xpub"
             :> ReqBody '[FormUrlEncoded] PostWalletViaXPub
             :> SessionedHtml Post
+        :<|> "wallet" :> SessionedHtml Delete
 
 type Home = SessionedHtml Get
 
@@ -121,6 +123,7 @@ walletPageLink :: Link
 walletLink :: Link
 walletPostMnemonicLink :: Link
 walletPostXPubLink :: Link
+walletDeleteLink :: Link
 homePageLink
     :<|> aboutPageLink
     :<|> networkPageLink
@@ -134,5 +137,7 @@ homePageLink
     :<|> walletMnemonicLink
     :<|> walletLink
     :<|> walletPostMnemonicLink
-    :<|> walletPostXPubLink =
+    :<|> walletPostXPubLink
+    :<|> walletDeleteLink
+    =
         allLinks (Proxy @UI)

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
@@ -98,6 +98,7 @@ type Data =
             :> ReqBody '[FormUrlEncoded] PostWalletViaXPub
             :> SessionedHtml Post
         :<|> "wallet" :> SessionedHtml Delete
+        :<|> "wallet" :> "delete" :> "modal" :> SessionedHtml Get
 
 type Home = SessionedHtml Get
 
@@ -124,6 +125,7 @@ walletLink :: Link
 walletPostMnemonicLink :: Link
 walletPostXPubLink :: Link
 walletDeleteLink :: Link
+walletDeleteModalLink :: Link
 homePageLink
     :<|> aboutPageLink
     :<|> networkPageLink
@@ -139,5 +141,6 @@ homePageLink
     :<|> walletPostMnemonicLink
     :<|> walletPostXPubLink
     :<|> walletDeleteLink
+    :<|> walletDeleteModalLink
     =
         allLinks (Proxy @UI)

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Lib.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Lib.hs
@@ -69,8 +69,8 @@ walletPresent :: SessionLayer WalletResource -> Handler WalletPresent
 walletPresent session = catchRunWalletResourceM session $ do
     s <- ask >>= liftIO . readStatus
     case s of
-        NotInitialized -> pure WalletAbsent
-        Initialized _ -> WalletPresent <$> walletPublicIdentity
+        Closed -> pure WalletAbsent
+        Open _ -> WalletPresent <$> walletPublicIdentity
         Vanished e -> pure $ WalletVanished e
-        FailedToInitialize e -> pure $ WalletFailedToInitialize e
-        Initializing -> pure WalletInitializing
+        FailedToOpen e -> pure $ WalletFailedToInitialize e
+        Opening -> pure WalletInitializing

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Lib.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Lib.hs
@@ -74,3 +74,4 @@ walletPresent session = catchRunWalletResourceM session $ do
         Vanished e -> pure $ WalletVanished e
         FailedToOpen e -> pure $ WalletFailedToInitialize e
         Opening -> pure WalletInitializing
+        Closing -> pure WalletClosing

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Wallet.hs
@@ -143,3 +143,16 @@ walletIsLoading
     -> (WalletPresent -> html)
     -> Handler html
 walletIsLoading layer render = render <$> walletPresent layer
+
+deleteWalletHandler
+    :: SessionLayer WalletResource
+    -> WalletResourceM ()
+    -- ^ deleteWallet
+    -> (BL.ByteString -> html)
+    -> (() -> html)
+    -> Handler html
+deleteWalletHandler layer deleteWallet alert render = do
+    r <- liftIO $ catchRunWalletResourceM layer deleteWallet
+    pure $ case r of
+        Left e -> alert $ BL.pack $ show e
+        Right _ -> render ()

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
@@ -15,6 +15,9 @@ import Prelude
 import Cardano.Wallet.UI.Common.Html.Html
     ( RawHtml (..)
     )
+import Cardano.Wallet.UI.Common.Html.Modal
+    ( modalsH
+    )
 import Cardano.Wallet.UI.Common.Html.Pages.Network
     ( networkH
     )
@@ -83,13 +86,15 @@ page c@PageConfig{..} p = RawHtml
     $ renderBS
     $ runWHtml Deposit
     $ pageFromBodyH faviconLink c
-    $ bodyH sseLink (headerH prefix p)
     $ do
-        case p of
-            About -> aboutH
-            Network -> networkH networkInfoLink
-            Settings -> settingsPageH settingsGetLink
-            Wallet -> walletH
+        bodyH sseLink (headerH prefix p)
+            $ do
+                modalsH
+                case p of
+                    About -> aboutH
+                    Network -> networkH networkInfoLink
+                    Settings -> settingsPageH settingsGetLink
+                    Wallet -> walletH
 
 headerH :: Text -> Page -> Monad m => HtmlT m ()
 headerH prefix p =

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -79,6 +79,7 @@ data WalletPresent
     | WalletFailedToInitialize ErrDatabase
     | WalletVanished SomeException
     | WalletInitializing
+    | WalletClosing
 
 instance Show WalletPresent where
     show (WalletPresent x) = "WalletPresent: " <> show x
@@ -86,6 +87,7 @@ instance Show WalletPresent where
     show (WalletFailedToInitialize _) = "WalletFailedToInitialize"
     show (WalletVanished _) = "WalletVanished"
     show WalletInitializing = "WalletInitializing"
+    show WalletClosing = "WalletClosing"
 
 walletH :: WHtml ()
 walletH = sseH walletLink "wallet" ["wallet"]
@@ -134,6 +136,7 @@ walletElementH alert = \case
                 <> BL.pack (show err)
     WalletVanished e -> alert $ "Wallet vanished " <> BL.pack (show e)
     WalletInitializing -> alert "Wallet is initializing"
+    WalletClosing -> alert "Wallet is closing"
 
 data BadgeStyle
     = Primary

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -20,6 +20,13 @@ import Cardano.Wallet.Deposit.REST
 import Cardano.Wallet.UI.Common.API
     ( Visible (..)
     )
+import Cardano.Wallet.UI.Common.Html.Htmx
+    ( hxDelete_
+    , hxTarget_
+    )
+import Cardano.Wallet.UI.Common.Html.Lib
+    ( linkText
+    )
 import Cardano.Wallet.UI.Common.Html.Pages.Lib
     ( copyButton
     , record
@@ -32,7 +39,8 @@ import Cardano.Wallet.UI.Common.Html.Pages.Wallet
     , newWalletFromXPubH
     )
 import Cardano.Wallet.UI.Deposit.API
-    ( walletLink
+    ( walletDeleteLink
+    , walletLink
     , walletMnemonicLink
     , walletPostMnemonicLink
     , walletPostXPubLink
@@ -62,6 +70,7 @@ import Lucid
     ( Html
     , HtmlT
     , ToHtml (..)
+    , button_
     , class_
     , div_
     , hidden_
@@ -113,6 +122,14 @@ walletElementH alert = \case
         record $ do
             simpleField "Public Key" $ pubKeyH xpub
             simpleField "Customer Discovery" $ toHtml $ toText customers
+        div_ [class_ "row"] $ do
+            button_
+                [ class_ "btn btn-danger"
+                , hxDelete_ $ linkText walletDeleteLink
+                , hxTarget_ "#delete-result"
+                ]
+                "Delete Wallet"
+            div_ [id_ "delete-result"] mempty
     WalletAbsent -> runWHtml Deposit $ do
         section_
             $ newWalletFromMnemonicH walletMnemonicLink

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Server.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Server.hs
@@ -22,9 +22,13 @@ import Cardano.Wallet.Deposit.IO
     ( WalletBootEnv
     , WalletInstance
     )
+import Cardano.Wallet.Deposit.IO.Resource
+    ( ResourceStatus
+    )
 import Cardano.Wallet.Deposit.REST
     ( ErrDatabase
     , WalletResource
+    , deleteWallet
     , initXPubWallet
     )
 import Cardano.Wallet.Network
@@ -90,7 +94,8 @@ import Cardano.Wallet.UI.Deposit.Handlers.Page
     ( pageHandler
     )
 import Cardano.Wallet.UI.Deposit.Handlers.Wallet
-    ( getWallet
+    ( deleteWalletHandler
+    , getWallet
     , postMnemonicWallet
     , postXPubWallet
     )
@@ -128,9 +133,6 @@ import Servant
     )
 
 import qualified Cardano.Read.Ledger.Block.Block as Read
-import Cardano.Wallet.Deposit.IO.Resource
-    ( ResourceStatus
-    )
 import qualified Data.ByteString.Lazy as BL
 
 showTime :: UTCTime -> String
@@ -163,6 +165,7 @@ serveUI tr ul env dbDir config _ nl bs =
         :<|> wsl (\l -> getWallet l (renderHtml . walletElementH alertH))
         :<|> (\v -> wsl (\l -> postMnemonicWallet l (initWallet l) alert ok v))
         :<|> (\v -> wsl (\l -> postXPubWallet l (initWallet l) alert ok v))
+        :<|> wsl (\l -> deleteWalletHandler l (deleteWallet dbDir) alert ok)
   where
     ph = pageHandler tr ul env dbDir config
     ok _ = renderHtml . rogerH @Text $ "ok"

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Server.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Server.hs
@@ -103,7 +103,8 @@ import Cardano.Wallet.UI.Deposit.Html.Pages.Page
     ( Page (..)
     )
 import Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
-    ( walletElementH
+    ( deleteWalletModalH
+    , walletElementH
     )
 import Control.Monad.Trans
     ( MonadIO (..)
@@ -166,6 +167,7 @@ serveUI tr ul env dbDir config _ nl bs =
         :<|> (\v -> wsl (\l -> postMnemonicWallet l (initWallet l) alert ok v))
         :<|> (\v -> wsl (\l -> postXPubWallet l (initWallet l) alert ok v))
         :<|> wsl (\l -> deleteWalletHandler l (deleteWallet dbDir) alert ok)
+        :<|> wsl (\_l -> pure $ renderHtml deleteWalletModalH)
   where
     ph = pageHandler tr ul env dbDir config
     ok _ = renderHtml . rogerH @Text $ "ok"


### PR DESCRIPTION
- Rename `ResourceStatus` constructors to give semantical space to `Closing`
- Add `Closing` state as a user pushed signal that the resource have to be closed
- Fix `waitForEndOfLife` to end life on `Closing` signal
- Add `deleteWallet` functionality to REST interface
- Add `delete` button to the wallet UI page


ADP-3435