### PR TITLE
[ADP-3458] Collect 100 artifacts indices during CI release

### DIFF
--- a/scripts/buildkite/release/push-artifacts.sh
+++ b/scripts/buildkite/release/push-artifacts.sh
@@ -22,7 +22,7 @@ artifact() {
     local artifact_name=$1
     # shellcheck disable=SC2155
     local artifact_value=$(curl -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-        -X GET "https://api.buildkite.com/v2/organizations/cardano-foundation/pipelines/cardano-wallet/builds/$main_build/artifacts" \
+        -X GET "https://api.buildkite.com/v2/organizations/cardano-foundation/pipelines/cardano-wallet/builds/$main_build/artifacts?per_page=100" \
         | jq -r ".[] | select(.filename == \"$artifact_name\") \
         | .download_url")
     curl -H "Authorization: Bearer $BUILDKITE_API_TOKEN" -L \


### PR DESCRIPTION
This PR solves a CI issue where we weren't collecting all the artifacts and so breaking the release process. ATM 71 artifacts are available. The `per_page` max is 100. After that we will have to use paging

ADP-3458