### PR TITLE
[ADP-3344] Implement `ChainFollower` for Deposit Wallet

### DIFF
--- a/lib/benchmarks/exe/restore-bench.hs
+++ b/lib/benchmarks/exe/restore-bench.hs
@@ -369,8 +369,8 @@ import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.Address.Derivation.Byron as Byron
 import qualified Cardano.Wallet.Address.Derivation.Shelley as Shelley
 import qualified Cardano.Wallet.DB.Sqlite.Migration.Old as Sqlite
+import qualified Cardano.Wallet.Network.Checkpoints.Policy as CP
 import qualified Cardano.Wallet.Primitive.Types as W
-import qualified Cardano.Wallet.Primitive.Types.Checkpoints.Policy as CP
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -50,6 +50,9 @@ import Cardano.Wallet.Deposit.Pure
 import Cardano.Wallet.Deposit.Read
     ( Address
     )
+import Cardano.Wallet.Network.Checkpoints.Policy
+    ( defaultPolicy
+    )
 import Control.Tracer
     ( Tracer
     , contramap
@@ -175,8 +178,13 @@ withWalletDBVar
         trChainSync = contramap (\_ -> WalletLogDummy) logger
         chainFollower w =
             Network.ChainFollower
-                { checkpointPolicy = undefined
-                , readChainPoints = undefined
+                { checkpointPolicy = defaultPolicy
+                , readChainPoints = do
+                    walletTip <- Wallet.getWalletTip <$> readWalletState w
+                    pure
+                        [ walletTip
+                        , Read.GenesisPoint
+                        ]
                 , rollForward = rollForward w
                 , rollBackward = rollBackward w
                 }

--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -43,6 +43,7 @@ library
   hs-source-dirs:  src
   exposed-modules:
     Cardano.Wallet.Network
+    Cardano.Wallet.Network.Checkpoints.Policy
     Cardano.Wallet.Network.Config
     Cardano.Wallet.Network.Implementation
     Cardano.Wallet.Network.Implementation.Ouroboros
@@ -124,6 +125,7 @@ test-suite unit
     , cardano-wallet-network-layer
     , cardano-wallet-primitive
     , cardano-wallet-read
+    , containers
     , contra-tracer
     , hspec
     , io-classes
@@ -133,4 +135,6 @@ test-suite unit
 
   build-tool-depends: hspec-discover:hspec-discover
   main-is:            Main.hs
-  other-modules:      Cardano.Wallet.Network.LightSpec
+  other-modules:
+    Cardano.Wallet.Network.Checkpoints.PolicySpec
+    Cardano.Wallet.Network.LightSpec

--- a/lib/network-layer/src/Cardano/Wallet/Network.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network.hs
@@ -33,6 +33,9 @@ import Cardano.Api
 import Cardano.Slotting.Slot
     ( SlotNo (..)
     )
+import Cardano.Wallet.Network.Checkpoints.Policy
+    ( CheckpointPolicy
+    )
 import Cardano.Wallet.Network.Logging
     ( ChainFollowLog (..)
     , ChainSyncLog (..)
@@ -49,9 +52,6 @@ import Cardano.Wallet.Primitive.Slotting
     )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..)
-    )
-import Cardano.Wallet.Primitive.Types.Checkpoints.Policy
-    ( CheckpointPolicy
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin

--- a/lib/network-layer/src/Cardano/Wallet/Network/Checkpoints/Policy.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Checkpoints/Policy.hs
@@ -1,10 +1,11 @@
 -- |
--- Copyright: © 2022 IOHK
+-- Copyright: © 2022 IOHK, 2024 Cardano Foundation
 -- License: Apache-2.0
 --
 -- Abstract data type that describes a policy for keeping and discarding
--- checkpoints. To be used with the 'Checkpoints' type.
-module Cardano.Wallet.Primitive.Types.Checkpoints.Policy
+-- checkpoints.
+-- Useful for 'ChainFollower'.
+module Cardano.Wallet.Network.Checkpoints.Policy
     ( BlockHeight
     , CheckpointPolicy
     , nextCheckpoint

--- a/lib/network-layer/test/Cardano/Wallet/Network/Checkpoints/PolicySpec.hs
+++ b/lib/network-layer/test/Cardano/Wallet/Network/Checkpoints/PolicySpec.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE DataKinds #-}
-module Cardano.Wallet.Checkpoints.PolicySpec
+module Cardano.Wallet.Network.Checkpoints.PolicySpec
     ( spec
     ) where
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.Checkpoints.Policy
+import Cardano.Wallet.Network.Checkpoints.Policy
     ( BlockHeight
     , CheckpointPolicy
     , nextCheckpoint
@@ -30,7 +30,7 @@ import Test.QuickCheck
     , (===)
     )
 
-import qualified Cardano.Wallet.Primitive.Types.Checkpoints.Policy as CP
+import qualified Cardano.Wallet.Network.Checkpoints.Policy as CP
 import qualified Data.Set as Set
 
 spec :: Spec

--- a/lib/network-layer/test/Cardano/Wallet/Network/LightSpec.hs
+++ b/lib/network-layer/test/Cardano/Wallet/Network/LightSpec.hs
@@ -89,7 +89,7 @@ import Test.QuickCheck
     , (===)
     )
 
-import qualified Cardano.Wallet.Primitive.Types.Checkpoints.Policy as CP
+import qualified Cardano.Wallet.Network.Checkpoints.Policy as CP
 import qualified Cardano.Wallet.Read as Read
 import qualified Cardano.Wallet.Read.Hash as Hash
 import qualified Data.List as L

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -154,7 +154,6 @@ library
     Cardano.Wallet.Primitive.Types.Block.Gen
     Cardano.Wallet.Primitive.Types.BlockSummary
     Cardano.Wallet.Primitive.Types.Certificates
-    Cardano.Wallet.Primitive.Types.Checkpoints.Policy
     Cardano.Wallet.Primitive.Types.Coin
     Cardano.Wallet.Primitive.Types.Coin.Gen
     Cardano.Wallet.Primitive.Types.DecentralizationLevel

--- a/lib/unit/cardano-wallet-unit.cabal
+++ b/lib/unit/cardano-wallet-unit.cabal
@@ -214,7 +214,6 @@ test-suite unit
     Cardano.Wallet.Balance.Migration.PlanningSpec
     Cardano.Wallet.Balance.Migration.SelectionSpec
     Cardano.Wallet.Balance.MigrationSpec
-    Cardano.Wallet.Checkpoints.PolicySpec
     Cardano.Wallet.CheckpointsSpec
     Cardano.Wallet.DB.Arbitrary
     Cardano.Wallet.DB.Fixtures

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -853,10 +853,10 @@ import qualified Cardano.Wallet.DB.Store.Delegations.Layer as Dlgs
 import qualified Cardano.Wallet.DB.Store.Submissions.Layer as Submissions
 import qualified Cardano.Wallet.DB.WalletState as WalletState
 import qualified Cardano.Wallet.DB.WalletState as WS
+import qualified Cardano.Wallet.Network.Checkpoints.Policy as CP
 import qualified Cardano.Wallet.Primitive.Ledger.Convert as Convert
 import qualified Cardano.Wallet.Primitive.Slotting as Slotting
 import qualified Cardano.Wallet.Primitive.Types as W
-import qualified Cardano.Wallet.Primitive.Types.Checkpoints.Policy as CP
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.Range as Range
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle

--- a/lib/wallet/src/Cardano/Wallet/Pools.hs
+++ b/lib/wallet/src/Cardano/Wallet/Pools.hs
@@ -292,7 +292,7 @@ import UnliftIO.STM
 
 import qualified Cardano.Pool.DB as PoolDb
 import qualified Cardano.Pool.DB.Layer as Pool
-import qualified Cardano.Wallet.Primitive.Types.Checkpoints.Policy as CP
+import qualified Cardano.Wallet.Network.Checkpoints.Policy as CP
 import qualified Cardano.Wallet.Read as Read
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE


### PR DESCRIPTION
This pull request implement all fields of a `ChainFollower` for the Deposit Wallet.

This implementation is still incomplete in that `readChainPoints` only returns the local tip and the genesis point — there is a chance that when the wallet is started, the previous tip has been rolled back, and we resync from genesis. This needs to be fixed later, but it's good enough for testing now.

### Issue Number

ADP-3344