### PR TITLE
[ADP-3443] Use new TxHistory in address ui page

### DIFF
--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -157,7 +157,6 @@ library rest
     , bytestring
     , cardano-addresses
     , cardano-crypto
-    , containers
     , contra-tracer
     , crypto-primitives
     , customer-deposit-wallet

--- a/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
@@ -35,8 +35,8 @@ module Cardano.Wallet.Deposit.REST
       -- ** Reading from the blockchain
     , getWalletTip
     , availableBalance
-    , getCustomerHistory
-    , getValueTransfers
+    , getTxHistoryByCustomer
+    , getTxHistoryByTime
     , ResolveAddress
     , addressToCustomer
 
@@ -49,7 +49,6 @@ module Cardano.Wallet.Deposit.REST
     , deleteWallet
     , deleteTheDepositWalletOnDisk
     , customerAddress
-    , getValueTransfersWithTxIds
     ) where
 
 import Prelude
@@ -75,6 +74,10 @@ import Cardano.Wallet.Deposit.Pure
     ( Customer
     , Word31
     , fromXPubAndGenesis
+    )
+import Cardano.Wallet.Deposit.Pure.API.TxHistory
+    ( ByCustomer
+    , ByTime
     )
 import Cardano.Wallet.Deposit.Read
     ( Address
@@ -113,9 +116,6 @@ import Data.ByteArray.Encoding
 import Data.List
     ( isPrefixOf
     )
-import Data.Map.Strict
-    ( Map
-    )
 import Data.Store
     ( Store (..)
     , newStore
@@ -130,7 +130,6 @@ import System.FilePath
 
 import qualified Cardano.Wallet.Deposit.IO as WalletIO
 import qualified Cardano.Wallet.Deposit.IO.Resource as Resource
-import qualified Cardano.Wallet.Deposit.Pure as Wallet
 import qualified Cardano.Wallet.Deposit.Read as Read
 import qualified Cardano.Wallet.Deposit.Write as Write
 import qualified Data.ByteString.Char8 as B8
@@ -390,23 +389,13 @@ getWalletTip = onWalletInstance WalletIO.getWalletTip
 availableBalance :: WalletResourceM Read.Value
 availableBalance = onWalletInstance WalletIO.availableBalance
 
-getCustomerHistory
-    :: Customer
-    -> WalletResourceM (Map Read.TxId Wallet.TxSummary)
-getCustomerHistory = onWalletInstance . WalletIO.getCustomerHistory
+getTxHistoryByCustomer
+    :: WalletResourceM ByCustomer
+getTxHistoryByCustomer = onWalletInstance WalletIO.getTxHistoryByCustomer
 
-getValueTransfers
-    :: WalletResourceM (Map Read.Slot (Map Address Wallet.ValueTransfer))
-getValueTransfers = onWalletInstance WalletIO.getValueTransfers
-
-getValueTransfersWithTxIds
-    :: WalletResourceM
-        ( Map
-            Read.Slot
-            (Map Address (Map Read.TxId Wallet.ValueTransfer))
-        )
-getValueTransfersWithTxIds =
-    onWalletInstance WalletIO.getValueTransfersWithTxIds
+getTxHistoryByTime
+    :: WalletResourceM ByTime
+getTxHistoryByTime = onWalletInstance WalletIO.getTxHistoryByTime
 
 {-----------------------------------------------------------------------------
     Operations

--- a/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
@@ -37,6 +37,8 @@ module Cardano.Wallet.Deposit.REST
     , availableBalance
     , getCustomerHistory
     , getValueTransfers
+    , ResolveAddress
+    , addressToCustomer
 
       -- ** Writing to the blockchain
     , createPayment
@@ -133,6 +135,7 @@ import qualified Cardano.Wallet.Deposit.Read as Read
 import qualified Cardano.Wallet.Deposit.Write as Write
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.Map.Strict as Map
 
 {-----------------------------------------------------------------------------
     Types
@@ -368,6 +371,14 @@ listCustomers = onWalletInstance WalletIO.listCustomers
 -- | Retrieve the address for a customer if it's tracked by the wallet.
 customerAddress :: Customer -> WalletResourceM (Maybe Address)
 customerAddress = onWalletInstance . WalletIO.customerAddress
+
+type ResolveAddress = Address -> Maybe Customer
+
+addressToCustomer :: WalletResourceM ResolveAddress
+addressToCustomer = do
+    customers <- listCustomers
+    pure $ \address ->
+        Map.lookup address . Map.fromList . fmap (\(a, c) -> (c, a)) $ customers
 
 {-----------------------------------------------------------------------------
     Operations

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -19,6 +19,8 @@ module Cardano.Wallet.Deposit.IO
       -- ** Mapping between customers and addresses
     , listCustomers
     , customerAddress
+    , addressToCustomer
+    , ResolveAddress
 
       -- ** Reading from the blockchain
     , getWalletTip
@@ -213,6 +215,13 @@ walletPublicIdentity w = do
             { pubXpub = Wallet.walletXPub state
             , pubNextUser = Wallet.trackedCustomers state
             }
+
+type ResolveAddress = Address -> Maybe Customer
+
+addressToCustomer :: WalletInstance -> IO ResolveAddress
+addressToCustomer w = do
+    state <- readWalletState w
+    pure $ flip Wallet.addressToCustomer state
 
 {-----------------------------------------------------------------------------
     Operations

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -23,8 +23,8 @@ module Cardano.Wallet.Deposit.IO
       -- ** Reading from the blockchain
     , getWalletTip
     , availableBalance
-    , getCustomerHistory
-    , getValueTransfers
+    , getTxHistoryByCustomer
+    , getTxHistoryByTime
 
       -- ** Writing to the blockchain
     , createPayment
@@ -32,7 +32,6 @@ module Cardano.Wallet.Deposit.IO
     , signTxBody
     , WalletStore
     , walletPublicIdentity
-    , getValueTransfersWithTxIds
     ) where
 
 import Prelude
@@ -45,15 +44,16 @@ import Cardano.Wallet.Address.BIP32
     )
 import Cardano.Wallet.Deposit.Pure
     ( Customer
-    , TxSummary
-    , ValueTransfer
     , WalletPublicIdentity (..)
     , WalletState
     , Word31
     )
+import Cardano.Wallet.Deposit.Pure.API.TxHistory
+    ( ByCustomer
+    , ByTime
+    )
 import Cardano.Wallet.Deposit.Read
     ( Address
-    , Slot
     )
 import Cardano.Wallet.Network.Checkpoints.Policy
     ( defaultPolicy
@@ -67,9 +67,6 @@ import Data.Bifunctor
     )
 import Data.List.NonEmpty
     ( NonEmpty
-    )
-import Data.Map.Strict
-    ( Map
     )
 
 import qualified Cardano.Wallet.Deposit.IO.Network.Type as Network
@@ -229,20 +226,14 @@ availableBalance :: WalletInstance -> IO Read.Value
 availableBalance w =
     Wallet.availableBalance <$> readWalletState w
 
-getCustomerHistory :: Customer -> WalletInstance -> IO (Map Read.TxId TxSummary)
-getCustomerHistory c w =
-    Wallet.getCustomerHistory c <$> readWalletState w
+getTxHistoryByCustomer :: WalletInstance -> IO ByCustomer
+getTxHistoryByCustomer w =
+    Wallet.getTxHistoryByCustomer <$> readWalletState w
 
-getValueTransfers
+getTxHistoryByTime
     :: WalletInstance
-    -> IO (Map Slot (Map Address ValueTransfer))
-getValueTransfers w = Wallet.getValueTransfers <$> readWalletState w
-
-getValueTransfersWithTxIds
-    :: WalletInstance
-    -> IO (Map Slot (Map Address (Map Read.TxId ValueTransfer)))
-getValueTransfersWithTxIds w =
-    Wallet.getValueTransfersWithTxIds <$> readWalletState w
+    -> IO ByTime
+getTxHistoryByTime w = Wallet.getTxHistoryByTime <$> readWalletState w
 
 rollForward
     :: WalletInstance -> NonEmpty (Read.EraValue Read.Block) -> tip -> IO ()

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -11,6 +11,7 @@ module Cardano.Wallet.Deposit.Pure
       -- ** Mapping between customers and addresses
     , Customer
     , listCustomers
+    , addressToCustomer
     , deriveAddress
     , knownCustomer
     , knownCustomerAddress
@@ -94,6 +95,7 @@ import qualified Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory as UTxOHistory
 import qualified Cardano.Wallet.Deposit.Read as Read
 import qualified Cardano.Wallet.Deposit.Write as Write
 import qualified Data.Delta as Delta
+import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
 {-----------------------------------------------------------------------------
@@ -130,6 +132,13 @@ listCustomers =
 
 customerAddress :: Customer -> WalletState -> Maybe Address
 customerAddress c = lookup c . listCustomers
+
+addressToCustomer :: Address -> WalletState -> Maybe Customer
+addressToCustomer address =
+    Map.lookup address
+        . Map.fromList
+        . fmap (\(a, c) -> (c, a))
+        . listCustomers
 
 -- depend on the public key only, not on the entire wallet state
 deriveAddress :: WalletState -> (Customer -> Address)

--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -123,6 +123,7 @@ library
     , lens
     , lucid
     , memory
+    , monoidal-containers
     , mmorph
     , mtl
     , ntp-client

--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -62,6 +62,7 @@ library
     Cardano.Wallet.UI.Deposit.API
     Cardano.Wallet.UI.Deposit.Handlers.Addresses
     Cardano.Wallet.UI.Deposit.Handlers.Addresses.Transactions
+    Cardano.Wallet.UI.Deposit.Handlers.Deposits.Mock
     Cardano.Wallet.UI.Deposit.Handlers.Lib
     Cardano.Wallet.UI.Deposit.Handlers.Wallet
     Cardano.Wallet.UI.Deposit.Html.Common

--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -64,6 +64,7 @@ library
     Cardano.Wallet.UI.Deposit.Handlers.Addresses.Transactions
     Cardano.Wallet.UI.Deposit.Handlers.Lib
     Cardano.Wallet.UI.Deposit.Handlers.Wallet
+    Cardano.Wallet.UI.Deposit.Html.Common
     Cardano.Wallet.UI.Deposit.Html.Pages.About
     Cardano.Wallet.UI.Deposit.Html.Pages.Addresses
     Cardano.Wallet.UI.Deposit.Html.Pages.Addresses.Transactions

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Addresses/Transactions.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Addresses/Transactions.hs
@@ -11,8 +11,20 @@ import Prelude hiding
     ( lookup
     )
 
+import Cardano.Wallet.Deposit.Map
+    ( Map (..)
+    , W
+    , forgetPatch
+    , lookup
+    , openMap
+    , unPatch
+    )
 import Cardano.Wallet.Deposit.Pure
     ( ValueTransfer (..)
+    )
+import Cardano.Wallet.Deposit.Pure.API.TxHistory
+    ( DownTime
+    , TxHistory (..)
     )
 import Cardano.Wallet.Deposit.Read
     ( Address
@@ -32,6 +44,9 @@ import Cardano.Wallet.UI.Common.Layer
 import Cardano.Wallet.UI.Deposit.API
     ( TransactionHistoryParams (..)
     )
+import Cardano.Wallet.UI.Deposit.Handlers.Deposits.Mock
+    ( getMockHistory
+    )
 import Cardano.Wallet.UI.Deposit.Handlers.Lib
     ( catchRunWalletResourceHtml
     )
@@ -41,14 +56,8 @@ import Cardano.Wallet.UI.Lib.Time.Direction
     , sortByDirection
     , utcTimeByDirection
     )
-
-import Cardano.Wallet.Deposit.Map
-    ( Map (..)
-    , W
-    , forgetPatch
-    , lookup
-    , openMap
-    , unPatch
+import Data.Bifunctor
+    ( first
     )
 import Data.Foldable
     ( fold
@@ -59,22 +68,11 @@ import Data.Monoid
 import Data.Ord
     ( Down (..)
     )
-import Servant
-    ( Handler
-    )
-
-import Cardano.Wallet.Deposit.Pure.API.TxHistory
-    ( DownTime
-    , TxHistory (..)
-    )
-import Cardano.Wallet.UI.Deposit.Handlers.Deposits.Mock
-    ( getMockHistory
-    )
-import Data.Bifunctor
-    ( first
-    )
 import Data.Time
     ( UTCTime
+    )
+import Servant
+    ( Handler
     )
 
 import qualified Data.ByteString.Lazy.Char8 as BL

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Addresses/Transactions.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Addresses/Transactions.hs
@@ -1,41 +1,30 @@
-{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 
 module Cardano.Wallet.UI.Deposit.Handlers.Addresses.Transactions
 where
 
-import Prelude
-
-import Cardano.Wallet.Deposit.IO.Network.Type
-    ( NetworkEnv
-    , slotsToUTCTimes
+import Prelude hiding
+    ( lookup
     )
+
 import Cardano.Wallet.Deposit.Pure
-    ( Customer
-    , TxSummary (..)
-    , ValueTransfer (ValueTransfer)
+    ( ValueTransfer (..)
     )
 import Cardano.Wallet.Deposit.Read
-    ( Slot
+    ( Address
+    , Slot
     )
 import Cardano.Wallet.Deposit.REST
     ( WalletResource
     , customerAddress
     )
-import Cardano.Wallet.Deposit.Time
-    ( unsafeSlotOfUTCTime
-    )
 import Cardano.Wallet.Read
-    ( Coin
-    , SlotNo (..)
+    ( TxId
     , WithOrigin (..)
-    , slotFromChainPoint
-    , txIdFromHash
-    )
-import Cardano.Wallet.Read.Hash
-    ( hashFromStringAsHex
     )
 import Cardano.Wallet.UI.Common.Layer
     ( SessionLayer (..)
@@ -52,61 +41,56 @@ import Cardano.Wallet.UI.Lib.Time.Direction
     , sortByDirection
     , utcTimeByDirection
     )
-import Control.Monad
-    ( replicateM
-    )
-import Control.Monad.IO.Class
-    ( MonadIO (..)
+
+import Cardano.Wallet.Deposit.Map
+    ( Map (..)
+    , W
+    , forgetPatch
+    , lookup
+    , openMap
+    , unPatch
     )
 import Data.Foldable
-    ( toList
+    ( fold
     )
-import Data.Function
-    ( on
+import Data.Monoid
+    ( First (..)
     )
-import Data.List
-    ( sortBy
-    )
-import Data.Map.Strict
-    ( Map
-    )
-import Data.Maybe
-    ( fromJust
-    )
-import Data.Time
-    ( UTCTime (..)
-    , getCurrentTime
+import Data.Ord
+    ( Down (..)
     )
 import Servant
     ( Handler
     )
-import System.Random.Stateful
-    ( StatefulGen
-    , UniformRange (..)
-    , mkStdGen
-    , runStateGen_
+
+import Cardano.Wallet.Deposit.Pure.API.TxHistory
+    ( DownTime
+    , TxHistory (..)
+    )
+import Cardano.Wallet.UI.Deposit.Handlers.Deposits.Mock
+    ( getMockHistory
+    )
+import Data.Bifunctor
+    ( first
+    )
+import Data.Time
+    ( UTCTime
     )
 
-import qualified Cardano.Wallet.Deposit.REST as REST
-import qualified Cardano.Wallet.Read as Read
 import qualified Data.ByteString.Lazy.Char8 as BL
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
+import qualified Data.Map.Monoidal.Strict as MonoidalMap
 
 getCustomerHistory
-    :: NetworkEnv IO a
-    -> SessionLayer WalletResource
+    :: SessionLayer WalletResource
     -> ( Bool
          -> TransactionHistoryParams
-         -> Map Slot (WithOrigin UTCTime)
-         -> [TxSummary]
+         -> [(WithOrigin UTCTime, (Slot, TxId, ValueTransfer))]
          -> html
        )
     -> (BL.ByteString -> html)
     -> TransactionHistoryParams
     -> Handler html
 getCustomerHistory
-    network
     layer
     render
     alert
@@ -116,32 +100,37 @@ getCustomerHistory
             case r of
                 Nothing -> pure $ alert "Address not discovered"
                 Just _ -> do
-                    h <- REST.getCustomerHistory txHistoryCustomer
-                    (b, summaries) <-
-                        liftIO
-                            $ fakeData txHistoryCustomer . toList
-                            $ h
-                    let slots =
-                            Set.fromList
-                                $ slotFromChainPoint
-                                    . txChainPoint
-                                    <$> summaries
-                    times <- liftIO $ slotsToUTCTimes network slots
+                    h <- byCustomer <$> getMockHistory
                     pure
-                        $ render b params times
-                        $ filterByParams params times summaries
+                        $ render True params
+                        $ filterByParams params
+                        $ convert
+                        $ lookup txHistoryCustomer h
+
+convert
+    :: Maybe
+        (Map '[W (First Address) DownTime, W (First Slot) TxId] ValueTransfer)
+    -> [(DownTime, (Slot, TxId, ValueTransfer))]
+convert = concatMap f . MonoidalMap.assocs . openMap . forgetPatch . fold
+    where
+        f :: (DownTime, Map '[W (First Slot) TxId] ValueTransfer)
+                -> [(DownTime, (Slot, TxId, ValueTransfer))]
+        f (time, txs) = do
+            (txId, Value (First (Just slot) , value) )
+                <- MonoidalMap.assocs . openMap . unPatch $ txs
+            pure (time, (slot, txId, value))
 
 filterByParams
     :: TransactionHistoryParams
-    -> Map Slot (WithOrigin UTCTime)
-    -> [TxSummary]
-    -> [TxSummary]
-filterByParams TransactionHistoryParams{..} times =
-    sortByDirection txHistorySorting txChainPoint
+    -> [(DownTime, (Slot, TxId, ValueTransfer))]
+    -> [(WithOrigin UTCTime, (Slot, TxId, ValueTransfer))]
+filterByParams TransactionHistoryParams{..} =
+    sortByDirection txHistorySorting fst
         . filterByDirection
             txHistorySorting
             startTime
             matchUTCTime
+        . fmap (first getDown)
         . filterByTransfer
   where
     startTime =
@@ -149,102 +138,20 @@ filterByParams TransactionHistoryParams{..} times =
             txHistorySorting
             txHistoryStartYear
             txHistoryStartMonth
-    matchUTCTime :: TxSummary -> Match UTCTime
-    matchUTCTime TxSummaryC{txChainPoint = cp} =
+    matchUTCTime (time, (_, _, _)) =
         do
-            let slot :: Slot = slotFromChainPoint cp
-            case Map.lookup slot times of
-                Just (At t) -> Match t
-                Just Origin -> DirectionMatch
-                _ -> NoMatch
+            case time of
+                At t -> Match t
+                Origin -> DirectionMatch
     filterByTransfer = case (txHistoryReceived, txHistorySpent) of
         (True, False) ->
             filter
-                ( \TxSummaryC{txTransfer = ValueTransfer _ received} ->
+                ( \(_, (_, _, ValueTransfer{received})) ->
                     received /= mempty
                 )
         (False, True) ->
             filter
-                ( \TxSummaryC{txTransfer = ValueTransfer spent _} ->
+                ( \(_, (_, _, ValueTransfer{spent})) ->
                     spent /= mempty
                 )
         _ -> id
-
--- fake data generation until DB is implemented
-
-fakeData :: Customer -> [TxSummary] -> IO (Bool, [TxSummary])
-fakeData c [] = do
-    now <- getCurrentTime
-    pure
-        $ (True,)
-        $ sortBy
-            (on compare $ \(TxSummaryC _ cp _) -> cp)
-        $ txSummaryG now (fromIntegral c)
-fakeData _c xs = pure (False, xs)
-
-unsafeMkTxId :: String -> Read.TxId
-unsafeMkTxId = txIdFromHash . fromJust . hashFromStringAsHex
-
-hexOfInt :: Int -> Char
-hexOfInt n = "0123456789abcdef" !! (n `mod` 16)
-
-headerHash :: StatefulGen g m => g -> m [Char]
-headerHash g = replicateM 64 $ hexOfInt <$> uniformRM (0, 15) g
-
-randomValue :: StatefulGen g f => g -> Read.Coin -> f Read.Value
-randomValue g l = Read.ValueC <$> uniformRM (0, l) g <*> pure mempty
-
-maxLovelaces :: Coin
-maxLovelaces = 1_000_000_000
-
-createSpent :: StatefulGen g f => g -> Int -> f Read.Value
-createSpent g r = randomValue g l
-  where
-    l = if r >= 0 && r < 5 || r == 11 then maxLovelaces else 0
-
-createReceived :: StatefulGen g f => g -> Int -> f Read.Value
-createReceived g r = randomValue g l
-  where
-    l = if r >= 5 && r <= 11 then maxLovelaces else 0
-
-valueTransferG :: StatefulGen g m => g -> m ValueTransfer
-valueTransferG g = do
-    spentOrReceived <- uniformRM (0, 11) g
-    spent <- createSpent g spentOrReceived
-    received <- createReceived g spentOrReceived
-    pure $ ValueTransfer spent received
-
-txSummaryG :: UTCTime -> Int -> [TxSummary]
-txSummaryG now c = runStateGen_ pureGen $ \g -> do
-    ns <- uniformRM (1, 200) g
-    replicateM ns $ do
-        txId <- txIdR g
-        cp <- chainPointR g
-        value <- valueTransferG g
-        pure $ TxSummaryC txId cp value
-  where
-    pureGen = mkStdGen c
-
-    chainPointR g = do
-        case unsafeSlotOfUTCTime now of
-            Origin -> pure Read.GenesisPoint
-            At (SlotNo slotNo) -> do
-                slotInt :: Int <- uniformRM (-1, fromIntegral slotNo) g
-                r <- hashFromStringAsHex <$> headerHash g
-                case r of
-                    Just h -> do
-                        pure
-                            $ if slotInt == -1
-                                then Read.GenesisPoint
-                                else
-                                    Read.BlockPoint
-                                        (SlotNo $ fromIntegral slotInt)
-                                        h
-                    Nothing -> error "chainPointR: invalid hash"
-txIdR :: StatefulGen g m => g -> m Read.TxId
-txIdR g = do
-    ls <-
-        fmap (concatMap $ replicate 8)
-            $ replicateM 8
-            $ hexOfInt <$> uniformRM (0, 15) g
-    pure $ unsafeMkTxId ls

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Deposits/Mock.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Deposits/Mock.hs
@@ -1,0 +1,110 @@
+module Cardano.Wallet.UI.Deposit.Handlers.Deposits.Mock
+    ( getMockHistory
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.Deposit.Pure.API.TxHistory
+    ( ResolveAddress
+    , ResolveSlot
+    , TxHistory
+    )
+import Cardano.Wallet.Deposit.Pure.API.TxHistory.Mock
+    ( mockTxHistory
+    )
+import Cardano.Wallet.Deposit.Read
+    ( Address
+    )
+import Cardano.Wallet.Deposit.REST
+    ( WalletResourceM
+    , addressToCustomer
+    , listCustomers
+    )
+import Cardano.Wallet.Deposit.Time
+    ( unsafeUTCTimeOfSlot
+    )
+import Control.Concurrent.STM
+    ( TVar
+    , atomically
+    , newTVarIO
+    , readTVarIO
+    , writeTVar
+    )
+import Control.Monad.IO.Class
+    ( MonadIO (..)
+    )
+import Data.Ord
+    ( Down (..)
+    )
+import Data.Time
+    ( UTCTime (..)
+    , diffUTCTime
+    , getCurrentTime
+    , secondsToNominalDiffTime
+    )
+import System.IO.Unsafe
+    ( unsafePerformIO
+    )
+
+nMockDeposits :: Int
+nMockDeposits = 10000
+
+type TxHistoryCache = TVar (Maybe (UTCTime, [Address], TxHistory))
+
+{-# NOINLINE globalTxHistoryMock #-}
+globalTxHistoryMock :: TxHistoryCache
+globalTxHistoryMock = unsafePerformIO $ newTVarIO Nothing
+
+getMockHistory :: WalletResourceM TxHistory
+getMockHistory = getMockDepositsByTimeWithCount nMockDeposits
+
+getMockDepositsByTimeWithCount
+    :: Int
+    -- ^ Number of deposits to generate
+    -> WalletResourceM TxHistory
+getMockDepositsByTimeWithCount nDeposits = do
+    addresses <- fmap snd <$> listCustomers
+    solveAddress <- addressToCustomer
+    let solveSlot = fmap Down <$> unsafeUTCTimeOfSlot
+    liftIO
+        $ getCachedMockDeposits
+            solveAddress
+            solveSlot
+            nDeposits
+            addresses
+
+getCachedMockDeposits
+    :: ResolveAddress
+    -> ResolveSlot
+    -> Int
+    -> [Address]
+    -> IO TxHistory
+getCachedMockDeposits solveAddress solveSlot nDeposits addresses = do
+    now <- getCurrentTime
+    cache <- readTVarIO globalTxHistoryMock
+    let generate = do
+            let newDeposits =
+                    mockTxHistory
+                        now
+                        solveAddress
+                        solveSlot
+                        addresses
+                        nDeposits
+            atomically
+                $ writeTVar globalTxHistoryMock
+                $ Just (now, addresses, newDeposits)
+            pure newDeposits
+    case cache of
+        Just (now', addresses', deposits)
+            | diffUTCTime now now'
+                < secondsToNominalDiffTime 60
+                && addresses' == addresses -> do
+                putStrLn "Using cached fake deposits"
+                pure deposits
+        Just _ -> do
+            putStrLn "Regenerating fake deposits"
+            generate
+        Nothing -> do
+            putStrLn "Generating fake deposits"
+            generate

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Common.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Html/Common.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.Wallet.UI.Deposit.Html.Common
+    ( downTimeH
+    , timeH
+    , slotH
+    , txIdH
+    , showTime
+    , showTimeSecs
+    , withOriginH
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.Deposit.Pure.API.TxHistory
+    ( DownTime
+    )
+import Cardano.Wallet.Deposit.Read
+    ( Slot
+    , TxId
+    , WithOrigin (..)
+    )
+import Cardano.Wallet.Read
+    ( SlotNo (..)
+    , hashFromTxId
+    )
+import Cardano.Wallet.Read.Hash
+    ( hashToStringAsHex
+    )
+import Cardano.Wallet.UI.Common.Html.Lib
+    ( WithCopy (..)
+    , truncatableText
+    )
+import Data.Ord
+    ( Down (..)
+    )
+import Data.Text.Class
+    ( ToText (..)
+    )
+import Data.Time
+    ( UTCTime
+    , defaultTimeLocale
+    , formatTime
+    )
+import Lucid
+    ( Html
+    , ToHtml (..)
+    )
+
+showTime :: UTCTime -> String
+showTime = formatTime defaultTimeLocale "%Y-%m-%d %H:%M"
+
+showTimeSecs :: UTCTime -> String
+showTimeSecs = formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S"
+
+withOriginH :: (a -> Html ()) -> WithOrigin a -> Html ()
+withOriginH f = \case
+    Origin -> "Origin"
+    At a -> f a
+
+timeH :: UTCTime -> Html ()
+timeH = toHtml . showTime
+
+downTimeH :: DownTime -> Html ()
+downTimeH (Down time) = withOriginH timeH time
+
+slotH :: Slot -> Html ()
+slotH = \case
+    Origin -> "Origin"
+    At (SlotNo s) -> toHtml $ show s
+
+txIdH :: TxId -> Html ()
+txIdH txId =
+    truncatableText WithCopy ("tx-id-text-" <> toText (take 16 h))
+        $ toHtml h
+  where
+    h =
+        hashToStringAsHex
+            $ hashFromTxId
+                txId

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Server.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Server.hs
@@ -21,9 +21,6 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Deposit.IO
     ( WalletBootEnv
     )
-import Cardano.Wallet.Deposit.IO.Network.Type
-    ( NetworkEnv
-    )
 import Cardano.Wallet.Deposit.REST
     ( WalletResource
     )
@@ -127,10 +124,9 @@ import qualified Cardano.Read.Ledger.Block.Block as Read
 import qualified Data.ByteString.Lazy as BL
 
 serveUI
-    :: forall n x
+    :: forall n
      . HasSNetworkId n
     => Tracer IO String
-    -> NetworkEnv IO x
     -> UILayer WalletResource
     -> WalletBootEnv IO
     -> FilePath
@@ -139,7 +135,7 @@ serveUI
     -> NetworkLayer IO Read.ConsensusBlock
     -> BlockchainSource
     -> Server UI
-serveUI tr network ul env dbDir config nid nl bs =
+serveUI tr ul env dbDir config nid nl bs =
     serveTabPage ul config Wallet
         :<|> serveTabPage ul config About
         :<|> serveTabPage ul config Network
@@ -161,7 +157,7 @@ serveUI tr network ul env dbDir config nid nl bs =
         :<|> serveGetAddress ul
         :<|> serveAddressesPage ul
         :<|> serveNavigation ul
-        :<|> serveCustomerHistory network ul
+        :<|> serveCustomerHistory ul
 
 serveTabPage
     :: UILayer s

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Server/Addresses.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Server/Addresses.hs
@@ -7,9 +7,6 @@ where
 
 import Prelude
 
-import Cardano.Wallet.Deposit.IO.Network.Type
-    ( NetworkEnv
-    )
 import Cardano.Wallet.Deposit.Pure
     ( Customer
     )
@@ -62,16 +59,14 @@ import Servant
     )
 
 serveCustomerHistory
-    :: NetworkEnv IO a
-    -> UILayer WalletResource
+    :: UILayer WalletResource
     -> TransactionHistoryParams
     -> Maybe RequestCookies
     -> Handler (CookieResponse RawHtml)
-serveCustomerHistory network ul params = do
+serveCustomerHistory ul params = do
     withSessionLayer ul $ \layer ->
         renderSmoothHtml
             <$> getCustomerHistory
-                network
                 layer
                 customerHistoryH
                 alertH


### PR DESCRIPTION
- Change the definition of TxHistory in the deposit wallet state 
- Use the new definition of TxHistory in the address page of the web UI 
- Uses the mock TxHistory value in the UI, as the network sync is not ready yet
- Re-implement the down-to-earth interfaces over TxHistory used in the Exchanges scenarios

ADP-3443