### PR TITLE
Use library function to read output from spawned processes

### DIFF
--- a/justfile
+++ b/justfile
@@ -120,9 +120,8 @@ integration-tests match:
     '.#cardano-wallet' \
     '.#local-cluster' \
     '.#integration-exe' \
-    -c integration-exe -j 2 --match="{{match}}"
-
-
+    -c integration-exe -j 6 --match="{{match}}"
+    
 node:
   nix shell \
   --accept-flake-config \


### PR DESCRIPTION
Replace the use of custom (and duplicated) code with battle-tested standard library function.
This is an alternative attempt at fixing #5045.
