### PR TITLE
[ADP-3479] Add more tests for `encodeAddress` & `decodeAddress`

### DIFF
--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -202,6 +202,9 @@ test-suite unit
     , aeson
     , aeson-pretty
     , base
+    , bech32
+    , bech32-th
+    , base58-bytestring
     , bytestring
     , cardano-crypto
     , cardano-ledger-core:testlib
@@ -220,6 +223,7 @@ test-suite unit
     , QuickCheck
     , temporary
     , time
+    , text
     , transformers
     , with-utf8
 

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/Address.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/Address.hs
@@ -82,7 +82,6 @@ data DecodingError
     | InvalidBase58Encoding
     | InvalidHumanReadablePart HumanReadablePart
     | InvalidDataPart DataPart
-    | InvalidNetwork
     | AddressFlavorMismatch
     | AddressDecodingError String
     | AddressNetworkMismatch

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Pure/API/AddressSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Pure/API/AddressSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE QuasiQuotes #-}
 module Cardano.Wallet.Deposit.Pure.API.AddressSpec
     ( spec
     )
@@ -10,8 +11,25 @@ import Cardano.Wallet.Deposit.Pure.API.Address
     , decodeAddress
     , encodeAddress
     )
+import Cardano.Wallet.Read.Address
+    ( toShortByteString
+    )
 import Control.Monad
     ( forM_
+    )
+import Data.ByteString.Base58
+    ( bitcoinAlphabet
+    , encodeBase58
+    )
+import Data.Either
+    ( isLeft
+    , isRight
+    )
+import Data.Function
+    ( (&)
+    )
+import Data.Text
+    ( Text
     )
 import Test.Cardano.Ledger.Core.Arbitrary
     ()
@@ -23,9 +41,21 @@ import Test.Hspec
     )
 import Test.QuickCheck
     ( Arbitrary (..)
+    , Gen
+    , checkCoverage
+    , cover
+    , elements
     , forAll
+    , label
+    , oneof
+    , property
     , (===)
     )
+
+import qualified Codec.Binary.Bech32 as Bech32
+import qualified Codec.Binary.Bech32.TH as Bech32
+import qualified Data.ByteString.Short as B8
+import qualified Data.Text.Encoding as T
 
 spec :: Spec
 spec = do
@@ -33,6 +63,25 @@ spec = do
         it "rountrips correctly on random addresses" $ forAll arbitrary $ \x ->
             decodeAddress (encodeAddress x)
                 === Right x
+
+        it "decodeAddress text = Right addr ==> encodeAddress addr == text"
+            $ checkCoverage $ forAll genArbitrarilyEncodedAddress $ \text -> do
+                let getErrorLabel e = case e of
+                        InvalidBech32Encoding _e -> "invalid bech32 encoding"
+                        InvalidBase58Encoding -> "invalid base58 encoding"
+                        InvalidHumanReadablePart _hrp -> "invalid hrp"
+                        InvalidDataPart _ -> "invalid data part"
+                        AddressFlavorMismatch -> "flavor mismatch"
+                        AddressDecodingError _ -> "decoding error"
+                        AddressNetworkMismatch -> "network mismatch"
+
+                let res = decodeAddress text
+                case res of
+                    Right addr -> label "success" $ encodeAddress addr === text
+                    Left e -> label (getErrorLabel e) $ property True
+                    & cover 0.2 (isLeft res) "failure"
+                    & cover 0.2 (isRight res) "success"
+
         it "roundtrips correctly on some addresses from online examples"
             $ do
                 let testCases =
@@ -48,3 +97,27 @@ spec = do
             let secretlyMainnetAddr = "addr_test1z92l7rnra7sxjn5qv5fzc4fwsrrm29mgkleqj9a0y46j5lyjz4gwd3njhyqwntdkcm8rrgapudajydteywgtuvl6etjshn59kk"
             decodeAddress secretlyMainnetAddr
                 `shouldBe` Left AddressNetworkMismatch
+
+-- | Generate 'Text' heavily biased towards values of incorrectly encoded
+-- addresses
+genArbitrarilyEncodedAddress :: Gen Text
+genArbitrarilyEncodedAddress = oneof
+    [ encodeAddrBech32 <$> genAddrHrp <*> arbitrary
+    , encodeAddrBase58 <$> arbitrary
+    ]
+  where
+    encodeAddrBech32 hrp addr = Bech32.encodeLenient hrp dataPart
+      where
+        bytes = B8.fromShort $ toShortByteString addr
+        dataPart = Bech32.dataPartFromBytes bytes
+
+    genAddrHrp = elements
+        [ [Bech32.humanReadablePart|addr|]
+        , [Bech32.humanReadablePart|addr_test|]
+        , [Bech32.humanReadablePart|notaddr|]
+        ]
+
+    encodeAddrBase58 = T.decodeUtf8
+        . encodeBase58 bitcoinAlphabet
+        . B8.fromShort
+        . toShortByteString

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Pure/API/AddressSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Pure/API/AddressSpec.hs
@@ -6,7 +6,8 @@ where
 import Prelude
 
 import Cardano.Wallet.Deposit.Pure.API.Address
-    ( decodeAddress
+    ( DecodingError (..)
+    , decodeAddress
     , encodeAddress
     )
 import Control.Monad
@@ -42,3 +43,8 @@ spec = do
                 forM_ testCases $ \addr ->
                     encodeAddress <$> decodeAddress addr
                         `shouldBe` Right addr
+
+        it "fails to decode addresses where the network tag doesn't match the bech32 hrp" $ do
+            let secretlyMainnetAddr = "addr_test1z92l7rnra7sxjn5qv5fzc4fwsrrm29mgkleqj9a0y46j5lyjz4gwd3njhyqwntdkcm8rrgapudajydteywgtuvl6etjshn59kk"
+            decodeAddress secretlyMainnetAddr
+                `shouldBe` Left AddressNetworkMismatch


### PR DESCRIPTION
- [x] Add basic unit test showing that the decoder rejects addresses where the internal network tag doesn't match the bech32 hrp encoding.
- [x] Drop unused `InvalidNetwork` error
- [x] Add `decodeAddress text = Right addr ==> encodeAddress addr == text` property 

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-3479
