### PR TITLE
Add errSameVote to responsesConstructTransaction in swagger

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -475,11 +475,7 @@ instance IsServerError ErrConstructTx where
             [ "I cannot construct a delegating transaction for a shared wallet "
             , "that is lacking a delegation script template."
             ]
-        ErrConstructTxVotingInWrongEra ->
-            apiError err403 VotingInInvalidEra $ mconcat
-            [ "I cannot construct a transaction that includes voting before "
-            , "the Conway era."
-            ]
+        ErrConstructTxVoting e -> toServerError e
         ErrConstructTxWithdrawalWithoutVoting ->
             apiError err403 WithdrawalNotPossibleWithoutVote $ mconcat
             [ "I cannot construct a transaction that contains withdrawals "

--- a/lib/integration/scenarios/Test/Integration/Scenario/API/Voting.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/API/Voting.hs
@@ -136,6 +136,14 @@ spec = describe "VOTING_TRANSACTIONS" $ do
         -- voting and re-voting
         _ <- voteAndRevote ctx src depositAmt
 
+         -- we are voting abstain now
+        let voteAbstainAgain = Json [json|{
+                "vote": "abstain"
+            }|]
+        rTx2 <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley src) Default voteAbstainAgain
+        decodeErrorInfo rTx2 `shouldBe` SameVote
+
         -- quitting, ie. deregistrating the stake key
         quit ctx src depositAmt
 

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -2842,10 +2842,7 @@ assertDifferentVoting DBLayer{..} votingActionM = \case
     _ -> pure ()
   where
     cmpDReps cDrep rDRep =
-        if cDrep == rDRep then
-            throwE $ ErrConstructTxVoting ErrWrongEra
-        else
-            pure ()
+        when (cDrep == rDRep) $ throwE $ ErrConstructTxVoting ErrWrongEra
 
 getCurrentVoting
     :: Functor stm

--- a/lib/wallet/src/Cardano/Wallet.hs
+++ b/lib/wallet/src/Cardano/Wallet.hs
@@ -116,6 +116,7 @@ module Cardano.Wallet
     , setChangeAddressMode
     , setChangeAddressModeShared
     , assertIsVoting
+    , assertDifferentVoting
 
     -- * Shared Wallet
     , updateCosigner

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Layer.hs
@@ -9,7 +9,6 @@ module Cardano.Wallet.DB.Store.Delegations.Layer
     , readDelegation
     , CurrentEpochSlotting (..)
     , mkCurrentEpochSlotting
-    , isVoting
     , getVoting
     )
 where
@@ -65,15 +64,6 @@ isStakeKeyRegistered :: Delegations -> Bool
 isStakeKeyRegistered m = fromMaybe False $ do
     (_, v) <- lookupMax m
     pure $ v /= Inactive
-
--- | Check whether the voting has been casted in the delegation state.
-isVoting :: Delegations -> Bool
-isVoting m = fromMaybe False $ do
-    (_, v) <- lookupMax m
-    let votedAlready = \case
-            Active (Just _) _ -> True
-            _ -> False
-    pure $ votedAlready v
 
 -- | Get the voting in the delegation state.
 getVoting :: Delegations -> Maybe DRep

--- a/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Layer.hs
+++ b/lib/wallet/src/Cardano/Wallet/DB/Store/Delegations/Layer.hs
@@ -10,6 +10,7 @@ module Cardano.Wallet.DB.Store.Delegations.Layer
     , CurrentEpochSlotting (..)
     , mkCurrentEpochSlotting
     , isVoting
+    , getVoting
     )
 where
 
@@ -72,6 +73,15 @@ isVoting m = fromMaybe False $ do
     let votedAlready = \case
             Active (Just _) _ -> True
             _ -> False
+    pure $ votedAlready v
+
+-- | Get the voting in the delegation state.
+getVoting :: Delegations -> Maybe DRep
+getVoting m = fromMaybe Nothing $ do
+    (_, v) <- lookupMax m
+    let votedAlready = \case
+            Active (Just drep) _ -> Just drep
+            _ -> Nothing
     pure $ votedAlready v
 
 -- | Binds a stake pool id to a wallet. This will have an influence on

--- a/lib/wallet/src/Cardano/Wallet/Delegation.hs
+++ b/lib/wallet/src/Cardano/Wallet/Delegation.hs
@@ -61,6 +61,7 @@ import Data.Generics.Internal.VL.Lens
     )
 import Data.Maybe
     ( fromJust
+    , isJust
     , isNothing
     )
 import Data.Set
@@ -187,7 +188,8 @@ quitStakePoolDelegationAction wallet rewards currentEpochSlotting withdrawal =
         Right () -> Right Tx.Quit
   where
     voting =
-        Dlgs.isVoting
+        isJust
+        $ Dlgs.getVoting
         $ WalletState.delegations wallet
     delegation =
         Dlgs.readDelegation currentEpochSlotting

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -6258,6 +6258,7 @@ x-responsesConstructTransaction: &responsesConstructTransaction
             - <<: *errVotingInInvalidEra
             - <<: *errWithdrawalNotPossibleWithoutVote
             - <<: *errInvalidMetadataEncryption
+            - <<: *errSameVote
   202:
     description: Accepted
     content:


### PR DESCRIPTION
<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->


- [x]  `errSameVote` is used in error specification of `responsesJoinStakePool` and `responsesJoinDRep` but was missing in `responsesConstructTransaction`
- [x]  We add also the guard in constructTransaction
- [x]  Checking in integration testing

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number
fix https://github.com/cardano-foundation/cardano-wallet/issues/4870

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
