### PR TITLE
[ADP-3226] Make it possible to run startup CI scripts from anywhere

### DIFF
--- a/run/common/nix/run-node.sh
+++ b/run/common/nix/run-node.sh
@@ -4,8 +4,10 @@
 # set -euox pipefail
 set -euo pipefail
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 # shellcheck disable=SC1091
-source .env
+source ${SCRIPT_DIR}/.env
 
 mkdir -p ./databases
 

--- a/run/common/nix/run-wallet.sh
+++ b/run/common/nix/run-wallet.sh
@@ -2,8 +2,10 @@
 # set -euox pipefail
 set -euo pipefail
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 # shellcheck disable=SC1091
-source .env
+source ${SCRIPT_DIR}/.env
 
 mkdir -p ./databases
 
@@ -31,7 +33,7 @@ NODE_SOCKET_DIR=${NODE_SOCKET_DIR:=$LOCAL_NODE_SOCKET_DIR}
 NODE_SOCKET_PATH=${NODE_SOCKET_DIR}/${NODE_SOCKET_NAME}
 
 # Define and export the local and actual configs directory for the node
-LOCAL_NODE_CONFIGS=./configs
+LOCAL_NODE_CONFIGS=${SCRIPT_DIR}/configs
 NODE_CONFIGS=${NODE_CONFIGS:=$LOCAL_NODE_CONFIGS}
 
 
@@ -68,8 +70,9 @@ else
     NETWORK_OPTION="--testnet ${NODE_CONFIGS}/byron-genesis.json"
 
 fi
+
 # shellcheck disable=SC2086
-cabal run --project-dir ../../.. -O0 cardano-wallet-exe:exe:cardano-wallet -- \
+cabal run --project-dir ${SCRIPT_DIR}/../../.. -O0 cardano-wallet-exe:exe:cardano-wallet -- \
     serve \
     --log-level DEBUG \
     --trace-application DEBUG \


### PR DESCRIPTION
Those scripts are generally useful to quickly start a wallet and a accompanying node, this small change makes them even more useful by allowing the user to call them from anywhere.

Before:

```
cardano-wallet % run/preprod/nix/run-wallet.sh
run/preprod/nix/run-wallet.sh: ligne 6: .env: No such file or directory
```

After:

```
cardano-wallet % run/preprod/nix/run-wallet.sh
Wallet service port: 23897
Wallet UI port: 16853
Deposit wallet UI port: 27351
Deposit wallet port: 22724
Running wallet in testnet mode
...
[cardano-wallet.main:Info:11] [2024-11-07 09:30:11.94 UTC] Wallet backend server listening on http://0.0.0.0:23897/
[cardano-wallet.network:Info:18] [2024-11-07 09:30:11.99 UTC] Protocol parameters for tip are:
 Decentralization level: 100.00%
 Transaction parameters: [Fee policy: 155381.0 + 44.0x, Tx max size: 16384, max exec units: max steps: 10000000000, max memory: 14000000]
 Desired number of pools: 500
 Eras:
   - byron from 0
   - shelley from 4
   - allegra from 5
   - mary from 6
   - alonzo from 7
   - babbage from 12
 Execution unit prices: 721 % 10000000 per step, 577 % 10000 per memory unit

Slotting parameters for tip are:
 Slot length:        1s
 Epoch length:       432000
 Active slot coeff:  5.0e-2
 Security parameter: 2160 block

```

