### PR TITLE
Remove failing snapshots download step from CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -214,35 +214,6 @@ steps:
       concurrency: 1
       concurrency_group: 'mithril-mainnet-full-sync'
 
-    - block: Preprod Full Sync
-      if: build.env("RELEASE_CANDIDATE") == null
-      depends_on: []
-      key: linux-preprod-full-sync-block
-
-    - label: Preprod Full Sync
-      depends_on:
-        - linux-preprod-full-sync-block
-      timeout_in_minutes: 240
-      soft_fail:
-        - exit_status: 45
-      command: |
-        cd run/preprod/nix
-        rm -rf logs
-        mkdir -p logs
-        rm -rf databases
-        ./snapshot.sh
-        ./run.sh sync
-      artifact_paths:
-        - "./run/preprod/nix/logs/*"
-      agents:
-        system: x86_64-linux
-      env:
-        NODE_LOGS_FILE: ./logs/node.log
-        WALLET_LOGS_FILE: ./logs/wallet.log
-        CLEANUP_DB: true
-        NETWORK: testnet
-
-
   - group: Code Quality Checks
     key: code-quality
     if: build.env("RELEASE_CANDIDATE") == null || build.env("TEST_RC") == "FALSE"
@@ -729,22 +700,6 @@ steps:
           system: x86_64-linux
         env:
           SUCCESS_STATUS: syncing
-          USE_LOCAL_IMAGE: true
-
-      - label: Preprod Full Sync
-        timeout_in_minutes: 240
-        soft_fail:
-          - exit_status: 45
-        command: |
-          cd run/preprod/docker
-          export WALLET_TAG=$(buildkite-agent meta-data get "release-cabal-version")
-          rm -rf databases
-          # necessary to avoid the broken network
-          ./snapshot.sh
-          ./run.sh sync
-        agents:
-          system: x86_64-linux
-        env:
           USE_LOCAL_IMAGE: true
 
   - group: Links


### PR DESCRIPTION
These steps have been failing consistently for a while, possibly because of a discrepancy between versions. We should switch to use mithril snapshots for all networks just like we do for mainnet.