### PR TITLE
[ADP-3468] Bump node dependency to 9.2.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -54,7 +54,7 @@ index-state: 2024-09-23T00:00:00Z
 
 index-state:
   , hackage.haskell.org 2024-09-23T00:00:00Z
-  , cardano-haskell-packages 2024-09-20T19:39:13Z
+  , cardano-haskell-packages 2024-09-23T21:46:49Z
 
 packages:
   lib/address-derivation-discovery
@@ -187,7 +187,7 @@ constraints:
   , io-classes >= 1.4
   , io-classes -asserts
 
-  , ouroboros-network ^>= 0.17
+  , ouroboros-network ^>= 0.17.1.1
 
 
 -- Related to: https://github.com/haskell/cabal/issues/8554

--- a/cabal.project
+++ b/cabal.project
@@ -187,7 +187,7 @@ constraints:
   , io-classes >= 1.4
   , io-classes -asserts
 
-  , ouroboros-network ^>= 0.17.1.1
+  , ouroboros-network == 0.17.1.1
 
 
 -- Related to: https://github.com/haskell/cabal/issues/8554

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     "CHaP_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1725978043,
-        "narHash": "sha256-3AwgQ308g74rISxUlbzQRX3At0trVoH836vBwkcFFYg=",
+        "lastModified": 1727170555,
+        "narHash": "sha256-kxB/xjSjqym5kKYDw/CZMb6O1OfCVWRjjsuqyWABd0w=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "ce5ba82d474225506523e66a4050718de7e2b3fe",
+        "rev": "d8beaf7e30330f8a70e626f63a5b47d1999fbf4b",
         "type": "github"
       },
       "original": {
@@ -319,16 +319,16 @@
         "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1726677789,
-        "narHash": "sha256-utAO4ZP9EAW4LdMT/hdMoykwT/h9gizoVvCbmYfAZSQ=",
+        "lastModified": 1727221818,
+        "narHash": "sha256-i582YpBy+hBth73JqfcjGFsJrTQeDG0NJ7vN8JLWeoI=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "341ea87ba3b4936188f8c2d4f09bbf1976a7926e",
+        "rev": "5d3da8ac771ee5ed424d6c78473c11deabb7a1f3",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "9.2.0",
+        "ref": "9.2.1",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1726886523,
-        "narHash": "sha256-AEcPggMhxKSPlQPxciYiuJ9RRSqvszaZQQq5JEGICwc=",
+        "lastModified": 1727364445,
+        "narHash": "sha256-i/m1fmNx0BQbRvHz9ZbY6t0I5BGqwyCA/Jd/BL1Lp0Q=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "110f4bd9adf3809fa00af7807fb7f3edbf3d6538",
+        "rev": "a28f93d778031ddabda3ac1aef9616ae933eea82",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -142,7 +142,7 @@
       flake = false;
     };
     customConfig.url = "github:input-output-hk/empty-flake";
-    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=9.2.0";
+    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=9.2.1";
   };
 
   outputs = { self, nixpkgs, nixpkgs-unstable, hostNixpkgs, flake-utils,


### PR DESCRIPTION
This pull request updates 
- the ouroboros-network dependency to version 0.17.1.1.
- the node runtime dependency to 9.2.1

ADP-3468