### PR TITLE
Run new e2e tests on linux

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -120,19 +120,17 @@ steps:
       concurrency: 8
       concurrency_group: 'linux-integration-tests'
 
-    - block: Run Ruby E2E Tests (linux)
+    - block: Run E2E Tests (linux)
       if: build.env("RELEASE_CANDIDATE") == null
       depends_on: []
       key: trigger-e2e-tests
 
-    - label: Run Ruby Linux E2E Tests (linux)
+    - label: Run Linux E2E Tests (linux)
       depends_on:
         - trigger-e2e-tests
       commands: |
-        nix shell 'nixpkgs#just' -c just ruby-e2e-linux
+        nix shell 'nixpkgs#just' -c just e2e
       artifact_paths:
-        - "./result/linux/**"
-        - "./logs/**/*"
       env:
 
       agents:


### PR DESCRIPTION
Depends on the preceding #4976.

- [x] Run new e2e tests on linux, instead of running the Ruby e2e tests.
- [x] Actually — I should create new preprod wallets that are unique to linux not to have contention. This will be purely a change of the secret value on the linux builder though.

### Comments

macOS is now the only platform running the old ruby e2e tests. The mac was a little annoying to configure and is busy with builds at the moment, so I think we might as well just leave it to last, after we've reviewed and are ready to drop the Ruby e2e tests completely.

### Issue Number

#4977
