### PR TITLE
[ADP-3344] Add `TimeInterpreter` to `Cardano.Wallet.Deposit.Time`

### DIFF
--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -60,6 +60,7 @@ library
     , cardano-strict-containers
     , cardano-wallet
     , cardano-wallet-network-layer
+    , cardano-wallet-primitive
     , cardano-wallet-read           ==0.2024.8.27
     , containers
     , contra-tracer
@@ -91,6 +92,7 @@ library
     Cardano.Wallet.Deposit.Pure.Submissions
     Cardano.Wallet.Deposit.Pure.UTxO
     Cardano.Wallet.Deposit.Read
+    Cardano.Wallet.Deposit.Time
     Cardano.Wallet.Deposit.Write
 
 test-suite scenario

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
@@ -67,6 +67,7 @@ import Data.Time.Clock.POSIX
     )
 
 import qualified Cardano.Wallet.Deposit.Read as Read
+import qualified Cardano.Wallet.Deposit.Time as Time
 import qualified Cardano.Wallet.Deposit.Write as Write
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -116,6 +117,8 @@ newNetworkEnvMock = do
                 -- brief delay to account for asynchronous chain followers
                 threadDelay 100
                 pure $ Right ()
+            , getTimeInterpreter =
+                pure Time.mockTimeInterpreter
             , slotsToUTCTimes = pure . unsafeSlotsToUTCTimes
             , utcTimeToSlot = pure . Just . unsafeSlotOfUTCTime
             }

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
@@ -7,11 +7,6 @@
 -- Mock implementation of a 'NetworkEnv'.
 module Cardano.Wallet.Deposit.IO.Network.Mock
     ( newNetworkEnvMock
-    , unsafeUTCTimeOfSlot
-    , unsafeSlotsToUTCTimes
-    , unsafeSlotOfUTCTime
-    , originTime
-    , shelleyTime
     ) where
 
 import Prelude
@@ -21,11 +16,6 @@ import Cardano.Wallet.Deposit.IO.Network.Type
     )
 import Cardano.Wallet.Network
     ( ChainFollower (..)
-    )
-import Cardano.Wallet.Read
-    ( Slot
-    , SlotNo (..)
-    , WithOrigin (..)
     )
 import Control.Concurrent.Class.MonadSTM
     ( MonadSTM
@@ -39,9 +29,6 @@ import Control.Concurrent.Class.MonadSTM
 import Control.Monad
     ( forever
     )
-import Control.Monad.Class.MonadTime
-    ( UTCTime
-    )
 import Control.Monad.Class.MonadTimer
     ( MonadDelay
     , threadDelay
@@ -52,25 +39,10 @@ import Data.Foldable
 import Data.List.NonEmpty
     ( NonEmpty ((:|))
     )
-import Data.Map.Strict
-    ( Map
-    )
-import Data.Maybe
-    ( maybeToList
-    )
-import Data.Set
-    ( Set
-    )
-import Data.Time.Clock.POSIX
-    ( posixSecondsToUTCTime
-    , utcTimeToPOSIXSeconds
-    )
 
 import qualified Cardano.Wallet.Deposit.Read as Read
 import qualified Cardano.Wallet.Deposit.Time as Time
 import qualified Cardano.Wallet.Deposit.Write as Write
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
 
 {-----------------------------------------------------------------------------
     Mock implementation of 'NetworkEnv'
@@ -119,45 +91,6 @@ newNetworkEnvMock = do
                 pure $ Right ()
             , getTimeInterpreter =
                 pure Time.mockTimeInterpreter
-            , slotsToUTCTimes = pure . unsafeSlotsToUTCTimes
-            , utcTimeToSlot = pure . Just . unsafeSlotOfUTCTime
+            , slotsToUTCTimes = pure . Time.unsafeSlotsToUTCTimes
+            , utcTimeToSlot = pure . Just . Time.unsafeSlotOfUTCTime
             }
-
-unsafeSlotsToUTCTimes :: Set Slot -> Map Slot (WithOrigin UTCTime)
-unsafeSlotsToUTCTimes slots =
-    Map.fromList $ do
-        slot <- Set.toList slots
-        time <- maybeToList $ unsafeUTCTimeOfSlot slot
-        pure (slot, time)
-
-unsafeUTCTimeOfSlot :: Slot -> Maybe (WithOrigin UTCTime)
-unsafeUTCTimeOfSlot Origin = Just Origin
-unsafeUTCTimeOfSlot (At (SlotNo n)) =
-    Just . At
-        $ posixSecondsToUTCTime
-        $ fromIntegral pt
-  where
-    pts = fromIntegral n - byronSlots
-    pt =
-        if pts >= 0
-            then shelleyTime + pts
-            else shelleyTime + pts * 20
-
-unsafeSlotOfUTCTime :: UTCTime -> Read.Slot
-unsafeSlotOfUTCTime t
-    | origin = Origin
-    | byron = At $ SlotNo $ fromIntegral $ (pt - originTime) `div` 20
-    | otherwise = At $ SlotNo $ fromIntegral $ pt - shelleyTime + byronSlots
-  where
-    pt = floor $ utcTimeToPOSIXSeconds t
-    origin = pt < originTime
-    byron = pt < shelleyTime
-
-byronSlots :: Integer
-byronSlots = 4924800
-
-shelleyTime :: Integer
-shelleyTime = 1596491091
-
-originTime :: Integer
-originTime = shelleyTime - byronSlots * 20

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Type.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Type.hs
@@ -73,14 +73,10 @@ mapBlock
     => (block1 -> block2)
     -> NetworkEnv m block1
     -> NetworkEnv m block2
-mapBlock f NetworkEnv{chainSync, postTx, slotsToUTCTimes, utcTimeToSlot} =
-    NetworkEnv
-        { chainSync = \tr follower ->
-            chainSync tr (mapChainFollower id id id (fmap f) follower)
-        , postTx = postTx
-        , slotsToUTCTimes = slotsToUTCTimes
-        , utcTimeToSlot = utcTimeToSlot
-        }
+mapBlock f env@NetworkEnv{chainSync} = env
+    { chainSync = \tr follower ->
+        chainSync tr (mapChainFollower id id id (fmap f) follower)
+    }
 
 {-------------------------------------------------------------------------------
     Errors

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Type.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Type.hs
@@ -43,6 +43,7 @@ import GHC.Generics
     )
 
 import qualified Cardano.Wallet.Deposit.Read as Read
+import qualified Cardano.Wallet.Deposit.Time as Time
 import qualified Cardano.Wallet.Deposit.Write as Write
 
 {-----------------------------------------------------------------------------
@@ -59,6 +60,9 @@ data NetworkEnv m block = NetworkEnv
         :: Write.Tx
         -> m (Either ErrPostTx ())
     -- ^ Post a transaction to the Cardano network.
+    , getTimeInterpreter
+        :: m Time.TimeInterpreter
+        -- ^ Get the current 'TimeInterpreter' from the Cardano node.
     , slotsToUTCTimes
         :: Set Slot
         -> m (Map Slot (WithOrigin UTCTime))

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory/Mock.hs
@@ -9,9 +9,6 @@ where
 
 import Prelude
 
-import Cardano.Wallet.Deposit.IO.Network.Mock
-    ( unsafeSlotOfUTCTime
-    )
 import Cardano.Wallet.Deposit.Map
     ( Map (..)
     , singletonMap
@@ -62,6 +59,8 @@ import System.Random.Stateful
     , runStateGen_
     )
 
+import qualified Cardano.Wallet.Deposit.Time as Time
+
 mockTxHistoryByTime
     :: UTCTime
     -- ^ Current time.
@@ -79,7 +78,7 @@ mockTxHistoryByTime now solveAddress solveSlot addresses ns =
         fmap mconcat
             $ replicateM ns
             $ do
-                slot <- case unsafeSlotOfUTCTime now of
+                slot <- case Time.unsafeSlotOfUTCTime now of
                     Origin -> pure Origin
                     At (SlotNo n) -> do
                         slotInt <-

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Time.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Time.hs
@@ -17,6 +17,12 @@ module Cardano.Wallet.Deposit.Time
     -- * from Write
     , Write.TimeTranslation
     , toTimeTranslation
+
+    -- * wishlist
+    , unsafeUTCTimeOfSlot
+    , unsafeSlotsToUTCTimes
+    , unsafeSlotOfUTCTime
+    , systemStartMainnet
     ) where
 
 import Prelude
@@ -35,8 +41,16 @@ import Cardano.Wallet.Primitive.Types.SlottingParameters
     , SlotLength (..)
     , SlottingParameters (..)
     )
+import Cardano.Wallet.Read
+    ( Slot
+    , SlotNo (..)
+    , WithOrigin (..)
+    )
 import Data.Functor.Identity
     ( Identity (..)
+    )
+import Data.Maybe
+    ( maybeToList
     )
 import Data.Quantity
     ( Quantity (..)
@@ -44,12 +58,19 @@ import Data.Quantity
 import Data.Time.Clock
     ( UTCTime (..)
     )
+import Data.Time.Clock.POSIX
+    ( posixSecondsToUTCTime
+    , utcTimeToPOSIXSeconds
+    )
 
 import qualified Cardano.Wallet.Primitive.Slotting as Primitive
+import qualified Cardano.Wallet.Read as Read
 import qualified Cardano.Write.Tx as Write
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 {-----------------------------------------------------------------------------
-    Time
+    TimeInterpreter
 ------------------------------------------------------------------------------}
 type TimeInterpreter = Primitive.TimeInterpreter Identity
 
@@ -66,3 +87,48 @@ mockSlottingParameters = SlottingParameters
     , getActiveSlotCoefficient = ActiveSlotCoefficient 1
     , getSecurityParameter = Quantity 2_160
     }
+
+{-----------------------------------------------------------------------------
+    TimeInterpreter
+------------------------------------------------------------------------------}
+unsafeSlotsToUTCTimes :: Set.Set Slot -> Map.Map Slot (WithOrigin UTCTime)
+unsafeSlotsToUTCTimes slots =
+    Map.fromList $ do
+        slot <- Set.toList slots
+        time <- maybeToList $ unsafeUTCTimeOfSlot slot
+        pure (slot, time)
+
+unsafeUTCTimeOfSlot :: Slot -> Maybe (WithOrigin UTCTime)
+unsafeUTCTimeOfSlot Origin = Just Origin
+unsafeUTCTimeOfSlot (At (SlotNo n)) =
+    Just . At
+        $ posixSecondsToUTCTime
+        $ fromIntegral pt
+  where
+    pts = fromIntegral n - byronSlots
+    pt =
+        if pts >= 0
+            then shelleyTime + pts
+            else shelleyTime + pts * 20
+
+unsafeSlotOfUTCTime :: UTCTime -> Read.Slot
+unsafeSlotOfUTCTime t
+    | origin = Origin
+    | byron = At $ SlotNo $ fromIntegral $ (pt - originTime) `div` 20
+    | otherwise = At $ SlotNo $ fromIntegral $ pt - shelleyTime + byronSlots
+  where
+    pt = floor $ utcTimeToPOSIXSeconds t
+    origin = pt < originTime
+    byron = pt < shelleyTime
+
+byronSlots :: Integer
+byronSlots = 4_924_800
+
+shelleyTime :: Integer
+shelleyTime = 1_596_491_091
+
+originTime :: Integer
+originTime = shelleyTime - byronSlots * 20
+
+systemStartMainnet :: UTCTime
+systemStartMainnet = posixSecondsToUTCTime $ fromIntegral originTime

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Time.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Time.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Indirection module that re-exports types
+-- related to computations involving Slots and wall-clock times.
+--
+-- TODO: Absorb this into a definition of 'TimeInterpreter'.
+module Cardano.Wallet.Deposit.Time
+    ( -- * from Primitive
+      TimeInterpreter
+    , PastHorizonException
+    , mockTimeInterpreter
+
+    -- * from Write
+    , Write.TimeTranslation
+    , toTimeTranslation
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Slotting
+    ( PastHorizonException
+    , StartTime (..)
+    , mkSingleEraInterpreter
+    )
+import Cardano.Wallet.Primitive.Slotting.TimeTranslation
+    ( toTimeTranslation
+    )
+import Cardano.Wallet.Primitive.Types.SlottingParameters
+    ( ActiveSlotCoefficient (..)
+    , EpochLength (..)
+    , SlotLength (..)
+    , SlottingParameters (..)
+    )
+import Data.Functor.Identity
+    ( Identity (..)
+    )
+import Data.Quantity
+    ( Quantity (..)
+    )
+import Data.Time.Clock
+    ( UTCTime (..)
+    )
+
+import qualified Cardano.Wallet.Primitive.Slotting as Primitive
+import qualified Cardano.Write.Tx as Write
+
+{-----------------------------------------------------------------------------
+    Time
+------------------------------------------------------------------------------}
+type TimeInterpreter = Primitive.TimeInterpreter Identity
+
+mockTimeInterpreter :: TimeInterpreter
+mockTimeInterpreter =
+    mkSingleEraInterpreter
+        (StartTime $ UTCTime (toEnum 0) 0)
+        mockSlottingParameters
+
+mockSlottingParameters :: SlottingParameters
+mockSlottingParameters = SlottingParameters
+    { getSlotLength = SlotLength 1
+    , getEpochLength = EpochLength 21_600
+    , getActiveSlotCoefficient = ActiveSlotCoefficient 1
+    , getSecurityParameter = Quantity 2_160
+    }


### PR DESCRIPTION
This pull request imports the `TimeInterpreter` type in `Cardano.Wallet.Deposit.Time` and adds it to the `NetworkEnv`.

### Comments

* This pull request is part of the preparations for using `balanceTx` in `createPayment`
* `Cardano.Wallet.Deposit.Time` is a temporary location for the re-export, until we separate out the `TimeInterpreter`-related stuff into a separate library.
* I messed up merging of #4816, this is the exact equal pull request, but with `master` as target.

### Issue Number

ADP-3344
