### PR TITLE
fix: bump mithril version to 2517.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -365,21 +365,6 @@
         "type": "github"
       }
     },
-    "crane": {
-      "locked": {
-        "lastModified": 1734808813,
-        "narHash": "sha256-3aH/0Y6ajIlfy7j52FGZ+s4icVX0oHhqBzRdlOeztqg=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "72e2d02dbac80c8c86bf6bf3e785536acf8ee926",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
     "customConfig": {
       "locked": {
         "lastModified": 1630400035,
@@ -616,24 +601,6 @@
         "owner": "input-output-hk",
         "ref": "hkm/gitlab-fix",
         "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1735774679,
-        "narHash": "sha256-soePLBazJk0qQdDVhdbM98vYdssfs3WFedcq+raipRI=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "f2f7418ce0ab4a5309a4596161d154cfc877af66",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -1436,17 +1403,16 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1741648051,
-        "narHash": "sha256-Wl1nQ2dak4b3fXA7+9rB2ntiKUS+yAzR2kOIUoAF0u8=",
+        "lastModified": 1745582862,
+        "narHash": "sha256-dMoJ6yHcRvUcB66nofzfAtmVxnDg8oPW3wiVtimXT/o=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "911835056d2b48a9ae65b4e3a2925c88a320a6ab",
+        "rev": "5c16fdfc45deda7a4ccf964b6dfa1c3cab72f1f7",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "911835056d2b48a9ae65b4e3a2925c88a320a6ab",
         "type": "github"
       }
     },
@@ -1528,28 +1494,6 @@
       "original": {
         "owner": "JoelCourtney",
         "repo": "mdbook-kroki-preprocessor",
-        "type": "github"
-      }
-    },
-    "mithril": {
-      "inputs": {
-        "crane": "crane",
-        "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs_7",
-        "treefmt-nix": "treefmt-nix"
-      },
-      "locked": {
-        "lastModified": 1739196933,
-        "narHash": "sha256-CIDPUNYUMyQupIQzKCIwvP4S4BJvyidy6dVSL5kS+XQ=",
-        "owner": "input-output-hk",
-        "repo": "mithril",
-        "rev": "2627f17b83be844151b254ac21b8cff6c6a97364",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "2506.0",
-        "repo": "mithril",
         "type": "github"
       }
     },
@@ -1886,18 +1830,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1735774519,
-        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
-      }
-    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -1948,11 +1880,11 @@
     },
     "nixpkgs-unstable_3": {
       "locked": {
-        "lastModified": 1716509168,
-        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
+        "lastModified": 1747542820,
+        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
+        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
         "type": "github"
       },
       "original": {
@@ -2034,22 +1966,6 @@
       "original": {
         "owner": "nixos",
         "ref": "release-23.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
-        "lastModified": 1735617354,
-        "narHash": "sha256-5zJyv66q68QZJZsXtmjDBazGnF0id593VSy+8eSckoo=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "69b9a8c860bdbb977adfa9c5e817ccb717884182",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -2179,7 +2095,6 @@
           "nixpkgs"
         ],
         "iohkNix": "iohkNix_2",
-        "mithril": "mithril",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
@@ -2415,27 +2330,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "mithril",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1735807918,
-        "narHash": "sha256-8b09m8eIT/0TPkrT3BVRZ+Bc5LOP8l1CYkBzrfQ/aok=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "8cfde27e47460d80e92f759caadddfb31f391d0f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -115,8 +115,8 @@
       flake = false;
     };
     customConfig.url = "github:input-output-hk/empty-flake";
-    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.2.1";
-
+    cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.3.1";
+    mithril.url = "github:input-output-hk/mithril?ref=2517.1";
   };
 
   outputs = { self, nixpkgs, nixpkgs-unstable, hostNixpkgs, flake-utils,

--- a/flake.nix
+++ b/flake.nix
@@ -107,7 +107,7 @@
     };
     flake-utils.url = "github:numtide/flake-utils";
     iohkNix = {
-      url = "github:input-output-hk/iohk-nix?rev=911835056d2b48a9ae65b4e3a2925c88a320a6ab";
+      url = "github:input-output-hk/iohk-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-compat = {
@@ -116,12 +116,12 @@
     };
     customConfig.url = "github:input-output-hk/empty-flake";
     cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.2.1";
-    mithril.url = "github:input-output-hk/mithril?ref=2517.1";
+
   };
 
   outputs = { self, nixpkgs, nixpkgs-unstable, hostNixpkgs, flake-utils,
               haskellNix, iohkNix, CHaP, customConfig, cardano-node-runtime,
-              mithril , ... }:
+               ... }:
     let
       # Import libraries
       lib = import ./nix/lib.nix nixpkgs.lib;
@@ -193,7 +193,6 @@
             collectChecks
             check;
 
-          mithrilPackages = mithril.packages.${system};
           nodePackages = cardano-node-runtime.packages.${system};
           nodeProject = cardano-node-runtime.project.${system};
           nodeConfigs = lib.fileset.toSource {
@@ -210,7 +209,6 @@
               pkgs.haskell-nix
               nixpkgs-unstable.legacyPackages.${system}
               nodePackages
-              mithrilPackages
               set-git-rev.packages.default
               rewrite-libs.packages.default
             ).appendModule [{

--- a/flake.nix
+++ b/flake.nix
@@ -116,7 +116,7 @@
     };
     customConfig.url = "github:input-output-hk/empty-flake";
     cardano-node-runtime.url = "github:IntersectMBO/cardano-node?ref=10.2.1";
-    mithril.url = "github:input-output-hk/mithril?ref=2506.0";
+    mithril.url = "github:input-output-hk/mithril?ref=2517.1";
   };
 
   outputs = { self, nixpkgs, nixpkgs-unstable, hostNixpkgs, flake-utils,

--- a/lib/launcher/src/Cardano/Launcher/Mithril.hs
+++ b/lib/launcher/src/Cardano/Launcher/Mithril.hs
@@ -91,7 +91,7 @@ downloadMithril workingDir = withCurrentDirectory workingDir $ do
             "aarch64" -> "arm64"
             other -> other
 
-    version       = "2450.0"
+    version       = "2517.1"
     mithrilTar    = "mithril-" <> version <> "-" <> platform <> ".tar"
     mithrilPackage = mithrilTar <> ".gz"
     downloadUrl   = "https://github.com/input-output-hk/mithril/releases/download/"

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -1,7 +1,7 @@
 ############################################################################
 # Builds Haskell packages with Haskell.nix
 ############################################################################
-CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-libs: haskell-nix.cabalProject' [
+CHaP: haskell-nix: nixpkgs-recent: nodePkgs: set-git-rev: rewrite-libs: haskell-nix.cabalProject' [
   ({ lib, pkgs, buildProject, ... }: {
     options = {
       gitrev = lib.mkOption {
@@ -146,7 +146,6 @@ CHaP: haskell-nix: nixpkgs-recent: nodePkgs: mithrilPkgs: set-git-rev: rewrite-l
           haskellPackages.pretty-simple
           haskellPackages.weeder
           haskellPackages.stylish-haskell
-          mithrilPkgs.mithril-client-cli
 
         ]);
         shellHook = "export LOCAL_CLUSTER_CONFIGS=${localClusterConfigs}";

--- a/run/common/docker/docker-compose.yml
+++ b/run/common/docker/docker-compose.yml
@@ -52,7 +52,7 @@ services:
   mithril:
     env_file:
       - .env
-    image: ghcr.io/input-output-hk/mithril-client:2506.0-2627f17
+    image: ghcr.io/input-output-hk/mithril-client:2517.1-b1a2faa
     user: ${USER_ID}:${GROUP_ID}
     volumes:
       - ${NODE_DB}:/app/db

--- a/run/common/nix/run.sh
+++ b/run/common/nix/run.sh
@@ -78,7 +78,7 @@ cleanup() {
 mithril() {
     # shellcheck disable=SC2048
     # shellcheck disable=SC2086
-    nix shell "github:input-output-hk/mithril?ref=2506.0" -c $*
+    nix shell "github:input-output-hk/mithril?ref=2517.1" -c $*
 }
 
 # Trap the cleanup function on exit

--- a/run/common/nix/snapshot.sh
+++ b/run/common/nix/snapshot.sh
@@ -2,7 +2,7 @@
 # shellcheck shell=bash
 
 function mithril() {
-    nix shell 'github:input-output-hk/mithril?ref=2506.0' --command mithril-client $@
+    nix shell 'github:input-output-hk/mithril?ref=2517.1' --command mithril-client $@
 }
 
 function jq() {

--- a/run/mainnet/docker/docker-compose.yml
+++ b/run/mainnet/docker/docker-compose.yml
@@ -49,7 +49,7 @@ services:
   mithril:
     env_file:
       - .env
-    image: ghcr.io/input-output-hk/mithril-client:2506.0-2627f17
+    image: ghcr.io/input-output-hk/mithril-client:2517.1-b1a2faa
     user: ${USER_ID}:${GROUP_ID}
     volumes:
       - ${NODE_DB}:/app/db

--- a/scripts/buildkite/admin/refresh-preprod-snapshot.sh
+++ b/scripts/buildkite/admin/refresh-preprod-snapshot.sh
@@ -11,7 +11,7 @@ export GENESIS_VERIFICATION_KEY=5b3132372c37332c3132342c3136312c362c3133372c3133
 mithril() {
     # shellcheck disable=SC2048
     # shellcheck disable=SC2086
-    nix shell "github:input-output-hk/mithril?ref=2506.0" -c $*
+    nix shell "github:input-output-hk/mithril?ref=2517.1" -c $*
 }
 
 mithril echo "mithril is available" || exit 44


### PR DESCRIPTION
pre-release builds have been failing because of Mithril for couple of weeks. Seems like there's been a breaking change we need to take care of...

## Changes

- bump mithril version to 2517.1
- remove mithril client from the wallet nix shell
