### PR TITLE
[ADP-3344] Extend public `Cardano.Write.Tx` module

### DIFF
--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -39,6 +39,7 @@ library
   hs-source-dirs:  lib/main
   build-depends:
     , cardano-balance-tx:internal
+    , cardano-ledger-api
   exposed-modules:
     Cardano.Write.Eras
     Cardano.Write.Tx

--- a/lib/balance-tx/lib/main/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/main/Cardano/Write/Tx.hs
@@ -1,11 +1,31 @@
 -- |
--- Copyright: © 2023 Cardano Foundation
+-- Copyright: © 2023-2024 Cardano Foundation
 -- License: Apache-2.0
+--
 --
 module Cardano.Write.Tx
     (
-    -- * Balancing transactions
-      balanceTx
+    -- * UTxO
+      UTxO (..)
+
+    -- * Tx
+    , Tx
+    , TxBody
+
+    -- ** PartialTx
+    , PartialTx (..)
+    , Redeemer (..)
+    , StakeKeyDepositLookup (..)
+    , TimelockKeyWitnessCounts (..)
+
+    -- ** Balancing
+    , balanceTx
+    , UTxOAssumptions (..)
+    , UTxOIndex
+    , constructUTxOIndex
+    , ChangeAddressGen (..)
+
+    -- ** Balancing Errors
     , ErrAssignRedeemers (..)
     , ErrBalanceTx (..)
     , ErrBalanceTxAssetsInsufficientError (..)
@@ -14,19 +34,18 @@ module Cardano.Write.Tx
     , ErrBalanceTxOutputError (..)
     , ErrBalanceTxOutputErrorInfo (..)
     , ErrBalanceTxUnableToCreateChangeError (..)
-
-    -- * UTxO-related types and functions
-    , UTxO
-    , UTxOAssumptions
-    , UTxOIndex
-    , constructUTxOIndex
     ) where
 
-import Internal.Cardano.Write.Tx
-    ( UTxO
+import Cardano.Ledger.Api
+    ( Tx
+    , TxBody
+    )
+import Cardano.Ledger.Api.UTxO
+    ( UTxO (..)
     )
 import Internal.Cardano.Write.Tx.Balance
-    ( ErrAssignRedeemers (..)
+    ( ChangeAddressGen (..)
+    , ErrAssignRedeemers (..)
     , ErrBalanceTx (..)
     , ErrBalanceTxAssetsInsufficientError (..)
     , ErrBalanceTxInsufficientCollateralError (..)
@@ -34,8 +53,14 @@ import Internal.Cardano.Write.Tx.Balance
     , ErrBalanceTxOutputError (..)
     , ErrBalanceTxOutputErrorInfo (..)
     , ErrBalanceTxUnableToCreateChangeError (..)
-    , UTxOAssumptions
+    , PartialTx (..)
+    , Redeemer (..)
+    , StakeKeyDepositLookup (..)
+    , UTxOAssumptions (..)
     , UTxOIndex
     , balanceTx
     , constructUTxOIndex
+    )
+import Internal.Cardano.Write.Tx.Sign
+    ( TimelockKeyWitnessCounts (..)
     )


### PR DESCRIPTION
This pull request extends the public module `Cardano.Write.Tx` to export sufficient types and constructors so that a client module can actually call `balanceTx`.

We also adapt the current usage sites of `balanceTx` to
* use the public module
* still using the `Write` qualifier.

### Issue Number

ADP-3344
