### PR TITLE
Add a delete-logs exe in buildkite lib

### DIFF
--- a/lib/benchmarks/exe/benchmark-history.hs
+++ b/lib/benchmarks/exe/benchmark-history.hs
@@ -12,6 +12,8 @@ import Buildkite.API
     , Build (branch, jobs, number)
     , Job (finished_at)
     , Time (Time)
+    , bailout
+    , skip410
     )
 import Buildkite.Artifacts.CSV
     ( fetchCSVArtifactContent
@@ -28,9 +30,7 @@ import Buildkite.Connection
     ( Connector
     , OrganizationName (..)
     , PipelineName (..)
-    , bailout
     , newConnector
-    , skip410
     )
 import Buildkite.LimitsLock
     ( LimitsLockLog (..)

--- a/lib/buildkite/cardano-wallet-buildkite.cabal
+++ b/lib/buildkite/cardano-wallet-buildkite.cabal
@@ -31,9 +31,8 @@ common opts-lib
     -fwarn-unused-do-bind -fwarn-incomplete-uni-patterns
     -freverse-errors
 
-
 library
-  import:           language, opts-lib
+  import:          language, opts-lib
   build-depends:
     , aeson
     , base
@@ -46,20 +45,33 @@ library
     , http-media
     , http-types
     , pretty-simple
+    , regex-tdfa
     , servant
     , servant-client
+    , stm
     , streaming
     , text
-    , stm
     , time
 
   if flag(release)
     ghc-options: -O2 -Werror
-  hs-source-dirs:   src
 
+  hs-source-dirs:  src
   exposed-modules:
     Buildkite.API
     Buildkite.Artifacts.CSV
     Buildkite.Client
     Buildkite.Connection
     Buildkite.LimitsLock
+
+executable delete-logs
+  import:         language, opts-lib
+  main-is:        delete-logs.hs
+  hs-source-dirs: exe
+  build-depends:
+    , base
+    , cardano-wallet-buildkite
+    , contra-tracer
+    , optparse-applicative
+    , text
+    , streaming

--- a/lib/buildkite/exe/delete-logs.hs
+++ b/lib/buildkite/exe/delete-logs.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import Prelude
+
+import Buildkite.API
+    ( Job (..)
+    )
+import Buildkite.Client
+    ( deleteJobLogsMatching
+    )
+import Buildkite.Connection
+    ( newConnector
+    )
+import Control.Tracer
+    ( Contravariant (..)
+    , stdoutTracer
+    )
+import Data.Text
+    ( Text
+    )
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import Options.Applicative
+    ( Parser
+    , execParser
+    , fullDesc
+    , help
+    , helper
+    , info
+    , long
+    , metavar
+    , progDesc
+    , short
+    , strOption
+    , (<**>)
+    )
+import qualified Streaming.Prelude as S
+
+data Options
+    = Options
+    { _branch :: String
+    , _job :: Text
+    }
+
+parseOptBranch :: Parser String
+parseOptBranch =
+    strOption
+        ( long "branch"
+            <> short 'b'
+            <> metavar "BRANCH"
+            <> help "Branch to delete logs from"
+        )
+
+parseOptJob :: Parser Text
+parseOptJob =
+    strOption
+        ( long "job"
+            <> short 'j'
+            <> metavar "JOB"
+            <> help "Part of job name to delete logs from"
+        )
+
+parseOptions :: Parser Options
+parseOptions =
+    Options
+        <$> parseOptBranch
+        <*> parseOptJob
+
+main :: IO ()
+main = do
+    Options branch job <-
+        execParser
+            $ info
+                (parseOptions <**> helper)
+                ( fullDesc
+                    <> progDesc "Delete logs from specific jobs on a branch"
+                )
+    connector <-
+        newConnector "BUILDKITE_API_TOKEN" 10 $ show `contramap` stdoutTracer
+    let query =
+            connector
+                "cardano-foundation"
+                "cardano-wallet"
+    S.mapM_ renderLink $ deleteJobLogsMatching query branch job
+
+renderLink :: (Int, Job) -> IO ()
+renderLink (build, Job id' _ _ _ _) =
+    T.putStrLn
+        $ "https://buildkite.com/cardano-foundation/cardano-wallet/builds/"
+            <> T.pack (show build)
+            <> "#"
+            <> id'

--- a/lib/buildkite/src/Buildkite/Client.hs
+++ b/lib/buildkite/src/Buildkite/Client.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 
 module Buildkite.Client
@@ -13,6 +14,8 @@ module Buildkite.Client
     , getArtifacts
     , getArtifactsContent
     , downloadArtifact
+    , deleteJobLog
+    , deleteJobLogsMatching
     )
 where
 
@@ -22,18 +25,30 @@ import Buildkite.API
     ( Artifact (..)
     , ArtifactURL (..)
     , Job
+    , Skipping
     , WithAuthPipeline
     , WithLockingAuthPipeline
+    , bailout
     , fetchArtifacts
     , fetchBuilds
     , fetchBuildsOfBranch
     , jobId
+    , jobNameContains
+    , jobs
     , number
     , overJobs
+    , skip400
+    )
+import Control.Exception
+    ( SomeException
+    , try
     )
 import Control.Monad.IO.Class
     ( MonadIO
     , liftIO
+    )
+import Data.Function
+    ( (&)
     )
 import Data.Map
     ( Map
@@ -56,6 +71,7 @@ import Streaming
     ( MonadTrans (lift)
     , Of
     , Stream
+    , void
     )
 
 import qualified Buildkite.API as BKAPI
@@ -101,13 +117,46 @@ getBuildsOfBranch :: Query -> String -> Stream (Of BuildAPI) IO ()
 getBuildsOfBranch (Query q w _) branch =
     paging $ q . w fetchBuildsOfBranch (Just branch)
 
-getArtifacts :: Query -> BuildAPI -> Stream (Of (BuildJobsMap, Artifact)) IO ()
+getArtifacts
+    :: Query -> BuildAPI -> Stream (Of (BuildJobsMap, Artifact)) IO ()
 getArtifacts (Query q w _) build =
     S.map (build',) $ paging $ q . w fetchArtifacts (number build)
   where
     build' = overJobs build $ \job' -> Map.fromList $ do
         jobV <- job'
         pure (jobId jobV, jobV)
+
+getJobsOfBranch :: BuildAPI -> Stream (Of (Int, Job)) IO ()
+getJobsOfBranch build = S.map (number build,) $ S.each $ jobs build
+
+deleteJobLog :: Query -> Int -> Job -> IO ()
+deleteJobLog (Query q w _) build job =
+    void $ q $ w BKAPI.deleteJobLog build (jobId job)
+
+deleteJobLogsMatching
+    :: (Skipping -> Query)
+    -- ^ Query
+    -> String
+    -- ^ Branch
+    -> Text
+    -- ^ Job name regex
+    -> Stream (Of (Int, Job)) IO ()
+deleteJobLogsMatching q branch jobName =
+    getBuildsOfBranch (q bailout) branch
+        & flip S.for getJobsOfBranch
+        & S.filter (jobNameContains jobName . snd)
+        & S.chain (ignoreFailures . uncurry (deleteJobLog skipping400))
+  where
+    skipping400 = q skip400
+
+ignoreFailures :: Monoid a => IO a -> IO a
+ignoreFailures f = do
+    res <- try f
+    case res of
+        Left (e :: SomeException) -> do
+            putStrLn $ "Failed to delete job log: " <> show e
+            pure mempty
+        Right a -> pure a
 
 getArtifactsContent
     :: MonadIO m


### PR DESCRIPTION
### Why

It happens to me to disclose sensitive information in the CI logs, then I want to clean up ASAP.

### What 

A cli tool to remove the logs of all jobs matching a name from a specific branch builds

### Changes 

- Add a `delete-logs` exe  stanza in buildkite lib 
- Cleanup client errors skipping logic
- Add API endpoint to delete logs

### Issues 

#4953 

### Notes

```
export BUILDKITE_API_TOKEN=<from password manager>
cabal run cardano-wallet-buildkite:exe:delete-logs -- -b "paolino/4953/add-mithril-client-exe-to-artifacts-and-shell" -j ".*E2E.*mac.*"
```