### PR TITLE
Move to new e2e tests on macOS

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -136,7 +136,7 @@ steps:
       agents:
         system: ${linux}
       concurrency: 1
-      concurrency_group: 'ruby-e2e-tests'
+      concurrency_group: 'linux-e2e-tests'
 
     - label: Preview Network Boot Sync
       timeout_in_minutes: 10

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -491,19 +491,17 @@ steps:
       concurrency: 3
       concurrency_group: 'macos-integration-tests'
 
-    - block: MacOS Ruby E2E Tests
+    - block: MacOS E2E Tests
       if: build.env("RELEASE_CANDIDATE") == null || build.env("TEST_RC") == "TRUE"
       depends_on: []
       key: macos-e2e-tests-block
 
-    - label: 'Run Ruby E2E Tests (macOS, arm64)'
+    - label: 'Run E2E Tests (macOS, arm64)'
       key: macos-silicon-e2e
       depends_on:
         - macos-e2e-tests-block
       commands: |
-        nix shell 'nixpkgs#just' -c just ruby-e2e-macos
-      artifact_paths:
-        - "./logs/**/*"
+        nix shell 'nixpkgs#just' -c just e2e
       agents:
         system: ${macos}
       concurrency: 1

--- a/lib/integration/cardano-wallet-integration.cabal
+++ b/lib/integration/cardano-wallet-integration.cabal
@@ -233,6 +233,7 @@ test-suite e2e
     , bytestring
     , cardano-addresses
     , cardano-wallet-api
+    , cardano-wallet-application-extras
     , cardano-wallet-exe
     , cardano-wallet-integration:framework
     , cardano-wallet-launcher

--- a/lib/integration/exe/e2e.hs
+++ b/lib/integration/exe/e2e.hs
@@ -42,6 +42,9 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Application.CLI
     ( Port (..)
     )
+import Cardano.Wallet.Network.Ports
+    ( getRandomPort
+    )
 import Cardano.Wallet.Primitive.NetworkId
     ( NetworkDiscriminant (Testnet)
     )
@@ -203,9 +206,10 @@ configureContext (E2EConfig preprodMnemonics alreadyRunningWallet) action =
                     }
 
         withCardanoNode nullTracer nodeConfig $ \(JustK node) -> do
+            walletPort <- getRandomPort
             let walletConfig =
                     CardanoWalletConfig
-                        { walletPort = 8090
+                        { walletPort = walletPort
                         , walletDatabaseDir = "wallet-db"
                         , walletNetwork = Launcher.Testnet "byron-genesis.json"
                         , executable = Nothing
@@ -213,8 +217,8 @@ configureContext (E2EConfig preprodMnemonics alreadyRunningWallet) action =
                         , extraArgs = []
                         }
             withCardanoWallet nullTracer node walletConfig
-                $ \(CardanoWalletConn walletPort _)  -> do
-                    action =<< contextFromWalletPort walletPort
+                $ \(CardanoWalletConn walletPort' _)  -> do
+                    action =<< contextFromWalletPort walletPort'
 
     contextFromWalletPort :: PortNumber -> IO Context
     contextFromWalletPort walletPort = do

--- a/lib/launcher/src/Cardano/Launcher/Mithril.hs
+++ b/lib/launcher/src/Cardano/Launcher/Mithril.hs
@@ -87,6 +87,7 @@ downloadMithril workingDir = withCurrentDirectory workingDir $ do
         osArch :: String
         osArch = case arch of
             "x86_64" -> "x64"
+            "aarch64" -> "arm64"
             other -> other
 
     version       = "2450.0"


### PR DESCRIPTION
- **Switch macOS to new Haskell e2e tests**
- **Rename concurrency group**

### Comments

With this PR, the ruby e2e tests are no longer run, and may be deleted in a future PR.

In my investigation in https://github.com/cardano-foundation/cardano-wallet/issues/4980#issuecomment-2684252738 I found no signs that deleting the ruby e2e tests now would lead to a particularly great loss of test coverage. I found a few things that **could** be "nice to preserve", but we can optionally deal with them later.

### Issue Number

fixes #5002

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
