### PR TITLE
bump benchmark history limit

### DIFF
--- a/scripts/buildkite/main/benchmark-history.sh
+++ b/scripts/buildkite/main/benchmark-history.sh
@@ -6,7 +6,7 @@ set -euox pipefail
 mkdir -p ./benchmark-history
 
 benchmark-history \
-    --since 2024-08-25 \
+    --since 2025-07-01 \
     --charts-dir benchmark-history
 
 # shellcheck disable=SC2295


### PR DESCRIPTION
## Why

It breaks before the new date
