### PR TITLE
[ADP-3458] Keep first occurrence of artifacts in release CI jobs

### DIFF
--- a/scripts/buildkite/release/push-artifacts.sh
+++ b/scripts/buildkite/release/push-artifacts.sh
@@ -23,7 +23,7 @@ artifact() {
     # shellcheck disable=SC2155
     local artifact_value=$(curl -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
         -X GET "https://api.buildkite.com/v2/organizations/cardano-foundation/pipelines/cardano-wallet/builds/$main_build/artifacts?per_page=100" \
-        | jq -r ".[] | select(.filename == \"$artifact_name\") \
+        | jq -r " [.[] | select(.filename == \"$artifact_name\")][0] \
         | .download_url")
     curl -H "Authorization: Bearer $BUILDKITE_API_TOKEN" -L \
         -o "artifacts/$artifact_name" \


### PR DESCRIPTION
This PR works around a bug I introduced fixing the missing artifact bug. 
The `per_page=100` (for the first time) revealed there are 2 artifacts for linux exe. They are there because passing artifacts requires to declare them also on the artifact consumer job and then the API shows them as 2 entries.

ADP-3458