### PR TITLE
Add dependency constraints on `local-cluster`

### DIFF
--- a/lib/local-cluster/lib/Cardano/Wallet/Faucet.hs
+++ b/lib/local-cluster/lib/Cardano/Wallet/Faucet.hs
@@ -116,9 +116,6 @@ import Control.Concurrent
 import Control.Exception
     ( throwIO
     )
-import Control.Monad.Extra
-    ( concatMapM
-    )
 import Control.Monad.IO.Class
     ( liftIO
     )
@@ -130,9 +127,6 @@ import Data.Functor
     )
 import Data.List
     ( unfoldr
-    )
-import Data.Tuple.Extra
-    ( dupe
     )
 import Numeric.Natural
     ( Natural
@@ -263,7 +257,7 @@ anyFunds mnemonicRange mlength style start end networkTag= FaucetM $ do
                     end
             pure $ ias <&> \ia ->
                 (unFaucetAddress . unIndexedAddress $ ia)
-    concatMapM run' $ enumRange mnemonicRange
+    concat <$> mapM run' (enumRange mnemonicRange)
 
 shelleyMnemonicRange :: MnemonicRange
 shelleyMnemonicRange = MnemonicRange 0 399
@@ -570,7 +564,7 @@ hwLedgerFunds networkTag = do
         addrXPrv = deriveAddressPrivateKey accXPrv Icarus.UTxOExternal
         paymentKeyIxs :: [Index (AddressIndexDerivationType Icarus) PaymentK] =
             let firstIx = minBound
-            in  firstIx : unfoldr (fmap dupe . nextIndex) firstIx
+            in  firstIx : unfoldr (fmap (\x -> (x, x)) . nextIndex) firstIx
 
 massiveWalletRange :: MnemonicRange
 massiveWalletRange = nextRange 1 preregKeyWalletRange

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -98,70 +98,73 @@ library
 
   build-depends:
     , address-derivation-discovery
-    , aeson
-    , aeson-pretty
-    , base
-    , base58-bytestring
-    , bytestring
-    , cardano-addresses
-    , cardano-api
-    , cardano-binary
-    , cardano-cli
-    , cardano-data
-    , cardano-ledger-api
+    , aeson >= 2.2 && < 2.3
+    , aeson-pretty >= 0.8.10 && < 0.9
+    , base >= 4.14 && < 5
+    , base58-bytestring >= 0.1 && < 0.2
+    , bytestring >= 0.10.6 && < 0.13
+    , cardano-addresses == 3.12.0
+    , cardano-api >= 10.1 && < 10.2
+    , cardano-binary == 1.7.1.0
+    , cardano-cli >= 10.1 && < 10.2
+    , cardano-data >= 1.2.3.1 && < 1.3
+    , cardano-ledger-api >= 1.9.2.0 && < 1.10
     , cardano-ledger-core
     , cardano-ledger-shelley
     , cardano-wallet-application-extras
     , cardano-wallet-launcher
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
-    , cborg
-    , comonad
-    , containers
-    , contra-tracer
+    , cborg >= 0.2.1 && < 0.3
+    -- comonad is used by foldl
+    , comonad >=4.0 && < 6
+    , containers >= 0.5 && < 0.8
+    , contra-tracer >= 0.1 && < 0.3
     , crypto-primitives
-    , directory
+    , directory >= 1.3.8 && < 1.4
     , extra
     , faucet
-    , filepath
-    , foldl
-    , generic-lens
-    , hkd
-    , http-client
-    , http-media
-    , insert-ordered-containers
-    , int-cast
-    , io-classes
-    , iohk-monitoring
+    , filepath >= 1.4.300.1 && < 1.6
+    , foldl >= 1.4.17 && < 1.5
+    , generic-lens >= 2.2.2.0 && < 2.3
+    , hkd >= 0.2.1 && < 0.3
+    , http-client >= 0.7.17 && < 0.8
+    , http-media >= 0.8.1.1 && < 0.9
+    -- insert-ordered-containers is used by openapi3
+    , insert-ordered-containers >=0.2.3 && < 0.3
+    , int-cast >= 0.2.0.0 && < 0.3
+    , io-classes >= 1.0 && < 1.8
+    , iohk-monitoring >= 0.2 && < 0.3
     , iohk-monitoring-extra
-    , lens
-    , lens-aeson
-    , machines
-    , memory
-    , mtl
-    , network
-    , OddWord
+    , lens >= 5.2.3 && < 5.4
+    , lens-aeson >= 1.2.3 && < 1.3
+    , machines >= 0.7.3 && < 0.8
+    , memory >= 0.18.0 && < 0.19
+    , mtl >= 2.3.1 && < 2.4
+    , network >= 3.1.2.5 && < 3.2
+    , OddWord >= 1.0.1.1 && < 1.1
     , openapi3
-    , optparse-applicative
+    , optparse-applicative >= 0.18.1.0 && < 0.19
     , ouroboros-network
-    , ouroboros-network-api
-    , pathtype
-    , profunctors
-    , QuickCheck
-    , retry
-    , servant
-    , servant-client
-    , servant-server
-    , tagged
-    , temporary
+    , ouroboros-network-api == 0.10.0.0
+    , pathtype >= 0.8.1.3 && < 0.9
+    , profunctors >= 5.6.2 && < 5.7
+    , QuickCheck >= 2.14 && < 2.16
+    , retry >= 0.9.3 && < 0.10
+    , servant >= 0.20.2 && < 0.21
+    , servant-client >= 0.20.2 && < 0.21
+    , servant-server >= 0.20.2 && < 0.21
+    , tagged >= 0.8.8 && < 0.9
+    , temporary >= 1.3 && < 1.4
     , temporary-extra
-    , text
+    , text >= 1.2 && < 2.2
     , text-class
-    , time
-    , typed-process
-    , unliftio
-    , warp
-    , yaml
+    , time >= 1.12.2 && < 1.15
+    , typed-process >= 0.2.12.0 && < 0.3
+    , unliftio >= 0.2.25 && < 0.3
+    -- newer versions of warp depend on crypton
+    , warp >= 3.3.25 && < 3.3.26
+    , yaml >= 0.11.7 && < 0.12
 
 library local-cluster-process
   import:          language
@@ -179,7 +182,7 @@ library local-cluster-process
     , cardano-wallet-primitive
     , contra-tracer
     , directory
-    , extra
+    , extra >= 1.7.16 && < 1.9
     , filepath
     , iohk-monitoring-extra
     , local-cluster
@@ -202,17 +205,17 @@ executable local-cluster
     , cardano-wallet-primitive
     , contra-tracer
     , directory
-    , extra
+    , extra >= 1.7.16 && < 1.9
     , iohk-monitoring-extra
     , lens
     , local-cluster
     , mtl
     , pathtype
-    , pretty-simple
+    , pretty-simple >= 4.1.2.0 && < 4.2
     , temporary-extra
     , text
     , unliftio
-    , with-utf8
+    , with-utf8 >= 1.1.0 && < 1.2 
 
 common test-common
   import:             language
@@ -221,7 +224,7 @@ common test-common
   build-depends:
     , aeson
     , aeson-pretty
-    , aeson-qq
+    , aeson-qq >= 0.8.4 && < 0.9
     , base
     , bytestring
     , cardano-addresses
@@ -239,23 +242,23 @@ common test-common
     , cardano-wallet-test-utils
     , containers
     , contra-tracer
-    , extra
+    , extra >= 1.7.16 && < 1.9
     , foldl
-    , hspec
-    , hspec-golden
+    , hspec >= 2.11.0 && < 2.12
+    , hspec-golden >= 0.2.2 && < 0.3
     , iohk-monitoring-extra
     , local-cluster
     , local-cluster:local-cluster-process
     , mtl
     , openapi3
-    , ouroboros-consensus-cardano
-    , ouroboros-network
+    , ouroboros-consensus-cardano >= 0.20 && < 0.21
+    , ouroboros-network >= 0.17 && < 0.18
     , pathtype
     , QuickCheck
-    , streaming
+    , streaming >= 0.2.4 && < 0.3
     , time
     , unliftio
-    , with-utf8
+    , with-utf8 >= 1.1.0 && < 1.2 
 
   build-tool-depends: hspec-discover:hspec-discover
 

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -122,7 +122,6 @@ library
     , contra-tracer >= 0.1 && < 0.3
     , crypto-primitives
     , directory >= 1.3.8 && < 1.4
-    , extra
     , faucet
     , filepath >= 1.4.300.1 && < 1.6
     , foldl >= 1.4.17 && < 1.5

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -143,7 +143,9 @@ library
     , mtl >= 2.3.1 && < 2.4
     , network >= 3.1.2.5 && < 3.2
     , OddWord >= 1.0.1.1 && < 1.1
-    , openapi3
+    -- openapi3 requires a fork https://github.com/paolino/openapi3
+    -- commit f22c31611c295637a3e72b341cd1c56d1d87b993
+    , openapi3 >= 3.2.3 && < 3.3
     , optparse-applicative >= 0.18.1.0 && < 0.19
     , ouroboros-network
     , ouroboros-network-api == 0.10.0.0


### PR DESCRIPTION
This pull request adds dependency constraints to the `local-cluster` package, as this package is a likely target for releasing on CHaP.

Where appropriate, we also remove the direct dependency on the following packages

* `extra`

because these dependencies do not cross the [Fairbairn threshold](https://wiki.haskell.org/Fairbairn_threshold).

### Issues

#4958
