### PR TITLE
fix cardano-wallet nixos module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -172,7 +172,7 @@
 
       nixosModule = { pkgs, lib, ... }: {
         imports = [ ./nix/nixos/cardano-wallet-service.nix ];
-        services.cardano-node.package = lib.mkDefault self.defaultPackage.${pkgs.system};
+        services.cardano-node.package = lib.mkDefault self.packages.${pkgs.system}.cardano-node;
       };
       nixosModules.cardano-wallet = nixosModule;
 


### PR DESCRIPTION
This fixes #4522.

The option `self.defaultPackage.${pkgs.system}` does not contain a `cardano-node` package, it only contains a `cardano-wallet` package.

Currently users are required to override the `services.cardano-node.package` option manually by pointing to a compatible cardano-node package. 

So we point to the correct `cardano-node` compatible with `cardano-wallet` by using `self.packages.${pkgs.system}.cardano-node` instead. 