### PR TITLE
[ADP-3344] Add `currentPParams` to `NetworkLayer`.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -157,8 +157,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/cardano-foundation/cardano-wallet-agda
-    tag: 6de42514a16ed2c059fc9899d9bcc271ce842a95
-    --sha256: 05yqr5vpzckcrcpfvypgy5cbim2xdgixcky30mls74mmd64q2p3s
+    tag: 20b263d494ee91d2f353e2645c045f728d7eb076
+    --sha256: 1j8mph2frsxqwq5ajsfhg0ixwxrs73dls34kbf0s0gh0y1gchvkb
     subdir:
       lib/customer-deposit-wallet-pure
       lib/cardano-wallet-read

--- a/lib/benchmarks/exe/api-bench.hs
+++ b/lib/benchmarks/exe/api-bench.hs
@@ -200,9 +200,6 @@ import qualified Cardano.Wallet.DB.Layer as Sqlite
 import qualified Cardano.Wallet.Primitive.Types.UTxOStatistics as UTxOStatistics
 import qualified Cardano.Wallet.Read as Read
 import qualified Cardano.Wallet.Transaction as Tx
-import qualified Cardano.Write.Eras as Write
-    ( MaybeInRecentEra (InRecentEraBabbage)
-    )
 import qualified Data.Aeson as Aeson
 import Data.Functor
     ( (<&>)
@@ -620,6 +617,10 @@ mockNetworkLayer :: NetworkLayer IO Read.ConsensusBlock
 mockNetworkLayer = dummyNetworkLayer
     { timeInterpreter = hoistTimeInterpreter liftIO mockTimeInterpreter
     , currentSlottingParameters = pure dummySlottingParameters
+    , currentPParams = pure $ Read.EraValue
+        ( Read.PParams dummyLedgerProtocolParameters
+            :: Read.PParams Read.Babbage
+        )
     , currentProtocolParameters = pure dummyProtocolParameters
     , currentProtocolParametersInRecentEras =
         pure $ Write.InRecentEraBabbage dummyLedgerProtocolParameters

--- a/lib/benchmarks/exe/api-bench.hs
+++ b/lib/benchmarks/exe/api-bench.hs
@@ -622,8 +622,6 @@ mockNetworkLayer = dummyNetworkLayer
             :: Read.PParams Read.Babbage
         )
     , currentProtocolParameters = pure dummyProtocolParameters
-    , currentProtocolParametersInRecentEras =
-        pure $ Write.InRecentEraBabbage dummyLedgerProtocolParameters
     , currentNodeEra = pure $ Cardano.anyCardanoEra Cardano.BabbageEra
     , currentNodeTip = pure Read.BlockTip
         { Read.slotNo = Read.SlotNo 123456789

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -161,6 +161,7 @@ library rest
     , crypto-primitives
     , customer-deposit-wallet
     , customer-deposit-wallet-pure
+    , deepseq
     , delta-store
     , directory
     , filepath

--- a/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
@@ -86,6 +86,9 @@ import Codec.Serialise
     ( deserialise
     , serialise
     )
+import Control.DeepSeq
+    ( deepseq
+    )
 import Control.Monad.IO.Class
     ( MonadIO (..)
     )
@@ -332,8 +335,8 @@ initXPubWallet tr bootEnv dir xpub users = do
                         xpub
                         users
                     $ \i -> do
-                        ls <- WalletIO.listCustomers i
-                        last ls `seq` f i
+                        addresses <- map snd <$> WalletIO.listCustomers i
+                        addresses `deepseq` f i
             Nothing ->
                 pure
                     $ Left

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory/Mock.hs
@@ -24,14 +24,13 @@ import Cardano.Wallet.Deposit.Pure.API.TxHistory
     )
 import Cardano.Wallet.Deposit.Read
     ( Address
-    , Value
-    , WithOrigin (..)
     )
 import Cardano.Wallet.Read
     ( Coin
     , SlotNo (..)
     , TxId
     , Value (..)
+    , WithOrigin (..)
     , txIdFromHash
     )
 import Cardano.Wallet.Read.Hash
@@ -125,7 +124,7 @@ valueTransferG g = do
     spentOrReceived <- uniformRM (0, 11) g
     spent <- createSpent g spentOrReceived
     received <- createReceived g spentOrReceived
-    pure $ ValueTransfer{..}
+    pure $ ValueTransferC{..}
 
 unsafeMkTxId :: String -> TxId
 unsafeMkTxId = txIdFromHash . fromJust . hashFromStringAsHex

--- a/lib/network-layer/src/Cardano/Wallet/Network.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network.hs
@@ -130,6 +130,10 @@ data NetworkLayer m block = NetworkLayer
     , currentNodeEra
         :: m AnyCardanoEra
     -- ^ Get the era the node is currently in.
+    , currentPParams
+        :: m (Read.EraValue Read.PParams)
+    -- ^ Get the last known protocol parameters. In principle, these can
+    -- only change once per epoch.
     , currentProtocolParameters
         :: m ProtocolParameters
     -- ^ Get the last known protocol parameters. In principle, these can

--- a/lib/network-layer/src/Cardano/Wallet/Network.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network.hs
@@ -138,9 +138,6 @@ data NetworkLayer m block = NetworkLayer
         :: m ProtocolParameters
     -- ^ Get the last known protocol parameters. In principle, these can
     -- only change once per epoch.
-    , currentProtocolParametersInRecentEras
-        :: m (MaybeInRecentEra Write.PParams)
-    -- ^ Get the last known protocol parameters for recent eras.
     , currentSlottingParameters
         :: m SlottingParameters
     -- ^ Get the last known slotting parameters. In principle, these can

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -430,7 +430,7 @@ withNetworkLayer tr pipeliningStrategy np conn ver tol action = do
 
 -- | Network parameters and protocol parameters for the node's current tip.
 data NetworkParams = NetworkParams
-    { protocolParams :: MaybeInRecentEra Write.PParams
+    { protocolParamsRecent :: MaybeInRecentEra Write.PParams
     , protocolParamsLegacy :: ProtocolParameters
     , slottingParamsLegacy :: SlottingParameters
     }
@@ -518,7 +518,7 @@ withNodeNetworkLayerBase
                     protocolParamsLegacy
                         <$> atomically (readTMVar networkParamsVar)
                 , currentProtocolParametersInRecentEras =
-                    protocolParams <$> atomically (readTMVar networkParamsVar)
+                    protocolParamsRecent <$> atomically (readTMVar networkParamsVar)
                 , currentSlottingParameters =
                     slottingParamsLegacy
                         <$> atomically (readTMVar networkParamsVar)
@@ -959,7 +959,7 @@ mkWalletToNodeProtocols
 
         let queryParams =
                 NetworkParams
-                    <$> LSQ.protocolParams
+                    <$> LSQ.protocolParamsRecent
                     <*> LSQ.protocolParamsLegacy
                     <*> (LSQ.slottingParamsLegacy np)
 

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -392,7 +392,6 @@ import qualified Data.ByteString as BS
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
-import qualified Internal.Cardano.Write.Tx as Write
 import qualified Ouroboros.Consensus.Cardano.Block as Consensus
 import qualified Ouroboros.Consensus.Shelley.Ledger.Mempool as Consensus
 
@@ -431,7 +430,6 @@ withNetworkLayer tr pipeliningStrategy np conn ver tol action = do
 -- | Network parameters and protocol parameters for the node's current tip.
 data NetworkParams = NetworkParams
     { protocolParams :: Read.EraValue Read.PParams
-    , protocolParamsRecent :: MaybeInRecentEra Write.PParams
     , protocolParamsLegacy :: ProtocolParameters
     , slottingParamsLegacy :: SlottingParameters
     }
@@ -520,8 +518,6 @@ withNodeNetworkLayerBase
                 , currentProtocolParameters =
                     protocolParamsLegacy
                         <$> atomically (readTMVar networkParamsVar)
-                , currentProtocolParametersInRecentEras =
-                    protocolParamsRecent <$> atomically (readTMVar networkParamsVar)
                 , currentSlottingParameters =
                     slottingParamsLegacy
                         <$> atomically (readTMVar networkParamsVar)
@@ -963,7 +959,6 @@ mkWalletToNodeProtocols
         let queryParams =
                 NetworkParams
                     <$> LSQ.protocolParams
-                    <*> LSQ.protocolParamsRecent
                     <*> LSQ.protocolParamsLegacy
                     <*> (LSQ.slottingParamsLegacy np)
 

--- a/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/Implementation.hs
@@ -430,7 +430,8 @@ withNetworkLayer tr pipeliningStrategy np conn ver tol action = do
 
 -- | Network parameters and protocol parameters for the node's current tip.
 data NetworkParams = NetworkParams
-    { protocolParamsRecent :: MaybeInRecentEra Write.PParams
+    { protocolParams :: Read.EraValue Read.PParams
+    , protocolParamsRecent :: MaybeInRecentEra Write.PParams
     , protocolParamsLegacy :: ProtocolParameters
     , slottingParamsLegacy :: SlottingParameters
     }
@@ -514,6 +515,8 @@ withNodeNetworkLayerBase
                     readCurrentNodeEra
                 , watchNodeTip =
                     _watchNodeTip readNodeTip
+                , currentPParams =
+                    protocolParams <$> atomically (readTMVar networkParamsVar)
                 , currentProtocolParameters =
                     protocolParamsLegacy
                         <$> atomically (readTMVar networkParamsVar)
@@ -959,7 +962,8 @@ mkWalletToNodeProtocols
 
         let queryParams =
                 NetworkParams
-                    <$> LSQ.protocolParamsRecent
+                    <$> LSQ.protocolParams
+                    <*> LSQ.protocolParamsRecent
                     <*> LSQ.protocolParamsLegacy
                     <*> (LSQ.slottingParamsLegacy np)
 

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery.hs
@@ -18,7 +18,6 @@ import Cardano.Wallet.Network.LocalStateQuery.Extra
 import Cardano.Wallet.Network.LocalStateQuery.PParams
     ( protocolParams
     , protocolParamsLegacy
-    , protocolParamsRecent
     , slottingParamsLegacy
     )
 import Cardano.Wallet.Network.LocalStateQuery.RewardAccount

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery.hs
@@ -18,6 +18,7 @@ import Cardano.Wallet.Network.LocalStateQuery.Extra
 import Cardano.Wallet.Network.LocalStateQuery.PParams
     ( protocolParams
     , protocolParamsLegacy
+    , protocolParamsRecent
     , slottingParamsLegacy
     )
 import Cardano.Wallet.Network.LocalStateQuery.RewardAccount

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/Extra.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/Extra.hs
@@ -11,6 +11,7 @@
 module Cardano.Wallet.Network.LocalStateQuery.Extra
     ( byronOrShelleyBased
     , onAnyEra
+    , onAnyEra'
     , shelleyBased
     , currentEra
     ) where
@@ -23,6 +24,15 @@ import Cardano.Api
     )
 import Cardano.Wallet.Network.Implementation.Ouroboros
     ( LSQ (..)
+    )
+import Cardano.Wallet.Read
+    ( Allegra
+    , Alonzo
+    , Babbage
+    , Byron
+    , Conway
+    , Mary
+    , Shelley
     )
 import Ouroboros.Consensus.Cardano
     ( CardanoBlock
@@ -55,6 +65,7 @@ import Ouroboros.Consensus.Shelley.Eras
     , StandardShelley
     )
 
+import qualified Cardano.Wallet.Read as Read
 import qualified Ouroboros.Consensus.Byron.Ledger as Byron
 import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley
 
@@ -82,6 +93,26 @@ byronOrShelleyBased onByron onShelleyBased =
         onShelleyBased
         onShelleyBased
         onShelleyBased
+
+-- | Combine era-specific local state queries into an era-agnostic one.
+onAnyEra'
+    :: LSQ Byron.ByronBlock m (f Byron)
+    -> LSQ (Shelley.ShelleyBlock (TPraos StandardCrypto) Shelley) m (f Shelley)
+    -> LSQ (Shelley.ShelleyBlock (TPraos StandardCrypto) Allegra) m (f Allegra)
+    -> LSQ (Shelley.ShelleyBlock (TPraos StandardCrypto) Mary) m (f Mary)
+    -> LSQ (Shelley.ShelleyBlock (TPraos StandardCrypto) Alonzo) m (f Alonzo)
+    -> LSQ (Shelley.ShelleyBlock (Praos StandardCrypto) Babbage) m (f Babbage)
+    -> LSQ (Shelley.ShelleyBlock (Praos StandardCrypto) Conway) m (f Conway)
+    -> LSQ (CardanoBlock StandardCrypto) m (Read.EraValue f)
+onAnyEra' a b c d e f g =
+    onAnyEra
+        (Read.EraValue <$> a)
+        (Read.EraValue <$> b)
+        (Read.EraValue <$> c)
+        (Read.EraValue <$> d)
+        (Read.EraValue <$> e)
+        (Read.EraValue <$> f)
+        (Read.EraValue <$> g)
 
 -- | Create a local state query specific to the each era.
 --

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/PParams.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/PParams.hs
@@ -8,7 +8,6 @@
 module Cardano.Wallet.Network.LocalStateQuery.PParams
     ( protocolParams
     , protocolParamsLegacy
-    , protocolParamsRecent
     , slottingParamsLegacy
     ) where
 
@@ -19,7 +18,6 @@ import Cardano.Wallet.Network.Implementation.Ouroboros
     )
 import Cardano.Wallet.Network.LocalStateQuery.Extra
     ( byronOrShelleyBased
-    , onAnyEra
     , onAnyEra'
     )
 import Cardano.Wallet.Primitive.Ledger.Read.PParams
@@ -39,9 +37,6 @@ import Cardano.Wallet.Primitive.Types.ProtocolParameters
     )
 import Cardano.Wallet.Primitive.Types.SlottingParameters
     ( SlottingParameters
-    )
-import Cardano.Write.Eras
-    ( MaybeInRecentEra (..)
     )
 import Ouroboros.Consensus.Cardano
     ( CardanoBlock
@@ -63,7 +58,6 @@ import qualified Cardano.Chain.Update.Validation.Interface as Byron
     ( adoptedProtocolParameters
     )
 import qualified Cardano.Wallet.Read as Read
-import qualified Internal.Cardano.Write.Tx as Write
 import qualified Ouroboros.Consensus.Byron.Ledger as Byron
 import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley
 
@@ -84,17 +78,6 @@ protocolParams =
         (Read.PParams <$> LSQry Shelley.GetCurrentPParams)
   where
     fromByron = Read.PParams . Byron.adoptedProtocolParameters
-
-protocolParamsRecent :: LSQ' m (MaybeInRecentEra Write.PParams)
-protocolParamsRecent =
-    onAnyEra
-        (pure InNonRecentEraByron)
-        (pure InNonRecentEraShelley)
-        (pure InNonRecentEraAllegra)
-        (pure InNonRecentEraMary)
-        (pure InNonRecentEraAlonzo)
-        (InRecentEraBabbage <$> LSQry Shelley.GetCurrentPParams)
-        (InRecentEraConway <$> LSQry Shelley.GetCurrentPParams)
 
 slottingParamsLegacy :: NetworkParameters -> LSQ' m SlottingParameters
 slottingParamsLegacy np =

--- a/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/PParams.hs
+++ b/lib/network-layer/src/Cardano/Wallet/Network/LocalStateQuery/PParams.hs
@@ -22,17 +22,11 @@ import Cardano.Wallet.Network.LocalStateQuery.Extra
     , onAnyEra
     , onAnyEra'
     )
-import Cardano.Wallet.Primitive.Ledger.Byron
-    ( protocolParametersFromUpdateState
+import Cardano.Wallet.Primitive.Ledger.Read.PParams
+    ( primitiveProtocolParameters
     )
 import Cardano.Wallet.Primitive.Ledger.Shelley
-    ( fromAllegraPParams
-    , fromAlonzoPParams
-    , fromBabbagePParams
-    , fromConwayPParams
-    , fromMaryPParams
-    , fromShelleyPParams
-    , slottingParametersFromGenesis
+    ( slottingParametersFromGenesis
     )
 import Cardano.Wallet.Primitive.Types.EraInfo
     ( EraInfo (..)
@@ -121,25 +115,5 @@ protocolParamsLegacy = do
             <*> LSQry (QueryAnytimeAlonzo GetEraStart)
             <*> LSQry (QueryAnytimeBabbage GetEraStart)
 
-    onAnyEra
-        ( protocolParametersFromUpdateState eraBounds
-            <$> LSQry Byron.GetUpdateInterfaceState
-        )
-        ( fromShelleyPParams eraBounds
-            <$> LSQry Shelley.GetCurrentPParams
-        )
-        ( fromAllegraPParams eraBounds
-            <$> LSQry Shelley.GetCurrentPParams
-        )
-        ( fromMaryPParams eraBounds
-            <$> LSQry Shelley.GetCurrentPParams
-        )
-        ( fromAlonzoPParams eraBounds
-            <$> LSQry Shelley.GetCurrentPParams
-        )
-        ( fromBabbagePParams eraBounds
-            <$> LSQry Shelley.GetCurrentPParams
-        )
-        ( fromConwayPParams eraBounds
-            <$> LSQry Shelley.GetCurrentPParams
-        )
+    Read.EraValue pparams <- protocolParams
+    pure $ primitiveProtocolParameters eraBounds pparams

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -121,6 +121,7 @@ library
     Cardano.Wallet.Primitive.Ledger.Read.Block
     Cardano.Wallet.Primitive.Ledger.Read.Block.Header
     Cardano.Wallet.Primitive.Ledger.Read.Eras
+    Cardano.Wallet.Primitive.Ledger.Read.PParams
     Cardano.Wallet.Primitive.Ledger.Read.Tx
     Cardano.Wallet.Primitive.Ledger.Read.Tx.TxExtended
     Cardano.Wallet.Primitive.Ledger.Read.Tx.Features.Certificates

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Byron.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Byron.hs
@@ -28,7 +28,7 @@ module Cardano.Wallet.Primitive.Ledger.Byron
     , fromProtocolMagicId
     , fromByronTxIn
     , fromByronTxOut
-    , protocolParametersFromUpdateState
+    , protocolParametersFromPP
     ) where
 
 import Prelude
@@ -99,7 +99,6 @@ import Ouroboros.Network.Block
     )
 
 import qualified Cardano.Chain.Update as Update
-import qualified Cardano.Chain.Update.Validation.Interface as Update
 import qualified Cardano.Crypto.Hashing as CC
 import qualified Cardano.Slotting.Slot as Slotting
 import qualified Cardano.Wallet.Primitive.Slotting as W
@@ -294,6 +293,8 @@ fromMaxSize :: Natural -> Quantity "byte" Word16
 fromMaxSize =
     Quantity . fromIntegral
 
+-- | Extract the protocol parameters relevant to the wallet
+-- from the Byron 'ProtocolParameters'.
 protocolParametersFromPP
     :: W.EraInfo Bound
     -> Update.ProtocolParameters
@@ -319,15 +320,6 @@ protocolParametersFromPP eraInfo pp =
   where
     fromBound (Bound _relTime _slotNo (O.EpochNo e)) =
         W.EpochNo $ fromIntegral e
-
--- | Extract the protocol parameters relevant to the wallet out of the
---   cardano-chain update state record.
-protocolParametersFromUpdateState
-    :: W.EraInfo Bound
-    -> Update.State
-    -> W.ProtocolParameters
-protocolParametersFromUpdateState b =
-    (protocolParametersFromPP b) . Update.adoptedProtocolParameters
 
 -- | Convert non AVVM balances to genesis UTxO.
 fromNonAvvmBalances :: GenesisNonAvvmBalances -> [W.TxOut]

--- a/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/PParams.hs
+++ b/lib/primitive/lib/Cardano/Wallet/Primitive/Ledger/Read/PParams.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Convert from "Cardano.Wallet.Read" to primitive types.
+--
+module Cardano.Wallet.Primitive.Ledger.Read.PParams
+    ( primitiveProtocolParameters
+    )
+    where
+
+import Cardano.Wallet.Primitive.Ledger.Byron
+    ( protocolParametersFromPP
+    )
+import Cardano.Wallet.Primitive.Ledger.Shelley
+    ( fromAllegraPParams
+    , fromAlonzoPParams
+    , fromBabbagePParams
+    , fromConwayPParams
+    , fromMaryPParams
+    , fromShelleyPParams
+    )
+import Cardano.Wallet.Primitive.Types.EraInfo
+    ( EraInfo (..)
+    )
+import Ouroboros.Consensus.HardFork.History.Summary
+    ( Bound
+    )
+
+import qualified Cardano.Wallet.Primitive.Types.ProtocolParameters as W
+import qualified Cardano.Wallet.Read as Read
+
+{-----------------------------------------------------------------------------
+    Protocol Parameters
+------------------------------------------------------------------------------}
+
+-- | Compute wallet primitive 'W.ProtocolParameters' from ledger 'PParams'.
+primitiveProtocolParameters
+    :: forall era. Read.IsEra era
+    => EraInfo Bound
+    -> Read.PParams era
+    -> W.ProtocolParameters
+primitiveProtocolParameters eraBounds (Read.PParams pparams) =
+    case Read.theEra :: Read.Era era of
+        Read.Byron -> protocolParametersFromPP eraBounds pparams
+        Read.Shelley -> fromShelleyPParams eraBounds pparams
+        Read.Allegra -> fromAllegraPParams eraBounds pparams
+        Read.Mary -> fromMaryPParams eraBounds pparams
+        Read.Alonzo -> fromAlonzoPParams eraBounds pparams
+        Read.Babbage -> fromBabbagePParams eraBounds pparams
+        Read.Conway -> fromConwayPParams eraBounds pparams

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Addresses/Transactions.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Addresses/Transactions.hs
@@ -144,12 +144,12 @@ filterByParams TransactionHistoryParams{..} =
     filterByTransfer = case (txHistoryReceived, txHistorySpent) of
         (True, False) ->
             filter
-                ( \(_, (_, _, ValueTransfer{received})) ->
+                ( \(_, (_, _, ValueTransferC{received})) ->
                     received /= mempty
                 )
         (False, True) ->
             filter
-                ( \(_, (_, _, ValueTransfer{spent})) ->
+                ( \(_, (_, _, ValueTransferC{spent})) ->
                     spent /= mempty
                 )
         _ -> id

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Deposits/Customers.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Deposits/Customers.hs
@@ -182,7 +182,7 @@ depositByCustomerH
     depositsTxIdsLink
     mexpand
     (Down time)
-    (customer, (_addr, ValueTransfer{received, spent}))
+    (customer, (_addr, ValueTransferC{received, spent}))
     widget
         | expand = do
             let trId = T.pack $ "customers-tx-ids-" <> show customer

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Deposits/Times.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Deposits/Times.hs
@@ -193,7 +193,7 @@ depositH
         , depositsFirstWeekDay
         }
     mexpand depositsCustomersLink
-    (dTime@(Down time), (slot, ValueTransfer{received, spent}))
+    (dTime@(Down time), (slot, ValueTransferC{received, spent}))
     widget
         | expanded = do
             let

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Deposits/TxIds.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Pages/Deposits/TxIds.hs
@@ -154,7 +154,7 @@ depositByTxIdH
     -> Html ()
 depositByTxIdH
     DepositsParams{depositsSpent}
-    (txId, ValueTransfer{received, spent}) = do
+    (txId, ValueTransferC{received, spent}) = do
         tr_ [scope_ "row"] $ do
             tdEnd $ txIdH txId
             tdEnd $ valueH received

--- a/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -157,8 +157,6 @@ dummyNetworkLayer = NetworkLayer
     , watchNodeTip = err "watchNodeTip"
     , currentPParams = err "currentPParams"
     , currentProtocolParameters = err "currentProtocolParameters"
-    , currentProtocolParametersInRecentEras
-        = err "currentProtocolParametersInRecentEras"
     , currentSlottingParameters = err "currentSlottingParameters"
     , getUTxOByTxIn = err "getUTxOByTxIn"
     , getStakeDelegDeposits = error "getStakeDelegDeposits"

--- a/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/unit/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -155,6 +155,7 @@ dummyNetworkLayer = NetworkLayer
     , currentNodeEra = err "currentNodeEra"
     , currentNodeTip = err "currentNodeTip"
     , watchNodeTip = err "watchNodeTip"
+    , currentPParams = err "currentPParams"
     , currentProtocolParameters = err "currentProtocolParameters"
     , currentProtocolParametersInRecentEras
         = err "currentProtocolParametersInRecentEras"


### PR DESCRIPTION
This pull request changes the `NetworkLayer` to retrieve era-indexed protocol parameters.

In particular, this pull request removes the field `currentProtocolParametersInRecentEras` from `NetworkLayer` and adds a field `currentPParams` instead.

This pull request also refactors the local state query for `currentProtocolParameters` to use a conversion on top of `PParams era` instead of trying to mingle conversion and query.

### Issue Number

ADP-3344
