### PR TITLE
[ADP-3488] Implement `signTx`

### DIFF
--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -62,6 +62,7 @@ library
     , cardano-addresses
     , cardano-balance-tx
     , cardano-crypto
+    , cardano-crypto-class
     , cardano-ledger-api
     , cardano-ledger-core
     , cardano-strict-containers

--- a/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
@@ -82,6 +82,7 @@ import Cardano.Wallet.Deposit.Pure
     ( Credentials
     , Customer
     , ErrCreatePayment
+    , Passphrase
     , Word31
     , fromCredentialsAndGenesis
     )
@@ -450,5 +451,6 @@ getBIP32PathsForOwnedInputs =
 
 signTx
     :: Write.Tx
+    -> Passphrase
     -> WalletResourceM (Maybe Write.Tx)
-signTx = onWalletInstance . WalletIO.signTx
+signTx tx = onWalletInstance . WalletIO.signTx tx

--- a/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
@@ -90,7 +90,7 @@ import Cardano.Wallet.Deposit.Pure.API.TxHistory
     , ByTime
     )
 import Cardano.Wallet.Deposit.Pure.State.Creation
-    ( xpubFromCredentials
+    ( accountXPubFromCredentials
     )
 import Cardano.Wallet.Deposit.Read
     ( Address
@@ -320,7 +320,7 @@ createTheDepositWalletOnDisk _tr dir credentials users action = do
             . convertToBase Base16
             . blake2b160
             . xpubToBytes
-            . xpubFromCredentials
+            . accountXPubFromCredentials
 
 -- | Load an existing wallet from disk.
 loadWallet

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -344,8 +344,9 @@ getBIP32PathsForOwnedInputs
 getBIP32PathsForOwnedInputs a w =
     Wallet.getBIP32PathsForOwnedInputs a <$> readWalletState w
 
-signTx :: Write.Tx -> WalletInstance -> IO (Maybe Write.Tx)
-signTx a w = Wallet.signTx a <$> readWalletState w
+signTx
+    :: Write.Tx -> Wallet.Passphrase -> WalletInstance -> IO (Maybe Write.Tx)
+signTx a b w = Wallet.signTx a b <$> readWalletState w
 
 {-----------------------------------------------------------------------------
     Operations

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -50,6 +50,7 @@ module Cardano.Wallet.Deposit.Pure
     , BIP32Path (..)
     , DerivationType (..)
     , getBIP32PathsForOwnedInputs
+    , Passphrase
     , signTx
     , addTxSubmission
     , listTxsInSubmission
@@ -74,7 +75,8 @@ import Cardano.Wallet.Deposit.Pure.State.Rolling
     , rollForwardOne
     )
 import Cardano.Wallet.Deposit.Pure.State.Signing
-    ( getBIP32PathsForOwnedInputs
+    ( Passphrase
+    , getBIP32PathsForOwnedInputs
     , signTx
     )
 import Cardano.Wallet.Deposit.Pure.State.Submissions


### PR DESCRIPTION
This pull request implements the `signTx` function in the Deposit Wallet.

This pull request also changes the semantics of `credentialsFromMnemonics` to store the *account* `XPub` as well as the *root* `XPrv` (the latter only if available).

### Issue Number

ADP-3488