### PR TITLE
[ADP-3468] Fix timeout of CI preview sync job with docker setup

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -772,9 +772,9 @@ steps:
           system: x86_64-linux
         env:
           USE_LOCAL_IMAGE: true
-        
-      - label: Preview Network Full Sync
-        timeout_in_minutes: 60
+
+      - label: Preview Network Boot Sync
+        timeout_in_minutes: 30
         command: |
           cd run/preview/docker
           export WALLET_TAG=$(buildkite-agent meta-data get "release-cabal-version")
@@ -783,6 +783,7 @@ steps:
         agents:
           system: x86_64-linux
         env:
+          SUCCESS_STATUS: syncing
           USE_LOCAL_IMAGE: true
 
       - label: Sanchonet Full Sync


### PR DESCRIPTION
This PR makes sure we do not wait 7 hours to sync preview node when testing preview network with docker setup

ADP-3468