### PR TITLE
Fix artifacts retrieval in release pipeline

### DIFF
--- a/scripts/buildkite/release/push-artifacts.sh
+++ b/scripts/buildkite/release/push-artifacts.sh
@@ -2,7 +2,7 @@
 
 set -euox pipefail
 
-base_build=$(buildkite-agent meta-data get base-build)
+TRIGGERED_BY=$(buildkite-agent meta-data get base-build)
 NEW_GIT_TAG=$(buildkite-agent meta-data get release-version)
 TEST_RC=$(buildkite-agent meta-data get test-rc)
 

--- a/scripts/buildkite/release/push-artifacts.sh
+++ b/scripts/buildkite/release/push-artifacts.sh
@@ -16,10 +16,12 @@ else
     TAG=$NEW_GIT_TAG
 fi
 
-main_build=$(curl -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-    -X GET "https://api.buildkite.com/v2/builds" \
-    | jq ".[] | select(.meta_data.\"triggered-by\" == \"$base_build\")" \
-    | jq .number)
+select_last_build="last(.[] | select(.meta_data.\"triggered-by\" == \"$TRIGGERED_BY\") | .number)"
+
+main_build=$(curl -s -H "Authorization: Bearer $BUILDKITE_API_TOKEN"     \
+    -X GET "https://api.buildkite.com/v2/builds"     \
+    | jq  "$select_last_build"
+    )
 
 mkdir -p artifacts
 

--- a/scripts/buildkite/release/push-to-dockerhub.sh
+++ b/scripts/buildkite/release/push-to-dockerhub.sh
@@ -17,11 +17,13 @@ else
     TAG=$NEW_GIT_TAG
 fi
 
-main_build=$(curl -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-    -X GET "https://api.buildkite.com/v2/builds" \
-    | jq ".[] | select(.meta_data.\"triggered-by\" == \"$TRIGGERED_BY\")" \
-    | jq .number)
+select_last_build="last(.[] | select(.meta_data.\"triggered-by\" == \"$TRIGGERED_BY\") | .number)"
 
+main_build=$(curl -s -H "Authorization: Bearer $BUILDKITE_API_TOKEN"     \
+    -X GET "https://api.buildkite.com/v2/builds"     \
+    | jq  "$select_last_build"
+    )
+    
 mkdir -p artifacts
 
 repo="cardanofoundation/cardano-wallet"


### PR DESCRIPTION
### Changes

- Use `last` in jq pipeline to select only the last main build when looking for artifact on release pipeline

### Issues

#4991