### PR TITLE
[ADP-3344] Implement `createPayment` using `balanceTx`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -157,8 +157,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/cardano-foundation/cardano-wallet-agda
-    tag: 20b263d494ee91d2f353e2645c045f728d7eb076
-    --sha256: 1j8mph2frsxqwq5ajsfhg0ixwxrs73dls34kbf0s0gh0y1gchvkb
+    tag: 04fb3e743ab874811d6c6850a218eee8bf110866
+    --sha256: 1m1kxinqir9a5i261ph7lah5wpy9qic9yqk47x54q65zws8r4ply
     subdir:
       lib/customer-deposit-wallet-pure
       lib/cardano-wallet-read

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -57,6 +57,7 @@ library
     , cardano-balance-tx
     , cardano-crypto
     , cardano-ledger-api
+    , cardano-ledger-core
     , cardano-strict-containers
     , cardano-wallet
     , cardano-wallet-network-layer
@@ -67,16 +68,19 @@ library
     , customer-deposit-wallet-pure
     , delta-store
     , delta-types
+    , digest
     , fingertree
     , io-classes
     , microlens
     , monoidal-containers
     , mtl
+    , MonadRandom
     , mwc-random
     , OddWord
     , random
     , text
     , time
+    , transformers
 
   exposed-modules:
     Cardano.Wallet.Deposit.IO

--- a/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
@@ -72,6 +72,7 @@ import Cardano.Wallet.Deposit.IO.Resource
     )
 import Cardano.Wallet.Deposit.Pure
     ( Customer
+    , ErrCreatePayment
     , Word31
     , fromXPubAndGenesis
     )
@@ -405,7 +406,7 @@ getTxHistoryByTime = onWalletInstance WalletIO.getTxHistoryByTime
 
 createPayment
     :: [(Address, Read.Value)]
-    -> WalletResourceM (Maybe Write.TxBody)
+    -> WalletResourceM (Either ErrCreatePayment Write.Tx)
 createPayment = onWalletInstance . WalletIO.createPayment
 
 getBIP32PathsForOwnedInputs

--- a/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
@@ -44,7 +44,7 @@ module Cardano.Wallet.Deposit.REST
       -- ** Writing to the blockchain
     , createPayment
     , getBIP32PathsForOwnedInputs
-    , signTxBody
+    , signTx
     , walletExists
     , walletPublicIdentity
     , deleteWallet
@@ -409,12 +409,12 @@ createPayment
 createPayment = onWalletInstance . WalletIO.createPayment
 
 getBIP32PathsForOwnedInputs
-    :: Write.TxBody
+    :: Write.Tx
     -> WalletResourceM [BIP32Path]
 getBIP32PathsForOwnedInputs =
     onWalletInstance . WalletIO.getBIP32PathsForOwnedInputs
 
-signTxBody
-    :: Write.TxBody
+signTx
+    :: Write.Tx
     -> WalletResourceM (Maybe Write.Tx)
-signTxBody = onWalletInstance . WalletIO.signTxBody
+signTx = onWalletInstance . WalletIO.signTx

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -33,7 +33,7 @@ module Cardano.Wallet.Deposit.IO
       -- ** Writing to the blockchain
     , createPayment
     , getBIP32PathsForOwnedInputs
-    , signTxBody
+    , signTx
     , WalletStore
     , walletPublicIdentity
     ) where
@@ -293,12 +293,12 @@ createPayment a w =
     Wallet.createPayment a <$> readWalletState w
 
 getBIP32PathsForOwnedInputs
-    :: Write.TxBody -> WalletInstance -> IO [BIP32Path]
+    :: Write.Tx -> WalletInstance -> IO [BIP32Path]
 getBIP32PathsForOwnedInputs a w =
     Wallet.getBIP32PathsForOwnedInputs a <$> readWalletState w
 
-signTxBody :: Write.TxBody -> WalletInstance -> IO (Maybe Write.Tx)
-signTxBody txbody w = Wallet.signTxBody txbody <$> readWalletState w
+signTx :: Write.Tx -> WalletInstance -> IO (Maybe Write.Tx)
+signTx a w = Wallet.signTx a <$> readWalletState w
 
 {-----------------------------------------------------------------------------
     Logging

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
@@ -89,6 +89,8 @@ newNetworkEnvMock = do
                 -- brief delay to account for asynchronous chain followers
                 threadDelay 100
                 pure $ Right ()
+            , currentPParams =
+                pure $ Read.EraValue Read.mockPParamsConway
             , getTimeInterpreter =
                 pure Time.mockTimeInterpreter
             , slotsToUTCTimes = pure . Time.unsafeSlotsToUTCTimes

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Type.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Type.hs
@@ -60,6 +60,9 @@ data NetworkEnv m block = NetworkEnv
         :: Write.Tx
         -> m (Either ErrPostTx ())
     -- ^ Post a transaction to the Cardano network.
+    , currentPParams
+        :: m (Read.EraValue Read.PParams)
+    -- ^ Current protocol paramters.
     , getTimeInterpreter
         :: m Time.TimeInterpreter
         -- ^ Get the current 'TimeInterpreter' from the Cardano node.

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -42,7 +42,7 @@ module Cardano.Wallet.Deposit.Pure
     , BIP32Path (..)
     , DerivationType (..)
     , getBIP32PathsForOwnedInputs
-    , signTxBody
+    , signTx
     , addTxSubmission
     , listTxsInSubmission
 
@@ -352,13 +352,15 @@ createPayment = undefined
 -- needs balanceTx
 -- needs to sign the transaction
 
-getBIP32PathsForOwnedInputs
-    :: Write.TxBody -> WalletState -> [BIP32Path]
-getBIP32PathsForOwnedInputs txbody w =
+getBIP32PathsForOwnedInputs :: Write.Tx -> WalletState -> [BIP32Path]
+getBIP32PathsForOwnedInputs tx w =
     getBIP32Paths w
         . resolveInputAddresses
-        $ Write.spendInputs txbody <> Write.collInputs txbody
+        $ Write.spendInputs txBody <> Write.collInputs txBody
   where
+    txBody :: Write.TxBody
+    txBody = undefined tx
+
     resolveInputAddresses :: Set Read.TxIn -> [Read.Address]
     resolveInputAddresses ins =
         map (Read.address . snd)
@@ -369,8 +371,8 @@ getBIP32Paths :: WalletState -> [Read.Address] -> [BIP32Path]
 getBIP32Paths w =
     mapMaybe $ Address.getBIP32Path (addresses w)
 
-signTxBody :: Write.TxBody -> WalletState -> Maybe Write.Tx
-signTxBody _txbody _w = undefined
+signTx :: Write.Tx -> WalletState -> Maybe Write.Tx
+signTx _tx _w = undefined
 
 addTxSubmission :: Write.Tx -> WalletState -> WalletState
 addTxSubmission _tx _w = undefined

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -217,7 +217,7 @@ fromXPubAndGenesis xpub knownCustomerCount genesisData =
         { walletTip = Read.GenesisPoint
         , addresses =
             Address.fromXPubAndCount network xpub knownCustomerCount
-        , utxoHistory = UTxOHistory.empty initialUTxO
+        , utxoHistory = UTxOHistory.fromOrigin initialUTxO
         , txHistory = mempty
         , submissions = Sbm.empty
         , rootXSignKey = Nothing

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Cardano.Wallet.Deposit.Pure
@@ -38,7 +39,9 @@ module Cardano.Wallet.Deposit.Pure
     , getTxHistoryByTime
 
       -- ** Writing to the blockchain
+    , ErrCreatePayment (..)
     , createPayment
+
     , BIP32Path (..)
     , DerivationType (..)
     , getBIP32PathsForOwnedInputs
@@ -93,6 +96,15 @@ import Cardano.Wallet.Deposit.Read
     , TxId
     , WithOrigin
     )
+import Control.Monad.Trans.Except
+    ( runExceptT
+    )
+import Data.Bifunctor
+    ( first
+    )
+import Data.Digest.CRC32
+    ( crc32
+    )
 import Data.Foldable
     ( fold
     , foldl'
@@ -127,6 +139,8 @@ import qualified Cardano.Wallet.Deposit.Pure.UTxO as UTxO
 import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory as UTxOHistory
 import qualified Cardano.Wallet.Deposit.Read as Read
 import qualified Cardano.Wallet.Deposit.Write as Write
+import qualified Cardano.Wallet.Read.Hash as Hash
+import qualified Control.Monad.Random.Strict as Random
 import qualified Data.Delta as Delta
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map
@@ -139,11 +153,18 @@ type Customer = Address.Customer
 
 data WalletState = WalletState
     { walletTip :: Read.ChainPoint
+    -- ^ The wallet includes information from all blocks until
+    -- and including this one.
     , addresses :: !Address.AddressState
+    -- ^ Addresses and public keys known to this wallet.
     , utxoHistory :: !UTxOHistory.UTxOHistory
+    -- ^ UTxO of this wallet, with support for rollbacks.
     , txHistory :: !TxHistory
+    -- ^ (Summarized) transaction history of this wallet.
     , submissions :: Sbm.TxSubmissions
+    -- ^ Queue of pending transactions.
     , rootXSignKey :: Maybe XPrv
+    -- ^ Maybe a private key for signing transactions.
     -- , info :: !WalletInfo
     }
 
@@ -342,15 +363,99 @@ wonders interval =
 
 {-----------------------------------------------------------------------------
     Operations
-    Writing to blockchain
+    Constructing transactions
 ------------------------------------------------------------------------------}
+data ErrCreatePayment
+    = ErrCreatePaymentNotRecentEra (Read.EraValue Read.Era)
+    | ErrCreatePaymentBalanceTx (Write.ErrBalanceTx Write.Conway)
+    deriving (Eq, Show)
 
+-- | Create a payment to a list of destinations.
 createPayment
-    :: [(Address, Write.Value)] -> WalletState -> Maybe Write.TxBody
-createPayment = undefined
+    :: Read.EraValue Read.PParams
+    -> Write.TimeTranslation
+    -> [(Address, Write.Value)]
+    -> WalletState
+    -> Either ErrCreatePayment Write.Tx
+createPayment (Read.EraValue (Read.PParams pparams :: Read.PParams era)) a b w =
+    case Read.theEra :: Read.Era era of
+        Read.Conway ->
+            first ErrCreatePaymentBalanceTx
+                $ createPaymentConway pparams a b w
+        era' -> Left $ ErrCreatePaymentNotRecentEra (Read.EraValue era')
 
--- needs balanceTx
--- needs to sign the transaction
+-- | In the Conway era: Create a payment to a list of destinations.
+createPaymentConway
+    :: Write.PParams Write.Conway
+    -> Write.TimeTranslation
+    -> [(Address, Write.Value)]
+    -> WalletState
+    -> Either (Write.ErrBalanceTx Write.Conway) Write.Tx
+createPaymentConway pparams timeTranslation destinations w =
+    fmap (Read.Tx . fst)
+    . flip Random.evalRand (pilferRandomGen w)
+    . runExceptT
+    . balance
+        (availableUTxO w)
+        (addresses w)
+    . mkPartialTx
+    $ paymentTxBody
+  where
+    paymentTxBody :: Write.TxBody
+    paymentTxBody = Write.TxBody
+        { spendInputs = mempty
+        , collInputs = mempty
+        , txouts =
+            Map.fromList $ zip [(toEnum 0)..] $ map (uncurry Write.mkTxOut) destinations
+        , collRet = Nothing
+        }
+
+    mkPartialTx :: Write.TxBody -> Write.PartialTx Write.Conway
+    mkPartialTx txbody = Write.PartialTx
+        { tx = Read.unTx $ Write.mkTx txbody
+        , extraUTxO = mempty :: Write.UTxO Write.Conway
+        , redeemers = mempty
+        , stakeKeyDeposits = Write.StakeKeyDepositMap mempty
+        , timelockKeyWitnessCounts = Write.TimelockKeyWitnessCounts mempty
+        }
+
+    balance utxo addressState =
+        Write.balanceTx
+            pparams
+            timeTranslation
+            Write.AllKeyPaymentCredentials
+            (Write.constructUTxOIndex $ Write.toConwayUTxO utxo)
+            (changeAddressGen addressState)
+            ()
+
+    changeAddressGen s = Write.ChangeAddressGen
+        { Write.genChangeAddress =
+            first Read.decompactAddr . Address.newChangeAddress s
+        , Write.maxLengthChangeAddress =
+            Read.decompactAddr $ Address.mockMaxLengthChangeAddress s
+        }
+
+-- | Use entropy contained in the current 'WalletState'
+-- to construct a pseudorandom seed.
+-- (NOT a viable source of cryptographic randomness.)
+--
+-- Possible downsides of this approach:
+--
+-- 1. security/privacy
+-- 2. concurrency
+-- 3. retries for different coin selections
+pilferRandomGen :: WalletState -> Random.StdGen
+pilferRandomGen =
+    Random.mkStdGen . fromEnum . fromChainPoint . walletTip
+  where
+    fromChainPoint (Read.GenesisPoint) = 0
+    fromChainPoint (Read.BlockPoint _ headerHash) =
+        crc32 $ Hash.hashToBytes headerHash
+
+{-----------------------------------------------------------------------------
+    Operations
+    Signing transactions
+------------------------------------------------------------------------------}
 
 getBIP32PathsForOwnedInputs :: Write.Tx -> WalletState -> [BIP32Path]
 getBIP32PathsForOwnedInputs tx w =
@@ -373,6 +478,11 @@ getBIP32Paths w =
 
 signTx :: Write.Tx -> WalletState -> Maybe Write.Tx
 signTx _tx _w = undefined
+
+{-----------------------------------------------------------------------------
+    Operations
+    Pending transactions
+------------------------------------------------------------------------------}
 
 addTxSubmission :: Write.Tx -> WalletState -> WalletState
 addTxSubmission _tx _w = undefined

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -49,6 +49,7 @@ module Cardano.Wallet.Deposit.Read
     , Read.mockRawHeaderHash
 
     , Read.PParams (..)
+    , Read.mockPParamsConway
 
     , Read.GenesisData
     , Read.GenesisHash

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -8,9 +8,11 @@
 --
 -- TODO: Match this up with the @Read@ hierarchy.
 module Cardano.Wallet.Deposit.Read
-    ( Read.IsEra
+    ( Read.IsEra (..)
+    , Read.Era (..)
     , Read.EraValue (..)
     , Read.Conway
+    , Read.getEra
 
     , Read.SlotNo
     , Read.ChainPoint (..)
@@ -22,6 +24,9 @@ module Cardano.Wallet.Deposit.Read
     , KeyHash
     , NetworkTag (..)
     , mkEnterpriseAddress
+    , Addr
+    , compactAddr
+    , decompactAddr
 
     , Ix
     , Read.TxIn
@@ -43,6 +48,8 @@ module Cardano.Wallet.Deposit.Read
     , mockNextBlock
     , Read.mockRawHeaderHash
 
+    , Read.PParams (..)
+
     , Read.GenesisData
     , Read.GenesisHash
     , Read.mockGenesisDataMainnet
@@ -53,6 +60,11 @@ module Cardano.Wallet.Deposit.Read
 
 import Prelude
 
+import Cardano.Ledger.Address
+    ( Addr
+    , compactAddr
+    , decompactAddr
+    )
 import Cardano.Wallet.Address.Encoding
     ( Credential (..)
     , EnterpriseAddr (..)

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Time.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Time.hs
@@ -34,7 +34,7 @@ import Cardano.Wallet.Primitive.Slotting
     , mkSingleEraInterpreter
     )
 import Cardano.Wallet.Primitive.Slotting.TimeTranslation
-    ( toTimeTranslation
+    ( toTimeTranslationPure
     )
 import Cardano.Wallet.Primitive.Types.SlottingParameters
     ( ActiveSlotCoefficient (..)
@@ -92,6 +92,9 @@ mockSlottingParameters = SlottingParameters
 {-----------------------------------------------------------------------------
     TimeInterpreter
 ------------------------------------------------------------------------------}
+toTimeTranslation :: TimeInterpreter -> Write.TimeTranslation
+toTimeTranslation = toTimeTranslationPure
+
 unsafeSlotsToUTCTimes :: Set.Set Slot -> Map.Map Slot (WithOrigin UTCTime)
 unsafeSlotsToUTCTimes slots =
     Map.fromList $ do

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
@@ -96,8 +96,9 @@ data TxBody = TxBody
     }
     deriving (Show)
 
+-- | Inject a number of ADA, i.e. a million lovelace.
 mkAda :: Integer -> Value
-mkAda = Read.injectCoin . Read.CoinC
+mkAda = Read.injectCoin . Read.CoinC . (* 1000000)
 
 mkTxOut :: Address -> Value -> TxOut
 mkTxOut = Read.mkBasicTxOut

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
@@ -122,14 +122,14 @@ payFromFaucet env destinations =
             Map.fromList $ zip [toEnum 0..] $ map toTxOut destinations
         , Write.collRet = Nothing
         }
-    tx = signTx (xprv (faucet env)) [] txBody
+    tx = signTx (xprv (faucet env)) [] $ Write.mkTx txBody
 
 {-----------------------------------------------------------------------------
     Transaction submission
 ------------------------------------------------------------------------------}
 
-signTx :: XPrv -> [BIP32Path] -> Write.TxBody -> Write.Tx
-signTx _ _ = Write.mkTx
+signTx :: XPrv -> [BIP32Path] -> Write.Tx -> Write.Tx
+signTx _ _ = id
 
 submitTx :: ScenarioEnv -> Write.Tx -> IO ()
 submitTx env tx = do

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Exchanges.lhs.md
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Exchanges.lhs.md
@@ -39,6 +39,7 @@ import Cardano.Wallet.Deposit.Read
     ( Address
     , Value
     , TxId
+    , lessOrEqual
     )
 import Test.Scenario.Blockchain
     ( ScenarioEnv
@@ -211,7 +212,7 @@ scenarioCreatePayment xprv env destination w = do
 
     -- funds have been moved out of the wallet
     value2 <- Wallet.availableBalance w
-    assert $ value2 <> coin == value1
+    assert $ (value2 <> coin) `lessOrEqual` value1
 
     -- but the original deposit amount is still recorded
     txsummaries <- getCustomerDeposits customer w

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Exchanges.lhs.md
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Exchanges.lhs.md
@@ -204,9 +204,9 @@ scenarioCreatePayment xprv env destination w = do
     assert $ value1 == (coin <> coin)
 
     -- createPayment
-    Just txBody <- Wallet.createPayment [(destination, coin)] w
-    paths <- Wallet.getBIP32PathsForOwnedInputs txBody w
-    let tx = signTx xprv paths txBody
+    Right txUnsigned <- Wallet.createPayment [(destination, coin)] w
+    paths <- Wallet.getBIP32PathsForOwnedInputs txUnsigned w
+    let tx = signTx xprv paths txUnsigned
     submitTx env tx
 
     -- funds have been moved out of the wallet

--- a/lib/wallet/src/Cardano/Wallet/Primitive/Slotting/TimeTranslation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Primitive/Slotting/TimeTranslation.hs
@@ -1,5 +1,6 @@
 module Cardano.Wallet.Primitive.Slotting.TimeTranslation
-    (  toTimeTranslation
+    ( toTimeTranslation
+    , toTimeTranslationPure
     ) where
 
 import Prelude
@@ -18,6 +19,9 @@ import Control.Monad.Trans.Except
     , runExcept
     , runExceptT
     )
+import Data.Functor.Identity
+    ( Identity (runIdentity)
+    )
 import Internal.Cardano.Write.Tx.TimeTranslation
     ( TimeTranslation
     , timeTranslationFromEpochInfo
@@ -34,3 +38,11 @@ toTimeTranslation timeInterpreter = do
         runExceptT (toEpochInfo timeInterpreter)
             >>= either throwIO (pure . hoistEpochInfo runExcept)
     pure $ timeTranslationFromEpochInfo (getSystemStart timeInterpreter) info
+
+toTimeTranslationPure
+    :: TimeInterpreter Identity
+    -> TimeTranslation
+toTimeTranslationPure ti =
+    timeTranslationFromEpochInfo
+        (getSystemStart ti)
+        (hoistEpochInfo runExcept $ runIdentity $ toEpochInfo ti)


### PR DESCRIPTION
This pull request implements the `createPayment` function in terms of `balanceTx`.

### Comments

* We make the scenario test for `createPayment` executable, but still mark it as pending, as we need to wait for the `getCustomerDeposits` function to support `rollForward`.

### Issue Number

ADP-3344
