### PR TITLE
[ADP-3392] Add run scripts and test for preview network

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -246,7 +246,8 @@ steps:
       depends_on:
         - linux-preprod-full-sync-block
       timeout_in_minutes: 240
-      if: 0 == 1 # Disabled until mithril builds again
+      soft_fail:
+        - exit_status: 45
       command: |
         cd run/preprod/nix
         rm -rf logs

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -145,7 +145,6 @@ steps:
 
     - label: Private Network Full Sync
       timeout_in_minutes: 30
-      if: 0 == 1 # Disabled until new mihtril snapshots
       depends_on: []
       command: |
         rm -rf run/private/nix/logs
@@ -164,7 +163,6 @@ steps:
 
     - label: Mainnet Boot Sync
       timeout_in_minutes: 2
-      if: 0 == 1 # Disabled until mithril builds again
       depends_on: []
       command: |
         cd run/mainnet/nix
@@ -190,7 +188,9 @@ steps:
 
     - label: Mainnet Boot Sync with Mithril
       timeout_in_minutes: 120
-      if: 0 == 1 # Disabled until new mihtril snapshots
+      # mithril is not compiling with nix ATM
+      soft_fail :
+        - exit_status: 44
       depends_on:
         - linux-mainnet-full-sync-block
       command: |
@@ -222,7 +222,6 @@ steps:
       depends_on:
         - linux-sanchonet-full-sync-block
       timeout_in_minutes: 120
-      if: 0 == 1 # Disabled until mithril builds again
       command: |
         rm -rf run/sanchonet/nix/logs
         mkdir -p run/sanchonet/nix/logs

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -772,6 +772,18 @@ steps:
           system: x86_64-linux
         env:
           USE_LOCAL_IMAGE: true
+        
+      - label: Preview Network Full Sync
+        timeout_in_minutes: 60
+        command: |
+          cd run/preview/docker
+          export WALLET_TAG=$(buildkite-agent meta-data get "release-cabal-version")
+          rm -rf databases
+          ./run.sh sync
+        agents:
+          system: x86_64-linux
+        env:
+          USE_LOCAL_IMAGE: true
 
       - label: Sanchonet Full Sync
         timeout_in_minutes: 240

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -161,6 +161,26 @@ steps:
         CLEANUP_DB: true
         NETWORK: testnet
 
+    - label: Preview Network Boot Sync
+      timeout_in_minutes: 2
+      depends_on: []
+      command: |
+        cd run/preview/nix
+        rm -rf logs
+        mkdir -p logs
+        rm -rf databases
+        ./run.sh sync
+      artifact_paths:
+        - "./run/private/nix/logs/*"
+      agents:
+        system: x86_64-linux
+      env:
+        SUCCESS_STATUS: syncing
+        NODE_LOGS_FILE: ./logs/node.log
+        WALLET_LOGS_FILE: ./logs/wallet.log
+        CLEANUP_DB: true
+        NETWORK: testnet
+
     - label: Mainnet Boot Sync
       timeout_in_minutes: 2
       depends_on: []

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -767,6 +767,8 @@ steps:
 
       - label: Preprod Full Sync
         timeout_in_minutes: 240
+        soft_fail:
+          - exit_status: 45
         command: |
           cd run/preprod/docker
           export WALLET_TAG=$(buildkite-agent meta-data get "release-cabal-version")

--- a/configs/cardano/preview/download.sh
+++ b/configs/cardano/preview/download.sh
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 rm ./*.json
-curl https://book.play.dev.cardano.org/environments-pre/preview/config.json > config.json
-curl https://book.play.dev.cardano.org/environments-pre/preview/conway-genesis.json  > conway-genesis.json
-curl https://book.play.dev.cardano.org/environments-pre/preview/topology.json  > topology.json
-curl https://book.play.dev.cardano.org/environments-pre/preview/byron-genesis.json  > byron-genesis.json
-curl https://book.play.dev.cardano.org/environments-pre/preview/shelley-genesis.json  > shelley-genesis.json
-curl https://book.play.dev.cardano.org/environments-pre/preview/alonzo-genesis.json  > alonzo-genesis.json
+curl https://book.play.dev.cardano.org/environments/preview/config.json > config.json
+curl https://book.play.dev.cardano.org/environments/preview/conway-genesis.json  > conway-genesis.json
+curl https://book.play.dev.cardano.org/environments/preview/topology.json  > topology.json
+curl https://book.play.dev.cardano.org/environments/preview/byron-genesis.json  > byron-genesis.json
+curl https://book.play.dev.cardano.org/environments/preview/shelley-genesis.json  > shelley-genesis.json
+curl https://book.play.dev.cardano.org/environments/preview/alonzo-genesis.json  > alonzo-genesis.json

--- a/lib/exe/lib/Cardano/Wallet/Application/CLI.hs
+++ b/lib/exe/lib/Cardano/Wallet/Application/CLI.hs
@@ -1527,13 +1527,12 @@ portOption = optionT $ mempty
     <> value (Port 8_090)
     <> showDefaultWith showT
 
--- | [--deposit-port=INT], default: 8093
+-- | [--deposit-port=INT]
 depositPortOption :: Parser (Port "Deposit Wallet")
 depositPortOption = optionT $ mempty
     <> long "deposit-port"
     <> metavar "INT"
     <> help "port used for serving the deposit wallet JSON API."
-    <> value (Port 8_093)
     <> showDefaultWith showT
 
 -- | [--shutdown-handler]

--- a/run/common/nix/run.sh
+++ b/run/common/nix/run.sh
@@ -1,9 +1,9 @@
-#! /usr/bin/env -S nix shell '.#cardano-wallet' '.#cardano-node' '.#cardano-cli' 'github:input-output-hk/mithril' --command bash
+#! /usr/bin/env -S nix shell '.#cardano-wallet' '.#cardano-node' '.#cardano-cli'  --command bash
 # shellcheck shell=bash
 
 # set -euox pipefail
 set -euo pipefail
-cardano-wallet serve --help-tracing
+
 usage() {
     echo "Usage: $0 [sync]"
     echo "  sync: Sync the service and wait for it to be ready"
@@ -17,8 +17,6 @@ fi
 
 # shellcheck disable=SC1091
 source .env
-
-
 
 mkdir -p ./databases
 
@@ -63,6 +61,7 @@ LOCAL_NODE_LOGS_FILE=./node.log
 NODE_LOGS_FILE="${NODE_LOGS_FILE:=$LOCAL_NODE_LOGS_FILE}"
 
 cleanup() {
+    exit_status=$?
     echo "Cleaning up..."
     kill "${NODE_ID-}" || echo "Failed to kill node"
     kill "${WALLET_ID-}" || echo "Failed to kill wallet"
@@ -73,6 +72,13 @@ cleanup() {
         rm -rf "${WALLET_DB:?}"/* || echo "Failed to clean wallet db"
     fi
     trap - ERR INT EXIT
+    exit $exit_status
+}
+
+mithril() {
+    # shellcheck disable=SC2048
+    # shellcheck disable=SC2086
+    nix shell "github:input-output-hk/mithril" -c $*
 }
 
 # Trap the cleanup function on exit
@@ -89,8 +95,9 @@ if [[ -z ${NO_NODE-} ]]; then
             rm -rf "${NODE_DB:?}"/*
             export AGGREGATOR_ENDPOINT
             export GENESIS_VERIFICATION_KEY
-            digest=$(mithril-client cdb  snapshot list --json | jq -r .[0].digest)
-            (cd "${NODE_DB}" && mithril-client cdb download "$digest")
+            mithril echo "mithril is available" || exit 44
+            digest=$(mithril mithril-client cdb  snapshot list --json | jq -r .[0].digest)
+            (cd "${NODE_DB}" && mithril mithril-client cdb download "$digest")
             (cd "${NODE_DB}" && mv db/* . && rmdir db)
     fi
 

--- a/run/common/nix/run.sh
+++ b/run/common/nix/run.sh
@@ -122,6 +122,7 @@ else
 fi
 
 
+magic=$(jq .networkMagic $LOCAL_NODE_CONFIGS/shelley-genesis.json)
 ##### Wait until the node is ready #####
 
 # Capture the start time
@@ -134,7 +135,7 @@ timeout_duration=3600
 while true; do
     # Execute the command
     failure_status=0
-    cardano-cli ping -u "${NODE_SOCKET_PATH}" 2>/dev/null || failure_status=1
+    cardano-cli ping -m "${magic}" -u "${NODE_SOCKET_PATH}" 2>/dev/null || failure_status=1
     # Check if the command succeeded
     # shellcheck disable=SC2181
     if [[ "$failure_status" -eq 0 ]]; then

--- a/run/common/snapshot.sh
+++ b/run/common/snapshot.sh
@@ -45,7 +45,7 @@ if [ -n "${LINK_TEST:-}" ]; then
     exit 0
 fi
 
-curl -SL "$SNAPSHOT_URL" | lz4 -c -d - | tar -x -C "$NODE_DB"
+curl -SL "$SNAPSHOT_URL"  | lz4 -c -d - | tar -x -C "$NODE_DB" || exit 45
 
 mv -f "$NODE_DB"/db/* "$NODE_DB"/
 rm -rf "$NODE_DB"/db

--- a/run/preview/docker/.env
+++ b/run/preview/docker/.env
@@ -1,0 +1,1 @@
+NETWORK="preview"

--- a/run/preview/docker/configs
+++ b/run/preview/docker/configs
@@ -1,0 +1,1 @@
+../../../configs/cardano/preview/

--- a/run/preview/docker/docker-compose.yml
+++ b/run/preview/docker/docker-compose.yml
@@ -1,0 +1,1 @@
+../../common/docker/docker-compose.yml

--- a/run/preview/docker/run.sh
+++ b/run/preview/docker/run.sh
@@ -1,0 +1,1 @@
+../../common/docker/run.sh

--- a/run/preview/nix/.env
+++ b/run/preview/nix/.env
@@ -1,0 +1,1 @@
+NETWORK="preview"

--- a/run/preview/nix/configs
+++ b/run/preview/nix/configs
@@ -1,0 +1,1 @@
+../../../configs/cardano/preview/

--- a/run/preview/nix/run-node.sh
+++ b/run/preview/nix/run-node.sh
@@ -1,0 +1,1 @@
+../../common/nix/run-node.sh

--- a/run/preview/nix/run-wallet.sh
+++ b/run/preview/nix/run-wallet.sh
@@ -1,0 +1,1 @@
+../../common/nix/run-wallet.sh

--- a/run/preview/nix/run.sh
+++ b/run/preview/nix/run.sh
@@ -1,0 +1,1 @@
+../../common/nix/run.sh

--- a/run/private/nix/run-node.sh
+++ b/run/private/nix/run-node.sh
@@ -1,0 +1,1 @@
+../../common/nix/run-node.sh

--- a/run/private/nix/run-wallet.sh
+++ b/run/private/nix/run-wallet.sh
@@ -1,0 +1,1 @@
+../../common/nix/run-wallet.sh


### PR DESCRIPTION
- Re-enable network synchronization CI checks by confining compilation of mithril where necessary. Mithril is not compiling ATM. The mithril test will soft fail in case of compilation error
- Re-enable preprod full sync based on snapshot. Will soft fail if the snapshot is broken
- Add a nix CI job to test we can connect to `preview`
- Add a docker CI job to test we can full sync with `preview`
- Remove 8093 as a default port for the deposit wallet

ADP-3392