### PR TITLE
[ADP-3455] Compact up navigation on small screens

### DIFF
--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Body.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Body.hs
@@ -13,9 +13,6 @@ import Cardano.Wallet.UI.Common.Html.Htmx
 import Cardano.Wallet.UI.Common.Html.Lib
     ( linkText
     )
-import Cardano.Wallet.UI.Common.Html.Pages.Template.Footer
-    ( footerH
-    )
 import Data.Text
     ( Text
     )
@@ -45,6 +42,3 @@ bodyH sseLink header body = do
     div_ [hxSse_ $ sseConnectFromLink sseLink] $
         div_ [class_ "container-fluid"] $ do
             div_ [class_ "main"] body
-            div_
-                [class_ "footer mt-5"]
-                footerH

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Footer.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Footer.hs
@@ -37,13 +37,13 @@ footerH =
                 $ do
                     ul_ [class_ "nav flex-column"] $ do
                         li_
-                            [class_ "nav-item mb-2"]
+                            [class_ "nav-item"]
                             "© 2024 Cardano Foundation, HAL team"
-                        li_ [class_ "nav-item mb-2"] $ do
+                        li_ [class_ "nav-item"] $ do
                             span_ "Source code on "
                             githubLinkH
 
             div_ [class_ "row d-md-flex align-items-center"]
                 $ div_
-                    [class_ "mb-3 mb-md-0 text-body-secondary"]
+                    [class_ "mb-md-0 text-body-secondary"]
                     "Powered by Haskell, Htmx, Servant, Lucid, Bootstrap"

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Navigation.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Navigation.hs
@@ -8,6 +8,9 @@ import Prelude
 import Cardano.Wallet.UI.Common.Html.Lib
     ( linkText
     )
+import Cardano.Wallet.UI.Deposit.API
+    ( faviconLink
+    )
 import Control.Monad
     ( forM_
     )
@@ -15,29 +18,28 @@ import Data.Text
     ( Text
     )
 import Lucid
-    ( Attribute
-    , HtmlT
+    ( HtmlT
     , a_
+    , alt_
+    , button_
     , class_
-    , header_
+    , div_
     , href_
-    , li_
+    , id_
+    , img_
+    , nav_
+    , span_
+    , src_
+    , style_
     , term
-    , ul_
+    , type_
     )
 import Servant
     ( Link
     )
 
--- | Add attributes for the active page.
-activePageH :: Bool -> [Attribute] -> [Attribute]
-activePageH c =
-    if c
-        then (<> [class_ "nav-link active", term "aria-current" "page"])
-        else (<> [class_ "nav-link"])
-
 -- | Wrap a content as link tab.
-tabOf
+navElem
     :: Monad m
     => Text
     -- ^ Link prefix
@@ -49,9 +51,10 @@ tabOf
     -- ^ Tab content
     -> HtmlT m ()
     -- ^ Tab
-tabOf prefix c p t =
-    li_ [class_ "nav-item"]
-        $ a_ (activePageH c [href_ $ prefix <> linkText p]) t
+navElem prefix c p = a_ ([href_ $ prefix <> linkText p, class_ class'])
+  where
+    class' = baseClass <> " " <> if c then "active" else ""
+    baseClass = "nav-link ms-auto fs-3"
 
 -- | Navigation bar definition.
 
@@ -64,6 +67,30 @@ navigationH
     -- ^ Pages
     -> HtmlT m ()
 navigationH prefix pages = do
-    header_ [class_ "d-flex justify-content-center py-3"] $ do
-        ul_ [class_ "nav nav-pills"] $ do
-            forM_ pages $ \(c, p, t) -> tabOf prefix c p t
+    nav_ [class_ "navbar navbar-expand-lg bg-body-tertiary mb-2"]
+        $ div_ [class_ "container-fluid"]
+        $ do
+            a_ [class_ "navbar-brand", href_ "/"]
+                $ img_ [src_ $ linkText faviconLink
+                    , alt_ "Cardano Deposit Wallet"
+                    , class_ "img-fluid"
+                    , style_ "height: 2em;"
+                    ]
+            button_
+                [ class_ "navbar-toggler"
+                , type_ "button"
+                , term "data-bs-toggle" "collapse"
+                , term "data-bs-target" "#navbar"
+                , term "aria-controls" "navbar"
+                , term "aria-expanded" "false"
+                , term "aria-label" "Toggle navigation"
+                ]
+                $ do
+                    span_ [class_ "navbar-toggler-icon"] ""
+            div_
+                [ class_ "collapse navbar-collapse"
+                , id_ "navbar"
+                ]
+                $ div_ [class_ "navbar-nav"]
+                $ forM_ pages
+                $ \(c, p, t) -> navElem prefix c p t

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/About.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/About.hs
@@ -2,6 +2,9 @@ module Cardano.Wallet.UI.Deposit.Html.Pages.About where
 
 import Prelude
 
+import Cardano.Wallet.UI.Common.Html.Pages.Template.Footer
+    ( footerH
+    )
 import Lucid
     ( HtmlT
     , p_
@@ -9,5 +12,5 @@ import Lucid
 
 aboutH :: Monad m => HtmlT m ()
 aboutH = do
-    p_
-        "This is the new builtin Cardano Deposit Wallet web UI, pre-alpha version"
+    p_ "Cardano Deposit Wallet web UI, pre-alpha version"
+    footerH


### PR DESCRIPTION
This PR makes space for the navigation on small screens by having a foldable navigation bar. It also remove the footer everywhere but on the about page.

ADP-3455