### PR TITLE
Add dependency constraints on `launcher`

### DIFF
--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -29,22 +29,21 @@ library
     ghc-options:
       -Werror
   build-depends:
-      base
-    , bytestring
-    , contra-tracer
-    , directory
-    , either
+      base >= 4.14 && < 5
+    , bytestring >= 0.10.6 && < 0.13
+    , contra-tracer >= 0.1 && < 0.3
+    , directory >= 1.3.8 && < 1.4
     , extra
-    , filepath
-    , fmt
-    , http-conduit
-    , iohk-monitoring
-    , network
-    , process
-    , text
+    , filepath >= 1.4.300.1 && < 1.6
+    , fmt >= 0.6.3.0 && < 0.7
+    , http-conduit >= 2.3.9 && < 2.4
+    , iohk-monitoring >= 0.2 && < 0.3
+    , network >= 3.1.2.5 && < 3.2
+    , process >= 1.6.19.0 && < 1.7
+    , text >= 1.2 && < 2.2
     , text-class
-    , unliftio
-    , unliftio-core
+    , unliftio >= 0.2.25 && < 0.3
+    , unliftio-core >= 0.1.1 && < 0.3
   hs-source-dirs:
       src
   exposed-modules:
@@ -80,15 +79,15 @@ test-suite unit
     , cardano-wallet-launcher
     , cardano-wallet-test-utils
     , contra-tracer
-    , fmt
-    , hspec
+    , fmt >= 0.6.3.0 && < 0.7
+    , hspec >= 2.11.0 && < 2.12
     , hspec-core
-    , hspec-expectations
+    , hspec-expectations >= 0.8.4 && < 0.9
     , iohk-monitoring
-    , retry
+    , retry >= 0.9.3 && < 0.10
     , text
     , text-class
-    , time
+    , time >= 1.12.2 && < 1.15
     , unliftio
   build-tool-depends:
       hspec-discover:hspec-discover

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -33,7 +33,6 @@ library
     , bytestring >= 0.10.6 && < 0.13
     , contra-tracer >= 0.1 && < 0.3
     , directory >= 1.3.8 && < 1.4
-    , extra
     , filepath >= 1.4.300.1 && < 1.6
     , fmt >= 0.6.3.0 && < 0.7
     , http-conduit >= 2.3.9 && < 2.4

--- a/lib/launcher/src/Cardano/Launcher.hs
+++ b/lib/launcher/src/Cardano/Launcher.hs
@@ -56,9 +56,6 @@ import Control.Tracer
     , contramap
     , traceWith
     )
-import Data.Either.Combinators
-    ( leftToMaybe
-    )
 import Data.List
     ( isPrefixOf
     )
@@ -291,7 +288,7 @@ withBackendCreateProcess tr process mTimeoutSecs ifToSendSigINT action = do
                     (traceWith tr' MsgLauncherActionDone)
                     (action $ ProcessHandles mstdin mstdout mstderr ph)
 
-    traceWith tr $ MsgLauncherFinish (leftToMaybe res)
+    traceWith tr $ MsgLauncherFinish $ either Just (const Nothing) res
     either throwIO pure res
   where
     -- Exceptions resulting from the @exec@ call for this command. The most

--- a/lib/launcher/src/Cardano/Launcher/Mithril.hs
+++ b/lib/launcher/src/Cardano/Launcher/Mithril.hs
@@ -11,8 +11,8 @@ import Prelude
 
 import qualified Data.ByteString as BS
 
-import Control.Monad.Extra
-    ( unlessM
+import Control.Monad
+    ( unless
     )
 import Network.HTTP.Simple
     ( getResponseBody
@@ -63,7 +63,8 @@ downloadMithril workingDir = withCurrentDirectory workingDir $ do
     callProcess "tar" ["xf", mithrilTar]
 
     let clientPath = workingDir </> ("mithril-client" <> if isWindows then ".exe" else "")
-    unlessM (doesFileExist clientPath) $
+    mithrilClientExists <- doesFileExist clientPath
+    unless mithrilClientExists $
         fail $ unwords
             [ "downloadLatest: didn't find"
             , clientPath

--- a/lib/launcher/src/Cardano/Startup.hs
+++ b/lib/launcher/src/Cardano/Startup.hs
@@ -39,9 +39,6 @@ import Control.Tracer
     ( Tracer
     , traceWith
     )
-import Data.Either.Extra
-    ( eitherToMaybe
-    )
 import Data.Text.Class
     ( ToText (..)
     )
@@ -104,7 +101,7 @@ withShutdownHandler' tr h action = do
     enabled <- hIsOpen h
     traceWith tr $ MsgShutdownHandler enabled
     let with
-            | enabled = fmap eitherToMaybe . race readerLoop
+            | enabled = fmap (either (const Nothing) Just) . race readerLoop
             | otherwise = fmap Just
     with action
   where


### PR DESCRIPTION
This pull request adds dependency constraints to the `launcher` package, as this package is a likely target for releasing on CHaP.

Where appropriate, we also remove the direct dependency on the following packages

* `either`
* `extra`

because these dependencies do not cross the [Fairbairn threshold](https://wiki.haskell.org/Fairbairn_threshold).

### Issues

#4958