### PR TITLE
[ADP-3344] Move `mockNextBlock` to `Cardano.Wallet.Deposit.Read`

### DIFF
--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
@@ -71,7 +71,7 @@ newNetworkEnvMock = do
             tipOld <- readTVar mtip
             let txRead = Write.toConwayTx (Write.mockTxId tipOld) tx
                 blockNew = mkNextBlock tipOld [txRead]
-                tipNew = getBlockPoint blockNew
+                tipNew = Read.getChainPoint blockNew
             writeTVar mtip tipNew
             modifyTVar mchain (blockNew:)
             pure (blockNew, tipNew)
@@ -95,18 +95,6 @@ newNetworkEnvMock = do
 
 genesis :: Read.ChainPoint
 genesis = Read.GenesisPoint
-
-getBlockPoint :: Read.Block -> Read.ChainPoint
-getBlockPoint block =
-    Read.BlockPoint
-        { Read.slotNo = slot
-        , Read.headerHash =
-            Read.mockRawHeaderHash
-            $ fromIntegral $ fromEnum slot
-        }
-  where
-    bhBody = Read.blockHeaderBody $ Read.blockHeader block
-    slot = Read.slotNo bhBody
 
 mkNextBlock :: Read.ChainPoint -> [Tx Conway] -> Read.Block
 mkNextBlock tipOld txs =

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
@@ -55,11 +55,11 @@ newNetworkEnvMock
     => m (NetworkEnv m Read.Block)
 newNetworkEnvMock = do
     mchain <- newTVarIO []
-    mtip <- newTVarIO genesis
+    mtip <- newTVarIO Read.GenesisPoint
     mfollowers <- newTVarIO []
 
     let registerAndUpdate follower = do
-            _ <- rollBackward follower genesis
+            _ <- rollBackward follower Read.GenesisPoint
             (chain, tip) <- atomically $ do
                 modifyTVar mfollowers (follower:)
                 (,) <$> readTVar mchain <*> readTVar mtip
@@ -92,9 +92,6 @@ newNetworkEnvMock = do
             threadDelay 100
             pure $ Right ()
         }
-
-genesis :: Read.ChainPoint
-genesis = Read.GenesisPoint
 
 mkNextBlock :: Read.ChainPoint -> [Tx Conway] -> Read.Block
 mkNextBlock tipOld txs =

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE BinaryLiterals #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 -- | Indirection module that re-exports types
 -- used for reading data from the blockchain,
@@ -31,6 +33,7 @@ module Cardano.Wallet.Deposit.Read
 
     , BlockNo
     , Block (..)
+    , getChainPoint
     , BHeader (..)
     , Read.mockRawHeaderHash
     , BHBody (..)
@@ -112,6 +115,9 @@ type TxBody = ()
 
 type TxWitness = ()
 
+{-----------------------------------------------------------------------------
+    Block
+------------------------------------------------------------------------------}
 type BlockNo = Natural
 
 -- type Block = O.CardanoBlock O.StandardCrypto
@@ -127,12 +133,6 @@ data BHeader = BHeader
     }
     deriving (Eq, Ord, Show)
 
-dummyBHeader :: BHeader
-dummyBHeader = BHeader
-    { blockHeaderBody = dummyBHBody
-    , blockHeaderSignature = ()
-    }
-
 type Sig = ()
 
 data BHBody = BHBody
@@ -146,6 +146,24 @@ data BHBody = BHBody
 type HashHeader = ()
 type HashBBody = ()
 
+getChainPoint :: Block -> Read.ChainPoint
+getChainPoint block =
+    Read.BlockPoint
+        { Read.slotNo = slot
+        , Read.headerHash =
+            Read.mockRawHeaderHash
+            $ fromIntegral $ fromEnum slot
+        }
+  where
+    bhBody = blockHeaderBody $ blockHeader block
+    slot = slotNo bhBody
+
+dummyBHeader :: BHeader
+dummyBHeader = BHeader
+    { blockHeaderBody = dummyBHBody
+    , blockHeaderSignature = ()
+    }
+
 dummyBHBody :: BHBody
 dummyBHBody = BHBody
     { prev = Nothing
@@ -153,6 +171,10 @@ dummyBHBody = BHBody
     , slotNo = Read.SlotNo 42
     , bhash = ()
     }
+
+{-----------------------------------------------------------------------------
+    Genesis
+------------------------------------------------------------------------------}
 
 -- GenesisData is not part of the ledger specification proper
 type GenesisData = Byron.GenesisData


### PR DESCRIPTION
This pull request moves functionality that is useful for creating mock `Block`s for testing from `Cardano.Wallet.Deposit.IO.Network.Mock` to `Cardano.Wallet.Deposit.Read`. In this way, the functionality can be used for unit testing the modules `Cardano.Wallet.Deposit.Pure` as well.

### Issue Number

ADP-3344