### PR TITLE
[ADP-3450] Fix copy buttons on mobile.

### DIFF
--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -43,6 +43,7 @@ library
     Cardano.Wallet.UI.Common.Handlers.SSE
     Cardano.Wallet.UI.Common.Handlers.State
     Cardano.Wallet.UI.Common.Handlers.Wallet
+    Cardano.Wallet.UI.Common.Html.Copy
     Cardano.Wallet.UI.Common.Html.Html
     Cardano.Wallet.UI.Common.Html.Htmx
     Cardano.Wallet.UI.Common.Html.Lib

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Copy.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Copy.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Wallet.UI.Common.Html.Copy
+    ( copyButton
+    )
+where
+
+import Prelude
+
+import Data.String.Interpolate
+    ( i
+    )
+import Data.Text
+    ( Text
+    )
+import Lucid
+    ( Attribute
+    , HtmlT
+    , Term (..)
+    , button_
+    , class_
+    , height_
+    , id_
+    , script_
+    , svg_
+    , width_
+    )
+import Lucid.Base
+    ( makeAttribute
+    )
+
+-- | A button that copies the content of a field to the clipboard.
+copyButton
+    :: Monad m
+    => Text
+    -- ^ Field id
+    -> HtmlT m ()
+copyButton field' = do
+    button_ [class_ "btn", id_ button] buttonImage
+    script_ $ copyButtonScript button field'
+  where
+    button = field' <> "-copy-button"
+
+buttonImage :: Monad m => HtmlT m ()
+buttonImage = svg_
+    [ class_ "bi bi-copy"
+    , width_ "16"
+    , height_ "16"
+    , fill_ "currentColor"
+    , viewBox_ "0 0 16 16"
+    ]
+    $ do
+        path_
+            [ fillRule_ "evenodd"
+            , d_ drawCopyButton
+            ]
+            mempty
+
+drawCopyButton :: Text
+drawCopyButton = "M4 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2zm2-1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM2 5a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-1h1v1a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1v1z"
+
+fill_ :: Text -> Attribute
+fill_ = makeAttribute "fill"
+
+viewBox_ :: Text -> Attribute
+viewBox_ = makeAttribute "viewBox"
+
+d_ :: Text -> Attribute
+d_ = makeAttribute "d"
+
+fillRule_ :: Text -> Attribute
+fillRule_ = makeAttribute "fill-rule"
+
+path_ :: Term arg result => arg -> result
+path_ = term "path"
+
+copyButtonScript :: Text -> Text -> Text
+copyButtonScript button field' =
+    [i|
+    document.getElementById('#{button}').addEventListener('click', function() {
+        var mnemonic = document.getElementById('#{field'}').innerText;
+        navigator.clipboard.writeText(mnemonic);
+    });
+    |]

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Lib.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Lib.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
@@ -22,7 +21,6 @@ module Cardano.Wallet.UI.Common.Html.Pages.Lib
     , showAda
     , showAdaOfLoveLace
     , showThousandDots
-    , copyButton
     , fadeInId
     )
 where
@@ -47,9 +45,6 @@ import Cardano.Wallet.UI.Lib.ListOf
 import Control.Monad.Operational
     ( singleton
     )
-import Data.String.Interpolate
-    ( i
-    )
 import Data.Text
     ( Text
     )
@@ -59,13 +54,11 @@ import Lucid
     , HtmlT
     , ToHtml (..)
     , b_
-    , button_
     , class_
     , div_
     , id_
     , role_
     , scope_
-    , script_
     , style_
     , table_
     , td_
@@ -161,7 +154,7 @@ sseH
     -> Monad m
     => HtmlT m ()
 sseH link target events = do
-     do
+    do
         div_
             [ hxTrigger_ triggered
             , hxGet_ $ linkText link
@@ -182,7 +175,7 @@ sseH link target events = do
 sseInH :: Text -> [Text] -> Html ()
 sseInH target events =
     div_
-        [hxExt_ "sse"
+        [ hxExt_ "sse"
         ]
         $ div_
             [ hxTarget_ $ "#" <> target
@@ -227,24 +220,3 @@ showThousandDots = reverse . showThousandDots' . reverse . show
             (a, b) = splitAt 3 xs
         in
             a <> if null b then [] else "." <> showThousandDots' b
-
--- | A button that copies the content of a field to the clipboard.
-copyButton
-    :: Monad m
-    => Text
-    -- ^ Field id
-    -> HtmlT m ()
-copyButton field' = do
-    button_ [class_ "btn btn-outline-secondary", id_ button] "Copy"
-    script_ $ copyButtonScript button field'
-  where
-    button = field' <> "-copy-button"
-
-copyButtonScript :: Text -> Text -> Text
-copyButtonScript button field' =
-    [i|
-    document.getElementById('#{button}').addEventListener('click', function() {
-        var mnemonic = document.getElementById('#{field'}').innerText;
-        navigator.clipboard.writeText(mnemonic);
-    });
-    |]

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Body.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Body.hs
@@ -7,6 +7,9 @@ where
 
 import Prelude
 
+import Cardano.Wallet.UI.Common.Html.Copy
+    ( initClipboardScript
+    )
 import Cardano.Wallet.UI.Common.Html.Htmx
     ( hxSse_
     )
@@ -42,3 +45,4 @@ bodyH sseLink header body = do
     div_ [hxSse_ $ sseConnectFromLink sseLink] $
         div_ [class_ "container-fluid"] $ do
             div_ [class_ "main"] body
+    initClipboardScript

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Head.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Head.hs
@@ -10,6 +10,9 @@ where
 
 import Prelude
 
+import Cardano.Wallet.UI.Common.Html.Copy
+    ( offscreenCss
+    )
 import Cardano.Wallet.UI.Common.Html.Htmx
     ( useHtmxExtension
     , useHtmxVersion
@@ -91,6 +94,18 @@ popperScript =
         ]
         $ pure ()
 
+clipboardScript :: Monad m => HtmlT m ()
+clipboardScript =
+    term
+        "script"
+        [ src_
+            "https://cdn.jsdelivr.net/npm/clipboard@2.0.11/dist/clipboard.min.js"
+        , integrity_
+            "sha384-J08i8An/QeARD9ExYpvphB8BsyOj3Gh2TSh1aLINKO3L0cMSH2dN3E22zFoXEi0Q"
+        , crossorigin_ "anonymous"
+        ]
+        $ pure ()
+
 -- | Render a favicon link.
 favicon :: Link -> Monad m => HtmlT m ()
 favicon path =
@@ -131,11 +146,13 @@ pageFromBodyH faviconLink PageConfig{..} body =
                 bootstrapLink
                 bootstrapScript
                 bootstrapIcons
+                clipboardScript
                 favicon faviconLink
                 useHtmxVersion (1, 9, 12)
                 useHtmxExtension "json-enc"
                 bodyCss
                 modalCssWorkaround
+                offscreenCss
             body_ $ do
                 fadeInId
                 body

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Wallet.hs
@@ -103,9 +103,9 @@ newWalletFromMnemonicH walletMnemonicLink config = do
 mnemonicH :: Maybe [Text] -> Html ()
 mnemonicH Nothing = ""
 mnemonicH (Just mnemonic) = do
-    div_ [class_ "card"] $ do
+    div_  [class_ "d-flex justify-content-end"] $ do
         div_
-            [ class_ "card-body text-muted small"
+            [ class_ ""
             , id_ "copy-mnemonic"
             ]
             $ toHtml

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Wallet.hs
@@ -8,6 +8,9 @@ import Prelude
 import Cardano.Wallet.UI.Common.API
     ( Visible (..)
     )
+import Cardano.Wallet.UI.Common.Html.Copy
+    ( copyButton
+    )
 import Cardano.Wallet.UI.Common.Html.Htmx
     ( hxGet_
     , hxPost_
@@ -15,9 +18,6 @@ import Cardano.Wallet.UI.Common.Html.Htmx
     )
 import Cardano.Wallet.UI.Common.Html.Lib
     ( linkText
-    )
-import Cardano.Wallet.UI.Common.Html.Pages.Lib
-    ( copyButton
     )
 import Cardano.Wallet.UI.Type
     ( WHtml

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -25,6 +25,7 @@ import Cardano.Wallet.UI.Common.API
     )
 import Cardano.Wallet.UI.Common.Html.Copy
     ( copyButton
+    , copyableHidden
     )
 import Cardano.Wallet.UI.Common.Html.Htmx
     ( hxDelete_
@@ -93,7 +94,6 @@ import Lucid
     , class_
     , div_
     , h5_
-    , hidden_
     , hr_
     , id_
     , input_
@@ -137,7 +137,7 @@ base64 = convertToBase Base64
 
 customerAddressH :: Monad m => Address -> HtmlT m ()
 customerAddressH addr = div_ [class_ "d-flex justify-content-end"] $ do
-    div_ [id_ "address", hidden_ "true"] $ toHtml encodedAddr
+    div_ (copyableHidden "address") $ toHtml encodedAddr
     div_ [class_ ""] $ toHtml addrShortened
     div_ [class_ "ms-1"] $ copyButton "address"
   where
@@ -149,7 +149,7 @@ customerAddressH addr = div_ [class_ "d-flex justify-content-end"] $ do
 
 pubKeyH :: Monad m => XPub -> HtmlT m ()
 pubKeyH xpub = div_ [class_ "d-flex justify-content-end"] $ do
-    div_ [id_ "public_key", hidden_ "true"] $ toHtml xpubByteString
+    div_ (copyableHidden "public_key") $ toHtml xpubByteString
     div_ [class_ ""] $ toHtml $ headAndTail 4 $ B8.dropEnd 1 xpubByteString
     div_ [class_ "ms-1"]
         $ copyButton "public_key"

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -23,6 +23,9 @@ import Cardano.Wallet.Deposit.REST
 import Cardano.Wallet.UI.Common.API
     ( Visible (..)
     )
+import Cardano.Wallet.UI.Common.Html.Copy
+    ( copyButton
+    )
 import Cardano.Wallet.UI.Common.Html.Htmx
     ( hxDelete_
     , hxPost_
@@ -40,8 +43,7 @@ import Cardano.Wallet.UI.Common.Html.Modal
     , mkModalButton
     )
 import Cardano.Wallet.UI.Common.Html.Pages.Lib
-    ( copyButton
-    , record
+    ( record
     , simpleField
     , sseH
     )
@@ -134,10 +136,10 @@ base64 :: ByteString -> ByteString
 base64 = convertToBase Base64
 
 customerAddressH :: Monad m => Address -> HtmlT m ()
-customerAddressH addr = div_ [class_ "row"] $ do
+customerAddressH addr = div_ [class_ "d-flex justify-content-end"] $ do
     div_ [id_ "address", hidden_ "true"] $ toHtml encodedAddr
-    div_ [class_ "col-8"] $ toHtml addrShortened
-    div_ [class_ "col-4"] $ copyButton "address"
+    div_ [class_ ""] $ toHtml addrShortened
+    div_ [class_ "ms-1"] $ copyButton "address"
   where
     encodedAddr = encodeMainnetAddress addr
     addrShortened =
@@ -146,10 +148,10 @@ customerAddressH addr = div_ [class_ "row"] $ do
             <> T.takeEnd 10 encodedAddr
 
 pubKeyH :: Monad m => XPub -> HtmlT m ()
-pubKeyH xpub = div_ [class_ "row"] $ do
+pubKeyH xpub = div_ [class_ "d-flex justify-content-end"] $ do
     div_ [id_ "public_key", hidden_ "true"] $ toHtml xpubByteString
-    div_ [class_ "col-8"] $ toHtml $ headAndTail 4 $ B8.dropEnd 1 xpubByteString
-    div_ [class_ "col-4"]
+    div_ [class_ ""] $ toHtml $ headAndTail 4 $ B8.dropEnd 1 xpubByteString
+    div_ [class_ "ms-1"]
         $ copyButton "public_key"
   where
     xpubByteString = base64 $ xpubToBytes xpub
@@ -189,7 +191,7 @@ walletElementH :: (BL.ByteString -> Html ()) -> WalletPresent -> Html ()
 walletElementH alert = \case
     WalletPresent (WalletPublicIdentity xpub customers) -> do
         div_ [class_ "row mt-5"] $ do
-            h5_ [class_ "text-center"] "Query Address"
+            h5_ [class_ "text-center"] "Addresses"
             div_ [class_ "col"] $ record $ do
                 simpleField "Customer Number"
                     $ input_
@@ -206,10 +208,10 @@ walletElementH alert = \case
                         ]
                 simpleField "Address" $ div_ [id_ "customer-address"] mempty
         div_ [class_ "row mt-5 "] $ do
-            h5_ [class_ "text-center"] "Wallet Details"
+            h5_ [class_ "text-center"] "Details"
             div_ [class_ "col"] $ record $ do
                 simpleField "Public Key" $ pubKeyH xpub
-                simpleField "Customer Discovery" $ toHtml $ toText customers
+                simpleField "Tracked Addresses" $ toHtml $ toText customers
         div_ [class_ "row mt-5"] $ do
             h5_ [class_ "text-center"] "Administration"
             div_ [class_ "col"] $ do

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Addresses.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Addresses.hs
@@ -27,9 +27,11 @@ import Cardano.Wallet.Primitive.NetworkId
 import Cardano.Wallet.Primitive.Types.Address
     ( Address
     )
-import Cardano.Wallet.UI.Common.Html.Pages.Lib
+import Cardano.Wallet.UI.Common.Html.Copy
     ( copyButton
-    , fieldHtml
+    )
+import Cardano.Wallet.UI.Common.Html.Pages.Lib
+    ( fieldHtml
     , record
     , simpleField
     , sseH

--- a/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Wallets/NewWallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Shelley/Html/Pages/Wallets/NewWallet.hs
@@ -30,11 +30,11 @@ import Lucid
 import Cardano.Wallet.UI.Common.API
     ( Visible (..)
     )
+import Cardano.Wallet.UI.Common.Html.Copy
+    ( copyButton
+    )
 import Cardano.Wallet.UI.Common.Html.Lib
     ( linkText
-    )
-import Cardano.Wallet.UI.Common.Html.Pages.Lib
-    ( copyButton
     )
 import Cardano.Wallet.UI.Shelley.API
     ( walletLink


### PR DESCRIPTION
This PR fixes the copy issues on mobile by using the clipboard.js library. Also use a standard icon on the copy button

ADP-3450