### PR TITLE
[ADP-3488] Add unit tests for mapping from `XPub` to `Address`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -157,8 +157,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/cardano-foundation/cardano-wallet-agda
-    tag: 4a95dadc7c7033d9cb83a3cd4a72cd34f04aaa48
-    --sha256: 1kk3v22pv8kr5ywjd3grb4s276cx1vcyz2djgg9dckn4nmywzdcs
+    tag: 7d223bf59e84f6bb0ec65761fbedfde9b7d453ae
+    --sha256: 1xq89f6x92pi5hrcsh71say36w8gy1g31782bcrgybb22k3pjm8f
     subdir:
       lib/customer-deposit-wallet-pure
       lib/cardano-wallet-read

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -117,6 +117,7 @@ library
     Cardano.Wallet.Deposit.Testing.DSL.Types
     Cardano.Wallet.Deposit.Time
     Cardano.Wallet.Deposit.Write
+    Cardano.Wallet.Deposit.Write.Keys
 
 test-suite scenario
   import:             language, opts-exe

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -217,6 +217,9 @@ test-suite unit
     , base58-bytestring
     , bytestring
     , cardano-crypto
+    , cardano-crypto-class
+    , cardano-ledger-api
+    , cardano-ledger-core
     , cardano-ledger-core:testlib
     , cardano-wallet-read
     , cardano-wallet-test-utils
@@ -225,6 +228,7 @@ test-suite unit
     , customer-deposit-wallet
     , customer-deposit-wallet:http
     , customer-deposit-wallet:rest
+    , customer-deposit-wallet-pure
     , directory
     , hspec
     , hspec-golden
@@ -247,6 +251,7 @@ test-suite unit
     Cardano.Wallet.Deposit.Pure.API.AddressSpec
     Cardano.Wallet.Deposit.PureSpec
     Cardano.Wallet.Deposit.RESTSpec
+    Cardano.Wallet.Deposit.Write.KeysSpec
     Paths_customer_deposit_wallet
     Spec
 

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Signing.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Signing.hs
@@ -11,12 +11,9 @@ import Cardano.Crypto.Wallet
     )
 import Cardano.Wallet.Address.BIP32
     ( BIP32Path (..)
-    , DerivationType (..)
     )
 import Cardano.Wallet.Address.BIP32_Ed25519
-    ( XPrv
-    , deriveXPrvHard
-    , deriveXPrvSoft
+    ( deriveXPrvBIP32Path
     )
 import Cardano.Wallet.Deposit.Pure.State.Submissions
     ( availableUTxO
@@ -71,12 +68,5 @@ signTx tx passphrase w = signTx' <$> rootXSignKey w
                 (T.encodeUtf8 passphrase)
                 BS.empty
                 encryptedXPrv
-        keys = deriveBIP32Path unencryptedXPrv
+        keys = deriveXPrvBIP32Path unencryptedXPrv
             <$> getBIP32PathsForOwnedInputs tx w
-
-deriveBIP32Path :: XPrv -> BIP32Path -> XPrv
-deriveBIP32Path xprv Root = xprv
-deriveBIP32Path xprv (Segment path Hardened ix) =
-    deriveXPrvHard (deriveBIP32Path xprv path) ix
-deriveBIP32Path xprv (Segment path Soft ix) =
-    deriveXPrvSoft (deriveBIP32Path xprv path) ix

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write/Keys.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write/Keys.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE DataKinds #-}
+
+-- | Module for converting key types from
+-- @Cardano.Ledger@  with key types from @Cardano.Crypto.Wallet@.
+--
+-- TODO: Match this up with the @Write@ hierarchy.
+module Cardano.Wallet.Deposit.Write.Keys
+    ( enterpriseAddressFromVKey
+    , vkeyFromXPub
+    , signedDSIGNfromXSignature
+    ) where
+
+import Prelude
+
+import Cardano.Crypto.Wallet
+    ( xpubPublicKey
+    )
+import Cardano.Ledger.Keys
+    ( SignedDSIGN
+    , VKey (..)
+    )
+import Cardano.Wallet.Address.BIP32_Ed25519
+    ( XPub
+    , XSignature
+    , rawSerialiseXSignature
+    )
+import Cardano.Wallet.Deposit.Read
+    ( Address
+    )
+import Data.Maybe
+    ( fromMaybe
+    )
+
+import qualified Cardano.Crypto.DSIGN as DSIGN
+import qualified Cardano.Ledger.Address as L
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Credential as L
+import qualified Cardano.Ledger.Hashes as L
+import qualified Cardano.Ledger.Keys as L
+
+{-----------------------------------------------------------------------------
+    Key conversion
+------------------------------------------------------------------------------}
+-- | Create an enterprise address from a ledger 'VKey'.
+enterpriseAddressFromVKey
+    :: L.Network
+    -> VKey 'L.Witness L.StandardCrypto
+    -> Address
+enterpriseAddressFromVKey network =
+    mkEnterpriseAddress
+    . L.coerceKeyRole
+    . L.hashKey
+  where
+    mkEnterpriseAddress h =
+        L.compactAddr
+        $ L.Addr network (L.KeyHashObj h) L.StakeRefNull
+
+-- | Convert 'XPub' to a ledger verification key.
+vkeyFromXPub :: XPub -> VKey 'L.Witness L.StandardCrypto
+vkeyFromXPub =
+    VKey
+    . fromMaybe impossible
+    . DSIGN.rawDeserialiseVerKeyDSIGN
+    . xpubPublicKey
+  where
+    impossible = error "impossible: Cannot convert XPub to VKey"
+
+-- | Convert 'XSignature' to a ledger signature.
+signedDSIGNfromXSignature
+    :: XSignature
+    -> SignedDSIGN L.StandardCrypto
+        (L.Hash L.StandardCrypto L.EraIndependentTxBody)
+signedDSIGNfromXSignature =
+    DSIGN.SignedDSIGN
+    . fromMaybe impossible
+    . DSIGN.rawDeserialiseSigDSIGN
+    . rawSerialiseXSignature
+  where
+    impossible = error "impossible: Cannot convert XSignature to SignedDSIGN"

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Write/KeysSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Write/KeysSpec.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- |
+-- Copyright: © 2024 Cardano Foundation
+-- License: Apache-2.0
+--
+-- Property tests for the deposit wallet.
+module Cardano.Wallet.Deposit.Write.KeysSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Crypto.Wallet
+    ( generate
+    )
+import Cardano.Wallet.Address.BIP32_Ed25519
+    ( XPrv
+    , XPub
+    , sign
+    , toXPub
+    )
+import Cardano.Wallet.Address.Encoding
+    ( EnterpriseAddr (..)
+    , NetworkTag (..)
+    , compactAddrFromEnterpriseAddr
+    , credentialFromXPub
+    )
+import Cardano.Wallet.Deposit.Write.Keys
+    ( enterpriseAddressFromVKey
+    , signedDSIGNfromXSignature
+    , vkeyFromXPub
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Blind (..)
+    , Property
+    , elements
+    , property
+    , vectorOf
+    , withMaxSuccess
+    , (===)
+    )
+
+import qualified Cardano.Crypto.Hash.Blake2b as Hash
+import qualified Cardano.Crypto.Hash.Class as Hash
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Hashes as L
+import qualified Cardano.Ledger.Keys as L
+import qualified Cardano.Wallet.Read as Read
+import qualified Data.ByteString as BS
+
+{-----------------------------------------------------------------------------
+    Spec
+------------------------------------------------------------------------------}
+spec :: Spec
+spec = do
+    describe "commutes with ledger" $ do
+        it "address" $ lessCryptography $ property $
+            \xpub networkTag ->
+                let network = toLedgerNetwork networkTag
+                in  enterpriseAddressFromVKey network (vkeyFromXPub xpub)
+                        === enterpriseAddressFromXPub networkTag xpub
+
+        it "verify" $ lessCryptography $ property $
+            \(Blind xprv) hash ->
+                let xpub = toXPub xprv
+                    xsig = sign xprv (Hash.hashToBytes hash)
+                in
+                    True ===
+                        L.verifySignedDSIGN
+                            (vkeyFromXPub xpub)
+                            hash
+                            (signedDSIGNfromXSignature xsig)
+
+lessCryptography :: Property -> Property
+lessCryptography = withMaxSuccess 20
+
+{-----------------------------------------------------------------------------
+    Helper functions
+------------------------------------------------------------------------------}
+enterpriseAddressFromXPub :: NetworkTag -> XPub -> Read.CompactAddr
+enterpriseAddressFromXPub networkTag =
+    compactAddrFromEnterpriseAddr
+    . EnterpriseAddrC networkTag
+    . credentialFromXPub
+
+toLedgerNetwork :: NetworkTag -> L.Network
+toLedgerNetwork MainnetTag = L.Mainnet
+toLedgerNetwork TestnetTag = L.Testnet
+
+instance Arbitrary NetworkTag where
+    arbitrary = elements [MainnetTag, TestnetTag]
+
+instance Arbitrary XPrv where
+    arbitrary =
+        generate
+            <$> (BS.pack <$> vectorOf 100 arbitrary)
+            <*> pure BS.empty
+
+instance Arbitrary XPub where
+    arbitrary = toXPub <$> arbitrary
+
+instance Arbitrary (Hash.Hash Hash.Blake2b_256 L.EraIndependentTxBody) where
+    arbitrary = do
+        bytes <- BS.pack <$> vectorOf (32) arbitrary
+        let Just hash = Hash.hashFromBytes bytes
+        pure hash


### PR DESCRIPTION
This pull request adds unit tests for

* The mapping `XPub` → `Address`
* Verification of `XSignature`

by comparing `Cardano.Wallet.Address.Encoding` against the implementation in `Cardano.Ledger`.

We adopt the fix of the mapping `XPub` → `Address` by adjusting to the latest version of the `cardano-wallet-agda` repository.

### Issue Number

ADP-3488