### PR TITLE
[ADP-3344] Use `Read.Block` instead of mock `Block` type in Deposit Wallet

### DIFF
--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -85,7 +85,7 @@ data WalletBootEnv m = WalletBootEnv
         -- ^ Logger for the wallet.
         , genesisData :: Read.GenesisData
         -- ^ Genesis data for the wallet.
-        , networkEnv :: Network.NetworkEnv m Read.Block
+        , networkEnv :: Network.NetworkEnv m (Read.EraValue Read.Block)
         -- ^ Network environment for the wallet.
     }
 
@@ -221,7 +221,8 @@ getCustomerHistories
 getCustomerHistories a w =
     Wallet.getCustomerHistories a <$> readWalletState w
 
-rollForward :: WalletInstance -> NonEmpty Read.Block -> tip -> IO ()
+rollForward
+    :: WalletInstance -> NonEmpty (Read.EraValue Read.Block) -> tip -> IO ()
 rollForward w blocks _nodeTip =
     onWalletState w
         $ Delta.update

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
@@ -48,7 +48,7 @@ import qualified Cardano.Wallet.Deposit.Write as Write
 ------------------------------------------------------------------------------}
 newNetworkEnvMock
     :: (MonadDelay m, MonadSTM m)
-    => m (NetworkEnv m Read.Block)
+    => m (NetworkEnv m (Read.Block Read.Conway))
 newNetworkEnvMock = do
     mchain <- newTVarIO []
     mtip <- newTVarIO Read.GenesisPoint

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Type.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Type.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NamedFieldPuns #-}
 module Cardano.Wallet.Deposit.IO.Network.Type
     ( NetworkEnv (..)
+    , mapBlock
     , ChainFollower (..)
     ) where
 
@@ -8,6 +10,7 @@ import Prelude
 
 import Cardano.Wallet.Network
     ( ChainFollower (..)
+    , mapChainFollower
     )
 import Control.Tracer
     ( Tracer
@@ -43,6 +46,17 @@ data NetworkEnv m block = NetworkEnv
         :: Write.Tx -> m (Either ErrPostTx ())
         -- ^ Post a transaction to the Cardano network.
 
+    }
+
+mapBlock
+    :: Functor m
+    => (block1 -> block2)
+    -> NetworkEnv m block1
+    -> NetworkEnv m block2
+mapBlock f NetworkEnv{chainSync,postTx} = NetworkEnv
+    { chainSync = \tr follower ->
+        chainSync tr (mapChainFollower id id id (fmap f) follower)
+    , postTx = postTx
     }
 
 {-------------------------------------------------------------------------------

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -197,7 +197,7 @@ rollForwardUTxO isOurs block u =
     UTxOHistory.appendBlock slot deltaUTxO u
   where
     (deltaUTxO,_) = Balance.applyBlock isOurs block (UTxOHistory.getUTxO u)
-    slot = Read.slotNo . Read.blockHeaderBody $ Read.blockHeader block
+    slot = Read.getEraSlotNo $ Read.getEraBHeader block
 
 rollBackward
     :: Read.ChainPoint

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -175,11 +175,13 @@ fromXPubAndGenesis xpub knownCustomerCount _ =
 getWalletTip :: WalletState -> Read.ChainPoint
 getWalletTip = error "getWalletTip"
 
-rollForwardMany :: NonEmpty Read.Block -> WalletState -> WalletState
+rollForwardMany
+    :: NonEmpty (Read.EraValue Read.Block) -> WalletState -> WalletState
 rollForwardMany blocks w = foldl' (flip rollForwardOne) w blocks
 
-rollForwardOne :: Read.Block -> WalletState -> WalletState
-rollForwardOne block w =
+rollForwardOne
+    :: Read.EraValue Read.Block -> WalletState -> WalletState
+rollForwardOne (Read.EraValue block) w =
     w
         { utxoHistory = rollForwardUTxO isOurs block (utxoHistory w)
         , submissions = Delta.apply (Sbm.rollForward block) (submissions w)
@@ -189,7 +191,8 @@ rollForwardOne block w =
     isOurs = Address.isOurs (addresses w)
 
 rollForwardUTxO
-    :: (Address -> Bool) -> Read.Block -> UTxOHistory -> UTxOHistory
+    :: Read.IsEra era
+    => (Address -> Bool) -> Read.Block era -> UTxOHistory -> UTxOHistory
 rollForwardUTxO isOurs block u =
     UTxOHistory.appendBlock slot deltaUTxO u
   where

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Balance.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Balance.hs
@@ -64,7 +64,7 @@ applyBlock isOurs block u0 =
   where
     (dus, u1) =
         mapAccumL' (applyTx isOurs) u0
-            $ Read.transactions block
+            $ Read.getEraTransactions block
 
 {-----------------------------------------------------------------------------
     Helpers

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Balance.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Balance.hs
@@ -57,7 +57,8 @@ availableUTxO u pending =
 --
 -- Returns both a delta and the new value.
 applyBlock
-    :: IsOurs Read.Address -> Read.Block -> UTxO -> (DeltaUTxO, UTxO)
+    :: Read.IsEra era
+    => IsOurs Read.Address -> Read.Block era -> UTxO -> (DeltaUTxO, UTxO)
 applyBlock isOurs block u0 =
     (DeltaUTxO.concat $ reverse dus, u1)
   where

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Submissions.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Submissions.hs
@@ -62,7 +62,7 @@ add = undefined
 listInSubmission :: TxSubmissions -> Set Read.Tx
 listInSubmission = undefined
 
-rollForward :: Read.Block -> DeltaTxSubmissions
+rollForward :: Read.Block era -> DeltaTxSubmissions
 rollForward block = [ Sbm.RollForward tip txs ]
   where
     tip = undefined block

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -8,7 +8,11 @@
 --
 -- TODO: Match this up with the @Read@ hierarchy.
 module Cardano.Wallet.Deposit.Read
-    ( Network (..)
+    ( Read.IsEra
+    , Read.EraValue (..)
+    , Read.Conway
+
+    , Network (..)
     , Read.SlotNo
     , Read.ChainPoint (..)
     , Slot
@@ -129,11 +133,10 @@ type TxWitness = ()
 type BlockNo = Natural
 
 -- type Block = O.CardanoBlock O.StandardCrypto
-data Block = Block
+data Block era = Block
     { blockHeader :: BHeader
-    , transactions :: [Read.Tx Read.Conway]
+    , transactions :: [Read.Tx era]
     }
-    deriving (Eq, Show)
 
 data BHeader = BHeader
     { blockHeaderBody :: BHBody
@@ -154,7 +157,7 @@ data BHBody = BHBody
 type HashHeader = Read.RawHeaderHash
 type HashBBody = ()
 
-getChainPoint :: Block -> Read.ChainPoint
+getChainPoint :: Read.IsEra era => Block era -> Read.ChainPoint
 getChainPoint block =
     Read.BlockPoint
         { Read.slotNo = slot
@@ -167,7 +170,7 @@ getChainPoint block =
     slot = slotNo bhBody
 
 -- | Create a new block from a sequence of transaction.
-mockNextBlock :: Read.ChainPoint -> [Read.Tx Read.Conway] -> Block
+mockNextBlock :: Read.ChainPoint -> [Read.Tx Read.Conway] -> Block Read.Conway
 mockNextBlock old txs =
     Block
         { blockHeader = BHeader

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
@@ -35,6 +35,7 @@ import Cardano.Wallet.Deposit.IO.Network.Mock
     )
 import Cardano.Wallet.Deposit.IO.Network.Type
     ( NetworkEnv (..)
+    , mapBlock
     )
 import Cardano.Wallet.Deposit.Pure
     ( BIP32Path
@@ -68,14 +69,14 @@ assert False = error "Assertion failed!"
 -- | Environment for scenarios.
 data ScenarioEnv = ScenarioEnv
     { genesisData :: Read.GenesisData
-    , networkEnv :: NetworkEnv IO Read.Block
+    , networkEnv :: NetworkEnv IO (Read.EraValue Read.Block)
     , faucet :: Faucet
     }
 
 -- | Acquire and release a mock environment for a blockchain
 withScenarioEnvMock :: (ScenarioEnv -> IO a) -> IO a
 withScenarioEnvMock action = do
-    networkEnv <- newNetworkEnvMock
+    networkEnv <- mapBlock Read.EraValue <$> newNetworkEnvMock
     action
         $ ScenarioEnv
             { genesisData = error "TODO: Mock Genesis Data"


### PR DESCRIPTION
This pull request replaces the mock `Block` type in the Deposit Wallet with the real thing, `Read.Block`.

### Comments

* After this pull request, we can connect the Deposit Wallet to a local cluster.
* In order to connect to one of the public test networks, we need to implement the `Testnet` tag in `Address`.

### Issue number

ADP-3344