### PR TITLE
Run release triggered main pipeline integration tests at concurrency 1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -116,7 +116,7 @@ steps:
           mkdir integration-test-dir
           export CLUSTER_LOGS_DIR_PATH=integration-test-dir/cluster.logs
           export INTEGRATION_TEST_DIR=integration-test-dir
-          nix shell 'nixpkgs#just' -c just conway-integration-tests
+          nix shell 'nixpkgs#just' -c just conway-integration-tests 6
       artifact_paths: [ "./integration-test-dir/**" ]
       agents:
         system: ${linux}
@@ -498,7 +498,7 @@ steps:
     - label: Run Integration Tests (macOS)
       key: macos-tests-integration
       depends_on: macos-integration-tests-block
-      command: nix shell 'nixpkgs#just' -c just conway-integration-tests
+      command: nix shell 'nixpkgs#just' -c just conway-integration-tests 2
       agents:
         system: ${macos}
         queue: "cardano-wallet"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,7 @@ env:
   PREPROD_AGGREGATOR_ENDPOINT: https://aggregator.release-preprod.api.mithril.network/aggregator
   PREPROD_GENESIS_VERIFICATION_KEY: 5b3132372c37332c3132342c3136312c362c3133372c3133312c3231332c3230372c3131372c3139382c38352c3137362c3139392c3136322c3234312c36382c3132332c3131392c3134352c31332c3233322c3234332c34392c3232392c322c3234392c3230352c3230352c33392c3233352c34345d
   PREPROD_CONFIGS_DIR: "./configs/cardano/preprod"
+  DEFAULT_TEST_CONCURRENCY: 6
 
   # Per-host variables - shared across containers on host
   macos: "aarch64-darwin"
@@ -116,7 +117,8 @@ steps:
           mkdir integration-test-dir
           export CLUSTER_LOGS_DIR_PATH=integration-test-dir/cluster.logs
           export INTEGRATION_TEST_DIR=integration-test-dir
-          nix shell 'nixpkgs#just' -c just conway-integration-tests 6
+          export TEST_CONCURRENCY=$(buildkite-agent meta-data get "test-concurrency" --default $DEFAULT_TEST_CONCURRENCY)
+          nix shell 'nixpkgs#just' -c just conway-integration-tests $$TEST_CONCURRENCY
       artifact_paths: [ "./integration-test-dir/**" ]
       agents:
         system: ${linux}

--- a/justfile
+++ b/justfile
@@ -125,16 +125,15 @@ babbage-integration-tests-cabal:
 conway-integration-tests-cabal:
   just conway-integration-tests-cabal-match ""
 
-
 # run any integration test matching the given pattern via nix
-integration-tests match:
+integration-tests j match:
   CARDANO_WALLET_TEST_DATA=lib/integration/test/data \
   TESTS_RETRY_FAILED=1 \
   nix shell \
     '.#cardano-wallet' \
     '.#local-cluster' \
     '.#integration-exe' \
-    -c integration-exe -j 6 --match="{{match}}"
+    -c integration-exe -j "{{j}}" --match="{{match}}"
 
 node:
   nix shell \
@@ -142,33 +141,21 @@ node:
   'github:IntersectMBO/cardano-node?ref=10.1.4#cardano-node' \
   'github:IntersectMBO/cardano-node?ref=10.1.4#cardano-cli'
 
-# run babbage integration tests matching the given pattern via nix
-babbage-integration-tests-match match:
-  LOCAL_CLUSTER_CONFIGS=lib/local-cluster/test/data/cluster-configs \
-  LOCAL_CLUSTER_ERA=babbage \
-  nix shell \
-    '.#cardano-node' \
-    '.#cardano-cli' \
-    --accept-flake-config \
-    -c just integration-tests "{{match}}"
 
 # run conway integration tests matching the given pattern via nix
-conway-integration-tests-match match:
+conway-integration-tests-match j match:
   LOCAL_CLUSTER_CONFIGS=lib/local-cluster/test/data/cluster-configs \
   LOCAL_CLUSTER_ERA=conway \
   nix shell \
     '.#cardano-node' \
     '.#cardano-cli' \
     --accept-flake-config \
-    -c just integration-tests "{{match}}"
+    -c just integration-tests "{{j}}" "{{match}}"
 
-# run babbage integration tests via nix
-babbage-integration-tests:
-  just babbage-integration-tests-match ""
 
 # run conway integration tests via nix
-conway-integration-tests:
-  just conway-integration-tests-match ""
+conway-integration-tests j:
+  just conway-integration-tests-match "{{j}}" ""
 
 latency-bench:
    BENCHMARK_CSV_FILE=ignore-me/latency-bench.csv \

--- a/justfile
+++ b/justfile
@@ -92,6 +92,10 @@ add_missing_json_goldens:
 integration-tests-cabal-match match:
     just integration-tests-cabal-options '--match="{{match}}"'
 
+# with seed for reproducibility
+integration-tests-cabal-match-seed match seed:
+    just integration-tests-cabal-options '--match "{{match}}" --seed="{{seed}}"'
+
 # run any integration test matching the given pattern via cabal
 integration-tests-cabal-options options:
   TESTS_TRACING_MIN_SEVERITY=Warning \

--- a/scripts/buildkite/release/generate-trigger.sh
+++ b/scripts/buildkite/release/generate-trigger.sh
@@ -34,5 +34,6 @@ steps:
             release-candidate-branch: "$BRANCH"
             release-cabal-version: "$CABAL"
             triggered-by: "$BASE_BUILD"
+            test-concurrency: "1"
 
 YAML


### PR DESCRIPTION
### Changes 

- Add `j` parameter to just command to control concurrency of integration tests
- Add buildkite controls for the parameter
- Set concurrency to 1 when building for release pipeline

### Issue
#5045

### Notes

- proof https://buildkite.com/cardano-foundation/cardano-wallet/builds/9740/canvas?jid=019595ce-b39a-4e87-8a56-d5f3480ea152#019595ce-b39a-4e87-8a56-d5f3480ea152/181-188