### PR TITLE
Update mithril version following security advisory

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1547,16 +1547,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1733844450,
-        "narHash": "sha256-jT3sjtACWtiS1agD8XR6EKz73YpL0QelIS4RcBJy3F8=",
+        "lastModified": 1739196933,
+        "narHash": "sha256-CIDPUNYUMyQupIQzKCIwvP4S4BJvyidy6dVSL5kS+XQ=",
         "owner": "input-output-hk",
         "repo": "mithril",
-        "rev": "c6c7ebafae0158b2c1672eb96f6ef832fd542f93",
+        "rev": "2627f17b83be844151b254ac21b8cff6c6a97364",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "2450.0",
+        "ref": "2506.0",
         "repo": "mithril",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -116,7 +116,7 @@
     };
     customConfig.url = "github:input-output-hk/empty-flake";
     cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.1.4";
-    mithril.url = "github:input-output-hk/mithril?ref=2450.0";
+    mithril.url = "github:input-output-hk/mithril?ref=2506.0";
   };
 
   outputs = { self, nixpkgs, nixpkgs-unstable, hostNixpkgs, flake-utils,

--- a/run/common/nix/run.sh
+++ b/run/common/nix/run.sh
@@ -77,7 +77,7 @@ cleanup() {
 mithril() {
     # shellcheck disable=SC2048
     # shellcheck disable=SC2086
-    nix shell "github:input-output-hk/mithril?ref=2450.0" -c $*
+    nix shell "github:input-output-hk/mithril?ref=2506.0" -c $*
 }
 
 # Trap the cleanup function on exit

--- a/run/common/nix/snapshot.sh
+++ b/run/common/nix/snapshot.sh
@@ -2,7 +2,7 @@
 # shellcheck shell=bash
 
 function mithril() {
-    nix shell 'github:input-output-hk/mithril?ref=2450.0' --command mithril-client $@
+    nix shell 'github:input-output-hk/mithril?ref=2506.0' --command mithril-client $@
 }
 
 function jq() {

--- a/run/mainnet/docker/docker-compose.yml
+++ b/run/mainnet/docker/docker-compose.yml
@@ -49,7 +49,7 @@ services:
   mithril:
     env_file:
       - .env
-    image: ghcr.io/input-output-hk/mithril-client:2450.0-c6c7eba
+    image: ghcr.io/input-output-hk/mithril-client:2506.0-2627f17
     user: ${USER_ID}:${GROUP_ID}
     volumes:
       - ${NODE_DB}:/app/db

--- a/scripts/buildkite/admin/refresh-preprod-snapshot.sh
+++ b/scripts/buildkite/admin/refresh-preprod-snapshot.sh
@@ -11,7 +11,7 @@ export GENESIS_VERIFICATION_KEY=5b3132372c37332c3132342c3136312c362c3133372c3133
 mithril() {
     # shellcheck disable=SC2048
     # shellcheck disable=SC2086
-    nix shell "github:input-output-hk/mithril" -c $*
+    nix shell "github:input-output-hk/mithril?ref=2506.0" -c $*
 }
 
 mithril echo "mithril is available" || exit 44


### PR DESCRIPTION
Mithril team published a security advisory, leading to version bumps. This PR uses fixed versions. Note that it does not update genesis verification key which is somewhat surprising but might be fine.

https://github.com/input-output-hk/mithril/security/advisories/GHSA-724h-fpm5-4qvr
