### PR TITLE
[ADP 3491] Relax policy key guard

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Handlers/MintBurn.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Handlers/MintBurn.hs
@@ -44,9 +44,6 @@ import Control.Category
 import Control.Monad.IO.Class
     ( MonadIO (liftIO)
     )
-import Control.Monad.Trans.Except
-    ( runExceptT
-    )
 import Data.Either.Extra
     ( eitherToMaybe
     )
@@ -62,7 +59,7 @@ convertApiAssetMintBurn
     -> Handler (ApiAssetMintBurn, ApiAssetMintBurn)
 convertApiAssetMintBurn ctx (mint, burn) = do
     xpubM <- fmap (fmap fst . eitherToMaybe)
-        <$> liftIO . runExceptT $ readPolicyPublicKey ctx
+        <$> liftIO $ readPolicyPublicKey ctx
     let  convert tokenWithScripts =  ApiAssetMintBurn
             { tokens = toApiTokens tokenWithScripts
             , walletPolicyKeyHash =

--- a/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Shelley/Server.hs
@@ -2716,7 +2716,10 @@ constructTransaction api knownPools poolStatus apiWalletId body = do
                 (Map.singleton (Cosigner 0) policyXPub)
                 <$> mintBurnReferenceScriptTemplate
             Nothing ->
-                liftHandler $ throwE W.ErrReadPolicyPublicKeyAbsent
+                if isJust mintBurnReferenceScriptTemplate then
+                    liftHandler $ throwE W.ErrReadPolicyPublicKeyAbsent
+                else
+                    pure Nothing
 
         let transactionCtx3 = transactionCtx2
                 { txReferenceScript = referenceScriptM


### PR DESCRIPTION
<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->


`policyXPub` is needed in constructTransaction in two cases:
- tx contains minting/burning action
- tx deals with reference scripting and has reference script template nonempty

instead of using `policyXPub` we use `policyXPubM` throught the function and only deconstruct it when checking those two cases. `ErrReadPolicyPublicKeyAbsen` is used for the those two valid situations when policy xpub is missing.

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

Fix https://github.com/cardano-foundation/cardano-wallet/issues/4872
<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
