### PR TITLE
Enable StrictData in `TxHistory` module

### DIFF
--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/API/TxHistory.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StrictData #-}
 
 module Cardano.Wallet.Deposit.Pure.API.TxHistory
     ( ByCustomer


### PR DESCRIPTION
- Make `TxHistory` strict

```haskell
data TxHistory = TxHistory
    { byCustomer :: ByCustomer
    , byTime :: ByTime
    }
```

### Heap profile before
![cardano-wallet-9-deposit-after-demo](https://github.com/user-attachments/assets/b4156f89-2e7b-43a9-8940-d73d9d94f00a)

### Heap profile after

![cardano-wallet](https://github.com/user-attachments/assets/cfe946e7-11f1-42dc-bef4-1558353b088d)

### Issue Number

Fixes #4876
