### PR TITLE
[ADP-3344] Support `Testnet` addresses in Deposit Wallet

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -157,8 +157,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/cardano-foundation/cardano-wallet-agda
-    tag: e2684108476c4c5f80a9d7d095e3bc201b7c3484
-    --sha256: 1bhldh54myqh4kbb02w2si5l4rf3dwblz75234nmg6w5319b7vm7
+    tag: 45aa257d25871b667cac6fb85e17ceeeac72f421
+    --sha256: 061hdzgskhp2cc4y8841v27zwkgczsx03xmca1a4aqfs0p600c98
     subdir:
       lib/customer-deposit-wallet-pure
       lib/cardano-wallet-read

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -57,7 +57,6 @@ library
     , bytestring
     , cardano-crypto
     , cardano-ledger-api
-    , cardano-ledger-byron
     , cardano-strict-containers
     , cardano-wallet
     , cardano-wallet-network-layer

--- a/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
@@ -240,7 +240,7 @@ findTheDepositWalletOnDisk dir action = do
                             fromXPubAndGenesis
                                 identity
                                 (fromIntegral @Int users)
-                                (error "FIXME")
+                                Read.mockGenesisDataMainnet
                     store <- newStore
                     writeS store state
                     action $ Right store

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -12,7 +12,6 @@ module Cardano.Wallet.Deposit.Read
     , Read.EraValue (..)
     , Read.Conway
 
-    , Network (..)
     , Read.SlotNo
     , Read.ChainPoint (..)
     , Slot
@@ -50,6 +49,9 @@ module Cardano.Wallet.Deposit.Read
     , GenesisData
     , GenesisHash
 
+    , Read.NetworkId (Read.Mainnet, Read.Testnet)
+    , Read.getNetworkId
+
     -- * Dummy Values useful for testing
     , dummyAddress
     ) where
@@ -83,7 +85,6 @@ import Data.Word
     ( Word8
     )
 
-import qualified Cardano.Chain.Genesis as Byron
 import qualified Cardano.Wallet.Read as Read
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -93,7 +94,6 @@ import qualified Data.ByteString.Short as SBS
     Type definitions
     with dummies
 ------------------------------------------------------------------------------}
-data Network = Testnet | Mainnet
 
 -- | Synonym for readability.
 -- The ledger specifications define @Addr@.
@@ -143,11 +143,3 @@ mockNextBlock old txs =
     slotNumber = case old of
         Read.GenesisPoint -> Read.SlotNo 0
         Read.BlockPoint{slotNo = n} -> succ n
-
-{-----------------------------------------------------------------------------
-    Genesis
-------------------------------------------------------------------------------}
-
--- GenesisData is not part of the ledger specification proper
-type GenesisData = Byron.GenesisData
-type GenesisHash = Byron.GenesisHash

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -46,8 +46,9 @@ module Cardano.Wallet.Deposit.Read
     , mockNextBlock
     , Read.mockRawHeaderHash
 
-    , GenesisData
-    , GenesisHash
+    , Read.GenesisData
+    , Read.GenesisHash
+    , Read.mockGenesisDataMainnet
 
     , Read.NetworkId (Read.Mainnet, Read.Testnet)
     , Read.getNetworkId

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
@@ -79,7 +79,7 @@ withScenarioEnvMock action = do
     networkEnv <- mapBlock Read.EraValue <$> newNetworkEnvMock
     action
         $ ScenarioEnv
-            { genesisData = error "TODO: Mock Genesis Data"
+            { genesisData = Read.mockGenesisDataMainnet
             , networkEnv
             , faucet = Faucet{xprv = error "TODO: Faucet xprv"}
             }

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/PureSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/PureSpec.hs
@@ -115,7 +115,7 @@ testXPub =
 ------------------------------------------------------------------------------}
 
 testGenesis :: Read.GenesisData
-testGenesis = undefined
+testGenesis = Read.mockGenesisDataMainnet
 
 spendOneTxOut :: UTxO.UTxO -> Read.Tx
 spendOneTxOut utxo =

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/RESTSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/RESTSpec.hs
@@ -52,7 +52,7 @@ import qualified Cardano.Wallet.Deposit.Read as Read
 import qualified Data.ByteString.Char8 as B8
 
 fakeBootEnv :: WalletBootEnv IO
-fakeBootEnv = WalletBootEnv undefined undefined undefined
+fakeBootEnv = WalletBootEnv nullTracer Read.mockGenesisDataMainnet undefined
 
 xpub :: XPub
 xpub =


### PR DESCRIPTION
This pull request adds support for Testnet addresses in the Deposit Wallet.

The fact whether we are in Mainnet or a Testnet is computed from `GenesisData`.

### Issue Number

ADP-3344