### PR TITLE
Add dependency constraints on `cardano-balance-tx`

### DIFF
--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -49,45 +49,45 @@ library internal
   hs-source-dirs:  lib/internal
   visibility:      public
   build-depends:
-    , base
-    , bytestring
-    , cardano-addresses
-    , cardano-api
+    , base >= 4.14 && < 5
+    , bytestring >= 0.10.6 && < 0.13
+    , cardano-addresses == 3.12.0
+    , cardano-api >= 10.1 && < 10.2
     , cardano-coin-selection
-    , cardano-crypto-class
+    , cardano-crypto-class >= 2.1.5.0 && < 2.2
     , cardano-ledger-allegra
     , cardano-ledger-alonzo
-    , cardano-ledger-api
+    , cardano-ledger-api >= 1.9.2.0 && < 1.10
     , cardano-ledger-babbage
     , cardano-ledger-binary
     , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-mary
     , cardano-ledger-shelley
-    , cardano-slotting
-    , cardano-strict-containers
+    , cardano-slotting >= 0.2 && < 0.3
+    , cardano-strict-containers >= 0.1.3.0 && < 0.2
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
-    , cborg
-    , containers
-    , deepseq
+    , cborg >= 0.2.1 && <0.3
+    , containers >= 0.5 && < 0.8
+    , deepseq >= 1.4.4 && < 1.6
     , either
-    , fmt
-    , generic-lens
-    , groups
-    , int-cast
-    , lens
-    , MonadRandom
-    , monoid-subclasses
-    , nonempty-containers
-    , ouroboros-consensus
+    , fmt >= 0.6.3 && < 0.7
+    , generic-lens >= 2.2.2.0 && < 2.3
+    , groups >= 0.5.3 && < 0.6
+    , int-cast >= 0.2.0.0 && < 0.3
+    , lens >= 5.2.3 && < 5.4
+    , MonadRandom >= 0.6 && < 0.7
+    , monoid-subclasses >= 1.2.5.1 && < 1.3
+    , nonempty-containers >= 0.3.4.5 && < 0.4
+    , ouroboros-consensus >= 0.20.0.0 && < 0.22.0.0
     , ouroboros-consensus-cardano
-    , pretty-simple
-    , QuickCheck
-    , serialise
+    , pretty-simple >= 4.1.2.0 && < 4.2
+    , QuickCheck >= 2.14 && <= 2.16
+    , serialise >= 0.2.6.1 && < 0.3
     , std-gen-seed
-    , text
-    , transformers
+    , text >= 1.2 && < 2.2
+    , transformers >= 0.6.1.0 && < 0.7
   exposed-modules:
     Internal.Cardano.Write.Eras
     Internal.Cardano.Write.Tx
@@ -118,13 +118,13 @@ test-suite test
     , cardano-api
     , cardano-api-extra
     , cardano-balance-tx:internal
-    , cardano-binary
+    , cardano-binary == 1.7.1.0
     , cardano-coin-selection
-    , cardano-crypto
+    , cardano-crypto >= 1.1.2 && < 1.2
     , cardano-crypto-class
-    , cardano-crypto-wrapper
+    , cardano-crypto-wrapper == 1.5.1.3
     , cardano-ledger-alonzo
-    , cardano-ledger-alonzo-test
+    , cardano-ledger-alonzo-test >= 1.3.0 && < 1.4
     , cardano-ledger-api
     , cardano-ledger-babbage:{cardano-ledger-babbage, testlib}
     , cardano-ledger-byron
@@ -141,16 +141,16 @@ test-suite test
     , cardano-wallet-test-utils
     , cborg
     , containers
-    , data-default
-    , directory
-    , filepath
-    , fmt
+    , data-default >= 0.7.1.1 && < 0.8
+    , directory >= 1.3.8 && < 1.4
+    , filepath >= 1.4.300.1 && < 1.6
+    , fmt >= 0.6.3.0 && < 0.7
     , generic-lens
-    , generics-sop
+    , generics-sop >= 0.5.1.4 && < 0.6
     , groups
-    , hspec
+    , hspec >= 2.11.0 && < 2.12
     , hspec-core
-    , hspec-golden
+    , hspec-golden >= 0.2.2 && < 0.3
     , int-cast
     , lens
     , MonadRandom
@@ -159,14 +159,14 @@ test-suite test
     , ouroboros-consensus
     , ouroboros-consensus-cardano
     , ouroboros-network-api
-    , QuickCheck
-    , quickcheck-classes
-    , sop-extras
+    , QuickCheck >= 2.14 && < 2.16
+    , quickcheck-classes >= 0.6.5 && < 0.7
+    , sop-extras >= 0.2.1 && < 0.3
     , std-gen-seed
     , text
-    , time
+    , time >= 1.12.2 && < 1.15
     , transformers
-    , with-utf8
+    , with-utf8 >= 1.1.0 && < 1.2 
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:
     Internal.Cardano.Write.Tx.Balance.CoinSelectionSpec

--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -71,7 +71,6 @@ library internal
     , cborg >= 0.2.1 && <0.3
     , containers >= 0.5 && < 0.8
     , deepseq >= 1.4.4 && < 1.6
-    , either
     , fmt >= 0.6.3 && < 0.7
     , generic-lens >= 2.2.2.0 && < 2.3
     , groups >= 0.5.3 && < 0.6

--- a/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/TxWithUTxO.hs
+++ b/lib/balance-tx/lib/internal/Internal/Cardano/Write/Tx/TxWithUTxO.hs
@@ -33,9 +33,6 @@ import Control.Lens
     ( over
     , view
     )
-import Data.Either.Combinators
-    ( maybeToLeft
-    )
 import Data.Maybe
     ( fromMaybe
     )
@@ -91,7 +88,7 @@ construct
     -> UTxO era
     -> Either (NESet TxIn) (TxWithUTxO era)
 construct tx utxo =
-    maybeToLeft txWithUTxO (unresolvableInputs txWithUTxO)
+    maybe (Right txWithUTxO) Left (unresolvableInputs txWithUTxO)
   where
     txWithUTxO = UnsafeTxWithUTxO tx utxo
 


### PR DESCRIPTION
This pull request adds dependency constraints to the `cardano-balance-tx` package, as this package is a likely target for releasing on CHaP.

We also remove the direct dependency on the `either` package, because it's easy.