### PR TITLE
Drop `W.Coin`, `W.UTxO`, `W.TxOut` usage in `BalanceSpec`

### DIFF
--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Eras.hs
@@ -188,6 +188,7 @@ type RecentEraConstraints era =
     , Core.EraCrypto era ~ StandardCrypto
     , Core.Script era ~ AlonzoScript era
     , Core.Tx era ~ Babbage.AlonzoTx era
+    , Core.EraTxOut era
     , Core.EraTxCert era
     , Core.Value era ~ MaryValue StandardCrypto
     , Core.TxWits era ~ AlonzoTxWits era


### PR DESCRIPTION
Drop a significant part of the usage of `W.Coin`, `W.TxOut`, `W.UTxO` in `BalanceSpec`, as part
of the effort to eventually consistently only use ledger types.

Depends on #4762 