### PR TITLE
[ADP-3456] Move address query UI in a separate page

### DIFF
--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -59,9 +59,11 @@ library
     Cardano.Wallet.UI.Common.Layer
     Cardano.Wallet.UI.Cookies
     Cardano.Wallet.UI.Deposit.API
+    Cardano.Wallet.UI.Deposit.Handlers.Addresses
     Cardano.Wallet.UI.Deposit.Handlers.Lib
     Cardano.Wallet.UI.Deposit.Handlers.Wallet
     Cardano.Wallet.UI.Deposit.Html.Pages.About
+    Cardano.Wallet.UI.Deposit.Html.Pages.Addresses
     Cardano.Wallet.UI.Deposit.Html.Pages.Page
     Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
     Cardano.Wallet.UI.Deposit.Server

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Body.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Body.hs
@@ -41,8 +41,8 @@ bodyH
     -- ^ Body content
     -> HtmlT m ()
 bodyH sseLink header body = do
-    header
-    div_ [hxSse_ $ sseConnectFromLink sseLink] $
+    div_ [hxSse_ $ sseConnectFromLink sseLink] $ do
+        header
         div_ [class_ "container-fluid"] $ do
             div_ [class_ "main"] body
     initClipboardScript

--- a/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Navigation.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Common/Html/Pages/Template/Navigation.hs
@@ -10,6 +10,7 @@ import Cardano.Wallet.UI.Common.Html.Lib
     )
 import Cardano.Wallet.UI.Deposit.API
     ( faviconLink
+    , homePageLink
     )
 import Control.Monad
     ( forM_
@@ -54,7 +55,7 @@ navElem
 navElem prefix c p = a_ ([href_ $ prefix <> linkText p, class_ class'])
   where
     class' = baseClass <> " " <> if c then "active" else ""
-    baseClass = "nav-link ms-auto fs-3"
+    baseClass = "nav-link ms-auto fs-4 fs-5-md"
 
 -- | Navigation bar definition.
 
@@ -70,7 +71,7 @@ navigationH prefix pages = do
     nav_ [class_ "navbar navbar-expand-lg bg-body-tertiary mb-2"]
         $ div_ [class_ "container-fluid"]
         $ do
-            a_ [class_ "navbar-brand", href_ "/"]
+            a_ [class_ "navbar-brand", href_ $ linkText homePageLink]
                 $ img_ [src_ $ linkText faviconLink
                     , alt_ "Cardano Deposit Wallet"
                     , class_ "img-fluid"

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/API.hs
@@ -66,6 +66,7 @@ type Pages =
         :<|> "network" :> SessionedHtml Get
         :<|> "settings" :> SessionedHtml Get
         :<|> "wallet" :> SessionedHtml Get
+        :<|> "addresses" :> SessionedHtml Get
 
 -- | Data endpoints
 type Data =
@@ -91,6 +92,7 @@ type Data =
         :<|> "wallet" :> "delete" :> "modal" :> SessionedHtml Get
         :<|> "customer" :> "address" :> ReqBody '[FormUrlEncoded] Customer
             :> SessionedHtml Post
+        :<|> "addresses" :> SessionedHtml Get
 
 instance FromForm Customer where
     fromForm form = fromIntegral @Int <$> parseUnique "customer" form
@@ -109,6 +111,7 @@ homePageLink :: Link
 aboutPageLink :: Link
 networkPageLink :: Link
 settingsPageLink :: Link
+addressesPageLink :: Link
 networkInfoLink :: Link
 settingsGetLink :: Link
 settingsSseToggleLink :: Link
@@ -122,11 +125,13 @@ walletPostXPubLink :: Link
 walletDeleteLink :: Link
 walletDeleteModalLink :: Link
 customerAddressLink :: Link
+addressesLink :: Link
 homePageLink
     :<|> aboutPageLink
     :<|> networkPageLink
     :<|> settingsPageLink
     :<|> walletPageLink
+    :<|> addressesPageLink
     :<|> networkInfoLink
     :<|> settingsGetLink
     :<|> settingsSseToggleLink
@@ -139,5 +144,6 @@ homePageLink
     :<|> walletDeleteLink
     :<|> walletDeleteModalLink
     :<|> customerAddressLink
+    :<|> addressesLink
     =
         allLinks (Proxy @UI)

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Addresses.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Addresses.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.Wallet.UI.Deposit.Handlers.Addresses
+where
+
+import Prelude
+
+import Cardano.Wallet.Deposit.Pure
+    ( Customer
+    )
+import Cardano.Wallet.Deposit.Read
+    ( Address
+    )
+import Cardano.Wallet.Deposit.REST
+    ( WalletResource
+    , customerAddress
+    )
+import Cardano.Wallet.UI.Common.Layer
+    ( SessionLayer (..)
+    )
+import Cardano.Wallet.UI.Deposit.Handlers.Lib
+    ( catchRunWalletResourceHtml
+    , walletPresence
+    )
+import Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
+    ( WalletPresent
+    )
+import Servant
+    ( Handler
+    )
+
+import qualified Data.ByteString.Lazy.Char8 as BL
+
+getAddresses
+    :: SessionLayer WalletResource
+    -> (WalletPresent -> html) -- success report
+    -> Handler html
+getAddresses layer render = render <$> walletPresence layer
+
+getCustomerAddress
+    :: SessionLayer WalletResource
+    -> (Address -> html)
+    -> (BL.ByteString -> html)
+    -> Customer
+    -> Handler html
+getCustomerAddress layer render alert customer = do
+    catchRunWalletResourceHtml layer alert render'
+        $ customerAddress customer
+    where
+    render' = \case
+        Just a -> render a
+        Nothing -> alert "Address not discovered"

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Wallet.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Cardano.Wallet.UI.Deposit.Handlers.Wallet
@@ -12,13 +11,9 @@ import Cardano.Address.Derivation
 import Cardano.Wallet.Deposit.Pure
     ( Customer
     )
-import Cardano.Wallet.Deposit.Read
-    ( Address
-    )
 import Cardano.Wallet.Deposit.REST
     ( WalletResource
     , WalletResourceM
-    , customerAddress
     )
 import Cardano.Wallet.Deposit.REST.Wallet.Create
     ( PostWalletViaMenmonic (..)
@@ -122,17 +117,3 @@ deleteWalletHandler
     -> Handler html
 deleteWalletHandler layer deleteWallet alert render =
     catchRunWalletResourceHtml layer alert render deleteWallet
-
-getCustomerAddress
-    :: SessionLayer WalletResource
-    -> (Address -> html)
-    -> (BL.ByteString -> html)
-    -> Customer
-    -> Handler html
-getCustomerAddress layer render alert customer = do
-    catchRunWalletResourceHtml layer alert render'
-        $ customerAddress customer
-  where
-    render' = \case
-        Just a -> render a
-        Nothing -> alert "Address not discovered"

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Addresses.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Addresses.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Wallet.UI.Deposit.Html.Pages.Addresses
+where
+
+import Prelude
+
+import Cardano.Wallet.Deposit.IO
+    ( WalletPublicIdentity (..)
+    )
+import Cardano.Wallet.Deposit.Read
+    ( Address
+    )
+import Cardano.Wallet.UI.Common.Html.Copy
+    ( copyButton
+    , copyableHidden
+    )
+import Cardano.Wallet.UI.Common.Html.Htmx
+    ( hxPost_
+    , hxTarget_
+    , hxTrigger_
+    )
+import Cardano.Wallet.UI.Common.Html.Lib
+    ( linkText
+    )
+import Cardano.Wallet.UI.Common.Html.Pages.Lib
+    ( record
+    , simpleField
+    , sseH
+    )
+import Cardano.Wallet.UI.Deposit.API
+    ( addressesLink
+    , customerAddressLink
+    )
+import Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
+    ( WalletPresent (..)
+    )
+import Cardano.Wallet.UI.Lib.Address
+    ( encodeMainnetAddress
+    )
+import Cardano.Wallet.UI.Type
+    ( WHtml
+    )
+import Data.Text.Class
+    ( ToText (..)
+    )
+import Lucid
+    ( Html
+    , HtmlT
+    , ToHtml (..)
+    , class_
+    , div_
+    , h5_
+    , id_
+    , input_
+    , min_
+    , name_
+    , type_
+    , value_
+    )
+import Lucid.Html5
+    ( max_
+    , step_
+    )
+
+import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.Text as T
+
+addressesH :: WHtml ()
+addressesH = do
+    sseH addressesLink "addresses" ["wallet"]
+
+customerAddressH :: Monad m => Address -> HtmlT m ()
+customerAddressH addr = div_ [class_ "d-flex justify-content-end"] $ do
+    div_ (copyableHidden "address") $ toHtml encodedAddr
+    div_ [class_ ""] $ toHtml addrShortened
+    div_ [class_ "ms-1"] $ copyButton "address"
+  where
+    encodedAddr = encodeMainnetAddress addr
+    addrShortened =
+        T.take 10 (T.drop 5 encodedAddr)
+            <> " .. "
+            <> T.takeEnd 10 encodedAddr
+
+addressElementH :: (BL.ByteString -> Html ()) -> WalletPresent -> Html ()
+addressElementH alert = \case
+    WalletPresent (WalletPublicIdentity _xpub customers) -> do
+        div_ [class_ "row mt-5"] $ do
+            h5_ [class_ "text-center"] "Addresses"
+            div_ [class_ "col"] $ record $ do
+                simpleField "Customer Number"
+                    $ input_
+                        [ type_ "number"
+                        , hxTarget_ "#customer-address"
+                        , class_ "form-control"
+                        , hxTrigger_ "load, change"
+                        , hxPost_ $ linkText customerAddressLink
+                        , min_ "0"
+                        , max_ $ toText $ customers - 1
+                        , step_ "1"
+                        , name_ "customer"
+                        , value_ "0"
+                        , class_ "w-3"
+                        ]
+                simpleField "Address" $ div_ [id_ "customer-address"] mempty
+    WalletAbsent -> alert "Wallet is absent"
+    WalletFailedToInitialize err ->
+        alert
+            $ "Failed to initialize wallet"
+                <> BL.pack (show err)
+    WalletVanished e -> alert $ "Wallet vanished " <> BL.pack (show e)
+    WalletInitializing -> alert "Wallet is initializing"
+    WalletClosing -> alert "Wallet is closing"

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Addresses.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Addresses.hs
@@ -52,7 +52,6 @@ import Lucid
     , ToHtml (..)
     , class_
     , div_
-    , h5_
     , id_
     , input_
     , min_
@@ -88,7 +87,6 @@ addressElementH :: (BL.ByteString -> Html ()) -> WalletPresent -> Html ()
 addressElementH alert = \case
     WalletPresent (WalletPublicIdentity _xpub customers) -> do
         div_ [class_ "row mt-5"] $ do
-            h5_ [class_ "text-center"] "Addresses"
             div_ [class_ "col"] $ record $ do
                 simpleField "Customer Number"
                     $ input_

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Addresses.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Addresses.hs
@@ -74,7 +74,8 @@ addressesH = do
 customerAddressH :: Monad m => Address -> HtmlT m ()
 customerAddressH addr = div_ [class_ "d-flex justify-content-end"] $ do
     div_ (copyableHidden "address") $ toHtml encodedAddr
-    div_ [class_ ""] $ toHtml addrShortened
+    div_ [class_ "d-block d-md-none"] $ toHtml addrShortened
+    div_ [class_ "d-none d-md-block"] $ toHtml encodedAddr
     div_ [class_ "ms-1"] $ copyButton "address"
   where
     encodedAddr = encodeMainnetAddress addr

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
@@ -36,6 +36,7 @@ import Cardano.Wallet.UI.Common.Html.Pages.Template.Navigation
     )
 import Cardano.Wallet.UI.Deposit.API
     ( aboutPageLink
+    , addressesPageLink
     , faviconLink
     , networkInfoLink
     , networkPageLink
@@ -47,8 +48,13 @@ import Cardano.Wallet.UI.Deposit.API
 import Cardano.Wallet.UI.Deposit.Html.Pages.About
     ( aboutH
     )
+import Cardano.Wallet.UI.Deposit.Html.Pages.Addresses
+    ( addressesH
+    )
 import Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
-    ( walletH
+    ( WalletPresent
+    , isPresent
+    , walletH
     )
 import Cardano.Wallet.UI.Type
     ( WalletType (..)
@@ -73,6 +79,7 @@ data Page
     | Network
     | Settings
     | Wallet
+    | Addresses
 
 makePrisms ''Page
 
@@ -81,13 +88,15 @@ page
     -- ^ Page configuration
     -> Page
     -- ^ Current page
+    -> WalletPresent
+    -- ^ Wallet present
     -> RawHtml
-page c@PageConfig{..} p = RawHtml
+page c@PageConfig{..} p wp = RawHtml
     $ renderBS
     $ runWHtml Deposit
     $ pageFromBodyH faviconLink c
     $ do
-        bodyH sseLink (headerH prefix p)
+        bodyH sseLink (headerH prefix p wp)
             $ do
                 modalsH
                 case p of
@@ -95,13 +104,18 @@ page c@PageConfig{..} p = RawHtml
                     Network -> networkH networkInfoLink
                     Settings -> settingsPageH settingsGetLink
                     Wallet -> walletH
+                    Addresses -> addressesH
 
-headerH :: Text -> Page -> Monad m => HtmlT m ()
-headerH prefix p =
+headerH :: Text -> Page -> WalletPresent -> Monad m => HtmlT m ()
+headerH prefix p wp =
     navigationH
-        prefix
+        prefix $
         [ (is _Wallet p, walletPageLink, "Wallet")
-        , (is _Network p, networkPageLink, "Network")
+        ]
+        <>
+        [(is _Addresses p, addressesPageLink, "Addresses") | isPresent wp]
+        <>
+        [ (is _Network p, networkPageLink, "Network")
         , (is _Settings p, settingsPageLink, "Settings")
         , (is _About p, aboutPageLink, "About")
         ]

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Page.hs
@@ -1,12 +1,11 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Cardano.Wallet.UI.Deposit.Html.Pages.Page
     ( Page (..)
     , page
+    , headerElementH
     )
 where
 
@@ -17,6 +16,9 @@ import Cardano.Wallet.UI.Common.Html.Html
     )
 import Cardano.Wallet.UI.Common.Html.Modal
     ( modalsH
+    )
+import Cardano.Wallet.UI.Common.Html.Pages.Lib
+    ( sseH
     )
 import Cardano.Wallet.UI.Common.Html.Pages.Network
     ( networkH
@@ -35,9 +37,16 @@ import Cardano.Wallet.UI.Common.Html.Pages.Template.Navigation
     ( navigationH
     )
 import Cardano.Wallet.UI.Deposit.API
-    ( aboutPageLink
+    ( Page (..)
+    , _About
+    , _Addresses
+    , _Network
+    , _Settings
+    , _Wallet
+    , aboutPageLink
     , addressesPageLink
     , faviconLink
+    , navigationLink
     , networkInfoLink
     , networkPageLink
     , settingsGetLink
@@ -60,43 +69,29 @@ import Cardano.Wallet.UI.Type
     ( WalletType (..)
     , runWHtml
     )
+import Control.Lens
+    ( _Just
+    )
 import Control.Lens.Extras
     ( is
-    )
-import Control.Lens.TH
-    ( makePrisms
-    )
-import Data.Text
-    ( Text
     )
 import Lucid
     ( HtmlT
     , renderBS
     )
 
-data Page
-    = About
-    | Network
-    | Settings
-    | Wallet
-    | Addresses
-
-makePrisms ''Page
-
 page
     :: PageConfig
     -- ^ Page configuration
     -> Page
     -- ^ Current page
-    -> WalletPresent
-    -- ^ Wallet present
     -> RawHtml
-page c@PageConfig{..} p wp = RawHtml
+page c p = RawHtml
     $ renderBS
     $ runWHtml Deposit
     $ pageFromBodyH faviconLink c
     $ do
-        bodyH sseLink (headerH prefix p wp)
+        bodyH sseLink (headerH p)
             $ do
                 modalsH
                 case p of
@@ -106,16 +101,20 @@ page c@PageConfig{..} p wp = RawHtml
                     Wallet -> walletH
                     Addresses -> addressesH
 
-headerH :: Text -> Page -> WalletPresent -> Monad m => HtmlT m ()
-headerH prefix p wp =
+headerH :: Monad m => Page -> HtmlT m ()
+headerH p = sseH (navigationLink $ Just p) "header" ["wallet"]
+
+headerElementH :: Maybe Page -> WalletPresent -> Monad m => HtmlT m ()
+headerElementH p wp =
     navigationH
-        prefix $
-        [ (is _Wallet p, walletPageLink, "Wallet")
-        ]
-        <>
-        [(is _Addresses p, addressesPageLink, "Addresses") | isPresent wp]
-        <>
-        [ (is _Network p, networkPageLink, "Network")
-        , (is _Settings p, settingsPageLink, "Settings")
-        , (is _About p, aboutPageLink, "About")
-        ]
+        mempty
+        $ [(is' _Wallet, walletPageLink, "Wallet")]
+            <> [ (is' _Addresses, addressesPageLink, "Addresses")
+               | isPresent wp
+               ]
+            <> [ (is' _Network, networkPageLink, "Network")
+               , (is' _Settings, settingsPageLink, "Settings")
+               , (is' _About, aboutPageLink, "About")
+               ]
+  where
+    is' l = is (_Just . l) p

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -89,7 +89,6 @@ import Lucid
     , button_
     , class_
     , div_
-    , h5_
     , hr_
     , id_
     , p_
@@ -182,12 +181,10 @@ walletElementH :: (BL.ByteString -> Html ()) -> WalletPresent -> Html ()
 walletElementH alert = \case
     WalletPresent (WalletPublicIdentity xpub customers) -> do
         div_ [class_ "row mt-5 "] $ do
-            h5_ [class_ "text-center"] "Details"
             div_ [class_ "col"] $ record $ do
                 simpleField "Public Key" $ pubKeyH xpub
                 simpleField "Tracked Addresses" $ toHtml $ toText customers
         div_ [class_ "row mt-5"] $ do
-            h5_ [class_ "text-center"] "Administration"
             div_ [class_ "col"] $ do
                 deleteWalletButtonH
             div_ [id_ "delete-result"] mempty

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -14,9 +14,6 @@ import Cardano.Address.Derivation
 import Cardano.Wallet.Deposit.IO
     ( WalletPublicIdentity (..)
     )
-import Cardano.Wallet.Deposit.Read
-    ( Address
-    )
 import Cardano.Wallet.Deposit.REST
     ( ErrDatabase
     )
@@ -58,9 +55,6 @@ import Cardano.Wallet.UI.Deposit.API
     , walletPostMnemonicLink
     , walletPostXPubLink
     )
-import Cardano.Wallet.UI.Lib.Address
-    ( encodeMainnetAddress
-    )
 import Cardano.Wallet.UI.Type
     ( WHtml
     , WalletType (..)
@@ -97,7 +91,6 @@ import Lucid
 
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy.Char8 as BL
-import qualified Data.Text as T
 
 data WalletPresent
     = WalletPresent WalletPublicIdentity
@@ -125,24 +118,15 @@ walletH = sseH walletLink "wallet" ["wallet"]
 base64 :: ByteString -> ByteString
 base64 = convertToBase Base64
 
-customerAddressH :: Monad m => Address -> HtmlT m ()
-customerAddressH addr = div_ [class_ "d-flex justify-content-end"] $ do
-    div_ (copyableHidden "address") $ toHtml encodedAddr
-    div_ [class_ ""] $ toHtml addrShortened
-    div_ [class_ "ms-1"] $ copyButton "address"
-  where
-    encodedAddr = encodeMainnetAddress addr
-    addrShortened =
-        T.take 10 (T.drop 5 encodedAddr)
-            <> " .. "
-            <> T.takeEnd 10 encodedAddr
-
 pubKeyH :: Monad m => XPub -> HtmlT m ()
 pubKeyH xpub = div_ [class_ "d-flex justify-content-end"] $ do
     div_ (copyableHidden "public_key") $ toHtml xpubByteString
-    div_ [class_ ""] $ toHtml $ headAndTail 4 $ B8.dropEnd 1 xpubByteString
-    div_ [class_ "ms-1"]
-        $ copyButton "public_key"
+    div_ [class_ "d-block d-lg-none"]
+        $ toHtml
+        $ headAndTail 5
+        $ B8.dropEnd 1 xpubByteString
+    div_ [class_ "d-none d-lg-block"] $ toHtml xpubByteString
+    div_ [class_ "ms-1"] $ copyButton "public_key"
   where
     xpubByteString = base64 $ xpubToBytes xpub
 

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Wallet.hs
@@ -29,10 +29,7 @@ import Cardano.Wallet.UI.Common.Html.Copy
     )
 import Cardano.Wallet.UI.Common.Html.Htmx
     ( hxDelete_
-    , hxPost_
     , hxSwap_
-    , hxTarget_
-    , hxTrigger_
     )
 import Cardano.Wallet.UI.Common.Html.Lib
     ( dataBsDismiss_
@@ -54,8 +51,7 @@ import Cardano.Wallet.UI.Common.Html.Pages.Wallet
     , newWalletFromXPubH
     )
 import Cardano.Wallet.UI.Deposit.API
-    ( customerAddressLink
-    , walletDeleteLink
+    ( walletDeleteLink
     , walletDeleteModalLink
     , walletLink
     , walletMnemonicLink
@@ -96,17 +92,8 @@ import Lucid
     , h5_
     , hr_
     , id_
-    , input_
-    , min_
-    , name_
     , p_
     , section_
-    , type_
-    , value_
-    )
-import Lucid.Html5
-    ( max_
-    , step_
     )
 
 import qualified Data.ByteString.Char8 as B8
@@ -121,6 +108,10 @@ data WalletPresent
     | WalletInitializing
     | WalletClosing
 
+isPresent :: WalletPresent -> Bool
+isPresent = \case
+    WalletPresent _ -> True
+    _ -> False
 instance Show WalletPresent where
     show (WalletPresent x) = "WalletPresent: " <> show x
     show WalletAbsent = "WalletAbsent"
@@ -190,23 +181,6 @@ deleteWalletModalH =
 walletElementH :: (BL.ByteString -> Html ()) -> WalletPresent -> Html ()
 walletElementH alert = \case
     WalletPresent (WalletPublicIdentity xpub customers) -> do
-        div_ [class_ "row mt-5"] $ do
-            h5_ [class_ "text-center"] "Addresses"
-            div_ [class_ "col"] $ record $ do
-                simpleField "Customer Number"
-                    $ input_
-                        [ type_ "number"
-                        , hxTarget_ "#customer-address"
-                        , class_ "form-control"
-                        , hxTrigger_ "load, change"
-                        , hxPost_ $ linkText customerAddressLink
-                        , min_ "0"
-                        , max_ $ toText $ customers - 1
-                        , step_ "1"
-                        , name_ "customer"
-                        , value_ "0"
-                        ]
-                simpleField "Address" $ div_ [id_ "customer-address"] mempty
         div_ [class_ "row mt-5 "] $ do
             h5_ [class_ "text-center"] "Details"
             div_ [class_ "col"] $ record $ do

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Server.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Server.hs
@@ -102,15 +102,13 @@ import Cardano.Wallet.UI.Deposit.Html.Pages.Addresses
     )
 import Cardano.Wallet.UI.Deposit.Html.Pages.Page
     ( Page (..)
+    , headerElementH
     , page
     )
 import Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
     ( customerAddressH
     , deleteWalletModalH
     , walletElementH
-    )
-import Control.Monad
-    ( (>=>)
     )
 import Control.Monad.Trans
     ( MonadIO (..)
@@ -180,8 +178,13 @@ serveUI tr ul env dbDir config _ nl bs =
         :<|> wsl (\_l -> pure $ renderSmoothHtml deleteWalletModalH)
         :<|> (\c -> wsl (\l -> getCustomerAddress l (renderSmoothHtml . customerAddressH) alert c))
         :<|> wsl (\l -> getAddresses l (renderSmoothHtml . addressElementH alertH))
+        :<|> serveNavigation -- (\l -> getAddresses l (renderSmoothHtml . headerElementH _ _ _))
   where
-    ph p = wsl $ walletPresence >=> pure . page config p
+    serveNavigation mp = wsl $ \l -> do
+        wp <- walletPresence l
+
+        pure $ renderSmoothHtml $ headerElementH mp wp
+    ph p = wsl $ \_ -> pure $ page config p
     ok _ = renderHtml . rogerH @Text $ "ok"
     alert = renderHtml . alertH
     nid = networkIdVal (sNetworkId @n)

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Server.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Server.hs
@@ -99,6 +99,7 @@ import Cardano.Wallet.UI.Deposit.Handlers.Wallet
     )
 import Cardano.Wallet.UI.Deposit.Html.Pages.Addresses
     ( addressElementH
+    , customerAddressH
     )
 import Cardano.Wallet.UI.Deposit.Html.Pages.Page
     ( Page (..)
@@ -106,8 +107,7 @@ import Cardano.Wallet.UI.Deposit.Html.Pages.Page
     , page
     )
 import Cardano.Wallet.UI.Deposit.Html.Pages.Wallet
-    ( customerAddressH
-    , deleteWalletModalH
+    ( deleteWalletModalH
     , walletElementH
     )
 import Control.Monad.Trans


### PR DESCRIPTION
This PR separates out the address query from the wallet details. This makes the navigation bar depends on the resource state.

ADP-3456