### PR TITLE
[ADP-3476] Add conway param to CLI calls in ruby e2e spec

### DIFF
--- a/scripts/buildkite/main/macos-silicon-e2e.sh
+++ b/scripts/buildkite/main/macos-silicon-e2e.sh
@@ -11,7 +11,9 @@ export TESTS_LOGDIR
 CARDANO_NODE_CONFIGS="$(pwd)/configs/cardano"
 export CARDANO_NODE_CONFIGS
 
-VERSION=$(buildkite-agent meta-data get "release-version" --default "v2024-07-27")
+CURRENT_VERSION=v2024-09-29
+
+VERSION=$(buildkite-agent meta-data get "release-version" --default $CURRENT_VERSION)
 echo "VERSION=$VERSION"
 
 buildkite-agent artifact \

--- a/scripts/buildkite/release/release-candidate.sh
+++ b/scripts/buildkite/release/release-candidate.sh
@@ -62,6 +62,8 @@ git commit -am "Update cardano-wallet version in README.md"
 
 sed -i "s|$OLD_GIT_TAG|$NEW_GIT_TAG|g" scripts/buildkite/main/linux-e2e.sh
 git commit -am "Update cardano-wallet version in linux-e2e.sh"
+sed -i "s|$OLD_GIT_TAG|$NEW_GIT_TAG|g" scripts/buildkite/main/macos-silicon-e2e.sh
+git commit -am "Update cardano-wallet version in macos-silicon-e2e.sh"
 
 RELEASE_COMMIT=$(git rev-parse HEAD)
 

--- a/test/e2e/helpers/cardano_cli.rb
+++ b/test/e2e/helpers/cardano_cli.rb
@@ -93,7 +93,7 @@ class CardanoCli
                                 target_addr,
                                 collateral_ret_addr)
     txbody = File.join(@node_state, 'txbody')
-    cli('transaction', 'build-raw',
+    cli('conway', 'transaction', 'build-raw',
         '--tx-in', script_utxo,
         '--tx-out', "#{target_addr}+#{50_000_000 - fee}",
         '--tx-in-script-file', script_file,
@@ -106,15 +106,13 @@ class CardanoCli
         '--tx-out-return-collateral', "#{collateral_ret_addr}+#{collateral_utxo_amt - (fee * 1.5).to_i}",
         '--tx-total-collateral', (fee * 1.5).to_i,
         '--script-invalid',
-        '--babbage-era',
         '--out-file', txbody)
     txbody
   end
 
   def tx_build(*options)
     txbody = File.join(@node_state, 'txbody')
-    cli('transaction', 'build',
-        '--babbage-era',
+    cli('conway', 'transaction', 'build',
         '--testnet-magic', @protocol_magic,
         '--out-file', txbody,
         *options)
@@ -124,7 +122,7 @@ class CardanoCli
   def tx_sign(txbody, keys)
     txsigned = File.join(@node_state, 'txsigned')
     signing_keys = keys.filter { |k, _| k.to_s.end_with?('_skey') }.map { |_, v| "--signing-key-file #{v}" }
-    cli('transaction', 'sign',
+    cli('conway', 'transaction', 'sign',
         '--tx-body-file', txbody,
         '--testnet-magic', @protocol_magic,
         signing_keys.join(' '), # --signing-key-file key1 --signing-key-file key2 ...
@@ -135,17 +133,17 @@ class CardanoCli
   # @return [String] - tx id
   def tx_submit(txsigned)
     # submit
-    cli('transaction', 'submit',
+    cli('conway', 'transaction', 'submit',
         '--tx-file', txsigned,
         '--testnet-magic', @protocol_magic)
 
     # return tx id
-    cli('transaction', 'txid',
+    cli('conway', 'transaction', 'txid',
         '--tx-file', txsigned).strip
   end
 
   def policy_id(script_file)
-    cli('transaction', 'policyid',
+    cli('conway', 'transaction', 'policyid',
         '--script-file', script_file).strip
   end
 end


### PR DESCRIPTION
Hotfix for the wallet release on node 10.1.2

- Add conway parameters to cardano cli transaction calls in ruby tests

ADP-3476