### PR TITLE
[ADP-3260] Drop Babbage integration tests from CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -101,20 +101,6 @@ steps:
       agents:
         system: ${linux}
 
-    - label: Babbage Integration Tests (linux)
-      key: linux-tests-integration-babbage
-      depends_on: []
-      command: |
-          mkdir integration-test-dir
-          export CLUSTER_LOGS_DIR_PATH=integration-test-dir/cluster.logs
-          export INTEGRATION_TEST_DIR=integration-test-dir
-          nix shell 'nixpkgs#just' -c just babbage-integration-tests
-      artifact_paths: [ "./integration-test-dir/**" ]
-      agents:
-        system: ${linux}
-      concurrency: 8
-      concurrency_group: 'linux-integration-tests'
-
     - label: Conway Integration Tests (linux)
       key: linux-tests-integration-conway
       depends_on: []
@@ -579,7 +565,7 @@ steps:
     - label: Run Integration Tests (macOS)
       key: macos-tests-integration
       depends_on: macos-integration-tests-block
-      command: nix shell 'nixpkgs#just' -c just babbage-integration-tests
+      command: nix shell 'nixpkgs#just' -c just conway-integration-tests
       agents:
         system: ${macos}
         queue: "cardano-wallet"


### PR DESCRIPTION
- [x] Drop linux Babbage integration tests in CI
- [x] Switch the macOS integration tests from Babbage to Conway

### Issue Number

ADP-3260
