### PR TITLE
Assert preprod wallets are funded with helpful error

### DIFF
--- a/lib/integration/cardano-wallet-integration.cabal
+++ b/lib/integration/cardano-wallet-integration.cabal
@@ -115,6 +115,7 @@ library framework
     Test.Integration.Framework.LocalCluster.SendFaucetAssets
     Test.Integration.Framework.Logging
     Test.Integration.Framework.PendingInEra
+    Test.Integration.Framework.Preprod
     Test.Integration.Framework.Request
     Test.Integration.Framework.Setup
     Test.Integration.Framework.TestData

--- a/lib/integration/exe/e2e.hs
+++ b/lib/integration/exe/e2e.hs
@@ -101,7 +101,7 @@ import Test.Hspec
 import Test.Integration.Framework.Context
     ( Context (..)
     )
-import Test.Integration.Framework.DSL
+import Test.Integration.Framework.Preprod
     ( PreprodSetupLog (..)
     , setupPreprodWallets
     )

--- a/lib/integration/framework/Test/Integration/Framework/DSL.hs
+++ b/lib/integration/framework/Test/Integration/Framework/DSL.hs
@@ -231,11 +231,6 @@ module Test.Integration.Framework.DSL
     , deleteTransactionViaCLI
     , getTransactionViaCLI
 
-    -- * Preprod e2e
-    , setupPreprodWallets
-    , fixturePreprodWallets
-    , PreprodSetupLog (..)
-
     -- * utilities
     , getRetirementEpoch
     , replaceStakeKey
@@ -470,15 +465,9 @@ import Control.Monad.Trans.Resource
     , runResourceT
     )
 import Control.Retry
-    ( RetryStatus
-    , capDelay
+    ( capDelay
     , constantDelay
-    , fibonacciBackoff
     , retrying
-    )
-import Control.Tracer
-    ( Tracer
-    , traceWith
     )
 import Cryptography.Hash.Blake
     ( Blake2b_160
@@ -544,9 +533,6 @@ import Data.List.NonEmpty
     )
 import Data.List.NonEmpty.Extra
     ( (!?)
-    )
-import Data.Map
-    ( Map
     )
 import Data.Maybe
     ( catMaybes
@@ -2286,102 +2272,6 @@ fixtureWallet
     -> ResourceT m ApiWallet
 fixtureWallet ctx =
     fst <$> fixtureWalletWithMnemonics nextShelleyMnemonic ctx "shelley"
-
-data PreprodSetupLog
-    = WaitingForNodeConnection
-    | CreatingWallets
-    | WaitingForWalletsToSync
-    | PreprodSetupReady
-
-setupPreprodWallets :: Tracer IO PreprodSetupLog -> [SomeMnemonic] -> Context -> IO Context
-setupPreprodWallets tr mnemonics ctx = do
-    traceWith tr WaitingForNodeConnection
-    waitForConnection
-
-    traceWith tr CreatingWallets
-    createWalletsIfNeeded mnemonics
-
-    wallets <- getResponse <$> request @[ApiWallet] ctx
-        (Link.listWallets @'Shelley) Default Empty
-    unless (length wallets == length mnemonics) $
-        expectationFailure $ unwords
-            [ "Setup error: have", show (length mnemonics), "mnemonics but only"
-            , show wallets, "have now been created."
-            ]
-
-    let walletIds = map (getApiT . view #id) wallets
-
-    traceWith tr WaitingForWalletsToSync
-    waitForAllWalletsToSync
-    traceWith tr PreprodSetupReady
-
-    pure ctx{ _preprodWallets = walletIds }
-  where
-    createWalletsIfNeeded :: [SomeMnemonic] -> IO ()
-    createWalletsIfNeeded = mapM_ createWalletIfNeeded
-
-    createWalletIfNeeded :: SomeMnemonic -> IO ()
-    createWalletIfNeeded (SomeMnemonic mnemonic) = do
-        (s, response) <- request @ApiWallet ctx (Link.postWallet @'Shelley) Default $ Json
-            [aesonQQ| {
-                "name": "Faucet Wallet",
-                "mnemonic_sentence": #{mnemonicToText mnemonic},
-                "passphrase": #{fixturePassphrase}
-            } |]
-        case response of
-            Right _ | s == HTTP.status201 -> pure ()
-            Left e | s == HTTP.status409 -> show e `shouldContain` "wallet_already_exists"
-            _ -> expectationFailure $ unwords
-                [ "setupPreprodWallets, createWalletsIfNeeded: unexpected response"
-                , show (s, response)
-                ]
-
-    waitForConnection :: IO ()
-    waitForConnection = void $ retrying
-        (capDelay (30*oneSecond) $ fibonacciBackoff oneSecond)
-        shouldWait
-        (\_retryStatus -> request @ApiNetworkInformation ctx
-          Link.getNetworkInfo Default Empty)
-      where
-        shouldWait
-            :: RetryStatus
-            -> (HTTP.Status, Either RequestException ApiNetworkInformation)
-            -> IO Bool
-        shouldWait _ (_, Right info) = pure $ info ^. #syncProgress . #getApiT <= NotResponding
-        shouldWait _ (_, Left _err) = pure True
-
-    waitForAllWalletsToSync :: IO ()
-    waitForAllWalletsToSync = do
-        eventuallyUsingDelay (5 * s) (90 * minutes) "setupPreprodWallets: all wallets are synced" $ do
-            wallets :: [ApiWallet] <- getResponse <$> request @[ApiWallet] ctx
-                (Link.listWallets @'Shelley) Default Empty
-            let progress = map (getApiT . view #state) wallets
-            all (== Ready) progress `shouldBe` True
-      where
-        s = 1_000_000
-        minutes = 60
-
-fixturePreprodWallets :: (HasCallStack, MonadUnliftIO m) => Context -> m [ApiWallet]
-fixturePreprodWallets ctx = do
-    wallets <- getResponse <$> request @[ApiWallet] ctx
-        (Link.listWallets @'Shelley) Default Empty
-
-    let keyByWalletId :: ApiWallet -> (WalletId, ApiWallet)
-        keyByWalletId w = (getApiT $ w ^. #id, w)
-
-        walletsById :: Map WalletId ApiWallet
-        walletsById = Map.fromList $ map keyByWalletId wallets
-
-        lookupWallet :: WalletId -> ApiWallet
-        lookupWallet wid = fromMaybe err $ Map.lookup wid walletsById
-          where
-            err = error $ unwords
-                [ "fixturePreprodWallets: expected", show wid, "to be an"
-                , "existing wallet. The wallets that could be found are:\n\n"
-                ] ++ unlines (map show wallets)
-
-    -- Use the information from 'wallets'
-    pure $ map lookupWallet $ _preprodWallets ctx
 
 fixtureShelleyWallet
     :: (HasCallStack, MonadUnliftIO m)

--- a/lib/integration/framework/Test/Integration/Framework/Preprod.hs
+++ b/lib/integration/framework/Test/Integration/Framework/Preprod.hs
@@ -1,0 +1,188 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Integration.Framework.Preprod
+    ( PreprodSetupLog(..)
+    , setupPreprodWallets
+    , fixturePreprodWallets
+    ) where
+
+import Prelude
+
+import qualified Cardano.Wallet.Api.Link as Link
+import qualified Data.Map as Map
+import qualified Network.HTTP.Types.Status as HTTP
+
+import Cardano.Mnemonic
+    ( SomeMnemonic (..)
+    , mnemonicToText
+    )
+import Cardano.Wallet.Api.Types
+    ( ApiNetworkInformation
+    , ApiWallet
+    , WalletStyle (..)
+    , getApiT
+    )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncProgress (..)
+    )
+import Cardano.Wallet.Primitive.Types
+    ( WalletId (..)
+    )
+import Control.Monad
+    ( unless
+    , void
+    )
+import Control.Monad.IO.Unlift
+    ( MonadUnliftIO
+    )
+import Control.Retry
+    ( RetryStatus
+    , capDelay
+    , fibonacciBackoff
+    , retrying
+    )
+import Control.Tracer
+    ( Tracer
+    , traceWith
+    )
+import Data.Aeson.QQ
+    ( aesonQQ
+    )
+import Data.Generics.Internal.VL.Lens
+    ( view
+    , (^.)
+    )
+import Data.Generics.Labels
+    ()
+import Data.Map
+    ( Map
+    )
+import Data.Maybe
+    ( fromMaybe
+    )
+import GHC.Stack
+    ( HasCallStack
+    )
+import Test.Hspec.Expectations.Lifted
+    ( expectationFailure
+    , shouldBe
+    , shouldContain
+    )
+import Test.Integration.Framework.Context
+    ( Context (..)
+    )
+import Test.Integration.Framework.DSL
+    ( Headers (Default)
+    , Payload (Empty, Json)
+    , eventuallyUsingDelay
+    , fixturePassphrase
+    , getResponse
+    , oneSecond
+    )
+import Test.Integration.Framework.Request
+    ( RequestException
+    , request
+    )
+
+data PreprodSetupLog
+    = WaitingForNodeConnection
+    | CreatingWallets
+    | WaitingForWalletsToSync
+    | PreprodSetupReady
+
+setupPreprodWallets :: Tracer IO PreprodSetupLog -> [SomeMnemonic] -> Context -> IO Context
+setupPreprodWallets tr mnemonics ctx = do
+    traceWith tr WaitingForNodeConnection
+    waitForConnection
+
+    traceWith tr CreatingWallets
+    createWalletsIfNeeded mnemonics
+
+    wallets <- getResponse <$> request @[ApiWallet] ctx
+        (Link.listWallets @'Shelley) Default Empty
+    unless (length wallets == length mnemonics) $
+        expectationFailure $ unwords
+            [ "Setup error: have", show (length mnemonics), "mnemonics but only"
+            , show wallets, "have now been created."
+            ]
+
+    let walletIds = map (getApiT . view #id) wallets
+
+    traceWith tr WaitingForWalletsToSync
+    waitForAllWalletsToSync
+    traceWith tr PreprodSetupReady
+
+    pure ctx{ _preprodWallets = walletIds }
+  where
+    createWalletsIfNeeded :: [SomeMnemonic] -> IO ()
+    createWalletsIfNeeded = mapM_ createWalletIfNeeded
+
+    createWalletIfNeeded :: SomeMnemonic -> IO ()
+    createWalletIfNeeded (SomeMnemonic mnemonic) = do
+        (s, response) <- request @ApiWallet ctx (Link.postWallet @'Shelley) Default $ Json
+            [aesonQQ| {
+                "name": "Faucet Wallet",
+                "mnemonic_sentence": #{mnemonicToText mnemonic},
+                "passphrase": #{fixturePassphrase}
+            } |]
+        case response of
+            Right _ | s == HTTP.status201 -> pure ()
+            Left e | s == HTTP.status409 -> show e `shouldContain` "wallet_already_exists"
+            _ -> expectationFailure $ unwords
+                [ "setupPreprodWallets, createWalletsIfNeeded: unexpected response"
+                , show (s, response)
+                ]
+
+    waitForConnection :: IO ()
+    waitForConnection = void $ retrying
+        (capDelay (30*oneSecond) $ fibonacciBackoff oneSecond)
+        shouldWait
+        (\_retryStatus -> request @ApiNetworkInformation ctx
+          Link.getNetworkInfo Default Empty)
+      where
+        shouldWait
+            :: RetryStatus
+            -> (HTTP.Status, Either RequestException ApiNetworkInformation)
+            -> IO Bool
+        shouldWait _ (_, Right info) = pure $ info ^. #syncProgress . #getApiT <= NotResponding
+        shouldWait _ (_, Left _err) = pure True
+
+    waitForAllWalletsToSync :: IO ()
+    waitForAllWalletsToSync = do
+        eventuallyUsingDelay (5 * s) (90 * minutes) "setupPreprodWallets: all wallets are synced" $ do
+            wallets :: [ApiWallet] <- getResponse <$> request @[ApiWallet] ctx
+                (Link.listWallets @'Shelley) Default Empty
+            let progress = map (getApiT . view #state) wallets
+            all (== Ready) progress `shouldBe` True
+      where
+        s = 1_000_000
+        minutes = 60
+
+fixturePreprodWallets :: (HasCallStack, MonadUnliftIO m) => Context -> m [ApiWallet]
+fixturePreprodWallets ctx = do
+    wallets <- getResponse <$> request @[ApiWallet] ctx
+        (Link.listWallets @'Shelley) Default Empty
+
+    let keyByWalletId :: ApiWallet -> (WalletId, ApiWallet)
+        keyByWalletId w = (getApiT $ w ^. #id, w)
+
+        walletsById :: Map WalletId ApiWallet
+        walletsById = Map.fromList $ map keyByWalletId wallets
+
+        lookupWallet :: WalletId -> ApiWallet
+        lookupWallet wid = fromMaybe err $ Map.lookup wid walletsById
+          where
+            err = error $ unwords
+                [ "fixturePreprodWallets: expected", show wid, "to be an"
+                , "existing wallet. The wallets that could be found are:\n\n"
+                ] ++ unlines (map show wallets)
+
+    -- Use the information from 'wallets'
+    pure $ map lookupWallet $ _preprodWallets ctx

--- a/lib/integration/scenarios/Test/Integration/Scenario/Preprod.hs
+++ b/lib/integration/scenarios/Test/Integration/Scenario/Preprod.hs
@@ -90,7 +90,6 @@ import Test.Integration.Framework.DSL
     , expectResponseCode
     , expectSuccess
     , fixturePassphrase
-    , fixturePreprodWallets
     , getFromResponse
     , getResponse
     , json
@@ -98,6 +97,9 @@ import Test.Integration.Framework.DSL
     , request
     , verify
     , (.<)
+    )
+import Test.Integration.Framework.Preprod
+    ( fixturePreprodWallets
     )
 
 spec :: forall n . HasSNetworkId n => SpecWith Context


### PR DESCRIPTION
- [x] Factor out separate `Framework.Preprod` module from `.DSL` (ℹ️ view commit-per commit)
- [x] Assert wallets are funded; fail with addrs if not


<img width="1038" alt="Skärmavbild 2025-02-12 kl  17 13 35" src="https://github.com/user-attachments/assets/8317216b-d94f-438a-a217-d51882cafa9c" />

### Issue Number

Follow-up to #4977
