### PR TITLE
[ADP-3487] Make deposit `WalletState` more strict

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -157,8 +157,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/cardano-foundation/cardano-wallet-agda
-    tag: 7d223bf59e84f6bb0ec65761fbedfde9b7d453ae
-    --sha256: 1xq89f6x92pi5hrcsh71say36w8gy1g31782bcrgybb22k3pjm8f
+    tag: f3479b501a2efe50bcf1ee0d09bc2d1325a982e7
+    --sha256: 10d6k7mw1zw9vpzz8dhb52vfmj2rshsk225nvyl8nrc94fr627kz
     subdir:
       lib/customer-deposit-wallet-pure
       lib/cardano-wallet-read

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Type.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Type.hs
@@ -53,17 +53,17 @@ data WalletState = WalletState
     { walletTip :: Read.ChainPoint
     -- ^ The wallet includes information from all blocks until
     -- and including this one.
-    , addresses :: !Address.AddressState
+    , addresses :: Address.AddressState
     -- ^ Addresses and public keys known to this wallet.
-    , utxoHistory :: !UTxOHistory.UTxOHistory
+    , utxoHistory :: UTxOHistory.UTxOHistory
     -- ^ UTxO of this wallet, with support for rollbacks.
-    , txHistory :: !TxHistory
+    , txHistory :: TxHistory
     -- ^ (Summarized) transaction history of this wallet.
     , submissions :: Sbm.TxSubmissions
     -- ^ Queue of pending transactions.
     , rootXSignKey :: Maybe XPrv
     -- ^ Maybe a private key for signing transactions.
-    -- , info :: !WalletInfo
+    -- , info :: WalletInfo
     }
 
 type DeltaWalletState = Delta.Replace WalletState

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Type.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Type.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StrictData #-}
 module Cardano.Wallet.Deposit.Pure.State.Type
     ( -- * Types
       WalletState (..)

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Submissions.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/Submissions.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE StrictData #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Blockchain.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RecordWildCards #-}
 
 {-|
@@ -39,6 +40,9 @@ import Cardano.Wallet.Deposit.IO.Network.Type
     )
 import Cardano.Wallet.Deposit.Pure
     ( BIP32Path
+    )
+import Control.Concurrent
+    ( threadDelay
     )
 import Control.Tracer
     ( nullTracer
@@ -135,4 +139,6 @@ signTx _ _ = id
 submitTx :: ScenarioEnv -> Write.Tx -> IO ()
 submitTx env tx = do
     _ <- postTx (networkEnv env) tx
-    pure ()
+
+    -- Wait a short while to give the tx time to make it on-chain.
+    threadDelay 500_000

--- a/lib/wallet/src/Cardano/Wallet/Submissions/Submissions.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/Submissions.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTSyntax #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 

--- a/lib/wallet/src/Cardano/Wallet/Submissions/TxStatus.hs
+++ b/lib/wallet/src/Cardano/Wallet/Submissions/TxStatus.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTSyntax #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 


### PR DESCRIPTION
- Make deposit wallet state more strict with StrictData
- Bump cardano-wallet-agda for new increased strictness from
    - https://github.com/cardano-foundation/cardano-wallet-agda/pull/116
    - https://github.com/cardano-foundation/cardano-wallet-agda/pull/117

Depends on #4856 (or tested with it at least, but probably mergeable without it as well)

## Results

### This PR

~600-800 MB memory usage when syncing with preprod

The heap profile suggests we still have a memory leak, but this is not immediately observable in the os's activity monitor, so this is a lot better than before.

![cardano-wallet-strictness-pr](https://github.com/user-attachments/assets/df9ef5c6-c5f5-4d21-963a-9c97dbf8fc82)

### Previously ([anviking/ADP-3487/NodeToClient](https://github.com/cardano-foundation/cardano-wallet/tree/anviking/ADP-3487/NodeToClient) )

9 GB and growing acording to os's activity monitor:

![cardano-wallet](https://github.com/user-attachments/assets/0e77e794-a439-425f-a686-f77f83e0a741)

### Issue Number

ADP-3494
