### PR TITLE
Add script and pipeline step to update documentation links

### DIFF
--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -132,3 +132,8 @@ steps:
           - "./docker-build-push"
         agents:
           system: x86_64-linux
+
+      - label: Update Documentation Links
+        depends_on: create-release
+        commands:
+          - nix develop path:$RELEASE_SCRIPTS_DIR -c $RELEASE_SCRIPTS_DIR/update-documentation-links.sh

--- a/scripts/buildkite/release/update-documentation-links.sh
+++ b/scripts/buildkite/release/update-documentation-links.sh
@@ -1,0 +1,13 @@
+#! /usr/bin/env bash
+
+set -euox pipefail
+
+RELEASE_VERSION=$(buildkite-agent meta-data get release-version)
+GH_PAGES_BRANCH="gh-pages"
+
+git checkout "${GH_PAGES_BRANCH}"
+git pull origin "${GH_PAGES_BRANCH}"
+cd releases
+./make_redirects.sh "${RELEASE_VERSION}"
+git remote set-url origin "https://$GITHUB_TOKEN@github.com/cardano-foundation/cardano-wallet.git"
+git push origin "${GH_PAGES_BRANCH}"


### PR DESCRIPTION
### Changes

- Introduce a script to fix release links in the gh-pages branch
- Add a step in the release pipeline to execute this script.

### Notes
  - I removed user interaction from make_redirects.sh in the gh-pages branch

fix #4902