### PR TITLE
Bump `cardano-wallet-agda` repository

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -155,8 +155,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/cardano-foundation/cardano-wallet-agda
-    tag: 11bee0f47c1950cd444835552a481d8b080c0299
-    --sha256: 1fg95ls2dy9ahjpw73pmilx5n3y434pffvllkd47q3my8iwfssjm
+    tag: b5f11bde33585277aa3628b01fe6f5ee8bed2101
+    --sha256: 0dc0b60vbq1ljwrdxr45nc99c3gdn98myjyd3c9xmlkn8cwpvjwx
     subdir:
       lib/customer-deposit-wallet-pure
       lib/cardano-wallet-read

--- a/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
+++ b/lib/customer-deposit-wallet/customer-deposit-wallet.cabal
@@ -228,12 +228,12 @@ test-suite unit
     , cardano-ledger-core:testlib
     , cardano-ledger-shelley
     , cardano-slotting
-    , cardano-wallet-read
+    , cardano-wallet-read == 1.0.0.0
     , cardano-wallet-test-utils
     , containers
     , contra-tracer
     , customer-deposit-wallet
-    , customer-deposit-wallet-pure
+    , customer-deposit-wallet-pure == 0.1.0.0
     , customer-deposit-wallet:http
     , customer-deposit-wallet:rest
     , data-default

--- a/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
+++ b/lib/customer-deposit-wallet/rest/Cardano/Wallet/Deposit/REST.hs
@@ -271,12 +271,12 @@ findTheDepositWalletOnDisk env dir action = do
     ds <- scanDirectoryForDepositPrefix dir
     case ds of
         [d] -> do
-            (credentials, maxCustomer) <-
+            (credentials, customers) <-
                 deserialise <$> BL.readFile (dir </> d)
             let state =
                     fromCredentialsAndGenesis
                         credentials
-                        (fromIntegral @Int maxCustomer)
+                        (fromIntegral @Int customers)
                         (genesisData env)
             store <- newStore
             writeS store state

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/IO.hs
@@ -189,13 +189,13 @@ withWalletInit
         , ..
         }
     credentials
-    maxCustomer
+    customers
     action = do
         walletState <-
             DBVar.initDBVar store
                 $ Wallet.fromCredentialsAndGenesis
                     credentials
-                    maxCustomer
+                    customers
                     genesisData
         withWalletDBVar wtc env walletState action
 

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Creation.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Creation.hs
@@ -115,14 +115,14 @@ rootXPrvFromCredentials (XPrvCredentials xprv _) = Just xprv
 
 fromCredentialsAndGenesis
     :: Credentials -> Word31 -> Read.GenesisData -> WalletState
-fromCredentialsAndGenesis credentials maxCustomer genesisData =
+fromCredentialsAndGenesis credentials customers genesisData =
     WalletState
         { walletTip = Read.GenesisPoint
         , addresses =
-            Address.fromXPubAndMax
+            Address.fromXPubAndCount
                 network
                 (accountXPubFromCredentials credentials)
-                maxCustomer
+                customers
         , utxoHistory = UTxOHistory.fromOrigin initialUTxO
         , txHistory = mempty
         , submissions = Sbm.empty

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Type.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Pure/State/Type.hs
@@ -112,7 +112,7 @@ fromRawCustomer = id
 
 -- | Maximum 'Customer' that is being tracked.
 trackedCustomers :: WalletState -> Customer
-trackedCustomers = Address.getMaxCustomer . addresses
+trackedCustomers = (+1) . Address.getMaxCustomer . addresses
 
 walletXPub :: WalletState -> XPub
 walletXPub = Address.getXPub . addresses

--- a/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Testing/DSL.hs
+++ b/lib/customer-deposit-wallet/src/Cardano/Wallet/Deposit/Testing/DSL.hs
@@ -170,8 +170,8 @@ data Scenario p a where
 type ScenarioP p m = ProgramT (Scenario p) m
 
 wallet :: Int -> Text -> Text -> ScenarioP p m ()
-wallet maxCustomer seed passphrase =
-    singleton (ResetWallet maxCustomer seed passphrase)
+wallet customers seed passphrase =
+    singleton (ResetWallet customers seed passphrase)
 
 existsTx :: ScenarioP p m TxI
 existsTx = singleton ExistsTx
@@ -333,12 +333,12 @@ interpret w runP slotTimes p = flip evalStateT w $ do
     put walletState'
   where
     go = viewT >=> eval
-    eval (ResetWallet maxCustomer seed passphrase :>>= k) = do
+    eval (ResetWallet customers seed passphrase :>>= k) = do
         Right mnemonics <- pure $ createMnemonicFromWords seed
         let new =
                 Wallet.fromCredentialsAndGenesis
                     (credentialsFromMnemonics mnemonics passphrase)
-                    (fromIntegral maxCustomer)
+                    (fromIntegral customers)
                     Read.mockGenesisDataMainnet
         id .= (new, freshInterpreterState)
         go $ k ()

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Pure/API/TransactionSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Pure/API/TransactionSpec.hs
@@ -236,6 +236,6 @@ spec = do
                     encodeAddress
                         $ fst
                         $ createAddress 0
-                        $ Address.fromXPubAndMax Mainnet xpub 1
+                        $ Address.fromXPubAndCount Mainnet xpub 1
 
             addr `shouldBe` address0

--- a/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Pure/API/TransactionSpec.hs
+++ b/lib/customer-deposit-wallet/test/unit/Cardano/Wallet/Deposit/Pure/API/TransactionSpec.hs
@@ -28,9 +28,6 @@ import Cardano.Slotting.Time
     , SystemStart (..)
     , mkSlotLength
     )
-import Cardano.Wallet.Deposit.Pure.Address
-    ( createAddress
-    )
 import qualified Cardano.Wallet.Deposit.Pure.Address as Address
 import Cardano.Wallet.Deposit.Pure.API.Address
     ( encodeAddress
@@ -234,8 +231,9 @@ spec = do
                 xpub = accountXPubFromCredentials creds
                 addr =
                     encodeAddress
-                        $ fst
-                        $ createAddress 0
+                        $ snd
+                        $ head
+                        $ Address.listCustomers
                         $ Address.fromXPubAndCount Mainnet xpub 1
 
             addr `shouldBe` address0


### PR DESCRIPTION
This pull request bumps our use of the `cardano-wallet-agda` repository to the latest commit.

This entails:

* Bump `cardano-wallet-read` to version `1.0.0.0`, which is the first version that specifies version constraints in its `.cabal` file.
* Bump `customer-deposit-wallet-pure`. In particular, go back to the previous definition of `fromXPubAndCount`.

### Issue

#4958