### PR TITLE
[ADP-3479] Fix private key creation

### DIFF
--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -54,8 +54,8 @@ library
   build-depends:
     , async
     , base
-    , base58-bytestring
     , base16-bytestring
+    , base58-bytestring
     , bech32
     , bech32-th
     , bytestring
@@ -69,7 +69,7 @@ library
     , cardano-wallet
     , cardano-wallet-network-layer
     , cardano-wallet-primitive
-    , cardano-wallet-read           ==0.2024.8.27
+    , cardano-wallet-read
     , containers
     , contra-tracer
     , customer-deposit-wallet-pure
@@ -77,8 +77,8 @@ library
     , delta-types
     , digest
     , fingertree
-    , io-classes
     , int-cast
+    , io-classes
     , lens
     , MonadRandom
     , monoidal-containers
@@ -104,8 +104,8 @@ library
     Cardano.Wallet.Deposit.Pure.API.TxHistory
     Cardano.Wallet.Deposit.Pure.Balance
     Cardano.Wallet.Deposit.Pure.State.Creation
-    Cardano.Wallet.Deposit.Pure.State.Payment.Inspect
     Cardano.Wallet.Deposit.Pure.State.Payment
+    Cardano.Wallet.Deposit.Pure.State.Payment.Inspect
     Cardano.Wallet.Deposit.Pure.State.Rolling
     Cardano.Wallet.Deposit.Pure.State.Signing
     Cardano.Wallet.Deposit.Pure.State.Submissions
@@ -214,26 +214,33 @@ test-suite unit
     , aeson
     , aeson-pretty
     , base
+    , base58-bytestring
+    , base16-bytestring
     , bech32
     , bech32-th
-    , base58-bytestring
     , bytestring
+    , cardano-addresses
+    , address-derivation-discovery
     , cardano-crypto
     , cardano-crypto-class
     , cardano-ledger-api
     , cardano-ledger-core
     , cardano-ledger-core:testlib
+    , cardano-ledger-shelley
+    , cardano-slotting
     , cardano-wallet-read
     , cardano-wallet-test-utils
     , containers
     , contra-tracer
     , customer-deposit-wallet
+    , customer-deposit-wallet-pure
     , customer-deposit-wallet:http
     , customer-deposit-wallet:rest
-    , customer-deposit-wallet-pure
+    , data-default
     , directory
     , hspec
     , hspec-golden
+    , lens
     , openapi3
     , pretty-simple
     , QuickCheck
@@ -241,7 +248,6 @@ test-suite unit
     , temporary
     , text
     , time
-    , text
     , transformers
     , with-utf8
 

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -257,6 +257,7 @@ test-suite unit
     Cardano.Wallet.Deposit.HTTP.OpenAPISpec
     Cardano.Wallet.Deposit.Map.TimedSpec
     Cardano.Wallet.Deposit.Pure.API.AddressSpec
+    Cardano.Wallet.Deposit.Pure.API.TransactionSpec
     Cardano.Wallet.Deposit.PureSpec
     Cardano.Wallet.Deposit.RESTSpec
     Cardano.Wallet.Deposit.Write.KeysSpec

--- a/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
@@ -50,11 +50,12 @@ module Cardano.Wallet.Deposit.REST
     , walletPublicIdentity
     , deleteWallet
     , deleteTheDepositWalletOnDisk
-    -- * Internals
+
+      -- * Internals
     , onWalletInstance
     , networkTag
+    , resolveCurrentEraTx
     , canSign
-
     ) where
 
 import Prelude
@@ -85,6 +86,7 @@ import Cardano.Wallet.Deposit.IO.Resource
 import Cardano.Wallet.Deposit.Pure
     ( CanSign
     , Credentials
+    , CurrentEraResolvedTx
     , Customer
     , ErrCreatePayment
     , Passphrase
@@ -290,7 +292,7 @@ instance Serialise XPrv where
     encode = encode . unXPrv
     decode = do
         b :: ByteString <- decode
-        case xprv  b of
+        case xprv b of
             Right x -> pure x
             Left e -> fail e
 
@@ -468,3 +470,6 @@ signTx
     -> Passphrase
     -> WalletResourceM (Maybe Write.Tx)
 signTx tx = onWalletInstance . WalletIO.signTx tx
+resolveCurrentEraTx
+    :: Write.Tx -> WalletResourceM CurrentEraResolvedTx
+resolveCurrentEraTx = onWalletInstance . WalletIO.resolveCurrentEraTx

--- a/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
@@ -57,6 +57,7 @@ module Cardano.Wallet.Deposit.REST
     , networkTag
     , resolveCurrentEraTx
     , canSign
+    , submitTx
     ) where
 
 import Prelude
@@ -159,6 +160,7 @@ import System.FilePath
     )
 
 import qualified Cardano.Wallet.Deposit.IO as WalletIO
+import qualified Cardano.Wallet.Deposit.IO.Network.Type as Network
 import qualified Cardano.Wallet.Deposit.IO.Resource as Resource
 import qualified Cardano.Wallet.Deposit.Read as Read
 import qualified Cardano.Wallet.Deposit.Write as Write
@@ -480,3 +482,6 @@ inspectTx = onWalletInstance . WalletIO.inspectTx
 
 resolveCurrentEraTx :: Write.Tx -> WalletResourceM CurrentEraResolvedTx
 resolveCurrentEraTx = onWalletInstance . WalletIO.resolveCurrentEraTx
+
+submitTx :: Write.Tx -> WalletResourceM (Either Network.ErrPostTx ())
+submitTx = onWalletInstance . WalletIO.submitTx

--- a/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
@@ -455,7 +455,7 @@ networkTag = onWalletInstance WalletIO.networkTag
 
 createPayment
     :: [(Address, Read.Value)]
-    -> WalletResourceM (Either ErrCreatePayment Write.Tx)
+    -> WalletResourceM (Either ErrCreatePayment CurrentEraResolvedTx)
 createPayment = onWalletInstance . WalletIO.createPayment
 
 getBIP32PathsForOwnedInputs

--- a/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
@@ -53,6 +53,7 @@ module Cardano.Wallet.Deposit.REST
     -- * Internals
     , onWalletInstance
     , networkTag
+    , canSign
 
     ) where
 
@@ -82,7 +83,8 @@ import Cardano.Wallet.Deposit.IO.Resource
     , ErrResourceMissing (..)
     )
 import Cardano.Wallet.Deposit.Pure
-    ( Credentials
+    ( CanSign
+    , Credentials
     , Customer
     , ErrCreatePayment
     , Passphrase
@@ -457,6 +459,9 @@ getBIP32PathsForOwnedInputs
     -> WalletResourceM [BIP32Path]
 getBIP32PathsForOwnedInputs =
     onWalletInstance . WalletIO.getBIP32PathsForOwnedInputs
+
+canSign :: WalletResourceM CanSign
+canSign = onWalletInstance WalletIO.canSign
 
 signTx
     :: Write.Tx

--- a/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
@@ -52,6 +52,7 @@ module Cardano.Wallet.Deposit.REST
     , deleteTheDepositWalletOnDisk
 
       -- * Internals
+    , inspectTx
     , onWalletInstance
     , networkTag
     , resolveCurrentEraTx
@@ -89,6 +90,7 @@ import Cardano.Wallet.Deposit.Pure
     , CurrentEraResolvedTx
     , Customer
     , ErrCreatePayment
+    , InspectTx
     , Passphrase
     , Word31
     , fromCredentialsAndGenesis
@@ -470,6 +472,11 @@ signTx
     -> Passphrase
     -> WalletResourceM (Maybe Write.Tx)
 signTx tx = onWalletInstance . WalletIO.signTx tx
-resolveCurrentEraTx
-    :: Write.Tx -> WalletResourceM CurrentEraResolvedTx
+
+inspectTx
+    :: CurrentEraResolvedTx
+    -> WalletResourceM InspectTx
+inspectTx = onWalletInstance . WalletIO.inspectTx
+
+resolveCurrentEraTx :: Write.Tx -> WalletResourceM CurrentEraResolvedTx
 resolveCurrentEraTx = onWalletInstance . WalletIO.resolveCurrentEraTx

--- a/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
@@ -52,6 +52,7 @@ module Cardano.Wallet.Deposit.REST
     , deleteTheDepositWalletOnDisk
     -- * Internals
     , onWalletInstance
+    , networkTag
 
     ) where
 
@@ -437,6 +438,9 @@ getTxHistoryByCustomer = onWalletInstance WalletIO.getTxHistoryByCustomer
 getTxHistoryByTime
     :: WalletResourceM ByTime
 getTxHistoryByTime = onWalletInstance WalletIO.getTxHistoryByTime
+
+networkTag :: WalletResourceM Read.NetworkTag
+networkTag = onWalletInstance WalletIO.networkTag
 
 {-----------------------------------------------------------------------------
     Operations

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -48,6 +48,7 @@ module Cardano.Wallet.Deposit.IO
       -- * Internals
     , onWalletState
     , networkTag
+    , canSign
     ) where
 
 import Prelude
@@ -70,6 +71,9 @@ import Cardano.Wallet.Deposit.Pure.API.TxHistory
     ( ByCustomer
     , ByTime
     , LookupTimeFromSlot
+    )
+import Cardano.Wallet.Deposit.Pure.State.Creation
+    ( CanSign
     )
 import Cardano.Wallet.Deposit.Read
     ( Address
@@ -341,6 +345,10 @@ createPayment a w = do
     Operations
     Signing transactions
 ------------------------------------------------------------------------------}
+
+canSign :: WalletInstance -> IO CanSign
+canSign w = do
+    Wallet.canSign <$> readWalletState w
 
 getBIP32PathsForOwnedInputs
     :: Write.Tx -> WalletInstance -> IO [BIP32Path]

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -45,8 +45,9 @@ module Cardano.Wallet.Deposit.IO
     , submitTx
     , listTxsInSubmission
 
-     -- * Internals
-     , onWalletState
+      -- * Internals
+    , onWalletState
+    , networkTag
     ) where
 
 import Prelude
@@ -314,6 +315,10 @@ slotResolver w = do
         $ networkEnv
         $ bootEnv
         $ env w
+
+networkTag :: WalletInstance -> IO Read.NetworkTag
+networkTag w = do
+    Wallet.networkTag <$> readWalletState w
 
 {-----------------------------------------------------------------------------
     Operations

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -48,6 +48,7 @@ module Cardano.Wallet.Deposit.IO
       -- * Internals
     , onWalletState
     , networkTag
+    , resolveCurrentEraTx
     , canSign
     ) where
 
@@ -61,6 +62,7 @@ import Cardano.Wallet.Deposit.IO.Network.Type
     )
 import Cardano.Wallet.Deposit.Pure
     ( Credentials
+    , CurrentEraResolvedTx
     , Customer
     , ValueTransfer
     , WalletPublicIdentity (..)
@@ -340,6 +342,13 @@ createPayment a w = do
     Wallet.createPayment pparams timeTranslation a <$> readWalletState w
   where
     network = networkEnv $ bootEnv $ env w
+
+resolveCurrentEraTx
+    :: Write.Tx
+    -> WalletInstance
+    -> IO CurrentEraResolvedTx
+resolveCurrentEraTx tx w =
+    Wallet.resolveCurrentEraTx tx <$> readWalletState w
 
 {-----------------------------------------------------------------------------
     Operations

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -49,6 +49,7 @@ module Cardano.Wallet.Deposit.IO
       -- * Internals
     , onWalletState
     , networkTag
+    , readWalletState
     , resolveCurrentEraTx
     , canSign
     ) where
@@ -335,7 +336,7 @@ networkTag w = do
 createPayment
     :: [(Address, Read.Value)]
     -> WalletInstance
-    -> IO (Either Wallet.ErrCreatePayment Write.Tx)
+    -> IO (Either Wallet.ErrCreatePayment CurrentEraResolvedTx)
 createPayment a w = do
     timeTranslation <- Network.getTimeTranslation network
     pparams <-

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -36,6 +36,7 @@ module Cardano.Wallet.Deposit.IO
 
       -- *** Create transactions
     , createPayment
+    , inspectTx
 
       -- *** Sign transactions
     , getBIP32PathsForOwnedInputs
@@ -342,6 +343,12 @@ createPayment a w = do
     Wallet.createPayment pparams timeTranslation a <$> readWalletState w
   where
     network = networkEnv $ bootEnv $ env w
+
+inspectTx
+    :: CurrentEraResolvedTx
+    -> WalletInstance
+    -> IO Wallet.InspectTx
+inspectTx tx w = flip Wallet.inspectTx tx <$> readWalletState w
 
 resolveCurrentEraTx
     :: Write.Tx

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -52,6 +52,7 @@ module Cardano.Wallet.Deposit.Pure
     , CurrentEraResolvedTx
     , BIP32Path (..)
     , DerivationType (..)
+    , ResolvedTx (..)
     , canSign
     , CanSign (..)
     , getBIP32PathsForOwnedInputs
@@ -122,6 +123,9 @@ import Cardano.Wallet.Deposit.Pure.State.Type
     , networkTag
     , trackedCustomers
     , walletXPub
+    )
+import Cardano.Wallet.Deposit.Pure.UTxO.Tx
+    ( ResolvedTx (..)
     )
 import Cardano.Wallet.Deposit.Pure.UTxO.ValueTransfer
     ( ValueTransfer (..)

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -50,6 +50,8 @@ module Cardano.Wallet.Deposit.Pure
     , createPayment
     , BIP32Path (..)
     , DerivationType (..)
+    , canSign
+    , CanSign (..)
     , getBIP32PathsForOwnedInputs
     , Passphrase
     , signTx
@@ -62,8 +64,10 @@ import Cardano.Wallet.Address.BIP32
     , DerivationType (..)
     )
 import Cardano.Wallet.Deposit.Pure.State.Creation
-    ( Credentials (..)
+    ( CanSign (..)
+    , Credentials (..)
     , WalletPublicIdentity (..)
+    , canSign
     , fromCredentialsAndGenesis
     )
 import Cardano.Wallet.Deposit.Pure.State.Payment

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -43,6 +43,7 @@ module Cardano.Wallet.Deposit.Pure
     , getEraSlotOfBlock
     , getCustomerDeposits
     , getAllDeposits
+    , networkTag
 
       -- ** Writing to the blockchain
     , ErrCreatePayment (..)
@@ -104,6 +105,7 @@ import Cardano.Wallet.Deposit.Pure.State.Type
     , knownCustomer
     , knownCustomerAddress
     , listCustomers
+    , networkTag
     , trackedCustomers
     , walletXPub
     )

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -48,6 +48,8 @@ module Cardano.Wallet.Deposit.Pure
       -- ** Writing to the blockchain
     , ErrCreatePayment (..)
     , createPayment
+    , resolveCurrentEraTx
+    , CurrentEraResolvedTx
     , BIP32Path (..)
     , DerivationType (..)
     , canSign
@@ -71,8 +73,10 @@ import Cardano.Wallet.Deposit.Pure.State.Creation
     , fromCredentialsAndGenesis
     )
 import Cardano.Wallet.Deposit.Pure.State.Payment
-    ( ErrCreatePayment (..)
+    ( CurrentEraResolvedTx
+    , ErrCreatePayment (..)
     , createPayment
+    , resolveCurrentEraTx
     )
 import Cardano.Wallet.Deposit.Pure.State.Rolling
     ( rollBackward

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure.hs
@@ -59,6 +59,8 @@ module Cardano.Wallet.Deposit.Pure
     , signTx
     , addTxSubmission
     , listTxsInSubmission
+    , inspectTx
+    , InspectTx (..)
     ) where
 
 import Cardano.Wallet.Address.BIP32
@@ -77,6 +79,10 @@ import Cardano.Wallet.Deposit.Pure.State.Payment
     , ErrCreatePayment (..)
     , createPayment
     , resolveCurrentEraTx
+    )
+import Cardano.Wallet.Deposit.Pure.State.Payment.Inspect
+    ( InspectTx (..)
+    , inspectTx
     )
 import Cardano.Wallet.Deposit.Pure.State.Rolling
     ( rollBackward

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Payment.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Payment.hs
@@ -75,12 +75,13 @@ createPayment
     -> Write.TimeTranslation
     -> [(Address, Write.Value)]
     -> WalletState
-    -> Either ErrCreatePayment Write.Tx
+    -> Either ErrCreatePayment CurrentEraResolvedTx
 createPayment (Read.EraValue (Read.PParams pparams :: Read.PParams era)) a b w =
     case Read.theEra :: Read.Era era of
         Read.Conway ->
             first ErrCreatePaymentBalanceTx
-                $ createPaymentConway pparams a b w
+                $ flip resolveCurrentEraTx w
+                    <$> createPaymentConway pparams a b w
         era' -> Left $ ErrCreatePaymentNotRecentEra (Read.EraValue era')
 
 -- | In the Conway era: Create a payment to a list of destinations.

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Payment.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Payment.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Wallet.Deposit.Pure.State.Payment
@@ -39,6 +40,9 @@ import Data.Bifunctor
 import Data.Digest.CRC32
     ( crc32
     )
+import Data.Text.Class.Extended
+    ( ToText (..)
+    )
 
 import qualified Cardano.Wallet.Deposit.Pure.Address as Address
 import qualified Cardano.Wallet.Deposit.Read as Read
@@ -46,11 +50,19 @@ import qualified Cardano.Wallet.Deposit.Write as Write
 import qualified Cardano.Wallet.Read.Hash as Hash
 import qualified Control.Monad.Random.Strict as Random
 import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
 
 data ErrCreatePayment
     = ErrCreatePaymentNotRecentEra (Read.EraValue Read.Era)
     | ErrCreatePaymentBalanceTx (Write.ErrBalanceTx Write.Conway)
     deriving (Eq, Show)
+
+instance ToText ErrCreatePayment where
+    toText = \case
+        ErrCreatePaymentNotRecentEra era ->
+            "Cannot create a payment in the era: " <> T.pack (show era)
+        ErrCreatePaymentBalanceTx err ->
+            "Cannot create a payment: " <> T.pack (show err)
 
 type CurrentEraResolvedTx = ResolvedTx Read.Conway
 

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Payment.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Payment.hs
@@ -6,6 +6,7 @@ module Cardano.Wallet.Deposit.Pure.State.Payment
     ( ErrCreatePayment (..)
     , createPayment
     , CurrentEraResolvedTx
+    , resolveCurrentEraTx
     ) where
 
 import Prelude hiding
@@ -20,12 +21,14 @@ import Cardano.Wallet.Deposit.Pure.State.Type
     )
 import Cardano.Wallet.Deposit.Pure.UTxO.Tx
     ( ResolvedTx (..)
+    , resolveInputs
     )
 import Cardano.Wallet.Deposit.Read
     ( Address
     )
 import Cardano.Wallet.Deposit.Write
-    ( TxBody (..)
+    ( Tx
+    , TxBody (..)
     )
 import Control.Monad.Trans.Except
     ( runExceptT
@@ -50,6 +53,9 @@ data ErrCreatePayment
     deriving (Eq, Show)
 
 type CurrentEraResolvedTx = ResolvedTx Read.Conway
+
+resolveCurrentEraTx :: Tx -> WalletState -> CurrentEraResolvedTx
+resolveCurrentEraTx tx w = resolveInputs (availableUTxO w) tx
 
 -- | Create a payment to a list of destinations.
 createPayment

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Signing.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Signing.hs
@@ -61,7 +61,7 @@ signTx :: Write.Tx -> Passphrase -> WalletState -> Maybe Write.Tx
 signTx tx passphrase w = signTx' <$> rootXSignKey w
   where
     signTx' encryptedXPrv =
-        foldr Write.addAddressWitness tx keys
+        foldr Write.addSignature tx keys
       where
         unencryptedXPrv =
             xPrvChangePass

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Type.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Type.hs
@@ -18,6 +18,7 @@ module Cardano.Wallet.Deposit.Pure.State.Type
     , walletXPub
     , getUTxO
     , getWalletTip
+    , networkTag
     ) where
 
 import Prelude hiding
@@ -30,6 +31,9 @@ import Cardano.Crypto.Wallet
     )
 import Cardano.Wallet.Deposit.Pure.API.TxHistory
     ( TxHistory (..)
+    )
+import Cardano.Wallet.Deposit.Read
+    ( NetworkTag
     )
 import Cardano.Wallet.Deposit.Write
     ( Address
@@ -118,3 +122,6 @@ getUTxO = UTxOHistory.getUTxO . utxoHistory
 
 getWalletTip :: WalletState -> Read.ChainPoint
 getWalletTip = walletTip
+
+networkTag :: WalletState -> NetworkTag
+networkTag = Address.getNetworkTag . addresses

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
@@ -34,7 +34,7 @@ module Cardano.Wallet.Deposit.Write
     , Write.balanceTx
 
       -- * Signing
-    , addAddressWitness
+    , addSignature
 
       -- ** Time interpreter
     , Write.TimeTranslation
@@ -42,6 +42,7 @@ module Cardano.Wallet.Deposit.Write
       -- * Helper functions
     , mkAda
     , mkTxOut
+    , txOutsL
     , toConwayTx
     , addTxIn
     , addTxOut
@@ -120,9 +121,8 @@ type Block = Read.Block Read.Conway
     Signing
 ------------------------------------------------------------------------------}
 -- | Add a signature to the transaction using the private key
--- corresponding to a payment address.
-addAddressWitness :: XPrv -> Tx -> Tx
-addAddressWitness xprv tx@(Read.Tx ledgerTx) =
+addSignature :: XPrv -> Tx -> Tx
+addSignature xprv tx@(Read.Tx ledgerTx) =
     Read.Tx
         (ledgerTx & (L.witsTxL . L.addrTxWitsL) %~ Set.insert witnessVKey)
   where

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
@@ -46,6 +46,8 @@ module Cardano.Wallet.Deposit.Write
     , addTxIn
     , addTxOut
     , emptyTxBody
+    , UTxO.resolvedTx
+    , UTxO.resolvedInputs
     ) where
 
 import Prelude
@@ -99,6 +101,7 @@ import Data.Set
 import qualified Cardano.Ledger.Api as L
 import qualified Cardano.Ledger.Api.Tx.In as L
 import qualified Cardano.Ledger.Slot as L
+import qualified Cardano.Wallet.Deposit.Pure.UTxO.Tx as UTxO
 import qualified Cardano.Wallet.Read as Read
 import qualified Cardano.Wallet.Read.Hash as Hash
 import qualified Cardano.Write.Eras as Write

--- a/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Exchanges.lhs.md
+++ b/lib/customer-deposit-wallet/test/scenario/Test/Scenario/Wallet/Deposit/Exchanges.lhs.md
@@ -35,6 +35,7 @@ import Cardano.Wallet.Deposit.Pure
     ( Customer
     , ValueTransfer (..)
     , Credentials (..)
+    , ResolvedTx (..)
     )
 import Cardano.Wallet.Deposit.Read
     ( Address
@@ -206,7 +207,7 @@ scenarioCreatePayment xprv env destination w = do
     assert $ value1 == (coin <> coin)
 
     -- createPayment
-    Right txUnsigned <- Wallet.createPayment [(destination, coin)] w
+    Right (ResolvedTx txUnsigned _) <- Wallet.createPayment [(destination, coin)] w
     paths <- Wallet.getBIP32PathsForOwnedInputs txUnsigned w
     let tx = signTx xprv paths txUnsigned
     submitTx env tx

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Pure/API/TransactionSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Pure/API/TransactionSpec.hs
@@ -1,0 +1,241 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+module Cardano.Wallet.Deposit.Pure.API.TransactionSpec
+    ( spec
+    )
+where
+
+import Prelude
+
+import Cardano.Ledger.Api
+    ( ppMaxTxSizeL
+    , ppMaxValSizeL
+    )
+import Cardano.Ledger.BaseTypes
+    ( EpochSize (..)
+    )
+import qualified Cardano.Ledger.BaseTypes as Ledger
+import qualified Cardano.Ledger.Core as Ledger
+import qualified Cardano.Ledger.Shelley.API.Mempool as Ledger
+import qualified Cardano.Ledger.Shelley.LedgerState as Ledger
+import qualified Cardano.Ledger.Shelley.Rules as Ledger
+import qualified Cardano.Slotting.EpochInfo as Slotting
+import Cardano.Slotting.Time
+    ( SlotLength
+    , SystemStart (..)
+    , mkSlotLength
+    )
+import Cardano.Wallet.Deposit.Pure.Address
+    ( createAddress
+    )
+import qualified Cardano.Wallet.Deposit.Pure.Address as Address
+import Cardano.Wallet.Deposit.Pure.API.Address
+    ( encodeAddress
+    )
+import Cardano.Wallet.Deposit.Pure.State.Creation
+    ( accountXPubFromCredentials
+    , createMnemonicFromWords
+    , credentialsFromMnemonics
+    )
+import Cardano.Wallet.Deposit.PureSpec
+    ( testOnWallet
+    )
+import Cardano.Wallet.Deposit.Read
+    ( Address
+    , Conway
+    , NetworkTag (..)
+    , UTxO
+    , mkEnterpriseAddress
+    )
+import Cardano.Wallet.Deposit.Testing.DSL
+    ( assert
+    , balance
+    , block
+    , deposit
+    , existsTx
+    , rollForward
+    , sign
+    , spend
+    , utxo
+    , wallet
+    )
+import Cardano.Wallet.Deposit.Write
+    ( Tx
+    )
+import qualified Cardano.Wallet.Deposit.Write as Write
+import Cardano.Wallet.Read
+    ( NetworkId (..)
+    )
+import qualified Cardano.Wallet.Read as Read
+import Control.Lens
+    ( (&)
+    , (.~)
+    )
+import qualified Data.ByteString.Short as SBS
+import Data.Default
+    ( Default (..)
+    )
+import Data.Maybe
+    ( fromMaybe
+    )
+import Data.Text
+    ( Text
+    )
+import qualified Data.Text.Lazy as TL
+import Data.Time.Clock.POSIX
+    ( posixSecondsToUTCTime
+    )
+import Test.Cardano.Ledger.Core.Arbitrary
+    ()
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldBe
+    )
+import Text.Pretty.Simple
+    ( pShow
+    )
+
+address :: Address
+address = mockAddress
+
+mockAddress :: Address
+mockAddress =
+    mkEnterpriseAddress
+        MainnetTag
+        (SBS.toShort "12345678901234567890123456789012")
+
+defaultPParams :: Ledger.PParams Conway
+defaultPParams =
+    def
+        & ppMaxTxSizeL .~ 16_384
+        & ppMaxValSizeL .~ 1_000_000_000
+
+-- | Create a new ledger env from given protocol parameters.
+newLedgerEnv :: Ledger.PParams Conway -> Ledger.LedgerEnv Conway
+newLedgerEnv protocolParams =
+    Ledger.LedgerEnv
+        { Ledger.ledgerSlotNo = 0
+        , -- NOTE: This can probably stay at 0 forever. This is used internally by the
+          -- node's mempool to keep track of transaction seen from peers. Transactions
+          -- in Hydra do not go through the node's mempool and follow a different
+          -- consensus path so this will remain unused.
+          Ledger.ledgerIx = minBound
+        , -- NOTE: This keeps track of the ledger's treasury and reserve which are
+          -- both unused in Hydra. There might be room for interesting features in the
+          -- future with these two but for now, we'll consider them empty.
+          Ledger.ledgerAccount = Ledger.AccountState mempty mempty
+        , Ledger.ledgerPp = protocolParams
+        , Ledger.ledgerMempool = False
+        }
+
+defaultLedgerEnv :: Ledger.LedgerEnv Conway
+defaultLedgerEnv = newLedgerEnv defaultPParams
+
+defaultGlobals :: Ledger.Globals
+defaultGlobals =
+    Ledger.Globals
+        { Ledger.epochInfo = Slotting.fixedEpochInfo epochSize slotLength
+        , Ledger.slotsPerKESPeriod = 20
+        , Ledger.stabilityWindow = 33
+        , Ledger.randomnessStabilisationWindow = 33
+        , Ledger.securityParameter = 10
+        , Ledger.maxKESEvo = 10
+        , Ledger.quorum = 5
+        , Ledger.maxLovelaceSupply = 45 * 1000 * 1000 * 1000 * 1000 * 1000
+        , Ledger.activeSlotCoeff =
+            Ledger.mkActiveSlotCoeff . unsafeBoundRational $ 0.9
+        , Ledger.networkId = Ledger.Mainnet
+        , Ledger.systemStart = SystemStart $ posixSecondsToUTCTime 0
+        }
+  where
+    unsafeBoundRational r =
+        fromMaybe (error $ "Could not convert from Rational: " <> show r)
+            $ Ledger.boundRational r
+
+epochSize :: EpochSize
+epochSize = EpochSize 100
+
+slotLength :: SlotLength
+slotLength = mkSlotLength 1
+
+applyTx
+    :: UTxO
+    -> Write.Tx
+    -> Either
+        (Ledger.ApplyTxError Conway)
+        ()
+applyTx utxos (Read.Tx tx) =
+    case Ledger.applyTx defaultGlobals defaultLedgerEnv memPoolState tx of
+        Left err -> Left err
+        Right _ -> Right ()
+  where
+    memPoolState =
+        Ledger.LedgerState
+            { Ledger.lsUTxOState =
+                def{Ledger.utxosUtxo = Write.toConwayUTxO utxos}
+            , Ledger.lsCertState = def
+            }
+newtype Ledger = Ledger
+    { validate :: Tx -> Either (Ledger.ApplyTxError Conway) ()
+    }
+
+ledgerFrom :: UTxO -> Ledger
+ledgerFrom = Ledger . applyTx
+
+accepts :: Ledger -> Tx -> IO ()
+accepts l t = case validate l t of
+    Left err ->
+        error
+            $ TL.unpack
+            $ "Transaction was not accepted by the ledger: \n"
+                <> pShow defaultPParams
+                <> "\n"
+                <> pShow t
+                <> "\n"
+                <> pShow err
+    Right _ -> pure ()
+
+mnemonics :: Text
+mnemonics = "vital minimum victory start lunch find city peanut shiver soft hedgehog artwork mushroom loud found"
+
+spec :: Spec
+spec = do
+    describe "balanced transaction" $ do
+        it "has correct witness for one tx-in"
+            $ testOnWallet
+            $ do
+                wallet 17 mnemonics "passphrase"
+                tx1 <- existsTx
+                u1 <- deposit tx1 1 100
+                b1 <- block [tx1]
+                rollForward [b1]
+                spending <- existsTx
+                spend spending address 10
+                balanced <- balance spending
+                utxos <- utxo u1
+                signedTx <- sign balanced "passphrase"
+                assert $ ledgerFrom utxos `accepts` signedTx
+
+    -- cat root1.prv
+    --  | cardano-address key child 1857H/1815H/0H/0/0 \
+    --  | cardano-address key public --with-chain-code \
+    --  | cardano-address address payment --network-tag mainnet
+    describe "generated address match golden cases" $ do
+        it "with empty passphrase in mainnet" $ do
+            let
+                Right seed = createMnemonicFromWords mnemonics
+                address0 = "addr1v8th5554xvd2us9hwh72p3yt9rg7uw9v7tk49t3yw3wrcgc3drxft"
+                creds = credentialsFromMnemonics seed mempty
+                xpub = accountXPubFromCredentials creds
+                addr =
+                    encodeAddress
+                        $ fst
+                        $ createAddress 0
+                        $ Address.fromXPubAndCount Mainnet xpub 1
+
+            addr `shouldBe` address0

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/PureSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/PureSpec.hs
@@ -9,10 +9,14 @@
 -- Property tests for the deposit wallet.
 module Cardano.Wallet.Deposit.PureSpec
     ( spec
+    , testOnWallet
     ) where
 
 import Prelude
 
+import Cardano.Mnemonic
+    ( SomeMnemonic
+    )
 import Cardano.Wallet.Deposit.Pure
     ( Credentials
     , Customer
@@ -21,7 +25,8 @@ import Cardano.Wallet.Deposit.Pure.API.TxHistory
     ( LookupTimeFromSlot
     )
 import Cardano.Wallet.Deposit.Pure.State.Creation
-    ( credentialsFromMnemonics
+    ( createMnemonicFromWords
+    , credentialsFromMnemonics
     )
 import Cardano.Wallet.Deposit.Testing.DSL
     ( InterpreterState (..)
@@ -300,9 +305,16 @@ emptyWalletWith17Addresses :: Wallet.WalletState
 emptyWalletWith17Addresses =
     Wallet.fromCredentialsAndGenesis testCredentials 17 testGenesis
 
+seed :: SomeMnemonic
+seed = case createMnemonicFromWords
+    "vital minimum victory start lunch find city peanut shiver soft hedgehog artwork mushroom loud found"
+    of
+    Right seed' -> seed'
+    Left e -> error $ show e
+
 testCredentials :: Credentials
 testCredentials =
-    credentialsFromMnemonics "random seed for a testing xpub lala" mempty
+    credentialsFromMnemonics seed mempty
 
 {-----------------------------------------------------------------------------
     Test blockchain

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/PureSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/PureSpec.hs
@@ -19,7 +19,6 @@ import Cardano.Mnemonic
     )
 import Cardano.Wallet.Deposit.Pure
     ( Credentials
-    , Customer
     )
 import Cardano.Wallet.Deposit.Pure.API.TxHistory
     ( LookupTimeFromSlot
@@ -92,10 +91,6 @@ timeFromSlot = unsafeUTCTimeOfSlot
 unsafeTimeForSlot :: Read.Slot -> Read.WithOrigin UTCTime
 unsafeTimeForSlot = fromJust . timeFromSlot
 
-unsafeCustomerAddress
-    :: Wallet.WalletState -> Customer -> Write.Address
-unsafeCustomerAddress w = fromJust . flip Wallet.customerAddress w
-
 testOnWallet
     :: ScenarioP
         (IO ())
@@ -106,7 +101,6 @@ testOnWallet =
     interpret
         emptyWalletWith17Addresses
         id
-        (unsafeCustomerAddress emptyWalletWith17Addresses)
         unsafeTimeForSlot
 
 spec :: Spec

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Write/KeysSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Write/KeysSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -23,7 +24,7 @@ import Cardano.Wallet.Address.BIP32_Ed25519
     , sign
     , toXPub
     )
-import Cardano.Wallet.Address.Encoding
+import "customer-deposit-wallet-pure" Cardano.Wallet.Address.Encoding
     ( EnterpriseAddr (..)
     , NetworkTag (..)
     , compactAddrFromEnterpriseAddr
@@ -101,10 +102,7 @@ instance Arbitrary NetworkTag where
     arbitrary = elements [MainnetTag, TestnetTag]
 
 instance Arbitrary XPrv where
-    arbitrary =
-        generate
-            <$> (BS.pack <$> vectorOf 100 arbitrary)
-            <*> pure BS.empty
+    arbitrary = generate . BS.pack <$> vectorOf 100 arbitrary <*> pure BS.empty
 
 instance Arbitrary XPub where
     arbitrary = toXPub <$> arbitrary

--- a/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Wallet.hs
+++ b/lib/ui/src/Cardano/Wallet/UI/Deposit/Handlers/Wallet.hs
@@ -10,7 +10,8 @@ import Cardano.Wallet.Deposit.Pure
     , Customer
     )
 import Cardano.Wallet.Deposit.Pure.State.Creation
-    ( credentialsFromEncodedXPub
+    ( createMnemonicFromWords
+    , credentialsFromEncodedXPub
     , credentialsFromMnemonics
     )
 import Cardano.Wallet.Deposit.REST
@@ -72,10 +73,13 @@ postMnemonicWallet
     alert
     render
     (PostWalletViaMnemonic mnemonic passphrase customers) = do
-        let credentials = credentialsFromMnemonics mnemonic passphrase
-        initWalletWithXPub l alert render
-            $ initWallet credentials
-            $ fromIntegral customers
+        case createMnemonicFromWords mnemonic of
+            Left e -> pure $ alert $ BL.pack $ show e
+            Right mnemonic' -> do
+                let credentials = credentialsFromMnemonics mnemonic' passphrase
+                initWalletWithXPub l alert render
+                    $ initWallet credentials
+                    $ fromIntegral customers
 
 postXPubWallet
     :: SessionLayer WalletResource


### PR DESCRIPTION
- Expose wallet state functions from the REST interface, useful in the the next PR and somehow happened here
- Use mnemonic management from cardano-addresses
- Add a golden test that we can create the same credentials ads `cardano-addresses` cli tool