### PR TITLE
[ADP-3476] Add docker image tag bump instructions

### DIFF
--- a/run/common/docker/run.sh
+++ b/run/common/docker/run.sh
@@ -24,7 +24,7 @@ fi
 source .env
 
 # Define and export wallet and node version tags
-RELEASE_WALLET_TAG=2024.7.27
+RELEASE_WALLET_TAG=2024.11.18
 
 WALLET_TAG=${WALLET_TAG:=$RELEASE_WALLET_TAG}
 export WALLET_TAG

--- a/scripts/buildkite/release/release-candidate.sh
+++ b/scripts/buildkite/release/release-candidate.sh
@@ -65,6 +65,9 @@ git commit -am "Update cardano-wallet version in linux-e2e.sh"
 sed -i "s|$OLD_GIT_TAG|$NEW_GIT_TAG|g" scripts/buildkite/main/macos-silicon-e2e.sh
 git commit -am "Update cardano-wallet version in macos-silicon-e2e.sh"
 
+sed -t "s|RELEASE_WALLET_TAG=.*|RELEASE_WALLET_TAG=$NEW_CABAL_VERSION|g" run/common/docker/run.sh
+git commit -am "Update cardano-wallet version in run/common/docker/run.sh"
+
 RELEASE_COMMIT=$(git rev-parse HEAD)
 
 git remote set-url origin "git@github.com:cardano-foundation/cardano-wallet.git"


### PR DESCRIPTION
Found out the docker script runner was not updated automatically during release

- Bump wallet tag version in the docker script runner to 2024.11.18 
- Amend the release pipeline to bump automatically the tag 

ADP-3476