### PR TITLE
Constrains all cardano lib dependencies via script

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -53,7 +53,7 @@ index-state: 2024-10-10T00:52:24Z
 
 index-state:
   , hackage.haskell.org 2024-10-10T00:52:24Z
-  , cardano-haskell-package 2025-01-07T17:42:00Z
+  , cardano-haskell-packages 2025-01-07T17:42:00Z
 
 packages:
   lib/address-derivation-discovery
@@ -190,7 +190,6 @@ constraints:
   -- Cardano Node dependencies:
   , io-classes == 1.5.0.0
   , io-classes -asserts
-
 
   , cardano-ledger-api == 1.9.4.0
 

--- a/lib/address-derivation-discovery/address-derivation-discovery.cabal
+++ b/lib/address-derivation-discovery/address-derivation-discovery.cabal
@@ -47,14 +47,14 @@ library
     , bech32-th
     , binary
     , bytestring
-    , cardano-addresses
-    , cardano-crypto
-    , cardano-crypto-class
-    , cardano-ledger-api
-    , cardano-ledger-byron
-    , cardano-ledger-core
-    , cardano-ledger-shelley
-    , cardano-slotting
+    , cardano-addresses >= 3.12.0 && < 3.13
+    , cardano-crypto >= 1.1.2 && < 1.2
+    , cardano-crypto-class >= 2.1.5.0 && < 2.2
+    , cardano-ledger-api >= 1.9.4.0 && < 1.10
+    , cardano-ledger-byron >= 1.0.1.0 && < 1.1
+    , cardano-ledger-core >= 1.15.0.0 && < 1.16
+    , cardano-ledger-shelley >= 1.14.1.0 && < 1.15
+    , cardano-slotting >= 0.2.0.0 && < 0.3
     , cardano-wallet-primitive
     , cardano-wallet-secrets
     , cborg
@@ -69,7 +69,7 @@ library
     , int-cast
     , lens
     , memory
-    , ouroboros-consensus-cardano
+    , ouroboros-consensus-cardano >= 0.20.0.0 && < 0.21
     , QuickCheck
     , quiet
     , random

--- a/lib/api/cardano-wallet-api.cabal
+++ b/lib/api/cardano-wallet-api.cabal
@@ -40,13 +40,13 @@ library
     , bech32-th
     , binary
     , bytestring
-    , cardano-addresses
-    , cardano-api:{cardano-api, internal}
+    , cardano-addresses >= 3.12.0 && < 3.13
+    , cardano-api:{cardano-api, internal} >= 10.1.0.0 && < 10.2
     , cardano-balance-tx:{cardano-balance-tx, internal}
-    , cardano-binary
-    , cardano-crypto
-    , cardano-ledger-api
-    , cardano-ledger-core
+    , cardano-binary >= 1.7.1.0 && < 1.8
+    , cardano-crypto >= 1.1.2 && < 1.2
+    , cardano-ledger-api >= 1.9.4.0 && < 1.10
+    , cardano-ledger-core >= 1.15.0.0 && < 1.16
     , cardano-wallet
     , cardano-wallet-launcher
     , cardano-wallet-network-layer
@@ -67,7 +67,7 @@ library
     , http-media
     , http-types
     , int-cast
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , memory
     , mtl
     , network-uri

--- a/lib/balance-tx/cardano-balance-tx.cabal
+++ b/lib/balance-tx/cardano-balance-tx.cabal
@@ -39,7 +39,7 @@ library
   hs-source-dirs:  lib/main
   build-depends:
     , cardano-balance-tx:internal
-    , cardano-ledger-api
+    , cardano-ledger-api >= 1.9.4.0 && < 1.10
   exposed-modules:
     Cardano.Write.Eras
     Cardano.Write.Tx
@@ -51,20 +51,20 @@ library internal
   build-depends:
     , base >= 4.14 && < 5
     , bytestring >= 0.10.6 && < 0.13
-    , cardano-addresses == 3.12.0
-    , cardano-api >= 10.1 && < 10.2
+    , cardano-addresses >= 3.12.0 && < 3.13
+    , cardano-api >= 10.1.0.0 && < 10.2
     , cardano-coin-selection
     , cardano-crypto-class >= 2.1.5.0 && < 2.2
-    , cardano-ledger-allegra
-    , cardano-ledger-alonzo
-    , cardano-ledger-api >= 1.9.2.0 && < 1.10
-    , cardano-ledger-babbage
+    , cardano-ledger-allegra >= 1.6.0.1 && < 1.7
+    , cardano-ledger-alonzo >= 1.11.0.0 && < 1.12
+    , cardano-ledger-api >= 1.9.4.0 && < 1.10
+    , cardano-ledger-babbage >= 1.10.0.0 && < 1.11
     , cardano-ledger-binary
-    , cardano-ledger-conway
-    , cardano-ledger-core
-    , cardano-ledger-mary
-    , cardano-ledger-shelley
-    , cardano-slotting >= 0.2 && < 0.3
+    , cardano-ledger-conway >= 1.17.3.0 && < 1.18
+    , cardano-ledger-core >= 1.15.0.0 && < 1.16
+    , cardano-ledger-mary >= 1.7.0.1 && < 1.8
+    , cardano-ledger-shelley >= 1.14.1.0 && < 1.15
+    , cardano-slotting >= 0.2.0.0 && < 0.3
     , cardano-strict-containers >= 0.1.3.0 && < 0.2
     , cardano-wallet-primitive
     , cardano-wallet-test-utils
@@ -79,8 +79,8 @@ library internal
     , MonadRandom >= 0.6 && < 0.7
     , monoid-subclasses >= 1.2.5.1 && < 1.3
     , nonempty-containers >= 0.3.4.5 && < 0.4
-    , ouroboros-consensus >= 0.20.0.0 && < 0.22.0.0
-    , ouroboros-consensus-cardano
+    , ouroboros-consensus >= 0.21.0.0 && < 0.22
+    , ouroboros-consensus-cardano >= 0.20.0.0 && < 0.21
     , pretty-simple >= 4.1.2.0 && < 4.2
     , QuickCheck >= 2.14 && <= 2.16
     , serialise >= 0.2.6.1 && < 0.3
@@ -113,28 +113,28 @@ test-suite test
     , address-derivation-discovery
     , base
     , bytestring
-    , cardano-addresses
-    , cardano-api
+    , cardano-addresses >= 3.12.0 && < 3.13
+    , cardano-api >= 10.1.0.0 && < 10.2
     , cardano-api-extra
     , cardano-balance-tx:internal
-    , cardano-binary == 1.7.1.0
+    , cardano-binary >= 1.7.1.0 && < 1.8
     , cardano-coin-selection
     , cardano-crypto >= 1.1.2 && < 1.2
-    , cardano-crypto-class
+    , cardano-crypto-class >= 2.1.5.0 && < 2.2
     , cardano-crypto-wrapper == 1.5.1.3
-    , cardano-ledger-alonzo
-    , cardano-ledger-alonzo-test >= 1.3.0 && < 1.4
-    , cardano-ledger-api
-    , cardano-ledger-babbage:{cardano-ledger-babbage, testlib}
-    , cardano-ledger-byron
-    , cardano-ledger-conway
-    , cardano-ledger-conway:testlib
-    , cardano-ledger-core
-    , cardano-ledger-mary:testlib
-    , cardano-ledger-shelley
+    , cardano-ledger-alonzo >= 1.11.0.0 && < 1.12
+    , cardano-ledger-alonzo-test >= 1.3.0.0 && < 1.4
+    , cardano-ledger-api >= 1.9.4.0 && < 1.10
+    , cardano-ledger-babbage:{cardano-ledger-babbage, testlib} >= 1.10.0.0 && < 1.11
+    , cardano-ledger-byron >= 1.0.1.0 && < 1.1
+    , cardano-ledger-conway >= 1.17.3.0 && < 1.18
+    , cardano-ledger-conway:testlib >= 1.17.3.0 && < 1.18
+    , cardano-ledger-core >= 1.15.0.0 && < 1.16
+    , cardano-ledger-mary:testlib >= 1.7.0.1 && < 1.8
+    , cardano-ledger-shelley >= 1.14.1.0 && < 1.15
     , cardano-numeric
-    , cardano-slotting
-    , cardano-strict-containers
+    , cardano-slotting >= 0.2.0.0 && < 0.3
+    , cardano-strict-containers >= 0.1.3.0 && < 0.2
     , cardano-wallet-primitive
     , cardano-wallet-secrets
     , cardano-wallet-test-utils
@@ -155,9 +155,9 @@ test-suite test
     , MonadRandom
     , monoid-subclasses
     , nonempty-containers
-    , ouroboros-consensus
-    , ouroboros-consensus-cardano
-    , ouroboros-network-api
+    , ouroboros-consensus >= 0.21.0.0 && < 0.22
+    , ouroboros-consensus-cardano >= 0.20.0.0 && < 0.21
+    , ouroboros-network-api >= 0.10.0.0 && < 0.11
     , QuickCheck >= 2.14 && < 2.16
     , quickcheck-classes >= 0.6.5 && < 0.7
     , sop-extras >= 0.2.1 && < 0.3

--- a/lib/benchmarks/cardano-wallet-benchmarks.cabal
+++ b/lib/benchmarks/cardano-wallet-benchmarks.cabal
@@ -66,7 +66,7 @@ library
     , hspec
     , http-client
     , http-types
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , iohk-monitoring-extra
     , JuicyPixels
     , local-cluster
@@ -107,7 +107,7 @@ benchmark restore
     , aeson
     , base
     , bytestring
-    , cardano-addresses
+    , cardano-addresses >= 3.12.0 && < 3.13
     , cardano-balance-tx
     , cardano-balance-tx:internal
     , cardano-wallet
@@ -122,7 +122,7 @@ benchmark restore
     , crypto-primitives
     , filepath
     , fmt
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , iohk-monitoring-extra
     , optparse-applicative
     , say
@@ -140,7 +140,7 @@ benchmark latency
   build-depends:
     , aeson
     , base
-    , cardano-addresses
+    , cardano-addresses >= 3.12.0 && < 3.13
     , cardano-wallet
     , cardano-wallet-api
     , cardano-wallet-exe
@@ -161,7 +161,7 @@ benchmark latency
     , hspec
     , http-client
     , http-types
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , iohk-monitoring-extra
     , local-cluster
     , mtl
@@ -186,9 +186,9 @@ benchmark db
     , address-derivation-discovery
     , base
     , bytestring
-    , cardano-addresses
-    , cardano-api
-    , cardano-crypto
+    , cardano-addresses >= 3.12.0 && < 3.13
+    , cardano-api >= 10.1.0.0 && < 10.2
+    , cardano-crypto >= 1.1.2 && < 1.2
     , cardano-wallet
     , cardano-wallet-benchmarks
     , cardano-wallet-network-layer
@@ -208,7 +208,7 @@ benchmark db
     , filepath
     , fmt
     , foldl
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , iohk-monitoring-extra
     , memory
     , mtl
@@ -229,7 +229,7 @@ benchmark api
     , aeson
     , base
     , bytestring
-    , cardano-api
+    , cardano-api >= 10.1.0.0 && < 10.2
     , cardano-balance-tx
     , cardano-balance-tx:internal
     , cardano-wallet
@@ -241,7 +241,7 @@ benchmark api
     , containers
     , filepath
     , fmt
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , iohk-monitoring-extra
     , mtl
     , say

--- a/lib/cardano-api-extra/cardano-api-extra.cabal
+++ b/lib/cardano-api-extra/cardano-api-extra.cabal
@@ -41,18 +41,18 @@ library
     , aeson
     , base
     , bytestring
-    , cardano-api
-    , cardano-binary
-    , cardano-crypto-class
-    , cardano-crypto-test
-    , cardano-ledger-alonzo
-    , cardano-ledger-api
-    , cardano-ledger-byron-test
-    , cardano-ledger-core
-    , cardano-ledger-core:testlib
-    , cardano-ledger-shelley
-    , cardano-ledger-conway:testlib
-    , cardano-strict-containers
+    , cardano-api >= 10.1.0.0 && < 10.2
+    , cardano-binary >= 1.7.1.0 && < 1.8
+    , cardano-crypto-class >= 2.1.5.0 && < 2.2
+    , cardano-crypto-test >= 1.5.0.2 && < 1.6
+    , cardano-ledger-alonzo >= 1.11.0.0 && < 1.12
+    , cardano-ledger-api >= 1.9.4.0 && < 1.10
+    , cardano-ledger-byron-test >= 1.5.1.1 && < 1.6
+    , cardano-ledger-core >= 1.15.0.0 && < 1.16
+    , cardano-ledger-core:testlib >= 1.15.0.0 && < 1.16
+    , cardano-ledger-shelley >= 1.14.1.0 && < 1.15
+    , cardano-ledger-conway:testlib >= 1.17.3.0 && < 1.18
+    , cardano-strict-containers >= 0.1.3.0 && < 0.2
     , cardano-wallet-test-utils
     , containers
     , hedgehog-quickcheck

--- a/lib/exe/cardano-wallet-exe.cabal
+++ b/lib/exe/cardano-wallet-exe.cabal
@@ -55,9 +55,9 @@ executable cardano-wallet
     , cardano-wallet-launcher
     , cardano-wallet-network-layer
     , contra-tracer
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , iohk-monitoring-extra
-    , lobemo-backend-ekg
+    , lobemo-backend-ekg >= 0.2.0.0 && < 0.3
     , network-uri
     , optparse-applicative
     , text
@@ -104,8 +104,8 @@ library
     , ansi-terminal
     , base
     , bytestring
-    , cardano-addresses
-    , cardano-addresses-cli
+    , cardano-addresses >= 3.12.0 && < 3.13
+    , cardano-addresses-cli >= 3.12.0 && < 3.13
     , cardano-wallet
     , cardano-wallet-api
     , cardano-wallet-network-layer
@@ -119,7 +119,7 @@ library
     , filepath
     , fmt
     , http-client
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , iohk-monitoring-extra
     , network
     , ntp-client

--- a/lib/faucet/faucet.cabal
+++ b/lib/faucet/faucet.cabal
@@ -58,7 +58,7 @@ library
     , aeson-pretty
     , base
     , bytestring
-    , cardano-addresses
+    , cardano-addresses >= 3.12.0 && < 3.13
     , containers
     , directory
     , extra

--- a/lib/integration/cardano-wallet-integration.cabal
+++ b/lib/integration/cardano-wallet-integration.cabal
@@ -51,8 +51,8 @@ library framework
     , bech32
     , bech32-th
     , bytestring
-    , cardano-addresses
-    , cardano-ledger-shelley
+    , cardano-addresses >= 3.12.0 && < 3.13
+    , cardano-ledger-shelley >= 1.14.1.0 && < 1.15
     , cardano-wallet
     , cardano-wallet-api
     , cardano-wallet-application-extras
@@ -84,10 +84,10 @@ library framework
     , http-client
     , http-types
     , HUnit
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , iohk-monitoring-extra
     , lens
-    , lobemo-backend-ekg
+    , lobemo-backend-ekg >= 0.2.0.0 && < 0.3
     , local-cluster
     , local-cluster:local-cluster-process
     , memory
@@ -135,12 +135,12 @@ library scenarios
     , base
     , bech32-th
     , bytestring
-    , cardano-addresses
-    , cardano-api
-    , cardano-crypto
-    , cardano-crypto-class
-    , cardano-ledger-alonzo
-    , cardano-ledger-core
+    , cardano-addresses >= 3.12.0 && < 3.13
+    , cardano-api >= 10.1.0.0 && < 10.2
+    , cardano-crypto >= 1.1.2 && < 1.2
+    , cardano-crypto-class >= 2.1.5.0 && < 2.2
+    , cardano-ledger-alonzo >= 1.11.0.0 && < 1.12
+    , cardano-ledger-core >= 1.15.0.0 && < 1.16
     , cardano-wallet
     , cardano-wallet-api
     , cardano-wallet-exe
@@ -231,7 +231,7 @@ test-suite e2e
   build-depends:
     , aeson
     , bytestring
-    , cardano-addresses
+    , cardano-addresses >= 3.12.0 && < 3.13
     , cardano-wallet-api
     , cardano-wallet-application-extras
     , cardano-wallet-exe

--- a/lib/iohk-monitoring-extra/iohk-monitoring-extra.cabal
+++ b/lib/iohk-monitoring-extra/iohk-monitoring-extra.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 name:          iohk-monitoring-extra
 version:       0.2025.1.9
-synopsis:      Extra functionality extending the iohk-monitoring package
+synopsis:      Extra functionality extending the iohk-monitoring >= 0.2.0.0 && < 0.3
 license:       Apache-2.0
 license-file:  LICENSE
 author:        Cardano Foundation (High Assurance Lab)
@@ -38,7 +38,7 @@ library
     , exceptions
     , filepath
     , fmt
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , stm
     , text
     , text-class

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -36,7 +36,7 @@ library
     , filepath >= 1.4.300.1 && < 1.6
     , fmt >= 0.6.3.0 && < 0.7
     , http-conduit >= 2.3.9 && < 2.4
-    , iohk-monitoring >= 0.2 && < 0.3
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , network >= 3.1.2.5 && < 3.2
     , process >= 1.6.19.0 && < 1.7
     , text >= 1.2 && < 2.2
@@ -82,7 +82,7 @@ test-suite unit
     , hspec >= 2.11.0 && < 2.12
     , hspec-core
     , hspec-expectations >= 0.8.4 && < 0.9
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , retry >= 0.9.3 && < 0.10
     , text
     , text-class

--- a/lib/local-cluster/local-cluster.cabal
+++ b/lib/local-cluster/local-cluster.cabal
@@ -103,14 +103,14 @@ library
     , base >= 4.14 && < 5
     , base58-bytestring >= 0.1 && < 0.2
     , bytestring >= 0.10.6 && < 0.13
-    , cardano-addresses == 3.12.0
-    , cardano-api >= 10.1 && < 10.2
-    , cardano-binary == 1.7.1.0
+    , cardano-addresses >= 3.12.0 && < 3.13
+    , cardano-api >= 10.1.0.0 && < 10.2
+    , cardano-binary >= 1.7.1.0 && < 1.8
     , cardano-cli >= 10.1 && < 10.2
     , cardano-data >= 1.2.3.1 && < 1.3
-    , cardano-ledger-api >= 1.9.2.0 && < 1.10
-    , cardano-ledger-core
-    , cardano-ledger-shelley
+    , cardano-ledger-api >= 1.9.4.0 && < 1.10
+    , cardano-ledger-core >= 1.15.0.0 && < 1.16
+    , cardano-ledger-shelley >= 1.14.1.0 && < 1.15
     , cardano-wallet-application-extras
     , cardano-wallet-launcher
     , cardano-wallet-primitive
@@ -133,7 +133,7 @@ library
     , insert-ordered-containers >=0.2.3 && < 0.3
     , int-cast >= 0.2.0.0 && < 0.3
     , io-classes >= 1.0 && < 1.8
-    , iohk-monitoring >= 0.2 && < 0.3
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , iohk-monitoring-extra
     , lens >= 5.2.3 && < 5.4
     , lens-aeson >= 1.2.3 && < 1.3
@@ -146,8 +146,8 @@ library
     -- commit f22c31611c295637a3e72b341cd1c56d1d87b993
     , openapi3 >= 3.2.3 && < 3.3
     , optparse-applicative >= 0.18.1.0 && < 0.19
-    , ouroboros-network
-    , ouroboros-network-api == 0.10.0.0
+    , ouroboros-network >= 0.17.1.2 && < 0.18
+    , ouroboros-network-api >= 0.10.0.0 && < 0.11
     , pathtype >= 0.8.1.3 && < 0.9
     , profunctors >= 5.6.2 && < 5.7
     , QuickCheck >= 2.14 && < 2.16
@@ -228,14 +228,14 @@ common test-common
     , aeson-qq >= 0.8.4 && < 0.9
     , base
     , bytestring
-    , cardano-addresses
-    , cardano-binary
-    , cardano-ledger-alonzo
-    , cardano-ledger-babbage
-    , cardano-ledger-byron
-    , cardano-ledger-core
-    , cardano-ledger-mary
-    , cardano-ledger-shelley
+    , cardano-addresses >= 3.12.0 && < 3.13
+    , cardano-binary >= 1.7.1.0 && < 1.8
+    , cardano-ledger-alonzo >= 1.11.0.0 && < 1.12
+    , cardano-ledger-babbage >= 1.10.0.0 && < 1.11
+    , cardano-ledger-byron >= 1.0.1.0 && < 1.1
+    , cardano-ledger-core >= 1.15.0.0 && < 1.16
+    , cardano-ledger-mary >= 1.7.0.1 && < 1.8
+    , cardano-ledger-shelley >= 1.14.1.0 && < 1.15
     , cardano-wallet-launcher
     , cardano-wallet-network-layer
     , cardano-wallet-primitive
@@ -252,8 +252,8 @@ common test-common
     , local-cluster:local-cluster-process
     , mtl
     , openapi3
-    , ouroboros-consensus-cardano >= 0.20 && < 0.21
-    , ouroboros-network >= 0.17 && < 0.18
+    , ouroboros-consensus-cardano >= 0.20.0.0 && < 0.21
+    , ouroboros-network >= 0.17.1.2 && < 0.18
     , pathtype
     , QuickCheck
     , streaming >= 0.2.4 && < 0.3

--- a/lib/network-layer/cardano-wallet-network-layer.cabal
+++ b/lib/network-layer/cardano-wallet-network-layer.cabal
@@ -69,19 +69,19 @@ library
   build-depends:
     , base >= 4.14 && < 5
     , bytestring >= 0.10.6 && < 0.13
-    , cardano-api >= 10.1 && < 10.2
+    , cardano-api >= 10.1.0.0 && < 10.2
     , cardano-balance-tx
     , cardano-balance-tx:internal
-    , cardano-binary >= 1.7.1 && < 1.8
+    , cardano-binary >= 1.7.1.0 && < 1.8
     , cardano-crypto-class >= 2.1.5.0 && < 2.2
-    , cardano-ledger-alonzo
-    , cardano-ledger-api >= 1.9.2.0 && < 1.10
-    , cardano-ledger-babbage
-    , cardano-ledger-byron
-    , cardano-ledger-core
-    , cardano-ledger-mary
-    , cardano-ledger-shelley
-    , cardano-slotting >= 0.2 && < 0.3
+    , cardano-ledger-alonzo >= 1.11.0.0 && < 1.12
+    , cardano-ledger-api >= 1.9.4.0 && < 1.10
+    , cardano-ledger-babbage >= 1.10.0.0 && < 1.11
+    , cardano-ledger-byron >= 1.0.1.0 && < 1.1
+    , cardano-ledger-core >= 1.15.0.0 && < 1.16
+    , cardano-ledger-mary >= 1.7.0.1 && < 1.8
+    , cardano-ledger-shelley >= 1.14.1.0 && < 1.15
+    , cardano-slotting >= 0.2.0.0 && < 0.3
     , cardano-wallet-launcher
     , cardano-wallet-primitive
     , cardano-wallet-read >= 1.0.0.0 && < 1.1
@@ -91,18 +91,18 @@ library
     , exceptions >= 0.10.7 && < 0.11
     , fmt >= 0.6.3 && < 0.7
     , io-classes >= 1.0 && < 1.8
-    , iohk-monitoring >= 0.2 && < 0.3
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , iohk-monitoring-extra
     , network-mux >= 0.4.5 && < 0.5
     , nothunks >= 0.1.5 && < 0.4
-    , ouroboros-consensus >= 0.20.0.0 && < 0.22.0.0
-    , ouroboros-consensus-cardano
-    , ouroboros-consensus-diffusion
-    , ouroboros-consensus-protocol
-    , ouroboros-network
-    , ouroboros-network-api == 0.10.0.0
-    , ouroboros-network-framework
-    , ouroboros-network-protocols
+    , ouroboros-consensus >= 0.21.0.0 && < 0.22
+    , ouroboros-consensus-cardano >= 0.20.0.0 && < 0.21
+    , ouroboros-consensus-diffusion >= 0.18.0.0 && < 0.19
+    , ouroboros-consensus-protocol >= 0.9.0.2 && < 0.10
+    , ouroboros-network >= 0.17.1.2 && < 0.18
+    , ouroboros-network-api >= 0.10.0.0 && < 0.11
+    , ouroboros-network-framework >= 0.13.2.5 && < 0.14
+    , ouroboros-network-protocols >= 0.11.0.0 && < 0.12
     , parallel >= 3.2.2 && < 3.3
     , retry >= 0.9.3 && < 0.10
     , safe >= 0.3.19 && < 0.4

--- a/lib/primitive/cardano-wallet-primitive.cabal
+++ b/lib/primitive/cardano-wallet-primitive.cabal
@@ -45,27 +45,27 @@ library
     , bech32-th
     , binary
     , bytestring
-    , cardano-addresses
-    , cardano-api:{cardano-api, internal}
-    , cardano-binary
-    , cardano-crypto
-    , cardano-crypto-class
+    , cardano-addresses >= 3.12.0 && < 3.13
+    , cardano-api:{cardano-api, internal} >= 10.1.0.0 && < 10.2
+    , cardano-binary >= 1.7.1.0 && < 1.8
+    , cardano-crypto >= 1.1.2 && < 1.2
+    , cardano-crypto-class >= 2.1.5.0 && < 2.2
     , cardano-crypto-wrapper
-    , cardano-data
-    , cardano-ledger-allegra
-    , cardano-ledger-alonzo
-    , cardano-ledger-api
-    , cardano-ledger-babbage
+    , cardano-data >= 1.2.3.1 && < 1.3
+    , cardano-ledger-allegra >= 1.6.0.1 && < 1.7
+    , cardano-ledger-alonzo >= 1.11.0.0 && < 1.12
+    , cardano-ledger-api >= 1.9.4.0 && < 1.10
+    , cardano-ledger-babbage >= 1.10.0.0 && < 1.11
     , cardano-ledger-binary
-    , cardano-ledger-byron
-    , cardano-ledger-conway
-    , cardano-ledger-core
-    , cardano-ledger-mary
-    , cardano-ledger-shelley
+    , cardano-ledger-byron >= 1.0.1.0 && < 1.1
+    , cardano-ledger-conway >= 1.17.3.0 && < 1.18
+    , cardano-ledger-core >= 1.15.0.0 && < 1.16
+    , cardano-ledger-mary >= 1.7.0.1 && < 1.8
+    , cardano-ledger-shelley >= 1.14.1.0 && < 1.15
     , cardano-numeric
     , cardano-protocol-tpraos
-    , cardano-slotting
-    , cardano-strict-containers
+    , cardano-slotting >= 0.2.0.0 && < 0.3
+    , cardano-strict-containers >= 0.1.3.0 && < 0.2
     , cardano-wallet-launcher
     , cardano-wallet-read
     , cardano-wallet-test-utils
@@ -84,7 +84,7 @@ library
     , generics-sop
     , hashable
     , int-cast
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , lattices
     , lens
     , memory
@@ -94,11 +94,11 @@ library
     , network-uri
     , nothunks
     , OddWord
-    , ouroboros-consensus
-    , ouroboros-consensus-cardano
-    , ouroboros-consensus-protocol
-    , ouroboros-network
-    , ouroboros-network-api
+    , ouroboros-consensus >= 0.21.0.0 && < 0.22
+    , ouroboros-consensus-cardano >= 0.20.0.0 && < 0.21
+    , ouroboros-consensus-protocol >= 0.9.0.2 && < 0.10
+    , ouroboros-network >= 0.17.1.2 && < 0.18
+    , ouroboros-network-api >= 0.10.0.0 && < 0.11
     , pretty-simple
     , QuickCheck
     , quiet
@@ -228,15 +228,15 @@ test-suite test
     , base58-bytestring
     , binary
     , bytestring
-    , cardano-addresses
-    , cardano-api
-    , cardano-crypto-class
-    , cardano-ledger-allegra:{testlib}
-    , cardano-ledger-api
-    , cardano-ledger-core:{cardano-ledger-core, testlib}
-    , cardano-ledger-shelley
+    , cardano-addresses >= 3.12.0 && < 3.13
+    , cardano-api >= 10.1.0.0 && < 10.2
+    , cardano-crypto-class >= 2.1.5.0 && < 2.2
+    , cardano-ledger-allegra:{testlib} >= 1.6.0.1 && < 1.7
+    , cardano-ledger-api >= 1.9.4.0 && < 1.10
+    , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.15.0.0 && < 1.16
+    , cardano-ledger-shelley >= 1.14.1.0 && < 1.15
     , cardano-numeric
-    , cardano-slotting
+    , cardano-slotting >= 0.2.0.0 && < 0.3
     , cardano-wallet-primitive:cardano-wallet-primitive
     , cardano-wallet-test-utils
     , containers
@@ -250,12 +250,12 @@ test-suite test
     , generic-lens
     , hspec
     , hspec-core
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , lens
     , memory
-    , ouroboros-consensus
-    , ouroboros-consensus-cardano
-    , ouroboros-network-api
+    , ouroboros-consensus >= 0.21.0.0 && < 0.22
+    , ouroboros-consensus-cardano >= 0.20.0.0 && < 0.21
+    , ouroboros-network-api >= 0.10.0.0 && < 0.11
     , QuickCheck
     , quickcheck-classes
     , quickcheck-instances

--- a/lib/secrets/cardano-wallet-secrets.cabal
+++ b/lib/secrets/cardano-wallet-secrets.cabal
@@ -40,7 +40,7 @@ library
   build-depends:
     , base
     , bytestring
-    , cardano-crypto
+    , cardano-crypto >= 1.1.2 && < 1.2
     , cborg
     , crypto-primitives
     , deepseq

--- a/lib/temporary-extra/temporary-extra.cabal
+++ b/lib/temporary-extra/temporary-extra.cabal
@@ -28,7 +28,7 @@ library
   exposed-modules:    System.IO.Temp.Extra
   build-depends:
     , base
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , iohk-monitoring-extra
     , temporary
     , text

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -46,7 +46,7 @@ library
     , hspec-golden-aeson
     , http-api-data
     , HUnit
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , int-cast
     , lattices
     , monoid-subclasses

--- a/lib/ui/cardano-wallet-ui.cabal
+++ b/lib/ui/cardano-wallet-ui.cabal
@@ -71,7 +71,7 @@ library common
     , aeson-pretty
     , base
     , bytestring
-    , cardano-addresses
+    , cardano-addresses >= 3.12.0 && < 3.13
     , cardano-wallet-network-layer
     , containers
     , contra-tracer
@@ -121,8 +121,8 @@ library shelley
     , aeson-pretty
     , base
     , bytestring
-    , cardano-addresses
-    , cardano-slotting
+    , cardano-addresses >= 3.12.0 && < 3.13
+    , cardano-slotting >= 0.2.0.0 && < 0.3
     , cardano-wallet
     , cardano-wallet-api
     , cardano-wallet-primitive

--- a/lib/unit/cardano-wallet-unit.cabal
+++ b/lib/unit/cardano-wallet-unit.cabal
@@ -44,7 +44,7 @@ library test-common
   build-depends:
     , base
     , bytestring
-    , cardano-api
+    , cardano-api >= 10.1.0.0 && < 10.2
     , cardano-balance-tx
     , cardano-balance-tx:internal
     , cardano-wallet
@@ -73,20 +73,20 @@ test-suite unit
     , bech32
     , bech32-th
     , bytestring
-    , cardano-addresses
-    , cardano-api
+    , cardano-addresses >= 3.12.0 && < 3.13
+    , cardano-api >= 10.1.0.0 && < 10.2
     , cardano-api-extra
-    , cardano-api:internal
+    , cardano-api:internal >= 10.1.0.0 && < 10.2
     , cardano-balance-tx
     , cardano-balance-tx:internal
-    , cardano-crypto
-    , cardano-crypto-class
-    , cardano-ledger-alonzo
-    , cardano-ledger-babbage
-    , cardano-ledger-core
-    , cardano-ledger-shelley
+    , cardano-crypto >= 1.1.2 && < 1.2
+    , cardano-crypto-class >= 2.1.5.0 && < 2.2
+    , cardano-ledger-alonzo >= 1.11.0.0 && < 1.12
+    , cardano-ledger-babbage >= 1.10.0.0 && < 1.11
+    , cardano-ledger-core >= 1.15.0.0 && < 1.16
+    , cardano-ledger-shelley >= 1.14.1.0 && < 1.15
     , cardano-sl-x509
-    , cardano-slotting
+    , cardano-slotting >= 0.2.0.0 && < 0.3
     , cardano-wallet
     , cardano-wallet-api
     , cardano-wallet-application-extras
@@ -130,7 +130,7 @@ test-suite unit
     , int-cast
     , io-classes
     , io-sim
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , iohk-monitoring-extra
     , lattices
     , lens
@@ -146,9 +146,9 @@ test-suite unit
     , OddWord
     , openapi3
     , optparse-applicative
-    , ouroboros-consensus
-    , ouroboros-network
-    , ouroboros-network-api
+    , ouroboros-consensus >= 0.21.0.0 && < 0.22
+    , ouroboros-network >= 0.17.1.2 && < 0.18
+    , ouroboros-network-api >= 0.10.0.0 && < 0.11
     , pathtype
     , persistent
     , persistent-sqlite

--- a/lib/wai-middleware-logging/wai-middleware-logging.cabal
+++ b/lib/wai-middleware-logging/wai-middleware-logging.cabal
@@ -46,7 +46,7 @@ library
     , bytestring
     , contra-tracer
     , http-types
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , servant-server
     , text
     , text-class
@@ -73,7 +73,7 @@ test-suite unit
     , hspec
     , http-client
     , http-types
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , network
     , QuickCheck
     , servant-server

--- a/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
+++ b/lib/wallet-benchmarks/cardano-wallet-blackbox-benchmarks.cabal
@@ -65,7 +65,7 @@ benchmark memory
     , cardano-wallet-launcher
     , contra-tracer
     , filepath
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , iohk-monitoring-extra
     , mtl
     , process

--- a/lib/wallet/cardano-wallet.cabal
+++ b/lib/wallet/cardano-wallet.cabal
@@ -47,19 +47,19 @@ library
     , async
     , base
     , bytestring
-    , cardano-addresses
-    , cardano-api:{cardano-api, internal}
+    , cardano-addresses >= 3.12.0 && < 3.13
+    , cardano-api:{cardano-api, internal} >= 10.1.0.0 && < 10.2
     , cardano-balance-tx:{cardano-balance-tx, internal}
-    , cardano-binary
-    , cardano-crypto
-    , cardano-crypto-class
+    , cardano-binary >= 1.7.1.0 && < 1.8
+    , cardano-crypto >= 1.1.2 && < 1.2
+    , cardano-crypto-class >= 2.1.5.0 && < 2.2
     , cardano-crypto-wrapper
-    , cardano-ledger-allegra
-    , cardano-ledger-api
-    , cardano-ledger-byron
-    , cardano-ledger-core
-    , cardano-slotting
-    , cardano-strict-containers
+    , cardano-ledger-allegra >= 1.6.0.1 && < 1.7
+    , cardano-ledger-api >= 1.9.4.0 && < 1.10
+    , cardano-ledger-byron >= 1.0.1.0 && < 1.1
+    , cardano-ledger-core >= 1.15.0.0 && < 1.16
+    , cardano-slotting >= 0.2.0.0 && < 0.3
+    , cardano-strict-containers >= 0.1.3.0 && < 0.2
     , cardano-wallet-launcher
     , cardano-wallet-network-layer
     , cardano-wallet-primitive
@@ -90,7 +90,7 @@ library
     , http-types
     , int-cast
     , io-classes
-    , iohk-monitoring
+    , iohk-monitoring >= 0.2.0.0 && < 0.3
     , iohk-monitoring-extra
     , lens
     , list-transformer
@@ -104,10 +104,10 @@ library
     , ntp-client
     , OddWord
     , optparse-applicative
-    , ouroboros-consensus
-    , ouroboros-consensus-cardano
-    , ouroboros-network
-    , ouroboros-network-api
+    , ouroboros-consensus >= 0.21.0.0 && < 0.22
+    , ouroboros-consensus-cardano >= 0.20.0.0 && < 0.21
+    , ouroboros-network >= 0.17.1.2 && < 0.18
+    , ouroboros-network-api >= 0.10.0.0 && < 0.11
     , path-pieces
     , persistent
     , persistent-sqlite

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -96,6 +96,8 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: haskell-nix.cabalProje
         filter = lib.cleanSourceFilter;
       };
 
+      # this is a local variable, it controls only the index-state of the
+      # tools
       indexState = "2024-08-20T21:35:22Z";
 
       localClusterConfigs = config.src + /lib/local-cluster/test/data/cluster-configs;

--- a/scripts/bump-constraints.sh
+++ b/scripts/bump-constraints.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+updates=(
+    "cardano-addresses-cli"
+    "cardano-addresses"
+    "cardano-api"
+    "cardano-binary"
+    "cardano-crypto-class"
+    "cardano-crypto-test"
+    "cardano-crypto"
+    "cardano-data"
+    "cardano-ledger-allegra"
+    "cardano-ledger-alonzo-test"
+    "cardano-ledger-alonzo"
+    "cardano-ledger-api"
+    "cardano-ledger-babbage-test"
+    "cardano-ledger-babbage"
+    "cardano-ledger-byron-test"
+    "cardano-ledger-byron"
+    "cardano-ledger-conway"
+    "cardano-ledger-core"
+    "cardano-ledger-mary"
+    "cardano-ledger-shelley"
+    "cardano-slotting"
+    "cardano-strict-containers"
+    "iohk-monitoring"
+    "lobemo-backend-ekg"
+    "ouroboros-consensus-cardano"
+    "ouroboros-consensus-diffusion"
+    "ouroboros-consensus-protocol"
+    "ouroboros-consensus"
+    "ouroboros-network-api"
+    "ouroboros-network-framework"
+    "ouroboros-network-protocols"
+    "ouroboros-network"
+)
+
+freeze_file="$1"
+
+# update all cabal files with one bump
+update_cabal_files() {
+    local update=$1
+    local constraint=$2
+    local internal_name="(:[a-zA-Z0-9-]*|:\{[^}]*\})?"
+    local match="s/$update$internal_name( .*)?$/$update\1 $constraint/"
+    find lib -name '*.cabal' -exec sed -i -E "$match" {} \;
+}
+
+# generate version constraint
+generate_constraint() {
+    local version=$1
+    # shellcheck disable=SC2155
+    local major_version=$(echo "$version" | cut -d. -f1)
+    # shellcheck disable=SC2155
+    local minor_version=$(echo "$version" | cut -d. -f2)
+    local next_minor_version=$((minor_version + 1))
+    echo ">= $version \&\& < $major_version.$next_minor_version"
+}
+
+# for every update, get the version from the freeze file and update the cabal files
+for update in "${updates[@]}"; do
+    version=$(sed -n "s/.*any\.$update ==\([0-9.]*\),.*/\1/p" "$freeze_file")
+    constraint=$(generate_constraint "$version")
+    echo "$update $constraint"
+    update_cabal_files "$update" "$constraint"
+done


### PR DESCRIPTION
### Changes

- Fix a typo in the project file, we were not constraining the CHaP index-state ....
- Add a script to constraint all cardano dependencies with exact lower bound and conservatives upper bound based on a `cabal.project.freeze` argument.
- Use the script to constraint cardano dependencies in all the `lib/*.cabal` passing the current wallet `cabal.project.freeze`

### Issues 

fix #5028
progress #4993 

### Notes

- The script is supposed to run against a `cabal freeze` taken from the node version we have to be compatible with. 
- It will be good to remove the project level constraints once we bump for a new node