### PR TITLE
Fix ruby e2e script cleanup to cover macos node socket definition

### DIFF
--- a/scripts/buildkite/main/ruby-e2e.sh
+++ b/scripts/buildkite/main/ruby-e2e.sh
@@ -111,5 +111,5 @@ rake "run_on[preprod,sync,true]" # SPEC_OPTS="-e '<match>'"
 # Cleanup
 ####################
 
-rm "$node_socket"
+rm -rf "$node_socket"
 rm -rf "$TESTS_E2E_BINDIR"


### PR DESCRIPTION
### Changes

- fix ruby-e2e.sh cleanup phase

### Issue

#4953
- https://buildkite.com/cardano-foundation/cardano-wallet/builds/9206#0194b8cf-281a-42ea-b904-95d871f5fa23/21-1213