### PR TITLE
Fix release pipeline

### DIFF
--- a/scripts/buildkite/release/openapi-diff.sh
+++ b/scripts/buildkite/release/openapi-diff.sh
@@ -14,6 +14,8 @@ swagger_tmp=$(mktemp -d)
 swagger_file="specifications/api/swagger.yaml"
 last_release_tag=$(curl -s https://api.github.com/repos/cardano-foundation/cardano-wallet/releases | jq -r '.[0].tag_name')
 
+git fetch --tags --force
+
 git show "$last_release_tag:$swagger_file" > "$swagger_tmp/last-release-swagger.yaml"
 
 mkdir -p artifacts

--- a/scripts/buildkite/release/release-candidate.sh
+++ b/scripts/buildkite/release/release-candidate.sh
@@ -72,8 +72,6 @@ git commit -am "Update cardano-wallet version in README.md"
 
 sed -i "s|$OLD_GIT_TAG|$NEW_GIT_TAG|g" scripts/buildkite/main/ruby-e2e.sh
 git commit -am "Update cardano-wallet version in ruby-e2e.sh"
-sed -i "s|$OLD_GIT_TAG|$NEW_GIT_TAG|g" scripts/buildkite/main/macos-silicon-e2e.sh
-git commit -am "Update cardano-wallet version in macos-silicon-e2e.sh"
 
 sed -i "s|RELEASE_WALLET_TAG=.*|RELEASE_WALLET_TAG=$NEW_CABAL_VERSION|g" run/common/docker/run.sh
 git commit -am "Update cardano-wallet version in run/common/docker/run.sh"


### PR DESCRIPTION
### Changes 

- Fix openapi diff step by adding a refresh tag before git show
- Fix release candidate step removing outdated sed command

### Issues 

#4953

### Proofs

- https://buildkite.com/cardano-foundation/cardano-wallet-release/builds/708