### PR TITLE
Update readme and contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,8 @@ If you find a bug or you'd like to propose a feature, please feel free to raise 
 > versions of the cardano-node, fixing bugs, improving quality and
 > stability of both the code and server stability, plus providing
 > general user support.
->
+
+  [cardano-node]: https://github.com/IntersectMBO/cardano-node
 > Contributions for new features are welcome and
 > will be thoroughly reviewed, but no new features will be developed
 > by the Cardano Foundation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,24 @@
 If you find a bug or you'd like to propose a feature, please feel free to raise an issue on our [issue tracker](https://github.com/cardano-foundation/cardano-wallet/issues).
 
-Pull requests are welcome!
+> [!IMPORTANT]
+>
+> Starting April 1st, 2025, the Cardano Wallet is entering
+> maintenance-only mode. The Cardano Foundation is committed to
+> maintaining it for the foreseeable future by upgrading to new
+> versions of the cardano-node, fixing bugs, improving quality and
+> stability of both the code and server stability, plus providing
+> general user support.
+>
+> Contributions for new features are welcome and
+> will be thoroughly reviewed, but no new features will be developed
+> by the Cardano Foundation.
 
-When creating a pull request, please make sure that your code adheres to our [coding standards](https://github.com/input-output-hk/adrestia/blob/master/docs/code/Coding-Standards.md).
+Notwithstanding the above statement, **Pull requests are welcome!**
+and will be thoroughly and diligently reviewed and shepherded.
 
-For more information, please consult our [Contributor Manual](https://cardano-foundation.github.io/cardano-wallet/contributor).
+When creating a pull request, please make sure that your code adheres
+to our [coding
+standards](https://github.com/input-output-hk/adrestia/blob/master/docs/code/Coding-Standards.md).
+
+For more information, please consult our [Contributor
+Manual](https://cardano-foundation.github.io/cardano-wallet/contributor).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ If you find a bug or you'd like to propose a feature, please feel free to raise 
 > Starting April 1st, 2025, the Cardano Wallet is entering
 > maintenance-only mode. The Cardano Foundation is committed to
 > maintaining it for the foreseeable future by upgrading to new
-> versions of the cardano-node, fixing bugs, improving quality and
+> versions of the [cardano-node][], fixing bugs, improving quality and
 > stability of both the code and server stability, plus providing
 > general user support.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 > Starting April 1st, 2025, the Cardano Wallet is entering
 > maintenance-only mode. The Cardano Foundation is committed to
 > maintaining it for the foreseeable future by upgrading to new
-> versions of the cardano-node, fixing bugs, improving quality and
+> versions of the [cardano-node][], fixing bugs, improving quality and
 > stability of both the code and server stability, plus providing
 > general user support.
 >

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 > will be thoroughly reviewed, but no new features will be developed
 > by the Cardano Foundation.
 
+  [cardano-node]: https://github.com/IntersectMBO/cardano-node
 ## Overview
 
 Cardano Wallet is software that helps you manage your ADA.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@
 
 <hr/>
 
+> [!IMPORTANT]
+>
+> Starting April 1st, 2025, the Cardano Wallet is entering
+> maintenance-only mode. The Cardano Foundation is committed to
+> maintaining it for the foreseeable future by upgrading to new
+> versions of the cardano-node, fixing bugs, improving quality and
+> stability of both the code and server stability, plus providing
+> general user support.
+>
+> Contributions for new features are welcome and
+> will be thoroughly reviewed, but no new features will be developed
+> by the Cardano Foundation.
+
 ## Overview
 
 Cardano Wallet is software that helps you manage your ADA.


### PR DESCRIPTION
This PR adds a statement on the `README` and to the `CONTRIBUTING` guidelines that the cardano-wallet enters maintenance mode starting on 2025-04-01.