### PR TITLE
Bump nix channels in release pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,7 +64,9 @@ steps:
     steps:
     - label: Nix Build (linux)
       commands:
-        - nix build .
+        - nix build .#cardano-wallet
+        - nix build .#cardano-node
+        - nix build .#cardano-cli
       agents:
         system: ${linux}
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -601,8 +601,6 @@ steps:
 
   - group: Docker
     key: docker-artifacts
-
-    # if: build.env("RELEASE_CANDIDATE") != null
     depends_on:
       - linux-artifacts
     steps:
@@ -619,7 +617,6 @@ steps:
     depends_on:
       - docker-artifacts
     key: docker-e2e
-    # if: (build.env("RELEASE_CANDIDATE") != null && build.env("TEST_RC") == "FALSE") || build.tag =~ /^v20/
     steps:
       - label: Mainnet Boot Sync
         timeout_in_minutes: 30
@@ -648,7 +645,7 @@ steps:
           USE_LOCAL_IMAGE: true
 
       - block: Mainnet Boot Sync via Mithril
-        if: build.env("RELEASE_CANDIDATE") == null
+        if: build.env("RELEASE_CANDIDATE") == null || build.env("TEST_RC") == "TRUE"
         depends_on: []
         key: mithril-mainnet-full-sync-block
 

--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -3,7 +3,7 @@ agents:
 
 env:
   LC_ALL: "C.UTF-8"
-  NIX_PATH: "channel:nixos-21.11"
+  NIX_PATH: "channel:nixos-24.11"
   STATE_DIR: "/var/lib/buildkite-agent/cache"
   STATE_DIR_MACOS: "/var/lib/buildkite-agent-hal-mac/cache"
   RELEASE_SCRIPTS_DIR: "./scripts/buildkite/release"

--- a/scripts/buildkite/release/flake.lock
+++ b/scripts/buildkite/release/flake.lock
@@ -5,31 +5,31 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681378341,
-        "narHash": "sha256-2qUN04W6X9cHHytEsJTM41CmusifPTC0bgTtYsHSNY8=",
-        "owner": "hamishmack",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "2767bafdb189cd623354620c2dacbeca8fd58b17",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
-        "owner": "hamishmack",
-        "ref": "hkm/nested-hydraJobs",
+        "owner": "numtide",
         "repo": "flake-utils",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719571325,
-        "narHash": "sha256-cyNYj2MtFvZJfNI3zdtGTIFxezT44QQ3y3NryOLzMyk=",
+        "lastModified": 1738410390,
+        "narHash": "sha256-xvTo0Aw0+veek7hvEVLzErmJyQkEcRk6PSR4zsRQFEc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c8201d6eef0554bec529465300e600be6ddcf79d",
+        "rev": "3a228057f5b619feb3186e986dbe76278d707b6e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/scripts/buildkite/release/flake.nix
+++ b/scripts/buildkite/release/flake.nix
@@ -5,8 +5,8 @@
   '';
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
-    flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs = inputs:


### PR DESCRIPTION
### Changes 

- Bump nixpkgs version to 24.11 in release pipeline
- Bump nixpkgs to unstable in release flake.nix
- Change release-candidate.sh so it can run outside buildkite

### Issues 

#4965

### Notes

I do not think this is solving the issue, but I was not able to reproduce it locally so I shot in the dark. Because it's flaky, it succeeded also on buildkite: https://buildkite.com/cardano-foundation/cardano-wallet-release/builds/718#0194cb3f-964e-44e9-b10b-ef4e42237734/169-311