### PR TITLE
[ADP-3344] Re-export `balanceTx` in `Cardano.Wallet.Deposit.Write`

### DIFF
--- a/lib/balance-tx/lib/main/Cardano/Write/Tx.hs
+++ b/lib/balance-tx/lib/main/Cardano/Write/Tx.hs
@@ -20,6 +20,7 @@ module Cardano.Write.Tx
 
     -- ** Balancing
     , balanceTx
+    , TimeTranslation
     , UTxOAssumptions (..)
     , UTxOIndex
     , constructUTxOIndex
@@ -63,4 +64,7 @@ import Internal.Cardano.Write.Tx.Balance
     )
 import Internal.Cardano.Write.Tx.Sign
     ( TimelockKeyWitnessCounts (..)
+    )
+import Internal.Cardano.Write.Tx.TimeTranslation
+    ( TimeTranslation
     )

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -54,7 +54,6 @@ library
   build-depends:
     , async
     , base
-    , bytestring
     , cardano-crypto
     , cardano-ledger-api
     , cardano-strict-containers

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -54,6 +54,7 @@ library
   build-depends:
     , async
     , base
+    , cardano-balance-tx
     , cardano-crypto
     , cardano-ledger-api
     , cardano-strict-containers

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -32,7 +32,7 @@ module Cardano.Wallet.Deposit.Read
     , UTxO
 
     , Read.TxId
-    , Read.Tx
+    , Read.Tx (..)
     , Read.utxoFromEraTx
 
     , Read.Block

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
@@ -4,7 +4,8 @@
 --
 -- TODO: Match this up with the @Write@ hierarchy.
 module Cardano.Wallet.Deposit.Write
-    ( Address
+    ( -- * Basic types
+      Address
 
     , Value
 
@@ -15,6 +16,24 @@ module Cardano.Wallet.Deposit.Write
     , TxIn
     , TxOut
 
+    -- * Transaction balancing
+    , Write.IsRecentEra
+    , Write.Conway
+    , L.PParams
+    , Write.UTxOAssumptions (..)
+    , Write.ChangeAddressGen (..)
+    , Write.StakeKeyDepositLookup (..)
+    , Write.TimelockKeyWitnessCounts (..)
+    , Write.UTxOIndex
+    , Write.constructUTxOIndex
+    , Write.UTxO
+    , toConwayUTxO
+    , Write.PartialTx (..)
+    , Write.ErrBalanceTx (..)
+    , Write.balanceTx
+
+    -- ** Time interpreter
+    , Write.TimeTranslation
     -- * Helper functions
     , mkAda
     , mkTxOut
@@ -59,12 +78,13 @@ import Lens.Micro
 import qualified Cardano.Ledger.Api as L
 import qualified Cardano.Ledger.Api.Tx.In as L
 import qualified Cardano.Wallet.Read as Read
+import qualified Cardano.Write.Eras as Write
+import qualified Cardano.Write.Tx as Write
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
 {-----------------------------------------------------------------------------
-    Type definitions
-    with dummies
+    Convenience TxBody
 ------------------------------------------------------------------------------}
 type Tx = Read.Tx Read.Conway
 
@@ -113,3 +133,6 @@ toConwayTxOut :: TxOut -> L.TxOut L.Conway
 toConwayTxOut txout =
     case toConwayOutput txout of
         Output o -> o
+
+toConwayUTxO :: Map TxIn TxOut -> Write.UTxO L.Conway
+toConwayUTxO = Write.UTxO . Map.map toConwayTxOut

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
@@ -18,7 +18,6 @@ module Cardano.Wallet.Deposit.Write
     -- * Helper functions
     , mkAda
     , mkTxOut
-    , mockTxId
     , toConwayTx
     ) where
 
@@ -35,18 +34,11 @@ import Cardano.Wallet.Deposit.Read
     , TxOut
     , Value
     )
-import Cardano.Wallet.Read.Hash
-    ( hashFromBytesShort
-    )
 import Cardano.Wallet.Read.Tx
     ( toConwayOutput
-    , txIdFromHash
     )
 import Data.Map
     ( Map
-    )
-import Data.Maybe
-    ( fromJust
     )
 import Data.Maybe.Strict
     ( StrictMaybe
@@ -67,9 +59,6 @@ import Lens.Micro
 import qualified Cardano.Ledger.Api as L
 import qualified Cardano.Ledger.Api.Tx.In as L
 import qualified Cardano.Wallet.Read as Read
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as B8
-import qualified Data.ByteString.Short as SBS
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
@@ -124,11 +113,3 @@ toConwayTxOut :: TxOut -> L.TxOut L.Conway
 toConwayTxOut txout =
     case toConwayOutput txout of
         Output o -> o
-
-mockTxId :: Show a => a -> TxId
-mockTxId x =
-    txIdFromHash
-    . fromJust
-    . hashFromBytesShort
-    . SBS.pack
-    $ take 32 (BS.unpack (B8.pack $ show x) <> repeat 0)


### PR DESCRIPTION
This pull request re-exports the `balanceTx` function from `Cardano.Wallet.Deposit.Write` and makes explicit the collection of types needed to call this function.

This pull request also removes the superfluous function `mockTxId`.

### Comments

* This pull request is part of the preparations for using `balanceTx` in `createPayment`.

### Issue Number

ADP-3344
