### PR TITLE
[ADP-3453] Soft fail `wallet-e2e` CI test as flaky

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -117,6 +117,8 @@ steps:
 
     - label: Run Haskell E2E Tests (linux)
       command: 'nix develop --command bash -c "just e2e-local"'
+      soft_fail:
+        - exit_status: 130
       timeout_in_minutes: 5
       agents:
         system: ${linux}


### PR DESCRIPTION
This PR exclude the haskell-e2e CI (mostly an empty box) from CI requirements to pass, by making it a soft failer.