### PR TITLE
Translate possible cases of `ErrBalanceTx` to `ErrCreatePayment`

### DIFF
--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -602,12 +602,6 @@ instance (Write.IsRecentEra era, IsServerError (ErrAssignRedeemers era))
                 TokenBundle shortfallAda shortfallAssets =
                     toWalletTokenBundle $ e ^. #shortfall
         ErrBalanceTxAssignRedeemers err -> toServerError err
-        ErrBalanceTxConflictingNetworks ->
-            apiError err403 BalanceTxConflictingNetworks $ T.unwords
-                [ "There are withdrawals for multiple networks (e.g. both"
-                , "mainnet and testnet) in the provided transaction. This"
-                , "makes no sense, and I'm confused."
-                ]
         ErrBalanceTxExistingCollateral ->
             apiError err403 BalanceTxExistingCollateral
                 "I cannot balance transactions with pre-defined collateral."

--- a/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
+++ b/lib/api/src/Cardano/Wallet/Api/Http/Server/Error.hs
@@ -619,7 +619,7 @@ instance (Write.IsRecentEra era, IsServerError (ErrAssignRedeemers era))
         ErrBalanceTxInsufficientCollateral e ->
             toServerError e
         ErrBalanceTxInternalError e -> toServerError e
-        ErrBalanceTxMaxSizeLimitExceeded ->
+        ErrBalanceTxMaxSizeLimitExceeded _ _ ->
             apiError err403 TransactionIsTooBig $ T.unwords
                 [ "I was not able to balance the transaction without exceeding"
                 , "the maximum transaction size."

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -395,7 +395,6 @@ data ErrBalanceTx era
     | ErrBalanceTxExistingReturnCollateral
     | ErrBalanceTxInsufficientCollateral
         (ErrBalanceTxInsufficientCollateralError era)
-    | ErrBalanceTxConflictingNetworks
     | ErrBalanceTxAssignRedeemers (ErrAssignRedeemers era)
     | ErrBalanceTxInternalError (ErrBalanceTxInternalError era)
     | ErrBalanceTxInputResolutionConflicts

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/Balance.hs
@@ -386,7 +386,7 @@ deriving instance IsRecentEra era => Show (ErrBalanceTxInternalError era)
 -- | Errors that can occur when balancing transactions.
 data ErrBalanceTx era
     = ErrBalanceTxAssetsInsufficient ErrBalanceTxAssetsInsufficientError
-    | ErrBalanceTxMaxSizeLimitExceeded
+    | ErrBalanceTxMaxSizeLimitExceeded { size :: W.TxSize, maxSize :: W.TxSize }
     | ErrBalanceTxExistingKeyWitnesses Int
     -- ^ Indicates that a transaction could not be balanced because a given
     -- number of existing key witnesses would be rendered invalid.
@@ -713,7 +713,7 @@ balanceTx
         -- using this strategy might allow us to generate a transaction within
         -- the size limit.
         maxSizeLimitExceeded = case e of
-            ErrBalanceTxMaxSizeLimitExceeded ->
+            ErrBalanceTxMaxSizeLimitExceeded{} ->
                 True
             _someOtherError ->
                 False
@@ -907,9 +907,10 @@ balanceTxInner
         -> Tx era
         -> ExceptT (ErrBalanceTx era) m (Tx era)
     guardTxSize witCount tx = do
-        let maxSize =  W.TxSize $ intCast (pp ^. ppMaxTxSizeL)
-        when (estimateSignedTxSize pp witCount tx > maxSize) $
-            throwE ErrBalanceTxMaxSizeLimitExceeded
+        let maxSize = W.TxSize $ intCast (pp ^. ppMaxTxSizeL)
+        let size = estimateSignedTxSize pp witCount tx
+        when (size > maxSize) $
+            throwE ErrBalanceTxMaxSizeLimitExceeded{size, maxSize}
         pure tx
 
     guardTxBalanced

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -1356,8 +1356,6 @@ prop_balanceTxValid
                 label "existing collateral return outputs" True
             Left ErrBalanceTxMaxSizeLimitExceeded ->
                 label "maxTxSize limit exceeded" $ property True
-            Left ErrBalanceTxConflictingNetworks ->
-                label "conflicting networks" $ property True
             Left ErrBalanceTxUnableToCreateInput ->
                 label "unable to create input" $ property True
             Left (ErrBalanceTxInternalError

--- a/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
+++ b/lib/balance-tx/test/spec/Internal/Cardano/Write/Tx/BalanceSpec.hs
@@ -669,7 +669,11 @@ spec_balanceTx = describe "balanceTx" $ do
                     [ W.TxOut dummyAddr
                         (W.TokenBundle.fromCoin (W.Coin 200_000_000))
                     ]
-            tx `shouldBe` Left ErrBalanceTxMaxSizeLimitExceeded
+            tx `shouldBe` Left
+                (ErrBalanceTxMaxSizeLimitExceeded
+                    { size = W.TxSize 28_226
+                    , maxSize = W.TxSize 16_384
+                    })
 
     describe "stake key deposit lookup" $ do
         let stakeCred = KeyHashObj $ KeyHash
@@ -1354,7 +1358,7 @@ prop_balanceTxValid
                 label "existing total collateral" True
             Left (ErrBalanceTxExistingReturnCollateral) ->
                 label "existing collateral return outputs" True
-            Left ErrBalanceTxMaxSizeLimitExceeded ->
+            Left ErrBalanceTxMaxSizeLimitExceeded{} ->
                 label "maxTxSize limit exceeded" $ property True
             Left ErrBalanceTxUnableToCreateInput ->
                 label "unable to create input" $ property True

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Write.hs
@@ -16,6 +16,7 @@ module Cardano.Wallet.Deposit.Write
     , TxBody (..)
     , TxIn
     , TxOut
+    , Coin
 
       -- * Transaction balancing
     , Write.IsRecentEra
@@ -31,6 +32,13 @@ module Cardano.Wallet.Deposit.Write
     , toConwayUTxO
     , Write.PartialTx (..)
     , Write.ErrBalanceTx (..)
+    , Write.ErrBalanceTxAssetsInsufficientError (..)
+    , Write.ErrBalanceTxInsufficientCollateralError (..)
+    , Write.ErrBalanceTxInternalError (..)
+    , Write.ErrBalanceTxOutputError (..)
+    , Write.ErrBalanceTxOutputErrorInfo (..)
+    , Write.ErrBalanceTxUnableToCreateChangeError (..)
+    , Write.ErrAssignRedeemers (..)
     , Write.balanceTx
 
       -- * Signing
@@ -53,6 +61,9 @@ module Cardano.Wallet.Deposit.Write
 
 import Prelude
 
+import Cardano.Ledger.Coin
+    ( Coin
+    )
 import Cardano.Read.Ledger.Tx.Output
     ( Output (..)
     )

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -5115,6 +5115,7 @@ x-errTxNotInNodeEra: &errTxNotInNodeEra
 x-errBalanceTxConflictingNetworks: &errBalanceTxConflictingNetworks
   <<: *responsesErr
   title: balance_tx_conflicting_networks
+  deprecated: true # TODO: Remove this error as soon as bump.sh allows us to
   properties:
     message:
       type: string


### PR DESCRIPTION
- Drop unused `ErrBalanceTxConflictingNetworks`
- Add details to ErrBalanceTxMaxSizeLimitExceeded
- Translate possible cases of `ErrBalanceTx` to `ErrCreatePayment`

### Comments

<img width="1198" alt="Skärmavbild 2024-12-19 kl  12 25 15" src="https://github.com/user-attachments/assets/7de1ccd1-2fc0-4bd8-ab4e-8f87f56bec0b" />


<img width="1194" alt="Skärmavbild 2024-12-19 kl  12 49 57" src="https://github.com/user-attachments/assets/266a41c2-4a17-4012-901d-34d5ec1d2c03" />


<img width="1189" alt="Skärmavbild 2024-12-19 kl  12 49 47" src="https://github.com/user-attachments/assets/87cd945a-a6b9-4be7-b6fd-effa9a4d5671" />

<img width="1165" alt="Skärmavbild 2024-12-19 kl  17 11 03" src="https://github.com/user-attachments/assets/66996bba-33fe-44c7-8a36-bdf6ece3896a" />


### Issue Number

fixes #4877
