### PR TITLE
[ADP-3476] Pinpoint mithril version to 2445.0

### DIFF
--- a/run/common/nix/run.sh
+++ b/run/common/nix/run.sh
@@ -78,7 +78,7 @@ cleanup() {
 mithril() {
     # shellcheck disable=SC2048
     # shellcheck disable=SC2086
-    nix shell "github:input-output-hk/mithril" -c $*
+    nix shell "github:input-output-hk/mithril?ref=2445.0" -c $*
 }
 
 # Trap the cleanup function on exit


### PR DESCRIPTION

Mithril version in the CI was not specified. ATM `master` is not compatibble with mainnet, 2445.0 is the last release.