### PR TITLE
Remove `.#ci.tests.run.integration` from nix flake

### DIFF
--- a/docs/site/src/contributor/what/building.md
+++ b/docs/site/src/contributor/what/building.md
@@ -44,12 +44,6 @@ or more comfortably, for pre-configured networks (`mainnet`, `testnet`, ...):
 > nix run .#mainnet/wallet -- <optional additional cardano wallet arguments>
 ```
 
-You can run the integration tests with:
-
-```console
-> nix build -L .#ci.x86_64-linux.tests.run.integration
-```
-
 #### Cross-compiling with Nix
 
 To build the wallet for Windows, from **Linux**:


### PR DESCRIPTION
We no longer run integration tests by building a nix derivation — we run shell scripts from the `justfile` instead. This means that we no longer specify configuration variables for our integration tests in nix.