### PR TITLE
[ADP-3443] Add roll forward and backward of TxHistory to deposit wallet

### DIFF
--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -212,7 +212,6 @@ test-suite unit
     , customer-deposit-wallet:http
     , customer-deposit-wallet:rest
     , directory
-    , fingertree
     , hspec
     , hspec-golden
     , openapi3

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -197,6 +197,7 @@ test-suite unit
   type:               exitcode-stdio-1.0
   hs-source-dirs:     test/unit
   main-is:            test-suite-unit.hs
+  ghc-options:        -Wno-unused-packages
   build-depends:
     , aeson
     , aeson-pretty
@@ -215,6 +216,7 @@ test-suite unit
     , hspec
     , hspec-golden
     , openapi3
+    , pretty-simple
     , QuickCheck
     , temporary
     , time

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -219,6 +219,7 @@ test-suite unit
     , QuickCheck
     , temporary
     , time
+    , transformers
     , with-utf8
 
   build-tool-depends: hspec-discover:hspec-discover

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -75,12 +75,13 @@ library
     , digest
     , fingertree
     , io-classes
-    , microlens
+    , lens
     , MonadRandom
     , monoidal-containers
     , mtl
     , mwc-random
     , OddWord
+    , operational
     , random
     , text
     , time
@@ -103,6 +104,9 @@ library
     Cardano.Wallet.Deposit.Pure.Submissions
     Cardano.Wallet.Deposit.Pure.UTxO
     Cardano.Wallet.Deposit.Read
+    Cardano.Wallet.Deposit.Testing.DSL
+    Cardano.Wallet.Deposit.Testing.DSL.ByTime
+    Cardano.Wallet.Deposit.Testing.DSL.Types
     Cardano.Wallet.Deposit.Time
     Cardano.Wallet.Deposit.Write
 
@@ -122,7 +126,7 @@ test-suite scenario
     , contra-tracer
     , customer-deposit-wallet
     , delta-store
-    , hspec                      >=2.8.2
+    , hspec
 
   other-modules:
     Test.Scenario.Blockchain

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Mock.hs
@@ -93,6 +93,6 @@ newNetworkEnvMock = do
                 pure $ Read.EraValue Read.mockPParamsConway
             , getTimeInterpreter =
                 pure Time.mockTimeInterpreter
-            , slotsToUTCTimes = pure . Time.unsafeSlotsToUTCTimes
+            , slotToUTCTime = pure Time.unsafeUTCTimeOfSlot
             , utcTimeToSlot = pure . Just . Time.unsafeSlotOfUTCTime
             }

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Type.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Type.hs
@@ -29,9 +29,6 @@ import Control.Tracer
 import Data.List.NonEmpty
     ( NonEmpty
     )
-import Data.Set
-    ( Set
-    )
 import Data.Text
     ( Text
     )
@@ -66,9 +63,8 @@ data NetworkEnv m block = NetworkEnv
     , getTimeInterpreter
         :: m Time.TimeInterpreter
         -- ^ Get the current 'TimeInterpreter' from the Cardano node.
-    , slotsToUTCTimes
-        :: Set Slot
-        -> m LookupTimeFromSlot
+    , slotToUTCTime
+        :: m LookupTimeFromSlot
     -- ^ Try to convert a set of slots to their UTCTimes counterparts
     , utcTimeToSlot
         :: UTCTime

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Type.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO/Network/Type.hs
@@ -12,7 +12,9 @@ import Prelude
 
 import Cardano.Wallet.Deposit.Read
     ( Slot
-    , WithOrigin
+    )
+import Cardano.Wallet.Deposit.Time
+    ( LookupTimeFromSlot
     )
 import Cardano.Wallet.Network
     ( ChainFollower (..)
@@ -26,9 +28,6 @@ import Control.Tracer
     )
 import Data.List.NonEmpty
     ( NonEmpty
-    )
-import Data.Map.Strict
-    ( Map
     )
 import Data.Set
     ( Set
@@ -69,7 +68,7 @@ data NetworkEnv m block = NetworkEnv
         -- ^ Get the current 'TimeInterpreter' from the Cardano node.
     , slotsToUTCTimes
         :: Set Slot
-        -> m (Map Slot (WithOrigin UTCTime))
+        -> m LookupTimeFromSlot
     -- ^ Try to convert a set of slots to their UTCTimes counterparts
     , utcTimeToSlot
         :: UTCTime

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Map.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Map.hs
@@ -46,6 +46,7 @@ module Cardano.Wallet.Deposit.Map
       -- * Modification
     , onMap
     , onFinger
+    , Peel
     )
 where
 
@@ -298,3 +299,8 @@ onFinger
     -> (TimedSeq k (Map ks a) -> TimedSeq k (Map ks a))
     -> Map (F w k : ks) a
 onFinger (Finger w m) f = Finger w $ f m
+
+type family Peel x where
+    Peel (Map (W w k : xs) v) =  Map xs v
+    Peel (Map (F w k : xs) v) =  Map xs v
+    Peel (Map '[] v) = v

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Map/Timed.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Map/Timed.hs
@@ -7,7 +7,7 @@ module Cardano.Wallet.Deposit.Map.Timed
     ( Timed (..)
     , TimedSeq
     , takeAfter
-    , takeBefore
+    , takeUpTo
     , extractInterval
     , minKey
     , maxKey
@@ -149,7 +149,7 @@ takeAfter bucket mstart mcount tseq =
 -- | Extract the last n elements from a timed seq before and excluding
 -- a given start time after applying a bucketing function.
 -- The result is a map of the extracted elements and the next time to start from.
-takeBefore
+takeUpTo
     :: (Monoid a, Ord q, Ord t)
     => (t -> q)
     -- ^ A function to bucket the timestamps.
@@ -160,7 +160,7 @@ takeBefore
     -> TimedSeq t a
     -- ^ The timed sequence to extract elements from.
     -> (TimedSeq t a, Maybe t)
-takeBefore bucket mstart mcount tseq =
+takeUpTo bucket mstart mcount tseq =
     takeBeforeElements bucket mcount
         $ takeUntil
             (\q -> mstart & maybe False (\t -> time q > Last (Just t)))

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Map/Timed.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Map/Timed.hs
@@ -93,6 +93,9 @@ fmapTimedSeq f = TimedSeq . fmap' (fmap f) . unTimedSeq
 singleton :: Monoid a => Timed t a -> TimedSeq t a
 singleton = TimedSeq . FingerTree.singleton
 
+instance Monoid a => Measured (Timed t a) (TimedSeq t a) where
+    measure = measure . unTimedSeq
+
 instance Foldable (TimedSeq t) where
     foldMap f = foldMap (f . monoid) . unTimedSeq
 

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Map/Timed.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Map/Timed.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Wallet.Deposit.Map.Timed
@@ -41,6 +43,12 @@ import Data.Function
 import Data.Monoid
     ( Last (..)
     )
+import GHC.IsList
+    ( IsList (..)
+    )
+
+import qualified Data.FingerTree as FingerTree
+import qualified Data.Foldable as F
 
 -- | A value paired with a timestamp.
 data Timed t a = Timed
@@ -60,6 +68,11 @@ instance Monoid a => Measured (Timed t a) (Timed t a) where
 
 -- | A sequence of timed values with a monoidal annotation as itself
 type TimedSeq t a = FingerTree (Timed t a) (Timed t a)
+
+instance Monoid a => IsList (TimedSeq t a) where
+    type Item (TimedSeq t a) = Timed t a
+    fromList = FingerTree.fromList
+    toList = F.toList
 
 takeAfterElement
     :: (Monoid a, Ord q)

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Map/Timed.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Map/Timed.hs
@@ -11,6 +11,8 @@ module Cardano.Wallet.Deposit.Map.Timed
     , extractInterval
     , minKey
     , maxKey
+    , dropAfter
+    , dropBefore
     )
 where
 
@@ -183,3 +185,11 @@ extractInterval t0 t1 tseq =
     measure
         $ takeUntil (\q -> time q > Last (Just t1))
         $ dropUntil (\q -> time q >= Last (Just t0)) tseq
+
+-- | Drop all elements from a tseq that are after the given time.
+dropAfter :: (Ord t, Monoid a) => t -> TimedSeq t a -> TimedSeq t a
+dropAfter t = takeUntil (\q -> time q > Last (Just t))
+
+-- | Drop all elements from a tseq that are before the given time.
+dropBefore :: (Ord t, Monoid a) => t -> TimedSeq t a -> TimedSeq t a
+dropBefore t = dropUntil (\q -> time q >= Last (Just t))

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -303,16 +303,19 @@ rollForwardUTxO isOurs block u =
     slot = Read.getEraSlotNo $ Read.getEraBHeader block
 
 rollBackward
-    :: Read.ChainPoint
+    :: LookupTimeFromSlot
+    -> Read.ChainPoint
     -> WalletState
     -> (WalletState, Read.ChainPoint)
-rollBackward targetPoint w =
+rollBackward timeFromSlot targetPoint w =
     ( w
         { walletTip = actualPoint
         , utxoHistory =
             UTxOHistory.rollBackward actualSlot (utxoHistory w)
         , submissions =
             Delta.apply (Sbm.rollBackward actualSlot) (submissions w)
+        , txHistory =
+            TxHistory.rollBackward timeFromSlot actualSlot (txHistory w)
         }
     , actualPoint
     )

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -112,6 +112,9 @@ import Data.Bifunctor
 import Data.Digest.CRC32
     ( crc32
     )
+import Data.FingerTree
+    ( Measured (..)
+    )
 import Data.Foldable
     ( fold
     , foldl'
@@ -385,7 +388,7 @@ wonders interval =
         => Maybe (WithOrigin UTCTime, WithOrigin UTCTime)
         -> TimedSeq (DownTime) a
         -> Timed (DownTime) a
-    extractInterval' Nothing = mempty
+    extractInterval' Nothing = measure
     extractInterval' (Just (t1, t2)) = extractInterval (Down t1) (Down t2)
 
 {-----------------------------------------------------------------------------

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -274,7 +274,7 @@ rollForwardUTxO
 rollForwardUTxO isOurs block u =
     UTxOHistory.rollForward slot deltaUTxO u
   where
-    (deltaUTxO, _) = Balance.applyBlock isOurs block (UTxOHistory.getUTxO u)
+    (deltaUTxO, _, _) = Balance.applyBlock isOurs block (UTxOHistory.getUTxO u)
     slot = Read.getEraSlotNo $ Read.getEraBHeader block
 
 rollBackward

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -37,11 +37,11 @@ module Cardano.Wallet.Deposit.Pure
     , ValueTransfer (..)
     , getTxHistoryByCustomer
     , getTxHistoryByTime
+    , getEraSlotOfBlock
 
       -- ** Writing to the blockchain
     , ErrCreatePayment (..)
     , createPayment
-
     , BIP32Path (..)
     , DerivationType (..)
     , getBIP32PathsForOwnedInputs
@@ -85,6 +85,9 @@ import Cardano.Wallet.Deposit.Pure.API.TxHistory
     , DownTime
     , TxHistory (..)
     )
+import Cardano.Wallet.Deposit.Pure.Balance
+    ( ValueTransferMap
+    )
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxOHistory
     ( UTxOHistory
     )
@@ -94,7 +97,11 @@ import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
 import Cardano.Wallet.Deposit.Read
     ( Address
     , TxId
-    , WithOrigin
+    , WithOrigin (..)
+    , getEraSlotOfBlock
+    )
+import Cardano.Wallet.Deposit.Time
+    ( LookupTimeFromSlot
     )
 import Control.Monad.Trans.Except
     ( runExceptT
@@ -132,6 +139,7 @@ import Data.Word.Odd
     )
 
 import qualified Cardano.Wallet.Deposit.Pure.Address as Address
+import qualified Cardano.Wallet.Deposit.Pure.API.TxHistory as TxHistory
 import qualified Cardano.Wallet.Deposit.Pure.Balance as Balance
 import qualified Cardano.Wallet.Deposit.Pure.RollbackWindow as Rollback
 import qualified Cardano.Wallet.Deposit.Pure.Submissions as Sbm
@@ -250,18 +258,34 @@ getWalletTip :: WalletState -> Read.ChainPoint
 getWalletTip = walletTip
 
 rollForwardMany
-    :: NonEmpty (Read.EraValue Read.Block) -> WalletState -> WalletState
-rollForwardMany blocks w = foldl' (flip rollForwardOne) w blocks
+    :: LookupTimeFromSlot
+    -> NonEmpty (Read.EraValue Read.Block)
+    -> WalletState
+    -> WalletState
+rollForwardMany timeFromSlot blocks w =
+    foldl' (flip $ rollForwardOne timeFromSlot) w blocks
 
 rollForwardOne
-    :: Read.EraValue Read.Block -> WalletState -> WalletState
-rollForwardOne (Read.EraValue block) w =
+    :: LookupTimeFromSlot
+    -> Read.EraValue Read.Block
+    -> WalletState
+    -> WalletState
+rollForwardOne timeFromSlot (Read.EraValue block) w =
     w
         { walletTip = Read.getChainPoint block
-        , utxoHistory = rollForwardUTxO isOurs block (utxoHistory w)
+        , utxoHistory = utxoHistory'
         , submissions = Delta.apply (Sbm.rollForward block) (submissions w)
+        , txHistory =
+            TxHistory.rollForward
+                valueTransfers
+                (`addressToCustomer` w)
+                timeFromSlot
+                (getEraSlotOfBlock block)
+                (txHistory w)
         }
   where
+    (utxoHistory', valueTransfers) =
+        rollForwardUTxO isOurs block (utxoHistory w)
     isOurs :: Address -> Bool
     isOurs = Address.isOurs (addresses w)
 
@@ -270,11 +294,12 @@ rollForwardUTxO
     => (Address -> Bool)
     -> Read.Block era
     -> UTxOHistory
-    -> UTxOHistory
+    -> (UTxOHistory, ValueTransferMap)
 rollForwardUTxO isOurs block u =
-    UTxOHistory.rollForward slot deltaUTxO u
+    (UTxOHistory.rollForward slot deltaUTxO u, valueTransfers)
   where
-    (deltaUTxO, _, _) = Balance.applyBlock isOurs block (UTxOHistory.getUTxO u)
+    (deltaUTxO, _, valueTransfers) =
+        Balance.applyBlock isOurs block (UTxOHistory.getUTxO u)
     slot = Read.getEraSlotNo $ Read.getEraBHeader block
 
 rollBackward
@@ -302,8 +327,8 @@ rollBackward targetPoint w =
     -- any other point than the target point (or genesis).
     actualPoint =
         if (targetSlot `Rollback.member` UTxOHistory.getRollbackWindow h)
-            -- FIXME: Add test for rollback window of `submissions`
-            then targetPoint
+            then -- FIXME: Add test for rollback window of `submissions`
+                targetPoint
             else Read.GenesisPoint
 
 availableBalance :: WalletState -> Read.Value
@@ -392,32 +417,36 @@ createPaymentConway
     -> Either (Write.ErrBalanceTx Write.Conway) Write.Tx
 createPaymentConway pparams timeTranslation destinations w =
     fmap (Read.Tx . fst)
-    . flip Random.evalRand (pilferRandomGen w)
-    . runExceptT
-    . balance
-        (availableUTxO w)
-        (addresses w)
-    . mkPartialTx
-    $ paymentTxBody
+        . flip Random.evalRand (pilferRandomGen w)
+        . runExceptT
+        . balance
+            (availableUTxO w)
+            (addresses w)
+        . mkPartialTx
+        $ paymentTxBody
   where
     paymentTxBody :: Write.TxBody
-    paymentTxBody = Write.TxBody
-        { spendInputs = mempty
-        , collInputs = mempty
-        , txouts =
-            Map.fromList $ zip [(toEnum 0)..] $ map (uncurry Write.mkTxOut) destinations
-        , collRet = Nothing
-        , expirySlot = Just . computeExpirySlot $ walletTip w
-        }
+    paymentTxBody =
+        Write.TxBody
+            { spendInputs = mempty
+            , collInputs = mempty
+            , txouts =
+                Map.fromList
+                    $ zip [(toEnum 0) ..]
+                    $ map (uncurry Write.mkTxOut) destinations
+            , collRet = Nothing
+            , expirySlot = Just . computeExpirySlot $ walletTip w
+            }
 
     mkPartialTx :: Write.TxBody -> Write.PartialTx Write.Conway
-    mkPartialTx txbody = Write.PartialTx
-        { tx = Read.unTx $ Write.mkTx txbody
-        , extraUTxO = mempty :: Write.UTxO Write.Conway
-        , redeemers = mempty
-        , stakeKeyDeposits = Write.StakeKeyDepositMap mempty
-        , timelockKeyWitnessCounts = Write.TimelockKeyWitnessCounts mempty
-        }
+    mkPartialTx txbody =
+        Write.PartialTx
+            { tx = Read.unTx $ Write.mkTx txbody
+            , extraUTxO = mempty :: Write.UTxO Write.Conway
+            , redeemers = mempty
+            , stakeKeyDeposits = Write.StakeKeyDepositMap mempty
+            , timelockKeyWitnessCounts = Write.TimelockKeyWitnessCounts mempty
+            }
 
     balance utxo addressState =
         Write.balanceTx
@@ -428,12 +457,13 @@ createPaymentConway pparams timeTranslation destinations w =
             (changeAddressGen addressState)
             ()
 
-    changeAddressGen s = Write.ChangeAddressGen
-        { Write.genChangeAddress =
-            first Read.decompactAddr . Address.newChangeAddress s
-        , Write.maxLengthChangeAddress =
-            Read.decompactAddr $ Address.mockMaxLengthChangeAddress s
-        }
+    changeAddressGen s =
+        Write.ChangeAddressGen
+            { Write.genChangeAddress =
+                first Read.decompactAddr . Address.newChangeAddress s
+            , Write.maxLengthChangeAddress =
+                Read.decompactAddr $ Address.mockMaxLengthChangeAddress s
+            }
 
 -- | Use entropy contained in the current 'WalletState'
 -- to construct a pseudorandom seed.
@@ -458,7 +488,7 @@ computeExpirySlot Read.GenesisPoint = 0
 computeExpirySlot (Read.BlockPoint slotNo _) =
     slotNo + hour
   where
-    hour = 60*60
+    hour = 60 * 60
 
 {-----------------------------------------------------------------------------
     Operations

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory.hs
@@ -6,7 +6,7 @@ module Cardano.Wallet.Deposit.Pure.API.TxHistory
     , ByTime
     , DownTime
     , ResolveAddress
-    , ResolveSlot
+    , LookupTimeFromSlot
     , TxHistory (..)
     , firstJust
     , transfers
@@ -84,4 +84,4 @@ instance Monoid TxHistory where
     mempty = TxHistory mempty mempty
 
 type ResolveAddress = Address -> Maybe Customer
-type ResolveSlot = Slot -> Maybe DownTime
+type LookupTimeFromSlot = Slot -> Maybe DownTime

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory.hs
@@ -155,10 +155,13 @@ rollBackward
     -> TxHistory
 rollBackward timeFromSlot slot TxHistory{byCustomer, byTime} =
     TxHistory
-        { byCustomer = onMap byCustomer $ fmap (`onFinger` takeToSlot)
+        { byCustomer =
+            onMap byCustomer
+                $ cleanNulls . fmap (`onFinger` takeToSlot)
         , byTime = onFinger byTime takeToSlot
         }
   where
     takeToSlot :: Monoid a => TimedSeq DownTime a -> TimedSeq DownTime a
-    takeToSlot x = maybe x (`forgetAfter` x)  $ timeFromSlot slot
+    takeToSlot x = maybe x (`forgetAfter` x) $ timeFromSlot slot
     forgetAfter t = dropBefore (Down t)
+    cleanNulls = MonoidalMap.filter (not . null)

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Cardano.Wallet.Deposit.Pure.API.TxHistory
     ( ByCustomer
@@ -10,6 +12,7 @@ module Cardano.Wallet.Deposit.Pure.API.TxHistory
     , TxHistory (..)
     , firstJust
     , transfers
+    , rollForward
     )
 where
 
@@ -19,24 +22,34 @@ import Cardano.Wallet.Deposit.Map
     ( F
     , Map (..)
     , W
+    , singletonFinger
+    , singletonMap
     )
-
 import Cardano.Wallet.Deposit.Pure.Address
     ( Customer
+    )
+import Cardano.Wallet.Deposit.Pure.Balance
+    ( ValueTransferMap
     )
 import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
     ( ValueTransfer
     )
 import Cardano.Wallet.Deposit.Read
     ( Address
+    , WithOrigin (..)
+    )
+import Cardano.Wallet.Deposit.Time
+    ( LookupTimeFromSlot
     )
 import Cardano.Wallet.Read
     ( Slot
     , TxId
-    , WithOrigin
     )
 import Data.Foldable
     ( Foldable (..)
+    )
+import Data.Maybe
+    ( maybeToList
     )
 import Data.Monoid
     ( First (..)
@@ -48,10 +61,13 @@ import Data.Time
     ( UTCTime
     )
 
+import qualified Data.Map.Monoidal.Strict as MonoidalMap
+
 firstJust :: a -> First a
 firstJust = First . Just
 
-transfers :: Foldable (Map xs) => Map xs ValueTransfer -> ValueTransfer
+transfers
+    :: Foldable (Map xs) => Map xs ValueTransfer -> ValueTransfer
 transfers = fold
 
 type DownTime = Down (WithOrigin UTCTime)
@@ -84,4 +100,40 @@ instance Monoid TxHistory where
     mempty = TxHistory mempty mempty
 
 type ResolveAddress = Address -> Maybe Customer
-type LookupTimeFromSlot = Slot -> Maybe DownTime
+
+rollForward
+    :: ValueTransferMap
+    -> ResolveAddress
+    -> LookupTimeFromSlot
+    -> Slot
+    -> TxHistory
+    -> TxHistory
+rollForward valueTransferMap resolveAddress timeFromSlot slot =
+    (txHistory' <>)
+  where
+    txHistory' =
+        blockToTxHistory valueTransferMap resolveAddress timeFromSlot slot
+
+blockToTxHistory
+    :: ValueTransferMap
+    -> ResolveAddress
+    -> LookupTimeFromSlot
+    -> Slot
+    -> TxHistory
+blockToTxHistory valueTransferMap resolveAddress timeFromSlot slot =
+    fold $ do
+        time <- fmap Down $ maybeToList $ timeFromSlot slot
+        (address, valueTransferByTxId) <- MonoidalMap.toList valueTransferMap
+        (txId, valueTransfer) <- MonoidalMap.toList valueTransferByTxId
+        customer <- maybeToList $ resolveAddress address
+        let byTime =
+                singletonFinger () time
+                    $ singletonMap (First $ Just slot) customer
+                    $ singletonMap (First $ Just address) txId
+                    $ Value valueTransfer
+        let byCustomer =
+                singletonMap () customer
+                    $ singletonFinger (First $ Just address) time
+                    $ singletonMap (First $ Just slot) txId
+                    $ Value valueTransfer
+        pure $ TxHistory{byCustomer, byTime}

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory/Mock.hs
@@ -19,8 +19,8 @@ import Cardano.Wallet.Deposit.Pure
     ( ValueTransfer (..)
     )
 import Cardano.Wallet.Deposit.Pure.API.TxHistory
-    ( ResolveAddress
-    , ResolveSlot
+    ( LookupTimeFromSlot
+    , ResolveAddress
     , TxHistory (..)
     )
 import Cardano.Wallet.Deposit.Read
@@ -70,7 +70,7 @@ mockTxHistory
     -- ^ Current time.
     -> ResolveAddress
     -- ^ Compute a customer from an address.
-    -> ResolveSlot
+    -> LookupTimeFromSlot
     -- ^ Compute a time from a slot.
     -> [Address]
     -- ^ List of addresses to use.

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory/Mock.hs
@@ -46,6 +46,9 @@ import Data.Maybe
 import Data.Monoid
     ( First (..)
     )
+import Data.Ord
+    ( Down (..)
+    )
 import Data.Time
     ( UTCTime (..)
     )
@@ -103,7 +106,7 @@ mockTxHistory now solveAddress solveSlot addresses ns =
                             Just c -> c
                             Nothing -> error "fakeDepositsCreate: address not found"
                     let time = case solveSlot slot of
-                            Just t -> t
+                            Just t -> Down t
                             Nothing -> error "fakeDepositsCreate: slot not found"
                         singletonByTime =
                             singletonMap () time

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory/Mock.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory/Mock.hs
@@ -22,6 +22,7 @@ import Cardano.Wallet.Deposit.Pure.API.TxHistory
     ( LookupTimeFromSlot
     , ResolveAddress
     , TxHistory (..)
+    , firstJust
     )
 import Cardano.Wallet.Deposit.Read
     ( Address
@@ -42,9 +43,6 @@ import Control.Monad
     )
 import Data.Maybe
     ( fromJust
-    )
-import Data.Monoid
-    ( First (..)
     )
 import Data.Ord
     ( Down (..)
@@ -110,13 +108,13 @@ mockTxHistory now solveAddress solveSlot addresses ns =
                             Nothing -> error "fakeDepositsCreate: slot not found"
                         singletonByTime =
                             singletonMap () time
-                                $ singletonMap (First $ Just slot) customer
-                                $ singletonMap (First $ Just address) txId
+                                $ singletonMap (firstJust slot) customer
+                                $ singletonMap (firstJust address) txId
                                 $ Value value
                         singletonByCustomer =
                             singletonMap () customer
-                                $ singletonMap (First $ Just address) time
-                                $ singletonMap (First $ Just slot) txId
+                                $ singletonMap (firstJust address) time
+                                $ singletonMap (firstJust slot) txId
                                 $ Value value
                     pure (singletonByCustomer, singletonByTime)
         byCustomer' = Map w $ fmap toFinger f

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Balance.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Balance.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE BangPatterns #-}
+
 -- | Wallet balance.
 module Cardano.Wallet.Deposit.Pure.Balance
     ( balance
     , availableUTxO
     , IsOurs
     , applyBlock
+    , ValueTransferMap
     ) where
 
 import Prelude
@@ -15,11 +17,30 @@ import Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO
 import Cardano.Wallet.Deposit.Pure.UTxO.Tx
     ( IsOurs
     , applyTx
+    , valueTransferFromDeltaUTxO
     )
 import Cardano.Wallet.Deposit.Pure.UTxO.UTxO
     ( UTxO
     , balance
     , excluding
+    )
+import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
+    ( ValueTransfer
+    )
+import Cardano.Wallet.Deposit.Read
+    ( Address
+    , TxId
+    )
+import Cardano.Wallet.Read
+    ( Block
+    , IsEra
+    , getTxId
+    )
+import Data.Foldable
+    ( Foldable (..)
+    )
+import Data.Map.Monoidal.Strict
+    ( MonoidalMap
     )
 import Data.Set
     ( Set
@@ -28,10 +49,13 @@ import Data.Set
 import qualified Cardano.Wallet.Deposit.Pure.UTxO.DeltaUTxO as DeltaUTxO
 import qualified Cardano.Wallet.Deposit.Write as Write
 import qualified Cardano.Wallet.Read as Read
+import qualified Data.Map.Monoidal.Strict as MonoidalMap
+import qualified Data.Map.Strict as Map
 
 {-----------------------------------------------------------------------------
     Wallet Balance
 ------------------------------------------------------------------------------}
+
 -- | Available = excluding pending transactions
 availableUTxO :: UTxO -> [Write.Tx] -> UTxO
 availableUTxO u pending =
@@ -45,31 +69,63 @@ availableUTxO u pending =
     getUsedTxIn :: Read.Tx Read.Conway -> Set Read.TxIn
     getUsedTxIn tx =
         Read.getInputs tx
-        <> Read.getCollateralInputs tx
+            <> Read.getCollateralInputs tx
 
 {-----------------------------------------------------------------------------
     Applying Blocks
 ------------------------------------------------------------------------------}
+
+-- | Get the value transfer of a 'DeltaUTxO'.
+getDeltaUTxOValueTransfer
+    :: UTxO
+    -> DeltaUTxO
+    -> TxId
+    -> ValueTransferMap
+getDeltaUTxOValueTransfer u du txId = fold $ do
+    (addr, value) <- Map.assocs $ valueTransferFromDeltaUTxO u du
+    pure
+        $ MonoidalMap.singleton addr
+        $ MonoidalMap.singleton
+            txId
+            value
+
+-- | A summary of all value transfers in a block.
+type ValueTransferMap =
+    MonoidalMap Address (MonoidalMap TxId ValueTransfer)
+
 -- | Apply a 'Block' to the 'UTxO'.
 --
 -- Returns both a delta and the new value.
 applyBlock
-    :: Read.IsEra era
-    => IsOurs Read.CompactAddr -> Read.Block era -> UTxO -> (DeltaUTxO, UTxO)
+    :: IsEra era
+    => IsOurs Read.CompactAddr
+    -> Block era
+    -> UTxO
+    -> (DeltaUTxO, UTxO, ValueTransferMap)
 applyBlock isOurs block u0 =
-    (DeltaUTxO.concat $ reverse dus, u1)
+    (DeltaUTxO.concat $ reverse dus, u1, totalValueTransfer)
   where
-    (dus, u1) =
-        mapAccumL' (applyTx isOurs) u0
+    (dus, (u1, totalValueTransfer)) =
+        mapAccumL' applyTx' (u0, mempty)
             $ Read.getEraTransactions block
+    applyTx' tx (u, total) =
+        let
+            (ds, u') = applyTx isOurs tx u
+            value = getDeltaUTxOValueTransfer u ds (getTxId tx)
+            total'
+                | null value = total
+                | otherwise = total <> value
+        in
+            (ds, (u', total'))
 
 {-----------------------------------------------------------------------------
     Helpers
 ------------------------------------------------------------------------------}
+
 -- | Strict variant of 'mapAccumL'.
-mapAccumL' :: (a -> s -> (o,s)) -> s -> [a] -> ([o],s)
+mapAccumL' :: (a -> s -> (o, s)) -> s -> [a] -> ([o], s)
 mapAccumL' f = go []
   where
-    go os !s0 []     = (reverse os, s0)
-    go os !s0 (x:xs) = case f x s0 of
-        (!o,!s1) -> go (o:os) s1 xs
+    go os !s0 [] = (reverse os, s0)
+    go os !s0 (x : xs) = case f x s0 of
+        (!o, !s1) -> go (o : os) s1 xs

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -62,6 +62,7 @@ module Cardano.Wallet.Deposit.Read
 
     , Read.NetworkId (Read.Mainnet, Read.Testnet)
     , Read.getNetworkId
+    , getEraSlotOfBlock
     ) where
 
 import Prelude
@@ -127,3 +128,6 @@ mockNextBlock old txs =
     slotNumber = case old of
         Read.GenesisPoint -> Read.SlotNo 0
         Read.BlockPoint{slotNo = n} -> succ n
+
+getEraSlotOfBlock :: Read.IsEra era => Read.Block era -> Read.Slot
+getEraSlotOfBlock = Read.At . Read.getEraSlotNo . Read.getEraBHeader

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Testing/DSL.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Testing/DSL.hs
@@ -1,0 +1,323 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Wallet.Deposit.Testing.DSL
+    ( Scenario (..)
+    , ScenarioP
+    , existsTx
+    , deposit
+    , deposit_
+    , withdrawal
+    , block
+    , rollForward
+    , rollBackward
+    , historyByTime
+    , newHistoryByTime
+    , availableBalance
+    , assert
+    , interpret
+    , InterpreterState (..)
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.Deposit.Pure
+    ( Customer
+    , WalletState
+    , getTxHistoryByTime
+    )
+import Cardano.Wallet.Deposit.Pure.API.TxHistory
+    ( ByTime
+    , LookupTimeFromSlot
+    )
+import Cardano.Wallet.Deposit.Read
+    ( Address
+    , ChainPoint (..)
+    , EraValue (..)
+    , getChainPoint
+    , mockNextBlock
+    , slotFromChainPoint
+    )
+import Cardano.Wallet.Deposit.Testing.DSL.ByTime
+    ( ByTimeM
+    , ByTimeMContext (..)
+    )
+import Cardano.Wallet.Deposit.Testing.DSL.Types
+    ( BlockI (..)
+    , TxI (..)
+    , UnspentI (..)
+    )
+import Cardano.Wallet.Deposit.Write
+    ( Block
+    , Tx
+    , TxBody
+    , addTxIn
+    , addTxOut
+    , emptyTxBody
+    , mkAda
+    , mkTx
+    , mkTxOut
+    )
+import Cardano.Wallet.Read
+    ( Coin (..)
+    , Slot
+    , Value (..)
+    , WithOrigin
+    , getTxId
+    , pattern TxIn
+    )
+import Control.Lens
+    ( At (..)
+    , Ixed (..)
+    , Lens'
+    , _1
+    , _2
+    , lens
+    , use
+    , uses
+    , zoom
+    , (%=)
+    , (.=)
+    )
+import Control.Monad
+    ( void
+    , (>=>)
+    )
+import Control.Monad.Operational
+    ( ProgramT
+    , ProgramViewT (..)
+    , singleton
+    , viewT
+    )
+import Control.Monad.Reader
+    ( MonadIO (..)
+    , runReader
+    )
+import Control.Monad.State
+    ( MonadState (..)
+    , MonadTrans (..)
+    , StateT
+    , evalStateT
+    , execStateT
+    , modify
+    )
+import Data.List
+    ( mapAccumL
+    )
+import Data.Map
+    ( Map
+    )
+import Data.Time
+    ( UTCTime
+    )
+
+import qualified Cardano.Wallet.Deposit.Pure as Wallet
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+
+data Scenario p a where
+    ExistsTx :: Scenario p TxI
+    Deposit :: TxI -> Customer -> Int -> Scenario p UnspentI
+    Withdrawal :: TxI -> UnspentI -> Scenario p ()
+    CreateBlock :: [TxI] -> Scenario p (BlockI)
+    RollForward :: [BlockI] -> Scenario p ()
+    RollBackward :: Maybe BlockI -> Scenario p ()
+    HistoryByTime :: Scenario p ByTime
+    NewHistoryByTime :: ByTimeM ByTime -> Scenario p ByTime
+    AvailableBalance :: Scenario p Int
+    Assert :: p -> Scenario p ()
+
+type ScenarioP p m = ProgramT (Scenario p) m
+
+existsTx :: ScenarioP p m TxI
+existsTx = singleton ExistsTx
+
+deposit :: TxI -> Customer -> Int -> ScenarioP p m UnspentI
+deposit tx customer value = singleton (Deposit tx customer value)
+
+deposit_ :: Monad m => TxI -> Customer -> Int -> ScenarioP p m ()
+deposit_ tx customer value = void $ deposit tx customer value
+
+withdrawal :: TxI -> UnspentI -> ScenarioP p m ()
+withdrawal tx unspent = singleton (Withdrawal tx unspent)
+
+block :: [TxI] -> ScenarioP p m BlockI
+block txs = singleton (CreateBlock txs)
+
+rollForward :: [BlockI] -> ScenarioP p m ()
+rollForward blocks = singleton (RollForward blocks)
+
+rollBackward :: Maybe BlockI -> ScenarioP p m ()
+rollBackward slot = singleton (RollBackward slot)
+
+historyByTime :: ScenarioP p m ByTime
+historyByTime = singleton HistoryByTime
+
+newHistoryByTime :: ByTimeM ByTime -> ScenarioP p m ByTime
+newHistoryByTime = singleton . NewHistoryByTime
+
+availableBalance :: ScenarioP p m Int
+availableBalance = singleton AvailableBalance
+
+assert :: p -> ScenarioP p m ()
+assert = singleton . Assert
+
+rollForwardBlocks
+    :: LookupTimeFromSlot
+    -> [BlockI]
+    -> (WalletState, InterpreterState)
+    -> (WalletState, InterpreterState)
+rollForwardBlocks timeOf blocks (w, interpreter@InterpreterState{..}) =
+    ( w'
+    , interpreter{iBlocks = newIBlocks, iBlockPoints = newIBlockPoints}
+    )
+  where
+    w' = Wallet.rollForwardMany timeOf (NE.fromList blocks') w
+    ((newIBlocks, newIBlockPoints), blocks') =
+        mapAccumL
+            rollForwardBlock
+            (iBlocks, iBlockPoints)
+            blocks
+    rollForwardBlock (iBlocksCurrent, iBlockPointsCurrent) blockI =
+        (
+            ( Map.insert blockPoint newBlock iBlocksCurrent
+            , Map.insert blockI blockPoint iBlockPointsCurrent
+            )
+        , EraValue newBlock
+        )
+      where
+        txs = iBlockContents Map.! blockI
+        newBlock = mockNextBlock startPoint txs
+        blockPoint = getChainPoint newBlock
+        startPoint =
+            maybe GenesisPoint fst
+                $ Map.lookupMax iBlocksCurrent
+
+rollBackwardBlock
+    :: LookupTimeFromSlot
+    -> Maybe BlockI
+    -> (WalletState, InterpreterState)
+    -> (WalletState, InterpreterState)
+rollBackwardBlock timeOf Nothing (w, interpreter) =
+    ( fst $ Wallet.rollBackward timeOf GenesisPoint w
+    , interpreter{iBlocks = mempty, iBlockPoints = mempty}
+    )
+rollBackwardBlock timeOf (Just blockI) (w, interpreter@InterpreterState{..}) =
+    case Map.lookup blockI iBlockPoints of
+        Just keep ->
+            ( w'
+            , interpreter{iBlocks = newIBlocks, iBlockPoints = newIBlockPoints}
+            )
+          where
+            w' = fst $ Wallet.rollBackward timeOf keep w
+            newIBlocks = Map.takeWhileAntitone (<= keep) iBlocks
+            newIBlockPoints = Map.filter (<= keep) iBlockPoints
+        Nothing -> (w, interpreter)
+
+data InterpreterState = InterpreterState
+    { iTxs :: Map TxI TxBody
+    , iBlockContents :: Map BlockI [Tx]
+    , iBlockPoints :: Map BlockI ChainPoint
+    , iBlocks :: Map ChainPoint Block
+    }
+    deriving (Show)
+
+iTxsL :: Lens' InterpreterState (Map TxI TxBody)
+iTxsL = lens iTxs (\s x -> s{iTxs = x})
+
+iBlockContentsL :: Lens' InterpreterState (Map BlockI [Tx])
+iBlockContentsL = lens iBlockContents (\s x -> s{iBlockContents = x})
+
+iBlockPointsL :: Lens' InterpreterState (Map BlockI ChainPoint)
+iBlockPointsL = lens iBlockPoints (\s x -> s{iBlockPoints = x})
+
+newTxId :: Monad m => StateT InterpreterState m TxI
+newTxId = zoom iTxsL $ do
+    txs <- get
+    let z = maybe 0 fst $ Map.lookupMax txs
+        txId = z + 1
+    put $ Map.insert txId emptyTxBody txs
+    return txId
+
+newBlockId :: Monad m => StateT InterpreterState m BlockI
+newBlockId = zoom iBlockContentsL $ do
+    blocks <- get
+    let z = maybe 0 fst $ Map.lookupMax blocks
+        blockId = z + 1
+    put $ Map.insert blockId [] blocks
+    return blockId
+
+interpret
+    :: (MonadIO m, MonadFail m)
+    => WalletState
+    -> (p -> m ())
+    -> (Customer -> Address)
+    -> (Slot -> WithOrigin UTCTime)
+    -> ScenarioP
+        p
+        (StateT (WalletState, InterpreterState) m)
+        ()
+    -> m ()
+interpret w runP customerAddresses slotTimes p = flip evalStateT w $ do
+    walletState <- get
+    (walletState', _) <-
+        lift
+            $ execStateT
+                (go p)
+                (walletState, InterpreterState mempty mempty mempty mempty)
+    put walletState'
+  where
+    go = viewT >=> eval
+    eval (Return x) = return x
+    eval (ExistsTx :>>= k) = do
+        txId <- zoom _2 newTxId
+        go $ k txId
+    eval (Deposit tx customer value :>>= k) = do
+        let v = mkAda $ fromIntegral value
+            txOut = mkTxOut (customerAddresses customer) v
+        Just txBody <- use (_2 . iTxsL . at tx)
+        let (txBody', tix) = addTxOut txOut txBody
+        _2 . iTxsL . ix tx .= txBody'
+        go $ k $ UnspentI (tx, tix)
+    eval (Withdrawal tx (UnspentI (tx', tix)) :>>= k) = do
+        Just txId <- uses (_2 . iTxsL . at tx') $ fmap (getTxId . mkTx)
+        _2 . iTxsL . ix tx %= \txBody -> addTxIn (TxIn txId tix) txBody
+        go $ k ()
+    eval (CreateBlock txs :>>= k) = do
+        blockId <- zoom _2 newBlockId
+        send <-
+            uses (_2 . iTxsL)
+                $ flip Map.restrictKeys
+                $ Set.fromList txs
+        _2 . iBlockContentsL . ix blockId .= (mkTx <$> Map.elems send)
+        go $ k blockId
+    eval (RollForward blocks :>>= k) = do
+        modify $ rollForwardBlocks (fmap Just slotTimes) blocks
+        go $ k ()
+    eval (RollBackward blockKeep :>>= k) = do
+        modify $ rollBackwardBlock (fmap Just slotTimes) blockKeep
+        go $ k ()
+    eval (HistoryByTime :>>= k) = do
+        v <- uses _1 getTxHistoryByTime
+        go $ k v
+    eval (NewHistoryByTime m :>>= k) = do
+        txIds' <- uses (_2 . iTxsL) $ (Map.!) . fmap (getTxId . mkTx)
+        blockSlots <-
+            uses (_2 . iBlockPointsL) $ (Map.!) . fmap slotFromChainPoint
+        go
+            $ k
+            $ runReader m
+            $ ByTimeMContext txIds' customerAddresses slotTimes blockSlots
+    eval (AvailableBalance :>>= k) = do
+        ValueC (CoinC v) _ <- uses _1 Wallet.availableBalance
+        go $ k $ fromIntegral v
+    eval (Assert assertion :>>= k) = do
+        lift $ runP assertion
+        go $ k ()

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Testing/DSL/ByTime.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Testing/DSL/ByTime.hs
@@ -1,0 +1,218 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use let" #-}
+
+module Cardano.Wallet.Deposit.Testing.DSL.ByTime
+    ( -- * ByTime
+      ByTimeM
+    , ByTimeMContext (..)
+    , ByTime
+
+      -- * At time
+    , atBlock
+    , atSlot
+    , newByTime
+
+      -- * For customer
+    , forCustomer
+
+      -- * In tx
+    , inTx
+
+      -- * Value transfer
+    , deposited
+    , withdrawn
+    )
+where
+
+import Prelude
+
+import Cardano.Wallet.Deposit.Map
+    ( Map (Map, Value)
+    , W
+    , toFinger
+    )
+import Cardano.Wallet.Deposit.Pure
+    ( Customer
+    , ValueTransfer (received, spent)
+    )
+import Cardano.Wallet.Deposit.Pure.API.TxHistory
+    ( ByTime
+    , DownTime
+    , firstJust
+    )
+import Cardano.Wallet.Deposit.Read
+    ( Address
+    )
+import Cardano.Wallet.Deposit.Testing.DSL.Types
+    ( BlockI
+    , TxI
+    )
+import Cardano.Wallet.Deposit.Write
+    ( mkAda
+    )
+import Cardano.Wallet.Read
+    ( Slot
+    , TxId
+    , WithOrigin (..)
+    )
+import Control.Monad.Reader
+    ( Reader
+    , asks
+    )
+import Control.Monad.State
+    ( State
+    , StateT
+    , execState
+    , execStateT
+    , modify'
+    )
+import Control.Monad.Trans
+    ( MonadTrans (..)
+    )
+import Data.Map.Monoidal.Strict
+    ( MonoidalMap
+    )
+import Data.Monoid
+    ( First
+    )
+import Data.Ord
+    ( Down (..)
+    )
+import Data.Time
+    ( UTCTime
+    )
+
+import qualified Data.Map.Monoidal.Strict as MonoidalMap
+
+-- -------------------------------------------------------------------------------
+-- -- AtTime
+-- -------------------------------------------------------------------------------
+
+data ByTimeMContext = ByTimeMContext
+    { txIdOfTxI :: TxI -> TxId
+    , addrOfCustomer :: Customer -> Address
+    , timeOfSlot :: Slot -> WithOrigin UTCTime
+    , slotOfBlock :: BlockI -> Slot
+    }
+
+type ByTimeM = Reader ByTimeMContext
+
+atBlock
+    :: BlockI
+    -> StateT
+        (MonoidalMap Customer (Map '[W (First Address) TxId] ValueTransfer))
+        ByTimeM
+        ()
+    -> StateT
+        ( MonoidalMap
+            DownTime
+            (Map '[W (First Slot) Customer, W (First Address) TxId] ValueTransfer)
+        )
+        ByTimeM
+        ()
+atBlock b v = do
+    slotOf <- asks slotOfBlock
+    atSlot (slotOf b) v
+
+atSlot
+    :: Slot
+    -> StateT
+        (MonoidalMap Customer (Map '[W (First Address) TxId] ValueTransfer))
+        ByTimeM
+        ()
+    -> StateT
+        ( MonoidalMap
+            DownTime
+            (Map '[W (First Slot) Customer, W (First Address) TxId] ValueTransfer)
+        )
+        ByTimeM
+        ()
+atSlot t v = do
+    timeOf <- asks timeOfSlot
+    txs <- lift $ newCustomers t v
+    modify' $ MonoidalMap.insert (Down $ timeOf t) txs
+
+newByTime
+    :: StateT
+        ( MonoidalMap
+            DownTime
+            (Map '[W (First Slot) Customer, W (First Address) TxId] ValueTransfer)
+        )
+        ByTimeM
+        ()
+    -> ByTimeM ByTime
+newByTime v = toFinger . Map () <$> execStateT v mempty
+
+-- -------------------------------------------------------------------------------
+-- -- Customer
+-- -------------------------------------------------------------------------------
+
+forCustomer
+    :: Customer
+    -> StateT
+        (MonoidalMap TxId (Map '[] ValueTransfer))
+        ByTimeM
+        ()
+    -> StateT
+        (MonoidalMap Customer (Map '[W (First Address) TxId] ValueTransfer))
+        ByTimeM
+        ()
+forCustomer c v = do
+    addrOf <- asks addrOfCustomer
+    txs <- lift $ newTxIds (addrOf c) v
+    modify' $ MonoidalMap.insert c txs
+
+newCustomers
+    :: Slot
+    -> StateT
+        (MonoidalMap Customer (Map '[W (First Address) TxId] ValueTransfer))
+        ByTimeM
+        ()
+    -> ByTimeM
+        (Map '[W (First Slot) Customer, W (First Address) TxId] ValueTransfer)
+newCustomers slot v = Map (firstJust slot) <$> execStateT v mempty
+
+-------------------------------------------------------------------------------
+-- Tx
+-------------------------------------------------------------------------------
+
+inTx
+    :: TxI
+    -> State ValueTransfer ()
+    -> StateT
+        (MonoidalMap TxId (Map '[] ValueTransfer))
+        ByTimeM
+        ()
+inTx tx v = do
+    w <- pure $ newValueTransferP v
+    txIdOf <- asks txIdOfTxI
+    modify' $ MonoidalMap.insert (txIdOf tx) w
+
+newTxIds
+    :: Address
+    -> StateT
+        (MonoidalMap TxId (Map '[] ValueTransfer))
+        ByTimeM
+        ()
+    -> ByTimeM (Map '[W (First Address) TxId] ValueTransfer)
+newTxIds addr v = Map (firstJust addr) <$> execStateT v mempty
+
+-------------------------------------------------------------------------------
+-- Value transfer
+-------------------------------------------------------------------------------
+
+deposited :: Int -> State ValueTransfer ()
+deposited n = modify' $ \s -> s{received = mkAda $ fromIntegral n}
+
+withdrawn :: Int -> State ValueTransfer ()
+withdrawn n = modify' $ \s -> s{spent = mkAda $ fromIntegral n}
+
+newValueTransferP
+    :: State ValueTransfer ()
+    -> Map '[] ValueTransfer
+newValueTransferP v = Value $ execState v mempty

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Testing/DSL/Types.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Testing/DSL/Types.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Wallet.Deposit.Testing.DSL.Types where
+
+import Prelude
+
+import Cardano.Wallet.Deposit.Read
+    ( Ix
+    )
+
+newtype TxI = TxI Int
+    deriving (Eq, Ord, Show, Num)
+
+newtype UnspentI = UnspentI (TxI, Ix)
+    deriving (Eq, Ord, Show)
+
+newtype BlockI = BlockI Int
+    deriving (Eq, Ord, Show, Num)
+
+newtype TimeI = TimeI Int
+    deriving (Eq, Ord, Show)

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Time.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Time.hs
@@ -19,6 +19,7 @@ module Cardano.Wallet.Deposit.Time
     , toTimeTranslation
 
     -- * wishlist
+    , LookupTimeFromSlot
     , unsafeUTCTimeOfSlot
     , unsafeSlotsToUTCTimes
     , unsafeSlotOfUTCTime
@@ -92,12 +93,15 @@ mockSlottingParameters = SlottingParameters
 {-----------------------------------------------------------------------------
     TimeInterpreter
 ------------------------------------------------------------------------------}
+
 toTimeTranslation :: TimeInterpreter -> Write.TimeTranslation
 toTimeTranslation = toTimeTranslationPure
 
-unsafeSlotsToUTCTimes :: Set.Set Slot -> Map.Map Slot (WithOrigin UTCTime)
+type LookupTimeFromSlot = Slot -> Maybe (WithOrigin UTCTime)
+
+unsafeSlotsToUTCTimes :: Set.Set Slot -> LookupTimeFromSlot
 unsafeSlotsToUTCTimes slots =
-    Map.fromList $ do
+    flip Map.lookup $ Map.fromList $ do
         slot <- Set.toList slots
         time <- maybeToList $ unsafeUTCTimeOfSlot slot
         pure (slot, time)

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Time.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Time.hs
@@ -21,7 +21,6 @@ module Cardano.Wallet.Deposit.Time
     -- * wishlist
     , LookupTimeFromSlot
     , unsafeUTCTimeOfSlot
-    , unsafeSlotsToUTCTimes
     , unsafeSlotOfUTCTime
     , systemStartMainnet
     , originTime
@@ -51,9 +50,6 @@ import Cardano.Wallet.Read
 import Data.Functor.Identity
     ( Identity (..)
     )
-import Data.Maybe
-    ( maybeToList
-    )
 import Data.Quantity
     ( Quantity (..)
     )
@@ -68,8 +64,6 @@ import Data.Time.Clock.POSIX
 import qualified Cardano.Wallet.Primitive.Slotting as Primitive
 import qualified Cardano.Wallet.Read as Read
 import qualified Cardano.Write.Tx as Write
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
 
 {-----------------------------------------------------------------------------
     TimeInterpreter
@@ -98,13 +92,6 @@ toTimeTranslation :: TimeInterpreter -> Write.TimeTranslation
 toTimeTranslation = toTimeTranslationPure
 
 type LookupTimeFromSlot = Slot -> Maybe (WithOrigin UTCTime)
-
-unsafeSlotsToUTCTimes :: Set.Set Slot -> LookupTimeFromSlot
-unsafeSlotsToUTCTimes slots =
-    flip Map.lookup $ Map.fromList $ do
-        slot <- Set.toList slots
-        time <- maybeToList $ unsafeUTCTimeOfSlot slot
-        pure (slot, time)
 
 unsafeUTCTimeOfSlot :: Slot -> Maybe (WithOrigin UTCTime)
 unsafeUTCTimeOfSlot Origin = Just Origin

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Time.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Time.hs
@@ -24,6 +24,7 @@ module Cardano.Wallet.Deposit.Time
     , unsafeSlotOfUTCTime
     , systemStartMainnet
     , originTime
+
     ) where
 
 import Prelude

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
@@ -11,6 +11,7 @@ module Cardano.Wallet.Deposit.Write
 
     , TxId
     , Tx
+    , Block
     , mkTx
     , TxBody (..)
     , TxIn
@@ -89,6 +90,8 @@ import qualified Data.Set as Set
     Convenience TxBody
 ------------------------------------------------------------------------------}
 type Tx = Read.Tx Read.Conway
+
+type Block = Read.Block Read.Conway
 
 data TxBody = TxBody
     { spendInputs :: Set TxIn

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
@@ -6,9 +6,7 @@
 module Cardano.Wallet.Deposit.Write
     ( -- * Basic types
       Address
-
     , Value
-
     , TxId
     , Tx
     , Block
@@ -17,7 +15,7 @@ module Cardano.Wallet.Deposit.Write
     , TxIn
     , TxOut
 
-    -- * Transaction balancing
+      -- * Transaction balancing
     , Write.IsRecentEra
     , Write.Conway
     , L.PParams
@@ -33,12 +31,16 @@ module Cardano.Wallet.Deposit.Write
     , Write.ErrBalanceTx (..)
     , Write.balanceTx
 
-    -- ** Time interpreter
+      -- ** Time interpreter
     , Write.TimeTranslation
-    -- * Helper functions
+
+      -- * Helper functions
     , mkAda
     , mkTxOut
     , toConwayTx
+    , addTxIn
+    , emptyTxBody
+    , addTxOut
     ) where
 
 import Prelude
@@ -58,6 +60,12 @@ import Cardano.Wallet.Deposit.Read
 import Cardano.Wallet.Read.Tx
     ( toConwayOutput
     )
+import Control.Lens
+    ( Lens'
+    , lens
+    , (&)
+    , (.~)
+    )
 import Data.Map
     ( Map
     )
@@ -71,10 +79,6 @@ import Data.Sequence.Strict
     )
 import Data.Set
     ( Set
-    )
-import Lens.Micro
-    ( (&)
-    , (.~)
     )
 
 import qualified Cardano.Ledger.Api as L
@@ -102,6 +106,24 @@ data TxBody = TxBody
     }
     deriving (Show)
 
+txOutsL :: Lens' TxBody (Map Ix TxOut)
+txOutsL = lens txouts (\s a -> s{txouts = a})
+
+nextIx :: TxBody -> Ix
+nextIx = maybe minBound (succ . fst) . Map.lookupMax . txouts
+
+addTxOut :: TxOut -> TxBody -> (TxBody, Ix)
+addTxOut txout txbody = (txBody', txIx)
+  where
+    txBody' = txbody & txOutsL .~ Map.insert txIx txout (txouts txbody)
+    txIx = nextIx txbody
+
+addTxIn :: TxIn -> TxBody -> TxBody
+addTxIn txin txbody = txbody{spendInputs = Set.insert txin (spendInputs txbody)}
+
+emptyTxBody :: TxBody
+emptyTxBody = TxBody mempty mempty mempty Nothing Nothing
+
 -- | Inject a number of ADA, i.e. a million lovelace.
 mkAda :: Integer -> Value
 mkAda = Read.injectCoin . Read.CoinC . (* 1000000)
@@ -118,19 +140,16 @@ mkTx txbody = Read.Tx $ L.mkBasicTx txBody
     txBody :: L.TxBody L.Conway
     txBody =
         L.mkBasicTxBody
-            & (L.inputsTxBodyL .~ Set.map toLedgerTxIn (spendInputs txbody))
-            & (L.collateralInputsTxBodyL
+            & L.inputsTxBodyL .~ Set.map toLedgerTxIn (spendInputs txbody)
+            & L.collateralInputsTxBodyL
                 .~ Set.map toLedgerTxIn (collInputs txbody)
-                )
-            & (L.outputsTxBodyL .~ toLedgerTxOuts (txouts txbody))
-            & (L.collateralReturnTxBodyL
+            & L.outputsTxBodyL .~ toLedgerTxOuts (txouts txbody)
+            & L.collateralReturnTxBodyL
                 .~ toLedgerMaybeTxOut (collRet txbody)
-                )
-            & (L.vldtTxBodyL .~
-                L.ValidityInterval
+            & L.vldtTxBodyL
+                .~ L.ValidityInterval
                     SNothing
                     (toLedgerSlotNo <$> maybeToStrictMaybe (expirySlot txbody))
-                )
 
 toLedgerSlotNo :: SlotNo -> L.SlotNo
 toLedgerSlotNo (SlotNo n) = L.SlotNo (fromInteger $ fromIntegral n)

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Run.hs
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Run.hs
@@ -20,7 +20,6 @@ import Test.Hspec
     ( SpecWith
     , describe
     , it
-    , pendingWith
     )
 import Test.Hspec.Extra
     ( aroundAll
@@ -64,7 +63,6 @@ scenarios = do
                     Exchanges.scenarioCreateAddressList
 
         it "4. Create payments to a different wallet" $ \env -> do
-            pendingWith "Waiting for getCustomerDeposits to support rollForward"
             withWalletEnvMock env $ \walletEnv ->
                 Wallet.withWalletInit walletEnv xpub 32
                     $ Exchanges.scenarioCreatePayment xprv env mockAddress

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Map/TimedSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Map/TimedSpec.hs
@@ -16,7 +16,7 @@ import Cardano.Wallet.Deposit.Map.Timed
     , maxKey
     , minKey
     , takeAfter
-    , takeBefore
+    , takeUpTo
     )
 import Data.FingerTree
     ( fromList
@@ -231,56 +231,56 @@ spec = do
                 `shouldBe` result [t1 <> t2 <> t3] (Just t4)
     describe "finger tree pager back" $ do
         it "can extract without start" $ do
-            takeBefore
+            takeUpTo
                 byDay
                 Nothing
                 (Just 1)
                 (fromList ts)
                 `shouldBe` result [t7] (Just t6)
         it "can extract without count" $ do
-            takeBefore
+            takeUpTo
                 byDay
                 (Just $ t "2022-03-05 12:00:00")
                 Nothing
                 (fromList ts)
                 `shouldBe` result [t7, t6, t4 <> t5, t3, t2, t1, t0] Nothing
         it "can extract 1 day" $ do
-            takeBefore
+            takeUpTo
                 byDay
                 (Just $ t "2022-03-05 12:00:00")
                 (Just 1)
                 (fromList ts)
                 `shouldBe` result [t7] (Just t6)
         it "can extract 2 days" $ do
-            takeBefore
+            takeUpTo
                 byDay
                 (Just $ t "2022-03-05 12:00:00")
                 (Just 2)
                 (fromList ts)
                 `shouldBe` result [t7, t6] (Just t5)
         it "can extract 3 days" $ do
-            takeBefore
+            takeUpTo
                 byDay
                 (Just $ t "2022-03-05 12:00:00")
                 (Just 3)
                 (fromList ts)
                 `shouldBe` result [t7, t6, t4 <> t5] (Just t3)
         it "can extract 1 month" $ do
-            takeBefore
+            takeUpTo
                 byMonth
                 (Just $ t "2022-03-05 12:00:00")
                 (Just 1)
                 (fromList ts)
                 `shouldBe` result [t6 <> t7] (Just t5)
         it "can extract 2 months" $ do
-            takeBefore
+            takeUpTo
                 byMonth
                 (Just $ t "2022-03-05 12:00:00")
                 (Just 2)
                 (fromList ts)
                 `shouldBe` result [t6 <> t7, t4 <> t5] (Just t3)
         it "can extract 2 years" $ do
-            takeBefore
+            takeUpTo
                 byYear
                 (Just $ t "2022-03-05 12:00:00")
                 (Just 2)
@@ -289,21 +289,21 @@ spec = do
                     [t4 <> t5 <> t6 <> t7, t0 <> t1 <> t2 <> t3]
                     Nothing
         it "can extract 1 day before t7" $ do
-            takeBefore
+            takeUpTo
                 byDay
                 (Just $ t "2022-03-05 11:59:59")
                 (Just 1)
                 (fromList ts)
                 `shouldBe` result [t6] (Just t5)
         it "can extract 1 month before t6" $ do
-            takeBefore
+            takeUpTo
                 byMonth
                 (Just $ t "2022-03-03 11:59:59")
                 (Just 1)
                 (fromList ts)
                 `shouldBe` result [t4 <> t5] (Just t3)
         it "can extract 1 year before t4" $ do
-            takeBefore
+            takeUpTo
                 byYear
                 (Just $ t "2022-01-02 23:59:59")
                 (Just 1)
@@ -323,7 +323,7 @@ spec = do
                     , [t7]
                     ]
         it "can consume scrolling backward by 1 day" $ do
-            scroll maxKey takeBefore byDay 1 (fromList ts)
+            scroll maxKey takeUpTo byDay 1 (fromList ts)
                 `shouldBe` results
                     [ [t7]
                     , [t6]
@@ -342,7 +342,7 @@ spec = do
                     , [t6 <> t7]
                     ]
         it "can consume scrolling backward by 1 month" $ do
-            scroll maxKey takeBefore byMonth 1 (fromList ts)
+            scroll maxKey takeUpTo byMonth 1 (fromList ts)
                 `shouldBe` results
                     [ [t6 <> t7]
                     , [t4 <> t5]
@@ -356,7 +356,7 @@ spec = do
                     , [t4 <> t5 <> t6 <> t7]
                     ]
         it "can consume scrolling backward by 1 year" $ do
-            scroll maxKey takeBefore byYear 1 (fromList ts)
+            scroll maxKey takeUpTo byYear 1 (fromList ts)
                 `shouldBe` results
                     [ [t4 <> t5 <> t6 <> t7]
                     , [t0 <> t1 <> t2 <> t3]

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Map/TimedSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Map/TimedSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Wallet.Deposit.Map.TimedSpec where
 
@@ -10,6 +11,8 @@ import Prelude
 import Cardano.Wallet.Deposit.Map.Timed
     ( Timed (..)
     , TimedSeq
+    , dropAfter
+    , dropBefore
     , maxKey
     , minKey
     , takeAfter
@@ -358,3 +361,37 @@ spec = do
                     [ [t4 <> t5 <> t6 <> t7]
                     , [t0 <> t1 <> t2 <> t3]
                     ]
+
+    describe "dropAfter function" $ do
+        it "works on empty" $ do
+            dropAfter (t "2021-01-01 00:00:00") (fromList @UTimed [])
+                `shouldBe` fromList []
+        it "drop a single" $ do
+            dropAfter (t "2021-01-01 00:00:00") (fromList @UTimed [t0])
+                `shouldBe` fromList [t0]
+        it "take one and drop the second, early cut" $ do
+            dropAfter (t "2021-01-01 00:00:00") (fromList @UTimed [t0, t1])
+                `shouldBe` fromList [t0]
+        it "take one and drop the second, late cut" $ do
+            dropAfter (t "2021-01-01 23:59:59") (fromList @UTimed [t0, t1])
+                `shouldBe` fromList [t0]
+        it "can take all" $ do
+            dropAfter (t "2021-01-02 00:00:00") (fromList @UTimed [t0, t1])
+                `shouldBe` fromList [t0, t1]
+
+    describe "dropBefore function" $ do
+        it "works on empty" $ do
+            dropBefore @UTCTime @() (t "2021-01-01 00:00:00") (fromList [])
+                `shouldBe` fromList []
+        it "drop a single" $ do
+            dropBefore (t "2021-01-01 00:00:01") (fromList [t0])
+                `shouldBe` fromList []
+        it "take second and drop the first, early cut" $ do
+            dropBefore (t "2021-01-01 00:00:01") (fromList [t0, t1])
+                `shouldBe` fromList [t1]
+        it "take the second and drop the first, late cut" $ do
+            dropBefore (t "2021-01-02 00:00:00") (fromList [t0, t1])
+                `shouldBe` fromList [t1]
+        it "can take all" $ do
+            dropBefore (t "2021-01-01 00:00:00") (fromList [t0, t1])
+                `shouldBe` fromList [t0, t1]

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/PureSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/PureSpec.hs
@@ -33,6 +33,7 @@ import Cardano.Wallet.Deposit.Testing.DSL
     , deposit
     , deposit_
     , existsTx
+    , historyByCustomer
     , historyByTime
     , interpret
     , newHistoryByTime
@@ -42,6 +43,7 @@ import Cardano.Wallet.Deposit.Testing.DSL
     )
 import Cardano.Wallet.Deposit.Testing.DSL.ByTime
     ( atBlock
+    , byCustomerFromByTime
     , deposited
     , forCustomer
     , inTx
@@ -117,8 +119,10 @@ spec = do
         it "is empty after initialization"
             $ testOnWallet
             $ do
-                h0 <- historyByTime
-                assert $ h0 `shouldBe` mempty
+                ht0 <- historyByTime
+                assert $ ht0 `shouldBe` mempty
+                hc0 <- historyByCustomer
+                assert $ hc0 `shouldBe` mempty
         it "reports a tx after a rollforward"
             $ testOnWallet
             $ do
@@ -132,6 +136,8 @@ spec = do
                         forCustomer 1 $ do
                             inTx tx1 $ deposited 100
                 assert $ h1 `shouldBe` h1'
+                hc1 <- historyByCustomer
+                assert $ hc1 `shouldBe` byCustomerFromByTime h1'
                 balance <- availableBalance
                 assert $ balance `shouldBe` 100_000_000
         it "reports multiple blocks after a rollforward"
@@ -153,6 +159,8 @@ spec = do
                         forCustomer 1 $ do
                             inTx tx2 $ deposited 200
                 assert $ h1 `shouldBe` h1'
+                hc1 <- historyByCustomer
+                assert $ hc1 `shouldBe` byCustomerFromByTime h1'
                 balance <- availableBalance
                 assert $ balance `shouldBe` 300_000_000
         it "reports withdrawals in separate blocks from deposits"
@@ -174,6 +182,8 @@ spec = do
                         forCustomer 1 $ do
                             inTx tx2 $ withdrawn 100
                 assert $ h1 `shouldBe` h1'
+                hc1 <- historyByCustomer
+                assert $ hc1 `shouldBe` byCustomerFromByTime h1'
                 balance <- availableBalance
                 assert $ balance `shouldBe` 0
         it "reports withdrawals in the same block as deposits"
@@ -192,6 +202,8 @@ spec = do
                             inTx tx1 $ deposited 100
                             inTx tx2 $ withdrawn 100
                 assert $ h1 `shouldBe` h1'
+                hc1 <- historyByCustomer
+                assert $ hc1 `shouldBe` byCustomerFromByTime h1'
                 balance <- availableBalance
                 assert $ balance `shouldBe` 0
 
@@ -205,6 +217,8 @@ spec = do
                 rollBackward Nothing
                 h1 <- historyByTime
                 assert $ h1 `shouldBe` mempty
+                hc1 <- historyByCustomer
+                assert $ hc1 `shouldBe` mempty
                 balance <- availableBalance
                 assert $ balance `shouldBe` 0
         it "contains the blocks not rolled back after a partial rollback"
@@ -224,6 +238,8 @@ spec = do
                         forCustomer 1 $ do
                             inTx tx1 $ deposited 100
                 assert $ h1 `shouldBe` h1'
+                hc1 <- historyByCustomer
+                assert $ hc1 `shouldBe` byCustomerFromByTime h1'
                 balance <- availableBalance
                 assert $ balance `shouldBe` 100_000_000
 

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/PureSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/PureSpec.hs
@@ -17,6 +17,12 @@ import Cardano.Crypto.Wallet
     , generate
     , toXPub
     )
+import Cardano.Wallet.Deposit.Pure.API.TxHistory
+    ( LookupTimeFromSlot
+    )
+import Cardano.Wallet.Deposit.Time
+    ( unsafeUTCTimeOfSlot
+    )
 import Test.Hspec
     ( Spec
     , describe
@@ -36,6 +42,9 @@ import qualified Cardano.Wallet.Deposit.Write as Write
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+
+timeFromSlot :: LookupTimeFromSlot
+timeFromSlot = unsafeUTCTimeOfSlot
 
 spec :: Spec
 spec = do
@@ -59,11 +68,11 @@ prop_availableBalance_rollForward_twice =
     tx1 = payFromFaucet [(addr1, Write.mkAda 1)]
     block1 = Read.mockNextBlock Read.GenesisPoint [tx1]
     chainPoint1 = Read.getChainPoint block1
-    w1 = Wallet.rollForwardOne (Read.EraValue block1) w0
+    w1 = Wallet.rollForwardOne  timeFromSlot (Read.EraValue block1) w0
 
     tx2 = payFromFaucet [(addr2, Write.mkAda 2)]
     block2 = Read.mockNextBlock chainPoint1 [tx2]
-    w2 = Wallet.rollForwardOne (Read.EraValue block2) w1
+    w2 = Wallet.rollForwardOne timeFromSlot (Read.EraValue block2) w1
 
 prop_availableBalance_rollForward_rollBackward :: Property
 prop_availableBalance_rollForward_rollBackward =
@@ -89,17 +98,17 @@ prop_availableBalance_rollForward_rollBackward =
 
     tx1 = payFromFaucet [(addr1, Write.mkAda 1)]
     block1 = Read.mockNextBlock chainPoint0 [tx1]
-    w1 = Wallet.rollForwardOne (Read.EraValue block1) w0
+    w1 = Wallet.rollForwardOne timeFromSlot (Read.EraValue block1) w0
     chainPoint1 = Read.getChainPoint block1
 
     tx2 = payFromFaucet [(addr2, Write.mkAda 2)]
     block2 = Read.mockNextBlock chainPoint1 [tx2]
     chainPoint2 = Read.getChainPoint block2
-    w2 = Wallet.rollForwardOne (Read.EraValue block2) w1
+    w2 = Wallet.rollForwardOne timeFromSlot (Read.EraValue block2) w1
 
     tx3 = spendOneTxOut (Wallet.availableUTxO w2)
     block3 = Read.mockNextBlock chainPoint2 [tx3]
-    w3 = Wallet.rollForwardOne (Read.EraValue block3) w2
+    w3 = Wallet.rollForwardOne timeFromSlot (Read.EraValue block3) w2
 
 emptyWalletWith17Addresses :: Wallet.WalletState
 emptyWalletWith17Addresses =

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/PureSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/PureSpec.hs
@@ -68,7 +68,7 @@ prop_availableBalance_rollForward_twice =
     tx1 = payFromFaucet [(addr1, Write.mkAda 1)]
     block1 = Read.mockNextBlock Read.GenesisPoint [tx1]
     chainPoint1 = Read.getChainPoint block1
-    w1 = Wallet.rollForwardOne  timeFromSlot (Read.EraValue block1) w0
+    w1 = Wallet.rollForwardOne timeFromSlot (Read.EraValue block1) w0
 
     tx2 = payFromFaucet [(addr2, Write.mkAda 2)]
     block2 = Read.mockNextBlock chainPoint1 [tx2]
@@ -76,13 +76,16 @@ prop_availableBalance_rollForward_twice =
 
 prop_availableBalance_rollForward_rollBackward :: Property
 prop_availableBalance_rollForward_rollBackward =
-        Wallet.availableBalance (fst $ Wallet.rollBackward chainPoint0 w3)
+        Wallet.availableBalance
+            (fst $ Wallet.rollBackward timeFromSlot chainPoint0 w3)
             === Wallet.availableBalance w0
     .&&.
-        Wallet.availableBalance (fst $ Wallet.rollBackward chainPoint1 w3)
+        Wallet.availableBalance
+            (fst $ Wallet.rollBackward timeFromSlot chainPoint1 w3)
             === Wallet.availableBalance w1
     .&&.
-        Wallet.availableBalance (fst $ Wallet.rollBackward chainPoint2 w3)
+        Wallet.availableBalance
+            (fst $ Wallet.rollBackward timeFromSlot chainPoint2 w3)
             === Wallet.availableBalance w2
     .&&.
         Wallet.availableBalance w3

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Addresses/Transactions.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Addresses/Transactions.hs
@@ -62,9 +62,6 @@ import Cardano.Wallet.UI.Lib.Time.Direction
 import Data.Bifunctor
     ( first
     )
-import Data.Foldable
-    ( toList
-    )
 import Data.Monoid
     ( First (..)
     , Last (..)
@@ -79,6 +76,7 @@ import Servant
     ( Handler
     )
 
+import qualified Cardano.Wallet.Deposit.Map.Timed as TimedSeq
 import qualified Data.ByteString.Lazy.Char8 as BL
 import qualified Data.Map.Monoidal.Strict as MonoidalMap
 
@@ -114,7 +112,7 @@ convert
         (Map [F (First Address) DownTime, W (First Slot) TxId] ValueTransfer)
     -> [(DownTime, (Slot, TxId, ValueTransfer))]
 convert Nothing = []
-convert (Just mtxs) = concatMap f $ toList $ value mtxs
+convert (Just mtxs) = concatMap f $ TimedSeq.toList $ value mtxs
   where
     f
         :: Timed DownTime (Map '[W (First Slot) TxId] ValueTransfer)

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Deposits/Mock.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Deposits/Mock.hs
@@ -34,9 +34,6 @@ import Control.Concurrent.STM
 import Control.Monad.IO.Class
     ( MonadIO (..)
     )
-import Data.Ord
-    ( Down (..)
-    )
 import Data.Time
     ( UTCTime (..)
     , diffUTCTime
@@ -66,7 +63,7 @@ getMockDepositsByTimeWithCount
 getMockDepositsByTimeWithCount nDeposits = do
     addresses <- fmap snd <$> listCustomers
     solveAddress <- addressToCustomer
-    let solveSlot = fmap Down <$> unsafeUTCTimeOfSlot
+    let solveSlot = unsafeUTCTimeOfSlot
     liftIO
         $ getCachedMockDeposits
             solveAddress

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Deposits/Mock.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Deposits/Mock.hs
@@ -6,8 +6,8 @@ where
 import Prelude
 
 import Cardano.Wallet.Deposit.Pure.API.TxHistory
-    ( ResolveAddress
-    , ResolveSlot
+    ( LookupTimeFromSlot
+    , ResolveAddress
     , TxHistory
     )
 import Cardano.Wallet.Deposit.Pure.API.TxHistory.Mock
@@ -76,7 +76,7 @@ getMockDepositsByTimeWithCount nDeposits = do
 
 getCachedMockDeposits
     :: ResolveAddress
-    -> ResolveSlot
+    -> LookupTimeFromSlot
     -> Int
     -> [Address]
     -> IO TxHistory

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Deposits/Times.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Deposits/Times.hs
@@ -71,6 +71,7 @@ import Data.Ord
     ( Down (..)
     )
 
+import qualified Cardano.Wallet.Deposit.Map.Timed as TimedSeq
 import qualified Data.Map.Strict as Map
 
 depositsPaginateM
@@ -96,7 +97,11 @@ depositsPaginateM
             , pageAtIndex = \t -> do
                 Paginate{pageAtIndex} <- history
                 pure
-                    $ second (Map.fromList . concatMap fromTimed . toList)
+                    $ second
+                        ( Map.fromList
+                            . concatMap fromTimed
+                            . TimedSeq.toList
+                        )
                         <$> pageAtIndex t
             , minIndex = do
                 Paginate{minIndex} <- paginate <$> retrieveByTime

--- a/lib/ui/src/Cardano/Wallet/UI/Lib/Pagination/TimedSeq.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Lib/Pagination/TimedSeq.hs
@@ -10,7 +10,7 @@ import Cardano.Wallet.Deposit.Map.Timed
     ( TimedSeq
     , minKey
     , takeAfter
-    , takeBefore
+    , takeUpTo
     )
 import Cardano.Wallet.UI.Lib.Pagination.Type
     ( MkPaginatePure
@@ -45,7 +45,7 @@ previous
     -> TimedSeq k a
     -> k
     -> Maybe k
-previous n proj s start' = snd $ takeBefore proj (Just start') (Just n) s
+previous n proj s start' = snd $ takeUpTo proj (Just start') (Just n) s
 
 nextPage
     :: (Ord q, Monoid a, Ord k)


### PR DESCRIPTION
- Add roll forward append operation to `TxHistory`
- Enable roll forward of `TxHistory` in the deposit wallet state operations
- Enable roll backward of `TxHistory` in the deposit wallet state operations
- Introduce a DSL to build `TxHistory` values
- Introduce a DSL for unit testing the `WalletState` with support for `TxHistory` DSL
- Test `TxHistory` roll forward and backward  as part of the `WalletState`
- Enable the exchange scenario that was pending waiting for this PR

ADP-3443