### PR TITLE
Fix CI nix sync steps timeout issues

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -142,14 +142,13 @@ steps:
       concurrency_group: 'linux-e2e-tests'
 
     - label: Preview Network Boot Sync
-      timeout_in_minutes: 10
       depends_on: []
       command: |
         cd run/preview/nix
         rm -rf logs
         mkdir -p logs
         rm -rf databases
-        ./run.sh sync
+        ./run.sh sync 600
       artifact_paths:
         - "./run/preview/nix/logs/*"
       agents:
@@ -162,14 +161,13 @@ steps:
         NETWORK: testnet
 
     - label: Mainnet Boot Sync
-      timeout_in_minutes: 10
       depends_on: []
       command: |
         cd run/mainnet/nix
         rm -rf logs
         mkdir -p logs
         rm -rf databases
-        ./run.sh sync
+        ./run.sh sync 600
       artifact_paths:
         - "./run/mainnet/nix/logs/*"
       agents:
@@ -187,7 +185,6 @@ steps:
       key: linux-mainnet-full-sync-block
 
     - label: Mainnet Boot Sync with Mithril
-      timeout_in_minutes: 120
       soft_fail :
         - exit_status: 44
       depends_on:
@@ -198,7 +195,7 @@ steps:
         mkdir -p logs
         rm -rf databases
         ./snapshot.sh
-        ./run.sh sync
+        ./run.sh sync 7200
       artifact_paths:
         - "./run/mainnet/nix/logs/*"
       agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,8 +4,6 @@ agents:
 env:
   LC_ALL: "C.UTF-8"
   NIX_PATH: "channel:nixos-21.11"
-  STATE_DIR: "/var/lib/buildkite-agent/cache"
-  STATE_DIR_MACOS: "/var/lib/buildkite-agent-hal-mac/cache"
   RELEASE_SCRIPTS_DIR: "./scripts/buildkite/release"
   MAIN_PIPELINE_DIR: "./scripts/buildkite/main"
   # Mithril variables
@@ -62,11 +60,17 @@ steps:
     depends_on:
       - linux-nix
     steps:
-    - label: Nix Build (linux)
+
+    - label: Nix build (linux)
+      key: linux-build
       commands:
         - nix build -L .#cardano-wallet
-        - nix build -L .#cardano-node
-        - nix build -L .#cardano-cli
+      agents:
+        system: ${linux}
+
+    - label: Nix evaluate shell (linux)
+      commands:
+        - nix shell -L .#cardano-node .#cardano-cli .#cardano-wallet --command cardano-wallet version
       agents:
         system: ${linux}
 
@@ -77,7 +81,6 @@ steps:
       artifact_paths: [ "./result/linux/**" ]
       agents:
         system: ${linux}
-
 
   - group: Linux Checks
     if: build.env("RELEASE_CANDIDATE") == null || build.env("TEST_RC") == "FALSE"

--- a/run/common/nix/run.sh
+++ b/run/common/nix/run.sh
@@ -1,4 +1,5 @@
-#! /usr/bin/env -S nix shell '.#cardano-wallet' '.#cardano-node' '.#cardano-cli'  --command bash
+#! /usr/bin/env nix
+#! nix shell .#cardano-wallet .#cardano-node .#cardano-cli  --command bash
 # shellcheck shell=bash
 
 # set -euox pipefail

--- a/run/common/nix/run.sh
+++ b/run/common/nix/run.sh
@@ -172,7 +172,7 @@ case "$1" in
         sleep 10
 
         # Initialize timeout and start time for the sync operation
-        timeout=10000
+        timeout=${2:=600}
         start_time=$(date +%s)
 
         # Commands to query service status and node tip time


### PR DESCRIPTION
### Changes

- Fix shebang in run.sh so it's usable on the mac
- Remove unused env vars in the main pipeline 
- Warm up nix with `nix shell` and not `nix build` as `nix shell` is invoked in the run.sh
- Remove buildkite level timeout in favor of run.sh internal timeout

### Issues 

fix #5051 