### PR TITLE
[ADP-3344] Tidy up Deposit Wallet `Read` and `Write`

### DIFF
--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
@@ -65,7 +65,7 @@ newNetworkEnvMock = do
 
     let forgeBlock tx = atomically $ do
             tipOld <- readTVar mtip
-            let txRead = Write.toConwayTx (Write.mockTxId tipOld) tx
+            let txRead = Write.toConwayTx tx
                 blockNew = Read.mockNextBlock tipOld [txRead]
                 tipNew = Read.getChainPoint blockNew
             writeTVar mtip tipNew

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Balance.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Balance.hs
@@ -29,8 +29,8 @@ import Data.Set
     )
 
 import qualified Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO as DeltaUTxO
-import qualified Cardano.Wallet.Deposit.Read as Read
 import qualified Cardano.Wallet.Deposit.Write as Write
+import qualified Cardano.Wallet.Read as Read
 
 {-----------------------------------------------------------------------------
     Wallet Balance
@@ -45,10 +45,10 @@ availableUTxO u pending =
 
     -- UTxO which have been spent or committed as collateral in a pending
     -- transaction are not available to use in future transactions.
-    getUsedTxIn :: Write.Tx -> Set Read.TxIn
+    getUsedTxIn :: Read.Tx Read.Conway -> Set Read.TxIn
     getUsedTxIn tx =
-        Write.spendInputs (Write.txbody tx)
-        <> Write.collInputs (Write.txbody tx)
+        Read.getInputs tx
+        <> Read.getCollateralInputs tx
 
 {-----------------------------------------------------------------------------
     Applying Blocks
@@ -58,7 +58,7 @@ availableUTxO u pending =
 -- Returns both a delta and the new value.
 applyBlock
     :: Read.IsEra era
-    => IsOurs Read.Address -> Read.Block era -> UTxO -> (DeltaUTxO, UTxO)
+    => IsOurs Read.CompactAddr -> Read.Block era -> UTxO -> (DeltaUTxO, UTxO)
 applyBlock isOurs block u0 =
     (DeltaUTxO.concat $ reverse dus, u1)
   where

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Submissions.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Submissions.hs
@@ -22,6 +22,7 @@ import Data.Set
     )
 
 import qualified Cardano.Wallet.Deposit.Read as Read
+import qualified Cardano.Wallet.Deposit.Write as Write
 import qualified Cardano.Wallet.Submissions.Operations as Sbm
 import qualified Cardano.Wallet.Submissions.Submissions as Sbm
 import qualified Cardano.Wallet.Submissions.TxStatus as Sbm
@@ -31,11 +32,11 @@ import qualified Data.Delta as Delta
     Types
 ------------------------------------------------------------------------------}
 type TxSubmissions
-    = Sbm.Submissions () Read.SlotNo (Read.TxId, Read.Tx)
+    = Sbm.Submissions () Read.SlotNo (Read.TxId, Write.Tx)
 type TxSubmissionsStatus
-    = Sbm.TxStatusMeta () Read.SlotNo (Read.TxId, Read.Tx)
+    = Sbm.TxStatusMeta () Read.SlotNo (Read.TxId, Write.Tx)
 type DeltaTxSubmissions1
-    = Sbm.Operation () Read.SlotNo (Read.TxId, Read.Tx)
+    = Sbm.Operation () Read.SlotNo (Read.TxId, Write.Tx)
 type DeltaTxSubmissions
     = [DeltaTxSubmissions1]
 
@@ -43,8 +44,8 @@ instance Delta.Delta DeltaTxSubmissions1 where
     type Base DeltaTxSubmissions1 = TxSubmissions
     apply = Sbm.applyOperations
 
-instance Sbm.HasTxId (Read.TxId, Read.Tx) where
-   type TxId (Read.TxId, Read.Tx) = Read.TxId
+instance Sbm.HasTxId (Read.TxId, Write.Tx) where
+   type TxId (Read.TxId, Write.Tx) = Read.TxId
    txId = fst
 
 {-----------------------------------------------------------------------------
@@ -56,10 +57,10 @@ empty = Sbm.mkEmpty 0
 
 -- | Add a /new/ transaction to the local submission pool
 -- with the most recent submission slot.
-add :: Read.Tx -> Read.SlotNo -> DeltaTxSubmissions
+add :: Write.Tx -> Read.SlotNo -> DeltaTxSubmissions
 add = undefined
 
-listInSubmission :: TxSubmissions -> Set Read.Tx
+listInSubmission :: TxSubmissions -> Set Write.Tx
 listInSubmission = undefined
 
 rollForward :: Read.Block era -> DeltaTxSubmissions

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -20,8 +20,8 @@ module Cardano.Wallet.Deposit.Read
 
     , Address
     , KeyHash
+    , NetworkTag (..)
     , mkEnterpriseAddress
-    , mockAddress
 
     , Ix
     , Read.TxIn
@@ -52,36 +52,28 @@ module Cardano.Wallet.Deposit.Read
 
     , Read.NetworkId (Read.Mainnet, Read.Testnet)
     , Read.getNetworkId
-
-    -- * Dummy Values useful for testing
-    , dummyAddress
     ) where
 
 import Prelude
 
+import Cardano.Wallet.Address.Encoding
+    ( Credential (..)
+    , EnterpriseAddr (..)
+    , KeyHash
+    , NetworkTag (..)
+    , compactAddrFromEnterpriseAddr
+    )
 import Cardano.Wallet.Read.Block.Gen
     ( mkBlockEra
     )
 import Cardano.Wallet.Read.Block.Gen.BlockParameters
     ( BlockParameters (..)
     )
-import Data.ByteString
-    ( ByteString
-    )
 import Data.Map
     ( Map
     )
-import Data.Maybe
-    ( fromJust
-    )
-import Data.Word
-    ( Word8
-    )
 
 import qualified Cardano.Wallet.Read as Read
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as B8
-import qualified Data.ByteString.Short as SBS
 
 {-----------------------------------------------------------------------------
     Type definitions
@@ -93,22 +85,12 @@ import qualified Data.ByteString.Short as SBS
 -- Byron addresses are represented by @Addr_bootstrap@.
 type Address = Read.CompactAddr
 
-mockAddress :: Show a => a -> Address
-mockAddress = mkEnterpriseAddress . B8.pack . show
-
--- 28 Bytes.
-type KeyHash = ByteString
-
-mkEnterpriseAddress :: KeyHash -> Address
-mkEnterpriseAddress keyHash =
-    fromJust . Read.fromShortByteString . SBS.pack
-        $ [tagEnterprise] <> take 28 (BS.unpack keyHash <> repeat 0)
-
-tagEnterprise :: Word8
-tagEnterprise = 0b01100001
-
-dummyAddress :: Address
-dummyAddress = mockAddress (0 :: Int)
+-- | Make an enterprise address from a given network and key hash.
+mkEnterpriseAddress :: NetworkTag -> KeyHash -> Address
+mkEnterpriseAddress network =
+    compactAddrFromEnterpriseAddr
+    . EnterpriseAddrC network
+    . KeyHashObj
 
 type Ix = Read.TxIx
 

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -32,11 +32,8 @@ module Cardano.Wallet.Deposit.Read
     , UTxO
 
     , Read.TxId
-    , Tx
+    , Read.Tx
     , Read.utxoFromEraTx
-
-    , TxBody
-    , TxWitness
 
     , Read.Block
     , Read.getChainPoint
@@ -98,12 +95,6 @@ address :: Read.TxOut -> Address
 address = Read.getCompactAddr
 
 type UTxO = Map Read.TxIn Read.TxOut
-
-type Tx = Read.Tx Read.Conway
-
-type TxBody = ()
-
-type TxWitness = ()
 
 {-----------------------------------------------------------------------------
     Block

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -14,9 +14,9 @@ module Cardano.Wallet.Deposit.Read
 
     , Read.SlotNo
     , Read.ChainPoint (..)
-    , Slot
-    , WithOrigin (..)
-    , slotFromChainPoint
+    , Read.Slot
+    , Read.WithOrigin (..)
+    , Read.slotFromChainPoint
 
     , Address
     , KeyHash
@@ -65,14 +65,6 @@ import Cardano.Wallet.Read.Block.Gen
 import Cardano.Wallet.Read.Block.Gen.BlockParameters
     ( BlockParameters (..)
     )
-import Cardano.Wallet.Read.Chain
-    ( Slot
-    , WithOrigin (..)
-    , slotFromChainPoint
-    )
-import Cardano.Wallet.Read.Tx
-    ( TxIx
-    )
 import Data.ByteString
     ( ByteString
     )
@@ -118,7 +110,7 @@ tagEnterprise = 0b01100001
 dummyAddress :: Address
 dummyAddress = mockAddress (0 :: Int)
 
-type Ix = TxIx
+type Ix = Read.TxIx
 
 address :: Read.TxOut -> Address
 address = Read.getCompactAddr

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
-
 -- | Indirection module that re-exports types
 -- used for writing transactions to the blockchain,
 -- in the most recent and the next future eras.
@@ -11,11 +9,11 @@ module Cardano.Wallet.Deposit.Write
     , Value
 
     , TxId
-    , Tx (..)
+    , Tx
+    , mkTx
     , TxBody (..)
     , TxIn
     , TxOut
-    , TxWitness
 
     -- * Helper functions
     , mkAda
@@ -35,7 +33,6 @@ import Cardano.Wallet.Deposit.Read
     , TxId
     , TxIn
     , TxOut
-    , TxWitness
     , Value
     )
 import Cardano.Wallet.Read.Hash
@@ -80,11 +77,7 @@ import qualified Data.Set as Set
     Type definitions
     with dummies
 ------------------------------------------------------------------------------}
-data Tx = Tx
-    { txbody :: TxBody
-    , txwits :: TxWitness
-    }
-    deriving (Show)
+type Tx = Read.Tx Read.Conway
 
 data TxBody = TxBody
     { spendInputs :: Set TxIn
@@ -100,8 +93,11 @@ mkAda = Read.injectCoin . Read.CoinC
 mkTxOut :: Address -> Value -> TxOut
 mkTxOut = Read.mkBasicTxOut
 
-toConwayTx :: TxId -> Tx -> Read.Tx Read.Conway
-toConwayTx _ Tx{txbody} = Read.Tx $ L.mkBasicTx txBody
+toConwayTx :: Tx -> Read.Tx Read.Conway
+toConwayTx = id
+
+mkTx :: TxBody -> Tx
+mkTx txbody = Read.Tx $ L.mkBasicTx txBody
   where
     txBody :: L.TxBody L.Conway
     txBody =

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
@@ -129,11 +129,7 @@ payFromFaucet env destinations =
 ------------------------------------------------------------------------------}
 
 signTx :: XPrv -> [BIP32Path] -> Write.TxBody -> Write.Tx
-signTx _ _ txbody =
-    Write.Tx
-        { Write.txbody = txbody
-        , Write.txwits = ()
-        }
+signTx _ _ = Write.mkTx
 
 submitTx :: ScenarioEnv -> Write.Tx -> IO ()
 submitTx env tx = do

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/HTTP/JSON/JSONSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/HTTP/JSON/JSONSpec.hs
@@ -29,7 +29,8 @@ import Cardano.Wallet.Deposit.Pure
     , fromRawCustomer
     )
 import Cardano.Wallet.Deposit.Read
-    ( mkEnterpriseAddress
+    ( NetworkTag (MainnetTag, TestnetTag)
+    , mkEnterpriseAddress
     )
 import Data.Aeson
     ( FromJSON (..)
@@ -74,8 +75,8 @@ import Test.QuickCheck
     )
 
 import qualified Cardano.Wallet.Read as Read
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.ByteString.Short as SBS
 import qualified Data.List as L
 
 spec :: Spec
@@ -133,8 +134,9 @@ prop_jsonRoundtrip val =
 
 genAddress :: Gen Address
 genAddress = do
-    keyhashCred <- BS.pack <$> vectorOf 28 arbitrary
-    pure $ mkEnterpriseAddress keyhashCred
+    network <- elements [MainnetTag, TestnetTag]
+    keyhashCred <- SBS.pack <$> vectorOf 28 arbitrary
+    pure $ mkEnterpriseAddress network keyhashCred
 
 genApiTAddress :: Gen (ApiT Address)
 genApiTAddress = ApiT <$> genAddress

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/PureSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/PureSpec.hs
@@ -117,9 +117,9 @@ testXPub =
 testGenesis :: Read.GenesisData
 testGenesis = Read.mockGenesisDataMainnet
 
-spendOneTxOut :: UTxO.UTxO -> Read.Tx
+spendOneTxOut :: UTxO.UTxO -> Write.Tx
 spendOneTxOut utxo =
-    Write.toConwayTx txid tx
+    Write.mkTx txBody
   where
     txBody = Write.TxBody
         { Write.spendInputs = Set.singleton . fst . head $ Map.toList utxo
@@ -127,15 +127,10 @@ spendOneTxOut utxo =
         , Write.txouts = Map.empty
         , Write.collRet = Nothing
         }
-    tx = Write.Tx
-        { Write.txbody = txBody
-        , Write.txwits = ()
-        }
-    txid = Write.mockTxId txBody
 
-payFromFaucet :: [(Write.Address, Write.Value)] -> Read.Tx
+payFromFaucet :: [(Write.Address, Write.Value)] -> Write.Tx
 payFromFaucet destinations =
-    Write.toConwayTx txid tx
+    Write.mkTx txBody
   where
     toTxOut (addr, value) = Write.mkTxOut addr value
     txBody = Write.TxBody
@@ -145,8 +140,3 @@ payFromFaucet destinations =
             Map.fromList $ zip [toEnum 0..] $ map toTxOut destinations
         , Write.collRet = Nothing
         }
-    tx = Write.Tx
-        { Write.txbody = txBody
-        , Write.txwits = ()
-        }
-    txid = Write.mockTxId txBody


### PR DESCRIPTION
This pull request tidies up the indirection modules

* `Cardano.Wallet.Deposit.Read`
* `Cardano.Wallet.Deposit.Write`

a bit in order to bring the closer to a state where they can be removed.

### Issue Number

ADP-3344