### PR TITLE
[ADP-3344] Make `fromWalletUTxO` and `toWalletUTxO` internal

### DIFF
--- a/lib/api/cardano-wallet-api.cabal
+++ b/lib/api/cardano-wallet-api.cabal
@@ -48,6 +48,7 @@ library
     , cardano-balance-tx:{cardano-balance-tx, internal}
     , cardano-binary
     , cardano-crypto
+    , cardano-ledger-api
     , cardano-ledger-core
     , cardano-wallet
     , cardano-wallet-launcher


### PR DESCRIPTION
This pull request removes all usages of the functions `fromWalletUTxO` and `toWalletUTxO` that is not internal to the `Internal.Cardano.Write.*` hierarchy, at the expense of maybe duplicating them at the usage site.

### Comments

This move contributes to the following goal:

* The public modules `Cardano.Write.*` should not export types that come from `Cardano.Wallet.Primitive.*`. Instead, `Cardano.Write.*` relies on `Cardano.Ledger.Api` as basis for talking about common blockchain concepts.

In this way, we can

1. Remove the `Cardano.Wallet.Primitive.*` types from _within_ the `balance-tx` package independently of the rest of the codebase — and e.g. postpone that removal.
2. Freeze the legacy `Cardano.Wallet` in place while advancing the `balance-tx` package.

### Issue Number

ADP-3344