### PR TITLE
[ADP-3344] Complete `getBIP32PathsForOwnedInputs`

### DIFF
--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -459,12 +459,9 @@ pilferRandomGen =
 
 getBIP32PathsForOwnedInputs :: Write.Tx -> WalletState -> [BIP32Path]
 getBIP32PathsForOwnedInputs tx w =
-    getBIP32Paths w
-        . resolveInputAddresses
-        $ Write.spendInputs txBody <> Write.collInputs txBody
+    getBIP32Paths w $ resolveInputAddresses inputs
   where
-    txBody :: Write.TxBody
-    txBody = undefined tx
+    inputs = Read.getInputs tx <> Read.getCollateralInputs tx
 
     resolveInputAddresses :: Set Read.TxIn -> [Read.Address]
     resolveInputAddresses ins =

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Read.hs
@@ -39,6 +39,8 @@ module Cardano.Wallet.Deposit.Read
     , Read.TxId
     , Read.Tx (..)
     , Read.utxoFromEraTx
+    , Read.getCollateralInputs
+    , Read.getInputs
 
     , Read.Block
     , Read.getChainPoint


### PR DESCRIPTION
This pull request completes the implementation of `getBIP32PathsForOwnedInputs` for the Deposit Wallet.

### Issue number

ADP-3344