### PR TITLE
Make sure to output `bump diff` failure reason in ci

### DIFF
--- a/scripts/buildkite/release/push-to-bump.sh
+++ b/scripts/buildkite/release/push-to-bump.sh
@@ -32,7 +32,7 @@ fi
 bump diff \
         --doc "$REPO" \
         --token "$TOKEN" \
-        specifications/api/swagger.yaml > artifacts/api-diffs.md;
+        specifications/api/swagger.yaml | tee artifacts/api-diffs.md;
 
 if [[ "${RELEASE_CANDIDATE_COMMIT}" != "" ]]; then
     bump deploy \


### PR DESCRIPTION
### Example ci output

```
<head></head>
* Comparing the given definition file with the currently deployed one... done
--
  | Modified: POST /wallets/{walletId}/transactions-balance
  | Response modified: 403
  | Content type modified: application/json
  | [Breaking] Alternative removed: balance_tx_conflicting_networks
  | Removing a resource is always breaking unless it was deprecated before (breaking)
  | 🚨 Error: The command exited with status 1
```