### PR TITLE
Add dependency constraints on `cardano-coin-selection`

### DIFF
--- a/lib/coin-selection/cardano-coin-selection.cabal
+++ b/lib/coin-selection/cardano-coin-selection.cabal
@@ -39,24 +39,24 @@ library
   hs-source-dirs:  lib
 
   build-depends:
-    , base
+    , base >= 4.14 && < 5
     , cardano-numeric
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
-    , containers
-    , deepseq
-    , exact-combinatorics
+    , containers >= 0.5 && < 0.8
+    , deepseq >= 1.4.4 && < 1.6
+    , exact-combinatorics >= 0.2 && < 0.3
     , extra
-    , generic-lens
-    , generics-sop
-    , int-cast
-    , lattices
-    , math-functions
-    , MonadRandom
-    , monoid-subclasses
-    , monoidmap
-    , QuickCheck
-    , transformers
+    , generic-lens >= 2.2.2.0 && < 2.3
+    , generics-sop >= 0.5.1.4 && < 0.6
+    , int-cast >= 0.2.0.0 && < 0.3
+    , lattices >= 2.2 && < 2.3
+    , math-functions >= 0.3.4.4 && < 0.4
+    , MonadRandom >= 0.6 && < 0.7
+    , monoid-subclasses >= 1.2.5.1 && < 1.3
+    , monoidmap >= 0.0.1.6 && < 0.1
+    , QuickCheck >= 2.14 && < 2.16
+    , transformers >= 0.6.1.0 && < 0.7
 
   exposed-modules:
     Cardano.CoinSelection
@@ -79,29 +79,29 @@ test-suite test
   main-is:            run-test-suite.hs
   build-depends:
     , base
-    , bytestring
+    , bytestring >= 0.10.6 && < 0.13
     , cardano-coin-selection
     , cardano-numeric
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
     , containers
-    , fmt
+    , fmt >= 0.6.3 && < 0.7
     , generic-lens
     , generics-sop
-    , hspec
+    , hspec >= 2.11.0 && < 2.12
     , hspec-core
     , int-cast
     , lattices
     , MonadRandom
     , monoid-subclasses
-    , pretty-simple
+    , pretty-simple >= 4.1.2.0 && < 4.2
     , QuickCheck
-    , quickcheck-classes
-    , quickcheck-quid
-    , safe
-    , text
-    , transformers
-    , with-utf8
+    , quickcheck-classes >= 0.6.5 && < 0.7
+    , quickcheck-quid >= 0.0.1.5 && < 0.1
+    , safe >= 0.3.19 && < 0.4
+    , text >= 1.2 && < 2.2
+    , transformers >= 0.6.1.0 && < 0.7
+    , with-utf8 >= 1.1.0 && < 1.2 
   build-tool-depends: hspec-discover:hspec-discover
   other-modules:
     Cardano.CoinSelection.BalanceSpec
@@ -128,7 +128,7 @@ benchmark utxo-index
       , cardano-wallet-test-utils
       , containers
       , deepseq
-      , format-numbers
+      , format-numbers >= 0.1.0.1 && < 0.2
       , QuickCheck
-      , tasty-bench
+      , tasty-bench >= 0.4 && < 0.5
       , text

--- a/lib/coin-selection/cardano-coin-selection.cabal
+++ b/lib/coin-selection/cardano-coin-selection.cabal
@@ -46,7 +46,6 @@ library
     , containers >= 0.5 && < 0.8
     , deepseq >= 1.4.4 && < 1.6
     , exact-combinatorics >= 0.2 && < 0.3
-    , extra
     , generic-lens >= 2.2.2.0 && < 2.3
     , generics-sop >= 0.5.1.4 && < 0.6
     , int-cast >= 0.2.0.0 && < 0.3

--- a/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
+++ b/lib/coin-selection/lib/Cardano/CoinSelection/UTxOIndex/Internal.hs
@@ -111,9 +111,6 @@ import Prelude hiding
 import Control.DeepSeq
     ( NFData
     )
-import Control.Monad.Extra
-    ( firstJustM
-    )
 import Control.Monad.Random.Class
     ( MonadRandom (..)
     )
@@ -497,6 +494,10 @@ selectRandomWithPriority
     -> m (Maybe ((u, W.TokenBundle), UTxOIndex u))
 selectRandomWithPriority i =
     firstJustM (selectRandom i) . NE.toList
+  where
+    firstJustM _ [] = pure Nothing
+    firstJustM p (x:xs) =
+        maybe (firstJustM p xs) (pure . Just) =<< p x
 
 --------------------------------------------------------------------------------
 -- Internal Interface


### PR DESCRIPTION
This pull request adds dependency constraints to the `cardano-coin-selection` package, as this package is a likely target for releasing on CHaP.

We also remove the direct dependency on the `extra` package, because it's easy.