### PR TITLE
Separate test from nightly tag in the assets

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -559,6 +559,7 @@ steps:
   - group: Windows Checks
     depends_on:
       - windows-artifacts
+    if: build.env("RELEASE_CANDIDATE") == null || build.env("TEST_RC") == "FALSE"
     steps:
     - label: Windows Unit Tests
       command: |
@@ -581,7 +582,7 @@ steps:
 
     - block: Windows E2E Tests
       depends_on: []
-      if: build.env("RELEASE_CANDIDATE") == null
+      if: build.env("RELEASE_CANDIDATE") == null || build.env("TEST_RC") == "TRUE"
       key: trigger-windows-e2e-tests
 
     - label: ⚙️ Windows E2E Tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -516,24 +516,10 @@ steps:
       concurrency: 1
       concurrency_group: 'macos-e2e-tests'
 
-  - group: Windows Agents Setup
-    key: windows-setup
-      # Assumes Ruby 2.7 + resource kit is correctly installed on the target
-      # machine
-    steps:
-        - label: 💎 Configure Ruby
-          key: windows-ruby
-          commands:
-              - cd test\e2e
-              - bundle install
-          agents:
-              system: ${windows}
-
   - group: Windows Artifacts
     key: windows-artifacts
     depends_on:
       - linux-nix
-      - windows-setup
     steps:
     - block: Build Windows Artifacts (windows)
       depends_on: []
@@ -543,6 +529,14 @@ steps:
           && build.branch != "rc-latest"
           && build.env("RELEASE_CANDIDATE") == null
       key: trigger-build-windows-artifacts
+
+    - label: 💎 Configure Ruby
+      key: windows-ruby
+      commands:
+          - cd test\e2e
+          - bundle install
+      agents:
+          system: ${windows}
 
     - label: Build Package (windows)
       key: windows-package

--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -35,10 +35,10 @@ steps:
       - artifacts/changes.md
 
   - group : Nightly
-    key: nightly
+    key: nightly-or-test
     depends_on: main-pipeline-build
     steps:
-      - label: Push swagger nightly
+      - label: Push swagger nightly or test
         commands:
           - nix develop path:$RELEASE_SCRIPTS_DIR -c $RELEASE_SCRIPTS_DIR/push-to-bump.sh
         artifacts:
@@ -48,8 +48,8 @@ steps:
         agents:
           system: x86_64-linux
 
-      - label: Push nightly release tag
-        key: push-nightly-tag
+      - label: Push nightly or test release tag
+        key: push-nightly-or-test-tag
         commands:
           - nix develop path:$RELEASE_SCRIPTS_DIR -c $RELEASE_SCRIPTS_DIR/push-tag.sh
         agents:
@@ -57,9 +57,9 @@ steps:
         env:
           RELEASE: false
 
-      - label: Push nightly release
-        depends_on: push-nightly-tag
-        key: push-nightly-release
+      - label: Push nightly or test release
+        depends_on: push-nightly-or-test-tag
+        key: push-nightly-or-test-release
         commands:
           - nix develop path:$RELEASE_SCRIPTS_DIR -c $RELEASE_SCRIPTS_DIR/push-release.sh
         agents:
@@ -67,8 +67,8 @@ steps:
         env:
           RELEASE: false
 
-      - label: Push nightly release artifacts
-        depends_on: push-nightly-release
+      - label: Push nightly or test release artifacts
+        depends_on: push-nightly-or-test-release
         commands:
           - nix develop path:$RELEASE_SCRIPTS_DIR -c $RELEASE_SCRIPTS_DIR/push-artifacts.sh
         agents:
@@ -77,7 +77,7 @@ steps:
           RELEASE: false
 
   - group: Release
-    depends_on: nightly
+    depends_on: nightly-or-test
     if: build.branch == "master"
     steps:
       - block: Create a release

--- a/scripts/buildkite/release/push-artifacts.sh
+++ b/scripts/buildkite/release/push-artifacts.sh
@@ -4,9 +4,14 @@ set -euox pipefail
 
 base_build=$(buildkite-agent meta-data get base-build)
 NEW_GIT_TAG=$(buildkite-agent meta-data get release-version)
+TEST_RC=$(buildkite-agent meta-data get test-rc)
 
 if [ "$RELEASE" == "false" ]; then
-    TAG=nightly
+    if [ "$TEST_RC" == "TRUE" ]; then
+        TAG="test"
+    else
+        TAG="nightly"
+    fi
 else
     TAG=$NEW_GIT_TAG
 fi
@@ -20,6 +25,7 @@ mkdir -p artifacts
 
 artifact() {
     local artifact_name=$1
+    local new_artifact_name=$2
     # shellcheck disable=SC2155
     local artifact_value=$(curl -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
         -X GET "https://api.buildkite.com/v2/organizations/cardano-foundation/pipelines/cardano-wallet/builds/$main_build/artifacts?per_page=100" \
@@ -28,11 +34,12 @@ artifact() {
     curl -H "Authorization: Bearer $BUILDKITE_API_TOKEN" -L \
         -o "artifacts/$artifact_name" \
         "$artifact_value"
-    gh release upload "$TAG" "artifacts/$artifact_name"
+    mv "artifacts/$artifact_name" "artifacts/$new_artifact_name"
+    gh release upload "$TAG" "artifacts/$new_artifact_name"
 }
 
-artifact "cardano-wallet-$NEW_GIT_TAG-linux64.tar.gz"
-artifact "cardano-wallet.exe-$NEW_GIT_TAG-win64.zip"
-artifact "cardano-wallet-$NEW_GIT_TAG-macos-silicon.tar.gz"
-artifact "cardano-wallet-$NEW_GIT_TAG-macos-intel.tar.gz"
-artifact "cardano-wallet-$NEW_GIT_TAG-docker-image.tgz"
+artifact "cardano-wallet-$NEW_GIT_TAG-linux64.tar.gz" "cardano-wallet-$TAG-linux64.tar.gz"
+artifact "cardano-wallet.exe-$NEW_GIT_TAG-win64.zip" "cardano-wallet.exe-$TAG-win64.zip"
+artifact "cardano-wallet-$NEW_GIT_TAG-macos-silicon.tar.gz" "cardano-wallet-$TAG-macos-silicon.tar.gz"
+artifact "cardano-wallet-$NEW_GIT_TAG-macos-intel.tar.gz" "cardano-wallet-$TAG-macos-intel.tar.gz"
+artifact "cardano-wallet-$NEW_GIT_TAG-docker-image.tgz" "cardano-wallet-$TAG-docker-image.tgz"

--- a/scripts/buildkite/release/push-release.sh
+++ b/scripts/buildkite/release/push-release.sh
@@ -3,10 +3,17 @@
 set -euox pipefail
 
 NEW_GIT_TAG=$(buildkite-agent meta-data get release-version)
+TEST_RC=$(buildkite-agent meta-data get test-rc)
 
 if [ "$RELEASE" == "false" ]; then
-    TAG=nightly
-    title="Nightly $NEW_GIT_TAG"
+    if [ "$TEST_RC" == "FALSE" ]; then
+        TAG=nightly
+        title="Nightly $NEW_GIT_TAG"
+    else
+        TAG="test"
+        title="Test $NEW_GIT_TAG"
+    fi
+
 else
     TAG=$NEW_GIT_TAG
     title="Release $TAG"
@@ -31,7 +38,7 @@ envsubst \
     > "$RELEASE_SCRIPTS_DIR/release-template-final.md"
 
 if [ "$RELEASE" == "false" ]; then
-    gh release delete nightly --yes || true
+    gh release delete "$TAG" --yes || true
 fi
 
 gh release create \

--- a/scripts/buildkite/release/push-tag.sh
+++ b/scripts/buildkite/release/push-tag.sh
@@ -3,13 +3,19 @@
 set -euox pipefail
 
 RELEASE_GIT_COMMIT=$(buildkite-agent meta-data get release-candidate-commit)
+TEST_RC=$(buildkite-agent meta-data get test-rc)
 
 git tag -l | xargs git tag -d
 git fetch --tags
 
 if [ "$RELEASE" == "false" ]; then
-    git tag -d nightly || true
-    TAG=nightly
+    if [ "$TEST_RC" == "TRUE" ]; then
+        git tag -d nightly || true
+        TAG=nightly
+    else
+        git tag -d test || true
+        TAG="test"
+    fi
 else
     TAG=$(buildkite-agent meta-data get release-version)
     exists=$(git tag -l "$TAG")

--- a/scripts/buildkite/release/push-to-bump.sh
+++ b/scripts/buildkite/release/push-to-bump.sh
@@ -2,6 +2,7 @@
 
 set -euox pipefail
 
+TEST_RC=$(buildkite-agent meta-data get test-rc --default "FALSE")
 
 if [[ -n "${BUILDKITE-}" ]]; then
     RELEASE_CANDIDATE_COMMIT=$(buildkite-agent meta-data get release-candidate-commit --default "")
@@ -11,7 +12,6 @@ if [[ -n "${BUILDKITE-}" ]]; then
 else
     RELEASE_CANDIDATE_COMMIT=""
 fi
-
 
 npm install bump-cli@2.8.4
 
@@ -25,8 +25,13 @@ if [[ "$RELEASE" == "true" ]]; then
     TOKEN="$BUMP_RELEASE_TOKEN"
     REPO=cardano-wallet-backend
 else
-    TOKEN="$BUMP_DAILY_TOKEN"
-    REPO=cardano-wallet-backend-daily
+    if [[ "$TEST_RC" == "TRUE" ]]; then
+        TOKEN="$BUMP_TEST_TOKEN"
+        REPO=cardano-wallet-backend-test
+    else
+        TOKEN="$BUMP_DAILY_TOKEN"
+        REPO=cardano-wallet-backend-daily
+    fi
 fi
 
 bump diff \

--- a/scripts/buildkite/release/push-to-bump.sh
+++ b/scripts/buildkite/release/push-to-bump.sh
@@ -29,8 +29,8 @@ else
         TOKEN="$BUMP_TEST_TOKEN"
         REPO=cardano-wallet-backend-test
     else
-        TOKEN="$BUMP_DAILY_TOKEN"
-        REPO=cardano-wallet-backend-daily
+        TOKEN="$BUMP_NIGHTLY_TOKEN"
+        REPO=cardano-wallet-backend-nightly
     fi
 fi
 

--- a/scripts/buildkite/release/release-candidate.sh
+++ b/scripts/buildkite/release/release-candidate.sh
@@ -31,7 +31,17 @@ OLD_GIT_TAG=$( git tag -l "v2*-*-*" | sort | tail -n1)
 
 LAST_RELEASE_DATE=$(tag_date "$OLD_GIT_TAG")
 
+if [ "$OLD_GIT_TAG" == "$NEW_GIT_TAG" ]; then
+    echo "Refusing to rewrite last release tag"
+    exit 1
+fi
+
 OLD_CABAL_VERSION=$(tag_cabal_ver "$OLD_GIT_TAG")
+
+if [ "$OLD_CABAL_VERSION" == "$NEW_CABAL_VERSION" ]; then
+    echo "Refusing to rewrite last release cabal version"
+    exit 1
+fi
 
 CARDANO_NODE_TAG=$(cardano-node version | head -n1 | awk '{print $2}')
 


### PR DESCRIPTION
### Changes

- Shrink the windows steps, moving the setup
- Make sure we fail when trying to rewrite cabal versions or release tags
- Skip unnecessary steps when testing the release pipeline
- Use `TEST_RC` variable in the pushing artifacts steps to respect nightly and test separation

### Issues

fix #4935 
fix #4895