### PR TITLE
[ADP-3344] Tidy up `Cardano.Write.Era`

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -883,9 +883,8 @@ import qualified Cardano.Wallet.Read as Read
 import qualified Cardano.Wallet.Read.Hash as Hash
 import qualified Cardano.Wallet.Registry as Registry
 import qualified Cardano.Write.Eras as Write
-    ( IsRecentEra
+    ( IsRecentEra (recentEra)
     , RecentEra
-    , cardanoEra
     , cardanoEraFromRecentEra
     )
 import qualified Control.Concurrent.Concierge as Concierge
@@ -4892,8 +4891,11 @@ fromApiRedeemer = \case
 
 sealWriteTx :: forall era. Write.IsRecentEra era => Write.Tx era -> W.SealedTx
 sealWriteTx = W.sealedTxFromCardano
-    . Cardano.InAnyCardanoEra (Write.cardanoEra @era)
+    . Cardano.InAnyCardanoEra cardanoEra
     . Write.toCardanoApiTx
+  where
+    cardanoEra =
+        Write.cardanoEraFromRecentEra (Write.recentEra :: Write.RecentEra era)
 
 toApiSerialisedTransaction
     :: Write.IsRecentEra era

--- a/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Types/Era.hs
@@ -70,9 +70,6 @@ import Text.Show
 
 import qualified Cardano.Wallet.Read as Read
 import qualified Cardano.Write.Eras as Write
-    ( allRecentEras
-    , toAnyCardanoEra
-    )
 import qualified Data.Aeson as Aeson
 import qualified Data.Set as Set
 
@@ -129,4 +126,9 @@ toAnyCardanoEra = \case
 --
 allRecentEras :: Set ApiEra
 allRecentEras =
-    Set.map (fromAnyCardanoEra . Write.toAnyCardanoEra) Write.allRecentEras
+    Set.map fromAnyRecentEra Write.allRecentEras
+
+fromAnyRecentEra :: Write.AnyRecentEra -> ApiEra
+fromAnyRecentEra = \case
+    Write.AnyRecentEra Write.RecentEraBabbage -> ApiBabbage
+    Write.AnyRecentEra Write.RecentEraConway -> ApiConway

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
@@ -28,7 +28,6 @@ module Internal.Cardano.Write.Eras
     , RecentEra (..)
     , IsRecentEra (..)
     , CardanoApiEra
-    , fromRecentEra
     , MaybeInRecentEra (..)
     , LatestLedgerEra
     , RecentEraConstraints
@@ -188,11 +187,6 @@ type RecentEraConstraints era =
     , Core.NativeScript era ~ Timelock era
     )
 
-fromRecentEra :: RecentEra era -> CardanoApi.CardanoEra (CardanoApiEra era)
-fromRecentEra = \case
-    RecentEraConway -> CardanoApi.ConwayEra
-    RecentEraBabbage -> CardanoApi.BabbageEra
-
 instance IsRecentEra BabbageEra where
     recentEra = RecentEraBabbage
 
@@ -202,10 +196,9 @@ instance IsRecentEra ConwayEra where
 cardanoEraFromRecentEra
     :: RecentEra era
     -> CardanoApi.CardanoEra (CardanoApiEra era)
-cardanoEraFromRecentEra era = case shelleyBasedEraFromRecentEra era of
-    CardanoApi.ShelleyBasedEraBabbage -> CardanoApi.toCardanoEra CardanoApi.BabbageEra
-    CardanoApi.ShelleyBasedEraConway -> CardanoApi.toCardanoEra CardanoApi.ConwayEra
-    _ -> error "we are expecting only Babbage and Conway"
+cardanoEraFromRecentEra = \case
+    RecentEraConway -> CardanoApi.ConwayEra
+    RecentEraBabbage -> CardanoApi.BabbageEra
 
 shelleyBasedEraFromRecentEra
     :: RecentEra era
@@ -283,7 +276,7 @@ allRecentEras = Set.fromList [minBound .. maxBound]
 
 toAnyCardanoEra :: AnyRecentEra -> CardanoApi.AnyCardanoEra
 toAnyCardanoEra (AnyRecentEra era) =
-    CardanoApi.AnyCardanoEra (fromRecentEra era)
+    CardanoApi.AnyCardanoEra (cardanoEraFromRecentEra era)
 
 fromAnyCardanoEra
     :: CardanoApi.AnyCardanoEra

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -37,7 +36,6 @@ module Internal.Cardano.Write.Eras
     , AnyRecentEra (..)
 
     -- ** Helpers for cardano-api compatibility
-    , shelleyBasedEra
     , CardanoApi.ShelleyLedgerEra
     , cardanoEraFromRecentEra
     , shelleyBasedEraFromRecentEra
@@ -203,15 +201,6 @@ shelleyBasedEraFromRecentEra
 shelleyBasedEraFromRecentEra = \case
     RecentEraConway -> CardanoApi.ShelleyBasedEraConway
     RecentEraBabbage -> CardanoApi.ShelleyBasedEraBabbage
-
--- | For convenience working with 'IsRecentEra'.
---
--- Similar to 'CardanoApi.shelleyBasedEra, but with a 'IsRecentEra era'
--- constraint instead of 'CardanoApi.IsShelleyBasedEra'.
-shelleyBasedEra
-    :: forall era. IsRecentEra era
-    => CardanoApi.ShelleyBasedEra (CardanoApiEra era)
-shelleyBasedEra = shelleyBasedEraFromRecentEra $ recentEra @era
 
 data MaybeInRecentEra (thing :: Type -> Type)
     = InNonRecentEraByron

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
@@ -36,7 +36,6 @@ module Internal.Cardano.Write.Eras
     , AnyRecentEra (..)
 
     -- ** Helpers for cardano-api compatibility
-    , CardanoApi.ShelleyLedgerEra
     , cardanoEraFromRecentEra
     , shelleyBasedEraFromRecentEra
     ) where

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
@@ -28,7 +28,6 @@ module Internal.Cardano.Write.Eras
     , RecentEra (..)
     , IsRecentEra (..)
     , CardanoApiEra
-    , toRecentEra
     , fromRecentEra
     , MaybeInRecentEra (..)
     , LatestLedgerEra
@@ -188,21 +187,6 @@ type RecentEraConstraints era =
     , AllegraEraScript era
     , Core.NativeScript era ~ Timelock era
     )
-
--- | Returns a proof that the given era is a recent era.
---
--- Otherwise, returns @Nothing@.
-toRecentEra
-    :: CardanoApi.CardanoEra era
-    -> Maybe (RecentEra (CardanoApi.ShelleyLedgerEra era))
-toRecentEra = \case
-    CardanoApi.ConwayEra  -> Just RecentEraConway
-    CardanoApi.BabbageEra -> Just RecentEraBabbage
-    CardanoApi.AlonzoEra  -> Nothing
-    CardanoApi.MaryEra    -> Nothing
-    CardanoApi.AllegraEra -> Nothing
-    CardanoApi.ShelleyEra -> Nothing
-    CardanoApi.ByronEra   -> Nothing
 
 fromRecentEra :: RecentEra era -> CardanoApi.CardanoEra (CardanoApiEra era)
 fromRecentEra = \case

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
@@ -35,7 +35,6 @@ module Internal.Cardano.Write.Eras
 
     -- ** Existential wrapper
     , AnyRecentEra (..)
-    , fromAnyCardanoEra
 
     -- ** Helpers for cardano-api compatibility
     , cardanoEra

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
@@ -37,7 +37,6 @@ module Internal.Cardano.Write.Eras
     , AnyRecentEra (..)
 
     -- ** Helpers for cardano-api compatibility
-    , cardanoEra
     , shelleyBasedEra
     , CardanoApi.ShelleyLedgerEra
     , cardanoEraFromRecentEra
@@ -204,13 +203,6 @@ shelleyBasedEraFromRecentEra
 shelleyBasedEraFromRecentEra = \case
     RecentEraConway -> CardanoApi.ShelleyBasedEraConway
     RecentEraBabbage -> CardanoApi.ShelleyBasedEraBabbage
-
--- Similar to 'CardanoApi.cardanoEra', but with an 'IsRecentEra era' constraint
--- instead of 'CardanoApi.IsCardanoEra'.
-cardanoEra
-    :: forall era. IsRecentEra era
-    => CardanoApi.CardanoEra (CardanoApiEra era)
-cardanoEra = cardanoEraFromRecentEra $ recentEra @era
 
 -- | For convenience working with 'IsRecentEra'.
 --

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
@@ -35,7 +35,6 @@ module Internal.Cardano.Write.Eras
 
     -- ** Existential wrapper
     , AnyRecentEra (..)
-    , toAnyCardanoEra
     , fromAnyCardanoEra
 
     -- ** Helpers for cardano-api compatibility

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -208,9 +208,9 @@ import GHC.Stack
     ( HasCallStack
     )
 import Internal.Cardano.Write.Eras
-    ( BabbageEra
+    ( Babbage
     , CardanoApiEra
-    , ConwayEra
+    , Conway
     , IsRecentEra (..)
     , LatestLedgerEra
     , MaybeInRecentEra (..)
@@ -288,7 +288,7 @@ unsafeMkTxIn hash ix = Ledger.mkTxInPartial
 
 type TxOut era = Core.TxOut era
 
-type TxOutInBabbage = Babbage.BabbageTxOut (Babbage.BabbageEra StandardCrypto)
+type TxOutInBabbage = Babbage.BabbageTxOut Babbage
 
 type Address = Ledger.Addr StandardCrypto
 
@@ -339,7 +339,7 @@ wrapTxOutInRecentEra out = case recentEra @era of
             BabbageTxOut addr v d s = out
         in
             TxOutInRecentEra addr v d (strictMaybeToMaybe s)
-    RecentEraBabbage -> wrapTxOutInRecentEra @ConwayEra $ upgradeTxOut out
+    RecentEraBabbage -> wrapTxOutInRecentEra @Conway $ upgradeTxOut out
 
 data ErrInvalidTxOutInEra
     = InlinePlutusV3ScriptNotSupportedInBabbage
@@ -361,7 +361,7 @@ recentEraToConwayTxOut (TxOutInRecentEra addr val datum mscript) =
 
 recentEraToBabbageTxOut
     :: TxOutInRecentEra
-    -> Either ErrInvalidTxOutInEra (BabbageTxOut BabbageEra)
+    -> Either ErrInvalidTxOutInEra (BabbageTxOut Babbage)
 recentEraToBabbageTxOut (TxOutInRecentEra addr val datum mscript) =
     Babbage.BabbageTxOut addr val
         (downgradeDatum datum)
@@ -376,8 +376,8 @@ recentEraToBabbageTxOut (TxOutInRecentEra addr val datum mscript) =
             Alonzo.Datum (coerce binaryData)
 
     downgradeScript
-        :: AlonzoScript ConwayEra
-        -> Either ErrInvalidTxOutInEra (AlonzoScript BabbageEra)
+        :: AlonzoScript Conway
+        -> Either ErrInvalidTxOutInEra (AlonzoScript Babbage)
     downgradeScript = \case
         TimelockScript timelockEra
             -> pure $ Alonzo.TimelockScript (translateTimelock timelockEra)
@@ -385,8 +385,8 @@ recentEraToBabbageTxOut (TxOutInRecentEra addr val datum mscript) =
             -> PlutusScript <$> downgradePlutusScript s
 
     downgradePlutusScript
-        :: PlutusScript ConwayEra
-        -> Either ErrInvalidTxOutInEra (PlutusScript BabbageEra)
+        :: PlutusScript Conway
+        -> Either ErrInvalidTxOutInEra (PlutusScript Babbage)
     downgradePlutusScript = \case
         ConwayPlutusV1 s -> pure $ BabbagePlutusV1 s
         ConwayPlutusV2 s -> pure $ BabbagePlutusV2 s

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx.hs
@@ -215,7 +215,7 @@ import Internal.Cardano.Write.Eras
     , LatestLedgerEra
     , MaybeInRecentEra (..)
     , RecentEra (..)
-    , shelleyBasedEra
+    , shelleyBasedEraFromRecentEra
     )
 import Numeric.Natural
     ( Natural
@@ -503,7 +503,8 @@ toCardanoApiTx
     => Core.Tx era
     -> CardanoApi.Tx (CardanoApiEra era)
 toCardanoApiTx =
-    CardanoApi.ShelleyTx (shelleyBasedEra @era)
+    CardanoApi.ShelleyTx
+    $ shelleyBasedEraFromRecentEra (recentEra :: RecentEra era)
 
 toCardanoApiUTxO
     :: forall era. IsRecentEra era
@@ -512,8 +513,10 @@ toCardanoApiUTxO
 toCardanoApiUTxO =
     CardanoApi.UTxO
     . Map.mapKeys CardanoApi.fromShelleyTxIn
-    . Map.map (CardanoApi.fromShelleyTxOut (shelleyBasedEra @era))
+    . Map.map (CardanoApi.fromShelleyTxOut shelleyBasedEra)
     . unUTxO
+  where
+    shelleyBasedEra = shelleyBasedEraFromRecentEra (recentEra :: RecentEra era)
 
 fromCardanoApiUTxO
     :: forall era. IsRecentEra era
@@ -523,8 +526,10 @@ fromCardanoApiUTxO =
     Shelley.UTxO
     . Map.mapKeys CardanoApi.toShelleyTxIn
     . Map.map
-        (CardanoApi.toShelleyTxOut (shelleyBasedEra @era))
+        (CardanoApi.toShelleyTxOut shelleyBasedEra)
     . CardanoApi.unUTxO
+  where
+    shelleyBasedEra = shelleyBasedEraFromRecentEra (recentEra :: RecentEra era)
 
 --------------------------------------------------------------------------------
 -- PParams

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Gen.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Gen.hs
@@ -28,8 +28,8 @@ import Data.Maybe
     ( fromMaybe
     )
 import Internal.Cardano.Write.Eras
-    ( BabbageEra
-    , ConwayEra
+    ( Babbage
+    , Conway
     , IsRecentEra (..)
     , RecentEra (..)
     )
@@ -106,7 +106,7 @@ mockPParams = case recentEra @era of
     unsafeWrap :: PParamsHKD Identity era -> PParams era
     unsafeWrap = unsafeCoerce
 
-    conwayPParams :: ConwayPParams Identity ConwayEra
+    conwayPParams :: ConwayPParams Identity Conway
     conwayPParams = upgradeConwayPParams upgrade babbagePParams
       where
         upgrade :: UpgradeConwayPParams Identity
@@ -140,7 +140,7 @@ mockPParams = case recentEra @era of
             , ucppPlutusV3CostModel = conwayPlutusV3CostModel
             }
 
-    babbagePParams :: BabbagePParams Identity BabbageEra
+    babbagePParams :: BabbagePParams Identity Babbage
     babbagePParams = BabbagePParams
       { bppMinFeeA = 44
       -- ^ The linear factor for the minimum fee calculation

--- a/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
@@ -21,7 +21,6 @@ module Cardano.Write.Eras
     , AnyRecentEra (..)
 
     -- ** Helpers for cardano-api compatibility
-    , cardanoEra
     , shelleyBasedEra
     , ShelleyLedgerEra
     , cardanoEraFromRecentEra
@@ -40,7 +39,6 @@ import Internal.Cardano.Write.Eras
     , RecentEraConstraints
     , ShelleyLedgerEra
     , allRecentEras
-    , cardanoEra
     , cardanoEraFromRecentEra
     , shelleyBasedEra
     , shelleyBasedEraFromRecentEra

--- a/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
@@ -19,7 +19,6 @@ module Cardano.Write.Eras
 
     -- ** Existential wrapper
     , AnyRecentEra (..)
-    , fromAnyCardanoEra
 
     -- ** Helpers for cardano-api compatibility
     , cardanoEra
@@ -43,7 +42,6 @@ import Internal.Cardano.Write.Eras
     , allRecentEras
     , cardanoEra
     , cardanoEraFromRecentEra
-    , fromAnyCardanoEra
     , shelleyBasedEra
     , shelleyBasedEraFromRecentEra
     )

--- a/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
@@ -19,7 +19,6 @@ module Cardano.Write.Eras
 
     -- ** Existential wrapper
     , AnyRecentEra (..)
-    , toAnyCardanoEra
     , fromAnyCardanoEra
 
     -- ** Helpers for cardano-api compatibility
@@ -47,5 +46,4 @@ import Internal.Cardano.Write.Eras
     , fromAnyCardanoEra
     , shelleyBasedEra
     , shelleyBasedEraFromRecentEra
-    , toAnyCardanoEra
     )

--- a/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
@@ -21,7 +21,6 @@ module Cardano.Write.Eras
     , AnyRecentEra (..)
 
     -- ** Helpers for cardano-api compatibility
-    , ShelleyLedgerEra
     , cardanoEraFromRecentEra
     , shelleyBasedEraFromRecentEra
     ) where
@@ -36,7 +35,6 @@ import Internal.Cardano.Write.Eras
     , MaybeInRecentEra (..)
     , RecentEra (..)
     , RecentEraConstraints
-    , ShelleyLedgerEra
     , allRecentEras
     , cardanoEraFromRecentEra
     , shelleyBasedEraFromRecentEra

--- a/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
@@ -4,32 +4,33 @@
 --
 module Cardano.Write.Eras
     (
-    -- * Eras
-      BabbageEra
-    , ConwayEra
+    -- * Recent Eras
+    -- ** Names
+      Babbage
+    , Conway
+    , LatestLedgerEra
 
-    -- ** RecentEra
+    -- * 'RecentEra' type
     , RecentEra (..)
     , IsRecentEra (..)
-    , CardanoApiEra
     , MaybeInRecentEra (..)
-    , LatestLedgerEra
     , RecentEraConstraints
-    , allRecentEras
 
     -- ** Existential wrapper
     , AnyRecentEra (..)
+    , allRecentEras
 
-    -- ** Helpers for cardano-api compatibility
+    -- ** Compatibility with "Cardano.Api"
+    , CardanoApiEra
     , cardanoEraFromRecentEra
     , shelleyBasedEraFromRecentEra
     ) where
 
 import Internal.Cardano.Write.Eras
     ( AnyRecentEra (..)
-    , BabbageEra
+    , Babbage
     , CardanoApiEra
-    , ConwayEra
+    , Conway
     , IsRecentEra (..)
     , LatestLedgerEra
     , MaybeInRecentEra (..)

--- a/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
@@ -12,7 +12,6 @@ module Cardano.Write.Eras
     , RecentEra (..)
     , IsRecentEra (..)
     , CardanoApiEra
-    , fromRecentEra
     , MaybeInRecentEra (..)
     , LatestLedgerEra
     , RecentEraConstraints
@@ -46,7 +45,6 @@ import Internal.Cardano.Write.Eras
     , cardanoEra
     , cardanoEraFromRecentEra
     , fromAnyCardanoEra
-    , fromRecentEra
     , shelleyBasedEra
     , shelleyBasedEraFromRecentEra
     , toAnyCardanoEra

--- a/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
@@ -21,7 +21,6 @@ module Cardano.Write.Eras
     , AnyRecentEra (..)
 
     -- ** Helpers for cardano-api compatibility
-    , shelleyBasedEra
     , ShelleyLedgerEra
     , cardanoEraFromRecentEra
     , shelleyBasedEraFromRecentEra
@@ -40,6 +39,5 @@ import Internal.Cardano.Write.Eras
     , ShelleyLedgerEra
     , allRecentEras
     , cardanoEraFromRecentEra
-    , shelleyBasedEra
     , shelleyBasedEraFromRecentEra
     )

--- a/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/main/Cardano/Write/Eras.hs
@@ -12,7 +12,6 @@ module Cardano.Write.Eras
     , RecentEra (..)
     , IsRecentEra (..)
     , CardanoApiEra
-    , toRecentEra
     , fromRecentEra
     , MaybeInRecentEra (..)
     , LatestLedgerEra
@@ -51,5 +50,4 @@ import Internal.Cardano.Write.Eras
     , shelleyBasedEra
     , shelleyBasedEraFromRecentEra
     , toAnyCardanoEra
-    , toRecentEra
     )

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/Balance/TokenBundleSizeSpec.hs
@@ -31,8 +31,8 @@ import Data.Word
     ( Word32
     )
 import Internal.Cardano.Write.Eras
-    ( BabbageEra
-    , ConwayEra
+    ( Babbage
+    , Conway
     , IsRecentEra (..)
     , RecentEra (..)
     )
@@ -173,7 +173,7 @@ unit_assessTokenBundleSize_fixedSizeBundle
             ]
   where
     actualAssessment = assessTokenBundleSize assessor bundle
-    v = eraProtVerLow @BabbageEra
+    v = eraProtVerLow @Babbage
     actualLengthBytes = computeTokenBundleSerializedLengthBytes bundle v
     counterexampleText = unlines
         [ "Expected min length bytes:"
@@ -270,8 +270,8 @@ instance Arbitrary Version where
     arbitrary = arbitraryBoundedEnum
 
 data PParamsInRecentEra
-    = PParamsInBabbage (PParams BabbageEra)
-    | PParamsInConway (PParams ConwayEra)
+    = PParamsInBabbage (PParams Babbage)
+    | PParamsInConway (PParams Conway)
     deriving (Show, Eq)
 
 instance Arbitrary PParamsInRecentEra where
@@ -306,8 +306,8 @@ instance Arbitrary PParamsInRecentEra where
 
 babbageTokenBundleSizeAssessor :: TokenBundleSizeAssessor
 babbageTokenBundleSizeAssessor = mkTokenBundleSizeAssessor
-    $ (def :: PParams BabbageEra)
-        & ppProtocolVersionL .~ (ProtVer (eraProtVerLow @BabbageEra) 0)
+    $ (def :: PParams Babbage)
+        & ppProtocolVersionL .~ (ProtVer (eraProtVerLow @Babbage) 0)
         & ppMaxValSizeL .~ maryTokenBundleMaxSizeBytes
   where
     maryTokenBundleMaxSizeBytes = 4000

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -252,7 +252,6 @@ import Internal.Cardano.Write.Eras
     , ConwayEra
     , IsRecentEra (recentEra)
     , RecentEra (..)
-    , cardanoEra
     , cardanoEraFromRecentEra
     , shelleyBasedEra
     , shelleyBasedEraFromRecentEra
@@ -2385,7 +2384,9 @@ instance forall era. IsRecentEra era => Arbitrary (Wallet era) where
 
 genTxForBalancing :: forall era. IsRecentEra era => Gen (Tx era)
 genTxForBalancing =
-    fromCardanoApiTx <$> CardanoApi.genTxForBalancing (cardanoEra @era)
+    fromCardanoApiTx <$> CardanoApi.genTxForBalancing cardanoEra
+  where
+    cardanoEra = cardanoEraFromRecentEra (recentEra :: RecentEra era)
 
 genTxIn :: Gen TxIn
 genTxIn = fromWalletTxIn <$> W.genTxIn
@@ -2397,7 +2398,9 @@ genTxOut =
     -- should ideally test what happens, and make it clear what
     -- code, if any, should validate.
     CardanoApi.toShelleyTxOut (shelleyBasedEra @era)
-        <$> CardanoApi.genTxOut (cardanoEra @era)
+        <$> CardanoApi.genTxOut cardanoEra
+  where
+    cardanoEra = cardanoEraFromRecentEra (recentEra :: RecentEra era)
 
 -- | For writing shrinkers in the style of https://stackoverflow.com/a/14006575
 prependOriginal :: (t -> [t]) -> t -> [t]

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -253,7 +253,6 @@ import Internal.Cardano.Write.Eras
     , IsRecentEra (recentEra)
     , RecentEra (..)
     , cardanoEraFromRecentEra
-    , shelleyBasedEra
     , shelleyBasedEraFromRecentEra
     )
 import Internal.Cardano.Write.Tx
@@ -1986,8 +1985,10 @@ cardanoToWalletTxOut
     => CardanoApi.TxOut CardanoApi.CtxUTxO (CardanoApiEra era)
     -> W.TxOut
 cardanoToWalletTxOut =
-    toWallet . CardanoApi.toShelleyTxOut (shelleyBasedEra @era)
+    toWallet . CardanoApi.toShelleyTxOut shelleyBasedEra
   where
+    shelleyBasedEra = shelleyBasedEraFromRecentEra (recentEra @era)
+
     toWallet :: TxOut era -> W.TxOut
     toWallet x = case recentEra @era of
         RecentEraBabbage -> Convert.fromBabbageTxOut x
@@ -2397,10 +2398,11 @@ genTxOut =
     -- `maxBound :: Word64`, however users could supply these. We
     -- should ideally test what happens, and make it clear what
     -- code, if any, should validate.
-    CardanoApi.toShelleyTxOut (shelleyBasedEra @era)
+    CardanoApi.toShelleyTxOut shelleyBasedEra
         <$> CardanoApi.genTxOut cardanoEra
   where
     cardanoEra = cardanoEraFromRecentEra (recentEra :: RecentEra era)
+    shelleyBasedEra = shelleyBasedEraFromRecentEra (recentEra :: RecentEra era)
 
 -- | For writing shrinkers in the style of https://stackoverflow.com/a/14006575
 prependOriginal :: (t -> [t]) -> t -> [t]

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -247,9 +247,9 @@ import GHC.Stack
     )
 import Internal.Cardano.Write.Eras
     ( AnyRecentEra (..)
-    , BabbageEra
+    , Babbage
     , CardanoApiEra
-    , ConwayEra
+    , Conway
     , IsRecentEra (recentEra)
     , RecentEra (..)
     , cardanoEraFromRecentEra
@@ -507,10 +507,10 @@ spec_balanceTx = describe "balanceTx" $ do
         $ property prop_balanceTxUnableToCreateInput
 
     it "produces valid transactions or fails (Babbage)"
-        $ property (prop_balanceTxValid @BabbageEra)
+        $ property (prop_balanceTxValid @Babbage)
 
     it "produces valid transactions or fails (Conway)"
-        $ property (prop_balanceTxValid @ConwayEra)
+        $ property (prop_balanceTxValid @Conway)
 
     describe "bootstrap witnesses" $ do
         -- Used in 'estimateTxSize', and in turn used by coin-selection
@@ -674,7 +674,7 @@ spec_balanceTx = describe "balanceTx" $ do
     describe "stake key deposit lookup" $ do
         let stakeCred = KeyHashObj $ KeyHash
                 "00000000000000000000000000000000000000000000000000000000"
-        let partialTxWithRefund :: Coin -> PartialTx BabbageEra
+        let partialTxWithRefund :: Coin -> PartialTx Babbage
             partialTxWithRefund r = PartialTx
                 { tx = mkBasicTx $ mkBasicTxBody
                     & certsTxBodyL .~ StrictSeq.fromList
@@ -735,7 +735,7 @@ spec_balanceTx = describe "balanceTx" $ do
         it "fails with ErrBalanceTxUnresolvedInputs" $ do
             let txin = W.TxIn (W.Hash $ B8.replicate 32 '3') 10
             -- 1 output, 1 input without utxo entry
-            let partialTx :: PartialTx BabbageEra
+            let partialTx :: PartialTx Babbage
                 partialTx = addExtraTxIns [txin] $
                     paymentPartialTx
                         [ W.TxOut dummyAddr
@@ -892,7 +892,7 @@ balanceTxGoldenSpec = describe "balance goldens" $ do
     it "testPParams" $
         let name = "testPParams"
             dir = $(getTestData) </> "balanceTx" </> "binary"
-            pparams = mockPParams @BabbageEra
+            pparams = mockPParams @Babbage
         in Golden
             { output = pparams
             , encodePretty = show
@@ -924,7 +924,7 @@ balanceTxGoldenSpec = describe "balance goldens" $ do
                     . T.pack
                     . B8.unpack
                     . hex
-                    . serializeTx @BabbageEra
+                    . serializeTx @Babbage
                     $ x
                 , readFromFile =
                     fmap (deserializeBabbageTx . unsafeFromHex . B8.pack)
@@ -943,7 +943,7 @@ balanceTxGoldenSpec = describe "balance goldens" $ do
     toCBORHex :: ToCBOR a => a -> String
     toCBORHex = B8.unpack . hex . serialize'
 
-    test :: String -> PartialTx BabbageEra -> Spec
+    test :: String -> PartialTx Babbage -> Spec
     test name partialTx = it name $ do
         goldenText name
             (map (mkGolden partialTx . W.Coin) defaultWalletBalanceRange)
@@ -965,7 +965,7 @@ balanceTxGoldenSpec = describe "balance goldens" $ do
             dir = $(getTestData) </> "balanceTx"
 
         mkGolden
-            :: PartialTx BabbageEra
+            :: PartialTx Babbage
             -> W.Coin
             -> BalanceTxGolden
         mkGolden ptx c =
@@ -999,12 +999,12 @@ balanceTxGoldenSpec = describe "balance goldens" $ do
     addr = W.Address $ unsafeFromHex
         "60b1e5e0fb74c86c801f646841e07cdb42df8b82ef3ce4e57cb5412e77"
 
-    payment :: PartialTx BabbageEra
+    payment :: PartialTx Babbage
     payment = paymentPartialTx
         [ W.TxOut addr (W.TokenBundle.fromCoin (W.Coin 1_000_000))
         ]
 
-    delegate :: PartialTx BabbageEra
+    delegate :: PartialTx Babbage
     delegate = PartialTx
         (mkBasicTx body)
         mempty
@@ -1012,7 +1012,7 @@ balanceTxGoldenSpec = describe "balance goldens" $ do
         (StakeKeyDepositMap mempty)
         mempty
       where
-        body :: TxBody BabbageEra
+        body :: TxBody Babbage
         body =
             mkBasicTxBody
                 & certsTxBodyL .~ StrictSeq.fromList certs
@@ -1150,7 +1150,7 @@ spec_updateTx = describe "updateTx" $ do
             pendingWith "todo: add test data"
   where
     readTestTransactions
-        :: SpecM a [(FilePath, Tx BabbageEra)]
+        :: SpecM a [(FilePath, Tx Babbage)]
     readTestTransactions = runIO $ do
         let dir = $(getTestData) </> "plutus"
         paths <- listDirectory dir
@@ -1167,7 +1167,7 @@ spec_updateTx = describe "updateTx" $ do
 --------------------------------------------------------------------------------
 
 prop_balanceTxExistingReturnCollateral
-    :: forall era. (era ~ BabbageEra)
+    :: forall era. (era ~ Babbage)
     => SuccessOrFailure (BalanceTxArgs era)
     -> Property
 prop_balanceTxExistingReturnCollateral
@@ -1186,7 +1186,7 @@ prop_balanceTxExistingReturnCollateral
     PartialTx {tx} = partialTx
 
 prop_balanceTxExistingTotalCollateral
-    :: forall era. (era ~ BabbageEra)
+    :: forall era. (era ~ Babbage)
     => SuccessOrFailure (BalanceTxArgs era)
     -> Property
 prop_balanceTxExistingTotalCollateral
@@ -1218,7 +1218,7 @@ prop_balanceTxExistingTotalCollateral
 --
 prop_balanceTxUnableToCreateInput
     -- TODO: Test with all recent eras [ADP-2997]
-    :: forall era. era ~ BabbageEra
+    :: forall era. era ~ Babbage
     => Success (BalanceTxArgs era)
     -> Property
 prop_balanceTxUnableToCreateInput
@@ -1642,7 +1642,7 @@ prop_bootstrapWitnesses
 -- TODO [ADO-2997] Test this property in all recent eras.
 -- https://cardanofoundation.atlassian.net/browse/ADP-2997
 prop_updateTx
-    :: forall era. era ~ BabbageEra
+    :: forall era. era ~ Babbage
     => Tx era
     -> Set W.TxIn
     -> Set W.TxIn
@@ -1832,8 +1832,8 @@ data Wallet era = Wallet UTxOAssumptions (UTxO era) AnyChangeAddressGenWithState
 -- Ideally merge with 'updateTx'
 addExtraTxIns
     :: [W.TxIn]
-    -> PartialTx BabbageEra
-    -> PartialTx BabbageEra
+    -> PartialTx Babbage
+    -> PartialTx Babbage
 addExtraTxIns extraIns =
     #tx . bodyTxL . inputsTxBodyL %~ (<> toLedgerInputs extraIns)
   where
@@ -1895,7 +1895,7 @@ balanceTxWithDummyChangeState utxoAssumptions utxo seed partialTx =
   where
     utxoIndex = constructUTxOIndex $ fromWalletUTxO utxo
 
-deserializeBabbageTx :: ByteString -> Tx BabbageEra
+deserializeBabbageTx :: ByteString -> Tx Babbage
 deserializeBabbageTx
     = fromCardanoApiTx
     . either (error . show) id
@@ -1940,7 +1940,7 @@ mkTestWallet walletUTxO =
   where
     utxo = fromWalletUTxO walletUTxO
 
-paymentPartialTx :: [W.TxOut] -> PartialTx BabbageEra
+paymentPartialTx :: [W.TxOut] -> PartialTx Babbage
 paymentPartialTx txouts =
     PartialTx (mkBasicTx body) mempty mempty (StakeKeyDepositMap mempty) mempty
   where
@@ -1976,8 +1976,8 @@ valueHasNegativeAndPositiveParts v =
 
 withValidityInterval
     :: ValidityInterval
-    -> PartialTx BabbageEra
-    -> PartialTx BabbageEra
+    -> PartialTx Babbage
+    -> PartialTx Babbage
 withValidityInterval vi = #tx . bodyTxL %~ vldtTxBodyL .~ vi
 
 cardanoToWalletTxOut
@@ -2104,7 +2104,7 @@ dummyTimeTranslationWithHorizon horizon =
 mainnetFeePerByte :: FeePerByte
 mainnetFeePerByte = FeePerByte 44
 
-pingPong_1 :: PartialTx BabbageEra
+pingPong_1 :: PartialTx Babbage
 pingPong_1 = PartialTx tx mempty mempty (StakeKeyDepositMap mempty) mempty
   where
     tx = deserializeBabbageTx $ unsafeFromHex $ mconcat
@@ -2113,7 +2113,7 @@ pingPong_1 = PartialTx tx mempty mempty (StakeKeyDepositMap mempty) mempty
         , "bed17320d8d1b9ff9ad086e86f44ec02000e80a10481d87980f5f6"
         ]
 
-pingPong_2 :: PartialTx BabbageEra
+pingPong_2 :: PartialTx Babbage
 pingPong_2 = PartialTx
     { tx = deserializeBabbageTx $ mconcat
         [ unsafeFromHex "84a50081825820"
@@ -2473,8 +2473,8 @@ shrinkTxBodyBabbage
         ]
   where
     shrinkLedgerTxBody
-        :: Ledger.TxBody BabbageEra
-        -> [Ledger.TxBody BabbageEra]
+        :: Ledger.TxBody Babbage
+        -> [Ledger.TxBody Babbage]
     shrinkLedgerTxBody body = tail
         [ body
             & withdrawalsTxBodyL .~ wdrls'

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -253,7 +253,7 @@ import Internal.Cardano.Write.Eras
     , IsRecentEra (recentEra)
     , RecentEra (..)
     , cardanoEra
-    , fromRecentEra
+    , cardanoEraFromRecentEra
     , shelleyBasedEra
     , shelleyBasedEraFromRecentEra
     )
@@ -2365,7 +2365,7 @@ instance forall era. IsRecentEra era => Arbitrary (Wallet era) where
                         <*> pure CardanoApi.TxOutDatumNone
                         <*> pure CardanoApi.ReferenceScriptNone
                   where
-                    era = fromRecentEra (recentEra @era)
+                    era = cardanoEraFromRecentEra (recentEra @era)
 
     shrink (Wallet utxoAssumptions utxo changeAddressGen) =
         [ Wallet utxoAssumptions utxo' changeAddressGen

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/TxSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/TxSpec.hs
@@ -28,8 +28,8 @@ import Data.Default
     )
 import Internal.Cardano.Write.Eras
     ( AnyRecentEra
-    , BabbageEra
-    , ConwayEra
+    , Babbage
+    , Conway
     )
 import Internal.Cardano.Write.Tx
     ( computeMinimumCoinForTxOut
@@ -108,7 +108,7 @@ spec = do
             it "isBelowMinimumCoinForTxOut (setCoin (result <> delta)) \
                \ == False (Babbage)"
                 $ property $ \out delta perByte -> do
-                    let pp = (def :: PParams BabbageEra)
+                    let pp = (def :: PParams Babbage)
                             & ppCoinsPerUTxOByteL .~ perByte
                     let c = delta <> computeMinimumCoinForTxOut pp out
                     isBelowMinimumCoinForTxOut pp
@@ -118,7 +118,7 @@ spec = do
             it "isBelowMinimumCoinForTxOut (setCoin (result <> delta)) \
                \ == False (Conway)"
                 $ property $ \out delta perByte -> do
-                    let pp = (def :: PParams ConwayEra)
+                    let pp = (def :: PParams Conway)
                             & ppCoinsPerUTxOByteL .~ perByte
                     let c = delta <> computeMinimumCoinForTxOut pp out
                     isBelowMinimumCoinForTxOut pp
@@ -129,10 +129,10 @@ spec = do
         it "is isomorphic to CardanoApi.UTxO" $ do
             testIsomorphism
                 (NamedFun
-                    (toCardanoApiUTxO @BabbageEra)
+                    (toCardanoApiUTxO @Babbage)
                     "toCardanoApiUTxO")
                 (NamedFun
-                    (fromCardanoApiUTxO @BabbageEra)
+                    (fromCardanoApiUTxO @Babbage)
                     "fromCardanoApiUTxO")
                 id
 

--- a/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -143,7 +143,7 @@ dummyNetworkParameters = NetworkParameters
 dummyProtocolParameters :: ProtocolParameters
 dummyProtocolParameters = fromConwayPParams
     emptyEraInfo
-    (mockPParams @Write.ConwayEra)
+    (mockPParams @Write.Conway)
 
 dummyLedgerProtocolParameters :: Write.IsRecentEra era => Write.PParams era
 dummyLedgerProtocolParameters = mockPParams

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -54,6 +54,9 @@ import Cardano.Api.Gen
     , genTxInEra
     , genWitnesses
     )
+import Cardano.Api.Shelley
+    ( ShelleyLedgerEra
+    )
 import Cardano.Mnemonic
     ( SomeMnemonic (SomeMnemonic)
     )
@@ -196,7 +199,6 @@ import Cardano.Write.Eras
     , CardanoApiEra
     , IsRecentEra
     , RecentEra (..)
-    , ShelleyLedgerEra
     , cardanoEraFromRecentEra
     )
 import Cardano.Write.Tx

--- a/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/unit/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -355,7 +355,7 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Write.Eras as Write
-    ( BabbageEra
+    ( Babbage
     , CardanoApiEra
     , IsRecentEra
     , RecentEra (RecentEraBabbage, RecentEraConway)
@@ -1383,7 +1383,7 @@ emptyTxSkeleton =
 mockTxConstraints :: TxConstraints
 mockTxConstraints =
     txConstraints
-        (mockPParams @Write.BabbageEra)
+        (mockPParams @Write.Babbage)
         TxWitnessShelleyUTxO
 data MockSelection = MockSelection
     { txInputCount :: Int

--- a/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/wallet/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -272,7 +272,6 @@ import qualified Cardano.Write.Eras as Write
     ( CardanoApiEra
     , IsRecentEra (recentEra)
     , RecentEra (RecentEraBabbage, RecentEraConway)
-    , shelleyBasedEra
     , shelleyBasedEraFromRecentEra
     )
 import qualified Data.ByteString as BS
@@ -1113,9 +1112,10 @@ mkShelleyWitness
     -> (XPrv, Passphrase "encryption")
     -> Cardano.KeyWitness (CardanoApiEra era)
 mkShelleyWitness body key =
-    Cardano.makeShelleyKeyWitness shelleyEra body (unencrypt key)
+    Cardano.makeShelleyKeyWitness shelleyBasedEra body (unencrypt key)
   where
-    shelleyEra = Write.shelleyBasedEra @era
+    shelleyBasedEra =
+        Write.shelleyBasedEraFromRecentEra (Write.recentEra @era)
     unencrypt (xprv, pwd) =
         Cardano.WitnessPaymentExtendedKey
         $ Cardano.PaymentExtendedSigningKey


### PR DESCRIPTION
This pull request tidies up the API of `Cardano.Write.Era` by removing several functions.

This pull request also renames the eras to `Babbage` and `Conway`, without `*Era` prefix, making the names consistent with `Cardano.Ledger.Api`.

The main, hidden, reason for this pull request is to reduce the dependency on `Cardano.Api`.

### Issue Number

ADP-3344
